### PR TITLE
DOC: Correct upsample doc to match interpolation

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2907,7 +2907,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=
         input (Tensor): the input tensor
         size (int or Tuple[int] or Tuple[int, int] or Tuple[int, int, int]):
             output spatial size.
-        scale_factor (float or Tuple[float]): multiplier for spatial size. Has to be an integer.
+        scale_factor (float or Tuple[float]): multiplier for spatial size. Has to match input size if it is a tuple.
         mode (string): algorithm used for upsampling:
             ``'nearest'`` | ``'linear'`` | ``'bilinear'`` | ``'bicubic'`` |
             ``'trilinear'``. Default: ``'nearest'``


### PR DESCRIPTION
Fix #38334 and correct the docs of `torch.nn.functional.upsample`