### PR TITLE
add fmt, take 7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -122,3 +122,7 @@
     ignore = dirty
     path = third_party/XNNPACK
     url = https://github.com/google/XNNPACK.git
+[submodule "third_party/fmt"]
+    ignore = dirty
+	path = third_party/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1738,6 +1738,7 @@ cc_library(
         "@foxi",
         "@gloo",
         "@onnx",
+        "@fmt",
     ] + if_cuda(
         [
             ":caffe2_cpp_cuda",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,6 +113,12 @@ new_local_repository(
     path = "third_party/sleef",
 )
 
+new_local_repository(
+    name = "fmt",
+    build_file = "//third_party:fmt.BUILD",
+    path = "third_party/fmt",
+)
+
 new_patched_local_repository(
     name = "tbb",
     patches = [

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -596,7 +596,7 @@ if(USE_FBGEMM)
   caffe2_update_option(USE_FBGEMM ON)
 else()
   caffe2_update_option(USE_FBGEMM OFF)
-  message(WARNING 
+  message(WARNING
     "Turning USE_FAKELOWP off as it depends on USE_FBGEMM.")
   caffe2_update_option(USE_FAKELOWP OFF)
 endif()
@@ -1552,3 +1552,16 @@ endif()
 #
 # End ATen checks
 #
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/fmt)
+
+# Disable compiler feature checks for `fmt`.
+#
+# CMake compiles a little program to check compiler features. Some of our build
+# configurations (notably the mobile build analyzer) will populate
+# CMAKE_CXX_FLAGS in ways that break feature checks. Since we already know
+# `fmt` is compatible with a superset of the compilers that PyTorch is, it
+# shouldn't be too bad to just disable the checks.
+set_target_properties(fmt-header-only PROPERTIES INTERFACE_COMPILE_FEATURES "")
+
+list(APPEND Caffe2_DEPENDENCY_LIBS fmt::fmt-header-only)

--- a/third_party/fmt.BUILD
+++ b/third_party/fmt.BUILD
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "fmt",
+    hdrs = glob(["include/fmt/*.h",]),
+    defines = ["FMT_HEADER_ONLY=1"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -17,6 +17,7 @@
 #include <caffe2/serialize/istream_adapter.h>
 
 #include <ATen/ATen.h>
+#include <fmt/format.h>
 
 #include <fstream>
 #include <string>
@@ -44,12 +45,11 @@ void postSetStateValidate(const IValue& v) {
     if (attrType->kind() != TypeKind::OptionalType) {
       TORCH_CHECK(
           !slot.isNone(),
-          "The field '",
-          attrName,
-          "' was left unitialized after __setstate__, but expected a ",
-          "value of type '",
-          attrType->python_str(),
-          "'");
+          fmt::format(
+              "The field '{}' was left uninitialized after '__setstate__', "
+              "but expected a value of type '{}'",
+              attrName,
+              attrType->python_str()));
     }
   }
 }


### PR DESCRIPTION
fmt is a formatting library for C++. It has several properties that make it nice
for inclusion in PyTorch:
- Widely used
- Basically copies how Python does it
- Support for all the compilers and platforms we care about
- Standards track (C++20)
- Small code size
- Header only

This PR includes it as a submodule and sets up the build. 