### PR TITLE
Run mypy on some test files, add iinfo/finfo annotations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,7 +17,9 @@ check_untyped_defs = True
 files =
     torch,
     caffe2,
-    aten/src/ATen/function_wrapper.py
+    aten/src/ATen/function_wrapper.py,
+    test/test_type_hints.py,
+    test/test_type_info.py
 
 
 # Minimum version supported - variable annotations were introduced

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,7 @@ files =
     torch,
     caffe2,
     aten/src/ATen/function_wrapper.py,
+    test/test_complex.py,
     test/test_type_hints.py,
     test/test_type_info.py
 

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -644,7 +644,8 @@ def gen_pyi(declarations_path, out):
                          for n in
                          ['float32', 'float', 'float64', 'double', 'float16', 'bfloat16', 'half',
                           'uint8', 'int8', 'int16', 'short', 'int32', 'int', 'int64', 'long',
-                          'complex32', 'complex64', 'complex128', 'quint8', 'qint8', 'qint32', 'bool']]
+                          'complex32', 'complex64', 'cfloat', 'complex128', 'cdouble',
+                          'quint8', 'qint8', 'qint32', 'bool']]
 
     # Write out the stub
     # ~~~~~~~~~~~~~~~~~~

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -38,6 +38,27 @@ class dtype:
     # TODO: is_floating_point, is_complex, is_Signed, __reduce__
     ...
 
+# Defined in torch/csrc/TypeInfo.cpp
+class iinfo:
+    bits: _int
+    min: _int
+    max: _int
+
+    def __init__(self, dtype: _dtype) -> None: ...
+
+class finfo:
+    bits: _float
+    min: _float
+    max: _float
+    eps: _float
+    tiny: _float
+
+    @overload
+    def __init__(self, dtype: _dtype) -> None: ...
+
+    @overload
+    def __init__(self) -> None: ...
+
 ${dtype_class_hints}
 
 # Defined in torch/csrc/Layout.cpp


### PR DESCRIPTION
Most test files have a ton of errors; there's not much point adding ignores for them though. The way of working is simply to run `mypy test/test_somefile.py`, fix up the errors, then add that file to the `files =` list in `mypy.ini`.

Can't add all of `test/*` by default, because the JIT test files have (on purpose) syntax errors that are meant to exercise the robustness of the JIT to bad annotations. Leave those alone for now.

_Depends on the ghstacked PRs in gh-38173, only the last 2 commits are new._