### PR TITLE
fix build breakage of //sigrid/...

### DIFF
--- a/caffe2/contrib/fakelowp/fp16_fma.cc
+++ b/caffe2/contrib/fakelowp/fp16_fma.cc
@@ -65,14 +65,18 @@ void fma_fp16(int N, const float* A, const float* B, float* Out) {
 
     __m256i cmp = _mm256_cmpgt_epi64(_mm256_set1_epi64x(-14), mExpv);
 
-    __m256i mExpoBouncer = _mm256_and_pd(cmp, _mm256_set1_epi64x(28));
+    __m256d mExpoBouncer = _mm256_and_pd(
+        _mm256_castsi256_pd(cmp), _mm256_castsi256_pd(_mm256_set1_epi64x(28)));
     mExpoBouncer = _mm256_or_pd(
         mExpoBouncer,
-        _mm256_andnot_pd(cmp, _mm256_add_epi64(_mm256_set1_epi64x(42), mExpv)));
+        _mm256_andnot_pd(
+            _mm256_castsi256_pd(cmp),
+            _mm256_castsi256_pd(
+                _mm256_add_epi64(_mm256_set1_epi64x(42), mExpv))));
 
-    __m256 mBouncer = _mm256_add_epi64(
+    __m256i mBouncer = _mm256_add_epi64(
         _mm256_set1_epi64x(dbl_threehalf),
-        _mm256_slli_epi64(mExpoBouncer, shift_bits));
+        (__m256i)_mm256_slli_epi64((__m256i)mExpoBouncer, shift_bits));
 
     mOut = _mm256_sub_pd(
         _mm256_add_pd(_mm256_castsi256_pd(mBouncer), mOut),

--- a/caffe2/contrib/fakelowp/fp16_fma_slow.cc
+++ b/caffe2/contrib/fakelowp/fp16_fma_slow.cc
@@ -501,7 +501,7 @@ void fma16(
     Word16* result,
     Word32* fsr_o) {
   Word16 res;
-  Word32 fsr;
+  Word32 fsr = 0;
   // Call fp utility
   fp_mac_h(b, input, a, 0, fcr, fsr_i, &res, &fsr);
   // Output result
@@ -513,7 +513,6 @@ float fake_fma_fp16_slow(float v1, float v2, float v3) {
   uint32_t fcr_val = 0;
   uint32_t fsr_val = 0x00000F80;
   uint32_t exception_flags = 0;
-  uint16_t result;
 
   uint16_t hv1, hv2, hv3, hresult;
   hv1 = _cvtss_sh(v1, 0);


### PR DESCRIPTION
Summary:
nothing wrong with the code, adding appropriate casts
to keep the compiler happy

Test Plan:
build //sigrid/...
tests in the same directory
buck test //glow/glow/tests/fakelowp/...

Differential Revision: D20911279

