### PR TITLE
[DistAutograd x JIT] Capture global state, dist autograd current context id, before thread switching triggered by JIT future.wait()

### DIFF
--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -1177,15 +1177,18 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
                 Callback(
                     c10::intrusive_ptr<InterpreterStateImpl> state,
                     Stack stack)
-                    : state_(std::move(state)), stack_(std::move(stack)) {}
+                    : state_(std::move(state)), stack_(std::move(stack)) {
+                  dist_autograd_context_id_ = getDistAutogradContextId();
+                }
                 void operator()() {
                   at::launch(InterpreterContinuation(
-                      state_, std::move(stack_), getDistAutogradContextId()));
+                      state_, std::move(stack_), dist_autograd_context_id_));
                 }
 
                private:
                 InterpreterState state_;
                 Stack stack_;
+                int64_t dist_autograd_context_id_;
               };
 
               // we are suspending, so we need to reset the stack to where we

--- a/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
@@ -1,32 +1,38 @@
 import unittest
+from typing import Tuple
 
 import torch
 import torch.distributed.autograd as dist_autograd
+import torch.distributed.rpc as rpc
+from torch import Tensor
+from torch.distributed.rpc import rpc_async
 from torch.testing import FileCheck
 from torch.testing._internal.dist_utils import dist_init, worker_name
 from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
     RpcAgentTestFixture,
 )
-from torch.distributed.rpc import rpc_async
+
 
 @torch.jit.script
 def local_add(t1, t2):
     return torch.add(t1, t2)
 
+
 @torch.jit.script
 def remote_add(t1, t2, dst: str):  # noqa: E999
     return rpc_async(dst, local_add, (t1, t2)).wait()
+
 
 @torch.jit.script
 def fork_add(t1, t2, dst: str):
     fut = torch.jit._fork(remote_add, t1, t2, dst)
     return torch.jit._wait(fut)
 
+
 @unittest.skipIf(
     not torch._six.PY3, "Pytorch distributed autograd package does not support python2"
 )
 class JitDistAutogradTest(RpcAgentTestFixture):
-
     @dist_init
     def test_get_gradients(self):
         dst_rank = self.rank
@@ -65,3 +71,32 @@ class JitDistAutogradTest(RpcAgentTestFixture):
             self.assertEqual(2, len(grads))
             self.assertIn(t1, grads)
             self.assertIn(t2, grads)
+
+    @dist_init
+    def test_restore_context_after_swtich_to_jit_thread(self):
+        if self.rank != 0:
+            return
+
+        @torch.jit.script
+        def forward_script(
+            context_id: int, dst_worker_name: str, t1: Tensor, t2: Tensor
+        ) -> Tuple[Tensor, Tensor]:
+            res1_fut = rpc.rpc_async(dst_worker_name, local_add, (t1, t1))
+            res1 = res1_fut.wait()  # After this, the script runs in a new JIT thread.
+            loss1 = res1.sum()
+
+            # SendRpcBackward is not attched, since DistAutogradContext is lost here.
+            res2_fut = rpc.rpc_async(dst_worker_name, local_add, (t2, t2))
+            res2 = res2_fut.wait()
+            loss2 = res2.sum()
+
+            return loss1, loss2
+
+        with dist_autograd.context() as context_id:
+            t1 = torch.ones((2, 3), requires_grad=True)
+            t2 = torch.ones((2, 3), requires_grad=True)
+            dst_worker_name = worker_name((self.rank + 1) % self.world_size)
+            loss0, loss1 = forward_script(context_id, dst_worker_name, t1, t2)
+            dist_autograd.backward(context_id, [loss0, loss1])
+            grad0, grad1 = dist_autograd.get_gradients(context_id)
+            self.assertEqual(grad0, grad1)


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#36395 [DistAutograd x JIT] Capture global state, dist autograd current context id, before thread switching triggered by JIT future.wait()**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D7857991/)

titled

Differential Revision: [D7857991](https://our.internmc.facebook.com/intern/diff/D7857991/)