### PR TITLE
Adding Conv1d to quantization default_mappings

### DIFF
--- a/torch/quantization/default_mappings.py
+++ b/torch/quantization/default_mappings.py
@@ -15,6 +15,7 @@ DEFAULT_MODULE_MAPPING = {
     nn.Linear: nnq.Linear,
     nn.ReLU: nnq.ReLU,
     nn.ReLU6: nnq.ReLU6,
+    nn.Conv1d: nnq.Conv1d,
     nn.Conv2d: nnq.Conv2d,
     nn.Conv3d: nnq.Conv3d,
     nn.BatchNorm2d: nnq.BatchNorm2d,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36352 Adding Conv1d to quantization default_mappings**

Differential Revision: [D20955781](https://our.internmc.facebook.com/intern/diff/D20955781)