### PR TITLE
[PyTorch] Modify `data_parallel` to work with small tensors

### DIFF
--- a/test/cpp/api/parallel.cpp
+++ b/test/cpp/api/parallel.cpp
@@ -217,10 +217,10 @@ TEST_F(ParallelTest, DataParallelUsesAllAvailableCUDADevices_CUDA) {
   };
 
   auto m = std::make_shared<M>();
-  auto input = torch::ones({10, 3});
+  const auto device_count = torch::cuda::device_count();
+  auto input = torch::ones({std::max(10, int(2 * device_count)), 3});
   auto output = parallel::data_parallel(m, input);
 
-  const auto device_count = torch::cuda::device_count();
   ASSERT_EQ(output.numel(), device_count);
   for (size_t i = 0; i < device_count; ++i) {
     ASSERT_EQ(output[i].item<int32_t>(), i);

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -271,6 +271,10 @@ Tensor data_parallel(
 
   autograd::Scatter scatter(*devices, /*chunk_sizes=*/nullopt, dim);
   auto scattered_inputs = fmap<Tensor>(scatter.apply({std::move(input)}));
+  // Input tensor might not be big enough to scale across all available devices
+  if (scattered_inputs.size() < devices->size()) {
+    devices->resize(scattered_inputs.size(), Device(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES));
+  }
 
   auto replicas = replicate(module, *devices);
   auto outputs = parallel_apply(replicas, scattered_inputs, *devices);


### PR DESCRIPTION
Summary:
If input tensor can not be chunked, run `parallel_apply` on fewer devices
Modfy input tensor dimention in `DataParallelUsesAllAvailableCUDADevices_CUDA` to be chunkable by any number of available CUDA devices

Test Plan: Run `test/cpp/api/parallel` on machine  with 6 GPUs

Differential Revision: D21365416

