### PR TITLE
Do not shadow operators in at::native

### DIFF
--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <stdexcept>
 
+struct __at_dont_care__ {};
+
 namespace at {
 
 inline Tensor & Tensor::operator=(Tensor const & rhs) && {
@@ -81,6 +83,10 @@ _(==,x.eq(y), y.eq(x)) \
 _(!=,x.ne(y), y.ne(x))
 
 #define DEFINE_OPERATOR(op,body,reverse_scalar_body) \
+} /* namespace at */  \
+inline void operator op(__at_dont_care__, __at_dont_care__) {}  \
+namespace at {  \
+using ::operator op; \
 static inline Tensor operator op(const Tensor & x, const Tensor & y) { \
   return body; \
 } \

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/variant_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduce_ops_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/memory_format_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/operator_visibility_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_rng_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ivalue_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/complex_test.cpp

--- a/aten/src/ATen/test/operator_visibility_test.cpp
+++ b/aten/src/ATen/test/operator_visibility_test.cpp
@@ -5,10 +5,16 @@ void operator+(x::A, x::A) {}
 
 #include <ATen/ATen.h>
 
+namespace y{
+class B {};
+}
+void operator+(y::B, y::B) {}
+
 namespace at { namespace native {
 
-void f(x::A a) {
+void f(x::A a, y::B b) {
   a + a;
+  b + b;
 }
 
 }}

--- a/aten/src/ATen/test/operator_visibility_test.cpp
+++ b/aten/src/ATen/test/operator_visibility_test.cpp
@@ -1,16 +1,14 @@
+namespace x {
 class A {};
-void operator+(A, A) {}
+}
+void operator+(x::A, x::A) {}
 
 #include <ATen/ATen.h>
 
-class B {};
-void operator+(B, B) {}
-
 namespace at { namespace native {
 
-void f(A a, B b) {
+void f(x::A a) {
   a + a;
-  b + b;
 }
 
 }}

--- a/aten/src/ATen/test/operator_visibility_test.cpp
+++ b/aten/src/ATen/test/operator_visibility_test.cpp
@@ -5,16 +5,10 @@ void operator+(x::A, x::A) {}
 
 #include <ATen/ATen.h>
 
-namespace y{
-class B {};
-}
-void operator+(y::B, y::B) {}
-
 namespace at { namespace native {
 
-void f(x::A a, y::B b) {
+void f(x::A a) {
   a + a;
-  b + b;
 }
 
 }}

--- a/aten/src/ATen/test/operator_visibility_test.cpp
+++ b/aten/src/ATen/test/operator_visibility_test.cpp
@@ -1,0 +1,14 @@
+#include <ATen/ATen.h>
+
+class A {};
+void operator+(A, A) {}
+
+namespace at { namespace native {
+
+void f(A a) {
+  a + a;
+}
+
+}}
+
+int main() {}

--- a/aten/src/ATen/test/operator_visibility_test.cpp
+++ b/aten/src/ATen/test/operator_visibility_test.cpp
@@ -1,12 +1,16 @@
-#include <ATen/ATen.h>
-
 class A {};
 void operator+(A, A) {}
 
+#include <ATen/ATen.h>
+
+class B {};
+void operator+(B, B) {}
+
 namespace at { namespace native {
 
-void f(A a) {
+void f(A a, B b) {
   a + a;
+  b + b;
 }
 
 }}


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/37563

This PR only fixes the case where `::operator` is defined before `TensorOperators.h` is included. I don't know how to generally fix it when `::operator` is defined after `TensorOperators.h`.