### PR TITLE
Disable tracing for Pytorch Mobile client

### DIFF
--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -190,7 +190,7 @@ def load_deprecated_signatures(aten_decls, deprecated_path):
     return declarations
 
 
-def gen_autograd(aten_path, out, autograd_dir, disable_autograd=False, disable_trace=False):
+def gen_autograd(aten_path, out, autograd_dir, disable_autograd=False):
     aten_decls = load_aten_declarations(aten_path)
 
     # Parse and load derivatives.yaml
@@ -203,7 +203,7 @@ def gen_autograd(aten_path, out, autograd_dir, disable_autograd=False, disable_t
     # Generate VariableType.h/cpp
     if not disable_autograd:
         from .gen_variable_type import gen_variable_type
-        gen_variable_type(out, aten_decls, template_path, disable_trace)
+        gen_variable_type(out, aten_decls, template_path)
 
     # Generate Functions.h/cpp
     from .gen_autograd_functions import gen_autograd_functions_lib
@@ -213,8 +213,7 @@ def gen_autograd(aten_path, out, autograd_dir, disable_autograd=False, disable_t
     # Generate variable_factories.h
     from .gen_variable_factories import gen_variable_factories
     gen_variable_factories(
-        out, aten_decls, template_path, disable_autograd=disable_autograd,
-        disable_trace=disable_trace)
+        out, aten_decls, template_path, disable_autograd=disable_autograd)
 
 
 def gen_autograd_python(aten_path, out, autograd_dir):

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -42,7 +42,7 @@ def fully_qualified_type(argument_type):
     return maybe_optional_type(qualified_type, opt_match)
 
 
-def gen_variable_factories(out, declarations, template_path, disable_autograd=False, disable_trace=False):
+def gen_variable_factories(out, declarations, template_path, disable_autograd=False):
     function_definitions = []
     for decl in declarations:
         has_tensor_options = any(a["simple_type"] == "TensorOptions" for a in decl["arguments"])
@@ -53,7 +53,6 @@ def gen_variable_factories(out, declarations, template_path, disable_autograd=Fa
                     decl,
                     has_tensor_options,
                     disable_autograd=disable_autograd,
-                    disable_trace=disable_trace
                 )
             )
     write(out,
@@ -62,7 +61,7 @@ def gen_variable_factories(out, declarations, template_path, disable_autograd=Fa
           {"function_definitions": function_definitions})
 
 
-def process_function(decl, has_tensor_options, disable_autograd, disable_trace):
+def process_function(decl, has_tensor_options, disable_autograd):
     formals = []
     actuals = []
     for argument in decl["arguments"]:
@@ -76,7 +75,7 @@ def process_function(decl, has_tensor_options, disable_autograd, disable_trace):
     requires_grad = "options.requires_grad()" if has_tensor_options else "false"
 
     if not disable_autograd:
-        pre_record_trace, post_record_trace = format_trace(decl, disable_trace)
+        pre_record_trace, post_record_trace = format_trace(decl)
     else:
         pre_record_trace, post_record_trace = '', ''
 

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -25,8 +25,7 @@ def generate_code(ninja_global=None,
                   install_dir=None,
                   subset=None,
                   disable_autograd=False,
-                  selected_op_list_path=None,
-                  disable_trace=False):
+                  selected_op_list_path=None):
     # cwrap depends on pyyaml, so we can't import it earlier
     root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     sys.path.insert(0, root)
@@ -54,7 +53,6 @@ def generate_code(ninja_global=None,
             autograd_gen_dir,
             autograd_dir,
             disable_autograd=disable_autograd,
-            disable_trace=disable_trace,
         )
         gen_jit_dispatch(
             declarations_path or DECLARATIONS_PATH,
@@ -84,12 +82,6 @@ def main():
         '--selected-op-list-path',
         help='Path to the yaml file that contains the list of operators to include for custom build.',
     )
-    parser.add_argument(
-        '--disable_gen_tracing',
-        default=False,
-        action='store_true',
-        help='Disable generating the tracing codes.',
-    )
     options = parser.parse_args()
     generate_code(
         options.ninja_global,
@@ -99,7 +91,6 @@ def main():
         options.subset,
         options.disable_autograd,
         options.selected_op_list_path,
-        options.disable_gen_tracing,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36007 Disable tracing for Pytorch Mobile client**

Tracing is not needed in Pytorch Mobile client. Disabling it has a couple of benefits:
1. It's a pre-requisite to build lite interpreter.
2. It saves the code size for full jit and Federated learning (around 600k).

Solution: use PYTORCH_DISABLE_TRACING to disable it. By default it's turned off. It's turned on only when building lite interpreter for internal usage. It's better than passing an argument to code-gen because:
1. It's a single-point change in the code template for both VariableType and VariableFactories.
2. code-gen does not handle VariableTypeManual.cpp. The macro is need there anyway.

Differential Revision: [D20852558](https://our.internmc.facebook.com/intern/diff/D20852558/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D20852558/)!