### PR TITLE
Add override name for aten::tensor and aten::as_tensor

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -67,6 +67,8 @@ white_list = [
     ('aten::__contains__', datetime.date(2020, 6, 30)),
     ('aten::_set_item', datetime.date(2020, 6, 30)),
     ('aten::dict', datetime.date(2020, 6, 30)),
+    ('aten::tensor', datetime.date(2020, 6, 30)),
+    ('aten::as_tensor', datetime.date(2020, 6, 30)),
 ]
 
 

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -300,7 +300,7 @@ RegisterOperators reg({
 
 #define DEFINE_TORCH_TENSOR_OP(operator_type, c_type, tensor_creation_op)  \
   Operator(                                                                \
-      "aten::tensor(" #operator_type                                       \
+      "aten::tensor." #operator_type "(" #operator_type                    \
       " t, *, ScalarType? dtype=None, Device? device=None"                 \
       ", bool requires_grad=False) -> Tensor",                             \
       [](Stack& stack) {                                                   \
@@ -317,7 +317,7 @@ RegisterOperators reg({
       },                                                                   \
       aliasAnalysisFromSchema()),                                          \
       Operator(                                                            \
-          "aten::as_tensor(" #operator_type                                \
+          "aten::as_tensor." #operator_type "(" #operator_type             \
           " t, *, ScalarType? dtype=None, Device? device=None) -> Tensor", \
           [](Stack& stack) {                                               \
             c_type scalar_val;                                             \


### PR DESCRIPTION
Summary:
Add override name for aten::tensor and aten::as_tensor.
These two ops are used in NLU model, and they will included them in lite interpreter

Test Plan: verified model can be loaded correctly

Differential Revision: D21346142

