### PR TITLE
[caffe2] Enable copying for caffe2::Tensor

### DIFF
--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -13,6 +13,7 @@
 #include "caffe2/core/qtensor.h"
 #include "caffe2/core/qtensor_serialization.h"
 #include "caffe2/core/tensor.h"
+#include "caffe2/core/test_utils.h"
 #include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
 #include "caffe2/proto/caffe2_pb.h"
@@ -588,6 +589,18 @@ TEST(TensorTest, Tensor64BitDimension) {
 TEST(TensorTest, UndefinedTensor) {
   Tensor x;
   EXPECT_FALSE(x.defined());
+}
+
+TEST(TensorTest, CopyAndAssignment) {
+  Tensor x(CPU);
+  x.Resize(16, 17);
+  testing::randomFill(x.template mutable_data<float>(), 16 * 17);
+  EXPECT_TRUE(x.defined());
+
+  Tensor y(x);
+  Tensor z = x;
+  testing::assertTensorEquals(x, y);
+  testing::assertTensorEquals(x, z);
 }
 
 TEST(TensorDeathTest, CannotCastDownLargeDims) {

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -40,18 +40,12 @@ class CAFFE2_API Tensor final {
  public:
   Tensor() : impl_() {}
 
-  // caffe2::Tensor is explicitly marked as moveable-only because before
-  // the refactoring the class used to be a value type and a lot of user code
-  // is written this way. With PyTorch unification, caffe2::Tensor actually
-  // has semantics of a shared_ptr now (via intrusive_ptr). However, to prevent
-  // accidental mistakes when changing legacy code we keep caffe2::Tensor
-  // to have movable semantics.
-  //
-  // If you need to get a pointer to the same Tensor instance (not to be
-  // confused with shared storage), `UnsafeSharedInstance` can be used. It has
-  // the same behavior as `at::Tensor a = b`.
-  Tensor(const Tensor&) = delete;
-  Tensor& operator=(const Tensor&) = delete;
+  Tensor(const Tensor& t) : impl_(t.impl_) {}
+  Tensor& operator=(const Tensor& t) {
+    impl_ = t.impl_;
+    return *this;
+  }
+
   Tensor(Tensor&&) = default;
   Tensor& operator=(Tensor&&) = default;
 


### PR DESCRIPTION
Summary: Since `caffe2::Tensor` is now refcounted, enabling copy constructor and the copy assignment operator should be fine.

Test Plan:
```
buck test mode/dev //caffe2/caffe2:caffe2_test_cpu -- TensorTest
```

Differential Revision: D20985924

