### PR TITLE
Ensure linearIndex of advanced indexing backwards is contiguous.

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -192,7 +192,7 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
   if (num_indices > 0 && sliceSize > 0) {
       const bool permuted = !src.is_contiguous();
       auto src_ = permuted ? src.contiguous() : src;
-      linearIndex = linearIndex.contiguous().view(-1);
+      linearIndex = linearIndex.reshape(-1);
       auto sorted_indices = at::empty_like(linearIndex, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       auto orig_indices = at::empty_like(linearIndex, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       using device_ptr = thrust::device_ptr<int64_t>;

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -192,7 +192,7 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
   if (num_indices > 0 && sliceSize > 0) {
       const bool permuted = !src.is_contiguous();
       auto src_ = permuted ? src.contiguous() : src;
-      linearIndex = linearIndex.view(-1);
+      linearIndex = linearIndex.contiguous().view(-1);
       auto sorted_indices = at::empty_like(linearIndex, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       auto orig_indices = at::empty_like(linearIndex, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
       using device_ptr = thrust::device_ptr<int64_t>;

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5419,8 +5419,8 @@ class TestAutogradDeviceType(TestCase):
     def test_advanced_indexing_backwards_memory_format(self, device):
         # See https://github.com/pytorch/pytorch/issues/36956
         shape = (2, 8, 1, 2)
-        i = torch.randint(1, shape, device='cuda').contiguous(memory_format=torch.channels_last)
-        x = torch.randn(shape, requires_grad=True, device='cuda')
+        i = torch.randint(1, shape, device=device).contiguous(memory_format=torch.channels_last)
+        x = torch.randn(shape, requires_grad=True, device=device)
         x[i].sum().backward()
 
     def _test_reentrant_parent_error_on_cpu(self, device):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5416,6 +5416,13 @@ class TestAutogradDeviceType(TestCase):
         a.sum().backward()
         self.assertEqual(x.grad, torch.ones(n, 1, device=device))
 
+    def test_advanced_indexing_backwards_memory_format(self, device):
+        # See https://github.com/pytorch/pytorch/issues/36956
+        shape = (2,8,1,2)
+        i = torch.randint(1, shape, device='cuda').contiguous(memory_format=torch.channels_last)
+        x = torch.randn(shape, requires_grad=True, device='cuda')
+        x[i].sum().backward()
+
     def _test_reentrant_parent_error_on_cpu(self, device):
         t1 = torch.rand([3, 3], requires_grad=True)
         t2 = torch.rand([3, 3], device=device, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5418,7 +5418,7 @@ class TestAutogradDeviceType(TestCase):
 
     def test_advanced_indexing_backwards_memory_format(self, device):
         # See https://github.com/pytorch/pytorch/issues/36956
-        shape = (2,8,1,2)
+        shape = (2, 8, 1, 2)
         i = torch.randint(1, shape, device='cuda').contiguous(memory_format=torch.channels_last)
         x = torch.randn(shape, requires_grad=True, device='cuda')
         x[i].sum().backward()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36959 Ensure linearIndex of advanced indexing backwards is contiguous.**

This is a more straightforward solution to the problem than https://github.com/pytorch/pytorch/pull/36957; I don't know about the relative performance.

Fixes: #36956

Differential Revision: [D21144146](https://our.internmc.facebook.com/intern/diff/D21144146)