### PR TITLE
scratch changes for optional int list testing

### DIFF
--- a/aten/src/ATen/native/UpSampleLinear1d.cpp
+++ b/aten/src/ATen/native/UpSampleLinear1d.cpp
@@ -214,18 +214,23 @@ static void upsample_linear1d_backward_out_cpu_template(
 Tensor& upsample_linear1d_out_cpu(
     Tensor& output,
     const Tensor& input,
-    IntArrayRef output_size,
+    c10::optional<IntArrayRef> output_size_opt,
     bool align_corners,
     c10::optional<double> scales) {
+  TORCH_CHECK(output_size_opt.has_value(), "HEY upsample_linear1d_out_cpu got output_size nullopt");
+  IntArrayRef output_size = *output_size_opt;
   upsample_linear1d_out_cpu_template(output, input, output_size, align_corners, scales);
   return output;
 }
 
 Tensor upsample_linear1d_cpu(
     const Tensor& input,
-    IntArrayRef output_size,
+    c10::optional<IntArrayRef> output_size_opt,
     bool align_corners,
     c10::optional<double> scales) {
+  TORCH_CHECK(output_size_opt.has_value(), "HEY upsample_linear1d_cpu got output_size nullopt");
+  IntArrayRef output_size = *output_size_opt;
+  std::cout << "HEY output_size " << output_size << "\n";
   auto output = at::empty({0}, input.options());
   upsample_linear1d_out_cpu_template(output, input, output_size, align_corners, scales);
   return output;
@@ -234,10 +239,12 @@ Tensor upsample_linear1d_cpu(
 Tensor& upsample_linear1d_backward_out_cpu(
     Tensor& grad_input,
     const Tensor& grad_output,
-    IntArrayRef output_size,
+    c10::optional<IntArrayRef> output_size_opt,
     IntArrayRef input_size,
     bool align_corners,
     c10::optional<double> scales) {
+  TORCH_CHECK(output_size_opt.has_value(), "HEY upsample_linear1d_backward_out_cpu got output_size nullopt");
+  IntArrayRef output_size = *output_size_opt;
   upsample_linear1d_backward_out_cpu_template(
       grad_input, grad_output, output_size, input_size, align_corners, scales);
   return grad_input;
@@ -245,10 +252,12 @@ Tensor& upsample_linear1d_backward_out_cpu(
 
 Tensor upsample_linear1d_backward_cpu(
     const Tensor& grad_output,
-    IntArrayRef output_size,
+    c10::optional<IntArrayRef> output_size_opt,
     IntArrayRef input_size,
     bool align_corners,
     c10::optional<double> scales) {
+  TORCH_CHECK(output_size_opt.has_value(), "HEY upsample_linear1d_backward_cpu got output_size nullopt");
+  IntArrayRef output_size = *output_size_opt;
   auto grad_input = at::zeros(input_size, grad_output.options());
   upsample_linear1d_backward_out_cpu_template(
       grad_input, grad_output, output_size, input_size, align_corners, scales);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6287,25 +6287,25 @@
     CPU: replication_pad3d_backward_cpu
     CUDA: replication_pad3d_backward_cuda
 
-- func: upsample_linear1d.out(Tensor self, int[1] output_size, bool align_corners, float? scales=None, *, Tensor(a!) out) -> Tensor(a!)
+- func: upsample_linear1d.out(Tensor self, int[1]? output_size_opt, bool align_corners, float? scales=None, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: upsample_linear1d_out_cpu
     CUDA: upsample_linear1d_out_cuda
 
-- func: upsample_linear1d(Tensor self, int[1] output_size, bool align_corners, float? scales=None) -> Tensor
+- func: upsample_linear1d(Tensor self, int[1]? output_size_opt, bool align_corners, float? scales=None) -> Tensor
   python_module: nn
   dispatch:
     CPU: upsample_linear1d_cpu
     CUDA: upsample_linear1d_cuda
 
-- func: upsample_linear1d_backward.grad_input(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners, float? scales=None, *, Tensor(a!) grad_input) -> Tensor(a!)
+- func: upsample_linear1d_backward.grad_input(Tensor grad_output, int[1]? output_size_opt, int[3] input_size, bool align_corners, float? scales=None, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: upsample_linear1d_backward_out_cpu
     CUDA: upsample_linear1d_backward_out_cuda
 
-- func: upsample_linear1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners, float? scales=None) -> Tensor
+- func: upsample_linear1d_backward(Tensor grad_output, int[1]? output_size_opt, int[3] input_size, bool align_corners, float? scales=None) -> Tensor
   python_module: nn
   dispatch:
     CPU: upsample_linear1d_backward_cpu

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1155,8 +1155,8 @@
 - name: replication_pad3d(Tensor self, int[6] padding) -> Tensor
   self: replication_pad3d_backward(grad, self, padding)
 
-- name: upsample_linear1d(Tensor self, int[1] output_size, bool align_corners, float? scales=None) -> Tensor
-  self: upsample_linear1d_backward(grad, output_size, self.sizes(), align_corners, scales)
+- name: upsample_linear1d(Tensor self, int[1]? output_size_opt, bool align_corners, float? scales=None) -> Tensor
+  self: upsample_linear1d_backward(grad, output_size_opt, self.sizes(), align_corners, scales)
 
 - name: upsample_bilinear2d(Tensor self, int[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor
   self: upsample_bilinear2d_backward(grad, output_size, self.sizes(), align_corners, scales_h, scales_w)
@@ -1422,8 +1422,8 @@
   grad_output: threshold_backward(grad, self, threshold)
   self: zeros_like(grad, at::MemoryFormat::Preserve)
 
-- name: upsample_linear1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners, float? scales=None) -> Tensor
-  grad_output: upsample_linear1d(grad, output_size, align_corners, scales)
+- name: upsample_linear1d_backward(Tensor grad_output, int[1]? output_size_opt, int[3] input_size, bool align_corners, float? scales=None) -> Tensor
+  grad_output: upsample_linear1d(grad, output_size_opt, align_corners, scales)
 
 - name: upsample_bilinear2d_backward(Tensor grad_output, int[2] output_size, int[4] input_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor
   grad_output: upsample_bilinear2d(grad, output_size, align_corners, scales_h, scales_w)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36867 scratch changes for optional int list testing**
* #36866 [WIP] add optional sized int list support in schemas

Modifies the signatures of `aten::upsample_linear1d*` to take optional output sizes list. Only tests the plumbing: kernels print message and throw if no list is actually passed.