### PR TITLE
[pytorch] add test for empty tensor support in nn.Linear

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9105,6 +9105,11 @@ class TestNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_module_empty_input(mod, inp, check_size=False)
 
+    def test_linear_empty(self, device):
+        mod = torch.nn.Linear(7, 7).to(device)
+        inp = torch.randn(0, 7, device=device)
+        self._test_module_empty_input(mod, inp)
+
     def test_one_hot(self, device):
         with self.assertRaises(RuntimeError):
             torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)


### PR DESCRIPTION
Summary:
fix https://github.com/pytorch/pytorch/issues/34202

it seems to be fixed now but without a test

Test Plan: sandcastle

Differential Revision: D21149623

