### PR TITLE
Prevent unbounded growth of sparse tensor in add operation

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -512,6 +512,13 @@ SparseTensor& add_out_sparse_non_contiguous(SparseTensor& r, const SparseTensor&
     Tensor r_values = at::cat({t_values, s_values}, 0).to(r.scalar_type());
     alias_into_sparse(r, r_indices, r_values);
 
+    // Prevent unbounded growth of nnz
+    // TODO: Improved heuristic on when to coalesce or remove need to coalesce
+    if (r._nnz() > r.numel()) {
+      auto c = r.coalesce();
+      alias_into_sparse(r, c._indices(), c._values());
+    }
+
     return r;
 }
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -467,13 +467,12 @@ SparseTensor& add_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t, const
 
   alias_into_sparse(r_, r_indices_, r_values_);
 
-  // FIXME: add some heuristic about when to call coalesce() here, so that
-  // tensors don't totally blow up in size by concatenation; e.g.
-  //   r->minUnique = max(a->minUnique + b->minUnique);
-  //   if (r->nnz / r->minUnique > COMPACTION_THRESHOLD) {
-  //     THCSTensor_(contiguous)(r);
-  //     r->minUnique = r->nnz;
-  //   }
+  // Prevent unbounded growth of nnz
+  // TODO: Improved heuristic on when to coalesce or remove need to coalesce
+  if (r_._nnz() > r_.numel()) {
+    auto c = r_.coalesce();
+    alias_into_sparse(r_, c._indices(), c._values());
+  }
 
   return r_;
 }

--- a/test/expect/TestCudaSparse.test_print.expect
+++ b/test/expect/TestCudaSparse.test_print.expect
@@ -25,9 +25,9 @@ tensor(indices=tensor([], size=(0, 2)),
        device='cuda:0', size=(), nnz=2, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 4)),
-       values=tensor([0., 1., 0., 1.]),
-       device='cuda:0', size=(), nnz=4, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([2.]),
+       device='cuda:0', size=(), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 2), dtype=torch.int64)
@@ -61,9 +61,9 @@ tensor(indices=tensor([], size=(0, 10)),
        device='cuda:0', size=(0,), nnz=10, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 20)),
-       values=tensor([], size=(20, 0)),
-       device='cuda:0', size=(0,), nnz=20, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([], size=(1, 0)),
+       device='cuda:0', size=(0,), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 10), dtype=torch.int64)
@@ -105,14 +105,9 @@ tensor(indices=tensor([], size=(0, 3)),
        device='cuda:0', size=(2,), nnz=3, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 6)),
-       values=tensor([[0.0000, 0.3333],
-                      [0.6667, 1.0000],
-                      [1.3333, 1.6667],
-                      [0.0000, 0.3333],
-                      [0.6667, 1.0000],
-                      [1.3333, 1.6667]]),
-       device='cuda:0', size=(2,), nnz=6, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([[4.0000, 6.0000]]),
+       device='cuda:0', size=(2,), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)
@@ -235,9 +230,9 @@ tensor(indices=tensor([], size=(0, 3)),
        device='cuda:0', size=(10, 0, 3), nnz=3, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 6)),
-       values=tensor([], size=(6, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=6, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([], size=(1, 10, 0, 3)),
+       device='cuda:0', size=(10, 0, 3), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)

--- a/test/expect/TestCudaUncoalescedSparse.test_print.expect
+++ b/test/expect/TestCudaUncoalescedSparse.test_print.expect
@@ -25,9 +25,9 @@ tensor(indices=tensor([], size=(0, 2)),
        device='cuda:0', size=(), nnz=2, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 4)),
-       values=tensor([0., 1., 0., 1.]),
-       device='cuda:0', size=(), nnz=4, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([2.]),
+       device='cuda:0', size=(), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 2), dtype=torch.int64)
@@ -61,9 +61,9 @@ tensor(indices=tensor([], size=(0, 10)),
        device='cuda:0', size=(0,), nnz=10, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 20)),
-       values=tensor([], size=(20, 0)),
-       device='cuda:0', size=(0,), nnz=20, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([], size=(1, 0)),
+       device='cuda:0', size=(0,), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 10), dtype=torch.int64)
@@ -105,14 +105,9 @@ tensor(indices=tensor([], size=(0, 3)),
        device='cuda:0', size=(2,), nnz=3, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 6)),
-       values=tensor([[0.0000, 0.3333],
-                      [0.6667, 1.0000],
-                      [1.3333, 1.6667],
-                      [0.0000, 0.3333],
-                      [0.6667, 1.0000],
-                      [1.3333, 1.6667]]),
-       device='cuda:0', size=(2,), nnz=6, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([[4.0000, 6.0000]]),
+       device='cuda:0', size=(2,), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)
@@ -235,9 +230,9 @@ tensor(indices=tensor([], size=(0, 3)),
        device='cuda:0', size=(10, 0, 3), nnz=3, dtype=torch.float32,
        layout=torch.sparse_coo, requires_grad=True)
 # after addition
-tensor(indices=tensor([], size=(0, 6)),
-       values=tensor([], size=(6, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=6, dtype=torch.float32,
+tensor(indices=tensor([], size=(0, 1)),
+       values=tensor([], size=(1, 10, 0, 3)),
+       device='cuda:0', size=(10, 0, 3), nnz=1, dtype=torch.float32,
        layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -758,6 +758,17 @@ class TestSparse(TestCase):
         test_shape(2, 20, [3, 17, 19, 5])
         test_shape(2, 20, [3, 17, 19, 0])
 
+    def test_add_sub_nnz(self):
+        # nnz should not grow unbounded (gh-34964)
+        x = torch.randn(10, device=self.device).to_sparse()
+        x.add_(x)
+        x.add_(x)
+        self.assertLessEqual(x._nnz(), 10)
+
+        x.sub_(2 * x)
+        x.sub_(2 * x)
+        self.assertLessEqual(x._nnz(), 10)
+
     def test_cat(self):
         # shapes: list of tuples (sparse_dims, nnz, sizes)
         def test_shapes(shapes, dim, fail_message=None):


### PR DESCRIPTION
Fixes #34964

Sparse cuda add was implemented by just concatenating the indices and values for the tensor. If called repeatedly in a tight loop this will let `nnz` grow unbounded. In the worst case of  `x.add_(x)` it grows exponentially.