### PR TITLE
Fix `cdist` backward calculation for `p=2`

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -530,7 +530,7 @@ _(aten, ones_like) \
 _(aten, orgqr) \
 _(aten, ormqr) \
 _(aten, pairwise_distance) \
-_(aten, _sqrt_euclidean_dist) \
+_(aten, _euclidean_dist) \
 _(aten, pdist) \
 _(aten, cdist) \
 _(aten, permute) \

--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -530,6 +530,7 @@ _(aten, ones_like) \
 _(aten, orgqr) \
 _(aten, ormqr) \
 _(aten, pairwise_distance) \
+_(aten, _sqrt_euclidean_dist) \
 _(aten, pdist) \
 _(aten, cdist) \
 _(aten, permute) \

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -25,7 +25,7 @@ Tensor pdist(const Tensor& self, const double p) {
   return at::_pdist_forward(self.contiguous(), p);
 }
 
-Tensor _euclidean_dist_squared(const Tensor& x1, const Tensor& x2) {
+Tensor _euclidean_dist(const Tensor& x1, const Tensor& x2) {
   /** This function does the fist part of the euclidean distance calculation
    * We divide it in two steps to simplify dealing with subgradients in the 
    * backward step */
@@ -36,15 +36,8 @@ Tensor _euclidean_dist_squared(const Tensor& x1, const Tensor& x2) {
   Tensor x1_ = at::cat({x1.mul(-2), x1_norm, x1_pad}, -1);
   Tensor x2_ = at::cat({x2, x2_pad, x2_norm}, -1);
   Tensor result = x1_.matmul(x2_.transpose(-2, -1));
-  result.clamp_min_(0);
+  result.clamp_min_(0).sqrt_();
   return result;
-}
-
-Tensor _sqrt_euclidean_dist(const Tensor& dist) {
-  // We will define a custom backward for this part since
-  // the gradient for sqrt is not defined for x=0
-  dist.sqrt_();
-  return dist;
 }
 
 static Tensor cdist_impl(const Tensor& x1, const Tensor& x2, const double p, c10::optional<int64_t> compute_mode) {
@@ -97,12 +90,8 @@ static Tensor cdist_impl(const Tensor& x1, const Tensor& x2, const double p, c10
   } else if (c1 == 0) {
     result = at::zeros(output_shape, x1.options());
   } else if (p == 2 && (mode == 1 || (mode == 0 && (r1 > 25 || r2 > 25)))) {
-    Tensor dist;
-    if (expand_batch_product == 1) {
-        dist = at::_sqrt_euclidean_dist(_euclidean_dist_squared(x1, x2));
-    } else {
-        dist = at::_sqrt_euclidean_dist(_euclidean_dist_squared(tensor1_expanded, tensor2_expanded));
-    }
+    Tensor dist = (expand_batch_product == 1) ? at::_euclidean_dist(x1, x2) :
+                  at::_euclidean_dist(tensor1_expanded, tensor2_expanded);
     result = dist.view(output_shape);
   } else {
     result = at::empty(output_shape, x1.options());

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -33,7 +33,8 @@ Tensor euclidean_dist_out(const Tensor& x1, const Tensor& x2) {
   Tensor x1_ = at::cat({x1.mul(-2), x1_norm, x1_pad}, -1);
   Tensor x2_ = at::cat({x2, x2_pad, x2_norm}, -1);
   Tensor result = x1_.matmul(x2_.transpose(-2, -1));
-  result.clamp_min_(0).sqrt_();
+  // Clamp to an eps to avoid invalid gradients when `sqrt` output is 0
+  result.clamp_min_(1e-9).sqrt_();
   return result;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2273,7 +2273,7 @@
   use_c10_dispatcher: full
   supports_named_tensor: True
 
-- func: _sqrt_euclidean_dist(Tensor dist) -> Tensor
+- func: _euclidean_dist(Tensor x1, Tensor x2) -> Tensor
   use_c10_dispatcher: full
 
 - func: _cdist_forward(Tensor x1, Tensor x2, float p, int? compute_mode) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2273,6 +2273,9 @@
   use_c10_dispatcher: full
   supports_named_tensor: True
 
+- func: _sqrt_euclidean_dist(Tensor dist) -> Tensor
+  use_c10_dispatcher: full
+
 - func: _cdist_forward(Tensor x1, Tensor x2, float p, int? compute_mode) -> Tensor
   use_c10_dispatcher: full
   supports_named_tensor: True

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5289,7 +5289,6 @@ class TestAutogradDeviceType(TestCase):
             x = x - (((x - y) < eps).float() * 2 * eps)
             x.requires_grad = True
             y.requires_grad = True
-            f_args_variable = (x, y)
             dist = torch.cdist(x, y, p=2)
             # Do a backward pass to check that it is valid for large
             # matrices
@@ -5304,6 +5303,21 @@ class TestAutogradDeviceType(TestCase):
         _test_cdist_for_size((1, 1), (S, 1))
         _test_euclidean_large_cdist((2000, 5))
 
+    def test_cdist_same_inputs(self, device):
+        # Test to detect issues in cdist gradient calculation
+        # When the distances are 0
+        sizex = (1, 27, 32)
+        for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
+            x = torch.randn(sizex, device=device, dtype=torch.float)
+            dist_grad = torch.randn((1, 27, 27), device=device, dtype=torch.float)
+            y = x.clone()
+            eps = 1e-6
+            x.requires_grad = True
+            d = torch.cdist(x, y)
+            d.backward(dist_grad)
+            # Check that the backward passs does not contain invalid 
+            # values such as nan or inf
+            assert not torch.isnan(x.grad).any() and not torch.isinf(x.grad).any()
 
     def test_parameter_resize(self, device):
         asd = torch.nn.Parameter(torch.ones(16, device=device))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5317,7 +5317,7 @@ class TestAutogradDeviceType(TestCase):
             d.backward(dist_grad)
             # Check that the backward passs does not contain invalid 
             # values such as nan or inf
-            assert not torch.isnan(x.grad).any() and not torch.isinf(x.grad).any()
+            assert torch.isfinite(x.grad).all()
 
     def test_parameter_resize(self, device):
         asd = torch.nn.Parameter(torch.ones(16, device=device))

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -669,6 +669,9 @@
   self: not_implemented("_pdist_backward")
   pdist: not_implemented("_pdist_backward")
 
+- name: _sqrt_euclidean_dist(Tensor dist) -> Tensor
+  dist: sqrt_euclidean_dist_backward(grad, dist)
+
 - name: _cdist_forward(Tensor x1, Tensor x2, float p, int? compute_mode) -> Tensor
   x1: _cdist_backward(grad.contiguous(), x1, x2, p, result)
   x2: _cdist_backward(grad.transpose(-1, -2).contiguous(), x2, x1, p, result.transpose(-1, -2).contiguous())

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -669,8 +669,9 @@
   self: not_implemented("_pdist_backward")
   pdist: not_implemented("_pdist_backward")
 
-- name: _sqrt_euclidean_dist(Tensor dist) -> Tensor
-  dist: sqrt_euclidean_dist_backward(grad, dist)
+- name: _euclidean_dist(Tensor x1, Tensor x2) -> Tensor
+  x1: _euclidean_dist_backward(grad, x1, x2, 0, result)
+  x2: _euclidean_dist_backward(grad, x1, x2, 1, result)
 
 - name: _cdist_forward(Tensor x1, Tensor x2, float p, int? compute_mode) -> Tensor
   x1: _cdist_backward(grad.contiguous(), x1, x2, p, result)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -670,8 +670,7 @@
   pdist: not_implemented("_pdist_backward")
 
 - name: _euclidean_dist(Tensor x1, Tensor x2) -> Tensor
-  x1: _euclidean_dist_backward(grad, x1, x2, 0, result)
-  x2: _euclidean_dist_backward(grad, x1, x2, 1, result)
+  x1, x2: _euclidean_dist_backward(grad, x1, x2, result)
 
 - name: _cdist_forward(Tensor x1, Tensor x2, float p, int? compute_mode) -> Tensor
   x1: _cdist_backward(grad.contiguous(), x1, x2, p, result)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -90,6 +90,13 @@ int64_t _safe_size(IntArrayRef sizes, IntArrayRef dim) {
   return size;
 }
 
+Tensor sqrt_euclidean_dist_backward(const Tensor & grad, const Tensor & self) {
+  // handle case at 0 where we return a subgradient containing 0
+  Tensor result = grad / (2 * self);
+  result.masked_fill_(self == 0, 0);
+  return result;
+}
+
 Tensor norm_backward(const Tensor & grad, const Tensor & self, const optional<Scalar> & p_, const Tensor & norm) {
   double p = p_.value_or(2.0).toDouble();
   Tensor self_scaled;

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -90,15 +90,13 @@ int64_t _safe_size(IntArrayRef sizes, IntArrayRef dim) {
   return size;
 }
 
-Tensor _euclidean_dist_backward(const Tensor & grad, const Tensor & x1, const Tensor & x2, int input, const Tensor & res) {
+std::tuple<Tensor, Tensor> _euclidean_dist_backward(const Tensor & grad, const Tensor & x1, const Tensor & x2, const Tensor & res) {
   // handle case at 0 where we return a subgradient containing 0
   Tensor ratio = grad / res;
   ratio.masked_fill_(res == 0, 0);
-  if (input == 0) {
-    return (x1 * ratio.sum(-1, true) - ratio.matmul(x2));
-  } else {
-    return (x2 * ratio.sum(-2, false).unsqueeze(-1) - ratio.transpose(-2, -1).matmul(x1));
-  }
+  return std::tuple<Tensor, Tensor>{
+            x1 * ratio.sum(-1, true) - ratio.matmul(x2),
+            x2 * ratio.sum(-2, false).unsqueeze(-1) - ratio.transpose(-2, -1).matmul(x1)};
 }
 
 Tensor norm_backward(const Tensor & grad, const Tensor & self, const optional<Scalar> & p_, const Tensor & norm) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -90,11 +90,15 @@ int64_t _safe_size(IntArrayRef sizes, IntArrayRef dim) {
   return size;
 }
 
-Tensor sqrt_euclidean_dist_backward(const Tensor & grad, const Tensor & self) {
+Tensor _euclidean_dist_backward(const Tensor & grad, const Tensor & x1, const Tensor & x2, int input, const Tensor & res) {
   // handle case at 0 where we return a subgradient containing 0
-  Tensor result = grad / (2 * self);
-  result.masked_fill_(self == 0, 0);
-  return result;
+  Tensor ratio = grad / res;
+  ratio.masked_fill_(res == 0, 0);
+  if (input == 0) {
+    return (x1 * ratio.sum(-1, true) - ratio.matmul(x2));
+  } else {
+    return (x2 * ratio.sum(-2, false).unsqueeze(-1) - ratio.transpose(-2, -1).matmul(x1));
+  }
 }
 
 Tensor norm_backward(const Tensor & grad, const Tensor & self, const optional<Scalar> & p_, const Tensor & norm) {


### PR DESCRIPTION
Closes #37154

Fixes a bug in `cdist` backward with `p=2`.
Under some circumstances, if the output has 0s, the gradient calculation of `sqrt` will be undefined. Leading to NaNs in the input gradients.

This PR defines a subgradient for this case.

A test is also added to verify this behavior, I was only able to reproduce it under certain shapes, so the shape is explicitly taken from #37154 example