### PR TITLE
[engine] Ensure future is complete when exiting Engine::mark_graph_task_completed()

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -936,7 +936,7 @@ void Engine::mark_graph_task_completed(
     const std::shared_ptr<GraphTask>& graph_task) {
   // Allow only one thread one attempt to process this logic.
   if (graph_task->future_completed_.exchange(true)) {
-    // Future is already  marked complete, or being marked as such.
+    // Future is already marked complete, or being marked as such.
     // In case the marking complete is only in progress, we add a
     // waitNoThrow() to guarantee the future is marked complete on exit.
     graph_task->future_result_->waitNoThrow();

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -936,7 +936,10 @@ void Engine::mark_graph_task_completed(
     const std::shared_ptr<GraphTask>& graph_task) {
   // Allow only one thread one attempt to process this logic.
   if (graph_task->future_completed_.exchange(true)) {
-    // Future is already marked as completed.
+    // Future is already  marked complete, or being marked as such.
+    // In case the marking complete is only in progress, we add a
+    // waitNoThrow() to guarantee the future is marked complete on exit.
+    graph_task->future_result_->waitNoThrow();
     return;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36856 [engine] Ensure future is complete when exiting Engine::mark_graph_task_completed()**

Previously, we could early-exit mark_graph_task_completed() without the future
actually being fully complete - we were only guaranteeing that it was at least
in the process of being marked complete.

This seems to be triggering an assert graph_task->future_result_->completed()

This change simply adds a 1-line waitNoThrow() call to ensure that the future
has been marked complete before exiting the mark_graph_task_completed() function.
The cost is relatively reasonable, since this isn't the common path.

Differential Revision: [D21104121](https://our.internmc.facebook.com/intern/diff/D21104121/)