### PR TITLE
[iOS] 1.5.0 Cocoapods Release

### DIFF
--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '1.6.0'
+    s.version          = '1.5.0'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37039 [iOS] 1.5.0 Cocoapods Release**

### Summary

Cocoapods 1.5.0 release. Binary has been pushed to AWS - https://ossci-ios.s3.amazonaws.com/libtorch_ios_1.5.0.zip

@ezyang I noticed that pybind11 was added to mobile, not sure if this is desired. I assume it's used to simplify the op registration process, do we want to include this for mobile as well?

```
├── ATen
├── TH
├── THCUNN
├── c10
├── caffe2
├── clog.h
├── cpuinfo.h
├── fp16
├── fp16.h
├── nnpack.h
├── psimd.h
├── pybind11
├── qnnpack_func.h
├── torch
└── xnnpack.h
```

### Test Plan

- ` pod spec lint --verbose --allow-warnings --no-clean --use-libraries --skip-import-validation`
- TestApp

Differential Revision: [D21169113](https://our.internmc.facebook.com/intern/diff/D21169113)