### PR TITLE
Fixes CMake lint error

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -501,7 +501,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     )
 
   # Required workaround for LLVM 9 includes.
-  if (NOT MSVC)
+  if(NOT MSVC)
     set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS -Wno-noexcept-type)
   endif()
 


### PR DESCRIPTION
```
Total Errors: 1
Ignoring file: aten/src/ATen/ATenConfig.cmake.in
caffe2/CMakeLists.txt:504: Extra spaces between 'if' and its () [whitespace/extra]
Ignoring file: cmake/Caffe2Config.cmake.in
Ignoring file: cmake/Caffe2ConfigVersion.cmake.in
```

Fixes that error. 