### PR TITLE
caffe2: preserve python exception type from PythonOp

### DIFF
--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -364,11 +364,10 @@ class PythonOpBase : public Operator<Context> {
                      OperatorBase::template GetSingleArgument<bool>(
                          "pass_workspace", false)});
       } catch (const py::error_already_set& e) {
-        std::stringstream error;
-        error << "Python exception encountered while creating PythonOp: "
-              << e.what();
-        LOG(ERROR) << error.str();
-        CAFFE_THROW(error.str());
+        LOG(ERROR) << "Python exception encountered while creating PythonOp: "
+                   << e.what();
+        // Rethrow exception to preserve python exception type.
+        throw;
       }
     }
   }
@@ -439,11 +438,10 @@ class PythonOpBase : public Operator<Context> {
           pyFunc->py_func(inputs, outputs);
         }
       } catch (const py::error_already_set& e) {
-        std::stringstream error;
-        error << "Exception encountered running PythonOp function: "
-              << e.what();
-        LOG(ERROR) << error.str();
-        CAFFE_THROW(error.str());
+        LOG(ERROR) << "Exception encountered running PythonOp function: "
+                   << e.what();
+        // Rethrow exception to preserve python exception type.
+        throw;
       }
     }
     return true;


### PR DESCRIPTION
Summary: This makes PythonOp throw the original python exception instead of wrapping it in a c10::Error type. This allows throwing exceptions from Python and preserving the type when they're caught again in Python. This is important for structured logging and handling non-retryable error types.

Test Plan: buck test caffe2/caffe2/python:python_op_test

Differential Revision: D20928098

