### PR TITLE
[Shape Inference] Set new shape according to precedence of dimType over previous value

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -45,6 +45,57 @@ int64_t SizeToDim(const TensorShape& shape, int axis) {
   }
   return r;
 }
+
+// Check precedence between two vector of ensorBoundShape::DimType.
+// If return 1: right take precedence over left
+// If return -1: left take precedence over right
+// If return 0: no precedence between left and right
+int takePrecedenceOver(
+    const std::vector<TensorBoundShape::DimType>& left,
+    const std::vector<TensorBoundShape::DimType>& right) {
+  const static std::unordered_map<
+      TensorBoundShape::DimType,
+      std::pair<TensorBoundShape::DimType, int>>
+      precedence = {
+          {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT,
+           {TensorBoundShape_DimType_FEATURE_MAX, 1}},
+          {TensorBoundShape_DimType_FEATURE_MAX,
+           {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT, -1}},
+          {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT,
+           {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX, 1}},
+          {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX,
+           {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT, -1}}};
+
+  // If left is empty and right is not, right take precedence
+  if (left.size() == 0 || right.size() == 0) {
+    return right.size() > left.size();
+  }
+  for (int i = 0; i < right.size(); i++) {
+    // If right.size > left.size and left[0:i] == right[0:i],
+    // right take precedence
+    if (i >= left.size()) {
+      return 1;
+    }
+    auto l = left[i];
+    auto r = right[i];
+    if (l == TensorBoundShape_DimType_UNKNOWN &&
+        r != TensorBoundShape_DimType_UNKNOWN) {
+      return 1;
+    }
+    if (r == TensorBoundShape_DimType_UNKNOWN &&
+        l != TensorBoundShape_DimType_UNKNOWN) {
+      return -1;
+    }
+    auto it = precedence.find(l);
+    if (it != precedence.end() && it->second.first == r) {
+      return it->second.second;
+    }
+    if (l != r) {
+      return 0;
+    }
+  }
+  return 0;
+}
 } // namespace
 
 void BoundShapeInferencer::EnsureShapeNames(
@@ -173,24 +224,32 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorBoundShape(
     shape_info.q_info.offset.push_back(0);
     shape_info.q_info.axis = 1;
   }
+  // If the shape information exists in shape_info_ already
   if (!rt.second) {
-    // Check shape consistency
+    // Check dim size consistency
     CAFFE_ENFORCE_EQ(
         shape.dims_size(),
         bound_dims.size(),
         "Dim size inconsistency found in tensor ",
         name);
-    // For shapes that was provided as a hint at the input of the net, fix the
-    // batch size first.
-    if ((!shape_info.dimTypeIsSet() ||
-         (shape.dims_size() &&
-          shape_info.getDimType(0) == TensorBoundShape_DimType_UNKNOWN)) &&
-        t.size() && t[0] > TensorBoundShape_DimType_CONSTANT) {
-      shape_info.setDimType(t);
-      shape.set_dims(0, bound_dims.front());
+    // Get precedence of previous shape vs new shape
+    int precedence = 0;
+    if (!shape_info.dimTypeIsSet()) {
+      precedence = 1;
+    } else {
+      precedence = takePrecedenceOver(shape_info.getDimType(), t);
     }
-
-    if (!allow_existing_shape) {
+    // If precedence == 0: check whether previous shape == new shape
+    // If precedence == 1, override shape with new value
+    // If precedence == -1, previous shape takes precedence and
+    // new value is skipped.
+    if (precedence == 1) {
+      shape_info.setDimType(t);
+      for (int i = 0; i < bound_dims.size(); i++) {
+        shape.set_dims(i, bound_dims[i]);
+      }
+    } else if (precedence == 0 && !allow_existing_shape) {
+      // Enforce previous dims and current dims are the same.
       for (int i = 0; i < shape.dims_size(); ++i) {
         CAFFE_ENFORCE_EQ(
             shape.dims(i),
@@ -208,7 +267,8 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorBoundShape(
     }
     return shape;
   }
-
+  // If shape information does not exist in shape_info_,
+  // set shape info according to inputs.
   shape_info.setDimType(t);
   shape.mutable_dims()->Clear();
   for (const auto d : bound_dims) {
@@ -674,10 +734,10 @@ void BoundShapeInferencer::InferCommonOp(const OperatorDef& op) {
     }
   } catch (const caffe2::EnforceNotMet& e) {
     LOG(ERROR) << "Enforce not met while inferring shapes for " << op.type()
-               << ": " << e.msg();
+               << ": " << e.msg() << " first output: " << op.output(0);
   } catch (const std::exception& e) {
     LOG(WARNING) << "Caught exception while inferring shapes for " << op.type()
-                 << ": " << e.what();
+                 << ": " << e.what() << " first output: " << op.output(0);
   }
 }
 


### PR DESCRIPTION
Summary:
In dper3, we firstly do shape inference for full predictor net and then disagg_acc nets to cover bridge quantization for pooled embedding.

D20731341 is moving position weighted handling to remote(which including lengthsRangeFill, and Gather) to remote.

During shape inference for full predictor net, we infer shape according to truncation (ClipRanges, ClipLengths).

During shape inference for disagg_acc nets, we don't have truncation ops. So for some ops, we just can infer default value.

Prevously when we try to set shape for a tensor, we check whether it's the same with existing shape. But in this case, they may not be same. example error:

RuntimeError: [enforce fail at bound_shape_inferencer.cc:206] shape.dims(i) == bound_dims[i]. 100 vs 3000. Shape inconsistency found in tensor sequential_58/sparse_nn_1/sparse_arch_1/position_weighted:GFF_S_C10215_ADS_RID_CLICK_AD_ACCOUNT_ID_SORTBY_TIME_EVENT_TS_TOP200_D173_1/lengths_range_fill_7/lengths_range_fill_7_0 on dim 0 (100 vs 3000)

This diff changes the logic to set shape according to precedence of dimtype. eg: FEATURE_MAX > FEATURE_MAX_DEFAULT.

Test Plan:
buck test dper3/dper3_models/ads_ranking/base_models/sparse_nn/tests:config_based_model_keeper_test -- test_instantiate_model_keeper_enable_bound_shape_inference
buck test caffe2/caffe2/fb/opt:bound_shape_inference_net_test
buck test caffe2/caffe2/opt:bound_shape_inference_test

Differential Revision: D20802884

