### PR TITLE
Function to get total grad norm of parameters

### DIFF
--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -3,7 +3,7 @@ import torch
 from torch._six import inf
 
 
-def clip_grad_and_get_total_norm(parameters, max_norm=None, norm_type=2):
+def clip_grad_and_get_total_norm_(parameters, max_norm=None, norm_type=2):
     r"""Gets the total gradient norm of an iterable of parameters.
     If `max_norm` is provided, clips the gradient norm of the parameters.
 
@@ -40,6 +40,7 @@ def clip_grad_and_get_total_norm(parameters, max_norm=None, norm_type=2):
                 p.grad.detach().mul_(clip_coef)
     return total_norm
 
+
 def clip_grad_norm_(parameters, max_norm, norm_type=2):
     r"""Clips gradient norm of an iterable of parameters.
 
@@ -56,10 +57,11 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2):
     Returns:
         Total norm of the parameters (viewed as a single vector).
     """
-    return clip_grad_and_get_total_norm(parameters, max_norm, norm_type)
+    return clip_grad_and_get_total_norm_(parameters, max_norm=max_norm, norm_type=norm_type)
 
-def get_total_grad_norm(parameters, norm_type=2):
-    r"""Get the total gradient norm of an iterable of parameters.
+
+def total_grad_norm(parameters, norm_type=2):
+    r"""Gets the total gradient norm of an iterable of parameters.
 
     The norm is computed over all gradients together, as if they were
     concatenated into a single vector.
@@ -73,7 +75,7 @@ def get_total_grad_norm(parameters, norm_type=2):
     Returns:
         Total norm of the parameters (viewed as a single vector).
     """
-    return clip_grad_and_get_total_norm(parameters, None, norm_type)
+    return clip_grad_and_get_total_norm_(parameters, norm_type=norm_type)
 
 
 def clip_grad_norm(parameters, max_norm, norm_type=2):

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -3,6 +3,43 @@ import torch
 from torch._six import inf
 
 
+def clip_grad_and_get_total_norm(parameters, max_norm=None, norm_type=2):
+    r"""Gets the total gradient norm of an iterable of parameters.
+    If `max_norm` is provided, clips the gradient norm of the parameters.
+
+    The norm is computed over all gradients together, as if they were
+    concatenated into a single vector.
+    If `max_norm` is provided, gradients are modified in-place.
+
+    Arguments:
+        parameters (Iterable[Tensor] or Tensor): an iterable of Tensors or a
+            single Tensor that will have gradients normalized
+        max_norm (float or int): max norm of the gradients
+            If provided, clips the gradients at this value
+        norm_type (float or int): type of the used p-norm. Can be ``'inf'`` for
+            infinity norm.
+
+    Returns:
+        Total norm of the parameters (viewed as a single vector).
+    """
+    if torch.is_tensor(parameters):
+        parameters = [parameters]
+    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    norm_type = float(norm_type)
+    if norm_type == inf:
+        total_norm = max(p.grad.detach().abs().max() for p in parameters)
+    else:
+        total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(), norm_type) for p in parameters]), norm_type)
+
+    # Clip gradients if required
+    if max_norm is not None:
+        max_norm = float(max_norm)
+        clip_coef = max_norm / (total_norm + 1e-6)
+        if clip_coef < 1:
+            for p in parameters:
+                p.grad.detach().mul_(clip_coef)
+    return total_norm
+
 def clip_grad_norm_(parameters, max_norm, norm_type=2):
     r"""Clips gradient norm of an iterable of parameters.
 
@@ -19,20 +56,24 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2):
     Returns:
         Total norm of the parameters (viewed as a single vector).
     """
-    if isinstance(parameters, torch.Tensor):
-        parameters = [parameters]
-    parameters = list(filter(lambda p: p.grad is not None, parameters))
-    max_norm = float(max_norm)
-    norm_type = float(norm_type)
-    if norm_type == inf:
-        total_norm = max(p.grad.detach().abs().max() for p in parameters)
-    else:
-        total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(), norm_type) for p in parameters]), norm_type)
-    clip_coef = max_norm / (total_norm + 1e-6)
-    if clip_coef < 1:
-        for p in parameters:
-            p.grad.detach().mul_(clip_coef)
-    return total_norm
+    return clip_grad_and_get_total_norm(parameters, max_norm, norm_type)
+
+def get_total_grad_norm(parameters, norm_type=2):
+    r"""Get the total gradient norm of an iterable of parameters.
+
+    The norm is computed over all gradients together, as if they were
+    concatenated into a single vector.
+
+    Arguments:
+        parameters (Iterable[Tensor] or Tensor): an iterable of Tensors or a
+            single Tensor that will have gradients normalized
+        norm_type (float or int): type of the used p-norm. Can be ``'inf'`` for
+            infinity norm.
+
+    Returns:
+        Total norm of the parameters (viewed as a single vector).
+    """
+    return clip_grad_and_get_total_norm(parameters, None, norm_type)
 
 
 def clip_grad_norm(parameters, max_norm, norm_type=2):
@@ -59,7 +100,7 @@ def clip_grad_value_(parameters, clip_value):
             The gradients are clipped in the range
             :math:`\left[\text{-clip\_value}, \text{clip\_value}\right]`
     """
-    if isinstance(parameters, torch.Tensor):
+    if torch.is_tensor(parameters):
         parameters = [parameters]
     clip_value = float(clip_value)
     for p in filter(lambda p: p.grad is not None, parameters):

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -5,11 +5,10 @@ from torch._six import inf
 
 def clip_grad_and_get_total_norm_(parameters, max_norm=None, norm_type=2):
     r"""Gets the total gradient norm of an iterable of parameters.
-    If `max_norm` is provided, clips the gradient norm of the parameters.
+    If ``max_norm`` is provided, clips the gradient norm of the parameters in-place.
 
     The norm is computed over all gradients together, as if they were
     concatenated into a single vector.
-    If `max_norm` is provided, gradients are modified in-place.
 
     Arguments:
         parameters (Iterable[Tensor] or Tensor): an iterable of Tensors or a

--- a/torch/nn/utils/clip_grad.pyi
+++ b/torch/nn/utils/clip_grad.pyi
@@ -4,7 +4,13 @@ from ... import Tensor
 _tensor_or_tensors = Union[Tensor, Iterable[Tensor]]
 
 
+def clip_grad_and_get_total_norm_(parameters: _tensor_or_tensors, max_norm: float, norm_type: float = ...): ...
+
+
 def clip_grad_norm_(parameters: _tensor_or_tensors, max_norm: float, norm_type: float = ...): ...
+
+
+def total_grad_norm(parameters: _tensor_or_tensors, norm_type: float = ...): ...
 
 
 def clip_grad_value_(parameters: _tensor_or_tensors, clip_value: float): ...


### PR DESCRIPTION
Currently, there's no inbuilt function for getting _just_ the Frobenius norm of the parameter gradients. `torch.nn.utils.clip_grad_norm_` returns the desired value, but (obviously) simultaneously clips the gradients in-place.

This PR creates a generic function `clip_grad_and_get_total_norm_` for getting the norm, and optionally clipping the gradients if param `max_norm` is provided. Using this function, `torch.nn.utils.clip_grad_norm_` would effectively remain unchanged, and an additional function `total_grad_norm()` is created, which simply returns the desired norm.