### PR TITLE
make simple executor our default for OSS

### DIFF
--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -29,7 +29,7 @@ static std::atomic<bool> executor_mode{false};
 static std::atomic<bool> profiling_mode{false};
 #else
 static std::atomic<bool> executor_mode{true};
-static std::atomic<bool> profiling_mode{true};
+static std::atomic<bool> profiling_mode{false};
 #endif
 
 static std::atomic<size_t> num_profiled_runs{1};


### PR DESCRIPTION
Given that we keep running into the issue of incredibly long compilation times, we decided to switch to the simple executor which skips fusion-related passes and analyses. It might affect some users that rely on fusion on GPU to achieve their performance. profile. We will make a note in our release notes for such users to enable the profiling executor.