### PR TITLE
Reduce number of Window test configurations

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -10,14 +10,13 @@ class WindowsJob:
         vscode_spec,
         cuda_version,
         force_on_cpu=False,
-        run_on_prs_pred=lambda job: job.vscode_spec.year != 2019,
+        master_only_pred=lambda job: job.vscode_spec.year != 2019,
     ):
-
         self.test_index = test_index
         self.vscode_spec = vscode_spec
         self.cuda_version = cuda_version
         self.force_on_cpu = force_on_cpu
-        self.run_on_prs_pred = run_on_prs_pred
+        self.master_only_pred = master_only_pred
 
     def gen_tree(self):
 
@@ -69,7 +68,7 @@ class WindowsJob:
             "requires": prerequisite_jobs,
         }
 
-        if self.run_on_prs_pred(self):
+        if self.master_only_pred(self):
             props_dict[
                 "filters"
             ] = cimodel.data.simple.util.branch_filters.gen_filter_dict()
@@ -113,28 +112,29 @@ class VcSpec:
     def render(self):
         return "_".join(filter(None, [self.prefixed_year(), self.dotted_version()]))
 
+def FalsePred(_):
+    return False
+
+def TruePred(_):
+    return True
 
 WORKFLOW_DATA = [
-    WindowsJob(None, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1)),
+    # VS2017 CUDA-10.1
+    WindowsJob(None, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1), master_only_pred=FalsePred),
     WindowsJob(1, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1)),
-    WindowsJob(2, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1)),
+    # VS2017 no-CUDA (builds only)
     WindowsJob(None, VcSpec(2017, ["14", "16"]), CudaVersion(10, 1)),
-    WindowsJob(1, VcSpec(2017, ["14", "16"]), CudaVersion(10, 1)),
-    WindowsJob(2, VcSpec(2017, ["14", "16"]), CudaVersion(10, 1)),
+    WindowsJob(None, VcSpec(2017, ["14", "16"]), None),
+    # VS2019 CUDA-10.1
     WindowsJob(None, VcSpec(2019), CudaVersion(10, 1)),
     WindowsJob(1, VcSpec(2019), CudaVersion(10, 1)),
     WindowsJob(2, VcSpec(2019), CudaVersion(10, 1)),
-    WindowsJob(None, VcSpec(2017, ["14", "11"]), None),
-    WindowsJob(1, VcSpec(2017, ["14", "11"]), None),
-    WindowsJob(2, VcSpec(2017, ["14", "11"]), None),
-    WindowsJob(None, VcSpec(2017, ["14", "16"]), None),
-    WindowsJob(1, VcSpec(2017, ["14", "16"]), None),
-    WindowsJob(2, VcSpec(2017, ["14", "16"]), None),
+    # VS2019 CPU-only
     WindowsJob(None, VcSpec(2019), None),
     WindowsJob(1, VcSpec(2019), None),
-    WindowsJob(2, VcSpec(2019), None),
+    WindowsJob(2, VcSpec(2019), None, master_only_pred=TruePred),
     WindowsJob(1, VcSpec(2019), CudaVersion(10, 1), force_on_cpu=True),
-    WindowsJob(2, VcSpec(2019), CudaVersion(10, 1), force_on_cpu=True),
+    WindowsJob(2, VcSpec(2019), CudaVersion(10, 1), force_on_cpu=True, master_only_pred=TruePred),
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7705,12 +7705,6 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2017-14-11-cuda10-cudnn7-py3
           cuda_version: "10"
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           name: pytorch_windows_vs2017_14.11_py36_cuda10.1_build
           python_version: "3.6"
           use_cuda: "1"
@@ -7736,25 +7730,6 @@ workflows:
           vc_product: BuildTools
           vc_version: "14.11"
           vc_year: "2017"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-11-cuda10-cudnn7-py3
-          cuda_version: "10"
-          executor: windows-with-nvidia-gpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.11_py36_cuda10.1_test2
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2017_14.11_py36_cuda10.1_build
-          test_name: pytorch-windows-test2
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.11"
-          vc_year: "2017"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2017-14-16-cuda10-cudnn7-py3
           cuda_version: "10"
@@ -7770,41 +7745,18 @@ workflows:
           vc_product: BuildTools
           vc_version: "14.16"
           vc_year: "2017"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-16-cuda10-cudnn7-py3
-          cuda_version: "10"
-          executor: windows-with-nvidia-gpu
+      - pytorch_windows_build:
+          build_environment: pytorch-win-vs2017-14-16-cpu-py3
+          cuda_version: cpu
           filters:
             branches:
               only:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2017_14.16_py36_cuda10.1_test1
+          name: pytorch_windows_vs2017_14.16_py36_cpu_build
           python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2017_14.16_py36_cuda10.1_build
-          test_name: pytorch-windows-test1
-          use_cuda: "1"
-          vc_product: BuildTools
-          vc_version: "14.16"
-          vc_year: "2017"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-16-cuda10-cudnn7-py3
-          cuda_version: "10"
-          executor: windows-with-nvidia-gpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.16_py36_cuda10.1_test2
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2017_14.16_py36_cuda10.1_build
-          test_name: pytorch-windows-test2
-          use_cuda: "1"
+          use_cuda: "0"
           vc_product: BuildTools
           vc_version: "14.16"
           vc_year: "2017"
