### PR TITLE
[quant][onnx] Mark upsample_nearest2d, sigmoid and reshape as no scale

### DIFF
--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -40,7 +40,10 @@ double getScaleFromInput(Node* input_node) {
                                                  "aten::slice",
                                                  "aten::avg_pool2d",
                                                  "quantized::cat",
-                                                 "prim::ListConstruct"};
+                                                 "prim::ListConstruct",
+                                                 "aten::upsample_nearest2d",
+                                                 "aten::sigmoid",
+                                                 "aten::reshape"};
   if (input_name == "aten::quantize_per_tensor") {
     TORCH_CHECK(
         input_node->inputs().size() > 1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36325 [quant][onnx] Mark upsample_nearest2d, sigmoid and reshape as no scale**

Summary:
return the scale of the input tensor

Test Plan:
python test/onnx/test_pytorch_onnx_caffe2_quantized.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D20947338](https://our.internmc.facebook.com/intern/diff/D20947338)