### PR TITLE
[Tensorpipe Agent] Implementing getMetrics with currently available metrics

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -20,6 +20,8 @@ namespace rpc {
 constexpr long kToMilliseconds = 1000;
 
 const std::string kGilAverageWaitTime = "agent.gil_average_wait_time_us";
+const std::string kThreadPoolSize = "agent.thread_pool_size";
+const std::string kNumIdleThreads = "agent.num_idle_threads";
 
 //////////////////////////  MetricsTracker  /////////////////////////////////
 
@@ -429,6 +431,25 @@ std::string TensorPipeAgent::createUniqueShmAddr() {
       threadLocalId++);
 }
 #endif
+
+std::unordered_map<std::string, std::string> TensorPipeAgent::getMetrics() {
+  std::unordered_map<std::string, std::string> metrics;
+  metrics[kThreadPoolSize] = c10::to_string(threadPool_.size());
+  metrics[kNumIdleThreads] = c10::to_string(threadPool_.numAvailable());
+  if (isGILProfilingEnabled()) {
+    {
+      std::unique_lock<std::mutex> lock(metricsMutex_);
+      // Include the averages for each time series metric. This is just the GIL
+      // Wait Time for now.
+      auto averageGilWaitTime =
+          timeSeriesMetrics_[kGilAverageWaitTime]->computeAverage();
+      lock.unlock();
+      metrics[kGilAverageWaitTime] = c10::to_string(averageGilWaitTime);
+    }
+  }
+
+  return metrics;
+}
 
 void TensorPipeAgent::addGilWaitTime(
     const std::chrono::microseconds gilWaitTime) {

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -65,10 +65,7 @@ class TensorPipeAgent : public RpcAgent {
   const WorkerInfo& getWorkerInfo(worker_id_t workerId) const override;
   std::vector<WorkerInfo> getWorkerInfos() const override;
 
-  std::unordered_map<std::string, std::string> getMetrics() override {
-    std::unordered_map<std::string, std::string> metrics;
-    return metrics;
-  }
+  std::unordered_map<std::string, std::string> getMetrics() override;
 
   void addGilWaitTime(const std::chrono::microseconds gilWaitTime) override;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37980 [Tensorpipe Agent] Implementing getMetrics with currently available metrics**
* #37852 [Tensorpipe Agent] Network Data Profiling
* #37851 [Tensorpipe Agent] Implement Global Interpreter Lock Wait Time Metric
* #37850 [Tensorpipe Agent] Base Structs for Tracking RPC Metrics

This implements `TensorPipeAgent::getMetrics` with the metrics currently available. Will add other metrics such as Client/Server Active Calls once time outs are implemented.

Differential Revision: [D21439184](https://our.internmc.facebook.com/intern/diff/D21439184/)