### PR TITLE
Throw an error instead of warning on Softmax Implicit dimension

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1368,8 +1368,8 @@ See :class:`~torch.nn.Softplus` for more details.
 
 def _get_softmax_dim(name, ndim, stacklevel):
     # type: (str, int, int) -> int
-    warnings.warn("Implicit dimension choice for {} has been deprecated. "
-                  "Change the call to include dim=X as an argument.".format(name), stacklevel=stacklevel)
+    raise ValueError("Implicit dimension choice for {} has been deprecated. "
+                  "Change the call to include dim=X as an argument.".format(name))
     if ndim == 0 or ndim == 1 or ndim == 3:
         ret = 0
     else:


### PR DESCRIPTION
Hello,
I have been debugging my model for hours until I realized I'm doing softmax along the wrong dimension because I didn't specify the Dim implicitly in Softmax argument and Apparently i have missed the warning message because i was printing lot of stuff on the way.
So i'm suggesting to make it raise an error instead of warning, i'm sure this will save people time