### PR TITLE
[future] Re-land some safe portions of the future change.

### DIFF
--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -157,10 +157,8 @@ PyRRef pyRemoteBuiltin(
         *agent, dst, std::move(*scriptRemoteCall).toMessage(), false, rf);
 
     ctx.addPendingUser(userRRef->forkId(), userRRef);
-    fm->addCallback([forkId{userRRef->forkId()}](
-                        const rpc::Message& message,
-                        const c10::optional<utils::FutureError>& futErr) {
-      callback::confirmPendingUser(message, futErr, forkId);
+    fm->addCallback([forkId{userRRef->forkId()}, fm]() {
+      callback::confirmPendingUser(fm, forkId);
     });
     return PyRRef(userRRef);
   } else {
@@ -175,7 +173,7 @@ PyRRef pyRemoteBuiltin(
 
     // Builtin operators does not return py::object, and hence does not require
     // GIL for destructing the potentially deleted OwerRRef.
-    fm->addCallback(callback::finishCreatingOwnerRRef);
+    fm->addCallback([fm]() { callback::finishCreatingOwnerRRef(fm); });
     return PyRRef(ownerRRef);
   }
 }
@@ -216,10 +214,8 @@ PyRRef pyRemotePythonUdf(
         rf);
 
     ctx.addPendingUser(userRRef->forkId(), userRRef);
-    fm->addCallback([forkId{userRRef->forkId()}](
-                        const rpc::Message& message,
-                        const c10::optional<utils::FutureError>& futErr) {
-      callback::confirmPendingUser(message, futErr, forkId);
+    fm->addCallback([forkId{userRRef->forkId()}, fm]() {
+      callback::confirmPendingUser(fm, forkId);
     });
     return PyRRef(userRRef);
   } else {
@@ -233,9 +229,8 @@ PyRRef pyRemotePythonUdf(
         ownerRRef->rrefId().toIValue(),
         rf);
 
-    fm->addCallback([](const Message& message,
-                       const c10::optional<utils::FutureError>& futErr) {
-      auto deletedRRef = callback::finishCreatingOwnerRRef(message, futErr);
+    fm->addCallback([fm]() {
+      auto deletedRRef = callback::finishCreatingOwnerRRef(fm);
       if (deletedRRef && deletedRRef->isPyObj()) {
         pybind11::gil_scoped_acquire ag;
         deletedRRef.reset();

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -67,10 +67,8 @@ std::shared_ptr<FutureMessage> RpcAgent::sendWithRetries(
       /* retryCount */ 0,
       retryOptions);
 
-  fm->addCallback([this, newTime, firstRetryRpc](
-                      const rpc::Message& lambdaMessage,
-                      const c10::optional<utils::FutureError>& futErr) {
-    rpcRetryCallback(lambdaMessage, futErr, newTime, firstRetryRpc);
+  fm->addCallback([this, newTime, firstRetryRpc, fm]() {
+    rpcRetryCallback(fm, newTime, firstRetryRpc);
   });
 
   return originalFuture;
@@ -132,10 +130,8 @@ void RpcAgent::retryExpiredRpcs() {
           earliestRpc->options_, earliestRpc->retryCount_);
       earliestRpc->retryCount_++;
 
-      fm->addCallback([this, newTime, earliestRpc](
-                          const rpc::Message& message,
-                          const c10::optional<utils::FutureError>& futErr) {
-        rpcRetryCallback(message, futErr, newTime, earliestRpc);
+      fm->addCallback([this, newTime, earliestRpc, fm]() {
+        rpcRetryCallback(fm, newTime, earliestRpc);
       });
     }
 
@@ -153,11 +149,10 @@ void RpcAgent::retryExpiredRpcs() {
 }
 
 void RpcAgent::rpcRetryCallback(
-    const rpc::Message& message,
-    const c10::optional<utils::FutureError>& futErr,
+    const std::shared_ptr<FutureMessage>& futureMessage,
     steady_clock_time_point newTime,
     std::shared_ptr<RpcRetryInfo> earliestRpc) {
-  if (futErr) {
+  if (futureMessage->hasError()) {
     // Adding one since we want to include the original send as well and not
     // just the retry count.
     LOG(INFO) << "Send try " << std::to_string(earliestRpc->retryCount_ + 1)
@@ -169,10 +164,8 @@ void RpcAgent::rpcRetryCallback(
       std::string errorMessage = c10::str(
           "RPC Agent is no longer running on Node ",
           RpcAgent::getWorkerInfo().id_,
-          ". Cannot retry message of type ",
-          message.type(),
-          ".");
-      earliestRpc->originalFuture_->setError(errorMessage);
+          ". Cannot retry message.");
+      earliestRpc->originalFuture_->setError(*futureMessage->error());
     } else if (earliestRpc->retryCount_ < earliestRpc->options_.maxRetries) {
       // If the previous future completed with an error and we haven't
       // completed maxRetries send attempts, we move the earliestRpc
@@ -196,7 +189,8 @@ void RpcAgent::rpcRetryCallback(
     }
   } else {
     // This try succeeded, so we can make the original future as complete.
-    earliestRpc->originalFuture_->markCompleted(message);
+    earliestRpc->originalFuture_->markCompleted(
+        std::move(*futureMessage).moveValue());
   }
 }
 

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -287,8 +287,7 @@ class TORCH_API RpcAgent {
   // error and do not retry again. In case 3, we move the RpcRetryInfo struct
   // to another time point in the map to schedule the RPC for a future send.
   void rpcRetryCallback(
-      const rpc::Message& message,
-      const c10::optional<utils::FutureError>& futErr,
+      const std::shared_ptr<FutureMessage>& message,
       steady_clock_time_point newTime,
       std::shared_ptr<RpcRetryInfo> earliestRpc);
 

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -16,16 +16,14 @@ namespace rpc {
 namespace callback {
 // It's the callback for RemoteCall.
 void TORCH_API confirmPendingUser(
-    const rpc::Message& message,
-    const c10::optional<utils::FutureError>& futErr,
+    const std::shared_ptr<FutureMessage>& futureMessage,
     const ForkId& expectedForkId);
 
 // It's the callback for finishing creating owner rref, it returned deletedRRef,
 // so that the deletedRRef can be handled under GIL in python_functions.cpp if
 // deletedRRef contains python object.
-c10::intrusive_ptr<RRef> TORCH_API finishCreatingOwnerRRef(
-    const Message& message,
-    const c10::optional<utils::FutureError>& futErr);
+c10::intrusive_ptr<RRef> TORCH_API
+finishCreatingOwnerRRef(const std::shared_ptr<FutureMessage>& futureMessage);
 } // namespace callback
 
 // Manages RRef lifetime and keeps track of RRef forks.
@@ -40,7 +38,7 @@ class TORCH_API RRefContext {
   static std::vector<c10::intrusive_ptr<RRef>> destroyInstance(
       bool ignoreRRefLeak = true);
 
-  static void handleException(const c10::optional<utils::FutureError>& futErr);
+  static void handleException(const std::shared_ptr<FutureMessage>& fm);
 
   RRefContext(const RRefContext&) = delete;
   RRefContext(RRefContext&& other) = delete;

--- a/torch/csrc/distributed/rpc/torchscript_functions.cpp
+++ b/torch/csrc/distributed/rpc/torchscript_functions.cpp
@@ -38,14 +38,12 @@ c10::intrusive_ptr<c10::ivalue::Future> rpcTorchscript(
   // Create a JIT future and pass it to futMessage's callback to set state
   // of the JIT future.
   auto futPtr = c10::make_intrusive<c10::ivalue::Future>(returnType);
-  futMessage->addCallback([futPtr](
-                              const rpc::Message& message,
-                              const c10::optional<utils::FutureError>& futErr) {
-    if (futErr) {
-      c10::ivalue::Future::FutureError jitFutErr(std::string((*futErr).what()));
+  futMessage->addCallback([futPtr, futMessage]() {
+    if (futMessage->hasError()) {
+      c10::ivalue::Future::FutureError jitFutErr(futMessage->error()->what());
       futPtr->setError(std::move(jitFutErr));
     } else {
-      futPtr->markCompleted(deserializeRespToIValue(message));
+      futPtr->markCompleted(deserializeRespToIValue(futMessage->constValue()));
     }
   });
   return futPtr;
@@ -87,10 +85,8 @@ c10::intrusive_ptr<RRef> remoteTorchscript(
         nullptr);
 
     ctx.addPendingUser(userRRefPtr->forkId(), userRRefPtr);
-    fm->addCallback([forkId{userRRefPtr->forkId()}](
-                        const rpc::Message& message,
-                        const c10::optional<utils::FutureError>& futErr) {
-      callback::confirmPendingUser(message, futErr, forkId);
+    fm->addCallback([forkId{userRRefPtr->forkId()}, fm]() {
+      callback::confirmPendingUser(fm, forkId);
     });
 
     return userRRefPtr;
@@ -112,7 +108,7 @@ c10::intrusive_ptr<RRef> remoteTorchscript(
         true /*forceGradRecording*/,
         nullptr);
 
-    fm->addCallback(callback::finishCreatingOwnerRRef);
+    fm->addCallback([fm]() { callback::finishCreatingOwnerRRef(fm); });
     return ownerRRefPtr;
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36254 [future] Re-land some safe portions of the future change.**
* #36220 [future] Undo some recent torch::utils::Future api changes

These future use changes were all landed yesterday as part of the future
refactoring, quickly reverted due to an observed OOM, but now being relanded, since
they've since been tested to be benign.

Differential Revision: [D20924010](https://our.internmc.facebook.com/intern/diff/D20924010/)