### PR TITLE
Revert "Reenable test/test_tensorexpr.py (#35914)"

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -76,7 +76,6 @@ TESTS = [
     'test_function_schema',
     'test_overrides',
     'test_jit_fuser_te',
-    'test_tensorexpr',
 ]
 
 # skip < 3.3 because mock is added in 3.3 and is used in rpc_spawn

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -60,7 +60,7 @@ class TestFuser(JitTestCase):
         self.old_profiling_executor = torch._C._jit_set_profiling_executor(True)
         self.old_profiling_mode = torch._C._jit_set_profiling_mode(True)
 
-        torch._C._jit_set_texpr_fuser_enabled(True)
+        torch._C._jit_register_tensorexpr_fuser()
 
         if GRAPH_EXECUTOR != ProfilingMode.PROFILING:
             torch._C._jit_set_profiling_executor(self.old_profiling_executor)
@@ -73,7 +73,7 @@ class TestFuser(JitTestCase):
         torch._C._jit_override_can_fuse_on_gpu(self.old_gpu_fuser_state)
         torch._C._jit_override_can_fuse_on_cpu(self.old_cpu_fuser_state)
 
-        torch._C._jit_set_texpr_fuser_enabled(False)
+        torch._C._jit_clear_tensorexpr_fuser()
 
     def assertAllFused(self, graph, except_for=()):
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -13,22 +13,6 @@
 namespace torch {
 namespace jit {
 
-static bool texpr_fuser_enabled_ = false;
-void setTensorExprFuserEnabled(bool val) {
-  texpr_fuser_enabled_ = val;
-}
-
-static bool tensorExprFuserEnabled() {
-  static const char* enable_c_str = std::getenv("PYTORCH_TENSOREXPR");
-  if (!enable_c_str) {
-    return texpr_fuser_enabled_;
-  }
-  if (std::string(enable_c_str) == "0") {
-    return false;
-  }
-  return true;
-}
-
 const Symbol& getTensorExprSymbol() {
   static Symbol s = Symbol::fromQualString("tensorexpr::Group");
   return s;
@@ -266,9 +250,6 @@ std::pair<graph_node_list::iterator, bool> scanNode(
 }
 
 void fuseTensorExprs(std::shared_ptr<Graph>& graph) {
-  if (!tensorExprFuserEnabled()) {
-    return;
-  }
   GRAPH_DUMP("Before TExprFuser: ", graph);
 
   // Get rid of dead code so that we don't waste effort fusing it.

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -12,7 +12,15 @@ struct Graph;
 // Run TensorExpressions-based fuser.
 TORCH_API void fuseTensorExprs(std::shared_ptr<Graph>& graph);
 
-TORCH_API void setTensorExprFuserEnabled(bool val);
+struct TORCH_API RegisterTensorExprFuser
+    : public PassManager<RegisterTensorExprFuser> {
+  static void registerPass() {
+    PassManager::registerPass(fuseTensorExprs);
+  }
+  static void clearPass() {
+    PassManager::clearPass();
+  }
+};
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -379,6 +379,10 @@ void initJITBindings(PyObject* module) {
       .def("_jit_can_fuse_on_gpu", &canFuseOnGPU)
       .def("_jit_override_can_fuse_on_cpu", &overrideCanFuseOnCPU)
       .def("_jit_override_can_fuse_on_gpu", &overrideCanFuseOnGPU)
+      .def(
+          "_jit_register_tensorexpr_fuser",
+          &RegisterTensorExprFuser::registerPass)
+      .def("_jit_clear_tensorexpr_fuser", &RegisterTensorExprFuser::clearPass)
       .def("_jit_can_fuse_on_cpu", &canFuseOnCPU)
       .def("_jit_can_fuse_on_gpu", &canFuseOnGPU)
       .def(
@@ -487,7 +491,6 @@ void initJITBindings(PyObject* module) {
             using namespace torch::jit::tensorexpr;
             return getTECudaPointwiseBlockSize() = block_size;
           })
-      .def("_jit_set_texpr_fuser_enabled", &setTensorExprFuserEnabled)
       .def(
           "_jit_fuser_get_fused_kernel_code",
           [](Graph& g, std::vector<at::Tensor> inps) {

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -28,7 +28,6 @@
 #include <torch/csrc/jit/passes/requires_grad_analysis.h>
 #include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/passes/specialize_autogradzero.h>
-#include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/resource_guard.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
 #include <torch/csrc/jit/runtime/autodiff.h>
@@ -772,8 +771,6 @@ void runNondiffOptimization(
   QuantFusion(graph);
 
   FuseGraph(graph, strict_fuser_check);
-
-  fuseTensorExprs(graph);
 
   // Run custom post-fusion passes
   for (const auto& passPair : getCustomPostPasses()) {

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -6,8 +6,6 @@
 
 #include <c10/macros/Macros.h>
 #include <c10/util/Logging.h>
-#include <c10/util/math_compat.h>
-#include <c10/util/string_utils.h>
 #include <torch/csrc/jit/tensorexpr/buffer.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
 #include <torch/csrc/jit/tensorexpr/exceptions.h>
@@ -794,7 +792,7 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
         float intpart;
         return std::modf(v, &intpart);
       default:
-        throw std::runtime_error("Invalid op_type: " + c10::to_string(op_type));
+        throw std::runtime_error("invalid op_type: " + std::to_string(op_type));
     }
   }
 
@@ -805,11 +803,11 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
       case kFmod:
         return std::fmod(v1, v2);
       case kRemainder:
-        return std::remainder(v1, v2);
+        return std::remainderf(v1, v2);
       case kAtan2:
         return std::atan2(v1, v2);
       default:
-        throw std::runtime_error("Invalid op_type: " + c10::to_string(op_type));
+        throw std::runtime_error("nvalid op_type: " + std::to_string(op_type));
     }
   }
 

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -74,7 +74,7 @@ class TORCH_API HashProvider : public IRVisitor {
   void visit(const Xor* v) override;
   void visit(const Lshift* v) override;
   void visit(const Rshift* v) override;
-  void visit(const CompareSelect* v) override;
+  void visit(const CompareSelect* v);
 
 // NOLINTNEXTLINE
 #define IMM_VISIT(Type, Name)                    \

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -245,7 +245,7 @@ int Intrinsics::OpArgCount(IntrinsicsOp op_type) {
     case kRemainder:
       return 2;
     default:
-      throw std::runtime_error("invalid op_type: " + c10::to_string(op_type));
+      throw std::runtime_error("invalid op_type: " + std::to_string(op_type));
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 
-#include <c10/util/string_utils.h>
 #include <torch/csrc/jit/tensorexpr/exceptions.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/stmt.h>
@@ -801,7 +800,7 @@ class Intrinsics : public CallNode<Intrinsics> {
         return "frac";
       default:
         throw std::runtime_error(
-            "invalid op_type: " + c10::to_string(op_type()));
+            "invalid op_type: " + std::to_string(op_type()));
     }
   }
   using BaseClass = CallNode<Intrinsics>;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -371,10 +371,10 @@ class TORCH_API TermExpander : public IRMutator {
   const Expr* factorizePolynomial(const Polynomial* poly);
 
   // Expand Polynomials out to a series of Adds.
-  const Expr* mutate(const Polynomial* v) override;
+  const Expr* mutate(const Polynomial* v);
 
   // Expand RoundOff to it's component: Mul(Div(lhs, rhs), rhs).
-  const Expr* mutate(const RoundOff* v) override;
+  const Expr* mutate(const RoundOff* v);
 };
 
 class TORCH_API IRSimplifier {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1,6 +1,5 @@
 #include <torch/csrc/jit/tensorexpr/kernel.h>
 
-#include <c10/util/string_utils.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
@@ -55,7 +54,7 @@ static std::vector<DimArg> texprDims(const torch::jit::Value* v) {
   std::vector<DimArg> dimArgs;
   int i = 0;
   for (auto const& s : texprSizes(tt->sizes())) {
-    dimArgs.emplace_back(DimArg(s, "i" + c10::to_string(i++)));
+    dimArgs.emplace_back(DimArg(s, "i" + std::to_string(i++)));
   }
   return dimArgs;
 }
@@ -1045,7 +1044,7 @@ void TensorExprKernel::lowerToBackend(BackendType backendType) {
         l.setGPUThreadIndex(inner2, 0);
       } else {
         throw std::runtime_error(
-            "Invalid loop-level: " + c10::to_string(loopLevels));
+            "Invalid loop-level: " + std::to_string(loopLevels));
       }
     }
   } else if (backendType == kLLVMCodeGen) {
@@ -1148,7 +1147,7 @@ void TensorExprKernel::lowerToBackend(BackendType backendType) {
     default:
       throw std::runtime_error(
           "invalid backend type: " +
-          c10::to_string(static_cast<int>(backendType_)));
+          std::to_string(static_cast<int>(backendType_)));
   }
 
   codegenCache_.emplace(
@@ -1276,8 +1275,8 @@ void TensorExprKernel::pickAndCheckBackendType(
     // TODO: if we have to support muliptole backends with the same subgraph,
     // we need to add kernel caching.
     throw std::runtime_error(
-        "Inconsistent backendType: " + c10::to_string(backendType_) + " vs " +
-        c10::to_string(backendType));
+        "Inconsistent backendType: " + std::to_string(backendType_) + " vs " +
+        std::to_string(backendType));
   }
 }
 
@@ -1291,7 +1290,7 @@ void TensorExprKernel::codeGenRun(
       break;
     default:
       throw std::runtime_error(
-          "Invalid backend type: " + c10::to_string(backendType_));
+          "Invalid backend type: " + std::to_string(backendType_));
   }
 }
 
