### PR TITLE
Use `std::chrono::high_resolution_clock` for profiling on Mac

### DIFF
--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -14,6 +14,9 @@
 #ifndef _WIN32
 #include <ctime>
 #endif
+#if defined(C10_IOS) && defined(C10_MOBILE)
+#include <sys/time.h> // for gettimeofday()
+#endif
 
 #include <torch/csrc/autograd/record_function.h>
 
@@ -65,24 +68,17 @@ constexpr inline size_t ceilToMultiple(size_t a, size_t b) {
   return ((a + b - 1) / b) * b;
 }
 
-#if (defined(__MACH__) && !defined(CLOCK_REALTIME)) || defined(C10_IOS)
-#include <sys/time.h>
-// clock_gettime is not implemented on older versions of OS X (< 10.12).
-// If implemented, CLOCK_REALTIME will have already been defined.
-
+inline int64_t getTime() {
+#if defined(C10_IOS) && defined(C10_MOBILE)
 // clock_gettime is only available on iOS 10.0 or newer. Unlike OS X, iOS can't rely on
 // CLOCK_REALTIME, as it is defined no matter if clock_gettime is implemented or not
-#endif
-
-inline int64_t getTime() {
-#ifdef _WIN32
-  using namespace std::chrono;
-  using clock = std::conditional<high_resolution_clock::is_steady, high_resolution_clock, steady_clock>::type;
-  return duration_cast<nanoseconds>(clock::now().time_since_epoch()).count();
-#elif (defined(__MACH__) && !defined(CLOCK_REALTIME)) || defined(C10_IOS)
   struct timeval now;
   gettimeofday(&now, NULL);
   return static_cast<int64_t>(now.tv_sec) * 1000000000 + static_cast<int64_t>(now.tv_usec) * 1000;
+#elif defined(_WIN32) || defined(__MACH__)
+  using namespace std::chrono;
+  using clock = std::conditional<high_resolution_clock::is_steady, high_resolution_clock, steady_clock>::type;
+  return duration_cast<nanoseconds>(clock::now().time_since_epoch()).count();
 #else
   // clock_gettime is *much* faster than std::chrono implementation on Linux
   struct timespec t{};


### PR DESCRIPTION
According to Darwin man-page:
    `CLOCK_REALTIME` the system's real time (i.e. wall time) clock, expressed as the amount of time since the Epoch.  This is the same as the value returned by `gettimeofday`(2).

I.e. its returns timestamp with microsecond resolution, as can be obvserved by running following small program:
```
#include <sys/time.h>
#include <stdint.h>
#include <stdbool.h>
#include <stdio.h>

bool conseq_time(clockid_t c) {
  struct timespec t1, t2;
  clock_gettime(c, &t1);
  clock_gettime(c, &t2);
  printf("t1={.tv_sec=%ld, .tv_nsec=%ld}\n", t1.tv_sec, t1.tv_nsec);
  printf("t2={.tv_sec=%ld, .tv_nsec=%ld}\n", t2.tv_sec, t2.tv_nsec);
  bool rc = t1.tv_sec == t2.tv_sec && t1.tv_nsec == t2.tv_nsec;
  printf("Two timestamps are %sequal\n", rc ? "" : "not ");
  return rc;
}

int main(void) {
  printf("using CLOCK_REALTIME\n");
  conseq_time(CLOCK_REALTIME);
  printf("using CLOCK_MONOTONIC_RAW\n");
  conseq_time(CLOCK_MONOTONIC_RAW);
  return 0;
}
```
which if compiled outputs something like:
```
using CLOCK_REALTIME
t1={.tv_sec=107519, .tv_nsec=860315000}
t2={.tv_sec=107519, .tv_nsec=860315000}
Two timestamps are equal
using CLOCK_MONOTONIC_RAW
t1={.tv_sec=107520, .tv_nsec=954297363}
t2={.tv_sec=107520, .tv_nsec=954297426}
Two timestamps are not equal
```

But why do it, if all this platform specific logic is already nicely abstracted in `std::chrono::`:
https://github.com/llvm/llvm-project/blob/master/libcxx/src/chrono.cpp#L117

