### PR TITLE
[TensorExpr] Turn on TensorExpr fuser and with fallbacks disabled.

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -13,7 +13,7 @@
 namespace torch {
 namespace jit {
 
-static bool texpr_fuser_enabled_ = false;
+static bool texpr_fuser_enabled_ = true;
 void setTensorExprFuserEnabled(bool val) {
   texpr_fuser_enabled_ = val;
 }

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -36,10 +36,10 @@ namespace jit {
 // TODO: keep the else clause for trial runs
 #if defined(FBCODE_CAFFE2) || defined(C10_MOBILE)
 static std::atomic<bool> executor_mode{true};
-static std::atomic<bool> profiling_mode{false};
+static std::atomic<bool> profiling_mode{true};
 #else
 static std::atomic<bool> executor_mode{true};
-static std::atomic<bool> profiling_mode{false};
+static std::atomic<bool> profiling_mode{true};
 #endif
 
 static std::atomic<size_t> num_profiled_runs{1};

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -17,7 +17,7 @@ namespace tensorexpr {
 static int te_cuda_pointwise_loop_levels = -1;
 static int te_cuda_pointwise_block_count = -1;
 static int te_cuda_pointwise_block_size = -1;
-static bool fallback_allowed = true;
+static bool fallback_allowed = false;
 
 bool setFallbackAllowed(bool value) {
   bool old_value = fallback_allowed;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38048 [TensorExpr] Turn on TensorExpr fuser and with fallbacks disabled.**
* #38086 Fix segfault in test_fibb.
* #38085 Correctly print 'bool' dtype in Cuda printer.
* #38060 Fixes in ir_simplifier and ir_printer.

Differential Revision: [D21463714](https://our.internmc.facebook.com/intern/diff/D21463714)