### PR TITLE
Pin Sphinx to 2.4.4 (take 2), fix docs CIs

### DIFF
--- a/.circleci/scripts/cpp_doc_push_script.sh
+++ b/.circleci/scripts/cpp_doc_push_script.sh
@@ -75,7 +75,7 @@ pushd docs/cpp
 pip install breathe>=4.13.0 bs4 lxml six
 pip install --no-cache-dir -e "git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme"
 pip install exhale>=0.2.1
-pip install sphinx>=2.0
+pip install sphinx==2.4.4
 # Uncomment once it is fixed
 # pip install -r requirements.txt
 time make VERBOSE=1 html -j

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx=2.4.4
+sphinx==2.4.4
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx=2.4.4
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36072 Pin Sphinx to 2.4.4 (take 2), fix docs CIs**

Update to https://github.com/pytorch/pytorch/pull/36065/ which was
almost there

Test Plan:
- Wait for CI

Differential Revision: [D20871661](https://our.internmc.facebook.com/intern/diff/D20871661)