### PR TITLE
[JIT] Peephole optimize list ops

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -577,6 +577,51 @@ class TestJit(JitTestCase):
         torch._C._jit_pass_peephole(fn.graph)
         self.assertEqual(s, str(fn.graph))
 
+    def test_peephole_list_ops(self):
+        @torch.jit.script
+        def foo(x, y, z):
+            return len([x, y, z])
+
+        self.run_pass('peephole', foo.graph)
+        FileCheck().check("value=3").check_next("return").run(foo.graph)
+
+        @torch.jit.script
+        def foo(x, y, z):
+            li = [x, y, z]
+            for i in range(len(x)):
+                li.append(x)
+            return len([x, y, z])
+
+        self.run_pass('peephole', foo.graph)
+        FileCheck().check_not("aten::len").run(foo.graph)
+
+        @torch.jit.script
+        def foo(x, y, z):
+            li = [x, y, z]
+            return li[1], li[-2]
+
+        FileCheck().check("aten::__getitem__").run(foo.graph)
+        self.run_pass('peephole', foo.graph)
+        FileCheck().check_not("aten::__getitem__").run(foo.graph)
+
+        @torch.jit.script
+        def foo(x, y, z):
+            li = [x, y, z]
+            return li[-7]
+
+        self.run_pass('peephole', foo.graph)
+        FileCheck().check("aten::__getitem__").run(foo.graph)
+
+        @torch.jit.script
+        def foo(x, y, z):
+            li = [x, y, z]
+            for i in range(len(x)):
+                li.append(x)
+            return li[-2]
+
+        self.run_pass('peephole', foo.graph)
+        FileCheck().check("aten::__getitem__").run(foo.graph)
+
     @unittest.skipIf(not RUN_CUDA, "cpp tests require CUDA")
     def test_peephole_cuda(self):
         a = torch.tensor([0.4], device='cpu')

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -122,6 +122,7 @@ libtorch_core_sources = [
     "torch/csrc/jit/passes/loop_unrolling.cpp",
     "torch/csrc/jit/passes/lower_grad_of.cpp",
     "torch/csrc/jit/passes/lower_tuples.cpp",
+    "torch/csrc/jit/passes/peephole_list_idioms.cpp",
     "torch/csrc/jit/passes/pass_manager.cpp",
     "torch/csrc/jit/passes/peephole.cpp",
     "torch/csrc/jit/passes/prepack_folding.cpp",

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -4,7 +4,7 @@
 #include <torch/csrc/jit/ir/ir_views.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
-#include <torch/csrc/jit/passes/peephole.h>
+#include <torch/csrc/jit/passes/peephole_list_idioms.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/utils/memory.h>
 
@@ -27,6 +27,7 @@ struct PeepholeOptimizeImpl {
         changed_(true),
         shape_peepholes_(!disable_shape_peepholes) {
     run(graph->block());
+    PeepholeOptimizeListIdioms(graph);
   }
 
   // The intent for this optimization pass is to catch all of the small, easy to

--- a/torch/csrc/jit/passes/peephole_list_idioms.cpp
+++ b/torch/csrc/jit/passes/peephole_list_idioms.cpp
@@ -1,0 +1,104 @@
+#include <ATen/core/jit_type.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
+#include <torch/csrc/jit/ir/ir_views.h>
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/peephole.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
+#include <torch/csrc/utils/memory.h>
+
+namespace torch {
+namespace jit {
+
+size_t normalizeIndex(int64_t index, size_t len) {
+  if (index < 0) {
+    return index + len;
+  } else {
+    return index;
+  }
+}
+
+// This pass only does optimizations on lists which aren't mutated,
+// so we first use the Alias Db to collect the set of list values
+// which we shouldn't optimize.
+struct PeepholeOptimizeListIdiomsImpl {
+  PeepholeOptimizeListIdiomsImpl(const std::shared_ptr<Graph>& graph)
+      : graph_(graph), aliasDb_(torch::make_unique<AliasDb>(graph_)) {
+    collectMutatedLists(graph_->block());
+    run(graph_->block());
+  }
+
+ private:
+  void checkForMutatedList(Value* v) {
+    if (v->type()->cast<ListType>() && aliasDb_->hasWriters(v)) {
+      mutated_lists_.insert(v);
+    }
+  }
+
+  void collectMutatedLists(Block* b) {
+    for (Value* v : b->inputs()) {
+      checkForMutatedList(v);
+    }
+    for (Node* n : b->nodes()) {
+      for (Value* v : n->outputs()) {
+        checkForMutatedList(v);
+      }
+      for (Block* block : n->blocks()) {
+        collectMutatedLists(block);
+      }
+    }
+  }
+
+  void run(Block* block) {
+    for (Node* node : block->nodes()) {
+      for (Block* b : node->blocks()) {
+        run(b);
+      }
+
+      // only optimizing list ops
+      if (node->inputs().size() == 0 ||
+          !node->inputs().at(0)->type()->cast<ListType>()) {
+        continue;
+      }
+
+      auto first_input = node->inputs().at(0);
+
+      // only optimizing ops with unmutated lists
+      if (mutated_lists_.count(first_input)) {
+        continue;
+      }
+
+      if (node->kind() == aten::len) {
+        if (first_input->node()->kind() == prim::ListConstruct) {
+          WithInsertPoint guard(node);
+          node->output()->replaceAllUsesWith(graph_->insertConstant(
+              static_cast<int64_t>(first_input->node()->inputs().size())));
+        }
+      } else if (node->kind() == aten::__getitem__) {
+        auto list_creation_node = first_input->node();
+        if (list_creation_node->kind() == prim::ListConstruct) {
+          if (auto index = toIValue(node->inputs().at(1))) {
+            size_t list_size = list_creation_node->inputs().size();
+            int64_t norm_index = normalizeIndex(index->toInt(), list_size);
+            if (norm_index >= 0 &&
+                norm_index < static_cast<int64_t>(list_size)) {
+              node->output()->replaceAllUsesWith(
+                  list_creation_node->inputs().at(norm_index));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  std::unordered_set<Value*> mutated_lists_;
+  std::shared_ptr<Graph> graph_;
+  std::unique_ptr<AliasDb> aliasDb_;
+};
+
+void PeepholeOptimizeListIdioms(const std::shared_ptr<Graph>& graph) {
+  PeepholeOptimizeListIdiomsImpl opt(graph);
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/peephole_list_idioms.h
+++ b/torch/csrc/jit/passes/peephole_list_idioms.h
@@ -5,7 +5,8 @@
 namespace torch {
 namespace jit {
 
-// Optimizes list idioms. Currently this is invoked as part of PeepholeOptimize
+// Peephole Optimizes List Ops such as len(li) and li[1].
+// Currently this is invoked as part of PeepholeOptimize
 TORCH_API void PeepholeOptimizeListIdioms(const std::shared_ptr<Graph>& graph);
 
 } // namespace jit

--- a/torch/csrc/jit/passes/peephole_list_idioms.h
+++ b/torch/csrc/jit/passes/peephole_list_idioms.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+// Optimizes list idioms. Currently this is invoked as part of PeepholeOptimize
+TORCH_API void PeepholeOptimizeListIdioms(const std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -140,11 +140,13 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
     torch._C._jit_pass_lint(graph)
 
     if operator_export_type != OperatorExportTypes.RAW:
+        torch._C._jit_pass_peephole(graph, True)
+        torch._C._jit_pass_lower_all_tuples(graph)
+
+        # _prepare_inplace_ops makes the IR invalid for JIT passes / alias db
         torch._C._jit_pass_onnx_prepare_inplace_ops_for_onnx(graph)
 
         # onnx does not support tuples, so try to remove them
-        torch._C._jit_pass_lower_all_tuples(graph)
-        torch._C._jit_pass_peephole(graph, True)
         torch._C._jit_pass_lint(graph)
 
         # onnx only supports tensors, but 1 / 2 = 0.5 and tensor(1) / tensor(2) = 0


### PR DESCRIPTION
Peephole optimize  `len(li)` and `li[index]` patterns. 

This changes the Profiled Graph IR for the following tests:
```
(Test Name, Num ifs loops, Num non-tensor nodes) 
Before:
('test_nn_Conv1d_reflect_stride2_pad2', 3, 14)	
('test_nn_Conv2d_reflect_stride2_pad2', 3, 14)	
('test_nn_Conv1d_circular_stride2_pad2', 5, 31)	
('test_nn_Conv2d_circular_stride2_pad2', 5, 31)	
('test_nn_Conv3d_circular_stride2_pad2', 5, 31)	
('test_nn_Conv1d_replicate_stride2_pad2', 3, 14)	
('test_nn_Conv2d_replicate_stride2_pad2', 3, 14)	
('test_nn_Conv3d_replicate_stride2_pad2', 3, 14)	
After
('test_nn_Conv1d_reflect_stride2_pad2', 0, 2)
('test_nn_Conv2d_reflect_stride2_pad2', 0, 2)
('test_nn_Conv1d_circular_stride2_pad2', 0, 4)
('test_nn_Conv2d_circular_stride2_pad2', 0, 7)
('test_nn_Conv3d_circular_stride2_pad2', 0, 10)
('test_nn_Conv1d_replicate_stride2_pad2', 0, 2)
('test_nn_Conv2d_replicate_stride2_pad2', 0, 2)
('test_nn_Conv3d_replicate_stride2_pad2', 0, 2)
```