### PR TITLE
[RELAND] Port to quantized and other operators to new registration API

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -550,7 +550,7 @@ at::Tensor convolution_overrideable(
     const Tensor& input, const Tensor& weight, const Tensor& bias,
     IntArrayRef stride, IntArrayRef padding, IntArrayRef dilation,
     bool transposed, IntArrayRef output_padding, int64_t groups) {
-  AT_ERROR("You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN, if this is intended, please use torch::RegisterOperators() to override this function ");
+  AT_ERROR("You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN, if this is intended, please use TORCH_LIBRARY_IMPL to override this function ");
 }
 
 at::Tensor _convolution(
@@ -798,7 +798,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
         const Tensor& grad_output, const Tensor& input, const Tensor& weight,
         IntArrayRef stride, IntArrayRef padding, IntArrayRef dilation,
         bool transposed, IntArrayRef output_padding, int64_t groups, std::array<bool, 3> output_mask) {
-  AT_ERROR("You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN, if this is intended, please use torch::RegisterOperators() to override this function ");
+  AT_ERROR("You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN, if this is intended, please use TORCH_LIBRARY_IMPL to override this function ");
   return std::tuple<Tensor, Tensor, Tensor>(
           at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT),
           at::empty_like(weight, LEGACY_CONTIGUOUS_MEMORY_FORMAT),

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -79,16 +79,13 @@ Tensor& resize_(
   return self;
 }
 
-static auto registry = torch::RegisterOperators()
-  .op(torch::RegisterOperators::options()
-    .schema("aten::resize_(Tensor(a!) self, int[] size, *, MemoryFormat? memory_format=None) -> Tensor(a!)")
-    .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-    .impl_unboxedOnlyKernel<decltype(resize_), &resize_>(DispatchKey::CPU))
-  .op(torch::RegisterOperators::options()
-    .schema("aten::resize_as_(Tensor(a!) self, Tensor the_template, *, MemoryFormat? memory_format=None) -> Tensor(a!)")
-    .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-    .impl_unboxedOnlyCatchAllKernel<decltype(resize_as_), &resize_as_>())
-  ;
+TORCH_LIBRARY_IMPL(aten, CPU, m) {
+  m.impl_UNBOXED("resize_", resize_);
+}
+
+TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
+  m.impl_UNBOXED("resize_as_", resize_as_);
+}
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -70,16 +70,10 @@ Tensor & detach_(Tensor & self) {
   return self;
 }
 
-static auto registry = torch::RegisterOperators()
-  .op(torch::RegisterOperators::options()
-    .schema("aten::detach(Tensor self) -> Tensor")
-    .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-    .catchAllKernel<decltype(detach), &detach>())
-  .op(torch::RegisterOperators::options()
-    .schema("aten::detach_(Tensor(a!) self) -> Tensor(a!)")
-    .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
-    .impl_unboxedOnlyCatchAllKernel<decltype(detach_), &detach_>())
-  ;
+TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
+  m.impl("detach", detach);
+  m.impl_UNBOXED("detach_", detach_);
+}
 
 Tensor contiguous(const Tensor & self) {
   return contiguous(self, MemoryFormat::Contiguous);

--- a/aten/src/ATen/native/cuda/Resize.cu
+++ b/aten/src/ATen/native/cuda/Resize.cu
@@ -28,11 +28,10 @@ Tensor& resize_cuda_(
   }
   return self;
 }
-static auto registry = torch::RegisterOperators()
-  .op(torch::RegisterOperators::options()
-    .schema("aten::resize_(Tensor(a!) self, int[] size, *, MemoryFormat? memory_format=None) -> Tensor(a!)")
-    .impl_unboxedOnlyKernel<decltype(resize_cuda_), &resize_cuda_>(DispatchKey::CUDA))
-  ;
+
+TORCH_LIBRARY_IMPL(aten, CUDA, m) {
+  m.impl_UNBOXED("resize_", resize_cuda_);
+}
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/README.md
+++ b/aten/src/ATen/native/quantized/README.md
@@ -55,42 +55,31 @@ In the example above, the resulting tensor will be the same as the `qa.scalar_ty
 3. Implementation lambda. The main implementation should sit in the body of this lambda.
 it should also use the aliases for the quantized data types instead of the explicit data types.
 
-### Step 1. Create the kernel
+### Step 1. Define the schema
 
-All kernels must be classes inheriting from `torch::OperatorKernel`.
-The implementation itself should be under the `operator()` method.
-In the `qxand.cpp` file, we create the following
+Update `aten/src/ATen/native/quantized/library.cpp` and add
+a `def` for your new operator:
 
 ```c++
-class QuantizedXAnd final : public torch::OperatorKernel {
- public:
-  Tensor operator(Tensor qa, Tensor qb) {
-    return quantized_xand(qa, qb);
+TORCH_LIBRARY(quantized, m) {
+  // ... the existing definitions ... 
+  m.def("quantized::xand(Tensor qa, Tensor qb) -> Tensor");
 }
-}
-;
 ```
 
-    ## #Step 2a. Register the kernel
-
-        The registration is done using the `torch::RegisterOperators()
-            .op(...)`.
-
-```c++ static auto registry = torch::RegisterOperators().op(
-    "quantized::xand(Tensor qa, Tensor qb) -> Tensor",
-    torch::RegisterOperators::options().kernel<QuantizedXAnd>(
-        QuantizedCPU()));
-```
-
-The registry takes two arguments:
-
-1. **Function schema string**: This schema describes the usage of the op.
+Def takes a **function schema string**: This schema describes the usage of the op.
 In the example above the schema is `"quantized::xand(Tensor qa, Tensor qb) -> Tensor"`.
 This translates to `torch._ops.ops.quantized.xand` function in Python of the appropriate signature.
-**Note:** The arguments signature in the schema is optional, and can also be written as `"quantized::xand"` (without args).
-2. **Registration options** should be of type `torch::RegisterOperators::options()`.
-To attach a kernel to it, use `.kernel<KERNEL_CLASS>(DISPATCH_KEY)`.
-In quantized ops you almost always want to use the `QuantizedCPU()` dispatcher.
+
+### Step 2. Register the implementation
+
+The registration is done using `TORCH_LIBRARY_IMPL`.
+
+```c++
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("xand", quantized_xand);
+}
+```
 
 ### Step 2b. [Optional] Registering the operation with the `native_functions.yaml`
 
@@ -138,25 +127,11 @@ namespace at {
     return qc;
   }
 
-  namespace {
-  class QuantizedXAnd final : public torch::OperatorKernel {
-   public:
-    Tensor operator(Tensor qa, Tensor qb) {
-      return quantized_xand(qa, qb);
-    }
-  };
-
-  static auto registry = torch::RegisterOperators().op(
-      "quantized::xand(Tensor qa, Tensor qb) -> Tensor",
-      torch::RegisterOperators::options().kernel<QuantizedXAnd>(
-          QuantizedCPU()));
-
-  } // namespace
-  }}  // namespace at::native
+  TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+    m.impl("xand", quantized_xand);
+  }
+}}  // namespace at::native
 ```
-
-Notice that we try to keep all the kernels in the anonymous namespace.
-The reason for that is that we access the kernels only through the `torch` namespace and this prevents symbol clashes in the linker.
 
 ### Step 3. Administrative stuff
 

--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -120,9 +120,8 @@ Tensor _add_scalar_out(Tensor& out, const Tensor& self, Scalar other) {
 }
 
 
