### PR TITLE
[Torch Device][c10] Fix the expected torch device error message

### DIFF
--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -34,7 +34,7 @@ DeviceType parse_type(const std::string& device_string) {
     return device->second;
   }
   AT_ERROR(
-      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, hip, msnpu device type at start of device string: ", device_string);
+      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, hip, msnpu, xla device type at start of device string: ", device_string);
 }
 } // namespace
 


### PR DESCRIPTION
This PR made the expected torch device string error message to include `xla` as the acceptable torch device prefix string.