### PR TITLE
[reland][quant][graphmode] Support a new category of ops in graph mode quantization

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1098,15 +1098,25 @@ graph(%input, %weight):
             def __init__(self):
                 super(M, self).__init__()
                 self.conv = torch.nn.Conv2d(3, 3, 3).float()
+                self.avgpool = torch.nn.AvgPool2d(3)
 
             def forward(self, x):
-                return self.conv(x)
+                x = self.conv(x)
+                x = self.avgpool(x)
+                return x
 
         data = [(torch.rand((1, 3, 10, 10), dtype=torch.float), torch.randint(0, 1, (1,), dtype=torch.long)) for _ in range(2)]
         qconfig_dict = {'': default_qconfig}
         model = torch.jit.script(M()).eval()
         model = quantize_script(model, qconfig_dict, _test_only_eval_fn, [data], inplace=False, debug=True)
         FileCheck().check_not("quantized::conv2d") \
+                   .check("aten::conv2d") \
+                   .check("aten::avg_pool2d") \
+                   .check("aten::q_scale") \
+                   .check_next("aten::q_zero_point") \
+                   .check_next("prim::dtype") \
+                   .check_next("aten::quantize_per_tensor") \
+                   .check("aten::dequantize") \
                    .run(model.graph)
 
     def test_module_list(self):
@@ -1618,9 +1628,10 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
         FileCheck().check_not("aten::layer_norm") \
                    .run(m.graph)
 
-    def test_swap_dequantize_all_ops(self):
+    def test_quantize_general_shape_ops(self):
         """ A test that checks dequantize will be swapped for
-        all supported general ops without actually checking for execution of these ops
+        all supported general shape ops like aten::flatten
+        without actually checking for execution of these ops
         """
         class M(torch.nn.Module):
             def __init__(self):
@@ -1729,6 +1740,60 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
                    .check_count("quantized::conv2d", 2, exactly=True) \
                    .check("aten::dequantize") \
                    .run(m.graph)
+
+    def test_quantize_general_value_ops(self):
+        """ A test that checks dequantize will be swapped for \
+        all supported general value ops like aten::avg_pool2d \
+        without actually checking for execution of these ops
+        """
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.avgpool2d = torch.nn.AvgPool2d(3)
+                self.conv = torch.nn.Conv2d(3, 3, 3)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.avgpool2d(x)
+                x = F.avg_pool2d(x, 3)
+                x = self.conv(x)
+                return x
+
+        m = torch.jit.script(M())
+        qconfig = script_qconfig(default_qconfig)
+        # dummy data to suppress warning
+        data = torch.rand((1, 3, 10, 10))
+        get_forward(qconfig.activation)(data)
+        get_forward(qconfig.weight)(data)
+
+        m = wrap_cpp_module(torch._C._jit_pass_insert_observers(
+            m._c, 'forward', {'': qconfig}, inplace=False))
+        # Checking the model before fianlize contain unfused patterns
+        # that numerically matches the model after quantize by checking
+        # number of aten::quantize_per_tensor functions
+        # conv has 3 quantize_per_tensor for activations and 1 for weight
+        # and for N general value op between conv we should have
+        # N + 1 quantize_per_tensor between these ops
+        m1 = convert_script(m, debug=True)
+        conv_op_quant = 4
+        # NB: This Needs to be updated when we add more ops to test
+        general_value_op_quant = 2
+        FileCheck().check_count("aten::quantize_per_tensor", conv_op_quant + general_value_op_quant + 1, exactly=True) \
+                   .run(m1.graph)
+
+        # This checks that the dequantize from the output of first conv
+        # is being propagated to the end, so that we don't insert extra
+        # observers and also successfully fused two quantized::conv2d
+        # patterns
+        # one quantize_per_tensor for input
+        m = wrap_cpp_module(torch._C._jit_pass_insert_observers(
+            torch.jit.script(M())._c, 'forward', {'': qconfig}, inplace=False))
+        m2 = convert_script(m, debug=False)
+        print(m2.graph)
+        FileCheck().check_count("aten::quantize_per_tensor", 1, exactly=True) \
+                   .check_count("quantized::conv2d", 2, exactly=True) \
+                   .check("aten::dequantize") \
+                   .run(m2.graph)
 
 class TestQuantizeDynamicScript(JitTestCase):
     def test_prepare_dynamic(self):

