### PR TITLE
Migrate CPU clamp to c10::complex

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -219,8 +219,8 @@ static void polygamma_kernel(TensorIterator& iter, int64_t n) {
 }
 
 static void clamp_kernel(TensorIterator& iter, Scalar min_scalar, Scalar max_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_cpu", [&]() {
-    ztype<scalar_t>::value_t (*zabs_)(scalar_t) = zabs;
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_cpu", [&]() {
+    c10::scalar_value_type<scalar_t>::type (*zabs_)(scalar_t) = zabs;
     auto min = min_scalar.to<scalar_t>();
     auto max = max_scalar.to<scalar_t>();
     auto min_vec = Vec256<scalar_t>(min);
@@ -232,8 +232,8 @@ static void clamp_kernel(TensorIterator& iter, Scalar min_scalar, Scalar max_sca
 }
 
 static void clamp_max_kernel(TensorIterator& iter, Scalar max_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_max_cpu", [&]() {
-    ztype<scalar_t>::value_t (*zabs_)(scalar_t) = zabs;
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_max_cpu", [&]() {
+    c10::scalar_value_type<scalar_t>::type (*zabs_)(scalar_t) = zabs;
     auto max = max_scalar.to<scalar_t>();
     auto max_vec = Vec256<scalar_t>(max);
     cpu_kernel_vec(iter,
@@ -243,8 +243,8 @@ static void clamp_max_kernel(TensorIterator& iter, Scalar max_scalar) {
 }
 
 static void clamp_min_kernel(TensorIterator& iter, Scalar min_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_min_cpu", [&]() {
-    ztype<scalar_t>::value_t (*zabs_)(scalar_t) = zabs;
+  AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_min_cpu", [&]() {
+    c10::scalar_value_type<scalar_t>::type (*zabs_)(scalar_t) = zabs;
     auto min = min_scalar.to<scalar_t>();
     auto min_vec = Vec256<scalar_t>(min);
     cpu_kernel_vec(iter,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38462 Kill AT_DISPATCH_ALL_TYPES_AND_C10_COMPLEX_AND
* #38461 Migrate CPU min max to c10::complex
* **#38460 Migrate CPU clamp to c10::complex**

Differential Revision: [D21663855](https://our.internmc.facebook.com/intern/diff/D21663855)