### PR TITLE
WIP: Added out-of-tree support for Torch-Vitis FPGA kernels Testing

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -368,10 +368,12 @@ def generate_storage_type_and_tensor(backend, density, declarations, per_op_regi
     if env['DeviceType'] == 'CPU':
         top_env['cpu_type_headers'].append(
             '#include <ATen/{}.h>'.format(env['Type']))
-    else:
+    elif env['DeviceType'] == 'CUDA':
         assert env['DeviceType'] == 'CUDA'
         top_env['cuda_type_headers'].append(
             '#include <ATen/{}.h>'.format(env['Type']))
+    else:  # Pass-through for out-of-tree devices
+        pass
 
 
 # yields (backend, density) tuples

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -32,6 +32,7 @@ enum class Backend {
   SparseCPU,
   SparseCUDA,
   SparseHIP,
+  FPGA,
   MSNPU,
   XLA,
   QuantizedCPU,
@@ -68,6 +69,8 @@ static inline Backend toDense(Backend b) {
       return Backend::CUDA;
     case Backend::HIP:
       return Backend::HIP;
+    case Backend::FPGA:
+      return Backend::FPGA;
     case Backend::MSNPU:
       return Backend::MSNPU;
     case Backend::XLA:
@@ -94,6 +97,8 @@ static inline Backend dispatchKeyToBackend(DispatchKey t) {
     return Backend::CUDA;
   } else if (t == DispatchKey::HIP) {
     return Backend::HIP;
+  } else if (t == DispatchKey::FPGA) {
+    return Backend::FPGA;
   } else if (t == DispatchKey::MSNPU) {
     return Backend::MSNPU;
   } else if (t == DispatchKey::XLA || t == DispatchKey::XLAPreAutograd) {
@@ -125,6 +130,8 @@ static inline DispatchKey backendToDispatchKey(Backend b) {
       return DispatchKey::CUDA;
     case Backend::HIP:
       return DispatchKey::HIP;
+    case Backend::FPGA:
+      return DispatchKey::FPGA;
     case Backend::MSNPU:
       return DispatchKey::MSNPU;
     case Backend::XLA:
@@ -156,6 +163,8 @@ static inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::CUDA;
     case Backend::HIP:
       return DeviceType::HIP;
+    case Backend::FPGA:
+      return DeviceType::FPGA;
     case Backend::MSNPU:
       return DeviceType::MSNPU;
     case Backend::XLA:
@@ -192,6 +201,8 @@ static inline Backend backendToCPU(Backend b) {
       return Backend::SparseCPU;
     case Backend::SparseHIP:
       return Backend::SparseCPU;
+    case Backend::FPGA:
+      return Backend::FPGA;
     case Backend::MSNPU:
     case Backend::XLA:
       return Backend::CPU;
@@ -213,6 +224,7 @@ static inline Backend backendToCUDA(Backend b) {
     case Backend::CPU:
     case Backend::CUDA:
     case Backend::HIP:
+    case Backend::FPGA:
     case Backend::MSNPU:
     case Backend::XLA:
       return Backend::CUDA;
@@ -232,6 +244,7 @@ static inline Backend backendToHIP(Backend b) {
     case Backend::CPU:
     case Backend::CUDA:
     case Backend::HIP:
+    case Backend::FPGA:
     case Backend::MSNPU:
     case Backend::XLA:
       return Backend::HIP;
@@ -255,6 +268,8 @@ static inline const char* toString(Backend b) {
       return "CUDA";
     case Backend::HIP:
       return "HIP";
+    case Backend::FPGA:
+      return "FPGA";
     case Backend::MSNPU:
       return "MSNPU";
     case Backend::XLA:

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -13,7 +13,7 @@
 namespace c10 {
 namespace {
 DeviceType parse_type(const std::string& device_string) {
-  static const std::array<std::pair<std::string, DeviceType>, 9> types = {{
+  static const std::array<std::pair<std::string, DeviceType>, 10> types = {{
       {"cpu", DeviceType::CPU},
       {"cuda", DeviceType::CUDA},
       {"mkldnn", DeviceType::MKLDNN},
@@ -21,6 +21,7 @@ DeviceType parse_type(const std::string& device_string) {
       {"opencl", DeviceType::OPENCL},
       {"ideep", DeviceType::IDEEP},
       {"hip", DeviceType::HIP},
+      {"fpga", DeviceType::FPGA},
       {"msnpu", DeviceType::MSNPU},
       {"xla", DeviceType::XLA},
   }};

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -34,6 +34,7 @@ enum class DeviceType : int16_t {
 constexpr DeviceType kCPU = DeviceType::CPU;
 constexpr DeviceType kCUDA = DeviceType::CUDA;
 constexpr DeviceType kHIP = DeviceType::HIP;
+constexpr DeviceType kFPGA = DeviceType::FPGA;
 constexpr DeviceType kMSNPU = DeviceType::MSNPU;
 constexpr DeviceType kXLA = DeviceType::XLA;
 

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -24,6 +24,8 @@ const char* toString(DispatchKey t) {
       return "IDEEP";
     case DispatchKey::HIP:
       return "HIP";
+    case DispatchKey::FPGA:
+      return "FPGA";
     case DispatchKey::SparseHIP:
       return "SparseHIP";
     case DispatchKey::MSNPU:

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -52,6 +52,7 @@ enum class DispatchKey : uint8_t {
   CUDA, // registered at build/aten/src/ATen/CUDAType.cpp
   HIP, // NB: I think this is not actually used, due to Note [Masquerading as
        // CUDA]
+  FPGA, // lives out of tree at https://gitlab.com/pytorch-complex/vitis_kernels.
   MSNPU, // unused externally, but tested at
          // test/cpp_extensions/msnpu_extension.cpp
   XLA, // lives out of tree at https://github.com/pytorch/xla

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -397,6 +397,8 @@ struct C10_API TensorOptions {
             return DispatchKey::IDEEP;
           case DeviceType::HIP:
             return DispatchKey::HIP;
+          case DeviceType::FPGA:
+            return DispatchKey::FPGA;
           case DeviceType::MSNPU:
             return DispatchKey::MSNPU;
           case DeviceType::XLA:
@@ -623,6 +625,8 @@ inline DeviceType computeDeviceType(DispatchKey tid) {
     return DeviceType::CUDA;
   } else if (tid == DispatchKey::HIP) {
     return DeviceType::HIP;
+  } else if (tid == DispatchKey::FPGA) {
+    return DeviceType::FPGA;
   } else if (tid == DispatchKey::MKLDNN) {
     return DeviceType::MKLDNN;
   } else if (tid == DispatchKey::OpenGL) {
@@ -631,8 +635,6 @@ inline DeviceType computeDeviceType(DispatchKey tid) {
     return DeviceType::OPENCL;
   } else if (tid == DispatchKey::IDEEP) {
     return DeviceType::IDEEP;
-  } else if (tid == DispatchKey::HIP) {
-    return DeviceType::HIP;
   } else if (tid == DispatchKey::MSNPU) {
     return DeviceType::MSNPU;
   } else if (tid == DispatchKey::XLA) {


### PR DESCRIPTION
Continuation of #37378

Out-of-Tree PyTorch-Vitis FPGA support is found [here](https://gitlab.com/pytorch-complex/vitis_kernels)
Xilinx Vitis Webpage is found [here](https://www.xilinx.com/products/design-tools/vitis/vitis-platform.html)
List of supported FPGAs is found [here](https://xilinx.github.io/XRT/2019.2/html/platforms.html)