### PR TITLE
graph mode: add hardswish op

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1573,6 +1573,12 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                        .check_not("quantized::relu") \
                        .run(m.graph)
 
+    def test_hardswish(self):
+        data = [(torch.rand((1, 3, 10, 10), dtype=torch.float), torch.randint(0, 1, (1,), dtype=torch.long)) for _ in range(2)]
+        m = self._test_op_impl(torch.nn.Hardswish(), data, "quantized::hardswish")
+        FileCheck().check_not("aten::hardswish") \
+                   .run(m.graph)
+
     def test_swap_dequantize_all_ops(self):
         """ A test that checks dequantize will be swapped for
         all supported general ops without actually checking for execution of these ops

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -51,6 +51,7 @@ std::vector<std::string> _quantizable_call_funcs = {
     "conv2d",
     "linear",
     "batch_norm",
+    "hardswish",
 };
 
 std::vector<std::string> _quantizable_aten_funcs = {
@@ -65,6 +66,7 @@ std::vector<std::string> _quantizable_aten_funcs = {
     "lstm",
     "mul",
     "mul_",
+    "hardswish",
 };
 
 // These are the prim::CallFunctions that doesn't require observation and

--- a/torch/csrc/jit/passes/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization_patterns.h
@@ -406,6 +406,20 @@ graph(%a_quant, %b_scalar):
 graph(%a_quant, %b_scalar):
          %r = quantized::mul_scalar_relu_out(%a_quant, %b_scalar, %a_quant)
          return (%r) )";
+
+  // quantized::hardswish
+  std::string hardswish = R"(
+graph(%a_quant, %r_scale, %r_zero_point, %r_dtype):
+         %a_dequant = aten::dequantize(%a_quant)
+         %r = aten::hardswish(%a_dequant)
+         %r_quant = aten::quantize_per_tensor(%r, %r_scale, %r_zero_point, %r_dtype)
+         return (%r_quant) )";
+
+  std::string quantized_hardswish = R"(
+graph(%a_quant, %r_scale, %r_zero_point, %r_dtype):
+         %r_quant = quantized::hardswish(%a_quant, %r_scale, %r_zero_point)
+         return (%r_quant) )";
+
   return {
       {"quantized::conv2d", conv2d, quantized_conv2d},
       {"quantized::conv2d_relu", conv2d_relu, quantized_conv2d_relu},
@@ -465,6 +479,7 @@ graph(%a_quant, %b_scalar):
       {"quantized::mul_relu", mul_inplace_relu, quantized_mul_relu},
       {"quantized::mul_relu", inplace_mul_relu, quantized_mul_relu},
       {"quantized::mul_relu", inplace_mul_inplace_relu, quantized_mul_relu},
+      {"quantized::hardswish", hardswish, quantized_hardswish},
   };
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37525 graph mode: add handling for layer_norm op
* **#37524 graph mode: add hardswish op**
* #37523 graph mode: refactor quantized hardswish API for easier graph handling
* #37522 graph mode: add hardsigmoid op
* #37521 graph mode: add elu op
* #37469 graph mode: add hardtanh op

Summary:

Adds graph mode handling for the hardswish op.

Test Plan:

```
python test/test_quantization.py TestQuantizeScriptPTSQOps.test_hardswish
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21310365](https://our.internmc.facebook.com/intern/diff/D21310365)