### PR TITLE
explain redundant branch/tag filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2056,6 +2056,11 @@ workflows:
       - setup:
           # Run this job on everything since it is
           # the dependency for everything.
+          #
+          # Note that these include-everything glob patterns are required; it is not equivalent to
+          # omit the filters entirely because tags are not included by default.
+          # And if you specify tags then you also need to specify branches since
+          # specifying tags disincludes branches by default.
           filters:
             tags:
               only: /.*/

--- a/.circleci/verbatim-sources/workflows-setup-job.yml
+++ b/.circleci/verbatim-sources/workflows-setup-job.yml
@@ -1,6 +1,11 @@
       - setup:
           # Run this job on everything since it is
           # the dependency for everything.
+          #
+          # Note that these include-everything glob patterns are required; it is not equivalent to
+          # omit the filters entirely because tags are not included by default.
+          # And if you specify tags then you also need to specify branches since
+          # specifying tags disincludes branches by default.
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
Add a comment because at first glance there doesn't seem to be any need to specify branch and tag filters, just to make them glob to everything.