### PR TITLE
[jit] fix trace checking reporting divergent names

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -349,6 +349,23 @@ class TestJit(JitTestCase):
 
         self.checkTrace(f, (x, y))
 
+    def test_trace_checking_with_global_name(self):
+        class MyClass(torch.nn.Module):
+            def __init__(self):
+                super(MyClass, self).__init__()
+
+            def forward(self, xs: List[Tensor]):
+                y = torch.cat(xs, dim=0)
+                return y
+
+        model = MyClass()
+        # Simulate these inputs being in the globals, like they would be if,
+        # e.g. they were defined outermost scope of a script
+        global input1, input2
+        input1 = torch.ones(2, 2)
+        input2 = torch.ones(2, 2)
+        m2 = torch.jit.trace(model, ((input1, input2),))
+
     def test_trace_aliased_parameter(self):
         class M(nn.Module):
             def __init__(self, x):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -316,9 +316,6 @@ def _create_interpreter_name_lookup_fn(frames_up=1):
         for k, v in f_locals.items():
             if isinstance(v, torch.Tensor) and var is v:
                 return k if k != 'self' else ''
-        for k, v in f_globals.items():
-            if isinstance(v, torch.Tensor) and var is v:
-                return k if k != 'self' else ''
         return ''
     return _get_interpreter_name_for_var
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37842 [jit] fix trace checking reporting divergent names**

Fixes https://github.com/pytorch/pytorch/issues/23993.

Previously our name lookup function for the tracer was looking in
f.globals for names. For example:
```
sample1 = torch.ones(1)
sample2 = torch.ones(1)
traced = torch.jit.trace(my_mod, ((sample1, sample2,),))
> produces a graph with something like:
> %sample1, %sample2 = prim::TupleUnpack(%input)
```

This is not great if you are, e.g. trace checking, because a non-local
bit of interpreter state is affected the graph produced:
```
traced = torch.jit.trace(my_mod, _clone_inputs((sample, sample,),))
> produces a graph with something like
> %0, %1 = prim::TupleUnpack(%input)
```
I have removed this functionality, as I don't think it provides huge
value. Things that look locally for names will still work, so e.g.
inputs, intermediate variables, and the like will be named correctly.

Differential Revision: [D21406478](https://our.internmc.facebook.com/intern/diff/D21406478)