### PR TITLE
Overload c10::complex operators inside c10 namespace

### DIFF
--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -3,7 +3,6 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/zmath.cuh>
 
 
 // NOTE: CUDA on Windows requires that the enclosing function

--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -12,10 +12,9 @@
 namespace at { namespace native {
 
 void eq_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "eq_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "eq_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "eq_cuda", [&] {
-      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(thrust_t a, thrust_t b) -> bool {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a == b;
       });
     });

--- a/aten/src/ATen/native/cuda/CompareNEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareNEKernel.cu
@@ -12,10 +12,9 @@
 namespace at { namespace native {
 
 void ne_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "ne_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "ne_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "ne_cuda", [&] {
-      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(thrust_t a, thrust_t b) -> bool {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
         return a != b;
       });
     });

--- a/aten/src/ATen/native/cuda/CompareNEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareNEKernel.cu
@@ -3,7 +3,6 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/zmath.cuh>
 
 
 // NOTE: CUDA on Windows requires that the enclosing function

--- a/c10/util/complex_type.h
+++ b/c10/util/complex_type.h
@@ -290,7 +290,6 @@ constexpr complex<double> operator"" _id(unsigned long long imag) {
 
 } // namespace complex_literals
 
-} // namespace c10
 
 template<typename T>
 constexpr c10::complex<T> operator+(const c10::complex<T>& val) {
@@ -415,6 +414,8 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
   x = tmp;
   return is;
 }
+
+} // namespace c10
 
 // std functions
 //


### PR DESCRIPTION
See:
https://github.com/pytorch/pytorch/issues/37563#issuecomment-622062118
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ro-namespace

Tested by eq and ne operator not failing