### PR TITLE
Add `sched_setaffinity` check from libgomp to `valgrind.sup`

### DIFF
--- a/aten/tools/valgrind.sup
+++ b/aten/tools/valgrind.sup
@@ -23,3 +23,12 @@
    obj:*libcuda.so*
    ...
 }
+
+{
+   ignore_libomp_setaffinity_check
+   Memcheck:Param
+   sched_setaffinity(mask)
+   fun:syscall
+   obj:*/lib*/libomp.so*
+   ...
+}


### PR DESCRIPTION
- It's valid to call `sched_setaffinity` with nullptr
- The call is coming from libomp which should be valgrind safe


Test Plan: CI
