### PR TITLE
simplify logic for CUDA_ALWAYS_ASSERT

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -228,14 +228,13 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #define CUDA_ALWAYS_ASSERT(cond)
 #else // __APPLE__, _MSC_VER
 #if defined(NDEBUG)
+
+#if (defined(__CUDA_ARCH__) ||  defined(__HIP_ARCH__))
 extern "C" {
-#if !defined(__CUDA_ARCH__)  || !defined(__clang__)
+#if !defined(__CUDA_ARCH__)
   [[noreturn]]
 #endif
-#if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__))) || \
-    defined(__HIP_ARCH__) || defined(__HIP__)
 __host__ __device__
-#endif // __CUDA_ARCH__
     void
     __assert_fail(
         const char* assertion,
@@ -243,6 +242,8 @@ __host__ __device__
         unsigned int line,
         const char* function) throw();
 }
+#endif // __CUDA_ARCH__
+
 #endif // NDEBUG
 #define CUDA_ALWAYS_ASSERT(cond)                                         \
   if (C10_UNLIKELY(!(cond))) {                                           \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37509 simplify logic for CUDA_ALWAYS_ASSERT**

The definition of assert_fail only needs
to exist for cuda device code where CUDA_ALWAYS_ASSERT is used.
All of the compilcated ifdef logic is only applying in cases
where it doesn't need declaration in the first place

Differential Revision: [D21304581](https://our.internmc.facebook.com/intern/diff/D21304581/)