### PR TITLE
[ONNX] GatherND Support for Opset 11

### DIFF
--- a/test/onnx/expect/TestOperators.test_index_opset11.expect
+++ b/test/onnx/expect/TestOperators.test_index_opset11.expect
@@ -1,0 +1,205 @@
+ir_version: 6
+producer_name: "pytorch"
+producer_version: "1.6"
+graph {
+  node {
+    input: "0"
+    output: "1"
+    name: "Shape_0"
+    op_type: "Shape"
+  }
+  node {
+    output: "2"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\001\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "1"
+    input: "2"
+    output: "3"
+    name: "Gather_2"
+    op_type: "Gather"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    output: "4"
+    name: "Constant_3"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\002\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "1"
+    input: "4"
+    output: "5"
+    name: "Gather_4"
+    op_type: "Gather"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "0"
+    output: "6"
+    name: "Transpose_5"
+    op_type: "Transpose"
+    attribute {
+      name: "perm"
+      ints: 0
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+  }
+  node {
+    input: "6"
+    output: "7"
+    name: "Flatten_6"
+    op_type: "Flatten"
+    attribute {
+      name: "axis"
+      i: 2
+      type: INT
+    }
+  }
+  node {
+    output: "8"
+    name: "Constant_7"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "8"
+    input: "5"
+    output: "9"
+    name: "Mul_8"
+    op_type: "Mul"
+  }
+  node {
+    output: "10"
+    name: "Constant_9"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 3
+        data_type: 7
+        raw_data: "\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "10"
+    input: "9"
+    output: "11"
+    name: "Add_10"
+    op_type: "Add"
+  }
+  node {
+    input: "7"
+    input: "11"
+    output: "12"
+    name: "Gather_11"
+    op_type: "Gather"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "11"
+    output: "13"
+    name: "Shape_12"
+    op_type: "Shape"
+  }
+  node {
+    input: "13"
+    input: "3"
+    output: "14"
+    name: "Concat_13"
+    op_type: "Concat"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "12"
+    input: "14"
+    output: "15"
+    name: "Reshape_14"
+    op_type: "Reshape"
+  }
+  name: "torch-jit-export"
+  input {
+    name: "0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "15"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -135,7 +135,7 @@ class TestOperators(TestCase):
 
     def test_index_opset11(self):
         x = torch.randn(3, 3, 3, requires_grad=True)
-        self.assertONNX(lambda x: x[[0],:, [1, 0, 0]], x)
+        self.assertONNX(lambda x: x[[0], :, [1, 0, 0]], x)
 
     def test_type_as(self):
         x = torch.tensor([0.0], requires_grad=True)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -685,9 +685,9 @@ class TestOperators(TestCase):
         x = torch.randn(3, 4, requires_grad=True)
         self.assertONNX(lambda x: torch.max(functional.dropout(x)), x, training=torch.onnx.TrainingMode.TRAINING)
 
-    #def test_dropout_training_opset12(self):
-    #    x = torch.randn(3, 4, requires_grad=True)
-    #    self.assertONNX(lambda x: torch.max(functional.dropout(x)), x, opset_version=12, training=torch.onnx.TrainingMode.TRAINING)
+    def test_dropout_training_opset12(self):
+        x = torch.randn(3, 4, requires_grad=True)
+        self.assertONNX(lambda x: torch.max(functional.dropout(x)), x, opset_version=12, training=torch.onnx.TrainingMode.TRAINING)
 
     def test_nonzero(self):
         x = torch.tensor([[[2., 2.], [1., 0.]], [[0., 0.], [1., 1.]]], requires_grad=True)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -133,6 +133,10 @@ class TestOperators(TestCase):
         x = torch.tensor([[0.0]], requires_grad=True)
         self.assertONNX(lambda x: x[0], x)
 
+    def test_index_opset11(self):
+        x = torch.randn(3, 3, 3, requires_grad=True)
+        self.assertONNX(lambda x: x[[0],:, [1, 0, 0]], x)
+
     def test_type_as(self):
         x = torch.tensor([0.0], requires_grad=True)
         self.assertONNX(lambda x: x.type_as(x), x)
@@ -681,15 +685,9 @@ class TestOperators(TestCase):
         x = torch.randn(3, 4, requires_grad=True)
         self.assertONNX(lambda x: torch.max(functional.dropout(x)), x, training=torch.onnx.TrainingMode.TRAINING)
 
-    @unittest.skip("disable test until onnx submodule is updated")
-    def test_dropout_opset12(self):
-        x = torch.randn(3, 4, requires_grad=True)
-        self.assertONNX(lambda x: torch.max(functional.dropout(x)), x, opset_version=12)
-
-    @unittest.skip("disable test until onnx submodule is updated")
-    def test_dropout_training_opset12(self):
-        x = torch.randn(3, 4, requires_grad=True)
-        self.assertONNX(lambda x: torch.max(functional.dropout(x)), x, opset_version=12, training=torch.onnx.TrainingMode.TRAINING)
+    #def test_dropout_training_opset12(self):
+    #    x = torch.randn(3, 4, requires_grad=True)
+    #    self.assertONNX(lambda x: torch.max(functional.dropout(x)), x, opset_version=12, training=torch.onnx.TrainingMode.TRAINING)
 
     def test_nonzero(self):
         x = torch.tensor([[[2., 2.], [1., 0.]], [[0., 0.], [1., 1.]]], requires_grad=True)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -61,6 +61,64 @@ def select(g, self, dim, index):
     return g.op("Gather", self, index, axis_i=dim)
 
 
+def index(g, self, index):
+    # ONNX GatherND does not support ':' semantics. In TorchScript, this
+    # is represented by indices with value prim::Constant(). To work around
+    # this, we can transpose corresponding data tensors. 
+    # Consider the general case of:
+    #    t: [x_1, y_1, x_2, x_3, ..., x_m, ..., y_n]
+    # where t is a tensor of rank m+n, {x_i} are axes where the tensor index is provided,
+    # and {y_i} are axes where the value is ':', we can map onto GatherND by transposing
+    # such that t becomes:
+    #    t: [x_1, x_2, ..., x_m, y_1, y_2, ..., y_n]    
+    # By applying the same transpose to the input data and dropping all {y_i} axes from t,
+    # we can then invoke ONNX GatherND and get the proper results. Or at least we could if
+    # not for one more small twist. ONNX expects the dimensions of each index to match so
+    # that the indices can be represented as a tensor rather than a sequence. To account
+    # for this, we'll also broadcast each non ':' axis in t and stack them into a single
+    # tensor.
+
+    # First check if this is a fallback operator.
+    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+        return g.op("ATen", self, index, operator_s="index")
+
+    # Unpack indices.
+    if sym_help._is_packed_list(index):
+        indices = sym_help._unpack_list(index)
+    else:
+        indices = [index]
+
+    # Lets identify which indices (if any) are non-':'.
+    tensor_indices = [i for i, idx in enumerate(indices) if not sym_help._is_none(idx)]
+    if len(tensor_indices) == 0:
+        return self
+    # Transpose out any axes that represent ':'
+    rank = self.type().dim()
+    self = g.op("Transpose", self, perm_i=tensor_indices + [i for i in range(rank) if i not in tensor_indices])
+    # Next we broadcast tensor indices and drop all ':' axes.
+    # First lets pull out the shapes of the indices.
+    index_shapes = [numpy.asarray(sym_help._get_const(indices[i], 'is', 'indices')).shape for i in tensor_indices]
+    # Now we'll find the target shape to broadcast to, we do this by finding the maximum dimension along each
+    # axis for the index shapes.
+    max_rank = max([len(s) for s in index_shapes])
+    # Now find the maximum dimension for each axis
+    base_shape = numpy.ones(max_rank)
+    for i in range(len(base_shape)):
+        for shape in index_shapes:
+            if len(shape) >= i:
+                if base_shape[i] < shape[i]:
+                    base_shape[i] = shape[i]
+    # Add new axis to stack on.
+    base_shape = numpy.expand_dims(base_shape, axis=0)
+    base_shape = g.op("Constant", value_t=torch.LongTensor(base_shape))
+    # Broadcast indices and stack into new tensor.
+    indices = [g.op("Expand", indices[i], base_shape) for i in tensor_indices]
+    # Finally, stack indices into a single tensor
+    indices = g.op("Concat", *indices, axis_i=0)
+    # Now we're ready to gather!
+    return g.op("GatherND", self, indices)
+
+
 def index_put(g, self, indices_list_value, values, accumulate=False):
     indices_list = sym_help._unpack_list(indices_list_value)
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2158,7 +2158,8 @@ def index(g, self, index):
                           str(sym_help._export_onnx_opset_version) +
                           " is achieved by combination of multiple ONNX operators, " +
                           "including Reshape, Transpose, Concat, and Gather. " +
-                          "If indices include negative values, the exported graph will produce incorrect results.")
+                          "If indices include negative values, the exported graph will produce incorrect results. " +
+                          "Consider using opset 11 or higher as it natively supports GatherND.")
             rank = self.type().dim()
             adv_idx_count = len(adv_idx_indices)
             shape_tensor = _shape_as_tensor(g, self)


### PR DESCRIPTION
This PR adds a converter for the ATen Index operator in Onnx opsets 11+ that uses GatherND rather than the hackier approach used in Opset 9. Although I've confirmed this implementation works well using the onnx runtime on output graphs, it's a little unclear to me how Onnx testing is meant to work within Pytorch. Not only are the onnx tests in `test_operators.py` failing on the master branch (before the changes in this PR), but it seems like the `expect` files used for testing are generated by the tests themselves which seems to defeat the purpose. I'd appreciate some pointers on how to make this testing more robust.