### PR TITLE
fix test/test_indexing.py

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -210,9 +210,9 @@ class TestIndexing(TestCase):
 
         for a in tensors:
             self.assertNotEqual(a.data_ptr(), a[True].data_ptr())
-            self.assertEqual(torch.empty(0, *a.shape), a[False])
+            self.assertEqualIgnoreType(torch.empty(0, *a.shape), a[False])
             self.assertNotEqual(a.data_ptr(), a[true].data_ptr())
-            self.assertEqual(torch.empty(0, *a.shape), a[false])
+            self.assertEqualIgnoreType(torch.empty(0, *a.shape), a[false])
             self.assertEqual(a.data_ptr(), a[None].data_ptr())
             self.assertEqual(a.data_ptr(), a[...].data_ptr())
 
@@ -348,9 +348,9 @@ class TestIndexing(TestCase):
             self.assertEquals(len(w), 1)
 
         self.assertEqual(x[0], value)
-        self.assertEqual(x[1], torch.arange(4, 8, device=device))
+        self.assertEqualIgnoreType(x[1], torch.arange(4, 8, device=device))
         self.assertEqual(x[2], value)
-        self.assertEqual(x[3], torch.arange(12, 16, device=device))
+        self.assertEqualIgnoreType(x[3], torch.arange(12, 16, device=device))
 
     def test_variable_slicing(self, device):
         x = torch.arange(0, 16, device=device).view(4, 4)
@@ -475,7 +475,7 @@ class NumpyTests(TestCase):
     def test_empty_fancy_index(self, device):
         # Empty list index creates an empty array
         a = tensor([1, 2, 3], device=device)
-        self.assertEqual(a[[]], torch.tensor([], device=device))
+        self.assertEqualIgnoreType(a[[]], torch.tensor([], device=device))
 
         b = tensor([], device=device).long()
         self.assertEqual(a[[]], torch.tensor([], dtype=torch.long, device=device))
@@ -658,7 +658,7 @@ class NumpyTests(TestCase):
         b = torch.arange(99, -1, -1, device=device).long()
         a[b] = v
         expected = b.double().unsqueeze(1).expand(100, 100)
-        self.assertEqual(a, expected)
+        self.assertEqualIgnoreType(a, expected)
 
 instantiate_device_type_tests(TestIndexing, globals())
 instantiate_device_type_tests(NumpyTests, globals())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38083 [WIP] Combined changes
* #38082 Fixes for test/test_type_promotion.py
* #38076 [WIP] Fix test_nn cases
* #38075 Fix tests that require MKL
* **#38064 fix test/test_indexing.py**
* #38063 Fix test/test_distributions.py
* #34165 Fix test_cuda
* #34163 Fix test_autograd
* #34156 Fix test_jit (partially)
* #34155 Fix test_nn and common_nn
* #34154 AssertEqual now checks tensors dtype

