### PR TITLE
Fixing RPC Shutdown and Thread Joining

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -246,14 +246,9 @@ void ProcessGroupAgent::startImpl() {
       std::thread(&ProcessGroupAgent::pollTimedOutRPCs, this);
 }
 
-void ProcessGroupAgent::shutdown() {
+void ProcessGroupAgent::shutdownImpl() {
   LOG(INFO) << "Shutting down ProcessGroupAgent on rank " << pg_->getRank()
             << ".";
-  std::unique_lock<std::mutex> lock{futureMutex_};
-  if (!rpcAgentRunning_.exchange(false)) {
-    return;
-  }
-  lock.unlock();
   futureTimeoutCV_.notify_one();
   futureTimeoutThread_.join();
   // Abort listener thread to stop accepting new work. We need to interrupt the

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -727,7 +727,7 @@ void ProcessGroupAgent::listenLoopInternal() {
 }
 
 void ProcessGroupAgent::pollTimedOutRPCs() {
-  while (rpcAgentRunning_.load()) {
+  while (timeoutThreadEnabled_.load()) {
     std::unique_lock<std::mutex> lock{futureMutex_};
     steady_clock_time_point minEndTime;
     // Estimate amount of time the first future will time out in, and sleep

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -76,7 +76,7 @@ class ProcessGroupAgent : public RpcAgent {
 
   void startImpl() override;
 
-  void shutdown() override;
+  void shutdownImpl() override;
 
   ~ProcessGroupAgent() override;
 

--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -249,6 +249,8 @@ class ProcessGroupAgent : public RpcAgent {
   //     NB: Ideally, this should be addressed by supporting asynchronous UDF.
   //         This is just a temporary solution for (2).
   ThreadPool threadPool_;
+  // Atomic to indicate whether the timeout thread is enabled.
+  std::atomic<bool> timeoutThreadEnabled_;
   // Mapping of request id to FutureInfo struct.
   std::unordered_map<int64_t, FutureInfo> futures_;
   // A map to keep track of when futures time out. The map is keyed by the time

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -23,7 +23,9 @@ RpcAgent::RpcAgent(
       rpcAgentRunning_(false) {}
 
 RpcAgent::~RpcAgent() {
-  cleanup();
+  if (rpcAgentRunning_.load()) {
+    shutdown();
+  }
 }
 
 void RpcAgent::start() {
@@ -32,14 +34,13 @@ void RpcAgent::start() {
   startImpl();
 }
 
-void RpcAgent::cleanup() {
+void RpcAgent::shutdown() {
   rpcAgentRunning_.store(false);
-  // We must notify the condition variable so it stops waiting in the
-  // retry thread, otherwise this thread cannot be joined.
   rpcRetryMapCV_.notify_one();
   if (rpcRetryThread_.joinable()) {
     rpcRetryThread_.join();
   }
+  shutdownImpl();
 }
 
 std::shared_ptr<FutureMessage> RpcAgent::sendWithRetries(

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -35,7 +35,9 @@ void RpcAgent::start() {
 }
 
 void RpcAgent::shutdown() {
+  std::unique_lock<std::mutex> lock(rpcRetryMutex_);
   rpcAgentRunning_.store(false);
+  lock.unlock();
   rpcRetryMapCV_.notify_one();
   if (rpcRetryThread_.joinable()) {
     rpcRetryThread_.join();

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -210,7 +210,12 @@ class TORCH_API RpcAgent {
 
   // Stop accepting requests and shutdown the RPC framework as soon as possible
   // by terminating all RPC threads.
-  virtual void shutdown() = 0;
+  virtual void shutdown();
+
+  // Derived classes must override this function to start accepting requests.
+  // THis is used to clean up any backend-specific state. Users must call
+  // shutdown, not shutdownImpl, to shutdown the RPC Agent.
+  virtual void shutdownImpl() = 0;
 
   // Check if current RPC agent is set.
   static bool isCurrentRpcAgentSet();
@@ -257,12 +262,6 @@ class TORCH_API RpcAgent {
   // Add GIL wait time data point to metrics
   virtual void addGilWaitTime(const std::chrono::microseconds gilWaitTime) = 0;
   friend class PythonRpcHandler;
-
-  // Function that cleans up the local state for RpcAgent. This is called from
-  // the destructor, and ensures that we can gracefully destruct even if the
-  // child class was not successfully constructed without calling a virtual
-  // function.
-  void cleanup();
 
   // Map that stores metadata for RPC's that may need to be re-tried as well as
   // the timepoint at which we should re-try them.

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -210,7 +210,7 @@ class TORCH_API RpcAgent {
 
   // Stop accepting requests and shutdown the RPC framework as soon as possible
   // by terminating all RPC threads.
-  virtual void shutdown();
+  void shutdown();
 
   // Derived classes must override this function to start accepting requests.
   // THis is used to clean up any backend-specific state. Users must call


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36239 Fixing RPC Shutdown and Thread Joining**

ProcessGroupAgent and ThriftAgent threads were joined at shutdown, but RpcAgent threads were joined by the destructor. This PR joins all threads at shutdown by using a pattern similar to `start` in RPC.

The derived classes implement a `shutdownImpl` class that cleans up backend-specific state. RpcAgent implements `shutdown` which cleans up generic state and calls the underlying `shutdownImpl`. The atomic running is now set and unset by RpcAgent so backends do not need to mutate it.

Fixes: https://github.com/pytorch/pytorch/issues/36242

Differential Revision: [D20902666](https://our.internmc.facebook.com/intern/diff/D20902666/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D20902666/)!