### PR TITLE
Add TorchServe in docs and reorder

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,12 +64,13 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
 .. toctree::
    :maxdepth: 1
    :caption: Libraries
-   
-   PyTorch on XLA Devices <http://pytorch.org/xla/>
-   PyTorch Elastic (torchelastic) <https://pytorch.org/elastic/>
+
    torchaudio <https://pytorch.org/audio>
    torchtext <https://pytorch.org/text>
    torchvision/index
+   TorchElastic <https://pytorch.org/elastic/>
+   TorchServe <https://pytorch.org/serve>
+   PyTorch on XLA Devices <http://pytorch.org/xla/>
 
 .. toctree::
    :glob:


### PR DESCRIPTION
Note: link to torchserve (https://pytorch.org/serve) will not work until it is turned public later today