### PR TITLE
Fixing Potential TSAN issue with joining RPC helper threads

### DIFF
--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -34,8 +34,10 @@ void RpcAgent::start() {
 
 void RpcAgent::cleanup() {
   rpcAgentRunning_.store(false);
+  // We must notify the condition variable so it stops waiting in the
+  // retry thread, otherwise this thread cannot be joined.
+  rpcRetryMapCV_.notify_one();
   if (rpcRetryThread_.joinable()) {
-    rpcRetryMapCV_.notify_one();
     rpcRetryThread_.join();
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36094 Fixing Potential TSAN issue with joining RPC helper threads**

In `rpc.shutdown`, we notify the retry thread waiting on `rpcRetryMapCV_`. Previously we only notified and joined if the thread was already joinable, and this resulted in a thread leak since the notification is what spuriously wakes up the retry thread and makes it joinable. 

This PR notifies the retry thread immediately after setting the atomic to False, whether the thread is joinable or not. This should ensure the retry thread is successfully joined, fixing the TSAN thread leak errors.

Differential Revision: [D20854763](https://our.internmc.facebook.com/intern/diff/D20854763/)