### PR TITLE
Move FakeFP16 back to internal to remove dependency on MKL

### DIFF
--- a/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
@@ -1,4 +1,4 @@
-#include <fbgemm/FbgemmFakeFP16.h>
+#include <fbgemm/FbgemmConvert.h>
 #include "caffe2/caffe2/operators/elementwise_add_op.h"
 #include "caffe2/caffe2/operators/elementwise_div_op.h"
 #include "caffe2/caffe2/operators/elementwise_mul_op.h"

--- a/caffe2/contrib/fakelowp/lengths_reducer_ops.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_ops.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <fbgemm/FbgemmFakeFP16.h>
+#include <fbgemm/FbgemmConvert.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/perfkernels/typed_axpy.h"

--- a/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include <fbgemm/FbgemmFakeFP16.h>
+#include <fbgemm/FbgemmConvert.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/eigen_utils.h"

--- a/caffe2/contrib/fakelowp/unary_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/unary_fp16_fake_op.cc
@@ -1,5 +1,5 @@
 #include "unary_fp16_fake_op.h"
-#include <fbgemm/FbgemmFakeFP16.h>
+#include <fbgemm/FbgemmConvert.h>
 
 #include "caffe2/utils/eigen_utils.h"
 

--- a/caffe2/contrib/fakelowp/unary_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/unary_fp16_fake_op.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include <fbgemm/FbgemmFakeFP16.h>
+#include <fbgemm/FbgemmConvert.h>
 #include "caffe2/operators/elementwise_ops.h"
 #include "caffe2/utils/math.h"
 


### PR DESCRIPTION
Summary:
We moved FakeFP16 back to close source and kept `RoundToFloat16` function in "fbgemm/FbgemmConvert.h".

This is because FakeFP16 introduced dependency on MKL in the FBGEMM core. Also it doesn't seem to be needed for open source, as it is not used anywhere.

Test Plan: CI

Differential Revision: D20937962

