### PR TITLE
Migrate item() to c10::complex

### DIFF
--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -20,7 +20,7 @@ Scalar item(const Tensor& self) {
 
 Scalar _local_scalar_dense_cpu(const Tensor& self) {
   Scalar r;
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND3(
     at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_local_scalar_dense_cpu", [&] {
         scalar_t value = *self.data_ptr<scalar_t>();
         r = Scalar(value);

--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -14,7 +14,7 @@ namespace native {
 Scalar _local_scalar_dense_cuda(const Tensor& self) {
   Scalar r;
 #if HIP_VERSION >= 301
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND3(
     at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_local_scalar_dense_cuda", [&] {
         scalar_t value;
         cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -22,7 +22,7 @@ Scalar _local_scalar_dense_cuda(const Tensor& self) {
         r = Scalar(value);
       });
 #else
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND3(
     at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_local_scalar_dense_cuda", [&] {
         scalar_t value;
         cudaStream_t stream = at::cuda::getCurrentCUDAStream();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37651 Migrate CUDA fill kernel to c10::complex
* #37650 Migrate CUDA cat, scatter, gather, index, index_put to c10::complex
* #37649 Migrate CPU casting copy kernel to c10::complex
* **#37648 Migrate item() to c10::complex**

Differential Revision: [D21382318](https://our.internmc.facebook.com/intern/diff/D21382318)