### PR TITLE
Change StorageImpl to track byte count rather than element count (#37028)

### DIFF
--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -298,17 +298,20 @@ std::vector<int64_t> defaultStrides(IntArrayRef sizes) {
   return strides;
 }
 
-int64_t computeStorageSize(IntArrayRef sizes, IntArrayRef strides) {
+size_t computeStorageNbytes(
+    IntArrayRef sizes,
+    IntArrayRef strides,
+    size_t itemsize_bytes) {
   // size of the underlying storage is 1 bigger than the offset
   // of the last element according to stride
-  int64_t size = 1;
+  size_t size = 1;
   for(size_t i = 0; i < sizes.size(); i++) {
     if(sizes[i] == 0) {
       return 0;
     }
     size += strides[i]*(sizes[i]-1);
   }
-  return size;
+  return size * itemsize_bytes;
 }
 
 // On a high level,

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -144,7 +144,8 @@ CAFFE2_API void check_dim_size(
 
 namespace detail {
 CAFFE2_API std::vector<int64_t> defaultStrides(IntArrayRef sizes);
-CAFFE2_API int64_t computeStorageSize(IntArrayRef sizes, IntArrayRef strides);
+CAFFE2_API size_t
+computeStorageNbytes(IntArrayRef sizes, IntArrayRef strides, size_t itemsize);
 CAFFE2_API c10::optional<std::vector<int64_t>> computeStride(
     IntArrayRef oldshape,
     IntArrayRef oldstride,

--- a/aten/src/ATen/core/boxing/impl/test_helpers.h
+++ b/aten/src/ATen/core/boxing/impl/test_helpers.h
@@ -17,12 +17,14 @@ inline at::Tensor dummyTensor(c10::DispatchKeySet ks) {
   auto* allocator = c10::GetCPUAllocator();
   int64_t nelements = 1;
   auto dtype = caffe2::TypeMeta::Make<float>();
+  int64_t size_bytes = nelements * dtype.itemsize();
   auto storage_impl = c10::make_intrusive<c10::StorageImpl>(
-    dtype,
-    nelements,
-    allocator->allocate(nelements * dtype.itemsize()),
-    allocator,
-    /*resizable=*/true);
+      c10::StorageImpl::use_byte_size_t(),
+      dtype,
+      size_bytes,
+      allocator->allocate(size_bytes),
+      allocator,
+      /*resizable=*/true);
   return at::detail::make_tensor<c10::TensorImpl>(storage_impl, ks);
 }
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -336,16 +336,16 @@ CHECKED_USE_NULLABLE = CodeTemplate('${arg_name}_ ? ${usage} : NULL')
 
 ALLOC_NOARGS_WRAP = {
     'THTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                 '(c10::Storage(scalarTypeToTypeMeta(${ScalarName}), 0, allocator(), true),'
+                 '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(${ScalarName}), 0, allocator(), true),'
                  'DispatchKey::${Backend}).release()',
     'THByteTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                     '(c10::Storage(scalarTypeToTypeMeta(ScalarType::Byte), 0, allocator(), true),'
+                     '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(ScalarType::Byte), 0, allocator(), true),'
                      'DispatchKey::${Backend}).release()',
     'THBoolTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                     '(c10::Storage(scalarTypeToTypeMeta(ScalarType::Bool), 0, allocator(), true),'
+                     '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(ScalarType::Bool), 0, allocator(), true),'
                      'DispatchKey::${Backend}).release()',
     'THIndexTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                     '(c10::Storage(scalarTypeToTypeMeta(ScalarType::Long), 0, allocator(), true),'
+                     '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(ScalarType::Long), 0, allocator(), true),'
                      'DispatchKey::${Backend}).release()',
 }
 

--- a/aten/src/ATen/native/Memory.cpp
+++ b/aten/src/ATen/native/Memory.cpp
@@ -22,11 +22,12 @@ Tensor pin_memory(const Tensor& self) {
   }
   auto* allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();
   auto storage = Storage(
+      Storage::use_byte_size_t(),
       self.dtype(),
-      detail::computeStorageSize(self.sizes(), self.strides()),
+      detail::computeStorageNbytes(
+          self.sizes(), self.strides(), self.dtype().itemsize()),
       allocator,
-      /*resizable=*/false
-  );
+      /*resizable=*/false);
   auto tensor = at::empty({0}, self.options()).set_(storage, 0, self.sizes(), self.strides());
   tensor.copy_(self);
   return tensor;

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -19,10 +19,10 @@ static inline void maybe_resize_storage_cpu(TensorImpl* self, int64_t new_size) 
     if (!THTensor_getStoragePtr(self)) {
       THTensor_stealAndSetStoragePtr(self, THStorage_new(self->dtype()));
     }
-    if (new_size + self->storage_offset() > self->storage().numel()) {
-      THStorage_resize(
-          THTensor_getStoragePtr(self),
-          new_size + self->storage_offset());
+    int64_t new_size_bytes =
+        (new_size + self->storage_offset()) * self->dtype().itemsize();
+    if (new_size_bytes > self->storage().nbytes()) {
+      THStorage_resizeBytes(THTensor_getStoragePtr(self), new_size_bytes);
     }
   }
 }
@@ -61,19 +61,31 @@ static inline void checkInBoundsForStorage(
     IntArrayRef size,
     IntArrayRef stride,
     int64_t storage_offset,
+    const caffe2::TypeMeta& data_type,
     const Storage& new_storage) {
-  int64_t storage_size = detail::computeStorageSize(size, stride);
-  if (storage_size == 0) {
+  int64_t storage_size_bytes =
+      detail::computeStorageNbytes(size, stride, data_type.itemsize());
+  int64_t storage_offset_bytes = storage_offset * data_type.itemsize();
+  if (storage_size_bytes == 0) {
     // NB: (a tensor with arbitrary 0 dims)'s storage can have any numel.
     return;
   }
-  int64_t new_storage_size = new_storage.numel();
+  int64_t new_storage_size_bytes = new_storage.nbytes();
   TORCH_CHECK(
-      storage_offset + storage_size <= new_storage_size,
-      "setStorage: sizes ", size, ", strides ", stride, ","
-      " and storage offset ", storage_offset,
-      " requiring a storage size of ", storage_size + storage_offset,
-      " are out of bounds for storage with numel ", new_storage_size);
+      storage_size_bytes + storage_offset_bytes <= new_storage_size_bytes,
+      "setStorage: sizes ",
+      size,
+      ", strides ",
+      stride,
+      ","
+      " storage offset ",
+      storage_offset,
+      ", and itemsize ",
+      data_type.itemsize(),
+      " requiring a storage size of ",
+      storage_size_bytes,
+      " are out of bounds for storage of size ",
+      new_storage_size_bytes);
 }
 
 static inline void checkSetStorage(Tensor& result, Storage storage, int64_t storage_offset,
@@ -124,7 +136,8 @@ inline void setStrided(
     IntArrayRef stride,
     int64_t storage_offset) {
   auto* self_ = self.unsafeGetTensorImpl();
-  checkInBoundsForStorage(size, stride, storage_offset, self_->storage());
+  checkInBoundsForStorage(
+      size, stride, storage_offset, self_->dtype(), self_->storage());
 
   /* storage offset */
   TORCH_CHECK(storage_offset >= 0, "Tensor: invalid storage offset ", storage_offset);

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -119,12 +119,14 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options_, c10::optional<
 
   int64_t nelements = prod_intlist(size);
   auto dtype = options.dtype();
+  int64_t size_bytes = nelements * dtype.itemsize();
   auto storage_impl = c10::make_intrusive<StorageImpl>(
-    dtype,
-    nelements,
-    allocator->allocate(nelements * dtype.itemsize()),
-    allocator,
-    /*resizeable=*/true);
+      c10::StorageImpl::use_byte_size_t(),
+      dtype,
+      size_bytes,
+      allocator->allocate(size_bytes),
+      allocator,
+      /*resizeable=*/true);
 
   auto tensor = detail::make_tensor<TensorImpl>(std::move(storage_impl), at::DispatchKey::CPU);
   // Default TensorImpl has size [0]
@@ -976,18 +978,20 @@ AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 
 Tensor from_file(std::string filename, c10::optional<bool> shared, c10::optional<int64_t> size, const TensorOptions& options) {
     TORCH_CHECK(!options.pinned_memory(), "tensors constructed from a file cannot be pinned");
-    size_t my_size = size.value_or(0);
+    int64_t my_size = size.value_or(0);
     int flags = shared.value_or(false) ? TH_ALLOCATOR_MAPPED_SHARED : 0;
     auto dtype = options.dtype();
+    size_t size_bytes = my_size * dtype.itemsize();
     auto storage_impl = c10::make_intrusive<at::StorageImpl>(
-      dtype,
-      my_size,
-      THMapAllocator::makeDataPtr(
-          filename.c_str(), flags, my_size * dtype.itemsize(), nullptr),
-      /*allocator=*/nullptr,
-      /*resizable=*/false);
+        c10::StorageImpl::use_byte_size_t(),
+        dtype,
+        size_bytes,
+        THMapAllocator::makeDataPtr(
+            filename.c_str(), flags, size_bytes, nullptr),
+        /*allocator=*/nullptr,
+        /*resizable=*/false);
     auto tensor = detail::make_tensor<at::TensorImpl>(storage_impl, at::DispatchKey::CPU);
-    tensor.unsafeGetTensorImpl()->set_sizes_contiguous({storage_impl->numel()});
+    tensor.unsafeGetTensorImpl()->set_sizes_contiguous({my_size});
     return tensor;
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -39,7 +39,9 @@ Tensor _shape_as_tensor(const Tensor& self) {
 }
 
 Tensor& set_(Tensor& result, Storage source) {
-  return result.set_(source, 0, static_cast<int64_t>(source.size()), {});
+  int64_t new_size =
+      static_cast<int64_t>(source.nbytes() / result.dtype().itemsize());
+  return result.set_(source, 0, new_size, {});
 }
 
 // unify with cuda implementation?  This is not done to avoid a dispatch in resize_impl_cpu_
@@ -64,7 +66,12 @@ Tensor& set_tensor_(Tensor& result, const Tensor& source) {
 // way of getting the allocator to use for a device (c10::GetAllocator is not
 // the same as at::cuda::getCUDADeviceAllocator().
 Tensor& set_cpu_(Tensor& result) {
-  Storage storage(result.dtype(), 0, c10::GetAllocator(kCPU), true);
+  Storage storage(
+      Storage::use_byte_size_t(),
+      result.dtype(),
+      0,
+      c10::GetAllocator(kCPU),
+      true);
   return result.set_(storage, 0, {0}, {});
 }
 

--- a/aten/src/ATen/native/cuda/MiscUtils.h
+++ b/aten/src/ATen/native/cuda/MiscUtils.h
@@ -80,11 +80,11 @@ static inline Storage pin_memory(int64_t size) {
   auto* allocator = cuda::getPinnedMemoryAllocator();
   int64_t adjusted_size = size * sizeof(T);
   return Storage(
+      Storage::use_byte_size_t(),
       caffe2::TypeMeta::Make<uint8_t>(),
       adjusted_size,
       allocator,
-      /*resizable=*/false
-  );
+      /*resizable=*/false);
 }
 
 } // namespace native

--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -21,11 +21,13 @@ static inline void maybe_resize_storage_cuda(TensorImpl* self, int64_t new_size)
     if (!THTensor_getStoragePtr(self)) {
       AT_ERROR("Tensor: invalid null storage");
     }
-    if (new_size + self->storage_offset() > self->storage().numel()) {
-      THCStorage_resize(
+    uint64_t new_size_bytes = (new_size + self->storage_offset()) * self->dtype().itemsize();
+    if (new_size_bytes > self->storage().nbytes()) {
+      THCStorage_resizeBytes(
           globalContext().getTHCState(),
           THTensor_getStoragePtr(self),
-          new_size + self->storage_offset());
+          new_size_bytes
+      );
     }
   }
 }

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -52,12 +52,14 @@ Tensor empty_cuda(IntArrayRef size, const TensorOptions& options, c10::optional<
   auto* allocator = at::cuda::getCUDADeviceAllocator();
   int64_t nelements = prod_intlist(size);
   auto dtype = options.dtype();
+  int64_t size_bytes = nelements * dtype.itemsize();
   auto storage_impl = c10::make_intrusive<StorageImpl>(
-    dtype,
-    nelements,
-    allocator->allocate(nelements * dtype.itemsize()),
-    allocator,
-    /*resizeable=*/true);
+      c10::StorageImpl::use_byte_size_t(),
+      dtype,
+      size_bytes,
+      allocator->allocate(size_bytes),
+      allocator,
+      /*resizeable=*/true);
 
   auto tensor = detail::make_tensor<TensorImpl>(storage_impl, DispatchKey::CUDA);
   // Default TensorImpl has size [0]

--- a/aten/src/ATen/native/cuda/TensorShapeCUDA.cpp
+++ b/aten/src/ATen/native/cuda/TensorShapeCUDA.cpp
@@ -11,7 +11,12 @@ namespace native {
 // way of getting the allocator to use for a device (c10::GetAllocator is not
 // the same as at::cuda::getCUDADeviceAllocator().
 Tensor& set_cuda_(Tensor& result) {
-  Storage storage(result.dtype(), 0, at::cuda::getCUDADeviceAllocator(), true);
+  Storage storage(
+      Storage::use_byte_size_t(),
+      result.dtype(),
+      0,
+      at::cuda::getCUDADeviceAllocator(),
+      true);
   return result.set_(storage, 0, {0}, {});
 }
 

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -109,10 +109,12 @@ Tensor MakeStridedQTensorCPU(
   TORCH_CHECK(
       isQIntType(typeMetaToScalarType(dtype)),
       "ScalarType is not supported in new_qtensor_cpu.");
+  int64_t size_bytes = nelements * dtype.itemsize();
   auto storage = c10::make_intrusive<StorageImpl>(
+      StorageImpl::use_byte_size_t(),
       dtype,
-      nelements,
-      allocator->allocate(nelements * dtype.itemsize()),
+      size_bytes,
+      allocator->allocate(size_bytes),
       allocator,
       /* resizable = */ true);
   auto tensor = detail::make_tensor<QTensorImpl>(

--- a/aten/src/ATen/native/xnnpack/Factory.cpp
+++ b/aten/src/ATen/native/xnnpack/Factory.cpp
@@ -16,17 +16,18 @@ Tensor empty_with_tail_padding(
     const DimnameList maybe_names) {
   auto* const allocator_ptr = c10::GetDefaultMobileCPUAllocator();
   const int64_t nelements = prod_intlist(size);
+  size_t size_bytes = nelements * dtype.itemsize();
 
-  Tensor tensor(
-      c10::make_intrusive<c10::TensorImpl>(
-          c10::Storage{
-              dtype,
-              nelements,
-              allocator_ptr->allocate(nelements * dtype.itemsize()),
-              allocator_ptr,
-              /*resizable=*/true,
-          },
-          DispatchKeySet{DispatchKey::CPU}));
+  Tensor tensor(c10::make_intrusive<c10::TensorImpl>(
+      c10::Storage{
+          c10::Storage::use_byte_size_t(),
+          dtype,
+          size_bytes,
+          allocator_ptr->allocate(size_bytes),
+          allocator_ptr,
+          /*resizable=*/true,
+      },
+      DispatchKeySet{DispatchKey::CPU}));
 
   return namedinference::propagate_names_if_nonempty(
       tensor.resize_(size, memory_format),

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -81,10 +81,12 @@ inline Tensor new_qtensor(
   TORCH_CHECK(
       isQIntType(typeMetaToScalarType(dtype)),
       "ScalarType is not supported in new_qtensor.");
+  int64_t size_bytes = nelements * dtype.itemsize();
   auto storage = c10::make_intrusive<StorageImpl>(
+      StorageImpl::use_byte_size_t(),
       dtype,
-      nelements,
-      allocator->allocate(nelements * dtype.itemsize()),
+      size_bytes,
+      allocator->allocate(size_bytes),
       allocator,
       /*resizable=*/true);
   auto tensor = detail::make_tensor<QTensorImpl>(

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -36,10 +36,10 @@ inline Tensor from_blob(
         " does not match device of data ", device);
   }
   auto storage = Storage(
+      Storage::use_byte_size_t(),
       options.dtype(),
-      detail::computeStorageSize(sizes, strides),
-      InefficientStdFunctionContext::makeDataPtr(
-          data, deleter, device),
+      detail::computeStorageNbytes(sizes, strides, options.dtype().itemsize()),
+      InefficientStdFunctionContext::makeDataPtr(data, deleter, device),
       /*allocator=*/nullptr,
       /*resizable=*/false);
   return empty({0}, options).set_(storage, 0, sizes, strides);
@@ -67,8 +67,9 @@ inline Tensor from_blob(
         " does not match device of data ", device);
   }
   auto storage = Storage(
+      Storage::use_byte_size_t(),
       options.dtype(),
-      detail::computeStorageSize(sizes, strides),
+      detail::computeStorageNbytes(sizes, strides, options.dtype().itemsize()),
       DataPtr(data, nullptr, [](void*) {}, device),
       /*allocator=*/nullptr,
       /*resizable=*/false);

--- a/aten/src/ATen/test/extension_backend_test.cpp
+++ b/aten/src/ATen/test/extension_backend_test.cpp
@@ -14,7 +14,12 @@ Tensor empty_override(IntArrayRef size, const TensorOptions & options, c10::opti
   test_int = 1;
   auto tensor_impl = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
       Storage(
-          caffe2::TypeMeta::Make<float>(), 0, at::DataPtr(nullptr, Device(DeviceType::MSNPU, 1)), nullptr, false),
+          Storage::use_byte_size_t(),
+          caffe2::TypeMeta::Make<float>(),
+          0,
+          at::DataPtr(nullptr, Device(DeviceType::MSNPU, 1)),
+          nullptr,
+          false),
       DispatchKey::MSNPU);
   return Tensor(std::move(tensor_impl));
 }

--- a/aten/src/TH/THFile.cpp
+++ b/aten/src/TH/THFile.cpp
@@ -137,15 +137,19 @@ IMPLEMENT_THFILE_SCALAR(Float, float)
 IMPLEMENT_THFILE_SCALAR(Double, double)
 IMPLEMENT_THFILE_SCALAR(Half, THHalf)
 
-#define IMPLEMENT_THFILE_STORAGE(TYPEC, TYPE)                           \
-  size_t THFile_read##TYPEC(THFile *self, TH##TYPEC##Storage *storage)    \
-  {                                                                     \
-    return THFile_read##TYPEC##Raw(self, TH##TYPEC##Storage_data(storage), storage->numel()); \
-  }                                                                     \
-                                                                        \
-  size_t THFile_write##TYPEC(THFile *self, TH##TYPEC##Storage *storage)   \
-  {                                                                     \
-    return THFile_write##TYPEC##Raw(self, TH##TYPEC##Storage_data(storage), storage->numel()); \
+#define IMPLEMENT_THFILE_STORAGE(TYPEC, TYPE)                             \
+  size_t THFile_read##TYPEC(THFile* self, TH##TYPEC##Storage* storage) {  \
+    return THFile_read##TYPEC##Raw(                                       \
+        self,                                                             \
+        TH##TYPEC##Storage_data(storage),                                 \
+        storage->nbytes() / sizeof(TYPE));                                \
+  }                                                                       \
+                                                                          \
+  size_t THFile_write##TYPEC(THFile* self, TH##TYPEC##Storage* storage) { \
+    return THFile_write##TYPEC##Raw(                                      \
+        self,                                                             \
+        TH##TYPEC##Storage_data(storage),                                 \
+        storage->nbytes() / sizeof(TYPE));                                \
   }
 
 IMPLEMENT_THFILE_STORAGE(Byte, uint8_t)

--- a/aten/src/TH/THStorageFunctions.hpp
+++ b/aten/src/TH/THStorageFunctions.hpp
@@ -32,7 +32,6 @@
 //
 
 TH_CPP_API THStorage* THStorage_new(caffe2::TypeMeta data_type);
-TH_API ptrdiff_t THStorage_size(const THStorage *self);
 
 TH_API void THStorage_retain(THStorage *storage);
-TH_API void THStorage_resize(THStorage *storage, ptrdiff_t size);
+TH_API void THStorage_resizeBytes(THStorage* storage, ptrdiff_t size_bytes);

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -13,11 +13,6 @@ scalar_t* THStorage_(data)(const THStorage *self)
 #endif
 }
 
-ptrdiff_t THStorage_(size)(const THStorage *self)
-{
-  return THStorage_size(self);
-}
-
 size_t THStorage_(elementSize)()
 {
   return sizeof(scalar_t);
@@ -35,14 +30,17 @@ THStorage* THStorage_(new)(void)
 THStorage* THStorage_(newWithSize)(ptrdiff_t size)
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
+                           c10::StorageImpl::use_byte_size_t(),
 #ifdef THQUANTIZED
-      caffe2::TypeMeta::Make<quantized_t>(),
+                           caffe2::TypeMeta::Make<quantized_t>(),
+                           size * sizeof(quantized_t),
 #else
-      caffe2::TypeMeta::Make<scalar_t>(),
+                           caffe2::TypeMeta::Make<scalar_t>(),
+                           size * sizeof(scalar_t),
 #endif
-      size,
-      getTHDefaultAllocator(),
-      true).release();
+                           getTHDefaultAllocator(),
+                           true)
+                           .release();
   return storage;
 }
 
@@ -50,14 +48,17 @@ THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
                                         at::Allocator *allocator)
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
+                           c10::StorageImpl::use_byte_size_t(),
 #ifdef THQUANTIZED
-      caffe2::TypeMeta::Make<quantized_t>(),
+                           caffe2::TypeMeta::Make<quantized_t>(),
+                           size * sizeof(quantized_t),
 #else
-      caffe2::TypeMeta::Make<scalar_t>(),
+                           caffe2::TypeMeta::Make<scalar_t>(),
+                           size * sizeof(scalar_t),
 #endif
-      size,
-      allocator,
-      true).release();
+                           allocator,
+                           true)
+                           .release();
   return storage;
 }
 
