### PR TITLE
[quant][graphmode] Add new tensorlist observer for LSTM

### DIFF
--- a/test/quantization/test_quantization.py
+++ b/test/quantization/test_quantization.py
@@ -1444,6 +1444,28 @@ class ObserverTest(QuantizationTestCase):
         self.assertEqual(ref[0], qparams[0])
         self.assertEqual(ref[1], qparams[1])
 
+    def test_tensor_list_observer(self):
+        from torch.quantization.observer import _MinMaxTensorListObserver
+        x = [torch.tensor([1.0, 2.5, 3.5]),
+             torch.tensor([2.0, 4.5, 3.5]),
+             torch.tensor([4.0, 2.5, 3.5]), ]
+        obs = _MinMaxTensorListObserver()
+        obs(x)
+        qparams = obs.calculate_qparams()
+        ref_min_val = []
+        ref_max_val = []
+        ref_qparams = []
+        for i in x:
+            obs_ref = MinMaxObserver()
+            obs_ref(i)
+            ref_min_val.append(obs_ref.min_val)
+            ref_max_val.append(obs_ref.max_val)
+            ref_qparams.append(obs_ref.calculate_qparams())
+        for i in range(len(x)):
+            self.assertEqual(obs.min_val[i], ref_min_val[i])
+            self.assertEqual(obs.max_val[i], ref_max_val[i])
+            self.assertEqual(torch.tensor([qparams[0][i]]), ref_qparams[i][0])
+            self.assertEqual(torch.tensor([qparams[1][i]]), ref_qparams[i][1])
 
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
            qscheme=st.sampled_from((torch.per_channel_affine, torch.per_channel_symmetric)),
@@ -1547,7 +1569,6 @@ class ObserverTest(QuantizationTestCase):
             x = torch.rand(3, 4)
             obs(x)
             scripted(x)
-
             self.assertEqual(obs.calculate_qparams(), scripted.calculate_qparams())
 
             buf = io.BytesIO()
@@ -1555,6 +1576,15 @@ class ObserverTest(QuantizationTestCase):
             buf.seek(0)
             loaded = torch.jit.load(buf)
             self.assertEqual(obs.calculate_qparams(), loaded.calculate_qparams())
+
+        # Check TensorListObserver
+        from torch.quantization.observer import _MinMaxTensorListObserver
+        obs =  _MinMaxTensorListObserver()
+        scripted = torch.jit.script(obs)
+        x = [torch.rand(3, 4), torch.rand(4, 5)]
+        obs(x)
+        scripted(x)
+        self.assertEqual(obs.calculate_qparams(), scripted.calculate_qparams())
 
     def test_no_qconfig_propagation(self):
         model = ModelWithNoQconfigPropagation()

--- a/test/quantization/test_quantization.py
+++ b/test/quantization/test_quantization.py
@@ -1579,7 +1579,7 @@ class ObserverTest(QuantizationTestCase):
 
         # Check TensorListObserver
         from torch.quantization.observer import _MinMaxTensorListObserver
-        obs =  _MinMaxTensorListObserver()
+        obs = _MinMaxTensorListObserver()
         scripted = torch.jit.script(obs)
         x = [torch.rand(3, 4), torch.rand(4, 5)]
         obs(x)

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -516,6 +516,9 @@ class MinMaxDynamicQuantObserver(MinMaxObserver):
 
         return scale.to(dtype=torch.float), torch.tensor([nudged_zero_point])
 
+# This observer is a temporary solution for quantizing modules with tensor lists as inputs.
+# If we decide to support more observers with TensorList this should be refactored
+# to work with multiple observer types.
 class _MinMaxTensorListObserver(MinMaxObserver):
     r"""Observer module that works on lists of tensors.
     It uses MinMaxObserver for computing the quantization parameters based on the

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -516,6 +516,49 @@ class MinMaxDynamicQuantObserver(MinMaxObserver):
 
         return scale.to(dtype=torch.float), torch.tensor([nudged_zero_point])
 
+class _MinMaxTensorListObserver(MinMaxObserver):
+    r"""Observer module that works on lists of tensors.
+    It uses MinMaxObserver for computing the quantization parameters based on the
+    tensor min and max values.
+    This observer is used currently for dynamic quantization of LSTM modules that
+    require list of tensors for weight inputs.
+    """
+    def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine, reduce_range=False):
+        super(_MinMaxTensorListObserver, self).__init__(dtype=dtype,
+                                                        qscheme=qscheme,
+                                                        reduce_range=reduce_range)
+
+    def forward(self, tensor_list):
+        # type: (List[Tensor]) -> (List[Tensor])
+        r"""Records the running minimum and maximum of ``tensor_list``."""
+        min_val = self.min_val
+        max_val = self.max_val
+        if min_val.numel() == 0 or max_val.numel() == 0:
+            min_val = torch.empty(len(tensor_list), dtype=torch.float32)
+            max_val = torch.empty(len(tensor_list), dtype=torch.float32)
+            for i in range(len(tensor_list)):
+                x = tensor_list[i].detach()
+                min_val[i] = torch.min(x)
+                max_val[i] = torch.max(x)
+        else:
+            for i in range(len(tensor_list)):
+                x = tensor_list[i].detach()
+                min_val[i] = torch.min(torch.min(x), min_val[i])
+                max_val[i] = torch.max(torch.max(x), max_val[i])
+        self.min_val = min_val
+        self.max_val = max_val
+        return tensor_list
+
+    def calculate_qparams(self):
+        scales = []
+        zero_points = []
+        for i in range(self.min_val.numel()):
+            x, y = self._calculate_qparams(self.min_val[i], self.max_val[i])
+            scales.append(x)
+            zero_points.append(y)
+        return scales, zero_points
+
+
 class PerChannelMinMaxObserver(_ObserverBase):
     r"""Observer module for computing the quantization parameters based on the
     running per channel min and max values.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35916 [quant][graphmode] Add quantize_per_tensor.tensors
* #35894 [quant][graphmode] Insert Observers for dynamic LSTM
* **#35893 [quant][graphmode] Add new tensorlist observer for LSTM**

Summary:
LSTM operator inputs have tensor list for activations and weights.
In graph mode we need a new observer to work with tensor list

Test Plan:
python test/quantization/test_quantization.py ObserverTest
Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20830389](https://our.internmc.facebook.com/intern/diff/D20830389)