-template <bool ReLUFused = false>
-class QAdd final : public c10::OperatorKernel {
 #ifdef USE_PYTORCH_QNNPACK
+template <bool ReLUFused = false>
 Tensor qnnpack_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   TORCH_CHECK(qa.ndimension() > 0, "qnnpack_add(): Got empty input tensor.");
   Tensor qa_contig = qa.contiguous(qa.suggest_memory_format());
@@ -206,102 +205,64 @@ Tensor qnnpack_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   return qy;
 }
 #endif
- public:
-  Tensor operator()(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
-    check_inputs(qa, qb);
+
+template <bool ReLUFused = false>
+Tensor qadd(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
+  check_inputs(qa, qb);
 #ifdef USE_PYTORCH_QNNPACK
-    if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
-        qa.scalar_type() == kQUInt8 && qb.scalar_type() == kQUInt8) {
-      return qnnpack_add(qa, qb, scale, zero_point);
-    }
+  if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
+      qa.scalar_type() == kQUInt8 && qb.scalar_type() == kQUInt8) {
+    return qnnpack_add<ReLUFused>(qa, qb, scale, zero_point);
+  }
 #endif
-    auto qc = at::_empty_affine_quantized(
-        qa.sizes(),
-        at::device(kCPU)
-           .dtype(qa.scalar_type())
-           .memory_format(qa.suggest_memory_format()),
-        scale,
-        zero_point,
-        c10::nullopt);
-    return _add_out<ReLUFused>(qc, qa, qb);
-  }
-};
+  auto qc = at::_empty_affine_quantized(
+      qa.sizes(),
+      at::device(kCPU)
+         .dtype(qa.scalar_type())
+         .memory_format(qa.suggest_memory_format()),
+      scale,
+      zero_point,
+      c10::nullopt);
+  return _add_out<ReLUFused>(qc, qa, qb);
+}
 
 template <bool ReLUFused = false>
-class QAddOut final : public c10::OperatorKernel {
- public:
-  Tensor operator()(Tensor qa, Tensor qb, Tensor out) {
-    check_inputs(qa, qb);
-    check_inputs(qa, out);
-    return _add_out<ReLUFused>(out, qa, qb);
-  }
-};
+Tensor qadd_out(Tensor qa, Tensor qb, Tensor out) {
+  check_inputs(qa, qb);
+  check_inputs(qa, out);
+  return _add_out<ReLUFused>(out, qa, qb);
+}
 
 
 template <bool ReLUFused = false>
-class QAddScalar final : public c10::OperatorKernel {
- public:
-  Tensor operator()(Tensor qa, Scalar b) {
+Tensor qadd_scalar(Tensor qa, Scalar b) {
   TORCH_CHECK(qa.qscheme() == kPerTensorAffine ||
               qa.qscheme() == kPerTensorSymmetric,
               "Only per tensor quantization is suuported in Add.");
-    auto qc = at::empty_like(qa, qa.suggest_memory_format());
-    return _add_scalar_out<ReLUFused>(qc, qa, b);
-  }
-};
+  auto qc = at::empty_like(qa, qa.suggest_memory_format());
+  return _add_scalar_out<ReLUFused>(qc, qa, b);
+}
 
 template <bool ReLUFused = false>
-class QAddScalarOut final : public c10::OperatorKernel {
- public:
-  Tensor operator()(Tensor qa, Scalar b, Tensor out) {
-    check_inputs(qa, out);
-    return _add_scalar_out<ReLUFused>(out, qa, b);
-  }
-};
+Tensor qadd_scalar_out(Tensor qa, Scalar b, Tensor out) {
+  check_inputs(qa, out);
+  return _add_scalar_out<ReLUFused>(out, qa, b);
+}
 
-static auto registry = c10::RegisterOperators()
-.op("quantized::add(Tensor qa, Tensor qb, float scale, int zero_point)"
-     "-> Tensor qc",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAdd</*ReLUFused=*/false>>(DispatchKey::QuantizedCPU))
-.op("_quantized::add(Tensor qa, Tensor qb, float scale, int zero_point)"
-     "-> Tensor qc",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAdd</*ReLUFused=*/false>>(DispatchKey::QuantizedCPU))
-.op("quantized::add_relu(Tensor qa, Tensor qb, float scale, int zero_point)"
-     "-> Tensor qc",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAdd</*ReLUFused=*/true>>(DispatchKey::QuantizedCPU))
-.op("quantized::add_out(Tensor qa, Tensor qb, Tensor(a!) out)"
-     "-> Tensor(a!) out",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAddOut</*ReLUFused=*/false>>(DispatchKey::QuantizedCPU))
-.op("quantized::add_relu_out(Tensor qa, Tensor qb, Tensor(a!) out)"
-     "-> Tensor(a!) out",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAddOut</*ReLUFused=*/true>>(DispatchKey::QuantizedCPU))
-.op("quantized::add_scalar(Tensor qa, Scalar b) -> Tensor qc",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAddScalar</*ReLUFused=*/false>>(DispatchKey::QuantizedCPU))
-.op("quantized::add_scalar_relu(Tensor qa, Scalar b) -> Tensor qc",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAddScalar</*ReLUFused=*/true>>(DispatchKey::QuantizedCPU))
-.op("quantized::add_scalar_out(Tensor qa, Scalar b, Tensor(a!) out)"
-     "-> Tensor(a!) out",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAddScalarOut</*ReLUFused=*/false>>(DispatchKey::QuantizedCPU))
-.op("quantized::add_scalar_relu_out(Tensor qa, Scalar b, Tensor(a!) out)"
-     "-> Tensor(a!) out",
-    c10::RegisterOperators::options()
-      .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-      .kernel<QAddScalarOut</*ReLUFused=*/true>>(DispatchKey::QuantizedCPU));
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("add",                 qadd</*ReLUFused=*/false>);
+  m.impl("add_relu",            qadd</*ReLUFused=*/true>);
+  m.impl("add_out",             qadd_out</*ReLUFused=*/false>);
+  m.impl("add_relu_out",        qadd_out</*ReLUFused=*/true>);
+  m.impl("add_scalar",          qadd_scalar</*ReLUFused=*/false>);
+  m.impl("add_scalar_relu",     qadd_scalar</*ReLUFused=*/true>);
+  m.impl("add_scalar_out",      qadd_scalar_out</*ReLUFused=*/false>);
+  m.impl("add_scalar_relu_out", qadd_scalar_out</*ReLUFused=*/true>);
+}
+
+TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
+  m.impl("add", qadd</*ReLUFused=*/false>);
+}
+
 }  // namespace
 }}  // namespace at::native

--- a/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qbatch_norm.cpp
@@ -236,88 +236,12 @@ Tensor quantized_batch_norm(
   return qy;
 }
 
-// Keep the registry in the anonymous namespace.
-namespace {
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("batch_norm2d",      q_batch_norm2d_impl<false>);
+  m.impl("batch_norm2d_relu", q_batch_norm2d_impl<true>);
+  m.impl("batch_norm3d",      q_batch_norm3d_impl<false>);
+  m.impl("batch_norm3d_relu", q_batch_norm3d_impl<true>);
+}
 
