### PR TITLE
Replace empty_affine_quantizer with new_qtensor_cpu.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
@@ -9,6 +9,8 @@
 #include <limits>
 #include <vector>
 
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
+
 namespace at {
 namespace native {
 
@@ -227,11 +229,64 @@ Tensor q_adaptive_avg_pool2d(const Tensor& input, IntArrayRef output_size) {
     return output;
   }
 }
+
+#ifdef USE_PYTORCH_QNNPACK
+Tensor qnnpack_adaptive_avg_pool2d(
+    const at::Tensor& input,
+    IntArrayRef output_size) {
+    std::array<int64_t, 2> kernel_size;
+    std::array<int64_t, 2> stride;
+    std::array<int64_t, 2> padding{0, 0};
+    bool ceil_mode{false};
+    bool count_include_pad{false};
+
+    const auto output_shape = get_output_shape(input, output_size);
+    auto output_height = output_shape[output_shape.size() - 2];
+    auto output_width = output_shape[output_shape.size() - 1];
+    auto input_height = input.sizes()[input.dim() - 2];
+    auto input_width = input.sizes()[input.dim() - 1];
+    stride[0] = input_height / output_height;
+    stride[1] = input_width / output_width;
+    // Given the constraint that input_height/width % output_height/width == 0
+    // stride and kernel size are same.
+    kernel_size[0] = stride[0];
+    kernel_size[1] = stride[1];
+
+    return at::native::qnnp_avgpool_helper::qnnpack_avg_pool2d(
+        input,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        c10::nullopt);
+}
+
+bool enable_qnnpack_for_ada_avgpool(
+    const at::Tensor& input,
+    IntArrayRef output_size) {
+    const auto output_shape = get_output_shape(input, output_size);
+    auto output_height = output_shape[output_shape.size() - 2];
+    auto output_width = output_shape[output_shape.size() - 1];
+    auto input_height = input.sizes()[input.dim() - 2];
+    auto input_width = input.sizes()[input.dim() - 1];
+
+    return ((input_height % output_height == 0) &&
+        (input_width % output_width) == 0);
+}
+#endif
 } // namespace
 
 Tensor quantized_adaptive_avg_pool2d(
     const at::Tensor& input,
     IntArrayRef output_size) {
+#ifdef USE_PYTORCH_QNNPACK
+  if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
+      input.scalar_type() == kQUInt8 &&
+      enable_qnnpack_for_ada_avgpool(input, output_size)) {
+    return qnnpack_adaptive_avg_pool2d(input, output_size);
+  }
+#endif
   Tensor output;
   AT_DISPATCH_QINT_TYPES(
       input.scalar_type(), "quantized_adaptive_avg_pool2d", [&]() {

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -286,7 +286,10 @@ Tensor q_avg_pool2d(
     return output;
   }
 }
+} // namespace
+
 #ifdef USE_PYTORCH_QNNPACK
+namespace qnnp_avgpool_helper {
 Tensor qnnpack_avg_pool2d(
     Tensor input,
     IntArrayRef kernel_size,
@@ -380,8 +383,8 @@ Tensor qnnpack_avg_pool2d(
       "failed to run QNNPACK Average Pool operator");
   return output.contiguous(input.suggest_memory_format());
 }
+} // qnnp_avgpool_helper
 #endif
