### PR TITLE
[caffe2] L2 regularization for rowwise fused sparse adagrad

### DIFF
--- a/caffe2/perfkernels/adagrad.cc
+++ b/caffe2/perfkernels/adagrad.cc
@@ -15,8 +15,10 @@ void adagrad_update__base(
     float* nh,
     float epsilon,
     float decay,
-    const float lr) {
-  internal::adagrad_update_base_inlined(N, w, g, h, nw, nh, decay, epsilon, lr);
+    const float lr,
+    const float weight_decay = 0.f) {
+  internal::adagrad_update_base_inlined(
+      N, w, g, h, nw, nh, decay, epsilon, lr, weight_decay);
 }
 
 void adagrad_update_prefetch__base(
@@ -36,8 +38,9 @@ void adagrad_update_prefetch__base(
     float* /* nh_n */, // prefetch ptr
 
     float epsilon,
-    float lr) {
-  adagrad_update__base(N, w, g, h, nw, nh, epsilon, 1.0f, lr);
+    float lr,
+    float weight_decay = 0.f) {
+  adagrad_update__base(N, w, g, h, nw, nh, epsilon, 1.0f, lr, weight_decay);
 }
 
 void adagrad_fp16_update_prefetch__base(
@@ -52,12 +55,14 @@ void adagrad_fp16_update_prefetch__base(
     at::Half* nh,
     at::Half* /* nh_n */, // prefetch ptr
     float epsilon,
-    float lr) {
-  internal::adagrad_update_base_inlined(N, w, g, h, nw, nh, 1.0f, epsilon, lr);
+    float lr,
+    float weight_decay = 0.f) {
+  internal::adagrad_update_base_inlined(
+      N, w, g, h, nw, nh, 1.0f, epsilon, lr, weight_decay);
 }
 
 // version without prefetching
-decltype(adagrad_update__base) adagrad_update__avx_f16c;
+decltype(adagrad_update__base) adagrad_update__avx2_fma;
 void adagrad_update(
     int N,
     const float* w,
@@ -67,12 +72,14 @@ void adagrad_update(
     float* nh,
     float epsilon,
     float decay,
-    float lr) {
-  AVX_F16C_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
-  BASE_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr);
+    float lr,
+    float weight_decay) {
+  AVX2_FMA_DO(
+      adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
+  BASE_DO(adagrad_update, N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
 }
 
-decltype(adagrad_update_prefetch__base) adagrad_update_prefetch__avx_f16c;
+decltype(adagrad_update_prefetch__base) adagrad_update_prefetch__avx2_fma;
 void adagrad_update_prefetch(
     int N,
     const float* w,
@@ -90,8 +97,9 @@ void adagrad_update_prefetch(
     float* nh_n, // prefetch ptr
 
     float epsilon,
-    float lr) {
-  AVX_F16C_DO(
+    float lr,
+    float weight_decay) {
+  AVX2_FMA_DO(
       adagrad_update_prefetch,
       N,
       w,
@@ -104,7 +112,8 @@ void adagrad_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
   BASE_DO(
       adagrad_update_prefetch,
       N,
@@ -118,13 +127,14 @@ void adagrad_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
 }
 
 // Version with prefetching for embeddings and
 // momentum using fp16
 decltype(
-    adagrad_fp16_update_prefetch__base) adagrad_fp16_update_prefetch__avx_f16c;
+    adagrad_fp16_update_prefetch__base) adagrad_fp16_update_prefetch__avx2_fma;
 void adagrad_fp16_update_prefetch(
     int N,
     const at::Half* w,
@@ -137,8 +147,9 @@ void adagrad_fp16_update_prefetch(
     at::Half* nh,
     at::Half* nh_n, // prefetch ptr
     float epsilon,
-    float lr) {
-  AVX_F16C_DO(
+    float lr,
+    float weight_decay) {
+  AVX2_FMA_DO(
       adagrad_fp16_update_prefetch,
       N,
       w,
@@ -151,7 +162,8 @@ void adagrad_fp16_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
   BASE_DO(
       adagrad_fp16_update_prefetch,
       N,
@@ -165,7 +177,8 @@ void adagrad_fp16_update_prefetch(
       nh,
       nh_n,
       epsilon,
-      lr);
+      lr,
+      weight_decay);
 }
 
 } // namespace caffe2

--- a/caffe2/perfkernels/adagrad_avx2.cc
+++ b/caffe2/perfkernels/adagrad_avx2.cc
@@ -7,7 +7,7 @@
 namespace caffe2 {
 
 // version without prefetching
-void adagrad_update__avx_f16c(
+void adagrad_update__avx2_fma(
     int N,
     const float* w,
     const float* g,
@@ -16,13 +16,15 @@ void adagrad_update__avx_f16c(
     float* nh,
     float epsilon,
     float decay,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   constexpr size_t kSize = 8;
   auto i = 0;
   for (; i + kSize <= N; i += kSize) {
     __m256 gi = _mm256_loadu_ps(g + i);
     __m256 hi = _mm256_loadu_ps(h + i);
     __m256 wi = _mm256_loadu_ps(w + i);
+    gi = _mm256_fmadd_ps(_mm256_set1_ps(weight_decay), wi, gi);
 
     __m256 nhi = _mm256_add_ps(
         _mm256_mul_ps(_mm256_set1_ps(decay), hi), _mm256_mul_ps(gi, gi));
@@ -34,13 +36,13 @@ void adagrad_update__avx_f16c(
   }
 
   for (; i < N; ++i) {
-    float gi = g[i];
+    float gi = std::fma(weight_decay, w[i], g[i]);
     float hi = nh[i] = decay * h[i] + gi * gi;
     nw[i] = w[i] + lr * gi / (std::sqrt(hi) + epsilon);
   }
 }
 
-void adagrad_update_prefetch__avx_f16c(
+void adagrad_update_prefetch__avx2_fma(
     int N,
     const float* w,
     const float* w_n, // prefetch ptr
@@ -57,13 +59,14 @@ void adagrad_update_prefetch__avx_f16c(
     float* nh_n, // prefetch ptr
 
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   internal::adagrad_update_prefetch_inlined(
-      N, w, w_n, g, h, h_n, nw, nw_n, nh, nh_n, epsilon, lr);
+      N, w, w_n, g, h, h_n, nw, nw_n, nh, nh_n, epsilon, lr, weight_decay);
 }
 
 // Compute adagrad sparse, assumes embedding and momentum are at::Half
-void adagrad_fp16_update_prefetch__avx_f16c(
+void adagrad_fp16_update_prefetch__avx2_fma(
     int N,
     const at::Half* w,
     const at::Half* w_n, // prefetch ptr
@@ -75,7 +78,8 @@ void adagrad_fp16_update_prefetch__avx_f16c(
     at::Half* nh,
     at::Half* nh_n, // prefetch ptr
     float epsilon,
-    float lr) {
+    float lr,
+    float weight_decay = 0.f) {
   constexpr int kSize = 8;
   auto i = 0;
   for (; i + kSize <= N; i += kSize) {
@@ -90,6 +94,7 @@ void adagrad_fp16_update_prefetch__avx_f16c(
     __m256 hi = _mm256_cvtph_ps(hhi);
     __m128i whi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w + i));
     __m256 wi = _mm256_cvtph_ps(whi);
+    gi = _mm256_fmadd_ps(_mm256_set1_ps(weight_decay), wi, gi);
 
     __m256 nhi = _mm256_add_ps(hi, _mm256_mul_ps(gi, gi));
     __m128i nhhi = _mm256_cvtps_ph(nhi, 0);
@@ -104,7 +109,10 @@ void adagrad_fp16_update_prefetch__avx_f16c(
   }
 
   for (; i < N; ++i) {
-    float gi = g[i];
+    float gi = std::fma(
+        weight_decay,
+        _cvtsh_ss(reinterpret_cast<const unsigned short*>(w)[i]),
+        g[i]);
     float nhi =
         _cvtsh_ss(reinterpret_cast<const unsigned short*>(h)[i]) + gi * gi;
     reinterpret_cast<unsigned short*>(nh)[i] = _cvtss_sh(nhi, 0);

--- a/caffe2/python/operator_test/adagrad_test.py
+++ b/caffe2/python/operator_test/adagrad_test.py
@@ -4,7 +4,6 @@ import functools
 
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
-import hypothesis
 import hypothesis.strategies as st
 import numpy as np
 from caffe2.python import core
@@ -24,9 +23,10 @@ class TestAdagrad(serial.SerializedTestCase):
         epsilon=st.floats(
             min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
         ),
+        weight_decay=st.sampled_from([0.0, 0.1]),
         **hu.gcs
     )
-    def test_adagrad(self, inputs, lr, epsilon, gc, dc):
+    def test_adagrad(self, inputs, lr, epsilon, weight_decay, gc, dc):
         param, momentum, grad = inputs
         momentum = np.abs(momentum)
         lr = np.array([lr], dtype=np.float32)
@@ -36,6 +36,7 @@ class TestAdagrad(serial.SerializedTestCase):
             ["param", "momentum", "grad", "lr"],
             ["param", "momentum"],
             epsilon=epsilon,
+            weight_decay=weight_decay,
             device_option=gc,
         )
 
@@ -43,7 +44,7 @@ class TestAdagrad(serial.SerializedTestCase):
             gc,
             op,
             [param, momentum, grad, lr],
-            functools.partial(ref_adagrad, epsilon=epsilon),
+            functools.partial(ref_adagrad, epsilon=epsilon, weight_decay=weight_decay),
         )
 
     @given(
@@ -54,9 +55,12 @@ class TestAdagrad(serial.SerializedTestCase):
         epsilon=st.floats(
             min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
         ),
+        weight_decay=st.sampled_from([0.0, 0.1]),
         **hu.gcs_cpu_only
     )
-    def test_adagrad_output_effective_lr(self, inputs, lr, epsilon, gc, dc):
+    def test_adagrad_output_effective_lr(
+        self, inputs, lr, epsilon, weight_decay, gc, dc
+    ):
         param, momentum, grad = inputs
         momentum = np.abs(momentum)
         lr = np.array([lr], dtype=np.float32)
@@ -66,6 +70,7 @@ class TestAdagrad(serial.SerializedTestCase):
             ["param", "momentum", "grad", "lr"],
             ["param", "momentum", "effective_lr"],
             epsilon=epsilon,
+            weight_decay=weight_decay,
             device_option=gc,
         )
 
@@ -73,7 +78,12 @@ class TestAdagrad(serial.SerializedTestCase):
             gc,
             op,
             [param, momentum, grad, lr],
-            functools.partial(ref_adagrad, epsilon=epsilon, output_effective_lr=True),
+            functools.partial(
+                ref_adagrad,
+                epsilon=epsilon,
+                output_effective_lr=True,
+                weight_decay=weight_decay,
+            ),
         )
 
     @given(
@@ -119,11 +129,20 @@ class TestAdagrad(serial.SerializedTestCase):
         epsilon=st.floats(
             min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
         ),
+        weight_decay=st.sampled_from([0.0, 0.1]),
         **hu.gcs
     )
-    def test_sparse_adagrad(self, inputs, lr, epsilon, gc, dc):
+    def test_sparse_adagrad(self, inputs, lr, epsilon, weight_decay, gc, dc):
         adagrad_sparse_test_helper(
-            self, inputs, lr, epsilon, None, ref_adagrad, gc, dc
+            self,
+            inputs,
+            lr,
+            epsilon,
+            None,
+            ref_adagrad,
+            gc,
+            dc,
+            weight_decay=weight_decay,
         )
 
     @serial.given(
@@ -162,7 +181,8 @@ class TestAdagrad(serial.SerializedTestCase):
                 None,
                 ref_adagrad,
                 gc,
-                dc)
+                dc,
+            )
 
     # Suppress filter_too_much health check.
     # Likely caused by `assume` call falling through too often.
@@ -175,9 +195,10 @@ class TestAdagrad(serial.SerializedTestCase):
         epsilon=st.floats(
             min_value=0.01, max_value=0.99, allow_nan=False, allow_infinity=False
         ),
+        weight_decay=st.sampled_from([0.0, 0.1]),
         **hu.gcs
     )
-    def test_row_wise_sparse_adagrad(self, inputs, lr, epsilon, gc, dc):
+    def test_row_wise_sparse_adagrad(self, inputs, lr, epsilon, weight_decay, gc, dc):
         adagrad_sparse_test_helper(
             self,
             inputs,
@@ -188,6 +209,7 @@ class TestAdagrad(serial.SerializedTestCase):
             gc,
             dc,
             row_wise=True,
+            weight_decay=weight_decay,
         )
 
     @serial.given(
@@ -200,9 +222,7 @@ class TestAdagrad(serial.SerializedTestCase):
         ),
         **hu.gcs
     )
-    def test_row_wise_sparse_adagrad_empty(
-        self, inputs, lr, epsilon, gc, dc
-    ):
+    def test_row_wise_sparse_adagrad_empty(self, inputs, lr, epsilon, gc, dc):
         param, momentum = inputs
         grad = np.empty(shape=(0,) + param.shape[1:], dtype=np.float32)
         adagrad_sparse_test_helper(

--- a/caffe2/python/operator_test/adagrad_test_helper.py
+++ b/caffe2/python/operator_test/adagrad_test_helper.py
@@ -18,6 +18,7 @@ def ref_adagrad(
     output_effective_lr_and_update=False,
     decay=1.0,
     row_wise=False,
+    weight_decay=0.0,
 ):
     mom_in_f32 = mom_in
     param_in_f32 = param_in
@@ -25,6 +26,7 @@ def ref_adagrad(
         mom_in_f32 = mom_in.astype(np.float32)
         param_in_f32 = param_in.astype(np.float32)
 
+    grad += weight_decay * param_in_f32
     if row_wise:
         mom_out = decay * mom_in_f32 + np.mean(np.square(grad))
     else:
@@ -69,7 +71,16 @@ def ref_adagrad(
 
 
 def adagrad_sparse_test_helper(
-    parent_test, inputs, lr, epsilon, engine, ref_adagrad, gc, dc, row_wise=False
+    parent_test,
+    inputs,
+    lr,
+    epsilon,
+    engine,
+    ref_adagrad,
+    gc,
+    dc,
+    row_wise=False,
+    weight_decay=0.0,
 ):
     param, momentum, grad = inputs
     if row_wise:
@@ -97,6 +108,7 @@ def adagrad_sparse_test_helper(
         ["param", "momentum", "indices", "grad", "lr"],
         ["param", "momentum"],
         epsilon=epsilon,
+        weight_decay=weight_decay,
         engine=engine,
         device_option=gc,
     )
@@ -118,6 +130,7 @@ def adagrad_sparse_test_helper(
                 grad[i],
                 lr,
                 epsilon,
+                weight_decay=weight_decay,
             )
         return (param_out, momentum_out)
 

--- a/caffe2/sgd/adagrad_fused.cc
+++ b/caffe2/sgd/adagrad_fused.cc
@@ -15,9 +15,10 @@ struct adagrad_update_prefetch_inlined {
       float* nh,
       float* nh_n, // prefetch ptr
       float epsilon,
-      float lr) {
+      float lr,
+      float weight_decay) {
     return internal::adagrad_update_prefetch_inlined(
-        N, w, w_n, g, h, h_n, nw, nw_n, nh, nh_n, epsilon, lr);
+        N, w, w_n, g, h, h_n, nw, nw_n, nh, nh_n, epsilon, lr, weight_decay);
   }
 };
 

--- a/caffe2/sgd/adagrad_fused.h
+++ b/caffe2/sgd/adagrad_fused.h
@@ -20,6 +20,8 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "SparseAdagradFusedWithSparseLengthsSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -148,6 +150,8 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -315,6 +319,9 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO)
+        << "gradient optimization operator in use: "
+        << "SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");

--- a/caffe2/sgd/adagrad_fused.h
+++ b/caffe2/sgd/adagrad_fused.h
@@ -19,7 +19,9 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
     LOG(INFO) << "gradient optimization operator in use: "
               << "SparseAdagradFusedWithSparseLengthsSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
@@ -96,7 +98,7 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
             Input(PARAM).numel());
 
         if (block_size == 1) {
-          float gi = gradIn[offsetI];
+          float gi = std::fma(weight_decay_, paramIn[idx], gradIn[offsetI]);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] =
               paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
@@ -124,7 +126,8 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
               &momentOut[idx_pref * block_size],
 
               epsilon_,
-              lr[0]);
+              lr[0],
+              weight_decay_);
         }
       }
     }
@@ -135,6 +138,7 @@ class SparseAdagradFusedWithSparseLengthsSumGradientOp final
 
  protected:
   T epsilon_;
+  T weight_decay_;
   adagradT kernel_;
 
   INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR, LENGTHS);
@@ -149,7 +153,9 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
     LOG(INFO) << "gradient optimization operator in use: "
               << "SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
@@ -262,7 +268,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         }
 
         if (block_size == 1) {
-          float gi = temp_grad[0];
+          float gi = std::fma(weight_decay_, paramIn[idx], temp_grad[0]);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] =
               paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
@@ -290,7 +296,8 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
               &momentOut[idx_pref * block_size],
 
               epsilon_,
-              lr[0]);
+              lr[0],
+              weight_decay_);
         }
       }
     }
