### PR TITLE
To fix caffe2 model with Copy OP cannot export to onnx model

### DIFF
--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -371,7 +371,8 @@ OnnxExporter::get_renamed_operators() const {
       {"MaxPool3D", "MaxPool"},
       {"AveragePool1D", "AveragePool"},
       {"AveragePool2D", "AveragePool"},
-      {"AveragePool3D", "AveragePool"}};
+      {"AveragePool3D", "AveragePool"},
+      {"Copy", "Identity"}};
   return kRenamedOperators;
 }
 

--- a/caffe2/operators/copy_op.cc
+++ b/caffe2/operators/copy_op.cc
@@ -16,6 +16,7 @@ OPERATOR_SCHEMA(Copy)
     .NumOutputs(1)
     .IdenticalTypeAndShape()
     .InputsCanCrossDevices()
+    .InheritOnnxSchema("Identity")
     .SetDoc(R"DOC(
 Copy input tensor into output, potentially across devices.
 


### PR DESCRIPTION
To fix caffe2 model with Copy OP cannot export to onnx model