### PR TITLE
PR for double backwards of nn.Fold and nn.Unfold  (issue #33452)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10899,7 +10899,7 @@ class TestNNDeviceType(NNTestCase):
         seeds = (13, 256, 811, 43, 7)
         for sd in seeds:
             torch.manual_seed(sd)
-            x = torch.randn(2, 3, 5, 5, device=device, requires_grad=True)
+            x = torch.randn(1, 1, 5, 5, device=device, requires_grad=True)
             gradcheck(func, [x])
             gradgradcheck(func, [x])
 
@@ -10909,7 +10909,7 @@ class TestNNDeviceType(NNTestCase):
         seeds = (44, 83, 71, 25, 999)
         for sd in seeds:
             torch.manual_seed(sd)
-            x = torch.randn(3, 12, 12, device=device, requires_grad=True)
+            x = torch.randn(1, 12, 12, device=device, requires_grad=True)
             gradcheck(func, [x])
             gradgradcheck(func, [x])
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10893,6 +10893,26 @@ class TestNNDeviceType(NNTestCase):
                                     r'lambda must be greater or equal to 0, but found to be -1\.'):
             m(input)
 
+    def test_unfold(self, device):
+        def func(x):
+            return F.unfold(x, kernel_size=(3, 3))
+        seeds = (13, 256, 811, 43, 7)
+        for sd in seeds:
+            torch.manual_seed(sd)
+            x = torch.randn(2, 3, 5, 5, device=device, requires_grad=True)
+            gradcheck(func, [x])
+            gradgradcheck(func, [x])
+
+    def test_fold(self, device):
+        def func(x):
+            return F.fold(x, output_size=(4, 5), kernel_size=(2, 2))
+        seeds = (44, 83, 71, 25, 999)
+        for sd in seeds:
+            torch.manual_seed(sd)
+            x = torch.randn(3, 12, 12, device=device, requires_grad=True)
+            gradcheck(func, [x])
+            gradgradcheck(func, [x])
+
 instantiate_device_type_tests(TestNNDeviceType, globals())
 
 if __name__ == '__main__':

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1272,6 +1272,11 @@
   self: im2col_backward(grad, {self.size(2), self.size(3)}, kernel_size, dilation, padding, stride)
 
 # NN double backwards support
+- name: im2col_backward(Tensor grad_output, int[2] input_size, int[2] kernel_size, int[2] dilation, int[2] padding, int[2] stride) -> Tensor
+  grad_output: im2col(grad, kernel_size, dilation, padding, stride)
+
+- name: col2im_backward(Tensor grad_output, int[2] kernel_size, int[2] dilation, int[2] padding, int[2] stride) -> Tensor
+  grad_output: col2im(grad, {grad_output.size(2), grad_output.size(3)}, kernel_size, dilation, padding, stride)
 
 - name: _adaptive_avg_pool2d_backward(Tensor grad_output, Tensor self) -> Tensor
   grad_output: _adaptive_avg_pool2d(grad, { grad_output.size(-2), grad_output.size(-1) })


### PR DESCRIPTION
@soumith @ezyang @albanD  After lots of experiments, I didn't manage to directly print the gradients of Fold/Unfold_backward (let me know if I am wrong).
Thus, in my testing codes, I compare the gradients of Fold/Unfold_backward implicitly by comparing the gradients of its following operation.