### PR TITLE
[resubmit] Enable global observers API

### DIFF
--- a/aten/src/ATen/ThreadLocalState.cpp
+++ b/aten/src/ATen/ThreadLocalState.cpp
@@ -15,7 +15,6 @@ ThreadLocalState::ThreadLocalState(bool keep_grad_mode)
     grad_mode_enabled_ = GradMode::is_enabled();
   }
 #endif
-  record_function_enabled_ = _tls_is_record_function_enabled();
 }
 
 /* static */
@@ -27,19 +26,9 @@ void ThreadLocalState::setThreadLocalState(
   }
 #endif
 
-  c10::impl::_force_tls_local_dispatch_key_set(state.dispatch_key_);
-
   ThreadLocalDebugInfo::_forceCurrentDebugInfo(state.debug_info_);
 
-  _tls_set_record_function_enabled(state.record_function_enabled_);
-}
-
-thread_local bool is_record_function_enabled_ = true;
-bool _tls_is_record_function_enabled() {
-  return is_record_function_enabled_;
-}
-void _tls_set_record_function_enabled(bool is_enabled) {
-  is_record_function_enabled_ = is_enabled;
+  c10::impl::_force_tls_local_dispatch_key_set(state.dispatch_key_);
 }
 
 } // namespace at

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -34,11 +34,6 @@ class TORCH_API ThreadLocalState {
   bool grad_mode_enabled_;
 #endif
 
-  // Whether RecordFunctions need to be disabled;
-  // used in core PyTorch to avoid infitite recursion
-  // in observers framework
-  bool record_function_enabled_;
-
   friend class ThreadLocalStateGuard;
 };
 
@@ -59,9 +54,5 @@ class TORCH_API ThreadLocalStateGuard {
  private:
   const ThreadLocalState prev_state_;
 };
-
-// Internal, turns on/off record function observers
-TORCH_API bool _tls_is_record_function_enabled();
-TORCH_API void _tls_set_record_function_enabled(bool);
 
 } // namespace at

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -70,15 +70,11 @@ struct _str_wrapper<const char*> final {
 
 // For c10::str() with an empty argument list (which is common in our assert macros),
 // we don't want to pay the binary size for constructing and destructing a stringstream
-// or even constructing a string. Let's just return a reference to a global empty string.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wglobal-constructors"
-const std::string empty_string_literal;
-#pragma GCC diagnostic pop
+// or even constructing a string. Let's just return a reference to an empty string.
 template<>
 struct _str_wrapper<> final {
   static const std::string& call() {
+    thread_local const std::string empty_string_literal;
     return empty_string_literal;
   }
 };

--- a/docs/source/notes/large_scale_deployments.rst
+++ b/docs/source/notes/large_scale_deployments.rst
@@ -61,6 +61,8 @@ Here's an example:
             /* needs_inputs */ true,
             /* sampling_prob */ 0.01
         );
