### PR TITLE
[TensorExpr] Distinguish aten::max reduction op from aten::max elementwise op and only fuse the latter.

### DIFF
--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -524,6 +524,42 @@ class TestTensorExprFuser(BaseTestClass):
         )
 
 
+    def test_min_max_reduction(self):
+        def test(x):
+            return torch.min(x) + torch.max(x)
+
+        traced = torch.jit.trace(test, (torch.zeros(1024)))
+        a = 8.0 * torch.rand(1024)
+        np.testing.assert_allclose(traced(a), np.amin(a.numpy()) + np.amax(a.numpy()))
+
+
+    def test_min_max_reduction2(self):
+        def test(x):
+            return x.min() + x.max()
+
+        traced = torch.jit.trace(test, (torch.zeros(1024)))
+        a = 8.0 * torch.rand(1024)
+        np.testing.assert_allclose(traced(a), np.amin(a.numpy()) + np.amax(a.numpy()))
+
+
+    def test_min_max_reduction_dim1(self):
+        def test(x):
+            return torch.min(x, 1)[0] + torch.max(x, 1)[0]
+
+        traced = torch.jit.trace(test, (torch.zeros(16, 16)))
+        a = 8.0 * torch.rand(16, 16)
+        np.testing.assert_allclose(traced(a), np.amin(a.numpy(), axis=1) + np.amax(a.numpy(), axis=1))
+
+
+    def test_min_max_reduction_dim1_2(self):
+        def test(x):
+            return torch.min(x, 1)
+
+        traced = torch.jit.trace(test, (torch.zeros(16, 16)))
+        a = 8.0 * torch.rand(16, 16)
+        np.testing.assert_allclose(traced(a)[0], np.amin(a.numpy(), axis=1))
+
+
     def test_clamp(self):
         def test(x):
             return torch.clamp(x + 3.0, 0.0, 6.0)

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -90,8 +90,6 @@ bool isSupported(Node* node) {
     case aten::gt:
     case aten::le:
     case aten::lt:
-    case aten::min:
-    case aten::max:
     case aten::pow:
     case aten::clamp:
     case aten::lerp:
@@ -143,6 +141,17 @@ bool isSupported(Node* node) {
     case aten::__lshift__:
     case aten::__rshift__:
     case aten::where:
+      return true;
+    // Operators that can be both elementwise or reductions:
+    case aten::min:
+    case aten::max:
+      if (node->inputs().size() != 2) {
+        return false;
+      }
+      if (!node->inputs()[0]->type()->cast<TensorType>() ||
+          !node->inputs()[1]->type()->cast<TensorType>()) {
+        return false;
+      }
       return true;
     default:
       return false;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38171 [TensorExpr] Distinguish aten::max reduction op from aten::max elementwise op and only fuse the latter.**

Differential Revision: [D21487389](https://our.internmc.facebook.com/intern/diff/D21487389)