### PR TITLE
Add preprocessing that fuses decomposed linear into linear.

### DIFF
--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/fuse_linear.h>
 #include <torch/csrc/jit/passes/graph_rewrite_helper.h>
 #include <torch/csrc/jit/passes/prepack_folding.h>
 #include <torch/csrc/jit/passes/quantization.h>
@@ -19,6 +20,9 @@ namespace jit {
 namespace {
 
 void insertPrePackedLinearOp(std::shared_ptr<Graph>& graph) {
+  // fuse decomposed linear into aten::linear
+  FuseLinear(graph);
+
   std::string linear_before_inline = R"(
     graph(%linear, %input, %weight, %bias):
         %r = prim::CallFunction(%linear, %input, %weight, %bias)


### PR DESCRIPTION
Summary:
Sometime traces models dont preseve aten::linear ops and they are decomposed
into addmm or mul + add. Adding thie preprocessing step helps us catch more
lowerable linear nodes.
Please see the test for example.

Test Plan: python test/test_xnnpack_integration.py

Differential Revision: D21428069

