### PR TITLE
Do not double compile generated files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2004,7 +2004,6 @@ cc_library(
             "torch/csrc/api/src/serialize/*.cpp",
             "torch/csrc/autograd/*.cpp",
             "torch/csrc/autograd/functions/*.cpp",
-            "torch/csrc/autograd/generated/*.cpp",
             "torch/csrc/distributed/autograd/*.cpp",
             "torch/csrc/distributed/autograd/context/*.cpp",
             "torch/csrc/distributed/autograd/functions/*.cpp",
@@ -2018,7 +2017,6 @@ cc_library(
             "torch/csrc/jit/fuser/*.cpp",
             "torch/csrc/jit/fuser/cpu/*.cpp",
             "torch/csrc/jit/ir/*.cpp",
-            "torch/csrc/jit/generated/*.cpp",
             "torch/csrc/jit/passes/*.cpp",
             "torch/csrc/jit/passes/onnx/*.cpp",
             "torch/csrc/jit/passes/utils/*.cpp",
@@ -2038,7 +2036,6 @@ cc_library(
             "torch/csrc/autograd/*_cuda.cpp",
         ]) + [
             "torch/csrc/autograd/functions/comm.cpp",
-            "torch/csrc/autograd/generated/VariableTypeEverything.cpp",
             "torch/lib/libshm/manager.cpp",
             "torch/lib/c10d/NCCLUtils.cpp",
             "torch/lib/c10d/ProcessGroupMPI.cpp",


### PR DESCRIPTION
Bazel puts generated files in its private hermetic builds, but for some reason also searches for files in `torch/csrcs/*/generated/` folders.
Test Plan: Use the same folder to compile pytorch using cmake and bazel

