### PR TITLE
Update docs for 1.5 to remove Python 2 references

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -790,21 +790,6 @@ New API:
 
     m = torch.jit.script(MyModule())
 
-Python 2
-""""""""
-If you are stuck on Python 2 and cannot use the class annotation syntax, you can use the ``__annotations__`` class member to directly apply type annotations.
-
-.. testcode::
-
-    from typing import Dict
-
-    class MyModule(torch.jit.ScriptModule):
-        __annotations__ = {'my_dict': Dict[str, int]}
-
-        def __init__(self):
-            super(MyModule, self).__init__()
-            self.my_dict = {}
-            self.my_int = 20
 
 Constants
 ^^^^^^^^^

--- a/docs/source/jit_language_reference.rst
+++ b/docs/source/jit_language_reference.rst
@@ -185,13 +185,10 @@ MyPy-style type annotations using the types listed above.
 
     ...
 
-  In our examples, we use comment-based type hints to ensure Python 2
-  compatibility as well.
-
 
 An empty list is assumed to be ``List[Tensor]`` and empty dicts
 ``Dict[str, Tensor]``. To instantiate an empty list or dict of other types,
-use `Python 3 type hints`_. If you are on Python 2, you can use ``torch.jit.annotate``.
+use `Python 3 type hints`_.
 
 Example (type annotations for Python 3):
 
@@ -216,31 +213,6 @@ Example (type annotations for Python 3):
 
     x = torch.jit.script(EmptyDataStructures())
 
-
-Example (``torch.jit.annotate`` for Python 2):
-
-.. testcode::
-
-    import torch
-    import torch.nn as nn
-    from typing import Dict, List, Tuple
-
-    class EmptyDataStructures(torch.nn.Module):
-        def __init__(self):
-            super(EmptyDataStructures, self).__init__()
-
-        def forward(self, x):
-            # type: (Tensor) -> Tuple[List[Tuple[int, float]], Dict[str, int]]
-
-            # This annotates the list to be a `List[Tuple[int, float]]`
-            my_list = torch.jit.annotate(List[Tuple[int, float]], [])
-            for i in range(10):
-                my_list.append((i, float(x.item())))
-
-            my_dict = torch.jit.annotate(Dict[str, int], {})
-            return my_list, my_dict
-
-    x = torch.jit.script(EmptyDataStructures())
 
 
 
@@ -856,28 +828,8 @@ Supported constant Python types are
 * tuples containing supported types
 * ``torch.nn.ModuleList`` which can be used in a TorchScript for loop
 
-.. note::
-    If you are on Python 2, you can mark an attribute as a constant by adding
-    its name to the ``__constants__`` property of the class:
 
-    .. testcode::
 
-        import torch
-        import torch.nn as nn
-
-        class Foo(nn.Module):
-            __constants__ = ['a']
-
-            def __init__(self):
-                super(Foo, self).__init__()
-                self.a = 1 + 4
-
-            def forward(self, input):
-                return self.a + input
-
-        f = torch.jit.script(Foo())
-
-    |
 
 .. _module attributes:
 
@@ -924,32 +876,3 @@ Example:
 
     f = torch.jit.script(Foo({'hi': 2}))
 
-
-.. note::
-    If you are on Python 2, you can mark an attribute's type by adding it to
-    the ``__annotations__`` class property as a dictionary of attribute name to
-    type
-
-    .. testcode::
-
-        from typing import List, Dict
-
-        class Foo(nn.Module):
-            __annotations__ = {'words': List[str], 'some_dict': Dict[str, int]}
-
-            def __init__(self, a_dict):
-                super(Foo, self).__init__()
-                self.words = []
-                self.some_dict = a_dict
-
-                # `int`s can be inferred
-                self.my_int = 10
-
-            def forward(self, input):
-                # type: (str) -> int
-                self.words.append(input)
-                return self.some_dict[input] + self.my_int
-
-        f = torch.jit.script(Foo({'hi': 2}))
-
-    |

--- a/docs/source/multiprocessing.rst
+++ b/docs/source/multiprocessing.rst
@@ -30,9 +30,8 @@ Sharing CUDA tensors
 --------------------
 
 Sharing CUDA tensors between processes is supported only in Python 3, using
