### PR TITLE
Enable float only requantization. Part 1.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x4c2-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x4c2-sse2.c
@@ -257,157 +257,33 @@ void pytorch_q8conv_ukernel_4x4c2__sse2(
     }
   } while (--ks != 0);
 
-  const __m128i vmultiplier =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.multiplier);
-  const __m128i vrounding =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.rounding);
+  const __m128 vmultiplier =
+      _mm_loadu_ps(quantization_params->sse2.requantization_scale);
 
-  const __m128i vnmask0x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc0x0123);
-  const __m128i vnmask1x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc1x0123);
-  const __m128i vnmask2x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc2x0123);
-  const __m128i vnmask3x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc3x0123);
-
-  const __m128i vabsacc0x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc0x0123, vnmask0x0123), vnmask0x0123);
-  const __m128i vabsacc1x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc1x0123, vnmask1x0123), vnmask1x0123);
-  const __m128i vabsacc2x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc2x0123, vnmask2x0123), vnmask2x0123);
-  const __m128i vabsacc3x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc3x0123, vnmask3x0123), vnmask3x0123);
-
-  const __m128i vabsacc0x1032 =
-      _mm_shuffle_epi32(vabsacc0x0123, _MM_SHUFFLE(2, 3, 0, 1));
-  const __m128i vabsacc1x1032 =
-      _mm_shuffle_epi32(vabsacc1x0123, _MM_SHUFFLE(2, 3, 0, 1));
-  const __m128i vabsacc2x1032 =
-      _mm_shuffle_epi32(vabsacc2x0123, _MM_SHUFFLE(2, 3, 0, 1));
-  const __m128i vabsacc3x1032 =
-      _mm_shuffle_epi32(vabsacc3x0123, _MM_SHUFFLE(2, 3, 0, 1));
-
-  const __m128i vabsprod0x02 = _mm_mul_epu32(vabsacc0x0123, vmultiplier);
-  const __m128i vabsprod1x02 = _mm_mul_epu32(vabsacc1x0123, vmultiplier);
-  const __m128i vabsprod2x02 = _mm_mul_epu32(vabsacc2x0123, vmultiplier);
-  const __m128i vabsprod3x02 = _mm_mul_epu32(vabsacc3x0123, vmultiplier);
-
-  const __m128i vnmask0x02 =
-      _mm_shuffle_epi32(vnmask0x0123, _MM_SHUFFLE(2, 2, 0, 0));
-  const __m128i vnmask1x02 =
-      _mm_shuffle_epi32(vnmask1x0123, _MM_SHUFFLE(2, 2, 0, 0));
-  const __m128i vnmask2x02 =
-      _mm_shuffle_epi32(vnmask2x0123, _MM_SHUFFLE(2, 2, 0, 0));
-  const __m128i vnmask3x02 =
-      _mm_shuffle_epi32(vnmask3x0123, _MM_SHUFFLE(2, 2, 0, 0));
-
-  const __m128i vprod0x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod0x02, vnmask0x02), vnmask0x02);
-  const __m128i vprod1x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod1x02, vnmask1x02), vnmask1x02);
-  const __m128i vprod2x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod2x02, vnmask2x02), vnmask2x02);
-  const __m128i vprod3x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod3x02, vnmask3x02), vnmask3x02);
-
-  const __m128i vq31prod0x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod0x02, vrounding), 31);
-  const __m128i vq31prod1x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod1x02, vrounding), 31);
-  const __m128i vq31prod2x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod2x02, vrounding), 31);
-  const __m128i vq31prod3x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod3x02, vrounding), 31);
-
-  const __m128i vabsprod0x13 = _mm_mul_epu32(vabsacc0x1032, vmultiplier);
-  const __m128i vabsprod1x13 = _mm_mul_epu32(vabsacc1x1032, vmultiplier);
-  const __m128i vabsprod2x13 = _mm_mul_epu32(vabsacc2x1032, vmultiplier);
-  const __m128i vabsprod3x13 = _mm_mul_epu32(vabsacc3x1032, vmultiplier);
-
-  const __m128i vnmask0x13 =
-      _mm_shuffle_epi32(vnmask0x0123, _MM_SHUFFLE(3, 3, 1, 1));
-  const __m128i vnmask1x13 =
-      _mm_shuffle_epi32(vnmask1x0123, _MM_SHUFFLE(3, 3, 1, 1));
-  const __m128i vnmask2x13 =
-      _mm_shuffle_epi32(vnmask2x0123, _MM_SHUFFLE(3, 3, 1, 1));
-  const __m128i vnmask3x13 =
-      _mm_shuffle_epi32(vnmask3x0123, _MM_SHUFFLE(3, 3, 1, 1));
-
-  const __m128i vprod0x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod0x13, vnmask0x13), vnmask0x13);
-  const __m128i vprod1x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod1x13, vnmask1x13), vnmask1x13);
-  const __m128i vprod2x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod2x13, vnmask2x13), vnmask2x13);
-  const __m128i vprod3x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod3x13, vnmask3x13), vnmask3x13);
-
-  const __m128i vq31prod0x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod0x13, vrounding), 31);
-  const __m128i vq31prod1x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod1x13, vrounding), 31);
-  const __m128i vq31prod2x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod2x13, vrounding), 31);
-  const __m128i vq31prod3x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod3x13, vrounding), 31);
-
-  const __m128i vq31prod0x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod0x02),
-      _mm_castsi128_ps(vq31prod0x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-  const __m128i vq31prod1x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod1x02),
-      _mm_castsi128_ps(vq31prod1x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-  const __m128i vq31prod2x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod2x02),
-      _mm_castsi128_ps(vq31prod2x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-  const __m128i vq31prod3x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod3x02),
-      _mm_castsi128_ps(vq31prod3x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-
-  const __m128i vq31prod0x0123 =
-      _mm_shuffle_epi32(vq31prod0x0213, _MM_SHUFFLE(3, 1, 2, 0));
-  const __m128i vq31prod1x0123 =
-      _mm_shuffle_epi32(vq31prod1x0213, _MM_SHUFFLE(3, 1, 2, 0));
-  const __m128i vq31prod2x0123 =
-      _mm_shuffle_epi32(vq31prod2x0213, _MM_SHUFFLE(3, 1, 2, 0));
-  const __m128i vq31prod3x0123 =
-      _mm_shuffle_epi32(vq31prod3x0213, _MM_SHUFFLE(3, 1, 2, 0));
-
-  const __m128i vremainder_mask =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.remainder_mask);
-
-  const __m128i vrem0x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod0x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod0x0123));
-  const __m128i vrem1x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod1x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod1x0123));
-  const __m128i vrem2x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod2x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod2x0123));
-  const __m128i vrem3x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod3x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod3x0123));
-
-  const __m128i vremainder_threshold = _mm_load_si128(
-      (const __m128i*)quantization_params->sse2.remainder_threshold);
-  const __m128i vshift =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.shift);
-
-  vacc0x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod0x0123, vshift),
-      _mm_cmpgt_epi32(vrem0x0123, vremainder_threshold));
-  vacc1x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod1x0123, vshift),
-      _mm_cmpgt_epi32(vrem1x0123, vremainder_threshold));
-  vacc2x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod2x0123, vshift),
-      _mm_cmpgt_epi32(vrem2x0123, vremainder_threshold));
-  vacc3x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod3x0123, vshift),
-      _mm_cmpgt_epi32(vrem3x0123, vremainder_threshold));
+  vacc0x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc0x0123),
+                  vmultiplier
+                  )
+                );
+  vacc1x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc1x0123),
+                  vmultiplier
+                  )
+                );
+  vacc2x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc2x0123),
+                  vmultiplier
+                  )
+                );
+  vacc3x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc3x0123),
+                  vmultiplier
+                  )
+                );
 
   const __m128i voutput_zero_point = _mm_load_si128(
       (const __m128i*)quantization_params->sse2.output_zero_point);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x8-aarch32-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x8-aarch32-neon.S
@@ -65,6 +65,8 @@ BEGIN_FUNCTION pytorch_q8conv_ukernel_4x8__aarch32_neon
     # Load multiplier:
     # - d12 = vmultiplier
     VLD1.32 {d12[]}, [r9]!
+    # add 4 bytes to get to vfmax
+    ADD r9, r9, 4
 
     .p2align 5
 0:
@@ -637,103 +639,99 @@ BEGIN_FUNCTION pytorch_q8conv_ukernel_4x8__aarch32_neon
     SUBS r3, r3, 1
     BNE 0b
 
-    # Load right_shift
-    # - q4 = d8:d9 = vright_shift
+    # Load vfmax:
+    VLD1.32 {d10[], d11[]}, [r9]!
+    # Load vfmin:
     VLD1.32 {d8[], d9[]}, [r9]!
+    # Load vfmagic:
+    VLD1.32 {d0[], d1[]}, [r9]!
+    # Load vimagic:
+    VLD1.32 {d2[], d3[]}, [r9]!
 
-    VQRDMULH.S32  q8, q8, d12[0]
-    VQRDMULH.S32  q9, q9, d12[0]
-    VQRDMULH.S32 q10, q10, d12[0]
-    VQRDMULH.S32 q11, q11, d12[0]
+    VCVT.F32.S32 q8, q8
+    VCVT.F32.S32 q9, q9
+    VCVT.F32.S32 q10, q10
+    VCVT.F32.S32 q11, q11
+    VCVT.F32.S32 q12, q12
+    VCVT.F32.S32 q13, q13
+    VCVT.F32.S32 q14, q14
+    VCVT.F32.S32 q15, q15
 
-    # Compute vzero_shift_mask
-    # - q5 = vzero_shift_mask
-    VCEQ.S32 q5, q4, 0
+    VMUL.F32 q8, q8, d12[0]
+    VMUL.F32 q9, q9, d12[0]
+    VMUL.F32 q10, q10, d12[0]
+    VMUL.F32 q11, q11, d12[0]
+    VMUL.F32 q12, q12, d12[0]
+    VMUL.F32 q13, q13, d12[0]
+    VMUL.F32 q14, q14, d12[0]
+    VMUL.F32 q15, q15, d12[0]
 
-    VQRDMULH.S32 q12, q12, d12[0]
-    VQRDMULH.S32 q13, q13, d12[0]
-    VQRDMULH.S32 q14, q14, d12[0]
-    VQRDMULH.S32 q15, q15, d12[0]
+    VMIN.F32 q8, q8, q5
+    VMIN.F32 q9, q9, q5
+    VMIN.F32 q10, q10, q5
+    VMIN.F32 q11, q11, q5
+    VMIN.F32 q12, q12, q5
+    VMIN.F32 q13, q13, q5
+    VMIN.F32 q14, q14, q5
+    VMIN.F32 q15, q15, q5
 
-    VBIC q0,  q8, q5
-    VBIC q1,  q9, q5
-    VBIC q2, q10, q5
-    VBIC q3, q11, q5
+    VMAX.F32 q8, q8, q4
+    VMAX.F32 q9, q9, q4
+    VMAX.F32 q10, q10, q4
+    VMAX.F32 q11, q11, q4
+    VMAX.F32 q12, q12, q4
+    VMAX.F32 q13, q13, q4
+    VMAX.F32 q14, q14, q4
+    VMAX.F32 q15, q15, q4
 
-    VSRA.S32  q8, q0, 31
-    VSRA.S32  q9, q1, 31
-    VSRA.S32 q10, q2, 31
-    VSRA.S32 q11, q3, 31
-
-    # Load output_zero_point
-    # - q7 = d14:d15 = voutput_zero_point
-    VLD1.16 {d14[], d15[]}, [r9]!
-
-    VBIC q0, q12, q5
-    VBIC q1, q13, q5
-    VBIC q2, q14, q5
-    VBIC q3, q15, q5
-
-    VSRA.S32 q12, q0, 31
-    VSRA.S32 q13, q1, 31
-    VSRA.S32 q14, q2, 31
-    VSRA.S32 q15, q3, 31
-
-    # Load max:
-    # - q5 = d10:d11 = voutput_max
-    VLD1.8 {d10[], d11[]}, [r9]!
-
-    VRSHL.S32  q8,  q8, q4
-    VRSHL.S32  q9,  q9, q4
-    VRSHL.S32 q10, q10, q4
-    VRSHL.S32 q11, q11, q4
-    VRSHL.S32 q12, q12, q4
-    VRSHL.S32 q13, q13, q4
-    VRSHL.S32 q14, q14, q4
-    VRSHL.S32 q15, q15, q4
+    VADD.F32 q8, q8, q0
+    VADD.F32 q9, q9, q0
+    VADD.F32 q10, q10, q0
+    VADD.F32 q11, q11, q0
+    VADD.F32 q12, q12, q0
+    VADD.F32 q13, q13, q0
+    VADD.F32 q14, q14, q0
+    VADD.F32 q15, q15, q0
 
     # Load c, c_stride:
     # - r2 = c
-    # - r3 = c_stride
+    # - r2 = c_stride
     LDRD r2, r3, [sp, 104]
 
+    VSUB.S32 q8, q8, q1
+    VSUB.S32 q9, q9, q1
+    VSUB.S32 q10, q10, q1
+    VSUB.S32 q11, q11, q1
+    VSUB.S32 q12, q12, q1
+    VSUB.S32 q13, q13, q1
+    VSUB.S32 q14, q14, q1
+    VSUB.S32 q15, q15, q1
+
+    ADD r4, r2, r3
     VQMOVN.S32 d16,  q8
     VQMOVN.S32 d17,  q9
+    CMP r0, 2
     VQMOVN.S32 d18, q10
     VQMOVN.S32 d19, q11
+    MOVLO r4, r2
     VQMOVN.S32 d20, q12
     VQMOVN.S32 d21, q13
     VQMOVN.S32 d22, q14
     VQMOVN.S32 d23, q15
 
-    # Load min:
-    # - q4 = q8:q9 = voutput_min
-    VLD1.8 {d8[], d9[]}, [r9]!
-    ADD r4, r2, r3
 
-    VQADD.S16  q8,  q8, q7
-    VQADD.S16  q9,  q9, q7
-    CMP r0, 2
-    VQADD.S16 q10, q10, q7
-    VQADD.S16 q11, q11, q7
-    MOVLO r4, r2
-
-    VQMOVUN.S16 d16,  q8
-    VQMOVUN.S16 d17,  q9
     ADD r5, r4, r3
-    VQMOVUN.S16 d18, q10
-    VQMOVUN.S16 d19, q11
+    VQMOVUN.S16 d16,  q8
     MOVLS r5, r4
-
-    VMIN.U8 q8, q8, q5
+    VQMOVUN.S16 d17,  q9
+    VQMOVUN.S16 d18, q10
     CMP r0, 4
-    VMIN.U8 q9, q9, q5
     ADD r3, r5, r3
 
-    VMAX.U8 q8, q8, q4
     MOVNE r3, r5
     CMP r1, 8
-    VMAX.U8 q9, q9, q4
+    VQMOVUN.S16 d19, q11
+
 
     BNE 5f
 

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-aarch64-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-aarch64-neon.S
@@ -511,96 +511,71 @@ BEGIN_FUNCTION pytorch_q8conv_ukernel_8x8__aarch64_neon
     SUB x3, x3, 1
     CBNZ x3, 3b
 
-    // Load right_shift:
-    // - v27 = vright_shift
-    LD1R {v27.4s}, [x8], 4
-
-    SQRDMULH  v8.4s,  v8.4s, v26.4s
-    SQRDMULH  v9.4s,  v9.4s, v26.4s
-    SQRDMULH v10.4s, v10.4s, v26.4s
-    SQRDMULH v11.4s, v11.4s, v26.4s
-    SQRDMULH v12.4s, v12.4s, v26.4s
-    SQRDMULH v13.4s, v13.4s, v26.4s
-    SQRDMULH v14.4s, v14.4s, v26.4s
-    SQRDMULH v15.4s, v15.4s, v26.4s
-
-    // Compute vzero_shift_mask
-    // - v28 = vzero_shift_mask
-    CMEQ v28.4s, v27.4s, 0
-
-    SQRDMULH v16.4s, v16.4s, v26.4s
-    SQRDMULH v17.4s, v17.4s, v26.4s
-    SQRDMULH v18.4s, v18.4s, v26.4s
-    SQRDMULH v19.4s, v19.4s, v26.4s
-    SQRDMULH v20.4s, v20.4s, v26.4s
-    SQRDMULH v21.4s, v21.4s, v26.4s
-    SQRDMULH v22.4s, v22.4s, v26.4s
-    SQRDMULH v23.4s, v23.4s, v26.4s
-
     // Load zero_point:
     // - v29 = vzero_point
     LD1R {v29.8h}, [x8], 2
-
-    BIC v0.16b,  v8.16b, v28.16b
-    BIC v1.16b,  v9.16b, v28.16b
-    BIC v2.16b, v10.16b, v28.16b
-    BIC v3.16b, v11.16b, v28.16b
-    BIC v4.16b, v12.16b, v28.16b
-    BIC v5.16b, v13.16b, v28.16b
-    BIC v6.16b, v14.16b, v28.16b
-    BIC v7.16b, v15.16b, v28.16b
-
-    SSRA  v8.4s, v0.4s, 31
-    SSRA  v9.4s, v1.4s, 31
-    SSRA v10.4s, v2.4s, 31
-    SSRA v11.4s, v3.4s, 31
-    SSRA v12.4s, v4.4s, 31
-    SSRA v13.4s, v5.4s, 31
-    SSRA v14.4s, v6.4s, 31
-    SSRA v15.4s, v7.4s, 31
 
     // Load max:
     // - v30 = vmax
     LD1R {v30.16b}, [x8], 1
 