@@ -300,6 +307,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
 
  protected:
   T epsilon_;
+  T weight_decay_;
   adagradT kernel_;
 
   INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS);
@@ -318,7 +326,9 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
     LOG(INFO)
         << "gradient optimization operator in use: "
         << "SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp";
@@ -414,7 +424,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
         }
 
         if (block_size == 1) {
-          float gi = temp_grad[0];
+          float gi = std::fma(weight_decay_, paramIn[idx], temp_grad[0]);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] =
               paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
@@ -442,7 +452,8 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
               &momentOut[idx_pref * block_size],
 
               epsilon_,
-              lr[0]);
+              lr[0],
+              weight_decay_);
         }
       }
     }
@@ -453,6 +464,7 @@ class SparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp final
 
  protected:
   T epsilon_;
+  T weight_decay_;
   adagradT kernel_;
 
   INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS);

--- a/caffe2/sgd/adagrad_op.h
+++ b/caffe2/sgd/adagrad_op.h
@@ -19,8 +19,10 @@ void adagrad_update(
     float epsilon,
     float decay,
     const float* lr,
-    Context* /*context*/) {
-  return adagrad_update(N, w, g, h, nw, nh, epsilon, decay, lr[0]);
+    Context* /*context*/,
+    float weight_decay = 0.f) {
+  return adagrad_update(
+      N, w, g, h, nw, nh, epsilon, decay, lr[0], weight_decay);
 }
 
 template <typename Context>
