### PR TITLE
graph mode: add handling for layer_norm op

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1579,6 +1579,14 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
         FileCheck().check_not("aten::hardswish") \
                    .run(m.graph)
 
+    def test_layer_norm(self):
+        data = [(torch.rand((1, 3, 10, 10), dtype=torch.float), torch.randint(0, 1, (1,), dtype=torch.long)) for _ in range(2)]
+        layer_norm = torch.nn.LayerNorm([3, 10, 10])
+        m = self._test_op_impl(layer_norm, data, "quantized::layer_norm")
+        FileCheck().check_not("aten::layer_norm") \
+                   .run(m.graph)
+
+
     def test_swap_dequantize_all_ops(self):
         """ A test that checks dequantize will be swapped for
         all supported general ops without actually checking for execution of these ops

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -52,6 +52,7 @@ std::vector<std::string> _quantizable_call_funcs = {
     "linear",
     "batch_norm",
     "hardswish",
+    "layer_norm",
 };
 
 std::vector<std::string> _quantizable_aten_funcs = {
@@ -67,6 +68,7 @@ std::vector<std::string> _quantizable_aten_funcs = {
     "mul",
     "mul_",
     "hardswish",
+    "layer_norm",
 };
 
 // These are the prim::CallFunctions that doesn't require observation and

--- a/torch/csrc/jit/passes/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization_patterns.h
@@ -420,6 +420,19 @@ graph(%a_quant, %r_scale, %r_zero_point, %r_dtype):
          %r_quant = quantized::hardswish(%a_quant, %r_scale, %r_zero_point)
          return (%r_quant) )";
 
+  // quantized::layer_norm
+  std::string layer_norm = R"(
+graph(%a_quant, %normalized_shape, %weight, %bias, %eps, %cudnn_enabled, %output_scale, %output_zero_point, %scalar_type):
+         %a_dequant = aten::dequantize(%a_quant)
+         %r_ln = aten::layer_norm(%a_dequant, %normalized_shape, %weight, %bias, %eps, %cudnn_enabled)
+         %r = aten::quantize_per_tensor(%r_ln, %output_scale, %output_zero_point, %scalar_type)
+         return (%r) )";
+
+  std::string quantized_layer_norm = R"(
+graph(%a_quant, %normalized_shape, %weight, %bias, %eps, %cudnn_enabled, %output_scale, %output_zero_point, %scalar_type):
+         %r = quantized::layer_norm(%a_quant, %normalized_shape, %weight, %bias, %eps, %output_scale, %output_zero_point)
+         return (%r) )";
+
   return {
       {"quantized::conv2d", conv2d, quantized_conv2d},
       {"quantized::conv2d_relu", conv2d_relu, quantized_conv2d_relu},
@@ -480,6 +493,7 @@ graph(%a_quant, %r_scale, %r_zero_point, %r_dtype):
       {"quantized::mul_relu", inplace_mul_relu, quantized_mul_relu},
       {"quantized::mul_relu", inplace_mul_inplace_relu, quantized_mul_relu},
       {"quantized::hardswish", hardswish, quantized_hardswish},
+      {"quantized::layer_norm", layer_norm, quantized_layer_norm},
   };
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37525 graph mode: add handling for layer_norm op**
* #37524 graph mode: add hardswish op
* #37523 graph mode: refactor quantized hardswish API for easier graph handling
* #37522 graph mode: add hardsigmoid op
* #37521 graph mode: add elu op
* #37469 graph mode: add hardtanh op

Summary:

Adds graph mode handling for the layer_norm op

Test Plan:

```
python test/test_quantization.py TestQuantizeScriptPTSQOps.test_layer_norm
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21310360](https://our.internmc.facebook.com/intern/diff/D21310360)