### PR TITLE
make vendor match with this implementation

### DIFF
--- a/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
@@ -330,9 +330,8 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
       T* beta) {
     EigenVectorArrayMap<T> alpha_arr(alpha, C);
     EigenVectorArrayMap<T> beta_arr(beta, C);
-    alpha_arr = ConstEigenVectorArrayMap<T>(scale, C) *
-        (ConstEigenVectorArrayMap<T>(var, C) + static_cast<T>(epsilon_))
-            .rsqrt();
+    alpha_arr = ConstEigenVectorArrayMap<T>(scale, C) /
+        (ConstEigenVectorArrayMap<T>(var, C) + static_cast<T>(epsilon_)).sqrt();
     beta_arr = ConstEigenVectorArrayMap<T>(bias, C) -
         alpha_arr * ConstEigenVectorArrayMap<T>(mean, C);
   }


### PR DESCRIPTION
Summary: used 1/sqrt(x) vs rsqrt(x)

Test Plan:
tested with the seed from testwarden 1586230820
tested without the seed

Differential Revision: D20939672

