### PR TITLE
Back out "[reland] Skip OpenMP Thread when OMP_NUM_THREADS is 1"

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -25,37 +25,35 @@ inline void parallel_for(
 #ifdef _OPENMP
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-  if (!omp_in_parallel() && ((end - begin) > grain_size) && omp_get_num_threads() > 1) {
-#pragma omp parallel
-    {
-      // choose number of tasks based on grain size and number of threads
-      // can't use num_threads clause due to bugs in GOMP's thread pool (See #32008)
-      int64_t num_threads = omp_get_num_threads();
-      if (grain_size > 0) {
-        num_threads = std::min(num_threads, divup((end - begin), grain_size));
-      }
 
-      int64_t tid = omp_get_thread_num();
-      int64_t chunk_size = divup((end - begin), num_threads);
-      int64_t begin_tid = begin + tid * chunk_size;
-      if (begin_tid < end) {
-        try {
-          f(begin_tid, std::min(end, chunk_size + begin_tid));
-        } catch (...) {
-          if (!err_flag.test_and_set()) {
-            eptr = std::current_exception();
-          }
+#pragma omp parallel if (!omp_in_parallel() && ((end - begin) > grain_size))
+  {
+    // choose number of tasks based on grain size and number of threads
+    // can't use num_threads clause due to bugs in GOMP's thread pool (See #32008)
+    int64_t num_threads = omp_get_num_threads();
+    if (grain_size > 0) {
+      num_threads = std::min(num_threads, divup((end - begin), grain_size));
+    }
+
+    int64_t tid = omp_get_thread_num();
+    int64_t chunk_size = divup((end - begin), num_threads);
+    int64_t begin_tid = begin + tid * chunk_size;
+    if (begin_tid < end) {
+      try {
+        f(begin_tid, std::min(end, chunk_size + begin_tid));
+      } catch (...) {
+        if (!err_flag.test_and_set()) {
+          eptr = std::current_exception();
         }
       }
     }
-    if (eptr) {
-      std::rethrow_exception(eptr);
-    }
-  } else
-#endif
-  {
-    f(begin, end);
   }
+  if (eptr) {
+    std::rethrow_exception(eptr);
+  }
+#else
+  f(begin, end);
+#endif
 }
 
 template <class scalar_t, class F, class SF>


### PR DESCRIPTION
Summary:
Original commit changeset: 4476a810dfe7

With the previous diff, when user sets KMP_AFFINITY, it will be ignored when OMP_NUM_THREADS is 1. That could cause performance regression.

Test Plan: n/a

Differential Revision: D20909628

