### PR TITLE
Move resize logic for bmm from codegen to native code.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -655,7 +655,6 @@
   arguments:
     - arg: THTensor* result
       output: True
-      resize: [ [self,0], [self,1], [mat2,2] ]
     - argument 0
     - THTensor* self
     - THTensor* mat2

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -44,12 +44,14 @@ Tensor& addbmm_cuda_out(Tensor& result, const Tensor& self, const Tensor& batch1
   return legacy::cuda::_th_addbmm_out(result, self, batch1, batch2, beta, alpha);
 }
 
-Tensor bmm_cuda(const Tensor& self, const Tensor& mat2) {
-  return legacy::cuda::_th_bmm(self, mat2);
+Tensor& bmm_out_cuda(Tensor &result, const Tensor& batch1, const Tensor& batch2) {
+  result.resize_({ batch1.size(0), batch1.size(1), batch2.size(2) });
+  return legacy::cuda::_th_bmm_out(result, batch1, batch2);
 }
 
-Tensor& bmm_out_cuda(Tensor &result, const Tensor& batch1, const Tensor& batch2) {
-  return legacy::cuda::_th_bmm_out(result, batch1, batch2);
+Tensor bmm_cuda(const Tensor& self, const Tensor& mat2) {
+  Tensor result = at::empty({0}, self.options());
+  return native::bmm_out_cuda(result, self, mat2);
 }
 
 Tensor prepare_matrix_for_cublas(Tensor& tensor, bool& transpose_tensor) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37958 Kill resize-ing and zero-ing from codegen.
* #37957 Move resize / zero logic for _thnn_conv_depthwise2d from codegen to native code.
* #37956 Move _thnn_conv2d resize and zero code from codegen to native code.
* **#37955 Move resize logic for bmm from codegen to native code.**
* #37907 [RESUBMIT] Kill broadcasting from the codegen layer.

Differential Revision: [D21433213](https://our.internmc.facebook.com/intern/diff/D21433213)