### PR TITLE
[easy] ThroughputBenchmark: make ScriptModuleBenchmark usable from c++

### DIFF
--- a/torch/csrc/utils/throughput_benchmark.cpp
+++ b/torch/csrc/utils/throughput_benchmark.cpp
@@ -6,6 +6,11 @@
 namespace torch {
 namespace throughput_benchmark {
 
+std::ostream& operator<<(std::ostream& os, const BenchmarkExecutionStats& value) {
+    return os << "Average latency / iter (ms): " << value.latency_avg_ms
+              << "\n Total number of iters: " << value.num_iters;
+}
+
 void ThroughputBenchmark::addInput(py::args args, py::kwargs kwargs) {
   CHECK(script_module_.initialized() ^ module_.initialized());
   if (script_module_.initialized()) {
@@ -102,6 +107,12 @@ void ScriptModuleBenchmark::addInput(py::args&& args, py::kwargs&& kwargs) {
       std::move(kwargs),
       model_._ivalue());
   inputs_.emplace_back(std::move(stack));
+}
+
+template <>
+void ScriptModuleBenchmark::addInput(ScriptModuleInput&& input) {
+  input.insert(input.begin(), model_._ivalue());
+  inputs_.emplace_back(std::move(input));
 }
 
 template <>

--- a/torch/csrc/utils/throughput_benchmark.h
+++ b/torch/csrc/utils/throughput_benchmark.h
@@ -6,8 +6,9 @@
 
 #include <torch/csrc/jit/python/pybind_utils.h>
 
-#include <vector>
+#include <iostream>
 #include <memory>
+#include <vector>
 
 namespace py = pybind11;
 
@@ -22,6 +23,8 @@ struct BenchmarkExecutionStats {
   float latency_avg_ms{-1};
   int64_t num_iters{-1};
 };
+
+std::ostream& operator<<(std::ostream& os, const BenchmarkExecutionStats& value);
 
 /**
  * Use this struct in order to configure a throughput benchmark run.
@@ -72,6 +75,7 @@ public:
   // Aggregate input in the format Model expects in order to avoid further
   // conversions at the benchmark time
   void addInput(py::args&&, py::kwargs&&);
+  void addInput(Input&&);
   BenchmarkExecutionStats benchmark(const BenchmarkConfig& config) const;
 
   bool initialized() const { return initialized_; }
@@ -135,6 +139,9 @@ ModuleOutput ModuleBenchmark::runOnce(py::args&& args, py::kwargs&& kwargs)
 
 template <>
 void ScriptModuleBenchmark::addInput(py::args&& args, py::kwargs&& kwargs);
+template <>
+void ScriptModuleBenchmark::addInput(ScriptModuleInput&& input);
+
 
 template <>
 void ModuleBenchmark::addInput(py::args&& args, py::kwargs&& kwargs);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35848 ThroughputBenchmark: make ScriptModuleBenchmark usable from c++**

This class so far was used from Python binding only. As a result, testing in c++ only environment is not currently possible. More specifically, adding inputs requires using
py::args and py::kwargs. This PR fixes this by adding another addInput function to ScriptModuleBenchmark class.

Differential Revision: [D20820772](https://our.internmc.facebook.com/intern/diff/D20820772)