### PR TITLE
Make futures vector a local function var

### DIFF
--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -304,11 +304,6 @@ class TORCH_API RpcAgent {
         std::chrono::steady_clock::now() + timedelta);
   }
 
-  // storing futures before adding callback
-  std::vector<
-      std::pair<std::shared_ptr<FutureMessage>, std::shared_ptr<RpcRetryInfo>>>
-      futures;
-
   // Condition Variable to signal when the rpcRetryMap_ has been populated.
   std::condition_variable rpcRetryMapCV_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36677 Make futures vector a local function var**

Move the `futures` vector to be a local function var like `errorFutures`. Holding the lock to clear the vector is now unnecessary.

Differential Revision: [D20884589](https://our.internmc.facebook.com/intern/diff/D20884589/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D20884589/)!