### PR TITLE
Reduce overheads on several CPU kernels by avoiding restrides.

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -768,6 +768,8 @@ void TensorIterator::check_mem_overlaps() {
 }
 
 void TensorIterator::compute_shape() {
+  if (static_shape_) return;
+
   all_ops_same_shape_ = true;
   bool has_scalars = false;
   bool has_tensors = false;
@@ -824,7 +826,7 @@ void TensorIterator::compute_shape() {
 void TensorIterator::compute_strides() {
   for (auto& op : operands_) {
     if (op.tensor.defined()) {
-      auto original_shape = op.tensor.sizes();
+      IntArrayRef original_shape = static_shape_ ? shape_ : op.tensor.sizes();
       auto original_stride = op.tensor.strides();
       auto element_size_in_bytes = op.tensor.element_size();
       auto offset = ndim() - original_shape.size();

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -298,7 +298,7 @@ void TensorIterator::allocate_outputs() {
         // As we are allocating output after permutations is done, we need to
         // make sure that operand's strides are matching element size and
         // dimensions permutations which are stored in _perm
-        op.stride_bytes = apply_perm_and_mul(op.tensor.strides(), element_size);
+        op.stride_bytes = apply_perm_and_mul(op.tensor_strides(), element_size);
       } else {
         op.stride_bytes = compatible_stride(element_size);
         // check if permutation is just an inverted order
@@ -692,9 +692,9 @@ TensorIterator TensorIterator::unary_op(Tensor& out, const Tensor& a,
 
 TensorIterator TensorIterator::nullary_op(Tensor& out) {
   auto iter = TensorIterator();
-  iter.add_output(out);
   // FIXME: workaround for bug: https://github.com/pytorch/pytorch/issues/20342
-  iter.resize_outputs_ = false;
+  iter.dont_resize_outputs();
+  iter.add_output(out);
   iter.build();
   return iter;
 }
@@ -702,10 +702,10 @@ TensorIterator TensorIterator::nullary_op(Tensor& out) {
 TensorIterator TensorIterator::reduce_op(Tensor& out, const Tensor& a) {
   TORCH_INTERNAL_ASSERT(out.defined());
   auto iter = TensorIterator();
+  iter.dont_resize_outputs();
   iter.add_output(out);
   iter.add_input(a);
   iter.promote_gpu_output_dtypes_ = true;
-  iter.resize_outputs_ = false;
   iter.is_reduction_ = true;
   // TODO: This is only really necessary for arg{min,max}
   iter.compute_common_dtype_only_for_inputs();
@@ -726,11 +726,11 @@ TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tenso
   TORCH_CHECK(out1.strides() == out2.strides(), "reduce_op(): expected both outputs to have same strides, but output1 has ", out1.strides(),
            " and output2 has ", out2.strides());
   auto iter = TensorIterator();
+  iter.dont_resize_outputs();
   iter.add_output(out1);
   iter.add_output(out2);
   iter.add_input(a);
   iter.promote_gpu_output_dtypes_ = true;
-  iter.resize_outputs_ = false;
   iter.is_reduction_ = true;
   iter.build();
   return iter;
@@ -778,7 +778,7 @@ void TensorIterator::compute_shape() {
     // This preserves the legacy behavior where torch.add(..., out=dst) resizes
     // the destination tensor.
     if (resize_outputs_ && op.is_output && !op.is_read_write) continue;
-    auto shape = op.tensor.sizes();
+    auto shape = op.tensor_sizes();
     if (shape.size() == 0) {
       has_scalars = true;
     } else {
@@ -799,8 +799,9 @@ void TensorIterator::compute_shape() {
   // our legacy behavior that functions with `out=` arguments resize their
   // outputs.
   for (int i = 0; i < num_outputs_; i++) {
-    auto& tensor = operands_[i].tensor;
-    if (tensor.defined() && !tensor.sizes().equals(shape_)) {
+    auto& op = operands_[i];
+    auto& tensor = op.tensor;
+    if (tensor.defined() && !op.tensor_sizes().equals(shape_)) {
       if (resize_outputs_ && !operands_[i].is_read_write) {
         // Preserve legacy resizing behavior of out=... arguments
         // TODO: issue warning
@@ -815,7 +816,7 @@ void TensorIterator::compute_shape() {
         }
         continue;
       }
-      TORCH_CHECK(is_reduction_, "output with shape ", tensor.sizes(), " doesn't match the broadcast shape ",
+      TORCH_CHECK(is_reduction_, "output with shape ", op.tensor_sizes(), " doesn't match the broadcast shape ",
                  shape_);
     }
   }
@@ -824,8 +825,8 @@ void TensorIterator::compute_shape() {
 void TensorIterator::compute_strides() {
   for (auto& op : operands_) {
     if (op.tensor.defined()) {
-      auto original_shape = op.tensor.sizes();
-      auto original_stride = op.tensor.strides();
+      auto original_shape = op.tensor_sizes();
+      auto original_stride = op.tensor_strides();
       auto element_size_in_bytes = op.tensor.element_size();
       auto offset = ndim() - original_shape.size();
       if (offset > 0)
@@ -955,7 +956,7 @@ bool TensorIterator::fast_set_up() {
           auto& op = operands_[i];
           if (!op.tensor.defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
-            op.tensor = at::empty_strided(shape_, operands_[i_defined].tensor.strides(), op.options());
+            op.tensor = at::empty_strided(shape_, operands_[i_defined].tensor_strides(), op.options());
             op.current_dtype = op.target_dtype;
           }
           else if (resize_outputs_ && !op.is_read_write) {
@@ -966,8 +967,8 @@ bool TensorIterator::fast_set_up() {
             //       it would probably be better to move this logic out of TensorIterator.
 
             // Check whether output tensor needs restride, output's stride can be different than input tensors
-            if (i != i_defined && !op.tensor.strides().equals(operands_[i_defined].tensor.strides())) {
-              op.tensor.as_strided_(op.tensor.sizes(), operands_[i_defined].tensor.strides());
+            if (i != i_defined && !op.tensor_strides().equals(operands_[i_defined].tensor_strides())) {
+              op.tensor.as_strided_(op.tensor_sizes(), operands_[i_defined].tensor_strides());
             }
           }
         }
@@ -1022,13 +1023,13 @@ FastSetupType TensorIterator::compute_fast_setup_type() {
     // if only the output's strides is inconstent but all inputs' strides are equal,
     // it is still a NON_OVERLAPPING_DENSE case and output will be restrided in fast_set_up()
     for (int64_t i = ntensors() - 1; i >= 0; --i) {
-      const auto& op = operands_[i];
+      auto& op = operands_[i];
       if (op.tensor.defined()) {
         if (prev < 0) {
           prev = i;
           continue;
         }
-        if (!operands_[prev].tensor.strides().equals(op.tensor.strides())) {
+        if (!operands_[prev].tensor_strides().equals(op.tensor_strides())) {
           if (!resize_outputs_ || !op.is_output || op.is_read_write) {
             return FastSetupType::NONE;
           }

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -368,6 +368,7 @@ struct CAFFE2_API TensorIterator {
 
   void declare_static_shape(IntArrayRef shape, const int64_t squash_dim){
     declare_static_shape(shape);
+    if (!shape_.size()) return;
     TORCH_CHECK(squash_dim >= 0 && squash_dim < shape_.size(),
                 "squash_dim ", squash_dim, " must be in [0, ", shape_.size(), ").");
     shape_[squash_dim] = 1;

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -357,6 +357,22 @@ struct CAFFE2_API TensorIterator {
     resize_outputs_ = false;
   }
 
+  void declare_static_shape(IntArrayRef shape) {
+    // WARNING:
+    //   This will bypass all shape checking in the TensorIterator. Kernels which call this method
+    //   are expected to check shapes before calling `add_input` or `add_output`.
+    TORCH_CHECK(!resize_outputs_, "dont_resize_outputs() must be called before declare_static_shape(...)")
+    shape_ = shape;
+    static_shape_ = true;
+  }
+
+  void declare_static_shape(IntArrayRef shape, const int64_t squash_dim){
+    declare_static_shape(shape);
+    TORCH_CHECK(squash_dim >= 0 && squash_dim < shape_.size(),
+                "squash_dim ", squash_dim, " must be in [0, ", shape_.size(), ").");
+    shape_[squash_dim] = 1;
+  }
+
   void build();
 
 protected:
@@ -397,6 +413,7 @@ protected:
   bool all_ops_same_shape_ = false;
   bool requires_channels_last_output_ = false;
   bool requires_channels_last_3d_output_ = false;
+  bool static_shape_ = false;
 };
 /// A container-like struct that acts as if it contains splits of a
 /// TensorIterator that can use 32-bit indexing. Taken together the splits cover

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -74,17 +74,29 @@ struct CAFFE2_API OperandInfo {
   using StrideVector = SmallVector<int64_t, 6>;
   OperandInfo() {}
   explicit OperandInfo(const Tensor& t) : tensor(t) {
-    if (t.defined()) {
-      device = t.device();
-      target_dtype = t.scalar_type();
-      current_dtype = target_dtype;
-    }
+    collect_attrs();
     validate();
   }
+
+  OperandInfo(const Tensor& t, const int64_t lazy_restride_dim) : tensor(t) {
+    lazy_restride(lazy_restride_dim);
+    collect_attrs();
+    validate();
+  }
+
   OperandInfo(const Tensor& t, Device device, ScalarType dtype)
     : tensor(t), device(device), target_dtype(dtype), current_dtype(t.scalar_type()) {
     validate();
   }
+
+  OperandInfo(const Tensor& t, Device device, ScalarType dtype, const int64_t lazy_restride_dim)
+    : tensor(t), device(device), target_dtype(dtype), current_dtype(t.scalar_type()) {
+    lazy_restride(lazy_restride_dim);
+    validate();
+  }
+
+  const IntArrayRef tensor_sizes() { return is_lazily_restrided ? IntArrayRef(sizes_) : tensor.sizes(); }
+  const IntArrayRef tensor_strides() { return is_lazily_restrided ? IntArrayRef(strides_) : tensor.strides(); }
 
   /// Stride after broadcasting. The stride is in bytes, not number of elements.
   StrideVector stride_bytes;
@@ -124,10 +136,49 @@ struct CAFFE2_API OperandInfo {
 
   bool is_read_write = false;
 
+  bool is_lazily_restrided = false;
+
+ private:
+  int64_t lazy_restride_dim_ = -1;
+  SmallVector<int64_t,5> sizes_;
+  SmallVector<int64_t,5> strides_;
+
+  void collect_attrs(){
+    if (tensor.defined()) {
+      device = tensor.device();
+      target_dtype = tensor.scalar_type();
+      current_dtype = target_dtype;
+    }
+  }
+
   void validate() {
     TORCH_CHECK(
         !tensor.defined() || tensor.layout() == kStrided,
         "unsupported tensor layout: ", tensor.layout());
+  }
+
+  void lazy_restride(const int64_t dim){
+    /* `dim` is traversed in the kernel. This will effectively hide that
+     * dimension from the TensorIterator. The stride prevents TensorIterator
+     * from advancing along dim, and the size makes sure that
+     * TensorIterator.DimCounter has the following form :
+     *   (i_1,..., i_{dim-1}, 0, i_{dim+1},...,i_n).
+     * Note that it is important that `tensor.sizes()` and `tensor.strides()`
+     * are not called directly outside of this function. Instead
+     * `tensor_sizes()` and `tensor_strides()` should be used.
+     */
+    TORCH_CHECK(tensor.defined(), "Cannot lazily restride an uninitialized Tensor.")
+    is_lazily_restrided = true;
+    lazy_restride_dim_ = dim;
+    sizes_ = tensor.sizes().vec();
+    strides_ = tensor.strides().vec();
+    if (tensor.dim()){
+      TORCH_CHECK(dim >= 0 && dim < tensor.dim(),
+                  "Cannot lazily restride dim ", dim,
+                  ". Not in range [0, ", tensor.dim(), ").")
+      sizes_[dim] = 1;
+      strides_[dim] = 0;
+    }
   }
 };
 
@@ -323,13 +374,9 @@ struct CAFFE2_API TensorIterator {
   }
 
   /// Construction
-  void add_output(const Tensor& output) {
-    operands_.emplace_back(output);
-    num_outputs_++;
-  }
-
-  void add_output(const Tensor& input, Device device, ScalarType dtype) {
-    operands_.emplace_back(input, device, dtype);
+  template<typename... Args>
+  void add_output(Args... args) {
+    add_input(args...);
     num_outputs_++;
   }
 
@@ -337,8 +384,18 @@ struct CAFFE2_API TensorIterator {
     operands_.emplace_back(input);
   }
 
+  void add_input(const Tensor& input, const int64_t lazy_restride_dim) {
+    TORCH_CHECK(!resize_outputs_, "lazy_restride_dim is incompatable with resize_inputs_");
+    operands_.emplace_back(input, lazy_restride_dim);
+  }
+
   void add_input(const Tensor& input, Device device, ScalarType dtype) {
     operands_.emplace_back(input, device, dtype);
+  }
+
+  void add_input(const Tensor& input, Device device, ScalarType dtype, const int64_t lazy_restride_dim) {
+    TORCH_CHECK(!resize_outputs_, "lazy_restride_dim is incompatable with resize_inputs_");
+    operands_.emplace_back(input, device, dtype, lazy_restride_dim);
   }
 
   void promote_common_dtype() {

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <vector>
-
 #include <ATen/ATen.h>
 #include <c10/util/FunctionRef.h>
 #include <c10/util/SmallVector.h>
@@ -80,9 +78,9 @@ struct CAFFE2_API OperandInfo {
     validate();
   }
 
-  explicit OperandInfo(const Tensor& t, const int64_t lazy_restride_dim) : tensor(t) {
+  OperandInfo(const Tensor& t, const int64_t lazy_restride_dim) : tensor(t) {
+    lazy_restride(lazy_restride_dim);
     collect_attrs();
-    collect_sizes_and_strides(lazy_restride_dim);
     validate();
   }
 
@@ -93,12 +91,12 @@ struct CAFFE2_API OperandInfo {
 
   OperandInfo(const Tensor& t, Device device, ScalarType dtype, const int64_t lazy_restride_dim)
     : tensor(t), device(device), target_dtype(dtype), current_dtype(t.scalar_type()) {
-    collect_sizes_and_strides(lazy_restride_dim);
+    lazy_restride(lazy_restride_dim);
     validate();
   }
 
-  const IntArrayRef tensor_sizes() { return !is_lazily_restrided_ ? tensor.sizes() : sizes_storage_; }
-  const IntArrayRef tensor_strides() { return !is_lazily_restrided_ ? tensor.strides() : strides_storage_; }
+  const IntArrayRef tensor_sizes() { return is_lazily_restrided ? IntArrayRef(sizes_) : tensor.sizes(); }
+  const IntArrayRef tensor_strides() { return is_lazily_restrided ? IntArrayRef(strides_) : tensor.strides(); }
 
   /// Stride after broadcasting. The stride is in bytes, not number of elements.
   StrideVector stride_bytes;
@@ -138,7 +136,13 @@ struct CAFFE2_API OperandInfo {
 
   bool is_read_write = false;
 
+  bool is_lazily_restrided = false;
+
  private:
+  int64_t lazy_restride_dim_ = -1;
+  SmallVector<int64_t,5> sizes_;
+  SmallVector<int64_t,5> strides_;
+
   void collect_attrs(){
     if (tensor.defined()) {
       device = tensor.device();
@@ -147,11 +151,13 @@ struct CAFFE2_API OperandInfo {
     }
   }
 
-  std::vector<int64_t> sizes_storage_;
-  std::vector<int64_t> strides_storage_;
-  bool is_lazily_restrided_ = false;
+  void validate() {
+    TORCH_CHECK(
+        !tensor.defined() || tensor.layout() == kStrided,
+        "unsupported tensor layout: ", tensor.layout());
+  }
 
-  void collect_sizes_and_strides(const int64_t lazy_restride_dim) {
+  void lazy_restride(const int64_t dim){
     /* `dim` is traversed in the kernel. This will effectively hide that
      * dimension from the TensorIterator. The stride prevents TensorIterator
      * from advancing along dim, and the size makes sure that
@@ -162,22 +168,17 @@ struct CAFFE2_API OperandInfo {
      * `tensor_sizes()` and `tensor_strides()` should be used.
      */
     TORCH_CHECK(tensor.defined(), "Cannot lazily restride an uninitialized Tensor.")
-    is_lazily_restrided_ = true;
-    sizes_storage_ = tensor.sizes().vec();
-    strides_storage_ = tensor.strides().vec();
+    is_lazily_restrided = true;
+    lazy_restride_dim_ = dim;
+    sizes_ = tensor.sizes().vec();
+    strides_ = tensor.strides().vec();
     if (tensor.dim()){
-      TORCH_CHECK(lazy_restride_dim >= 0 && lazy_restride_dim < tensor.dim(),
-                  "Cannot lazily restride dim ", lazy_restride_dim,
+      TORCH_CHECK(dim >= 0 && dim < tensor.dim(),
+                  "Cannot lazily restride dim ", dim,
                   ". Not in range [0, ", tensor.dim(), ").")
-      sizes_storage_[lazy_restride_dim] = 1;
-      strides_storage_[lazy_restride_dim] = 0;
+      sizes_[dim] = 1;
+      strides_[dim] = 0;
     }
-  }
-
-  void validate() {
-    TORCH_CHECK(
-        !tensor.defined() || tensor.layout() == kStrided,
-        "unsupported tensor layout: ", tensor.layout());
   }
 };
 

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -36,17 +36,12 @@ static inline void cpu_cum_base_kernel(Tensor& result,
     return;
   }
 
-  auto self_sizes = ensure_nonempty_vec(self.sizes().vec());
-  self_sizes[dim] = 1;
-
-  auto result_restrided = restride_dim(result, dim, self_sizes);
-  auto self_restrided = restride_dim(self, dim, self_sizes);
-
   auto iter = TensorIterator();
   iter.dont_compute_common_dtype();
   iter.dont_resize_outputs();
-  iter.add_output(result_restrided);
-  iter.add_input(self_restrided);
+  iter.declare_static_shape(self.sizes(), /*squash_dim=*/dim);
+  iter.add_output(result);
+  iter.add_input(self);
   iter.build();
 
   auto result_dim_stride = ensure_nonempty_stride(result, dim);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -36,11 +36,17 @@ static inline void cpu_cum_base_kernel(Tensor& result,
     return;
   }
 
+  auto self_sizes = ensure_nonempty_vec(self.sizes().vec());
+  self_sizes[dim] = 1;
+
+  auto result_restrided = restride_dim(result, dim, self_sizes);
+  auto self_restrided = restride_dim(self, dim, self_sizes);
+
   auto iter = TensorIterator();
   iter.dont_compute_common_dtype();
   iter.dont_resize_outputs();
-  iter.add_output(result, /*lazy_restride_dim=*/dim);
-  iter.add_input(self, /*lazy_restride_dim=*/dim);
+  iter.add_output(result_restrided);
+  iter.add_input(self_restrided);
   iter.build();
 
   auto result_dim_stride = ensure_nonempty_stride(result, dim);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -36,17 +36,11 @@ static inline void cpu_cum_base_kernel(Tensor& result,
     return;
   }
 
-  auto self_sizes = ensure_nonempty_vec(self.sizes().vec());
-  self_sizes[dim] = 1;
-
-  auto result_restrided = restride_dim(result, dim, self_sizes);
-  auto self_restrided = restride_dim(self, dim, self_sizes);
-
   auto iter = TensorIterator();
   iter.dont_compute_common_dtype();
   iter.dont_resize_outputs();
-  iter.add_output(result_restrided);
-  iter.add_input(self_restrided);
+  iter.add_output(result, /*lazy_restride_dim=*/dim);
+  iter.add_input(self, /*lazy_restride_dim=*/dim);
   iter.build();
 
   auto result_dim_stride = ensure_nonempty_stride(result, dim);

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -134,12 +134,30 @@ struct cpu_scatter_gather_base_kernel {
       gather_shape_check(self, dim, index);
     }
 
+    auto index_sizes = ensure_nonempty_vec(index.sizes().vec());
+    auto index_strides = ensure_nonempty_vec(index.strides().vec());
+
+    // `dim` is traversed in the kernel,
+    // that is why index.stride(dim) = 0 and index.size(dim) = 1.
+    // Also, index.size(dim) = 1 makes sure that TensorIterator.DimCounter
+    // has the following form : (i_1,..., i_{dim-1}, 0, i_{dim+1},...,i_n).
+    index_sizes[dim] = 1;
+    index_strides[dim] = 0;
+
+    // set self.shape = src.shape = index.shape,
+    // this defines the number of elements to iterate over,
+    // and set self.stride(dim) = src.stride(dim) = 0,
+    // because `dim` is traversed in the kernel.
+    auto self_restrided = restride_dim(self, dim, index_sizes);
+    auto index_restrided = index.as_strided(index_sizes, index_strides);
+    auto src_restrided = restride_dim(src, dim, index_sizes);
+
     auto iter = TensorIterator();
     iter.dont_compute_common_dtype();
     iter.dont_resize_outputs();
-    iter.add_output(self, /*lazy_restride_dim=*/dim);
-    iter.add_input(src, src.device(), src.scalar_type(), /*lazy_restride_dim=*/dim);
-    iter.add_input(index, /*lazy_restride_dim=*/dim);
+    iter.add_output(self_restrided);
+    iter.add_input(src_restrided, src.device(), src.scalar_type());
+    iter.add_input(index_restrided);
     iter.build();
 
     auto self_dim_stride = ensure_nonempty_stride(self, dim);

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -134,30 +134,12 @@ struct cpu_scatter_gather_base_kernel {
       gather_shape_check(self, dim, index);
     }
 
-    auto index_sizes = ensure_nonempty_vec(index.sizes().vec());
-    auto index_strides = ensure_nonempty_vec(index.strides().vec());
-
-    // `dim` is traversed in the kernel,
-    // that is why index.stride(dim) = 0 and index.size(dim) = 1.
-    // Also, index.size(dim) = 1 makes sure that TensorIterator.DimCounter
-    // has the following form : (i_1,..., i_{dim-1}, 0, i_{dim+1},...,i_n).
-    index_sizes[dim] = 1;
-    index_strides[dim] = 0;
-
-    // set self.shape = src.shape = index.shape,
-    // this defines the number of elements to iterate over,
-    // and set self.stride(dim) = src.stride(dim) = 0,
-    // because `dim` is traversed in the kernel.
-    auto self_restrided = restride_dim(self, dim, index_sizes);
-    auto index_restrided = index.as_strided(index_sizes, index_strides);
-    auto src_restrided = restride_dim(src, dim, index_sizes);
-
     auto iter = TensorIterator();
     iter.dont_compute_common_dtype();
     iter.dont_resize_outputs();
-    iter.add_output(self_restrided);
-    iter.add_input(src_restrided, src.device(), src.scalar_type());
-    iter.add_input(index_restrided);
+    iter.add_output(self, /*lazy_restride_dim=*/dim);
+    iter.add_input(src, src.device(), src.scalar_type(), /*lazy_restride_dim=*/dim);
+    iter.add_input(index, /*lazy_restride_dim=*/dim);
     iter.build();
 
     auto self_dim_stride = ensure_nonempty_stride(self, dim);

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -41,15 +41,15 @@ static inline void compare_base_kernel(Tensor& result, Tensor& indice,
     indice.set_(indices_view);
   }
 
-  Tensor self_restrided = restride_dim(self, dim, self_sizes);
   auto self_dim_stride = ensure_nonempty_stride(self, dim);
 
   auto iter = TensorIterator();
   iter.dont_compute_common_dtype();
   iter.dont_resize_outputs();
+  iter.declare_static_shape(self.sizes(), /*squash_dim=*/dim);
   iter.add_output(result);
   iter.add_output(indice);
-  iter.add_input(self_restrided);
+  iter.add_input(self);
   iter.build();
 
   auto loop = [&](char** data, const int64_t* strides, int64_t n) {

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -41,7 +41,6 @@ static inline void compare_base_kernel(Tensor& result, Tensor& indice,
     indice.set_(indices_view);
   }
 
-  Tensor self_restrided = restride_dim(self, dim, self_sizes);
   auto self_dim_stride = ensure_nonempty_stride(self, dim);
 
   auto iter = TensorIterator();
@@ -49,7 +48,7 @@ static inline void compare_base_kernel(Tensor& result, Tensor& indice,
   iter.dont_resize_outputs();
   iter.add_output(result);
   iter.add_output(indice);
-  iter.add_input(self_restrided);
+  iter.add_input(self, /*lazy_restride_dim=*/dim);
   iter.build();
 
   auto loop = [&](char** data, const int64_t* strides, int64_t n) {

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -41,6 +41,7 @@ static inline void compare_base_kernel(Tensor& result, Tensor& indice,
     indice.set_(indices_view);
   }
 
+  Tensor self_restrided = restride_dim(self, dim, self_sizes);
   auto self_dim_stride = ensure_nonempty_stride(self, dim);
 
   auto iter = TensorIterator();
@@ -48,7 +49,7 @@ static inline void compare_base_kernel(Tensor& result, Tensor& indice,
   iter.dont_resize_outputs();
   iter.add_output(result);
   iter.add_output(indice);
-  iter.add_input(self, /*lazy_restride_dim=*/dim);
+  iter.add_input(self_restrided);
   iter.build();
 
   auto loop = [&](char** data, const int64_t* strides, int64_t n) {


### PR DESCRIPTION
Calling `t.as_strided(..., ...)` must make a new `TensorImpl` to back the new tensor, which takes 300-400 ns. Reduction, scatter/gather, and comparison kernels currently restride inputs and outputs in order to handle `dim` inside the function passed to TensorIterator. Because these Tensors are created solely for consumption by the iterator a full restride and metadata copy is surplus to requirements. Moreover, shapes are already checked by these kernels prior to calling `add_input` and `add_output`, so shape inference and broadcasting are also unnecessary.

This PR adds a `TensorIterator::declare_static_shape(...)` method, which allows certain kernels to use a much more constrained and efficient shape path. This results in a 900-1200 ns speedup for `gather / scatter / scatter_add / cumsum / cumprod` and a 250-500 ns speedup for elementwise `min` and `max`.

Measurements were taken with [this python script](https://gist.github.com/robieta/51ac5db2f9c7e812d5ff264403ce4f92), which is driven by [this bash script](https://gist.github.com/robieta/1420e917cf38885de3093f8c3a7bd437). The general procedure for mitigating environmental skew is to repeatedly switch between an environment which is built with master and one which is built with this branch while running the python script. Within the python measurement script the following was used to reduce variation:
* Set number of threads to 1
* Aggressively and randomly interleave task measurements to limit correlation between tasks and system state based on when they were run or what task preceded the current one.
* Warmup period, dropping the first three passes through all of the tasks.
Two independent end-to-end runs are included since there is some variation even with the above measures. Overall measurement error seems to be about +/- 100 ns.

The benchmark also includes several tasks which are not affected by this PR, both to check for a degradation in TensorIterator performance when static shapes are not set (which did happen for an earlier iteration of this optimization) and to estimate measurement variability and validate that measured improvements are significant.

**First run**:
```
                          Delta (median)     Master     (25%,  75%)          Branch     (25%,  75%)
---------------------------------------------------------------------------------------------------------
gather_1D                |     920      |    4,000     (-170, +230)       |  3,100     (-110, +140)
gather_dim0              |     910      |    4,100     (-170, +230)       |  3,200     (-110, +150)
gather_dim1              |   1,200      |    4,400     (-190, +240)       |  3,200     (-120, +150)
scatter_1D               |   1,100      |    2,800     (-120, +160)       |  1,700     (-64 , +81)
scatter_dim0             |   1,000      |    2,900     (-130, +160)       |  1,900     (-72 , +95)
scatter_dim1             |   1,200      |    3,200     (-130, +170)       |  1,900     (-67 , +87)
scatter_add_1D           |   1,100      |    2,800     (-120, +150)       |  1,700     (-68 , +89)
scatter_add_dim0         |   1,000      |    2,900     (-120, +150)       |  1,900     (-77 , +93)
scatter_add_dim1         |   1,300      |    3,100     (-140, +180)       |  1,900     (-76 , +92)
cumsum_1D                |   1,000      |    4,600     (-200, +260)       |  3,600     (-120, +170)
cumsum_dim0              |     860      |    4,500     (-190, +240)       |  3,700     (-140, +180)
cumsum_dim1              |   1,200      |    4,800     (-210, +260)       |  3,700     (-130, +180)
cumprod_1D               |   1,000      |    4,600     (-200, +270)       |  3,600     (-130, +170)
cumprod_dim0             |     910      |    4,600     (-210, +270)       |  3,700     (-130, +170)
cumprod_dim1             |   1,200      |    4,900     (-220, +290)       |  3,700     (-130, +170)
min_dim0                 |     280      |    5,900     (-220, +270)       |  5,600     (-220, +260)
min_dim1                 |     560      |    6,200     (-230, +310)       |  5,600     (-230, +270)
max_dim0                 |     320      |    5,900     (-220, +280)       |  5,600     (-200, +250)
max_dim1                 |     540      |    6,100     (-250, +310)       |  5,600     (-200, +250)
std       (reference)    |      58      |    4,300     (-180, +280)       |  4,200     (-160, +200)
clamp     (reference)    |      87      |    3,400     (-160, +220)       |  3,400     (-140, +170)
argmin    (reference)    |     -85      |    3,900     (-170, +250)       |  4,000     (-170, +200)
sum       (reference)    |     -11      |    4,200     (-180, +240)       |  4,200     (-160, +190)
x < y     (reference)    |     110      |    3,700     (-170, +290)       |  3,500     (-140, +150)
max(x, y) (reference)    |     170      |    3,600     (-170, +200)       |  3,400     (-140, +180)

* Times in nanoseconds
**Deltas: positive is improvement, negative is regression.
```


**Second run:**
```
                          Delta (median)     Master     (25%,  75%)          Branch     (25%,  75%)
---------------------------------------------------------------------------------------------------------
gather_1D                |     850      |    3,900     (-130, +150)       |  3,000     (-110, +130)
gather_dim0              |     860      |    4,000     (-140, +150)       |  3,200     (-110, +150)
gather_dim1              |   1,200      |    4,300     (-160, +160)       |  3,200     (-110, +150)
scatter_1D               |   1,100      |    2,700     (-98 , +110)       |  1,700     (-64 , +83)
scatter_dim0             |     950      |    2,800     (-100, +110)       |  1,900     (-67 , +88)
scatter_dim1             |   1,200      |    3,100     (-120, +140)       |  1,900     (-69 , +88)
scatter_add_1D           |   1,100      |    2,700     (-92 , +110)       |  1,700     (-65 , +95)
scatter_add_dim0         |     960      |    2,800     (-100, +100)       |  1,900     (-74 , +100)
scatter_add_dim1         |   1,200      |    3,100     (-100, +130)       |  1,900     (-72 , +100)
cumsum_1D                |     960      |    4,500     (-140, +190)       |  3,600     (-130, +170)
cumsum_dim0              |     820      |    4,500     (-140, +180)       |  3,700     (-130, +170)
cumsum_dim1              |   1,100      |    4,800     (-160, +200)       |  3,600     (-120, +170)
cumprod_1D               |     960      |    4,500     (-130, +190)       |  3,600     (-130, +180)
cumprod_dim0             |     820      |    4,500     (-150, +190)       |  3,700     (-130, +180)
cumprod_dim1             |   1,100      |    4,800     (-150, +220)       |  3,700     (-130, +180)
min_dim0                 |     260      |    5,800     (-210, +250)       |  5,500     (-200, +230)
min_dim1                 |     580      |    6,100     (-230, +270)       |  5,500     (-200, +220)
max_dim0                 |     250      |    5,800     (-210, +230)       |  5,600     (-170, +210)
max_dim1                 |     520      |    6,100     (-220, +240)       |  5,600     (-180, +210)
std       (reference)    |     170      |    4,300     (-210, +220)       |  4,100     (-160, +190)
clamp     (reference)    |     140      |    3,400     (-140, +170)       |  3,300     (-120, +170)
argmin    (reference)    |     -51      |    3,800     (-170, +190)       |  3,900     (-140, +160)
sum       (reference)    |     -58      |    4,100     (-160, +170)       |  4,200     (-170, +190)
x < y     (reference)    |      64      |    3,600     (-150, +210)       |  3,500     (-140, +180)
max(x, y) (reference)    |     120      |    3,500     (-130, +150)       |  3,400     (-130, +150)

* Times in nanoseconds
**Deltas: positive is improvement, negative is regression.
```

CC @ilia-cher @VitalyFedyunin @glaringlee @gdankel