### PR TITLE
Remove unused imports in aten/src/ATen/function_wrapper.py

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -4,16 +4,7 @@
 import re
 from code_template import CodeTemplate
 
-try:
-    import typing  # noqa: F401
-except ImportError:
-    raise RuntimeError(
-        'Missing build dependency: Unable to import the `typing` module. '
-        'Please install it via `conda install typing` or `pip install typing`')
-
-# flake8 doesn't take into account usages in type annotations.
-from typing import Union, Set  # noqa: F401
-from typing import Any, Dict, List, Optional, Tuple, NamedTuple
+from typing import Any, Dict, List, Optional, Set, Tuple, NamedTuple
 
 try:
     from mypy_extensions import TypedDict


### PR DESCRIPTION
typing is available since Python 3.5, no need to try-import.

