### PR TITLE
add missing include file for fake_nnpi_ops_utils

### DIFF
--- a/caffe2/contrib/fakelowp/fake_nnpi_ops_utils.cc
+++ b/caffe2/contrib/fakelowp/fake_nnpi_ops_utils.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cinttypes>
 #include <cmath>
 


### PR DESCRIPTION
Summary: add missing include file

Test Plan: tested fix on OSS

Reviewed By: yinghai

Differential Revision: D21498580

