### PR TITLE
Update Default Value of recompute_scale_factor in Interpolate

### DIFF
--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
@@ -4,283 +4,9 @@ producer_version: "1.6"
 graph {
   node {
     input: "input"
-    output: "1"
-    name: "Shape_0"
-    op_type: "Shape"
-  }
-  node {
-    output: "2"
-    name: "Constant_1"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 7
-        raw_data: "\002\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "1"
-    input: "2"
-    output: "3"
-    name: "Gather_2"
-    op_type: "Gather"
-    attribute {
-      name: "axis"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    input: "3"
-    output: "4"
-    name: "Cast_3"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 1
-      type: INT
-    }
-  }
-  node {
-    output: "5"
-    name: "Constant_4"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\000@"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "4"
-    input: "5"
-    output: "6"
-    name: "Mul_5"
-    op_type: "Mul"
-  }
-  node {
-    input: "6"
-    output: "7"
-    name: "Cast_6"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 1
-      type: INT
-    }
-  }
-  node {
-    input: "7"
-    output: "8"
-    name: "Floor_7"
-    op_type: "Floor"
-  }
-  node {
-    input: "input"
-    output: "9"
-    name: "Shape_8"
-    op_type: "Shape"
-  }
-  node {
-    output: "10"
-    name: "Constant_9"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 7
-        raw_data: "\003\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
     input: "9"
-    input: "10"
-    output: "11"
-    name: "Gather_10"
-    op_type: "Gather"
-    attribute {
-      name: "axis"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    input: "11"
-    output: "12"
-    name: "Cast_11"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 1
-      type: INT
-    }
-  }
-  node {
-    output: "13"
-    name: "Constant_12"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 1
-        raw_data: "\000\000\000@"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "12"
-    input: "13"
-    output: "14"
-    name: "Mul_13"
-    op_type: "Mul"
-  }
-  node {
-    input: "14"
-    output: "15"
-    name: "Cast_14"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 1
-      type: INT
-    }
-  }
-  node {
-    input: "15"
-    output: "16"
-    name: "Floor_15"
-    op_type: "Floor"
-  }
-  node {
-    input: "8"
-    output: "17"
-    name: "Unsqueeze_16"
-    op_type: "Unsqueeze"
-    attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-  }
-  node {
-    input: "16"
-    output: "18"
-    name: "Unsqueeze_17"
-    op_type: "Unsqueeze"
-    attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-  }
-  node {
-    input: "17"
-    input: "18"
-    output: "19"
-    name: "Concat_18"
-    op_type: "Concat"
-    attribute {
-      name: "axis"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    output: "20"
-    name: "Constant_19"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        dims: 2
-        data_type: 1
-        raw_data: "\000\000\200?\000\000\200?"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "19"
-    output: "21"
-    name: "Cast_20"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 1
-      type: INT
-    }
-  }
-  node {
-    input: "input"
-    output: "22"
-    name: "Shape_21"
-    op_type: "Shape"
-  }
-  node {
-    input: "22"
-    output: "23"
-    name: "Slice_22"
-    op_type: "Slice"
-    attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-    attribute {
-      name: "ends"
-      ints: 9223372036854775807
-      type: INTS
-    }
-    attribute {
-      name: "starts"
-      ints: 2
-      type: INTS
-    }
-  }
-  node {
-    input: "23"
-    output: "24"
-    name: "Cast_23"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 1
-      type: INT
-    }
-  }
-  node {
-    input: "21"
-    input: "24"
-    output: "25"
-    name: "Div_24"
-    op_type: "Div"
-  }
-  node {
-    input: "20"
-    input: "25"
-    output: "26"
-    name: "Concat_25"
-    op_type: "Concat"
-    attribute {
-      name: "axis"
-      i: 0
-      type: INT
-    }
-  }
-  node {
-    input: "input"
-    input: "26"
-    output: "27"
-    name: "Upsample_26"
+    output: "6"
+    name: "Upsample_0"
     op_type: "Upsample"
     attribute {
       name: "mode"
@@ -289,6 +15,12 @@ graph {
     }
   }
   name: "torch-jit-export"
+  initializer {
+    dims: 3
+    data_type: 1
+    name: "9"
+    raw_data: "\000\000\200?\000\000\200?\000\000\000@"
+  }
   input {
     name: "input"
     type {
@@ -312,7 +44,7 @@ graph {
     }
   }
   output {
-    name: "27"
+    name: "6"
     type {
       tensor_type {
         elem_type: 1

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -53,8 +53,8 @@ inline std::vector<int64_t> _interp_output_size(
       }
     }
     if (is_float_scale_factor) {
-      TORCH_WARN("The default behavior for interpolate/upsample with float scale_factor will change "
-                 "in 1.6.0 to align with other frameworks/libraries, and use scale_factor directly, "
+      TORCH_WARN("The default behavior for interpolate/upsample with float scale_factor changed "
+                 "in 1.6.0 to align with other frameworks/libraries, and uses scale_factor directly, "
                  "instead of relying on the computed output size. "
                  "If you wish to keep the old behavior, please set recompute_scale_factor=True. "
                  "See the documentation of nn.Upsample for details. ");
@@ -98,7 +98,7 @@ inline Tensor interpolate(
 
   auto scale_factor_len = input.dim() - 2;
   std::vector<c10::optional<double>> scale_factor_list(scale_factor_len, c10::nullopt);
-  if (scale_factor != c10::nullopt && recompute_scale_factor.has_value() && !recompute_scale_factor.value()) {
+  if (scale_factor != c10::nullopt && (recompute_scale_factor == c10::nullopt || (recompute_scale_factor.has_value() && !recompute_scale_factor.value()))) {
     auto _scale_factor_repeated = *scale_factor;
     scale_factor_list = {};
     for (const auto& elem : _scale_factor_repeated) {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -1493,16 +1493,12 @@ at::Tensor interpolate(
 
     if (warn_recompute_scale_factor) {
       TORCH_WARN(
-          "The default behavior for interpolate/upsample with float scale_factor changed "
-          "in 1.5.0 to align with other frameworks/libraries, and uses scale_factor directly, "
+          "The default behavior for interpolate/upsample with float scale_factor will change "
+          "in 1.5.0 to align with other frameworks/libraries, and use scale_factor directly, "
           "instead of relying on the computed output size. "
           "If you wish to keep the old behavior, please set recompute_scale_factor=True. "
           "See the documentation of nn.Upsample for details.");
     }
-  }
-
-  if (recompute_scale_factor == c10::nullopt) {
-    recompute_scale_factor = false;
   }
 
   if (recompute_scale_factor == false) {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -1493,12 +1493,16 @@ at::Tensor interpolate(
 
     if (warn_recompute_scale_factor) {
       TORCH_WARN(
-          "The default behavior for interpolate/upsample with float scale_factor will change "
-          "in 1.5.0 to align with other frameworks/libraries, and use scale_factor directly, "
+          "The default behavior for interpolate/upsample with float scale_factor changed "
+          "in 1.5.0 to align with other frameworks/libraries, and uses scale_factor directly, "
           "instead of relying on the computed output size. "
           "If you wish to keep the old behavior, please set recompute_scale_factor=True. "
           "See the documentation of nn.Upsample for details.");
     }
+  }
+
+  if (recompute_scale_factor == c10::nullopt) {
+    recompute_scale_factor = false;
   }
 
   if (recompute_scale_factor == false) {

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2997,8 +2997,8 @@ def _interp_output_size(closed_over_args):  # noqa: F811
                 break
 
         if is_float_scale_factor:
-            warnings.warn("The default behavior for interpolate/upsample with float scale_factor will change "
-                          "in 1.6.0 to align with other frameworks/libraries, and use scale_factor directly, "
+            warnings.warn("The default behavior for interpolate/upsample with float scale_factor changed "
+                          "in 1.6.0 to align with other frameworks/libraries, and uses scale_factor directly, "
                           "instead of relying on the computed output size. "
                           "If you wish to keep the old behavior, please set recompute_scale_factor=True. "
                           "See the documentation of nn.Upsample for details. ")
@@ -3094,8 +3094,8 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         scale_factor is used to compute the output_size which will then
         be used to infer new scales for the interpolation. This is the current
         default behavior when recompute_scale_factor is not specified.
-        The default behavior for recompute_scale_factor will change to False
-        in 1.6.0, and scale_factor will be used in the interpolation
+        The default behavior for recompute_scale_factor changed to False
+        in 1.6.0, and scale_factor is be used in the interpolation
         calculation.
 
     Note:
@@ -3124,7 +3124,8 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
 
     scale_factor_len = input.dim() - 2
     scale_factor_list = torch.jit.annotate(List[Optional[float]], [None for _ in range(scale_factor_len)])
-    if scale_factor is not None and recompute_scale_factor is False:
+    # default value of recompute_scale_factor is False
+    if scale_factor is not None and (recompute_scale_factor is False or recompute_scale_factor is None):
         if isinstance(scale_factor, list):
             _scale_factor_repeated = scale_factor
         else:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3126,7 +3126,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
     scale_factor_list = torch.jit.annotate(List[Optional[float]], [None for _ in range(scale_factor_len)])
     # default value of recompute_scale_factor is False
     if scale_factor is not None and (recompute_scale_factor is False or recompute_scale_factor is None):
-        if isinstance(scale_factor, list):
+        if isinstance(scale_factor, list) or isinstance(scale_factor, tuple):
             _scale_factor_repeated = scale_factor
         else:
             _scale_factor_repeated = [scale_factor for _ in range(scale_factor_len)]  # noqa: C416


### PR DESCRIPTION
This PR completes Interpolate's deprecation process for recomputing the scales values, by updating the default value of the parameter recompute_scale_factor as planned for pytorch 1.6.0.
The warning message is also updated accordingly. 