### PR TITLE
Report an error if the compiler does not support 32-byte alignment.

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -23,7 +23,7 @@
 #elif defined(_WIN32)
 #define __at_align32__ __declspec(align(32))
 #else
-#define __at_align32__
+#error "The compiler must support 256-bit alignment."
 #endif
 
 namespace at {


### PR DESCRIPTION
Some part of the codebase requires __at_align32__ to be effective to
work correctly (e.g., bitwise_binary_op). Error out if there is no
256-bit alignment support.

