### PR TITLE
Fixes in ir_simplifier and ir_printer.

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -165,7 +165,7 @@ void IRPrinter::visit(const CompareSelect* v) {
     }
     e->accept(this);
     if (prec >= self_prec) {
-      os() << "(";
+      os() << ")";
     }
   };
   withParens(v->ret_val1());

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -696,6 +696,9 @@ const Expr* PolynomialTransformer::isRoundOff(
   }
 
   if (div->rhs()->isConstant() && other->isConstant()) {
+    if (immediateEquals(div->rhs(), 0) || immediateEquals(other, 0)) {
+      return nullptr;
+    }
     // If they are both scalar we may be able to find a common factor.
     if (immediateEquals(evaluateOp(new Mod(other, div->rhs())), 0)) {
       Expr* scalar = evaluateOp(new Div(other, div->rhs()));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38087 [TensorExpr] Turn on TensorExpr fuser and with fallbacks disabled.
* #38086 Fix segfault in test_fibb.
* #38085 Correctly print 'bool' dtype in Cuda printer.
* **#38060 Fixes in ir_simplifier and ir_printer.**

Differential Revision: [D21464831](https://our.internmc.facebook.com/intern/diff/D21464831)