@@ -66,16 +67,19 @@ THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t size, int 
 {
   auto type_meta = caffe2::TypeMeta::Make<scalar_t>();
   size_t actual_size = -1;
-  THStorage* storage = c10::make_intrusive<at::StorageImpl>(
-      type_meta,
-      size,
-      THMapAllocator::makeDataPtr(
-          filename, flags, size * type_meta.itemsize(), &actual_size),
-      /* allocator */ nullptr,
-      false).release();
+  THStorage* storage =
+      c10::make_intrusive<at::StorageImpl>(
+          c10::StorageImpl::use_byte_size_t(),
+          type_meta,
+          size * type_meta.itemsize(),
+          THMapAllocator::makeDataPtr(
+              filename, flags, size * type_meta.itemsize(), &actual_size),
+          /* allocator */ nullptr,
+          false)
+          .release();
 
   if (size <= 0) {
-    storage->set_numel(actual_size / type_meta.itemsize());
+    storage->set_nbytes(actual_size);
   }
 
   return storage;
@@ -102,39 +106,47 @@ void THStorage_(free)(THStorage *storage)
 THStorage* THStorage_(newWithDataAndAllocator)(at::DataPtr&& data, ptrdiff_t size,
                                                at::Allocator* allocator) {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
+                           c10::StorageImpl::use_byte_size_t(),
 #ifdef THQUANTIZED
-      caffe2::TypeMeta::Make<quantized_t>(),
+                           caffe2::TypeMeta::Make<quantized_t>(),
+                           size * sizeof(quantized_t),
 #else
-      caffe2::TypeMeta::Make<scalar_t>(),
+                           caffe2::TypeMeta::Make<scalar_t>(),
+                           size * sizeof(scalar_t),
 #endif
-      size,
-      std::move(data),
-      allocator,
-      allocator != nullptr).release();
+                           std::move(data),
+                           allocator,
+                           allocator != nullptr)
+                           .release();
   return storage;
 }
 
