### PR TITLE
quant: remove hypothesis and int32 from layernorm test

### DIFF
--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -327,105 +327,89 @@ class TestQuantizedOps(TestCase):
 
 
     """Tests the correctness of the quantized::qlayer_norm op."""
-    @given(shapes=hu.array_shapes(3, 5, 1, 32),
-           torch_type=st.sampled_from((torch.qint8, torch.quint8, torch.qint32)),
-           X_rand_scale=st.floats(0.01, 1e3),
-           Y_scale=st.floats(0.2, 2.6),
-           Y_zero_point=st.integers(0, 5))
-    def test_qlayer_norm(self, shapes, torch_type, X_rand_scale, Y_scale, Y_zero_point):
+    def test_qlayer_norm(self):
         if "fbgemm" not in torch.backends.quantized.supported_engines:
             return
 
+        # hypothesis is flaky for this test, create test cases manually
+        max_sides = (4, 5)
+        side_lens = (1, 8, 11)
+        torch_types = (torch.qint8, torch.quint8)
+        y_scales = (0.1, 4.23)
+        y_zero_points = (0, 1)
+        combined = [max_sides, side_lens, torch_types, y_scales, y_zero_points]
+        test_cases = itertools.product(*combined)
+
         with override_quantized_engine("fbgemm"):
+            for test_case in test_cases:
 
-            # In the FP kernel, mean and variance are calculated in floating point.
-            # In the quantized kernel, they are calculated in integer arithmetic.
-            # Because of this, the numerics do not always match exactly which is
-            # expected and acceptable. We do two things to whitelist this failure
-            # in this test:
-            # 1. do not use Hypothesis to generate the input tensor.  Hypothesis
-            #    favors homogeneous inputs in its search strategies which isn't
-            #    representative of the inputs we care about, and tends to maximize
-            #    this particular numerics difference.
-            # 2. whitelist a small % of off by Y_scale errors.  Even when the
-            #    variance of the input is high, there can be off by one errors
-            #    in the result if the input value happens to fall exactly on
-            #    the bin boundary of the output scale.
-            #
-            # If we want the numerics to match we could switch to calculating
-            # mean+var in floating point in the future, at the cost of speed.
+                max_side, side_len, torch_type, Y_scale, Y_zero_point = test_case
+                shapes = [side_len] * max_side
 
-            X = (np.random.rand(*shapes).astype(np.float32) - 0.5) * X_rand_scale
+                # In the FP kernel, mean and variance are calculated in floating point.
+                # In the quantized kernel, they are calculated in integer arithmetic.
+                # Because of this, the numerics do not always match exactly which is
+                # expected and acceptable. We do two things to whitelist this failure
+                # in this test:
+                # 1. do not use Hypothesis to generate the input tensor.  Hypothesis
+                #    favors homogeneous inputs in its search strategies which isn't
+                #    representative of the inputs we care about, and tends to maximize
+                #    this particular numerics difference.
+                # 2. whitelist a small % of off by Y_scale errors.  Even when the
+                #    variance of the input is high, there can be off by one errors
+                #    in the result if the input value happens to fall exactly on
+                #    the bin boundary of the output scale.
+                #
+                # If we want the numerics to match we could switch to calculating
+                # mean+var in floating point in the future, at the cost of speed.
+                X, X_scale, X_zero_point = \
+                    _get_random_tensor_and_q_params(shapes, 1.0, torch_type)
 
-            # Calculate reasonable quantization params
-            min_val = np.min(X)
-            max_val = np.max(X)
-            if torch_type == torch.qint32:
-                X_zero_point = 0
-                num_bins = 2 ** 32
-                X_scale = float(max_val - min_val) / num_bins
-            elif torch_type == torch.qint8:
-                X_zero_point = 0
-                num_bins = 2 ** 8
-                X_scale = float(max_val - min_val) / num_bins
-            else:  # torch.quint8
-                X_zero_point = 127
-                num_bins = 2 ** 8
-                X_scale = float(max_val - min_val) / num_bins
-            if X_scale == 0:
-                X_scale = 1e-10
+                qX = torch.quantize_per_tensor(X, scale=X_scale,
+                                               zero_point=X_zero_point,
+                                               dtype=torch_type)
+                dqX = qX.dequantize()
 
-            X = torch.from_numpy(X)
-            qX = torch.quantize_per_tensor(X, scale=X_scale,
-                                           zero_point=X_zero_point,
-                                           dtype=torch_type)
-            dqX = qX.dequantize()
+                # Enforce non-homogeneous inputs
+                enough_unique_vals_in_each_layer = sum(
+                    1 if (
+                        dqX[i].shape[0] < 5 or
+                        float(torch.unique(dqX[i]).shape[0]) / dqX[i].shape[0] > 0.01
+                    ) else 0
+                    for i in range(dqX.shape[0])
+                ) == dqX.shape[0]
+                assume(enough_unique_vals_in_each_layer)
 
