### PR TITLE
Fix for hooks with no name

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -421,6 +421,17 @@ class TestAutograd(TestCase):
             self.assertEqual(x.grad, expected_grad)
             self.assertIsNone(x_list[i].grad)
 
+    def test_hook_with_no_name(self):
+        # Create a hook that do not have a __name__ attribute
+        class MyHookClass:
+            def __call__(self, grad):
+                return grad.clone()
+
+        x = torch.randn(5, requires_grad=True).clone()
+        x.register_hook(MyHookClass())
+        x.sum().backward()
+        # Should run fine
+
     def test_sharded_grad(self):
         leaves = [torch.zeros(5, 5, requires_grad=True) for _ in range(10)]
         intermediates = [l * i + l * l for i, l in enumerate(leaves)]

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -164,9 +164,13 @@ static void check_single_result(PyObject* _original, PyObject* _result, PyObject
 }
 
 static std::string hook_name(PyObject* hook) {
-  THPObjectPtr name(PyObject_GetAttrString(hook, "__name__"));
-  if (name && THPUtils_checkString(name.get())) {
-    return THPUtils_unpackString(name.get());
+  if (PyObject_HasAttrString(hook, "__name__")) {
+    THPObjectPtr name(PyObject_GetAttrString(hook, "__name__"));
+    if (!name) throw python_error();
+
+    if (name && THPUtils_checkString(name.get())) {
+      return THPUtils_unpackString(name.get());
+    }
   }
   return "<unknown>";
 }


### PR DESCRIPTION
Fix #37672 

Make sure we only access fields that exist and handle python errors correctly.

Before the fix, the given test would throw:
```
AttributeError: 'MyHookClass' object has no attribute '__name__'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "test_autograd.py", line 432, in test_hook_with_no_name
    x.sum().backward()
  File "/Users/albandes/workspace/pytorch_dev/torch/tensor.py", line 184, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph)
  File "/Users/albandes/workspace/pytorch_dev/torch/autograd/__init__.py", line 115, in backward
    allow_unreachable=True)  # allow_unreachable flag
SystemError: <built-in method run_backward of torch._C._EngineBase object at 0x112fd8100> returned a result with an error set
```