### PR TITLE
Fixed check for the buffer overflow in assert

### DIFF
--- a/torch/csrc/jit/ir/attributes.h
+++ b/torch/csrc/jit/ir/attributes.h
@@ -34,7 +34,7 @@ static inline const char* toString(AttributeKind kind) {
                                 "ty",
                                 "tys",
                                 "ival"};
-  AT_ASSERT(size_t(kind) < sizeof(names) / sizeof(AttributeKind));
+  AT_ASSERT(size_t(kind) < sizeof(names) / sizeof(*names));
   return names[int(kind)];
 }
 


### PR DESCRIPTION
This code looks like a mistake
```C++
AT_ASSERT(size_t(kind) < sizeof(names) / sizeof(AttributeKind));
```
It does not check if `kind` variable fits in array of pointer called `names`

Even if we write something like this: that assert won't fail
```C++
AttributeKind kind = AttributeKind::ival;
*((unsigned int*)&kind2) += 1;
```
So I fixed it

