### PR TITLE
Move _thnn_conv2d resize and zero code from codegen to native code.

### DIFF
--- a/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
+++ b/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/LegacyTHFunctionsCUDA.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
+++ b/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
@@ -3,8 +3,6 @@
 namespace at {
 namespace native {
 
-namespace {
-
 std::tuple<Tensor&, Tensor&, Tensor&> slow_conv2d_backward_out_cuda(
     Tensor& grad_input,
     Tensor& grad_weight,

--- a/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
+++ b/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
@@ -1,0 +1,67 @@
+#include <ATen/ATen.h>
+
+namespace at {
+namespace native {
+
+namespace {
+
+std::tuple<Tensor&, Tensor&, Tensor&> slow_conv2d_backward_out_cuda(
+    Tensor& grad_input,
+    Tensor& grad_weight,
+    Tensor& grad_bias,
+    const Tensor& grad_output,
+    const Tensor& self,
+    const Tensor& weight,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    const Tensor& finput,
+    const Tensor& fgrad_input) {
+  if (grad_weight.defined()) {
+    grad_weight.resize_(weight.sizes());
+    grad_weight.zero_();
+  }
+  if (grad_bias.defined()) {
+    grad_bias.resize_({ weight.size(0) });
+    grad_bias.zero_();
+  }
+  return legacy::cuda::_thnn_conv2d_backward_out(grad_input, grad_weight, grad_bias,
+                                                 grad_output, self, weight,
+                                                 kernel_size, stride, padding,
+                                                 finput, fgrad_input);
+}
+
+std::tuple<Tensor, Tensor, Tensor> slow_conv2d_backward_cuda(
+    const Tensor& grad_output,
+    const Tensor& self,
+    const Tensor& weight,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    const Tensor& finput,
+    const Tensor& fgrad_input,
+    std::array<bool, 3> output_mask) {
+  Tensor grad_input;
+  Tensor grad_weight;
+  Tensor grad_bias;
+
+  if (output_mask[0]) {
+    grad_input = at::empty({0}, grad_output.options());
+  }
+
+  if (output_mask[1]) {
+    grad_weight = at::empty({0}, grad_output.options());
+  }
+
+  if (output_mask[2]) {
+    grad_bias = at::empty({0}, grad_output.options());
+  }
+
+  return native::slow_conv2d_backward_out_cuda(grad_input, grad_weight, grad_bias,
+                                               grad_output, self, weight,
+                                               kernel_size, stride, padding,
+                                               finput, fgrad_input);
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6820,14 +6820,14 @@
   python_module: nn
   dispatch:
     CPU: slow_conv2d_backward_out_cpu
-    CUDA: legacy::cuda::_thnn_conv2d_backward_out
+    CUDA: slow_conv2d_backward_out_cuda
 
 - func: thnn_conv2d_backward.output_mask(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, Tensor finput, Tensor fgrad_input, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   use_c10_dispatcher: full
   python_module: nn
   dispatch:
     CPU: slow_conv2d_backward_cpu
-    CUDA: legacy::cuda::_thnn_conv2d_backward
+    CUDA: slow_conv2d_backward_cuda
 
 - func: thnn_conv_depthwise2d.out(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -295,10 +295,10 @@ def backward_declaration(base, thnn_functions, backend_types):
         arg['is_nullable'] = True
 
         # grad_weight and grad_bias need to be resized and zeroed
-        if arg['name'] == 'grad_weight':
+        if arg['name'] == 'grad_weight' and base['name'] != '_thnn_conv2d':
             arg['resize'] = 'weight'
             arg['zero'] = True
-        if arg['name'] == 'grad_bias':
+        if arg['name'] == 'grad_bias' and base['name'] != '_thnn_conv2d':
             dim = 1 if 'transpose' in name else 0
             arg['resize'] = [('weight', dim)]
             arg['zero'] = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37958 Kill resize-ing and zero-ing from codegen.
* #37957 Move resize / zero logic for _thnn_conv_depthwise2d from codegen to native code.
* **#37956 Move _thnn_conv2d resize and zero code from codegen to native code.**
* #37955 Move resize logic for bmm from codegen to native code.
* #37907 [RESUBMIT] Kill broadcasting from the codegen layer.

This is basically just doing what the CPU code already does, but with keeping the kernel in THC, unlike in CPU where that has already moved to native.

Differential Revision: [D21433211](https://our.internmc.facebook.com/intern/diff/D21433211)