### PR TITLE
[quantization] Switch quantization serialized size solution

### DIFF
--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -90,7 +90,7 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
-        self._all_params = ([m.param for m in _all_weight_values])
+        self._all_weight_values = torch.nn.ModuleList(_all_weight_values)
 
     def _get_name(self):
         return 'DynamicQuantizedRNN'
@@ -254,7 +254,7 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
-        qRNNBase._all_params = ([m.param for m in _all_weight_values])
+        qRNNBase._all_weight_values = torch.nn.ModuleList(_all_weight_values)
 
         return qRNNBase
 
@@ -286,12 +286,13 @@ class LSTM(RNNBase):
 
         self.check_forward_args(input, hx, batch_sizes)
 
+        _all_params = ([m.param for m in self._all_weight_values])
         if batch_sizes is None:
-            result = torch.quantized_lstm(input, hx, self._all_params, self.bias, self.num_layers,
+            result = torch.quantized_lstm(input, hx, _all_params, self.bias, self.num_layers,
                                           float(self.dropout), self.training, self.bidirectional,
                                           self.batch_first, dtype=self.dtype, use_dynamic=True)
         else:
-            result = torch.quantized_lstm(input, batch_sizes, hx, self._all_params, self.bias,
+            result = torch.quantized_lstm(input, batch_sizes, hx, _all_params, self.bias,
                                           self.num_layers, float(self.dropout), self.training,
                                           self.bidirectional, dtype=self.dtype, use_dynamic=True)
         output = result[0]

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -254,7 +254,6 @@ class RNNBase(torch.nn.Module):
                         packed_ih, packed_hh)
 
                 _all_weight_values.append(PackedParameter(cell_params))
-        qRNNBase._all_weight_values = torch.nn.ModuleList(_all_weight_values)
         qRNNBase._all_params = ([m.param for m in _all_weight_values])
 
         return qRNNBase


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38504 Remove _all_weight_values again**

The original fix caused tracing of RNNs to fail because the TorchBind objects need to be exposed to the module/attribute hierarchy for trace value lifting to work

Differential Revision: [D21579530](https://our.internmc.facebook.com/intern/diff/D21579530)