### PR TITLE
Add missing IValue Python binding

### DIFF
--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -556,6 +556,7 @@ void initPythonIRBindings(PyObject* module_) {
       .CREATE_ACCESSOR(Ints, is)
       .CREATE_ACCESSOR(Graph, g)
       .CREATE_ACCESSOR(Graphs, gs)
+      .CREATE_ACCESSOR(IValue, ival)
 #undef CREATE_ACCESSOR
       // Tensor (t_) -- manually written to unwrap the variable into a tensor.
       .def(


### PR DESCRIPTION
Summary:
We uses the following snippet to extract value from `prim::const` nodes
  if jit_node.hasAttribute("value"):
      getter = getattr(jit_node, jit_node.kindOf("value"))
      value = getter("value")
Some recent change caused `kindOf` to return `"ival"` in some cases, so we need to add this binding.

Let me know if there's a better way to achieve the above though.

Differential Revision: D21339406

