### PR TITLE
Update docs for 1.5 to remove Python 2 references

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -790,21 +790,6 @@ New API:
 
     m = torch.jit.script(MyModule())
 
-Python 2
-""""""""
-If you are stuck on Python 2 and cannot use the class annotation syntax, you can use the ``__annotations__`` class member to directly apply type annotations.
-
-.. testcode::
-
-    from typing import Dict
-
-    class MyModule(torch.jit.ScriptModule):
-        __annotations__ = {'my_dict': Dict[str, int]}
-
-        def __init__(self):
-            super(MyModule, self).__init__()
-            self.my_dict = {}
-            self.my_int = 20
 
 Constants
 ^^^^^^^^^

--- a/docs/source/jit_language_reference.rst
+++ b/docs/source/jit_language_reference.rst
@@ -185,13 +185,11 @@ MyPy-style type annotations using the types listed above.
 
     ...
 
-  In our examples, we use comment-based type hints to ensure Python 2
-  compatibility as well.
 
 
 An empty list is assumed to be ``List[Tensor]`` and empty dicts
 ``Dict[str, Tensor]``. To instantiate an empty list or dict of other types,
-use `Python 3 type hints`_. If you are on Python 2, you can use ``torch.jit.annotate``.
+use `Python 3 type hints`_. 
 
 Example (type annotations for Python 3):
 
@@ -216,31 +214,6 @@ Example (type annotations for Python 3):
 
     x = torch.jit.script(EmptyDataStructures())
 
-
-Example (``torch.jit.annotate`` for Python 2):
-
-.. testcode::
-
-    import torch
-    import torch.nn as nn
-    from typing import Dict, List, Tuple
-
-    class EmptyDataStructures(torch.nn.Module):
-        def __init__(self):
-            super(EmptyDataStructures, self).__init__()
-
-        def forward(self, x):
-            # type: (Tensor) -> Tuple[List[Tuple[int, float]], Dict[str, int]]
-
-            # This annotates the list to be a `List[Tuple[int, float]]`
-            my_list = torch.jit.annotate(List[Tuple[int, float]], [])
-            for i in range(10):
-                my_list.append((i, float(x.item())))
-
-            my_dict = torch.jit.annotate(Dict[str, int], {})
-            return my_list, my_dict
-
-    x = torch.jit.script(EmptyDataStructures())
 
 
 
@@ -856,29 +829,6 @@ Supported constant Python types are
 * tuples containing supported types
 * ``torch.nn.ModuleList`` which can be used in a TorchScript for loop
 
-.. note::
-    If you are on Python 2, you can mark an attribute as a constant by adding
-    its name to the ``__constants__`` property of the class:
-
-    .. testcode::
-
-        import torch
-        import torch.nn as nn
-
-        class Foo(nn.Module):
-            __constants__ = ['a']
-
-            def __init__(self):
-                super(Foo, self).__init__()
-                self.a = 1 + 4
-
-            def forward(self, input):
-                return self.a + input
-
-        f = torch.jit.script(Foo())
-
-    |
-
 .. _module attributes:
 
 Module Attributes
@@ -924,11 +874,6 @@ Example:
 
     f = torch.jit.script(Foo({'hi': 2}))
 
-
-.. note::
-    If you are on Python 2, you can mark an attribute's type by adding it to
-    the ``__annotations__`` class property as a dictionary of attribute name to
-    type
 
     .. testcode::
 

--- a/docs/source/multiprocessing.rst
+++ b/docs/source/multiprocessing.rst
@@ -30,9 +30,7 @@ Sharing CUDA tensors
 --------------------
 
 Sharing CUDA tensors between processes is supported only in Python 3, using
-a ``spawn`` or ``forkserver`` start methods. :mod:`python:multiprocessing` in
-Python 2 can only create subprocesses using ``fork``, and it's not supported
-by the CUDA runtime.
+a ``spawn`` or ``forkserver`` start methods. 
 
 Unlike CPU tensors, the sending process is required to keep the original tensor
 as long as the receiving process retains a copy of the tensor. The refcounting is

--- a/docs/source/named_tensor.rst
+++ b/docs/source/named_tensor.rst
@@ -187,7 +187,7 @@ mentioning all of them as in required by :meth:`~Tensor.permute`.
     # Move the F (dim 5) and E dimension (dim 4) to the front while keeping
     # the rest in the same order
     >>> tensor.permute(5, 4, 0, 1, 2, 3)
-    >>> named_tensor.align_to('F', 'E', ...)  # Use '...' instead in Python 2
+    >>> named_tensor.align_to('F', 'E', ...)
 
 Use :meth:`~Tensor.flatten` and :meth:`~Tensor.unflatten` to flatten and unflatten
 dimensions, respectively. These methods are more verbose than :meth:`~Tensor.view`
@@ -317,4 +317,3 @@ operators, see :ref:`name_inference_reference-doc`.
 
       .. warning::
           The named tensor API is experimental and subject to change.
-

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -27,10 +27,7 @@ others that require asynchronous operation.
 CUDA in multiprocessing
 -----------------------
 
-The CUDA runtime does not support the ``fork`` start method. However,
-:mod:`python:multiprocessing` in Python 2 can only create subprocesses using
-``fork``. So Python 3 and either ``spawn`` or ``forkserver`` start method are
-required to use CUDA in subprocesses.
+The CUDA runtime does not support the ``fork`` start method. In Python 3, either the ``spawn`` or ``forkserver`` start method are
 
 .. note::
   The start method can be set via either creating a context with

--- a/docs/source/notes/windows.rst
+++ b/docs/source/notes/windows.rst
@@ -151,12 +151,6 @@ Package not found in win-32 channel.
 PyTorch doesn't work on 32-bit system. Please use Windows and
 Python 64-bit version.
 
-Why are there no Python 2 packages for Windows?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Because it's not stable enough. There're some issues that need to
-be solved before we officially release it. You can build it by yourself.
-
 Import error
 ^^^^^^^^^^^^
 
@@ -290,4 +284,3 @@ tensors cannot succeed, there are two alternatives for this.
 
 2. Share CPU tensors instead. Make sure your custom
 :class:`~torch.utils.data.DataSet` returns CPU tensors.
-


### PR DESCRIPTION
Full details in task: https://our.internmc.facebook.com/intern/tasks/?t=64776265

With pytorch 1.5+, we remove python2 support from PyTorch. All documentation under docs/ and on the pytorch.org website needs to remove Python 2 references.