### PR TITLE
Returns float from complex angle

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -44,11 +44,50 @@ static inline Tensor& unary_op_impl_out(Tensor& result, const Tensor& self, Stub
   return result;
 }
 
+// Mimics returning a floating point tensor for complex inputs by default
+// Note: This is done by running the operation as usual and then copying the
+// operation's result to the expected result type.
+template <typename Stub>
+static inline Tensor& unary_op_impl_out_complex_to_float(Tensor& result, const Tensor& self, Stub& stub) {
+    if (self.is_complex() && !result.is_complex()) {
+      // Checks if the corresponding float type can be cast to the desired dtype
+      const auto float_type = c10::toValueType(self.scalar_type());
+      TORCH_CHECK(canCast(float_type, result.scalar_type()),
+            "result type ", float_type, " can't be cast to the desired output type ",
+            result.scalar_type());
+
+      // Runs the function complex->complex, as TensorIterator expects
+      Tensor complex_result = at::empty({0}, self.options());
+      auto iter = TensorIterator::unary_op(complex_result, self,
+        /*check_mem_overlap=*/true);
+      stub(iter.device_type(), iter);
+
+      // Copies the complex result to the actual result and returns it
+      result.resize_(complex_result.sizes());
+      result.copy_(complex_result);
+      return result;
+    }
+
+    return unary_op_impl_out(result, self, stub);
+}
+
 // out_impl passed into unary_op_impl and unary_op_impl_  must go through at:: device dispatch
 // otherwise it won't dispatch to out-of-source devices like XLA.
 // For example it must be at::bitwise_not_out instead of bitwise_not_out(which is at::native!).
 template <typename OutImpl>
 static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl) {
+  Tensor result = at::empty({0}, self.options());
+  return out_impl(result, self);
+}
+
+template <typename OutImpl>
+static inline Tensor unary_op_impl_complex_to_float(const Tensor& self, OutImpl& out_impl) {
+  if (self.is_complex()) {
+    const auto float_type = c10::toValueType(self.scalar_type());
+    Tensor result = at::empty({0}, self.options().dtype(float_type));
+    return out_impl(result, self);
+  }
+
   Tensor result = at::empty({0}, self.options());
   return out_impl(result, self);
 }
@@ -66,51 +105,25 @@ Tensor& asin_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(
 Tensor asin(const Tensor& self) { return unary_op_impl(self, at::asin_out); }
 Tensor& asin_(Tensor& self) { return unary_op_impl_(self, at::asin_out); }
 
-// Note [Complex abs]
-// Complex inputs to abs return float results by default.
-// abs, in both NumPy and C++, returns a float result when given a complex input.
-// This makes sense mathematically since the absolute value of a complex
-// number has no imaginary part.
+// Note [Complex abs and angle]
+// Complex inputs to abs and angle return float results by default.
+// abs and angle, in both NumPy and C++, returns a float result when given a
+// complex input. This makes sense mathematically since the absolute value
+// and angle of a complex number has no imaginary part.
 Tensor& abs_out(Tensor& result, const Tensor& self) {
-  // Mimics abs returning a floating point tensor for complex inputs by default
-  // Note: This is done by running the operation as usual and then copying the
-  // operation's result to the expected result type.
-  if (self.is_complex() && !result.is_complex()) {
-    // Checks if the corresponding float type can be cast to the desired dtype
-    const auto float_type = c10::toValueType(self.scalar_type());
-    TORCH_CHECK(canCast(float_type, result.scalar_type()),
-          "result type ", float_type, " can't be cast to the desired output type ",
-          result.scalar_type());
-
-    // Runs the function complex->complex, as TensorIterator expects
-    Tensor complex_result = at::empty({0}, self.options());
-    auto iter = TensorIterator::unary_op(complex_result, self,
-      /*check_mem_overlap=*/false);
-    abs_stub(iter.device_type(), iter);
-
-    // Copies the complex result to the actual result and returns it
-    result.resize_(complex_result.sizes());
-    result.copy_(complex_result);
-    return result;
-  }
-
-  return unary_op_impl_out(result, self, abs_stub);
+  return unary_op_impl_out_complex_to_float(result, self, abs_stub);
 }
 Tensor abs(const Tensor& self) {
-  // Overrides default return type to be floating point when given a
-  // complex input. See note [Complex abs].
-  if (self.is_complex()) {
-    const auto float_type = c10::toValueType(self.scalar_type());
-    Tensor result = at::empty({0}, self.options().dtype(float_type));
-    return at::abs_out(result, self);
-  }
-
-  return unary_op_impl(self, at::abs_out);
+  return unary_op_impl_complex_to_float(self, at::abs_out);
 }
 Tensor& abs_(Tensor& self) { return unary_op_impl_(self, at::abs_out); }
 
-Tensor& angle_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, angle_stub); }
-Tensor angle(const Tensor& self) { return unary_op_impl(self, at::angle_out); }
+Tensor& angle_out(Tensor& result, const Tensor& self) {
+  return unary_op_impl_out_complex_to_float(result, self, angle_stub);
+}
+Tensor angle(const Tensor& self) {
+  return unary_op_impl_complex_to_float(self, at::angle_out);
+}
 
 Tensor real(const Tensor& self) {
   TORCH_CHECK(!self.is_complex(), "real is not yet implemented for complex tensors.");

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -44,7 +44,9 @@ static inline Tensor& unary_op_impl_out(Tensor& result, const Tensor& self, Stub
   return result;
 }
 
-// Mimics returning a floating point tensor for complex inputs by default
+// An alternate version of unary_op_impl_out that follows the same pattern
+// for non-complex inputs, but returns a floating point tensor
+// for complex inputs by default.
 // Note: This is done by running the operation as usual and then copying the
 // operation's result to the expected result type.
 template <typename Stub>
@@ -80,6 +82,9 @@ static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl) {
   return out_impl(result, self);
 }
 
