### PR TITLE
Fix dummy typo in `skipIfNoFBGEMM`

### DIFF
--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -116,14 +116,14 @@ def _make_conv_test_input(
 
 def skipIfNoFBGEMM(fn):
     reason = 'Quantized operations require FBGEMM. FBGEMM is only optimized for CPUs with instruction set support AVX2 or newer.'
-    if isinstance(fn, type):
+    if isinstance(fn, type) and 'fbgemm' not in torch.backends.quantized.supported_engines:
         fn.__unittest_skip__ = True
         fn.__unittest_skip_why__ = reason
         return fn
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        if True:
+        if 'fbgemm' not in torch.backends.quantized.supported_engines:
             raise unittest.SkipTest(reason)
         else:
             fn(*args, **kwargs)


### PR DESCRIPTION
I've picked wrong revision when landed the diff, it should have had an actual check rather than `if True`:

