### PR TITLE
Set eval mode during optimization for mobile.

### DIFF
--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -114,9 +114,10 @@ void FoldPrePackingOps(script::Module& m) {
 }
 
 void optimizeForMobile(script::Module& m) {
+  m.eval();
   m = FoldConvBatchNorm2d(m);
-  m = freeze_module(m);
   insertPrePackedOps(m);
+  m = freeze_module(m);
   FoldPrePackingOps(m);
 }
 


### PR DESCRIPTION
Summary:
Eval mode must be set for module freezing, which is required for prepack
folding.

Test Plan: Test locally by transforming a model. As shown in the diff above this one.

Differential Revision: D20824420

