### PR TITLE
[quant] Enable fusion for conv modules with bias

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -89,6 +89,7 @@ class IntrinsicQATModuleTest(TestCase):
                 (pad_h, pad_w),
                 (dilation_h, dilation_w),
                 groups,
+                None,  # bias
                 padding_mode,
                 eps,
                 momentum,

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -14,7 +14,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
                  in_channels, out_channels, kernel_size, stride,
                  padding, dilation, transposed, output_padding,
                  groups,
-                 # bias: None, only support Conv with no bias
+                 bias,
                  padding_mode,
                  # BatchNormNd args
                  # num_features: out_channels
@@ -26,7 +26,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
                  qconfig=None):
         nn.modules.conv._ConvNd.__init__(self, in_channels, out_channels, kernel_size,
                                          stride, padding, dilation, transposed,
-                                         output_padding, groups, False, padding_mode)
+                                         output_padding, groups, False if bias is None else True, padding_mode)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
         self.eps = eps
@@ -96,17 +96,18 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
 
         if self.training and not self.freeze_bn:
             # recovering original conv to get original batch_mean and batch_var
-            conv_orig = conv / scale_factor.reshape([1, -1, 1, 1])
+            if self.bias is not None:
+                conv_orig = conv / scale_factor.reshape([1, -1, 1, 1]) + self.bias.reshape([1, -1, 1, 1])
+            else:
+                conv_orig = conv / scale_factor.reshape([1, -1, 1, 1])
             batch_mean = torch.mean(conv_orig, dim=[0, 2, 3])
             batch_var = torch.var(conv_orig, dim=[0, 2, 3], unbiased=False)
             n = float(conv_orig.numel() / conv_orig.size()[1])
             unbiased_batch_var = batch_var * (n / (n - 1))
             batch_rstd = torch.ones_like(batch_var, memory_format=torch.contiguous_format) / torch.sqrt(batch_var + self.eps)
 
-            rescale_factor = running_std * batch_rstd
-            conv = conv * rescale_factor.reshape([1, -1, 1, 1])
-            conv = conv + (self.beta - self.gamma * batch_mean * batch_rstd).reshape([1, -1, 1, 1])
-
+            conv = (self.gamma * batch_rstd).reshape([1, -1, 1, 1]) * conv_orig + \
+                (self.beta - self.gamma * batch_rstd * batch_mean).reshape([1, -1, 1, 1])
             self.running_mean = exponential_average_factor * batch_mean.detach() + \
                 (1 - exponential_average_factor) * self.running_mean
             self.running_var = exponential_average_factor * unbiased_batch_var.detach() + \
@@ -139,13 +140,13 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
         conv, bn = mod[0], mod[1]
         qat_convbn = cls(conv.in_channels, conv.out_channels, conv.kernel_size,
                          conv.stride, conv.padding, conv.dilation,
-                         conv.groups,
+                         conv.groups, conv.bias,
                          conv.padding_mode,
                          bn.eps, bn.momentum,
                          False,
                          qconfig)
-        assert qat_convbn.bias is None, 'QAT ConvBn should not have bias'
         qat_convbn.weight = conv.weight
+        qat_convbn.bias = conv.bias
         qat_convbn.gamma = bn.weight
         qat_convbn.beta = bn.bias
         qat_convbn.running_mean = bn.running_mean
@@ -179,7 +180,7 @@ class ConvBn2d(_ConvBnNd, nn.Conv2d):
                  # ConvNd args
                  in_channels, out_channels, kernel_size, stride=1,
                  padding=0, dilation=1, groups=1,
-                 # bias: None, only support Conv with no bias
+                 bias=None,
                  padding_mode='zeros',
                  # BatchNorm2d args
                  # num_features: out_channels
@@ -194,7 +195,7 @@ class ConvBn2d(_ConvBnNd, nn.Conv2d):
         padding = _pair(padding)
         dilation = _pair(dilation)
         _ConvBnNd.__init__(self, in_channels, out_channels, kernel_size, stride,
-                           padding, dilation, False, _pair(0), groups, padding_mode,
+                           padding, dilation, False, _pair(0), groups, bias, padding_mode,
                            eps, momentum, freeze_bn, qconfig)
 
 class ConvBnReLU2d(ConvBn2d):
