### PR TITLE
[TensorExpr] add support for Reduction Ops

### DIFF
--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -1,0 +1,538 @@
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+#include "test/cpp/tensorexpr/test_base.h"
+
+#include "test/cpp/tensorexpr/padded_buffer.h"
+#include "torch/csrc/jit/tensorexpr/buffer.h"
+#include "torch/csrc/jit/tensorexpr/eval.h"
+#include "torch/csrc/jit/tensorexpr/function.h"
+#include "torch/csrc/jit/tensorexpr/ir.h"
+#include "torch/csrc/jit/tensorexpr/ir_printer.h"
+#include "torch/csrc/jit/tensorexpr/ir_simplifier.h"
+#include "torch/csrc/jit/tensorexpr/loopnest.h"
+#include "torch/csrc/jit/tensorexpr/tensor.h"
+
+namespace torch {
+namespace jit {
+
+using namespace torch::jit::tensorexpr;
+
+// Sum an array to a single value.
+void testReduceSum1D() {
+  KernelScope kernel_scope;
+
+  Buffer b(BufHandle("b", {10}), kFloat);
+  std::vector<float> in(10);
+  for (int j = 0; j < 10; ++j) {
+    in[j] = j;
+  }
+
+  std::vector<float> out(1, -1.f);
+
+  Tensor* c = Reduce("sum", {}, Sum(), b, {{10, "m"}});
+  LoopNest loop({c});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {b, c});
+
+  cg.call({in, out});
+  ASSERT_EQ(out[0], 45);
+}
+// Sum a 2D tensor to a 1D tensor with dynamic shapes.
+void testReduceSum2D() {
+  KernelScope kernel_scope;
+
+  const int M = 3;
+  const int N = 7;
+
+  VarHandle m("m", kInt);
+  VarHandle n("n", kInt);
+
+  Buffer b(BufHandle("b", {m, n}), kFloat);
+  std::vector<float> in(M * N);
+  for (int i = 0; i < M; ++i) {
+    for (int j = 0; j < N; ++j) {
+      in[i * N + j] = j;
+    }
+  }
+
+  std::vector<float> out(M, -1.f);
+
+  Tensor* c = Reduce("sum", {{M, "m"}}, Sum(), b, {{N, "n"}});
+  LoopNest loop({c});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {b, c, n, m});
+
+  cg.call({in, out, 5, 7});
+
+  float expected = 0;
+  for (int i = 0; i < N; ++i) {
+    expected += i;
+  }
+
+  for (int i = 0; i < M; ++i) {
+    ASSERT_EQ(out[i], expected);
+  }
+}
+
+// Sum a 3D tensor to both a 2D and 1D tensor, then reduce the 2D tensor flat to
+// check our work.
+void testReduceSum3D() {
+  KernelScope kernel_scope;
+
+  const int M = 10;
+  VarHandle m("m", kInt);
+
+  Buffer b(BufHandle("b", {2, 3, m}), kFloat);
+
+  Tensor* c = Reduce("sum", {{2, "l"}, {3, "n"}}, Sum(), b, {{m, "m"}});
+  LoopNest loop({c});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {b, c, m});
+
+  std::vector<float> bData(2 * 3 * M, 0);
+  std::vector<float> cData(2 * 3, 6.0f);
+  std::vector<float> dData(2, 1.0f);
+  std::vector<float> eData(2, 1.0f);
+
+  for (int i = 0; i < 2 * 3; ++i) {
+    for (int j = 0; j < M; ++j) {
+      bData[i * M + j] = j;
+    }
+  }
+
+  cg.call({bData, cData, M});
+  float expected = 0;
+  for (int i = 0; i < M; ++i) {
+    expected += i;
+  }
+
+  for (int i = 0; i < 2 * 3; ++i) {
+    ASSERT_EQ(cData[i], expected);
+  }
+
+  Tensor* d = Reduce("sum2", {{2, "l"}}, Sum(), b, {{3, "n"}, {m, "m"}});
+  LoopNest loop2({d});
+  loop2.prepareForCodegen();
+  Stmt* s2 = loop2.root_stmt();
+  s2 = IRSimplifier::simplify(s2);
+
+  SimpleIREvaluator cg2(s2, {b, d, m});
+  cg2.call({bData, dData, M});
+
+  // We're combining an additional dimension of 3, so the sum is 3x.
+  expected = expected * 3;
+
+  for (int i = 0; i < 2; ++i) {
+    ASSERT_EQ(dData[i], expected);
+  }
+
+  // This is the same as just reducing the original result across that axis.
+  Buffer c_buf(BufHandle(c->func_var()), kFloat);
+  Tensor* e = Reduce("sum3", {{2, "l"}}, Sum(), c_buf, {{3, "m"}});
+  LoopNest loop3({e});
+  loop3.prepareForCodegen();
+  Stmt* s3 = loop3.root_stmt();
+  s3 = IRSimplifier::simplify(s3);
+
+  SimpleIREvaluator cg3(s3, {c, e});
+  cg3.call({cData, eData});
+
+  for (int i = 0; i < 2; ++i) {
+    ASSERT_EQ(eData[i], expected);
+  }
+}
+
+// Sum a large (10 D) Tensor 5 dimensions in.
+void testReduceSum10D() {
+  KernelScope kernel_scope;
+
+  Buffer in_(BufHandle("in_", {2, 3, 2, 3, 2, 3, 2, 3, 2, 3}), kFloat);
+  const int InputSize = 2 * 3 * 2 * 3 * 2 * 3 * 2 * 3 * 2 * 3;
+  Buffer out_(BufHandle("out_", {2, 3, 2, 3, 2}), kFloat);
+  const int OutputSize = 2 * 3 * 2 * 3 * 2;
+
+  std::vector<float> in(InputSize, 1.f);
+  std::vector<float> out(OutputSize, -1.f);
+
+  Tensor* c = Reduce(
+      "sum",
+      {{2, "a"}, {3, "b"}, {2, "c"}, {3, "d"}, {2, "e"}},
+      Sum(),
+      in_,
+      {{3, "f"}, {2, "g"}, {3, "h"}, {2, "i"}, {3, "j"}});
+  LoopNest loop({c});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {in_, c});
+
+  cg.call({in, out});
+
+  float expected = InputSize / OutputSize;
+  for (int i = 0; i < OutputSize; ++i) {
+    ASSERT_EQ(out[i], expected);
+  }
+}
+
+// Reduce via Mul rather than Add using a custom Reducer.
+void testReduceProduct() {
+  KernelScope kernel_scope;
+
+  const int M = 4;
+  const int N = 4;
+
+  Buffer b(BufHandle("b", {M, N}), kFloat);
+  std::vector<float> in(M * N);
+  for (int i = 0; i < M; ++i) {
+    for (int j = 0; j < N; ++j) {
+      in[i * N + j] = 2 + j;
+    }
+  }
+
+  std::vector<float> out(M, -1.f);
+
+  Reducer product(
+      ExprHandle(1.f), [](ExprHandle a, ExprHandle b) { return a * b; });
+
+  Tensor* c = Reduce("product", {{M, "m"}}, product, b, {{N, "n"}});
+  LoopNest loop({c});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {b, c});
+
+  cg.call({in, out});
+
+  float expected = 1;
+  for (int i = 0; i < N; ++i) {
+    expected *= 2 + i;
+  }
+
+  for (int i = 0; i < M; ++i) {
+    ASSERT_EQ(out[i], expected);
+  }
+}
+
+// Maximum reductions.
+void testReduceMax() {
+  KernelScope kernel_scope;
+
+  Buffer in_(BufHandle("b", {10}), kFloat);
+
+  std::vector<float> in(10);
+  std::vector<float> out(1, -1.f);
+  for (int j = 0; j < 10; ++j) {
+    in[j] = j;
+  }
+
+  Tensor* dm1 = Reduce("max", {}, Maximum(kFloat), in_, {{10, "m"}});
+
+  LoopNest loop({dm1});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+  SimpleIREvaluator cg(s, {in_, dm1});
+
+  cg.call({in, out});
+
+  ASSERT_EQ(out[0], 9);
+
+  Buffer in2_(BufHandle("b", {2, 5}), kFloat);
+  std::vector<float> out2(2, -1.f);
+
+  Tensor* m2d = Reduce("max", {{2, "n"}}, Maximum(kFloat), in2_, {{5, "m"}});
+
+  loop = LoopNest({m2d});
+  loop.prepareForCodegen();
+  s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg2(s, {in2_, m2d});
+  cg2.call({in, out2});
+
+  ASSERT_EQ(out2[0], 4);
+  ASSERT_EQ(out2[1], 9);
+}
+
+// Minimum reduction, with custom initialization.
+void testReduceMinCustomInitializer() {
+  KernelScope kernel_scope;
+
+  VarHandle minInit("minInit", kFloat);
+  Buffer in_(BufHandle("b", {10}), kFloat);
+
+  std::vector<float> in(10);
+  std::vector<float> out(1, -1.f);
+  for (int j = 0; j < 10; ++j) {
+    in[j] = 10 + j;
+  }
+
+  Tensor* min = Reduce(
+      "min",
+      {},
+      Minimum(ExprHandle(minInit)),
+      [&](ParameterList& v) { return in_.call(v); },
+      {{10, "m"}});
+
+  LoopNest loop({min});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {in_, min, minInit});
+
+  // Works normally (note that out data starts lower than the correct
+  // minimum).
+  cg.call({in, out, std::numeric_limits<float>::max()});
+  ASSERT_EQ(out[0], 10);
+
+  // With an initalizer lower than the min, that's the min.
+  cg.call({in, out, 5.f});
+  ASSERT_EQ(out[0], 5);
+}
+
+// Example implementation of Any/All.
+// TODO: this is very awkward without logical And/Or operators.
+void testReduceAnyAll() {
+  KernelScope kernel_scope;
+
+  VarHandle searchValue("searchValue", kInt);
+  Buffer b(BufHandle("b", {4, 10}), kInt);
+
+  Reducer anyEqSV(ExprHandle(0), [](ExprHandle a, ExprHandle b) {
+    return CompareSelect::make(a, 1, 1, b, kEQ);
+  });
+
+  Tensor* any = Reduce(
+      "anyEqual",
+      {{4, "i"}},
+      anyEqSV,
+      [&](const auto& i, const auto& j) {
+        return CompareSelect::make(b(i, j), searchValue, kEQ);
+      },
+      {{10, "j"}});
+
+  LoopNest loop({any});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {b, any, searchValue});
+
+  std::vector<int> in(40, 0);
+  std::vector<int> out(4, 0);
+
+  // input has 0-39 in 4 rows.
+  for (int i = 0; i < 40; ++i) {
+    in[i] = i;
+  }
+  cg.call({in, out, 1});
+
+  // only the first row has 1
+  ASSERT_EQ(out[0], 1);
+  ASSERT_EQ(out[1], 0);
+  ASSERT_EQ(out[2], 0);
+  ASSERT_EQ(out[3], 0);
+
+  cg.call({in, out, 15});
+
+  // 15 in the 3rd row
+  ASSERT_EQ(out[0], 0);
+  ASSERT_EQ(out[1], 1);
+  ASSERT_EQ(out[2], 0);
+  ASSERT_EQ(out[3], 0);
+
+  Reducer allGTSV(ExprHandle(1), [](ExprHandle a, ExprHandle b) {
+    return CompareSelect::make(a, 0, 0, b, kEQ);
+  });
+
+  Tensor* allGreaterThan = Reduce(
+      "allGreaterThan",
+      {{4, "i"}},
+      allGTSV,
+      [&](const auto& i, const auto& j) {
+        return CompareSelect::make(b(i, j), searchValue, kGT);
+      },
+      {{10, "j"}});
+
+  loop = LoopNest({allGreaterThan});
+  loop.prepareForCodegen();
+  s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg2(s, {b, allGreaterThan, searchValue});
+
+  cg2.call({in, out, 11});
+
+  // 11 is in row 2.
+  ASSERT_EQ(out[0], 0);
+  ASSERT_EQ(out[1], 0);
+  ASSERT_EQ(out[2], 1);
+  ASSERT_EQ(out[3], 1);
+
+  cg2.call({in, out, -3});
+
+  // All are positive.
+  ASSERT_EQ(out[0], 1);
+  ASSERT_EQ(out[1], 1);
+  ASSERT_EQ(out[2], 1);
+  ASSERT_EQ(out[3], 1);
+}
+
+void testReduceMatmul2D() {
+  KernelScope kernel_scope;
+
+  Buffer tA(BufHandle("tA", {3, 2}), kFloat);
+  Buffer tB(BufHandle("tB", {2, 3}), kFloat);
+
+  std::vector<float> tA_(6);
+  std::vector<float> tB_(6);
+
+  std::vector<float> out(9, -1.f);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      tA_[i * 2 + j] = i * 2 + j;
+      tB_[j * 3 + i] = i * 2 + j;
+    }
+  }
+
+  Tensor* mm = Reduce(
+      "mm",
+      {{3, "m"}, {3, "n"}},
+      Sum(),
+      [&](const ExprHandle& m, const ExprHandle& n, const ExprHandle& k) {
+        return tA(m, k) * tB(k, n);
+      },
+      {{2, "k"}});
+
+  LoopNest loop({mm});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {tA, tB, mm});
+  cg.call({tA_, tB_, out});
+
+  std::vector<float> expected(
+      {1.f, 3.f, 5.f, 3.f, 13.f, 23.f, 5.f, 23.f, 41.f});
+
+  for (int i = 0; i < 9; ++i) {
+    ASSERT_EQ(out[i], expected[i]);
+  }
+}
+
+void testReduceRfactorLike() {
+  KernelScope kernel_scope;
+
+  Buffer in(BufHandle("in", {10, 10}), kFloat);
+  std::vector<float> in_(100);
+  for (int i = 0; i < 100; ++i) {
+    in_[i] = i;
+  }
+  std::vector<float> in_rf_(10, -2.f);
+  std::vector<float> out(1, -1.f);
+
+  Tensor* l1 = Reduce("l1", {{10, "i"}}, Sum(), in, {{10, "j"}});
+  Buffer in_rf(BufHandle(l1->func_var()), kFloat);
+
+  Tensor* l2 = Reduce("l2", {}, Sum(), in_rf, {{10, "i"}});
+
+  LoopNest loop({l1, l2});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {in, l1, l2});
+  cg.call({in_, in_rf_, out});
+
+  ASSERT_EQ(out[0], 99 * 50);
+}
+
+void testSplitReduceAxis() {
+  KernelScope kernel_scope;
+
+  Buffer in(BufHandle("in", {16, 8}), kFloat);
+
+  std::vector<float> in_(16 * 8);
+  for (int i = 0; i < 16; ++i) {
+    for (int j = 0; j < 8; ++j) {
+      in_[i * 8 + j] = i;
+    }
+  }
+  std::vector<float> out(16, -1.f);
+
+  Tensor* tensor = Reduce("sum", {{16, "m"}}, Sum(), in, {{8, "n"}});
+  LoopNest l({tensor});
+  For* x_outer;
+  For* x_inner;
+  For* x_tail;
+  std::vector<For*> loops = l.getLoopStmtsFor(tensor);
+  l.splitWithTail(loops[1], 2, &x_outer, &x_inner, &x_tail);
+
+  l.prepareForCodegen();
+
+  Stmt* s = l.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {in, tensor});
+  cg.call({in_, out});
+
+  for (int i = 0; i < 16; ++i) {
+    ASSERT_EQ(out[i], i * 8);
+  }
+}
+
+void testSplitNonReduceAxis() {
+  KernelScope kernel_scope;
+
+  Buffer in(BufHandle("in", {16, 8}), kFloat);
+
+  std::vector<float> in_(16 * 8);
+  for (int i = 0; i < 16; ++i) {
+    for (int j = 0; j < 8; ++j) {
+      in_[i * 8 + j] = i;
+    }
+  }
+  std::vector<float> out(16, -1.f);
+  Tensor* tensor = Reduce("sum", {{16, "m"}}, Sum(), in, {{8, "n"}});
+  LoopNest l({tensor});
+  For* x_outer;
+  For* x_inner;
+  For* x_tail;
+  std::vector<For*> loops = l.getLoopStmtsFor(tensor);
+  l.splitWithTail(loops[0], 2, &x_outer, &x_inner, &x_tail);
+
+  For* x_2;
+  For* x_1;
+  For* x_tail_2;
+  l.splitWithTail(x_outer, 2, &x_2, &x_1, &x_tail_2);
+
+  l.prepareForCodegen();
+
+  Stmt* s = l.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {in, tensor});
+  cg.call({in_, out});
+
+  for (int i = 0; i < 16; ++i) {
+    ASSERT_EQ(out[i], i * 8);
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -47,6 +47,18 @@ namespace jit {
   _(ScheduleFuserStyle)                   \
   _(ScheduleFuserThreeArg)                \
   _(ScheduleDynamicShape2D)               \
+  _(ReduceSum1D)                          \
+  _(ReduceSum2D)                          \
+  _(ReduceSum3D)                          \
+  _(ReduceSum10D)                         \
+  _(ReduceProduct)                        \
+  _(ReduceMax)                            \
+  _(ReduceMinCustomInitializer)           \
+  _(ReduceAnyAll)                         \
+  _(ReduceMatmul2D)                       \
+  _(ReduceRfactorLike)                    \
+  _(SplitReduceAxis)                      \
+  _(SplitNonReduceAxis)                   \
   _(TypeTest01)                           \
   _(TypePropagation)                      \
   _(Cond01)                               \

--- a/torch/csrc/jit/tensorexpr/dim_arg.h
+++ b/torch/csrc/jit/tensorexpr/dim_arg.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <torch/csrc/jit/tensorexpr/expr.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+// A helper structure to store the arguments to specify dimensions. In the
+// Compute arugments for dim_args, all of the following is supported. For
+// example:
+//    dim_args: {1, 2, 3, 4}
+//    dim_args: {{1, "x"}, {2, "y"}, {3, "z"}}
+//    dim_args: {1, 2, {3, "x"}}
+class DimArg {
+ public:
+  // Intentionally leave out explicit to allow implicit conversions.
+  DimArg(const ExprHandle& dim) : dim_(dim) {}
+  DimArg(const ExprHandle& dim, const std::string& name_hint)
+      : dim_(dim), name_hint_(name_hint) {}
+  const ExprHandle& dim() const {
+    return dim_;
+  }
+  const std::string& name_hint() const {
+    return name_hint_;
+  }
+
+ private:
+  ExprHandle dim_;
+  std::string name_hint_;
+};
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -17,6 +17,7 @@
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 #include <torch/csrc/jit/tensorexpr/types.h>
+#include <torch/csrc/jit/tensorexpr/var_substitutor.h>
 
 namespace torch {
 namespace jit {
@@ -818,33 +819,6 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
   std::unordered_map<const Var*, void*> buffer_mapping_;
   std::unordered_map<const Var*, std::unique_ptr<std::vector<int>>>
       internal_buffers_;
-};
-
-using VarMapping = std::vector<std::pair<const Var*, const Expr*>>;
-
-class VarSubMutator : public IRMutator {
- public:
-  VarSubMutator(const VarMapping& var_mapping) {
-    for (const auto& entry : var_mapping) {
-      const Var* key_var = entry.first;
-      const Expr* value = entry.second;
-      if (!key_var) {
-        throw malformed_input("missing key in VarSubMutator");
-      }
-      var_mapping_[key_var] = value;
-    }
-  }
-
-  const Expr* mutate(const Var* var) override {
-    auto iter = var_mapping_.find(var);
-    if (iter == var_mapping_.end()) {
-      return var;
-    }
-    return iter->second;
-  }
-
- private:
-  std::unordered_map<const Var*, const Expr*> var_mapping_;
 };
 
 template <class CodeGenType>

--- a/torch/csrc/jit/tensorexpr/function.h
+++ b/torch/csrc/jit/tensorexpr/function.h
@@ -20,6 +20,7 @@ class Function : public KernelScopedObject {
       // TODO: Function should not create buffers, they should be created
       // manually before constructing a function.
       : func_vars_({new Buf(new Var(func_name, kHandle), dims)}),
+        dims_(dims),
         args_(args),
         bodies_({body}) {}
   Function(
@@ -27,10 +28,35 @@ class Function : public KernelScopedObject {
       const std::vector<const Expr*>& dims,
       const std::vector<const Var*>& args,
       const std::vector<const Expr*>& bodies)
-      : func_vars_(func_names.size()), args_(args), bodies_(bodies) {
+      : func_vars_(func_names.size()),
+        dims_(dims),
+        args_(args),
+        bodies_(bodies) {
     for (size_t i = 0; i < func_names.size(); i++) {
       func_vars_[i] = new Buf(new Var(func_names[i], kHandle), dims);
     }
+  }
+  Function(
+      const std::string& func_name,
+      Buf* func_var,
+      const std::vector<const Expr*>& dims,
+      const std::vector<const Var*>& args,
+      const Expr* body)
+      : func_vars_({func_var}), dims_(dims), args_(args), bodies_({body}) {}
+
+  size_t ndim() const {
+    return dims_.size();
+  }
+
+  const Expr* dim(size_t index) const {
+    if (index < 0 || index >= dims_.size()) {
+      throw out_of_range_index();
+    }
+
+    return dims_[index];
+  }
+  const std::vector<const Expr*>& dims() const {
+    return dims_;
   }
 
   const Var* arg(size_t index) const {
@@ -69,6 +95,7 @@ class Function : public KernelScopedObject {
 
  private:
   std::vector<const Buf*> func_vars_;
+  std::vector<const Expr*> dims_;
   std::vector<const Var*> args_;
   std::vector<const Expr*> bodies_;
 };

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -12,7 +12,8 @@ static Dtype ChooseDtype(const Dtype& buffer_dtype, const Dtype& index_dtype) {
 
 static Dtype dtypeOfIndices(const std::vector<const Expr*>& indices) {
   if (!indices.size()) {
-    throw malformed_input("cant get dtype of empty indices");
+    // Return something so we can handle scalar buffers.
+    return kInt;
   }
   Dtype dt = indices.at(0)->dtype();
   for (size_t i = 1; i < indices.size(); ++i) {
@@ -25,7 +26,7 @@ static Dtype dtypeOfIndices(const std::vector<const Expr*>& indices) {
 
 static bool indicesValid(const std::vector<const Expr*>& indices) {
   if (indices.size() == 0) {
-    return false;
+    return true;
   }
   Dtype index_dtype = dtypeOfIndices(indices);
   if (indices.size() > 1 && index_dtype.lanes() > 1) {
@@ -58,6 +59,7 @@ Load::Load(
     throw malformed_input(
         "Load base handle dtype must be Handle", buf->base_handle());
   }
+
   if (!indicesValid(indices)) {
     throw malformed_input("invalid indices in Load");
   }

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/jit/tensorexpr/eval.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/reduction.h>
 
 namespace torch {
 namespace jit {
@@ -267,6 +268,19 @@ const Expr* IRMutator::mutate(const Polynomial* v) {
 const Expr* IRMutator::mutate(const RoundOff* v) {
   return new RoundOff(
       v->lhs()->accept_mutator(this), v->rhs()->accept_mutator(this));
+}
+
+const Expr* IRMutator::mutate(const ReduceOp* v) {
+  auto accum = v->accumulator().node()->accept_mutator(this);
+  Stmt* init = v->initializer()->accept_mutator(this);
+  auto body = v->body().node()->accept_mutator(this);
+
+  return new ReduceOp(
+      ExprHandle(accum),
+      init,
+      ExprHandle(body),
+      v->interaction(),
+      v->reduce_args());
 }
 
 const Expr* IRMutator::mutate(const BaseCallNode* v) {

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -49,6 +49,7 @@ class Stmt;
 class Term;
 class Polynomial;
 class RoundOff;
+class ReduceOp;
 
 class TORCH_API IRMutator {
  public:
@@ -93,6 +94,8 @@ class TORCH_API IRMutator {
   virtual const Expr* mutate(const Term* v);
   virtual const Expr* mutate(const Polynomial* v);
   virtual const Expr* mutate(const RoundOff* v);
+
+  virtual const Expr* mutate(const ReduceOp* v);
 
   virtual Stmt* mutate(const For* v);
   virtual Stmt* mutate(const Block* v);

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -51,6 +51,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const Term* v) override;
   void visit(const Polynomial* v) override;
   void visit(const RoundOff* v) override;
+  void visit(const ReduceOp* v) override;
 
   std::ostream& os() {
     return printer_os_;

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/reduction.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 
 namespace torch {
@@ -200,6 +201,12 @@ void IRVisitor::visit(const Polynomial* v) {
 void IRVisitor::visit(const RoundOff* v) {
   v->lhs()->accept(this);
   v->rhs()->accept(this);
+}
+
+void IRVisitor::visit(const ReduceOp* v) {
+  v->accumulator().node()->accept(this);
+  v->initializer()->accept(this);
+  v->body().node()->accept(this);
 }
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -46,6 +46,7 @@ class Cond;
 class Term;
 class Polynomial;
 class RoundOff;
+class ReduceOp;
 
 class TORCH_API IRVisitor {
  public:
@@ -97,6 +98,7 @@ class TORCH_API IRVisitor {
   virtual void visit(const Term* v);
   virtual void visit(const Polynomial* v);
   virtual void visit(const RoundOff* v);
+  virtual void visit(const ReduceOp* v);
 };
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -1,92 +1,231 @@
 #pragma once
 
-#include <functional>
-#include <vector>
-
+#include <torch/csrc/jit/tensorexpr/buffer.h>
+#include <torch/csrc/jit/tensorexpr/dim_arg.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/types.h>
+
+#include <functional>
+#include <vector>
 
 namespace torch {
 namespace jit {
 namespace tensorexpr {
 
-class Function : public KernelScopedObject {
+using ParameterList = const std::vector<VarHandle>;
+using ReduceInteraction = std::function<ExprHandle(ExprHandle, ExprHandle)>;
+
+// An expression representing a Reduction operation (e.g. Sum, Max) broken into
+// it's component parts: initialization, accumulation var, acquisition of value
+// to be reduced and interaction.
+//
+// This is intended to be expanded in the loopnest and not make it to codegen.
+class ReduceOp : public ExprNode<ReduceOp> {
  public:
-  Function(
-      const std::string& func_name,
-      const std::vector<const Expr*>& dims,
-      const std::vector<const Var*>& args,
-      const Expr* body)
-      : func_vars_({VarHandle(func_name, kHandle).node()}),
-        dims_(dims),
-        args_(args),
-        bodies_({body}) {}
-  Function(
-      const std::vector<std::string>& func_names,
-      const std::vector<const Expr*>& dims,
-      const std::vector<const Var*>& args,
-      const std::vector<const Expr*>& bodies)
-      : func_vars_(func_names.size()),
-        dims_(dims),
-        args_(args),
-        bodies_(bodies) {
-    for (size_t i = 0; i < func_names.size(); i++) {
-      func_vars_[i] = new Var(func_names[i], kHandle);
-    }
+  ReduceOp(
+      ExprHandle accum,
+      Stmt* init,
+      ExprHandle body,
+      ReduceInteraction c,
+      const std::vector<const Var*>& reduce_args)
+      : ExprNodeBase(body.dtype()),
+        accumulator_(accum),
+        initializer_(init),
+        body_(body),
+        interaction_(c),
+        reduce_args_(reduce_args) {}
+
+  // return the accumulation load expression.
+  ExprHandle accumulator() const {
+    return accumulator_;
   }
 
-  int ndim() const {
-    return dims_.size();
-  }
-  const Expr* dim(int index) const {
-    if (index < 0 || index >= ndim()) {
-      throw out_of_range_index();
-    }
-
-    return dims_[index];
-  }
-  const std::vector<const Expr*>& dims() const {
-    return dims_;
-  }
-  const Var* arg(int index) const {
-    if (index < 0 || index >= ndim()) {
-      throw out_of_range_index();
-    }
-
-    return args_[index];
-  }
-  const std::vector<const Var*>& args() const {
-    return args_;
+  // return a Statement which stores the initializer into the accumulation
+  // buffer.
+  Stmt* initializer() const {
+    return initializer_;
   }
 
-  std::vector<const Expr*> bodies() const {
-    return bodies_;
-  }
-  const Expr* body(size_t index) const {
-    if (index >= bodies_.size()) {
-      throw out_of_range_index();
-    }
-
-    return bodies_[index];
+  // return the body expression which obtains the value to be reduced.
+  ExprHandle body() const {
+    return body_;
   }
 
-  std::vector<const Var*> func_vars() const {
-    return func_vars_;
-  }
-  const Var* func_var(size_t index) const {
-    if (index >= func_vars_.size()) {
-      throw out_of_range_index();
-    }
-    return func_vars_[index];
+  // returns a function encoding the interaction between accumulator and the
+  // reduction value.
+  ReduceInteraction interaction() const {
+    return interaction_;
   }
 
-  Stmt* ElementStmt(size_t index);
+  // returns variables associated with the axes of reduction.
+  const std::vector<const Var*>& reduce_args() const {
+    return reduce_args_;
+  }
+
+  // Completes the reduction operator by applying the interaction function to
+  // the accumulation and the body expression.
+  ExprHandle complete() const {
+    return interaction_(accumulator_, body_);
+  }
 
  private:
-  std::vector<const Var*> func_vars_;
-  std::vector<const Expr*> dims_;
-  std::vector<const Var*> args_;
-  std::vector<const Expr*> bodies_;
+  ExprHandle accumulator_;
+  Stmt* initializer_;
+  ExprHandle body_;
+  ReduceInteraction interaction_;
+  std::vector<const Var*> reduce_args_;
+};
+
+// A Reducer is a user interface describing a particular reduction operation. It
+// has three components: An initializtion value, a way of interacting each value
+// with the accumulation, and a method for obtaining the current value to be
+// reduced. It is materialized into a ReduceOp when loop variables are known.
+class Reducer {
+ public:
+  Reducer(ExprHandle init, ReduceInteraction& interaction)
+      : init_(init.node()), interaction_(interaction) {}
+
+  Reducer(ExprHandle init, ReduceInteraction& interaction, Buffer& buf)
+      : init_(init.node()), interaction_(interaction) {}
+
+  template <typename RI>
+  Reducer(ExprHandle init, RI interaction) : init_(init.node()) {
+    interaction_ = interaction;
+  }
+
+  ReduceOp* operator()(
+      Buf* result_buf,
+      ExprHandle body,
+      std::vector<const Var*> outer,
+      std::vector<const Var*> inner) const {
+    std::vector<const Expr*> indices;
+    for (size_t i = 0; i < outer.size(); i++) {
+      indices.push_back(outer[i]);
+    }
+
+    ExprHandle accum =
+        ExprHandle(new Load(body.dtype(), result_buf, indices, new IntImm(1)));
+    Stmt* init = new Store(
+        result_buf, indices, new Cast(body.dtype(), init_), new IntImm(1));
+
+    return new ReduceOp(accum, init, body, interaction_, inner);
+  }
+
+  // Polymorphic handling of Body functions with a variety of parameters.
+  static ExprHandle getReduceBody(
+      const std::function<ExprHandle(ParameterList&)>& func,
+      const std::vector<VarHandle>& vars) {
+    return func(vars);
+  }
+
+  static ExprHandle getReduceBody(
+      const std::function<ExprHandle(const VarHandle&)>& func,
+      const std::vector<VarHandle>& vars) {
+    if (vars.size() != 1) {
+      throw malformed_input("mismatch between reduce body and arg size (1)");
+    }
+
+    return func(vars[0]);
+  }
+
+  static ExprHandle getReduceBody(
+      const std::function<ExprHandle(const VarHandle&, const VarHandle&)>& func,
+      const std::vector<VarHandle>& vars) {
+    if (vars.size() != 2) {
+      throw malformed_input("mismatch between reduce body and arg size (2)");
+    }
+    return func(vars[0], vars[1]);
+  }
+
+  static ExprHandle getReduceBody(
+      const std::function<
+          ExprHandle(const VarHandle&, const VarHandle&, const VarHandle&)>&
+          func,
+      const std::vector<VarHandle>& vars) {
+    if (vars.size() != 3) {
+      throw malformed_input("mismatch between reduce body and arg size (3)");
+    }
+    return func(vars[0], vars[1], vars[2]);
+  }
+
+  static ExprHandle getReduceBody(
+      const std::function<ExprHandle(
+          const VarHandle&,
+          const VarHandle&,
+          const VarHandle&,
+          const VarHandle&)>& func,
+      const std::vector<VarHandle>& vars) {
+    if (vars.size() != 4) {
+      throw malformed_input("mismatch between reduce body and arg size (4)");
+    }
+    return func(vars[0], vars[1], vars[2], vars[3]);
+  }
+
+ private:
+  const Expr* init_;
+  ReduceInteraction interaction_;
+};
+
+class Sum : public Reducer {
+ public:
+  Sum()
+      : Reducer(ExprHandle(0), [](ExprHandle a, ExprHandle b) {
+          return a + b;
+        }) {}
+};
+
+namespace {
+ExprHandle maximumVal(ScalarType type) {
+  switch (type) {
+#define MAX_BY_TYPE_CASE(Type, Name) \
+  case ScalarType::Name:             \
+    return ExprHandle(std::numeric_limits<Type>::max());
+    AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, MAX_BY_TYPE_CASE)
+#undef MAX_BY_TYPE_CASE
+    default:
+      throw unsupported_dtype();
+  }
+  return ExprHandle();
+}
+
+static ExprHandle minimumVal(ScalarType type) {
+  switch (type) {
+#define MAX_BY_TYPE_CASE(Type, Name) \
+  case ScalarType::Name:             \
+    return ExprHandle(std::numeric_limits<Type>::min());
+    AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, MAX_BY_TYPE_CASE)
+#undef MAX_BY_TYPE_CASE
+    default:
+      throw unsupported_dtype();
+  }
+}
+} // namespace
+
+class Maximum : public Reducer {
+ public:
+  // TODO possible to remove this arg by deferring the init value until we know
+  // the dtype of the body.
+  Maximum(Dtype dtype)
+      : Reducer(
+            minimumVal(dtype.scalar_type()),
+            [](ExprHandle a, ExprHandle b) { return Max::make(a, b, true); }) {}
+  Maximum(ExprHandle initializer)
+      : Reducer(initializer, [](ExprHandle a, ExprHandle b) {
+          return Max::make(a, b, true);
+        }) {}
+};
+
+class Minimum : public Reducer {
+ public:
+  Minimum(Dtype dtype)
+      : Reducer(
+            maximumVal(dtype.scalar_type()),
+            [](ExprHandle a, ExprHandle b) { return Min::make(a, b, true); }) {}
+  Minimum(ExprHandle initializer)
+      : Reducer(initializer, [](ExprHandle a, ExprHandle b) {
+          return Min::make(a, b, true);
+        }) {}
 };
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -3,8 +3,10 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <vector>
 
+#include <torch/csrc/jit/tensorexpr/dim_arg.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/function.h>
+#include <torch/csrc/jit/tensorexpr/reduction.h>
 
 namespace torch {
 namespace jit {
@@ -61,30 +63,6 @@ class Tensor {
   int output_index_;
 };
 
-// A helper structure to store the arguments to specify dimensions. In the
-// Compute arugments for dim_args, all of the following is supported. For
-// example:
-//    dim_args: {1, 2, 3, 4}
-//    dim_args: {{1, "x"}, {2, "y"}, {3, "z"}}
-//    dim_args: {1, 2, {3, "x"}}
-class DimArg {
- public:
-  // Intentionally leave out explicit to allow implicit conversions.
-  DimArg(const ExprHandle& dim) : dim_(dim) {}
-  DimArg(const ExprHandle& dim, const std::string& name_hint)
-      : dim_(dim), name_hint_(name_hint) {}
-  const ExprHandle& dim() const {
-    return dim_;
-  }
-  const std::string& name_hint() const {
-    return name_hint_;
-  }
-
- private:
-  ExprHandle dim_;
-  std::string name_hint_;
-};
-
 TORCH_API Tensor* Compute(
     const std::string& func_name,
     const std::vector<DimArg>& dim_args,
@@ -112,6 +90,71 @@ TORCH_API Tensor* Compute(
     const std::string& func_name,
     const std::vector<DimArg>& dim_args,
     const std::function<ExprHandle(const std::vector<VarHandle>&)>& body_func);
+
+namespace {
+
+static inline void unpack_dim_args(
+    const std::vector<DimArg>& dim_args,
+    std::vector<const Expr*>* dims,
+    std::vector<const Var*>* vars) {
+  dims->clear();
+  vars->clear();
+  for (const DimArg& dim_arg : dim_args) {
+    dims->push_back(dim_arg.dim().node());
+    vars->push_back(new Var(dim_arg.name_hint(), kInt));
+  }
+}
+} // namespace
+
+// Handle reductions over a Reducer and a body_func which produces values.
+template <typename BodyFunc>
+Tensor* Reduce(
+    const std::string& func_name,
+    const std::vector<DimArg>& dim_args,
+    const Reducer& reducer,
+    const BodyFunc& body_func,
+    const std::vector<DimArg>& reduce_args) {
+  std::vector<const Expr*> dims;
+  std::vector<const Var*> vars;
+  unpack_dim_args(dim_args, &dims, &vars);
+
+  std::vector<const Expr*> reduce_dims;
+  std::vector<const Var*> reduce_vars;
+  unpack_dim_args(reduce_args, &reduce_dims, &reduce_vars);
+
+  std::vector<const Var*> all_vars;
+  all_vars.insert(all_vars.end(), vars.begin(), vars.end());
+  all_vars.insert(all_vars.end(), reduce_vars.begin(), reduce_vars.end());
+
+  Buf* func_result = new Buf(new Var(func_name, kHandle), dims);
+
+  ExprHandle body =
+      Reducer::getReduceBody(body_func, VarVectorToVarHandleVector(all_vars));
+  const ReduceOp* reduce_op = reducer(func_result, body, vars, reduce_vars);
+  dims.insert(dims.end(), reduce_dims.begin(), reduce_dims.end());
+  Function* func =
+      new Function(func_name, func_result, dims, all_vars, reduce_op);
+  return new Tensor(func_result, func, 0);
+}
+
+// Overload which allows inline lambda functions for the body_func.
+template <typename BodyFunc>
+Tensor* Reduce(
+    const std::string& func_name,
+    const std::vector<DimArg>& dim_args,
+    const Reducer& reducer,
+    const BodyFunc&& body_func,
+    const std::vector<DimArg>& reduce_args) {
+  return Reduce(func_name, dim_args, reducer, body_func, reduce_args);
+}
+
+// Overload for the common case of all dimensions of a Buffer.
+TORCH_API Tensor* Reduce(
+    const std::string& func_name,
+    const std::vector<DimArg>& dim_args,
+    const Reducer& reducer,
+    const Buffer& buffer,
+    const std::vector<DimArg>& reduce_args);
 
 class FunctionCall : public CallNode<FunctionCall> {
  public:

--- a/torch/csrc/jit/tensorexpr/var_substitutor.h
+++ b/torch/csrc/jit/tensorexpr/var_substitutor.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_mutator.h>
+#include <torch/csrc/jit/tensorexpr/ir_visitor.h>
+#include <torch/csrc/jit/tensorexpr/reduction.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+using VarMapping = std::vector<std::pair<const Var*, const Expr*>>;
+
+// Finds all Vars present in a subexpr.
+class VarFinder : public IRVisitor {
+ public:
+  std::set<const Var*> findVars(const Expr* expr) {
+    vars_.clear();
+    expr->accept(this);
+    return vars_;
+  }
+
+  void visit(const Var* v) {
+    vars_.insert(v);
+  }
+
+ private:
+  std::set<const Var*> vars_;
+};
+
+class VarSubMutator : public IRMutator {
+ public:
+  VarSubMutator(const VarMapping& var_mapping) {
+    for (const auto& entry : var_mapping) {
+      const Var* key_var = entry.first;
+      const Expr* value = entry.second;
+      if (!key_var) {
+        throw malformed_input("missing key in VarSubMutator");
+      }
+      var_mapping_[key_var] = value;
+    }
+  }
+
+  const Expr* mutate(const Var* var) override {
+    auto iter = var_mapping_.find(var);
+    if (iter == var_mapping_.end()) {
+      return var;
+    }
+    return iter->second;
+  }
+
+  const Expr* mutate(const ReduceOp* var) override {
+    auto accum = var->accumulator().node()->accept_mutator(this);
+    Stmt* init = var->initializer()->accept_mutator(this);
+    auto body = var->body().node()->accept_mutator(this);
+    std::vector<const Var*> new_vars;
+
+    for (auto* v : var->reduce_args()) {
+      const Expr* e = v->accept_mutator(this);
+      if (const Var* new_var = dynamic_cast<const Var*>(e)) {
+        new_vars.push_back(new_var);
+      } else {
+        VarFinder varFinder;
+        auto varlist = varFinder.findVars(e);
+        new_vars.insert(new_vars.end(), varlist.begin(), varlist.end());
+      }
+    }
+
+    return new ReduceOp(
+        ExprHandle(accum),
+        init,
+        ExprHandle(body),
+        var->interaction(),
+        new_vars);
+  }
+
+ private:
+  std::unordered_map<const Var*, const Expr*> var_mapping_;
+};
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Second attempt at the reduction frontend for the TensorExpr compiler. Has two APIs, a simple version for common reduction types and a customizable Reducer fronted which allows specifying initializer, reduction interaction via lambda and body via lambda.

Simple API looks like so:
```
Buffer b(BufHandle("b", {10}), kInt);
Tensor* c = Reduce("sum", {}, Sum(b), {{10, "m"}});
```

An example of specializing a Sum to do Matmul:
```
Buffer tA(BufHandle("tA", {M, K}), kFloat);
Buffer tB(BufHandle("tB", {K, N}), kFloat);
Sum matmul([&](ParameterList& v) {
  ExprHandle m = v[0];
  ExprHandle n = v[1];
  ExprHandle k = v[2];
  return tA(m, k) * tB(k, n);
});
Tensor* mm = Reduce("mm", {{M, "m"}, {N, "n"}}, matmul, {{K, "k"}});
```

A fully specialized Reduction:
```
VarHandle searchValue("searchValue", kInt);
Buffer b(BufHandle("b", {4, 10}), kInt);

Reducer anyEqSV(
    ExprHandle(0),
    [](ExprHandle a, ExprHandle b) {
      return CompareSelect::make(a, 1, 1, b, kEQ);
    },
    [&](ParameterList& v) {
      return CompareSelect::make(b.call(v), searchValue, kEQ);
    });

Tensor* any = Reduce("anyEqual", {{4, "i"}}, anyEqSV, {{10, "j"}});
```

---

Until lowering, Reductions are held in a compound form for easier optimization:
```
  VarHandle m("m", kInt);
  Buffer b(BufHandle("b", {2, 3, m}), kFloat);

  Tensor* c = Reduce("sum", {{2, "l"}, {3, "n"}}, Sum(b), {{m, "m"}});
  LoopNest loop({c});
  std::cout << *loop.root_stmt() << "\n";
```
```
for (int l = 0; l < 2; l++) {
  for (int n = 0; n < 3; n++) {
    for (int m = 0; m < m_1; m++) {
      sum[l, n] = ReduceOp(sum[l, n] = float(0);, (sum[l, n]) + (b[l, n, m]), {m});
    }
  }
}
```
```
  loop.prepareForCodegen();
  std::cout << *loop.root_stmt() << "\n";
```
```
for (int l = 0; l < 2; l++) {
  for (int n = 0; n < 3; n++) {
    sum[(0 + l * (1 * 3)) + n * 1] = float(0);
    for (int m = 0; m < m_1; m++) {
      sum[(0 + l * (1 * 3)) + n * 1] = (sum[(0 + l * (1 * 3)) + n * 1]) + (b[((0 + l * ((1 * m_1) * 3)) + n * (1 * m_1)) + m * 1]);
    }
  }
}
```