### PR TITLE
Use CompareSelect when lowering aten operators where both selectands are guaranteed to be the same size.

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -822,7 +822,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
           [](const ExprHandle& a,
              const ExprHandle& threshold,
              const ExprHandle& value) {
-            return ifThenElse(CompareSelect::make(a, threshold, kGT), a, value);
+            return CompareSelect::make(a, threshold, a, value, kGT);
           });
     } break;
 
@@ -831,7 +831,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
           "aten_where",
           v,
           [](const ExprHandle& a0, const ExprHandle& a1, const ExprHandle& a2) {
-            return ifThenElse(a0, a1, a2);
+            return CompareSelect::make(a0, ExprHandle(0), a1, a2, kNE);
           });
     } break;
 


### PR DESCRIPTION
This is vectorizable unlike IfThenElse.