### PR TITLE
Add `__init__.py` to `test/quantization` folder

### DIFF
--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -22,6 +22,7 @@ class DeterminationTest(unittest.TestCase):
         "test_cpp_extensions_aot_no_ninja",
         "test_utils",
         "test_determination",
+        "test_quantization",
     ]
 
     @classmethod
@@ -70,6 +71,17 @@ class DeterminationTest(unittest.TestCase):
         self.assertEqual(
             self.determined_tests(["test/distributed/rpc/test_rpc_spawn.py"]),
             ["distributed/rpc/test_rpc_spawn"],
+        )
+        self.assertEqual(
+            self.determined_tests(["test/quantization/test_quantize.py"]),
+            ["test_quantization"],
+        )
+
+    def test_test_internal_file(self):
+        """testing/_internal files trigger dependent tests"""
+        self.assertEqual(
+            self.determined_tests(["torch/testing/_internal/common_quantization.py"]),
+            ["test_quantization"],
         )
 
     def test_torch_file(self):


### PR DESCRIPTION
This makes it a proper python package, therefor `ModuleFinder` will parse dependencies from this module, and as results, changes to `torch/testing/_internal/common_quantization` or `test/quantization/*.py` would be considered affecting `test_quantization.py`.