### PR TITLE
Allow DDP to wrap modules that take no inputs.

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -684,19 +684,20 @@ class TestDataParallel(TestCase):
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_module_with_no_inputs(self):
         # gh-37814
+        shape = 3
+
         class Holder(torch.nn.Module):
-            def __init__(self):
+            def __init__(self, shape):
                 super().__init__()
-                self.x = torch.nn.Parameter(torch.arange(3).float())
+                self.x = torch.nn.Parameter(torch.arange(shape).float())
 
             def forward(self):
                 return self.x
 
-        expected = torch.arange(3).float().cuda()
-        holder = dp.DataParallel(Holder().cuda())
+        expected = torch.arange(shape).float().cuda()
+        holder = dp.DataParallel(Holder(shape).cuda())
         output = holder()
-        for replica in output.split(3):
-            self.assertEqual(expected, replica)
+        self.assertEqual(expected, output)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -2172,7 +2172,6 @@ class _DistTestBase(object):
 
     @unittest.skipIf(BACKEND != 'nccl' and BACKEND != 'gloo',
                      "Only Nccl & Gloo backend support DistributedDataParallel")
-    @skip_if_no_cuda_distributed
     @skip_if_no_gpu
     def test_DDP_module_with_no_inputs(self):
         # gh-37814

--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -2178,17 +2178,18 @@ class _DistTestBase(object):
         # gh-37814
         group, group_id, rank = self._init_global_test()
         rank_to_GPU = self._init_multigpu_helper()
+        shape = 3
 
         class Holder(torch.nn.Module):
-            def __init__(self):
+            def __init__(self, shape):
                 super().__init__()
-                self.x = torch.nn.Parameter(torch.arange(3).float())
+                self.x = torch.nn.Parameter(torch.arange(shape).float())
 
             def forward(self):
                 return self.x
 
-        expected = torch.arange(3).float().cuda()
-        holder = nn.parallel.DistributedDataParallel(Holder().cuda(rank), device_ids=[rank])
+        expected = torch.arange(shape).float().cuda()
+        holder = nn.parallel.DistributedDataParallel(Holder(shape).cuda(rank), device_ids=[rank])
         output = holder()
         self.assertEqual(expected, output)
 

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -33,16 +33,12 @@ def scatter(inputs, target_gpus, dim=0):
 
 def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
     r"""Scatter with support for kwargs dictionary"""
-    inputs = scatter(inputs, target_gpus, dim) if inputs else []
-    kwargs = scatter(kwargs, target_gpus, dim) if kwargs else []
+    inputs = scatter(inputs, target_gpus, dim) if inputs else [()]
+    kwargs = scatter(kwargs, target_gpus, dim) if kwargs else [{}]
     if len(inputs) < len(kwargs):
         inputs.extend([() for _ in range(len(kwargs) - len(inputs))])
     elif len(kwargs) < len(inputs):
         kwargs.extend([{} for _ in range(len(inputs) - len(kwargs))])
-
-    if len(inputs) == 0 and len(kwargs) == 0:
-        inputs = [tuple() for _ in range(len(target_gpus))]
-        kwargs = [dict() for _ in range(len(target_gpus))]
 
     inputs = tuple(inputs)
     kwargs = tuple(kwargs)

--- a/torch/nn/parallel/scatter_gather.py
+++ b/torch/nn/parallel/scatter_gather.py
@@ -39,6 +39,11 @@ def scatter_kwargs(inputs, kwargs, target_gpus, dim=0):
         inputs.extend([() for _ in range(len(kwargs) - len(inputs))])
     elif len(kwargs) < len(inputs):
         kwargs.extend([{} for _ in range(len(inputs) - len(kwargs))])
+
+    if len(inputs) == 0 and len(kwargs) == 0:
+        inputs = [tuple() for _ in range(len(target_gpus))]
+        kwargs = [dict() for _ in range(len(target_gpus))]
+
     inputs = tuple(inputs)
     kwargs = tuple(kwargs)
     return inputs, kwargs


### PR DESCRIPTION
Modify `scatter_kwargs()` to produce empty inputs for each replica if the wrapped module was given no inputs.

When run in SPMD mode (`len(device_ids) > 1)`), this will produce multiple copies of the wrapped module's output which may or may not be desirable. I know SPMD will be going away and I don't see any point in wrapping these no-input modules in SPMD-DDP anyway so maybe this isn't a concern.

Closes #37814