### PR TITLE
Resubmit "Fix NaN error in dynamic quantization in qLinear, re-enable test_quantized_rnn""

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/quant_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/quant_utils.h
@@ -62,7 +62,7 @@ inline TensorQuantizationParams ChooseQuantizationParams(
   // adjust the scale to 0.1 . We want to avoid scale's reciprocal being
   // infinity because some of fbgemm code pre-computes scale's reciprocal to do
   // multiplication instead of division in the time critical part of code.
-  if (scale == 0.0f || std::isinf(1.0f / scale)) {
+  if (float(scale) == 0.0f || std::isinf(1.0f / float(scale))) {
     scale = 0.1;
   }
   TORCH_CHECK(scale > 0, "quantization scale should be > 0");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37159 Dynamic quantization support for GRU, LSTMCell, RNNCell and GRUCell
* #35961 Fix weight quantization in RNNs
* **#37458 Resubmit "Fix NaN error in dynamic quantization in qLinear, re-enable test_quantized_rnn""**

Original commit changeset: 0204c360ef2c

Differential Revision: [D21287904](https://our.internmc.facebook.com/intern/diff/D21287904/)