### PR TITLE
properly whitelist clang-format in CI

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -27,16 +27,22 @@ jobs:
       - name: Run clang-format
         run: |
           set -eux
-          tools/git-clang-format --verbose ${{ github.event.pull_request.base.sha }}
+          # only run clang-format on whitelisted files
+          find . -type f \
+            -path './torch/csrc/jit/*' -or \
+            -path './test/cpp/jit/*' -or \
+            -path './test/cpp/tensorexpr/*' \
+            | xargs tools/git-clang-format --verbose ${{ github.event.pull_request.base.sha }} --
+
           GIT_DIFF=$(git diff)
           if [[ -z $GIT_DIFF ]]; then
             exit 0
           fi
+          echo $GIT_DIFF
           echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
           echo "| Run: "
           echo "|    tools/git-clang-format ${{ github.event.pull_request.base.sha }} "
           echo "| to fix this error. "
           echo "| For more info, see: https://github.com/pytorch/pytorch/wiki/clang-format "
           echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-          echo $GIT_DIFF
           exit 1

--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -19,4 +19,4 @@ else
 fi
 
 echo "Running pre-commit clang-format"
-tools/git-clang-format HEAD~
+tools/git-clang-format HEAD~ --force


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37122 properly whitelist clang-format in CI**

Differential Revision: [D21194505](https://our.internmc.facebook.com/intern/diff/D21194505)