### PR TITLE
Blanket disable stateless xnnpack.

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -7,9 +7,12 @@
 #include <ATen/native/xnnpack/Engine.h>
 
 #include <ATen/Config.h>
+#include <c10/macros/Macros.h>
+
 #if AT_NNPACK_ENABLED()
 #include <nnpack.h>
 #endif
+
 
 constexpr int MIOPEN_DIM_MAX = 5;
 
@@ -724,6 +727,7 @@ at::Tensor _convolution(
                                       params.padding, params.stride, params.dilation, params.groups);
     }
 #endif
+#if !defined(C10_IOS)
   } else if (params.use_xnnpack(input, weight, bias)) {
     // Using prepacked conv is preferred, but XNNPACK is still the fastest
     // option for NHWC.
@@ -735,6 +739,7 @@ at::Tensor _convolution(
         params.stride,
         params.dilation,
         params.groups);
+#endif
   } else if (params.use_cpu_depthwise3x3_winograd(input, weight, bias)) {
     output = convolution_depthwise3x3_winograd_stub(
         input.device().type(),

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -2,6 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/xnnpack/Engine.h>
 #include <ATen/WrapDimUtilsMulti.h>
+#include <c10/macros/Macros.h>
 
 #include <array>
 #include <cctype>
@@ -17,9 +18,11 @@ Tensor linear(const Tensor& input, const Tensor& weight, const Tensor& bias) {
     return at::mkldnn_linear(input, weight, bias);
   }
 #ifdef C10_MOBILE
+#if !defined(C10_IOS)
   if (xnnpack::use_linear(input, weight, bias)) {
     return xnnpack::linear(input, weight, bias);
   }
+#endif
 #endif
   if (input.dim() == 2 && bias.defined()) {
     // Fused op is marginally faster.

--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -4,6 +4,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/native/xnnpack/Engine.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
 #include <tuple>
@@ -134,11 +135,13 @@ Tensor max_pool2d(
         self, kernel_size, stride, padding, dilation, ceil_mode);
   }
 #if defined(C10_MOBILE)
+#if !defined(C10_IOS)
   if(xnnpack::use_max_pool2d(self, kernel_size, padding, stride,
                              dilation, ceil_mode)) {
     return xnnpack::max_pool2d(
         self, kernel_size, padding, stride, dilation, ceil_mode);
   }
+#endif
 #endif
   auto output_and_indices = at::max_pool2d_with_indices(
       self, kernel_size, stride, padding, dilation, ceil_mode);


### PR DESCRIPTION
Summary:
It seems that stateless xnnpack integration for Convolution is breaking iOS
runs.
Issue seems to be stemming from passing some invalid pointer or pointer that is
not longer valid. But beyond this the issue has not been root caused.
The issues seems to appear only for iOS so far but blanket disabling it for
both ios and android since this improvement had only been recent so no
production models are running with this perf improvement yet. Hence no perf
regression expected.

Test Plan: buck run aibench:run_bench -- -b aibench/specifications/models/pytorch/pytext/pytext_mobile_inference.json --platform ios --framework pytorch --remote --devices D221AP-12.0.1

Reviewed By: xta0

Differential Revision: D21284385

