### PR TITLE
[PyTorch] Make DDP reducer work under distributed autograd

### DIFF
--- a/test/distributed/test_ddp_under_dist_autograd.py
+++ b/test/distributed/test_ddp_under_dist_autograd.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+
+from typing import NamedTuple
+import enum
+import logging
+import os
+
+import torch
+from torch.distributed import rpc
+from torch.nn.parallel import DistributedDataParallel
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    requires_gloo,
+)
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TEST_WITH_ASAN,
+)
+from torch.testing._internal.dist_utils import dist_init
+from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
+from torch._utils_internal import TEST_MASTER_PORT as MASTER_PORT
+import torch.distributed as dist
+import torch.distributed.autograd as dist_autograd
+import torch.distributed.distributed_c10d as dist_c10d
+import torch.nn as nn
+import unittest
+
+
+NUM_EM_ROW = 2
+D_SPARSE = 3
+D_DENSE = 2
+D_HID = 3
+D_OUT = 1
+NUM_TRAINERS = 4
+# Trainers + the master + the remote worker
+WORLD_SIZE = NUM_TRAINERS + 2
+TRAINER_GROUP = "trainer_group"
+TRAINER_RANKS = list(range(1, NUM_TRAINERS + 1))
+REMOTE_WORKER_RANK = NUM_TRAINERS + 1
+MASTER_RANK = 0
+
+
+class DdpMode(enum.Enum):
+    # Don't apply DDP
+    NONE = enum.auto()
+    # Apply DDP to the top level nn.Module
+    OUTSIDE = enum.auto()
+    # Embed DDP inside the top level nn.Module
+    INSIDE = enum.auto()
+
+
+def init_logger():
+    logger = logging.getLogger(__name__)
+    level = logging.DEBUG if "debug" in os.environ else logging.INFO
+    logger.setLevel(level)
+    console = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s %(filename)s:%(lineno)s %(levelname)s p:%(processName)s t:%(threadName)s: %(message)s"
+    )
+    console.setFormatter(formatter)
+    console.setLevel(level)
+    # add the handlers to the logger
+    logger.addHandler(console)
+    logger.propagate = False
+    return logger
+
+
+gLogger = init_logger()
+
+
+class FeatureSet(NamedTuple):
+    """ A feature set has 2 types of features"""
+
+    dense_features: torch.Tensor
+    sparse_features: torch.LongTensor
+    values: torch.Tensor
+
+
+def _call_method(method, rref, *args, **kwargs):
+    return method(rref.local_value(), *args, **kwargs)
+
+
+def _remote_method(method, rref, *args, **kwargs):
+    args_tup = tuple([method, rref] + list(args))
+    return rpc.rpc_sync(
+        rref.owner(), _call_method, args=args_tup, kwargs=kwargs
+    )
+
+
+def _remote_method_async(method, rref, *args, **kwargs):
+    args_tup = tuple([method, rref] + list(args))
+    return rpc.rpc_async(
+        rref.owner(), _call_method, args=args_tup, kwargs=kwargs
+    )
+
+
+class RemoteEM(nn.Module):
+    def __init__(self, num_embeddings: int, embedding_dim: int):
+        gLogger.info(f"Initing RemoteEM with {num_embeddings} {embedding_dim}")
+        super(RemoteEM, self).__init__()
+        init_em = [0.5] * embedding_dim
+        self.em = nn.EmbeddingBag(
+            num_embeddings,
+            embedding_dim,
+            _weight=torch.Tensor([init_em] * num_embeddings),
+        )
+
+    def forward(self, input: torch.Tensor):
+        gLogger.debug(f"Running RemoteEM.forward() on: {input}")
+        return self.em(input, offsets=torch.LongTensor(range(input.shape[0])))
+
+
+# Return a linear module with predefined parameters.
+def getLinear(d_in, d_out):
+    l = nn.Linear(d_in, d_out, bias=False)
+    w = torch.ones((d_out, d_in))
+    w[0][0] = -1
+    w.requires_grad_()
+    l.weight.data = w
+    return l
+
+
+class RemoteNet(nn.Module):
+    def __init__(self, d_in: int, d_out: int):
+        gLogger.info(f"Initing RemoteNet with {d_in} {d_out}")
+        super(RemoteNet, self).__init__()
+        self.fc = getLinear(d_in, d_out)
+        self.relu = nn.ReLU()
+
+    def forward(self, input: torch.Tensor):
+        gLogger.debug(f"Running RemoteNet.forward() on: {input}")
+        return self.relu(self.fc(input))
+
+
+class HybridModel(nn.Module):
+    def __init__(
+        self,
+        remote_em_rref: rpc.RRef,
+        remote_net_rref: rpc.RRef,
+        process_group_for_ddp: dist.ProcessGroup = None,
+    ):
+        super(HybridModel, self).__init__()
+        self.remote_em_rref = remote_em_rref
+        self.remote_net_rref = remote_net_rref
+        self.fc1 = getLinear(D_DENSE, D_DENSE)
+        self.fc2 = getLinear(D_HID, D_OUT)
+
+        self.non_ddp_params = tuple(self.fc1.parameters()) + tuple(
+            self.fc2.parameters()
+        )
+        self.ddp_params = ()
+
+        if process_group_for_ddp is not None:
+            self.non_ddp_params, self.ddp_params = (
+                tuple(self.fc1.parameters()),
+                tuple(self.fc2.parameters()),
+            )
+            gLogger.info(f"Use DDP for the second local net.")
+            self.fc2 = DistributedDataParallel(
+                self.fc2,
+                process_group=process_group_for_ddp,
+                check_reduction=True,
+            )
+
+        gLogger.info(
+            f"HybridModel has {len(list(self.parameters()))} groups of parameters."
+        )
+
+    def forward(self, input: FeatureSet):
+        gLogger.debug(f"Running HybridModel.forward on {input}")
+        sparse = _remote_method(
+            RemoteEM.forward, self.remote_em_rref, input.sparse_features
+        )
+        # The same size of mini batch.
+        assert sparse.shape[0] == input.dense_features.shape[0]
+        dense = self.fc1(input.dense_features)
+        x = torch.cat((dense, sparse), 1)
+        gLogger.debug(f"Concatenated feature: {x}")
+        x = _remote_method(RemoteNet.forward, self.remote_net_rref, x)
+        return self.fc2(x)
+
+
+class Trainer:
+    def __init__(
+        self,
+        remote_em_rref: rpc.RRef,
+        remote_net_rref: rpc.RRef,
+        ddp_mode: DdpMode,
+        rank: int,
+    ):
+        gLogger.info(
+            f"Initing trainer process group by trainer #{rank} with ranks {TRAINER_RANKS}"
+        )
+        self.process_group_for_ddp = dist_c10d.new_group(ranks=TRAINER_RANKS)
+
+        self.remote_em_rref = remote_em_rref
+        self.remote_net_rref = remote_net_rref
+        self.hybrid_module = HybridModel(
+            self.remote_em_rref,
+            self.remote_net_rref,
+            self.process_group_for_ddp
+            if ddp_mode in (DdpMode.INSIDE,)
+            else None,
+        )
+        self.ddp_params, self.non_ddp_params = (
+            self.hybrid_module.ddp_params,
+            self.hybrid_module.non_ddp_params,
+        )
+        if ddp_mode == DdpMode.OUTSIDE:
+            gLogger.info(f"Wrapping the whole hybrid module into DDP.")
+            self.ddp_params += self.non_ddp_params
+            self.non_ddp_params = ()
+            self.hybrid_module = DistributedDataParallel(
+                self.hybrid_module,
+                process_group=self.process_group_for_ddp,
+                check_reduction=True,
+            )
+        gLogger.info(
+            f"Succeeded in creating a HybridModel instance with "
+            f"{len(self.ddp_params)} ddp params and {len(self.non_ddp_params)} "
+            f"other local params."
+        )
+
+    def __del__(self):
+        dist.destroy_process_group(self.process_group_for_ddp)
+
+    def do_backward(self, mini_batch: FeatureSet):
+        grads_dict = None
+        with dist_autograd.context() as context_id:
+            output = self.hybrid_module.forward(mini_batch)
+            loss = (output * mini_batch.values).sum()
+            dist_autograd.backward(context_id, [loss])
+            grads_dict = dist_autograd.get_gradients(context_id)
+            gLogger.info(
+                f"Loss is {loss} for mini batch: {mini_batch}. "
+                f"Grads dict has {len(grads_dict)} entries: {grads_dict}"
+            )
+        return (
+            tuple(grads_dict[param] for param in self.ddp_params),
+            tuple(grads_dict[param] for param in self.non_ddp_params),
+        )
+
+
+def get_training_examples():
+    n = 16
+    training_examples = FeatureSet(
+        dense_features=torch.zeros((n, D_DENSE)),
+        sparse_features=torch.zeros(n, dtype=torch.long),
+        values=torch.zeros(n),
+    )
+    idx = 0
+    # Every example has another one that has exactly the same features but an
+    # opposite value. Therefore, their grads cancel each other in all-reduce.
+    for value in (-1, 1):
+        for x in (-1 * value, 1 * value):
+            for y in (1 * value, -1 * value):
+                for z in (0, 1):
+                    training_examples.dense_features[idx, :] = torch.Tensor(
+                        (x, y)
+                    )
+                    training_examples.sparse_features[idx] = z
+                    training_examples.values[idx] = value
+                    idx += 1
+
+    # Split the examples among NUM_TRAINERS trainers
+    assert 0 == (n % NUM_TRAINERS)
+    examples_per_trainer = int(n / NUM_TRAINERS)
+    return [
+        FeatureSet(
+            dense_features=training_examples.dense_features[
+                start : start + examples_per_trainer, :
+            ],
+            sparse_features=training_examples.sparse_features[
+                start : start + examples_per_trainer
+            ],
+            values=training_examples.values[
+                start : start + examples_per_trainer
+            ],
+        )
+        for start in range(0, n, examples_per_trainer)
+    ]
+
+
+@unittest.skipIf(
+    TEST_WITH_ASAN,
+    "Skip ASAN as torch + multiprocessing spawn have known issues",
+)
+class TestDdpUnderDistAutograd(MultiProcessTestCase):
+    rpc_backend = rpc.backend_registry.BackendType.PROCESS_GROUP
+    rpc_backend_options = None
+
+    @property
+    def world_size(self) -> int:
+        return WORLD_SIZE
+
+    def remote_worker_name(self) -> str:
+        # The name has to be consistent with that in 'dist_init' decorator.
+        return f"worker{REMOTE_WORKER_RANK}"
+
+    def trainer_name(self, rank):
+        # The name has to be consistent with that in 'dist_init' decorator.
+        return f"worker{rank}"
+
+    def setUp(self):
+        super(TestDdpUnderDistAutograd, self).setUp()
+
+        os.environ["MASTER_ADDR"] = str(MASTER_ADDR)
+        os.environ["MASTER_PORT"] = str(MASTER_PORT)
+        self._spawn_processes()
+
+    def tearDown(self):
+        super(TestDdpUnderDistAutograd, self).tearDown()
+
+    @dist_init
+    def _remote_worker_process(self):
+        process_group_for_ddp = dist_c10d.new_group(ranks=TRAINER_RANKS)
+        gLogger.info(f"The remote worker is running.")
+        dist.destroy_process_group(process_group_for_ddp)
+        gLogger.info(f"Exiting remote worker.")
+
+    @dist_init
+    def _trainer_process(self, rank: int):
+        gLogger.info(f"Running the trainer #{rank}...")
+
+    @dist_init
+    def _master_process(self, ddp_mode: DdpMode):
+        gLogger.info(f"Running the master process...")
+        process_group_for_ddp = dist_c10d.new_group(ranks=TRAINER_RANKS)
+        remote_em_rref = rpc.remote(
+            self.remote_worker_name(), RemoteEM, args=(NUM_EM_ROW, D_SPARSE)
+        )
+        remote_net_rref = rpc.remote(
+            self.remote_worker_name(),
+            RemoteNet,
+            args=(D_DENSE + D_SPARSE, D_HID),
+        )
+        gLogger.info(f"Created remote rrefs on master")
+        self.do_test_on_master(ddp_mode, remote_em_rref, remote_net_rref)
+        dist.destroy_process_group(process_group_for_ddp)
+
+    def do_test_on_master(
+        self,
+        ddp_mode: DdpMode,
+        remote_em_rref: rpc.RRef,
+        remote_net_rref: rpc.RRef,
+    ):
+        trainer_rrefs = []
+        for rank in TRAINER_RANKS:
+            trainer = self.trainer_name(rank)
+            trainer_rrefs.append(
+                rpc.remote(
+                    trainer,
+                    Trainer,
+                    args=(remote_em_rref, remote_net_rref, ddp_mode, rank),
+                )
+            )
+
+        training_examples = get_training_examples()
+        for _ in range(3):
+            futures = []
+            for idx, trainer_rref in enumerate(trainer_rrefs):
+                futures.append(
+                    _remote_method_async(
+                        Trainer.do_backward,
+                        trainer_rref,
+                        training_examples[idx],
+                    )
+                )
+
+            for future in futures:
+                ddp_grads, non_ddp_grads = future.wait()
+                for grad in ddp_grads:
+                    self.assertAlmostEqual(
+                        0.0,
+                        float(grad.norm()),
+                        msg="The grad for any ddp parameter should be zeros, because "
+                        "the training examples' grads cancel each other.",
+                    )
+                for grad in non_ddp_grads:
+                    self.assertNotAlmostEqual(
+                        0.0,
+                        float(grad.norm()),
+                        msg="The grad for any non-ddp parameter shouldn't be zeros",
+                    )
+
+    def _do_test(self, ddp_mode):
+        if self.rank == MASTER_RANK:
+            self._master_process(ddp_mode)
+        elif self.rank == REMOTE_WORKER_RANK:
+            self._remote_worker_process()
+        elif self.rank in TRAINER_RANKS:
+            self._trainer_process(self.rank)
+        else:
+            raise RuntimeError(f"Unknow process rank: {self.rank}")
+
+    @requires_gloo()
+    def test_backward_no_ddp(self):
+        self._do_test(DdpMode.NONE)
+
+    @requires_gloo()
+    def test_backward_ddp_outside(self):
+        self._do_test(DdpMode.OUTSIDE)
+
+    @requires_gloo()
+    def test_backward_ddp_inside(self):
+        self._do_test(DdpMode.INSIDE)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/test_ddp_under_dist_autograd.py
+++ b/test/distributed/test_ddp_under_dist_autograd.py
@@ -224,7 +224,7 @@ class Trainer:
     def __del__(self):
         dist.destroy_process_group(self.process_group_for_ddp)
 
