### PR TITLE
Mark prim::rpc_async as having side effect

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1046,6 +1046,7 @@ bool Node::hasSideEffects() const {
     case prim::profile:
     case prim::BailOut:
     case prim::Guard:
+    case prim::rpc_async: // It represents RPC message sent.
     case aten::wait: // It can represent RPC message received.
       return true;
   }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#35994 Mark prim::rpc_async as having side effect**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D7850846/)

prim::rpc_async was optimized out if we don't takes its returned future and wait on the future.

Differential Revision: [D7850846](https://our.internmc.facebook.com/intern/diff/D7850846/)