### PR TITLE
[Tensorpipe Agent] Network Data Profiling

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -452,7 +452,7 @@ NetworkSourceInfo TensorPipeAgent::getNetworkSourceInfo() {
 void TensorPipeAgent::trackNetworkData(
     uint64_t requestSize,
     uint64_t responseSize,
-    std::string destWorkerName) {
+    const std::string& destWorkerName) {
   std::lock_guard<std::mutex> lock(networkDataMutex_);
   networkData_[destWorkerName].numCalls++;
   networkData_[destWorkerName].totalSentBytes += requestSize;
@@ -461,7 +461,7 @@ void TensorPipeAgent::trackNetworkData(
 
 void TensorPipeAgent::trackNetworkError(
     uint64_t requestSize,
-    std::string destWorkerName) {
+    const std::string& destWorkerName) {
   std::lock_guard<std::mutex> lock(networkDataMutex_);
   networkData_[destWorkerName].numCalls++;
   networkData_[destWorkerName].totalSentBytes += requestSize;

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -452,20 +452,20 @@ NetworkSourceInfo TensorPipeAgent::getNetworkSourceInfo() {
 void TensorPipeAgent::trackNetworkData(
     uint64_t requestSize,
     uint64_t responseSize,
-    worker_id_t destRank) {
+    worker_id_t destWorkerId) {
   std::lock_guard<std::mutex> lock(networkDataMutex_);
-  networkData_[destRank].numCalls++;
-  networkData_[destRank].totalSentBytes += requestSize;
-  networkData_[destRank].totalRecvBytes += responseSize;
+  networkData_[destWorkerId].numCalls++;
+  networkData_[destWorkerId].totalSentBytes += requestSize;
+  networkData_[destWorkerId].totalRecvBytes += responseSize;
 }
 
 void TensorPipeAgent::trackNetworkError(
     uint64_t requestSize,
-    worker_id_t destRank) {
+    worker_id_t destWorkerId) {
   std::lock_guard<std::mutex> lock(networkDataMutex_);
-  networkData_[destRank].numCalls++;
-  networkData_[destRank].totalSentBytes += requestSize;
-  networkData_[destRank].totalErrors++;
+  networkData_[destWorkerId].numCalls++;
+  networkData_[destWorkerId].totalSentBytes += requestSize;
+  networkData_[destWorkerId].totalErrors++;
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -452,20 +452,20 @@ NetworkSourceInfo TensorPipeAgent::getNetworkSourceInfo() {
 void TensorPipeAgent::trackNetworkData(
     uint64_t requestSize,
     uint64_t responseSize,
-    worker_id_t destWorkerId) {
+    std::string destWorkerName) {
   std::lock_guard<std::mutex> lock(networkDataMutex_);
-  networkData_[destWorkerId].numCalls++;
-  networkData_[destWorkerId].totalSentBytes += requestSize;
-  networkData_[destWorkerId].totalRecvBytes += responseSize;
+  networkData_[destWorkerName].numCalls++;
+  networkData_[destWorkerName].totalSentBytes += requestSize;
+  networkData_[destWorkerName].totalRecvBytes += responseSize;
 }
 
 void TensorPipeAgent::trackNetworkError(
     uint64_t requestSize,
-    worker_id_t destWorkerId) {
+    std::string destWorkerName) {
   std::lock_guard<std::mutex> lock(networkDataMutex_);
-  networkData_[destWorkerId].numCalls++;
-  networkData_[destWorkerId].totalSentBytes += requestSize;
-  networkData_[destWorkerId].totalErrors++;
+  networkData_[destWorkerName].numCalls++;
+  networkData_[destWorkerName].totalSentBytes += requestSize;
+  networkData_[destWorkerName].totalErrors++;
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -73,7 +73,7 @@ class TensorPipeAgent : public RpcAgent {
   void addGilWaitTime(const std::chrono::microseconds gilWaitTime) override;
 
   using NetworkDataDict =
-      std::unordered_map<worker_id_t, AggregatedNetworkData>;
+      std::unordered_map<std::string, AggregatedNetworkData>;
 
   NetworkDataDict getNetworkData();
   NetworkSourceInfo getNetworkSourceInfo();

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -169,7 +169,7 @@ class TensorPipeAgent : public RpcAgent {
     // being tracked) to the running sum and count.
     void addData(uint64_t dataPoint);
     // Returns the average of all the data points seen so far.
-    float computeAverage const();
+    float computeAverage() const;
   };
 
   // Map of Time-Series metrics tracked by the RPC Agent

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -115,10 +115,10 @@ class TensorPipeAgent : public RpcAgent {
   void trackNetworkData(
       uint64_t requestSize,
       uint64_t responseSize,
-      worker_id_t destRank);
+      worker_id_t destWorkerId);
 
   // Collects metrics from failed RPC calls
-  void trackNetworkError(uint64_t requestSize, worker_id_t destRank);
+  void trackNetworkError(uint64_t requestSize, worker_id_t destWorkerId);
 
   // State per client pipe to keep tracking of pending response message
   // and error sate. pendingResponseMessage_ should be protected by

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -115,10 +115,12 @@ class TensorPipeAgent : public RpcAgent {
   void trackNetworkData(
       uint64_t requestSize,
       uint64_t responseSize,
-      std::string destWorkerName);
+      const std::string& destWorkerName);
 
   // Collects metrics from failed RPC calls
-  void trackNetworkError(uint64_t requestSize, std::string destWorkerName);
+  void trackNetworkError(
+      uint64_t requestSize,
+      const std::string& destWorkerName);
 
   // State per client pipe to keep tracking of pending response message
   // and error sate. pendingResponseMessage_ should be protected by

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -115,10 +115,10 @@ class TensorPipeAgent : public RpcAgent {
   void trackNetworkData(
       uint64_t requestSize,
       uint64_t responseSize,
-      worker_id_t destWorkerId);
+      std::string destWorkerName);
 
   // Collects metrics from failed RPC calls
-  void trackNetworkError(uint64_t requestSize, worker_id_t destWorkerId);
+  void trackNetworkError(uint64_t requestSize, std::string destWorkerName);
 
   // State per client pipe to keep tracking of pending response message
   // and error sate. pendingResponseMessage_ should be protected by

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -118,10 +118,7 @@ class TensorPipeAgent : public RpcAgent {
       worker_id_t destRank);
 
   // Collects metrics from failed RPC calls
-  void trackNetworkError(
-      uint64_t requestSize,
-      uint64_t responseSize,
-      worker_id_t destRank);
+  void trackNetworkError(uint64_t requestSize, worker_id_t destRank);
 
   // State per client pipe to keep tracking of pending response message
   // and error sate. pendingResponseMessage_ should be protected by


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37980 [Tensorpipe Agent] Implementing getMetrics with currently available metrics
* **#37852 [Tensorpipe Agent] Network Data Profiling**
* #37851 [Tensorpipe Agent] Implement Global Interpreter Lock Wait Time Metric
* #37850 [Tensorpipe Agent] Base Structs for Tracking RPC Metrics

This tracks network-related metrics in the Tensorpipe RPC Agent including number of bytes sent and recieved on each node, number of errors, number of successful calls, etc.

Differential Revision: [D21340499](https://our.internmc.facebook.com/intern/diff/D21340499/)