### PR TITLE
Port register_prim_ops_c10.cpp to new registration API

### DIFF
--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -65,6 +65,14 @@ TORCH_LIBRARY(aten, m) {
   m.def("split.str(str self, str separator=' ', int max=-1) -> str[]");
   m.def("rsplit(str self, str separator=' ', int max=-1) -> str[]");
   m.def("join(str self, str[] values) -> str");
+
+  // Integer Ops
+  // Implementations located in torch/csrc/jit/runtime/register_prim_ops_c10.cp
+  m.def("Int.Tensor(Tensor a) -> int");
+  m.def("Int.bool(bool a) -> int");
+  m.def("Int.float(float a) -> int");
+  m.def("Int.Scalar(Scalar a) -> int");
+  m.def("Int.str(str a) -> int");
 }
 
 }  // namespace at

--- a/torch/csrc/jit/runtime/register_prim_ops_c10.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_c10.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/stack.h>
 #include <c10/util/string_utils.h>
+#include <torch/library.h>
 
 using Stack = std::vector<c10::IValue>;
 using at::Scalar;
@@ -13,39 +14,33 @@ using torch::jit::peek;
 using torch::jit::pop;
 using torch::jit::push;
 
-static auto registry_prim =
-    torch::RegisterOperators()
-        .op("aten::Int.Tensor(Tensor a) -> int",
-            torch::RegisterOperators::options()
-                .catchAllKernel(
-                    [](at::Tensor a) -> int64_t { return a.item<int64_t>(); })
-                .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
-        .op("aten::Int.bool(bool a) -> int",
-            torch::RegisterOperators::options()
-                .catchAllKernel(
-                    [](bool b) -> int64_t { return static_cast<int64_t>(b); })
-                .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
-        .op("aten::Int.float(float a) -> int",
-            torch::RegisterOperators::options()
-                .catchAllKernel(
-                    [](double d) -> int64_t { return static_cast<int64_t>(d); })
-                .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
-        .op("aten::Int.Scalar(Scalar a) -> int",
-            torch::RegisterOperators::options()
-                .catchAllKernel(
-                    [](Scalar scalar) -> int64_t { return scalar.toInt(); })
-                .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA))
-        .op("aten::Int.str(str a) -> int",
-            torch::RegisterOperators::options()
-                .catchAllKernel([](const std::string& str) -> int64_t {
-                  std::string::size_type sz;
-                  int64_t val = static_cast<int64_t>(c10::stoll(str, &sz));
-                  if (sz != str.size()) {
-                    std::stringstream error_str;
-                    error_str << "invalid literal for int() "
-                              << "with base 10: '" << str << "'";
-                    throw std::runtime_error(error_str.str());
-                  }
-                  return val;
-                })
-                .aliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA));
+// Implementations located in torch/csrc/jit/runtime/register_prim_ops_c10.cpp
+TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
+  m.impl("Int.Tensor",[](at::Tensor a) {
+    return a.item<int64_t>();
+  });
+
+  m.impl("Int.bool", [](bool b) {
+    return static_cast<int64_t>(b);
+  });
+
+  m.impl("Int.float", [](double d) {
+    return static_cast<int64_t>(d);
+  });
+
+  m.impl("Int.Scalar", [](Scalar scalar) {
+    return static_cast<int64_t>(scalar.toInt());
+  });
+
+  m.impl("Int.str", [](const std::string& str) {
+    std::string::size_type sz;
+    int64_t val = static_cast<int64_t>(c10::stoll(str, &sz));
+    if (sz != str.size()) {
+      std::stringstream error_str;
+      error_str << "invalid literal for int() "
+                << "with base 10: '" << str << "'";
+      throw std::runtime_error(error_str.str());
+    }
+    return val;
+  });
+}

--- a/torch/csrc/jit/runtime/register_prim_ops_c10.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_c10.cpp
@@ -16,17 +16,11 @@ using torch::jit::push;
 
 // Implementations located in torch/csrc/jit/runtime/register_prim_ops_c10.cpp
 TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
-  m.impl("Int.Tensor",[](at::Tensor a) {
-    return a.item<int64_t>();
-  });
+  m.impl("Int.Tensor", [](at::Tensor a) { return a.item<int64_t>(); });
 
-  m.impl("Int.bool", [](bool b) {
-    return static_cast<int64_t>(b);
-  });
+  m.impl("Int.bool", [](bool b) { return static_cast<int64_t>(b); });
 
-  m.impl("Int.float", [](double d) {
-    return static_cast<int64_t>(d);
-  });
+  m.impl("Int.float", [](double d) { return static_cast<int64_t>(d); });
 
   m.impl("Int.Scalar", [](Scalar scalar) {
     return static_cast<int64_t>(scalar.toInt());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37834 Port register_prim_ops_c10.cpp to new registration API**

Ported all use sites of the old registration API to use new Integer operator registration API.

Differential Revision: [D21415700](https://our.internmc.facebook.com/intern/diff/D21415700)