### PR TITLE
Lazily initialise thread local num_threads value

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/ATen.h>
 #include <ATen/core/ivalue.h>
+#include <c10/macros/Macros.h>
 
 namespace at {
 namespace internal {
@@ -31,6 +32,19 @@ CAFFE2_API int get_thread_num();
 
 // Checks whether the code runs in parallel region
 CAFFE2_API bool in_parallel_region();
+
+namespace internal {
+
+// Initialise num_threads lazily at first parallel call
+inline CAFFE2_API void lazy_init_num_threads() {
+  thread_local bool init = false;
+  if (C10_UNLIKELY(!init)) {
+    at::init_num_threads();
+    init = true;
+  }
+}
+
+}
 
 /*
 parallel_for

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -121,6 +121,8 @@ void _parallel_run(
   const int64_t end,
   const int64_t grain_size,
   const std::function<void(int64_t, int64_t, size_t)>& f) {
+  at::internal::lazy_init_num_threads();
+
   size_t num_tasks, chunk_size;
   std::tie(num_tasks, chunk_size) =
       internal::calc_num_tasks_and_chunk_size(begin, end, grain_size);

--- a/aten/src/ATen/ParallelNativeTBB.h
+++ b/aten/src/ATen/ParallelNativeTBB.h
@@ -22,6 +22,7 @@ inline void parallel_for(
     const int64_t grain_size,
     const F& f) {
   TORCH_CHECK(grain_size >= 0);
+  at::internal::lazy_init_num_threads();
   if (begin >= end) {
     return;
   }
@@ -61,6 +62,7 @@ inline scalar_t parallel_reduce(
     const F& f,
     const SF& sf) {
   TORCH_CHECK(grain_size >= 0);
+  at::internal::lazy_init_num_threads();
   if (begin >= end) {
     return ident;
   }

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -19,6 +19,7 @@ inline void parallel_for(
     const int64_t grain_size,
     const F& f) {
   TORCH_CHECK(grain_size >= 0);
+  at::internal::lazy_init_num_threads();
   if (begin >= end) {
     return;
   }
@@ -65,6 +66,7 @@ inline scalar_t parallel_reduce(
     const F& f,
     const SF& sf) {
   TORCH_CHECK(grain_size >= 0);
+  at::internal::lazy_init_num_threads();
   if (begin >= end) {
     return ident;
   } else if (in_parallel_region() || get_num_threads() == 1) {

--- a/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/Parallel.h>
 
 namespace at {
 namespace native {
@@ -30,6 +31,7 @@ static void adaptive_avg_pool3d_out_frame(
     int64_t istrideH,
     int64_t istrideW) {
   int64_t d = 0;
+  at::internal::lazy_init_num_threads();
 #pragma omp parallel for private(d)
   for (d = 0; d < sizeD; d++) {
     /* loop over output */
@@ -135,6 +137,7 @@ void adaptive_avg_pool3d_out_cpu_template(
         });
   } else {
     output.resize_({input.size(-5), sizeD, osizeT, osizeH, osizeW});
+    at::internal::lazy_init_num_threads();
     int64_t b;
 #pragma omp parallel for private(b)
     for (b = 0; b < input.size(0); b++) {
@@ -173,6 +176,7 @@ static void adaptive_avg_pool3d_backward_out_frame(
     int64_t osizeH,
     int64_t osizeW) {
   int64_t d = 0;
+  at::internal::lazy_init_num_threads();
 #pragma omp parallel for private(d)
   for (d = 0; d < sizeD; d++) {
     scalar_t* gradInput_p_d = gradInput_p + d * isizeT * isizeW * isizeH;
@@ -251,6 +255,7 @@ Tensor& adaptive_avg_pool3d_backward_out_cpu_template(
               osizeW);
         });
   } else {
+    at::internal::lazy_init_num_threads();
     int64_t b;
 #pragma omp parallel for private(b)
     for (b = 0; b < input.size(0); b++) {

--- a/aten/src/ATen/native/MaxUnpooling.cpp
+++ b/aten/src/ATen/native/MaxUnpooling.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/Parallel.h>
 #include <tuple>
 
 namespace at {
@@ -29,6 +30,8 @@ Tensor max_unpooling2d_forward_out_cpu_frame(
   auto* rawInput = input.data_ptr<scalar_t>();
   auto* rawIndices = indices.data_ptr<int64_t>();
   auto* rawOutput = output.data_ptr<scalar_t>();
+
+  at::internal::lazy_init_num_threads();
 
   for (int64_t n = 0; n < numBatch; n++) {
     int64_t nOutputOffset = n * numChannels * owidth * oheight;
@@ -160,6 +163,8 @@ Tensor max_unpooling3d_forward_out_cpu_frame(
   scalar_t* input_data = input.data_ptr<scalar_t>();
   scalar_t* output_data = output.data_ptr<scalar_t>();
   int64_t* indices_data = indices.data_ptr<int64_t>();
+
+  at::internal::lazy_init_num_threads();
 
   for (int64_t p = 0; p < nBatch; p++) {
     int64_t inputOffset = p * nSlices * iT * iW * iH;
@@ -353,6 +358,8 @@ static void max_unpooling2d_backward_out_cpu_frame(
   bool has_error = false;
   int64_t error_index = 0;
   int k = 0;
+
+  at::internal::lazy_init_num_threads();
 #pragma omp parallel for private(k)
   for (k = 0; k < nslices; k++) {
     scalar_t* gradInput_p_k = gradInput_p + k * iwidth * iheight;
@@ -487,6 +494,9 @@ static void max_unpooling3d_backward_out_cpu_frame(
   int k = 0;
   bool has_error = false;
   int error_index = 0;
+
+  at::internal::lazy_init_num_threads();
+
 #pragma omp parallel for private(k)
   for (k = 0; k < nslices; k++) {
     scalar_t* gradInput_p_k = gradInput_p + k * iT * iH * iW;

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -456,6 +456,7 @@ def gen_pyi(declarations_path, out):
         'as_tensor': ["def as_tensor(data: Any, dtype: _dtype=None, device: Optional[_device]=None) -> Tensor: ..."],
         'get_num_threads': ['def get_num_threads() -> _int: ...'],
         'set_num_threads': ['def set_num_threads(num: _int) -> None: ...'],
+        'init_num_threads': ['def init_num_threads() -> None: ...'],
         'get_num_interop_threads': ['def get_num_interop_threads() -> _int: ...'],
         'set_num_interop_threads': ['def set_num_interop_threads(num: _int) -> None: ...'],
         # These functions are explicitly disabled by

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -51,6 +51,7 @@ def get_ignored_functions():
         torch.get_default_dtype,
         torch.get_num_interop_threads,
         torch.get_num_threads,
+        torch.init_num_threads,
         torch.import_ir_module,
         torch.import_ir_module_from_buffer,
         torch.is_anomaly_enabled,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5102,6 +5102,16 @@ WARNING: Can only be called once and before any inter-op parallel work
 is started (e.g. JIT execution).
 """)
 
+add_docstr(torch.init_num_threads,
+           r"""
+init_num_threads()
+
+Initializes the number of parallel threads used on the current thread.
+
+Call this whenever a new thread is created in order to propagate values from
+:func:`torch.set_num_threads` onto the new thread.
+""")
+
 add_docstr(torch.sigmoid,
            r"""
 sigmoid(input, out=None) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5102,16 +5102,6 @@ WARNING: Can only be called once and before any inter-op parallel work
 is started (e.g. JIT execution).
 """)
 
-add_docstr(torch.init_num_threads,
-           r"""
-init_num_threads()
-
-Initializes the number of parallel threads used on the current thread.
-
-Call this whenever a new thread is created in order to propagate values from
-:func:`torch.set_num_threads` onto the new thread.
-""")
-
 add_docstr(torch.sigmoid,
            r"""
 sigmoid(input, out=None) -> Tensor

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -626,7 +626,7 @@ __declspec(dllexport)
 #endif
 PyObject* initModule() {
   HANDLE_TH_ERRORS
-  at::init_num_threads();
+  at::internal::lazy_init_num_threads();
 
   C10_LOG_API_USAGE_ONCE("torch.python.import");
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -176,6 +176,11 @@ static PyObject * THPModule_setNumThreads(PyObject *module, PyObject *arg)
   Py_RETURN_NONE;
 }
 
+static PyObject * THPModule_initNumThreads(PyObject *self, PyObject */*args*/) {
+  at::init_num_threads();
+  Py_RETURN_NONE;
+}
+
 static PyObject * THPModule_getNumInteropThreads(PyObject *module, PyObject *noargs)
 {
   return PyLong_FromLong(at::get_num_interop_threads());
@@ -548,6 +553,7 @@ static PyMethodDef TorchMethods[] = {
   {"_get_backcompat_keepdim_warn", (PyCFunction)THPModule_getBackcompatKeepdimWarn, METH_NOARGS, nullptr},
   {"get_num_threads", (PyCFunction)THPModule_getNumThreads,     METH_NOARGS,  nullptr},
   {"set_num_threads", (PyCFunction)THPModule_setNumThreads,     METH_O,       nullptr},
+  {"init_num_threads", (PyCFunction)THPModule_initNumThreads,   METH_NOARGS,  nullptr},
   {"get_num_interop_threads", (PyCFunction)THPModule_getNumInteropThreads,     METH_NOARGS,  nullptr},
   {"set_num_interop_threads", (PyCFunction)THPModule_setNumInteropThreads,     METH_O,       nullptr},
   {"_get_cudnn_enabled", (PyCFunction)THPModule_userEnabledCuDNN, METH_NOARGS,     nullptr},


### PR DESCRIPTION
Fixes #37259, fixes #20156

This lazily calls `at::init_num_threads` once for each thread by adding a call to `lazy_init_num_threads` in `at::parallel_for` and `at::parallel_reduce`.

If this solution is okay, then we should add the same to guard other places that might use MKL or OpenMP.