### PR TITLE
Switch xla job to use bionic clang9 image

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -21,11 +21,6 @@ CONFIG_TREE_DATA = [
             ("5", [
                 XImportant("3.6"),  # This is actually the ASAN build
             ]),
-            ("7", [
-                ("3.6", [
-                    ("xla", [XImportant(True)]),
-                ]),
-            ]),
         ]),
         ("cuda", [
             ("9", [
@@ -55,6 +50,15 @@ CONFIG_TREE_DATA = [
                     ("android_abi", [X("arm-v7a")]),
                     ("android_abi", [X("arm-v8a")]),
                 ])
+            ]),
+        ]),
+    ]),
+    ("bionic", [
+        ("clang", [
+            ("9", [
+                ("3.6", [
+                    ("xla", [XImportant(True)]),
+                ]),
             ]),
         ]),
     ]),
@@ -100,6 +104,7 @@ class DistroConfigNode(TreeConfigNode):
 
         next_nodes = {
             "xenial": XenialCompilerConfigNode,
+            "bionic": BionicCompilerConfigNode,
         }
         return next_nodes[distro]
 
@@ -204,8 +209,28 @@ class XenialCompilerConfigNode(TreeConfigNode):
 
         return XenialCompilerVersionConfigNode if self.props["compiler_name"] else PyVerConfigNode
 
+class BionicCompilerConfigNode(TreeConfigNode):
+
+    def modify_label(self, label):
+        return label or "<unspecified>"
+
+    def init2(self, node_name):
+        self.props["compiler_name"] = node_name
+
+    # noinspection PyMethodMayBeStatic
+    def child_constructor(self):
+
+        return BionicCompilerVersionConfigNode if self.props["compiler_name"] else PyVerConfigNode
 
 class XenialCompilerVersionConfigNode(TreeConfigNode):
+    def init2(self, node_name):
+        self.props["compiler_version"] = node_name
+
+    # noinspection PyMethodMayBeStatic
+    def child_constructor(self):
+        return PyVerConfigNode
+
+class BionicCompilerVersionConfigNode(TreeConfigNode):
     def init2(self, node_name):
         self.props["compiler_version"] = node_name
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2146,20 +2146,6 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59"
           resource_class: large
       - pytorch_linux_build:
-          name: pytorch_xla_linux_xenial_py3_6_clang7_build
-          requires:
-            - setup
-          build_environment: "pytorch-xla-linux-xenial-py3.6-clang7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59"
-      - pytorch_linux_test:
-          name: pytorch_xla_linux_xenial_py3_6_clang7_test
-          requires:
-            - setup
-            - pytorch_xla_linux_xenial_py3_6_clang7_build
-          build_environment: "pytorch-xla-linux-xenial-py3.6-clang7-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59"
-          resource_class: large
-      - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_cudnn7_py3_build
           requires:
             - setup
@@ -2386,6 +2372,20 @@ workflows:
                 - /release\/.*/
           build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v8a-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59"
+      - pytorch_linux_build:
+          name: pytorch_xla_linux_bionic_py3_6_clang9_build
+          requires:
+            - setup
+          build_environment: "pytorch-xla-linux-bionic-py3.6-clang9-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9:8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59"
+      - pytorch_linux_test:
+          name: pytorch_xla_linux_bionic_py3_6_clang9_test
+          requires:
+            - setup
+            - pytorch_xla_linux_bionic_py3_6_clang9_build
+          build_environment: "pytorch-xla-linux-bionic-py3.6-clang9-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9:8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59"
+          resource_class: large
       # Warning: indentation here matters!
 
       # Pytorch MacOS builds

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -169,15 +169,17 @@ if [[ "$BUILD_ENVIRONMENT" == *ppc64le* ]]; then
   export TORCH_CUDA_ARCH_LIST="6.0"
 fi
 
+if [[ "${BUILD_ENVIRONMENT}" == *clang* ]]; then
+  export CC=clang
+  export CXX=clang++
+fi
+
 # Patch required to build xla
 if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   git clone --recursive https://github.com/pytorch/xla.git
   ./xla/scripts/apply_patches.sh
-fi
-
-if [[ "${BUILD_ENVIRONMENT}" == *clang* ]]; then
-  export CC=clang
-  export CXX=clang++
+  # PyTorch doesn't build with clang9 yet. So we use system default gcc for it
+  unset CC CXX
 fi
 
 if [[ "$BUILD_ENVIRONMENT" == *-bazel-* ]]; then
@@ -254,18 +256,8 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
 
   pip_install lark-parser
 
-  # Bazel doesn't work with sccache gcc. https://github.com/bazelbuild/bazel/issues/3642
-  sudo add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   sudo apt-get -qq update
-
-  # Install clang-8 clang++-8 for xla
-  sudo apt-get -qq install clang-8 clang++-8
-
-  sudo apt-get -qq install npm
-  npm config set strict-ssl false
-  curl -sL --retry 3 https://deb.nodesource.com/setup_6.x | sudo -E bash -
-  sudo apt-get install -qq nodejs
+  sudo apt-get -qq install npm nodejs
 
   # XLA build requires Bazel
   # We use bazelisk to avoid updating Bazel version manually.
@@ -282,7 +274,7 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
 
   bazels3cache --bucket=${XLA_CLANG_CACHE_S3_BUCKET_NAME} --maxEntrySizeBytes=0
   pushd xla
-  export CC=clang-8 CXX=clang++-8
+  export CC=clang-9 CXX=clang++-9
   # Use cloud cache to build when available.
   sed -i '/bazel build/ a --remote_http_cache=http://localhost:7777 \\' build_torch_xla_libs.sh
 

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -139,22 +139,17 @@ else
 fi
 
 # Use conda cmake in some CI build. Conda cmake will be newer than our supported
-# min version 3.5, so we only do it in two builds that we know should use conda.
-if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda* ]]; then
-  if [[ "$BUILD_ENVIRONMENT" == *cuda9-cudnn7-py2* ]] || \
-     [[ "$BUILD_ENVIRONMENT" == *cuda10.1-cudnn7-py3* ]]; then
-    if ! which conda; then
-      echo "Expected ${BUILD_ENVIRONMENT} to use conda, but 'which conda' returns empty"
-      exit 1
-    else
-      conda install -q -y cmake
-    fi
+# min version (3.5 for xenial and 3.10 for bionic),
+# so we only do it in three builds that we know should use conda.
+# Linux bionic cannot find conda mkl with cmake 3.10, so we need a newer cmake from conda.
+if [[ "$BUILD_ENVIRONMENT" == *pytorch-xla-linux-bionic* ]] || \
+   [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda9-cudnn7-py2* ]] || \
+   [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda10.1-cudnn7-py3* ]]; then
+  if ! which conda; then
+    echo "Expected ${BUILD_ENVIRONMENT} to use conda, but 'which conda' returns empty"
+    exit 1
   else
-    if ! cmake --version | grep 'cmake version 3\.5'; then
-      echo "Expected ${BUILD_ENVIRONMENT} to have cmake version 3.5.* (min support version), but 'cmake --version' returns:"
-      cmake --version
-      exit 1
-    fi
+    conda install -q -y cmake
   fi
 fi
 

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -244,7 +244,7 @@ test_xla() {
 
   echo "Running C++ Tests"
   pushd test/cpp
-  CC=clang-7 CXX=clang++-7 ./run_tests.sh
+  CC=clang-9 CXX=clang++-9 ./run_tests.sh
   popd
   assert_git_not_dirty
 }


### PR DESCRIPTION
XLA need to switch to clang9 to build with latest TF dependency. 
We keep pytorch/pytorch build remain using gcc for now. 