### PR TITLE
Update Cpp, rpc docs and Libraries section to match 1.5

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    :maxdepth: 1
    :caption: Language Bindings
 
-   C++ API <https://pytorch.org/cppdocs/>
+   cpp_index
    packages
 
 .. toctree::
@@ -45,7 +45,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    onnx
    optim
    quantization
-   rpc
+   rpc/index.rst
    torch.random <random>
    sparse
    storage
@@ -65,11 +65,12 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    :maxdepth: 1
    :caption: Libraries
    
-   PyTorch on XLA Devices <http://pytorch.org/xla/>
-   PyTorch Elastic (torchelastic) <https://pytorch.org/elastic/>
    torchaudio <https://pytorch.org/audio>
    torchtext <https://pytorch.org/text>
    torchvision/index
+   TorchElastic <https://pytorch.org/elastic/>
+   TorchServe <https://pytorch.org/serve>
+   PyTorch on XLA Devices <http://pytorch.org/xla/>
 
 .. toctree::
    :glob:


### PR DESCRIPTION
* Link cpp docs to the cpp landing page
* Link to rpc.rst landing page
* Update Libraries to match 1.5 (https://github.com/pytorch/pytorch/blob/release/1.5/docs/source/index.rst)

