### PR TITLE
Expose rpc.Future.set_result() as a Python API

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -14,7 +14,6 @@
 #include <torch/csrc/utils/python_compat.h>
 #include <torch/types.h>
 
-
 #include <pybind11/chrono.h>
 #include <pybind11/functional.h>
 #include <pybind11/operators.h>

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -445,18 +445,16 @@ If the future completes with an error, an exception is thrown.
           )")
       .def(
           "__getstate__",
-          [](FutureIValue& self) {
+          [](FutureIValue& /* unused */) {
             TORCH_CHECK(
-                false,
-                "Can not pickle rpc.Future or send it over RPC.");
+                false, "Can not pickle rpc.Future or send it over RPC.");
           },
           py::call_guard<py::gil_scoped_release>())
       .def(
           "__setstate__",
-          [](FutureIValue& fv, py::tuple t) {
+          [](FutureIValue& /* unused */, py::tuple /* unused */) {
             TORCH_CHECK(
-                false,
-                "Can not unpickle rpc.Future or send it over RPC.");
+                false, "Can not unpickle rpc.Future or send it over RPC.");
           },
           py::call_guard<py::gil_scoped_release>());
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -442,7 +442,23 @@ If the future completes with an error, an exception is thrown.
                   >>>     lambda rpc_fut : fut.set_result(rpc_fut.wait() + 1)
                   >>> )
                   >>> print(fut.wait())  # tensor([3., 3.])
-          )");
+          )")
+      .def(
+          "__getstate__",
+          [](FutureIValue& self) {
+            TORCH_CHECK(
+                false,
+                "Can not pickle rpc.Future or send it over RPC.");
+          },
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "__setstate__",
+          [](FutureIValue& fv, py::tuple t) {
+            TORCH_CHECK(
+                false,
+                "Can not unpickle rpc.Future or send it over RPC.");
+          },
+          py::call_guard<py::gil_scoped_release>());
 
   shared_ptr_class_<ProcessGroupRpcBackendOptions>(
       module,

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -411,8 +411,7 @@ If the future completes with an error, an exception is thrown.
           "set_result",
           [&](FutureIValue& fut, py::object result) {
             fut.markCompleted(torch::jit::toIValue(
-                std::move(result),
-                PyObjectType::get()));
+                std::move(result), PyObjectType::get()));
           },
           py::call_guard<py::gil_scoped_release>(),
           R"(
@@ -445,14 +444,14 @@ If the future completes with an error, an exception is thrown.
           )")
       .def(
           "__getstate__",
-          [](FutureIValue& /* unused */) {
+          [](const FutureIValue& /* unused */) {
             TORCH_CHECK(
                 false, "Can not pickle rpc.Future or send it over RPC.");
           },
           py::call_guard<py::gil_scoped_release>())
       .def(
           "__setstate__",
-          [](FutureIValue& /* unused */, py::tuple /* unused */) {
+          [](const FutureIValue& /* unused */, const py::tuple& /* unused */) {
             TORCH_CHECK(
                 false, "Can not unpickle rpc.Future or send it over RPC.");
           },

--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -61,7 +61,10 @@ class TORCH_API Future final {
 
   void markCompleted(T value) {
     std::unique_lock<std::mutex> lock(mutex_);
-    TORCH_CHECK(!completed_);
+    TORCH_CHECK(
+        !completed_,
+        "Attempting to mark a completed Future as complete again. Note that "
+        "a Future can only be marked completed once.");
     // Set value first as completed_ is accessed without lock
     value_ = std::move(value);
     completed_ = true;

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -2506,33 +2506,22 @@ class RpcTest(RpcAgentTestFixture):
     @dist_init
     def test_pickle_future(self):
         fut = rpc.Future()
+        errMsg = "Can not pickle rpc.Future or send it over RPC"
         with TemporaryFileName() as fname:
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Can not pickle rpc.Future or send it over RPC"
-            ):
+            with self.assertRaisesRegex(RuntimeError, errMsg):
                 torch.save(fut, fname)
 
         dst = worker_name((self.rank + 1) % self.world_size)
         with TemporaryFileName() as fname:
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Can not pickle rpc.Future or send it over RPC"
-            ):
+            with self.assertRaisesRegex(RuntimeError, errMsg):
                 rpc.rpc_sync(dst, fail_on_fut, args=(fut,))
 
         with TemporaryFileName() as fname:
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Can not pickle rpc.Future or send it over RPC"
-            ):
+            with self.assertRaisesRegex(RuntimeError, errMsg):
                 rpc.rpc_async(dst, fail_on_fut, args=(fut,))
 
         with TemporaryFileName() as fname:
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "Can not pickle rpc.Future or send it over RPC"
-            ):
+            with self.assertRaisesRegex(RuntimeError, errMsg):
                 rpc.remote(dst, fail_on_fut, args=(fut,))
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37638 Remove unnecessary pickle and unpickle invocation in PyRRef __setstate__/__getstate__ methods
* **#37607 Expose rpc.Future.set_result() as a Python API**
* #37311 Let rpc.Future expose an add_done_callback API

Differential Revision: [D21336330](https://our.internmc.facebook.com/intern/diff/D21336330)