### PR TITLE
Revert "Revert D20885968: [pytorch][PR] Enable backtrace with MSVC"

### DIFF
--- a/c10/util/Backtrace.cpp
+++ b/c10/util/Backtrace.cpp
@@ -8,6 +8,16 @@
 #include <string>
 #include <vector>
 
+#ifdef _MSC_VER
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <iomanip>
+#include <Windows.h>
+#include <dbghelp.h>
+#pragma comment(lib, "Dbghelp.lib")
+#endif
+
 #if (defined(__ANDROID__)) ||                                                 \
     (defined(__APPLE__) &&                                                    \
      (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE)) || \
@@ -22,11 +32,6 @@
 
 namespace c10 {
 
-// TODO: This backtrace retrieval can be implemented on Windows via the Windows
-// API using `CaptureStackBackTrace` and `SymFromAddr`.
-// https://stackoverflow.com/questions/5693192/win32-backtrace-from-c-code
-// https://stackoverflow.com/questions/26398064/counterpart-to-glibcs-backtrace-and-backtrace-symbols-on-windows
-// https://msdn.microsoft.com/en-us/library/windows/desktop/bb204633%28v=vs.85%29.aspx.
 #if SUPPORTS_BACKTRACE
 namespace {
 
@@ -115,7 +120,55 @@ c10::optional<FrameInformation> parse_frame_information(
   frame.function_name = demangle(mangled_function_name.c_str());
   return frame;
 }
+} // anonymous namespace
+#elif defined(_MSC_VER)
+namespace {
+const int max_name_len = 256;
+std::string get_module_base_name(void* addr) {
+  HMODULE h_module;
+  char module[max_name_len];
+  strcpy(module, "");
+  GetModuleHandleEx(
+      GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+          GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+      (LPCTSTR)addr,
+      &h_module);
+  if (h_module != NULL) {
+    GetModuleFileNameA(h_module, module, max_name_len);
+  }
+  char* last_slash_pos = strrchr(module, '\\');
+  if (last_slash_pos) {
+    std::string module_base_name(last_slash_pos + 1);
+    return module_base_name;
+  } else {
+    std::string module_base_name(module);
+    return module_base_name;
+  }
+}
+class SymbolHelper {
+ public:
+  static SymbolHelper& getInstance() {
+    static SymbolHelper instance;
+    return instance;
+  }
+  bool inited = false;
+  HANDLE process;
 
+ private:
+  SymbolHelper() {
+    process = GetCurrentProcess();
+    inited = SymInitialize(process, NULL, TRUE);
+  }
+  ~SymbolHelper() {
+    if (inited) {
+      SymCleanup(process);
+    }
+  }
+
+ public:
+  SymbolHelper(SymbolHelper const&) = delete;
+  void operator=(SymbolHelper const&) = delete;
+};
 } // anonymous namespace
 #endif // SUPPORTS_BACKTRACE
 
@@ -194,7 +247,85 @@ std::string get_backtrace(
   }
 
   return stream.str();
-#else // !SUPPORTS_BACKTRACE
+#elif defined(_MSC_VER) // !SUPPORTS_BACKTRACE
+  // This backtrace retrieval is implemented on Windows via the Windows
+  // API using `CaptureStackBackTrace`, `SymFromAddr` and `SymGetLineFromAddr64`.
+  // https://stackoverflow.com/questions/5693192/win32-backtrace-from-c-code
+  // https://stackoverflow.com/questions/26398064/counterpart-to-glibcs-backtrace-and-backtrace-symbols-on-windows
+  // https://docs.microsoft.com/en-us/windows/win32/debug/capturestackbacktrace
+  // https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-symfromaddr
+  // https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-symgetlinefromaddr64
+  // TODO: Support skipping python frames
+
+  // We always skip this frame (backtrace).
+  frames_to_skip += 1;
+
+  DWORD64 displacement;
+  DWORD disp;
+  std::unique_ptr<IMAGEHLP_LINE64> line;
+
+  char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+  PSYMBOL_INFO p_symbol = (PSYMBOL_INFO)buffer;
+
+  std::unique_ptr<void*[]> back_trace(new void*[maximum_number_of_frames]);
+  bool with_symbol = false;
+  bool with_line = false;
+
+  // The backtrace string goes into here.
+  std::ostringstream stream;
+
+  // Get the frames
+  const USHORT n_frame = CaptureStackBackTrace(
+      static_cast<DWORD>(frames_to_skip),
+      static_cast<DWORD>(maximum_number_of_frames),
+      back_trace.get(),
+      NULL);
+
+  // Initialize symbols if necessary
+  SymbolHelper& sh = SymbolHelper::getInstance();
+
+  for (USHORT i_frame = 0; i_frame < n_frame; ++i_frame) {
+    // Get the address and the name of the symbol
+    if (sh.inited) {
+      p_symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+      p_symbol->MaxNameLen = MAX_SYM_NAME;
+      with_symbol = SymFromAddr(
+          sh.process, (ULONG64)back_trace[i_frame], &displacement, p_symbol);
+    }
+
+    // Get the line number and the module
+    if (sh.inited) {
+      line.reset(new IMAGEHLP_LINE64());
+      line->SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+      with_line = SymGetLineFromAddr64(
+          sh.process, (ULONG64)back_trace[i_frame], &disp, line.get());
+    }
+
+    // Get the module basename
+    std::string module = get_module_base_name(back_trace[i_frame]);
+
+    // The pattern on Windows is
+    // `<return-address> <symbol-address>
+    // <module-name>!<demangled-function-name> [<file-name> @ <line-number>]
+    stream << std::setfill('0') << std::setw(16) << std::uppercase << std::hex
+           << back_trace[i_frame] << std::dec;
+    if (with_symbol) {
+      stream << std::setfill('0') << std::setw(16) << std::uppercase << std::hex
+             << p_symbol->Address << std::dec << " " << module << "!" << p_symbol->Name;
+    } else {
+      stream << " <unknown symbol address> " << module << "!<unknown symbol>";
+    }
+    stream << " [";
+    if (with_line) {
+      stream << line->FileName << " @ " << line->LineNumber;
+    } else {
+      stream << "<unknown file> @ <unknown line number>";
+    }
+    stream << "]" << std::endl;
+  }
+
+  return stream.str();
+#else // !SUPPORTS_BACKTRACE && !_WIN32
   return "(no backtrace available)";
 #endif // SUPPORTS_BACKTRACE
 }

--- a/c10/util/Backtrace.cpp
+++ b/c10/util/Backtrace.cpp
@@ -157,6 +157,8 @@ class SymbolHelper {
  private:
   SymbolHelper() {
     process = GetCurrentProcess();
+    DWORD flags = SymGetOptions();
+    SymSetOptions(flags | SYMOPT_DEFERRED_LOADS);
     inited = SymInitialize(process, NULL, TRUE);
   }
   ~SymbolHelper() {


### PR DESCRIPTION
This reverts commit 8afa001d898914a48d6b9e3d944a99607d2819c1 and made a few improvements including the following items.
1. return `std::string` for `get_module_base_name`
2. eliminate `module should always be true` warning
3. do `SymInitialize` and `SymCleanup` once to save time

