### PR TITLE
Use lld-link over link.exe

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -88,8 +88,8 @@ sccache --start-server
 sccache --zero-stats
 set CC=sccache-cl
 set CXX=sccache-cl
-set LD=lld-link
 
+set CMAKE_LINKER=lld-link
 set CMAKE_GENERATOR=Ninja
 
 :: The following code will try to build PyTorch twice if USE_CUDA is neither 0

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -4,7 +4,7 @@ if "%DEBUG%" == "1" (
   set BUILD_TYPE=release
 )
 
-set PATH=C:\Program Files\CMake\bin;C:\Program Files\7-Zip;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\Program Files\Amazon\AWSCLI;C:\Program Files\Amazon\AWSCLI\bin;%PATH%
+set PATH=C:\Program Files\LLVM\bin;C:\Program Files\CMake\bin;C:\Program Files\7-Zip;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\Program Files\Amazon\AWSCLI;C:\Program Files\Amazon\AWSCLI\bin;%PATH%
 
 :: This inflates our log size slightly, but it is REALLY useful to be
 :: able to see what our cl.exe commands are (since you can actually
@@ -15,6 +15,7 @@ set CMAKE_VERBOSE_MAKEFILE=1
 
 set INSTALLER_DIR=%SCRIPT_HELPERS_DIR%\installation-helpers
 
+call %INSTALLER_DIR%\install_llvm.bat
 call %INSTALLER_DIR%\install_mkl.bat
 call %INSTALLER_DIR%\install_magma.bat
 call %INSTALLER_DIR%\install_sccache.bat
@@ -87,6 +88,7 @@ sccache --start-server
 sccache --zero-stats
 set CC=sccache-cl
 set CXX=sccache-cl
+set LD=lld-link
 
 set CMAKE_GENERATOR=Ninja
 

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_llvm.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_llvm.bat
@@ -1,0 +1,10 @@
+mkdir %TMP_DIR_WIN%\bin
+
+if "%REBUILD%"=="" (
+  if "%BUILD_ENVIRONMENT%"=="" (
+    curl --retry 3 -k https://s3.amazonaws.com/ossci-windows/LLVM-9.0.1-win64.exe --output %TMP_DIR_WIN%\LLVM-9.0.1-win64.exe
+  ) else (
+    aws s3 cp s3://ossci-windows/LLVM-9.0.1-win64.exe %TMP_DIR_WIN%\LLVM-9.0.1-win64.exe --quiet
+  )
+  7z x -aoa %TMP_DIR_WIN%\LLVM-9.0.1-win64.exe -o"C:\Program Files\LLVM"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,9 @@ if(MSVC)
       CMAKE_SHARED_LINKER_FLAGS CMAKE_STATIC_LINKER_FLAGS
       CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS)
     string(APPEND ${flag_var} " /ignore:4049 /ignore:4217")
+    if(CMAKE_LINKER MATCHES "lld-link")
+      string(APPEND ${flag_var} " -threads:no")
+    endif()
   endforeach(flag_var)
 
   # Try harder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,10 +301,12 @@ if(MSVC)
       CMAKE_SHARED_LINKER_FLAGS CMAKE_STATIC_LINKER_FLAGS
       CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS)
     string(APPEND ${flag_var} " /ignore:4049 /ignore:4217")
-    if(CMAKE_LINKER MATCHES "lld-link")
-      string(APPEND ${flag_var} " /threads:no")
-    endif()
   endforeach(flag_var)
+
+  if(CMAKE_LINKER MATCHES "lld-link")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " /threads:no")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " /threads:no")
+  endif()
 
   # Try harder
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler /w -w")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ if(MSVC)
       CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS)
     string(APPEND ${flag_var} " /ignore:4049 /ignore:4217")
     if(CMAKE_LINKER MATCHES "lld-link")
-      string(APPEND ${flag_var} " -threads:no")
+      string(APPEND ${flag_var} " /threads:no")
     endif()
   endforeach(flag_var)
 


### PR DESCRIPTION
Link time for `torch_cpu.dll` on a 16-core machine
link.exe ~7m
lld-link.exe (/threads) ~1m
lld-link.exe (/threads:no) ?