### PR TITLE
Tighten error checking in ConcreteModuleType

### DIFF
--- a/torch/csrc/jit/frontend/concrete_module_type.cpp
+++ b/torch/csrc/jit/frontend/concrete_module_type.cpp
@@ -176,9 +176,7 @@ std::shared_ptr<ConcreteModuleType> ConcreteModuleType::
       [&](const ConcreteModuleTypeBuilder::ModuleInfo& info) {
         return info.name_ == name;
       });
-  if (it == data_.modules_.end()) {
-    return nullptr;
-  }
+  TORCH_INTERNAL_ASSERT(it != data_.modules_.end());
   return it->meta_;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37813 Tighten error checking in ConcreteModuleType**

This condition should never fire.

Differential Revision: [D21398021](https://our.internmc.facebook.com/intern/diff/D21398021)