### PR TITLE
Make aten_tensor_iterator ASAN safe

### DIFF
--- a/aten/src/ATen/test/tensor_iterator_test.cpp
+++ b/aten/src/ATen/test/tensor_iterator_test.cpp
@@ -53,14 +53,14 @@ Tensor random_tensor_for_type(at::ScalarType scalar_type) {
   }
 }
 
-#define UNARY_TEST_ITER_FOR_TYPE(ctype,name)                                  \
-TEST(TensorIteratorTest, SerialLoopUnary_##name) {                            \
-  Tensor out;                                                                 \
-  auto in = random_tensor_for_type(k##name);                                  \
-  auto expected = in.add(1);                                                  \
-  auto iter = TensorIterator::unary_op(out, in);                              \
-  at::native::cpu_serial_kernel(iter, [=](ctype a) -> int { return a + 1; }); \
-  ASSERT_ANY_THROW(out.equal(expected));                                      \
+#define UNARY_TEST_ITER_FOR_TYPE(ctype,name)                                    \
+TEST(TensorIteratorTest, SerialLoopUnary_##name) {                              \
+  Tensor out;                                                                   \
+  auto in = random_tensor_for_type(k##name);                                    \
+  auto expected = in.add(1);                                                    \
+  auto iter = TensorIterator::unary_op(out, in);                                \
+  at::native::cpu_serial_kernel(iter, [=](ctype a) -> ctype { return a + 1; }); \
+  ASSERT_ANY_THROW(out.equal(expected));                                        \
 }
 
 #define NO_OUTPUT_UNARY_TEST_ITER_FOR_TYPE(ctype,name)                         \
@@ -74,15 +74,15 @@ TEST(TensorIteratorTest, SerialLoopUnaryNoOutput_##name) {                     \
   EXPECT_TRUE(acc == in.numel());                                              \
 }
 
-#define BINARY_TEST_ITER_FOR_TYPE(ctype,name)                                          \
-TEST(TensorIteratorTest, SerialLoopBinary_##name) {                                    \
-  Tensor out;                                                                          \
-  auto in1 = random_tensor_for_type(k##name);                                          \
-  auto in2 = random_tensor_for_type(k##name);                                          \
-  auto expected = in1.add(in2);                                                        \
-  auto iter = TensorIterator::binary_op(out, in1, in2);                                \
-  at::native::cpu_serial_kernel(iter, [=](ctype a, ctype b) -> int { return a + b; }); \
-  ASSERT_ANY_THROW(out.equal(expected));                                               \
+#define BINARY_TEST_ITER_FOR_TYPE(ctype,name)                                            \
+TEST(TensorIteratorTest, SerialLoopBinary_##name) {                                      \
+  Tensor out;                                                                            \
+  auto in1 = random_tensor_for_type(k##name);                                            \
+  auto in2 = random_tensor_for_type(k##name);                                            \
+  auto expected = in1.add(in2);                                                          \
+  auto iter = TensorIterator::binary_op(out, in1, in2);                                  \
+  at::native::cpu_serial_kernel(iter, [=](ctype a, ctype b) -> ctype { return a + b; }); \
+  ASSERT_ANY_THROW(out.equal(expected));                                                 \
 }
 
 #define NO_OUTPUT_BINARY_TEST_ITER_FOR_TYPE(ctype,name)                          \
@@ -98,21 +98,21 @@ TEST(TensorIteratorTest, SerialLoopBinaryNoOutput_##name) {                     
   EXPECT_TRUE(acc == in1.numel());                                               \
 }
 
-#define POINTWISE_TEST_ITER_FOR_TYPE(ctype,name)                                                    \
-TEST(TensorIteratorTest, SerialLoopPointwise_##name) {                                              \
-  Tensor out;                                                                                       \
-  auto in1 = random_tensor_for_type(k##name);                                                       \
-  auto in2 = random_tensor_for_type(k##name);                                                       \
-  auto in3 = random_tensor_for_type(k##name);                                                       \
-  auto expected = in1.add(in2).add(in3);                                                            \
-  auto iter = at::TensorIterator();                                                                 \
-  iter.add_output(out);                                                                             \
-  iter.add_input(in1);                                                                              \
-  iter.add_input(in2);                                                                              \
-  iter.add_input(in3);                                                                              \
-  iter.build();                                                                                     \
-  at::native::cpu_serial_kernel(iter, [=](ctype a, ctype b, ctype c) -> int { return a + b + c; }); \
-  ASSERT_ANY_THROW(out.equal(expected));                                                            \
+#define POINTWISE_TEST_ITER_FOR_TYPE(ctype,name)                                                      \
+TEST(TensorIteratorTest, SerialLoopPointwise_##name) {                                                \
+  Tensor out;                                                                                         \
+  auto in1 = random_tensor_for_type(k##name);                                                         \
+  auto in2 = random_tensor_for_type(k##name);                                                         \
+  auto in3 = random_tensor_for_type(k##name);                                                         \
+  auto expected = in1.add(in2).add(in3);                                                              \
+  auto iter = at::TensorIterator();                                                                   \
+  iter.add_output(out);                                                                               \
+  iter.add_input(in1);                                                                                \
+  iter.add_input(in2);                                                                                \
+  iter.add_input(in3);                                                                                \
+  iter.build();                                                                                       \
+  at::native::cpu_serial_kernel(iter, [=](ctype a, ctype b, ctype c) -> ctype { return a + b + c; }); \
+  ASSERT_ANY_THROW(out.equal(expected));                                                              \
 }
 
 #define NO_OUTPUT_POINTWISE_TEST_ITER_FOR_TYPE(ctype,name)                                \


### PR DESCRIPTION
Summary:
Return type of `cpu_serial_kernel` functor should match type of the Tensor
Closes https://github.com/pytorch/pytorch/issues/37490

Test Plan: CI

Differential Revision: D21410450

