### PR TITLE
[caffe2] fix type and shape inference for common gradient ops

### DIFF
--- a/caffe2/operators/abs_op.cc
+++ b/caffe2/operators/abs_op.cc
@@ -86,7 +86,10 @@ Y: [0.3005476  1.551666   1.3591481  0.39191285 0.21866608]
         "*(type: Tensor`<float>`)* Absolute value of input element-wise.")
     .InheritOnnxSchema();
 
-OPERATOR_SCHEMA(AbsGradient).NumInputs(2).NumOutputs(1).IdenticalTypeAndShape();
+OPERATOR_SCHEMA(AbsGradient)
+    .NumInputs(2)
+    .NumOutputs(1)
+    .IdenticalTypeAndShapeOfInput(0);
 
 namespace {
 

--- a/caffe2/operators/cbrt_op.cc
+++ b/caffe2/operators/cbrt_op.cc
@@ -51,7 +51,7 @@ OPERATOR_SCHEMA(CbrtGradient)
     .NumInputs(2)
     .NumOutputs(1)
     .AllowInplace({{0, 0}})
-    .IdenticalTypeAndShape();
+    .IdenticalTypeAndShapeOfInput(0);
 
 namespace {
 

--- a/caffe2/operators/cosh_op.cc
+++ b/caffe2/operators/cosh_op.cc
@@ -93,7 +93,7 @@ Y: [1.22883528 1.05188156 1.35112322 1.43744212 1.07812598]
 OPERATOR_SCHEMA(CoshGradient)
     .NumInputs(2)
     .NumOutputs(1)
-    .IdenticalTypeAndShape();
+    .IdenticalTypeAndShapeOfInput(0);
 
 namespace {
 

--- a/caffe2/operators/elementwise_ops_schema.cc
+++ b/caffe2/operators/elementwise_ops_schema.cc
@@ -214,7 +214,9 @@ C:
 </details>
 )DOC";
 
-std::function<void(OpSchema&)> MathDocGenerator(const char* name, const char* extra) {
+std::function<void(OpSchema&)> MathDocGenerator(
+    const char* name,
+    const char* extra) {
   return [=](OpSchema& schema) {
     string doc = R"DOC(
 Performs element-wise binary {name} (with limited broadcast support).
@@ -226,10 +228,9 @@ Performs element-wise binary {name} (with limited broadcast support).
     c10::ReplaceAll(doc, "{broadcast_doc}", kBroadcastDoc);
     c10::ReplaceAll(doc, "{extra}", extra);
     schema.SetDoc(doc);
-    schema.Arg("broadcast", "*(type: int; default: 0)* Pass 1 to enable broadcasting");
     schema.Arg(
-        "axis",
-        "*(type: int; default: -1)* Axis to concatenate on.");
+        "broadcast", "*(type: int; default: 0)* Pass 1 to enable broadcasting");
+    schema.Arg("axis", "*(type: int; default: -1)* Axis to concatenate on.");
     schema.Input(
         0,
         "A",
@@ -239,7 +240,10 @@ Performs element-wise binary {name} (with limited broadcast support).
         "B",
         "*(type: Tensor`<float>`)* Second operand. With broadcasting can be of smaller size than A. "
         "If broadcasting is disabled it should be of the same size as A.");
-    schema.Output(0, "C", "*(type: Tensor`<float>`)* Output tensor with same dimensions and type as A.");
+    schema.Output(
+        0,
+        "C",
+        "*(type: Tensor`<float>`)* Output tensor with same dimensions and type as A.");
   };
 }
 
@@ -265,6 +269,15 @@ std::vector<TensorShape> ElementwiseOpShapeInference(
   return out;
 }
 
+std::vector<TensorShape> ElementwiseGradientOpShapeInference(
+    const OperatorDef& def,
+    const std::vector<TensorShape>& in) {
+  std::vector<TensorShape> out;
+  out.push_back(in.at(1));
+  out.push_back(in.at(2));
+  return out;
+}
+
 } // namespace
 
 OPERATOR_SCHEMA(Add)
@@ -278,6 +291,7 @@ OPERATOR_SCHEMA(Add)
 OPERATOR_SCHEMA(AddGradient)
     .NumInputs(3)
     .NumOutputs(2)
+    .TensorInferenceFunction(ElementwiseGradientOpShapeInference)
     .AllowInplace({{0, 0}, {0, 1}});
 
 OPERATOR_SCHEMA(Sub)
@@ -291,6 +305,7 @@ OPERATOR_SCHEMA(Sub)
 OPERATOR_SCHEMA(SubGradient)
     .NumInputs(3)
     .NumOutputs(2)
+    .TensorInferenceFunction(ElementwiseGradientOpShapeInference)
     .AllowInplace({{0, 0}, {0, 1}});
 
 OPERATOR_SCHEMA(Mul)
@@ -304,6 +319,7 @@ OPERATOR_SCHEMA(Mul)
 OPERATOR_SCHEMA(MulGradient)
     .NumInputs(3)
     .NumOutputs(2)
+    .TensorInferenceFunction(ElementwiseGradientOpShapeInference)
     .AllowInplace({{0, 0}, {0, 1}});
 
 OPERATOR_SCHEMA(Div)
@@ -317,6 +333,7 @@ OPERATOR_SCHEMA(Div)
 OPERATOR_SCHEMA(DivGradient)
     .NumInputs(3, 4)
     .NumOutputs(2)
+    .TensorInferenceFunction(ElementwiseGradientOpShapeInference)
     .AllowInplace({{0, 0}});
 
 OPERATOR_SCHEMA(SumReduceLike)
@@ -586,10 +603,8 @@ C: [False  True  True False False  True]
 </details>
 )DOC";
 
