### PR TITLE
graph mode: add hardtanh op

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1593,6 +1593,7 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                 self.conv = torch.nn.Conv2d(3, 3, 3)
                 self.sigmoid = torch.nn.Sigmoid()
                 self.tanh = torch.nn.Tanh()
+                self.hardtanh = torch.nn.Hardtanh()
 
             def forward(self, x):
                 x = self.conv(x)
@@ -1639,6 +1640,7 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                 x = self.tanh(x)
                 x = F.tanh(x)
                 x = torch.tanh(x)
+                x = self.hardtanh(x)
                 x = F.hardtanh(x)
                 x = self.conv(x)
                 return x

--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1165,11 +1165,7 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
     def _test_op_impl(self, module, data, quantized_op):
         qconfig_dict = {'': get_default_qconfig('fbgemm')}
         model = torch.jit.script(module).eval()
-        print(1)
-        print(model._c.dump_to_str(True, False, False))
         model = quantize_script(model, qconfig_dict, _test_only_eval_fn, [data], inplace=False)
-        print(2)
-        print(model._c.dump_to_str(True, False, False))
         FileCheck().check(quantized_op) \
                    .run(model.graph)
 
@@ -1576,22 +1572,6 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                        .check_not("aten::relu") \
                        .check_not("quantized::relu") \
                        .run(m.graph)
-
-    def test_hardtanh(self):
-        class Hardtanh(torch.nn.Module):
-            def __init__(self):
-                super(Hardtanh, self).__init__()
-
-            def forward(self, x):
-                return F.hardtanh(x)
-
-        data = [
-            (torch.rand((1, 3, 10, 10), dtype=torch.float),
-             torch.randint(0, 1, (1,), dtype=torch.long)) for _ in range(2)]
-
-        m = self._test_op_impl(Hardtanh(), data, "quantized::hardtanh")
-        print(m)
-
 
     def test_swap_dequantize_all_ops(self):
         """ A test that checks dequantize will be swapped for

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -90,6 +90,7 @@ std::vector<std::string> _single_input_general_call_funcs = {
     "relu",
     "sigmoid",
     "tanh",
+    "hardtanh",
 };
 
 // Similar to prim::CallFunctions, there are aten ops that doesn't
@@ -130,6 +131,7 @@ std::vector<std::string> _single_input_general_aten_funcs = {
     "relu",
     "sigmoid",
     "tanh",
+    "hardtanh",
 };
 
 struct FuncArg {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37525 graph mode: add handling for layer_norm op
* #37524 graph mode: add hardswish op
* #37523 graph mode: refactor quantized hardswish API for easier graph handling
* #37522 graph mode: add hardsigmoid op
* #37521 graph mode: add elu op
* **#37469 graph mode: add hardtanh op**

Summary:

Adds graph mode handling for hardtanh op.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21310362](https://our.internmc.facebook.com/intern/diff/D21310362)