### PR TITLE
[rpc] Avoid wireDeserializer overreading buffers by 1 byte

### DIFF
--- a/test/cpp/rpc/test_wire_serialization.cpp
+++ b/test/cpp/rpc/test_wire_serialization.cpp
@@ -68,6 +68,13 @@ TEST(WireSerialize, CloneSparseTensors) {
   EXPECT_TRUE(v3.get(0).is_same(sparse));
 }
 
+TEST(WireSerialize, Errors) {
+  EXPECT_THROW((void)torch::distributed::rpc::wireDeserialize("", 0), std::runtime_error);
+  EXPECT_THROW((void)torch::distributed::rpc::wireDeserialize(" ", 1), std::runtime_error);
+  auto serialized = torch::distributed::rpc::wireSerialize({}, {torch::randn({5, 5})});
+  EXPECT_THROW((void)torch::distributed::rpc::wireDeserialize(serialized.data(), serialized.size() / 2), std::runtime_error);
+}
+
 // Enable this once JIT Pickler supports sparse tensors.
 TEST(WireSerialize, DISABLED_Sparse) {
   at::Tensor main =

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -173,7 +173,7 @@ parseWireSections(const void* data, size_t data_size) {
     }
     // Parse name
     const char* namePtr = ptr;
-    while (*ptr != ' ' && ptr != endp) {
+    while (ptr != endp && *ptr != ' ') {
       ptr++;
     }
     if (ptr == endp) {
@@ -185,7 +185,7 @@ parseWireSections(const void* data, size_t data_size) {
     }
     // Parse size
     const char* sizePtr = ptr;
-    while (*ptr != '\n' && ptr != endp) {
+    while (ptr != endp && *ptr != '\n') {
       ptr++;
     }
     if (ptr == endp) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36976 [rpc] Avoid wireDeserializer overreading buffers by 1 byte**

The bounds check and the read were swapped in two places - I noticed
ASAN complaining in an unrelated change on an erroneous buffer.

Adding a couple simple test cases.

Differential Revision: [D21148936](https://our.internmc.facebook.com/intern/diff/D21148936/)