### PR TITLE
Fix ONNX export of RNNs with no bias

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -148,7 +148,7 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
     # default pip version is too old(9.0.2), unable to support tag `manylinux2010`.
     # Fix the pip error: Couldn't find a version that satisfies the requirement
     sudo pip install --upgrade pip
-    pip install -q --user -i https://test.pypi.org/simple/ ort-nightly==1.3.0.dev202005121
+    pip install -q --user -i https://test.pypi.org/simple/ ort-nightly==1.3.0.dev202005123
   fi
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1842,7 +1842,6 @@ class TestONNXRuntime(unittest.TestCase):
     def test_rnn_no_bias(self):
         def make_model(layers, packed_sequence):
             batch_first = True if packed_sequence == 2 else False
-
             model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False, \
                 batch_first=batch_first, bias=False)
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1842,8 +1842,8 @@ class TestONNXRuntime(unittest.TestCase):
     def test_rnn_no_bias(self):
         def make_model(layers, packed_sequence):
             batch_first = True if packed_sequence == 2 else False
-            model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False, \
-                batch_first=batch_first, bias=False)
+            model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False,
+                                 batch_first=batch_first, bias=False)
 
             if packed_sequence == 1:
                 model = RnnModelWithPackedSequence(model, False)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1842,12 +1842,9 @@ class TestONNXRuntime(unittest.TestCase):
     def test_rnn_no_bias(self):
         def make_model(layers, packed_sequence):
             batch_first = True if packed_sequence == 2 else False
-            model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False,
-<<<<<<< HEAD
-                                 batch_first=batch_first, bias=False)
-=======
-                             batch_first=batch_first, bias=False)
->>>>>>> Fix ONNX export of RNNs with no bias
+
+            model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False, \
+                batch_first=batch_first, bias=False)
 
             if packed_sequence == 1:
                 model = RnnModelWithPackedSequence(model, False)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1842,8 +1842,8 @@ class TestONNXRuntime(unittest.TestCase):
     def test_rnn_no_bias(self):
         def make_model(layers, packed_sequence):
             batch_first = True if packed_sequence == 2 else False
-            model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False,
-                             batch_first=batch_first, bias=False)
+            model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False, \
+                batch_first=batch_first, bias=False)
 
             if packed_sequence == 1:
                 model = RnnModelWithPackedSequence(model, False)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1893,7 +1893,6 @@ class TestONNXRuntime(unittest.TestCase):
         model = make_model(3, 2)
         self.run_test(model, input, batch_size=RNN_BATCH_SIZE)
 
-    @unittest.skip("Possible ORT bug?")
     def test_gru_no_bias(self):
         class GruNet(torch.nn.Module):
             def __init__(self, input_size, hidden_size, num_layers, bidirectional):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1843,7 +1843,11 @@ class TestONNXRuntime(unittest.TestCase):
         def make_model(layers, packed_sequence):
             batch_first = True if packed_sequence == 2 else False
             model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=False,
+<<<<<<< HEAD
                                  batch_first=batch_first, bias=False)
+=======
+                             batch_first=batch_first, bias=False)
+>>>>>>> Fix ONNX export of RNNs with no bias
 
             if packed_sequence == 1:
                 model = RnnModelWithPackedSequence(model, False)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1705,8 +1705,8 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         if variant == 'RNN':
             weight_ih, weight_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
-                weight_ih, weight_hh = \
-                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+            weight_ih, weight_hh = \
+                [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh))
 
     def transform_weights(layer_index):
@@ -1714,8 +1714,8 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         if variant == 'RNN':
             weight_ih, weight_hh, bias_ih, bias_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
-                weight_ih, weight_hh, bias_ih, bias_hh = \
-                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+            weight_ih, weight_hh, bias_ih, bias_hh = \
+                [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
         bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh, bias_concat))
 
@@ -1740,7 +1740,7 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
                 weight_ih_f, weight_hh_f = transform_weights_no_bias(2 * i)
                 weight_ih_b, weight_hh_b = transform_weights_no_bias(2 * i + 1)
                 bias_concat = unused(g)
-                    
+
             weight_ih = g.op('Concat', weight_ih_f, weight_ih_b, axis_i=0)
             weight_hh = g.op('Concat', weight_hh_f, weight_hh_b, axis_i=0)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1705,8 +1705,13 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         if variant == 'RNN':
             weight_ih, weight_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
+<<<<<<< HEAD
             weight_ih, weight_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+=======
+                weight_ih, weight_hh = \
+                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+>>>>>>> Fix ONNX export of RNNs with no bias
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh))
 
     def transform_weights(layer_index):
@@ -1714,8 +1719,13 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         if variant == 'RNN':
             weight_ih, weight_hh, bias_ih, bias_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
+<<<<<<< HEAD
             weight_ih, weight_hh, bias_ih, bias_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+=======
+                weight_ih, weight_hh, bias_ih, bias_hh = \
+                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+>>>>>>> Fix ONNX export of RNNs with no bias
         bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh, bias_concat))
 
@@ -1740,7 +1750,11 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
                 weight_ih_f, weight_hh_f = transform_weights_no_bias(2 * i)
                 weight_ih_b, weight_hh_b = transform_weights_no_bias(2 * i + 1)
                 bias_concat = unused(g)
+<<<<<<< HEAD
 
+=======
+                    
+>>>>>>> Fix ONNX export of RNNs with no bias
             weight_ih = g.op('Concat', weight_ih_f, weight_ih_b, axis_i=0)
             weight_hh = g.op('Concat', weight_hh_f, weight_hh_b, axis_i=0)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1705,13 +1705,11 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         if variant == 'RNN':
             weight_ih, weight_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
-<<<<<<< HEAD
             weight_ih, weight_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
