### PR TITLE
Move complex utilities out of Half.h

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -378,35 +378,6 @@ struct alignas(4) complex<Half> {
   }
 };
 
-template <typename T>
-struct is_complex_t : public std::false_type {};
-
-template <typename T>
-struct is_complex_t<std::complex<T>> : public std::true_type {};
-
-template <typename T>
-struct is_complex_t<c10::complex<T>> : public std::true_type {};
-
-
-// Extract double from std::complex<double>; is identity otherwise
-// TODO: Write in more idiomatic C++17
-template <typename T>
-struct scalar_value_type {
-  using type = T;
-};
-template <typename T>
-struct scalar_value_type<std::complex<T>> {
-  using type = T;
-};
-template <typename T>
-struct scalar_value_type<c10::complex<T>> {
-  using type = T;
-};
-template <>
-struct scalar_value_type<complex<Half>> {
-  using type = Half;
-};
-
 // In some versions of MSVC, there will be a compiler error when building.
 // C4146: unary minus operator applied to unsigned type, result still unsigned
 // C4804: unsafe use of type 'bool' in operation

--- a/c10/util/complex_type.h
+++ b/c10/util/complex_type.h
@@ -492,3 +492,5 @@ C10_HOST_DEVICE c10::complex<T> polar(const T& r, const T& theta = T()) {
 
 // math functions are included in a separate file
 #include <c10/util/complex_math.h>
+// utilities for complex types
+#include <c10/util/complex_utils.h>

--- a/c10/util/complex_utils.h
+++ b/c10/util/complex_utils.h
@@ -1,0 +1,28 @@
+namespace c10 {
+
+template <typename T>
+struct is_complex_t : public std::false_type {};
+
+template <typename T>
+struct is_complex_t<std::complex<T>> : public std::true_type {};
+
+template <typename T>
+struct is_complex_t<c10::complex<T>> : public std::true_type {};
+
+
+// Extract double from std::complex<double>; is identity otherwise
+// TODO: Write in more idiomatic C++17
+template <typename T>
+struct scalar_value_type {
+  using type = T;
+};
+template <typename T>
+struct scalar_value_type<std::complex<T>> {
+  using type = T;
+};
+template <typename T>
+struct scalar_value_type<c10::complex<T>> {
+  using type = T;
+};
+
+}


### PR DESCRIPTION
There is no reason to put complex utilities to half header.