### PR TITLE
Make Optimizer.state_dict() nondeterministic

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -162,6 +162,10 @@ class TestOptim(TestCase):
         self.assertEqual(state_dict, state_dict_c)
         # Make sure state dict is deterministic with equal but not identical parameters
         self.assertEqual(optimizer.state_dict(), optimizer_c.state_dict())
+        # Make sure repeated parameters have identical representation in state dict
+        optimizer_c.param_groups.extend(optimizer_c.param_groups)
+        self.assertEqual(optimizer.state_dict()['param_groups'][-1],
+                         optimizer_c.state_dict()['param_groups'][-1])
 
         # Check that state dict can be loaded even when we cast parameters
         # to a different type and move to a different device.

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -160,6 +160,8 @@ class TestOptim(TestCase):
             self.assertEqual(bias, bias_c)
         # Make sure state dict wasn't modified
         self.assertEqual(state_dict, state_dict_c)
+        # Make sure state dict is deterministic with equal but not identical parameters
+        self.assertEqual(optimizer.state_dict(), optimizer_c.state_dict())
 
         # Check that state dict can be loaded even when we cast parameters
         # to a different type and move to a different device.

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -80,14 +80,20 @@ class Optimizer(object):
             differs between optimizer classes.
         * param_groups - a dict containing all parameter groups
         """
-        # Save ids instead of Tensors
+        # Save order indices instead of Tensors
+        param_mappings = {}
+        start_index = 0
+
         def pack_group(group):
+            nonlocal start_index
             packed = {k: v for k, v in group.items() if k != 'params'}
-            packed['params'] = [id(p) for p in group['params']]
+            param_mappings.update({id(p): i for i, p in enumerate(group['params'], start_index)})
+            packed['params'] = [param_mappings[id(p)] for p in group['params']]
+            start_index += len(packed['params'])
             return packed
         param_groups = [pack_group(g) for g in self.param_groups]
-        # Remap state to use ids as keys
-        packed_state = {(id(k) if isinstance(k, torch.Tensor) else k): v
+        # Remap state to use order indices as keys
+        packed_state = {(param_mappings[id(k)] if isinstance(k, torch.Tensor) else k): v
                         for k, v in self.state.items()}
         return {
             'state': packed_state,

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -87,7 +87,8 @@ class Optimizer(object):
         def pack_group(group):
             nonlocal start_index
             packed = {k: v for k, v in group.items() if k != 'params'}
-            param_mappings.update({id(p): i for i, p in enumerate(group['params'], start_index)})
+            param_mappings.update({id(p): i for i, p in enumerate(group['params'], start_index)
+                                   if id(p) not in param_mappings})
             packed['params'] = [param_mappings[id(p)] for p in group['params']]
             start_index += len(packed['params'])
             return packed


### PR DESCRIPTION
Fixes #36831.

Instead of using `id()`, an arbitrary yet consistent order-based index is used instead. This results in a deterministic output between runs.

I am not the biggest fan of using `nonlocal` (it appears to be used sparingly in the codebase) to get `start_index` between calls to `pack_group()`, but the alternatives had larger issues:
- Using the last value added to `param_mappings` would be ideal, but that only works if `dict` iteration order is consistent, and PyTorch currently supports Python <3.7.
- Using the maximum value added to `param_mappings` wouldn't have that issue but would not be constant time.

For testing, I confirmed that `test_optim.py` works before and after these changes. Randomizing the indices in `param_mappings` causes the tests to fail, which is further evidence these changes work. I'm not 100% if these tests are sufficient, but they're a start.