### PR TITLE
fix undef CUDA_VERSION warning

### DIFF
--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -2,7 +2,7 @@ namespace std {
 
 // Exponential functions
 
-#if CUDA_VERSION < 10000
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 10000)
 #define CUDA92_BUG(x) thrust::complex<T>(x.real(), x.imag())
 #else
 #define CUDA92_BUG(x) x


### PR DESCRIPTION
Summary: make sure not to check `CUDA_VERSION` if it is not defined

Test Plan: CI gree

Differential Revision: D21408844

