### PR TITLE
[quant][fix] A typo in quantized::conv2d_relu

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -455,7 +455,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_relu(
     const at::Tensor& input,
     double output_scale,
     int64_t output_zero_point) {
-  return apply_impl<false>(input, output_scale, output_zero_point);
+  return apply_impl<true>(input, output_scale, output_zero_point);
 }
 
 template <int kSpatialDim>

--- a/test/quantization/test_quantized_module.py
+++ b/test/quantization/test_quantized_module.py
@@ -335,8 +335,6 @@ class TestStaticQuantizedModule(QuantizationTestCase):
         # Smoke test extra_repr
         self.assertTrue(module_name in str(converted_qconv_module))
 
-    # TODO: reenable use_fused=True, currently it is set to False
-    # because of the flakiness
     @given(batch_size=st.integers(1, 3),
            in_channels_per_group=st.sampled_from([2, 4, 5, 8, 16, 32]),
            H=st.integers(4, 16),
@@ -357,7 +355,7 @@ class TestStaticQuantizedModule(QuantizationTestCase):
            Y_scale=st.floats(4.2, 5.6),
            Y_zero_point=st.integers(0, 4),
            use_bias=st.booleans(),
-           use_fused=st.sampled_from([False]),
+           use_fused=st.booleans(),
            use_channelwise=st.booleans(),
            qengine=st.sampled_from(("qnnpack", "fbgemm")))
     def test_conv2d_api(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37964 [quant][fix] A typo in quantized::conv2d_relu**

Summary:
I thought it was because of flakiness that we didn't pass the conv2d_relu test, but turns out to
be a typo in the implementation
Also re-enabled the `use_fused` option in `test_conv2d_api`

Test Plan:
.

Reviewers:
.

Subscribers:

Tasks:

Tags:

Differential Revision: [D21434776](https://our.internmc.facebook.com/intern/diff/D21434776)