@@ -7844,108 +7796,6 @@ workflows:
           vc_version: ""
           vc_year: "2019"
       - pytorch_windows_build:
-          build_environment: pytorch-win-vs2017-14-11-cpu-py3
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.11_py36_cpu_build
-          python_version: "3.6"
-          use_cuda: "0"
-          vc_product: BuildTools
-          vc_version: "14.11"
-          vc_year: "2017"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-11-cpu-py3
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.11_py36_cpu_test1
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2017_14.11_py36_cpu_build
-          test_name: pytorch-windows-test1
-          use_cuda: "0"
-          vc_product: BuildTools
-          vc_version: "14.11"
-          vc_year: "2017"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-11-cpu-py3
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.11_py36_cpu_test2
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2017_14.11_py36_cpu_build
-          test_name: pytorch-windows-test2
-          use_cuda: "0"
-          vc_product: BuildTools
-          vc_version: "14.11"
-          vc_year: "2017"
-      - pytorch_windows_build:
-          build_environment: pytorch-win-vs2017-14-16-cpu-py3
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.16_py36_cpu_build
-          python_version: "3.6"
-          use_cuda: "0"
-          vc_product: BuildTools
-          vc_version: "14.16"
-          vc_year: "2017"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-16-cpu-py3
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.16_py36_cpu_test1
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2017_14.16_py36_cpu_build
-          test_name: pytorch-windows-test1
-          use_cuda: "0"
-          vc_product: BuildTools
-          vc_version: "14.16"
-          vc_year: "2017"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-16-cpu-py3
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          name: pytorch_windows_vs2017_14.16_py36_cpu_test2
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2017_14.16_py36_cpu_build
-          test_name: pytorch-windows-test2
-          use_cuda: "0"
-          vc_product: BuildTools
-          vc_version: "14.16"
-          vc_year: "2017"
-      - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cpu-py3
           cuda_version: cpu
           name: pytorch_windows_vs2019_py36_cpu_build
@@ -7969,6 +7819,12 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
           cuda_version: cpu
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cpu_test2
           python_version: "3.6"
           requires:
@@ -7993,6 +7849,12 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10"
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test2
           python_version: "3.6"
           requires:

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -142,7 +142,7 @@ test_python_ge_config_legacy() {
   assert_git_not_dirty
 }
 
-test_python_all_except_nn() {
+test_python_all_except_nn_and_cpp_extensions() {
   time python test/run_test.py --exclude test_nn test_jit_profiling test_jit_legacy test_jit_fuser_legacy test_jit_fuser_te test_tensorexpr --verbose --determine-from="$DETERMINE_FROM"
   assert_git_not_dirty
 }
@@ -272,7 +272,7 @@ test_bazel() {
   tools/bazel test --test_output=all --test_tag_filters=-gpu-required --test_filter=-*CUDA :all_tests
 }
 
-test_cpp_extension() {
+test_cpp_extensions() {
   # This is to test whether cpp extension build is compatible with current env. No need to test both ninja and no-ninja build
   time python test/run_test.py --include test_cpp_extensions_aot_ninja --verbose --determine-from="$DETERMINE_FROM"
   assert_git_not_dirty
@@ -298,9 +298,10 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   echo "no-op at the moment"
 elif [[ "${BUILD_ENVIRONMENT}" == *-test1 || "${JOB_BASE_NAME}" == *-test1 ]]; then
   test_python_nn
+  test_cpp_extensions
 elif [[ "${BUILD_ENVIRONMENT}" == *-test2 || "${JOB_BASE_NAME}" == *-test2 ]]; then
   test_torchvision
-  test_python_all_except_nn
+  test_python_all_except_nn_and_cpp_extensions
   test_aten
   test_libtorch
   test_custom_script_ops
@@ -310,11 +311,12 @@ elif [[ "${BUILD_ENVIRONMENT}" == *-bazel-* ]]; then
 elif [[ "${BUILD_ENVIRONMENT}" == pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4* ]]; then
   # test cpp extension for xenial + cuda 9.2 + gcc 5.4 to make sure 
   # cpp extension can be built correctly under this old env 
-  test_cpp_extension
+  test_cpp_extensions
 else
   test_torchvision
   test_python_nn
-  test_python_all_except_nn
+  test_python_all_except_nn_and_cpp_extensions
+  test_cpp_extensions
   test_aten
   test_libtorch
   test_custom_script_ops


### PR DESCRIPTION
    After this diff, on PR following compilation configuration would be running:
     - VS2017 14.11, CUDA10.1
     - VS2017 no CUDA, CUDA10.1
     - VS2019, CUDA10.1
    And tested:
     - VS2017 14.11, CUDA10.1
     - VS2017 14.11 no CUDA (only 1st half of tests)
     - VS2017 14.11 force on CPU (only 1st half of test)
    
    And on master, we would be building both VS2017 14.11 and 14.16, but testing only VS2017 14.11 and VS2019 builds.
