### PR TITLE
Unify Tensor and Storage copy

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -110,8 +110,8 @@ Tensor new_with_sizes(c10::DispatchKey dispatch_key, at::ScalarType scalar_type,
   return torch::empty(sizes, options(dispatch_key, scalar_type, device));
 }
 
-Tensor new_with_storage(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, Storage storage) {
-  auto tensor = at::empty({}, options(dispatch_key, scalar_type));
+Tensor new_with_storage(c10::DispatchKey dispatch_key, Storage storage) {
+  auto tensor = at::empty({}, options(dispatch_key, c10::typeMetaToScalarType(storage.dtype())));
   tensor.set_(std::move(storage));
   return tensor;
 }
@@ -489,7 +489,7 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
     at::OptionalDeviceGuard device_guard(deviceOptional);
     return at::empty({0}, options(dispatch_key, scalar_type));
   } else if (r.idx == 1) {
-    return new_with_storage(dispatch_key, scalar_type, r.storage(0));
+    return new_with_storage(dispatch_key, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
     return at::unsafeTensorFromTH(cdata, true);
@@ -536,7 +536,7 @@ Tensor legacy_tensor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_ty
     at::OptionalDeviceGuard device_guard(deviceOptional);
     return at::empty({0}, options(dispatch_key, scalar_type));
   } else if (r.idx == 1) {
-    return new_with_storage(dispatch_key, scalar_type, r.storage(0));
+    return new_with_storage(dispatch_key, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
     return at::unsafeTensorFromTH(cdata, true);

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -110,8 +110,8 @@ Tensor new_with_sizes(c10::DispatchKey dispatch_key, at::ScalarType scalar_type,
   return torch::empty(sizes, options(dispatch_key, scalar_type, device));
 }
 
-Tensor new_with_storage(c10::DispatchKey dispatch_key, Storage storage) {
-  auto tensor = at::empty({}, options(dispatch_key, c10::typeMetaToScalarType(storage.dtype())));
+Tensor new_with_storage(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, Storage storage) {
+  auto tensor = at::empty({}, options(dispatch_key, scalar_type));
   tensor.set_(std::move(storage));
   return tensor;
 }
@@ -489,7 +489,7 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
     at::OptionalDeviceGuard device_guard(deviceOptional);
     return at::empty({0}, options(dispatch_key, scalar_type));
   } else if (r.idx == 1) {
-    return new_with_storage(dispatch_key, r.storage(0));
+    return new_with_storage(dispatch_key, scalar_type, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
     return at::unsafeTensorFromTH(cdata, true);
@@ -536,7 +536,7 @@ Tensor legacy_tensor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_ty
     at::OptionalDeviceGuard device_guard(deviceOptional);
     return at::empty({0}, options(dispatch_key, scalar_type));
   } else if (r.idx == 1) {
-    return new_with_storage(dispatch_key, r.storage(0));
+    return new_with_storage(dispatch_key, scalar_type, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
     return at::unsafeTensorFromTH(cdata, true);

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -43,7 +43,7 @@ class _StorageBase(object):
         """Returns a copy of this storage"""
         device = self.get_device() if self.is_cuda else -1
         with torch.cuda.device(device):
-            new_tensor = torch.tensor((), dtype=self.dtype).set_(self)
+            new_tensor = torch.tensor((), dtype=self.dtype, device=self.device).set_(self)
             return new_tensor.clone().storage()
 
     def tolist(self):

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -43,8 +43,11 @@ class _StorageBase(object):
         """Returns a copy of this storage"""
         device = self.get_device() if self.is_cuda else -1
         with torch.cuda.device(device):
-            new_tensor = torch.tensor((), dtype=self.dtype, device=self.device).set_(self)
-            return new_tensor.clone().storage()
+            if self.dtype in [torch.qint8, torch.quint8, torch.qint32]:
+                return type(self)(self.size()).copy_(self)
+            else:
+                new_tensor = torch.tensor((), dtype=self.dtype, device=self.device).set_(self)
+                return new_tensor.clone().storage()
 
     def tolist(self):
         """Returns a list containing the elements of this storage"""

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -43,7 +43,8 @@ class _StorageBase(object):
         """Returns a copy of this storage"""
         device = self.get_device() if self.is_cuda else -1
         with torch.cuda.device(device):
-            return type(self)(self.size()).copy_(self)
+            new_tensor = torch.Tensor(self)
+            return new_tensor.clone().storage()
 
     def tolist(self):
         """Returns a list containing the elements of this storage"""

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -43,7 +43,7 @@ class _StorageBase(object):
         """Returns a copy of this storage"""
         device = self.get_device() if self.is_cuda else -1
         with torch.cuda.device(device):
-            new_tensor = torch.tensor((), dtype=self.dtype).set_(self)
+            new_tensor = torch.Tensor(self)
             return new_tensor.clone().storage()
 
     def tolist(self):

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -43,7 +43,7 @@ class _StorageBase(object):
         """Returns a copy of this storage"""
         device = self.get_device() if self.is_cuda else -1
         with torch.cuda.device(device):
-            new_tensor = torch.Tensor(self)
+            new_tensor = torch.tensor((), dtype=self.dtype).set_(self)
             return new_tensor.clone().storage()
 
     def tolist(self):


### PR DESCRIPTION
Currently, Tensor has a completely disjoint code for copy than storage. This PR updates the storage clone() method to create a tensor, copy the tensor and return its storage.

`'aten::empty.memory_format' is only available for these backends: [CPU, MkldnnCPU, SparseCPU, BackendSelect, Autograd, Profile]`, so quantized storage types will still use the storage copy logic.

Follow-up on [this](https://github.com/pytorch/pytorch/pull/35851) discussion