### PR TITLE
[RELAND] Add temporary impl_UNBOXED syntax sugar for unboxed-only defs.

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -364,13 +364,13 @@ Therefore, for the moment, this is all copy pasted in from VariableTypeEverythin
     &WrapFunction<CastPolicy::POLICY, SIGNATURE, SIGNATURE, &FUNC>::type::call)
 
 #define KERNEL_UNBOXED_ONLY(FUNC, REGISTER_NAME, SIGNATURE, POLICY) \
-  .impl(REGISTER_NAME, DispatchKey::AutocastTensorId, \
-    c10::CppFunction::makeUnboxedOnly(&WrapFunction<CastPolicy::POLICY, SIGNATURE, SIGNATURE, &FUNC>::type::call))
+  .impl_UNBOXED(REGISTER_NAME, DispatchKey::AutocastTensorId, \
+    &WrapFunction<CastPolicy::POLICY, SIGNATURE, SIGNATURE, &FUNC>::type::call)
 
 // Less-common but still useful case: redispatching to a function with a new signature (e.g. appending a dtype)
 #define KERNEL_UNBOXED_ONLY_DIFFERENT_REDISPATCH_SIGNATURE(REDISPATCH_FUNC, REGISTER_NAME, REGISTER_SIGNATURE, REDISPATCH_SIGNATURE, POLICY) \
