### PR TITLE
[Tensorpipe Agent] Base Structs for Tracking RPC Metrics

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -31,7 +31,7 @@ void TensorPipeAgent::TimeSeriesMetricsTracker::addData(uint64_t dataPoint) {
   ++currentCount_;
 }
 
-float TensorPipeAgent::TimeSeriesMetricsTracker::computeAverage() {
+float TensorPipeAgent::TimeSeriesMetricsTracker::computeAverage() const {
   return currentCount_ == 0 ? 0 : currentSum_ / (float)currentCount_;
 }
 

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -21,17 +21,17 @@ constexpr long kToMilliseconds = 1000;
 
 //////////////////////////  MetricsTracker  /////////////////////////////////
 
-TimeSeriesMetricsTracker::TimeSeriesMetricsTracker(
+TensorPipeAgent::TimeSeriesMetricsTracker::TimeSeriesMetricsTracker(
     uint64_t currentSum,
     uint64_t currentCount)
     : currentSum_(currentSum), currentCount_(currentCount) {}
 
-void TimeSeriesMetricsTracker::addData(uint64_t dataPoint) {
+void TensorPipeAgent::TimeSeriesMetricsTracker::addData(uint64_t dataPoint) {
   currentSum_ += dataPoint;
   ++currentCount_;
 }
 
-float TimeSeriesMetricsTracker::computeAverage() {
+float TensorPipeAgent::TimeSeriesMetricsTracker::computeAverage() {
   return currentCount_ == 0 ? 0 : currentSum_ / (float)currentCount_;
 }
 

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -19,6 +19,24 @@ namespace rpc {
 
 constexpr long kToMilliseconds = 1000;
 
+//////////////////////////  MetricsTracker  /////////////////////////////////
+
+TimeSeriesMetricsTracker::TimeSeriesMetricsTracker(
+    uint64_t currentSum,
+    uint64_t currentCount)
+    : currentSum_(currentSum), currentCount_(currentCount) {}
+
+void TimeSeriesMetricsTracker::addData(uint64_t dataPoint) {
+  currentSum_ += dataPoint;
+  ++currentCount_;
+}
+
+float TimeSeriesMetricsTracker::computeAverage() {
+  return currentCount_ == 0 ? 0 : currentSum_ / (float)currentCount_;
+}
+
+////////////////////////  TensorpipeRpcAgent  /////////////////////////////////
+
 TensorPipeAgent::TensorPipeAgent(
     worker_id_t selfId,
     std::string selfName,

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -120,6 +120,25 @@ class TensorPipeAgent : public RpcAgent {
 
   mutable std::mutex mutex_;
   uint64_t nextMessageID_{0};
+
+  // Struct for capturing Time-Series Metrics
+  struct TimeSeriesMetricsTracker {
+    uint64_t currentSum_;
+    uint64_t currentCount_;
+
+    explicit TimeSeriesMetricsTracker(
+        uint64_t currentSum = 0,
+        uint64_t currentCount = 0);
+
+    void addData(uint64_t dataPoint);
+    float computeAverage();
+  };
+
+  // Map of Time-Series metrics tracked by the RPC Agent
+  std::unordered_map<std::string, std::unique_ptr<TimeSeriesMetricsTracker>>
+      timeSeriesMetrics_;
+  // Mutex to guard timeSeriesMetrics_
+  std::mutex metricsMutex_;
 };
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -121,17 +121,26 @@ class TensorPipeAgent : public RpcAgent {
   mutable std::mutex mutex_;
   uint64_t nextMessageID_{0};
 
-  // Struct for capturing Time-Series Metrics
+  // This is a generic struct for capturing Time-Series Metrics. It keeps a
+  // running sum and count of data points (observations), and can return an
+  // average of the data points seen so far. This is currently only used for
+  // tracking the GIL Wait Time in RPC Agents, but can be used for other metrics
+  // as well.
   struct TimeSeriesMetricsTracker {
+    // Running sum of the data points seen so far
     uint64_t currentSum_;
+    // Running count of the data points seen so far
     uint64_t currentCount_;
 
     explicit TimeSeriesMetricsTracker(
         uint64_t currentSum = 0,
         uint64_t currentCount = 0);
 
+    // Adds a data point (which is basically one observation for the metric
+    // being tracked) to the running sum and count.
     void addData(uint64_t dataPoint);
-    float computeAverage();
+    // Returns the average of all the data points seen so far.
+    float computeAverage const();
   };
 
   // Map of Time-Series metrics tracked by the RPC Agent

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -140,7 +140,7 @@ class TensorPipeAgent : public RpcAgent {
     // being tracked) to the running sum and count.
     void addData(uint64_t dataPoint);
     // Returns the average of all the data points seen so far.
-    float computeAverage const();
+    float computeAverage() const;
   };
 
   // Map of Time-Series metrics tracked by the RPC Agent


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37980 [Tensorpipe Agent] Implementing getMetrics with currently available metrics
* #37852 [Tensorpipe Agent] Network Data Profiling
* #37851 [Tensorpipe Agent] Implement Global Interpreter Lock Wait Time Metric
* **#37850 [Tensorpipe Agent] Base Structs for Tracking RPC Metrics**

Adding the base structs for tracking time-series metrics in the Tensorpipe RPC Agent

Differential Revision: [D21339520](https://our.internmc.facebook.com/intern/diff/D21339520/)