### PR TITLE
Using LoadLibraryEX [Reland]

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -64,22 +64,46 @@ if platform.system() == 'Windows':
     else:
         cuda_path = ''
 
-    if sys.version_info >= (3, 8):
-        dll_paths = list(filter(os.path.exists, [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]))
+    kernel32 = ctypes.WinDLL('kernel32.dll', use_last_error=True)
+    dll_paths = list(filter(os.path.exists, [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]))
+    with_load_library_flags = hasattr(kernel32, 'AddDllDirectory')
+    prev_error_mode = kernel32.SetErrorMode(0x0001)
 
-        for dll_path in dll_paths:
+    for dll_path in dll_paths:
+        if sys.version_info >= (3, 8):
             os.add_dll_directory(dll_path)
-
-    if is_conda or sys.version_info < (3, 8):
-        dll_paths = [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]
-        dll_paths = list(filter(os.path.exists, dll_paths)) + [os.environ['PATH']]
-
-        os.environ['PATH'] = ';'.join(dll_paths)
+        elif with_load_library_flags:
+            res = kernel32.AddDllDirectory(dll_path)
+            if res == 0:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += ' Error adding "{}" to the DLL directories.'.format(dll_path)
+                raise err
 
     import glob
     dlls = glob.glob(os.path.join(th_dll_path, '*.dll'))
+    path_patched = False
     for dll in dlls:
