### PR TITLE
Treat cross-execution-space-call as errors for NVCC on Windows

### DIFF
--- a/c10/util/BFloat16-math.h
+++ b/c10/util/BFloat16-math.h
@@ -31,7 +31,11 @@ inline c10::BFloat16 rsqrt(c10::BFloat16 a) { return 1.0 / std::sqrt(float(a));}
 inline c10::BFloat16 abs(c10::BFloat16 a) { return std::abs(float(a));}
 inline c10::BFloat16 min(c10::BFloat16 a, c10::BFloat16 b) { return std::min(float(a), float(b));}
 inline c10::BFloat16 max(c10::BFloat16 a, c10::BFloat16 b) { return std::max(float(a), float(b));}
+#if defined(_MSC_VER) && defined(__CUDACC__)
+inline c10::BFloat16 pow(c10::BFloat16 a, double b) { return std::pow(float(a), float(b));}
+#else
 inline c10::BFloat16 pow(c10::BFloat16 a, double b) { return std::pow(float(a), b);}
+#endif
 inline c10::BFloat16 pow(c10::BFloat16 a, c10::BFloat16 b) { return std::pow(float(a), float(b));}
 
 } // namespace std

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -45,8 +45,10 @@ namespace detail {
   }
 
   inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
-#ifdef __HIP_PLATFORM_HCC__
+#if defined(__HIP_PLATFORM_HCC__)
     if(src != src) {
+#elif defined(_MSC_VER)
+    if (isnan(src)) {
 #else
     if (std::isnan(src)) {
 #endif

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -450,13 +450,24 @@ list(APPEND CUDA_NVCC_FLAGS ${NVCC_FLAGS_EXTRA})
 message(STATUS "Added CUDA NVCC flags for: ${NVCC_FLAGS_EXTRA}")
 
 # disable some nvcc diagnostic that appears in boost, glog, glags, opencv, etc.
-foreach(diag cc_clobber_ignored integer_sign_change useless_using_declaration set_but_not_used)
+foreach(diag cc_clobber_ignored integer_sign_change useless_using_declaration
+             set_but_not_used field_without_dll_interface
+             base_class_has_different_dll_interface
+             dll_interface_conflict_none_assumed
+             dll_interface_conflict_dllexport_assumed
+             implicit_return_from_non_void_function
+             unsigned_compare_with_zero
+             declared_but_not_referenced
+             bad_friend_decl)
   list(APPEND CUDA_NVCC_FLAGS -Xcudafe --diag_suppress=${diag})
 endforeach()
 
 # Set C++14 support
 set(CUDA_PROPAGATE_HOST_FLAGS_BLACKLIST "-Werror")
-if(NOT MSVC)
+if(MSVC)
+  list(APPEND CUDA_NVCC_FLAGS "--Werror" "cross-execution-space-call")
+  list(APPEND CUDA_NVCC_FLAGS "--no-host-device-move-forward")
+else()
   list(APPEND CUDA_NVCC_FLAGS "-std=c++14")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-fPIC")
 endif()


### PR DESCRIPTION
On Windows, when you call those unsupported functions like `std::pow`, `std::isnan` or `std::isinf` in the device function and compile, a warning is thrown:
```
kernel.cu
kernel.cu(39): warning: calling a __host__ function from a __host__ __device__ function is not allowed

kernel.cu(42): warning: calling a __host__ function from a __host__ __device__ function is not allowed

kernel.cu(39): warning: calling a __host__ function("isnan<double> ") from a __host__ __device__ function("test_") is not allowed

kernel.cu(42): warning: calling a __host__ function("isinf<double> ") from a __host__ __device__ function("test_") is not allowed
```
However, those calls will lead to runtime errors, see https://github.com/pytorch/pytorch/pull/36749#issuecomment-619239788 and https://github.com/pytorch/pytorch/issues/31108.  So we should treat them as errors.
Previously, the situation is worse because the warnings are turned off by passing in `-w`.