-std::function<void(OpSchema&)> ComparisonDocGenerator(
-    const char* name,
-    const char* desc,
-    const char* extra) {
+std::function<void(OpSchema&)>
+ComparisonDocGenerator(const char* name, const char* desc, const char* extra) {
   return [=](OpSchema& schema) {
     string doc = R"DOC(
 Performs element-wise {desc} comparison **{name}** (with limited broadcast support).
@@ -603,7 +618,9 @@ Performs element-wise {desc} comparison **{name}** (with limited broadcast suppo
     c10::ReplaceAll(doc, "{broadcast_doc}", kBroadcastDoc);
     c10::ReplaceAll(doc, "{extra}", extra);
     schema.SetDoc(doc);
-    schema.Arg("broadcast", "*(type: int; default: 0)* Pass 1 to enable broadcasting.");
+    schema.Arg(
+        "broadcast",
+        "*(type: int; default: 0)* Pass 1 to enable broadcasting.");
     schema.Arg(
         "axis",
         "*(type: int; default: -1)* Axis to concatenate on. If set, defines the broadcast dimensions.");
@@ -616,39 +633,50 @@ Performs element-wise {desc} comparison **{name}** (with limited broadcast suppo
         "B",
         "*(type: Tensor`<bool>`)* Second operand. With broadcasting can be of smaller size than `A`. "
         "If broadcasting is disabled it should be of the same size.");
-    schema.Output(0, "C", "*(type: Tensor`<bool>`)* Output tensor with same dimensions as `A`.");
+    schema.Output(
+        0,
+        "C",
+        "*(type: Tensor`<bool>`)* Output tensor with same dimensions as `A`.");
   };
 }
 
-#define CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(name, symbol, desc, extra)      \
-  OPERATOR_SCHEMA(name)                                                        \
-      .NumInputs(2)                                                            \
-      .NumOutputs(1)                                                           \
-      .TensorInferenceFunction(                                                \
-          [](const OperatorDef& def, const vector<TensorShape>& in) {          \
-            ArgumentHelper helper(def);                                        \
-            const auto broadcasted =                                           \
-                helper.GetSingleArgument<bool>("broadcast", false);            \
-            if (!broadcasted) {                                                \
-              CAFFE_ENFORCE_EQ(in[0].dims().size(), in[1].dims().size());      \
-              for (int i = 0; i < in[0].dims().size(); ++i) {                  \
-                CAFFE_ENFORCE_EQ(in[0].dims(i), in[1].dims(i));                \
-              }                                                                \
-            }                                                                  \
-            auto output_dims =                                                 \
-                std::vector<int64_t>(in[0].dims().begin(), in[0].dims().end()); \
-            return vector<TensorShape>{                                        \
-                CreateTensorShape(output_dims, TensorProto::BOOL)};            \
-          })                                                                   \
-      .FillUsing(ComparisonDocGenerator(symbol, desc, extra));                 \
+#define CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(name, symbol, desc, extra)   \
+  OPERATOR_SCHEMA(name)                                                     \
+      .NumInputs(2)                                                         \
+      .NumOutputs(1)                                                        \
+      .TensorInferenceFunction([](const OperatorDef& def,                   \
+                                  const vector<TensorShape>& in) {          \
+        ArgumentHelper helper(def);                                         \
+        const auto broadcasted =                                            \
+            helper.GetSingleArgument<bool>("broadcast", false);             \
+        if (!broadcasted) {                                                 \
+          CAFFE_ENFORCE_EQ(in[0].dims().size(), in[1].dims().size());       \
+          for (int i = 0; i < in[0].dims().size(); ++i) {                   \
+            CAFFE_ENFORCE_EQ(in[0].dims(i), in[1].dims(i));                 \
+          }                                                                 \
+        }                                                                   \
+        auto output_dims =                                                  \
+            std::vector<int64_t>(in[0].dims().begin(), in[0].dims().end()); \
+        return vector<TensorShape>{                                         \
+            CreateTensorShape(output_dims, TensorProto::BOOL)};             \
+      })                                                                    \
+      .FillUsing(ComparisonDocGenerator(symbol, desc, extra));              \
   SHOULD_NOT_DO_GRADIENT(name)
 
 CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(EQ, "==", "equal to", kEQExample);
 CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(NE, "!=", "not equal to", kNEExample);
 CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(LT, "<", "less than", kLTExample);
-CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(LE, "<=", "less or equal than", kLEExample);
+CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(
+    LE,
+    "<=",
+    "less or equal than",
+    kLEExample);
 CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(GT, ">", "greater than", kGTExample);
-CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(GE, ">=", "greater or equal than", kGEExample);
+CAFFE2_SCHEMA_FOR_BINARY_COMPARISON_OP(
+    GE,
+    ">=",
+    "greater or equal than",
+    kGEExample);
 
 const char kAndExample[] = R"DOC(
 <details>
@@ -794,7 +822,9 @@ C:
 </details>
 )DOC";
 
-std::function<void(OpSchema&)> LogicalDocGenerator(const char* name, const char* extra) {
+std::function<void(OpSchema&)> LogicalDocGenerator(
+    const char* name,
+    const char* extra) {
   return [=](OpSchema& schema) {
     string doc = R"DOC(
 Performs element-wise logical operation **{name}** (with limited broadcast support).
@@ -808,7 +838,9 @@ Both input operands should be of type `bool`.
     c10::ReplaceAll(doc, "{broadcast_doc}", kBroadcastDoc);
     c10::ReplaceAll(doc, "{extra}", extra);
     schema.SetDoc(doc);
-    schema.Arg("broadcast", "*(type: int; default: 0)* Pass 1 to enable broadcasting.");
+    schema.Arg(
+        "broadcast",
+        "*(type: int; default: 0)* Pass 1 to enable broadcasting.");
     schema.Arg(
         "axis",
         "*(type: int; default: -1)* Axis to concatenate on. If set, defines the broadcast dimensions.");
@@ -818,7 +850,10 @@ Both input operands should be of type `bool`.
         "B",
         "*(type: Tensor`<bool>`)* Second operand. With broadcasting can be of smaller size than `A`. "
         "If broadcasting is disabled it should be of the same size.");
-    schema.Output(0, "C", "*(type: Tensor`<bool>`)* Output tensor of booleans. Has same dimensions as input `A`.");
+    schema.Output(
+        0,
+        "C",
+        "*(type: Tensor`<bool>`)* Output tensor of booleans. Has same dimensions as input `A`.");
   };
 }
 
@@ -847,7 +882,9 @@ Both input operands should be of type `bool`.
     c10::ReplaceAll(doc, "{name}", name);
     c10::ReplaceAll(doc, "{broadcast_doc}", kBroadcastDoc);
     schema.SetDoc(doc);
-    schema.Arg("broadcast", "*(type: int; default: 0)* Pass 1 to enable broadcasting.");
+    schema.Arg(
+        "broadcast",
+        "*(type: int; default: 0)* Pass 1 to enable broadcasting.");
     schema.Arg(
         "axis",
         "*(type: int; default: -1)* Axis to concatenate on. If set, defines the broadcast dimensions.");
@@ -857,7 +894,10 @@ Both input operands should be of type `bool`.
         "B",
         "*(type: Tensor)* Second operand. With broadcasting can be of smaller size than `A`. "
         "If broadcasting is disabled it should be of the same size.");
