### PR TITLE
[jit] Fix bound method copying

### DIFF
--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -348,7 +348,9 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
             if not inspect.ismethod(item):
                 continue
             if _jit_internal.is_ignored_fn(item):
-                setattr(script_module, name, item)
+                unbound_function = getattr(type(nn_module), name)
+                bound_method = unbound_function.__get__(script_module)
+                setattr(script_module, name, bound_method)
 
         # For convenience, attach the concrete type to the new ScriptModule
         script_module._concrete_type = concrete_type


### PR DESCRIPTION
Previously we were copying the bound method of the original class to the
new script module class, which causes `self` to be wrong. This PR
changes it so we fetch the unbound function, then bind it to the new
script module, then attach it to the module.

Fixes #28280

Differential Revision: [D21023329](https://our.internmc.facebook.com/intern/diff/21023329/)