### PR TITLE
[v1.5.0] Ensure remainder of advanced indexing backwards is contiguous.

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -106,7 +106,10 @@ static Tensor wrapIndexOnce(const Tensor & index, int64_t dim, int64_t dim_size,
       AT_INDEX_ERROR("index ", min_idx, " is out of bounds for dimension ", dim, " with size ", dim_size);
     }
   }
-  return index.remainder(dim_size);
+
+  // require that the output is contiguous
+  auto out = at::empty_like(index, MemoryFormat::Contiguous);
+  return at::remainder_out(out, index, dim_size);
 }
 
 static std::vector<int64_t> computeLinearStride(const Tensor & tensor) {

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5332,8 +5332,8 @@ class TestAutogradDeviceType(TestCase):
     def test_advanced_indexing_backwards_memory_format(self, device):
         # See https://github.com/pytorch/pytorch/issues/36956
         shape = (2, 8, 1, 2)
-        i = torch.randint(1, shape, device='cuda').contiguous(memory_format=torch.channels_last)
-        x = torch.randn(shape, requires_grad=True, device='cuda')
+        i = torch.randint(1, shape, device=device).contiguous(memory_format=torch.channels_last)
+        x = torch.randn(shape, requires_grad=True, device=device)
         x[i].sum().backward()
 
     # test for backward in https://github.com/pytorch/pytorch/issues/15511

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5329,6 +5329,13 @@ class TestAutogradDeviceType(TestCase):
         a.sum().backward()
         self.assertEqual(x.grad, torch.ones(n, 1, device=device))
 
+    def test_advanced_indexing_backwards_memory_format(self, device):
+        # See https://github.com/pytorch/pytorch/issues/36956
+        shape = (2, 8, 1, 2)
+        i = torch.randint(1, shape, device='cuda').contiguous(memory_format=torch.channels_last)
+        x = torch.randn(shape, requires_grad=True, device='cuda')
+        x[i].sum().backward()
+
     # test for backward in https://github.com/pytorch/pytorch/issues/15511
     def test_pdist_large(self, device):
         def func(x):


### PR DESCRIPTION
This is attempt to make the current master behavior the same as on 1.4.  I don't know if this is more performant than just making the linearIndex contiguous.

Fixes: https://github.com/pytorch/pytorch/issues/36956

ghstack-source-id: f5ac46a6e77dce2e82396079d2ec426953ac5966
Pull Request resolved: https://github.com/pytorch/pytorch/pull/36957

