### PR TITLE
[quant][test] Fix macos/windows CI test

### DIFF
--- a/test/quantization/test_quantized_module.py
+++ b/test/quantization/test_quantized_module.py
@@ -35,7 +35,7 @@ def override_qengines(qfunction):
         for qengine in supported_qengines:
             with override_quantized_engine(qengine):
                 result = qfunction(*args, **kwargs)
-        return result
+            return result
     return test_fn
 
 class TestStaticQuantizedModule(QuantizationTestCase):

--- a/test/quantization/test_quantized_module.py
+++ b/test/quantization/test_quantized_module.py
@@ -34,8 +34,8 @@ def override_qengines(qfunction):
     def test_fn(*args, **kwargs):
         for qengine in supported_qengines:
             with override_quantized_engine(qengine):
-                result = qfunction(*args, **kwargs)
-            return result
+                # qfunction should not return anything.
+                qfunction(*args, **kwargs)
     return test_fn
 
 class TestStaticQuantizedModule(QuantizationTestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37939 [quant][test] Fix macos/windows CI test**

Summary:
macos and windows test were skipped for quantization tests in CI target determinator

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: