### PR TITLE
[TensorExpr] add simplication of constant branches to IR Simplifier

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -125,6 +125,8 @@ namespace jit {
   _(SimplifyRoundModPatternFactorization) \
   _(SimplifyRoundModPatternMultivar)      \
   _(SimplifyDivisionScalarFactorization)  \
+  _(SimplifyConstantBranches)             \
+  _(SimplifyConstantCond)                 \
   _(StmtClone)
 
 #define TH_FORALL_TENSOREXPR_TESTS_LLVM(_) \

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -368,6 +368,10 @@ class TORCH_API PolynomialTransformer : public IRMutator {
 
   const Expr* mutate(const Cast* v) override;
 
+  const Expr* mutate(const IfThenElse* v) override;
+
+  Stmt* mutate(const Cond* v) override;
+
   template <typename Op>
   static const Expr* mutateBinaryOp(
       const BinaryOpNode<Op>* v,


### PR DESCRIPTION
Adds handling of constant branches to the TensorExpr IR Simplifier. This covers both IfThenElse and Cond when the condition expression is a known constant (e.g. `IfThenElse(1, X, Y) => X`), or when both arms of the branch are the same (e.g. `IfThenElse(Y, X, X) => X`).