@@ -35,9 +37,10 @@ void adagrad_update_output_effective_lr(
     float epsilon,
     float decay,
     const float* lr,
-    Context* /*context*/) {
+    Context* /*context*/,
+    float weight_decay = 0.f) {
   for (auto i = 0; i < N; ++i) {
-    float grad = gradIn[i];
+    float grad = std::fma(weight_decay, paramIn[i], gradIn[i]);
     float moment = momentOut[i] = decay * momentIn[i] + grad * grad;
     float effective_lr = effectiveLROut[i] =
         lr[0] / (std::sqrt(moment) + epsilon);
@@ -58,9 +61,10 @@ void adagrad_update_output_effective_lr_and_update(
     float epsilon,
     float decay,
     const float* lr,
-    Context* /*context*/) {
+    Context* /*context*/,
+    float weight_decay = 0.f) {
   for (auto i = 0; i < N; ++i) {
-    float grad = gradIn[i];
+    float grad = std::fma(weight_decay, paramIn[i], gradIn[i]);
     float moment = momentOut[i] = decay * momentIn[i] + grad * grad;
     float effective_lr = effectiveLROut[i] =
         lr[0] / (std::sqrt(moment) + epsilon);
@@ -76,7 +80,13 @@ class AdagradOp final : public Operator<Context> {
   AdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
-        decay_(this->template GetSingleArgument<float>("decay", 1.0f)) {}
+        decay_(this->template GetSingleArgument<float>("decay", 1.0f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "AdagradOp"
+              << " weight_decay_=" << weight_decay_;
+  }
 
   bool RunOnDevice() override {
     CAFFE_ENFORCE_EQ(
@@ -105,7 +115,8 @@ class AdagradOp final : public Operator<Context> {
           epsilon_,
           decay_,
           Input(LR).template data<float>(),
-          &context_);
+          &context_,
+          weight_decay_);
     } else if (OutputSize() == 3) {
       Output(OUTPUT_EFFECTIVE_LR)->ResizeLike(Input(GRAD));
       adagrad_update_output_effective_lr<Context>(
@@ -119,7 +130,8 @@ class AdagradOp final : public Operator<Context> {
           epsilon_,
           decay_,
           Input(LR).template data<float>(),
-          &context_);
+          &context_,
+          weight_decay_);
     } else {
       Output(OUTPUT_EFFECTIVE_LR)->ResizeLike(Input(GRAD));
       Output(OUTPUT_UPDATE)->ResizeLike(Input(GRAD));
@@ -135,7 +147,8 @@ class AdagradOp final : public Operator<Context> {
           epsilon_,
           decay_,
           Input(LR).template data<float>(),
-          &context_);
+          &context_,
+          weight_decay_);
     }
 
     return true;
@@ -144,6 +157,7 @@ class AdagradOp final : public Operator<Context> {
  protected:
   float epsilon_;
   float decay_;
+  float weight_decay_;
   INPUT_TAGS(PARAM, MOMENT_1, GRAD, LR);
   OUTPUT_TAGS(
       OUTPUT_PARAM,
@@ -156,7 +170,12 @@ class SparseAdagradOp final : public Operator<CPUContext> {
  public:
   SparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "SparseAdagradOp"
+              << " weight_decay_=" << weight_decay_;
     const float decay = this->template GetSingleArgument<float>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -207,13 +226,18 @@ class SparseAdagradOp final : public Operator<CPUContext> {
         n);
 
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
+    C10_LOG_FIRST_N(INFO, 1)
+        << "using fbgemm::GenerateSparseAdaGrad in SparseAdagradOp";
+
     if (block_size != last_block_size_) {
       last_block_size_ = block_size;
       if (std::is_same<SIndex, std::int32_t>::value) {
-        kernel_i32_ = fbgemm::GenerateSparseAdaGrad<std::int32_t>(block_size);
+        kernel_i32_ = fbgemm::GenerateSparseAdaGrad<std::int32_t>(
+            block_size, /*rowwise=*/false, /*prefetch=*/16, weight_decay_);
       } else {
         CAFFE_ENFORCE((std::is_same<SIndex, std::int64_t>::value));
-        kernel_i64_ = fbgemm::GenerateSparseAdaGrad<std::int64_t>(block_size);
+        kernel_i64_ = fbgemm::GenerateSparseAdaGrad<std::int64_t>(
+            block_size, /*rowwise=*/false, /*prefetch=*/16, weight_decay_);
       }
     }
 
@@ -258,6 +282,9 @@ class SparseAdagradOp final : public Operator<CPUContext> {
     }
 #endif
 
+    C10_LOG_FIRST_N(INFO, 1)
+        << "using internal::adagrad_update_prefetch_inlined in SparseAdagradOp";
+
     const auto* paramIn = Input(PARAM).template data<float>();
     const auto* momentIn = Input(MOMENT_1).template data<float>();
 
@@ -284,7 +311,7 @@ class SparseAdagradOp final : public Operator<CPUContext> {
           Input(PARAM).numel());
 
       if (block_size == 1) {
-        float gi = gradIn[i];
+        float gi = std::fma(weight_decay_, paramIn[idx], gradIn[i]);
         float hi = momentOut[idx] = momentIn[idx] + gi * gi;
         paramOut[idx] = paramIn[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
       } else {
@@ -305,7 +332,8 @@ class SparseAdagradOp final : public Operator<CPUContext> {
             momentOut + offsetIdx,
             &momentOut[idx_pref * block_size],
             epsilon_,
-            lr[0]);
+            lr[0],
+            weight_decay_);
       }
     }
     return true;
@@ -313,6 +341,7 @@ class SparseAdagradOp final : public Operator<CPUContext> {
 
  protected:
   float epsilon_;
+  float weight_decay_;
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
   fbgemm::SparseAdaGradSignature<std::int32_t>::Type kernel_i32_;
   fbgemm::SparseAdaGradSignature<std::int64_t>::Type kernel_i64_;
@@ -329,7 +358,13 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   RowWiseSparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {}
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "RowWiseSparseAdagradOp"
+              << " weight_decay_=" << weight_decay_;
+  }
 
   bool RunOnDevice() override {
     // Enforce shapes
@@ -381,15 +416,18 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
         n);
 
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
+    C10_LOG_FIRST_N(INFO, 1)
+        << "using fbgemm::GenerateSparseAdaGrad in RowWiseSparseAdagradOp";
+
     if (block_size != last_block_size_) {
       last_block_size_ = block_size;
       if (std::is_same<SIndex, std::int32_t>::value) {
         kernel_i32_ = fbgemm::GenerateSparseAdaGrad<std::int32_t>(
-            block_size, /*rowwise=*/true);
+            block_size, /*rowwise=*/true, /*prefetch=*/16, weight_decay_);
       } else {
         CAFFE_ENFORCE((std::is_same<SIndex, std::int64_t>::value));
         kernel_i64_ = fbgemm::GenerateSparseAdaGrad<std::int64_t>(
-            block_size, /*rowwise=*/true);
+            block_size, /*rowwise=*/true, /*prefetch=*/16, weight_decay_);
       }
     }
 
@@ -436,10 +474,13 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
       return true;
     }
 #else
+    C10_LOG_FIRST_N(INFO, 1)
+        << "using plain adagrad updates in RowWiseSparseAdagradOp";
+
     for (auto i = 0; i < n; ++i) {
       auto idx = indices[i];
       if (block_size == 1) {
-        float gi = gradIn[i];
+        float gi = std::fma(weight_decay_, param[idx], gradIn[i]);
         float hi = moment[idx] = moment[idx] + gi * gi;
         param[idx] = param[idx] + lr[0] * gi / (std::sqrt(hi) + epsilon_);
       } else {
@@ -472,13 +513,14 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
         float* h = moment + idx;
         float hs = 0.;
         for (auto j = 0; j < block_size; ++j) {
-          float gj = g[j];
+          float gj = std::fma(weight_decay_, w[j], g[j]);
           hs += gj * gj;
         }
         float hi = h[0] = h[0] + hs / block_size;
         float step = lr[0] / (std::sqrt(hi) + epsilon_);
         for (auto j = 0; j < block_size; ++j) {
-          w[j] = w[j] + g[j] * step;
+          float gj = std::fma(weight_decay_, w[j], g[j]);
+          w[j] = w[j] + gj * step;
         }
       }
     }
@@ -488,6 +530,7 @@ class RowWiseSparseAdagradOp final : public Operator<Context> {
 
  protected:
   float epsilon_;
+  float weight_decay_;
 #if defined(USE_FBGEMM) && !defined(__NVCC__)
   fbgemm::SparseAdaGradSignature<std::int32_t>::Type kernel_i32_;
   fbgemm::SparseAdaGradSignature<std::int64_t>::Type kernel_i64_;

--- a/caffe2/sgd/adagrad_op_gpu.cu
+++ b/caffe2/sgd/adagrad_op_gpu.cu
@@ -16,9 +16,10 @@ __global__ void AdagradUpdate(
     float* nh,
     float epsilon,
     float decay,
-    const float* lr) {
+    const float* lr,
+    float weight_decay = 0.f) {
   CUDA_1D_KERNEL_LOOP(i, N) {
-    float gi = g[i];
+    float gi = g[i] + weight_decay * w[i];
     float hi = nh[i] = decay * h[i] + gi * gi;
     nw[i] = w[i] + lr[0] * gi / (sqrtf(hi) + epsilon);
   }
@@ -35,12 +36,14 @@ void adagrad_update<CUDAContext>(
     float epsilon,
     float decay,
     const float* lr,
-    CUDAContext* context) {
+    CUDAContext* context,
+    float weight_decay) {
   AdagradUpdate<<<
       CAFFE_GET_BLOCKS(N),
       CAFFE_CUDA_NUM_THREADS,
       0,
-      context->cuda_stream()>>>(N, w, g, h, nw, nh, epsilon, decay, lr);
+      context->cuda_stream()>>>(
+      N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
 }
 
 template <typename SIndex, typename THalf>
@@ -52,17 +55,18 @@ __global__ void SparseAdagradKernel(
     THalf* param_mom,
     const SIndex* indices,
     const float* grad,
-    const float* lr) {
+    const float* lr,
+    float weight_decay = 0.f) {
   const float LR = lr[0];
   CUDA_1D_KERNEL_LOOP(i, N) {
     const size_t gradIdx = i;
     const SIndex index = indices[i / grad_slice_sz];
     const size_t paramIdx = index * grad_slice_sz + (i % grad_slice_sz);
 
-    float mom_new = grad[gradIdx] * grad[gradIdx] + param_mom[paramIdx];
+    float gi = grad[gradIdx] + weight_decay * param[paramIdx];
+    float mom_new = gi * gi + param_mom[paramIdx];
     param_mom[paramIdx] = mom_new;
-    float param_new =
-        LR * grad[gradIdx] / (sqrtf(mom_new) + epsilon) + param[paramIdx];
+    float param_new = LR * gi / (sqrtf(mom_new) + epsilon) + param[paramIdx];
     param[paramIdx] = param_new;
   }
 }
@@ -85,7 +89,8 @@ __global__ void RowWiseSparseAdagradKernel(
     float* param_mom,
     const SIndex* indices,
     const float* grad,
-    const float* lr) {
+    const float* lr,
+    float weight_decay = 0.f) {
   typedef cub::BlockReduce<float, CAFFE_CUDA_NUM_THREADS> BlockReduce;
   __shared__ BlockReduce::TempStorage temp_storage;
   int valid = min(N, CAFFE_CUDA_NUM_THREADS);
@@ -97,7 +102,7 @@ __global__ void RowWiseSparseAdagradKernel(
 
     // in case N is bigger than block size which is 512 by default
     for (int j = threadIdx.x; j < N; j += blockDim.x) {
-      const float x_ij = grad[i * N + j];
+      const float x_ij = grad[i * N + j] + weight_decay * param[index * N + j];
       sum_squares += x_ij * x_ij;
     }
     float reduce_result = BlockReduce(temp_storage).Sum(sum_squares, valid);
@@ -109,7 +114,8 @@ __global__ void RowWiseSparseAdagradKernel(
     // update param
     float step = lr[0] / (sqrtf(param_mom[index]) + epsilon);
     for (int j = threadIdx.x; j < N; j += blockDim.x) {
-      param[index * N + j] = param[index * N + j] + grad[i * N + j] * step;
+      const float x_ij = grad[i * N + j] + weight_decay * param[index * N + j];
+      param[index * N + j] = param[index * N + j] + x_ij * step;
     }
   }
 }
@@ -120,7 +126,12 @@ class CUDASparseAdagradOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   CUDASparseAdagradOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "CUDASparseAdagradOp"
+              << " weight_decay_=" << weight_decay_;
     const T decay = this->template GetSingleArgument<T>("decay", 1.0f);
     CAFFE_ENFORCE_EQ(decay, 1.0, "Decay is not supported for SparseAdagradOp");
   }
@@ -175,12 +186,14 @@ class CUDASparseAdagradOp final : public Operator<Context> {
             Output(OUTPUT_MOMENT_1)->template mutable_data<THalf>(),
             Input(INDICES).template data<IndexType>(),
             Input(GRAD).template data<float>(),
-            Input(LR).template data<float>());
+            Input(LR).template data<float>(),
+            weight_decay_);
     return true;
   }
 
  protected:
   T epsilon_;
+  T weight_decay_;
   INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR);
   OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1);
 };
@@ -216,7 +229,8 @@ bool RowWiseSparseAdagradOp<CUDAContext>::DoRunWithType() {
       Output(OUTPUT_MOMENT_1)->template mutable_data<float>(),
       Input(INDICES).template data<SIndex>(),
       Input(GRAD).template data<float>(),
-      Input(LR).template data<float>());
+      Input(LR).template data<float>(),
+      weight_decay_);
   return true;
 }
 

