### PR TITLE
Automatic update of fbcode/onnx to 79a7e0df7e86e0f32e7a05f563b24a566540c18b

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -96,6 +96,16 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_.*negative_ind.*'  # negative axis is not supported yet
                      '|test_argmax_.*select_last_index.*'  # unsupported case
                      '|test_argmin_.*select_last_index_.*'  # unsupported case
+                     '|test_celu.*'  # unsupported case
+                     '|test_gathernd.*'  # unsupported case
+                     '|test_greater_equal.*'  # unsupported case
+                     '|test_inverse.*'  # unsupported case
+                     '|test_less_equal.*'  # unsupported case
+                     '|test_max_.*'  # unsupported case
+                     '|test_min_.*'  # unsupported case
+                     '|test_mean_square_distance_.*'  # unsupported case
+                     '|test_softmax_cross_entropy.*'  # unsupported case
+                     '|test_unfoldtodepth.*'  # unsupported case
                      '|test_.*gradient.*'  # no support for gradient op in c2-onnx
                      ')')
 


### PR DESCRIPTION
Summary:
Previous import was 807c62cf7e4c96ce49040bcf073b7e4a054f28a5

Included changes:
- **[79a7e0df](https://github.com/onnx/onnx/commit/79a7e0df)**: Fix copy paste error of Min op test case (#2640) <Takeshi Watanabe>
- **[4cd2538d](https://github.com/onnx/onnx/commit/4cd2538d)**: Add a release pipeline for Windows python packages (#2632) <Changming Sun>
- **[e8b33a5a](https://github.com/onnx/onnx/commit/e8b33a5a)**: Adding UnfoldToDepth op [1.7 Release] (#2616) <Negin Raoof>
- **[c2a8d525](https://github.com/onnx/onnx/commit/c2a8d525)**: update docs (#2627) <Ksenija Stanojevic>
- **[22752354](https://github.com/onnx/onnx/commit/22752354)**: Generate tests for MeanSquareDistance and SoftmaxCrossEntropyLoss (#2623) <Jonny Shipton>
- **[602bd622](https://github.com/onnx/onnx/commit/602bd622)**: Add section about external tensor data to IR.md (#2323) <Jonny Shipton>
- **[165c3f3b](https://github.com/onnx/onnx/commit/165c3f3b)**: Add integer support to Clip (#2532) <Jonny Shipton>
- **[a5fabf87](https://github.com/onnx/onnx/commit/a5fabf87)**: Add operators LessOrEqual and GreaterOrEqual (as functions) (#2606) <Jeremy Cochoy>
- **[f1dcdafc](https://github.com/onnx/onnx/commit/f1dcdafc)**: Fix input document of quantized operators (#2117) <Takeshi Watanabe>
- **[43af9b69](https://github.com/onnx/onnx/commit/43af9b69)**: Add reference impl for sequence ops (#2380) <Bowen Bao>
- **[aa50aa12](https://github.com/onnx/onnx/commit/aa50aa12)**: Print value case of TypeProto more friendly (#2422) <Takeshi Watanabe>
- **[2e67bfc3](https://github.com/onnx/onnx/commit/2e67bfc3)**: Fix issue #2436 (#2447) <daquexian>
- **[d27ffc6b](https://github.com/onnx/onnx/commit/d27ffc6b)**: Add support for integer tensors to Min and Max (#2608) <Jonny Shipton>
- **[5cc668af](https://github.com/onnx/onnx/commit/5cc668af)**: Update IR.md to describe training extension. (#2615) <G. Ramalingam>
- **[8c5bf9d4](https://github.com/onnx/onnx/commit/8c5bf9d4)**: Generate node backend tests for celu operator (#2607) <Jonny Shipton>
- **[7b65287e](https://github.com/onnx/onnx/commit/7b65287e)**: Change dtype of dd_da in gradient test to float32 (#2620) <Shinichiro Hamaji>
- **[e91739f2](https://github.com/onnx/onnx/commit/e91739f2)**: Introduce SoftmaxCrossentropy as a loss function (#2573) <Ksenija Stanojevic>
- **[b008ed3a](https://github.com/onnx/onnx/commit/b008ed3a)**: Support gathernd with batch_dim mode (#2585) <wezuo>
- **[d2fe4f22](https://github.com/onnx/onnx/commit/d2fe4f22)**: Introduce MeanSquaredError as Loss Function (#2570) <Ksenija Stanojevic>
- **[10b812a6](https://github.com/onnx/onnx/commit/10b812a6)**: Add support for default attributes within FunctionExpandHelper (#2588) <Ewa Tusień>
- **[3368834c](https://github.com/onnx/onnx/commit/3368834c)**: adding version update content. (#2609) <Ke Zhang>
- **[8873cb02](https://github.com/onnx/onnx/commit/8873cb02)**: Adding Inverse Op (#2578) <Negin Raoof>

Test Plan: ci

Reviewed By: hl475

Differential Revision: D21471424

