### PR TITLE
Fix CUDA memory management issues caused by not using PinnedCPUAllocator

### DIFF
--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -380,7 +380,13 @@ void Caffe2UsePinnedCPUAllocator() {
     return;
   }
   VLOG(1) << "Caffe2 gpu: setting CPUAllocator to PinnedCPUAllocator.";
-  SetCPUAllocator(&g_pinned_cpu_alloc);
+
+  // If CUDA is enabled, using CPU allocators other than PinnedCPUAllocator
+  // will cause memory corruptions. Therefore, we need to set the priority
+  // to highest to avoid being overwritten.
+  SetCPUAllocator(
+      &g_pinned_cpu_alloc,
+      std::numeric_limits<uint8_t>::max() /* priority */);
 #endif
 }
 


### PR DESCRIPTION
Summary: Increasing priority for PinnedCPUAllocator to make sure it is set when CUDA is enabled.

Test Plan: buck test mode/dev-nosan //vision/fair/detectron2/tests:test_export_caffe2 -- 'testMaskRCNNGPU \(test_export_caffe2\.TestCaffe2Export\)'

Reviewed By: ppwwyyxx

Differential Revision: D21465835

