### PR TITLE
reenable quantization test_qadd_scalar_relu test (redo)

### DIFF
--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -534,7 +534,6 @@ class TestQuantizedOps(TestCase):
         _test_hardswish(self, X, Y_scale, Y_zero_point, 'fbgemm')
 
     """Tests the correctness of the scalar addition."""
-    @unittest.skip("Failing on MacOS")
     @given(A=hu.tensor(shapes=hu.array_shapes(1, 4, 1, 5),
                        elements=hu.floats(-1e6, 1e6, allow_nan=False),
                        qparams=hu.qparams()),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37932 reenable quantization test_qadd_scalar_relu test (redo)**

Summary:

Redo of https://github.com/pytorch/pytorch/pull/37423, which got
reverted.  Hoping the CI gives a real failure this time.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags: