### PR TITLE
Open source fbgemm fp16 pack op

### DIFF
--- a/caffe2/contrib/fakelowp/batch_matmul_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/batch_matmul_fp16_fake_op.cc
@@ -1,0 +1,66 @@
+#include "batch_matmul_fp16_fake_op.h"
+
+#include "caffe2/core/operator_schema.h"
+
+namespace caffe2 {
+
+vector<TensorShape> TensorInferenceForBatchMatMul(
+    const OperatorDef& def,
+    const vector<TensorShape>& in);
+OpSchema::Cost CostInferenceForBatchMatMul(
+    const OperatorDef& def,
+    const vector<TensorShape>& in);
+
+REGISTER_CPU_OPERATOR(BatchMatMulFP16Fake, BatchMatMulFP16FakeOp<CPUContext>);
+
+OPERATOR_SCHEMA(BatchMatMulFP16Fake)
+    .NumInputs(2)
+    .NumOutputs(1)
+    .SetDoc(R"DOC(
+Batch Matrix multiplication Yi = Ai * Bi, where A has shape (dim0, dim1, ... M, K),
+B has shape (dim0, dim1, ... K, N), Y has shape (dim0, dim1, ... M, N) and i ranges
+from 0 to (dim0 * dim1 ...) - 1. rank(A) == rank(B) >= 2. In case of A and B being
+two diemnsional, it behaves like normal matrix multiplication.
+)DOC")
+    .Input(0, "A", "tensor of shape (dim0, dim1 ... M, K)")
+    .Input(1, "B", "tensor of shpae (dim0, dim2 ... K, N)")
+    .Output(0, "Y", "tensor of shape (dim0, dim1 ... M, N)")
+    .Arg(
+        "trans_a",
+        "Pass 1 to transpose the last two dimensions of A before "
+        "doing multiplication")
+    .Arg(
+        "trans_b",
+        "Pass 1 to transpose the last two dimensions of B before "
+        "doing multiplication")
+    .Arg(
+        "broadcast",
+        "Pass 1 to allow broadcasting of dimensions. Behavior is the same as numpy.matmul. Gradient is currently not supported when running in broadcast mode.")
+    .TensorInferenceFunction(TensorInferenceForBatchMatMul)
+    .CostInferenceFunction(
+        OpSchema::CostInferenceFunctionType(CostInferenceForBatchMatMul))
+    .InheritOnnxSchema();
+
+REGISTER_CPU_OPERATOR(
+    BatchMatMulFP16Acc16Fake,
+    BatchMatMulFP16FakeOp<
+        CPUContext,
+        DefaultEngine,
+        true /*use custom fp16 gemm acc16*/,
+        false /*not using temp accmulator*/,
+        false /*use math fp16 gemm acc 32*/>);
+
+OPERATOR_SCHEMA(BatchMatMulFP16Acc16Fake).NumInputs(2).NumOutputs(1);
+
+REGISTER_CPU_OPERATOR(
+    BatchMatMulFP16Acc32Fake,
+    BatchMatMulFP16FakeOp<
+        CPUContext,
+        DefaultEngine,
+        false /*use custom fp16 gemm acc16*/,
+        false /*not using temp accmulator*/,
+        true /*use custom fp16 gemm acc32*/>);
+
+OPERATOR_SCHEMA(BatchMatMulFP16Acc32Fake).NumInputs(2).NumOutputs(1);
+
+} // namespace caffe2

