### PR TITLE
Remove THCudaMemGetInfo. Use c10's cacheInfo instead.

### DIFF
--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -310,31 +310,6 @@ void THCudaHostRecord(THCState *state, void *ptr) {
   }
 }
 
-cudaError_t THCudaMemGetInfo(THCState *state,  size_t* freeBytes, size_t* totalBytes, size_t* largestBlock)
-{
-  size_t cachedBytes = 0;
-
-  *largestBlock = 0;
-  /* get info from CUDA first */
-  cudaError_t ret = cudaMemGetInfo(freeBytes, totalBytes);
-  if (ret!= cudaSuccess)
-    return ret;
-
-  int device;
-  ret = cudaGetDevice(&device);
-  if (ret!= cudaSuccess)
-    return ret;
-
-  /* not always true - our optimistic guess here */
-  *largestBlock = *freeBytes;
-
-  c10::cuda::CUDACachingAllocator::cacheInfo(device, &cachedBytes, largestBlock);
-
-  /* Adjust resulting free bytes number. largesBlock unused for now */
-  *freeBytes += cachedBytes;
-  return cudaSuccess;
-}
-
 #undef MIN_GLOBAL_SCRATCH_SPACE_PER_SM_STREAM
 #undef MIN_GLOBAL_SCRATCH_SPACE_PER_DEVICE
 

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -73,6 +73,4 @@ at::DataPtr THCudaHostAlloc(THCState *state, size_t size);
 
 THC_API void THCudaHostRecord(THCState *state, void *ptr);
 
-THC_API cudaError_t THCudaMemGetInfo(THCState *state, size_t* freeBytes, size_t* totalBytes, size_t* largestBlock);
-
 #endif

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -427,6 +427,11 @@ class THCCachingAllocator {
   /** Retrieves info (total size + largest block) of the memory cache **/
   void cacheInfo(int dev_id, size_t* total, size_t* largest) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
+    if (*largest == 0) {  // make an initial guess if a zero *largest is passed in
+      size_t tmp_bytes;
+      cudaMemGetInfo(largest,  // Use free memory as an optimistic initial guess of *largest
+                     &tmp_bytes);
+    }
     cache_info_aux(large_blocks, dev_id, total, largest);
     cache_info_aux(small_blocks, dev_id, total, largest);
   }


### PR DESCRIPTION
`THCudaMemGetInfo` has only been used in `aten/src/ATen/native/cudnn/Conv.cpp`. We can extract `c10::cuda::CUDACachingAllocator::cacheInfo` out from it and use it in `aten/src/ATen/native/cudnn/Conv.cpp` directly and drop lines that are not used in `THCudaMemGetInfo`.