### PR TITLE
Clean up formatting in upsample ops

### DIFF
--- a/aten/src/ATen/native/UpSampleNearest1d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest1d.cpp
@@ -82,7 +82,10 @@ Tensor& upsample_nearest1d_out_cpu(
   return output;
 }
 
-Tensor upsample_nearest1d_cpu(const Tensor& input, IntArrayRef output_size, c10::optional<double> scales) {
+Tensor upsample_nearest1d_cpu(
+    const Tensor& input,
+    IntArrayRef output_size,
+    c10::optional<double> scales) {
   auto output = at::empty({0}, input.options());
   upsample_nearest1d_out_cpu_template(output, input, output_size, scales);
   return output;

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -93,7 +93,11 @@ Tensor& upsample_nearest2d_out_cpu(
   return output;
 }
 
-Tensor upsample_nearest2d_cpu(const Tensor& input, IntArrayRef output_size, c10::optional<double> scales_h, c10::optional<double> scales_w) {
+Tensor upsample_nearest2d_cpu(
+    const Tensor& input,
+    IntArrayRef output_size,
+    c10::optional<double> scales_h,
+    c10::optional<double> scales_w) {
   auto output = at::empty({0}, input.options());
   upsample_nearest2d_out_cpu_template(output, input, output_size, scales_h, scales_w);
   return output;

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -106,8 +106,12 @@ Tensor& upsample_nearest3d_out_cpu(
   return output;
 }
 
-Tensor upsample_nearest3d_cpu(const Tensor& input, IntArrayRef output_size,
-                              c10::optional<double> scales_d, c10::optional<double> scales_h, c10::optional<double> scales_w) {
+Tensor upsample_nearest3d_cpu(
+    const Tensor& input,
+    IntArrayRef output_size,
+    c10::optional<double> scales_d,
+    c10::optional<double> scales_h,
+    c10::optional<double> scales_w) {
   auto output = at::empty({0}, input.options());
   upsample_nearest3d_out_cpu_template(output, input, output_size, scales_d, scales_h, scales_w);
   return output;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37178 recompute_scale_factor default True (half-baked)
* #37177 Update interpolate (half-baked)
* #37176 Add interpolate-style overloads to aten::upsample* ops
* #37175 Add support for float[]? arguments in native_functions.yaml
* #37174 Add support for int[]? arguments in native_functions.yaml
* #37173 In interpolate, inline the call to _interp_output_size
* #37172 In interpolate, move exceptional cases to the bottom
* #37171 In interpolate, use if instead of elif
* #37170 In interpolate, join short lines
* #37169 In interpolate, give a short name to scale_factor_list
* #37168 In interpolate, only call _interp_output_size in one place
* **#37166 Clean up formatting in upsample ops**
* #37165 Whitespace cleanup

Differential Revision: [D21210001](https://our.internmc.facebook.com/intern/diff/D21210001/)