### PR TITLE
[ROCm] Enable BFloat16 type for add_out_sparse

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -94,8 +94,9 @@ SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
     int64_t stride = at::prod_intlist(values.sizes().slice(1));
     dim3 grid(THCCeilDiv(newNnz, (int64_t) SZ), THCCeilDiv(stride, (int64_t) C10_WARP_SIZE*SZ));
     dim3 block(C10_WARP_SIZE, SZ);
-    AT_DISPATCH_ALL_TYPES_AND(
-      at::ScalarType::Half,values.scalar_type(), "coalesce_sparse_cuda", [&] {
+    AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, values.scalar_type(), "coalesce_sparse_cuda", [&] {
+        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "coalesce_sparse_cuda", [&] {
           using cuda_accscalar_t = acc_type<scalar_t, /* is_cuda */ true>;
           apply::coalesceValuesKernel<scalar_t, cuda_accscalar_t><<<grid, block, 0, stream>>>(
             uniqueOffsets.data_ptr<int64_t>(),
@@ -107,6 +108,7 @@ SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
             stride
           );
         });
+      });
   }
 
 // this grid-strided version is slower but probably more flexible

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -435,12 +435,14 @@ SparseTensor& add_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t, const
   Tensor t_values_ = t._values().to(commonDtype);
   Tensor s_values_ = src._values().to(commonDtype);
 
-  AT_DISPATCH_ALL_TYPES_AND(
-    at::ScalarType::Half, commonDtype, "add_out_sparse_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND2(
+    at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_sparse_cuda", [&] {
+      AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "add_out_sparse_cuda", [&] {
         if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
           s_values_ = s_values_.mul(value);
         }
       });
+    });
   LongTensor r_indices_ = at::cat({t_indices_, s_indices_}, 1);
   Tensor r_values_ = at::cat({t_values_, s_values_}, 0);
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1092,7 +1092,7 @@ class TestSparse(TestCase):
         x = x.bfloat16()
         y = y.bfloat16()
         res_bf16 = torch.add(x, y)
-        res_bf16 = res_bf16.float() # to compare with reference
+        res_bf16 = res_bf16.float()  # to compare with reference
         self.assertEqual(res_fp32, res_bf16, prec=1e-2)
 
     def test_norm(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -10,7 +10,7 @@ import random
 import sys
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, skipIfRocm, do_test_dtypes, \
-    do_test_empty_full, load_tests, TEST_NUMPY
+    do_test_empty_full, load_tests, TEST_NUMPY, TEST_WITH_ROCM
 from torch.testing._internal.common_cuda import TEST_CUDA
 from numbers import Number
 from torch.autograd.gradcheck import gradcheck
@@ -1077,6 +1077,23 @@ class TestSparse(TestCase):
         self._test_spadd_shape(0, [50, 0, 20], [2, 0])
         self._test_spadd_shape(0, [50, 30, 0], [2, 0])
         self._test_spadd_shape(10, [50, 30, 20], [2, 0])
+
+    @cuda_only
+    @unittest.skipIf(not TEST_WITH_ROCM, "runs only on ROCm")
+    def test_sparse_add_out_bfloat16(self):
+        # fp32
+        x, _, _ = self._gen_sparse(3, 5, 10)
+        y, _, _ = self._gen_sparse(3, 5, 10)
+        x = x.float().cuda()
+        y = y.float().cuda()
+        res_fp32 = torch.add(x, y)
+
+        # bfloat16
+        x = x.bfloat16()
+        y = y.bfloat16()
+        res_bf16 = torch.add(x, y)
+        res_bf16 = res_bf16.float() # to compare with reference
+        self.assertEqual(res_fp32, res_bf16, prec=1e-2)
 
     def test_norm(self):
         def test_shape(sparse_dims, nnz, with_size):


### PR DESCRIPTION
Enables bfloat16 type for add_out of sparse tensors. Also enabled it for coalesce() which is used in unit test reference checking.

@iotamudelta @ezyang 