### PR TITLE
[c2][opt] nomnigraph transform for ClipRangesGatherSigridHash fusion

### DIFF
--- a/caffe2/opt/custom/converter.cc
+++ b/caffe2/opt/custom/converter.cc
@@ -248,6 +248,53 @@ REGISTER_CONVERTER(
     ClipRangesGatherSigridHash,
     ClipRangesGatherSigridHashConverter);
 
+class ClipRangesGatherSigridHashV2Converter : public Converter {
+  std::unique_ptr<repr::NeuralNetOperator> convertToNeuralNetOperator(
+      const OperatorDef& op) override {
+    std::unique_ptr<repr::NeuralNetOperator> nnOp =
+        util::make_unique<repr::ClipRangesGatherSigridHashV2>();
+    const caffe2::ArgumentHelper args(op);
+
+    auto c = dyn_cast<repr::ClipRangesGatherSigridHashV2>(nnOp.get());
+    if (args.HasArgument("max_lengths")) {
+      c->setMaxLengths(args.GetRepeatedArgument<int64_t>("max_lengths"));
+    }
+    if (args.HasArgument("salts")) {
+      c->setSalts(args.GetRepeatedArgument<int64_t>("salts"));
+    }
+    if (args.HasArgument("max_values")) {
+      c->setMaxValues(args.GetRepeatedArgument<int64_t>("max_values"));
+    }
+    if (args.HasArgument("hash_into_int32")) {
+      c->setHashIntoInt32(
+          args.GetSingleArgument<bool>("hash_into_int32", false));
+    }
+    return nnOp;
+  }
+
+  OperatorDef convertToOperatorDef(
+      const nom::repr::NeuralNetOperator* nnOp) override {
+    auto fuse = dyn_cast<repr::ClipRangesGatherSigridHashV2>(nnOp);
+    OperatorDef op;
+    op.set_type("ClipRangesGatherSigridHashV2");
+    op.add_arg()->CopyFrom(caffe2::MakeArgument<vector<int64_t>>(
+        "max_lengths", fuse->getMaxLengths()));
+    op.add_arg()->CopyFrom(
+        caffe2::MakeArgument<vector<int64_t>>("salts", fuse->getSalts()));
+    op.add_arg()->CopyFrom(caffe2::MakeArgument<vector<int64_t>>(
+        "max_values", fuse->getMaxValues()));
+    op.add_arg()->CopyFrom(caffe2::MakeArgument<bool>(
+        "hash_into_int32", fuse->getHashIntoInt32()));
+    op.mutable_device_option()->CopyFrom(getDeviceOption(nnOp));
+    return op;
+  }
+
+  ~ClipRangesGatherSigridHashV2Converter() override {}
+};
+REGISTER_CONVERTER(
+    ClipRangesGatherSigridHashV2,
+    ClipRangesGatherSigridHashV2Converter);
+
 class ClipRangesConverter : public Converter {
   std::unique_ptr<repr::NeuralNetOperator> convertToNeuralNetOperator(
       const OperatorDef& op) override {

--- a/caffe2/opt/custom/converter_test.cc
+++ b/caffe2/opt/custom/converter_test.cc
@@ -31,3 +31,23 @@ TEST(Converter, ClipRangesGatherSigridHashConverter) {
   EXPECT_TRUE(pNNDef2);
   EXPECT_FALSE(pNNDef2->getHashIntoInt32());
 }
+
+TEST(Converter, ClipRangesGatherSigridHashV2Converter) {
+  OperatorDef op;
+  op.set_type("ClipRangesGatherSigridHashV2");
+  op.add_arg()->CopyFrom(caffe2::MakeArgument<bool>("hash_into_int32", true));
+  auto nnDef = convertToNeuralNetOperator(op);
+  auto* pNNDef =
+      static_cast<nom::repr::ClipRangesGatherSigridHashV2*>(nnDef.get());
+  EXPECT_TRUE(pNNDef);
+  EXPECT_TRUE(pNNDef->getHashIntoInt32());
+
+  OperatorDef op2;
+  op2.set_type("ClipRangesGatherSigridHashV2");
+  op2.add_arg()->CopyFrom(caffe2::MakeArgument<bool>("hash_into_int32", false));
+  auto nnDef2 = convertToNeuralNetOperator(op2);
+  auto* pNNDef2 =
+      static_cast<nom::repr::ClipRangesGatherSigridHashV2*>(nnDef2.get());
+  EXPECT_TRUE(pNNDef2);
+  EXPECT_FALSE(pNNDef2->getHashIntoInt32());
+}


### PR DESCRIPTION
Summary:
Fuse ClipRanges + GatherRanges + SigridHash -> ClipRangesGatherSigridHash

dpa_product_ctr model's dper2 to dper3 migration is blocked by 3.6% higher prospector cpu usage. Root cause is traced down to sigrid transforms, where ClipRanges, GatherRanges, SigridHash are separately called, instead of fused, as is the case in dper2.

Further context:
https://fb.quip.com/GijaAZtX5mav
https://fb.quip.com/pIDdAjJP2uiG

Test Plan:
Local benchmarking with small model 181513584_0
(Dper3 full model is 178772812, dper2 refresh is 178770392)

Transform turned on: P129799373
Iters per second: 609.291

Transform turned off: P129799397
Iters per second: 519.088

We also want to confirm this performance on the full model in canary and in qrt.

`buck build mode/opt-clang mode/no-gpu caffe2/caffe2/fb/predictor:ptvsc2_predictor_bench`

`MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --pred_net=/data/users/ansha/tmp/dpa/small_pred_net.pb --c2_model=/data/users/ansha/tmp/dpa/181513584_0.predictor --c2_inputs=/data/users/ansha/tmp/dpa/c2_inputs_small.pb --iters=3000 --warmup_iters=100 --num_threads=32 --c2_apply_nomnigraph_passes=1 --caffe2_predictor_enable_preproc_fusion=1`

Prospector canary:
https://our.intern.facebook.com/intern/ads/canary/426280288521552095/
Check that ClipRangesGatherSigridHash is used: https://fburl.com/scuba/caffe2_operator_stats_canary/e6qfdsat

Differential Revision: D21262085

