### PR TITLE
[TensorPipe] Use the new multi-payload message API

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -122,17 +122,6 @@ void TensorPipeAgent::pipeRead(
 
     // Allocate memory and fill in pointers
     Message rpcMessage = tensorpipeAllocateMessage(tpMessage);
-    TORCH_INTERNAL_ASSERT(
-        tpMessage.payloads.size() == 1, "Payload num mismatch");
-    TORCH_INTERNAL_ASSERT(
-        rpcMessage.tensors().size() == tpMessage.tensors.size(),
-        "Tensor num mismatch");
-    tpMessage.payloads[0].data = (uint8_t*)(rpcMessage.payload().data());
-    for (size_t i = 0; i < rpcMessage.tensors().size(); i++) {
-      auto& rpcTensor = rpcMessage.tensors()[i];
-      auto& tpTensor = tpMessage.tensors[i];
-      tpTensor.data = (uint8_t*)(rpcTensor.data_ptr());
-    }
 
     pipe->read(
         std::move(tpMessage),

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -123,9 +123,11 @@ void TensorPipeAgent::pipeRead(
     // Allocate memory and fill in pointers
     Message rpcMessage = tensorpipeAllocateMessage(tpMessage);
     TORCH_INTERNAL_ASSERT(
+        tpMessage.payloads.size() == 1, "Payload num mismatch");
+    TORCH_INTERNAL_ASSERT(
         rpcMessage.tensors().size() == tpMessage.tensors.size(),
         "Tensor num mismatch");
-    tpMessage.data = (uint8_t*)(rpcMessage.payload().data());
+    tpMessage.payloads[0].data = (uint8_t*)(rpcMessage.payload().data());
     for (size_t i = 0; i < rpcMessage.tensors().size(); i++) {
       auto& rpcTensor = rpcMessage.tensors()[i];
       auto& tpTensor = tpMessage.tensors[i];

--- a/torch/csrc/distributed/rpc/utils.h
+++ b/torch/csrc/distributed/rpc/utils.h
@@ -60,8 +60,7 @@ TORCH_API TensorPipeEntry tensorpipeSerialize(const Message& rpcMessage);
 // necessary information for memory allocation, like payload length
 // and tensor metadata. The returned RPC message doesn't have any
 // data, but would be valid after tensorpipe finishs data transfer.
-TORCH_API Message
-tensorpipeAllocateMessage(const tensorpipe::Message& tpMessage);
+TORCH_API Message tensorpipeAllocateMessage(tensorpipe::Message& tpMessage);
 
 // Some Tensors are effectively views of larger Tensors, where only a small
 // subset of the Storage data is referenced. This normally is good and avoids


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37919 [TensorPipe] Use the new multi-payload message API**
* #37918 [TensorPipe] Allow passing args to agent options constructor

In D21209901 TensorPipe added support for a vector of payloads inside each message, instead of a single one, so that users with multiple payloads can send them separately as they are instead of having to copy them into a new block of contiguous memory. The PyTorch agent is using the old API, which is preventing us from deleting it. This change has no effects on over-the-wire format and thus on performance.



Differential Revision: [D21425536](https://our.internmc.facebook.com/intern/diff/D21425536/)

Differential Revision: [D21425536](https://our.internmc.facebook.com/intern/diff/D21425536)