### PR TITLE
Log error in setErrorIfNeeded

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -944,6 +944,12 @@ void Engine::mark_graph_task_completed(const std::shared_ptr<GraphTask>& graph_t
     graph_task->future_result_->markCompleted(
         std::move(graph_task->captured_vars_));
   } catch (std::exception& e) {
+    // If the callbacks (triggered by markCompleted) throw an exception, just
+    // propagate it further. If we don't do this, setErrorIfNeeded would just
+    // swallow the exception since the future is marked as completed.
+    if (graph_task->future_result_->completed()) {
+      std::rethrow_exception(std::current_exception());
+    }
     graph_task->future_result_->setErrorIfNeeded(e.what());
   }
 }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -944,12 +944,6 @@ void Engine::mark_graph_task_completed(const std::shared_ptr<GraphTask>& graph_t
     graph_task->future_result_->markCompleted(
         std::move(graph_task->captured_vars_));
   } catch (std::exception& e) {
-    // If the callbacks (triggered by markCompleted) throw an exception, just
-    // propagate it further. If we don't do this, setErrorIfNeeded would just
-    // swallow the exception since the future is marked as completed.
-    if (graph_task->future_result_->completed()) {
-      std::rethrow_exception(std::current_exception());
-    }
     graph_task->future_result_->setErrorIfNeeded(e.what());
   }
 }

--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -83,7 +83,8 @@ class TORCH_API Future final {
   void setErrorIfNeeded(std::string errorMsg) {
     std::unique_lock<std::mutex> lock(mutex_);
     if (completed_) {
-      // This should be rare and shouldn't cause log spew. Its important to log errors and thats why we have this log here.
+      // This should be rare and shouldn't cause log spew. Its important to
+      // log errors and thats why we have this log here.
       LOG (INFO) << "Skipping setting following error on the Future since " <<
         "it is already marked completed (this is not neccessarily an error): "
         << errorMsg;

--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -83,6 +83,10 @@ class TORCH_API Future final {
   void setErrorIfNeeded(std::string errorMsg) {
     std::unique_lock<std::mutex> lock(mutex_);
     if (completed_) {
+      // This should be rare and shouldn't cause log spew. Its important to log errors and thats why we have this log here.
+      LOG (INFO) << "Skipping setting following error on the Future since " <<
+        "it is already marked completed (this is not neccessarily an error): "
+        << errorMsg;
       return;
     } else {
       setErrorInternal(std::move(errorMsg), lock);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36019 Appropriately handle exceptions in autograd engine.**

Once the autograd engine is finished with a GraphTask it would call
`markCompleted` on the Future. This could trigger callbacks on the Future that
could throw exceptions.

If one of the callbacks did throw an exception, we would call setErrorIfNeeded,
which would be no-op since the Future is already marked as completed. This
would effectively mean we would be swallowing exceptions. To avoid this in `setErrorIfNeeded`, we log the error if we are ignoring it.

Differential Revision: [D20854806](https://our.internmc.facebook.com/intern/diff/D20854806/)