### PR TITLE
Use handlExceptionGILHeld in future.wait pybind

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -342,7 +342,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
                           const auto& value = fut.wait();
                           pybind11::gil_scoped_acquire ag;
                           auto obj = torch::jit::toPyObject(value);
-                          pythonRpcHandler.handleException(obj);
+                          pythonRpcHandler.handleExceptionGILHeld(obj);
                           return obj;
                         },
                         py::call_guard<py::gil_scoped_release>(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38146 Use handlExceptionGILHeld in future.wait pybind**

This code already grabs the GIL, but
PythonRpcHandler::handleException() does too. This would result in the gil
being unnecessarily acquired twice

Differential Revision: [D21480846](https://our.internmc.facebook.com/intern/diff/D21480846/)