### PR TITLE
Do not run valgrind on the Aten unit tests compiled with clang

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -177,6 +177,10 @@ test_aten() {
     ${SUDO} ln -s "$TORCH_LIB_PATH"/libmkldnn* build/bin
     ${SUDO} ln -s "$TORCH_LIB_PATH"/libnccl* build/bin
 
+    if [[ "$BUILD_ENVIRONMENT" == *clang* ]]; then
+      echo "Disable valgrind testing due to https://github.com/pytorch/pytorch/issues/37117"
+      VALGRIND=OFF
+    fi
     ls build/bin
     aten/tools/run_tests.sh build/bin
     assert_git_not_dirty


### PR DESCRIPTION
Valgrind detects some unitialized variables if torch_cpu is compiled with clang, which are not reproducible if the same code is compiled with gcc nor using address sanitizer tool
See https://github.com/pytorch/pytorch/issues/37117