-a ``spawn`` or ``forkserver`` start methods. :mod:`python:multiprocessing` in
-Python 2 can only create subprocesses using ``fork``, and it's not supported
-by the CUDA runtime.
+a ``spawn`` or ``forkserver`` start methods. 
+
 
 Unlike CPU tensors, the sending process is required to keep the original tensor
 as long as the receiving process retains a copy of the tensor. The refcounting is

--- a/docs/source/multiprocessing.rst
+++ b/docs/source/multiprocessing.rst
@@ -1,134 +1,182 @@
-.. _multiprocessing-best-practices:
+:orphan:
 
-Multiprocessing best practices
-==============================
+.. _multiprocessing-doc:
 
-:mod:`torch.multiprocessing` is a drop in replacement for Python's
-:mod:`python:multiprocessing` module. It supports the exact same operations,
-but extends it, so that all tensors sent through a
-:class:`python:multiprocessing.Queue`, will have their data moved into shared
-memory and will only send a handle to another process.
+Multiprocessing package - torch.multiprocessing
+===============================================
 
-.. note::
-
-    When a :class:`~torch.Tensor` is sent to another process, the
-    :class:`~torch.Tensor` data is shared. If :attr:`torch.Tensor.grad` is
-    not ``None``, it is also shared. After a :class:`~torch.Tensor` without
-    a :attr:`torch.Tensor.grad` field is sent to the other process, it
-    creates a standard process-specific ``.grad`` :class:`~torch.Tensor` that
-    is not automatically shared across all processes, unlike how the
-    :class:`~torch.Tensor`'s data has been shared.
-
-This allows to implement various training methods, like Hogwild, A3C, or any
-others that require asynchronous operation.
-
-.. _multiprocessing-cuda-note:
-
-CUDA in multiprocessing
------------------------
-
-The CUDA runtime does not support the ``fork`` start method. In Python 3, either the ``spawn`` or ``forkserver`` start method are
-required to use CUDA in subprocesses.
-
-.. note::
-  The start method can be set via either creating a context with
-  ``multiprocessing.get_context(...)`` or directly using
-  ``multiprocessing.set_start_method(...)``.
-
-Unlike CPU tensors, the sending process is required to keep the original tensor
-as long as the receiving process retains a copy of the tensor. It is implemented
-under the hood but requires users to follow the best practices for the program
-to run correctly. For example, the sending process must stay alive as long as
-the consumer process has references to the tensor, and the refcounting can not
-save you if the consumer process exits abnormally via a fatal signal. See
-:ref:`this section <multiprocessing-cuda-sharing-details>`.
-
-See also: :ref:`cuda-nn-ddp-instead`
-
-
-Best practices and tips
------------------------
-
-Avoiding and fighting deadlocks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-There are a lot of things that can go wrong when a new process is spawned, with
-the most common cause of deadlocks being background threads. If there's any
-thread that holds a lock or imports a module, and ``fork`` is called, it's very
-likely that the subprocess will be in a corrupted state and will deadlock or
-fail in a different way. Note that even if you don't, Python built in
-libraries do - no need to look further than :mod:`python:multiprocessing`.
-:class:`python:multiprocessing.Queue` is actually a very complex class, that
-spawns multiple threads used to serialize, send and receive objects, and they
-can cause aforementioned problems too. If you find yourself in such situation
-try using a :class:`~python:multiprocessing.queues.SimpleQueue`, that doesn't
-use any additional threads.
-
-We're trying our best to make it easy for you and ensure these deadlocks don't
-happen but some things are out of our control. If you have any issues you can't
-cope with for a while, try reaching out on forums, and we'll see if it's an
-issue we can fix.
-
-Reuse buffers passed through a Queue
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Remember that each time you put a :class:`~torch.Tensor` into a
-:class:`python:multiprocessing.Queue`, it has to be moved into shared memory.
-If it's already shared, it is a no-op, otherwise it will incur an additional
-memory copy that can slow down the whole process. Even if you have a pool of
-processes sending data to a single one, make it send the buffers back - this
-is nearly free and will let you avoid a copy when sending next batch.
-
-Asynchronous multiprocess training (e.g. Hogwild)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Using :mod:`torch.multiprocessing`, it is possible to train a model
-asynchronously, with parameters either shared all the time, or being
-periodically synchronized. In the first case, we recommend sending over the whole
-model object, while in the latter, we advise to only send the
-:meth:`~torch.nn.Module.state_dict`.
-
-We recommend using :class:`python:multiprocessing.Queue` for passing all kinds
-of PyTorch objects between processes. It is possible to e.g. inherit the tensors
-and storages already in shared memory, when using the ``fork`` start method,
-however it is very bug prone and should be used with care, and only by advanced
-users. Queues, even though they're sometimes a less elegant solution, will work
-properly in all cases.
+.. automodule:: torch.multiprocessing
+.. currentmodule:: torch.multiprocessing
 
 .. warning::
 
