### PR TITLE
Fix out-of-boundary access in `caffe2::StartsWith`

### DIFF
--- a/caffe2/utils/string_utils.h
+++ b/caffe2/utils/string_utils.h
@@ -18,7 +18,8 @@ CAFFE2_API size_t editDistance(
   const std::string& s1, const std::string& s2, size_t max_distance = 0);
 
 CAFFE2_API inline bool StartsWith(const std::string& str, const std::string& prefix) {
-  return std::mismatch(prefix.begin(), prefix.end(), str.begin()).first ==
+  return str.length() >= prefix.length() &&
+    std::mismatch(prefix.begin(), prefix.end(), str.begin()).first ==
       prefix.end();
 }
 


### PR DESCRIPTION
`std::mismatch( InputIt1 first1, InputIt1 last1, InputIt2 first2 )` assumes that container for `first2` iterator contains at least `last1 - first` elements, which is not the case if `prefix` is longer than `str`
Found while running unit tests on Windows

