### PR TITLE
Remove unnecessary whitespace in complex tensors

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -80,8 +80,18 @@ class _Formatter(object):
             tensor_view = tensor.reshape(-1)
 
         if not self.floating_dtype:
+            complex_has_decimal = False
+            if self.complex_dtype:
+                # max width for complex tensors depends on whether or not tensor contains ints only
+                complex_has_decimal = sum([not (value.item().real.is_integer() and value.item().imag.is_integer()) \
+                    for value in tensor_view])
             for value in tensor_view:
-                value_str = '{}'.format(value)
+                if self.complex_dtype and complex_has_decimal:
+                    value_str = ('{{:.{}f}}').format(PRINT_OPTS.precision).format(value)
+                elif self.complex_dtype and not complex_has_decimal:
+                    value_str = "{:.0f}".format(value.item())
+                else:
+                    value_str = '{}'.format(value)
                 self.max_width = max(self.max_width, len(value_str))
 
         else:

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -72,25 +72,27 @@ class _Formatter(object):
     def __init__(self, tensor):
         self.floating_dtype = tensor.dtype.is_floating_point
         self.complex_dtype = tensor.dtype.is_complex
-        self.complex_with_decimal = False
         self.int_mode = True
         self.sci_mode = False
         self.max_width = 1
+
+        # only used for complex tensors
+        self.has_non_zero_decimal_val = False
 
         with torch.no_grad():
             tensor_view = tensor.reshape(-1)
 
         if not self.floating_dtype:
-            self.complex_with_decimal = False
             if self.complex_dtype:
                 # max width for complex tensors depends on whether or not tensor contains ints only
-                self.complex_with_decimal = sum([not (value.item().real.is_integer() and value.item().imag.is_integer())
-                                                for value in tensor_view])
+                self.has_non_zero_decimal_val = sum([not (value.item().real.is_integer() and value.item().imag.is_integer())
+                                                     for value in tensor_view])
             for value in tensor_view:
-                if self.complex_dtype and self.complex_with_decimal:
-                    value_str = ('{{:.{}f}}').format(PRINT_OPTS.precision).format(value)
-                elif self.complex_dtype:
-                    value_str = "{:.0f}".format(value.item())
+                if self.complex_dtype:
+                    if self.has_non_zero_decimal_val:
+                        value_str = ('{{:.{}f}}').format(PRINT_OPTS.precision).format(value)
+                    else:
+                        value_str = "{:.0f}".format(value.item())
                 else:
                     value_str = '{}'.format(value)
                 self.max_width = max(self.max_width, len(value_str))
@@ -157,7 +159,7 @@ class _Formatter(object):
         elif self.complex_dtype:
             p = PRINT_OPTS.precision
             ret = '({{:.{}f}} {{}} {{:.{}f}}j)'.format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
-            if not self.complex_with_decimal:
+            if not self.has_non_zero_decimal_val:
                 # complex tensor contains integer elements only
                 ret = "({{:.0f}}. {{}} {{:.0f}}.j)".format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
         else:

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -84,7 +84,7 @@ class _Formatter(object):
             if self.complex_dtype:
                 # max width for complex tensors depends on whether or not tensor contains ints only
                 complex_has_decimal = sum([not (value.item().real.is_integer() and value.item().imag.is_integer())
-                                            for value in tensor_view])
+                                        for value in tensor_view])
             for value in tensor_view:
                 if self.complex_dtype and complex_has_decimal:
                     value_str = ('{{:.{}f}}').format(PRINT_OPTS.precision).format(value)

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -182,7 +182,6 @@ def _vector_str(self, indent, formatter, summarize):
                 [' ...'] +
                 [formatter.format(val) for val in self[-PRINT_OPTS.edgeitems:].tolist()])
     else:
-        # variable to keep track of complex float tensors
         data = [formatter.format(val) for val in self.tolist()]
 
     data_lines = [data[i:i + elements_per_line] for i in range(0, len(data), elements_per_line)]

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -158,7 +158,7 @@ class _Formatter(object):
             ret = '({{:.{}f}} {{}} {{:.{}f}}j)'.format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
             if not has_non_zero_decimal_val:
                 # complex tensor contains integer elements only
