### PR TITLE
CI failure tips

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -974,7 +974,3 @@ following steps:
 4. Now you can find the pytorch working directory, which could be
    `~/workspace` or `~/project`, and run commands locally to debug
    the failure.
-
-Alternatively, if your CI failure is not hardware-related, you can
-download the CI job's docker image and run it
-on your own machine using the instructions [here](https://github.com/Quansight/pytorch/wiki/Reproducing-build-failures-with-Docker-images-on-QGPU).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@
     + [Why LD_PRELOAD in the build function?](#why-ld-preload-in-the-build-function-)
     + [Why no leak detection?](#why-no-leak-detection-)
 - [Caffe2 notes](#caffe2-notes)
+- [CI failure tips](#ci-failure-tips)
 
 ## Contributing to PyTorch
 
@@ -938,3 +939,42 @@ are Caffe2/PyTorch specific. Here they are:
 - `mypy*`, `requirements.txt`, `setup.py`, `test`, `tools` are
   PyTorch-specific. Don't put Caffe2 code in them without extra
   coordination.
+
+## CI failure tips
+
+Once you submit a PR or push a new commit to a branch that is in
+an active PR, CI jobs will be run automatically. Some of these may
+fail and you will need to find out why, by looking at the logs.
+
+Fairly often, a CI failure might be unrelated to your changes. In this
+case, you can usually ignore the failure.
+
+Some failures might be related to specific hardware or environment
+configurations. In this case, if the job is run by CircleCI, you can
+ssh into the job's session to perform manual debugging using the
+following steps:
+
+1. In the CircleCI page for the failed job, make sure you are logged in
+   and then click the `Rerun` actions dropdown button on the top right.
+   Click `Rerun Job with SSH`.
+
+2. When the job reruns, a new step will be added in the `STEPS` tab
+   labelled `Set up SSH`. Inside that tab will be an ssh command that
+   you can execute in a shell.
+
+3. Once you are connected through ssh, you may need to enter a docker
+   container. Run `docker ps` to check if there are any docker
+   containers running. Note that your CI job might be in the process
+   of initiating a docker container, which means it will not show up
+   yet. It is best to wait until the CI job reaches a step where it is
+   building pytorch or running pytorch tests. If the job does have a
+   docker container, run `docker exec -it IMAGE_ID /bin/bash` to
+   connect to it.
+
+4. Now you can find the pytorch working directory, which could be
+   `~/workspace` or `~/project`, and run commands locally to debug
+   the failure.
+
+Alternatively, if your CI failure is not hardware-related, you can
+download the CI job's docker image and run it
+on your own machine using the instructions [here](https://github.com/Quansight/pytorch/wiki/Reproducing-build-failures-with-Docker-images-on-QGPU).


### PR DESCRIPTION
Finding out how to ssh into a CircleCI job to debug a failure is a challenge because, as far as I know, there isn't any concise documentation about it. I figured it might be nice to include this in CONTRIBUTING.md.

Maybe there are some other tips about non-CircleCI jobs that could be added in the future as well.