### PR TITLE
[JIT] Rewrite unaliased if output mutation

### DIFF
--- a/test/jit/test_functional_blocks.py
+++ b/test/jit/test_functional_blocks.py
@@ -128,7 +128,6 @@ class TestFunctionalBlocks(JitTestCase):
         self.assertEqual(test_intermediary_use(), fn())
 
     def test_remove_mutation_if_output(self):
-
         def foo(x, cond: bool):
             if cond:
                 y = x + 5
@@ -139,10 +138,9 @@ class TestFunctionalBlocks(JitTestCase):
 
         out_eager = foo(torch.tensor(5), True)
         foo_script = torch.jit.script(foo)
-        self.run_pass('inline', mod.forward.graph)
-        FileCheck().check("aten::add_").check("aten::relu_").run(mod.forward.graph)
-        self.run_pass('remove_mutation', mod.forward.graph)
-        FileCheck().check_not("aten::add_").run(mod.forward.graph)
+        FileCheck().check("aten::add_").run(foo_script.graph)
+        self.run_pass('remove_mutation', foo_script.graph)
+        FileCheck().check_not("aten::add_").run(foo_script.graph)
 
         self.assertEqual(out_eager, foo_script(torch.tensor(5), True))
 

--- a/torch/csrc/jit/passes/create_functional_graphs.cpp
+++ b/torch/csrc/jit/passes/create_functional_graphs.cpp
@@ -300,13 +300,13 @@ struct MutationRemover {
       Value* mutated_value,
       Node* mutating_op) {
     // if cond:
-    //    x0 = op()
+    //    x = op()
     // else:
-    //    x1 = op()
-    // x2.add_(1)
-    // if x0 and x1 have no other uses and are unaliased in the graph,
+    //    x = op()
+    // x = add_(1)
+    // if x in both blocks have no other uses and are unaliased in the graph,
     // and we make the if node and the mutation atomic,
-    // then removing mutation to x2 does not change observable semantics
+    // then removing mutation add_ does not change observable semantics
 
     if (mutated_value->node()->kind() != prim::If) {
       return false;

--- a/torch/csrc/jit/passes/create_functional_graphs.cpp
+++ b/torch/csrc/jit/passes/create_functional_graphs.cpp
@@ -226,15 +226,17 @@ struct MutationRemover {
 
  private:
   bool newMemoryLocation(Value* v) {
-    // bail on nodes with side effects, blocks, or graphs
+    // bail on nodes with side effects, blocks, or graph / graph inputs
     Node* n = v->node();
     bool unhandled_node = n->blocks().size() != 0 ||
-        n->hasAttribute(attr::Subgraph) || n->hasSideEffects();
+        n->hasAttribute(attr::Subgraph) || n->hasSideEffects() ||
+        (v->node()->kind() == prim::Param);
 
     // if the output isn't contained or alias by the inputs to its node, it's
     // unique
     return !unhandled_node &&
-        !aliasDb_->mayContainAlias(v->node()->inputs(), v);
+        !aliasDb_->mayContainAlias(v->node()->inputs(), v) &&
+        !(v->node()->kind() == prim::Param);
   }
 
   bool inplaceOpVariant(Node* n) {
@@ -294,6 +296,38 @@ struct MutationRemover {
         mutated_value->node(), mutating_op);
   }
 
+  bool tryMakeUnaliasedIfOutputAndMutationAtomic(
+      Value* mutated_value,
+      Node* mutating_op) {
+    // if cond:
+    //    x0 = op()
+    // else:
+    //    x1 = op()
+    // x2.add_(1)
+    // if x0 and x1 have no other uses and are unaliased in the graph,
+    // and we make the if node and the mutation atomic,
+    // then removing mutation to x2 does not change observable semantics
+
+    if (mutated_value->node()->kind() != prim::If) {
+      return false;
+    }
+
+    auto if_node = mutated_value->node();
+    auto offset = mutated_value->offset();
+    auto true_value = if_node->blocks().at(0)->outputs().at(offset);
+    auto false_value = if_node->blocks().at(1)->outputs().at(offset);
+
+    if (true_value->uses().size() > 1 || false_value->uses().size() > 1) {
+      return false;
+    }
+
+    if (!newMemoryLocation(true_value) || !newMemoryLocation(false_value)) {
+      return false;
+    }
+
+    return aliasDb_->moveBeforeTopologicallyValid(if_node, mutating_op);
+  }
+
   void RemoveListMutation(Block* block) {
     for (auto it = block->nodes().begin(); it != block->nodes().end();) {
       auto* node = *it;
@@ -345,7 +379,8 @@ struct MutationRemover {
       }
 
       Value* mutated_value = node->inputs().at(0);
-      if (!tryMakeCreationAndMutationAtomic(mutated_value, node)) {
+      if (!tryMakeCreationAndMutationAtomic(mutated_value, node) &&
+          !tryMakeUnaliasedIfOutputAndMutationAtomic(mutated_value, node)) {
         continue;
       }
 


### PR DESCRIPTION
In a case like below,  if x0 and x1 are both unaliased an only have a single use, than we can rewite the mutation to x2 without breaking observable semantics. This PR makes torchvision.models.alexnet functionalizable.  
```
if cond:
    x0 = op()
else:
    x1 = op()
x2.add_(1)
```
