### PR TITLE
[quant][graph] Update quantize_dynamic_script API to take sample model args

### DIFF
--- a/test/quantization/test_quantization.py
+++ b/test/quantization/test_quantization.py
@@ -1176,7 +1176,7 @@ class GraphModePostTrainingQuantTest(QuantizationTestCase):
                 model_under_test,
                 qconfig_dict,
                 test_only_eval_fn,
-                [self.calib_data])
+                [self.calib_data[0][0]])
             self.assertEqual(model_quantized(self.calib_data[0][0]), result_eager)
 
             # Check to make sure choose_qparams->quant->dequant->linear is numerically
@@ -1185,7 +1185,7 @@ class GraphModePostTrainingQuantTest(QuantizationTestCase):
                 model_under_test,
                 qconfig_dict,
                 test_only_eval_fn,
-                [self.calib_data],
+                [self.calib_data[0][0]],
                 debug=True)
             self.assertEqual(model_fake_quantized(self.calib_data[0][0]), result_eager)
 

--- a/test/quantization/test_quantization.py
+++ b/test/quantization/test_quantization.py
@@ -1175,7 +1175,6 @@ class GraphModePostTrainingQuantTest(QuantizationTestCase):
             model_quantized = quantize_dynamic_script(
                 model_under_test,
                 qconfig_dict,
-                test_only_eval_fn,
                 [self.calib_data[0][0]])
             self.assertEqual(model_quantized(self.calib_data[0][0]), result_eager)
 
@@ -1184,7 +1183,6 @@ class GraphModePostTrainingQuantTest(QuantizationTestCase):
             model_fake_quantized = quantize_dynamic_script(
                 model_under_test,
                 qconfig_dict,
-                test_only_eval_fn,
                 [self.calib_data[0][0]],
                 debug=True)
             self.assertEqual(model_fake_quantized(self.calib_data[0][0]), result_eager)

--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1681,10 +1681,10 @@ class TestQuantizeDynamicScript(JitTestCase):
             def forward(self, x):
                 return self.fc(x)
 
-        data = [(torch.rand((1, 5), dtype=torch.float), torch.randint(0, 1, (1,), dtype=torch.long)) for _ in range(2)]
+        data = torch.rand((1, 5), dtype=torch.float)
         qconfig_dict = {'': default_dynamic_qconfig}
         model = torch.jit.script(M()).eval()
-        model = quantize_dynamic_script(model, qconfig_dict, _test_only_eval_fn, [data])
+        model = quantize_dynamic_script(model, qconfig_dict, data)
         FileCheck().check("quantized::linear_dynamic") \
                    .run(model.graph)
 

--- a/torch/quantization/_quantize_script.py
+++ b/torch/quantization/_quantize_script.py
@@ -118,7 +118,7 @@ def _quantize_script(model, qconfig_dict, run_fn, run_args, is_dynamic, debug):
     model = wrap_cpp_module(torch._C._jit_pass_fold_convbn(model._c))
     if is_dynamic:
         model = prepare_dynamic_script(model, qconfig_dict)
-        run_fn(model._c._get_method('forward'), *run_args)
+        model(*run_args)
         model = convert_dynamic_script(model, debug)
     else:
         model = prepare_script(model, qconfig_dict, True)
@@ -133,5 +133,5 @@ def quantize_script(model, qconfig_dict, run_fn, run_args, inplace=False, debug=
         model = model.copy()
     return _quantize_script(model, qconfig_dict, run_fn, run_args, is_dynamic=False, debug=debug)
 
-def quantize_dynamic_script(model, qconfig_dict, run_fn, run_args, debug=False):
-    return _quantize_script(model, qconfig_dict, run_fn, run_args, is_dynamic=True, debug=debug)
+def quantize_dynamic_script(model, qconfig_dict, sample_model_inputs, debug=False):
+    return _quantize_script(model, qconfig_dict, None, sample_model_inputs, is_dynamic=True, debug=debug)

--- a/torch/quantization/_quantize_script.py
+++ b/torch/quantization/_quantize_script.py
@@ -111,7 +111,7 @@ def convert_script(model, inplace=False, debug=False):
 def convert_dynamic_script(model, debug=False):
     return _convert_script(model, is_dynamic=True, debug=debug)
 
-def _quantize_script(model, qconfig_dict, run_fn, run_args, is_dynamic, debug):
+def _quantize_script(model, qconfig_dict, run_fn=None, run_args=None, is_dynamic=False, debug=False):
     _check_is_script_module(model)
     _check_forward_method(model)
     torch._C._jit_pass_dedup_module_uses(model._c)
@@ -134,4 +134,4 @@ def quantize_script(model, qconfig_dict, run_fn, run_args, inplace=False, debug=
     return _quantize_script(model, qconfig_dict, run_fn, run_args, is_dynamic=False, debug=debug)
 
 def quantize_dynamic_script(model, qconfig_dict, sample_model_inputs, debug=False):
-    return _quantize_script(model, qconfig_dict, None, sample_model_inputs, is_dynamic=True, debug=debug)
+    return _quantize_script(model, qconfig_dict, run_args=sample_model_inputs, is_dynamic=True, debug=debug)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36844 [quant][graph] Add quantized::mul_relu and quantized::mul_scalar_relu ops
* #36818 [quant][graph] Support for quantized::mul and quantized::mul_scalar
* **#36817 [quant][graph] Update quantize_dynamic_script API to take sample model args**

Summary:
For dynamic quant we need to run the observers on the weights to calculate the qparams before calling convert on the model.
The API requires the user to provide dummy inputs that will be fed to the model after the prepare step to run the observers

Test Plan:
test_quanitze_script.py
test_quantization.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21134439](https://our.internmc.facebook.com/intern/diff/D21134439)