### PR TITLE
[PyTorch Docs] Updated RRef docs to indicate RPC Retries

### DIFF
--- a/docs/source/rpc/rref.rst
+++ b/docs/source/rpc/rref.rst
@@ -39,7 +39,7 @@ Assumptions
 
 RRef protocol is designed with the following assumptions.
 
-- **Transient Network Failures**: The RRef design aims to handle transient
+- **Transient Network Failures**: The RRef design handles transient
   network failures by retrying messages. Node crashes or permanent network
   partition is beyond the scope. When those incidents occur, the application
   may take down all workers, revert to the previous checkpoint, and resume
@@ -48,8 +48,8 @@ RRef protocol is designed with the following assumptions.
   :meth:`~torch.distributed.rpc.rpc_sync`,
   :meth:`~torch.distributed.rpc.rpc_async` or
   :meth:`~torch.distributed.rpc.remote` are not idempotent and therefore
-  cannot be retried. However, internal RRef control messages will be made
-  idempotent and retryable.
+  cannot be retried. However, internal RRef control messages are idempotent and
+  retried upon message failure.
 - **Out of Order Message Delivery**: We do not assume message delivery order
   between any pair of nodes, because both sender and receiver are using multiple
   threads. There is no guarantee on which message will be processed first.

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -73,7 +73,7 @@ struct TORCH_API RRefForkData {
 //
 // TODO: current RRef implementation does not tolerate failures
 //
-// The RRef design aims to handle transient network failures by retrying
+// The RRef design handles transient network failures by retrying
 // messages. Node crashes or permanent network partition is beyond the scope.
 // When those incidents occur, the application may take down all workers, revert
 // to the previous checkpoint, and resume training.
@@ -81,7 +81,8 @@ struct TORCH_API RRefForkData {
 // 2. Non-idempotent UDFs
 //
 // We assume UDFs are not idempotent and therefore cannot be retried. However,
-// internal RRef control messages will be made idempotent and retryable.
+// internal RRef control messages are idempotent and retried upon message
+// failure.
 //
 // TODO: RRef internal messages are not yet idempotent
 //


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36678 [PyTorch Docs] Updated RRef docs to indicate RPC Retries**

Updated the docs to explicitly indicate that RRef control messages are
idempotent and retried upon failure.

Differential Revision: [D20828041](https://our.internmc.facebook.com/intern/diff/D20828041/)