### PR TITLE
Fixing SyncBN dgrad

### DIFF
--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -1856,7 +1856,7 @@ class _DistTestBase(object):
     def _test_DDP_helper(self, model, input_var, target, loss, scale_factor=1.0):
         model.train()
         output = model(input_var)
-        l = loss(output, target)*scale_factor
+        l = loss(output, target) * scale_factor
         l.backward()
 
     def _assert_equal_param(self, param_gpu, param_DDP):
@@ -2174,7 +2174,7 @@ class _DistTestBase(object):
                 input[bs_offset : bs_offset + rank + 2],
                 target[bs_offset : bs_offset + rank + 2],
                 loss,
-                num_processes * (rank+2) / global_bs,
+                num_processes * (rank + 2) / global_bs,
             )
 
             # Update weights and run a second iteration to shake out errors

--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -1865,18 +1865,22 @@ class _DistTestBase(object):
             self.assertEqual(p_gpu, p_DDP)
 
     def _test_DDP_5iter(
-        self, model_base, model_DDP, input, target, loss, local_bs, rank, batch_size, test_save
+        self, model_base, model_DDP, input, target, loss, local_bs, rank, batch_size, test_save, offset=None, world_size=0
     ):
         for idx in range(5):
             # single cpu/gpu training
             self._test_DDP_helper(model_base, input, target, loss)
 
+            if offset is None:
+                offset = rank * local_bs
+
             # DDP training, DDP scatters subsets of input_cpu to nodes/GPUs
             self._test_DDP_helper(
                 model_DDP,
-                input[rank * local_bs: (rank + 1) * local_bs],
-                target[rank * local_bs: (rank + 1) * local_bs],
+                input[offset: offset + local_bs],
+                target[offset: offset + local_bs],
                 loss,
+                world_size * local_bs / batch_size if world_size != 0 else 1,
             )
 
             # Update weights and run a second iteration to shake out errors
@@ -1993,7 +1997,7 @@ class _DistTestBase(object):
         gpus = list(map(lambda i: torch.device('cuda:' + str(i)), gpus))
         self._test_DistributedDataParallel(gpu_subset=gpus, rank=rank, output_device=torch.device('cuda'))
 
-    def _test_DistributedDataParallel_SyncBatchNorm(self, gpu_subset, rank, output_device=None):
+    def _test_DistributedDataParallel_SyncBatchNorm(self, gpu_subset, rank, local_bs, global_bs, offset, output_device=None):
         # Run a simple end to end DDP model, use result of single node model
         # as baseline
 
@@ -2016,9 +2020,10 @@ class _DistTestBase(object):
             torch.save(model_DDP, tmp.name)
             model_DDP = torch.load(tmp.name)
 
-        # dummy data initialization
-        local_bs = len(gpu_subset)
-        global_bs, input_cpu, target, loss = self._prepare_dummy_data(local_bs)
+        # data initialization
+        input_cpu = torch.randn(global_bs, 2)
+        target = torch.randn(global_bs, 4)
+        loss = nn.MSELoss()
 
         # check two model parameters over 5 iterations
         self._test_DDP_5iter(
@@ -2030,7 +2035,9 @@ class _DistTestBase(object):
             local_bs,
             rank,
             global_bs,
-            True
+            True,
+            offset,
+            int(WORLD_SIZE)
         )
         self._barrier()
 
@@ -2044,14 +2051,20 @@ class _DistTestBase(object):
         # DDP does not support replicating BN layers within a process, hence
         # testing with one module replica per process
         gpus = [rank]
-        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank)
+
+        num_processes = int(WORLD_SIZE)
+        local_bs = 2
+        bs_offset = int(rank * 2)
+        global_bs = int(num_processes * 2)
+
+        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset)
 
         # test output_device
-        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, output_device=torch.device('cuda'))
+        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset, output_device=torch.device('cuda'))
 
         # test device_ids
         gpus = list(map(lambda i: torch.device('cuda:' + str(i)), gpus))
