### PR TITLE
[JIT] Disallow plain List type annotation without arg

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1097,6 +1097,19 @@ class TestList(JitTestCase):
         self.checkScript(to_list_float_1D, (torch.randn(
             5, dtype=torch.double).cuda(),))
 
+    def test_no_element_type_annotation(self):
+        def fn(x):
+            # type: (torch.Tensor) -> List
+            a: List = x.tolist()
+            return a
+
+        with self.assertRaisesRegex(RuntimeError, r"Unknown type name"):
+            cu = torch.jit.CompilationUnit()
+            cu.define(dedent(inspect.getsource(fn)))
+
+        with self.assertRaisesRegex(RuntimeError, r"Unknown type name"):
+            torch.jit.script(fn)
+
 
 class TestDict(JitTestCase):
     def dict(self):

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -249,7 +249,9 @@ def try_ann_to_type(ann, loc):
     elif is_tuple(ann):
         return TupleType([try_ann_to_type(a, loc) for a in ann.__args__])
     elif is_list(ann):
-        return ListType(try_ann_to_type(ann.__args__[0], loc))
+        elem_type = try_ann_to_type(ann.__args__[0], loc)
+        if elem_type:
+            return ListType(elem_type)
     elif is_dict(ann):
         key = try_ann_to_type(ann.__args__[0], loc)
         value = try_ann_to_type(ann.__args__[1], loc)


### PR DESCRIPTION
**Summary**
This commit detects and prohibits the case in which `typing.List` is
used as an annotation without a type argument (i.e. `typing.List[T]`).
At present, `typing.List` is always assumed to have one argument, and
when it is used without one, `typing.List.__args__[0]` is nonempty and
set to some `typing.TypeVar` instance, which has no JIT type equivalent.
Consequently, trying to convert `typing.List` to a JIT type results in
a `c10::ListType` with `nullptr` for its element type, which can cause
a segmentation fault.

This is fixed by returning a `ListType` from
`jit.annotations.try_ann_to_type` only if the element type is converted
successfully to a JIT type and returning `None` otherwise.

**Test Plan**
I ran the code from the issue (#37530) that reported this problem and also ran some unit tests.

*Before*
```
$ python3 segfault.py 
Segmentation fault (core dumped)
```

*After*
```
$ python3 segfault.py 
Traceback (most recent call last):
...
RuntimeError: 
Unknown type name 'List':
  File "segfault.py", line 9
    @classmethod
    def cat(cls, box_lists: List):
                            ~~~~ <--- HERE
        return cls(torch.cat([x for x in box_lists]))
'Boxes.cat' is being compiled since it was called from 'Boxes'
  File "segfault.py", line 13
def f(t: torch.Tensor):
    b = Boxes(t)
        ~~~~~ <--- HERE
    c = Boxes(torch.tensor([3, 4]))
    return Boxes.cat([b, c])
'Boxes' is being compiled since it was called from 'f'
  File "segfault.py", line 13
def f(t: torch.Tensor):
    b = Boxes(t)
    ~~~~~~~~~~~ <--- HERE
    c = Boxes(torch.tensor([3, 4]))
    return Boxes.cat([b, c])
```

**Fixes**
This pull request fixes #37530.