### PR TITLE
fix spatialbatchnorm on nnpi

### DIFF
--- a/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.h
@@ -26,7 +26,6 @@ class SpatialBNFakeLoweredFp16Op : public Operator<CPUContext> {
       : Operator<CPUContext>(std::forward<Args>(args)...),
         OP_SINGLE_ARG(bool, OpSchema::Arg_IsTest, is_test_, false),
         OP_SINGLE_ARG(double, "epsilon", epsilon_, 1e-5),
-        OP_SINGLE_ARG(float, "momentum", momentum_, 0.9f),
         order_(StringToStorageOrder(
             this->template GetSingleArgument<std::string>("order", "NCHW"))),
         OP_SINGLE_ARG(int, "num_batches", num_batches_, 1) {
@@ -35,8 +34,6 @@ class SpatialBNFakeLoweredFp16Op : public Operator<CPUContext> {
     CAFFE_ENFORCE(
         (is_test_ && OutputSize() == 1) || (!is_test_ && OutputSize() == 5));
     CAFFE_ENFORCE_GT(epsilon_, 0);
-    CAFFE_ENFORCE_GE(momentum_, 0);
-    CAFFE_ENFORCE_LE(momentum_, 1);
   }
 
   virtual ~SpatialBNFakeLoweredFp16Op() override = default;
@@ -182,7 +179,6 @@ class SpatialBNFakeLoweredFp16Op : public Operator<CPUContext> {
 
   const bool is_test_;
   double epsilon_;
-  const float momentum_;
   const StorageOrder order_;
   const int num_batches_;
 
@@ -208,18 +204,15 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
   explicit SpatialBNFakeFp16Op(Args&&... args)
       : Operator<CPUContext>(std::forward<Args>(args)...),
         OP_SINGLE_ARG(bool, OpSchema::Arg_IsTest, is_test_, false),
-        OP_SINGLE_ARG(double, "epsilon", epsilon_, 1e-5),
-        OP_SINGLE_ARG(float, "momentum", momentum_, 0.9f),
+        OP_SINGLE_ARG(float, "epsilon", epsilon_, 1e-5),
         order_(StringToStorageOrder(
             this->template GetSingleArgument<std::string>("order", "NCHW"))),
         OP_SINGLE_ARG(int, "num_batches", num_batches_, 1) {
     // TODO: only support NCHW for now
     CAFFE_ENFORCE_EQ(order_, StorageOrder::NCHW);
-    CAFFE_ENFORCE(
-        (is_test_ && OutputSize() == 1) || (!is_test_ && OutputSize() == 5));
+    // We only support this case at the moment
+    CAFFE_ENFORCE(is_test_);
     CAFFE_ENFORCE_GT(epsilon_, 0);
-    CAFFE_ENFORCE_GE(momentum_, 0);
-    CAFFE_ENFORCE_LE(momentum_, 1);
   }
 
   virtual ~SpatialBNFakeFp16Op() override = default;
@@ -257,9 +250,6 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
     T* alpha_data = alpha_.template mutable_data<T>();
     T* beta_data = beta_.template mutable_data<T>();
 
-    // We only support this case at the moment
-    CAFFE_ENFORCE(is_test_);
-
     std::vector<float> X_fp16(X.numel());
 
     fbgemm::RoundToFloat16(
@@ -296,6 +286,7 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
         C,
         FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
+    // This part is run on the CPU/x86 core
     ComputeFusedParam<T>(
         C,
         scale_fp16.data(),
@@ -304,12 +295,6 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
         var_fp16.data(),
         alpha_data,
         beta_data);
-
-    fbgemm::RoundToFloat16(
-        alpha_data, alpha_data, C, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-    fbgemm::RoundToFloat16(
-        beta_data, beta_data, C, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-
     AffineChannel_NCHW(N, C, HxW, X_fp16.data(), alpha_data, beta_data, Y_data);
 
     fbgemm::RoundToFloat16(
@@ -328,13 +313,32 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
       const T* var,
       T* alpha,
       T* beta) {
+    // alpha = scale / sqrt(var + epsilon)
+    // beta = bias - alpha * mean
     EigenVectorArrayMap<T> alpha_arr(alpha, C);
     EigenVectorArrayMap<T> beta_arr(beta, C);
-    alpha_arr = ConstEigenVectorArrayMap<T>(scale, C) *
-        (ConstEigenVectorArrayMap<T>(var, C) + static_cast<T>(epsilon_))
-            .rsqrt();
+
+    std::vector<T> tmp(C, 0.0);
+    EigenVectorArrayMap<T> tmp_arr(tmp.data(), C);
+    tmp_arr = ConstEigenVectorArrayMap<T>(var, C) + static_cast<T>(epsilon_);
+
+    // sqrt using intrinsics
+    int i = 0;
+    constexpr int blockSize = 8;
+    for (i = 0; i + blockSize <= C; i += blockSize) {
+      __m256 t = _mm256_loadu_ps(&tmp[i]);
+      _mm256_storeu_ps(&tmp[i], _mm256_sqrt_ps(t));
+    }
+    for (; i < C; i++) {
+      tmp[i] = sqrt(tmp[i]);
+    }
+
+    alpha_arr = ConstEigenVectorArrayMap<T>(scale, C) / tmp_arr;
     beta_arr = ConstEigenVectorArrayMap<T>(bias, C) -
         alpha_arr * ConstEigenVectorArrayMap<T>(mean, C);
+    fbgemm::RoundToFloat16(
+        alpha, alpha, C, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+    fbgemm::RoundToFloat16(beta, beta, C, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
   }
 
   void AffineChannel_NCHW(
@@ -370,8 +374,7 @@ class SpatialBNFakeFp16Op : public Operator<CPUContext> {
   }
 
   const bool is_test_;
-  double epsilon_;
-  const float momentum_;
+  float epsilon_;
   const StorageOrder order_;
   const int num_batches_;
 

--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -43,12 +43,13 @@ def reference_spatialbn_test16(X, scale, bias, mean, var, epsilon, order):
 # Test the lowered BN op
 class BatchnormTest(unittest.TestCase):
     # TODO: using hypothesis seed, sweep dimensions
-    @given(seed=st.integers(0, 65535))
-    def test_bn(self, seed):
+    @given(seed=st.integers(0, 65535),
+           size=st.integers(2, 30),
+           input_channels=st.integers(2, 40),
+           batch_size=st.integers(2, 20))
+    @settings(max_examples=100)
+    def test_bn(self, seed, size, input_channels, batch_size):
         workspace.ResetWorkspace()
-        size = 30
-        input_channels = 20
-        batch_size = 40
         np.random.seed(seed)
 
         order = "NCHW"
@@ -134,13 +135,14 @@ class BatchnormTest(unittest.TestCase):
             diff = np.abs(Y_glow - Y_c2).astype(np.float16)
             print_test_debug_info(
                 "bn",
-                {"seed": seed,
-                "scale": scale,
-                "bias": bias,
-                "mean": mean,
-                "var": var,
-                "Y_np": Y_c2.shape,
-                "Y_glow": Y_glow.shape,
-                "diff": diff,
-                "rowwise_diff": np.max(np.abs(diff), -1)})
+                {
+                    "seed": seed,
+                    "scale": scale,
+                    "bias": bias,
+                    "mean": mean,
+                    "var": var,
+                    "Y_np": Y_c2,
+                    "Y_glow": Y_glow,
+                    "diff": diff,
+                    "rowwise_diff": np.max(np.abs(diff), -1)})
             assert(0)


### PR DESCRIPTION
Summary:
the discrepancy comes from using eigen's sqrt.
Replaced it with std::sqrt and worked, so using MKLs version
Removed momentum, made epsilon float, enhanced the test with hypothesis

Test Plan: testing the mkl dependencies in prod, if things work, will remove the intrinsics implementation, if no, will use intrinsics

Differential Revision: D21151661

