### PR TITLE
Reduction support

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -422,6 +422,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/tensor_view.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/transform_iter.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/transform_replay.cpp
+      ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/transform_rfactor.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/type.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/utils.cpp
       ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/register_interface.cpp

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -710,7 +710,7 @@ void testGPU_FusionCodeGen() {
   at::Tensor output = at::empty({16, 8, 8}, options);
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
-  torch::jit::fuser::cuda::runTestKernel(prog, {}, {}, {output}, {});
+  torch::jit::fuser::cuda::runTestKernel(&prog, {}, {output});
 
   at::Tensor output_ref = at::zeros_like(output, options);
   output_ref = output_ref + 0.0 + 1.0 + 2.0 + 3.0;
@@ -759,7 +759,7 @@ void testGPU_FusionCodeGen2() {
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   torch::jit::fuser::cuda::runTestKernel(
-      prog, {input1, input2}, {}, {output}, {});
+      &prog, {input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -821,7 +821,7 @@ void testGPU_FusionSimplePWise() {
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   torch::jit::fuser::cuda::runTestKernel(
-      prog, {input1, input2}, {}, {output}, {});
+      &prog, {input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -879,7 +879,7 @@ void testGPU_FusionExecKernel() {
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   torch::jit::fuser::cuda::runTestKernel(
-      prog, {input1, input2}, {}, {output}, {});
+      &prog, {input1, input2}, {output});
 
   at::Tensor check = at::full({1, 128}, 4, options);
   ;
@@ -979,7 +979,7 @@ void testGPU_FusionAdvancedComputeAt() {
     prog.block(128);
     torch::jit::fuser::cuda::compileKernel(fusion, &prog);
     torch::jit::fuser::cuda::runTestKernel(
-        prog, {t0}, {}, {kernel_tv5, kernel_tv6}, {});
+        &prog, {t0}, {kernel_tv5, kernel_tv6});
 
     TORCH_INTERNAL_ASSERT(at::allclose(kernel_tv5, t5));
     TORCH_INTERNAL_ASSERT(at::allclose(kernel_tv6, t6));
@@ -1062,7 +1062,7 @@ void testGPU_FusionAdvancedComputeAt() {
     prog.block(128);
     torch::jit::fuser::cuda::compileKernel(fusion, &prog);
     torch::jit::fuser::cuda::runTestKernel(
-        prog, {t0}, {}, {kernel_tv5, kernel_tv6}, {});
+        &prog, {t0}, {kernel_tv5, kernel_tv6});
 
     GPULower gpulw(&fusion);
     std::stringstream cdg;
@@ -1130,7 +1130,7 @@ void testGPU_FusionAdvancedComputeAt() {
     prog.block(128);
     torch::jit::fuser::cuda::compileKernel(fusion, &prog);
     torch::jit::fuser::cuda::runTestKernel(
-        prog, {t0, t1}, {}, {kernel_tv3}, {});
+        &prog, {t0, t1}, {kernel_tv3});
 
     GPULower gpulw(&fusion);
     std::stringstream cdg;
@@ -1210,7 +1210,7 @@ void testGPU_FusionAdvancedComputeAt() {
     prog.block(128);
     torch::jit::fuser::cuda::compileKernel(fusion, &prog);
     torch::jit::fuser::cuda::runTestKernel(
-        prog, {t0, t1, t2, t3}, {}, {kernel_tv6}, {});
+        &prog, {t0, t1, t2, t3}, {kernel_tv6});
 
     GPULower gpulw(&fusion);
     std::stringstream cdg;
@@ -1300,8 +1300,18 @@ void testGPU_FusionScalarInputs() {
   prog.grid(blocks);
   prog.block(128);
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
+
   torch::jit::fuser::cuda::runTestKernel(
-      prog, {t0, t1, t2, t3}, {fl0, fl1, fl2, fl3}, {kernel_tv4}, {});
+      &prog,
+      {at::Scalar(fl0),
+       at::Scalar(fl1),
+       at::Scalar(fl2),
+       at::Scalar(fl3),
+       t0,
+       t1,
+       t2,
+       t3},
+      {kernel_tv4});
 
   GPULower gpulw(&fusion);
   std::stringstream cdg;
@@ -1363,7 +1373,7 @@ void testGPU_FusionLoopUnroll() {
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   torch::jit::fuser::cuda::runTestKernel(
-      prog, {input1, input2}, {}, {output}, {});
+      &prog, {input1, input2}, {output});
 
   at::Tensor check = at::full({inp_size}, 4, options);
 

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -747,8 +747,7 @@ void testGPU_FusionCodeGen2() {
   at::Tensor output = at::empty_like(input1);
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
-  torch::jit::fuser::cuda::runTestKernel(
-      &prog, {input1, input2}, {output});
+  torch::jit::fuser::cuda::runTestKernel(&prog, {input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -809,8 +808,7 @@ void testGPU_FusionSimplePWise() {
   at::Tensor output = at::empty_like(input1);
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
-  torch::jit::fuser::cuda::runTestKernel(
-      &prog, {input1, input2}, {output});
+  torch::jit::fuser::cuda::runTestKernel(&prog, {input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -867,14 +865,12 @@ void testGPU_FusionExecKernel() {
   at::Tensor output = at::empty_like(input1);
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
-  torch::jit::fuser::cuda::runTestKernel(
-      &prog, {input1, input2}, {output});
+  torch::jit::fuser::cuda::runTestKernel(&prog, {input1, input2}, {output});
 
   at::Tensor check = at::full({1, 128}, 4, options);
   ;
   TORCH_CHECK(output.equal(check));
 }
-
 
 int ceilDiv_(int a, int b) {
   return (a + b - 1) / b;
@@ -1118,8 +1114,7 @@ void testGPU_FusionAdvancedComputeAt() {
     prog.grid(blocks);
     prog.block(128);
     torch::jit::fuser::cuda::compileKernel(fusion, &prog);
-    torch::jit::fuser::cuda::runTestKernel(
-        &prog, {t0, t1}, {kernel_tv3});
+    torch::jit::fuser::cuda::runTestKernel(&prog, {t0, t1}, {kernel_tv3});
 
     GPULower gpulw(&fusion);
     std::stringstream cdg;
@@ -1290,7 +1285,7 @@ void testGPU_FusionScalarInputs() {
   prog.block(128);
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
   at::Scalar test(fl0);
-  
+
   torch::jit::fuser::cuda::runTestKernel(
       &prog,
       {t0,
@@ -1298,8 +1293,7 @@ void testGPU_FusionScalarInputs() {
        at::Scalar(fl0),
        at::Scalar(fl1),
        at::Scalar(fl2),
-       at::Scalar(fl3)
-       },
+       at::Scalar(fl3)},
       {kernel_tv4});
 
   GPULower gpulw(&fusion);
@@ -1361,13 +1355,11 @@ void testGPU_FusionLoopUnroll() {
   at::Tensor output = at::empty_like(input1);
 
   torch::jit::fuser::cuda::compileKernel(fusion, &prog);
-  torch::jit::fuser::cuda::runTestKernel(
-      &prog, {input1, input2}, {output});
+  torch::jit::fuser::cuda::runTestKernel(&prog, {input1, input2}, {output});
 
   at::Tensor check = at::full({inp_size}, 4, options);
 
   TORCH_CHECK(output.equal(check));
-
 }
 
 void testGPU_FusionForLoop() {
@@ -1908,7 +1900,6 @@ void testGPU_FusionCastOps() {
       "\n");
 }
 
-
 // We want split/merge/reorder all tested both on and off rfactor domains, also
 // want compute at into the rfactor domain, and into its consumer
 void testGPU_FusionRFactorReplay() {
@@ -1997,7 +1988,7 @@ void testGPU_FusionRFactorReplay() {
               dom2.end(),
               [](IterDomain* id) { return id->isReduction(); }),
       "Error in rFactor, there seems to be something wrong in root domain.");
-  }
+}
 
 void testGPU_FusionSimpleReduction() {
   Fusion fusion;
@@ -2055,7 +2046,6 @@ void testGPU_FusionSimpleReduction() {
   // GPULower lower(&fusion);
   // lower.printKernel(std::cout);
 }
-
 
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -103,7 +103,6 @@ namespace jit {
   _(GPU_FusionDispatch)          \
   _(GPU_FusionSimpleArith)       \
   _(GPU_FusionSimpleTypePromote) \
-  _(GPU_FusionCastOp)            \
   _(GPU_FusionMutator)           \
   _(GPU_FusionRegister)          \
   _(GPU_FusionTopoSort)          \
@@ -126,7 +125,6 @@ namespace jit {
   _(GPU_FusionBinaryOps)         \
   _(GPU_FusionTernaryOps)        \
   _(GPU_FusionCompoundOps)       \
-  _(GPU_FusionCastOps)           \
   _(GPU_FusionAdvancedComputeAt) \
   _(GPU_FusionScalarInputs)      \
   _(GPU_FusionRFactorReplay)     \

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -103,6 +103,7 @@ namespace jit {
   _(GPU_FusionDispatch)          \
   _(GPU_FusionSimpleArith)       \
   _(GPU_FusionSimpleTypePromote) \
+  _(GPU_FusionCastOp)            \
   _(GPU_FusionMutator)           \
   _(GPU_FusionRegister)          \
   _(GPU_FusionTopoSort)          \
@@ -113,10 +114,10 @@ namespace jit {
   _(GPU_FusionTVReorder)         \
   _(GPU_FusionEquality)          \
   _(GPU_FusionReplaceAll)        \
+  _(GPU_FusionParser)            \
   _(GPU_FusionDependency)        \
   _(GPU_FusionCodeGen)           \
   _(GPU_FusionCodeGen2)          \
-  _(GPU_FusionCodeGen3)          \
   _(GPU_FusionSimplePWise)       \
   _(GPU_FusionExecKernel)        \
   _(GPU_FusionForLoop)           \
@@ -125,8 +126,11 @@ namespace jit {
   _(GPU_FusionBinaryOps)         \
   _(GPU_FusionTernaryOps)        \
   _(GPU_FusionCompoundOps)       \
-  _(GPU_FusionCastOps)
-//_(GPU_FusionCodeGen4)
+  _(GPU_FusionCastOps)           \
+  _(GPU_FusionAdvancedComputeAt) \
+  _(GPU_FusionScalarInputs)      \
+  _(GPU_FusionRFactorReplay)     \
+  _(GPU_FusionSimpleReduction)
 #else
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -280,6 +280,7 @@ libtorch_cuda_sources = [
     "torch/csrc/jit/codegen/cuda/tensor_view.cpp",
     "torch/csrc/jit/codegen/cuda/transform_iter.cpp",
     "torch/csrc/jit/codegen/cuda/transform_replay.cpp",
+    "torch/csrc/jit/codegen/cuda/transform_rfactor.cpp",
     "torch/csrc/jit/codegen/cuda/type.cpp",
     "torch/csrc/jit/codegen/cuda/utils.cpp",
     "torch/csrc/jit/codegen/cuda/register_interface.cpp",

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -1,6 +1,6 @@
 #include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <c10/util/Exception.h>
-#include <torch/csrc/jit/codegen/cuda/ir_internal_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -192,7 +192,7 @@ Val* reductionOp(
     if (axis < 0)
       axis += int(tv->nDims());
 
-  TORCH_CHECK(
+    TORCH_CHECK(
         axis >= 0 && axis < tv->nDims(),
         "Reduction on invalid axis, recieved: ",
         axis,
@@ -201,7 +201,7 @@ Val* reductionOp(
         " dims.");
 
     uint_axes.push_back((unsigned int)axis);
-}
+  }
 
   Val* out = tv->newForReduction(uint_axes);
   if (init->getDataType().value() != v1->getDataType().value())

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -96,14 +96,6 @@ TORCH_CUDA_API Val* castOp(DataType dtype, Val* v1) {
     return v1;
 
   auto uop_type = cast_type(v1->getDataType().value(), dtype);
-  if (uop_type == c10::nullopt) {
-    TORCH_CHECK(
-        false,
-        "Illegal Cast value from  DataType: ",
-        v1->getDataType().value(),
-        " to DataType: ",
-        dtype);
-  }
 
   Val* out = newValLike(v1, dtype);
   Statement* expr = new UnaryOp(uop_type.value(), out, v1);

--- a/torch/csrc/jit/codegen/cuda/arith.h
+++ b/torch/csrc/jit/codegen/cuda/arith.h
@@ -32,6 +32,15 @@ TORCH_CUDA_API Val* unaryOp(UnaryOpType type, Val* v1);
 // Mod, CeilDiv, and LT are considered Int only output operations for now.
 TORCH_CUDA_API Val* binaryOp(BinaryOpType type, Val* v1, Val* v2);
 
+// Perform a reduction operation on v1, initial value for reduction is init,
+// reduces across axes, and reduction operation defined by BinaryOp.
+TORCH_CUDA_API Val* reductionOp(
+    BinaryOpType reduction_op_type,
+    std::vector<int> axes,
+    Val* init,
+    Val* v1);
+
+// BINARY OPAERATIONS
 TORCH_CUDA_API Val* add(Val* v1, Val* v2);
 TORCH_CUDA_API Val* sub(Val* v1, Val* v2);
 TORCH_CUDA_API Val* mul(Val* v1, Val* v2);
@@ -41,12 +50,17 @@ TORCH_CUDA_API Val* lt(Val* v1, Val* v2);
 TORCH_CUDA_API Val* ceilDiv(Val* v1, Val* v2);
 TORCH_CUDA_API Val* andOp(Val* v1, Val* v2);
 
+// REDUCTION OPERATIONS
+TORCH_CUDA_API Val* sum(Val* v1, std::vector<int> reduction_axes);
+
+// COMPOUND OPERATIONS
 TORCH_CUDA_API Val* add_alpha(Val* v1, Val* v2, Val* s);
 TORCH_CUDA_API Val* sub_alpha(Val* v1, Val* v2, Val* s);
 TORCH_CUDA_API Val* lerp(Val* start, Val* end, Val* weight);
 TORCH_CUDA_API Val* addcmul(Val* v1, Val* v2, Val* v3, Val* s);
-
 TORCH_CUDA_API Val* where(Val* c, Val* v1, Val* v2);
+
+// TERNARY OPERATIONS
 TORCH_CUDA_API Val* threshold(Val* in, Val* thresh, Val* value);
 TORCH_CUDA_API Val* clamp(Val* in, Val* min_val, Val* max_val);
 

--- a/torch/csrc/jit/codegen/cuda/dispatch.cpp
+++ b/torch/csrc/jit/codegen/cuda/dispatch.cpp
@@ -101,6 +101,9 @@ void Expr::dispatch(T handler, Expr* expr) {
     case ExprType::TernaryOp:
       ptr(handler)->handle(static_cast<TernaryOp*>(expr));
       return;
+    case ExprType::ReductionOp:
+      ptr(handler)->handle(static_cast<ReductionOp*>(expr));
+      return;
     case ExprType::ForLoop:
       ptr(handler)->handle(static_cast<ForLoop*>(expr));
       return;
@@ -187,6 +190,9 @@ void Expr::constDispatch(T handler, const Expr* const expr) {
     case ExprType::TernaryOp:
       ptr(handler)->handle(static_cast<const TernaryOp* const>(expr));
       return;
+    case ExprType::ReductionOp:
+      ptr(handler)->handle(static_cast<const ReductionOp* const>(expr));
+      return;
     case ExprType::ForLoop:
       ptr(handler)->handle(static_cast<const ForLoop* const>(expr));
       return;
@@ -269,6 +275,8 @@ Statement* Expr::mutatorDispatch(T mutator, Expr* expr) {
       return ptr(mutator)->mutate(static_cast<BinaryOp*>(expr));
     case ExprType::TernaryOp:
       return ptr(mutator)->mutate(static_cast<TernaryOp*>(expr));
+    case ExprType::ReductionOp:
+      return ptr(mutator)->mutate(static_cast<ReductionOp*>(expr));
     case ExprType::ForLoop:
       return ptr(mutator)->mutate(static_cast<ForLoop*>(expr));
     case ExprType::IfThenElse:

--- a/torch/csrc/jit/codegen/cuda/dispatch.h
+++ b/torch/csrc/jit/codegen/cuda/dispatch.h
@@ -73,6 +73,7 @@ struct Reorder;
 struct UnaryOp;
 struct BinaryOp;
 struct TernaryOp;
+struct ReductionOp;
 struct ForLoop;
 struct IfThenElse;
 struct Allocate;
@@ -114,6 +115,7 @@ struct TORCH_CUDA_API OptOutConstDispatch {
   virtual void handle(const UnaryOp* const) {}
   virtual void handle(const BinaryOp* const) {}
   virtual void handle(const TernaryOp* const) {}
+  virtual void handle(const ReductionOp* const) {}
   virtual void handle(const ForLoop* const) {}
   virtual void handle(const IfThenElse* const) {}
   virtual void handle(const Allocate* const) {}
@@ -152,6 +154,7 @@ struct TORCH_CUDA_API OptOutDispatch {
   virtual void handle(UnaryOp*) {}
   virtual void handle(BinaryOp*) {}
   virtual void handle(TernaryOp*) {}
+  virtual void handle(ReductionOp*) {}
   virtual void handle(ForLoop*) {}
   virtual void handle(IfThenElse*) {}
   virtual void handle(Allocate*) {}
@@ -219,6 +222,9 @@ struct TORCH_CUDA_API OptInConstDispatch {
   }
   virtual void handle(const TernaryOp* const) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for TernaryOp.");
+  }
+  virtual void handle(const ReductionOp* const) {
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for ReductionOp.");
   }
   virtual void handle(const ForLoop* const) {
     AT_ERROR("Handle not overriden for ForLoop.");
@@ -294,6 +300,9 @@ struct TORCH_CUDA_API OptInDispatch {
   virtual void handle(TernaryOp*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for TernaryOp.");
   }
+  virtual void handle(ReductionOp*) {
+    TORCH_INTERNAL_ASSERT(false, "Handle not overriden for ReductionOp.");
+  }
   virtual void handle(ForLoop*) {
     TORCH_INTERNAL_ASSERT(false, "Handle not overriden for ForLoop.");
   }
@@ -362,6 +371,7 @@ struct TORCH_CUDA_API OptOutMutator {
   virtual Statement* mutate(UnaryOp*);
   virtual Statement* mutate(BinaryOp*);
   virtual Statement* mutate(TernaryOp*);
+  virtual Statement* mutate(ReductionOp*);
   virtual Statement* mutate(ForLoop*);
   virtual Statement* mutate(IfThenElse*);
   virtual Statement* mutate(Allocate*);
@@ -436,6 +446,9 @@ struct TORCH_CUDA_API OptInMutator {
   }
   virtual Statement* mutate(TernaryOp*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for TernaryOp.");
+  }
+  virtual Statement* mutate(ReductionOp*) {
+    TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for ReductionOp.");
   }
   virtual Statement* mutate(ForLoop*) {
     TORCH_INTERNAL_ASSERT(false, "Mutate not overriden for ForLoop.");

--- a/torch/csrc/jit/codegen/cuda/fusion.cpp
+++ b/torch/csrc/jit/codegen/cuda/fusion.cpp
@@ -34,10 +34,9 @@ std::vector<Expr*> ExprSort::getExprs(
   return es.exprs;
 }
 
-std::vector<Statement*> InputsOf::next(Val* v) {
+void InputsOf::handle(Val* v) {
   if (FusionGuard::getCurFusion()->origin(v) == nullptr)
     inputs.emplace(v);
-  return IterVisitor::next(v);
 }
 
 std::set<Val*> InputsOf::output(Fusion* fusion, Val* output_) {
@@ -47,7 +46,7 @@ std::set<Val*> InputsOf::output(Fusion* fusion, Val* output_) {
       output_,
       " however, it is not an output of the provided fusion.");
   InputsOf io;
-  io.traverseFrom(FusionGuard::getCurFusion(), {output_});
+  io.traverseFrom(FusionGuard::getCurFusion(), {output_}, false);
   return io.inputs;
 }
 

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -81,12 +81,10 @@ struct ExprSort : public IterVisitor {
 };
 
 struct InputsOf : public IterVisitor {
-  using IterVisitor::handle;
-
  private:
   std::set<Val*> inputs;
 
-  std::vector<Statement*> next(Val* v) final;
+  void handle(Val* v) final;
 
  public:
   static std::set<Val*> output(Fusion* fusion, Val* output_);

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -1,73 +1,84 @@
 #include <torch/csrc/jit/codegen/cuda/index_compute.h>
 #include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 
 namespace torch {
 namespace jit {
 namespace fuser {
 
-void IndexCompute::replayBackward(Split* expr) {
-  int ax = expr->axis();
+TensorDomain* IndexCompute::replayBackward(Split* split, TensorDomain*) {
+  int ax = split->axis();
   TORCH_INTERNAL_ASSERT(
       ax >= 0 && ax + 1 < indices.size(),
       "Hit an invalid Split transformation during IndexCompute, axis is not within bounds.");
-  indices[ax] = add(mul(indices[ax], expr->factor()), indices[ax + 1]);
+  indices[ax] = add(mul(indices[ax], split->factor()), indices[ax + 1]);
   indices.erase(indices.begin() + ax + 1);
+  return split->in();
 }
 
-void IndexCompute::replayBackward(Merge* expr) {
-  int ax = expr->axis();
+TensorDomain* IndexCompute::replayBackward(Merge* merge, TensorDomain*) {
+  int ax = merge->axis();
   TORCH_INTERNAL_ASSERT(
       ax >= 0 && ax < indices.size(),
       "Hit an invalid MERGE transformation during IndexCompute, axis is not within bounds.");
 
-  Val* I = expr->in()->axis(ax + 1)->extent();
+  Val* I = merge->in()->axis(ax + 1)->extent();
   Val* ind = indices[ax];
   indices[ax] = div(ind, I);
   indices.insert(indices.begin() + ax + 1, mod(ind, I));
+  return merge->in();
 }
 
-void IndexCompute::replayBackward(Reorder* expr) {
-  // pos2axis[new_pos] = old_pos Generate new axis2pos map
-  const std::vector<int>& pos2axis = expr->pos2axis();
+TensorDomain* IndexCompute::replayBackward(Reorder* reorder, TensorDomain*) {
+  // new2old[new_pos] = old_pos Generate new old2new map
+  const std::vector<int>& new2old = reorder->new2old();
 
   std::vector<Val*> reordered_indices;
 
   // Reverse the map so we can simply push back into reordered_indices
-  // axis2pos[old_pos] = new_pos
-  std::vector<int> axis2pos(pos2axis.size(), -1);
+  // old2new[old_pos] = new_pos
+  std::vector<int> old2new(new2old.size(), -1);
 
-  for (decltype(pos2axis.size()) i = 0; i < pos2axis.size(); i++) {
+  for (decltype(new2old.size()) i = 0; i < new2old.size(); i++) {
     int new_pos = i;
-    int old_pos = pos2axis[i];
+    int old_pos = new2old[i];
     TORCH_INTERNAL_ASSERT(
         new_pos >= 0 && new_pos < indices.size() && old_pos >= 0 &&
             old_pos < indices.size(),
         "Hit an invalid reorder transformation during IndexCompute,"
         " at least one move position is not within bounds.");
-    axis2pos[old_pos] = new_pos;
+    old2new[old_pos] = new_pos;
   }
-  for (decltype(axis2pos.size()) i = 0; i < axis2pos.size(); i++) {
-    int new_pos = axis2pos[i];
+  for (decltype(old2new.size()) i = 0; i < old2new.size(); i++) {
+    int new_pos = old2new[i];
     int old_pos = i;
     // reordered_indices[old_pos] = indices[new_pos];
     reordered_indices.push_back(indices[new_pos]);
   }
 
   indices = reordered_indices;
+  return reorder->in();
 }
 
-IndexCompute::IndexCompute(const TensorView* tv, std::vector<Val*> _indices) {
-  indices = std::move(_indices);
+TensorDomain* IndexCompute::runBackward(std::vector<Expr*> history) {
+  TensorDomain* running_td = nullptr;
+  for (auto it = history.rbegin(); it != history.rend(); it++)
+    running_td = TransformIter::replayBackward(*it, running_td);
 
-  TensorDomain* td = tv->domain();
+  return running_td;
+}
+
+IndexCompute::IndexCompute(TensorDomain* td, std::vector<Val*> _indices) {
+  indices = std::move(_indices);
 
   bool exclude_reduction = td->nDims() > indices.size();
 
-  TORCH_CHECK(
-      exclude_reduction || td->nDims() == indices.size(),
-      "For IndexCompute the number of axis should match the number of dimensions"
-      " in the TensorView.");
+  TORCH_INTERNAL_ASSERT(
+      td->noReductions()->nDims() == indices.size() ||
+          td->nDims() == indices.size(),
+      "For IndexCompute the number of axes should match the number of dimensions"
+      " in the TensorDomain.");
 
   // If we need to ignore the reduction dimensions because a tensor is
   // being consumed, not produced, then insert dummy dimensions in the
@@ -77,31 +88,263 @@ IndexCompute::IndexCompute(const TensorView* tv, std::vector<Val*> _indices) {
       if (td->axis(i)->isReduction())
         indices.insert(indices.begin() + i, new Int(-1));
 
+  TORCH_INTERNAL_ASSERT(
+      indices.size() == td->nDims(),
+      "Attempted to modify indices for IndexCompute, but didn't work.");
+
   // Run the split/merge/reorder operations backwards. This will
   // Modify std::vector<Int*> indices so it can be used to index
   // the root TensorDomain which should now match the physical axes.
-  TensorDomain* root = TransformIter::runBackward(td, true);
+  TensorDomain* root = TransformIter::getRoot(td);
+  auto history = TransformIter::getHistory(td);
+  if (exclude_reduction && td->hasRFactor()) {
+    root = TransformIter::getRFactorRoot(td);
+    auto rfactor_history = TransformIter::getHistory(root);
+    history.erase(history.begin(), history.begin() + rfactor_history.size());
+  }
+
+  runBackward(history);
 
   TORCH_INTERNAL_ASSERT(
       root->nDims() == indices.size(),
       "Error during IndexCompute. The number of indices generated"
       " after running the transformations backwards should match"
-      " the number of dimensions of the root TensorView.");
-
-  // Remove indices associated with reduction axes, we had them just for
-  // bookkeeping.
-  if (exclude_reduction) {
-    for (auto i = root->nDims() - 1; i >= 0; i--)
-      if (root->axis(i)->isReduction())
-        indices.erase(indices.begin() + i);
-  }
+      " the number of dimensions of the root TensorDomain.");
 }
 
-std::vector<Val*> IndexCompute::computeIndices(
-    const TensorView* tv,
+std::vector<Val*> IndexCompute::get(
+    TensorDomain* td,
     std::vector<Val*> _indices) {
-  IndexCompute ic(tv, std::move(_indices));
+  IndexCompute ic(td, std::move(_indices));
   return ic.indices;
+}
+
+TensorIndex* Index::getGlobalProducerIndex(
+    TensorView* producer,
+    TensorView* consumer,
+    std::vector<ForLoop*> loops) {
+  // This replay will ignore reduction dimensions on the producer
+  auto pind =
+      TransformReplay::replayPasC(producer->domain(), consumer->domain(), -1);
+
+  TORCH_INTERNAL_ASSERT(
+      loops.size() == pind->noReductions()->nDims(),
+      "Dimensionality error in code generator while computing indexing.");
+
+  std::vector<Val*> indices(loops.size());
+  std::transform(loops.begin(), loops.end(), indices.begin(), [](ForLoop* fl) {
+    return fl->index();
+  });
+  std::vector<Val*> computed_inds = IndexCompute::get(pind, indices);
+
+  auto root_producer = producer->getRootDomain();
+
+  TORCH_INTERNAL_ASSERT(
+      computed_inds.size() == root_producer->nDims(),
+      "Dimensionality error in code generator while computing indexing.");
+
+  for (decltype(computed_inds.size()) i{0}; i < computed_inds.size(); i++) {
+    if (root_producer->axis(i)->isReduction())
+      computed_inds.erase(computed_inds.begin() + i);
+  }
+
+  std::vector<Val*> strided_inds;
+  for (decltype(computed_inds.size()) i{0}; i < computed_inds.size(); i++) {
+    std::stringstream ss;
+    ss << "T" << producer->name() << ".stride[" << i << "]";
+    strided_inds.push_back(
+        mul(computed_inds[i], new NamedScalar(ss.str(), DataType::Int)));
+  }
+
+  // Probably shouldn't ever hit this
+  if (strided_inds.size() == 0)
+    strided_inds.push_back(new Int(0));
+
+  return new TensorIndex(producer, strided_inds);
+}
+
+// Producer index for either shared or local memory
+TensorIndex* Index::getProducerIndex_impl(
+    TensorView* producer,
+    TensorView* consumer,
+    std::vector<ForLoop*> loops) {
+  TORCH_INTERNAL_ASSERT(
+      loops.size() == producer->domain()->noReductions()->nDims(),
+      "Expected a tensor with ",
+      loops.size(),
+      " dimensions but got one with ",
+      producer->nDims());
+
+  std::vector<IterDomain*> ranges(loops.size());
+  std::transform(loops.begin(), loops.end(), ranges.begin(), [](ForLoop* fl) {
+    return fl->iter_domain();
+  });
+
+  std::vector<Val*> indices(loops.size());
+  std::transform(loops.begin(), loops.end(), indices.begin(), [](ForLoop* fl) {
+    return fl->index();
+  });
+
+  std::vector<Val*> used_inds;
+  std::vector<IterDomain*> used_ranges;
+  bool unrolled = false;
+  for (decltype(loops.size()) i{0}; i < loops.size(); i++) {
+    if (ranges[i]->parallel_method() == ParallelType::Unroll)
+      unrolled = true;
+    if (!unrolled && producer->hasComputeAt() &&
+        i < producer->getComputeAtAxis())
+      continue;
+    if (producer->getMemoryType() == MemoryType::Shared &&
+        ranges[i]->isBlockDim())
+      continue;
+    if (producer->getMemoryType() == MemoryType::Local && ranges[i]->isThread())
+      continue;
+    used_inds.push_back(indices[i]);
+    used_ranges.push_back(ranges[i]);
+  }
+
+  for (decltype(used_inds.size()) i{0}; i < used_inds.size(); i++) {
+    Val* ind = used_inds[i];
+    for (decltype(used_ranges.size()) j{i + 1}; j < used_ranges.size(); j++)
+      ind = mul(ind, used_ranges[j]->extent());
+    used_inds[i] = ind;
+  }
+  if (used_inds.size() == 0)
+    used_inds.push_back(new Int(0));
+
+  return new TensorIndex(producer, used_inds);
+}
+
+TensorIndex* Index::getGlobalConsumerIndex(
+    TensorView* consumer,
+    std::vector<ForLoop*> loops) {
+  // If we're initializing a reduction buffer, we won't have the reduction
+  // loops. If we're actually performing the reduction, we will.
+
+  bool ignore_reduction = loops.size() < consumer->nDims();
+
+  std::vector<Val*> indices(loops.size());
+  std::transform(loops.begin(), loops.end(), indices.begin(), [](ForLoop* fl) {
+    return fl->index();
+  });
+
+  std::vector<Val*> computed_inds =
+      IndexCompute::get(consumer->domain(), indices);
+
+  TensorDomain* root_dom = consumer->getRootDomain();
+  TORCH_INTERNAL_ASSERT(
+      computed_inds.size() == root_dom->nDims(),
+      "Dimensionality error in code generator while computing indexing.");
+
+  for (decltype(root_dom->nDims()) i{0}; i < root_dom->nDims(); i++) {
+    // Do this backwards so erase offset will be right
+    auto axis = root_dom->nDims() - i - 1;
+    if (root_dom->axis(axis)->isReduction())
+      computed_inds.erase(computed_inds.begin() + axis);
+  }
+
+  std::vector<Val*> strided_inds;
+  for (decltype(computed_inds.size()) i{0}; i < computed_inds.size(); i++) {
+    std::stringstream ss;
+    ss << "T" << consumer->name() << ".stride[" << i << "]";
+    strided_inds.push_back(
+        mul(computed_inds[i], new NamedScalar(ss.str(), DataType::Int)));
+  }
+
+  // Probably shouldn't ever hit this
+  if (strided_inds.size() == 0)
+    strided_inds.push_back(new Int(0));
+
+  return new TensorIndex(consumer, strided_inds);
+}
+
+TensorIndex* Index::getConsumerIndex_impl(
+    TensorView* consumer,
+    std::vector<ForLoop*> loops) {
+  // If we're initializing a reduction buffer, we won't have the reduction
+  // loops. If we're actually performing the reduction, we will.
+
+  bool have_reduction_iters = loops.size() == consumer->nDims();
+
+  if (!have_reduction_iters) {
+    TORCH_INTERNAL_ASSERT(
+        // Init reduction space
+        loops.size() == consumer->domain()->noReductions()->nDims(),
+        "Expected a tensor with ",
+        loops.size(),
+        " dimensions but got one with ",
+        consumer->domain()->noReductions()->nDims());
+  } else {
+    TORCH_INTERNAL_ASSERT(
+        // Calling the reduction op
+        loops.size() == consumer->nDims(),
+        "Expected a tensor with ",
+        loops.size(),
+        " dimensions but got one with ",
+        consumer->nDims());
+  }
+
+  std::vector<IterDomain*> ranges(loops.size());
+  std::transform(loops.begin(), loops.end(), ranges.begin(), [](ForLoop* fl) {
+    return fl->iter_domain();
+  });
+
+  std::vector<Val*> indices(loops.size());
+  std::transform(loops.begin(), loops.end(), indices.begin(), [](ForLoop* fl) {
+    return fl->index();
+  });
+
+  std::vector<Val*> used_inds;
+  std::vector<IterDomain*> used_ranges;
+  bool unrolled = false;
+  for (decltype(loops.size()) i{0}; i < loops.size(); i++) {
+    if (have_reduction_iters && consumer->axis(i)->isReduction())
+      continue;
+    if (ranges[i]->parallel_method() == ParallelType::Unroll)
+      unrolled = true;
+    if (!unrolled && consumer->hasComputeAt() &&
+        i < consumer->getComputeAtAxis())
+      continue;
+    if (consumer->getMemoryType() == MemoryType::Shared &&
+        ranges[i]->isBlockDim())
+      continue;
+    if (consumer->getMemoryType() == MemoryType::Local && ranges[i]->isThread())
+      continue;
+
+    used_inds.push_back(indices[i]);
+    used_ranges.push_back(ranges[i]);
+  }
+
+  for (decltype(used_inds.size()) i{0}; i < used_inds.size(); i++) {
+    Val* ind = used_inds[i];
+    for (decltype(used_ranges.size()) j{i + 1}; j < used_ranges.size(); j++)
+      ind = mul(ind, used_ranges[j]->extent());
+    used_inds[i] = ind;
+  }
+
+  if (used_inds.size() == 0)
+    used_inds.push_back(new Int(0));
+
+  return new TensorIndex(consumer, used_inds);
+}
+
+// Producer is the inputs of an expression
+TensorIndex* Index::getProducerIndex(
+    TensorView* producer,
+    TensorView* consumer,
+    std::vector<ForLoop*> loops) {
+  if (producer->getMemoryType() == MemoryType::Global)
+    return getGlobalProducerIndex(producer, consumer, loops);
+  return getProducerIndex_impl(producer, consumer, loops);
+}
+
+// Consumer is the output of an expression
+TensorIndex* Index::getConsumerIndex(
+    TensorView* consumer,
+    std::vector<ForLoop*> loops) {
+  if (consumer->getMemoryType() == MemoryType::Global)
+    return getGlobalConsumerIndex(consumer, loops);
+  return getConsumerIndex_impl(consumer, loops);
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/index_compute.h
+++ b/torch/csrc/jit/codegen/cuda/index_compute.h
@@ -55,24 +55,63 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
-// Play split/merge/reorder operations backwards to compute indexing into
-// original tensor.
 struct IndexCompute : public TransformIter {
- protected:
-  // Replay overrides which modify indices
-  void replayBackward(Split* expr) override;
-  void replayBackward(Merge* expr) override;
-  void replayBackward(Reorder* expr) override;
+ private:
+  TensorDomain* replayBackward(Split*, TensorDomain*) override;
+  TensorDomain* replayBackward(Merge*, TensorDomain*) override;
+  TensorDomain* replayBackward(Reorder*, TensorDomain*) override;
 
-  // Axis_map for
+  TensorDomain* runBackward(std::vector<Expr*> history);
+
+  IndexCompute(TensorDomain* td, std::vector<Val*> _indices);
   std::vector<Val*> indices;
 
-  IndexCompute(const TensorView* tv, std::vector<Val*> _indices);
+ public:
+  static std::vector<Val*> get(TensorDomain* td, std::vector<Val*> _indices);
+};
+
+// Simple interface for IndexCompute
+struct Index : public TransformIter {
+ private:
+  // Producer indexing if it's in shared or local memory
+  static TensorIndex* getProducerIndex_impl(
+      TensorView* producer,
+      TensorView* consumer,
+      std::vector<ForLoop*> loops);
+
+  // Consumer indexing if it's in shared or local memory
+  static TensorIndex* getConsumerIndex_impl(
+      TensorView* consumer,
+      std::vector<ForLoop*> loops);
 
  public:
-  static std::vector<Val*> computeIndices(
-      const TensorView* tv,
-      std::vector<Val*> _indices);
+  // Producer if it's in global memory
+  static TensorIndex* getGlobalProducerIndex(
+      TensorView* producer,
+      TensorView* consumer,
+      std::vector<ForLoop*> loops);
+
+  // Consumer indexing if it's in global memory
+  static TensorIndex* getGlobalConsumerIndex(
+      TensorView* consumer,
+      std::vector<ForLoop*> loops);
+
+  // Indexing functions
+  // Consumer = Producer
+  // i.e. T0 = T1... -> T0 is the consumer, T1 is the producer
+  // Producer indexing dispatch
+  static TensorIndex* getProducerIndex(
+      TensorView* producer,
+      TensorView* consumer,
+      std::vector<ForLoop*> loops);
+
+  // Consumer index dispatch
+  static TensorIndex* getConsumerIndex(
+      TensorView* consumer,
+      std::vector<ForLoop*> loops);
+
+  // Will run inds through back prop index computation for tv
+  static TensorIndex* manualBackprop(TensorView tv, std::vector<Val*> inds);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -155,6 +155,7 @@ struct TORCH_CUDA_API Int : public Val {
 struct TransformReplay;
 struct TransformIter;
 struct OptOutMutator;
+struct LoopNestGenerator;
 struct GPULower;
 /*
  * TensorView is our primitive Tensor Type used in code generation. It can be
@@ -192,12 +193,18 @@ struct TORCH_CUDA_API TensorView : public Val {
   // (minus reduction IterDomains).
   TensorView* newForOutput(DataType dtype) const;
 
+  // Make a new tensor with the given dtype, same domain as this tensor, minus
+  // reduction IterDomains, with new reduced axes marked as so.
+  TensorView* newForReduction(std::vector<unsigned int> axes) const;
+
   // Make an exact copy of this tensor with the same dtype and same domain
   TensorView* clone() const;
 
   TensorDomain* domain() const noexcept {
     return domain_;
   }
+
+  bool hasReduction() const;
 
   // Is there an active computeAt TensorView/Axis
   bool hasComputeAt() const {
@@ -219,9 +226,9 @@ struct TORCH_CUDA_API TensorView : public Val {
 
   // Will check if an axis is inside computeAtAxis and will fetch the reference
   // to be used in code generation.
-  IterDomain* getComputeAtAxis(int pos) {
+  std::pair<IterDomain*, TensorView*> getComputeAtAxis(int pos) {
     if (!hasComputeAt() || getComputeAtAxis() <= pos)
-      return axis(pos);
+      return std::pair<IterDomain*, TensorView*>(axis(pos), this);
     return compute_at_view_->getComputeAtAxis(pos);
   }
 
@@ -234,7 +241,7 @@ struct TORCH_CUDA_API TensorView : public Val {
   TensorView* computeAt(TensorView* consumer, int axis);
 
   void clearComputeAt() {
-    compute_at_axis_ = -1;
+    compute_at_axis_ = 0;
     compute_at_view_ = nullptr;
   }
 
@@ -245,28 +252,76 @@ struct TORCH_CUDA_API TensorView : public Val {
   // Merge "axis" and "axis+1" into 1 dimension
   TensorView* merge(int axis);
 
-  // Reorder axes according to axis2pos[old_pos] = new_pos
-  TensorView* reorder(const std::unordered_map<int, int>& axis2pos);
+  // Reorder axes according to old2new[old_pos] = new_pos
+  TensorView* reorder(const std::unordered_map<int, int>& old2new);
+
+  /*
+   * WARNING: Does not return this TensorView, returns a new tensorview consumed
+   * to create this!! Take reduction axes out of this domain, and create a new
+   * domain. New domain will be used to create this domain. For example: TV1[I0,
+   * I1] = TV0[I0, R0, R1, I1] TV0->rfactor({1}) TV0 is transformed to ->
+   * TV0[I0, R1, I1] The TensorView returned is: TV2[I0, R0, I3, I1] The
+   * reduction will now beset as: TV1[I0, R1, I1] = TV2[I0, R0, I3, I1] TV0[I0,
+   * I1] = TV1[I0, R1, I1]
+   */
+  TensorView* rFactor(const std::vector<int> axes);
+
+  MemoryType getMemoryType() {
+    return memory_type_;
+  }
 
   friend TORCH_CUDA_API TransformReplay;
   friend TORCH_CUDA_API TransformIter;
   friend TORCH_CUDA_API OptOutMutator;
   friend TORCH_CUDA_API GPULower;
+  friend TORCH_CUDA_API LoopNestGenerator;
 
  protected:
+  // Make an exact copy of this tensor (similar to clone()), however, also grabs
+  // the same name. Current use of this is for initialization of reductions.
+  // This will break our dependency chain as it is a literal clone of a
+  // TensorView but it has a different dependency chain. We need to improve our
+  // dependency model to allow for initailziation of reduction buffers. The only
+  // reason we can get away with this for now is because we don't use dependency
+  // analysis for the IR after we call this.
+  TensorView* unsafeClone() const;
+
   void setDomain(TensorDomain* td) {
     domain_ = td;
   }
 
   void setComputeAt(TensorView* computeAtView, int axis) {
+    TORCH_INTERNAL_ASSERT(
+        axis > 0 && axis <= nDims(),
+        "Invalid computeAt on ",
+        this,
+        " tried to set to ",
+        axis);
     compute_at_view_ = computeAtView;
     compute_at_axis_ = axis;
   }
 
+  void setMemoryType(MemoryType mt) {
+    memory_type_ = mt;
+    bool is_inp_or_out =
+        this->fusion()->hasInput(this) || this->fusion()->hasOutput(this);
+    if (is_inp_or_out)
+      TORCH_INTERNAL_ASSERT(
+          mt == MemoryType::Global,
+          "Tried to set an input or output to the fusion to a non-global memory type.");
+  }
+
  private:
+  // Transform this view like consumer, mark compute_at_(viw,axis)
+  void computeAt_impl(TensorView* consumer, int axis);
+
+  // Transform this view like producer, mark producer as compute_at_(this, axis)
+  void forwardComputeAt_impl(TensorView* producer, int axis);
+
   TensorDomain* domain_;
   TensorView* compute_at_view_ = nullptr;
   unsigned int compute_at_axis_ = 0;
+  MemoryType memory_type_ = MemoryType::Global;
 
   // Make a copy of the domain (used for Tensor based constructor), likely to be
   // removed soon.

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -140,6 +140,50 @@ struct TORCH_CUDA_API ReductionOp : public Expr {
 };
 
 /*
+ * A specialization for Ternary operations.
+ * There are 3 inputs and 1 output
+ * Examples include:
+ *  1) Threshold
+ *  2) Where
+ */
+struct TORCH_CUDA_API TernaryOp : public Expr {
+  ~TernaryOp() = default;
+  TernaryOp(TernaryOpType _type, Val* _out, Val* _in1, Val* _in2, Val* _in3);
+
+  TernaryOp(const TernaryOp& other) = delete;
+  TernaryOp& operator=(const TernaryOp& other) = delete;
+
+  TernaryOp(TernaryOp&& other) = delete;
+  TernaryOp& operator=(TernaryOp&& other) = delete;
+
+  Val* out() const noexcept {
+    return out_;
+  }
+  Val* in1() const noexcept {
+    return in1_;
+  }
+  Val* in2() const noexcept {
+    return in2_;
+  }
+  Val* in3() const noexcept {
+    return in3_;
+  }
+
+  TernaryOpType getTernaryOpType() const noexcept {
+    return ternary_op_type_;
+  }
+
+  bool sameAs(const TernaryOp* other) const;
+
+ private:
+  const TernaryOpType ternary_op_type_;
+  Val* const out_;
+  Val* const in1_;
+  Val* const in2_;
+  Val* const in3_;
+};
+
+/*
  * Simply a representation of an annotated 1D iterable from start to extent.
  * TensorDomains which represent how to iterate over a tensor is made up of
  * IterDomains to form an ND iterable. We directly set parallization strategies

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -99,47 +99,44 @@ struct TORCH_CUDA_API BinaryOp : public Expr {
 };
 
 /*
- * A specialization for Ternary operations.
- * There are 3 inputs and 1 output
- * Examples include:
- *  1) Threshold
- *  2) Where
+ * A specialization for Unary operations. Unary operations take in a single
+ * input and produce a single output. Examples include:
+ *   1) Casting operation i.e. float(a_val)
+ *   2) Negation i.e. val * -1
+ *   3) Reduction across a dimension i.e. val.sum(axis=2)
+ *   4) split/merge/reorder
  */
-struct TORCH_CUDA_API TernaryOp : public Expr {
-  ~TernaryOp() = default;
-  TernaryOp(TernaryOpType _type, Val* _out, Val* _in1, Val* _in2, Val* _in3);
+struct TORCH_CUDA_API ReductionOp : public Expr {
+  ~ReductionOp() = default;
+  ReductionOp(BinaryOpType _reduction_op_type, Val* _init, Val* _out, Val* _in);
 
-  TernaryOp(const TernaryOp& other) = delete;
-  TernaryOp& operator=(const TernaryOp& other) = delete;
+  ReductionOp(const ReductionOp& other) = delete;
+  ReductionOp& operator=(const ReductionOp& other) = delete;
 
-  TernaryOp(TernaryOp&& other) = delete;
-  TernaryOp& operator=(TernaryOp&& other) = delete;
+  ReductionOp(ReductionOp&& other) = delete;
+  ReductionOp& operator=(ReductionOp&& other) = delete;
 
   Val* out() const noexcept {
     return out_;
   }
-  Val* in1() const noexcept {
-    return in1_;
+  Val* in() const noexcept {
+    return in_;
   }
-  Val* in2() const noexcept {
-    return in2_;
-  }
-  Val* in3() const noexcept {
-    return in3_;
+  Val* init() const noexcept {
+    return init_;
   }
 
-  TernaryOpType getTernaryOpType() const noexcept {
-    return ternary_op_type_;
+  BinaryOpType getReductionOpType() const noexcept {
+    return reduction_op_type_;
   }
 
-  bool sameAs(const TernaryOp* other) const;
+  bool sameAs(const ReductionOp* const other) const;
 
  private:
-  const TernaryOpType ternary_op_type_;
+  const BinaryOpType reduction_op_type_;
+  Val* const init_;
   Val* const out_;
-  Val* const in1_;
-  Val* const in2_;
-  Val* const in3_;
+  Val* const in_;
 };
 
 /*
@@ -157,12 +154,21 @@ struct TORCH_CUDA_API IterDomain : public Val {
       Val* _start,
       Val* _extent,
       ParallelType _parallel_method = ParallelType::Serial,
-      bool _reduction_domain = false);
+      bool _reduction_domain = false,
+      bool _rfactor_domain = false);
 
   bool sameAs(const IterDomain* const other) const;
 
+  IterDomain* clone() const {
+    return new IterDomain(start(), extent(), parallel_method(), isReduction());
+  }
+
   bool isReduction() const noexcept {
     return is_reduction_domain_;
+  }
+
+  bool isRFactorProduct() const noexcept {
+    return is_rfactor_domain_;
   }
 
   bool isParallelized() const {
@@ -192,26 +198,31 @@ struct TORCH_CUDA_API IterDomain : public Val {
 
   void parallelize(ParallelType t) {
     parallel_method_ = t;
-    if (isBlockDim()) {
+    if (isBlockDim())
       TORCH_CHECK(
           !isReduction(),
           "Cannot parallelize reductions across a block dimension.");
+
+    // Currently a limitation as we allocate shared memory as static (not based
+    // off a dynamic size.)
+    if (isReduction())
       if (isThreadDim())
         TORCH_CHECK(
-            !isReduction(),
-            "Thread parallelized reductions not yet supported.");
+            extent()->isConstScalar(),
+            "Reductions can only be parallelized across dimensions of compile-time known constants.");
+
+    TORCH_CHECK(
+        t != ParallelType::Vectorize, "Vectorization not yet supported.");
+
+    if (t == ParallelType::Unroll)
       TORCH_CHECK(
-          t != ParallelType::Vectorize, "Vectorization not yet supported.");
-      if (t == ParallelType::Unroll)
-        TORCH_CHECK(
-            start()->isZeroInt() && extent()->isConstScalar(),
-            "Unrolling only supported with start = 0 and extent as a const int, but got ",
-            "a start of ",
-            start(),
-            " and extent ",
-            extent(),
-            " .");
-    }
+          start()->isZeroInt() && extent()->isConstScalar(),
+          "Unrolling only supported with start = 0 and extent as a const int, but got ",
+          "a start of ",
+          start(),
+          " and extent ",
+          extent(),
+          " .");
   }
 
   ParallelType parallel_method() const noexcept {
@@ -234,6 +245,7 @@ struct TORCH_CUDA_API IterDomain : public Val {
   Val* const extent_;
   ParallelType parallel_method_ = ParallelType::Serial;
   bool is_reduction_domain_;
+  bool is_rfactor_domain_;
 };
 /*
  * TensorDomain holds a vector of IterDomains. It holds an IterDomain for every
@@ -270,6 +282,10 @@ struct TORCH_CUDA_API TensorDomain : public Val {
     return domain_;
   }
 
+  bool hasReduction() const;
+
+  bool hasRFactor() const;
+
   TensorDomain* noReductions() const;
 
   // i here is int, as we want to accept negative value and ::size_type can be a
@@ -284,7 +300,10 @@ struct TORCH_CUDA_API TensorDomain : public Val {
   TensorDomain* merge(int axis);
 
   // Reorder axes according to map[old_pos] = new_pos
-  TensorDomain* reorder(const std::unordered_map<int, int>& axis2pos);
+  TensorDomain* reorder(const std::unordered_map<int, int>& old2new);
+
+  // pair is in order where second is the consumer of first
+  std::pair<TensorDomain*, TensorDomain*> rFactor(const std::vector<int> axes);
 
   TensorDomain* rootDomain();
 
@@ -366,11 +385,11 @@ struct TORCH_CUDA_API Merge : public Expr {
 
 /*
  * Reorder the IterDomains of a tensor domain with the map
- * pos2axis[new_position] = old_position
+ * new2old[new_position] = old_position
  */
 struct TORCH_CUDA_API Reorder : public Expr {
   ~Reorder() = default;
-  Reorder(TensorDomain* _out, TensorDomain* _in, std::vector<int> _pos2axis);
+  Reorder(TensorDomain* _out, TensorDomain* _in, std::vector<int> _new2old);
 
   Reorder(const Reorder& other) = delete;
   Reorder& operator=(const Reorder& other) = delete;
@@ -384,8 +403,8 @@ struct TORCH_CUDA_API Reorder : public Expr {
   TensorDomain* in() const noexcept {
     return in_;
   }
-  const std::vector<int>& pos2axis() const noexcept {
-    return pos2axis_;
+  const std::vector<int>& new2old() const noexcept {
+    return new2old_;
   }
 
   bool sameAs(const Reorder* const other) const;
@@ -393,7 +412,7 @@ struct TORCH_CUDA_API Reorder : public Expr {
  private:
   TensorDomain* const out_;
   TensorDomain* const in_;
-  const std::vector<int> pos2axis_;
+  const std::vector<int> new2old_;
 };
 
 /*
@@ -579,20 +598,20 @@ struct TORCH_CUDA_API Allocate : public Expr {
   Allocate(Allocate&& other) = delete;
   Allocate& operator=(Allocate&& other) = delete;
 
-  Allocate(TensorView* _tv, Val* size);
+  Allocate(Val* _tv, Val* size);
 
   DataType buf_type() const;
   Val* extent() const noexcept {
     return extent_;
   }
-  TensorView* buffer() const noexcept {
+  Val* buffer() const noexcept {
     return buffer_;
   }
 
   bool sameAs(const Allocate* other) const;
 
  private:
-  TensorView* buffer_;
+  Val* buffer_;
   Val* extent_;
 };
 

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -525,7 +525,7 @@ struct TORCH_CUDA_API ForLoop : public Expr {
 struct TORCH_CUDA_API IfThenElse : public Expr {
   ~IfThenElse() = default;
   IfThenElse(
-      Int* _cond,
+      Bool* _cond,
       const std::vector<Expr*>& _if_body = {},
       const std::vector<Expr*>& _else_body = {},
       Expr* _parent_scope = nullptr);
@@ -536,7 +536,7 @@ struct TORCH_CUDA_API IfThenElse : public Expr {
   IfThenElse(IfThenElse&& other) = delete;
   IfThenElse& operator=(IfThenElse&& other) = delete;
 
-  Int* cond() const noexcept {
+  Bool* cond() const noexcept {
     return cond_;
   }
 
@@ -567,7 +567,7 @@ struct TORCH_CUDA_API IfThenElse : public Expr {
   }
 
  private:
-  Int* const cond_;
+  Bool* const cond_;
   Scope body_;
   Scope else_body_;
   Expr* parent_scope_;

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -347,7 +347,7 @@ void IRPrinter::handle(const ReductionOp* const rop) {
   os << rop->out() << " = reduction( " << rop->in()
      << ", op = " << rop->getReductionOpType()
      << ", initial value = " << rop->init() << " )\n";
-  }
+}
 
 void IRPrinter::handle(const ForLoop* const fl) {
   if (fl->iter_domain()->isThread()) {
@@ -410,7 +410,7 @@ void IRPrinter::handle(const Allocate* const a) {
   os << a->buf_type();
   if (a->buffer()->getValType() == ValType::TensorView) {
     os << " T" << a->buffer()->name() << "[";
-  print_inline(a->extent());
+    print_inline(a->extent());
     os << "];\n";
   } else {
     if (a->extent()->isOneInt()) {

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -20,6 +20,7 @@ struct Expr;
 struct UnaryOp;
 struct BinaryOp;
 struct TernaryOp;
+struct ReductionOp;
 
 struct ForLoop;
 struct IfThenElse;
@@ -109,6 +110,7 @@ struct TORCH_CUDA_API IRPrinter : public OptInConstDispatch {
   virtual void handle(const UnaryOp* const);
   virtual void handle(const BinaryOp* const);
   virtual void handle(const TernaryOp* const);
+  virtual void handle(const ReductionOp* const);
 
   virtual void handle(const ForLoop* const);
   virtual void handle(const IfThenElse* const);

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -586,7 +586,7 @@ bool ForLoop::sameAs(const ForLoop* other) const {
 }
 
 IfThenElse::IfThenElse(
-    Int* _cond,
+    Bool* _cond,
     const std::vector<Expr*>& _if_body,
     const std::vector<Expr*>& _else_body,
     Expr* _parent_scope)

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -148,7 +148,6 @@ bool TernaryOp::sameAs(const TernaryOp* other) const {
   return true;
 }
 
-
 ReductionOp::ReductionOp(
     BinaryOpType _reduction_op_type,
     Val* _init,

--- a/torch/csrc/jit/codegen/cuda/iter_visitor.h
+++ b/torch/csrc/jit/codegen/cuda/iter_visitor.h
@@ -4,7 +4,7 @@
 
 #include <torch/csrc/jit/codegen/cuda/dispatch.h>
 
-#include <stack>
+#include <deque>
 #include <vector>
 
 namespace torch {
@@ -20,23 +20,19 @@ struct Fusion;
 enum class ValType;
 
 /*
- * IterVisitor walks a Fusion topologically ordered from outputs of the fusion.
- * By default outputs are any leaf Vars that don't have uses, but can be set to
- * registered outputs of the Fusion. On every node handle(NodeType*) will be
- * called (topologically ordered).
+ * IterVisitor starts from leaf nodes, fusion outputs, or the provided values.
+ * It walks the DAG bacwkards from the starting nodes, to roots. Each node in
+ * the dag will be called with handle(Statement*) in topolgical order inputs of
+ * the fusion to outputs of the fusion.
  *
- * stopCondition can be overridden if it is desired to stop the traversal at any
- * particular point. toVisitCallback can also be overridden and will be called
- * when a node is added to the to_visit queue. The use of these two functions
- * can be seen in DependencyCheck which uses them to find if a value is in the
- * dependency chain of another value. stopCondition is called when the value is
- * found to stop traversal. toVisitCallback is used to maintain a dependency
- * stack.
+ * TODO: We may want a BFS version of this code to extract ILP, not implemented
+ * yet.
+ *
+ * TODO: We may want to have ordering of outputs to inputs. I'm not sure why we
+ * would want this, but seems like it would be a reasonable request.
  */
 struct TORCH_CUDA_API IterVisitor : public OptOutDispatch {
   virtual ~IterVisitor() = default;
-
-  using OptOutDispatch::handle;
 
   IterVisitor() = default;
 
@@ -47,86 +43,84 @@ struct TORCH_CUDA_API IterVisitor : public OptOutDispatch {
   IterVisitor& operator=(IterVisitor&& other) = default;
 
   // Functions return nodes in reverse order to be added to the to_visit queue
-  // These functions will start at outputs and propagate op through the DAG
-  // in depth first traversal. Next could be called on nodes multiple times,
-  // however, once handle is called on a node next will not be called.
+  // These functions will start at outputs and propagate up through the DAG
+  // to inputs based on depth first traversal. Next could be called on a node
+  // multiple times.
   virtual std::vector<Statement*> next(Statement* stmt);
   virtual std::vector<Statement*> next(Expr* expr);
   virtual std::vector<Statement*> next(Val* v);
 
+  // This handle functions is called on every Statement* in topological order,
+  // starting from outputs to inputs.
   virtual void handle(Statement* s) {
     OptOutDispatch::handle(s);
   }
+  // This handle functions is called on every Expr* in topological order,
+  // starting from outputs to inputs.
   virtual void handle(Expr* e) {
     OptOutDispatch::handle(e);
   }
+  // This handle functions is called on every Val* in topological order,
+  // starting from outputs to inputs.
   virtual void handle(Val* v) {
     OptOutDispatch::handle(v);
   }
 
-  // Stop condition allows users to stop iteration if a certain condition is met
-  virtual bool stopCondition() {
-    return false;
-  }
-
-  // Callback function when a Stmt is added to the "to_visit" queue
-  virtual void toVisitCallback(Statement* stmt) {}
+  // The entire stack during traversal. stmt_stack.back().back() is the node
+  // that is being called in handle(). stmt_stack.back() contains siblings (not
+  // guarenteed to be all siblings throughout traversal). stmt_stack.front()
+  // contains the outputs we started with (not guarenteed to be all outputs
+  // throughout traversal).
+  std::vector<std::vector<Statement*>> stmt_stack;
 
  public:
-  // This version of traverse collects the points of the graph to start from
-  // The "from_outputs_only" argument forces the graph to start from outputs
-  // instead of search for Val typed nodes that have no uses.
-  // The output type set limits further the set of Val nodes to search by type.
+  // Starts at nodes provided in from, traverses from these nodes to inputs.
+  // Calls handle on all Statement*s in topological sorted order.
+  // traverseAllPaths = false only call handle on each Statement* once
+  // traverseAllPaths = true traverses all paths from nodes in from to inputs.
+  //   Handle on a Statement* for every path from "from" nodes, to inputs.
+  void traverseFrom(
+      Fusion* const fusion,
+      const std::vector<Val*>& from,
+      bool traverseAllPaths = false);
+
+  // from_outputs_only = true start from outputs registered with fusion,
+  // from_outputs_only = false start from all leaf nodes,
+  // bool breadth_first = true is not implemented yet
   void traverse(
       Fusion* const fusion,
       bool from_outputs_only = false,
       bool breadth_first = false);
 
-  // Starts at from, traverses backwards through DAG, calls handle on nodes
-  // in depth first topological sorted order.
-  void traverseFrom(Fusion* const fusion, const std::vector<Val*>& from);
+  // from_outputs_only = true start from outputs registered with fusion,
+  // from_outputs_only = false start from all leaf nodes,
+  // bool breadth_first = true is not implemented yet
+  void traverseAllPaths(
+      Fusion* const fusion,
+      bool from_outputs_only = false,
+      bool breadth_first = false);
 };
 
-// Class to check if nodes are in the dependency chain of another node.
-struct TORCH_CUDA_API DependencyCheck : public IterVisitor {
- private:
-  // Class constructor checking if _dependency is a dependency of _of.
-  DependencyCheck(Val* _dependency, Val* _of)
-      : dependency_{_dependency}, of_{_of}, is_dependency{false} {}
-
-  // when handle is called on val, we know 2 things. Val is a dependency of of.
-  // and dep_chain contains the values in between of and dependency.
-  void handle(Val* val) override;
-
-  // When we handle an expr we pop off its outputs from the dep_chain
-  void handle(Expr* expr) override;
-
-  // When we visit an Expr we place its outputs on the dep_chain
-  void toVisitCallback(Statement* stmt);
-
-  // Traverse the dep chain from of, return if dependency was found in it
-  bool check();
-
-  Val* const dependency_;
-  Val* const of_;
-  bool is_dependency;
-  std::stack<Val*> dep_chain;
-
-  // Stop once we've found the dependency
-  bool stopCondition() {
-    return is_dependency;
-  }
-
+struct TORCH_CUDA_API DependencyCheck {
  public:
-  // Returns if dependency is a dependency of of.
-  static bool isDependencyOf(Val* dependency, Val* of) {
-    DependencyCheck dp(dependency, of);
-    return dp.check();
-  }
+  // Returns if "dependency" is a dependency of "of".
+  static bool isDependencyOf(Val* dependency, Val* of);
 
-  // Return the dependency chain, including dependency and of. If no dependency
-  // was found, returns an empty stack.
-  static std::stack<Val*> getDependencyChain(Val* dependency, Val* of);
+  // Finds a Val* path from "of" to "dependency". Returns that path.
+  // deque.back() is "of", deque[0] is dependency if a chain exists.
+  static std::deque<Val*> getSingleDependencyChain(Val* dependency, Val* of);
+
+  // Finds all Val* paths from "of" to "dependency". Returns those paths.
+  // deque[i].back() is "of", and deque[i][0] is "dependency". Returns an
+  // empty deque if no dependency found.
+  static std::deque<std::deque<Val*>> getAllDependencyChains(
+      Val* dependency,
+      Val* of);
+
+  // Finds all Val* paths from all leaf nodes to "dependency". Returns those
+  // paths. deque[i].back() are leaf nodes, and deque[i][0] is "dependency".
+  // Returns an empty deque if there are no uses of dependency found.
+  static std::deque<std::deque<Val*>> getAllDependencyChainsTo(Val* dependency);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -341,7 +341,9 @@ void runTestKernel(
   KernelArgumentHolder kernel_args;
 
   auto exprs = entry->outputs[0]->fusion()->exprs(true);
-  bool has_reduction = std::any_of(exprs.begin(), exprs.end(), [](Expr* expr){return expr->getExprType() == ExprType::ReductionOp;});
+  bool has_reduction = std::any_of(exprs.begin(), exprs.end(), [](Expr* expr) {
+    return expr->getExprType() == ExprType::ReductionOp;
+  });
 
   // Naive I/O setup, I'm ignoring all the potential transformation (i.e. I/O
   // allocated here from the subgraph could be, and very likely are, different
@@ -351,7 +353,9 @@ void runTestKernel(
       TORCH_INTERNAL_ASSERT(
           input.toTensor().device().index() == entry->device_,
           "input to kernel on device that is not compiled for");
-      TORCH_INTERNAL_ASSERT(!entry->outputs.empty(), "No output found for this kernel, aborting.");
+      TORCH_INTERNAL_ASSERT(
+          !entry->outputs.empty(),
+          "No output found for this kernel, aborting.");
       if (has_reduction) {
         kernel_args.push(input.toTensor());
       } else {
@@ -363,7 +367,7 @@ void runTestKernel(
   }
 
   for (auto& output : outputs) {
-      kernel_args.push(output);
+    kernel_args.push(output);
   }
 
   // TODO: this probably won't work for us.

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -245,8 +245,8 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
 
 void runKernel(
     CudaKernel* entry,
-    const at::ArrayRef<IValue>& inputs,
-    std::vector<at::Tensor>& outputs) {
+    const at::ArrayRef<IValue> inputs,
+    std::vector<at::Tensor> outputs) {
   const auto prior_device = at::cuda::current_device();
   at::cuda::set_device(entry->device_);
   auto stream = at::cuda::getCurrentCUDAStream();
@@ -316,8 +316,8 @@ void runKernel(
 // This function is here for testing purposes only
 void runTestKernel(
     CudaKernel* entry,
-    const at::ArrayRef<IValue>& inputs,
-    std::vector<at::Tensor>& outputs) {
+    const at::ArrayRef<IValue> inputs,
+    std::vector<at::Tensor> outputs) {
   const auto prior_device = at::cuda::current_device();
   at::cuda::set_device(entry->device_);
   auto stream = at::cuda::getCurrentCUDAStream();

--- a/torch/csrc/jit/codegen/cuda/kernel.h
+++ b/torch/csrc/jit/codegen/cuda/kernel.h
@@ -36,6 +36,9 @@ struct KernelArgsReq {
 
 class CudaKernel {
  public:
+  std::deque<Val*> inputs;
+  std::deque<Val*> outputs;
+
   CudaKernel() = default;
 
   CUmodule& getModule() {

--- a/torch/csrc/jit/codegen/cuda/kernel.h
+++ b/torch/csrc/jit/codegen/cuda/kernel.h
@@ -78,14 +78,14 @@ TORCH_CUDA_API void compileKernel(Fusion& fusion, CudaKernel* entry);
 // wraps IO data structure for tensors on host.
 TORCH_CUDA_API void runKernel(
     CudaKernel* entry,
-    const at::ArrayRef<IValue>& inputs,
-    std::vector<at::Tensor>& outputs);
+    const at::ArrayRef<IValue> inputs,
+    std::vector<at::Tensor> outputs);
 
 // Facility API to run kernel in tests.
 TORCH_CUDA_API void runTestKernel(
     CudaKernel* entry,
-    const at::ArrayRef<IValue>& inputs,
-    std::vector<at::Tensor>& outputs);
+    const at::ArrayRef<IValue> inputs,
+    std::vector<at::Tensor> outputs);
 
 } // namespace cuda
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
@@ -170,6 +170,91 @@ __device__ float randLike(Philox rnd) {
 };
 )";
 
+static auto code_template_block_reduction = R"(
+// [Z,Y,X]_THREADS is the number of participating threads in the z, y, x
+// dimension of the block. If set to 0 it means that dimension doesn't
+// participate, otherwise it is the number of threads. We could start with warp
+// reductions, then reduce the warps, this could save some shared memory, but
+// may actually be slower.
+template<int X_THREADS, int Y_THREADS, int Z_THREADS, typename T, typename Func>
+__inline__ __device__
+void blockReduce(const T inp_val, T& out, Func reduction_op) {
+
+  static constexpr int X_STRIDE = (X_THREADS > 0 ? X_THREADS: 1);
+  static constexpr int Y_STRIDE = (Y_THREADS > 0 ? Y_THREADS: 1);
+  static constexpr int Z_STRIDE = (Z_THREADS > 0 ? Z_THREADS: 1);
+
+  static constexpr int numel = X_STRIDE * Y_STRIDE * Z_STRIDE;
+
+  __shared__ T shared_mem[numel];
+
+  unsigned int reduction_size = 1;
+  unsigned int linear_tid = 0;
+
+  if(X_THREADS > 0){
+    linear_tid += threadIdx.x;
+    reduction_size *= X_STRIDE;
+  }
+  if(Y_THREADS > 0){
+    linear_tid += threadIdx.y * X_STRIDE;
+    reduction_size *= Y_STRIDE;
+  }
+  if(Z_THREADS > 0){
+    linear_tid += threadIdx.z * Y_STRIDE * X_STRIDE;
+    reduction_size *= Z_STRIDE;
+  }
+
+  // how many threads in inner most contig reduction, i.e. if this is >32 we can
+  // do warp shuffles. We could do some template magic to make this a constexpr
+  // value.
+  int contig_threads = X_STRIDE;
+  if(Y_THREADS > 0){
+    contig_threads*=Y_THREADS;
+    if(Z_THREADS>0)
+      contig_threads*=Z_THREADS;
+  }
+
+  // Round contig_threads down to nearest power of 2
+  contig_threads = 1 << (31 - __clz(contig_threads));
+  // If greater than a warp round down to a warp
+  contig_threads = contig_threads > 32 ? 32 : contig_threads;
+
+  shared_mem[linear_tid] = inp_val;
+  __syncthreads();
+  // Reduce down to nearest power of 2:
+  int np2 =  1 << (31 - __clz(reduction_size));
+
+  if( linear_tid < np2 ){
+    if( linear_tid + np2 < reduction_size){
+      reduction_op( shared_mem[linear_tid], shared_mem[linear_tid + np2] );
+    }
+  }
+  __syncthreads();
+  for (int factor = np2/2; factor >= contig_threads; factor>>=1) {
+    if (linear_tid < factor) {
+      reduction_op( shared_mem[linear_tid], shared_mem[linear_tid + factor] );
+    }
+    __syncthreads();
+  }
+
+  unsigned int mask = 0;
+  mask = ~mask; // flip all bits to 1
+  mask >>= (32 - contig_threads); // Move bits right
+
+  T val = shared_mem[linear_tid];
+  if( linear_tid < contig_threads / 2){
+     reduction_op(val, shared_mem[linear_tid + contig_threads / 2] );
+    for (int offset = contig_threads/2; offset > 0; offset /= 2){
+      reduction_op(val, __shfl_down_sync(mask, val, offset));
+    }
+  }
+
+  if(linear_tid == 0)
+    out = val;
+}
+
+)";
+
 } // namespace cuda
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -28,163 +28,6 @@ void GPULower::setActiveView(const TensorView* const tv) {
   active_view = tv->getComputeAtView();
 }
 
-TensorIndex* GPULower::getGlobalProducerIndex(
-    TensorView* producer,
-    TensorView* consumer) {
-  // Get new reference so replay inline doesn't change the original.
-  TensorView* cloned_tv = producer->clone();
-  // This replay will ignore reduction dimensions on the producer
-  TransformReplay::fullReplay(consumer, cloned_tv);
-  TORCH_INTERNAL_ASSERT(
-      scope_utils::getLoopIndices(active_scope).size() == cloned_tv->nDims(),
-      "Dimensionality error in code generator while computing indexing.");
-
-  const std::vector<Val*> computed_inds = IndexCompute::computeIndices(
-      cloned_tv, scope_utils::getLoopIndices(active_scope));
-
-  TORCH_INTERNAL_ASSERT(
-      computed_inds.size() == producer->getRootDomain()->nDims(),
-      "Dimensionality error in code generator while computing indexing.");
-
-  std::vector<Val*> strided_inds;
-  for (decltype(computed_inds.size()) i{0}; i < computed_inds.size(); i++) {
-    std::stringstream ss;
-    ss << "T" << producer->name() << ".stride[" << i << "]";
-    strided_inds.push_back(
-        mul(computed_inds[i], new NamedScalar(ss.str(), DataType::Int)));
-  }
-
-  // Probably shouldn't ever hit this
-  if (strided_inds.size() == 0)
-    strided_inds.push_back(new Int(0));
-
-  return new TensorIndex(producer, strided_inds);
-}
-
-TensorIndex* GPULower::getLocalProducerIndex(
-    TensorView* producer,
-    TensorView* consumer) {
-  TORCH_INTERNAL_ASSERT(
-      scope_utils::computeForDepth(active_scope) == producer->nDims(),
-      "Expected a tensor with ",
-      scope_utils::computeForDepth(active_scope),
-      " dimensions but got one with ",
-      producer->nDims());
-
-  std::vector<Val*> loopInds = scope_utils::getLoopIndices(active_scope);
-  std::vector<IterDomain*> ranges =
-      scope_utils::getLoopIterDomains(active_scope);
-  std::vector<Val*> computed_inds;
-  std::vector<IterDomain*> used_ranges;
-  bool unrolled = false;
-  for (decltype(loopInds.size()) i{0}; i < loopInds.size(); i++) {
-    if (ranges[i]->parallel_method() == ParallelType::Unroll)
-      unrolled = true;
-    if (!unrolled && producer->hasComputeAt() &&
-        i < producer->getComputeAtAxis())
-      continue;
-    if (ranges[i]->isThread())
-      continue;
-    computed_inds.push_back(loopInds[i]);
-    used_ranges.push_back(ranges[i]);
-  }
-
-  for (decltype(computed_inds.size()) i{0}; i < computed_inds.size(); i++) {
-    Val* ind = computed_inds[i];
-    for (decltype(used_ranges.size()) j{i + 1}; j < used_ranges.size(); j++)
-      ind = mul(ind, used_ranges[i]->extent());
-    computed_inds[i] = ind;
-  }
-  if (computed_inds.size() == 0)
-    computed_inds.push_back(new Int(0));
-
-  return new TensorIndex(producer, computed_inds);
-}
-
-// Producer is the inputs of an expression
-TensorIndex* GPULower::getProducerIndex(
-    TensorView* producer,
-    TensorView* consumer) {
-  if (fusion_->hasInput(producer) || fusion_->hasOutput(producer))
-    return getGlobalProducerIndex(producer, consumer);
-  return getLocalProducerIndex(producer, consumer);
-}
-
-TensorIndex* GPULower::getGlobalConsumerIndex(TensorView* consumer) {
-  TORCH_INTERNAL_ASSERT(
-      scope_utils::getLoopIndices(active_scope).size() == consumer->nDims(),
-      "Dimensionality error in code generator while computing indexing.");
-
-  const std::vector<Val*> computed_inds = IndexCompute::computeIndices(
-      consumer, scope_utils::getLoopIndices(active_scope));
-
-  TORCH_INTERNAL_ASSERT(
-      computed_inds.size() == consumer->getRootDomain()->nDims(),
-      "Dimensionality error in code generator while computing indexing.");
-
-  std::vector<Val*> strided_inds;
-  for (decltype(computed_inds.size()) i{0}; i < computed_inds.size(); i++) {
-    std::stringstream ss;
-    ss << "T" << consumer->name() << ".stride[" << i << "]";
-    strided_inds.push_back(
-        mul(computed_inds[i], new NamedScalar(ss.str(), DataType::Int)));
-  }
-
-  // Probably shouldn't ever hit this
-  if (strided_inds.size() == 0)
-    strided_inds.push_back(new Int(0));
-
-  return new TensorIndex(consumer, strided_inds);
-}
-
-TensorIndex* GPULower::getLocalConsumerIndex(TensorView* consumer) {
-  TORCH_INTERNAL_ASSERT(
-      scope_utils::computeForDepth(active_scope) == consumer->nDims(),
-      "Expected a tensor with ",
-      scope_utils::computeForDepth(active_scope),
-      " dimensions but got one with ",
-      consumer->nDims());
-
-  std::vector<Val*> loopInds = scope_utils::getLoopIndices(active_scope);
-  std::vector<IterDomain*> ranges =
-      scope_utils::getLoopIterDomains(active_scope);
-  std::vector<Val*> computed_inds;
-  std::vector<IterDomain*> used_ranges;
-  bool unrolled = false;
-  for (decltype(loopInds.size()) i{0}; i < loopInds.size(); i++) {
-    if (ranges[i]->parallel_method() == ParallelType::Unroll)
-      unrolled = true;
-    if (!unrolled && consumer->hasComputeAt() &&
-        i < consumer->getComputeAtAxis())
-      continue;
-    if (ranges[i]->isThread())
-      continue;
-    computed_inds.push_back(loopInds[i]);
-    used_ranges.push_back(ranges[i]);
-  }
-
-  for (decltype(computed_inds.size()) i{0}; i < computed_inds.size(); i++) {
-    Val* ind = computed_inds[i];
-    for (decltype(used_ranges.size()) j{i + 1}; j < used_ranges.size(); j++)
-      ind = mul(ind, used_ranges[i]->extent());
-    computed_inds[i] = ind;
-  }
-
-  if (computed_inds.size() == 0)
-    computed_inds.push_back(new Int(0));
-
-  return new TensorIndex(consumer, computed_inds);
-}
-
-// Consumer is the output of an expression
-TensorIndex* GPULower::getConsumerIndex(TensorView* consumer) {
-  // GLOBAL MEMORY HANDLING
-  if (FusionGuard::getCurFusion()->hasInput(consumer) ||
-      FusionGuard::getCurFusion()->hasOutput(consumer))
-    return getGlobalConsumerIndex(consumer);
-  return getLocalConsumerIndex(consumer);
-}
-
 void GPULower::pushBack(Expr* expr) {
   if (active_scope == nullptr)
     lowered_exprs.push_back(expr);
@@ -268,10 +111,14 @@ Statement* GPULower::mutate(UnaryOp* uop) {
   if (!ir_utils::isTVOp(uop))
     return OptOutMutator::mutate(uop);
 
-  TensorIndex* out = getConsumerIndex(ir_utils::asTV(uop->out()));
+  TensorIndex* out = Index::getConsumerIndex(
+      ir_utils::asTV(uop->out()), scope_utils::getLoops(active_scope));
   Val* in = uop->in();
   if (ir_utils::isTV(in))
-    in = getProducerIndex(ir_utils::asTV(in), ir_utils::asTV(uop->out()));
+    in = Index::getProducerIndex(
+        ir_utils::asTV(in),
+        ir_utils::asTV(uop->out()),
+        scope_utils::getLoops(active_scope));
   Expr* new_op = new UnaryOp(uop->getUnaryOpType(), out, in);
 
   return new_op;
@@ -281,15 +128,23 @@ Statement* GPULower::mutate(BinaryOp* bop) {
   if (!ir_utils::isTVOp(bop))
     return OptOutMutator::mutate(bop);
 
-  TensorIndex* out = getConsumerIndex(ir_utils::asTV(bop->out()));
+  TensorIndex* out = Index::getConsumerIndex(
+      ir_utils::asTV(bop->out()), scope_utils::getLoops(active_scope));
+
   Val* lhs = bop->lhs();
   Val* rhs = bop->rhs();
 
   if (ir_utils::isTV(lhs))
-    lhs = getProducerIndex(ir_utils::asTV(lhs), ir_utils::asTV(bop->out()));
+    lhs = Index::getProducerIndex(
+        ir_utils::asTV(lhs),
+        ir_utils::asTV(bop->out()),
+        scope_utils::getLoops(active_scope));
 
   if (ir_utils::isTV(rhs))
-    rhs = getProducerIndex(ir_utils::asTV(rhs), ir_utils::asTV(bop->out()));
+    rhs = Index::getProducerIndex(
+        ir_utils::asTV(rhs),
+        ir_utils::asTV(bop->out()),
+        scope_utils::getLoops(active_scope));
 
   Expr* new_op = new BinaryOp(bop->getBinaryOpType(), out, lhs, rhs);
 
@@ -315,6 +170,23 @@ Statement* GPULower::mutate(TernaryOp* top) {
     in3 = getProducerIndex(ir_utils::asTV(in3), ir_utils::asTV(top->out()));
 
   Expr* new_op = new TernaryOp(top->getTernaryOpType(), out, in1, in2, in3);
+
+  return new_op;
+}
+
+Statement* GPULower::mutate(ReductionOp* rop) {
+  if (!ir_utils::isTVOp(rop))
+    return OptOutMutator::mutate(rop);
+  TensorIndex* out = Index::getConsumerIndex(
+      ir_utils::asTV(rop->out()), scope_utils::getLoops(active_scope));
+  Val* in = rop->in();
+  if (ir_utils::isTV(in))
+    in = Index::getProducerIndex(
+        ir_utils::asTV(in),
+        ir_utils::asTV(rop->out()),
+        scope_utils::getLoops(active_scope));
+
+  Expr* new_op = new BinaryOp(rop->getReductionOpType(), out, out, in);
 
   return new_op;
 }
@@ -364,8 +236,14 @@ void GPULower::replaceSizes() {
     // Replace the domain with one based on Ti.size[j]
     std::vector<IterDomain*> new_domain_iters;
     TensorDomain* root_td = tv->getRootDomain();
+
     for (decltype(root_td->nDims()) i{0}; i < root_td->nDims(); i++) {
+      // Output sizes could have reduction axes, which isn't what gets output.
+      if (root_td->axis(i)->isReduction())
+        continue;
+
       Val* orig_size = root_td->axis(i)->extent();
+
       std::stringstream ss;
       ss << "T" << tv->name() << ".size[" << i << "]";
       Val* new_size =
@@ -380,6 +258,7 @@ void GPULower::replaceSizes() {
   if (size_map.size() == 0)
     return;
 
+  // Set domains to be based on symbolic sizes (i.e. Ti.size[...])
   for (TensorView* tv : all_tvs) {
     std::vector<IterDomain*> new_domain_iters;
     TensorDomain* root_td = tv->getRootDomain();
@@ -388,16 +267,25 @@ void GPULower::replaceSizes() {
       Val* new_size = root_td->axis(i)->extent();
       if (size_map.find(new_size) != size_map.end())
         new_size = size_map[new_size];
+
       new_domain_iters.push_back(new IterDomain(
           root_td->axis(i)->start(),
           new_size,
           root_td->axis(i)->parallel_method(),
-          root_td->axis(i)->isReduction()));
+          root_td->axis(i)->isReduction(),
+          root_td->axis(i)->isRFactorProduct()));
     }
 
     TensorDomain* old_domain = tv->domain();
-    TensorDomain* new_domain = TransformReplay::fullReplay(
-        old_domain, new TensorDomain(new_domain_iters));
+    TensorDomain* new_domain = new TensorDomain(new_domain_iters);
+
+    // We should just be able to replace sizes in place, but mutator is setup to
+    // do that as it set up to replace vals in Exprs, but
+    // IterDomain/TensorDomain are vals.
+    std::vector<int> axis_map(new_domain->nDims());
+    std::iota(axis_map.begin(), axis_map.end(), 0);
+    new_domain = TransformIter::replaySelf(
+        new_domain, TransformIter::getHistory(old_domain), axis_map);
 
     TORCH_INTERNAL_ASSERT(
         old_domain->nDims() == new_domain->nDims(),
@@ -411,6 +299,16 @@ void GPULower::replaceSizes() {
 
     tv->setDomain(new_domain);
   }
+
+  // Adjust memory types to make sure they are valid
+  for (TensorView* tv : all_tvs) {
+    if (fusion->hasInput(tv) || fusion->hasOutput(tv)) {
+      tv->setMemoryType(MemoryType::Global);
+    } else {
+      if (tv->getMemoryType() == MemoryType::Global)
+        tv->setMemoryType(MemoryType::Local);
+    }
+  }
 }
 
 namespace {
@@ -423,12 +321,12 @@ void validate(Fusion* fusion) {
     if (ir_utils::isTV(val)) {
       TensorView* tv = ir_utils::asTV(val);
       for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
-        IterDomain* id = tv->getComputeAtAxis(i);
+        IterDomain* id = tv->getComputeAtAxis(i).first;
 
-        if (id->isThread())
+        if (id->isBlockDim())
           TORCH_CHECK(
               !id->isReduction(),
-              "Parallelization on reduction axes not support at the moment found on, ",
+              "Parallelization across blocks on reduction axes not support at the moment but found on, ",
               tv,
               ".");
       }
@@ -436,8 +334,10 @@ void validate(Fusion* fusion) {
   } // for(Val* val : fusion->vals())
 } // validate
 
+} // namespace
+
 // Remove circular computeAt references
-void fixComputeAt(Fusion* fusion) {
+void GPULower::fixComputeAt(Fusion* fusion) {
   FusionGuard fg(fusion);
 
   std::vector<Expr*> exprs = fusion->exprs(true);
@@ -451,29 +351,30 @@ void fixComputeAt(Fusion* fusion) {
     TensorView* ctv = tv->getComputeAtView();
 
     if (ctv != nullptr && visited.find(ctv) == visited.end()) {
-      ctv->computeAt(tv, static_cast<int>(ctv->getComputeAtAxis()));
+      ctv->setComputeAt(tv, ctv->getComputeAtAxis());
       tv->clearComputeAt();
     }
     visited.emplace(tv);
   }
 }
 
-} // namespace
-
 // Traverse through the fusion and print CUDA code associated with it
 std::vector<Expr*> GPULower::getLoweredExprs() {
   FusionGuard fg(fusion_);
 
-  validate(fusion_);
+  // Compute at can have some circular references. Before we can call any tv
+  // with tv->getComputeAtAxis(i) we need to break those circular dependencies.
   fixComputeAt(fusion_);
 
   // Initialize members of the class
   active_view = nullptr;
   active_view_axis = 0;
 
+  validate(fusion_);
   replaceSizes();
+  auto loop_nests =
+      LoopNestGenerator::getLoopNest(fusion_, fusion_->exprs(true));
 
-  auto loop_nests = LoopNestGenerator::getLoopNest(fusion_);
   auto unrolled_loops = UnrollPass::runPass(fusion_, loop_nests);
 
   // Run through loop nests and further lower the expressions

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -155,19 +155,29 @@ Statement* GPULower::mutate(TernaryOp* top) {
   if (!ir_utils::isTVOp(top))
     return OptOutMutator::mutate(top);
 
-  TensorIndex* out = Index::getConsumerIndex(ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
+  TensorIndex* out = Index::getConsumerIndex(
+      ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
   Val* in1 = top->in1();
   Val* in2 = top->in2();
   Val* in3 = top->in3();
 
   if (ir_utils::isTV(in1))
-    in1 = Index::getProducerIndex(ir_utils::asTV(in1), ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
+    in1 = Index::getProducerIndex(
+        ir_utils::asTV(in1),
+        ir_utils::asTV(top->out()),
+        scope_utils::getLoops(active_scope));
 
   if (ir_utils::isTV(in2))
-    in2 = Index::getProducerIndex(ir_utils::asTV(in2), ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
+    in2 = Index::getProducerIndex(
+        ir_utils::asTV(in2),
+        ir_utils::asTV(top->out()),
+        scope_utils::getLoops(active_scope));
 
   if (ir_utils::isTV(in3))
-    in3 = Index::getProducerIndex(ir_utils::asTV(in3), ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
+    in3 = Index::getProducerIndex(
+        ir_utils::asTV(in3),
+        ir_utils::asTV(top->out()),
+        scope_utils::getLoops(active_scope));
 
   Expr* new_op = new TernaryOp(top->getTernaryOpType(), out, in1, in2, in3);
 

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -155,19 +155,19 @@ Statement* GPULower::mutate(TernaryOp* top) {
   if (!ir_utils::isTVOp(top))
     return OptOutMutator::mutate(top);
 
-  TensorIndex* out = getConsumerIndex(ir_utils::asTV(top->out()));
+  TensorIndex* out = Index::getConsumerIndex(ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
   Val* in1 = top->in1();
   Val* in2 = top->in2();
   Val* in3 = top->in3();
 
   if (ir_utils::isTV(in1))
-    in1 = getProducerIndex(ir_utils::asTV(in1), ir_utils::asTV(top->out()));
+    in1 = Index::getProducerIndex(ir_utils::asTV(in1), ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
 
   if (ir_utils::isTV(in2))
-    in2 = getProducerIndex(ir_utils::asTV(in2), ir_utils::asTV(top->out()));
+    in2 = Index::getProducerIndex(ir_utils::asTV(in2), ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
 
   if (ir_utils::isTV(in3))
-    in3 = getProducerIndex(ir_utils::asTV(in3), ir_utils::asTV(top->out()));
+    in3 = Index::getProducerIndex(ir_utils::asTV(in3), ir_utils::asTV(top->out()), scope_utils::getLoops(active_scope));
 
   Expr* new_op = new TernaryOp(top->getTernaryOpType(), out, in1, in2, in3);
 

--- a/torch/csrc/jit/codegen/cuda/lower2device.h
+++ b/torch/csrc/jit/codegen/cuda/lower2device.h
@@ -32,29 +32,6 @@ struct TORCH_CUDA_API GPULower : public OptOutMutator {
   // Set active views from computeAtView
   void setActiveView(const TensorView* const);
 
-  // Indexing functions
-  // Consumer = Producer
-  // i.e. T0 = T1... -> T0 is the consumer, T1 is the producer
-  // Producer indexing dispatch
-  TensorIndex* getProducerIndex(TensorView* producer, TensorView* consumer);
-  // Producer if it's in global memory
-  TensorIndex* getGlobalProducerIndex(
-      TensorView* producer,
-      TensorView* consumer);
-  // Producer indexing if it's in registers
-  TensorIndex* getLocalProducerIndex(
-      TensorView* producer,
-      TensorView* consumer);
-  // Consumer index dispatch
-  TensorIndex* getConsumerIndex(TensorView* consumer);
-  // Consumer indexing if it's in global memory
-  TensorIndex* getGlobalConsumerIndex(TensorView* consumer);
-  // Consumer indexing if it's in local memory
-  TensorIndex* getLocalConsumerIndex(TensorView* consumer);
-
-  // Get a predicate based on a particular tensorview
-  IfThenElse* getPredicate(const TensorView* const);
-
   // Wrap pushBack in lower_utils if active_scope is null we want it to go
   // straight to lower_exprs
   void pushBack(Expr*);
@@ -72,6 +49,7 @@ struct TORCH_CUDA_API GPULower : public OptOutMutator {
   Statement* mutate(UnaryOp*) final;
   Statement* mutate(BinaryOp*) final;
   Statement* mutate(TernaryOp*) final;
+  Statement* mutate(ReductionOp*) final;
 
   // TensorViews are all based on symbolic sizes. When we first initialize them
   // we don't know if they're inputs or outputs which would mean that they have
@@ -80,6 +58,7 @@ struct TORCH_CUDA_API GPULower : public OptOutMutator {
   // the kernel being fetched for shapes, we want to replace input and output
   // tensors to reference the runtime structure containing sizes.
   void replaceSizes();
+  void fixComputeAt(Fusion* fusion);
 
  public:
   // Init printer on ostream

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -5,10 +5,18 @@
 #include <torch/csrc/jit/codegen/cuda/index_compute.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 #include <torch/csrc/jit/codegen/cuda/predicate_compute.h>
+#include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 
 namespace torch {
 namespace jit {
 namespace fuser {
+
+bool operator==(
+    const std::pair<IterDomain*, TensorView*>& p1,
+    const std::pair<IterDomain*, TensorView*>& p2) {
+  return p1.first->sameAs(p2.first) && p1.second == p2.second;
+}
+
 // all the way in the loop nest, grab predicate
 /*
 for( i : ceil(I/4) ) {
@@ -35,11 +43,15 @@ void UnrollPass::handle(Expr* expr) {
 }
 
 namespace {
-Int* getPredicate(const TensorView* const pred_tv, std::vector<Val*> indices) {
-  TensorIndex* ti = new TensorIndex(
-      pred_tv, IndexCompute::computeIndices(pred_tv, std::move(indices)));
-
-  std::vector<Int*> all_preds = PredicateCompute::computePredicates(ti);
+Int* getPredicate(TensorView* tv, std::vector<Val*> inds) {
+  if (tv->nDims() > inds.size()) {
+    for (decltype(tv->nDims()) i{0}; i < tv->nDims(); i++) {
+      if (tv->axis(i)->isReduction())
+        inds.insert(inds.begin() + i, new Int(0));
+    }
+  }
+  std::vector<Int*> all_preds = PredicateCompute::computePredicates(
+      new TensorIndex(tv, IndexCompute::get(tv->domain(), inds)));
 
   std::vector<Int*> preds;
 
@@ -58,10 +70,9 @@ Int* getPredicate(const TensorView* const pred_tv, std::vector<Val*> indices) {
 
   TORCH_INTERNAL_ASSERT(
       cond->getValType().value() == ValType::Scalar &&
-          cond->getDataType().value() == DataType::Bool,
-      "Error computing predicate, should be returning an Bool, but returning ",
+          cond->getDataType().value() == DataType::Int,
+      "Error computing predicate, should be returning an Int, but returning ",
       cond);
-
   return static_cast<Int*>(cond);
 }
 } // namespace
@@ -78,17 +89,22 @@ void UnrollPass::handle(ForLoop* fl) {
     OptOutDispatch::handle(expr);
   }
 
-  TensorView* out;
-  bool has_TV_op = false;
+  TensorView* out = nullptr;
+  bool has_global = false;
   for (Expr* expr : fl->body().exprs())
     if (ir_utils::isTVOp(expr)) {
       // Predicate determining op for unroll
       out = ir_utils::asTV(expr->output(0));
-      has_TV_op = true;
-      break;
+      has_global = has_global || out->getMemoryType() == MemoryType::Global;
+      for (auto inp : expr->inputs())
+        if (ir_utils::isTV(inp))
+          has_global = has_global ||
+              ir_utils::asTV(inp)->getMemoryType() == MemoryType::Global;
     }
 
-  if (within_unroll && has_TV_op) {
+  bool has_TV_op = out != nullptr;
+
+  if (within_unroll && has_TV_op && has_global) {
     // Setup unrolled loop information:
 
     // Indices used to detect when we can unroll a loop safely
@@ -150,8 +166,8 @@ void UnrollPass::handle(ForLoop* fl) {
         continue;
 
       // Setup the expressions that need predicates around them.
-      Int* inline_predicate =
-          getPredicate(out, scope_utils::getLoopIndices(for_loops.back()));
+      Int* inline_predicate = getPredicate(out, ir_utils::indices(for_loops));
+
       IfThenElse* inline_ite =
           new IfThenElse(inline_predicate, {expr}, {}, inner_most_inlined_loop);
       std::unordered_map<Expr*, Expr*> inline_replacement_map;
@@ -164,19 +180,23 @@ void UnrollPass::handle(ForLoop* fl) {
     // modify in place, so grab a copy of exprs first.
     std::vector<Expr*> exprs(
         fl->body().exprs().begin(), fl->body().exprs().end());
+
     for (auto expr : exprs) {
       if (!ir_utils::isTVOp(expr))
         continue;
 
-      // ! within_unroll
       TensorView* out = ir_utils::asTV(ir_utils::asExpr(expr)->outputs()[0]);
-      Int* pred =
-          getPredicate(out, scope_utils::getLoopIndices(for_loops.back()));
-      if (!pred->isOneInt()) {
-        IfThenElse* inline_ite =
-            new IfThenElse(pred, {expr}, {}, for_loops.back());
-        for_loops.back()->body().insert_before(expr, inline_ite);
-        for_loops.back()->body().erase(expr);
+
+      if (has_global) {
+        Int* pred = getPredicate(out, ir_utils::indices(for_loops));
+
+        // If we need a predicate, put expr inside an if then else
+        if (!pred->isOneInt()) {
+          IfThenElse* inline_ite =
+              new IfThenElse(pred, {expr}, {}, for_loops.back());
+          for_loops.back()->body().insert_before(expr, inline_ite);
+          for_loops.back()->body().erase(expr);
+        }
       }
     }
   } // else (if(!within_unroll))
@@ -188,10 +208,6 @@ void UnrollPass::handle(ForLoop* fl) {
 // Generate the loop nest structure and place it in lowered_exprs
 void UnrollPass::computeMap() {
   FusionGuard fg(fusion_);
-
-  // Initialize members of the class
-  active_view = nullptr;
-  active_view_axis = 0;
 
   // Run through loop nests and further lower the expressions
   for (auto* expr : incoming_exprs_) {
@@ -233,7 +249,7 @@ void LoopNestGenerator::pushAlloc(TensorView* tv) {
       break;
     }
     if (alloc_pos < tv->nDims() &&
-        tv->getComputeAtAxis(alloc_pos)->parallel_method() ==
+        tv->getComputeAtAxis(alloc_pos).first->parallel_method() ==
             ParallelType::Unroll) {
       reset = false;
       break;
@@ -244,8 +260,8 @@ void LoopNestGenerator::pushAlloc(TensorView* tv) {
 
   std::vector<Val*> alloc_dims;
   for (auto i = alloc_pos; i < tv->nDims(); i++) {
-    IterDomain* dim = tv->getComputeAtAxis(i);
-    if (dim->isThreadDim())
+    IterDomain* dim = tv->getComputeAtAxis(i).first;
+    if (dim->isThreadDim() || dim->isReduction())
       continue;
     // TORCH_INTERNAL_ASSERT()
     alloc_dims.push_back(dim->extent());
@@ -272,19 +288,9 @@ void LoopNestGenerator::pushAlloc(TensorView* tv) {
   }
 }
 
-// Clear out the last recorded computeAtView
-void LoopNestGenerator::clearActiveView() {
-  active_view_axis = 0;
-  active_view = nullptr;
-}
-
-// Set active views from computeAtView
-void LoopNestGenerator::setActiveView(const TensorView* const tv) {
-  active_view_axis = tv->getComputeAtAxis();
-  active_view = tv->getComputeAtView();
-}
-
-void LoopNestGenerator::openFor(IterDomain* id) {
+void LoopNestGenerator::openFor(std::pair<IterDomain*, TensorView*> id_pair) {
+  compute_at_scope.push_back(id_pair);
+  IterDomain* id = id_pair.first;
   if (for_loops.size() > 0) {
     ForLoop* new_scope = scope_utils::openFor(for_loops.back(), id);
     for_loops.push_back(new_scope);
@@ -294,6 +300,14 @@ void LoopNestGenerator::openFor(IterDomain* id) {
   }
 }
 
+void LoopNestGenerator::popFor() {
+  TORCH_INTERNAL_ASSERT(
+      !for_loops.empty() && !compute_at_scope.empty(),
+      "Can't pop for loop, scope is empty.");
+  for_loops.pop_back();
+  compute_at_scope.pop_back();
+}
+
 void LoopNestGenerator::pushBack(Expr* expr) {
   if (for_loops.size() == 0)
     lowered_exprs.push_back(expr);
@@ -301,92 +315,87 @@ void LoopNestGenerator::pushBack(Expr* expr) {
     scope_utils::pushBack(for_loops.back(), expr);
 }
 
-/*
- *  This is one of the most complex parts of the code lowering logic. what we
- * need to do is: 1) Reduce loop structure
- *    - Reset all loops if active_view == nullptr (I'm not the last in a series
- * of computeAts)
- *    - Else reduce to active_view_axis if loop_depth > active_view_axis
- *  2) Set active_view(_axis)
- *    - If there is a computeAt set for this TV
- *  3) Open to compute At
- *    - If there is a computeAt set for this TV
- *  4) Allocate the output.
- *  5) If this is a reduction, initialize the output (open for loops to inner
- * most, predicate, initialize, close predicate, close to computeAt) 6) Open to
- * inner most loop 7) Open predicate 8) Run operation 9) Close predicate
- */
-
-// Update fors based on tv.
-void LoopNestGenerator::updateLoopNest(TensorView* tv) {
-  // 1) Reduce loop structure
-  if (active_view != nullptr) {
-    // - Else reduce to active_view_axis if loop_depth > active_view_axis
-    auto depth = for_loops.size();
-    for (auto i = depth; i > active_view_axis; i--) {
-      for_loops.pop_back();
-    }
-  }
-
-  if (tv->hasComputeAt()) {
-    //  2) Set active_view(_axis)
-    //    - If there is a computeAt set for this TV
-    setActiveView(tv);
-
-    //  3) Open to compute At
-    //    - If there is a computeAt set for this TV
-    auto depth = for_loops.size();
-
-    for (auto i = depth; i < tv->getComputeAtAxis(); i++)
+// Update for loop structure based on this TensorView
+void LoopNestGenerator::initReduction(TensorView* tv, Val* init_val) {
+  TORCH_INTERNAL_ASSERT(
+      tv->getComputeAtAxis() <= for_loops.size(),
+      "Initialization of reduction was trying to be placed at the wrong point in the loop nest.");
+  int depth = for_loops.size();
+  for (decltype(tv->nDims()) i = depth; i < tv->nDims(); i++) {
+    if (!tv->axis(i)->isReduction())
       openFor(tv->getComputeAtAxis(i));
-  } else {
-    if (active_view != nullptr)
-      // If we're the last computeAt of a block, active view should match this
-      // tv
-      TORCH_INTERNAL_ASSERT(
-          tv->sameAs(active_view),
-          "Error detected in code lowering. Expected ",
-          active_view,
-          " but recieved ",
-          tv);
-
-    clearActiveView();
   }
-  //  4) Allocate the output.
-  if (!FusionGuard::getCurFusion()->hasInput(tv) &&
-      !FusionGuard::getCurFusion()->hasOutput(tv)) {
-    pushAlloc(tv);
-  }
-  // TODO:
-  //  5) If this is a reduction, initialize the output (open for loops to inner
-  //  most, predicate, initialize, close predicate, close to computeAt)
+  auto clone = tv->unsafeClone();
+  pushBack(new UnaryOp(UnaryOpType::Set, clone, init_val));
 
-  //  6) Open to inner most loop
-  for (decltype(tv->nDims()) i = for_loops.size(); i < tv->nDims(); i++)
-    openFor(tv->getComputeAtAxis(i));
+  while (for_loops.size() > depth)
+    popFor();
 }
 
-// Custom dispatch for Expr, want to find out of it's a TV op
+/*
+ *  This is one of the most complex parts of the code lowering logic. what we
+ * need to do is:
+ *  1) Reduce loop structure if needed
+ *  2) Open to compute At
+ *    - If there is a computeAt set for this TV
+ *  3) Allocate the output.
+ *  4) If this is a reduction, initialize the output (open for loops to inner
+ *       most, predicate, initialize, close predicate, close to computeAt)
+ *  5) Open to inner most loop
+ *  6) Run operation
+ *  7) Close to computeAt
+ */
 void LoopNestGenerator::handle(Expr* expr) {
-  if (!ir_utils::isTVOp(expr))
+  if (!ir_utils::isTVOp(expr)) {
+    for (auto out : expr->outputs())
+      pushBack(new Allocate(out, new Int(1)));
+    pushBack(expr);
     return;
+  }
 
   TensorView* out = static_cast<TensorView*>(expr->output(0));
-  updateLoopNest(out);
+  // 1) Reduce loop structure
+  while (compute_at_scope.size() > out->getComputeAtAxis() &&
+         compute_at_scope.back().second != out &&
+         compute_at_scope.back() !=
+             out->getComputeAtAxis(compute_at_scope.size() - 1)) {
+    popFor();
+  }
 
+  // 2) Open back up to computeAt
+  while (compute_at_scope.size() < out->getComputeAtAxis()) {
+    openFor(out->getComputeAtAxis(compute_at_scope.size()));
+  }
+
+  //  3) Allocate the output.
+  if (!FusionGuard::getCurFusion()->hasInput(out) &&
+      !FusionGuard::getCurFusion()->hasOutput(out))
+    pushAlloc(out);
+
+  //  4) If this is a reduction, initialize the output (open for loops to inner
+  //  most, predicate, initialize, F predicate, close to computeAt)
+  if (out->hasReduction())
+    initReduction(out, static_cast<ReductionOp*>(expr)->init());
+
+  //  5) Open to inner most loop
+  for (decltype(out->nDims()) i = for_loops.size(); i < out->nDims(); i++)
+    openFor(out->getComputeAtAxis(i));
+  //  6) Run expression
   pushBack(expr);
+
+  // 7) Reduce loop structure back to computeAt
+  while (!compute_at_scope.empty() &&
+         compute_at_scope.size() > out->getComputeAtAxis())
+    popFor();
 }
 
 // Generate the loop nest structure and place it in lowered_exprs
-void LoopNestGenerator::generate() {
+void LoopNestGenerator::generate(std::vector<Expr*> exprs) {
   FusionGuard fg(fusion_);
 
   // Initialize members of the class
   lowered_exprs = std::vector<Expr*>();
-  active_view = nullptr;
-  active_view_axis = 0;
 
-  std::vector<Expr*> exprs = fusion_->exprs(true);
   for (auto* expr : exprs)
     handle(expr);
 }

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -191,7 +191,7 @@ void UnrollPass::handle(ForLoop* fl) {
         Bool* pred = getPredicate(out, ir_utils::indices(for_loops));
 
         // If we need a predicate, put expr inside an if then else
-      
+
         if (!(pred->isConst()) || !(pred->isConst() && pred->value().value())) {
           IfThenElse* inline_ite =
               new IfThenElse(pred, {expr}, {}, for_loops.back());

--- a/torch/csrc/jit/codegen/cuda/lower_loops.h
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.h
@@ -20,10 +20,6 @@ struct UnrollPass : public OptOutDispatch {
   // keep track if we're within an unrolled loop
   bool within_unroll = false;
 
-  // Track the last computeAt TensorView and axis
-  const TensorView* active_view;
-  unsigned int active_view_axis;
-
   // Custom dispatch for Expr, want to find out of it's a TV op
   void handle(Expr*) final;
 
@@ -46,23 +42,18 @@ struct TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   std::vector<Expr*> lowered_exprs;
   Fusion* fusion_;
 
-  // Track the last computeAt TensorView and axis
-  const TensorView* active_view;
-  unsigned int active_view_axis;
-
   // Keep all for loops conveniently to make unrolling easier
   std::vector<ForLoop*> for_loops;
+  // computeAT scope is determined by the iterat domain, and the tensor view it
+  // belongs to (the final TensorView when following the computeAt path)
+  std::vector<std::pair<IterDomain*, TensorView*>> compute_at_scope;
 
   // Get Register allocation statement for tensorview
   void pushAlloc(TensorView*);
 
-  // Clear out the last recorded computeAtView
-  void clearActiveView();
-  // Set active views from computeAtView
-  void setActiveView(const TensorView* const);
-
   // Open a new inner most for loop
-  void openFor(IterDomain*);
+  void openFor(std::pair<IterDomain*, TensorView*>);
+  void popFor();
 
   // Wrap pushBack in lower_utils if active_scope is null we want it to go
   // straight to lower_exprs
@@ -71,19 +62,24 @@ struct TORCH_CUDA_API LoopNestGenerator : public OptOutDispatch {
   // Update for loop structure based on this TensorView
   void updateLoopNest(TensorView*);
 
+  // Update for loop structure based on this TensorView
+  void initReduction(TensorView* tv, Val* init_val);
+
   // Check if a TV op, generate for loop nest around it
   void handle(Expr*) final;
 
   // Generate the loop nest structure and place it in lowered_exprs
-  void generate();
+  void generate(std::vector<Expr*> exprs);
 
   LoopNestGenerator(Fusion* _fusion) : fusion_(_fusion) {}
 
  public:
-  static std::vector<Expr*> getLoopNest(Fusion* fusion) {
+  static std::vector<Expr*> getLoopNest(
+      Fusion* fusion,
+      std::vector<Expr*> exprs) {
     FusionGuard fg(fusion);
     LoopNestGenerator lng(fusion);
-    lng.generate();
+    lng.generate(exprs);
     return lng.lowered_exprs;
   }
 };

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -347,8 +347,10 @@ Expr* getParent(Expr* scope) {
 ForLoop* openFor(Expr* scope, IterDomain* id) {
   ForLoop* new_scope = nullptr;
   if (id->isThread()) {
+    std::stringstream ss;
+    ss << id->parallel_method();
     new_scope = new ForLoop(
-        new NamedScalar(stringify(id->parallel_method()), DataType::Int),
+        new NamedScalar(ss.str(), DataType::Int),
         id,
         {},
         scope);

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -349,11 +349,8 @@ ForLoop* openFor(Expr* scope, IterDomain* id) {
   if (id->isThread()) {
     std::stringstream ss;
     ss << id->parallel_method();
-    new_scope = new ForLoop(
-        new NamedScalar(ss.str(), DataType::Int),
-        id,
-        {},
-        scope);
+    new_scope =
+        new ForLoop(new NamedScalar(ss.str(), DataType::Int), id, {}, scope);
   } else {
     new_scope = new ForLoop(new Int(), id, {}, scope);
   }

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -424,6 +424,7 @@ bool isTVOp(const Expr* expr) {
   if (expr->nOutputs() == 1 && isTV(expr->output(0)) &&
       (expr->getExprType().value() == ExprType::BinaryOp ||
        expr->getExprType().value() == ExprType::UnaryOp ||
+       expr->getExprType().value() == ExprType::TernaryOp ||
        expr->getExprType().value() == ExprType::ReductionOp))
     return true;
   return false;

--- a/torch/csrc/jit/codegen/cuda/lower_utils.h
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.h
@@ -12,11 +12,8 @@ namespace fuser {
 
 namespace scope_utils {
 
-// Grab the index variables of the active loop nest
-std::vector<Val*> getLoopIndices(Expr* scope);
-
-// Grab the iterDomains of the active loops
-std::vector<IterDomain*> getLoopIterDomains(Expr* scope);
+// Grab the ForLoop starting from scope working out
+std::vector<ForLoop*> getLoops(Expr* scope);
 
 // Track how far our for loop scope is
 unsigned int computeForDepth(Expr* scope);
@@ -39,7 +36,8 @@ Expr* closeScope(Expr* scope);
 // Clear all expressions from the scope
 Expr* clearScope(Expr* scope);
 
-// Provide a new for loop matching the one provided
+// Provide a new for loop matching the one provided, sets parent_scope as
+// parent_scope, but does not insert into parent scope.
 ForLoop* cloneLoopNest(ForLoop* to_clone, Expr* parent_scope);
 
 // Run through a scope and replace expressions inside with replacement_map
@@ -53,9 +51,15 @@ Expr* firstInnerMostScope(Expr* scope);
 
 namespace ir_utils {
 
+std::vector<Val*> indices(std::vector<ForLoop*>);
+
+std::vector<IterDomain*> iterDomains(std::vector<ForLoop*>);
+
 bool isTV(const Val* const);
 
 bool isTVOp(const Expr*);
+
+bool isScalarOp(const Expr*);
 
 void ASSERT_EXPR(Statement*);
 

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -102,14 +102,24 @@ Statement* OptOutMutator::mutate(TensorIndex* ti) {
   return mutated_val;
 }
 
-Statement* OptOutMutator::mutate(Float* n) {
-  return n;
+Statement* OptOutMutator::mutate(Bool* b) {
+  return b;
 }
-Statement* OptOutMutator::mutate(Int* n) {
-  return n;
+
+Statement* OptOutMutator::mutate(Float* f) {
+  return f;
 }
-Statement* OptOutMutator::mutate(NamedScalar* n) {
-  return n;
+
+Statement* OptOutMutator::mutate(Half* h) {
+  return h;
+}
+
+Statement* OptOutMutator::mutate(Int* i) {
+  return i;
+}
+
+Statement* OptOutMutator::mutate(NamedScalar* ns) {
+  return ns;
 }
 
 // MUTATE FUNCTIONS FOR EXPRESSIONS.

--- a/torch/csrc/jit/codegen/cuda/mutator.cpp
+++ b/torch/csrc/jit/codegen/cuda/mutator.cpp
@@ -243,8 +243,8 @@ Statement* OptOutMutator::mutate(IfThenElse* ite) {
   Val* val_cond = mutateAsVal(ite->cond())->asVal();
   TORCH_INTERNAL_ASSERT(
       val_cond->getValType().value() == ValType::Scalar &&
-      val_cond->getDataType().value() == DataType::Int);
-  Int* cond = static_cast<Int*>(cond);
+      val_cond->getDataType().value() == DataType::Bool);
+  Bool* cond = static_cast<Bool*>(cond);
 
   bool is_mutated = !cond->sameAs(ite->cond());
 

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -93,7 +93,7 @@ class IrParser {
       out->split(0, nthreads);
       // Split by another 4 which will be our unroll factor
       auto ur_factor = disable_unroll ? 1 : unroll_factor;
-      if(!disable_unroll){
+      if (!disable_unroll) {
         out->split(0, ur_factor);
         cuda_kernel_->unroll_factor_ = ur_factor;
       }
@@ -102,14 +102,14 @@ class IrParser {
     // Run through outputs, grab all inputs of outputs
     // squeeze with computeAt to set overall structure.
     for (auto output : fusion_->outputs()) {
-      if(output->getValType() != ValType::TensorView)
+      if (output->getValType() != ValType::TensorView)
         continue;
       TensorView* out_tv = static_cast<TensorView*>(output);
       for (Val* inp : fusion_->inputsOf(output)) {
         if (inp->getValType().value() == ValType::TensorView)
           static_cast<TensorView*>(inp)->computeAt(out_tv, 1);
       }
-      out_tv->axis(0)->parallelize(ParallelType::BIDx); 
+      out_tv->axis(0)->parallelize(ParallelType::BIDx);
     }
 
     // Run through intermediates, unroll, and bind their axes
@@ -123,9 +123,8 @@ class IrParser {
       if (!disable_unroll && tv->nDims() == 3) {
         tv->axis(-2)->parallelize(ParallelType::Unroll);
         tv->axis(-1)->parallelize(ParallelType::TIDx);
-      }
-      else{
-        if(tv->nDims() == 2)
+      } else {
+        if (tv->nDims() == 2)
           tv->axis(-1)->parallelize(ParallelType::TIDx);
       }
     }

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -93,36 +93,41 @@ class IrParser {
       out->split(0, nthreads);
       // Split by another 4 which will be our unroll factor
       auto ur_factor = disable_unroll ? 1 : unroll_factor;
-      out->split(0, ur_factor);
-      cuda_kernel_->unroll_factor_ = ur_factor;
-
-      // Map blocks/threads
-      out->axis(0)->parallelize(ParallelType::BIDx);
-      out->axis(1)->parallelize(ParallelType::Unroll);
-      out->axis(-1)->parallelize(ParallelType::TIDx);
+      if(!disable_unroll){
+        out->split(0, ur_factor);
+        cuda_kernel_->unroll_factor_ = ur_factor;
+      }
     }
 
     // Run through outputs, grab all inputs of outputs
     // squeeze with computeAt to set overall structure.
-    for (auto jit_output : block->outputs()) {
-      TensorView* out =
-          static_cast<TensorView*>(value_map_[jit_output->unique()]);
-
-      for (Val* inp : fusion_->inputsOf(out)) {
+    for (auto output : fusion_->outputs()) {
+      if(output->getValType() != ValType::TensorView)
+        continue;
+      TensorView* out_tv = static_cast<TensorView*>(output);
+      for (Val* inp : fusion_->inputsOf(output)) {
         if (inp->getValType().value() == ValType::TensorView)
-          static_cast<TensorView*>(inp)->computeAt(out, 1);
+          static_cast<TensorView*>(inp)->computeAt(out_tv, 1);
       }
+      out_tv->axis(0)->parallelize(ParallelType::BIDx); 
     }
 
     // Run through intermediates, unroll, and bind their axes
     for (auto val : fusion_->vals()) {
-      if (fusion_->hasInput(val) || fusion_->hasOutput(val))
-        continue;
       if (val->getValType().value() != ValType::TensorView)
         continue;
       TensorView* tv = static_cast<TensorView*>(val);
-      tv->axis(-2)->parallelize(ParallelType::Unroll);
-      tv->axis(-1)->parallelize(ParallelType::TIDx);
+
+      // Should be true for all intermediates, but if one isn't hooked
+      // up right, skip it and hope for the best for now
+      if (!disable_unroll && tv->nDims() == 3) {
+        tv->axis(-2)->parallelize(ParallelType::Unroll);
+        tv->axis(-1)->parallelize(ParallelType::TIDx);
+      }
+      else{
+        if(tv->nDims() == 2)
+          tv->axis(-1)->parallelize(ParallelType::TIDx);
+      }
     }
   }
 

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -9,18 +9,18 @@ namespace jit {
 namespace fuser {
 
 bool PredicateCompute::hasPredicates(const TensorIndex* ti) {
-  std::vector<Int*> preds;
+  std::vector<Bool*> preds;
   for (auto ind : ti->indices())
     if (FusionGuard::getCurFusion()->origin(ind) != nullptr)
       return true;
   return false;
 }
 
-std::vector<Int*> PredicateCompute::computePredicates(const TensorIndex* ti) {
+std::vector<Bool*> PredicateCompute::computePredicates(const TensorIndex* ti) {
   const TensorView* tv = ti->view();
   TensorDomain* root = tv->getRootDomain();
 
-  std::vector<Int*> preds;
+  std::vector<Bool*> preds;
   if (FusionGuard::getCurFusion()->origin(tv->domain()) == nullptr &&
       tv->nDims() == ti->nDims())
     return preds;
@@ -32,10 +32,10 @@ std::vector<Int*> PredicateCompute::computePredicates(const TensorIndex* ti) {
       Val* pred = lt(ti->index(i), root->axis(i)->extent());
       TORCH_INTERNAL_ASSERT(
           pred->getValType().value() == ValType::Scalar &&
-          pred->getDataType().value() == DataType::Int);
-      preds.push_back(static_cast<Int*>(pred));
+          pred->getDataType().value() == DataType::Bool);
+      preds.push_back(static_cast<Bool*>(pred));
     } else {
-      preds.push_back(new Int(1));
+      preds.push_back(new Bool(true));
     }
 
   return preds;

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -17,20 +17,22 @@ bool PredicateCompute::hasPredicates(const TensorIndex* ti) {
 }
 
 std::vector<Int*> PredicateCompute::computePredicates(const TensorIndex* ti) {
-  std::vector<Int*> preds;
-  if (!hasPredicates(ti))
-    return preds;
   const TensorView* tv = ti->view();
-
   TensorDomain* root = tv->getRootDomain();
-  TORCH_CHECK(root->nDims() == ti->nDims());
+
+  std::vector<Int*> preds;
+  if (FusionGuard::getCurFusion()->origin(tv->domain()) == nullptr &&
+      tv->nDims() == ti->nDims())
+    return preds;
+
+  TORCH_INTERNAL_ASSERT(root->nDims() == ti->nDims());
   for (decltype(ti->nDims()) i{0}; i < ti->nDims(); i++)
 
     if (FusionGuard::getCurFusion()->origin(ti->index(i)) != nullptr) {
       Val* pred = lt(ti->index(i), root->axis(i)->extent());
-      TORCH_CHECK(
+      TORCH_INTERNAL_ASSERT(
           pred->getValType().value() == ValType::Scalar &&
-          pred->getDataType().value() == DataType::Bool);
+          pred->getDataType().value() == DataType::Int);
       preds.push_back(static_cast<Int*>(pred));
     } else {
       preds.push_back(new Int(1));

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.h
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.h
@@ -38,7 +38,7 @@ struct PredicateCompute {
 
   // Return the series of predicates, if an axis doesn't have a predicate
   // reutrns 1
-  static std::vector<Int*> computePredicates(const TensorIndex*);
+  static std::vector<Bool*> computePredicates(const TensorIndex*);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/tensor_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/tensor_view.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 #include <torch/csrc/jit/codegen/cuda/iter_visitor.h>
 #include <torch/csrc/jit/codegen/cuda/mutator.h>
+#include <torch/csrc/jit/codegen/cuda/transform_iter.h>
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 
 namespace torch {
@@ -50,6 +51,10 @@ TensorView* TensorView::clone() const {
   return new_view;
 }
 
+bool TensorView::hasReduction() const {
+  return domain()->hasReduction();
+}
+
 TensorView* TensorView::newForOutput(DataType dtype) const {
   std::vector<IterDomain*> domain_copy;
   for (decltype(this->nDims()) i = 0; i < this->nDims(); i++) {
@@ -62,6 +67,38 @@ TensorView* TensorView::newForOutput(DataType dtype) const {
   }
   TensorDomain* td = new TensorDomain(domain_copy);
   return new TensorView(td, dtype);
+};
+
+// TODO: How do we adjust this so we can reduce to a single scalar value?
+TensorView* TensorView::newForReduction(std::vector<unsigned int> axes) const {
+  TensorDomain* orig_domain = this->getRootDomain()->noReductions();
+  std::set<unsigned int> axes_set(axes.begin(), axes.end());
+
+  std::vector<IterDomain*> new_domain;
+
+  TORCH_INTERNAL_ASSERT(
+      (*axes_set.end()) < orig_domain->nDims(),
+      "Error setting up reduction, reduction axis is outside nDims. Keep in mind reductions are relative to root domains, not modified views.");
+
+  for (decltype(orig_domain->nDims()) dim = 0; dim < orig_domain->nDims();
+       dim++) {
+    IterDomain* orig_dom = orig_domain->axis(dim);
+
+    bool isReduction = false;
+    if ((*axes_set.begin()) == dim) {
+      isReduction = true;
+      axes_set.erase(axes_set.begin());
+    }
+
+    new_domain.push_back(new IterDomain(
+        orig_dom->start(),
+        orig_dom->extent(),
+        ParallelType::Serial,
+        isReduction));
+  }
+
+  TensorDomain* td = new TensorDomain(new_domain);
+  return new TensorView(td, this->getDataType().value());
 };
 
 TensorDomain* TensorView::getRootDomain() const {
@@ -90,6 +127,17 @@ IterDomain* TensorView::axis(int pos) const {
   return domain()->axis(pos);
 }
 
+TensorView* TensorView::unsafeClone() const {
+  TensorView* new_view = new TensorView(domain_, getDataType().value());
+  new_view->compute_at_view_ = compute_at_view_;
+  new_view->compute_at_axis_ = compute_at_axis_;
+  new_view->setMemoryType(memory_type_);
+  new_view->name_ = name();
+  MemoryType memory_type_ = MemoryType::Global;
+
+  return new_view;
+}
+
 void TensorView::copyDomain(const TensorDomain* td) {
   std::vector<IterDomain*> idv;
   for (decltype(td->nDims()) i = 0; i < td->nDims(); i++)
@@ -97,20 +145,67 @@ void TensorView::copyDomain(const TensorDomain* td) {
   setDomain(new TensorDomain(idv));
 }
 
+void TensorView::computeAt_impl(TensorView* consumer, int axis) {
+  // Reset view otherwise will conflict with replay.
+  this->compute_at_view_ = nullptr;
+  this->compute_at_axis_ = 0;
+  // replay this as consumer / producer as consumer
+  TransformReplay::replayPasC(this, consumer, axis);
+  this->compute_at_view_ = consumer;
+  this->compute_at_axis_ = (unsigned int)axis;
+}
+
+void TensorView::forwardComputeAt_impl(TensorView* producer, int axis) {
+  // Reset view otherwise will conflict with replay.
+  producer->compute_at_view_ = nullptr;
+  producer->compute_at_axis_ = 0;
+  TransformReplay::replayCasP(this, producer, axis);
+  producer->compute_at_view_ = this;
+  producer->compute_at_axis_ = (unsigned int)axis;
+}
+
+namespace {
+// Wrapper around set_intersection
+template <typename T>
+std::set<T> set_intersection(const std::set<T>& set1, const std::set<T>& set2) {
+  std::set<T> intersection;
+  std::set_intersection(
+      set1.begin(),
+      set1.end(),
+      set2.begin(),
+      set2.end(),
+      std::inserter(intersection, intersection.begin()));
+  return intersection;
+}
+
+// convert an iterable of Val* to be an iterable of TensorView*
+template <typename T1, typename T2>
+T1 tv_iterable(const T2& val_iterable) {
+  T1 tv_iterable = T1();
+  std::transform(
+      val_iterable.begin(),
+      val_iterable.end(),
+      std::back_inserter(tv_iterable),
+      [](Val* v) {
+        TORCH_INTERNAL_ASSERT(
+            v->getValType().value() == ValType::TensorView,
+            "When following the computeAt dependency chain, a non TensorView value was found.");
+        return static_cast<TensorView*>(v);
+      });
+  return tv_iterable;
+}
+} // namespace
+
 TensorView* TensorView::computeAt(TensorView* consumer, int axis) {
-  /*
-   * Recursive compute_at:
-   * Recurse backward from consumer, to this, make sure there's a dependency
-   * chain there. Call ComputeAt for all tensors between this and consumer.
-   *
-   * Compute at modifies this, not consumer.
-   */
   TORCH_CHECK(
       this->fusion() == consumer->fusion(),
       this,
       " and ",
       consumer,
       " are not in the same fusion.");
+
+  FusionGuard fg(this->fusion());
+
   TORCH_CHECK(
       !this->sameAs(consumer), "Cannot call this->computeAt(this, ...)");
 
@@ -123,90 +218,119 @@ TensorView* TensorView::computeAt(TensorView* consumer, int axis) {
       axis >= 0 && axis < consumer->nDims() + 1,
       "Compute at called on an axis outside valid range.");
 
-  std::stack<Val*> dep_chain =
-      DependencyCheck::getDependencyChain(this, consumer);
+  // If not direct relationship follow dependency chain.
+  auto dep_chains = DependencyCheck::getAllDependencyChains(this, consumer);
+
+  std::deque<Val*> dep_chain;
+  if (!dep_chains.empty())
+    dep_chain = dep_chains.front();
 
   TORCH_CHECK(
-      DependencyCheck::getDependencyChain(consumer, this).size() == 0,
-      "Expected ",
+      !dep_chain.empty(),
+      "Compute At expects ",
       this,
-      " computeAt ",
+      " is a dependency of ",
       consumer,
-      " but got the reverse.");
+      ", however it is not.");
 
-  if (dep_chain.size() == 0) {
-    // Make sure ordering is correct based on ordered vars in Fusion.
-    auto vals = FusionGuard::getCurFusion()->deterministic_vals();
-    for (auto val : vals) {
-      if (val == this) {
-        break;
-      } else if (val == consumer) {
-        consumer->computeAt(this, axis);
-        return this;
-      }
-    }
-  }
+  TORCH_INTERNAL_ASSERT(
+      dep_chain.back() == consumer && dep_chain[0] == this,
+      "Error computing dependency chain.");
 
-  // forward apply to uses of this.
-  // Recursively apply replay.
-  TensorView* running_consumer = consumer;
-  // dep_chain = deps <- consumer (this chain doesn't contain this)
-  // We want to apply:
-  //  dep[n-1].compute_at(consumer)
-  //  ...
-  //  this.compute_at(dep[0])
-  while (!dep_chain.empty()) {
-    Val* val = dep_chain.top();
-    dep_chain.pop();
+  // Replay from consumer to producer
+  while (dep_chain.size() > 1) {
+    Val* consumer_val = dep_chain.back();
+    dep_chain.pop_back();
+    Val* producer_val = dep_chain.back();
+
     TORCH_INTERNAL_ASSERT(
-        val->getValType() == ValType::TensorView,
-        "When following the transform dependency chain, an invalid value was found.");
-    TensorView* tv = static_cast<TensorView*>(val);
-    if (tv->sameAs(consumer))
-      continue;
-    tv->computeAt(running_consumer, axis);
-    // TransformReplay::replay(running_consumer, tv, axis);
-    running_consumer = tv; // replay is in-place
+        consumer_val->getValType().value() == ValType::TensorView &&
+            producer_val->getValType().value() == ValType::TensorView,
+        "When following the computeAt dependency chain, a non TensorView value was found.");
+
+    TensorView* running_consumer = static_cast<TensorView*>(consumer_val);
+    TensorView* running_producer = static_cast<TensorView*>(producer_val);
+    running_producer->computeAt_impl(running_consumer, axis);
   }
-  // At this point running_consumer is the direct consumer of this
 
-  // If another view consumes this, we may be computing this at a position that
-  // doesn't match that consumer. Likely producing too little for that next
-  // consumer
-  for (Expr* other_use : FusionGuard::getCurFusion()->uses(this)) {
-    for (Val* maybe_other_consumer : other_use->outputs()) {
-      if (*(maybe_other_consumer->getValType()) != ValType::TensorView)
-        continue;
+  /*
+   * Compute At has now worked from consumer to producer, transforming producer
+   * to match computeAt selected in consumer We now need to work from producer
+   * up to its consumers (including indirect consumption) so their use also
+   * matches. If we can find a TV that contains all uses of producer, we can
+   * terminate this propagation there. If not, we need to propagate all the way
+   * to outputs.
+   *
+   * First we'll look for that terminating point.
+   */
 
-      TensorView* other_consumer =
-          static_cast<TensorView*>(maybe_other_consumer);
-      if (running_consumer->sameAs(other_consumer))
-        continue;
+  // Grab all uses of producer
+  auto val_all_consumer_chains =
+      DependencyCheck::getAllDependencyChainsTo(this);
 
-      if (DependencyCheck::isDependencyOf(running_consumer, other_consumer)) {
-        // There seem to be two choices here, either running_consumer or
-        // consumer I believe they end up being equivelent, but uncertain they
-        // actually are.
-        running_consumer->computeAt(other_consumer, axis);
-      } else {
-        other_consumer->computeAt(running_consumer, axis);
+  // Convert dep chains to tensor view chains
+  std::deque<std::deque<TensorView*>> all_consumer_chains;
+  for (auto val_dep_chain : val_all_consumer_chains)
+    all_consumer_chains.push_back(
+        tv_iterable<std::deque<TensorView*>>(val_dep_chain));
+
+  std::set<TensorView*> common_consumers(
+      all_consumer_chains.front().begin(), all_consumer_chains.front().end());
+  for (auto dep_chain : all_consumer_chains) {
+    std::set<TensorView*> chain_consumers(dep_chain.begin(), dep_chain.end());
+    common_consumers = set_intersection(
+        common_consumers,
+        std::set<TensorView*>(dep_chain.begin(), dep_chain.end()));
+  }
+
+  // Remove all TVs between producer and consumer
+  for (auto dep_chain : dep_chains) {
+    auto tv_chain = tv_iterable<std::deque<TensorView*>>(dep_chain);
+    for (auto tv : tv_chain) {
+      if (tv != consumer)
+        common_consumers.erase(tv);
+    }
+  }
+
+  // Grab the first (topologically) common consumer
+  TensorView* common_consumer = nullptr;
+  if (!common_consumers.empty()) {
+    for (TensorView* tv : all_consumer_chains.front())
+      if (common_consumers.find(tv) != common_consumers.end()) {
+        common_consumer = tv;
+        break;
+      }
+  }
+
+  // Forward compute at through all consumers until common_consumer if there is
+  // one
+  std::set<TensorView*> output_set;
+  std::vector<TensorView*> ordered_outputs;
+  for (auto dep_chain : all_consumer_chains) {
+    while (dep_chain.size() > 1) {
+      TensorView* running_producer = dep_chain.front();
+      dep_chain.pop_front();
+      TensorView* running_consumer = dep_chain.front();
+
+      if (running_producer == common_consumer)
+        break;
+
+      running_consumer->forwardComputeAt_impl(running_producer, axis);
+      if (dep_chain.size() == 1) { // last one
+        if (output_set.find(running_consumer) == output_set.end()) {
+          output_set.emplace(running_consumer);
+          ordered_outputs.push_back(running_consumer);
+        }
       }
     }
   }
 
-  if (FusionGuard::getCurFusion()->origin(this) == nullptr)
-    return this;
+  for (decltype(ordered_outputs.size()) i{0};
+       i < ordered_outputs.size() - 1 && ordered_outputs.size() > 0;
+       i++) {
+    ordered_outputs[i]->computeAt_impl(ordered_outputs[i + 1], axis);
+  }
 
-  // Dep chain doesn't contain this, try to run on replay, as it may be merging
-  // two independent loop nests of the same sizes.
-
-  // Reset view otherwise will conflict with replay.
-
-  this->compute_at_view_ = nullptr;
-  this->compute_at_axis_ = -1;
-  TransformReplay::replay(running_consumer, this, axis);
-  this->compute_at_view_ = running_consumer;
-  this->compute_at_axis_ = (unsigned int)axis;
   return this;
 }
 
@@ -246,16 +370,16 @@ TensorView* TensorView::merge(int axis) {
 }
 
 // Reorder axes according to map[old_pos] = new_pos
-TensorView* TensorView::reorder(const std::unordered_map<int, int>& axis2pos_) {
+TensorView* TensorView::reorder(const std::unordered_map<int, int>& old2new_) {
   // START VALIDATION CHECKS
   // adjust based on negative values (any negative values gets nDims added to
   // it)
-  std::unordered_map<int, int> axis2pos;
+  std::unordered_map<int, int> old2new;
   auto ndims = nDims();
   std::transform(
-      axis2pos_.begin(),
-      axis2pos_.end(),
-      std::inserter(axis2pos, axis2pos.begin()),
+      old2new_.begin(),
+      old2new_.end(),
+      std::inserter(old2new, old2new.begin()),
       [ndims](std::unordered_map<int, int>::value_type entry) {
         return std::unordered_map<int, int>::value_type({
             entry.first < 0 ? entry.first + ndims : entry.first,
@@ -265,8 +389,8 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& axis2pos_) {
 
   // Check if any adjusted values are < 0, or >= nDims, which are invalid
   bool out_of_range = std::any_of(
-      axis2pos.begin(),
-      axis2pos.end(),
+      old2new.begin(),
+      old2new.end(),
       [ndims](std::unordered_map<int, int>::value_type entry) {
         return entry.first < 0 || entry.first >= ndims || entry.second < 0 ||
             entry.second >= ndims;
@@ -280,8 +404,8 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& axis2pos_) {
 
   std::set<int> old_pos_set;
   std::transform(
-      axis2pos.begin(),
-      axis2pos.end(),
+      old2new.begin(),
+      old2new.end(),
       std::inserter(old_pos_set, old_pos_set.begin()),
       [](std::unordered_map<int, int>::value_type entry) {
         return entry.first;
@@ -289,8 +413,8 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& axis2pos_) {
 
   std::set<int> new_pos_set;
   std::transform(
-      axis2pos.begin(),
-      axis2pos.end(),
+      old2new.begin(),
+      old2new.end(),
       std::inserter(new_pos_set, new_pos_set.begin()),
       [](std::unordered_map<int, int>::value_type entry) {
         return entry.first;
@@ -298,8 +422,8 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& axis2pos_) {
 
   // Error out if duplicate values are found.
   TORCH_CHECK(
-      old_pos_set.size() == axis2pos.size() &&
-          new_pos_set.size() == axis2pos.size(),
+      old_pos_set.size() == old2new.size() &&
+          new_pos_set.size() == old2new.size(),
       "Duplicate entries in transformation map sent to TensorView reorder.");
 
   // Check if we're trying to reorder any values outside of the computeAt axis
@@ -307,8 +431,8 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& axis2pos_) {
   if (hasComputeAt()) {
     auto compute_at_axis = getComputeAtAxis();
     bool outside_computeat = std::any_of(
-        axis2pos.begin(),
-        axis2pos.end(),
+        old2new.begin(),
+        old2new.end(),
         [compute_at_axis](std::unordered_map<int, int>::value_type entry) {
           return entry.first < compute_at_axis ||
               entry.second < compute_at_axis;
@@ -318,9 +442,50 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& axis2pos_) {
         "Cannot reorder dimensions that are outside computeAt axis.");
   }
   // END VALIDATION CHECKS
-  setDomain(domain()->reorder(axis2pos_));
+  setDomain(domain()->reorder(old2new_));
 
   return this;
+}
+
+/*
+ * Take reduction axes out of this domain, and create a new domain. New domain
+ * will be used to create this domain. For example: TV1[I0, I1] = TV0[I0, R0,
+ * R1, I1] TV0->rfactor({1}) TV0 is transformed to -> TV0[I0, R1, I1] The
+ * TensorView returned is: TV2[I0, R0, I3, I1] The reduction will now beset
+ * as: TV1[I0, R1, I1] = TV2[I0, R0, I3, I1] TV0[I0, I1] = TV1[I0, R1, I1]
+ */
+TensorView* TensorView::rFactor(const std::vector<int> axes) {
+  auto domain_pair = domain()->rFactor(axes);
+  auto producer_domain = domain_pair.first;
+  auto consumer_domain = domain_pair.second;
+  FusionGuard fg(this->fusion());
+  Expr* origin_expr = this->fusion()->origin(this);
+  TORCH_CHECK(
+      origin_expr != nullptr &&
+          origin_expr->getExprType() == ExprType::ReductionOp,
+      "Error rfactoring ",
+      this,
+      " its origin is either a nullptr or not a reduction.");
+  ReductionOp* this_origin = static_cast<ReductionOp*>(origin_expr);
+
+  TensorView* producer =
+      new TensorView(producer_domain, this->getDataType().value());
+
+  this->setDomain(consumer_domain);
+  TensorView* consumer = this;
+
+  Expr* producer_origin = new ReductionOp(
+      this_origin->getReductionOpType(),
+      this_origin->init(),
+      producer,
+      this_origin->in());
+  Expr* consumer_origin = new ReductionOp(
+      this_origin->getReductionOpType(),
+      this_origin->init(),
+      consumer,
+      producer);
+
+  return producer;
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_iter.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.cpp
@@ -1,42 +1,45 @@
 #include <torch/csrc/jit/codegen/cuda/transform_iter.h>
+#include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 
 namespace torch {
 namespace jit {
 namespace fuser {
 
-void TransformIter::replayBackward(Split* expr) {}
+TensorDomain* TransformIter::replayBackward(Split* split, TensorDomain* td) {
+  return split->in();
+}
 
-void TransformIter::replayBackward(Merge* expr) {}
+TensorDomain* TransformIter::replayBackward(Merge* merge, TensorDomain* td) {
+  return merge->in();
+}
 
-void TransformIter::replayBackward(Reorder* expr) {}
+TensorDomain* TransformIter::replayBackward(
+    Reorder* reorder,
+    TensorDomain* td) {
+  return reorder->in();
+}
 
-void TransformIter::replayBackward(Expr* expr) {
+TensorDomain* TransformIter::replayBackward(Expr* expr, TensorDomain* td) {
   TORCH_INTERNAL_ASSERT(
       expr->isExpr(),
       "Dispatch in transform iteration is expecting Exprs only.");
   switch (*(expr->getExprType())) {
     case (ExprType::Split):
-      replayBackward(static_cast<Split*>(expr));
-      break;
+      return replayBackward(static_cast<Split*>(expr), td);
     case (ExprType::Merge):
-      replayBackward(static_cast<Merge*>(expr));
-      break;
+      return replayBackward(static_cast<Merge*>(expr), td);
     case (ExprType::Reorder):
-      replayBackward(static_cast<Reorder*>(expr));
-      break;
+      return replayBackward(static_cast<Reorder*>(expr), td);
     default:
       TORCH_INTERNAL_ASSERT(
           false, "Could not detect expr type in replayBackward.");
   }
 }
 
-TensorDomain* TransformIter::runBackward(
-    TensorDomain* td,
-    bool generate_record) {
-  if (generate_record)
-    record = std::vector<Expr*>();
-
+std::vector<Expr*> TransformIter::getHistory(TensorDomain* td) {
+  std::vector<Expr*> ops;
   TensorDomain* root = td; // backward running td
   Fusion* fusion = FusionGuard::getCurFusion();
 
@@ -50,7 +53,7 @@ TensorDomain* TransformIter::runBackward(
       TORCH_INTERNAL_ASSERT(
           false,
           "TransformReplay::runBackward is not traversing a correct history.");
-
+    ops.push_back(orig);
     visited_exprs.emplace(orig);
     TensorDomain* previous_td = nullptr;
     // Check inputs of this operation, make sure there isn't more than one TD
@@ -62,22 +65,27 @@ TensorDomain* TransformIter::runBackward(
               false,
               "TransformReplay::runBackward could not decifer transform history of a TensorDomain.");
 
-        // Place transform op on top of stack.
-        if (generate_record)
-          record.push_back(orig);
-
-        // run operation
-        replayBackward(orig);
-
         // Traverse back
         root = static_cast<TensorDomain*>(inp);
         orig = fusion->origin(root);
       }
   }
-  if (generate_record)
-    std::reverse(record.begin(), record.end());
+  return std::vector<Expr*>(ops.rbegin(), ops.rend());
+}
 
-  return root;
+TensorDomain* TransformIter::runBackward(TensorDomain* td) {
+  std::vector<Expr*> ops = getHistory(td);
+
+  // We want to iterate backwards, reverse history.
+  ops = std::vector<Expr*>(ops.rbegin(), ops.rend());
+
+  Fusion* fusion = FusionGuard::getCurFusion();
+
+  TensorDomain* running_td = td;
+  for (Expr* op : ops)
+    running_td = replayBackward(op, running_td);
+
+  return running_td;
 }
 
 TensorDomain* TransformIter::replay(Split* expr, TensorDomain* td) {
@@ -90,10 +98,10 @@ TensorDomain* TransformIter::replay(Merge* expr, TensorDomain* td) {
 }
 
 TensorDomain* TransformIter::replay(Reorder* expr, TensorDomain* td) {
-  std::unordered_map<int, int> axis2pos;
-  for (decltype(expr->pos2axis().size()) i{0}; i < expr->pos2axis().size(); i++)
-    axis2pos[expr->pos2axis()[i]] = i;
-  return td->reorder(axis2pos);
+  std::unordered_map<int, int> old2new;
+  for (decltype(expr->new2old().size()) i{0}; i < expr->new2old().size(); i++)
+    old2new[expr->new2old()[i]] = i;
+  return td->reorder(old2new);
 }
 
 TensorDomain* TransformIter::replay(Expr* expr, TensorDomain* td) {
@@ -110,11 +118,1127 @@ TensorDomain* TransformIter::replay(Expr* expr, TensorDomain* td) {
   }
 }
 
-TensorDomain* TransformIter::runReplay(TensorDomain* td) {
-  for (auto it = record.begin(); it < record.end(); ++it) {
-    td = TransformIter::replay(*it, td);
-  }
+TensorDomain* TransformIter::runReplay(
+    TensorDomain* td,
+    std::vector<Expr*> history) {
+  for (Expr* op : history)
+    td = TransformIter::replay(op, td);
   return td;
+}
+
+namespace {
+
+void validate_axis_map(int nDims, std::vector<int> axis_map) {
+  TORCH_INTERNAL_ASSERT(
+      axis_map.size() == nDims,
+      "Invalid axis map in replay transform. NDims doesn't match.");
+
+  TORCH_INTERNAL_ASSERT(
+      !std::any_of(
+          axis_map.begin(),
+          axis_map.end(),
+          [nDims](int i) { return i < -1 || i >= nDims; }),
+      "Invalid axis map in replay transform, map goes outside domains of provided TensorDomain.");
+}
+
+void validate_history_entry(Expr* expr, int nDims) {
+  TORCH_INTERNAL_ASSERT(
+      expr->input(0)->getValType().value() == ValType::TensorDomain &&
+          static_cast<TensorDomain*>(expr->input(0))->nDims() == nDims,
+      "Invalid history, or invalid axis_map in TransformIter.");
+}
+
+struct Influence : public TransformIter {
+ private:
+  // BACKWARD INFLUENCE
+
+  TensorDomain* replayBackward(Split* split, TensorDomain* td) override {
+    int axis = split->axis();
+
+    TORCH_INTERNAL_ASSERT(
+        axis + 1 < influence.size(),
+        "Error during replay backwards, td/influence size mismatch.");
+    influence[axis] = influence[axis] | influence[axis + 1];
+    influence.erase(influence.begin() + axis + 1);
+
+    return split->in();
+  }
+
+  TensorDomain* replayBackward(Merge* merge, TensorDomain* td) override {
+    int axis = merge->axis();
+    TORCH_INTERNAL_ASSERT(
+        axis < influence.size(),
+        "Error during replay backwards, td/influence size mismatch.");
+    influence.insert(influence.begin() + axis + 1, influence[axis]);
+
+    return merge->in();
+  }
+
+  TensorDomain* replayBackward(Reorder* reorder, TensorDomain* td) override {
+    // new2old[new_pos] = old_pos Generate new old2new map
+    const std::vector<int>& new2old = reorder->new2old();
+
+    std::vector<bool> reorder_influence(influence.size(), false);
+    for (decltype(new2old.size()) i = 0; i < new2old.size(); i++) {
+      int new_pos = i;
+      int old_pos = new2old[i];
+      TORCH_INTERNAL_ASSERT(
+          new_pos < influence.size() && old_pos < reorder_influence.size(),
+          "Error during replay backwards, td/influence size mismatch.");
+      reorder_influence[old_pos] = influence[new_pos];
+    }
+
+    influence = reorder_influence;
+    return reorder->in();
+  }
+
+  // FORWARD INFLUENCE
+
+  TensorDomain* replay(Split* split, TensorDomain* td) {
+    int axis = split->axis();
+    TORCH_INTERNAL_ASSERT(
+        axis < influence.size(),
+        "Error during replay, td/influence size mismatch.");
+    influence.insert(influence.begin() + axis + 1, influence[axis]);
+    return nullptr;
+  }
+
+  TensorDomain* replay(Merge* merge, TensorDomain* td) {
+    int axis = merge->axis();
+    TORCH_INTERNAL_ASSERT(
+        axis >= 0 && axis + 1 < influence.size(),
+        "Error during replay, td/influence size mismatch.");
+    influence[axis] = influence[axis] | influence[axis + 1];
+    influence.erase(influence.begin() + axis + 1);
+    return nullptr;
+  }
+
+  TensorDomain* replay(Reorder* reorder, TensorDomain* td) {
+    // new2old[new_pos] = old_pos Generate new old2new map
+    const std::vector<int>& new2old = reorder->new2old();
+
+    std::vector<bool> reorder_influence(influence.size(), false);
+    for (decltype(new2old.size()) i = 0; i < new2old.size(); i++) {
+      int new_pos = i;
+      int old_pos = new2old[i];
+      TORCH_INTERNAL_ASSERT(
+          new_pos < influence.size() && old_pos < reorder_influence.size(),
+          "Error during replay, td/influence size mismatch.");
+      reorder_influence[new_pos] = influence[old_pos];
+    }
+
+    influence = reorder_influence;
+    return nullptr;
+  }
+
+  // INTERFACE
+
+  std::vector<bool> influence;
+
+  Influence(std::vector<Expr*> history, std::vector<bool> td_influence)
+      : influence(td_influence) {}
+
+  using TransformIter::replayBackward;
+  using TransformIter::runReplay;
+
+ public:
+  static std::vector<bool> computeBackward(
+      std::vector<Expr*> history,
+      std::vector<bool> td_influence) {
+    if (history.empty())
+      return td_influence;
+
+    Val* last_val = history[history.size() - 1]->output(0);
+    TORCH_INTERNAL_ASSERT(
+        last_val->getValType().value() == ValType::TensorDomain &&
+            static_cast<TensorDomain*>(last_val)->nDims() ==
+                td_influence.size(),
+        "Tried to compute influence, but recieved an influence vector that does not match the expected size.");
+
+    Influence inf(history, td_influence);
+    std::vector<Expr*> ops(history.rbegin(), history.rend());
+    for (Expr* op : ops)
+      inf.replayBackward(op, nullptr);
+    return inf.influence;
+  }
+
+  static std::vector<bool> computeForward(
+      std::vector<Expr*> history,
+      std::vector<bool> td_influence) {
+    if (history.empty())
+      return td_influence;
+
+    TORCH_INTERNAL_ASSERT(
+        history[0]->input(0)->getValType().value() == ValType::TensorDomain &&
+            static_cast<TensorDomain*>(history[0]->input(0))->nDims() ==
+                td_influence.size(),
+        "Tried to compute influence, but recieved an influence vector that does not match the expected size.");
+    Influence inf(history, td_influence);
+    inf.runReplay(nullptr, history);
+    return inf.influence;
+  }
+
+}; // struct Influence
+
+struct Replay : public TransformIter {
+  /*
+   * Replay functions, takes a TensorDomain and steps through the operations in
+   * "record" based on influence axes. Will also update influence and propagate
+   * it forward.
+   */
+  TensorDomain* replay(Split* split, TensorDomain* td) {
+    int saxis = split->axis();
+
+    TORCH_INTERNAL_ASSERT(
+        saxis >= 0 && saxis < axis_map.size(),
+        "TransformReplay tried to modify an axis out of range, recieved ",
+        saxis,
+        " but this value should be >=0 and <",
+        axis_map.size());
+
+    // Axis relative to td
+    int axis = axis_map[saxis];
+
+    if (axis == -1) {
+      // don't modify path, we need an extra axis as there would have been one
+      // there, but we shouldn't modify it.
+      axis_map.insert(axis_map.begin() + saxis + 1, -1);
+      return td;
+    }
+
+    // Move indices up as we now have an extra axis
+    std::transform(
+        axis_map.begin(), axis_map.end(), axis_map.begin(), [axis](int i) {
+          return i > axis ? i + 1 : i;
+        });
+
+    // Insert new axis in map
+    axis_map.insert(axis_map.begin() + saxis + 1, axis + 1);
+
+    TORCH_INTERNAL_ASSERT(
+        split->factor()->isConst(),
+        "Cannot replay split as it's not based on a const value.");
+    td = td->split(axis, split->factor()->value().value());
+
+    return td;
+  }
+
+  TensorDomain* replay(Merge* merge, TensorDomain* td) {
+    int maxis = merge->axis();
+
+    TORCH_INTERNAL_ASSERT(
+        maxis >= 0 && maxis < axis_map.size(),
+        "TransformReplay tried to modify an axis out of range, recieved ",
+        maxis,
+        " but this value should be >= 0 and < axis_map.size()");
+
+    // Get axis relative to what we actually have in td.
+    int axis = axis_map[maxis];
+    int axis_p_1 = axis_map[maxis + 1];
+    // If either dim is not to be touch, set both not to be touched
+    axis = axis_p_1 == -1 ? -1 : axis;
+    axis_map[maxis] = axis;
+
+    // Remove axis from axis_map as in original transformations it didn't exist
+    axis_map.erase(axis_map.begin() + maxis + 1);
+
+    // Don't modify:
+    if (axis == -1)
+      return td;
+
+    // Move indices down as we're removing an axis
+    std::transform(
+        axis_map.begin(), axis_map.end(), axis_map.begin(), [axis](int i) {
+          return i > axis ? i - 1 : i;
+        });
+
+    return td->merge(axis);
+  }
+
+  // This transform requires reordering axes in td, then updating the axis_map
+  // We want to replay axes in td, not marked with -1, to match that in the
+  // provided reorder. This must be done because there may be a reorder that's
+  // required for a merge, as merge is specified by the first axes and merges
+  // the next consecutive axis.
+  //
+  // Once we transform td, we need to update axis_map or the mapping to provide:
+  // reorder->in()->axis(i) == reorder->axis(axis_map[i])
+  //
+  // Axes not marked with -1 should be placed in the outer most dimensions in
+  // the relative order specified by reorder. Remaining axes should be placed in
+  // the inner most dimensions maintaining their original relative positioning.
+  TensorDomain* replay(Reorder* reorder, TensorDomain* td) {
+    // convert to old2new as it makes this easier to do, and we need that map
+    // anyways in the end to replay reorder
+    const std::vector<int>& new2old_orig = reorder->new2old();
+    std::vector<int> old2new_orig(new2old_orig.size());
+    for (decltype(new2old_orig.size()) i{0}; i < new2old_orig.size(); i++)
+      old2new_orig[new2old_orig[i]] = i;
+
+    // old2new_orig: reorder->in()->axis(i) ==
+    // reorder->out()->axis(old2new_orig[i])
+
+    // We would like old2new: td->axis(i) == td_out->axis(old2new[i])
+    // if td->axis(i) will participate in the reorder defined by "reorder"
+    auto extent = reorder->in()->nDims() > td->nDims() ? reorder->in()->nDims()
+                                                       : td->nDims();
+    std::vector<int> old2new(extent, -1);
+    for (decltype(old2new_orig.size()) i{0}; i < old2new_orig.size(); i++) {
+      int old_pos = axis_map[i];
+      int new_pos = old2new_orig[i];
+      if (old_pos != -1)
+        old2new[old_pos] = new_pos;
+    }
+
+    // We want to push to the left the new positions in td_out therefore if our
+    // map looks like:
+    //
+    // Going to move all new_pos to the left so there's no gaps, for example if
+    // we have: old2new = 2 -1 4 -1 0 (0 -> 2, 2 -> 4, 4->0) we will the new
+    // positions down to: old2new = 1 -1 2 -1 0 (0 -> 1, 2 -> 2, 4->0)
+    //  0 -1 -1  3 -1 -1  6
+    //  0 -1 -1  0 -1 -1  0
+    //  0 -1 -2 -2 -3 -4 -4
+    // offset[0]  =  0 0->0
+    // offset[3]  = -2 3->1
+    // offset[6]  = -4 6->2
+    // --------------------
+    // -1 -1 -1  3 -1 -1  6
+    // -1 -1 -1  0 -1 -1  0
+    // -1 -2 -3 -3 -4 -5 -5
+    // offset[3]  = -3 3->0
+    // offset[6]  = -5 6->1
+
+    std::vector<int> offset(old2new.size(), -1);
+    for (decltype(offset.size()) i{0}; i < offset.size(); i++) {
+      // If we process this axis
+      if (old2new[i] != -1)
+        // we wouldn't offset based on this value
+        offset[old2new[i]] = 0;
+    }
+
+    // Prefix sum offset
+    for (decltype(offset.size()) i{1}; i < offset.size(); i++) {
+      offset[i] += offset[i - 1];
+    }
+    // Offset is now computed
+
+    // Apply offset
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++) {
+      if (old2new[i] == -1)
+        continue;
+      old2new[i] += offset[old2new[i]];
+    }
+
+    /*
+     * old2new should now be the output of what we mention ^^ for offset, i.e.
+     * old2new = 2 -1 4 -1 0 (0 -> 2, 2 -> 4, 4->0)
+     * should now be:
+     * old2new = 1 -1 2 -1 0 (0 -> 1, 2->2, 4->0)
+     * OR:
+     * old2new = 1 -1 4 -1 -1 (0->1, 2->4)
+     * should now be:
+     * old2new = 0 -1 1 -1 -1 (0->0, 2->1)
+     * Now we want to fill in -1 positions in relative order, i.e.
+     * old2new = 1 -1 2 -1 0 (0 -> 1, 2->2, 4->0)
+     * we want as:
+     * old2new = 1 3 2 4 0 (0 -> 1, 1->3, 2->2, 3->4, 4->0)
+     * OR:
+     * old2new = 0 -1 1 -1 -1 (0->0, 2->1)
+     * we want as:
+     * old2new = 0 2 1 3 4 (0->0, 1->2, 2->1, 3->3, 4->4)
+     */
+    // grab the highest index in new_pos
+    int max_new_pos = *std::max_element(old2new.begin(), old2new.end());
+    // Fill in the -1 values in order
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++)
+      if (old2new[i] == -1)
+        old2new[i] = ++max_new_pos;
+    old2new.erase(old2new.begin() + td->nDims(), old2new.end());
+
+    std::set<int> missed_pos;
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++)
+      missed_pos.emplace(i);
+
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++) {
+      TORCH_INTERNAL_ASSERT(
+          missed_pos.find(i) != missed_pos.end(),
+          "Duplicate entries in replayed reorder map.");
+      missed_pos.erase(i);
+    }
+
+    TORCH_INTERNAL_ASSERT(
+        missed_pos.empty(),
+        "It's a real mystery how we ended up here. Congrats.");
+
+    // Check if this is a null opt i.e. no actual reordering needs to be done
+    bool nullopt = true;
+    std::unordered_map<int, int> old2new_map;
+    for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
+      if (old2new[i] != i) {
+        nullopt = false;
+      }
+      old2new_map[i] = old2new[i];
+    }
+
+    // Even if null opt, I'm worried we could have a desynced axis_map as some
+    // how reorder wasn't a null opt, but after axis_map it was. I'm uncertain
+    // if this can happen but we can reorder axis_map anyways.
+
+    // HAVE:
+    // td->axis(old2new[i]) == td_out->axis(i)
+    // reorder->in()->axis(old2new_orig[i]) = reorder->out()->axis(i)
+    // reorder->in()->axis(i) ~= td->axis(axis_map[i])
+    // NEED:
+    // td_out->axis(reorder_axis_map[i]) ~= reorder->out()->axis(i)
+    decltype(axis_map) reordered_axis_map(axis_map.size(), -1);
+    for (decltype(axis_map.size()) i{0}; i < axis_map.size(); i++) {
+      int reorder_in_axis = i;
+      int td_axis = axis_map[i];
+      if (td_axis == -1)
+        continue;
+
+      int reorder_out_axis = old2new_orig[reorder_in_axis];
+      int td_axis_out = old2new[td_axis];
+      reordered_axis_map[reorder_out_axis] = td_axis_out;
+    }
+
+    axis_map = reordered_axis_map;
+
+    // If null opt do nothing, return td
+    if (nullopt)
+      return td;
+
+    // Rerun reorder
+    return td->reorder(old2new_map);
+  }
+
+  std::vector<int> axis_map;
+  Replay(std::vector<int> _axis_map) : axis_map(_axis_map) {}
+
+ public:
+  // Replays history provided on td, axis_map is the mapping from td axes to
+  // those expected in history, if an axis shouldn't be transformed, it needs to
+  // be marked as -1 in the axis_map
+  static TensorDomain* replay(
+      TensorDomain* td,
+      std::vector<Expr*> history,
+      std::vector<int> axis_map) {
+    if (history.empty())
+      return td;
+
+    Replay r(axis_map);
+    return r.runReplay(td, history);
+  }
+
+}; // struct Replay
+
+struct ReplaySelf : public TransformIter {
+  /*
+   * Replay functions, takes a TensorDomain and steps through its own history
+   * and reapplies it based on influence axes. Will replay rfactor axes
+   * correctly as well.
+   */
+  TensorDomain* replay(Split* split, TensorDomain* td) {
+    int saxis = split->axis();
+
+    TORCH_INTERNAL_ASSERT(
+        saxis >= 0 && saxis < axis_map.size(),
+        "TransformReplay tried to modify an axis out of range, recieved ",
+        saxis,
+        " but this value should be >=0 and <",
+        axis_map.size());
+
+    // Axis relative to td
+    int axis = axis_map[saxis];
+
+    if (axis == -1) {
+      // don't modify path, we need an extra axis as there would have been one
+      // there, but we shouldn't modify it.
+      axis_map.insert(axis_map.begin() + saxis + 1, -1);
+      return td;
+    }
+
+    // Move indices up as we now have an extra axis
+    std::transform(
+        axis_map.begin(), axis_map.end(), axis_map.begin(), [axis](int i) {
+          return i > axis ? i + 1 : i;
+        });
+
+    // Insert new axis in map
+    axis_map.insert(axis_map.begin() + saxis + 1, axis + 1);
+
+    TORCH_INTERNAL_ASSERT(
+        split->factor()->isConst(),
+        "Cannot replay split as it's not based on a const value.");
+
+    // Create new domain reflecting split
+    std::vector<IterDomain*> new_domain;
+    for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
+      if (i == axis) {
+        // We want to support cases where our root domain has changed sizes
+        // this happens in lowering when we replace sizes with runtime look ups
+        IterDomain* td_axis = td->axis(axis);
+        IterDomain* saxis_1 = split->out()->axis(saxis);
+        IterDomain* saxis_2 = split->out()->axis(saxis + 1);
+        // manually replay split domains using td extent, otherwise matching
+        // split axes params.
+        TORCH_CHECK(
+            td_axis->start()->isZeroInt(),
+            "Splitting IterDomains with starting values that aren't 0, is not supported at this time.");
+
+        IterDomain* ido = new IterDomain(
+            new Int(0),
+            ceilDiv(td_axis->extent(), split->factor()),
+            saxis_1->parallel_method(),
+            saxis_1->isReduction(),
+            saxis_1->isRFactorProduct());
+        new_domain.push_back(ido);
+
+        // inner loop IterDomain
+        IterDomain* idi = new IterDomain(
+            new Int(0),
+            split->factor(),
+            saxis_2->parallel_method(),
+            saxis_2->isReduction(),
+            saxis_2->isRFactorProduct());
+        new_domain.push_back(idi);
+      } else {
+        // Add in all other axes, these may not match the input td to the split.
+        new_domain.push_back(td->axis(i));
+      }
+    }
+
+    TensorDomain* replayed = new TensorDomain(new_domain);
+    Split* replayed_split = new Split(replayed, td, axis, split->factor());
+    return replayed;
+  }
+
+  TensorDomain* replay(Merge* merge, TensorDomain* td) {
+    int maxis = merge->axis();
+
+    TORCH_INTERNAL_ASSERT(
+        maxis >= 0 && maxis < axis_map.size(),
+        "TransformReplay tried to modify an axis out of range, recieved ",
+        maxis,
+        " but this value should be >= 0 and < axis_map.size()");
+
+    // Get axis relative to what we actually have in td.
+    int axis = axis_map[maxis];
+    int axis_p_1 = axis_map[maxis + 1];
+    // If either dim is not to be touch, set both not to be touched
+    axis = axis_p_1 == -1 ? -1 : axis;
+    axis_map[maxis] = axis;
+
+    // Remove axis from axis_map as in original transformations it didn't exist
+    axis_map.erase(axis_map.begin() + maxis + 1);
+
+    // Don't modify:
+    if (axis == -1)
+      return td;
+
+    // Move indices down as we're removing an axis
+    std::transform(
+        axis_map.begin(), axis_map.end(), axis_map.begin(), [axis](int i) {
+          return i > axis ? i - 1 : i;
+        });
+
+    // Create new domain reflecting post-merge
+    std::vector<IterDomain*> new_domain;
+    for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
+      if (i == axis) {
+        // We want to support cases where our root domain has changed sizes
+        // this happens in lowering when we replace sizes with runtime look ups
+        IterDomain* td_axis1 = td->axis(axis);
+        IterDomain* td_axis2 = td->axis(axis_p_1);
+        IterDomain* m_axis = merge->out()->axis(maxis);
+
+        TORCH_INTERNAL_ASSERT(
+            td_axis1->start()->isZeroInt() && td_axis2->start()->isZeroInt(),
+            "Splitting IterDomains with starting values that aren't 0, is not supported at this time.");
+
+        IterDomain* merged = new IterDomain(
+            new Int(0),
+            mul(td_axis1->extent(), td_axis2->extent()),
+            m_axis->parallel_method(),
+            m_axis->isReduction(),
+            m_axis->isRFactorProduct());
+        new_domain.push_back(merged);
+
+      } else if (i != axis_p_1) {
+        // Add in all other axes, these may not match the input td to the split.
+        new_domain.push_back(td->axis(i));
+      }
+    }
+
+    TensorDomain* replayed = new TensorDomain(new_domain);
+    Merge* replayed_merge = new Merge(replayed, td, axis);
+    return replayed;
+  }
+
+  // TODO: This is the same as Replay::replay, should work towards code reuse.
+  TensorDomain* replay(Reorder* reorder, TensorDomain* td) {
+    // convert to old2new as it makes this easier to do, and we need that map
+    // anyways in the end to replay reorder
+    const std::vector<int>& new2old_orig = reorder->new2old();
+    std::vector<int> old2new_orig(new2old_orig.size());
+    for (decltype(new2old_orig.size()) i{0}; i < new2old_orig.size(); i++)
+      old2new_orig[new2old_orig[i]] = i;
+
+    // old2new_orig: reorder->in()->axis(i) ==
+    // reorder->out()->axis(old2new_orig[i])
+
+    // We would like old2new: td->axis(i) == td_out->axis(old2new[i])
+    // if td->axis(i) will participate in the reorder defined by "reorder"
+    auto extent = reorder->in()->nDims() > td->nDims() ? reorder->in()->nDims()
+                                                       : td->nDims();
+    std::vector<int> old2new(extent, -1);
+    for (decltype(old2new_orig.size()) i{0}; i < old2new_orig.size(); i++) {
+      int old_pos = axis_map[i];
+      int new_pos = old2new_orig[i];
+      if (old_pos != -1)
+        old2new[old_pos] = new_pos;
+    }
+
+    // We want to push to the left the new positions in td_out therefore if our
+    // map looks like:
+    //
+    // Going to move all new_pos to the left so there's no gaps, for example if
+    // we have: old2new = 2 -1 4 -1 0 (0 -> 2, 2 -> 4, 4->0) we will the new
+    // positions down to: old2new = 1 -1 2 -1 0 (0 -> 1, 2 -> 2, 4->0)
+    //  0 -1 -1  3 -1 -1  6
+    //  0 -1 -1  0 -1 -1  0
+    //  0 -1 -2 -2 -3 -4 -4
+    // offset[0]  =  0 0->0
+    // offset[3]  = -2 3->1
+    // offset[6]  = -4 6->2
+    // --------------------
+    // -1 -1 -1  3 -1 -1  6
+    // -1 -1 -1  0 -1 -1  0
+    // -1 -2 -3 -3 -4 -5 -5
+    // offset[3]  = -3 3->0
+    // offset[6]  = -5 6->1
+
+    std::vector<int> offset(old2new.size(), -1);
+    for (decltype(offset.size()) i{0}; i < offset.size(); i++) {
+      // If we process this axis
+      if (old2new[i] != -1)
+        // we wouldn't offset based on this value
+        offset[old2new[i]] = 0;
+    }
+
+    // Prefix sum offset
+    for (decltype(offset.size()) i{1}; i < offset.size(); i++) {
+      offset[i] = offset[i] + offset[i - 1];
+    }
+    // Offset is now computed
+
+    // Apply offset
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++) {
+      if (old2new[i] == -1)
+        continue;
+      old2new[i] += offset[old2new[i]];
+    }
+
+    /*
+     * old2new should now be the output of what we mention ^^ for offset, i.e.
+     * old2new = 2 -1 4 -1 0 (0 -> 2, 2 -> 4, 4->0)
+     * should now be:
+     * old2new = 1 -1 2 -1 0 (0 -> 1, 2->2, 4->0)
+     * OR:
+     * old2new = 1 -1 4 -1 -1 (0->1, 2->4)
+     * should now be:
+     * old2new = 0 -1 1 -1 -1 (0->0, 2->1)
+     * Now we want to fill in -1 positions in relative order, i.e.
+     * old2new = 1 -1 2 -1 0 (0 -> 1, 2->2, 4->0)
+     * we want as:
+     * old2new = 1 3 2 4 0 (0 -> 1, 1->3, 2->2, 3->4, 4->0)
+     * OR:
+     * old2new = 0 -1 1 -1 -1 (0->0, 2->1)
+     * we want as:
+     * old2new = 0 2 1 3 4 (0->0, 1->2, 2->1, 3->3, 4->4)
+     */
+    // grab the highest index in new_pos
+    int max_new_pos = -1;
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++)
+      max_new_pos = max_new_pos > old2new[i] ? max_new_pos : old2new[i];
+    // Fill in the -1 values in order
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++)
+      if (old2new[i] == -1)
+        old2new[i] = ++max_new_pos;
+    old2new.erase(old2new.begin() + td->nDims(), old2new.end());
+
+    std::set<int> missed_pos;
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++)
+      missed_pos.emplace(i);
+
+    for (decltype(old2new.size()) i{0}; i < old2new.size(); i++) {
+      TORCH_INTERNAL_ASSERT(
+          missed_pos.find(i) != missed_pos.end(),
+          "Duplicate entries in replayed reorder map.");
+      missed_pos.erase(i);
+    }
+
+    TORCH_INTERNAL_ASSERT(
+        missed_pos.empty(),
+        "It's a real mystery how we ended up here. Congrats.");
+
+    // Check if this is a null opt i.e. no actual reordering needs to be done
+    bool nullopt = true;
+    std::unordered_map<int, int> old2new_map;
+    for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
+      if (old2new[i] != i) {
+        nullopt = false;
+      }
+      old2new_map[i] = old2new[i];
+    }
+
+    // Even if null opt, I'm worried we could have a desynced axis_map as some
+    // how reorder wasn't a null opt, but after axis_map it was. I'm uncertain
+    // if this can happen but we can reorder axis_map anyways.
+
+    // HAVE:
+    // td->axis(old2new[i]) == td_out->axis(i)
+    // reorder->in()->axis(old2new_orig[i]) = reorder->out()->axis(i)
+    // reorder->in()->axis(i) ~= td->axis(axis_map[i])
+    // NEED:
+    // td_out->axis(reorder_axis_map[i]) ~= reorder->out()->axis(i)
+    decltype(axis_map) reordered_axis_map(axis_map.size(), -1);
+    for (decltype(axis_map.size()) i{0}; i < axis_map.size(); i++) {
+      int reorder_in_axis = i;
+      int td_axis = axis_map[i];
+      if (td_axis == -1)
+        continue;
+
+      int reorder_out_axis = old2new_orig[reorder_in_axis];
+      int td_axis_out = old2new[td_axis];
+      reordered_axis_map[reorder_out_axis] = td_axis_out;
+    }
+
+    axis_map = reordered_axis_map;
+
+    // If null opt do nothing, return td
+    if (nullopt)
+      return td;
+
+    // Rerun reorder
+    return td->reorder(old2new_map);
+  }
+
+  std::vector<int> axis_map;
+  ReplaySelf(std::vector<int> _axis_map) : axis_map(_axis_map) {}
+
+ public:
+  // Replays history provided on td, axis_map is the mapping from td axes to
+  // those expected in history, if an axis shouldn't be transformed, it needs to
+  // be marked as -1 in the axis_map
+  static TensorDomain* replay(
+      TensorDomain* td,
+      std::vector<Expr*> history,
+      std::vector<int> axis_map) {
+    ReplaySelf r(axis_map);
+    return r.runReplay(TransformIter::getRoot(td), history);
+  }
+
+}; // struct ReplaySelf
+
+struct TORCH_CUDA_API TransformBackward : public TransformIter {
+ private:
+  // axis_map goes from the transform position to the position in our modified
+  // td.
+  TensorDomain* replayBackward(Split* split, TensorDomain* td) {
+    int saxis = split->axis();
+
+    TORCH_INTERNAL_ASSERT(
+        saxis >= 0 && saxis < axis_map.size(),
+        "TransformBackward tried to modify an axis out of range, recieved ",
+        saxis,
+        " but this value should be >= 0 and < axis_map.size()");
+
+    // Get axis relative to what we actually have in td.
+    int axis = axis_map[saxis];
+    int axis_p_1 = axis_map[saxis + 1];
+    // If either dim is not to be touch, set both not to be touched
+    axis = axis_p_1 == -1 ? -1 : axis;
+    axis_map[saxis] = axis;
+
+    // Remove axis from axis_map as in original transformations it didn't exist
+    axis_map.erase(axis_map.begin() + saxis + 1);
+
+    // Don't modify:
+    if (axis == -1)
+      return td;
+
+    // Move indices down as previously we didn't have the split axis
+    std::transform(
+        axis_map.begin(), axis_map.end(), axis_map.begin(), [axis](int i) {
+          return i > axis ? i - 1 : i;
+        });
+
+    // Create new domain reflecting pre-split
+    std::vector<IterDomain*> new_domain;
+    for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
+      if (i == axis) {
+        IterDomain* orig_axis = split->in()->axis(saxis);
+        // Insert pre-split axis, make sure isReduction matches what is expected
+        new_domain.push_back(new IterDomain(
+            orig_axis->start(),
+            orig_axis->extent(),
+            orig_axis->parallel_method(),
+            td->axis(axis)->isReduction(),
+            td->axis(axis)->isRFactorProduct()));
+      } else if (i != axis_p_1) {
+        // Add in all other axes, these may not match the input td to the split.
+        new_domain.push_back(td->axis(i));
+      }
+    }
+
+    TensorDomain* replayed_inp = new TensorDomain(new_domain);
+    Split* replayed_split = new Split(td, replayed_inp, axis, split->factor());
+    return replayed_inp;
+  }
+
+  TensorDomain* replayBackward(Merge* merge, TensorDomain* td) {
+    /*
+     * Remember axis_map goes from merge information -> how it's stored in td
+     * When we're done we want axis_map to match the returned td before or not
+     * before the merge depending on should_modify.
+     */
+
+    int maxis = merge->axis();
+
+    TORCH_INTERNAL_ASSERT(
+        maxis >= 0 && maxis < axis_map.size(),
+        "TransformBackward tried to modify an axis out of range, recieved ",
+        maxis,
+        " but this value should be >=0 and <",
+        axis_map.size());
+
+    if (axis_map[maxis] == -1) {
+      // don't modify path, we need an extra axis as there was previously one
+      // there, but we shouldn't modify it.
+      axis_map.insert(axis_map.begin() + maxis + 1, -1);
+      return td;
+    }
+
+    // Recreate the merge, axis is relative to the td
+    int axis = axis_map[maxis];
+    // Move indices up as previously we had an extra axis
+    std::transform(
+        axis_map.begin(), axis_map.end(), axis_map.begin(), [axis](int i) {
+          return i > axis ? i + 1 : i;
+        });
+
+    // Insert pre-merged axis back into map
+    axis_map.insert(axis_map.begin() + maxis + 1, axis_map[maxis] + 1);
+
+    // Create new domain reflecting pre-merge
+    std::vector<IterDomain*> new_domain;
+    for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
+      if (i == axis) {
+        IterDomain* td_axis = td->axis(axis);
+        IterDomain* maxis_1 = merge->in()->axis(maxis);
+        IterDomain* maxis_2 = merge->in()->axis(maxis + 1);
+        new_domain.push_back(new IterDomain(
+            maxis_1->start(),
+            maxis_1->extent(),
+            ParallelType::Serial,
+            td_axis->isReduction(),
+            td_axis->isRFactorProduct()));
+        new_domain.push_back(new IterDomain(
+            maxis_2->start(),
+            maxis_2->extent(),
+            ParallelType::Serial,
+            td_axis->isReduction(),
+            td_axis->isRFactorProduct()));
+      } else {
+        // Add in all other axes, these may not match the input td to the split.
+        new_domain.push_back(td->axis(i));
+      }
+    }
+
+    TensorDomain* replayed_inp = new TensorDomain(new_domain);
+    Merge* replayed_merge = new Merge(td, replayed_inp, axis);
+    return replayed_inp;
+  }
+
+  TensorDomain* replayBackward(Reorder* reorder, TensorDomain* td) {
+    const std::vector<int>& new2old_orig = reorder->new2old();
+
+    // We want to convert new2old to something with td->nDims which it isn't
+    // guarenteed to be
+    std::vector<int> new2old(td->nDims(), -1);
+    auto extent = axis_map.size() > td->nDims() ? axis_map.size() : td->nDims();
+
+    for (decltype(new2old_orig.size()) i{0}; i < new2old_orig.size(); i++) {
+      int new_pos = axis_map[i]; // position in td
+      int old_pos = new2old_orig[i]; // position it should be at before td
+
+      if (new_pos != -1)
+        new2old[new_pos] = old_pos;
+    }
+
+    // We want to push to the RIGHT the modified positions in td_in. This is
+    // in comparison with forward replay which moves modified positions to the
+    // left.
+
+    // Easiest to start by moving to left like forward replay
+
+    std::vector<int> new2old_offset(new2old_orig.size(), -1);
+    // Create offset map
+    for (decltype(new2old.size()) i{0}; i < new2old.size(); i++)
+      if (new2old[i] != -1)
+        new2old_offset[new2old[i]] = 0;
+
+    // Prefix sum new2old_offset
+    for (decltype(new2old_offset.size()) i{1}; i < new2old_offset.size(); i++)
+      new2old_offset[i] += new2old_offset[i - 1];
+    // Apply offset
+    for (decltype(new2old.size()) i{0}; i < new2old.size(); i++) {
+      if (new2old[i] == -1)
+        continue;
+      new2old[i] += new2old_offset[new2old[i]];
+    }
+
+    int max_elem = *std::max_element(new2old.begin(), new2old.end());
+    // Now lets push all elements to the right
+    int right_offset = td->nDims() - max_elem - 1;
+    TORCH_INTERNAL_ASSERT(
+        right_offset >= 0,
+        "Error during backward replay, couldn't move modified axes to the right in reorder.");
+
+    // Move to the right
+    for (decltype(new2old.size()) i{0}; i < new2old.size(); i++) {
+      if (new2old[i] == -1)
+        continue;
+      new2old[i] += right_offset;
+    }
+
+    // Fill in unmodified positions in order to the left
+    int it = 0;
+    for (decltype(td->nDims()) i{0}; i < td->nDims(); i++)
+      if (new2old[i] == -1)
+        new2old[i] = it++;
+
+    // Trim new2old to match td
+    new2old.erase(new2old.begin() + td->nDims(), new2old.end());
+
+    // new2old_orig[reorder->out()->pos] = reorder->in()->pos
+    // axis_map[reorder->out()->pos] = td->pos
+    // new2old[td->pos] = old_td->pos
+    // NEED: new_axis_map[reorder->in()->pos] = old_td->pos
+
+    std::vector<int> new_axis_map(axis_map.size(), -1);
+    for (decltype(new_axis_map.size()) i{0}; i < new_axis_map.size(); i++) {
+      int reorder_out_pos = i;
+      int reorder_in_pos = new2old_orig[reorder_out_pos];
+      int td_pos = axis_map[reorder_out_pos];
+      int old_td_pos = td_pos == -1 ? -1 : new2old[td_pos];
+
+      new_axis_map[reorder_in_pos] = old_td_pos;
+    }
+
+    axis_map = new_axis_map;
+
+    std::vector<IterDomain*> old_td(td->nDims(), nullptr);
+    for (decltype(new2old.size()) i{0}; i < new2old.size(); i++) {
+      // new2old[new] = old relative to td
+      int new_pos = i; // position in td
+      int old_pos = new2old[i]; // position it should be at before td
+      old_td[old_pos] = td->axis(new_pos);
+    }
+
+    TensorDomain* replayed_inp = new TensorDomain(old_td);
+    Reorder* replayed_split = new Reorder(td, replayed_inp, new2old);
+    return replayed_inp;
+  }
+
+  // Entry for backward influence propagation on td following record, history
+  // should be present -> past as you go through the vector
+  TensorDomain* replayBackward(TensorDomain* td, std::vector<Expr*> history) {
+    TensorDomain* running_td = td;
+
+    history = std::vector<Expr*>(history.rbegin(), history.rend());
+    for (Expr* op : history)
+      running_td = TransformIter::replayBackward(op, running_td);
+    return running_td;
+  }
+
+  std::vector<int> axis_map;
+
+  TransformBackward(std::vector<int> _axis_map) : axis_map(_axis_map){};
+
+ public:
+  static TensorDomain* replay(
+      TensorDomain* td,
+      std::vector<Expr*> history,
+      std::vector<int> axis_map) {
+    TransformBackward tb(axis_map);
+    return tb.replayBackward(td, history);
+  }
+};
+
+struct RFactorRoot : public TransformIter {
+  bool found_non_rfactor_op = false;
+
+  TensorDomain* replay(Split* split, TensorDomain*) final {
+    if (!split->in()->axis(split->axis())->isRFactorProduct())
+      found_non_rfactor_op = true;
+    return split->out();
+  }
+
+  TensorDomain* replay(Merge* merge, TensorDomain*) final {
+    if (!merge->in()->axis(merge->axis())->isRFactorProduct())
+      found_non_rfactor_op = true;
+    return merge->out();
+  }
+
+  TensorDomain* replay(Reorder* reorder, TensorDomain*) final {
+    return reorder->out();
+  }
+
+  // Replay forward until we hit an operation that doesn't involve an rfactor
+  // axis
+  TensorDomain* runReplay(TensorDomain*, std::vector<Expr*> history) final {
+    TORCH_INTERNAL_ASSERT(
+        !history.empty(), "No history provided to find rfactor root domain.");
+
+    auto last_rfactor_op = history.begin();
+    auto running_op = history.begin();
+
+    for (auto it = history.begin(); it != history.end(); it++) {
+      TransformIter::replay(*it, nullptr);
+      if (found_non_rfactor_op)
+        break;
+      running_op = it;
+      if ((*it)->getExprType() != ExprType::Reorder) {
+        last_rfactor_op = it;
+      }
+    }
+
+    // We need to make sure the rfactor root is ordered correctly.
+    bool found_valid_rfactor_root = false;
+
+    Val* val;
+
+    while (!found_valid_rfactor_root && last_rfactor_op != history.end()) {
+      // Try next val
+      val = (*last_rfactor_op++)->output(0);
+      TORCH_INTERNAL_ASSERT(
+          val->getValType().value() == ValType::TensorDomain,
+          "Invalid history to find rfactor root.");
+
+      TensorDomain* td = static_cast<TensorDomain*>(val);
+      bool found_rfactor_dim = false;
+      for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
+        if (found_rfactor_dim) {
+          if (!td->axis(i)->isRFactorProduct())
+            break;
+        } else {
+          if (td->axis(i)->isRFactorProduct())
+            found_rfactor_dim = true;
+        }
+        if (i == td->nDims() - 1)
+          found_valid_rfactor_root = true;
+      }
+    }
+    TORCH_INTERNAL_ASSERT(
+        found_valid_rfactor_root, "Could not find a valid rfactor root.");
+    return static_cast<TensorDomain*>(val);
+  }
+
+ public:
+  static TensorDomain* get(TensorDomain* td) {
+    auto history = TransformIter::getHistory(td);
+    if (history.empty())
+      return td;
+    RFactorRoot rfr;
+    return rfr.runReplay(nullptr, history);
+  }
+};
+
+} // namespace
+
+// API INTO TRANSFORM ITER
+
+std::vector<bool> TransformIter::getRootInfluence(
+    TensorDomain* td,
+    std::vector<bool> td_influence) {
+  return Influence::computeBackward(
+      TransformIter::getHistory(td), td_influence);
+}
+
+std::vector<bool> TransformIter::replayBackwardInfluence(
+    std::vector<Expr*> history,
+    std::vector<bool> td_influence) {
+  return Influence::computeBackward(history, td_influence);
+}
+
+std::vector<bool> TransformIter::replayInfluence(
+    std::vector<Expr*> history,
+    std::vector<bool> td_influence) {
+  if (history.empty())
+    return td_influence;
+
+  return Influence::computeForward(history, td_influence);
+}
+
+TensorDomain* TransformIter::replay(
+    TensorDomain* td,
+    std::vector<Expr*> history,
+    std::vector<int> axis_map) {
+  if (history.empty())
+    return td;
+  if (std::none_of(
+          axis_map.begin(), axis_map.end(), [](int i) { return i > -1; }))
+    return td;
+
+  validate_history_entry(history[0], axis_map.size());
+  return Replay::replay(td, history, axis_map);
+}
+
+TensorDomain* TransformIter::replaySelf(
+    TensorDomain* td,
+    std::vector<Expr*> history,
+    std::vector<int> axis_map) {
+  if (std::none_of(
+          axis_map.begin(), axis_map.end(), [](int i) { return i > -1; }))
+    return TransformIter::getRoot(td);
+
+  validate_axis_map(TransformIter::getRoot(td)->nDims(), axis_map);
+  return ReplaySelf::replay(td, history, axis_map);
+}
+
+TensorDomain* TransformIter::replayBackward(
+    TensorDomain* td,
+    std::vector<Expr*> history,
+    std::vector<int> axis_map) {
+  if (history.empty())
+    return td;
+  if (std::none_of(
+          axis_map.begin(), axis_map.end(), [](int i) { return i > -1; }))
+    return td;
+
+  TORCH_INTERNAL_ASSERT(
+      history[history.size() - 1]->output(0)->getValType().value() ==
+              ValType::TensorDomain &&
+          static_cast<TensorDomain*>(history[history.size() - 1]->output(0))
+                  ->nDims() == axis_map.size(),
+      "Invalid history, or invalid axis_map in TransformIter.");
+
+  return TransformBackward::replay(td, history, axis_map);
+}
+
+TensorDomain* TransformIter::getRFactorRoot(TensorDomain* td) {
+  auto td_root = TransformIter::getRoot(td);
+  if (std::none_of(
+          td_root->domain().begin(),
+          td_root->domain().end(),
+          [](IterDomain* id) { return id->isRFactorProduct(); }))
+    return td_root;
+
+  auto ret = RFactorRoot::get(td);
+  return ret;
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_iter.h
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.h
@@ -5,6 +5,8 @@
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/iter_visitor.h>
 
+#include <vector>
+
 namespace torch {
 namespace jit {
 namespace fuser {
@@ -18,37 +20,77 @@ namespace fuser {
  */
 struct TORCH_CUDA_API TransformIter : public IterVisitor {
  protected:
-  virtual void replayBackward(Split* expr);
-  virtual void replayBackward(Merge* expr);
-  virtual void replayBackward(Reorder* expr);
+  virtual TensorDomain* replayBackward(Split*, TensorDomain*);
+  virtual TensorDomain* replayBackward(Merge*, TensorDomain*);
+  virtual TensorDomain* replayBackward(Reorder*, TensorDomain*);
 
   // dispatch
-  void replayBackward(Expr* expr);
+  TensorDomain* replayBackward(Expr*, TensorDomain*);
 
   // Iterates td's history starting with td, then origin(td), origin(origin(td))
   // etc. Returns root TensorDomain once it iterates through history. If
   // generate_record=true It will record the history of td in record. Record is
   // order operations root->td.
-  TensorDomain* runBackward(TensorDomain* td, bool generate_record);
+  virtual TensorDomain* runBackward(TensorDomain*);
 
-  virtual TensorDomain* replay(Split* expr, TensorDomain* tv);
-  virtual TensorDomain* replay(Merge* expr, TensorDomain* tv);
-  virtual TensorDomain* replay(Reorder* expr, TensorDomain* tv);
+  virtual TensorDomain* replay(Split*, TensorDomain*);
+  virtual TensorDomain* replay(Merge*, TensorDomain*);
+  virtual TensorDomain* replay(Reorder*, TensorDomain*);
 
   // dispatch
-  TensorDomain* replay(Expr* expr, TensorDomain* tv);
+  virtual TensorDomain* replay(Expr*, TensorDomain*);
 
-  // Runs through operations recorded in record from root-> present
-  TensorDomain* runReplay(TensorDomain* tv);
-
-  // Forward record from root, to replay_ref/ref_root
-  std::vector<Expr*> record;
+  // Runs through operations in history and applies them to TD, runs exprs from
+  // begining to end
+  virtual TensorDomain* runReplay(TensorDomain*, std::vector<Expr*>);
 
  public:
+  // Returns transformation exprs in forward order
+  static std::vector<Expr*> getHistory(TensorDomain*);
+
+  // TODO: make td const
   static TensorDomain* getRoot(TensorDomain* td) {
     TransformIter ti;
-    return ti.runBackward(td, false);
+    return ti.runBackward(td);
   }
+
+  // Takes influence vector of bools, tracks them back to propagate true to root
+  // axes that were modified into td axes matching marked influence vector
+  static std::vector<bool> getRootInfluence(
+      TensorDomain* td,
+      std::vector<bool> influence);
+
+  static std::vector<bool> replayBackwardInfluence(
+      std::vector<Expr*> history,
+      std::vector<bool> td_influence);
+
+  // Runs through history, applying only on influence to track how modifications
+  // would influence the original axes.
+  static std::vector<bool> replayInfluence(
+      std::vector<Expr*> history,
+      std::vector<bool> td_influence);
+
+  // Goes through history and applies it to td, with the axis_map provided.
+  // Axis_map entries of -1 mean those axes won't be modified
+  static TensorDomain* replay(
+      TensorDomain* td,
+      std::vector<Expr*> history,
+      std::vector<int> axis_map);
+
+  // Takes td, and replays history backwards on it to create a new root tensor
+  // domain using axis_map. Entries in axis_map == -1 will not be modified
+  static TensorDomain* replayBackward(
+      TensorDomain* td,
+      std::vector<Expr*> history,
+      std::vector<int> axis_map);
+
+  static TensorDomain* replaySelf(
+      TensorDomain* td,
+      std::vector<Expr*> history,
+      std::vector<int> axis_map);
+
+  // Replays backwards all non-rfactor axes
+  static TensorDomain* getRFactorRoot(TensorDomain* td);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_replay.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_replay.cpp
@@ -1,351 +1,328 @@
 #include <torch/csrc/jit/codegen/cuda/transform_replay.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
+#include <torch/csrc/jit/codegen/cuda/transform_iter.h>
+
+#include <vector>
 
 namespace torch {
 namespace jit {
 namespace fuser {
 
-/*
- * Functions to backward propagate influence from split/merge/reorder
- */
-void TransformReplay::replayBackward(Split* expr) {
-  int axis = expr->axis();
+// Replay producer as consumer.
+TensorDomain* TransformReplay::fullSelfReplay(
+    TensorDomain* self,
+    TensorDomain* self_copy) {
+  // Want producer root with no reductions, rfactor included
+  TensorDomain* self_root = self->rootDomain();
+
+  // Want full consumer root, even before rfactor
+  TensorDomain* self_copy_root = self_copy->rootDomain();
+
   TORCH_INTERNAL_ASSERT(
-      axis + 1 < influence.size(),
-      "Error during replay backwards, influence is not sized correctly.");
-  influence[axis] = influence[axis] | influence[axis + 1];
-  influence.erase(influence.begin() + axis + 1);
-}
+      self_root->nDims(), self_copy_root->nDims(), "Invalid self replay.");
 
-void TransformReplay::replayBackward(Merge* expr) {
-  int axis = expr->axis();
-  TORCH_INTERNAL_ASSERT(
-      axis < influence.size(),
-      "Error during replay backwards, influence is not sized correctly.");
-  influence.insert(influence.begin() + axis + 1, influence[axis]);
-}
-
-void TransformReplay::replayBackward(Reorder* expr) {
-  // pos2axis[new_pos] = old_pos Generate new axis2pos map
-  const std::vector<int>& pos2axis = expr->pos2axis();
-
-  std::vector<bool> reorder_influence(influence.size(), false);
-  for (decltype(pos2axis.size()) i = 0; i < pos2axis.size(); i++) {
-    int new_pos = i;
-    int old_pos = pos2axis[i];
+  for (decltype(self_root->nDims()) i{0}; i < self_root->nDims(); i++)
     TORCH_INTERNAL_ASSERT(
-        new_pos < influence.size() && old_pos < reorder_influence.size(),
-        "Error during replay backwards, influence is not sized correctly.");
-    reorder_influence[old_pos] = influence[new_pos];
-  }
+        self_root->axis(i)->parallel_method() ==
+                self_copy_root->axis(i)->parallel_method() &&
+            self_root->axis(i)->isReduction() ==
+                self_copy_root->axis(i)->isReduction() &&
+            self_root->axis(i)->start() == self_copy_root->axis(i)->start(),
+        "Invalid self replay detected, root domain does not match.");
 
-  influence = reorder_influence;
-}
+  std::vector<int> axis_map(self_root->nDims());
+  std::iota(axis_map.begin(), axis_map.end(), 0);
 
-// Entry for backward influence propagation on td following record
-TensorDomain* TransformReplay::replayBackward(
-    TensorDomain* td,
-    bool create_record) {
-  influence = std::vector<bool>(td->nDims(), false);
-  for (int i = 0; i < compute_at_axis; i++)
-    influence[i] = true;
-  return TransformIter::runBackward(td, create_record);
-}
+  // Finally replay producer as consumer on marked axes
 
-/*
- * Replay functions, takes a TensorDomain and steps through the operations in
- * "record" based on influence axes. Will also update influence and propagate
- * it forward.
- */
-TensorDomain* TransformReplay::replay(Split* expr, TensorDomain* td) {
-  int axis = expr->axis();
-  bool run_split = influence[axis];
-
-  // Propagate influence
-  influence.insert(influence.begin() + axis + 1, influence[axis]);
-
-  // Forward prop influence
-  if (run_split) {
-    // Make sure split axis is real.
-    int real_axis = axis_map[expr->axis()];
-    TORCH_INTERNAL_ASSERT(
-        real_axis != -1,
-        "During transformation replay attempted to split an imaginary axis.");
-    TORCH_INTERNAL_ASSERT(
-        td->axis(real_axis)->start()->isZeroInt(),
-        "Transform Replay tried to split an IterDomain with a start value that is not 0,",
-        " this is not currently supported.");
-    // Inserted a real axis, push everything in axis_map over to the right
-    // after this inserted axis
-    for (decltype(axis_map.size()) i{0}; i < axis_map.size(); i++)
-      if (axis_map[i] > real_axis)
-        axis_map[i] = axis_map[i] + 1;
-
-    axis_map.insert(
-        axis_map.begin() + expr->axis() + 1,
-        real_axis + 1); // insert axis at position axis.
-
-    // Replay split
-    return td->split(real_axis, *(expr->factor()->value()));
-  } else {
-    // Fake it
-    axis_map.insert(axis_map.begin() + expr->axis() + 1, -1);
-  }
-
-  return td;
-}
-
-TensorDomain* TransformReplay::replay(Merge* expr, TensorDomain* td) {
-  int axis = expr->axis();
-  bool merge = influence[axis] || influence[axis + 1];
-  axis_map.erase(axis_map.begin() + expr->axis() + 1);
-
-  for (decltype(axis_map.size()) i = expr->axis() + 1; i < axis_map.size(); i++)
-    if (axis_map[i] != -1)
-      axis_map[i]--;
-
-  // Forward prop influence
-  influence[axis] = influence[axis] || influence[axis + 1];
-  influence.erase(influence.begin() + axis + 1);
-
-  if (merge) {
-    // Make sure both merge axes are real.
-    TORCH_INTERNAL_ASSERT(
-        axis_map[axis] != -1 && axis_map[axis + 1] != -1,
-        "During transformation replay attempted to merge an imaginary axis.");
-    // Replay merge
-    TORCH_INTERNAL_ASSERT(
-        td->axis(axis)->start()->isZeroInt() &&
-            td->axis(axis + 1)->start()->isZeroInt(),
-        "Transform Replay tried to Merge IterDomains with a start value that is not 0,",
-        " this is not currently supported.");
-    return td->merge(axis_map[axis]);
-  } else {
-    // If we aren't applying the merge, we won't change any following axis
-    // Doesn't matter which axis we propagate for the merge in the axis_map
-    assert(axis_map[axis + 1] == -1);
-    return td;
-  }
-}
-
-TensorDomain* TransformReplay::replay(Reorder* expr, TensorDomain* td) {
-  // axis2pos[old_pos] = new_pos is sent to reorder, Reorder holds
-  // pos2axis[new_pos] = old_pos Generate new axis2pos map
-  std::unordered_map<int, int> axis2pos;
-  const std::vector<int>& pos2axis = expr->pos2axis();
-
-  std::vector<int> reordered_axis_map(axis_map.size(), -1);
-  std::vector<bool> reordered_influence(pos2axis.size(), false);
-
-  // We have
-  // axis_map[old_fake_pos] -> old_real_pos
-  // pos2axis[new_fake_pos] -> old_fake_pos
-  // f2r[new_fake_pos] -> new_real_pos
-  //
-  // We want:
-  // axis2pos[old_real_pos] -> new_real_pos
-  // axis_map[new_fake_pos] -> new_real_pos
-
-  std::vector<std::pair<int, int>> needed_real_reorder;
-  for (decltype(pos2axis.size()) i{0}; i < pos2axis.size(); i++) {
-    int new_fake_axis = i;
-    int old_fake_axis = pos2axis[i];
-    int old_real_axis = axis_map[old_fake_axis];
-    bool is_real_axis = old_real_axis != -1;
-    // If a real axis
-    if (is_real_axis)
-      if (influence[old_fake_axis]) {
-        needed_real_reorder.push_back({old_real_axis, new_fake_axis});
-      }
-  }
-
-  // Sort needed_real_reorder by new_fake_axis.
-  std::sort(
-      needed_real_reorder.begin(),
-      needed_real_reorder.end(),
-      [](std::pair<int, int> a, std::pair<int, int> b) -> bool {
-        return a.second < b.second;
-      });
-
-  // axis2pos[old_real_axis] -> new_real_axis
-  int axis = 0;
-  for (auto entry : needed_real_reorder) {
-    axis2pos[entry.first] = axis++;
-  }
-
-  for (decltype(td->nDims()) i{0}; i < td->nDims(); i++) {
-    if (axis2pos.find(i) == axis2pos.end())
-      axis2pos[i] = axis++;
-  }
-
-  // replay reorder
-  TensorDomain* reordered_td = td->reorder(axis2pos);
-
-  // Fake transform:
-  for (decltype(pos2axis.size()) i = 0; i < pos2axis.size(); i++) {
-    int new_pos = i;
-    int old_pos = pos2axis[i];
-    // Forward prop influence
-    reordered_influence[new_pos] = influence[old_pos];
-    if (axis_map[old_pos] != -1)
-      reordered_axis_map[new_pos] = axis2pos[axis_map[old_pos]];
-  }
-  influence = reordered_influence;
-  axis_map = reordered_axis_map;
-
-  return reordered_td;
-}
-
-/*
- * TODO: When we compare root axes, we should ignore reduction axes in the
- * producer. Reduction axes are owned by a consumer.
- *
- * TODO: We should be able to relax the constraints of replay a bit. Right now
- * it requires that the root domain of the target and replay are completely
- * the same. However, we should only require that the root derived from the
- * axes < compute_at_axis match. We could even go further and look for those
- * matching axes as they don't necessairly need to be in the same order.
- * However, once they're replayed they should be.
- *
- * 1) Take the reference, trace back its domain history to get all the
- * split/merge/reorder calls, as well as its original domain. Get the
- * original domain of the target as well.
- *
- * 2) We only need compute_at_axis and earlier dimensions to match for
- * compute_at. Therefore, we want to find all original axes that must have
- * been modified in order to produce the axes below compute_at_axis. We take a
- * bool vector called influence, and mark axes below compute_at_axis as true,
- * and all others as false. This vector is propagated up through
- * split/merge/reorder if split/merge/reorder output a marked axis, their
- * input will be marked as well. This marks all original axes required to be
- * modified to produce the axes below compute_at_axis.
- *
- * 3) We take the ordered list of split/merge/reorder and the influence vector
- * on the inputs and we apply split/merge/reorder operations on the
- * replay_target. We also forward propagate the influence vector again (as this
- * time it could be different than originally marked), a map from "fake axes"
- * (refrence axes corresponding to the full replay) to real axes (axes produced
- * by running the selected split/merge/reorder operations). Reorder replay's can
- * actually be partial and non-equivelent to the original, as some axes may
- * never have been produced based on split, and we don't want to reorder axes
- * outside of compute_at_axis.
- *
- */
-TensorDomain* TransformReplay::runReplay(
-    TensorDomain* replay_ref,
-    TensorDomain* replay_target,
-    int compute_at_axis) {
-  if (compute_at_axis < 0)
-    compute_at_axis += int(replay_ref->nDims()) + 1;
-
-  TORCH_CHECK(
-      compute_at_axis >= 0 && compute_at_axis < int(replay_ref->nDims()) + 1,
-      "Transform replay cannot be performed as the compute_at_axis is not in the valid range, it should be 0 or greater, and less than ",
-      int(replay_ref->nDims()) + 1,
-      ".");
-
-  this->compute_at_axis = compute_at_axis;
-
-  /* STEP 1 */
-  // Reset the tensor domain of the target, this is the only way we can be
-  // certain That we can actually replay the ops of ref.
-  // Trace back to the root TensorDomain's of ref and target
-  replay_target = replay_target->rootDomain();
-
-  /* STEP 2 */
-  // Mark compute_at_axis and below as "influenced", trace back through
-  // operations, and map these axes to the ref root axis that were modified to
-  // produce these axis
-  // As we trace the ref, record the operations to go from replay_ref ->
-  // ref_root, save in "record"
-  TensorDomain* ref_root = replayBackward(replay_ref, true);
-  // We're going to save a copy of this vector, class member influnce will be
-  // used during replay to forward propagate influence.
-  std::vector<bool> root_influence_vector = influence;
-
-  // Remove isReduction from the axis_map of a producer
-  // isReduction is only impactful when its on a consumer
-  auto init_size = replay_target->nDims();
-  for (decltype(init_size) i = 0; i < init_size; i++)
-    if (!replay_target->axis(i)->isReduction())
-      axis_map.push_back(i);
-
-  // Domain sizes must match at root for replay.
-  if (axis_map.size() != ref_root->nDims()) {
-    std::stringstream err_msg;
-    err_msg
-        << "Transforms cannot be replayed as source and destinations do not have the same root sizes."
-        << " " << ref_root << " vs " << replay_target->domain() << std::endl;
-    TORCH_CHECK(false, err_msg.str());
-  }
-
-  /*
-   * TODO: The JIT graph has symbolic sizes, so inputs may actually have the
-   * same sizes (assuming no broadcasts/reductions), we at some point want to
-   * have some size matching, and sizes should actually match at this point, but
-   * the check below won't work.
-   */
-
-  // for (decltype(axis_map.size()) i{0}; i < axis_map.size(); i++) {
-  //   TORCH_CHECK(
-  //       ref_root->axis(i)->size()->same_as(
-  //           target_root->axis(axis_map[i])->size()),
-  //       "Transforms cannot be replayed as source and destinations do not have
-  //       the same root sizes.");
-  // }
-
-  /* STEP 3 */
-  // Replay operations while forward propagating influence. The resulting
-  // influence can be different in forward propagation, than in backward
-  // propagation depending on the combination of merge/split/reorder nodes
-  // There are multiple things we have to track here. We need to track
-  // the propagation of axes for all operations, though we only want to
-  // actually execute those based on influence. If we didn't track all
-  // axes, we wouldn't know what axis split/merge/reorder are referencing
-  // as they're relative to the "full" replay that produced the reference.
-  TensorDomain* replayed = TransformIter::runReplay(replay_target);
-
-  for (decltype(replayed->nDims()) i{0}; i < compute_at_axis; i++)
-    if (replayed->axis(i)->isReduction())
-      TORCH_CHECK(
-          false,
-          "Generated a compute_at dependency where a reduction would be used before computed.");
+  auto replayed = TransformIter::replay(
+      self_copy_root, TransformIter::getHistory(self), axis_map);
 
   return replayed;
 }
 
-TensorView* TransformReplay::runReplay(
-    TensorView* replay_ref,
-    TensorView* replay_target,
+// Replay producer as consumer.
+TensorDomain* TransformReplay::replayPasC(
+    TensorDomain* producer,
+    TensorDomain* consumer,
     int compute_at_axis) {
+  if (compute_at_axis < 0)
+    compute_at_axis += consumer->nDims() + 1;
+  TORCH_INTERNAL_ASSERT(
+      compute_at_axis >= 0 && compute_at_axis <= consumer->nDims(),
+      "Invalid axis in transform replayPasC.");
+
+  // Consumer in rfactor cases is based off producer's rfactor root, not
+  // producer's root
+  TensorDomain* producer_rfactor_root = TransformIter::getRFactorRoot(producer);
+
+  // Want full consumer root, even before rfactor
+  TensorDomain* consumer_root = TransformIter::getRoot(consumer);
+
+  // We want to see which axes in the consumer root were modified to create axes
+  // < compute_at_axis
+  std::vector<bool> consumer_influence(consumer->nDims(), false);
+  for (int i = 0; i < compute_at_axis; i++)
+    consumer_influence[i] = true;
+
+  // Check which axes in ref_root need to be modified to honor transformations
+  // to compute at axis
+  std::vector<bool> consumer_root_influence =
+      TransformIter::getRootInfluence(consumer, consumer_influence);
+
+  // We have the influence on the consumer root, we need it on producer, we
+  // want to keep those axes that don't need to be modified by the replay
+  std::vector<bool> producer_rfactor_root_influence(
+      producer_rfactor_root->nDims(), false);
+
+  // Map is based on producer
+  std::vector<int> replay_axis_map(consumer_root->nDims(), -1);
+  // Setup producer_rfactor_root_influence vector on root for replay
+  decltype(producer_rfactor_root_influence.size()) ip = 0, ic = 0;
+
+  while (ip < producer_rfactor_root_influence.size() &&
+         ic < consumer_root->nDims()) {
+    bool is_reduction = producer_rfactor_root->axis(ip)->isReduction();
+    if (is_reduction) {
+      producer_rfactor_root_influence[ip++] = false;
+    } else {
+      if (consumer_root_influence[ic]) {
+        replay_axis_map[ic] = ip;
+      } else {
+        replay_axis_map[ic] = -1;
+      }
+      producer_rfactor_root_influence[ip++] = consumer_root_influence[ic++];
+    }
+  }
+
+  for (decltype(producer_rfactor_root->nDims()) i{0};
+       i < producer_rfactor_root->nDims();
+       i++)
+    TORCH_INTERNAL_ASSERT(
+        !(producer_rfactor_root_influence[i] &&
+          producer_rfactor_root->axis(i)->isRFactorProduct()),
+        "An illegal attempt to modify an rfactor axis detected.");
+
+  // We should have hit the end of the consumer root domain
+  TORCH_INTERNAL_ASSERT(
+      ic == consumer_root->nDims(),
+      "Error when trying to run replay, didn't reach end of consumer/target root.");
+
+  TORCH_INTERNAL_ASSERT(
+      producer_rfactor_root_influence.size() == producer_rfactor_root->nDims(),
+      "Error detected during replay, expected matching sizes of influence map to root dimensions.");
+
+  auto producer_root_influence = TransformIter::getRootInfluence(
+      producer_rfactor_root, producer_rfactor_root_influence);
+
+  TensorDomain* producer_root = TransformIter::getRoot(producer_rfactor_root);
+
+  std::vector<int> producer_replay_map(producer_root->nDims());
+  for (decltype(producer_replay_map.size()) i{0};
+       i < producer_replay_map.size();
+       i++) {
+    if (producer_root->axis(i)->isRFactorProduct()) {
+      producer_replay_map[i] = i;
+    } else {
+      producer_replay_map[i] = producer_root_influence[i] ? -1 : i;
+    }
+  }
+
+  // Replay axes that won't be modified by transform replay
+  TensorDomain* producer_replay_root = TransformIter::replaySelf(
+      producer, TransformIter::getHistory(producer), producer_replay_map);
+
+  // Record axes positions.
+  std::unordered_map<IterDomain*, int> new_position;
+  for (decltype(producer_replay_root->nDims()) i{0};
+       i < producer_replay_root->nDims();
+       i++)
+    new_position[producer_replay_root->axis(i)] = i;
+
+  std::unordered_map<int, int> root_axis_map;
+  // reorder producer_replay_root to respect replay_axis_map
+  for (decltype(replay_axis_map.size()) i{0}; i < replay_axis_map.size(); i++) {
+    if (replay_axis_map[i] == -1)
+      continue;
+    auto ax = producer_root->axis(replay_axis_map[i]);
+    TORCH_INTERNAL_ASSERT(
+        new_position.find(ax) != new_position.end(),
+        "Error hit during transform replay, could not find ",
+        ax,
+        " expected in root domain.");
+    root_axis_map[new_position[ax]] = replay_axis_map[i];
+  }
+
+  producer_replay_root = producer_replay_root->reorder(root_axis_map);
+
+  // Finally replay producer as consumer on marked axes
+  TensorDomain* replayed = TransformIter::replay(
+      producer_replay_root,
+      TransformIter::getHistory(consumer),
+      replay_axis_map);
+
+  TORCH_INTERNAL_ASSERT(
+      std::none_of(
+          replayed->domain().begin(),
+          replayed->domain().begin() + compute_at_axis,
+          [](IterDomain* id) { return id->isReduction(); }),
+      "Reduction axes found within compute_at_axis in replay of producer.");
+  return replayed;
+}
+
+// Replay producer as consumer.
+TensorDomain* TransformReplay::replayCasP(
+    TensorDomain* consumer,
+    TensorDomain* producer,
+    int compute_at_axis) {
+  if (compute_at_axis < 0)
+    compute_at_axis += producer->nDims() + 1;
+  TORCH_INTERNAL_ASSERT(
+      compute_at_axis >= 0 && compute_at_axis <= producer->nDims(),
+      "Invalid axis in transform replayPasC.");
+
+  // Want producer root with no reductions, rfactor included
+  TensorDomain* producer_rfactor_root = TransformIter::getRFactorRoot(producer);
+  TensorDomain* producer_root = TransformIter::getRoot(producer);
+  // Producer root still has reductions
+
+  // Want full consumer root, even before rfactor
+  TensorDomain* consumer_root = TransformIter::getRoot(consumer);
+
+  // We want to see which axes in the producer root were modified to create axes
+  // < compute_at_axis
+  std::vector<bool> producer_influence(producer->nDims(), false);
+  for (int i = 0; i < compute_at_axis; i++)
+    producer_influence[i] = true;
+
+  // Check which axes in ref_root need to be modified to honor transformations
+  // to compute at axis
+  std::vector<bool> producer_root_influence =
+      TransformIter::getRootInfluence(producer, producer_influence);
+
+  for (decltype(producer_root->nDims()) i{0}; i < producer_root->nDims(); i++) {
+    TORCH_INTERNAL_ASSERT(
+        !(producer_root_influence[i] && producer_root->axis(i)->isReduction()),
+        "Error during replay, likely due to an illegal bad computeAt.");
+  }
+
+  std::vector<bool> producer_rfactor_root_influence =
+      TransformIter::replayInfluence(
+          TransformIter::getHistory(producer_rfactor_root),
+          producer_root_influence);
+
+  // We have the influence on the producer root, we need it on consumer, we
+  // want to keep those axes that don't need to be modified by the replay
+  std::vector<bool> consumer_root_influence(
+      consumer->rootDomain()->nDims(), false);
+
+  // Producer -> consumer axis map
+  std::vector<int> replay_axis_map(producer_rfactor_root->nDims(), -1);
+
+  // Setup consumer_root_influence vector on root for replay
+  decltype(consumer_root_influence.size()) ip = 0, ic = 0;
+  while (ic < consumer_root_influence.size() &&
+         ip < producer_rfactor_root->nDims()) {
+    bool is_reduction = producer_rfactor_root->axis(ip)->isReduction();
+    if (is_reduction) {
+      replay_axis_map[ip++] = -1;
+      continue;
+    }
+    if (producer_rfactor_root_influence[ip]) {
+      replay_axis_map[ip] = ic;
+    } else {
+      replay_axis_map[ip] = -1;
+    }
+    consumer_root_influence[ic++] = producer_rfactor_root_influence[ip++];
+  }
+
+  // Unlike PasC if last axes in producer_rfactor_root is a reduction we won't
+  // be guarneteed that ip == producer_rfactor_root->nDims(), that's why we
+  // initialize replay_axis_map with -1
+
+  TORCH_INTERNAL_ASSERT(
+      consumer_root_influence.size() == consumer_root->nDims(),
+      "Error detected during replay, expected matching sizes of influence map to root dimensions.");
+
+  std::vector<int> consumer_replay_map(consumer_root->nDims());
+  for (decltype(consumer_replay_map.size()) i{0};
+       i < consumer_replay_map.size();
+       i++) {
+    if (consumer_root->axis(i)->isRFactorProduct()) {
+      consumer_replay_map[i] = i;
+    } else {
+      consumer_replay_map[i] = consumer_root_influence[i] ? -1 : i;
+    }
+  }
+
+  // Replay axes that won't be modified by transform replay
+  TensorDomain* consumer_replay_root = TransformIter::replaySelf(
+      consumer, TransformIter::getHistory(consumer), consumer_replay_map);
+
+  // Record axes positions.
+  std::unordered_map<IterDomain*, int> new_position;
+  for (decltype(consumer_replay_root->nDims()) i{0};
+       i < consumer_replay_root->nDims();
+       i++)
+    new_position[consumer_replay_root->axis(i)] = i;
+
+  std::unordered_map<int, int> root_axis_map;
+  // reorder consumer_replay_root to respect replay_axis_map
+  for (decltype(replay_axis_map.size()) i{0}; i < replay_axis_map.size(); i++) {
+    if (replay_axis_map[i] == -1)
+      continue;
+    auto ax = consumer_root->axis(replay_axis_map[i]);
+    TORCH_INTERNAL_ASSERT(
+        new_position.find(ax) != new_position.end(),
+        "Error hit during transform replay, could not find ",
+        ax,
+        " expected in root domain.");
+    root_axis_map[new_position[ax]] = replay_axis_map[i];
+  }
+
+  auto replay_history = TransformIter::getHistory(producer);
+  auto rfactor_history = TransformIter::getHistory(producer_rfactor_root);
+  replay_history.erase(
+      replay_history.begin(), replay_history.begin() + rfactor_history.size());
+
+  consumer_replay_root = consumer_replay_root->reorder(root_axis_map);
+  // Finally replay consumer as producer on marked axes
+
+  auto replayed = TransformIter::replay(
+      consumer_replay_root, replay_history, replay_axis_map);
+
+  return replayed;
+}
+
+TensorView* TransformReplay::replayPasC(
+    TensorView* producer,
+    TensorView* consumer,
+    int compute_at_axis) {
+  // If this is a reduction operation, we may call transform_replay on the same
+  // tensor view. When this happens, just return thet target view.
+  if (producer == consumer)
+    return producer;
+
   TensorDomain* td =
-      runReplay(replay_ref->domain(), replay_target->domain(), compute_at_axis);
-  replay_target->setDomain(td);
-  return replay_target;
+      replayPasC(producer->domain(), consumer->domain(), compute_at_axis);
+  producer->setDomain(td);
+  return producer;
 }
 
-TensorView* TransformReplay::replay(
-    TensorView* replay_ref,
-    TensorView* replay_target,
+TensorView* TransformReplay::replayCasP(
+    TensorView* consumer,
+    TensorView* producer,
     int compute_at_axis) {
-  TransformReplay tr;
-  tr.runReplay(replay_ref, replay_target, compute_at_axis);
-  return replay_target;
-}
-
-TensorView* TransformReplay::fullReplay(
-    TensorView* replay_ref,
-    TensorView* replay_target) {
-  TransformReplay tr;
-  return tr.runReplay(replay_ref, replay_target, -1);
-}
-
-TensorDomain* TransformReplay::fullReplay(
-    TensorDomain* replay_ref,
-    TensorDomain* replay_target) {
-  TransformReplay tr;
-  return tr.runReplay(replay_ref, replay_target, -1);
+  // If this is a reduction operation, we may call transform_replay on the same
+  // tensor view. When this happens, just return thet target view.
+  if (consumer == producer)
+    return consumer;
+  TensorDomain* td =
+      replayCasP(consumer->domain(), producer->domain(), compute_at_axis);
+  consumer->setDomain(td);
+  return consumer;
 }
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_replay.h
+++ b/torch/csrc/jit/codegen/cuda/transform_replay.h
@@ -2,9 +2,6 @@
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
-#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
-#include <torch/csrc/jit/codegen/cuda/transform_iter.h>
-
 #include <algorithm>
 #include <vector>
 
@@ -118,76 +115,40 @@ namespace fuser {
  *
  */
 
-struct TORCH_CUDA_API TransformReplay : public TransformIter {
+struct TensorDomain;
+struct TensorView;
+
+struct TORCH_CUDA_API TransformReplay {
  private:
-  /*
-   * Functions to backward propagate influence from split/merge/reorder
-   */
-  void replayBackward(Split* expr);
-  void replayBackward(Merge* expr);
-  void replayBackward(Reorder* expr);
-
-  // Entry for backward influence propagation on td following record
-  TensorDomain* replayBackward(TensorDomain* td, bool generate_record = false);
-
-  /*
-   * Replay functions, takes a TensorView and steps through the operations in
-   * "record" based on influence axes. Will also update influence and propagate
-   * it forward.
-   */
-  TensorDomain* replay(Split* expr, TensorDomain* tv);
-  TensorDomain* replay(Merge* expr, TensorDomain* tv);
-  TensorDomain* replay(Reorder* expr, TensorDomain* tv);
-
-  /*
-   * Takes replay_ref and replays its transformations on replay_target
-   * Replays from begining of both TensorDomains. could be more efficient to try
-   * and find a common ancestor to start from, but likely not a worthwhile
-   * optimization.
-   */
-  TensorDomain* runReplay(
-      TensorDomain* replay_ref,
-      TensorDomain* replay_target,
-      int compute_at_axis);
-
-  /*
-   * Takes replay_ref and replays its transformations on replay_target
-   * Replays from begining of both TensorDomains. could be more efficient to try
-   * and find a common ancestor to start from, but likely not a worthwhile
-   * optimization.
-   */
-  TensorView* runReplay(
-      TensorView* replay_ref,
-      TensorView* replay_target,
-      int compute_at_axis);
-
-  // Running influence vector
-  std::vector<bool> influence;
-
-  // compute_at_axis
-  int compute_at_axis;
-
-  // In the replay we won't apply all transformations, but will need relative
-  // axes for later transformations. axis_map[full transform position] = partial
-  // transform position Full transform position is relative to if we played all
-  // transformations if full transform position is not in partial transform
-  // position it will return -1
-  // axis_map[fake_pos] = real_pos
-  std::vector<int> axis_map;
-
  public:
-  static TensorView* replay(
-      TensorView* replay_ref,
-      TensorView* replay_target,
+  // Self replay.
+  static TensorDomain* fullSelfReplay(
+      TensorDomain* self,
+      TensorDomain* self_copy);
+
+  // Replay producer as consumer.
+  static TensorDomain* replayPasC(
+      TensorDomain* producer,
+      TensorDomain* consumer,
       int compute_at_axis);
 
-  static TensorView* fullReplay(
-      TensorView* replay_ref,
-      TensorView* replay_target);
+  // Replay producer as consumer.
+  static TensorView* replayPasC(
+      TensorView* producer,
+      TensorView* consumer,
+      int compute_at_axis);
 
-  static TensorDomain* fullReplay(
-      TensorDomain* replay_ref,
-      TensorDomain* replay_target);
+  // Replay producer as consumer.
+  static TensorDomain* replayCasP(
+      TensorDomain* consumer,
+      TensorDomain* producer,
+      int compute_at_axis);
+
+  // Replay producer as consumer.
+  static TensorView* replayCasP(
+      TensorView* consumer,
+      TensorView* producer,
+      int compute_at_axis);
 };
 
 } // namespace fuser

--- a/torch/csrc/jit/codegen/cuda/transform_rfactor.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_rfactor.cpp
@@ -1,0 +1,239 @@
+#include <torch/csrc/jit/codegen/cuda/transform_rfactor.h>
+
+#include <torch/csrc/jit/codegen/cuda/fusion.h>
+#include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+
+TensorDomain* TransformRFactor::runReplay(
+    TensorDomain* orig_td,
+    std::vector<int> axes) {
+  int ndims = (int)orig_td->nDims();
+
+  // Adjust and check provided axes
+  std::transform(axes.begin(), axes.end(), axes.begin(), [ndims](int i) {
+    TORCH_CHECK(
+        i >= -ndims && i < ndims,
+        "Rfactor replay recieved an axis outside the number of dims in the tensor, acceptable inclusive range is ",
+        -ndims,
+        " to ",
+        ndims - 1);
+    return i < 0 ? i + ndims : i;
+  });
+
+  // remove duplicates, and put into a set for searching
+  std::set<int> axes_set(axes.begin(), axes.end());
+
+  // Make a copy of orig_td as we're going to change its history:
+  bool found_rfactor = false;
+  std::vector<IterDomain*> domain_copy;
+  for (int i{0}; i < ndims; i++) {
+    IterDomain* orig_axis = orig_td->axis(i);
+    if (axes_set.find(i) != axes_set.end())
+      TORCH_CHECK(
+          orig_axis->isReduction(),
+          "Tried to rFactor an axis that is not a reduction.");
+
+    if (orig_axis->isReduction()) {
+      if (axes_set.find(i) == axes_set.end()) {
+        domain_copy.push_back(new IterDomain(
+            orig_axis->start(),
+            orig_axis->extent(),
+            orig_axis->parallel_method(),
+            false,
+            true));
+        found_rfactor = true;
+      } else {
+        domain_copy.push_back(new IterDomain(
+            orig_axis->start(),
+            orig_axis->extent(),
+            orig_axis->parallel_method(),
+            true,
+            true));
+      }
+    } else {
+      domain_copy.push_back(orig_td->axis(i));
+    }
+  }
+  TORCH_CHECK(found_rfactor, "Could not find axis to rfactor out.");
+
+  // TD that we will actually modify,
+  TensorDomain* out_td = new TensorDomain(domain_copy);
+
+  // Axis map to create history for non-rfactor axes
+  std::vector<int> axis_map(ndims, -1);
+  std::vector<int> orig_rfactor_axis_map(ndims, -1);
+  std::set<IterDomain*> rfactor_ids;
+  for (decltype(out_td->nDims()) i{0}; i < out_td->nDims(); i++)
+    if (!out_td->axis(i)->isRFactorProduct()) {
+      axis_map[i] = i;
+    } else {
+      orig_rfactor_axis_map[i] = i;
+    }
+
+  // Replay non-rfactor axes
+  auto running_td = TransformIter::replayBackward(
+      out_td, TransformIter::getHistory(orig_td), axis_map);
+
+  // running_td has iteration domains on the right, but to find a valid rfactor
+  // root, we want those to be on the right. If we continued to replay backward
+  // we likely won't have a valid rfactor root. Lets manually insert a reorder
+  // so we have a valid rfactor root.
+
+  std::vector<int> new2old(running_td->nDims());
+  {
+    int running_pos = 0;
+    for (decltype(running_td->nDims()) i{0}; i < running_td->nDims(); i++)
+      if (!running_td->axis(i)->isRFactorProduct())
+        new2old[i] = running_pos++;
+
+    for (decltype(running_td->nDims()) i{0}; i < running_td->nDims(); i++)
+      if (running_td->axis(i)->isRFactorProduct())
+        new2old[i] = running_pos++;
+  }
+  std::vector<int> reorder_axis_map(running_td->nDims());
+  std::iota(reorder_axis_map.begin(), reorder_axis_map.end(), 0);
+
+  running_td = TransformIter::replayBackward(
+      running_td,
+      // include dummy reorder
+      {new Reorder(
+          new TensorDomain(running_td->domain()), running_td, new2old)},
+      reorder_axis_map);
+
+  // how do we find axes
+  // Need axis map from rfactor axes in running_td to corresponding axes in
+  // orig_td orig_rfactor_axis_map goes from orig_td to out_td we want it to
+  // go from orig_td to running_td
+
+  // Go from IterDomain to its position in running_td
+  std::unordered_map<IterDomain*, int> new_pos;
+  for (decltype(running_td->nDims()) i{0}; i < running_td->nDims(); i++) {
+    new_pos[running_td->axis(i)] = i;
+  }
+
+  for (decltype(out_td->nDims()) i{0}; i < out_td->nDims(); i++)
+    if (orig_rfactor_axis_map[i] != -1) {
+      int orig_td_pos = i;
+      int out_td_pos = orig_rfactor_axis_map[i];
+      TORCH_INTERNAL_ASSERT(
+          new_pos.find(out_td->axis(out_td_pos)) != new_pos.end(),
+          "Error aligning axes in rfactor first TD replay.");
+      int running_td_pos = new_pos[out_td->axis(out_td_pos)];
+      orig_rfactor_axis_map[i] = running_td_pos;
+    }
+
+  TransformIter::replayBackward(
+      running_td, TransformIter::getHistory(orig_td), orig_rfactor_axis_map);
+
+  return out_td;
+}
+
+TensorDomain* TransformRFactor::runReplay2(
+    TensorDomain* in_td,
+    std::vector<int> axes) {
+  int ndims = (int)in_td->nDims();
+
+  // Adjust and check provided axes
+  std::transform(axes.begin(), axes.end(), axes.begin(), [ndims](int i) {
+    TORCH_CHECK(
+        i >= -ndims && i < ndims,
+        "Rfactor replay recieved an axis outside the number of dims in the tensor, acceptable inclusive range is ",
+        -ndims,
+        " to ",
+        ndims - 1);
+    return i < 0 ? i + ndims : i;
+  });
+
+  // remove duplicates, and put into a set for searching
+  std::set<int> axes_set(axes.begin(), axes.end());
+
+  bool found_rfactor = false;
+  // Axes marked as rfactor, these will be removed from this domain
+  std::vector<bool> rfactor_axes(in_td->nDims(), false);
+  for (int i{0}; i < ndims; i++) {
+    bool in_set = axes_set.find(i) != axes_set.end();
+    IterDomain* orig_axis = in_td->axis(i);
+
+    if (in_set) {
+      TORCH_CHECK(
+          orig_axis->isReduction(),
+          "Tried to rFactor an axis that is not a reduction.");
+      rfactor_axes[i] = true;
+      found_rfactor = true;
+    }
+  }
+
+  TORCH_CHECK(found_rfactor, "Could not find axis to rfactor out.");
+  auto root_rfactor_axes = TransformIter::getRootInfluence(in_td, rfactor_axes);
+
+  // Root axes involved in rfactor, these axes should not be replayed, they need
+  // to be either removed completely, or part of the root domain
+  auto root_dom = TransformIter::getRoot(in_td);
+  TORCH_INTERNAL_ASSERT(
+      root_rfactor_axes.size() == root_dom->nDims(),
+      "Error backpropagating influence of rfactor.");
+
+  // Forward propagate influence back to the end we want to mark everything
+  // that's part of the rfactor
+  rfactor_axes = TransformIter::replayInfluence(
+      TransformIter::getHistory(in_td), root_rfactor_axes);
+
+  // Axes part of rfactor we need to keep
+  std::vector<IterDomain*> rfactor_axes_keep;
+
+  for (int i{0}; i < ndims; i++) {
+    if (rfactor_axes[i] && axes_set.find(i) == axes_set.end()) {
+      TORCH_INTERNAL_ASSERT(
+          in_td->axis(i)->isReduction(),
+          "Error occured when tracking rfactor axes.");
+      rfactor_axes_keep.push_back(in_td->axis(i));
+    }
+  }
+
+  int root_ndims = (int)root_dom->nDims();
+  std::vector<IterDomain*> domain_copy;
+  // These are the axes that are not involved in the rfactor.
+  for (int i{0}; i < root_ndims; i++) {
+    if (!root_rfactor_axes[i]) {
+      domain_copy.push_back(root_dom->axis(i));
+    }
+  }
+
+  TORCH_INTERNAL_ASSERT(
+      domain_copy.size() < root_dom->nDims(),
+      "Error during rfactor, didn't get any rfactor axes.");
+
+  // Setup axis map before we add back in the rfactor_axes
+  std::vector<int> replay_axis_map(root_dom->nDims(), -1);
+  {
+    int it = 0, ir = 0;
+    while (it < domain_copy.size() && ir < root_dom->nDims()) {
+      if (root_rfactor_axes[ir]) {
+        ir++;
+      } else {
+        replay_axis_map[ir++] = it++;
+      }
+    }
+    TORCH_INTERNAL_ASSERT(
+        it == domain_copy.size(),
+        "Error during rfactor, missed an unmodified root domain.");
+  }
+
+  // Push back the rfactor axes we need to keep
+  domain_copy.insert(
+      domain_copy.end(), rfactor_axes_keep.begin(), rfactor_axes_keep.end());
+
+  // TD that we will actually modify
+  TensorDomain* replay_root_td = new TensorDomain(domain_copy);
+  auto td = TransformIter::replay(
+      replay_root_td, TransformIter::getHistory(in_td), replay_axis_map);
+
+  return td;
+}
+
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/transform_rfactor.h
+++ b/torch/csrc/jit/codegen/cuda/transform_rfactor.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+#include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
+#include <torch/csrc/jit/codegen/cuda/transform_iter.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace torch {
+namespace jit {
+namespace fuser {
+
+// TODO: Only replay dispatch is really borrowed from TransformIter, we should
+// reevaluate the reuse of dispatch for classes that inherit TransformIter.
+struct TORCH_CUDA_API TransformRFactor {
+ public:
+  // Create a copy of td, change its history by presrving axes so they appear in
+  // the root domain
+  static TensorDomain* runReplay(TensorDomain*, std::vector<int> axes);
+  static TensorDomain* runReplay2(TensorDomain*, std::vector<int> axes);
+};
+
+} // namespace fuser
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -31,15 +31,11 @@ ValType promote_type(const ValType& t1, const ValType& t2) {
   return t1 < t2 ? t1 : t2;
 }
 
-c10::optional<UnaryOpType> cast_type(const DataType& t1, const DataType& t2) {
+bool is_cast_legal(const DataType& t1, const DataType& t2) {
   if ((DataType::Null == t1) || (DataType::Null == t2))
-    return c10::nullopt;
-  if ((DataType::Half == t1) && (DataType::Float == t2))
-    return UnaryOpType::HalfToFloat;
-  if ((DataType::Float == t1) && (DataType::Half == t2))
-    return UnaryOpType::FloatToHalf;
+    return false;
   // In theory there could be stronger real check here in the future
-  return c10::nullopt;
+  return true;
 }
 
 template <typename T>
@@ -52,9 +48,7 @@ template <typename KeyType, typename ValType>
 using _enum_unordered_map =
     std::unordered_map<KeyType, ValType, _enum_class_hash<KeyType>>;
 static _enum_unordered_map<DataType, std::string> data_type_string_map{
-    {DataType::Bool, "bool"},
     {DataType::Float, "float"},
-    {DataType::Half, "__half"},
     {DataType::Int, "size_t"}};
 static _enum_unordered_map<ValType, std::string> val_type_string_map{
     {ValType::TensorIndex, "TensorIndex"},
@@ -67,7 +61,6 @@ static _enum_unordered_map<ValType, std::string> val_type_string_map{
 static _enum_unordered_map<ExprType, std::string> expr_type_string_map{
     {ExprType::UnaryOp, "UnaryOp"},
     {ExprType::BinaryOp, "BinaryOp"},
-    {ExprType::TernaryOp, "TernaryOp"},
     {ExprType::ForLoop, "ForLoop"},
     {ExprType::IfThenElse, "IfThenElse"},
     {ExprType::Allocate, "Allocate"},
@@ -75,87 +68,29 @@ static _enum_unordered_map<ExprType, std::string> expr_type_string_map{
     {ExprType::Merge, "Merge"},
     {ExprType::Reorder, "Reorder"}};
 static _enum_unordered_map<UnaryOpType, std::string> unary_op_type_string_map{
-    {UnaryOpType::Abs, "fabs"},
-    {UnaryOpType::Acos, "acosf"},
-    {UnaryOpType::Asin, "asinf"},
-    {UnaryOpType::Atan, "atanf"},
-    {UnaryOpType::Atanh, "atanhf"},
-    //{UnaryOpType::Cast,       "cast"},
-    {UnaryOpType::Ceil, "ceilf"},
-    {UnaryOpType::Cos, "cosf"},
-    {UnaryOpType::Cosh, "coshf"},
-    {UnaryOpType::Exp, "expf"},
-    {UnaryOpType::Expm1, "expm1f"},
-    {UnaryOpType::Erf, "erff"},
-    {UnaryOpType::Erfc, "erfcf"},
-    {UnaryOpType::FloatToHalf, "__float2half"},
-    {UnaryOpType::Floor, "floorf"},
-    {UnaryOpType::Frac, "frac"},
-    {UnaryOpType::Gelu, "gelu"},
-    {UnaryOpType::HalfToFloat, "__half2float"},
-    {UnaryOpType::Lgamma, "lgammaf"},
-    {UnaryOpType::Log, "logf"},
-    {UnaryOpType::Log10, "log10f"},
-    {UnaryOpType::Log1p, "log1pf"},
-    {UnaryOpType::Log2, "log2f"},
-    {UnaryOpType::Neg, "neg"},
-    {UnaryOpType::RandLike, "randLike"},
-    {UnaryOpType::Reciprocal, "reciprocal"},
-    {UnaryOpType::Relu, "relu"},
-    {UnaryOpType::Rsqrt, "rsqrtf"},
-    {UnaryOpType::Round, "roundf"},
-    {UnaryOpType::Sigmoid, "sigmoid"},
-    {UnaryOpType::Sin, "sinf"},
-    {UnaryOpType::Sinh, "sinhf"},
-    {UnaryOpType::Sqrt, "sqrtf"},
-    {UnaryOpType::Tan, "tanf"},
-    {UnaryOpType::Tanh, "tanhf"},
-    {UnaryOpType::Trunc, "truncf"}};
+    {UnaryOpType::Neg, "Neg"},
+    {UnaryOpType::Cast, "Cast"},
+    {UnaryOpType::Set, "Set"}};
 static _enum_unordered_map<UnaryOpType, std::string>
-    unary_op_type_inline_op_string_map{{UnaryOpType::Neg, "-"}};
+    unary_op_type_inline_op_string_map{{UnaryOpType::Neg, "~"},
+                                       {UnaryOpType::Set, ""}};
 static _enum_unordered_map<BinaryOpType, std::string> binary_op_type_string_map{
-    {BinaryOpType::Add, "add"},
-    {BinaryOpType::Atan2, "atan2f"},
-    {BinaryOpType::Div, "div"},
-    {BinaryOpType::Fmod, "fmodf"},
-    {BinaryOpType::Max, "fmaxf"},
-    {BinaryOpType::Min, "fminf"},
-    {BinaryOpType::Mul, "mul"},
-    {BinaryOpType::Pow, "powf"},
-    {BinaryOpType::Remainder, "remainder"},
-    {BinaryOpType::Sub, "sub"},
-    //{BinaryOpType::TypeAs,
-
-    // Logical Ops
-    {BinaryOpType::Mod, "mod"},
+    {BinaryOpType::Add, "Add"},
+    {BinaryOpType::Sub, "Sub"},
+    {BinaryOpType::Mul, "Mul"},
+    {BinaryOpType::Div, "Div"},
+    {BinaryOpType::Mod, "Mod"},
+    {BinaryOpType::LT, "LessThan"},
     {BinaryOpType::CeilDiv, "ceilDiv"},
-    {BinaryOpType::And, "and"},
-    {BinaryOpType::Eq, "equal"},
-    {BinaryOpType::GE, "greaterThanOrEqual"},
-    {BinaryOpType::GT, "greaterThan"},
-    {BinaryOpType::LE, "lessThanOrEqual"},
-    {BinaryOpType::LT, "lessThan"},
-    {BinaryOpType::NE, "notEqual"}};
-
+    {BinaryOpType::And, "And"}};
 static _enum_unordered_map<BinaryOpType, std::string>
     binary_op_type_inline_op_string_map{{BinaryOpType::Add, "+"},
+                                        {BinaryOpType::Sub, "-"},
+                                        {BinaryOpType::Mul, "*"},
                                         {BinaryOpType::Div, "/"},
                                         {BinaryOpType::Mod, "%"},
-                                        {BinaryOpType::Mul, "*"},
-                                        {BinaryOpType::Sub, "-"},
-
-                                        // Logical Ops
-                                        {BinaryOpType::And, "&&"},
-                                        {BinaryOpType::Eq, "=="},
-                                        {BinaryOpType::GE, ">="},
-                                        {BinaryOpType::GT, ">"},
-                                        {BinaryOpType::LE, "<="},
                                         {BinaryOpType::LT, "<"},
-                                        {BinaryOpType::NE, "!="}};
-static _enum_unordered_map<TernaryOpType, std::string>
-    ternary_op_type_string_map{{TernaryOpType::Clamp, "clamp"},
-                               {TernaryOpType::Threshold, "threshold"},
-                               {TernaryOpType::Where, "where"}};
+                                        {BinaryOpType::And, "&&"}};
 
 static _enum_unordered_map<ParallelType, std::string> parallel_type_string_map{
     {ParallelType::BIDz, "blockIdx.z"},
@@ -168,10 +103,13 @@ static _enum_unordered_map<ParallelType, std::string> parallel_type_string_map{
     {ParallelType::Unroll, "Unroll"},
     {ParallelType::Serial, "Serial"}};
 
+static _enum_unordered_map<MemoryType, std::string> memory_type_string_map{
+    {MemoryType::Local, "register"},
+    {MemoryType::Shared, "shared"},
+    {MemoryType::Global, "global"}};
+
 static _enum_unordered_map<at::ScalarType, DataType> at_type_map{
-    {at::ScalarType::Bool, DataType::Bool},
     {at::ScalarType::Float, DataType::Float},
-    {at::ScalarType::Half, DataType::Half},
     {at::ScalarType::Int, DataType::Int}};
 
 static _enum_unordered_map<ParallelType, std::string> thread_size_string_map{
@@ -181,18 +119,6 @@ static _enum_unordered_map<ParallelType, std::string> thread_size_string_map{
     {ParallelType::TIDz, "blockDim.z"},
     {ParallelType::TIDy, "blockDim.y"},
     {ParallelType::TIDx, "blockDim.x"}};
-
-static std::unordered_set<BinaryOpType> logical_binary_ops{BinaryOpType::And,
-                                                           BinaryOpType::Eq,
-                                                           BinaryOpType::GE,
-                                                           BinaryOpType::GT,
-                                                           BinaryOpType::LE,
-                                                           BinaryOpType::LT,
-                                                           BinaryOpType::NE};
-
-bool is_logical_op(const BinaryOpType& bot) {
-  return logical_binary_ops.count(bot) > 0;
-}
 
 DataType aten_to_data_type(const at::ScalarType& scalar_type) {
   TORCH_INTERNAL_ASSERT(
@@ -240,15 +166,6 @@ TORCH_CUDA_API std::ostream& operator<<(
       binary_op_type_string_map.count(botype) != 0,
       "No string found for BinaryOp type.");
   return out << binary_op_type_string_map[botype];
-}
-
-TORCH_CUDA_API std::ostream& operator<<(
-    std::ostream& out,
-    const TernaryOpType totype) {
-  TORCH_INTERNAL_ASSERT(
-      ternary_op_type_string_map.count(totype) != 0,
-      "No string found for TernaryOp type.");
-  return out << ternary_op_type_string_map[totype];
 }
 
 std::string stringify(const ParallelType ptype) {

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -31,12 +31,22 @@ ValType promote_type(const ValType& t1, const ValType& t2) {
   return t1 < t2 ? t1 : t2;
 }
 
-bool is_cast_legal(const DataType& t1, const DataType& t2) {
-  if ((DataType::Null == t1) || (DataType::Null == t2))
-    return false;
+c10::optional<UnaryOpType> cast_type(const DataType& t1, const DataType& t2) {
+ 
+  c10::optional<UnaryOpType> cast = c10::nullopt;
+
+  if ((DataType::Half == t1) && (DataType::Float == t2))
+    cast = UnaryOpType::HalfToFloat;
+  if ((DataType::Float == t1) && (DataType::Half == t2))
+    cast = UnaryOpType::FloatToHalf;
+
+  TORCH_CHECK(
+      !cast, "Illegal Cast value from  DataType: ", t1, " to DataType: ", t2);
+
   // In theory there could be stronger real check here in the future
-  return true;
+  return cast;
 }
+
 
 template <typename T>
 struct _enum_class_hash {

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -32,7 +32,6 @@ ValType promote_type(const ValType& t1, const ValType& t2) {
 }
 
 c10::optional<UnaryOpType> cast_type(const DataType& t1, const DataType& t2) {
- 
   c10::optional<UnaryOpType> cast = c10::nullopt;
 
   if ((DataType::Half == t1) && (DataType::Float == t2))
@@ -46,7 +45,6 @@ c10::optional<UnaryOpType> cast_type(const DataType& t1, const DataType& t2) {
   // In theory there could be stronger real check here in the future
   return cast;
 }
-
 
 template <typename T>
 struct _enum_class_hash {
@@ -119,10 +117,8 @@ static _enum_unordered_map<UnaryOpType, std::string> unary_op_type_string_map{
     {UnaryOpType::Tanh, "tanhf"},
     {UnaryOpType::Trunc, "truncf"}};
 static _enum_unordered_map<UnaryOpType, std::string>
-    unary_op_type_inline_op_string_map{
-      {UnaryOpType::Neg, "-"},
-      {UnaryOpType::Set, ""}
-      };
+    unary_op_type_inline_op_string_map{{UnaryOpType::Neg, "-"},
+                                       {UnaryOpType::Set, ""}};
 static _enum_unordered_map<BinaryOpType, std::string> binary_op_type_string_map{
     {BinaryOpType::Add, "add"},
     {BinaryOpType::Atan2, "atan2f"},

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -48,7 +48,9 @@ template <typename KeyType, typename ValType>
 using _enum_unordered_map =
     std::unordered_map<KeyType, ValType, _enum_class_hash<KeyType>>;
 static _enum_unordered_map<DataType, std::string> data_type_string_map{
+    {DataType::Bool, "bool"},
     {DataType::Float, "float"},
+    {DataType::Half, "__half"},
     {DataType::Int, "size_t"}};
 static _enum_unordered_map<ValType, std::string> val_type_string_map{
     {ValType::TensorIndex, "TensorIndex"},
@@ -61,6 +63,7 @@ static _enum_unordered_map<ValType, std::string> val_type_string_map{
 static _enum_unordered_map<ExprType, std::string> expr_type_string_map{
     {ExprType::UnaryOp, "UnaryOp"},
     {ExprType::BinaryOp, "BinaryOp"},
+    {ExprType::TernaryOp, "TernaryOp"},
     {ExprType::ForLoop, "ForLoop"},
     {ExprType::IfThenElse, "IfThenElse"},
     {ExprType::Allocate, "Allocate"},
@@ -68,29 +71,91 @@ static _enum_unordered_map<ExprType, std::string> expr_type_string_map{
     {ExprType::Merge, "Merge"},
     {ExprType::Reorder, "Reorder"}};
 static _enum_unordered_map<UnaryOpType, std::string> unary_op_type_string_map{
-    {UnaryOpType::Neg, "Neg"},
-    {UnaryOpType::Cast, "Cast"},
-    {UnaryOpType::Set, "Set"}};
+    {UnaryOpType::Abs, "fabs"},
+    {UnaryOpType::Acos, "acosf"},
+    {UnaryOpType::Asin, "asinf"},
+    {UnaryOpType::Atan, "atanf"},
+    {UnaryOpType::Atanh, "atanhf"},
+    //{UnaryOpType::Cast,       "cast"},
+    {UnaryOpType::Ceil, "ceilf"},
+    {UnaryOpType::Cos, "cosf"},
+    {UnaryOpType::Cosh, "coshf"},
+    {UnaryOpType::Exp, "expf"},
+    {UnaryOpType::Expm1, "expm1f"},
+    {UnaryOpType::Erf, "erff"},
+    {UnaryOpType::Erfc, "erfcf"},
+    {UnaryOpType::FloatToHalf, "__float2half"},
+    {UnaryOpType::Floor, "floorf"},
+    {UnaryOpType::Frac, "frac"},
+    {UnaryOpType::Gelu, "gelu"},
+    {UnaryOpType::HalfToFloat, "__half2float"},
+    {UnaryOpType::Lgamma, "lgammaf"},
+    {UnaryOpType::Log, "logf"},
+    {UnaryOpType::Log10, "log10f"},
+    {UnaryOpType::Log1p, "log1pf"},
+    {UnaryOpType::Log2, "log2f"},
+    {UnaryOpType::Neg, "neg"},
+    {UnaryOpType::RandLike, "randLike"},
+    {UnaryOpType::Reciprocal, "reciprocal"},
+    {UnaryOpType::Relu, "relu"},
+    {UnaryOpType::Rsqrt, "rsqrtf"},
+    {UnaryOpType::Round, "roundf"},
+    {UnaryOpType::Set, "set"},
+    {UnaryOpType::Sigmoid, "sigmoid"},
+    {UnaryOpType::Sin, "sinf"},
+    {UnaryOpType::Sinh, "sinhf"},
+    {UnaryOpType::Sqrt, "sqrtf"},
+    {UnaryOpType::Tan, "tanf"},
+    {UnaryOpType::Tanh, "tanhf"},
+    {UnaryOpType::Trunc, "truncf"}};
 static _enum_unordered_map<UnaryOpType, std::string>
-    unary_op_type_inline_op_string_map{{UnaryOpType::Neg, "~"},
-                                       {UnaryOpType::Set, ""}};
+    unary_op_type_inline_op_string_map{
+      {UnaryOpType::Neg, "-"},
+      {UnaryOpType::Set, ""}
+      };
 static _enum_unordered_map<BinaryOpType, std::string> binary_op_type_string_map{
-    {BinaryOpType::Add, "Add"},
-    {BinaryOpType::Sub, "Sub"},
-    {BinaryOpType::Mul, "Mul"},
-    {BinaryOpType::Div, "Div"},
-    {BinaryOpType::Mod, "Mod"},
-    {BinaryOpType::LT, "LessThan"},
+    {BinaryOpType::Add, "add"},
+    {BinaryOpType::Atan2, "atan2f"},
+    {BinaryOpType::Div, "div"},
+    {BinaryOpType::Fmod, "fmodf"},
+    {BinaryOpType::Max, "fmaxf"},
+    {BinaryOpType::Min, "fminf"},
+    {BinaryOpType::Mul, "mul"},
+    {BinaryOpType::Pow, "powf"},
+    {BinaryOpType::Remainder, "remainder"},
+    {BinaryOpType::Sub, "sub"},
+    //{BinaryOpType::TypeAs,
+
+    // Logical Ops
+    {BinaryOpType::Mod, "mod"},
     {BinaryOpType::CeilDiv, "ceilDiv"},
-    {BinaryOpType::And, "And"}};
+    {BinaryOpType::And, "and"},
+    {BinaryOpType::Eq, "equal"},
+    {BinaryOpType::GE, "greaterThanOrEqual"},
+    {BinaryOpType::GT, "greaterThan"},
+    {BinaryOpType::LE, "lessThanOrEqual"},
+    {BinaryOpType::LT, "lessThan"},
+    {BinaryOpType::NE, "notEqual"}};
+
 static _enum_unordered_map<BinaryOpType, std::string>
     binary_op_type_inline_op_string_map{{BinaryOpType::Add, "+"},
-                                        {BinaryOpType::Sub, "-"},
-                                        {BinaryOpType::Mul, "*"},
                                         {BinaryOpType::Div, "/"},
                                         {BinaryOpType::Mod, "%"},
+                                        {BinaryOpType::Mul, "*"},
+                                        {BinaryOpType::Sub, "-"},
+
+                                        // Logical Ops
+                                        {BinaryOpType::And, "&&"},
+                                        {BinaryOpType::Eq, "=="},
+                                        {BinaryOpType::GE, ">="},
+                                        {BinaryOpType::GT, ">"},
+                                        {BinaryOpType::LE, "<="},
                                         {BinaryOpType::LT, "<"},
-                                        {BinaryOpType::And, "&&"}};
+                                        {BinaryOpType::NE, "!="}};
+static _enum_unordered_map<TernaryOpType, std::string>
+    ternary_op_type_string_map{{TernaryOpType::Clamp, "clamp"},
+                               {TernaryOpType::Threshold, "threshold"},
+                               {TernaryOpType::Where, "where"}};
 
 static _enum_unordered_map<ParallelType, std::string> parallel_type_string_map{
     {ParallelType::BIDz, "blockIdx.z"},
@@ -109,7 +174,9 @@ static _enum_unordered_map<MemoryType, std::string> memory_type_string_map{
     {MemoryType::Global, "global"}};
 
 static _enum_unordered_map<at::ScalarType, DataType> at_type_map{
+    {at::ScalarType::Bool, DataType::Bool},
     {at::ScalarType::Float, DataType::Float},
+    {at::ScalarType::Half, DataType::Half},
     {at::ScalarType::Int, DataType::Int}};
 
 static _enum_unordered_map<ParallelType, std::string> thread_size_string_map{
@@ -119,6 +186,19 @@ static _enum_unordered_map<ParallelType, std::string> thread_size_string_map{
     {ParallelType::TIDz, "blockDim.z"},
     {ParallelType::TIDy, "blockDim.y"},
     {ParallelType::TIDx, "blockDim.x"}};
+
+static std::unordered_set<BinaryOpType, _enum_class_hash<BinaryOpType>>
+    logical_binary_ops{BinaryOpType::And,
+                       BinaryOpType::Eq,
+                       BinaryOpType::GE,
+                       BinaryOpType::GT,
+                       BinaryOpType::LE,
+                       BinaryOpType::LT,
+                       BinaryOpType::NE};
+
+bool is_logical_op(const BinaryOpType& bot) {
+  return logical_binary_ops.count(bot) > 0;
+}
 
 DataType aten_to_data_type(const at::ScalarType& scalar_type) {
   TORCH_INTERNAL_ASSERT(
@@ -168,17 +248,31 @@ TORCH_CUDA_API std::ostream& operator<<(
   return out << binary_op_type_string_map[botype];
 }
 
-std::string stringify(const ParallelType ptype) {
+TORCH_CUDA_API std::ostream& operator<<(
+    std::ostream& out,
+    const TernaryOpType totype) {
   TORCH_INTERNAL_ASSERT(
-      parallel_type_string_map.count(ptype) != 0,
-      "No string found for parallel type.");
-  return parallel_type_string_map[ptype];
+      ternary_op_type_string_map.count(totype) != 0,
+      "No string found for TernaryOp type.");
+  return out << ternary_op_type_string_map[totype];
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const ParallelType ptype) {
-  return out << stringify(ptype);
+  TORCH_INTERNAL_ASSERT(
+      parallel_type_string_map.count(ptype) != 0,
+      "No string found for provided parallel type.");
+  return out << parallel_type_string_map[ptype];
+}
+
+TORCH_CUDA_API std::ostream& operator<<(
+    std::ostream& out,
+    const MemoryType mtype) {
+  TORCH_INTERNAL_ASSERT(
+      memory_type_string_map.count(mtype) != 0,
+      "No string found for provided memory type.");
+  return out << memory_type_string_map[mtype];
 }
 
 TORCH_CUDA_API c10::optional<std::string> inline_op_str(

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -29,6 +29,7 @@ enum class ExprType {
   UnaryOp,
   BinaryOp,
   TernaryOp,
+  ReductionOp,
   ForLoop,
   IfThenElse,
   Allocate,
@@ -43,7 +44,7 @@ enum class UnaryOpType {
   Asin,
   Atan,
   Atanh,
-  // Cast,
+  Cast,
   Ceil,
   Cos,
   Cosh,
@@ -67,6 +68,7 @@ enum class UnaryOpType {
   Relu,
   Rsqrt,
   Round,
+  Set,
   Sigmoid,
   Sin,
   Sinh,
@@ -118,6 +120,8 @@ enum class ParallelType {
   Unroll,
   Serial
 };
+
+enum class MemoryType { Local, Shared, Global };
 
 ValType promote_type(const ValType& t1, const ValType& t2);
 DataType promote_type(const DataType& t1, const DataType& t2);

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -138,7 +138,6 @@ TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const BinaryOpType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const TernaryOpType);
 TORCH_CUDA_API std::ostream& operator<<(std::ostream&, const ParallelType);
 
-std::string stringify(const ParallelType);
 std::string stringifyThreadSize(const ParallelType);
 
 TORCH_CUDA_API c10::optional<std::string> inline_op_str(const UnaryOpType);


### PR DESCRIPTION
Build out in code generation for reduction support. RFactor is enabled with full transform replay support, meaning it has full functionality with computeAt. 

There's still quite a bit of work for me to do:

- Hook up thread all reduces
- Cross block reductions
- Thread predicates after reductions or generally for loop nests if their thread/block usage differs
- Disable rfactor being called multiple times on the same tensor
- Remove TensorView Reorder code, use tensor domain.
- Refactor datatype usage in tests as data type is always associated with a Val and easily retrievable