-    You should be careful about having global statements, that are not guarded
-    with an ``if __name__ == '__main__'``. If a different start method than
-    ``fork`` is used, they will be executed in all subprocesses.
+    If the main process exits abruptly (e.g. because of an incoming signal),
+    Python's ``multiprocessing`` sometimes fails to clean up its children.
+    It's a known caveat, so if you're seeing any resource leaks after
+    interrupting the interpreter, it probably means that this has just happened
+    to you.
 
-Hogwild
-~~~~~~~
+Strategy management
+-------------------
 
-A concrete Hogwild implementation can be found in the `examples repository`__,
-but to showcase the overall structure of the code, there's also a minimal
-example below as well::
+.. autofunction:: get_all_sharing_strategies
+.. autofunction:: get_sharing_strategy
+.. autofunction:: set_sharing_strategy
 
-    import torch.multiprocessing as mp
-    from model import MyModel
 
-    def train(model):
-        # Construct data_loader, optimizer, etc.
-        for data, labels in data_loader:
-            optimizer.zero_grad()
-            loss_fn(model(data), labels).backward()
-            optimizer.step()  # This will update the shared parameters
+.. _multiprocessing-cuda-sharing-details:
 
-    if __name__ == '__main__':
-        num_processes = 4
-        model = MyModel()
-        # NOTE: this is required for the ``fork`` method to work
-        model.share_memory()
-        processes = []
-        for rank in range(num_processes):
-            p = mp.Process(target=train, args=(model,))
-            p.start()
-            processes.append(p)
-        for p in processes:
-            p.join()
+Sharing CUDA tensors
+--------------------
 
