### PR TITLE
[FBGEMM] Open sourcing fbgemm_fp16 ops (#342)

### DIFF
--- a/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
@@ -1,8 +1,8 @@
+#include <fbgemm/FbgemmFakeFP16.h>
 #include "caffe2/caffe2/operators/elementwise_add_op.h"
 #include "caffe2/caffe2/operators/elementwise_div_op.h"
 #include "caffe2/caffe2/operators/elementwise_mul_op.h"
 #include "caffe2/caffe2/operators/elementwise_sub_op.h"
-#include "caffe2/fb/fbgemm/fbgemm_fp16/include/fbgemm/FbgemmFloat16.h"
 #include "caffe2/fb/fbgemm/sum_fp16_fake_op.h"
 #include "caffe2/operators/utility_ops.h"
 

--- a/caffe2/contrib/fakelowp/lengths_reducer_ops.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_ops.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <fbgemm/FbgemmFakeFP16.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/fb/fbgemm/fbgemm_fp16/include/fbgemm/FbgemmFloat16.h"
 #include "caffe2/perfkernels/typed_axpy.h"
 
 C10_DECLARE_bool(caffe2_fbgemm_fake_fp16_clamp);

--- a/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
@@ -6,9 +6,9 @@
 #include <string>
 #include <vector>
 
+#include <fbgemm/FbgemmFakeFP16.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
-#include "caffe2/fb/fbgemm/fbgemm_fp16/include/fbgemm/FbgemmFloat16.h"
 #include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 #include "fp16_fma.h"

--- a/caffe2/contrib/fakelowp/unary_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/unary_fp16_fake_op.cc
@@ -1,5 +1,5 @@
 #include "unary_fp16_fake_op.h"
-#include "caffe2/fb/fbgemm/fbgemm_fp16/include/fbgemm/FbgemmFloat16.h"
+#include <fbgemm/FbgemmFakeFP16.h>
 
 #include "caffe2/utils/eigen_utils.h"
 

--- a/caffe2/contrib/fakelowp/unary_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/unary_fp16_fake_op.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "caffe2/fb/fbgemm/fbgemm_fp16/include/fbgemm/FbgemmFloat16.h"
+#include <fbgemm/FbgemmFakeFP16.h>
 #include "caffe2/operators/elementwise_ops.h"
 #include "caffe2/utils/math.h"
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/342

So that we can let vendor use this as a reference for fp16 emulated ops.

Will modify the dependent TARGETS and CMakefiles.

Test Plan:
```
buck test deeplearning/fbgemm:
```

Differential Revision: D20911460