-    BIC v0.16b, v16.16b, v28.16b
-    BIC v1.16b, v17.16b, v28.16b
-    BIC v2.16b, v18.16b, v28.16b
-    BIC v3.16b, v19.16b, v28.16b
-    BIC v4.16b, v20.16b, v28.16b
-    BIC v5.16b, v21.16b, v28.16b
-    BIC v6.16b, v22.16b, v28.16b
-    BIC v7.16b, v23.16b, v28.16b
-
-    SSRA v16.4s, v0.4s, 31
-    SSRA v17.4s, v1.4s, 31
-    SSRA v18.4s, v2.4s, 31
-    SSRA v19.4s, v3.4s, 31
-    SSRA v20.4s, v4.4s, 31
-    SSRA v21.4s, v5.4s, 31
-    SSRA v22.4s, v6.4s, 31
-    SSRA v23.4s, v7.4s, 31
-
     // Load min:
     // - v31 = vmin
     LD1R {v31.16b}, [x8]
 
-    SRSHL  v8.4s,  v8.4s, v27.4s
-    SRSHL  v9.4s,  v9.4s, v27.4s
-    SRSHL v10.4s, v10.4s, v27.4s
-    SRSHL v11.4s, v11.4s, v27.4s
-    SRSHL v12.4s, v12.4s, v27.4s
-    SRSHL v13.4s, v13.4s, v27.4s
-    SRSHL v14.4s, v14.4s, v27.4s
-    SRSHL v15.4s, v15.4s, v27.4s
-    SRSHL v16.4s, v16.4s, v27.4s
-    SRSHL v17.4s, v17.4s, v27.4s
-    SRSHL v18.4s, v18.4s, v27.4s
-    SRSHL v19.4s, v19.4s, v27.4s
-    SRSHL v20.4s, v20.4s, v27.4s
-    SRSHL v21.4s, v21.4s, v27.4s
-    SRSHL v22.4s, v22.4s, v27.4s
-    SRSHL v23.4s, v23.4s, v27.4s
+    SCVTF v8.4s, v8.4s
+    SCVTF v9.4s, v9.4s
+    SCVTF v10.4s, v10.4s
+    SCVTF v11.4s, v11.4s
+    SCVTF v12.4s, v12.4s
+    SCVTF v13.4s, v13.4s
+    SCVTF v14.4s, v14.4s
+    SCVTF v15.4s, v15.4s
+
+    SCVTF v16.4s, v16.4s
+    SCVTF v17.4s, v17.4s
+    SCVTF v18.4s, v18.4s
+    SCVTF v19.4s, v19.4s
+    SCVTF v20.4s, v20.4s
+    SCVTF v21.4s, v21.4s
+    SCVTF v22.4s, v22.4s
+    SCVTF v23.4s, v23.4s
+
+    FMUL v8.4s, v8.4s, v26.4s
+    FMUL v9.4s, v9.4s, v26.4s
+    FMUL v10.4s, v10.4s, v26.4s
+    FMUL v11.4s, v11.4s, v26.4s
+    FMUL v12.4s, v12.4s, v26.4s
+    FMUL v13.4s, v13.4s, v26.4s
+    FMUL v14.4s, v14.4s, v26.4s
+    FMUL v15.4s, v15.4s, v26.4s
+
+    FMUL v16.4s, v16.4s, v26.4s
+    FMUL v17.4s, v17.4s, v26.4s
+    FMUL v18.4s, v18.4s, v26.4s
+    FMUL v19.4s, v19.4s, v26.4s
+    FMUL v20.4s, v20.4s, v26.4s
+    FMUL v21.4s, v21.4s, v26.4s
+    FMUL v22.4s, v22.4s, v26.4s
+    FMUL v23.4s, v23.4s, v26.4s
+
+    FCVTNS v8.4s, v8.4s
+    FCVTNS v9.4s, v9.4s
+    FCVTNS v10.4s, v10.4s
+    FCVTNS v11.4s, v11.4s
+    FCVTNS v12.4s, v12.4s
+    FCVTNS v13.4s, v13.4s
+    FCVTNS v14.4s, v14.4s
+    FCVTNS v15.4s, v15.4s
+
+    FCVTNS v16.4s, v16.4s
+    FCVTNS v17.4s, v17.4s
+    FCVTNS v18.4s, v18.4s
+    FCVTNS v19.4s, v19.4s
+    FCVTNS v20.4s, v20.4s
+    FCVTNS v21.4s, v21.4s
+    FCVTNS v22.4s, v22.4s
+    FCVTNS v23.4s, v23.4s
 
     SQXTN   v8.4h,  v8.4s
     SQXTN  v10.4h, v10.4s

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-neon.c
@@ -873,82 +873,63 @@ void pytorch_q8conv_ukernel_8x8__neon(
     }
   } while (--ks != 0);
 
-  const int32x4_t vmultiplier =
-      vld1q_dup_s32(&quantization_params->neon.multiplier);
-  vacc0x0123 = vqrdmulhq_s32(vacc0x0123, vmultiplier);
-  vacc0x4567 = vqrdmulhq_s32(vacc0x4567, vmultiplier);
-  vacc1x0123 = vqrdmulhq_s32(vacc1x0123, vmultiplier);
-  vacc1x4567 = vqrdmulhq_s32(vacc1x4567, vmultiplier);
-  vacc2x0123 = vqrdmulhq_s32(vacc2x0123, vmultiplier);
-  vacc2x4567 = vqrdmulhq_s32(vacc2x4567, vmultiplier);
-  vacc3x0123 = vqrdmulhq_s32(vacc3x0123, vmultiplier);
-  vacc3x4567 = vqrdmulhq_s32(vacc3x4567, vmultiplier);
-  vacc4x0123 = vqrdmulhq_s32(vacc4x0123, vmultiplier);
-  vacc4x4567 = vqrdmulhq_s32(vacc4x4567, vmultiplier);
-  vacc5x0123 = vqrdmulhq_s32(vacc5x0123, vmultiplier);
-  vacc5x4567 = vqrdmulhq_s32(vacc5x4567, vmultiplier);
-  vacc6x0123 = vqrdmulhq_s32(vacc6x0123, vmultiplier);
-  vacc6x4567 = vqrdmulhq_s32(vacc6x4567, vmultiplier);
-  vacc7x0123 = vqrdmulhq_s32(vacc7x0123, vmultiplier);
-  vacc7x4567 = vqrdmulhq_s32(vacc7x4567, vmultiplier);
+  const float32x4_t requantization_scale_v =
+      vdupq_n_f32(quantization_params->neon.requantization_scale);
 
-  const int32x4_t vright_shift =
-      vld1q_dup_s32(&quantization_params->neon.right_shift);
-  const int32x4_t vzero_shift_mask =
-      vreinterpretq_s32_u32(vceqq_s32(vright_shift, vmovq_n_s32(0)));
-  vacc0x0123 =
-      vsraq_n_s32(vacc0x0123, vbicq_s32(vacc0x0123, vzero_shift_mask), 31);
-  vacc0x4567 =
-      vsraq_n_s32(vacc0x4567, vbicq_s32(vacc0x4567, vzero_shift_mask), 31);
-  vacc1x0123 =
-      vsraq_n_s32(vacc1x0123, vbicq_s32(vacc1x0123, vzero_shift_mask), 31);
-  vacc1x4567 =
-      vsraq_n_s32(vacc1x4567, vbicq_s32(vacc1x4567, vzero_shift_mask), 31);
-  vacc2x0123 =
-      vsraq_n_s32(vacc2x0123, vbicq_s32(vacc2x0123, vzero_shift_mask), 31);
-  vacc2x4567 =
-      vsraq_n_s32(vacc2x4567, vbicq_s32(vacc2x4567, vzero_shift_mask), 31);
-  vacc3x0123 =
-      vsraq_n_s32(vacc3x0123, vbicq_s32(vacc3x0123, vzero_shift_mask), 31);
-  vacc3x4567 =
-      vsraq_n_s32(vacc3x4567, vbicq_s32(vacc3x4567, vzero_shift_mask), 31);
-  vacc4x0123 =
-      vsraq_n_s32(vacc4x0123, vbicq_s32(vacc4x0123, vzero_shift_mask), 31);
-  vacc4x4567 =
-      vsraq_n_s32(vacc4x4567, vbicq_s32(vacc4x4567, vzero_shift_mask), 31);
-  vacc5x0123 =
-      vsraq_n_s32(vacc5x0123, vbicq_s32(vacc5x0123, vzero_shift_mask), 31);
-  vacc5x4567 =
-      vsraq_n_s32(vacc5x4567, vbicq_s32(vacc5x4567, vzero_shift_mask), 31);
-  vacc6x0123 =
-      vsraq_n_s32(vacc6x0123, vbicq_s32(vacc6x0123, vzero_shift_mask), 31);
-  vacc6x4567 =
-      vsraq_n_s32(vacc6x4567, vbicq_s32(vacc6x4567, vzero_shift_mask), 31);
-  vacc7x0123 =
-      vsraq_n_s32(vacc7x0123, vbicq_s32(vacc7x0123, vzero_shift_mask), 31);
-  vacc7x4567 =
-      vsraq_n_s32(vacc7x4567, vbicq_s32(vacc7x4567, vzero_shift_mask), 31);
+  const float32x4_t vacc0x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc0x0123), requantization_scale_v);
+  const float32x4_t vacc1x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc1x0123), requantization_scale_v);
+  const float32x4_t vacc2x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc2x0123), requantization_scale_v);
+  const float32x4_t vacc3x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc3x0123), requantization_scale_v);
+  const float32x4_t vacc0x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc0x4567), requantization_scale_v);
+  const float32x4_t vacc1x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc1x4567), requantization_scale_v);
+  const float32x4_t vacc2x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc2x4567), requantization_scale_v);
+  const float32x4_t vacc3x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc3x4567), requantization_scale_v);
+  const float32x4_t vacc4x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc4x0123), requantization_scale_v);
+  const float32x4_t vacc5x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc5x0123), requantization_scale_v);
+  const float32x4_t vacc6x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc6x0123), requantization_scale_v);
+  const float32x4_t vacc7x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc7x0123), requantization_scale_v);
+  const float32x4_t vacc4x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc4x4567), requantization_scale_v);
+  const float32x4_t vacc5x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc5x4567), requantization_scale_v);
+  const float32x4_t vacc6x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc6x4567), requantization_scale_v);
+  const float32x4_t vacc7x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc7x4567), requantization_scale_v);
 
-  vacc0x0123 = vrshlq_s32(vacc0x0123, vright_shift);
-  vacc0x4567 = vrshlq_s32(vacc0x4567, vright_shift);
-  vacc1x0123 = vrshlq_s32(vacc1x0123, vright_shift);
-  vacc1x4567 = vrshlq_s32(vacc1x4567, vright_shift);
-  vacc2x0123 = vrshlq_s32(vacc2x0123, vright_shift);
-  vacc2x4567 = vrshlq_s32(vacc2x4567, vright_shift);
-  vacc3x0123 = vrshlq_s32(vacc3x0123, vright_shift);
-  vacc3x4567 = vrshlq_s32(vacc3x4567, vright_shift);
-  vacc4x0123 = vrshlq_s32(vacc4x0123, vright_shift);
-  vacc4x4567 = vrshlq_s32(vacc4x4567, vright_shift);
-  vacc5x0123 = vrshlq_s32(vacc5x0123, vright_shift);
-  vacc5x4567 = vrshlq_s32(vacc5x4567, vright_shift);
-  vacc6x0123 = vrshlq_s32(vacc6x0123, vright_shift);
-  vacc6x4567 = vrshlq_s32(vacc6x4567, vright_shift);
-  vacc7x0123 = vrshlq_s32(vacc7x0123, vright_shift);
-  vacc7x4567 = vrshlq_s32(vacc7x4567, vright_shift);
-
+#ifdef __aarch64__
   const int16x8_t voutput_zero_point =
       vld1q_dup_s16(&quantization_params->neon.output_zero_point);
-#ifdef __aarch64__
+
+  vacc0x0123 = vcvtnq_s32_f32(vacc0x0123_f);
+  vacc1x0123 = vcvtnq_s32_f32(vacc1x0123_f);
+  vacc2x0123 = vcvtnq_s32_f32(vacc2x0123_f);
+  vacc3x0123 = vcvtnq_s32_f32(vacc3x0123_f);
+  vacc0x4567 = vcvtnq_s32_f32(vacc0x4567_f);
+  vacc1x4567 = vcvtnq_s32_f32(vacc1x4567_f);
+  vacc2x4567 = vcvtnq_s32_f32(vacc2x4567_f);
+  vacc3x4567 = vcvtnq_s32_f32(vacc3x4567_f);
+  vacc4x0123 = vcvtnq_s32_f32(vacc4x0123_f);
+  vacc5x0123 = vcvtnq_s32_f32(vacc5x0123_f);
+  vacc6x0123 = vcvtnq_s32_f32(vacc6x0123_f);
+  vacc7x0123 = vcvtnq_s32_f32(vacc7x0123_f);
+  vacc4x4567 = vcvtnq_s32_f32(vacc4x4567_f);
+  vacc5x4567 = vcvtnq_s32_f32(vacc5x4567_f);
+  vacc6x4567 = vcvtnq_s32_f32(vacc6x4567_f);
+  vacc7x4567 = vcvtnq_s32_f32(vacc7x4567_f);
+
   const int16x8_t vacc0x01234567 = vqaddq_s16(
       vqmovn_high_s32(vqmovn_s32(vacc0x0123), vacc0x4567), voutput_zero_point);
   const int16x8_t vacc1x01234567 = vqaddq_s16(
@@ -974,41 +955,7 @@ void pytorch_q8conv_ukernel_8x8__neon(
       vqmovun_high_s16(vqmovun_s16(vacc4x01234567), vacc5x01234567);
   uint8x16_t vout6x01234567_7x01234567 =
       vqmovun_high_s16(vqmovun_s16(vacc6x01234567), vacc7x01234567);
-#else
-  const int16x8_t vacc0x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc0x0123), vqmovn_s32(vacc0x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc1x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc1x0123), vqmovn_s32(vacc1x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc2x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc2x0123), vqmovn_s32(vacc2x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc3x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc3x0123), vqmovn_s32(vacc3x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc4x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc4x0123), vqmovn_s32(vacc4x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc5x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc5x0123), vqmovn_s32(vacc5x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc6x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc6x0123), vqmovn_s32(vacc6x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc7x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc7x0123), vqmovn_s32(vacc7x4567)),
-      voutput_zero_point);
 
-  uint8x16_t vout0x01234567_1x01234567 =
-      vcombine_u8(vqmovun_s16(vacc0x01234567), vqmovun_s16(vacc1x01234567));
-  uint8x16_t vout2x01234567_3x01234567 =
-      vcombine_u8(vqmovun_s16(vacc2x01234567), vqmovun_s16(vacc3x01234567));
-  uint8x16_t vout4x01234567_5x01234567 =
-      vcombine_u8(vqmovun_s16(vacc4x01234567), vqmovun_s16(vacc5x01234567));
-  uint8x16_t vout6x01234567_7x01234567 =
-      vcombine_u8(vqmovun_s16(vacc6x01234567), vqmovun_s16(vacc7x01234567));
-#endif
   const uint8x16_t voutput_min =
       vld1q_dup_u8(&quantization_params->neon.output_min);
   const uint8x16_t voutput_max =