@@ -223,7 +224,7 @@ class ConvBnReLU2d(ConvBn2d):
                  # Conv2d args
                  in_channels, out_channels, kernel_size, stride=1,
                  padding=0, dilation=1, groups=1,
-                 # bias: None, only support Conv with no bias
+                 bias=None,
                  padding_mode='zeros',
                  # BatchNorm2d args
                  # num_features: out_channels
@@ -234,7 +235,7 @@ class ConvBnReLU2d(ConvBn2d):
                  freeze_bn=False,
                  qconfig=None):
         super(ConvBnReLU2d, self).__init__(in_channels, out_channels, kernel_size, stride,
-                                           padding, dilation, groups,
+                                           padding, dilation, groups, bias,
                                            padding_mode, eps, momentum,
                                            freeze_bn,
                                            qconfig)

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -121,8 +121,11 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
             self.running_var = exponential_average_factor * unbiased_batch_var.detach() + \
                 (1 - exponential_average_factor) * self.running_var
         else:
-            conv = conv + (self.beta - self.gamma * self.running_mean /
-                           running_std).reshape([1, -1, 1, 1])
+            if self.bias is None:
+                conv = conv + (self.beta - self.gamma * self.running_mean /
+                               running_std).reshape([1, -1, 1, 1])
+            else:
+                conv = conv + (self.gamma * (self.bias - self.running_mean) / running_std + self.beta).reshape([1, -1, 1, 1])
         return conv
 
     def extra_repr(self):

--- a/torch/quantization/fuse_modules.py
+++ b/torch/quantization/fuse_modules.py
@@ -24,7 +24,6 @@ def fuse_conv_bn(conv, bn):
     is_3d = isinstance(conv, torch.nn.Conv3d)
 
     if conv.training:
-        assert conv.bias is None, 'Only support fusing Conv2d that does not have bias'
         assert bn.num_features == conv.out_channels, 'Output channel of Conv2d must match num_features of BatchNorm2d'
         assert bn.affine, 'Only support fusing BatchNorm2d with affine set to True'
         assert bn.track_running_stats, 'Only support fusing BatchNorm2d with tracking_running_stats set to True'
@@ -50,7 +49,6 @@ def fuse_conv_bn_relu(conv, bn, relu):
         "Conv and BN both must be in the same mode (train or eval)."
     is_3d = isinstance(conv, torch.nn.Conv3d)
     if conv.training:
-        assert conv.bias is None, 'Only support fusing Conv that does not have bias'
         assert bn.num_features == conv.out_channels, 'Output channel of Conv must match num_features of BatchNorm'
         assert bn.affine, 'Only support fusing BatchNorm with affine set to True'
         assert bn.track_running_stats, 'Only support fusing BatchNorm with tracking_running_stats set to True'

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -556,6 +556,26 @@ class ModelWithSequentialFusion(nn.Module):
         x = self.dequant(x)
         return x
 
+class ModelForFusionWithBias(nn.Module):
+    def __init__(self):
+        super(ModelForFusionWithBias, self).__init__()
+        self.conv1 = nn.Conv2d(3, 2, 5, bias=True).to(dtype=torch.float)
+        self.bn1 = nn.BatchNorm2d(2).to(dtype=torch.float)
+        self.relu1 = nn.ReLU(inplace=True).to(dtype=torch.float)
+        self.conv2 = nn.Conv2d(2, 2, 1, bias=True).to(dtype=torch.float)
+        self.bn2 = nn.BatchNorm2d(2).to(dtype=torch.float)
+        self.quant = QuantStub()
+        self.dequant = DeQuantStub()
+
+    def forward(self, x):
+        x = self.quant(x)
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu1(x)
+        x = self.conv2(x)
+        x = self.bn2(x)
+        x = self.dequant(x)
+        return x
 
 class DummyObserver(torch.nn.Module):
     def calculate_qparams(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36173 [quant] Enable fusion for conv modules with bias**

Summary:
Previously we were ignoring the conv bias during training if it existed
This PR adds the bias from the conv op during the conv+bn fusion process

Test Plan:
python test/quantization/test_quantization.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20921613](https://our.internmc.facebook.com/intern/diff/D20921613)