-void THStorage_(resize)(THStorage *storage, ptrdiff_t size)
-{
-  return THStorage_resize(storage, size);
+void THStorage_(resizeBytes)(THStorage* storage, ptrdiff_t size_bytes) {
+  return THStorage_resizeBytes(storage, size_bytes);
 }
 
 void THStorage_(fill)(THStorage *storage, scalar_t value)
 {
   ptrdiff_t i;
-  for(i = 0; i < storage->numel(); i++)
+  auto type_meta = caffe2::TypeMeta::Make<scalar_t>();
+  size_t numel = storage->nbytes() / type_meta.itemsize();
+  for (i = 0; i < numel; i++)
     THStorage_(data)(storage)[i] = value;
 }
 
 void THStorage_(set)(THStorage *self, ptrdiff_t idx, scalar_t value)
 {
-  THArgCheck((idx >= 0) && (idx < self->numel()), 2, "out of bounds");
+  auto type_meta = caffe2::TypeMeta::Make<scalar_t>();
+  size_t numel = self->nbytes() / type_meta.itemsize();
+  THArgCheck((idx >= 0) && (idx < numel), 2, "out of bounds");
   THStorage_(data)(self)[idx] = value;
 }
 
 scalar_t THStorage_(get)(const THStorage *self, ptrdiff_t idx)
 {
-  THArgCheck((idx >= 0) && (idx < self->numel()), 2, "out of bounds");
+  auto type_meta = caffe2::TypeMeta::Make<scalar_t>();
+  size_t numel = self->nbytes() / type_meta.itemsize();
+  THArgCheck((idx >= 0) && (idx < numel), 2, "out of bounds");
   return THStorage_(data)(self)[idx];
 }
 

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -42,7 +42,6 @@
 #define THComplexDoubleStorage THStorage
 
 TH_API scalar_t* THStorage_(data)(const THStorage*);
-TH_API ptrdiff_t THStorage_(size)(const THStorage*);
 TH_API size_t THStorage_(elementSize)(void);
 
 /* slow access -- checks everything */
@@ -67,7 +66,7 @@ TH_API void THStorage_(swap)(THStorage *storage1, THStorage *storage2);
 
 /* might differ with other API (like CUDA) */
 TH_API void THStorage_(free)(THStorage *storage);
-TH_API void THStorage_(resize)(THStorage *storage, ptrdiff_t size);
+TH_API void THStorage_(resizeBytes)(THStorage* storage, ptrdiff_t size_bytes);
 TH_API void THStorage_(fill)(THStorage *storage, scalar_t value);
 
 #endif

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -19,9 +19,11 @@
 
 #include <c10/util/intrusive_ptr.h>
 
-void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
-{
-  THArgCheck(size >= 0, 2, "invalid size");
+void THCStorage_resizeBytes(
+    THCState* state,
+    THCStorage* self,
+    ptrdiff_t size_bytes) {
+  THArgCheck(size_bytes >= 0, 2, "invalid size");
   THAssert(self->allocator() != nullptr);
   int device;
   THCudaCheck(cudaGetDevice(&device));
@@ -29,32 +31,27 @@ void THCStorage_resize(THCState *state, THCStorage *self, ptrdiff_t size)
   if (!self->resizable())
     THError("Trying to resize storage that is not resizable");
 
-  size_t itemsize = self->itemsize();
-
-  if(size == 0)
-  {
+  if (size_bytes == 0) {
     self->set_data_ptr(at::DataPtr(nullptr, at::Device(at::DeviceType::CUDA, device)));
-    self->set_numel(0);
-  }
-  else
-  {
-    at::DataPtr data =
-      self->allocator()->allocate(size * itemsize);
+    self->set_nbytes(0);
+  } else {
+    at::DataPtr data = self->allocator()->allocate(size_bytes);
 
     if (self->data_ptr()) {
       // Enable p2p access when the memcpy is across devices
       THCState_getPeerToPeerAccess(state, device, THCStorage_getDevice(state, self));
 
-      THCudaCheck(cudaMemcpyAsync(data.get(),
-                                  self->data(),
-                                  THMin(self->numel(), size) * itemsize,
-                                  cudaMemcpyDeviceToDevice,
-                                  c10::cuda::getCurrentCUDAStream()));
+      THCudaCheck(cudaMemcpyAsync(
+          data.get(),
+          self->data(),
+          THMin(self->nbytes(), size_bytes),
+          cudaMemcpyDeviceToDevice,
+          c10::cuda::getCurrentCUDAStream()));
     }
 
     // Destructively overwrite data_ptr
     self->set_data_ptr(std::move(data));
-    self->set_numel(size);
+    self->set_nbytes(size_bytes);
   }
 }
 
@@ -66,9 +63,11 @@ THCStorage* THCStorage_new(
     THCState* state,
     caffe2::TypeMeta data_type) {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
-      data_type,
-      0,
-      c10::cuda::CUDACachingAllocator::get(),
-      true).release();
+                           c10::StorageImpl::use_byte_size_t(),
+                           data_type,
+                           0,
+                           c10::cuda::CUDACachingAllocator::get(),
+                           true)
+                           .release();
   return storage;
 }

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -17,7 +17,10 @@ THC_API THCStorage* THCStorage_new(THCState* state, caffe2::TypeMeta);
 
 THC_API void THCStorage_retain(THCState *state, THCStorage *storage);
 
-THC_API void THCStorage_resize(THCState *state, THCStorage *storage, ptrdiff_t size);
+THC_API void THCStorage_resizeBytes(
+    THCState* state,
+    THCStorage* storage,
+    ptrdiff_t size_bytes);
 THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -14,11 +14,6 @@ scalar_t* THCStorage_(data)(THCState *state, const THCStorage *self)
   return self->data<scalar_t>();
 }
 
