### PR TITLE
[ONNX] Squeeze operator should give an error when trying to apply to a dimension with shape > 1

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -12,7 +12,6 @@ import io
 import itertools
 import copy
 
-from torch import select
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
 from model_defs.rnn_model_with_packed_sequence import RnnModelWithPackedSequence

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -728,6 +728,10 @@ class TestONNXRuntime(unittest.TestCase):
         x_squeeze = torch.randn(2, 2, 1)
         self.squeeze_model_tests(2, x_noop, x_squeeze)
 
+    def test_squeeze_no_op_without_additional_inputs(self):
+        x_noop = torch.randn(2, 1, 4)
+        self.squeeze_model_tests(2, x_noop, None)
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_squeeze_runtime_dim(self):
         class Squeeze(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -694,7 +694,7 @@ class TestONNXRuntime(unittest.TestCase):
                 else:
                     return torch.squeeze(x)
 
-        x2 = [] if x2 == None else x2
+        x2 = [] if x2 is None else x2
         self.run_test(Squeeze(), x1, input_names=['input'], dynamic_axes={'input': {0: '0', 1: '1', 2: '2'}}, test_with_inputs=x2)
 
     def test_squeeze_without_no_op(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1572,8 +1572,16 @@ class TestONNXRuntime(unittest.TestCase):
     def test_select(self):
         class Select(torch.nn.Module):
             def forward(self, x):
-                return torch.select(x, 0, 1)
+                return x[:, 1]
         
+        x = torch.randn(3, 4)
+        self.run_test(Select(), x)
+
+    def test_select_negative_index(self):
+        class Select(torch.nn.Module):
+            def forward(self, x):
+                return x[:, -1]
+
         x = torch.randn(3, 4)
         self.run_test(Select(), x)
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -694,13 +694,22 @@ class TestONNXRuntime(unittest.TestCase):
                 else:
                     return torch.squeeze(x)
 
-        self.run_test(Squeeze(), x1, input_names=['input'], dynamic_axes={'input': {0: '0', 1: '1', 2: '2'}}, test_with_inputs=[x2])
+        x2 = [] if x2 == None else x2
+        self.run_test(Squeeze(), x1, input_names=['input'], dynamic_axes={'input': {0: '0', 1: '1', 2: '2'}}, test_with_inputs=x2)
+
+    def test_squeeze_without_no_op(self):
+        x = torch.randn(2, 1, 4)
+        self.squeeze_model_tests(1, x, None)
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_squeeze(self):
         x_squeeze = torch.randn(2, 1, 4)
         x_noop = torch.randn(2, 2, 3)
         self.squeeze_model_tests(1, x_squeeze, x_noop)
+
+    def test_squeeze_neg_without_no_op(self):
+        x = torch.randn(2, 1, 4)
+        self.squeeze_model_tests(-2, x, None)
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_squeeze_neg(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -694,7 +694,7 @@ class TestONNXRuntime(unittest.TestCase):
                 else:
                     return torch.squeeze(x)
 
-        x2 = [] if x2 is None else x2
+        x2 = [] if x2 is None else [x2]
         self.run_test(Squeeze(), x1, input_names=['input'], dynamic_axes={'input': {0: '0', 1: '1', 2: '2'}}, test_with_inputs=x2)
 
     def test_squeeze_without_no_op(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -12,6 +12,7 @@ import io
 import itertools
 import copy
 
+from torch import select
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
 from model_defs.rnn_model_with_packed_sequence import RnnModelWithPackedSequence
@@ -1567,6 +1568,14 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(3, 4, 5, requires_grad=True)
         self.run_test(IndexCopyModel(), x)
+
+    def test_select(self):
+        class Select(torch.nn.Module):
+            def forward(self, x):
+                return torch.select(x, 0, 1)
+        
+        x = torch.randn(3, 4)
+        self.run_test(Select(), x)
 
     # TODO: enable for opset 10 when ONNXRuntime version will be updated
 

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -49,5 +49,15 @@ void buildParamsMapFromValueToParamsMap(
     paramsDict.insert(nameTensorParamPair.second);
   }
 }
+
+Node* addNodeToBlock(Block* block, Value* input, Symbol kind) {
+  auto new_node = block->appendNode(block->owningGraph()->create(kind));
+  auto new_input = new_node->addInput(input);
+  for (size_t i = 0; i < new_node->outputs().size(); i++) {
+    auto output = new_node->outputs()[i];
+    block->registerOutput(output);
+  }
+  return new_node;
+}
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/helper.h
+++ b/torch/csrc/jit/passes/onnx/helper.h
@@ -26,6 +26,7 @@ void eraseUnusedBlockInputs(Block* b);
 void buildParamsMapFromValueToParamsMap(
     const ValueToParamPairMap& valsToParamsMap,
     ParamMap& paramsDict);
+Node* addNodeToBlock(Block* block, Value* input, Symbol kind);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/shape_analysis.h>
+#include <torch/csrc/jit/passes/onnx/helper.h>
 #include <torch/csrc/jit/python/pybind.h>
 #include <torch/csrc/jit/python/python_tracer.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
@@ -13,7 +14,6 @@
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_strings.h>
-
 #include <iostream>
 #include <sstream>
 
@@ -123,16 +123,6 @@ Node* findNode(
 Node* findNode(Block* block, Symbol kind, bool recurse = true) {
   std::vector<Block*> blocks = {block};
   return findNode(blocks, kind, recurse);
-}
-
-Node* addNodeToBlock(Block* block, Value* input, Symbol kind) {
-  auto new_node = block->appendNode(block->owningGraph()->create(kind));
-  auto new_input = new_node->addInput(input);
-  for (size_t i = 0; i < new_node->outputs().size(); i++) {
-    auto output = new_node->outputs()[i];
-    block->registerOutput(output);
-  }
-  return new_node;
 }
 
 std::string ConcretePythonOp::name() const {

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -125,10 +125,8 @@ Node* findNode(Block* block, Symbol kind, bool recurse = true) {
   return findNode(blocks, kind, recurse);
 }
 
-Node* addNodeToBlock(Block* block, Value* input, Symbol kind)
-{
-  auto new_node = block->appendNode(
-    block->owningGraph()->create(kind));
+Node* addNodeToBlock(Block* block, Value* input, Symbol kind) {
+  auto new_node = block->appendNode(block->owningGraph()->create(kind));
   auto new_input = new_node->addInput(input);
   for (size_t i = 0; i < new_node->outputs().size(); i++) {
     auto output = new_node->outputs()[i];
@@ -480,12 +478,9 @@ void initPythonIRBindings(PyObject* module_) {
           })
       .def("returnNode", [](Block& b) { return b.return_node(); })
       .def("paramNode", [](Block& b) { return b.param_node(); })
-      .def(
-          "addNode",
-          [](Block& b, Value& input, const char* str) {
-            return addNodeToBlock(&b, &input, Symbol::fromQualString(str));
-          }
-      );
+      .def("addNode", [](Block& b, Value& input, const char* str) {
+        return addNodeToBlock(&b, &input, Symbol::fromQualString(str));
+      });
 
 #define NS(name) def(#name, &Node ::name)
   py::class_<Node, std::unique_ptr<Node, py::nodelete>>(m, "Node")

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -4,7 +4,6 @@
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
-#include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/passes/onnx/helper.h>
 #include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/python/pybind.h>

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/passes/onnx/helper.h>
+#include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/python/pybind.h>
 #include <torch/csrc/jit/python/python_tracer.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -7,6 +7,7 @@ import torch.onnx.symbolic_helper as sym_help
 import warnings
 import numpy
 
+from torch.onnx import OperatorExportTypes
 from torch.onnx.symbolic_helper import parse_args, _unimplemented
 from torch.onnx.symbolic_opset9 import expand, unused
 from torch.nn.modules.utils import _single, _pair, _triple
@@ -505,21 +506,47 @@ def squeeze(g, self, dim=None):
         # return g.op("Squeeze", self, axes_i=dims)
 
     dim = sym_help._get_const(dim, 'i', 'dim')
+    class Squeeze(torch.jit.ScriptModule):
+        @torch.jit.script_method
+        def forward(self, x):
+            if x.shape[0] > 1:
+                return x
+            else:
+                x.squeeze(0)
+    
+    sq = Squeeze()
+    sq_graph = sq.forward.graph
+    
+    for i, n in enumerate(sq_graph.nodes()):
+        if n.kind() == 'prim::If':
+            sq_if_node = n
+            break
+
     # create 'cond' node (condition is shape[i]==1)
-    shape_op = g.op("Shape", self)
-    slice_op = sym_help._slice_helper(g, shape_op, axes = [0], starts = [dim], ends = [dim])
+    size = sym_help._size_helper(g, self, dim)
+    # shape_op = g.op("Shape", self)
+    # slice_op = sym_help._slice_helper(g, shape_op, axes = [0], starts = [dim], ends = [dim])
     const_one = g.op("Constant", value_t=torch.ones(1, dtype=torch.int64))
-    cond = g.op("Equal", slice_op, const_one)
+    cond = g.op("Equal", size, const_one)
     # create a subgraph containing "Squeeze" called branch1
-    class Identity(torch.jit.Module):
-        def forward(self, input):
-            return input
-    from torch.onnx.utils import _trace_and_get_graph_from_model
-    branch1_graph, torch_out = _trace_and_get_graph_from_model(Identity(), torch.tensor(self.type().sizes()))
-    branch1_graph.op("Squeeze", *(branch1_graph.nodes()), axes_i=[dim])
+    # class Identity(torch.jit.Module):
+    #     def forward(self, input):
+    #         return input
+    # from torch.onnx.utils import _trace_and_get_graph_from_model
+    # branch1_graph, torch_out = _trace_and_get_graph_from_model(Identity(), torch.tensor(self.type().sizes()))
+    # branch1_graph.op("Squeeze", *(branch1_graph.nodes()), axes_i=[dim])
     # and a subgraph containing no-op called branch2
-    branch2_graph, torch_out = _trace_and_get_graph_from_model(Identity(), torch.tensor(self.type().sizes()))
-    g = g.op("If", cond, then_branch_g=branch1_graph, else_branch_g=branch2_graph)
+    # branch2_graph, torch_out = _trace_and_get_graph_from_model(Identity(), torch.tensor(self.type().sizes()))
+    # if_node = g.op("If", cond, then_branch_g=branch1_graph, else_branch_g=branch2_graph)
+    if_node_outputs = g.op("If", cond)
+    if_node = if_node_outputs.node()
+    for b in sq_if_node.blocks():
+        new_block = if_node.addBlock()
+        torch._C._jit_pass_onnx_block(b, new_block, OperatorExportTypes.ONNX, dict())
+
+    # then_block = if_node.addBlock()
+    # torch._C._jit_pass_onnx_block(branch1_graph, then_block, OperatorExportTypes.ONNX)
+
     return g
 
 @parse_args('v', 'i')

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -561,25 +561,38 @@ def squeeze(g, self, dim=None):
     if dim is None:
         return g.op("Squeeze", self)
 
-    dims = [sym_help._get_const(dim, 'i', 'dim')]
+    squeeze_dim = sym_help._get_const(dim, 'i', 'dim')
     # Handle negative dims
-    for i, dim in enumerate(dims):
-        if dim < 0:
-            rank = self.type().dim()
-            if rank:
-                warnings.warn("ONNX export squeeze with negative axis " + str(dim) +
-                              " might cause the onnx model to be incorrect. " +
-                              "Negative axis is not supported in ONNX. " +
-                              "Axis is converted to " + str(dim + rank) +
-                              " based on input shape at export time. " +
-                              "Passing an tensor of different rank in execution will be incorrect.")
-                dims[i] += rank
-            else:
-                return _unimplemented('squeeze', 'negative axis with unknown input rank')
+    if squeeze_dim < 0:
+        rank = self.type().dim()
+        if rank:
+            warnings.warn("ONNX export squeeze with negative axis " + str(squeeze_dim) +
+                          " might cause the onnx model to be incorrect. " +
+                          "Negative axis is not supported in ONNX. " +
+                          "Axis is converted to " + str(squeeze_dim + rank) +
+                          " based on input shape at export time. " +
+                          "Passing an tensor of different rank in execution will be incorrect.")
+            squeeze_dim += rank
+        else:
+            return _unimplemented('squeeze', 'negative axis with unknown input rank')
 
-    warnings.warn("Opset version 9 does not support squeezing on dimensions of shape greater than 1." + 
-                  " It is recommended to use opset version 11 or higher to export this model.")
-    return g.op("Squeeze", self, axes_i=dims)
+    input_shape = self.type().sizes()
+    if input_shape is None:
+        warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + " on an input with unknown shape. " +
+                      "Note that if the size of dimension " + str(squeeze_dim) + " of the input is not 1, the ONNX model will return an error." +
+                      "Opset version 11 supports squeezing on non-singleton dimensions, it is recommended to export this model using " +
+                      "opset version 11 or higher.")
+        return g.op("Squeeze", self, axes_i=[squeeze_dim])
+    if input_shape[squeeze_dim] > 1:
+        warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". The size of this dimension in the given " +
+                      "input is " + str(input_shape[squeeze_dim]) + ". The model will be exported without the squeeze node. If the model is " +
+                      "intended to be used with different input shapes than the shapes passed at export time, please use opset version 11 to " +
+                      "export the model.")
+        return self
+
+    warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". If the model is intended to be used with " +
+                  "different input shapes than the shapes passed at export time, please use opset version 11 to export the model.")
+    return g.op("Squeeze", self, axes_i=[squeeze_dim])
 
 def prelu(g, self, weight):
     if self.isCompleteTensor():

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -579,7 +579,7 @@ def squeeze(g, self, dim=None):
 
     warnings.warn("Opset version 9 does not support squeezing on dimensions of shape greater than 1." + 
                   " It is recommended to use opset version 11 or higher to export this model.")
-    return g.op("Squeeze", self, axes_i = dims)
+    return g.op("Squeeze", self, axes_i=dims)
 
 def prelu(g, self, weight):
     if self.isCompleteTensor():

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -578,20 +578,23 @@ def squeeze(g, self, dim=None):
 
     input_shape = self.type().sizes()
     if input_shape is None:
-        warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + " on an input with unknown shape. " +
-                      "Note that if the size of dimension " + str(squeeze_dim) + " of the input is not 1, the ONNX model will return an error." +
-                      "Opset version 11 supports squeezing on non-singleton dimensions, it is recommended to export this model using " +
-                      "opset version 11 or higher.")
+        warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + " on an input " +
+                      "with unknown shape. Note that if the size of dimension " + str(squeeze_dim) + " of the input " +
+                      "is not 1, the ONNX model will return an error. Opset version 11 supports squeezing on " +
+                      "non-singleton dimensions, it is recommended to export this model using opset " +
+                      "version 11 or higher.")
         return g.op("Squeeze", self, axes_i=[squeeze_dim])
     if input_shape[squeeze_dim] > 1:
-        warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". The size of this dimension in the given " +
-                      "input is " + str(input_shape[squeeze_dim]) + ". The model will be exported without the squeeze node. If the model is " +
-                      "intended to be used with different input shapes than the shapes passed at export time, please use opset version 11 to " +
+        warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". The size of " +
+                      "this dimension in the given input is " + str(input_shape[squeeze_dim]) + ". The model will " +
+                      "be exported without the squeeze node. If the model is intended to be used with different " +
+                      "input shapes than the shapes passed at export time, please use opset version 11 to " +
                       "export the model.")
         return self
 
-    warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". If the model is intended to be used with " +
-                  "different input shapes than the shapes passed at export time, please use opset version 11 to export the model.")
+    warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". If the model is " +
+                  "intended to be used with different input shapes than the shapes passed at export time, please " +
+                  "use opset version 11 to export the model.")
     return g.op("Squeeze", self, axes_i=[squeeze_dim])
 
 def prelu(g, self, weight):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -577,17 +577,9 @@ def squeeze(g, self, dim=None):
             else:
                 return _unimplemented('squeeze', 'negative axis with unknown input rank')
 
