### PR TITLE
Allow reduce on empty tensor over non-empty dimension

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -630,8 +630,14 @@ Tensor max_values(const Tensor& self, DimnameList dims, bool keepdim) {
 }
 
 Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
-  TORCH_CHECK(self.numel() > 0, "cannot perform reduction function argmax on a "
-      "tensor with no elements because the operation does not have an identity");
+  TORCH_CHECK(dim.has_value() || self.numel() > 0,
+              "cannot perform reduction function argmax "
+              "on a tensor ", self.sizes(), " with no elements because the operation does not have an identity."
+              " Try performing reduction over a non-zero dimension.");
+  TORCH_CHECK(dim.has_value() && self.size(dim.value()) != 0,
+              "cannot perform reduction function argmax "
+              "on a zero dimension ", dim.value(), " of ", self.sizes(), " because the operation does not have an identity."
+              " Try performing reduction over a non-zero dimension.");
   Tensor in;
   if (dim) {
     in = self;
@@ -651,8 +657,14 @@ Tensor argmax(const Tensor& self, c10::optional<int64_t> dim, bool keepdims) {
 }
 
 Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
-  TORCH_CHECK(self.numel() > 0, "cannot perform reduction function argmin on a "
-      "tensor with no elements because the operation does not have an identity");
+  TORCH_CHECK(dim.has_value() || self.numel() > 0,
+              "cannot perform reduction function argmin "
+              "on a tensor ", self.sizes(), " with no elements because the operation does not have an identity."
+              " Try performing reduction over a non-zero dimension.");
+  TORCH_CHECK(dim.has_value() && self.size(dim.value()) != 0,
+              "cannot perform reduction function argmin "
+              "on a zero dimension ", dim.value(), " of ", self.sizes(), " because the operation does not have an identity."
+              " Try performing reduction over a non-zero dimension.");
   Tensor in;
   if (dim) {
     in = self;

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -83,9 +83,16 @@ inline bool _dimreduce_return_trivial_no_ident(Tensor &result, const Tensor &sel
     return true;
   }
 
-  if (self.numel() == 0) {
+  if (dim < 0 && self.numel() == 0) {
     AT_ERROR("cannot perform reduction function ", fn_name,
-             " on tensor with no elements because the operation does not have an identity");
+              " on a tensor ", self.sizes(), " with no elements because the operation does not have an identity."
+              " Try performing reduction over a non-zero dimension.");
+  }
+
+  if (dim >= 0 && self.size(dim) == 0) {
+    AT_ERROR("cannot perform reduction function ", fn_name,
+             " on a zero dimension ", dim, " of ", self.sizes(), " because the operation does not have an identity."
+             " Try performing reduction over a non-zero dimension.");
   }
   return false;
 }

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -101,14 +101,13 @@ static std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
     int64_t dim_,
     bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
-  TORCH_CHECK((dim >= 0) || self.numel() > 0,
-              "cannot perform reduction function kthvalue "
-              "on a tensor ", self.sizes(), " with no elements because the operation does not have an identity."
-              " Try performing reduction over a non-zero dimension.");
-  TORCH_CHECK(self.size(dim) != 0,
-              "cannot perform reduction function kthvalue "
-              "on a zero dimension ", dim, " of ", self.sizes(), " because the operation does not have an identity."
-              " Try performing reduction over a non-zero dimension.");
+  // FIXME: This seems bogus, I only do this because it was the old behaviour.
+  //        The reductions are fine, as long as the axis being reduced along
+  //        isn't of 0 elements (and the output has elements).
+  TORCH_CHECK(
+      self.numel() > 0,
+      "cannot perform reduction function kthvalue",
+      " on tensor with no elements because the operation does not have an identity");
   TORCH_CHECK(
       k > 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
       "selected index k out of range");

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -101,13 +101,14 @@ static std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
     int64_t dim_,
     bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
-  // FIXME: This seems bogus, I only do this because it was the old behaviour.
-  //        The reductions are fine, as long as the axis being reduced along
-  //        isn't of 0 elements (and the output has elements).
-  TORCH_CHECK(
-      self.numel() > 0,
-      "cannot perform reduction function kthvalue",
-      " on tensor with no elements because the operation does not have an identity");
+  TORCH_CHECK((dim >= 0) || self.numel() > 0,
+              "cannot perform reduction function kthvalue "
+              "on a tensor ", self.sizes(), " with no elements because the operation does not have an identity."
+              " Try performing reduction over a non-zero dimension.");
+  TORCH_CHECK(self.size(dim) != 0,
+              "cannot perform reduction function kthvalue "
+              "on a zero dimension ", dim, " of ", self.sizes(), " because the operation does not have an identity."
+              " Try performing reduction over a non-zero dimension.");
   TORCH_CHECK(
       k > 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
       "selected index k out of range");

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9279,6 +9279,38 @@ class TestTorchDeviceType(TestCase):
             expected = fn(y, 1, keepdim=False)
             self.assertEqual(x[:, 1], expected, msg='{} with out= kwarg'.format(fn_name))
 
+    def test_no_ident_reduction_on_emptytensor(self, device):
+        a = torch.zeros((0, 1, 0), device=device)
+        b = torch.zeros((1, 0, 0), device=device)
+
+        for fn in [torch.max, torch.min]:
+            ident_err = 'operation does not have an identity'
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a))
+
+            ident_err = 'operation does not have an identity'
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a, dim=0))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(b, dim=1))
+            self.assertEqual(fn(a, dim=1).values.nelement(), 0)
+            self.assertEqual(fn(b, dim=0).values.nelement(), 0)
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a, dim=2))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(b, dim=-1))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a, dim=2))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(b, dim=-1))
+
+        for fn in [torch.argmax, torch.argmin]:
+            ident_err = 'operation does not have an identity'
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a))
+
+            ident_err = 'operation does not have an identity'
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a, dim=0))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(b, dim=1))
+            self.assertEqual(fn(a, dim=1).nelement(), 0)
+            self.assertEqual(fn(b, dim=0).nelement(), 0)
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a, dim=2))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(a, dim=-1))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(b, dim=2))
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(b, dim=-1))
+
     @largeCUDATensorTest('10GB')
     def test_reduction_split(self, device):
         # Test reduction when there is a 32bit-indexing split

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12829,14 +12829,9 @@ class TestTorchDeviceType(TestCase):
         for item in fns_to_test:
             name, fn, identity = item
             if identity is None:
-                output = fn(x, dim=2)
-                output = output[0] if isinstance(output, tuple) else output
-                self.assertEqual(output.nelement(), 0)
-                output = fn(x, dim=2, keepdim=True)
-                output = output[0] if isinstance(output, tuple) else output
-                self.assertEqual(output.nelement(), 0)
-                ident_err = '.*does not have an identity.*'
-                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x))
+                ident_err = 'does not have an identity'
+                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2))
+                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2, keepdim=True))
                 self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1))
                 self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1, keepdim=True))
             else:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12829,9 +12829,14 @@ class TestTorchDeviceType(TestCase):
         for item in fns_to_test:
             name, fn, identity = item
             if identity is None:
-                ident_err = 'does not have an identity'
-                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2))
-                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2, keepdim=True))
+                output = fn(x, dim=2)
+                output = output[0] if isinstance(output, tuple) else output
+                self.assertEqual(output.nelement(), 0)
+                output = fn(x, dim=2, keepdim=True)
+                output = output[0] if isinstance(output, tuple) else output
+                self.assertEqual(output.nelement(), 0)
+                ident_err = '.*does not have an identity.*'
+                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x))
                 self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1))
                 self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1, keepdim=True))
             else:


### PR DESCRIPTION
My go at fixing reduction over non-empty dimensions for empty tensors. This PR tries to achieve the same as #35062 but for `argmax`, `argmin` and `kthvalue`. Issues that this PR fixes are: #34907,  #28380. The fix *should* make reduction operations on empty tensors behave as numpy, that is if the reduction is applied over non-empty dimension, result is an empty tensor, and Error otherwise. This is clearly explained in the PR #34907. Thanks to the author for showing me where to look at for this fix!

I first created new tests, and then found the existing tests and updated them in the second commit. I'm tending to just extending on existing tests and remove the new ones. Let me know what you think.

This is my first look at pytorch code so I'm a bit lost. However, these checks seem like they should all be handled in `_dimreduce_return_trivial_no_ident` inside `ReduceOpsUtils.h`. If someone can help me along I would like to refactor the checks to remove duplication.