### PR TITLE
Ensure DataParallel replicas can be saved

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -647,7 +647,7 @@ class TestDataParallel(TestCase):
             def forward(self, x):
                 with self._testcase.assertWarnsRegex(
                         UserWarning,
-                        r"Calling \.zero_grad\(\) from a module that was passed to a nn\.DataParallel\(\) has no effect."):
+                        r"Calling \.zero_grad\(\) from a module created with nn\.DataParallel\(\) has no effect."):
                     self.zero_grad()
                 return x
 

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -1,8 +1,8 @@
 import contextlib
+import io
 import unittest
 from copy import deepcopy
 from collections import OrderedDict
-import io
 
 import torch
 from torch import nn
@@ -675,8 +675,10 @@ class TestDataParallel(TestCase):
     def test_save_replica_module(self):
         # DataParallel replicas can be saved (gh-37182)
         module = torch.nn.Linear(8, 8).cuda()
-        dpm = torch.nn.parallel.replicate(module, devices=[0, 1])
+        dpm = torch.nn.parallel.replicate(module, devices=[0, 1], detach=False)
         data = io.BytesIO()
+        torch.save(dpm, data)
+        dpm = torch.nn.parallel.replicate(module, devices=[0, 1], detach=True)
         torch.save(dpm, data)
 
 

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -2,6 +2,7 @@ import contextlib
 import unittest
 from copy import deepcopy
 from collections import OrderedDict
+import io
 
 import torch
 from torch import nn
@@ -668,6 +669,15 @@ class TestDataParallel(TestCase):
         model = dp.DataParallel(Model().cuda().to(dtype=torch.float32))
         input = torch.randn((8, 8), dtype=torch.float32, device="cuda")
         self.assertTrue(model(input).dtype is torch.float16)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    @skipIfRocm
+    def test_save_replica_module(self):
+        # DataParallel replicas can be saved (gh-37182)
+        module = torch.nn.Linear(8, 8).cuda()
+        dpm = torch.nn.parallel.replicate(module, devices=[0, 1])
+        data = io.BytesIO()
+        torch.save(dpm, data)
 
 
 if __name__ == '__main__':

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1124,7 +1124,7 @@ class Module(object):
         r"""Sets gradients of all model parameters to zero."""
         if getattr(self, '_is_replica', False):
             warnings.warn(
-                "Calling .zero_grad() from a module that was passed to a nn.DataParallel() has no effect. "
+                "Calling .zero_grad() from a module created with nn.DataParallel() has no effect. "
                 "The parameters are copied (in a differentiable manner) from the original module. "
                 "This means they are not leaf nodes in autograd and so don't accumulate gradients. "
                 "If you need gradients in your forward method, consider using autograd.grad instead.")

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict, namedtuple
 import functools
 import itertools
-import weakref
 import warnings
 
 import torch
@@ -1123,6 +1122,13 @@ class Module(object):
 
     def zero_grad(self):
         r"""Sets gradients of all model parameters to zero."""
+        if getattr(self, '_is_replica', False):
+            warnings.warn(
+                "Calling .zero_grad() from a module that was passed to a nn.DataParallel() has no effect. "
+                "The parameters are copied (in a differentiable manner) from the original module. "
+                "This means they are not leaf nodes in autograd and so don't accumulate gradients. "
+                "If you need gradients in your forward method, consider using autograd.grad instead.")
+
         for p in self.parameters():
             if p.grad is not None:
                 p.grad.detach_()
@@ -1190,21 +1196,6 @@ class Module(object):
         replica._parameters = OrderedDict()
         replica._buffers = replica._buffers.copy()
         replica._modules = replica._modules.copy()
-
-        # Warn users that gradients don't behave as expected on replica modules
-        old_zero_grad = replica.__class__.zero_grad
-        weak_self = weakref.ref(replica)
-
-        def zero_grad():
-            warnings.warn(
-                "Calling .zero_grad() from a module that was passed to a nn.DataParallel() has no effect. "
-                "The parameters are copied (in a differentiable manner) from the original module. "
-                "This means they are not leaf nodes in autograd and so don't accumulate gradients. "
-                "If you need gradients in your forward method, consider using autograd.grad instead.")
-            replica = weak_self()
-            if replica:
-                old_zero_grad(replica)
-
-        replica.zero_grad = zero_grad
+        replica._is_replica = True
 
         return replica


### PR DESCRIPTION
Fixes #37182

The `zero_grad` wrapper from `_replicate_for_data_parallel` can't be pickled. So instead, I set an attribute `_is_replica = True` and check for this in `Module.zero_grad`.