### PR TITLE
[TensorExpr] Make the way we treat indices in Store/Load and Function consistent.

### DIFF
--- a/test/cpp/tensorexpr/padded_buffer.cpp
+++ b/test/cpp/tensorexpr/padded_buffer.cpp
@@ -20,14 +20,18 @@ PaddedBufferBase::PaddedBufferBase(
     const std::vector<int>& dims,
     const std::string& name)
     : dims_(dims), name_(name), strides_(dims.size()) {
-  for (int i = dims.size() - 1; i >= 0; --i) {
-    if (i == dims.size() - 1) {
-      strides_[i] = 1;
-    } else {
-      strides_[i] = strides_[i + 1] * dims[i + 1];
-    }
+  // stride[0] = 1
+  // stride[i] = stride[i-1]*dims[i-1], i > 0
+  size_t ndim = dims.size();
+  if (!ndim) {
+    total_size_ = 0;
+    return;
   }
-  total_size_ = strides_[0] * dims[0];
+  strides_[0] = 1;
+  for (size_t i = 1; i < ndim; ++i) {
+    strides_[i] = strides_[i - 1] * dims[i - 1];
+  }
+  total_size_ = strides_[ndim - 1] * dims[ndim - 1];
 }
 
 } // namespace tensorexpr

--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -1068,9 +1068,9 @@ void testLLVMBroadcastAdd() {
   std::vector<void*> args({av.data(), bv.data(), cv.data()});
   ASSERT_EQ(cg.value<int>(args), 0);
 
-  for (int i = 0; i < M; i++) {
-    for (int j = 0; j < N; j++) {
-      ASSERT_EQ(cv[i * N + j], av[i * N + j] + bv[j]);
+  for (int j = 0; j < N; j++) {
+    for (int i = 0; i < M; i++) {
+      ASSERT_EQ(cv[j * M + i], av[j * M + i] + bv[j]);
     }
   }
 }

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -57,13 +57,13 @@ void testExprSimple02() {
   auto func = [](const ExprHandle& x, const ExprHandle& y) {
     return ExprHandle(1.0f) + cast<float>(x) * x + cast<float>(y) * y;
   };
-  Tensor* tensor = Compute("f", {{26, "x"}, {5, "y"}}, func);
+  Tensor* tensor = Compute("f", {{5, "x"}, {26, "y"}}, func);
   LoopNest l({tensor});
-  For* x_outer;
-  For* x_inner;
-  For* x_tail;
+  For* y_outer;
+  For* y_inner;
+  For* y_tail;
   std::vector<For*> loops = l.getLoopStmtsFor(tensor);
-  l.splitWithTail(loops[0], 4, &x_outer, &x_inner, &x_tail);
+  l.splitWithTail(loops[1], 4, &y_outer, &y_inner, &y_tail);
 
   Stmt* stmt = l.root_stmt();
   std::ostringstream oss;
@@ -73,29 +73,29 @@ void testExprSimple02() {
 
   {
     // Compare to a reference loop structure structure.
-    VarHandle x_outer("x_outer", kInt);
-    VarHandle x_inner("x_inner", kInt);
-    VarHandle y("y", kInt);
-    VarHandle x_tail("x_tail", kInt);
-    BufHandle f("f", {26, 5});
-    ExprHandle x_1 = x_outer * 4 + x_inner;
-    ExprHandle x_outer_end = (ExprHandle(26) - 0) / 4;
+    VarHandle y_outer("y_outer", kInt);
+    VarHandle y_inner("y_inner", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y_tail("y_tail", kInt);
+    BufHandle f("f", {5, 26});
+    ExprHandle y_1 = y_outer * 4 + y_inner;
+    ExprHandle y_outer_end = (ExprHandle(26) - 0) / 4;
     For* stmt1 = For::make(
-        x_outer,
+        y_outer,
         0,
-        x_outer_end,
+        y_outer_end,
         For::make(
-            x_inner,
+            y_inner,
             0,
             4,
             For::make(
-                y, 0, 5, Store::make(f, {x_1, y}, func(x_1, y), 1))));
-    ExprHandle x_2 = x_tail + x_outer_end * 4;
+                x, 0, 5, Store::make(f, {x, y_1}, func(x, y_1), 1))));
+    ExprHandle y_2 = y_tail + y_outer_end * 4;
     For* stmt2 = For::make(
-        x_tail,
+        y_tail,
         0,
         (ExprHandle(26) - 0) % 4,
-        For::make(y, 0, 5, Store::make(f, {x_2, y}, func(x_2, y), 1)));
+        For::make(x, 0, 5, Store::make(f, {x, y_2}, func(x, y_2), 1)));
     Stmt* stmt = Block::make({stmt1, stmt2});
 
     std::ostringstream oss_ref;
@@ -104,15 +104,15 @@ void testExprSimple02() {
   }
 
   {
-    PaddedBuffer<float> f_v(26, 5, "f_v");
-    PaddedBuffer<float> f_ref(26, 5, "f_res");
+    PaddedBuffer<float> f_v(5, 26, "f_v");
+    PaddedBuffer<float> f_ref(5, 26, "f_res");
 
     stmt = FlattenIndexes(stmt);
     SimpleIREvaluator ir_eval(stmt, tensor);
     ir_eval(f_v);
 
-    for (int x = 0; x < 26; x++) {
-      for (int y = 0; y < 5; y++) {
+    for (int y = 0; y < 26; y++) {
+      for (int x = 0; x < 5; x++) {
         f_ref(x, y) = 1 + x * x + y * y;
       }
     }
@@ -126,13 +126,13 @@ void testExprSplitWithTailNone() {
   auto func = [](const ExprHandle& x, const ExprHandle& y) {
     return ExprHandle(1.0f) + cast<float>(x) * x + cast<float>(y) * y;
   };
-  Tensor* tensor = Compute("f", {{24, "x"}, {5, "y"}}, func);
+  Tensor* tensor = Compute("f", {{5, "x"}, {24, "y"}}, func);
   LoopNest l({tensor});
-  For* x_outer;
-  For* x_inner;
-  For* x_tail;
+  For* y_outer;
+  For* y_inner;
+  For* y_tail;
   std::vector<For*> loops = l.getLoopStmtsFor(tensor);
-  l.splitWithTail(loops[0], 4, &x_outer, &x_inner, &x_tail);
+  l.splitWithTail(loops[1], 4, &y_outer, &y_inner, &y_tail);
 
   Stmt* stmt = l.root_stmt();
   std::ostringstream oss;
@@ -142,23 +142,23 @@ void testExprSplitWithTailNone() {
 
   {
     // Compare to a reference loop structure structure.
-    VarHandle x_outer("x_outer", kInt);
-    VarHandle x_inner("x_inner", kInt);
-    VarHandle y("y", kInt);
-    VarHandle x_tail("x_tail", kInt);
-    BufHandle f("f", {24, 5});
-    ExprHandle x_1 = x_outer * 4 + x_inner;
-    ExprHandle x_outer_end = (ExprHandle(24) - 0) / 4;
+    VarHandle y_outer("y_outer", kInt);
+    VarHandle y_inner("y_inner", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y_tail("y_tail", kInt);
+    BufHandle f("f", {5, 24});
+    ExprHandle y_1 = y_outer * 4 + y_inner;
+    ExprHandle y_outer_end = (ExprHandle(24) - 0) / 4;
     For* stmt = For::make(
-        x_outer,
+        y_outer,
         0,
-        x_outer_end,
+        y_outer_end,
         For::make(
-            x_inner,
+            y_inner,
             0,
             4,
             For::make(
-                y, 0, 5, Store::make(f, {x_1, y}, func(x_1, y), 1))));
+                x, 0, 5, Store::make(f, {x, y_1}, func(x, y_1), 1))));
 
     std::ostringstream oss_ref;
     oss_ref << *stmt;
@@ -167,14 +167,14 @@ void testExprSplitWithTailNone() {
   }
 
   {
-    PaddedBuffer<float> f_v(24, 5, "f_v");
-    PaddedBuffer<float> f_ref(24, 5, "f_res");
+    PaddedBuffer<float> f_v(5, 24, "f_v");
+    PaddedBuffer<float> f_ref(5, 24, "f_res");
 
     SimpleIREvaluator ir_eval(stmt, tensor);
     ir_eval(f_v);
 
-    for (int x = 0; x < 24; x++) {
-      for (int y = 0; y < 5; y++) {
+    for (int y = 0; y < 24; y++) {
+      for (int x = 0; x < 5; x++) {
         f_ref(x, y) = 1 + x * x + y * y;
       }
     }

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -173,11 +173,11 @@ const Expr* flatten_index(
     return new IntImm(0);
   }
   std::vector<const Expr*> strides(ndim);
-  // stride[i] = stride[i+1]*dims[i+1], i < ndim-1
-  // stride[i] = 1,                     i = ndim-1
-  strides[ndim - 1] = new IntImm(1);
+  // stride[0] = 1,
+  // stride[i] = stride[i-1]*dims[i-1], i > 0
+  strides[0] = new IntImm(1);
   for (size_t i = 1; i < ndim; i++) {
-    strides[ndim - 1 - i] = new Mul(strides[ndim - i], dims[ndim - i]);
+    strides[i] = new Mul(strides[i - 1], dims[i - 1]);
   }
 
   const Expr* total_index = new IntImm(0);

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -685,15 +685,8 @@ Stmt* LoopNest::lowerToStmt(Tensor* t) {
     return body;
   }
 
-  if (t->buf()->ndim() == 0) {
-    throw malformed_input();
-  }
-
   for (size_t i = 0; i < t->buf()->ndim(); i++) {
-    // Going in reverse order: from innermost loop to the outermost
-    size_t dim_index = t->buf()->ndim() - i - 1;
-    Range r(new IntImm(0), t->buf()->dim(dim_index));
-    body = new For(f->arg(dim_index), r.start(), r.stop(), body);
+    body = new For(f->arg(i), new IntImm(0), t->buf()->dim(i), body);
   }
   return body;
 }
@@ -891,7 +884,7 @@ std::vector<For*> LoopNest::getLoopStmtsFor(Tensor* t) const {
     }
     cur_stmt = cur_stmt->get_parent();
   }
-  return std::vector<For*>(result.rbegin(), result.rend());
+  return result;
 }
 
 void LoopNest::setGPUBlockIndex(For* f, int block_index) {

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -27,6 +27,11 @@ class TORCH_API LoopNest {
     return root_stmt_;
   }
 
+  /*
+   * Return a vector of `For` statements enclosing the compute statement
+   * corresponding to the given `Tensor`. The `For` statements are ordered inner
+   * to outer.
+   */
   std::vector<For*> getLoopStmtsFor(Tensor*) const;
   Stmt* getLoopBodyFor(Tensor*) const;
   bool hasLoopBodyFor(Tensor*) const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #35120 [NOT READY][TensorExpr] Bounds inference
* **#35981 [TensorExpr] Make the way we treat indices in Store/Load and Function consistent.**

With this change the first index/dimension/parameter always corresponds
to the innermost loop when lowered to a loopnest.

Differential Revision: [D20848239](https://our.internmc.facebook.com/intern/diff/D20848239)