-    def do_backward(self, mini_batch: FeatureSet):
+    def train_batch(self, mini_batch: FeatureSet):
         grads_dict = None
         with dist_autograd.context() as context_id:
             output = self.hybrid_module.forward(mini_batch)
@@ -361,7 +361,7 @@ class TestDdpUnderDistAutograd(MultiProcessTestCase):
             for idx, trainer_rref in enumerate(trainer_rrefs):
                 futures.append(
                     _remote_method_async(
-                        Trainer.do_backward,
+                        Trainer.train_batch,
                         trainer_rref,
                         training_examples[idx],
                     )

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -82,6 +82,7 @@ TESTS = [
     'distributed/rpc/jit/test_rpc_spawn',
     'distributed/rpc/faulty_agent/test_rpc_spawn',
     'test_futures',
+    'distributed/test_ddp_under_dist_autograd',
 ]
 
 WINDOWS_BLACKLIST = [
@@ -96,6 +97,7 @@ WINDOWS_BLACKLIST = [
     'distributed/rpc/test_dist_optimizer_spawn',
     'distributed/rpc/test_rpc_spawn',
     'distributed/test_distributed',
+    'distributed/test_ddp_under_dist_autograd',
 ]
 
 ROCM_BLACKLIST = [
@@ -107,6 +109,7 @@ ROCM_BLACKLIST = [
     'distributed/rpc/tensorpipe/test_dist_optimizer_spawn',
     'distributed/rpc/tensorpipe/test_rpc_spawn',
     'distributed/rpc/test_dist_autograd_spawn',
+    'distributed/test_ddp_under_dist_autograd',
     'distributed/rpc/test_dist_optimizer_spawn',
     'distributed/rpc/test_rpc_spawn',
     'test_determination',
@@ -150,6 +153,7 @@ SLOW_TESTS = [
     'distributed/rpc/tensorpipe/test_rpc_spawn',
     'distributed/rpc/test_dist_autograd_spawn',
     'distributed/rpc/test_rpc_spawn',
+    'distributed/test_ddp_under_dist_autograd',
     'test_cuda',
     'test_cuda_primary_ctx',
     'test_cpp_extensions_aot_ninja',

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -291,20 +291,17 @@ void Engine::thread_init(int device, const std::shared_ptr<ReadyQueue>& ready_qu
   }
 }
 
-// The guard that sets and restores current_graph_task.
-struct GraphTaskGuard {
-  GraphTaskGuard(std::shared_ptr<GraphTask> graph_task) {
-    last_graph_task_ = std::move(current_graph_task);
-    current_graph_task = std::move(graph_task);
-  }
-  ~GraphTaskGuard() { restore_current_graph_task(); }
+GraphTaskGuard::GraphTaskGuard(std::shared_ptr<GraphTask> graph_task) {
+  last_graph_task_ = std::move(current_graph_task);
+  current_graph_task = std::move(graph_task);
+}
+GraphTaskGuard::~GraphTaskGuard() {
+  restore_current_graph_task();
+}
 
-  void restore_current_graph_task() {
-    current_graph_task = std::move(last_graph_task_);
-  }
-
-  std::shared_ptr<GraphTask> last_graph_task_;
-};
+void GraphTaskGuard::restore_current_graph_task() {
+  current_graph_task = std::move(last_graph_task_);
+}
 
 // NOTE: graph_tasks do not necessarily form a stack. Imagine this
 // case:

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -179,6 +179,18 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
   void exec_post_processing();
 };
 
+// The guard that sets and restores current_graph_task.
+class GraphTaskGuard {
+ public:
+  explicit GraphTaskGuard(std::shared_ptr<GraphTask> graph_task);
+  ~GraphTaskGuard();
+
+  void restore_current_graph_task();
+
+ private:
+  std::shared_ptr<GraphTask> last_graph_task_;
+};
+
 struct NodeTask {
   std::weak_ptr<GraphTask> base_;
   std::shared_ptr<Node> fn_;

--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -1,8 +1,9 @@
+#include <torch/csrc/distributed/autograd/context/context.h>
+
 #include <functional>
 
 #include <c10/util/Exception.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
-#include <torch/csrc/distributed/autograd/context/context.h>
 
 namespace torch {
 namespace distributed {
@@ -209,6 +210,40 @@ const c10::Dict<torch::Tensor, torch::Tensor> DistAutogradContext::
     getGradients() const {
   std::lock_guard<std::mutex> guard(lock_);
   return accumulatedGrads_;
+}
+
+void DistAutogradContext::runGradCallbackForVariable(
+    const torch::autograd::Variable& variable,
+    GradCallback&& cb) {
+  std::lock_guard<std::mutex> guard(lock_);
+  auto it = accumulatedGrads_.find(variable);
+  TORCH_INTERNAL_ASSERT(
+      it != accumulatedGrads_.end(),
+      "The grad for the variable should exist in dist_autograd context.");
+  auto grad = it->value();
+  if (cb(grad)) {
+    // Needs to update the grad in the map.
+    accumulatedGrads_.insert(variable, std::move(grad));
+  }
+}
+
+namespace {
+thread_local ContextWeakPtr tl_context_weak_ptr;
+} // namespace
+
+ThreadLocalDistAutogradContext::ThreadLocalDistAutogradContext(
+    ContextWeakPtr&& new_context_wp)
+    : prev_context_weak_ptr_(std::move(tl_context_weak_ptr)) {
+  tl_context_weak_ptr = std::move(new_context_wp);
+}
+
+ThreadLocalDistAutogradContext::~ThreadLocalDistAutogradContext() {
+  tl_context_weak_ptr = std::move(prev_context_weak_ptr_);
+}
+
+// static
+ContextWeakPtr ThreadLocalDistAutogradContext::getContextWeakPtr() {
+  return tl_context_weak_ptr;
 }
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -227,7 +227,7 @@ void DistAutogradContext::runGradCallbackForVariable(
   if (cb(grad)) {
     std::lock_guard<std::mutex> guard(lock_);
     // Needs to update the grad in the map.
-    accumulatedGrads_.insert(variable, std::move(grad));
+    accumulatedGrads_.insert_or_assign(variable, std::move(grad));
   }
 }
 

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -141,19 +141,18 @@ class TORCH_API DistAutogradContext {
 };
 
 using ContextPtr = std::shared_ptr<DistAutogradContext>;
-using ContextWeakPtr = std::weak_ptr<DistAutogradContext>;
 
 // This class stores a weak_ptr to the current dist_autograd context in a thread
 // local variable so that a reader can retrieve the context.
 class TORCH_API ThreadLocalDistAutogradContext {
  public:
-  explicit ThreadLocalDistAutogradContext(ContextWeakPtr&& new_context_wp);
+  explicit ThreadLocalDistAutogradContext(ContextPtr&& new_context);
   ~ThreadLocalDistAutogradContext();
 
-  static ContextWeakPtr getContextWeakPtr();
+  static ContextPtr getContextPtr();
 
  private:
-  ContextWeakPtr prev_context_weak_ptr_;
+  ContextPtr prev_context_ptr_;
 };
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -142,13 +142,16 @@ class TORCH_API DistAutogradContext {
 
 using ContextPtr = std::shared_ptr<DistAutogradContext>;
 
-// This class stores a weak_ptr to the current dist_autograd context in a thread
-// local variable so that a reader can retrieve the context.
+// This class stores a shared_ptr to a DistAutogradContext instance in a
+// thread local variable. The instance is given by the call site. The class
+// doesn't know the current context. It's just a util class.
 class TORCH_API ThreadLocalDistAutogradContext {
  public:
+  // Store 'new_context' to the thread local varaible maintained by this class.
   explicit ThreadLocalDistAutogradContext(ContextPtr&& new_context);
   ~ThreadLocalDistAutogradContext();
 
+  // Retrieve the stored DistAutogradContext instance.
   static ContextPtr getContextPtr();
 
  private:

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -41,8 +41,7 @@ class DistAccumulateGradCaptureHook
         autogradContext_(std::move(autogradContext)) {}
 
   at::Tensor operator()(const at::Tensor& grad) override {
-    ThreadLocalDistAutogradContext contextGuard{
-        ContextWeakPtr(autogradContext_)};
+    ThreadLocalDistAutogradContext contextGuard{ContextPtr(autogradContext_)};
     variable_list inputGrads = {grad};
     // It's intended that pre/post hooks are still called even if the grad is
     // undenfined here.
@@ -279,7 +278,7 @@ void DistEngine::execute_graph_task_until_ready_queue_empty(
       if (task.fn_ && !local_graph_task->has_error_.load()) {
         AutoGradMode grad_mode(local_graph_task->grad_mode_);
         try {
-          GraphTaskGuard guard(graph_task);
+          GraphTaskGuard guard(local_graph_task);
           engine_.evaluate_function(
               local_graph_task, task.fn_.get(), task.inputs_, cpu_ready_queue);
         } catch (std::exception& e) {

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -126,7 +126,7 @@ Reducer::Reducer(
                     [=](const torch::autograd::variable_list& outputs,
                         const torch::autograd::variable_list& /* unused */) {
                       this->rpc_context_.set(
-                          ThreadLocalDistAutogradContext::getContextWeakPtr());
+                          ThreadLocalDistAutogradContext::getContextPtr());
                       this->autograd_hook(index);
                       return outputs;
                     })),
@@ -779,13 +779,12 @@ void Reducer::runGradCallbackForVariable(
   if (context_ptr == nullptr) {
     cb(variable.grad());
   } else {
-    // Under distributed autograa
+    // Under distributed autograd
     context_ptr->runGradCallbackForVariable(variable, std::move(cb));
   }
 }
 
-void Reducer::RpcContext::set(ContextWeakPtr&& context_weak_ptr) {
-  auto new_context_ptr = context_weak_ptr.lock();
+void Reducer::RpcContext::set(ContextPtr&& new_context_ptr) {
   if (!new_context_ptr) {
     // Not under distributed autograd
     return;

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -118,12 +118,15 @@ Reducer::Reducer(
         auto grad_accumulator =
             torch::autograd::impl::grad_accumulator(variable);
 
+        using torch::distributed::autograd::ThreadLocalDistAutogradContext;
         // Hook to execute after the gradient accumulator has executed.
         hooks_.emplace_back(
             grad_accumulator->add_post_hook(
                 torch::make_unique<torch::autograd::utils::LambdaPostHook>(
                     [=](const torch::autograd::variable_list& outputs,
                         const torch::autograd::variable_list& /* unused */) {
+                      this->rpc_context_.set(
+                          ThreadLocalDistAutogradContext::getContextWeakPtr());
                       this->autograd_hook(index);
                       return outputs;
                     })),
@@ -213,26 +216,29 @@ void Reducer::mark_variable_ready_dense(VariableIndex index) {
   // as part of the current backwards pass, and zero the part
   // of the bucket it would otherwise hold.
   auto bucket_view = replica.contents.narrow(0, offset, length);
-  auto& grad = variable.grad();
-  if (grad.defined()) {
-    // Ensure that the gradient type matches the bucket type.
-    TORCH_CHECK(
-        grad.options().type_equal(bucket_view.options()),
-        "Expected ",
-        bucket_view.toString(),
-        ", got ",
-        grad.toString());
-    // Assert that the grad tensor and the bucket don't share storage.
-    // If they did, we could avoid the copy altogether.
-    // The reason for not doing this is that existing code calls
-    // `detach_` from `zero_grad`, which is incompatible with views.
-    TORCH_INTERNAL_ASSERT(!grad.is_alias_of(bucket_view));
-    TORCH_INTERNAL_ASSERT(grad.device() == bucket_view.device());
-    TORCH_INTERNAL_ASSERT(grad.numel() == bucket_view.numel());
-    bucket_view.copy_(grad.view({-1}), /* non_blocking */ true);
-  } else {
-    bucket_view.zero_();
-  }
+  runGradCallbackForVariable(variable, [&](auto& grad) {
+    if (grad.defined()) {
+      // Ensure that the gradient type matches the bucket type.
+      TORCH_CHECK(
+          grad.options().type_equal(bucket_view.options()),
+          "Expected ",
+          bucket_view.toString(),
+          ", got ",
+          grad.toString());
+      // Assert that the grad tensor and the bucket don't share storage.
+      // If they did, we could avoid the copy altogether.
+      // The reason for not doing this is that existing code calls
+      // `detach_` from `zero_grad`, which is incompatible with views.
+      TORCH_INTERNAL_ASSERT(!grad.is_alias_of(bucket_view));
+      TORCH_INTERNAL_ASSERT(grad.device() == bucket_view.device());
+      TORCH_INTERNAL_ASSERT(grad.numel() == bucket_view.numel());
+      bucket_view.copy_(grad.view({-1}), /* non_blocking */ true);
+    } else {
+      bucket_view.zero_();
+    }
+    // The grad is not modified and dosesn't need to be written back.
+    return false;
+  });
 }
 
 void Reducer::mark_variable_ready_sparse(VariableIndex index) {
@@ -242,18 +248,21 @@ void Reducer::mark_variable_ready_sparse(VariableIndex index) {
   auto& bucket = buckets_[bucket_index.bucket_index];
   auto& replica = bucket.replicas[replica_index];
   auto& variable = replica.variables[bucket_index.intra_bucket_index];
-  auto& grad = variable.grad();
-  TORCH_CHECK(grad.defined(), "Expected sparse gradient to be defined.");
-  TORCH_CHECK(
-      grad.options().layout() == c10::kSparse,
-      "Expected variable to have sparse gradient.");
+  runGradCallbackForVariable(variable, [&](auto& grad) {
+    TORCH_CHECK(grad.defined(), "Expected sparse gradient to be defined.");
+    TORCH_CHECK(
+        grad.options().layout() == c10::kSparse,
+        "Expected variable to have sparse gradient.");
 
-  // Sparse tensors cannot be grouped together with other sparse tensors
-  // in a single reduction operation like we can for dense tensors.
-  // Therefore, the `offsets` and `lengths` vectors in the bucket replica
-  // struct are empty, and there is no pre-existing accumulation tensor.
-  // Directly assign the sparse tensor to the `contents` field.
-  replica.contents = grad;
+    // Sparse tensors cannot be grouped together with other sparse tensors
+    // in a single reduction operation like we can for dense tensors.
+    // Therefore, the `offsets` and `lengths` vectors in the bucket replica
+    // struct are empty, and there is no pre-existing accumulation tensor.
+    // Directly assign the sparse tensor to the `contents` field.
+    replica.contents = grad;
+    // The grad is not modified and dosesn't need to be written back.
+    return false;
+  });
 }
 
 // The function `autograd_hook` is called after the gradient for a
@@ -693,15 +702,19 @@ void Reducer::finalize_bucket_dense(Bucket& bucket) {
 
       auto bucket_view =
           replica.contents.narrow(0, offset, length).view(variable.sizes());
-      auto& grad = variable.grad();
-
-      // If a parameter is globally unused, we keep its grad untouched.
-      if (!global_unused) {
-        if (!grad.defined()) {
-          grad = at::empty(bucket_view.sizes(), bucket_view.options());
+      runGradCallbackForVariable(variable, [&](auto& grad) {
+        // If a parameter is globally unused, we keep its grad untouched.
+        if (!global_unused) {
+          if (!grad.defined()) {
+            grad = at::empty(bucket_view.sizes(), bucket_view.options());
+          }
+          grad.copy_(bucket_view);
+          // The grad is modified and needs to be written back.
+          return true;
         }
-        grad.copy_(bucket_view);
-      }
+        // The grad is not modified.
+        return false;
+      });
     }
   }
 }
@@ -756,6 +769,39 @@ void Reducer::finalize_backward() {
     local_used_work_->wait();
   }
   local_used_maps_reduced_ = false;
+  rpc_context_.clear();
+}
+
+void Reducer::runGradCallbackForVariable(
+    torch::autograd::Variable& variable,
+    GradCallback&& cb) {
+  auto context_ptr = rpc_context_.context_ptr.load();
+  if (context_ptr == nullptr) {
+    cb(variable.grad());
+  } else {
+    // Under distributed autograa
+    context_ptr->runGradCallbackForVariable(variable, std::move(cb));
+  }
+}
+
+void Reducer::RpcContext::set(ContextWeakPtr&& context_weak_ptr) {
+  auto new_context_ptr = context_weak_ptr.lock();
+  if (!new_context_ptr) {
+    // Not under distributed autograd
+    return;
+  }
+  if (context_ptr.exchange(new_context_ptr.get()) == nullptr) {
+    // Set the shared ptr to the context only if it's set first time.
+    // All call sites should use the same context ptr.
+    // Use an atomic to avoid data race from multiple threads.
+    context_ptr_holder = std::move(new_context_ptr);
+  }
+}
+
+void Reducer::RpcContext::clear() {
+  if (context_ptr.exchange(nullptr) != nullptr) {
+    context_ptr_holder.reset();
+  }
 }
 
 void Reducer::sync_bucket_indices(

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -784,10 +784,8 @@ void Reducer::runGradCallbackForVariable(
 }
 
 void Reducer::RpcContext::set(ContextPtr&& new_context_ptr) {
-  if (!new_context_ptr) {
-    // Not under distributed autograd
-    return;
-  }
+  // We should set 'new_context_ptr' even if it's nullptr. That means the
+  // reducer is under a local backward run.
   const auto new_context_raw_ptr = new_context_ptr.get();
   if (context_ptr.exchange(new_context_raw_ptr) != new_context_raw_ptr) {
     // Set the shared ptr to the context only if it's set first time.

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -10,6 +10,7 @@
 #include <c10d/ProcessGroup.hpp>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
+#include <torch/csrc/distributed/autograd/context/context.h>
 
 namespace c10d {
 
@@ -126,6 +127,12 @@ class Reducer {
   // the performance cost is negligible.
   std::vector<std::vector<size_t>> rebuildBuckets();
 
+  using GradCallback =
+      torch::distributed::autograd::DistAutogradContext::GradCallback;
+  void runGradCallbackForVariable(
+      torch::autograd::Variable& variable,
+      GradCallback&& cb);
+
   // A bucket replica represents [1..N] gradients to be reduced,
   // with the same dtype, on the same device.
   //
@@ -210,6 +217,18 @@ class Reducer {
   std::vector<at::Tensor> rebuilt_params_;
   std::vector<int64_t> rebuilt_param_indices_;
   const int64_t bucket_bytes_cap_;
+
+  struct RpcContext {
+    using ContextPtr = torch::distributed::autograd::ContextPtr;
+    using ContextWeakPtr = torch::distributed::autograd::ContextWeakPtr;
+    // The shared_ptr is to hold the context instance.
+    ContextPtr context_ptr_holder;
+    std::atomic<ContextPtr::element_type*> context_ptr{nullptr};
+
+    void set(ContextWeakPtr&& context_weak_ptr);
+    void clear();
+  };
+  RpcContext rpc_context_;
 };
 
 std::vector<std::vector<size_t>> compute_bucket_assignment_by_size(

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -220,12 +220,11 @@ class Reducer {
 
   struct RpcContext {
     using ContextPtr = torch::distributed::autograd::ContextPtr;
-    using ContextWeakPtr = torch::distributed::autograd::ContextWeakPtr;
     // The shared_ptr is to hold the context instance.
     ContextPtr context_ptr_holder;
     std::atomic<ContextPtr::element_type*> context_ptr{nullptr};
 
-    void set(ContextWeakPtr&& context_weak_ptr);
+    void set(ContextPtr&& new_context_ptr);
     void clear();
   };
   RpcContext rpc_context_;

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -226,6 +226,16 @@ class Reducer {
 
     void set(ContextPtr&& new_context_ptr);
     void clear();
+
+    struct ClearGuard {
+      explicit ClearGuard(RpcContext& context);
+      ~ClearGuard();
+
+      RpcContext& context_;
+    };
+    ClearGuard getClearGuard() {
+      return ClearGuard(*this);
+    }
   };
   RpcContext rpc_context_;
 };

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -225,17 +225,6 @@ class Reducer {
     std::atomic<ContextPtr::element_type*> context_ptr{nullptr};
 
     void set(ContextPtr&& new_context_ptr);
-    void clear();
-
-    struct ClearGuard {
-      explicit ClearGuard(RpcContext& context);
-      ~ClearGuard();
-
-      RpcContext& context_;
-    };
-    ClearGuard getClearGuard() {
-      return ClearGuard(*this);
-    }
   };
   RpcContext rpc_context_;
 };


### PR DESCRIPTION
## Why doesn’t DDP work under dist_autograd?
DDP follows the steps below
1. [DDP Python constructor](https://github.com/pytorch/pytorch/blob/8d6a8d2b3fd2a6ec788378843fc518824acf274b/torch/nn/parallel/distributed.py#L389-L393) (on a module) creates a [C++ Reducer](https://github.com/pytorch/pytorch/blob/master/torch/csrc/distributed/c10d/reducer.cpp), which holds references to all parameters (or variables in C++ code).
2. The reducer installs a post hook on each model parameter.
3. The backward run starts and triggers the post hooks installed above.
4. The post hook of a parameter simply marks the parameter ready for all-reduce.
5. Once all parameters in a bucket are ready, an all-reduce process starts by reading variable `.grad` and writes to variable `.grad`.

But under dist_autograd, `.grad` of a variable is not populated at all. Instead, grads are in a global map in distributed context from variables to their grads.

## Solution of this PR
The distributed engine to set a thread_local variable in a backward run indicating we're running in distributed mode. DDP reducer can then appropriately use `.grad` or the distributed context based on the thread local. More precisely, the thread local is set before calling the post hooks installed by the DDP reducer so that DDP post hooks can retrieve this thread local.

