### PR TITLE
fix discrepancies with 5.1.8

### DIFF
--- a/caffe2/contrib/fakelowp/lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h
@@ -81,15 +81,12 @@ class SparseLengthsFused4BitRowwiseFakeFP16Op final : public Operator<Context> {
     std::vector<float> rowTempSums[2];
     rowTempSums[0].resize(output_block_size);
     rowTempSums[1].resize(output_block_size);
-    std::vector<float> sumWeightedOffsets(2);
 
     const auto scale_bias_offset = 2 * sizeof(at::Half);
     const int64_t input_fused_block_size = input_block_size + scale_bias_offset;
     int64_t current = 0;
     for (int m = 0; m < output_size; ++m) {
       if (!use_fp16_for_embedding_only) {
-        sumWeightedOffsets[0] = 0.0;
-        sumWeightedOffsets[1] = 0.0;
         memset(rowTempSums[0].data(), 0, sizeof(float) * output_block_size);
         memset(rowTempSums[1].data(), 0, sizeof(float) * output_block_size);
       }
@@ -173,43 +170,31 @@ class SparseLengthsFused4BitRowwiseFakeFP16Op final : public Operator<Context> {
         } else {
           std::vector<float> product(output_block_size);
           std::vector<float> scalev(output_block_size, scale);
+          std::vector<float> mBias(output_block_size, bias);
+          std::vector<float> mWeight(output_block_size, weight);
+
+          fake_fp16::fma_fp16(
+              output_block_size,
+              mBias.data(),
+              mWeight.data(),
+              rowTempSums[accIdx].data());
+
           fake_fp16::fma_fp16(
               output_block_size,
               scalev.data(),
               input_rounded.data(),
               rowTempSums[accIdx].data());
-
-          fake_fp16::fma_fp16(1, &weight, &bias, &sumWeightedOffsets[accIdx]);
         }
         ++current;
       }
 
       if (!use_fp16_for_embedding_only) {
-        float totalWeightedOffsets =
-            sumWeightedOffsets[0] + sumWeightedOffsets[1];
-
-        fbgemm::RoundToFloat16(
-            &totalWeightedOffsets,
-            &totalWeightedOffsets,
-            1,
-            FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-
         for (int j = 0; j < output_block_size; ++j) {
           out[j] = rowTempSums[0][j] + rowTempSums[1][j];
         }
         fbgemm::RoundToFloat16(
             reinterpret_cast<const float*>(out),
             out,
-            output_block_size,
-            FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-
-        for (int j = 0; j < output_block_size; j++) {
-          out[j] += totalWeightedOffsets;
-        }
-
-        fbgemm::RoundToFloat16(
-            reinterpret_cast<const float*>(out),
-            reinterpret_cast<float*>(out),
             output_block_size,
             FLAGS_caffe2_fbgemm_fake_fp16_clamp);
       }

--- a/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
@@ -78,7 +78,6 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
     std::vector<float> rowTempSums[2];
     rowTempSums[0].resize(block_size);
     rowTempSums[1].resize(block_size);
-    std::vector<float> sumWeightedOffsets(2);
 
     // block_size is the number of elements and fused_block_size is the size of
     // an entire row, including scale and bias.
@@ -86,8 +85,6 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
     const int64_t fused_block_size = block_size + scale_bias_offset;
     int64_t current = 0;
     for (int m = 0; m < output_size; ++m) {
-      sumWeightedOffsets[0] = 0.0;
-      sumWeightedOffsets[1] = 0.0;
       memset(out, 0, sizeof(float) * block_size);
       memset(rowTempSums[0].data(), 0, sizeof(float) * block_size);
       memset(rowTempSums[1].data(), 0, sizeof(float) * block_size);
@@ -147,9 +144,6 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
               &scale, &scale, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
           fbgemm::RoundToFloat16(
               &bias, &bias, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-        }
-
-        if (!use_fp16_for_embedding_only && !use_acc_fp32) {
           scale *= weight;
           // Fake fp16 rounding of scale and bias
           fbgemm::RoundToFloat16(
@@ -191,14 +185,20 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
 
         } else if (use_nnpi_fma) {
           std::vector<float> mScale(block_size, scale);
+          std::vector<float> mBias(block_size, bias);
+          std::vector<float> mWeight(block_size, weight);
+
+          fake_fp16::fma_fp16(
+              block_size,
+              mBias.data(),
+              mWeight.data(),
+              rowTempSums[accIdx].data());
+
           fake_fp16::fma_fp16(
               block_size,
               mScale.data(),
               input_rounded.data(),
               rowTempSums[accIdx].data());
-
-          fake_fp16::fma_fp16(1, &weight, &bias, &sumWeightedOffsets[accIdx]);
-
         } else if (use_acc_fp16) {
           bias *= weight;
           fbgemm::RoundToFloat16(
@@ -239,11 +239,9 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
               block_size,
               FLAGS_caffe2_fbgemm_fake_fp16_clamp);
         } else if (use_acc_fp32) {
-          bias *= weight;
-          scale *= weight;
           for (int j = 0; j < block_size; ++j) {
-            rowTempSums[accIdx].data()[j] = scale * input_rounded.data()[j] +
-                bias + rowTempSums[accIdx].data()[j];
+            float deqVal = scale * input_rounded[j] + bias;
+            rowTempSums[accIdx][j] += deqVal * weight;
           }
         } else {
           bias *= weight;
@@ -259,21 +257,16 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
         ++current;
       }
 
+      for (int j = 0; j < block_size; ++j) {
+        out[j] = rowTempSums[0][j] + rowTempSums[1][j];
+      }
+
       if (use_nnpi_fma) {
-        for (int j = 0; j < block_size; ++j) {
-          out[j] = rowTempSums[0][j] + rowTempSums[1][j];
-        }
         fbgemm::RoundToFloat16(
             reinterpret_cast<const float*>(out),
             out,
             block_size,
             FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-      }
-
-      if (use_acc_fp32) {
-        for (int j = 0; j < block_size; ++j) {
-          out[j] = rowTempSums[0][j] + rowTempSums[1][j];
-        }
       }
 
       if (normalize_by_length && lengths_data[m]) {
@@ -293,27 +286,6 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
         // hack: context is not really used
         math::Scale<float, float, CPUContext>(
             block_size, scale, out, out, nullptr);
-      }
-
-      // Fake fp16 rounding of out
-      if (use_nnpi_fma) {
-        float totalWeightedOffsets =
-            sumWeightedOffsets[0] + sumWeightedOffsets[1];
-        fbgemm::RoundToFloat16(
-            &totalWeightedOffsets,
-            &totalWeightedOffsets,
-            1,
-            FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-
-        for (int j = 0; j < block_size; j++) {
-          out[j] += totalWeightedOffsets;
-        }
-
-        fbgemm::RoundToFloat16(
-            reinterpret_cast<const float*>(out),
-            reinterpret_cast<float*>(out),
-            block_size,
-            FLAGS_caffe2_fbgemm_fake_fp16_clamp);
       }
 
       out += block_size;

--- a/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
@@ -206,6 +206,7 @@ class SparseLengthsSumTest(TestCase):
             print_test_debug_info(
                 "slws_fused_4bit",
                 {
+                    "seed": seed,
                     "indices": indices,
                     "data": data.shape,
                     "lengths": lengths,


### PR DESCRIPTION
Summary:
- make sls use bias accumulation per row, 8 and 4 bit
- make fp32 accumulation sls match

Test Plan:
everything matches ice-ref
https://our.intern.facebook.com/intern/testinfra/testconsole/testrun/8444249311164278/

dsp has failures
https://our.intern.facebook.com/intern/testinfra/testconsole/testrun/281475136520152/

Differential Revision: D21011920

