### PR TITLE
[TensorExpr] Don't include prim::Constant nodes with Tensor type into TE fusion groups - we can't handle them.

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -151,6 +151,10 @@ bool isSupported(Node* node) {
 
 bool canHandle(Node* node, AliasDb& aliasDb) {
   if (node->kind() == prim::Constant) {
+    if (node->output()->type()->cast<TensorType>()) {
+      // TODO: add support for tensor constants.
+      return false;
+    }
     return true;
   }
   if (node->kind() == prim::Loop) {
@@ -158,6 +162,16 @@ bool canHandle(Node* node, AliasDb& aliasDb) {
   }
   if (!allShapesAreKnown(node)) {
     return false;
+  }
+
+  // Don't include nodes whose inputs are tensor constants - we cannot handle
+  // them at the moment.
+  // TODO: actually support tensor constants and remove this.
+  for (torch::jit::Value* input : node->inputs()) {
+    if (input->node()->kind() == prim::Constant &&
+        input->type()->cast<TensorType>()) {
+      return false;
+    }
   }
   return isSupported(node);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38077 [TensorExpr] Correctly print 'bool' dtype in Cuda printer.
* **#38105 [TensorExpr] Don't include prim::Constant nodes with Tensor type into TE fusion groups - we can't handle them.**
* #38104 [TensorExpr] Properly handle Bool dtype in several other places.

Differential Revision: [D21471611](https://our.internmc.facebook.com/intern/diff/D21471611)