### PR TITLE
graph mode: add hardsigmoid op

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1595,6 +1595,7 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                 self.tanh = torch.nn.Tanh()
                 self.hardtanh = torch.nn.Hardtanh()
                 self.elu = torch.nn.ELU()
+                self.hardsigmoid = torch.nn.Hardsigmoid()
 
             def forward(self, x):
                 x = self.conv(x)
@@ -1645,6 +1646,8 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                 x = F.hardtanh(x)
                 x = self.elu(x)
                 x = F.elu(x)
+                x = self.hardsigmoid(x)
+                x = F.hardsigmoid(x)
                 x = self.conv(x)
                 return x
 

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -92,6 +92,7 @@ std::vector<std::string> _single_input_general_call_funcs = {
     "tanh",
     "hardtanh",
     "elu",
+    "hardsigmoid",
 };
 
 // Similar to prim::CallFunctions, there are aten ops that doesn't
@@ -134,6 +135,7 @@ std::vector<std::string> _single_input_general_aten_funcs = {
     "tanh",
     "hardtanh",
     "elu",
+    "hardsigmoid",
 };
 
 struct FuncArg {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37525 graph mode: add handling for layer_norm op
* #37524 graph mode: add hardswish op
* #37523 graph mode: refactor quantized hardswish API for easier graph handling
* **#37522 graph mode: add hardsigmoid op**
* #37521 graph mode: add elu op
* #37469 graph mode: add hardtanh op

Summary:

Adds hardsigmoid op to graph mode handling.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21310363](https://our.internmc.facebook.com/intern/diff/D21310363)