### PR TITLE
[rpc] Allow profiling in RPC to work with torchscript function invocations

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -431,6 +431,7 @@ If the future completes with an error, an exception is thrown.
       "_invoke_rpc_torchscript",
       [](const std::string& dstWorkerName,
          const std::string& qualifiedNameStr,
+         const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
          const py::tuple& argsTuple,
          const py::dict& kwargsDict) {
         // No need to catch exception here, if function can not be found,
@@ -454,8 +455,8 @@ If the future completes with an error, an exception is thrown.
               c10::nullopt);
         }
         DCHECK(!PyGILState_Check());
-        c10::intrusive_ptr<c10::ivalue::Future> fut =
-            rpcTorchscript(dstWorkerName, qualifiedName, functionSchema, stack);
+        c10::intrusive_ptr<c10::ivalue::Future> fut = rpcTorchscript(
+            dstWorkerName, qualifiedName, functionSchema, stack, rf);
         return torch::jit::PythonFutureWrapper(fut);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -476,6 +477,7 @@ If the future completes with an error, an exception is thrown.
       "_invoke_remote_torchscript",
       [](const std::string& dstWorkerName,
          const std::string& qualifiedNameStr,
+         const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf,
          const py::args& args,
          const py::kwargs& kwargs) {
         DCHECK(!PyGILState_Check());
@@ -493,7 +495,7 @@ If the future completes with an error, an exception is thrown.
         }
         DCHECK(!PyGILState_Check());
         auto rrefPtr = remoteTorchscript(
-            dstWorkerName, qualifiedName, functionSchema, stack);
+            dstWorkerName, qualifiedName, functionSchema, stack, rf);
         return PyRRef(rrefPtr);
       },
       py::call_guard<py::gil_scoped_release>());

--- a/torch/csrc/distributed/rpc/torchscript_functions.h
+++ b/torch/csrc/distributed/rpc/torchscript_functions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/distributed/autograd/utils.h>
 #include <torch/csrc/distributed/rpc/rref_context.h>
 #include <torch/csrc/distributed/rpc/script_remote_call.h>
@@ -23,13 +24,17 @@ c10::intrusive_ptr<c10::ivalue::Future> TORCH_API rpcTorchscript(
     const std::string& dstWorkerName,
     const c10::QualifiedName& qualifiedName,
     const c10::FunctionSchema& functionSchema,
-    std::vector<c10::IValue>& stack);
+    std::vector<c10::IValue>& stack,
+    const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf =
+        nullptr);
 
 c10::intrusive_ptr<RRef> TORCH_API remoteTorchscript(
     const std::string& dstWorkerName,
     const c10::QualifiedName& qualifiedName,
     const c10::FunctionSchema& functionSchema,
-    std::vector<c10::IValue>& stack);
+    std::vector<c10::IValue>& stack,
+    const std::shared_ptr<torch::autograd::profiler::RecordFunction>& rf =
+        nullptr);
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -429,9 +429,19 @@ def remote(to, func, args=None, kwargs=None):
     # RecordFunction instance.
     rf = None
     if torch.autograd._profiler_enabled():
+        # Create appropriate string representation based on type of func
+        # (builtin, script, python)
+        if qualified_name is None:
+            func_name = (
+                torch.jit._qualified_name(func)
+                if isinstance(func, torch.jit.ScriptFunction)
+                else func.__qualname__
+            )
+        else:
+            func_name = qualified_name
         rf = _start_record_function(
             RPCExecMode.REMOTE,
-            str(qualified_name) if qualified_name is not None else func.__qualname__,
+            func_name,
             get_worker_info().name,
             dst_worker_info.name,
         )
