### PR TITLE
[pytorch] Fix fblearner flow compiling errors

### DIFF
--- a/test/cpp/jit/test_base.cpp
+++ b/test/cpp/jit/test_base.cpp
@@ -9,6 +9,7 @@ inline c10::AliasAnalysisKind aliasAnalysisFromSchema() {
   return c10::AliasAnalysisKind::FROM_SCHEMA;
 }
 
+namespace {
 RegisterOperators reg({
     // This operator is intended to be used in JIT analysis and transformation
     // pass unit tests in which Values with type Tensor are often required. It
@@ -22,6 +23,7 @@ RegisterOperators reg({
         },
         aliasAnalysisFromSchema()),
 });
+}
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -36,6 +36,7 @@ void fuseGraph(std::shared_ptr<Graph>& graph) {
 } // namespace cuda
 } // namespace fuser
 
+namespace {
 RegisterOperators reg({
     Operator(
         prim::CudaFusionGroup,
@@ -47,6 +48,7 @@ RegisterOperators reg({
         },
         c10::AliasAnalysisKind::INTERNAL_SPECIAL_CASE),
 });
+}
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Move operator registration to anonymous namespace to avoid collision.

Reviewed By: soumith

Differential Revision: D20822382

