### PR TITLE
Error out of default_collate for lists of unequal size

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1633,6 +1633,11 @@ except RuntimeError as e:
         arr = np.array([[[object(), object(), object()]]])
         self.assertRaises(TypeError, lambda: _utils.collate.default_collate(arr))
 
+    def test_default_collate_bad_sequence_type(self):
+        batch = [['X'], ['X', 'X']]
+        self.assertRaises(AssertionError, lambda: _utils.collate.default_collate(batch))
+        self.assertRaises(AssertionError, lambda: _utils.collate.default_collate(batch[::-1]))
+
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_default_collate_shared_tensor(self):
         import numpy as np
@@ -1730,6 +1735,7 @@ class TestDictDataLoader(TestCase):
         for sample in loader:
             self.assertTrue(sample['a_tensor'].is_pinned())
             self.assertTrue(sample['another_dict']['a_number'].is_pinned())
+
 
 
 class NamedTupleDataset(Dataset):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1737,7 +1737,6 @@ class TestDictDataLoader(TestCase):
             self.assertTrue(sample['another_dict']['a_number'].is_pinned())
 
 
-
 class NamedTupleDataset(Dataset):
     from collections import namedtuple
     Batch = namedtuple('Batch', ['data', 'label', 'random_tensor'])

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1635,8 +1635,8 @@ except RuntimeError as e:
 
     def test_default_collate_bad_sequence_type(self):
         batch = [['X'], ['X', 'X']]
-        self.assertRaises(AssertionError, lambda: _utils.collate.default_collate(batch))
-        self.assertRaises(AssertionError, lambda: _utils.collate.default_collate(batch[::-1]))
+        self.assertRaises(RuntimeError, lambda: _utils.collate.default_collate(batch))
+        self.assertRaises(RuntimeError, lambda: _utils.collate.default_collate(batch[::-1]))
 
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_default_collate_shared_tensor(self):

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -75,6 +75,10 @@ def default_collate(batch):
     elif isinstance(elem, tuple) and hasattr(elem, '_fields'):  # namedtuple
         return elem_type(*(default_collate(samples) for samples in zip(*batch)))
     elif isinstance(elem, container_abcs.Sequence):
+        it = iter(batch)
+        elem_size = len(next(it))
+        assert all(len(elem) == elem_size for elem in it), \
+            "each element in list of batch to be equal size"
         transposed = zip(*batch)
         return [default_collate(samples) for samples in transposed]
 

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -75,10 +75,11 @@ def default_collate(batch):
     elif isinstance(elem, tuple) and hasattr(elem, '_fields'):  # namedtuple
         return elem_type(*(default_collate(samples) for samples in zip(*batch)))
     elif isinstance(elem, container_abcs.Sequence):
+        # check to make sure that the elements in batch have consistent size
         it = iter(batch)
         elem_size = len(next(it))
-        assert all(len(elem) == elem_size for elem in it), \
-            "each element in list of batch to be equal size"
+        if not all(len(elem) == elem_size for elem in it):
+            raise RuntimeError('each element in list of batch should be of equal size')
         transposed = zip(*batch)
         return [default_collate(samples) for samples in transposed]
 


### PR DESCRIPTION
Fix issue https://github.com/pytorch/pytorch/issues/23141#

In the below example ```default_collate``` collates each element of the list. Since the second element isn't present in all samples, it is discarded:
```
from torch.utils.data import Dataset
from torch.utils.data import DataLoader
import numpy as np

class CustomDataset(Dataset):
    def __len__(self):
        return 2

    def __getitem__(self, idx):
        tmp = {
            "foo": np.array([1, 2, 3]),
            "bar": ["X"] * (idx+1),
        }

        return tmp

training = CustomDataset()

for batch in DataLoader(training, batch_size=2):
    print(batch)
```
Yields 
```
{
  'foo': tensor(
    [
      [1, 2, 3],
      [1, 2, 3]
    ]
  ),
  'bar': [
      ('X', 'X'),
    ]
}
```

Based on discussion in the issue, it seems the best course of action is to error out in this case. This seems consistent with what is done for tensor elements, as seen in [TensorShape.cpp line 1066](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/TensorShape.cpp#L1060) which is called when ```torch.stack``` is called. In this PR, I introduce a similar message to error out for lists.

@SsnL 