### PR TITLE
[profiler] Allow record_function ctx manager to profile futures

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2638,16 +2638,6 @@ class TestAutograd(TestCase):
             self.assertEqual(info.name, expected_name)
             last_end = info.cpu_interval.end
 
-    def test_record_function_callbacks(self):
-        x = torch.randn(10, 10)
-        with profile() as p:
-            with record_function("foo"):
-                y = x * 2 + 4
-
-        function_events = p.function_events
-        foo_event = [event for event in function_events if "foo" in event.name][0]
-        self.assertEqual(foo_event.count, 1)
-
     def test_profiler_aggregation_fake(self):
         events = EventList()
         id = [0]

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -366,13 +366,45 @@ class record_function(ContextDecorator):
     """
     def __init__(self, name):
         self.name = name
+        # Whether or not we should run record function's end callbacks when exiting.
+        self.run_callbacks_on_exit = True
 
     def __enter__(self):
         self.handle = torch.ops.profiler._record_function_enter(self.name)
+        return self
 
     def __exit__(self, *args):
-        torch.ops.profiler._record_function_exit(self.handle)
+        if self.run_callbacks_on_exit:
+            torch.ops.profiler._record_function_exit(self.handle)
         return False
+
+    def _call_end_callbacks_on_future(self, fut):
+        """
+        _call_end_callbacks_on_future is meant to be used for profiling async
+        calls that return a future. Calling this function will extend recording
+        beyond this scope, until the future is satisfied. It is useful for profiling
+        the end to end time of asynchronous calls. This function should only be called
+        once to attach the callback onto the future, and will throw if called multiple
+        times.
+
+        Arguments:
+            fut: (torch.distributed.rpc.Future): future for which to schedule
+            callback for.
+        """
+        # Throw if we have already attached a callback onto the future.
+        if not self.run_callbacks_on_exit:
+            raise RuntimeError("_call_end_callbacks_on_future can only be called once.")
+
+        # We are scheduling to run this RecordFunction's end callbacks when the
+        # passed in future completes, so don't run end callbacks on exit.
+        self.run_callbacks_on_exit = False
+        # TODO: Currently, we have two different futures that can be returned,
+        # thus, two different code paths. We should clean this up when the
+        # futures are merged (https://github.com/pytorch/pytorch/issues/34999).
+        if isinstance(fut, torch.distributed.rpc.Future):
+            torch.autograd._call_end_callbacks_on_fut(self.handle, fut)
+        else:
+            raise NotImplementedError("Future type {} is not supported".format(type(fut)))
 
 
 class emit_nvtx(object):

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/autograd/grad_mode.h>
 #include <ATen/autocast_mode.h>
 #include <torch/csrc/autograd/profiler.h>
+#include <torch/csrc/autograd/record_function_ops.h>
 #include <torch/csrc/autograd/python_function.h>
 #include <torch/csrc/autograd/function.h>
 
@@ -52,10 +53,13 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
   m.def("_enable_profiler", enableProfiler);
   m.def("_disable_profiler", disableProfiler);
   m.def("_profiler_enabled", profilerEnabled);
-  m.def("_run_before_callbacks", _runBeforeCallbacks);
 
-  py::class_<RecordFunction, std::shared_ptr<RecordFunction>>(m, "_RecordFunction")
-    .def(py::init<>());
+  m.def(
+      "_call_end_callbacks_on_fut",
+      [](const at::Tensor& handle,
+         const std::shared_ptr<torch::distributed::rpc::FutureMessage>& fut) {
+        torch::autograd::profiler::_call_end_callbacks_on_fut(handle, fut);
+      });
 
   Py_RETURN_TRUE;
 }

--- a/torch/csrc/autograd/record_function_ops.h
+++ b/torch/csrc/autograd/record_function_ops.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <torch/csrc/autograd/record_function.h>
+#include <torch/csrc/utils/future.h>
+#include <torch/csrc/distributed/rpc/message.h>
+
+namespace torch {
+namespace autograd {
+namespace profiler {
+// Creates a new profiling scope using RecordFunction and invokes its starting
+// callbacks.
+at::Tensor record_function_enter(const std::string& name);
+
+// Cast Tensor that was created with at::cpp_custom_type_hack back to
+// RecordFunction. This is a temporary workaround until RecordFunction is
+// registered as a custom C++ class.
+TORCH_API RecordFunction& getRecordFunctionFromTensor(const at::Tensor& handle);
+
+// Schedules RecordFunction's end callbacks to be run on completion of a future.
+template <typename T>
+TORCH_API void _call_end_callbacks_on_fut(
+    const at::Tensor& handle,
+    const std::shared_ptr<torch::utils::Future<T>> fut);
+
+// Ends the profiling scope created with record_function_enter.
+void record_function_exit(const at::Tensor& handle);
+
+} // namespace profiler
+} // namespace autograd
+} // namespace torch

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -95,7 +95,10 @@ TypePtr tryInferTypeWithTypeHint(
 
 ///////////////////////////  PyRRef  //////////////////////////////////
 
-PyRRef::PyRRef(c10::intrusive_ptr<RRef> rref) : rref_(std::move(rref)) {
+PyRRef::PyRRef(
+    c10::intrusive_ptr<RRef> rref,
+    const std::shared_ptr<FutureMessage> fm)
+    : rref_(std::move(rref)), fm_(fm) {
   TORCH_CHECK(rref_, "PyRRef must not wrap nullptr");
 }
 
@@ -108,6 +111,10 @@ PyRRef::PyRRef(const py::object& value, const py::object& type_hint)
         rref->setValue(std::move(ivalue));
         return rref;
       }()) {}
+
+const std::shared_ptr<FutureMessage> PyRRef::getFuture() {
+  return fm_;
+}
 
 bool PyRRef::isOwner() const {
   return rref_->isOwner();

--- a/torch/csrc/distributed/rpc/py_rref.h
+++ b/torch/csrc/distributed/rpc/py_rref.h
@@ -13,7 +13,9 @@ namespace rpc {
 class PyRRef {
  public:
   explicit PyRRef(const py::object& value, const py::object& type_hint);
-  explicit PyRRef(c10::intrusive_ptr<RRef> rref);
+  explicit PyRRef(
+      c10::intrusive_ptr<RRef> rref,
+      const std::shared_ptr<FutureMessage> fm = nullptr);
 
   bool isOwner() const;
   bool confirmedByOwner() const;
@@ -25,9 +27,12 @@ class PyRRef {
   py::tuple pickle() const;
   static PyRRef unpickle(const py::tuple& t);
   c10::IValue toIValue();
+  // Future that is associated with the creation of this RRef on the remote end.
+  const std::shared_ptr<FutureMessage> getFuture();
 
  private:
   c10::intrusive_ptr<RRef> rref_;
+  const std::shared_ptr<FutureMessage> fm_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -14,28 +14,24 @@ py::object toPyObj(const Message& message);
 std::shared_ptr<FutureMessage> pyRpcBuiltin(
     const WorkerInfo& dst,
     const std::string& opName,
-    const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
     const py::args& args,
     const py::kwargs& kwargs);
 
 std::shared_ptr<FutureMessage> pyRpcPythonUdf(
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
-    std::vector<torch::Tensor>& tensors,
-    const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf);
+    std::vector<torch::Tensor>& tensors);
 
 PyRRef pyRemoteBuiltin(
     const WorkerInfo& dst,
     const std::string& opName,
-    const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
     const py::args& args,
     const py::kwargs& kwargs);
 
 PyRRef pyRemotePythonUdf(
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
-    std::vector<torch::Tensor>& tensors,
-    const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf);
+    std::vector<torch::Tensor>& tensors);
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -14,6 +14,10 @@ import torch.distributed as dist
 # objects
 _thread_local_tensor_tables = threading.local()
 
+# Flag to enable and disable RPC profiling with the autograd profiler. Only disabled
+# in some unit tests to test the profiler functionality at a granular level.
+profiling_flag = True
+
 
 class RPCExecMode(Enum):
     SYNC = "sync"
@@ -161,6 +165,36 @@ def _run_function(python_udf):
 def _handle_exception(result):
     if isinstance(result, RemoteException):
         raise result.exception_type(result.msg)
+
+def _disable_profiling_for_testing():
+    global profiling_flag
+    profiling_flag = False
+
+def _profiling_enabled():
+    global profiling_flag
+    return profiling_flag
+
+def build_rpc_profiling_key(exec_type, func_name, current_worker_name, dst_worker_name):
+    """
+    Builds the key that RPC calls are profiled with using the autograd profiler.
+    This will be the name of the corresponding Event recorded in the profiler.
+
+    Arguments:
+        exec_type (RPCExecMode): Type of RPC/RRef call
+        func_name (str): Name of function being profiled.
+        current_worker_name (str): Name of current worker.
+        dst_worker_name (str): Name of the destination worker.
+
+    Returns:
+        str
+    """
+    profile_key = "rpc_{rpc_type}#{func_name}({current_worker} -> {dst_worker})".format(
+        rpc_type=exec_type.value,
+        func_name=str(func_name),
+        current_worker=current_worker_name,
+        dst_worker=dst_worker_name,
+    )
+    return profile_key
 
 
 def _start_record_function(exec_type, func_name, current_worker_name, dest_worker_name):

--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -182,3 +182,16 @@ def initialize_pg(init_method, rank, world_size):
 
 def worker_name(rank):
     return "worker{}".format(rank)
+
+def get_function_event(function_events, partial_event_name):
+    """
+    Returns the first event that matches partial_event_name in the provided
+    function_events. These function_events should be the output of
+    torch.autograd.profiler.function_events().
+
+    Args:
+    function_events: function_events returned by the profiler.
+    event_name (str): partial key that the event was profiled with.
+    """
+    event = [event for event in function_events if partial_event_name in event.name][0]
+    return event


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

https://github.com/pytorch/pytorch/pull/35055

This is the first step to improving the way RPCs are profiled as suggested by Ilia. For now, since RPC can return two different types of futures, we have to implement two different code paths, one for the python eager mode future and one for the jit future.

This diff implements the python eager part. We have defined a method `_call_end_callbacks_on_future` that takes in a future and schedules a `RecordFunction` to be completed as a callback on the future.

Once https://github.com/pytorch/pytorch/pull/35039 lands, we can implement the JIT codepath by registering an operator that takes a `Future(t)` as well.

These code paths will be merged once the futures are merged.

Differential Revision: [D20452003](https://our.internmc.facebook.com/intern/diff/D20452003/)