--- a/caffe2/contrib/fakelowp/batch_matmul_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/batch_matmul_fp16_fake_op.h
@@ -1,0 +1,443 @@
+#ifndef CAFFE2_OPERATORS_BATCH_MATMUL_OP_H_
+#define CAFFE2_OPERATORS_BATCH_MATMUL_OP_H_
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <fbgemm/FbgemmConvert.h>
+#include "caffe2/contrib/fakelowp/fp16_gemm_utils.h"
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+
+C10_DECLARE_bool(caffe2_fbgemm_fake_fp16_clamp);
+
+namespace caffe2 {
+
+template <
+    class Context,
+    class Engine = DefaultEngine,
+    bool USE_ACC_FP16 = false,
+    bool USE_TMP_ACCUMULATOR = false,
+    bool USE_CUSTOM_ACC32 =
+        false> /* if  USE_ACC_FP16=false, set to true to use custom gemm kernel
+                 in fp16_gemm_utils.cc instead of math.h gemm functions */
+class BatchMatMulFP16FakeOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  template <class... Args>
+  explicit BatchMatMulFP16FakeOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        OP_SINGLE_ARG(bool, "trans_a", trans_a_, false),
+        OP_SINGLE_ARG(bool, "trans_b", trans_b_, false),
+        OP_SINGLE_ARG(bool, "broadcast", broadcast_, false) {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<float>>::call(this, Input(0));
+  }
+
+  template <typename T>
+  bool DoRunWithType() {
+    const auto& A = Input(0);
+    const auto& B = Input(1);
+    const int A_ndim = A.dim();
+    const int B_ndim = B.dim();
+    const std::vector<std::int64_t> A_dims = A.sizes().vec();
+    const std::vector<std::int64_t> B_dims = B.sizes().vec();
+    const T* A_data = A.template data<T>();
+    const T* B_data = B.template data<T>();
+
+    // Fake fp16 rounding of input
+    std::vector<float> A_rounded(A.numel());
+    std::vector<float> B_rounded(B.numel());
+    fbgemm::RoundToFloat16(
+        A_data,
+        A_rounded.data(),
+        A.numel(),
+        FLAGS_caffe2_fbgemm_fake_fp16_clamp,
+        USE_ACC_FP16);
+    fbgemm::RoundToFloat16(
+        B_data,
+        B_rounded.data(),
+        B.numel(),
+        FLAGS_caffe2_fbgemm_fake_fp16_clamp,
+        USE_ACC_FP16);
+    A_data = A_rounded.data();
+    B_data = B_rounded.data();
+
+    if (A_ndim == 1 && B_ndim == 1) {
+      CAFFE_ENFORCE_EQ(A.numel(), B.numel());
+      auto* Y = Output(0, {1}, at::dtype<T>());
+      T* Y_data = Y->template mutable_data<T>();
+      math::Dot<T, Context>(A.numel(), A_data, B_data, Y_data, &context_);
+      fbgemm::RoundToFloat16(
+          reinterpret_cast<const float*>(Y_data),
+          Y_data,
+          Y->numel(),
+          FLAGS_caffe2_fbgemm_fake_fp16_clamp,
+          USE_ACC_FP16);
+      return true;
+    }
+    if (A_ndim == 1) {
+      const int N = A.numel();
+      if (trans_b_) {
+        CAFFE_ENFORCE_EQ(B_dims[B_ndim - 1], N);
+      } else {
+        CAFFE_ENFORCE_EQ(B_dims[B_ndim - 2], N);
+      }
+      std::vector<std::int64_t> Y_dims(B_ndim - 1);
+      if (trans_b_) {
+        std::copy_n(B_dims.cbegin(), B_ndim - 1, Y_dims.begin());
+      } else {
+        std::copy_n(B_dims.cbegin(), B_ndim - 2, Y_dims.begin());
+        Y_dims.back() = B_dims.back();
+      }
+      auto* Y = Output(0, Y_dims, at::dtype<T>());
+      T* Y_data = Y->template mutable_data<T>();
+      if (trans_b_) {
+        const int M = B.numel() / N;
+        caffe2::custom_fp16_gemv(
+            USE_ACC_FP16,
+            USE_CUSTOM_ACC32,
+            USE_TMP_ACCUMULATOR,
+            CblasNoTrans,
+            M,
+            N,
+            1.0f,
+            B_data,
+            A_data,
+            0.0f,
+            Y_data,
+            &context_);
+      } else {
+        const int M = B_dims[B_ndim - 1];
+        const int batch_size = B.numel() / (M * N);
+        if (batch_size == 1) {
+          caffe2::custom_fp16_gemv(
+              USE_ACC_FP16,
+              USE_CUSTOM_ACC32,
+              USE_TMP_ACCUMULATOR,
+              CblasTrans,
+              N,
+              M,
+              1.0f,
+              B_data,
+              A_data,
+              0.0f,
+              Y_data,
+              &context_);
+        } else {
+          caffe2::custom_fp16_gemm_strided_batched(
+              USE_ACC_FP16,
+              USE_CUSTOM_ACC32,
+              USE_TMP_ACCUMULATOR,
+              CblasTrans,
+              CblasNoTrans,
+              batch_size,
+              M,
+              1,
+              N,
+              1.0f,
+              B_data,
+              M * N,
+              A_data,
+              0,
+              0.0f,
+              Y_data,
+              M,
+              &context_);
+        }
+      }
+      fbgemm::RoundToFloat16(
+          reinterpret_cast<const float*>(Y_data),
+          Y_data,
+          Y->numel(),
+          FLAGS_caffe2_fbgemm_fake_fp16_clamp,
+          USE_ACC_FP16);
+      return true;
+    }
+    if (B_ndim == 1) {
+      const int N = B.numel();
+      if (trans_a_) {
+        CAFFE_ENFORCE_EQ(A_dims[A_ndim - 2], N);
+      } else {
+        CAFFE_ENFORCE_EQ(A_dims[A_ndim - 1], N);
+      }
+      const std::vector<std::int64_t> Y_dims(
+          A_dims.cbegin(), A_dims.cbegin() + A_ndim - 1);
+      auto* Y = Output(0, Y_dims, at::dtype<T>());
+      T* Y_data = Y->template mutable_data<T>();
+      if (trans_a_) {
+        const int M = A_dims[A_ndim - 1];
+        const int batch_size = A.numel() / (M * N);
+        if (batch_size == 1) {
+          caffe2::custom_fp16_gemv(
+              USE_ACC_FP16,
+              USE_CUSTOM_ACC32,
+              USE_TMP_ACCUMULATOR,
+              CblasTrans,
+              N,
+              M,
+              1.0f,
+              A_data,
+              B_data,
+              0.0f,
+              Y_data,
+              &context_);
+        } else {
+          caffe2::custom_fp16_gemm_strided_batched(
+              USE_ACC_FP16,
+              USE_CUSTOM_ACC32,
+              USE_TMP_ACCUMULATOR,
+              CblasTrans,
+              CblasNoTrans,
+              batch_size,
+              M,
+              1,
+              N,
+              1.0f,
+              A_data,
+              M * N,
+              B_data,
+              0,
+              0.0f,
+              Y_data,
+              M,
+              &context_);
+        }
+      } else {
+        const int M = A.numel() / N;
+        caffe2::custom_fp16_gemv(
+            USE_ACC_FP16,
+            USE_CUSTOM_ACC32,
+            USE_TMP_ACCUMULATOR,
+            CblasNoTrans,
+            M,
+            N,
+            1.0f,
+            A_data,
+            B_data,
+            0.0f,
+            Y_data,
+            &context_);
+      }
+      fbgemm::RoundToFloat16(
+          reinterpret_cast<const float*>(Y_data),
+          Y_data,
+          Y->numel(),
+          FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+      return true;
+    }
+
+    const int M = trans_a_ ? A_dims[A_ndim - 1] : A_dims[A_ndim - 2];
+    const int K = trans_a_ ? A_dims[A_ndim - 2] : A_dims[A_ndim - 1];
+    if (trans_b_) {
+      CAFFE_ENFORCE_EQ(B_dims[B_ndim - 1], K);
+    } else {
+      CAFFE_ENFORCE_EQ(B_dims[B_ndim - 2], K);
+    }
+    const int N = trans_b_ ? B_dims[B_ndim - 2] : B_dims[B_ndim - 1];
+    const int ndim = std::max(A_ndim, B_ndim);
+    std::vector<std::int64_t> A_broadcast_dims(ndim);
+    std::vector<std::int64_t> B_broadcast_dims(ndim);
+    std::vector<std::int64_t> Y_broadcast_dims(ndim);
+    math::utils::ComputeBroadcastBinaryOpDims(
+        A_ndim - 2,
+        A_dims.data(),
+        B_ndim - 2,
+        B_dims.data(),
+        A_broadcast_dims.data(),
+        B_broadcast_dims.data(),
+        Y_broadcast_dims.data());
+    Y_broadcast_dims[ndim - 2] = M;
+    Y_broadcast_dims[ndim - 1] = N;
+    auto* Y = Output(0, Y_broadcast_dims, at::dtype<T>());
+    T* Y_data = Y->template mutable_data<T>();
+
+    const int batch_dim = ndim - 2;
+    const bool is_broadcast_dims = !std::equal(
+        A_broadcast_dims.cbegin(),
+        A_broadcast_dims.cbegin() + batch_dim,
+        B_broadcast_dims.cbegin());
+    if (is_broadcast_dims) {
+      CAFFE_ENFORCE(broadcast_);
+    }
+
+    const std::int64_t A_batch_size = std::accumulate(
+        A_broadcast_dims.cbegin(),
+        A_broadcast_dims.cbegin() + batch_dim,
+        1LL,
+        std::multiplies<std::int64_t>());
+    const std::int64_t B_batch_size = std::accumulate(
+        B_broadcast_dims.cbegin(),
+        B_broadcast_dims.cbegin() + batch_dim,
+        1LL,
+        std::multiplies<std::int64_t>());
+    const std::int64_t Y_batch_size = std::accumulate(
+        Y_broadcast_dims.cbegin(),
+        Y_broadcast_dims.cbegin() + batch_dim,
+        1LL,
+        std::multiplies<std::int64_t>());
+    if (Y_batch_size == 0) {
+      fbgemm::RoundToFloat16(
+          reinterpret_cast<const float*>(Y_data),
+          Y_data,
+          Y->numel(),
+          FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+      return true;
+    }
+    if (A_batch_size == 1 && B_batch_size == 1) {
+      if (USE_ACC_FP16) {
+        caffe2::custom_fp16_gemm_with_trans(
+            trans_a_ ? CblasTrans : CblasNoTrans,
+            trans_b_ ? CblasTrans : CblasNoTrans,
+            M,
+            K,
+            N,
+            A_data,
+            B_data,
+            0.0f,
+            Y_data,
+            true, /* use acc16*/
+            USE_TMP_ACCUMULATOR);
+      } else if (USE_CUSTOM_ACC32) {
+        caffe2::custom_fp16_gemm_with_trans(
+            trans_a_ ? CblasTrans : CblasNoTrans,
+            trans_b_ ? CblasTrans : CblasNoTrans,
+            M,
+            K,
+            N,
+            A_data,
+            B_data,
+            0.0f,
+            Y_data,
+            false, /* use acc32*/
+            USE_TMP_ACCUMULATOR);
+      } else {
+        math::Gemm<T, Context, Engine>(
+            trans_a_ ? CblasTrans : CblasNoTrans,
+            trans_b_ ? CblasTrans : CblasNoTrans,
+            M,
+            N,
+            K,
+            1.0f,
+            A_data,
+            B_data,
+            0.0f,
+            Y_data,
+            &context_);
+      }
+
+    } else if (A_batch_size == 1) {
+      caffe2::custom_fp16_gemm_strided_batched(
+          USE_ACC_FP16,
+          USE_CUSTOM_ACC32,
+          USE_TMP_ACCUMULATOR,
+          trans_a_ ? CblasTrans : CblasNoTrans,
+          trans_b_ ? CblasTrans : CblasNoTrans,
+          Y_batch_size,
+          M,
+          N,
+          K,
+          1.0f,
+          A_data,
+          0,
+          B_data,
+          K * N,
+          0.0f,
+          Y_data,
+          M * N,
+          &context_);
+    } else if (B_batch_size == 1) {
+      caffe2::custom_fp16_gemm_strided_batched(
+          USE_ACC_FP16,
+          USE_CUSTOM_ACC32,
+          USE_TMP_ACCUMULATOR,
+          trans_a_ ? CblasTrans : CblasNoTrans,
+          trans_b_ ? CblasTrans : CblasNoTrans,
+          Y_batch_size,
+          M,
+          N,
+          K,
+          1.0f,
+          A_data,
+          M * K,
+          B_data,
+          0,
+          0.0f,
+          Y_data,
+          M * N,
+          &context_);
+    } else if (!is_broadcast_dims) {
+      caffe2::custom_fp16_gemm_strided_batched(
+          USE_ACC_FP16,
+          USE_CUSTOM_ACC32,
+          USE_TMP_ACCUMULATOR,
+          trans_a_ ? CblasTrans : CblasNoTrans,
+          trans_b_ ? CblasTrans : CblasNoTrans,
+          Y_batch_size,
+          M,
+          N,
+          K,
+          1.0f,
+          A_data,
+          M * K,
+          B_data,
+          K * N,
+          0.0f,
+          Y_data,
+          M * N,
+          &context_);
+    } else {
+      std::vector<const T*> A_ptr(Y_batch_size);
+      std::vector<const T*> B_ptr(Y_batch_size);
+      std::vector<T*> Y_ptr(Y_batch_size);
+      std::vector<std::int64_t> index(batch_dim);
+      for (std::int64_t i = 0; i < Y_batch_size; ++i) {
+        const std::int64_t A_index = math::utils::GetIndexFromDims(
+            batch_dim, A_broadcast_dims.data(), index.data());
+        const std::int64_t B_index = math::utils::GetIndexFromDims(
+            batch_dim, B_broadcast_dims.data(), index.data());
+        A_ptr[i] = A_data + A_index * M * K;
+        B_ptr[i] = B_data + B_index * K * N;
+        Y_ptr[i] = Y_data + i * M * N;
+        math::utils::IncreaseIndexInDims(
+            batch_dim, Y_broadcast_dims.data(), index.data());
+      }
+      caffe2::custom_fp16_gemm_batched(
+          USE_ACC_FP16,
+          USE_CUSTOM_ACC32,
+          USE_TMP_ACCUMULATOR,
+          trans_a_ ? CblasTrans : CblasNoTrans,
+          trans_b_ ? CblasTrans : CblasNoTrans,
+          Y_batch_size,
+          M,
+          N,
+          K,
+          1.0f,
+          A_ptr.data(),
+          B_ptr.data(),
+          0.0f,
+          Y_ptr.data(),
+          &context_);
+    }
+    fbgemm::RoundToFloat16(
+        reinterpret_cast<const float*>(Y_data),
+        Y_data,
+        Y->numel(),
+        FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+    return true;
+  }
+
+ private:
+  const bool trans_a_;
+  const bool trans_b_;
+  const bool broadcast_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_BATCH_MATMUL_OP_H_

--- a/caffe2/contrib/fakelowp/fp16_gemm_utils.cc
+++ b/caffe2/contrib/fakelowp/fp16_gemm_utils.cc
@@ -1,0 +1,485 @@
+#include "caffe2/contrib/fakelowp/fp16_gemm_utils.h"
+#include <fbgemm/FbgemmConvert.h>
+#include <fbgemm/FbgemmFP16.h>
+#include <glog/logging.h>
+#include <immintrin.h>
+#include "caffe2/core/context.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+// dimA(before transpose) = M x N, dimA (after transpose) = N x M.
+void transpose(const float* A, std::vector<float>& A_trans, int M, int N) {
+  CAFFE_ENFORCE_EQ(M * N, A_trans.size());
+  fbgemm::transpose_simd(M, N, A, N, A_trans.data(), M);
+}
+
+void custom_fp16_gemm_with_trans(
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int m,
+    const int k,
+    const int n,
+    const float* A,
+    const float* B,
+    const float beta,
+    float* C,
+    const bool use_acc_fp16,
+    const bool use_temp_accumulator) {
+  if (!use_acc_fp16 && !use_temp_accumulator) {
+    math::Gemm<float, CPUContext>(
+        trans_A, trans_B, m, n, k, 1.0f, A, B, beta, C, nullptr);
+    return;
+  }
+
+  switch (trans_A) {
+    case CblasNoTrans: {
+      switch (trans_B) {
+        case CblasNoTrans: {
+          // A * B
+          custom_fp16_gemm(
+              m, k, n, A, B, beta, C, use_acc_fp16, use_temp_accumulator);
+          break;
+        }
+        case CblasTrans: {
+          // A * B_trans
+          std::vector<float> B_trans(n * k);
+          transpose(B, B_trans, n, k);
+          custom_fp16_gemm(
+              m,
+              k,
+              n,
+              A,
+              B_trans.data(),
+              beta,
+              C,
+              use_acc_fp16,
+              use_temp_accumulator);
+          break;
+        }
+        default:
+          LOG(FATAL) << "Unexpected CBLAS_TRAnSPOSE for trans_B";
+      }
+    } break;
+    case CblasTrans: {
+      switch (trans_B) {
+        case CblasNoTrans: {
+          // A_trans * B
+          std::vector<float> A_trans(k * m);
+          transpose(A, A_trans, k, m);
+          custom_fp16_gemm(
+              m,
+              k,
+              n,
+              A_trans.data(),
+              B,
+              beta,
+              C,
+              use_acc_fp16,
+              use_temp_accumulator);
+          break;
+        }
+        case CblasTrans: {
+          // A_trans * B_trans
+          std::vector<float> A_trans(k * m);
+          std::vector<float> B_trans(n * k);
+          transpose(A, A_trans, k, m);
+          transpose(B, B_trans, n, k);
+          custom_fp16_gemm(
+              m,
+              k,
+              n,
+              A_trans.data(),
+              B_trans.data(),
+              beta,
+              C,
+              use_acc_fp16,
+              use_temp_accumulator);
+          break;
+        }
+        default:
+          LOG(FATAL) << "Unexpected CBLAS_TRAnSPOSE for trans_B";
+      }
+    } break;
+    default:
+      LOG(FATAL) << "Unexpected CBLAS_TRAnSPOSE for trans_A";
+  }
+}
+
+static inline __m256 clamp_subnormals(__m256 input, const float epsilon_) {
+  __m256 epsilon = _mm256_set1_ps(epsilon_);
+  __m256 nepsilon = _mm256_set1_ps(-epsilon_);
+
+  __m256 mask = _mm256_or_ps(
+      _mm256_cmp_ps(input, nepsilon, _CMP_LE_OS),
+      _mm256_cmp_ps(input, epsilon, _CMP_GE_OS));
+  return _mm256_and_ps(input, mask);
+}
+
+void custom_fp16_gemm(
+    const int m,
+    const int k,
+    const int n,
+    const float* A_fp16,
+    const float* B_fp16,
+    const float beta,
+    float* C,
+    const bool use_acc_fp16,
+    const bool use_temp_accumulator) {
+  if (!use_acc_fp16 && !use_temp_accumulator) {
+    math::Gemm<float, CPUContext>(
+        CblasNoTrans,
+        CblasNoTrans,
+        m,
+        n,
+        k,
+        1.0f,
+        A_fp16,
+        B_fp16,
+        beta,
+        C,
+        nullptr);
+    return;
+  }
+
+#ifdef LOG_LEVEL_FOR_FBFCPACkEDACC16_PERFORmAnCE_LOG
+  clock_t begin = clock();
+#endif
+  int C_size = m * n;
+  if (beta == 0) {
+    // In Caffe2 we often do a lazy initialization, which may contain NaNs in
+    // the float values. As a result, if beta is 0, we explicitly do a setzero.
+    memset(C, 0, C_size * sizeof(C[0]));
+  } else {
+    float beta_fp16 = fbgemm::cpu_half2float(fbgemm::cpu_float2half_rn(beta));
+
+    __m256 mBetaFp16 = _mm256_broadcast_ss(&beta_fp16);
+    int i = 0;
+    for (i = 0; i + 8 <= C_size; i += 8) {
+      __m256 mC = _mm256_loadu_ps(C + i);
+      mC = _mm256_mul_ps(mC, mBetaFp16);
+      _mm256_storeu_ps(C + i, mC);
+    }
+    for (; i < C_size; i++) {
+      C[i] = C[i] * beta_fp16;
+    }
+  }
+
+  // Encode the smallest normal number in float16
+  union epsilon_t {
+    float f;
+    uint32_t i;
+  };
+
+  union epsilon_t epsilon;
+  epsilon.i = 0x38800000u; // 1 / 16384
+
+  constexpr int VLEn = 8;
+  const int kb_max = 128;
+  for (int i = 0; i < m; i++) {
+    for (int l = 0; l < k; l += kb_max) {
+      int kb = std::min(kb_max, k - l);
+      for (int j = 0; j < n; j += VLEn) {
+        int nb = std::min(VLEn, n - j);
+        if (nb == VLEn) {
+          __m256 mC = _mm256_loadu_ps(C + i * n + j);
+          __m256 mC_temp = _mm256_setzero_ps();
+          for (int l2 = l; l2 < l + kb; l2++) {
+            __m256 mA_fp16 = _mm256_broadcast_ss(A_fp16 + i * k + l2);
+            __m256 mB_fp16 = _mm256_loadu_ps((B_fp16 + l2 * n + j));
+
+            if (use_acc_fp16) {
+              mA_fp16 = clamp_subnormals(mA_fp16, epsilon.f);
+              mB_fp16 = clamp_subnormals(mB_fp16, epsilon.f);
+            }
+
+            __m256 mAB = _mm256_mul_ps(mA_fp16, mB_fp16);
+
+            if (use_acc_fp16) {
+              __m256 mAB_fp16 = _mm256_cvtph_ps(_mm256_cvtps_ph(mAB, 0));
+              mAB_fp16 = clamp_subnormals(mAB_fp16, epsilon.f);
+
+              if (use_temp_accumulator) {
+                mC_temp = _mm256_add_ps(mC_temp, mAB_fp16);
+                mC_temp = _mm256_cvtph_ps(_mm256_cvtps_ph(mC_temp, 0));
+              } else {
+                mC = _mm256_add_ps(mC, mAB_fp16);
+                mC = _mm256_cvtph_ps(_mm256_cvtps_ph(mC, 0));
+              }
+            } else {
+              if (use_temp_accumulator) {
+                mC_temp = _mm256_add_ps(mC_temp, mAB);
+              } else {
+                mC = _mm256_add_ps(mC, mAB);
+              }
+            }
+
+            if (use_acc_fp16) {
+              mC = clamp_subnormals(mC, epsilon.f);
+            }
+          }
+          if (use_temp_accumulator) {
+            if (use_acc_fp16) {
+              mC = _mm256_cvtph_ps(_mm256_cvtps_ph(mC, 0));
+              mC = _mm256_add_ps(mC, mC_temp);
+              mC = _mm256_cvtph_ps(_mm256_cvtps_ph(mC, 0));
+            } else {
+              mC = _mm256_add_ps(mC, mC_temp);
+            }
+          }
+          _mm256_storeu_ps(C + i * n + j, mC);
+        } else {
+          __m256 mC_temp = _mm256_setzero_ps();
+          int32_t mask_src[] = {
+              -1,
+              -1,
+              -1,
+              -1,
+              -1,
+              -1,
+              -1,
+              -1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+          };
+          __m256i imask =
+              _mm256_loadu_si256((__m256i const*)(mask_src + 8 - nb));
+          __m256 mC = _mm256_maskload_ps(C + i * n + j, imask);
+          for (int l2 = l; l2 < l + kb; l2++) {
+            __m256 mA_fp16 = _mm256_broadcast_ss(A_fp16 + i * k + l2);
+            __m256 mB_fp16 = _mm256_maskload_ps(B_fp16 + l2 * n + j, imask);
+
+            if (use_acc_fp16) {
+              mA_fp16 = clamp_subnormals(mA_fp16, epsilon.f);
+              mB_fp16 = clamp_subnormals(mB_fp16, epsilon.f);
+            }
+
+            __m256 mAB = _mm256_mul_ps(mA_fp16, mB_fp16);
+
+            if (use_acc_fp16) {
+              __m256 mAB_fp16 = _mm256_cvtph_ps(_mm256_cvtps_ph(mAB, 0));
+              mAB_fp16 = clamp_subnormals(mAB_fp16, epsilon.f);
+
+              if (use_temp_accumulator) {
+                mC_temp = _mm256_add_ps(mC_temp, mAB_fp16);
+                mC_temp = _mm256_cvtph_ps(_mm256_cvtps_ph(mC_temp, 0));
+              } else {
+                mC = _mm256_add_ps(mC, mAB_fp16);
+                mC = _mm256_cvtph_ps(_mm256_cvtps_ph(mC, 0));
+              }
+            } else {
+              if (use_temp_accumulator) {
+                mC_temp = _mm256_add_ps(mC_temp, mAB);
+              } else {
+                mC = _mm256_add_ps(mC, mAB);
+              }
+            }
+
+            if (use_acc_fp16) {
+              mC = clamp_subnormals(mC, epsilon.f);
+            }
+          }
+
+          if (use_temp_accumulator) {
+            if (use_acc_fp16) {
+              mC = _mm256_cvtph_ps(_mm256_cvtps_ph(mC, 0));
+              mC = _mm256_add_ps(mC, mC_temp);
+              mC = _mm256_cvtph_ps(_mm256_cvtps_ph(mC, 0));
+            } else {
+              mC = _mm256_add_ps(mC, mC_temp);
+            }
+          }
+          _mm256_maskstore_ps(C + i * n + j, imask, mC);
+        }
+      }
+    }
+  }
+#ifdef LOG_LEVEL_FOR_FBFCPACkEDACC16_PERFORmAnCE_LOG
+  clock_t end = clock();
+  double elapsed_secs = double(end - begin) / CLOCkS_PER_SEC;
+  VLOG(LOG_LEVEL_FOR_FBFCPACKEDACC16_ACCURACY_LOG)
+      << "cblas_gemm_compute_acc16 run time = " << elapsed_secs << endl;
+#endif
+}
+
+void custom_fp16_gemv(
+    const bool use_acc_fp16,
+    const bool use_custom_acc32,
+    const bool use_temp_accumulator,
+    const CBLAS_TRANSPOSE trans_A,
+    const int M,
+    const int N,
+    const float alpha,
+    const float* A,
+    const float* x,
+    const float beta,
+    float* y,
+    CPUContext* context) {
+  if (use_acc_fp16) {
+    custom_fp16_gemm_with_trans(
+        trans_A,
+        CblasNoTrans,
+        M,
+        1,
+        N,
+        A,
+        x,
+        beta,
+        y,
+        true /* use acc_fp16 */,
+        use_temp_accumulator);
+  } else if (use_custom_acc32 && use_temp_accumulator) {
+    custom_fp16_gemm_with_trans(
+        trans_A,
+        CblasNoTrans,
+        M,
+        1,
+        N,
+        A,
+        x,
+        beta,
+        y,
+        false /* use acc_fp32 */,
+        use_temp_accumulator);
+  } else {
+    math::Gemv<float, CPUContext>(trans_A, M, N, alpha, A, x, beta, y, context);
+  }
+}
+
+void custom_fp16_gemm_batched(
+    const bool use_acc_fp16,
+    const bool use_custom_acc32,
+    const bool use_temp_accumulator,
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int batch_size,
+    const int M,
+    const int N,
+    const int K,
+    const float alpha,
+    const float** A,
+    const float** B,
+    const float beta,
+    float** C,
+    CPUContext* context) {
+  if (!use_acc_fp16 && (!use_custom_acc32 || !use_temp_accumulator)) {
+    math::GemmBatched<float, CPUContext>(
+        trans_A, trans_B, batch_size, M, N, K, alpha, A, B, beta, C, context);
+    return;
+  }
+
+  for (int i = 0; i < batch_size; ++i) {
+    if (use_acc_fp16) {
+      custom_fp16_gemm_with_trans(
+          trans_A,
+          trans_B,
+          M,
+          K,
+          N,
+          A[i],
+          B[i],
+          beta,
+          C[i],
+          true /* use acc_fp16 */,
+          use_temp_accumulator);
+    } else {
+      CAFFE_ENFORCE(use_custom_acc32 && use_temp_accumulator);
+      custom_fp16_gemm_with_trans(
+          trans_A,
+          trans_B,
+          M,
+          K,
+          N,
+          A[i],
+          B[i],
+          beta,
+          C[i],
+          false /* use acc_fp32 */,
+          use_temp_accumulator);
+    }
+  }
+}
+
+void custom_fp16_gemm_strided_batched(
+    const bool use_acc_fp16,
+    const bool use_custom_acc32,
+    const bool use_temp_accumulator,
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int batch_size,
+    const int M,
+    const int N,
+    const int K,
+    const float alpha /* unused */,
+    const float* A,
+    const int A_stride,
+    const float* B,
+    const int B_stride,
+    const float beta,
+    float* C,
+    const int C_stride,
+    CPUContext* context) {
+  if (!use_acc_fp16 && (!use_custom_acc32 || !use_temp_accumulator)) {
+    math::GemmStridedBatched<float, CPUContext>(
+        trans_A,
+        trans_B,
+        batch_size,
+        M,
+        N,
+        K,
+        alpha,
+        A,
+        A_stride,
+        B,
+        B_stride,
+        beta,
+        C,
+        C_stride,
+        context);
+    return;
+  }
+
+  // loop over matrices in the batch
+  for (int i = 0; i < batch_size; ++i) {
+    if (use_acc_fp16) {
+      custom_fp16_gemm_with_trans(
+          trans_A,
+          trans_B,
+          M,
+          K,
+          N,
+          A,
+          B,
+          beta,
+          C,
+          true /* use_acc_fp16 */,
+          use_temp_accumulator);
+
+    } else {
+      CAFFE_ENFORCE(use_custom_acc32 && use_temp_accumulator);
+      custom_fp16_gemm_with_trans(
+          trans_A,
+          trans_B,
+          M,
+          K,
+          N,
+          A,
+          B,
+          beta,
+          C,
+          false /* use acc_fp32*/,
+          use_temp_accumulator);
+    }
+    A += A_stride;
+    B += B_stride;
+    C += C_stride;
+  }
+}
+
+} // namespace caffe2

--- a/caffe2/contrib/fakelowp/fp16_gemm_utils.h
+++ b/caffe2/contrib/fakelowp/fp16_gemm_utils.h
@@ -1,0 +1,81 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+#pragma once
+#include "caffe2/core/context.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+void custom_fp16_gemm(
+    const int m,
+    const int k,
+    const int n,
+    const float* A_fp16,
+    const float* B_fp16,
+    const float beta,
+    float* C,
+    const bool use_acc_fp16,
+    const bool use_temp_accumulator);
+
+void custom_fp16_gemm_with_trans(
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int m,
+    const int k,
+    const int n,
+    const float* A_fp16,
+    const float* B_fp16,
+    const float beta,
+    float* C,
+    const bool use_acc_fp16,
+    const bool use_temp_accumulator);
+
+void transpose(const float* A, float* A_trans, int M, int N);
+void custom_fp16_gemv(
+    const bool use_acc_fp16,
+    const bool use_custom_acc32,
+    const bool use_temp_accumulator,
+    const CBLAS_TRANSPOSE trans_A,
+    const int M,
+    const int N,
+    const float alpha,
+    const float* A,
+    const float* x,
+    const float beta,
+    float* y,
+    CPUContext* context);
+
+void custom_fp16_gemm_batched(
+    const bool use_acc_fp16,
+    const bool use_custom_acc32,
+    const bool use_temp_accumulator,
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int batch_size,
+    const int M,
+    const int N,
+    const int K,
+    const float alpha,
+    const float** A,
+    const float** B,
+    const float beta,
+    float** C,
+    CPUContext* context);
+void custom_fp16_gemm_strided_batched(
+    const bool use_acc_fp16,
+    const bool use_custom_acc32,
+    const bool use_temp_accumulator,
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int batch_size,
+    const int M,
+    const int N,
+    const int K,
+    const float alpha /* unused */,
+    const float* A,
+    const int A_stride,
+    const float* B,
+    const int B_stride,
+    const float beta,
+    float* C,
+    const int C_stride,
+    CPUContext* context);
+} // namespace caffe2

--- a/caffe2/contrib/fakelowp/test/README.md
+++ b/caffe2/contrib/fakelowp/test/README.md
@@ -1,25 +1,35 @@
 # How to run FakeLowP vs Glow tests
 This was tested on Ubuntu 16.04 LTS but should work in general Linux system.
 
-## Install and Build Glow
+## Build Glow Onnxifi Library
 Follow https://github.com/pytorch/glow/blob/master/README.md to install the dependency of Glow. Then at glow root run
 ```
 mkdir build && cd build
 cmake -G Ninja -DGLOW_BUILD_ONNXIFI_DYNLIB=ON ..
 ninja all
 ```
-Note that here you probably want to add other flags like `-DGLOW_WITH_NNPI=1` to enable specific backend if you have the flow setup.
+Note that here you probably want to add other flags like `-DGLOW_WITH_NNPI=1` to enable specific backend if you have the flow set up.
 Once built successfully, you will get an dynamic library at `build/lib/Onnxifi/libonnxifi.so`. We will use it later.
 
-## Install and Build PyTorch
+## Build and Install PyTorch
 Follow https://github.com/pytorch/pytorch/blob/master/README.md to install the dependency of PyTorch. It might be easy to 
 setup a python virtualenv or conda. And please use Python > 3.5.2 because hypothesis library will expose a bug in Python which 
-is fixed after 3.5.2. Something like 3.7 mighr be good enough. Here I give a virtualenv flow:
+is fixed after 3.5.2. Something like 3.7 might be good enough. You can install python3.7 with
 ```
+sudo apt-get install -y build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev zlib1g-dev openssl libffi-dev python3-dev python3-setuptools wget
+wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz && tar -xf Python-3.7.4.tgz
+cd Python-3.7.4
+./configure && make -j 8 && sudo make altinstall
+```
+
+Once you installed Python 3.7, here I give a virtualenv flow:
+```
+sudo pip3.7 install virtualenv
 python3.7 -m venv venv3
 source venv3/bin/active
 cd pytorch
 pip install -r requirements.txt
+pip install pytest hypothesis
 ```
 You probably need to install gflags-dev too with
 ```
@@ -36,6 +46,6 @@ use gflags in Glow to pass options. Other flags are mostl for fast build time an
 ## Run the test
 You can now run the tests with command like the following  when you are inside the virtual python env:
 ```
-OSS_ONNXIFI_LIB=${PATH_TO_GLOW}/build/lib/Onnxifi/libonnxifi.so python pytorch/caffe2/contrib/fakelowp/test/test_sls_nnpi_fp16.py
+OSS_ONNXIFI_LIB=${PATH_TO_GLOW}/build/lib/Onnxifi/libonnxifi.so pytest pytorch/caffe2/contrib/fakelowp/test/test_sls_nnpi_fp16.py --hypothesis-show-statistics
 ```
 

--- a/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
@@ -4,13 +4,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+import unittest
 import caffe2.python.fakelowp.init_shared_libs  # noqa
 
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
-from hypothesis import given
+from hypothesis import given, settings
 import hypothesis.strategies as st
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
@@ -21,7 +22,6 @@ GLOW_MATMUL_RTOL = 1e-3
 
 
 class TestBatchMatMul(serial.SerializedTestCase):
-    # @settings(max_examples=30)
     @given(
         #C=0, #st.integers(min_value=0, max_value=3),  # number of batch dims
         M=st.integers(min_value=1, max_value=10),
@@ -116,5 +116,4 @@ class TestBatchMatMul(serial.SerializedTestCase):
 
 
 if __name__ == "__main__":
-    import unittest
     unittest.main()

--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -4,9 +4,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+import time
+import unittest
 
 import caffe2.python.fakelowp.init_shared_libs  # noqa
-import time
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from caffe2.python import workspace
@@ -38,13 +41,14 @@ def reference_spatialbn_test16(X, scale, bias, mean, var, epsilon, order):
 
 
 # Test the lowered BN op
-class BatchnormTest(TestCase):
-    # TODO: replace with hypothesis
+class BatchnormTest(unittest.TestCase):
+    # TODO: using hypothesis seed, sweep dimensions
     def test_bn(self):
+        seed = int(time.time())
+        workspace.ResetWorkspace()
         size = 30
         input_channels = 20
         batch_size = 40
-        seed = int(time.time())
         np.random.seed(seed)
 
         order = "NCHW"

--- a/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
@@ -4,14 +4,16 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+import time
+import unittest
 
 import caffe2.python.fakelowp.init_shared_libs  # noqa
-import time
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.onnx.tests.test_utils import TestCase
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
 
 core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
@@ -19,7 +21,7 @@ core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
 GLOW_MATMUL_RTOL = 0
 
 
-class FCTest(TestCase):
+class FCTest(unittest.TestCase):
     def test_clip(self):
         m, n, k = 8, 8, 8
         dtype = np.float32
@@ -236,11 +238,12 @@ class FCTest(TestCase):
                      "rowdiff": rowdiff})
                 assert(0)
 
-    def test_fc_num0(self):
+    @given(seed=st.integers(0, 65535))
+    def test_fc_num0(self, seed):
         """ Test numerics, fix a dimension and determine the ranges of error.
             Use Fp16FCAcc16 as a reference.
         """
-        np.random.seed(int(time.time()))
+        np.random.seed(seed)
         m = np.random.randint(low=4, high=50)
         k = np.random.randint(low=4, high=1000)
         n = np.random.randint(low=4, high=50)
@@ -322,3 +325,6 @@ class FCTest(TestCase):
                      "b0": b0, "Y_glow": Y_glow, "Y_c2": Y_c2, "diff": diff,
                      "rowdiff": rowdiff})
                 assert(0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
@@ -5,10 +5,13 @@ from __future__ import unicode_literals
 
 import numpy as np
 import time
+import unittest
 
 # Must happen before importing caffe2.python.*
 import caffe2.python.fakelowp.init_shared_libs  # noqa
 
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace, dyndep
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
@@ -20,10 +23,9 @@ workspace.GlobalInit(["caffe2", "--glow_global_fp16=1",
                       "--glow_global_force_sls_fp16_accum=1"])
 
 
-class SparseLengthsSumTest(TestCase):
-    def test_slws_fused_4bit_rowwise_all_same(self):
-        # Comment out for predictable debugging
-        seed = int(time.time())
+class SparseLengthsSumTest(unittest.TestCase):
+    @given(seed=st.integers(0, 65535))
+    def test_slws_fused_4bit_rowwise_all_same(self, seed):
         np.random.seed(seed)
         workspace.ResetWorkspace()
         n = 1
@@ -119,10 +121,8 @@ class SparseLengthsSumTest(TestCase):
                  "rowwise_diff": (Y_glow - Y_c2)[:, 0]})
             assert(0)
 
-    def test_slws_fused_4bit_rowwise(self):
-        # Comment out for predictable debugging
-        seed = int(time.time() * 1000) % 2 ** 16
-        print(seed)
+    @given(seed=st.integers(0, 65535))
+    def test_slws_fused_4bit_rowwise(self, seed):
         np.random.seed(seed)
         workspace.ResetWorkspace()
 
@@ -217,3 +217,6 @@ class SparseLengthsSumTest(TestCase):
                 },
             )
             assert 0
+
+if __name__ == '__main__':
+    unittest.main()

--- a/caffe2/contrib/fakelowp/test/test_sls_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_nnpi_fp16.py
@@ -6,6 +6,8 @@ import unittest
 # Must happen before importing caffe2.python.*
 import caffe2.python.fakelowp.init_shared_libs  # noqa
 import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
@@ -97,9 +99,10 @@ class SparseLengthsSumTest(unittest.TestCase):
             )
             assert 0
 
-    def test_slws_fused_8bit_rowwise_all_same(self):
+    @given(seed=st.integers(0, 65535))
+    def test_slws_fused_8bit_rowwise_all_same(self, seed):
         # Comment out for predictable debugging
-        np.random.seed(int(time.time()))
+        np.random.seed(seed)
         workspace.ResetWorkspace()
         n = 1
         m = 2
@@ -196,10 +199,8 @@ class SparseLengthsSumTest(unittest.TestCase):
             )
             assert 0
 
-    def test_slws_fused_8bit_rowwise_turkey(self):
-        # Comment out for predictable debugging
-        seed = int(time.time() * 1000) % 2 ** 16
-        print(seed)
+    @given(seed=st.integers(0, 65535))
+    def test_slws_fused_8bit_rowwise_turkey(self, seed):
         np.random.seed(seed)
         workspace.ResetWorkspace()
 
@@ -297,9 +298,8 @@ class SparseLengthsSumTest(unittest.TestCase):
 
     # Simple test to aid debugging order of operations
     # Minimize the case to an SLS that adds two rows
-    def test_small_sls(self):
-        seed = int(time.time() * 1000) % 2 ** 16
-        print(seed)
+    @given(seed=st.integers(0, 65535))
+    def test_small_sls(self, seed):
         np.random.seed(seed)
         workspace.ResetWorkspace()
 
@@ -398,8 +398,8 @@ class SparseLengthsSumTest(unittest.TestCase):
             )
             assert 0
 
-    def test_small_sls_acc32(self):
-
+    @given(seed=st.integers(0, 65535))
+    def test_small_sls_acc32(self, seed):
         workspace.GlobalInit(
             [
                 "caffe2",
@@ -408,8 +408,6 @@ class SparseLengthsSumTest(unittest.TestCase):
                 "--glow_global_force_sls_fp16_accum=0",
             ]
         )
-        seed = int(time.time() * 1000) % 2 ** 16
-        print(seed)
         np.random.seed(seed)
         workspace.ResetWorkspace()
 
@@ -508,7 +506,8 @@ class SparseLengthsSumTest(unittest.TestCase):
             )
             assert 0
 
-    def test_slws_fused_8bit_rowwise_acc32_nnpi(self):
+    @given(seed=st.integers(0, 65535))
+    def test_slws_fused_8bit_rowwise_acc32_nnpi(self, seed):
         workspace.GlobalInit(
             [
                 "caffe2",
@@ -517,9 +516,6 @@ class SparseLengthsSumTest(unittest.TestCase):
                 "--glow_global_force_sls_fp16_accum=0",
             ]
         )
-        # Comment out for predictable debugging
-        seed = int(time.time() * 1000) % 2 ** 16
-        print(seed)
         np.random.seed(seed)
         workspace.ResetWorkspace()
 

--- a/caffe2/quantization/server/fbgemm_fp16_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_fp16_pack_op.cc
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "caffe2/quantization/server/fbgemm_fp16_pack_op.h"
+
+#include <functional>
+
+#include "caffe2/core/common.h"
+
+namespace caffe2 {
+
+// Expilictly register TypeMeta
+CAFFE_KNOWN_TYPE(unique_ptr<fbgemm::PackedGemmMatrixFP16>);
+
+REGISTER_CPU_OPERATOR(
+    FbGemmPack,
+    FbGemmPackOp<CPUContext, DefaultEngine, true, fbgemm::float16>);
+
+REGISTER_CPU_OPERATOR(
+    FbGemmPackTranspose,
+    FbGemmPackOp<CPUContext, DefaultEngine, false, fbgemm::float16>);
+
+using namespace std::placeholders;
+OPERATOR_SCHEMA(FbGemmPack)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .AllowInplace({{0, 0}})
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT16);
+      return out;
+    })
+    .SetDoc(R"DOC(Prepack weight for fbgemm)DOC")
+    .Input(0, "X", "row major format weight matrix")
+    .Output(0, "Y", "Block row major packed format weight matrix");
+
+OPERATOR_SCHEMA(FbGemmPackTranspose)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .AllowInplace({{0, 0}})
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+
+      X.set_dims(1, in[0].dims(0));
+      X.set_dims(0, in[0].dims(1));
+      out.push_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT16);
+      return out;
+    })
+    .SetDoc(R"DOC(Prepack weight for fbgemm)DOC")
+    .Input(0, "X", "col major format weight matrix")
+    .Output(0, "Y", "Block col major packed format weight matrix");
+
+} // namespace caffe2

--- a/caffe2/quantization/server/fbgemm_fp16_pack_op.h
+++ b/caffe2/quantization/server/fbgemm_fp16_pack_op.h
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fbgemm/FbgemmFP16.h>
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/conversions.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <
+    class Context,
+    class Engine = DefaultEngine,
+    bool TransposeWeight = true,
+    typename TPacked = fbgemm::float16>
+class FbGemmPackOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  FbGemmPackOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        axis_(this->template GetSingleArgument<int32_t>("axis_w", 1)),
+        no_packing_(
+            this->template GetSingleArgument<int32_t>("no_packing", 0)) {}
+  ~FbGemmPackOp() {}
+
+  bool RunOnDevice() override {
+    const auto& X = Input(0);
+    const auto canonical_axis = X.canonical_axis_index(axis_);
+    const auto N = X.size_to_dim(canonical_axis);
+    const auto K = X.size_from_dim(canonical_axis);
+
+    fbgemm::PackedGemmMatrixFP16* resultPtr;
+    if (TransposeWeight) {
+      resultPtr = new fbgemm::PackedGemmMatrixFP16(
+          fbgemm::matrix_op_t::Transpose,
+          K,
+          N,
+          1.0f, /*alpha*/
+          X.template data<float>());
+    } else {
+      resultPtr = new fbgemm::PackedGemmMatrixFP16(
+          fbgemm::matrix_op_t::NoTranspose,
+          N,
+          K,
+          1.0f, /*alpha*/
+          X.template data<float>());
+    }
+
+    if (no_packing_) {
+      LOG_FIRST_N(WARNING, 10) << "no_packing will be deprecated soon";
+
+      vector<fbgemm::float16> src_mat(resultPtr->matSize());
+      fbgemm::float16* pmat = resultPtr->pmat();
+      memcpy(
+          src_mat.data(), pmat, resultPtr->matSize() * sizeof(fbgemm::float16));
+      resultPtr->unpackFromSrc(fbgemm::matrix_op_t::Transpose, src_mat.data());
+    }
+
+    auto* Y =
+        this->template Output<unique_ptr<fbgemm::PackedGemmMatrixFP16>>(0);
+    Y->reset(resultPtr);
+    return true;
+  }
+
+ protected:
+  size_t axis_{1};
+  // Do not pack the layout, for testing only
+  bool no_packing_;
+};
+
+} // namespace caffe2


### PR DESCRIPTION
Summary: This should enable `test_fc_nnpi_fp16.py` test in fakelowp test.

Test Plan:
```
buck test caffe2/caffe2/fb/fbgemm:
```

Differential Revision: D21085221