-=======
-                weight_ih, weight_hh = \
-                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
->>>>>>> Fix ONNX export of RNNs with no bias
+            weight_ih, weight_hh = \
+                [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+>>>>>>> Fix whitespace
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh))
 
     def transform_weights(layer_index):
@@ -1720,12 +1718,17 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
             weight_ih, weight_hh, bias_ih, bias_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
 <<<<<<< HEAD
+<<<<<<< HEAD
             weight_ih, weight_hh, bias_ih, bias_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
 =======
                 weight_ih, weight_hh, bias_ih, bias_hh = \
                     [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
 >>>>>>> Fix ONNX export of RNNs with no bias
+=======
+            weight_ih, weight_hh, bias_ih, bias_hh = \
+                [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+>>>>>>> Fix whitespace
         bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh, bias_concat))
 
@@ -1751,10 +1754,14 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
                 weight_ih_b, weight_hh_b = transform_weights_no_bias(2 * i + 1)
                 bias_concat = unused(g)
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 =======
                     
 >>>>>>> Fix ONNX export of RNNs with no bias
+=======
+
+>>>>>>> Fix whitespace
             weight_ih = g.op('Concat', weight_ih_f, weight_ih_b, axis_i=0)
             weight_hh = g.op('Concat', weight_hh_f, weight_hh_b, axis_i=0)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1700,14 +1700,23 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         slices = [sym_help._slice_helper(g, w, axes=[0], starts=[x * n], ends=[y * n]) for x, y in intervals]
         return g.op('Concat', *slices, axis_i=0)
 
-    def transform_weights(layer_index):
+    def transform_weights_no_bias(layer_index):
+        weights = layer_weights[layer_index]
         if variant == 'RNN':
-            weight_ih, weight_hh, bias_ih, bias_hh = layer_weights[layer_index]
+            weight_ih, weight_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
-            weight_ih, weight_hh, bias_ih, bias_hh = \
-                [reform_weights(g, w, hidden_size, reform_permutation) for w in layer_weights[layer_index]]
-        bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
+                weight_ih, weight_hh = \
+                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+        return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh))
 
+    def transform_weights(layer_index):
+        weights = layer_weights[layer_index]
+        if variant == 'RNN':
+            weight_ih, weight_hh, bias_ih, bias_hh = weights
+        elif variant == 'GRU' or variant == 'LSTM':
+                weight_ih, weight_hh, bias_ih, bias_hh = \
+                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
+        bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh, bias_concat))
 
     def retrieve_state(x, start, end):
@@ -1715,15 +1724,25 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
 
     for i in range(num_layers):
         if unidirectional:
-            weight_ih, weight_hh, bias_concat = transform_weights(i)
+            if weights_per_layer == 4:
+                weight_ih, weight_hh, bias_concat = transform_weights(i)
+            else:
+                weight_ih, weight_hh = transform_weights_no_bias(i)
+                bias_concat = unused(g)
+
             state_indices = i, i + 1
         else:
-            weight_ih_f, weight_hh_f, bias_f = transform_weights(2 * i)
-            weight_ih_b, weight_hh_b, bias_b = transform_weights(2 * i + 1)
-
+            if weights_per_layer == 4:
+                weight_ih_f, weight_hh_f, bias_f = transform_weights(2 * i)
+                weight_ih_b, weight_hh_b, bias_b = transform_weights(2 * i + 1)
+                bias_concat = g.op('Concat', bias_f, bias_b, axis_i=0)
+            else:
+                weight_ih_f, weight_hh_f = transform_weights_no_bias(2 * i)
+                weight_ih_b, weight_hh_b = transform_weights_no_bias(2 * i + 1)
+                bias_concat = unused(g)
+                    
             weight_ih = g.op('Concat', weight_ih_f, weight_ih_b, axis_i=0)
             weight_hh = g.op('Concat', weight_hh_f, weight_hh_b, axis_i=0)
-            bias_concat = g.op('Concat', bias_f, bias_b, axis_i=0)
 
             state_indices = 2 * i, 2 * i + 2
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1707,9 +1707,6 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         elif variant == 'GRU' or variant == 'LSTM':
             weight_ih, weight_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
-            weight_ih, weight_hh = \
-                [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
->>>>>>> Fix whitespace
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh))
 
     def transform_weights(layer_index):
@@ -1717,18 +1714,8 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         if variant == 'RNN':
             weight_ih, weight_hh, bias_ih, bias_hh = weights
         elif variant == 'GRU' or variant == 'LSTM':
-<<<<<<< HEAD
-<<<<<<< HEAD
             weight_ih, weight_hh, bias_ih, bias_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
-=======
-                weight_ih, weight_hh, bias_ih, bias_hh = \
-                    [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
->>>>>>> Fix ONNX export of RNNs with no bias
-=======
-            weight_ih, weight_hh, bias_ih, bias_hh = \
-                [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
->>>>>>> Fix whitespace
         bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh, bias_concat))
 
@@ -1753,15 +1740,7 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
                 weight_ih_f, weight_hh_f = transform_weights_no_bias(2 * i)
                 weight_ih_b, weight_hh_b = transform_weights_no_bias(2 * i + 1)
                 bias_concat = unused(g)
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-=======
-                    
->>>>>>> Fix ONNX export of RNNs with no bias
-=======
-
->>>>>>> Fix whitespace
             weight_ih = g.op('Concat', weight_ih_f, weight_ih_b, axis_i=0)
             weight_hh = g.op('Concat', weight_hh_f, weight_hh_b, axis_i=0)
 


### PR DESCRIPTION
Fixes #34800 .

Currently, the LSTM/RNN/GRU export to ONNX can't handle models without a bias term.