### PR TITLE
[quant][mobile] Return for conv with empty batch

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
@@ -303,6 +303,11 @@ enum pytorch_qnnp_status qnnpackConv(
   const size_t dilation_height = conv_p.dilation[1];
   const size_t groups = conv_p.groups;
 
+  if (batch_size == 0) {
+    // If no batches, return
+    return pytorch_qnnp_status_success;
+  }
+
   const float convolution_scale =
       input_scale * conv_p.kernel_scale / output_scale;
   if (convolution_scale >= 1.0f) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37779 [quant][mobile] Return for conv with empty batch**
* #37637 [quant][graph] Fix bug in replicateDequant
* #37635 [quant][graph] Fix bug in replaceConvolutionWithConv2d

Summary:
We should just return empty output

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21385789](https://our.internmc.facebook.com/intern/diff/D21385789)