### PR TITLE
Fix argmax/min to return first index

### DIFF
--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -319,14 +319,14 @@ template <typename T1, typename T2> using pair = std::pair<T1, T2>;
 #endif
 
 template <typename scalar_t>
-struct LessOrNan {
+struct LessEqualOrNan {
   C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
     return at::_isnan(a) || a <= b;
   }
 };
 
 template <typename scalar_t>
-struct GreaterOrNan {
+struct GreaterEqualOrNan {
   C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
     return at::_isnan(a) || a >= b;
   }
@@ -366,12 +366,12 @@ struct ArgReductionOps {
 
 template <typename scalar_t>
 struct ArgMaxOps :
-  public detail::ArgReductionOps<detail::GreaterOrNan<scalar_t>> {
+  public detail::ArgReductionOps<detail::GreaterEqualOrNan<scalar_t>> {
 };
 
 template <typename scalar_t>
 struct ArgMinOps :
-  public detail::ArgReductionOps<detail::LessOrNan<scalar_t>> {
+  public detail::ArgReductionOps<detail::LessEqualOrNan<scalar_t>> {
 };
 
 }} // namespace at::native

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -321,14 +321,14 @@ template <typename T1, typename T2> using pair = std::pair<T1, T2>;
 template <typename scalar_t>
 struct LessOrNan {
   C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
-    return at::_isnan(a) || a < b;
+    return at::_isnan(a) || a <= b;
   }
 };
 
 template <typename scalar_t>
 struct GreaterOrNan {
   C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
-    return at::_isnan(a) || a > b;
+    return at::_isnan(a) || a >= b;
   }
 };
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8876,6 +8876,86 @@ class TestTorchDeviceType(TestCase):
             expected = fn(y, 1, keepdim=False)
             self.assertEqual(x[:, 1], expected, '{} with out= kwarg'.format(fn_name))
 
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_argmaxmin_numpy2d(self, device):
+        example = [[-1, 2, 1], [5, 3, -2]]
+
+        t_types = [torch.double,
+                torch.float,
+                torch.int64,
+                torch.int32,
+                torch.int16]
+
+        n_types = [np.double,
+                np.float,
+                np.int64,
+                np.int32,
+                np.int16]
+
+        for i in range(len(t_types)):
+            t = torch.tensor(example, device=device, dtype=t_types[i])
+            n = np.array(example, dtype=n_types[i])
+
+            self.assertEqual(t.argmax().item(), n.argmax().item())
+            self.assertEqual(t.argmax(dim=None).item(), n.argmax().item())
+            self.assertEqual(t.argmax(dim=0), torch.from_numpy(n.argmax(axis=0)).to(device))
+            self.assertEqual(t.argmax(dim=1), torch.from_numpy(n.argmax(axis=1)).to(device))
+            # test that non-contiguous tensors work
+            self.assertEqual(t[:, :2].argmax().item(), n[:,:2].argmax().item())
+
+            # argmin
+            self.assertEqual(t.argmin().item(), n.argmin().item())
+            self.assertEqual(t.argmin(dim=None).item(), n.argmin().item())
+            self.assertEqual(t.argmin(dim=0), torch.from_numpy(n.argmin(axis=0)).to(device))
+            self.assertEqual(t.argmin(dim=1), torch.from_numpy(n.argmin(axis=1)).to(device))
+            # test that non-contiguous tensors work
+            self.assertEqual(t[:, :2].argmin().item(), n[:, :2].argmin().item())
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_argmaxmin_numpy3d(self, device):
+        # dim 2, 3, 3
+        example = [[[-12,  8, -14],
+            [12,  12,  12],
+            [ 8,  9, 9]],
+
+            [[-8, -5,  -7],
+            [4,  6,  2],
+            [15, -19, -13]]]
+
+        t_types = [torch.double,
+                torch.float,
+                torch.int64,
+                torch.int32,
+                torch.int16]
+
+        n_types = [np.double,
+                np.float,
+                np.int64,
+                np.int32,
+                np.int16]
+
+        for i in range(len(t_types)):
+            t = torch.tensor(example, device=device, dtype=t_types[i])
+            n = np.array(example, dtype=n_types[i])
+
+            self.assertEqual(t.argmax().item(), n.argmax().item())
+            self.assertEqual(t.argmax(dim=None).item(), n.argmax().item())
+            self.assertEqual(t.argmax(dim=0), torch.from_numpy(n.argmax(axis=0)).to(device))
+            self.assertEqual(t.argmax(dim=1), torch.from_numpy(n.argmax(axis=1)).to(device))
+            self.assertEqual(t.argmax(dim=2), torch.from_numpy(n.argmax(axis=2)).to(device))
+            # test that non-contiguous tensors work
+            self.assertEqual(t[:, :2, :1].argmax().item(), n[:,:2, :1].argmax().item())
+
+            # argmin
+            self.assertEqual(t.argmin().item(), n.argmin().item())
+            self.assertEqual(t.argmin(dim=None).item(), n.argmin().item())
+            self.assertEqual(t.argmin(dim=0), torch.from_numpy(n.argmin(axis=0)).to(device))
+            self.assertEqual(t.argmin(dim=1), torch.from_numpy(n.argmin(axis=1)).to(device))
+            self.assertEqual(t.argmin(dim=2), torch.from_numpy(n.argmin(axis=2)).to(device))
+            # test that non-contiguous tensors work
+            self.assertEqual(t[:, :2, :1].argmin().item(), n[:, :2, :1].argmin().item())
+
+
     @onlyCUDA
     @dtypes(torch.half, torch.float, torch.double)
     def test_reduction_vectorized_corner(self, device, dtype):


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/pytorch/pytorch/issues/10370 and https://github.com/pytorch/pytorch/issues/37921, where PyTorch currently returns the last index value rather than the first index value for argmax/min.

Example output:

```
t = torch.ones(3, 4).cpu()
t[1, 0] = 0
print("argmax :")
print(t.argmax(1, keepdim=True))
print("argmin :")
print(t.argmin(1, keepdim=True))
```
Output:
```
argmax :
tensor([[0],
        [1],
        [0]])
argmin :
tensor([[0],
        [0],
        [0]])
```

Example 2:

```
t = torch.eye(3)
print("argmax :")
print(t.argmax(1, keepdim=True))
print("argmin :")
print(t.argmin(1, keepdim=True))
```
Output:
```
argmax :
tensor([[0],
        [1],
        [2]])

argmin :
tensor([[1],
        [0],
        [0]])
```