### PR TITLE
In interpolate, only call _interp_output_size in one place

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2835,27 +2835,28 @@ def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=
     return interpolate(input, size, scale_factor, mode, align_corners)
 
 @_overload  # noqa: F811
-def _interp_output_size(dim, closed_over_args):  # noqa: F811
-    # type: (int, Tuple[Tensor, Optional[int], Optional[List[float]], Optional[bool]]) -> List[int]
+def _interp_output_size(closed_over_args):  # noqa: F811
+    # type: (Tuple[Tensor, Optional[int], Optional[List[float]], Optional[bool]]) -> List[int]
     pass
 
 @_overload  # noqa: F811
-def _interp_output_size(dim, closed_over_args):  # noqa: F811
-    # type: (int, Tuple[Tensor, Optional[List[int]], Optional[List[float]], Optional[bool]]) -> List[int]
+def _interp_output_size(closed_over_args):  # noqa: F811
+    # type: (Tuple[Tensor, Optional[List[int]], Optional[List[float]], Optional[bool]]) -> List[int]
     pass
 
 @_overload  # noqa: F811
-def _interp_output_size(dim, closed_over_args):  # noqa: F811
-    # type: (int, Tuple[Tensor, Optional[int], Optional[float], Optional[bool]]) -> List[int]
+def _interp_output_size(closed_over_args):  # noqa: F811
+    # type: (Tuple[Tensor, Optional[int], Optional[float], Optional[bool]]) -> List[int]
     pass
 
 @_overload  # noqa: F811
-def _interp_output_size(dim, closed_over_args):  # noqa: F811
-    # type: (int, Tuple[Tensor, Optional[List[int]], Optional[float], Optional[bool]]) -> List[int]
+def _interp_output_size(closed_over_args):  # noqa: F811
+    # type: (Tuple[Tensor, Optional[List[int]], Optional[float], Optional[bool]]) -> List[int]
     pass
 
-def _interp_output_size(dim, closed_over_args):  # noqa: F811
+def _interp_output_size(closed_over_args):  # noqa: F811
     input, size, scale_factor, recompute_scale_factor = closed_over_args
+    dim = input.dim() - 2
     if size is None and scale_factor is None:
         raise ValueError('either size or scale_factor should be defined')
     if size is not None and scale_factor is not None:
@@ -3020,25 +3021,26 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
             _scale_factor_repeated = [scale_factor for _ in range(scale_factor_len)]  # noqa: C416
         scale_factor_list = torch.jit.annotate(List[Optional[float]], [elem for elem in _scale_factor_repeated])  # noqa: C416
 
-    # TODO: rewrite _interp_output_size as inner function when TS supports closures
+    # TODO: rewrite _interp_output_size as inner function when TS supports closures, or just inline it.
     closed_over_args = (input, size, scale_factor, recompute_scale_factor)
+    output_size = _interp_output_size(closed_over_args)
     if input.dim() == 3 and mode == 'nearest':
-        return torch._C._nn.upsample_nearest1d(input, _interp_output_size(1, closed_over_args), scale_factor_list[0])
+        return torch._C._nn.upsample_nearest1d(input, output_size, scale_factor_list[0])
     elif input.dim() == 4 and mode == 'nearest':
-        return torch._C._nn.upsample_nearest2d(input, _interp_output_size(2, closed_over_args),
+        return torch._C._nn.upsample_nearest2d(input, output_size,
                                                scale_factor_list[0], scale_factor_list[1])
     elif input.dim() == 5 and mode == 'nearest':
-        return torch._C._nn.upsample_nearest3d(input, _interp_output_size(3, closed_over_args),
+        return torch._C._nn.upsample_nearest3d(input, output_size,
                                                scale_factor_list[0], scale_factor_list[1], scale_factor_list[2])
     elif input.dim() == 3 and mode == 'area':
-        return adaptive_avg_pool1d(input, _interp_output_size(1, closed_over_args))
+        return adaptive_avg_pool1d(input, output_size)
     elif input.dim() == 4 and mode == 'area':
-        return adaptive_avg_pool2d(input, _interp_output_size(2, closed_over_args))
+        return adaptive_avg_pool2d(input, output_size)
     elif input.dim() == 5 and mode == 'area':
-        return adaptive_avg_pool3d(input, _interp_output_size(3, closed_over_args))
+        return adaptive_avg_pool3d(input, output_size)
     elif input.dim() == 3 and mode == 'linear':
         assert align_corners is not None
-        return torch._C._nn.upsample_linear1d(input, _interp_output_size(1, closed_over_args), align_corners, scale_factor_list[0])
+        return torch._C._nn.upsample_linear1d(input, output_size, align_corners, scale_factor_list[0])
     elif input.dim() == 3 and mode == 'bilinear':
         raise NotImplementedError("Got 3D input, but bilinear mode needs 4D input")
     elif input.dim() == 3 and mode == 'trilinear':
@@ -3047,7 +3049,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         raise NotImplementedError("Got 4D input, but linear mode needs 3D input")
     elif input.dim() == 4 and mode == 'bilinear':
         assert align_corners is not None
-        return torch._C._nn.upsample_bilinear2d(input, _interp_output_size(2, closed_over_args), align_corners,
+        return torch._C._nn.upsample_bilinear2d(input, output_size, align_corners,
                                                 scale_factor_list[0], scale_factor_list[1])
     elif input.dim() == 4 and mode == 'trilinear':
         raise NotImplementedError("Got 4D input, but trilinear mode needs 5D input")
@@ -3057,11 +3059,11 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         raise NotImplementedError("Got 5D input, but bilinear mode needs 4D input")
     elif input.dim() == 5 and mode == 'trilinear':
         assert align_corners is not None
-        return torch._C._nn.upsample_trilinear3d(input, _interp_output_size(3, closed_over_args), align_corners,
+        return torch._C._nn.upsample_trilinear3d(input, output_size, align_corners,
                                                  scale_factor_list[0], scale_factor_list[1], scale_factor_list[2])
     elif input.dim() == 4 and mode == 'bicubic':
         assert align_corners is not None
-        return torch._C._nn.upsample_bicubic2d(input, _interp_output_size(2, closed_over_args), align_corners,
+        return torch._C._nn.upsample_bicubic2d(input, output_size, align_corners,
                                                scale_factor_list[0], scale_factor_list[1])
     else:
         raise NotImplementedError("Input Error: Only 3D, 4D and 5D input Tensors supported"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37178 recompute_scale_factor default True (half-baked)
* #37177 Update interpolate (half-baked)
* #37176 Add interpolate-style overloads to aten::upsample* ops
* #37175 Add support for float[]? arguments in native_functions.yaml
* #37174 Add support for int[]? arguments in native_functions.yaml
* #37173 In interpolate, inline the call to _interp_output_size
* #37172 In interpolate, move exceptional cases to the bottom
* #37171 In interpolate, use if instead of elif
* #37170 In interpolate, join short lines
* #37169 In interpolate, give a short name to scale_factor_list
* **#37168 In interpolate, only call _interp_output_size in one place**
* #37166 Clean up formatting in upsample ops
* #37165 Whitespace cleanup

It looks like this was made a separate function because of the `dim` argument,
but that argument is always equal to `input.dim() - 2`.  Remove the argument
and consolidate all call sites into one.  This also means that this will be
called on paths that previously didn't call it, but all those cases throw
exceptions anyway.

Differential Revision: [D21209993](https://our.internmc.facebook.com/intern/diff/D21209993/)