### PR TITLE
[JIT] add copies to functional graph

### DIFF
--- a/torch/csrc/jit/passes/create_functional_graphs.h
+++ b/torch/csrc/jit/passes/create_functional_graphs.h
@@ -16,5 +16,13 @@ TORCH_API void InlineFunctionalGraphs(const std::shared_ptr<Graph>& graph);
 // be proven that this does not change graph semantics.
 TORCH_API void RemoveMutation(const std::shared_ptr<Graph>& graph);
 
+// Functional Graphs are created with the condition that graph outputs may
+// not alias graph outputs. Passes may make optimizations such that this
+// is no longer true, such as replacing x + 0 with x.
+// This pass takes in a prim::FunctionalGraph and adds copies until outputs do
+// not alias inputs.
+TORCH_API void EnsureOutputsDontAliasInputs(
+    const std::shared_ptr<Graph>& graph);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -467,6 +467,7 @@ void initPythonIRBindings(PyObject* module_) {
       .def("sourceRange", [](Node& n) { return n.sourceRange().str(); })
       .def("hasMultipleOutputs", [](Node& n) { return n.outputs().size() > 1; })
       .def("outputsSize", [](Node& n) { return n.outputs().size(); })
+      .def("subgraph", [](Node& n) { return n.g(attr::Subgraph); })
       .NS(kind)
       .def("inputsAt", [](Node& n, size_t i) { return n.inputs().at(i); })
       .def(


### PR DESCRIPTION
Functional Graphs are created with the following conditions:
- graph inputs may be mutable values
-  everything computed inside the graph is not - mutated / completely functional
- graph outputs cannot alias graph inputs

A pass may take in a functional graph and make optimizations such that these conditions no longer hold, such as replacing x + 0 with x. This pass adds implicit copies such that the graph semantics are preserved. 
