### PR TITLE
[Onnxifi] Cache output shape inference result for OnnxifiOp

### DIFF
--- a/caffe2/opt/onnxifi_op.cc
+++ b/caffe2/opt/onnxifi_op.cc
@@ -199,11 +199,38 @@ OnnxifiOp<CPUContext>::buildInitializationList(
 }
 
 template <>
-void OnnxifiOp<CPUContext>::extractOutputBatchSizes() {
-  output_reshape_info_.skip = false;
+details::OutputReshapeInfo OnnxifiOp<CPUContext>::initOutputReshapeInfo()
+    const {
+  details::OutputReshapeInfo output_reshape_info;
+  output_reshape_info.begins.reserve(output_names_.size());
+  output_reshape_info.ends.reserve(output_names_.size());
+  output_reshape_info.fast_path.reserve(output_names_.size());
+  for (int i = 0; i < output_names_.size(); ++i) {
+    const auto it = output_shape_hints_.find(i);
+    CAFFE_ENFORCE(
+        it != output_shape_hints_.end(),
+        "Cannot find output shape hints for ",
+        output_names_[i]);
+    int64_t num_dims = it->second.dims.size();
+    // Initialize the tensors used to slice the output
+    output_reshape_info.begins.emplace_back();
+    ReinitializeTensor(
+        &output_reshape_info.begins.back(),
+        {num_dims},
+        at::dtype<int32_t>().device(CPU));
+    output_reshape_info.ends.emplace_back();
+    ReinitializeTensor(
+        &output_reshape_info.ends.back(),
+        {num_dims},
+        at::dtype<int32_t>().device(CPU));
+  }
+  return output_reshape_info;
+}
+
+template <>
+int OnnxifiOp<CPUContext>::extractOutputBatchSizes() {
   if (use_onnx_ || !adjust_output_batch_) {
-    output_reshape_info_.skip = true;
-    return;
+    return max_batch_size_;
   }
 
   // Get the real batch size from nominal input. If it's equal to
@@ -212,13 +239,22 @@ void OnnxifiOp<CPUContext>::extractOutputBatchSizes() {
   // outputs.
   const auto& t = Input(nominal_batch_idx_);
   const auto dims = t.sizes();
+  const int current_batch_size = dims[0];
   CAFFE_ENFORCE(
       !t.sizes().empty(), input_names_[nominal_batch_idx_], " cannot be empty");
-  if (dims[0] == max_batch_size_) {
-    output_reshape_info_.skip = true;
-    return;
+  if (current_batch_size == max_batch_size_) {
+    return max_batch_size_;
   }
 
+  // We still need to adjust output size but we can skip the shape inference as
+  // it was done before.
+  if (output_reshape_info_.count(current_batch_size)) {
+    return current_batch_size;
+  }
+
+  auto it =
+      output_reshape_info_.emplace(current_batch_size, initOutputReshapeInfo());
+  auto& output_reshape_info = it.first->second;
   BoundShapeSpec spec(dims[0], max_seq_size_);
   auto bound_shape_inferencer =
       BoundShapeInferencerRegistry()->Create("C10", spec);
@@ -246,10 +282,10 @@ void OnnxifiOp<CPUContext>::extractOutputBatchSizes() {
     const auto& max_shape = output_shapes_[i];
     CAFFE_ENFORCE_EQ(real_shape.dims_size(), max_shape.size());
     const auto dim_size = real_shape.dims_size();
-    auto& begin = output_reshape_info_.begins[i];
+    auto& begin = output_reshape_info.begins[i];
     begin.Resize(dim_size);
     int32_t* begin_ptr = begin.template mutable_data<int32_t>();
-    auto& end = output_reshape_info_.ends[i];
+    auto& end = output_reshape_info.ends[i];
     end.Resize(dim_size);
     int32_t* end_ptr = end.template mutable_data<int32_t>();
     int32_t mismatch = 0;
@@ -274,26 +310,25 @@ void OnnxifiOp<CPUContext>::extractOutputBatchSizes() {
         end_ptr[j] = -1;
       }
     }
-    output_reshape_info_.fast_path[i] = !mismatch;
+    output_reshape_info.fast_path[i] = !mismatch;
   }
+  return current_batch_size;
 }
 
 template <>
-void OnnxifiOp<CPUContext>::maybeAdjustOutputBatchSizes() {
-  if (output_reshape_info_.skip) {
-    return;
-  }
+void OnnxifiOp<CPUContext>::adjustOutputBatchSizes(int current_batch_size) {
+  const auto& output_reshape_info = output_reshape_info_.at(current_batch_size);
   CPUContext context;
   Tensor tmp(CPU);
   for (int i = 0; i < OutputSize(); ++i) {
     auto* output_tensor = Output(i);
-    const auto& end = output_reshape_info_.ends[i];
-    if (output_reshape_info_.fast_path[i]) {
+    const auto& end = output_reshape_info.ends[i];
+    if (output_reshape_info.fast_path[i]) {
       output_tensor->ShrinkTo(end.data<int32_t>()[0]);
     } else {
       // We need to use generic Slice
       SliceImpl<int32_t, CPUContext>(
-          &tmp, *output_tensor, output_reshape_info_.begins[i], end, &context);
+          &tmp, *output_tensor, output_reshape_info.begins[i], end, &context);
       output_tensor->CopyFrom(tmp);
     }
   }
@@ -350,6 +385,7 @@ bool OnnxifiOp<CPUContext>::RunOnDevice() {
   onnxMemoryFenceV1 input_fence;
   onnxMemoryFenceV1 output_fence;
   std::vector<int> output_batch_sizes;
+  int current_batch_size = max_batch_size_;
 #ifdef ONNXIFI_ENABLE_EXT
   /**
    * If onnxifi extension mode is enabled,
@@ -383,7 +419,7 @@ bool OnnxifiOp<CPUContext>::RunOnDevice() {
             &output_fence,
             traces_.get()),
         ONNXIFI_STATUS_SUCCESS);
-    extractOutputBatchSizes();
+    current_batch_size = extractOutputBatchSizes();
     CAFFE_ENFORCE_EQ(
         lib_->onnxWaitEvent(output_fence.event), ONNXIFI_STATUS_SUCCESS);
     CAFFE_ENFORCE_EQ(
@@ -415,7 +451,7 @@ bool OnnxifiOp<CPUContext>::RunOnDevice() {
         ONNXIFI_STATUS_SUCCESS);
     CAFFE_ENFORCE_EQ(
         lib_->onnxSignalEvent(input_fence.event), ONNXIFI_STATUS_SUCCESS);
-    extractOutputBatchSizes();
+    current_batch_size = extractOutputBatchSizes();
     CAFFE_ENFORCE_EQ(
         lib_->onnxWaitEvent(output_fence.event), ONNXIFI_STATUS_SUCCESS);
 
@@ -426,8 +462,8 @@ bool OnnxifiOp<CPUContext>::RunOnDevice() {
         lib_->onnxReleaseEvent(output_fence.event), ONNXIFI_STATUS_SUCCESS);
   }
 
-  if (adjust_output_batch_) {
-    maybeAdjustOutputBatchSizes();
+  if (adjust_output_batch_ && current_batch_size != max_batch_size_) {
+    adjustOutputBatchSizes(current_batch_size);
   }
   enable_tracing_ = false;
   return true;

--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -15,24 +15,27 @@
 #include "caffe2/utils/string_utils.h"
 
 namespace caffe2 {
+namespace details {
+
+/// Provides slicing info for the outputs. All the vector members should be of
+/// the same size as number of outpus of the Onnxifi op.
+struct OutputReshapeInfo {
+  std::vector<Tensor> begins;
+  std::vector<Tensor> ends;
+  std::vector<bool> fast_path;
+};
+
+struct TensorInfo {
+  TensorInfo() {}
+  TensorInfo(TensorInfo&&) = default;
+  TensorInfo& operator=(TensorInfo&&) = default;
+  std::vector<uint64_t> dims;
+  uint64_t onnxifi_type;
+};
+} // namespace details
 
 template <typename Context>
 class OnnxifiOp final : public Operator<Context> {
-  struct TensorInfo {
-    TensorInfo() {}
-    TensorInfo(TensorInfo&&) = default;
-    TensorInfo& operator=(TensorInfo&&) = default;
-    std::vector<uint64_t> dims;
-    uint64_t onnxifi_type;
-  };
-
-  struct OutputReshapeInfo {
-    std::vector<Tensor> begins;
-    std::vector<Tensor> ends;
-    std::vector<bool> fast_path;
-    bool skip{false};
-  };
-
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   explicit OnnxifiOp(const OperatorDef& operator_def, Workspace* ws)
@@ -68,9 +71,6 @@ class OnnxifiOp final : public Operator<Context> {
     all_scales_.reserve(ws->Blobs().size());
     input_shapes_.resize(input_names_.size());
     output_shapes_.resize(output_names_.size());
-    output_reshape_info_.begins.reserve(output_names_.size());
-    output_reshape_info_.ends.reserve(output_names_.size());
-    output_reshape_info_.fast_path.reserve(output_names_.size());
     int output_idx = 0;
     for (const auto& output : output_names_) {
       output_desc_.push_back(onnxTensorDescriptorV1());
@@ -81,7 +81,7 @@ class OnnxifiOp final : public Operator<Context> {
       const std::string key = c10::str("output_shape_hint_", output_idx);
       auto output_shape_hint = this->template GetRepeatedArgument<int>(key);
       if (!output_shape_hint.empty()) {
-        TensorInfo info;
+        details::TensorInfo info;
         info.onnxifi_type = output_shape_hint.front();
         for (size_t i = 1; i < output_shape_hint.size(); ++i) {
           info.dims.push_back(output_shape_hint[i]);
@@ -89,19 +89,6 @@ class OnnxifiOp final : public Operator<Context> {
         num_dims = info.dims.size();
         output_shape_hints_.emplace(output_idx, std::move(info));
       }
-
-      // Initialize the tensors used to slice the output
-      output_reshape_info_.begins.emplace_back();
-      ReinitializeTensor(
-          &output_reshape_info_.begins.back(),
-          {num_dims},
-          at::dtype<int32_t>().device(CPU));
-      output_reshape_info_.ends.emplace_back();
-      ReinitializeTensor(
-          &output_reshape_info_.ends.back(),
-          {num_dims},
-          at::dtype<int32_t>().device(CPU));
-      output_reshape_info_.fast_path.push_back(false);
       ++output_idx;
     }
 
@@ -297,15 +284,18 @@ class OnnxifiOp final : public Operator<Context> {
 #endif
   }
 
-  void extractOutputBatchSizes();
+  /// Extract output batch size. If the output batch size is going to be at
+  /// max_batch_size_, return true indicating that no output shape adjustment is
+  /// needed. Otherwise, return false.
+  int extractOutputBatchSizes();
 
-  // If needed, adjust output tensor shape based on the real input batch size.
-  // If the output shape is conditioned on first dim (batch size), we have a
-  // fast path to shrink the tensor shape by just manipulating the meta data.
-  // Otherwise, we have to slice it in the middle of the dimension with copy
-  // invoked. This is a slow path and we don't expect it to happen very often.
-  // We can already omit this step by setting "adjust_output_batch_" to false
-  void maybeAdjustOutputBatchSizes();
+  /// Adjust output tensor shape based on the current input batch size.
+  /// If the output shape is conditioned on first dim (batch size), we have a
+  /// fast path to shrink the tensor shape by just manipulating the meta data.
+  /// Otherwise, we have to slice it in the middle of the dimension with copy
+  /// invoked. This is a slow path and we don't expect it to happen very often.
+  /// We can already omit this step by setting "adjust_output_batch_" to false
+  void adjustOutputBatchSizes(int current_batch_size);
 
   std::vector<onnxTensorDescriptorV1> buildInitializationList(
       Workspace* ws,
@@ -314,6 +304,9 @@ class OnnxifiOp final : public Operator<Context> {
       std::vector<std::vector<uint64_t>>* weight_shapes,
       std::vector<std::vector<float>>* all_scales,
       std::vector<std::vector<int32_t>>* all_offsets) const;
+
+  /// initialize an OutputReshapeInfo object
+  details::OutputReshapeInfo initOutputReshapeInfo() const;
 
   // pointer to loaded onnxifi library
   onnxifi_library* lib_{nullptr};
@@ -330,7 +323,9 @@ class OnnxifiOp final : public Operator<Context> {
   std::vector<onnxTensorDescriptorV1> output_desc_;
 
   // Output reshape info
-  OutputReshapeInfo output_reshape_info_;
+  // It is a map keyed on batch size and the value OutputReshapeInfo for the
+  // batch size.
+  std::unordered_map<int, details::OutputReshapeInfo> output_reshape_info_;
 
 #ifdef ONNXIFI_ENABLE_EXT
   // onnxifi extension mode function pointer
@@ -383,7 +378,7 @@ class OnnxifiOp final : public Operator<Context> {
   std::vector<std::vector<int32_t>> all_offsets_;
 
   // output shape hints
-  std::unordered_map<int, TensorInfo> output_shape_hints_;
+  std::unordered_map<int, details::TensorInfo> output_shape_hints_;
 
   // input shape info. Used by shape inference when inputs are not at
   // max_batch_size


### PR DESCRIPTION
Summary: Shape inference is costly. In bad cases, if we have a lot of uneven tails, we are going to do quite amount of shape inference. This diff will enable each Onnxifi operator to cache the shape inference result for given batch size. In the worst case, we will occupy `num_inference_threads * max_batch_size` OutputReshapeInfo objects per model, where `num_inference_threads` and `max_batch_size` are smaller than 64.

Differential Revision: D21389946

