### PR TITLE
[quant] Disable qnnpack test when TSAN is enabled

### DIFF
--- a/torch/testing/_internal/common_quantized.py
+++ b/torch/testing/_internal/common_quantized.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import torch
 from contextlib import contextmanager
-from torch.testing._internal.common_utils import TEST_WITH_ASAN, TEST_WITH_UBSAN, IS_PPC, IS_MACOS, IS_WINDOWS
+from torch.testing._internal.common_utils import TEST_WITH_ASAN, TEST_WITH_TSAN, TEST_WITH_UBSAN, IS_PPC, IS_MACOS, IS_WINDOWS
 
 supported_qengines = torch.backends.quantized.supported_engines
 supported_qengines.remove('none')
@@ -13,7 +13,7 @@ supported_qengines.remove('none')
 # QNNPACK is not supported on PPC
 # QNNPACK throws ASAN heap-buffer-overflow error.
 if 'qnnpack' in supported_qengines:
-    if IS_PPC or TEST_WITH_ASAN or TEST_WITH_UBSAN or IS_MACOS or IS_WINDOWS:
+    if IS_PPC or TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN or IS_MACOS or IS_WINDOWS:
         supported_qengines.remove('qnnpack')
 
 """Computes the output shape given convolution parameters."""


### PR DESCRIPTION
Summary: Test fails when opt-tsan is enabled

Test Plan: buck test mode/opt-tsan //caffe2/test:quantization -- 'test_single_linear_dynamic \(quantization\.test_quantize\.TestGraphModePostTrainingStatic\)' --run-disabled

Reviewed By: vkuzo

Differential Revision: D21482799