@@ -443,7 +453,7 @@ def remote(to, func, args=None, kwargs=None):
         return _invoke_remote_builtin(dst_worker_info, qualified_name, rf, *args, **kwargs)
     elif isinstance(func, torch.jit.ScriptFunction):
         return _invoke_remote_torchscript(
-            dst_worker_info.name, torch._jit_internal._qualified_name(func), *args, **kwargs
+            dst_worker_info.name, torch._jit_internal._qualified_name(func), rf, *args, **kwargs
         )
     else:
         (pickled_python_udf, tensors) = _default_pickler.serialize(
@@ -462,9 +472,19 @@ def _invoke_rpc(to, func, rpc_type, args=None, kwargs=None):
     # RecordFunction instance.
     rf = None
     if torch.autograd._profiler_enabled():
+        # Create appropriate string representation based on type of func
+        # (builtin, script, python)
+        if qualified_name is None:
+            func_name = (
+                torch.jit._qualified_name(func)
+                if isinstance(func, torch.jit.ScriptFunction)
+                else func.__qualname__
+            )
+        else:
+            func_name = qualified_name
         rf = _start_record_function(
             rpc_type,
-            str(qualified_name) if qualified_name is not None else func.__qualname__,
+            func_name,
             get_worker_info().name,
             dst_worker_info.name,
         )
@@ -476,7 +496,7 @@ def _invoke_rpc(to, func, rpc_type, args=None, kwargs=None):
         fut = _invoke_rpc_builtin(dst_worker_info, qualified_name, rf, *args, **kwargs)
     elif isinstance(func, torch.jit.ScriptFunction):
         fut = _invoke_rpc_torchscript(
-            dst_worker_info.name, torch.jit._qualified_name(func), args, kwargs
+            dst_worker_info.name, torch.jit._qualified_name(func), rf, args, kwargs
         )
     else:
         (pickled_python_udf, tensors) = _default_pickler.serialize(

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -639,19 +639,6 @@ class RpcTest(RpcAgentTestFixture):
         )
         self.assertEqual(ret, my_function(n, n + 1, n + 2))
 
-    @dist_init
-    def test_profiler_with_script(self):
-        func = my_script_func
-        args = (torch.tensor(1),)
-        dst = (self.rank + 1) % self.world_size
-        if self.rank == 1:
-            with torch.autograd.profiler.profile() as prof:
-                rpc.remote(worker_name(dst), func, args=args)
-                wait_until_pending_users_flushed()
-                import time ; time.sleep(0.5)
-            print("DONE")
-            print(prof.key_averages())
-
     def _profiler_test_with_rpc(self, rpc_exec_mode, func, args, use_record_function=False):
         dst = (self.rank + 1) % self.world_size
         # only run profiler on rank 1.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36275 [rpc] Allow profiling in RPC to work with torchscript function**

Calling a TorchScript function from within RPC was added after initial
support for the profiler with RPC, hence, we were not recording torchscript
funtions invoked under RPC correctly. This diff passes the `RecordFunction` to
the `_invoke_torchscript..` calls similar to what is done for builtin and UDFs.

However, this is only a temporary solution. We will be removing the use of
`RecordFunction` as a standalone in the RPC code in
https://github.com/pytorch/pytorch/pull/35055. This diff is to unblock
recording of torchscript functions in the meantime.

Test plan:
Added tests for calling a script function with builtin, sync, and
asyc. The output looks like below:

```
------  ---------------  ---------------  ---------------  ---------------  ---------------
> Name                                                                                                        Self CPU
total %  Self CPU total   CPU total %      CPU total        CPU time avg     Number of Calls
> ----------------------------------------------------------------------------------------------------------  ---------
------  ---------------  ---------------  ---------------  ---------------  ---------------
> rpc_sync#__torch__.torch.testing._internal.distributed.rpc.rpc_test.my_script_func(worker1 -> worker2)      99.92%
        1.056s           99.92%           1.056s           1.056s           1
> select                                                                                                      0.04%
        383.661us        0.04%            383.661us        95.915us         4
> fill_                                                                                                       0.02%
        210.966us        0.02%            210.966us        52.741us         4
> to                                                                                                          0.00%
        26.276us         0.00%            26.276us         26.276us         1
> empty                                                                                                       0.02%
        159.802us        0.02%            159.802us        79.901us         2
> set_                                                                                                        0.01%
        93.818us         0.01%            93.818us         93.818us         1
> ----------------------------------------------------------------------------------------------------------  ---------
------  ---------------  ---------------  ---------------  ---------------  ---------------
> Self CPU time total: 1.057s
```

Note that we use `torch.jit._qualified_name` to get the name of the script fn.

Differential Revision: [D20930453](https://our.internmc.facebook.com/intern/diff/D20930453/)