### PR TITLE
[caffe2] Fast path for single tensor in UnPackRecordsOp

### DIFF
--- a/caffe2/operators/dataset_ops.cc
+++ b/caffe2/operators/dataset_ops.cc
@@ -388,13 +388,19 @@ class UnPackRecordsOp : public Operator<CPUContext> {
       for (int i = 0; i < numRows; i++) {
         data_ptr->emplace_back(*inputs[i]);
       }
-    } else {
+    } else if (Input(0).IsType<Shared2DTensorVectorPtr>()) {
       CAFFE_ENFORCE_EQ(Input(0).numel(), 1);
       const auto* inputs = Input(0).template data<Shared2DTensorVectorPtr>();
       CAFFE_ENFORCE(inputs[0] != nullptr);
       data_ptr = inputs[0];
       numRows = inputs[0]->size();
       CAFFE_ENFORCE_GE(numRows, 0);
+    } else {
+      // input contains a single tensor
+      CAFFE_ENFORCE_EQ(InputSize(), 1);
+      CAFFE_ENFORCE_EQ(OutputSize(), 1);
+      *Output(0) = Input(0);
+      return true;
     }
 
     auto numTensors = OutputSize();


### PR DESCRIPTION
Summary: Add a fast path for the case of batch_size = 1 and single ad embedding in UnPackRecordsOp. In this case, there is no need to pack the single tensor into a shared_ptr<vector<vector<Tensor>>> and then unpack it in UnPackRecordsOp. Instead, we can just pass the tensor as it is into UnPackRecordsOp and share the data with the output tensor.

Reviewed By: yinghai

Differential Revision: D21224497

