### PR TITLE
[iOS] Fix the import path for benchmarking code

### DIFF
--- a/ios/TestApp/TestApp/Benchmark.mm
+++ b/ios/TestApp/TestApp/Benchmark.mm
@@ -1,12 +1,11 @@
 #import "Benchmark.h"
 #include <string>
 #include <vector>
-#include "ATen/ATen.h"
-#include "caffe2/core/timer.h"
-#include "caffe2/utils/string_utils.h"
-#include "torch/csrc/autograd/grad_mode.h"
-#include "torch/csrc/jit/serialization/import.h"
-#include "torch/script.h"
+#include <ATen/ATen.h>
+#include <caffe2/core/timer.h>
+#include <caffe2/utils/string_utils.h>
+#include <torch/csrc/autograd/grad_mode.h>
+#include <torch/script.h>
 
 static std::string model = "model.pt";
 static std::string input_dims = "1,3,224,224";

--- a/ios/TestApp/TestApp/ViewController.mm
+++ b/ios/TestApp/TestApp/ViewController.mm
@@ -1,5 +1,4 @@
 #import "ViewController.h"
-#import <torch/script.h>
 #import "Benchmark.h"
 
 @interface ViewController ()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36475 [iOS] Fix the import path for benchmarking code**

### Summary

1. Clean up the unused header files
2. Fix the import path if using cocoapods

### Test Plan

- Watch CI 

