### PR TITLE
[rref] Minor tweaks in rref_context

### DIFF
--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -298,7 +298,7 @@ class TORCH_API RRefContext {
   // without confirmation is OK, because the creator would either call to_here
   // or forward the UserRRef, and both would then require confirmations from the
   // owner.
-  static thread_local bool recording;
+  static thread_local bool recording_;
 };
 
 } // namespace rpc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36419 [rref] Minor tweaks in rref_context**

Since we call waitForThreadLocalPendingRRefs per-RPC, construct it
already-satisfied in the common empty case, to avoid extra mutex/cv work.

Also, naming consistency for recording_.

Differential Revision: [D20977879](https://our.internmc.facebook.com/intern/diff/D20977879/)