### PR TITLE
Add Sphinx to requirements for docs build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ pyyaml
 requests
 setuptools
 six
+sphinx==1.8
+javasphinx
+sphinxcontrib-katex
+git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
Current `requirements.txt` lacks dependencies for documentation build and https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md#building-documentation doesn't mention that we need Sphinx and contrib to build.

The reason the version of sphinx is specified is that `javasphinx` uses a module that the latest stable `Sphinx` doesn't have. I found 1.8 works by chance.