### PR TITLE
Preserve references to buffers when doing module.apply_

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4837,8 +4837,10 @@ class NewCriterionTest(InputVariableMixin, CriterionTest):
         try:
             cpu_input = self._get_input()
             cpu_target = self._get_target()
+            # don't implicitly share arguments between modules
+            args_copy = deepcopy(self.constructor_args)
             cpu_module = self.constructor(*self.constructor_args)
-            gpu_module = self.constructor(*self.constructor_args)
+            gpu_module = self.constructor(*args_copy)
 
             # Convert input, target and module parameters to dtype
             if dtype is not None:


### PR DESCRIPTION
Currently, if one moves a module between devices or casts to a different datatype, by default the references to parameters will be preserved, but references to buffers won't be. This PR makes handling of parameters and buffers consistent. 