### PR TITLE
Batchnorm now always updates var and mean inplace

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -515,7 +515,7 @@ Tensor batch_norm(
     if (bias.defined()) out = out + bias[0];
     return out;
   }
-  auto result = at::_batch_norm_impl_index(
+  return std::get<0>(at::_batch_norm_impl_index(
       input,
       weight,
       bias,
@@ -524,9 +524,7 @@ Tensor batch_norm(
       training,
       momentum,
       eps,
-      cudnn_enabled);
-
-  return std::get<0>(result);
+      cudnn_enabled));
 }
 
 Tensor instance_norm(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11186,7 +11186,7 @@ class TestNNDeviceType(NNTestCase):
 
         def inplace_non_contig(a):
             size = a.shape[0]
-            a.resize_(size*2)
+            a.resize_(size * 2)
             a.as_strided_((size,), (2,))
 
         bn = torch.nn.BatchNorm2d(3).double().to(device=device)


### PR DESCRIPTION
Fixes: #33867

Also fixes similar case for miopen.

Do nothing with version counters.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38040 Batchnorm now always updates var and mean inplace**

Differential Revision: [D21460273](https://our.internmc.facebook.com/intern/diff/D21460273)