### PR TITLE
Fix typo in build environment name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,7 @@ jobs:
             if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-bionic-py3.6-clang9-test" ]; then
               return 0
             fi
-            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-xenial-py3.6-gcc-5.4-test" ]; then
+            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-xenial-py3.6-gcc5.4-test" ]; then
               return 0
             fi
             return 1

--- a/.circleci/verbatim-sources/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/pytorch-job-specs.yml
@@ -114,7 +114,7 @@ jobs:
             if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-bionic-py3.6-clang9-test" ]; then
               return 0
             fi
-            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-xenial-py3.6-gcc-5.4-test" ]; then
+            if [ "${BUILD_ENVIRONMENT}" == "pytorch-linux-xenial-py3.6-gcc5.4-test" ]; then
               return 0
             fi
             return 1


### PR DESCRIPTION
Test Plan: `grep pytorch-linux-xenial-py3.6-gcc5.4-test .circleci -R` + CI

