### PR TITLE
[Caffe2] Increase timing threshold to 50 ms on Windows

### DIFF
--- a/caffe2/core/parallel_net_test.cc
+++ b/caffe2/core/parallel_net_test.cc
@@ -8,7 +8,12 @@
 namespace caffe2 {
 
 // When measuring time, we relax the measured time by +- 40ms.
+#ifndef _WIN32
 const int kTimeThreshold = 40;
+#else
+// Even more so on Windows
+const int kTimeThreshold = 50;
+#endif
 
 // SleepOp basically sleeps for a given number of seconds.
 // We allow arbitrary inputs and at most one output so that we can


### PR DESCRIPTION
Helps prevent following accidental failures:
```
..\caffe2\core\parallel_net_test.cc:303
The difference between ms and 350 is 41, which exceeds kTimeThreshold, where
ms evaluates to 391,
350 evaluates to 350, and
kTimeThreshold evaluates to 40.
```

