### PR TITLE
graph mode: add elu op

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1594,6 +1594,7 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                 self.sigmoid = torch.nn.Sigmoid()
                 self.tanh = torch.nn.Tanh()
                 self.hardtanh = torch.nn.Hardtanh()
+                self.elu = torch.nn.ELU()
 
             def forward(self, x):
                 x = self.conv(x)
@@ -1642,6 +1643,8 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                 x = torch.tanh(x)
                 x = self.hardtanh(x)
                 x = F.hardtanh(x)
+                x = self.elu(x)
+                x = F.elu(x)
                 x = self.conv(x)
                 return x
 

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -91,6 +91,7 @@ std::vector<std::string> _single_input_general_call_funcs = {
     "sigmoid",
     "tanh",
     "hardtanh",
+    "elu",
 };
 
 // Similar to prim::CallFunctions, there are aten ops that doesn't
@@ -132,6 +133,7 @@ std::vector<std::string> _single_input_general_aten_funcs = {
     "sigmoid",
     "tanh",
     "hardtanh",
+    "elu",
 };
 
 struct FuncArg {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37525 graph mode: add handling for layer_norm op
* #37524 graph mode: add hardswish op
* #37523 graph mode: refactor quantized hardswish API for easier graph handling
* #37522 graph mode: add hardsigmoid op
* **#37521 graph mode: add elu op**
* #37469 graph mode: add hardtanh op

Summary:

Adds ELU to graph mode handling.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21310361](https://our.internmc.facebook.com/intern/diff/D21310361)