### PR TITLE
[future] Undo some recent torch::utils::Future api changes

### DIFF
--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -187,16 +187,18 @@ void DistAutogradContainer::sendReleaseContextRpc(int64_t context_id) {
           CleanupAutogradContextReq(context_id).toMessage(),
           options);
 
-      cleanupFuture->addCallback([cleanupFuture]() {
-        if (cleanupFuture->hasError()) {
-          std::string errorMsg = c10::str(
-              "Could not release Dist Autograd Context after ",
-              kNumCleanupContextRetries,
-              " attempts.");
-          LOG(ERROR) << errorMsg;
-          return;
-        }
-      });
+      cleanupFuture->addCallback(
+          [](const rpc::Message& message /* unused */,
+             const c10::optional<torch::utils::FutureError>& error) {
+            if (error) {
+              std::string errorMsg = c10::str(
+                  "Could not release Dist Autograd Context after ",
+                  kNumCleanupContextRetries,
+                  " attempts.");
+              LOG(ERROR) << errorMsg;
+              return;
+            }
+          });
     } catch (const std::exception& e) {
       LOG(INFO)
           << "Failed to send RPC to clear Dist Autograd context to worker id: "

--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -122,21 +122,25 @@ void DistAutogradContext::resetGraphTask() {
 
 void DistAutogradContext::addOutstandingRpc(
     const std::shared_ptr<rpc::FutureMessage>& futureMessage) {
-  futureMessage->addCallback([this, futureMessage]() {
-    if (futureMessage->hasError()) {
-      // If we have an error, let the local autograd engine know about it.
-      std::runtime_error err(futureMessage->error()->what());
-      std::unique_lock<std::mutex> lock(lock_);
-      if (graphTask_) {
-        graphTask_->set_exception_without_signal(nullptr);
-        lock.unlock();
-        graphTask_->future_result_->setErrorIfNeeded(err.what());
-      } else {
-        LOG(WARNING) << "Ignoring error since GraphTask is no longer valid: "
-                     << err.what();
-      }
-    }
-  });
+  futureMessage->addCallback(
+      [this](
+          const rpc::Message& /* unused */,
+          const c10::optional<utils::FutureError>& futErr) {
+        if (futErr) {
+          // If we have an error, let the local autograd engine know about it.
+          std::runtime_error err((*futErr).what());
+          std::unique_lock<std::mutex> lock(lock_);
+          if (graphTask_) {
+            graphTask_->set_exception_without_signal(nullptr);
+            lock.unlock();
+            graphTask_->future_result_->setErrorIfNeeded(err.what());
+          } else {
+            LOG(WARNING)
+                << "Ignoring error since GraphTask is no longer valid: "
+                << err.what();
+          }
+        }
+      });
   std::lock_guard<std::mutex> guard(lock_);
   outStandingRpcs_.push_back(futureMessage);
 }
@@ -164,8 +168,10 @@ std::shared_ptr<rpc::FutureMessage> DistAutogradContext::
     state->future->markCompleted(rpc::Message());
   } else {
     for (auto& rpc : outStandingRpcs) {
-      rpc->addCallback([state, rpc]() {
-        if (rpc->hasError()) {
+      rpc->addCallback([state](
+                           const rpc::Message& /* unused */,
+                           const c10::optional<utils::FutureError>& err) {
+        if (err) {
           // If there's an error, we want to setError() on the future, unless
           // another error has already been sent - use a CAS to guard.
           //
@@ -176,7 +182,7 @@ std::shared_ptr<rpc::FutureMessage> DistAutogradContext::
           bool expectedAlreadySent = false;
           if (state->alreadySentError.compare_exchange_strong(
                   expectedAlreadySent, true)) {
-            state->future->setError(rpc->error()->what());
+            state->future->setError(err->what());
           }
           return;
         }

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -15,8 +15,8 @@ using torch::autograd::Engine;
 using torch::autograd::FutureVariableList;
 using torch::autograd::GraphRoot;
 using torch::autograd::GraphTask;
-using torch::autograd::Node;
 using torch::autograd::ReadyQueue;
+using torch::autograd::Node;
 using torch::autograd::validate_outputs;
 using torch::autograd::variable_list;
 
@@ -90,6 +90,7 @@ void DistEngine::computeDependencies(
       /* depth */ 0,
       /* cpu_ready_queue */ cpu_ready_queue,
       /* exit_on_error */ true);
+
 
   // Run BFS to traverse the graph locally. The roots of the graph are
   // GraphRoot and all send functions for this autograd context.
@@ -199,8 +200,7 @@ std::shared_ptr<rpc::FutureMessage> DistEngine::runEngineAndAccumulateGradients(
   // passes ran into errors.
   autogradContext->clearOutstandingRpcs();
 
-  auto futureGrads = engine_.execute_with_graph_task(
-      autogradContext->retrieveGraphTask(), graphRoot, /*async_mode=*/true);
+  auto futureGrads = engine_.execute_with_graph_task(autogradContext->retrieveGraphTask(), graphRoot, /*async_mode=*/true);
 
   // Build a future that waits for the callbacks to execute (since callbacks
   // execute after the original future is completed). This ensures we return a
@@ -208,8 +208,10 @@ std::shared_ptr<rpc::FutureMessage> DistEngine::runEngineAndAccumulateGradients(
   auto accumulateGradFuture = std::make_shared<rpc::FutureMessage>();
 
   futureGrads->addCallback(
-      [autogradContext, outputEdges, accumulateGradFuture, futureGrads]() {
-        if (futureGrads->hasError()) {
+      [autogradContext, outputEdges, accumulateGradFuture](
+          const variable_list& grads,
+          const c10::optional<torch::utils::FutureError>& error) {
+        if (error) {
           // Don't accumulate gradients if we receive an error.
           // We must add the node information here since DistEngine::execute
           // waits on accumulateGradFuture and will throw an exception once we
@@ -218,11 +220,11 @@ std::shared_ptr<rpc::FutureMessage> DistEngine::runEngineAndAccumulateGradients(
               "Error on Node ",
               DistAutogradContainer::getInstance().getWorkerId(),
               ": ",
-              futureGrads->error()->what());
+              error->what());
           accumulateGradFuture->setError(errorMsg);
           return;
         }
-        const variable_list& grads = futureGrads->constValue();
+
         TORCH_INTERNAL_ASSERT(grads.size() == outputEdges.size());
 
         // Accumulate all the gradients in the context.
@@ -264,6 +266,7 @@ std::shared_ptr<rpc::FutureMessage> DistEngine::executeSendFunctionAsync(
     initializedContextIds_.insert(autogradContext->contextId());
     lock.unlock();
 
+
     // Enqueue the current send function.
     auto graphTask = autogradContext->retrieveGraphTask();
     engine_.enqueue_blocked_task_on_cpu(torch::autograd::NodeTask(
@@ -276,34 +279,39 @@ std::shared_ptr<rpc::FutureMessage> DistEngine::executeSendFunctionAsync(
     // Build the 'uber' future that waits for everything.
     auto callbackFuture = std::make_shared<rpc::FutureMessage>();
 
-    accumulateGradFuture->addCallback([autogradContext,
-                                       callbackFuture,
-                                       accumulateGradFuture]() {
-      if (accumulateGradFuture->hasError()) {
-        // Perform cleanup at the end of the backward pass (before we mark
-        // the future as completed).
-        DistEngine::getInstance().cleanupBackwardPass(autogradContext);
+    accumulateGradFuture->addCallback(
+        [autogradContext, callbackFuture](
+            const rpc::Message& message /* unused */,
+            const c10::optional<torch::utils::FutureError>& error) {
+          if (error) {
+            // Perform cleanup at the end of the backward pass (before we mark
+            // the future as completed).
+            DistEngine::getInstance().cleanupBackwardPass(autogradContext);
 
-        // Skip any further processing on errors.
-        callbackFuture->setError(*accumulateGradFuture->error());
-        return;
-      }
+            // Skip any further processing on errors.
+            callbackFuture->setError(error->what());
+            return;
+          }
 
-      // Wait for all RPCs after the autograd engine is done.
-      auto rpcFuture = autogradContext->clearAndWaitForOutstandingRpcsAsync();
-      rpcFuture->addCallback([callbackFuture, autogradContext, rpcFuture]() {
-        // Perform cleanup at the end of the backward pass (before we
-        // mark the future as completed).
-        DistEngine::getInstance().cleanupBackwardPass(autogradContext);
+          // Wait for all RPCs after the autograd engine is done.
+          auto rpcFuture =
+              autogradContext->clearAndWaitForOutstandingRpcsAsync();
+          rpcFuture->addCallback(
+              [callbackFuture, autogradContext](
+                  const rpc::Message& /* unused */,
+                  const c10::optional<torch::utils::FutureError>& error) {
+                // Perform cleanup at the end of the backward pass (before we
+                // mark the future as completed).
+                DistEngine::getInstance().cleanupBackwardPass(autogradContext);
 
-        // Finally mark the 'uber' future as completed.
-        if (!rpcFuture->hasError()) {
-          callbackFuture->markCompleted(rpc::Message());
-        } else {
-          callbackFuture->setError(*rpcFuture->error());
-        }
-      });
-    });
+                // Finally mark the 'uber' future as completed.
+                if (!error) {
+                  callbackFuture->markCompleted(rpc::Message());
+                } else {
+                  callbackFuture->setError(error->what());
+                }
+              });
+        });
 
     // Return the future which waits for all async processing to be done.
     return callbackFuture;
@@ -371,7 +379,7 @@ void DistEngine::cleanupBackwardPass(const ContextPtr& autogradContext) {
   // not leaking any references to the gradients anywhere else.
   const auto& futureGrads =
       autogradContext->retrieveGraphTask()->future_result_;
-  TORCH_INTERNAL_ASSERT(futureGrads.use_count() <= 2);
+  TORCH_INTERNAL_ASSERT(futureGrads.use_count() == 1);
 
   // Reset the graph task once we're done with all processing.
   autogradContext->resetGraphTask();
@@ -394,15 +402,12 @@ std::unordered_map<std::string, std::string> DistEngine::getDebugInfo() const {
   std::unordered_map<std::string, std::string> debugInfo;
   auto& DistAutogradContainer = DistAutogradContainer::getInstance();
   debugInfo[kNumBackwardPasses] = std::to_string(numBackwardPasses());
-  // fill in all cpu queue size information for each graph task of the
-  // context_id in initializedContextIds_
+  // fill in all cpu queue size information for each graph task of the context_id
+  // in initializedContextIds_
   std::lock_guard<std::mutex> guard(initializedContextIdsLock_);
-  for (auto context_id : initializedContextIds_) {
-    std::shared_ptr<torch::autograd::GraphTask> graph_task =
-        DistAutogradContainer.retrieveContext(context_id)->retrieveGraphTask();
-    std::string kGraphTaskCPUQueueSize =
-        "context_id: " + std::to_string(context_id) +
-        " graph_task_cpu_queue_size";
+  for(auto context_id : initializedContextIds_) {
+    std::shared_ptr<torch::autograd::GraphTask> graph_task = DistAutogradContainer.retrieveContext(context_id)->retrieveGraphTask();
+    std::string kGraphTaskCPUQueueSize = "context_id: "  + std::to_string(context_id) + " graph_task_cpu_queue_size";
     debugInfo[kGraphTaskCPUQueueSize] =
         std::to_string(engine_.ready_queue_size(graph_task, at::kCPU));
   }

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -287,7 +287,8 @@ class TORCH_API RpcAgent {
   // error and do not retry again. In case 3, we move the RpcRetryInfo struct
   // to another time point in the map to schedule the RPC for a future send.
   void rpcRetryCallback(
-      const std::shared_ptr<FutureMessage>& message,
+      const rpc::Message& message,
+      const c10::optional<utils::FutureError>& futErr,
       steady_clock_time_point newTime,
       std::shared_ptr<RpcRetryInfo> earliestRpc);
 

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -16,14 +16,16 @@ namespace rpc {
 namespace callback {
 // It's the callback for RemoteCall.
 void TORCH_API confirmPendingUser(
-    const std::shared_ptr<FutureMessage>& futureMessage,
+    const rpc::Message& message,
+    const c10::optional<utils::FutureError>& futErr,
     const ForkId& expectedForkId);
 
 // It's the callback for finishing creating owner rref, it returned deletedRRef,
 // so that the deletedRRef can be handled under GIL in python_functions.cpp if
 // deletedRRef contains python object.
-c10::intrusive_ptr<RRef> TORCH_API
-finishCreatingOwnerRRef(const std::shared_ptr<FutureMessage>& futureMessage);
+c10::intrusive_ptr<RRef> TORCH_API finishCreatingOwnerRRef(
+    const Message& message,
+    const c10::optional<utils::FutureError>& futErr);
 } // namespace callback
 
 // Manages RRef lifetime and keeps track of RRef forks.
@@ -38,7 +40,7 @@ class TORCH_API RRefContext {
   static std::vector<c10::intrusive_ptr<RRef>> destroyInstance(
       bool ignoreRRefLeak = true);
 
-  static void handleException(const std::shared_ptr<FutureMessage>& fm);
+  static void handleException(const c10::optional<utils::FutureError>& futErr);
 
   RRefContext(const RRefContext&) = delete;
   RRefContext(RRefContext&& other) = delete;

--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -123,7 +123,13 @@ class TORCH_API Future final {
     callbacks_.emplace_back(std::move(cb));
   }
 
-private:
+  // Remove this once we've migrated underlying use-cases.
+  void addCallback(const std::function<
+                   void(const T&, const c10::optional<torch::utils::FutureError>&)>& cb) {
+    addCallback([cb,this]() { cb(value_, error_); });
+  }
+
+  private:
   void setErrorInternal(
       FutureError error,
       std::unique_lock<std::mutex>& lock) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36220 [future] Undo some recent torch::util::future api changes**

The torch::utils::Future change from yesterday may have introduced a reference cycle,
leading to OOM on PS. This change reverts the lambda  capture changes with
torch::utils::Future until we can analyze further.

Differential Revision: [D20918904](https://our.internmc.facebook.com/intern/diff/D20918904/)