### PR TITLE
[jit] `__copy__` for `RecursiveScriptModule`

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -470,6 +470,57 @@ std::shared_ptr<ClassType> ivalue::Object::type() const {
   return type_.type_->expect<ClassType>();
 }
 
+IValue IValue::copy() const {
+  IValue copy;
+  switch(tag) {
+    case IValue::Tag::Tensor:
+      copy = IValue(toTensor());
+      break;
+    case IValue::Tag::Tuple: {
+      std::vector<IValue> copied_tuple;
+      for (const auto& e : toTuple()->elements()) {
+        copied_tuple.push_back(e.copy());
+      }
+      copy = IValue(ivalue::Tuple::create(copied_tuple));
+    }
+      break;
+    case IValue::Tag::GenericList: {
+      auto list = toList();
+      auto copied_list = c10::impl::GenericList(list.elementType());
+      for (IValue v : list) {
+        copied_list.push_back(v.copy());
+      }
+      copy = IValue(copied_list);
+    }
+      break;
+    case IValue::Tag::GenericDict: {
+      auto dict = toGenericDict();
+      auto copied_dict = c10::impl::GenericDict(dict.keyType(), dict.valueType());
+      for (const auto& entry : dict) {
+        copied_dict.insert(entry.key().copy(), entry.value().copy());
+      }
+      copy = IValue(copied_dict);
+    }
+      break;
+    case IValue::Tag::Object: {
+      copy = IValue(toObject()->copy());
+      break;
+    case IValue::Tag::String:
+    case IValue::Tag::None:
+    case IValue::Tag::Double:
+    case IValue::Tag::Int:
+    case IValue::Tag::Bool:
+    case IValue::Tag::Device:
+    case IValue::Tag::Uninitialized:
+      copy = *this;
+      break;
+    default:
+      AT_ERROR("Can't deepcopy IValue with tag: ", tagKind());
+    }
+  }
+  return copy;
+}
+
 IValue IValue::deepcopy() const {
   IValue::HashAliasedIValueMap memo;
   return deepcopy(memo);
@@ -555,6 +606,14 @@ void ivalue::Object::unsafeRemoveAttr(const std::string& name) {
 void ivalue::Object::resizeObject(size_t slot) {
   AT_ASSERT(slot < type()->numAttributes());
   slots_.resize(type()->numAttributes());
+}
+
+c10::intrusive_ptr<ivalue::Object> ivalue::Object::copy() const {
+  auto object = ivalue::Object::create(c10::StrongTypePtr(type_.cu_, type()), type()->numAttributes());
+  for (auto i = 0; i < slots_.size(); ++i) {
+    object->setSlot(i, slots_[i].copy());
+  }
+  return object;
 }
 
 c10::intrusive_ptr<ivalue::Object> ivalue::Object::deepcopy() const {

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -629,6 +629,8 @@ struct CAFFE2_API IValue final {
   // Inserts all subvalues of this in subValues.
   void getSubValues(HashAliasedIValues& subValues) const;
 
+  IValue copy() const;
+
   IValue deepcopy() const;
   IValue deepcopy(
       HashAliasedIValueMap& memo) const;

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -433,6 +433,8 @@ struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
     return type_.cu_;
   }
 
+  c10::intrusive_ptr<Object> copy() const;
+
   c10::intrusive_ptr<Object> deepcopy() const;
   c10::intrusive_ptr<Object> deepcopy(IValue::HashAliasedIValueMap& memo) const;
 

--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -109,12 +109,12 @@ void testModuleDeepcopy() {
   m.setattr(tensor_attr, at::randn(5));
 
   Module m2 = m.deepcopy();
-  Module m3 = m.clone_instance();
+  Module m3 = m.copy();
   // Make sure copy works
   ASSERT_EQ(m2.attr(int_attr).toInt(), 2);
   ASSERT_EQ(m3.attr(int_attr).toInt(), 2);
 
-  // Both deepcopy and clone_instance will preserve the type
+  // Both deepcopy and copy will preserve the type
   ASSERT_EQ(m.type(), m2.type());
   ASSERT_EQ(m.type(), m3.type());
 
@@ -129,7 +129,7 @@ void testModuleDeepcopy() {
   // change Tensor value of copied instances
   at::Tensor t1 = m.attr(tensor_attr).toTensor();
   at::Tensor t2 = m2.attr(tensor_attr).toTensor(); // deepcopy will copy the Tensor
-  at::Tensor t3 = m3.attr(tensor_attr).toTensor(); // clone_instance will not copy the Tensor
+  at::Tensor t3 = m3.attr(tensor_attr).toTensor(); // copy will not copy the Tensor
   // check copy works
   ASSERT_TRUE(t1.equal(t2));
   ASSERT_TRUE(t1.equal(t3));

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -163,6 +163,10 @@ void Module::clone_method(const Module& orig, const std::string& name) {
   return clone_method(orig, orig.get_method(name).function(), type_remap);
 }
 
+Module Module::copy() const {
+  return Module(_ivalue()->copy());
+}
+
 Module Module::deepcopy() const {
   return Module(_ivalue()->deepcopy());
 }
@@ -228,22 +232,7 @@ Module Module::clone_impl(
 }
 
 Module Module::clone_instance() const {
-  Module r(_ivalue()->compilation_unit(), type());
-
-  // Copy slots. If a slot is a module - recursively clone it.
-  size_t N = type()->numAttributes();
-  for (size_t i = 0; i < N; ++i) {
-    IValue s = _ivalue()->getSlot(i);
-    if (type()->getAttribute(i)->is_module()) {
-      const Module& orig = Module(s.toObject());
-      Module cloned = orig.clone_instance();
-      r._ivalue()->setAttr(type()->getAttributeName(i), cloned._ivalue());
-    } else {
-      r._ivalue()->setAttr(type()->getAttributeName(i), s);
-    }
-  }
-
-  return r;
+  return Module(_ivalue()->copy());
 }
 
 void Module::train(bool on) {

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -221,6 +221,8 @@ struct TORCH_API Module : public Object {
       const std::string& filename,
       const ExtraFilesMap& extra_files = ExtraFilesMap()) const;
 
+  Module copy() const;
+
   Module deepcopy() const;
 
   // Clones both the underlying `ClassType` and the module instance(data), this

--- a/torch/csrc/jit/api/object.cpp
+++ b/torch/csrc/jit/api/object.cpp
@@ -35,6 +35,18 @@ void Object::define(const std::string& src, const ResolverPtr& resolver) {
       *type()->name(), src, resolver ? resolver : nativeResolver(), &self);
 }
 
+Object Object::copy() const {
+  Object obj(_ivalue()->compilation_unit(), type());
+
+  size_t N = type()->numAttributes();
+  for (size_t i = 0; i < N; ++i) {
+    IValue s = _ivalue()->getSlot(i);
+    obj._ivalue()->setAttr(type()->getAttributeName(i), s.copy());
+  }
+
+  return obj;
+}
+
 Object Object::deepcopy() const {
   c10::IValue::HashAliasedIValueMap memo;
   return deepcopy(memo);

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -124,6 +124,9 @@ struct TORCH_API Object {
     return _ivalue()->slots().size();
   }
 
+  // sallow copy the object
+  Object copy() const;
+
   // Copies all the attributes of the object recursively without creating new
   // `ClassType`, including deepcopy of Tensors
   Object deepcopy() const;

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1776,6 +1776,9 @@ if _enabled:
         def copy_instance(self):
             return torch.jit._recursive.wrap_cpp_module(self._c._clone_instance())
 
+        def __copy__(self):
+            return torch.jit._recursive.wrap_cpp_module(self._c._copy())
+
         def __deepcopy__(self):
             return torch.jit._recursive.wrap_cpp_module(self._c._deepcopy())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36783 [jit] `__copy__` for `RecursiveScriptModule`**
* #32685 [jit] Remove `copy` from public API
* #32684 [jit] Deepcopy for `script::Module`

Summary:

Test Plan:
build/bin/test_jit

Reviewers:
.

Subscribers:

Tasks:

Tags: