### PR TITLE
[Tensorpipe Agent] Tracking Active Call Metrics

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -328,6 +328,7 @@ std::shared_ptr<FutureMessage> TensorPipeAgent::send(
           const tensorpipe::Error& error) {
         if (error) {
           LOG(WARNING) << "client write error: " << error.what();
+          --clientActiveCalls_;
           futureResponseMessage->setError(error.what());
           return;
         }

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -371,7 +371,8 @@ std::shared_ptr<FutureMessage> TensorPipeAgent::send(
               }
 
               threadPool_.run(
-                  [futureResponseMessage,
+                  [this,
+                   futureResponseMessage,
                    responseMessage{std::move(responseMessage)}]() mutable {
                     --clientActiveCalls_;
                     if (responseMessage.type() == MessageType::EXCEPTION) {

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -344,6 +344,7 @@ std::shared_ptr<FutureMessage> TensorPipeAgent::send(
                 // Flushing all future messages belonging to this pipe due to
                 // error state.
                 for (auto& p : clientPipe.pendingResponseMessage_) {
+                  --clientActiveCalls_;
                   std::shared_ptr<FutureMessage>& futureMessage = p.second;
                   futureMessage->setError(error.what());
                 }

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -186,6 +186,13 @@ class TensorPipeAgent : public RpcAgent {
   NetworkDataDict networkData_;
   // Mutex to guarg networkData_
   std::mutex networkDataMutex_;
+
+  // Running total of un-processed, un-errored RPC calls sent
+  std::atomic<int32_t> clientActiveCalls_{0};
+  // Running total of un-processed RPC requests received
+  std::atomic<int32_t> serverActiveCalls_{0};
+  // Running total of RPC requests that will be completed asynchronously
+  std::atomic<int32_t> serverActiveAsyncCalls_{0};
 };
 
 } // namespace rpc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38266 [Tensorpipe Agent] Add Call Counts to Metrics
* **#38265 [Tensorpipe Agent] Tracking Active Call Metrics**

Tracking the active calls counts in the TensorPipe Agent:
* clientActiveCalls: running count of un-responded/un-errored RPC's sent
* serverActiveCalls: running count of un-responded RPC's received
* serverAsyncCallCount: running count of received RPC's set to be completed asynchronously

This matches the metrics stored by the other 2 RPC Agents.

Differential Revision: [D21508957](https://our.internmc.facebook.com/intern/diff/D21508957/)