-    # create 'cond' node (condition is shape[i]==1)
-    dim_constant = g.op("Constant", value_t=torch.tensor(dims))
-    size = sym_help._size_helper(g, self, dim_constant)
-    const_one = g.op("Constant", value_t=torch.ones(1, dtype=torch.int64))
-    cond = g.op("Equal", size, const_one)
-    # create the 'If' node and add the 'then' and 'else' blocks to it.
-    if_node_outputs = g.op("If", cond)
-    if_node = if_node_outputs.node()
-    torch.onnx.utils._add_block(if_node, self, "onnx::Squeeze", axes_i=dims)
-    torch.onnx.utils._add_block(if_node, self, "onnx::Identity")
-    return if_node_outputs
+    warnings.warn("Opset version 9 does not support squeezing on dimensions of shape greater than 1." + 
+                  " It is recommended to use opset version 11 or higher to export this model.")
+    return g.op("Squeeze", self, axes_i = dims)
 
 def prelu(g, self, weight):
     if self.isCompleteTensor():

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -565,7 +565,6 @@ def squeeze(g, self, dim=None):
                 dims.append(i)
     else:
         dims = [sym_help._get_const(dim, 'i', 'dim')]
-        input_dims = self.type().sizes()
         # Handle negative dims
         for i, dim in enumerate(dims):
             if dim < 0:
