### PR TITLE
Fix precision issues in CPU remainder

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec256/vec256_bfloat16.h
@@ -252,6 +252,15 @@ public:
   Vec256<BFloat16> expm1() const {
     return map(Sleef_expm1f8_u10);
   }
+  Vec256<BFloat16> fmod(const Vec256<BFloat16> & q) const {
+    __m256 x_lo, x_hi;
+    cvtbf16_fp32(values, x_lo, x_hi);
+    __m256 q_lo, q_hi;
+    cvtbf16_fp32(q.values, q_lo, q_hi);
+    auto o1 = Sleef_fmodf8(x_lo, q_lo);
+    auto o2 = Sleef_fmodf8(x_hi, q_hi);
+    return cvtfp32_bf16(o1, o2);
+  }
   Vec256<BFloat16> log() const {
     return map(Sleef_logf8_u10);
   }

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -120,7 +120,6 @@ void remainder_kernel(TensorIterator& iter) {
           return mod;
         },
         [=](Vec256<scalar_t> a, Vec256<scalar_t> b) {
-          // TODO: Sleef 3.5 will have a Sleef_remainder{d4,f8}
           auto mod = a.fmod(b);
           const auto zero = Vec256<scalar_t>(0);
           auto mask = (mod != zero) & ((b < zero) ^ (mod < zero));

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -115,11 +115,16 @@ void remainder_kernel(TensorIterator& iter) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "remainder_cpu", [&]() {
       cpu_kernel_vec(iter,
         [=](scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
-          return a - b * at::native::floor_impl(a / b);
+          scalar_t mod = std::fmod(a, b);
+          if ((mod != 0) && ((b < 0) != (mod < 0))) mod += b;
+          return mod;
         },
         [=](Vec256<scalar_t> a, Vec256<scalar_t> b) {
-          Vec256<scalar_t> r = a - b * (a / b).floor();
-          return r;
+          // TODO: Sleef 3.5 will have a Sleef_remainder{d4,f8}
+          auto mod = a.fmod(b);
+          const auto zero = Vec256<scalar_t>(0);
+          auto mask = (mod != zero) & ((b < zero) ^ (mod < zero));
+          return Vec256<scalar_t>::blendv(mod, mod + b, mask);
         });
     });
   }

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -549,7 +549,7 @@ void fmod_kernel(TensorIterator& iter) {
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "fmod_cpu", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND(kHalf, iter.dtype(), "fmod_cpu", [&]() {
       cpu_kernel_vec(
         iter,
         [](scalar_t x, scalar_t d) -> scalar_t {
@@ -571,7 +571,7 @@ void fmod_scalar_kernel(TensorIterator& iter, Scalar divisor) {
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "fmod_scalar_cpu", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND(kHalf, iter.dtype(), "fmod_scalar_cpu", [&]() {
       const auto div = divisor.to<scalar_t>();
       const auto div_vec = Vec256<scalar_t>(div);
       cpu_kernel_vec(

--- a/benchmarks/operator_benchmark/pt/remainder_test.py
+++ b/benchmarks/operator_benchmark/pt/remainder_test.py
@@ -1,0 +1,62 @@
+import operator_benchmark as op_bench
+import torch
+
+
+"""Microbenchmarks for remainder operators."""
+
+
+# Benchmark ops performance with broadcast
+remainder_ops_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['fmod', torch.fmod],
+        ['remainder', torch.remainder],
+    ],
+)
+
+remainder_short_configs = op_bench.config_list(
+    attr_names=['M', 'N', 'K'],
+    attrs=[
+        [1, 1, 1],
+        [64, 64, 64],
+        [64, 64, 128],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dtype' : [torch.int32, torch.float, torch.double],
+    },
+    tags=['short'],
+)
+
+remainder_long_configs = op_bench.cross_product_configs(
+    M=[8, 128],
+    N=[32, 64],
+    K=[256, 512],
+    device=['cpu', 'cuda'],
+    dtype=[torch.int32, torch.float, torch.double],
+    tags=['long']
+)
+
+
+class RemainderOpBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, device, dtype, op_func):
+        self.dividend = torch.rand(M, N, K, device=device)
+        self.dividend = (self.dividend * 1000 - 500).to(dtype=dtype)
+
+        self.divisor = torch.rand(M, N, K, device=device)
+        # +1 so we don't divide by zero
+        self.divisor = (self.divisor * 40 + 1).to(dtype=dtype)
+
+        self.op_func = op_func
+
+    def forward(self):
+        return self.op_func(self.dividend, self.divisor)
+
+
+op_bench.generate_pt_tests_from_op_list(remainder_ops_list,
+                                        remainder_short_configs + remainder_long_configs,
+                                        RemainderOpBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15449,8 +15449,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
                 long_res1 = long_m1.clone()
                 long_res1.remainder_(long_qs.unsqueeze(0).expand_as(long_res1))
 
-    # remove onlyCUDA after CPU impl of remainder_kernel be fixed
-    @onlyCUDA
     @dtypes(torch.float, torch.double)
     def test_remainder_fmod_large_dividend(self, device, dtype):
         alarge = 1e9


### PR DESCRIPTION
Together with #37758, this fixes #37743 and fixes #24861.

This follows the CUDA fix in #37758, vectorised using a `blendv` to replace the if conditionals.

Most of the complication is from `remainder` supporting `at::Half` where `fmod` doesn't. I've now got `fmod` working on `Vec256<at::Half>` as well as enabling half dispatch for `fmod` so it matches `remainder`.

I also added `fmod` support to `Vec256<at::BFloat16>` before realising that `remainder` doesn't support `BFloat16` anyway. I could also enable `BFloat16` if that's desirable. If not, I don't think `Vec256<BFloat16>` should be missing `fmod` anyway.