-        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, output_device=torch.device('cuda'))
+        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset, output_device=torch.device('cuda'))
 
     @unittest.skipIf(BACKEND != 'nccl' and BACKEND != 'gloo',
                      "Only Nccl & Gloo backend support DistributedDataParallel")
@@ -2139,55 +2152,18 @@ class _DistTestBase(object):
     def test_DistributedDataParallel_SyncBatchNorm_Diff_Input_Sizes_gradient(self):
         group, group_id, rank = self._init_global_test()
         # only do single GPU per process
-        gpu = rank
+        gpus = [rank]
 
         # cpu training setup
         model = BN_NET
 
-        # single gpu training setup
-        model_gpu = copy.deepcopy(model)
-        model_gpu.cuda(gpu)
-
-        # DDP training setup
-        model_DDP = nn.SyncBatchNorm.convert_sync_batchnorm(copy.deepcopy(model))
-        model_DDP.cuda(gpu)
-        model_DDP = nn.parallel.DistributedDataParallel(
-            model_DDP, device_ids=[gpu]
-        )
-
-        # dummy data initialization
-        # varying input batch size -> rank i with batch_size i+2
         num_processes = int(WORLD_SIZE)
-        global_bs = int((num_processes + 3) * num_processes / 2)
-        input = torch.randn(global_bs, 2).cuda(gpu)
-        target = torch.randn(global_bs, 4).cuda(gpu)
-        loss = nn.MSELoss()
+        local_bs = rank + 2
         bs_offset = int((rank + 3) * rank / 2)
+        global_bs = int((num_processes + 3) * num_processes / 2)
 
-        # check two model parameters over 5 iterations
-        for idx in range(5):
-            # single cpu/gpu training
-            self._test_DDP_helper(model_gpu, input, target, loss)
-            # DDP training, DDP scatters subsets of input_cpu to nodes/GPUs
-            self._test_DDP_helper(
-                model_DDP,
-                input[bs_offset : bs_offset + rank + 2],
-                target[bs_offset : bs_offset + rank + 2],
-                loss,
-                num_processes * (rank + 2) / global_bs,
-            )
-
-            # Update weights and run a second iteration to shake out errors
-            self._model_step(model_gpu)
-            self._model_step(model_DDP)
-            self._assert_equal_param(
-                list(model_gpu.parameters()), list(model_DDP.module.parameters())
-            )
-
-            # Shuffle the input so that DDP input is different
-            input = input[torch.randperm(global_bs)]
-
-        self._barrier()
+        self._test_DistributedDataParallel_SyncBatchNorm(
+            gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset)
 
     @skipIfNoTorchVision
     def test_SyncBatchNorm_process_group(self):

--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -2057,14 +2057,31 @@ class _DistTestBase(object):
         bs_offset = int(rank * 2)
         global_bs = int(num_processes * 2)
 
-        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset)
+        self._test_DistributedDataParallel_SyncBatchNorm(
+            gpu_subset=gpus,
+            rank=rank,
+            local_bs=local_bs,
+            global_bs=global_bs,
+            offset=bs_offset)
 
         # test output_device
-        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset, output_device=torch.device('cuda'))
+        self._test_DistributedDataParallel_SyncBatchNorm(
+            gpu_subset=gpus,
+            rank=rank,
+            local_bs=local_bs,
+            global_bs=global_bs,
+            offset=bs_offset,
+            output_device=torch.device('cuda'))
 
         # test device_ids
         gpus = list(map(lambda i: torch.device('cuda:' + str(i)), gpus))
-        self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset, output_device=torch.device('cuda'))
+        self._test_DistributedDataParallel_SyncBatchNorm(
+            gpu_subset=gpus,
+            rank=rank,
+            local_bs=local_bs,
+            global_bs=global_bs,
+            offset=bs_offset,
+            output_device=torch.device('cuda'))
 
     @unittest.skipIf(BACKEND != 'nccl' and BACKEND != 'gloo',
                      "Only Nccl & Gloo backend support DistributedDataParallel")
