### PR TITLE
Fix @skipIfNoFBGEMM for types

### DIFF
--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -254,6 +254,7 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
+        qRNNBase._all_weight_values = torch.nn.ModuleList(_all_weight_values)
         qRNNBase._all_params = ([m.param for m in _all_weight_values])
 
         return qRNNBase

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -116,9 +116,10 @@ def _make_conv_test_input(
 
 def skipIfNoFBGEMM(fn):
     reason = 'Quantized operations require FBGEMM. FBGEMM is only optimized for CPUs with instruction set support AVX2 or newer.'
-    if isinstance(fn, type) and 'fbgemm' not in torch.backends.quantized.supported_engines:
-        fn.__unittest_skip__ = True
-        fn.__unittest_skip_why__ = reason
+    if isinstance(fn, type):
+        if 'fbgemm' not in torch.backends.quantized.supported_engines:
+            fn.__unittest_skip__ = True
+            fn.__unittest_skip_why__ = reason
         return fn
 
     @functools.wraps(fn)


### PR DESCRIPTION
Return unmodified type from decorator if fbgemm is present.

Fix `Tried to trace <__torch__.torch.classes.rnn.CellParamsBase object at 0x55f504c56b40> but it is not part of the active trace. Modules that are called during a trace must be registered as submodules of the thing being traced` thrown from `TestPostTrainingDynamic.test_quantized_rnn`  by preserving modules in returned qRNNBase (i.e. by partially reverting https://github.com/pytorch/pytorch/pull/38134 )

