### PR TITLE
Migrate OwnerRRef value store to generic torch Future

### DIFF
--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -202,61 +202,24 @@ RRefForkData UserRRef::fork() const {
 //////////////////////////  OwnerRRef  /////////////////////////////////////
 
 const IValue& OwnerRRef::getValue() const {
-  std::unique_lock<std::mutex> lock(mutex_);
-  valueCV_.wait(
-      lock, [this] { return value_.has_value() || error_.has_value(); });
-  if (error_) {
-    std::runtime_error err(*error_);
-    throw err;
-  }
-  return value_.value();
+  future_->wait();
+  return future_->constValue();
 }
 
 bool OwnerRRef::hasValue() const {
-  std::lock_guard<std::mutex> lock(mutex_);
-  return value_.has_value() || error_.has_value();
+  return future_->completed();
 }
 
 std::shared_ptr<FutureIValue> OwnerRRef::getFuture() {
-  std::unique_lock<std::mutex> lock(mutex_);
-  if (future_.get()) {
-    return future_;
-  }
-  future_ = std::make_shared<FutureIValue>();
-  std::shared_ptr<FutureIValue> ret = future_;
-  if (value_.has_value()) {
-    lock.unlock();
-    ret->markCompleted(IValue());
-  } else if (error_.has_value()) {
-    auto err = *error_;
-    lock.unlock();
-    ret->setError(std::move(err));
-  }
-  return ret;
+  return future_;
 }
 
 void OwnerRRef::setValue(IValue&& value) {
-  std::unique_lock<std::mutex> lock(mutex_);
-  value_ = std::move(value);
-  std::shared_ptr<FutureIValue> future;
-  future.swap(future_);
-  lock.unlock();
-  valueCV_.notify_all();
-  if (future.get() && !future->completed()) {
-    future->markCompleted(IValue());
-  }
+  future_->markCompleted(value);
 }
 
 void OwnerRRef::setError(const std::string& error) {
-  std::unique_lock<std::mutex> lock(mutex_);
-  error_ = error;
-  std::shared_ptr<FutureIValue> future;
-  future.swap(future_);
-  lock.unlock();
-  valueCV_.notify_all();
-  if (future.get()) {
-    future->setErrorIfNeeded(error);
-  }
+  future_->setErrorIfNeeded(error);
 }
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -339,7 +339,10 @@ class TORCH_API OwnerRRef final : public RRef {
       TypePtr type,
       c10::optional<IValue> value)
       : RRef(ownerId, rrefId, std::move(type)) {
-    value_ = std::move(value);
+    future_ = std::make_shared<FutureIValue>();
+    if (value.has_value()) {
+      future_->markCompleted(value.value());
+    }
   }
 
   inline bool isOwner() const override {
@@ -371,11 +374,6 @@ class TORCH_API OwnerRRef final : public RRef {
  private:
   friend class RRefContext;
 
-  // See #32608 for dicussion on whether value_ should be merged into future_
-  c10::optional<IValue> value_;
-  c10::optional<std::string> error_;
-  mutable std::mutex mutex_;
-  mutable std::condition_variable valueCV_;
   std::shared_ptr<FutureIValue> future_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38143 Migrate OwnerRRef value store to generic torch Future**

It's a followup of https://github.com/pytorch/pytorch/pull/32556, where an error handling boilerplate code path was added to the FutureMessage callback.

However, I noticed that the FutureMessage could never be set with an error, because the FutureMessage is a member in OwnerRRef,

- OwnerRRef does not have a setError method yet.
- The FutureMessage is only used for signaling
- The value of the RRef is contained in the `value_` field.

With the Future being generalized, it could contain more value types, not limited to Message.

This PR migrates the OwnerRRef value from the `value_` field to the generic Future.

In a later PR, it will be super easy to add a `setError` method for OwnerRRef, which calls `future_.setError(..)`. (I decide to do it later. I think it's better to migrate the call sites together with adding the new `setError` method.)

Also, this fixes the issue pointed out by https://github.com/pytorch/pytorch/pull/31086/files#r422256916.

This PR was submitted as https://github.com/pytorch/pytorch/pull/32608.

Differential Revision: [D5707692](https://our.internmc.facebook.com/intern/diff/D5707692/)