### PR TITLE
Change input scale to double type for conv params.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -88,7 +88,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
       torch::List<int64_t> padding,
       torch::List<int64_t> dilation,
       int64_t groups,
-      c10::optional<float> input_scale,
+      c10::optional<double> input_scale,
       std::vector<int64_t> kernel,
       float w_scale,
       int32_t w_zp)
@@ -111,7 +111,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
   torch::List<int64_t> padding_;
   torch::List<int64_t> dilation_;
   int64_t groups_;
-  c10::optional<float> input_scale;
+  c10::optional<double> input_scale;
   std::vector<int64_t> kernel;
   float w_scale;
   int32_t w_zp;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #37829 Some TODO fixes.
* #37626 Perf optimization for conv and gemm kernels.
* #37624 Added per channel separate test cases for fc and deconv tests.
* #37623 Changes to enable per channel support on dynamic linear.
* #37622 Enabled per channel quantized static linear/conv
* #37621 Added per channel kernels for depthwise conv.
* #37620 Changes to enable per channel requant.
* #37619 Enable per channel zero point.
* #37618 Interface changes to enable per channel quant.
* **#38346 Change input scale to double type for conv params.**

Summary:
Given qtensor stores scale as double, this mismatch can cause use to
repack weights everytime in QNNPACK. Worse given that we release
original weights runtime can crash.

Test Plan:
pytest test/quantization/test_quantized_module.py::TestStaticQuantizedModule::test_conv2d_api

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21529384](https://our.internmc.facebook.com/intern/diff/D21529384)