### PR TITLE
[v1.5.0] Fix incorrect merge of #34136.

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryArithmeticKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryArithmeticKernel.cu
@@ -69,7 +69,6 @@ void remainder_kernel_cuda(TensorIterator& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "remainder_cuda", [&]() {
       using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(thrust_t a, thrust_t b) -> thrust_t {
-        CUDA_KERNEL_ASSERT(b != 0);
         thrust_t r = a % b;
         if ((r != 0) && ((r < 0) != (b < 0))) {
           r += b;


### PR DESCRIPTION
If you look at https://github.com/pytorch/pytorch/pull/34136/, you will notice a commit (https://github.com/pytorch/pytorch/pull/34136/commits/80c15c087ca652c535f5883cfb2564c8930aa593) that didn't get merged.
This is to address that, to avoid crashing on remainder when the rhs is 0.

ghstack-source-id: e805e290bd4b7d3165fd78d4e537e56e4c459162
Pull Request resolved: https://github.com/pytorch/pytorch/pull/36760