-.. __: https://github.com/pytorch/examples/tree/master/mnist_hogwild
+Sharing CUDA tensors between processes is supported only in Python 3, using
+a ``spawn`` or ``forkserver`` start methods. 
+
+Unlike CPU tensors, the sending process is required to keep the original tensor
+as long as the receiving process retains a copy of the tensor. The refcounting is
+implemented under the hood but requires users to follow the next best practices.
+
+.. warning::
+    If the consumer process dies abnormally to a fatal signal, the shared tensor
+    could be forever kept in memory as long as the sending process is running.
+
+
+1. Release memory ASAP in the consumer.
+
+::
+
+    ## Good
+    x = queue.get()
+    # do somethings with x
+    del x
+
+::
+
+    ## Bad
+    x = queue.get()
+    # do somethings with x
+    # do everything else (producer have to keep x in memory)
+
+2. Keep producer process running until all consumers exits. This will prevent
+the situation when the producer process releasing memory which is still in use
+by the consumer.
+
+::
+
+    ## producer
+    # send tensors, do something
+    event.wait()
+
+
+::
+
+    ## consumer
+    # receive tensors and use them
+    event.set()
+
+3. Don't pass received tensors.
+
+::
+
+    # not going to work
+    x = queue.get()
+    queue_2.put(x)
+
+
+::
+
+    # you need to create a process-local copy
+    x = queue.get()
+    x_clone = x.clone()
+    queue_2.put(x_clone)
+
+
+::
+
+    # putting and getting from the same queue in the same process will likely end up with segfault
+    queue.put(tensor)
+    x = queue.get()
+
+
+Sharing strategies
+------------------
+
+This section provides a brief overview into how different sharing strategies
+work. Note that it applies only to CPU tensor - CUDA tensors will always use
+the CUDA API, as that's the only way they can be shared.
+
+File descriptor - ``file_descriptor``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+.. note::
+
+    This is the default strategy (except for macOS and OS X where it's not
+    supported).
+
+This strategy will use file descriptors as shared memory handles. Whenever a
+storage is moved to shared memory, a file descriptor obtained from ``shm_open``
+is cached with the object, and when it's going to be sent to other processes,
+the file descriptor will be transferred (e.g. via UNIX sockets) to it. The
+receiver will also cache the file descriptor and ``mmap`` it, to obtain a shared
+view onto the storage data.
+
+Note that if there will be a lot of tensors shared, this strategy will keep a
+large number of file descriptors open most of the time. If your system has low
+limits for the number of open file descriptors, and you can't raise them, you
+should use the ``file_system`` strategy.
+
+File system - ``file_system``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This strategy will use file names given to ``shm_open`` to identify the shared
+memory regions. This has a benefit of not requiring the implementation to cache
+the file descriptors obtained from it, but at the same time is prone to shared
+memory leaks. The file can't be deleted right after its creation, because other
+processes need to access it to open their views. If the processes fatally
+crash, or are killed, and don't call the storage destructors, the files will
+remain in the system. This is very serious, because they keep using up the
+memory until the system is restarted, or they're freed manually.
+
+To counter the problem of shared memory file leaks, :mod:`torch.multiprocessing`
+will spawn a daemon named ``torch_shm_manager`` that will isolate itself from
+the current process group, and will keep track of all shared memory allocations.
+Once all processes connected to it exit, it will wait a moment to ensure there
+will be no new connections, and will iterate over all shared memory files
+allocated by the group. If it finds that any of them still exist, they will be
+deallocated. We've tested this method and it proved to be robust to various
+failures. Still, if your system has high enough limits, and ``file_descriptor``
+is a supported strategy, we do not recommend switching to this one.
+
+Spawning subprocesses
+---------------------
+
+.. note::
+
+   Available for Python >= 3.4.
+
+   This depends on the ``spawn`` start method in Python's
+   ``multiprocessing`` package.
+
+Spawning a number of subprocesses to perform some function can be done
+by creating ``Process`` instances and calling ``join`` to wait for
+their completion. This approach works fine when dealing with a single
+subprocess but presents potential issues when dealing with multiple
+processes.
+
+Namely, joining processes sequentially implies they will terminate
+sequentially. If they don't, and the first process does not terminate,
+the process termination will go unnoticed. Also, there are no native
+facilities for error propagation.
+
+The ``spawn`` function below addresses these concerns and takes care
+of error propagation, out of order termination, and will actively
+terminate processes upon detecting an error in one of them.
+
+.. autofunction:: spawn
+
+.. class:: SpawnContext
+
+   Returned by :func:`~spawn` when called with ``join=False``.
+
+   .. automethod:: join

--- a/docs/source/multiprocessing.rst
+++ b/docs/source/multiprocessing.rst
@@ -1,183 +1,134 @@
-:orphan:
+.. _multiprocessing-best-practices:
 
-.. _multiprocessing-doc:
+Multiprocessing best practices
+==============================
 
-Multiprocessing package - torch.multiprocessing
-===============================================
+:mod:`torch.multiprocessing` is a drop in replacement for Python's
+:mod:`python:multiprocessing` module. It supports the exact same operations,
+but extends it, so that all tensors sent through a
+:class:`python:multiprocessing.Queue`, will have their data moved into shared
+memory and will only send a handle to another process.
 
-.. automodule:: torch.multiprocessing
-.. currentmodule:: torch.multiprocessing
+.. note::
 
