### PR TITLE
Don't use Profiler key in lite interpreter

### DIFF
--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -48,14 +48,10 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   at::DebugInfoGuard guard(at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
 #endif
 
-  c10::IValue result;
-  {
-    at::RecordFunctionGuard g;
-    auto m = find_method(method_name);
-    stack.insert(stack.begin(), object_);
-    m->run(stack);
-    result = stack.front();
-  }
+  auto m = find_method(method_name);
+  stack.insert(stack.begin(), object_);
+  m->run(stack);
+  c10::IValue result = stack.front();
 
 #if defined(PYTORCH_MOBILE_OBSERVER)
   if (observer) {


### PR DESCRIPTION
Summary:
Temporarily re-enable RecordFunction in lite interpreter when profiler key is not set,
this allows the profiler to work without profiled wrappers in the build

Test Plan: CI

Differential Revision: D21409120

