### PR TITLE
Renamed *_transformation to transformation::*

### DIFF
--- a/aten/src/ATen/core/DistributionsHelper.h
+++ b/aten/src/ATen/core/DistributionsHelper.h
@@ -57,9 +57,9 @@ struct uniform_int_from_to_distribution {
       std::is_same<T, float>::value ||
       std::is_same<T, at::BFloat16>::value) && range_ >= 1ULL << 32)
     {
-      return uniform_int_from_to_transformation<T>(generator->random64(), range_, base_);
+      return transformation::uniform_int_from_to<T>(generator->random64(), range_, base_);
     } else {
-      return uniform_int_from_to_transformation<T>(generator->random(), range_, base_);
+      return transformation::uniform_int_from_to<T>(generator->random(), range_, base_);
     }
   }
 
@@ -76,7 +76,7 @@ struct uniform_int_full_range_distribution {
 
   template <typename RNG>
   C10_HOST_DEVICE inline T operator()(RNG generator) {
-    return uniform_int_full_range_transformation<T>(generator->random64());
+    return transformation::uniform_int_full_range<T>(generator->random64());
   }
 
 };
@@ -91,9 +91,9 @@ struct uniform_int_distribution {
   template <typename RNG>
   C10_HOST_DEVICE inline T operator()(RNG generator) {
     if (std::is_same<T, double>::value || std::is_same<T, int64_t>::value) {
-      return uniform_int_transformation<T>(generator->random64());
+      return transformation::uniform_int<T>(generator->random64());
     } else {
-      return uniform_int_transformation<T>(generator->random());
+      return transformation::uniform_int<T>(generator->random());
     }
   }
 
@@ -115,9 +115,9 @@ struct uniform_real_distribution {
   template <typename RNG>
   C10_HOST_DEVICE inline dist_acctype<T> operator()(RNG generator){
     if(std::is_same<T, double>::value) {
-      return uniform_real_transformation<T>(generator->random64(), from_, to_);
+      return transformation::uniform_real<T>(generator->random64(), from_, to_);
     } else {
-      return uniform_real_transformation<T>(generator->random(), from_, to_);
+      return transformation::uniform_real<T>(generator->random(), from_, to_);
     }
   }
 

--- a/aten/src/ATen/core/TransformationHelper.h
+++ b/aten/src/ATen/core/TransformationHelper.h
@@ -25,13 +25,15 @@ template <> struct DistAccumType<double> { using type = double; };
 template <typename T>
 using dist_acctype = typename DistAccumType<T>::type;
 
+namespace transformation {
+
 /**
  * A transformation function for `torch.Tensor.random_()`, when both `from` and `to` are specified.
  * `range` is `to - from`
  * `base` is `from`
  */
 template <typename T, typename V>
-C10_HOST_DEVICE inline T uniform_int_from_to_transformation(V val, uint64_t range, int64_t base) {
+C10_HOST_DEVICE inline T uniform_int_from_to(V val, uint64_t range, int64_t base) {
   return static_cast<T>(static_cast<int64_t>((val % range) + base));
 }
 
@@ -39,7 +41,7 @@ C10_HOST_DEVICE inline T uniform_int_from_to_transformation(V val, uint64_t rang
  * A transformation function for `torch.Tensor.random_()`, when `from=min_value(int64_t)` and to=None
  */
 template <typename T, typename V>
-C10_HOST_DEVICE inline T uniform_int_full_range_transformation(V val) {
+C10_HOST_DEVICE inline T uniform_int_full_range(V val) {
   return static_cast<T>(static_cast<int64_t>(val));
 }
 
@@ -47,7 +49,7 @@ C10_HOST_DEVICE inline T uniform_int_full_range_transformation(V val) {
  * A transformation function for `torch.Tensor.random_()`, when used without specifying `from` and `to`.
  */
 template <typename T, typename V>
-C10_HOST_DEVICE inline T uniform_int_transformation(V val) {
+C10_HOST_DEVICE inline T uniform_int(V val) {
   if (std::is_same<T, bool>::value) {
     return static_cast<bool>(val & 1);
   } else if (std::is_same<T, double>::value) {
@@ -65,11 +67,11 @@ C10_HOST_DEVICE inline T uniform_int_transformation(V val) {
 }
 
 template <typename T, typename V>
-C10_HOST_DEVICE inline dist_acctype<T> uniform_real_transformation(V val, T from, T to) {
+C10_HOST_DEVICE inline dist_acctype<T> uniform_real(V val, T from, T to) {
   constexpr auto MASK = static_cast<V>((static_cast<uint64_t>(1) << std::numeric_limits<T>::digits) - 1);
   constexpr auto DIVISOR = static_cast<dist_acctype<T>>(1) / (static_cast<uint64_t>(1) << std::numeric_limits<T>::digits);
   dist_acctype<T> x = (val & MASK) * DIVISOR;
   return (x * (to - from) + from);
 }
 
-} // namespace at
+}} // namespace at::transformation

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -287,7 +287,7 @@ void random_from_to_kernel(TensorIterator& iter, uint64_t range, int64_t base, R
     {
       // define lambda to mod with range and add base
       auto random_func = [range, base] __device__ (uint64_t rand) {
-        return uniform_int_from_to_transformation<scalar_t>(rand, range, base);
+        return transformation::uniform_int_from_to<scalar_t>(rand, range, base);
       };
       distribution_nullary_kernel<scalar_t, uint64_t, curand4_engine_calls/2>(iter,
         gen,
@@ -301,7 +301,7 @@ void random_from_to_kernel(TensorIterator& iter, uint64_t range, int64_t base, R
         random_func);
     } else {
       auto random_func = [range, base] __device__ (uint32_t rand) {
-        return uniform_int_from_to_transformation<scalar_t>(rand, range, base);
+        return transformation::uniform_int_from_to<scalar_t>(rand, range, base);
       };
       distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
         gen,
@@ -330,7 +330,7 @@ void random_full_64_bits_range_kernel(TensorIterator& iter, RNG gen) {
         std::is_same<scalar_t, float>::value ||
         std::is_same<scalar_t, at::BFloat16>::value) {
       auto random_func = [] __device__ (uint64_t rand) {
-        return uniform_int_full_range_transformation<scalar_t>(rand);
+        return transformation::uniform_int_full_range<scalar_t>(rand);
       };
       distribution_nullary_kernel<scalar_t, uint64_t, curand4_engine_calls/2>(iter,
         gen,
@@ -369,7 +369,7 @@ void random_kernel(TensorIterator& iter, RNG gen) {
   AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::BFloat16, at::ScalarType::Bool, iter.dtype(), "random_kernel_cuda", [&] {
     if (std::is_same<scalar_t, double>::value || std::is_same<scalar_t, int64_t>::value) {
       auto random_func = [] __device__ (uint64_t rand) {
-        return uniform_int_transformation<scalar_t>(rand);
+        return transformation::uniform_int<scalar_t>(rand);
       };
       distribution_nullary_kernel<scalar_t, uint64_t, curand4_engine_calls/2>(iter, gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
@@ -382,7 +382,7 @@ void random_kernel(TensorIterator& iter, RNG gen) {
         random_func);
     } else {
       auto random_func = [] __device__ (uint32_t rand) {
-        return uniform_int_transformation<scalar_t>(rand);
+        return transformation::uniform_int<scalar_t>(rand);
       };
       distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
         gen,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36633 CSPRNG PoC
* #37984 RNG infrastructure improvements
* **#38301 Renamed *_transformation to transformation::***
* #38299 Add skipIfNoSciPy/get_all_int_dtypes/get_all_fp_dtypes to common_utils
* #38298 Fixing DistributionsHelper.h includes
* #38287 Forgotten changes for Tensor.random_()'s from and to bounds for floating-point types

Differential Revision: [D21534886](https://our.internmc.facebook.com/intern/diff/D21534886)