### PR TITLE
Sphinx syntax touchup for Amp incompleteness warnings

### DIFF
--- a/docs/source/amp.rst
+++ b/docs/source/amp.rst
@@ -18,7 +18,7 @@ range of ``float32``. Networks running in mixed precision try to match each oper
     :class:`GradScaler` is only useful if you manually run regions of your model in ``float16``.
     If you aren't sure how to choose op precision manually, the master branch and nightly pip/conda
     builds include a context manager that chooses op precision automatically wherever it's enabled.
-    See the `master documentation<https://pytorch.org/docs/master/amp.html>`_ for details.
+    See the `master documentation <https://pytorch.org/docs/master/amp.html>`_ for details.
 
 .. contents:: :local:
 

--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -10,7 +10,7 @@ Automatic Mixed Precision examples
     :class:`GradScaler` is only useful if you manually run regions of your model in ``float16``.
     If you aren't sure how to choose op precision manually, the master branch and nightly pip/conda
     builds include a context manager that chooses op precision automatically wherever it's enabled.
-    See the `master documentation<https://pytorch.org/docs/master/amp.html>`_ for details.
+    See the `master documentation <https://pytorch.org/docs/master/amp.html>`_ for details.
 
 .. contents:: :local:
 


### PR DESCRIPTION
Built docs locally as a sanity check, discovered the syntax for embedded links was stricter than I expected. This PR fixes the formatting errors I observed.