### PR TITLE
Remove python-2 or python<3.5 checks from unit tests

### DIFF
--- a/test/custom_operator/test_custom_classes.py
+++ b/test/custom_operator/test_custom_classes.py
@@ -4,7 +4,6 @@ from torch import ops
 import torch.jit as jit
 import glob
 import os
-import sys
 
 def get_custom_class_library_path():
     library_filename = glob.glob("build/*custom_class*")
@@ -20,16 +19,6 @@ def test_equality(f, cmp_key):
     return (cmp_key(obj1), cmp_key(obj2))
 
 class TestCustomOperators(unittest.TestCase):
-    if sys.version_info < (3, 2):
-        # assertRegexpMatches renamed to assertRegex in 3.2
-        assertRegex = unittest.TestCase.assertRegexpMatches
-        # assertRaisesRegexp renamed to assertRaisesRegex in 3.2
-        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
-    if sys.version_info < (3, 5):
-        # assertNotRegexpMatches renamed to assertNotRegex in 3.5
-        assertNotRegex = unittest.TestCase.assertNotRegexpMatches
-
     def setUp(self):
         ops.load_library(get_custom_class_library_path())
 

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import unittest
 import inspect
 from typing import List, Dict
 from textwrap import dedent
@@ -648,7 +647,6 @@ class TestList(JitTestCase):
 
         self.checkScript(test_pop_slice, ())
 
-    @unittest.skipIf(sys.version_info < (3, 3), "clear not supported in version < 3.3")
     def test_mutable_list_clear_empty(self):
         def test_clear_empty():
             a = torch.jit.annotate(List[int], [])
@@ -657,7 +655,6 @@ class TestList(JitTestCase):
             return len(a) == 0
         self.checkScript(test_clear_empty, ())
 
-    @unittest.skipIf(sys.version_info < (3, 3), "clear not supported in version < 3.3")
     def test_mutable_list_clear(self):
         def test_clear():
             a = [1, 2, 3, 4]

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -17,8 +17,6 @@ import torch._six
 from torch.utils import cpp_extension
 from torch.testing._internal.common_utils import TEST_WITH_ROCM, shell
 import torch.distributed as dist
