### PR TITLE
Bump produced file format version

### DIFF
--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -92,7 +92,12 @@ namespace serialize {
 
 constexpr uint64_t kMinSupportedFileFormatVersion = 0x1L;
 constexpr uint64_t kMaxSupportedFileFormatVersion = 0x3L;
-constexpr uint64_t kProducedFileFormatVersion = 0x2L;
+
+// Versions (i.e. why was the version number bumped?)
+// 1. Initial version
+// 2. Removed op_version_set version numbers
+// 3. Added type tags to pickle serialization of container types
+constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 
 // Writer-specific constants
 constexpr uint64_t kFieldAlignment = 64;


### PR DESCRIPTION
This was left off of #35741, but the max supported file format change
has been landed for several weeks, so this should be fine to land.

Differential Revision: [D20875051](https://our.internmc.facebook.com/intern/diff/20875051/)