### PR TITLE
[TensorExpr] Don't include aten::rand_like to TE fusion groups since we can't handle rand+broadcast case yet.

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -803,6 +803,7 @@ class TestFuser(JitTestCase):
 
     @skipIfRocm
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    @unittest.skip("rand_like is not supported yet")
     @skipIfRocm
     def test_rand_cuda(self):
         class M(torch.jit.ScriptModule):
@@ -855,6 +856,7 @@ class TestFuser(JitTestCase):
                                                          "aten::_size_if_not_equal"))
 
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    @unittest.skip("rand_like is not supported yet")
     def test_rand_broadcast_cuda(self):
         def fn_test_rand(x, y):
             r = torch.rand_like(y)
@@ -886,6 +888,7 @@ class TestFuser(JitTestCase):
         self.assertEqual(out[0, :] + torch.zeros(4, 4, device='cuda'), out)
 
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    @unittest.skip("rand_like is not supported yet")
     @skipIfRocm
     def test_rand_diamond(self):
         def fn_test_diamond(x, y):

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -134,7 +134,8 @@ bool isSupported(Node* node) {
     case aten::slice:
     case aten::unsqueeze:
     case aten::frac:
-    case aten::rand_like:
+    // TODO: uncomment once we can handle rand+broadcasts
+    // case aten::rand_like:
     case aten::_sigmoid_backward:
     case aten::_tanh_backward:
     case aten::__and__:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38132 [TensorExpr] Don't include aten::rand_like to TE fusion groups since we can't handle rand+broadcast case yet.**

Differential Revision: [D21479256](https://our.internmc.facebook.com/intern/diff/D21479256)