### PR TITLE
Explicitly decref py::object in PythonRpcHandler

### DIFF
--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -56,6 +56,13 @@ py::object getFunction(const py::object& module, const char* name) {
   return fn;
 }
 
+void cleanupPyObj(py::object& obj) {
+  obj.dec_ref();
+  // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
+  // decref on the PyObject again.
+  obj.ptr() = nullptr;
+}
+
 } // namespace
 
 PythonRpcHandler::PythonRpcHandler() {
@@ -81,15 +88,15 @@ PythonRpcHandler::PythonRpcHandler() {
 
 void PythonRpcHandler::cleanup() {
   PROFILE_GIL_SCOPED_ACQUIRE;
-  pyRunFunction_ = py::none();
-  pySerialize_ = py::none();
-  pyDeserialize_ = py::none();
-  pyHandleException_ = py::none();
+  cleanupPyObj(pyRunFunction_);
+  cleanupPyObj(pySerialize_);
+  cleanupPyObj(pyDeserialize_);
+  cleanupPyObj(pyHandleException_);
 
-  rrefProxyFunctions_.rpcSync_ = py::none();
-  rrefProxyFunctions_.rpcAsync_ = py::none();
-  rrefProxyFunctions_.remote_ = py::none();
-  rrefProxyFunctions_.rrefProxyCtor_ = py::none();
+  cleanupPyObj(rrefProxyFunctions_.rpcSync_);
+  cleanupPyObj(rrefProxyFunctions_.rpcAsync_);
+  cleanupPyObj(rrefProxyFunctions_.remote_);
+  cleanupPyObj(rrefProxyFunctions_.rrefProxyCtor_);
 
   jitCompilationUnit_ = nullptr;
   typeParser_ = nullptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38376 Use GIL to guard decref of jit::toPyObj return value in processRpc
* #38348 Use GIL to guard py::object's destruction
* **#38366 Explicitly decref py::object in PythonRpcHandler**
* #38364 Explicitly decref py::object in ConcretePyObjectHolder and PythonFunctionGuard
* #38340 Minor code cleanup

Differential Revision: [D21537612](https://our.internmc.facebook.com/intern/diff/D21537612)