### PR TITLE
remove deprecation warning on get_contiguous_memory_format

### DIFF
--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -31,7 +31,7 @@ enum class MemoryFormat : int8_t { Contiguous, Preserve, ChannelsLast, ChannelsL
 // behaviour of contiguous
 #define LEGACY_CONTIGUOUS_MEMORY_FORMAT c10::get_contiguous_memory_format()
 
-C10_DEPRECATED inline MemoryFormat get_contiguous_memory_format() {
+inline MemoryFormat get_contiguous_memory_format() {
   return MemoryFormat::Contiguous;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37963 remove deprecation warning on get_contiguous_memory_format**

This function is still widely used in the codebase, so we don't want
to add noise to builds with a bunch of warnings. Seems like the
comment + macro are already pretty good indications that this
functionality is considered legacy

Differential Revision: [D21434447](https://our.internmc.facebook.com/intern/diff/D21434447)