### PR TITLE
Update `custom_fwd` signature

### DIFF
--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -161,9 +161,7 @@ def _cast(value, dtype):
 # this also works:
 #     @custom_fwd(cast_inputs=torch.float)
 #     def forward(...):
-# TODO:  when python 2 support is dropped, change the signature to
-# def custom_fwd(fwd=None, *, cast_inputs=None) with internal changes following the link above.
-def custom_fwd(fwd=None, **kwargs):
+def custom_fwd(fwd=None, *, cast_inputs=None):
     """
     Helper decorator for ``forward`` methods of custom autograd functions (subclasses of
     :class:`torch.autograd.Function`).  See the :ref:`example page<amp-custom-examples>` for more detail.
@@ -175,18 +173,7 @@ def custom_fwd(fwd=None, **kwargs):
             If ``None``, ``forward``'s internal ops execute with the current autocast state.
     """
     if fwd is None:
-        if len(kwargs) == 0:
-            cast_inputs = None
-        else:
-            assert len(kwargs) == 1
-            cast_inputs = kwargs["cast_inputs"]
         return functools.partial(custom_fwd, cast_inputs=cast_inputs)
-
-    if len(kwargs) == 0:
-        cast_inputs = None
-    else:
-        assert len(kwargs) == 1
-        cast_inputs = kwargs["cast_inputs"]
 
     @functools.wraps(fwd)
     def decorate_fwd(*args, **kwargs):


### PR DESCRIPTION
With the reference of https://pytorch.org/blog/pytorch-1-dot-5-released-with-new-and-updated-apis/#python-2-no-longer-supported, this PR updates the signature of `custom_fwd`.

cc: @mcarilli