### PR TITLE
Don't set CXX_FLAGS in code analyzer directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ cmake_dependent_option(
 option(USE_FBGEMM "Use FBGEMM (quantized 8-bit server operators)" ON)
 option(USE_FAKELOWP "Use FakeLowp operators" OFF)
 option(USE_FFMPEG "Use ffmpeg" OFF)
+option(USE_CODE_ANALYZER "Build with settings for tools/code_analyzer" OFF)
 option(USE_GFLAGS "Use GFLAGS" OFF)
 option(USE_GLOG "Use GLOG" OFF)
 option(USE_LEVELDB "Use LEVELDB" OFF)
@@ -434,6 +435,10 @@ if(USE_FBGEMM AND ((CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_SIZEOF_VO
 endif()
 
 include(cmake/Dependencies.cmake)
+
+if(USE_CODE_ANALYZER)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -S -emit-llvm -DSTRIP_ERROR_MESSAGES")
+endif()
 
 if(USE_FBGEMM)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_FBGEMM")

--- a/tools/code_analyzer/build.sh
+++ b/tools/code_analyzer/build.sh
@@ -62,8 +62,8 @@ build_torch_mobile() {
 
   if [ ! -d "${TORCH_INSTALL_PREFIX}" ]; then
     BUILD_ROOT="${TORCH_BUILD_ROOT}" "${SRC_ROOT}/scripts/build_mobile.sh" \
-      -DCMAKE_CXX_FLAGS="-S -emit-llvm -DSTRIP_ERROR_MESSAGES" \
-      -DUSE_STATIC_DISPATCH=OFF
+      -DUSE_STATIC_DISPATCH=OFF \
+      -DUSE_CODE_ANALYZER=ON
   fi
 }
 
@@ -75,7 +75,7 @@ build_test_project() {
   BUILD_ROOT="${TEST_BUILD_ROOT}" \
     TORCH_INSTALL_PREFIX="${TORCH_INSTALL_PREFIX}" \
     "${TEST_SRC_ROOT}/build.sh" \
-    -DCMAKE_CXX_FLAGS="-S -emit-llvm -DSTRIP_ERROR_MESSAGES"
+    -DUSE_CODE_ANALYZER=ON
 }
 
 call_analyzer() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37241 add fmt
* **#37289 Don't set CXX_FLAGS in code analyzer directly**

Apparently `target_compile_features` propagates `CXX_FLAGS` set from the
command line. If you pass `-S`, all compiler feature tests will fail
(since they rely on building and running a small program). So instead of
passing them in on the command line, use a cmake option instead.