### PR TITLE
[pt][quant] Add vector path to copy kernel for quantized data types

### DIFF
--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -19,9 +19,10 @@ static void copy_kernel(TensorIterator& iter, bool non_blocking) {
       cpu_kernel(iter, [=](at::BFloat16 a) -> at::BFloat16 { return a; });
     } else if (isQIntType(dtype)) {
       AT_DISPATCH_QINT_TYPES(dtype, "copy_kernel", [&] {
-        cpu_kernel(
+        cpu_kernel_vec(
             iter,
-            [=](scalar_t a) -> scalar_t {return a; });
+            [=](scalar_t a) -> scalar_t { return a; },
+            [=](Vec256<scalar_t> a) -> Vec256<scalar_t> { return a; });
       });
     } else if (isComplexType(dtype)) {
       AT_DISPATCH_COMPLEX_TYPES(dtype, "copy_kernel", [&] {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36189 [pt][quant] Add vector path to copy kernel for quantized data types**

We only had a scalar path for the copy kernel for quantized data types. This diff adds a vector path. It should improve all the ops where copy is used. This results in 10x better performance for mul_scalar in one of the benchmarked models.

### Before:
```
 -------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name                       Self CPU total %  Self CPU total   CPU total %      CPU total        CPU time avg     Number of Calls
-------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
quantize_per_tensor        0.16%            171.287us        0.16%            171.287us        171.287us        1
quantized::conv2d          56.65%           58.830ms         56.65%           58.830ms         387.040us        152
quantized::add_scalar      6.02%            6.256ms          6.02%            6.256ms          67.270us         93
quantized::relu6           2.04%            2.121ms          2.04%            2.121ms          22.808us         93
quantized::mul_scalar      19.33%           20.076ms         19.33%           20.076ms         215.876us        93
quantized::mul             13.79%           14.320ms         13.79%           14.320ms         124.520us        115
quantized::add             1.17%            1.215ms          1.17%            1.215ms          43.388us         28
adaptive_avg_pool2d        0.04%            41.684us         0.64%            661.083us        28.743us         23
_adaptive_avg_pool2d       0.60%            619.399us        0.60%            619.399us        26.930us         23
sigmoid                    0.17%            180.745us        0.17%            180.745us        8.216us          22
dropout                    0.00%            1.798us          0.00%            1.798us          1.798us          1
view                       0.01%            8.529us          0.01%            8.529us          8.529us          1
dequantize                 0.01%            7.481us          0.01%            7.481us          7.481us          1
-------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Self CPU time total: 103.849ms
```

### After:
```
 -------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name                       Self CPU total %  Self CPU total   CPU total %      CPU total        CPU time avg     Number of Calls
-------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
quantize_per_tensor        0.23%            193.581us        0.23%            193.581us        193.581us        1
quantized::conv2d          68.66%           58.702ms         68.66%           58.702ms         386.197us        152
quantized::add_scalar      7.11%            6.082ms          7.11%            6.082ms          65.401us         93
quantized::relu6           2.40%            2.056ms          2.40%            2.056ms          22.104us         93
quantized::mul_scalar      2.34%            2.001ms          2.34%            2.001ms          21.513us         93
quantized::mul             16.85%           14.410ms         16.85%           14.410ms         125.308us        115
quantized::add             1.34%            1.149ms          1.34%            1.149ms          41.033us         28
adaptive_avg_pool2d        0.05%            46.415us         0.78%            667.620us        29.027us         23
_adaptive_avg_pool2d       0.73%            621.205us        0.73%            621.205us        27.009us         23
sigmoid                    0.25%            215.650us        0.25%            215.650us        9.802us          22
dropout                    0.00%            2.503us          0.00%            2.503us          2.503us          1
view                       0.01%            11.608us         0.01%            11.608us         11.608us         1
dequantize                 0.01%            9.221us          0.01%            9.221us          9.221us          1
-------------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Self CPU time total: 85.500ms
```
```
import time
import torch
import torch.nn as nn
torch.set_num_threads(1)
# print(torch.__config__.parallel_info())

A = torch.rand(1, 54, 54, 256)
B = torch.rand(1, 54, 54, 256)

scale = .05
zero_point = 50

for dtype in [torch.quint8, torch.qint8, torch.qint32]:

    qA = torch.quantize_per_tensor(A, scale=scale, zero_point=zero_point,
            dtype=dtype)
    qB = torch.quantize_per_tensor(B, scale=scale, zero_point=zero_point,
            dtype=dtype)

    NITER = 1000
    s = time.time()
    for i in range(NITER):
        qB.copy_(qA)
    time_per_iter = (time.time() - s) / NITER

    print('dtype: {} time per iter ms: {:.3f}'.format(dtype, time_per_iter * 1000))
```
### Before: 
dtype: torch.quint8 time per iter ms: 0.766
dtype: torch.qint8 time per iter ms: 0.513
dtype: torch.qint32 time per iter ms: 0.511
### After: 
dtype: torch.quint8 time per iter ms: 0.061
dtype: torch.qint8 time per iter ms: 0.064
dtype: torch.qint32 time per iter ms: 0.242

Differential Revision: [D20906956](https://our.internmc.facebook.com/intern/diff/D20906956/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D20906956/)!