### PR TITLE
Change a division to multiplication in c10d/reducer 

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -359,7 +359,7 @@ void Reducer::mark_variable_ready(VariableIndex index) {
   // Check if this was the final gradient for this bucket.
   if (--replica.pending == 0) {
     // Prescale bucket contents to turn the global sum into the global average.
-    replica.contents.div_(process_group_->getSize());
+    replica.contents.mul_(1.0/process_group_->getSize());
     // Kick off reduction if all replicas for this bucket are ready.
     if (--bucket.pending == 0) {
       mark_bucket_ready(bucket_index.bucket_index);


### PR DESCRIPTION
According to 

https://github.com/pytorch/pytorch/blob/b801d873ad6e289dce46ad0502dbcd8cf9377763/aten/src/ATen/native/cuda/BinaryArithmeticKernel.cu#L29-L50 

divisions with non-integral type divisor will be converted to multiplication to the reciprocal. However, `getSize()` returns an `int`, and this division is not automatically converted. Converting this division to multiplication will improve performance. 

cc @csarofeen @ptrblck 
