### PR TITLE
Synchronize MAGMA functions with the current CUDA stream

### DIFF
--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -138,16 +138,16 @@ template<>
 void magmaSolve<double>(
     magma_int_t n, magma_int_t nrhs, double* dA, magma_int_t ldda,
     magma_int_t* ipiv, double* dB, magma_int_t lddb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dgesv_gpu(n, nrhs, dA, ldda, ipiv, dB, lddb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaSolve<float>(
     magma_int_t n, magma_int_t nrhs, float* dA, magma_int_t ldda,
     magma_int_t* ipiv, float* dB, magma_int_t lddb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_sgesv_gpu(n, nrhs, dA, ldda, ipiv, dB, lddb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -172,16 +172,16 @@ template<>
 void magmaLu<double>(
     magma_int_t m, magma_int_t n, double* dA, magma_int_t ldda,
     magma_int_t* ipiv, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dgetrf_gpu(m, n, dA, ldda, ipiv, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaLu<float>(
     magma_int_t m, magma_int_t n, float* dA, magma_int_t ldda,
     magma_int_t* ipiv, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_sgetrf_gpu(m, n, dA, ldda, ipiv, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -206,16 +206,16 @@ template<>
 void magmaLuNoPiv<double>(
     magma_int_t m, magma_int_t n, double* dA, magma_int_t ldda,
     magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dgetrf_nopiv_gpu(m, n, dA, ldda, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaLuNoPiv<float>(
     magma_int_t m, magma_int_t n, float* dA, magma_int_t ldda,
     magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_sgetrf_nopiv_gpu(m, n, dA, ldda, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -248,16 +248,16 @@ template<>
 void magmaGetri<double>(
     magma_int_t n, double* dA, magma_int_t ldda, magma_int_t* ipiv, double* dwork,
     magma_int_t lwork, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dgetri_gpu(n, dA, ldda, ipiv, dwork, lwork, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaGetri<float>(
     magma_int_t n, float* dA, magma_int_t ldda, magma_int_t* ipiv, float* dwork,
     magma_int_t lwork, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_sgetri_gpu(n, dA, ldda, ipiv, dwork, lwork, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -282,16 +282,16 @@ template<>
 void magmaCholeskySolve<double>(
     magma_uplo_t uplo, magma_int_t n, magma_int_t nrhs, double* dA, magma_int_t ldda,
     double* dB, magma_int_t lddb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dpotrs_gpu(uplo, n, nrhs, dA, ldda, dB, lddb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaCholeskySolve<float>(
     magma_uplo_t uplo, magma_int_t n, magma_int_t nrhs, float* dA, magma_int_t ldda,
     float* dB, magma_int_t lddb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_spotrs_gpu(uplo, n, nrhs, dA, ldda, dB, lddb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -314,16 +314,16 @@ template<>
 void magmaCholesky<double>(
     magma_uplo_t uplo, magma_int_t n, double* dA,
     magma_int_t ldda, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dpotrf_gpu(uplo, n, dA, ldda, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaCholesky<float>(
     magma_uplo_t uplo, magma_int_t n, float* dA,
     magma_int_t ldda, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_spotrf_gpu(uplo, n, dA, ldda, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -346,16 +346,16 @@ template<>
 void magmaTriangularSolve<double>(
     magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
     double* dA, magma_int_t ldda, double* dB, magma_int_t lddb) {
+  MagmaStreamSyncGuard guard;
   magma_dtrsm(MagmaLeft, uplo, trans, diag, m, n, 1, dA, ldda, dB, lddb);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaTriangularSolve<float>(
     magma_uplo_t uplo, magma_trans_t trans, magma_diag_t diag, magma_int_t m, magma_int_t n,
     float* dA, magma_int_t ldda, float* dB, magma_int_t lddb) {
+  MagmaStreamSyncGuard guard;
   magma_strsm(MagmaLeft, uplo, trans, diag, m, n, 1, dA, ldda, dB, lddb);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -390,40 +390,40 @@ template<>
 void magmaGeqrf<double>(
     magma_int_t m, magma_int_t n, double* dA, magma_int_t ldda,
     double* tau, double* dT, magma_int_t* info, bool is_v2) {
+  MagmaStreamSyncGuard guard;
   if (!is_v2) {
     magma_dgeqrf_gpu(m, n, dA, ldda, tau, dT, info);
   } else {
     magma_dgeqrf2_gpu(m, n, dA, ldda, tau, info);
   }
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaGeqrf<float>(
     magma_int_t m, magma_int_t n, float* dA, magma_int_t ldda,
     float* tau, float* dT, magma_int_t* info, bool is_v2) {
+  MagmaStreamSyncGuard guard;
   if (!is_v2) {
     magma_sgeqrf_gpu(m, n, dA, ldda, tau, dT, info);
   } else {
     magma_sgeqrf2_gpu(m, n, dA, ldda, tau, info);
   }
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaOrgqr<double>(
     magma_int_t m, magma_int_t n, magma_int_t k, double* dA, magma_int_t ldda,
     double* tau, double* dT, magma_int_t nb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dorgqr_gpu(m, n, k, dA, ldda, tau, dT, nb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaOrgqr<float>(
     magma_int_t m, magma_int_t n, magma_int_t k, float* dA, magma_int_t ldda,
     float* tau, float* dT, magma_int_t nb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_sorgqr_gpu(m, n, k, dA, ldda, tau, dT, nb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -431,8 +431,8 @@ void magmaSymeig<double>(
     magma_vec_t jobz, magma_uplo_t uplo, magma_int_t n, double* dA, magma_int_t ldda,
     double* w, double* wA, magma_int_t ldwa, double* work, magma_int_t lwork,
     magma_int_t* iwork, magma_int_t liwork, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dsyevd_gpu(jobz, uplo, n, dA, ldda, w, wA, ldwa, work, lwork, iwork, liwork, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -440,8 +440,8 @@ void magmaSymeig<float>(
     magma_vec_t jobz, magma_uplo_t uplo, magma_int_t n, float* dA, magma_int_t ldda,
     float* w, float* wA, magma_int_t ldwa, float* work, magma_int_t lwork,
     magma_int_t* iwork, magma_int_t liwork, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_ssyevd_gpu(jobz, uplo, n, dA, ldda, w, wA, ldwa, work, lwork, iwork, liwork, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -450,8 +450,8 @@ void magmaSvd<double>(
     magma_int_t lda, double* s, double* U, magma_int_t ldu,
     double* VT, magma_int_t ldvt, double* work, magma_int_t lwork,
     magma_int_t* iwork, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dgesdd(jobz, m, n, A, lda, s, U, ldu, VT, ldvt, work, lwork, iwork, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -460,24 +460,24 @@ void magmaSvd<float>(
     magma_int_t lda, float* s, float* U, magma_int_t ldu,
     float* VT, magma_int_t ldvt, float* work, magma_int_t lwork,
     magma_int_t* iwork, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_sgesdd(jobz, m, n, A, lda, s, U, ldu, VT, ldvt, work, lwork, iwork, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaLuSolve<double>(
     magma_int_t n, magma_int_t nrhs, double* dA, magma_int_t ldda, magma_int_t* ipiv,
     double* dB, magma_int_t lddb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_dgetrs_gpu(MagmaNoTrans, n, nrhs, dA, ldda, ipiv, dB, lddb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
 void magmaLuSolve<float>(
     magma_int_t n, magma_int_t nrhs, float* dA, magma_int_t ldda, magma_int_t* ipiv,
     float* dB, magma_int_t lddb, magma_int_t* info) {
+  MagmaStreamSyncGuard guard;
   magma_sgetrs_gpu(MagmaNoTrans, n, nrhs, dA, ldda, ipiv, dB, lddb, info);
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 
@@ -1214,7 +1214,7 @@ AT_ERROR("symeig: MAGMA library not found in "
   magma_int_t liwork = -1;
   magma_int_t iwkopt;
   magmaSymeig<scalar_t>(jobz, uplo, n, self_data, n, eigvals_data, wA, n, &wkopt, lwork, &iwkopt, liwork, &info);
-  
+
   scalar_t* work;
   magma_int_t* iwork;
   lwork = magma_int_cast(wkopt, "work_size");

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -140,6 +140,7 @@ void magmaSolve<double>(
     magma_int_t* ipiv, double* dB, magma_int_t lddb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dgesv_gpu(n, nrhs, dA, ldda, ipiv, dB, lddb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -148,6 +149,7 @@ void magmaSolve<float>(
     magma_int_t* ipiv, float* dB, magma_int_t lddb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_sgesv_gpu(n, nrhs, dA, ldda, ipiv, dB, lddb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -174,6 +176,7 @@ void magmaLu<double>(
     magma_int_t* ipiv, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dgetrf_gpu(m, n, dA, ldda, ipiv, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -182,6 +185,7 @@ void magmaLu<float>(
     magma_int_t* ipiv, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_sgetrf_gpu(m, n, dA, ldda, ipiv, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -208,6 +212,7 @@ void magmaLuNoPiv<double>(
     magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dgetrf_nopiv_gpu(m, n, dA, ldda, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -216,6 +221,7 @@ void magmaLuNoPiv<float>(
     magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_sgetrf_nopiv_gpu(m, n, dA, ldda, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -250,6 +256,7 @@ void magmaGetri<double>(
     magma_int_t lwork, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dgetri_gpu(n, dA, ldda, ipiv, dwork, lwork, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -258,6 +265,7 @@ void magmaGetri<float>(
     magma_int_t lwork, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_sgetri_gpu(n, dA, ldda, ipiv, dwork, lwork, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -284,6 +292,7 @@ void magmaCholeskySolve<double>(
     double* dB, magma_int_t lddb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dpotrs_gpu(uplo, n, nrhs, dA, ldda, dB, lddb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -292,6 +301,7 @@ void magmaCholeskySolve<float>(
     float* dB, magma_int_t lddb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_spotrs_gpu(uplo, n, nrhs, dA, ldda, dB, lddb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -316,6 +326,7 @@ void magmaCholesky<double>(
     magma_int_t ldda, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dpotrf_gpu(uplo, n, dA, ldda, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -324,6 +335,7 @@ void magmaCholesky<float>(
     magma_int_t ldda, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_spotrf_gpu(uplo, n, dA, ldda, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -348,6 +360,7 @@ void magmaTriangularSolve<double>(
     double* dA, magma_int_t ldda, double* dB, magma_int_t lddb) {
   MagmaStreamSyncGuard guard;
   magma_dtrsm(MagmaLeft, uplo, trans, diag, m, n, 1, dA, ldda, dB, lddb);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -356,6 +369,7 @@ void magmaTriangularSolve<float>(
     float* dA, magma_int_t ldda, float* dB, magma_int_t lddb) {
   MagmaStreamSyncGuard guard;
   magma_strsm(MagmaLeft, uplo, trans, diag, m, n, 1, dA, ldda, dB, lddb);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -396,6 +410,7 @@ void magmaGeqrf<double>(
   } else {
     magma_dgeqrf2_gpu(m, n, dA, ldda, tau, info);
   }
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -408,6 +423,7 @@ void magmaGeqrf<float>(
   } else {
     magma_sgeqrf2_gpu(m, n, dA, ldda, tau, info);
   }
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -416,6 +432,7 @@ void magmaOrgqr<double>(
     double* tau, double* dT, magma_int_t nb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dorgqr_gpu(m, n, k, dA, ldda, tau, dT, nb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -424,6 +441,7 @@ void magmaOrgqr<float>(
     float* tau, float* dT, magma_int_t nb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_sorgqr_gpu(m, n, k, dA, ldda, tau, dT, nb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -433,6 +451,7 @@ void magmaSymeig<double>(
     magma_int_t* iwork, magma_int_t liwork, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dsyevd_gpu(jobz, uplo, n, dA, ldda, w, wA, ldwa, work, lwork, iwork, liwork, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -442,6 +461,7 @@ void magmaSymeig<float>(
     magma_int_t* iwork, magma_int_t liwork, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_ssyevd_gpu(jobz, uplo, n, dA, ldda, w, wA, ldwa, work, lwork, iwork, liwork, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -452,6 +472,7 @@ void magmaSvd<double>(
     magma_int_t* iwork, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dgesdd(jobz, m, n, A, lda, s, U, ldu, VT, ldvt, work, lwork, iwork, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -462,6 +483,7 @@ void magmaSvd<float>(
     magma_int_t* iwork, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_sgesdd(jobz, m, n, A, lda, s, U, ldu, VT, ldvt, work, lwork, iwork, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -470,6 +492,7 @@ void magmaLuSolve<double>(
     double* dB, magma_int_t lddb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_dgetrs_gpu(MagmaNoTrans, n, nrhs, dA, ldda, ipiv, dB, lddb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 template<>
@@ -478,6 +501,7 @@ void magmaLuSolve<float>(
     float* dB, magma_int_t lddb, magma_int_t* info) {
   MagmaStreamSyncGuard guard;
   magma_sgetrs_gpu(MagmaNoTrans, n, nrhs, dA, ldda, ipiv, dB, lddb, info);
+  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 

--- a/aten/src/ATen/native/cuda/MiscUtils.h
+++ b/aten/src/ATen/native/cuda/MiscUtils.h
@@ -59,14 +59,15 @@ static inline magma_int_t magma_int_cast(int64_t value, const char* varname) {
 struct MagmaStreamSyncGuard {
   MagmaStreamSyncGuard() {
     auto stream = at::cuda::getCurrentCUDAStream();
-    if (stream != 0) {
+    if (stream != at::cuda::getDefaultCUDAStream()) {
       AT_CUDA_CHECK(cudaStreamSynchronize(stream));
     }
   }
 
   ~MagmaStreamSyncGuard() noexcept(false) {
-    if (at::cuda::getCurrentCUDAStream() != 0) {
-      AT_CUDA_CHECK(cudaStreamSynchronize(0));
+    auto default_stream = at::cuda::getDefaultCUDAStream();
+    if (at::cuda::getCurrentCUDAStream() != default_stream) {
+      AT_CUDA_CHECK(cudaStreamSynchronize(default_stream));
     }
   }
 };

--- a/aten/src/ATen/native/cuda/MiscUtils.h
+++ b/aten/src/ATen/native/cuda/MiscUtils.h
@@ -65,9 +65,7 @@ struct MagmaStreamSyncGuard {
   }
 
   ~MagmaStreamSyncGuard() noexcept(false) {
-    if (at::cuda::getCurrentCUDAStream() == 0) {
-      AT_CUDA_CHECK(cudaGetLastError());
-    } else {
+    if (at::cuda::getCurrentCUDAStream() != 0) {
       AT_CUDA_CHECK(cudaStreamSynchronize(0));
     }
   }

--- a/aten/src/THC/THCTensorMathMagma.cu
+++ b/aten/src/THC/THCTensorMathMagma.cu
@@ -5,6 +5,7 @@
 #include <THC/THCTensor.hpp>
 #include <THC/THCStorage.hpp>
 #include <algorithm>
+#include <ATen/native/cuda/MiscUtils.h>
 
 #ifdef USE_MAGMA
 #include <magma.h>


### PR DESCRIPTION
Fixes #21821

This follows @ngimel's [suggestion](https://github.com/pytorch/pytorch/issues/21821#issuecomment-502968982) to manually synchronize MAGMA calls with the current stream. This is handled automatically with `MagmaStreamSyncGuard`. 

I think for the functions with `_batched` variants we could possibly avoid synchronisation by using a batch of size 1 since these have a `magma_queue_t` argument. However, I presume there's a reason it wasn't written like that in the first place.

I also figured out why porting to aten ["magically fixed"](https://github.com/pytorch/pytorch/issues/21821#issuecomment-527647971) `torch.svd`. The magma functions for svd all take host arrays as input and output. The ATen port uses blocking `copy_`s which fully synchronize the operation. On the other hand, the THC functions use `cudaMemcpy` which doesn't synchronize with streams created with `cudaStreamNonBlocking` (which `aten` does). The fix is to use `cudaMemcpyAsync` and `cudaStreamSynchronize`, the same as `copy_` does internally:
https://github.com/pytorch/pytorch/blob/835ee34e38eed3f5b35726b40be9c48e75201618/aten/src/ATen/native/cuda/Copy.cu#L192-L193

I'm not sure how to test these changes as I wasn't able to reproduce any of the stream sync issues. Possibly a mixture of non-determinism and because some of these functions are implicitly synchronous anyway.