### PR TITLE
Remove unpacked int8 blob after constructing the packed blob to save memory

### DIFF
--- a/caffe2/quantization/server/pybind.cc
+++ b/caffe2/quantization/server/pybind.cc
@@ -373,9 +373,14 @@ PYBIND11_MODULE(dnnlowp_pybind11, m) {
         const Int8FCDNNLowPPackedWeightBlob& packedInt8Blob =
             blob->template Get<Int8FCDNNLowPPackedWeightBlob>();
         auto& qparams = packedInt8Blob.qparams;
-        auto& int8_tensor = packedInt8Blob.original_tensor;
+        auto& unpacked_tensor = packedInt8Blob.original_tensor;
+        auto& packed_tensor = packedInt8Blob.W;
 
-        auto shape = int8_tensor.sizes();
+        auto shape = unpacked_tensor.sizes();
+        vector<int8_t> unpacked_int8_data;
+        CAFFE_ENFORCE(shape.size() == 2);
+        unpacked_int8_data.resize(shape[0] * shape[1]);
+        packed_tensor->unpack(unpacked_int8_data.data());
 
         ofstream fout;
         fout.open(weights_out_file);
@@ -392,13 +397,12 @@ PYBIND11_MODULE(dnnlowp_pybind11, m) {
                << to_string(qparams[i].zero_point);
         }
         fout << endl;
-        int8_t* int8_data = int8_tensor.data<int8_t>();
         for (int i = 0; i < shape[0]; ++i) {
           for (int j = 0; j < shape[1]; ++j) {
             if (j > 0) {
               fout << " ";
             }
-            fout << to_string(int8_data[i * shape[1] + j]);
+            fout << to_string(unpacked_int8_data.data()[i * shape[1] + j]);
           }
           fout << endl;
         }


### PR DESCRIPTION
Summary: Fix the unexpected memory usage issue in model QRT for the OC model.

Test Plan:
```
buck test mode/opt caffe2/caffe2/quantization/server:fully_connected_dnnlowp_op_test
```
```
buck test  mode/opt caffe2/caffe2/fb/fbgemm:int8_serializer_test
```

Differential Revision: D21422257