-    schema.Output(0, "C", "*(type: Tensor)* Output tensor. Has same dimensions as input `A`.");
+    schema.Output(
+        0,
+        "C",
+        "*(type: Tensor)* Output tensor. Has same dimensions as input `A`.");
   };
 }
 

--- a/caffe2/operators/gelu_op.cc
+++ b/caffe2/operators/gelu_op.cc
@@ -107,7 +107,7 @@ is applied to the tensor elementwise.
 OPERATOR_SCHEMA(GeluGradient)
     .NumInputs(2)
     .NumOutputs(1)
-    .IdenticalTypeAndShape();
+    .IdenticalTypeAndShapeOfInput(1);
 
 namespace {
 

--- a/caffe2/operators/leaky_relu_op.cc
+++ b/caffe2/operators/leaky_relu_op.cc
@@ -110,7 +110,8 @@ OPERATOR_SCHEMA(LeakyReluGradient)
     .NumOutputs(1)
     .AllowInplace({{1, 0}})
     .Arg("alpha", "Coefficient of leakage")
-    .InheritOnnxSchema();
+    .InheritOnnxSchema()
+    .IdenticalTypeAndShapeOfInput(1);
 
 class GetLeakyReluGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/prelu_op.cc
+++ b/caffe2/operators/prelu_op.cc
@@ -26,10 +26,9 @@ void runNeonPrelu(float* out, const float* in, int size, float w) {
   }
 
   // We want to load aligned from the input, but assume the output is unaligned
-  int prologue =
-    kVecSizeInFloat -
-    // remainder in floats
-    (((uintptr_t) in) % (sizeof(float32x4_t))) / sizeof(float);
+  int prologue = kVecSizeInFloat -
+      // remainder in floats
+      (((uintptr_t)in) % (sizeof(float32x4_t))) / sizeof(float);
 
   int i = 0;
 
@@ -91,7 +90,7 @@ void runNeonPrelu(float* out, const float* in, int size, float w) {
   }
 }
 
