### PR TITLE
Make cpp ProcessGroupGloo have same timeout as python

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -622,7 +622,8 @@ They are used in specifying strategies for reduction collectives, e.g.,
           py::arg("store"),
           py::arg("rank"),
           py::arg("size"),
-          py::arg("timeout") = std::chrono::milliseconds(10 * 1000));
+          py::arg("timeout") = std::chrono::milliseconds(
+              ::c10d::kProcessGroupGlooDefaultTimeoutMillis));
 #endif
 
 #ifdef USE_C10D_NCCL

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -27,6 +27,10 @@
 
 namespace c10d {
 
+// Default timeout for operations against ProcessGroupGloo (30 mins)
+constexpr std::chrono::milliseconds kProcessGroupGlooDefaultTimeoutMillis =
+    std::chrono::milliseconds(1000 * 60 * 30);
+
 // ProcessGroupGloo implements Gloo bindings for c10d.
 //
 // All functions on this class are expected to be called in the same


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#37992 Make cpp ProcessGroupGloo have same timeout as python**

Previously this was 10k ms, but we default to 30min in Python. We should make them the same for clarity.

Differential Revision: [D21444339](https://our.internmc.facebook.com/intern/diff/D21444339/)