### PR TITLE
Respect CMAKE_SHARED_LINKER_FLAGS on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ set(OP_DEPENDENCY "" CACHE STRING
 # symbol lookup error: miniconda3/envs/pytorch-py3.7/lib/libmkl_intel_lp64.so: undefined symbol: mkl_blas_dsyrk
 # https://software.intel.com/en-us/articles/symbol-lookup-error-when-linking-intel-mkl-with-gcc-on-ubuntu
 if(LINUX)
-  set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-as-needed")
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Currently cmake build overwrites user defined `CMAKE_SHARED_LINKER_FLAGS` on Linux.
```
if(LINUX)
  set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")
```

Other linker flags such as `CMAKE_EXE_LINKER_FLAGS` and `CMAKE_MODULE_LINKER_FLAGS` work differently. Cmake does not overwrite them but appends new values to user defined flags, e.g.
```
set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s")
set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${CAFFE2_ASAN_FLAG}")
```

This PR fixes `CMAKE_SHARED_LINKER_FLAGS`. Instead of overwriting the values are appended to the flag.
```
if(LINUX)
  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-as-needed")
```
