### PR TITLE
Add fallback wrapper for profiler

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2655,6 +2655,15 @@ class TestAutograd(TestCase):
         with torch.autograd.profiler.profile() as prof:
             x.resize_([3, 2])
 
+    def test_profiler_custom_op(self):
+        inst = torch.classes._TorchScriptTesting._PickleTester([3, 4])
+
+        with torch.autograd.profiler.profile() as prof:
+            torch.ops._TorchScriptTesting.take_an_instance(inst)
+
+        self.assertEqual(len(prof.function_events), 1)
+        self.assertEqual(prof.function_events[0].name, '_TorchScriptTesting::take_an_instance')
+
     def test_record_function_callbacks(self):
         x = torch.randn(10, 10)
         with profile() as p:

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -350,7 +350,11 @@ void RecordProfile::processEvents(const std::vector<Event*>& events) {
 
 void profile_wrapper(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   c10::impl::ExcludeDispatchKeyGuard key_guard(c10::DispatchKey::Profiler);
+#if !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
   RECORD_FUNCTION(op.schema().name(), *stack, torch::autograd::Node::peek_at_next_sequence_nr());
+#else
+  RECORD_FUNCTION(op.schema().name(), *stack);
+#endif
   op.callBoxed(stack);
 }
 

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/jit/runtime/operator.h>
 
 #include <ATen/core/op_registration/op_registration.h>
+#include <torch/library.h>
 
 #include <fstream>
 #include <list>
@@ -353,8 +354,6 @@ void profile_wrapper(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   op.callBoxed(stack);
 }
 
-auto registry = c10::Dispatcher::singleton()
-  .registerFallback(
-    c10::DispatchKey::Profiler,
-    c10::KernelFunction::makeFromBoxedFunction<&profile_wrapper>(),
-    "");
+TORCH_LIBRARY_IMPL(_, Profiler, m) {
+  m.fallback(torch::CppFunction::makeFromBoxedFunction<&profile_wrapper>());
+}

--- a/torch/csrc/jit/runtime/register_c10_ops.cpp
+++ b/torch/csrc/jit/runtime/register_c10_ops.cpp
@@ -18,7 +18,6 @@ namespace {
 Operator createOperatorFromC10_withTracingHandledHere(
     const c10::OperatorHandle& op) {
   return Operator(op, [op](Stack& stack) {
-    RECORD_FUNCTION(op.schema().name(), stack);
     const auto input_size = op.schema().arguments().size();
     const auto output_size = op.schema().returns().size();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37194 Add fallback wrapper for profiler**

Benchmark
```
import torch, time

NITER = 10000

inst = torch.classes._TorchScriptTesting._PickleTester([1, 3, 3, 7])

with torch.autograd.profiler.profile() as prof:
    s = time.time()
    for _ in range(NITER):
        torch.ops._TorchScriptTesting.take_an_instance(inst)
    e = time.time()

print('time per iter (ms)', (e - s) / 1000)
```

Before this change
```
time per iter (ms) 0.00014818763732910156
```

After this change
```
time per iter (ms) 0.00014342880249023436
```

Differential Revision: [D21217886](https://our.internmc.facebook.com/intern/diff/D21217886)