--- a/caffe2/sgd/rowwise_adagrad_fused.h
+++ b/caffe2/sgd/rowwise_adagrad_fused.h
@@ -30,6 +30,82 @@ inline float compute_square_average_inlined_(const float* a, int len) {
 
   return sum / len;
 }
+
+inline float compute_square_average_with_weight_decay_inlined_(
+    const float* a,
+    const float* w,
+    int len,
+    float weight_decay) {
+  float sum = 0.0f;
+
+  int i = 0;
+#ifdef __AVX__
+  constexpr int kSize = 8;
+  __m256 partial_sum = _mm256_setzero_ps();
+  __m256 weight_decay_v = _mm256_set1_ps(weight_decay);
+  for (; i + kSize <= len; i += kSize) {
+    __m256 ai = _mm256_loadu_ps(a + i);
+    __m256 wi = _mm256_loadu_ps(w + i);
+#ifdef __AVX2__
+    ai = _mm256_fmadd_ps(weight_decay_v, wi, ai);
+#else
+    ai = _mm256_add_ps(_mm256_mul_ps(weight_decay_v, wi), ai);
+#endif
+    partial_sum = _mm256_add_ps(partial_sum, _mm256_mul_ps(ai, ai));
+  }
+  // Reduce sum to 1 value
+  __m256 partial_sum_2 = _mm256_hadd_ps(partial_sum, partial_sum);
+  __m256 partial_sum_3 = _mm256_hadd_ps(partial_sum_2, partial_sum_2);
+  sum = _mm_cvtss_f32(_mm256_castps256_ps128(partial_sum_3)) +
+      _mm_cvtss_f32(_mm256_extractf128_ps(partial_sum_3, 1));
+#endif
+
+  for (; i < len; ++i) {
+    float ai = std::fma(weight_decay, w[i], a[i]);
+    sum = std::fma(ai, ai, sum);
+  }
+
+  return sum / len;
+}
+
+inline float compute_square_average_with_weight_decay_inlined_(
+    const float* a,
+    const at::Half* w,
+    int len,
+    float weight_decay) {
+  float sum = 0.0f;
+
+  int i = 0;
+#ifdef __AVX__
+  constexpr int kSize = 8;
+  __m256 partial_sum = _mm256_setzero_ps();
+  __m256 weight_decay_v = _mm256_set1_ps(weight_decay);
+  for (; i + kSize <= len; i += kSize) {
+    __m256 ai = _mm256_loadu_ps(a + i);
+    __m128i whi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(w + i));
+    __m256 wi = _mm256_cvtph_ps(whi);
+#ifdef __AVX2__
+    ai = _mm256_fmadd_ps(weight_decay_v, wi, ai);
+#else
+    ai = _mm256_add_ps(_mm256_mul_ps(weight_decay_v, wi), ai);
+#endif
+    partial_sum = _mm256_add_ps(partial_sum, _mm256_mul_ps(ai, ai));
+  }
+  // Reduce sum to 1 value
+  __m256 partial_sum_2 = _mm256_hadd_ps(partial_sum, partial_sum);
+  __m256 partial_sum_3 = _mm256_hadd_ps(partial_sum_2, partial_sum_2);
+  sum = _mm_cvtss_f32(_mm256_castps256_ps128(partial_sum_3)) +
+      _mm_cvtss_f32(_mm256_extractf128_ps(partial_sum_3, 1));
+#endif
+
+  for (; i < len; ++i) {
+    float ai = std::fma(weight_decay, w[i], a[i]);
+    sum = std::fma(ai, ai, sum);
+  }
+
+  return sum / len;
+}
+
 } // namespace internal
 
 /**
@@ -61,7 +137,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
     LOG(INFO) << "gradient optimization operator in use: "
               << "RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
@@ -139,12 +217,13 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
         momentOut,
         epsilon_,
         lr[0],
+        weight_decay_,
         kernel_);
 
     return true;
   }
 
-  template <typename SIndex>
+  template <typename SIndex, bool HAS_WEIGHT_DECAY>
   static void compute(
       int64_t block_size,
       const SIndex* indices,
@@ -159,6 +238,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       T* momentOut,
       float epsilon,
       T lr,
+      T weight_decay,
       rowWiseAdagradT& kernel) {
     int dataIndex = 0;
     for (auto rangeIndex = 0; rangeIndex < numSegments; ++rangeIndex) {
@@ -166,7 +246,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       const float* g = gradIn + offsetI;
 
       float g_sq_avg = 0;
-      if (block_size > 1) {
+      if (block_size > 1 && !HAS_WEIGHT_DECAY) {
         g_sq_avg = internal::compute_square_average_inlined_(g, block_size);
       }
 
@@ -191,7 +271,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
             numParams);
 
         if (block_size == 1) {
-          float gi = *g;
+          float gi = std::fma(weight_decay, paramIn[idx], *g);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] = paramIn[idx] + lr / (std::sqrt(hi) + epsilon) * gi;
         } else {
@@ -200,6 +280,12 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
           int i_pref = (dataIndex < n - prefdist_T0) ? dataIndex + prefdist_T0
                                                      : dataIndex;
           std::size_t idx_pref = indices[i_pref];
+
+          if (HAS_WEIGHT_DECAY) {
+            g_sq_avg =
+                internal::compute_square_average_with_weight_decay_inlined_(
+                    g, paramOut + offsetIdx, block_size, weight_decay);
+          }
 
           kernel(
               block_size,
@@ -214,15 +300,71 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
               momentOut + idx_pref,
 
               epsilon,
-              lr);
+              lr,
+              HAS_WEIGHT_DECAY ? weight_decay : 0.0f);
         }
       }
     }
     CAFFE_ENFORCE_EQ(dataIndex, n);
   }
 
+  template <typename SIndex>
+  static void compute(
+      int64_t block_size,
+      const SIndex* indices,
+      int64_t n,
+      const TLengths* lengths,
+      int64_t numSegments,
+      const T* gradIn,
+      const Tdata* paramIn,
+      int64_t numParams,
+      const T* momentIn,
+      Tdata* paramOut,
+      T* momentOut,
+      float epsilon,
+      T lr,
+      T weight_decay,
+      rowWiseAdagradT& kernel) {
+    if (weight_decay == 0.0f) {
+      compute<SIndex, false>(
+          block_size,
+          indices,
+          n,
+          lengths,
+          numSegments,
+          gradIn,
+          paramIn,
+          numParams,
+          momentIn,
+          paramOut,
+          momentOut,
+          epsilon,
+          lr,
+          0.0f,
+          kernel);
+    } else {
+      compute<SIndex, true>(
+          block_size,
+          indices,
+          n,
+          lengths,
+          numSegments,
+          gradIn,
+          paramIn,
+          numParams,
+          momentIn,
+          paramOut,
+          momentOut,
+          epsilon,
+          lr,
+          weight_decay,
+          kernel);
+    }
+  }
+
  protected:
   T epsilon_;
+  T weight_decay_;
   rowWiseAdagradT kernel_;
 
   INPUT_TAGS(PARAM, MOMENT_1, INDICES, GRAD, LR, LENGTHS);
@@ -241,7 +383,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
     LOG(INFO)
         << "gradient optimization operator in use: "
         << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp";
@@ -327,13 +471,14 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         auxGrad,
         epsilon_,
         lr[0],
+        weight_decay_,
         kernel_,
         &context_);
 
     return true;
   }
 
-  template <typename SIndex>
+  template <typename SIndex, bool HAS_WEIGHT_DECAY>
   static void compute(
       int64_t block_size,
       const SIndex* indices,
@@ -350,6 +495,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       T* auxGrad,
       float epsilon,
       T lr,
+      T weight_decay,
       rowWiseAdagradT& kernel,
       CPUContext* context) {
     // Cannot fuse this loop with the loop below because paramIn is updated
@@ -400,7 +546,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       const float* g = gradIn + offsetI;
 
       float g_sq_avg;
-      if (block_size > 1) {
+      if (block_size > 1 && !HAS_WEIGHT_DECAY) {
         g_sq_avg = internal::compute_square_average_inlined_(g, block_size);
       }
 
@@ -415,7 +561,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
         }
 
         if (block_size == 1) {
-          float gi = temp_grad[0];
+          float gi = std::fma(weight_decay, paramIn[idx], temp_grad[0]);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] = paramIn[idx] + lr / (std::sqrt(hi) + epsilon) * gi;
         } else {
@@ -424,6 +570,16 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           int i_pref = (dataIndex < n - prefdist_T0) ? dataIndex + prefdist_T0
                                                      : dataIndex;
           std::size_t idx_pref = indices[i_pref];
+
+          if (HAS_WEIGHT_DECAY) {
+            g_sq_avg =
+                internal::compute_square_average_with_weight_decay_inlined_(
+                    temp_grad.data(),
+                    paramOut + offsetIdx,
+                    block_size,
+                    weight_decay);
+          }
+
           kernel(
               block_size,
 
@@ -431,20 +587,88 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
               &paramOut[idx_pref * block_size],
 
               temp_grad.data(),
-              g_sq_avg * auxParamIn[localOffset] * auxParamIn[localOffset],
+              g_sq_avg *
+                  (HAS_WEIGHT_DECAY
+                       ? 1
+                       : auxParamIn[localOffset] * auxParamIn[localOffset]),
 
               momentOut + idx,
               momentOut + idx_pref,
 
               epsilon,
-              lr);
+              lr,
+              HAS_WEIGHT_DECAY ? weight_decay : 0.0f);
         }
       }
     }
   }
 
+  template <typename SIndex>
+  static void compute(
+      int64_t block_size,
+      const SIndex* indices,
+      int64_t n,
+      const TLengths* lengths,
+      int64_t numSegments,
+      const T* gradIn,
+      const Tdata* paramIn,
+      int64_t numParams,
+      const T* momentIn,
+      const T* auxParamIn,
+      Tdata* paramOut,
+      T* momentOut,
+      T* auxGrad,
+      float epsilon,
+      T lr,
+      T weight_decay,
+      rowWiseAdagradT& kernel,
+      CPUContext* context) {
+    if (weight_decay == 0.0f) {
+      compute<SIndex, /*HAS_WEIGHT_DECAY=*/false>(
+          block_size,
+          indices,
+          n,
+          lengths,
+          numSegments,
+          gradIn,
+          paramIn,
+          numParams,
+          momentIn,
+          auxParamIn,
+          paramOut,
+          momentOut,
+          auxGrad,
+          epsilon,
+          lr,
+          0.0f,
+          kernel,
+          context);
+    } else {
+      compute<SIndex, /*HAS_WEIGHT_DECAY=*/true>(
+          block_size,
+          indices,
+          n,
+          lengths,
+          numSegments,
+          gradIn,
+          paramIn,
+          numParams,
+          momentIn,
+          auxParamIn,
+          paramOut,
+          momentOut,
+          auxGrad,
+          epsilon,
+          lr,
+          weight_decay,
+          kernel,
+          context);
+    }
+  }
+
  protected:
   T epsilon_;
