### PR TITLE
Correct $ANDROID_HOME string empty check

### DIFF
--- a/scripts/build_pytorch_android.sh
+++ b/scripts/build_pytorch_android.sh
@@ -20,7 +20,7 @@ echo "PYTORCH_DIR:$PYTORCH_DIR"
 echo "WORK_DIR:$WORK_DIR"
 
 echo "ANDROID_HOME:$ANDROID_HOME"
-if [ ! -z "$ANDROID_HOME" ]; then
+if [ -z "$ANDROID_HOME" ]; then
   echo "ANDROID_HOME not set; please set it to Android sdk directory"
 fi
 


### PR DESCRIPTION
Updated file to correct shell code to test whether $ANDROID_HOME env variable is empty or not.

