### PR TITLE
[iOS] 1.5.0 cocoapods release

### DIFF
--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '1.6.0'
+    s.version          = '1.5.0'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37036 [iOS] 1.5.0 cocoapods release**
* #37033 [DO NOT MERGE] iOS 1.5.0 binary push

