### PR TITLE
Move resize / zero logic for _thnn_conv_depthwise2d from codegen to native code.

### DIFF
--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -1,0 +1,55 @@
+#include <ATen/ATen.h>
+
+namespace at {
+namespace native {
+
+namespace {
+
+std::tuple<Tensor &,Tensor &> thnn_conv_depthwise2d_backward_out(
+    Tensor & grad_input,
+    Tensor & grad_weight,
+    const Tensor & grad_output,
+    const Tensor & self,
+    const Tensor & weight,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation) {
+  if (grad_weight.defined()) {
+    grad_weight.resize_(weight.sizes());
+    grad_weight.zero_();
+  }
+
+  return legacy::cuda::_thnn_conv_depthwise2d_backward_out(grad_input, grad_weight,
+                                                           grad_output, self, weight,
+                                                           kernel_size, stride, padding, dilation);
+}
+
+std::tuple<Tensor, Tensor, Tensor> thnn_conv_depthwise2d_backward(
+    const Tensor& grad_output,
+    const Tensor& self,
+    const Tensor& weight,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    std::array<bool, 2> output_mask) {
+  Tensor grad_input;
+  Tensor grad_weight;
+
+  if (output_mask[0]) {
+    grad_input = at::empty({0}, grad_output.options());
+  }
+
+  if (output_mask[1]) {
+    grad_weight = at::empty({0}, grad_output.options());
+  }
+
+  return native::thnn_conv_depthwise2d_backward_out(grad_input, grad_weight,
+                                                    grad_output, self, weight,
+                                                    kernel_size, stride, padding,
+                                                    dilation);
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6848,13 +6848,13 @@
 - func: thnn_conv_depthwise2d_backward.grad_input(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, *, Tensor(a!)? grad_input, Tensor(b!)? grad_weight) -> (Tensor(a!), Tensor(b!))
   python_module: nn
   dispatch:
-    CUDA: legacy::cuda::_thnn_conv_depthwise2d_backward_out
+    CUDA: thnn_conv_depthwise2d_backward_out
 
 - func: thnn_conv_depthwise2d_backward.output_mask(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool[2] output_mask) -> (Tensor grad_input, Tensor grad_weight)
   use_c10_dispatcher: full
   python_module: nn
   dispatch:
-    CUDA: legacy::cuda::_thnn_conv_depthwise2d_backward
+    CUDA: thnn_conv_depthwise2d_backward
 
 - func: slow_conv3d.out(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -295,10 +295,10 @@ def backward_declaration(base, thnn_functions, backend_types):
         arg['is_nullable'] = True
 
         # grad_weight and grad_bias need to be resized and zeroed
-        if arg['name'] == 'grad_weight' and base['name'] != '_thnn_conv2d':
+        if arg['name'] == 'grad_weight' and base['name'] != '_thnn_conv2d' and base['name'] != '_thnn_conv_depthwise2d':
             arg['resize'] = 'weight'
             arg['zero'] = True
-        if arg['name'] == 'grad_bias' and base['name'] != '_thnn_conv2d':
+        if arg['name'] == 'grad_bias' and base['name'] != '_thnn_conv2d' and base['name'] != '_thnn_conv_depthwise2d':
             dim = 1 if 'transpose' in name else 0
             arg['resize'] = [('weight', dim)]
             arg['zero'] = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37958 Kill resize-ing and zero-ing from codegen.
* **#37957 Move resize / zero logic for _thnn_conv_depthwise2d from codegen to native code.**
* #37956 Move _thnn_conv2d resize and zero code from codegen to native code.
* #37955 Move resize logic for bmm from codegen to native code.
* #37907 [RESUBMIT] Kill broadcasting from the codegen layer.

Differential Revision: [D21433212](https://our.internmc.facebook.com/intern/diff/D21433212)