### PR TITLE
Minor doc improvement for code_analyzer

### DIFF
--- a/tools/code_analyzer/build.sh
+++ b/tools/code_analyzer/build.sh
@@ -16,6 +16,13 @@
 # 3. Analyze torch and generate yaml file of op dependency with debug path:
 # LLVM_DIR=${HOME}/src/llvm8/build/install \
 # ANALYZE_TORCH=1 tools/code_analyzer/build.sh -debug_path=true
+#
+# If you're a Facebook employee, chances are you're running on CentOS 8.
+# If that's the case, you can install all the dependencies you need with:
+#
+#   sudo dnf install llvm-devel llvm-static clang ncurses-devel
+#
+# and then set LLVM_DIR=/usr
 
 set -ex
 

--- a/tools/code_analyzer/op_dependency.cpp
+++ b/tools/code_analyzer/op_dependency.cpp
@@ -257,7 +257,9 @@ private:
             // One registration/invocation API might call another registration/
             // invocation API in which case we can skip processing the nested
             // call. This is a simple trick to avoid "cannot find registered/
-            // invoked op" warning and doesn't affect correctness.
+            // invoked op" warning and doesn't affect correctness, because
+            // later in scanOpRegistration we'll walk the transitively reachable
+            // IR graph again from each registration instance.
             if (!OpRegistrationPatternLoc.pattern->match(callerDemangled) &&
                 OpRegistrationPatternLoc.pattern->match(calleeDemangled)) {
               (*opRegistrationInsts).insert(&I);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36223 Add temporary impl_UNBOXED syntax sugar for unboxed-only defs.
* #36222 Add DispatchKey impl overload; remove use of torch::dispatch
* **#36177 Minor doc improvement for code_analyzer**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20904241](https://our.internmc.facebook.com/intern/diff/D20904241)