### PR TITLE
Fix DDP bug in single process multiple device use cases

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -1878,6 +1878,87 @@ class QuadraGpuNet(nn.Module):
         return F.softmax(x, dim=1).to(dev0)
 
 
+@requires_gloo()
+@unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
+class DistributedDataParallelSingleProcessTest(TestCase):
+    def setUp(self):
+        self.rank = 0
+        self.world_size = 1
+        self.file = tempfile.NamedTemporaryFile(delete=False)
+
+    def _test_base(self, net, inp, check_params=True):
+        store = c10d.FileStore(self.file.name, self.world_size)
+        process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
+
+        ddp = nn.parallel.DistributedDataParallel(
+            copy.deepcopy(net),
+            process_group=process_group
+        )
+
+        net_opt = torch.optim.Adam(net.parameters(), lr=10)
+        ddp_opt = torch.optim.Adam(ddp.parameters(), lr=10)
+
+        for i, j in zip(ddp.parameters(), net.parameters()):
+            self.assertTrue(i.allclose(j))
+
+        for _ in range(4):
+            net(*inp).sum().backward()
+            ddp(*inp).sum().backward()
+
+            net_opt.step()
+            ddp_opt.step()
+
+        if check_params:
+            for i, j in zip(ddp.parameters(), net.parameters()):
+                self.assertTrue(i.allclose(j))
+
+    def test_cpu(self):
+        torch.manual_seed(1337)
+        self._test_base(nn.Linear(2, 2), [torch.randn(30, 2)])
+
+    @skip_if_lt_x_gpu(1)
+    def test_cuda(self):
+        torch.manual_seed(1337)
+        self._test_base(nn.Linear(2, 2).to(0), [torch.randn(30, 2).to(0)])
+
+    @skip_if_lt_x_gpu(1)
+    def test_rnn(self):
+        # This test is inspired by the bug reported in
+        # https://github.com/pytorch/pytorch/issues/36268
+        BATCH_SIZE = 4
+        INPUT_DIM = 256
+        OUTPUT_DIM = 256
+        HIDDEN_DIM = 256
+        N_LAYERS = 3
+        SEQ_LEN = 100
+
+        torch.manual_seed(1337)
+
+        class Net(nn.Module):
+            def __init__(self, input_dim, hidden_dim, output_dim, hidden_layers):
+                super(Net, self).__init__()
+                self.input_dim = input_dim
+                self.hidden_dim = hidden_dim
+                self.output_dim = output_dim
+                self.hidden_layers = hidden_layers
+
+                self.lstm = nn.LSTM(input_dim, hidden_dim, hidden_layers, batch_first=True)
+                self.h2o = nn.Linear(hidden_dim, output_dim)
+
+            def forward(self, x, y):
+                self.lstm.flatten_parameters()
+                h_t, _ = self.lstm(x)
+                return self.h2o(h_t)
+
+        net = Net(INPUT_DIM, HIDDEN_DIM, OUTPUT_DIM, N_LAYERS).to(0)
+        inp = [
+            torch.randn((BATCH_SIZE, SEQ_LEN, INPUT_DIM)).to(0),
+            torch.randn((BATCH_SIZE, SEQ_LEN, OUTPUT_DIM)).to(0)
+        ]
+
+        self._test_base(net, inp, check_params=False)
+
+
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class DistributedDataParallelTest(MultiProcessTestCase):
     def setUp(self):

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -314,6 +314,20 @@ class DistributedDataParallel(Module):
         (4) registering the grad hooks
         (5) passing a handle of DDP to SyncBatchNorm Layer
         """
+
+        def parameters(m, recurse=True):
+            def model_parameters(m):
+                ps = m._former_parameters.values() \
+                    if hasattr(m, "_former_parameters") \
+                    else m.parameters(recurse=False)
+                for p in ps:
+                    yield p
+
+            ms = m.modules() if recurse else [m]
+            for m in ms:
+                for p in model_parameters(m):
+                    yield p
+
         if self.device_ids and len(self.device_ids) > 1:
             # only create replicas for single-device CUDA modules
             #
@@ -324,13 +338,13 @@ class DistributedDataParallel(Module):
             self._module_copies[0] = self.module
 
             for module_copy in self._module_copies[1:]:
-                for param, copy_param in zip(self.module.parameters(), module_copy.parameters()):
+                for param, copy_param in zip(self.module.parameters(), parameters(module_copy)):
                     copy_param.requires_grad = param.requires_grad
 
         else:
             self._module_copies = [self.module]
 
-        self.modules_params = [list(m.parameters()) for m in self._module_copies]
+        self.modules_params = [list(parameters(m)) for m in self._module_copies]
         self.modules_buffers = [list(m.buffers()) for m in self._module_copies]
 
         # Build tuple of (module, parameter) for all parameters that require grads.
@@ -340,7 +354,7 @@ class DistributedDataParallel(Module):
                 for module in replica.modules()
                 for parameter in filter(
                     lambda parameter: parameter.requires_grad,
-                    module.parameters(recurse=False))
+                    parameters(module, recurse=False))
             ] for replica in self._module_copies]
 
         # Build list of parameters.

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -2,6 +2,8 @@ import torch
 import torch.cuda.comm as comm
 from torch.cuda._utils import _get_device_index
 
+from collections import OrderedDict
+
 
 def _is_script_module(module):
     import torch.jit
@@ -121,6 +123,13 @@ def replicate(network, devices, detach=False):
 
             module_copies[j].append(replica)
 
+            # This is a temporary fix for DDP. DDP needs to access the 
+            # replicated model parameters. It used to do so through 
+            # `mode.parameters()`. The fix added in #33907 for DP stops the
+            # `parameters()` API from exposing the replicated parameters.
+            # Hence, we add a `_former_parameters` dict here to support DDP.
+            replica._former_parameters = OrderedDict()
+
     for i, module in enumerate(modules):
         for key, child in module._modules.items():
             if child is None:
@@ -149,6 +158,8 @@ def replicate(network, devices, detach=False):
                     if (not _is_script_module(replica)):
                         del replica._parameters[key]
                     setattr(replica, key, param)
+                    # expose the parameter for DDP
+                    replica._former_parameters[key] = param
         for key, buf in module._buffers.items():
             if buf is None:
                 for j in range(num_replicas):


### PR DESCRIPTION
DDP was expecting .parameters() would return a all parameters
of a replicated module. However, after #33907, we no longer
populating _parameters for replicated modules. This PR fixes
that problem by keeping params in a _former_parameters ordered
dict on every module replica.

