### PR TITLE
Update cusparse deprecated Xcsrmm2 call

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -7,6 +7,12 @@
 #include <TH/THGeneral.h>
 
 #include <cusparse.h>
+#include <library_types.h>
+
+// LIMITATION (cusparseSpMM): 
+// The generic APIs are currently (CUDA 10.1) available for all platforms except Windows. 
+// Using these APIs in any other systems will result in compile-time or run-time failures. 
+// Their support will be extended in the next releases. 
 
 #if !defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 10200)
 const char* cusparseGetErrorString(cusparseStatus_t status) {
@@ -71,6 +77,119 @@ cusparseOperation_t convertTransToCusparseOperation(char trans) {
   }
 }
 
+#if !defined(MSC_VER) && CUSPARSE_VERSION >= 10301 // CUDA release >= 10.2 and not windows
+
+template<typename T> 
+void csrmm2(
+  char transa, char transb, 
+  int64_t m, int64_t n, int64_t k, int64_t nnz, 
+  T alpha, T *csrvala, int *csrrowptra, int *csrcolinda, 
+  T *b, int64_t ldb, T beta, T *c, int64_t ldc)
+{
+  static_assert(std::is_same<float, T>::value || std::is_same<double, T>::value); 
+  constexpr auto cusparse_value_type = std::is_same<float, T>::value ? CUDA_R_32F : CUDA_R_64F; 
+
+  if (csrvala == nullptr || b == nullptr || c == nullptr) return; 
+
+  cusparseOperation_t opa = convertTransToCusparseOperation(transa);
+  cusparseOperation_t opb = convertTransToCusparseOperation(transb);
+
+  // cusparseSpMM actually supports int64_t. 
+  // In order to support int64 here, index pointers csrrowptra, csrcolinda have to be passed as int64_t. 
+  TORCH_CHECK((m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX) && (ldb <= INT_MAX) && (ldc <= INT_MAX),
+    "By now, cusparseSpMM only supports m, n, k, nnz, ldb, ldc with the bound [val] <= ", INT_MAX, ".", 
+    "Please submit an issue on Github."
+  );
+
+  int64_t ma = m, ka = k; 
+  if (transa != 'n') std::swap(ma, ka); 
+
+  cusparseSpMatDescr_t descA; 
+  TORCH_CUDASPARSE_CHECK(cusparseCreateCsr(
+    &descA,                     /* output */
+    ma, ka, nnz,                /* rows, cols, number of non zero elements */
+    csrrowptra,                 /* row offsets of the sparse matrix, size = rows +1 */
+    csrcolinda,                 /* column indices of the sparse matrix, size = nnz */
+    csrvala,                    /* values of the sparse matrix, size = nnz */
+    CUSPARSE_INDEX_32I,         /* data type of row offsets index */
+    CUSPARSE_INDEX_32I,         /* data type of col indices */
+    CUSPARSE_INDEX_BASE_ZERO,   /* base index of row offset and col indes */
+    cusparse_value_type         /* data type of values */
+  )); 
+
+  int64_t kb = k, nb = n;
+  if (transb != 'n') std::swap(kb, nb); 
+
+  cusparseDnMatDescr_t descB; 
+  TORCH_CUDASPARSE_CHECK(cusparseCreateDnMat(
+    &descB,               /* output */
+    kb, nb, ldb,          /* rows, cols, leading dimension */
+    b,                    /* values */
+    cusparse_value_type,  /* data type of values */
+    CUSPARSE_ORDER_COL    /* memory layout, ONLY column-major is supported now */
+  )); 
+
+  cusparseDnMatDescr_t descC; 
+  TORCH_CUDASPARSE_CHECK(cusparseCreateDnMat(
+    &descC,               /* output */
+    m, n, ldc,            /* rows, cols, leading dimension */
+    c,                    /* values */ 
+    cusparse_value_type,  /* data type of values */ 
+    CUSPARSE_ORDER_COL    /* memory layout, ONLY column-major is supported now */
+  )); 
+
+
+  auto handle = at::cuda::getCurrentCUDASparseHandle();
+
+  // cusparseSpMM_bufferSize returns the bufferSize that can be used by cusparseSpMM
+  size_t bufferSize; 
+  TORCH_CUDASPARSE_CHECK(cusparseSpMM_bufferSize(
+    handle, opa, opb,     
+    &alpha,               
+    descA, descB, 
+    &beta, 
+    descC, 
+    cusparse_value_type,  /* data type in which the computation is executed */
+    CUSPARSE_CSRMM_ALG1,  /* default computing algorithm for CSR sparse matrix format */
+    &bufferSize           /* output */
+  )); 
+
+  void* externalBuffer; // device pointer
+  AT_CUDA_CHECK(cudaMalloc(&externalBuffer, bufferSize)); 
+
+  TORCH_CUDASPARSE_CHECK(cusparseSpMM(
+    handle, opa, opb, 
+    &alpha, 
+    descA, descB, 
+    &beta, 
+    descC, 
+    cusparse_value_type,  /* data type in which the computation is executed */
+    CUSPARSE_CSRMM_ALG1,  /* default computing algorithm for CSR sparse matrix format */
+    externalBuffer        /* external buffer */
+  )); 
+
+  AT_CUDA_CHECK(cudaFree(externalBuffer)); 
+  TORCH_CUDASPARSE_CHECK(cusparseDestroySpMat(descA)); 
+  TORCH_CUDASPARSE_CHECK(cusparseDestroyDnMat(descB)); 
+  TORCH_CUDASPARSE_CHECK(cusparseDestroyDnMat(descC)); 
+
+  AT_CUDA_CHECK(cudaDeviceSynchronize());
+
+  // TODO: Proper fix is to create real descriptor classes
+}
+template void csrmm2<float>(
+  char transa, char transb, 
+  int64_t m, int64_t n, int64_t k, int64_t nnz, 
+  float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, 
+  float *b, int64_t ldb, float beta, float *c, int64_t ldc); 
+template void csrmm2<double>(
+  char transa, char transb, 
+  int64_t m, int64_t n, int64_t k, int64_t nnz, 
+  double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, 
+  double *b, int64_t ldb, double beta, double *c, int64_t ldc); 
+
+#else 
+
 void adjustLd(char transb, int64_t m, int64_t n, int64_t k, int64_t *ldb, int64_t *ldc)
 {
   int transb_ = ((transb == 't') || (transb == 'T'));
@@ -90,7 +209,6 @@ void adjustLd(char transb, int64_t m, int64_t n, int64_t k, int64_t *ldb, int64_
   }
 }
 
