### PR TITLE
Use py::pickle in RRef pickling pybind code

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -305,7 +305,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
                     return py::make_tuple();
                   },
                   /* __setstate__ */
-                  [](const py::tuple& /* unused */) {
+                  [](py::tuple /* unused */) { // NOLINT
                     TORCH_CHECK(
                         false,
                         "Can not unpickle rref in python pickler, rref can only be "

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -305,7 +305,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
                     return py::make_tuple();
                   },
                   /* __setstate__ */
-                  [](py::tuple /* unused */) {
+                  [](const py::tuple& /* unused */) {
                     TORCH_CHECK(
                         false,
                         "Can not unpickle rref in python pickler, rref can only be "

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -292,22 +292,31 @@ PyObject* rpc_init(PyObject* /* unused */) {
                       >>> rref.remote().view(1, 4).to_here()  # returns tensor([[1., 1., 1., 1.]])
               )")
           .def(
-              "__getstate__",
-              [](const PyRRef& /* unused */) {
-                TORCH_CHECK(
-                    false,
-                    "Can not pickle rref in python pickler, rref can only be "
-                    "pickled when using RPC");
-              },
-              py::call_guard<py::gil_scoped_release>())
-          .def(
-              "__setstate__",
-              [](const PyRRef& /* unused */, const py::tuple& /* unused */) {
-                TORCH_CHECK(
-                    false,
-                    "Can not unpickle rref in python pickler, rref can only be "
-                    "unpickled when using RPC");
-              },
+              py::pickle(
+                  /* __getstate__ */
+                  [](const PyRRef& /* unused */) {
+                    TORCH_CHECK(
+                        false,
+                        "Can not pickle rref in python pickler, rref can only be "
+                        "pickled when using RPC");
+                    // Note that this return has no meaning since we always
+                    // throw, it's only here to satisfy Pybind API's
+                    // requirement.
+                    return py::make_tuple();
+                  },
+                  /* __setstate__ */
+                  [](py::tuple /* unused */) {
+                    TORCH_CHECK(
+                        false,
+                        "Can not unpickle rref in python pickler, rref can only be "
+                        "unpickled when using RPC");
+                    // Note that this return has no meaning since we always
+                    // throw, it's only here to satisfy PyBind's API
+                    // requirement.
+                    return PyRRef(
+                        py::cast<py::none>(Py_None),
+                        py::cast<py::none>(Py_None));
+                  }),
               py::call_guard<py::gil_scoped_release>())
           .def(
               "_serialize",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38147 Use py::pickle in RRef pickling pybind code**

We're seeing many warnings of the form:
```
/home/rvarm1/pytorch/torch/distributed/rpc/__init__.py:14: FutureWarning:
pybind11-bound class 'torch.distributed.rpc.R
Ref' is using an old-style placement-new '__setstate__' which has been
deprecated. See the upgrade guide in pybind11's
docs. This message is only visible when compiled in debug mode.
```
in test logs, it turns out this is because pybind recommends using `py::pickle`
instead of manually defining getstate and setstate (see https://github.com/pybind/pybind11/blob/master/docs/upgrade.rst#id5). Changing to use pybind's
recommendation will silence these warnings. We maintain the same functionality which is to throw in all cases if this is called

Note that return types need to be added to the function to satisfy the contract
pybind expects, but they don't return anything since we TORCH_CHECK(false) in
all cases.

Differential Revision: [D21446260](https://our.internmc.facebook.com/intern/diff/D21446260/)