### PR TITLE
fmadd in vec256_base should be on Vec256<T>, not T

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -692,7 +692,7 @@ inline Vec256<T> operator^(const Vec256<T>& a, const Vec256<T>& b) {
 #endif
 
 template <typename T>
-inline T fmadd(const T& a, const T& b, const T& c) {
+inline Vec256<T> fmadd(const Vec256<T>& a, const Vec256<T>& b, const Vec256<T>& c) {
   return a * b + c;
 }
 


### PR DESCRIPTION
This should have been intended to be the general version of fmadd in
vec256_double and vec256_float.

