### PR TITLE
[TensorExpr] simplify trivial adds/subs/muls even in Float

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -251,6 +251,23 @@ const Expr* PolynomialTransformer::mutate(const Add* v) {
     }
   }
 
+  const Expr* scalar = nullptr;
+  const Expr* variable = nullptr;
+  if (lhs_new->isConstant()) {
+    scalar = evaluateOp(lhs_new);
+    variable = rhs_new;
+  } else if (rhs_new->isConstant()) {
+    scalar = evaluateOp(rhs_new);
+    variable = lhs_new;
+  }
+
+  // If there is a scalar, and it's zero: short circuit and return the other
+  // side.
+  if (scalar && immediateEquals(scalar, 0)) {
+    auto* c = new Cast(v->dtype(), variable);
+    return c->accept_mutator(this);
+  }
+
   // If this is a floating point Add then order of operations is important, we
   // dont want to combine ops.
   if (lhs_new->dtype().is_floating_point() ||
@@ -294,22 +311,6 @@ const Expr* PolynomialTransformer::mutate(const Add* v) {
     // terms.
     return new Polynomial(
         hasher_, getImmediateByType(v->dtype(), 0), lhsTerm, rhsTerm);
-  }
-
-  const Expr* scalar = nullptr;
-  const Expr* variable = nullptr;
-  if (lhs_new->isConstant()) {
-    scalar = evaluateOp(lhs_new);
-    variable = rhs_new;
-  } else if (rhs_new->isConstant()) {
-    scalar = evaluateOp(rhs_new);
-    variable = lhs_new;
-  }
-
-  // If there is a scalar, and it's zero: short circuit and return the other
-  // side.
-  if (scalar && immediateEquals(scalar, 0)) {
-    return variable;
   }
 
   // Adds are commutative.
@@ -449,6 +450,11 @@ const Expr* PolynomialTransformer::mutate(const Sub* v) {
     if (auto* ret = combineMultilane<Sub>(lhs_new, rhs_new)) {
       return ret->accept_mutator(this);
     }
+  }
+
+  if (rhs_new->isConstant() && immediateEquals(rhs_new, 0)) {
+    auto* c = new Cast(v->dtype(), lhs_new);
+    return c->accept_mutator(this);
   }
 
   // If this is a floating point Sub then order of operations is important, we
@@ -751,11 +757,34 @@ const Expr* PolynomialTransformer::mutate(const Mul* v) {
     }
   }
 
+  // Order doesn't matter.
+  const Expr* scalar = nullptr;
+  const Expr* variable = nullptr;
+  if (lhs_new->isConstant()) {
+    scalar = lhs_new;
+    variable = rhs_new;
+  } else if (rhs_new->isConstant()) {
+    scalar = rhs_new;
+    variable = lhs_new;
+  }
+
+  // Handle special case mul by 1 since thats safe for floating point, even if
+  // it's Nan/Inf.
+  if (scalar && immediateEquals(scalar, 1)) {
+    auto* c = new Cast(v->dtype(), variable);
+    return c->accept_mutator(this);
+  }
+
   // If this is a floating point Mul then order of operations is important, we
   // dont want to combine ops.
   if (lhs_new->dtype().is_floating_point() ||
       rhs_new->dtype().is_floating_point()) {
     return new Mul(lhs_new, rhs_new);
+  }
+
+  // Handle special case mul by 0.
+  if (scalar && immediateEquals(scalar, 0)) {
+    return getImmediateByType(v->dtype(), 0);
   }
 
   // Catch cases of rounding (Div(A/B) * B).
@@ -785,21 +814,6 @@ const Expr* PolynomialTransformer::mutate(const Mul* v) {
 
   if (lhsTerm && rhsTerm) {
     return mulTerms(lhsTerm, rhsTerm);
-  }
-
-  const Expr* scalar = nullptr;
-  const Expr* variable = nullptr;
-  if (lhs_new->isConstant()) {
-    scalar = lhs_new;
-    variable = rhs_new;
-  } else if (rhs_new->isConstant()) {
-    scalar = rhs_new;
-    variable = lhs_new;
-  }
-
-  // If there is a scalar and its zero then return zero.
-  if (scalar && immediateEquals(scalar, 0)) {
-    return scalar;
   }
 
   if (scalar && lhsTerm) {
@@ -969,6 +983,10 @@ const Expr* PolynomialTransformer::mutate(const Cast* v) {
   const Expr* node = v->src_value()->accept_mutator(this);
   if (node->isConstant()) {
     return evaluateOp(new Cast(v->dtype(), node));
+  }
+
+  if (v->dtype() == node->dtype()) {
+    return node;
   }
 
   return new Cast(v->dtype(), node);


### PR DESCRIPTION
The IR Simplifier early exits when working with dtypes that are not safe to reorder. There are some cases where we still want to simplify ops in these dtypes: x + 0,  x - 0, x * 0 and x * 1.  It's safe to eliminate the op here and it reduces clutter in the expr.

Also added a quick simplification of casts which do nothing (their type is the same as the underlying).