### PR TITLE
Minor format cleanup in py_rref.cpp

### DIFF
--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -36,6 +36,7 @@ py::tuple toPyTuple(const RRefForkData& rrefForkData) {
       rrefForkData.parent_,
       rrefForkData.typeStr_);
 }
+
 RRefForkData fromPyTuple(const py::tuple& pyTuple) {
   // add GIL as it is accessing a py::object
   pybind11::gil_scoped_acquire ag;
@@ -103,7 +104,7 @@ TypePtr tryInferTypeWithTypeHint(
   // Otherwise it's a pure pyobject, create the RRef
   // that holds an IValue of an pyobject.
   return PyObjectType::get();
-} // namespace
+}
 
 } // namespace
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37536 Cleanup internal functions in python_functions.cpp
* **#37520 Minor format cleanup in py_rref.cpp**
* #37519 Let RPC return FutureIValue instead of FutureMessage

Differential Revision: [D21308889](https://our.internmc.facebook.com/intern/diff/D21308889)