### PR TITLE
Change CPU cauchy_kernel from double to double/float

### DIFF
--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -229,10 +229,13 @@ struct UniformKernel {
 // ==================================================== Cauchy ========================================================
 
 template<typename RNG>
-void cauchy_kernel(TensorIterator& iter, double median, double sigma, RNG generator) {
+void cauchy_kernel(TensorIterator& iter, double median_, double sigma_, RNG generator) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "cauchy_cpu", [&]() {
+    using accscalar_t = at::acc_type<scalar_t, false>;
     std::lock_guard<std::mutex> lock(generator->mutex_);
-    at::cauchy_distribution<double> cauchy(median, sigma);
+    auto median = static_cast<accscalar_t>(median_);
+    auto sigma = static_cast<accscalar_t>(sigma_);
+    at::cauchy_distribution<accscalar_t> cauchy(median, sigma);
     cpu_serial_kernel(iter, [&cauchy, generator]() -> scalar_t {
       return static_cast<scalar_t>(cauchy(generator));
     });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #36633 CSPRNG PoC
* #38406 Change CPU log_normal_kernel from double to double/float
* **#38405 Change CPU cauchy_kernel from double to double/float**
* #38404 Change CPU exponential_kernel from double to double/float
* #38371 Change CPU geometric_kernel from double to double/float
* #38427 Add bfloat16 to CPU cauchy_kernel, log_normal_kernel, exponential_kernel
* #37984 RNG infrastructure improvements

