### PR TITLE
Enabled dropout removal pass in mobile optimizer.

### DIFF
--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
+#include <torch/csrc/jit/passes/remove_dropout.h>
 #include <torch/csrc/jit/passes/fold_conv_bn.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/fuse_linear.h>
@@ -307,6 +308,7 @@ c10::optional<script::Module> optimizeForMobile(const script::Module& m) {
   insertPrePackedOps(cloned_module);
   cloned_module = freeze_module(cloned_module);
   FoldPrePackingOps(cloned_module);
+  removeDropout(cloned_module);
   return cloned_module;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38251 Enabled dropout removal pass in mobile optimizer.**
* #38250 Add dropout removal pass.

Differential Revision: [D21505862](https://our.internmc.facebook.com/intern/diff/D21505862/)