### PR TITLE
[clang-format] Disable progress bar if stdout is piped

### DIFF
--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -178,7 +178,7 @@ def download_clang_format(path):
     print("Downloading clang-format to {}".format(path))
     try:
         urllib.request.urlretrieve(
-            cf_url, filename, reporthook=report_download_progress
+            cf_url, filename, reporthook=report_download_progress if sys.stdout.isatty() else None
         )
     except urllib.error.URLError as e:
         print("Error downloading {}: {}".format(filename, str(e)))


### PR DESCRIPTION
**Summary**
This commit disables the progress bar for the `clang-format` binary
download if stdout is not attached to a terminal. The cursor
repositioning tricks used to print out the progress bar don't work if
stdout is redirected something that is not a terminal, and so the file
ends up containing each progress bar update on a separate line. This
happens in the GitHub workflow for checking formatting and is annoying
to scroll through.

**Test Plan**
1. Manual invocation of the script still produces progress bar.
```
(pytorch) me@devgpuXXX:pytorch  (disable-cf-progress-bar)$ with-proxy tools/clang_format.py 
Downloading clang-format to /home/me/local/repos/pytorch/.clang-format-bin                                                                     
0% |################################################################| 100%                                                                          
Using clang-format located at /home/me/local/repos/pytorch/.clang-format-bin/clang-format
```
2. GitHub `clang-format` workflow output no longer contains progress bar.
```
Run set -eux
+ echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ echo '| Run tools/clang_format.py to fix formatting errors |'
| Run tools/clang_format.py to fix formatting errors |
+ echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ tools/clang_format.py --verbose --diff
Created directory /home/runner/work/pytorch/pytorch/.clang-format-bin for clang-format binary
Downloading clang-format to /home/runner/work/pytorch/pytorch/.clang-format-bin

Reference Hash: d1365110da598d148d8143a7f2ccfd8bac7df499
Actual Hash: d1365110da598d148d8143a7f2ccfd8bac7df499
Using clang-format located at /home/runner/work/pytorch/pytorch/.clang-format-bin/clang-format
All files formatted correctly
```
**Fixes**
This PR fixes #36949.

