### PR TITLE
Enable global observers API

### DIFF
--- a/aten/src/ATen/ThreadLocalState.cpp
+++ b/aten/src/ATen/ThreadLocalState.cpp
@@ -15,7 +15,6 @@ ThreadLocalState::ThreadLocalState(bool keep_grad_mode)
     grad_mode_enabled_ = GradMode::is_enabled();
   }
 #endif
-  record_function_enabled_ = _tls_is_record_function_enabled();
 }
 
 /* static */
@@ -27,19 +26,9 @@ void ThreadLocalState::setThreadLocalState(
   }
 #endif
 
-  c10::impl::_force_tls_local_dispatch_key_set(state.dispatch_key_);
-
   ThreadLocalDebugInfo::_forceCurrentDebugInfo(state.debug_info_);
 
-  _tls_set_record_function_enabled(state.record_function_enabled_);
-}
-
-thread_local bool is_record_function_enabled_ = true;
-bool _tls_is_record_function_enabled() {
-  return is_record_function_enabled_;
-}
-void _tls_set_record_function_enabled(bool is_enabled) {
-  is_record_function_enabled_ = is_enabled;
+  c10::impl::_force_tls_local_dispatch_key_set(state.dispatch_key_);
 }
 
 } // namespace at

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -34,11 +34,6 @@ class TORCH_API ThreadLocalState {
   bool grad_mode_enabled_;
 #endif
 
-  // Whether RecordFunctions need to be disabled;
-  // used in core PyTorch to avoid infitite recursion
-  // in observers framework
-  bool record_function_enabled_;
-
   friend class ThreadLocalStateGuard;
 };
 
@@ -59,9 +54,5 @@ class TORCH_API ThreadLocalStateGuard {
  private:
   const ThreadLocalState prev_state_;
 };
-
-// Internal, turns on/off record function observers
-TORCH_API bool _tls_is_record_function_enabled();
-TORCH_API void _tls_set_record_function_enabled(bool);
 
 } // namespace at

--- a/docs/source/notes/large_scale_deployments.rst
+++ b/docs/source/notes/large_scale_deployments.rst
@@ -61,6 +61,8 @@ Here's an example:
             /* needs_inputs */ true,
             /* sampling_prob */ 0.01
         );
+        // Note, to enable observers in the model calling thread,
+        // call enableObservers() in the thread before running a model
     }
 
     bool onFunctionEnter(const RecordFunction& fn) {

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -197,7 +197,6 @@ void enableProfiler(ProfilerConfig config) {
       /* sampling_prob */ 1.0,
       /* scopes */ {RecordScope::FUNCTION, RecordScope::USER_SCOPE});
   state = new_state;
-  c10::impl::tls_set_dispatch_key_included(c10::DispatchKey::Profiler, true);
 
   if(state == ProfilerState::CUDA) {
     // event recording appears to have some startup overhead, so we need to
@@ -228,7 +227,6 @@ thread_event_lists disableProfiler() {
 
   popCallback();
   state = ProfilerState::Disabled;
-  c10::impl::tls_set_dispatch_key_included(c10::DispatchKey::Profiler, false);
 
   if (old_state == ProfilerState::NVTX) {
     return thread_event_lists();

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -200,6 +200,9 @@ void pushCallback(
     bool needs_inputs,
     double sampling_prob,
     std::unordered_set<RecordScope, std::hash<RecordScope>> scopes) {
+  if (!hasCallbacks()) {
+    enableObservers(true);
+  }
   manager().pushCallback(
       std::move(start),
       std::move(end),
@@ -210,6 +213,17 @@ void pushCallback(
 
 void popCallback() {
   manager().popCallback();
+  if (!hasCallbacks()) {
+    enableObservers(false);
+  }
+}
+
+bool observersEnabled() {
+  return c10::impl::tls_is_dispatch_key_included(c10::DispatchKey::Profiler);
+}
+
+void enableObservers(bool enable) {
+  c10::impl::tls_set_dispatch_key_included(c10::DispatchKey::Profiler, enable);
 }
 
 void _runBeforeCallbacks(RecordFunction* rf, const std::string& funcName) {
@@ -218,7 +232,7 @@ void _runBeforeCallbacks(RecordFunction* rf, const std::string& funcName) {
 }
 
 RecordFunction::RecordFunction(RecordScope scope) : scope_(scope) {
-  if (manager().hasCallbacks() && at::_tls_is_record_function_enabled()) {
+  if (manager().hasCallbacks() && observersEnabled()) {
     active_ = true;
   }
 }

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -220,25 +220,6 @@ struct TORCH_API RecordFunction {
   uint64_t callbacks_version_ = 0;
 };
 
-class TORCH_API RecordFunctionGuard {
- public:
-  explicit RecordFunctionGuard(bool is_enabled)
-      : prev_value_(at::_tls_is_record_function_enabled()) {
-    at::_tls_set_record_function_enabled(is_enabled);
-  }
-  virtual ~RecordFunctionGuard() {
-    at::_tls_set_record_function_enabled(prev_value_);
-  }
- private:
-  bool prev_value_ = false;
-};
-
-class TORCH_API DisableRecordFunctionGuard : public RecordFunctionGuard {
- public:
-  DisableRecordFunctionGuard() : RecordFunctionGuard(false) {}
-  virtual ~DisableRecordFunctionGuard() {}
-};
-
 // Returns whether there're callbacks registered with pushCallback
 TORCH_API bool hasCallbacks();
 
@@ -311,6 +292,33 @@ TORCH_API void pushCallback(
  * WARNING: not thread safe, must not overlap with other PyTorch code execution
  */
 TORCH_API void popCallback();
+
+// Enable observers thread locally
+TORCH_API void enableObservers(bool enable = true);
+
+// Returns whether observers are enabled (thread locally)
+TORCH_API bool observersEnabled();
+
+class TORCH_API RecordFunctionGuard {
+ public:
+  explicit RecordFunctionGuard(bool is_enabled)
+      : prev_value_(observersEnabled()) {
+    enableObservers(is_enabled);
+  }
+
+  virtual ~RecordFunctionGuard() {
+    enableObservers(prev_value_);
+  }
+
+ private:
+  bool prev_value_ = false;
+};
+
+class TORCH_API DisableRecordFunctionGuard : public RecordFunctionGuard {
+ public:
+  DisableRecordFunctionGuard() : RecordFunctionGuard(false) {}
+  virtual ~DisableRecordFunctionGuard() {}
+};
 
 } // namespace profiler
 }} // namespace torch::autograd


### PR DESCRIPTION
Summary:
After adding c10::DispatchKey::Profiler the behavior of RecordFunction
observers is also controlled by the dispatch key,
this PR moves the logic outside of the profiler into the record function

Differential Revision: D21213786

