### PR TITLE
Add a utility function for bundling large input tensors

### DIFF
--- a/test/test_bundled_inputs.py
+++ b/test/test_bundled_inputs.py
@@ -82,8 +82,7 @@ class TestBundledInputs(TestCase):
         sample_tensor = torch.randn(1 << 16)
         # We can store tensors with custom inflation functions regardless
         # of size, even if inflation is just the identity.
-        sample = torch.utils.bundled_inputs.InflatableArg(
-            value=sample_tensor, fmt="{}")
+        sample = torch.utils.bundled_inputs.bundle_large_tensor(sample_tensor)
         torch.utils.bundled_inputs.augment_model_with_bundled_inputs(
             sm, [(sample,)])
 

--- a/torch/utils/bundled_inputs.py
+++ b/torch/utils/bundled_inputs.py
@@ -153,3 +153,8 @@ def bundle_randn(*size, dtype=None):
     """Generate a tensor that will be inflated with torch.randn."""
     stub = torch.zeros(1, dtype=dtype).expand(*size)
     return InflatableArg(value=stub, fmt="torch.randn_like({})")
+
+
+def bundle_large_tensor(t):
+    """Wrap a tensor to allow bundling regardless of size."""
+    return InflatableArg(value=t, fmt="{}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37055 Add a utility function for bundling large input tensors**
* #36764 Add channels-last support to bundled_inputs

Summary:
Sometimes it's okay to bundle a large example input tensor with a model.
Add a utility function to make it easy for users to do that *on purpose*.

Test Plan:
Unit test.

Differential Revision: [D22264239](https://our.internmc.facebook.com/intern/diff/D22264239)