### PR TITLE
[Tensorpipe Agent] Call Shutdown from Destructor and Join

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -42,7 +42,7 @@ TensorPipeAgent::TensorPipeAgent(
 }
 
 TensorPipeAgent::~TensorPipeAgent() {
-  shutdownImpl();
+  shutdown();
 }
 
 void TensorPipeAgent::startImpl() {
@@ -351,7 +351,7 @@ void TensorPipeAgent::sync() {}
 
 // TODO: Remove join()
 void TensorPipeAgent::join() {
-  shutdownImpl();
+  shutdown();
 }
 
 void TensorPipeAgent::shutdownImpl() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37839 [Tensorpipe Agent] Call Shutdown from Destructor and Join**

Calling `RpcAgent::shutdown` from the TensorpipeAgent will ensure that parent class threads are joined and the atomic is set to False.

Differential Revision: [D21291974](https://our.internmc.facebook.com/intern/diff/D21291974/)