### PR TITLE
`MultiProcessTestCase` to use instance rather than class method wrappers

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -60,6 +60,9 @@ test_python_all() {
     file_diff_from_base "$DETERMINE_FROM"
   fi
 
+  # Increase default limit on open file handles from 256 to 1024
+  ulimit -n 1024
+
   python test/run_test.py --verbose --determine-from="$DETERMINE_FROM"
 
   assert_git_not_dirty

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -183,7 +183,7 @@ class MultiProcessTestCase(TestCase):
         return types.MethodType(wrapper, self)
 
     # The main process spawns N subprocesses that run the test.
-    # This function patches overwrites every test function to either
+    # Constructor patches current instance test method to
     # assume the role of the main process and join its subprocesses,
     # or run the underlying test function.
     def __init__(self, method_name='runTest'):

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -7,6 +7,7 @@ import unittest
 import logging
 import six
 import traceback
+import types
 
 from collections import namedtuple
 from functools import wraps
@@ -167,31 +168,28 @@ class MultiProcessTestCase(TestCase):
     def world_size(self):
         return 4
 
-    @staticmethod
-    def join_or_run(fn):
+    def join_or_run(self, fn):
         @wraps(fn)
         def wrapper(self):
             if self.rank == self.MAIN_PROCESS_RANK:
                 self._join_processes(fn)
             else:
                 try:
-                    fn(self)
+                    fn()
                 except Exception as e:
                     logging.error('Caught exception: \n{}exiting process with exit code: {}'
                                   .format(traceback.format_exc(), MultiProcessTestCase.TEST_ERROR_EXIT_CODE))
                     sys.exit(MultiProcessTestCase.TEST_ERROR_EXIT_CODE)
-        return wrapper
+        return types.MethodType(wrapper, self)
 
     # The main process spawns N subprocesses that run the test.
     # This function patches overwrites every test function to either
     # assume the role of the main process and join its subprocesses,
     # or run the underlying test function.
-    @classmethod
-    def setUpClass(cls):
-        for attr in dir(cls):
-            if attr.startswith('test'):
-                fn = getattr(cls, attr)
-                setattr(cls, attr, cls.join_or_run(fn))
+    def __init__(self, method_name='runTest'):
+        super().__init__(method_name)
+        fn = getattr(self, method_name)
+        setattr(self, method_name, self.join_or_run(fn))
 
     def setUp(self):
         super(MultiProcessTestCase, self).setUp()


### PR DESCRIPTION
This makes its wrappers stackable with `common_utils.TestCase` ones

Test Plan: CI

