### PR TITLE
Fixed buffer update in BatchNorm when track_running_stats is set to False

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6276,6 +6276,23 @@ class TestNN(NNTestCase):
             with self.assertRaises(RuntimeError):
                 F.batch_norm(input, running_mean, running_var, bias=Parameter(torch.rand(size)))
 
+    def test_batchnorm_buffer_update_when_stats_are_not_tracked(self):
+        input_size = (32, 4)
+        # Instantiate BN with buffers that are not None
+        bn = nn.BatchNorm1d(input_size[1], track_running_stats=True)
+        # Use buffers for normalization but don't update them
+        bn.track_running_stats = False
+        # Store initial values
+        num_batches = bn.num_batches_tracked.clone()
+        running_mean = bn.running_mean.clone()
+        running_var = bn.running_var.clone()
+        # Forward random tensor
+        _ = bn(torch.rand(input_size))
+        # Ensure none of the buffers has been updated
+        self.assertTrue(torch.equal(num_batches, bn.num_batches_tracked))
+        self.assertTrue(torch.equal(running_mean, bn.running_mean))
+        self.assertTrue(torch.equal(running_var, bn.running_var))
+
     def test_pairwise_distance(self):
         input1 = torch.randn(4, 4, requires_grad=True)
         input2 = torch.randn(4, 4, requires_grad=True)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -127,8 +127,10 @@ class _BatchNorm(_NormBase):
             bn_training = self.running_mean is None and self.running_var is None
 
         return F.batch_norm(
-            input, self.running_mean, self.running_var, self.weight, self.bias,
-            bn_training, exponential_average_factor, self.eps)
+            input,
+            self.running_mean if not self.training or self.track_running_stats else None,
+            self.running_var if not self.training or self.track_running_stats else None,
+            self.weight, self.bias, bn_training, exponential_average_factor, self.eps)
 
 
 class BatchNorm1d(_BatchNorm):

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -119,7 +119,7 @@ class _BatchNorm(_NormBase):
         # Handle the different cases for the `training` value to forward to F.batch_norm
         if self.track_running_stats:
             # If BN stats are tracked, we want to update them only in training mode when the buffers
-            # are not None. If they are passed when None, they will not be updated by F.batch_norm
+            # are not None. If they are passed as None, they will not be updated by F.batch_norm
             bn_training = self.training
         else:
             # If BN stats are not being tracked, when the buffers are not None,

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -118,12 +118,14 @@ class _BatchNorm(_NormBase):
 
         # Handle the different cases for the `training` value to forward to F.batch_norm
         if self.track_running_stats:
-            # If BN stats are tracked, we want to update them only in training mode when the buffers
-            # are not None. If they are passed as None, they will not be updated by F.batch_norm
+            """If BN stats are tracked, we want to update them only in training mode
+            when the buffers are not None.
+            If they are passed as None, they will not be updated by F.batch_norm"""
             bn_training = self.training
         else:
-            # If BN stats are not being tracked, when the buffers are not None,
-            # we ensure that they will not be updated
+            """If BN stats are not being tracked, when the buffers are not None,
+            we ensure that they will not be updated
+            """
             bn_training = self.running_mean is None and self.running_var is None
 
         return F.batch_norm(

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -179,8 +179,8 @@ class BatchNorm1d(_BatchNorm):
             learnable affine parameters. Default: ``True``
         track_running_stats: a boolean value that when set to ``True``, this
             module tracks the running mean and variance, and when set to ``False``,
-            this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``True``
+            this module does not track such statistics and uses batch statistics instead
+            in both training and eval modes if the running mean and variance are ``None``. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C)` or :math:`(N, C, L)`
@@ -250,8 +250,8 @@ class BatchNorm2d(_BatchNorm):
             learnable affine parameters. Default: ``True``
         track_running_stats: a boolean value that when set to ``True``, this
             module tracks the running mean and variance, and when set to ``False``,
-            this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``True``
+            this module does not track such statistics and uses batch statistics instead
+            in both training and eval modes if the running mean and variance are ``None``. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C, H, W)`
@@ -322,8 +322,8 @@ class BatchNorm3d(_BatchNorm):
             learnable affine parameters. Default: ``True``
         track_running_stats: a boolean value that when set to ``True``, this
             module tracks the running mean and variance, and when set to ``False``,
-            this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``True``
+            this module does not track such statistics and uses batch statistics instead
+            in both training and eval modes if the running mean and variance are ``None``. Default: ``True``
 
     Shape:
         - Input: :math:`(N, C, D, H, W)`
@@ -402,8 +402,8 @@ class SyncBatchNorm(_BatchNorm):
             learnable affine parameters. Default: ``True``
         track_running_stats: a boolean value that when set to ``True``, this
             module tracks the running mean and variance, and when set to ``False``,
-            this module does not track such statistics and always uses batch
-            statistics in both training and eval modes. Default: ``True``
+            this module does not track such statistics and uses batch statistics instead
+            in both training and eval modes if the running mean and variance are ``None``. Default: ``True``
         process_group: synchronization of stats happen within each process group
             individually. Default behavior is synchronization across the whole
             world

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -116,16 +116,17 @@ class _BatchNorm(_NormBase):
                 else:  # use exponential moving average
                     exponential_average_factor = self.momentum
 
-        # Decide whether the mini-batch stats should be used for normalization rather than the buffers
+        """ Decide whether the mini-batch stats should be used for normalization rather than the buffers.
+        Mini-batch stats are used in training mode, and in eval mode when buffers are None.
+        """
         if self.training:
             bn_training = True
         else:
-            # Mini-batch stats are used in eval mode when buffers are None
             bn_training = (self.running_mean is None) and (self.running_var is None)
 
         """Buffers are only updated if they are to be tracked and we are in training mode. Thus they only need to be
         passed when the update should occur (i.e. in training mode when they are tracked), or when buffer stats are
-        used for normalization (i.e. in eval mode when buffers are not None)
+        used for normalization (i.e. in eval mode when buffers are not None).
         """
         return F.batch_norm(
             input,

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -122,8 +122,8 @@ class _BatchNorm(_NormBase):
             # are not None. If they are passed when None, they will not be updated by F.batch_norm
             bn_training = self.training
         else:
-            # If BN stats are not being tracked, when the buffers are not None, we ensure that they will not be
-            # updated
+            # If BN stats are not being tracked, when the buffers are not None,
+            # we ensure that they will not be updated
             bn_training = self.running_mean is None and self.running_var is None
 
         return F.batch_norm(


### PR DESCRIPTION
This PR aims at tackling #37823 by:
- ensuring that buffers will be used for normalization computation but won't be updated, when buffers are not None, and `track_running_stats=False`
- adding a corresponding unittest to ensure expected behaviour

Any feedback is welcome!

_Note: we might want to update the docstrings of  `BatchNorm*d`, feel free to share any suggestion!_
