### PR TITLE
[pytorch] Route default warning sync to LOG(WARNING)

### DIFF
--- a/c10/test/util/exception_test.cpp
+++ b/c10/test/util/exception_test.cpp
@@ -18,3 +18,7 @@ TEST(ExceptionTest, TORCH_INTERNAL_ASSERT_DEBUG_ONLY) {
   ASSERT_NO_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(true));
 #endif
 }
+
+TEST(WarningTest, JustPrintWarning) {
+  TORCH_WARN("I'm a warning");
+}

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -111,7 +111,8 @@ WarningHandler* get_warning_handler() noexcept(true) {
 void WarningHandler::process(
     const SourceLocation& source_location,
     const std::string& msg) {
-  std::cerr << "Warning: " << msg << " (" << source_location << ")\n";
+  LOG_AT_FILE_LINE(WARNING, source_location.file, source_location.line)
+      << "Warning: " << msg << " (function " << source_location.function << ")";
 }
 
 

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -147,7 +147,7 @@ using fLI::FLAGS_v;
 
 C10_DEFINE_int(
     caffe2_log_level,
-    google::GLOG_ERROR,
+    google::GLOG_WARNING,
     "The minimum log level that caffe2 will output.");
 
 // Google glog's api does not have an external function that allows one to check
@@ -184,7 +184,7 @@ void UpdateLoggingLevelsFromFlags() {
   // we will transfer the caffe2_log_level setting to glog to override that.
   FLAGS_minloglevel = std::min(FLAGS_caffe2_log_level, FLAGS_minloglevel);
   // If caffe2_log_level is explicitly set, let's also turn on logtostderr.
-  if (FLAGS_caffe2_log_level < google::GLOG_ERROR) {
+  if (FLAGS_caffe2_log_level < google::GLOG_WARNING) {
     FLAGS_logtostderr = 1;
   }
   // Also, transfer the caffe2_log_level verbose setting to glog.
@@ -207,7 +207,7 @@ void ShowLogInfoToStderr() {
 
 C10_DEFINE_int(
     caffe2_log_level,
-    ERROR,
+    WARNING,
     "The minimum log level that caffe2 will output.");
 
 namespace c10 {

--- a/c10/util/logging_is_google_glog.h
+++ b/c10/util/logging_is_google_glog.h
@@ -49,4 +49,13 @@ INSTANTIATE_FOR_CONTAINER(set)
 
 #include <glog/logging.h>
 
+// Additional macros on top of glog
+
+// Log with source location information override (to be used in generic
+// warning/error handlers implemented as functions, not macros)
+//
+// Note, we don't respect GOOGLE_STRIP_LOG here for simplicity
+#define LOG_AT_FILE_LINE(n, file, line) \
+  ::google::LogMessage(file, line, ::google::GLOG_##n).stream()
+
 #endif // C10_UTIL_LOGGING_IS_GOOGLE_GLOG_H_

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -105,6 +105,12 @@ static_assert(
 
 #define VLOG_IS_ON(verboselevel) (CAFFE2_LOG_THRESHOLD <= -(verboselevel))
 
+// Log with source location information override (to be used in generic
+// warning/error handlers implemented as functions, not macros)
+#define LOG_AT_FILE_LINE(n, file, line) \
+  if (n >= CAFFE2_LOG_THRESHOLD)        \
+  ::c10::MessageLogger(file, line, n).stream()
+
 // Log only if condition is met.  Otherwise evaluates to void.
 #define FATAL_IF(condition)            \
   condition ? (void)0                  \

--- a/caffe2/contrib/aten/aten_op.cc
+++ b/caffe2/contrib/aten/aten_op.cc
@@ -3,6 +3,21 @@
 
 namespace caffe2 {
 
+namespace internal {
+at::Tensor index_with_uint8_handling(
+    const at::Tensor& self,
+    at::TensorList indices) {
+  // Support BC only for the simplest case of mask indexing
+  if (indices.size() == 1 && indices[0].scalar_type() == at::kByte) {
+    TORCH_WARN(
+        "Indexing with uint8 mask tensor in ATenOp is now deprecated,"
+        " please use a bool mask instead.");
+    return at::index(self, {indices[0].to(at::kBool)});
+  }
+  return at::index(self, indices);
+}
+} // namespace internal
+
 REGISTER_CPU_OPERATOR(ATen, ATenOp<CPUContext>);
 template <>
 at::Backend ATenOp<CPUContext>::backend() const {

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -17,6 +17,12 @@ namespace caffe2 {
 
 using at::Half; // for AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, ...)
 
+namespace internal {
+CAFFE2_API at::Tensor index_with_uint8_handling(
+    const at::Tensor& self,
+    at::TensorList indices);
+}
+
 template <class Context>
 class ATenOp : public Operator<Context> {
  public:

--- a/caffe2/contrib/aten/aten_test.py
+++ b/caffe2/contrib/aten/aten_test.py
@@ -77,6 +77,23 @@ class TestATen(hu.HypothesisTestCase):
         self.assertReferenceChecks(gc, op, inputs, ref)
 
     @given(**hu.gcs)
+    def test_index_uint8(self, gc, dc):
+        # Indexing with uint8 is deprecated, but we need to provide backward compatibility for some old models exported through ONNX
+        op = core.CreateOperator(
+            "ATen",
+            ['self', 'mask'],
+            ["Z"],
+            operator="index")
+
+        def ref(self, mask):
+            return (self[mask.astype(np.bool)],)
+
+        tensor = np.random.randn(2, 3, 4).astype(np.float32)
+        mask = np.array([[1, 0, 0], [1, 1, 0]]).astype(np.uint8)
+
+        self.assertReferenceChecks(gc, op, [tensor, mask], ref)
+
+    @given(**hu.gcs)
     def test_index_put(self, gc, dc):
         op = core.CreateOperator(
             "ATen",

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -93,6 +93,12 @@ ARGUMENT_MAP = {
     'std::array<bool,3>': 'auto ${arg} = readBoolMask<3>("${arg}");',
 }
 
+# for BC reasons we want to route some of the functions to different
+# implementations
+SPECIAL_IMPLEMENTATIONS = {
+    'index': 'internal::index_with_uint8_handling',
+}
+
 def expand(o):
     num_defaults = sum(1 if 'default' in arg else 0 for arg in o['arguments'])
     results = [o]
@@ -287,7 +293,9 @@ if __name__ == '__main__':
 
         emit_assignments(o, env)
 
-        if 'namespace' in o['method_of']:
+        if o['name'] in SPECIAL_IMPLEMENTATIONS:
+            env['invocation'] = "{}({})".format(SPECIAL_IMPLEMENTATIONS[o['name']], ','.join(env['arguments']))
+        elif 'namespace' in o['method_of']:
             env['invocation'] = CT("at::${name}(${arguments})").substitute(env)
         else:
             assert('Tensor' in o['method_of'])

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -533,6 +533,28 @@ C10_EXPORT const Argument& GetArgument(const NetDef& def, const string& name) {
   }
 }
 
+C10_EXPORT const Argument* GetArgumentPtr(
+    const OperatorDef& def,
+    const string& name) {
+  int index = GetArgumentIndex(def.arg(), name);
+  if (index != -1) {
+    return &def.arg(index);
+  } else {
+    return nullptr;
+  }
+}
+
+C10_EXPORT const Argument* GetArgumentPtr(
+    const NetDef& def,
+    const string& name) {
+  int index = GetArgumentIndex(def.arg(), name);
+  if (index != -1) {
+    return &def.arg(index);
+  } else {
+    return nullptr;
+  }
+}
+
 C10_EXPORT bool GetFlagArgument(
     const google::protobuf::RepeatedPtrField<Argument>& args,
     const string& name,

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -299,6 +299,10 @@ class C10_EXPORT ArgumentHelper {
 // name. Throws if argument does not exist.
 CAFFE2_API const Argument& GetArgument(const OperatorDef& def, const string& name);
 CAFFE2_API const Argument& GetArgument(const NetDef& def, const string& name);
+// Helper methods to get an argument from OperatorDef or NetDef given argument
+// name. Returns nullptr if argument does not exist.
+CAFFE2_API const Argument* GetArgumentPtr(const OperatorDef& def, const string& name);
+CAFFE2_API const Argument* GetArgumentPtr(const NetDef& def, const string& name);
 
 // Helper methods to query a boolean argument flag from OperatorDef or NetDef
 // given argument name. If argument does not exist, return default value.


### PR DESCRIPTION
Summary:
Follow LOG(WARNING) format for c++ side warnings in order to play well with larger services, especially when using glog. I need to hook up into GLOG internals a bit in order to override FILE/LINE without having to change the whole thing to be macros, but it seems to be stable between glog versions.

Note, this also changes caffe2_log_level to warning by default - I think it's a much better default when compiling without glog (or maybe even have info)

Test Plan:
Run unittest in both glog and non-glog build mode:

glog:
```
W0416 12:06:49.778215 3311666 exception_test.cpp:23] Warning: I'm a warning (function TestBody)
```

no-glog:
```
[W exception_test.cpp:23] Warning: I'm a warning (function TestBody)
```

Reviewed By: ilia-cher

Differential Revision: D21078446

