### PR TITLE
Remove requantization scale constraint.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
@@ -305,16 +305,6 @@ enum pytorch_qnnp_status qnnpackConv(
 
   const float convolution_scale =
       input_scale * conv_p.kernel_scale / output_scale;
-  if (convolution_scale >= 1.0f) {
-    pytorch_qnnp_log_error(
-        "failed to create convolution with %.7g input scale, %.7g kernel scale,"
-        " and %.7g output scale: "
-        "convolution scale %.7g is greater or equal to 1.0",
-        input_scale,
-        conv_p.kernel_scale,
-        output_scale,
-        convolution_scale);
-  }
   union pytorch_qnnp_q31_requantization_params requantization_params;
   union pytorch_qnnp_conv_quantization_params conv_quantization_params;
   if (conv_p.ukernel_type == pytorch_qnnp_ukernel_type_xzp_gemm) {

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/fc-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/fc-run.cc
@@ -80,17 +80,6 @@ enum pytorch_qnnp_status qnnpackLinear(
 
   const size_t output_size = batch_size * 1;
   const float requantization_scale = input_scale * kernel_scale / output_scale;
-  if (requantization_scale >= 1.0f) {
-    pytorch_qnnp_log_error(
-        "failed to create fully connected operator with %.7g input scale, %.7g "
-        "kernel scale, and %.7g output scale: "
-        "requantization scale %.7g is greater or equal to 1.0",
-        input_scale,
-        kernel_scale,
-        output_scale,
-        requantization_scale);
-    return pytorch_qnnp_status_unsupported_parameter;
-  }
   union pytorch_qnnp_conv_quantization_params conv_quantization_params = pytorch_qnnp_compute_conv_quantization_params(
       input_zero_point, kernel_zero_point, requantization_scale, output_zero_point, output_min, output_max);
 


### PR DESCRIPTION
Summary:
Now that we landed float requantization for conv/linear, we do not need
the constraint for requant_scale < 1.
Removing that.

Test Plan:
Quantization tests

Reviewers:

Subscribers:

Tasks:

Tags:

