### PR TITLE
Named tensor serialization support

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1573,6 +1573,7 @@
 - func: isclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> Tensor
   use_c10_dispatcher: full
   variants: function, method
+  supports_named_tensor: True
 
 - func: isnan(Tensor self) -> Tensor
   use_c10_dispatcher: full
@@ -2119,9 +2120,11 @@
 - func: mul.Scalar(Tensor self, Scalar other) -> Tensor
   use_c10_dispatcher: full
   variants: function, method
+  supports_named_tensor: True
 
 - func: mul_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: mv(Tensor self, Tensor vec) -> Tensor
   use_c10_dispatcher: full
@@ -4270,12 +4273,14 @@
 
 - func: bitwise_and.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
+  supports_named_tensor: True
   dispatch:
     CPU: bitwise_and_out
     CUDA: bitwise_and_out
 
 - func: bitwise_and.Scalar_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
+  supports_named_tensor: True
   dispatch:
     CPU: bitwise_and_out
     CUDA: bitwise_and_out
@@ -4283,39 +4288,49 @@
 - func: bitwise_and.Scalar(Tensor self, Scalar other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: bitwise_and.Tensor(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: bitwise_and_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: bitwise_and_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: __and__.Scalar(Tensor self, Scalar other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: __and__.Tensor(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: __iand__.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: __iand__.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: bitwise_or.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
+  supports_named_tensor: True
   dispatch:
     CPU: bitwise_or_out
     CUDA: bitwise_or_out
 
 - func: bitwise_or.Scalar_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
+  supports_named_tensor: True
   dispatch:
     CPU: bitwise_or_out
     CUDA: bitwise_or_out
@@ -4323,30 +4338,38 @@
 - func: bitwise_or.Scalar(Tensor self, Scalar other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: bitwise_or.Tensor(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
   variants: method, function
+  supports_named_tensor: True
 
 - func: bitwise_or_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: bitwise_or_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: __or__.Scalar(Tensor self, Scalar other) -> Tensor
   use_c10_dispatcher: full
+  supports_named_tensor: True
   variants: method, function
 
 - func: __or__.Tensor(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
+  supports_named_tensor: True
   variants: method, function
 
 - func: __ior__.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: __ior__.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
+  supports_named_tensor: True
 
 - func: bitwise_xor.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   variants: function

--- a/docs/source/named_tensor.rst
+++ b/docs/source/named_tensor.rst
@@ -271,8 +271,6 @@ We also do not support the following subsystems, though some may work out
 of the box:
 
 - distributions
-- serialization (:func:`torch.load`, :func:`torch.save`)
-- multiprocessing
 - JIT
 - distributed
 - ONNX

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -7,9 +7,6 @@ import functools
 import torch
 from torch import Tensor
 import torch.nn.functional as F
-from multiprocessing.reduction import ForkingPickler
-import pickle
-import io
 import sys
 import warnings
 
@@ -290,22 +287,6 @@ class TestNamedTensor(TestCase):
             check_tuple_return(F.max_pool2d_with_indices, [named_tensor_2d, [2, 2]], named_tensor_2d.names)
             check_tuple_return(F.max_pool3d_with_indices, [named_tensor_3d, [2, 2, 2]], named_tensor_3d.names)
 
-    def test_no_save_support(self):
-        named_tensor = torch.zeros(2, 3, names=('N', 'C'))
-        buf = io.BytesIO()
-        with self.assertRaisesRegex(RuntimeError, "NYI"):
-            torch.save(named_tensor, buf)
-
-    def test_no_pickle_support(self):
-        named_tensor = torch.zeros(2, 3, names=('N', 'C'))
-        with self.assertRaisesRegex(RuntimeError, "NYI"):
-            serialized = pickle.dumps(named_tensor)
-
-    def test_no_multiprocessing_support(self):
-        named_tensor = torch.zeros(2, 3, names=('N', 'C'))
-        buf = io.BytesIO()
-        with self.assertRaisesRegex(RuntimeError, "NYI"):
-            ForkingPickler(buf, pickle.HIGHEST_PROTOCOL).dump(named_tensor)
 
     def test_big_tensor_repr_has_names(self):
         def check_repr(named_tensor):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -82,6 +82,7 @@ class SerializationMixin(object):
         t2 = torch.FloatTensor().set_(a[0].reshape(-1)[1:4].clone().storage(), 0, (3,), (1,))
         b += [(t1.storage(), t1.storage(), t2.storage())]  # 7
         b += [a[0].reshape(-1)[0:2].storage()]  # 8
+        b += [torch.rand(1).rename('test')]  # 9 -- test named tensors
         return b
 
     def _test_serialization_assert(self, b, c):

--- a/torch/_namedtensor_internals.py
+++ b/torch/_namedtensor_internals.py
@@ -7,13 +7,6 @@ subject to change or deletion.
 """
 
 
-def check_serializing_named_tensor(tensor):
-    if tensor.has_names():
-        raise RuntimeError(
-            "NYI: Named tensors don't support serialization. Please drop "
-            "names via `tensor = tensor.rename(None)` before serialization.")
-
-
 def build_dim_map(tensor):
     """Returns a map of { dim: dim_name } where dim is a name if the dim is named
     and the dim index otherwise."""

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -125,14 +125,19 @@ def _get_async_or_non_blocking(function_name, non_blocking, kwargs):
 # OrderedDict(), if you pass a None you'll run afoul #12219.
 
 
-def _rebuild_tensor(storage, storage_offset, size, stride):
+def _rebuild_tensor(storage, storage_offset, size, stride, names=None):
     # first construct a tensor with the correct dtype/device
     t = torch.tensor([], dtype=storage.dtype, device=storage.device)
-    return t.set_(storage, storage_offset, size, stride)
+    t = t.set_(storage, storage_offset, size, stride)
+    if names is not None:
+        return t.rename(*names)
+    else:
+        return t
 
 
-def _rebuild_tensor_v2(storage, storage_offset, size, stride, requires_grad, backward_hooks):
-    tensor = _rebuild_tensor(storage, storage_offset, size, stride)
+
+def _rebuild_tensor_v2(storage, storage_offset, size, stride, requires_grad, backward_hooks, names=None):
+    tensor = _rebuild_tensor(storage, storage_offset, size, stride, names)
     tensor.requires_grad = requires_grad
     # NB: This line exists only for backwards compatibility; the
     # general expectation is that backward_hooks is an empty

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -258,7 +258,8 @@ def reduce_tensor(tensor):
                  event_sync_required, tensor.names))
 
     # _backward_hooks purposely omitted here, see Note [Don't serialize hooks]
-    metadata = (tensor.storage_offset(), tensor.size(), tensor.stride(), tensor.requires_grad, tensor.names if tensor.has_names() else None)
+    metadata = (tensor.storage_offset(), tensor.size(), tensor.stride(), tensor.requires_grad,
+                tensor.names if tensor.has_names() else None)
     return (rebuild_tensor, (type(tensor), storage, metadata))
 
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -1,6 +1,6 @@
 import torch
 import torch._C as _C
-from torch._namedtensor_internals import update_names, check_serializing_named_tensor, resolve_ellipsis
+from torch._namedtensor_internals import update_names, resolve_ellipsis
 from torch._namedtensor_internals import unzip_namedshape, single_ellipsis_index, is_ellipsis
 from collections import OrderedDict
 import torch.utils.hooks as hooks
@@ -71,7 +71,6 @@ class Tensor(torch._C._TensorBase):
             return new_tensor
 
     def __reduce_ex__(self, proto):
-        check_serializing_named_tensor(self)
         # See Note [Don't serialize hooks]
         torch.utils.hooks.warn_if_has_hooks(self)
         # Note: Numpy array is chosen to be the rebuild component for XLA Tensor.
@@ -129,7 +128,8 @@ class Tensor(torch._C._TensorBase):
                     tuple(self.size()),
                     self.stride(),
                     self.requires_grad,
-                    OrderedDict())  # previously was self._backward_hooks
+                    OrderedDict(),  # previously was self._backward_hooks
+                    self.names)
             return (torch._utils._rebuild_tensor_v2, args)
 
     def __setstate__(self, state):


### PR DESCRIPTION
The primary purpose of this pull request is to add serialization capabilities to named tensors.  This allows them to be persisted as well as work in multiprocess mode.  I also modified the serialization tests to cover named tensors, but in order to get those tests to pass I had to add named tensor support for a lot of other ops.  All these others ended up "just working", they only needed `supports_named_tensor: True` added in `native_functions.yaml`.

cc @zou3519 