### PR TITLE
Link NCCL lib to TORCH_PYTHON_LINK_LIBRARIES when USE_NCCL=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,9 @@ cmake_dependent_option(
 cmake_dependent_option(
     USE_GLOO "Use Gloo. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED" OFF)
+cmake_dependent_option(
+    USE_NCCL "Use NCCL. Only available if USE_DISTRIBUTED is on." ON
+    "USE_DISTRIBUTED" OFF)
 option(USE_TBB "Use TBB" OFF)
 option(ONNX_ML "Enable traditional ONNX ML API." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,9 +204,8 @@ cmake_dependent_option(
 cmake_dependent_option(
     USE_GLOO "Use Gloo. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED" OFF)
-cmake_dependent_option(
-    USE_NCCL "Use NCCL. Only available if USE_DISTRIBUTED is on." ON
-    "USE_DISTRIBUTED" OFF)
+# NB: USE_NCCL is intentionally left independent from USE_DISTRIBUTED, because
+# DataParallel also uses NCCL.
 option(USE_TBB "Use TBB" OFF)
 option(ONNX_ML "Enable traditional ONNX ML API." ON)
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -279,6 +279,7 @@ if(USE_NCCL)
     list(APPEND TORCH_PYTHON_SRCS
       ${TORCH_SRC_DIR}/csrc/cuda/python_nccl.cpp)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_NCCL)
+    list(APPEND TORCH_PYTHON_LINK_LIBRARIES __caffe2_nccl)
 endif()
 
 # In the most recent CMake versions, a new 'TRANSFORM' subcommand of 'list' allows much of the boilerplate of defining the lists


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36948 Link NCCL lib to TORCH_PYTHON_LINK_LIBRARIES when USE_NCCL=1**

Compiling with USE_DISTRIBUTED=0 fails as it would still try to
compile python_nccl.cpp which requires NCCL but the NCCL lib is not
linked.

fixes #36870

Differential Revision: [D21142012](https://our.internmc.facebook.com/intern/diff/D21142012)