### PR TITLE
Vectorize non-persistent Softmax kernels

### DIFF
--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -723,7 +723,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
           dispatch_softmax_forward<scalar_t, accscalar_t, accscalar_t, is_log_softmax>(
               output.data_ptr<accscalar_t>(), input.data_ptr<scalar_t>(), dim_size, dim_size, outer_size);
         } else {
-          constexpr int ILP = sizeof(float4) / std::max(sizeof(scalar_t), sizeof(accscalar_t));
+          constexpr int ILP = sizeof(float4) / sizeof(accscalar_t);
           dim3 block = SoftMax_getBlockSize(ILP, dim_size);
           cunn_SoftMaxForward<ILP, scalar_t, accscalar_t, accscalar_t, Epilogue>
             <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
@@ -813,7 +813,7 @@ Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t
         dispatch_softmax_backward<accscalar_t, scalar_t, accscalar_t, is_log_softmax>(
             gI.data_ptr<scalar_t>(), grad.data_ptr<accscalar_t>(), output.data_ptr<accscalar_t>(), dim_size, dim_size, outer_size);
       } else {
-        constexpr int ILP = sizeof(float4) / std::max(sizeof(scalar_t), sizeof(accscalar_t));
+        constexpr int ILP = sizeof(float4) / sizeof(accscalar_t);
         dim3 block = SoftMax_getBlockSize(ILP, dim_size);
         cunn_SoftMaxBackward<ILP, scalar_t, accscalar_t, accscalar_t, Epilogue>
          <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -442,7 +442,7 @@ cunn_SoftMaxForward(outscalar_t *output, scalar_t *input, int classes)
   input += blockIdx.x * classes;
   output += blockIdx.x * classes;
 
-	const int shift = ((uint64_t)input) % ALIGN_BYTES / sizeof(scalar_t);
+  const int shift = ((uint64_t)input) % ALIGN_BYTES / sizeof(scalar_t);
   // find the max
   accscalar_t threadMax = ilpReduce<MaxFloat, ILP, scalar_t, accscalar_t>(
       shift, input, classes, MaxFloat<scalar_t, accscalar_t>(), -at::numeric_limits<accscalar_t>::max());

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -711,7 +711,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
           dispatch_softmax_forward<scalar_t, scalar_t, accscalar_t, is_log_softmax>(
               output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), dim_size, dim_size, outer_size);
         } else {
-          const int ILP = sizeof(float4) / sizeof(scalar_t);
+          constexpr int ILP = sizeof(float4) / sizeof(scalar_t);
           dim3 block = SoftMax_getBlockSize(ILP, dim_size);
           cunn_SoftMaxForward<ILP, scalar_t, accscalar_t, scalar_t, Epilogue>
             <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
@@ -723,7 +723,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
           dispatch_softmax_forward<scalar_t, accscalar_t, accscalar_t, is_log_softmax>(
               output.data_ptr<accscalar_t>(), input.data_ptr<scalar_t>(), dim_size, dim_size, outer_size);
         } else {
-          const int ILP = sizeof(float4) / std::max(sizeof(scalar_t), sizeof(accscalar_t));
+          constexpr int ILP = sizeof(float4) / std::max(sizeof(scalar_t), sizeof(accscalar_t));
           dim3 block = SoftMax_getBlockSize(ILP, dim_size);
           cunn_SoftMaxForward<ILP, scalar_t, accscalar_t, accscalar_t, Epilogue>
             <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
@@ -801,7 +801,7 @@ Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t
         dispatch_softmax_backward<scalar_t, scalar_t, accscalar_t, is_log_softmax>(
             gI.data_ptr<scalar_t>(), grad.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), dim_size, dim_size, outer_size);
       } else {
-        const int ILP = sizeof(float4) / sizeof(scalar_t);
+        constexpr int ILP = sizeof(float4) / sizeof(scalar_t);
         dim3 block = SoftMax_getBlockSize(ILP, dim_size);
         cunn_SoftMaxBackward<ILP, scalar_t, accscalar_t, scalar_t, Epilogue>
          <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(
@@ -813,7 +813,7 @@ Tensor host_softmax_backward(const Tensor &grad_, const Tensor &output_, int64_t
         dispatch_softmax_backward<accscalar_t, scalar_t, accscalar_t, is_log_softmax>(
             gI.data_ptr<scalar_t>(), grad.data_ptr<accscalar_t>(), output.data_ptr<accscalar_t>(), dim_size, dim_size, outer_size);
       } else {
-        const int ILP = sizeof(float4) / std::max(sizeof(scalar_t), sizeof(accscalar_t));
+        constexpr int ILP = sizeof(float4) / std::max(sizeof(scalar_t), sizeof(accscalar_t));
         dim3 block = SoftMax_getBlockSize(ILP, dim_size);
         cunn_SoftMaxBackward<ILP, scalar_t, accscalar_t, accscalar_t, Epilogue>
          <<<grid, block, block.x * sizeof(accscalar_t), stream>>>(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9700,6 +9700,7 @@ class TestNNDeviceType(NNTestCase):
     @dtypesIfCUDA(torch.half, torch.float)
     @dtypes(torch.float)
     def test_softmax_backward(self, device, dtype):
+        # Non-even sizes and non-zero shifts test fallback paths in vectorized kernel
         sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23)]
         shifts = [(0, 0), (1, 0), (0, 1), (1, 1)]
         for fn in [F.softmax, F.log_softmax]:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9701,7 +9701,8 @@ class TestNNDeviceType(NNTestCase):
     @dtypes(torch.float)
     def test_softmax_backward(self, device, dtype):
         # Non-even sizes and non-zero shifts test fallback paths in vectorized kernel
-        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23)]
+        # Note: dim1 > 1024 is needed to exercise the vectorized (non-persistent) path, (16, 30576) is BERT-esque
+        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23), (32, 1536), (31, 2048), (16, 30576)]
         shifts = [(0, 0), (1, 0), (0, 1), (1, 1)]
         for fn in [F.softmax, F.log_softmax]:
             for size in sizes:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9700,14 +9700,17 @@ class TestNNDeviceType(NNTestCase):
     @dtypesIfCUDA(torch.half, torch.float)
     @dtypes(torch.float)
     def test_softmax_backward(self, device, dtype):
-        sizes = [(0, 10), (32, 20), (10, 0)]
+        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23)]
+        shifts = [(0, 0), (1, 0), (0, 1), (1, 1)]
         for fn in [F.softmax, F.log_softmax]:
             for size in sizes:
-                input = torch.rand(size, device=device, dtype=dtype, requires_grad=True)
-                for dim in [0, 1]:
-                    output = fn(input, dtype=torch.float, dim=dim).sum()
-                    grad_input, = torch.autograd.grad(output, input, create_graph=True)
-                    grad_input.sum().backward()
+                for shift in shifts:
+                    input = torch.rand(size, device=device, dtype=dtype, requires_grad=True)
+                    input = input[shift[0]:, shift[1]:]
+                    for dim in [0, 1]:
+                        output = fn(input, dtype=torch.float, dim=dim).sum()
+                        grad_input, = torch.autograd.grad(output, input, create_graph=True)
+                        grad_input.sum().backward()
 
     @largeCUDATensorTest('12GB')
     def test_conv_large_nosplit(self, device):


### PR DESCRIPTION
Add read/write vectorization to non-persistent softmax kernels only. At this point launch logic has minimal changes, and `ILP=vectorization=2` is always used (the code can handle other values, but `ILP=2` has been the most consistent performer).

Dispatch to persistent / non-persistent kernels is unchanged. 