### PR TITLE
[JIT] Convert float Tensor argument to double in prim::tolist

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -992,6 +992,13 @@ class TestList(JitTestCase):
             li = torch.jit.annotate(List[List[List[float]]], x.tolist())
             return li
 
+        # Test with torch.float dtype Tensors to check that they are converted to double automatically.
+        self.checkScript(to_list_float_0D, (torch.randn(5, dtype=torch.float)[0],))
+        self.checkScript(to_list_float_1D, (torch.randn(5, dtype=torch.float),))
+        self.checkScript(to_list_float_2D, (torch.randn(5, 6, dtype=torch.float),))
+        self.checkScript(to_list_float_3D, (torch.randn(5, 6, 7, dtype=torch.float),))
+        self.checkScript(to_list_float_3D, (torch.randn(5, 6, 7, dtype=torch.float).transpose(0, 1),))
+
         self.checkScript(to_list_float_0D, (torch.randn(5, dtype=torch.double)[0],))
         self.checkScript(to_list_float_1D, (torch.randn(5, dtype=torch.double),))
         self.checkScript(to_list_float_2D, (torch.randn(5, 6, dtype=torch.double),))

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -142,6 +142,7 @@ IValue tensorToListRecursive(
     int64_t cur_dim,
     int64_t num_tensor_dims,
     TypePtr ty,
+    at::ScalarType scalar_ty,
     at::IntArrayRef sizes,
     at::IntArrayRef strides,
     size_t element_size) {
@@ -155,7 +156,12 @@ IValue tensorToListRecursive(
       int64_t scalar = *(int64_t*)data;
       return IValue(scalar);
     } else if (ty == FloatType::get()) {
-      double scalar = *(double*)data;
+      TORCH_INTERNAL_ASSERT(
+          scalar_ty == at::ScalarType::Float ||
+              scalar_ty == at::ScalarType::Double,
+          "Unexpected scalar type for Tensor");
+      double scalar =
+          scalar_ty == at::ScalarType::Float ? *(float*)data : *(double*)data;
       return IValue(scalar);
     } else if (ty == BoolType::get()) {
       bool scalar = *(bool*)data;
@@ -178,7 +184,14 @@ IValue tensorToListRecursive(
   // recursively on each slice of the tensor in the current dimension.
   for (int64_t i = 0, e = sizes[cur_dim]; i < e; ++i) {
     auto inner_result = tensorToListRecursive(
-        data, cur_dim + 1, num_tensor_dims, ty, sizes, strides, element_size);
+        data,
+        cur_dim + 1,
+        num_tensor_dims,
+        ty,
+        scalar_ty,
+        sizes,
+        strides,
+        element_size);
 
     if (inner_result.isList()) {
       result.emplace_back(inner_result.toList());

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -60,14 +60,15 @@ void checkImplicitTensorToNum(at::Tensor t, bool toInt);
 // Convert the tensor pointed to by \p data to a nested list. \p dim is the
 // number of dimensions in the tensor and \p cur_dim is the dimension being
 // processed by the current invocation. \p ty is the expected output IR type of
-// the operation. \p sizes and \p strides are the sizes and strides of the
-// tensor operand and \p element_size is the size in bytes of one tensor
-// element.
+// the operation. \p is the scalar type of \p data. \p sizes and \p strides are
+// the sizes and strides of the tensor operand and \p element_size is the size
+// in bytes of one tensor element.
 IValue tensorToListRecursive(
     char* data,
     int64_t cur_dim,
     int64_t num_tensor_dims,
     TypePtr ty,
+    at::ScalarType scalar_ty,
     at::IntArrayRef sizes,
     at::IntArrayRef strides,
     size_t element_size);


### PR DESCRIPTION
**Summary**
Converting a float `Tensor` to a Python list is not supported because
Python's float is actually a double. This commit modifies the
implementation of `prim::tolist` so that it converts an input argument
that is a float Tensor into a double Tensor and emits a warning.

**Test Plan**
Modified and ran the corresponding unit test.

*Before*
```
======================================================================
ERROR: test_to_list (jit.test_list_dict.TestList)
Unit tests for Tensor.tolist() function.
----------------------------------------------------------------------
...
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
RuntimeError: Output annotation element type and runtime tensor element type must match for tolist()
----------------------------------------------------------------------
Ran 1 test in 0.151s

FAILED (errors=1)
```

*After*
```
UserWarning: Converting float Tensor to double because tolist is only supported for double type Tensors (Triggered internally at  ../torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp:626.)
  return callable(*args, **kwargs)
.
----------------------------------------------------------------------
Ran 1 test in 0.210s

OK
```