-ptrdiff_t THCStorage_(size)(THCState *state, const THCStorage *self)
-{
-  return THStorage_size(self);
-}
-
 int THCStorage_(elementSize)(THCState *state)
 {
   return sizeof(scalar_t);
@@ -26,7 +21,10 @@ int THCStorage_(elementSize)(THCState *state)
 
 void THCStorage_(set)(THCState *state, THCStorage *self, ptrdiff_t index, scalar_t value)
 {
-  THArgCheck((index >= 0) && (index < self->numel()), 2, "index out of bounds");
+  THArgCheck(
+      (index >= 0) && (index < (self->nbytes() / sizeof(scalar_t))),
+      2,
+      "index out of bounds");
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 #if HIP_VERSION >= 301
   THCudaCheck(hipMemcpyWithStream(THCStorage_(data)(state, self) + index, &value, sizeof(scalar_t),
@@ -42,7 +40,10 @@ void THCStorage_(set)(THCState *state, THCStorage *self, ptrdiff_t index, scalar
 
 scalar_t THCStorage_(get)(THCState *state, const THCStorage *self, ptrdiff_t index)
 {
-  THArgCheck((index >= 0) && (index < self->numel()), 2, "index out of bounds");
+  THArgCheck(
+      (index >= 0) && (index < (self->nbytes() / sizeof(scalar_t))),
+      2,
+      "index out of bounds");
   scalar_t value;
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 #if HIP_VERSION >= 301
@@ -59,20 +60,24 @@ scalar_t THCStorage_(get)(THCState *state, const THCStorage *self, ptrdiff_t ind
 THCStorage* THCStorage_(new)(THCState *state)
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
-      caffe2::TypeMeta::Make<scalar_t>(),
-      0,
-      c10::cuda::CUDACachingAllocator::get(),
-      true).release();
+                           c10::StorageImpl::use_byte_size_t(),
+                           caffe2::TypeMeta::Make<scalar_t>(),
+                           0,
+                           c10::cuda::CUDACachingAllocator::get(),
+                           true)
+                           .release();
   return storage;
 }
 
 THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size)
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
-      caffe2::TypeMeta::Make<scalar_t>(),
-      size,
-      c10::cuda::CUDACachingAllocator::get(),
-      true).release();
+                           c10::StorageImpl::use_byte_size_t(),
+                           caffe2::TypeMeta::Make<scalar_t>(),
+                           size * sizeof(scalar_t),
+                           c10::cuda::CUDACachingAllocator::get(),
+                           true)
+                           .release();
   return storage;
 }
 
@@ -80,10 +85,12 @@ THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
                                           at::Allocator* allocator)
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
-      caffe2::TypeMeta::Make<scalar_t>(),
-      size,
-      allocator,
-      true).release();
+                           c10::StorageImpl::use_byte_size_t(),
+                           caffe2::TypeMeta::Make<scalar_t>(),
+                           size * sizeof(scalar_t),
+                           allocator,
+                           true)
+                           .release();
   return storage;
 }
 
@@ -106,11 +113,13 @@ THCStorage* THCStorage_(newWithDataAndAllocator)(
     ptrdiff_t size,
     at::Allocator* allocator) {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
-      caffe2::TypeMeta::Make<scalar_t>(),
-      size,
-      std::move(data),
-      allocator,
-      allocator != nullptr).release();
+                           c10::StorageImpl::use_byte_size_t(),
+                           caffe2::TypeMeta::Make<scalar_t>(),
+                           size * sizeof(scalar_t),
+                           std::move(data),
+                           allocator,
+                           allocator != nullptr)
+                           .release();
   return storage;
 }
 

--- a/aten/src/THC/generic/THCStorage.cu
+++ b/aten/src/THC/generic/THCStorage.cu
@@ -8,14 +8,16 @@ void THCStorage_(fill)(THCState *state, THCStorage *self, scalar_t value)
   thrust::device_ptr<scalar_t> self_data(THCStorage_(data)(state, self));
   thrust::fill(
 #if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
-    thrust::cuda::par(thrustAlloc).on(c10::cuda::getCurrentCUDAStream()),
+      thrust::cuda::par(thrustAlloc).on(c10::cuda::getCurrentCUDAStream()),
 #endif
-    self_data, self_data+self->numel(), value);
+      self_data,
+      self_data + (self->nbytes() / sizeof(scalar_t)),
+      value);
 }
 
