### PR TITLE
[1.5 cherrypick][JIT] Fix fake_range()

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5472,6 +5472,25 @@ def foo(x):
         with self.assertRaisesRegex(RuntimeError, 'Tried to instantiate class foo.IDontExist but it does not exist!'):
             torch.classes.foo.IDontExist(3, 4, 5)
 
+    @skipIfRocm
+    def test_torchbind_optional_explicit_attr(self):
+        class TorchBindOptionalExplicitAttr(torch.nn.Module):
+            foo : Optional[torch.classes._TorchScriptTesting._StackString]
+
+            def __init__(self):
+                super().__init__()
+                self.foo = torch.classes._TorchScriptTesting._StackString(["test"])
+
+            def forward(self) -> str:
+                foo_obj = self.foo
+                if foo_obj is not None:
+                    return foo_obj.pop()
+                else:
+                    return '<None>'
+
+        mod = TorchBindOptionalExplicitAttr()
+        scripted = torch.jit.script(mod)
+
     def test_jitter_bug(self):
         @torch.jit.script
         def fn2(input, kernel_size):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -801,4 +801,4 @@ class SourceContext(torch._C._jit_tree_views.SourceRangeFactory):
 
 
 def fake_range():
-    return SourceContext('', None, 0, 0)
+    return SourceContext('', None, 0, 0).make_raw_range(0, 1)


### PR DESCRIPTION
Cherry-pick of https://github.com/pytorch/pytorch/pull/36083

This fixes type annotations for torchbind classes in some instances