### PR TITLE
Fix a segfault in DeviceThreadHandlePool and PoolWindow

### DIFF
--- a/aten/src/ATen/cuda/CuSparseHandlePool.cpp
+++ b/aten/src/ATen/cuda/CuSparseHandlePool.cpp
@@ -21,14 +21,14 @@ void destroyCusparseHandle(cusparseHandle_t handle) {
 #endif
 }
 
-DeviceThreadHandlePool<cusparseHandle_t, createCusparseHandle, destroyCusparseHandle> pool;
+auto pool = std::make_shared<DeviceThreadHandlePool<cusparseHandle_t, createCusparseHandle, destroyCusparseHandle>>();
 
 // Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
 // to avoid initialization issues that caused hangs on Windows.
 // See: https://github.com/pytorch/pytorch/pull/22405
 // This thread local unique_ptrs will be destroyed when the thread terminates,
 // releasing its reserved handles back to the pool.
-thread_local std::unique_ptr<decltype(pool)::PoolWindow> myPoolWindow;
+thread_local std::unique_ptr<decltype(pool)::element_type::PoolWindow> myPoolWindow;
 
 } // namespace
 
@@ -37,7 +37,7 @@ cusparseHandle_t getCurrentCUDASparseHandle() {
   AT_CUDA_CHECK(cudaGetDevice(&device));
 
   if (!myPoolWindow)
-    myPoolWindow.reset(pool.newPoolWindow());
+    myPoolWindow.reset(pool->newPoolWindow());
 
   auto handle = myPoolWindow->reserve(device);
   cusparseSetStream(handle, c10::cuda::getCurrentCUDAStream());

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -21,14 +21,14 @@ void destroyCublasHandle(cublasHandle_t handle) {
 #endif
 }
 
-DeviceThreadHandlePool<cublasHandle_t, createCublasHandle, destroyCublasHandle> pool;
+auto pool = std::make_shared<DeviceThreadHandlePool<cublasHandle_t, createCublasHandle, destroyCublasHandle>>();
 
 // Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
 // to avoid initialization issues that caused hangs on Windows.
 // See: https://github.com/pytorch/pytorch/pull/22405
 // This thread local unique_ptrs will be destroyed when the thread terminates,
 // releasing its reserved handles back to the pool.
-thread_local std::unique_ptr<decltype(pool)::PoolWindow> myPoolWindow;
+thread_local std::unique_ptr<decltype(pool)::element_type::PoolWindow> myPoolWindow;
 
 } // namespace
 
@@ -37,7 +37,7 @@ cublasHandle_t getCurrentCUDABlasHandle() {
   AT_CUDA_CHECK(cudaGetDevice(&device));
 
   if (!myPoolWindow)
-    myPoolWindow.reset(pool.newPoolWindow());
+    myPoolWindow.reset(pool->newPoolWindow());
   auto handle = myPoolWindow->reserve(device);
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));

--- a/aten/src/ATen/cuda/detail/DeviceThreadHandles.h
+++ b/aten/src/ATen/cuda/detail/DeviceThreadHandles.h
@@ -26,7 +26,7 @@
 namespace at { namespace cuda { namespace {
 
 template <typename Handle_t, void Create(Handle_t *), void Destroy(Handle_t)>
-struct DeviceThreadHandlePool {
+struct DeviceThreadHandlePool : public std::enable_shared_from_this<DeviceThreadHandlePool<Handle_t, Create, Destroy>> {
 
     struct Handle {
     Handle_t handle;
@@ -82,9 +82,9 @@ struct DeviceThreadHandlePool {
     // so in the common case handle access doesn't incur either handle creation or a mutex lock.
     class PoolWindow
     {
-    DeviceThreadHandlePool &parent;
+    std::shared_ptr<DeviceThreadHandlePool> parent;
     public:
-    PoolWindow(DeviceThreadHandlePool &parent): parent(parent) {}
+    PoolWindow(std::shared_ptr<DeviceThreadHandlePool> parent): parent(std::move(parent)) {}
     ~PoolWindow(){ release(); }
 
     Handle_t reserve(int device)
@@ -95,19 +95,19 @@ struct DeviceThreadHandlePool {
 
         // otherwise, either grab a handle from the pool if one is available,
         // or if not, create a new one.
-        std::lock_guard<std::mutex> guard(parent.mutex);
+        std::lock_guard<std::mutex> guard(parent->mutex);
 
-        if(parent.available_handles[device].size() > 0)
+        if(parent->available_handles[device].size() > 0)
         {
-        my_handles[device] = parent.available_handles[device].back();
-        parent.available_handles[device].pop_back();
+        my_handles[device] = parent->available_handles[device].back();
+        parent->available_handles[device].pop_back();
         }
         else
         {
         // In local testing, I do observe that emplace_back sometimes routes through temporaries
         // that incur move-constructor and destructor calls.  See comments in Handle above.
-        parent.created_handles[device].emplace_back(true /*create*/);
-        my_handles[device] = parent.created_handles[device].back().handle;
+        parent->created_handles[device].emplace_back(true /*create*/);
+        my_handles[device] = parent->created_handles[device].back().handle;
         }
 
         return my_handles[device];
@@ -120,9 +120,9 @@ struct DeviceThreadHandlePool {
     // Called by the destructor.  Releases this thread's handles back into the pool.
     void release() {
         if(my_handles.size() > 0) {
-            std::lock_guard<std::mutex> guard(parent.mutex);
+            std::lock_guard<std::mutex> guard(parent->mutex);
             for(auto d_h : my_handles)
-                parent.available_handles[d_h.first].push_back(d_h.second);
+                parent->available_handles[d_h.first].push_back(d_h.second);
         }
     }
     };
@@ -134,7 +134,7 @@ struct DeviceThreadHandlePool {
     PoolWindow *newPoolWindow() {
         // The returned pointer will be owned by a thread local variable
         // so that different threads does not share the same PoolWindow.
-        return new PoolWindow(*this);
+        return new PoolWindow(this->shared_from_this());
     }
 };
 


### PR DESCRIPTION
This PR fixes a bug related to object destruction order across threads. The bug can cause segfaults during shutdown of processes that use libtorch.

See https://github.com/pytorch/pytorch/issues/36408 for more detail