### PR TITLE
Use temporary variable to store input parameters in loop.

### DIFF
--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -56,10 +56,10 @@ __global__ void max_pool_forward_nchw(const int nthreads, const scalar_t* bottom
       wstart += dilation_w;
     accscalar_t maxval = at::numeric_limits<accscalar_t>::lower_bound(); // -Infinity
     int maxidx = hstart * width + wstart;
-    bottom_data += (n * channels + c) * height * width;
+    const scalar_t* btm_data = bottom_data + (n * channels + c) * height * width;
     for (int h = hstart; h < hend; h += dilation_h) {
       for (int w = wstart; w < wend; w += dilation_w) {
-        scalar_t val = bottom_data[h * width + w];
+        scalar_t val = btm_data[h * width + w];
         if ((ScalarConvert<scalar_t, accscalar_t>::to(val) > maxval) || THCNumerics<scalar_t>::isnan(val)) {
           maxidx = h * width + w;
           maxval = ScalarConvert<scalar_t, accscalar_t>::to(val);

--- a/aten/src/ATen/native/cuda/im2col.cuh
+++ b/aten/src/ATen/native/cuda/im2col.cuh
@@ -46,16 +46,16 @@ __global__ void im2col_kernel(
   CUDA_KERNEL_LOOP(index, n) {
     int64_t w_out = index % width_col;
 
-    index /= width_col;
+    int64_t idx = index / width_col;
 
-    int64_t h_out = index % height_col;
-    int64_t channel_in = index / height_col;
+    int64_t h_out = idx % height_col;
+    int64_t channel_in = idx / height_col;
     int64_t channel_out = channel_in * kernel_height * kernel_width;
     int64_t h_in = h_out * stride_height - pad_height;
     int64_t w_in = w_out * stride_width - pad_width;
 
-    data_col += (channel_out * height_col + h_out) * width_col + w_out;
-    data_im += (channel_in * height + h_in) * width + w_in;
+    dt* col = data_col + (channel_out * height_col + h_out) * width_col + w_out;
+    const dt* im = data_im + (channel_in * height + h_in) * width + w_in;
 
     for (int64_t i = 0; i < kernel_height; ++i) {
       for (int64_t j = 0; j < kernel_width; ++j) {

--- a/aten/src/ATen/native/cuda/im2col.cuh
+++ b/aten/src/ATen/native/cuda/im2col.cuh
@@ -61,10 +61,10 @@ __global__ void im2col_kernel(
       for (int64_t j = 0; j < kernel_width; ++j) {
         int64_t h = h_in + i * dilation_height;
         int64_t w = w_in + j * dilation_width;
-        *data_col = (h >= 0 && w >= 0 && h < height && w < width)
-            ? data_im[i * dilation_height * width + j * dilation_width]
+        *col = (h >= 0 && w >= 0 && h < height && w < width)
+            ? im[i * dilation_height * width + j * dilation_width]
             : ScalarConvert<int, dt>::to(0);
-        data_col += height_col * width_col;
+        col += height_col * width_col;
       }
     }
   }


### PR DESCRIPTION
The original implementation of maxpool and im2col kernels will fail if `gridSize` * `blockSize` is smaller than the `nthreads` in maxpool kernel or `n` in im2col kernel. Input parameters `bottom_data`, `data_col`, `data_im`, and loop index `index` are modified inside the loop body and the corrupted data will be carried to the second iteration.  

This patch uses temporary variables to replace the input parameters and loop indices. 