-  .impl(REGISTER_NAME, DispatchKey::AutocastTensorId, \
-    c10::CppFunction::makeUnboxedOnly(&WrapFunction<CastPolicy::POLICY, REGISTER_SIGNATURE, REDISPATCH_SIGNATURE, &REDISPATCH_FUNC>::type::call))
+  .impl_UNBOXED(REGISTER_NAME, DispatchKey::AutocastTensorId, \
+    &WrapFunction<CastPolicy::POLICY, REGISTER_SIGNATURE, REDISPATCH_SIGNATURE, &REDISPATCH_FUNC>::type::call)
 
 /*****************************************
 Explicit registration for out-of-place ops
@@ -425,8 +425,8 @@ auto register_out_of_place = c10::import()
   KERNEL(ADD_NS(gelu), "aten::gelu", Tensor (const Tensor &), fp32)
   KERNEL_UNBOXED_ONLY(ADD_NS(layer_norm), "aten::layer_norm", Tensor (const Tensor &, IntArrayRef, const Tensor &, const Tensor &, double, bool), fp32)
   // The macro doesn't like this one so I had to write it out manually.
-  .impl("aten::native_layer_norm", DispatchKey::AutocastTensorId,
-      CppFunction::makeUnboxedOnly(&WrapFunction<CastPolicy::fp32, std::tuple<Tensor,Tensor,Tensor> (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, double), std::tuple<Tensor,Tensor,Tensor> (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, double), &ADD_NS(native_layer_norm)>::type::call))
+  .impl_UNBOXED("aten::native_layer_norm", DispatchKey::AutocastTensorId,
+                &WrapFunction<CastPolicy::fp32, std::tuple<Tensor,Tensor,Tensor> (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, double), std::tuple<Tensor,Tensor,Tensor> (const Tensor &, const Tensor &, const Tensor &, int64_t, int64_t, double), &ADD_NS(native_layer_norm)>::type::call)
   KERNEL_UNBOXED_ONLY(ADD_NS(group_norm), "aten::group_norm", Tensor (const Tensor &, int64_t, const Tensor &, const Tensor &, double, bool), fp32)
   KERNEL_UNBOXED_ONLY(ADD_NS(frobenius_norm), "aten::frobenius_norm", Tensor (const Tensor &), fp32)
   KERNEL_UNBOXED_ONLY(ADD_NS(frobenius_norm), "aten::frobenius_norm.dim", Tensor (const Tensor &, IntArrayRef, bool), fp32)
@@ -494,8 +494,8 @@ auto register_out_of_place = c10::import()
   ;
 
 auto register_banned = torch::import()
-  .impl("aten::binary_cross_entropy", DispatchKey::AutocastTensorId,
-        CppFunction::makeUnboxedOnly(&at::autocast::binary_cross_entropy_banned));
+  .impl_UNBOXED("aten::binary_cross_entropy", DispatchKey::AutocastTensorId,
+                &at::autocast::binary_cross_entropy_banned);
 }
 #endif
 

--- a/aten/src/ATen/core/op_registration/op_registration.h
+++ b/aten/src/ATen/core/op_registration/op_registration.h
@@ -892,6 +892,26 @@ public:
     impl(name, std::forward<Dispatch>(key), std::forward<Func>(raw_f));
     return std::move(*this);
   }
+  // Convenience overload for unboxed only kernels.  These are quite common
+  // but will be eventually eliminated; this function makes it easy to grep for
+  // them.
+  //
+  // If you're looking how to def or impl with no DispatchKey, use the
+  // CppFunction::makeUnboxedOnly factory directly (the API is compositional;
+  // it's just that we have a LOT of impl calls that are unboxed, so there is
+  // just a little syntax sugar for this case.)
+  //
+  // TODO: Remove these overloads once the makeUnboxedOnly incidence rate
+  // goes way down
+  template <typename Dispatch, typename Func>
+  Module& impl_UNBOXED(const char* name, Dispatch&& key, Func* raw_f) & {
+    return impl(name, dispatch(std::forward<Dispatch>(key), CppFunction::makeUnboxedOnly(raw_f)));
+  }
+  template <typename Dispatch, typename Func>
+  Module&& impl_UNBOXED(const char* name, Dispatch&& key, Func* raw_f) && {
+    impl_UNBOXED(name, std::forward<Dispatch>(key), raw_f);
+    return std::move(*this);
+  }
 
   // Register a fallback implementation for all operators which will be used
   // if there is not a specific implementation for an operator available.

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -117,9 +117,9 @@ DEFAULT_UNBOXEDONLY_FUNCTION_REGISTRATION = CodeTemplate("""\
       CppFunction::makeUnboxedOnly(TypeDefault::${type_wrapper_name}))
 """)
 BACKEND_UNBOXEDONLY_FUNCTION_REGISTRATION = CodeTemplate("""\
-.impl("${operator_name_with_overload}",
-    DispatchKey::${Backend}TensorId,
-    CppFunction::makeUnboxedOnly(${Type}::${type_wrapper_name}))
+.impl_UNBOXED("${operator_name_with_overload}",
+              DispatchKey::${Backend}TensorId,
+              ${Type}::${type_wrapper_name})
 """)
 DEFAULT_FUNCTION_REGISTRATION = CodeTemplate("""\
 .impl("${operator_name_with_overload}", &TypeDefault::${type_wrapper_name})

--- a/aten/src/ATen/test/cpu_rng_test.cpp
+++ b/aten/src/ATen/test/cpu_rng_test.cpp
@@ -100,20 +100,20 @@ class RNGTest : public ::testing::Test {
   void SetUp() override {
     static auto registry = torch::import()
       // Random
-      .impl("aten::random_.from", kCustomRNG, CppFunction::makeUnboxedOnly(random_from_to))
-      .impl("aten::random_.to",   kCustomRNG, CppFunction::makeUnboxedOnly(random_to))
-      .impl("aten::random_",      kCustomRNG, CppFunction::makeUnboxedOnly(random_))
+      .impl_UNBOXED("aten::random_.from",             kCustomRNG, random_from_to)
+      .impl_UNBOXED("aten::random_.to",               kCustomRNG, random_to)
+      .impl_UNBOXED("aten::random_",                  kCustomRNG, random_)
       // Normal
-      .impl("aten::normal_",      kCustomRNG, CppFunction::makeUnboxedOnly(normal_))
-      .impl("aten::normal.Tensor_float_out",  kCustomRNG, CppFunction::makeUnboxedOnly(normal_Tensor_float_out))
-      .impl("aten::normal.float_Tensor_out",  kCustomRNG, CppFunction::makeUnboxedOnly(normal_float_Tensor_out))
-      .impl("aten::normal.Tensor_Tensor_out", kCustomRNG, CppFunction::makeUnboxedOnly(normal_Tensor_Tensor_out))
-      .impl("aten::normal.Tensor_float",      kCustomRNG, CppFunction::makeUnboxedOnly(normal_Tensor_float))
-      .impl("aten::normal.float_Tensor",      kCustomRNG, CppFunction::makeUnboxedOnly(normal_float_Tensor))
-      .impl("aten::normal.Tensor_Tensor",     kCustomRNG, CppFunction::makeUnboxedOnly(normal_Tensor_Tensor))
-      .impl("aten::uniform_",                 kCustomRNG, CppFunction::makeUnboxedOnly(uniform_))
+      .impl_UNBOXED("aten::normal_",                  kCustomRNG, normal_)
+      .impl_UNBOXED("aten::normal.Tensor_float_out",  kCustomRNG, normal_Tensor_float_out)
+      .impl_UNBOXED("aten::normal.float_Tensor_out",  kCustomRNG, normal_float_Tensor_out)
+      .impl_UNBOXED("aten::normal.Tensor_Tensor_out", kCustomRNG, normal_Tensor_Tensor_out)
+      .impl_UNBOXED("aten::normal.Tensor_float",      kCustomRNG, normal_Tensor_float)
+      .impl_UNBOXED("aten::normal.float_Tensor",      kCustomRNG, normal_float_Tensor)
+      .impl_UNBOXED("aten::normal.Tensor_Tensor",     kCustomRNG, normal_Tensor_Tensor)
+      .impl_UNBOXED("aten::uniform_",                 kCustomRNG, uniform_)
       // Cauchy
-      .impl("aten::cauchy_",      kCustomRNG, CppFunction::makeUnboxedOnly(custom_rng_cauchy_))
+      .impl_UNBOXED("aten::cauchy_",                  kCustomRNG, custom_rng_cauchy_)
     ;
   }
 };

--- a/test/cpp_extensions/msnpu_extension.cpp
+++ b/test/cpp_extensions/msnpu_extension.cpp
@@ -49,10 +49,10 @@ std::tuple<Tensor,Tensor,Tensor> fake_convolution_backward(
 
 void init_msnpu_extension() {
   static auto registry = torch::import()
-    .impl("aten::empty.memory_format",                kMSNPU, CppFunction::makeUnboxedOnly(empty_override))
-    .impl("aten::add.Tensor",                         kMSNPU, CppFunction::makeUnboxedOnly(add_override))
-    .impl("aten::convolution_overrideable",           kMSNPU, CppFunction::makeUnboxedOnly(fake_convolution))
-    .impl("aten::convolution_backward_overrideable",  kMSNPU, CppFunction::makeUnboxedOnly(fake_convolution_backward))
+    .impl_UNBOXED("aten::empty.memory_format",                kMSNPU, empty_override)
+    .impl_UNBOXED("aten::add.Tensor",                         kMSNPU, add_override)
+    .impl_UNBOXED("aten::convolution_overrideable",           kMSNPU, fake_convolution)
+    .impl_UNBOXED("aten::convolution_backward_overrideable",  kMSNPU, fake_convolution_backward)
     ;
 }
 

--- a/test/mobile/op_deps/simple_ops.cpp
+++ b/test/mobile/op_deps/simple_ops.cpp
@@ -78,7 +78,7 @@ auto registerer = torch::import()
   .def("aten::BB(Tensor self) -> Tensor", &BB_op)
   .impl("aten::CC", kCPU, &CC_op)
   .impl("aten::DD", &DD_op)
-  .def("aten::EE(Tensor self) -> Tensor", torch::dispatch(kCPU, CppFunction::makeUnboxedOnly(EE_op)))
+  .impl_UNBOXED("aten::EE", kCPU, EE_op)
   .def("aten::FF(Tensor self) -> Tensor", CppFunction::makeUnboxedOnly(FF_op))
   .impl("aten::GG",
     kCPU, [] (Tensor a) -> Tensor {

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -183,14 +183,14 @@ ${return_type} ${type_wrapper_name}(${type_method_formals}) {
 """)
 
 UNBOXEDONLY_WRAPPER_REGISTRATION = CodeTemplate("""\
-.impl("${operator_name_with_overload}", torch::kAutograd,
-        CppFunction::makeUnboxedOnly(VariableType::${type_wrapper_name})
+.impl_UNBOXED("${operator_name_with_overload}", torch::kAutograd,
+        VariableType::${type_wrapper_name}
       )
 """)
 
 WRAPPER_REGISTRATION = CodeTemplate("""\
 .impl("${operator_name_with_overload}", torch::kAutograd,
-        &VariableType::${type_wrapper_name}
+        VariableType::${type_wrapper_name}
      )
 """)
 

--- a/tools/code_analyzer/run_analyzer.sh
+++ b/tools/code_analyzer/run_analyzer.sh
@@ -8,9 +8,14 @@ set -exu
 
 echo "Analyze: ${INPUT}"
 
+# NB: op_register_pattern actually contains "too" many entries.  We only
+# need to regex for symbols which occur after inlining; and most of the
+# public API for the registration API disappears after inlining (e.g.,
+# only _def and _impl are retained).  But the inliner isn't guaranteed
+# to operate, so for safety we match a more expansive set.
 "${ANALYZER_BIN}" \
   -op_schema_pattern="^(_aten|_prim|aten|quantized|profiler|_test)::[^ ]+" \
-  -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)|c10::Module::(_?def|_?impl)" \
+  -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)|c10::Module::(_?def|_?impl|impl_UNBOXED)" \
   -op_invoke_pattern="c10::Dispatcher::findSchema|callOp" \
   -format="${FORMAT}" \
   ${EXTRA_ANALYZER_FLAGS} \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36264 Propagate and report the file/line number of registrations on errors.
* #36258 Switch to pybind11 style registration function API.
* #36250 Unconditionally register schema even for manual registration.
* #36240 Expunge TensorId from all DispatchKey names.
* **#36223 [RELAND] Add temporary impl_UNBOXED syntax sugar for unboxed-only defs.**
* #36222 [RELAND] Add DispatchKey impl overload; remove use of torch::dispatch

Previously #35714

There are a lot of unboxed only defs.  We're committed to removing
them at the end of the half but as I am about to do a lot of porting
to the new API, let's get them into a form where they're easy to
remove.  This is a new overload impl_UNBOXED that will pass
the function pointer straight to CppFunction::makeUnboxedOnly

I don't attempt to make the _UNBOXED API complete; in particular,
catchall declarations don't get this sugar (as there are very few
of them).

To get some coverage of _UNBOXED API for code analysis, I switched
one of our unboxed tests to be an impl rather than a def.  This
shouldn't materially affect coverage.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20929259](https://our.internmc.facebook.com/intern/diff/D20929259)