### PR TITLE
Whitespace cleanup

### DIFF
--- a/aten/src/ATen/native/cuda/UpSample.cuh
+++ b/aten/src/ATen/native/cuda/UpSample.cuh
@@ -38,7 +38,7 @@ static inline void upsample_1d_shape_check(
     // Allow for empty batch size but not other dimensions
     bool valid_empty = false;
     valid_empty = input.size(0) == 0 && input.size(1) != 0 && input.size(2) != 0;
-    
+
     TORCH_CHECK(
                 (input.numel() != 0 || valid_empty) && input.dim() == 3,
                 "Non-empty 3D data tensor expected but got a tensor with sizes ",

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -215,7 +215,7 @@ auto handle_torch_function(PythonArgs &r, PyObject* args, PyObject* kwargs, PyOb
  *  precedence.
  *
  *  'obj' is an object to check for a __torch_function__ implementation
- * 
+ *
  * If changing this file in a way that can affect the __torch_function__
  * overhead, please report the benchmarks in 'benchmarks/overrides_benchmark'.
  * See the instructions in the 'README.md' in that directory.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37178 recompute_scale_factor default True (half-baked)
* #37177 Update interpolate (half-baked)
* #37176 Add interpolate-style overloads to aten::upsample* ops
* #37175 Add support for float[]? arguments in native_functions.yaml
* #37174 Add support for int[]? arguments in native_functions.yaml
* #37173 In interpolate, inline the call to _interp_output_size
* #37172 In interpolate, move exceptional cases to the bottom
* #37171 In interpolate, use if instead of elif
* #37170 In interpolate, join short lines
* #37169 In interpolate, give a short name to scale_factor_list
* #37168 In interpolate, only call _interp_output_size in one place
* #37166 Clean up formatting in upsample ops
* **#37165 Whitespace cleanup**

Differential Revision: [D21209997](https://our.internmc.facebook.com/intern/diff/D21209997/)