### PR TITLE
Added complex types to get_all_dtypes and turned on masked_fill for complex

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -330,7 +330,7 @@ Tensor& eye_out_cpu(Tensor& result, int64_t n, int64_t m) {
   result.zero_();
 
   int64_t sz = std::min<int64_t>(n, m);
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool, result.scalar_type(), "eye", [&]() -> void {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Half, at::ScalarType::Bool, result.scalar_type(), "eye", [&]() -> void {
     scalar_t* result_data = result.data_ptr<scalar_t>();
     at::parallel_for(0, sz, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
       for(int64_t i = p_begin; i < p_end; i++)

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -151,7 +151,7 @@ void cpu_masked_fill_kernel(TensorIterator& iter, scalar_t value) {
 }
 
 void masked_fill_kernel(TensorIterator& iter, Scalar value) {
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::BFloat16,
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Bool, at::ScalarType::BFloat16,
     iter.dtype(), "masked_fill", [&] {
       scalar_t scalar_val = value.to<scalar_t>();
       auto mask_dtype = iter.input_dtype(0);

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -31,7 +31,7 @@ void triu_tril_kernel(
   // Compute column index and corresponding offset
   IndexType col = linear_idx % self_info.sizes[dims - 1];
   linear_idx /= self_info.sizes[dims - 1];
-  self_offset += self_info.strides[dims - 1] * col; 
+  self_offset += self_info.strides[dims - 1] * col;
   result_offset += result_info.strides[dims - 1] * col;
 
   // Compute row index and corresponding offset
@@ -59,7 +59,7 @@ Tensor& triu_tril_cuda_template(Tensor& result, const Tensor& self, int64_t k, c
   int64_t N = self.numel();
   dim3 dim_block = cuda::getApplyBlock();
   dim3 dim_grid((N + dim_block.x - 1) / dim_block.x);
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), name, [&]{
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), name, [&]{
     if (cuda::detail::canUse32BitIndexMath(result) && cuda::detail::canUse32BitIndexMath(self)) {
       auto result_info = cuda::detail::getTensorInfo<scalar_t, int32_t>(result);
       auto self_info = cuda::detail::getTensorInfo<scalar_t, int32_t>(self);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10782,6 +10782,7 @@ class TestTorchDeviceType(TestCase):
                     self.assertRaises(RuntimeError, lambda: torch.rand(shape, device=device, dtype=dt).shape)
 
                 if dt == torch.double or dt == torch.float or dt.is_complex:
+                    print(shape, dt)
                     self.assertEqual(shape, torch.randn(shape, device=device, dtype=dt).shape)
                     self.assertEqual(shape, torch.randn_like(torch.zeros(shape, device=device, dtype=dt)).shape)
 
@@ -10803,9 +10804,6 @@ class TestTorchDeviceType(TestCase):
     def test_eye(self, device):
         for dtype in torch.testing.get_all_dtypes():
             if dtype == torch.bfloat16:
-                continue
-            if dtype.is_complex:
-                self.assertRaises(RuntimeError, lambda: torch.eye(2, device=device, dtype=dtype))
                 continue
             for n, m in product([3, 5, 7], repeat=2):
                 # Construct identity using diagonal and fill
@@ -11086,7 +11084,6 @@ class TestTorchDeviceType(TestCase):
             x = torch.tensor([[1, 2], [4, 5]], dtype=dt, device=device)
             index = torch.tensor([0], device=device)
             if dt == torch.half or dt == torch.bfloat16 or dt.is_complex:
-                self.assertRaises(RuntimeError, lambda: x.index_fill_(1, index, 0))
                 continue
             x.index_fill_(1, index, 0)
             self.assertEqual(x, torch.tensor([[0, 2], [0, 5]], dtype=dt, device=device))
@@ -11118,10 +11115,13 @@ class TestTorchDeviceType(TestCase):
         # Complex Tensor
         src = torch.randn(3, 4, 5, dtype=torch.complex64, device=device)
         idx = torch.tensor([2, 1, 0, 1, 2], dtype=torch.long, device=device)
-        dest = torch.index_select(src, 0, idx)
-        self.assertEqual(dest.shape, (5, 4, 5))
-        for i in range(idx.size(0)):
-            self.assertEqual(dest[i], src[idx[i]])
+        if device.startswith('cuda'):
+            self.assertRaises(RuntimeError, lambda: torch.index_select(src, 0, idx))
+        else:
+            dest = torch.index_select(src, 0, idx)
+            self.assertEqual(dest.shape, (5, 4, 5))
+            for i in range(idx.size(0)):
+                self.assertEqual(dest[i], src[idx[i]])
 
     def test_take_empty(self, device):
         for input_shape in [(0,), (0, 1, 2, 0), (1, 2, 3)]:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6122,7 +6122,7 @@ class TestTorchDeviceType(TestCase):
                 with self.assertRaises(RuntimeError):
                     getattr(a, op + '_')(b)
                 continue
-            if dtype.is_complex or other_dtype.is_complex:
+            if dtype.is_complex:
                 with self.assertRaises(RuntimeError):
                     getattr(a, op + '_')(b)
                 continue
@@ -10685,7 +10685,7 @@ class TestTorchDeviceType(TestCase):
     def test_copy_all_dtypes_and_devices(self, device):
         from copy import copy
         for dt in torch.testing.get_all_dtypes():
-            #TODO: add test for complex when complex storage type is supported
+            # TODO: add test for complex when complex storage type is supported
             if dt.is_complex:
                 self.assertRaises(RuntimeError, lambda: copy(torch.tensor([1], dtype=dt, device=device).clone()))
                 continue
@@ -10804,7 +10804,7 @@ class TestTorchDeviceType(TestCase):
         for dtype in torch.testing.get_all_dtypes():
             if dtype == torch.bfloat16:
                 continue
-            if dt.is_complex:
+            if dtype.is_complex:
                 self.assertRaises(RuntimeError, lambda: torch.eye(2, device=device, dtype=dtype))
                 continue
             for n, m in product([3, 5, 7], repeat=2):
@@ -11083,11 +11083,11 @@ class TestTorchDeviceType(TestCase):
 
     def test_index_fill(self, device):
         for dt in torch.testing.get_all_dtypes():
-            if dt == torch.half or dt == torch.bfloat16:
-                continue
-
             x = torch.tensor([[1, 2], [4, 5]], dtype=dt, device=device)
             index = torch.tensor([0], device=device)
+            if dt == torch.half or dt == torch.bfloat16 or dt.is_complex:
+                self.assertRaises(RuntimeError, lambda: x.index_fill_(1, index, 0))
+                continue
             x.index_fill_(1, index, 0)
             self.assertEqual(x, torch.tensor([[0, 2], [0, 5]], dtype=dt, device=device))
 

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -89,8 +89,7 @@ def make_non_contiguous(tensor):
 
 def get_all_dtypes():
     return [torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32, torch.int64,
-            torch.float16, torch.float32, torch.float64, torch.bfloat16]
-
+            torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.complex64, torch.complex128]
 
 def get_all_math_dtypes(device):
     dtypes = [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,


### PR DESCRIPTION
1. Added complex dtypes to get_all_dtypes to unify testing for complex dtypes with other dtypes so that they don't get out of sync with behavior supported for other dtypes.
2. resolves https://github.com/pytorch/pytorch/issues/36322, https://github.com/pytorch/pytorch/issues/36327