### PR TITLE
LoopOptions::gpu_block_index(): bool -> int

### DIFF
--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -350,7 +350,7 @@ class TORCH_API LoopOptions {
     return gpu_block_index_ != -1;
   }
 
-  bool gpu_block_index() const {
+  int gpu_block_index() const {
     return gpu_block_index_;
   }
 


### PR DESCRIPTION
Small change to allow MSVC build pass.
The error is

```
D:\pytorch-scripts\caffe2_builders\v141\pytorch\torch/csrc/jit/tensorexpr/stmt.h(370): error C4805: '!=': unsafe mix
of type 'bool' and type 'int' in operation (compiling source file D:\pytorch-scripts\caffe2_builders\v141\pytorch\torch
\csrc\jit\passes\tensorexpr_fuser.cpp) [D:\pytorch-scripts\caffe2_builders\v141\pytorch\build\RelWithDebInfo\caffe2\tor
ch_cpu.vcxproj]
```