### PR TITLE
cmake: improve dependencies in incremental builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 #    endif()
 set(CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO ON)
 
+# Googletest's cmake files are going to set it on once they are processed. Let's
+# set it at the very beginning so that the entire build is deterministic.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 if(NOT DEFINED BLAS_SET_BY_USER)
   if(DEFINED BLAS)
     set(BLAS_SET_BY_USER TRUE)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -881,9 +881,11 @@ if(BUILD_PYTHON)
 endif()
 
 # ---[ pybind11
-find_package(pybind11 CONFIG)
-if(NOT pybind11_FOUND)
-  find_package(pybind11)
+if(NOT ${pybind11_PREFER_third_party})
+  find_package(pybind11 CONFIG)
+  if(NOT pybind11_FOUND)
+    find_package(pybind11)
+  endif()
 endif()
 
 if(pybind11_FOUND)
@@ -891,6 +893,9 @@ if(pybind11_FOUND)
 else()
     message(STATUS "Using third_party/pybind11.")
     set(pybind11_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../third_party/pybind11/include)
+    set(pybind11_PREFER_third_party ON CACHE BOOL
+        "Use the third_party/pybind11 submodule, instead of looking for system
+        installation of pybind11")
 endif()
 message(STATUS "pybind11 include dirs: " "${pybind11_INCLUDE_DIRS}")
 include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -891,9 +891,6 @@ if(pybind11_FOUND)
 else()
     message(STATUS "Using third_party/pybind11.")
     set(pybind11_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../third_party/pybind11/include)
-    install(DIRECTORY ${pybind11_INCLUDE_DIRS}
-            DESTINATION ${CMAKE_INSTALL_PREFIX}
-            FILES_MATCHING PATTERN "*.h")
 endif()
 message(STATUS "pybind11 include dirs: " "${pybind11_INCLUDE_DIRS}")
 include_directories(SYSTEM ${pybind11_INCLUDE_DIRS})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1125,7 +1125,12 @@ if(USE_ROCM)
   else()
     caffe2_update_option(USE_ROCM OFF)
   endif()
+endif()
 
+# ---[ ROCm
+if(USE_ROCM)
+  # We check again for USE_ROCM because it might have been set to OFF
+  # in the if above
   include_directories(SYSTEM ${HIP_PATH}/include)
   include_directories(SYSTEM ${ROCBLAS_PATH}/include)
   include_directories(SYSTEM ${ROCFFT_PATH}/include)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1130,7 +1130,12 @@ if(USE_ROCM)
   else()
     caffe2_update_option(USE_ROCM OFF)
   endif()
+endif()
 
+# ---[ ROCm
+if(USE_ROCM)
+  # We check again for USE_ROCM because it might have been set to OFF
+  # in the if above
   include_directories(SYSTEM ${HIP_PATH}/include)
   include_directories(SYSTEM ${ROCBLAS_PATH}/include)
   include_directories(SYSTEM ${ROCFFT_PATH}/include)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -893,6 +893,9 @@ if(pybind11_FOUND)
 else()
     message(STATUS "Using third_party/pybind11.")
     set(pybind11_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../third_party/pybind11/include)
+    install(DIRECTORY ${pybind11_INCLUDE_DIRS}
+            DESTINATION ${CMAKE_INSTALL_PREFIX}
+            FILES_MATCHING PATTERN "*.h")
     set(pybind11_PREFER_third_party ON CACHE BOOL
         "Use the third_party/pybind11 submodule, instead of looking for system
         installation of pybind11")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -881,10 +881,10 @@ if(BUILD_PYTHON)
 endif()
 
 # ---[ pybind11
-set(OLD_CMAKE_FIND_PACKAGE_PREFER_CONFIG ${CMAKE_FIND_PACKAGE_PREFER_CONFIG})
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
-find_package(pybind11)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${OLD_CMAKE_FIND_PACKAGE_PREFER_CONFIG})
+find_package(pybind11 CONFIG)
+if(NOT pybind11_FOUND)
+  find_package(pybind11)
+endif()
 
 if(pybind11_FOUND)
     message(STATUS "System pybind11 found")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1074,61 +1074,62 @@ endif()
 # ---[ HIP
 if(USE_ROCM)
   include(${CMAKE_CURRENT_LIST_DIR}/public/LoadHIP.cmake)
-  if(NOT PYTORCH_FOUND_HIP)
-    message(FATAL_ERROR "Cannot find HIP, perhaps you should set USE_ROCM to OFF")
+  if(PYTORCH_FOUND_HIP)
+    message(INFO "Compiling with HIP for AMD.")
+    caffe2_update_option(USE_ROCM ON)
+
+    if(USE_NCCL AND NOT USE_SYSTEM_NCCL)
+      message(INFO "Forcing USE_SYSTEM_NCCL to ON since it's required by using RCCL")
+      caffe2_update_option(USE_SYSTEM_NCCL ON)
+    endif()
+
+    list(APPEND HIP_CXX_FLAGS -fPIC)
+    list(APPEND HIP_CXX_FLAGS -D__HIP_PLATFORM_HCC__=1)
+    list(APPEND HIP_CXX_FLAGS -DCUDA_HAS_FP16=1)
+    list(APPEND HIP_CXX_FLAGS -D__HIP_NO_HALF_OPERATORS__=1)
+    list(APPEND HIP_CXX_FLAGS -D__HIP_NO_HALF_CONVERSIONS__=1)
+    list(APPEND HIP_CXX_FLAGS -Wno-macro-redefined)
+    list(APPEND HIP_CXX_FLAGS -Wno-inconsistent-missing-override)
+    list(APPEND HIP_CXX_FLAGS -Wno-exceptions)
+    list(APPEND HIP_CXX_FLAGS -Wno-shift-count-negative)
+    list(APPEND HIP_CXX_FLAGS -Wno-shift-count-overflow)
+    list(APPEND HIP_CXX_FLAGS -Wno-unused-command-line-argument)
+    list(APPEND HIP_CXX_FLAGS -Wno-duplicate-decl-specifier)
+    list(APPEND HIP_CXX_FLAGS -Wno-implicit-int-float-conversion)
+    list(APPEND HIP_CXX_FLAGS -DCAFFE2_USE_MIOPEN)
+    list(APPEND HIP_CXX_FLAGS -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP)
+    list(APPEND HIP_CXX_FLAGS -std=c++14)
+
+    if(CMAKE_BUILD_TYPE MATCHES Debug)
+       list(APPEND HIP_CXX_FLAGS -g)
+       list(APPEND HIP_CXX_FLAGS -O0)
+    endif(CMAKE_BUILD_TYPE MATCHES Debug)
+
+    set(HIP_HCC_FLAGS ${HIP_CXX_FLAGS})
+    # Ask hcc to generate device code during compilation so we can use
+    # host linker to link.
+    list(APPEND HIP_HCC_FLAGS -fno-gpu-rdc)
+    foreach(pytorch_rocm_arch ${PYTORCH_ROCM_ARCH})
+      list(APPEND HIP_HCC_FLAGS --amdgpu-target=${pytorch_rocm_arch})
+    endforeach()
+
+    set(Caffe2_HIP_INCLUDE
+       ${thrust_INCLUDE_DIRS} ${hipcub_INCLUDE_DIRS} ${rocprim_INCLUDE_DIRS} ${miopen_INCLUDE_DIRS} ${rocblas_INCLUDE_DIRS} ${rocrand_INCLUDE_DIRS} ${hiprand_INCLUDE_DIRS} ${roctracer_INCLUDE_DIRS} ${hip_INCLUDE_DIRS} ${hcc_INCLUDE_DIRS} ${hsa_INCLUDE_DIRS} $<INSTALL_INTERFACE:include> ${Caffe2_HIP_INCLUDE})
+    # This is needed for library added by hip_add_library (same for hip_add_executable)
+    hip_include_directories(${Caffe2_HIP_INCLUDE})
+
+    set(Caffe2_HIP_DEPENDENCY_LIBS
+      ${PYTORCH_HIP_HCC_LIBRARIES} ${PYTORCH_MIOPEN_LIBRARIES} ${PYTORCH_RCCL_LIBRARIES} ${hipcub_LIBRARIES} ${ROCM_HIPRTC_LIB} ${ROCM_ROCTX_LIB})
+
+    # Note [rocblas & rocfft cmake bug]
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # TODO: There is a bug in rocblas's & rocfft's cmake files that exports the wrong targets name in ${rocblas_LIBRARIES}
+    # If you get this wrong, you'll get a complaint like 'ld: cannot find -lrocblas-targets'
+    list(APPEND Caffe2_HIP_DEPENDENCY_LIBS
+      roc::rocblas roc::rocfft hip::hiprand roc::hipsparse)
+  else()
+    caffe2_update_option(USE_ROCM OFF)
   endif()
-  message(INFO "Compiling with HIP for AMD.")
-  caffe2_update_option(USE_ROCM ON)
-
-  if(USE_NCCL AND NOT USE_SYSTEM_NCCL)
-    message(INFO "Forcing USE_SYSTEM_NCCL to ON since it's required by using RCCL")
-    caffe2_update_option(USE_SYSTEM_NCCL ON)
-  endif()
-
-  list(APPEND HIP_CXX_FLAGS -fPIC)
-  list(APPEND HIP_CXX_FLAGS -D__HIP_PLATFORM_HCC__=1)
-  list(APPEND HIP_CXX_FLAGS -DCUDA_HAS_FP16=1)
-  list(APPEND HIP_CXX_FLAGS -D__HIP_NO_HALF_OPERATORS__=1)
-  list(APPEND HIP_CXX_FLAGS -D__HIP_NO_HALF_CONVERSIONS__=1)
-  list(APPEND HIP_CXX_FLAGS -Wno-macro-redefined)
-  list(APPEND HIP_CXX_FLAGS -Wno-inconsistent-missing-override)
-  list(APPEND HIP_CXX_FLAGS -Wno-exceptions)
-  list(APPEND HIP_CXX_FLAGS -Wno-shift-count-negative)
-  list(APPEND HIP_CXX_FLAGS -Wno-shift-count-overflow)
-  list(APPEND HIP_CXX_FLAGS -Wno-unused-command-line-argument)
-  list(APPEND HIP_CXX_FLAGS -Wno-duplicate-decl-specifier)
-  list(APPEND HIP_CXX_FLAGS -Wno-implicit-int-float-conversion)
-  list(APPEND HIP_CXX_FLAGS -DCAFFE2_USE_MIOPEN)
-  list(APPEND HIP_CXX_FLAGS -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP)
-  list(APPEND HIP_CXX_FLAGS -std=c++14)
-
-  if(CMAKE_BUILD_TYPE MATCHES Debug)
-     list(APPEND HIP_CXX_FLAGS -g)
-     list(APPEND HIP_CXX_FLAGS -O0)
-  endif(CMAKE_BUILD_TYPE MATCHES Debug)
-
-  set(HIP_HCC_FLAGS ${HIP_CXX_FLAGS})
-  # Ask hcc to generate device code during compilation so we can use
-  # host linker to link.
-  list(APPEND HIP_HCC_FLAGS -fno-gpu-rdc)
-  foreach(pytorch_rocm_arch ${PYTORCH_ROCM_ARCH})
-    list(APPEND HIP_HCC_FLAGS --amdgpu-target=${pytorch_rocm_arch})
-  endforeach()
-
-  set(Caffe2_HIP_INCLUDE
-     ${thrust_INCLUDE_DIRS} ${hipcub_INCLUDE_DIRS} ${rocprim_INCLUDE_DIRS} ${miopen_INCLUDE_DIRS} ${rocblas_INCLUDE_DIRS} ${rocrand_INCLUDE_DIRS} ${hiprand_INCLUDE_DIRS} ${roctracer_INCLUDE_DIRS} ${hip_INCLUDE_DIRS} ${hcc_INCLUDE_DIRS} ${hsa_INCLUDE_DIRS} $<INSTALL_INTERFACE:include> ${Caffe2_HIP_INCLUDE})
-  # This is needed for library added by hip_add_library (same for hip_add_executable)
-  hip_include_directories(${Caffe2_HIP_INCLUDE})
-
-  set(Caffe2_HIP_DEPENDENCY_LIBS
-    ${PYTORCH_HIP_HCC_LIBRARIES} ${PYTORCH_MIOPEN_LIBRARIES} ${PYTORCH_RCCL_LIBRARIES} ${hipcub_LIBRARIES} ${ROCM_HIPRTC_LIB} ${ROCM_ROCTX_LIB})
-
-  # Note [rocblas & rocfft cmake bug]
-  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # TODO: There is a bug in rocblas's & rocfft's cmake files that exports the wrong targets name in ${rocblas_LIBRARIES}
-  # If you get this wrong, you'll get a complaint like 'ld: cannot find -lrocblas-targets'
-  list(APPEND Caffe2_HIP_DEPENDENCY_LIBS
-    roc::rocblas roc::rocfft hip::hiprand roc::hipsparse)
 
   include_directories(SYSTEM ${HIP_PATH}/include)
   include_directories(SYSTEM ${ROCBLAS_PATH}/include)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1130,12 +1130,7 @@ if(USE_ROCM)
   else()
     caffe2_update_option(USE_ROCM OFF)
   endif()
-endif()
 
-# ---[ ROCm
-if(USE_ROCM)
-  # We check again for USE_ROCM because it might have been set to OFF
-  # in the if above
   include_directories(SYSTEM ${HIP_PATH}/include)
   include_directories(SYSTEM ${ROCBLAS_PATH}/include)
   include_directories(SYSTEM ${ROCFFT_PATH}/include)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -881,10 +881,10 @@ if(BUILD_PYTHON)
 endif()
 
 # ---[ pybind11
-find_package(pybind11 CONFIG)
-if(NOT pybind11_FOUND)
-  find_package(pybind11)
-endif()
+set(OLD_CMAKE_FIND_PACKAGE_PREFER_CONFIG ${CMAKE_FIND_PACKAGE_PREFER_CONFIG})
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+find_package(pybind11)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${OLD_CMAKE_FIND_PACKAGE_PREFER_CONFIG})
 
 if(pybind11_FOUND)
     message(STATUS "System pybind11 found")

