### PR TITLE
[TensorExpr] Expression cost estimator

### DIFF
--- a/test/cpp/tensorexpr/test_cost_estimator.cpp
+++ b/test/cpp/tensorexpr/test_cost_estimator.cpp
@@ -1,0 +1,284 @@
+#include "test/cpp/tensorexpr/test_base.h"
+
+#include <torch/csrc/jit/tensorexpr/cost_estimator.h>
+#include "test/cpp/tensorexpr/test_utils.h"
+
+namespace torch {
+namespace jit {
+using namespace torch::jit::tensorexpr;
+
+void testCostEstimatorSimple() {
+  KernelScope kernel_scope;
+  Expr* f =
+      new Add(getImmediateByType(kFloat, 2.f), getImmediateByType(kFloat, 3.f));
+
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(f);
+
+  // There are 3 Exprs, but only one has cost.
+  ASSERT_TRUE(cost->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost), 1);
+}
+
+void testCostEstimatorCompound() {
+  KernelScope kernel_scope;
+  ExprHandle a(59);
+  ExprHandle b(22);
+  ExprHandle c(101);
+  ExprHandle f = (a ^ b) & c;
+
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(f.node());
+
+  // Two binary ops.
+  ASSERT_TRUE(cost->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost), 2);
+}
+
+void testCostEstimatorStaticFor() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {4}, kInt));
+  Buffer c(BufHandle("C", {4}, kInt));
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto body =
+      For::make(i, 0, 10, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(body);
+
+  // 10 loop * store + load + 10 increments + 11 compare with stop.
+  ASSERT_TRUE(cost->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost), 271);
+}
+
+void testCostEstimatorVariableFor() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {4}, kInt));
+  Buffer c(BufHandle("C", {4}, kInt));
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  VarHandle j("j", kInt);
+  auto body =
+      For::make(i, 0, j, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(body);
+
+  // j loops * (store + load = 25) + j increments + (j+1) compares:
+  //  25 * j + j + j + 1 => 27 * j + 1.
+  ASSERT_FALSE(cost->isConstant());
+
+  ExprHandle expected = ExprHandle(27) * j + ExprHandle(1);
+
+  // Compare via hash.
+  HashProvider hasher;
+  ASSERT_EQ(hasher.hash(cost), hasher.hash(expected.node()));
+}
+
+void testCostEstimatorBlock() {
+  KernelScope kernel_scope;
+  Buffer c(BufHandle("C", {4}, kInt));
+  auto mask = IntImm::make(1);
+
+  auto store1 = Store::make(c, {0}, IntImm::make(0), mask);
+  auto store2 = Store::make(c, {2}, IntImm::make(2), mask);
+  auto store3 = Store::make(c, {3}, IntImm::make(3), mask);
+  auto store4 = Store::make(c, {1}, IntImm::make(1), mask);
+
+  auto body = Block::make({store1, store2, store3, store4});
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(body);
+
+  // 4 store (15 cost) statements = 60.
+  ASSERT_TRUE(cost->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost), 60);
+}
+
+void testCostEstimatorLoadStoreIndices() {
+  KernelScope kernel_scope;
+  Buffer c(BufHandle("C", {5, 5, 5}, kInt));
+  auto mask = IntImm::make(1);
+
+  auto idx1 = ExprHandle(1) + ExprHandle(2);
+  auto idx2 = ExprHandle(2) * ExprHandle(2);
+  auto idx3 = ExprHandle(10) / ExprHandle(2);
+
+  auto store1 = Store::make(c, {idx1, idx2, idx3}, IntImm::make(0), mask);
+
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(store1);
+
+  // store (15 costs) + indexes (1, 1 and 1) => 18.
+  ASSERT_TRUE(cost->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost), 18);
+
+  VarHandle i("i", kInt);
+  auto body = For::make(i, 0, 5, store1);
+  const Expr* cost2 = estimator.estimateCost(body);
+
+  // Cost is 5 * store (18) + 5 + (5+1) => 101.
+  ASSERT_TRUE(cost2->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost2), 101);
+}
+
+void testCostEstimatorCond() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  VarHandle i("i", kInt);
+
+  Buffer c(BufHandle("C", {4}, kInt));
+  auto body = Cond::make(
+      x > y,
+      For::make(
+          i, 0, 10, Store::make(c, {0}, IntImm::make(1), IntImm::make(1))),
+      For::make(
+          i, 0, 3, Store::make(c, {1}, IntImm::make(1), IntImm::make(1))));
+
+  // true branch is cost 10 * 15 + 20, false branch is cost 3 * 15 + 7. We don't
+  // know which branch to take so assume worse case. total cost then is
+  // max(10*15, 3
+  // * 15) + 1 (for the compare).
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(body);
+
+  ASSERT_TRUE(cost->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost), 172);
+}
+
+void testCostEstimatorAllocFree() {
+  KernelScope kernel_scope;
+  Buffer c(BufHandle("C", {5, 5, 5}, kInt));
+  VarHandle cV(c.data()->base_handle());
+
+  auto* allocStmt = Allocate::make(cV, kInt, {2, 3, 4});
+  auto* storeStmt = Store::make(c, {0, 0, 0}, 1, 1);
+  auto* freeStmt = Free::make(cV);
+
+  auto* block = Block::make({allocStmt, storeStmt, freeStmt});
+
+  CostEstimator estimator;
+  const Expr* cost = estimator.estimateCost(block);
+
+  // Alloc cost is dependent on the amount of bytes allocated, but just check
+  // its >0.
+  ASSERT_TRUE(cost->isConstant());
+  ASSERT_GT(immediateAs<float>(cost), 17);
+}
+
+void testCostEstimatorDictionary() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  ExprHandle body = ((ExprHandle(2)) * (x / y) * y) - ((x / y) * y);
+
+  CostEstimator estimator1;
+  const Expr* cost1 = estimator1.estimateCost(body.node());
+
+  // Six binary ops.
+  ASSERT_TRUE(cost1->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost1), 6);
+
+  // Use a dictionary that makes referencing vars very expensive.
+  OpCostDictionary dict;
+  dict.VAR_REF_COST = 1000;
+
+  CostEstimator estimator2(dict);
+  const Expr* cost2 = estimator2.estimateCost(body.node());
+
+  // Six binary ops and six expensive var references.
+  ASSERT_TRUE(cost2->isConstant());
+  ASSERT_EQ(immediateAs<int>(cost2), 6006);
+}
+
+void testCostEstimatorSanityCheck() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  ExprHandle body = ((ExprHandle(2)) * (x / y) * y) - ((x / y) * y);
+
+  CostEstimator estimator;
+  const Expr* cost1 = estimator.estimateCost(body.node());
+
+  ExprHandle simplified = IRSimplifier::simplify(body);
+  const Expr* cost2 = estimator.estimateCost(simplified.node());
+
+  // Check that simplification reduces estimated op cost for this expression
+  // where we know it will.
+  ASSERT_TRUE(cost1->isConstant());
+  ASSERT_TRUE(cost2->isConstant());
+  ASSERT_GT(immediateAs<int>(cost1), immediateAs<int>(cost2));
+}
+
+void testCostEstimatorFindCommonExpr() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+
+  ExprHandle body = ((ExprHandle(2)) * (x / y) * y) - ((x / y) * y);
+
+  Buffer c(BufHandle("C", {2}, kInt));
+  auto* store1 = Store::make(c, {0}, body, 1);
+  auto* store2 = Store::make(c, {1}, body, 1);
+
+  auto* block = Block::make({store1, store2});
+
+  CostEstimator estimator;
+  auto info = estimator.getInfo(block);
+
+  ASSERT_EQ(info.count, 1);
+
+  // The body appears twice (in both stores).
+  info = estimator.getInfo(body.node());
+  ASSERT_EQ(info.count, 2);
+
+  // TODO: the stores would also be count two because we don't have the
+  // dependency info to know they're different. We should probably ensure all
+  // Stores have different hashes.
+}
+
+void testCostEstimatorFindCommonParent() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  VarHandle i("i", kInt);
+
+  ExprHandle body = ((ExprHandle(2)) * (x / y) * y) - ((x / y) * y);
+
+  Buffer c(BufHandle("C", {2}, kInt));
+  auto* store1 = Store::make(c, {0}, body, 1);
+  auto* for1 = For::make(i, 0, 5, store1);
+  auto* store2 = Store::make(c, {1}, body, 1);
+  auto* for2 = For::make(i, 0, 5, store2);
+
+  auto* block = Block::make({for1, for2});
+
+  CostEstimator estimator;
+  auto info = estimator.getInfo(for1);
+  ASSERT_EQ(info.count, 1);
+  info = estimator.getInfo(body.node());
+  ASSERT_EQ(info.parent, for1->body());
+
+  estimator.clear();
+  info = estimator.getInfo(block);
+
+  // The body appears twice (in both stores).
+  info = estimator.getInfo(body.node());
+  ASSERT_EQ(info.count, 2);
+  ASSERT_EQ(info.parent, block);
+
+  // verify that if they have no shared parent we recognize that.
+  estimator.clear();
+
+  // don't care about info here but want to add the store's state.
+  info = estimator.getInfo(store1);
+  info = estimator.getInfo(store2);
+
+  info = estimator.getInfo(body.node());
+  ASSERT_EQ(info.count, 2);
+  ASSERT_EQ(info.parent, nullptr);
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -111,6 +111,18 @@ namespace jit {
   _(ATengtInt)                              \
   _(ATenleInt)                              \
   _(ATenltInt)                              \
+  _(CostEstimatorSimple)                    \
+  _(CostEstimatorCompound)                  \
+  _(CostEstimatorStaticFor)                 \
+  _(CostEstimatorVariableFor)               \
+  _(CostEstimatorBlock)                     \
+  _(CostEstimatorLoadStoreIndices)          \
+  _(CostEstimatorCond)                      \
+  _(CostEstimatorAllocFree)                 \
+  _(CostEstimatorDictionary)                \
+  _(CostEstimatorSanityCheck)               \
+  _(CostEstimatorFindCommonExpr)            \
+  _(CostEstimatorFindCommonParent)          \
   _(ConstantFoldSimple)                     \
   _(ConstantFoldTwoLayer)                   \
   _(ConstantFoldShifts)                     \

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -199,6 +199,7 @@ libtorch_core_sources = [
     "torch/csrc/jit/tensorexpr/codegen.cpp",
     "torch/csrc/jit/tensorexpr/eval.cpp",
     "torch/csrc/jit/tensorexpr/expr.cpp",
+    "torch/csrc/jit/tensorexpr/cost_estimator.cpp",
     "torch/csrc/jit/tensorexpr/function.cpp",
     "torch/csrc/jit/tensorexpr/hash_provider.cpp",
     "torch/csrc/jit/tensorexpr/ir.cpp",

--- a/torch/csrc/jit/tensorexpr/cost_estimator.cpp
+++ b/torch/csrc/jit/tensorexpr/cost_estimator.cpp
@@ -1,0 +1,372 @@
+#include <torch/csrc/jit/tensorexpr/cost_estimator.h>
+
+#include <set>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+const Stmt* CostEstimator::getSharedParent(const Stmt* a, const Stmt* b) {
+  std::set<const Stmt*> ancestors;
+  const Stmt* p = a;
+  while (p) {
+    ancestors.insert(p);
+    p = p->get_parent();
+  }
+
+  p = b;
+  bool found = false;
+  while (p) {
+    if (ancestors.count(p) > 0) {
+      found = true;
+      break;
+    }
+    p = p->get_parent();
+  }
+
+  return p;
+}
+
+void CostEstimator::visit(const Add* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Sub* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Mul* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Div* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Mod* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Max* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Min* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const And* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Or* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Xor* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Lshift* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const Rshift* v) {
+  scanBinaryOp(v);
+}
+
+void CostEstimator::visit(const CompareSelect* v) {
+  v->lhs()->accept(this);
+  v->rhs()->accept(this);
+  v->ret_val1()->accept(this);
+  v->ret_val2()->accept(this);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  auto lhsInfo = exprInfo_[hasher_.hash(v->lhs())];
+  auto rhsInfo = exprInfo_[hasher_.hash(v->rhs())];
+  auto ret1Info = exprInfo_[hasher_.hash(v->ret_val1())];
+  auto ret2Info = exprInfo_[hasher_.hash(v->ret_val2())];
+
+  const Expr* cost = new Add(
+      getImmediateByType(kInt, dict_.COMPARE_OP_COST),
+      new Add(lhsInfo.cost, rhsInfo.cost));
+  cost = new Add(cost, new Max(ret1Info.cost, ret2Info.cost, true));
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Cast* v) {
+  v->src_value()->accept(this);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  auto srcInfo = exprInfo_[hasher_.hash(v->src_value())];
+  const Expr* cost =
+      new Add(getImmediateByType(kInt, dict_.CAST_OP_COST), srcInfo.cost);
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Var* v) {
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash,
+      SubExprInfo(1, getImmediateByType(kInt, dict_.VAR_REF_COST), lastBlock_));
+}
+
+void CostEstimator::visit(const Ramp* v) {
+  v->base()->accept(this);
+  v->stride()->accept(this);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  auto baseInfo = exprInfo_[hasher_.hash(v->base())];
+  auto strideInfo = exprInfo_[hasher_.hash(v->stride())];
+  const Expr* cost = new Add(
+      baseInfo.cost,
+      new Mul(strideInfo.cost, getImmediateByType(kInt, v->lanes())));
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Load* v) {
+  v->base_handle()->accept(this);
+  const Expr* cost = getImmediateByType(kInt, dict_.LOAD_OP_COST);
+
+  for (const Expr* ind : v->indices()) {
+    ind->accept(this);
+    cost = new Add(cost, exprInfo_[hasher_.hash(ind)].cost);
+  }
+  v->mask()->accept(this);
+  cost = new Add(cost, exprInfo_[hasher_.hash(v->mask())].cost);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Store* v) {
+  v->base_handle()->accept(this);
+  const Expr* cost = getImmediateByType(kInt, dict_.STORE_OP_COST);
+
+  for (const Expr* ind : v->indices()) {
+    ind->accept(this);
+    cost = new Add(cost, exprInfo_[hasher_.hash(ind)].cost);
+  }
+
+  v->value()->accept(this);
+  cost = new Add(cost, exprInfo_[hasher_.hash(v->value())].cost);
+  v->mask()->accept(this);
+
+  // TODO: does the mark affect the cost of the store (ie. mask of 0 is free?).
+  cost = new Add(cost, exprInfo_[hasher_.hash(v->mask())].cost);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Block* v) {
+  // push this block onto block stack.
+  const Stmt* prev = lastBlock_;
+  lastBlock_ = v;
+
+  const Expr* cost = getImmediateByType(kInt, 0);
+  for (Stmt* s : *v) {
+    s->accept(this);
+    cost = new Add(cost, exprInfo_[hasher_.hash(s)].cost);
+  }
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+
+  // pop this block.
+  lastBlock_ = prev;
+}
+
+void CostEstimator::visit(const For* v) {
+  v->var()->accept(this);
+  v->start()->accept(this);
+  v->stop()->accept(this);
+
+  const Expr* var_cost = exprInfo_[hasher_.hash(v->var())].cost;
+  auto start_cost = exprInfo_[hasher_.hash(v->start())].cost;
+  auto stop_cost = exprInfo_[hasher_.hash(v->stop())].cost;
+
+  // cost of For
+  //  = start_cost + (loops+1) * (compare_cost) + loops * (body_cost +
+  //  increment_cost).
+  const Expr* loops = new Sub(v->stop(), v->start());
+
+  const Expr* compare_cost = new Add(
+      getImmediateByType(kInt, dict_.COMPARE_OP_COST),
+      new Add(var_cost, stop_cost));
+  const Expr* increment_cost = getImmediateByType(kInt, dict_.BINARY_OP_COST);
+
+  const Expr* cost = new Add(
+      start_cost,
+      new Mul(new Add(getImmediateByType(kInt, 1), loops), compare_cost));
+
+  cost = new Add(cost, new Mul(loops, increment_cost));
+
+  if (v->body()) {
+    v->body()->accept(this);
+    auto bodyInfo = exprInfo_[hasher_.hash(v->body())];
+    cost = new Add(cost, new Mul(loops, bodyInfo.cost));
+  }
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Broadcast* v) {
+  v->value()->accept(this);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  const Expr* cost = new Mul(
+      exprInfo_[hasher_.hash(v->value())].cost,
+      getImmediateByType(kInt, v->lanes()));
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const IfThenElse* v) {
+  v->condition()->accept(this);
+  v->true_value()->accept(this);
+  v->false_value()->accept(this);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  auto conditionInfo = exprInfo_[hasher_.hash(v->condition())];
+  auto trueInfo = exprInfo_[hasher_.hash(v->true_value())];
+  auto falseInfo = exprInfo_[hasher_.hash(v->false_value())];
+
+  const Expr* cost =
+      new Add(conditionInfo.cost, new Max(trueInfo.cost, falseInfo.cost, true));
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const BaseCallNode* v) {
+  const Expr* cost = getImmediateByType(kInt, dict_.CALL_OP_COST);
+  for (int i = 0; i < v->nparams(); i++) {
+    v->param(i)->accept(this);
+    cost = new Add(cost, exprInfo_[hasher_.hash(v->param(i))].cost);
+  }
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Allocate* v) {
+  v->buffer_var()->accept(this);
+  const Expr* cost = exprInfo_[hasher_.hash(v->buffer_var())].cost;
+
+  const Expr* allocWeight = getImmediateByType(kFloat, dict_.ALLOC_COST);
+  std::vector<const Expr*> dims = v->dims();
+  for (const Expr* dim : dims) {
+    dim->accept(this);
+    allocWeight = new Mul(dim, allocWeight);
+    cost = new Add(cost, exprInfo_[hasher_.hash(dim)].cost);
+  }
+
+  cost = new Add(cost, allocWeight);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Free* v) {
+  v->buffer_var()->accept(this);
+
+  const Expr* cost = new Add(
+      exprInfo_[hasher_.hash(v->buffer_var())].cost,
+      getImmediateByType(kInt, dict_.FREE_OP_COST));
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+void CostEstimator::visit(const Cond* v) {
+  v->condition()->accept(this);
+  v->true_stmt()->accept(this);
+  v->false_stmt()->accept(this);
+
+  auto hash = hasher_.hash(v);
+  if (canUpdateExisting(v, hash)) {
+    return;
+  }
+
+  auto condInfo = exprInfo_[hasher_.hash(v->condition())];
+  auto trueInfo = exprInfo_[hasher_.hash(v->true_stmt())];
+  auto falseInfo = exprInfo_[hasher_.hash(v->false_stmt())];
+
+  const Expr* cost =
+      new Add(condInfo.cost, new Max(trueInfo.cost, falseInfo.cost, true));
+
+  exprInfo_.emplace(
+      hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/cost_estimator.h
+++ b/torch/csrc/jit/tensorexpr/cost_estimator.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <torch/csrc/jit/tensorexpr/hash_provider.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+struct SubExprInfo {
+  SubExprInfo() {
+    throw std::logic_error("blah");
+  }
+  SubExprInfo(size_t c, const Expr* e, const Stmt* p)
+      : count(c), cost(e), parent(p) {}
+  SubExprInfo(size_t c, size_t o, const Stmt* p)
+      : count(c), cost(getImmediateByType(kInt, o)), parent(p) {}
+  size_t count{0};
+  const Expr* cost{0};
+  const Stmt* parent{nullptr};
+};
+
+// Fixed costs per Op type for estimating the runtime cost of a subexpr.
+struct OpCostDictionary {
+  int IMMEDIATE_COST{0};
+  int BINARY_OP_COST{1};
+  int COMPARE_OP_COST{1};
+  int CAST_OP_COST{1};
+  int VAR_REF_COST{0};
+  int LOAD_OP_COST{10};
+  int STORE_OP_COST{15};
+  int CALL_OP_COST{5}; // TODO: different funcs obv have different costs.
+  float ALLOC_COST{0.01};
+  int FREE_OP_COST{2};
+};
+
+class TORCH_API CostEstimator : public IRVisitor {
+  OpCostDictionary dict_;
+  HashProvider hasher_;
+  std::unordered_map<SimplifierHashType, SubExprInfo> exprInfo_;
+  const Stmt* lastBlock_{nullptr};
+
+  template <typename Op>
+  bool canUpdateExisting(const Op* e, SimplifierHashType hash) {
+    auto existing = exprInfo_.find(hash);
+    if (existing == exprInfo_.end()) {
+      return false;
+    }
+
+    existing->second.count++;
+    // assume cost is the same.
+
+    // Set the shared parent.
+    if (lastBlock_ != existing->second.parent) {
+      existing->second.parent =
+          getSharedParent(lastBlock_, existing->second.parent);
+    }
+
+    return true;
+  }
+
+  const Stmt* getSharedParent(const Stmt* a, const Stmt* b);
+
+  template <typename Op>
+  void scanBinaryOp(const BinaryOpNode<Op>* v) {
+    v->lhs()->accept(this);
+    v->rhs()->accept(this);
+
+    auto hash = hasher_.hash(v);
+    if (canUpdateExisting(v, hash)) {
+      return;
+    }
+
+    auto lhsInfo = exprInfo_[hasher_.hash(v->lhs())];
+    auto rhsInfo = exprInfo_[hasher_.hash(v->rhs())];
+    Expr* cost = new Add(
+        getImmediateByType(kInt, dict_.BINARY_OP_COST),
+        new Add(lhsInfo.cost, rhsInfo.cost));
+    exprInfo_.emplace(
+        hash, SubExprInfo(1, IRSimplifier::simplify(cost), lastBlock_));
+  }
+
+ public:
+  CostEstimator() = default;
+  CostEstimator(OpCostDictionary& dict) : dict_(dict) {}
+
+  const Expr* estimateCost(const Expr* e) {
+    auto it = exprInfo_.find(hasher_.hash(e));
+    if (it == exprInfo_.end()) {
+      e->accept(this);
+      it = exprInfo_.find(hasher_.hash(e));
+    }
+    return it->second.cost;
+  }
+
+  const Expr* estimateCost(Stmt* s) {
+    auto it = exprInfo_.find(hasher_.hash(s));
+    if (it == exprInfo_.end()) {
+      s->accept(this);
+      it = exprInfo_.find(hasher_.hash(s));
+    }
+    return it->second.cost;
+  }
+
+  SubExprInfo getInfo(const Expr* e) {
+    auto it = exprInfo_.find(hasher_.hash(e));
+    if (it == exprInfo_.end()) {
+      e->accept(this);
+      it = exprInfo_.find(hasher_.hash(e));
+    }
+    return it->second;
+  }
+
+  SubExprInfo getInfo(Stmt* s) {
+    auto it = exprInfo_.find(hasher_.hash(s));
+    if (it == exprInfo_.end()) {
+      s->accept(this);
+      it = exprInfo_.find(hasher_.hash(s));
+    }
+    return it->second;
+  }
+
+  void clear() {
+    exprInfo_.clear();
+    lastBlock_ = nullptr;
+    // don't clear hasher state.
+  }
+
+  void visit(const Add* v) override;
+  void visit(const Sub* v) override;
+  void visit(const Mul* v) override;
+  void visit(const Div* v) override;
+  void visit(const Mod* v) override;
+  void visit(const Max* v) override;
+  void visit(const Min* v) override;
+  void visit(const And* v) override;
+  void visit(const Or* v) override;
+  void visit(const Xor* v) override;
+  void visit(const Lshift* v) override;
+  void visit(const Rshift* v) override;
+  void visit(const CompareSelect* v) override;
+
+// NOLINTNEXTLINE
+#define IMM_VISIT(Type, Name)                                               \
+  void visit(const Name##Imm* v) override {                                 \
+    exprInfo_.emplace(                                                      \
+        hasher_.hash(v), SubExprInfo(1, dict_.IMMEDIATE_COST, lastBlock_)); \
+  }
+  AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_VISIT);
+#undef IMM_VISIT
+
+  void visit(const Cast* v) override;
+  void visit(const Var* v) override;
+  void visit(const Ramp* v) override;
+  void visit(const Load* v) override;
+  void visit(const Store* v) override;
+  void visit(const Block* v) override;
+  void visit(const For* v) override;
+  void visit(const Broadcast* v) override;
+  void visit(const IfThenElse* v) override;
+  void visit(const BaseCallNode* v) override;
+  void visit(const Allocate* v) override;
+  void visit(const Free* v) override;
+  void visit(const Cond* v) override;
+};
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <torch/csrc/jit/tensorexpr/expr.h>
+
 namespace torch {
 namespace jit {
 namespace tensorexpr {


### PR DESCRIPTION
When considering what we need for both Autotuning and CSE I realized we need a new piece of helper infrastructure which estimates the runtime cost of a program or subexpression, which we can use as a cheap heuristic for ranking transformations. 

Here's a framework for recursively building a cost for the expression using a configurable dictionary of per-op costs, the starting point of these op costs is a very rough estimate and likely not correct.

It works like this:
```
Stmt* s =  ....;
CostEstimator estimator;
Expr* cost = estimator.estimateCost(s);
```

The estimator is an Expr because it can depend on a Var in the case of dynamic shapes.

It made sense to roll in tracking common expressions and their shared parent, since we may want to consume that info at the same time.