### PR TITLE
[ONNX] Add GreaterOrEqual and LessOrEqual to opset 12 ONNX export

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -208,7 +208,9 @@ namespace c10 {
   _(onnx, Expand)                    \
   _(onnx, Equal)                     \
   _(onnx, Greater)                   \
+  _(onnx, GreaterOrEqual)            \
   _(onnx, Less)                      \
+  _(onnx, LessOrEqual)               \
   _(onnx, Not)                       \
   _(onnx, ATen)                      \
   _(onnx, Split)                     \

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1956,42 +1956,70 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(5, 6)
         self.run_test(DimArange(), x)
 
+    def _test_compare_ops(self, model, num_inputs):
+        x = torch.randn(1, 2, 3, 4, requires_grad=True)
+        if num_inputs > 1:
+            y = torch.randn(1, 2, 3, 4, requires_grad=True)
+            x = (x, y)
+        self.run_test(model, x)
+
+        x = torch.randint(10, (3, 4), dtype=torch.int32)
+        if num_inputs > 1:
+            y = torch.randint(10, (3, 4), dtype=torch.int32)
+            x = (x, y)
+        self.run_test(model, x)
+
     def test_gt(self):
         class GreaterModel(torch.nn.Module):
             def forward(self, input, other):
                 return input > other
+        self._test_compare_ops(GreaterModel(), 2)
 
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        y = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.run_test(GreaterModel(), (x, y))
-
-        x = torch.randint(10, (3, 4), dtype=torch.int32)
-        y = torch.randint(10, (3, 4), dtype=torch.int32)
-        self.run_test(GreaterModel(), (x, y))
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_ge(self):
+        class GreaterOrEqualModel(torch.nn.Module):
+            def forward(self, input, other):
+                return input >= other
+        self._test_compare_ops(GreaterOrEqualModel(), 2)
 
     def test_gt_scalar(self):
         class GreaterModel(torch.nn.Module):
             def forward(self, input):
                 return input > 1
+        self._test_compare_ops(GreaterModel(), 1)
 
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.run_test(GreaterModel(), x)
-
-        x = torch.randint(10, (3, 4), dtype=torch.int32)
-        self.run_test(GreaterModel(), x)
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_ge_scalar(self):
+        class GreaterOrEqualModel(torch.nn.Module):
+            def forward(self, input):
+                return input >= 1
+        self._test_compare_ops(GreaterOrEqualModel(), 1)
 
     def test_lt(self):
         class LessModel(torch.nn.Module):
             def forward(self, input, other):
                 return input > other
+        self._test_compare_ops(LessModel(), 2)
 
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        y = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.run_test(LessModel(), (x, y))
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_le(self):
+        class LessOrEqualModel(torch.nn.Module):
+            def forward(self, input, other):
+                return input <= other
+        self._test_compare_ops(LessOrEqualModel(), 2)
 
-        x = torch.randint(10, (3, 4), dtype=torch.int32)
-        y = torch.randint(10, (3, 4), dtype=torch.int32)
-        self.run_test(LessModel(), (x, y))
+    def test_lt_scalar(self):
+        class LessModel(torch.nn.Module):
+            def forward(self, input):
+                return input < 1
+        self._test_compare_ops(LessModel(), 1)
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_le_scalar(self):
+        class LessOrEqualModel(torch.nn.Module):
+            def forward(self, input):
+                return input <= 1
+        self._test_compare_ops(LessOrEqualModel(), 1)
 
     def test_matmul(self):
         class MatmulModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1957,17 +1957,18 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(DimArange(), x)
 
     def _test_compare_ops(self, model, num_inputs):
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
+        x_float = torch.randn(1, 2, 3, 4, requires_grad=True)
+        x_int = torch.randint(10, (3, 4), dtype=torch.int32)
         if num_inputs > 1:
-            y = torch.randn(1, 2, 3, 4, requires_grad=True)
-            x = (x, y)
-        self.run_test(model, x)
-
-        x = torch.randint(10, (3, 4), dtype=torch.int32)
-        if num_inputs > 1:
-            y = torch.randint(10, (3, 4), dtype=torch.int32)
-            x = (x, y)
-        self.run_test(model, x)
+            y_float = torch.randn(1, 2, 3, 4, requires_grad=True)
+            y_int = torch.randint(10, (3, 4), dtype=torch.int32)
+            self.run_test(model, (x_float, y_float))
+            self.run_test(model, (x_float, y_int))
+            self.run_test(model, (x_int, y_float))
+            self.run_test(model, (x_int, y_int))
+        else:
+            self.run_test(model, x_float)
+            self.run_test(model, x_int)
 
     def test_gt(self):
         class GreaterModel(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -60,8 +60,7 @@ static const std::unordered_set<NodeKind> comparisonOps = {onnx::Greater,
                                                            onnx::Less,
                                                            onnx::Equal,
                                                            onnx::GreaterOrEqual,
-                                                           onnx::LessOrEqual
-                                                           };
+                                                           onnx::LessOrEqual};
 
 static bool IsComparisonOp(const NodeKind& nkind) {
   return comparisonOps.find(nkind) != comparisonOps.end();

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -56,11 +56,12 @@ static bool IsStandardOp(const NodeKind& nkind) {
 
 // For these operators, all inputs share the same scalar type.
 // The output scalar type is always Bool.
-static const std::unordered_set<NodeKind> comparisonOps = {
-    onnx::Greater,
-    onnx::Less,
-    onnx::Equal,
-};
+static const std::unordered_set<NodeKind> comparisonOps = {onnx::Greater,
+                                                           onnx::Less,
+                                                           onnx::Equal,
+                                                           onnx::GreaterOrEqual,
+                                                           onnx::LessOrEqual
+                                                           };
 
 static bool IsComparisonOp(const NodeKind& nkind) {
   return comparisonOps.find(nkind) != comparisonOps.end();

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -62,3 +62,9 @@ def nll_loss2d(g, self, target, weight, reduction, ignore_index):
 
 def pow(g, self, exponent):
     return g.op("Pow", self, exponent)
+
+def ge(g, input, other):
+    return g.op('GreaterOrEqual', input, other)
+
+def le(g, input, other):
+    return g.op('LessOrEqual', input, other)


### PR DESCRIPTION
GreaterOrEqual and LessOrEqual were added in opset 12, this PR adds support to export these operators to ONNX instead of using "not" and "less than" or "greater than".