-        ctypes.CDLL(dll)
+        is_loaded = False
+        if with_load_library_flags:
+            res = kernel32.LoadLibraryExW(dll, 0, 0x00001100)
+            last_error = ctypes.get_last_error()
+            if res == 0 and last_error != 126:
+                err = ctypes.WinError(last_error)
+                err.strerror += ' Error loading "{}" or one of its dependencies.'.format(dll)
+                raise err
+            elif res != 0:
+                is_loaded = True
+        if not is_loaded:
+            if not path_patched:
+                os.environ['PATH'] = ';'.join(dll_paths + [os.environ['PATH']])
+                path_patched = True
+            res = kernel32.LoadLibraryW(dll)
+            if res == 0:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += ' Error loading "{}" or one of its dependencies.'.format(dll)
+                raise err
+
+    kernel32.SetErrorMode(prev_error_mode)
 
 
 # See Note [Global dependencies]

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -42,7 +42,6 @@ __all__ = [
 ################################################################################
 
 if platform.system() == 'Windows':
-    is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
     py_dll_path = os.path.join(sys.exec_prefix, 'Library', 'bin')
     th_dll_path = os.path.join(os.path.dirname(__file__), 'lib')
 
@@ -75,7 +74,7 @@ if platform.system() == 'Windows':
         elif with_load_library_flags:
             res = kernel32.AddDllDirectory(dll_path)
             if res == 0:
-                err = ctypes.WinError(ctypes.get_last_error())
+                err = ctypes.WinError(ctypes.get_last_error())  # type: ignore
                 err.strerror += ' Error adding "{}" to the DLL directories.'.format(dll_path)
                 raise err
 
@@ -86,9 +85,9 @@ if platform.system() == 'Windows':
         is_loaded = False
         if with_load_library_flags:
             res = kernel32.LoadLibraryExW(dll, 0, 0x00001100)
-            last_error = ctypes.get_last_error()
+            last_error = ctypes.get_last_error()  # type: ignore
             if res == 0 and last_error != 126:
-                err = ctypes.WinError(last_error)
+                err = ctypes.WinError(last_error)  # type: ignore
                 err.strerror += ' Error loading "{}" or one of its dependencies.'.format(dll)
                 raise err
             elif res != 0:
@@ -99,7 +98,7 @@ if platform.system() == 'Windows':
                 path_patched = True
             res = kernel32.LoadLibraryW(dll)
             if res == 0:
-                err = ctypes.WinError(ctypes.get_last_error())
+                err = ctypes.WinError(ctypes.get_last_error())  # type: ignore
                 err.strerror += ' Error loading "{}" or one of its dependencies.'.format(dll)
                 raise err
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -63,7 +63,7 @@ if platform.system() == 'Windows':
     else:
         cuda_path = ''
 
-    kernel32 = ctypes.WinDLL('kernel32.dll', use_last_error=True)
+    kernel32 = ctypes.WinDLL('kernel32.dll', use_last_error=True)  # type: ignore
     dll_paths = list(filter(os.path.exists, [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]))
     with_load_library_flags = hasattr(kernel32, 'AddDllDirectory')
     prev_error_mode = kernel32.SetErrorMode(0x0001)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -41,7 +41,7 @@ __all__ = [
 # Load the extension module
 ################################################################################
 
-if platform.system() == 'Windows':
+if sys.platform == 'win32':
     py_dll_path = os.path.join(sys.exec_prefix, 'Library', 'bin')
     th_dll_path = os.path.join(os.path.dirname(__file__), 'lib')
 
@@ -63,7 +63,7 @@ if platform.system() == 'Windows':
     else:
         cuda_path = ''
 
-    kernel32 = ctypes.WinDLL('kernel32.dll', use_last_error=True)  # type: ignore
+    kernel32 = ctypes.WinDLL('kernel32.dll', use_last_error=True)
     dll_paths = list(filter(os.path.exists, [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]))
     with_load_library_flags = hasattr(kernel32, 'AddDllDirectory')
     prev_error_mode = kernel32.SetErrorMode(0x0001)
@@ -74,7 +74,7 @@ if platform.system() == 'Windows':
         elif with_load_library_flags:
             res = kernel32.AddDllDirectory(dll_path)
             if res == 0:
-                err = ctypes.WinError(ctypes.get_last_error())  # type: ignore
+                err = ctypes.WinError(ctypes.get_last_error())
                 err.strerror += ' Error adding "{}" to the DLL directories.'.format(dll_path)
                 raise err
 
@@ -85,9 +85,9 @@ if platform.system() == 'Windows':
         is_loaded = False
         if with_load_library_flags:
             res = kernel32.LoadLibraryExW(dll, 0, 0x00001100)
-            last_error = ctypes.get_last_error()  # type: ignore
+            last_error = ctypes.get_last_error()
             if res == 0 and last_error != 126:
-                err = ctypes.WinError(last_error)  # type: ignore
+                err = ctypes.WinError(last_error)
                 err.strerror += ' Error loading "{}" or one of its dependencies.'.format(dll)
                 raise err
             elif res != 0:
@@ -98,7 +98,7 @@ if platform.system() == 'Windows':
                 path_patched = True
             res = kernel32.LoadLibraryW(dll)
             if res == 0:
-                err = ctypes.WinError(ctypes.get_last_error())  # type: ignore
+                err = ctypes.WinError(ctypes.get_last_error())
                 err.strerror += ' Error loading "{}" or one of its dependencies.'.format(dll)
                 raise err
 


### PR DESCRIPTION
This reverts commit 1ab4f35499aa933677152aca6a1ba2cbe86639f8.

Without this PR, the OS try to find the DLL in the following directories.
- The directory from which the application loaded.
- The system directory. Use the GetSystemDirectory function to get the path of this directory.
- The 16-bit system directory. There is no function that obtains the path of this directory, but it is searched.
- The Windows directory. Use the GetWindowsDirectory function to get the path of this directory.
- The current directory.
- The directories that are listed in the PATH environment variable. Note that this does not include the per-application path specified by the App Paths registry key. The App Paths key is not used when computing the DLL search path.

If we use  LoadLibraryEx with LOAD_LIBRARY_SEARCH_* flags, the directories are searched in the following order.

- The directory that contains the DLL (LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR). This directory is searched only for dependencies of the DLL to be loaded.
- The application directory (LOAD_LIBRARY_SEARCH_APPLICATION_DIR).
- Paths explicitly added to the application search path with the AddDllDirectory function (LOAD_LIBRARY_SEARCH_USER_DIRS) or the SetDllDirectory function. If more than one path has been added, the order in which the paths are searched is unspecified.
- The System32 directory (LOAD_LIBRARY_SEARCH_SYSTEM32).

Advantages:
1. The directory that contains the DLL comes first and it's desirable for us, because the dependencies in `lib` should always be preferred.
2. The system directory is considered in the last place. According to some of the bug reports, the DLL load failure are caused by loading the conflicting ones in systemroot.

Neural:
1. The directories in `PATH` are not considered. Similar things happen as described in the previous point. So it may be beneficial for normal users. However, it may cause failures if there are some new dependencies if built from source. (Resolved by making the fallback to `LoadLibraryW` if error code is `126`)

Disadvantages:
1. LoadLibraryEx with LOAD_LIBRARY_SEARCH_* flags is only available for Win7/2008 R2 + KB2533623 and up. (Resolved by making the fallback to `LoadLibraryW` if it is not supported)
2. Failure during the call of `LoadLibraryEx` will lead to the OS to pop up a modal dialog, which can block the process if user is using a CLI-only interface. This can be switched off by calling `SetErrorMode`. (Resolved by calling `SetErrorMode`)

Test plan:
Test some common cases (in a new repo maybe) including
1. Python 3.6/3.7/3.8, conda python, conda install
2. Python 3.6/3.7/3.8, conda python, pip install
3. Python 3.6/3.7/3.8, official python, pip install
Plus some corner cases like
1. Conflicting DLLs in systemroot or `PATH`
2. Remove some local dependencies and use global ones

References:
1. https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-seterrormode
2. https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa
3. https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-desktop-applications
