### PR TITLE
Fix segfault in test_fibb.

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -414,10 +414,14 @@ Tensor* TensorExprKernel::computeFourOperand(
 Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
   switch (v->node()->kind()) {
     case aten::add: {
-      return computeTwoOperandWithAlpha(
-          "aten_add", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
-            return lhs + rhs;
-          });
+      auto add_lambda = [](const ExprHandle& lhs, const ExprHandle& rhs) {
+        return lhs + rhs;
+      };
+      TORCH_INTERNAL_ASSERT(
+          v->node()->inputs().size() == 2 || v->node()->inputs().size() == 3);
+      return (v->node()->inputs().size() > 2)
+          ? computeTwoOperandWithAlpha("aten_add", v, add_lambda)
+          : computeTwoOperand("aten_add", v, add_lambda);
     } break;
 
     case aten::_cast_Float: {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38087 [TensorExpr] Turn on TensorExpr fuser and with fallbacks disabled.
* **#38086 Fix segfault in test_fibb.**
* #38085 Correctly print 'bool' dtype in Cuda printer.
* #38060 Fixes in ir_simplifier and ir_printer.

Differential Revision: [D21468349](https://our.internmc.facebook.com/intern/diff/D21468349)