### PR TITLE
[Tensorpipe Agent] Implement Global Interpreter Lock Wait Time Metric

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -56,7 +56,7 @@ class TensorPipeAgent : public RpcAgent {
     return metrics;
   }
 
-  void addGilWaitTime(const std::chrono::microseconds gilWaitTime);
+  void addGilWaitTime(const std::chrono::microseconds gilWaitTime) override;
 
  private:
   const std::string& findWorkerURL(const WorkerInfo& worker) const;

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -56,7 +56,7 @@ class TensorPipeAgent : public RpcAgent {
     return metrics;
   }
 
-  void addGilWaitTime(const std::chrono::microseconds /* unused */) override {}
+  void addGilWaitTime(const std::chrono::microseconds gilWaitTime);
 
  private:
   const std::string& findWorkerURL(const WorkerInfo& worker) const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37980 [Tensorpipe Agent] Implementing getMetrics with currently available metrics
* #37852 [Tensorpipe Agent] Network Data Profiling
* **#37851 [Tensorpipe Agent] Implement Global Interpreter Lock Wait Time Metric**
* #37850 [Tensorpipe Agent] Base Structs for Tracking RPC Metrics

Tracks `GilWaitTime` metric in the Tensorpipe RPC Agent.

Differential Revision: [D21339527](https://our.internmc.facebook.com/intern/diff/D21339527/)