### PR TITLE
Include the value of unsupported scalarType and layout in the error message

### DIFF
--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -91,7 +91,7 @@ void registerLayoutObject(THPLayout *thp_layout, at::Layout layout) {
 THPDtype* getTHPDtype(at::ScalarType scalarType) {
   auto dtype = dtype_registry[static_cast<int>(scalarType)];
   if (!dtype) {
-    throw std::invalid_argument("unsupported scalarType");
+    throw std::invalid_argument(c10::str("unsupported scalarType: ", scalarType));
   }
   return dtype;
 }
@@ -99,7 +99,7 @@ THPDtype* getTHPDtype(at::ScalarType scalarType) {
 THPLayout* getTHPLayout(at::Layout layout) {
   auto thp_layout = layout_registry[static_cast<int>(layout)];
   if (!thp_layout) {
-    throw std::invalid_argument("unsupported at::Layout");
+    throw std::invalid_argument(c10::str("unsupported at::Layout: ", layout));
   }
   return thp_layout;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37804 Include the value of unsupported scalarType and layout in the error message**

Differential Revision: [D21396019](https://our.internmc.facebook.com/intern/diff/D21396019)