-.. warning::
+    When a :class:`~torch.Tensor` is sent to another process, the
+    :class:`~torch.Tensor` data is shared. If :attr:`torch.Tensor.grad` is
+    not ``None``, it is also shared. After a :class:`~torch.Tensor` without
+    a :attr:`torch.Tensor.grad` field is sent to the other process, it
+    creates a standard process-specific ``.grad`` :class:`~torch.Tensor` that
+    is not automatically shared across all processes, unlike how the
+    :class:`~torch.Tensor`'s data has been shared.
 
-    If the main process exits abruptly (e.g. because of an incoming signal),
-    Python's ``multiprocessing`` sometimes fails to clean up its children.
-    It's a known caveat, so if you're seeing any resource leaks after
-    interrupting the interpreter, it probably means that this has just happened
-    to you.
+This allows to implement various training methods, like Hogwild, A3C, or any
+others that require asynchronous operation.
 
-Strategy management
--------------------
+.. _multiprocessing-cuda-note:
 
-.. autofunction:: get_all_sharing_strategies
-.. autofunction:: get_sharing_strategy
-.. autofunction:: set_sharing_strategy
+CUDA in multiprocessing
+-----------------------
 
+The CUDA runtime does not support the ``fork`` start method. In Python 3, either the ``spawn`` or ``forkserver`` start method are
+required to use CUDA in subprocesses.
 
-.. _multiprocessing-cuda-sharing-details:
-
-Sharing CUDA tensors
---------------------
-
-Sharing CUDA tensors between processes is supported only in Python 3, using
-a ``spawn`` or ``forkserver`` start methods. 
-
+.. note::
+  The start method can be set via either creating a context with
+  ``multiprocessing.get_context(...)`` or directly using
+  ``multiprocessing.set_start_method(...)``.
 
 Unlike CPU tensors, the sending process is required to keep the original tensor
-as long as the receiving process retains a copy of the tensor. The refcounting is
-implemented under the hood but requires users to follow the next best practices.
+as long as the receiving process retains a copy of the tensor. It is implemented
+under the hood but requires users to follow the best practices for the program
+to run correctly. For example, the sending process must stay alive as long as
+the consumer process has references to the tensor, and the refcounting can not
+save you if the consumer process exits abnormally via a fatal signal. See
+:ref:`this section <multiprocessing-cuda-sharing-details>`.
+
+See also: :ref:`cuda-nn-ddp-instead`
+
+
+Best practices and tips
+-----------------------
+
+Avoiding and fighting deadlocks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are a lot of things that can go wrong when a new process is spawned, with
+the most common cause of deadlocks being background threads. If there's any
+thread that holds a lock or imports a module, and ``fork`` is called, it's very
+likely that the subprocess will be in a corrupted state and will deadlock or
+fail in a different way. Note that even if you don't, Python built in
+libraries do - no need to look further than :mod:`python:multiprocessing`.
+:class:`python:multiprocessing.Queue` is actually a very complex class, that
+spawns multiple threads used to serialize, send and receive objects, and they
+can cause aforementioned problems too. If you find yourself in such situation
+try using a :class:`~python:multiprocessing.queues.SimpleQueue`, that doesn't
+use any additional threads.
+
+We're trying our best to make it easy for you and ensure these deadlocks don't
+happen but some things are out of our control. If you have any issues you can't
+cope with for a while, try reaching out on forums, and we'll see if it's an
+issue we can fix.
+
+Reuse buffers passed through a Queue
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Remember that each time you put a :class:`~torch.Tensor` into a
+:class:`python:multiprocessing.Queue`, it has to be moved into shared memory.
+If it's already shared, it is a no-op, otherwise it will incur an additional
+memory copy that can slow down the whole process. Even if you have a pool of
+processes sending data to a single one, make it send the buffers back - this
+is nearly free and will let you avoid a copy when sending next batch.
+
+Asynchronous multiprocess training (e.g. Hogwild)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Using :mod:`torch.multiprocessing`, it is possible to train a model
+asynchronously, with parameters either shared all the time, or being
+periodically synchronized. In the first case, we recommend sending over the whole
+model object, while in the latter, we advise to only send the
+:meth:`~torch.nn.Module.state_dict`.
+
+We recommend using :class:`python:multiprocessing.Queue` for passing all kinds
+of PyTorch objects between processes. It is possible to e.g. inherit the tensors
+and storages already in shared memory, when using the ``fork`` start method,
+however it is very bug prone and should be used with care, and only by advanced
+users. Queues, even though they're sometimes a less elegant solution, will work
+properly in all cases.
 
 .. warning::
