### PR TITLE
Move masked_select broadcasting from codegen layer to native layer.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -69,8 +69,7 @@
   arguments:
     - arg: THTensor* result
       output: True
-    - arg: THTensor* self
-      broadcast: mask fallback types:Byte
+    - THTensor* self
     - THByteTensor* mask
 ]]
 [[
@@ -86,8 +85,7 @@
   arguments:
     - arg: THTensor* result
       output: True
-    - arg: THTensor* self
-      broadcast: mask fallback types:Bool
+    - THTensor* self
     - THBoolTensor* mask
 ]]
 [[

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -24,21 +24,27 @@ Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & s
 
 Tensor masked_select_cpu(const Tensor & self, const Tensor & mask) {
   namedinference::compute_broadcast_outnames(self, mask);
-  if (mask.dtype() == at::ScalarType::Byte) {
+
+  Tensor b_self, b_mask;
+  std::tie(b_self, b_mask) = expand_outplace(self, mask, "masked_select");
+  if (b_mask.dtype() == at::ScalarType::Byte) {
     TORCH_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    return legacy::cpu::_th_masked_select(self, mask);
+    return legacy::cpu::_th_masked_select(b_self, b_mask);
   } else {
-    return legacy::cpu::_th_masked_select_bool(self, mask);
+    return legacy::cpu::_th_masked_select_bool(b_self, b_mask);
   }
 }
 
 Tensor & masked_select_out_cpu(Tensor & result, const Tensor & self, const Tensor & mask) {
   namedinference::compute_broadcast_outnames(self, mask);
-  if (mask.dtype() == at::ScalarType::Bool) {
-    return legacy::cpu::_th_masked_select_bool_out(result, self, mask);
+
+  Tensor b_self, b_mask;
+  std::tie(b_self, b_mask) = expand_outplace(self, mask, "masked_select_out");
+  if (b_mask.dtype() == at::ScalarType::Bool) {
+    return legacy::cpu::_th_masked_select_bool_out(result, b_self, b_mask);
   } else {
-    return legacy::cpu::_th_masked_select_out(result, self, mask);
+    return legacy::cpu::_th_masked_select_out(result, b_self, b_mask);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37582 Specify _th_ ops in CUDAUnaryOps macros so they are easier to find.
* #37547 Kill the ability to codegen tensor-based broadcasting.
* #37546 Move addr broadcasting from codegen layer to native layer.
* #37545 Move broadcasting code for fmod, fmod_ from codegen layer.
* #37544 Move baddbmm broadcasting from codegen layer to native layer.
* **#37543 Move masked_select broadcasting from codegen layer to native layer.**

Differential Revision: [D21315038](https://our.internmc.facebook.com/intern/diff/D21315038)