### PR TITLE
[hotfix] Workaround for older versions of ninja

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -210,7 +210,7 @@ function(append_filelist name outputvar)
   set(_rootdir "${CMAKE_CURRENT_LIST_DIR}/../")
   # configure_file adds its input to the list of CMAKE_RERUN dependencies
   configure_file(
-      ${CMAKE_CURRENT_LIST_DIR}/../tools/build_variables.bzl
+      ${CMAKE_SOURCE_DIR}/tools/build_variables.bzl
       ${CMAKE_BINARY_DIR}/caffe2/build_variables.bzl)
   execute_process(
     COMMAND "${PYTHON_EXECUTABLE}" -c


### PR DESCRIPTION
Older versions of ninja don't like relative paths in configure_file when it is called twice.

https://gitlab.kitware.com/cmake/cmake/issues/17601

Fix suggested in comments https://gitlab.kitware.com/cmake/cmake/-/issues/18584