### PR TITLE
torch.isclose for complex dtype

### DIFF
--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -6,7 +6,7 @@ in one of the `cpp` files in this directory.
 
 Like all ATen methods/functions, native functions are made available
 from both ATen's C++ and Python APIs.  In C++, they are made available
-either as methods on `Tensor` (`t.mymeth()`) and functions in the ATen
+either as methods on `Tensor` (`t.mymeth()`) or functions in the ATen
 namespace (`at::myfunc()`).  In PyTorch, they are made available as
 methods on `Variable` or as functions on `torch._C._FunctionBase`
 (it is the user's responsibility to re-exporting these functions in

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -44,12 +44,10 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
 
   auto close = actual_error <= max_error;
 
-  if (isFloatingType(self.scalar_type()) && isFloatingType(other.scalar_type())) {
+  if (isFloatingType(self.scalar_type()) && isFloatingType(other.scalar_type())
+  || isComplexType(self.scalar_type()) && isComplexType(other.scalar_type())) {
     // Handle +/-inf
     close.__ior__(self == other);
-    close.__iand__((self == INFINITY) == (other == INFINITY));
-    close.__iand__((self == -INFINITY) == (other == -INFINITY));
-
     if (equal_nan) {
       close.__ior__((self != self).__and__((other != other)));
     }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16066,6 +16066,8 @@ _cpu_types = []
 
 _unsigned_types = [torch.uint8]
 
+_complex_and_float_types_no_half = [torch.complex64, torch.complex128] + _float_types_no_half
+
 # Helper values and functions for producing tensors and scalars to use in tensor op tests.
 # Tensor dimension sizes (Small, Medium, Large, Giant)
 _S = 5
@@ -16615,7 +16617,13 @@ def _generate_reference_input(dtype, device):
     input.append(torch.randn(10).tolist())
     input.append((torch.randn(10) * 1e6).tolist())
     input.append([math.pi * (x / 2) for x in range(-5, 5)])
-    return torch.tensor(input, dtype=dtype, device=device)
+
+    input_tensor = torch.tensor(input, dtype=dtype, device=device)
+
+    if dtype.is_complex:
+        input_tensor = (input_tensor + 1j) * 1j
+
+    return input_tensor
 
 def _generate_gamma_input(dtype, device, test_poles=True):
     input = []
@@ -16687,7 +16695,7 @@ torch_op_tests = [_TorchMathTestMeta('sin'),
                   _TorchMathTestMeta('sqrt'),
                   _TorchMathTestMeta('erf', ref_backend='scipy'),
                   _TorchMathTestMeta('erfc', ref_backend='scipy'),
-                  _TorchMathTestMeta('exp'),
+                  _TorchMathTestMeta('exp', dtypes=_complex_and_float_types_no_half),
                   _TorchMathTestMeta('expm1'),
                   _TorchMathTestMeta('floor'),
                   _TorchMathTestMeta('ceil'),

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -27,6 +27,11 @@ def assert_allclose(actual, expected, rtol=None, atol=None, equal_nan=True):
             raise ValueError("rtol and atol must both be specified or both be unspecified")
         rtol, atol = _get_default_tolerance(actual, expected)
 
+    if actual.is_complex() and expected.is_complex():
+        close_real = torch.isclose(actual.copy_real(), expected.copy_real())
+        close_imag = torch.isclose(actual.copy_imag(), expected.copy_imag())
+        if close_real.all() and close_imag.all():
+            return
     close = torch.isclose(actual, expected, rtol, atol, equal_nan)
     if close.all():
         return


### PR DESCRIPTION
I added tests for the complex `exp` function under `test_torch.py`, made changes to `assert_allclose` to work with complex tensors, removed extraneous comparisons from `TensorCompare.cpp` (as pointed out by @ngimel), and fixed a typo in the ATen native README.

Fixes #36029

cc: @dylanbespalko @anjali411 @ngimel 