### PR TITLE
Replacing EHa with EHsc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,16 +269,10 @@ if(MSVC)
     # NB2: This is NOT enough to prevent warnings from nvcc on MSVC.  At the
     # moment only CMP0092 is enough to prevent those warnings too.
     string(REPLACE "/W3" "" ${flag_var} "${${flag_var}}")
-    # Suppress EHs is overridden by EHa warning
-    string(REPLACE "/EHsc" "" ${flag_var} "${${flag_var}}")
 
     # Turn off warnings (Windows build is currently is extremely warning
     # unclean and the warnings aren't telling us anything useful.)
-    #
-    # Turn on EHa; I'm not altogether clear why we use the asynchronous
-    # exception handling model, but someone added it at some point, so
-    # keep using it.
-    string(APPEND ${flag_var} " /w /EHa")
+    string(APPEND ${flag_var} " /w")
 
     if(${CAFFE2_USE_MSVC_STATIC_RUNTIME})
       if(${flag_var} MATCHES "/MD")

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -310,7 +310,7 @@ namespace detail {
     const float scale_to_inf = scale_to_inf_val;
     const float scale_to_zero = scale_to_zero_val;
 
-          float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
+          float base = (std::fabsf(f) * scale_to_inf) * scale_to_zero;
 
           const uint32_t w = fp32_to_bits(f);
           const uint32_t shl1_w = w + w;

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -310,7 +310,11 @@ namespace detail {
     const float scale_to_inf = scale_to_inf_val;
     const float scale_to_zero = scale_to_zero_val;
 
-          float base = (std::fabsf(f) * scale_to_inf) * scale_to_zero;
+#if defined(_MSC_VER) && _MSC_VER == 1916
+          float base = ((std::signbit(f) != 0 ? -f : f) * scale_to_inf) * scale_to_zero;
+#else
+          float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
+#endif
 
           const uint32_t w = fp32_to_bits(f);
           const uint32_t shl1_w = w + w;

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -12,7 +12,9 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/C++17.h>
 
-#if defined(__cplusplus) && (__cplusplus >= 201103L)
+// MSVC >= 2015 reports _MSVC_LANG as __cplusplus
+#if (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
+    (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))
 #include <cmath>
 #include <cstdint>
 #elif !defined(__OPENCL_VERSION__)

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -309,7 +309,7 @@ namespace detail {
     const float scale_to_zero = scale_to_zero_val;
 
 #if defined(_MSC_VER) && _MSC_VER == 1916
-          float base = ((std::signbit(f) != 0 ? -f : f) * scale_to_inf) * scale_to_zero;
+          float base = ((signbit(f) != 0 ? -f : f) * scale_to_inf) * scale_to_zero;
 #else
           float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
 #endif

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -12,9 +12,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/C++17.h>
 
-// MSVC >= 2015 reports _MSVC_LANG as __cplusplus
-#if (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
-    (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
 #include <cmath>
 #include <cstdint>
 #elif !defined(__OPENCL_VERSION__)

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -428,9 +428,7 @@ endforeach()
 
 # Set C++14 support
 set(CUDA_PROPAGATE_HOST_FLAGS_BLACKLIST "-Werror")
-if(MSVC)
-  list(APPEND CUDA_PROPAGATE_HOST_FLAGS_BLACKLIST "/EHa")
-else()
+if(NOT MSVC)
   list(APPEND CUDA_NVCC_FLAGS "-std=c++14")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-fPIC")
 endif()

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -233,7 +233,7 @@ function(torch_compile_options libname)
       target_compile_options(${libname} PUBLIC
         ${MSVC_RUNTIME_LIBRARY_OPTION}
         ${MSVC_DEBINFO_OPTION}
-        /EHa
+        /EHsc
         /DNOMINMAX
         /wd4267
         /wd4251

--- a/setup.py
+++ b/setup.py
@@ -573,12 +573,11 @@ def configure_extension_build():
         # /MD links against DLL runtime
         # and matches the flags set for protobuf and ONNX
         # /Z7 turns on symbolic debugging information in .obj files
-        # /EHa is about native C++ catch support for asynchronous
-        # structured exception handling (SEH)
+        # /EHsc is about standard C++ exception handling
         # /DNOMINMAX removes builtin min/max functions
         # /wdXXXX disables warning no. XXXX
         extra_compile_args = ['/MD', '/Z7',
-                              '/EHa', '/DNOMINMAX',
+                              '/EHsc', '/DNOMINMAX',
                               '/wd4267', '/wd4251', '/wd4522', '/wd4522', '/wd4838',
                               '/wd4305', '/wd4244', '/wd4190', '/wd4101', '/wd4996',
                               '/wd4275']


### PR DESCRIPTION
We should not rely on the async exceptions. Catching C++ only exception is more sensible and may get a boost in both space (1163 MB -> 1073 MB, 0.92x) and performance(51m -> 49m, 0.96x).