### PR TITLE
Replace instance of  assertEqualIgnoreType

### DIFF
--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -177,8 +177,7 @@ class TestTypePromotion(TestCase):
         d = torch.tensor([1, 1, 1, 1], dtype=torch.double, device=device)
         torch.add(f, f, out=d)
         self.assertEqual(d.dtype, torch.double)
-        # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-        self.assertEqualIgnoreType(f + f, d)
+        self.assertEqual((f + f).to(torch.double), d)
 
     @float_double_default_dtype
     def test_mixed_type_backward(self, device):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38195 Replace instance of  assertEqualIgnoreType**
* #38152 Tests: Remove exact_dtype from test classes
* #38124 Remove asserEqualIgnoreType from test_complex
* #38123 Fix tests for non MKL enviroments
* #38103 assertEqual now requires matching dtypes
* #38102 Replacing assertEqual with assertEqualIgnoreType wherever types missmatch
* #34154 Introduce assertEqualIgnoreType to prevent type checking of assertEqual

Differential Revision: [D21491497](https://our.internmc.facebook.com/intern/diff/D21491497)