### PR TITLE
Enable jit trace check_trace for quantized inputs

### DIFF
--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -131,12 +131,7 @@ class QuantizationTestCase(TestCase):
         self._checkScriptable(orig_mod, scripted, calib_data, check_save_load)
 
         # Use first calib_data entry as trace input
-        #
-        # TODO: Trace checking is blocked on this issue:
-        # https://github.com/pytorch/pytorch/issues/23986
-        #
-        # Once that's resolved we can remove `check_trace=False`
-        traced = torch.jit.trace(orig_mod, calib_data[0][0], check_trace=False)
+        traced = torch.jit.trace(orig_mod, calib_data[0][0])
         self._checkScriptable(orig_mod, traced, calib_data, check_save_load)
 
     # Call this twice: once for a scripted module and once for a traced module


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36740 Enable jit trace check_trace for quantized inputs**

Summary:
Issue #23986

Test Plan:
python test/quantization/test_quantized_nn_mods.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21077551](https://our.internmc.facebook.com/intern/diff/D21077551)