### PR TITLE
[JIT] fix alias assertion

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9492,6 +9492,16 @@ a")
         self.assertEqual(any_refinement(3, 4), 7)
         self.assertEqual(any_refinement(3, "hi"), 0)
 
+        @torch.jit.script
+        def any_refinement2(a):
+            # type: (Any) -> Tensor
+            if isinstance(a, Tensor):
+                return a
+            return torch.tensor(3)
+
+        self.assertEqual(any_refinement2(3), torch.tensor(3))
+        self.assertEqual(any_refinement2(torch.tensor(5)), torch.tensor(5))
+
     def test_any_in_class_fails(self):
         with self.assertRaisesRegex(RuntimeError, "contains an Any"):
             @torch.jit.script

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -862,7 +862,7 @@ void AliasDb::makePointerTo(const Value* from, const Value* to) {
 
   // covariant type containers can be point to types which are not
   // also mutable/immutable because we unify the contained types
-  // Any tyype can
+  // Any can point to/from immutable types
   if (isMutableTypeInternal(from) != isMutableTypeInternal(to)) {
     auto from_kind = from->type()->kind();
     bool expected_kind = false;

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -860,16 +860,17 @@ void AliasDb::makePointerTo(const Value* from, const Value* to) {
     return;
   }
 
-  // covariant type containers can be point to types which are not
-  // also mutable/immutable because we unify the contained types
-  // Any can point to/from immutable types
+  // the contained types of immutable type containers (optional, tuple, future)
+  // are unified, so these types can be mutable or immutable
+  // and point to a type which is mutable or immutable.
+  // Any is mutable but can point to a immutable type through refinement
   if (isMutableTypeInternal(from) != isMutableTypeInternal(to)) {
-    auto from_kind = from->type()->kind();
     bool expected_kind = false;
     for (auto kind : {from->type()->kind(), to->type()->kind()}) {
-      expected_kind = expected_kind || kind == TypeKind::OptionalType ||
-          kind == TypeKind::FutureType || kind == TypeKind::TupleType ||
-          kind == TypeKind::AnyType;
+      expected_kind = expected_kind ||
+          (kind == TypeKind::OptionalType || kind == TypeKind::FutureType ||
+           kind == TypeKind::TupleType) // immutable type containers
+          || kind == TypeKind::AnyType;
     }
     TORCH_INTERNAL_ASSERT(
         expected_kind, from->type()->str(), to->type()->str());


### PR DESCRIPTION
AnyType wasn't listed as a mutable type, so the assertion triggered (yay!). Also update the `isMutableTypeInternal(from) != isMutableTypeInternal` logic to be more encompassing.