### PR TITLE
[JIT] Fix GetAttr inconsistency

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -16914,7 +16914,9 @@ a")
 
         def foo():
             a = FooTest()
-            return hasattr(a, "foo"), hasattr(a, "x"), hasattr(a, "bla")
+            val1 = hasattr(a, "foo"), hasattr(a, "x"), hasattr(a, "bla")
+            val2 = hasattr(FooTest, "foo"), hasattr(FooTest, "a")
+            return val1, val2
 
         self.assertEqual(foo(), torch.jit.script(foo)())
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -16866,7 +16866,57 @@ a")
         torch.jit.script(MaybeHasAttr2(True))
         torch.jit.script(MaybeHasAttr2(False))
 
+        class MyMod(torch.nn.Module):
+            def forward(self):
+                if hasattr(self, "foo"):
+                    return 1
+                else:
+                    return 0
 
+            @torch.jit.export
+            def fee(self):
+                return 1
+
+        self.checkModule(MyMod(), ())
+
+        class HasAttrMod(torch.nn.Module):
+            __constants__ = ["fee"]
+
+            def __init__(self):
+                super().__init__()
+                self.fee = 3
+
+            def forward(self):
+                a = hasattr(self, "fee")
+                b = hasattr(self, "foo")
+                c = hasattr(self, "hi")
+                d = hasattr(self, "nonexistant")
+                return (a, b, c, d)
+
+            def foo(self):
+                return 1
+
+            @torch.jit._overload_method
+            def hi(self, x: Tensor): ...  # noqa: E704
+
+            def hi(self, x):  # noqa: F811
+                return 2
+
+        self.checkModule(HasAttrMod(), ())
+
+        @torch.jit.script
+        class FooTest(object):
+            def __init__(self):
+                self.x = 1
+
+            def foo(self, y):
+                return self.x + y
+
+        def foo():
+            a = FooTest()
+            return hasattr(a, "foo"), hasattr(a, "x"), hasattr(a, "bla")
+
+        self.assertEqual(foo(), torch.jit.script(foo)())
 
     def test_optional_tuple(self):
         def fn(x=None):

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1496,21 +1496,13 @@ struct to_ir {
   }
 
   CondValue emitHasAttr(const Expr& objExpr, const Expr& attrExpr) {
-    auto obj = emitExpr(objExpr);
-    const auto& type = obj->type();
+    auto obj = emitSugaredExpr(objExpr, 1);
     if (attrExpr.kind() != TK_STRINGLITERAL) {
       throw ErrorReport(attrExpr)
           << "hasattr's second argument must be a string literal";
     }
-    auto cls = type->cast<ClassType>();
-    if (!cls) {
-      throw ErrorReport(objExpr)
-          << "hasattr's first argument must be an object, got "
-          << type->python_str() << " instead";
-    }
-
     const std::string& name = StringLiteral(attrExpr).text();
-    const bool hasAttr = cls->hasAttribute(name);
+    const bool hasAttr = obj->hasAttr(objExpr.range(), method, name);
     return CondValue(*graph, objExpr.range(), hasAttr, {});
   }
 

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -63,6 +63,20 @@ struct EnumClassHash {
   }
 };
 
+bool SimpleValue::hasAttr(
+    const SourceRange& loc,
+    Function& m,
+    const std::string& field) {
+  auto class_type = value_->type()->cast<ClassType>();
+  if (!class_type) {
+    throw ErrorReport(loc) << "hasattr's first argument must be an object, got "
+                           << value_->type()->python_str() << " instead";
+  }
+
+  return class_type->getMethod(field) || class_type->hasAttribute(field) ||
+      class_type->hasConstant(field);
+}
+
 // support syntax sugar for x.foo(y, z) by allowing x.foo to return a
 // callable value that will resolve to foo(x, y, z) when called.
 std::shared_ptr<SugaredValue> SimpleValue::attr(

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -41,6 +41,13 @@ struct TORCH_API SugaredValue
     throw ErrorReport(loc) << "attribute lookup is not defined on " << kind();
   }
 
