### PR TITLE
[PyTorch] Remove duplicate jit core sources filelists

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
 load("//third_party:substitution.bzl", "template_rule")
-load("//:tools/build_variables.bzl", "torch_cpp_srcs", "libtorch_core_sources", "libtorch_distributed_sources", "libtorch_extra_sources")
+load("//:tools/build_variables.bzl", "torch_cpp_srcs", "libtorch_core_sources", "libtorch_distributed_sources", "libtorch_extra_sources", "jit_core_sources")
 load("//tools/rules:cu.bzl", "cu_library")
 load("//tools/config:defs.bzl", "if_cuda")
 load("//:aten.bzl", "intern_build_aten_ops")
@@ -1979,13 +1979,7 @@ cc_library(
             "torch/csrc/cuda/python_nccl.cpp",
             "torch/csrc/cuda/nccl.cpp",
         ],
-    )) + libtorch_core_sources + libtorch_distributed_sources + torch_cpp_srcs + libtorch_extra_sources + [
-        "torch/csrc/jit/frontend/error_report.cpp",
-        "torch/csrc/jit/frontend/lexer.cpp",
-        "torch/csrc/jit/frontend/function_schema_parser.cpp",
-        "torch/csrc/jit/frontend/strtod.cpp",
-        "torch/csrc/jit/frontend/source_range.cpp",
-        "torch/csrc/jit/frontend/schema_type_parser.cpp",
+    )) + libtorch_core_sources + libtorch_distributed_sources + torch_cpp_srcs + libtorch_extra_sources + jit_core_sources + [
         ":generated_code",
     ],
     copts = TORCH_COPTS + if_cuda(["-DUSE_CUDA=1"]),

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -39,6 +39,34 @@ libtorch_generated_sources = [
     "torch/csrc/autograd/VariableTypeManual.cpp",
 ]
 
+# copied from https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/CMakeLists.txt
+jit_core_headers = [
+    "torch/csrc/utils/memory.h",
+    "torch/csrc/WindowsTorchApiMacro.h",
+    "torch/csrc/jit/frontend/source_range.h",
+    "torch/csrc/jit/serialization/source_range_serialization.h",
+    "torch/csrc/jit/frontend/lexer.h",
+    "torch/csrc/jit/frontend/strtod.h",
+    "torch/csrc/jit/frontend/parser_constants.h",
+    "torch/csrc/jit/frontend/function_schema_parser.h",
+    "torch/csrc/jit/frontend/parse_string_literal.h",
+    "torch/csrc/jit/frontend/schema_type_parser.h",
+    "torch/csrc/jit/frontend/error_report.h",
+    "torch/csrc/jit/frontend/tree.h",
+    "torch/custom_class.h",
+    "torch/custom_class_detail.h",
+    "torch/library.h",
+]
+
+jit_core_sources = [
+    "torch/csrc/jit/frontend/error_report.cpp",
+    "torch/csrc/jit/frontend/function_schema_parser.cpp",
+    "torch/csrc/jit/frontend/lexer.cpp",
+    "torch/csrc/jit/frontend/schema_type_parser.cpp",
+    "torch/csrc/jit/frontend/strtod.cpp",
+    "torch/csrc/jit/frontend/source_range.cpp",
+]
+
 # copied from https://github.com/pytorch/pytorch/blob/master/tools/cpp_build/torch/CMakeLists.txt
 libtorch_core_sources = [
     "torch/csrc/autograd/anomaly_mode.cpp",


### PR DESCRIPTION
Summary: Add `jit_core_[sources|headers]` to `build_variables.bzl`, use them from BUILD.bazel as wel as from internal build systems

Test Plan: CI

Differential Revision: D21555649

