### PR TITLE
[v1.5.0] [CI] fix test_distributed for python 3.8+ (#36542)

### DIFF
--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -4,6 +4,7 @@ import errno
 import fcntl
 import multiprocessing
 import os
+import six
 import sys
 import time
 import tempfile
@@ -2097,7 +2098,18 @@ if BACKEND == "gloo" or BACKEND == "nccl":
         def _spawn_process(self, rank):
             os.environ["RANK"] = str(rank)
             name = "process " + str(rank)
-            process = multiprocessing.Process(target=self._run, name=name, args=(rank,))
+            # TODO: test_distributed.py test suite does not work with spawn
+            # mode, so we enforce fork mode for now. In the long term, we should
+            # enable spawn mode and refactor this suite to inherit from
+            # common_distributed.MultiProcessTestCase.
+            if six.PY3:
+                # Note: explicitly specifying fork, as spawn is the default in
+                # py3.8+ on macos.
+                proc_handler = multiprocessing.get_context("fork").Process
+            else:
+                # fork is the default on Python 2
+                proc_handler = multiprocessing.Process
+            process = proc_handler(target=self._run, name=name, args=(rank,))
             process.start()
             return process
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -222,6 +222,7 @@ class MultiProcessTestCase(TestCase):
         if six.PY3:
             proc = torch.multiprocessing.get_context("fork").Process
         else:
+            # fork is the default on Python 2
             proc = torch.multiprocessing.Process
         self._start_processes(proc)
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/36542

Python 3.8 set the default multiprocessing start mode to spawn, but we
need fork in these tests, otherwise there are some pickling issues.
Test: Ensure that these tests succeed when run with python 3.8
ghstack-source-id: 102093824

Test Plan: Ensure success with python 3.8

Differential Revision: D21007753

fbshipit-source-id: 4b39844c6ba76a53293c0dfde7c98ec5a78fe113

