### PR TITLE
Skip c2 ref onnx model tests

### DIFF
--- a/caffe2/python/onnx/tests/c2_ref_test.py
+++ b/caffe2/python/onnx/tests/c2_ref_test.py
@@ -799,42 +799,69 @@ class TestCaffe2End2End(TestCase):
         onnx_outputs = c2_ir.run(inputs)
         self.assertSameOutputs(c2_outputs, onnx_outputs, decimal=decimal)
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_alexnet(self):
         self._test_net('bvlc_alexnet', decimal=4)
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_resnet50(self):
         self._test_net('resnet50')
 
     @unittest.skipIf(
-        os.environ.get('JENKINS_URL'),
+        os.environ.get('JENKINS_URL') or os.environ.get('SKIP_IN_FB'),
         'Taking too long to download!')
     def test_vgg16(self):
         self._test_net('vgg16')
 
     @unittest.skipIf(
-        os.environ.get('JENKINS_URL'),
+        os.environ.get('JENKINS_URL') or os.environ.get('SKIP_IN_FB'),
         'Taking too long to download!')
     def test_zfnet(self):
         self._test_net('zfnet')
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_inception_v1(self):
         self._test_net('inception_v1', decimal=2)
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_inception_v2(self):
         self._test_net('inception_v2')
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_squeezenet(self):
         self._test_net('squeezenet')
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_densenet121(self):
         self._test_net('densenet121')
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_bvlc_googlenet(self):
         self._test_net('bvlc_googlenet')
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_bvlc_reference_caffenet(self):
         self._test_net('bvlc_reference_caffenet')
 
+    @unittest.skipIf(
+        os.environ.get('SKIP_IN_FB'),
+        'Skip internally!')
     def test_bvlc_reference_rcnn_ilsvrc13(self):
         self._test_net('bvlc_reference_rcnn_ilsvrc13')
 


### PR DESCRIPTION
Summary: skip the tests since gluster is gone.

Test Plan: ci

Reviewed By: ezyang

Differential Revision: D21330359

