### PR TITLE
Enable supplying memory format directly to set_sizes_contiguous.

### DIFF
--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -1,0 +1,30 @@
+#include <ATen/native/TensorTransformations.h>
+
+#include <ATen/NativeFunctions.h>
+#include <c10/util/Exception.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace at {
+namespace native {
+
+Tensor channel_shuffle(const Tensor& self, int64_t groups) {
+  AT_ASSERTM(self.dim() == 4,
+             "channel_shuffle expects 4D input, but got input with sizes ",self.sizes());
+  int64_t b = self.size(0);
+  int64_t c = self.size(1);
+  int64_t h = self.size(2);
+  int64_t w = self.size(3);
+  AT_ASSERTM((c % groups) == 0,
+             "Number of channels must be divisible gy groups. Got ",
+             c, " channels and ", groups, " groups.");
+  int64_t oc = c / groups;
+
+  auto input_reshaped = self.reshape({b, groups, oc, h, w});
+  return input_reshaped.permute({0 /* b */, 2 /* oc */, 1 /* groups */, 3 /* h */, 4 /* w */})
+                       .contiguous()
+                       .reshape({b, c, h, w});
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2236,6 +2236,12 @@
 - func: pixel_shuffle(Tensor self, int upscale_factor) -> Tensor
   use_c10_dispatcher: full
 
+- func: channel_shuffle(Tensor self, int groups) -> Tensor
+  use_c10_dispatcher: full
+  dispatch:
+    CPU: channel_shuffle
+    QuantizedCPU: quantized_channel_shuffle
+
 - func: is_pinned(Tensor self) -> bool
   use_c10_dispatcher: full
   variants: method

--- a/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
@@ -9,6 +9,8 @@
 #include <limits>
 #include <vector>
 
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
+
 namespace at {
 namespace native {
 
@@ -227,11 +229,64 @@ Tensor q_adaptive_avg_pool2d(const Tensor& input, IntArrayRef output_size) {
     return output;
   }
 }
+
+#ifdef USE_PYTORCH_QNNPACK
+Tensor qnnpack_adaptive_avg_pool2d(
+    const at::Tensor& input,
+    IntArrayRef output_size) {
+    std::array<int64_t, 2> kernel_size;
+    std::array<int64_t, 2> stride;
+    std::array<int64_t, 2> padding{0, 0};
+    bool ceil_mode{false};
+    bool count_include_pad{false};
+
+    const auto output_shape = get_output_shape(input, output_size);
+    auto output_height = output_shape[output_shape.size() - 2];
+    auto output_width = output_shape[output_shape.size() - 1];
+    auto input_height = input.sizes()[input.dim() - 2];
+    auto input_width = input.sizes()[input.dim() - 1];
+    stride[0] = input_height / output_height;
+    stride[1] = input_width / output_width;
+    // Given the constraint that input_height/width % output_height/width == 0
+    // stride and kernel size are same.
+    kernel_size[0] = stride[0];
+    kernel_size[1] = stride[1];
+
+    return at::native::qnnp_avgpool_helper::qnnpack_avg_pool2d(
+        input,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        c10::nullopt);
+}
+
+bool enable_qnnpack_for_ada_avgpool(
+    const at::Tensor& input,
+    IntArrayRef output_size) {
+    const auto output_shape = get_output_shape(input, output_size);
+    auto output_height = output_shape[output_shape.size() - 2];
+    auto output_width = output_shape[output_shape.size() - 1];
+    auto input_height = input.sizes()[input.dim() - 2];
+    auto input_width = input.sizes()[input.dim() - 1];
+
+    return ((input_height % output_height == 0) &&
+        (input_width % output_width) == 0);
+}
+#endif
 } // namespace
 
 Tensor quantized_adaptive_avg_pool2d(
     const at::Tensor& input,
     IntArrayRef output_size) {
+#ifdef USE_PYTORCH_QNNPACK
+  if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
+      input.scalar_type() == kQUInt8 &&
+      enable_qnnpack_for_ada_avgpool(input, output_size)) {
+    return qnnpack_adaptive_avg_pool2d(input, output_size);
+  }
+#endif
   Tensor output;
   AT_DISPATCH_QINT_TYPES(
       input.scalar_type(), "quantized_adaptive_avg_pool2d", [&]() {

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -286,7 +286,10 @@ Tensor q_avg_pool2d(
     return output;
   }
 }
+} // namespace
+
 #ifdef USE_PYTORCH_QNNPACK
+namespace qnnp_avgpool_helper {
 Tensor qnnpack_avg_pool2d(
     Tensor input,
     IntArrayRef kernel_size,
@@ -380,8 +383,8 @@ Tensor qnnpack_avg_pool2d(
       "failed to run QNNPACK Average Pool operator");
   return output.contiguous(input.suggest_memory_format());
 }
+} // qnnp_avgpool_helper
 #endif
-} // namespace
 
 Tensor quantized_avg_pool2d(
     const Tensor& input,
@@ -395,7 +398,7 @@ Tensor quantized_avg_pool2d(
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
       input.scalar_type() == kQUInt8) {
-    return qnnpack_avg_pool2d(
+    return at::native::qnnp_avgpool_helper::qnnpack_avg_pool2d(
         input,
         kernel_size,
         stride,

--- a/aten/src/ATen/native/quantized/cpu/qchannel_shuffle.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qchannel_shuffle.cpp
@@ -1,0 +1,116 @@
+#include <ATen/ATen.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/cpu/Loops.h>
+#include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <ATen/quantized/Quantizer.h>
+#include <ATen/native/quantized/cpu/init_qnnpack.h>
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <c10/core/TensorOptions.h>
+#include <caffe2/utils/threadpool/ThreadPoolMobile.h>
+
+#include <algorithm>
+
+namespace at {
+namespace native {
+
+namespace {
+Tensor quantized_channel_shuffle_impl(
+    const Tensor& self,
+    int64_t groups) {
+
+  TORCH_CHECK(
+      self.dim() == 4,
+      "channel_shuffle expects 4D input, but got input with sizes ",
+      self.sizes());
+  TORCH_CHECK(
+      self.scalar_type() == kQUInt8,
+      "Quantized channel shuffle works only on uint8_t.",
+      "But got:", self.scalar_type());
+  const Tensor self_nhwc = self.contiguous(MemoryFormat::ChannelsLast);
+  Tensor qy = at::new_qtensor_cpu(
+      self_nhwc.sizes(),
+      TensorOptions(kQUInt8)
+          .device(kCPU)
+          .memory_format(self_nhwc.suggest_memory_format()),
+      make_per_tensor_affine_quantizer(
+          self_nhwc.q_scale(), self_nhwc.q_zero_point(), kQUInt8)
+      );
+
+  // Degenerate case of just copying.
+  if (groups == 1) {
+    qy.copy_(self_nhwc);
+    return qy.contiguous(self.suggest_memory_format());
+  }
+
+  int64_t channels = self.size(1);
+  TORCH_CHECK((channels % groups) == 0,
+             "Number of channels must be divisible gy groups. Got ",
+             channels, " channels and ", groups, " groups.");
+
+  initQNNPACK();
+
+  pytorch_qnnp_operator_t qnnpack_operator{nullptr};
+
+  const pytorch_qnnp_status createStatus = pytorch_qnnp_create_channel_shuffle_nc_x8(
+      groups /* groups */,
+      channels / groups /* group channels */,
+      0 /* flags */,
+      &qnnpack_operator);
+  TORCH_INTERNAL_ASSERT(
+      createStatus == pytorch_qnnp_status_success,
+      "failed to create QNNPACK Add operator");
+
+  const pytorch_qnnp_status setupStatus = pytorch_qnnp_setup_channel_shuffle_nc_x8(
+      qnnpack_operator,
+      self_nhwc.numel() / channels /* batch size */,
+      (uint8_t*)self_nhwc.data_ptr<c10::quint8>() /* slef data */,
+      channels /* self stride */,
+      (uint8_t*)qy.data_ptr<c10::quint8>() /* qy data */,
+      channels /* qy stride */);
+  TORCH_INTERNAL_ASSERT(
+      setupStatus == pytorch_qnnp_status_success,
+      "failed to setup QNNPACK Add operator");
+
+#ifdef FBCODE_CAFFE2
+  const pytorch_qnnp_status runStatus =
+      pytorch_qnnp_run_operator(qnnpack_operator, nullptr /* thread pool */);
+#else
+  pthreadpool_t threadpool = caffe2::mobile_pthreadpool();
+  const pytorch_qnnp_status runStatus =
+      pytorch_qnnp_run_operator(qnnpack_operator, threadpool);
+#endif
+  TORCH_INTERNAL_ASSERT(
+      runStatus == pytorch_qnnp_status_success,
+      "failed to run QNNPACK Add operator");
+
+  return qy.contiguous(self.suggest_memory_format());
+}
+} // namespace
+
+// at::native functions for the native_functions.yaml
+Tensor quantized_channel_shuffle(
+    const Tensor& self,
+    int64_t groups) {
+  return quantized_channel_shuffle_impl(self, groups);
+}
+
+// Keep the registry in the anonymous namespace.
+namespace {
+class QChannelShuffle final : public c10::OperatorKernel {
+ public:
+  Tensor operator()(Tensor qx, int64_t groups) {
+    return quantized_channel_shuffle_impl(qx, groups);
+  }
+};
+
+static auto registry = c10::RegisterOperators().op(
+    "quantized::channel_shuffle(Tensor qx, int groups) -> Tensor qy",
+    c10::RegisterOperators::options()
+        .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
+        .kernel<QChannelShuffle>(DispatchKey::QuantizedCPUTensorId));
+} // namespace
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/average-pooling.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/average-pooling.c
@@ -270,6 +270,67 @@ enum pytorch_qnnp_status pytorch_qnnp_setup_average_pooling2d_nhwc_q8(
    * buffer */
   const uint32_t mr = pytorch_qnnp_params.q8avgpool.mr;
 
+  /*
+   * Indirection buffer:
+   * Imagine a we want to do dw conv or avgpooling with these parameters:
+   * kernel_width/height=3 stride=2
+   * Input is:
+   *  ---------------
+   *  |0|1|2|3|4|5|6|
+   *  ---------------       -------
+   *  | | | | | | | |   to  |0|1|2|
+   *  ---------------       -------
+   *  | | | | | | | |       | | | |
+   *  ---------------       -------
+   *  | | | | | | | |
+   *  ---------------
+   *  | | | | | | | |
+   *  ---------------
+   *
+   *  Thus we are going from width=7 height=5 input to height=2 width=3
+   *  Convince yourself that input 5x7 with pooling params of 3x3 kernel
+   *  with 2x2 stride gets you to 2x3 output.
+   *  Now for each output place (0,0), (0,1), (0,2), (1,0), (1,1), (1,2)
+   *  we have 3x3 input.
+   *  For just the first row of output this will look like as follows:
+   *  pixel:0   pixel:1  pixel:2
+   *  -------   -------  -------
+   *  |0|1|2|   |2|3|4|  |4|5|6|
+   *  -------   -------  -------
+   *  | | | |   | | | |  | | | |
+   *  -------   -------  -------
+   *  | | | |   | | | |  | | | |
+   *  -------   -------  -------
+   *  As you can see there is some overlap in the input needed for each
+   *  output pixel.
+   *  What is indirection buffer:
+   *  Indirection buffer just stores the pointer to the underlying data.
+   *  In this case pointer for a particular input position will point to
+   *  all the input channels of that position in NHWC format.
+   *  So one option for the aforemnetioned storage would be:
+   *  For each output position: store a 3x3 array of pointers. Thus we
+   *  would have 3x3 * 3 (3 output pixel of the first row) = 27 pointers
+   *  stored.
+   *  Now instead we store the pointer in this format:
+   *  ---------------
+   *  |0|1|2|3|4|5|6|
+   *  ---------------
+   *  | | | | | | | |
+   *  ---------------
+   *  | | | | | | | |
+   *  ---------------
+   *  Then we have all the pointers needed as before, but with less duplication.
+   *  So instead of 27 pointers now we have:
+   *  (3 (# of output pixels) - 1) * (stride) * 3 (kernel height) * + 3 * 3 (kernel h*w)
+   *  = 4 * 3 + 9
+   *  = 21 pointers.
+   *  which is the equation below.
+   *  Now in order for this to work the kernel has to be adjusted.
+   *  Here the kernel produced output worth of entire width. Thus as you move from one
+   *  pixel to the next, the jump in the indirection buffer has to be not 3*3 = 9
+   *  but kernel height (3) * stride (2) = 6.
+   *  This you will see operator-run.c
+   */
   const size_t step_width = min(average_pooling->stride_width, pooling_width);
   const size_t step_height =
       pooling_size + (output_width * step_width - 1) * pooling_height;

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -83,4 +83,19 @@ inline std::pair<uint8_t, uint8_t> activationLimits(
 #endif
   }
 }
+
+namespace at {
+namespace native {
+namespace qnnp_avgpool_helper {
+Tensor qnnpack_avg_pool2d(
+    Tensor input,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    bool ceil_mode,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override);
+} // qnnp_avgpool_helper
+} // namespace native
+} // namespace at
 #endif

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -548,8 +548,7 @@ inline Tensor new_qtensor_cpu(
       /*resizable=*/true);
   auto tensor = detail::make_tensor<QTensorImpl>(
       storage, at::DispatchKeySet(at::DispatchKey::QuantizedCPUTensorId), quantizer);
-  get_qtensorimpl(tensor)->set_sizes_contiguous(sizes);
-  get_qtensorimpl(tensor)->empty_tensor_restride(memory_format);
+  get_qtensorimpl(tensor)->set_sizes_contiguous(sizes, memory_format);
   return tensor;
 }
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -699,7 +699,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * sizes/strides are in bounds for the storage that is allocated;
    * this is the responsibility of the caller
    */
-  void set_sizes_contiguous(IntArrayRef new_size) {
+  void set_sizes_contiguous(
+      IntArrayRef new_size,
+      MemoryFormat memory_format=MemoryFormat::Contiguous) {
     TORCH_CHECK(allow_tensor_metadata_change(), "set_sizes_contiguous ", err_msg_tensor_metadata_change_not_allowed);
     auto new_dim = new_size.size();
 
@@ -709,7 +711,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     }
 
     refresh_numel();
-    empty_tensor_restride(MemoryFormat::Contiguous);
+    empty_tensor_restride(memory_format);
   }
 
   /**

--- a/test/quantization/test_quantized.py
+++ b/test/quantization/test_quantized.py
@@ -2689,6 +2689,54 @@ class TestQNNPackOps(TestCase):
 
     @given(batch_size=st.integers(1, 5),
            channels=st.sampled_from([2, 4, 5, 8, 16, 32]),
+           height=st.integers(4, 20),
+           width=st.integers(4, 20),
+           output_height=st.integers(2, 10),
+           output_width=st.integers(2, 10),
+           scale=st.floats(0.2, 1.6),
+           zero_point=st.integers(0, 25)
+           )
+    def test_adaptive_avg_pool2d(
+            self,
+            batch_size,
+            channels,
+            height,
+            width,
+            output_height,
+            output_width,
+            scale,
+            zero_point
+
+    ):
+        with override_quantized_engine('qnnpack'):
+            # Check constraints
+            assume(height >= output_height)
+            assume(width >= output_width)
+
+            import torch.nn.functional as F
+            X_init = torch.from_numpy(np.random.randint(
+                0, 50, (batch_size, channels, height, width)))
+
+            X = scale * (X_init - zero_point).to(dtype=torch.float)
+
+            iH, iW = X.shape[-2:]
+
+            q_avg_pool = torch.nn.quantized.functional.adaptive_avg_pool2d
+
+            x_q = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                            dtype=torch.quint8)
+
+            a_pool = F.adaptive_avg_pool2d(x_q.dequantize().to(torch.float), (output_height, output_width))
+            qa_pool = q_avg_pool(x_q, (output_height, output_width))
+            # Quantize Ref Output
+            a_pool_q = torch.quantize_per_tensor(a_pool, scale=scale, zero_point=zero_point,
+                                                 dtype=torch.quint8)
+            np.testing.assert_array_almost_equal(a_pool_q.int_repr().numpy(),
+                                                 qa_pool.int_repr().numpy(), decimal=0)
+
+
+    @given(batch_size=st.integers(1, 5),
+           channels=st.sampled_from([2, 4, 5, 8, 16, 32]),
            height=st.integers(4, 10),
            width=st.integers(4, 10),
            scale=st.floats(0.02, 2.6),

--- a/test/quantization/test_quantized.py
+++ b/test/quantization/test_quantized.py
@@ -671,6 +671,31 @@ class TestQuantizedOps(TestCase):
         np.testing.assert_equal(qC, qC_hat.int_repr(),
                                 "Quantized multiplication failed.")
 
+    """Tests channel shuffle operation on quantized tensors."""
+    @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
+                                              min_side=2, max_side=32),
+                       qparams=hu.qparams()),
+           groups=st.integers(2, 6))
+    def test_channel_shuffle(self, X, groups):
+        X, (scale, zero_point, torch_type) = X
+        channels = X.shape[-3]
+        iH, iW = X.shape[-2:]
+        assume(channels % groups == 0)
+
+        a = torch.from_numpy(X)
+        a = torch.rand(a.shape)
+        a_out = torch.nn.functional.channel_shuffle(a, groups)
+
+        a_ref = torch.quantize_per_tensor(a_out, scale=scale,
+                                          zero_point=zero_point, dtype=torch.quint8)
+        a_ref = a_ref.dequantize()
+        qa = torch.quantize_per_tensor(a, scale=scale, zero_point=zero_point,
+                                       dtype=torch.quint8)
+
+        a_hat = torch.nn.functional.channel_shuffle(qa, groups)
+        self.assertEqual(a_ref, a_hat.dequantize(),
+                         message="torch.nn.functional.channel_shuffle results are off")
+
     """Tests max pool operation on quantized tensors."""
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
                                               min_side=1, max_side=10),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7131,6 +7131,32 @@ class TestNN(NNTestCase):
 
             assert np.abs(scipy_ary - gridsample_ary).max() < 1e-5
 
+    def test_channel_shuffle(self):
+        x = torch.tensor(
+                [[[[1, 2],
+                   [3, 4]],
+                  [[5, 6],
+                   [7, 8]],
+                  [[9, 10],
+                   [11, 12]],
+                  [[13, 14],
+                   [15, 16]],
+                 ]]
+                )
+        y_ref = torch.tensor(
+                [[[[1, 2],
+                   [3, 4]],
+                  [[9, 10],
+                   [11, 12]],
+                  [[5, 6],
+                   [7, 8]],
+                  [[13, 14],
+                   [15, 16]],
+                 ]]
+                )
+        y = F.channel_shuffle(x, 2)
+        self.assertEqual(y, y_ref)
+
     def test_upsamplingNearest1d(self):
         m = nn.Upsample(size=4, mode='nearest')
         in_t = torch.ones(1, 1, 2)
@@ -9442,7 +9468,7 @@ class TestNNDeviceType(NNTestCase):
             result = torch.nn.functional.grid_sample(image, grid, padding_mode='zeros')
             self.assertEqual(result, torch.tensor([[[[[27., 26., 25.], [24., 23., 22.], [21., 20., 19.]],
                                                      [[18., 17., 16.], [15., 0., 13.], [12., 11., 10.]],
-                                                     [[9., 8., 7.], [6., 5., 4.], [3., 2., 1.]]]]], 
+                                                     [[9., 8., 7.], [6., 5., 4.], [3., 2., 1.]]]]],
                                                   device=device, dtype=dtype))
             result.backward(torch.ones_like(result))
             expected_grad = torch.ones_like(image)

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -208,6 +208,7 @@ def get_testing_overrides():
         torch.ceil: lambda input, out=None: -1,
         torch.celu: lambda input, alhpa=1., inplace=False: -1,
         torch.chain_matmul: lambda *matrices: -1,
+        torch.channel_shuffle: lambda input, groups : -1,
         torch.cholesky: lambda input, upper=False, out=None: -1,
         torch.cholesky_inverse: lambda input, upper=False, out=None: -1,
         torch.cholesky_solve: lambda input1, input2, upper=False, out=None: -1,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2764,6 +2764,44 @@ Examples::
     torch.Size([1, 1, 12, 12])
 """)
 
+channel_shuffle = _add_docstr(torch.channel_shuffle, r"""
+Divide the channels in a tensor of shape :math:`(*, C , H, W)`
+into g groups and rearrange them as :math:`(*, C \frac g, g, H, W)`,
+while keeping the original tensor shape.
+
+See :class:`~torch.nn.ChannelShuffle` for details.
+
+Args:
+    input (Tensor): the input tensor
+    gorups (int): number of groups to divide channels in and rearrange.
+
+Examples::
+
+    >>> channel_shuffle = nn.ChannelShuffle(3)
+    >>> input = torch.randn(1, 4, 2, 2)
+    >>> print(input)
+    [[[[1, 2],
+       [3, 4]],
+      [[5, 6],
+       [7, 8]],
+      [[9, 10],
+       [11, 12]],
+      [[13, 14],
+       [15, 16]],
+     ]]
+    >>> output = channel_shuffle(input)
+    >>> print(output)
+    [[[[1, 2],
+       [3, 4]],
+      [[9, 10],
+       [11, 12]],
+      [[5, 6],
+       [7, 8]],
+      [[13, 14],
+       [15, 16]],
+     ]]
+""")
+
 @_overload  # noqa: F811
 def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=None):  # noqa: F811
     # type: (Tensor, Optional[int], Optional[float], str, Optional[bool]) -> Tensor

--- a/torch/nn/modules/channelhuffle.py
+++ b/torch/nn/modules/channelhuffle.py
@@ -1,0 +1,49 @@
+from .module import Module
+from .. import functional as F
+
+
+class ChannelShuffle(Module):
+    r"""Divide the channels in a tensor of shape :math:`(*, C , H, W)`
+    into g groups and rearrange them as :math:`(*, C \frac g, g, H, W)`,
+    while keeping the original tensor shape.
+
+    Args:
+        groups (int): number of groups to divide channels in.
+
+    Examples::
+
+        >>> channel_shuffle = nn.ChannelShuffle(2)
+        >>> input = torch.randn(1, 4, 2, 2)
+        >>> print(input)
+        [[[[1, 2],
+           [3, 4]],
+          [[5, 6],
+           [7, 8]],
+          [[9, 10],
+           [11, 12]],
+          [[13, 14],
+           [15, 16]],
+         ]]
+        >>> output = channel_shuffle(input)
+        >>> print(output)
+        [[[[1, 2],
+           [3, 4]],
+          [[9, 10],
+           [11, 12]],
+          [[5, 6],
+           [7, 8]],
+          [[13, 14],
+           [15, 16]],
+         ]]
+    """
+    __constants__ = ['groups']
+
+    def __init__(self, groups):
+        super(ChanelShuffle, self).__init__()
+        self.groups = groups
+
+    def forward(self, input):
+        return F.channel_shuffle(input, self.groups)
+
+    def extra_repr(self):
+        return 'groups={}'.format(self.groups)


### PR DESCRIPTION
Summary:
- Also change new_qtensor_cpu to use this new API.
- This helps us remove subsequent call to restride.
Otherwise restride is called twice. Once for MemoryFormat::Contiguous from
set_sizes_contiguous and then again form the memory format we want.

Differential Revision: D20972228

