### PR TITLE
handle grad with `stride=0` on GPU MvBackward

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cu
+++ b/aten/src/ATen/native/cuda/Blas.cu
@@ -6,26 +6,27 @@ namespace at { namespace native {
 
 Tensor &addmv_impl_cuda(Tensor& result, const Tensor &self, const Tensor &mat, const Tensor &vec, Scalar beta_, Scalar alpha_) {
   auto r_stride = result.stride(0);
-  auto vec_stride = vec.stride(0);
+  const auto vec_contiguous = vec.contiguous();
+  auto vec_stride = vec_contiguous.stride(0);
 
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, mat.scalar_type(), "addmv_impl_cuda", [&] {
     auto beta = beta_.to<scalar_t>();
     auto alpha = alpha_.to<scalar_t>();
     if (mat.stride(0) == 1) {
       at::cuda::blas::gemv<scalar_t>('n',
-        mat.size(0), mat.size(1), alpha, mat.data_ptr<scalar_t>(), mat.stride(1), vec.data_ptr<scalar_t>(),
+        mat.size(0), mat.size(1), alpha, mat.data_ptr<scalar_t>(), mat.stride(1), vec_contiguous.data_ptr<scalar_t>(),
         vec_stride, beta, result.data_ptr<scalar_t>(), r_stride);
     }
     else if (mat.stride(1) == 1) {
       at::cuda::blas::gemv<scalar_t>('t',
         mat.size(1), mat.size(0), alpha, mat.data_ptr<scalar_t>(), mat.stride(0),
-        vec.data_ptr<scalar_t>(), vec_stride, beta, result.data_ptr<scalar_t>(), r_stride);
+        vec_contiguous.data_ptr<scalar_t>(), vec_stride, beta, result.data_ptr<scalar_t>(), r_stride);
     }
     else {
       Tensor cmat = mat.contiguous();
       at::cuda::blas::gemv<scalar_t>('t',
           mat.size(1), mat.size(0), alpha, cmat.data_ptr<scalar_t>(), cmat.stride(0),
-          vec.data_ptr<scalar_t>(), vec.stride(0), beta, result.data_ptr<scalar_t>(), r_stride);
+          vec_contiguous.data_ptr<scalar_t>(), vec.stride(0), beta, result.data_ptr<scalar_t>(), r_stride);
     }
 
     // In cublasSgemv, cublasDgemv (x,0).mv(0) does not

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6152,6 +6152,7 @@ class TestAutogradDeviceType(TestCase):
         x.sum().backward()
         self.assertEqual(root.grad.tolist(), [[1, 2], [1, 1], [1, 1]])
 
+    @unittest.skip("Wrong Gradient: https://github.com/pytorch/pytorch/issues/38586")
     def test_mv_grad_stride_0(self, device):
         # Reference: https://github.com/pytorch/pytorch/issues/38315
         mat = torch.randn(2, 2, device=device)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6152,6 +6152,18 @@ class TestAutogradDeviceType(TestCase):
         x.sum().backward()
         self.assertEqual(root.grad.tolist(), [[1, 2], [1, 1], [1, 1]])
 
+    def test_mv_grad_stride_0(self, device):
+        # Reference: https://github.com/pytorch/pytorch/issues/38315
+        mat = torch.randn(2, 2, device=device)
+        vec = torch.randn(2, device=device).requires_grad_(True)
+
+        def fn(vec):
+            return (mat @ vec).sum()
+
+        gradcheck(fn, (vec))
+        gradgradcheck(fn, (vec))
+
+
 class TestMultithreadAutograd(TestCase):
     def _run_py_multithread_fn(self, fn, args=(), num_threads=10, kwargs=None):
         threads = []

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6155,7 +6155,7 @@ class TestAutogradDeviceType(TestCase):
     def test_mv_grad_stride_0(self, device):
         # Reference: https://github.com/pytorch/pytorch/issues/38315
         mat = torch.randn(2, 2, device=device)
-        vec = torch.randn(2, device=device).requires_grad_(True)
+        vec = torch.randn(1, device=device).expand(2).requires_grad_(True)
 
         def fn(vec):
             return (mat @ vec).sum()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13012,7 +13012,6 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(torch.full((2, 3), beta * value, dtype=dtype, device=device),
                          torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out))
 
-    @onlyCPU  # not supported by CUBLAS
     def test_blas_nan_out(self, device):
         # These functions should work correctly with NaN filled outputs,
         # but need special handling, see [NOTE: cpu_zero]

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16618,6 +16618,15 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
                 if lazy_init_scale:
                     self.assertEqual(b.scale(torch.tensor([4.0], dtype=torch.float32, device=device)), 12.0)
 
+    @onlyCUDA
+    def test_mv_stride_0(self, device):
+        # Reference: https://github.com/pytorch/pytorch/issues/38315
+        mat = torch.randn(2, 2, device=device)
+        vec = torch.tensor(2., device=device).expand(2)
+        mat_cpu = mat.cpu()
+        vec_cpu = vec.cpu()
+        self.assertEqual(mat @ vec, mat_cpu @ vec_cpu)
+
 
 # NOTE [Linspace+Logspace precision override]
 # Our Linspace and logspace torch.half CUDA kernels are not very precise.

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -623,7 +623,7 @@
 
 - name: mv(Tensor self, Tensor vec) -> Tensor
   self: grad.ger(vec)
-  vec: "self.t().mv(grad.device().is_cpu() ? grad : grad.clone())"
+  vec: "self.t().mv(grad.device().is_cpu() ? grad : grad.contiguous())"
 
 - name: mvlgamma(Tensor self, int p) -> Tensor
   self: mvlgamma_backward(grad, self, p)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -623,7 +623,7 @@
 
 - name: mv(Tensor self, Tensor vec) -> Tensor
   self: grad.ger(vec)
-  vec: "self.t().mv(grad.device().is_cpu() ? grad : grad.contiguous())"
+  vec: self.t().mv(grad)
 
 - name: mvlgamma(Tensor self, int p) -> Tensor
   self: mvlgamma_backward(grad, self, p)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -623,7 +623,7 @@
 
 - name: mv(Tensor self, Tensor vec) -> Tensor
   self: grad.ger(vec)
-  vec: self.t().mv(grad)
+  vec: "self.t().mv(grad.device().is_cpu() ? grad : grad.clone())"
 
 - name: mvlgamma(Tensor self, int p) -> Tensor
   self: mvlgamma_backward(grad, self, p)


### PR DESCRIPTION
References : #38315 ,  #29984

cuBlas expects strides to be greater than 0.
Cloning the `grad` allocates a new vector with
non-zero strides.

For CPU, we don't clone and allocate a new vector
as CPU implementation works with stride=0.

