### PR TITLE
[TensorExpr] Add print functions for Tensor and Function.

### DIFF
--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -699,7 +699,6 @@ void testSimplifyMuls() {
     // But not for Float since nan * 0 = nan.
     ExprHandle body = ExprHandle(1.f) * (x * ExprHandle(0.f));
     ExprHandle simplified = IRSimplifier::simplify(body);
-    std::cout << simplified << "\n";
 
     IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
     IS_NODE_WITH_NAME(Cast, mul->lhs(), cast);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -1,7 +1,9 @@
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
 
+#include <torch/csrc/jit/tensorexpr/function.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/reduction.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
 
 namespace torch {
 namespace jit {
@@ -520,6 +522,16 @@ std::ostream& operator<<(std::ostream& stream, const Stmt& stmt) {
   return stream;
 }
 
+std::ostream& operator<<(std::ostream& stream, const Tensor& t) {
+  stream << std::to_string(&t);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, const Function& f) {
+  stream << std::to_string(&f);
+  return stream;
+}
+
 void print(const Expr* expr) {
   if (expr) {
     IRPrinter p(std::cout);
@@ -538,6 +550,14 @@ void print(const Stmt* stmt) {
   }
 }
 
+void print(const Tensor* t) {
+  std::cout << std::to_string(t);
+}
+
+void print(const Function* f) {
+  std::cout << std::to_string(f);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch
@@ -552,6 +572,42 @@ std::string to_string(const Expr* expr) {
 std::string to_string(const Stmt* stmt) {
   std::ostringstream oss;
   oss << *stmt;
+  return oss.str();
+}
+
+std::string to_string(const Tensor* t) {
+  if (!t) {
+    return "(null tensor)\n";
+  }
+  std::ostringstream oss;
+  oss << "Tensor " << t->buf()->name_hint() << "(";
+  for (size_t i = 0; i < t->ndim(); i++) {
+    if (i != 0) {
+      oss << ", ";
+    }
+    oss << *t->arg(i) << "[" << *t->dim(i) << "]";
+  }
+  oss << ") = " << *t->body() << "\n";
+  return oss.str();
+}
+
+std::string to_string(const Function* f) {
+  if (!f) {
+    return "(null function)\n";
+  }
+  std::ostringstream oss;
+  oss << "Function F(";
+  for (size_t i = 0; i < f->ndim(); i++) {
+    if (i != 0) {
+      oss << ", ";
+    }
+    oss << *f->arg(i) << "[" << *f->dim(i) << "]";
+  }
+  oss << ") {\n";
+  for (size_t i = 0; i < f->bodies().size(); i++) {
+    oss << "  " << *f->func_var(i) << " = " << *f->body(i) << "\n";
+  }
+  oss << "}\n";
   return oss.str();
 }
 } // namespace std

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -10,6 +10,9 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+class Tensor;
+class Function;
+
 class TORCH_API IRPrinter : public IRVisitor {
  public:
   explicit IRPrinter(std::ostream& os) : printer_os_(this, os) {}
@@ -87,10 +90,13 @@ class TORCH_API IRPrinter : public IRVisitor {
 TORCH_API std::ostream& operator<<(std::ostream& stream, const Expr&);
 TORCH_API std::ostream& operator<<(std::ostream& stream, const ExprHandle&);
 TORCH_API std::ostream& operator<<(std::ostream& stream, const Stmt&);
-TORCH_API std::ostream& operator<<(std::ostream& stream, Stmt*);
+TORCH_API std::ostream& operator<<(std::ostream& stream, const Tensor&);
+TORCH_API std::ostream& operator<<(std::ostream& stream, const Function&);
 
 TORCH_API void print(const Expr* expr);
 TORCH_API void print(const Stmt* stmt);
+TORCH_API void print(const Tensor* t);
+TORCH_API void print(const Function* f);
 
 } // namespace tensorexpr
 } // namespace jit
@@ -99,8 +105,12 @@ TORCH_API void print(const Stmt* stmt);
 namespace std {
 
 using torch::jit::tensorexpr::Expr;
+using torch::jit::tensorexpr::Function;
 using torch::jit::tensorexpr::Stmt;
+using torch::jit::tensorexpr::Tensor;
 
 TORCH_API std::string to_string(const Expr* expr);
 TORCH_API std::string to_string(const Stmt* stmt);
+TORCH_API std::string to_string(const Tensor* t);
+TORCH_API std::string to_string(const Function* f);
 } // namespace std

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -12,7 +12,7 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
-class Tensor {
+class Tensor : KernelScopedObject {
  public:
   Function* function() const {
     return function_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38175 [TensorExpr] Add print functions for Tensor and Function.**

Also, make Tensor derived from KernelScopedObject - we must have missed
that originally.

Differential Revision: [D21489136](https://our.internmc.facebook.com/intern/diff/D21489136)