### PR TITLE
Adding support for manifold files in DBReader

### DIFF
--- a/caffe2/python/db_file_reader.py
+++ b/caffe2/python/db_file_reader.py
@@ -99,8 +99,9 @@ class DBFileReader(Reader):
         if field_names:
             return from_column_list(field_names)
 
-        assert os.path.exists(self.db_path), \
-            'db_path [{db_path}] does not exist'.format(db_path=self.db_path)
+        if self.db_type == "log_file_db":
+            assert os.path.exists(self.db_path), \
+                'db_path [{db_path}] does not exist'.format(db_path=self.db_path)
         with core.NameScope(self.name):
             # blob_prefix is for avoiding name conflict in workspace
             blob_prefix = scope.CurrentNameScope()
@@ -156,8 +157,9 @@ class DBFileReader(Reader):
 
     def _feed_field_blobs_from_db_file(self, net):
         """Load from the DB file at db_path and feed dataset field blobs"""
-        assert os.path.exists(self.db_path), \
-            'db_path [{db_path}] does not exist'.format(db_path=self.db_path)
+        if self.db_type == "log_file_db":
+            assert os.path.exists(self.db_path), \
+                'db_path [{db_path}] does not exist'.format(db_path=self.db_path)
         net.Load(
             [],
             self.ds.get_blobs(),
@@ -170,7 +172,8 @@ class DBFileReader(Reader):
     def _extract_db_name_from_db_path(self):
         """Extract DB name from DB path
 
-            E.g. given self.db_path=`/tmp/sample.db`,
+            E.g. given self.db_path=`/tmp/sample.db`, or
+            self.db_path = `dper_test_data/cached_reader/sample.db`
             it returns `sample`.
 
             Returns:


### PR DESCRIPTION
Summary: Check if the file exists locally only for `log_file_db` db_type. Reader files in other `db_type` like `manifold_log_file_db` are excluded from this check.

Test Plan: Verified that files stored in manifold can be loaded using `DBFileReader`.

Differential Revision: D21329671

