### PR TITLE
Migrate CUDA fill kernel to c10::complex

### DIFF
--- a/aten/src/ATen/native/cuda/FillKernel.cu
+++ b/aten/src/ATen/native/cuda/FillKernel.cu
@@ -7,7 +7,7 @@
 namespace at { namespace native {
 
 void fill_kernel_cuda(TensorIterator& iter, Scalar value) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "fill_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "fill_cuda", [&]() {
     auto value_converted = value.to<scalar_t>();
     gpu_kernel(iter, [value_converted]GPU_LAMBDA() -> scalar_t {
       return value_converted;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37651 Migrate CUDA fill kernel to c10::complex**
* #37650 Migrate CUDA cat, scatter, gather, index, index_put to c10::complex
* #37649 Migrate CPU casting copy kernel to c10::complex
* #37648 Migrate item() to c10::complex

Differential Revision: [D21394351](https://our.internmc.facebook.com/intern/diff/D21394351)