### PR TITLE
[rpc] Remove redundant call to createExceptionResponse

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -792,13 +792,9 @@ void ProcessGroupAgent::pollTimedOutRPCs() {
           "RPC ran for more than ",
           timedOutFuture.timeout_.count(),
           " milliseconds and timed out.");
-      // This is a dummy response that's not send over RPC, so the ID field is
-      // not used for any request/response matching.
-      const auto exceptionMsg = createExceptionResponse(err, -1);
       if (!timedOutFuture.future_->hasError()) {
         --clientActiveCalls_;
-        timedOutFuture.future_->setError(std::string(
-            exceptionMsg.payload().begin(), exceptionMsg.payload().end()));
+        timedOutFuture.future_->setError(err);
         // The future timed out and will not be processed by handleRecv(), even
         // if we eventually get a response. In order to keep track of all
         // send/recv pairs, we increment the count here.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36857 [rpc] Remove redundant call to createExceptionResponse**

This was a redundant call as we immediately took the msg and converted
it back to a string

Differential Revision: [D21104235](https://our.internmc.facebook.com/intern/diff/D21104235/)