### PR TITLE
Make listenLoopInternal non-virtual

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.h
+++ b/torch/csrc/distributed/rpc/process_group_agent.h
@@ -158,10 +158,10 @@ class ProcessGroupAgent : public RpcAgent {
   // the timeout). This ensures that the messages accounted for in
   // hasPendingMessage() are tallied properly during a graceful shutdown.
   bool handleRecv(RecvWork& work);
-  // Loop for receiving messages. Calls listenLoopInternal and handles errors
-  // such as timeouts on the process group.
-  virtual void listenLoopInternal();
-  // Main function for receiving messages
+  // Loop that receives and processes messages
+  void listenLoopInternal();
+  // Calls listenLoopInternal and handles errors such as timeouts on the
+  // process group.
   void listenLoop();
   // exception_pointer correspnding to an exception raised in listenLoop (if
   // there is one), and lock to guard access.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37265 Make listenLoopInternal non-virtual**

In PGA, `listenLoopInternal` should not be virtual - PGA doesn't have any child classes that override this. Re-arranged some comments for `listenLoop` as well.

Differential Revision: [D21238761](https://our.internmc.facebook.com/intern/diff/D21238761/)