### PR TITLE
Macro generate ScalarTypeToCPPType, including all ScalarTypes.

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -70,67 +70,30 @@ enum class ScalarType : int8_t {
 
 namespace impl {
 
-// These are used to map ScalarTypes to C++ types.  Feel free to add more or even
-// macro generate this; the examples here are just those we have found to be
-// necessary.
+// These are used to map ScalarTypes to C++ types.
 
 template <c10::ScalarType N>
 struct ScalarTypeToCPPType;
 
-template<>
-struct ScalarTypeToCPPType<c10::ScalarType::Half> {
-  using type = c10::Half;
-
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
-  // TODO: remove once the bug is fixed.
-  static type t;
+#define SPECIALIZE_ScalarTypeToCPPType(cpp_type, scalar_type)                  \
+template<>                                                                     \
+struct ScalarTypeToCPPType<c10::ScalarType::scalar_type> {                     \
+  using type = cpp_type;                                                       \
+                                                                               \
+  /* This is a workaround for the CUDA bug which prevents */                   \
+  /* ::detail::ScalarTypeToCType<T>::type being used directly due to */        \
+  /* ambiguous reference which can't to be resolved. For some reason it */     \
+  /* cant pick between at::detail and at::cuda::detail. */                     \
+  /* For repro example, please see: */                                         \
+  /* https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba */        \
+  /* TODO: remove once the bug is fixed. */                                    \
+  static type t;                                                               \
 };
 
-template<>
-struct ScalarTypeToCPPType<c10::ScalarType::BFloat16> {
-  using type = c10::BFloat16;
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_ScalarTypeToCPPType)
 
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
-  // TODO: remove once the bug is fixed.
-  static type t;
-};
+#undef SPECIALIZE_ScalarTypeToCPPType
 
-template<>
-struct ScalarTypeToCPPType<c10::ScalarType::Bool> {
-  using type = bool;
-
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
-  // TODO: remove once the bug is fixed.
-  static type t;
-};
-
-template<>
-struct ScalarTypeToCPPType<c10::ScalarType::Byte> {
-  using type = uint8_t;
-
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
-  // TODO: remove once the bug is fixed.
-  static type t;
-};
-
-template<>
-struct ScalarTypeToCPPType<c10::ScalarType::Long> {
-  using type = int64_t;
-
-  // This is a workaround for the CUDA bug which prevents ::detail::ScalarTypeToCType<T>::type being used directly
-  // due to ambiguous reference which can't to be resolved. For some reason it cant pick between at::detail and at::cuda::detail.
-  // For repro example, please see: https://gist.github.com/izdeby/952ae7cf256ddb740a73776d39a7e7ba
-  // TODO: remove once the bug is fixed.
-  static type t;
-};
 
 // These are used to map C++ types to ScalarTypes.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38070 Move (most) generated return statements for TH functions out of the switch.
* #38069 Remove codegen for IntArrayRefStride, which isn't used.
* **#38068 Macro generate ScalarTypeToCPPType, including all ScalarTypes.**
* #37958 Kill resize-ing and zero-ing from codegen.
* #37957 Move resize / zero logic for _thnn_conv_depthwise2d from codegen to native code.
* #37956 Move _thnn_conv2d resize and zero code from codegen to native code.
* #37955 Move resize logic for bmm from codegen to native code.
* #37907 [RESUBMIT] Kill broadcasting from the codegen layer.

Fixes: https://github.com/pytorch/pytorch/issues/34826