### PR TITLE
Let RPC return FutureIValue instead of FutureMessage

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -62,7 +62,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
   m.def(
       "_call_end_callbacks_on_fut",
       [](const at::Tensor& handle,
-         const std::shared_ptr<torch::distributed::rpc::FutureMessage>& fut) {
+         const std::shared_ptr<torch::distributed::rpc::FutureIValue>& fut) {
         torch::autograd::profiler::_call_end_callbacks_on_fut(handle, fut);
       });
 #endif

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -331,13 +331,17 @@ PyObject* rpc_init(PyObject* /* unused */) {
   // pythonRpcHandler is cleaned up in shutdown(), after
   // shutdown(), python objects returned from rpc python call can not be
   // resolved.
-  // TODO Once python object can be tagged as IValue and c10::ivalue::Future is
-  // implemented as generic Future<IValue>, we can consider all rpc call
-  // to return a future<IValue> later on.
-  auto future = shared_ptr_class_<FutureMessage>(module, "Future")
+  auto future = shared_ptr_class_<FutureIValue>(module, "Future")
                     .def(
                         "wait",
-                        [&](FutureMessage& fut) { return toPyObj(fut.wait()); },
+                        [&](FutureIValue& fut) {
+                            auto& pythonRpcHandler = PythonRpcHandler::getInstance();
+                            const auto& value = fut.wait();
+                            pybind11::gil_scoped_acquire ag;
+                            auto obj = torch::jit::toPyObject(value);
+                            pythonRpcHandler.handleException(obj);
+                            return obj;
+                        },
                         py::call_guard<py::gil_scoped_release>(),
                         R"(
 Wait on future to complete and return the object it completed with.

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -335,12 +335,13 @@ PyObject* rpc_init(PyObject* /* unused */) {
                     .def(
                         "wait",
                         [&](FutureIValue& fut) {
-                            auto& pythonRpcHandler = PythonRpcHandler::getInstance();
-                            const auto& value = fut.wait();
-                            pybind11::gil_scoped_acquire ag;
-                            auto obj = torch::jit::toPyObject(value);
-                            pythonRpcHandler.handleException(obj);
-                            return obj;
+                          auto& pythonRpcHandler =
+                              PythonRpcHandler::getInstance();
+                          const auto& value = fut.wait();
+                          pybind11::gil_scoped_acquire ag;
+                          auto obj = torch::jit::toPyObject(value);
+                          pythonRpcHandler.handleException(obj);
+                          return obj;
                         },
                         py::call_guard<py::gil_scoped_release>(),
                         R"(

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -128,6 +128,8 @@ TORCH_API Message createExceptionResponse(const std::exception& e, int64_t id);
 TORCH_API Message
 createExceptionResponse(const std::string& exceptionStr, int64_t id);
 
+// FutureMessage is an internal type used in the communication layer. All
+// user-facing surface APIs should use FutureIValue instead.
 using FutureMessage = torch::utils::Future<Message>;
 using FutureIValue = torch::utils::Future<at::IValue>;
 

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -128,7 +128,8 @@ TORCH_API Message createExceptionResponse(const std::exception& e, int64_t id);
 TORCH_API Message
 createExceptionResponse(const std::string& exceptionStr, int64_t id);
 
-typedef torch::utils::Future<Message> FutureMessage;
+using FutureMessage = torch::utils::Future<Message>;
+using FutureIValue = torch::utils::Future<at::IValue>;
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -19,10 +19,7 @@ std::shared_ptr<FutureIValue> toFutureIValue(
   auto fv = std::make_shared<FutureIValue>();
 
   fm->addCallback(
-      [fv](const FutureMessage& fm) {
-        fv->markCompleted(IValue());
-      }
-  );
+      [fv](const FutureMessage& fm) { fv->markCompleted(IValue()); });
 
   return fv;
 }

--- a/torch/csrc/distributed/rpc/py_rref.h
+++ b/torch/csrc/distributed/rpc/py_rref.h
@@ -30,7 +30,7 @@ class PyRRef {
   // Future that is associated with the creation of this RRef on the remote end.
   // This is only used to get the future corresponding to the rref for profiling
   // use cases.
-  const std::shared_ptr<FutureMessage> getFuture() const;
+  const std::shared_ptr<FutureIValue> getFuture() const;
 
   // create a proxy on this RRef, which can be used to launch RPC on the owner
   // of this RRef to run functions on the object referenced by this RRef.

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -18,7 +18,7 @@ namespace rpc {
 // FutureError if there is an error.
 std::shared_ptr<FutureIValue> toFutureIValue(
     const std::shared_ptr<FutureMessage>& fm,
-    bool hasValue=true);
+    bool hasValue = true);
 
 std::shared_ptr<FutureIValue> pyRpcBuiltin(
     const WorkerInfo& dst,

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -8,7 +8,17 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-py::object toPyObj(const Message& message);
+// Converts an internal FutureMessage type into a user-facing FutureIValue type
+// by creating a new FutureIValue and call its markCompleted as a callback in
+// the given FutureMessage.
+// If hasValue is true, the Message will be converted into a py::object and then
+// wrap it with an IValue. If hasValue is false, this FutureIValue is only used
+// for signaling and launching callbacks. In this case, the message will be
+// discarded and then set the FutureIValue using an empty IValue or the given
+// FutureError if there is an error.
+std::shared_ptr<FutureIValue> toFutureIValue(
+    const std::shared_ptr<FutureMessage>& fm,
+    bool hasValue=true);
 
 std::shared_ptr<FutureIValue> pyRpcBuiltin(
     const WorkerInfo& dst,

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -10,14 +10,14 @@ namespace rpc {
 
 py::object toPyObj(const Message& message);
 
-std::shared_ptr<FutureMessage> pyRpcBuiltin(
+std::shared_ptr<FutureIValue> pyRpcBuiltin(
     const WorkerInfo& dst,
     const std::string& opName,
     const py::args& args,
     const py::kwargs& kwargs,
     const float rpcTimeoutSeconds);
 
-std::shared_ptr<FutureMessage> pyRpcPythonUdf(
+std::shared_ptr<FutureIValue> pyRpcPythonUdf(
     const WorkerInfo& dst,
     std::string& pickledPythonUDF,
     std::vector<torch::Tensor>& tensors,

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -336,7 +336,7 @@ void RequestCallbackImpl::processRpc(
         // Our response is satisfied when the rpc.remote() request
         // finishes executing on the owner.
         whenValueSet->addCallback([responseFuture, messageId, rref](
-                                      const FutureMessage& whenValueSet) {
+                                      const FutureIValue& whenValueSet) {
           if (whenValueSet.hasError()) {
             responseFuture->setError(*whenValueSet.error());
             return;
@@ -378,7 +378,7 @@ void RequestCallbackImpl::processRpc(
         // Our response is satisfied when the the rpc.remote() request
         // finishes executing on the owner.
         whenValueSet->addCallback([responseFuture, messageId, rref](
-                                      const FutureMessage& whenValueSet) {
+                                      const FutureIValue& whenValueSet) {
           if (whenValueSet.hasError()) {
             responseFuture->setError(*whenValueSet.error());
             return;

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -366,16 +366,17 @@ class TORCH_API OwnerRRef final : public RRef {
   // Has a value or error been set?
   bool hasValue() const;
   // Gets a future that is satisfied when the value or error is set.
-  std::shared_ptr<FutureMessage> getFuture();
+  std::shared_ptr<FutureIValue> getFuture();
 
  private:
   friend class RRefContext;
 
+  // TODO: consolidate value_ into future_
   c10::optional<IValue> value_;
   c10::optional<std::string> error_;
   mutable std::mutex mutex_;
   mutable std::condition_variable valueCV_;
-  std::shared_ptr<FutureMessage> future_;
+  std::shared_ptr<FutureIValue> future_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -371,7 +371,7 @@ class TORCH_API OwnerRRef final : public RRef {
  private:
   friend class RRefContext;
 
-  // TODO: consolidate value_ into future_
+  // See #32608 for dicussion on whether value_ should be merged into future_
   c10::optional<IValue> value_;
   c10::optional<std::string> error_;
   mutable std::mutex mutex_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37536 Cleanup internal functions in python_functions.cpp
* #37520 Minor format cleanup in py_rref.cpp
* **#37519 Let RPC return FutureIValue instead of FutureMessage**

closes #37446

Currently FutureMessage is used in several places:

1. `rpc_async` returns a `FutureMessage` object and we expose it
   as `torch.distributed.rpc.Future`. From applications perspective,
   they are expecting a `py::object` instead of a `Message`, and we
   do the conversion in the `Future.wait()` pybind method.
2. RPC autograd profiler takes `FutureMessage` and installs
   callbacks to it. The profiler actually only need a `Future<T>`
   and does not care what `T` is.
3. `OwnerRRef` exposes a `getFuture()` API which returns a
   `FutureMessage`. This `FutureMessage` will be marked completed
   when the value referenced by the `OwnerRRef` is ready.
   `OwnerRRef` does not need it to be a Message type either, it
   actually creates an empty `Message` to mark the `Future`.

The above places are using `FutureMessage`, but they don't really
need a `Message`, and `Message` is a communication layer type that
applications or profiler or the RRef shouldn't be aware of.

Another motivation for making this change is that for async RPC
UDF #36071, we are going to allow application to call
`markCompleted` in Python. If we still use `FutureMessage`, then
in the `markCompleted` pybind function, it needs to convert the
provided `py::object` into a specific message type, which is
leaking communication layer code to pybind functions. Even if
this is doable, we will have two entities (RPC agent and pybind
Python frontend) accessing the same request callback logic. This is too messy.

This commit replaces all surface `FutureMessage` with `FutureIValue`,
so that `FutureMessage` is no longer visible from Python land. Note
that this does not cause BC issues, as the Python Future type name
and its API stay intact. Internally, we still have `FutureMessage`
in the communication layer.

Differential Revision: [D21308887](https://our.internmc.facebook.com/intern/diff/D21308887)