### PR TITLE
[WIP] [cmake] create symlink third_party/googletest pointint to GOOGLETEST_SOURCE_DIR when appropriate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,11 @@ if(USE_SYSTEM_LIBS)
   set(USE_SYSTEM_FXDIV ON)
   set(USE_SYSTEM_BENCHMARK ON)
 endif()
+# prepare the third_party/googletest symlink if the path does not exist
+if(DEFINED GOOGLETEST_SOURCE_DIR AND NOT EXISTS "${CMAKE_SOURCE_DIR}/third_party/googletest")
+  execute_process(COMMAND ln -s ${GOOGLETEST_SOURCE_DIR} third_party/googletest
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()
 
 # Used when building Caffe2 through setup.py
 option(BUILDING_WITH_TORCH_LIBS "Tell cmake if Caffe2 is being built alongside torch libs" ON)


### PR DESCRIPTION
Some other cmake files do not honour the GOOGLETEST_SOURCE_DIR variable,
and insist on using the hardcoded <...>/third_party/googletest path.
This commits works around the problem.

@ezyang 

as a part of #14699 