### PR TITLE
workaround nvcc host function bug

### DIFF
--- a/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
@@ -69,10 +69,18 @@ __host__ __device__ static inline thrust::complex<T> reciprocal_wrapper(thrust::
     return (::isinf(real) && ::isinf(imag));
   };
 
-  if (::isnan(v.real()) || ::isnan(v.imag()) || both_inf(v.real(), v.imag())) {
+  auto either_inf = [](T real, T imag) {
+    return ::isinf(real) || ::isinf(imag);
+  };
+
+  auto either_nan = [](T real, T imag) {
+    return ::isnan(real) || ::isnan(imag);
+  };
+
+  if (either_nan(v.real(), v.imag()) || both_inf(v.real(), v.imag())) {
     // If either is Nan or both are infinite, return {nan, nan}
     return {std::numeric_limits<T>::quiet_NaN(), std::numeric_limits<T>::quiet_NaN()};
-  } else if (::isinf(v.real()) || ::isinf(v.imag())) {
+  } else if (either_inf(v.real(), v.imag())) {
     // If either is Inf, return {0, 0}
     return {0, 0};
   }


### PR DESCRIPTION
Summary:
this is to work around internal issue we are hitting with nvcc in ovrsource.
It does not seem to overload to the correct device version of `isinf` and `isnan` without this fudging of the code.

Test Plan:
CI green,
internal builds pass

Differential Revision: D21408263

