### PR TITLE
hardswish: remove unnecessary quantize call

### DIFF
--- a/benchmarks/operator_benchmark/pt/qactivation_test.py
+++ b/benchmarks/operator_benchmark/pt/qactivation_test.py
@@ -66,12 +66,12 @@ class QActivationBenchmarkBase(op_bench.TorchBenchmarkBase):
     def _setup(self, dims, contig, dtype):
         # Input
         f_input = (torch.rand(*dims) - 0.5) * 256
-        scale = 1.0
-        zero_point = 0
+        self.scale = 1.0
+        self.zero_point = 0
 
         # Quantize the tensor
-        self.q_input = torch.quantize_per_tensor(f_input, scale=scale,
-                                                 zero_point=zero_point,
+        self.q_input = torch.quantize_per_tensor(f_input, scale=self.scale,
+                                                 zero_point=self.zero_point,
                                                  dtype=dtype)
         if not contig:
             # Make non-contiguous
@@ -83,6 +83,8 @@ class QActivationBenchmarkBase(op_bench.TorchBenchmarkBase):
         self.qop = op_func
 
     def forward(self):
+        if self.qop == nnq.functional.hardswish:
+            return self.qop(self.q_input, scale=self.scale, zero_point=self.zero_point)
         return self.qop(self.q_input)
 
 

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -393,8 +393,8 @@ def hardswish(input, scale, zero_point):
     """
     if not input.is_quantized:
         raise ValueError("Input to 'quantized.hardswish' must be quantized!")
-    output = torch.quantize_per_tensor(torch.zeros(input.shape),
-                                       scale, int(zero_point), input.dtype)
+    output = torch._empty_affine_quantized(
+        input.shape, scale=scale, zero_point=int(zero_point), dtype=input.dtype)
     torch._C._nn.hardswish(input, out=output)
     return output
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36981 quantized activations: clean up more unneeded quantizations
* **#36980 hardswish: remove unnecessary quantize call**

Summary:

Missed this on the original diff, fixing.  Create the output tensor directly instead of quantizing it.

Test Plan:

tests still pass
microbenchmarks show a 2x performance improvment for int8:
https://gist.github.com/vkuzo/3b321b428e4c38e805000961c263286b (this
will depend on input size)

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21185970](https://our.internmc.facebook.com/intern/diff/D21185970)