### PR TITLE
change to find_method of lite_interpreter API to return nullptr if method not found

### DIFF
--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -49,6 +49,9 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
 #endif
 
   auto m = find_method(method_name);
+  if (m == nullptr) {
+    AT_ERROR("Method '", method_name, "' is not defined.");
+  }
   stack.insert(stack.begin(), object_);
   m->run(stack);
   c10::IValue result = stack.front();
@@ -67,7 +70,7 @@ Function* Module::find_method(const std::string& basename) const {
       return fn.get();
     }
   }
-  AT_ERROR("Method '", basename, "' is not defined.");
+  return nullptr;
 }
 
 namespace {


### PR DESCRIPTION
Summary:
Modify find_method to not error out if method doesn't
exist to be more similar to:
https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/api/object.h#L100

Test Plan: run functions as part of mobile ASR

Reviewed By: iseeyuan

Differential Revision: D21466638

