### PR TITLE
[caffe2][debuggability] add length checks to MergeMultiScalarFeatureTensors

### DIFF
--- a/caffe2/operators/feature_maps_ops.h
+++ b/caffe2/operators/feature_maps_ops.h
@@ -421,13 +421,17 @@ class MergeMultiScalarFeatureTensorsOp : public Operator<Context> {
       for (int inputIndex = 0; inputIndex < numInputs_; ++inputIndex) {
         const int32_t* inLengthsData =
             Input(kNumTensorsPerInput * inputIndex).template data<int32_t>();
-        const int64_t* inKeysData = Input(kNumTensorsPerInput * inputIndex + 1)
-                                        .template data<int64_t>();
+        auto inputKeysBlobIdx = kNumTensorsPerInput * inputIndex + 1;
+        const int64_t* inKeysData =
+            Input(inputKeysBlobIdx).template data<int64_t>();
         const T* inValuesData =
             Input(kNumTensorsPerInput * inputIndex + 2).template data<T>();
         outLengthsData[exampleIndex] += inLengthsData[exampleIndex];
         for (int featureIndex = 0; featureIndex < inLengthsData[exampleIndex];
              ++featureIndex) {
+          CAFFE_ENFORCE_LT(outKeysOffset, totalNumFeatures);
+          CAFFE_ENFORCE_LT(
+              inKeysOffset_[inputIndex], Input(inputKeysBlobIdx).numel());
           outKeysData[outKeysOffset] = inKeysData[inKeysOffset_[inputIndex]];
           outValuesData[outKeysOffset] =
               inValuesData[inKeysOffset_[inputIndex]];


### PR DESCRIPTION
Summary:
Add basic index/length checks to MergeMultiScalarFeatureTensors to avoid segfaults.

But I don't really understand this op: what would cause this mismatch (see test plan) -- would iike to add it to the assertion description.

Reviewed By: houseroad

Differential Revision: D20912048

