### PR TITLE
graph mode: refactor quantized hardswish API for easier graph handling

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5950,11 +5950,6 @@
 
 - func: hardswish.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
-  dispatch:
-    CPU: hardswish_out
-    CUDA: hardswish_out
-    QuantizedCPU: quantized_hardswish_out
-
 
 - func: hardswish(Tensor self) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
@@ -65,7 +65,15 @@ Tensor qnnpack_hardswish(const Tensor& qx, Tensor& qy) {
 
 } // namespace
 
-Tensor& quantized_hardswish_out(Tensor& qy, const Tensor& qx) {
+Tensor quantized_hardswish(const Tensor& qx, double output_scale, int64_t output_zero_point) {
+  Tensor qy = at::_empty_affine_quantized(
+      qx.sizes(),
+      at::device(kCPU)
+        .dtype(qx.scalar_type()),
+        // .memory_format(MemoryFormat::ChannelsLast),
+      output_scale,
+      output_zero_point,
+      c10::nullopt);
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
       qx.scalar_type() == kQUInt8) {
@@ -77,6 +85,10 @@ Tensor& quantized_hardswish_out(Tensor& qy, const Tensor& qx) {
 #endif  // USE_PYTORCH_QNNPACK
   qhardswish_stub(qx.device().type(), qx, qy);
   return qy;
+}
+
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl("hardswish", quantized_hardswish);
 }
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -30,6 +30,7 @@ TORCH_LIBRARY(quantized, m) {
   m.def("conv_unpack(Tensor packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)");
   m.def("conv2d_unpack(Tensor packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)");
   m.def("conv3d_unpack(Tensor packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)");
+  m.def("hardswish(Tensor input, float output_scale, int output_zero_point) -> Tensor");
   m.def("layer_norm(Tensor input, int[] normalized_shape, Tensor weight, Tensor bias, float eps, float output_scale, int output_zero_point) -> Tensor");
   m.def("linear(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y");
   m.def("linear_relu(Tensor X, Tensor W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y");

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -395,10 +395,7 @@ def hardswish(input, scale, zero_point):
     """
     if not input.is_quantized:
         raise ValueError("Input to 'quantized.hardswish' must be quantized!")
-    output = torch._empty_affine_quantized(
-        input.shape, scale=scale, zero_point=int(zero_point), dtype=input.dtype)
-    torch._C._nn.hardswish(input, out=output)
-    return output
+    return torch._ops.ops.quantized.hardswish(input, scale, zero_point)
 
 def elu(input, alpha=1., inplace=False, scale=None, zero_point=None):
     # type: (Tensor, Optional[float], bool, Optional[float], Optional[int]) -> Tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37525 graph mode: add handling for layer_norm op
* #37524 graph mode: add hardswish op
* **#37523 graph mode: refactor quantized hardswish API for easier graph handling**
* #37522 graph mode: add hardsigmoid op
* #37521 graph mode: add elu op
* #37469 graph mode: add hardtanh op

Summary:

Makes the quantized hardswish function API more suited to graph mode
handling, which will come in the next PR.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21310364](https://our.internmc.facebook.com/intern/diff/D21310364)