### PR TITLE
Explicitly decref py::object in ConcretePyObjectHolder and PythonFunctionGuard

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -148,7 +148,10 @@ struct VISIBILITY_HIDDEN PythonFutureWrapper
 
     ~PythonFunctionGuard() {
       pybind11::gil_scoped_acquire ag;
-      func_ = py::none();
+      func_.dec_ref();
+      // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
+      // decref on the PyObject again.
+      func_.ptr() = nullptr;
     }
 
     py::function func_;

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -151,6 +151,7 @@ struct VISIBILITY_HIDDEN PythonFutureWrapper
       func_.dec_ref();
       // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
       // decref on the PyObject again.
+      // See Note [Destructing py::object] in python_ivalue.h
       func_.ptr() = nullptr;
     }
 

--- a/torch/csrc/jit/python/python_ivalue.h
+++ b/torch/csrc/jit/python/python_ivalue.h
@@ -27,8 +27,11 @@ struct C10_EXPORT ConcretePyObjectHolder final : PyObjectHolder {
   ~ConcretePyObjectHolder() {
     pybind11::gil_scoped_acquire ag;
     py_obj_.dec_ref();
+    // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
+    // decref on the PyObject again.
     py_obj_.ptr() = nullptr;
   }
+
   // explicit construction to avoid errornous implicit conversion and
   // copy-initialization
   explicit ConcretePyObjectHolder(py::object py_obj)

--- a/torch/csrc/jit/python/python_ivalue.h
+++ b/torch/csrc/jit/python/python_ivalue.h
@@ -24,6 +24,19 @@ struct C10_EXPORT ConcretePyObjectHolder final : PyObjectHolder {
     return py_obj_.ptr();
   }
 
+  // Note [Destructing py::object]
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //
+  // (1) Why py_obj_ = py::none(); does not work. Because we also need to
+  // acquire GIL when destructing py::object of None that de-references None.
+  // https://docs.python.org/3/c-api/none.html#c.Py_RETURN_NONE
+  //
+  // https://stackoverflow.com/questions/15287590/why-should-py-increfpy-none-be-required-before-returning-py-none-in-c
+  //
+  // (2) Why we need to call dec_ref() explicitly. Because py::object of
+  // nullptr, on destruction, effectively does nothing because of it calls
+  // Py_XDECREF(NULL) underlying.
+  // https://docs.python.org/3/c-api/refcounting.html#c.Py_XDECREF
   ~ConcretePyObjectHolder() {
     pybind11::gil_scoped_acquire ag;
     py_obj_.dec_ref();

--- a/torch/csrc/jit/python/python_ivalue.h
+++ b/torch/csrc/jit/python/python_ivalue.h
@@ -26,7 +26,8 @@ struct C10_EXPORT ConcretePyObjectHolder final : PyObjectHolder {
 
   ~ConcretePyObjectHolder() {
     pybind11::gil_scoped_acquire ag;
-    py_obj_ = py::none();
+    py_obj_.dec_ref();
+    py_obj_.ptr() = nullptr;
   }
   // explicit construction to avoid errornous implicit conversion and
   // copy-initialization


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38376 Use GIL to guard decref of jit::toPyObj return value in processRpc
* #38348 Use GIL to guard py::object's destruction
* #38366 Explicitly decref py::object in PythonRpcHandler
* **#38364 Explicitly decref py::object in ConcretePyObjectHolder and PythonFunctionGuard**
* #38340 Minor code cleanup

Differential Revision: [D21537611](https://our.internmc.facebook.com/intern/diff/D21537611)