### PR TITLE
Remove prim::CudaFusionGroup from register_prim_ops_fulljit.cpp: it is registered in jit/codegen/cuda/interface.cpp.

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -37,17 +37,6 @@ RegisterOperators reg(
          },
          aliasAnalysisSpecialCase()),
      Operator(
-         prim::CudaFusionGroup,
-         [](const Node* node) -> Operation {
-           const auto key = registerFusion(node);
-           return [key](Stack& stack) {
-             RECORD_FUNCTION("CudaFusionGroup", std::vector<c10::IValue>());
-             runFusion(key, stack);
-             return 0;
-           };
-         },
-         aliasAnalysisSpecialCase()),
-     Operator(
          prim::FusionGroup,
          [](const Node* node) -> Operation {
            const auto key = registerFusion(node);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36661 Remove prim::CudaFusionGroup from register_prim_ops_fulljit.cpp: it is registered in jit/codegen/cuda/interface.cpp.**

Differential Revision: [D21044112](https://our.internmc.facebook.com/intern/diff/D21044112)