@@ -580,9 +579,9 @@ def squeeze(g, self, dim=None):
                     dims[i] += rank
                 else:
                     return _unimplemented('squeeze', 'negative axis with unknown input rank')
-            # Handle input dimensions > 1, which are disallowed in the ONNX spec.
-            if input_dims[dim] > 1:
-                return _unimplemented('squeeze', 'cannot apply squeeze operator on shape entries not equal to 1')
+            # # Handle input dimensions > 1, which are disallowed in the ONNX spec.
+            # if input_dims[dim] > 1:
+            #     return _unimplemented('squeeze', 'cannot apply squeeze operator on shape entries not equal to 1')
 
     return g.op("Squeeze", self, axes_i=dims)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -565,6 +565,7 @@ def squeeze(g, self, dim=None):
                 dims.append(i)
     else:
         dims = [sym_help._get_const(dim, 'i', 'dim')]
+        input_dims = self.type().sizes()
         # Handle negative dims
         for i, dim in enumerate(dims):
             if dim < 0:
@@ -579,6 +580,9 @@ def squeeze(g, self, dim=None):
                     dims[i] += rank
                 else:
                     return _unimplemented('squeeze', 'negative axis with unknown input rank')
+            # Handle input dimensions > 1, which are disallowed in the ONNX spec.
+            if input_dims[dim] > 1:
+                return _unimplemented('squeeze', 'cannot apply squeeze operator on shape entries not equal to 1')
 
     return g.op("Squeeze", self, axes_i=dims)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -587,14 +587,13 @@ def squeeze(g, self, dim=None):
     if input_shape[squeeze_dim] > 1:
         warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". The size of " +
                       "this dimension in the given input is " + str(input_shape[squeeze_dim]) + ". The model will " +
