### PR TITLE
Allow customizing retryable message types in Faulty agent tests

### DIFF
--- a/torch/distributed/rpc/_testing/__init__.py
+++ b/torch/distributed/rpc/_testing/__init__.py
@@ -11,4 +11,5 @@ if is_available() and not torch._C._faulty_agent_init():
     raise RuntimeError("Failed to initialize torch.distributed.rpc._testing")
 
 if is_available():
+    # Registers FAULTY_PROCESS_GROUP RPC backend.
     from . import faulty_agent_backend_registry

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -23,6 +23,17 @@ def _backend_type_repr(self):
 BackendType = enum.Enum(value="BackendType", names={})
 BackendType.__repr__ = _backend_type_repr
 
+def backend_registered(backend_name):
+    """
+    Checks if backend_name is registered as an RPC backend.
+
+    Arguments:
+        backend_name (str): string to identify the RPC backend.
+    Returns:
+        True if the backend has been registered with `register_backend`, else False.
+    """
+    return backend_name in BackendType.__members__.keys()
+
 
 def register_backend(
     backend_name, construct_rpc_backend_options_handler, init_backend_handler
@@ -39,7 +50,7 @@ def register_backend(
              This returns the agent.
     """
     global BackendType
-    if backend_name in BackendType.__members__.keys():
+    if backend_registered(backend_name):
         raise RuntimeError("RPC backend {}: already registered".format(backend_name))
     # Create a new enum type, `BackendType`, with extended members.
     existing_enum_dict = {member.name: member.value for member in BackendType}

--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -65,8 +65,12 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True,
 
         self.worker_id = self.rank
 
-        if faulty_messages:
-            _build_faulty_backend_options(faulty_messages)
+        if (
+            rpc.backend_registry.backend_registered("FAULTY_PROCESS_GROUP")
+            and self.rpc_backend
+            == rpc.backend_registry.BackendType.FAULTY_PROCESS_GROUP
+        ):
+            _build_faulty_backend_options(self, faulty_messages)
 
         if setup_rpc:
             rpc.init_rpc(
@@ -96,18 +100,22 @@ TEST_CONFIG.build_rpc_backend_options = lambda test_object: rpc.backend_registry
     num_send_recv_threads=8,
 )
 
-def _build_faulty_backend_options(faulty_messages):
+def _build_faulty_backend_options(faulty_agent_fixture, faulty_messages):
     '''
     Constructs the backend options object for the faulty process group agent
     based on the faulty_messages input to dist_init.
     '''
+    default_retryable_msg_types = faulty_agent_fixture.retryable_message_types
     TEST_CONFIG.build_rpc_backend_options = lambda test_object: rpc.backend_registry.construct_rpc_backend_options(
         test_object.rpc_backend,
         init_method=test_object.init_method,
         num_send_recv_threads=8,
-        num_fail_sends=1,
-        messages_to_fail=faulty_messages,
+        num_fail_sends=faulty_agent_fixture.num_fail_sends,
+        messages_to_fail=faulty_messages
+        if faulty_messages is not None
+        else default_retryable_msg_types,
     )
+
 
 def noop():
     pass

--- a/torch/testing/_internal/distributed/rpc/faulty_rpc_agent_test_fixture.py
+++ b/torch/testing/_internal/distributed/rpc/faulty_rpc_agent_test_fixture.py
@@ -1,5 +1,4 @@
 import torch.distributed.rpc as rpc
-import torch.testing._internal.dist_utils
 import torch.distributed.rpc._testing  # noqa
 from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
     RpcAgentTestFixture,
@@ -21,11 +20,9 @@ class FaultyRpcAgentTestFixture(RpcAgentTestFixture):
         ]
 
     @property
-    def rpc_backend_options(self):
-        return rpc.backend_registry.construct_rpc_backend_options(
-            self.rpc_backend,
-            init_method=self.init_method,
-            num_send_recv_threads=8,
-            num_fail_sends=3,
-            messages_to_fail=retryable_message_types,
-        )
+    def retryable_message_types(self):
+        return retryable_message_types
+
+    @property
+    def num_fail_sends(self):
+        return 3

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -2382,3 +2382,14 @@ class FaultyAgentRpcTest(FaultyRpcAgentTestFixture):
         self.assertEqual(self.rpc_backend_options.num_fail_sends, 3)
         self.assertEqual(len(self.rpc_backend_options.messages_to_fail), 4)
         self.assertEqual(self.rpc_backend_options.rpc_timeout, rpc.constants.DEFAULT_RPC_TIMEOUT_SEC)
+
+    @dist_init(faulty_messages=["RREF_FORK_REQUEST", "RREF_CHILD_ACCEPT"])
+    def test_custom_faulty_messages(self):
+        self.assertEqual(
+            set(["RREF_FORK_REQUEST", "RREF_CHILD_ACCEPT"]),
+            set(self.rpc_backend_options.messages_to_fail),
+        )
+
+    @dist_init(faulty_messages=[])
+    def test_no_faulty_messages(self):
+        self.assertEqual(len(self.rpc_backend_options.messages_to_fail), 0)


### PR DESCRIPTION
Summary:
It doesn't seem like we could customize the retryable message types by
passing faulty_messages into dist_utils, as the `FaultyRpcAgentTestFixture`
overrode the `rpc_backend_options` function and provided the default list of
retryable message types. Needed to fix this as part of adding timeout injection
support as mentioned in https://github.com/pytorch/pytorch/issues/36272


Differential Revision: D21270127

