### PR TITLE
[TensorExpr] Properly handle Bool dtype in several other places.

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -289,7 +289,7 @@ Expr* getImmediateByType(ScalarType immType, T initialVal) {
 #define TYPE_CASE(Type, Name) \
   case ScalarType::Name:      \
     return new Name##Imm(initialVal);
-    AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+    AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
 #undef TYPE_CASE
     default:
       throw unsupported_dtype();
@@ -308,7 +308,7 @@ T immediateAs(const Expr* e) {
   if (const Name##Imm* imm = dynamic_cast<const Name##Imm*>(e)) { \
     return imm->value();                                          \
   }
-  AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+  AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
 #undef TYPE_CASE
   throw unsupported_dtype();
   return 0;
@@ -320,7 +320,7 @@ bool immediateEquals(const Expr* e, T val) {
   if (const Name##Imm* imm = dynamic_cast<const Name##Imm*>(e)) { \
     return imm->value() == val;                                   \
   }
-  AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+  AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
 #undef TYPE_CASE
   throw unsupported_dtype();
   return false;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -95,6 +95,8 @@ ExprHandle TensorExprKernel::constant(const torch::jit::Value* v) {
       return FloatImm::make(static_cast<float>(val.toDouble()));
     } else if (val.isInt()) {
       return IntImm::make(val.toInt());
+    } else if (val.isBool()) {
+      return BoolImm::make(val.toBool());
     } else if (val.isNone()) {
       // This is just a placeholder so we don't throw.  None-handling
       // is operator-specific and should be handled properly in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38077 [TensorExpr] Correctly print 'bool' dtype in Cuda printer.
* #38105 [TensorExpr] Don't include prim::Constant nodes with Tensor type into TE fusion groups - we can't handle them.
* **#38104 [TensorExpr] Properly handle Bool dtype in several other places.**

Differential Revision: [D21471612](https://our.internmc.facebook.com/intern/diff/D21471612)