### PR TITLE
jit/OVERVIEW.md: screen * in 'Node*' for proper rendering.

### DIFF
--- a/torch/csrc/jit/OVERVIEW.md
+++ b/torch/csrc/jit/OVERVIEW.md
@@ -756,7 +756,7 @@ Operations also return a jump offset relative to the address of the next operato
 
 [runtime/operator.h](runtime/operator.h)
 
-The Operator object represents a single registered operator in the system. It combines a FunctionSchema that describes how an Operation executes with a method to lookup the corresponding Operation given the Node representing the operator in a Graph.  Most Operators are defined by providing a FunctionSchema and an Operation function. However, primitives like prim::Unpack require knowledge of their Node to know how to operate (e.g. how many elements to unpack). These Operators have a function that takes a Node* and returns an operation.
+The Operator object represents a single registered operator in the system. It combines a FunctionSchema that describes how an Operation executes with a method to lookup the corresponding Operation given the Node representing the operator in a Graph.  Most Operators are defined by providing a FunctionSchema and an Operation function. However, primitives like prim::Unpack require knowledge of their Node to know how to operate (e.g. how many elements to unpack). These Operators have a function that takes a `Node*` and returns an operation.
 
 
 ## Interpreter ##


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37686 jit/OVERVIEW.md: screen * in 'Node*' for proper rendering.**

Differential Revision: [D21358819](https://our.internmc.facebook.com/intern/diff/D21358819)