### PR TITLE
Do not define list "0" in torch/CMakeLists.txt

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -213,8 +213,8 @@ if(USE_CUDNN)
     # Basically, this is the case where $CUDA_HOME/lib64 has an old or
     # incompatible libcudnn.so, which we can inadvertently link to if
     # we're not careful.
-    list(INSERT 0 TORCH_PYTHON_LINK_LIBRARIES ${CUDNN_LIBRARY_PATH})
-    list(INSERT 0 TORCH_PYTHON_INCLUDE_DIRECTORIES ${CUDNN_INCLUDE_PATH})
+    list(INSERT TORCH_PYTHON_LINK_LIBRARIES 0 ${CUDNN_LIBRARY_PATH})
+    list(INSERT TORCH_PYTHON_INCLUDE_DIRECTORIES 0 ${CUDNN_INCLUDE_PATH})
     list(APPEND TORCH_PYTHON_SRCS
       ${TORCH_SRC_DIR}/csrc/cuda/shared/cudnn.cpp
       )


### PR DESCRIPTION
Per https://cmake.org/cmake/help/latest/command/list.html list insert arguments order is
`list(INSERT <list> <index> [<element>...])`

That is first argument is list name not the index it gets inserted into

