### PR TITLE
add complex support to `reciprocal_cuda` kernel

### DIFF
--- a/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
@@ -66,13 +66,13 @@ template<typename T>
 __host__ __device__ static inline thrust::complex<T> reciprocal_wrapper(thrust::complex<T> v) {
   // Handle extreme cases for numpy compatibility
   auto both_inf = [](T real, T imag) {
-    return (std::isinf(real) && std::isinf(imag));
+    return (::isinf(real) && ::isinf(imag));
   };
 
-  if (std::isnan(v.real()) || std::isnan(v.imag()) || both_inf(v.real(), v.imag())) {
+  if (::isnan(v.real()) || ::isnan(v.imag()) || both_inf(v.real(), v.imag())) {
     // If either is Nan or both are infinite, return {nan, nan}
     return {std::numeric_limits<T>::quiet_NaN(), std::numeric_limits<T>::quiet_NaN()};
-  } else if (std::isinf(v.real()) || std::isinf(v.imag())) {
+  } else if (::isinf(v.real()) || ::isinf(v.imag())) {
     // If either is Inf, return {0, 0}
     return {0, 0};
   }

--- a/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
@@ -64,6 +64,18 @@ __host__ __device__ static inline scalar_t reciprocal_wrapper(scalar_t a) {
 
 template<typename T>
 __host__ __device__ static inline thrust::complex<T> reciprocal_wrapper(thrust::complex<T> v) {
+  // Handle extreme cases for numpy compatibility
+  auto both_inf = [](T real, T imag) {
+    return (std::isinf(real) && std::isinf(imag));
+  };
+
+  if (std::isnan(v.real()) || std::isnan(v.imag()) || both_inf(v.real(), v.imag())) {
+    // If either is Nan or both are infinite, return {nan, nan}
+    return {std::numeric_limits<T>::quiet_NaN(), std::numeric_limits<T>::quiet_NaN()};
+  } else if (std::isinf(v.real()) || std::isinf(v.imag())) {
+    // If either is Inf, return {0, 0}
+    return {0, 0};
+  }
   const thrust::complex<T> one = thrust::complex<T>(1.0, 0);
   return one/v;
 }

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -1,7 +1,6 @@
 import math
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_NUMPY
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU
 import unittest
 
 if TEST_NUMPY:
@@ -11,16 +10,13 @@ devices = (torch.device('cpu'), torch.device('cuda:0'))
 
 
 class TestComplexTensor(TestCase):
-
-    @onlyCPU
-    def test_to_list_with_complex_64(self, device):
+    def test_to_list_with_complex_64(self):
         # test that the complex float tensor has expected values and
         # there's no garbage value in the resultant list
         self.assertEqual(torch.zeros((2, 2), dtype=torch.complex64).tolist(), [[0j, 0j], [0j, 0j]])
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    @onlyCPU
-    def test_exp(self, device):
+    def test_exp(self):
         def exp_fn(dtype):
             a = torch.tensor(1j, dtype=dtype) * torch.arange(18) / 3 * math.pi
             expected = np.exp(a.numpy())
@@ -30,15 +26,12 @@ class TestComplexTensor(TestCase):
         exp_fn(torch.complex64)
         exp_fn(torch.complex128)
 
-    @onlyCPU
-    def test_copy_real_imag_methods(self, device):
+    def test_copy_real_imag_methods(self):
         real = torch.randn(4)
         imag = torch.randn(4)
         complex_tensor = real + 1j * imag
         self.assertEqual(complex_tensor.copy_real(), real)
         self.assertEqual(complex_tensor.copy_imag(), imag)
-
-instantiate_device_type_tests(TestComplexTensor, globals())
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -1,4 +1,3 @@
-import itertools
 import math
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_NUMPY

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -1,3 +1,4 @@
+import itertools
 import math
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_NUMPY
@@ -25,6 +26,22 @@ class TestComplexTensor(TestCase):
 
         exp_fn(torch.complex64)
         exp_fn(torch.complex128)
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_reciprocal(self):
+        def reciprocal_fn(device, dtype):
+            x = torch.randn(10, 10, dtype=dtype, device=device)
+            if device != 'cpu':
+                expected = np.reciprocal(x.cpu().numpy())
+            else:
+                expected = np.reciprocal(x.numpy())
+            actual = torch.reciprocal(x)
+            self.assertEqual(actual, torch.from_numpy(expected))
+
+        dtypes_to_test = [torch.complex64, torch.complex128]
+        for (device, dtype) in itertools.product(devices, dtypes_to_test):
+            reciprocal_fn(device, dtype)
+            reciprocal_fn(device, dtype)
 
     def test_copy_real_imag_methods(self):
         real = torch.randn(4)

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -2,6 +2,7 @@ import itertools
 import math
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_NUMPY
+from torch.testing._internal.common_device_type import instantiate_device_type_tests, onlyCPU
 import unittest
 
 if TEST_NUMPY:
@@ -11,13 +12,16 @@ devices = (torch.device('cpu'), torch.device('cuda:0'))
 
 
 class TestComplexTensor(TestCase):
-    def test_to_list_with_complex_64(self):
+
+    @onlyCPU
+    def test_to_list_with_complex_64(self, device):
         # test that the complex float tensor has expected values and
         # there's no garbage value in the resultant list
         self.assertEqual(torch.zeros((2, 2), dtype=torch.complex64).tolist(), [[0j, 0j], [0j, 0j]])
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_exp(self):
+    @onlyCPU
+    def test_exp(self, device):
         def exp_fn(dtype):
             a = torch.tensor(1j, dtype=dtype) * torch.arange(18) / 3 * math.pi
             expected = np.exp(a.numpy())
@@ -28,7 +32,7 @@ class TestComplexTensor(TestCase):
         exp_fn(torch.complex128)
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_reciprocal(self):
+    def test_reciprocal(self, device):
         def reciprocal_fn(device, dtype):
             x = torch.randn(10, 10, dtype=dtype, device=device)
             if device != 'cpu':
@@ -38,17 +42,18 @@ class TestComplexTensor(TestCase):
             actual = torch.reciprocal(x)
             self.assertEqual(actual, torch.from_numpy(expected))
 
-        dtypes_to_test = [torch.complex64, torch.complex128]
-        for (device, dtype) in itertools.product(devices, dtypes_to_test):
-            reciprocal_fn(device, dtype)
-            reciprocal_fn(device, dtype)
+        reciprocal_fn(device, torch.complex64)
+        reciprocal_fn(device, torch.complex128)
 
-    def test_copy_real_imag_methods(self):
+    @onlyCPU
+    def test_copy_real_imag_methods(self, device):
         real = torch.randn(4)
         imag = torch.randn(4)
         complex_tensor = real + 1j * imag
         self.assertEqual(complex_tensor.copy_real(), real)
         self.assertEqual(complex_tensor.copy_imag(), imag)
+
+instantiate_device_type_tests(TestComplexTensor, globals())
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -30,20 +30,6 @@ class TestComplexTensor(TestCase):
         exp_fn(torch.complex64)
         exp_fn(torch.complex128)
 
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_reciprocal(self, device):
-        def reciprocal_fn(device, dtype):
-            x = torch.randn(10, 10, dtype=dtype, device=device)
-            if device != 'cpu':
-                expected = np.reciprocal(x.cpu().numpy())
-            else:
-                expected = np.reciprocal(x.numpy())
-            actual = torch.reciprocal(x)
-            self.assertEqual(actual, torch.from_numpy(expected))
-
-        reciprocal_fn(device, torch.complex64)
-        reciprocal_fn(device, torch.complex128)
-
     @onlyCPU
     def test_copy_real_imag_methods(self, device):
         real = torch.randn(4)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5960,7 +5960,6 @@ class TestTorchDeviceType(TestCase):
 
         t = torch.tensor(vals, device=device, dtype=dtype)
         torch_result = torch_fn(t).cpu()
-        print(np_result, torch_result)
         self.assertEqual(np_result, torch_result)
 
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5960,7 +5960,7 @@ class TestTorchDeviceType(TestCase):
 
         t = torch.tensor(vals, device=device, dtype=dtype)
         torch_result = torch_fn(t).cpu()
-
+        print(np_result, torch_result)
         self.assertEqual(np_result, torch_result)
 
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
@@ -15117,6 +15117,44 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         res_reciprocal = a.clone()
         res_reciprocal.reciprocal_()
         self.assertEqual(res_reciprocal, res_div)
+
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    @dtypes(torch.float, torch.double, torch.complex64, torch.complex128)
+    def test_reciprocal_complex(self, device, dtype):
+        t = torch.randn(10, 10, dtype=dtype, device=device)
+        expected = torch.from_numpy(np.reciprocal(t.cpu().numpy()))
+        actual = torch.reciprocal(t).cpu()
+        self.assertEqual(expected, actual)
+
+    @onlyCUDA
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    @dtypes(torch.complex64, torch.complex128)
+    def test_reciprocal_complex_extremal(self, device, dtype):
+        vals = (
+            # Inf and Zeros
+            complex(float('inf'), float('inf')), 
+            complex(float('inf'), 0.),
+            complex(0., float('inf')),
+            complex(0., 0.),
+
+            # Nans and Zeros
+            complex(float('nan'), 0.),
+            complex(0., float('nan')),
+            complex(float('nan'), float('nan')),
+
+            # Inf and Nans
+            complex(float('nan'), float('inf')),
+            complex(float('inf'), float('nan')),
+
+            # Extremal and Normal Number
+            complex(float('nan'), 2.0),
+            complex(float('inf'), 2.0),
+            complex(2.0, float('nan')),
+            complex(2.0, float('inf')),
+            complex(2.0, 0.0),
+            complex(0.0, 2.0))
+
+        self._np_compare('reciprocal', vals, device, dtype)
 
     @onlyCPU
     @dtypes(torch.bfloat16, torch.float)


### PR DESCRIPTION
@dylanbespalko @anjali411 

Not sure if the test should be added to `test_torch` or `test_complex`.