### PR TITLE
Do not call optimizations within freezing API

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -323,7 +323,6 @@ class TestFreezing(JitTestCase):
         output = m.forward(input)
         output_s = ms.forward(input)
         output_f = mf.forward(input)
-        print(output, " ", output_s, " ", output_f)
         # Should be equal
         self.assertNotEqual(output, output_s)
         self.assertEqual(output_s, output_f)

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -2,9 +2,8 @@
 #include <torch/csrc/jit/jit_log.h>
 
 #include <torch/csrc/jit/ir/alias_analysis.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/inliner.h>
-#include <torch/csrc/jit/runtime/graph_executor_impl.h>
-
 #include <stack>
 
 namespace torch {
@@ -19,7 +18,7 @@ class AttributePropagator {
   void run(std::shared_ptr<Graph>& graph) {
     Inline(*graph);
     propagateAttributes(graph);
-    runOptimization(graph, /* unroll? */ false);
+    EliminateDeadCode(graph);
     cleanupFrozenModule(graph);
   }
 


### PR DESCRIPTION
This patch removes call to run optimizations within freezing API.
Only dead code elimination is invoked to clean up the frozen module.