+  T weight_decay_;
   rowWiseAdagradT kernel_;
 
   INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS);
@@ -463,7 +687,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)),
+        weight_decay_(
+            this->template GetSingleArgument<float>("weight_decay", 0.f)) {
     LOG(INFO)
         << "gradient optimization operator in use: "
         << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp";
@@ -485,6 +711,15 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
   }
 
   template <typename SIndex>
+  bool DoRunWithType() {
+    if (weight_decay_ == 0.0f) {
+      return DoRunWithType<SIndex, false>();
+    } else {
+      return DoRunWithType<SIndex, true>();
+    }
+  }
+
+  template <typename SIndex, bool HAS_WEIGHT_DECAY>
   bool DoRunWithType() {
     const auto* lr = Input(LR).template data<T>();
     Output(OUTPUT_PARAM)->ResizeLike(Input(PARAM));
@@ -542,7 +777,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
       const float* g = gradIn + offsetI;
 
       float g_sq_avg;
-      if (block_size > 1) {
+      if (block_size > 1 && !HAS_WEIGHT_DECAY) {
         g_sq_avg = internal::compute_square_average_inlined_(g, block_size);
       }
 
@@ -613,7 +848,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
         auxGrad[dataIndex] = acc;
 
         if (block_size == 1) {
-          float gi = temp_grad[0];
+          float gi = std::fma(weight_decay_, paramIn[idx], temp_grad[0]);
           float hi = momentOut[idx] = momentIn[idx] + gi * gi;
           paramOut[idx] =
               paramIn[idx] + lr[0] / (std::sqrt(hi) + epsilon_) * gi;
@@ -623,6 +858,16 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
           int i_pref = (dataIndex < n - prefdist_T0) ? dataIndex + prefdist_T0
                                                      : dataIndex;
           std::size_t idx_pref = indices[i_pref];
+
+          if (HAS_WEIGHT_DECAY) {
+            g_sq_avg =
+                internal::compute_square_average_with_weight_decay_inlined_(
+                    temp_grad.data(),
+                    paramOut + offsetIdx,
+                    block_size,
+                    weight_decay_);
+          }
+
           kernel_(
               block_size,
 
@@ -630,13 +875,17 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
               &paramOut[idx_pref * block_size],
 
               temp_grad.data(),
-              g_sq_avg * auxParamIn[localOffset] * auxParamIn[localOffset],
+              g_sq_avg *
+                  (HAS_WEIGHT_DECAY
+                       ? 1
+                       : auxParamIn[localOffset] * auxParamIn[localOffset]),
 
               momentOut + idx,
               momentOut + idx_pref,
 
               epsilon_,
-              lr[0]);
+              lr[0],
+              HAS_WEIGHT_DECAY ? weight_decay_ : 0.0f);
         }
       }
     }
