### PR TITLE
In interpolate, join short lines

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3030,11 +3030,9 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
     if input.dim() == 3 and mode == 'nearest':
         return torch._C._nn.upsample_nearest1d(input, output_size, sfl[0])
     elif input.dim() == 4 and mode == 'nearest':
-        return torch._C._nn.upsample_nearest2d(input, output_size,
-                                               sfl[0], sfl[1])
+        return torch._C._nn.upsample_nearest2d(input, output_size, sfl[0], sfl[1])
     elif input.dim() == 5 and mode == 'nearest':
-        return torch._C._nn.upsample_nearest3d(input, output_size,
-                                               sfl[0], sfl[1], sfl[2])
+        return torch._C._nn.upsample_nearest3d(input, output_size, sfl[0], sfl[1], sfl[2])
     elif input.dim() == 3 and mode == 'area':
         return adaptive_avg_pool1d(input, output_size)
     elif input.dim() == 4 and mode == 'area':
@@ -3052,8 +3050,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         raise NotImplementedError("Got 4D input, but linear mode needs 3D input")
     elif input.dim() == 4 and mode == 'bilinear':
         assert align_corners is not None
-        return torch._C._nn.upsample_bilinear2d(input, output_size, align_corners,
-                                                sfl[0], sfl[1])
+        return torch._C._nn.upsample_bilinear2d(input, output_size, align_corners, sfl[0], sfl[1])
     elif input.dim() == 4 and mode == 'trilinear':
         raise NotImplementedError("Got 4D input, but trilinear mode needs 5D input")
     elif input.dim() == 5 and mode == 'linear':
@@ -3062,12 +3059,10 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         raise NotImplementedError("Got 5D input, but bilinear mode needs 4D input")
     elif input.dim() == 5 and mode == 'trilinear':
         assert align_corners is not None
-        return torch._C._nn.upsample_trilinear3d(input, output_size, align_corners,
-                                                 sfl[0], sfl[1], sfl[2])
+        return torch._C._nn.upsample_trilinear3d(input, output_size, align_corners, sfl[0], sfl[1], sfl[2])
     elif input.dim() == 4 and mode == 'bicubic':
         assert align_corners is not None
-        return torch._C._nn.upsample_bicubic2d(input, output_size, align_corners,
-                                               sfl[0], sfl[1])
+        return torch._C._nn.upsample_bicubic2d(input, output_size, align_corners, sfl[0], sfl[1])
     else:
         raise NotImplementedError("Input Error: Only 3D, 4D and 5D input Tensors supported"
                                   " (got {}D) for the modes: nearest | linear | bilinear | bicubic | trilinear"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37178 recompute_scale_factor default True (half-baked)
* #37177 Update interpolate (half-baked)
* #37176 Add interpolate-style overloads to aten::upsample* ops
* #37175 Add support for float[]? arguments in native_functions.yaml
* #37174 Add support for int[]? arguments in native_functions.yaml
* #37173 In interpolate, inline the call to _interp_output_size
* #37172 In interpolate, move exceptional cases to the bottom
* #37171 In interpolate, use if instead of elif
* **#37170 In interpolate, join short lines**
* #37169 In interpolate, give a short name to scale_factor_list
* #37168 In interpolate, only call _interp_output_size in one place
* #37166 Clean up formatting in upsample ops
* #37165 Whitespace cleanup

Differential Revision: [D21209998](https://our.internmc.facebook.com/intern/diff/D21209998/)