### PR TITLE
skip test_torchbind_no_init on rocm

### DIFF
--- a/test/jit/test_torchbind.py
+++ b/test/jit/test_torchbind.py
@@ -240,6 +240,7 @@ class TestTorchbind(JitTestCase):
         mod = TorchBindOptionalExplicitAttr()
         scripted = torch.jit.script(mod)
 
+    @skipIfRocm
     def test_torchbind_no_init(self):
         with self.assertRaisesRegex(RuntimeError, 'torch::init'):
             x = torch.classes._TorchScriptTesting._NoInit()


### PR DESCRIPTION
CC @ezyang @xw285cornell 

Skip new test `test_torchbind_no_init` added by #37474 (0d220ef3810d1fa99e0dc18e426c1c89c3e4d00d).  This fixes ROCm CI.