@@ -1022,6 +969,104 @@ void pytorch_q8conv_ukernel_8x8__neon(
   vout2x01234567_3x01234567 = vminq_u8(vout2x01234567_3x01234567, voutput_max);
   vout4x01234567_5x01234567 = vminq_u8(vout4x01234567_5x01234567, voutput_max);
   vout6x01234567_7x01234567 = vminq_u8(vout6x01234567_7x01234567, voutput_max);
+#else
+  const float32x4_t vfmin = vdupq_n_f32(quantization_params->neon.vfmin);
+  const float32x4_t vfmax = vdupq_n_f32(quantization_params->neon.vfmax);
+  const float32x4_t vfmagic = vdupq_n_f32(quantization_params->neon.vfmagic);
+  const int32x4_t vimagic = vdupq_n_s32(quantization_params->neon.vimagic);
+
+  const float32x4_t vacc0x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc0x0123_f, vfmin), vfmax);
+  const float32x4_t vacc1x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc1x0123_f, vfmin), vfmax);
+  const float32x4_t vacc2x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc2x0123_f, vfmin), vfmax);
+  const float32x4_t vacc3x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc3x0123_f, vfmin), vfmax);
+  const float32x4_t vacc0x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc0x4567_f, vfmin), vfmax);
+  const float32x4_t vacc1x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc1x4567_f, vfmin), vfmax);
+  const float32x4_t vacc2x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc2x4567_f, vfmin), vfmax);
+  const float32x4_t vacc3x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc3x4567_f, vfmin), vfmax);
+  const float32x4_t vacc4x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc4x0123_f, vfmin), vfmax);
+  const float32x4_t vacc5x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc5x0123_f, vfmin), vfmax);
+  const float32x4_t vacc6x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc6x0123_f, vfmin), vfmax);
+  const float32x4_t vacc7x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc7x0123_f, vfmin), vfmax);
+  const float32x4_t vacc4x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc4x4567_f, vfmin), vfmax);
+  const float32x4_t vacc5x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc5x4567_f, vfmin), vfmax);
+  const float32x4_t vacc6x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc6x4567_f, vfmin), vfmax);
+  const float32x4_t vacc7x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc7x4567_f, vfmin), vfmax);
+
+  vacc0x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc0x0123_f_clamped, vfmagic)), vimagic);
+  vacc1x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc1x0123_f_clamped, vfmagic)), vimagic);
+  vacc2x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc2x0123_f_clamped, vfmagic)), vimagic);
+  vacc3x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc3x0123_f_clamped, vfmagic)), vimagic);
+  vacc0x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc0x4567_f_clamped, vfmagic)), vimagic);
+  vacc1x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc1x4567_f_clamped, vfmagic)), vimagic);
+  vacc2x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc2x4567_f_clamped, vfmagic)), vimagic);
+  vacc3x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc3x4567_f_clamped, vfmagic)), vimagic);
+  vacc4x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc4x0123_f_clamped, vfmagic)), vimagic);
+  vacc5x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc5x0123_f_clamped, vfmagic)), vimagic);
+  vacc6x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc6x0123_f_clamped, vfmagic)), vimagic);
+  vacc7x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc7x0123_f_clamped, vfmagic)), vimagic);
+  vacc4x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc4x4567_f_clamped, vfmagic)), vimagic);
+  vacc5x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc5x4567_f_clamped, vfmagic)), vimagic);
+  vacc6x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc6x4567_f_clamped, vfmagic)), vimagic);
+  vacc7x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc7x4567_f_clamped, vfmagic)), vimagic);
+
+  const int16x8_t vacc0x01234567 =
+      vcombine_s16(vqmovn_s32(vacc0x0123), vqmovn_s32(vacc0x4567));
+  const int16x8_t vacc1x01234567 =
+      vcombine_s16(vqmovn_s32(vacc1x0123), vqmovn_s32(vacc1x4567));
+  const int16x8_t vacc2x01234567 =
+      vcombine_s16(vqmovn_s32(vacc2x0123), vqmovn_s32(vacc2x4567));
+  const int16x8_t vacc3x01234567 =
+      vcombine_s16(vqmovn_s32(vacc3x0123), vqmovn_s32(vacc3x4567));
+  const int16x8_t vacc4x01234567 =
+      vcombine_s16(vqmovn_s32(vacc4x0123), vqmovn_s32(vacc4x4567));
+  const int16x8_t vacc5x01234567 =
+      vcombine_s16(vqmovn_s32(vacc5x0123), vqmovn_s32(vacc5x4567));
+  const int16x8_t vacc6x01234567 =
+      vcombine_s16(vqmovn_s32(vacc6x0123), vqmovn_s32(vacc6x4567));
+  const int16x8_t vacc7x01234567 =
+      vcombine_s16(vqmovn_s32(vacc7x0123), vqmovn_s32(vacc7x4567));
+
+  uint8x16_t vout0x01234567_1x01234567 =
+      vcombine_u8(vqmovun_s16(vacc0x01234567), vqmovun_s16(vacc1x01234567));
+  uint8x16_t vout2x01234567_3x01234567 =
+      vcombine_u8(vqmovun_s16(vacc2x01234567), vqmovun_s16(vacc3x01234567));
+  uint8x16_t vout4x01234567_5x01234567 =
+      vcombine_u8(vqmovun_s16(vacc4x01234567), vqmovun_s16(vacc5x01234567));
+  uint8x16_t vout6x01234567_7x01234567 =
+      vcombine_u8(vqmovun_s16(vacc6x01234567), vqmovun_s16(vacc7x01234567));
+#endif
 
   uint8_t* c0 = c;
   uint8_t* c1 = (uint8_t*)((uintptr_t)c0 + c_stride);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/mp8x25-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/mp8x25-sse2.c
