### PR TITLE
Improve Error Message for Dist Autograd Context Cleanup Failure

### DIFF
--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -244,7 +244,7 @@ void DistAutogradContainer::sendReleaseContextRpc(
                   "Could not release Dist Autograd Context on node ",
                   worker_id,
                   ": ",
-                  error->what());
+                  cleanupFuture.error()->what());
               LOG(ERROR) << errorMsg;
               return;
             }

--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -237,17 +237,18 @@ void DistAutogradContainer::sendReleaseContextRpc(
           CleanupAutogradContextReq(context_id).toMessage(),
           options);
 
-      cleanupFuture->addCallback([worker_id](const rpc::FutureMessage& cleanupFuture) {
-        if (cleanupFuture.hasError()) {
-          std::string errorMsg = c10::str(
-              "Could not release Dist Autograd Context on node ",
-              worker_id,
-              ": ",
-              error->what());
-          LOG(ERROR) << errorMsg;
-          return;
-        }
-      });
+      cleanupFuture->addCallback(
+          [worker_id](const rpc::FutureMessage& cleanupFuture) {
+            if (cleanupFuture.hasError()) {
+              std::string errorMsg = c10::str(
+                  "Could not release Dist Autograd Context on node ",
+                  worker_id,
+                  ": ",
+                  error->what());
+              LOG(ERROR) << errorMsg;
+              return;
+            }
+          });
     } catch (const std::exception& e) {
       LOG(INFO)
           << "Failed to send RPC to clear Dist Autograd context to worker id: "

--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -237,12 +237,13 @@ void DistAutogradContainer::sendReleaseContextRpc(
           CleanupAutogradContextReq(context_id).toMessage(),
           options);
 
-      cleanupFuture->addCallback([](const rpc::FutureMessage& cleanupFuture) {
+      cleanupFuture->addCallback([worker_id](const rpc::FutureMessage& cleanupFuture) {
         if (cleanupFuture.hasError()) {
           std::string errorMsg = c10::str(
-              "Could not release Dist Autograd Context after ",
-              kNumCleanupContextRetries,
-              " attempts.");
+              "Could not release Dist Autograd Context on node ",
+              worker_id,
+              ": ",
+              error->what());
           LOG(ERROR) << errorMsg;
           return;
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37255 Improve Error Message for Dist Autograd Context Cleanup Failure**

Improved error message logged when Distributed Autograd Context cleanup fails - added node information and underlying error. The previous error message also assumed that the cause of the error was due to too many RPC's failing, but this is not necessarily the case.

Differential Revision: [D20950664](https://our.internmc.facebook.com/intern/diff/D20950664/)