### PR TITLE
[docs] Fix broken links in `contribution_guide.rst` and `governance.rst`

### DIFF
--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -7,8 +7,8 @@ building deep neural networks built on tape-based autograd systems.
 The PyTorch Contribution Process
 --------------------------------
 
-The PyTorch organization is governed by `PyTorch
-Governance </docs/source/community/governance.rst>`__.
+The PyTorch organization is governed by :doc:`PyTorch
+Governance <governance>`.
 
 The PyTorch development process involves a healthy amount of open
 discussions between the core development team and the community.

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -53,8 +53,8 @@ Core Developers
 ~~~~~~~~~~~~~~~
 
 The PyTorch project is developed by a team of core developers. You can
-find the list of core developers at `PyTorch Governance \| Persons of
-Interest </docs/source/community/persons_of_interest.rst>`__.
+find the list of core developers at :doc:`PyTorch Governance \| Persons of
+Interest <persons_of_interest>`.
 
 While membership is determined by presence in the "PyTorch core" team in
 the "PyTorch"
@@ -135,8 +135,8 @@ discuss.
 relatively minor, a pull request on GitHub can be opened up immediately
 for review and merge by the project committers. For larger changes,
 please open an issue to make a proposal to discuss prior. Please also
-see the `PyTorch Contributor
-Guide </docs/source/community/contribution_guide.rst>`__ for contribution
+see the :doc:`PyTorch Contributor
+Guide <contribution_guide>` for contribution
 guidelines.
 
 **Q: Can I become a committer on the project?** Unfortunately, the


### PR DESCRIPTION
Fix #37716

Fix three broken links in the documentation: 
- [PyTorch Governance](https://pytorch.org/docs/source/community/governance.rst) in the [Contribution Guide page](https://pytorch.org/docs/master/community/contribution_guide.html#the-pytorch-contribution-process)
- [PyTorch Governance | Persons of Interest](https://pytorch.org/docs/source/community/persons_of_interest.rst) under the [Core Developer section](https://pytorch.org/docs/master/community/governance.html#core-developers)
- [PyTorch Contributor Guide](https://pytorch.org/docs/source/community/contribution_guide.rst) under the [FAQ session of the Governance Page](https://pytorch.org/docs/master/community/governance.html#faq)

The old link leads to the `.rst` source file, which does not exist on the server. 

It's now fixed using the [document cross-referencing syntax](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/roles.html#cross-referencing-documents)