### PR TITLE
`ivalue::Future::markCompleted()` to call notify under lock

### DIFF
--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -127,9 +127,9 @@ void _parallel_run(
 
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-  std::vector<std::shared_ptr<c10::ivalue::Future>> futures(num_tasks);
+  std::vector<c10::intrusive_ptr<c10::ivalue::Future>> futures(num_tasks);
   for (size_t task_id = 0; task_id < num_tasks; ++task_id) {
-    futures[task_id] = std::make_shared<c10::ivalue::Future>(c10::NoneType::get());
+    futures[task_id] = c10::make_intrusive<c10::ivalue::Future>(c10::NoneType::get());
   }
   auto task = [f, &eptr, &err_flag, &futures, begin, end, chunk_size]
       (int /* unused */, size_t task_id) {

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -257,9 +257,9 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
 
     std::vector<std::function<void(void)>> cbs;
     cbs.swap(callbacks_);
+    finished_cv_.notify_all();
     lock.unlock();
 
-    finished_cv_.notify_all();
     for (auto& callback : cbs) {
       callback();
     }
@@ -278,9 +278,9 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
 
     std::vector<std::function<void(void)>> cbs;
     cbs.swap(callbacks_);
+    finished_cv_.notify_all();
     lock.unlock();
 
-    finished_cv_.notify_all();
     for (auto& callback : cbs) {
       callback();
     }


### PR DESCRIPTION
Once complete flag is set and lock is released, `this` and therefore conditional variable is not guaranteed to be valid.

Allocate futures  as vector of `intrusive_ptrs` in `_parallel_run()`

Test Plan: Run `while true; do python test_nn.py  -f -v TestNN.test_BatchNorm2d_momentum; done` in code compiled with `gcc-5.4`