### PR TITLE
[release/1.5] Move all nccl from torch_python to torch_cuda

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -274,7 +274,6 @@ if (USE_NCCL)
     list(APPEND TORCH_PYTHON_SRCS
       ${TORCH_SRC_DIR}/csrc/cuda/python_nccl.cpp)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_NCCL)
-    list(APPEND TORCH_PYTHON_LINK_LIBRARIES __caffe2_nccl)
 endif()
 
 # In the most recent CMake versions, a new 'TRANSFORM' subcommand of 'list' allows much of the boilerplate of defining the lists

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -10,7 +10,7 @@
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #ifdef USE_NCCL
-#include <nccl.h>
+#include <torch/csrc/cuda/python_nccl.h>
 #endif
 
 #include <torch/csrc/cuda/THCP.h>
@@ -473,17 +473,6 @@ static PyObject * THCPModule_initExtension(PyObject *self, PyObject *noargs)
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-
-#ifdef USE_NCCL
-#include <torch/csrc/cuda/python_nccl.h>
-
-void THCPModule_useNccl()
-{
-  // Use NCCL to ensure that the symbols are loaded
-  ncclUniqueId uniqueId;
-  ncclGetUniqueId(&uniqueId);
-}
-#endif
 
 PyObject * THCPModule_getCurrentBlasHandle_wrap(PyObject *self, PyObject *noargs)
 {

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -37,16 +37,6 @@ struct NcclCommList {
   }
   NcclCommList(NcclCommList&& foo) = default;
   ~NcclCommList() {
-    /*
-     * TODO(T30279827) Temporarily disable calling ncclCommDestroy
-     * Calling ncclCommDestroy while program exiting is undefined
-     * according to Nvidia, and lead to segfault in NCCL 2
-     * (whether it is called before or after the CUDA runtime destructor).
-     * Temporarily disable it in destructor to avoid segfault.
-     * Following up with Nvidia for long term solution.
-     */
-    return;
-
     if (comms) {
       for (int i = 0; i < ndevices; i++) {
         int dummy_var;
@@ -56,7 +46,7 @@ struct NcclCommList {
            In these cases, skip ncclCommDestroy */
           return;
         }
-        ncclCommDestroy(comms[i]);
+        comm_destroy(comms[i]);
       }
     }
   }
@@ -204,6 +194,45 @@ std::uint64_t version() {
 #endif
 }
 
+void get_unique_id(ncclUniqueId& id)
+{
+#ifdef USE_NCCL
+  using namespace torch::cuda::nccl::detail;
+  NCCL_CHECK(ncclGetUniqueId(&id));
+#else
+  AT_ERROR("PyTorch built without NCCL support");
+#endif
+}
+
+ncclComm_t comm_init_rank(int nranks, const ncclUniqueId& comm_id, int rank) {
+#ifdef USE_NCCL
+  using namespace torch::cuda::nccl::detail;
+  ncclComm_t comm;
+  NCCL_CHECK(ncclCommInitRank(&comm, nranks, comm_id, rank));
+  return comm;
+#else
+  return nullptr;
+#endif
+}
+
+void comm_destroy(ncclComm_t comm)
+{
+  /*
+   * TODO(T30279827) Temporarily disable calling ncclCommDestroy
+   * Calling ncclCommDestroy while program exiting is undefined
+   * according to Nvidia, and lead to segfault in NCCL 2
+   * (whether it is called before or after the CUDA runtime destructor).
+   * Temporarily disable it in destructor to avoid segfault.
+   * Following up with Nvidia for long term solution.
+   */
+  return;
+
+#ifdef USE_NCCL
+  using namespace torch::cuda::nccl::detail;
+  NCCL_CHECK(ncclCommDestroy(comm));
+#endif
+}
+
 namespace {
 // NCCL changed the numerical type used for count between NCCL1 and NCCL2.
 // So we use the following struct, which gets the type of the second argument
@@ -317,6 +346,137 @@ void reduce(
     const stream_list& streams,
     const comm_list& user_comms) {
   reduce(inputs, /*outputs=*/inputs, root, op, streams, user_comms);
+}
+
+void all_reduce(
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    int32_t op,
+    const stream_list& streams,
+    const comm_list& user_comms) {
+#ifdef USE_NCCL
+  using namespace torch::cuda::nccl::detail;
+  check_inputs(inputs, outputs, 1, 1);
+  const auto len = inputs.size();
+
+  ncclDataType_t data_type = get_data_type(inputs[0]);
+
+  const auto count = inputs[0].numel();
+  auto comms_ref = user_comms.empty() ? get_communicators(inputs)
+                                      : ArrayRef<ncclComm_t>(user_comms);
+
+  AutoNcclGroup nccl_group_guard;
+  at::cuda::OptionalCUDAGuard device_guard;
+  for (size_t i = 0; i < len; i++) {
+    int device = inputs[i].device().index();
+    device_guard.set_index(device);
+    // Default to the current stream
+    const auto stream = (streams.empty() || !streams[i])
+        ? at::cuda::getCurrentCUDAStream(device).stream()
+        : streams[i]->stream();
+
+    NCCL_CHECK(ncclAllReduce(
+        inputs[i].data_ptr(),
+        outputs[i].data_ptr(),
+        count,
+        data_type,
+        (ncclRedOp_t)op,
+        comms_ref[i],
+        stream));
+  }
+#else
+  AT_ERROR("PyTorch built without NCCL support");
+#endif
+}
+
+void reduce_scatter(
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    int32_t op,
+    const stream_list& streams,
+    const comm_list& user_comms) {
+#ifdef USE_NCCL
+  using namespace torch::cuda::nccl::detail;
+  const auto len = inputs.size();
+  check_inputs(inputs, outputs, 1, len);
+
+  ncclDataType_t data_type = get_data_type(inputs[0]);
+
+  const auto count = inputs[0].numel() / len;
+  auto comms_ref = user_comms.empty() ? get_communicators(inputs)
+                                      : ArrayRef<ncclComm_t>(user_comms);
+
+  AutoNcclGroup nccl_group_guard;
+  at::cuda::OptionalCUDAGuard device_guard;
+  for (size_t i = 0; i < len; i++) {
+    int device = inputs[i].device().index();
+    device_guard.set_index(device);
+    // Default to the current stream
+    const auto stream = (streams.empty() || !streams[i])
+        ? at::cuda::getCurrentCUDAStream(device).stream()
+        : streams[i]->stream();
+
+    NCCL_CHECK(ncclReduceScatter(
+        inputs[i].data_ptr(),
+        outputs[i].data_ptr(),
+        count,
+        data_type,
+        (ncclRedOp_t)op,
+        comms_ref[i],
+        stream));
+  }
+#else
+  AT_ERROR("PyTorch built without NCCL support");
+#endif
+}
+
+void all_gather(
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    const stream_list& streams,
+    const comm_list& user_comms) {
+#ifdef USE_NCCL
+  using namespace torch::cuda::nccl::detail;
+  const auto len = inputs.size();
+  check_inputs(inputs, outputs, len, 1);
+
+  ncclDataType_t data_type = get_data_type(inputs[0]);
+
+  const auto count = inputs[0].numel();
+  auto comms_ref = user_comms.empty() ? get_communicators(inputs)
+                                      : ArrayRef<ncclComm_t>(user_comms);
+
+  AutoNcclGroup nccl_group_guard;
+  at::cuda::OptionalCUDAGuard device_guard;
+  for (size_t i = 0; i < len; i++) {
+    int device = inputs[i].device().index();
+    device_guard.set_index(device);
+    // Default to the current stream
+    const auto stream = (streams.empty() || !streams[i])
+        ? at::cuda::getCurrentCUDAStream(device).stream()
+        : streams[i]->stream();
+
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
+      NCCL_CHECK(ncclAllGather(
+          inputs[i].data_ptr(),
+          outputs[i].data_ptr(),
+          count,
+          data_type,
+          comms_ref[i],
+          stream));
+#else
+      NCCL_CHECK(ncclAllGather(
+          inputs[i].data_ptr(),
+          count,
+          data_type,
+          outputs[i].data_ptr(),
+          comms_ref[i],
+          stream));
+#endif
+  }
+#else
+  AT_ERROR("PyTorch built without NCCL support");
+#endif
 }
 } // namespace nccl
 } // namespace cuda

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -59,6 +59,10 @@ TORCH_CUDA_API std::uint64_t version();
 
 bool is_available(at::TensorList tensors);
 