@@ -647,6 +896,7 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
 
  protected:
   T epsilon_;
+  T weight_decay_;
   rowWiseAdagradT kernel_;
 
   INPUT_TAGS(PARAM, MOMENT_1, AUX_PARAM, INDICES, GRAD, LR, LENGTHS);
@@ -663,7 +913,8 @@ struct rowwise_adagrad_update_inlined {
       float* h,
       float* h_n, // prefetch ptr
       float epsilon,
-      float lr) {
+      float lr,
+      float weight_decay) {
 #ifdef __AVX__
     constexpr int kSize = 8;
     _mm_prefetch(reinterpret_cast<const char*>(h_n), _MM_HINT_T0);
@@ -675,19 +926,28 @@ struct rowwise_adagrad_update_inlined {
 
 #ifdef __AVX__
     __m256 step = _mm256_set1_ps(float_step);
+    __m256 weight_decay_v = _mm256_set1_ps(weight_decay);
 
     for (i = 0; i + kSize <= N; i += kSize) {
       _mm_prefetch(reinterpret_cast<const char*>(&w_n[i]), _MM_HINT_T0);
 
       __m256 gi = _mm256_loadu_ps(g + i);
       __m256 wi = _mm256_loadu_ps(w + i);
+      if (weight_decay != 0.0f) {
+#ifdef __AVX2__
+        gi = _mm256_fmadd_ps(weight_decay_v, wi, gi);
+#else
+        gi = _mm256_add_ps(_mm256_mul_ps(weight_decay_v, wi), gi);
+#endif
+      }
 
       _mm256_storeu_ps(w + i, _mm256_add_ps(wi, _mm256_mul_ps(gi, step)));
     }
 #endif
 
     for (; i < N; ++i) {
-      float gi = g[i];
+      float gi =
+          weight_decay != 0.0f ? std::fma(weight_decay, w[i], g[i]) : g[i];
       w[i] = w[i] + gi * float_step;
     }
   }

--- a/caffe2/sgd/rowwise_adagrad_fused.h
+++ b/caffe2/sgd/rowwise_adagrad_fused.h
@@ -62,6 +62,8 @@ class RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO) << "gradient optimization operator in use: "
+              << "RowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");
@@ -239,7 +241,11 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
-        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {}
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO)
+        << "gradient optimization operator in use: "
+        << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp";
+  }
 
   bool RunOnDevice() override {
     // Enforce shapes
@@ -458,6 +464,9 @@ class RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp
       Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5)) {
+    LOG(INFO)
+        << "gradient optimization operator in use: "
+        << "RowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientApproxOp";
     const T decay = this->template GetSingleArgument<T>("decay", 1.0);
     CAFFE_ENFORCE_EQ(
         decay, 1.0, "Decay is not supported for SparseSimdAdagradOp");


### PR DESCRIPTION
Summary: Following up D21320243 adding weight_decay to rowwise fused sparse adagrad. This is more involved because we can't reuse g_sq_avg multiple times.

Test Plan: CI

Differential Revision: D21335643

