### PR TITLE
[JIT] fix comprehension scope writes

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -54,7 +54,7 @@ namespace c10 {
   _(prim, ReturnStmt)                \
   _(prim, BreakStmt)                 \
   _(prim, ContinueStmt)              \
-  _(prim, ComprehensionScope)        \
+  _(prim, LocalVariableScope)        \
   _(prim, Store)                     \
   _(prim, AutogradZero)              \
   _(prim, AutogradAnyNonZero)        \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -54,6 +54,7 @@ namespace c10 {
   _(prim, ReturnStmt)                \
   _(prim, BreakStmt)                 \
   _(prim, ContinueStmt)              \
+  _(prim, ComprehensionScope)        \
   _(prim, Store)                     \
   _(prim, AutogradZero)              \
   _(prim, AutogradAnyNonZero)        \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13967,7 +13967,7 @@ a")
         def foo():
             i = 1
             x = [i if i != 5 else 3 for i in range(7)]  # noqa: C416
-            return i
+            return i, x
 
         self.assertEqual(foo(), torch.jit.script(foo)())
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13962,6 +13962,15 @@ a")
         with self.assertRaisesRegex(Exception, "Expected list type annotation"):
             torch.jit.script(bad_type_annotation)
 
+    def test_list_comprehension_variable_write(self):
+        # i in comprehension doesn't write to function scope
+        def foo():
+            i = 1
+            x = [i if i != 5 else 3 for i in range(7)]  # noqa: C416
+            return i
+
+        self.assertEqual(foo(), torch.jit.script(foo)())
+
     def test_for_in_zip(self):
         def fn(x, y):
             # type: (List[int], List[int]) -> int

--- a/torch/csrc/jit/frontend/convert_to_ssa.cpp
+++ b/torch/csrc/jit/frontend/convert_to_ssa.cpp
@@ -157,7 +157,7 @@ struct ControlFlowLoadStores {
         case prim::Store: {
           environment_stack->setVar(n->s(attr::name), n->input()->type());
         } break;
-        case prim::ComprehensionScope: {
+        case prim::LocalVariableScope: {
           addControlFlowLoadStores(n->blocks().at(0));
         } break;
       }
@@ -204,9 +204,8 @@ struct EraseLoadStores {
           n->output()->replaceAllUsesWith(var);
           n->destroy();
         } break;
-        case prim::ComprehensionScope: {
-          // Comprehensions introduce their own scope, so we need to introduce a
-          // scope here so that writes within the comprehension do not leak into
+        case prim::LocalVariableScope: {
+          // writes within a local variable scope do not leak into
           // the rest of the graph
           auto body = n->blocks().at(0);
           eraseBlockLoadStores(body);

--- a/torch/csrc/jit/frontend/convert_to_ssa.cpp
+++ b/torch/csrc/jit/frontend/convert_to_ssa.cpp
@@ -209,7 +209,7 @@ struct EraseLoadStores {
           // the rest of the graph
           auto body = n->blocks().at(0);
           eraseBlockLoadStores(body);
-          // inline the comprehension scope into the graph
+          // inline the local variable scope into the graph
           for (auto it_cmpr = body->nodes().begin();
                it_cmpr != body->nodes().end();) {
             Node* body_node = *it_cmpr;

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1189,7 +1189,7 @@ struct to_ir {
     // comprehension introduces it's own scope. no variable assigned
     // leaks into the rest of the graph
     Node* n =
-        graph->insertNode(create(prim::ComprehensionScope, lc.range(), 0));
+        graph->insertNode(create(prim::LocalVariableScope, lc.range(), 0));
     auto* comprehension_block = n->addBlock();
     pushFrame(comprehension_block);
     WithInsertPoint guard(comprehension_block);

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1185,6 +1185,14 @@ struct to_ir {
       list_value->setType(type_hint);
       type_set = true;
     }
+
+    // comprehension introduces it's own scope. no variable assigned
+    // leaks into the rest of the graph
+    Node* n =
+        graph->insertNode(create(prim::ComprehensionScope, lc.range(), 0));
+    auto* comprehension_block = n->addBlock();
+    pushFrame(comprehension_block);
+    WithInsertPoint guard(comprehension_block);
     auto emit_body = [&]() {
       auto comprehension_out = emitExpr(lc.elt());
       if (!type_set) {
@@ -1196,6 +1204,7 @@ struct to_ir {
       emitBuiltinCall(loc, *graph, aten::append, {input}, {}, self);
     };
     emitFor(targets_list, itrs, loc, emit_body);
+    popFrame();
     return list_value;
   }
 


### PR DESCRIPTION
In a comprehension like:
```
    def f()->int:
        i = 1
        x = [i for i in range(7)]
        return i
```
the variables inside the comprehension do not write to the function environment. 