### PR TITLE
Move cauchy_() to DistributionTemplates

### DIFF
--- a/aten/src/ATen/native/DistributionTemplates.h
+++ b/aten/src/ATen/native/DistributionTemplates.h
@@ -318,6 +318,15 @@ Tensor& exponential_impl_(Tensor& self, double lambda, c10::optional<Generator> 
   return self;
 }
 
+// ==================================================== Cauchy ========================================================
+
+template<template<typename> class cauchy_kernel, typename RNG>
+Tensor& cauchy_impl_(Tensor& self, double median, double sigma, c10::optional<Generator> gen) {
+  auto iter = TensorIterator::nullary_op(self);
+  cauchy_kernel<RNG>()(iter, median, sigma, gen);
+  return self;
+}
+
 #undef CHECK_OUT_OF_BOUNDS_AND_SHOW_WARNING
 
 }}}

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -206,12 +206,17 @@ Tensor& log_normal_(Tensor& self, double mean, double std, c10::optional<Generat
   return at::native::templates::log_normal_impl_<LogNormalStub, Generator>(self, mean, std, gen);
 }
 
-// ====================================================================================================================
+// ==================================================== Cauchy ========================================================
+
+template<typename RNG>
+struct CauchyStub {
+  void operator()(TensorIterator& iter, double median, double sigma, c10::optional<Generator> gen) {
+    cauchy_stub(iter.device_type(), iter, median, sigma, gen);
+  }
+};
 
 Tensor& cauchy_(Tensor& self, double median, double sigma, c10::optional<Generator> gen) {
-  auto iter = TensorIterator::nullary_op(self);
-  cauchy_stub(iter.device_type(), iter, median, sigma, gen);
-  return self;
+  return at::native::templates::cauchy_impl_<CauchyStub, Generator>(self, median, sigma, gen);
 }
 
 // ================================================== Exponential =====================================================

--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -236,6 +236,13 @@ void cauchy_kernel(TensorIterator& iter, double median, double sigma, RNG genera
   });
 }
 
+template<typename RNG>
+struct CauchyKernel {
+  void operator()(TensorIterator& iter, double median, double sigma, c10::optional<Generator> gen) {
+    cauchy_kernel(iter, median, sigma, check_generator<RNG>(gen));
+  }
+};
+
 // ================================================== LogNormal =======================================================
 
 template<typename RNG>

--- a/aten/src/ATen/native/cuda/DistributionCauchyKernel.cu
+++ b/aten/src/ATen/native/cuda/DistributionCauchyKernel.cu
@@ -29,34 +29,9 @@
 
 namespace at { namespace native {
 
-void cauchy_kernel(TensorIterator& iter, double median_, double sigma_, c10::optional<Generator> gen_) {
-  auto gen = get_generator_or_default<CUDAGeneratorImpl>(gen_, cuda::detail::getDefaultCUDAGenerator());
-  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "cauchy_cuda", [&] {
-    using accscalar_t = at::acc_type<scalar_t, true>;
-    auto median = static_cast<accscalar_t>(median_);
-    auto sigma = static_cast<accscalar_t>(sigma_);
-    if (std::is_same<scalar_t, double>::value) {
-      // define lambda for cauchy transformation
-      auto cauchy_func = [median, sigma] __device__ (accscalar_t rand) {
-        return static_cast<scalar_t>(median + sigma *
-                ::tan(static_cast<accscalar_t>(M_PI) * (rand-static_cast<accscalar_t>(0.5))));
-      };
-      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls/2>(iter,
-        gen,
-        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform2_double(state); },
-        cauchy_func);
-    } else {
-      // use __tanf fast approximation for peak bandwidth
-      auto cauchy_func = [median, sigma] __device__ (accscalar_t rand) {
-        return static_cast<scalar_t>(median + sigma *
-                __tanf(static_cast<accscalar_t>(M_PI) * (rand-static_cast<accscalar_t>(0.5))));
-      };
-      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls>(iter,
-        gen,
-        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform4(state); },
-        cauchy_func);
-    }
-   });
+void cauchy_kernel(TensorIterator& iter, double median, double sigma, c10::optional<Generator> gen) {
+  auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen, cuda::detail::getDefaultCUDAGenerator());
+  at::native::templates::cuda::cauchy_kernel(iter, median, sigma, generator);
 }
 
 REGISTER_DISPATCH(cauchy_stub, &cauchy_kernel);

--- a/aten/src/ATen/test/cpu_rng_test.cpp
+++ b/aten/src/ATen/test/cpu_rng_test.cpp
@@ -89,10 +89,8 @@ Tensor& uniform_(Tensor& self, double from, double to, c10::optional<Generator> 
 
 // ==================================================== Cauchy ========================================================
 
-Tensor& custom_rng_cauchy_(Tensor& self, double median, double sigma, c10::optional<Generator> generator) {
-  auto iter = TensorIterator::nullary_op(self);
-  native::templates::cpu::cauchy_kernel(iter, median, sigma, check_generator<TestCPUGenerator>(generator));
-  return self;
+Tensor& cauchy_(Tensor& self, double median, double sigma, c10::optional<Generator> generator) {
+  return at::native::templates::cauchy_impl_<native::templates::cpu::CauchyKernel, TestCPUGenerator>(self, median, sigma, generator);
 }
 
 // ================================================== LogNormal =======================================================
@@ -128,7 +126,7 @@ TORCH_LIBRARY_IMPL(aten, CustomRNGKeyId, m) {
   m.impl_UNBOXED("normal.Tensor_Tensor",     normal_Tensor_Tensor);
   m.impl_UNBOXED("uniform_",                 uniform_);
   // Cauchy
-  m.impl_UNBOXED("cauchy_",                  custom_rng_cauchy_);
+  m.impl_UNBOXED("cauchy_",                  cauchy_);
   // LogNormal
   m.impl_UNBOXED("log_normal_",              log_normal_);
   // Geometric


### PR DESCRIPTION
Fixes #37371

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37602 Move cauchy_() to DistributionTemplates**

Differential Revision: [D21334739](https://our.internmc.facebook.com/intern/diff/D21334739)