### PR TITLE
ONNX: Use correct opset version in symbolic_caffe2 operators

### DIFF
--- a/test/onnx/expect/TestOperators.test_avg_pool2d_pad_11.expect
+++ b/test/onnx/expect/TestOperators.test_avg_pool2d_pad_11.expect
@@ -1,0 +1,110 @@
+ir_version: 6
+producer_name: "pytorch"
+producer_version: "1.6"
+graph {
+  node {
+    output: "1"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 8
+        data_type: 7
+        raw_data: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "0"
+    input: "1"
+    output: "2"
+    name: "Pad_1"
+    op_type: "Pad"
+    attribute {
+      name: "mode"
+      s: "constant"
+      type: STRING
+    }
+  }
+  node {
+    input: "2"
+    output: "3"
+    name: "AveragePool_2"
+    op_type: "AveragePool"
+    attribute {
+      name: "ceil_mode"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "kernel_shape"
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 0
+      ints: 0
+      ints: 0
+      ints: 0
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+  }
+  name: "torch-jit-export"
+  input {
+    name: "0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 20
+          }
+          dim {
+            dim_value: 16
+          }
+          dim {
+            dim_value: 50
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "3"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 20
+          }
+          dim {
+            dim_value: 16
+          }
+          dim {
+            dim_value: 24
+          }
+          dim {
+            dim_value: 15
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -317,6 +317,12 @@ class TestOperators(TestCase):
         x = torch.randn(20, 16, 50, 32)
         self.assertONNX(nn.AvgPool2d(3, stride=2), x)
 
+    def test_avg_pool2d_pad_11(self):
+        x = torch.randn(20, 16, 50, 32)
+        self.assertONNX(nn.AvgPool2d(3, stride=2), x, opset_version=11)
+        self.assertONNX(nn.AvgPool2d(3, stride=2), x, opset_version=11,
+                        operator_export_type=torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK)
+
     def test_maxpool_indices(self):
         x = torch.randn(20, 16, 50)
         self.assertONNX(nn.MaxPool1d(3, stride=2, return_indices=True), x)

--- a/torch/onnx/symbolic_caffe2.py
+++ b/torch/onnx/symbolic_caffe2.py
@@ -118,7 +118,7 @@ def register_quantized_ops(domain, version):
 
     def upsample_nearest2d(g, input, output_size, align_corners=None, scales_h=None, scales_w=None):
         if input not in sym_help._quantized_ops:
-            upsample_nearest2d_impl = torch.onnx.symbolic_registry.get_registered_op('upsample_nearest2d', '', version)
+            upsample_nearest2d_impl = sym_registry.get_registered_op('upsample_nearest2d', '', version)
             return upsample_nearest2d_impl(g, input, output_size, align_corners)
 
         output_size = sym_help._parse_arg(output_size, 'is')
@@ -136,7 +136,7 @@ def register_quantized_ops(domain, version):
     @parse_args('v', 'is', 'is', 'is', 'is', 'i')
     def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
         if input not in sym_help._quantized_ops:
-            max_pool2d = torch.onnx.symbolic_registry.get_registered_op('max_pool2d', '', version)
+            max_pool2d = sym_registry.get_registered_op('max_pool2d', '', version)
             return max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode)
         kwargs = {
             "strides_i": stride,
@@ -155,7 +155,7 @@ def register_quantized_ops(domain, version):
     @parse_args('v', 'is', 'is', 'is', 'i', 'i', 'none')
     def avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override=None):
         if input not in sym_help._quantized_ops:
-            avg_pool2d = torch.onnx.symbolic_registry.get_registered_op('avg_pool2d', '', version)
+            avg_pool2d = sym_registry.get_registered_op('avg_pool2d', '', version)
             return avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
         kwargs = {
             "strides_i": stride,
@@ -173,7 +173,7 @@ def register_quantized_ops(domain, version):
 
     def reshape(g, input, shape):
         if input not in sym_help._quantized_ops:
-            reshape = torch.onnx.symbolic_registry.get_registered_op('reshape', '', version)
+            reshape = sym_registry.get_registered_op('reshape', '', version)
             return reshape(g, input, shape)
 
         kwargs = {
@@ -187,7 +187,7 @@ def register_quantized_ops(domain, version):
     @parse_args('v', 'v', 'v', 'v', 'i')
     def slice(g, input, dim, start, end, step):
         if input not in sym_help._quantized_ops:
-            slice = torch.onnx.symbolic_registry.get_registered_op('slice', '', version)
+            slice = sym_registry.get_registered_op('slice', '', version)
             return slice(g, input, dim, start, end, step)
 
         if step != 1:
@@ -210,7 +210,7 @@ def register_quantized_ops(domain, version):
     @parse_args('v')
     def sigmoid(g, input):
         if input not in sym_help._quantized_ops:
-            sigmoid = torch.onnx.symbolic_registry.get_registered_op('sigmoid', '', version)
+            sigmoid = sym_registry.get_registered_op('sigmoid', '', version)
             return sigmoid(g, input)
         # Caffe2 expects the output scale to be 1/2^8
         # and output zero_point to be 0 (quint8 type)
@@ -227,7 +227,7 @@ def register_quantized_ops(domain, version):
     @parse_args('v')
     def relu(g, input):
         if input not in sym_help._quantized_ops:
-            relu = torch.onnx.symbolic_registry.get_registered_op('relu', '', version)
+            relu = sym_registry.get_registered_op('relu', '', version)
             return relu(g, input)
         kwargs = {
             "Y_scale_f": input.node()["Y_scale"],
@@ -241,7 +241,7 @@ def register_quantized_ops(domain, version):
         tensors = sym_help._unpack_list(tensor_list)
         input = tensors[0]
         if input not in sym_help._quantized_ops:
-            cat = torch.onnx.symbolic_registry.get_registered_op('cat', '', version)
+            cat = sym_registry.get_registered_op('cat', '', version)
             return cat(g, tensor_list, dim)
 
         dim = sym_help._parse_arg(dim, 'i')

--- a/torch/onnx/symbolic_caffe2.py
+++ b/torch/onnx/symbolic_caffe2.py
@@ -2,7 +2,6 @@ from torch.onnx.symbolic_helper import parse_args
 import torch.onnx.symbolic_helper as sym_help
 import torch.onnx.symbolic_registry as sym_registry
 import importlib
-from inspect import getmembers, isfunction
 
 def _permute_helper(g, input, axes):
     quant_args = {

--- a/torch/onnx/symbolic_caffe2.py
+++ b/torch/onnx/symbolic_caffe2.py
@@ -4,22 +4,6 @@ import torch.onnx.symbolic_registry as sym_registry
 import importlib
 from inspect import getmembers, isfunction
 
-def register_quantized_ops(domain, version):
-    # Register all the non-quantized ops
-    sym_registry.register_version('', version)
-    # Register all quantized ops
-    module = importlib.import_module('torch.onnx.symbolic_caffe2')
-    sym_registry._symbolic_versions['caffe2'] = module
-    quant_version_ops = getmembers(sym_registry._symbolic_versions['caffe2'])
-    for op in quant_version_ops:
-        if isfunction(op[1]) and not sym_registry.is_registered_op(op[0], domain, version):
-            aten_q_ops = ['relu', '_empty_affine_quantized', 'dequantize',
-                          'quantize_per_tensor', 'upsample_nearest2d', 'avg_pool2d',
-                          'reshape', 'slice', 'cat', 'max_pool2d', 'sigmoid']
-            if op[0] in aten_q_ops:
-                sym_registry.register_op(op[0], op[1], '', version)
-            sym_registry.register_op(op[0], op[1], domain, version)
-
 def _permute_helper(g, input, axes):
     quant_args = {
         "axes_i": axes,
@@ -108,19 +92,6 @@ def add(g, input_a, input_b, scale, zero_point):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v')
-def relu(g, input):
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import relu
-        return relu(g, input)
-    kwargs = {
-        "Y_scale_f": input.node()["Y_scale"],
-        "Y_zero_point_i": input.node()["Y_zero_point"],
-    }
-    output = g.op("_caffe2::Int8Relu", input, **kwargs)
-    sym_help._quantized_ops.add(output)
-    return output
-
 @parse_args('v', 'f', 'i', 't')
 def quantize_per_tensor(g, input, scale, zero_point, dtype):
     kwargs = {
@@ -139,125 +110,175 @@ def dequantize(g, input):
 def _empty_affine_quantized(g, input, shape, scale, zero_point, dtype, pin_memory, memory_format, layout):
     return input
 
-def upsample_nearest2d(g, input, output_size, align_corners=None, scales_h=None, scales_w=None):
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import upsample_nearest2d as upsample_nearest2d_impl
-        return upsample_nearest2d_impl(g, input, output_size, align_corners)
+def register_quantized_ops(domain, version):
+    # Register all the non-quantized ops
+    sym_registry.register_version('', version)
+    # Register all quantized ops
+    module = importlib.import_module('torch.onnx.symbolic_caffe2')
+    sym_registry._symbolic_versions['caffe2'] = module
 
-    output_size = sym_help._parse_arg(output_size, 'is')
-    kwargs = {
-        "output_size_i": output_size,
-        "Y_scale_f": input.node()["Y_scale"],
-        "Y_zero_point_i": input.node()["Y_zero_point"],
-    }
-    input = nchw2nhwc(g, input)
-    output = g.op("_caffe2::Int8ResizeNearest", input, **kwargs)
-    output = nhwc2nchw(g, output)
-    sym_help._quantized_ops.add(output)
-    return output
-@parse_args('v', 'is', 'is', 'is', 'is', 'i')
-def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import max_pool2d
-        return max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode)
-    kwargs = {
-        "strides_i": stride,
-        "pads_i": padding + padding,
-        "kernel_i": kernel_size[0],
-        "order_s": "NHWC",
-        "Y_scale_f": input.node()["Y_scale"],
-        "Y_zero_point_i": input.node()["Y_zero_point"],
-    }
-    input = nchw2nhwc(g, input)
-    output = g.op("_caffe2::Int8MaxPool", input, **kwargs)
-    output = nhwc2nchw(g, output)
-    sym_help._quantized_ops.add(output)
-    return output
+    def upsample_nearest2d(g, input, output_size, align_corners=None, scales_h=None, scales_w=None):
+        if input not in sym_help._quantized_ops:
+            upsample_nearest2d_impl = torch.onnx.symbolic_registry.get_registered_op('upsample_nearest2d', '', version)
+            return upsample_nearest2d_impl(g, input, output_size, align_corners)
 
-@parse_args('v', 'is', 'is', 'is', 'i', 'i', 'none')
-def avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override=None):
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import avg_pool2d
-        return avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
-    kwargs = {
-        "strides_i": stride,
-        "pads_i": padding + padding,
-        "kernel_i": kernel_size[0],
-        "order_s": "NHWC",
-        "Y_scale_f": input.node()["Y_scale"],
-        "Y_zero_point_i": input.node()["Y_zero_point"],
-    }
-    input = nchw2nhwc(g, input)
-    output = g.op("_caffe2::Int8AveragePool", input, **kwargs)
-    output = nhwc2nchw(g, output)
-    sym_help._quantized_ops.add(output)
-    return output
+        output_size = sym_help._parse_arg(output_size, 'is')
+        kwargs = {
+            "output_size_i": output_size,
+            "Y_scale_f": input.node()["Y_scale"],
+            "Y_zero_point_i": input.node()["Y_zero_point"],
+        }
+        input = nchw2nhwc(g, input)
+        output = g.op("_caffe2::Int8ResizeNearest", input, **kwargs)
+        output = nhwc2nchw(g, output)
+        sym_help._quantized_ops.add(output)
+        return output
 
-def reshape(g, input, shape):
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import reshape
-        return reshape(g, input, shape)
+    @parse_args('v', 'is', 'is', 'is', 'is', 'i')
+    def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
+        if input not in sym_help._quantized_ops:
+            max_pool2d = torch.onnx.symbolic_registry.get_registered_op('max_pool2d', '', version)
+            return max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode)
+        kwargs = {
+            "strides_i": stride,
+            "pads_i": padding + padding,
+            "kernel_i": kernel_size[0],
+            "order_s": "NHWC",
+            "Y_scale_f": input.node()["Y_scale"],
+            "Y_zero_point_i": input.node()["Y_zero_point"],
+        }
+        input = nchw2nhwc(g, input)
+        output = g.op("_caffe2::Int8MaxPool", input, **kwargs)
+        output = nhwc2nchw(g, output)
+        sym_help._quantized_ops.add(output)
+        return output
 
-    kwargs = {
-        "Y_scale_f": input.node()["Y_scale"],
-        "Y_zero_point_i": input.node()["Y_zero_point"],
-    }
-    output = g.op("_caffe2::Int8Reshape", input, shape, **kwargs)
-    sym_help._quantized_ops.add(output)
-    return output
+    @parse_args('v', 'is', 'is', 'is', 'i', 'i', 'none')
+    def avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override=None):
+        if input not in sym_help._quantized_ops:
+            avg_pool2d = torch.onnx.symbolic_registry.get_registered_op('avg_pool2d', '', version)
+            return avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override)
+        kwargs = {
+            "strides_i": stride,
+            "pads_i": padding + padding,
+            "kernel_i": kernel_size[0],
+            "order_s": "NHWC",
+            "Y_scale_f": input.node()["Y_scale"],
+            "Y_zero_point_i": input.node()["Y_zero_point"],
+        }
+        input = nchw2nhwc(g, input)
+        output = g.op("_caffe2::Int8AveragePool", input, **kwargs)
+        output = nhwc2nchw(g, output)
+        sym_help._quantized_ops.add(output)
+        return output
 
-@parse_args('v', 'v', 'v', 'v', 'i')
-def slice(g, input, dim, start, end, step):
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import slice
-        return slice(g, input, dim, start, end, step)
+    def reshape(g, input, shape):
+        if input not in sym_help._quantized_ops:
+            reshape = torch.onnx.symbolic_registry.get_registered_op('reshape', '', version)
+            return reshape(g, input, shape)
 
-    if step != 1:
-        raise RuntimeError("ONNX quantized slice export only works for step 1.")
-    start = sym_help._parse_arg(start, 'i')
-    end = sym_help._parse_arg(end, 'i')
-    dim = sym_help._parse_arg(dim, 'i')
+        kwargs = {
+            "Y_scale_f": input.node()["Y_scale"],
+            "Y_zero_point_i": input.node()["Y_zero_point"],
+        }
+        output = g.op("_caffe2::Int8Reshape", input, shape, **kwargs)
+        sym_help._quantized_ops.add(output)
+        return output
 
-    kwargs = {
-        "start_idx_i": start,
-        "end_idx_i": end,
-        "dim_i": dim,
-        "Y_scale_f": input.node()["Y_scale"],
-        "Y_zero_point_i": input.node()["Y_zero_point"],
-    }
-    output = g.op("_caffe2::Int8Slice", input, **kwargs)
-    sym_help._quantized_ops.add(output)
-    return output
+    @parse_args('v', 'v', 'v', 'v', 'i')
+    def slice(g, input, dim, start, end, step):
+        if input not in sym_help._quantized_ops:
+            slice = torch.onnx.symbolic_registry.get_registered_op('slice', '', version)
+            return slice(g, input, dim, start, end, step)
 
-def cat(g, tensor_list, dim, scale=None, zero_point=None):
-    tensors = sym_help._unpack_list(tensor_list)
-    input = tensors[0]
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import cat
-        return cat(g, tensor_list, dim)
+        if step != 1:
+            raise RuntimeError("ONNX quantized slice export only works for step 1.")
+        start = sym_help._parse_arg(start, 'i')
+        end = sym_help._parse_arg(end, 'i')
+        dim = sym_help._parse_arg(dim, 'i')
 
-    dim = sym_help._parse_arg(dim, 'i')
-    kwargs = {
-        "Y_scale_f": tensors[0].node()["Y_scale"],
-        "Y_zero_point_i": tensors[0].node()["Y_zero_point"],
-    }
-    output = g.op("_caffe2::Int8Concat", *tensors, axis_i=dim, **kwargs)
-    sym_help._quantized_ops.add(output)
-    return output
+        kwargs = {
+            "start_idx_i": start,
+            "end_idx_i": end,
+            "dim_i": dim,
+            "Y_scale_f": input.node()["Y_scale"],
+            "Y_zero_point_i": input.node()["Y_zero_point"],
+        }
+        output = g.op("_caffe2::Int8Slice", input, **kwargs)
+        sym_help._quantized_ops.add(output)
+        return output
 
-@parse_args('v')
-def sigmoid(g, input):
-    if input not in sym_help._quantized_ops:
-        from torch.onnx.symbolic_opset9 import sigmoid
-        return sigmoid(g, input)
-    # Caffe2 expects the output scale to be 1/2^8
-    # and output zero_point to be 0 (quint8 type)
-    out_scale = 1.0 / 256
-    zero_point = 0
-    kwargs = {
-        "Y_scale_f": out_scale,
-        "Y_zero_point_i": zero_point,
-    }
-    output = g.op("_caffe2::Int8Sigmoid", input, **kwargs)
-    sym_help._quantized_ops.add(output)
-    return output
+    @parse_args('v')
+    def sigmoid(g, input):
+        if input not in sym_help._quantized_ops:
+            sigmoid = torch.onnx.symbolic_registry.get_registered_op('sigmoid', '', version)
+            return sigmoid(g, input)
+        # Caffe2 expects the output scale to be 1/2^8
+        # and output zero_point to be 0 (quint8 type)
+        out_scale = 1.0 / 256
+        zero_point = 0
+        kwargs = {
+            "Y_scale_f": out_scale,
+            "Y_zero_point_i": zero_point,
+        }
+        output = g.op("_caffe2::Int8Sigmoid", input, **kwargs)
+        sym_help._quantized_ops.add(output)
+        return output
+
+    @parse_args('v')
+    def relu(g, input):
+        if input not in sym_help._quantized_ops:
+            relu = torch.onnx.symbolic_registry.get_registered_op('relu', '', version)
+            return relu(g, input)
+        kwargs = {
+            "Y_scale_f": input.node()["Y_scale"],
+            "Y_zero_point_i": input.node()["Y_zero_point"],
+        }
+        output = g.op("_caffe2::Int8Relu", input, **kwargs)
+        sym_help._quantized_ops.add(output)
+        return output
+
+    def cat(g, tensor_list, dim, scale=None, zero_point=None):
+        tensors = sym_help._unpack_list(tensor_list)
+        input = tensors[0]
+        if input not in sym_help._quantized_ops:
+            cat = torch.onnx.symbolic_registry.get_registered_op('cat', '', version)
+            return cat(g, tensor_list, dim)
+
+        dim = sym_help._parse_arg(dim, 'i')
+        kwargs = {
+            "Y_scale_f": tensors[0].node()["Y_scale"],
+            "Y_zero_point_i": tensors[0].node()["Y_zero_point"],
+        }
+        output = g.op("_caffe2::Int8Concat", *tensors, axis_i=dim, **kwargs)
+        sym_help._quantized_ops.add(output)
+        return output
+
+    funcs = [
+        nchw2nhwc,
+        nhwc2nchw,
+        linear_prepack,
+        linear,
+        conv_prepack,
+        conv2d,
+        conv2d_relu,
+        add,
+        relu,
+        quantize_per_tensor,
+        dequantize,
+        _empty_affine_quantized,
+        cat,
+        upsample_nearest2d,
+        max_pool2d,
+        avg_pool2d,
+        reshape,
+        slice,
+        sigmoid,
+    ]
+    for f in funcs:
+        aten_q_ops = ['relu', '_empty_affine_quantized', 'dequantize',
+                      'quantize_per_tensor', 'upsample_nearest2d', 'avg_pool2d',
+                      'reshape', 'slice', 'cat', 'max_pool2d', 'sigmoid']
+        if f.__name__ in aten_q_ops:
+            sym_registry.register_op(f.__name__, f, '', version)
+        sym_registry.register_op(f.__name__, f, domain, version)

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -77,6 +77,8 @@ def register_op(opname, op, domain, version):
     global _registry
     if not is_registered_version(domain, version):
         _registry[(domain, version)] = {}
+    if opname in _registry[(domain, version)]:
+        warnings.warn('Overwriting already registered operator: {}-{} ({})'.format(opname, version, domain or 'onnx'))
     _registry[(domain, version)][opname] = op
 
 

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -110,3 +110,12 @@ def get_registered_op(opname, domain, version):
             msg += "Please open a bug to request ONNX export support for the missing operator."
         raise RuntimeError(msg)
     return _registry[(domain, version)][opname]
+
+def get_supported_op(opname, domain, version):
+    if domain is None or version is None:
+        warnings.warn("ONNX export failed. The ONNX domain and/or version are None.")
+    global _registry
+    supported_version = get_op_supported_version(opname, domain, version)
+    if not supported_version:
+        raise RuntimeError('{}-{} ({}) is not supported'.format(opname, version, domain or 'ai.onnx'))
+    return _registry[(domain, supported_version)][opname]


### PR DESCRIPTION
Due to change to Pad-11 exporting model with symbolic_caffe2 operators cause incorrect output for AveragePool-11.
To avoid it symbolic_caffe2 should use fallback operators with correct opset version.

cc @BowenBao @neginraoof