@@ -808,106 +808,26 @@ void pytorch_q8dwconv_ukernel_mp8x25__sse2(
             _mm_add_epi32(vacc_hi, _mm_loadu_si128((__m128i*)(outacc + 4)));
         outacc += 8;
 
-        const __m128i vmultiplier = _mm_load_si128(
-            (const __m128i*)quantization_params->sse2.multiplier);
-        const __m128i vrounding =
-            _mm_load_si128((const __m128i*)quantization_params->sse2.rounding);
+        const __m128 vmultiplier =
+            _mm_loadu_ps(quantization_params->sse2.requantization_scale);
 
-        const __m128i vnmask_lo0123 =
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vacc_lo);
-        const __m128i vnmask_hi0123 =
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vacc_hi);
-
-        const __m128i vabsacc_lo0123 =
-            _mm_sub_epi32(_mm_xor_si128(vacc_lo, vnmask_lo0123), vnmask_lo0123);
-        const __m128i vabsacc_hi0123 =
-            _mm_sub_epi32(_mm_xor_si128(vacc_hi, vnmask_hi0123), vnmask_hi0123);
-
-        const __m128i vabsacc_lo1032 =
-            _mm_shuffle_epi32(vabsacc_lo0123, _MM_SHUFFLE(2, 3, 0, 1));
-        const __m128i vabsacc_hi1032 =
-            _mm_shuffle_epi32(vabsacc_hi0123, _MM_SHUFFLE(2, 3, 0, 1));
-
-        const __m128i vabsprod_lo02 =
-            _mm_mul_epu32(vabsacc_lo0123, vmultiplier);
-        const __m128i vabsprod_hi02 =
-            _mm_mul_epu32(vabsacc_hi0123, vmultiplier);
-
-        const __m128i vnmask_lo02 =
-            _mm_shuffle_epi32(vnmask_lo0123, _MM_SHUFFLE(2, 2, 0, 0));
-        const __m128i vnmask_hi02 =
-            _mm_shuffle_epi32(vnmask_hi0123, _MM_SHUFFLE(2, 2, 0, 0));
-
-        const __m128i vprod_lo02 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_lo02, vnmask_lo02), vnmask_lo02);
-        const __m128i vprod_hi02 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_hi02, vnmask_hi02), vnmask_hi02);
-
-        const __m128i vq31prod_lo02 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_lo02, vrounding), 31);
-        const __m128i vq31prod_hi02 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_hi02, vrounding), 31);
-
-        const __m128i vabsprod_lo13 =
-            _mm_mul_epu32(vabsacc_lo1032, vmultiplier);
-        const __m128i vabsprod_hi13 =
-            _mm_mul_epu32(vabsacc_hi1032, vmultiplier);
-
-        const __m128i vnmask_lo13 =
-            _mm_shuffle_epi32(vnmask_lo0123, _MM_SHUFFLE(3, 3, 1, 1));
-        const __m128i vnmask_hi13 =
-            _mm_shuffle_epi32(vnmask_hi0123, _MM_SHUFFLE(3, 3, 1, 1));
-
-        const __m128i vprod_lo13 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_lo13, vnmask_lo13), vnmask_lo13);
-        const __m128i vprod_hi13 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_hi13, vnmask_hi13), vnmask_hi13);
-
-        const __m128i vq31prod_lo13 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_lo13, vrounding), 31);
-        const __m128i vq31prod_hi13 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_hi13, vrounding), 31);
-
-        const __m128i vq31prod_lo0213 = _mm_castps_si128(_mm_shuffle_ps(
-            _mm_castsi128_ps(vq31prod_lo02),
-            _mm_castsi128_ps(vq31prod_lo13),
-            _MM_SHUFFLE(2, 0, 2, 0)));
-        const __m128i vq31prod_hi0213 = _mm_castps_si128(_mm_shuffle_ps(
-            _mm_castsi128_ps(vq31prod_hi02),
-            _mm_castsi128_ps(vq31prod_hi13),
-            _MM_SHUFFLE(2, 0, 2, 0)));
-
-        const __m128i vq31prod_lo0123 =
-            _mm_shuffle_epi32(vq31prod_lo0213, _MM_SHUFFLE(3, 1, 2, 0));
-        const __m128i vq31prod_hi0123 =
-            _mm_shuffle_epi32(vq31prod_hi0213, _MM_SHUFFLE(3, 1, 2, 0));
-
-        const __m128i vremainder_mask = _mm_load_si128(
-            (const __m128i*)quantization_params->sse2.remainder_mask);
-
-        const __m128i vrem_lo0123 = _mm_add_epi32(
-            _mm_and_si128(vq31prod_lo0123, vremainder_mask),
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod_lo0123));
-        const __m128i vrem_hi0123 = _mm_add_epi32(
-            _mm_and_si128(vq31prod_hi0123, vremainder_mask),
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod_hi0123));
-
-        const __m128i vremainder_threshold = _mm_load_si128(
-            (const __m128i*)quantization_params->sse2.remainder_threshold);
-        const __m128i vshift =
-            _mm_load_si128((const __m128i*)quantization_params->sse2.shift);
-
-        const __m128i vout_lo = _mm_sub_epi32(
-            _mm_sra_epi32(vq31prod_lo0123, vshift),
-            _mm_cmpgt_epi32(vrem_lo0123, vremainder_threshold));
-        const __m128i vout_hi = _mm_sub_epi32(
-            _mm_sra_epi32(vq31prod_hi0123, vshift),
-            _mm_cmpgt_epi32(vrem_hi0123, vremainder_threshold));
+        vacc_lo = _mm_cvtps_epi32(
+                      _mm_mul_ps(
+                        _mm_cvtepi32_ps(vacc_lo),
+                        vmultiplier
+                        )
+                      );
+        vacc_hi = _mm_cvtps_epi32(
+                      _mm_mul_ps(
+                        _mm_cvtepi32_ps(vacc_hi),
+                        vmultiplier
+                        )
+                      );
 
         const __m128i voutput_zero_point = _mm_load_si128(
             (const __m128i*)quantization_params->sse2.output_zero_point);
         __m128i vout = _mm_adds_epi16(
-            _mm_packs_epi32(vout_lo, vout_hi), voutput_zero_point);
+            _mm_packs_epi32(vacc_lo, vacc_hi), voutput_zero_point);
         vout = _mm_packus_epi16(vout, vout);
         vout = _mm_max_epu8(
             vout,
@@ -1007,106 +927,26 @@ void pytorch_q8dwconv_ukernel_mp8x25__sse2(
             _mm_add_epi32(vacc_hi, _mm_loadu_si128((__m128i*)(outacc + 4)));
         outacc += 8;
 
-        const __m128i vmultiplier = _mm_load_si128(
-            (const __m128i*)quantization_params->sse2.multiplier);
-        const __m128i vrounding =
-            _mm_load_si128((const __m128i*)quantization_params->sse2.rounding);
+        const __m128 vmultiplier =
+            _mm_loadu_ps(quantization_params->sse2.requantization_scale);
 
-        const __m128i vnmask_lo0123 =
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vacc_lo);
-        const __m128i vnmask_hi0123 =
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vacc_hi);
-
-        const __m128i vabsacc_lo0123 =
-            _mm_sub_epi32(_mm_xor_si128(vacc_lo, vnmask_lo0123), vnmask_lo0123);
-        const __m128i vabsacc_hi0123 =
-            _mm_sub_epi32(_mm_xor_si128(vacc_hi, vnmask_hi0123), vnmask_hi0123);
-
-        const __m128i vabsacc_lo1032 =
-            _mm_shuffle_epi32(vabsacc_lo0123, _MM_SHUFFLE(2, 3, 0, 1));
-        const __m128i vabsacc_hi1032 =
-            _mm_shuffle_epi32(vabsacc_hi0123, _MM_SHUFFLE(2, 3, 0, 1));
-
-        const __m128i vabsprod_lo02 =
-            _mm_mul_epu32(vabsacc_lo0123, vmultiplier);
-        const __m128i vabsprod_hi02 =
-            _mm_mul_epu32(vabsacc_hi0123, vmultiplier);
-
-        const __m128i vnmask_lo02 =
-            _mm_shuffle_epi32(vnmask_lo0123, _MM_SHUFFLE(2, 2, 0, 0));
-        const __m128i vnmask_hi02 =
-            _mm_shuffle_epi32(vnmask_hi0123, _MM_SHUFFLE(2, 2, 0, 0));
-
-        const __m128i vprod_lo02 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_lo02, vnmask_lo02), vnmask_lo02);
-        const __m128i vprod_hi02 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_hi02, vnmask_hi02), vnmask_hi02);
-
-        const __m128i vq31prod_lo02 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_lo02, vrounding), 31);
-        const __m128i vq31prod_hi02 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_hi02, vrounding), 31);
-
-        const __m128i vabsprod_lo13 =
-            _mm_mul_epu32(vabsacc_lo1032, vmultiplier);
-        const __m128i vabsprod_hi13 =
-            _mm_mul_epu32(vabsacc_hi1032, vmultiplier);
-
-        const __m128i vnmask_lo13 =
-            _mm_shuffle_epi32(vnmask_lo0123, _MM_SHUFFLE(3, 3, 1, 1));
-        const __m128i vnmask_hi13 =
-            _mm_shuffle_epi32(vnmask_hi0123, _MM_SHUFFLE(3, 3, 1, 1));
-
-        const __m128i vprod_lo13 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_lo13, vnmask_lo13), vnmask_lo13);
-        const __m128i vprod_hi13 = _mm_sub_epi64(
-            _mm_xor_si128(vabsprod_hi13, vnmask_hi13), vnmask_hi13);
-
-        const __m128i vq31prod_lo13 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_lo13, vrounding), 31);
-        const __m128i vq31prod_hi13 =
-            _mm_srli_epi64(_mm_add_epi64(vprod_hi13, vrounding), 31);
-
-        const __m128i vq31prod_lo0213 = _mm_castps_si128(_mm_shuffle_ps(
-            _mm_castsi128_ps(vq31prod_lo02),
-            _mm_castsi128_ps(vq31prod_lo13),
-            _MM_SHUFFLE(2, 0, 2, 0)));
-        const __m128i vq31prod_hi0213 = _mm_castps_si128(_mm_shuffle_ps(
-            _mm_castsi128_ps(vq31prod_hi02),
-            _mm_castsi128_ps(vq31prod_hi13),
-            _MM_SHUFFLE(2, 0, 2, 0)));
-
-        const __m128i vq31prod_lo0123 =
-            _mm_shuffle_epi32(vq31prod_lo0213, _MM_SHUFFLE(3, 1, 2, 0));
-        const __m128i vq31prod_hi0123 =
-            _mm_shuffle_epi32(vq31prod_hi0213, _MM_SHUFFLE(3, 1, 2, 0));
-
-        const __m128i vremainder_mask = _mm_load_si128(
-            (const __m128i*)quantization_params->sse2.remainder_mask);
-
-        const __m128i vrem_lo0123 = _mm_add_epi32(
-            _mm_and_si128(vq31prod_lo0123, vremainder_mask),
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod_lo0123));
-        const __m128i vrem_hi0123 = _mm_add_epi32(
-            _mm_and_si128(vq31prod_hi0123, vremainder_mask),
-            _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod_hi0123));
-
-        const __m128i vremainder_threshold = _mm_load_si128(
-            (const __m128i*)quantization_params->sse2.remainder_threshold);
-        const __m128i vshift =
-            _mm_load_si128((const __m128i*)quantization_params->sse2.shift);
-
-        const __m128i vout_lo = _mm_sub_epi32(
-            _mm_sra_epi32(vq31prod_lo0123, vshift),
-            _mm_cmpgt_epi32(vrem_lo0123, vremainder_threshold));
-        const __m128i vout_hi = _mm_sub_epi32(
-            _mm_sra_epi32(vq31prod_hi0123, vshift),
-            _mm_cmpgt_epi32(vrem_hi0123, vremainder_threshold));
+        vacc_lo = _mm_cvtps_epi32(
+                      _mm_mul_ps(
+                        _mm_cvtepi32_ps(vacc_lo),
+                        vmultiplier
+                        )
+                      );
+        vacc_hi = _mm_cvtps_epi32(
+                      _mm_mul_ps(
+                        _mm_cvtepi32_ps(vacc_hi),
+                        vmultiplier
+                        )
+                      );
 
         const __m128i voutput_zero_point = _mm_load_si128(
             (const __m128i*)quantization_params->sse2.output_zero_point);
         __m128i vout = _mm_adds_epi16(
-            _mm_packs_epi32(vout_lo, vout_hi), voutput_zero_point);
+            _mm_packs_epi32(vacc_lo, vacc_hi), voutput_zero_point);
         vout = _mm_packus_epi16(vout, vout);
         vout = _mm_max_epu8(
             vout,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-aarch32-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-aarch32-neon.S
@@ -51,29 +51,34 @@ BEGIN_FUNCTION pytorch_q8dwconv_ukernel_up8x9__aarch32_neon
     # - d30 = vinput_zero_point
     VLD1.8 {d30[]}, [r12], r4
 
-    # Load multiplier:
-    # - q14 = d28:d29 = vmultiplier
+    # Load requantization_scale:
+    # - q14 = d28:d29 = requantization_scale
     VLD1.32 {d28[], d29[]}, [r12]!
+    # add 4 bytes to get to vfmax
+    ADD r12, r12, 4
 
-    # Load right shift:
-    # - q13 = d26:d27 = vright_shift
+    # Load vfmax:
+    # - q13 = d26:d27 = vfmax
     VLD1.32 {d26[], d27[]}, [r12]!
 
-    # Load output zero point:
-    # - q12 = d24:d25 = voutput_zero_point
-    VLD1.16 {d24[], d25[]}, [r12]!
+    # Load vfmin:
+    # - q12 = d24:d25 = vfmin
+    VLD1.32 {d24[], d25[]}, [r12]!
 
-    # Compute vzero_shift_mask
-    # - q11 = vzero_shift_mask
-    VCEQ.S32 q11, q13, 0
+    # Load vfmagic:
+    # - q10 = d20:d21 = vfmagic
+    VLD1.32 {d20[], d21[]}, [r12]!
 
-    # Load output max:
-    # - d20 = voutput_max
-    VLD1.8 {d20[]}, [r12]!
+    # Load vimagic:
+    # - q11 = d22:d23 = vimagic
+    # Since q11/d22 gets used in the remainder channels section
+    # This load will have to occur in that section again.
+    # But since r12 is overwritten below, we will have to push it
+    # on the stack and pop it back.
+    VLD1.32 {d22[], d23[]}, [r12]
 
-    # Load output min:
-    # - d21 = voutput_min
-    VLD1.8 {d21[]}, [r12]
+    VSTR d22, [sp, #-16]
+    VSTR d23, [sp, #-24]
 
     .p2align 3
 0:
@@ -195,25 +200,27 @@ BEGIN_FUNCTION pytorch_q8dwconv_ukernel_up8x9__aarch32_neon
     VMLAL.S16 q0, d12, d14
     VMLAL.S16 q1, d13, d15
 
-    VQRDMULH.S32 q0, q0, q14
-    VQRDMULH.S32 q1, q1, q14
+    VCVT.F32.S32 q0, q0
+    VCVT.F32.S32 q1, q1
 
-    VBIC q2, q0, q11
-    VBIC q3, q1, q11
+    VMUL.F32 q0, q0, q14
+    VMUL.F32 q1, q1, q14
 
-    VSRA.S32 q0, q2, 31
-    VSRA.S32 q1, q3, 31
+    VMIN.F32 q0, q0, q13
+    VMIN.F32 q1, q1, q13
 
-    VRSHL.S32 q0, q0, q13
-    VRSHL.S32 q1, q1, q13
+    VMAX.F32 q0, q0, q12
+    VMAX.F32 q1, q1, q12
+
+    VADD.F32 q0, q0, q10
+    VADD.F32 q1, q1, q10
+
+    VSUB.S32 q0, q0, q11
+    VSUB.S32 q1, q1, q11
 
     VQMOVN.S32 d0, q0
     VQMOVN.S32 d1, q1
-
-    VQADD.S16 q0, q12
     VQMOVUN.S16 d0, q0
-    VMIN.U8 d0, d0, d20
-    VMAX.U8 d0, d0, d21
 
     VST1.8 {d0}, [lr]!
     SUBS r0, r0, 8
@@ -336,27 +343,31 @@ BEGIN_FUNCTION pytorch_q8dwconv_ukernel_up8x9__aarch32_neon
     VMLAL.S16 q0, d4, d6
     VMLAL.S16 q1, d5, d7
 
-    VQRDMULH.S32 q0, q0, q14
-    VQRDMULH.S32 q1, q1, q14
+    VLDR.64 d22, [sp, #-16]
+    VLDR.64 d23, [sp, #-24]
 
-    VCEQ.S32 q11, q13, 0
+    VCVT.F32.S32 q0, q0
+    VCVT.F32.S32 q1, q1
 
-    VBIC q2, q0, q11
-    VBIC q3, q1, q11
+    VMUL.F32 q0, q0, q14
+    VMUL.F32 q1, q1, q14
 
-    VSRA.S32 q0, q2, 31
-    VSRA.S32 q1, q3, 31
+    VMIN.F32 q0, q0, q13
+    VMIN.F32 q1, q1, q13
 
-    VRSHL.S32 q0, q0, q13
-    VRSHL.S32 q1, q1, q13
+    VMAX.F32 q0, q0, q12
+    VMAX.F32 q1, q1, q12
+
+    VADD.F32 q0, q0, q10
+    VADD.F32 q1, q1, q10
+
+    VSUB.S32 q0, q0, q11
+    VSUB.S32 q1, q1, q11
 
     VQMOVN.S32 d0, q0
     VQMOVN.S32 d1, q1
-
-    VQADD.S16 q0, q12
     VQMOVUN.S16 d0, q0
-    VMIN.U8 d0, d0, d20
-    VMAX.U8 d0, d0, d21
+
 
     TST r0, 32
     BEQ 3f

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-neon.c
@@ -25,16 +25,18 @@ void pytorch_q8dwconv_ukernel_up8x9__neon(
       vld1_dup_u8((const uint8_t*)&quantization_params->neon.input_zero_point);
   const uint8x8_t vkernel_zero_point =
       vld1_dup_u8((const uint8_t*)&quantization_params->neon.kernel_zero_point);
-  const int32x4_t vmultiplier =
-      vld1q_dup_s32(&quantization_params->neon.multiplier);
-  const int32x4_t vright_shift =
-      vld1q_dup_s32(&quantization_params->neon.right_shift);
+  const float32x4_t requantization_scale_v =
+      vdupq_n_f32(quantization_params->neon.requantization_scale);
   const int16x8_t voutput_zero_point =
       vld1q_dup_s16(&quantization_params->neon.output_zero_point);
   const uint8x8_t voutput_min =
       vld1_dup_u8(&quantization_params->neon.output_min);
   const uint8x8_t voutput_max =
       vld1_dup_u8(&quantization_params->neon.output_max);
+  const float32x4_t vfmin = vdupq_n_f32(quantization_params->neon.vfmin);
+  const float32x4_t vfmax = vdupq_n_f32(quantization_params->neon.vfmax);
+  const float32x4_t vfmagic = vdupq_n_f32(quantization_params->neon.vfmagic);
+  const int32x4_t vimagic = vdupq_n_s32(quantization_params->neon.vimagic);
 
 #ifdef __aarch64__
   /* Larger number of registers on AArch64 make it possible to process few
@@ -261,34 +263,18 @@ void pytorch_q8dwconv_ukernel_up8x9__neon(
             vmlal_s16(vacc2_lo, vget_low_s16(vxk22), vget_low_s16(vxi24));
         vacc2_hi = vmlal_high_s16(vacc2_hi, vxk22, vxi24);
 
-        vacc0_lo = vqrdmulhq_s32(vacc0_lo, vmultiplier);
-        vacc0_hi = vqrdmulhq_s32(vacc0_hi, vmultiplier);
-        vacc1_lo = vqrdmulhq_s32(vacc1_lo, vmultiplier);
-        vacc1_hi = vqrdmulhq_s32(vacc1_hi, vmultiplier);
-        vacc2_lo = vqrdmulhq_s32(vacc2_lo, vmultiplier);
-        vacc2_hi = vqrdmulhq_s32(vacc2_hi, vmultiplier);
-
-        const int32x4_t vzero_shift_mask =
-            vreinterpretq_s32_u32(vceqq_s32(vright_shift, vmovq_n_s32(0)));
-        vacc0_lo =
-            vsraq_n_s32(vacc0_lo, vbicq_s32(vacc0_lo, vzero_shift_mask), 31);
-        vacc0_hi =
-            vsraq_n_s32(vacc0_hi, vbicq_s32(vacc0_hi, vzero_shift_mask), 31);
-        vacc1_lo =
-            vsraq_n_s32(vacc1_lo, vbicq_s32(vacc1_lo, vzero_shift_mask), 31);
-        vacc1_hi =
-            vsraq_n_s32(vacc1_hi, vbicq_s32(vacc1_hi, vzero_shift_mask), 31);
-        vacc2_lo =
-            vsraq_n_s32(vacc2_lo, vbicq_s32(vacc2_lo, vzero_shift_mask), 31);
-        vacc2_hi =
-            vsraq_n_s32(vacc2_hi, vbicq_s32(vacc2_hi, vzero_shift_mask), 31);
-
-        vacc0_lo = vrshlq_s32(vacc0_lo, vright_shift);
-        vacc0_hi = vrshlq_s32(vacc0_hi, vright_shift);
-        vacc1_lo = vrshlq_s32(vacc1_lo, vright_shift);
-        vacc1_hi = vrshlq_s32(vacc1_hi, vright_shift);
-        vacc2_lo = vrshlq_s32(vacc2_lo, vright_shift);
-        vacc2_hi = vrshlq_s32(vacc2_hi, vright_shift);
+        vacc0_lo = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc0_lo), requantization_scale_v));
+        vacc0_hi = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc0_hi), requantization_scale_v));
+        vacc1_lo = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc1_lo), requantization_scale_v));
+        vacc1_hi = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc1_hi), requantization_scale_v));
+        vacc2_lo = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc2_lo), requantization_scale_v));
+        vacc2_hi = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc2_hi), requantization_scale_v));
 
         const int16x8_t vacc0 = vqaddq_s16(
             vqmovn_high_s32(vqmovn_s32(vacc0_lo), vacc0_hi),
@@ -530,34 +516,18 @@ void pytorch_q8dwconv_ukernel_up8x9__neon(
             vmlal_s16(vacc2_lo, vget_low_s16(vxk22), vget_low_s16(vxi24));
         vacc2_hi = vmlal_high_s16(vacc2_hi, vxk22, vxi24);
 
-        vacc0_lo = vqrdmulhq_s32(vacc0_lo, vmultiplier);
-        vacc0_hi = vqrdmulhq_s32(vacc0_hi, vmultiplier);
-        vacc1_lo = vqrdmulhq_s32(vacc1_lo, vmultiplier);
-        vacc1_hi = vqrdmulhq_s32(vacc1_hi, vmultiplier);
-        vacc2_lo = vqrdmulhq_s32(vacc2_lo, vmultiplier);
-        vacc2_hi = vqrdmulhq_s32(vacc2_hi, vmultiplier);
-
-        const int32x4_t vzero_shift_mask =
-            vreinterpretq_s32_u32(vceqq_s32(vright_shift, vmovq_n_s32(0)));
-        vacc0_lo =
-            vsraq_n_s32(vacc0_lo, vbicq_s32(vacc0_lo, vzero_shift_mask), 31);
-        vacc0_hi =
-            vsraq_n_s32(vacc0_hi, vbicq_s32(vacc0_hi, vzero_shift_mask), 31);
-        vacc1_lo =
-            vsraq_n_s32(vacc1_lo, vbicq_s32(vacc1_lo, vzero_shift_mask), 31);
-        vacc1_hi =
-            vsraq_n_s32(vacc1_hi, vbicq_s32(vacc1_hi, vzero_shift_mask), 31);
-        vacc2_lo =
-            vsraq_n_s32(vacc2_lo, vbicq_s32(vacc2_lo, vzero_shift_mask), 31);
-        vacc2_hi =
-            vsraq_n_s32(vacc2_hi, vbicq_s32(vacc2_hi, vzero_shift_mask), 31);
-
-        vacc0_lo = vrshlq_s32(vacc0_lo, vright_shift);
-        vacc0_hi = vrshlq_s32(vacc0_hi, vright_shift);
-        vacc1_lo = vrshlq_s32(vacc1_lo, vright_shift);
-        vacc1_hi = vrshlq_s32(vacc1_hi, vright_shift);
-        vacc2_lo = vrshlq_s32(vacc2_lo, vright_shift);
-        vacc2_hi = vrshlq_s32(vacc2_hi, vright_shift);
+        vacc0_lo = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc0_lo), requantization_scale_v));
+        vacc0_hi = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc0_hi), requantization_scale_v));
+        vacc1_lo = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc1_lo), requantization_scale_v));
+        vacc1_hi = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc1_hi), requantization_scale_v));
+        vacc2_lo = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc2_lo), requantization_scale_v));
+        vacc2_hi = vcvtnq_s32_f32(
+            vmulq_f32(vcvtq_f32_s32(vacc2_hi), requantization_scale_v));
 
         const int16x8_t vacc0 = vqaddq_s16(
             vqmovn_high_s32(vqmovn_s32(vacc0_lo), vacc0_hi),
@@ -767,28 +737,35 @@ void pytorch_q8dwconv_ukernel_up8x9__neon(
       int32x4_t vacc_lo = vaddq_s32(vaccX0_lo, vaccX1_lo);
       int32x4_t vacc_hi = vaddq_s32(vaccX0_hi, vaccX1_hi);
 
-      vacc_lo = vqrdmulhq_s32(vacc_lo, vmultiplier);
-      vacc_hi = vqrdmulhq_s32(vacc_hi, vmultiplier);
-
-      const int32x4_t vzero_shift_mask =
-          vreinterpretq_s32_u32(vceqq_s32(vright_shift, vmovq_n_s32(0)));
-      vacc_lo = vsraq_n_s32(vacc_lo, vbicq_s32(vacc_lo, vzero_shift_mask), 31);
-      vacc_hi = vsraq_n_s32(vacc_hi, vbicq_s32(vacc_hi, vzero_shift_mask), 31);
-
-      vacc_lo = vrshlq_s32(vacc_lo, vright_shift);
-      vacc_hi = vrshlq_s32(vacc_hi, vright_shift);
+      const float32x4_t vacc_lo_f =
+        vmulq_f32(vcvtq_f32_s32(vacc_lo), requantization_scale_v);
+      const float32x4_t vacc_hi_f =
+        vmulq_f32(vcvtq_f32_s32(vacc_hi), requantization_scale_v);
 
 #ifdef __aarch64__
+      vacc_lo = vcvtnq_s32_f32(vacc_lo_f);
+      vacc_hi = vcvtnq_s32_f32(vacc_hi_f);
+
       const int16x8_t vacc = vqaddq_s16(
           vqmovn_high_s32(vqmovn_s32(vacc_lo), vacc_hi), voutput_zero_point);
-#else
-      const int16x8_t vacc = vqaddq_s16(
-          vcombine_s16(vqmovn_s32(vacc_lo), vqmovn_s32(vacc_hi)),
-          voutput_zero_point);
-#endif
+
       uint8x8_t vout = vqmovun_s16(vacc);
       vout = vmax_u8(vout, voutput_min);
       vout = vmin_u8(vout, voutput_max);
+#else
+      const float32x4_t vacc_lo_f_clamped =
+          vminq_f32(vmaxq_f32(vacc_lo_f, vfmin), vfmax);
+      const float32x4_t vacc_hi_f_clamped =
+          vminq_f32(vmaxq_f32(vacc_hi_f, vfmin), vfmax);
+      vacc_lo = vsubq_s32(
+          vreinterpretq_s32_f32(vaddq_f32(vacc_lo_f_clamped, vfmagic)), vimagic);
+      vacc_hi = vsubq_s32(
+          vreinterpretq_s32_f32(vaddq_f32(vacc_hi_f_clamped, vfmagic)), vimagic);
+      const int16x8_t vacc =
+          vcombine_s16(vqmovn_s32(vacc_lo), vqmovn_s32(vacc_hi));
+
+      uint8x8_t vout = vqmovun_s16(vacc);
+#endif
 
       vst1_u8(output, vout);
       output += 8;
@@ -920,28 +897,35 @@ void pytorch_q8dwconv_ukernel_up8x9__neon(
       int32x4_t vacc_lo = vaddq_s32(vaccX0_lo, vaccX1_lo);
       int32x4_t vacc_hi = vaddq_s32(vaccX0_hi, vaccX1_hi);
 
-      vacc_lo = vqrdmulhq_s32(vacc_lo, vmultiplier);
-      vacc_hi = vqrdmulhq_s32(vacc_hi, vmultiplier);
-
-      const int32x4_t vzero_shift_mask =
-          vreinterpretq_s32_u32(vceqq_s32(vright_shift, vmovq_n_s32(0)));
-      vacc_lo = vsraq_n_s32(vacc_lo, vbicq_s32(vacc_lo, vzero_shift_mask), 31);
-      vacc_hi = vsraq_n_s32(vacc_hi, vbicq_s32(vacc_hi, vzero_shift_mask), 31);
-
-      vacc_lo = vrshlq_s32(vacc_lo, vright_shift);
-      vacc_hi = vrshlq_s32(vacc_hi, vright_shift);
+      const float32x4_t vacc_lo_f =
+        vmulq_f32(vcvtq_f32_s32(vacc_lo), requantization_scale_v);
+      const float32x4_t vacc_hi_f =
+        vmulq_f32(vcvtq_f32_s32(vacc_hi), requantization_scale_v);
 
 #ifdef __aarch64__
+      vacc_lo = vcvtnq_s32_f32(vacc_lo_f);
+      vacc_hi = vcvtnq_s32_f32(vacc_hi_f);
+
       const int16x8_t vacc = vqaddq_s16(
           vqmovn_high_s32(vqmovn_s32(vacc_lo), vacc_hi), voutput_zero_point);
-#else
-      const int16x8_t vacc = vqaddq_s16(
-          vcombine_s16(vqmovn_s32(vacc_lo), vqmovn_s32(vacc_hi)),
-          voutput_zero_point);
-#endif
+
       uint8x8_t vout = vqmovun_s16(vacc);
       vout = vmax_u8(vout, voutput_min);
       vout = vmin_u8(vout, voutput_max);
+#else
+      const float32x4_t vacc_lo_f_clamped =
+          vminq_f32(vmaxq_f32(vacc_lo_f, vfmin), vfmax);
+      const float32x4_t vacc_hi_f_clamped =
+          vminq_f32(vmaxq_f32(vacc_hi_f, vfmin), vfmax);
+      vacc_lo = vsubq_s32(
+          vreinterpretq_s32_f32(vaddq_f32(vacc_lo_f_clamped, vfmagic)), vimagic);
+      vacc_hi = vsubq_s32(
+          vreinterpretq_s32_f32(vaddq_f32(vacc_hi_f_clamped, vfmagic)), vimagic);
+      const int16x8_t vacc =
+          vcombine_s16(vqmovn_s32(vacc_lo), vqmovn_s32(vacc_hi));
+
+      uint8x8_t vout = vqmovun_s16(vacc);
+#endif
 
       if (c & 4) {
         vst1_lane_u32(

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x4c2-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x4c2-sse2.c
@@ -244,157 +244,33 @@ void pytorch_q8gemm_ukernel_4x4c2__sse2(
     }
   }
 
-  const __m128i vmultiplier =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.multiplier);
-  const __m128i vrounding =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.rounding);
+  const __m128 vmultiplier =
+      _mm_loadu_ps(quantization_params->sse2.requantization_scale);
 
-  const __m128i vnmask0x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc0x0123);
-  const __m128i vnmask1x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc1x0123);
-  const __m128i vnmask2x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc2x0123);
-  const __m128i vnmask3x0123 = _mm_cmpgt_epi32(_mm_setzero_si128(), vacc3x0123);
-
-  const __m128i vabsacc0x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc0x0123, vnmask0x0123), vnmask0x0123);
-  const __m128i vabsacc1x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc1x0123, vnmask1x0123), vnmask1x0123);
-  const __m128i vabsacc2x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc2x0123, vnmask2x0123), vnmask2x0123);
-  const __m128i vabsacc3x0123 =
-      _mm_sub_epi32(_mm_xor_si128(vacc3x0123, vnmask3x0123), vnmask3x0123);
-
-  const __m128i vabsacc0x1032 =
-      _mm_shuffle_epi32(vabsacc0x0123, _MM_SHUFFLE(2, 3, 0, 1));
-  const __m128i vabsacc1x1032 =
-      _mm_shuffle_epi32(vabsacc1x0123, _MM_SHUFFLE(2, 3, 0, 1));
-  const __m128i vabsacc2x1032 =
-      _mm_shuffle_epi32(vabsacc2x0123, _MM_SHUFFLE(2, 3, 0, 1));
-  const __m128i vabsacc3x1032 =
-      _mm_shuffle_epi32(vabsacc3x0123, _MM_SHUFFLE(2, 3, 0, 1));
-
-  const __m128i vabsprod0x02 = _mm_mul_epu32(vabsacc0x0123, vmultiplier);
-  const __m128i vabsprod1x02 = _mm_mul_epu32(vabsacc1x0123, vmultiplier);
-  const __m128i vabsprod2x02 = _mm_mul_epu32(vabsacc2x0123, vmultiplier);
-  const __m128i vabsprod3x02 = _mm_mul_epu32(vabsacc3x0123, vmultiplier);
-
-  const __m128i vnmask0x02 =
-      _mm_shuffle_epi32(vnmask0x0123, _MM_SHUFFLE(2, 2, 0, 0));
-  const __m128i vnmask1x02 =
-      _mm_shuffle_epi32(vnmask1x0123, _MM_SHUFFLE(2, 2, 0, 0));
-  const __m128i vnmask2x02 =
-      _mm_shuffle_epi32(vnmask2x0123, _MM_SHUFFLE(2, 2, 0, 0));
-  const __m128i vnmask3x02 =
-      _mm_shuffle_epi32(vnmask3x0123, _MM_SHUFFLE(2, 2, 0, 0));
-
-  const __m128i vprod0x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod0x02, vnmask0x02), vnmask0x02);
-  const __m128i vprod1x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod1x02, vnmask1x02), vnmask1x02);
-  const __m128i vprod2x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod2x02, vnmask2x02), vnmask2x02);
-  const __m128i vprod3x02 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod3x02, vnmask3x02), vnmask3x02);
-
-  const __m128i vq31prod0x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod0x02, vrounding), 31);
-  const __m128i vq31prod1x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod1x02, vrounding), 31);
-  const __m128i vq31prod2x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod2x02, vrounding), 31);
-  const __m128i vq31prod3x02 =
-      _mm_srli_epi64(_mm_add_epi64(vprod3x02, vrounding), 31);
-
-  const __m128i vabsprod0x13 = _mm_mul_epu32(vabsacc0x1032, vmultiplier);
-  const __m128i vabsprod1x13 = _mm_mul_epu32(vabsacc1x1032, vmultiplier);
-  const __m128i vabsprod2x13 = _mm_mul_epu32(vabsacc2x1032, vmultiplier);
-  const __m128i vabsprod3x13 = _mm_mul_epu32(vabsacc3x1032, vmultiplier);
-
-  const __m128i vnmask0x13 =
-      _mm_shuffle_epi32(vnmask0x0123, _MM_SHUFFLE(3, 3, 1, 1));
-  const __m128i vnmask1x13 =
-      _mm_shuffle_epi32(vnmask1x0123, _MM_SHUFFLE(3, 3, 1, 1));
-  const __m128i vnmask2x13 =
-      _mm_shuffle_epi32(vnmask2x0123, _MM_SHUFFLE(3, 3, 1, 1));
-  const __m128i vnmask3x13 =
-      _mm_shuffle_epi32(vnmask3x0123, _MM_SHUFFLE(3, 3, 1, 1));
-
-  const __m128i vprod0x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod0x13, vnmask0x13), vnmask0x13);
-  const __m128i vprod1x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod1x13, vnmask1x13), vnmask1x13);
-  const __m128i vprod2x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod2x13, vnmask2x13), vnmask2x13);
-  const __m128i vprod3x13 =
-      _mm_sub_epi64(_mm_xor_si128(vabsprod3x13, vnmask3x13), vnmask3x13);
-
-  const __m128i vq31prod0x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod0x13, vrounding), 31);
-  const __m128i vq31prod1x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod1x13, vrounding), 31);
-  const __m128i vq31prod2x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod2x13, vrounding), 31);
-  const __m128i vq31prod3x13 =
-      _mm_srli_epi64(_mm_add_epi64(vprod3x13, vrounding), 31);
-
-  const __m128i vq31prod0x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod0x02),
-      _mm_castsi128_ps(vq31prod0x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-  const __m128i vq31prod1x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod1x02),
-      _mm_castsi128_ps(vq31prod1x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-  const __m128i vq31prod2x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod2x02),
-      _mm_castsi128_ps(vq31prod2x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-  const __m128i vq31prod3x0213 = _mm_castps_si128(_mm_shuffle_ps(
-      _mm_castsi128_ps(vq31prod3x02),
-      _mm_castsi128_ps(vq31prod3x13),
-      _MM_SHUFFLE(2, 0, 2, 0)));
-
-  const __m128i vq31prod0x0123 =
-      _mm_shuffle_epi32(vq31prod0x0213, _MM_SHUFFLE(3, 1, 2, 0));
-  const __m128i vq31prod1x0123 =
-      _mm_shuffle_epi32(vq31prod1x0213, _MM_SHUFFLE(3, 1, 2, 0));
-  const __m128i vq31prod2x0123 =
-      _mm_shuffle_epi32(vq31prod2x0213, _MM_SHUFFLE(3, 1, 2, 0));
-  const __m128i vq31prod3x0123 =
-      _mm_shuffle_epi32(vq31prod3x0213, _MM_SHUFFLE(3, 1, 2, 0));
-
-  const __m128i vremainder_mask =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.remainder_mask);
-
-  const __m128i vrem0x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod0x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod0x0123));
-  const __m128i vrem1x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod1x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod1x0123));
-  const __m128i vrem2x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod2x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod2x0123));
-  const __m128i vrem3x0123 = _mm_add_epi32(
-      _mm_and_si128(vq31prod3x0123, vremainder_mask),
-      _mm_cmpgt_epi32(_mm_setzero_si128(), vq31prod3x0123));
-
-  const __m128i vremainder_threshold = _mm_load_si128(
-      (const __m128i*)quantization_params->sse2.remainder_threshold);
-  const __m128i vshift =
-      _mm_load_si128((const __m128i*)quantization_params->sse2.shift);
-
-  vacc0x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod0x0123, vshift),
-      _mm_cmpgt_epi32(vrem0x0123, vremainder_threshold));
-  vacc1x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod1x0123, vshift),
-      _mm_cmpgt_epi32(vrem1x0123, vremainder_threshold));
-  vacc2x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod2x0123, vshift),
-      _mm_cmpgt_epi32(vrem2x0123, vremainder_threshold));
-  vacc3x0123 = _mm_sub_epi32(
-      _mm_sra_epi32(vq31prod3x0123, vshift),
-      _mm_cmpgt_epi32(vrem3x0123, vremainder_threshold));
+  vacc0x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc0x0123),
+                  vmultiplier
+                  )
+                );
+  vacc1x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc1x0123),
+                  vmultiplier
+                  )
+                );
+  vacc2x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc2x0123),
+                  vmultiplier
+                  )
+                );
+  vacc3x0123 = _mm_cvtps_epi32(
+                _mm_mul_ps(
+                  _mm_cvtepi32_ps(vacc3x0123),
+                  vmultiplier
+                  )
+                );
 
   const __m128i voutput_zero_point = _mm_load_si128(
       (const __m128i*)quantization_params->sse2.output_zero_point);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-aarch32-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-aarch32-neon.S
@@ -11,6 +11,20 @@
 
 .syntax unified
 
+#
+# New Struct for pytorch_qnnp_conv_quantization_params
+# kernel zp             : 0 offset
+# input zp              : 2
+# requantization_scale  : 4
+# output zp             : 8
+# output max            : 10
+# output min            : 11
+# vfmin                 : 12
+# vfmax                 : 16
+# vfmagic               : 20
+# vimagic               : 24
+#
+
 # void pytorch_q8gemm_ukernel_4x8__aarch32_neon(
 #     size_t mr,
 #     size_t nr,
@@ -78,9 +92,11 @@ BEGIN_FUNCTION pytorch_q8gemm_ukernel_4x8__aarch32_neon
     SUBS r2, r2, 8
     # q15 := vacc3x4567
     VMOV.I32 q15, q9
-    # Load multiplier:
-    # - d12 = vmultiplier
+    # Load requantization_scale:
+    # - d12 = requantization_scale 
     VLD1.32 {d12[]}, [r7]!
+    # add 4 bytes to get to vfmax
+    ADD r7, r7, 4
     BLO 1f
 
     .p2align 5
@@ -639,103 +655,100 @@ BEGIN_FUNCTION pytorch_q8gemm_ukernel_4x8__aarch32_neon
 
     .p2align 4
 2:
-    # Load right_shift
-    # - q4 = d8:d9 = vright_shift
+    # Load vfmax:
+    VLD1.32 {d10[], d11[]}, [r7]!
+    # Load vfmin:
     VLD1.32 {d8[], d9[]}, [r7]!
+    # Load vfmagic:
+    VLD1.32 {d0[], d1[]}, [r7]!
+    # Load vimagic:
+    VLD1.32 {d2[], d3[]}, [r7]!
 
-    VQRDMULH.S32  q8, q8, d12[0]
-    VQRDMULH.S32  q9, q9, d12[0]
-    VQRDMULH.S32 q10, q10, d12[0]
-    VQRDMULH.S32 q11, q11, d12[0]
+    # Moved here to hide load latency on d14
+    VCVT.F32.S32 q8, q8
+    VCVT.F32.S32 q9, q9
+    VCVT.F32.S32 q10, q10
+    VCVT.F32.S32 q11, q11
+    VCVT.F32.S32 q12, q12
+    VCVT.F32.S32 q13, q13
+    VCVT.F32.S32 q14, q14
+    VCVT.F32.S32 q15, q15
 
-    # Compute vzero_shift_mask
-    # - q5 = vzero_shift_mask
-    VCEQ.S32 q5, q4, 0
+    VMUL.F32 q8, q8, d12[0]
+    VMUL.F32 q9, q9, d12[0]
+    VMUL.F32 q10, q10, d12[0]
+    VMUL.F32 q11, q11, d12[0]
+    VMUL.F32 q12, q12, d12[0]
+    VMUL.F32 q13, q13, d12[0]
+    VMUL.F32 q14, q14, d12[0]
+    VMUL.F32 q15, q15, d12[0]
 
-    VQRDMULH.S32 q12, q12, d12[0]
-    VQRDMULH.S32 q13, q13, d12[0]
-    VQRDMULH.S32 q14, q14, d12[0]
-    VQRDMULH.S32 q15, q15, d12[0]
+    VMIN.F32 q8, q8, q5
+    VMIN.F32 q9, q9, q5
+    VMIN.F32 q10, q10, q5
+    VMIN.F32 q11, q11, q5
+    VMIN.F32 q12, q12, q5
+    VMIN.F32 q13, q13, q5
+    VMIN.F32 q14, q14, q5
+    VMIN.F32 q15, q15, q5
 
-    VBIC q0,  q8, q5
-    VBIC q1,  q9, q5
-    VBIC q2, q10, q5
-    VBIC q3, q11, q5
+    VMAX.F32 q8, q8, q4
+    VMAX.F32 q9, q9, q4
+    VMAX.F32 q10, q10, q4
+    VMAX.F32 q11, q11, q4
+    VMAX.F32 q12, q12, q4
+    VMAX.F32 q13, q13, q4
+    VMAX.F32 q14, q14, q4
+    VMAX.F32 q15, q15, q4
 
-    VSRA.S32  q8, q0, 31
-    VSRA.S32  q9, q1, 31
-    VSRA.S32 q10, q2, 31
-    VSRA.S32 q11, q3, 31
-
-    # Load zero_point
-    # - q7 = d14:d15 = vzero_point
-    VLD1.16 {d14[], d15[]}, [r7]!
-
-    VBIC q0, q12, q5
-    VBIC q1, q13, q5
-    VBIC q2, q14, q5
-    VBIC q3, q15, q5
-
-    VSRA.S32 q12, q0, 31
-    VSRA.S32 q13, q1, 31
-    VSRA.S32 q14, q2, 31
-    VSRA.S32 q15, q3, 31
-
-    # Load max:
-    # - q5 = d10:d11 = vmax
-    VLD1.8 {d10[], d11[]}, [r7]!
-
-    VRSHL.S32  q8,  q8, q4
-    VRSHL.S32  q9,  q9, q4
-    VRSHL.S32 q10, q10, q4
-    VRSHL.S32 q11, q11, q4
-    VRSHL.S32 q12, q12, q4
-    VRSHL.S32 q13, q13, q4
-    VRSHL.S32 q14, q14, q4
-    VRSHL.S32 q15, q15, q4
+    VADD.F32 q8, q8, q0
+    VADD.F32 q9, q9, q0
+    VADD.F32 q10, q10, q0
+    VADD.F32 q11, q11, q0
+    VADD.F32 q12, q12, q0
+    VADD.F32 q13, q13, q0
+    VADD.F32 q14, q14, q0
+    VADD.F32 q15, q15, q0
 
     # Load c, c_stride:
     # - r2 = c
     # - r2 = c_stride
     LDRD r2, r3, [sp, 88]
 
+    VSUB.S32 q8, q8, q1
+    VSUB.S32 q9, q9, q1
+    VSUB.S32 q10, q10, q1
+    VSUB.S32 q11, q11, q1
+    VSUB.S32 q12, q12, q1
+    VSUB.S32 q13, q13, q1
+    VSUB.S32 q14, q14, q1
+    VSUB.S32 q15, q15, q1
+
+    ADD r4, r2, r3
     VQMOVN.S32 d16,  q8
     VQMOVN.S32 d17,  q9
+    CMP r0, 2
     VQMOVN.S32 d18, q10
     VQMOVN.S32 d19, q11
+    MOVLO r4, r2
     VQMOVN.S32 d20, q12
     VQMOVN.S32 d21, q13
     VQMOVN.S32 d22, q14
     VQMOVN.S32 d23, q15
 
-    # Load min:
-    # - q4 = q8:q9 = vmin
-    VLD1.8 {d8[], d9[]}, [r7]!
-    ADD r4, r2, r3
 
-    VQADD.S16  q8,  q8, q7
-    VQADD.S16  q9,  q9, q7
-    CMP r0, 2
-    VQADD.S16 q10, q10, q7
-    VQADD.S16 q11, q11, q7
-    MOVLO r4, r2
-
-    VQMOVUN.S16 d16,  q8
-    VQMOVUN.S16 d17,  q9
     ADD r5, r4, r3
-    VQMOVUN.S16 d18, q10
-    VQMOVUN.S16 d19, q11
+    VQMOVUN.S16 d16,  q8
     MOVLS r5, r4
-
-    VMIN.U8 q8, q8, q5
+    VQMOVUN.S16 d17,  q9
+    VQMOVUN.S16 d18, q10
     CMP r0, 4
-    VMIN.U8 q9, q9, q5
     ADD r3, r5, r3
 
-    VMAX.U8 q8, q8, q4
     MOVNE r3, r5
     CMP r1, 8
-    VMAX.U8 q9, q9, q4
+    VQMOVUN.S16 d19, q11
+
 
     BNE 4f
 

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-neon.c
@@ -504,50 +504,55 @@ void pytorch_q8gemm_ukernel_4x8__neon(
     }
   }
 
-  const int32x4_t vmultiplier =
-      vld1q_dup_s32(&quantization_params->neon.multiplier);
-  vacc0x0123 = vqrdmulhq_s32(vacc0x0123, vmultiplier);
-  vacc0x4567 = vqrdmulhq_s32(vacc0x4567, vmultiplier);
-  vacc1x0123 = vqrdmulhq_s32(vacc1x0123, vmultiplier);
-  vacc1x4567 = vqrdmulhq_s32(vacc1x4567, vmultiplier);
-  vacc2x0123 = vqrdmulhq_s32(vacc2x0123, vmultiplier);
-  vacc2x4567 = vqrdmulhq_s32(vacc2x4567, vmultiplier);
-  vacc3x0123 = vqrdmulhq_s32(vacc3x0123, vmultiplier);
-  vacc3x4567 = vqrdmulhq_s32(vacc3x4567, vmultiplier);
+  const float32x4_t requantization_scale_v =
+      vdupq_n_f32(quantization_params->neon.requantization_scale);
 
-  const int32x4_t vright_shift =
-      vld1q_dup_s32(&quantization_params->neon.right_shift);
-  const int32x4_t vzero_shift_mask =
-      vreinterpretq_s32_u32(vceqq_s32(vright_shift, vmovq_n_s32(0)));
-  vacc0x0123 =
-      vsraq_n_s32(vacc0x0123, vbicq_s32(vacc0x0123, vzero_shift_mask), 31);
-  vacc0x4567 =
-      vsraq_n_s32(vacc0x4567, vbicq_s32(vacc0x4567, vzero_shift_mask), 31);
-  vacc1x0123 =
-      vsraq_n_s32(vacc1x0123, vbicq_s32(vacc1x0123, vzero_shift_mask), 31);
-  vacc1x4567 =
-      vsraq_n_s32(vacc1x4567, vbicq_s32(vacc1x4567, vzero_shift_mask), 31);
-  vacc2x0123 =
-      vsraq_n_s32(vacc2x0123, vbicq_s32(vacc2x0123, vzero_shift_mask), 31);
-  vacc2x4567 =
-      vsraq_n_s32(vacc2x4567, vbicq_s32(vacc2x4567, vzero_shift_mask), 31);
-  vacc3x0123 =
-      vsraq_n_s32(vacc3x0123, vbicq_s32(vacc3x0123, vzero_shift_mask), 31);
-  vacc3x4567 =
-      vsraq_n_s32(vacc3x4567, vbicq_s32(vacc3x4567, vzero_shift_mask), 31);
+  /*
+   * Convert int32_t input to FP32 and multiply by FP32 scale.
+   * Both operations involve statistically unbiased roundings:
+   * - Large int32_t values can't be exactly represented as FP32. The
+   * conversion instruction in ARM NEON would round it to nearest FP32 value
+   * with ties to even.
+   * - Product of two FP32 values is generally not exactly representation as
+   * an FP32 value, and will be rounded to nearest FP32 value with ties to
+   * even.
+   */
+  const float32x4_t vacc0x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc0x0123), requantization_scale_v);
+  const float32x4_t vacc1x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc1x0123), requantization_scale_v);
+  const float32x4_t vacc2x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc2x0123), requantization_scale_v);
+  const float32x4_t vacc3x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc3x0123), requantization_scale_v);
+  const float32x4_t vacc0x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc0x4567), requantization_scale_v);
+  const float32x4_t vacc1x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc1x4567), requantization_scale_v);
+  const float32x4_t vacc2x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc2x4567), requantization_scale_v);
+  const float32x4_t vacc3x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc3x4567), requantization_scale_v);
 
