### PR TITLE
[jit] Adding vectorized load/store support for JIT generated CUDA kernel

### DIFF
--- a/torch/csrc/jit/codegen/fuser/codegen.cpp
+++ b/torch/csrc/jit/codegen/fuser/codegen.cpp
@@ -313,6 +313,46 @@ static void emitIndexingFor(
   }
 }
 
+static void emitCheckFor(
+    std::ostream& out,
+    const std::string& tensor,
+    const int ndim,
+    const TensorDesc& desc) {
+  TemplateEnv env;
+  env.s("tensor", tensor);
+  env.s("scalar_type", scalarTypeName(desc.scalar_type));
+
+  // allocate buffer to load 4
+  out << format("${scalar_type} ${tensor}_buf[4];\n", env);
+
+  // check if last dim is contiguous
+  if(!desc.lastIsContiguous()) {
+    out << "flag_vec4 = false;\n";
+    return;
+  }
+
+  // disable on dtype > 4 bytes for performance
+  if( at::elementSize(desc.scalar_type) > 4 ) {
+    out << "flag_vec4 = false;\n";
+    return;
+  }
+
+  // last dim size multiple of 4, other dim stride multiple of 4
+  for (int d = ndim - 1; d >= 0; --d) {
+    env.d("d", d);
+    if(d == ndim-1){
+      // last dim stride already checked above at compile time
+      out << format("if(${tensor}.sizes[${d}] % 4 != 0) flag_vec4 = false;\n", env);
+    } else {
+      out << format("if(${tensor}.strides[${d}] % 4 != 0) flag_vec4 = false;\n", env);
+    }
+  }
+
+  // pointer aligned
+  out << format("if(((uint64_t) ${tensor}.data) % (4 * sizeof(${scalar_type})) != 0) flag_vec4 = false;\n", env);
+}
+
+
 // TODO: handle cases where we need to generate > 2^32 element tensors
 std::string generateKernel(
     const std::string& name,
@@ -327,7 +367,11 @@ std::string generateKernel(
       "IndexType",
       "unsigned int"); // Note: not uint32_t to avoid including cstdint
 
+  std::stringstream tensorChecks;
   std::stringstream body;
+  std::stringstream body_vec4;
+  std::stringstream load;
+  std::stringstream store;
   std::stringstream tensorOffsets;
   std::vector<std::string> formals;
   std::vector<std::string> argument_loads;
@@ -343,6 +387,7 @@ std::string generateKernel(
         c10::to_string(
             formals.size()); // can't be unique() because Param may be an output
     const auto nDim = desc.nDim();
+    emitCheckFor(tensorChecks, tensor, nDim, desc);
     emitIndexingFor(tensorOffsets, tensor, nDim, desc.lastIsContiguous());
     env.s("tensor", tensor);
     env.d("nDim", nDim);
@@ -410,6 +455,9 @@ std::string generateKernel(
         env.s(
             "access",
             format("__half2float(t${formal}.data[t${formal}_offset])", env));
+        env.s(
+            "access_vec4",
+            format("__half2float(t${formal}_buf[i])", env));
         has_half_tensor = true;
       } else if (use_cuda) {
         // No __ldg overload for bool
@@ -420,15 +468,41 @@ std::string generateKernel(
               "access",
               format("__ldg(&t${formal}.data[t${formal}_offset])", env));
         }
+        env.s("access_vec4", format("t${formal}_buf[i]", env));
       } else {
         env.s("access", format("t${formal}.data[t${formal}_offset]", env));
+        env.s("access_vec4", format("t${formal}_buf[i]", env));
       }
       env.s("lhs_type", calcScalarTypeName(input.second.value().scalar_type));
+
+      // load input in vectorized code path
+      auto ele_size = at::elementSize((*input.second).scalar_type);
+      if(ele_size == 1) {
+        env.s("load4",
+              format("*(reinterpret_cast<float*>(t${formal}_buf)) = *(reinterpret_cast<float*>(t${formal}.data + t${formal}_offset))",
+                     env));
+      } else if(ele_size == 2) {
+        env.s("load4",
+              format("*(reinterpret_cast<float2*>(t${formal}_buf)) = *(reinterpret_cast<float2*>(t${formal}.data + t${formal}_offset))",
+                     env));
+      } else if(ele_size == 4) {
+        env.s("load4",
+              format("*(reinterpret_cast<float4*>(t${formal}_buf)) = *(reinterpret_cast<float4*>(t${formal}.data + t${formal}_offset))",
+                     env));
+      } else {
+        env.s("load4",
+              format("for(int i = 0; i<4; i++) t${formal}_buf[i] = t${formal}.data[t${formal}_offset + i]",
+                     env));
+      }
+      load << format("${load4};\n", env);
+
     } else {
       env.s("access", format("s${formal}", env));
+      env.s("access_vec4", format("s${formal}", env));
       env.s("lhs_type", variableType(input.first->type()));
     }
     body << format("${lhs_type} ${node} = ${access};\n", env);
+    body_vec4 << format("${lhs_type} ${node} = ${access_vec4};\n", env);
   }
 
   bool has_random = false;
@@ -475,12 +549,14 @@ std::string generateKernel(
     }
 
     body << format("${lhs_type} ${node} = ${rhs};\n", env);
