### PR TITLE
Add skipIfNoSciPy/get_all_int_dtypes/get_all_fp_dtypes to common_utils

### DIFF
--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -88,23 +88,36 @@ def make_non_contiguous(tensor):
     return input.data
 
 
-def get_all_dtypes():
-    return [torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32, torch.int64,
-            torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.complex64, torch.complex128]
+def get_all_dtypes(include_half=True, include_bfloat16=True, include_bool=True, include_complex=True):
+    dtypes = get_all_int_dtypes() + get_all_fp_dtypes(include_half=include_half, include_bfloat16=include_bfloat16)
+    if include_bool:
+        dtypes.append(torch.bool)
+    if include_complex:
+        dtypes += get_all_complex_dtypes()
+    return dtypes
+
 
 def get_all_math_dtypes(device):
-    dtypes = [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
-              torch.float32, torch.float64, torch.complex64, torch.complex128]
+    return get_all_int_dtypes() + get_all_fp_dtypes(include_half=device.startswith('cuda'),
+                                                    include_bfloat16=False) + get_all_complex_dtypes()
 
-    # torch.float16 is a math dtype on cuda but not cpu.
-    if device.startswith('cuda'):
-        dtypes.append(torch.float16)
-
-    return dtypes
 
 def get_all_complex_dtypes():
-    dtypes = [torch.complex64, torch.complex128]
+    return [torch.complex64, torch.complex128]
+
+
+def get_all_int_dtypes():
+    return [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]
+
+
+def get_all_fp_dtypes(include_half=True, include_bfloat16=True):
+    dtypes = [torch.float32, torch.float64]
+    if include_half:
+        dtypes.append(torch.float16)
+    if include_bfloat16:
+        dtypes.append(torch.bfloat16)
     return dtypes
+
 
 def get_all_device_types():
     return ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -431,6 +431,16 @@ def skipIfNotRegistered(op_name, message):
     return skipper
 
 
+def skipIfNoSciPy(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not TEST_SCIPY:
+            raise unittest.SkipTest("test require SciPy, but SciPy not found")
+        else:
+            fn(*args, **kwargs)
+    return wrapper
+
+
 def slowTest(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36633 CSPRNG PoC
* #37984 RNG infrastructure improvements
* #38301 Renamed *_transformation to transformation::*
* **#38299 Add skipIfNoSciPy/get_all_int_dtypes/get_all_fp_dtypes to common_utils**
* #38298 Fixing DistributionsHelper.h includes
* #38287 Forgotten changes for Tensor.random_()'s from and to bounds for floating-point types

Differential Revision: [D21534876](https://our.internmc.facebook.com/intern/diff/D21534876)