-  vacc0x0123 = vrshlq_s32(vacc0x0123, vright_shift);
-  vacc0x4567 = vrshlq_s32(vacc0x4567, vright_shift);
-  vacc1x0123 = vrshlq_s32(vacc1x0123, vright_shift);
-  vacc1x4567 = vrshlq_s32(vacc1x4567, vright_shift);
-  vacc2x0123 = vrshlq_s32(vacc2x0123, vright_shift);
-  vacc2x4567 = vrshlq_s32(vacc2x4567, vright_shift);
-  vacc3x0123 = vrshlq_s32(vacc3x0123, vright_shift);
-  vacc3x4567 = vrshlq_s32(vacc3x4567, vright_shift);
-
+#ifdef __aarch64__
   const int16x8_t voutput_zero_point =
       vld1q_dup_s16(&quantization_params->neon.output_zero_point);
-#ifdef __aarch64__
+  /*
+   * Leverage "Floating-point Convert to Signed integer, rounding to nearest
+   * with ties to even" instruction. This is an ARMv8 instruction (always
+   * available in AArch64), which saturates result on overflow. We don't need
+   * to specifically consider saturated results, they will be clamped at the
+   * last stage.
+   */
+  vacc0x0123 = vcvtnq_s32_f32(vacc0x0123_f);
+  vacc1x0123 = vcvtnq_s32_f32(vacc1x0123_f);
+  vacc2x0123 = vcvtnq_s32_f32(vacc2x0123_f);
+  vacc3x0123 = vcvtnq_s32_f32(vacc3x0123_f);
+  vacc0x4567 = vcvtnq_s32_f32(vacc0x4567_f);
+  vacc1x4567 = vcvtnq_s32_f32(vacc1x4567_f);
+  vacc2x4567 = vcvtnq_s32_f32(vacc2x4567_f);
+  vacc3x4567 = vcvtnq_s32_f32(vacc3x4567_f);
+
   const int16x8_t vacc0x01234567 = vqaddq_s16(
       vqmovn_high_s32(vqmovn_s32(vacc0x0123), vacc0x4567), voutput_zero_point);
   const int16x8_t vacc1x01234567 = vqaddq_s16(
@@ -561,25 +566,7 @@ void pytorch_q8gemm_ukernel_4x8__neon(
       vqmovun_high_s16(vqmovun_s16(vacc0x01234567), vacc1x01234567);
   uint8x16_t vout2x01234567_3x01234567 =
       vqmovun_high_s16(vqmovun_s16(vacc2x01234567), vacc3x01234567);
-#else
-  const int16x8_t vacc0x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc0x0123), vqmovn_s32(vacc0x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc1x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc1x0123), vqmovn_s32(vacc1x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc2x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc2x0123), vqmovn_s32(vacc2x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc3x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc3x0123), vqmovn_s32(vacc3x4567)),
-      voutput_zero_point);
 
