### PR TITLE
Backward-compatible workaround for ATenOp index with dtype=uint8

### DIFF
--- a/caffe2/contrib/aten/aten_op.cc
+++ b/caffe2/contrib/aten/aten_op.cc
@@ -3,6 +3,21 @@
 
 namespace caffe2 {
 
+namespace internal {
+at::Tensor index_with_uint8_handling(
+    const at::Tensor& self,
+    at::TensorList indices) {
+  // Support BC only for the simplest case of mask indexing
+  if (indices.size() == 1 && indices[0].scalar_type() == at::kByte) {
+    TORCH_WARN(
+        "Indexing with uint8 mask tensor in ATenOp is now deprecated,"
+        " please use a bool mask instead.");
+    return at::index(self, {indices[0].to(at::kBool)});
+  }
+  return at::index(self, indices);
+}
+} // namespace internal
+
 REGISTER_CPU_OPERATOR(ATen, ATenOp<CPUContext>);
 template <>
 at::Backend ATenOp<CPUContext>::backend() const {

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -17,6 +17,12 @@ namespace caffe2 {
 
 using at::Half; // for AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, ...)
 
+namespace internal {
+CAFFE2_API at::Tensor index_with_uint8_handling(
+    const at::Tensor& self,
+    at::TensorList indices);
+}
+
 template <class Context>
 class ATenOp : public Operator<Context> {
  public:

--- a/caffe2/contrib/aten/aten_test.py
+++ b/caffe2/contrib/aten/aten_test.py
@@ -77,6 +77,23 @@ class TestATen(hu.HypothesisTestCase):
         self.assertReferenceChecks(gc, op, inputs, ref)
 
     @given(**hu.gcs)
+    def test_index_uint8(self, gc, dc):
+        # Indexing with uint8 is deprecated, but we need to provide backward compatibility for some old models exported through ONNX
+        op = core.CreateOperator(
+            "ATen",
+            ['self', 'mask'],
+            ["Z"],
+            operator="index")
+
+        def ref(self, mask):
+            return (self[mask.astype(np.bool)],)
+
+        tensor = np.random.randn(2, 3, 4).astype(np.float32)
+        mask = np.array([[1, 0, 0], [1, 1, 0]]).astype(np.uint8)
+
+        self.assertReferenceChecks(gc, op, [tensor, mask], ref)
+
+    @given(**hu.gcs)
     def test_index_put(self, gc, dc):
         op = core.CreateOperator(
             "ATen",

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -93,6 +93,12 @@ ARGUMENT_MAP = {
     'std::array<bool,3>': 'auto ${arg} = readBoolMask<3>("${arg}");',
 }
 
+# for BC reasons we want to route some of the functions to different
+# implementations
+SPECIAL_IMPLEMENTATIONS = {
+    'index': 'internal::index_with_uint8_handling',
+}
+
 def expand(o):
     num_defaults = sum(1 if 'default' in arg else 0 for arg in o['arguments'])
     results = [o]
@@ -287,7 +293,9 @@ if __name__ == '__main__':
 
         emit_assignments(o, env)
 
-        if 'namespace' in o['method_of']:
+        if o['name'] in SPECIAL_IMPLEMENTATIONS:
+            env['invocation'] = "{}({})".format(SPECIAL_IMPLEMENTATIONS[o['name']], ','.join(env['arguments']))
+        elif 'namespace' in o['method_of']:
             env['invocation'] = CT("at::${name}(${arguments})").substitute(env)
         else:
             assert('Tensor' in o['method_of'])


### PR DESCRIPTION
Summary:
Hacky workaround that would allow us to reland https://github.com/pytorch/pytorch/pull/34418

Basically moves the type conversion into ATenOp wrapper that is still used in some models.

Test Plan: Added unittest. Before it was producing warnings about wrong dtype, with this fix it doesn't

Differential Revision: D21037368

