### PR TITLE
[JIT] Dont optimize shape peepholes on inline

### DIFF
--- a/test/cpp/jit/test_peephole_optimize.cpp
+++ b/test/cpp/jit/test_peephole_optimize.cpp
@@ -94,7 +94,6 @@ graph(%1 : Float(*, *, *)?):
   }
 
   // tests addmm fusion
-  // Note: addmm fusion is disabled by default
   {
     auto graph = std::make_shared<Graph>();
     parseIR(
@@ -110,7 +109,7 @@ graph(%1 : Float(*, *, *)?):
         return (%6)
         )IR",
         graph.get());
-    PeepholeOptimize(graph, true);
+    FuseAddMM(graph);
     testing::FileCheck().check("addmm")->run(*graph);
   }
 }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2900,6 +2900,26 @@ graph(%Ra, %Rb):
         x = torch.rand(3, 4)
         self.assertEqual(random_bar(x), (x + 1)[0:1])
 
+    def test_trace_inline_shape(self):
+        # testing peephole optimization of size is turned into a constant
+        # in script fn
+
+        @torch.jit.script
+        def tensor_size(x: torch.Tensor) -> torch.Tensor:
+            return torch.tensor([x.size()[0]])
+
+        self.assertEqual(
+            tensor_size(torch.rand(15,)),
+            torch.tensor([15])
+        )
+
+        traced_tensor_size = torch.jit.trace(tensor_size, torch.rand(7,))
+
+        self.assertEqual(
+            traced_tensor_size(torch.rand(15,)),
+            torch.tensor([15])
+        )
+
     def test_export_tensoroption_to(self):
         def foo(x):
             return x[0].clone().detach().cpu() + x

--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -72,7 +72,7 @@ void preoptimizeGraph(std::shared_ptr<Graph>& graph) {
   Inline(*graph);
   // Peephole Optimize cleans up many "is None" checks and creates constant prop
   // opportunities
-  PeepholeOptimize(graph);
+  PeepholeOptimize(graph, true);
   // // AliasDb construction can be slow, so run it just on immutable types
   // // to clean up constant Ifs & other easy wins
   ConstantPropagationImmutableTypes(graph);

--- a/torch/csrc/jit/passes/peephole.h
+++ b/torch/csrc/jit/passes/peephole.h
@@ -7,10 +7,12 @@ namespace jit {
 
 TORCH_API void PeepholeOptimize(
     const std::shared_ptr<Graph>& graph,
-    bool addmm_fusion_enabled = false);
+    bool disable_shape_peepholes = false);
 TORCH_API void PeepholeOptimize(
     Block* block,
-    bool addmm_fusion_enabled = false);
+    bool disable_shape_peepholes = false);
+
+TORCH_API void FuseAddMM(const std::shared_ptr<Graph>& graph);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -283,6 +283,9 @@ void initJITBindings(PyObject* module) {
           py::arg("graph"),
           py::arg("addmm_fusion_enabled") = false)
       .def(
+          "_jit_pass_fuse_addmm",
+          [](std::shared_ptr<Graph>& g) { return FuseAddMM(g); })
+      .def(
           "_jit_pass_canonicalize",
           [](const std::shared_ptr<Graph>& g) { return Canonicalize(g); })
       .def("_jit_pass_lint", LintGraph)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -136,6 +136,7 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
     torch._C._jit_pass_lint(graph)
 
     torch._C._jit_pass_peephole(graph, True)
+    torch._C._jit_pass_fuse_addmm(graph)
     torch._C._jit_pass_lint(graph)
 
     if operator_export_type != OperatorExportTypes.RAW:


### PR DESCRIPTION
With https://github.com/pytorch/pytorch/pull/35562, we are running peephole optimization on inlining to reduce the number of nodes that are copied. 

The tracer encodes the sizes in the graph like:
```
graph(%0 : Double(7)):
  %1 : Function = prim::Constant[name="tensor_size"]()
  %2 : Tensor = prim::CallFunction(%1, %0)
  return (%2)
```

however people would like to reuse the graph with different shapes so running size invalidations would invalidate that. long term it might be better for the tracer to not include shape information but there are downstream users of that. 

Separates out FuseAddMM from peephole so that now there is a single `disable_size_optimizations` parameter, and onnx explicitly invokes fuseaddmm.