### PR TITLE
[TensorExpr] fix a bug in LLVM codegen around empty kernels

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -267,6 +267,8 @@ namespace jit {
   _(LLVMBindDynamicShapeAdd)               \
   _(LLVMTensorDynamicShapeAdd)             \
   _(LLVMDynamicShape2D)                    \
+  _(LLVMEmptyStmt)                         \
+  _(LLVMEliminatedStmt)                    \
   _(LLVMIfThenElseTest)                    \
   _(LLVMVectorizerLoadStoreTest)
 

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -40,7 +40,7 @@ class LLVMCodeGenImpl : public IRVisitor {
   std::unique_ptr<llvm::Module> module_;
   llvm::Function* fn_;
   llvm::BasicBlock* bb_;
-  llvm::Value* value_;
+  llvm::Value* value_{nullptr};
   llvm::JITTargetAddress kernelAddress_;
 
 #define LLVM_TYPE_DECLARE(_1, Name) llvm::Type* Name##Ty_;
@@ -324,6 +324,12 @@ void LLVMCodeGenImpl::emitKernel(
 
   // Compile the kernel.
   stmt->accept(this);
+
+  // If the kernel is empty, set a default return value.
+  if (value_ == nullptr) {
+    value_ = llvm::ConstantInt::get(IntTy_, 0);
+  }
+
   irb_.CreateRet(value_);
 
 #if DEBUG_PRINT


### PR DESCRIPTION
LLVM Codegen assumes that the kernel contains real statements, but that is not guaranteed, especially after IR Simplification. This PR adds a catch for the case where no value is generated after recursing the LLVMCodegen visitor through the kernel.