### PR TITLE
Minor code cleanup

### DIFF
--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -42,8 +42,7 @@ py::object toPyObj(const Message& message) {
       // TODO: Try to avoid a copy here.
       auto& resp = static_cast<PythonResp&>(*response);
       auto& pythonRpcHandler = PythonRpcHandler::getInstance();
-      py::object ret = pythonRpcHandler.deserialize(resp.serializedPyObj());
-      return ret;
+      return pythonRpcHandler.deserialize(resp.serializedPyObj());
     }
     default: {
       TORCH_CHECK(false, "Unrecognized response message type ", msgType);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38376 Use GIL to guard decref of jit::toPyObj return value in processRpc
* #38348 Use GIL to guard py::object's destruction
* #38366 Explicitly decref py::object in PythonRpcHandler
* #38364 Explicitly decref py::object in ConcretePyObjectHolder and PythonFunctionGuard
* **#38340 Minor code cleanup**



Differential Revision: [D21530281](https://our.internmc.facebook.com/intern/diff/D21530281)