-                ret = "({{:.0f}} {{}} {{:.0f}}.j)".format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
+                ret = "({{:.0f}}. {{}} {{:.0f}}.j)".format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
         else:
             ret = '{}'.format(value)
         return (self.max_width - len(ret)) * ' ' + ret

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -83,8 +83,8 @@ class _Formatter(object):
             complex_has_decimal = False
             if self.complex_dtype:
                 # max width for complex tensors depends on whether or not tensor contains ints only
-                complex_has_decimal = sum([not (value.item().real.is_integer() and value.item().imag.is_integer()) \
-                    for value in tensor_view])
+                complex_has_decimal = sum([not (value.item().real.is_integer() and value.item().imag.is_integer())
+                                            for value in tensor_view])
             for value in tensor_view:
                 if self.complex_dtype and complex_has_decimal:
                     value_str = ('{{:.{}f}}').format(PRINT_OPTS.precision).format(value)

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -158,10 +158,10 @@ class _Formatter(object):
                 ret = ('{{:.{}f}}').format(PRINT_OPTS.precision).format(value)
         elif self.complex_dtype:
             p = PRINT_OPTS.precision
-            ret = '({{:.{}f}} {{}} {{:.{}f}}j)'.format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
+            ret = '({{:.{}f}}{{}}{{:.{}f}}j)'.format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
             if not self.has_non_zero_decimal_val:
                 # complex tensor contains integer elements only
-                ret = "({{:.0f}}. {{}} {{:.0f}}.j)".format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
+                ret = "({{:.0f}}.{{}}{{:.0f}}.j)".format(p, p).format(value.real, '+-'[value.imag < 0], abs(value.imag))
         else:
             ret = '{}'.format(value)
         return (self.max_width - len(ret)) * ' ' + ret

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -84,7 +84,7 @@ class _Formatter(object):
             if self.complex_dtype:
                 # max width for complex tensors depends on whether or not tensor contains ints only
                 complex_has_decimal = sum([not (value.item().real.is_integer() and value.item().imag.is_integer())
-                                        for value in tensor_view])
+                                           for value in tensor_view])
             for value in tensor_view:
                 if self.complex_dtype and complex_has_decimal:
                     value_str = ('{{:.{}f}}').format(PRINT_OPTS.precision).format(value)


### PR DESCRIPTION
This PR addresses Issue #36279. 
Previously, printing of complex tensors would sometimes yield extra spaces before the elements as shown below:
```
print(torch.tensor([[1 + 1.340j, 3 + 4j], [1.2 + 1.340j, 6.5 + 7j]], dtype=torch.complex64))
```
would yield
```
tensor([[(1.0000 + 1.3400j),
         (3.0000 + 4.0000j)],
        [(1.2000 + 1.3400j),
         (6.5000 + 7.0000j)]], dtype=torch.complex64)
```
This occurs primarily because when the max width for the element is being assigned, the formatter's max_width is calculated prior to truncating the float values. As a result, ```self.max_width``` would end up being much longer than the final length of the element string to be printed.

I address this by adding a boolean variable that checks if a complex tensor contains only ints and change the control flow for calculating ```self.max_width``` accordingly.

Here are some sample outputs of both float and complex tensors:

```
tensor([[0., 0.],
        [0., 0.]], dtype=torch.float64) 

tensor([[(0.+0.j), (0.+0.j)],
        [(0.+0.j), (0.+0.j)]], dtype=torch.complex64) 

tensor([1.2000, 1.3400], dtype=torch.float64) 

tensor([(1.2000+1.3400j)], dtype=torch.complex64) 

tensor([[(1.0000+1.3400j), (3.0000+4.0000j)],
        [(1.2000+1.3400j), (6.5000+7.0000j)]], dtype=torch.complex64) 

tensor([1.0000, 2.0000, 3.0000, 4.5000]) 

tensor([(1.+2.j)], dtype=torch.complex64) 
```

cc @ezyang @anjali411 @dylanbespalko