### PR TITLE
Remove read-only enforcement for WorkerInfo

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -657,15 +657,6 @@ def test_worker_info_init_fn(worker_id):
     dataset = worker_info.dataset
     assert isinstance(dataset, TestWorkerInfoDataset), "worker_info should have correct dataset copy"
     assert not hasattr(dataset, 'value'), "worker_info should have correct dataset copy"
-    # test that WorkerInfo attributes are read-only
-    try:
-        worker_info.id = 3999
-    except RuntimeError as e:
-        assert str(e) == "Cannot assign attributes to WorkerInfo objects"
-    try:
-        worker_info.a = 3
-    except RuntimeError as e:
-        assert str(e) == "Cannot assign attributes to WorkerInfo objects"
     dataset.value = [worker_id, os.getpid()]
 
 

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -58,16 +58,11 @@ _worker_info = None
 
 
 class WorkerInfo(object):
-    __initialized = False
-
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
-        self.__initialized = True
 
     def __setattr__(self, key, val):
-        if self.__initialized:
-            raise RuntimeError("Cannot assign attributes to {} objects".format(self.__class__.__name__))
         return super(WorkerInfo, self).__setattr__(key, val)
 
 


### PR DESCRIPTION
Summary:
The read-only property of WorkInfo was not really enforced as user can still change the internal state of the attr inside WorkerInfo. e.g. https://fburl.com/diffusion/88rpcy87

Currently it throws an exception if user wanna directly override some attr for each worker process, so the work around on user side is to override internal attr instead, which sounds like a bad practice.

We would like to have more flexibility here, so something like:
```
def worker_init_func():
  workerInfo.dataset = Dataset(...)
```

instead of
```
def worker_init_func():
  dataset = workerInfo.dataset
  dataset.dataset.value = "foo"
```

Thus removing the read-only enforcement here.

Test Plan: caffe2/test:test_dataloader (there are failures in trunk...)

Differential Revision: D21161184

