### PR TITLE
[TensorExpr] remove Let and LetStmt in favour of binding in Block

### DIFF
--- a/test/cpp/tensorexpr/test_ir_printer.cpp
+++ b/test/cpp/tensorexpr/test_ir_printer.cpp
@@ -34,46 +34,16 @@ void testIRPrinterBasicValueTest02() {
   ASSERT_EQ(ss.str(), "(2.f + 3.f) - (4.f + 5.f)");
 }
 
-void testIRPrinterLetTest01() {
-  KernelScope kernel_scope;
-  VarHandle x("x", kFloat);
-  ExprHandle body = ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f));
-  ExprHandle result = Let::make(x, ExprHandle(3.f), body);
-
-  std::stringstream ss;
-  ss << result;
-  ASSERT_EQ(ss.str(), "let x = 3.f in 2.f + (x * 3.f + 4.f)");
-}
-
-void testIRPrinterLetTest02() {
-  KernelScope kernel_scope;
-  VarHandle x("x", kFloat);
-  VarHandle y("y", kFloat);
-  ExprHandle body =
-      ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f) * y);
-  ExprHandle e1 = Let::make(x, ExprHandle(3.f), body);
-  ExprHandle e2 = Let::make(y, ExprHandle(6.f), e1);
-
-  std::stringstream ss;
-  ss << e2;
-  ASSERT_EQ(
-      ss.str(), "let y = 6.f in (let x = 3.f in 2.f + (x * 3.f + 4.f * y))");
-}
-
 void testIRPrinterCastTest() {
   KernelScope kernel_scope;
-  VarHandle x("x", kFloat);
+  VarHandle x("x", kHalf);
   VarHandle y("y", kFloat);
-  ExprHandle body =
-      ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f) * y);
-  ExprHandle e1 = Let::make(x, Cast::make(kInt, ExprHandle(3.f)), body);
-  ExprHandle e2 = Let::make(y, ExprHandle(6.f), e1);
+  ExprHandle body = ExprHandle(2.f) +
+      (Cast::make(kFloat, x) * ExprHandle(3.f) + ExprHandle(4.f) * y);
 
   std::stringstream ss;
-  ss << e2;
-  ASSERT_EQ(
-      ss.str(),
-      "let y = 6.f in (let x = int(3.f) in 2.f + (x * 3.f + 4.f * y))");
+  ss << body;
+  ASSERT_EQ(ss.str(), "2.f + (float(x) * 3.f + 4.f * y)");
 }
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -178,8 +178,8 @@ void testConstantFoldWithVar() {
     ASSERT_NE(root, nullptr);
     ASSERT_NE(dynamic_cast<const IntImm*>(root->lhs()), nullptr);
 
-    ExprHandle result = Let::make(x, ExprHandle(3), newF);
-    SimpleIRExprEval eval(result);
+    SimpleIRExprEval eval(newF);
+    eval.bindVar(x, ExprHandle(3));
     ASSERT_EQ(eval.value<int>(), 3 * (2 + 4));
   }
 
@@ -192,8 +192,8 @@ void testConstantFoldWithVar() {
     ASSERT_NE(root, nullptr);
     ASSERT_NE(dynamic_cast<const FloatImm*>(root->rhs()), nullptr);
 
-    ExprHandle result = Let::make(x, ExprHandle(3.f), newF);
-    SimpleIRExprEval eval(result);
+    SimpleIRExprEval eval(newF);
+    eval.bindVar(x, ExprHandle(3.f));
     ASSERT_EQ(eval.value<float>(), 3 * (2 + 4));
   }
 }
@@ -210,23 +210,11 @@ void testUnFoldableExpr() {
   ASSERT_EQ(dynamic_cast<const FloatImm*>(root->lhs()), nullptr);
   ASSERT_EQ(dynamic_cast<const FloatImm*>(root->rhs()), nullptr);
 
-  ExprHandle result = Let::make(x, ExprHandle(3.f), newF);
-  result = Let::make(y, ExprHandle(2.f), result);
-  SimpleIRExprEval eval(result);
+  SimpleIRExprEval eval(newF);
+  eval.bindVar(x, ExprHandle(3.f));
+  eval.bindVar(y, ExprHandle(2.f));
   ASSERT_EQ(eval.value<float>(), 9 + 10);
 }
