### PR TITLE
[TensorExpr] fix warnings

### DIFF
--- a/test/cpp/tensorexpr/padded_buffer.cpp
+++ b/test/cpp/tensorexpr/padded_buffer.cpp
@@ -1,7 +1,7 @@
 #include "test/cpp/tensorexpr/padded_buffer.h"
 
-#include <sstream>
 #include <c10/util/Logging.h>
+#include <sstream>
 
 namespace torch {
 namespace jit {
@@ -10,7 +10,7 @@ namespace tensorexpr {
 int PaddedBufferBase::Index(const std::vector<int>& indices) const {
   DCHECK_EQ(dims_.size(), indices.size());
   int total_index = 0;
-  for (int i = 0; i < dims_.size(); i++) {
+  for (size_t i = 0; i < dims_.size(); i++) {
     total_index += indices[i] * strides_[i];
   }
   return total_index;
@@ -20,8 +20,8 @@ PaddedBufferBase::PaddedBufferBase(
     const std::vector<int>& dims,
     const std::string& name)
     : dims_(dims), name_(name), strides_(dims.size()) {
-  for (int i = dims.size() - 1; i >= 0; --i) {
-    if (i == dims.size() - 1) {
+  for (int i = (int)dims.size() - 1; i >= 0; --i) {
+    if (i == (int)dims.size() - 1) {
       strides_[i] = 1;
     } else {
       strides_[i] = strides_[i + 1] * dims[i + 1];

--- a/test/cpp/tensorexpr/test_base.h
+++ b/test/cpp/tensorexpr/test_base.h
@@ -4,9 +4,9 @@
 #include <gtest/gtest.h>
 #include <test/cpp/common/support.h>
 #else
+#include <cmath>
 #include "c10/util/Exception.h"
 #include "test/cpp/tensorexpr/gtest_assert_float_eq.h"
-#include <cmath>
 #define ASSERT_EQ(x, y, ...) TORCH_INTERNAL_ASSERT((x) == (y), __VA_ARGS__)
 #define ASSERT_FLOAT_EQ(x, y, ...) \
   TORCH_INTERNAL_ASSERT(AlmostEquals((x), (y)), __VA_ARGS__)
@@ -52,7 +52,7 @@ void ExpectAllNear(
     V threshold,
     const std::string& name = "") {
   ASSERT_EQ(v1.size(), v2.size());
-  for (int i = 0; i < v1.size(); i++) {
+  for (size_t i = 0; i < v1.size(); i++) {
     ASSERT_NEAR(
         v1[i], v2[i], threshold, "element index: ", i, ", name: ", name);
   }

--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -44,7 +44,6 @@ void testExprBasicValueTest02() {
 void testExprLetTest01() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
-  ExprHandle value = ExprHandle(3.f);
   ExprHandle body = ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f));
   ExprHandle result = Let::make(x, ExprHandle(3.f), body);
   SimpleIRExprEval eval(result);
@@ -55,7 +54,6 @@ void testExprLetTest02() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
   VarHandle y("y", kFloat);
-  ExprHandle value = ExprHandle(3.f);
   ExprHandle body =
       ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f) * y);
   ExprHandle e1 = Let::make(x, ExprHandle(3.f), body);
@@ -86,14 +84,9 @@ void testExprLetStmtTest01() {
   ExpectAllNear(b_v, b_ref, 1e-5);
 }
 
-static ExprHandle test_01(const ExprHandle& expr) {
-  return expr;
-}
-
 void testExprIntTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kInt);
-  ExprHandle value = ExprHandle(3);
   ExprHandle body = ExprHandle(2) + (x * ExprHandle(3) + ExprHandle(4));
   ExprHandle result = Let::make(x, ExprHandle(3), body);
   SimpleIRExprEval eval(result);
@@ -103,7 +96,6 @@ void testExprIntTest() {
 void testExprFloatTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
-  ExprHandle value = ExprHandle((float)3);
   ExprHandle body =
       ExprHandle((float)2) + (x * ExprHandle((float)3) + ExprHandle((float)4));
   ExprHandle result = Let::make(x, ExprHandle((float)3), body);
@@ -114,7 +106,6 @@ void testExprFloatTest() {
 void testExprByteTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kByte);
-  ExprHandle value = ExprHandle((uint8_t)3);
   ExprHandle body = ExprHandle((uint8_t)2) +
       (x * ExprHandle((uint8_t)3) + ExprHandle((uint8_t)4));
   ExprHandle result = Let::make(x, ExprHandle((uint8_t)3), body);
@@ -125,7 +116,6 @@ void testExprByteTest() {
 void testExprCharTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kChar);
-  ExprHandle value = ExprHandle((int8_t)3);
   ExprHandle body = ExprHandle((int8_t)2) +
       (x * ExprHandle((int8_t)3) + ExprHandle((int8_t)4));
   ExprHandle result = Let::make(x, ExprHandle((int8_t)3), body);
@@ -136,7 +126,6 @@ void testExprCharTest() {
 void testExprShortTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kShort);
-  ExprHandle value = ExprHandle((int16_t)3);
   ExprHandle body = ExprHandle((int16_t)2) +
       (x * ExprHandle((int16_t)3) + ExprHandle((int16_t)4));
   ExprHandle result = Let::make(x, ExprHandle((int16_t)3), body);
@@ -147,7 +136,6 @@ void testExprShortTest() {
 void testExprLongTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kLong);
-  ExprHandle value = ExprHandle((int64_t)3);
   ExprHandle body = ExprHandle((int64_t)2) +
       (x * ExprHandle((int64_t)3) + ExprHandle((int64_t)4));
   ExprHandle result = Let::make(x, ExprHandle((int64_t)3), body);
@@ -158,7 +146,6 @@ void testExprLongTest() {
 void testExprHalfTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kHalf);
-  ExprHandle value = ExprHandle((at::Half)3);
   ExprHandle body = ExprHandle((at::Half)2) +
       (x * ExprHandle((at::Half)3) + ExprHandle((at::Half)4));
   ExprHandle result = Let::make(x, ExprHandle((at::Half)3), body);
@@ -169,7 +156,6 @@ void testExprHalfTest() {
 void testExprDoubleTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kDouble);
-  ExprHandle value = ExprHandle((double)3);
   ExprHandle body = ExprHandle((double)2) +
       (x * ExprHandle((double)3) + ExprHandle((double)4));
   ExprHandle result = Let::make(x, ExprHandle((double)3), body);
@@ -475,8 +461,7 @@ void testStmtClone() {
 
   Buffer a_buf("a", kInt, {N});
   VarHandle index = VarHandle("index", kInt);
-  Stmt* body =
-      Store::make(BufHandle(a_buf.data()), {index}, 5, 1);
+  Stmt* body = Store::make(BufHandle(a_buf.data()), {index}, 5, 1);
   Stmt* loop = For::make(index, 0, N, body);
 
   Stmt* cloned_loop = Stmt::clone(loop);

--- a/test/cpp/tensorexpr/test_ir_printer.cpp
+++ b/test/cpp/tensorexpr/test_ir_printer.cpp
@@ -37,7 +37,6 @@ void testIRPrinterBasicValueTest02() {
 void testIRPrinterLetTest01() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
-  ExprHandle value = ExprHandle(3.f);
   ExprHandle body = ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f));
   ExprHandle result = Let::make(x, ExprHandle(3.f), body);
 
@@ -50,7 +49,6 @@ void testIRPrinterLetTest02() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
   VarHandle y("y", kFloat);
-  ExprHandle value = ExprHandle(3.f);
   ExprHandle body =
       ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f) * y);
   ExprHandle e1 = Let::make(x, ExprHandle(3.f), body);
@@ -66,7 +64,6 @@ void testIRPrinterCastTest() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
   VarHandle y("y", kFloat);
-  ExprHandle value = ExprHandle(3.f);
   ExprHandle body =
       ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f) * y);
   ExprHandle e1 = Let::make(x, Cast::make(kInt, ExprHandle(3.f)), body);

--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -161,7 +161,6 @@ void testLLVMByteToDoubleCastTest() {
 void testLLVMLetTest01() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
-  ExprHandle value = ExprHandle(3.f);
   ExprHandle body = ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f));
   ExprHandle result = Let::make(x, ExprHandle(3.f), body);
   LLVMExprEval cg(result, {});
@@ -172,7 +171,6 @@ void testLLVMLetTest02() {
   KernelScope kernel_scope;
   VarHandle x("x", kFloat);
   VarHandle y("y", kFloat);
-  ExprHandle value = ExprHandle(3.f);
   ExprHandle body =
       ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f) * y);
   ExprHandle e1 = Let::make(x, ExprHandle(3.f), body);
@@ -185,7 +183,6 @@ void testLLVMLetTestMultitype() {
   KernelScope kernel_scope;
   VarHandle x("x", kByte);
   VarHandle y("y", kHalf);
-  ExprHandle value = ExprHandle((short)3);
   ExprHandle body = ExprHandle((double)2.f) +
       (x * ExprHandle(3) + ExprHandle((int64_t)4) * y);
   ExprHandle e1 = Let::make(x, ExprHandle((uint8_t)3), body);
@@ -293,8 +290,8 @@ void testLLVMVecLoadStoreTest() {
 #define FLOAT_INTRINSICS_TEST(Name, Lanes)                       \
   void testLLVMVecFloat_##Name##Lane##Lanes##Test() {            \
     KernelScope kernel_scope;                                    \
-    Buffer a(BufHandle("A", {1}), kFloat);              \
-    Buffer b(BufHandle("B", {1}), kFloat);              \
+    Buffer a(BufHandle("A", {1}), kFloat);                       \
+    Buffer b(BufHandle("B", {1}), kFloat);                       \
     float val = 0.5f;                                            \
     std::vector<float> a_buffer(Lanes, val);                     \
     std::vector<float> b_buffer(Lanes, val);                     \
@@ -308,7 +305,6 @@ void testLLVMVecLoadStoreTest() {
         Broadcast::make(IntImm::make(1), Lanes));                \
     LLVMCodeGen cg(store, {a, b});                               \
     std::vector<void*> args({a_buffer.data(), b_buffer.data()}); \
-    float ref = std::Name(0.5f);                                 \
     ASSERT_EQ(cg.value<int>(args), 0);                           \
     for (int i = 0; i < Lanes; i++) {                            \
       ASSERT_FLOAT_EQ(a_buffer[i], val);                         \
@@ -339,8 +335,8 @@ FLOAT_INTRINSICS_TEST(lgamma, 8)
 #define DOUBLE_INTRINSICS_TEST(Name, Lanes)                      \
   void testLLVMVecDouble_##Name##Lane##Lanes##Test() {           \
     KernelScope kernel_scope;                                    \
-    Buffer a(BufHandle("A", {1}), kDouble);             \
-    Buffer b(BufHandle("B", {1}), kDouble);             \
+    Buffer a(BufHandle("A", {1}), kDouble);                      \
+    Buffer b(BufHandle("B", {1}), kDouble);                      \
     float val = 0.5f;                                            \
     std::vector<double> a_buffer(Lanes, val);                    \
     std::vector<double> b_buffer(Lanes, val);                    \
@@ -354,7 +350,6 @@ FLOAT_INTRINSICS_TEST(lgamma, 8)
         Broadcast::make(IntImm::make(1), Lanes));                \
     LLVMCodeGen cg(store, {a, b});                               \
     std::vector<void*> args({a_buffer.data(), b_buffer.data()}); \
-    float ref = std::Name(0.5f);                                 \
     ASSERT_EQ(cg.value<int>(args), 0);                           \
     for (int i = 0; i < Lanes; i++) {                            \
       ASSERT_FLOAT_EQ(a_buffer[i], val);                         \
@@ -501,7 +496,8 @@ void testLLVMElemwiseAddFloat() {
       i,
       0,
       N,
-      Store::make(c, {i}, Load::make(a, {i}, mask) + Load::make(b, {i}, mask), mask));
+      Store::make(
+          c, {i}, Load::make(a, {i}, mask) + Load::make(b, {i}, mask), mask));
 
   LLVMCodeGen cg(expr, {a, b, c});
 

--- a/torch/csrc/jit/tensorexpr/buffer.h
+++ b/torch/csrc/jit/tensorexpr/buffer.h
@@ -15,7 +15,7 @@ class Buffer {
     }
 
     std::vector<ExprHandle> stride_handles(ndim());
-    for (int i = ndim() - 1; i >= 0; i--) {
+    for (int i = (int)ndim() - 1; i >= 0; i--) {
       if (i == ndim() - 1) {
         stride_handles[i] = 1;
       } else {

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -941,28 +941,6 @@ inline Stmt* Substitute(Stmt* stmt, const VarMapping& var_mapping) {
   return stmt->accept_mutator(&var_sub);
 }
 
-// Uses the evaluator to fold an Expression with constant terms.
-// E.g. evaluateOp(Add(3, 4)) => 7.
-// Expr v must not have any unbound Vars.
-static Expr* evaluateOp(const Expr* v) {
-  ExprHandle handle(v);
-  ExprEval<SimpleIREvaluator> eval(handle);
-
-  switch (v->dtype().scalar_type()) {
-#define TYPE_CASE(Type, Name)                                 \
-  case ScalarType::Name: {                                    \
-    Type val = eval.value<Type>();                            \
-    return getImmediateByType(v->dtype().scalar_type(), val); \
-  }
-    AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
-#undef TYPE_CASE
-    default:
-      LOG(FATAL) << "Unsupported datatype: " << v->dtype();
-      return nullptr;
-  }
-  return nullptr;
-}
-
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -36,7 +36,8 @@ enum IRNodeType {
   kPolynomial,
   kTerm,
   kRoundOff,
-  kNone
+  kNone,
+  kExtra
 };
 
 // The common base between all expression node.
@@ -181,10 +182,10 @@ class TORCH_API Buf : public ExprNode<Buf> {
     TORCH_CHECK(var);
   }
 
-  int ndim() const {
+  size_t ndim() const {
     return dims_.size();
   }
-  const Expr* dim(int index) const {
+  const Expr* dim(size_t index) const {
     return dims_[index];
   }
   std::vector<const Expr*> dims() const {

--- a/torch/csrc/jit/tensorexpr/function.cpp
+++ b/torch/csrc/jit/tensorexpr/function.cpp
@@ -114,7 +114,7 @@ Tensor* Compute(
 Stmt* Function::ElementStmt(size_t index) {
   const Buf* buf = func_var(index);
   std::vector<const Expr*> indices;
-  for (size_t i = 0; i < buf->ndim(); i++) {
+  for (int i = 0; i < buf->ndim(); i++) {
     indices.push_back(this->args_[i]);
   }
 

--- a/torch/csrc/jit/tensorexpr/function.h
+++ b/torch/csrc/jit/tensorexpr/function.h
@@ -33,7 +33,7 @@ class Function : public KernelScopedObject {
     }
   }
 
-  const Var* arg(int index) const {
+  const Var* arg(size_t index) const {
     if (index < 0 || index >= args_.size()) {
       throw out_of_range_index();
     }

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -337,41 +337,6 @@ bool immediateIsNegative(const T* e) {
   return false;
 }
 
-// Creates a new Expr of the given type with the provided lhs and rhs.
-static const Expr* newBinaryOpOfType(
-    IRNodeType expr_type,
-    const Expr* lhs,
-    const Expr* rhs,
-    bool option) {
-  switch (expr_type) {
-    case IRNodeType::kAdd:
-      return new Add(lhs, rhs);
-    case IRNodeType::kSub:
-      return new Sub(lhs, rhs);
-    case IRNodeType::kMul:
-      return new Mul(lhs, rhs);
-    case IRNodeType::kDiv:
-      return new Div(lhs, rhs);
-    case IRNodeType::kMod:
-      return new Mod(lhs, rhs);
-    case IRNodeType::kMax:
-      return new Max(lhs, rhs, option);
-    case IRNodeType::kMin:
-      return new Min(lhs, rhs, option);
-    case IRNodeType::kAnd:
-      return new And(lhs, rhs);
-    case IRNodeType::kXor:
-      return new Xor(lhs, rhs);
-    case IRNodeType::kLshift:
-      return new Lshift(lhs, rhs);
-    case IRNodeType::kRshift:
-      return new Rshift(lhs, rhs);
-    default:
-      LOG(FATAL) << "unsupported expr_type: " << static_cast<int>(expr_type);
-      return nullptr;
-  }
-}
-
 // Bind the value to the var and evaluate the body.
 class Let : public ExprNode<Let> {
  public:

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -465,7 +465,6 @@ Stmt* StmtClone::mutate(const Free* v) {
 }
 
 Stmt* StmtClone::mutate(const Cond* v) {
-  const Expr* cond_old = v->condition();
   Stmt* true_old = v->true_stmt();
   Stmt* false_old = v->false_stmt();
 

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -13,6 +13,13 @@ T gcd(T a, T b) {
   return gcd(b, a % b);
 }
 
+// Helper for determining if an Expr is a multi-lane primitive (e.g. Broadcast
+// or Ramp).
+bool isMultilanePrimitive(const Expr* e) {
+  return e->expr_type() == IRNodeType::kBroadcast ||
+      e->expr_type() == IRNodeType::kRamp;
+}
+
 SimplifierHashType Term::hashVars() const {
   SimplifierHashType hash;
   for (auto* v : variables_) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1010,7 +1010,6 @@ void TensorExprKernel::lowerToBackend(BackendType backendType) {
       l.computeInline(l.getLoopBodyFor(tensorOutputs_[i]));
 
       Tensor* tensor = tensorOutputs[i];
-      const Var* index = tensor->arg(0);
       int loopLevels = getTECudaPointwiseLoopLevels();
       const int kDefaultLoopLevels = 2;
       loopLevels = (loopLevels > 0) ? loopLevels : kDefaultLoopLevels;

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -12,7 +12,7 @@ namespace tensorexpr {
 template <typename T>
 inline std::vector<int64_t> bufferSizes(const T& t) {
   std::vector<int64_t> sizes;
-  for (int i = 0; i < t->buf()->ndim(); i++) {
+  for (size_t i = 0; i < t->buf()->ndim(); i++) {
     sizes.push_back(dynamic_cast<const IntImm*>(t->buf()->dim(i))->value());
   }
   return sizes;

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -236,7 +236,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   // Emit prototype and bind argument Vars to parameter indices.
   llvm::Type* retTy = dtypeToLLVM(dtype);
   std::vector<llvm::Type*> params;
-  for (int i = 0; i < args.size(); i++) {
+  for (size_t i = 0; i < args.size(); i++) {
     auto const& arg = args[i];
     if (arg.isVar()) {
       params.push_back(dtypeToLLVM(arg.dtype()));
@@ -248,7 +248,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   llvm::FunctionType* fntype = llvm::FunctionType::get(retTy, params, false);
   fn_ = llvm::Function::Create(
       fntype, llvm::Function::PrivateLinkage, "pytorch", module_.get());
-  for (int i = 0; i < args.size(); i++) {
+  for (size_t i = 0; i < args.size(); i++) {
     if (!args[i].isVar()) {
       fn_->addParamAttr(i, llvm::Attribute::NoAlias);
     }
@@ -961,7 +961,6 @@ void LLVMCodeGenImpl::emitMaskedStore(
     llvm::Value* mask,
     llvm::Value* val) {
   // Create block structure for the masked store.
-  auto preheader = irb_.GetInsertBlock();
   auto condblock = llvm::BasicBlock::Create(getContext(), "cond", fn_);
   auto tailblock = llvm::BasicBlock::Create(getContext(), "tail", fn_);
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -382,7 +382,7 @@ class FunctionInliner : public IRMutator {
 
     if (should_inline(func)) {
       // Insert the caller/callee pair into the mapping.
-      for (int i = 0; i < buf->ndim(); i++) {
+      for (size_t i = 0; i < buf->ndim(); i++) {
         const Var* func_callee_arg = dynamic_cast<const Var*>(func->arg(i));
         const Expr* func_caller_param = v->param(i);
         auto iter = inline_mapping_.find(func_callee_arg);
@@ -398,7 +398,7 @@ class FunctionInliner : public IRMutator {
       const Expr* result = body->accept_mutator(this);
 
       // Remove the caller/callee relationship.
-      for (int i = 0; i < buf->ndim(); i++) {
+      for (size_t i = 0; i < buf->ndim(); i++) {
         const Var* func_callee_arg = dynamic_cast<const Var*>(func->arg(i));
         auto iter = inline_mapping_.find(func_callee_arg);
         if (iter == inline_mapping_.end()) {


### PR DESCRIPTION
Fix a bunch of minor warnings in jit/tensorexpr, mostly unused variable & wrong sign comparisons.