### PR TITLE
[aten] Split some at::launch code into at::internal::launch_no_thread_state()

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -128,6 +128,9 @@ CAFFE2_API int get_num_interop_threads();
 
 // Launches inter-op parallel task
 CAFFE2_API void launch(std::function<void()> func);
+namespace internal {
+  void launch_no_thread_state(std::function<void()> fn);
+} // namespace internal
 
 // Launches intra-op parallel task
 CAFFE2_API void intraop_launch(std::function<void()> func);

--- a/aten/src/ATen/ParallelThreadPoolNative.cpp
+++ b/aten/src/ATen/ParallelThreadPoolNative.cpp
@@ -67,21 +67,25 @@ int get_num_interop_threads() {
   }
 }
 
+namespace internal {
+void launch_no_thread_state(std::function<void()> fn) {
+#if AT_EXPERIMENTAL_SINGLE_THREAD_POOL
+  intraop_launch(std::move(fn));
+#else
+  get_pool().run(std::move(fn));
+#endif
+}
+} // namespace internal
+
 void launch(std::function<void()> func) {
-  auto fn = std::bind([](
+  internal::launch_no_thread_state(std::bind([](
     std::function<void()> f, ThreadLocalState thread_locals) {
       ThreadLocalStateGuard guard(std::move(thread_locals));
       f();
     },
     std::move(func),
     ThreadLocalState()
-  );
-
-#if AT_EXPERIMENTAL_SINGLE_THREAD_POOL
-  intraop_launch(std::move(fn));
-#else
-  get_pool().run(std::move(fn));
-#endif
+  ));
 }
 
 } // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38477 [aten] Split some at::launch code into at::internal::launch_no_thread_state()**

A few specific uses (e.g. Thrift rpc parsing) don't need source thread
state to be copied over. In microbenchmarks, this seems to add ~500ns,
so split code across functions, so some code can use directly.

Differential Revision: [D21573168](https://our.internmc.facebook.com/intern/diff/D21573168/)