### PR TITLE
implement L2 regularization for Adagrad in caffe2 and dper

### DIFF
--- a/caffe2/perfkernels/adagrad.cc
+++ b/caffe2/perfkernels/adagrad.cc
@@ -15,8 +15,10 @@ void adagrad_update__base(
     float* nh,
     float epsilon,
     float decay,
-    const float lr) {
-  internal::adagrad_update_base_inlined(N, w, g, h, nw, nh, decay, epsilon, lr);
+    const float lr,
+    const float weight_decay = 0.f) {
+  internal::adagrad_update_base_inlined(
+      N, w, g, h, nw, nh, decay, epsilon, lr, weight_decay);
 }
 
 void adagrad_update_prefetch__base(
@@ -36,8 +38,9 @@ void adagrad_update_prefetch__base(
     float* /* nh_n */, // prefetch ptr
 
     float epsilon,
-    float lr) {
-  adagrad_update__base(N, w, g, h, nw, nh, epsilon, 1.0f, lr);
+    float lr,
+    float weight_decay = 0.f) {
+  adagrad_update__base(N, w, g, h, nw, nh, epsilon, 1.0f, lr, weight_decay);
 }
 
 void adagrad_fp16_update_prefetch__base(
@@ -52,8 +55,10 @@ void adagrad_fp16_update_prefetch__base(
     at::Half* nh,
     at::Half* /* nh_n */, // prefetch ptr
     float epsilon,
-    float lr) {
-  internal::adagrad_update_base_inlined(N, w, g, h, nw, nh, 1.0f, epsilon, lr);
+    float lr,
+    float weight_decay = 0.f) {
+  internal::adagrad_update_base_inlined(
+      N, w, g, h, nw, nh, 1.0f, epsilon, lr, weight_decay);
 }
 
 // version without prefetching
@@ -67,9 +72,11 @@ void adagrad_update(
     float* nh,
     float epsilon,
     float decay,
-    float lr) {
-  AVX_F16C_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
-  BASE_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
+    float lr,
+    float weight_decay) {
+  AVX_F16C_DO(
+      adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
+  BASE_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
 }
 
 decltype(adagrad_update_prefetch__base) adagrad_update_prefetch__avx_f16c;
@@ -90,7 +97,8 @@ void adagrad_update_prefetch(
     float* nh_n, // prefetch ptr
 
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay) {
   AVX_F16C_DO(
       adagrad_update_prefetch,
       N,
@@ -104,7 +112,8 @@ void adagrad_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
   BASE_DO(
       adagrad_update_prefetch,
       N,
@@ -118,7 +127,8 @@ void adagrad_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
 }
 
 // Version with prefetching for embeddings and
@@ -137,7 +147,8 @@ void adagrad_fp16_update_prefetch(
     at::Half* nh,
     at::Half* nh_n, // prefetch ptr
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay) {
   AVX_F16C_DO(
       adagrad_fp16_update_prefetch,
       N,
@@ -151,7 +162,8 @@ void adagrad_fp16_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
   BASE_DO(
       adagrad_fp16_update_prefetch,
       N,
@@ -165,7 +177,8 @@ void adagrad_fp16_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
 }
 
 } // namespace caffe2

--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -24,9 +24,10 @@ static inline void adagrad_update_base_inlined(
     T* nh,
     float decay,
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   for (auto i = 0; i < N; ++i) {
-    float gi = g[i];
+    float gi = std::fma(weight_decay, w[i], g[i]);
     float hi = decay * h[i] + gi * gi;
     nh[i] = hi;
     nw[i] = w[i] + lr * gi / (std::sqrt(hi) + epsilon);
@@ -83,7 +84,8 @@ inline void adagrad_update_prefetch_inlined(
 #endif
 
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   auto i = 0;
 
 #ifdef CAFFE2_PERFKERNELS_ADAGRAD_H_USE_INTRINSIC
@@ -94,9 +96,10 @@ inline void adagrad_update_prefetch_inlined(
     _mm_prefetch(reinterpret_cast<const char*>(&nw_n[i]), _MM_HINT_T0);
     _mm_prefetch(reinterpret_cast<const char*>(&nh_n[i]), _MM_HINT_T0);
 
-    __m256 gi = _mm256_loadu_ps(g + i);
     __m256 hi = _mm256_loadu_ps(h + i);
     __m256 wi = _mm256_loadu_ps(w + i);
+    __m256 gi = _mm256_fmadd_ps(
+        _mm256_set1_ps(weight_decay), wi, _mm256_loadu_ps(g + i));
 
     __m256 nhi = _mm256_add_ps(hi, _mm256_mul_ps(gi, gi));
     _mm256_storeu_ps(nh + i, nhi);
@@ -108,7 +111,16 @@ inline void adagrad_update_prefetch_inlined(
 #endif
 
   adagrad_update_base_inlined(
-      N - i, w + i, g + i, h + i, nw + i, nh + i, 1.0f, epsilon, lr);
+      N - i,
+      w + i,
+      g + i,
+      h + i,
+      nw + i,
+      nh + i,
+      1.0f,
+      epsilon,
+      lr,
+      weight_decay);
 }
 
 } // namespace internal
@@ -147,7 +159,8 @@ void adagrad_update_prefetch(
     float* nh_n, // prefetch ptr
 
     float epsilon,
-    float lr);
+    float lr,
+    float weight_decay = 0.f);
 
 // Version with prefetching for embeddings and
 // momentum using fp16
@@ -163,7 +176,8 @@ void adagrad_fp16_update_prefetch(
     at::Half* nh,
     at::Half* nh_n, // prefetch ptr
     float epsilon,
-    float lr);
+    float lr,
+    float weight_decay = 0.f);
 
 // version without prefetching
 void adagrad_update(
@@ -175,7 +189,8 @@ void adagrad_update(
     float* nh,
     float epsilon,
     float decay,
-    float lr);
+    float lr,
+    float weight_decay = 0.f);
 
 } // namespace caffe2
 

--- a/caffe2/perfkernels/adagrad_avx.cc
+++ b/caffe2/perfkernels/adagrad_avx.cc
@@ -16,13 +16,15 @@ void adagrad_update__avx_f16c(
     float* nh,
     float epsilon,
     float decay,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   constexpr size_t kSize = 8;
   auto i = 0;
   for (; i + kSize <= N; i += kSize) {
-    __m256 gi = _mm256_loadu_ps(g + i);
     __m256 hi = _mm256_loadu_ps(h + i);
     __m256 wi = _mm256_loadu_ps(w + i);
+    __m256 gi = _mm256_fmadd_ps(
+        _mm256_set1_ps(weight_decay), wi, _mm256_loadu_ps(g + i));
 
     __m256 nhi = _mm256_add_ps(
         _mm256_mul_ps(_mm256_set1_ps(decay), hi), _mm256_mul_ps(gi, gi));
@@ -34,7 +36,7 @@ void adagrad_update__avx_f16c(
   }
 
   for (; i < N; ++i) {
-    float gi = g[i];
+    float gi = std::fma(weight_decay, w[i], g[i]);
     float hi = nh[i] = decay * h[i] + gi * gi;
     nw[i] = w[i] + lr * gi / (std::sqrt(hi) + epsilon);
   }
@@ -57,9 +59,10 @@ void adagrad_update_prefetch__avx_f16c(
     float* nh_n, // prefetch ptr
 
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   internal::adagrad_update_prefetch_inlined(
-      N, w, w_n, g, h, h_n, nw, nw_n, nh, nh_n, epsilon, lr);
+      N, w, w_n, g, h, h_n, nw, nw_n, nh, nh_n, epsilon, lr, weight_decay);
 }
 
 // Compute adagrad sparse, assumes embedding and momentum are at::Half
@@ -75,7 +78,8 @@ void adagrad_fp16_update_prefetch__avx_f16c(
     at::Half* nh,
     at::Half* nh_n, // prefetch ptr
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   constexpr int kSize = 8;
   auto i = 0;
   for (; i + kSize <= N; i += kSize) {
@@ -85,11 +89,13 @@ void adagrad_fp16_update_prefetch__avx_f16c(
     _mm_prefetch(reinterpret_cast<const char*>(&nh_n[i]), _MM_HINT_T0);
 
     // only convert momentum and embedding, gradient is fp32
-    __m256 gi = _mm256_loadu_ps(g + i);
     __m128i hhi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(h + i));
     __m256 hi = _mm256_cvtph_ps(hhi);
     __m128i whi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w + i));
     __m256 wi = _mm256_cvtph_ps(whi);
+    __m256 gi = _mm256_add_ps(
+        _mm256_loadu_ps(g + i),
+        _mm256_mul_ps(wi, _mm256_set1_ps(weight_decay)));
 
     __m256 nhi = _mm256_add_ps(hi, _mm256_mul_ps(gi, gi));
     __m128i nhhi = _mm256_cvtps_ph(nhi, 0);
@@ -104,7 +110,10 @@ void adagrad_fp16_update_prefetch__avx_f16c(
   }
 
   for (; i < N; ++i) {
-    float gi = g[i];
+    float gi = std::fma(
+        weight_decay,
+        _cvtsh_ss(reinterpret_cast<const unsigned short*>(w)[i]),
+        g[i]);
     float nhi =
         _cvtsh_ss(reinterpret_cast<const unsigned short*>(h)[i]) + gi * gi;
     reinterpret_cast<unsigned short*>(nh)[i] = _cvtss_sh(nhi, 0);

--- a/caffe2/sgd/adagrad_fused.h
+++ b/caffe2/sgd/adagrad_fused.h
@@ -20,6 +20,8 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "SparseAdagradFusedWithSparseLengthsSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -148,6 +150,8 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -315,6 +319,9 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO)
+        << "gradient optimization operator in use: "
+        << "SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -19,8 +19,10 @@ void adagrad_update(
     float epsilon,
     float decay,
     const float* lr,
-    Context* /*context*/) {
-  return adagrad_update(N, w, g, h, nw, nh, epsilon, decay, lr[0]);
+    Context* /*context*/,
+    float weight_decay = 0.f) {
+  return adagrad_update(
+      N, w, g, h, nw, nh, epsilon, decay, lr[0], weight_decay);
 }
 
 template <typename Context>
@@ -35,13 +37,14 @@ void adagrad_update_output_effective_lr(
     float epsilon,
     float decay,
     const float* lr,
-    Context* /*context*/) {
+    Context* /*context*/,
+    float weight_decay = 0.f) {
   for (auto i = 0; i < N; ++i) {
-    float grad = gradIn[i];
+    float grad = std::fma(weight_decay, paramIn[i], gradIn[i]);
     float moment = momentOut[i] = decay * momentIn[i] + grad * grad;
     float effective_lr = effectiveLROut[i] =
         lr[0] / (std::sqrt(moment) + epsilon);
-    paramOut[i] = paramIn[i] + effective_lr * grad;
+    paramOut[i] = std::fma(effective_lr, grad, paramIn[i]);
   }
 }
 
@@ -58,9 +61,10 @@ void adagrad_update_output_effective_lr_and_update(
     float epsilon,
     float decay,
     const float* lr,
-    Context* /*context*/) {
+    Context* /*context*/,
+    float weight_decay = 0.f) {
   for (auto i = 0; i < N; ++i) {
-    float grad = gradIn[i];
+    float grad = std::fma(weight_decay, paramIn[i], gradIn[i]);
     float moment = momentOut[i] = decay * momentIn[i] + grad * grad;
     float effective_lr = effectiveLROut[i] =
         lr[0] / (std::sqrt(moment) + epsilon);
@@ -76,7 +80,13 @@ class AdagradOp final : public Operator<Context> {
   AdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
-        decay_(this->template GetSingleArgument<float>("decay", 1.0f)) {}
+        decay_(this->template GetSingleArgument<float>("decay", 1.0f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "AdagradOp"
+              << " weight_decay_=" << weight_decay_;
+  }
 
   bool RunOnDevice() override {
     CAFFE_ENFORCE_EQ(
@@ -105,7 +115,8 @@ class AdagradOp final : public Operator<Context> {
           epsilon_,
           decay_,
           Input(LR).template data<float>(),
-          &context_);
+          &context_,
+          weight_decay_);
     } else if (OutputSize() == 3) {
       Output(OUTPUT_EFFECTIVE_LR)->ResizeLike(Input(GRAD));
       adagrad_update_output_effective_lr<Context>(
@@ -119,7 +130,8 @@ class AdagradOp final : public Operator<Context> {
           epsilon_,
           decay_,
           Input(LR).template data<float>(),
-          &context_);
+          &context_,
+          weight_decay_);
     } else {
       Output(OUTPUT_EFFECTIVE_LR)->ResizeLike(Input(GRAD));
       Output(OUTPUT_UPDATE)->ResizeLike(Input(GRAD));
@@ -135,7 +147,8 @@ class AdagradOp final : public Operator<Context> {
           epsilon_,
           decay_,
           Input(LR).template data<float>(),
-          &context_);
+          &context_,
+          weight_decay_);
     }
 
     return true;
@@ -144,6 +157,7 @@ class AdagradOp final : public Operator<Context> {
  protected:
   float epsilon_;
   float decay_;
+  float weight_decay_;
   INPUT_TAGS(PARAM, MOMENT_1, GRAD, LR);
   OUTPUT_TAGS(
       OUTPUT_PARAM,
@@ -156,7 +170,12 @@ class SparseAdagradOp final : public Operator<CPUContext> {
  public:
   SparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "SparseAdagradOp"
+              << " weight_decay_=" << weight_decay_;
     const float decay = this->template GetSingleArgument<float>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -207,6 +226,9 @@ class SparseAdagradOp final : public Operator<CPUContext> {
         n);
 
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
+    LOG_FIRST_N(INFO, 1)
+        << "using fbgemm::GenerateSparseAdaGrad in SparseAdagradOp";
+
     if (block_size != last_block_size_) {
       last_block_size_ = block_size;
       if (std::is_same<SIndex, std::int32_t>::value) {
@@ -227,7 +249,8 @@ class SparseAdagradOp final : public Operator<CPUContext> {
           momentOut,
           reinterpret_cast<const std::int32_t*>(indices),
           epsilon_,
-          lr[0]);
+          lr[0],
+          weight_decay_);
     } else {
       num_rows_processed = kernel_i64_(
           n,
@@ -237,7 +260,8 @@ class SparseAdagradOp final : public Operator<CPUContext> {
           momentOut,
           reinterpret_cast<const std::int64_t*>(indices),
           epsilon_,
-          lr[0]);
+          lr[0],
+          weight_decay_);
     }
     if (num_rows_processed < n) {
       CAFFE_ENFORCE_GE(
@@ -257,6 +281,9 @@ class SparseAdagradOp final : public Operator<CPUContext> {
       return true;
     }
 #endif
+
+    LOG_FIRST_N(INFO, 1)
+        << "using internal::adagrad_update_prefetch_inlined in SparseAdagradOp";
 
     const auto* paramIn = Input(PARAM).template data<float>();
     const auto* momentIn = Input(MOMENT_1).template data<float>();
@@ -284,8 +311,8 @@ class SparseAdagradOp final : public Operator<CPUContext> {
           Input(PARAM).numel());
 
       if (block_size == 1) {
-        float gi = gradIn[i];
-        float hi = momentOut[idx] = momentIn[idx] + gi * gi;
+        float gi = std::fma(weight_decay_, paramIn[idx], gradIn[i]);
+        float hi = momentOut[idx] = std::fma(gi, gi, momentIn[idx]);
         paramOut[idx] = paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
       } else {
         // prefetching
@@ -305,7 +332,8 @@ class SparseAdagradOp final : public Operator<CPUContext> {
             momentOut + offsetIdx,
             &momentOut[idx_pref * block_size],
             epsilon_,
-            lr[0]);
+            lr[0],
+            weight_decay_);
       }
     }
     return true;
@@ -313,6 +341,7 @@ class SparseAdagradOp final : public Operator<CPUContext> {
 
  protected:
   float epsilon_;
+  float weight_decay_;
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
   fbgemm::SparseAdaGradSignature<std::int32_t>::Type kernel_i32_;
   fbgemm::SparseAdaGradSignature<std::int64_t>::Type kernel_i64_;
@@ -329,7 +358,13 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   RowWiseSparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {}
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "RowWiseSparseAdagradOp"
+              << " weight_decay_=" << weight_decay_;
+  }
 
   bool RunOnDevice() override {
     // Enforce shapes
@@ -381,6 +416,9 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
         n);
 
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
+    LOG_FIRST_N(INFO, 1)
+        << "using fbgemm::GenerateSparseAdaGrad in RowWiseSparseAdagradOp";
+
     if (block_size != last_block_size_) {
       last_block_size_ = block_size;
       if (std::is_same<SIndex, std::int32_t>::value) {
@@ -403,7 +441,8 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
           moment,
           reinterpret_cast<const std::int32_t*>(indices),
           epsilon_,
-          lr[0]);
+          lr[0],
+          weight_decay_);
     } else {
       num_rows_processed = kernel_i64_(
           n,
@@ -413,7 +452,8 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
           moment,
           reinterpret_cast<const std::int64_t*>(indices),
           epsilon_,
-          lr[0]);
+          lr[0],
+          weight_decay_);
     }
 
     if (num_rows_processed < n) {
@@ -436,11 +476,14 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
       return true;
     }
 #else
+    LOG_FIRST_N(INFO, 1)
+        << "using plain adagrad updates in RowWiseSparseAdagradOp";
+
     for (auto i = 0; i < n; ++i) {
       auto idx = indices[i];
       if (block_size == 1) {
-        float gi = gradIn[i];
-        float hi = moment[idx] = moment[idx] + gi * gi;
+        float gi = std::fma(weight_decay_, param[idx], gradIn[i]);
+        float hi = moment[idx] = std::fma(gi, gi, moment[idx]);
         param[idx] = param[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
       } else {
         auto offsetI = i * block_size;
@@ -472,13 +515,14 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
         float* h = moment + idx;
         float hs = 0.;
         for (auto j = 0; j < block_size; ++j) {
-          float gj = g[j];
+          float gj = std::fma(weight_decay_, w[j], g[j]);
           hs += gj * gj;
         }
         float hi = h[0] = h[0] + hs / block_size;
         float step = lr[0] / (std::sqrt(hi) + epsilon_);
         for (auto j = 0; j < block_size; ++j) {
-          w[j] = w[j] + g[j] * step;
+          float gj = std::fma(weight_decay_, w[j], g[j]);
+          w[j] = std::fma(gj, step, w[j]);
         }
       }
     }
@@ -488,6 +532,7 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
 
  protected:
   float epsilon_;
+  float weight_decay_;
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
   fbgemm::SparseAdaGradSignature<std::int32_t>::Type kernel_i32_;
   fbgemm::SparseAdaGradSignature<std::int64_t>::Type kernel_i64_;

--- a/caffe2/sgd/adagrad_op_gpu.cu
+++ b/caffe2/sgd/adagrad_op_gpu.cu
@@ -16,9 +16,10 @@ __global__ void AdagradUpdate(
     float* nh,
     float epsilon,
     float decay,
-    const float* lr) {
+    const float* lr,
+    float weight_decay = 0.f) {
   CUDA_1D_KERNEL_LOOP(i, N) {
-    float gi = g[i];
+    float gi = g[i] + weight_decay * w[i];
     float hi = nh[i] = decay * h[i] + gi * gi;
     nw[i] = w[i] + lr[0] * gi / (sqrtf(hi) + epsilon);
   }
@@ -35,12 +36,14 @@ void adagrad_update<CUDAContext>(
     float epsilon,
     float decay,
     const float* lr,
-    CUDAContext* context) {
+    CUDAContext* context,
+    float weight_decay) {
   AdagradUpdate<<<
       CAFFE_GET_BLOCKS(N),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context->cuda_stream()>>>(N, w, g, h, nw, nh, epsilon, decay, lr);
+      context->cuda_stream()>>>(
+      N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
 }
 
 template <typename SIndex, typename THalf>
@@ -52,17 +55,18 @@ __global__ void SparseAdagradKernel(
     THalf* param_mom,
     const SIndex* indices,
     const float* grad,
-    const float* lr) {
+    const float* lr,
+    float weight_decay = 0.f) {
   const float LR = lr[0];
   CUDA_1D_KERNEL_LOOP(i, N) {
     const size_t gradIdx = i;
     const SIndex index = indices[i / grad_slice_sz];
     const size_t paramIdx = index * grad_slice_sz + (i % grad_slice_sz);
 
-    float mom_new = grad[gradIdx] * grad[gradIdx] + param_mom[paramIdx];
+    float gi = grad[gradIdx] + weight_decay * param[paramIdx];
+    float mom_new = gi * gi + param_mom[paramIdx];
     param_mom[paramIdx] = mom_new;
-    float param_new =
-        LR * grad[gradIdx] / (sqrtf(mom_new) + epsilon) + param[paramIdx];
+    float param_new = LR * gi / (sqrtf(mom_new) + epsilon) + param[paramIdx];
     param[paramIdx] = param_new;
   }
 }
@@ -85,7 +89,8 @@ __global__ void RowWiseSparseAdagradKernel(
     float* param_mom,
     const SIndex* indices,
     const float* grad,
-    const float* lr) {
+    const float* lr,
+    float weight_decay = 0.f) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ BlockReduce::TempStorage temp_storage;
   int valid = min(N, CAFFE_CUDA_NUM_THREADS);
@@ -97,7 +102,7 @@ __global__ void RowWiseSparseAdagradKernel(
 
     // in case N is bigger than block size which is 512 by default
     for (int j = threadIdx.x; j < N; j += blockDim.x) {
-      const float x_ij = grad[i * N + j];
+      const float x_ij = grad[i * N + j] + weight_decay * param[index * N + j];
       sum_squares += x_ij * x_ij;
     }
     float reduce_result = BlockReduce(temp_storage).Sum(sum_squares, valid);
@@ -109,7 +114,8 @@ __global__ void RowWiseSparseAdagradKernel(
     // update param
     float step = lr[0] / (sqrtf(param_mom[index]) + epsilon);
     for (int j = threadIdx.x; j < N; j += blockDim.x) {
-      param[index * N + j] = param[index * N + j] + grad[i * N + j] * step;
+      const float x_ij = grad[i * N + j] + weight_decay * param[index * N + j];
+      param[index * N + j] = param[index * N + j] + x_ij * step;
     }
   }
 }
@@ -120,7 +126,12 @@ class CUDASparseAdagradOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   CUDASparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "CUDASparseAdagradOp"
+              << " weight_decay_=" << weight_decay_;
     const T decay = this->template GetSingleArgument<T>("decay", 1.0f);
     CAFFE_ENFORCE_EQ(decay, 1.0, "Decay is not supported for SparseAdagradOp");
   }
@@ -175,12 +186,14 @@ class CUDASparseAdagradOp final : public Operator<Context> {
             Output(OUTPUT_MOMENT_1)->template mutable_data<THalf>(),
             Input(INDICES).template data<IndexType>(),
             Input(GRAD).template data<float>(),
-            Input(LR).template data<float>());
+            Input(LR).template data<float>(),
+            weight_decay_);
     return true;
   }
 
  protected:
   T epsilon_;
+  T weight_decay_;
   INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1);
 };
@@ -216,7 +229,8 @@ bool RowWiseSparseAdagradOp<CUDAContext>::DoRunWithType() {
       Output(OUTPUT_MOMENT_1)->template mutable_data<float>(),
       Input(INDICES).template data<SIndex>(),
       Input(GRAD).template data<float>(),
-      Input(LR).template data<float>());
+      Input(LR).template data<float>(),
+      weight_decay_);
   return true;
 }
 

--- a/caffe2/sgd/rowwise_adagrad_fused.h
+++ b/caffe2/sgd/rowwise_adagrad_fused.h
@@ -62,6 +62,8 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -239,7 +241,11 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {}
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO)
+        << "gradient optimization operator in use: "
+        << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp";
+  }
 
   bool RunOnDevice() override {
     // Enforce shapes
@@ -458,6 +464,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO)
+        << "gradient optimization operator in use: "
+        << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");


### PR DESCRIPTION
Summary:
Posted note: [Regularizing SparseNN Against Over-fitting](https://fb.workplace.com/notes/taiqing-wang/regularizing-sparsenn-against-over-fitting/220306075902708/)

**Problem formulation**

L(w) = J(w) + lambda/2 * ||w||^2
J(w) is the empirical loss, and ||w||^2 is the squared L2 norm of the parameters, a.k.a. L2 regularizer.

dL(w)/ dw_i = dJ(w)/dw_i + lambda w_i
dL(w)/ dw_i is the gradient of L(w) w.r.t. w_i.

To implement the L2 regularizer, the gradient of J(w) w.r.t. w_i is added with w_i. lambda is called as weight decay in this implementation.

**Code changes**
* In the initialization method of AdagradOptimizer, a new input argument, weight_decay, is added.
* In the _run function of AdagradOptimizer, the weight decay will be skipped for 1d bias vectors.
* In the parameter update functions of Adagrad, the gradient is updated by weight_decay * w_i. The default value for weight_decay is zero.

Test Plan:
`
buck build caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_weight_decay
`

`
./buck-out/gen/caffe2/caffe2/fb/dper/layer_models/tests/split_1/sparse_nn_test_weight_decay#binary.par
`

Differential Revision: D21258652

