### PR TITLE
[TensorExpr] IRPrinter: show output_args separate from reduce_args when printing ReduceOp.

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -332,8 +332,10 @@ void IRPrinter::visit(const ReduceOp* v) {
   os() << "ReduceOp(";
   os() << *v->accumulator() << ", ";
   os() << *v->initializer() << ", ";
-  os() << v->complete() << ", {";
+  os() << v->complete() << ", ";
+
   bool first = true;
+  os() << "out_args={";
   for (auto* d : v->output_args()) {
     if (!first) {
       os() << ", ";
@@ -341,8 +343,10 @@ void IRPrinter::visit(const ReduceOp* v) {
     os() << *d;
     first = false;
   }
-  first = true;
+  os() << "}, ";
 
+  first = true;
+  os() << "reduce_args={";
   for (auto* d : v->reduce_args()) {
     if (!first) {
       os() << ", ";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37367 [TensorExpr] IRPrinter: show output_args separate from reduce_args when printing ReduceOp.**

Before this change we printed all the args in the same list, for example:
```
BEFORE RFACTOR:
{
  for (int m = 0; m < m_1; m++) {
    for (int n = 0; n < n_1; n++) {
      sum[0] = ReduceOp(sum, float(0), (sum[0]) + (b[m, n]), {m, n});
    }
  }
}
AFTER RFACTOR:
{
  for (int m = 0; m < m_1; m++) {
    for (int n = 0; n < n_1; n++) {
      tmp_buf[n] = ReduceOp(tmp_buf, float(0), (tmp_buf[n]) + (b[m, n]), {nm}); # <<< n is out, m is reduce here
    }
  }
  for (int n = 0; n < n_1; n++) {
    sum[0] = ReduceOp(sum, float(0), (sum[0]) + (tmp_buf[n]), {n});
  }
}
```

With this change we explicitly show which args are reduce args:
```
BEFORE RFACTOR:
{
  for (int m = 0; m < m_1; m++) {
    for (int n = 0; n < n_1; n++) {
      sum[0] = ReduceOp(sum, float(0), (sum[0]) + (b[m, n]), out_args={}, reduce_args={m, n});
    }
  }
}
AFTER RFACTOR:
{
  for (int m = 0; m < m_1; m++) {
    for (int n = 0; n < n_1; n++) {
      tmp_buf[n] = ReduceOp(tmp_buf, float(0), (tmp_buf[n]) + (b[m, n]), out_args={n}, reduce_args={m});
    }
  }
  for (int n = 0; n < n_1; n++) {
    sum[0] = ReduceOp(sum, float(0), (sum[0]) + (tmp_buf[n]), out_args={}, reduce_args={n});
  }
}
```

Differential Revision: [D21265807](https://our.internmc.facebook.com/intern/diff/D21265807)