### PR TITLE
[TensorExpr] Add python bindings for TE fuser.

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -496,6 +496,9 @@ void initJITBindings(PyObject* module) {
       .def("_jit_set_texpr_fuser_enabled", &setTensorExprFuserEnabled)
       .def("_jit_texpr_fuser_enabled", &tensorExprFuserEnabled)
       .def(
+          "_jit_pass_fuse_tensorexprs",
+          [](std::shared_ptr<Graph>& g) { return FuseTensorExprs(g); })
+      .def(
           "_jit_fuser_get_fused_kernel_code",
           [](Graph& g, std::vector<at::Tensor> inps) {
             return debugGetFusedKernelCode(g, inps);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37831 [TensorExpr] Add python bindings for TE fuser.**

Differential Revision: [D21404947](https://our.internmc.facebook.com/intern/diff/D21404947)