### PR TITLE
WIP::Added out-of-tree support for Torch-Vitis FPGA kernels

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -368,10 +368,11 @@ def generate_storage_type_and_tensor(backend, density, declarations, per_op_regi
     if env['DeviceType'] == 'CPU':
         top_env['cpu_type_headers'].append(
             '#include <ATen/{}.h>'.format(env['Type']))
-    else:
-        assert env['DeviceType'] == 'CUDA'
+    elif env['DeviceType'] == 'CUDA':
         top_env['cuda_type_headers'].append(
             '#include <ATen/{}.h>'.format(env['Type']))
+    else:  # Allow gen.py to be called by out-of-tree devices
+        pass
 
 
 # yields (backend, density) tuples

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -78,7 +78,7 @@ void copy_same_type_transpose_(Tensor& self, const Tensor& src) {
 // (e.g. XLA) may be supported by overriding copy_ and _copy_from.
 bool is_supported_device(Device device) {
   DeviceType device_type = device.type();
-  return device_type == kCPU || device_type == kCUDA || device_type == kHIP;
+  return device_type == kCPU || device_type == kCUDA || device_type == kHIP || device_type == kFPGA;
 }
 
 } // namespace

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -80,6 +80,9 @@ struct CAFFE2_API DispatchStub<rT (*)(Args...), T> {
     } else if (device_type == DeviceType::HIP) {
       AT_ASSERTM(hip_dispatch_ptr, "DispatchStub: missing HIP kernel");
       return (*hip_dispatch_ptr)(std::forward<ArgTypes>(args)...);
+    } else if (device_type == DeviceType::FPGA) {
+      AT_ASSERTM(fpga_dispatch_ptr, "DispatchStub: missing FPGA kernel");
+      return (*fpga_dispatch_ptr)(std::forward<ArgTypes>(args)...);
     } else {
       AT_ERROR("DispatchStub: unsupported device type", device_type);
     }
@@ -110,10 +113,12 @@ struct CAFFE2_API DispatchStub<rT (*)(Args...), T> {
   std::atomic<FnPtr> cpu_dispatch_ptr;
   FnPtr cuda_dispatch_ptr;
   FnPtr hip_dispatch_ptr;
+  FnPtr fpga_dispatch_ptr;
 #else
   std::atomic<FnPtr> cpu_dispatch_ptr{nullptr};
   FnPtr cuda_dispatch_ptr = nullptr;
   FnPtr hip_dispatch_ptr = nullptr;
+  FnPtr fpga_dispatch_ptr = nullptr;
 #endif
   static FnPtr DEFAULT;
 #ifdef HAVE_AVX_CPU_DEFINITION
@@ -137,6 +142,13 @@ struct RegisterHIPDispatch {
   RegisterHIPDispatch(DispatchStub<FnPtr, T>& stub, FnPtr value) {
     // TODO: make this point at hip_dispatch_ptr
     stub.cuda_dispatch_ptr = value;
+  }
+};
+
+template <typename FnPtr, typename T>
+struct RegisterFPGADispatch {
+  RegisterFPGADispatch(DispatchStub<FnPtr, T>& stub, FnPtr value) {
+    stub.fpga_dispatch_ptr = value;
   }
 };
 } // anonymous namespace
@@ -181,6 +193,9 @@ struct RegisterHIPDispatch {
 
 #define REGISTER_HIP_DISPATCH(name, fn) \
   static RegisterHIPDispatch<decltype(fn), struct name> name ## __register(name, fn);
+
+#define REGISTER_FPGA_DISPATCH(name, fn) \
+  static RegisterFPGADispatch<decltype(fn), struct name> name ## __register(name, fn);
 
 // NB: This macro must be used in an actual 'cu' file; if you try using
 // it from a 'cpp' file it will not work!

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -331,7 +331,10 @@ Tensor& _clamp_out_cpu(
     const Tensor& self,
     optional<Scalar> min,
     optional<Scalar> max) {
+  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
   if (min && max) {
+    TORCH_CHECK(self.device().type() == DeviceType::CPU,
+                "clamp only supports CPU device type, got: ", self.device().type());
     TORCH_CHECK(self.layout() == Layout::Strided,
                 "clamp only supports strided layout, got: ", self.layout());
     auto iter = TensorIterator::unary_op(result, self,
@@ -348,10 +351,14 @@ Tensor& _clamp_out_cpu(
 }
 
 Tensor& _clamp_max__cpu(Tensor& self, Scalar max) {
+  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
   return clamp_max_out(self, self, max);
 }
 
 Tensor& _clamp_max_out_cpu(Tensor& result, const Tensor& self, Scalar max) {
+  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
+  TORCH_CHECK(self.device().type() == DeviceType::CPU,
+              "clamp_max only supports CPU device type, got: ", self.device().type());
   TORCH_CHECK(self.layout() == Layout::Strided,
               "clamp_max only supports strided layout, got: ", self.layout());
   auto iter = TensorIterator::unary_op(result, self,
@@ -361,10 +368,14 @@ Tensor& _clamp_max_out_cpu(Tensor& result, const Tensor& self, Scalar max) {
 }
 
 Tensor& _clamp_min__cpu(Tensor& self, Scalar min) {
+  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
   return clamp_min_out(self, self, min);
 }
 
 Tensor& _clamp_min_out_cpu(Tensor& result, const Tensor& self, Scalar min) {
+  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
+  TORCH_CHECK(self.device().type() == DeviceType::CPU,
+              "clamp_min only supports CPU device type, got: ", self.device().type());
   TORCH_CHECK(self.layout() == Layout::Strided,
               "clamp_min only supports strided layout, got: ", self.layout());
   auto iter = TensorIterator::unary_op(result, self,
@@ -410,6 +421,7 @@ Tensor& mvlgamma_(Tensor& self, int64_t p) {
     return at::op##_out(self, self);                                   \
   }                                                                    \
   Tensor& _##op##_out_##prefix(Tensor& result, const Tensor& self) {   \
+    checkDeviceType(#op, result, DeviceType::device);                  \
     checkLayout(#op, result, Layout::Strided);                         \
     auto iter = TensorIterator::unary_op(result, self,                 \
       /*check_mem_overlap=*/true);                                     \
@@ -426,23 +438,13 @@ Tensor& mvlgamma_(Tensor& self, int64_t p) {
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cpu, CPU)                         \
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cuda, CUDA)
 
-#define IMPLEMENT_UNARY_OP_VEC_FPGA(op)                                \
-  IMPLEMENT_UNARY_OP_CORE(op)                                          \
-  IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cpu, CPU)                         \
-  IMPLEMENT_UNARY_OP_OUT_INPLACE(op, fpga, FPGA)
-
 IMPLEMENT_UNARY_OP_VEC(atan)
-IMPLEMENT_UNARY_OP_VEC_FPGA(cos)
+IMPLEMENT_UNARY_OP_VEC(cos)
 IMPLEMENT_UNARY_OP_VEC(erf)
 IMPLEMENT_UNARY_OP_VEC(erfc)
 IMPLEMENT_UNARY_OP_VEC_CUDA(erfinv)
 IMPLEMENT_UNARY_OP_VEC(exp)
-<<<<<<< HEAD
 IMPLEMENT_UNARY_OP_VEC(tan)
-=======
-IMPLEMENT_UNARY_OP_VEC_FPGA(tan)
-IMPLEMENT_UNARY_OP_VEC(tanh)
->>>>>>> Added initial support for FPGA device
 IMPLEMENT_UNARY_OP_VEC_CUDA(lgamma)
 
 DEFINE_DISPATCH(abs_stub);

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -331,10 +331,7 @@ Tensor& _clamp_out_cpu(
     const Tensor& self,
     optional<Scalar> min,
     optional<Scalar> max) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
   if (min && max) {
-    TORCH_CHECK(self.device().type() == DeviceType::CPU,
-                "clamp only supports CPU device type, got: ", self.device().type());
     TORCH_CHECK(self.layout() == Layout::Strided,
                 "clamp only supports strided layout, got: ", self.layout());
     auto iter = TensorIterator::unary_op(result, self,
@@ -351,14 +348,10 @@ Tensor& _clamp_out_cpu(
 }
 
 Tensor& _clamp_max__cpu(Tensor& self, Scalar max) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
   return clamp_max_out(self, self, max);
 }
 
 Tensor& _clamp_max_out_cpu(Tensor& result, const Tensor& self, Scalar max) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
-  TORCH_CHECK(self.device().type() == DeviceType::CPU,
-              "clamp_max only supports CPU device type, got: ", self.device().type());
   TORCH_CHECK(self.layout() == Layout::Strided,
               "clamp_max only supports strided layout, got: ", self.layout());
   auto iter = TensorIterator::unary_op(result, self,
@@ -368,14 +361,10 @@ Tensor& _clamp_max_out_cpu(Tensor& result, const Tensor& self, Scalar max) {
 }
 
 Tensor& _clamp_min__cpu(Tensor& self, Scalar min) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
   return clamp_min_out(self, self, min);
 }
 
 Tensor& _clamp_min_out_cpu(Tensor& result, const Tensor& self, Scalar min) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
-  TORCH_CHECK(self.device().type() == DeviceType::CPU,
-              "clamp_min only supports CPU device type, got: ", self.device().type());
   TORCH_CHECK(self.layout() == Layout::Strided,
               "clamp_min only supports strided layout, got: ", self.layout());
   auto iter = TensorIterator::unary_op(result, self,
@@ -421,7 +410,6 @@ Tensor& mvlgamma_(Tensor& self, int64_t p) {
     return at::op##_out(self, self);                                   \
   }                                                                    \
   Tensor& _##op##_out_##prefix(Tensor& result, const Tensor& self) {   \
-    checkDeviceType(#op, result, DeviceType::device);                  \
     checkLayout(#op, result, Layout::Strided);                         \
     auto iter = TensorIterator::unary_op(result, self,                 \
       /*check_mem_overlap=*/true);                                     \
@@ -438,13 +426,23 @@ Tensor& mvlgamma_(Tensor& self, int64_t p) {
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cpu, CPU)                         \
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cuda, CUDA)
 
+#define IMPLEMENT_UNARY_OP_VEC_FPGA(op)                                \
+  IMPLEMENT_UNARY_OP_CORE(op)                                          \
+  IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cpu, CPU)                         \
+  IMPLEMENT_UNARY_OP_OUT_INPLACE(op, fpga, FPGA)
+
 IMPLEMENT_UNARY_OP_VEC(atan)
-IMPLEMENT_UNARY_OP_VEC(cos)
+IMPLEMENT_UNARY_OP_VEC_FPGA(cos)
 IMPLEMENT_UNARY_OP_VEC(erf)
 IMPLEMENT_UNARY_OP_VEC(erfc)
 IMPLEMENT_UNARY_OP_VEC_CUDA(erfinv)
 IMPLEMENT_UNARY_OP_VEC(exp)
+<<<<<<< HEAD
 IMPLEMENT_UNARY_OP_VEC(tan)
+=======
+IMPLEMENT_UNARY_OP_VEC_FPGA(tan)
+IMPLEMENT_UNARY_OP_VEC(tanh)
+>>>>>>> Added initial support for FPGA device
 IMPLEMENT_UNARY_OP_VEC_CUDA(lgamma)
 
 DEFINE_DISPATCH(abs_stub);

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -29,6 +29,7 @@ enum class Backend {
   CPU,
   CUDA,
   HIP,
+  FPGA,
   SparseCPU,
   SparseCUDA,
   SparseHIP,
@@ -68,6 +69,8 @@ static inline Backend toDense(Backend b) {
       return Backend::CUDA;
     case Backend::HIP:
       return Backend::HIP;
+    case Backend::FPGA:
+      return Backend::FPGA;
     case Backend::MSNPU:
       return Backend::MSNPU;
     case Backend::XLA:
@@ -94,6 +97,8 @@ static inline Backend dispatchKeyToBackend(DispatchKey t) {
     return Backend::CUDA;
   } else if (t == DispatchKey::HIP) {
     return Backend::HIP;
+  } else if (t == DispatchKey::FPGA) {
+    return Backend::FPGA;
   } else if (t == DispatchKey::MSNPU) {
     return Backend::MSNPU;
   } else if (t == DispatchKey::XLA || t == DispatchKey::XLAPreAutograd) {
@@ -125,6 +130,8 @@ static inline DispatchKey backendToDispatchKey(Backend b) {
       return DispatchKey::CUDA;
     case Backend::HIP:
       return DispatchKey::HIP;
+    case Backend::FPGA:
+      return DispatchKey::FPGA;
     case Backend::MSNPU:
       return DispatchKey::MSNPU;
     case Backend::XLA:
@@ -156,6 +163,8 @@ static inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::CUDA;
     case Backend::HIP:
       return DeviceType::HIP;
+    case Backend::FPGA:
+      return DeviceType::FPGA;
     case Backend::MSNPU:
       return DeviceType::MSNPU;
     case Backend::XLA:
@@ -186,6 +195,8 @@ static inline Backend backendToCPU(Backend b) {
       return Backend::CPU;
     case Backend::HIP:
       return Backend::CPU;
+    case Backend::FPGA:
+      return Backend::CPU;
     case Backend::SparseCPU:
       return Backend::SparseCPU;
     case Backend::SparseCUDA:
@@ -213,6 +224,7 @@ static inline Backend backendToCUDA(Backend b) {
     case Backend::CPU:
     case Backend::CUDA:
     case Backend::HIP:
+    case Backend::FPGA:
     case Backend::MSNPU:
     case Backend::XLA:
       return Backend::CUDA;
@@ -232,6 +244,7 @@ static inline Backend backendToHIP(Backend b) {
     case Backend::CPU:
     case Backend::CUDA:
     case Backend::HIP:
+    case Backend::FPGA:
     case Backend::MSNPU:
     case Backend::XLA:
       return Backend::HIP;
@@ -255,6 +268,8 @@ static inline const char* toString(Backend b) {
       return "CUDA";
     case Backend::HIP:
       return "HIP";
+    case Backend::FPGA:
+      return "FPGA";
     case Backend::MSNPU:
       return "MSNPU";
     case Backend::XLA:

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -13,7 +13,7 @@
 namespace c10 {
 namespace {
 DeviceType parse_type(const std::string& device_string) {
-  static const std::array<std::pair<std::string, DeviceType>, 9> types = {{
+  static const std::array<std::pair<std::string, DeviceType>, 10> types = {{
       {"cpu", DeviceType::CPU},
       {"cuda", DeviceType::CUDA},
       {"mkldnn", DeviceType::MKLDNN},
@@ -21,6 +21,7 @@ DeviceType parse_type(const std::string& device_string) {
       {"opencl", DeviceType::OPENCL},
       {"ideep", DeviceType::IDEEP},
       {"hip", DeviceType::HIP},
+      {"fpga", DeviceType::FPGA},
       {"msnpu", DeviceType::MSNPU},
       {"xla", DeviceType::XLA},
   }};

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -34,6 +34,7 @@ enum class DeviceType : int16_t {
 constexpr DeviceType kCPU = DeviceType::CPU;
 constexpr DeviceType kCUDA = DeviceType::CUDA;
 constexpr DeviceType kHIP = DeviceType::HIP;
+constexpr DeviceType kFPGA = DeviceType::FPGA;
 constexpr DeviceType kMSNPU = DeviceType::MSNPU;
 constexpr DeviceType kXLA = DeviceType::XLA;
 

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -26,6 +26,8 @@ const char* toString(DispatchKey t) {
       return "HIP";
     case DispatchKey::SparseHIP:
       return "SparseHIP";
+    case DispatchKey::FPGA:
+      return "FPGA";
     case DispatchKey::MSNPU:
       return "MSNPU";
     case DispatchKey::XLA:

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -52,6 +52,7 @@ enum class DispatchKey : uint8_t {
   CUDA, // registered at build/aten/src/ATen/CUDAType.cpp
   HIP, // NB: I think this is not actually used, due to Note [Masquerading as
        // CUDA]
+  FPGA, // lives out of tree at https://gitlab.com/pytorch-complex/vitis_kernels
   MSNPU, // unused externally, but tested at
          // test/cpp_extensions/msnpu_extension.cpp
   XLA, // lives out of tree at https://github.com/pytorch/xla

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -52,7 +52,7 @@ enum class DispatchKey : uint8_t {
   CUDA, // registered at build/aten/src/ATen/CUDAType.cpp
   HIP, // NB: I think this is not actually used, due to Note [Masquerading as
        // CUDA]
-  FPGA, // lives out of tree at https://gitlab.com/pytorch-complex/vitis_kernels
+  FPGA, // lives out of tree at https://gitlab.com/pytorch-complex/vitis_kernels.
   MSNPU, // unused externally, but tested at
          // test/cpp_extensions/msnpu_extension.cpp
   XLA, // lives out of tree at https://github.com/pytorch/xla

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -397,6 +397,8 @@ struct C10_API TensorOptions {
             return DispatchKey::IDEEP;
           case DeviceType::HIP:
             return DispatchKey::HIP;
+          case DeviceType::FPGA:
+            return DispatchKey::FPGA;
           case DeviceType::MSNPU:
             return DispatchKey::MSNPU;
           case DeviceType::XLA:
@@ -633,6 +635,8 @@ inline DeviceType computeDeviceType(DispatchKey tid) {
     return DeviceType::IDEEP;
   } else if (tid == DispatchKey::HIP) {
     return DeviceType::HIP;
+  } else if (tid == DispatchKey::FPGA) {
+    return DeviceType::FPGA;
   } else if (tid == DispatchKey::MSNPU) {
     return DeviceType::MSNPU;
   } else if (tid == DispatchKey::XLA) {

--- a/torch/csrc/utils/tensor_layouts.cpp
+++ b/torch/csrc/utils/tensor_layouts.cpp
@@ -21,6 +21,7 @@ void initializeLayouts() {
   // for now, let's look these up by Backend; we could create our own enum in the future.
   registerLayoutObject((THPLayout*)strided_layout, at::Backend::CPU);
   registerLayoutObject((THPLayout*)strided_layout, at::Backend::CUDA);
+  registerLayoutObject((THPLayout*)strided_layout, at::Backend::FPGA);
   registerLayoutObject((THPLayout*)strided_layout, at::Backend::MSNPU);
   registerLayoutObject((THPLayout*)strided_layout, at::Backend::XLA);
   registerLayoutObject((THPLayout*)strided_layout, at::Backend::QuantizedCPU);


### PR DESCRIPTION
Out-of-Tree PyTorch-Vitis FPGA support is found [here](https://gitlab.com/pytorch-complex/vitis_kernels)
Xilinx Vitis Webpage is found [here](https://www.xilinx.com/products/design-tools/vitis/vitis-platform.html)
List of supported FPGAs is found [here](https://xilinx.github.io/XRT/2019.2/html/platforms.html)


Modifications in the PR:
- [x] c10 backends and dispatch keys are modified to include FPGA.
- [x] gen.py is slightly modified so that I can call it from Torch-Vitis to create FPGAType.h and FPGAType.cpp.
- [ ] I have made a couple changes that should not be done in-tree. **These need discussion.**
   - aten/src/ATen/native/DispatchStub.h
   - aten/src/ATen/native/Copy.cpp
   - torch/csrc/utils/tensor_layouts.cpp

**Eager mode:**
The solution uses OpenCL to move data to the FPGA only when calling kernels (ie. `add_stub()`), therefore it re-uses cpu code when running in eager mode. If there is a `TORCH_CHECK(self.device().type() == DeviceType::CPU,...)` blocking execution, I simply copy the file into my extension and add a FPGA specific dispatch in `native_functions.yaml`

**JIT mode:**
This connects multiple FPGA kernels together on the FPGA, thus bypassing the cpu code. This mode only supports the default function arguments.

I currently do not need to import `DispatchStub.h` anywhere in my code for the above reasons. I assume, I will need to:
    1. Create a `FPGADispatchStub.h` that specializes `DispatchStub<rT (*)(Args...), T> ` somehow ....
    2. Import `FPGADispatchStub.h` in my cpp kernel files.

Please let me know how I can make these changes.

@ezyang @anjali411

cc: @ tataetae
