### PR TITLE
[TensorExpr] Correctly print dtypes in Cast and Allocate.

### DIFF
--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -227,6 +227,13 @@ void CudaPrinter::visit(const For* v) {
   }
 }
 
+void CudaPrinter::visit(const Cast* v) override {
+  os() << cudaDtypeCppString(v->dtype());
+  os() << "(";
+  v->src_value()->accept(this);
+  os() << ")";
+}
+
 void CudaPrinter::visit(const Intrinsics* v) {
   if (v->op_type() == IntrinsicsOp::kRand) {
     os() << "Uint32ToFloat(" << *rand_func_ << "())";

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -227,7 +227,7 @@ void CudaPrinter::visit(const For* v) {
   }
 }
 
-void CudaPrinter::visit(const Cast* v) override {
+void CudaPrinter::visit(const Cast* v) {
   os() << cudaDtypeCppString(v->dtype());
   os() << "(";
   v->src_value()->accept(this);

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -47,18 +47,7 @@ class CudaPrinter : public IRPrinter {
     }
   }
 
-  void visit(const Cast* v) override {
-    auto dtype = v->dtype();
-    if (dtype == kHalf) {
-      os() << "half";
-    } else {
-      os() << dtype;
-    }
-    os() << "(";
-    v->src_value()->accept(this);
-    os() << ")";
-  }
-
+  void visit(const Cast* v) override;
   void visit(const Intrinsics* v) override;
   void visit(const For* v) override;
 

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -214,7 +214,7 @@ AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_PRINT_VISIT);
 
 void IRPrinter::visit(const Cast* v) {
   auto dtype = v->dtype();
-  os() << dtype << "(";
+  os() << dtype.ToCppString() << "(";
   v->src_value()->accept(this);
   os() << ")";
 }
@@ -426,7 +426,7 @@ void IRPrinter::visit(const Block* v) {
 
 void IRPrinter::visit(const Allocate* v) {
   emitIndent();
-  os() << "Allocate(" << *v->buffer_var() << ", " << v->dtype();
+  os() << "Allocate(" << *v->buffer_var() << ", " << v->dtype().ToCppString();
   os() << ", {";
   const std::vector<const Expr*>& dims = v->dims();
   for (size_t i = 0; i < dims.size(); i++) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38091 [TensorExpr] Correctly print dtypes in Cast and Allocate.**

Differential Revision: [D21469100](https://our.internmc.facebook.com/intern/diff/D21469100)