### PR TITLE
Pin Sphinx to 2.4.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==2.4.4
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36065 Pin Sphinx to 2.4.4**

Latest version is incompatible with javasphinx

See also https://github.com/pytorch/pytorch/issues/36064

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20870442](https://our.internmc.facebook.com/intern/diff/D20870442)