-    If the consumer process dies abnormally to a fatal signal, the shared tensor
-    could be forever kept in memory as long as the sending process is running.
 
+    You should be careful about having global statements, that are not guarded
+    with an ``if __name__ == '__main__'``. If a different start method than
+    ``fork`` is used, they will be executed in all subprocesses.
 
-1. Release memory ASAP in the consumer.
+Hogwild
+~~~~~~~
 
-::
+A concrete Hogwild implementation can be found in the `examples repository`__,
+but to showcase the overall structure of the code, there's also a minimal
+example below as well::
 
-    ## Good
-    x = queue.get()
-    # do somethings with x
-    del x
+    import torch.multiprocessing as mp
+    from model import MyModel
 
-::
+    def train(model):
+        # Construct data_loader, optimizer, etc.
+        for data, labels in data_loader:
+            optimizer.zero_grad()
+            loss_fn(model(data), labels).backward()
+            optimizer.step()  # This will update the shared parameters
 
-    ## Bad
-    x = queue.get()
-    # do somethings with x
-    # do everything else (producer have to keep x in memory)
+    if __name__ == '__main__':
+        num_processes = 4
+        model = MyModel()
+        # NOTE: this is required for the ``fork`` method to work
+        model.share_memory()
+        processes = []
+        for rank in range(num_processes):
+            p = mp.Process(target=train, args=(model,))
+            p.start()
+            processes.append(p)
+        for p in processes:
+            p.join()
 
-2. Keep producer process running until all consumers exits. This will prevent
-the situation when the producer process releasing memory which is still in use
-by the consumer.
-
-::
-
-    ## producer
-    # send tensors, do something
-    event.wait()
-
-
-::
-
-    ## consumer
-    # receive tensors and use them
-    event.set()
-
-3. Don't pass received tensors.
-
-::
-
-    # not going to work
-    x = queue.get()
-    queue_2.put(x)
-
-
-::
-
-    # you need to create a process-local copy
-    x = queue.get()
-    x_clone = x.clone()
-    queue_2.put(x_clone)
-
-
-::
-
-    # putting and getting from the same queue in the same process will likely end up with segfault
-    queue.put(tensor)
-    x = queue.get()
-
-
-Sharing strategies
-------------------
-
-This section provides a brief overview into how different sharing strategies
-work. Note that it applies only to CPU tensor - CUDA tensors will always use
-the CUDA API, as that's the only way they can be shared.
-
-File descriptor - ``file_descriptor``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-.. note::
-
-    This is the default strategy (except for macOS and OS X where it's not
-    supported).
-
-This strategy will use file descriptors as shared memory handles. Whenever a
-storage is moved to shared memory, a file descriptor obtained from ``shm_open``
-is cached with the object, and when it's going to be sent to other processes,
-the file descriptor will be transferred (e.g. via UNIX sockets) to it. The
-receiver will also cache the file descriptor and ``mmap`` it, to obtain a shared
-view onto the storage data.
-
-Note that if there will be a lot of tensors shared, this strategy will keep a
-large number of file descriptors open most of the time. If your system has low
-limits for the number of open file descriptors, and you can't raise them, you
-should use the ``file_system`` strategy.
-
-File system - ``file_system``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This strategy will use file names given to ``shm_open`` to identify the shared
-memory regions. This has a benefit of not requiring the implementation to cache
-the file descriptors obtained from it, but at the same time is prone to shared
-memory leaks. The file can't be deleted right after its creation, because other
-processes need to access it to open their views. If the processes fatally
-crash, or are killed, and don't call the storage destructors, the files will
-remain in the system. This is very serious, because they keep using up the
-memory until the system is restarted, or they're freed manually.
-
-To counter the problem of shared memory file leaks, :mod:`torch.multiprocessing`
-will spawn a daemon named ``torch_shm_manager`` that will isolate itself from
-the current process group, and will keep track of all shared memory allocations.
-Once all processes connected to it exit, it will wait a moment to ensure there
-will be no new connections, and will iterate over all shared memory files
-allocated by the group. If it finds that any of them still exist, they will be
-deallocated. We've tested this method and it proved to be robust to various
-failures. Still, if your system has high enough limits, and ``file_descriptor``
-is a supported strategy, we do not recommend switching to this one.
-
-Spawning subprocesses
----------------------
-
-.. note::
-
-   Available for Python >= 3.4.
-
-   This depends on the ``spawn`` start method in Python's
-   ``multiprocessing`` package.
-
-Spawning a number of subprocesses to perform some function can be done
-by creating ``Process`` instances and calling ``join`` to wait for
-their completion. This approach works fine when dealing with a single
-subprocess but presents potential issues when dealing with multiple
-processes.
-
-Namely, joining processes sequentially implies they will terminate
-sequentially. If they don't, and the first process does not terminate,
-the process termination will go unnoticed. Also, there are no native
-facilities for error propagation.
-
-The ``spawn`` function below addresses these concerns and takes care
-of error propagation, out of order termination, and will actively
-terminate processes upon detecting an error in one of them.
-
-.. autofunction:: spawn
-
-.. class:: SpawnContext
-
-   Returned by :func:`~spawn` when called with ``join=False``.
-
-   .. automethod:: join
+.. __: https://github.com/pytorch/examples/tree/master/mnist_hogwild

