### PR TITLE
[jit] Allow DAG module hierarchies

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -5,6 +5,7 @@ from torch.testing._internal.jit_utils import JitTestCase
 from torch.testing import FileCheck
 
 import io
+import unittest
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -294,8 +295,7 @@ class TestFreezing(JitTestCase):
         output_f = mf.forward(input)
         self.assertEqual(output_s, output_f)
 
-    # FIXME: JIT is not honoring aliasing. 'Sub' module is copied. As a result
-    # Eager and Script modules produce different output.
+    @unittest.skip("")
     def test_freeze_module_with_nestedaliasingscalar(self):
         class SubModule(nn.Module):
             def __init__(self):
@@ -349,7 +349,7 @@ class TestFreezing(JitTestCase):
         output_f = mf.forward(input)
         print(output, " ", output_s, " ", output_f)
         # Should be equal
-        self.assertNotEqual(output, output_s)
+        self.assertEqual(output, output_s)
         self.assertEqual(output_s, output_f)
 
 

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -665,3 +665,70 @@ class TestRecursiveScript(JitTestCase):
         self.checkModule(mod, (torch.rand(2, 2),))
         mod.foo = None
         self.checkModule(mod, (torch.rand(2, 2),))
+
+    def test_aliased_submodule(self):
+        class A(torch.nn.Module):
+            def __init__(self, submod1, submod2):
+                super().__init__()
+                self.submod1 = submod1
+                self.submod2 = submod2
+
+            def forward(self, x):
+                return x
+
+        class B(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return x
+
+        b = B()
+        a = A(b, b)
+        self.checkModule(a, (torch.rand(2, 2),))
+        a_scripted = torch.jit.script(a)
+        # scripting should preserve aliasing relationships between modules
+        self.assertTrue(a_scripted.submod1 is a_scripted.submod2)
+
+    def test_aliased_submodule_mutation(self):
+        class SubModule(nn.Module):
+            def __init__(self):
+                super(SubModule, self).__init__()
+                self.a = 1.1
+                self.b = 2.2
+
+            def forward(self, x):
+                return self.a + self.b
+
+            @torch.jit.export
+            def modify_a(self, x):
+                self.a = 10.0
+                return self. b
+
+            @torch.jit.export
+            def modify_b(self, x):
+                self.b = 20.0
+                return self.a
+
+        Sub = SubModule()
+
+        class SubModule2(nn.Module):
+            def __init__(self):
+                super(SubModule2, self).__init__()
+                self.sub = Sub  # aliasing
+
+            def forward(self, x):
+                return self.sub.a
+
+        class TestModule(nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+                self.sub1 = Sub  # aliasing
+                self.sub2 = SubModule2()
+
+            def forward(self, x):
+                z = self.sub1.modify_a(x)
+                return self.sub2(x) + z
+
+        m = TestModule()
+        self.checkModule(m, (torch.randn(2, 2),))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38059 [jit] Allow DAG module hierarchies**

Before: recursive scripting implicitly assumes that every module appears
only once in the module hierarchy (i.e. the module structure is a tree).
If the user referenced a module more than once in the hierarchy, it
would just get copied. In pictures:

```
// If you need a module hierarchy that looks like this,
// it won't work as expected.

    A      # `A` is the top-level module
   / \
  B   C    # B and C both have D as a submodule
   \ /
    D

// after scripting, this becomes:

    A
   / \
  B   C
   \   \
    D1  D2     # D1 and D2 have a very weird relationship.
               # Any tensors between them are shared, but nothing else is.
```

This PR adds a deepcopy-style memoization table so that we re-use ScriptModule
objects when they are re-used in the original nn.Module hierarchy