### PR TITLE
[pytorch] Fix the extra_repr print message for float16 dynamic quantization

### DIFF
--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -51,9 +51,12 @@ class Linear(nnq.Linear):
         return 'DynamicQuantizedLinear'
 
     def extra_repr(self):
-        return 'in_features={}, out_features={}, qscheme={}'.format(
-            self.in_features, self.out_features, self.weight().qscheme()
+        extra_repr_str = 'in_features={}, out_features={}, dtype={}'.format(
+            self.in_features, self.out_features, self._packed_params.dtype
         )
+        if self._packed_params.dtype == torch.qint8:
+            extra_repr_str += ', qscheme={}'.format(self.weight().qscheme())
+        return extra_repr_str
 
     @classmethod
     def from_float(cls, mod):


### PR DESCRIPTION
When applying the float16 dynamic quantization with
```
        model = torch.quantization.quantize_dynamic(
            model, {torch.nn.Linear}, dtype=torch.float16
        )
        print(model)
```
there is an issue when we try to print the model. Basically we cannot print the `qscheme` information for float16 weight (It is not per-tensor or per-channel quantization defined for int8 dynamic quantization).

Before this PR:
```
Traceback (most recent call last):
  File "dlrm_s_pytorch.py", line 860, in <module>
    print(dlrm)
  File "/home/jianyuhuang/miniconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1142, in __repr__
    mod_str = repr(module)
  File "/home/jianyuhuang/miniconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1142, in __repr__
    mod_str = repr(module)
  File "/home/jianyuhuang/miniconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1136, in __repr__
    extra_repr = self.extra_repr()
  File "/home/jianyuhuang/miniconda3/lib/python3.7/site-packages/torch/nn/quantized/dynamic/modules/linear.py", line 55, in extra_repr
    self.in_features, self.out_features, self.weight().qscheme()
RuntimeError: Could not run 'aten::qscheme' with arguments from the 'CPUTensorId' backend. 'aten::qscheme' is only available for these back
ends: [QuantizedCPUTensorId, VariableTensorId].
```

After this PR:
```
    (4): DynamicQuantizedLinear(
      in_features=2, out_features=1, dtype=torch.float16
      (_packed_params): LinearPackedParams()
    )
```
