### PR TITLE
Cherry pick 3 commits into release 1.5

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -673,11 +673,11 @@ Tensor & leaky_relu_(
   return at::leaky_relu_out(self, self, neg_val);
 }
 
-// Note: leakyReLu backward calculation doesn't support in-place call with non-positive slope.
+// Note: leakyReLu backward calculation doesn't support in-place call with negative slope.
 // The reason is that for in-place forward call, the forward result will be saved into autograd
 // node instead of the input itself, when calculating backward gradient, there is no way to know
 // whether the original input for current node is positive or not if the input slope is
-// non-positive. eg. forward is 2, slope is -0.2, the original input for this node could be
+// negative. eg. forward is 2, slope is -0.2, the original input for this node could be
 // either 2, or -10, so no way to get a correct backward gradient in this case.
 Tensor leaky_relu_backward(
     const Tensor& grad_output,
@@ -685,11 +685,11 @@ Tensor leaky_relu_backward(
     Scalar negval,
     bool is_result) {
   TORCH_CHECK(
-    !is_result || negval.to<double>() > 0.0,
-    "In-place leakyReLu backward calculation is triggered with a non-positive slope which is not supported. "
-    "This is caused by calling in-place forward function with a non-positive slope, "
+    !is_result || negval.to<double>() >= 0.0,
+    "In-place leakyReLu backward calculation is triggered with a negative slope which is not supported. "
+    "This is caused by calling in-place forward function with a negative slope, "
     "please call out-of-place version instead. File an issue at https://github.com/pytorch/pytorch if you do "
-    "require supporting in-place leakRelu backward calculation with non-positive slope");
+    "require supporting in-place leakRelu backward calculation with negative slope");
 
   Tensor result;
   auto iter = TensorIterator::binary_op(result, self_or_result, grad_output);

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5441,7 +5441,7 @@ class TestAutogradDeviceType(TestCase):
         self.assertEqual(grad_cudnn, grad_native, prec=1e-4)
 
     @skipCUDAIfRocm
-    def test_leaky_relu_inplace_with_zero_or_neg_slope(self, device):
+    def test_leaky_relu_inplace_with_neg_slope(self, device):
         a = torch.tensor([-1., 1.], device=device, requires_grad=True)
         b = torch.nn.functional.leaky_relu_(a.clone(), -2)
         with self.assertRaisesRegex(RuntimeError, "call out-of-place version"):
@@ -5452,10 +5452,13 @@ class TestAutogradDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, "call out-of-place version"):
             b.backward(torch.ones(2, device=device))
 
+    @skipCUDAIfRocm
+    def test_leaky_relu_inplace_with_zero_slope(self, device):
         a = torch.tensor([-2., 0., 2.], device=device, requires_grad=True)
         b = torch.nn.functional.leaky_relu_(a.clone(), 0.0)
         b.backward(torch.ones(3, device=device))
-        self.assertEqual(a.grad, torch.tensor([0., 0., 1.], device=device))
+        expected = torch.tensor([0., 0., 1.], device=device)
+        self.assertEqual(a.grad, expected)
 
     @onlyCUDA
     def test_free_unneeded_tensor(self, device):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5441,7 +5441,7 @@ class TestAutogradDeviceType(TestCase):
         self.assertEqual(grad_cudnn, grad_native, prec=1e-4)
 
     @skipCUDAIfRocm
-    def test_leaky_relu_inplace_with_neg_slope(self, device):
+    def test_leaky_relu_inplace_with_zero_or_neg_slope(self, device):
         a = torch.tensor([-1., 1.], device=device, requires_grad=True)
         b = torch.nn.functional.leaky_relu_(a.clone(), -2)
         with self.assertRaisesRegex(RuntimeError, "call out-of-place version"):
@@ -5451,6 +5451,11 @@ class TestAutogradDeviceType(TestCase):
         b = torch.nn.functional.rrelu_(a.clone(), -5.0, 1.0)
         with self.assertRaisesRegex(RuntimeError, "call out-of-place version"):
             b.backward(torch.ones(2, device=device))
+
+        a = torch.tensor([-2., 0., 2.], device=device, requires_grad=True)
+        b = torch.nn.functional.leaky_relu_(a.clone(), 0.0)
+        b.backward(torch.ones(3, device=device))
+        self.assertEqual(a.grad, torch.tensor([0., 0., 1.], device=device))
 
     @onlyCUDA
     def test_free_unneeded_tensor(self, device):

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -41,8 +41,12 @@ class Cloneable : public virtual Module {
     copy->buffers_.clear();
     copy->children_.clear();
     copy->reset();
+    // [[this pointer note]]
+    // Don't remove 'this' pointer, nvcc needs it to be explicitly given in some envs.
+    // eg. ubuntu 16.04 + gcc 5.x + cuda 9.2
+    //     ubuntu 16.04 + gcc 7.x + cuda 9.2
     TORCH_CHECK(
-        copy->parameters_.size() == parameters_.size(),
+        copy->parameters_.size() == this->parameters_.size(),
         "The cloned module does not have the same number of "
         "parameters as the original module after calling reset(). "
         "Are you sure you called register_parameter() inside reset() "
@@ -53,8 +57,9 @@ class Cloneable : public virtual Module {
           tensor.to(*device) : autograd::Variable(tensor).clone();
       copy->parameters_[parameter.key()].set_data(data);
     }
+    // Don't remove 'this' pointer. See [[this pointer note]]
     TORCH_CHECK(
-        copy->buffers_.size() == buffers_.size(),
+        copy->buffers_.size() == this->buffers_.size(),
         "The cloned module does not have the same number of "
         "buffers as the original module after calling reset(). "
         "Are you sure you called register_buffer() inside reset() "
@@ -65,13 +70,15 @@ class Cloneable : public virtual Module {
           tensor.to(*device) : autograd::Variable(tensor).clone();
       copy->buffers_[buffer.key()].set_data(data);
     }
+    // Don't remove 'this' pointer. See [[this pointer note]]
     TORCH_CHECK(
-        copy->children_.size() == children_.size(),
+        copy->children_.size() == this->children_.size(),
         "The cloned module does not have the same number of "
         "child modules as the original module after calling reset(). "
         "Are you sure you called register_module() inside reset() "
         "and not the constructor?");
-    for (const auto& child : children_) {
+    // Don't remove 'this' pointer. See [[this pointer note]]
+    for (const auto& child : this->children_) {
       copy->children_[child.key()]->clone_(*child.value(), device);
     }
     return copy;

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -226,6 +226,14 @@ module_tests = [
         desc='with_negval'
     ),
     dict(
+        module_name='LeakyReLU',
+        constructor_args=(0.0,),
+        cpp_constructor_args='torch::nn::LeakyReLUOptions().negative_slope(0.0)',
+        input_fn=lambda: torch.randn(10, 10),
+        check_inplace=True,
+        desc='with_zero_negval'
+    ),
+    dict(
         module_name='LogSigmoid',
         input_size=(2, 3, 4),
         reference_fn=lambda i, *_: i.sigmoid().log(),


### PR DESCRIPTION
1. Allow inplace leaky_relu backward calculation with zero slope
https://github.com/pytorch/pytorch/pull/37559
https://github.com/pytorch/pytorch/pull/37453

2. Fix cpp extension compile failure under some env (eg. ubuntu 16.04 + gcc5 + cuda9.2)
https://github.com/pytorch/pytorch/pull/37221