### PR TITLE
Fix doc-gen warnings in RPC

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _distributed-rpc-framework:
 
 Distributed RPC Framework
@@ -9,7 +11,7 @@ higher-level API to automatically differentiate models split across several
 machines.
 
 .. warning ::
-     APIs in the RPC package are stable. There are multiple ongoing work items 
+     APIs in the RPC package are stable. There are multiple ongoing work items
      to improve performance and error handling, which will ship in future releases.
 
 

--- a/docs/source/rpc/distributed_autograd.rst
+++ b/docs/source/rpc/distributed_autograd.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _distributed-autograd-design:
 
 Distributed Autograd Design

--- a/docs/source/rpc/index.rst
+++ b/docs/source/rpc/index.rst
@@ -1,14 +1,14 @@
 .. _rpc-index:
 
 Distributed RPC Framework
-==============================
+=========================
 
 The distributed RPC framework provides mechanisms for multi-machine model training through a set of primitives to allow for remote communication, and a higher-level API to automatically differentiate models split across several machines.
 
 -  :ref:`distributed-rpc-framework`
 
 Design Notes
------------
+------------
 The distributed autograd design note covers the design of the RPC-based distributed autograd framework that is useful for applications such as model parallel training.
 
 -  :ref:`distributed-autograd-design`

--- a/docs/source/rpc/rref.rst
+++ b/docs/source/rpc/rref.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _remote-reference-protocol:
 
 Remote Reference Protocol


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37667 Add pointer to RPC parameter server tutorial
* **#37666 Fix doc-gen warnings in RPC**

Add `:orphan:` to avoid "WARNING: document isn't included in any toctree".

Differential Revision: [D21351053](https://our.internmc.facebook.com/intern/diff/D21351053)