-            # Enforce non-homogeneous inputs
-            enough_unique_vals_in_each_layer = sum(
-                1 if (
-                    dqX[i].shape[0] < 5 or
-                    float(torch.unique(dqX[i]).shape[0]) / dqX[i].shape[0] > 0.01
-                ) else 0
-                for i in range(dqX.shape[0])
-            ) == dqX.shape[0]
-            assume(enough_unique_vals_in_each_layer)
+                # Initialize the weights non-randomly for reproducibility, to avoid
+                # flaky tests
+                weight = torch.ones(*qX.size()[1:], dtype=torch.float) * 0.5
+                bias = torch.ones(*qX.size()[1:], dtype=torch.float) * 1
+                epsilon = 1e-5
 
-            # Initialize the weights non-randomly for reproducibility, to avoid
-            # flaky tests
-            weight = torch.ones(*qX.size()[1:], dtype=torch.float) * 0.5
-            bias = torch.ones(*qX.size()[1:], dtype=torch.float) * 1
-            epsilon = 1e-5
+                qY = torch.ops.quantized.layer_norm(
+                    qX, qX.size()[1:], weight=weight, bias=bias, eps=epsilon,
+                    output_scale=Y_scale, output_zero_point=Y_zero_point)
 
-            qY = torch.ops.quantized.layer_norm(
-                qX, qX.size()[1:], weight=weight, bias=bias, eps=epsilon,
-                output_scale=Y_scale, output_zero_point=Y_zero_point)
+                Y_hat = F.layer_norm(
+                    dqX, dqX.size()[1:], weight=weight, bias=bias, eps=epsilon)
+                qY_hat = torch.quantize_per_tensor(
+                    Y_hat, scale=Y_scale, zero_point=Y_zero_point, dtype=torch_type)
 
-            Y_hat = F.layer_norm(
-                dqX, dqX.size()[1:], weight=weight, bias=bias, eps=epsilon)
-            qY_hat = torch.quantize_per_tensor(
-                Y_hat, scale=Y_scale, zero_point=Y_zero_point, dtype=torch_type)
+                # Due to the numerics difference mentioned above between calculating
+                # the variance in float vs int, the results can still be slightly
+                # different.
+                dqY = qY.dequantize()
+                dqY_hat = qY_hat.dequantize()
+                diff = dqY - dqY_hat
 
-            # Due to the numerics difference mentioned above between calculating
-            # the variance in float vs int, the results can still be slightly
-            # different.
-            dqY = qY.dequantize()
-            dqY_hat = qY_hat.dequantize()
-            diff = dqY - dqY_hat
+                # off-by-one errors are magnitude of Y_scale
+                num_diff = torch.sum(diff > Y_scale * 1.0001)
+                pct_diff = float(num_diff) / (diff.numel() + 1e-5)
+                num_diff_off_by_one = torch.sum((diff > 0) * (diff <= Y_scale))
+                pct_diff_off_by_one = float(num_diff_off_by_one) / (diff.numel() + 1e-5)
 
-            # off-by-one errors are magnitude of Y_scale
-            num_diff = torch.sum(diff > Y_scale * 1.0001)
-            pct_diff = float(num_diff) / (diff.numel() + 1e-5)
-            num_diff_off_by_one = torch.sum((diff > 0) * (diff <= Y_scale))
-            pct_diff_off_by_one = float(num_diff_off_by_one) / (diff.numel() + 1e-5)
-
-            note("LayerNorm failed:\n {} input vs\n {} actual vs \n{} expected"
-                 .format(X, qY, qY_hat))
-            note("Pct diff: {}".format(pct_diff))
-            note("Pct diff off by one: {}".format(pct_diff_off_by_one))
-
-            self.assertTrue(pct_diff < 1e-6)
-            self.assertTrue(pct_diff_off_by_one < 0.01)
+                self.assertTrue(pct_diff < 1e-6)
+                self.assertTrue(pct_diff_off_by_one < 0.01)
 
 
     """Tests the correctness of the quantized::qnnpack_tanh op."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37802 quant: clean up normalization channels_last handling
* #37781 quant: add test util for testing off by one quantized tensors
* #37352 move quantization normalization layers to aten/src/ATen/native/quantized/cpu/
* #36847 add quantized instancenorm operator
* #36835 add quantized groupnorm operator
* **#37947 quant: remove hypothesis and int32 from layernorm test**

Summary:

The current test is flaky, removing two potential causes of flakiness.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21434861](https://our.internmc.facebook.com/intern/diff/D21434861)