### PR TITLE
Reduce number of variables in codegen

### DIFF
--- a/aten/src/ATen/gen_backend_select_register.py
+++ b/aten/src/ATen/gen_backend_select_register.py
@@ -36,7 +36,7 @@ FUNCTION_DEFINITION = CodeTemplate("""\
 Tensor ${function_name}(${method_formals}) {
   static OperatorHandle OP = c10::Dispatcher::singleton().findSchemaOrThrow("aten::${name}", "${overload_name}");
   ${dispatch_key_init}
-  return OP.callWithDispatchKey<${formals_types}>(_dk, ${type_method_actuals});
+  return OP.callWithDispatchKey<${formals_types}>(_dk, ${actuals});
 }
 """)
 
@@ -68,6 +68,7 @@ def register_backend_select_methods(declarations, template_path, file_manager):
 
                 dispatch_key_init = gen_dispatch_key_init('_dk', option['formals_list'])
 
+                assert option['actuals'] == option['type_method_actuals']
                 method_def = FUNCTION_DEFINITION.substitute(function_name=name,
                                                             schema_string=option['schema_string'],
                                                             method_formals=option['formals_with_defaults'],
@@ -75,7 +76,7 @@ def register_backend_select_methods(declarations, template_path, file_manager):
                                                             overload_name=option['overload_name'],
                                                             dispatch_key_init=dispatch_key_init,
                                                             formals_types=option['formals_types_with_return'],
-                                                            type_method_actuals=option['type_method_actuals'])
+                                                            actuals=option['actuals'])
 
                 backend_select_function_registrations.append(func_reg)
                 backend_select_method_definitions.append(method_def)

--- a/aten/src/ATen/gen_backend_select_register.py
+++ b/aten/src/ATen/gen_backend_select_register.py
@@ -68,7 +68,6 @@ def register_backend_select_methods(declarations, template_path, file_manager):
 
                 dispatch_key_init = gen_dispatch_key_init('_dk', option['formals_list'])
 
-                assert option['actuals'] == option['type_method_actuals']
                 method_def = FUNCTION_DEFINITION.substitute(function_name=name,
                                                             schema_string=option['schema_string'],
                                                             method_formals=option['formals_with_defaults'],

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -111,6 +111,7 @@ def load_aten_declarations(path):
         declaration['args'] = [arg['name'] for arg in declaration['arguments']]
         declaration['type_method_formals'] = [arg['type'] + ' ' + arg['name']
                                               for arg in declaration['arguments']]
+        assert declaration['type_method_formals'] == declaration['formals']
         declaration['type_method_args'] = [arg['name'] for arg in declaration['arguments']]
         declaration['api_name'] = declaration['name']
         # NB: keep this in sync with common_with_cwrap.py

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -109,10 +109,6 @@ def load_aten_declarations(path):
         declaration['formals'] = [arg['type'] + ' ' + arg['name']
                                   for arg in declaration['arguments']]
         declaration['args'] = [arg['name'] for arg in declaration['arguments']]
-        declaration['type_method_formals'] = [arg['type'] + ' ' + arg['name']
-                                              for arg in declaration['arguments']]
-        assert declaration['type_method_formals'] == declaration['formals']
-        declaration['type_method_args'] = [arg['name'] for arg in declaration['arguments']]
         declaration['api_name'] = declaration['name']
         # NB: keep this in sync with common_with_cwrap.py
         if declaration.get('overload_name'):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -219,7 +219,7 @@ grad_fn->set_next_edges(collect_next_edges( ${args_with_derivatives} ));
 """)
 
 CALL_DEFAULT = CodeTemplate("""\
-TypeDefault::${type_wrapper_name}(${type_method_args})""")
+TypeDefault::${type_wrapper_name}(${args})""")
 
 CALL_DISPATCH_VIA_NAMESPACE = CodeTemplate("""\
 at::${api_name}(${unpacked_args})""")
@@ -545,10 +545,8 @@ def gen_variable_type(out, aten_declarations, template_path):
 
     for declaration in aten_declarations:
         if dispatch_strategy(declaration) == 'use_derived':
-            assert declaration['type_method_formals'] == declaration['formals']
             registration_declarations.append(REGISTRATION_DECLARATION.substitute(declaration, compound='false'))
         else:
-            assert declaration['type_method_formals'] == declaration['formals']
             registration_declarations.append(REGISTRATION_DECLARATION.substitute(declaration, compound='true'))
 
     env = {
@@ -569,11 +567,9 @@ def gen_variable_type_shard(out, aten_declarations, template_path, suffix, heade
 
     for declaration in aten_declarations:
         formal_types = [arg['type'] for arg in declaration['arguments']]
-        assert declaration['type_method_formals'] == declaration['formals']
         type_declarations.append(METHOD_DECLARATION.substitute(declaration))
         if not declaration['manual_kernel_registration']:
             body = emit_body(declaration)
-            assert declaration['type_method_formals'] == declaration['formals']
             type_definitions.append(METHOD_DEFINITION.substitute(
                 declaration, type_definition_body=body))
             if declaration['use_c10_dispatcher'] == 'full':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38369 Reduce number of variables in codegen **

Seems we have a lot of variables in codegen that carry duplicate information.
This PR is removing them. It unifies all use sites to use the same instance

Differential Revision: [D21537983](https://our.internmc.facebook.com/intern/diff/D21537983/)