### PR TITLE
Cast shape_.size() to int64_t before comparing with squash_dim

### DIFF
--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -369,7 +369,7 @@ struct CAFFE2_API TensorIterator {
   void declare_static_shape(IntArrayRef shape, const int64_t squash_dim){
     declare_static_shape(shape);
     if (!shape_.size()) return;
-    TORCH_CHECK(squash_dim >= 0 && squash_dim < shape_.size(),
+    TORCH_CHECK(squash_dim >= 0 && squash_dim < static_cast<int64_t>(shape_.size()),
                 "squash_dim ", squash_dim, " must be in [0, ", shape_.size(), ").");
     shape_[squash_dim] = 1;
   }


### PR DESCRIPTION
This is generating a considerable amount of warning messages since TensorIterator.h is included from a lot of files:

    /home/hong/xusrc/pytorch/aten/src/ATen/native/TensorIterator.h:372:47:
    warning: comparison of integers of different signs: 'const int64_t' (aka 'const long') and 'c10::SmallVectorTemplateCommon::size_type' (aka 'unsigned long') [-Wsign-compare]
        TORCH_CHECK(squash_dim >= 0 && squash_dim < shape_.size(),

