### PR TITLE
[autograd] Demote the dist container shard line to VLOG(1)

### DIFF
--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -68,7 +68,7 @@ uint32_t DistAutogradContainer::computeNumShards() {
       num_shards <<= 1;
     }
   }
-  LOG(INFO) << "Number of shards for DistAutogradContainer: " << num_shards;
+  VLOG(1) << "Number of shards for DistAutogradContainer: " << num_shards;
   return num_shards;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36978 [autograd] Demote the dist container shard line to VLOG(1)**

We're seeing quite a bit of these running unittests, might be a
bit verbose at LOG(INFO)

Differential Revision: [D21149262](https://our.internmc.facebook.com/intern/diff/D21149262/)