### PR TITLE
Migrate CUDA abs and neg to c10::complex

### DIFF
--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -7,7 +7,6 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Math.cuh>
-#include <ATen/native/cuda/zmath.cuh>
 
 namespace at { namespace native {
 
@@ -18,8 +17,8 @@ __host__ __device__ static inline scalar_t abs_wrapper(scalar_t v) {
 }
 
 template<typename T>
-__host__ __device__ static inline thrust::complex<T> abs_wrapper(thrust::complex<T> v) {
-  return thrust::abs(v);
+__host__ __device__ static inline c10::complex<T> abs_wrapper(c10::complex<T> v) {
+  return std::abs(v);
 }
 
 __host__ __device__ static inline uint8_t abs_wrapper(uint8_t v) {
@@ -31,9 +30,8 @@ __host__ __device__ static inline bool abs_wrapper(bool v) {
 }
 
 void abs_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(ScalarType::Half, ScalarType::Bool, iter.dtype(), "abs_cuda", [&]() {
-    using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-    gpu_kernel(iter, []GPU_LAMBDA(thrust_t a) -> thrust_t {
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND2(ScalarType::Half, ScalarType::Bool, iter.dtype(), "abs_cuda", [&]() {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
       return abs_wrapper(a);
     });
   });
@@ -49,10 +47,9 @@ void logical_not_kernel_cuda(TensorIterator& iter) {
 }
 
 void neg_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "neg_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND2(ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "neg_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "neg_cuda", [&] {
-      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-      gpu_kernel(iter, []GPU_LAMBDA(thrust_t a) -> thrust_t {
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
         return -a;
       });
     });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37900 Migrate CUDA abs and neg to c10::complex**
* #37899 Migrate CPU eye to c10::complex
* #37898 Migrate CPU unary ops to c10::complex
* #37897 Migrate CPU tril, triu, masked_fill to c10::complex
* #37896 Migrate CUDA where, tril, triu to c10::complex

