### PR TITLE
Fix const-cast lint error in process_group_agent.cpp

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -437,6 +437,7 @@ void ProcessGroupAgent::handleSend(const SendWork& work) {
   std::vector<std::shared_ptr<c10d::ProcessGroup::Work>> pendingSends;
   const auto dst = work.to_.id_;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   auto serializedPayloadData = const_cast<char*>(serializedPayload->data());
   auto serializedPayloadSize = serializedPayload->size();
   std::string* deleteWhenDone = serializedPayload.release();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #32731 Supporting create an RPC gang of size 1
* **#37184 Fix const-cast lint error in process_group_agent.cpp**

Differential Revision: [D21213292](https://our.internmc.facebook.com/intern/diff/D21213292)