### PR TITLE
[pytorch] Route default warning sync to LOG(WARNING) - second try

### DIFF
--- a/c10/test/util/exception_test.cpp
+++ b/c10/test/util/exception_test.cpp
@@ -18,3 +18,7 @@ TEST(ExceptionTest, TORCH_INTERNAL_ASSERT_DEBUG_ONLY) {
   ASSERT_NO_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(true));
 #endif
 }
+
+TEST(WarningTest, JustPrintWarning) {
+  TORCH_WARN("I'm a warning");
+}

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -111,7 +111,8 @@ WarningHandler* get_warning_handler() noexcept(true) {
 void WarningHandler::process(
     const SourceLocation& source_location,
     const std::string& msg) {
-  std::cerr << "Warning: " << msg << " (" << source_location << ")\n";
+  LOG_AT_FILE_LINE(WARNING, source_location.file, source_location.line)
+      << "Warning: " << msg << " (function " << source_location.function << ")";
 }
 
 

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -147,7 +147,7 @@ using fLI::FLAGS_v;
 
 C10_DEFINE_int(
     caffe2_log_level,
-    google::GLOG_ERROR,
+    google::GLOG_WARNING,
     "The minimum log level that caffe2 will output.");
 
 // Google glog's api does not have an external function that allows one to check
@@ -184,7 +184,7 @@ void UpdateLoggingLevelsFromFlags() {
   // we will transfer the caffe2_log_level setting to glog to override that.
   FLAGS_minloglevel = std::min(FLAGS_caffe2_log_level, FLAGS_minloglevel);
   // If caffe2_log_level is explicitly set, let's also turn on logtostderr.
-  if (FLAGS_caffe2_log_level < google::GLOG_ERROR) {
+  if (FLAGS_caffe2_log_level < google::GLOG_WARNING) {
     FLAGS_logtostderr = 1;
   }
   // Also, transfer the caffe2_log_level verbose setting to glog.
@@ -207,7 +207,7 @@ void ShowLogInfoToStderr() {
 
 C10_DEFINE_int(
     caffe2_log_level,
-    ERROR,
+    WARNING,
     "The minimum log level that caffe2 will output.");
 
 namespace c10 {

--- a/c10/util/logging_is_google_glog.h
+++ b/c10/util/logging_is_google_glog.h
@@ -49,4 +49,13 @@ INSTANTIATE_FOR_CONTAINER(set)
 
 #include <glog/logging.h>
 
+// Additional macros on top of glog
+
+// Log with source location information override (to be used in generic
+// warning/error handlers implemented as functions, not macros)
+//
+// Note, we don't respect GOOGLE_STRIP_LOG here for simplicity
+#define LOG_AT_FILE_LINE(n, file, line) \
+  ::google::LogMessage(file, line, ::google::GLOG_##n).stream()
+
 #endif // C10_UTIL_LOGGING_IS_GOOGLE_GLOG_H_

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -105,6 +105,12 @@ static_assert(
 
 #define VLOG_IS_ON(verboselevel) (CAFFE2_LOG_THRESHOLD <= -(verboselevel))
 
+// Log with source location information override (to be used in generic
+// warning/error handlers implemented as functions, not macros)
+#define LOG_AT_FILE_LINE(n, file, line) \
+  if (n >= CAFFE2_LOG_THRESHOLD)        \
+  ::c10::MessageLogger(file, line, n).stream()
+
 // Log only if condition is met.  Otherwise evaluates to void.
 #define FATAL_IF(condition)            \
   condition ? (void)0                  \

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -22,26 +22,27 @@ void torch_warn() {
 
 TEST(UtilsTest, WarnOnce) {
   {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+    WarningCapture warnings;
 
     torch_warn_once_A();
     torch_warn_once_A();
     torch_warn_once_B();
     torch_warn_once_B();
 
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "warn once"), 1);
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "warn something else once"), 1);
+    ASSERT_EQ(count_substr_occurrences(warnings.str(), "warn once"), 1);
+    ASSERT_EQ(
+        count_substr_occurrences(warnings.str(), "warn something else once"),
+        1);
   }
   {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+    WarningCapture warnings;
 
     torch_warn();
     torch_warn();
     torch_warn();
 
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "warn multiple times"), 3);
+    ASSERT_EQ(
+        count_substr_occurrences(warnings.str(), "warn multiple times"), 3);
   }
 }
 

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -148,8 +148,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
     ASSERT_EQ(model.parameters().size(), 0);
   }
   {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+    WarningCapture warnings;
 
     TestModel model;
     model.register_parameter("undefined_tensor", torch::Tensor());
@@ -157,7 +156,7 @@ TEST_F(ModuleTest, RegisterParameterUndefinedTensor) {
 
     ASSERT_EQ(
       count_substr_occurrences(
-        buffer.str(),
+        warnings.str(),
         "Ignoring the `requires_grad=true` function parameter"
       ),
     1);

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -174,18 +174,15 @@ TEST(OptimTest, OptimizerAccessors) {
   optimizer_.state();
 }
 
-#define OLD_INTERFACE_WARNING_CHECK(func) \
-{ \
-  std::stringstream buffer;\
-  torch::test::CerrRedirect cerr_redirect(buffer.rdbuf());\
-  func;\
-  ASSERT_EQ(\
-    torch::test::count_substr_occurrences(\
-      buffer.str(),\
-      "will be removed"\
-    ),\
-  1);\
-}
+#define OLD_INTERFACE_WARNING_CHECK(func)       \
+  {                                             \
+    torch::test::WarningCapture warnings;       \
+    func;                                       \
+    ASSERT_EQ(                                  \
+        torch::test::count_substr_occurrences(  \
+            warnings.str(), "will be removed"), \
+        1);                                     \
+  }
 
 struct MyOptimizerOptions : public OptimizerCloneableOptions<MyOptimizerOptions> {
   MyOptimizerOptions(double lr = 1.0) : lr_(lr) {};

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -193,17 +193,12 @@ void write_step_buffers(
 }
 
 #define OLD_SERIALIZATION_LOGIC_WARNING_CHECK(funcname, optimizer, filename) \
-{ \
-  std::stringstream buffer;\
-  CerrRedirect cerr_redirect(buffer.rdbuf());\
-  funcname(optimizer, filename);\
-  ASSERT_EQ(\
-    count_substr_occurrences(\
-      buffer.str(),\
-      "old serialization"\
-    ),\
-  1);\
-}
+  {                                                                          \
+    WarningCapture warnings;                                                 \
+    funcname(optimizer, filename);                                           \
+    ASSERT_EQ(                                                               \
+        count_substr_occurrences(warnings.str(), "old serialization"), 1);   \
+  }
 
 TEST(SerializeTest, KeysFunc) {
   auto tempfile = c10::make_tempfile();

--- a/test/cpp/api/support.h
+++ b/test/cpp/api/support.h
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <c10/util/Exception.h>
 #include <ATen/TensorIndexing.h>
 #include <torch/nn/cloneable.h>
 #include <torch/types.h>
@@ -35,15 +36,31 @@ struct SeedingFixture : public ::testing::Test {
   }
 };
 
-struct CerrRedirect {
-  CerrRedirect(std::streambuf * new_buffer) : prev_buffer(std::cerr.rdbuf(new_buffer)) {}
-
-  ~CerrRedirect( ) {
-    std::cerr.rdbuf(prev_buffer);
+struct WarningCapture : public WarningHandler {
+  WarningCapture() : prev_(Warning::get_warning_handler()) {
+    Warning::set_warning_handler(this);
   }
 
-private:
-  std::streambuf * prev_buffer;
+  ~WarningCapture() {
+    Warning::set_warning_handler(prev_);
+  }
+
+  const std::vector<std::string>& messages() {
+    return messages_;
+  }
+
+  std::string str() {
+    return c10::Join("\n", messages_);
+  }
+
+  void process(const SourceLocation& source_location, const std::string& msg)
+      override {
+    messages_.push_back(msg);
+  }
+
+ private:
+  WarningHandler* prev_;
+  std::vector<std::string> messages_;
 };
 
 inline bool pointer_equal(at::Tensor first, at::Tensor second) {

--- a/test/cpp/api/tensor_indexing.cpp
+++ b/test/cpp/api/tensor_indexing.cpp
@@ -159,14 +159,13 @@ TEST(TensorIndexingTest, TestBoolIndices) {
     auto uint8Indices = torch::tensor({1, 0, 0}, torch::kUInt8);
 
     {
-      std::stringstream buffer;
-      CerrRedirect cerr_redirect(buffer.rdbuf());
+      WarningCapture warnings;
 
       ASSERT_EQ(v.index({boolIndices}).sizes(), v.index({uint8Indices}).sizes());
       assert_tensor_equal(v.index({boolIndices}), v.index({uint8Indices}));
       assert_tensor_equal(v.index({boolIndices}), torch::tensor({true}, torch::kBool));
 
-      ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
+      ASSERT_EQ(count_substr_occurrences(warnings.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
     }
   }
 }
@@ -192,13 +191,12 @@ TEST(TensorIndexingTest, TestByteMask) {
     auto v = torch::randn({5, 7, 3});
     auto mask = torch::tensor({1, 0, 1, 1, 0}, torch::kByte);
     {
-      std::stringstream buffer;
-      CerrRedirect cerr_redirect(buffer.rdbuf());
+      WarningCapture warnings;
 
       ASSERT_EQ(v.index({mask}).sizes(), torch::IntArrayRef({3, 7, 3}));
       assert_tensor_equal(v.index({mask}), torch::stack({v[0], v[2], v[3]}));
 
-      ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
+      ASSERT_EQ(count_substr_occurrences(warnings.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
     }
   }
   {
@@ -211,13 +209,12 @@ TEST(TensorIndexingTest, TestByteMaskAccumulate) {
   auto mask = torch::zeros({10}, torch::kUInt8);
   auto y = torch::ones({10, 10});
   {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+    WarningCapture warnings;
 
     y.index_put_({mask}, y.index({mask}), /*accumulate=*/true);
     assert_tensor_equal(y, torch::ones({10, 10}));
 
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
+    ASSERT_EQ(count_substr_occurrences(warnings.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
   }
 }
 
@@ -227,12 +224,11 @@ TEST(TensorIndexingTest, TestMultipleByteMask) {
   auto mask1 = torch::tensor({1, 0, 1, 1, 0}, torch::kByte);
   auto mask2 = torch::tensor({1, 1, 1}, torch::kByte);
   {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+    WarningCapture warnings;
 
     ASSERT_EQ(v.index({mask1, Slice(), mask2}).sizes(), torch::IntArrayRef({3, 7}));
 
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
+    ASSERT_EQ(count_substr_occurrences(warnings.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
   }
 }
 
@@ -539,12 +535,11 @@ TEST(TensorIndexingTest, TestByteTensorAssignment) {
   auto value = torch::tensor({3., 4., 5., 6.});
 
   {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+    WarningCapture warnings;
 
     x.index_put_({b}, value);
 
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 1);
+    ASSERT_EQ(count_substr_occurrences(warnings.str(), "indexing with dtype torch.uint8 is now deprecated"), 1);
   }
 
   assert_tensor_equal(x.index({0}), value);
@@ -705,14 +700,13 @@ TEST(NumpyTests, TestBooleanShapeMismatch) {
   ASSERT_THROWS_WITH(arr.index({index}), "mask");
 
   {
-    std::stringstream buffer;
-    CerrRedirect cerr_redirect(buffer.rdbuf());
+    WarningCapture warnings;
 
     index = torch::empty({4, 4}, torch::kByte).zero_();
     ASSERT_THROWS_WITH(arr.index({index}), "mask");
     ASSERT_THROWS_WITH(arr.index({Slice(), index}), "mask");
 
-    ASSERT_EQ(count_substr_occurrences(buffer.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
+    ASSERT_EQ(count_substr_occurrences(warnings.str(), "indexing with dtype torch.uint8 is now deprecated"), 2);
   }
 }
 


### PR DESCRIPTION
Summary:
Follow LOG(WARNING) format for c++ side warnings in order to play well with larger services, especially when using glog. I need to hook up into GLOG internals a bit in order to override FILE/LINE without having to change the whole thing to be macros, but it seems to be stable between glog versions.

Note, this also changes caffe2_log_level to warning by default - I think it's a much better default when compiling without glog (or maybe even have info).

With glog output, stderr capture doesn't work any more in tests. That's why we instead use c10-level warnings capture.

Test Plan:
Run unittest in both glog and non-glog build mode:

glog:
```
W0416 12:06:49.778215 3311666 exception_test.cpp:23] Warning: I'm a warning (function TestBody)
```

no-glog:
```
[W exception_test.cpp:23] Warning: I'm a warning (function TestBody)
```

Differential Revision: D21151351

