### PR TITLE
[TensorPipe/RPC] Serialize and deserialize message

### DIFF
--- a/test/cpp/rpc/CMakeLists.txt
+++ b/test/cpp/rpc/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TORCH_RPC_TEST_DIR "${TORCH_ROOT}/test/cpp/rpc")
 set(TORCH_RPC_TEST_SOURCES
   ${TORCH_ROOT}/test/cpp/common/main.cpp
   ${TORCH_RPC_TEST_DIR}/test_wire_serialization.cpp
+  ${TORCH_RPC_TEST_DIR}/test_tensorpipe_serialization.cpp
 )
 
 add_executable(test_cpp_rpc ${TORCH_RPC_TEST_SOURCES})

--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include <tensorpipe/core/message.h>
+#include <torch/torch.h>
+#include <torch/csrc/distributed/rpc/utils.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+
+TEST(TensorpipeSerialize, Base) {
+  // Sender serializes
+  at::Tensor t1 = torch::ones({1024}, at::ScalarType::Int);
+  at::Tensor t2 = torch::ones({1024}, at::ScalarType::Float);
+  std::vector<at::Tensor> tensors{t1, t2};
+  std::vector<char> payload = {'1', '2', '3'};
+  std::vector<char> payloadCopy = payload; // for testing
+  torch::distributed::rpc::MessageType mtype =
+      torch::distributed::rpc::MessageType::UNKNOWN;
+  torch::distributed::rpc::Message sendingRpcMessage(
+      std::move(payload), std::move(tensors), mtype);
+  torch::distributed::rpc::TensorPipeEntry tpEntry =
+      torch::distributed::rpc::tensorpipeSerialize(sendingRpcMessage);
+  tensorpipe::Message sendingTpMessage = std::move(tpEntry.message);
+  EXPECT_EQ(sendingTpMessage.tensors.size(), 2);
+
+  // Mimic receiving message descriptor
+  tensorpipe::Message recvingTpMessage;
+  recvingTpMessage.length = sendingTpMessage.length;
+  recvingTpMessage.metadata = sendingTpMessage.metadata;
+  recvingTpMessage.tensors.reserve(sendingTpMessage.tensors.size());
+  for (auto& tpTensor : sendingTpMessage.tensors) {
+    tensorpipe::Message::Tensor t;
+    t.length = tpTensor.length;
+    t.metadata = tpTensor.metadata;
+    recvingTpMessage.tensors.push_back(std::move(t));
+  }
+  EXPECT_EQ(
+      recvingTpMessage.tensors.size(), sendingTpMessage.tensors.size());
+
+  // Mimic readDescriptor() callback:
+  // 1. Allocate rpc message
+  // 2. Fill pointers to tensorpipe message
+  torch::distributed::rpc::Message recvingRpcMessage =
+      torch::distributed::rpc::tensorpipeAllocateMessage(recvingTpMessage);
+  EXPECT_EQ(
+      recvingRpcMessage.tensors().size(), recvingTpMessage.tensors.size());
+  recvingTpMessage.data = (uint8_t*)(recvingRpcMessage.payload().data());
+  for (int i = 0; i < recvingRpcMessage.tensors().size(); i++) {
+    auto& rpcTensor = recvingRpcMessage.tensors()[i];
+    auto& tpTensor = recvingTpMessage.tensors[i];
+    tpTensor.data = (uint8_t*)(rpcTensor.data_ptr());
+  }
+
+  // Mimic tensorpipe data transfer
+  for (int i = 0; i < recvingTpMessage.tensors.size(); i++) {
+    auto& srcTensor = sendingTpMessage.tensors[i];
+    auto& dstTensor = recvingTpMessage.tensors[i];
+    memcpy(dstTensor.data, srcTensor.data, srcTensor.length);
+  }
+  memcpy(recvingTpMessage.data, sendingTpMessage.data, sendingTpMessage.length);
+  recvingTpMessage.metadata = sendingTpMessage.metadata;
+
+  // Data is ready
+  EXPECT_EQ(mtype, recvingRpcMessage.type());
+  EXPECT_EQ(payloadCopy, recvingRpcMessage.payload());
+  EXPECT_TRUE(torch::equal(t1, recvingRpcMessage.tensors()[0]));
+  EXPECT_TRUE(torch::equal(t2, recvingRpcMessage.tensors()[1]));
+}
+
+TEST(TensorpipeSerialize, RecopySparseTensors) {
+  // Take a 1K row of a 1M tensors, and make sure we don't send across 1M rows.
+  constexpr size_t k1K = 1024;
+  at::Tensor main = torch::randn({k1K, k1K});
+  at::Tensor tiny = main.select(0, 2); // Select a row in the middle
+  EXPECT_EQ(tiny.numel(), k1K);
+  EXPECT_EQ(tiny.storage().numel(), k1K * k1K);
+
+  std::vector<at::Tensor> tensors{main, tiny};
+  std::vector<char> payload = {'1', '2', '3'};
+  torch::distributed::rpc::MessageType mtype =
+      torch::distributed::rpc::MessageType::UNKNOWN;
+  torch::distributed::rpc::Message sendingRpcMessage(
+      std::move(payload), std::move(tensors), mtype);
+
+  torch::distributed::rpc::TensorPipeEntry tpEntry =
+      torch::distributed::rpc::tensorpipeSerialize(sendingRpcMessage);
+  tensorpipe::Message sendingTpMessage = std::move(tpEntry.message);
+
+  EXPECT_EQ(tpEntry.reservedTensors.size(), 2);
+  EXPECT_EQ(sendingTpMessage.tensors.size(), 2);
+  EXPECT_TRUE(torch::equal(main, tpEntry.reservedTensors[0]));
+  EXPECT_TRUE(torch::equal(tiny, tpEntry.reservedTensors[1]));
+  // Test cloned storage
+  EXPECT_EQ(main.storage().data(), sendingTpMessage.tensors[0].data);
+  EXPECT_NE(tiny.storage().data(), sendingTpMessage.tensors[1].data);
+  EXPECT_EQ(tiny.element_size() * k1K, sendingTpMessage.tensors[1].length);
+}
+
+TEST(TensorpipeSerialize, NoDeleterTensors) {
+  std::vector<float> blob1{.8, .2};
+  std::vector<float> blob2{.7, .5, .9};
+  at::Tensor t1 = torch::from_blob((float*)(blob1.data()), blob1.size());
+  at::Tensor t2 = torch::from_blob((float*)(blob2.data()), blob2.size());
+  std::vector<at::Tensor> tensors{t1, t2};
+  std::vector<char> payload = {'1', '2', '3'};
+  torch::distributed::rpc::MessageType mtype =
+      torch::distributed::rpc::MessageType::UNKNOWN;
+  torch::distributed::rpc::Message sendingRpcMessage(
+      std::move(payload), std::move(tensors), mtype);
+
+  torch::distributed::rpc::TensorPipeEntry tpEntry =
+      torch::distributed::rpc::tensorpipeSerialize(sendingRpcMessage);
+  tensorpipe::Message sendingTpMessage = std::move(tpEntry.message);
+
+  EXPECT_EQ(tpEntry.copiedTensors.size(), 2);
+  EXPECT_EQ(sendingTpMessage.tensors.size(), 2);
+  EXPECT_EQ(tpEntry.copiedTensors[0].size(), sendingTpMessage.tensors[0].length);
+  EXPECT_EQ(tpEntry.copiedTensors[1].size(), sendingTpMessage.tensors[1].length);
+  EXPECT_EQ(tpEntry.copiedTensors[0].data(), sendingTpMessage.tensors[0].data);
+  EXPECT_EQ(tpEntry.copiedTensors[1].data(), sendingTpMessage.tensors[1].data);
+  EXPECT_TRUE(
+      memcmp(
+          tpEntry.copiedTensors[0].data(),
+          t1.storage().data(),
+          sendingTpMessage.tensors[0].length) == 0);
+  EXPECT_TRUE(
+      memcmp(
+          tpEntry.copiedTensors[1].data(),
+          t2.storage().data(),
+          sendingTpMessage.tensors[1].length) == 0);
+}

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -524,6 +524,7 @@ def add_torch_libs():
             "//caffe2/caffe2:caffe2_cpu",
             "//caffe2/caffe2/quantization/server:dnnlowp_ops",
             "//caffe2/torch/lib/libshm:libshm",
