### PR TITLE
[caffe2] Copy tensor in single tensor input case in UnPackRecordsOp

### DIFF
--- a/caffe2/operators/dataset_ops.cc
+++ b/caffe2/operators/dataset_ops.cc
@@ -399,7 +399,7 @@ class UnPackRecordsOp : public Operator<CPUContext> {
       // input contains a single tensor
       CAFFE_ENFORCE_EQ(InputSize(), 1);
       CAFFE_ENFORCE_EQ(OutputSize(), 1);
-      *Output(0) = Input(0);
+      Output(0)->CopyFrom(Input(0));
       return true;
     }
 


### PR DESCRIPTION
Summary:
Fix a bug introduced in D21224497.

In the case of having a single unpacked tensor as input, we still need to copy the underline memory because only inputs are guaranteed to be read-only. The output could be overwritten later during inference. If we share the tensor, we could potentially overwrite the input, which in principle should be read only.

Test Plan:
```
buck test caffe2/caffe2/python/operator_test:dataset_ops_test
```

AdIndexer canary:
https://our.intern.facebook.com/intern/ads/canary/426290361213982683

Reviewed By: yinghai

Differential Revision: D21274309

