### PR TITLE
Fix torch.tensor dtype inference

### DIFF
--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -33,5 +33,11 @@ class TestComplexTensor(TestCase):
         self.assertEqual(complex_tensor.copy_real(), real)
         self.assertEqual(complex_tensor.copy_imag(), imag)
 
+    def test_dtype_inference(self):
+        # issue: https://github.com/pytorch/pytorch/issues/36834
+        torch.set_default_dtype(torch.double)
+        x = torch.tensor([3., 3.+5.j])
+        self.assertEqual(x.dtype, torch.cdouble)
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -197,7 +197,7 @@ ScalarType infer_scalar_type(PyObject *obj) {
       ScalarType item_scalarType = infer_scalar_type(cur_item);
       scalarType = (scalarType) ?
           at::promoteTypes(*scalarType, item_scalarType) : item_scalarType;
-      if (scalarType == ScalarType::Double) {
+      if (scalarType == ScalarType::ComplexDouble) {
         // this won't change (unless we hit undefined, but that will fail later).
         return *scalarType;
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38031 Fix tensor printing
* **#38030 Fix dtype inference**

Resolves: https://github.com/pytorch/pytorch/issues/36834

Differential Revision: [D21462729](https://our.internmc.facebook.com/intern/diff/D21462729)