### PR TITLE
[TensorExpr] Add simplification of length 0 and 1 For loops to IR Simplifier

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -139,6 +139,10 @@ namespace jit {
   _(SimplifyDivisionScalarFactorization)  \
   _(SimplifyConstantBranches)             \
   _(SimplifyConstantCond)                 \
+  _(SimplifyEliminateZeroLengthFor)       \
+  _(SimplifyOneLoopFor)                   \
+  _(SimplifyForWontLoseLoopOptions)       \
+  _(SimplifyMultilevelFor)                \
   _(StmtClone)                            \
   _(BoundsInference_1)                    \
   _(BoundsInference_2)                    \

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1042,6 +1042,41 @@ Stmt* PolynomialTransformer::mutate(const Cond* v) {
   return new Cond(cond_new, true_new, false_new);
 }
 
+Stmt* PolynomialTransformer::mutate(const For* v) {
+  const Expr* var = v->var();
+  const Expr* start = v->start();
+  const Expr* stop = v->stop();
+  Stmt* body = v->body();
+  LoopOptions loop_options = v->loop_options();
+  const Expr* var_new_expr = var->accept_mutator(this);
+  const Var* var_new = dynamic_cast<const Var*>(var_new_expr);
+  const Expr* start_new = start->accept_mutator(this);
+  const Expr* stop_new = stop->accept_mutator(this);
+  Stmt* body_new = body->accept_mutator(this);
+  if (!body_new) {
+    return new Block({});
+  }
+
+  const Expr* loops = new Sub(stop_new, start_new);
+  loops = loops->accept_mutator(this);
+  if (loop_options.isDefault() && loops->isConstant()) {
+    if (immediateEquals(loops, 0)) {
+      return new Block({});
+    } else if (immediateEquals(loops, 1)) {
+      return Substitute(body_new, {{var_new, start_new}});
+    }
+  }
+
+  if (var == var_new && start == start_new && stop == stop_new &&
+      body == body_new) {
+    return (Stmt*)v;
+  }
+  if (body_new == body) {
+    body_new = Stmt::clone(body);
+  }
+  return new For(var_new, start_new, stop_new, body_new, loop_options);
+}
+
 // TermExpander
 
 const Expr* TermExpander::mutate(const Term* v) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -372,6 +372,8 @@ class TORCH_API PolynomialTransformer : public IRMutator {
 
   Stmt* mutate(const Cond* v) override;
 
+  Stmt* mutate(const For* v) override;
+
   template <typename Op>
   static const Expr* mutateBinaryOp(
       const BinaryOpNode<Op>* v,

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -412,6 +412,10 @@ class LoopOptions {
     return oss.str();
   }
 
+  bool isDefault() const {
+    return gpu_block_index_ == -1 && gpu_thread_index_ == -1;
+  }
+
  private:
   int gpu_block_index_ = -1;
   int gpu_thread_index_ = -1;


### PR DESCRIPTION
Simplifies loops which can be collapsed down into a single block or removed entirely. E.g.

```
For 0..1 {
  Statements...
}
```

Is now just `Block({Statements...})`