### PR TITLE
Move unboxing for aten::backward to after dispatch

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -39,7 +39,6 @@
 
 # Computes the gradient of current tensor w.r.t. graph leaves.
 - func: backward(Tensor self, Tensor? gradient=None, bool keep_graph=False, bool create_graph=False) -> ()
-  use_c10_dispatcher: unboxed_only
   manual_kernel_registration: True
   variants: method
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36566 Move unboxing for aten::backward to after dispatch**
* #36564 Move unboxing for factory ops to after dispatch

-

Differential Revision: [D21014390](https://our.internmc.facebook.com/intern/diff/D21014390/)