### PR TITLE
[jit] Fix type comparisons segfault

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5353,6 +5353,15 @@ def foo(x):
 
         self.checkModule(Add(), [torch.randn(2, 2)])
 
+    def test_pybind_type_comparisons(self):
+        @torch.jit.script
+        def f():
+            return None
+
+        node = list(f.graph.nodes())[0]
+        t = node.outputsAt(0).type()
+        self.assertFalse(t == None)
+
     @unittest.skipIf(IS_WINDOWS and sys.version_info >= (3, 8), 'TODO: need to fix the test case')
     def test_unmatched_type_annotation(self):
         message1 = re.escape("Number of type annotations (2) did not match the number of function parameters (1):")

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -684,11 +684,17 @@ void initPythonIRBindings(PyObject* module_) {
       .def(
           "__eq__",
           [](std::shared_ptr<Type>& self, std::shared_ptr<Type>& other) {
+            if (!other) {
+              return false;
+            }
             return *self == *other;
           })
       .def(
           "isSubtypeOf",
           [](std::shared_ptr<Type>& self, std::shared_ptr<Type> other) {
+            if (!other) {
+              return false;
+            }
             return self->isSubtypeOf(other);
           })
       .def("is_interface_type", [](const std::shared_ptr<Type>& self) {


### PR DESCRIPTION
Pybind will convert `None`s to `nullptr`s, so this adds a check to make
sure those don't get into the actual type comparison logic. Fixes #35778

Differential Revision: [D20831278](https://our.internmc.facebook.com/intern/diff/20831278/)