### PR TITLE
[XNNPACK] Disable xnnpack ops for both iOS and macOS

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -17,12 +17,12 @@ Tensor linear(const Tensor& input, const Tensor& weight, const Tensor& bias) {
   if (input.is_mkldnn()) {
     return at::mkldnn_linear(input, weight, bias);
   }
-#ifdef C10_MOBILE
-#if !defined(C10_IOS)
+// Disable the xnnpack operators for both iOS and macOS temporarily due to the crash in pthreadpool
+// TODO:T66297472 remove `!defined(__APPLE__)` once we figure out the root cause of the crash.
+#if defined(C10_MOBILE) && !defined(__APPLE__)
   if (xnnpack::use_linear(input, weight, bias)) {
     return xnnpack::linear(input, weight, bias);
   }
-#endif
 #endif
   if (input.dim() == 2 && bias.defined()) {
     // Fused op is marginally faster.

--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -134,14 +134,15 @@ Tensor max_pool2d(
     return at::mkldnn_max_pool2d(
         self, kernel_size, stride, padding, dilation, ceil_mode);
   }
-#if defined(C10_MOBILE)
-#if !defined(C10_IOS)
+
+// Disable the xnnpack operators for both iOS and macOS temporarily due to the crash in pthreadpool
+// TODO:T66297472 remove `!defined(__APPLE__)` once we figure out the root cause of the crash.
+#if defined(C10_MOBILE) && !defined(__APPLE__)
   if(xnnpack::use_max_pool2d(self, kernel_size, padding, stride,
                              dilation, ceil_mode)) {
     return xnnpack::max_pool2d(
         self, kernel_size, padding, stride, dilation, ceil_mode);
   }
-#endif
 #endif
   auto output_and_indices = at::max_pool2d_with_indices(
       self, kernel_size, stride, padding, dilation, ceil_mode);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37528 [XNNPACK] Disable xnnpack ops for both iOS and macOS**

The XNNPACK is currently running into some threading issues using the pthreadpool on iOS. The AIBench has been failing since 4/23. The fix could take days to land, so disable it for the time being.

Differential Revision: [D21309715](https://our.internmc.facebook.com/intern/diff/D21309715/)