### PR TITLE
Add at::Generator to IValue

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -127,6 +127,14 @@ inline c10::intrusive_ptr<torch::CustomClassHolder> IValue::toCapsule() const & 
   TORCH_INTERNAL_ASSERT(isCapsule());
   return toIntrusivePtr<torch::CustomClassHolder>();
 }
+inline at::Generator IValue::toGenerator() && {
+  AT_ASSERT(isGenerator(), "Expected Generator but got ", tagKind());
+  return at::Generator(moveToIntrusivePtr<at::GeneratorImpl>());
+}
+inline at::Generator IValue::toGenerator() const & {
+  AT_ASSERT(isGenerator(), "Expected Generator but got ", tagKind());
+  return at::Generator(toIntrusivePtr<at::GeneratorImpl>());
+}
 
 namespace ivalue {
 
@@ -508,6 +516,7 @@ DEFINE_TO(at::ScalarType, toScalarType)
 DEFINE_TO(at::Layout, toLayout)
 DEFINE_TO(at::MemoryFormat, toMemoryFormat)
 DEFINE_TO(at::QScheme, toQScheme)
+DEFINE_TO(at::Generator, toGenerator)
 
 template <class T>
 struct _fake_type {};


### PR DESCRIPTION
This PR prepares the source code to make at::Generator non-nullable and replace `at::Generator generator = nullptr` with `c10::optional<at::Generator> = c10::nullopt`

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36232 [WIP] replace Generator arguments with c10::optional<Generator>
* **#36231 Add at::Generator to IValue**
* #36230 Replace std::shared_ptr with c10::intrusive_ptr in at::Generator

Differential Revision: [D20923443](https://our.internmc.facebook.com/intern/diff/D20923443)