### PR TITLE
[shape inference] use max_seq_size as max_feature_len in SLS and LengthsRangeFill inference

### DIFF
--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -77,8 +77,8 @@ TEST(BoundShapeInference, SparseLengthsSum) {
   verifyShapeInfo(
       out_shape,
       "Data",
-      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-      {spec.max_seq_size},
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec.max_batch_size * spec.max_seq_size},
       TensorProto_DataType_INT64);
   verifyShapeInfo(
       out_shape,
@@ -122,8 +122,8 @@ TEST(BoundShapeInference, SparseLengthsSumFused8BitRowwise) {
   verifyShapeInfo(
       out_shape,
       "Data",
-      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-      {spec.max_seq_size},
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec.max_batch_size * spec.max_seq_size},
       TensorProto_DataType_INT64);
   verifyShapeInfo(
       out_shape,
@@ -167,8 +167,8 @@ TEST(BoundShapeInference, SparseLengthsSumFused4BitRowwise) {
   verifyShapeInfo(
       out_shape,
       "Data",
-      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-      {spec.max_seq_size},
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec.max_batch_size * spec.max_seq_size},
       TensorProto_DataType_INT64);
   verifyShapeInfo(
       out_shape,
@@ -202,14 +202,14 @@ TEST(BoundShapeInference, LengthsRangeFill) {
   verifyShapeInfo(
       out_shape,
       "Y",
-      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-      {spec.max_seq_size},
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec.max_batch_size * spec.max_seq_size},
       TensorProto_DataType_INT32);
   verifyShapeInfo(
       out_shape,
       "Z",
-      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-      {spec.max_seq_size},
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec.max_batch_size * spec.max_seq_size},
       TensorProto_DataType_INT32);
 }
 

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -317,11 +317,11 @@ void BoundShapeInferencer::InferLengthsRangeFill(const OperatorDef& op) {
       false);
   CheckAndSetTensorBoundShape(
       op.output(0),
-      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-      {spec_.max_seq_size},
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec_.max_batch_size * spec_.max_seq_size},
       TensorProto_DataType_INT32,
       false);
-  current_dim_type_ = TensorBoundShape_DimType_FEATURE_MAX_DEFAULT;
+  current_dim_type_ = TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT;
 }
 
 void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
@@ -354,8 +354,8 @@ void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
         op.input_size(), 4, "SparseLengthsWeightedSum must have 4 inputs");
     SetTensorBoundShapeIfNotExist(
         op.input(weight),
-        {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-        {spec_.max_seq_size},
+        {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+        {spec_.max_batch_size * spec_.max_seq_size},
         TensorProto_DataType_FLOAT,
         false);
   }
@@ -363,8 +363,8 @@ void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
   // Bound inputs
   SetTensorBoundShapeIfNotExist(
       op.input(1 + weight),
-      {TensorBoundShape_DimType_FEATURE_MAX_DEFAULT},
-      {spec_.max_seq_size},
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec_.max_batch_size * spec_.max_seq_size},
       TensorProto_DataType_INT64,
       false);
   CheckAndSetTensorBoundShape(

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -10,9 +10,11 @@
 #include <unordered_set>
 
 namespace caffe2 {
-// This struct stores the max bound size for batch in the general sense. We have
-// the conventioal batch size and the look-up sequence, which is also batch in a
-// sense.
+// This struct stores the max bound size for batch in the general sense.
+// max_batch_size is the upper bound of batch_size.
+// max_seq_size is the upper bound of length of every item in a batch.
+// Upper bound of length of a batch of items should be max_batch_size *
+// max_seq_size.
 struct CAFFE2_API BoundShapeSpec {
   explicit BoundShapeSpec(int64_t b, int64_t q)
       : max_batch_size(b), max_seq_size(q) {}


### PR DESCRIPTION
Summary: ATT

Differential Revision: D20952490

