### PR TITLE
Add priority flag in c10::Allocator

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -17,9 +17,13 @@ at::DataPtr InefficientStdFunctionContext::makeDataPtr(
 }
 
 C10_API at::Allocator* allocator_array[at::COMPILE_TIME_MAX_DEVICE_TYPES];
+C10_API uint8_t allocator_priority[at::COMPILE_TIME_MAX_DEVICE_TYPES] = {0};
 
-void SetAllocator(at::DeviceType t, at::Allocator* alloc) {
-  allocator_array[static_cast<int>(t)] = alloc;
+void SetAllocator(at::DeviceType t, at::Allocator* alloc, uint8_t priority) {
+  if (priority >= allocator_priority[static_cast<int>(t)]) {
+    allocator_array[static_cast<int>(t)] = alloc;
+    allocator_priority[static_cast<int>(t)] = priority;
+  }
 }
 
 at::Allocator* GetAllocator(const at::DeviceType& t) {

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -198,8 +198,13 @@ struct C10_API InefficientStdFunctionContext {
  *
  *  Also note that this is not thread-safe, and we assume this function will
  *  only be called during initialization.
+ *
+ *  The 'priority' flag is introduced when we want to overwrite the default
+ *  allocator, since the allocators are set statically. The default priority
+ *  is 0, which means the lowest. Only higher or equal priority can overwrite
+ *  existing ones.
  */
-C10_API void SetAllocator(DeviceType t, Allocator* alloc);
+C10_API void SetAllocator(DeviceType t, Allocator* alloc, uint8_t priority = 0);
 C10_API Allocator* GetAllocator(const DeviceType& t);
 
 template <DeviceType t>

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -209,8 +209,8 @@ at::Allocator* GetCPUAllocator() {
   return GetAllocator(DeviceType::CPU);
 }
 
-void SetCPUAllocator(at::Allocator* alloc) {
-  SetAllocator(DeviceType::CPU, alloc);
+void SetCPUAllocator(at::Allocator* alloc, uint8_t priority) {
+  SetAllocator(DeviceType::CPU, alloc, priority);
 }
 
 // The Mobile CPU allocator must always be present even on non-mobile builds

--- a/c10/core/CPUAllocator.h
+++ b/c10/core/CPUAllocator.h
@@ -41,7 +41,7 @@ C10_API void free_cpu(void* data);
 C10_API at::Allocator* GetCPUAllocator();
 // Sets the CPU allocator to the given allocator: the caller gives away the
 // ownership of the pointer.
-C10_API void SetCPUAllocator(at::Allocator* alloc);
+C10_API void SetCPUAllocator(at::Allocator* alloc, uint8_t priority = 0);
 
 // Get the Default CPU Allocator
 C10_API at::Allocator* GetDefaultCPUAllocator();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37640 Add priority flag in c10::Allocator**

In some cases we may need to install a custom allocator statically. To ensure it is correctly installed regardless of static initialization order, we add a priority flag in c10::SetAllocator, and only higher priority allocators can overwrite existing ones.

Differential Revision: [D21258581](https://our.internmc.facebook.com/intern/diff/D21258581/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D21258581/)!