### PR TITLE
ThroughputBenchmark: integration with Autograd Profiler

### DIFF
--- a/test/test_throughput_benchmark.py
+++ b/test/test_throughput_benchmark.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import torch
+import tempfile
 from torch.utils import ThroughputBenchmark
 from torch.testing import assert_allclose
 
@@ -34,7 +35,7 @@ class TwoLayerNetModule(torch.nn.Module):
         return y_pred
 
 class TestThroughputBenchmark(TestCase):
-    def linear_test(self, Module):
+    def linear_test(self, Module, profiler_output_path=""):
         D_in = 10
         H = 5
         D_out = 15
@@ -63,6 +64,7 @@ class TestThroughputBenchmark(TestCase):
             num_calling_threads=4,
             num_warmup_iters=100,
             num_iters=1000,
+            profiler_output_path=profiler_output_path,
         )
 
         print(stats)
@@ -73,6 +75,11 @@ class TestThroughputBenchmark(TestCase):
 
     def test_module(self):
         self.linear_test(TwoLayerNetModule)
+
+    def test_profiling(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            self.linear_test(TwoLayerNetModule, profiler_output_path=f.name)
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/utils/init.cpp
+++ b/torch/csrc/utils/init.cpp
@@ -16,7 +16,8 @@ void initThroughputBenchmarkBindings(PyObject* module) {
           "num_calling_threads", &BenchmarkConfig::num_calling_threads)
       .def_readwrite("num_worker_threads", &BenchmarkConfig::num_worker_threads)
       .def_readwrite("num_warmup_iters", &BenchmarkConfig::num_warmup_iters)
-      .def_readwrite("num_iters", &BenchmarkConfig::num_iters);
+      .def_readwrite("num_iters", &BenchmarkConfig::num_iters)
+      .def_readwrite("profiler_output_path", &BenchmarkConfig::profiler_output_path);
 
   py::class_<BenchmarkExecutionStats>(m, "BenchmarkExecutionStats")
       .def_readonly("latency_avg_ms", &BenchmarkExecutionStats::latency_avg_ms)

--- a/torch/csrc/utils/throughput_benchmark-inl.h
+++ b/torch/csrc/utils/throughput_benchmark-inl.h
@@ -120,6 +120,7 @@ BenchmarkExecutionStats BenchmarkHelper<Input, Output, Model>::benchmark(
         lock, [&]() { return finished == config.num_calling_threads; });
   }
   auto end_time = std::chrono::high_resolution_clock::now();
+  profiler_guard.reset();
   LOG(INFO) << "Finished benchmark";
 
   BenchmarkExecutionStats stats;

--- a/torch/csrc/utils/throughput_benchmark-inl.h
+++ b/torch/csrc/utils/throughput_benchmark-inl.h
@@ -3,8 +3,9 @@
 #include <random>
 #include <thread>
 
-#include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
+#include <torch/csrc/utils/pybind.h>
 
 #include <aten/src/ATen/Parallel.h>
 
