### PR TITLE
[ROCm] Don't use MIOpen for tensors with more than INT_MAX number of elements

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9442,7 +9442,6 @@ class TestNNDeviceType(NNTestCase):
                     grad_input, = torch.autograd.grad(output, input, create_graph=True)
                     grad_input.sum().backward()
 
-    @skipCUDAIfRocm
     @largeCUDATensorTest('12GB')
     def test_conv_large_nosplit(self, device):
         # Here we just test the convolution correctly route to the fallback implementation


### PR DESCRIPTION
This pull request extends the fallback implemented in #31383 to not use MIOpen for tensors where number of elements in a tensor exceeds INT_MAX. The PR also enables the corresponding test in TestNN

cc: @ezyang @jeffdaily 