### PR TITLE
[TensorPipe] Allow passing args to agent options constructor

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -448,7 +448,11 @@ If the future completes with an error, an exception is thrown.
   // Base class: torch.distributed.rpc.RpcBackendOptions.
   py::class_<TensorPipeRpcBackendOptions>(
       module, "TensorPipeRpcBackendOptions", rpcBackendOptions)
-      .def(py::init<>())
+      .def(
+          py::init<std::map<std::string, worker_id_t>, float, std::string>(),
+          py::arg("worker_name_to_id"),
+          py::arg("rpc_timeout") = kDefaultRpcTimeoutSeconds,
+          py::arg("init_method") = kDefaultInitMethod)
       .def_readwrite(
           "worker_name_to_id", &TensorPipeRpcBackendOptions::workerNameToId);
 

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -15,6 +15,13 @@ namespace distributed {
 namespace rpc {
 
 struct TensorPipeRpcBackendOptions : public RpcBackendOptions {
+  TensorPipeRpcBackendOptions(
+      std::map<std::string, worker_id_t> worker_name_to_id,
+      float rpc_timeout,
+      std::string init_method)
+      : RpcBackendOptions(rpc_timeout, init_method),
+        workerNameToId(std::move(worker_name_to_id)) {}
+
   std::map<std::string, worker_id_t> workerNameToId;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37919 [TensorPipe] Use the new multi-payload message API
* **#37918 [TensorPipe] Allow passing args to agent options constructor**





Differential Revision: [D21425537](https://our.internmc.facebook.com/intern/diff/D21425537/)

Differential Revision: [D21425537](https://our.internmc.facebook.com/intern/diff/D21425537)