### PR TITLE
Fix RecordFunctionGuard usage in profiler

### DIFF
--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -201,7 +201,7 @@ void enableProfiler(ProfilerConfig config) {
       /* sampling_prob */ 1.0,
       /* scopes */ {RecordScope::FUNCTION, RecordScope::USER_SCOPE});
   state = new_state;
-  g_.emplace_back();
+  g_.emplace_back(std::make_shared<RecordFunctionGuard>());
 
   if(state == ProfilerState::CUDA) {
     // event recording appears to have some startup overhead, so we need to


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37380 Fix RecordFunctionGuard usage in profiler**

Summary:
Need to actually create the guard

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: