### PR TITLE
Exclude `torch/csrc/cuda/*nccl*` from `clang-tidy`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -161,6 +161,8 @@ jobs:
             -g"-torch/csrc/jit/import.cpp"            \
             -g"-torch/csrc/jit/netdef_converter.cpp"  \
             -g"-torch/csrc/onnx/init.cpp"             \
+            -g"-torch/csrc/cuda/nccl.*"               \
+            -g"-torch/csrc/cuda/python_nccl.cpp"      \
             "$@" > ${GITHUB_WORKSPACE}/clang-tidy-output.txt
 
           cat ${GITHUB_WORKSPACE}/clang-tidy-output.txt


### PR DESCRIPTION
Since workflow configures pytorch with 'USE_NCCL` set to 0, we can not tidy those files

