### PR TITLE
[v1.5 Patch] Disable flaky test_backward_node_failure_python_udf test in dist_autograd_test.py

### DIFF
--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -1411,10 +1411,7 @@ class DistAutogradTest(RpcAgentTestFixture):
             time.sleep(0.1)
 
     @dist_init(clean_shutdown=False)
-    @unittest.skipIf(
-        IS_MACOS,
-        "Test is flaky on MacOS since libuv error handling is not as robust as TCP",
-    )
+    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/35099")
     def test_backward_node_failure_python_udf(self):
         # Set a short timeout to quickly time out failed RPCs.
         rpc._set_rpc_timeout(timedelta(milliseconds=5000))


### PR DESCRIPTION
This test is flaky on the 1.5 release branch. Below is a failed CI run:
https://app.circleci.com/pipelines/github/pytorch/pytorch/157331/workflows/b3e0bd6b-6c55-4d14-bde8-96b8345cf9e2/jobs/5190025