-  uint8x16_t vout0x01234567_1x01234567 =
-      vcombine_u8(vqmovun_s16(vacc0x01234567), vqmovun_s16(vacc1x01234567));
-  uint8x16_t vout2x01234567_3x01234567 =
-      vcombine_u8(vqmovun_s16(vacc2x01234567), vqmovun_s16(vacc3x01234567));
-#endif
   const uint8x16_t voutput_min =
       vld1q_dup_u8(&quantization_params->neon.output_min);
   const uint8x16_t voutput_max =
@@ -589,6 +576,76 @@ void pytorch_q8gemm_ukernel_4x8__neon(
   vout2x01234567_3x01234567 = vmaxq_u8(vout2x01234567_3x01234567, voutput_min);
   vout0x01234567_1x01234567 = vminq_u8(vout0x01234567_1x01234567, voutput_max);
   vout2x01234567_3x01234567 = vminq_u8(vout2x01234567_3x01234567, voutput_max);
+#else
+  const float32x4_t vfmin = vdupq_n_f32(quantization_params->neon.vfmin);
+  const float32x4_t vfmax = vdupq_n_f32(quantization_params->neon.vfmax);
+  const float32x4_t vfmagic = vdupq_n_f32(quantization_params->neon.vfmagic);
+  const int32x4_t vimagic = vdupq_n_s32(quantization_params->neon.vimagic);
+  /*
+   * ARMv7 NEON offers only a floating-point to integer conversion instruction
+   * with rounding towards zero. In lieu of conversion instruction with
+   * rounding-to-nearest-even, we use a magic trick of adding a large number
+   * (1.5 * 2**23) to scaled value to cause rounding to integer, and then
+   * substracing this magic number as integer. This trick works only in a
+   * limited range (absolute value of input must be less than 2**22), so
+   * generally we have to clamp input to this range before using the magic.
+   * However, clamping to any smaller range works just as well, and thus we
+   * clamp to [qmin - zero point, qmax - zero point] range so that after we
+   * add zero point to the result, it gets into target [qmin, qmax] range.
+   */
+  const float32x4_t vacc0x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc0x0123_f, vfmin), vfmax);
+  const float32x4_t vacc1x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc1x0123_f, vfmin), vfmax);
+  const float32x4_t vacc2x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc2x0123_f, vfmin), vfmax);
+  const float32x4_t vacc3x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc3x0123_f, vfmin), vfmax);
+  const float32x4_t vacc0x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc0x4567_f, vfmin), vfmax);
+  const float32x4_t vacc1x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc1x4567_f, vfmin), vfmax);
+  const float32x4_t vacc2x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc2x4567_f, vfmin), vfmax);
+  const float32x4_t vacc3x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc3x4567_f, vfmin), vfmax);
+
+  /*
+   * Conversion to integer using the "magic trick". Rounding is performed in
+   * the output of addition operation, and result is rounded to nearest even
+   * integer with ties to even.
+   */
+  vacc0x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc0x0123_f_clamped, vfmagic)), vimagic);
+  vacc1x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc1x0123_f_clamped, vfmagic)), vimagic);
+  vacc2x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc2x0123_f_clamped, vfmagic)), vimagic);
+  vacc3x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc3x0123_f_clamped, vfmagic)), vimagic);
+  vacc0x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc0x4567_f_clamped, vfmagic)), vimagic);
+  vacc1x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc1x4567_f_clamped, vfmagic)), vimagic);
+  vacc2x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc2x4567_f_clamped, vfmagic)), vimagic);
+  vacc3x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc3x4567_f_clamped, vfmagic)), vimagic);
+
+  const int16x8_t vacc0x01234567 =
+      vcombine_s16(vqmovn_s32(vacc0x0123), vqmovn_s32(vacc0x4567));
+  const int16x8_t vacc1x01234567 =
+      vcombine_s16(vqmovn_s32(vacc1x0123), vqmovn_s32(vacc1x4567));
+  const int16x8_t vacc2x01234567 =
+      vcombine_s16(vqmovn_s32(vacc2x0123), vqmovn_s32(vacc2x4567));
+  const int16x8_t vacc3x01234567 =
+      vcombine_s16(vqmovn_s32(vacc3x0123), vqmovn_s32(vacc3x4567));
+
+  uint8x16_t vout0x01234567_1x01234567 =
+      vcombine_u8(vqmovun_s16(vacc0x01234567), vqmovun_s16(vacc1x01234567));
+  uint8x16_t vout2x01234567_3x01234567 =
+      vcombine_u8(vqmovun_s16(vacc2x01234567), vqmovun_s16(vacc3x01234567));
+#endif
 
   uint8_t* c0 = c;
   uint8_t* c1 = (uint8_t*)((uintptr_t)c0 + c_stride);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-aarch64-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-aarch64-neon.S
@@ -75,8 +75,8 @@ BEGIN_FUNCTION pytorch_q8gemm_ukernel_8x8__aarch64_neon
     # v23 := vacc7x4567
     MOV v23.16b, v9.16b
 
-    // Load multiplier
-    // - v26 = vmultiplier
+    // Load requantization_scale
+    // - v26 = requantization_scale 
     LD1R {v26.4s}, [x8], 4
 
     # a1
@@ -526,96 +526,71 @@ BEGIN_FUNCTION pytorch_q8gemm_ukernel_8x8__aarch64_neon
     .p2align 4
 #endif
 2:
-    // Load right_shift:
-    // - v27 = vright_shift
-    LD1R {v27.4s}, [x8], 4
-
-    SQRDMULH  v8.4s,  v8.4s, v26.4s
-    SQRDMULH  v9.4s,  v9.4s, v26.4s
-    SQRDMULH v10.4s, v10.4s, v26.4s
-    SQRDMULH v11.4s, v11.4s, v26.4s
-    SQRDMULH v12.4s, v12.4s, v26.4s
-    SQRDMULH v13.4s, v13.4s, v26.4s
-    SQRDMULH v14.4s, v14.4s, v26.4s
-    SQRDMULH v15.4s, v15.4s, v26.4s
-
-    // Compute vzero_shift_mask
-    // - v28 = vzero_shift_mask
-    CMEQ v28.4s, v27.4s, 0
-
-    SQRDMULH v16.4s, v16.4s, v26.4s
-    SQRDMULH v17.4s, v17.4s, v26.4s
-    SQRDMULH v18.4s, v18.4s, v26.4s
-    SQRDMULH v19.4s, v19.4s, v26.4s
-    SQRDMULH v20.4s, v20.4s, v26.4s
-    SQRDMULH v21.4s, v21.4s, v26.4s
-    SQRDMULH v22.4s, v22.4s, v26.4s
-    SQRDMULH v23.4s, v23.4s, v26.4s
-
     // Load zero_point:
     // - v29 = vzero_point
     LD1R {v29.8h}, [x8], 2
-
-    BIC v0.16b,  v8.16b, v28.16b
-    BIC v1.16b,  v9.16b, v28.16b
-    BIC v2.16b, v10.16b, v28.16b
-    BIC v3.16b, v11.16b, v28.16b
-    BIC v4.16b, v12.16b, v28.16b
-    BIC v5.16b, v13.16b, v28.16b
-    BIC v6.16b, v14.16b, v28.16b
-    BIC v7.16b, v15.16b, v28.16b
-
-    SSRA  v8.4s, v0.4s, 31
-    SSRA  v9.4s, v1.4s, 31
-    SSRA v10.4s, v2.4s, 31
-    SSRA v11.4s, v3.4s, 31
-    SSRA v12.4s, v4.4s, 31
-    SSRA v13.4s, v5.4s, 31
-    SSRA v14.4s, v6.4s, 31
-    SSRA v15.4s, v7.4s, 31
 
     // Load max:
     // - v30 = vmax
     LD1R {v30.16b}, [x8], 1
 
-    BIC v0.16b, v16.16b, v28.16b
-    BIC v1.16b, v17.16b, v28.16b
-    BIC v2.16b, v18.16b, v28.16b
-    BIC v3.16b, v19.16b, v28.16b
-    BIC v4.16b, v20.16b, v28.16b
-    BIC v5.16b, v21.16b, v28.16b
-    BIC v6.16b, v22.16b, v28.16b
-    BIC v7.16b, v23.16b, v28.16b
-
-    SSRA v16.4s, v0.4s, 31
-    SSRA v17.4s, v1.4s, 31
-    SSRA v18.4s, v2.4s, 31
-    SSRA v19.4s, v3.4s, 31
-    SSRA v20.4s, v4.4s, 31
-    SSRA v21.4s, v5.4s, 31
-    SSRA v22.4s, v6.4s, 31
-    SSRA v23.4s, v7.4s, 31
-
     // Load min:
     // - v31 = vmin
     LD1R {v31.16b}, [x8]
 
-    SRSHL  v8.4s,  v8.4s, v27.4s
-    SRSHL  v9.4s,  v9.4s, v27.4s
-    SRSHL v10.4s, v10.4s, v27.4s
-    SRSHL v11.4s, v11.4s, v27.4s
-    SRSHL v12.4s, v12.4s, v27.4s
-    SRSHL v13.4s, v13.4s, v27.4s
-    SRSHL v14.4s, v14.4s, v27.4s
-    SRSHL v15.4s, v15.4s, v27.4s
-    SRSHL v16.4s, v16.4s, v27.4s
-    SRSHL v17.4s, v17.4s, v27.4s
-    SRSHL v18.4s, v18.4s, v27.4s
-    SRSHL v19.4s, v19.4s, v27.4s
-    SRSHL v20.4s, v20.4s, v27.4s
-    SRSHL v21.4s, v21.4s, v27.4s
-    SRSHL v22.4s, v22.4s, v27.4s
-    SRSHL v23.4s, v23.4s, v27.4s
+    SCVTF v8.4s, v8.4s
+    SCVTF v9.4s, v9.4s
+    SCVTF v10.4s, v10.4s
+    SCVTF v11.4s, v11.4s
+    SCVTF v12.4s, v12.4s
+    SCVTF v13.4s, v13.4s
+    SCVTF v14.4s, v14.4s
+    SCVTF v15.4s, v15.4s
+
+    SCVTF v16.4s, v16.4s
+    SCVTF v17.4s, v17.4s
+    SCVTF v18.4s, v18.4s
+    SCVTF v19.4s, v19.4s
+    SCVTF v20.4s, v20.4s
+    SCVTF v21.4s, v21.4s
+    SCVTF v22.4s, v22.4s
+    SCVTF v23.4s, v23.4s
+
+    FMUL v8.4s, v8.4s, v26.4s
+    FMUL v9.4s, v9.4s, v26.4s
+    FMUL v10.4s, v10.4s, v26.4s
+    FMUL v11.4s, v11.4s, v26.4s
+    FMUL v12.4s, v12.4s, v26.4s
+    FMUL v13.4s, v13.4s, v26.4s
+    FMUL v14.4s, v14.4s, v26.4s
+    FMUL v15.4s, v15.4s, v26.4s
+
+    FMUL v16.4s, v16.4s, v26.4s
+    FMUL v17.4s, v17.4s, v26.4s
+    FMUL v18.4s, v18.4s, v26.4s
+    FMUL v19.4s, v19.4s, v26.4s
+    FMUL v20.4s, v20.4s, v26.4s
+    FMUL v21.4s, v21.4s, v26.4s
+    FMUL v22.4s, v22.4s, v26.4s
+    FMUL v23.4s, v23.4s, v26.4s
+
+    FCVTNS v8.4s, v8.4s
+    FCVTNS v9.4s, v9.4s
+    FCVTNS v10.4s, v10.4s
+    FCVTNS v11.4s, v11.4s
+    FCVTNS v12.4s, v12.4s
+    FCVTNS v13.4s, v13.4s
+    FCVTNS v14.4s, v14.4s
+    FCVTNS v15.4s, v15.4s
+
+    FCVTNS v16.4s, v16.4s
+    FCVTNS v17.4s, v17.4s
+    FCVTNS v18.4s, v18.4s
+    FCVTNS v19.4s, v19.4s
+    FCVTNS v20.4s, v20.4s
+    FCVTNS v21.4s, v21.4s
+    FCVTNS v22.4s, v22.4s
+    FCVTNS v23.4s, v23.4s
 
     SQXTN   v8.4h,  v8.4s
     SQXTN  v10.4h, v10.4s

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-neon.c
@@ -872,82 +872,64 @@ void pytorch_q8gemm_ukernel_8x8__neon(
     }
   }
 