-/* Level 3 */
 void Scsrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t nnz, float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, float *b, int64_t ldb, float beta, float *c, int64_t ldc)
 {
   adjustLd(transb, m, n, k, &ldb, &ldc);
@@ -136,6 +254,36 @@ void Dcsrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t 
   TORCH_CUDASPARSE_CHECK(cusparseDestroyMatDescr(desc));
   // TODO: Proper fix is to create real descriptor classes
 }
+
+// T can only be float or double
+template<typename T> 
+void csrmm2(
+  char transa, char transb, 
+  int64_t m, int64_t n, int64_t k, int64_t nnz, 
+  T alpha, T *csrvala, int *csrrowptra, int *csrcolinda, 
+  T *b, int64_t ldb, T beta, T *c, int64_t ldc)
+{
+  TORCH_INTERNAL_ASSERT(false, "cusparse csr MM only supports data type of float and double.");
+}
+
+template<> void csrmm2<float>(
+  char transa, char transb, 
+  int64_t m, int64_t n, int64_t k, int64_t nnz, 
+  float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, 
+  float *b, int64_t ldb, float beta, float *c, int64_t ldc)
+{
+  Scsrmm2(transa, transb, m, n, k, nnz, alpha, csrvala, csrrowptra, csrcolinda, b, ldb, beta, c, ldc);
+} 
+template<> void csrmm2<double>(
+  char transa, char transb, 
+  int64_t m, int64_t n, int64_t k, int64_t nnz, 
+  double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, 
+  double *b, int64_t ldb, double beta, double *c, int64_t ldc)
+{
+  Dcsrmm2(transa, transb, m, n, k, nnz, alpha, csrvala, csrrowptra, csrcolinda, b, ldb, beta, c, ldc); 
+} 
+
+#endif
 
 /* format conversion */
 void CreateIdentityPermutation(int64_t nnz, int *P) {

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -7,7 +7,10 @@
 #include <TH/THGeneral.h>
 
 #include <cusparse.h>
+
+#if !defined(MSC_VER) && defined(__CUDACC__) && CUSPARSE_VERSION >= 10301 // CUDA release >= 10.2 and not windows
 #include <library_types.h>
+#endif
 
 // LIMITATION (cusparseSpMM): 
 // The generic APIs are currently (CUDA 10.1) available for all platforms except Windows. 
@@ -77,7 +80,7 @@ cusparseOperation_t convertTransToCusparseOperation(char trans) {
   }
 }
 
-#if !defined(MSC_VER) && CUSPARSE_VERSION >= 10301 // CUDA release >= 10.2 and not windows
+#if !defined(MSC_VER) && defined(__CUDACC__) && CUSPARSE_VERSION >= 10301 // CUDA release >= 10.2 and not windows
 
 template<typename T> 
 void csrmm2(

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cuh
@@ -7,12 +7,8 @@ namespace at { namespace native { namespace sparse { namespace cuda {
 TORCH_CUDA_API void Xcoo2csr(const int *coorowind, int64_t nnz, int64_t m, int *csrrowptr);
 
 /* Level 3 */
-TORCH_CUDA_API void Scsrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t nnz, float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, float *b, int64_t ldb, float beta, float *c, int64_t ldc);
-TORCH_CUDA_API void Dcsrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t nnz, double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, double *b, int64_t ldb, double beta, double *c, int64_t ldc);
-
-// overloaded version
-inline void csrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t nnz, float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, float *b, int64_t ldb, float beta, float *c, int64_t ldc) { Scsrmm2(transa, transb, m, n, k, nnz, alpha, csrvala, csrrowptra, csrcolinda, b, ldb, beta, c, ldc); }
-inline void csrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t nnz, double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, double *b, int64_t ldb, double beta, double *c, int64_t ldc) { Dcsrmm2(transa, transb, m, n, k, nnz, alpha, csrvala, csrrowptra, csrcolinda, b, ldb, beta, c, ldc); }
+template<typename T> 
+TORCH_CUDA_API void csrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t nnz, T alpha, T *csrvala, int *csrrowptra, int *csrcolinda, T *b, int64_t ldb, T beta, T *c, int64_t ldc);
 
 /* format conversion */
 TORCH_CUDA_API void CreateIdentityPermutation(int64_t nnz, int *P);


### PR DESCRIPTION
The new function signature https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-spmm. 

Please also check https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-api-reference for the limitations. I have added windows guard in this PR. 

> LIMITATION: The generic APIs are currently available for all platforms except Windows. Using these APIs in any other systems will result in compile-time or run-time failures. Their support will be extended in the next releases. 

Edit: also add a cuda guard to let ROCm use old version API (avoid build failures)

Since the new cusparse signatures sometimes give inaccurate results in CUDA 10.1, and this was fixed in CUDA 10.2, the new signatures should only be used with CUDA >= 10.2

cc @csarofeen @ptrblck 