-}
+} // namespace
 #endif // defined(__ARM_NEON__) || defined(__ARM_NEON)
 
 template <>
@@ -133,9 +132,11 @@ bool PReluOp<float, CPUContext>::RunOnDevice() {
       // Pointwise for each channel
       for (int n = 0; n < N; ++n) {
         for (int c = 0; c < C; ++c) {
-          runNeonPrelu(Ydata + (n * C + c) * dim,
-                       Xdata + (n * C + c) * dim,
-                       dim, Wdata[c]);
+          runNeonPrelu(
+              Ydata + (n * C + c) * dim,
+              Xdata + (n * C + c) * dim,
+              dim,
+              Wdata[c]);
         }
       }
 #else
@@ -335,12 +336,16 @@ Y:
     .InheritOnnxSchema();
 
 // Input: Y, dY, output: dX
-GRADIENT_OPERATOR_SCHEMA(PReluGradient).NumInputs(4).NumOutputs(2).SetDoc(R"DOC(
+GRADIENT_OPERATOR_SCHEMA(PReluGradient)
+    .NumInputs(4)
+    .NumOutputs(2)
+    .SetDoc(R"DOC(
 
 PReluGradient takes both Y and dY and uses this to update dX and dW according
 to the chain rule and derivatives of the rectified linear function.
 
-)DOC");
+)DOC")
+    .IdenticalTypeAndShapeOfMultipleInputs({2, 3});
 
 class GetPReluGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;

--- a/caffe2/operators/relu_op.cc
+++ b/caffe2/operators/relu_op.cc
@@ -144,6 +144,7 @@ GRADIENT_OPERATOR_SCHEMA(ReluGradient)
     .NumInputs(2)
     .NumOutputs(1)
     .AllowInplace({{1, 0}})
+    .IdenticalTypeAndShapeOfInput(1)
     .SetDoc(R"DOC(
 ReluGradient takes both Y and dY and uses this to update dX according to the
 chain rule and derivatives of the rectified linear function.

--- a/caffe2/operators/sigmoid_op.cc
+++ b/caffe2/operators/sigmoid_op.cc
@@ -82,6 +82,7 @@ OPERATOR_SCHEMA(SigmoidGradient)
     .NumInputs(2)
     .NumOutputs(1)
     .AllowInplace({{1, 0}})
+    .IdenticalTypeAndShapeOfInput(1)
     .SetDoc(R"DOC(
 SigmoidGradient takes both Y and dY and uses this to update dX according to the
 chain rule and derivatives of the sigmoid function.

--- a/caffe2/operators/sinh_op.cc
+++ b/caffe2/operators/sinh_op.cc
@@ -93,7 +93,7 @@ Y: [1.15841695 0.5541099  0.03216984 1.09924557 0.49732079]
 OPERATOR_SCHEMA(SinhGradient)
     .NumInputs(2)
     .NumOutputs(1)
-    .IdenticalTypeAndShape();
+    .IdenticalTypeAndShapeOfInput(0);
 
 namespace {
 

--- a/caffe2/operators/tanh_op.cc
+++ b/caffe2/operators/tanh_op.cc
@@ -90,6 +90,10 @@ X:
         "element-wise")
     .InheritOnnxSchema();
 
-OPERATOR_SCHEMA(TanhGradient).NumInputs(2).NumOutputs(1).AllowInplace({{1, 0}});
+OPERATOR_SCHEMA(TanhGradient)
+    .NumInputs(2)
+    .NumOutputs(1)
+    .IdenticalTypeAndShapeOfInput(1)
+    .AllowInplace({{1, 0}});
 
 } // namespace caffe2

--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -428,6 +428,7 @@ class HypothesisTestCase(test_util.TestCase):
         threshold=0.005,
         stepsize=0.05,
         input_device_options=None,
+        ensure_outputs_are_inferred=False,
     ):
         """
         Implements a standard numerical gradient checker for the operator
@@ -455,7 +456,8 @@ class HypothesisTestCase(test_util.TestCase):
         res, grad, grad_estimated = gc.CheckSimple(
             op, inputs, outputs_to_check, outputs_with_grads,
             grad_ops=grad_ops,
-            input_device_options=input_device_options
+            input_device_options=input_device_options,
+            ensure_outputs_are_inferred=ensure_outputs_are_inferred,
         )
         self.assertEqual(grad.shape, grad_estimated.shape)
         self.assertTrue(

--- a/caffe2/python/operator_test/activation_ops_test.py
+++ b/caffe2/python/operator_test/activation_ops_test.py
@@ -39,9 +39,9 @@ class TestActivations(serial.SerializedTestCase):
         X += 0.02 * np.sign(X)
         X[X == 0.0] += 0.02
 
-        self.assertReferenceChecks(gc, op, [X], relu_ref)
+        self.assertReferenceChecks(gc, op, [X], relu_ref, ensure_outputs_are_inferred=True)
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertGradientChecks(gc, op, [X], 0, [0], ensure_outputs_are_inferred=True)
 
     @given(N=st.integers(1, 10), M=st.integers(1, 10), in_place=st.booleans(),
            **hu.gcs)
@@ -57,9 +57,9 @@ class TestActivations(serial.SerializedTestCase):
 
         X = np.random.randn(0, N, M).astype(np.float32)
 
-        self.assertReferenceChecks(gc, op, [X], relu_ref)
+        self.assertReferenceChecks(gc, op, [X], relu_ref, ensure_outputs_are_inferred=True)
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertGradientChecks(gc, op, [X], 0, [0], ensure_outputs_are_inferred=True)
 
     @unittest.skipIf(not workspace.has_gpu_support,
                      "Relu for float16 can only run on GPU now.")
@@ -119,9 +119,10 @@ class TestActivations(serial.SerializedTestCase):
         X[X == 0.0] -= 0.02
         X += n
 
-        self.assertReferenceChecks(gc, op, [X], relu_n_ref)
+        self.assertReferenceChecks(gc, op, [X], relu_n_ref, ensure_outputs_are_inferred=True)
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0], stepsize=0.005)
+        self.assertGradientChecks(gc, op, [X], 0, [0], stepsize=0.005,
+                                  ensure_outputs_are_inferred=True)
 
     @serial.given(X=hu.tensor(),
                   alpha=st.floats(min_value=0.1, max_value=2.0),
@@ -145,9 +146,9 @@ class TestActivations(serial.SerializedTestCase):
         X += 0.04 * np.sign(X)
         X[X == 0.0] += 0.04
 
-        self.assertReferenceChecks(gc, op, [X], elu_ref)
+        self.assertReferenceChecks(gc, op, [X], elu_ref, ensure_outputs_are_inferred=True)
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0], stepsize=1e-2)
+        self.assertGradientChecks(gc, op, [X], 0, [0], stepsize=1e-2, ensure_outputs_are_inferred=True)
 
     @given(X=hu.tensor(min_dim=4, max_dim=4),
            alpha=st.floats(min_value=0.1, max_value=2.0),
@@ -182,15 +183,15 @@ class TestActivations(serial.SerializedTestCase):
         op = core.CreateOperator(
             "PRelu", ["X", "W"], ["Y" if not inplace else "X"],
             alpha=alpha, order=order)
-        self.assertReferenceChecks(gc, op, [X, W], prelu_ref)
+        self.assertReferenceChecks(gc, op, [X, W], prelu_ref, ensure_outputs_are_inferred=True)
         # Check over multiple devices
         self.assertDeviceChecks(dc, op, [X, W], [0])
 
         if not inplace:
             # Gradient check wrt X
-            self.assertGradientChecks(gc, op, [X, W], 0, [0], stepsize=1e-2)
+            self.assertGradientChecks(gc, op, [X, W], 0, [0], stepsize=1e-2, ensure_outputs_are_inferred=True)
             # Gradient check wrt W
-            self.assertGradientChecks(gc, op, [X, W], 1, [0], stepsize=1e-2)
+            self.assertGradientChecks(gc, op, [X, W], 1, [0], stepsize=1e-2, ensure_outputs_are_inferred=True)
 
     @serial.given(X=hu.tensor(),
                   alpha=st.floats(min_value=0.1, max_value=2.0),
@@ -211,7 +212,8 @@ class TestActivations(serial.SerializedTestCase):
             "LeakyRelu",
             ["X"], ["Y" if not inplace else "X"],
             alpha=alpha)
-        self.assertReferenceChecks(gc, op, [X], leaky_relu_ref)
+        self.assertReferenceChecks(gc, op, [X], leaky_relu_ref,
+                                   ensure_outputs_are_inferred=True)
         # Check over multiple devices
         self.assertDeviceChecks(dc, op, [X], [0])
 
@@ -251,9 +253,11 @@ class TestActivations(serial.SerializedTestCase):
             return (X * norm.cdf(X),)
 
         tol = 1e-3 if fast_gelu else 1e-4
-        self.assertReferenceChecks(gc, op, [X], gelu_ref, threshold=tol)
+        self.assertReferenceChecks(gc, op, [X], gelu_ref, threshold=tol,
+                                   ensure_outputs_are_inferred=True)
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertGradientChecks(gc, op, [X], 0, [0],
+                                  ensure_outputs_are_inferred=True)
 
 
 if __name__ == "__main__":

--- a/caffe2/python/operator_test/concat_split_op_test.py
+++ b/caffe2/python/operator_test/concat_split_op_test.py
@@ -62,10 +62,14 @@ class TestConcatSplitOps(serial.SerializedTestCase):
             gc, op, splits, lambda *splits: (
                 np.concatenate(splits, axis=axis),
                 np.array([a.shape[axis] for a in splits])
-            )
+            ),
+            ensure_outputs_are_inferred=True,
         )
         self.assertDeviceChecks(dc, op, splits, [0, 1])
-        self.assertGradientChecks(gc, op, splits, 0, [0])
+        self.assertGradientChecks(
+            gc, op, splits, 0, [0],
+            ensure_outputs_are_inferred=True,
+        )
 
     @given(tensor_splits=_tensor_splits(add_axis=True),
            **hu.gcs)
@@ -87,11 +91,15 @@ class TestConcatSplitOps(serial.SerializedTestCase):
                     axis=axis
                 ),
                 np.array([1] * len(splits))
-            )
+            ),
+            ensure_outputs_are_inferred=True,
         )
         self.assertDeviceChecks(dc, op, splits, [0, 1])
         for i in range(len(splits)):
-            self.assertGradientChecks(gc, op, splits, i, [0])
+            self.assertGradientChecks(
+                gc, op, splits, i, [0],
+                ensure_outputs_are_inferred=True,
+            )
 
     @serial.given(tensor_splits=_tensor_splits(),
            split_as_arg=st.booleans(),
@@ -124,9 +132,15 @@ class TestConcatSplitOps(serial.SerializedTestCase):
                 for i in range(len(split))
             ]
         outputs_with_grad = range(len(split_info))
-        self.assertReferenceChecks(gc, op, input_tensors, split_ref, ensure_outputs_are_inferred=True)
+        self.assertReferenceChecks(
+            gc, op, input_tensors, split_ref,
+            ensure_outputs_are_inferred=True,
+        )
         self.assertDeviceChecks(dc, op, input_tensors, outputs_with_grad)
-        self.assertGradientChecks(gc, op, input_tensors, 0, outputs_with_grad)
+        self.assertGradientChecks(
+            gc, op, input_tensors, 0, outputs_with_grad,
+            ensure_outputs_are_inferred=True,
+        )
 
     @serial.given(
         inputs=hu.lengths_tensor(

--- a/caffe2/python/operator_test/elementwise_ops_test.py
+++ b/caffe2/python/operator_test/elementwise_ops_test.py
@@ -33,7 +33,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             ensure_outputs_are_inferred=True,
         )
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertGradientChecks(gc, op, [X], 0, [0], ensure_outputs_are_inferred=True)
 
     @given(X=hu.tensor(dtype=np.float32), inplace=st.booleans(), **hu.gcs)
     def test_exp(self, X, inplace, gc, dc):
@@ -54,7 +54,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             ensure_outputs_are_inferred=True,
         )
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertGradientChecks(gc, op, [X], 0, [0], ensure_outputs_are_inferred=True)
 
     @given(n=st.integers(0, 6), m=st.integers(4, 6),
            seed=st.integers(0, 1000), **hu.gcs)
@@ -80,7 +80,8 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         )
 
         self.assertGradientChecks(
-            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2)
+            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2,
+            ensure_outputs_are_inferred=True)
 
     @given(n=st.integers(0, 10), m=st.integers(4, 6),
            d=st.integers(2, 3), seed=st.integers(0, 1000), **hu.gcs)
@@ -136,7 +137,8 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         )
 
         self.assertGradientChecks(
-            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2)
+            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2,
+            ensure_outputs_are_inferred=True)
 
     @given(
         X=hu.tensor(
@@ -167,7 +169,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         # stepsize need to be smaller than the possible minimum X, so the
         # sqrt is well defined
         self.assertGradientChecks(
-            gc, op, [X], 0, [0], stepsize=1e-2)
+            gc, op, [X], 0, [0], stepsize=1e-2, ensure_outputs_are_inferred=True)
 
     @given(X=hu.tensor(dtype=np.float32), inplace=st.booleans(), **hu.gcs)
     def test_softsign(self, X, inplace, gc, dc):
@@ -189,7 +191,10 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         )
         self.assertDeviceChecks(dc, op, [X], [0])
         if not inplace:
-            self.assertGradientChecks(gc, op, [X], 0, [0])
+            self.assertGradientChecks(
+                gc, op, [X], 0, [0],
+                ensure_outputs_are_inferred=True,
+            )
 
     @given(X=hu.tensor(elements=st.floats(0.1, 10.0), dtype=np.float32),
            inplace=st.booleans(), **hu.gcs)
@@ -211,7 +216,10 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             ensure_outputs_are_inferred=True,
         )
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0], stepsize=5e-3)
+        self.assertGradientChecks(
+            gc, op, [X], 0, [0], stepsize=5e-3,
+            ensure_outputs_are_inferred=True,
+        )
 
     @given(X=hu.tensor(dtype=np.float32), **hu.gcs)
     def test_cube(self, X, gc, dc):
@@ -268,8 +276,14 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             ["X"] if in_place else ["Y"],
         )
 
-        self.assertGradientChecks(gc, op, [X], 0, [0])
-        self.assertGradientChecks(gc, op, [-X], 0, [0])
+        self.assertGradientChecks(
+            gc, op, [X], 0, [0],
+            ensure_outputs_are_inferred=True,
+        )
+        self.assertGradientChecks(
+            gc, op, [-X], 0, [0],
+            ensure_outputs_are_inferred=True,
+        )
 
     @given(n=st.integers(0, 6), m=st.integers(4, 6),
            seed=st.integers(0, 1000), **hu.gcs)
@@ -295,7 +309,8 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         )
 
         self.assertGradientChecks(
-            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2)
+            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2,
+            ensure_outputs_are_inferred=True)
 
     @given(n=st.integers(0, 6), m=st.integers(4, 6),
            seed=st.integers(0, 1000), **hu.gcs)
@@ -345,7 +360,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             ensure_outputs_are_inferred=True,
         )
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertGradientChecks(gc, op, [X], 0, [0], ensure_outputs_are_inferred=True)
 
     @given(X=hu.tensor(dtype=np.float32),
            inplace=st.booleans(),
@@ -386,7 +401,8 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         )
         self.assertDeviceChecks(dc, op, [X], [0])
         self.assertGradientChecks(
-            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2)
+            gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2,
+            ensure_outputs_are_inferred=True)
 
     @given(n=st.integers(0, 6), m=st.integers(4, 6), **hu.gcs)
     def test_eq(self, n, m, gc, dc):
@@ -466,7 +482,10 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         self.assertDeviceChecks(dc, op, inputs, [0])
         if test_grad:
             for i in range(len(inputs)):
-                self.assertGradientChecks(gc, op, inputs, i, [0])
+                self.assertGradientChecks(
+                    gc, op, inputs, i, [0],
+                    ensure_outputs_are_inferred=True,
+                )
 
         if reverse_inputs:
             inputs = [B, A]
@@ -480,7 +499,10 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             self.assertDeviceChecks(dc, op, inputs, [0])
             if test_grad:
                 for i in range(len(inputs)):
-                    self.assertGradientChecks(gc, op, inputs, i, [0])
+                    self.assertGradientChecks(
+                        gc, op, inputs, i, [0],
+                        ensure_outputs_are_inferred=True,
+                    )
 
     def _test_binary_op(
             self, op_name, np_ref, n, m, k, t, bias, test_grad, gc, dc):
@@ -688,7 +710,8 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         )
         self.assertDeviceChecks(dc, op, [X], [0])
         self.assertGradientChecks(
-            gc, op, [X], 0, [0], stepsize=1e-3, threshold=0.05)
+            gc, op, [X], 0, [0], stepsize=1e-3, threshold=0.05,
+            ensure_outputs_are_inferred=True)
 
     @given(X=hu.tensor(dtype=np.bool), **hu.gcs)
     def test_not(self, X, gc, dc):
@@ -712,5 +735,4 @@ class TestElementwiseOps(hu.HypothesisTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     unittest.main()

--- a/caffe2/python/operator_test/hyperbolic_ops_test.py
+++ b/caffe2/python/operator_test/hyperbolic_ops_test.py
@@ -27,9 +27,10 @@ class TestHyperbolicOps(serial.SerializedTestCase):
             op=op,
             inputs=[X],
             reference=ref,
+            ensure_outputs_are_inferred=True,
         )
         self.assertDeviceChecks(dc, op, [X], [0])
-        self.assertGradientChecks(gc, op, [X], 0, [0])
+        self.assertGradientChecks(gc, op, [X], 0, [0], ensure_outputs_are_inferred=True)
 
     @serial.given(X=hu.tensor(dtype=np.float32), **hu.gcs)
     def test_sinh(self, X, gc, dc):


### PR DESCRIPTION
Summary:
This fixes a lot of common ops for InferBlobShapesAndTypes as well as adds support for testing the inferred shapes and types of gradient ops.

Ops:
* Concat
* Split
* LeakyReLU
* Relu
* Prelu
* Gelu
* Elu
* Sinh, Tanh, Cosh
* Abs
* ... and a number of other simple element wise ops

Test Plan:
Added support to hypothesis test to check the shape and type of gradient ops.

Enabled it for all the ops I fixed the shape and type inference for.

  buck test caffe2/caffe2/python/operator_test:

Differential Revision: D20806284