-                      "be exported without the squeeze node. If the model is intended to be used with different " +
-                      "input shapes than the shapes passed at export time, please use opset version 11 to " +
+                      "be exported without the squeeze node. If the model is intended to be used with dynamic " +
+                      "input shapes, please use opset version 11 to " +
                       "export the model.")
         return self
 
     warnings.warn("This model contains a squeeze operation on dimension " + str(squeeze_dim) + ". If the model is " +
-                  "intended to be used with different input shapes than the shapes passed at export time, please " +
-                  "use opset version 11 to export the model.")
+                  "intended to be used with dynamic input shapes, please use opset version 11 to export the model.")
     return g.op("Squeeze", self, axes_i=[squeeze_dim])
 
 def prelu(g, self, weight):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -986,6 +986,12 @@ def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names):
                     value_dict[x] = str(key) + '_dynamic_axes_' + str(i + 1)
             dynamic_axes[key] = value_dict
 
+def _add_block(node, input_node, op_name, **kwargs):
+    new_block = node.addBlock()
+    new_node = new_block.addNode(input_node, op_name)
+    for k, v in kwargs.items():
+        _add_attribute(new_node, k, v, False)
+
 torch._C.Graph.op = _graph_op
 torch._C.Graph.at = _graph_at
 torch._C.Graph.constant = _graph_constant


### PR DESCRIPTION

The ONNX spec for the Squeeze operator:

> Remove single-dimensional entries from the shape of a tensor. Takes a parameter axes with a list of axes to squeeze. If axes is not provided, all the single dimensions will be removed from the shape. If an axis is selected with shape entry not equal to one, an error is raised.

Currently, as explained in issue #36796, it is possible to export such a model to ONNX, and this results in an exception from ONNX runtime.

Fixes #36796.