### PR TITLE
[v1.5 Patch][Source-Code-Only] Link NCCL lib to TORCH_PYTHON_LINK_LIBRARIES when USE_NCCL=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,8 @@ cmake_dependent_option(
 cmake_dependent_option(
     USE_GLOO "Use Gloo. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED" OFF)
+# NB: USE_NCCL is intentionally left independent from USE_DISTRIBUTED, because
+# DataParallel also uses NCCL.
 option(USE_TBB "Use TBB" OFF)
 option(ONNX_ML "Enable traditional ONNX ML API." ON)
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -274,6 +274,7 @@ if (USE_NCCL)
     list(APPEND TORCH_PYTHON_SRCS
       ${TORCH_SRC_DIR}/csrc/cuda/python_nccl.cpp)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_NCCL)
+    list(APPEND TORCH_PYTHON_LINK_LIBRARIES __caffe2_nccl)
 endif()
 
 # In the most recent CMake versions, a new 'TRANSFORM' subcommand of 'list' allows much of the boilerplate of defining the lists


### PR DESCRIPTION
This PR is to merge #36948 into the 1.5 release branch. It fixes the build error when setting `USE_DISTRIBUTED=0`. #36948 is landed into master at a14a837. 

NB: This does not need to be added into the v1.5 binary as they are compile with USE_DISTRIBUTED=1, but we will need to land this into the release/1.5 source branch in case users would like to compile from source using USE_DISTRIBUTED=0.

---- Original Commit Description Follows ----

    Link NCCL lib to TORCH_PYTHON_LINK_LIBRARIES when USE_NCCL=1 (#36948)

    Summary:
    Pull Request resolved: https://github.com/pytorch/pytorch/pull/36948

    Compiling with USE_DISTRIBUTED=0 fails as it would still try to
    compile python_nccl.cpp which requires NCCL but the NCCL lib is not
    linked.

    Test Plan: Imported from OSS

    Differential Revision: D21142012

    Pulled By: mrshenli

    fbshipit-source-id: 6ca94056ca859da7f833a31edcb4c5260d8625e4
