### PR TITLE
[model transform] tuple to arglist jit pass

### DIFF
--- a/aten/src/ATen/core/builtin_function.h
+++ b/aten/src/ATen/core/builtin_function.h
@@ -68,6 +68,12 @@ struct BuiltinOpFunction : public Function {
       "special case on Function::isGraphFunction()");
   }
 
+  void clear_execution_info() override {
+    TORCH_INTERNAL_ASSERT(false , "BuiltinFunction had a graph requested "
+      "from it. This probably indicates that the JIT calling context needs a "
+      "special case on Function::isGraphFunction()");
+  }
+
   GraphExecutor& get_executor() override {
     TORCH_INTERNAL_ASSERT(false , "BuiltinFunction had a GraphExecutor requested "
       "from it. This probably indicates that the JIT calling context needs a "

--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -48,6 +48,8 @@ struct TORCH_API Function {
 
   virtual std::shared_ptr<Graph> optimized_graph() const = 0;
 
+  virtual void clear_execution_info() = 0;
+
   virtual GraphExecutor& get_executor() = 0;
 
   virtual const c10::FunctionSchema& getSchema() const = 0;

--- a/torch/csrc/jit/api/function_impl.h
+++ b/torch/csrc/jit/api/function_impl.h
@@ -46,6 +46,14 @@ struct TORCH_API GraphFunction : public Function {
     return *optimized_graph_;
   }
 
+  void clear_execution_info() override {
+    std::lock_guard<std::recursive_mutex> lock(compile_mutex);
+    if (optimized_graph_) {
+      optimized_graph_.reset();
+    }
+    executor_.reset();
+  }
+
   const c10::QualifiedName& qualname() const override {
     return name_;
   }

--- a/torch/csrc/jit/runtime/graph_executor.h
+++ b/torch/csrc/jit/runtime/graph_executor.h
@@ -64,6 +64,9 @@ struct TORCH_API GraphExecutor {
   explicit operator bool() const {
     return pImpl != nullptr;
   }
+  void reset() {
+    pImpl.reset();
+  }
   std::shared_ptr<Graph> graph() const;
   GraphExecutorState getDebugState();
 


### PR DESCRIPTION
Summary:
Unwrap any tuples (including NamedTuples) in the module forward
function input list to be arglist.
1. Supports multiple tuple inputs, and traces their use through CallMethods and
TupleIndex
2. Does not unwrap inner use of other tuples that did not show up in the
original toplevel graph inputs

We work from the ScriptModule level instead of the Graph level because:
1. If the ScriptModule was previously called with the original set of inputs, the GraphExecutor caches the ExecutionPlan (specifically, ArgumentSpecCreator is derived from the Graph and type check the inputs passed in)
2. Since we are changing this graph's inputs, we clone the module and clear the GraphExecutor.

Since we work from ScriptModule level, we cannot take advantage of jit level syntactic sugar like run_pass(), so I jit exposed this as a cpp extension. Let me know if there are other ideas about this.

Test Plan:
buck test caffe2/torch/fb/model_transform:signature_translation_test
Todo: Verify use in bento

Untranslated graph:
```
> graph(%self : __torch__.test_jit.SparseNNWrapper,
>       %inputs.1 : NamedTuple(dense : Tensor, sparse : Dict(int, Tensor))):
>   %2 : __torch__.test_jit.SparseNN = prim::GetAttr[name="main_module"](%self)
>   %4 : Tensor = prim::CallMethod[name="forward"](%2, %inputs.1) # /data/users/ansha/fbsource/fbcode/buck-out/dev/gen/caffe2/test/jit#binary,link-tree/test_jit.py:12141:23
>   return (%4)
```

Translated graph:
```
> graph(%self : __torch__.test_jit.___torch_mangle_1.SparseNNWrapper,
>       %inputs.1_0 : Tensor,
>       %inputs.1_1 : Dict(int, Tensor)):
>   %2 : __torch__.test_jit.___torch_mangle_2.SparseNN = prim::GetAttr[name="main_module"](%self)
>   %3 : Tensor = prim::CallMethod[name="forward"](%2, %inputs.1_0, %inputs.1_1) # /data/users/ansha/fbsource/fbcode/buck-out/dev/gen/caffe2/test/jit#binary,link-tree/test_jit.py:12141:23
>   return (%3)
```

Differential Revision: D20313673

