### PR TITLE
Quantization: preserving pre and post forward hooks

### DIFF
--- a/torch/quantization/fuse_modules.py
+++ b/torch/quantization/fuse_modules.py
@@ -124,6 +124,15 @@ def fuse_known_modules(mod_list):
         raise NotImplementedError("Cannot fuse modules: {}".format(types))
     new_mod = [None] * len(mod_list)
     new_mod[0] = fuser_method(*mod_list)
+    # NOTE: forward hooks not processed in the two following for loops will be lost after the fusion
+    # Move pre forward hooks of the base module to resulting fused module
+    for handle_id, pre_hook_fn in mod_list[0]._forward_pre_hooks.items():
+        new_mod[0].register_forward_pre_hook(pre_hook_fn)
+        del mod_list[0]._forward_pre_hooks[handle_id]
+    # Move post forward hooks of the last module to resulting fused module
+    for handle_id, hook_fn in mod_list[-1]._forward_hooks.items():
+        new_mod[0].register_forward_hook(hook_fn)
+        del mod_list[-1]._forward_hooks[handle_id]
 
     for i in range(1, len(mod_list)):
         new_mod[i] = torch.nn.Identity()

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -119,7 +119,10 @@ def add_observer_(module, non_leaf_module_list=None, device=None):
         if device is not None:
             activation.to(device)
         module.add_module('activation_post_process', activation)
-        module.register_forward_hook(_observer_forward_hook)
+        # Register observer as the first entry in the hook list
+        # All post forward hooks are preserved and will be executed after the observer before convert
+        handle = module.register_forward_hook(_observer_forward_hook)
+        module._forward_hooks.move_to_end(handle.id, last=False)
 
 def get_unique_devices_(module):
     return {p.device for p in module.parameters()} | \
@@ -393,6 +396,14 @@ def swap_module(mod, mapping):
             )
             device = next(iter(devices)) if len(devices) > 0 else None
             new_mod = mapping[type(mod)].from_float(mod)
+            # Preserve module's pre forward hooks. They'll be called on quantized input
+            for pre_hook_fn in mod._forward_pre_hooks.values():
+                new_mod.register_forward_pre_hook(pre_hook_fn)
+            # Preserve module's post forward hooks except _observer_forward_hook
+            # After convert they'll work with quantized output
+            for hook_fn in mod._forward_hooks.values():
+                if hook_fn is not _observer_forward_hook:
+                    new_mod.register_forward_hook(hook_fn)
             if device:
                 new_mod.to(device)
     return new_mod


### PR DESCRIPTION
1. While do convert() preserve module's **pre and post forward** hooks
2. While do fusion preserve only module's **pre forward** hooks (because after fusion output no longer the same)

