### PR TITLE
[future] Minor: std::move() callback in future for the convenience operator case.

### DIFF
--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -130,7 +130,7 @@ class TORCH_API Future final {
   }
 
   void addCallback(std::function<void(const Future<T>& future)> cb) {
-    addCallback([this, cb]() { cb(*this); });
+    addCallback([this, cb = std::move(cb)]() { cb(*this); });
   }
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37861 [future] Minor: std::move() callback in future for the convenience operator case.**

This avoids an unnecessary copy in the cases where this operator is used.

Differential Revision: [D21409650](https://our.internmc.facebook.com/intern/diff/D21409650/)