### PR TITLE
[TensorExpr] Fix a bug in the IR Simplifier that could introduce a division by zero

### DIFF
--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -699,7 +699,6 @@ void testSimplifyMuls() {
     // But not for Float since nan * 0 = nan.
     ExprHandle body = ExprHandle(1.f) * (x * ExprHandle(0.f));
     ExprHandle simplified = IRSimplifier::simplify(body);
-    std::cout << simplified << "\n";
 
     IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
     IS_NODE_WITH_NAME(Cast, mul->lhs(), cast);
@@ -1502,6 +1501,24 @@ void testSimplifyRoundModPatternFactorization() {
     IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
     IS_IMM_WITH_VAL(Int, mul->lhs(), 5);
     IS_VAR_WITH_NAME(mul->rhs(), "x");
+  }
+
+  {
+    VarHandle x("x", kInt);
+    ExprHandle body = (x / 5) * 10 + ExprHandle(2) * (x % 5);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 2);
+    IS_VAR_WITH_NAME(mul->rhs(), "x");
+  }
+
+  {
+    VarHandle x("x", kInt);
+    ExprHandle body = (x / 10) * 0 + x % 5;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "x");
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 5);
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -702,6 +702,9 @@ const Expr* PolynomialTransformer::isRoundOff(
   }
 
   if (div->rhs()->isConstant() && other->isConstant()) {
+    if (immediateEquals(div->rhs(), 0) || immediateEquals(other, 0)) {
+      return nullptr;
+    }
     // If they are both scalar we may be able to find a common factor.
     if (immediateEquals(evaluateOp(new Mod(other, div->rhs())), 0)) {
       Expr* scalar = evaluateOp(new Div(other, div->rhs()));


### PR DESCRIPTION
In the IR Simplifier when doing partial factorization of Round+Mod patterns we divide by the lower number, which could be zero. Add in a quick check against zero avoid the crash.