### PR TITLE
Run QEMU to test that default dispatch doesn't use AVX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,6 +500,27 @@ jobs:
           echo "export PARALLEL_FLAGS=\"${PARALLEL_FLAGS}\"" >> $BASH_ENV
           echo "export id=$id" >> $BASH_ENV
     - run:
+        name: Check for no AVX instruction by default
+        no_output_timeout: "20m"
+        command: |
+          set -e
+          is_vanilla_build() {
+            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-bionic-py3.6-clang9-test" ]; then
+              return 0
+            fi
+            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-xenial-py3.6-gcc-5.4-test" ]; then
+              return 0
+            fi
+            return 1
+          }
+
+          if is_vanilla_build; then
+            echo "apt-get update && apt-get install -y qemu-user" | docker exec -u root -i "$id" bash
+            echo "cd workspace/build; qemu-x86_64 -cpu Broadwell -E ATEN_CPU_CAPABILITY=default ./bin/basic --gtest_filter=BasicTest.BasicTestCPU" | docker exec -u jenkins -i "$id" bash
+          else
+            echo "Skipping for ${BUILD_ENVIRONMENT}"
+          fi
+    - run:
         name: Run tests
         no_output_timeout: "90m"
         command: |

--- a/.circleci/verbatim-sources/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/pytorch-job-specs.yml
@@ -106,6 +106,27 @@ jobs:
           echo "export PARALLEL_FLAGS=\"${PARALLEL_FLAGS}\"" >> $BASH_ENV
           echo "export id=$id" >> $BASH_ENV
     - run:
+        name: Check for no AVX instruction by default
+        no_output_timeout: "20m"
+        command: |
+          set -e
+          is_vanilla_build() {
+            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-bionic-py3.6-clang9-test" ]; then
+              return 0
+            fi
+            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-xenial-py3.6-gcc-5.4-test" ]; then
+              return 0
+            fi
+            return 1
+          }
+
+          if is_vanilla_build; then
+            echo "apt-get update && apt-get install -y qemu-user" | docker exec -u root -i "$id" bash
+            echo "cd workspace/build; qemu-x86_64 -cpu Broadwell -E ATEN_CPU_CAPABILITY=default ./bin/basic --gtest_filter=BasicTest.BasicTestCPU" | docker exec -u jenkins -i "$id" bash
+          else
+            echo "Skipping for ${BUILD_ENVIRONMENT}"
+          fi
+    - run:
         name: Run tests
         no_output_timeout: "90m"
         command: |


### PR DESCRIPTION
`qemu-x86_64 -cpu Haswell` jit compiels x86_64 code to the host OS but lacks support for AVX/AVX2 instruction set emulation, which makes it ideal target for testing instruction set violation (especially via static initializes) even if it runs on CPU physically capable of executing AVX2 instructions.
It's quite easy to validate, that it is the case, by invoking ATen's `basic` cpp test with dispatch set to AVX: `qemu-x86_64 -cpu Broadwell -E ATEN_CPU_CAPABILITY=avx ./bin/basic --gtest_filter=BasicTest.BasicTestCPU`

This PR adds extra step to CircleCI tessuite that executes `basic` test with default CPU capability for `pytorch-linux-[xenial|bionic]-py3.6-...-test` configurations using qemu and validates that it completes successfully. (And fails before https://github.com/pytorch/pytorch/pull/38088 is merged)


Closes https://github.com/pytorch/pytorch/issues/37786