--- a/notes.txt
+++ b/notes.txt
@@ -1,4 +1,0 @@
-https://cmake.org/cmake/help/latest/command/file.html#generate: Generated files are modified and their timestamp updated on subsequent cmake runs only if their content is changed.
-
-third_party/fbgemm/third_party/googletest/googletest/cmake/internal_utils.cmake:179:
-Flag -pthread (most likely)

--- a/notes.txt
+++ b/notes.txt
@@ -1,1 +1,4 @@
 https://cmake.org/cmake/help/latest/command/file.html#generate: Generated files are modified and their timestamp updated on subsequent cmake runs only if their content is changed.
+
+third_party/fbgemm/third_party/googletest/googletest/cmake/internal_utils.cmake:179:
+Flag -pthread (most likely)

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,1 @@
+https://cmake.org/cmake/help/latest/command/file.html#generate: Generated files are modified and their timestamp updated on subsequent cmake runs only if their content is changed.

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -351,6 +351,7 @@ class CMake:
         # build detector.
         # This line works around that bug by manually updating the build.ninja timestamp
         # after the entire build is finished.
-        ninja_build_file = os.path.join(self.build_dir, 'build.ninja')
-        if os.path.exists(ninja_build_file):
-            os.utime(ninja_build_file, None)
+        if False:
+          ninja_build_file = os.path.join(self.build_dir, 'build.ninja')
+          if os.path.exists(ninja_build_file):
+              os.utime(ninja_build_file, None)

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -338,20 +338,3 @@ class CMake:
         else:
             build_args += ['--', '-j', max_jobs]
         self.run(build_args, my_env)
