### PR TITLE
Fix signed-unsigned warnings

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -189,7 +189,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     }
 #if defined(EXPOSE_C2_OPS) || \
     !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
-    DCHECK_LT(0, newstyle_inputs_.size());
+    DCHECK_LT(0U, newstyle_inputs_.size());
     IValue ival;
     if (newstyle_inputs_[0].isTensorList()) {
       // if the first input is a tensor list, we get input tensors by indexing into that list.

--- a/caffe2/operators/conv_pool_op_base.h
+++ b/caffe2/operators/conv_pool_op_base.h
@@ -533,8 +533,8 @@ class ConvPoolOpBase : public Operator<Context> {
       const vector<TensorShape>& in,
       int output_channel) {
     ArgumentHelper helper(def);
-    CAFFE_ENFORCE_GT(in.size(), 0);
-    CAFFE_ENFORCE_GT(in[0].dims_size(), 0);
+    CAFFE_ENFORCE_GT(in.size(), 0U);
+    CAFFE_ENFORCE_GT(in[0].dims_size(), 0U);
     vector<int> pads = helper.GetRepeatedArgument<int>("pads");
     vector<int> kernel = helper.GetRepeatedArgument<int>("kernels");
     vector<int> strides = helper.GetRepeatedArgument<int>("strides");


### PR DESCRIPTION
Otherwise, while bazel spews following multi-line warning for every single caffe2 operator:
```
In file included from ./c10/util/logging_is_google_glog.h:50,
                 from ./c10/util/Logging.h:26,
                 from ./caffe2/core/logging.h:2,
                 from ./caffe2/core/blob.h:13,
                 from ./caffe2/core/operator.h:18,
                 from ./caffe2/sgd/adadelta_op.h:1,
                 from caffe2/sgd/adadelta_op.cc:1:
bazel-out/k8-fastbuild/bin/external/com_github_glog/_virtual_includes/glog/glog/logging.h: In instantiation of 'std::string* google::Check_LTImpl(const T1&, const T2&, const char*) [with T1 = int; T2 = long unsigned int; std::string = std::__cxx11::basic_string<char>]':
./caffe2/core/operator.h:192:5:   required from 'const T& caffe2::OperatorBase::Input(int, caffe2::DeviceType) [with T = caffe2::Tensor; caffe2::DeviceType = c10::DeviceType]'
./caffe2/core/operator.h:890:48:   required from 'const caffe2::Tensor& caffe2::Operator<Context>::Input(int, caffe2::DeviceType) [with Context = caffe2::CPUContext; caffe2::DeviceType = c10::DeviceType]'
./caffe2/sgd/adadelta_op.h:87:5:   required from 'bool caffe2::SparseAdadeltaOp<Context>::RunOnDevice() [with Context = caffe2::CPUContext]'
./caffe2/sgd/adadelta_op.h:85:8:   required from here
bazel-out/k8-fastbuild/bin/external/com_github_glog/_virtual_includes/glog/glog/logging.h:722:32: warning: comparison of integer expressions of different signedness: 'const int' and 'const long unsigned int' [-Wsign-compare]
  722 | DEFINE_CHECK_OP_IMPL(Check_LT, < )
      |                                ^
bazel-out/k8-fastbuild/bin/external/com_github_glog/_virtual_includes/glog/glog/logging.h:148:53: note: in definition of macro 'GOOGLE_PREDICT_TRUE'
  148 | #define GOOGLE_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
      |                                                     ^
bazel-out/k8-fastbuild/bin/external/com_github_glog/_virtual_includes/glog/glog/logging.h:722:1: note: in expansion of macro 'DEFINE_CHECK_OP_IMPL'
  722 | DEFINE_CHECK_OP_IMPL(Check_LT, < )
      | ^~~~~~~~~~~~~~~~~~~~
```