+        // Note, to enable observers in the model calling thread,
+        // call enableObservers() in the thread before running a model
     }
 
     bool onFunctionEnter(const RecordFunction& fn) {

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -827,8 +827,10 @@ void checkScopeCallbacks() {
 }
 
 void testRecordFunction() {
+  // enable observers
+  c10::impl::IncludeDispatchKeyGuard observer_guard(c10::DispatchKey::Profiler);
   // disabling the inlining of method calls
-  GraphOptimizerEnabledGuard guard(false);
+  GraphOptimizerEnabledGuard opt_guard(false);
 
   // [(fn, [[sizes], [sizes], ...]), ...]
   TracedTestInputs traced_inputs;
@@ -858,9 +860,6 @@ void testRecordFunction() {
 
   TracedTestInputs eager_inputs, jit_inputs;
   {
-    c10::impl::IncludeDispatchKeyGuard profile_guard(
-        c10::DispatchKey::Profiler);
-
     auto t = torch::randn({1, 2, 3}, at::kCPU);
     t.set_requires_grad(true);
     auto t2 = invokeTestRecordFunction(t);
@@ -999,6 +998,9 @@ void checkDebugInfo(at::DebugInfoKind kind, int model_id) {
 }
 
 void testThreadLocalDebugInfo() {
+  // enable observers
+  c10::impl::IncludeDispatchKeyGuard observer_guard(c10::DispatchKey::Profiler);
+
   TORCH_CHECK(
       at::ThreadLocalDebugInfo::get(at::DebugInfoKind::TEST_INFO) == nullptr);
   auto debug_info = std::make_shared<TestThreadLocalDebugInfo>();

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -32,6 +32,10 @@ std::unordered_map<uint16_t, std::shared_ptr<RangeEventList>>
 thread_local std::shared_ptr<RangeEventList> event_list;
 thread_local uint16_t thread_id;
 
+// use RecordFunctionGuard to keep track of observers,
+// enable/disableProfiler are tied to the code range
+thread_local std::vector<std::shared_ptr<RecordFunctionGuard>> g_;
+
 } // namespace
 
 void registerCUDAMethods(CUDAStubs* stubs) {
@@ -197,7 +201,7 @@ void enableProfiler(ProfilerConfig config) {
       /* sampling_prob */ 1.0,
       /* scopes */ {RecordScope::FUNCTION, RecordScope::USER_SCOPE});
   state = new_state;
-  c10::impl::tls_set_dispatch_key_included(c10::DispatchKey::Profiler, true);
+  g_.emplace_back(std::make_shared<RecordFunctionGuard>());
 
   if(state == ProfilerState::CUDA) {
     // event recording appears to have some startup overhead, so we need to
@@ -228,7 +232,8 @@ thread_event_lists disableProfiler() {
 
   popCallback();
   state = ProfilerState::Disabled;
-  c10::impl::tls_set_dispatch_key_included(c10::DispatchKey::Profiler, false);
+  TORCH_INTERNAL_ASSERT(!g_.empty());
+  g_.pop_back();
 
   if (old_state == ProfilerState::NVTX) {
     return thread_event_lists();

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -213,13 +213,21 @@ void popCallback() {
   manager().popCallback();
 }
 
+bool observersEnabled() {
+  return c10::impl::tls_is_dispatch_key_included(c10::DispatchKey::Profiler);
+}
+
+void enableObservers(bool enable) {
+  c10::impl::tls_set_dispatch_key_included(c10::DispatchKey::Profiler, enable);
+}
+
 void _runBeforeCallbacks(RecordFunction* rf, const std::string& funcName) {
   TORCH_INTERNAL_ASSERT(rf != nullptr);
   rf->_before(funcName);
 }
 
 RecordFunction::RecordFunction(RecordScope scope) : scope_(scope) {
-  if (manager().hasCallbacks() && at::_tls_is_record_function_enabled()) {
+  if (manager().hasCallbacks() && observersEnabled()) {
     active_ = true;
   }
 }

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -220,25 +220,6 @@ struct TORCH_API RecordFunction {
   uint64_t callbacks_version_ = 0;
 };
 
-class TORCH_API RecordFunctionGuard {
- public:
-  explicit RecordFunctionGuard(bool is_enabled)
-      : prev_value_(at::_tls_is_record_function_enabled()) {
-    at::_tls_set_record_function_enabled(is_enabled);
-  }
-  virtual ~RecordFunctionGuard() {
-    at::_tls_set_record_function_enabled(prev_value_);
-  }
- private:
-  bool prev_value_ = false;
-};
-
-class TORCH_API DisableRecordFunctionGuard : public RecordFunctionGuard {
- public:
-  DisableRecordFunctionGuard() : RecordFunctionGuard(false) {}
-  virtual ~DisableRecordFunctionGuard() {}
-};
-
 // Returns whether there're callbacks registered with pushCallback
 TORCH_API bool hasCallbacks();
 
@@ -311,6 +292,33 @@ TORCH_API void pushCallback(
  * WARNING: not thread safe, must not overlap with other PyTorch code execution
  */
 TORCH_API void popCallback();
+
+// Enable observers thread locally
+TORCH_API void enableObservers(bool enable = true);
+
+// Returns whether observers are enabled (thread locally)
+TORCH_API bool observersEnabled();
+
+class TORCH_API RecordFunctionGuard {
+ public:
+  explicit RecordFunctionGuard(bool is_enabled = true)
+      : prev_value_(observersEnabled()) {
+    enableObservers(is_enabled);
+  }
+
+  virtual ~RecordFunctionGuard() {
+    enableObservers(prev_value_);
+  }
+
+ private:
+  bool prev_value_ = false;
+};
+
+class TORCH_API DisableRecordFunctionGuard : public RecordFunctionGuard {
+ public:
+  DisableRecordFunctionGuard() : RecordFunctionGuard(false) {}
+  virtual ~DisableRecordFunctionGuard() {}
+};
 
 } // namespace profiler
 }} // namespace torch::autograd

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -5,6 +5,8 @@
 #include <torch/csrc/jit/mobile/observer.h>
 #endif
 
+#include <torch/csrc/autograd/record_function.h>
+
 namespace torch {
 namespace jit {
 std::ostream& operator<<(std::ostream& out, Instruction inst);
@@ -46,10 +48,14 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   at::DebugInfoGuard guard(at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
 #endif
 
-  auto m = find_method(method_name);
-  stack.insert(stack.begin(), object_);
-  m->run(stack);
-  c10::IValue result = stack.front();
+  c10::IValue result;
+  {
+    torch::autograd::profiler::RecordFunctionGuard g;
+    auto m = find_method(method_name);
+    stack.insert(stack.begin(), object_);
+    m->run(stack);
+    result = stack.front();
+  }
 
 #if defined(PYTORCH_MOBILE_OBSERVER)
   if (observer) {


### PR DESCRIPTION
Summary:
After adding c10::DispatchKey::Profiler the behavior of RecordFunction
observers is also controlled by the dispatch key,
this PR moves the logic outside of the profiler into the record function

Differential Revision: D21268320

