### PR TITLE
[quant][graph] Fix bug in replicateDequant

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1213,7 +1213,8 @@ graph(%input, %weight):
         qconfig_dict = {'': default_qconfig}
         model = torch.jit.script(Mul()).eval()
         m = quantize_script(model, qconfig_dict, _test_only_eval_fn, [data])
-        FileCheck().check_not("aten::mul") \
+        FileCheck().check("quantized::mul") \
+                   .check_not("aten::mul") \
                    .run(m.graph)
 
 class TestQuantizeScriptPTSQOps(JitTestCase):

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -1539,7 +1539,7 @@ void insertDeQuantForAllUse(
     // in the same block so that quant fusion can happen
     WithInsertPoint ins(user);
     Node* dequant = insertDeQuant(graph, quantized_val, original_val, i);
-    user->replaceInputWith(original_val, dequant->output());
+    user->replaceInput(uses[i].offset, dequant->output());
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37779 [quant][mobile] Return for conv with empty batch
* **#37637 [quant][graph] Fix bug in replicateDequant**
* #37635 [quant][graph] Fix bug in replaceConvolutionWithConv2d

Summary:
Insert dequant op at specific offset, rather than for all inputs of user

Test Plan:
python test/test_quantization.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21354931](https://our.internmc.facebook.com/intern/diff/D21354931)