### PR TITLE
Math functions of c10::complex should be overloaded as const reference

### DIFF
--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -9,7 +9,7 @@ namespace std {
 #endif
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> exp(c10::complex<T> x) {
+C10_HOST_DEVICE inline c10::complex<T> exp(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::exp(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -18,7 +18,7 @@ C10_HOST_DEVICE c10::complex<T> exp(c10::complex<T> x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> log(c10::complex<T> x) {
+C10_HOST_DEVICE inline c10::complex<T> log(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::log(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -27,7 +27,7 @@ C10_HOST_DEVICE c10::complex<T> log(c10::complex<T> x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> log10(c10::complex<T> x) {
+C10_HOST_DEVICE inline c10::complex<T> log10(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::log10(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -38,7 +38,7 @@ C10_HOST_DEVICE c10::complex<T> log10(c10::complex<T> x) {
 // Power functions
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> sqrt(c10::complex<T> x) {
+C10_HOST_DEVICE inline c10::complex<T> sqrt(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::sqrt(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -47,7 +47,7 @@ C10_HOST_DEVICE c10::complex<T> sqrt(c10::complex<T> x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> pow(c10::complex<T> x, c10::complex<T> y) {
+C10_HOST_DEVICE inline c10::complex<T> pow(const c10::complex<T> &x, const c10::complex<T> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
 #else
@@ -56,7 +56,7 @@ C10_HOST_DEVICE c10::complex<T> pow(c10::complex<T> x, c10::complex<T> y) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> pow(c10::complex<T> x, const T &y) {
+C10_HOST_DEVICE inline c10::complex<T> pow(const c10::complex<T> &x, const T &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), y));
 #else
@@ -65,7 +65,7 @@ C10_HOST_DEVICE c10::complex<T> pow(c10::complex<T> x, const T &y) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> pow(const T &x, c10::complex<T> y) {
+C10_HOST_DEVICE inline c10::complex<T> pow(const T &x, const c10::complex<T> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::pow(x, static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
 #else
@@ -74,7 +74,7 @@ C10_HOST_DEVICE c10::complex<T> pow(const T &x, c10::complex<T> y) {
 }
 
 template<typename T, typename U>
-C10_HOST_DEVICE c10::complex<decltype(T() * U())> pow(c10::complex<T> x, c10::complex<U> y) {
+C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const c10::complex<T> &x, const c10::complex<U> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
 #else
@@ -83,7 +83,7 @@ C10_HOST_DEVICE c10::complex<decltype(T() * U())> pow(c10::complex<T> x, c10::co
 }
 
 template<typename T, typename U>
-C10_HOST_DEVICE c10::complex<decltype(T() * U())> pow(c10::complex<T> x, const U &y) {
+C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const c10::complex<T> &x, const U &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), y));
 #else
@@ -92,7 +92,7 @@ C10_HOST_DEVICE c10::complex<decltype(T() * U())> pow(c10::complex<T> x, const U
 }
 
 template<typename T, typename U>
-C10_HOST_DEVICE c10::complex<decltype(T() * U())> pow(const T &x, c10::complex<U> y) {
+C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const T &x, const c10::complex<U> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::pow(x, static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
 #else
@@ -103,7 +103,7 @@ C10_HOST_DEVICE c10::complex<decltype(T() * U())> pow(const T &x, c10::complex<U
 // Trigonometric functions
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> sin(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> sin(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::sin(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -112,7 +112,7 @@ C10_HOST_DEVICE c10::complex<T> sin(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> cos(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> cos(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::cos(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -121,7 +121,7 @@ C10_HOST_DEVICE c10::complex<T> cos(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> tan(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> tan(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::tan(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -130,7 +130,7 @@ C10_HOST_DEVICE c10::complex<T> tan(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> asin(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> asin(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::asin(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -139,7 +139,7 @@ C10_HOST_DEVICE c10::complex<T> asin(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> acos(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> acos(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::acos(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -148,7 +148,7 @@ C10_HOST_DEVICE c10::complex<T> acos(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> atan(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> atan(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::atan(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -159,7 +159,7 @@ C10_HOST_DEVICE c10::complex<T> atan(const c10::complex<T> &x) {
 // Hyperbolic functions
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> sinh(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> sinh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::sinh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -168,7 +168,7 @@ C10_HOST_DEVICE c10::complex<T> sinh(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> cosh(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> cosh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::cosh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -177,7 +177,7 @@ C10_HOST_DEVICE c10::complex<T> cosh(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> tanh(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> tanh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::tanh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -186,7 +186,7 @@ C10_HOST_DEVICE c10::complex<T> tanh(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> asinh(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> asinh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::asinh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -195,7 +195,7 @@ C10_HOST_DEVICE c10::complex<T> asinh(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> acosh(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> acosh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::acosh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else
@@ -204,7 +204,7 @@ C10_HOST_DEVICE c10::complex<T> acosh(const c10::complex<T> &x) {
 }
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> atanh(const c10::complex<T> &x) {
+C10_HOST_DEVICE inline c10::complex<T> atanh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::atanh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
 #else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37690 Add vec256 for c10::complex
* **#37689 Math functions of c10::complex should be overloaded as const reference**

It has to be this way, otherwise, we will not be able to use it in vec256 because the function pointers declared there are using const reference.

Differential Revision: [D21394603](https://our.internmc.facebook.com/intern/diff/D21394603)