-  const int32x4_t vmultiplier =
-      vld1q_dup_s32(&quantization_params->neon.multiplier);
-  vacc0x0123 = vqrdmulhq_s32(vacc0x0123, vmultiplier);
-  vacc0x4567 = vqrdmulhq_s32(vacc0x4567, vmultiplier);
-  vacc1x0123 = vqrdmulhq_s32(vacc1x0123, vmultiplier);
-  vacc1x4567 = vqrdmulhq_s32(vacc1x4567, vmultiplier);
-  vacc2x0123 = vqrdmulhq_s32(vacc2x0123, vmultiplier);
-  vacc2x4567 = vqrdmulhq_s32(vacc2x4567, vmultiplier);
-  vacc3x0123 = vqrdmulhq_s32(vacc3x0123, vmultiplier);
-  vacc3x4567 = vqrdmulhq_s32(vacc3x4567, vmultiplier);
-  vacc4x0123 = vqrdmulhq_s32(vacc4x0123, vmultiplier);
-  vacc4x4567 = vqrdmulhq_s32(vacc4x4567, vmultiplier);
-  vacc5x0123 = vqrdmulhq_s32(vacc5x0123, vmultiplier);
-  vacc5x4567 = vqrdmulhq_s32(vacc5x4567, vmultiplier);
-  vacc6x0123 = vqrdmulhq_s32(vacc6x0123, vmultiplier);
-  vacc6x4567 = vqrdmulhq_s32(vacc6x4567, vmultiplier);
-  vacc7x0123 = vqrdmulhq_s32(vacc7x0123, vmultiplier);
-  vacc7x4567 = vqrdmulhq_s32(vacc7x4567, vmultiplier);
+  const float32x4_t requantization_scale_v =
+      vdupq_n_f32(quantization_params->neon.requantization_scale);
 
-  const int32x4_t vright_shift =
-      vld1q_dup_s32(&quantization_params->neon.right_shift);
-  const int32x4_t vzero_shift_mask =
-      vreinterpretq_s32_u32(vceqq_s32(vright_shift, vmovq_n_s32(0)));
-  vacc0x0123 =
-      vsraq_n_s32(vacc0x0123, vbicq_s32(vacc0x0123, vzero_shift_mask), 31);
-  vacc0x4567 =
-      vsraq_n_s32(vacc0x4567, vbicq_s32(vacc0x4567, vzero_shift_mask), 31);
-  vacc1x0123 =
-      vsraq_n_s32(vacc1x0123, vbicq_s32(vacc1x0123, vzero_shift_mask), 31);
-  vacc1x4567 =
-      vsraq_n_s32(vacc1x4567, vbicq_s32(vacc1x4567, vzero_shift_mask), 31);
-  vacc2x0123 =
-      vsraq_n_s32(vacc2x0123, vbicq_s32(vacc2x0123, vzero_shift_mask), 31);
-  vacc2x4567 =
-      vsraq_n_s32(vacc2x4567, vbicq_s32(vacc2x4567, vzero_shift_mask), 31);
-  vacc3x0123 =
-      vsraq_n_s32(vacc3x0123, vbicq_s32(vacc3x0123, vzero_shift_mask), 31);
-  vacc3x4567 =
-      vsraq_n_s32(vacc3x4567, vbicq_s32(vacc3x4567, vzero_shift_mask), 31);
-  vacc4x0123 =
-      vsraq_n_s32(vacc4x0123, vbicq_s32(vacc4x0123, vzero_shift_mask), 31);
-  vacc4x4567 =
-      vsraq_n_s32(vacc4x4567, vbicq_s32(vacc4x4567, vzero_shift_mask), 31);
-  vacc5x0123 =
-      vsraq_n_s32(vacc5x0123, vbicq_s32(vacc5x0123, vzero_shift_mask), 31);
-  vacc5x4567 =
-      vsraq_n_s32(vacc5x4567, vbicq_s32(vacc5x4567, vzero_shift_mask), 31);
-  vacc6x0123 =
-      vsraq_n_s32(vacc6x0123, vbicq_s32(vacc6x0123, vzero_shift_mask), 31);
-  vacc6x4567 =
-      vsraq_n_s32(vacc6x4567, vbicq_s32(vacc6x4567, vzero_shift_mask), 31);
-  vacc7x0123 =
-      vsraq_n_s32(vacc7x0123, vbicq_s32(vacc7x0123, vzero_shift_mask), 31);
-  vacc7x4567 =
-      vsraq_n_s32(vacc7x4567, vbicq_s32(vacc7x4567, vzero_shift_mask), 31);
+  const float32x4_t vacc0x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc0x0123), requantization_scale_v);
+  const float32x4_t vacc1x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc1x0123), requantization_scale_v);
+  const float32x4_t vacc2x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc2x0123), requantization_scale_v);
+  const float32x4_t vacc3x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc3x0123), requantization_scale_v);
+  const float32x4_t vacc0x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc0x4567), requantization_scale_v);
+  const float32x4_t vacc1x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc1x4567), requantization_scale_v);
+  const float32x4_t vacc2x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc2x4567), requantization_scale_v);
+  const float32x4_t vacc3x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc3x4567), requantization_scale_v);
+  const float32x4_t vacc4x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc4x0123), requantization_scale_v);
+  const float32x4_t vacc5x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc5x0123), requantization_scale_v);
+  const float32x4_t vacc6x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc6x0123), requantization_scale_v);
+  const float32x4_t vacc7x0123_f =
+    vmulq_f32(vcvtq_f32_s32(vacc7x0123), requantization_scale_v);
+  const float32x4_t vacc4x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc4x4567), requantization_scale_v);
+  const float32x4_t vacc5x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc5x4567), requantization_scale_v);
+  const float32x4_t vacc6x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc6x4567), requantization_scale_v);
+  const float32x4_t vacc7x4567_f =
+    vmulq_f32(vcvtq_f32_s32(vacc7x4567), requantization_scale_v);
 
-  vacc0x0123 = vrshlq_s32(vacc0x0123, vright_shift);
-  vacc0x4567 = vrshlq_s32(vacc0x4567, vright_shift);
-  vacc1x0123 = vrshlq_s32(vacc1x0123, vright_shift);
-  vacc1x4567 = vrshlq_s32(vacc1x4567, vright_shift);
-  vacc2x0123 = vrshlq_s32(vacc2x0123, vright_shift);
-  vacc2x4567 = vrshlq_s32(vacc2x4567, vright_shift);
-  vacc3x0123 = vrshlq_s32(vacc3x0123, vright_shift);
-  vacc3x4567 = vrshlq_s32(vacc3x4567, vright_shift);
-  vacc4x0123 = vrshlq_s32(vacc4x0123, vright_shift);
-  vacc4x4567 = vrshlq_s32(vacc4x4567, vright_shift);
-  vacc5x0123 = vrshlq_s32(vacc5x0123, vright_shift);
-  vacc5x4567 = vrshlq_s32(vacc5x4567, vright_shift);
-  vacc6x0123 = vrshlq_s32(vacc6x0123, vright_shift);
-  vacc6x4567 = vrshlq_s32(vacc6x4567, vright_shift);
-  vacc7x0123 = vrshlq_s32(vacc7x0123, vright_shift);
-  vacc7x4567 = vrshlq_s32(vacc7x4567, vright_shift);
-
+#ifdef __aarch64__
   const int16x8_t voutput_zero_point =
       vld1q_dup_s16(&quantization_params->neon.output_zero_point);
-#ifdef __aarch64__
+
+  vacc0x0123 = vcvtnq_s32_f32(vacc0x0123_f);
+  vacc1x0123 = vcvtnq_s32_f32(vacc1x0123_f);
+  vacc2x0123 = vcvtnq_s32_f32(vacc2x0123_f);
+  vacc3x0123 = vcvtnq_s32_f32(vacc3x0123_f);
+  vacc0x4567 = vcvtnq_s32_f32(vacc0x4567_f);
+  vacc1x4567 = vcvtnq_s32_f32(vacc1x4567_f);
+  vacc2x4567 = vcvtnq_s32_f32(vacc2x4567_f);
+  vacc3x4567 = vcvtnq_s32_f32(vacc3x4567_f);
+  vacc4x0123 = vcvtnq_s32_f32(vacc4x0123_f);
+  vacc5x0123 = vcvtnq_s32_f32(vacc5x0123_f);
+  vacc6x0123 = vcvtnq_s32_f32(vacc6x0123_f);
+  vacc7x0123 = vcvtnq_s32_f32(vacc7x0123_f);
+  vacc4x4567 = vcvtnq_s32_f32(vacc4x4567_f);
+  vacc5x4567 = vcvtnq_s32_f32(vacc5x4567_f);
+  vacc6x4567 = vcvtnq_s32_f32(vacc6x4567_f);
+  vacc7x4567 = vcvtnq_s32_f32(vacc7x4567_f);
+
+
   const int16x8_t vacc0x01234567 = vqaddq_s16(
       vqmovn_high_s32(vqmovn_s32(vacc0x0123), vacc0x4567), voutput_zero_point);
   const int16x8_t vacc1x01234567 = vqaddq_s16(
@@ -973,41 +955,7 @@ void pytorch_q8gemm_ukernel_8x8__neon(
       vqmovun_high_s16(vqmovun_s16(vacc4x01234567), vacc5x01234567);
   uint8x16_t vout6x01234567_7x01234567 =
       vqmovun_high_s16(vqmovun_s16(vacc6x01234567), vacc7x01234567);
-#else
-  const int16x8_t vacc0x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc0x0123), vqmovn_s32(vacc0x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc1x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc1x0123), vqmovn_s32(vacc1x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc2x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc2x0123), vqmovn_s32(vacc2x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc3x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc3x0123), vqmovn_s32(vacc3x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc4x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc4x0123), vqmovn_s32(vacc4x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc5x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc5x0123), vqmovn_s32(vacc5x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc6x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc6x0123), vqmovn_s32(vacc6x4567)),
-      voutput_zero_point);
-  const int16x8_t vacc7x01234567 = vqaddq_s16(
-      vcombine_s16(vqmovn_s32(vacc7x0123), vqmovn_s32(vacc7x4567)),
-      voutput_zero_point);
 
-  uint8x16_t vout0x01234567_1x01234567 =
-      vcombine_u8(vqmovun_s16(vacc0x01234567), vqmovun_s16(vacc1x01234567));
-  uint8x16_t vout2x01234567_3x01234567 =
-      vcombine_u8(vqmovun_s16(vacc2x01234567), vqmovun_s16(vacc3x01234567));
-  uint8x16_t vout4x01234567_5x01234567 =
-      vcombine_u8(vqmovun_s16(vacc4x01234567), vqmovun_s16(vacc5x01234567));
-  uint8x16_t vout6x01234567_7x01234567 =
-      vcombine_u8(vqmovun_s16(vacc6x01234567), vqmovun_s16(vacc7x01234567));
-#endif
   const uint8x16_t voutput_min =
       vld1q_dup_u8(&quantization_params->neon.output_min);
   const uint8x16_t voutput_max =
@@ -1021,6 +969,104 @@ void pytorch_q8gemm_ukernel_8x8__neon(
   vout2x01234567_3x01234567 = vminq_u8(vout2x01234567_3x01234567, voutput_max);
   vout4x01234567_5x01234567 = vminq_u8(vout4x01234567_5x01234567, voutput_max);
   vout6x01234567_7x01234567 = vminq_u8(vout6x01234567_7x01234567, voutput_max);
+#else
+  const float32x4_t vfmin = vdupq_n_f32(quantization_params->neon.vfmin);
+  const float32x4_t vfmax = vdupq_n_f32(quantization_params->neon.vfmax);
+  const float32x4_t vfmagic = vdupq_n_f32(quantization_params->neon.vfmagic);
+  const int32x4_t vimagic = vdupq_n_s32(quantization_params->neon.vimagic);
+
+  const float32x4_t vacc0x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc0x0123_f, vfmin), vfmax);
+  const float32x4_t vacc1x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc1x0123_f, vfmin), vfmax);
+  const float32x4_t vacc2x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc2x0123_f, vfmin), vfmax);
+  const float32x4_t vacc3x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc3x0123_f, vfmin), vfmax);
+  const float32x4_t vacc0x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc0x4567_f, vfmin), vfmax);
+  const float32x4_t vacc1x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc1x4567_f, vfmin), vfmax);
+  const float32x4_t vacc2x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc2x4567_f, vfmin), vfmax);
+  const float32x4_t vacc3x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc3x4567_f, vfmin), vfmax);
+  const float32x4_t vacc4x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc4x0123_f, vfmin), vfmax);
+  const float32x4_t vacc5x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc5x0123_f, vfmin), vfmax);
+  const float32x4_t vacc6x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc6x0123_f, vfmin), vfmax);
+  const float32x4_t vacc7x0123_f_clamped =
+      vminq_f32(vmaxq_f32(vacc7x0123_f, vfmin), vfmax);
+  const float32x4_t vacc4x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc4x4567_f, vfmin), vfmax);
+  const float32x4_t vacc5x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc5x4567_f, vfmin), vfmax);
+  const float32x4_t vacc6x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc6x4567_f, vfmin), vfmax);
+  const float32x4_t vacc7x4567_f_clamped =
+      vminq_f32(vmaxq_f32(vacc7x4567_f, vfmin), vfmax);
+
+  vacc0x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc0x0123_f_clamped, vfmagic)), vimagic);
+  vacc1x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc1x0123_f_clamped, vfmagic)), vimagic);
+  vacc2x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc2x0123_f_clamped, vfmagic)), vimagic);
+  vacc3x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc3x0123_f_clamped, vfmagic)), vimagic);
+  vacc0x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc0x4567_f_clamped, vfmagic)), vimagic);
+  vacc1x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc1x4567_f_clamped, vfmagic)), vimagic);
+  vacc2x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc2x4567_f_clamped, vfmagic)), vimagic);
+  vacc3x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc3x4567_f_clamped, vfmagic)), vimagic);
+  vacc4x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc4x0123_f_clamped, vfmagic)), vimagic);
+  vacc5x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc5x0123_f_clamped, vfmagic)), vimagic);
+  vacc6x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc6x0123_f_clamped, vfmagic)), vimagic);
+  vacc7x0123 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc7x0123_f_clamped, vfmagic)), vimagic);
+  vacc4x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc4x4567_f_clamped, vfmagic)), vimagic);
+  vacc5x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc5x4567_f_clamped, vfmagic)), vimagic);
+  vacc6x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc6x4567_f_clamped, vfmagic)), vimagic);
+  vacc7x4567 = vsubq_s32(
+      vreinterpretq_s32_f32(vaddq_f32(vacc7x4567_f_clamped, vfmagic)), vimagic);
+
+  const int16x8_t vacc0x01234567 =
+      vcombine_s16(vqmovn_s32(vacc0x0123), vqmovn_s32(vacc0x4567));
+  const int16x8_t vacc1x01234567 =
+      vcombine_s16(vqmovn_s32(vacc1x0123), vqmovn_s32(vacc1x4567));
+  const int16x8_t vacc2x01234567 =
+      vcombine_s16(vqmovn_s32(vacc2x0123), vqmovn_s32(vacc2x4567));
+  const int16x8_t vacc3x01234567 =
+      vcombine_s16(vqmovn_s32(vacc3x0123), vqmovn_s32(vacc3x4567));
+  const int16x8_t vacc4x01234567 =
+      vcombine_s16(vqmovn_s32(vacc4x0123), vqmovn_s32(vacc4x4567));
+  const int16x8_t vacc5x01234567 =
+      vcombine_s16(vqmovn_s32(vacc5x0123), vqmovn_s32(vacc5x4567));
+  const int16x8_t vacc6x01234567 =
+      vcombine_s16(vqmovn_s32(vacc6x0123), vqmovn_s32(vacc6x4567));
+  const int16x8_t vacc7x01234567 =
+      vcombine_s16(vqmovn_s32(vacc7x0123), vqmovn_s32(vacc7x4567));
+
+  uint8x16_t vout0x01234567_1x01234567 =
+      vcombine_u8(vqmovun_s16(vacc0x01234567), vqmovun_s16(vacc1x01234567));
+  uint8x16_t vout2x01234567_3x01234567 =
+      vcombine_u8(vqmovun_s16(vacc2x01234567), vqmovun_s16(vacc3x01234567));
+  uint8x16_t vout4x01234567_5x01234567 =
+      vcombine_u8(vqmovun_s16(vacc4x01234567), vqmovun_s16(vacc5x01234567));
+  uint8x16_t vout6x01234567_7x01234567 =
+      vcombine_u8(vqmovun_s16(vacc6x01234567), vqmovun_s16(vacc7x01234567));
+#endif
 
   uint8_t* c0 = c;
   uint8_t* c1 = (uint8_t*)((uintptr_t)c0 + c_stride);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/params.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/params.h