+// An alternate version of unary_op_impl that follows the same pattern 
+// for non-complex inputs, but returns a floating point tensor
+// for complex inputs by default.
 template <typename OutImpl>
 static inline Tensor unary_op_impl_with_complex_to_float(const Tensor& self, OutImpl& out_impl) {
   if (self.is_complex()) {

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -48,7 +48,7 @@ static inline Tensor& unary_op_impl_out(Tensor& result, const Tensor& self, Stub
 // Note: This is done by running the operation as usual and then copying the
 // operation's result to the expected result type.
 template <typename Stub>
-static inline Tensor& unary_op_impl_out_complex_to_float(Tensor& result, const Tensor& self, Stub& stub) {
+static inline Tensor& unary_op_impl_with_complex_to_float_out(Tensor& result, const Tensor& self, Stub& stub) {
     if (self.is_complex() && !result.is_complex()) {
       // Checks if the corresponding float type can be cast to the desired dtype
       const auto float_type = c10::toValueType(self.scalar_type());
@@ -81,7 +81,7 @@ static inline Tensor unary_op_impl(const Tensor& self, OutImpl& out_impl) {
 }
 
 template <typename OutImpl>
-static inline Tensor unary_op_impl_complex_to_float(const Tensor& self, OutImpl& out_impl) {
+static inline Tensor unary_op_impl_with_complex_to_float(const Tensor& self, OutImpl& out_impl) {
   if (self.is_complex()) {
     const auto float_type = c10::toValueType(self.scalar_type());
     Tensor result = at::empty({0}, self.options().dtype(float_type));
@@ -111,18 +111,18 @@ Tensor& asin_(Tensor& self) { return unary_op_impl_(self, at::asin_out); }
 // complex input. This makes sense mathematically since the absolute value
 // and angle of a complex number has no imaginary part.
 Tensor& abs_out(Tensor& result, const Tensor& self) {
-  return unary_op_impl_out_complex_to_float(result, self, abs_stub);
+  return unary_op_impl_with_complex_to_float_out(result, self, abs_stub);
 }
 Tensor abs(const Tensor& self) {
-  return unary_op_impl_complex_to_float(self, at::abs_out);
+  return unary_op_impl_with_complex_to_float(self, at::abs_out);
 }
 Tensor& abs_(Tensor& self) { return unary_op_impl_(self, at::abs_out); }
 
 Tensor& angle_out(Tensor& result, const Tensor& self) {
-  return unary_op_impl_out_complex_to_float(result, self, angle_stub);
+  return unary_op_impl_with_complex_to_float_out(result, self, angle_stub);
 }
 Tensor angle(const Tensor& self) {
-  return unary_op_impl_complex_to_float(self, at::angle_out);
+  return unary_op_impl_with_complex_to_float(self, at::angle_out);
 }
 
 Tensor real(const Tensor& self) {

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -684,7 +684,7 @@ class TestTypePromotion(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @dtypes(torch.complex64, torch.complex128)
-    def test_abs_complex_to_float(self, device, dtype):
+    def test_abs_angle_complex_to_float(self, device, dtype):
         # Constructs random complex values
         from random import random
         random_vals = []
@@ -696,45 +696,50 @@ class TestTypePromotion(TestCase):
             a = np.array(vals, dtype=torch_to_numpy_dtype_dict[dtype])
             t = torch.tensor(vals, device=device, dtype=dtype)
 
-            # Tests abs
-            np_result = torch.from_numpy(np.abs(a))
-            torch_result = torch.abs(t).cpu()
-            self.assertEqual(np_result, torch_result, exact_dtype=True)
+            for fn_name in ('abs', 'angle'):
+                torch_fn = getattr(torch, fn_name)
+                np_fn = getattr(np, fn_name)
 
-            # Tests float out
-            float_dtype = torch.float32 if dtype is torch.complex64 else torch.float64
-            np_float_out = np.empty_like(a).astype(np.float32)
-            np.abs(a, out=np_float_out)
-            float_out = torch.empty_like(t).float()
-            torch.abs(t, out=float_out)
-            self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
+                # Tests function
+                np_result = torch.from_numpy(np_fn(a))
+                torch_result = torch_fn(t).cpu()
+                self.assertEqual(np_result, torch_result, exact_dtype=True)
 
-            # Tests float out (resized out)
-            float_out = torch.empty(1, device=device, dtype=float_dtype)
-            torch.abs(t, out=float_out)
-            self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
+                # Tests float out
+                float_dtype = torch.float32 if dtype is torch.complex64 else torch.float64
+                np_float_out = np_fn(a).astype(torch_to_numpy_dtype_dict[float_dtype])
+                float_out = torch.empty_like(t).float()
+                torch_fn(t, out=float_out)
+                self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
 
-            # Tests complex out
-            np_complex_out = np.empty_like(a)
-            np.abs(a, out=np_complex_out)
-            complex_out = torch.empty_like(t)
-            torch.abs(t, out=complex_out)
-            self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
+                # Tests float out (resized out)
+                float_out = torch.empty(1, device=device, dtype=float_dtype)
+                torch_fn(t, out=float_out)
+                self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
 
-            # Tests complex out (resized out)
-            complex_out = torch.empty(1, device=device, dtype=dtype)
-            torch.abs(t, out=complex_out)
-            self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
+                # Tests complex out
+                np_complex_out = np_fn(a)
+                complex_out = torch.empty_like(t)
+                torch_fn(t, out=complex_out)
+                self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
 
-            # Tests long out behavior (expected failure)
-            long_out = torch.empty(0, device=device, dtype=torch.long)
-            with self.assertRaises(RuntimeError):
-                torch.abs(t, out=long_out)
+                # Tests complex out (resized out)
+                complex_out = torch.empty(1, device=device, dtype=dtype)
+                torch_fn(t, out=complex_out)
+                self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
 
-            # Tests inplace
-            np.abs(a, out=a)
-            t.abs_()
-            self.assertEqual(torch.from_numpy(a), t.cpu())
+                # Tests long out behavior (expected failure)
+                long_out = torch.empty(0, device=device, dtype=torch.long)
+                with self.assertRaises(RuntimeError):
+                    torch_fn(t, out=long_out)
+
+                # Tests inplace
+                # Note: angle does not have an in-place variant
+                if fn_name == 'abs':
+                    torch_inplace_method = getattr(torch.Tensor, fn_name + "_")
+                    np_fn(a, out=a)
+                    torch_inplace_method(t)
+                    self.assertEqual(torch.from_numpy(a), t.cpu())
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @float_double_default_dtype

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -734,12 +734,16 @@ class TestTypePromotion(TestCase):
                     torch_fn(t, out=long_out)
 
                 # Tests inplace
-                # Note: angle does not have an in-place variant
                 if fn_name == 'abs':
                     torch_inplace_method = getattr(torch.Tensor, fn_name + "_")
                     np_fn(a, out=a)
                     torch_inplace_method(t)
                     self.assertEqual(torch.from_numpy(a), t.cpu())
+
+                # Note: angle does not have an in-place variant
+                if fn_name == 'angle':
+                    with self.assertRaises(AttributeError):
+                        torch_inplace_method = getattr(torch.Tensor, fn_name + "_")
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @float_double_default_dtype


### PR DESCRIPTION
Updates angle to return a float tensor, by default, when given complex inputs. This behavior is compatible with Python, NumPy, and C++. The implementation follows the former implementation for complex abs, extracting the logic into a common function for both abs and angle.

The test for complex abs's behavior in test_type_promotion.py is updated to also test the behavior of complex angle by comparing its results to NumPy's. 