-void THCStorage_(resize)(THCState *state, THCStorage *self, ptrdiff_t size)
-{
-  THCStorage_resize(state, self, size);
+void THCStorage_(
+    resizeBytes)(THCState* state, THCStorage* self, ptrdiff_t size_bytes) {
+  THCStorage_resizeBytes(state, self, size_bytes);
 }
 
 int THCStorage_(getDevice)(THCState* state, const THCStorage* storage) {

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -20,7 +20,6 @@
 #define THCudaComplexDoubleStorage          THCStorage
 
 THC_API scalar_t* THCStorage_(data)(THCState *state, const THCStorage*);
-THC_API ptrdiff_t THCStorage_(size)(THCState *state, const THCStorage*);
 THC_API int THCStorage_(elementSize)(THCState *state);
 
 /* slow access -- checks everything */
@@ -44,7 +43,8 @@ THC_API void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const 
 THC_API void THCStorage_(retain)(THCState *state, THCStorage *storage);
 
 THC_API void THCStorage_(free)(THCState *state, THCStorage *storage);
-THC_API void THCStorage_(resize)(THCState *state, THCStorage *storage, ptrdiff_t size);
+THC_API void THCStorage_(
+    resizeBytes)(THCState* state, THCStorage* storage, ptrdiff_t size_bytes);
 THC_API void THCStorage_(fill)(THCState *state, THCStorage *storage, scalar_t value);
 
 THC_API int THCStorage_(getDevice)(THCState* state, const THCStorage* storage);

--- a/aten/src/THC/generic/THCStorageCopy.cpp
+++ b/aten/src/THC/generic/THCStorageCopy.cpp
@@ -8,35 +8,37 @@
 
 void THCStorage_(copyCPU)(THCState *state, THCStorage *self, struct THStorage *src)
 {
-  THArgCheck(self->numel() == src->numel(), 2, "size does not match");
+  THArgCheck(self->nbytes() == src->nbytes(), 2, "size does not match");
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 #if HIP_VERSION >= 301
-  THCudaCheck(hipMemcpyWithStream(THCStorage_(data)(state, self),
-                                  THStorage_(data)(src),
-                                  self->numel() * sizeof(scalar_t),
-                                  cudaMemcpyHostToDevice,
-                                  stream));
+  THCudaCheck(hipMemcpyWithStream(
+      THCStorage_(data)(state, self),
+      THStorage_(data)(src),
+      self->nbytes(),
+      cudaMemcpyHostToDevice,
+      stream));
 #else
-  THCudaCheck(cudaMemcpyAsync(THCStorage_(data)(state, self),
-                              THStorage_(data)(src),
-                              self->numel() * sizeof(scalar_t),
-                              cudaMemcpyHostToDevice,
-                              stream));
+  THCudaCheck(cudaMemcpyAsync(
+      THCStorage_(data)(state, self),
+      THStorage_(data)(src),
+      self->nbytes(),
+      cudaMemcpyHostToDevice,
+      stream));
   THCudaCheck(cudaStreamSynchronize(stream));
 #endif
 }
 
-#define TH_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC)                          \
-void THCStorage_(copy##TYPEC)(THCState *state, THCStorage *self, struct TH##TYPEC##Storage *src)  \
-{                                                                      \
-  THCTensor* selfTensor =                                              \
-      THCTensor_(newWithStorage1d)(state, self, 0, self->numel(), 1);     \
-  struct TH##TYPEC##Tensor* srcTensor =                                \
-      TH##TYPEC##Tensor_newWithStorage1d(src, 0, src->numel(), 1);        \
-  THCTensor_(copy)(state, selfTensor, srcTensor);               \
-  TH##TYPEC##Tensor_free(srcTensor);                                   \
-  THCTensor_(free)(state, selfTensor);                                 \
-}
+#define TH_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC)                                 \
+  void THCStorage_(copy##TYPEC)(                                              \
+      THCState * state, THCStorage * self, struct TH##TYPEC##Storage * src) { \
+    THCTensor* selfTensor = THCTensor_(newWithStorage1d)(                     \
+        state, self, 0, src->nbytes() / sizeof(scalar_t), 1);                 \
+    struct TH##TYPEC##Tensor* srcTensor = TH##TYPEC##Tensor_newWithStorage1d( \
+        src, 0, src->nbytes() / sizeof(scalar_t), 1);                         \
+    THCTensor_(copy)(state, selfTensor, srcTensor);                           \
+    TH##TYPEC##Tensor_free(srcTensor);                                        \
+    THCTensor_(free)(state, selfTensor);                                      \
+  }
 
 // TODO: Add cross-dtype storage copy for complex storage
 #if !defined(THC_REAL_IS_COMPLEXFLOAT) && !defined(THC_REAL_IS_COMPLEXDOUBLE)
@@ -57,35 +59,37 @@ void THCStorage_(copy##TYPEC)(THCState *state, THCStorage *self, struct TH##TYPE
 
 void THStorage_(copyCuda)(THCState *state, THStorage *self, struct THCStorage *src)
 {
-  THArgCheck(self->numel() == src->numel(), 2, "size does not match");
+  THArgCheck(self->nbytes() == src->nbytes(), 2, "size does not match");
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
 #if HIP_VERSION >= 301
-  THCudaCheck(hipMemcpyWithStream(THStorage_(data)(self),
-                                  THCStorage_(data)(state, src),
-                                  self->numel() * sizeof(scalar_t),
-                                  cudaMemcpyDeviceToHost,
-                                  stream));
+  THCudaCheck(hipMemcpyWithStream(
+      THStorage_(data)(self),
+      THCStorage_(data)(state, src),
+      self->nbytes(),
+      cudaMemcpyDeviceToHost,
+      stream));
 #else
-  THCudaCheck(cudaMemcpyAsync(THStorage_(data)(self),
-                              THCStorage_(data)(state, src),
-                              self->numel() * sizeof(scalar_t),
-                              cudaMemcpyDeviceToHost,
-                              stream));
+  THCudaCheck(cudaMemcpyAsync(
+      THStorage_(data)(self),
+      THCStorage_(data)(state, src),
+      self->nbytes(),
+      cudaMemcpyDeviceToHost,
+      stream));
   THCudaCheck(cudaStreamSynchronize(stream));
 #endif
 }
 
-#define TH_CUDA_STORAGE_IMPLEMENT_COPYTO(TYPEC)                             \
-void TH_CONCAT_4(TH,TYPEC,Storage_copyCuda,Real)(THCState *state, TH##TYPEC##Storage *self, struct THCStorage *src) \
-{                                                                           \
-  TH##TYPEC##Tensor* selfTensor =                                           \
-      TH##TYPEC##Tensor_newWithStorage1d(self, 0, self->numel(), 1);           \
-  struct THCTensor* srcTensor =                                             \
-      THCTensor_(newWithStorage1d)(state, src, 0, src->numel(), 1);            \
-  THCTensor_(copy)(state, selfTensor, srcTensor);                           \
-  THCTensor_(free)(state, srcTensor);                                       \
-  TH##TYPEC##Tensor_free(selfTensor);                                   \
-}
+#define TH_CUDA_STORAGE_IMPLEMENT_COPYTO(TYPEC)                               \
+  void TH_CONCAT_4(TH, TYPEC, Storage_copyCuda, Real)(                        \
+      THCState * state, TH##TYPEC##Storage * self, struct THCStorage * src) { \
+    TH##TYPEC##Tensor* selfTensor = TH##TYPEC##Tensor_newWithStorage1d(       \
+        self, 0, self->nbytes() / sizeof(scalar_t), 1);                       \
+    struct THCTensor* srcTensor = THCTensor_(newWithStorage1d)(               \
+        state, src, 0, src->nbytes() / sizeof(scalar_t), 1);                  \
+    THCTensor_(copy)(state, selfTensor, srcTensor);                           \
+    THCTensor_(free)(state, srcTensor);                                       \
+    TH##TYPEC##Tensor_free(selfTensor);                                       \
+  }
 
 // TODO: Add cross-dtype storage copy for complex storage
 #if !defined(THC_REAL_IS_COMPLEXFLOAT) && !defined(THC_REAL_IS_COMPLEXDOUBLE)

--- a/aten/src/THC/generic/THCStorageCopy.cu
+++ b/aten/src/THC/generic/THCStorageCopy.cu
@@ -3,17 +3,24 @@
 #else
 
 // conversions are delegated to THCTensor implementation
-#define THC_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC,TYPECUDA)                                 \
-void THCStorage_(copyCuda##TYPEC)(THCState *state, THCStorage *self, struct THCuda##TYPECUDA##Storage *src)  \
-{                                                                                       \
-  THArgCheck(self->numel() == src->numel(), 2, "size does not match");                        \
-  THCTensor* selfTensor = THCTensor_(newWithStorage1d)(state, self, 0, self->numel(), 1);  \
-  struct THCuda##TYPECUDA##Tensor* srcTensor =                                          \
-      THCuda##TYPECUDA##Tensor_newWithStorage1d(state, src, 0, src->numel(), 1);           \
-  THCTensor_(copy)(state, selfTensor, srcTensor);                            \
-  THCuda##TYPECUDA##Tensor_free(state, srcTensor);                                      \
-  THCTensor_(free)(state, selfTensor);                                                  \
-}
+#define THC_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC, TYPECUDA)              \
+  void THCStorage_(copyCuda##TYPEC)(                                  \
+      THCState * state,                                               \
+      THCStorage * self,                                              \
+      struct THCuda##TYPECUDA##Storage * src) {                       \
+    size_t self_numel = self->nbytes() / sizeof(scalar_t);            \
+    size_t src_numel =                                                \
+        src->nbytes() / THCuda##TYPECUDA##Storage_elementSize(state); \
+    THArgCheck(self_numel == src_numel, 2, "size does not match");    \
+    THCTensor* selfTensor =                                           \
+        THCTensor_(newWithStorage1d)(state, self, 0, self_numel, 1);  \
+    struct THCuda##TYPECUDA##Tensor* srcTensor =                      \
+        THCuda##TYPECUDA##Tensor_newWithStorage1d(                    \
+            state, src, 0, src_numel, 1);                             \
+    THCTensor_(copy)(state, selfTensor, srcTensor);                   \
+    THCuda##TYPECUDA##Tensor_free(state, srcTensor);                  \
+    THCTensor_(free)(state, selfTensor);                              \
+  }
 
 #if !defined(THC_REAL_IS_COMPLEXFLOAT) && !defined(THC_REAL_IS_COMPLEXDOUBLE)
   THC_CUDA_STORAGE_IMPLEMENT_COPY(Byte,Byte)

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -18,7 +18,7 @@ void THCTensor_(calculateMode)(THCState *state,
   // to calculate the mode for --> we do this by manually doing the stride
   // calculations to get an offset
   scalar_t *data = THCTensor_(data)(state, input);
-  for (int i = 0; i < THLongStorage_size(position); ++i) {
+  for (int i = 0; i < (position->nbytes() / sizeof(int64_t)); ++i) {
     data += THLongStorage_data(position)[i] * THTensor_strideLegacyNoScalars(input, i);
   }
 
@@ -121,7 +121,7 @@ void THCTensor_(calculateMode)(THCState *state,
   ptrdiff_t valuesOffset = THCTensor_(storageOffset)(state, values);
   int64_t indicesOffset = THCudaLongTensor_storageOffset(state, indices);
 
-  for (int i = 0; i < THLongStorage_size(position); ++i) {
+  for (int i = 0; i < (position->nbytes() / sizeof(int64_t)); ++i) {
     int64_t pos = THLongStorage_data(position)[i];
     valuesOffset += THTensor_strideLegacyNoScalars(values, i) * pos;
     indicesOffset += THTensor_strideLegacyNoScalars(indices, i) * pos;

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -6,18 +6,22 @@ namespace c10 {
 
 struct C10_API Storage {
  public:
+  struct use_byte_size_t {};
+
   Storage() {}
   Storage(c10::intrusive_ptr<StorageImpl> ptr) : storage_impl_(std::move(ptr)) {}
 
   // Allocates memory buffer using given allocator and creates a storage with it
   Storage(
+      use_byte_size_t use_byte_size,
       caffe2::TypeMeta data_type,
-      size_t size,
+      size_t size_bytes,
       Allocator* allocator,
       bool resizable)
       : storage_impl_(c10::make_intrusive<StorageImpl>(
+            StorageImpl::use_byte_size_t(),
             data_type,
-            size,
+            size_bytes,
             allocator,
             resizable)) {}
 
@@ -25,14 +29,16 @@ struct C10_API Storage {
   // potential future reallocations, however it can be nullptr if the storage
   // is non-resizable
   Storage(
+      use_byte_size_t use_byte_size,
       caffe2::TypeMeta data_type,
-      int64_t numel,
+      size_t size_bytes,
       at::DataPtr data_ptr,
       at::Allocator* allocator,
       bool resizable)
       : storage_impl_(c10::make_intrusive<StorageImpl>(
+            StorageImpl::use_byte_size_t(),
             data_type,
-            numel,
+            size_bytes,
             std::move(data_ptr),
             allocator,
             resizable)) {}
@@ -43,11 +49,12 @@ struct C10_API Storage {
   static Storage create_legacy(at::Device device, caffe2::TypeMeta data_type) {
     auto allocator = GetAllocator(device.type());
     return Storage(c10::make_intrusive<StorageImpl>(
-            data_type,
-            0,
-            allocator->allocate(0), // materialize a non-default Device.
-            allocator,
-            true));
+        StorageImpl::use_byte_size_t(),
+        data_type,
+        0,
+        allocator->allocate(0), // materialize a non-default Device.
+        allocator,
+        true));
   }
 
   template <typename T>
@@ -61,33 +68,17 @@ struct C10_API Storage {
   template <typename T>
   T* unsafe_data() const { return storage_impl_->unsafe_data<T>(); }
 
-  size_t elementSize() const {
-    return storage_impl_->itemsize();
-  }
-
-  inline size_t itemsize() const {
-    return storage_impl_->itemsize();
-  }
-
-  ptrdiff_t size() const {
-    return storage_impl_->numel();
-  }
-
-  int64_t numel() const {
-    return storage_impl_->numel();
-  }
-
   // TODO: remove later
-  void set_numel(int64_t numel) const {
-    storage_impl_.get()->set_numel(numel);
+  void set_nbytes(size_t size_bytes) const {
+    storage_impl_.get()->set_nbytes(size_bytes);
   }
 
   bool resizable() const {
     return storage_impl_->resizable();
   }
 
-  size_t capacity() const {
-    return storage_impl_->capacity();
+  size_t nbytes() const {
+    return storage_impl_->nbytes();
   }
   // get() use here is to get const-correctness
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -998,7 +998,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         newDims.end(),
         static_cast<int64_t>(1),
         std::multiplies<int64_t>());
-    if (newNumel * storage_.itemsize() <= storage_.capacity()) {
+    if (newNumel * data_type_.itemsize() <= storage_.nbytes()) {
       sizes_ = newDims;
       numel_ = newNumel;
       return;
@@ -1059,7 +1059,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         newCapacity.end(),
         static_cast<int64_t>(1),
         std::multiplies<int64_t>());
-    if (newNumel * storage_.itemsize() <= storage_.capacity()) {
+    if (newNumel * data_type_.itemsize() <= storage_.nbytes()) {
       return;
     }
     // Old data is discarded
@@ -1098,15 +1098,16 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       // will create the data storage.
       bool reset_tensor = false;
       if (reserved_) {
-        // If tensor is reserved then don't claim its memeory unless capacity()
+        // If tensor is reserved then don't claim its memeory unless nbytes()
         // is smaller than new size
-        reset_tensor = storage_.capacity() < (storage_offset_ + numel_) * storage_.itemsize();
+        reset_tensor = storage_.nbytes() <
+            (storage_offset_ + numel_) * data_type_.itemsize();
       } else {
-        reset_tensor = storage_.capacity() <
-                (storage_offset_ + numel_) * storage_.itemsize() ||
+        reset_tensor = storage_.nbytes() <
+                (storage_offset_ + numel_) * data_type_.itemsize() ||
             !FLAGS_caffe2_keep_on_shrink ||
-            storage_.capacity() -
-                    (storage_offset_ + numel_) * storage_.itemsize() >
+            storage_.nbytes() -
+                    (storage_offset_ + numel_) * data_type_.itemsize() >
                 static_cast<size_t>(FLAGS_caffe2_max_keep_on_shrink_memory);
       }
 
@@ -1187,7 +1188,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         src.storage_initialized(),
         "Source tensor has no content and has size > 0");
     // Finally, do sharing.
-    /* Since we create new Storage whenever we need to change data_type/capacity
+    /* Since we create new Storage whenever we need to change data_type/nbytes
      * this still keeps the original semantics
      */
     storage_ = src.storage();
@@ -1199,26 +1200,26 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   void ShareExternalPointer(
       DataPtr&& data_ptr,
       const caffe2::TypeMeta& data_type,
-      size_t capacity) {
+      size_t size_bytes) {
     TORCH_CHECK(
         data_type.id() != caffe2::TypeIdentifier::uninitialized(),
         "To share with a raw external pointer you need to pass in an "
         "initialized data_type(TypeMeta).");
-    if (!capacity) {
-      capacity = numel_ * data_type.itemsize();
+    if (!size_bytes) {
+      size_bytes = numel_ * data_type.itemsize();
     }
     if (storage_.unique()) {
       storage_.UniqueStorageShareExternalPointer(
-          std::move(data_ptr), data_type, capacity);
+          std::move(data_ptr), data_type, size_bytes);
       data_type_ = data_type;
       device_opt_ = storage_.device();
       storage_offset_ = 0;
     } else {
-      int64_t numel = capacity / data_type.itemsize();
       // Create a new Storage
       storage_ = Storage(
+          Storage::use_byte_size_t(),
           data_type,
-          numel,
+          size_bytes,
           std::move(data_ptr),
           /*allocator=*/nullptr,
           /*resizable=*/false);
@@ -1261,7 +1262,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       // constructor.
       if (numel_ == 0 ||
           (meta.placementNew() == nullptr && !had_special_dtor &&
-           storage_.numel() >= numel_)) {
+           (storage_.nbytes() >= (numel_ * data_type_.itemsize())))) {
         TORCH_INTERNAL_ASSERT(storage_offset_ == 0); // because we just reallocated
         return storage_.data();
       }
@@ -1279,16 +1280,16 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         // destruction procedure.
         auto size = numel_;
         auto dtor = data_type_.placementDelete();
-        auto data_ptr = allocator->allocate(numel_ * storage_.itemsize());
+        auto data_ptr = allocator->allocate(numel_ * data_type_.itemsize());
         storage_.set_data_ptr(PlacementDeleteContext::makeDataPtr(
             std::move(data_ptr), dtor, size, storage_.device()));
         data_type_.placementNew()(storage_.data(), numel_);
       } else {
         // For fundamental type, new and delete is easier.
         storage_.set_data_ptr(
-            allocator->allocate(numel_ * storage_.itemsize()));
+            allocator->allocate(numel_ * data_type_.itemsize()));
       }
-      storage_.set_numel(numel_);
+      storage_.set_nbytes(numel_ * data_type_.itemsize());
       TORCH_INTERNAL_ASSERT(storage_offset_ == 0); // because we just reallocated
       device_opt_ = storage_.device();
       return storage_.data();

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -97,7 +97,7 @@ GetTensorInfo(const void* c, size_t* capacity, DeviceOption* device) {
   CHECK(tc);
   CHECK(tc->unsafeGetTensorImpl());
   CHECK(tc->unsafeGetTensorImpl()->storage().unsafeGetStorageImpl());
-  *capacity = tc->storage().capacity();
+  *capacity = tc->storage().nbytes();
   ExtractDeviceOption(device, tc->GetDevice());
   return tc->sizes().vec();
 }

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -260,8 +260,8 @@ class CAFFE2_API Tensor final {
    */
   string DebugString() const {
     std::stringstream ss;
-    ss << "A Tensor of item size " << impl_->storage().itemsize()
-       << " and type " << impl_->dtype().name() << " and dimension (";
+    ss << "A Tensor of item size " << impl_->dtype().itemsize() << " and type "
+       << impl_->dtype().name() << " and dimension (";
     for (int d : impl_->sizes()) {
       ss << d << ",";
     }
@@ -402,7 +402,7 @@ class CAFFE2_API Tensor final {
    * Return the number of bytes each item takes in the tensor.
    */
   inline size_t itemsize() const {
-    return impl_->storage().itemsize();
+    return impl_->dtype().itemsize();
   }
 
   /**

--- a/test/cpp/rpc/test_wire_serialization.cpp
+++ b/test/cpp/rpc/test_wire_serialization.cpp
@@ -42,7 +42,7 @@ TEST(WireSerialize, RecopySparseTensors) {
   at::Tensor main = torch::randn({k1K, k1K});
   at::Tensor tiny = main.select(0, 2); // Select a row in the middle
   EXPECT_EQ(tiny.numel(), k1K);
-  EXPECT_EQ(tiny.storage().numel(), k1K * k1K);
+  EXPECT_EQ(tiny.storage().nbytes() / tiny.dtype().itemsize(), k1K * k1K);
   auto ser = torch::distributed::rpc::wireSerialize({}, {tiny});
   auto deser = torch::distributed::rpc::wireDeserialize(ser.data(), ser.size());
   EXPECT_TRUE(torch::equal(tiny, deser.second[0]));

--- a/test/cpp_extensions/msnpu_extension.cpp
+++ b/test/cpp_extensions/msnpu_extension.cpp
@@ -8,7 +8,12 @@ static int test_int;
 Tensor get_tensor(caffe2::TypeMeta dtype, IntArrayRef size) {
   auto tensor_impl = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
       Storage(
-          dtype, 0, at::DataPtr(nullptr, Device(DeviceType::MSNPU, 0)), nullptr, false),
+          Storage::use_byte_size_t(),
+          dtype,
+          0,
+          at::DataPtr(nullptr, Device(DeviceType::MSNPU, 0)),
+          nullptr,
+          false),
       DispatchKey::MSNPU);
   // This is a hack to workaround the shape checks in _convolution.
   tensor_impl->set_sizes_contiguous(size);

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -223,7 +223,7 @@ c10::List<at::Tensor> cloneSparseTensors(
     if (!t.has_storage()) {
       return false; // avoid throwing below.
     }
-    auto storageSize = t.storage().elementSize() * t.storage().numel();
+    auto storageSize = t.storage().nbytes();
     auto usefulSize = t.element_size() * t.numel();
     constexpr size_t kMinMultiple = 2;
     constexpr size_t kMinRecopyBytes = 8 * 1024;

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -135,7 +135,7 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 static Py_ssize_t THPStorage_(length)(THPStorage *self)
 {
   HANDLE_TH_ERRORS
-  return THWStorage_(size)(LIBRARY_STATE self->cdata);
+  return self->cdata->nbytes() / sizeof(scalar_t);
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 
@@ -146,10 +146,15 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
   if (THPUtils_checkLong(index)) {
     int64_t nindex = THPUtils_unpackLong(index);
     if (nindex < 0)
-      nindex += THWStorage_(size)(LIBRARY_STATE self->cdata);
-    if (nindex < 0 || nindex >= self->cdata->numel()) {
-      PyErr_Format(PyExc_IndexError, "index %" PRId64 " out of range for storage of "
-              "size %" PRId64, (int64_t) nindex, (int64_t) self->cdata->numel());
+      nindex += (self->cdata->nbytes() / sizeof(scalar_t));
+    if (nindex < 0 || nindex >= (self->cdata->nbytes() / sizeof(scalar_t))) {
+      PyErr_Format(
+          PyExc_IndexError,
+          "index %" PRId64
+          " out of range for storage of "
+          "size %" PRId64,
+          (int64_t)nindex,
+          (int64_t)(self->cdata->nbytes() / sizeof(scalar_t)));
       return nullptr;
     }
     scalar_t value = THWStorage_(get)(LIBRARY_STATE self->cdata, nindex);
@@ -157,7 +162,7 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
   /* Slice index */
   } else if (PySlice_Check(index)) {
     Py_ssize_t start, stop, slicelength, step;
-    int64_t len = THWStorage_(size)(LIBRARY_STATE self->cdata);
+    int64_t len = self->cdata->nbytes() / sizeof(scalar_t);
     if (!THPUtils_parseSlice(index, len, &start, &stop, &step, &slicelength))
       return nullptr;
     if (step != 1) {
@@ -170,15 +175,20 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
 
     at::StorageImpl* old_storage = self->cdata;
     c10::raw::intrusive_ptr::incref(old_storage);
+    caffe2::TypeMeta dtype = old_storage->dtype();
     at::Storage new_storage(c10::make_intrusive<at::StorageImpl>(
-      old_storage->dtype(),
-      slicelength,
-      at::DataPtr(static_cast<void*>(data + start),
-                  old_storage,
-                  [](void* s) { c10::raw::intrusive_ptr::decref(static_cast<at::StorageImpl*>(s)); },
-                  old_storage->device()),
-      old_storage->allocator(),
-      /* resizable */ false));
+        c10::StorageImpl::use_byte_size_t(),
+        dtype,
+        slicelength * dtype.itemsize(),
+        at::DataPtr(
+            static_cast<void*>(data + start),
+            old_storage,
+            [](void* s) {
+              c10::raw::intrusive_ptr::decref(static_cast<at::StorageImpl*>(s));
+            },
+            old_storage->device()),
+        old_storage->allocator(),
+        /* resizable */ false));
 
     PyObject *_ret = THPStorage_(New)(new_storage.unsafeReleaseStorageImpl());
     return _ret;
@@ -206,7 +216,7 @@ static int THPStorage_(set)(THPStorage *self, PyObject *index, PyObject *value)
     return 0;
   } else if (PySlice_Check(index)) {
     Py_ssize_t start, stop, slicelength, step;
-    int64_t len = THWStorage_(size)(LIBRARY_STATE self->cdata);
+    int64_t len = self->cdata->nbytes() / sizeof(scalar_t);
     if (!THPUtils_parseSlice(index, len, &start, &stop, &step, &slicelength))
       return -1;
     if (step != 1) {

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -13,7 +13,7 @@
 static PyObject * THPStorage_(size)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
-  return PyLong_FromLong(THWStorage_(size)(LIBRARY_STATE self->cdata));
+  return PyLong_FromLong(self->cdata->nbytes() / sizeof(scalar_t));
   END_HANDLE_TH_ERRORS
 }
 
@@ -65,7 +65,8 @@ static PyObject * THPStorage_(resize_)(THPStorage *self, PyObject *number_arg)
   THPUtils_assert(THPUtils_checkLong(number_arg), "resize_ expects an int, "
       "but got %s", THPUtils_typename(number_arg));
   int64_t newsize = THPUtils_unpackLong(number_arg);
-  THWStorage_(resize)(LIBRARY_STATE self->cdata, newsize);
+  THWStorage_(resizeBytes)(
+      LIBRARY_STATE self->cdata, newsize * sizeof(scalar_t));
   Py_INCREF(self);
   return (PyObject*)self;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -80,7 +80,8 @@ static PyObject * THPStorage_(shareFilename)(THPStorage *self, PyObject *noargs)
   } else {
     // TODO: retry on collision
     // TODO: free GIL - but remember to reacquire it when an exception is thrown
-    THWStoragePtr new_storage(THPStorage_(newFilenameStorage)(storage->numel()));
+    THWStoragePtr new_storage(
+        THPStorage_(newFilenameStorage)(storage->nbytes() / sizeof(scalar_t)));
     THWStorage_(copy)(new_storage, storage);
     THWStorage_(swap)(storage, new_storage);
     ctx = THManagedMapAllocator::fromDataPtr(storage->data_ptr());
@@ -91,7 +92,7 @@ static PyObject * THPStorage_(shareFilename)(THPStorage *self, PyObject *noargs)
   if (!manager_handle) return nullptr;
   THPObjectPtr storage_handle(PyBytes_FromString(ctx->filename()));
   if (!storage_handle) return nullptr;
-  THPObjectPtr size(PyLong_FromLong(storage->numel()));
+  THPObjectPtr size(PyLong_FromLong(storage->nbytes() / sizeof(scalar_t)));
   if (!size) return nullptr;
 
   THPObjectPtr tuple(PyTuple_New(3));
@@ -159,7 +160,8 @@ static PyObject * THPStorage_(shareFd)(THPStorage *self, PyObject *noargs)
   if ((ctx = THMapAllocator::fromDataPtr(storage->data_ptr()))) {
     // done
   } else {
-    THWStoragePtr new_storage(THPStorage_(newFdStorage)(storage->numel()));
+    THWStoragePtr new_storage(
+        THPStorage_(newFdStorage)(storage->nbytes() / sizeof(scalar_t)));
     THWStorage_(copy)(new_storage, storage);
     THWStorage_(swap)(storage, new_storage);
     ctx = THMapAllocator::fromDataPtr(storage->data_ptr());
@@ -168,7 +170,7 @@ static PyObject * THPStorage_(shareFd)(THPStorage *self, PyObject *noargs)
 
   THPObjectPtr storage_handle(PyLong_FromLong(ctx->fd()));
   if (!storage_handle) return nullptr;
-  THPObjectPtr size(PyLong_FromLong(storage->numel()));
+  THPObjectPtr size(PyLong_FromLong(storage->nbytes() / sizeof(scalar_t)));
   if (!size) return nullptr;
 
   THPObjectPtr tuple(PyTuple_New(2));
@@ -227,7 +229,7 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self, PyObject *noargs)
   THPObjectPtr device(PyLong_FromLong(storage->device().index()));
   THPObjectPtr _handle(Py_None);
   Py_INCREF(Py_None);
-  THPObjectPtr size_bytes(PyLong_FromLong(storage->numel() * sizeof(scalar_t)));
+  THPObjectPtr size_bytes(PyLong_FromLong(storage->nbytes()));
   THPObjectPtr _offset_bytes(PyLong_FromLong(0));
   THPObjectPtr _ref_counter(Py_None);
   Py_INCREF(Py_None);

--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -17,23 +17,28 @@ void THPStorage_(writeFileRaw)(THWStorage *self, io fd, bool save_size)
 #endif
 
   scalar_t *data;
-  int64_t size = THWStorage_(size)(LIBRARY_STATE self);
+  int64_t size_bytes = self->nbytes();
+  int64_t numel = size_bytes / sizeof(scalar_t);
 #ifndef THC_GENERIC_FILE
   data = THWStorage_(data)(LIBRARY_STATE self);
 #else
-  std::unique_ptr<char[]> cpu_data(new char[size * sizeof(scalar_t)]);
+  std::unique_ptr<char[]> cpu_data(new char[size_bytes]);
   data = (scalar_t*)cpu_data.get();
-  THCudaCheck(cudaMemcpy(data, THWStorage_(data)(LIBRARY_STATE self), size * sizeof(scalar_t), cudaMemcpyDeviceToHost));
+  THCudaCheck(cudaMemcpy(
+      data,
+      THWStorage_(data)(LIBRARY_STATE self),
+      size_bytes,
+      cudaMemcpyDeviceToHost));
 #endif
   if (save_size) {
     if (torch::utils::THP_nativeByteOrder() ==
         torch::utils::THPByteOrder::THP_LITTLE_ENDIAN)
-      doWrite(fd, &size, sizeof(int64_t));
+      doWrite(fd, &numel, sizeof(int64_t));
     else {
       int64_t nsize; // convert big endian cpu to little endian storage
       torch::utils::THP_encodeInt64Buffer(
           (uint8_t*)&nsize,
-          (const int64_t*)&size,
+          (const int64_t*)&numel,
           torch::utils::THPByteOrder::THP_LITTLE_ENDIAN,
           1);
       doWrite(fd, &nsize, sizeof(int64_t));
@@ -43,12 +48,12 @@ void THPStorage_(writeFileRaw)(THWStorage *self, io fd, bool save_size)
   if (sizeof(scalar_t) == 1 ||
       torch::utils::THP_nativeByteOrder() ==
           torch::utils::THPByteOrder::THP_LITTLE_ENDIAN) {
-    doWrite(fd, data, sizeof(scalar_t) * size);
+    doWrite(fd, data, size_bytes);
   } else {
-    int64_t buffer_size = std::min(size, (int64_t)5000);
+    int64_t buffer_size = std::min(numel, (int64_t)5000);
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(scalar_t)]);
-    for (int64_t i = 0; i < size; i += buffer_size) {
-      size_t to_convert = std::min(size - i, buffer_size);
+    for (int64_t i = 0; i < numel; i += buffer_size) {
+      size_t to_convert = std::min(numel - i, buffer_size);
       if (sizeof(scalar_t) == 2) {
         torch::utils::THP_encodeInt16Buffer(
             (uint8_t*)le_buffer.get(),
@@ -100,9 +105,12 @@ THWStorage * THPStorage_(readFileRaw)(io file, THWStorage *_storage)
   if (_storage == nullptr) {
     storage = THWStorage_(newWithSize)(LIBRARY_STATE size);
   } else {
-    THPUtils_assert(THWStorage_(size)(LIBRARY_STATE _storage) == size,
+    int64_t _storage_numel = _storage->nbytes() / sizeof(scalar_t);
+    THPUtils_assert(
+        _storage_numel == size,
         "storage has wrong size: expected %ld got %ld",
-        size, THWStorage_(size)(LIBRARY_STATE _storage));
+        size,
+        _storage_numel);
     storage = _storage;
   }
 
@@ -117,7 +125,7 @@ THWStorage * THPStorage_(readFileRaw)(io file, THWStorage *_storage)
   if (sizeof(scalar_t) == 1 ||
       torch::utils::THP_nativeByteOrder() ==
           torch::utils::THPByteOrder::THP_LITTLE_ENDIAN) {
-    doRead(file, data, sizeof(scalar_t) * THWStorage_(size)(LIBRARY_STATE storage));
+    doRead(file, data, storage->nbytes());
   } else {
     int64_t buffer_size = std::min(size, (int64_t)5000);
     std::unique_ptr<uint8_t[]> le_buffer(new uint8_t[buffer_size * sizeof(scalar_t)]);

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -178,8 +178,9 @@ at::Tensor ScriptModuleDeserializer::LEGACY_loadTensor(
     uint64_t record_size;
     std::tie(storage_ptr, record_size) = reader_->getRecord(record_key);
     auto cpu_storage = at::Storage(
+        c10::Storage::use_byte_size_t(),
         at::CPU(type).typeMeta(),
-        record_size / at::CPU(type).typeMeta().itemsize(),
+        record_size,
         std::move(storage_ptr),
         /*allocator=*/nullptr,
         /*resizable=*/false); // NB: we didn't set any allocator for the tensor

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -289,7 +289,7 @@ void Pickler::pushStorageOfTensor(const at::Tensor& tensor) {
   // location
   pushString(tensor.device().str());
   // size
-  pushInt(tensor.storage().size());
+  pushInt(tensor.storage().nbytes() / tensor.element_size());
 
   push<PickleOpCode>(PickleOpCode::TUPLE);
   push<PickleOpCode>(PickleOpCode::BINPERSID);
@@ -593,23 +593,24 @@ void Pickler::pushTuple(const IValue& ivalue) {
 WriteableTensorData getWriteableTensorData(const at::Tensor& tensor) {
   WriteableTensorData result;
   result.tensor_ = tensor;
-  result.size_ = tensor.element_size() * tensor.storage().size();
+  result.size_ = tensor.storage().nbytes();
   // TODO HIP support
   if (tensor.storage().device_type() == at::DeviceType::CUDA) {
     // NB: This new tensor is created to support cuda tensors.
     // Storages can be mutated when converting tensors from cuda to cpu,
     // and we need a cpu tensor to copy data from.
-    result.tensor_ = at::empty({0}, tensor.options())
-                         .set_(
-                             tensor.storage(),
-                             /* storage_offset = */ 0,
-                             /* size = */
-                             {static_cast<int64_t>(tensor.storage().size())},
-                             /* stride = */ {1})
-                         .cpu();
+    result.tensor_ =
+        at::empty({0}, tensor.options())
+            .set_(
+                tensor.storage(),
+                /* storage_offset = */ 0,
+                /* size = */
+                {static_cast<int64_t>(
+                    tensor.storage().nbytes() / tensor.element_size())},
+                /* stride = */ {1})
+            .cpu();
     TORCH_CHECK(
-        result.tensor_.element_size() * result.tensor_.storage().size() ==
-            result.size_,
+        result.tensor_.storage().nbytes() == result.size_,
         "Storage tensor size did not match record size");
   }
   return result;

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -97,8 +97,8 @@ struct WriteableTensorData {
   size_t sizeInBytes() const {
     return size_;
   }
-  size_t numel() const {
-    return tensor_.storage().numel();
+  size_t nbytes() const {
+    return tensor_.storage().nbytes();
   }
   bool storageHasDeleter() const {
     return tensor_.storage().data_ptr().get_context() != nullptr;

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -410,9 +410,11 @@ PickleOpCode Unpickler::readInstruction() {
       }
       at::DataPtr storage_ptr = read_record_(key);
       int64_t numel = args.at(4).toInt();
+      caffe2::TypeMeta dtype = at::CPU(type).typeMeta();
       at::Storage storage(
-          at::CPU(type).typeMeta(),
-          numel,
+          c10::Storage::use_byte_size_t(),
+          dtype,
+          numel * dtype.itemsize(),
           std::move(storage_ptr),
           /*allocator=*/nullptr,
           /*resizable=*/false); // NB: we didn't set any allocator for the

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -222,8 +222,10 @@ void setOutput(O& opts, at::Tensor& tensor, std::vector<size_t>& counts) {
 at::Tensor pinnedLike(at::Tensor& tensor) {
   auto* allocator = at::cuda::getPinnedMemoryAllocator();
   auto storage = c10::Storage(
+      c10::Storage::use_byte_size_t(),
       tensor.dtype(),
-      at::detail::computeStorageSize(tensor.sizes(), tensor.strides()),
+      at::detail::computeStorageNbytes(
+          tensor.sizes(), tensor.strides(), tensor.dtype().itemsize()),
       allocator,
       /*resizable=*/false);
   return at::empty({0}, tensor.options().device(at::kCPU))


### PR DESCRIPTION
Summary:
* Remove type-specific size tracking in favor of byte size tracking in Storage and StorageImpl
* Changed numel() and set_numel() to nbytes() and set_nbytes()
* Added enum argument to Storage/StorageImpl constructor to indicate new meaning of the size parameter
* Update all callers of the changed API

Part of issue https://github.com/pytorch/pytorch/issues/33950
Pull Request resolved: https://github.com/pytorch/pytorch/pull/37028

Differential Revision: D21171334

Pulled By: ezyang

