### PR TITLE
Move DistributonTemplates to anonymous namespace

### DIFF
--- a/aten/src/ATen/core/DistributionsHelper.h
+++ b/aten/src/ATen/core/DistributionsHelper.h
@@ -36,6 +36,7 @@
 
 
 namespace at {
+namespace {
 
 /**
  * Samples a discrete uniform distribution in the range [base, base+range) of type T
@@ -295,5 +296,5 @@ struct lognormal_distribution {
     T mean;
     T stdv;
 };
-
+}
 } // namespace at

--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -16,6 +16,7 @@ namespace at {
 namespace native {
 namespace templates {
 namespace cpu {
+namespace {
 
 // ==================================================== Random ========================================================
 
@@ -235,4 +236,4 @@ void cauchy_kernel(TensorIterator& iter, double median, double sigma, RNG genera
   });
 }
 
-}}}}
+}}}}}


### PR DESCRIPTION
All templates which are included from `ATen/native/cpu` must be in anonymous namespace, especially if they are using instruction set extensions but do not support dynamic dispatching.

Otherwise, linker is free to pick AVX2, AVX or DEFAULT version of instantiated templates during final linking stage

Test Plan; Apply on top of https://github.com/pytorch/pytorch/pull/37121 and make sure that `basic` test successfully finishes on CircleCI MacPro (that does not support AVX2), but `ATEN_CPU_CAPABILITY=avx2 ./basic --gtest_filter=*HalfCPU` crashes with illegal instruction

