### PR TITLE
[TensorPipe Agent] Bind device IP address

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -9,9 +9,16 @@
 #endif
 #ifdef TP_ENABLE_SHM
 #include <tensorpipe/transport/shm/context.h>
-#include <unistd.h>
 #endif
 #include <tensorpipe/transport/uv/context.h>
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace torch {
 namespace distributed {
@@ -112,7 +119,7 @@ void TensorPipeAgent::startImpl() {
   // Ideally tensorpipe could provide a helper to get IP address for given
   // device interface or host names, or return the IP address of the default
   // host name. https://github.com/pytorch/pytorch/issues/36715
-  std::vector<std::string> addresses = {"tcp://127.0.0.1"};
+  std::vector<std::string> addresses = {"tcp://" + getDefaultIPAddress()};
 #ifdef TP_ENABLE_SHM
   addresses.push_back(createUniqueShmAddr());
 #endif
@@ -514,6 +521,65 @@ void TensorPipeAgent::trackNetworkError(
   networkData_[destWorkerName].numCalls++;
   networkData_[destWorkerName].totalSentBytes += requestSize;
   networkData_[destWorkerName].totalErrors++;
+}
+
+std::string TensorPipeAgent::getDefaultIPAddress() {
+  std::string defaultIP = "127.0.0.1";
+
+  std::array<char, NI_MAXHOST> hostname{};
+  int rv = gethostname(hostname.data(), NI_MAXHOST);
+  if (rv != 0) {
+    LOG(WARNING) << "Unable to get local hostname. Falling back to "
+                 << "bind with " << defaultIP;
+    return defaultIP;
+  }
+
+  struct addrinfo hints{};
+  memset(&hints, 0, sizeof hints);
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = IPPROTO_TCP;
+  struct addrinfo* servinfo;
+  rv = getaddrinfo(hostname.data(), nullptr, &hints, &servinfo);
+  if (rv != 0) {
+    LOG(WARNING) << "Get address info error: " << gai_strerror(rv)
+                 << ". Falling back to bind with " << defaultIP;
+    return defaultIP;
+  }
+
+  // Loop through all the results and pick up the first we can bind.
+  for (struct addrinfo* p = servinfo; p != nullptr; p = p->ai_next) {
+    int fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+    if (fd == -1) {
+      continue;
+    }
+    int bind_rv = bind(fd, p->ai_addr, p->ai_addrlen);
+    if (bind_rv == -1) {
+      close(fd);
+      continue;
+    }
+    close(fd);
+
+    if (p->ai_family == AF_INET6) {
+      std::string ipv6(INET6_ADDRSTRLEN, '\0');
+      struct sockaddr_in6* h = (struct sockaddr_in6*)p->ai_addr;
+      inet_ntop(AF_INET6, &h->sin6_addr, (char*)ipv6.data(), INET6_ADDRSTRLEN);
+      freeaddrinfo(servinfo);
+      return ipv6;
+    } else if (p->ai_family == AF_INET) {
+      std::string ipv4(INET_ADDRSTRLEN, '\0');
+      struct sockaddr_in* h = (struct sockaddr_in*)p->ai_addr;
+      inet_ntop(AF_INET, &h->sin_addr, (char*)ipv4.data(), INET_ADDRSTRLEN);
+      freeaddrinfo(servinfo);
+      return ipv4;
+    }
+  }
+
+  freeaddrinfo(servinfo);
+
+  LOG(WARNING) << "TensorPipe agent didn't find associated IP address with "
+               << hostname.data() << ". Using " << defaultIP << " to bind";
+  return defaultIP;
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -86,6 +86,11 @@ class TensorPipeAgent : public RpcAgent {
   std::string createUniqueShmAddr();
 #endif
 
+  // Retrieve IP address for a given network device for corss-hosts
+  // to set up tensorpipe connection. For now we default the device
+  // name eth0.
+  static std::string getDefaultIPAddress();
+
   // TensorPipe read function that could be used to read response messages
   // by client, and read request messages by server.
   void pipeRead(


### PR DESCRIPTION
To resolve the issue: https://github.com/pytorch/pytorch/issues/36715

In tensorpipe rpc agent, we currently hardcoded localhost as pipes handshake IP address. This prevents us from setting up cross-host connections. As the first step, we start binding IP address for a given network device. For now it's defaulted to eth0. Will provide options to let user configure

Differential Revision: D21421094

