### PR TITLE
[TensorExpr] fix bug in IRSimplifier when multiplying by 0

### DIFF
--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -748,6 +748,20 @@ void testSimplifySubs() {
 
     IS_IMM_WITH_VAL(Int, simplified.node(), 0);
   }
+
+  {
+    // Cancel out opaque modulus.
+    ExprHandle body = (x % y + 2) - (x % y);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_IMM_WITH_VAL(Int, simplified.node(), 2);
+  }
+
+  {
+    // Cancel out opaque modulus with a bit more going on.
+    ExprHandle body = (x % y + (x * 2 - x - y * 0) - x + 2) - (x % y);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_IMM_WITH_VAL(Int, simplified.node(), 2);
+  }
 }
 
 // Test that mixing ops together simplifies as expected.

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -797,20 +797,18 @@ const Expr* PolynomialTransformer::mutate(const Mul* v) {
     variable = lhs_new;
   }
 
+  // If there is a scalar and its zero then return zero.
+  if (scalar && immediateEquals(scalar, 0)) {
+    return scalar;
+  }
+
   if (scalar && lhsTerm) {
     const Expr* newScalar = evaluateOp(new Mul(scalar, lhsTerm->scalar()));
-    if (immediateEquals(newScalar, 0)) {
-      return newScalar;
-    }
     return new Term(hasher_, newScalar, lhsTerm->variables());
   }
 
   if (scalar && rhsTerm) {
     const Expr* newScalar = evaluateOp(new Mul(scalar, rhsTerm->scalar()));
-
-    if (immediateEquals(newScalar, 0)) {
-      return newScalar;
-    }
     return new Term(hasher_, newScalar, rhsTerm->variables());
   }
 


### PR DESCRIPTION
In the IR Simplifier we were not treating multiply by zero specially, which meant some constant expressions were stored in formats that were not constant.