### PR TITLE
Add dropout removal pass.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12519,6 +12519,39 @@ a")
         self.run_pass('erase_number_types', graph)
         FileCheck().check_not("int = prim::Constant").check_not("aten::add_").run(str(graph))
 
+    def test_remove_dropout(self):
+        weight_0_shape = (20, 5)
+        weight_1_shape = (20, 20)
+        input_shape = (10, 5)
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.weight_0 = torch.nn.Parameter(torch.Tensor(torch.rand(weight_0_shape)))
+                self.weight_1 = torch.nn.Parameter(torch.Tensor(torch.rand(weight_1_shape)))
+
+            def forward(self, x):
+                o = F.linear(x, self.weight_0)
+                o = F.dropout(o, training=self.training)
+                o = F.linear(o, self.weight_1)
+                return o
+
+        data = torch.rand(input_shape)
+        m = M()
+        m = torch.jit.script(m)
+        with self.assertRaisesRegex(RuntimeError, r'Dropout removal module in training mode is not yet supported'):
+            torch._C._jit_pass_remove_dropout(m._c)
+        m.eval()
+        ref_res = m(data)
+        # Need to inline otherwise we see instances of Function.
+        # We would have to use torch.linear/dropout to get around it otherwise.
+        from torch.jit._recursive import wrap_cpp_module
+        m = wrap_cpp_module(torch._C._freeze_module(m._c))
+        torch._C._jit_pass_remove_dropout(m._c)
+        res = m(data)
+        FileCheck().check_not("aten::dropout").run(str(m.graph))
+        torch.testing.assert_allclose(ref_res, res, rtol=1e-2, atol=1e-3)
+
     def test_mm_batching(self):
 
         with enable_profiling_mode_for_profiling_tests():

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -129,6 +129,7 @@ libtorch_core_sources = [
     "torch/csrc/jit/passes/prepack_folding.cpp",
     "torch/csrc/jit/passes/fold_conv_bn.cpp",
     "torch/csrc/jit/passes/remove_expands.cpp",
+    "torch/csrc/jit/passes/remove_dropout.cpp",
     "torch/csrc/jit/passes/requires_grad_analysis.cpp",
     "torch/csrc/jit/passes/shape_analysis.cpp",
     "torch/csrc/jit/passes/specialize_autogradzero.cpp",

--- a/torch/csrc/jit/passes/remove_dropout.cpp
+++ b/torch/csrc/jit/passes/remove_dropout.cpp
@@ -1,0 +1,54 @@
+#include <torch/csrc/jit/passes/remove_dropout.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+bool isDropoutRemovable(const Node* node) {
+  const auto inputs = node->inputs();
+  TORCH_INTERNAL_ASSERT(inputs.size() == 3);
+  const Value* training_input = inputs[2];
+  auto optional_ivalue = toIValue(training_input);
+  TORCH_INTERNAL_ASSERT(optional_ivalue.has_value());
+  const IValue& val = optional_ivalue.value();
+  TORCH_INTERNAL_ASSERT(val.isBool());
+  const bool is_training = val.toBool();
+  return !is_training;
+}
+
+void removeDropoutImpl(Block* block) {
+  auto graph = block->owningGraph();
+  std::vector<Node*> deleted_nodes;
+
+  for (auto it = block->nodes().rbegin(); it != block->nodes().rend(); it++) {
+    Node* node = *it;
+    for (auto block : node->blocks()) {
+      removeDropoutImpl(block);
+    }
+    if ((node->kind() == c10::Symbol::fromQualString("aten::dropout")
+          || node->kind() == c10::Symbol::fromQualString("aten::dropout_"))
+        && isDropoutRemovable(*it)) {
+      // Input tensor of dropout.
+      Value* input_value = node->inputs()[0];
+      // Output tensor.
+      Value* output_value = node->outputs()[0];
+      output_value->replaceAllUsesWith(input_value);
+      deleted_nodes.push_back(node);
+    }
+  }
+  for(auto del_node : deleted_nodes) {
+    del_node->destroy();
+  }
+}
+} // namespace
+
+void removeDropout(script::Module& module) {
+  TORCH_CHECK(
+      !module.hasattr("training") || !module.is_training(),
+      "Dropout removal module in training mode is not yet supported");
+  auto graph = module.get_method("forward").graph();
+  removeDropoutImpl(graph->block());
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/remove_dropout.h
+++ b/torch/csrc/jit/passes/remove_dropout.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+TORCH_API void removeDropout(script::Module& module);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -43,6 +43,7 @@
 #include <torch/csrc/jit/passes/quantization/finalize.h>
 #include <torch/csrc/jit/passes/quantization/insert_observers.h>
 #include <torch/csrc/jit/passes/quantization/insert_quant_dequant.h>
+#include <torch/csrc/jit/passes/remove_dropout.h>
 #include <torch/csrc/jit/passes/remove_expands.h>
 #include <torch/csrc/jit/passes/remove_inplace_ops.h>
 #include <torch/csrc/jit/passes/shape_analysis.h>
@@ -499,6 +500,9 @@ void initJITBindings(PyObject* module) {
           [](Graph& g, std::vector<at::Tensor> inps) {
             return debugGetFusedKernelCode(g, inps);
           })
+      .def(
+          "_jit_pass_remove_dropout",
+          [](script::Module& module) { return removeDropout(module); })
       .def(
           "_jit_pass_insert_prepacked_ops",
           [](std::shared_ptr<Graph>& graph) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38251 Enabled dropout removal pass in mobile optimizer.
* **#38250 Add dropout removal pass.**

This pass removes dropout and dropout_ nodes when training is false. It
requires to have run freeze_module pass which does both inlining and constant
propagation, without which training variable remains as attribute instead of
constant.

Differential Revision: [D21505863](https://our.internmc.facebook.com/intern/diff/D21505863/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D21505863/)!