### PR TITLE
[caffe2] Add support for std::shared_ptr<std::vector<TensorList>> in PackRecordsOp and UnPackRecordsOp

### DIFF
--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -13,6 +13,7 @@
 #include "caffe2/core/qtensor.h"
 #include "caffe2/core/qtensor_serialization.h"
 #include "caffe2/core/tensor.h"
+#include "caffe2/core/test_utils.h"
 #include "caffe2/core/types.h"
 #include "caffe2/core/workspace.h"
 #include "caffe2/proto/caffe2_pb.h"
@@ -588,6 +589,18 @@ TEST(TensorTest, Tensor64BitDimension) {
 TEST(TensorTest, UndefinedTensor) {
   Tensor x;
   EXPECT_FALSE(x.defined());
+}
+
+TEST(TensorTest, CopyAndAssignment) {
+  Tensor x(CPU);
+  x.Resize(16, 17);
+  testing::randomFill(x.template mutable_data<float>(), 16 * 17);
+  EXPECT_TRUE(x.defined());
+
+  Tensor y(x);
+  Tensor z = x;
+  testing::assertTensorEquals(x, y);
+  testing::assertTensorEquals(x, z);
 }
 
 TEST(TensorDeathTest, CannotCastDownLargeDims) {

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -40,18 +40,12 @@ class CAFFE2_API Tensor final {
  public:
   Tensor() : impl_() {}
 
-  // caffe2::Tensor is explicitly marked as moveable-only because before
-  // the refactoring the class used to be a value type and a lot of user code
-  // is written this way. With PyTorch unification, caffe2::Tensor actually
-  // has semantics of a shared_ptr now (via intrusive_ptr). However, to prevent
-  // accidental mistakes when changing legacy code we keep caffe2::Tensor
-  // to have movable semantics.
-  //
-  // If you need to get a pointer to the same Tensor instance (not to be
-  // confused with shared storage), `UnsafeSharedInstance` can be used. It has
-  // the same behavior as `at::Tensor a = b`.
-  Tensor(const Tensor&) = delete;
-  Tensor& operator=(const Tensor&) = delete;
+  Tensor(const Tensor& t) : impl_(t.impl_) {}
+  Tensor& operator=(const Tensor& t) {
+    impl_ = t.impl_;
+    return *this;
+  }
+
   Tensor(Tensor&&) = default;
   Tensor& operator=(Tensor&&) = default;
 

--- a/caffe2/operators/dataset_ops.cc
+++ b/caffe2/operators/dataset_ops.cc
@@ -14,6 +14,7 @@ namespace caffe2 {
 CAFFE_KNOWN_TYPE(std::unique_ptr<dataset_ops::TreeCursor>);
 CAFFE_KNOWN_TYPE(dataset_ops::TensorVectorPtr);
 CAFFE_KNOWN_TYPE(dataset_ops::SharedTensorVectorPtr);
+CAFFE_KNOWN_TYPE(dataset_ops::Shared2DTensorVectorPtr);
 
 namespace dataset_ops {
 namespace {
@@ -305,7 +306,10 @@ class PackRecordsOp : public Operator<CPUContext> {
   template <class... Args>
   explicit PackRecordsOp(Args&&... args)
       : Operator(std::forward<Args>(args)...),
-        fields_(OperatorBase::GetRepeatedArgument<std::string>("fields")) {}
+        fields_(OperatorBase::GetRepeatedArgument<std::string>("fields")),
+        packToSingleSharedPtr_(OperatorBase::GetSingleArgument<int>(
+            "pack_to_single_shared_ptr",
+            0)) {}
 
   bool RunOnDevice() override {
     // There should be one input per field
@@ -316,26 +320,44 @@ class PackRecordsOp : public Operator<CPUContext> {
 
     TreeWalker walker(Inputs(), cursor);
 
-    Output(0)->Resize(walker.size());
+    if (packToSingleSharedPtr_) {
+      Output(0)->Resize(1);
+      auto* dst = Output(0)->template mutable_data<Shared2DTensorVectorPtr>();
+      dst[0] = std::make_shared<std::vector<std::vector<TensorCPU>>>();
+      dst[0]->resize(walker.size());
 
-    // Output(0)->raw_mutable_data(TypeMeta::Make<SharedTensorVectorPtr>()));
-    auto* dst = Output(0)->template mutable_data<SharedTensorVectorPtr>();
-
-    for (int batchId = 0; batchId < walker.size(); ++batchId) {
-      dst[batchId] = std::make_shared<std::vector<TensorCPU>>();
-      dst[batchId]->reserve(walker.fields().size());
-
-      for (const auto& field : walker.fields()) {
-        dst[batchId]->emplace_back(field.dim(), CPU);
-        auto& tensor = dst[batchId]->back();
-        context_.CopyItemsSameDevice(
-            field.meta(),
-            tensor.numel(),
-            field.ptr() /* src */,
-            tensor.raw_mutable_data(field.meta()) /* dst */);
+      for (int batchId = 0; batchId < walker.size(); ++batchId) {
+        std::vector<TensorCPU>& tensors = dst[0]->at(batchId);
+        tensors.reserve(walker.fields().size());
+        for (const auto& field : walker.fields()) {
+          tensors.emplace_back(field.dim(), CPU);
+          auto& tensor = tensors.back();
+          context_.CopyItemsSameDevice(
+              field.meta(),
+              tensor.numel(),
+              field.ptr() /* src */,
+              tensor.raw_mutable_data(field.meta()) /* dst */);
+        }
+        walker.advance();
       }
+    } else {
+      Output(0)->Resize(walker.size());
+      auto* dst = Output(0)->template mutable_data<SharedTensorVectorPtr>();
 
-      walker.advance();
+      for (int batchId = 0; batchId < walker.size(); ++batchId) {
+        dst[batchId] = std::make_shared<std::vector<TensorCPU>>();
+        dst[batchId]->reserve(walker.fields().size());
+        for (const auto& field : walker.fields()) {
+          dst[batchId]->emplace_back(field.dim(), CPU);
+          auto& tensor = dst[batchId]->back();
+          context_.CopyItemsSameDevice(
+              field.meta(),
+              tensor.numel(),
+              field.ptr() /* src */,
+              tensor.raw_mutable_data(field.meta()) /* dst */);
+        }
+        walker.advance();
+      }
     }
 
     return true;
@@ -343,6 +365,7 @@ class PackRecordsOp : public Operator<CPUContext> {
 
  private:
   std::vector<std::string> fields_;
+  const bool packToSingleSharedPtr_;
 };
 
 class UnPackRecordsOp : public Operator<CPUContext> {
@@ -353,10 +376,26 @@ class UnPackRecordsOp : public Operator<CPUContext> {
         fields_(OperatorBase::GetRepeatedArgument<std::string>("fields")) {}
 
   bool RunOnDevice() override {
-    const auto* inputs = Input(0).template data<SharedTensorVectorPtr>();
-    const auto numRows = Input(0).numel();
+    size_t numRows = 0;
+    Shared2DTensorVectorPtr data_ptr = nullptr;
+    if (Input(0).IsType<SharedTensorVectorPtr>()) {
+      numRows = Input(0).numel();
+      CAFFE_ENFORCE_GE(numRows, 0);
+      data_ptr = std::make_shared<dataset_ops::Tensor2DVector>();
+      data_ptr->reserve(numRows);
 
-    CAFFE_ENFORCE_GE(numRows, 0);
+      const auto* inputs = Input(0).template data<SharedTensorVectorPtr>();
+      for (int i = 0; i < numRows; i++) {
+        data_ptr->emplace_back(*inputs[i]);
+      }
+    } else {
+      CAFFE_ENFORCE_EQ(Input(0).numel(), 1);
+      const auto* inputs = Input(0).template data<Shared2DTensorVectorPtr>();
+      CAFFE_ENFORCE(inputs[0] != nullptr);
+      data_ptr = inputs[0];
+      numRows = inputs[0]->size();
+      CAFFE_ENFORCE_GE(numRows, 0);
+    }
 
     auto numTensors = OutputSize();
 
@@ -370,15 +409,16 @@ class UnPackRecordsOp : public Operator<CPUContext> {
         "undefined state.");
 
     if (InputSize() == 1) {
-      getShapeAndMetaFromInput(outputDims, metas);
+      getShapeAndMetaFromInput(data_ptr, outputDims, metas);
     } else {
       getShapeAndMetaFromPrototypeBlobs(outputDims, metas);
     }
 
+    // inputs contains a single shared_ptr of vector<vector<caffe2::TensorCPU>>
+    auto& tensors = *data_ptr;
     for (int i = 0; i < numRows; ++i) {
-      CAFFE_ENFORCE(inputs[i]);
-      for (int j = 0; j < inputs[i]->size(); ++j) {
-        const auto& input = inputs[i]->at(j);
+      for (int j = 0; j < tensors[i].size(); ++j) {
+        const auto& input = tensors[i][j];
 
         // Checks to ensure that dimensions/sizes match
         CAFFE_ENFORCE_EQ(outputDims[j].size(), input.dim());
@@ -401,7 +441,7 @@ class UnPackRecordsOp : public Operator<CPUContext> {
 
     for (int i = 0; i < numRows; ++i) {
       for (int j = 0; j < numTensors; ++j) {
-        const auto& input = inputs[i]->at(j);
+        const auto& input = tensors[i][j];
 
         context_.CopyItemsSameDevice(
             *metas[j],
@@ -420,22 +460,20 @@ class UnPackRecordsOp : public Operator<CPUContext> {
 
  private:
   void getShapeAndMetaFromInput(
+      const Shared2DTensorVectorPtr& inputs,
       std::vector<std::vector<int64_t>>& outputDims,
       std::vector<const TypeMeta*>& metas) {
-    const auto* inputs = Input(0).template data<SharedTensorVectorPtr>();
+    const auto& inputZero = inputs->at(0);
 
-    const auto& inputZero = inputs[0];
-    CAFFE_ENFORCE(inputZero);
-
-    const auto numTensors = inputZero->size();
+    const auto numTensors = inputZero.size();
 
     CAFFE_ENFORCE_EQ(numTensors, fields_.size());
     CAFFE_ENFORCE_EQ(numTensors, OutputSize());
 
     for (int i = 0; i < numTensors; ++i) {
-      outputDims[i] = inputZero->at(i).sizes().vec();
+      outputDims[i] = inputZero[i].sizes().vec();
       outputDims[i][0] = 0;
-      metas[i] = &inputZero->at(i).dtype();
+      metas[i] = &inputZero[i].dtype();
     }
   }
 

--- a/caffe2/operators/dataset_ops.h
+++ b/caffe2/operators/dataset_ops.h
@@ -191,6 +191,11 @@ class TreeWalker {
 
 using SharedTensorVectorPtr = std::shared_ptr<std::vector<TensorCPU>>;
 
+using Shared2DTensorVectorPtr =
+    std::shared_ptr<std::vector<std::vector<caffe2::TensorCPU>>>;
+
+using Tensor2DVector = std::vector<std::vector<caffe2::TensorCPU>>;
+
 using TensorVectorPtr = std::unique_ptr<std::vector<Tensor>>;
 
 class SharedTensorVectorPtrSerializer : public BlobSerializerBase {

--- a/caffe2/python/operator_test/dataset_ops_test.py
+++ b/caffe2/python/operator_test/dataset_ops_test.py
@@ -172,30 +172,32 @@ class TestDatasetOps(TestCase):
 
         dataset_fields = schema.field_names()
 
-        net = core.Net('pack_unpack_net')
 
-        batch = NewRecord(net, contents)
-        FeedRecord(batch, contents)
+        for pack_to_single_shared_ptr in (True, False):
+            net = core.Net('pack_unpack_net')
+            batch = NewRecord(net, contents)
+            FeedRecord(batch, contents)
 
-        packed = net.PackRecords(
-            batch.field_blobs(), 1,
-            fields=dataset_fields
-        )
-
-        unpacked = packed.UnPackRecords(
-            [], len(dataset_fields),
-            fields=dataset_fields
-        )
-
-        workspace.RunNetOnce(net)
-
-        for initial_tensor, unpacked_tensor in zip(
-            batch.field_blobs(), unpacked
-        ):
-            npt.assert_array_equal(
-                workspace.FetchBlob(initial_tensor),
-                workspace.FetchBlob(unpacked_tensor)
+            packed = net.PackRecords(
+                batch.field_blobs(), 1,
+                fields=dataset_fields,
+                pack_to_single_shared_ptr=pack_to_single_shared_ptr
             )
+
+            unpacked = packed.UnPackRecords(
+                [], len(dataset_fields),
+                fields=dataset_fields
+            )
+
+            workspace.RunNetOnce(net)
+
+            for initial_tensor, unpacked_tensor in zip(
+                batch.field_blobs(), unpacked
+            ):
+                npt.assert_array_equal(
+                    workspace.FetchBlob(initial_tensor),
+                    workspace.FetchBlob(unpacked_tensor)
+                )
 
     def test_dataset_ops(self):
         """


### PR DESCRIPTION
Summary: Separate dataset_ops changes into a separate diff.

Test Plan:
```
buck test caffe2/caffe2/python/operator_test:dataset_ops_test
```

AI/AF canary (tested with D20959214):
https://our.intern.facebook.com/intern/experiment_store/experiment/3298538636995/#commit1-commit2
https://our.intern.facebook.com/intern/experiment_store/experiment/2199027015376/#commit1-commit2

Reviewed By: yinghai

Differential Revision: D20988910

