### PR TITLE
Print GPU info for ROCm test runs

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -36,6 +36,8 @@ if [ -n "${IN_CIRCLECI}" ]; then
 fi
 
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+  # Print GPU info
+  rocminfo | egrep 'Name:.*\sgfx|Marketing'
   # TODO: Move this to Docker
   sudo apt-get -qq update
   sudo apt-get -qq install --no-install-recommends libsndfile1


### PR DESCRIPTION
Printing the GPU device info for ROCm test runs could aid in triaging device-specific issues. Printing gfx generation and device Name for now.
Sample output:
```
  Marketing Name:          AMD EPYC 7702 64-Core Processor
  Marketing Name:          AMD EPYC 7702 64-Core Processor
  Name:                    gfx906
  Marketing Name:          Device 66a1
  Name:                    gfx906
  Marketing Name:          Device 66a1
  Name:                    gfx906
  Marketing Name:          Device 66a1
  Name:                    gfx906
  Marketing Name:          Device 66a1
  Name:                    gfx906
  Marketing Name:          Device 66a1
  Name:                    gfx906
  Marketing Name:          Device 66a1
  Name:                    gfx906
  Marketing Name:          Device 66a1
```
cc @iotamudelta 