### PR TITLE
[caffe2] Fix signed/unsigned mismatch warning in Half.h

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -435,7 +435,7 @@ typename std::enable_if<std::is_integral<From>::value && !std::is_same<From, boo
     // For example, with uint8, this allows for `a - b` to be treated as
     // `a + 255 * b`.
     return f > limit::max() ||
-        (f < 0 && -static_cast<uint64_t>(f) > limit::max());
+        (f < 0 && static_cast<int64_t>(-static_cast<uint64_t>(f)) > limit::max());
   } else {
     return f < limit::lowest() || f > limit::max();
   }


### PR DESCRIPTION
Summary:
This line does require the cast to `uint64_t` to do a zero-extend, but then we do a signed comparison immediately after that.  Fixes the following warning:
```
caffe2\tensorbody.h_ovrsource#header-mode-symlink-tree-only,headers\aten\core\tensorbody.h(1174): warning C4522: 'at::Tensor': multiple assignment operators specified
caffe2\c10\util\half.h(439): warning C4018: '>': signed/unsigned mismatch
caffe2\c10\util\typecast.h(152): note: see reference to function template instantiation 'bool c10::overflows<To,From>(From)' being compiled
        with
        [
            To=int64_t,
            From=int64_t
        ]
caffe2\c10\core\scalar.h(74): note: see reference to function template instantiation 'To c10::checked_convert<int64_t,int64_t>(From,const char *)' being compiled
        with
        [
            To=int64_t,
            From=int64_t
        ]
```

Test Plan: Pass all CI builds

Differential Revision: D21064936

