### PR TITLE
Consolidate usage on torch::jit::toPyObject in RPC request_callback

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -363,9 +363,8 @@ void RequestCallbackImpl::processRpc(
         // the OwnerRRef has been created
         const auto& rref = futureOwner->constValue();
         if (rref->hasValue()) {
-          SerializedPyObj result =
-              PythonRpcHandler::getInstance().serialize(
-                  toPyObj(rref->getValue()));
+          SerializedPyObj result = PythonRpcHandler::getInstance().serialize(
+              toPyObj(rref->getValue()));
           markComplete(
               PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
           return;
@@ -385,9 +384,8 @@ void RequestCallbackImpl::processRpc(
             return;
           }
           try {
-            SerializedPyObj result =
-                PythonRpcHandler::getInstance().serialize(
-                    toPyObj(rref->getValue()));
+            SerializedPyObj result = PythonRpcHandler::getInstance().serialize(
+                toPyObj(rref->getValue()));
             Message m =
                 PythonRRefFetchRet(std::move(result).toIValues()).toMessage();
             m.setId(messageId);

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -33,6 +33,11 @@ using namespace torch::distributed::autograd;
 
 namespace {
 
+py::object toPyObj(IValue value) {
+  pybind11::gil_scoped_acquire ag;
+  return torch::jit::toPyObject(std::move(value));
+}
+
 std::unique_ptr<RpcCommandBase> deserializePythonRpcCommandReference(
     RpcCommandBase& rpc,
     const MessageType& messageType) {
@@ -358,14 +363,9 @@ void RequestCallbackImpl::processRpc(
         // the OwnerRRef has been created
         const auto& rref = futureOwner->constValue();
         if (rref->hasValue()) {
-          auto value = rref->getValue();
-          py::object pyValue;
-          {
-            pybind11::gil_scoped_acquire ag;
-            pyValue = torch::jit::toPyObject(std::move(value));
-          }
           SerializedPyObj result =
-              PythonRpcHandler::getInstance().serialize(pyValue);
+              PythonRpcHandler::getInstance().serialize(
+                  toPyObj(rref->getValue()));
           markComplete(
               PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
           return;
@@ -385,14 +385,9 @@ void RequestCallbackImpl::processRpc(
             return;
           }
           try {
-            IValue value = rref->getValue();
-            py::object pyValue;
-            {
-              pybind11::gil_scoped_acquire ag;
-              pyValue = torch::jit::toPyObject(std::move(value));
-            }
             SerializedPyObj result =
-                PythonRpcHandler::getInstance().serialize(pyValue);
+                PythonRpcHandler::getInstance().serialize(
+                    toPyObj(rref->getValue()));
             Message m =
                 PythonRRefFetchRet(std::move(result).toIValues()).toMessage();
             m.setId(messageId);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37249 Consolidate usage on torch::jit::toPyObject in RPC request_callback**
* #36811 Add using torch::utils::Future to simplify code in RRefContext
* #36805 Prevent RRef.to_here() to block an RPC thread on the callee using Future callbacks
* #36785 Prevent RRef unpickle to block waiting for OwnerRRef creation

Differential Revision: [D21234990](https://our.internmc.facebook.com/intern/diff/D21234990)