### PR TITLE
[jit] fix named tuples as attributes

### DIFF
--- a/aten/src/ATen/test/type_test.cpp
+++ b/aten/src/ATen/test/type_test.cpp
@@ -87,7 +87,7 @@ static TypePtr importType(
         return source;
       },
       /*version=*/2);
-  return si.loadNamedType(qual_name);
+  return si.loadType(qual_name);
 }
 
 TEST(TypeEquality, ClassBasic) {

--- a/test/cpp/jit/test_class_import.cpp
+++ b/test/cpp/jit/test_class_import.cpp
@@ -42,7 +42,7 @@ static void import_libs(
       &tensor_table,
       [&](const std::string& name) -> std::shared_ptr<Source> { return src; },
       /*version=*/2);
-  si.loadNamedType(QualifiedName(class_name));
+  si.loadType(QualifiedName(class_name));
 }
 
 void testClassImport() {

--- a/test/cpp/jit/test_interface.cpp
+++ b/test/cpp/jit/test_interface.cpp
@@ -41,7 +41,7 @@ static void import_libs(
       &tensor_table,
       [&](const std::string& name) -> std::shared_ptr<Source> { return src; },
       /*version=*/2);
-  si.loadNamedType(QualifiedName(class_name));
+  si.loadType(QualifiedName(class_name));
 }
 
 void testModuleInterfaceSerialization() {

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -154,6 +154,24 @@ class TestScriptPy3(JitTestCase):
         self.assertEqual(out.sequence_features, [3.0])
         self.assertEqual(out.time_since_first, 3.0)
 
+    def test_named_tuple_as_attr(self):
+        class Config(NamedTuple):
+            size: int
+
+        class MyMod(nn.Module):
+            configs: Dict[int, Config]
+
+            def __init__(self, configs):
+                super().__init__()
+                self.configs = configs
+
+            def forward(self, x):
+                for _id, config in self.configs.items():
+                    x += config.size
+                return x
+
+        s = torch.jit.script(MyMod({0: Config(size=16)}))
+
     def test_types_as_values(self):
         def fn(m: torch.Tensor) -> torch.device:
             return m.device

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -135,7 +135,7 @@ class ScriptModuleDeserializer final {
 
 IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
   auto type_resolver = [&](const c10::QualifiedName& qn) {
-    auto cls = source_importer_.loadNamedType(qn)->expect<ClassType>();
+    auto cls = source_importer_.loadType(qn);
     return c10::StrongTypePtr(compilation_unit_, std::move(cls));
   };
 

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -29,7 +29,7 @@ struct ClassResolver : public Resolver {
       : source_importer_(std::move(source_importer)) {}
   TypePtr resolveType(const std::string& name, const SourceRange& loc)
       override {
-    return source_importer_.loadNamedType(c10::QualifiedName(name));
+    return source_importer_.loadType(c10::QualifiedName(name));
   }
 
  private:
@@ -137,7 +137,7 @@ IValue ScriptModuleDeserializer::LEGACY_loadPickleArchive(
       reinterpret_cast<const char*>(attributes_ptr.get()),
       attributes_size,
       [&](const c10::QualifiedName& qn) {
-        auto cls = source_importer_.loadNamedType(qn)->expect<ClassType>();
+        auto cls = source_importer_.loadType(qn)->expect<ClassType>();
         return c10::StrongTypePtr(compilation_unit_, std::move(cls));
       },
       &constants_table_);

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -494,9 +494,9 @@ SourceImporter::SourceImporter(
           std::move(loader),
           version)) {}
 
-TypePtr SourceImporter::loadNamedType(const QualifiedName& name) const {
-  TypePtr t = pImpl->findNamedType(name);
-  TORCH_INTERNAL_ASSERT(t != nullptr);
+TypePtr SourceImporter::loadType(const QualifiedName& name) const {
+  ScriptTypeParser type_parser(pImpl);
+  TypePtr t = type_parser.parseType(name.qualifiedName());
   return t;
 }
 

--- a/torch/csrc/jit/serialization/import_source.h
+++ b/torch/csrc/jit/serialization/import_source.h
@@ -26,10 +26,10 @@ struct TORCH_API SourceImporter {
       SourceLoader loader,
       size_t version);
 
-  TypePtr loadNamedType(const QualifiedName& name) const;
+  TypePtr loadType(const QualifiedName& name) const;
 
   // Add the methods defined in `src` to the module `mod`, using SourceImporter
-  // to resolve any classes via loadNamedType
+  // to resolve any classes via loadType
   void LEGACY_import_methods(
       const Module& mod,
       const std::shared_ptr<Source>& src);

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -490,7 +490,13 @@ void Unpickler::readGlobal(
         if (entry != type_cache_.end()) {
           type = entry->second;
         } else {
-          type = c10::parseType(type_str);
+          if (type_resolver_ == nullptr) {
+            // If we haven't injected a custom way of retrieving types from names,
+            // use a barebones type parser.
+            type = c10::parseType(type_str);
+          } else {
+            type = type_resolver_(type_str).type_;
+          }
           type_cache_[type_str] = type;
         }
         // TODO: Use lookahead to avoid creating the tuple and immediately

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -491,8 +491,8 @@ void Unpickler::readGlobal(
           type = entry->second;
         } else {
           if (type_resolver_ == nullptr) {
-            // If we haven't injected a custom way of retrieving types from names,
-            // use a barebones type parser.
+            // If we haven't injected a custom way of retrieving types from
+            // names, use a barebones type parser.
             type = c10::parseType(type_str);
           } else {
             type = type_resolver_(type_str).type_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37251 [jit] fix named tuples as attributes**

This was broken by recent changes to how we serialize with type tags. We
save a name (like `Dict[str, MyNamedTuple]`) and then relied on the
mobile type parser to resolve that name back into a set of types.

This doesn't work for any NamedTypes as the mobile type parser doesn't
know how to resolve those. The unpickler allows the caller to inject a
type resolver in for this purpose, use that so that when importing in a
non-mobile environment you get the right results.

A second problem also had to be fixed: the SourceImporter type loader
would only load named types directly (e.g. `MyNamedTuple`) and choked if
it was a general type that contained a named tupe (e.g.
`List[MyNamedTuple]`). Fixed that and renamed `loadNamedType` to
`loadType` for clarity.

Differential Revision: [D21235213](https://our.internmc.facebook.com/intern/diff/D21235213)