### PR TITLE
[JIT] Handle del statements with variables as targets

### DIFF
--- a/test/jit/test_builtins.py
+++ b/test/jit/test_builtins.py
@@ -74,6 +74,37 @@ class TestBuiltins(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, "hasattr"):
             torch.jit.script(Mod())
 
+    def test_del(self):
+        def fn(x):
+            # type: (List[int]) -> List[int]
+            a = x * 2
+            del a
+            return x
+
+        self.checkScript(fn, ([1, 2, 3],))
+
+        with self.assertRaisesRegex(RuntimeError, "undefined value"):
+            @torch.jit.script
+            def fn(x):
+                a = x ** 2
+                del a
+                return a
+
+        with self.assertRaisesRegex(RuntimeError, "undefined value"):
+            @torch.jit.script
+            def fn(x):
+                a = x ** 2
+                if a:
+                    del a
+                return a
+
+        with self.assertRaisesRegex(RuntimeError, "undefined value"):
+            @torch.jit.script
+            def fn(x):
+                a = x ** 2
+                del b
+                return a
+
     def test_del_multiple_operands(self):
 
         with self.assertRaisesRegex(torch.jit.frontend.NotSupportedError,

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -122,11 +122,6 @@ class TestList(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, "out of range"):
             fn2([])
 
-        with self.assertRaisesRegex(RuntimeError, "only supported for list and dict"):
-            @torch.jit.script
-            def fn(x):
-                del x
-
         with self.assertRaisesRegex(RuntimeError, "deletion at a single index"):
             @torch.jit.script
             def fn(x):


### PR DESCRIPTION
**Summary**
This commit modifies the JIT frontend to handle `del` statements with
variables as targets by dropping the mapping corresponding to that
variable from the environment stack maintained by the IR emitter code.

**Test Plan**
This commit adds test cases for deleting a variable, deleting a variable
and then using it, and deleting a variable in a if-statement, and then
using it.

