### PR TITLE
Disable accessing an opaque tensor from  prim::constant

### DIFF
--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -70,6 +70,11 @@ c10::optional<Value*> tryInsertConstant(
   Node* n = g.create(prim::Constant);
   if (val.isTensor()) {
     at::Tensor ref = val.toTensor();
+    if (!ref.has_storage()) {
+      // bail if tensor has no storage i.e. opaque tensor used in MKLdnn.
+      n->destroy();
+      return c10::nullopt;
+    }
     if (!ref.defined()) {
       n->destroy();
       return g.insertNode(g.createNone())->output();


### PR DESCRIPTION
If the tensor has no storage then do not inline as a constant. This
situation when Mkldnn tensors are used.

