### PR TITLE
[WIP] Inconsistency between torch.abs() and np.absolute() for complex tensors

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -18,6 +18,10 @@
 // linear algebra function uses that routine
 #ifdef USE_LAPACK
 
+// gels
+extern "C" void dgels_(char *trans, int *m, int *n, int *nrhs, double *a, int *lda, double *b, int *ldb, double *work, int *lwork, int *info);
+extern "C" void sgels_(char *trans, int *m, int *n, int *nrhs, float *a, int *lda, float *b, int *ldb, float *work, int *lwork, int *info);
+
 // gesv
 extern "C" void zgesv_(int *n, int *nrhs, std::complex<double> *a, int *lda, int *ipiv, std::complex<double> *b, int *ldb, int *info);
 extern "C" void cgesv_(int *n, int *nrhs, std::complex<float> *a, int *lda, int *ipiv, std::complex<float> *b, int *ldb, int *info);
@@ -1145,7 +1149,11 @@ Tensor& lu_solve_out(Tensor& result, const Tensor& self, const Tensor& LU_data, 
 
 std::tuple<Tensor, Tensor> lstsq(const Tensor& B, const Tensor& A) {
   std::cout << "Andrzej" << std::endl;
-  return std::tuple<Tensor, Tensor>();
+  auto B_working = B.clone();
+  auto A_working = A.clone();
+  
+  // std::cout << sgels_ << std::endl;
+  return std::tuple<Tensor, Tensor>(B_working, A_working);
 }
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -415,7 +415,7 @@ static void apply_lstsq(Tensor& B, Tensor& A) {
 }
 
 std::tuple<Tensor, Tensor> lstsq(const Tensor& B, const Tensor& A) {
-  TORCH_CHECK(A.dim() == 1 || A.dim() == 2, "A should have 1 or 2 "
+  TORCH_CHECK(A.dim() == 2, "A should have 1 or 2 "
       "dimensions, but has ", A.dim());
   TORCH_CHECK(B.dim() == 1 || B.dim() == 2, "B should have 1 or 2 "
       "dimensions, but has ", B.dim());

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -415,6 +415,12 @@ static void apply_lstsq(Tensor& B, Tensor& A) {
 }
 
 std::tuple<Tensor, Tensor> lstsq(const Tensor& B, const Tensor& A) {
+  TORCH_CHECK(A.dim() == 1 || A.dim() == 2, "A should have 1 or 2 "
+      "dimensions, but has ", A.dim());
+  TORCH_CHECK(B.dim() == 1 || B.dim() == 2, "B should have 1 or 2 "
+      "dimensions, but has ", B.dim());
+  TORCH_CHECK(A.size(0) == B.size(0), "Expected A and B to have same size "
+      "at dim 0, but A has ", A.size(0), " rows and B has ", B.size(0), " rows");
   // lapackGels is working on column major matrixes
   // Tensors are row major by default
   Tensor B_working = B.clone().t().contiguous().t();

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -421,6 +421,11 @@ std::tuple<Tensor, Tensor> lstsq(const Tensor& B, const Tensor& A) {
       "dimensions, but has ", B.dim());
   TORCH_CHECK(A.size(0) == B.size(0), "Expected A and B to have same size "
       "at dim 0, but A has ", A.size(0), " rows and B has ", B.size(0), " rows");
+
+  
+  if(B.dim() == 1) {
+    B.unsqueeze_(1);
+  }
   // lapackGels is working on column major matrixes
   // Tensors are row major by default
   Tensor B_working = B.clone().t().contiguous().t();

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <ATen/ATen.h>
 #include <ATen/CPUApplyUtils.h>
 #include <ATen/Dispatch.h>
@@ -1140,6 +1141,11 @@ Tensor& lu_solve_out(Tensor& result, const Tensor& self, const Tensor& LU_data, 
   Tensor result_tmp = at::lu_solve(self, LU_data, LU_pivots);
   result.resize_as_(result_tmp).copy_(result_tmp);
   return result;
+}
+
+std::tuple<Tensor, Tensor> lstsq(const Tensor& B, const Tensor& A) {
+  std::cout << "Andrzej" << std::endl;
+  return std::tuple<Tensor, Tensor>();
 }
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4960,7 +4960,7 @@
   use_c10_dispatcher: full
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_gels
+    CPU: lstsq
     CUDA: legacy::cuda::_th_gels
 
 - func: triangular_solve.X(Tensor self, Tensor A, bool upper=True, bool transpose=False, bool unitriangular=False, *, Tensor(a!) X, Tensor(b!) M) -> (Tensor(a!) solution, Tensor(b!) cloned_coefficient)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -104,24 +104,24 @@ factory_data_common_args = parse_kwargs("""
         the pinned memory. Works only for CPU tensors. Default: ``False``.
 """)
 
-add_docstr(torch.abs,
-           r"""
-abs(input, out=None) -> Tensor
+# add_docstr(torch.abs,
+#            r"""
+# abs(input, out=None) -> Tensor
 
-Computes the element-wise absolute value of the given :attr:`input` tensor.
+# Computes the element-wise absolute value of the given :attr:`input` tensor.
 
-.. math::
-    \text{out}_{i} = |\text{input}_{i}|
-""" + r"""
-Args:
-    {input}
-    {out}
+# .. math::
+#     \text{out}_{i} = |\text{input}_{i}|
+# """ + r"""
+# Args:
+#     {input}
+#     {out}
 
-Example::
+# Example::
 
-    >>> torch.abs(torch.tensor([-1, -2, 3]))
-    tensor([ 1,  2,  3])
-""".format(**common_args))
+#     >>> torch.abs(torch.tensor([-1, -2, 3]))
+#     tensor([ 1,  2,  3])
+# """.format(**common_args))
 
 add_docstr(torch.absolute,
            r"""

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -11,6 +11,7 @@ Tensor = torch.Tensor
 from torch import _VF
 
 __all__ = [
+    'abs',
     'align_tensors',
     'broadcast_tensors',
     'cartesian_prod',
@@ -32,6 +33,30 @@ __all__ = [
     'unique_consecutive',
 ]
 
+def abs(tensor):
+    r"""abs(input, out=None) -> Tensor
+    
+    Computes the element-wise absolute value of the given :attr:`input` tensor.
+    
+    .. math::
+        \text{out}_{i} = |\text{input}_{i}|
+    
+    Args:
+        input (Tensor): the input tensor.
+        out (Tensor, optional): the output tensor.
+    
+    Example::
+    
+        >>> torch.abs(torch.tensor([-1, -2, 3]))
+        tensor([ 1,  2,  3])
+    """
+    result = _VF.abs(tensor)
+    my_dtype = tensor.dtype
+    if my_dtype == torch.complex128:
+        return result.double()
+    elif my_dtype == torch.complex64:
+        return result.float()
+    return result
 
 def broadcast_tensors(*tensors):
     r"""broadcast_tensors(*tensors) -> List of Tensors

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -436,7 +436,24 @@ class Tensor(torch._C._TensorBase):
     __le__ = _wrap_type_error_to_not_implemented(_C._TensorBase.le)
     __gt__ = _wrap_type_error_to_not_implemented(_C._TensorBase.gt)
     __ge__ = _wrap_type_error_to_not_implemented(_C._TensorBase.ge)
-    __abs__ = _C._TensorBase.abs
+
+    def abs(self):
+        r"""Computes the element-wise absolute value of the given :attr:`input` tensor.
+
+        See :func:`torch.abs`
+        """
+        return torch.abs(self)
+    
+    def abs_(self):
+        r"""Computes the element-wise absolute value of the given :attr:`input` tensor.
+        and makes an in-place save.
+
+        See :func:`torch.abs`
+        """
+        # Needs to be finished
+        return abs(self)
+
+    __abs__ = abs
 
     def __len__(self):
         if self.dim() == 0:


### PR DESCRIPTION
@anjali411 Would You mind looking at this potential solution? It seems to be working when I play with it python IDE. I made the torch.abs() function to be kind of like a decorator of it’s c++ version.  Speedwise it shouldn’t be a big difference since it’s just casting to a double/float tensor, which has to be done anyway. Either on c++ or python level. I think the castings are written in c++ anyway. 

I couldn’t figure out how to make in-place change to the tensor. That is, how to implement tensor.abs_() having tensor.abs(). 
I am also not sure if this solution will work for TorchScript programs. Haven't read about them enough yet.
I will later add tests and delete unnecessary comments.

Issue: #33567