### PR TITLE
Amp gradient accumulation example

### DIFF
--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -121,16 +121,16 @@ Gradient accumulation
 
 Gradient accumulation adds gradients over an effective batch of size ``batch_per_iter * iters_to_accumulate``
 (``* num_procs`` if distributed).  The scale should be calibrated for the effective batch, which means inf/NaN checking,
-step skipping, and scale updates should occur once for each effective batch.  Also, gradients should remain scaled,
-and the scale factor should remain constant, while gradients for a given effective batch are accumulated.
-If gradients are unscaled (or the scale factor changes) before accumulation is complete, the next backward pass will
-add scaled gradients to unscaled gradients (or gradients scaled by a different factor) after which it's impossible to
-recover the accumulated unscaled gradients :meth:`step<step>` must apply.
+step skipping if inf/NaN grads are found, and scale updates should occur at effective-batch granularity.
+Also, grads should remain scaled, and the scale factor should remain constant, while grads for a given effective
+batch are accumulated.  If grads are unscaled (or the scale factor changes) before accumulation is complete,
+the next backward pass will add scaled grads to unscaled grads (or grads scaled by a different factor)
+after which it's impossible to recover the accumulated unscaled grads :meth:`step<step>` must apply.
 
-Therefore, if you want to :meth:`unscale_<unscale_>` gradients (e.g., to allow clipping unscaled gradients),
-call :meth:`unscale_<unscale_>` just before :meth:`step<step>`, after all (scaled) gradients for the upcoming
+Therefore, if you want to :meth:`unscale_<unscale_>` grads (e.g., to allow clipping unscaled grads),
+call :meth:`unscale_<unscale_>` just before :meth:`step<step>`, after all (scaled) grads for the upcoming
 :meth:`step<step>` have been accumulated.  Also, only call :meth:`update<update>` at the end of iterations
-over which the gradients applied in step were accumulated::
+where you called :meth:`step<step>` for a full effective batch::
 
     scaler = GradScaler()
 

--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -129,8 +129,8 @@ recover the accumulated unscaled gradients :meth:`step<step>` must apply.
 
 Therefore, if you want to :meth:`unscale_<unscale_>` gradients (e.g., to allow clipping unscaled gradients),
 call :meth:`unscale_<unscale_>` just before :meth:`step<step>`, after all (scaled) gradients for the upcoming
-:meth:`step<step>` have been accumulated.  Also, only call :meth:`update<update>` at the end of iterations where
-you called :meth:`step<step>`::
+:meth:`step<step>` have been accumulated.  Also, only call :meth:`update<update>` at the end of iterations
+over which the gradients applied in step were accumulated::
 
     scaler = GradScaler()
 

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -53,7 +53,7 @@ class GradScaler(object):
                 scaler.update()
 
     See the :ref:`Automatic Mixed Precision examples<amp-examples>` for usage
-    (along with autocasting) in more complex cases like gradient clipping, gradient penalty,
+    (along with autocasting) in more complex cases like gradient clipping, gradient accumulation, gradient penalty,
     and multiple losses/optimizers.
 
     ``scaler`` dynamically estimates the scale factor each iteration.  To minimize gradient underflow,


### PR DESCRIPTION
Several people have asked me about proper Amp usage with gradient accumulation.  In particular, it's [unclear to people](https://github.com/NVIDIA/apex/issues/439#issuecomment-610351482) that you should only call `scaler.unscale_()` (if desired) and `scaler.update()` in iterations where you actually plan to step.  This PR adds a minimal accumulation example.

I built the docs locally and it looks free from sphinx errors, at least.