### PR TITLE
Fix ldflags string for HIPExtensions

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1298,12 +1298,11 @@ def _prepare_ldflags(extra_ldflags, with_cuda, verbose):
             extra_ldflags.append('cudart.lib')
             if CUDNN_HOME is not None:
                 extra_ldflags.append(os.path.join(CUDNN_HOME, 'lib/x64'))
-        else:
-            if not IS_HIP_EXTENSION:
-                extra_ldflags.append('-L{}'.format(_join_cuda_home('lib64')))
-                extra_ldflags.append('-lcudart')
-                if CUDNN_HOME is not None:
-                    extra_ldflags.append('-L{}'.format(os.path.join(CUDNN_HOME, 'lib64')))
+        elif not IS_HIP_EXTENSION:
+            extra_ldflags.append('-L{}'.format(_join_cuda_home('lib64')))
+            extra_ldflags.append('-lcudart')
+            if CUDNN_HOME is not None:
+                extra_ldflags.append('-L{}'.format(os.path.join(CUDNN_HOME, 'lib64')))
 
     return extra_ldflags
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1299,10 +1299,11 @@ def _prepare_ldflags(extra_ldflags, with_cuda, verbose):
             if CUDNN_HOME is not None:
                 extra_ldflags.append(os.path.join(CUDNN_HOME, 'lib/x64'))
         else:
-            extra_ldflags.append('-L{}'.format(_join_cuda_home('lib64')))
-            extra_ldflags.append('-lcudart')
-            if CUDNN_HOME is not None:
-                extra_ldflags.append('-L{}'.format(os.path.join(CUDNN_HOME, 'lib64')))
+            if not IS_HIP_EXTENSION:
+                extra_ldflags.append('-L{}'.format(_join_cuda_home('lib64')))
+                extra_ldflags.append('-lcudart')
+                if CUDNN_HOME is not None:
+                    extra_ldflags.append('-L{}'.format(os.path.join(CUDNN_HOME, 'lib64')))
 
     return extra_ldflags
 


### PR DESCRIPTION
This pull request adds a check for ROCm environment and skips adding CUDA specific flags for the scenario when a pytorch extension is built on ROCm.

@ezyang @jeffdaily 