### PR TITLE
Fixed error Regex Parsing for Node Failure Tests

### DIFF
--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -126,7 +126,7 @@ def wait_until_node_failure(rank, expected_error_regex=".*"):
             rpc.rpc_sync("worker{}".format(rank), noop, args=())
             time.sleep(0.1)
         except Exception as e:
-            if re.match(pattern=expected_error_regex, string=str(e)):
+            if re.search(pattern=expected_error_regex, string=str(e)):
                 return str(e)
 
 # Shutdown sequence is not well defined, so we may see any of the following errors
@@ -137,7 +137,13 @@ def get_shutdown_error_regex(rpc_backend):
     is used to match against possible errors to ensure failures were raised properly.
     """
     if rpc_backend == "PROCESS_GROUP":
-        error_regexes = ["Encountered exception in ProcessGroupAgent::enqueueSend"]
+        error_regexes = [
+            "Encountered exception in ProcessGroupAgent::enqueueSend",
+            "Encountered exception in ProcessGroupAgent::listenLoop()",
+            "Exception in thread pool task",
+            "Connection reset by peer",
+            "Connection closed by peer"
+        ]
     else:
         error_regexes = [
             "Request aborted during client shutdown",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36620 Fixed error Regex Parsing for Node Failure Tests**
* #35263 Fix for test_backward_node_failure: Error Handling in RPC Agent

Sending to a node that has been shutdown in ProcessGroupAgent could throw several possible exceptions. This PR updates the tests to check for the right exceptions while waiting for other nodes in the gang to fail in `test_backward_node_failure` and `test_backward_node_failure_python_udf`.

Differential Revision: [D21027280](https://our.internmc.facebook.com/intern/diff/D21027280/)