### PR TITLE
[TensorExpr] Remove the Tensor argument from loopnest.reorderAxis

### DIFF
--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -1257,7 +1257,7 @@ void testLLVMRFactorReduction() {
   std::vector<For*> loops = loop.getLoopStmtsFor(b);
   For* loop_m = loops.at(1);
   For* loop_n = loops.at(2);
-  loop.reorderAxis(b, loop_m, loop_n);
+  loop.reorderAxis(loop_m, loop_n);
 
   loops = loop.getLoopStmtsFor(b);
   loop_m = loops.at(2);
@@ -1306,7 +1306,7 @@ void testLLVMRFactorVectorizedReduction() {
   For* loop_k = loops.at(0);
   For* loop_m = loops.at(1);
   For* loop_n = loops.at(2);
-  loopnest.reorderAxis(b, loop_n, loop_m);
+  loopnest.reorderAxis(loop_n, loop_m);
   loops = loopnest.getLoopStmtsFor(b);
   loop_k = loops.at(0);
   loop_n = loops.at(1);

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -1141,7 +1141,7 @@ void testLoopNestReorderAxis1() {
   cg.call({stmt1_output});
 
   auto loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[0], loops[1]);
+  l.reorderAxis(loops[0], loops[1]);
   Stmt* stmt2 = Stmt::clone(l.root_stmt());
 
   ASSERT_NE(stmt1, stmt2);
@@ -1162,7 +1162,7 @@ void testLoopNestReorderAxis1() {
 
   // Reorder them back.
   loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[0], loops[1]);
+  l.reorderAxis(loops[0], loops[1]);
   Stmt* stmt3 = l.root_stmt();
 
   std::string order3 = loopOrderHelper.getOrder(stmt3);
@@ -1196,7 +1196,7 @@ void testLoopNestReorderPartialAxes() {
   cg.call({stmt1_output});
 
   auto loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[0], loops[1]);
+  l.reorderAxis(loops[0], loops[1]);
   ASSERT_EQ(loopOrderHelper.getOrder(l.root_stmt()), "y,x,z,");
 
   Stmt* stmt2 = Stmt::clone(l.root_stmt());
@@ -1210,7 +1210,7 @@ void testLoopNestReorderPartialAxes() {
   }
 
   loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[1], loops[2]);
+  l.reorderAxis(loops[1], loops[2]);
   ASSERT_EQ(loopOrderHelper.getOrder(l.root_stmt()), "y,z,x,");
 
   Stmt* stmt3 = Stmt::clone(l.root_stmt());
@@ -1247,7 +1247,7 @@ void testLoopNestReorderInternalAxis() {
   cg.call({stmt1_output});
 
   auto loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[2], loops[1]);
+  l.reorderAxis(loops[2], loops[1]);
   ASSERT_EQ(loopOrderHelper.getOrder(l.root_stmt()), "w,y,x,z,");
 
   Stmt* stmt2 = l.root_stmt();
@@ -1283,7 +1283,7 @@ void testLoopNestReorderEnclosingAxis() {
   cg.call({stmt1_output});
 
   auto loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[0], loops[3]);
+  l.reorderAxis(loops[0], loops[3]);
   ASSERT_EQ(loopOrderHelper.getOrder(l.root_stmt()), "z,x,y,w,");
 
   Stmt* stmt2 = l.root_stmt();
@@ -1307,7 +1307,7 @@ void testLoopNestReorderSameAxis() {
   Stmt* stmt1 = Stmt::clone(l.root_stmt());
 
   auto loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[1], loops[1]);
+  l.reorderAxis(loops[1], loops[1]);
   Stmt* stmt2 = Stmt::clone(l.root_stmt());
 
   std::ostringstream oss, oss2;
@@ -1376,7 +1376,7 @@ void testLoopNestReorderExtraStatements() {
    *
    */
 
-  l.reorderAxis(tensor, loops[1], loops[2]);
+  l.reorderAxis(loops[1], loops[2]);
   Stmt* stmt2 = Stmt::clone(l.root_stmt());
 
   std::ostringstream oss;
@@ -1429,7 +1429,7 @@ void testLoopNestReorderExtraStatements() {
    *
    */
   loops = l.getLoopStmtsFor(tensor);
-  l.reorderAxis(tensor, loops[0], loops[2]);
+  l.reorderAxis(loops[0], loops[2]);
   Stmt* stmt3 = Stmt::clone(l.root_stmt());
 
   std::ostringstream oss2;
@@ -1520,7 +1520,7 @@ void LoopNestReorderTestHelper(
   }
 
   loops = l.getLoopStmtsFor(c);
-  l.reorderAxis(c, loops[index1], loops[index2]);
+  l.reorderAxis(loops[index1], loops[index2]);
   Stmt* stmt2 = Stmt::clone(l.root_stmt());
 
   std::ostringstream oss, oss2;

--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -560,7 +560,7 @@ void testReorderedReductionInitializer() {
   l.setGPUBlockIndex(loops[0], 0);
   l.setGPUThreadIndex(loops[1], 0);
 
-  l.reorderAxis(tensor, loops[1], loops[2]);
+  l.reorderAxis(loops[1], loops[2]);
 
   Stmt* s = l.root_stmt();
   s = IRSimplifier::simplify(s);
@@ -767,7 +767,6 @@ void testReduce3DRfactorRepeated() {
   Tensor* c = Reduce("sum", {}, Sum(), b, {{m, "m"}, {n, "n"}, {k, "k"}});
   LoopNest loop({c});
   std::vector<For*> loops = loop.getLoopStmtsFor(c);
-  auto vk = loops.at(2)->var(); // k
   auto vn = loops.at(1)->var(); // n
   auto vm = loops.at(0)->var(); // m
   loop.rfactor(c->body(), vm);

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1089,34 +1089,55 @@ void LoopNest::splitWithMask(For* f, int factor, For** outer, For** inner) {
   // TODO: record history of transformations
 }
 
-void LoopNest::reorderAxis(Tensor* t, For* a, For* b) {
+For* findOuterFor(For* a, For* b) {
+  Stmt* s = b; // guess b is the latter.
+  while (s != nullptr) {
+    if (s == a) {
+      // yes, b is after a.
+      return a;
+    }
+    s = s->get_parent();
+  }
+
+  // check that the two are in the same loop nest.
+  s = a;
+  while (s != nullptr) {
+    if (s == b) {
+      // a is after b.
+      return b;
+    }
+    s = s->get_parent();
+  }
+
+  // a and b have no relationship.
+  return nullptr;
+}
+
+void LoopNest::reorderAxis(For* a, For* b) {
   if (a == b) {
     // nothing to do.
     return;
   }
   // find inner and outer.
-  For* outer{nullptr};
-  For* inner{nullptr};
+  For* outer = findOuterFor(a, b);
+  if (outer == nullptr) {
+    throw std::runtime_error("Reordered a loop not in LoopNest");
+  }
+
+  For* inner = a == outer ? b : a;
   std::deque<For*> internal_axes;
 
   // Find relevant axes, store reversed.
-  for (For* loop : getLoopStmtsFor(t)) {
-    if (loop == a || loop == b) {
-      if (outer == nullptr) {
-        outer = loop;
-        internal_axes.push_front(loop);
-      } else {
-        inner = loop;
-        internal_axes.push_front(loop);
-      }
-    } else if (outer && !inner) {
-      internal_axes.push_front(loop);
+  Stmt* s = inner;
+  while (s != outer) {
+    if (For* f = dynamic_cast<For*>(s)) {
+      internal_axes.push_back(f);
     }
+
+    s = s->get_parent();
   }
 
-  if (!inner || !outer) {
-    throw std::runtime_error("Reordered a loop not in LoopNest");
-  }
+  internal_axes.push_back(outer);
 
   Block* root = dynamic_cast<Block*>(outer->get_parent());
   CHECK(root);

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -38,7 +38,7 @@ class TORCH_API LoopNest {
   void prepareForCodegen();
   void splitWithTail(For* f, int factor, For** outer, For** inner, For** tail);
   void splitWithMask(For* f, int factor, For** outer, For** inner);
-  void reorderAxis(Tensor* t, For* a, For* b);
+  void reorderAxis(For* a, For* b);
 
   void setGPUBlockIndex(For* f, int idx);
   void setGPUThreadIndex(For* f, int idx);


### PR DESCRIPTION
Remove the requirement for the axes provided to reorderAxis to come from a Tensor. We were using that to determine the relevant loops, but we can alternatively determine it by traversing the parents of each provided For.

@resistor does this work for you?