### PR TITLE
Update ostream << TensorOptions printer.

### DIFF
--- a/c10/core/TensorOptions.cpp
+++ b/c10/core/TensorOptions.cpp
@@ -9,14 +9,35 @@
 
 namespace c10 {
 
-std::ostream& operator<<(
-    std::ostream& stream,
-    const TensorOptions& options) {
-  return stream << "TensorOptions(dtype=" << options.dtype()
-                << ", device=" << options.device()
-                << ", layout=" << options.layout()
-                << ", requires_grad=" << std::boolalpha
-                << options.requires_grad() << ")";
+// Note: TensorOptions properties are all optional, but (almost) all have
+// getters that supply a default when the corresponding property is missing.
+// Here we print the values returned by the default-supplying getters for
+// properties that have them, along with an annotation if the value is
+// returned by default. This gives the full picture of both the object's
+// internal state and what its getters will return.
+
+std::ostream& operator<<(std::ostream& stream, const TensorOptions& options) {
+
+  auto print = [&](const char *label, auto prop, bool has_prop) {
+    stream << label << std::boolalpha << prop << (has_prop ? "" : " (default)");
+  };
+
+  print("TensorOptions(dtype=", options.dtype(), options.has_dtype());
+  print(", device=", options.device(), options.has_device());
+  print(", layout=", options.layout(), options.has_layout());
+  print(", requires_grad=", options.requires_grad(), options.has_requires_grad());
+  print(", pinned_memory=", options.pinned_memory(), options.has_pinned_memory());
+
+  // note: default-supplying memory_format() getter not provided; no canonical default
+  stream << ", memory_format=";
+  if (options.has_memory_format()) {
+    stream << *options.memory_format_opt();
+  } else {
+    stream << "(nullopt)";
+  }
+  stream << ")";
+
+  return stream;
 }
 
 } // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35892 Update ostream << TensorOptions printer.**

A couple recent property additions were missing, plus we weren't
distinguishing between defaults and bona fide property values.

Differential Revision: [D20834147](https://our.internmc.facebook.com/intern/diff/D20834147)