### PR TITLE
[TEST] [1.5 cherrypick] #35959 Fix handling of non-finite values in topk

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -169,7 +169,8 @@ if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
   # the build process, leaving undefined symbols in the shared lib
   # which will cause undefined symbol errors when later running
   # tests. Setting MAX_JOBS to smaller number to make CI less flaky.
-  export MAX_JOBS=1
+  export MAX_JOBS=4
+  export SCCACHE_RECACHE=1
 
   ########## HIPIFY Caffe2 operators
   ${PYTHON} "${ROOT_DIR}/tools/amd_build/build_amd.py"

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -249,6 +249,8 @@ else
 
   $PYTHON setup.py install --user
 
+  ls -l /var/lib/jenkins/workspace/build/caffe2/CMakeFiles/torch_hip.dir/__/aten/src/THH/
+
   report_compile_cache_stats
 fi
 

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -169,7 +169,7 @@ if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
   # the build process, leaving undefined symbols in the shared lib
   # which will cause undefined symbol errors when later running
   # tests. Setting MAX_JOBS to smaller number to make CI less flaky.
-  export MAX_JOBS=4
+  export MAX_JOBS=1
 
   ########## HIPIFY Caffe2 operators
   ${PYTHON} "${ROOT_DIR}/tools/amd_build/build_amd.py"

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12531,6 +12531,19 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(top1, top2)
         self.assertEqual(idx1, idx2)
 
+    def test_topk_nonfinite(self, device):
+        for dtype in (torch.float, torch.double):
+            x = torch.tensor([float('nan'), float('inf'), 1e10, 0, -1e10, -float('inf')], device=device)
+            val, idx = x.topk(4)
+            expect = torch.tensor([float('nan'), float('inf'), 1e10, 0], device=device)
+            self.assertEqual(val, expect, allow_inf=True)
+            self.assertEqual(idx, [0, 1, 2, 3])
+
+            val, idx = x.topk(4, largest=False)
+            expect = torch.tensor([-float('inf'), -1e10, 0, 1e10], device=device)
+            self.assertEqual(val, expect, allow_inf=True)
+            self.assertEqual(idx, [5, 4, 3, 2])
+
     def test_is_signed(self, device):
         self.assertEqual(torch.IntTensor(5).to(device).is_signed(), True)
         self.assertEqual(torch.ByteTensor(5).to(device).is_signed(), False)


### PR DESCRIPTION
Experiment plan:
1. Try changing Caffe2 ROCm build MAX_JOBS to 1, see what happens
  Result: same error as `MAX_JOBS=4`.
2. Try using `SCCACHE_RECACHE=1` (https://github.com/mozilla/sccache/issues/639#issuecomment-574364665), see what happens