### PR TITLE
[jit] split out refinements into their own file

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -449,6 +449,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/runtime/register_special_ops.cpp
     ${TORCH_SRC_DIR}/csrc/jit/ir/scope.cpp
     ${TORCH_SRC_DIR}/csrc/jit/frontend/ir_emitter.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/frontend/refinements.cpp
     ${TORCH_SRC_DIR}/csrc/jit/frontend/name_mangler.cpp
     ${TORCH_SRC_DIR}/csrc/jit/testing/file_check.cpp
     ${TORCH_SRC_DIR}/csrc/jit/frontend/convert_to_ssa.cpp

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -160,6 +160,7 @@ libtorch_sources = [
     "torch/csrc/jit/runtime/register_special_ops.cpp",
     "torch/csrc/jit/ir/scope.cpp",
     "torch/csrc/jit/frontend/ir_emitter.cpp",
+    "torch/csrc/jit/frontend/refinements.cpp",
     "torch/csrc/jit/frontend/name_mangler.cpp",
     "torch/csrc/jit/frontend/edit_distance.cpp",
     "torch/csrc/jit/runtime/logging.cpp",

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1,10 +1,12 @@
 #include <torch/csrc/jit/frontend/ir_emitter.h>
+
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/frontend/canonicalize_modified_loop.h>
 #include <torch/csrc/jit/frontend/convert_to_ssa.h>
 #include <torch/csrc/jit/frontend/parser.h>
+#include <torch/csrc/jit/frontend/refinements.h>
 #include <torch/csrc/jit/frontend/schema_matching.h>
 #include <torch/csrc/jit/frontend/script_type_parser.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -36,102 +38,6 @@ using ValueTable = std::unordered_map<std::string, SugaredValuePtr>;
 using TypeTable = std::unordered_map<std::string, TypePtr>;
 using AttributeMap = std::unordered_map<std::string, Const>;
 using ListAttributeMap = std::unordered_map<std::string, std::vector<Const>>;
-
-struct Refinement {
-  Refinement(std::string identifier, TypePtr type)
-      : identifier_(std::move(identifier)), type_(type) {}
-  const std::string& identifier() const {
-    return identifier_;
-  }
-  TypePtr type() const {
-    return type_;
-  }
-
- private:
-  std::string identifier_;
-  TypePtr type_;
-};
-
-struct RefinementSet {
-  // When a comparison like x is None is made, we associate type refinements
-  // with its true value and its false value. If a boolean that has refinements
-  // associated with it is used in a conditional of an if statememt, the true
-  // and false refinements are inserted into the corresponding blocks
-  using Refinements = std::vector<Refinement>;
-
-  RefinementSet(Refinements true_refinements, Refinements false_refinements)
-      : true_refinements_(std::move(true_refinements)),
-        false_refinements_(std::move(false_refinements)) {}
-  RefinementSet(Refinement single) : RefinementSet({std::move(single)}, {}) {}
-  RefinementSet(Refinement single_true, Refinement single_false)
-      : RefinementSet(
-            Refinements({std::move(single_true)}),
-            Refinements({std::move(single_false)})) {}
-  RefinementSet() {} // empty
-  RefinementSet And(const RefinementSet& rhs) const {
-    // if the result of an AND is true, both a & b had to be true,
-    // so we take the union of a.true_refinements and b.true_refinements.
-    // if the result is false, either a or b could have been false,
-    // so we take their intersection.
-    return RefinementSet(
-        unionSet(true_refinements_, rhs.true_refinements_),
-        intersectSet(false_refinements_, rhs.false_refinements_));
-  }
-  RefinementSet Or(const RefinementSet& rhs) const {
-    // if the result of an OR is true, either a & b could have been true,
-    // so we take the intersection of a.true_refinements & b.true_refinements.
-    // if the result is false, both a and b had to be false,
-    // so we take their union.
-    return RefinementSet(
-        intersectSet(true_refinements_, rhs.true_refinements_),
-        unionSet(false_refinements_, rhs.false_refinements_));
-  }
-
-  RefinementSet Not() const {
-    return RefinementSet(false_refinements_, true_refinements_);
-  }
-  const std::vector<Refinement> activeRefinements() const {
-    return true_refinements_;
-  }
-
- private:
-  static bool sameVar(const Refinement& a, const Refinement& b) {
-    return a.identifier() == b.identifier();
-  }
-  static Refinements unionSet(const Refinements& a, const Refinements& b) {
-    Refinements result = a;
-    for (const Refinement& r : b) {
-      auto it =
-          std::find_if(result.begin(), result.end(), [&](const Refinement& e) {
-            return e.identifier() == r.identifier();
-          });
-      if (it == result.end()) {
-        result.push_back(r);
-      } else if (*it->type() != *r.type()) {
-        // we only keep refinements when they exactly match one
-        // refinement type, for instance, we do not attempt to refine:
-        // isinstance(x, float) and isinstance(x, int)
-        result.erase(it);
-      }
-    }
-    return result;
-  }
-  static Refinements intersectSet(const Refinements& a, const Refinements& b) {
-    Refinements result;
-    for (const Refinement& r : a) {
-      auto it = std::find_if(b.begin(), b.end(), [&](const Refinement& e) {
-        return e.identifier() == r.identifier();
-      });
-      if (it != b.end() && r.type() == it->type()) {
-        result.push_back(r);
-      }
-    }
-    return result;
-  }
-
-  Refinements true_refinements_;
-  Refinements false_refinements_;
-};
 
 struct CondValue {
   CondValue(

--- a/torch/csrc/jit/frontend/refinements.cpp
+++ b/torch/csrc/jit/frontend/refinements.cpp
@@ -57,6 +57,7 @@ Refinements RefinementSet::unionSet(
   }
   return result;
 }
+
 Refinements RefinementSet::intersectSet(
     const Refinements& a,
     const Refinements& b) {

--- a/torch/csrc/jit/frontend/refinements.cpp
+++ b/torch/csrc/jit/frontend/refinements.cpp
@@ -1,0 +1,75 @@
+#include <torch/csrc/jit/frontend/refinements.h>
+
+namespace torch {
+namespace jit {
+
+RefinementSet::RefinementSet(
+    Refinements true_refinements,
+    Refinements false_refinements)
+    : true_refinements_(std::move(true_refinements)),
+      false_refinements_(std::move(false_refinements)) {}
+
+RefinementSet::RefinementSet(Refinement single)
+    : RefinementSet({std::move(single)}, {}) {}
+
+RefinementSet::RefinementSet(Refinement single_true, Refinement single_false)
+    : RefinementSet(
+          Refinements({std::move(single_true)}),
+          Refinements({std::move(single_false)})) {}
+
+RefinementSet RefinementSet::And(const RefinementSet& rhs) const {
+  // if the result of an AND is true, both a & b had to be true,
+  // so we take the union of a.true_refinements and b.true_refinements.
+  // if the result is false, either a or b could have been false,
+  // so we take their intersection.
+  return RefinementSet(
+      unionSet(true_refinements_, rhs.true_refinements_),
+      intersectSet(false_refinements_, rhs.false_refinements_));
+}
+
+RefinementSet RefinementSet::Or(const RefinementSet& rhs) const {
+  // if the result of an OR is true, either a & b could have been true,
+  // so we take the intersection of a.true_refinements & b.true_refinements.
+  // if the result is false, both a and b had to be false,
+  // so we take their union.
+  return RefinementSet(
+      intersectSet(true_refinements_, rhs.true_refinements_),
+      unionSet(false_refinements_, rhs.false_refinements_));
+}
+
+Refinements RefinementSet::unionSet(
+    const Refinements& a,
+    const Refinements& b) {
+  Refinements result = a;
+  for (const Refinement& r : b) {
+    auto it =
+        std::find_if(result.begin(), result.end(), [&](const Refinement& e) {
+          return e.identifier() == r.identifier();
+        });
+    if (it == result.end()) {
+      result.push_back(r);
+    } else if (*it->type() != *r.type()) {
+      // we only keep refinements when they exactly match one
+      // refinement type, for instance, we do not attempt to refine:
+      // isinstance(x, float) and isinstance(x, int)
+      result.erase(it);
+    }
+  }
+  return result;
+}
+Refinements RefinementSet::intersectSet(
+    const Refinements& a,
+    const Refinements& b) {
+  Refinements result;
+  for (const Refinement& r : a) {
+    auto it = std::find_if(b.begin(), b.end(), [&](const Refinement& e) {
+      return e.identifier() == r.identifier();
+    });
+    if (it != b.end() && r.type() == it->type()) {
+      result.push_back(r);
+    }
+  }
+  return result;
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/frontend/refinements.h
+++ b/torch/csrc/jit/frontend/refinements.h
@@ -48,7 +48,6 @@ using Refinements = std::vector<Refinement>;
  * conditionals.
  */
 struct RefinementSet {
-
   RefinementSet(Refinements true_refinements, Refinements false_refinements);
   RefinementSet(Refinement single);
   RefinementSet(Refinement single_true, Refinement single_false);

--- a/torch/csrc/jit/frontend/refinements.h
+++ b/torch/csrc/jit/frontend/refinements.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "ATen/core/jit_type.h"
+
+/**
+ * This file contains helpers for tracking type refinements.
+ *
+ * When we encounter a conditional expression that tells us information about a
+ * type statically, we want to be able to "refine" the type to be more specific
+ * in the bodies of the if-else blocks.
+ *
+ *   # a: Optional[Tensor]
+ *   if a is None:
+ *      # we know a: None
+ *   else:
+ *      # we know a: Tensor
+ */
+namespace torch {
+namespace jit {
+
+/**
+ * Tracks the refined type for the variable `identifier` as it exists in a
+ * single if- or else-block.
+ */
+struct Refinement {
+  Refinement(std::string identifier, c10::TypePtr type)
+      : identifier_(std::move(identifier)), type_(type) {}
+  const std::string& identifier() const {
+    return identifier_;
+  }
+  c10::TypePtr type() const {
+    return type_;
+  }
+
+ private:
+  std::string identifier_;
+  c10::TypePtr type_;
+};
+
+using Refinements = std::vector<Refinement>;
+
+/*
+ * Structure for tracking type refinements on a conditional expression. Keeps
+ * track of what refinements apply if the expression is true or false, and
+ * offers logical conjuction operators to combine refinements from different
+ * conditionals.
+ */
+struct RefinementSet {
+
+  RefinementSet(Refinements true_refinements, Refinements false_refinements);
+  RefinementSet(Refinement single);
+  RefinementSet(Refinement single_true, Refinement single_false);
+  RefinementSet() {} // empty
+
+  RefinementSet And(const RefinementSet& rhs) const;
+  RefinementSet Or(const RefinementSet& rhs) const;
+  RefinementSet Not() const {
+    return RefinementSet(false_refinements_, true_refinements_);
+  }
+  const std::vector<Refinement> activeRefinements() const {
+    return true_refinements_;
+  }
+
+ private:
+  static bool sameVar(const Refinement& a, const Refinement& b) {
+    return a.identifier() == b.identifier();
+  }
+  static Refinements unionSet(const Refinements& a, const Refinements& b);
+  static Refinements intersectSet(const Refinements& a, const Refinements& b);
+
+  Refinements true_refinements_;
+  Refinements false_refinements_;
+};
+
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#35963 [jit] split out refinements into their own file**

I'm trying to reduce the overall complexity of the ir_emitter file and
this seemed like a reasonable candidate to split out and document
separately. Ideally we'd have tests for this logic as well

Differential Revision: [D20845963](https://our.internmc.facebook.com/intern/diff/D20845963)