### PR TITLE
[TensorExpr] Fix bug in For elimination in the IRSimplifier.

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -143,6 +143,7 @@ namespace jit {
   _(SimplifyOneLoopFor)                     \
   _(SimplifyForWontLoseLoopOptions)         \
   _(SimplifyMultilevelFor)                  \
+  _(SimplifyForCleansUp)                    \
   _(StmtClone)                              \
   _(BoundsInference_1)                      \
   _(BoundsInference_2)                      \

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1052,10 +1052,7 @@ Stmt* PolynomialTransformer::mutate(const For* v) {
   const Var* var_new = dynamic_cast<const Var*>(var_new_expr);
   const Expr* start_new = start->accept_mutator(this);
   const Expr* stop_new = stop->accept_mutator(this);
-  Stmt* body_new = body->accept_mutator(this);
-  if (!body_new) {
-    return new Block({});
-  }
+  Stmt* body_new = body;
 
   const Expr* loops = new Sub(stop_new, start_new);
   loops = loops->accept_mutator(this);
@@ -1063,8 +1060,15 @@ Stmt* PolynomialTransformer::mutate(const For* v) {
     if (immediateEquals(loops, 0)) {
       return new Block({});
     } else if (immediateEquals(loops, 1)) {
-      return Substitute(body_new, {{var_new, start_new}});
+      body_new = Substitute(body, {{var_new, start_new}});
+      body_new = body_new->accept_mutator(this);
+      return body_new;
     }
+  }
+
+  body_new = body_new->accept_mutator(this);
+  if (!body_new) {
+    return new Block({});
   }
 
   if (var == var_new && start == start_new && stop == stop_new &&


### PR DESCRIPTION
When doing elimination of For loops which execute once, e.g. `for i = 0; i < 1; ++i { thing; } => thing;` we do var substitution while the temporary simplifier ExprNodes still exist, which could put them in an invalid state and leave unsimplified terms in the expression. The fix is to apply substitution before simplifying the body of the for loop.