### PR TITLE
Fix test_avg_pool3d issue in pytorch_paralleltbb_linux_xenial_py3_6_gcc5_4_test

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -856,8 +856,8 @@ void do_avg_pool_nhwc_on_AVX2(
   constexpr int cb_size = 16;
   constexpr int vec_width = Vec256<T>::size() / 4;
   constexpr int cb_step = cb_size * vec_width;
-  static Vec256<int32_t> acc_buffer[cb_size];
-  static Vec256<float> acc_buffer_fp[cb_size];
+  Vec256<int32_t> acc_buffer[cb_size];
+  Vec256<float> acc_buffer_fp[cb_size];
 
   if (vec_width == 8) {
     for (int c = c_start; c < csize; c += cb_step) {

--- a/test/quantization/test_quantized.py
+++ b/test/quantization/test_quantized.py
@@ -889,7 +889,6 @@ class TestQuantizedOps(TestCase):
                              message=error_message.format(name + '.zero_point', scale,
                              X_hat.q_zero_point()))
 
-    @unittest.skip("Fix me! to stop breaking the builds")
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=5, max_dims=5,
                                               min_side=5, max_side=10),
                        qparams=hu.qparams(dtypes=torch.quint8)),


### PR DESCRIPTION
Summary:
Fix parallel execution issue introduced by #35740

Test Plan:
test_quantized.py

Reviewers:

Subscribers:

Tasks:

Tags:

