### PR TITLE
[autograd] lower MAX_DEPTH limit according to TSAN limit

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -508,6 +508,9 @@ TEST(CustomAutogradTest, Reentrant) {
   ASSERT_VARIABLE_EQ(x.grad(), y_data);
 }
 
+
+// NOTE: If this fails for apparently unrelated reasons in TSAN be aware of 
+// the TSAN limit on mutex: https://github.com/google/sanitizers/issues/95
 TEST(CustomAutogradTest, DeepReentrant) {
   struct DeepReenter : public Function<DeepReenter> {
     static Variable forward(AutogradContext *ctx, Variable x) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -215,8 +215,7 @@ bool ReadyQueue::empty() const {
   return heap_.empty();
 }
 
-// This limit is based on the default python recursion limit which is 1000
-Engine::Engine() : max_recursion_depth_(100), non_reentrant_device_thread_count_(0) {}
+Engine::Engine() : max_recursion_depth_(MAX_DEPTH), non_reentrant_device_thread_count_(0) {}
 
 // Send shutdown tasks to all device_ready_queues_ if no backward tasks are running
 // Even though readyQueue should be empty, shutdown tasks have the highest priority

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -37,6 +37,14 @@ void validate_outputs(
 static constexpr int NO_DEVICE = -2;
 static constexpr int CPU_DEVICE = -1;
 
+// Maximum reentrant backward depth before switching to a new thread
+// This limit is based on the TSAN's deadlock detector, where it will
+// fail if a program hold more than 65 locks in one thread at once.
+// As we hold mutex in every of our custom C++ autograd Node, we would
+// like to avoid TSAN complains on this when doing reentrant backwards
+// For reference, see https://github.com/google/sanitizers/issues/950
+static constexpr int MAX_DEPTH = 60;
+
 // GraphTask holds metadata needed for a single execution of backward()
 struct GraphTask {
   std::atomic<uint64_t> outstanding_tasks_{0};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36745 [autograd] lower MAX_DEPTH limit according to TSAN limit**

As we hold a mutex for our custom C++ Node, when calling reentrant
backward from custom C++ function, we will cocurrently holding many
mutexes up to MAX_DEPTH. TSAN only allow 65 mutexes at once, otherwise
it will complain. This PR lower the limit according to TSAN.

TSAN Reference: https://github.com/google/sanitizers/issues/950

Differential Revision: [D21072604](https://our.internmc.facebook.com/intern/diff/D21072604)