### PR TITLE
Remove codegen for IntArrayRefStride, which isn't used.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -300,8 +300,6 @@ CHECKED_CAST = {
             'checked_dense_tensor_unwrap('
             '${arg_name}, "${arg_name}", ${arg_pos}, "${api_name}", ${null_okay}, '
             'DeviceType::${DeviceType}, ScalarType::Long)'),
-    # This is a cast done via direct-construction
-    'IntArrayRefStride': CodeTemplate('at::IntArrayRef ${result_name} = get_intlist_stride_th(${arg_name});'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
     'TensorList': CodeTemplate(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38070 Move (most) generated return statements for TH functions out of the switch.
* **#38069 Remove codegen for IntArrayRefStride, which isn't used.**
* #38068 Macro generate ScalarTypeToCPPType, including all ScalarTypes.
* #37958 Kill resize-ing and zero-ing from codegen.
* #37957 Move resize / zero logic for _thnn_conv_depthwise2d from codegen to native code.
* #37956 Move _thnn_conv2d resize and zero code from codegen to native code.
* #37955 Move resize logic for bmm from codegen to native code.
* #37907 [RESUBMIT] Kill broadcasting from the codegen layer.

