### PR TITLE
[caffe2] Fix build

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -35,7 +35,7 @@ static bool in_bad_fork = false;  // True for children forked after cuda init
 // Called in the forked child if cuda has already been initialized
 static void forked_child() {
   in_bad_fork = true;
-  utils::set_run_yet_variable_to_false();
+  torch::utils::set_run_yet_variable_to_false();
   state = nullptr;
 }
 #endif


### PR DESCRIPTION
Summary: util::XXX is ambiguous because there are torch::util and c10::util two namespaces.

Test Plan: A green build

Differential Revision: D21083564

