### PR TITLE
[TensorExpr] Support Bool dtype in Or, Xor, And ops and in TensorExprKernel::bindInput.

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -155,7 +155,7 @@ class And : public BinaryOpNode<And> {
  public:
   And(const Expr* lhs, const Expr* rhs)
       : BinaryOpNode(lhs, rhs, IRNodeType::kAnd) {
-    if (lhs->dtype().scalar_type() != ScalarType::Int) {
+    if (!lhs->dtype().is_integral()) {
       throw unsupported_dtype();
     }
     if (lhs->dtype() != rhs->dtype()) {
@@ -168,7 +168,7 @@ class Or : public BinaryOpNode<Or> {
  public:
   Or(const Expr* lhs, const Expr* rhs)
       : BinaryOpNode(lhs, rhs, IRNodeType::kOr) {
-    if (lhs->dtype().scalar_type() != ScalarType::Int) {
+    if (!lhs->dtype().is_integral()) {
       throw unsupported_dtype();
     }
     if (lhs->dtype() != rhs->dtype()) {
@@ -181,7 +181,7 @@ class Xor : public BinaryOpNode<Xor> {
  public:
   Xor(const Expr* lhs, const Expr* rhs)
       : BinaryOpNode(lhs, rhs, IRNodeType::kXor) {
-    if (lhs->dtype().scalar_type() != ScalarType::Int) {
+    if (!lhs->dtype().is_integral()) {
       throw unsupported_dtype();
     }
     if (lhs->dtype() != rhs->dtype()) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1308,6 +1308,12 @@ void TensorExprKernel::bindInput(const torch::jit::Value* input) {
       scalars_.emplace(input->unique(), v);
       break;
     }
+    case TypeKind::BoolType: {
+      VarHandle v("v" + input->debugName(), kBool);
+      kernelArgs_.emplace_back(v);
+      scalars_.emplace(input->unique(), v);
+      break;
+    }
     case TypeKind::IntType: {
       VarHandle v("v" + input->debugName(), kInt);
       kernelArgs_.emplace_back(v);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37948 [TensorExpr] TensorExprKernel: don't do any compilation or lowering in run().
* **#37938 [TensorExpr] Support Bool dtype in Or, Xor, And ops and in TensorExprKernel::bindInput.**

Differential Revision: [D21428552](https://our.internmc.facebook.com/intern/diff/D21428552)