### PR TITLE
Pin Breathe to avoid future CI failure

### DIFF
--- a/.circleci/scripts/cpp_doc_push_script.sh
+++ b/.circleci/scripts/cpp_doc_push_script.sh
@@ -72,7 +72,7 @@ time python tools/setup_helpers/generate_code.py \
 
 # Build the docs
 pushd docs/cpp
-pip install breathe>=4.13.0 bs4 lxml six
+pip install breathe==4.13.0 bs4 lxml six
 pip install --no-cache-dir -e "git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme"
 pip install exhale>=0.2.1
 pip install sphinx==2.4.4


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36100 Pin Breathe to avoid future CI failure**

See #36072 for more context. The pinned version of Breathe supports
Sphinx < 3 and is compatible with what we've pinned Sphinx to in our CI
(2.4.4).

Test Plan:
- wait for CI