### PR TITLE
[pytorch] expose __ldg(const Half* ptr) to Clang in host mode

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -45,7 +45,8 @@ inline C10_HOST_DEVICE Half::operator __half() const {
 
 // CUDA intrinsics
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 350)
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 350)) || \
+    (defined(__clang__) && defined(__CUDA__))
 inline __device__ Half __ldg(const Half* ptr) {
     return __ldg(reinterpret_cast<const __half*>(ptr));
 }


### PR DESCRIPTION
Summary: We need to expose this method to Clang unconditionally when building CUDA, otherwise it would error on device code calling `__ldg` with `Half*`.

Test Plan:
```
buck build -c fbcode.caffe2_use_mpi=1 -c fbcode.cuda_use_clang=true mode/opt //experimental/training_supercomputer/trainer/hpc_pt:trainer
```

Differential Revision: D21481297

