### PR TITLE
Delete docker build job for pytorch-linux-bionic-clang9-thrift-llvmdev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6644,9 +6644,6 @@ workflows:
           name: "pytorch-linux-bionic-py3.6-clang9"
           image_name: "pytorch-linux-bionic-py3.6-clang9"
       - docker_build_job:
-          name: "pytorch-linux-bionic-clang9-thrift-llvmdev"
-          image_name: "pytorch-linux-bionic-clang9-thrift-llvmdev"
-      - docker_build_job:
           name: "pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7"
           image_name: "pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7"
       - docker_build_job:

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -35,12 +35,6 @@ TRAVIS_DL_URL_PREFIX="https://s3.amazonaws.com/travis-python-archives/binaries/u
 # configuration, so we hardcode everything here rather than do it
 # from scratch
 case "$image" in
-  pytorch-linux-bionic-clang9-thrift-llvmdev)
-    CLANG_VERSION=9
-    THRIFT=yes
-    LLVMDEV=yes
-    PROTOBUF=yes
-    ;;
   pytorch-linux-xenial-py3.8)
     # TODO: This is a hack, get rid of this as soon as you get rid of the travis downloads
     TRAVIS_DL_URL_PREFIX="https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/16.04/x86_64"
@@ -181,6 +175,8 @@ fi
 tmp_tag="tmp-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 32 | head -n 1)"
 
 # Build image
+# TODO: build-arg THRIFT is not turned on for any image, remove it once we confirm
+# it's no longer needed.
 docker build \
        --no-cache \
        --build-arg "TRAVIS_DL_URL_PREFIX=${TRAVIS_DL_URL_PREFIX}" \

--- a/.circleci/verbatim-sources/workflows-docker-builder.yml
+++ b/.circleci/verbatim-sources/workflows-docker-builder.yml
@@ -12,9 +12,6 @@
           name: "pytorch-linux-bionic-py3.6-clang9"
           image_name: "pytorch-linux-bionic-py3.6-clang9"
       - docker_build_job:
-          name: "pytorch-linux-bionic-clang9-thrift-llvmdev"
-          image_name: "pytorch-linux-bionic-clang9-thrift-llvmdev"
-      - docker_build_job:
           name: "pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7"
           image_name: "pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7"
       - docker_build_job:


### PR DESCRIPTION
Seems like no one is using this image. We could delete it from our docker hub. 
I think we don't need to regenerate a new set of images, since we are only deleting. But please correct me if I'm wrong. 
