### PR TITLE
stop creating integer type Tensors that require gradients

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4054,6 +4054,13 @@ for shape in [(1,), ()]:
         foo = MyFn.apply(base, True)
         self.assertEqual(foo.grad_fn.__class__.__name__, "MyFnBackward")
 
+    def test_integer_outputs(self):
+        inp = torch.rand(4, requires_grad=True)
+
+        out = inp.argmax()
+        self.assertFalse(out.dtype.is_floating_point)
+        self.assertFalse(out.requires_grad)
+
 
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8778,9 +8778,8 @@ for test_params in module_tests + new_module_tests:
         test_params['input_fn'] = gen_long_tensor_input(test_params['input_size'])
         test_params['reference_fn'] = reference_fn
         test_params['check_forward_only'] = True
-        if fullname and "Conv" in fullname:
-            # Currently we don't support conv2d/conv3d for LongTensor in CUDA
-            test_params['test_cuda'] = False
+        # Currently we don't support conv2d/conv3d for LongTensor in CUDA
+        test_params['test_cuda'] = False
         test = NewModuleTest(**test_params)
 
         add_test(test, decorator)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -109,7 +109,9 @@ DONT_REQUIRE_DERIVATIVE = {
     # This is an unsafe method that is meant to be out of reach of autograd.
     '_coalesced_',
     # Quantize functions should not record gradients
-    'quantize_per_tensor', 'quantize_per_channel'
+    'quantize_per_tensor', 'quantize_per_channel',
+    # Functions that return integers should not have output that require gradients
+    'argmax', 'argmin', 'argsort',
 }
 
 # Some operators invalidate the grad_accumulator. Let's reset it.

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -53,6 +53,9 @@ inline void set_history(
     const std::shared_ptr<Node>& grad_fn) {
   AT_ASSERT(grad_fn);
   if (variable.defined()) {
+    // If the codegen triggers this, you most likely want to add your newly added function
+    // to the DONT_REQUIRE_DERIVATIVE list in tools/autograd/gen_variable_type.py
+    TORCH_INTERNAL_ASSERT(isFloatingType(variable.scalar_type()) || isComplexType(variable.scalar_type()));
     auto output_nr =
         grad_fn->add_input_metadata(variable);
     impl::set_gradient_edge(variable, {grad_fn, output_nr});


### PR DESCRIPTION
Fix #37680

Makes two changes:
- Add `argmin`, `argmax` and `argsort` to the list of non-differentiable functions to prevent them from generating outputs that requires_grad.
- Add a check to make sure we don't add such functions to the codegen by mistake.

The first point is BC breaking in the sense that the output created by these functions does not require gradients anymore (calling backward on them before would lead an error anyway).
The second point has a bit more impact because current user code that used to create a graph for integer Tensors won't work anymore (note that this graph had to be discarded, so we do not remove any feature). One important case where this happens is when using custom Function. This will be addressed in a follow up PR to make sure user don't inadvertently create integer Tensor that require gradients.