+            "//tensorpipe/core:core",
         ],
         external_deps = [
             ("nanopb", None, "protobuf-nanopb"),

--- a/torch/csrc/distributed/rpc/utils.h
+++ b/torch/csrc/distributed/rpc/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <tensorpipe/core/message.h>
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 
 namespace torch {
@@ -38,6 +39,18 @@ TORCH_API std::string wireSerialize(
 TORCH_API std::pair<std::vector<char>, std::vector<at::Tensor>> wireDeserialize(
     const void* data,
     size_t data_size);
+
+// Tensorpipe message conversion
+struct TensorPipeEntry {
+  tensorpipe::Message message;
+  std::vector<torch::Tensor> reservedTensors;
+  std::vector<std::vector<uint8_t>> copiedTensors;
+};
+
+TORCH_API TensorPipeEntry tensorpipeSerialize(const Message& rpcMessage);
+
+TORCH_API Message
+tensorpipeAllocateMessage(const tensorpipe::Message& tpMessage);
 
 // Some Tensors are effectively views of larger Tensors, where only a small
 // subset of the Storage data is referenced. This normally is good and avoids


### PR DESCRIPTION
Summary:
Create APIs to convert between rpc::message and tensorpipe::message
1. tensorpipeSerialize() - converts rpc::message to tensorpipe::message without memory copy (tensors).
2. tensorpipeAllocateMessage - allocates rpc::message based on received tensorpipe descriptor to prepare memory-copy-free receiving.

Test Plan: buck test caffe2/test/cpp/rpc:test_tensorpipe_serialization

Differential Revision: D20084125

