### PR TITLE
Remove redundant definition of fmadd functions in complex Vec256

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -448,12 +448,6 @@ Vec256<std::complex<double>> Vec256<std::complex<double>>::ne(const Vec256<std::
   return (*this != other) & Vec256<std::complex<double>>::ones;
 }
 
-#ifdef __AVX2__
-template <> inline Vec256<std::complex<double>> fmadd(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b, const Vec256<std::complex<double>>& c) {
-  return a * b + c;
-}
-#endif
-
 #endif
 
 }}}

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -490,12 +490,6 @@ Vec256<std::complex<float>> Vec256<std::complex<float>>::ne(
   return (*this != other) & Vec256<std::complex<float>>::ones;
 }
 
-#ifdef __AVX2__
-template <> inline Vec256<std::complex<float>> fmadd(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b, const Vec256<std::complex<float>>& c) {
-  return a * b + c;
-}
-#endif
-
 #endif
 
 }}}


### PR DESCRIPTION
These straightforward implementations have already been covered in
vec256_base.h. No need to specialize the template function for complex
types.

https://github.com/pytorch/pytorch/blob/7aec364bdf9ed7297b77e8445a6a6d4116265dde/aten/src/ATen/cpu/vec256/vec256_base.h#L696-L698

