### PR TITLE
fix multinomial kernels to properly advance random states

### DIFF
--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -124,8 +124,8 @@ sampleMultinomialWithReplacement(std::pair<uint64_t, uint64_t> seeds,
   // search due to divergence. It seems possible to compute multiple
   // values and limit divergence though later on.
 
-  // global index formula for 1D grid of 2D blocks
-  int idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.y * blockDim.x + threadIdx.x;
+  // global index formula for 1D grid of 1D blocks
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
   curandStatePhilox4_32_10_t state;
   curand_init(seeds.first, idx, seeds.second, &state);
@@ -134,26 +134,23 @@ sampleMultinomialWithReplacement(std::pair<uint64_t, uint64_t> seeds,
   for (int64_t curDist = blockIdx.x;
        curDist < distributions;
        curDist += gridDim.x) {
-    for (int sampleBase = 0;
-         sampleBase < totalSamples; sampleBase += blockDim.y) {
-      // The warp determines the sample
-      int sample = sampleBase + threadIdx.y;
+    for (int sample = threadIdx.x;
+         sample < totalSamples; sample += blockDim.x) {
 
-      // All threads participate in this
+      //we are losing 3 out of 4 generated numbers but it's ok
+      //this kernel is not very efficient anyway
       auto rand = curand_uniform4(&state);
       scalar_t r = static_cast<scalar_t>(rand.x);
 
-      if (threadIdx.x == 0 && sample < totalSamples) {
-        // Find the bucket that a uniform sample lies in
-        int choice = binarySearchForMultinomial<scalar_t>(
-            normDistPrefixSum + curDist * categories,
-            normDist + curDist * categories,
-            categories,
-            r);
+      // Find the bucket that a uniform sample lies in
+      int choice = binarySearchForMultinomial<scalar_t>(
+          normDistPrefixSum + curDist * categories,
+          normDist + curDist * categories,
+          categories,
+          r);
 
-        // Torch indices are 1-based
-        dest[curDist * totalSamples + sample] = choice;
-      }
+      dest[curDist * totalSamples + sample] = choice;
+
     }
   }
 }
@@ -180,17 +177,14 @@ sampleMultinomialWithoutReplacement(std::pair<uint64_t, uint64_t> seeds,
 
   // The block and warp determines the distribution for which we
   // generate a point
-  for (int64_t curDistBase = blockIdx.x * blockDim.y;
-       curDistBase < distributions;
-       curDistBase += gridDim.x * blockDim.y) {
-    // The warp determines the distribution
-    int64_t curDist = curDistBase + threadIdx.y;
+  for (int64_t curDist = blockIdx.x * blockDim.y + threadIdx.y;
+       curDist < distributions;
+       curDist += gridDim.x * blockDim.y) {
 
-    // All threads must participate in this
     auto rand = curand_uniform4(&state);
     scalar_t r = static_cast<scalar_t>(rand.x);
 
-    if (threadIdx.x == 0 && curDist < distributions) {
+    if (threadIdx.x == 0) {
       // Find the bucket that a uniform sample lies in
       int choice = binarySearchForMultinomial<scalar_t>(
           normDistPrefixSum + curDist * categories,
@@ -415,25 +409,25 @@ void multinomial_kernel_impl(Tensor& result, const Tensor& self, const int64_t n
       std::pair<uint64_t, uint64_t> rng_engine_inputs;
 
       if (with_replacement) {
+        // Binary search is warp divergent (so effectively we're running
+        // with just a single thread), but for better utilization,
+        // we need each block to have at least 4 warps.
+        dim3 block(128);
+
+        // Each block will generate a sample from one
+        // distribution concurrently.
+        dim3 grid(numDist < MAX_NUM_BLOCKS ? numDist : MAX_NUM_BLOCKS);
         {
           // See Note [Acquire lock when using random generators]
           std::lock_guard<std::mutex> lock(gen->mutex_);
 
-          // each thread will utilize one random, however, since we have to use
+          // each thread will utilize several randoms (numdist/numblocks*numsamples/numthreads), however, since we have to use
           // curand_uniform4 (See Note [Register spilling in curand call for CUDA < 10]),
-          // offset is 4.
-          rng_engine_inputs = gen->philox_engine_inputs(4);
+          // offset is 4 times that.
+          auto offset = (((n_sample-1)/block.x+1)*((numDist-1)/grid.x+1))*4;
+          rng_engine_inputs = gen->philox_engine_inputs(offset);
         }
         // Sample with replacement
-
-        // Binary search is warp divergent (so effectively we're running
-        // with just a single thread), but for better utilization,
-        // we need each block to have at least 4 warps.
-        dim3 block(32, 4);
-
-        // Each warp in a block will generate a sample from one
-        // distribution concurrently.
-        dim3 grid(numDist < MAX_NUM_BLOCKS ? numDist : MAX_NUM_BLOCKS);
 
         sampleMultinomialWithReplacement
             <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
@@ -470,10 +464,11 @@ void multinomial_kernel_impl(Tensor& result, const Tensor& self, const int64_t n
             // See Note [Acquire lock when using random generators]
             std::lock_guard<std::mutex> lock(gen->mutex_);
 
-            // each thread will utilize one random, however, since we have to use
+            // each thread will utilize distributions/(gridDim.x*blockDim.y) randoms, however, since we have to use
             // curand_uniform4 (See Note [Register spilling in curand call for CUDA < 10]),
-            // offset is 4.
-            rng_engine_inputs = gen->philox_engine_inputs(4);
+            // offset is 4 times that.
+            auto offset = ((numDist-1)/(grid.x*block.y)+1)*4;
+            rng_engine_inputs = gen->philox_engine_inputs(offset);
           }
 
           // The kernel can only draw one sample before we have to

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -422,10 +422,10 @@ void multinomial_kernel_impl(Tensor& result, const Tensor& self, const int64_t n
           // See Note [Acquire lock when using random generators]
           std::lock_guard<std::mutex> lock(gen->mutex_);
 
-          // each thread will utilize several randoms (numdist/numblocks*numsamples/numthreads), however, since we have to use
+          // each thread generates a single sample for (numdist/numblocks.y) distributions, however, since we have to use
           // curand_uniform4 (See Note [Register spilling in curand call for CUDA < 10]),
           // offset is 4 times that.
-          auto offset = (((n_sample-1)/block.x+1)*((numDist-1)/grid.x+1))*4;
+          auto offset = ((numDist-1)/grid.y+1)*4;
           rng_engine_inputs = gen->philox_engine_inputs(offset);
         }
         // Sample with replacement

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14238,10 +14238,7 @@ class TestTorchDeviceType(TestCase):
         print(samples.unique().size(0))
         # expect no more than 1 repeating elements generated in 2 attempts
         # the probability of at least element being repeated is surprisingly large, 18%
-        self.assertLessEqual(2*n_sample - samples.unique().size(0), 2)
-
-
-
+        self.assertLessEqual(2 * n_sample - samples.unique().size(0), 2)
 
     def test_var_unbiased(self, device):
         tensor = torch.randn(100, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14226,6 +14226,23 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(prob_dist.dim(), 1, "wrong number of prob_dist dimensions")
             self.assertEqual(sample_indices.size(0), n_sample, "wrong number of samples")
 
+    @slowTest
+    @dtypes(torch.float)
+    def test_multinomial_rng_state_advance(self, device, dtype):
+        corpus_size = 100000
+        freqs = torch.ones(corpus_size, dtype=torch.float, device=device)
+        n_sample = 100
+        samples1 = torch.multinomial(freqs, n_sample, replacement=True)
+        samples2 = torch.multinomial(freqs, n_sample, replacement=True)
+        samples = torch.cat([samples1, samples2])
+        print(samples.unique().size(0))
+        # expect no more than 1 repeating elements generated in 2 attempts
+        # the probability of at least element being repeated is surprisingly large, 18%
+        self.assertLessEqual(2*n_sample - samples.unique().size(0), 2)
+
+
+
+
     def test_var_unbiased(self, device):
         tensor = torch.randn(100, device=device)
         self.assertEqual(tensor.var(0), tensor.var(0, unbiased=True))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14235,10 +14235,14 @@ class TestTorchDeviceType(TestCase):
         samples1 = torch.multinomial(freqs, n_sample, replacement=True)
         samples2 = torch.multinomial(freqs, n_sample, replacement=True)
         samples = torch.cat([samples1, samples2])
-        print(samples.unique().size(0))
         # expect no more than 1 repeating elements generated in 2 attempts
         # the probability of at least element being repeated is surprisingly large, 18%
         self.assertLessEqual(2 * n_sample - samples.unique().size(0), 2)
+        samples1 = torch.multinomial(freqs, n_sample, replacement=False)
+        samples2 = torch.multinomial(freqs, n_sample, replacement=False)
+        samples = torch.cat([samples1, samples2])
+        # expect no more than 1 repeating elements generated in 2 attempts
+        self.assertLessEqual(2 * n_sample - samples.unique().size(0), 1)
 
     def test_var_unbiased(self, device):
         tensor = torch.randn(100, device=device)


### PR DESCRIPTION
Before, multinomial kernels did not advance random states enough, which lead to the same sequence being generated over and over with a shift of 4. This PR fixes that. 
Fixes #37403