### PR TITLE
Do not inline strings as constants if they contain non ASCII characters

### DIFF
--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -21,8 +21,9 @@ bool insertableTensor(const at::Tensor& ten) {
 // Check that TorchScript can handle inlining string.
 // TODO: support inlining any string (e.g. \x, \u, \U escapes).
 static bool isSupportedStringLiteral(const std::string& str) {
+  const auto maxASCII = 0x7fu;
   for (auto c : str) {
-    if (c > 0x7fu)
+    if (c > maxASCII)
       return false;
   }
   return true;

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -18,7 +18,6 @@ bool insertableTensor(const at::Tensor& ten) {
   return !ten.requires_grad();
 }
 
-
 // Check that TorchScript can handle inlining string.
 // TODO: support inlining any string (e.g. \x, \u, \U escapes).
 static bool isSupportedStringLiteral(const std::string& str) {
@@ -31,7 +30,7 @@ static bool isSupportedStringLiteral(const std::string& str) {
 
 bool insertableIValue(const IValue& ivalue) {
   if (ivalue.isString()) {
-     return isSupportedStringLiteral(ivalue.toString()->string());
+    return isSupportedStringLiteral(ivalue.toString()->string());
   }
   if (ivalue.isInt() || ivalue.isNone() || ivalue.isBool() ||
       ivalue.isDouble() || ivalue.isDevice()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37044 Freezing Module containing fork subgraphs
* **#37043 Do not inline strings as constants if they contain non ASCII characters**

Currently serialization support only basic string, as a result disable
inlining string literals containing unicode or other extensions.