### PR TITLE
[TensorExpr] Add IRPrinter::visit for AtomicAdd.

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -459,6 +459,23 @@ void IRPrinter::visit(const Cond* v) {
   }
 }
 
+void IRPrinter::visit(const AtomicAdd* v) {
+  emitIndent();
+  os() << "atomicAdd(&" << *v->base_handle() << "[";
+  size_t i = 0;
+  for (const Expr* ind : v->indices()) {
+    if (i++) {
+      os() << ", ";
+    }
+    ind->accept(this);
+  }
+  if (v->indices().empty()) {
+    os() << "0";
+  }
+  os() << "], " << *v->value() << ");";
+  os() << std::endl;
+}
+
 void IRPrinter::emitIndent() {
   os() << std::setw(2 * indent_) << "";
 }

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -36,22 +36,24 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const Cast* v) override;
   void visit(const Var* v) override;
   void visit(const Let* v) override;
-  void visit(const LetStmt* v) override;
   void visit(const Ramp* v) override;
   void visit(const Load* v) override;
-  void visit(const For* v) override;
-  void visit(const Block* v) override;
-  void visit(const Store* v) override;
   void visit(const Broadcast* v) override;
   void visit(const IfThenElse* v) override;
   void visit(const BaseCallNode* v) override;
-  void visit(const Allocate* v) override;
-  void visit(const Free* v) override;
-  void visit(const Cond* v) override;
   void visit(const Term* v) override;
   void visit(const Polynomial* v) override;
   void visit(const RoundOff* v) override;
   void visit(const ReduceOp* v) override;
+
+  void visit(const LetStmt* v) override;
+  void visit(const AtomicAdd* v) override;
+  void visit(const Store* v) override;
+  void visit(const For* v) override;
+  void visit(const Cond* v) override;
+  void visit(const Block* v) override;
+  void visit(const Allocate* v) override;
+  void visit(const Free* v) override;
 
   std::ostream& os() {
     return printer_os_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37305 [TensorExpr] Fix indendation in CudaPrinter.
* **#37304 [TensorExpr] Add IRPrinter::visit for AtomicAdd.**

Differential Revision: [D21245881](https://our.internmc.facebook.com/intern/diff/D21245881)