### PR TITLE
Skips test_tiny_half_norm_ on ROCm

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1813,6 +1813,7 @@ class TestCuda(TestCase):
         counted = t.bincount(minlength=65536)
         self.assertEqual(torch.sum(counted), 10)
 
+    @skipIfRocm
     def test_tiny_half_norm_(self):
         a = torch.arange(25).cuda().float()
         a /= 100000000


### PR DESCRIPTION
Skips test_tiny_half_norm_ on ROCm.

See issue: https://github.com/pytorch/pytorch/issues/37493.