### PR TITLE
Replace calls to contiguous with contiguous(suggested memory format)

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/make_per_tensor_quantized_tensor.cpp
+++ b/aten/src/ATen/native/quantized/cpu/make_per_tensor_quantized_tensor.cpp
@@ -12,8 +12,9 @@ Tensor make_per_tensor_quantized_tensor_cpu(
       self.sizes(),
       self.options().dtype(toQIntType(self.scalar_type())),
       scale,
-      zero_point);
-  Tensor self_contig = self.contiguous();
+      zero_point,
+      self.suggest_memory_format());
+  Tensor self_contig = self.contiguous(self.suggest_memory_format());
   AT_DISPATCH_QINT_TYPES(
       dst.scalar_type(), "make_per_tensor_quantized_tensor", [&]() {
         underlying_t* self_data = self_contig.data_ptr<underlying_t>();

--- a/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
@@ -68,17 +68,14 @@ Tensor qnnpack_hardswish(const Tensor& qx, Tensor& qy) {
 Tensor quantized_hardswish(const Tensor& qx, double output_scale, int64_t output_zero_point) {
   Tensor qy = at::_empty_affine_quantized(
       qx.sizes(),
-      at::device(kCPU)
-        .dtype(qx.scalar_type()),
-        // .memory_format(MemoryFormat::ChannelsLast),
+      at::device(kCPU).dtype(qx.scalar_type()),
       output_scale,
       output_zero_point,
-      c10::nullopt);
+      qx.suggest_memory_format());
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
       qx.scalar_type() == kQUInt8) {
     Tensor qx_contig = qx.contiguous(qx.suggest_memory_format());
-    TORCH_CHECK(qy.is_contiguous(), "qy must be contiguous");
     qnnpack_hardswish(qx_contig, qy);
     return qy;
   }

--- a/aten/src/ATen/native/quantized/cpu/qreduction.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qreduction.cpp
@@ -26,10 +26,7 @@ Tensor qnnpack_mean(const Tensor& input, IntArrayRef dim) {
   const int64_t inH = input.size(2);
   const int64_t inW = input.size(3);
 
-  // TODO: change it to contiguous(MemoryFormat::ChannelsLast) once a perf
-  // regression of it is fixed. Today it's equivalent because `input` sizes
-  // are not used below
-  Tensor input_contig = input.permute({0, 2, 3, 1}).contiguous();
+  Tensor input_contig = input.contiguous(MemoryFormat::ChannelsLast);
 
   initQNNPACK();
   const auto scale = input_contig.q_scale();

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -28,7 +28,7 @@ Tensor qnnpack_sigmoid(Tensor input) {
 
   initQNNPACK();
 
-  Tensor input_contig = input.contiguous();
+  Tensor input_contig = input.contiguous(input.suggest_memory_format());
   size_t num_elems = 1;
   for (int i = 1; i < input_contig.ndimension(); ++i) {
     num_elems *= input_contig.size(i);

--- a/aten/src/ATen/native/quantized/cpu/qtanh.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qtanh.cpp
@@ -27,7 +27,7 @@ Tensor qnnpack_tanh(Tensor input) {
 
   initQNNPACK();
 
-  Tensor input_contig = input.contiguous();
+  Tensor input_contig = input.contiguous(input.suggest_memory_format());
   size_t num_elems = 1;
   for (int i = 1; i < input_contig.ndimension(); ++i) {
     num_elems *= input_contig.size(i);


### PR DESCRIPTION
Summary:
Wherever applicable it would be better to call contiguous with appropriate
memory format.
Plus output should be allocated with the same memory format as input when
applicable. Otherwise convert to that format upon returning.
This helps with some perf where otherwise calls to contiguous may involve
allocation and memcpy.

Test Plan: quantization tests

Differential Revision: D21559301

