### PR TITLE
[V1.5 Patch][Doc-Only] Move rpc.rst back to the source folder to preserve existing doc URLs

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -9,7 +9,8 @@ higher-level API to automatically differentiate models split across several
 machines.
 
 .. warning ::
-     APIs in the RPC package are stable. There are multiple ongoing work items to improve performance and error handling, which will ship in future releases.
+     APIs in the RPC package are stable. There are multiple ongoing work items 
+     to improve performance and error handling, which will ship in future releases.
 
 
 Basics


### PR DESCRIPTION
This is a PR to merge #36675 into the 1.5 release. It moves `rpc.rst` back to `docs/source` from `docs/source/rpc/` to make sure existing URLs to docs still work. #36675 is landed into master at 049dede.

---- Original Commit Description Follows ----

Move rpc.rst back to the source folder to preserve existing doc URLs (#36675)

Summary: Pull Request resolved: #36675

Test Plan: Imported from OSS

Differential Revision: D21048628

Pulled By: mrshenli

fbshipit-source-id: 3cb1b35ddc1f40c673b0db9048d77dfa024be1e7

