### PR TITLE
Remove unnecessary py::object copy in PyRRef ctor

### DIFF
--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -108,8 +108,10 @@ PyRRef::PyRRef(const py::object& value, const py::object& type_hint)
     : PyRRef([&value, &type_hint]() {
         TypePtr elem_type = tryInferTypeWithTypeHint(value, type_hint);
         auto rref = RRefContext::getInstance().createOwnerRRef(elem_type);
-        py::object copy(value); // increases refcount
-        IValue ivalue = jit::toIValue(std::move(copy), elem_type);
+        // jit::toIValue takes a py::handle as the first argument, and it calls
+        // py::handle.cast<py::object>() to incref of provided value. The
+        // returned ivalue will keep the reference alive.
+        IValue ivalue = jit::toIValue(value, elem_type);
         rref->setValue(std::move(ivalue));
         return rref;
       }()) {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38415 Enforce const on PyRRef functions
* **#38402 Remove unnecessary py::object copy in PyRRef ctor**
* #38376 Use GIL to guard decref of jit::toPyObj return value in processRpc
* #38348 Use GIL to guard py::object's destruction
* #38366 Explicitly decref py::object in PythonRpcHandler
* #38364 Explicitly decref py::object in ConcretePyObjectHolder and PythonFunctionGuard
* #38340 Minor code cleanup

Differential Revision: [D21554724](https://our.internmc.facebook.com/intern/diff/D21554724)