@@ -95,10 +96,17 @@ BenchmarkExecutionStats BenchmarkHelper<Input, Output, Model>::benchmark(
   using TimePoint = std::chrono::time_point<Clock>;
   TimePoint start_time;
 
+  std::unique_ptr<torch::autograd::profiler::RecordProfile> profiler_guard;
   {
     std::unique_lock<std::mutex> lock(m);
     while (initialized != config.num_calling_threads) {
       worker_main_cv.wait(lock);
+    }
+    if (!config.profiler_output_path.empty()) {
+      LOG(INFO) << "Using Autograd profiler. Trace will be saved to "
+                << config.profiler_output_path;
+      profiler_guard.reset(new torch::autograd::profiler::RecordProfile(
+        config.profiler_output_path));
     }
     LOG(INFO) << "Starting threads";
     start = true;

--- a/torch/csrc/utils/throughput_benchmark.h
+++ b/torch/csrc/utils/throughput_benchmark.h
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace py = pybind11;
@@ -24,7 +25,7 @@ struct BenchmarkExecutionStats {
   int64_t num_iters{-1};
 };
 
-std::ostream& operator<<(std::ostream& os, const BenchmarkExecutionStats& value);
+C10_EXPORT std::ostream& operator<<(std::ostream& os, const BenchmarkExecutionStats& value);
 
 /**
  * Use this struct in order to configure a throughput benchmark run.
@@ -52,6 +53,10 @@ struct BenchmarkConfig {
   // Number of iterations the benchmark should run with. This number is separate
   // from the warmup iterations
   int64_t num_iters{100};
+  // If set autograd profiler will be enabled. I.e. this variable would be created
+  // before the main benchmark loop (but after the warmup):
+  // RecordProfile guard(profiler_output_path);
+  std::string profiler_output_path{""};
 };
 
 namespace detail {
@@ -60,7 +65,7 @@ namespace detail {
  * A helper class to abstract out different models we test throughput of
  */
 template <class Input, class Output, class Model>
-class BenchmarkHelper {
+class C10_EXPORT BenchmarkHelper {
 public:
   BenchmarkHelper();
   explicit BenchmarkHelper(Model model): model_(model), initialized_(true) {}

--- a/torch/csrc/utils/throughput_benchmark.h
+++ b/torch/csrc/utils/throughput_benchmark.h
@@ -25,7 +25,7 @@ struct BenchmarkExecutionStats {
   int64_t num_iters{-1};
 };
 
-C10_EXPORT std::ostream& operator<<(std::ostream& os, const BenchmarkExecutionStats& value);
+std::ostream& operator<<(std::ostream& os, const BenchmarkExecutionStats& value);
 
 /**
  * Use this struct in order to configure a throughput benchmark run.
@@ -65,7 +65,7 @@ namespace detail {
  * A helper class to abstract out different models we test throughput of
  */
 template <class Input, class Output, class Model>
-class C10_EXPORT BenchmarkHelper {
+class BenchmarkHelper {
 public:
   BenchmarkHelper();
   explicit BenchmarkHelper(Model model): model_(model), initialized_(true) {}

--- a/torch/utils/throughput_benchmark.py
+++ b/torch/utils/throughput_benchmark.py
@@ -117,7 +117,12 @@ class ThroughputBenchmark(object):
         '''
         self._benchmark.add_input(*args, **kwargs)
 
-    def benchmark(self, num_calling_threads=1, num_warmup_iters=10, num_iters=100):
+    def benchmark(
+            self,
+            num_calling_threads=1,
+            num_warmup_iters=10,
+            num_iters=100,
+            profiler_output_path=""):
         '''
         Args:
             num_warmup_iters (int): Warmup iters are used to make sure we run a module
@@ -132,6 +137,12 @@ class ThroughputBenchmark(object):
                 iterations might be slightly larger. Which is reported as
                 stats.num_iters where stats is the result of this function
 
+            profiler_output_path (string): Location to save Autograd Profiler trace.
+                If not empty, Autograd Profiler will be enabled for the main benchmark
+                execution (but not the warmup phase). The full trace will be saved
+                into the file path provided by this argument
+
+
         This function returns BenchmarkExecutionStats object which is defined via pybind11.
         It currently has two fields:
             - num_iters - number of actual iterations the benchmark have made
@@ -141,5 +152,6 @@ class ThroughputBenchmark(object):
         config.num_calling_threads = num_calling_threads
         config.num_warmup_iters = num_warmup_iters
         config.num_iters = num_iters
+        config.profiler_output_path = profiler_output_path
         c_stats = self._benchmark.benchmark(config)
         return ExecutionStats(c_stats, config)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36282 ThroughputBenchmark: integration with Autograd Profiler**

The reason to do this explicitly in the tool is that we don't want to capture warmup in profiling (as well as input cloning). So instead we make the benchmarking code explicitly aware of the profiler.

Example output:

```
I0408 16:06:40.300040 85516 throughput_benchmark-inl.h:106] Using Autograd profiler. Trace will be saved to /tmp/tmpt0gsz85y
I0408 16:06:40.302232 85516 throughput_benchmark-inl.h:111] Starting threads
I0408 16:06:40.302258 85524 throughput_benchmark-inl.h:78] Starting forward thread 1
I0408 16:06:40.302259 85525 throughput_benchmark-inl.h:78] Starting forward thread 2
I0408 16:06:40.302261 85523 throughput_benchmark-inl.h:78] Starting forward thread 0
I0408 16:06:40.302259 85526 throughput_benchmark-inl.h:78] Starting forward thread 3
I0408 16:06:40.412879 85525 throughput_benchmark-inl.h:88] Shutting down forward thread 2. Total number of finished threads: 1
I0408 16:06:40.412971 85523 throughput_benchmark-inl.h:88] Shutting down forward thread 0. Total number of finished threads: 2
I0408 16:06:40.412989 85526 throughput_benchmark-inl.h:88] Shutting down forward thread 3. Total number of finished threads: 3
I0408 16:06:40.413033 85524 throughput_benchmark-inl.h:88] Shutting down forward thread 1. Total number of finished threads: 4
I0408 16:06:40.413056 85516 throughput_benchmark-inl.h:123] Finished benchmark
Average latency per example: 443.256us
Total number of iterations: 1000
Total number of iterations per second (across all threads): 9024.12
Total time: 110.814ms
```

Differential Revision: [D20987125](https://our.internmc.facebook.com/intern/diff/D20987125)