-
-        # in cmake, .cu compilation involves generating certain intermediates
-        # such as .cu.o and .cu.depend, and these intermediates finally get compiled
-        # into the final .so.
-        # Ninja updates build.ninja's timestamp after all dependent files have been built,
-        # and re-kicks cmake on incremental builds if any of the dependent files
-        # have a timestamp newer than build.ninja's timestamp.
-        # There is a cmake bug with the Ninja backend, where the .cu.depend files
-        # are still compiling by the time the build.ninja timestamp is updated,
-        # so the .cu.depend file's newer timestamp is screwing with ninja's incremental
-        # build detector.
-        # This line works around that bug by manually updating the build.ninja timestamp
-        # after the entire build is finished.
-        if False:
-          ninja_build_file = os.path.join(self.build_dir, 'build.ninja')
-          if os.path.exists(ninja_build_file):
-              os.utime(ninja_build_file, None)


### PR DESCRIPTION
Fixes #26304

Test procedure:
With ninja:
[x] Build a clean checkout
[x] Build again. Result: Only 10 libraries are (needlessly) linked again, the extra delay on a 24-core machine is <10s.
[x] Build for the third time. Result: Virtually instantaneous, with no extra rebuilding.
[x] Modify DispatchTable.h. Build again. Result: `.cu` files are rebuilt, as well as many `.cpp` files
[x] Build for the fifth time. Result: Virtually instantaneous, with no extra rebuilding.
[x] Touch one of the `.depend` files. Build again. Result: Only 10 libraries are (needlessly) linked again, the extra delay on a 24-core machine is <10s.

Without ninja:
[x] Build a clean checkout
[x] Build again. Result: There is some unnecessary rebuilding. But it was also happening before this change.
[x] Build for the third time. Result: Virtually instantaneous, with no extra rebuilding.