-PY33 = sys.version_info >= (3, 3)
-PY36 = sys.version_info >= (3, 6)
 
 TESTS = [
     'test_autograd',
@@ -71,27 +69,17 @@ TESTS = [
     'test_overrides',
     'test_jit_fuser_te',
     'test_tensorexpr',
+    'distributed/rpc/faulty_agent/test_dist_autograd_spawn',
+    'distributed/rpc/faulty_agent/test_rpc_spawn',
+    'distributed/rpc/jit/test_dist_autograd_spawn',
+    'distributed/rpc/test_dist_autograd_spawn',
+    'distributed/rpc/test_dist_optimizer_spawn',
+    'distributed/rpc/test_rpc_spawn',
+    'test_jit_py3',
+    'test_determination',
+    'distributed/rpc/jit/test_rpc_spawn',
+    'distributed/rpc/faulty_agent/test_rpc_spawn',
 ]
-
-# skip < 3.3 because mock is added in 3.3 and is used in rpc_spawn
-if PY33:
-    TESTS.extend([
-        'distributed/rpc/faulty_agent/test_dist_autograd_spawn',
-        'distributed/rpc/faulty_agent/test_rpc_spawn',
-        'distributed/rpc/jit/test_dist_autograd_spawn',
-        'distributed/rpc/test_dist_autograd_spawn',
-        'distributed/rpc/test_dist_optimizer_spawn',
-        'distributed/rpc/test_rpc_spawn',
-    ])
-
-# skip < 3.6 b/c fstrings added in 3.6
-if PY36:
-    TESTS.extend([
-        'test_jit_py3',
-        'test_determination',
-        'distributed/rpc/jit/test_rpc_spawn',
-        'distributed/rpc/faulty_agent/test_rpc_spawn',
-    ])
 
 WINDOWS_BLACKLIST = [
     'distributed/rpc/faulty_agent/test_dist_autograd_spawn',

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -99,8 +99,6 @@ if torch.cuda.is_available():
             RUN_CUDA_HALF = False
 
 
-PY35 = sys.version_info >= (3, 5)
-
 def canonical(graph):
     return torch._C._jit_pass_canonicalize(graph).str(False)
 
@@ -5437,7 +5435,6 @@ a")
         b = torch.rand(1, requires_grad=True)
         self.checkScript(func, (a, b), optimize=True)
 
-    @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_matmul_py3(self):
         code = dedent("""
         def fn(a, b):
@@ -11050,7 +11047,6 @@ a")
         self.checkScript(fn2, (x, y, z), optimize=True)
         self.checkScript(fn3, (x, y, z), optimize=True)
 
-    @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_type_annotation_py3(self):
         code = dedent("""
         import torch
@@ -14120,7 +14116,6 @@ a")
             return fn
 
     #  Python AST Frontend , Python 3-style type annotations , Script function
-    @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_annot_ast_py3_fn(self):
         code = dedent('''
             from typing import Tuple, List, Optional
@@ -14137,7 +14132,6 @@ a")
             test_str.append(str(fn.schema))
         self.assertExpectedStripMangled("\n".join(test_str))
 
-    @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_multiline_annot_ast_py3_fn(self):
         code = dedent('''
             from typing import Tuple, List, Optional
@@ -14193,7 +14187,6 @@ a")
                 return a + b + c
 
     #  Python AST Frontend , Python 3-style type annotations , Script method
-    @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_annot_ast_py3_method(self):
         code = dedent('''
             from typing import Tuple, List, Optional
@@ -14215,7 +14208,6 @@ a")
         self.assertExpectedStripMangled("\n".join(test_str))
 
     #  Python AST Frontend , MyPy-style type comments , Script function
-    @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_annot_ast_mypy_fn(self):
         code = dedent('''
             import torch
@@ -14232,7 +14224,6 @@ a")
         self.assertExpected("\n".join(test_str))
 
     #  Python AST Frontend , MyPy-style type comments , Script method
-    @unittest.skipIf(not PY35, "Python 3.5 needed")
     def test_annot_ast_mypy_method(self):
         code = dedent('''
             import torch
@@ -17860,11 +17851,9 @@ for test in criterion_tests:
 
 if __name__ == '__main__':
     run_tests()
-    PY36 = sys.version_info >= (3, 6)
-    if PY36:
-        import test_jit_py3
-        import jit.test_module_interface
-        suite = unittest.findTestCases(test_jit_py3)
-        unittest.TextTestRunner().run(suite)
-        suite = unittest.findTestCases(jit.test_module_interface)
-        unittest.TextTestRunner().run(suite)
+    import test_jit_py3
+    import jit.test_module_interface
+    suite = unittest.findTestCases(test_jit_py3)
+    unittest.TextTestRunner().run(suite)
+    suite = unittest.findTestCases(jit.test_module_interface)
+    unittest.TextTestRunner().run(suite)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -551,14 +551,10 @@ class TestOldSerialization(TestCase, SerializationMixin):
         tmpmodule_name = 'tmpmodule{}'.format(unique_key)
 
         def import_module(name, filename):
-            if sys.version_info >= (3, 5):
-                import importlib.util
-                spec = importlib.util.spec_from_file_location(name, filename)
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-            else:
-                import imp
-                module = imp.load_source(name, filename)
+            import importlib.util
+            spec = importlib.util.spec_from_file_location(name, filename)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
             sys.modules[module.__name__] = module
             return module
 

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -192,7 +192,6 @@ class TestTypeHints(TestCase):
             except subprocess.CalledProcessError as e:
                 raise AssertionError("mypy failed for example {}.  Look above this error for mypy's output.".format(example))
 
-    @unittest.skipIf(sys.version_info[0] == 2, "no type hints for Python 2")
     @unittest.skipIf(not HAVE_MYPY, "need mypy")
     def test_run_mypy(self):
         """


### PR DESCRIPTION
Test Plan: CI

