### PR TITLE
Correctly print 'bool' dtype in Cuda printer.

### DIFF
--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -107,6 +107,8 @@ void CudaPrinter::maybe_insert_sync() {
 
 std::string cudaDtypeCppString(const Dtype& dtype) {
   switch (dtype.scalar_type()) {
+    case ScalarType::Bool:
+      return "bool";
     case ScalarType::Half:
       return "half";
     case ScalarType::Char:
@@ -117,9 +119,9 @@ std::string cudaDtypeCppString(const Dtype& dtype) {
       return "short";
     case ScalarType::Long:
       return "long";
-    default:; /* nothing */
+    default:
+      throw unsupported_dtype();
   }
-  return dtype.ToCppString();
 }
 
 static void print_flat_alloc(std::ostream& os, const Allocate* alloc) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38087 [TensorExpr] Turn on TensorExpr fuser and with fallbacks disabled.
* #38086 Fix segfault in test_fibb.
* **#38085 Correctly print 'bool' dtype in Cuda printer.**
* #38060 Fixes in ir_simplifier and ir_printer.

Differential Revision: [D21468348](https://our.internmc.facebook.com/intern/diff/D21468348)