### PR TITLE
[WIP] Fix py::object refcnt bug in RPC return value

### DIFF
--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -127,13 +127,20 @@ std::shared_ptr<FutureIValue> toFutureIValue(
     std::shared_ptr<FutureIValue> fv(new FutureIValue(), DeleteFutureIValue);
 
     fm->addCallback([fv](const FutureMessage& fm) {
-      // Don't need to acquire GIL here, as toPyObj acquires GIL
-      // when creating the py::object
       if (fm.hasError()) {
         fv->setError(*fm.error());
       } else {
-        fv->markCompleted(
-            jit::toIValue(toPyObj(fm.constValue()), PyObjectType::get()));
+        IValue value;
+        // Don't need to acquire GIL here, as toPyObj acquires GIL
+        // when creating the py::object
+        {
+          // the toPyObj() method already acquires GIL when necessary but we
+          // still need GIL here as jit::toIValue() would create a copy of the
+          // py::object
+          pybind11::gil_scoped_acquire ag;
+          value = jit::toIValue(toPyObj(fm.constValue()), PyObjectType::get());
+        }
+        fv->markCompleted(value);
       }
     });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37871 [WIP] Fix py::object refcnt bug in RPC return value**
* #37870 Acquire GIL when constructing/destructing ConcretePyObjectHolder

jit::toIValue would create a copy of the py::object so we need to
guard it with GIL.

Differential Revision: [D21410786](https://our.internmc.facebook.com/intern/diff/D21410786)