### PR TITLE
more fixes

### DIFF
--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -6,6 +6,7 @@
 
 #include <c10/macros/Macros.h>
 #include <c10/util/Logging.h>
+#include <c10/util/math_compat.h>
 #include <torch/csrc/jit/tensorexpr/buffer.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
 #include <torch/csrc/jit/tensorexpr/exceptions.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35914 Reenable test/test_tensorexpr.py
* #35913 Invoke TensorExpr fuser pass from a graph executor.
* **#35927 more fixes**
* #35925 [TensorExpr] Compiler warnings cleanups.

Differential Revision: [D20831224](https://our.internmc.facebook.com/intern/diff/D20831224)