+  virtual bool hasAttr(
+      const SourceRange& loc,
+      Function& m,
+      const std::string& field) {
+    throw ErrorReport(loc) << "attribute lookup is not defined on " << kind();
+  }
+
   // assign an attribute on it, e.g. `this.field = newValue`
   virtual void setAttr(
       const SourceRange& loc,
@@ -154,6 +161,9 @@ struct TORCH_API SimpleValue : public SugaredValue {
       const SourceRange& loc,
       Function& m,
       const std::string& field) override;
+
+  bool hasAttr(const SourceRange& loc, Function& m, const std::string& field)
+      override;
 
   void setAttr(
       const SourceRange& loc,

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -362,8 +362,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
   }
 }
 
-// This method controls how we desugar attribute lookups on ScriptModules.
-std::shared_ptr<SugaredValue> ModuleValue::attr(
+// This method controls how we desugar attribute lookups on ScriptModules
+std::shared_ptr<SugaredValue> ModuleValue::tryGetAttr(
     const SourceRange& loc,
     Function& m,
     const std::string& field) {
@@ -455,14 +455,35 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
     return attr(loc, m, field);
   }
 
-  // We've exhausted all possibilities. Bailout with a hint to the user.
+  return nullptr;
+}
+
+bool ModuleValue::hasAttr(
+    const SourceRange& loc,
+    Function& m,
+    const std::string& field) {
+  return tryGetAttr(loc, m, field) != nullptr;
+}
+
+// This method controls how we desugar attribute lookups on ScriptModules.
+std::shared_ptr<SugaredValue> ModuleValue::attr(
+    const SourceRange& loc,
+    Function& m,
+    const std::string& field) {
+  if (auto attr = tryGetAttr(loc, m, field)) {
+    return attr;
+  }
+
+  // We don't define this attr. Bailout with a hint to the user.
   std::string hint;
   if (auto failureReason = concreteType_->findFailedAttribute(field)) {
     hint = *failureReason;
   }
 
-  throw ErrorReport(loc) << "Module '" << selfType->name()->name() << "'"
-                         << " has no attribute '" << field << "' " << hint;
+  throw ErrorReport(loc)
+      << "Module '"
+      << concreteType_->getJitType()->expect<ClassType>()->name()->name() << "'"
+      << " has no attribute '" << field << "' " << hint;
 }
 
 SugaredValuePtr ModuleValue::iter(const SourceRange& loc, Function& m) {
@@ -494,6 +515,18 @@ std::shared_ptr<SugaredValue> PythonClassValue::attr(
   }
 
   return ClassValue::attr(loc, m, field);
+}
+
+bool PythonClassValue::hasAttr(
+    const SourceRange& loc,
+    Function& m,
+    const std::string& field) {
+  try {
+    py::getattr(py_type_, field.c_str());
+    return true;
+  } catch (...) {
+    return false;
+  }
 }
 
 void ModuleValue::setAttr(

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -524,7 +524,7 @@ bool PythonClassValue::hasAttr(
   try {
     py::getattr(py_type_, field.c_str());
     return true;
-  } catch (...) {
+  } catch (py::error_already_set& e) {
     return false;
   }
 }

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -146,10 +146,20 @@ struct VISIBILITY_HIDDEN ModuleValue : public SugaredValue {
   Value* asValue(const SourceRange& loc, Function& m) override;
 
   // select an attribute on it, e.g. `this.field`
+  std::shared_ptr<SugaredValue> tryGetAttr(
+      const SourceRange& loc,
+      Function& m,
+      const std::string& field);
+
+  // select an attribute on it, e.g. `this.field`
   std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
       Function& m,
       const std::string& field) override;
+
+  // select an attribute on it, e.g. `this.field`
+  bool hasAttr(const SourceRange& loc, Function& m, const std::string& field)
+      override;
 
   // call module.forward
   std::shared_ptr<SugaredValue> call(
@@ -264,6 +274,9 @@ struct VISIBILITY_HIDDEN PythonClassValue : public ClassValue {
       const SourceRange& loc,
       Function& m,
       const std::string& field) override;
+
+  bool hasAttr(const SourceRange& loc, Function& m, const std::string& field)
+      override;
 
  private:
   py::object py_type_;


### PR DESCRIPTION
We were previously only looking at class attributes, so that didn't include methods etc, and would silently give wrong semantics. This makes hasAttr go through the same resolution as our other attribute lookups. 