-template <bool ReLUFused = false>
-class QBatchNorm2d final : public torch::OperatorKernel {
- public:
-  Tensor operator()(
-      Tensor qx,
-      Tensor weight,
-      Tensor bias,
-      Tensor mean,
-      Tensor var,
-      double eps,
-      double output_scale,
-      int64_t output_zero_point) {
-    return q_batch_norm2d_impl<ReLUFused>(
-        qx, weight, bias, mean, var, eps, output_scale, output_zero_point);
-  }
-};
-
-template <bool ReLUFused = false>
-class QBatchNorm3d final : public torch::OperatorKernel {
- public:
-  Tensor operator()(
-      Tensor qx,
-      Tensor weight,
-      Tensor bias,
-      Tensor mean,
-      Tensor var,
-      double eps,
-      double output_scale,
-      int64_t output_zero_point) {
-    return q_batch_norm3d_impl<ReLUFused>(
-        qx, weight, bias, mean, var, eps, output_scale, output_zero_point);
-  }
-};
-
-static auto registry = torch::RegisterOperators().op(
-    "quantized::batch_norm2d(Tensor qx, "
-    "Tensor weight, "
-    "Tensor bias, "
-    "Tensor mean, "
-    "Tensor var, "
-    "float eps, "
-    "float output_scale, "
-    "int output_zero_point) -> Tensor",
-    torch::RegisterOperators::options().kernel<QBatchNorm2d<false>>(
-        DispatchKey::QuantizedCPU))
-.op(
-    "quantized::batch_norm2d_relu(Tensor qx, "
-    "Tensor weight, "
-    "Tensor bias, "
-    "Tensor mean, "
-    "Tensor var, "
-    "float eps, "
-    "float output_scale, "
-    "int output_zero_point) -> Tensor",
-    torch::RegisterOperators::options().kernel<QBatchNorm2d<true>>(
-        DispatchKey::QuantizedCPU))
-.op(
-    "quantized::batch_norm3d(Tensor qx, "
-    "Tensor weight, "
-    "Tensor bias, "
-    "Tensor mean, "
-    "Tensor var, "
-    "float eps, "
-    "float output_scale, "
-    "int output_zero_point) -> Tensor",
-    torch::RegisterOperators::options().kernel<QBatchNorm3d<false>>(
-        DispatchKey::QuantizedCPU))
-.op(
-    "quantized::batch_norm3d_relu(Tensor qx, "
-    "Tensor weight, "
-    "Tensor bias, "
-    "Tensor mean, "
-    "Tensor var, "
-    "float eps, "
-    "float output_scale, "
-    "int output_zero_point) -> Tensor",
-    torch::RegisterOperators::options().kernel<QBatchNorm3d<true>>(
-        DispatchKey::QuantizedCPU));
-
-} // namespace
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qclamp.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qclamp.cpp
@@ -71,21 +71,9 @@ Tensor& quantized_hardtanh_(
   return self;
 }
 
-// Keep the registry in the anonymous namespace.
-namespace {
-class QClamp final : public c10::OperatorKernel {
- public:
-  Tensor operator()(Tensor qx, optional<Scalar> min, optional<Scalar> max) {
-    return quantized_clamp(qx, min, max);
-  }
-};
-
-static auto registry = c10::RegisterOperators().op(
-    "quantized::clamp(Tensor qx, Scalar? min, Scalar? max) -> Tensor qy",
-    c10::RegisterOperators::options()
-        .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-        .kernel<QClamp>(DispatchKey::QuantizedCPU));
-} // namespace
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("clamp", quantized_clamp);
+}
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qconcat.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconcat.cpp
@@ -75,61 +75,39 @@ Tensor quantized_cat_impl(
 }
 
 template <bool ReLUFused = false>
-class QCat final : public torch::OperatorKernel {
- public:
-  Tensor operator()(
-      const c10::List<Tensor>& qxs,
-      int64_t dim,
-      c10::optional<double> scale,
-      c10::optional<int64_t> zero_point) {
-    TORCH_CHECK(is_valid_quantization_scheme(qxs[0]),
-                "Only per-tensor quantization is supported in 'cat'!")
-    double _scale = scale.has_value() ? scale.value() : qxs.get(0).q_scale();
-    int64_t _zero_point =
-        zero_point.has_value() ? zero_point.value() : qxs.get(0).q_zero_point();
-    return quantized_cat_impl<ReLUFused>(qxs, dim, _scale, _zero_point);
-  }
-};
+Tensor qcat(
+    const c10::List<Tensor>& qxs,
+    int64_t dim,
+    c10::optional<double> scale,
+    c10::optional<int64_t> zero_point) {
+  TORCH_CHECK(is_valid_quantization_scheme(qxs[0]),
+              "Only per-tensor quantization is supported in 'cat'!")
+  double _scale = scale.has_value() ? scale.value() : qxs.get(0).q_scale();
+  int64_t _zero_point =
+      zero_point.has_value() ? zero_point.value() : qxs.get(0).q_zero_point();
+  return quantized_cat_impl<ReLUFused>(qxs, dim, _scale, _zero_point);
+}
 
 template <bool ReLUFused = false>
-class QCatOut final : public torch::OperatorKernel {
- public:
-  Tensor operator()(const c10::List<Tensor>& qxs, int64_t dim, Tensor out) {
-    TORCH_CHECK(is_valid_quantization_scheme(qxs[0]),
-                "Only per-tensor quantization is supported in 'cat'!")
-    TORCH_CHECK(is_valid_quantization_scheme(out),
-                "Only per-tensor quantization is supported in 'cat'!")
-    auto out_ =
-        quantized_cat_impl<ReLUFused>(qxs, dim, out.q_scale(), out.q_zero_point());
-    at::native::copy_(out, out_, /*non_blocking=*/false);
-    return out;
-  }
-};
-
-static auto registry =
-    torch::RegisterOperators()
-        .op("quantized::cat(Tensor[] qx, int dim, float? scale, int? zero_point)"
-            " -> Tensor",
-            torch::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QCat<false>>(DispatchKey::QuantizedCPU))
-        .op("quantized::cat_relu(Tensor[] qx, int dim, float? scale, int? zero_point)"
-            " -> Tensor",
-            torch::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QCat<true>>(DispatchKey::QuantizedCPU))
-        .op("quantized::cat_out(Tensor[] qx, int dim, Tensor(a!) out)"
-            " -> Tensor(a!)",
-            torch::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QCatOut<false>>(DispatchKey::QuantizedCPU))
-        .op("quantized::cat_relu_out(Tensor[] qx, int dim, Tensor(a!) out)"
-            " -> Tensor(a!)",
-            torch::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QCatOut<true>>(DispatchKey::QuantizedCPU));
+Tensor qcat_out(const c10::List<Tensor>& qxs, int64_t dim, Tensor out) {
+  TORCH_CHECK(is_valid_quantization_scheme(qxs[0]),
+              "Only per-tensor quantization is supported in 'cat'!")
+  TORCH_CHECK(is_valid_quantization_scheme(out),
+              "Only per-tensor quantization is supported in 'cat'!")
+  auto out_ =
+      quantized_cat_impl<ReLUFused>(qxs, dim, out.q_scale(), out.q_zero_point());
+  at::native::copy_(out, out_, /*non_blocking=*/false);
+  return out;
+}
 
 } // namespace
