### PR TITLE
Remove unused capture in tensorpipe_agent.cpp

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -328,8 +328,7 @@ std::shared_ptr<FutureMessage> TensorPipeAgent::send(
               }
 
               threadPool_.run(
-                  [this,
-                   futureResponseMessage,
+                  [futureResponseMessage,
                    responseMessage{std::move(responseMessage)}]() mutable {
                     if (responseMessage.type() == MessageType::EXCEPTION) {
                       futureResponseMessage->setError(std::string(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37828 Remove unused capture in tensorpipe_agent.cpp**

Differential Revision: [D21407942](https://our.internmc.facebook.com/intern/diff/D21407942)