### PR TITLE
[TorchScript] Explicitly disallow del with more than 1 operand.

### DIFF
--- a/test/jit/test_builtins.py
+++ b/test/jit/test_builtins.py
@@ -74,6 +74,24 @@ class TestBuiltins(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, "hasattr"):
             torch.jit.script(Mod())
 
+    def test_del_multiple_operands(self):
+
+        with self.assertRaisesRegex(torch.jit.frontend.NotSupportedError,
+                                    "with more than one operand"):
+            @torch.jit.script
+            def del_list_multiple_operands(x):
+                # type: (List[int]) -> List[int]
+                del x[0], x[1]
+                return x
+
+        with self.assertRaisesRegex(torch.jit.frontend.NotSupportedError,
+                                    "with more than one operand"):
+            @torch.jit.script
+            def del_dict_multiple_operands(x):
+                # type: (Dict[str, int]) -> Dict[str, int]
+                del x['hi'], x['there']
+                return x
+
 
 class TestTensorBuiltins(JitTestCase):
     def test_tensor_properties(self):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -285,6 +285,11 @@ class StmtBuilder(Builder):
 
     @staticmethod
     def build_Delete(ctx, stmt):
+        if len(stmt.targets) > 1:
+            source_range = ctx.make_range(stmt.lineno, stmt.col_offset,
+                                          stmt.col_offset + len("del"))
+            raise NotSupportedError(
+                source_range, 'del with more than one operand is not supported')
         return Delete(build_expr(ctx, stmt.targets[0]))
 
     @staticmethod


### PR DESCRIPTION
Summary: del in python supports multiple operands, but PyTorch c++ frontend doesn't support that. To be consistent across different frontends, we decided to throw an exception when finding del with multiple operands inside torchscript.

Test Plan: Unit tests in test/jit/test_builtins.py