--- a/docs/source/named_tensor.rst
+++ b/docs/source/named_tensor.rst
@@ -187,7 +187,7 @@ mentioning all of them as in required by :meth:`~Tensor.permute`.
     # Move the F (dim 5) and E dimension (dim 4) to the front while keeping
     # the rest in the same order
     >>> tensor.permute(5, 4, 0, 1, 2, 3)
-    >>> named_tensor.align_to('F', 'E', ...)  # Use '...' instead in Python 2
+    >>> named_tensor.align_to('F', 'E', ...)
 
 Use :meth:`~Tensor.flatten` and :meth:`~Tensor.unflatten` to flatten and unflatten
 dimensions, respectively. These methods are more verbose than :meth:`~Tensor.view`
@@ -317,4 +317,3 @@ operators, see :ref:`name_inference_reference-doc`.
 
       .. warning::
           The named tensor API is experimental and subject to change.
-

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -27,10 +27,7 @@ others that require asynchronous operation.
 CUDA in multiprocessing
 -----------------------
 
-The CUDA runtime does not support the ``fork`` start method. However,
-:mod:`python:multiprocessing` in Python 2 can only create subprocesses using
-``fork``. So Python 3 and either ``spawn`` or ``forkserver`` start method are
-required to use CUDA in subprocesses.
+The CUDA runtime does not support the ``fork`` start method. In Python 3, either the ``spawn`` or ``forkserver`` start method are
 
 .. note::
   The start method can be set via either creating a context with

--- a/docs/source/notes/windows.rst
+++ b/docs/source/notes/windows.rst
@@ -151,11 +151,6 @@ Package not found in win-32 channel.
 PyTorch doesn't work on 32-bit system. Please use Windows and
 Python 64-bit version.
 
-Why are there no Python 2 packages for Windows?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Because it's not stable enough. There're some issues that need to
-be solved before we officially release it. You can build it by yourself.
 
 Import error
 ^^^^^^^^^^^^
@@ -290,4 +285,3 @@ tensors cannot succeed, there are two alternatives for this.
 
 2. Share CPU tensors instead. Make sure your custom
 :class:`~torch.utils.data.DataSet` returns CPU tensors.
-


### PR DESCRIPTION
Fix compile error from original PR in jit_language_references.rst: https://github.com/pytorch/pytorch/pull/36116

Full details in task: https://our.internmc.facebook.com/intern/tasks/?t=64776265

With pytorch 1.5+, we remove python2 support from PyTorch. All documentation under docs/ and on the pytorch.org website needs to remove Python 2 references.