### PR TITLE
extend gather shape check to handle incorrectly sized outputs

### DIFF
--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -9,8 +9,8 @@ namespace {
 
 // Used for `gather`-like methods
 // Test:
-// 1. index.size(d) == self.size(d) for all d != dim
-// 2. index.size(d) == src.size(d) for all d
+// 1. index.size(d) == src.size(d) for all d != dim
+// 2. index.size(d) == self.size(d) for all d
 void gather_shape_check(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   auto self_dims = ensure_nonempty_dim(self.dim());
   auto src_dims = ensure_nonempty_dim(src.dim());
@@ -27,19 +27,19 @@ void gather_shape_check(const Tensor& self, int64_t dim, const Tensor& index, co
     auto index_size = ensure_nonempty_size(index, i);
     if (i != dim) {
       TORCH_CHECK(
-        index_size == ensure_nonempty_size(self, i),
-        "Input size does not match at dimension ", i,
-        " get ", ensure_nonempty_size(self, i),
+        index_size == ensure_nonempty_size(src, i),
+        "Output size does not match at dimension ", i,
+        " get ", ensure_nonempty_size(src, i),
         " vs ", ensure_nonempty_size(index, i)
       );
     }
-
     TORCH_CHECK(
-      index_size == ensure_nonempty_size(src, i),
-      "Output size does not match at dimension ", i,
-      " get ", ensure_nonempty_size(src, i),
+      index_size == ensure_nonempty_size(self, i),
+      "Input size does not match at dimension ", i,
+      " get ", ensure_nonempty_size(self, i),
       " vs ", ensure_nonempty_size(index, i)
     );
+
   }
 }
 

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -10,23 +10,39 @@ namespace {
 // Used for `gather`-like methods
 // Test:
 // 1. index.size(d) == self.size(d) for all d != dim
-void gather_shape_check(const Tensor& self, int64_t dim, const Tensor& index) {
+// 2. index.size(d) == src.size(d) for all d
+void gather_shape_check(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& src) {
   auto self_dims = ensure_nonempty_dim(self.dim());
+  auto src_dims = ensure_nonempty_dim(src.dim());
 
   TORCH_CHECK(self_dims == ensure_nonempty_dim(index.dim()),
     "Index tensor must have the same number of dimensions as input tensor"
   );
 
+  TORCH_CHECK(src_dims == ensure_nonempty_dim(index.dim()),
+    "Index tensor must have the same number of dimensions as output tensor"
+  );
+
   for (int64_t i = 0; i < self_dims; ++i) {
+    auto index_size = ensure_nonempty_size(index, i);
     if (i != dim) {
       TORCH_CHECK(
-        ensure_nonempty_size(index, i) == ensure_nonempty_size(self, i),
-        "Size does not match at dimension ", i,
+        index_size == ensure_nonempty_size(self, i),
+        "Input size does not match at dimension ", i,
         " get ", ensure_nonempty_size(self, i),
         " vs ", ensure_nonempty_size(index, i)
       );
     }
+
+    TORCH_CHECK(
+      index_size == ensure_nonempty_size(src, i),
+      "Output size does not match at dimension ", i,
+      " get ", ensure_nonempty_size(src, i),
+      " vs ", ensure_nonempty_size(index, i)
+    );
   }
+
+
 }
 
 // Used for `scatter`-like methods
@@ -131,7 +147,7 @@ struct cpu_scatter_gather_base_kernel {
       scatter_shape_check(self, dim, index, src);
     }
     else {
-      gather_shape_check(self, dim, index);
+      gather_shape_check(self, dim, index, src);
     }
 
     auto iter = TensorIterator();

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -41,8 +41,6 @@ void gather_shape_check(const Tensor& self, int64_t dim, const Tensor& index, co
       " vs ", ensure_nonempty_size(index, i)
     );
   }
-
-
 }
 
 // Used for `scatter`-like methods

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2553,6 +2553,9 @@ class _TestTorchMixin(object):
                     expected[i, j, k] = src[tuple(ii)]
         self.assertEqual(actual, expected, 0)
 
+        bad_src = torch.randn(*[i - 1 for i in idx_size])
+        self.assertRaises(RuntimeError, lambda: torch.gather(bad_src, dim, idx))
+
         if test_bounds:
             idx[0][0][0] = 23
             self.assertRaises(RuntimeError, lambda: torch.gather(src, dim, idx))


### PR DESCRIPTION
Fixes a safety issue (Nonsense values and segfaults) introduced by https://github.com/pytorch/pytorch/pull/36875 when in-place gather tries to use incorrect shapes.

Consider the following block of code:
```
k0 = 8
k1 = 8
m = 100

x = torch.rand((k0, k1))
ind = torch.randint(0, k0, (m, k1))
output = torch.empty((m, k1))

print(torch.gather(x, 0, ind, out=output))
print(torch.gather(x, 1, ind, out=output))
```

The first gather is legal, the second is not. (`ind` and `output` need to be transposed) Previously this was caught when the kernel tried to restride inputs for TensorIterator, but we can no longer rely on those checks and must test explicitly. If `m` is small the second gather returns gibberish; if it is large enough to push the read out of memory block the program segfaults.