### PR TITLE
[jit] fix trace checking reporting divergent names

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -316,6 +316,20 @@ class TestJit(JitTestCase):
 
         traced_rec = torch.jit.trace(rec, (input))
 
+    def test_trace_aliased_input(self):
+        class MyClass(torch.nn.Module):
+            def __init__(self):
+                super(MyClass, self).__init__()
+
+            def forward(self, xs: List[Tensor]):
+                y = torch.cat(xs, dim=0)  # torch.stack() results in error as well
+                return y
+
+
+        model = MyClass()
+        sample = torch.ones(2, 2)
+        m2 = torch.jit.trace(model, ((sample, sample, sample),))
+
     def test_trace_legacy_ctor(self):
         class MyModule(nn.Module):
             def forward(self, x):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -310,9 +310,6 @@ def _create_interpreter_name_lookup_fn(frames_up=1):
         for k, v in f_locals.items():
             if isinstance(v, torch.Tensor) and var is v:
                 return k if k != 'self' else ''
-        for k, v in f_globals.items():
-            if isinstance(v, torch.Tensor) and var is v:
-                return k if k != 'self' else ''
         return ''
     return _get_interpreter_name_for_var
 
@@ -371,20 +368,8 @@ class ONNXTracedModule(Module):
 
 
 def _clone_inputs(args):
-    def clone_input(a):
-        if a is None:
-            return None
-        elif isinstance(a, torch.Tensor):
-            # TODO: figure out one liner to .clone() and set requires_grad
-            v = a.detach().clone(memory_format=torch.preserve_format).requires_grad_(a.requires_grad)
-            if a.grad is not None:
-                v.grad = clone_input(v.grad)
-            return v
-        else:
-            return a.clone(memory_format=torch.preserve_format)
-    return function._nested_map(lambda x: isinstance(x, torch.Tensor),
-                                clone_input, condition_msg="tensors")(args)
-
+    memo = {}
+    return copy.deepcopy(args, memo)
 
 # This is purely for developer debugging.  We are not going to advertise it.
 _JIT_TIME = os.environ.get('PYTORCH_JIT_TIME', False)  # CUDA-only timing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37464 [jit] fix trace checking reporting divergent names**

Fixes https://github.com/pytorch/pytorch/issues/23993.

There are two fixes here:
1. Previously our name lookup function for the tracer was looking in
f.globals for names. For example:
```
sample = torch.ones(1)
traced = torch.jit.trace(my_mod, ((sample, sample,),))
# produces a graph with something like
# %sample, %sample = prim::TupleUnpack(%input)
```
This is not great if you are, e.g. trace checking, because a non-local
bit of interpreter state is affected the graph produced:
```
traced = torch.jit.trace(my_mod, _clone_inputs((sample, sample,),))
# produces a graph with something like
# %0, %1 = prim::TupleUnpack(%input)
```
I have removed this functionality, as I don't think it provides huge
value. Things that look locally for names will still work, so e.g.
inputs, intermediate variables, and the like will be named correctly.

2. Previously, our input cloning for trace checking didn't do a memoized
deep copy. So:
```
_clone_inputs((sample, sample, sample))
```
produces a tuple with three non-aliased tensors. That's wrong! Use
copy.deepcopy with a memoization argument to fix this.

Differential Revision: [D21297549](https://our.internmc.facebook.com/intern/diff/D21297549)