### PR TITLE
Refactor native/cpu/zmath.h

### DIFF
--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -1,27 +1,12 @@
 #pragma once
 
 // Complex number math operations that act as no-ops for other dtypes.
-#include <complex>
+#include <c10/util/complex_type.h>
 #include <c10/util/math_compat.h>
 #include<ATen/NumericUtils.h>
 
 namespace at { namespace native {
 namespace {
-
-template <typename TYPE>
-struct ztype {
-  using value_t = TYPE;
-};
-
-template <>
-struct ztype<std::complex<double>> {
-  using value_t = double;
-};
-
-template <>
-struct ztype<std::complex<float>> {
-  using value_t = float;
-};
 
 template <typename SCALAR_TYPE, typename VALUE_TYPE=SCALAR_TYPE>
 inline VALUE_TYPE zabs (SCALAR_TYPE z) {
@@ -29,22 +14,22 @@ inline VALUE_TYPE zabs (SCALAR_TYPE z) {
 }
 
 template<>
-inline std::complex<float> zabs <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(std::abs(z));
+inline c10::complex<float> zabs <c10::complex<float>> (c10::complex<float> z) {
+  return c10::complex<float>(std::abs(z));
 }
 
 template<>
-inline float zabs <std::complex<float>, float> (std::complex<float> z) {
+inline float zabs <c10::complex<float>, float> (c10::complex<float> z) {
   return std::abs(z);
 }
 
 template<>
-inline std::complex<double> zabs <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(std::abs(z));
+inline c10::complex<double> zabs <c10::complex<double>> (c10::complex<double> z) {
+  return c10::complex<double>(std::abs(z));
 }
 
 template<>
-inline double zabs <std::complex<double>, double> (std::complex<double> z) {
+inline double zabs <c10::complex<double>, double> (c10::complex<double> z) {
   return std::abs(z);
 }
 
@@ -54,22 +39,22 @@ inline VALUE_TYPE angle_impl (SCALAR_TYPE z) {
 }
 
 template<>
-inline std::complex<float> angle_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(std::arg(z), 0.0);
+inline c10::complex<float> angle_impl <c10::complex<float>> (c10::complex<float> z) {
+  return c10::complex<float>(std::arg(z), 0.0);
 }
 
 template<>
-inline float angle_impl <std::complex<float>, float> (std::complex<float> z) {
+inline float angle_impl <c10::complex<float>, float> (c10::complex<float> z) {
   return std::arg(z);
 }
 
 template<>
-inline std::complex<double> angle_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(std::arg(z), 0.0);
+inline c10::complex<double> angle_impl <c10::complex<double>> (c10::complex<double> z) {
+  return c10::complex<double>(std::arg(z), 0.0);
 }
 
 template<>
-inline double angle_impl <std::complex<double>, double> (std::complex<double> z) {
+inline double angle_impl <c10::complex<double>, double> (c10::complex<double> z) {
   return std::arg(z);
 }
 
@@ -79,22 +64,22 @@ constexpr VALUE_TYPE real_impl (SCALAR_TYPE z) {
 }
 
 template<>
-constexpr std::complex<float> real_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(z.real(), 0.0);
+constexpr c10::complex<float> real_impl <c10::complex<float>> (c10::complex<float> z) {
+  return c10::complex<float>(z.real(), 0.0);
 }
 
 template<>
-constexpr float real_impl <std::complex<float>, float> (std::complex<float> z) {
+constexpr float real_impl <c10::complex<float>, float> (c10::complex<float> z) {
   return z.real();
 }
 
 template<>
-constexpr std::complex<double> real_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(z.real(), 0.0);
+constexpr c10::complex<double> real_impl <c10::complex<double>> (c10::complex<double> z) {
+  return c10::complex<double>(z.real(), 0.0);
 }
 
 template<>
-constexpr double real_impl <std::complex<double>, double> (std::complex<double> z) {
+constexpr double real_impl <c10::complex<double>, double> (c10::complex<double> z) {
   return z.real();
 }
 
@@ -104,22 +89,22 @@ constexpr VALUE_TYPE imag_impl (SCALAR_TYPE z) {
 }
 
 template<>
-constexpr std::complex<float> imag_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(z.imag(), 0.0);
+constexpr c10::complex<float> imag_impl <c10::complex<float>> (c10::complex<float> z) {
+  return c10::complex<float>(z.imag(), 0.0);
 }
 
 template<>
-constexpr float imag_impl <std::complex<float>, float> (std::complex<float> z) {
+constexpr float imag_impl <c10::complex<float>, float> (c10::complex<float> z) {
   return z.imag();
 }
 
 template<>
-constexpr std::complex<double> imag_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(z.imag(), 0.0);
+constexpr c10::complex<double> imag_impl <c10::complex<double>> (c10::complex<double> z) {
+  return c10::complex<double>(z.imag(), 0.0);
 }
 
 template<>
-constexpr double imag_impl <std::complex<double>, double> (std::complex<double> z) {
+constexpr double imag_impl <c10::complex<double>, double> (c10::complex<double> z) {
   return z.imag();
 }
 
@@ -129,13 +114,13 @@ inline TYPE conj_impl (TYPE z) {
 }
 
 template<>
-inline std::complex<float> conj_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(z.real(), -z.imag());
+inline c10::complex<float> conj_impl <c10::complex<float>> (c10::complex<float> z) {
+  return c10::complex<float>(z.real(), -z.imag());
 }
 
 template<>
-inline std::complex<double> conj_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(z.real(), -z.imag());
+inline c10::complex<double> conj_impl <c10::complex<double>> (c10::complex<double> z) {
+  return c10::complex<double>(z.real(), -z.imag());
 }
 
 template <typename TYPE>
@@ -144,13 +129,13 @@ inline TYPE ceil_impl (TYPE z) {
 }
 
 template <>
-inline std::complex<float> ceil_impl (std::complex<float> z) {
-  return std::complex<float>(std::ceil(z.real()), std::ceil(z.imag()));
+inline c10::complex<float> ceil_impl (c10::complex<float> z) {
+  return c10::complex<float>(std::ceil(z.real()), std::ceil(z.imag()));
 }
 
 template <>
-inline std::complex<double> ceil_impl (std::complex<double> z) {
-  return std::complex<double>(std::ceil(z.real()), std::ceil(z.imag()));
+inline c10::complex<double> ceil_impl (c10::complex<double> z) {
+  return c10::complex<double>(std::ceil(z.real()), std::ceil(z.imag()));
 }
 
 template <typename TYPE>
@@ -159,13 +144,13 @@ inline TYPE floor_impl (TYPE z) {
 }
 
 template <>
-inline std::complex<float> floor_impl (std::complex<float> z) {
-  return std::complex<float>(std::floor(z.real()), std::floor(z.imag()));
+inline c10::complex<float> floor_impl (c10::complex<float> z) {
+  return c10::complex<float>(std::floor(z.real()), std::floor(z.imag()));
 }
 
 template <>
-inline std::complex<double> floor_impl (std::complex<double> z) {
-  return std::complex<double>(std::floor(z.real()), std::floor(z.imag()));
+inline c10::complex<double> floor_impl (c10::complex<double> z) {
+  return c10::complex<double>(std::floor(z.real()), std::floor(z.imag()));
 }
 
 template <typename TYPE>
@@ -174,13 +159,13 @@ inline TYPE round_impl (TYPE z) {
 }
 
 template <>
-inline std::complex<float> round_impl (std::complex<float> z) {
-  return std::complex<float>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
+inline c10::complex<float> round_impl (c10::complex<float> z) {
+  return c10::complex<float>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
 }
 
 template <>
-inline std::complex<double> round_impl (std::complex<double> z) {
-  return std::complex<double>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
+inline c10::complex<double> round_impl (c10::complex<double> z) {
+  return c10::complex<double>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
 }
 
 template <typename TYPE>
@@ -189,13 +174,13 @@ inline TYPE trunc_impl (TYPE z) {
 }
 
 template <>
-inline std::complex<float> trunc_impl (std::complex<float> z) {
-  return std::complex<float>(std::trunc(z.real()), std::trunc(z.imag()));
+inline c10::complex<float> trunc_impl (c10::complex<float> z) {
+  return c10::complex<float>(std::trunc(z.real()), std::trunc(z.imag()));
 }
 
 template <>
-inline std::complex<double> trunc_impl (std::complex<double> z) {
-  return std::complex<double>(std::trunc(z.real()), std::trunc(z.imag()));
+inline c10::complex<double> trunc_impl (c10::complex<double> z) {
+  return c10::complex<double>(std::trunc(z.real()), std::trunc(z.imag()));
 }
 
 template <typename TYPE, std::enable_if_t<!c10::is_complex_t<TYPE>::value, int> = 0>
@@ -240,3 +225,5 @@ inline TYPE min_impl (TYPE a, TYPE b) {
 
 } // end namespace
 }} //end at::native
+
+#include <ATen/native/cpu/zmath_std.h>

--- a/aten/src/ATen/native/cpu/zmath_std.h
+++ b/aten/src/ATen/native/cpu/zmath_std.h
@@ -1,0 +1,157 @@
+#pragma once
+
+// Complex number math operations that act as no-ops for other dtypes.
+#include <complex>
+#include <c10/util/math_compat.h>
+#include<ATen/NumericUtils.h>
+
+namespace at { namespace native {
+namespace {
+
+template <typename TYPE>
+struct ztype {
+  using value_t = TYPE;
+};
+
+template <>
+struct ztype<std::complex<double>> {
+  using value_t = double;
+};
+
+template <>
+struct ztype<std::complex<float>> {
+  using value_t = float;
+};
+
+template<>
+inline std::complex<float> zabs <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(std::abs(z));
+}
+
+template<>
+inline float zabs <std::complex<float>, float> (std::complex<float> z) {
+  return std::abs(z);
+}
+
+template<>
+inline std::complex<double> zabs <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(std::abs(z));
+}
+
+template<>
+inline double zabs <std::complex<double>, double> (std::complex<double> z) {
+  return std::abs(z);
+}
+
+template<>
+inline std::complex<float> angle_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(std::arg(z), 0.0);
+}
+
+template<>
+inline float angle_impl <std::complex<float>, float> (std::complex<float> z) {
+  return std::arg(z);
+}
+
+template<>
+inline std::complex<double> angle_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(std::arg(z), 0.0);
+}
+
+template<>
+inline double angle_impl <std::complex<double>, double> (std::complex<double> z) {
+  return std::arg(z);
+}
+
+template<>
+constexpr std::complex<float> real_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(z.real(), 0.0);
+}
+
+template<>
+constexpr float real_impl <std::complex<float>, float> (std::complex<float> z) {
+  return z.real();
+}
+
+template<>
+constexpr std::complex<double> real_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(z.real(), 0.0);
+}
+
+template<>
+constexpr double real_impl <std::complex<double>, double> (std::complex<double> z) {
+  return z.real();
+}
+
+template<>
+constexpr std::complex<float> imag_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(z.imag(), 0.0);
+}
+
+template<>
+constexpr float imag_impl <std::complex<float>, float> (std::complex<float> z) {
+  return z.imag();
+}
+
+template<>
+constexpr std::complex<double> imag_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(z.imag(), 0.0);
+}
+
+template<>
+constexpr double imag_impl <std::complex<double>, double> (std::complex<double> z) {
+  return z.imag();
+}
+
+template<>
+inline std::complex<float> conj_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(z.real(), -z.imag());
+}
+
+template<>
+inline std::complex<double> conj_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(z.real(), -z.imag());
+}
+
+template <>
+inline std::complex<float> ceil_impl (std::complex<float> z) {
+  return std::complex<float>(std::ceil(z.real()), std::ceil(z.imag()));
+}
+
+template <>
+inline std::complex<double> ceil_impl (std::complex<double> z) {
+  return std::complex<double>(std::ceil(z.real()), std::ceil(z.imag()));
+}
+
+template <>
+inline std::complex<float> floor_impl (std::complex<float> z) {
+  return std::complex<float>(std::floor(z.real()), std::floor(z.imag()));
+}
+
+template <>
+inline std::complex<double> floor_impl (std::complex<double> z) {
+  return std::complex<double>(std::floor(z.real()), std::floor(z.imag()));
+}
+
+template <>
+inline std::complex<float> round_impl (std::complex<float> z) {
+  return std::complex<float>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
+}
+
+template <>
+inline std::complex<double> round_impl (std::complex<double> z) {
+  return std::complex<double>(std::nearbyint(z.real()), std::nearbyint(z.imag()));
+}
+
+template <>
+inline std::complex<float> trunc_impl (std::complex<float> z) {
+  return std::complex<float>(std::trunc(z.real()), std::trunc(z.imag()));
+}
+
+template <>
+inline std::complex<double> trunc_impl (std::complex<double> z) {
+  return std::complex<double>(std::trunc(z.real()), std::trunc(z.imag()));
+}
+
+} // end namespace
+}} //end at::native


### PR DESCRIPTION
There is now a `zmath.h` and `zmath_std.h`, where the latter is the copy-paste of the original `zmath.h` and supporting `std::complex`, and `zmath.h` is for supporting `c10::complex`. `zmath_std.h` will be removed eventually.