### PR TITLE
Save view_fn for inplace update on view tensors

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -319,11 +319,6 @@ class CAFFE2_API Tensor {
   /// Returns if a `Tensor` has quantized backend.
   bool is_quantized() const;
 
-  /// Returns true if a `Tensor` supports as_strided.
-  bool support_as_strided() const {
-    return impl_->support_as_strided();
-  }
-
   /// If a tensor is a quantized tensor, returns its quantizer
   /// TODO: it's not in native_functions.yaml yet as it's not exposed to python
   QuantizerPtr quantizer() const;

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -319,6 +319,11 @@ class CAFFE2_API Tensor {
   /// Returns if a `Tensor` has quantized backend.
   bool is_quantized() const;
 
+  /// Returns true if a `Tensor` supports as_strided.
+  bool support_as_strided() const {
+    return impl_->support_as_strided();
+  }
+
   /// If a tensor is a quantized tensor, returns its quantizer
   /// TODO: it's not in native_functions.yaml yet as it's not exposed to python
   QuantizerPtr quantizer() const;

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -510,6 +510,20 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     is_wrapped_number_ = value;
   }
 
+  /**
+   * Returns true if Tensor supports as_strided and as_strided_backward.
+   * This is used in autograd to perform inplace update on view Tensors.
+   * See Note [View + Inplace update for base tensor] and
+   * [View + Inplace update for view tensor] for details.
+   * Note this method only returns true for XLA backend, where it
+   * simulates strided Tensor to support most view ops, but it cannot
+   * fully support general `as_strided` case.
+   * It can be expanded as needed in the future, e.g sparse Tensor.
+   */
+  inline bool support_as_strided() const {
+    return device().type() != at::kXLA;
+  }
+
   // ~~~~~ Autograd API ~~~~~
   // Some methods below are defined in TensorImpl.cpp because Tensor is an
   // incomplete type.

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5880,6 +5880,13 @@ class TestAutogradDeviceType(TestCase):
         go = torch.randn(a.size(), device=device, requires_grad=True)
         gradgradcheck(func, (a, b), (go,))
 
+    def test_inplace_view_multiple_outputs(self, device):
+        root = torch.arange(9.).reshape(3, 3).requires_grad_()
+        x = root.clone()
+        v1 = x.unbind()
+        with self.assertRaises(RuntimeError):
+            v1[0].mul_(2)
+
     def test_inplace_view_makes_base_require_grad(self, device):
         # in-place modification to view makes base require grad
         a = torch.randn(4, 4, device=device, requires_grad=False)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -796,12 +796,12 @@ def emit_body(declaration):
                 updated_unpacked_args.append(arg)
         if 'namespace' in declaration['method_of']:
             replay_view_call = CALL_DISPATCH_VIA_NAMESPACE.substitute(
-                api_name=declaration['api_name'],
+                combined,
                 unpacked_args=updated_unpacked_args)
         else:
             replay_view_call = CALL_DISPATCH_VIA_METHOD.substitute(
+                combined,
                 var=input_base,
-                api_name=declaration['api_name'],
                 unpacked_method_args=updated_unpacked_args[1:])
 
         call += REPLAY_VIEW_LAMBDA_FUNC.substitute(

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -106,29 +106,43 @@ template<typename... Args> inline variable_list flatten_tensor_args(Args&&... ar
 
 // See NOTE [ Autograd View Variables ] for details.
 inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable,
-        c10::optional<std::function<Tensor(const Tensor&)>> func=c10::nullopt,
+        c10::optional<std::function<Tensor(const Tensor&)>> view_func=c10::nullopt,
         CreationMeta creation_meta=CreationMeta::DEFAULT) {
   auto base_var = Variable(base);
   if (base_var.is_view()) {
-    // Set `func` using the root base as input.
-    // `func` is used to recover views in backward when as_strided is not supported.
+    // Set `view_func` using the root base as input.
+    // `view_func` is used to recover views in backward when as_strided is not supported.
     // See Note [View + Inplace update on base tensor] and [View + Inplace update on view tensor]
     // for more details how we use this function in backward.
-    if (func.has_value()) {
-      auto fn = func.value();
+    if (view_func.has_value()) {
+      auto fn = view_func.value();
       auto diff_view_meta = static_cast<DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(base_var));
-      if (!diff_view_meta->support_as_strided()) {
+      if (diff_view_meta->has_view_fn()) {
         auto prev_fn = diff_view_meta->view_fn();
-        func = [=](const at::Tensor& root_base) {
+        view_func = [=](const at::Tensor& root_base) {
           auto temp = prev_fn(root_base);
           return fn(temp);
+        };
+      } else {
+        // When base_var is a view but doesn't carry a view_fn in DifferentiableViewMeta, it's
+        // a view that doesn't support inplace update, e.g. unbind.
+        // In this case we should throw an error when inplace update happens in **forward**.
+        // One would naturally think the following function will be first called in backward pass.
+        // But the first call site is indeed in **forward** pass when we refresh `grad_fn`
+        // triggered by inplace update.
+        // Search Note [View + Inplace update for view tensor] to for the call site.
+        view_func = [=](const at::Tensor& root_base) {
+          TORCH_CHECK(false, "This view is the output of a function that returns multiple views."
+                  "Such functions do not allow the output views to be modified inplace."
+                  "You should replace the inplace operation by an out-of-place one");
+          return root_base;
         };
       }
     }
     base_var = base_var._base();
   }
   if (is_differentiable) {
-    return make_variable_differentiable_view(std::move(base_var), std::move(tensor), creation_meta, std::move(func));
+    return make_variable_differentiable_view(std::move(base_var), std::move(tensor), creation_meta, std::move(view_func));
   } else {
     TORCH_CHECK(creation_meta == CreationMeta::DEFAULT,
                 "Non-differentiable views must have creation_meta=CreationMeta::DEFAULT");

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -116,7 +116,7 @@ inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable
       // func could be nullptr if tensor is a view created through CreationMeta::MULTI_OUTPUT_NODE.
       base_var = base_var._base();
     } else if (base_var.device().type() == at::kXLA) {
-      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(base_var.getIntrusivePtr()->autograd_meta());
+      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(base_var));
       auto prev_fn = diff_view_meta->view_fn_;
       if (prev_fn != nullptr) {
         func = [=](const at::Tensor& new_base) {
@@ -139,7 +139,7 @@ inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable
     }
   }
   if (is_differentiable) {
-    return make_variable_differentiable_view(std::move(base_var), std::move(tensor), func, creation_meta);
+    return make_variable_differentiable_view(std::move(base_var), std::move(tensor), std::move(func), creation_meta);
   } else {
     TORCH_CHECK(creation_meta == CreationMeta::DEFAULT,
                 "Non-differentiable views must have creation_meta=CreationMeta::DEFAULT");

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -39,10 +39,12 @@ auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
 
 CopySlices::CopySlices(
     const Variable& base_var,
+    std::function<at::Tensor(at::Tensor)> view_fn_,
     at::TensorGeometry view_,
     std::shared_ptr<Node> fn_)
     : Node(),
       base(base_var),
+      view_fn(std::move(view_fn_)),
       view(std::move(view_)),
       fn(std::move(fn_)) {
   // Take the next_edges of fn as our own, except for index 0 which goes
@@ -71,8 +73,9 @@ auto CopySlices::apply(variable_list&& inputs) -> variable_list {
   auto result = at::empty_strided(base.sizes(), base.strides(), grad.options());
   result.copy_(grad);
 
-  auto offset = view.storage_offset() - base.storage_offset();
-  auto grad_slice = result.as_strided(view.sizes(), view.strides(), offset);
+  //auto offset = view.storage_offset() - base.storage_offset();
+  //auto grad_slice = result.as_strided(view.sizes(), view.strides(), offset);
+  auto grad_slice = view_fn(result);
 
   // TODO: We clone grad_slice because we modify it below and "fn" might save
   // it for the backward of res. We might be able to avoid the clone() if

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -71,6 +71,7 @@ auto CopySlices::apply(variable_list&& inputs) -> variable_list {
   auto result = at::empty_strided(base.sizes(), base.strides(), grad.options());
   result.copy_(grad);
 
+  TORCH_CHECK(view_fn != nullptr, "view_fn is empty.")
   auto grad_slice = view_fn(result);
 
   // TODO: We clone grad_slice because we modify it below and "fn" might save

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -71,7 +71,7 @@ auto CopySlices::apply(variable_list&& inputs) -> variable_list {
   auto result = at::empty_strided(base.sizes(), base.strides(), grad.options());
   result.copy_(grad);
 
-  TORCH_CHECK(view_fn != nullptr, "view_fn is empty.")
+  AT_ASSERT(view_fn != nullptr);
   auto grad_slice = view_fn(result);
 
   // TODO: We clone grad_slice because we modify it below and "fn" might save

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -40,12 +40,10 @@ auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
 CopySlices::CopySlices(
     const Variable& base_var,
     std::function<at::Tensor(at::Tensor)> view_fn_,
-    at::TensorGeometry view_,
     std::shared_ptr<Node> fn_)
     : Node(),
       base(base_var),
       view_fn(std::move(view_fn_)),
-      view(std::move(view_)),
       fn(std::move(fn_)) {
   // Take the next_edges of fn as our own, except for index 0 which goes
   // to base instead of the view.
@@ -73,8 +71,6 @@ auto CopySlices::apply(variable_list&& inputs) -> variable_list {
   auto result = at::empty_strided(base.sizes(), base.strides(), grad.options());
   result.copy_(grad);
 
-  //auto offset = view.storage_offset() - base.storage_offset();
-  //auto grad_slice = result.as_strided(view.sizes(), view.strides(), offset);
   auto grad_slice = view_fn(result);
 
   // TODO: We clone grad_slice because we modify it below and "fn" might save

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -40,7 +40,7 @@ auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
 CopySlices::CopySlices(
     const Variable& base_var,
     at::TensorGeometry view_,
-    std::function<at::Tensor(const at::Tensor&)> view_fn_,
+    c10::optional<std::function<at::Tensor(const at::Tensor&)>> view_fn_,
     std::shared_ptr<Node> fn_)
     : Node(),
       base(base_var),
@@ -74,8 +74,9 @@ auto CopySlices::apply(variable_list&& inputs) -> variable_list {
   result.copy_(grad);
 
   at::Tensor grad_slice;
-  if (view_fn) {
-    grad_slice = view_fn(result);
+  if (view_fn.has_value()) {
+    auto fn = view_fn.value();
+    grad_slice = fn(result);
   } else {
     auto offset = view.storage_offset() - base.storage_offset();
     grad_slice = result.as_strided(view.sizes(), view.strides(), offset);

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -30,6 +30,7 @@ struct TORCH_API CopyBackwards : public Node {
 struct TORCH_API CopySlices : public Node {
   CopySlices(
       const Variable& base_var,
+      std::function<at::Tensor(at::Tensor)> view_fn_,
       at::TensorGeometry view_,
       std::shared_ptr<Node> fn_);
 
@@ -37,6 +38,7 @@ struct TORCH_API CopySlices : public Node {
   void release_variables() override;
 
   at::TensorGeometry base;
+  std::function<at::Tensor(at::Tensor)> view_fn;
   at::TensorGeometry view;
   std::shared_ptr<Node> fn;
 };

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -93,6 +93,8 @@ struct TORCH_API CopySlices : public Node {
   void release_variables() override;
 
   at::TensorGeometry base;
+  // view and view_fn are redundant and view_fn will be used if available.
+  // See Note [View + Inplace update for base tensor] for details.
   at::TensorGeometry view;
   c10::optional<std::function<at::Tensor(const at::Tensor&)>> view_fn;
   std::shared_ptr<Node> fn;

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -31,7 +31,6 @@ struct TORCH_API CopySlices : public Node {
   CopySlices(
       const Variable& base_var,
       std::function<at::Tensor(at::Tensor)> view_fn_,
-      at::TensorGeometry view_,
       std::shared_ptr<Node> fn_);
 
   variable_list apply(variable_list&& inputs) override;
@@ -39,7 +38,6 @@ struct TORCH_API CopySlices : public Node {
 
   at::TensorGeometry base;
   std::function<at::Tensor(at::Tensor)> view_fn;
-  at::TensorGeometry view;
   std::shared_ptr<Node> fn;
 };
 

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -82,14 +82,16 @@ struct TORCH_API CopyBackwards : public Node {
 struct TORCH_API CopySlices : public Node {
   CopySlices(
       const Variable& base_var,
-      std::function<at::Tensor(at::Tensor)> view_fn_,
+      at::TensorGeometry view_,
+      std::function<at::Tensor(const at::Tensor&)> view_fn_,
       std::shared_ptr<Node> fn_);
 
   variable_list apply(variable_list&& inputs) override;
   void release_variables() override;
 
   at::TensorGeometry base;
-  std::function<at::Tensor(at::Tensor)> view_fn;
+  at::TensorGeometry view;
+  std::function<at::Tensor(const at::Tensor&)> view_fn;
   std::shared_ptr<Node> fn;
 };
 

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -20,13 +20,59 @@ struct TORCH_API CopyBackwards : public Node {
   at::Device src_device = at::kCPU;
 };
 
-// Performs grad[idx] = fn(grad[idx]), but out-of-place. The slicing operation
-// grad[idx] is defined by the relative sizes, strides, and offset of base and
-// view.
+// Note [View + Inplace update for base tensor]
+// Performs grad_view = fn(grad_view), but out-of-place. The view tensor
+// grad_view is done by grad_view = view_fn_(grad_base). view_fn_ is a
+// lambda function saved in DifferentiableViewMeta in forward pass,
+// where view = view_fn_(base).
+// This view_fn_ is represented using `as_strided` in CPU/CUDA backends for
+// effieciency.
+//
+// For example:
+//   view_1 = view_op_1(base)
+//   view_2 = view_op_2(view_1)
+//   ...
+//   view_n = view_op_n(view_n-1)
+//   view_n = inplace_op(view_n)
+//
+// In CPU/CUDA case where we support efficient as_strided implementation,
+// grad_view_n can be calculated through 1 step.
+//
+//   view_fn_ = [=](const at::Tensor& new_base) {
+//       return new_base.as_strided(view_sizes, view_strides, view_offset);
+//   };
+//   grad_view_n = view_fn_(grad_base)
+//
+// But in XLA backend where we don't have full support of as_strided,
+// it has to save a chained lambda function view_fn_, to exactly
+// replay how the view was done in forward.
+//
+//   view_fn_ = view_op_n(...(view_op_2(view_op_1())))
+//   grad_view_n = view_fn_(grad_base)
+//
+// This chain view_fn_ works as long as forward view ops are implemented,
+// e.g XLA simulates view without a real Storage behind Tensor, but it's less
+// efficient than the as_strided one so we should be careful to only use it when
+// necessary.
+//
+// What do we save in view_fn_/CopySlices Node?
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// All arguments in view_fn_ are copyied by **value**.
+// In CPU/CUDA case we save int[] sizes, int[] strides, and int storage_offset.
+// In XLA cases we save arguments passed into forward view op.
+// E.g for at::narrow, int dim, int start, in length are saved.
+
+// Theorectically we could also save Variable view in CopySlices Node, but
+// it's far more expensive than what we currently save. We cannot afford
+// keeping large tensors alive to recover views, TensorGeometry or a few arguments
+// are sufficient to do it.
+//
 // When an in-place operation is done on a differentiable view, the base's
 // grad_fn is updated to become a `CopySlice` wrapping the backward of the
 // in-place operation.
-// See NOTE [ Autograd View Variables ].
+
+// See Note [View + Inplace update for view tensor] for what we do to view
+// tensor when an in-place operation happens.
 struct TORCH_API CopySlices : public Node {
   CopySlices(
       const Variable& base_var,

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -365,9 +365,9 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(const Tenso
       // See Note [View + Inplace update for base tensor] for what we do to base tensor when
       // an in-place operation happens.
       //
-      // TODO: Potentially the following logic can be moved to VariableType_x.cpp through codegen
-      //       so that we directly save a view_grad_fn in DifferentiableViewMeta.
-      if (!diff_view_meta->support_as_strided()) {
+      // TODO: Potentially the following logic can be replaced by special logic in VariableType_x.cpp
+      //       that would provide a way to recreate the grad_fn chain.
+      if (diff_view_meta->has_view_fn()) {
         auto view_fn = diff_view_meta->view_fn();
         auto diff_view = view_fn(diff_view_meta->base_);
         diff_view_meta->grad_fn_ = diff_view.grad_fn();

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -399,11 +399,12 @@ struct TORCH_API DifferentiableViewMeta : public AutogradMeta {
     return requires_grad_ || grad_fn_ || (is_view_ && base_.requires_grad());
   }
 
-  bool support_as_strided() const {
-    return !view_fn_.has_value();
+  bool has_view_fn() const {
+    return view_fn_.has_value();
   }
 
   std::function<at::Tensor(const at::Tensor&)> view_fn() const {
+    TORCH_CHECK(has_view_fn(), "view_fn is not set.");
     return view_fn_.value();
   }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -426,7 +426,7 @@ struct TORCH_API DifferentiableViewMeta : public AutogradMeta {
 inline Variable make_variable_differentiable_view(
     Variable base,
     at::Tensor data,
-    std::function<at::Tensor(at::Tensor)> view_func,
+    std::function<at::Tensor(const at::Tensor&)> view_func,
     CreationMeta creation_meta) {
   if (data.defined()) {
     auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(


### PR DESCRIPTION
This PR enables inplace updates on view Tensors for tensor types(XLA) that doesn't support as_strided. 
(See Notes inside PR) 