### PR TITLE
modify `select_equals_backward` to propage only to a single value

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5266,6 +5266,13 @@ class TestAutogradFunctional(TestCase):
 # Generic device type autograd tests.
 class TestAutogradDeviceType(TestCase):
 
+    def test_min_max_median_backprops_to_single_value(self, device):
+        for f in [torch.min, torch.max, torch.median]:
+            x = torch.tensor([1., 0., 1., 0., 1., 0.], device=device, requires_grad=True)
+            y = f(x)
+            y.backward()
+            self.assertEqual(x.grad.sum(), 1.)
+
     # skip this test if running on rocm, because in cdist
     # we use __shfl_down_sync on CUDA for fast reduction
     # and it gives incorrect results on rocm platform

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -565,7 +565,7 @@
   self: index_select_backward(grad, dim, indices, self.sizes(), keepdim)
 
 - name: max(Tensor self) -> Tensor
-  self: select_equals_backward(grad, self, result)
+  self: select_first_equal_backward(grad, self, result)
 
 - name: max.other(Tensor self, Tensor other) -> Tensor
   self: grad.clone().masked_fill_(self <= other, 0)
@@ -578,7 +578,7 @@
   self: sum_backward(grad, self.sizes(), dim, keepdim).to(self.scalar_type()) / _safe_size(self.sizes(), dim)
 
 - name: median(Tensor self) -> Tensor
-  self: select_equals_backward(grad, self, result)
+  self: select_first_equal_backward(grad, self, result)
 
 # This is in theory incorrect in the following case:
 #   sorted list: [..., a, b, b, ..., b, b, c, ...] with median = b and the value
@@ -601,7 +601,7 @@
   self: index_select_backward(grad, dim, indices, self.sizes(), keepdim)
 
 - name: min(Tensor self) -> Tensor
-  self: select_equals_backward(grad, self, result)
+  self: select_first_equal_backward(grad, self, result)
 
 - name: min.other(Tensor self, Tensor other) -> Tensor
   self: grad.clone().masked_fill_(self >= other, 0)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -652,18 +652,17 @@ Tensor _fused_dropout_backward(Tensor grad, Tensor mask, double p1m) {
 }
 
 Tensor select_first_equal_backward(Tensor grad, const Tensor & input, const Tensor & value) {
-  auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto grad_input = at::zeros_like(input);
 
   // find indices of the first element for which input[idx] == value
   auto first_value_idx = (input == value).nonzero().select(0, 0);
 
-  // grad_input[first_value_idx]
-  auto grad_input_value = grad_input;
-  for (int64_t dim = 0; dim < grad_input.sizes().size(); ++dim) {
-    grad_input_value = grad_input_value.select(0, first_value_idx[dim].item().to<int64_t>());
+  if (grad_input.dim() == 0) {
+    grad_input.copy_(grad);
   }
-  // grad_input[first_value_idx] = grad
-  grad_input_value.copy_(grad);
+  else {
+    grad_input.index_put_(at::chunk(first_value_idx, grad_input.dim()), grad);
+  }
 
   return grad_input;
 }

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -651,7 +651,7 @@ Tensor _fused_dropout_backward(Tensor grad, Tensor mask, double p1m) {
   }
 }
 
-Tensor select_equals_backward(Tensor grad, const Tensor & input, const Tensor & value) {
+Tensor select_first_equal_backward(Tensor grad, const Tensor & input, const Tensor & value) {
   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
   // find indices of the first element for which input[idx] == value


### PR DESCRIPTION
Renames `select_equals_backward` to `select_first_equal_backward` and makes sure it propagates to a single value.
Fixes [#35699](https://github.com/pytorch/pytorch/issues/35699).