### PR TITLE
[TEST] add ops for portal TTS model

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -397,13 +397,39 @@ RegisterOperators reg(
          listMulIntLeftInPlace,
          aliasAnalysisFromSchema()),
      Operator("aten::len.t(t[] a) -> int", listLen, aliasAnalysisFromSchema()),
+     Operator(
+        "prim::Uninitialized() -> Any",
+        [](Stack& stack) {
+          push(stack, IValue::uninitialized());
+          return 0;
+        },
+        aliasAnalysisSpecialCase()),
+     Operator(
+        "prim::Print(...) -> ()",
+        [](Stack& stack) {
+          auto num_inputs = pop(stack).toInt();
+          std::stringstream ss;
+          bool first = true;
+          for (const IValue& i : last(stack, num_inputs)) {
+            if (!first)
+              ss << " ";
+            first = false;
+            ss << i;
+          }
+          drop(stack, num_inputs);
+          ss << std::endl;
+          auto* handler = getPrintHandler();
+          TORCH_INTERNAL_ASSERT(handler);
+          handler(ss.str());
+          return 0;
+        },
+        aliasAnalysisSpecialCase()),
      DEFINE_COMPARISON_OP(aten::eq, a == b),
      DEFINE_COMPARISON_OP(aten::ne, a != b),
      DEFINE_COMPARISON_OP(aten::lt, a < b),
      DEFINE_COMPARISON_OP(aten::gt, a > b),
      DEFINE_COMPARISON_OP(aten::le, a <= b),
      DEFINE_COMPARISON_OP(aten::ge, a >= b),
-
      DEFINE_BINARY_OP(aten::add, a + b),
      DEFINE_BINARY_OP(aten::sub, a - b),
      DEFINE_BINARY_OP(aten::mul, a* b),

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -169,26 +169,6 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      Operator(
-         "prim::Print(...) -> ()",
-         [](Stack& stack) {
-           auto num_inputs = pop(stack).toInt();
-           std::stringstream ss;
-           bool first = true;
-           for (const IValue& i : last(stack, num_inputs)) {
-             if (!first)
-               ss << " ";
-             first = false;
-             ss << i;
-           }
-           drop(stack, num_inputs);
-           ss << std::endl;
-           auto* handler = getPrintHandler();
-           TORCH_INTERNAL_ASSERT(handler);
-           handler(ss.str());
-           return 0;
-         },
-         aliasAnalysisSpecialCase()),
-     Operator(
          "prim::IgnoredPythonOp(...) -> None",
          [](Stack& stack) {
            throw JITException(
@@ -743,13 +723,6 @@ RegisterOperators reg(
          [](Stack& stack) {
            TORCH_CHECK(
                false, "wait is implemented directly in the interpreter");
-           return 0;
-         },
-         aliasAnalysisSpecialCase()),
-     Operator(
-         "prim::Uninitialized() -> Any",
-         [](Stack& stack) {
-           push(stack, IValue::uninitialized());
            return 0;
          },
          aliasAnalysisSpecialCase())});


### PR DESCRIPTION
Summary: Add lite interpreter ops for portal TTS model.

Test Plan:
Convert to lite interpreter model:
buck run //xplat/caffe2/fb/pytorch_predictor:converter <FULL_JIT_MODEL> <LITE_MODEL>

Load model using benchmark program (on devserver)
buck run //xplat/caffe2/fb/lite_predictor:lite_predictor_tts -- --model <MODEL>

(Expect benchmark to fail because inputs are invalid)

Reviewed By: iseeyuan

Differential Revision: D20961463

