### PR TITLE
Use _sparse_coo_tensor_unsafe to shallow copy sparse tensors in accumulate_grad

### DIFF
--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -75,7 +75,7 @@ struct TORCH_API AccumulateGrad : public Node {
         // earlier we would clone the entire SparseTensor which cloned indices
         // and values.
         // For details see https://github.com/pytorch/pytorch/issues/34375.
-        update_grad(at::sparse_coo_tensor(
+        update_grad(at::_sparse_coo_tensor_unsafe(
             new_grad._indices(),
             new_grad._values(),
             new_grad.sizes(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36292 Use _sparse_coo_tensor_unsafe to shallow copy sparse tensors in accumulate_grad**

As reported in https://github.com/pytorch/pytorch/issues/36120,
sparse_coo_tensor has some expensive checks and we were using that to shallow
copy a sparse tensor in AccumulateGrad. This can be avoided by using
_sparse_tensor_coo_unsafe since we're just reusing the indices and values from
a valid sparse tensor to shallow copy it.

Using the benchmark code mentioned in
https://github.com/pytorch/pytorch/issues/36120, these are the results:

1) 65.1 ms on master with this PR.
2) 127.5 ms for PyTorch 1.4
3) 916.5 ms on master without this patch.

Closes: https://github.com/pytorch/pytorch/issues/36120

Differential Revision: [D20935573](https://our.internmc.facebook.com/intern/diff/D20935573/)