### PR TITLE
Remove Backend -> THPLayout mapping.

### DIFF
--- a/c10/core/Layout.h
+++ b/c10/core/Layout.h
@@ -6,7 +6,7 @@
 #include <iostream>
 
 namespace c10 {
-enum class Layout : int8_t { Strided, Sparse, Mkldnn };
+enum class Layout : int8_t { Strided, Sparse, Mkldnn, NumOptions };
 
 constexpr auto kStrided = Layout::Strided;
 constexpr auto kSparse = Layout::Sparse;

--- a/tools/autograd/templates/python_nn_functions.cpp
+++ b/tools/autograd/templates/python_nn_functions.cpp
@@ -37,7 +37,7 @@ static PyObject * THPVariable__parse_to(PyObject* module, PyObject* args, PyObje
     PyTuple_SET_ITEM(tuple.get(), 0, Py_None);
   }
   if (scalarType) {
-    PyTuple_SET_ITEM(tuple.get(), 1, torch::autograd::utils::wrap(torch::getDtype(*scalarType)));
+    PyTuple_SET_ITEM(tuple.get(), 1, torch::autograd::utils::wrap(torch::getTHPDtype(*scalarType)));
   } else {
     Py_INCREF(Py_None);
     PyTuple_SET_ITEM(tuple.get(), 1, Py_None);

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -32,7 +32,7 @@ THPDtype* dtype_registry
   [static_cast<int>(at::ScalarType::NumOptions)] = {};
 
 THPLayout* layout_registry
-  [static_cast<int>(at::Backend::NumOptions)] = {};
+  [static_cast<int>(at::Layout::NumOptions)] = {};
 
 at::Backend get_backend(bool is_cuda, bool is_sparse) {
   if (is_cuda) {
@@ -84,11 +84,11 @@ void registerDtypeObject(THPDtype *dtype, at::ScalarType scalarType) {
   dtype_registry[static_cast<int>(scalarType)] = dtype;
 }
 
-void registerLayoutObject(THPLayout *layout, at::Backend backend) {
-  layout_registry[static_cast<int>(backend)] = layout;
+void registerLayoutObject(THPLayout *thp_layout, at::Layout layout) {
+  layout_registry[static_cast<int>(layout)] = thp_layout;
 }
 
-THPDtype* getDtype(at::ScalarType scalarType) {
+THPDtype* getTHPDtype(at::ScalarType scalarType) {
   auto dtype = dtype_registry[static_cast<int>(scalarType)];
   if (!dtype) {
     throw std::invalid_argument("unsupported scalarType");
@@ -96,12 +96,12 @@ THPDtype* getDtype(at::ScalarType scalarType) {
   return dtype;
 }
 
-THPLayout* getLayout(at::Backend backend) {
-  auto layout = layout_registry[static_cast<int>(backend)];
-  if (!layout) {
-    throw std::invalid_argument("unsupported at::Backend");
+THPLayout* getTHPLayout(at::Layout layout) {
+  auto thp_layout = layout_registry[static_cast<int>(layout)];
+  if (!thp_layout) {
+    throw std::invalid_argument("unsupported at::Layout");
   }
-  return layout;
+  return thp_layout;
 }
 
 PyObject* createPyObject(const at::Storage& storage)

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -7,6 +7,7 @@
 #include <ATen/Device.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/Backend.h>
+#include <c10/core/Layout.h>
 
 #include <memory>
 #include <string>
@@ -24,12 +25,12 @@ void registerStoragePyTypeObject(
     PyTypeObject *pytype, at::Backend backend, at::ScalarType scalarType);
 
 void registerDtypeObject(THPDtype *dtype, at::ScalarType scalarType);
-void registerLayoutObject(THPLayout *layout, at::Backend backend);
+void registerLayoutObject(THPLayout *thp_layout, at::Layout layout);
 
 PyObject* createPyObject(const at::Storage& storage);
 at::Storage createStorage(PyObject* obj);
 bool isStorage(PyObject* obj);
 
-THPDtype* getDtype(at::ScalarType scalarType);
-THPLayout* getLayout(at::Backend backend);
+THPDtype* getTHPDtype(at::ScalarType scalarType);
+THPLayout* getTHPLayout(at::Layout layout);
 }  // namespace torch

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -476,7 +476,7 @@ PyObject *THPModule_setFlushDenormal(PyObject *_unused, PyObject *arg) {
 PyObject *THPModule_getDefaultDtype(PyObject *_unused, PyObject *arg) {
   HANDLE_TH_ERRORS
   auto scalar_type = torch::tensors::get_default_scalar_type();
-  auto dtype = (PyObject*)torch::getDtype(scalar_type);
+  auto dtype = (PyObject*)torch::getTHPDtype(scalar_type);
   Py_INCREF(dtype);
   return dtype;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -498,14 +498,14 @@ static PyObject *THPVariable_dtype(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
   auto& self_ = self->cdata;
-  return torch::autograd::utils::wrap(torch::getDtype(self_.scalar_type()));
+  return torch::autograd::utils::wrap(torch::getTHPDtype(self_.scalar_type()));
   END_HANDLE_TH_ERRORS
 }
 
 static PyObject * THPVariable_layout(THPVariable* self, void *unused) {
   HANDLE_TH_ERRORS
   auto& self_ = self->cdata;
-  return torch::autograd::utils::wrap(torch::getLayout(self_.options().backend()));
+  return torch::autograd::utils::wrap(torch::getTHPLayout(self_.layout()));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -49,12 +49,16 @@ inline PyObject* wrap(THPDtype *dtype) {
 }
 
 inline PyObject* wrap(at::ScalarType scalarType) {
-  return wrap(getDtype(scalarType));
+  return wrap(getTHPDtype(scalarType));
 }
 
 inline PyObject* wrap(THPLayout *layout) {
   Py_INCREF(layout);
   return (PyObject*)layout;
+}
+
+inline PyObject* wrap(at::Layout layout) {
+  return wrap(getTHPLayout(layout));
 }
 
 inline PyObject* wrap(at::Tensor tensor) {

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -289,7 +289,7 @@ static PyObject * THPStorage_(dtype)(THPStorage *self, void *unused)
 {
   HANDLE_TH_ERRORS
   return torch::autograd::utils::wrap(
-      torch::getDtype(at::typeMetaToScalarType(self->cdata->dtype())));
+      torch::getTHPDtype(at::typeMetaToScalarType(self->cdata->dtype())));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -211,8 +211,8 @@ static void set_type(PyTensorType& type_obj, Backend backend, ScalarType scalarT
   // This field is lazily initialized from backend and scalar_type
   type_obj.backend = static_cast<int>(backend);
   type_obj.scalar_type = static_cast<int>(scalarType);
-  type_obj.layout = torch::getLayout(backend);
-  type_obj.dtype = torch::getDtype(scalarType);
+  type_obj.layout = torch::getTHPLayout(layout_from_backend(backend));
+  type_obj.dtype = torch::getTHPDtype(scalarType);
   type_obj.is_cuda = (backend == at::Backend::CUDA || backend == at::Backend::SparseCUDA);
 }
 

--- a/torch/csrc/utils/tensor_layouts.cpp
+++ b/torch/csrc/utils/tensor_layouts.cpp
@@ -19,27 +19,21 @@ void initializeLayouts() {
     throw python_error();
   }
   // for now, let's look these up by Backend; we could create our own enum in the future.
-  registerLayoutObject((THPLayout*)strided_layout, at::Backend::CPU);
-  registerLayoutObject((THPLayout*)strided_layout, at::Backend::CUDA);
-  registerLayoutObject((THPLayout*)strided_layout, at::Backend::MSNPU);
-  registerLayoutObject((THPLayout*)strided_layout, at::Backend::XLA);
-  registerLayoutObject((THPLayout*)strided_layout, at::Backend::QuantizedCPU);
-  registerLayoutObject((THPLayout*)strided_layout, at::Backend::QuantizedCUDA);
+  registerLayoutObject((THPLayout*)strided_layout, at::Layout::Strided);
 
   PyObject *sparse_coo_layout = THPLayout_New(at::Layout::Sparse, "torch.sparse_coo");
   Py_INCREF(sparse_coo_layout);
   if (PyModule_AddObject(torch_module, "sparse_coo", sparse_coo_layout) != 0) {
     throw python_error();
   }
-  registerLayoutObject((THPLayout*)sparse_coo_layout, at::Backend::SparseCPU);
-  registerLayoutObject((THPLayout*)sparse_coo_layout, at::Backend::SparseCUDA);
+  registerLayoutObject((THPLayout*)sparse_coo_layout, at::Layout::Sparse);
 
   PyObject *mkldnn_layout = THPLayout_New(at::Layout::Mkldnn, "torch._mkldnn");
   Py_INCREF(mkldnn_layout);
   if (PyModule_AddObject(torch_module, "_mkldnn", mkldnn_layout) != 0) {
     throw python_error();
   }
-  registerLayoutObject((THPLayout*)mkldnn_layout, at::Backend::MkldnnCPU);
+  registerLayoutObject((THPLayout*)mkldnn_layout, at::Layout::Mkldnn);
 }
 
 }} // namespace torch::utils

--- a/torch/csrc/utils/tensor_layouts.cpp
+++ b/torch/csrc/utils/tensor_layouts.cpp
@@ -18,7 +18,6 @@ void initializeLayouts() {
   if (PyModule_AddObject(torch_module, "strided", strided_layout) != 0) {
     throw python_error();
   }
-  // for now, let's look these up by Backend; we could create our own enum in the future.
   registerLayoutObject((THPLayout*)strided_layout, at::Layout::Strided);
 
   PyObject *sparse_coo_layout = THPLayout_New(at::Layout::Sparse, "torch.sparse_coo");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37527 Remove Backend -> THPLayout mapping.**

This is yet another place that needs to be updated for adding a new "Backend" and is unnecessary.  Instead, just use layout_from_backend and have a map from Layout -> THPLayout.

Other changes:
- rename torch::getDtype and torch::getLayout to torch::getTHPDtype and torch::getTHPLayout since e.g. for layout you are both passing in and returning a "layout" type.
- add NumOptions to Layout to match the dtype/ScalarType formulation.

Differential Revision: [D21309836](https://our.internmc.facebook.com/intern/diff/D21309836)