### PR TITLE
Skip ROCm test in test/test_cpp_extensions_aot.py

### DIFF
--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 import torch.testing._internal.common_utils as common
-from torch.testing._internal.common_utils import IS_WINDOWS
+from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm
 from torch.testing._internal.common_cuda import TEST_CUDA
 import torch
 import torch.backends.cudnn
@@ -55,6 +55,7 @@ class TestCppExtensionAOT(common.TestCase):
         expected_tensor_grad = torch.ones([4, 4], dtype=torch.double).mm(weights.t())
         self.assertEqual(tensor.grad, expected_tensor_grad)
 
+    @skipIfRocm
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_cuda_extension(self):
         import torch_test_cpp_extension.cuda as cuda_extension


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35839 Fix another case of float2::x and float2::y may not be the same on ROCm"
* **#35838 Skip ROCm test in test/test_cpp_extensions_aot.py**
* #35816 Make test_leaky_relu_inplace_with_neg_slope device-generic and skipIfRocm.

It may be flaky.

Differential Revision: [D20807409](https://our.internmc.facebook.com/intern/diff/D20807409)