### PR TITLE
[jit] Add return statement back to Future::addCallback()

### DIFF
--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -124,6 +124,7 @@ class TORCH_API Future final {
     if (completed_) {
       lock.unlock();
       cb();
+      return;
     }
     callbacks_.emplace_back(std::move(cb));
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36662 [jit] Add return statement back to Future::addCallback()**

This was a mistake from an earlier change, though the expected impact is
relatively minimal - mostly keeping callback around longer than necessary
in the case of callbacks already-completed futures.

Differential Revision: [D21044145](https://our.internmc.facebook.com/intern/diff/D21044145/)