### PR TITLE
[quant][graph] Fix bug in replaceConvolutionWithConv2d

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1169,6 +1169,36 @@ graph(%input, %weight):
                    .check("quantized::linear") \
                    .run(model.graph)
 
+    def test_conv_trace(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.conv1d = torch.nn.Conv1d(3, 3, 3).float()
+                self.conv2d = torch.nn.Conv2d(3, 3, 3).float()
+                self.conv3d = torch.nn.Conv3d(3, 3, 3).float()
+
+            def forward(self, x, y, z):
+                a = self.conv1d(x)
+                b = self.conv2d(y)
+                c = self.conv3d(z)
+                return (a, b, c)
+
+        qconfig_dict = {'': default_qconfig}
+        inputs = (torch.rand((1, 3, 10), dtype=torch.float),
+                  torch.rand((1, 3, 10, 10), dtype=torch.float),
+                  torch.rand((1, 3, 10, 10, 10), dtype=torch.float))
+        model = torch.jit.trace(M(), inputs).eval()
+        m = prepare_script(model, qconfig_dict)
+        FileCheck().check('aten::conv1d') \
+                   .check_not("aten::_convolution") \
+                   .run(str(get_forward_graph(m.conv1d._c)))
+        FileCheck().check('aten::conv2d') \
+                   .check_not("aten::_convolution") \
+                   .run(str(get_forward_graph(m.conv2d._c)))
+        FileCheck().check('aten::conv3d') \
+                   .check_not("aten::_convolution") \
+                   .run(str(get_forward_graph(m.conv3d._c)))
+
 class TestQuantizeScriptPTSQOps(JitTestCase):
     """ Test graph mode post training static quantization works
     for individual ops end to end.

--- a/torch/csrc/jit/passes/graph_rewrite_helper.cpp
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.cpp
@@ -66,6 +66,10 @@ void replaceConvolutionWithConv2d(std::shared_ptr<Graph>& graph) {
     auto output_padding_value =
         getIValue("output_padding", match_vmap, vmap).value().toIntList();
 
+    // For conv1d output_padding size is always 1, so return false here.
+    if (output_padding_value.size() < 2) {
+      return false;
+    }
     if (!transposed_value && !benchmark_value && !deterministic_value &&
         cudnn_enabled_value && (output_padding_value[0] == 0) &&
         (output_padding_value[1] == 0)) {

--- a/torch/csrc/jit/passes/graph_rewrite_helper.cpp
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.cpp
@@ -34,7 +34,7 @@ c10::optional<IValue> getIValue(
   return toIValue(getValue(name, match_vmap, vmap));
 }
 
-void replaceConvolutionWithConv2d(std::shared_ptr<Graph>& graph) {
+void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
   ConstantPropagation(graph);
   std::string convolution = R"(
       graph(%a, %w, %b, %stride:int[], %padding:int[], %dilation:int[],

--- a/torch/csrc/jit/passes/graph_rewrite_helper.cpp
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.cpp
@@ -34,6 +34,30 @@ c10::optional<IValue> getIValue(
   return toIValue(getValue(name, match_vmap, vmap));
 }
 
+void get_conv_params(
+    const Match& match,
+    const std::unordered_map<std::string, Value*>& vmap,
+    std::unordered_map<std::string, c10::IValue>& calc_values) {
+  const auto& match_vmap = match.values_map;
+  auto transposed_value = getIValue("transposed", match_vmap, vmap).value();
+  calc_values["transposed"] = transposed_value;
+  auto benchmark_value = getIValue("benchmark", match_vmap, vmap).value();
+  calc_values["benchmark"] = benchmark_value;
+  auto deterministic_value =
+      getIValue("deterministic", match_vmap, vmap).value();
+  calc_values["deterministic"] = deterministic_value;
+  auto cudnn_enabled_value =
+      getIValue("cudnn_enabled", match_vmap, vmap).value();
+  calc_values["cudnn_enabled"] = cudnn_enabled_value;
+  auto output_padding_value =
+      getIValue("output_padding", match_vmap, vmap).value();
+  calc_values["output_padding"] = output_padding_value;
+  auto stride_value = getIValue("stride", match_vmap, vmap).value();
+  calc_values["stride"] = stride_value;
+  auto dilation_value = getIValue("dilation", match_vmap, vmap).value();
+  calc_values["dilation"] = dilation_value;
+}
+
 void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
   ConstantPropagation(graph);
   std::string convolution = R"(
@@ -58,47 +82,61 @@ void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
         %r = aten::conv1d(%a, %w, %b, %stride, %padding, %dilation, %groups)
         return (%r) )";
 
+  std::string conv3d = R"(
+      graph(%a, %w, %b, %stride:int[], %padding:int[], %dilation:int[],
+          %transposed:bool, %output_padding:int[], %groups:int, %benchmark:bool,
+          %deterministic:bool, %cudnn_enabled:bool):
+        %r = aten::conv3d(%a, %w, %b, %stride, %padding, %dilation, %groups)
+        return (%r) )";
+
   // Filter the unsupported case
   auto filter_conv1d = [](const Match& match,
                           const std::unordered_map<std::string, Value*>& vmap) {
-    const auto& match_vmap = match.values_map;
-    auto transposed_value =
-        getIValue("transposed", match_vmap, vmap).value().toBool();
-    auto benchmark_value =
-        getIValue("benchmark", match_vmap, vmap).value().toBool();
-    auto deterministic_value =
-        getIValue("deterministic", match_vmap, vmap).value().toBool();
-    auto cudnn_enabled_value =
-        getIValue("cudnn_enabled", match_vmap, vmap).value().toBool();
-    auto output_padding_value =
-        getIValue("output_padding", match_vmap, vmap).value().toIntList();
-
-    if (output_padding_value.size() != 1) {
+    std::unordered_map<std::string, c10::IValue> calc_value_map;
+    get_conv_params(match, vmap, calc_value_map);
+    if (calc_value_map["output_padding"].toIntList().size() != 1 ||
+        calc_value_map["stride"].toIntList().size() != 1 ||
+        calc_value_map["dilation"].toIntList().size() != 1) {
       return false;
     }
-    return !transposed_value && !benchmark_value && !deterministic_value &&
-        cudnn_enabled_value && (output_padding_value[0] == 0);
+    return !calc_value_map["transposed"].toBool() &&
+        !calc_value_map["benchmark"].toBool() &&
+        !calc_value_map["deterministic"].toBool() &&
+        calc_value_map["cudnn_enabled"].toBool() &&
+        (calc_value_map["output_padding"].toIntList()[0] == 0);
   };
   auto filter_conv2d = [](const Match& match,
                           const std::unordered_map<std::string, Value*>& vmap) {
-    const auto& match_vmap = match.values_map;
-    auto transposed_value =
-        getIValue("transposed", match_vmap, vmap).value().toBool();
-    auto benchmark_value =
-        getIValue("benchmark", match_vmap, vmap).value().toBool();
-    auto deterministic_value =
-        getIValue("deterministic", match_vmap, vmap).value().toBool();
-    auto cudnn_enabled_value =
-        getIValue("cudnn_enabled", match_vmap, vmap).value().toBool();
-    auto output_padding_value =
-        getIValue("output_padding", match_vmap, vmap).value().toIntList();
-
-    if (output_padding_value.size() != 2) {
+    std::unordered_map<std::string, c10::IValue> calc_value_map;
+    get_conv_params(match, vmap, calc_value_map);
+    if (calc_value_map["output_padding"].toIntList().size() != 2 ||
+        calc_value_map["stride"].toIntList().size() != 2 ||
+        calc_value_map["dilation"].toIntList().size() != 2) {
       return false;
     }
-    return !transposed_value && !benchmark_value && !deterministic_value &&
-        cudnn_enabled_value && (output_padding_value[0] == 0) &&
-        (output_padding_value[1] == 0);
+    return !calc_value_map["transposed"].toBool() &&
+        !calc_value_map["benchmark"].toBool() &&
+        !calc_value_map["deterministic"].toBool() &&
+        calc_value_map["cudnn_enabled"].toBool() &&
+        (calc_value_map["output_padding"].toIntList()[0] == 0) &&
+        (calc_value_map["output_padding"].toIntList()[1] == 0);
+  };
+  auto filter_conv3d = [](const Match& match,
+                          const std::unordered_map<std::string, Value*>& vmap) {
+    std::unordered_map<std::string, c10::IValue> calc_value_map;
+    get_conv_params(match, vmap, calc_value_map);
+    if (calc_value_map["output_padding"].toIntList().size() != 3 ||
+        calc_value_map["stride"].toIntList().size() != 3 ||
+        calc_value_map["dilation"].toIntList().size() != 3) {
+      return false;
+    }
+    return !calc_value_map["transposed"].toBool() &&
+        !calc_value_map["benchmark"].toBool() &&
+        !calc_value_map["deterministic"].toBool() &&
+        calc_value_map["cudnn_enabled"].toBool() &&
+        (calc_value_map["output_padding"].toIntList()[0] == 0) &&
+        (calc_value_map["output_padding"].toIntList()[1] == 0) &&
+        (calc_value_map["output_padding"].toIntList()[2] == 0);
   };
 
   SubgraphRewriter rewriter_conv1d;
@@ -107,6 +145,9 @@ void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
   SubgraphRewriter rewriter_conv2d;
   rewriter_conv2d.RegisterRewritePattern(convolution, conv2d);
   rewriter_conv2d.runOnGraph(graph, filter_conv2d);
+  SubgraphRewriter rewriter_conv3d;
+  rewriter_conv3d.RegisterRewritePattern(convolution, conv3d);
+  rewriter_conv3d.runOnGraph(graph, filter_conv3d);
 }
 
 } // namespace graph_rewrite_helper

--- a/torch/csrc/jit/passes/graph_rewrite_helper.h
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.h
@@ -16,7 +16,7 @@ c10::optional<IValue> getIValue(
     const std::string& name,
     const std::unordered_map<const Value*, Value*>& match_vmap,
     const std::unordered_map<std::string, Value*>& vmap);
-void replaceConvolutionWithConv2d(std::shared_ptr<Graph>& graph);
+void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph);
 
 // This struct contains a compiled IR patterns slated for use in the
 // findPatternMatches function. The struct encapsulates the common

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -33,7 +33,7 @@ using graph_rewrite_helper::getFuncName;
 using graph_rewrite_helper::getIValue;
 using graph_rewrite_helper::getValue;
 using graph_rewrite_helper::PatternInfo;
-using graph_rewrite_helper::replaceConvolutionWithConv2d;
+using graph_rewrite_helper::replaceConvolutionWithAtenConv;
 
 // Map of quantization parameter name and value
 // for example _scale, _zero_point,
@@ -1093,7 +1093,7 @@ void InsertObserversHelper::preprocess(
   ConstantPooling(graph);
   ConstantPropagation(graph);
   // must do constant propagation first before replacement
-  replaceConvolutionWithConv2d(graph);
+  replaceConvolutionWithAtenConv(graph);
   // fuse decomposed linear into aten::linear
   FuseLinear(graph);
 

--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -65,7 +65,7 @@ void insertPrePackedLinearOp(std::shared_ptr<Graph>& graph) {
 
 void insertPrePackedConv2dOp(std::shared_ptr<Graph>& graph) {
   // Replace _convolution with conv2d
-  graph_rewrite_helper::replaceConvolutionWithConv2d(graph);
+  graph_rewrite_helper::replaceConvolutionWithAtenConv(graph);
 
   std::string conv_2d_pattern = R"(
     graph(%input, %weight, %bias, %stride:int[], %padding:int[], %dilation:int[], %groups:int):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37779 [quant][mobile] Return for conv with empty batch
* #37637 [quant][graph] Fix bug in replicateDequant
* **#37635 [quant][graph] Fix bug in replaceConvolutionWithConv2d**

Summary:
replaceConvolutionWithConv2d incorrectly assumes that the size of padding is 2. For Conv1d it is 1, in which case we cannot replace with aten::conv2d

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21354930](https://our.internmc.facebook.com/intern/diff/D21354930)