### PR TITLE
Migrate CPU tensor factories to c10::complex

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -157,7 +157,7 @@ public:
   static Vec256<T> arange(T base = static_cast<T>(0), step_t step = static_cast<step_t>(1)) {
     Vec256 vec;
     for (int64_t i = 0; i < size(); i++) {
-      vec.values[i] = base + i * step;
+      vec.values[i] = base + static_cast<step_t>(i) * step;
     }
     return vec;
   }

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -953,7 +953,7 @@ template <typename T>
 Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
   auto result = at::empty(values.size(), options);
   AT_ASSERT(result.is_contiguous());
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(result.scalar_type(), "tensor_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX(result.scalar_type(), "tensor_cpu", [&] {
     std::copy(values.begin(), values.end(), result.template data_ptr<scalar_t>());
   });
   return result;

--- a/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
+++ b/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
@@ -19,23 +19,23 @@ static void linspace_kernel(TensorIterator& iter, Scalar scalar_start, Scalar sc
     int64_t idx(0);
     scalar_t start = scalar_start.to<scalar_t>();
     scalar_t end = scalar_end.to<scalar_t>();
-    step_t step = static_cast<step_t>(end - start) / (steps - 1);
+    step_t step = static_cast<step_t>(end - start) / static_cast<step_t>(steps - 1);
     int64_t halfway = steps / 2;
     cpu_serial_kernel_vec(
         iter,
         [start, end, step, halfway, steps, &idx]() -> scalar_t {
           if (idx < halfway) {
-            return start + step * (idx++);
+            return start + step * static_cast<step_t>(idx++);
           } else {
-            return end - step * (steps - (idx++) - 1);
+            return end - step * static_cast<step_t>(steps - (idx++) - 1);
           }
         },
         [start, end, step, halfway, steps, &idx]() -> Vec256<scalar_t> {
           Vec256<scalar_t> res;
           if (idx < halfway) {
-            res = Vec256<scalar_t>::arange(start + step * idx, step);
+            res = Vec256<scalar_t>::arange(start + step * static_cast<step_t>(idx), step);
           } else {
-            res = Vec256<scalar_t>::arange(end - step * (steps - idx - 1), step);
+            res = Vec256<scalar_t>::arange(end - step * static_cast<step_t>(steps - idx - 1), step);
           }
           idx += Vec256<scalar_t>::size();
           return res;

--- a/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
+++ b/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
@@ -13,7 +13,7 @@ namespace {
 using namespace vec256;
 
 static void linspace_kernel(TensorIterator& iter, Scalar scalar_start, Scalar scalar_end, int64_t steps) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(iter.dtype(), "linspace_cpu", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX(iter.dtype(), "linspace_cpu", [&]() {
     // step should be of double type for all integral types
     using step_t = std::conditional_t<std::is_integral<scalar_t>::value, double, scalar_t>;
     int64_t idx(0);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38023 Migrate CPU cross and some elementwise to c10::complex
* #38022 Migrate CPU reduction to c10::complex
* **#38021 Migrate CPU tensor factories to c10::complex**

Differential Revision: [D21518263](https://our.internmc.facebook.com/intern/diff/D21518263)