### PR TITLE
Add missing TORCH_API annotation

### DIFF
--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -85,7 +85,7 @@ static int64_t floordiv(int64_t a, int64_t b) {
     return (r.rem) ? r.quot - 1 : r.quot;
   }
 }
-void checkDoubleInRange(double a);
+TORCH_API void checkDoubleInRange(double a);
 static int64_t floor(double a) {
   checkDoubleInRange(a);
   return std::floor(a);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36391 Add missing TORCH_API annotation**

Without it I get

```
ImportError: /data/users/ezyang/pytorch-tmp/torch/lib/libtorch_python.so: undefined symbol: _ZN5torch3jit18checkDoubleInRangeEd
```

when I build with DEBUG=1

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D20964292](https://our.internmc.facebook.com/intern/diff/D20964292)