+TORCH_CUDA_API void get_unique_id(ncclUniqueId& id);
+TORCH_CUDA_API ncclComm_t comm_init_rank(int nranks, const ncclUniqueId& comm_id, int rank);
+TORCH_CUDA_API void comm_destroy(ncclComm_t comm);
+
 TORCH_CUDA_API void broadcast(
     at::TensorList tensors,
     const stream_list& streams = {},
@@ -78,6 +82,26 @@ TORCH_CUDA_API void reduce(
     std::vector<at::Tensor>& inputs,
     int32_t root = 0,
     int32_t op = ncclSum,
+    const stream_list& streams = {},
+    const comm_list& user_comms = {});
+
+TORCH_CUDA_API void all_reduce(
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    int32_t op = ncclSum,
+    const stream_list& streams = {},
+    const comm_list& user_comms = {});
+
+TORCH_CUDA_API void reduce_scatter(
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    int32_t op = ncclSum,
+    const stream_list& streams = {},
+    const comm_list& user_comms = {});
+
+TORCH_CUDA_API void all_gather(
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
     const stream_list& streams = {},
     const comm_list& user_comms = {});
 


### PR DESCRIPTION
Cherry pick of https://github.com/pytorch/pytorch/pull/36193

# Original Text

Because torch_python is supposed to be thin wrapper around torch

In this PR, all invocation of functions from nccl library are moved from python_nccl.cpp (which is part of torch_python) to nccl.cpp (which is part of torch_cuda)