### PR TITLE
[caffe2] Factor libtorch_python_sources into exposed definition

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -324,12 +324,10 @@ libtorch_python_cuda_sources = [
     "torch/csrc/distributed/c10d/ddp.cpp",
 ]
 
-def add_torch_libs():
-    r = {}
+def glob_libtorch_python_sources():
 
-    torch_cpp_headers = native.glob(["torch/csrc/api/include/**/*.h"]) + ["torch/script.h"]
 
-    libtorch_python_sources = [
+    _libtorch_python_sources = [
         ":generate-code=autograd/generated/python_functions.cpp",
         ":generate-code=autograd/generated/python_nn_functions.cpp",
         ":generate-code=autograd/generated/python_torch_functions.cpp",
@@ -426,7 +424,7 @@ def add_torch_libs():
         "test/cpp/tensorexpr/padded_buffer.cpp",
     ]
 
-    libtorch_python_sources.extend([
+    _libtorch_python_sources.extend([
         "test/cpp/jit/test_alias_analysis.cpp",
         "test/cpp/jit/test_argument_spec.cpp",
         "test/cpp/jit/test_autodiff.cpp",
@@ -463,7 +461,16 @@ def add_torch_libs():
         "test/cpp/jit/test_utils.cpp",
     ])
 
-    libtorch_python_sources.extend(native.glob(["test/cpp/tensorexpr/test_*.cpp"]))
+    _libtorch_python_sources.extend(native.glob(["test/cpp/tensorexpr/test_*.cpp"]))
+
+    return _libtorch_python_sources
+
+
+def add_torch_libs():
+    r = {}
+
+    torch_cpp_headers = native.glob(["torch/csrc/api/include/**/*.h"]) + ["torch/script.h"]
+    libtorch_python_sources = glob_libtorch_python_sources()
 
     compiler_flags_cpu = [
         "-DUSE_C10D",


### PR DESCRIPTION
Summary:
Getting ovrsource pytorch working, requires single source list across ovrsource and fbsource to avoid build failures every time the source list changes.
This diff factors out libtorch_python_sources into a separate function (needs to be function because it uses glob which is disallowed at global scope)

Test Plan: CI

Differential Revision: D20852072

