### PR TITLE
[TensorExpr] Move controlling knob out of the TE fuser pass.

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -291,9 +291,6 @@ std::pair<graph_node_list::iterator, bool> scanNode(
 }
 
 void FuseTensorExprs(std::shared_ptr<Graph>& graph) {
-  if (!tensorExprFuserEnabled()) {
-    return;
-  }
   GRAPH_DUMP("Before TExprFuser: ", graph);
 
   // Get rid of dead code so that we don't waste effort fusing it.

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -779,9 +779,11 @@ void runNondiffOptimization(
   // Fuse the dequant - op - quant patterns into quantized ops
   QuantFusion(graph);
 
-  FuseGraph(graph, strict_fuser_check);
-
-  FuseTensorExprs(graph);
+  if (tensorExprFuserEnabled()) {
+    FuseTensorExprs(graph);
+  } else {
+    FuseGraph(graph, strict_fuser_check);
+  }
 
   // Run custom post-fusion passes
   for (const auto& passPair : getCustomPostPasses()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37971 [TensorExpr] Allow to enable/disable fallback mechanism thru an envvar PYTORCH_TENSOREXPR_FALLBACK.
* **#37970 [TensorExpr] Move controlling knob out of the TE fuser pass.**

This change makes the pass friendlier for users who try to invoke it
directly.

Differential Revision: [D21444832](https://our.internmc.facebook.com/intern/diff/D21444832)