### PR TITLE
Profiler: Call `populate_cpu_children` inside `__str__` and fix typo

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2767,6 +2767,24 @@ class TestAutograd(TestCase):
 
         assert([get_children_ids(event) for event in events] == res)
 
+    def test_profiler_aggregation_table(self):
+        """
+        Test if the profiling result is aggregated for `repr(prof)` and `str(prof)`
+
+        See: https://github.com/pytorch/pytorch/issues/37500
+        """
+
+        x = torch.randn(1024)
+        with torch.autograd.profiler.profile() as prof:
+            torch.einsum("i->", x)
+
+        prof_str = str(prof)
+        prof_repr = repr(prof)
+        prof_table = prof.table()
+
+        self.assertEqual(prof_table, prof_str)
+        self.assertEqual(prof_table, prof_repr)
+
     def test_profiler_function_event_avg(self):
         avg = FunctionEventAvg()
         avg.add(FunctionEvent(id=0, name="foo", thread=0, cpu_start=10, cpu_end=15))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2779,11 +2779,9 @@ class TestAutograd(TestCase):
             torch.einsum("i->", x)
 
         prof_str = str(prof)
-        prof_repr = repr(prof)
         prof_table = prof.table()
 
         self.assertEqual(prof_table, prof_str)
-        self.assertEqual(prof_table, prof_repr)
 
     def test_profiler_function_event_avg(self):
         avg = FunctionEventAvg()

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2769,7 +2769,7 @@ class TestAutograd(TestCase):
 
     def test_profiler_aggregation_table(self):
         """
-        Test if the profiling result is aggregated for `repr(prof)` and `str(prof)`
+        Test if the profiling result is aggregated for `str(prof)`
 
         See: https://github.com/pytorch/pytorch/issues/37500
         """

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -40,7 +40,7 @@ class EventList(list):
         Example: In event list [[0, 10], [1, 3], [3, 4]] would have make [0, 10]
         be a parent of two other intervals.
 
-        If for any reason two intervals intersect only partialy, this function
+        If for any reason two intervals intersect only partially, this function
         will not record a parent child relationship between then.
         """
         if self.cpu_children_populated:
@@ -291,11 +291,13 @@ class profile(object):
     def __repr__(self):
         if self.function_events is None:
             return '<unfinished torch.autograd.profile>'
+        self.function_events.populate_cpu_children()
         return repr(self.function_events)
 
     def __str__(self):
         if self.function_events is None:
             return '<unfinished torch.autograd.profile>'
+        self.function_events.populate_cpu_children()
         return str(self.function_events)
 
     def _check_finish(self):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -291,7 +291,6 @@ class profile(object):
     def __repr__(self):
         if self.function_events is None:
             return '<unfinished torch.autograd.profile>'
-        self.function_events.populate_cpu_children()
         return repr(self.function_events)
 
     def __str__(self):


### PR DESCRIPTION
Fix #37500

I messed up with the old PR https://github.com/pytorch/pytorch/pull/37755 during rebasing and thus opened this one.

- Add call to `populate_cpu_children` for `__str__` to make sure that the printed result is correctly populated. 
- Add test `test_profiler_aggregation_table`
- Fix a minor typo
