### PR TITLE
Use GIL to guard decref of jit::toPyObj return value in processRpc

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -376,7 +376,7 @@ void RequestCallbackImpl::processRpc(
       futureOwner->addCallback([responseFuture,
                                 messageId,
                                 futureOwner,
-                                serialize{std::move(serialize)}]() {
+                                serialize{std::move(serialize)}]() mutable {
         const auto& rref = futureOwner->constValue();
         auto whenValueSet = rref->getFuture();
 
@@ -386,7 +386,7 @@ void RequestCallbackImpl::processRpc(
                                    messageId,
                                    rref,
                                    whenValueSet,
-                                   serialize{std::move(serialize)}] {
+                                   serialize{std::move(serialize)}]() mutable {
           if (whenValueSet->hasError()) {
             responseFuture->setError(whenValueSet->error()->what());
             return;

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -349,7 +349,8 @@ void RequestCallbackImpl::processRpc(
       return;
     }
     case MessageType::PYTHON_RREF_FETCH_CALL: {
-      auto serialize = [](IValue value) -> SerializedPyObj {
+      // Making this lambda mutable to allow move-capture it in callbacks
+      auto serialize = [](IValue value) mutable -> SerializedPyObj {
         auto& pythonRpcHandler = PythonRpcHandler::getInstance();
         // Need this GIL to guard jit::toPyObj and destruct its returned
         // py::object

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -168,7 +168,7 @@ void RequestCallbackImpl::processRpc(
       auto& pythonRpcHandler = PythonRpcHandler::getInstance();
       std::shared_ptr<SerializedPyObj> serializedPyObj = nullptr;
       {
-        pybind11::gil_scoped_acquire ag;
+        py::gil_scoped_acquire acquire;
         serializedPyObj =
             std::make_shared<SerializedPyObj>(pythonRpcHandler.serialize(
                 pythonRpcHandler.runPythonUdf(std::move(upc).movePythonUdf())));
@@ -279,7 +279,7 @@ void RequestCallbackImpl::processRpc(
       IValue py_ivalue;
       try {
         {
-          pybind11::gil_scoped_acquire ag;
+          py::gil_scoped_acquire acquire;
           py_ivalue = jit::toIValue(
               pythonRpcHandler.runPythonUdf(std::move(uprc).movePythonUdf()),
               PyObjectType::get());
@@ -354,7 +354,7 @@ void RequestCallbackImpl::processRpc(
         auto& pythonRpcHandler = PythonRpcHandler::getInstance();
         // Need this GIL to guard jit::toPyObj and destruct its returned
         // py::object
-        pybind11::gil_scoped_acquire ag;
+        py::gil_scoped_acquire acquire;
         return pythonRpcHandler.serialize(jit::toPyObject(std::move(value)));
       };
       auto& prf = static_cast<PythonRRefFetchCall&>(rpc);
@@ -410,7 +410,7 @@ void RequestCallbackImpl::processRpc(
       auto& ctx = RRefContext::getInstance();
       auto deletedRRef = ctx.delForkOfOwner(rud.rrefId(), rud.forkId());
       if (deletedRRef && deletedRRef->isPyObj()) {
-        pybind11::gil_scoped_acquire ag;
+        py::gil_scoped_acquire acquire;
         deletedRRef.reset();
       }
       markComplete(std::move(RRefAck()).toMessage());

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -33,13 +33,6 @@ using namespace torch::distributed::autograd;
 
 namespace {
 
-SerializedPyObj toSerializedPyObj(IValue value) {
-  auto& pythonRpcHandler = PythonRpcHandler::getInstance();
-  // Need this GIL to guard jit::toPyObj and destruct its returned py::object
-  pybind11::gil_scoped_acquire ag;
-  return pythonRpcHandler.serialize(jit::toPyObject(std::move(value)));
-}
-
 std::unique_ptr<RpcCommandBase> deserializePythonRpcCommandReference(
     RpcCommandBase& rpc,
     const MessageType& messageType) {
@@ -356,6 +349,13 @@ void RequestCallbackImpl::processRpc(
       return;
     }
     case MessageType::PYTHON_RREF_FETCH_CALL: {
+      auto serialize = [](IValue value) -> SerializedPyObj {
+        auto& pythonRpcHandler = PythonRpcHandler::getInstance();
+        // Need this GIL to guard jit::toPyObj and destruct its returned
+        // py::object
+        pybind11::gil_scoped_acquire ag;
+        return pythonRpcHandler.serialize(jit::toPyObject(std::move(value)));
+      };
       auto& prf = static_cast<PythonRRefFetchCall&>(rpc);
       auto& ctx = RRefContext::getInstance();
 
@@ -365,14 +365,17 @@ void RequestCallbackImpl::processRpc(
         // the OwnerRRef has been created
         const auto& rref = futureOwner->constValue();
         if (rref->hasValue()) {
-          SerializedPyObj result = toSerializedPyObj(rref->getValue());
+          SerializedPyObj result = serialize(rref->getValue());
           markComplete(
               PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
           return;
         }
       }
 
-      futureOwner->addCallback([responseFuture, messageId, futureOwner]() {
+      futureOwner->addCallback([responseFuture,
+                                messageId,
+                                futureOwner,
+                                serialize{std::move(serialize)}]() {
         const auto& rref = futureOwner->constValue();
         auto whenValueSet = rref->getFuture();
 
@@ -381,13 +384,14 @@ void RequestCallbackImpl::processRpc(
         whenValueSet->addCallback([responseFuture,
                                    messageId,
                                    rref,
-                                   whenValueSet] {
+                                   whenValueSet,
+                                   serialize{std::move(serialize)}] {
           if (whenValueSet->hasError()) {
             responseFuture->setError(whenValueSet->error()->what());
             return;
           }
           try {
-            SerializedPyObj result = toSerializedPyObj(rref->getValue());
+            SerializedPyObj result = serialize(rref->getValue());
             Message m =
                 PythonRRefFetchRet(std::move(result).toIValues()).toMessage();
             m.setId(messageId);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38415 Enforce const on PyRRef functions
* #38402 Remove unnecessary py::object copy in PyRRef ctor
* **#38376 Use GIL to guard decref of jit::toPyObj return value in processRpc**
* #38348 Use GIL to guard py::object's destruction
* #38366 Explicitly decref py::object in PythonRpcHandler
* #38364 Explicitly decref py::object in ConcretePyObjectHolder and PythonFunctionGuard
* #38340 Minor code cleanup



Differential Revision: [D21540179](https://our.internmc.facebook.com/intern/diff/D21540179)