### PR TITLE
Handle log_sigmoid(out=) properly.

### DIFF
--- a/aten/src/ATen/native/LegacyNNDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyNNDefinitions.cpp
@@ -31,15 +31,6 @@ Tensor nll_loss2d(const Tensor & self, const Tensor & target, const Tensor & wei
   return std::get<0>(at::nll_loss2d_forward(self, target, weight, reduction, ignore_index));
 }
 
-Tensor & log_sigmoid_out(Tensor & output, const Tensor & self) {
-  Tensor buffer = at::empty({0}, self.options());
-  return std::get<0>(at::log_sigmoid_forward_out(output, buffer, self));
-}
-
-Tensor log_sigmoid(const Tensor & self) {
-  return std::get<0>(at::log_sigmoid_forward(self));
-}
-
 Tensor & thnn_conv2d_out(Tensor & output, const Tensor & self, const Tensor & weight, IntArrayRef kernel_size, const Tensor & bias, IntArrayRef stride, IntArrayRef padding) {
   Tensor finput = at::empty({0}, self.options());
   Tensor fgrad_input = at::empty({0}, self.options());

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10938,6 +10938,17 @@ class TestNNDeviceType(NNTestCase):
             gradcheck(func, [x])
             gradgradcheck(func, [x])
 
+    def test_logsigmoid_out(self, device):
+        # this isn't actually documented, but was broken previously:
+        # https://github.com/pytorch/pytorch/issues/36499
+        x = torch.randn(2, 3, device=device).t()
+        empty_out = torch.randn(0, device=device)
+        self.assertEqual(F.logsigmoid(x), F.logsigmoid(x, out=empty_out))
+
+        noncontig_out = torch.randn(2, 3, device=device).t()
+        self.assertEqual(F.logsigmoid(x), F.logsigmoid(x, out=noncontig_out))
+
+
 instantiate_device_type_tests(TestNNDeviceType, globals())
 
 if __name__ == '__main__':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36736 Handle log_sigmoid(out=) properly.**

Fixes: https://github.com/pytorch/pytorch/issues/36499

Changes:
1) Moves some bindings from LegacyNNDefinitions to Activation so all of log_sigmoid lives together
2) Properly handle non-contiguous / incorrectly sized out parameters to log_sigmoid.  This is done by copying from a buffer if necessary.
3) Require that the internal buffer (different from 2)) is contiguous.  This should always be the case because it's always created internally.
4) Adds a test

Differential Revision: [D21070934](https://our.internmc.facebook.com/intern/diff/D21070934)