@@ -1320,7 +1319,7 @@ ExprHandle TensorExprKernel::createInputIndexExpr(
     // For discontiguous tensors, create a parameter to represent stride.
     if (!*contiguity[i]) {
       VarHandle v = VarHandle{
-          "stride_" + buffer.data()->name_hint() + "_" + c10::to_string(i),
+          "stride_" + buffer.data()->name_hint() + "_" + std::to_string(i),
           kInt};
       strideArgs.emplace_back(n - i, v);
       stride = v;
@@ -1365,14 +1364,14 @@ void TensorExprKernel::bindInput(const torch::jit::Value* input) {
         auto const& size = *tt->sizes()[i];
         if (size < 0) {
           VarHandle v(
-              "size_" + c10::to_string(input->unique()) + "_" +
-                  c10::to_string(i),
+              "size_" + std::to_string(input->unique()) + "_" +
+                  std::to_string(i),
               kInt);
           sizeVars.emplace(size, v);
           inputTensorDims.emplace_back(v);
         } else {
           inputTensorDims.emplace_back(
-              DimArg(IntImm::make(size), "i" + c10::to_string(i)));
+              DimArg(IntImm::make(size), "i" + std::to_string(i)));
         }
       }
 #ifdef DYNAMIC_SHAPES

--- a/torch/csrc/jit/tensorexpr/mem_arena.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_arena.cpp
@@ -21,6 +21,11 @@ KernelScopedObject::KernelScopedObject() {
   kernel->kernel_objects_.push_back(this);
 }
 
+static std::vector<KernelArena*>& GetKernelArenaStack() {
+  thread_local std::vector<KernelArena*> kernel_arena_stack;
+  return kernel_arena_stack;
+}
+
 void KernelArena::SetCurrentKernelArena(KernelArena* new_kernel_arena) {
   current_arena = new_kernel_arena;
 }

--- a/torch/csrc/jit/tensorexpr/mem_arena.h
+++ b/torch/csrc/jit/tensorexpr/mem_arena.h
@@ -36,6 +36,7 @@ class KernelScope {
  private:
   KernelScope(const KernelScope&) = delete;
   KernelScope& operator=(const KernelScope&) = delete;
+  KernelArena* kernel_arena_ = nullptr; // arena to be used in this scope
   KernelArena* old_kernel_arena_ =
       nullptr; // previous arena, will be restored in destructor
   bool owning_ = false; // determines whether the arena will be freed along with

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -361,7 +361,9 @@ class LoopOptions {
       throw std::runtime_error("Cannot set both gpu block and thread index");
     }
     if (is_gpu_block_index() && gpu_block_index() != index) {
-      throw std::runtime_error("Cannot set a previously set block index");
+      throw std::runtime_error(
+          "Cannot set a previously set block index: " +
+          std::to_string(gpu_block_index()) + " vs " + std::to_string(index));
     }
     gpu_block_index_ = index;
   }
@@ -395,7 +397,9 @@ class LoopOptions {
       throw std::runtime_error("Cannot set both gpu thread and block index");
     }
     if (is_gpu_thread_index() && gpu_thread_index() != index) {
-      throw std::runtime_error("Cannot set a previously set thread index");
+      throw std::runtime_error(
+          "Cannot set a previously set thread index: " +
+          std::to_string(gpu_thread_index()) + " vs " + std::to_string(index));
     }
     gpu_thread_index_ = index;
   }

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -146,7 +146,7 @@ class FunctionCall : public CallNode<FunctionCall> {
     return new FunctionCall(tensor_, new_params);
   }
 
