### PR TITLE
Remove uses of type() part 2

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1327,7 +1327,7 @@ class TestAutograd(TestCase):
 
             @staticmethod
             def backward(ctx, grad_output):
-                return (grad_output * 0).type(torch.DoubleTensor)
+                return (grad_output * 0).to(torch.double)
 
         x = torch.randn(5, 5, requires_grad=True)
         mask = MyFunction.apply(x)
@@ -4182,7 +4182,7 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
     self_variable = f_args_variable[0]
     if isinstance(output_variable, torch.Tensor) and output_variable.requires_grad and self_variable is not None:
         output_variable.backward(randn_like(output_variable))
-        test_case.assertEqual(self_variable.type(), self_variable.grad.type())
+        test_case.assertEqualTypeString(self_variable, self_variable.grad)
         test_case.assertEqual(self_variable.size(), self_variable.grad.size())
 
 # white list for complex

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -323,7 +323,7 @@ def gradcheck(func, inputs, eps=1e-6, atol=1e-5, rtol=1e-3, raise_exception=True
                 i = i.to_dense()
             if not gi.eq(0).all():
                 return fail_test('backward not multiplied by grad_output')
-            if gi.type() != i.type():
+            if gi.dtype != i.dtype or gi.device != i.device or gi.is_sparse != i.is_sparse:
                 return fail_test("grad is incorrect type")
             if gi.size() != i.size():
                 return fail_test('grad is incorrect size')

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -51,10 +51,10 @@ def version():
     return __cudnn_version
 
 
-CUDNN_TENSOR_TYPES = {
-    'torch.cuda.HalfTensor',
-    'torch.cuda.FloatTensor',
-    'torch.cuda.DoubleTensor',
+CUDNN_TENSOR_DTYPES = {
+    torch.half,
+    torch.float,
+    torch.double,
 }
 
 
@@ -66,7 +66,7 @@ def is_available():
 def is_acceptable(tensor):
     if not torch._C._get_cudnn_enabled():
         return False
-    if tensor.type() not in CUDNN_TENSOR_TYPES:
+    if tensor.device.type != 'cuda' or tensor.dtype not in CUDNN_TENSOR_DTYPES:
         return False
     if not is_available():
         warnings.warn(


### PR DESCRIPTION
I'm mostly done with cleaning up test/ folder. There're a bunch of remaining callsites but they're "valid" in testing `type()` functionalities. We cannot remove them until it's fully deprecated. 
Next PR would mainly focus on move some callsites to an internal API. 