### PR TITLE
quantized activations: clean up more unneeded quantizations

### DIFF
--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -343,8 +343,8 @@ def leaky_relu(input, negative_slope=0.01, inplace=False,
     """
     if scale is not None and zero_point is not None:
         assert not inplace, "Cannot rescale with `inplace`"
-        output = torch.quantize_per_tensor(torch.zeros(input.shape),
-                                           scale, int(zero_point), input.dtype)
+        output = torch._empty_affine_quantized(
+            input.shape, scale=scale, zero_point=int(zero_point), dtype=input.dtype)
         torch._C._nn.leaky_relu(input, negative_slope, out=output)
         return output
     if inplace:
@@ -419,8 +419,8 @@ def elu(input, alpha=1., inplace=False, scale=None, zero_point=None):
 
     if scale is not None and zero_point is not None:
         assert not inplace, "Cannot rescale with `inplace`"
-        output = torch.quantize_per_tensor(torch.zeros(input.shape),
-                                           scale, int(zero_point), input.dtype)
+        output = torch._empty_affine_quantized(
+            input.shape, scale=scale, zero_point=int(zero_point), dtype=input.dtype)
         torch._C._nn.elu(input, alpha, out=output)
         return output
     elif inplace:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#36981 quantized activations: clean up more unneeded quantizations**
* #36980 hardswish: remove unnecessary quantize call

Summary:

Replaces unneeded quantize calls for remaining quantized
activations with empty tensor creation.
Should be a perf win for anyone who uses these.

Test Plan:

python test/quantization/test_quantized.py TestQuantizedOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21185969](https://our.internmc.facebook.com/intern/diff/D21185969)