### PR TITLE
[ROCm] add exact_dtype=False to bfloat16 test

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11054,8 +11054,8 @@ class TestNNDeviceType(NNTestCase):
         out2 = op_bfp16(input2)
         out2.backward(grad_input2)
 
-        self.assertEqual(out1, out2, atol=prec)
-        self.assertEqual(input1.grad.data, input2.grad.data, atol=prec)
+        self.assertEqual(out1, out2, atol=prec, exact_dtype=False)
+        self.assertEqual(input1.grad.data, input2.grad.data, atol=prec, exact_dtype=False)
 
     @onlyCUDA
     @skipCUDAIfNotRocm


### PR DESCRIPTION
CC @rohithkrn @ezyang @xw285cornell 

Fixes
- TestNNDeviceTypeCUDA.test_activations_bfloat16_cuda
- TestNNDeviceTypeCUDA.test_pooling_bfloat16_cuda
- TestNNDeviceTypeCUDA.test_softmax_bfloat16_cuda