@@ -2163,7 +2180,11 @@ class _DistTestBase(object):
         global_bs = int((num_processes + 3) * num_processes / 2)
 
         self._test_DistributedDataParallel_SyncBatchNorm(
-            gpu_subset=gpus, rank=rank, local_bs=local_bs, global_bs=global_bs, offset=bs_offset)
+            gpu_subset=gpus,
+            rank=rank,
+            local_bs=local_bs,
+            global_bs=global_bs,
+            offset=bs_offset)
 
     @skipIfNoTorchVision
     def test_SyncBatchNorm_process_group(self):

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -46,9 +46,8 @@ class SyncBatchNorm(Function):
             count_all.view(-1).long().tolist()
         )
 
-        self.save_for_backward(input, weight, mean, invstd)
+        self.save_for_backward(input, weight, mean, invstd, count_all)
         self.process_group = process_group
-        self.world_size = world_size
 
         # apply element-wise normalization
         out = torch.batch_norm_elemt(input, weight, bias, mean, invstd, eps)
@@ -57,13 +56,12 @@ class SyncBatchNorm(Function):
     @staticmethod
     def backward(self, grad_output):
         grad_output = grad_output.contiguous()
-        saved_input, weight, mean, invstd = self.saved_tensors
+        saved_input, weight, mean, invstd, count_tensor = self.saved_tensors
         grad_input = grad_weight = grad_bias = None
         process_group = self.process_group
-        world_size = self.world_size
 
         # calculate local stats as well as grad_weight / grad_bias
-        mean_dy, mean_dy_xmu, grad_weight, grad_bias = torch.batch_norm_backward_reduce(
+        sum_dy, sum_dy_xmu, grad_weight, grad_bias = torch.batch_norm_backward_reduce(
             grad_output,
             saved_input,
             mean,
@@ -77,17 +75,18 @@ class SyncBatchNorm(Function):
         if self.needs_input_grad[0]:
             # synchronizing stats used to calculate input gradient.
             # TODO: move div_ into batch_norm_backward_elemt kernel
-            mean_dy_all_reduce = torch.distributed.all_reduce(
-                mean_dy, torch.distributed.ReduceOp.SUM, process_group, async_op=True)
-            mean_dy_xmu_all_reduce = torch.distributed.all_reduce(
-                mean_dy_xmu, torch.distributed.ReduceOp.SUM, process_group, async_op=True)
+            sum_dy_all_reduce = torch.distributed.all_reduce(
+                sum_dy, torch.distributed.ReduceOp.SUM, process_group, async_op=True)
+            sum_dy_xmu_all_reduce = torch.distributed.all_reduce(
+                sum_dy_xmu, torch.distributed.ReduceOp.SUM, process_group, async_op=True)
 
             # wait on the async communication to finish
-            mean_dy_all_reduce.wait()
-            mean_dy_xmu_all_reduce.wait()
+            sum_dy_all_reduce.wait()
+            sum_dy_xmu_all_reduce.wait()
 
-            mean_dy.div_(world_size)
-            mean_dy_xmu.div_(world_size)
+            dividor = count_tensor.sum() 
+            mean_dy = sum_dy / dividor
+            mean_dy_xmu = sum_dy_xmu / dividor
             # backward pass for gradient calculation
             grad_input = torch.batch_norm_backward_elemt(
                 grad_output,

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -84,9 +84,9 @@ class SyncBatchNorm(Function):
             sum_dy_all_reduce.wait()
             sum_dy_xmu_all_reduce.wait()
 
-            dividor = count_tensor.sum() 
-            mean_dy = sum_dy / dividor
-            mean_dy_xmu = sum_dy_xmu / dividor
+            divisor = count_tensor.sum()
+            mean_dy = sum_dy / divisor
+            mean_dy_xmu = sum_dy_xmu / divisor
             # backward pass for gradient calculation
             grad_input = torch.batch_norm_backward_elemt(
                 grad_output,


### PR DESCRIPTION
Previous PR #22248 which provides support for variadic batch size across processes doesn't account the mean_dy/mean_dy_xmu on backward path, which produces wrong dgrad.