### PR TITLE
disable clang-tidy modernize-trailing-return

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,7 @@ modernize-*,
 -modernize-use-auto,
 -modernize-use-default-member-init,
 -modernize-use-using,
+-modernize-use-trailing-return-type,
 performance-*,
 -performance-noexcept-move-constructor,
   '


### PR DESCRIPTION
too much noise from this warning 
![image](https://user-images.githubusercontent.com/5086322/81123764-b6e15900-8ee8-11ea-8f2f-49d69ddde25d.png)
