### PR TITLE
[pytorch] fix -Wlogical-op-parentheses in SortingKthValue.cu

### DIFF
--- a/aten/src/ATen/native/cuda/SortingKthValue.cu
+++ b/aten/src/ATen/native/cuda/SortingKthValue.cu
@@ -73,8 +73,10 @@ __global__ void gatherKthValue(
     bool inRange = (i < inputSliceSize);
     scalar_t v = inRange ? doLdg(&inputSliceStart[i * inputWithinSliceStride])
                          : static_cast<scalar_t>(0);
-    bool isKValue = inRange && ((v == kValue)
-                    || THCNumerics<scalar_t>::isnan(v) && THCNumerics<scalar_t>::isnan(kValue));
+    bool isKValue = inRange &&
+        ((v == kValue) ||
+         (THCNumerics<scalar_t>::isnan(v) &&
+          THCNumerics<scalar_t>::isnan(kValue)));
     if (isKValue) {
       kValueIndex = i;
       foundKValue = true;


### PR DESCRIPTION
Summary:
Reported  by Clang:
```
caffe2/aten/src/ATen/native/cuda/SortingKthValue.cu:77:56: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
                    || THCNumerics<scalar_t>::isnan(v) && THCNumerics<scalar_t>::isnan(kValue));
                    ~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
caffe2/aten/src/ATen/native/cuda/SortingKthValue.cu:77:56: note: place parentheses around the '&&' expression to silence this warning
                    || THCNumerics<scalar_t>::isnan(v) && THCNumerics<scalar_t>::isnan(kValue));
                                                       ^
                       (                                                                      )
```

Test Plan:
```
buck build mode/opt -c fbcode.cuda_use_clang=true fblearner/flow/projects/dper:workflow
```

Differential Revision: D21578871

