### PR TITLE
Enhance error message for MPI unavailability.

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -474,7 +474,10 @@ def _new_process_group_helper(world_size,
     backend = Backend(backend)
     if backend == Backend.MPI:
         if not is_mpi_available():
-            raise RuntimeError("Distributed package doesn't have MPI built in")
+            raise RuntimeError(
+                "Distributed package doesn't have MPI built in."
+                " MPI is only included if you build PyTorch from"
+                " source on a host that has MPI installed.")
         pg = ProcessGroupMPI.create(group_ranks)
         if not pg:
             return GroupMember.NON_GROUP_MEMBER


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36781 Enhance error message for MPI unavailability.**

Mention that you need to to build PyTorch from source to enable MPI.
Additional context:
https://discuss.pytorch.org/t/distributed-pytorch-with-mpi/77106.

Differential Revision: [D21082009](https://our.internmc.facebook.com/intern/diff/D21082009/)