### PR TITLE
fix an infininte loop in liveness

### DIFF
--- a/torch/csrc/jit/passes/liveness.cpp
+++ b/torch/csrc/jit/passes/liveness.cpp
@@ -14,6 +14,9 @@ struct LivenessAnalyzer {
       : graph_(std::move(graph)), changed_(false) {}
 
   std::unordered_map<Node*, std::vector<Value*>> run() {
+    std::vector<Node*> counters;
+    insertExplicitUsesOfLoopCounters(graph_->block(), counters);
+
     // we implement the canonical fixed-point liveness
     // the analysis is run until there are no more changes
     // to liveness sets for each node
@@ -22,12 +25,42 @@ struct LivenessAnalyzer {
       processBlock(graph_->block(), SparseBitVector{});
     } while (changed_);
 
+    removeCounterNodes(counters);
     std::unordered_map<Node*, std::vector<Value*>> result;
 
     for (const auto& e : liveness_sets_) {
       result.insert({e.first, toValueVector(e.second)});
     }
     return result;
+  }
+
+  // temporary make loop counts live for the duration of the loop
+  // as they are needed by BailOuts in the loop
+  void insertExplicitUsesOfLoopCounters(
+      Block* b,
+      std::vector<Node*>& counters) {
+    for (auto it : b->nodes()) {
+      if (it->kind() == prim::Loop) {
+        LoopView lv(it);
+        WithInsertPoint guard(lv.bodyBlock());
+        auto ctc = graph_->create(prim::Store, {lv.currentTripCount()}, 0);
+        graph_->insertNode(ctc);
+        counters.push_back(ctc);
+        auto mtc = graph_->create(prim::Store, {lv.maxTripCount()}, 0);
+        graph_->insertNode(mtc);
+        counters.push_back(mtc);
+      }
+
+      for (auto ib : it->blocks()) {
+        insertExplicitUsesOfLoopCounters(ib, counters);
+      }
+    }
+  }
+
+  void removeCounterNodes(std::vector<Node*>& counters) {
+    for (auto n : counters) {
+      n->destroy();
+    }
   }
 
   void dump(
@@ -93,19 +126,7 @@ struct LivenessAnalyzer {
         // N.B. merge in changes from the loop header
         auto loop_header = *lv.bodyBlock()->nodes().begin();
         auto loop_block = liveness | liveness_sets_[loop_header];
-        // loop's outputs aren't live inside the loop
-        // loop's block outputs, OTOH, will be considered
-        // as uses
-        WithInsertPoint guard(*lv.bodyBlock()->nodes().end());
-        // temporary make loop counts live for the duration of the loop
-        // as they are needed by BailOuts in the loop
-        auto ctc = graph_->create(prim::Store, {lv.currentTripCount()}, 0);
-        graph_->insertNode(ctc);
-        auto mtc = graph_->create(prim::Store, {lv.maxTripCount()}, 0);
-        graph_->insertNode(mtc);
         loop_block = processBlock(lv.bodyBlock(), loop_block);
-        ctc->destroy();
-        mtc->destroy();
         // loop block's inputs die outside loop's block
         loop_block -= toSparseBitVector(lv.bodyBlock()->inputs());
         liveness |= loop_block;


### PR DESCRIPTION
This should fix https://github.com/pytorch/pytorch/issues/36434 

We create new nodes to insert explicit uses of loop counters while doing liveness analysis. This was totally fine when we had a two-pass liveness (since we don't really care about liveness sets for those nodes), but with the fixed-point algorithm we can *never* achieve the fixed point because the initial liveness sets for these new nodes start empty and we always add some live values to those sets thus `changed_` is always set `true`.
Now it's amazing that this didn't get exposed and worked for such a long time! Apparently, when we destroyed and recreated those new nodes they were allocated at the exact same addresses in the memory!!!!!! And we use those addresses as keys to get liveness sets, so these new nodes **inherited** the liveness sets 🤦 
I was still a bit sceptical of this explanation, so I added more tracing to liveness analysis and AFAICT this is exactly how we were able to get away with this bug for such a long time!!!

Here's a few excerpts from the trace.

Before we enter a loop we create a node to use loop's upper bound.

```
[DEBUG liveness.cpp:121] @#$Creating a store for mtc : 0x555777c19eb0
```

When processing the loop, we also process this node. Its liveness sets are empty!
```
[DEBUG liveness.cpp:099] Processing node  = prim::Store(%3) addr = 0x555777c19eb0
[DEBUG liveness.cpp:148] @#$liveness_sets_[it] : {}
```

We are done with this loop. We remove the node we added
```
[DEBUG liveness.cpp:127] @#$Destroying a store for ctc : 0x555777c19eb0
```

We are about to process the loop for the second time, so we create the use node again.
Note, it's allocated at the exact same address!!!
```
[DEBUG liveness.cpp:118] @#$Creating a store for ctc : 0x555777c19eb0
```

Now we process it again. But now it has non-empty sets even though it's a brand new node!!!!

```
[DEBUG liveness.cpp:099] Processing node  = prim::Store(%i) addr = 0x555777c19eb0
[DEBUG liveness.cpp:148] @#$liveness_sets_[it] : {2, 3, 10}
```