### PR TITLE
Enforce const on PyRRef functions

### DIFF
--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -140,7 +140,7 @@ std::string PyRRef::ownerName() const {
   return rref_->ownerName();
 }
 
-py::object PyRRef::toHere() {
+py::object PyRRef::toHere() const {
   if (rref_->isOwner()) {
     return localValue();
   } else {
@@ -165,7 +165,7 @@ py::object PyRRef::toHere() {
   }
 }
 
-py::object PyRRef::localValue() {
+py::object PyRRef::localValue() const {
   TORCH_CHECK(
       rref_->isOwner(),
       "Cannot call localValue() on a non-local reference. Call it on ",
@@ -235,7 +235,7 @@ PyRRef PyRRef::unpickle(const py::tuple& pyTuple) {
   return PyRRef(std::move(rref));
 }
 
-c10::IValue PyRRef::toIValue() {
+c10::IValue PyRRef::toIValue() const {
   // cast to RRefInterface to hold it into IValue
   auto rrefPtr = c10::static_intrusive_pointer_cast<c10::RRefInterface>(rref_);
   return IValue(rrefPtr);

--- a/torch/csrc/distributed/rpc/py_rref.h
+++ b/torch/csrc/distributed/rpc/py_rref.h
@@ -21,12 +21,12 @@ class PyRRef {
   bool confirmedByOwner() const;
   WorkerInfo owner() const;
   std::string ownerName() const;
-  py::object toHere();
-  py::object localValue();
+  py::object toHere() const;
+  py::object localValue() const;
   std::string str() const;
   py::tuple pickle() const;
   static PyRRef unpickle(const py::tuple& t);
-  c10::IValue toIValue();
+  c10::IValue toIValue() const;
   // Future that is associated with the creation of this RRef on the remote end.
   // This is only used to get the future corresponding to the rref for profiling
   // use cases.

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -106,7 +106,7 @@ const ForkId& UserRRef::forkId() const {
   return forkId_;
 }
 
-IValue UserRRef::toHere() {
+IValue UserRRef::toHere() const {
   // see Note [Best-Effort Check on Deleted UserRRefs]
   TORCH_CHECK(
       !deletedOnOwner_,

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -212,7 +212,7 @@ class TORCH_API RRef : public RRefInterface {
     return rrefId_;
   }
 
-  inline bool isPyObj() {
+  inline bool isPyObj() const {
     return type_ == PyObjectType::get();
   }
   inline const TypePtr type() const override {
@@ -287,7 +287,7 @@ class TORCH_API UserRRef final : public RRef {
 
   // Get of copy of the value from the ``OwnerRRef``. If the value is not ready
   // yet, this call will block.
-  IValue toHere();
+  IValue toHere() const;
 
   void tryDel() override;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38415 Enforce const on PyRRef functions**
* #38402 Remove unnecessary py::object copy in PyRRef ctor
* #38376 Use GIL to guard decref of jit::toPyObj return value in processRpc
* #38348 Use GIL to guard py::object's destruction
* #38366 Explicitly decref py::object in PythonRpcHandler
* #38364 Explicitly decref py::object in ConcretePyObjectHolder and PythonFunctionGuard
* #38340 Minor code cleanup

Differential Revision: [D21554722](https://our.internmc.facebook.com/intern/diff/D21554722)