--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -1789,12 +1789,9 @@ class TestQuantizeScriptPTSQOps(JitTestCase):
         m = wrap_cpp_module(torch._C._jit_pass_insert_observers(
             torch.jit.script(M())._c, 'forward', {'': qconfig}, inplace=False))
         m2 = convert_script(m, debug=False)
-        print(m2.graph)
-        FileCheck().check_count("aten::quantize_per_tensor", 1, exactly=True) \
-                   .run(m2.graph)
-
-        FileCheck().check_count("quantized::conv2d", 2, exactly=True) \
-                   .check("aten::dequantize") \
+        FileCheck().check_count("aten::quantize_per_tensor(", 1, exactly=True) \
+                   .check_count("quantized::conv2d(", 2, exactly=True) \
+                   .check("aten::dequantize(") \
                    .run(m2.graph)
 
 class TestQuantizeDynamicScript(JitTestCase):

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -91,7 +91,6 @@ std::vector<std::string> _single_input_general_shape_call_funcs = {
     "adaptive_avg_pool2d",
     "adaptive_avg_pool3d",
     "avg_pool1d",
-    "avg_pool2d",
     "avg_pool3d",
     "_max_pool1d",
     "_max_pool2d",
@@ -125,7 +124,6 @@ std::vector<std::string> _single_input_general_shape_aten_funcs = {
     "max_pool2d",
     "max_pool3d",
     "avg_pool1d",
-    "avg_pool2d",
     "avg_pool3d",
     "flatten",
     "max",
@@ -169,13 +167,17 @@ std::vector<std::string> _single_input_general_shape_aten_funcs = {
 // Theses are prim::CallFunctions for ops that doesn't require observation and
 // have a single input Tensor
 // Also these ops do computation on the value of Tensor
-std::vector<std::string> _single_input_general_value_call_funcs = {};
+std::vector<std::string> _single_input_general_value_call_funcs = {
+    "avg_pool2d",
+};
 
 // Theses are aten functions for ops that doesn't require observation and
 // have a single input Tensor
 // Also these ops do computation on the value of Tensor
-// e.g. `aten::maxpool(%input_tensor, ...)`
-std::vector<std::string> _single_input_general_value_aten_funcs = {};
+// e.g. `aten::avg_pool2d(%input_tensor, ...)`
+std::vector<std::string> _single_input_general_value_aten_funcs = {
+    "avg_pool2d",
+};
 
 struct FuncArg {
   std::string func_name;
@@ -268,6 +270,13 @@ bool hasScalarInput(Node* n) {
   return isAtenFunc(n, scalar_ops) &&
       n->input(0)->type()->isSubtypeOf(TensorType::get()) &&
       n->input(1)->type()->isSubtypeOf(NumberType::get());
+}
+
+bool isSingleInputGeneralValueAtenFunction(Node* n) {
+  return isFunctionNode(
+      n,
+      /* call_funcs = */ {},
+      /* aten_funcs = */ _single_input_general_value_aten_funcs);
 }
 
 bool isSingleInputGeneralCallFunction(Node* n) {
@@ -1651,6 +1660,7 @@ void insertQuantizationOps(
   }
   observer_out->replaceAllUsesWith(original_val);
   std::vector<Use> uses = original_val->uses();
+  // TODO: use replaceAllUsesAfterNodeWith?
   for (const auto& use : uses) {
     auto* user = use.user;
     if (user != quant && user != observer && user != choose_qparams) {
@@ -1731,6 +1741,9 @@ class InsertQuantDeQuantHelper {
     is_dynamic_ = is_dynamic;
   }
 
+  // In order to propagate quantization ops through the ops that doesn't
+  // require observation, we'll first inline the graph, and call the
+  // PropgateQuantizationOps pass
   void propagateQuantizationOps(Module& module);
 
  private:
@@ -2688,6 +2701,20 @@ void addBiasForConv2dIfNone(Module& module) {
   }
 }
 
+Node* insertQParam(
+    Graph* graph,
+    Value* quantized_input,
+    NodeKind node_kind,
+    const TypePtr& output_type,
+    const std::string& param_name) {
+  Node* qparam = graph->create(node_kind, {quantized_input});
+  qparam->output()
+      ->setDebugName(quantized_input->debugName() + "." + param_name)
+      ->setType(output_type);
+  graph->insertNode(qparam);
+  return qparam;
+}
+
 void propagateQuantizationOps(Block* block) {
   auto graph = block->owningGraph();
   for (Node* n : block->nodes()) {
@@ -2718,22 +2745,69 @@ void propagateQuantizationOps(Block* block) {
         if (!is_dequantized) {
           continue;
         }
-        // Delete dequantize node, we have one dequantize
-        // for each use of the value
-        for (auto* dequantized_val : inputs) {
-          auto* dequantize_node = dequantized_val->node();
+        if (isSingleInputGeneralValueAtenFunction(n)) {
+          // for ops like average pool, we'll insert quant dequant after the op
+          // We'll assume the tensor is a PerTensorAffine quantized Tensor for
+          // now, and may generalize later if this becomes an issue
           TORCH_INTERNAL_ASSERT(
-              dequantized_val->uses().size() == 1,
-              "Expect to have one dequantize node for each use");
-          // Replace useses of dequantized_val with the input of
-          // dequantize node
-          dequantized_val->replaceAllUsesWith(dequantize_node->inputs()[0]);
-          dequantize_node->removeAllInputs();
-          dequantize_node->destroy();
+              inputs.size() == 1,
+              "Expecting single input for the aten function");
+          // input of the dequantize node
+          Value* quantized_input = inputs[0]->node()->input(0);
+          // insert ops after the general op
+          WithInsertPoint ins(n->next());
+          // get quantization parameters from previous quantized op
+          Node* scale = insertQParam(
+              graph,
+              quantized_input,
+              at::Symbol::aten("q_scale"),
+              FloatType::get(),
+              "q_scale");
+          Node* zero_point = insertQParam(
+              graph,
+              quantized_input,
+              at::Symbol::aten("q_zero_point"),
+              IntType::get(),
+              "q_zero_point");
+          Node* dtype = insertQParam(
+              graph, quantized_input, prim::dtype, IntType::get(), "dtype");
+          Value* original_output = n->output();
+          std::vector<Value*> quant_inputs = {original_output,
+                                              scale->output(),
+                                              zero_point->output(),
+                                              dtype->output()};
+          auto quant_kind = at::Symbol::aten("quantize_per_tensor");
+          Node* quant = insertQuant(
+              graph,
+              quant_inputs,
+              quant_kind,
+              original_output->debugName() + ".quant");
+          Value* quantized_output = quant->output();
+          // replace uses of original output of the general op with quantized
+          // output
+          original_output->replaceAllUsesAfterNodeWith(quant, quantized_output);
+          std::vector<Use> quantized_uses = quantized_output->uses();
+          GRAPH_DEBUG("quantized uses: ", quantized_uses.size());
+          insertDeQuantForAllUse(
+              graph, quantized_output, quantized_output, quantized_uses);
+        } else {
+          // Delete dequantize node, we have one dequantize
+          // for each use of the value
+          for (auto* dequantized_val : inputs) {
+            auto* dequantize_node = dequantized_val->node();
+            TORCH_INTERNAL_ASSERT(
+                dequantized_val->uses().size() == 1,
+                "Expect to have one dequantize node for each use");
+            // Replace useses of dequantized_val with the input of
+            // dequantize node
+            dequantized_val->replaceAllUsesWith(dequantize_node->inputs()[0]);
+            dequantize_node->removeAllInputs();
+            dequantize_node->destroy();
+          }
+          std::vector<Use> uses = output->uses();
+          // Insert new dequantize node for each use of the output
+          insertDeQuantForAllUse(graph, output, output, uses);
         }
-        std::vector<Use> uses = output->uses();
-        // Insert new dequantize node for each use of the output
-        insertDeQuantForAllUse(graph, output, output, uses);
       }
     }
   }

--- a/torch/csrc/jit/passes/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization_patterns.h
@@ -439,6 +439,23 @@ graph(%a_quant, %normalized_shape, %weight, %bias, %eps, %cudnn_enabled, %output
          %r = quantized::layer_norm(%a_quant, %normalized_shape, %weight, %bias, %eps, %output_scale, %output_zero_point)
          return (%r) )";
 
+  // ============= General Ops that doesn't require observation =============
+  // aten::avg_pool2d
+  std::string avg_pool2d = R"(
+graph(%a_quant, %kernel_size, %stride, %padding, %ceil_mode, %count_include_pad, %divisor_override):
+          %a_dequant = aten::dequantize(%a_quant)
+          %r = aten::avg_pool2d(%a_dequant, %kernel_size, %stride, %padding, %ceil_mode, %count_include_pad, %divisor_override)
+          %r_scale : float = aten::q_scale(%a_quant)
+          %r_zero_point : int = aten::q_zero_point(%a_quant)
+          %r_dtype : int = prim::dtype(%a_quant)
+          %r_quant = aten::quantize_per_tensor(%r, %r_scale, %r_zero_point, %r_dtype)
+          return (%r_quant) )";
+
+  std::string quantized_avg_pool2d = R"(
+graph(%a_quant, %kernel_size, %stride, %padding, %ceil_mode, %count_include_pad, %divisor_override):
+          %r = aten::avg_pool2d(%a_quant, %kernel_size, %stride, %padding, %ceil_mode, %count_include_pad, %divisor_override)
+          return (%r) )";
+
   return {
       {"quantized::conv2d", conv2d, quantized_conv2d},
       {"quantized::conv2d_relu", conv2d_relu, quantized_conv2d_relu},
@@ -500,6 +517,7 @@ graph(%a_quant, %normalized_shape, %weight, %bias, %eps, %cudnn_enabled, %output
       {"quantized::mul_relu", inplace_mul_inplace_relu, quantized_mul_relu},
       {"quantized::hardswish", hardswish, quantized_hardswish},
       {"quantized::layer_norm", layer_norm, quantized_layer_norm},
+      {"aten::avg_pool2d", avg_pool2d, quantized_avg_pool2d},
   };
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37936 [reland][quant][graphmode] Support a new category of ops in graph mode quantization**

Summary:

Previously we classify ops like average pool to the category that doesn't require observation and
the quantization of these ops are done by swapping with dequantize ops: https://github.com/pytorch/pytorch/pull/33481
However, this operation is done in finalize, which means finalize is a numerics changing pass when we swap dequantize with
ops like average pool, this is not ideal since we want to restrict the scope of numerics changing passes.
Because although average pool doesn't require observation, quantized average pool = dequant + float32 average pool + quant
and swapping average pool with dequantize is a numerics changing operation.

This PR implements the support for that. We'll classify ops like average pool to a new category and we'll get average pool through fusion, like we did for other quantized ops. And the numerics changing pass will only happen in insert quant dequant pass, so the model will have the same numerics before and after finalize. With the new category, the debug only option(the model before finalize) for quantize_script will actually produce a model that's numerically consistent with the finalized model.

Test Plan:
python test/test_quantization.py TestQuantizeScriptJitPasses

Differential Revision: [D21432871](https://our.internmc.facebook.com/intern/diff/D21432871)