### PR TITLE
Permit registration of multiple triggers, but insert warning

### DIFF
--- a/torch/csrc/jit/tensorexpr/execution_counter.h
+++ b/torch/csrc/jit/tensorexpr/execution_counter.h
@@ -66,7 +66,7 @@ class ExecutionTriggerList {
   void AddTrigger(const std::string& name, ExecutionTrigger* trigger) {
     auto insert_ret = trigger_list_.insert(std::make_pair(name, trigger));
     if (!insert_ret.second) {
-      throw std::runtime_error("Duplicated trigger name: " + name);
+      std::cerr << "Warning: duplicated trigger name: " << name << "\n";
     }
   }
 


### PR DESCRIPTION
If linking the same file multiple times, the trigger check becomes severe and crashes execution at startup.