### PR TITLE
Remove unnecessary to_string in RPC logging code.

### DIFF
--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -197,8 +197,7 @@ void RpcAgent::rpcRetryCallback(
   if (futureMessage->hasError()) {
     // Adding one since we want to include the original send as well and not
     // just the retry count.
-    LOG(INFO) << "Send try " << std::to_string(earliestRpc->retryCount_ + 1)
-              << " failed";
+    LOG(INFO) << "Send try " << (earliestRpc->retryCount_ + 1) << " failed";
     if (!rpcAgentRunning_.load()) {
       // If the RPC Agent has shutdown, we cannot retry messages. Thus we mark
       // the future with an error since the RPC was never completed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38414 Remove unnecessary to_string in RPC logging code.**

`std::to_string` call is unnecessary when using glog.

Differential Revision: [D21266330](https://our.internmc.facebook.com/intern/diff/D21266330/)