### PR TITLE
`clang-tidy` workflow only needs `cuda-toolkit`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -111,7 +111,7 @@ jobs:
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
           sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
           sudo apt-get update
-          sudo apt-get --no-install-recommends -y install cuda
+          sudo apt-get --no-install-recommends -y install cuda-toolkit-10-2
           # Install dependencies
           pip install pyyaml
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -


### PR DESCRIPTION
`cuda` metapackage install both kernel driver + runtime libraries + toolchain, while `cuda-toolkit` metapackage as name suggests installs only toolchain + library headers.

This reduces install dependencies time for `clang-tidy` step by 60+ sec


Test Plan: CI

