### PR TITLE
[Tensorpipe Agent] Adding Tensorpipe Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,10 @@
 /torch/distributed/autograd @mrshenli @pritamdamania87 @zhaojuanmao
 /torch/distributed/optim @mrshenli @pritamdamania87 @zhaojuanmao @aazzolini
 
+# Tensorpipe RPC Agent.
+/torch/csrc/distributed/rpc/tensorpipe_agent.cpp @jiayisuse @osalpekar @lw @beauby
+/torch/csrc/distributed/rpc/tensorpipe_agent.h @jiayisuse @osalpekar @lw @beauby
+
 # Distributed tests
 /test/distributed @mrshenli @pritamdamania87 @zhaojuanmao
 /torch/testing/_internal/distributed @mrshenli @pritamdamania87 @zhaojuanmao


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37854 [Tensorpipe Agent] Adding Tensorpipe Codeowners**

Adding Tensorpipe contributors to the Codeowners file for Tensorpipe-related functionality in PyTorch.

Differential Revision: [D21408676](https://our.internmc.facebook.com/intern/diff/D21408676/)