### PR TITLE
Mask all high dispatch keys in BackendSelect kernels

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -769,7 +769,7 @@ def gen_dispatch_key_init(var_name, formals):
         subexprs.append('c10::detail::multi_dispatch_key_set({})'.format(args))
     return [
         'DispatchKeySet _dk_set = {};'.format(' | '.join(subexprs)),
-        'DispatchKeySet _dk_mask = c10::DispatchKeySet(c10::DispatchKeySet::FULL).remove(DispatchKey::BackendSelect);',
+        'DispatchKeySet _dk_mask = c10::DispatchKeySet(DispatchKeySet::FULL_AFTER, DispatchKey::BackendSelect);',
         'DispatchKey {} = c10::impl::dispatchTypeId(_dk_set, _dk_mask);'.format(var_name),
     ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37257 Mask all high dispatch keys in BackendSelect kernels**

Previously, we were relying on fragile invariants to avoid collecting
and feeding high precedence, non-backend dispatch keys to backend
initialization machinery, which would assert on them. (These same
keys are then used for redispatch, so a second latent problem lurks
behind the first.) Here we mask off the BackendDispatch key and all
keys to its left.

Followup: move backend init code to backend-specific wrappers
(`CPUType` etc.). This will let us remove the backend init code from
both BackendSelect and STATIC_DISPATCH wrappers. (Though BackendSelect
will still need to compute a dispatch key, so the logic introduced
here will still be necessary.)

Differential Revision: [D21235856](https://our.internmc.facebook.com/intern/diff/D21235856)