+    body_vec4 << format("${lhs_type} ${node} = ${rhs};\n", env);
   }
 
   // Generates writes to output tensors
   for (const auto& output : outputs) {
     env.d("formal", formal_count++);
     env.s("access", format("t${formal}.data[t${formal}_offset]", env));
+    env.s("access_vec4", format("t${formal}_buf[i]", env));
     env.s("node", valueName(output.first));
 
     // Acquires and converts (if needed) outputs
@@ -489,10 +565,34 @@ std::string generateKernel(
     if (is_half) {
       AT_ASSERT(use_cuda);
       body << format("${access} = __float2half(${node});\n", env);
+      body_vec4 << format("${access_vec4} = __float2half(${node});\n", env);
       has_half_tensor = true;
     } else {
       body << format("${access} = ${node};\n", env);
+      body_vec4 << format("${access_vec4} = ${node};\n", env);
     }
+
+    // store output in vectorized code path
+    auto ele_size = at::elementSize(output.second.scalar_type);
+    if(ele_size == 1) {
+      env.s("store4",
+            format("*(reinterpret_cast<float*>(t${formal}.data + t${formal}_offset)) = *(reinterpret_cast<float*>(t${formal}_buf))",
+                   env));
+    } else if(ele_size == 2) {
+      env.s("store4",
+            format("*(reinterpret_cast<float2*>(t${formal}.data + t${formal}_offset)) = *(reinterpret_cast<float2*>(t${formal}_buf))",
+                   env));
+    } else if(ele_size == 4) {
+      env.s("store4",
+            format("*(reinterpret_cast<float4*>(t${formal}.data + t${formal}_offset)) = *(reinterpret_cast<float4*>(t${formal}_buf))",
+                   env));
+    } else {
+      env.s("store4",
+            format("for(int i = 0; i<4; i++) t${formal}.data[t${formal}_offset + i] = t${formal}_buf[i]",
+                   env));
+    }
+    store << format("${store4};\n", env);
+
   }
 
   // Includes headers
@@ -515,7 +615,11 @@ std::string generateKernel(
 
   // Instantiates the CUDA or CPU-specific templates
   env.s("tensorOffsets", tensorOffsets.str());
+  env.s("tensorChecks", tensorChecks.str());
   env.s("kernelBody", body.str());
+  env.s("kernelBody_vec4", body_vec4.str());
+  env.s("kernelLoad", load.str());
+  env.s("kernelStore", store.str());
   env.v("formals", formals);
   env.v("argument_loads", argument_loads);
   std::string code_string;

--- a/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
@@ -40,6 +40,7 @@ typedef unsigned char uint8_t;
 typedef signed char int8_t;
 typedef short int  int16_t;
 typedef long long int int64_t;
+typedef unsigned long long int uint64_t;
 ${HalfHeader}
 ${RandHeader}
 
@@ -171,14 +172,35 @@ ${type_declarations}
 extern "C" __global__
 void ${kernelName}(IndexType totalElements, ${formals} ${RandParam}) {
   ${RandInit}
-  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
-        linearIndex < totalElements;
-        linearIndex += gridDim.x * blockDim.x) {
+  // check whether do vectorized load/store and allocate buffer
+  bool flag_vec4 = true;
+  ${tensorChecks}
+  if (flag_vec4) {
+    for (IndexType linearIndex = 4 * (blockIdx.x * blockDim.x + threadIdx.x);
+         linearIndex < totalElements;
+         linearIndex += 4 * gridDim.x * blockDim.x) {
+      // Convert `linearIndex` into an offset of tensor as it is:
+      ${tensorOffsets}
+      // load 4 at a time
+      ${kernelLoad}
+      #pragma unroll 4
+      for (int i=0; i<4; i++) {
+        // calculate the results
+        ${kernelBody_vec4}
+      }
+      // store 4 at a time
+      ${kernelStore}
+    }
+  } else {
+    for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+         linearIndex < totalElements;
+         linearIndex += gridDim.x * blockDim.x) {
       // Convert `linearIndex` into an offset of tensor:
       ${tensorOffsets}
       // calculate the results
       ${kernelBody}
     }
+  }
 }
 )");
 


### PR DESCRIPTION
JIT pointwise kernel currently does not do vectorized load/store, which may lead to not optimal performance in shorter data types, like half and int8.

In this PR, a fixed length of 4 elements per load/store is added for supported tensor shape, implemented as a runtime check inside kernel. 

Supported tensor shape:
- all input/output data point are aligned to 4*sizeof(dtype)
- last dimension contiguous(stride 1) and size is multiple of 4
- all other dimension have stride that is multiple of 4

All test_jit* passed, and here is performance result on a simple `ax+by+c` fusion
result before PR:
```
torch.float32 kernel time: 0.748 ms.
torch.float16 kernel time: 0.423 ms.
torch.int8 kernel time: 0.268 ms.
```
result after PR:
```
torch.float32 kernel time: 0.733 ms.
torch.float16 kernel time: 0.363 ms.
torch.int8 kernel time: 0.191 ms.
```
test code:
```
import torch
import time

# disable profiling to test all data types
torch._C._jit_set_profiling_mode(False)
torch._C._jit_set_profiling_executor(False)

@torch.jit.script
def axpby(x, y):
    return  x * 2 - y * 3 + 1

for test_dtype in [torch.float32, torch.float16, torch.int8]:
    a = torch.randn(12345,4096, device="cuda").to(test_dtype)
    b = torch.randn(12345,4096, device="cuda").to(test_dtype)

    # warm up
    for _ in range(100):
        c = axpby(a,b)

    torch.cuda.synchronize()
    start = time.time()

    for _ in range(1000):
        c = axpby(a,b)

    torch.cuda.synchronize()
    end = time.time()
    print("{} kernel time: {:.3f} ms.".format(test_dtype, end-start))
```
Generated code:
[log_with_generated_code.txt](https://github.com/pytorch/pytorch/files/4472813/log_with_generated_code.txt)

Additional note:
double type is disabled from vectorized code path.

We can later improve it with dynamic vectorization length support and less in-kernel check when we can use tensor shape information in codegen. For now, this implementation is following cache through TensorDesc mechanism, which does not have enough compile time information.
