### PR TITLE
Fp16 compression of dense feature network traffic in disagg predictor setup

### DIFF
--- a/caffe2/quantization/server/fbgemm_fp16_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_fp16_pack_op.cc
@@ -33,6 +33,10 @@ REGISTER_CPU_OPERATOR(
     FbGemmPackTranspose,
     FbGemmPackOp<CPUContext, DefaultEngine, false, fbgemm::float16>);
 
+REGISTER_CPU_OPERATOR(
+    FbGemmUnpack,
+    FbGemmUnpackOp<CPUContext, DefaultEngine, true, fbgemm::float16>);
+
 using namespace std::placeholders;
 OPERATOR_SCHEMA(FbGemmPack)
     .NumInputs(1)
@@ -68,5 +72,13 @@ OPERATOR_SCHEMA(FbGemmPackTranspose)
     .SetDoc(R"DOC(Prepack weight for fbgemm)DOC")
     .Input(0, "X", "col major format weight matrix")
     .Output(0, "Y", "Block col major packed format weight matrix");
+
+OPERATOR_SCHEMA(FbGemmUnpack)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .AllowInplace({{0, 0}})
+    .SetDoc(R"DOC(Unpack weight for fbgemm)DOC")
+    .Input(0, "X", "Block row major packed format weight matrix")
+    .Output(0, "X", "Row major format weight matrix");
 
 } // namespace caffe2


### PR DESCRIPTION
Summary: Made modification based on Summer's diff D17083582, add fake fp32 to fp16 conversion op after the bottom FC in the local net to emulate the fp16 compression of dense feature network traffic in disagg predictor setup.

Test Plan: P130050516

Differential Revision: D21331843

