### PR TITLE
Dont store redundant packed params in dynamic quantized RNN

### DIFF
--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -90,7 +90,6 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh, b_ih, b_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
-        # self._all_weight_values = torch.nn.ModuleList(_all_weight_values)
         self._all_params = ([m.param for m in _all_weight_values])
 
     def _get_name(self):
@@ -255,7 +254,6 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh, bias_ih, bias_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
-        # qRNNBase._all_weight_values = torch.nn.ModuleList(_all_weight_values)
         qRNNBase._all_params = ([m.param for m in _all_weight_values])
 
         return qRNNBase

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -90,8 +90,8 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh, b_ih, b_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
-        self._all_weight_values = torch.nn.ModuleList(_all_weight_values)
-        self._all_params = ([m.param for m in self._all_weight_values])
+        # self._all_weight_values = torch.nn.ModuleList(_all_weight_values)
+        self._all_params = ([m.param for m in _all_weight_values])
 
     def _get_name(self):
         return 'DynamicQuantizedRNN'
@@ -255,8 +255,8 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh, bias_ih, bias_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
-        qRNNBase._all_weight_values = torch.nn.ModuleList(_all_weight_values)
-        qRNNBase._all_params = ([m.param for m in qRNNBase._all_weight_values])
+        # qRNNBase._all_weight_values = torch.nn.ModuleList(_all_weight_values)
+        qRNNBase._all_params = ([m.param for m in _all_weight_values])
 
         return qRNNBase
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38134 Dont store redundant packed params in dynamic quantized RNN**

Differential Revision: [D21479289](https://our.internmc.facebook.com/intern/diff/D21479289)