### PR TITLE
Fix tests that require MKL

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -29,7 +29,7 @@ from torch.testing._internal.common_utils import TestCase, iter_indices, TEST_NU
     BytesIOContext, skipIfRocm, torch_to_numpy_dtype_dict
 from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, \
-    skipCPUIfNoLapack, skipCPUIfNoMkl, skipCUDAIfNoMagma, skipCUDAIfRocm, skipCUDAIfNotRocm, onlyCUDA, onlyCPU, \
+    skipCPUIfNoLapack, skipCPUIfNoMkl, skipIfNoMkl, skipCUDAIfNoMagma, skipCUDAIfRocm, skipCUDAIfNotRocm, onlyCUDA, onlyCPU, \
     dtypes, dtypesIfCUDA, dtypesIfCPU, deviceCountAtLeast, skipCUDAIf, precisionOverride, \
     PYTORCH_CUDA_MEMCHECK, largeCUDATensorTest, onlyOnCPUAndCUDA
 import torch.backends.quantized
@@ -12738,6 +12738,7 @@ class TestTorchDeviceType(TestCase):
 
     @onlyOnCPUAndCUDA
     @skipIfRocm
+    @skipIfNoMkl
     @dtypes(torch.double)
     def test_istft_of_sine(self, device, dtype):
         def _test(amplitude, L, n):
@@ -12773,6 +12774,7 @@ class TestTorchDeviceType(TestCase):
     @onlyOnCPUAndCUDA
     @skipIfRocm
     @dtypes(torch.double)
+    @skipCPUIfNoMkl
     def test_istft_linearity(self, device, dtype):
         num_trials = 100
 
@@ -12837,6 +12839,7 @@ class TestTorchDeviceType(TestCase):
 
     @onlyOnCPUAndCUDA
     @skipIfRocm
+    @skipCPUIfNoMkl
     def test_batch_istft(self, device):
         original = torch.tensor([
             [[4., 0.], [4., 0.], [4., 0.], [4., 0.], [4., 0.]],

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -604,6 +604,9 @@ def skipCPUIfNoLapack(fn):
 def skipCPUIfNoMkl(fn):
     return skipCPUIf(not TEST_MKL, "PyTorch is built without MKL support")(fn)
 
+# Skips a test if MKL is not available.
+def skipIfNoMkl(fn):
+    return skipIf(not TEST_MKL, "PyTorch is built without MKL support")(fn)
 
 # Skips a test on CUDA if MAGMA is not available.
 def skipCUDAIfNoMagma(fn):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38083 [WIP] Combined changes
* #38082 Fixes for test/test_type_promotion.py
* #38076 [WIP] Fix test_nn cases
* **#38075 Fix tests that require MKL**
* #38064 fix test/test_indexing.py
* #38063 Fix test/test_distributions.py
* #34165 Fix test_cuda
* #34163 Fix test_autograd
* #34156 Fix test_jit (partially)
* #34155 Fix test_nn and common_nn
* #34154 AssertEqual now checks tensors dtype

