### PR TITLE
Make dim, numel, element_size into prim ops

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -462,26 +462,7 @@ def gen_jit_dispatch(
                          groupby(sorted_decls, key=lambda decl: decl['name'])]
         return [sorted(g, key=declkey) for g in grouped_decls]
 
-    # We need to add methods implemented manually in TensorImpl
-    # TODO: This seems to claim sizes() returns an int64_t.  Really?
-    tensor_impl_methods = [{
-        'name': name,
-        'api_name': name,
-        'schema_string': schema_string,
-        'overload_name': '',
-        'method_of': ['Tensor'],
-        'arguments': [{'name': 'self', 'simple_type': 'Tensor'}],
-        'returns': [{'name': 'result', 'type': 'int64_t', 'dynamic_type': 'int64_t', 'simple_type': 'int64_t'}],
-        'use_c10_dispatcher': 'unboxed_only',
-    } for name, schema_string in [
-        ('sizes', 'aten::sizes(Tensor self) -> int'),
-        ('strides', 'aten::strides(Tensor self) -> int'),
-        ('dim', 'aten::dim(Tensor self) -> int'),
-        ('numel', 'aten::numel(Tensor self) -> int'),
-        ('element_size', 'aten::element_size(Tensor self) -> int'),
-    ]]
-
-    aten_decls = load_aten_declarations(declarations) + tensor_impl_methods
+    aten_decls = load_aten_declarations(declarations)
     jit_decls = [d for d in aten_decls if is_jit_op(d)]
 
     # add arguments dtype and device for functions like zeros

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -193,25 +193,25 @@ RegisterOperators reg({
     Operator(
         "aten::element_size(Tensor self) -> int",
         [](Stack& stack) {
-            at::Tensor arg = pop(stack).toTensor();
-            push(stack, arg.element_size());
-            return 0;
+          at::Tensor arg = pop(stack).toTensor();
+          push(stack, arg.element_size());
+          return 0;
         },
         aliasAnalysisFromSchema()),
     Operator(
         "aten::numel(Tensor self) -> int",
         [](Stack& stack) {
-            at::Tensor arg = pop(stack).toTensor();
-            push(stack, arg.numel());
-            return 0;
+          at::Tensor arg = pop(stack).toTensor();
+          push(stack, arg.numel());
+          return 0;
         },
         aliasAnalysisFromSchema()),
     Operator(
         "aten::dim(Tensor self) -> int",
         [](Stack& stack) {
-            at::Tensor arg = pop(stack).toTensor();
-            push(stack, arg.dim());
-            return 0;
+          at::Tensor arg = pop(stack).toTensor();
+          push(stack, arg.dim());
+          return 0;
         },
         aliasAnalysisFromSchema()),
     // these ops are generic over the list element type.

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -190,6 +190,30 @@ RegisterOperators reg({
           return 0;
         },
         aliasAnalysisFromSchema()),
+    Operator(
+        "aten::element_size(Tensor self) -> int",
+        [](Stack& stack) {
+            at::Tensor arg = pop(stack).toTensor();
+            push(stack, arg.element_size());
+            return 0;
+        },
+        aliasAnalysisFromSchema()),
+    Operator(
+        "aten::numel(Tensor self) -> int",
+        [](Stack& stack) {
+            at::Tensor arg = pop(stack).toTensor();
+            push(stack, arg.numel());
+            return 0;
+        },
+        aliasAnalysisFromSchema()),
+    Operator(
+        "aten::dim(Tensor self) -> int",
+        [](Stack& stack) {
+            at::Tensor arg = pop(stack).toTensor();
+            push(stack, arg.dim());
+            return 0;
+        },
+        aliasAnalysisFromSchema()),
     // these ops are generic over the list element type.
     // CREATING GENERIC_LIST_OPS
     Operator(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36551 Make dim, numel, element_size into prim ops**

Before, those ops were special cased in the jit codegen but that blocks our unboxing refactoring.
Instead, make those regular prim ops.

Differential Revision: [D21009196](https://our.internmc.facebook.com/intern/diff/D21009196/)