### PR TITLE
[TensorExpr] Fix bug when splitting inner reduce axis with tail

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -63,6 +63,10 @@ namespace jit {
   _(Reduce3DRfactorRepeated)                \
   _(ReduceRfactorInsertionPoint)            \
   _(Reduce3DRfactorInsertionPoint)          \
+  _(ReduceSplitTail)                        \
+  _(ReduceSplitNoTail)                      \
+  _(ReduceSplitMask)                        \
+  _(ReduceSplitNoMask)                      \
   _(SplitReduceAxis)                        \
   _(SplitNonReduceAxis)                     \
   _(TypeTest01)                             \

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -797,6 +797,14 @@ class Intrinsics : public CallNode<Intrinsics> {
   IntrinsicsOp op_type_;
 };
 
+class NoOp : public ExprNode<NoOp> {
+ public:
+  NoOp() : ExprNodeBase(kVoid) {}
+  static ExprHandle make() {
+    return ExprHandle(new NoOp());
+  }
+};
+
 class Polynomial;
 class Term;
 

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -216,6 +216,10 @@ const Expr* IRMutator::mutate(const FunctionCall* v) {
   return this->mutate(base);
 }
 
+const Expr* IRMutator::mutate(const NoOp* v) {
+  return v;
+}
+
 const Expr* IRMutator::mutate(const Term* v) {
   const Expr* newScalar = v->scalar()->accept_mutator(this);
 

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -49,6 +49,7 @@ class Polynomial;
 class RoundOff;
 class ReduceOp;
 class AtomicAdd;
+class NoOp;
 
 class TORCH_API IRMutator {
  public:
@@ -87,6 +88,7 @@ class TORCH_API IRMutator {
   virtual const Expr* mutate(const BaseCallNode* v);
   virtual const Expr* mutate(const Intrinsics* v);
   virtual const Expr* mutate(const FunctionCall* v);
+  virtual const Expr* mutate(const NoOp* v);
 
   virtual const Expr* mutate(const Term* v);
   virtual const Expr* mutate(const Polynomial* v);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -332,6 +332,10 @@ void IRPrinter::visit(const ReduceOp* v) {
   os() << "})";
 }
 
+void IRPrinter::visit(const NoOp* v) {
+  os() << "NoOp";
+}
+
 // === Stmt visitors below ===
 // Some invariants to keep in mind when changing printer visitors for statement:
 //  1) every statement first outputs the indendation with emitIndent

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -47,6 +47,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const Polynomial* v) override;
   void visit(const RoundOff* v) override;
   void visit(const ReduceOp* v) override;
+  void visit(const NoOp* v) override;
 
   void visit(const AtomicAdd* v) override;
   void visit(const Store* v) override;

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -217,6 +217,10 @@ void IRVisitor::visit(const ReduceOp* v) {
   }
 }
 
+void IRVisitor::visit(const NoOp* v) {
+  // do nothing
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -46,6 +46,7 @@ class Polynomial;
 class RoundOff;
 class ReduceOp;
 class AtomicAdd;
+class NoOp;
 
 class TORCH_API IRVisitor {
  public:
@@ -97,6 +98,7 @@ class TORCH_API IRVisitor {
   virtual void visit(const RoundOff* v);
   virtual void visit(const ReduceOp* v);
   virtual void visit(const AtomicAdd* v);
+  virtual void visit(const NoOp* v);
 };
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -61,79 +61,6 @@ class IndexFlattener : public IRMutator {
   }
 };
 
-class ReductionExpander : public IRMutator {
- public:
-  Stmt* expand(Stmt* s) {
-    return s->accept_mutator(this);
-  }
-
-  Stmt* mutate(const For* v) override {
-    Stmt* body_new = v->body()->accept_mutator(this);
-    if (body_new == v->body()) {
-      body_new = Stmt::clone(v->body());
-    }
-
-    Stmt* ret = v->cloneWithNewBody(body_new);
-
-    for (size_t i = 0; i < initializers_.size();) {
-      InitializerInfo& info = initializers_[i];
-
-      auto end = std::remove(info.vars.begin(), info.vars.end(), v->var());
-      if (end == info.vars.end()) {
-        info.skipped_loops.push_back(v);
-        i++;
-        continue;
-      }
-
-      info.vars.erase(end);
-      if (info.vars.empty()) {
-        const ReduceOp* op = info.op;
-        std::vector<const Expr*> indices(
-            op->output_args().begin(), op->output_args().end());
-
-        Stmt* init = new Store(
-            op->accumulator(), indices, op->initializer(), new IntImm(1));
-
-        for (auto it = info.skipped_loops.rbegin();
-             it != info.skipped_loops.rend();
-             it++) {
-          const For* old_for = *it;
-          init = old_for->cloneWithNewBody(init);
-        }
-        info.skipped_loops.clear();
-
-        if (Block* b = dynamic_cast<Block*>(ret)) {
-          b->prepend_stmt(init);
-        } else {
-          ret = new Block({init, ret});
-        }
-        initializers_.erase(initializers_.begin() + i);
-        continue;
-      }
-
-      i++;
-    }
-    return ret;
-  }
-
-  const Expr* mutate(const ReduceOp* v) override {
-    const std::vector<const Var*>& reduce_vars(v->reduce_args());
-    initializers_.emplace_back(InitializerInfo(v, reduce_vars));
-    return v->complete().node();
-  }
-
- private:
-  struct InitializerInfo {
-    InitializerInfo(const ReduceOp* o, std::vector<const Var*> v)
-        : op(o), vars(std::move(v)) {}
-    const ReduceOp* op;
-    std::vector<const Var*> vars;
-    std::vector<const For*> skipped_loops;
-  };
-
-  std::vector<InitializerInfo> initializers_;
-};
-
 class Vectorizer : public IRMutator {
  public:
   Stmt* vectorize(const For* v) {
@@ -1015,6 +942,8 @@ void LoopNest::splitWithTail(
 
     Stmt* body_tail =
         Substitute(Stmt::clone(f->body()), {{f->var(), combined_index2}});
+    ReductionInitCleaner cleaner;
+    body_tail = cleaner.clean(body_tail);
     *tail = new For(i_tail, new IntImm(0), tail_size, body_tail);
 
     p->insert_stmt_after(*tail, *outer);

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -237,6 +237,109 @@ class Minimum : public Reducer {
         }) {}
 };
 
+class ReductionInitCleaner : public IRMutator {
+ public:
+  Stmt* clean(Stmt* s) {
+    return s->accept_mutator(this);
+  }
+
+  const Expr* mutate(const ReduceOp* v) override {
+    if (v->initializer()->dtype() == kVoid) {
+      return v;
+    }
+
+    return new ReduceOp(
+        v->accumulator(),
+        new NoOp(),
+        v->body(),
+        v->interaction(),
+        v->output_args(),
+        v->reduce_args());
+    return v->complete().node();
+  }
+};
+
+class ReductionExpander : public IRMutator {
+ public:
+  Stmt* expand(Stmt* s) {
+    Stmt* s_new = s->accept_mutator(this);
+    if (!initializers_.empty()) {
+      throw std::runtime_error("failed to initialize all reductions");
+    }
+
+    return s_new;
+  }
+
+  Stmt* mutate(const For* v) override {
+    Stmt* body_new = v->body()->accept_mutator(this);
+    if (body_new == v->body()) {
+      body_new = Stmt::clone(v->body());
+    }
+
+    Stmt* ret = v->cloneWithNewBody(body_new);
+
+    for (size_t i = 0; i < initializers_.size();) {
+      InitializerInfo& info = initializers_[i];
+
+      auto end = std::remove(info.vars.begin(), info.vars.end(), v->var());
+      if (end == info.vars.end()) {
+        info.skipped_loops.push_back(v);
+        i++;
+        continue;
+      }
+
+      info.vars.erase(end);
+      if (info.vars.empty()) {
+        const ReduceOp* op = info.op;
+        std::vector<const Expr*> indices(
+            op->output_args().begin(), op->output_args().end());
+
+        Stmt* init = new Store(
+            op->accumulator(), indices, op->initializer(), new IntImm(1));
+
+        for (auto it = info.skipped_loops.rbegin();
+             it != info.skipped_loops.rend();
+             it++) {
+          const For* old_for = *it;
+          init = old_for->cloneWithNewBody(init);
+        }
+        info.skipped_loops.clear();
+
+        if (Block* b = dynamic_cast<Block*>(ret)) {
+          b->prepend_stmt(init);
+        } else {
+          ret = new Block({init, ret});
+        }
+        initializers_.erase(initializers_.begin() + i);
+        continue;
+      }
+
+      i++;
+    }
+    return ret;
+  }
+
+  const Expr* mutate(const ReduceOp* v) override {
+    if (v->initializer()->dtype() != kVoid) {
+      const std::vector<const Var*>& reduce_vars(v->reduce_args());
+      initializers_.emplace_back(InitializerInfo(v, reduce_vars));
+    }
+
+    return v->complete().node();
+  }
+
+ private:
+  struct InitializerInfo {
+    InitializerInfo(const ReduceOp* o, std::vector<const Var*> v)
+        : op(o), vars(std::move(v)) {}
+    const ReduceOp* op;
+    std::vector<const Var*> vars;
+    std::vector<const For*> skipped_loops;
+  };
+
+  std::vector<InitializerInfo> initializers_;
+};
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/types.cpp
+++ b/torch/csrc/jit/tensorexpr/types.cpp
@@ -51,6 +51,7 @@ AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, DTYPE_DEFINE)
 
 TORCH_API Dtype kHandle(ScalarType::Handle, 1);
 TORCH_API Dtype kUninitialized(ScalarType::Uninitialized, 1);
+TORCH_API Dtype kVoid(ScalarType::None, 1);
 
 Dtype ToDtype(ScalarType type) {
   switch (type) {
@@ -65,6 +66,8 @@ Dtype ToDtype(ScalarType type) {
       return kHandle;
     case ScalarType::Uninitialized:
       return kUninitialized;
+    case ScalarType::None:
+      return kVoid;
     default:
       throw unsupported_dtype();
   }

--- a/torch/csrc/jit/tensorexpr/types.h
+++ b/torch/csrc/jit/tensorexpr/types.h
@@ -84,6 +84,7 @@ class TORCH_API Dtype {
 
 extern TORCH_API Dtype kUninitialized;
 extern TORCH_API Dtype kHandle;
+extern TORCH_API Dtype kVoid;
 
 #define NNC_DTYPE_DECLARATION(ctype, name) extern TORCH_API Dtype k##name;
 


### PR DESCRIPTION
Fixes a bug in the following code:
```
    Tensor* c = Reduce("sum", {{10, "m"}}, Sum(), b, {{10, "n"}, {10, "k"}});
    // split N loop with tail:
    loop.splitWithTail(loop.getLoopStmtsFor(c)[1], 8, &outer, &inner, &tail);
```

When this is expanded there are two ReduceOps:

```
for (int m = 0; m < 10; m++) {
  for (int n_outer = 0; n_outer < (10 - 0) / 8; n_outer++) {
    for (int n_inner = 0; n_inner < 8; n_inner++) {
      for (int k = 0; k < 10; k++) {
        sum[m] = ReduceOp(sum, float(0), (sum[m]) + (b[m, n_outer * 8 + n_inner, k]), out_args={m}, reduce_args={n_inner, n_outer, k});
      }
    }
  }
  for (int n_tail = 0; n_tail < (10 - 0) % 8; n_tail++) {
    for (int k = 0; k < 10; k++) {
      sum[m] = ReduceOp(sum, float(0), (sum[m]) + (b[m, n_tail + ((10 - 0) / 8) * 8, k]), out_args={m}, reduce_args={n_tail, k});
    }
  }
}
```

But each ReduceOp will expand it's initializer, which in this case will overwrite the sum of the split loop:

```
for (int m = 0; m < 10; m++) {
  sum[m] = 0.f;
  for (int n_inner = 0; n_inner < 8; n_inner++) {
    for (int k = 0; k < 10; k++) {
      sum[m] = (sum[m]) + (b[(100 * m + k) + 10 * n_inner]);
    }
  }
  sum[m] = 0.f;          <------- *HERE*
  for (int n_tail = 0; n_tail < 2; n_tail++) {
    for (int k = 0; k < 10; k++) {
      sum[m] = (sum[m]) + (b[((100 * m + k) + 10 * n_tail) + 80]);
    }
  }
}
```

The simplest fix is to remove the initializer from the tail loop, which requires adding support for Reductions without an initializer (I did via adding a NoOp Expr rather than handling nullptr). Also moved the ReductionExpander from loopnest.cpp to reduction.h as loopnest is getting a bit heavy.

Added tests for all kinds of splits on a simple 3D reduction to verify no more problems of this type.