### PR TITLE
Fixing `CatTransform` so it works with `event_dim > 0` transforms

### DIFF
--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -657,9 +657,9 @@ class CatTransform(Transform):
         for trans, length in zip(self.transforms, self.lengths):
             xslice = x.narrow(self.dim, start, length)
             yslice = y.narrow(self.dim, start, length)
-            logdetjacs.append(trans.log_abs_det_jacobian(xslice, yslice).view(x.shape + (1,) * self.event_dim))
+            logdetjacs.append(trans.log_abs_det_jacobian(xslice, yslice).reshape(x.shape + (1,) * self.event_dim))
             start = start + length  # avoid += for jit compat
-        return torch.cat(logdetjacs, dim=self.dim)._sum_rightmost(self.event_dim)
+        return _sum_rightmost(torch.cat(logdetjacs, dim=self.dim), self.event_dim)
 
     @property
     def bijective(self):


### PR DESCRIPTION
This PR fixes a bug described in https://github.com/pyro-ppl/pyro/issues/2423 for which the `.log_abs_det_jacobian` method in `torch.distributions.transforms.CatTransform` fails when it operates on transforms with `event_dim > 0` (transforms that operate on vectors, matrices, etc.)

This issue I believe will need to be fixed in a separate PR for `StackTransform` once my solution has been reviewed/approved

cc @fritzo @alicanb @neerajprad 