### PR TITLE
[JIT] fix torch.tensor jit dtype

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7765,7 +7765,7 @@ a")
                 self.assertEqual(t1, t2)
                 self.assertEqual(t1.device, t2.device)
 
-
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.LEGACY, "Simple Executor doesn't have any shapes to propagate")
     def test_tensor_as_tensor_shape_prop(self):
         tensor_template = dedent('''
         def func():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7892,6 +7892,17 @@ a")
         inp = torch.randn(3, 4)
         self.checkScript(test_as_tensor_tensor_input, (inp,))
 
+    def test_torch_tensor_dtype(self):
+        def foo(s: float):
+            return torch.tensor(s)
+
+        scripted_foo = torch.jit.script(foo)
+        self.assertEqual(scripted_foo(1.).dtype, foo(1.).dtype)
+        saved_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(torch.float32)
+        self.assertEqual(scripted_foo(1.).dtype, foo(1.).dtype)
+        torch.set_default_dtype(saved_dtype)
+
     def test_empty_like_memory_format_bc(self):
         def f(x):
             # type: (Tensor) -> Tensor

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/core/jit_type.h>
 #include <aten/src/ATen/ExpandUtils.h>
+#include <c10/core/DefaultDtype.h>
 #include <torch/csrc/api/include/torch/utils.h>
 #include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -293,7 +294,12 @@ RegisterOperators reg({
           },                                                               \
           aliasAnalysisFromSchema()),
 
-    DEFINE_TORCH_TENSOR_OP(float, double, at::scalar_to_tensor(scalar_val))
+    DEFINE_TORCH_TENSOR_OP(
+        float,
+        double,
+        at::native::scalar_tensor(
+            scalar_val,
+            at::device(at::kCPU).dtype(c10::get_default_dtype())))
         DEFINE_TORCH_TENSOR_OP(int, int64_t, at::scalar_to_tensor(scalar_val))
             DEFINE_TORCH_TENSOR_OP(
                 bool,

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -101,13 +101,45 @@ void storeLastDimension(
   }
 }
 
+void storeLastDimensionFloat(
+    char* data,
+    const std::vector<int64_t>& sizes,
+    const c10::ArrayRef<int64_t>& strides,
+    int64_t dim,
+    int elementSize,
+    at::ArrayRef<IValue> obj) {
+  auto n = sizes[dim];
+  auto seq_size = obj.size();
+  checkSequenceSize(n, dim, seq_size);
+  for (int64_t i = 0; i < n; i++) {
+    *(float*)data = static_cast<float>(obj[i].to<double>());
+    data += strides[dim] * elementSize;
+  }
+}
+
+void storeLastDimensionHalf(
+    char* data,
+    const std::vector<int64_t>& sizes,
+    const c10::ArrayRef<int64_t>& strides,
+    int64_t dim,
+    int elementSize,
+    at::ArrayRef<IValue> obj) {
+  auto n = sizes[dim];
+  auto seq_size = obj.size();
+  checkSequenceSize(n, dim, seq_size);
+  for (int64_t i = 0; i < n; i++) {
+    *(at::Half*)data = at::convert<at::Half, double>(obj[i].to<double>());
+    data += strides[dim] * elementSize;
+  }
+}
+
 // reference python implementation recursive_store in tensor_new.cpp
 void recursiveStore(
     char* data,
     const std::vector<int64_t>& sizes,
     const c10::ArrayRef<int64_t>& strides,
     int64_t dim,
-    int elementSize,
+    int tenElementSize,
     const IValue& obj) {
   auto ndim = sizes.size();
   auto n = sizes[dim];
@@ -115,17 +147,33 @@ void recursiveStore(
   checkSequenceSize(n, dim, seq.size());
   if (dim + 1 < static_cast<long>(ndim)) {
     for (int64_t i = 0; i < n; i++) {
-      recursiveStore(data, sizes, strides, dim + 1, elementSize, seq[i]);
-      data += strides[dim] * elementSize;
+      recursiveStore(data, sizes, strides, dim + 1, tenElementSize, seq[i]);
+      data += strides[dim] * tenElementSize;
     }
   } else {
-    AT_ASSERT(obj.isIntList() || obj.isDoubleList() || obj.isBoolList());
     if (obj.isIntList()) {
-      storeLastDimension<int64_t>(data, sizes, strides, dim, elementSize, seq);
-    } else if (obj.isDoubleList()) {
-      storeLastDimension<double>(data, sizes, strides, dim, elementSize, seq);
-    } else {
+      storeLastDimension<int64_t>(
+          data, sizes, strides, dim, tenElementSize, seq);
+    } else if (obj.isBoolList()) {
       storeLastDimension<bool>(data, sizes, strides, dim, elementSize, seq);
+    } else if (obj.isDoubleList()) {
+      if (tenElementSize ==
+          static_cast<int>(elementSize(at::ScalarType::Double))) {
+        storeLastDimension<double>(
+            data, sizes, strides, dim, tenElementSize, seq);
+      } else if (
+          tenElementSize ==
+          static_cast<int>(elementSize(at::ScalarType::Float))) {
+        storeLastDimensionFloat(data, sizes, strides, dim, tenElementSize, seq);
+      } else if (
+          tenElementSize ==
+          static_cast<int>(elementSize(at::ScalarType::Half))) {
+        storeLastDimensionHalf(data, sizes, strides, dim, tenElementSize, seq);
+      } else {
+        TORCH_INTERNAL_ASSERT(false);
+      }
+    } else {
+      TORCH_INTERNAL_ASSERT(false);
     }
   }
 }
@@ -150,6 +198,9 @@ int createTensorFromList(Stack& stack) {
   auto sizes = compute_sizes(data);
   checkListInputType(elem_type, sizes.size() == 1 && sizes[0] == 0);
   at::ScalarType initial_scalar_type = scalarTypeFromJitType(elem_type);
+  if (initial_scalar_type == at::ScalarType::Double) {
+    initial_scalar_type = typeMetaToScalarType(c10::get_default_dtype());
+  }
 
   auto tensor =
       at::empty(sizes, at::initialTensorOptions().dtype(initial_scalar_type));

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -155,7 +155,7 @@ void recursiveStore(
       storeLastDimension<int64_t>(
           data, sizes, strides, dim, tenElementSize, seq);
     } else if (obj.isBoolList()) {
-      storeLastDimension<bool>(data, sizes, strides, dim, elementSize, seq);
+      storeLastDimension<bool>(data, sizes, strides, dim, tenElementSize, seq);
     } else if (obj.isDoubleList()) {
       if (tenElementSize ==
           static_cast<int>(elementSize(at::ScalarType::Double))) {

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -482,6 +482,12 @@ def freeze_rng_state():
         torch.cuda.set_rng_state(cuda_rng_state)
     torch.set_rng_state(rng_state)
 
+@contextlib.contextmanager
+def set_default_dtype(dtype):
+    saved_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    yield
+    torch.set_default_dtype(saved_dtype)
 
 def iter_indices(tensor):
     if tensor.dim() == 0:


### PR DESCRIPTION
Previously we were always creating a double tensor from `torch.tensor(1.)`, whereas python eager uses the current default dtype. Fix for https://github.com/pytorch/pytorch/issues/36369

