### PR TITLE
[nomni] fix outputs check to replaceSubgraph

### DIFF
--- a/caffe2/core/nomnigraph/Representations/NeuralNet.cc
+++ b/caffe2/core/nomnigraph/Representations/NeuralNet.cc
@@ -62,12 +62,16 @@ void NNModule::replaceSubgraph(
   auto sg_outputs = nn::getOutputs(sg);
 
   auto sg_inputs_copy = sg_inputs;
+  auto sg_outputs_copy = sg_outputs;
+
   for (const auto& input : node_inputs) {
     sg_inputs_copy.erase(input);
+    // outputs may contain inputs that have additional
+    // consumers external to the subgraph
+    sg_outputs_copy.erase(input);
   }
   assert(sg_inputs_copy.size() == 0 && "Not all inputs were listed");
 
-  auto sg_outputs_copy = sg_outputs;
   for (const auto& output : node_outputs) {
     sg_outputs_copy.erase(output);
   }


### PR DESCRIPTION
Summary:
D21445887 runs into a dbgo build crash on this stack P130135519

It is because the assertion sg_inputs_copy.size() == 0 is too restrictive.
nn::getOutputs(sg) returns "output" nodes which can include any inputs
that have additional consumers that are not in the subgraph itself.
To fix, proposing to remove inputs from the output check.

Test Plan:
Run tests

Sanity canaries:
https://our.intern.facebook.com/intern/ads/canary/426498931666198610/
https://our.intern.facebook.com/intern/ads/canary/426498935267166205/

Differential Revision: D21445881