-} // namespace
 
 Tensor quantized_avg_pool2d(
     const Tensor& input,
@@ -395,7 +398,7 @@ Tensor quantized_avg_pool2d(
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
       input.scalar_type() == kQUInt8) {
-    return qnnpack_avg_pool2d(
+    return at::native::qnnp_avgpool_helper::qnnpack_avg_pool2d(
         input,
         kernel_size,
         stride,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/average-pooling.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/average-pooling.c
@@ -270,6 +270,67 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_average_pooling2d_nhwc_q8(
    * buffer */
   const uint32_t mr = pytorch_qnnp_params.q8avgpool.mr;
 
+  /*
+   * Indirection buffer:
+   * Imagine a we want to do dw conv or avgpooling with these parameters:
+   * kernel_width/height=3 stride=2
+   * Input is:
+   *  ---------------
+   *  |0|1|2|3|4|5|6|
+   *  ---------------       -------
+   *  | | | | | | | |   to  |0|1|2|
+   *  ---------------       -------
+   *  | | | | | | | |       | | | |
+   *  ---------------       -------
+   *  | | | | | | | |
+   *  ---------------
+   *  | | | | | | | |
+   *  ---------------
+   *
+   *  Thus we are going from width=7 height=5 input to height=2 width=3
+   *  Convince yourself that input 5x7 with pooling params of 3x3 kernel
+   *  with 2x2 stride gets you to 2x3 output.
+   *  Now for each output place (0,0), (0,1), (0,2), (1,0), (1,1), (1,2)
+   *  we have 3x3 input.
+   *  For just the first row of output this will look like as follows:
+   *  pixel:0   pixel:1  pixel:2
+   *  -------   -------  -------
+   *  |0|1|2|   |2|3|4|  |4|5|6|
+   *  -------   -------  -------
+   *  | | | |   | | | |  | | | |
+   *  -------   -------  -------
+   *  | | | |   | | | |  | | | |
+   *  -------   -------  -------
+   *  As you can see there is some overlap in the input needed for each
+   *  output pixel.
+   *  What is indirection buffer:
+   *  Indirection buffer just stores the pointer to the underlying data.
+   *  In this case pointer for a particular input position will point to
+   *  all the input channels of that position in NHWC format.
+   *  So one option for the aforemnetioned storage would be:
+   *  For each output position: store a 3x3 array of pointers. Thus we
+   *  would have 3x3 * 3 (3 output pixel of the first row) = 27 pointers
+   *  stored.
+   *  Now instead we store the pointer in this format:
+   *  ---------------
+   *  |0|1|2|3|4|5|6|
+   *  ---------------
+   *  | | | | | | | |
+   *  ---------------
+   *  | | | | | | | |
+   *  ---------------
+   *  Then we have all the pointers needed as before, but with less duplication.
+   *  So instead of 27 pointers now we have:
+   *  (3 (# of output pixels) - 1) * (stride) * 3 (kernel height) * + 3 * 3 (kernel h*w)
+   *  = 4 * 3 + 9
+   *  = 21 pointers.
+   *  which is the equation below.
+   *  Now in order for this to work the kernel has to be adjusted.
+   *  Here the kernel produced output worth of entire width. Thus as you move from one
+   *  pixel to the next, the jump in the indirection buffer has to be not 3*3 = 9
+   *  but kernel height (3) * stride (2) = 6.
+   *  This you will see operator-run.c
+   */
   const size_t step_width = min(average_pooling->stride_width, pooling_width);
   const size_t step_height =
       pooling_size + (output_width * step_width - 1) * pooling_height;

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -83,4 +83,19 @@ inline std::pair<uint8_t, uint8_t> activationLimits(
 #endif
   }
 }
+
+namespace at {
+namespace native {
+namespace qnnp_avgpool_helper {
+Tensor qnnpack_avg_pool2d(
+    Tensor input,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    bool ceil_mode,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override);
+} // qnnp_avgpool_helper
+} // namespace native
+} // namespace at
 #endif

--- a/test/quantization/test_quantized.py
+++ b/test/quantization/test_quantized.py
@@ -2689,6 +2689,54 @@ class TestQNNPackOps(TestCase):
 
     @given(batch_size=st.integers(1, 5),
            channels=st.sampled_from([2, 4, 5, 8, 16, 32]),
+           height=st.integers(4, 20),
+           width=st.integers(4, 20),
+           output_height=st.integers(2, 10),
+           output_width=st.integers(2, 10),
+           scale=st.floats(0.2, 1.6),
+           zero_point=st.integers(0, 25)
+           )
+    def test_adaptive_avg_pool2d(
+            self,
+            batch_size,
+            channels,
+            height,
+            width,
+            output_height,
+            output_width,
+            scale,
+            zero_point
+
+    ):
+        with override_quantized_engine('qnnpack'):
+            # Check constraints
+            assume(height >= output_height)
+            assume(width >= output_width)
+
+            import torch.nn.functional as F
+            X_init = torch.from_numpy(np.random.randint(
+                0, 50, (batch_size, channels, height, width)))
+
+            X = scale * (X_init - zero_point).to(dtype=torch.float)
+
+            iH, iW = X.shape[-2:]
+
+            q_avg_pool = torch.nn.quantized.functional.adaptive_avg_pool2d
+
+            x_q = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                            dtype=torch.quint8)
+
+            a_pool = F.adaptive_avg_pool2d(x_q.dequantize().to(torch.float), (output_height, output_width))
+            qa_pool = q_avg_pool(x_q, (output_height, output_width))
+            # Quantize Ref Output
+            a_pool_q = torch.quantize_per_tensor(a_pool, scale=scale, zero_point=zero_point,
+                                                 dtype=torch.quint8)
+            np.testing.assert_array_almost_equal(a_pool_q.int_repr().numpy(),
+                                                 qa_pool.int_repr().numpy(), decimal=0)
+
+
+    @given(batch_size=st.integers(1, 5),
+           channels=st.sampled_from([2, 4, 5, 8, 16, 32]),
            height=st.integers(4, 10),
            width=st.integers(4, 10),
            scale=st.floats(0.02, 2.6),


### PR DESCRIPTION
Summary:
From the flamegraph it seems 40% the time we are spending going through the dispatch stack. I think in quantized model where compute can take less time, such overheads become noticeable
{F233762101}

Test Plan: Quantized ops tests.

Differential Revision: D20972119

