### PR TITLE
[ONNX] Correct Tensor type in testing for ONNX to meet the constraint

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -973,7 +973,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
             def forward(self, x, y):
                 return x.ge(0.5) & y.le(2)
 
-        x = torch.ones(2, 3, dtype=torch.float)
+        x = torch.ones(2, 3, dtype=torch.double)
         y = torch.ones(2, 3, dtype=torch.float32)
         self.run_model_test(ComparisonModel(), input=(x, y), train=False, batch_size=BATCH_SIZE)
 

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -973,7 +973,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
             def forward(self, x, y):
                 return x.ge(0.5) & y.le(2)
 
-        x = torch.ones(2, 3, dtype=torch.int32)
+        x = torch.ones(2, 3, dtype=torch.float)
         y = torch.ones(2, 3, dtype=torch.float32)
         self.run_model_test(ComparisonModel(), input=(x, y), train=False, batch_size=BATCH_SIZE)
 


### PR DESCRIPTION
Fixes https://github.com/onnx/onnx/pull/2744

This PR is for correcting the Tensor type in ONNX test in order to pass the stricter onnx checker.
According to the [document](https://github.com/onnx/onnx/blob/master/docs/Operators.md), the valid tensor type includes "double", "float" and "float16" for certain functions. 

I am improving the onnx checker for detecting malformed models. This modification is required to solve the onnx-build-CI failures caused by PyTorch/Caffe2 tests. 

cc @BowenBao @neginraoof