### PR TITLE
Early Return Pattern 'if return else return' -> 'if return return'

### DIFF
--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -253,15 +253,13 @@ def get_default_args(fn):
         argspec = inspect.getargspec(fn)
         if argspec.defaults is not None:
             return dict(zip(argspec.args[-len(argspec.defaults):], argspec.defaults))
-        else:
-            return {}
-    else:
-        signature = inspect.signature(fn)
-        return {
-            k: v.default
-            for k, v in signature.parameters.items()
-            if v.default is not inspect.Parameter.empty
-        }
+        return {}
+    signature = inspect.signature(fn)
+    return {
+        k: v.default
+        for k, v in signature.parameters.items()
+        if v.default is not inspect.Parameter.empty
+    }
 
 
 class StmtBuilder(Builder):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -135,11 +135,10 @@ def _uses_true_division(fn):
         return True
     if inspect.ismethod(fn):
         return _uses_true_division(fn.__func__)
-    elif inspect.isfunction(fn):
+    if inspect.isfunction(fn):
         return fn.__globals__.get('division') is __future__.division
-    else:
-        raise RuntimeError(
-            '_uses_true_division: expected function or method, got {}'.format(type(fn)))
+    raise RuntimeError(
+        '_uses_true_division: expected function or method, got {}'.format(type(fn)))
 
 
 def get_jit_class_def(cls, self_name):

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -519,8 +519,7 @@ class QuantizedLSTM(QuantizedRNNBase):
     def forward(self, input, hx=None):
         if isinstance(input, PackedSequence):
             return self.forward_packed(input, hx)
-        else:
-            return self.forward_tensor(input, hx)
+        return self.forward_tensor(input, hx)
 
 
 class QuantizedGRU(QuantizedRNNBase):

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -617,11 +617,10 @@ def quantize_linear_modules(module, dtype=torch.int8):
     if isinstance(module, torch.nn.Linear):
         if dtype == torch.int8:
             return QuantizedLinear(module)
-        elif dtype == torch.float16:
+        if dtype == torch.float16:
             return QuantizedLinearFP16(module)
-        else:
-            raise RuntimeError(
-                "Unsupported dtype: {}".format(dtype))
+        raise RuntimeError(
+            "Unsupported dtype: {}".format(dtype))
     return module
 
 

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -578,8 +578,7 @@ class QuantizedGRU(QuantizedRNNBase):
     def forward(self, input, hx=None):
         if isinstance(input, PackedSequence):
             return self.forward_packed(input, hx)
-        else:
-            return self.forward_tensor(input, hx)
+        return self.forward_tensor(input, hx)
 
 
 def quantize_rnn_cell_modules(module):


### PR DESCRIPTION
I think 'if return' is better than 'if return return' in the early return pattern. Also, I think this method is better to match the uniformity of the code. Thank you.