### PR TITLE
Improve checkpoint docs to warn users about detached gradient issues

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -129,6 +129,14 @@ def checkpoint(function, *args, **kwargs):
         checkpointed version won't be equivalent, and unfortunately it can't be
         detected.
 
+    .. warning::
+        If checkpointed segment contains tensors detached from the computational
+        graph by `detach()` or `torch.no_grad()`, the backward pass will raise an
+        error. This is because `checkpoint` makes all the outputs require 
+        gradients which causes issues when a tensor is defined to have no 
+        gradient in the model. To circumvent this, detach the tensors outside of 
+        the `checkpoint` function.
+
     .. warning:
         At least one of the inputs needs to have :code:`requires_grad=True` if
         grads are needed for model inputs, otherwise the checkpointed part of the


### PR DESCRIPTION
See https://discuss.pytorch.org/t/training-with-gradient-checkpoints-torch-utils-checkpoint-appears-to-reduce-performance-of-model/78102/3?u=jwl for details.

Updated the docs to warn users about issues with checkpointing models that use `detach()` or `torch.no_grad()` to freeze their model layers/weights during training. When they do this, training with `checkpoint` will fail as it forces the outputs to require gradients when the model itself does not. Hence, during the backward pass it will output the error:
```
[4]<stderr>:RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
```

Maybe it is possible to fix this directly in the code, but I am not sure how in the current codebase.