### PR TITLE
Removes integer division call sites

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -198,7 +198,7 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
       using device_ptr = thrust::device_ptr<int64_t>;
       const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-      linearIndex.div_(sliceSize);
+      linearIndex.floor_divide_(sliceSize);
       {
       sorted_indices.copy_(linearIndex);
       auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -138,7 +138,7 @@ SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
       // broadcasting logic; instead, it will blast the elements from one
       // to the other so long as the numel is the same
       indicesSlice.copy_(indices1D);
-      indices1D.div_(self.size(d));
+      indices1D.floor_divide_(self.size(d));
       indicesSlice.add_(indices1D, -self.size(d));
     }
   }

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -56,7 +56,7 @@ def assert_allclose(actual, expected, rtol=None, atol=None, equal_nan=True):
 
     raise AssertionError(msg.format(
         rtol, atol, list(index), actual[index].item(), expected[index].item(),
-        count - 1, 100 * count / actual.numel()))
+        count - 1, 100. * count / actual.numel()))
 
 def make_non_contiguous(tensor):
     if tensor.numel() <= 1:  # can't make non-contiguous


### PR DESCRIPTION
Per title. Tests of integer division are unchanged.

The intent of this PR is to eliminate warning noise as users see our integer div deprecation warning and try to update their programs to be conformant. In particular, some CUDA indexing operations could perform a deprecated integer division, possibly confusing users. 