### PR TITLE
C++ make constructor NamedAnyModule(name,any) public

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/container/named_any.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/named_any.h
@@ -67,6 +67,10 @@ class NamedAnyModule {
   NamedAnyModule(std::string name, const ModuleHolder<M>& module_holder)
       : NamedAnyModule(std::move(name), module_holder.ptr()) {}
 
+  /// Creates a `NamedAnyModule` from a type-erased `AnyModule`.
+  NamedAnyModule(std::string name, AnyModule any_module)
+    : name_(std::move(name)), module_(std::move(any_module)) {}
+
   /// Returns a reference to the name.
   const std::string& name() const noexcept {
     return name_;
@@ -83,10 +87,6 @@ class NamedAnyModule {
   }
 
  private:
-  /// Creates a `NamedAnyModule` from a type-erased `AnyModule`.
-  NamedAnyModule(std::string name, AnyModule any_module)
-    : name_(std::move(name)), module_(std::move(any_module)) {}
-
   std::string name_;
   AnyModule module_;
 };


### PR DESCRIPTION
Allows creation of _NamedAnyModule_ directly from _AnyModule_, e.g.

```
  auto a=torch::nn::AnyModule(torch::nn::Linear(1,2));
  auto m=torch::nn::NamedAnyModule("fc", a);
```
Without the public constructor, it would be necessary to recast the AnyModule to underlying type,
then have the constructor cast it back to AnyModule.

With the public AnyModule constructor,
possible to do
```
auto q=Sequential({m});
```
or
```
q->push_back(m.name, m.module());
```

(works in conjunction with PR #36720 which allowed adding _AnyModule_ directly)
