### PR TITLE
Re-enable test_avg_pool3d_nhwc

### DIFF
--- a/test/quantization/test_quantized.py
+++ b/test/quantization/test_quantized.py
@@ -942,7 +942,6 @@ class TestQuantizedOps(TestCase):
                              message=error_message.format(name + '.zero_point', scale,
                                                           qX_hat.q_zero_point()))
 
-    @unittest.skip("Failing - see https://github.com/pytorch/pytorch/issues/36129")
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=5, max_dims=5,
                                               min_side=5, max_side=10),
                        qparams=hu.qparams(dtypes=torch.qint8)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36259 Re-enable test_avg_pool3d_nhwc**

Summary:
Re-enable test disabled Related to #36129, which should be fixed by an
earlier PR #36103.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20933100](https://our.internmc.facebook.com/intern/diff/D20933100)