### PR TITLE
[pytorch] move prim::TupleIndex from register_prim_ops_fulljit to register_prim_ops

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -26,6 +26,22 @@ namespace {
 
 RegisterOperators reg({
     Operator(
+        // note the compiler knows to type TupleIndex more accurately than it
+        // is listed here.
+        "prim::TupleIndex(Any tup, int i) -> Any",
+        [](Stack& stack) {
+          int64_t index = pop(stack).toInt();
+          auto tuple = pop(stack).toTuple();
+          auto norm_index = normalizeIndex(index, tuple->elements().size());
+          if (norm_index < 0 ||
+              norm_index > static_cast<int64_t>(tuple->elements().size())) {
+            throw std::out_of_range("Tuple list index out of range");
+          }
+          stack.emplace_back(tuple->elements()[norm_index]);
+          return 0;
+        },
+        aliasAnalysisSpecialCase()),
+    Operator(
         "prim::TupleUnpack(Any tup) -> ...",
         [](Stack& stack) {
           tupleUnpack(stack);

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -629,22 +629,6 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      Operator(
-         // note the compiler knows to type TupleIndex more accurately than it
-         // is listed here.
-         "prim::TupleIndex(Any tup, int i) -> Any",
-         [](Stack& stack) {
-           int64_t index = pop(stack).toInt();
-           auto tuple = pop(stack).toTuple();
-           auto norm_index = normalizeIndex(index, tuple->elements().size());
-           if (norm_index < 0 ||
-               norm_index > static_cast<int64_t>(tuple->elements().size())) {
-             throw std::out_of_range("Tuple list index out of range");
-           }
-           stack.emplace_back(tuple->elements()[norm_index]);
-           return 0;
-         },
-         aliasAnalysisSpecialCase()),
-     Operator(
          prim::tolist,
          // This operator has to be unschematized because the return type
          // depends on the type hint and input. The implementation of this


### PR DESCRIPTION
Summary: Trying to run a model on mobile and prim::TupleIndex is reported as missing.  Moving it out from fulljit.

Differential Revision: D21065879