-  std::string func_name() const override {
+  std::string func_name() const {
     return tensor_->func_var()->name_hint();
   }
 

--- a/torch/csrc/jit/tensorexpr/unique_name_manager.cpp
+++ b/torch/csrc/jit/tensorexpr/unique_name_manager.cpp
@@ -1,6 +1,5 @@
 #include <torch/csrc/jit/tensorexpr/unique_name_manager.h>
 
-#include <c10/util/string_utils.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <cctype>
 
@@ -30,7 +29,7 @@ const std::string& UniqueNameManager::get_unique_name(const Var* v) {
     int count_v = count++;
     std::string unique_name = name_hint;
     if (count_v > 0) {
-      unique_name += "_" + c10::to_string(count_v);
+      unique_name += "_" + std::to_string(count_v);
     }
     if (all_unique_names_.count(unique_name) == 0) {
       all_unique_names_.insert(unique_name);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36067 Revert "Reenable test/test_tensorexpr.py (#35914)"**

This reverts commit ba3cec867f8224bd4122ab34af78fc94f2b65d21.

Revert "Invoke TensorExpr fuser pass from a graph executor. (#35913)"

This reverts commit af5121f62ad4f911b404ebc354deec75e1ceaa88.

Revert "[TensorExpr] Compiler warnings cleanups. (#35925)"

This reverts commit b3d30f2dc44014dc6f13336dd17e79bef4dd4f7a.