### PR TITLE
Documentation LU Decomposition: deriving L, U, and P

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -984,6 +984,9 @@ def _lu_impl(A, pivot=True, get_infos=False, out=None):
         for singular matrices due to the bug in the MAGMA library (see
         magma issue 13).
 
+    .. note::
+       ``L``, ``U``, and ``P`` can be derived using :func:`torch.lu_unpack`.
+
     Arguments:
         A (Tensor): the tensor to factor of size :math:`(*, m, n)`
         pivot (bool, optional): controls whether pivoting is done. Default: ``True``


### PR DESCRIPTION
Add note to LU decomposition to use `lu_unpack` to get `L`, `U`, and `P`.

Fixes #36752.