-
-// bool operator==(
-//     const torch::jit::tensorexpr::SimplifierHashType& a,
-//     const torch::jit::tensorexpr::SimplifierHashType& b) {
-//   return a._h == b._h;
-// }
-
-// bool operator==(
-//     const torch::jit::tensorexpr::SimplifierHashType& a,
-//     const size_t s) {
-//   return a._h == s;
-// }
 
 void testHashSimple() {
   KernelScope kernel_scope;

--- a/test/cpp/tensorexpr/test_type.cpp
+++ b/test/cpp/tensorexpr/test_type.cpp
@@ -49,9 +49,7 @@ void testTypePropagation() {
     VarHandle y("y", kFloat);
     ExprHandle body = FloatImm::make(2.f) +
         (x * FloatImm::make(3.f) + FloatImm::make(4.f) * y);
-    ExprHandle e1 = Let::make(x, FloatImm::make(3.f), body);
-    ExprHandle e2 = Let::make(y, FloatImm::make(6.f), e1);
-    ASSERT_EQ(e2.dtype(), kFloat);
+    ASSERT_EQ(body.dtype(), kFloat);
   }
   // Int to bigger int:
   {
@@ -60,9 +58,7 @@ void testTypePropagation() {
     VarHandle y("y", kLong);
     ExprHandle body =
         ShortImm::make(2.f) + (x * ShortImm::make(3) + ShortImm::make(4) * y);
-    ExprHandle e1 = Let::make(x, ShortImm::make(3), body);
-    ExprHandle e2 = Let::make(y, LongImm::make(6), e1);
-    ASSERT_EQ(e2.dtype(), kLong);
+    ASSERT_EQ(body.dtype(), kLong);
   }
   // Float to bigger float:
   {
@@ -71,9 +67,7 @@ void testTypePropagation() {
     VarHandle y("y", kDouble);
     ExprHandle body =
         HalfImm::make(2.f) + (x * HalfImm::make(3) + HalfImm::make(4) * y);
-    ExprHandle e1 = Let::make(x, HalfImm::make(3), body);
-    ExprHandle e2 = Let::make(y, DoubleImm::make(6), e1);
-    ASSERT_EQ(e2.dtype(), kDouble);
+    ASSERT_EQ(body.dtype(), kDouble);
   }
   // Int to Float:
   {
@@ -82,9 +76,7 @@ void testTypePropagation() {
     VarHandle y("y", kInt);
     ExprHandle body =
         IntImm::make(2) + (x * IntImm::make(3) + IntImm::make(4) * y);
-    ExprHandle e1 = Let::make(x, FloatImm::make(3.f), body);
-    ExprHandle e2 = Let::make(y, IntImm::make(6), e1);
-    ASSERT_EQ(e2.dtype(), kFloat);
+    ASSERT_EQ(body.dtype(), kFloat);
   }
   // Smaller float, bigger Int:
   {
@@ -93,9 +85,7 @@ void testTypePropagation() {
     VarHandle y("y", kLong);
     ExprHandle body =
         HalfImm::make(2) + (x * HalfImm::make(3) + HalfImm::make(4) * y);
-    ExprHandle e1 = Let::make(x, HalfImm::make(3), body);
-    ExprHandle e2 = Let::make(y, LongImm::make(6), e1);
-    ASSERT_EQ(e2.dtype(), kHalf);
+    ASSERT_EQ(body.dtype(), kHalf);
   }
   // Bigger float, smaller Int:
   {
@@ -104,9 +94,7 @@ void testTypePropagation() {
     VarHandle y("y", kDouble);
     ExprHandle body =
         CharImm::make(2) + (x * CharImm::make(3) + CharImm::make(4) * y);
-    ExprHandle e1 = Let::make(x, CharImm::make(3), body);
-    ExprHandle e2 = Let::make(y, DoubleImm::make(6), e1);
-    ASSERT_EQ(e2.dtype(), kDouble);
+    ASSERT_EQ(body.dtype(), kDouble);
   }
   // Sign change char/byte upgrades to short:
   {
@@ -115,9 +103,7 @@ void testTypePropagation() {
     VarHandle y("y", kByte);
     ExprHandle body =
         CharImm::make(2) + (x * CharImm::make(3) + CharImm::make(4) * y);
-    ExprHandle e1 = Let::make(x, CharImm::make(3), body);
-    ExprHandle e2 = Let::make(y, ByteImm::make(6), e1);
-    ASSERT_EQ(e2.dtype(), kShort);
+    ASSERT_EQ(body.dtype(), kShort);
   }
 }
 } // namespace jit

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -33,8 +33,6 @@ namespace jit {
   _(ExprBitwiseOps)                         \
   _(IRPrinterBasicValueTest)                \
   _(IRPrinterBasicValueTest02)              \
-  _(IRPrinterLetTest01)                     \
-  _(IRPrinterLetTest02)                     \
   _(IRPrinterCastTest)                      \
   _(ExprSimple01)                           \
   _(ExprLower01)                            \

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -56,8 +56,8 @@ class CudaPrinter : public IRPrinter {
   void visit(const AtomicAdd* v) override;
   void visit(const Max* v) override;
   void visit(const Min* v) override;
-  void visit(const LetStmt* v) override;
   void visit(const IfThenElse* v) override;
+  void visit(const Block* v) override;
   void visit(const Allocate* v) override;
   void visit(const Free* v) override;
 

--- a/torch/csrc/jit/tensorexpr/hash_provider.cpp
+++ b/torch/csrc/jit/tensorexpr/hash_provider.cpp
@@ -137,29 +137,6 @@ void HashProvider::visit(const Var* v) {
   putHash(v, hash_combine("var", name_manager_.get_unique_name(v)));
 }
 
-void HashProvider::visit(const Let* v) {
-  CACHE_GUARD();
-  v->var()->accept(this);
-  v->value()->accept(this);
-  v->body()->accept(this);
-
-  putHash(
-      v,
-      hash_combine(
-          "let", hashOf(v->var()), hashOf(v->value()), hashOf(v->body())));
-}
-
-void HashProvider::visit(const LetStmt* v) {
-  CACHE_GUARD();
-  v->var()->accept(this);
-  v->value()->accept(this);
-  v->body()->accept(this);
-  putHash(
-      v,
-      hash_combine(
-          "letstmt", hashOf(v->var()), hashOf(v->value()), hashOf(v->body())));
-}
-
 void HashProvider::visit(const Ramp* v) {
   CACHE_GUARD();
   v->base()->accept(this);
@@ -207,6 +184,12 @@ void HashProvider::visit(const Store* v) {
 void HashProvider::visit(const Block* v) {
   CACHE_GUARD();
   SimplifierHashType hash;
+  for (const auto& pair : v->varBindings()) {
+    pair.first->accept(this);
+    pair.second->accept(this);
+    hash = hash_combine(hash, hashOf(pair.first), hashOf(pair.second));
+  }
+
   for (Stmt* s : *v) {
     s->accept(this);
     hash = hash_combine(hash, hashOf(s));

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -87,8 +87,6 @@ class TORCH_API HashProvider : public IRVisitor {
 
   void visit(const Cast* v) override;
   void visit(const Var* v) override;
-  void visit(const Let* v) override;
-  void visit(const LetStmt* v) override;
   void visit(const Ramp* v) override;
   void visit(const Load* v) override;
   void visit(const Store* v) override;

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -49,7 +49,6 @@ inline int getPrecedence(IRNodeType ty) {
     case kXor:
       return 12;
     case kCompareSelect:
-    case kLet:
       return 16;
     default:
       return 99;
@@ -336,38 +335,6 @@ bool immediateIsNegative(const T* e) {
 #undef TYPE_CASE
   return false;
 }
-
-// Bind the value to the var and evaluate the body.
-class Let : public ExprNode<Let> {
- public:
-  const Expr* var() const {
-    return var_;
-  }
-  const Expr* value() const {
-    return value_;
-  }
-  const Expr* body() const {
-    return body_;
-  }
-
-  static ExprHandle make(
-      const ExprHandle& var,
-      const ExprHandle& value,
-      const ExprHandle& body) {
-    return ExprHandle(new Let(var.node(), value.node(), body.node()));
-  }
-
-  Let(const Expr* var, const Expr* value, const Expr* body)
-      : ExprNodeBase(body->dtype(), kLet),
-        var_(var),
-        value_(value),
-        body_(body) {}
-
- private:
-  const Expr* var_;
-  const Expr* value_;
-  const Expr* body_;
-};
 
 // Represents a ramp vector node:
 //     [base, base + 1 * stride, ... , base + (lanes - 1) * stride]

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -143,35 +143,6 @@ const Expr* IRMutator::mutate(const Var* v) {
   return v;
 }
 
-const Expr* IRMutator::mutate(const Let* v) {
-  const Expr* var = v->var();
-  const Expr* value = v->value();
-  const Expr* body = v->body();
-  const Expr* var_new = var->accept_mutator(this);
-  const Expr* value_new = value->accept_mutator(this);
-  const Expr* body_new = body->accept_mutator(this);
-  if ((var == var_new) && (value == value_new) && (body == body_new)) {
-    return v;
-  }
-  return new Let(var_new, value_new, body_new);
-}
-
-Stmt* IRMutator::mutate(const LetStmt* v) {
-  const Var* var = v->var();
-  const Expr* value = v->value();
-  Stmt* body = v->body();
-  const Var* var_new = dynamic_cast<const Var*>(var->accept_mutator(this));
-  if (var_new == nullptr) {
-    throw std::runtime_error("LetStmt var must be variable");
-  }
-  const Expr* value_new = value->accept_mutator(this);
-  Stmt* body_new = body->accept_mutator(this);
-  if ((var == var_new) && (value == value_new) && (body == body_new)) {
-    return (Stmt*)v;
-  }
-  return new LetStmt(var_new, value_new, body_new);
-}
-
 const Expr* IRMutator::mutate(const Ramp* v) {
   const Expr* base = v->base();
   const Expr* stride = v->stride();
@@ -337,6 +308,19 @@ Stmt* IRMutator::mutate(const For* v) {
 
 Stmt* IRMutator::mutate(const Block* v) {
   bool any_change = false;
+
+  Block::VarMapping varMapping;
+  for (const auto& pair : v->varBindings()) {
+    const Var* new_var =
+        static_cast<const Var*>(pair.first->accept_mutator(this));
+    const Expr* new_val = pair.second->accept_mutator(this);
+    if (new_var != pair.first || new_val != pair.second) {
+      any_change = true;
+    }
+
+    varMapping.push_back({new_var, new_val});
+  }
+
   std::vector<Stmt*> stmts;
   for (Stmt* stmt : *v) {
     Stmt* stmt_new = stmt->accept_mutator(this);
@@ -352,7 +336,7 @@ Stmt* IRMutator::mutate(const Block* v) {
   if (!any_change) {
     return (Stmt*)v;
   }
-  return Block::make(stmts);
+  return Block::make(varMapping, stmts);
 }
 
 Stmt* IRMutator::mutate(const Store* v) {
@@ -462,7 +446,6 @@ const Expr* IRMutator::DefaultMutator(
 
 class StmtClone : public IRMutator {
  public:
-  Stmt* mutate(const LetStmt* v) override;
   Stmt* mutate(const For* v) override;
   Stmt* mutate(const Block* v) override;
   Stmt* mutate(const Store* v) override;
@@ -471,18 +454,6 @@ class StmtClone : public IRMutator {
   Stmt* mutate(const Cond* v) override;
   Stmt* mutate(const AtomicAdd* v) override;
 };
-
-Stmt* StmtClone::mutate(const LetStmt* v) {
-  // Expressions are immutable => we don't need to clone them
-  const Var* var = v->var();
-  const Expr* value = v->value();
-
-  // Statements are mutable => we need to clone them
-  Stmt* body_new = v->body()->accept_mutator(this);
-
-  // Create a new LetStmt with the cloned statement for body
-  return new LetStmt(var, value, body_new);
-}
 
 Stmt* StmtClone::mutate(const For* v) {
   // Only body needs to be cloned as only statements are mutable
@@ -496,7 +467,7 @@ Stmt* StmtClone::mutate(const Block* v) {
   for (Stmt* stmt : *v) {
     stmts.push_back(stmt->accept_mutator(this));
   }
-  return new Block(stmts);
+  return new Block(v->varBindings(), stmts);
 }
 
 Stmt* StmtClone::mutate(const Store* v) {

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -28,8 +28,6 @@ AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_DECLARE);
 class Cast;
 class Var;
 class Buf;
-class Let;
-class LetStmt;
 class Ramp;
 class Load;
 class For;
@@ -75,8 +73,6 @@ class TORCH_API IRMutator {
   virtual const Expr* mutate(const Cast* v);
   virtual const Expr* mutate(const Var* v);
   virtual const Expr* mutate(const Buf* v);
-  virtual const Expr* mutate(const Let* v);
-  virtual Stmt* mutate(const LetStmt* v);
   virtual const Expr* mutate(const Ramp* v);
   virtual const Expr* mutate(const Load* v);
   virtual const Expr* mutate(const Broadcast* v);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -223,33 +223,6 @@ void IRPrinter::visit(const Var* v) {
   os() << name_manager_.get_unique_name(v);
 }
 
-void IRPrinter::visit(const Let* v) {
-  int self_prec = getPrecedence(v->expr_type());
-  int value_prec = getPrecedence(v->value()->expr_type());
-  int body_prec = getPrecedence(v->body()->expr_type());
-  os() << "let ";
-  v->var()->accept(this);
-  os() << " = ";
-
-  if (value_prec >= self_prec) {
-    os() << "(";
-  }
-  v->value()->accept(this);
-  if (value_prec >= self_prec) {
-    os() << ")";
-  }
-
-  os() << " in ";
-
-  if (body_prec >= self_prec) {
-    os() << "(";
-  }
-  v->body()->accept(this);
-  if (body_prec >= self_prec) {
-    os() << ")";
-  }
-}
-
 void IRPrinter::visit(const Ramp* v) {
   os() << "Ramp(" << *v->base() << ", " << *v->stride() << ", " << v->lanes()
        << ")";
@@ -385,15 +358,6 @@ void IRPrinter::visit(const Store* v) {
   os() << std::endl;
 }
 
-void IRPrinter::visit(const LetStmt* v) {
-  emitIndent();
-  const Var* var = v->var();
-  os() << var->dtype().ToCppString() << " " << *var << " = " << *v->value()
-       << "; " << std::endl;
-  v->body()->accept(this);
-  os() << std::endl;
-}
-
 void IRPrinter::visit(const For* v) {
   const Var* var = v->var();
   VarHandle vv(var);
@@ -416,6 +380,15 @@ void IRPrinter::visit(const For* v) {
 void IRPrinter::visit(const Block* v) {
   os() << "{" << std::endl;
   indent_++;
+
+  for (const auto& pair : v->varBindings()) {
+    const Var* var = pair.first;
+    const Expr* val = pair.second;
+    emitIndent();
+    os() << var->dtype().ToCppString() << " " << *var << " = " << *val << "; "
+         << std::endl;
+  }
+
   for (Stmt* s : *v) {
     os() << *s;
   }

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -35,7 +35,6 @@ class TORCH_API IRPrinter : public IRVisitor {
 #undef IMM_PRINT_VISIT
   void visit(const Cast* v) override;
   void visit(const Var* v) override;
-  void visit(const Let* v) override;
   void visit(const Ramp* v) override;
   void visit(const Load* v) override;
   void visit(const Broadcast* v) override;
@@ -46,7 +45,6 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const RoundOff* v) override;
   void visit(const ReduceOp* v) override;
 
-  void visit(const LetStmt* v) override;
   void visit(const AtomicAdd* v) override;
   void visit(const Store* v) override;
   void visit(const For* v) override;
@@ -78,8 +76,9 @@ class TORCH_API IRPrinter : public IRVisitor {
   }
   void emitIndent();
 
- private:
   int indent_ = 0;
+
+ private:
   PrinterStream printer_os_;
   UniqueNameManager name_manager_;
 };

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1103,6 +1103,7 @@ Stmt* PolynomialTransformer::mutate(const For* v) {
 }
 
 Stmt* PolynomialTransformer::mutate(const Block* v) {
+  auto vars = v->varBindings();
   std::vector<Stmt*> stmts;
   for (Stmt* stmt : *v) {
     Stmt* stmt_new = stmt->accept_mutator(this);
@@ -1111,6 +1112,10 @@ Stmt* PolynomialTransformer::mutate(const Block* v) {
     }
 
     if (auto* subBlock = dynamic_cast<Block*>(stmt_new)) {
+      for (auto& pair : subBlock->varBindings()) {
+        vars.emplace_back(pair.first, pair.second);
+      }
+
       for (Block::iterator I = subBlock->begin(), E = subBlock->end();
            I != E;) {
         // Be careful to avoid invalidating the iterator.
@@ -1123,7 +1128,7 @@ Stmt* PolynomialTransformer::mutate(const Block* v) {
     }
   }
 
-  return new Block(stmts);
+  return new Block(vars, stmts);
 }
 
 // TermExpander

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -80,17 +80,6 @@ void IRVisitor::visit(const Cast* v) {
   v->src_value()->accept(this);
 }
 void IRVisitor::visit(const Var* v) {}
-void IRVisitor::visit(const Let* v) {
-  v->var()->accept(this);
-  v->value()->accept(this);
-  v->body()->accept(this);
-}
-
-void IRVisitor::visit(const LetStmt* v) {
-  v->var()->accept(this);
-  v->value()->accept(this);
-  v->body()->accept(this);
-}
 
 void IRVisitor::visit(const Ramp* v) {
   v->base()->accept(this);
@@ -127,6 +116,10 @@ void IRVisitor::visit(const AtomicAdd* v) {
 }
 
 void IRVisitor::visit(const Block* v) {
+  for (const auto& pair : v->varBindings()) {
+    pair.first->accept(this);
+    pair.second->accept(this);
+  }
   for (Stmt* s : *v) {
     s->accept(this);
   }

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -28,8 +28,6 @@ AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_DECLARE)
 class Cast;
 class Var;
 class Buf;
-class Let;
-class LetStmt;
 class Ramp;
 class Load;
 class For;
@@ -74,8 +72,6 @@ class TORCH_API IRVisitor {
   virtual void visit(const Cast* v);
   virtual void visit(const Var* v);
   virtual void visit(const Buf* v);
-  virtual void visit(const Let* v);
-  virtual void visit(const LetStmt* v);
   virtual void visit(const Ramp* v);
   virtual void visit(const Load* v);
   virtual void visit(const For* v);

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <list>
 #include <string>
 #include <vector>
@@ -58,42 +59,10 @@ Stmt* StmtNode<Op>::accept_mutator(IRMutator* mutator) {
 }
 
 // Concrete Stmt classes
-class TORCH_API LetStmt : public StmtNode<LetStmt> {
- public:
-  const Var* var() const {
-    return var_;
-  }
-
-  const Expr* value() const {
-    return value_;
-  }
-
-  Stmt* body() const {
-    return body_;
-  }
-
-  static LetStmt* make(
-      const VarHandle& var,
-      const ExprHandle& value,
-      Stmt* body) {
-    if (body->get_parent()) {
-      throw malformed_input("LetStmt body has existing parent", body);
-    }
-
-    return new LetStmt(var.node(), value.node(), body);
-  }
-
-  LetStmt(const Var* var, const Expr* value, Stmt* body)
-      : var_(var), value_(value), body_(body) {}
-
- private:
-  const Var* var_;
-  const Expr* value_;
-  Stmt* body_;
-};
-
 class TORCH_API Block : public StmtNode<Block> {
  public:
+  using VarMapping = std::vector<std::pair<const Var*, const Expr*>>;
+
   static Block* make(const std::vector<Stmt*>& stmts) {
     std::vector<Stmt*> valid_stmts;
     for (size_t i = 0; i < stmts.size(); i++) {
@@ -106,6 +75,20 @@ class TORCH_API Block : public StmtNode<Block> {
       return nullptr;
     }
     return new Block(valid_stmts);
+  }
+
+  static Block* make(const VarMapping& vars, const std::vector<Stmt*>& stmts) {
+    std::vector<Stmt*> valid_stmts;
+    for (size_t i = 0; i < stmts.size(); i++) {
+      if (!stmts[i]) {
+        continue;
+      }
+      valid_stmts.push_back(stmts[i]);
+    }
+    if (valid_stmts.empty()) {
+      return nullptr;
+    }
+    return new Block(vars, valid_stmts);
   }
 
   int nstmts() const {
@@ -177,6 +160,42 @@ class TORCH_API Block : public StmtNode<Block> {
     return true;
   }
 
+  // adds a new binding to the map, replace
+  bool add_var_binding(const Var* v, const Expr* e) {
+    auto it =
+        std::find_if(varBindings_.begin(), varBindings_.end(), [v](auto p) {
+          return p.first == v;
+        });
+    if (it != varBindings_.end()) {
+      throw malformed_input(
+          "Var binding in Block would shadow existing binding");
+      return false;
+    }
+
+    varBindings_.emplace_back(v, e);
+    return true;
+  }
+
+  bool remove_var_binding(const Var* v) {
+    auto it =
+        std::find_if(varBindings_.begin(), varBindings_.end(), [v](auto p) {
+          return p.first == v;
+        });
+    if (it != varBindings_.end()) {
+      varBindings_.erase(it);
+      return true;
+    }
+    return false;
+  }
+
+  std::list<Stmt*> stmts() const {
+    return stmts_;
+  }
+
+  VarMapping varBindings() const {
+    return varBindings_;
+  }
+
   explicit Block(const std::vector<Stmt*>& stmts) {
     for (Stmt* s : stmts) {
       if (s->get_parent()) {
@@ -232,7 +251,24 @@ class TORCH_API Block : public StmtNode<Block> {
     stmts_.splice(it, other->stmts_);
   }
 
+  explicit Block(const VarMapping& vars, const std::vector<Stmt*>& stmts) {
+    for (auto& pair : vars) {
+      add_var_binding(pair.first, pair.second);
+    }
+
+    for (Stmt* s : stmts) {
+      if (s->get_parent()) {
+        throw malformed_input(
+            "Block creation has Stmt with existing parent", s);
+      }
+
+      stmts_.push_back(s);
+      set_parent(s, this);
+    }
+  }
+
  private:
+  VarMapping varBindings_;
   std::list<Stmt*> stmts_;
 };
 


### PR DESCRIPTION
Implementation of the less popular proposal for eliminating overlap between LetStmt and Let: removing both and storing a mapping between Var and value Expr in the Block.

This complicates some tests but simplifies the IR by restricting where variable binding can occur.

I used the unit tests & python integration tests to verify this is correct but I'm unsure of coverage, particularly around the dependency checker in loopnest - @ZolotukhinM your review would be useful there.