### PR TITLE
Replace std::shared_ptr with c10::intrusive_ptr in at::Generator

### DIFF
--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -19,8 +19,10 @@ GeneratorImpl::GeneratorImpl(Device device_in, DispatchKeySet key_set)
  * Clone this generator. Note that clone() is the only
  * method for copying for Generators in ATen.
  */
-std::shared_ptr<GeneratorImpl> GeneratorImpl::clone() const {
-  return std::shared_ptr<GeneratorImpl>(static_cast<GeneratorImpl*>(this->clone_impl()));
+c10::intrusive_ptr<GeneratorImpl> GeneratorImpl::clone() const {
+  auto res = this->clone_impl();
+  c10::raw::intrusive_ptr::incref(res);
+  return c10::intrusive_ptr<GeneratorImpl>::reclaim(res);
 }
 
 /**

--- a/c10/core/GeneratorImpl.h
+++ b/c10/core/GeneratorImpl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <memory>
 #include <mutex>
 #include <deque>
 #include <atomic>
@@ -10,6 +9,7 @@
 
 #include <c10/util/Exception.h>
 #include <c10/util/C++17.h>
+#include <c10/util/intrusive_ptr.h>
 #include <c10/core/Device.h>
 #include <c10/core/DispatchKeySet.h>
 #include <c10/util/python_stub.h>
@@ -54,7 +54,7 @@ namespace c10 {
 // with good distribution of 0s and 1s in bit representation
 constexpr uint64_t default_rng_seed_val = 67280421310721;
 
-struct C10_API GeneratorImpl {
+struct C10_API GeneratorImpl : public c10::intrusive_ptr_target {
   // Constructors
   GeneratorImpl(Device device_in, DispatchKeySet key_set);
 
@@ -65,7 +65,7 @@ struct C10_API GeneratorImpl {
   GeneratorImpl& operator=(const GeneratorImpl& other) = delete;
 
   virtual ~GeneratorImpl() = default;
-  std::shared_ptr<GeneratorImpl> clone() const;
+  c10::intrusive_ptr<GeneratorImpl> clone() const;
 
   // Common methods for all generators
   virtual void set_current_seed(uint64_t seed) = 0;


### PR DESCRIPTION
To make `at::Generator` compatible with `IValue` this PR replaces `std::shared_ptr<c10::GeneratorImpl>` with `c10::intrusive_ptr<c10::GeneratorImpl>`

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36232 [WIP] replace Generator arguments with c10::optional<Generator>
* #36231 Add at::Generator to IValue
* **#36230 Replace std::shared_ptr with c10::intrusive_ptr in at::Generator**

Differential Revision: [D20923377](https://our.internmc.facebook.com/intern/diff/D20923377)