### PR TITLE
Strip relocatable cubins during CUDA separable compilation

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -742,8 +742,12 @@ elseif(USE_CUDA)
     set(_generated_name "torch_cuda_w_sort_by_key_intermediate_link${CMAKE_C_OUTPUT_EXTENSION}")
     set(torch_cuda_w_sort_by_key_link_file "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/torch_cuda.dir/${CMAKE_CFG_INTDIR}/${_generated_name}")
     cuda_wrap_srcs(torch_cuda OBJ Caffe2_GPU_W_SORT_BY_KEY_OBJ ${Caffe2_GPU_SRCS_W_SORT_BY_KEY})
-    CUDA_LINK_SEPARABLE_COMPILATION_OBJECTS("${torch_cuda_w_sort_by_key_link_file}" torch_cpu "${_options}" "${torch_cuda_SEPARABLE_COMPILATION_OBJECTS}")
+    CUDA_LINK_SEPARABLE_COMPILATION_OBJECTS("${torch_cuda_w_sort_by_key_link_file}" torch_cpu "${_options}"
+      "${torch_cuda_SEPARABLE_COMPILATION_OBJECTS}"
+      "${torch_cuda_UNSTRIPPED_SEPARABLE_COMPILATION_OBJECTS}"
+      )
     set( torch_cuda_SEPARABLE_COMPILATION_OBJECTS )
+    set( torch_cuda_UNSTRIPPED_SEPARABLE_COMPILATION_OBJECTS )
     # Pass compiled sort-by-key object + device-linked fatbin as extra dependencies of torch_cuda
     cuda_add_library(torch_cuda ${Caffe2_GPU_SRCS} ${torch_cuda_w_sort_by_key_link_file} ${Caffe2_GPU_W_SORT_BY_KEY_OBJ})
   else()

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/run_nvcc.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/run_nvcc.cmake
@@ -66,6 +66,8 @@ set(CUDA_make2cmake "@CUDA_make2cmake@") # path
 set(CUDA_parse_cubin "@CUDA_parse_cubin@") # path
 set(build_cubin @build_cubin@) # bool
 set(CUDA_HOST_COMPILER "@CUDA_HOST_COMPILER@") # path
+set(CUDA_strip_relfatbin @CUDA_strip_relfatbin@) # bool
+set(CUDA_OBJCOPY "@CUDA_OBJCOPY@") # path
 # We won't actually use these variables for now, but we need to set this, in
 # order to force this file to be run again if it changes.
 set(generated_file_path "@generated_file_path@") # path
@@ -177,6 +179,12 @@ cuda_execute_process(
   "Removing ${generated_file}"
   COMMAND "${CMAKE_COMMAND}" -E remove "${generated_file}"
   )
+if(CUDA_strip_relfatbin)
+cuda_execute_process(
+  "Removing ${generated_strip_file}"
+  COMMAND "${CMAKE_COMMAND}" -E remove "${generated_strip_file}"
+  )
+endif()
 
 # For CUDA 2.3 and below, -G -M doesn't work, so remove the -G flag
 # for dependency generation and hope for the best.
@@ -275,6 +283,17 @@ else()
   if(verbose)
     message("Generated ${generated_file} successfully.")
   endif()
+endif()
+
+if(CUDA_strip_relfatbin)
+  # Strip relocatable FATBINS
+  cuda_execute_process(
+    "Stripping nv_relfatbin ${generated_strip_file}"
+    COMMAND "${CUDA_OBJCOPY}"
+    --remove-relocations .nvFatBinSegment --remove-section __nv_relfatbin
+    "${generated_file}"
+    "${generated_strip_file}"
+  )
 endif()
 
 # Cubin resource report commands.


### PR DESCRIPTION
Use `objcopy` to remove `__nvrel_fatbin` section(containing intermediate CUDA object files) from host object files.
I.e.  use `__nvrel_fatbin` only to create device-linked CUDA code, but stripped version of object files to link host target
    
Test Plan: Build torch_cuda with separate compilation and run smoke tests
