### PR TITLE
Move (most) generated return statements for TH functions out of the switch.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -44,6 +44,7 @@ switch (dispatch_scalar_type) {
     default:
         AT_ERROR("${api_name} not supported on ${Type} for ", dispatch_scalar_type);
 }
+${switch_epilogue}
 """)
 
 LEGACY_TH_DEFINITION_CASE = CodeTemplate("""\
@@ -1438,19 +1439,7 @@ def create_derived(backend_type_env, declarations):
 
                 if ret['kind'] == 'arguments':
                     case_body.extend([call + ';' for call in calls])
-                    arguments_indices = ret['arguments']
-                    arguments = [option['arguments'][argi]
-                                 for argi in arguments_indices]
-                    if len(arguments_indices) == 1:
-                        arg = arguments[0]
-                        case_body.append("return {};".format(arg['name']))
-                    else:
-                        types = [to_return_type(arg, option)['type']
-                                 for arg in arguments]
-                        # TODO: check for move semantics...
-                        names = [arg['name'] for arg in arguments]
-                        case_body.append(CodeTemplate("return std::tuple<${types}>(${names});").substitute(
-                            types=types, names=names))
+                    # return handled later
                 elif ret['kind'] == 'type':
                     assert len(calls) == 1
                     call = calls[0]
@@ -1468,7 +1457,26 @@ def create_derived(backend_type_env, declarations):
                     raise Exception("NYI - return handling")
 
                 cases.append(LEGACY_TH_DEFINITION_CASE.substitute(case_env, case_body=case_body))
-        body.append(LEGACY_TH_DEFINITION_SWITCH_STATEMENT.substitute(env, cases=cases, switch_prologue=switch_prologue))
+        switch_epilogue = []
+        if ret['kind'] == 'arguments':
+            #pass
+            #case_body.extend([call + ';' for call in calls])
+            arguments_indices = ret['arguments']
+            arguments = [option['arguments'][argi]
+                         for argi in arguments_indices]
+            if len(arguments_indices) == 1:
+                arg = arguments[0]
+                switch_epilogue = "return {};".format(arg['name'])
+            else:
+                types = [to_return_type(arg, option)['type']
+                         for arg in arguments]
+                # TODO: check for move semantics...
+                names = [arg['name'] for arg in arguments]
+                switch_epilogue = CodeTemplate("return std::tuple<${types}>(${names});").substitute(
+                    types=types, names=names)
+        body.append(LEGACY_TH_DEFINITION_SWITCH_STATEMENT.substitute(env, cases=cases,
+                                                                     switch_prologue=switch_prologue,
+                                                                     switch_epilogue=switch_epilogue))
         return body
 
     def process_legacy_th_option(option):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38070 Move (most) generated return statements for TH functions out of the switch.**
* #38069 Remove codegen for IntArrayRefStride, which isn't used.
* #38068 Macro generate ScalarTypeToCPPType, including all ScalarTypes.
* #37958 Kill resize-ing and zero-ing from codegen.
* #37957 Move resize / zero logic for _thnn_conv_depthwise2d from codegen to native code.
* #37956 Move _thnn_conv2d resize and zero code from codegen to native code.
* #37955 Move resize logic for bmm from codegen to native code.
* #37907 [RESUBMIT] Kill broadcasting from the codegen layer.

Most of the generated return statements don't depend on the scalar type and it saves ~900 lines of generated code.