### PR TITLE
Fix autograd profiler memory leak for not releasing cudaEvent_t memory

### DIFF
--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -417,6 +417,12 @@ void Event::record(bool record_cuda) {
   cpu_ns_ = getTime();
 }
 
+void Event::destroy(bool record_cuda) {
+  if (record_cuda) {
+    cuda_stubs->destroy(&cuda_event);
+  }
+}
+
 double Event::cuda_elapsed_us(const Event & e) {
   TORCH_CHECK(e.has_cuda() && has_cuda(), "Events were not recorded for CUDA");
   TORCH_CHECK(e.device() == device(), "Events are not on the same device");

--- a/torch/csrc/autograd/profiler_cuda.cpp
+++ b/torch/csrc/autograd/profiler_cuda.cpp
@@ -39,6 +39,9 @@ struct CUDAMethods : public CUDAStubs {
     *cpu_ns = getTime();
     TORCH_CUDA_CHECK(cudaEventRecord(*event, stream));
   }
+  void destroy(CUDAEventStub* event) override {
+    TORCH_CUDA_CHECK(cudaEventDestroy(*event));
+  }
   float elapsed(CUDAEventStub event, CUDAEventStub event2) override {
     TORCH_CUDA_CHECK(cudaEventSynchronize(event));
     TORCH_CUDA_CHECK(cudaEventSynchronize(event2));


### PR DESCRIPTION
Fix #38183
Probably fix #37313
May be related to #35391

Before this PR, the `cudaEvent_t Event::event` was never released with `cudaEventDestroy()` in `autograd.profiler` with `use_cuda=True`. This will cause memory issue while doing autograd profilings inside a loop. 

However, the `struct Event` can be copy-initialized, so we cannot just simply destruct cuda event with a simple destructor. I added reference counter to solve this problem, and it worked well for my issue in #38183. I saw #37313 also has autograd profiler inside a large for loop, so it should be fixed as well. 

Not quite sure how to add tests for this. The existed tests in test_autograd should be good enough?

cc @ptrblck 