### PR TITLE
[ROCm] Hotfix: Black list tensorexpr test set that has failures on ROCm

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -126,6 +126,7 @@ ROCM_BLACKLIST = [
     'test_jit_simple',
     'test_jit_legacy',
     'test_jit_fuser_legacy',
+    'test_tensorexpr',
 ]
 
 # These tests are slow enough that it's worth calculating whether the patch


### PR DESCRIPTION
Test set got enabled with ROCm failures in https://github.com/pytorch/pytorch/pull/35914 - black list it for now.