### PR TITLE
Skip c2_ref_tests on network failures

### DIFF
--- a/caffe2/python/models/download.py
+++ b/caffe2/python/models/download.py
@@ -80,8 +80,6 @@ def downloadFromURLToFile(url, filename, show_progress=True):
     except URLError as e:
         raise Exception("Could not download model. [URL Error] {reason}."
                         .format(reason=e.reason))
-    except Exception as e:
-        raise e
 
 
 def getURLFromName(name, filename):

--- a/caffe2/python/onnx/tests/c2_ref_test.py
+++ b/caffe2/python/onnx/tests/c2_ref_test.py
@@ -777,9 +777,11 @@ class TestCaffe2End2End(TestCase):
         np.random.seed(seed=0)
         try:
             c2_init_net, c2_predict_net, value_info, debug_str = self.model_downloader.get_c2_model_dbg(net_name)
-        except (OSError, IOError) as e:
+        except Exception as e:
             # catch IOError/OSError that is caused by FileNotFoundError and PermissionError
             # This is helpful because sometimes we get errors due to gfs not available
+            # get_c2_model_dbg wraps URLError/HTTPErrors into generic Exception
+            # Skip the tests if model can not be downloaded due to the any of the above
             print("\n_test_net exception: ", e)
             self.skipTest(str(e))
 


### PR DESCRIPTION
Skip the tests if network is unaccessible and model can not be downloaded