+
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("cat", qcat<false>);
+  m.impl("cat_relu", qcat<true>);
+  m.impl("cat_out", qcat_out<false>);
+  m.impl("cat_relu_out", qcat_out<true>);
+}
 
 Tensor quantized_cat(TensorList qxs, int64_t dim) {
   TORCH_CHECK(is_valid_quantization_scheme(qxs[0]),

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -165,9 +165,9 @@ SmallVector<int64_t, 5> MakeConvOutputShape<3>(
  *
  */
 template <int kSpatialDim, bool kReluFused>
-class QConvInt8 final : public c10::OperatorKernel {
+class QConvInt8 final {
  public:
-  Tensor operator()(
+  static Tensor run(
       Tensor act,
       Tensor packed_weight,
       torch::List<int64_t> stride,
@@ -256,7 +256,7 @@ class QConvInt8 final : public c10::OperatorKernel {
     }
   }
 
-  at::Tensor FbgemmConv(
+  static at::Tensor FbgemmConv(
       Tensor act,
       Tensor packed_weight,
       torch::List<int64_t> stride,
@@ -501,7 +501,7 @@ class QConvInt8 final : public c10::OperatorKernel {
 #endif
 
 #ifdef USE_PYTORCH_QNNPACK
-  at::Tensor QnnpackConv(
+  static at::Tensor QnnpackConv(
       Tensor act,
       Tensor packed_weight,
       torch::List<int64_t> stride,
@@ -643,26 +643,17 @@ class QConvInt8 final : public c10::OperatorKernel {
 #endif
 };
 
-static auto registry =
-    c10::RegisterOperators()
-        .op("quantized::conv2d",
-            c10::RegisterOperators::options().kernel<QConvInt8<2, false>>(
-                DispatchKey::QuantizedCPU))
-        .op("_quantized::conv2d",
-            c10::RegisterOperators::options().kernel<QConvInt8<2, false>>(
-                DispatchKey::QuantizedCPU))
-        .op("quantized::conv2d_relu",
-            c10::RegisterOperators::options().kernel<QConvInt8<2, true>>(
-                DispatchKey::QuantizedCPU))
-        .op("_quantized::conv2d_relu",
-            c10::RegisterOperators::options().kernel<QConvInt8<2, true>>(
-                DispatchKey::QuantizedCPU))
-        .op("quantized::conv3d",
-            c10::RegisterOperators::options().kernel<QConvInt8<3, false>>(
-                DispatchKey::QuantizedCPU))
-        .op("quantized::conv3d_relu",
-            c10::RegisterOperators::options().kernel<QConvInt8<3, true>>(
-                DispatchKey::QuantizedCPU));
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("conv2d",      QConvInt8<2, false>::run);
+  m.impl("conv2d_relu", QConvInt8<2, true>::run);
+  m.impl("conv3d",      QConvInt8<3, false>::run);
+  m.impl("conv3d_relu", QConvInt8<3, true>::run);
+}
+
+TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
+  m.impl("conv2d",      QConvInt8<2, false>::run);
+  m.impl("conv2d_relu", QConvInt8<2, true>::run);
+}
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
@@ -19,9 +19,9 @@ namespace {
  */
 
 template <int kSpatialDim = 2>
-class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
+class QConvUnpackWeightsInt8 final {
  public:
-  std::tuple<at::Tensor, c10::optional<at::Tensor>> operator()(
+  static std::tuple<at::Tensor, c10::optional<at::Tensor>> run(
       Tensor packed_weights) {
     auto& ctx = at::globalContext();
 
@@ -49,7 +49,7 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
 
  private:
 #ifdef USE_FBGEMM
-  std::tuple<Tensor, c10::optional<Tensor>> fbgemm_conv_unpack(
+  static std::tuple<Tensor, c10::optional<Tensor>> fbgemm_conv_unpack(
       Tensor packed_weights) {
     // Pull out the packed weight instance from the owning tensor.
     auto& pack_ptr = cpp_custom_type_hack::cast<PackedConvWeight<kSpatialDim>>(
@@ -130,7 +130,7 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
 #endif
 
 #ifdef USE_PYTORCH_QNNPACK
-  std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_conv_unpack(
+  static std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_conv_unpack(
       at::Tensor packed_weight) {
     auto& pack_ptr =
         cpp_custom_type_hack::cast<PackedConvWeightsQnnp>(packed_weight);
@@ -140,21 +140,13 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
 #endif
 };
 
-static auto registry =
-    c10::RegisterOperators()
-        .op("quantized::conv_unpack(Tensor packed_weights)"
-            " -> (Tensor unpacked_weights, Tensor? B_origin)",
-            c10::RegisterOperators::options().kernel<QConvUnpackWeightsInt8<2>>(
-                DispatchKey::CPU)) // conv_unpack is deprecated, please
-                                            // use conv2d_unpack for 2D conv.
-        .op("quantized::conv2d_unpack(Tensor packed_weights)"
-            " -> (Tensor unpacked_weights, Tensor? B_origin)",
-            c10::RegisterOperators::options().kernel<QConvUnpackWeightsInt8<2>>(
-                DispatchKey::CPU)) // We use  conv2d_unpack to be
-                                            // consistent with conv3d_unpack
-        .op("quantized::conv3d_unpack",
-            c10::RegisterOperators::options().kernel<QConvUnpackWeightsInt8<3>>(
-                DispatchKey::CPU));
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  // conv_unpack is deprecated, please use conv2d_unpack for 2D conv.
+  m.impl("conv_unpack", QConvUnpackWeightsInt8<2>::run);
+  // We use  conv2d_unpack to be consistent with conv3d_unpack
+  m.impl("conv2d_unpack", QConvUnpackWeightsInt8<2>::run);
+  m.impl("conv3d_unpack", QConvUnpackWeightsInt8<3>::run);
+}
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -14,10 +14,10 @@ namespace native {
 namespace {
 
 template <bool ReluFused>
-class QLinearInt8 final : public torch::OperatorKernel {
+class QLinearInt8 final {
  public:
 #ifdef USE_FBGEMM
-  at::Tensor fbgemm_linear(
+  static at::Tensor fbgemm_linear(
       at::Tensor input,
       at::Tensor packed_weight,
       double output_scale,
@@ -218,7 +218,7 @@ class QLinearInt8 final : public torch::OperatorKernel {
   }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-  at::Tensor qnnpack_linear(
+  static at::Tensor qnnpack_linear(
       at::Tensor input,
       at::Tensor packed_weight,
       double output_scale,
@@ -326,7 +326,7 @@ class QLinearInt8 final : public torch::OperatorKernel {
     return output;
   }
 #endif
-  at::Tensor operator()(
+  static at::Tensor run(
       at::Tensor input,
       at::Tensor packed_weight,
       double output_scale,
@@ -352,17 +352,15 @@ class QLinearInt8 final : public torch::OperatorKernel {
   }
 };
 
-static auto registry =
-    torch::RegisterOperators()
-        .op("quantized::linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
-            torch::RegisterOperators::options().kernel<QLinearInt8<false>>(
-                DispatchKey::QuantizedCPU))
-        .op("_quantized::linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
-            torch::RegisterOperators::options().kernel<QLinearInt8<false>>(
-                DispatchKey::QuantizedCPU))
-        .op("quantized::linear_relu(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
-            torch::RegisterOperators::options().kernel<QLinearInt8<true>>(
-                DispatchKey::QuantizedCPU));
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("linear", QLinearInt8<false>::run);
+  m.impl("linear_relu", QLinearInt8<true>::run);
+}
+
+TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
+  m.impl("linear", QLinearInt8<false>::run);
+}
+
 } // namespace
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -15,10 +15,10 @@ namespace native {
 namespace {
 
 template <bool ReluFused>
-class QLinearDynamicInt8 final : public torch::OperatorKernel {
+class QLinearDynamicInt8 final {
  public:
 #ifdef USE_FBGEMM
-  at::Tensor fbgemm_linear(at::Tensor input, at::Tensor packed_weight) {
+  static at::Tensor fbgemm_linear(at::Tensor input, at::Tensor packed_weight) {
     // fp32 * int8 -> fp32 (with quantization on activation, and dequantization
     // on the result).
 
@@ -213,7 +213,7 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
 #endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
 
-  at::Tensor qnnpack_linear(at::Tensor input, at::Tensor packed_weight) {
+  static at::Tensor qnnpack_linear(at::Tensor input, at::Tensor packed_weight) {
     TORCH_CHECK(
         input.dim() >= 2,
         "The dimension of input tensor should be larger than or equal to 2");
@@ -316,7 +316,8 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
     return output;
   }
 #endif // USE_PYTORCH_QNNPACK
-  at::Tensor operator()(at::Tensor input, at::Tensor packed_weight) {
+
+  static at::Tensor run(at::Tensor input, at::Tensor packed_weight) {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
@@ -337,10 +338,10 @@ class QLinearDynamicInt8 final : public torch::OperatorKernel {
 };
 
 template <bool ReluFused>
-class QLinearDynamicFp16 final : public torch::OperatorKernel {
+class QLinearDynamicFp16 final {
  public:
 #ifdef USE_FBGEMM
-  at::Tensor operator()(at::Tensor input, at::Tensor packed_weight) {
+  static at::Tensor run(at::Tensor input, at::Tensor packed_weight) {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
     // a fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -383,7 +384,7 @@ class QLinearDynamicFp16 final : public torch::OperatorKernel {
     return output;
   }
 #else // USE_FBGEMM
-  at::Tensor operator()(
+  static at::Tensor run(
       at::Tensor /* input */,
       at::Tensor /* packed_weight */) {
     // We make a strong guarantee that models using these operators will have
@@ -395,20 +396,15 @@ class QLinearDynamicFp16 final : public torch::OperatorKernel {
 #endif // USE_FBGEMM
 };
 
-static auto registry =
-    torch::RegisterOperators()
-        .op("quantized::linear_dynamic(Tensor X, Tensor W_prepack) -> Tensor Y",
-            torch::RegisterOperators::options()
-                .kernel<QLinearDynamicInt8<false>>(DispatchKey::CPU))
-        .op("_quantized::linear_dynamic(Tensor X, Tensor W_prepack) -> Tensor Y",
-            torch::RegisterOperators::options()
-                .kernel<QLinearDynamicInt8<false>>(DispatchKey::CPU))
-        .op("quantized::linear_relu_dynamic(Tensor X, Tensor W_prepack) -> Tensor Y",
-            torch::RegisterOperators::options()
-                .kernel<QLinearDynamicInt8<true>>(DispatchKey::CPU))
-        .op("quantized::linear_dynamic_fp16(Tensor X, Tensor W_prepack) -> Tensor Y",
-            torch::RegisterOperators::options()
-                .kernel<QLinearDynamicFp16<false>>(DispatchKey::CPU));
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  m.impl("linear_dynamic", QLinearDynamicInt8<false>::run);
+  m.impl("linear_relu_dynamic", QLinearDynamicInt8<true>::run);
+  m.impl("linear_dynamic_fp16", QLinearDynamicFp16<false>::run);
+}
+
+TORCH_LIBRARY_IMPL(_quantized, CPU, m) {
+  m.impl("linear_dynamic", QLinearDynamicInt8<false>::run);
+}
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -24,14 +24,14 @@ namespace at {
 namespace native {
 namespace {
 
-class QLinearPackWeightInt8 final : public c10::OperatorKernel {
+class QLinearPackWeightInt8 final {
  public:
 #ifdef USE_FBGEMM
   // Calculate the column offsets.
   // Note this includes the sum of the columns as well as the scalar term
   // B_zero_point * K, whereas the row_offsets created by
   // PackAWithQuantRowOffset is only the sum of the A rows.
-  void calc_col_offsets_transpose(
+  static void calc_col_offsets_transpose(
       int K,
       int N,
       const int8_t* Bint8,
@@ -50,7 +50,7 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
       }
     }
   }
-  at::Tensor fbgemm_linear_prepack(
+  static at::Tensor fbgemm_linear_prepack(
       at::Tensor weight,
       c10::optional<Tensor> bias) {
     TORCH_CHECK(
@@ -126,7 +126,7 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
   }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-  at::Tensor qnnpack_linear_prepack(
+  static at::Tensor qnnpack_linear_prepack(
       at::Tensor weight,
       c10::optional<Tensor> bias_in) {
     TORCH_CHECK(
@@ -173,7 +173,7 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
     return cpp_custom_type_hack::create(std::move(wt_ptr), weight.options());
   }
 #endif
-  at::Tensor operator()(at::Tensor weight, c10::optional<Tensor> bias) {
+  static at::Tensor run(at::Tensor weight, c10::optional<Tensor> bias) {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
@@ -193,10 +193,10 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
   }
 };
 
-class QLinearPackWeightFp16 final : public c10::OperatorKernel {
- public:
+class QLinearPackWeightFp16 final {
+public:
 #ifdef USE_FBGEMM
-  at::Tensor fbgemm_linear_prepack_fp16(
+  static at::Tensor fbgemm_linear_prepack_fp16(
       at::Tensor weight,
       c10::optional<Tensor> bias) {
     const int64_t K = weight.size(1);
@@ -220,7 +220,7 @@ class QLinearPackWeightFp16 final : public c10::OperatorKernel {
   }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-  at::Tensor qnnpack_linear_prepack_fp16(
+  static at::Tensor qnnpack_linear_prepack_fp16(
       at::Tensor weight,
       c10::optional<Tensor> bias_in) {
     TORCH_CHECK(
@@ -229,7 +229,7 @@ class QLinearPackWeightFp16 final : public c10::OperatorKernel {
         "not supported by QNNPACK");
   }
 #endif // USE_PYTORCH_QNNPACK
-  at::Tensor operator()(at::Tensor weight, c10::optional<Tensor> bias) {
+  static at::Tensor run(at::Tensor weight, c10::optional<Tensor> bias) {
     auto& ctx = at::globalContext();
 #ifdef USE_FBGEMM
     if (ctx.qEngine() == at::QEngine::FBGEMM) {
@@ -249,7 +249,7 @@ class QLinearPackWeightFp16 final : public c10::OperatorKernel {
 
  private:
 #ifdef USE_FBGEMM
-  float RawUint16ToFp16(unsigned short value) {
+  static float RawUint16ToFp16(unsigned short value) {
     // Convert raw 16 bits half precision floating point number
     // to single precision floating point number.
     const unsigned short sign_bits = value >> 15;
@@ -265,7 +265,7 @@ class QLinearPackWeightFp16 final : public c10::OperatorKernel {
   }
 
   template <typename T>
-  bool CheckAndSaturate(T max_val, T* element) {
+  static bool CheckAndSaturate(T max_val, T* element) {
     if (*element > max_val) {
       *element = max_val;
       return true;
@@ -280,7 +280,7 @@ class QLinearPackWeightFp16 final : public c10::OperatorKernel {
   // The range for using FP16 quantization of weights requires that the elements
   // should be in the range of [5.96e-8, 65504]. If it is out of range, then the
   // number will be saturated to max or min representable values by FP16.
-  void HandleWeightsSaturation(int64_t N, float* weight) {
+  static void HandleWeightsSaturation(int64_t N, float* weight) {
     const float kFp16Max = RawUint16ToFp16(0x7BFF);
     bool found_out_of_range = false;
     for (int64_t i = 0; i < N; ++i) {
@@ -295,24 +295,21 @@ class QLinearPackWeightFp16 final : public c10::OperatorKernel {
 #endif // USE_FBGEMM
 };
 
-static auto registry =
-    c10::RegisterOperators()
-        .op("quantized::linear_prepack(Tensor W, Tensor? B=None) -> Tensor W_prepack",
-            c10::RegisterOperators::options()
-            .aliasAnalysis(at::AliasAnalysisKind::PURE_FUNCTION)
-            .kernel<QLinearPackWeightInt8>(DispatchKey::QuantizedCPU))
-        .op("quantized::linear_prepack_fp16(Tensor W, Tensor? B=None) -> Tensor W_prepack",
-            c10::RegisterOperators::options()
-            .aliasAnalysis(at::AliasAnalysisKind::PURE_FUNCTION)
-            .kernel<QLinearPackWeightFp16>(DispatchKey::CPU))
-        .op("_quantized::linear_prepack(Tensor W, Tensor? B=None) -> Tensor W_prepack",
-            c10::RegisterOperators::options()
-            .aliasAnalysis(at::AliasAnalysisKind::PURE_FUNCTION)
-            .kernel<QLinearPackWeightInt8>(DispatchKey::QuantizedCPU))
-        .op("_quantized::linear_prepack_fp16(Tensor W, Tensor? B=None) -> Tensor W_prepack",
-            c10::RegisterOperators::options()
-            .aliasAnalysis(at::AliasAnalysisKind::PURE_FUNCTION)
-            .kernel<QLinearPackWeightFp16>(DispatchKey::CPU));
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("linear_prepack", QLinearPackWeightInt8::run);
+}
+
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  m.impl("linear_prepack", QLinearPackWeightFp16::run);
+}
+
+TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
+  m.impl("linear_prepack", QLinearPackWeightInt8::run);
+}
+
+TORCH_LIBRARY_IMPL(_quantized, CPU, m) {
+  m.impl("linear_prepack", QLinearPackWeightFp16::run);
+}
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -300,7 +300,7 @@ TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
 }
 
 TORCH_LIBRARY_IMPL(quantized, CPU, m) {
-  m.impl("linear_prepack", QLinearPackWeightFp16::run);
+  m.impl("linear_prepack_fp16", QLinearPackWeightFp16::run);
 }
 
 TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
@@ -308,7 +308,7 @@ TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
 }
 
 TORCH_LIBRARY_IMPL(_quantized, CPU, m) {
-  m.impl("linear_prepack", QLinearPackWeightFp16::run);
+  m.impl("linear_prepack_fp16", QLinearPackWeightFp16::run);
 }
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -8,10 +8,10 @@ namespace at {
 namespace native {
 namespace {
 
-class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
+class QLinearUnpackWeightInt8 final {
  public:
 #ifdef USE_FBGEMM
-  std::tuple<at::Tensor, c10::optional<Tensor>> fbgemm_linear_unpack(
+  static std::tuple<at::Tensor, c10::optional<Tensor>> fbgemm_linear_unpack(
       at::Tensor packed_weight) {
     // Pull out the PackBMatrix instance from the owning tensor.
     auto& pack_ptr =
@@ -56,7 +56,7 @@ class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
   }
 #endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
-  std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_linear_unpack(
+  static std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_linear_unpack(
       at::Tensor packed_weight) {
     auto& pack_ptr =
         cpp_custom_type_hack::cast<PackedLinearWeightsQnnp>(packed_weight);
@@ -64,7 +64,7 @@ class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
         pack_ptr.orig_weight, pack_ptr.bias);
   }
 #endif // USE_PYTORCH_QNNPACK
-  std::tuple<at::Tensor, c10::optional<Tensor>> operator()(
+  static std::tuple<at::Tensor, c10::optional<Tensor>> run(
       at::Tensor packed_weight) {
     auto& ctx = at::globalContext();
 
@@ -85,10 +85,10 @@ class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
   }
 };
 
-class QLinearUnpackWeightFp16 final : public c10::OperatorKernel {
+class QLinearUnpackWeightFp16 final {
  public:
 #ifdef USE_FBGEMM
-  std::tuple<at::Tensor, c10::optional<Tensor>> fbgemm_linear_unpack(
+  static std::tuple<at::Tensor, c10::optional<Tensor>> fbgemm_linear_unpack(
       at::Tensor packed_weight) {
     // Pull out the PackBMatrix instance from the owning tensor.
     auto& packed_struct =
@@ -109,7 +109,7 @@ class QLinearUnpackWeightFp16 final : public c10::OperatorKernel {
   }
 #endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
-  std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_linear_unpack(
+  static std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_linear_unpack(
       at::Tensor packed_weight) {
     TORCH_CHECK(
         false,
@@ -117,7 +117,7 @@ class QLinearUnpackWeightFp16 final : public c10::OperatorKernel {
         "not supported by QNNPACK");
   }
 #endif // USE_PYTORCH_QNNPACK
-  std::tuple<at::Tensor, c10::optional<Tensor>> operator()(
+  static std::tuple<at::Tensor, c10::optional<Tensor>> run(
       at::Tensor packed_weight) {
     auto& ctx = at::globalContext();
 
@@ -138,14 +138,10 @@ class QLinearUnpackWeightFp16 final : public c10::OperatorKernel {
   }
 };
 
-static auto registry =
-    c10::RegisterOperators()
-        .op("quantized::linear_unpack(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)",
-            c10::RegisterOperators::options().kernel<QLinearUnpackWeightInt8>(
-                DispatchKey::CPU))
-        .op("quantized::linear_unpack_fp16(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)",
-            c10::RegisterOperators::options().kernel<QLinearUnpackWeightFp16>(
-                DispatchKey::CPU));
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  m.impl("linear_unpack", QLinearUnpackWeightInt8::run);
+  m.impl("linear_unpack_fp16", QLinearUnpackWeightFp16::run);
+}
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qmul.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qmul.cpp
@@ -100,9 +100,9 @@ Tensor _mul_scalar_out(Tensor& out, const Tensor& self, Scalar other) {
 }
 
 template <bool ReLUFused = false>
-class QMul final : public c10::OperatorKernel {
+class QMul final {
  public:
-  Tensor operator()(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
+  static Tensor run(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
     check_inputs(qa, qb);
     auto qc = at::_empty_affine_quantized(
         qa.sizes(),
@@ -115,9 +115,9 @@ class QMul final : public c10::OperatorKernel {
 };
 
 template <bool ReLUFused = false>
-class QMulOut final : public c10::OperatorKernel {
+class QMulOut final {
  public:
-  Tensor operator()(at::Tensor qa, at::Tensor qb, Tensor out) {
+  static Tensor run(at::Tensor qa, at::Tensor qb, Tensor out) {
     check_inputs(qa, qb);
     return _mul_out<ReLUFused>(out, qa, qb);
   }
@@ -125,9 +125,9 @@ class QMulOut final : public c10::OperatorKernel {
 
 
 template <bool ReLUFused = false>
-class QMulScalar final : public c10::OperatorKernel {
+class QMulScalar final {
  public:
-  Tensor operator()(Tensor qa, Scalar b) {
+  static Tensor run(Tensor qa, Scalar b) {
     TORCH_CHECK(qa.qscheme() == kPerTensorAffine ||
               qa.qscheme() == kPerTensorSymmetric,
               "Only per tensor quantization is suuported in Mul.");
@@ -137,64 +137,24 @@ class QMulScalar final : public c10::OperatorKernel {
 };
 
 template <bool ReLUFused = false>
-class QMulScalarOut final : public c10::OperatorKernel {
+class QMulScalarOut final {
  public:
-  Tensor operator()(Tensor qa, Scalar b, Tensor out) {
+  static Tensor run(Tensor qa, Scalar b, Tensor out) {
     check_inputs(qa, out);
     return _mul_scalar_out<ReLUFused>(out, qa, b);
   }
 };
 
-static auto registry =
-    c10::RegisterOperators()
-        .op("quantized::mul(Tensor qa, Tensor qb, float scale, int zero_point)"
-            "-> Tensor qc",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMul</*ReLUFused=*/false>>(
-                    DispatchKey::QuantizedCPU))
-        .op("quantized::mul_relu(Tensor qa, Tensor qb, float scale, int zero_point)"
-            "-> Tensor qc",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMul</*ReLUFused=*/true>>(
-                    DispatchKey::QuantizedCPU))
-        .op("quantized::mul_out(Tensor qa, Tensor qb, Tensor(a!) out)"
-            "-> Tensor(a!) out",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMulOut</*ReLUFused=*/false>>(
-                    DispatchKey::QuantizedCPU))
-        .op("quantized::mul_relu_out(Tensor qa, Tensor qb, Tensor(a!) out)"
-            "-> Tensor(a!) out",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMulOut</*ReLUFused=*/true>>(
-                    DispatchKey::QuantizedCPU))
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("mul",                 QMul</*ReLUFused=*/false>::run);
+  m.impl("mul_relu",            QMul</*ReLUFused=*/true>::run);
+  m.impl("mul_out",             QMulOut</*ReLUFused=*/false>::run);
+  m.impl("mul_relu_out",        QMulOut</*ReLUFused=*/true>::run);
+  m.impl("mul_scalar",          QMulScalar</*ReLUFused=*/false>::run);
+  m.impl("mul_scalar_relu",     QMulScalar</*ReLUFused=*/true>::run);
+  m.impl("mul_scalar_out",      QMulScalarOut</*ReLUFused=*/false>::run);
+  m.impl("mul_scalar_relu_out", QMulScalarOut</*ReLUFused=*/true>::run);
+}
 
-        .op("quantized::mul_scalar(Tensor qa, Scalar b)"
-            "-> Tensor qc",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMulScalar</*ReLUFused=*/false>>(
-                    DispatchKey::QuantizedCPU))
-        .op("quantized::mul_scalar_relu(Tensor qa, Scalar b)"
-            "-> Tensor qc",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMulScalar</*ReLUFused=*/true>>(
-                    DispatchKey::QuantizedCPU))
-        .op("quantized::mul_scalar_out(Tensor qa, Scalar b, Tensor(a!) out)"
-            "-> Tensor(a!) out",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMulScalarOut</*ReLUFused=*/false>>(
-                    DispatchKey::QuantizedCPU))
-        .op("quantized::mul_scalar_relu_out(Tensor qa, Scalar b, Tensor(a!) out)"
-            "-> Tensor(a!) out",
-            c10::RegisterOperators::options()
-                .aliasAnalysis(at::AliasAnalysisKind::FROM_SCHEMA)
-                .kernel<QMulScalarOut</*ReLUFused=*/true>>(
-                    DispatchKey::QuantizedCPU));
 }  // namespace
 }}  // namespace at::native

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -268,10 +268,10 @@ Tensor quantized_max_pool2d(
 
 // Keep the registry in the anonymous namespace.
 namespace {
-class QMaxPool2D_arr_args final : public torch::OperatorKernel {
+class QMaxPool2D_arr_args final {
  public:
   #ifdef USE_PYTORCH_QNNPACK
-   Tensor qnnpack_maxpool(
+   static Tensor qnnpack_maxpool(
        Tensor input,
        IntArrayRef kernel_size,
        IntArrayRef stride,
@@ -396,7 +396,7 @@ class QMaxPool2D_arr_args final : public torch::OperatorKernel {
      return qy.permute({0, 3, 1, 2});
    }
    #endif
-  Tensor operator()(
+  static Tensor run(
       Tensor qx,
       std::vector<int64_t> kernel_size,
       std::vector<int64_t> stride,
@@ -412,15 +412,9 @@ class QMaxPool2D_arr_args final : public torch::OperatorKernel {
   }
 };
 
-static auto registry = torch::RegisterOperators().op(
-    "quantized::max_pool2d(Tensor qx, "
-    "int[] kernel_size, "
-    "int[] stride, "
-    "int[] padding, "
-    "int[] dilation,"
-    "bool ceil_mode) -> Tensor",
-    torch::RegisterOperators::options().kernel<QMaxPool2D_arr_args>(
-        DispatchKey::QuantizedCPU));
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("max_pool2d", QMaxPool2D_arr_args::run);
+}
 
 } // namespace
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -157,9 +157,9 @@ Tensor quantized_relu6_(Tensor& qx) {
   return qx;
 }
 
-class QRelu6 final : public c10::OperatorKernel {
+class QRelu6 final {
  public:
-  Tensor operator()(Tensor qx, bool inplace) {
+  static Tensor run(Tensor qx, bool inplace) {
     if (inplace) {
       return quantized_relu6_(qx);
     } else {
@@ -168,9 +168,10 @@ class QRelu6 final : public c10::OperatorKernel {
   }
 };
 
-static auto registry = c10::RegisterOperators()
-.op("quantized::relu6(Tensor qx, bool inplace=False) -> Tensor",
-    c10::RegisterOperators::options().kernel<QRelu6>(DispatchKey::QuantizedCPU));
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("relu6", QRelu6::run);
+}
+
 } // namespace
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/quantized/cpu/tensor_operators.cpp
+++ b/aten/src/ATen/native/quantized/cpu/tensor_operators.cpp
@@ -78,11 +78,10 @@ Tensor& quantized_resize_cpu_(
   resize_impl_cpu_(self_, size, /*strides=*/c10::nullopt);
   return self;
 }
-static auto registry = torch::RegisterOperators()
-  .op(torch::RegisterOperators::options()
-    .schema("aten::resize_(Tensor(a!) self, int[] size, *, MemoryFormat? memory_format=None) -> Tensor(a!)")
-    .impl_unboxedOnlyKernel<decltype(quantized_resize_cpu_), &quantized_resize_cpu_>(DispatchKey::QuantizedCPU))
-  ;
+
+TORCH_LIBRARY_IMPL(aten, QuantizedCPU, m) {
+  m.impl_UNBOXED("resize_", quantized_resize_cpu_);
+}
 
 }  // namespcae
 }}  // at::native

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -26,6 +26,10 @@ TORCH_LIBRARY(quantized, m) {
   m.def("conv_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
   m.def("conv2d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
   m.def("conv3d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  // conv_unpack is deprecated, please use conv2d_unpack for 2D conv.
+  m.def("conv_unpack(Tensor packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)");
+  m.def("conv2d_unpack(Tensor packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)");
+  m.def("conv3d_unpack(Tensor packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)");
   m.def("layer_norm(Tensor input, int[] normalized_shape, Tensor weight, Tensor bias, float eps, float output_scale, int output_zero_point) -> Tensor");
   m.def("linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y");
   m.def("linear_relu(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y");

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -1,0 +1,64 @@
+#include <ATen/core/op_registration/op_registration.h>
+
+TORCH_LIBRARY(quantized, m) {
+  m.def("add(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc");
+  m.def("add_relu(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc");
+  m.def("add_out(Tensor qa, Tensor qb, Tensor(a!) out) -> Tensor(a!) out");
+  m.def("add_relu_out(Tensor qa, Tensor qb, Tensor(a!) out) -> Tensor(a!) out");
+  m.def("add_scalar(Tensor qa, Scalar b) -> Tensor qc");
+  m.def("add_scalar_relu(Tensor qa, Scalar b) -> Tensor qc");
+  m.def("add_scalar_out(Tensor qa, Scalar b, Tensor(a!) out) -> Tensor(a!) out");
+  m.def("add_scalar_relu_out(Tensor qa, Scalar b, Tensor(a!) out) -> Tensor(a!) out");
+  m.def("batch_norm2d(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor");
+  m.def("batch_norm2d_relu(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor");
+  m.def("batch_norm3d(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor");
+  m.def("batch_norm3d_relu(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor");
+  m.def("clamp(Tensor qx, Scalar? min, Scalar? max) -> Tensor qy");
+  m.def("cat(Tensor[] qx, int dim, float? scale, int? zero_point) -> Tensor");
+  m.def("cat_relu(Tensor[] qx, int dim, float? scale, int? zero_point) -> Tensor");
+  m.def("cat_out(Tensor[] qx, int dim, Tensor(a!) out) -> Tensor(a!)");
+  m.def("cat_relu_out(Tensor[] qx, int dim, Tensor(a!) out) -> Tensor(a!)");
+  m.def("conv2d(Tensor qx, Tensor weight, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor");
+  m.def("conv2d_relu(Tensor qx, Tensor weight, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor");
+  m.def("conv3d(Tensor qx, Tensor weight, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor");
+  m.def("conv3d_relu(Tensor qx, Tensor weight, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor");
+  // conv_prepack is deprecated, please use conv2d_prepack for 2D conv.
+  m.def("conv_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def("conv2d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def("conv3d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def("layer_norm(Tensor input, int[] normalized_shape, Tensor weight, Tensor bias, float eps, float output_scale, int output_zero_point) -> Tensor");
+  m.def("linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y");
+  m.def("linear_relu(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y");
+  m.def("linear_dynamic(Tensor X, Tensor W_prepack) -> Tensor Y");
+  m.def("linear_relu_dynamic(Tensor X, Tensor W_prepack) -> Tensor Y");
+  m.def("linear_dynamic_fp16(Tensor X, Tensor W_prepack) -> Tensor Y");
+  m.def("linear_prepack(Tensor W, Tensor? B=None) -> Tensor W_prepack");
+  m.def("linear_prepack_fp16(Tensor W, Tensor? B=None) -> Tensor W_prepack");
+  m.def("linear_unpack(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)");
+  m.def("linear_unpack_fp16(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)");
+  m.def("mul(Tensor qa, Tensor qb, float scale, int zero_point)-> Tensor qc");
+  m.def("mul_relu(Tensor qa, Tensor qb, float scale, int zero_point)-> Tensor qc");
+  m.def("mul_out(Tensor qa, Tensor qb, Tensor(a!) out)-> Tensor(a!) out");
+  m.def("mul_relu_out(Tensor qa, Tensor qb, Tensor(a!) out)-> Tensor(a!) out");
+  m.def("mul_scalar(Tensor qa, Scalar b)-> Tensor qc");
+  m.def("mul_scalar_relu(Tensor qa, Scalar b)-> Tensor qc");
+  m.def("mul_scalar_out(Tensor qa, Scalar b, Tensor(a!) out)-> Tensor(a!) out");
+  m.def("mul_scalar_relu_out(Tensor qa, Scalar b, Tensor(a!) out)-> Tensor(a!) out");
+  // NB: missing a space after comma here...
+  m.def("max_pool2d(Tensor qx, int[] kernel_size, int[] stride, int[] padding, int[] dilation,bool ceil_mode) -> Tensor");
+  m.def("relu6(Tensor qx, bool inplace=False) -> Tensor");
+}
+
+// According to #33294: The "_" prefix registration will be
+// removed when the operators are all migrated to mobile.
+// https://github.com/pytorch/pytorch/issues/36510
+TORCH_LIBRARY(_quantized, m) {
+  m.def("add(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc");
+  m.def("conv2d(Tensor qx, Tensor weight, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor");
+  m.def("conv2d_relu(Tensor qx, Tensor weight, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor");
+  m.def("conv2d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor");
+  m.def("linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y");
+  m.def("linear_dynamic(Tensor X, Tensor W_prepack) -> Tensor Y");
+  m.def("linear_prepack(Tensor W, Tensor? B=None) -> Tensor W_prepack");
+  m.def("linear_prepack_fp16(Tensor W, Tensor? B=None) -> Tensor W_prepack");
+}

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -37,6 +37,7 @@ white_list = [
     ('aten::backward', datetime.date(2020, 4, 30)),
     ('quantized::conv_prepack', datetime.date(2020, 6, 1)),
     ('quantized::conv3d_prepack', datetime.date(2020, 6, 1)),
+    ('quantized::conv3d_unpack', datetime.date(2020, 6, 1)),
     ('quantized::conv3d', datetime.date(2020, 6, 1)),
     ('quantized::conv2d_relu', datetime.date(2020, 6, 1)),
     ('quantized::conv2d', datetime.date(2020, 6, 1)),

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -35,6 +35,15 @@ white_list = [
     ('aten::sizes', datetime.date(2020, 4, 30)),
     ('aten::strides', datetime.date(2020, 4, 30)),
     ('aten::backward', datetime.date(2020, 4, 30)),
+    ('quantized::conv_prepack', datetime.date(2020, 6, 1)),
+    ('quantized::conv3d_prepack', datetime.date(2020, 6, 1)),
+    ('quantized::conv3d', datetime.date(2020, 6, 1)),
+    ('quantized::conv2d_relu', datetime.date(2020, 6, 1)),
+    ('quantized::conv2d', datetime.date(2020, 6, 1)),
+    ('_quantized::conv2d_relu', datetime.date(2020, 6, 1)),
+    ('_quantized::conv2d', datetime.date(2020, 6, 1)),
+    ('quantized::conv2d_prepack', datetime.date(2020, 6, 1)),
+    ('quantized::conv3d_relu', datetime.date(2020, 6, 1)),
 ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36800 Port xnnpack operators to new registration API
* #36742 Add custom class API to TORCH_LIBRARY API.
* **#36799 [RELAND] Port to quantized and other operators to new registration API**

This is a roll up of a bunch of small PRs for ease of landing.

- Update reference to RegisterOperators in error message in Convolution.
- Add explicit schema for quantized conv/conv_prepack (fixes #36511)
- Add a centralized TORCH_LIBRARY declaration for quantized and xnnpack ops (fixes #36510)
- Port to new registration API:
  - Resize
  - detach/detach_
  - All quantization operators
- Update quantized README for registering operators with new API

Differential Revision: [D21089649](https://our.internmc.facebook.com/intern/diff/D21089649)