### PR TITLE
Remove global CMAKE_INSTALL_RPATH_USE_LINK_PATH directive

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -25,7 +25,8 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   chown jenkins:jenkins /opt/conda
 
   as_jenkins() {
-    # NB: unsetting the environment variables works around a conda bug
+    # NB 2020-05-06: this work-around may no longer be needed
+    # NB 2018-02-24: unsetting the environment variables works around a conda bug
     # https://github.com/conda/conda/issues/6576
     # NB: Pass on PATH and LD_LIBRARY_PATH to sudo invocation
     # NB: This must be run from a directory that jenkins has access to,
@@ -39,9 +40,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   as_jenkins ./"${CONDA_FILE}" -b -f -p "/opt/conda"
   popd
 
-  # NB: Don't do this, rely on the rpath to get it right
-  #echo "/opt/conda/lib" > /etc/ld.so.conf.d/conda-python.conf
-  #ldconfig
+  # NB gh-37737: prefer this to setting rpath
+  echo "/opt/conda/lib" > /etc/ld.so.conf.d/conda-python.conf
+  ldconfig
   sed -e 's|PATH="\(.*\)"|PATH="/opt/conda/bin:\1"|g' -i /etc/environment
   export PATH="/opt/conda/bin:$PATH"
 

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -157,6 +157,28 @@ if [[ "$BUILD_ENVIRONMENT" == *pytorch-xla-linux-bionic* ]] || \
     conda install -q -y cmake
   fi
 fi
+if which conda; then
+  # MKL is provided via conda. Usually, users will activate their conda
+  # environment before building a project, which will add LDFLAGS
+  # (and much more). Without LDFLAGS, we get
+  # "not found (try using -rpath or -rpath-link)"
+  # errors when looking for MKL libraries while linking
+  # Without the ldconfig conda-provided libs are not found at runtime
+  if [[ "$BUILD_ENVIRONMENT" != *pytorch-win-* ]]; then
+    CONDA_LIBS=${CONDA_PREFIX:-"$(dirname $(dirname $(which conda)))/lib"}
+    export LDFLAGS="-Wl,-rpath-link=${CONDA_LIBS}"
+    # TODO: once the new docker images in this PR (PR 37737) are created, this is
+    # redundant (it should be part of .circleci/docker/common/install_conda.sh)
+    if [ -e /etc/ld.so.conf.d/conda-python.conf ]; then
+      echo Now safe to remove this temporary fix from .jenkins/pytorch/commmon.sh
+    else
+      echo Temporarily adding "${CONDA_LIBS}" to ldconfig
+      sudo sh -c "echo ${CONDA_LIBS} > /etc/ld.so.conf.d/conda-python.conf"
+      sudo ldconfig
+    fi
+  fi
+  unset CONDA_LIBS
+fi
 
 function pip_install() {
   # retry 3 times

--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -20,6 +20,12 @@ if [ ! -d "${WORKSPACE_DIR}/miniconda3" ]; then
 fi
 export PATH="${WORKSPACE_DIR}/miniconda3/bin:$PATH"
 source ${WORKSPACE_DIR}/miniconda3/bin/activate
+# While usually setting DYLD_FALLBACK_LIBRARY_PATH would be considered bad practice,
+# here we are using it to connect locally available shared objects to the
+# wheel-installed environment. When the package is distributed to an end-user,
+# the rpath directives will replace this.
+export DYLD_FALLBACK_LIBRARY_PATH="${CONDA_PREFIX}/lib:$DYLD_FALLBACK_LIBRARY_PATH"
+
 retry conda install -y mkl mkl-include numpy pyyaml=5.3 setuptools=46.0.0 cmake cffi ninja
 
 # The torch.hub tests make requests to GitHub.

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -11,9 +11,6 @@ set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 # Don't use the install-rpath during the build phase
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH "${_rpath_portable_origin}")
-# Automatically add all linked folders that are NOT in the build directory to
-# the rpath (per library?)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
  # UBSAN triggers when compiling protobuf, so we need to disable it.
 set(UBSAN_FLAG "-fsanitize=undefined")

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1,10 +1,12 @@
+import copy
 import sys
 import io
 import inspect
 import math
+import os
 import random
 import re
-import copy
+import subprocess
 import torch
 import torch.cuda
 import torch.backends.cuda
@@ -18132,6 +18134,28 @@ class TestTorchMathOps(TestCase):
 
 class TestTorch(TestCase, _TestTorchMixin):
     exact_dtype = True
+
+class TestRPATH(TestCase):
+    @unittest.skipIf(not sys.platform.startswith('linux'), "linux-only test")
+    def test_rpath(self):
+        """
+        Make sure RPATH (or RUNPATH) in nvrtc does not contain a cuda path
+        issue gh-35418
+        """
+        libdir = os.path.join(os.path.dirname(torch._C.__file__), 'lib')
+        caffe2_nvrtc = os.path.join(libdir, 'libcaffe2_nvrtc.so')
+        output = subprocess.check_output(['objdump', '-x', caffe2_nvrtc])
+        nRPATHfound = 0
+        for line in output.split(b'\n'):
+            if b'RPATH' in line or b'RUNPATH' in line:
+                # If CMake adds a path, it will be after $ORIGIN
+                # The before-$origin paths are ones added via -L linkpaths
+                # in $CFLAGS
+                segments = line.split(b'$ORIGIN')
+                if len(segments) > 1:
+                    self.assertFalse(b'cuda' in segments[-1])
+                nRPATHfound += 1
+        self.assertNotEqual(nRPATHfound, 0)
 
 
 # Generates tests

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -18144,18 +18144,19 @@ class TestRPATH(TestCase):
         """
         libdir = os.path.join(os.path.dirname(torch._C.__file__), 'lib')
         caffe2_nvrtc = os.path.join(libdir, 'libcaffe2_nvrtc.so')
-        output = subprocess.check_output(['objdump', '-x', caffe2_nvrtc])
-        nRPATHfound = 0
-        for line in output.split(b'\n'):
-            if b'RPATH' in line or b'RUNPATH' in line:
-                # If CMake adds a path, it will be after $ORIGIN
-                # The before-$origin paths are ones added via -L linkpaths
-                # in $CFLAGS
-                segments = line.split(b'$ORIGIN')
-                if len(segments) > 1:
-                    self.assertFalse(b'cuda' in segments[-1])
-                nRPATHfound += 1
-        self.assertNotEqual(nRPATHfound, 0)
+        if os.path.exists(caffe2_nvrtc):
+            output = subprocess.check_output(['objdump', '-x', caffe2_nvrtc])
+            nRPATHfound = 0
+            for line in output.split(b'\n'):
+                if b'RPATH' in line or b'RUNPATH' in line:
+                    # If CMake adds a path, it will be after $ORIGIN
+                    # The before-$origin paths are ones added via -L linkpaths
+                    # in $CFLAGS
+                    segments = line.split(b'$ORIGIN')
+                    if len(segments) > 1:
+                        self.assertFalse(b'cuda' in segments[-1])
+                    nRPATHfound += 1
+            self.assertNotEqual(nRPATHfound, 0)
 
 
 # Generates tests


### PR DESCRIPTION
Closes gh-35418, 

PR gh-16414 added [the `CMAKE_INSTALL_RPATH_USE_LINK_PATH`directive](https://github.com/pytorch/pytorch/pull/16414/files#diff-dcf5891602b4162c36c2125c806639c5R16) which is non-standard and will cause CMake to write an `RPATH` entry for libraries outside the current build. Removing it leaves an RPATH entry for `$ORIGIN` but removes the entries for things like `/usr/local/cuda-10.2/lib64/stubs:/usr/local/cuda-10.2/lib64` for `libcaffe2_nvrtc.so` on linux. 

The added test fails before this PR, passes after. It is equivalent to checking `objdump -p torch/lib/libcaffe2_nvrtc.so | grep RPATH` for an external path to the directory where cuda "lives"

I am not sure if it solve the `@rpath/libc++.1.dylib` problem for `_C.cpython-37m-darwin.so` on macOS in issue gh-36941