### PR TITLE
[quant][graph] Add quantized batch_norm2d support to graph mode

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1390,6 +1390,22 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                    .check("quantized::cat") \
                    .run(m.graph_for(data, data))
 
+    def test_qbatch_norm(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.bn = torch.nn.BatchNorm2d(3).to(torch.float)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        data = [(torch.rand((1, 3, 10, 10), dtype=torch.float), torch.randint(0, 1, (1,), dtype=torch.long)) for _ in range(2)]
+        model = self._test_op_impl(M, data, "quantized::batch_norm2d")
+
+        FileCheck().check_not("aten::batch_norm") \
+                   .run(model.graph)
+
+
     def test_swap_dequantize_all_ops(self):
         """ A test that checks dequantize will be swapped for
         all supported general ops without actually checking for execution of these ops

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -50,6 +50,7 @@ struct PatternsAndModules {
 std::vector<std::string> _quantizable_call_funcs = {
     "conv2d",
     "linear",
+    "batch_norm",
 };
 
 std::vector<std::string> _quantizable_aten_funcs = {
@@ -134,7 +135,7 @@ using CallFuncArgs = std::vector<FuncArg>;
 // For each operator in this list observers are inserted for the input based
 // on the index specified.
 AtenFuncArgs _observe_inputs_aten_func = {};
-CallFuncArgs _observe_inputs_call_func = {};
+CallFuncArgs _observe_inputs_call_func = {{"batch_norm", 1}};
 
 void fillQConfigMap(
     const Module& module,

--- a/torch/csrc/jit/passes/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization_patterns.h
@@ -226,6 +226,18 @@ graph(%a_quant, %b_scalar, %alpha):
          %r = quantized::add_scalar_relu_out(%a_quant, %b_scalar, %a_quant)
          return (%r) )";
 
+  // quantized::batch_norm
+  std::string batch_norm2d = R"(
+graph(%a_quant, %weight, %bias, %mean, %var, %training, %eaf, %eps, %7, %scale, %zero_point, %scalar_type):
+         %a_dequant = aten::dequantize(%a_quant)
+         %r_bn = aten::batch_norm(%a_dequant, %weight, %bias, %mean, %var, %training, %eaf, %eps, %7)
+         %r = aten::quantize_per_tensor(%r_bn, %scale, %zero_point, %scalar_type)
+         return (%r) )";
+  std::string quantized_batch_norm2d = R"(
+graph(%a_quant, %weight, %bias, %mean, %var, %training, %eaf, %eps, %7, %scale, %zero_point, %scalar_type):
+         %r = quantized::batch_norm2d(%a_quant, %weight, %bias, %mean, %var, %eps, %scale, %zero_point)
+         return (%r) )";
+
   return {
       {"quantized::conv2d", conv2d, quantized_conv2d},
       {"quantized::conv3d", conv3d, quantized_conv3d},
@@ -254,6 +266,7 @@ graph(%a_quant, %b_scalar, %alpha):
        quantized_add_scalar_out,
        add_scalar_filter},
       {"quantized::cat", cat, quantized_cat},
+      {"quantized::batch_norm2d", batch_norm2d, quantized_batch_norm2d},
   };
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36622 [quant][graph] Graph mode quantization support for sigmoid
* #36552 [quant][graph] Add quantized batch_norm2d_relu to graph mode
* **#36692 [quant][graph] Add quantized batch_norm2d support to graph mode**
* #36691 [quant][graph] Add useQuantizable function

Summary:

Test Plan:
python test_quantize_script.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21055596](https://our.internmc.facebook.com/intern/diff/D21055596)