### PR TITLE
Get rid of javasphinx dependency.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,3 @@ sphinx==2.4.4
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib
-javasphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinxcontrib.katex',
     'sphinx.ext.autosectionlabel',
-    'javasphinx',
 ]
 
 # build the templated autosummary files


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38042 Get rid of javasphinx dependency.**

Fixes https://github.com/pytorch/pytorch/issues/36064

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D21460484](https://our.internmc.facebook.com/intern/diff/D21460484)