### PR TITLE
bypass `getDeviceFromPtr` check when device is known

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -195,12 +195,12 @@ Tensor fromDLPack(const DLManagedTensor* src) {
         deleter,
         at::device(device).dtype(stype));
   }
-
   return at::from_blob(
       src->dl_tensor.data,
       IntArrayRef(src->dl_tensor.shape, src->dl_tensor.ndim),
       IntArrayRef(src->dl_tensor.strides, src->dl_tensor.ndim),
       deleter,
-      at::device(device).dtype(stype));
+      at::device(device).dtype(stype),
+      { device });
 }
 } // namespace at

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -26,9 +26,11 @@ inline Tensor from_blob(
     IntArrayRef sizes,
     IntArrayRef strides,
     const std::function<void(void*)>& deleter,
-    const TensorOptions& options = {}) {
+    const TensorOptions& options = {},
+    const c10::optional<Device> target_device = c10::nullopt) {
   AutoNonVariableTypeMode guard;
-  auto device = globalContext().getDeviceFromPtr(data, options.device().type());
+  auto device = (target_device.has_value()?
+    target_device.value() : globalContext().getDeviceFromPtr(data, options.device().type()));
   if (options.device().has_index()) {
     TORCH_CHECK(
         options.device() == device,

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -83,6 +83,11 @@ void THCudaInit(THCState* state)
       MIN_GLOBAL_SCRATCH_SPACE_PER_DEVICE :
       numSM * MIN_GLOBAL_SCRATCH_SPACE_PER_SM_STREAM;
     res->scratchSpacePerStream = sizePerStream;
+
+    /* Force device initialization, in some scenarios such as using external
+       allocated memory, not having a completely initialized cuda context
+       may produce unexpected errors*/
+    THCudaCheck(cudaFree(0));
   }
 
   /* Restore to previous device */

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -83,11 +83,6 @@ void THCudaInit(THCState* state)
       MIN_GLOBAL_SCRATCH_SPACE_PER_DEVICE :
       numSM * MIN_GLOBAL_SCRATCH_SPACE_PER_SM_STREAM;
     res->scratchSpacePerStream = sizePerStream;
-
-    /* Force device initialization, in some scenarios such as using external
-       allocated memory, not having a completely initialized cuda context
-       may produce unexpected errors*/
-    THCudaCheck(cudaFree(0));
   }
 
   /* Restore to previous device */


### PR DESCRIPTION
Fixes #36594 

In some cases, when using memory that was allocated in another process before doing any memory-related operation in PyTorch, there are errors because the GPU CUDA context is not completely initialized. 

I guess there is an explicit reason to leave the context not initialized at first, and don't do it in `THCudaInit` where other CUDA calls are going on.
I'd like to discuss it in this PR. 

Possible better solutions are
Initialize the device context in `fromDLPack` or `from_blob`, probably by creating some dummy array with one element. But this feels like a hack.

Another possibility is to catch the exception in `getDeviceFromPtr`, check if the context was initialized, and if not repeat this operation. but we will need to check for every device. 

This PR bypasses the `getDeviceFromPtr` call which is the one causing the problem if we already know the device. This allows us to create the Tensor from the shared memory storage but the context will not be initialized. However, it will be when the tensor is accessed later.