### PR TITLE
fix the incorrect merge of profiling information of two tensor types for the same value

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3496,6 +3496,7 @@ class TestScript(JitTestCase):
                 eplan.code.request_bailout(i)
                 self.assertEqual(jitted(x), expected)
 
+<<<<<<< HEAD
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "skip if profiling isn't enabled")
     def test_dominated_bailout(self):
         with enable_profiling_mode():
@@ -3560,6 +3561,28 @@ class TestScript(JitTestCase):
                 g = torch.jit.last_executed_optimized_graph()
                 # there should still be a Bailout after disable_grad call
                 FileCheck().check("disable_grad").check("BailOut[").check("BailoutTemplate").run(g)
+=======
+
+    def test_profiling_merge(self):
+        @torch.jit.script
+        def test_not_const(x):
+            if x.size(0) == 1:
+                return 1
+            else:
+                return 2
+
+        with enable_profiling_mode():
+            old_num_runs = torch._C._jit_set_num_profiled_runs(2)
+            test_not_const(torch.rand([1, 2]))
+            test_not_const(torch.rand([2, 2]))
+            test_not_const(torch.rand([3, 2]))
+
+            graph_str = torch.jit.last_executed_optimized_graph()
+            FileCheck().check("Double(*, 2) = ").run(graph_str)
+            FileCheck().check_not("Double(2, 2) = ").run(graph_str)
+
+        torch._C._jit_set_num_profiled_runs(old_num_runs)
+>>>>>>> fix incorrect profiling merge
 
     def test_nested_bailouts(self):
         @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3496,7 +3496,6 @@ class TestScript(JitTestCase):
                 eplan.code.request_bailout(i)
                 self.assertEqual(jitted(x), expected)
 
-<<<<<<< HEAD
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "skip if profiling isn't enabled")
     def test_dominated_bailout(self):
         with enable_profiling_mode():
@@ -3561,8 +3560,8 @@ class TestScript(JitTestCase):
                 g = torch.jit.last_executed_optimized_graph()
                 # there should still be a Bailout after disable_grad call
                 FileCheck().check("disable_grad").check("BailOut[").check("BailoutTemplate").run(g)
-=======
 
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "skip if profiling isn't enabled")
     def test_profiling_merge(self):
         @torch.jit.script
         def test_not_const(x):
@@ -3582,7 +3581,6 @@ class TestScript(JitTestCase):
             FileCheck().check_not("Double(2, 2) = ").run(graph_str)
 
         torch._C._jit_set_num_profiled_runs(old_num_runs)
->>>>>>> fix incorrect profiling merge
 
     def test_nested_bailouts(self):
         @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3577,8 +3577,8 @@ class TestScript(JitTestCase):
             test_not_const(torch.rand([3, 2]))
 
             graph_str = torch.jit.last_executed_optimized_graph()
-            FileCheck().check("Double(*, 2) = ").run(graph_str)
-            FileCheck().check_not("Double(2, 2) = ").run(graph_str)
+            FileCheck().check("Double(*:2, 2:1) = ").run(graph_str)
+            FileCheck().check_not("Double(1:2, 2:1) = ").run(graph_str)
 
         torch._C._jit_set_num_profiled_runs(old_num_runs)
 

--- a/torch/csrc/jit/runtime/profiling_record.h
+++ b/torch/csrc/jit/runtime/profiling_record.h
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 
 #include <list>
+#include <unordered_set>
 #include <vector>
 
 namespace torch {
@@ -27,6 +28,7 @@ struct ProfilingRecord {
   std::shared_ptr<Graph> profiled_graph_;
   std::mutex mutex_;
   size_t profiling_count_;
+  std::unordered_set<Value*> seen_;
   bool ready() const {
     return profiling_count_ == 0;
   }


### PR DESCRIPTION
as a part of moving to the dynamic shapes we are now passing `frame_id` to each profiling callback. The implementation of that requires copying profiling callbacks into Interpreter, so `first`s are actually different for every run. The dynamic shapes merging algorithm won't be using `first`, but in the meantime, while we get there, this should be a good enough fix.