### PR TITLE
Propagate static_if more completely.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18117,6 +18117,37 @@ a")
         f = Foo()
         torch.jit.script(f)
 
+    def test_static_if_prop(self):
+        class MaybeHasAttr(torch.nn.Module):
+            def __init__(self, add_attr):
+                super(MaybeHasAttr, self).__init__()
+                if add_attr:
+                    self.maybe_attr = 1
+
+            def forward(self):
+                if hasattr(self, "maybe_attr") and True:
+                    return self.maybe_attr
+                else:
+                    return 0
+        class MaybeHasAttr2(torch.nn.Module):
+            def __init__(self, add_attr):
+                super(MaybeHasAttr2, self).__init__()
+                if add_attr:
+                    self.maybe_attr = 1
+
+            def forward(self):
+                if not hasattr(self, "maybe_attr") or False:
+                    return 0
+                else:
+                    return self.maybe_attr
+
+        torch.jit.script(MaybeHasAttr(True))
+        torch.jit.script(MaybeHasAttr(False))
+        torch.jit.script(MaybeHasAttr2(True))
+        torch.jit.script(MaybeHasAttr2(False))
+
+
+
     def test_optional_tuple(self):
         def fn(x=None):
             # type: (Optional[Tuple[int, int]]) -> Tuple[int, int]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18129,6 +18129,7 @@ a")
                     return self.maybe_attr
                 else:
                     return 0
+
         class MaybeHasAttr2(torch.nn.Module):
             def __init__(self, add_attr):
                 super(MaybeHasAttr2, self).__init__()

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1239,7 +1239,8 @@ struct to_ir {
     if (is_or) {
       new_result = emitIfExpr(loc, lhs, get_const_expr, get_continue_expr);
       refinements = lhs.refinements().Or(rhs->refinements());
-      if ((lhs.staticIf() && *lhs.staticIf()) || (rhs->staticIf() && *rhs->staticIf())) { 
+      if ((lhs.staticIf() && *lhs.staticIf()) ||
+          (rhs->staticIf() && *rhs->staticIf())) {
         static_if = true;
       } else if (lhs.staticIf() && rhs->staticIf()) {
         static_if = *lhs.staticIf() || *rhs->staticIf();
@@ -1247,7 +1248,8 @@ struct to_ir {
     } else {
       new_result = emitIfExpr(loc, lhs, get_continue_expr, get_const_expr);
       refinements = lhs.refinements().And(rhs->refinements());
-      if (((lhs.staticIf() && !*lhs.staticIf()) || (rhs->staticIf() && !*rhs->staticIf()))) {
+      if (((lhs.staticIf() && !*lhs.staticIf()) ||
+           (rhs->staticIf() && !*rhs->staticIf()))) {
         static_if = false;
       } else if (lhs.staticIf() && rhs->staticIf()) {
         static_if = *lhs.staticIf() && *rhs->staticIf();

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1239,13 +1239,17 @@ struct to_ir {
     if (is_or) {
       new_result = emitIfExpr(loc, lhs, get_const_expr, get_continue_expr);
       refinements = lhs.refinements().Or(rhs->refinements());
-      if (lhs.staticIf() && rhs->staticIf()) {
+      if ((lhs.staticIf() && *lhs.staticIf()) || (rhs->staticIf() && *rhs->staticIf())) { 
+        static_if = true;
+      } else if (lhs.staticIf() && rhs->staticIf()) {
         static_if = *lhs.staticIf() || *rhs->staticIf();
       }
     } else {
       new_result = emitIfExpr(loc, lhs, get_continue_expr, get_const_expr);
       refinements = lhs.refinements().And(rhs->refinements());
-      if (lhs.staticIf() && rhs->staticIf()) {
+      if (((lhs.staticIf() && !*lhs.staticIf()) || (rhs->staticIf() && !*rhs->staticIf()))) {
+        static_if = false;
+      } else if (lhs.staticIf() && rhs->staticIf()) {
         static_if = *lhs.staticIf() && *rhs->staticIf();
       }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35834 Propagate static_if more completely.**

This handles the cases we did not handle before in AND and OR statements:

    static_true || <unknown> -> static_true
    static_false && <unknown> -> static_false

Differential Revision: [D20801125](https://our.internmc.facebook.com/intern/diff/D20801125)