### PR TITLE
[TensorExpr] Cleanup IRPrinter implementation for statements.

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -150,7 +150,7 @@ void testExprSplitWithTailNone() {
     BufHandle f("f", {24, 5});
     ExprHandle x_1 = x_outer * 4 + x_inner;
     ExprHandle x_outer_end = (ExprHandle(24) - 0) / 4;
-    For* stmt = For::make(
+    Stmt* stmt = new Block({For::make(
         x_outer,
         0,
         x_outer_end,
@@ -158,11 +158,10 @@ void testExprSplitWithTailNone() {
             x_inner,
             0,
             4,
-            For::make(y, 0, 5, Store::make(f, {x_1, y}, func(x_1, y), 1))));
+            For::make(y, 0, 5, Store::make(f, {x_1, y}, func(x_1, y), 1))))});
 
     std::ostringstream oss_ref;
     oss_ref << *stmt;
-    oss_ref << "\n"; // TODO: fix printing instead of adding \n here
     ASSERT_EQ(oss.str(), oss_ref.str());
   }
 

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -250,13 +250,6 @@ void IRPrinter::visit(const Let* v) {
   }
 }
 
-void IRPrinter::visit(const LetStmt* v) {
-  const Var* var = v->var();
-  os() << var->dtype().ToCppString() << " " << *var << " = " << *v->value()
-       << "; " << std::endl;
-  v->body()->accept(this);
-}
-
 void IRPrinter::visit(const Ramp* v) {
   os() << "Ramp(" << *v->base() << ", " << *v->stride() << ", " << v->lanes()
        << ")";
@@ -278,50 +271,6 @@ void IRPrinter::visit(const Load* v) {
   os() << "]";
 }
 
-void IRPrinter::visit(const For* v) {
-  const Var* var = v->var();
-  VarHandle vv(var);
-  emitIndent();
-  os() << "for (" << var->dtype().ToCppString() << " " << vv << " = "
-       << ExprHandle(v->start()) << "; " << vv << " < " << ExprHandle(v->stop())
-       << "; " << vv << "++) {";
-  std::string loop_options_str = v->loop_options().ToString();
-  if (!loop_options_str.empty()) {
-    os() << " // " << loop_options_str;
-  }
-  os() << std::endl;
-  if (v->body()) {
-    indent_++;
-    os() << *v->body();
-    indent_--;
-  }
-  emitIndent();
-  os() << "}";
-}
-
-void IRPrinter::visit(const Block* v) {
-  for (Stmt* s : v->stmts()) {
-    os() << *s << std::endl;
-  }
-}
-
-void IRPrinter::visit(const Store* v) {
-  // TODO: handle the mask
-  emitIndent();
-  os() << *v->base_handle() << "[";
-  size_t i = 0;
-  for (const Expr* ind : v->indices()) {
-    if (i++) {
-      os() << ", ";
-    }
-    ind->accept(this);
-  }
-  if (v->indices().empty()) {
-    os() << "0";
-  }
-  os() << "] = " << *v->value() << ";";
-}
-
 void IRPrinter::visit(const Broadcast* v) {
   os() << "Broadcast(" << *v->value() << ", " << v->lanes() << ")";
 }
@@ -340,56 +289,6 @@ void IRPrinter::visit(const BaseCallNode* v) {
     os() << *v->param(i);
   }
   os() << ")";
-}
-
-void IRPrinter::visit(const Allocate* v) {
-  emitIndent();
-  os() << "Allocate(" << *v->buffer_var() << ", " << v->dtype();
-  os() << ", {";
-  const std::vector<const Expr*>& dims = v->dims();
-  for (size_t i = 0; i < dims.size(); i++) {
-    if (i != 0) {
-      os() << ", ";
-    }
-    os() << *dims[i];
-  }
-  os() << "});";
-}
-
-void IRPrinter::visit(const Free* v) {
-  emitIndent();
-  os() << "Free(" << *v->buffer_var() << ");";
-}
-
-void IRPrinter::visit(const Cond* v) {
-  const Expr* cond = v->condition();
-  Stmt* true_stmt = v->true_stmt();
-  Stmt* false_stmt = v->false_stmt();
-  if (!true_stmt) {
-    emitIndent();
-    os() << "if (!" << *cond << ") {" << std::endl;
-    indent_++;
-    os() << *false_stmt << std::endl;
-    indent_--;
-    emitIndent();
-    os() << "}";
-  } else {
-    emitIndent();
-    os() << "if (" << *cond << ") {" << std::endl;
-    indent_++;
-    os() << *true_stmt << std::endl;
-    indent_--;
-    emitIndent();
-    os() << "}";
-    if (false_stmt) {
-      os() << " else {" << std::endl;
-      indent_++;
-      os() << *false_stmt << std::endl;
-      indent_--;
-      emitIndent();
-      os() << "}";
-    }
-  }
 }
 
 void IRPrinter::visit(const Term* v) {
@@ -452,6 +351,112 @@ void IRPrinter::visit(const ReduceOp* v) {
     first = false;
   }
   os() << "})";
+}
+
+// === Stmt visitors below ===
+// Some invariants to keep in mind when changing printer visitors for statement:
+//  1) every statement first outputs the indendation with emitIndent
+//  2) every statement ends with a new line
+//
+// Block is an exception here as we want to allow it to be printed in the same
+// line as its parent stmt. Thus, block does not outputs the indentation in the
+// beginning and does not output a new line in the end - this should be done in
+// the parent stmt.
+
+void IRPrinter::visit(const Store* v) {
+  // TODO: handle the mask
+  emitIndent();
+  os() << *v->base_handle() << "[";
+  size_t i = 0;
+  for (const Expr* ind : v->indices()) {
+    if (i++) {
+      os() << ", ";
+    }
+    ind->accept(this);
+  }
+  if (v->indices().empty()) {
+    os() << "0";
+  }
+  os() << "] = " << *v->value() << ";";
+  os() << std::endl;
+}
+
+void IRPrinter::visit(const LetStmt* v) {
+  emitIndent();
+  const Var* var = v->var();
+  os() << var->dtype().ToCppString() << " " << *var << " = " << *v->value()
+       << "; " << std::endl;
+  v->body()->accept(this);
+  os() << std::endl;
+}
+
+void IRPrinter::visit(const For* v) {
+  const Var* var = v->var();
+  VarHandle vv(var);
+  emitIndent();
+  os() << "for (" << var->dtype().ToCppString() << " " << vv << " = "
+       << ExprHandle(v->start()) << "; " << vv << " < " << ExprHandle(v->stop())
+       << "; " << vv << "++) ";
+  std::string loop_options_str = v->loop_options().ToString();
+  if (!loop_options_str.empty()) {
+    os() << " /* " << loop_options_str << " */";
+  }
+  if (v->body()) {
+    os() << *v->body();
+  } else {
+    os() << "{}";
+  }
+  os() << std::endl;
+}
+
+void IRPrinter::visit(const Block* v) {
+  os() << "{" << std::endl;
+  indent_++;
+  for (Stmt* s : v->stmts()) {
+    os() << *s;
+  }
+  indent_--;
+  emitIndent();
+  os() << "}";
+}
+
+void IRPrinter::visit(const Allocate* v) {
+  emitIndent();
+  os() << "Allocate(" << *v->buffer_var() << ", " << v->dtype();
+  os() << ", {";
+  const std::vector<const Expr*>& dims = v->dims();
+  for (size_t i = 0; i < dims.size(); i++) {
+    if (i != 0) {
+      os() << ", ";
+    }
+    os() << *dims[i];
+  }
+  os() << "});" << std::endl;
+}
+
+void IRPrinter::visit(const Free* v) {
+  emitIndent();
+  os() << "Free(" << *v->buffer_var() << ");" << std::endl;
+}
+
+void IRPrinter::visit(const Cond* v) {
+  const Expr* cond = v->condition();
+  Stmt* true_stmt = v->true_stmt();
+  Stmt* false_stmt = v->false_stmt();
+  if (!true_stmt) {
+    emitIndent();
+    os() << "if (!" << *cond << ") ";
+    os() << *false_stmt << std::endl;
+  } else {
+    emitIndent();
+    os() << "if (" << *cond << ") ";
+    os() << *true_stmt;
+    if (false_stmt) {
+      os() << " else ";
+      os() << *false_stmt;
+    }
+    os() << std::endl;
+  }
 }
 
 void IRPrinter::emitIndent() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37050 [TensorExpr] Cleanup IRPrinter implementation for statements.**

With this change curly braces are printed as a part of Block rather than
a part of the enclosing statement. It allows us, for instance, to more
easily see nested blocks: now they will be printed each in its own
curly-braced scope.

As a side effect, I had to change how we print loop options. Previously
we did it like this:
```
for (...) { // <loop options>
  <loop body (Block)>
}
```

Now, since everything in between { and } is a part of the block, we have
to do it the following way:
```
for (...) /* <loop options> */ {
  <loop body (Block)>
}
```
Note the change from '//' to '/* .. */' for the loop option comments.

Differential Revision: [D21171851](https://our.internmc.facebook.com/intern/diff/D21171851)