@@ -30,6 +30,9 @@ struct pytorch_qnnp_fp32_clamping_params {
 union pytorch_qnnp_fp32_requantization_params {
   struct {
     float scale;
+    uint8_t output_zero_point;
+    uint8_t output_max;
+    uint8_t output_min;
     float min_less_zero_point;
     float max_less_zero_point;
     float magic;
@@ -127,10 +130,7 @@ union pytorch_qnnp_conv_quantization_params {
   struct {
     int32_t kernel_zero_point;
     int32_t input_zero_point;
-    int32_t multiplier;
-    int32_t remainder_mask;
-    int32_t remainder_threshold;
-    uint32_t shift;
+    float requantization_scale;
     int32_t output_min_less_zero_point;
     int32_t output_max_less_zero_point;
     int32_t output_zero_point;
@@ -139,22 +139,24 @@ union pytorch_qnnp_conv_quantization_params {
   struct {
     int16_t kernel_zero_point;
     int16_t input_zero_point;
-    int32_t multiplier;
-    int32_t right_shift;
+    float requantization_scale;
     int16_t output_zero_point;
     uint8_t output_max;
     uint8_t output_min;
+    // Following four are for nearest-ties-to-even
+    // rounding in aarch32. This saves some instructions
+    // needed otherwise.
+    float vfmax;
+    float vfmin;
+    float vfmagic;
+    int32_t vimagic;
   } neon;
 #endif /* CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 */
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
   struct {
     PYTORCH_QNNP_ALIGN(16) int16_t kernel_zero_point[8];
     PYTORCH_QNNP_ALIGN(16) int16_t input_zero_point[8];
-    PYTORCH_QNNP_ALIGN(16) uint32_t multiplier[4];
-    PYTORCH_QNNP_ALIGN(16) uint64_t rounding[2];
-    PYTORCH_QNNP_ALIGN(16) int32_t remainder_mask[4];
-    PYTORCH_QNNP_ALIGN(16) int32_t remainder_threshold[4];
-    PYTORCH_QNNP_ALIGN(16) uint64_t shift[2];
+    PYTORCH_QNNP_ALIGN(16) float requantization_scale[4];
     PYTORCH_QNNP_ALIGN(16) int16_t output_zero_point[8];
     PYTORCH_QNNP_ALIGN(16) uint8_t output_max[16];
     PYTORCH_QNNP_ALIGN(16) uint8_t output_min[16];

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/requantization.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/requantization.h
@@ -61,9 +61,6 @@ pytorch_qnnp_compute_scalar_fp32_requantization_params(
     uint8_t zero_point,
     uint8_t min,
     uint8_t max) {
-  /* Compute requantization parameters */
-  assert(scale < 1.0f);
-  assert(scale >= 0x1.0p-32f);
 
   union pytorch_qnnp_fp32_requantization_params params;
   params.scalar.scale = scale;
@@ -157,8 +154,6 @@ pytorch_qnnp_compute_conv_quantization_params(
     uint8_t output_zero_point,
     uint8_t output_min,
     uint8_t output_max) {
-  assert(scale > 0);
-  assert(scale <= 1);
 
   union pytorch_qnnp_conv_quantization_params params;
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/requantization.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/requantization.h
@@ -55,6 +55,31 @@ pytorch_qnnp_compute_scalar_requantization_params(
   return params;
 }
 
+static inline union pytorch_qnnp_fp32_requantization_params
+pytorch_qnnp_compute_scalar_fp32_requantization_params(
+    float scale,
+    uint8_t zero_point,
+    uint8_t min,
+    uint8_t max) {
+  /* Compute requantization parameters */
+  assert(scale < 1.0f);
+  assert(scale >= 0x1.0p-32f);
+
+  union pytorch_qnnp_fp32_requantization_params params;
+  params.scalar.scale = scale;
+  params.scalar.output_zero_point = zero_point;
+  params.scalar.output_max = max;
+  params.scalar.output_min = min;
+  params.scalar.min_less_zero_point = ((float)((int32_t)(uint32_t)min -
+      (int32_t)(uint32_t)zero_point));
+  params.scalar.max_less_zero_point = ((float)((int32_t)(uint32_t)max -
+      (int32_t)(uint32_t)zero_point));
+  params.scalar.magic = 12582912.0f;
+  params.scalar.magic_less_zero_point = (INT32_C(0x4B400000) -
+      (int32_t)(uint32_t)zero_point);
+  return params;
+}
+
 static inline union pytorch_qnnp_q31_requantization_params
 pytorch_qnnp_compute_requantization_params(
     float scale,
@@ -128,48 +153,23 @@ static inline union pytorch_qnnp_conv_quantization_params
 pytorch_qnnp_compute_conv_quantization_params(
     uint8_t input_zero_point,
     uint8_t kernel_zero_point,
-    float scale,
+    float requantization_scale,
     uint8_t output_zero_point,
     uint8_t output_min,
     uint8_t output_max) {
-  /* Compute requantization parameters */
-  const uint32_t scale_bits = fp32_to_bits(scale);
-
-  /* Multiplier is in [0x40000000, 0x7FFFFF80] range */
-  const int32_t multiplier = (int32_t)(
-      ((scale_bits & UINT32_C(0x007FFFFF)) | UINT32_C(0x00800000)) << 7);
-  assert(multiplier >= INT32_C(0x40000000));
-  assert(multiplier <= INT32_C(0x7FFFFF80));
-
-  /* Shift is in [0, 31] range */
-  const int32_t shift = 127 + 31 - 32 - (fp32_to_bits(scale) >> 23);
-  assert(shift >= 0);
-  assert(shift < 32);
+  assert(scale > 0);
+  assert(scale <= 1);
 
   union pytorch_qnnp_conv_quantization_params params;
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
-  const uint32_t remainder_mask = (UINT32_C(1) << shift) - UINT32_C(1);
-  const uint32_t remainder_threshold = remainder_mask >> 1;
   for (uint32_t i = 0; i < 8; i++) {
     params.sse2.input_zero_point[i] = (int16_t)(uint16_t)input_zero_point;
     params.sse2.kernel_zero_point[i] = (int16_t)(uint16_t)kernel_zero_point;
   }
-  params.sse2.multiplier[0] = multiplier;
-  params.sse2.multiplier[1] = multiplier;
-  params.sse2.multiplier[2] = multiplier;
-  params.sse2.multiplier[3] = multiplier;
-  params.sse2.rounding[0] = UINT64_C(0x40000000);
-  params.sse2.rounding[1] = UINT64_C(0x40000000);
-  params.sse2.remainder_mask[0] = (int32_t)remainder_mask;
-  params.sse2.remainder_mask[1] = (int32_t)remainder_mask;
-  params.sse2.remainder_mask[2] = (int32_t)remainder_mask;
-  params.sse2.remainder_mask[3] = (int32_t)remainder_mask;
-  params.sse2.remainder_threshold[0] = (int32_t)remainder_threshold;
-  params.sse2.remainder_threshold[1] = (int32_t)remainder_threshold;
-  params.sse2.remainder_threshold[2] = (int32_t)remainder_threshold;
-  params.sse2.remainder_threshold[3] = (int32_t)remainder_threshold;
-  params.sse2.shift[0] = (uint64_t)(uint32_t)shift;
-  params.sse2.shift[1] = (uint64_t)(uint32_t)shift;
+  params.sse2.requantization_scale[0] = requantization_scale;
+  params.sse2.requantization_scale[1] = requantization_scale;
+  params.sse2.requantization_scale[2] = requantization_scale;
+  params.sse2.requantization_scale[3] = requantization_scale;
   for (uint32_t i = 0; i < 8; i++) {
     params.sse2.output_zero_point[i] = (int16_t)(uint16_t)output_zero_point;
   }
@@ -180,20 +180,21 @@ pytorch_qnnp_compute_conv_quantization_params(
 #elif CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
   params.neon.input_zero_point = (int16_t)(uint16_t)input_zero_point;
   params.neon.kernel_zero_point = (int16_t)(uint16_t)kernel_zero_point;
-  params.neon.multiplier = multiplier;
-  params.neon.right_shift = -shift;
+  params.neon.requantization_scale = requantization_scale;
   params.neon.output_zero_point = (int16_t)(uint16_t)output_zero_point;
   params.neon.output_max = output_max;
   params.neon.output_min = output_min;
+  params.neon.vfmin = ((float)((int32_t)(uint32_t)output_min -
+      (int32_t)(uint32_t)output_zero_point));
+  params.neon.vfmax = ((float)((int32_t)(uint32_t)output_max -
+      (int32_t)(uint32_t)output_zero_point));
+  params.neon.vfmagic = 12582912.0f;
+  params.neon.vimagic = (INT32_C(0x4B400000) -
+      (int32_t)(uint32_t)output_zero_point);
 #else
-  const uint32_t remainder_mask = (UINT32_C(1) << shift) - UINT32_C(1);
-  const uint32_t remainder_threshold = remainder_mask >> 1;
   params.scalar.input_zero_point = (int32_t)(uint32_t)input_zero_point;
   params.scalar.kernel_zero_point = (int32_t)(uint32_t)kernel_zero_point;
-  params.scalar.multiplier = multiplier;
-  params.scalar.remainder_mask = (int32_t)remainder_mask;
-  params.scalar.remainder_threshold = (int32_t)remainder_threshold;
-  params.scalar.shift = (uint32_t)shift;
+  params.scalar.requantization_scale = requantization_scale;
   params.scalar.output_min_less_zero_point =
       (int32_t)(uint32_t)output_min - (int32_t)(uint32_t)output_zero_point;
   params.scalar.output_max_less_zero_point =
@@ -503,6 +504,44 @@ static inline uint8_t pytorch_qnnp_q31_requantize(
   }
 
   return (uint8_t)(n + params.scalar.zero_point);
+}
+
+static inline uint8_t pytorch_qnnp_fp32_requantize(
+    int32_t n,
+    union pytorch_qnnp_fp32_requantization_params params) {
+
+  const long lmin =
+      (long)((int32_t)(uint32_t)params.scalar.output_min -
+          (int32_t)(uint32_t)params.scalar.output_zero_point);
+  const long lmax =
+      (long)((int32_t)(uint32_t)params.scalar.output_max -
+          (int32_t)(uint32_t)params.scalar.output_zero_point);
+
+  const float n_scaled = (float)n * params.scalar.scale;
+  const long n_rounded = lrintf(n_scaled);
+  const int32_t n_clamped = (int32_t)(
+      n_rounded < lmin ? lmin : n_rounded > lmax ? lmax : n_rounded);
+  const int32_t n_biased =
+      n_clamped + (int32_t)(uint32_t)params.scalar.output_zero_point;
+
+  return (uint8_t)n_biased;
+}
+
+static inline uint8_t pytorch_qnnp_fp32_requantize_magic(
+    int32_t n,
+    union pytorch_qnnp_fp32_requantization_params params) {
+
+  const float fmin = params.scalar.min_less_zero_point;
+  const float fmax = params.scalar.max_less_zero_point;
+  const float fmagic = params.scalar.magic;
+  const int32_t imagic = params.scalar.magic_less_zero_point;
+
+  const float n_scaled = (float)n * params.scalar.scale;
+  const float n_clamped =
+      n_scaled < fmin ? fmin : n_scaled > fmax ? fmax : n_scaled;
+  const int32_t n_biased = (int32_t)fp32_to_bits(n_clamped + fmagic) - imagic;
+
+  return (uint8_t)n_biased;
 }
 
 static inline uint8_t pytorch_qnnp_avgpool_quantize(

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/dwconv-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/dwconv-microkernel-tester.h
@@ -271,9 +271,9 @@ class DWConvMicrokernelTester {
               outputZeroPoint,
               qmin(),
               qmax());
-      const union pytorch_qnnp_q31_requantization_params
+      const union pytorch_qnnp_fp32_requantization_params
           scalarRequantizationParams =
-              pytorch_qnnp_compute_scalar_requantization_params(
+              pytorch_qnnp_compute_scalar_fp32_requantization_params(
                   requantizationScale, outputZeroPoint, qmin(), qmax());
 
       q8dwconv(
@@ -288,8 +288,13 @@ class DWConvMicrokernelTester {
 
       for (size_t x = 0; x < width(); x++) {
         for (size_t c = 0; c < channels(); c++) {
-          const uint8_t referenceOutput = pytorch_qnnp_q31_requantize(
+#if defined(__arm__) || defined(_M_ARM)
+          const uint8_t referenceOutput = pytorch_qnnp_fp32_requantize_magic(
               accumulators[x * channels() + c], scalarRequantizationParams);
+#else
+          const uint8_t referenceOutput = pytorch_qnnp_fp32_requantize(
+              accumulators[x * channels() + c], scalarRequantizationParams);
+#endif
           const double scaledAccumulator =
               accumulators[x * channels() + c] / outputScale +
               double(outputZeroPoint);
@@ -445,9 +450,9 @@ class DWConvMicrokernelTester {
               outputZeroPoint,
               qmin(),
               qmax());
-      const union pytorch_qnnp_q31_requantization_params
+      const union pytorch_qnnp_fp32_requantization_params
           scalarRequantizationParams =
-              pytorch_qnnp_compute_scalar_requantization_params(
+              pytorch_qnnp_compute_scalar_fp32_requantization_params(
                   requantizationScale, outputZeroPoint, qmin(), qmax());
 
       q8dwconv(
@@ -463,8 +468,13 @@ class DWConvMicrokernelTester {
 
       for (size_t x = 0; x < width(); x++) {
         for (size_t c = 0; c < channels(); c++) {
-          const uint8_t referenceOutput = pytorch_qnnp_q31_requantize(
+#if defined(__arm__) || defined(_M_ARM)
+          const uint8_t referenceOutput = pytorch_qnnp_fp32_requantize_magic(
               accumulators[x * channels() + c], scalarRequantizationParams);
+#else
+          const uint8_t referenceOutput = pytorch_qnnp_fp32_requantize(
+              accumulators[x * channels() + c], scalarRequantizationParams);
+#endif
           const double scaledAccumulator =
               accumulators[x * channels() + c] / outputScale +
               double(outputZeroPoint);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-microkernel-tester.h
@@ -276,9 +276,9 @@ class GemmMicrokernelTester {
               cZeroPoint,
               qmin(),
               qmax());
-      const union pytorch_qnnp_q31_requantization_params
+      const union pytorch_qnnp_fp32_requantization_params
           scalarRequantizationParams =
-              pytorch_qnnp_compute_scalar_requantization_params(
+              pytorch_qnnp_compute_scalar_fp32_requantization_params(
                   requantizationScale, cZeroPoint, qmin(), qmax());
 
       qgemm(
@@ -294,8 +294,13 @@ class GemmMicrokernelTester {
 
       for (size_t mIndex = 0; mIndex < m(); mIndex++) {
         for (size_t nIndex = 0; nIndex < n(); nIndex++) {
-          cRef[mIndex * n() + nIndex] = pytorch_qnnp_q31_requantize(
+#if defined(__arm__) || defined(_M_ARM)
+          cRef[mIndex * n() + nIndex] = pytorch_qnnp_fp32_requantize_magic(
               acc[mIndex * n() + nIndex], scalarRequantizationParams);
+#else
+          cRef[mIndex * n() + nIndex] = pytorch_qnnp_fp32_requantize(
+              acc[mIndex * n() + nIndex], scalarRequantizationParams);
+#endif
         }
       }
 
@@ -539,9 +544,9 @@ class GemmMicrokernelTester {
               cZeroPoint,
               qmin(),
               qmax());
-      const union pytorch_qnnp_q31_requantization_params
+      const union pytorch_qnnp_fp32_requantization_params
           scalarRequantizationParams =
-              pytorch_qnnp_compute_scalar_requantization_params(
+              pytorch_qnnp_compute_scalar_fp32_requantization_params(
                   requantizationScale, cZeroPoint, qmin(), qmax());
 
       qconv(
@@ -557,8 +562,13 @@ class GemmMicrokernelTester {
 
       for (size_t mIndex = 0; mIndex < m(); mIndex++) {
         for (size_t nIndex = 0; nIndex < n(); nIndex++) {
-          cRef[mIndex * n() + nIndex] = pytorch_qnnp_q31_requantize(
+#if defined(__arm__) || defined(_M_ARM)
+          cRef[mIndex * n() + nIndex] = pytorch_qnnp_fp32_requantize_magic(
               acc[mIndex * n() + nIndex], scalarRequantizationParams);
+#else
+          cRef[mIndex * n() + nIndex] = pytorch_qnnp_fp32_requantize(
+              acc[mIndex * n() + nIndex], scalarRequantizationParams);
+#endif
         }
       }
 


### PR DESCRIPTION
This PR is motivated by two issues it tries to address:
1) relax the constraint on requantization scale (<1). 
2) Unify requantization methodology across pytorch integration of QNNPACK and FBGEMM.

Here we are trying to address the first part for Conv and Linear.
Existing requantization scheme performs scale multiplication entirely in integer arithmetic by extracting mantissa and exponent part of FP scale and processing them. This including appropriate rounding required. The set of instruction, corresponding to this, are specifically tailored for the condition when scale < 1.

Relaxing this constraint requires us to fix that sequence of instruction. In this PR we take a simpler approach of essentially converting Int32 to FP32, apply scale, convert FP32 to Int32 with appropriate rounding, to-nearest-ties-to-even. This is followed by zero point add and clipping. Since in 32-bit ARM nearest-ties-to-even rounding instruction is not available, the sequence is little different. Sequence for both 32-bit and 64-bit are taken from https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/qnnpack/src/requantization/fp32-neon.c.

Furthermore relaxing the scale constraint and moving towards FP requantization also helps us move towards unifying requantization producer across QNNPACK and FBGEMM.


Summary of the PR:
- requantization params are modified to lift some computation that would have to be in the kernel otherwise for aarch32 kernels, particularly:
   - Computing vfmin, vfmax, vfmagic and vimagic.
- Fixed q8gemm, q8conv and q8dwconv kernels.
- Fixed the corresponding tests.

What is not done:
- XZP kernels are not changed as part of this PR.