### PR TITLE
fixes #36671 : Handle __rdiv__ for complex dtype

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16336,6 +16336,15 @@ class TestViewOps(TestCase):
             v[0, 0] = idx + 1
             self.assertEqual(t[idx, 0], v[0, 0])
 
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    @dtypes(torch.complex64, torch.complex128)
+    @onlyCPU  # "reciprocal_cuda" not implemented for 'Complex{Float/Double}'
+    def test_rdiv_complex(self, device, dtype):
+        # Reference: https://github.com/pytorch/pytorch/pull/36726
+        x = torch.randn(1, device=device, dtype=dtype)
+        x_np = x.numpy()
+        rand_num = random.random() * 10
+        self.assertEqual(rand_num / x, torch.from_numpy(rand_num / x_np))
 
 # Below are fixtures and functions that generate tensor op comparison tests
 # These tests run a single op on both a CPU and device tensor and compare the

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15633,6 +15633,16 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         test_output_dtype(torch.int32, False)
         test_output_dtype(torch.int64, True)
 
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    @dtypes(torch.complex64, torch.complex128)
+    @onlyCPU  # "reciprocal_cuda" not implemented for 'Complex{Float/Double}'
+    def test_rdiv_complex(self, device, dtype):
+        # Reference: https://github.com/pytorch/pytorch/pull/36726
+        x = torch.randn(1, device=device, dtype=dtype)
+        x_np = x.numpy()
+        rand_num = random.random() * 10
+        self.assertEqual(rand_num / x, torch.from_numpy(rand_num / x_np))
+
 
 # NOTE [Linspace+Logspace precision override]
 # Our Linspace and logspace torch.half CUDA kernels are not very precise.
@@ -16335,16 +16345,6 @@ class TestViewOps(TestCase):
 
             v[0, 0] = idx + 1
             self.assertEqual(t[idx, 0], v[0, 0])
-
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    @dtypes(torch.complex64, torch.complex128)
-    @onlyCPU  # "reciprocal_cuda" not implemented for 'Complex{Float/Double}'
-    def test_rdiv_complex(self, device, dtype):
-        # Reference: https://github.com/pytorch/pytorch/pull/36726
-        x = torch.randn(1, device=device, dtype=dtype)
-        x_np = x.numpy()
-        rand_num = random.random() * 10
-        self.assertEqual(rand_num / x, torch.from_numpy(rand_num / x_np))
 
 # Below are fixtures and functions that generate tensor op comparison tests
 # These tests run a single op on both a CPU and device tensor and compare the

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -405,6 +405,8 @@ class Tensor(torch._C._TensorBase):
     def __rdiv__(self, other):
         if self.dtype.is_floating_point:
             return self.reciprocal() * other
+        elif self.is_complex():
+            return (self.reciprocal() * other).type_as(self)
         else:
             return (self.double().reciprocal() * other).type_as(self)
 


### PR DESCRIPTION
Closes #36671 