### PR TITLE
Use aten:: namespace to recognize non-custom ops

### DIFF
--- a/torch/csrc/jit/runtime/register_c10_ops.cpp
+++ b/torch/csrc/jit/runtime/register_c10_ops.cpp
@@ -170,13 +170,13 @@ class RegistrationListener final : public c10::OpRegistrationListener {
       return;
     }
     if (c10::string_view(op.schema().name()).starts_with("aten::")) {
-      TORCH_INTERNAL_ASSERT(!at::is_custom_op(op.schema().operator_name()));
+      TORCH_INTERNAL_ASSERT(!at::is_custom_op(op.schema().operator_name()), "Is custom op but has aten:: namespace: ", op.schema());
       // Ops from native_functions.yaml do tracing/autograd in VariableType,
       // no need to handle it here
       torch::jit::registerOperator(
           createOperatorFromC10_withTracingNotHandledHere(op));
     } else {
-      TORCH_INTERNAL_ASSERT(at::is_custom_op(op.schema().operator_name()));
+      TORCH_INTERNAL_ASSERT(at::is_custom_op(op.schema().operator_name()), "Isn't custom op but doesn't have aten:: namespace", op.schema());
       // custom ops don't do tracing/autograd in VariableType yet, we need to
       // handle tracing here.
       torch::jit::registerOperator(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37054 Use aten:: namespace to recognize non-custom ops**

If this works (i.e. the assertions don't fail and we can land this), then we have proven that the aten:: namespace
is enough to determine if an op is a custom op or not (i.e. ops in aten:: are not, all other ops are).
Assuming that's the case, then - after landing this - we can land a PR that removes the is_custom_op check and the codegen creating it.

Differential Revision: [D21172585](https://our.internmc.facebook.com/intern/diff/D21172585/)