### PR TITLE
Check compiler -v to determine compiler (fix #33701)

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -193,7 +193,23 @@ def check_compiler_ok_for_platform(compiler):
     which = subprocess.check_output(['which', compiler], stderr=subprocess.STDOUT)
     # Use os.path.realpath to resolve any symlinks, in particular from 'c++' to e.g. 'g++'.
     compiler_path = os.path.realpath(which.decode().strip())
-    return any(name in compiler_path for name in _accepted_compilers_for_platform())
+    # Check the compiler name
+    if any(name in compiler_path for name in _accepted_compilers_for_platform()):
+        return True
+    # If ccache is used the compiler path is /usr/bin/ccache. Check by -v flag.
+    version_string = subprocess.check_output([compiler, '-v'], stderr=subprocess.STDOUT).decode()
+    if sys.platform.startswith('linux'):
+        # Check for 'gcc' or 'g++'
+        pattern = re.compile("^COLLECT_GCC=(.*)$", re.MULTILINE)
+        results = re.findall(pattern, version_string)
+        if len(results) != 1:
+            return False
+        compiler_path = os.path.realpath(results[0].strip())
+        return any(name in compiler_path for name in _accepted_compilers_for_platform())
+    if sys.platform.startswith('darwin'):
+        # Check for 'clang' or 'clang++'
+        return version_string.startswith("Apple clang")
+    return False
 
 
 def check_compiler_abi_compatibility(compiler):


### PR DESCRIPTION
	Summary:
	As described in the issue (#33701) the compiler check
	for building cpp extensions does not work with ccache.
	In this case we check compiler -v to determine which
	compiler is actually used and check it.

