### PR TITLE
[quant] Support empty batch input for quantized ops

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_adaavgpool.cpp
@@ -94,7 +94,8 @@ static void adaptive_avg_pool2d_single_out_frame(
 std::vector<int64_t> get_output_shape(
     const Tensor& input,
     IntArrayRef output_size) {
-  for (int64_t i = 0; i < input.dim(); i++) {
+  for (int64_t i = 1; i < input.dim(); i++) {
+    // Allow for empty batch.
     TORCH_CHECK(
         input.size(i) > 0,
         "adaptive_avg_pooling2d(): expected input to have non-empty spatial "

--- a/aten/src/ATen/native/quantized/cpu/qclamp.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qclamp.cpp
@@ -26,7 +26,10 @@ Tensor qnnpack_clamp(Tensor input, Scalar min, Scalar max) {
   initQNNPACK();
 
   Tensor input_contig = input.contiguous(input.suggest_memory_format());
-  size_t num_elems = input_contig.numel() / input_contig.size(0);
+  size_t num_elems = 1;
+  for (int i = 1; i < input_contig.ndimension(); ++i) {
+    num_elems *= input_contig.size(i);
+  }
 
   auto min_f = min.to<float>();
   auto max_f = max.to<float>();

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -326,15 +326,16 @@ at::Tensor PackedConvWeight<kSpatialDim>::apply_impl(
 
   const at::SmallVector<int64_t, kSpatialDim + 2> output_shape =
       MakeConvOutputShape<kSpatialDim>(N, M, conv_p.OUT_DIM);
-  TORCH_CHECK(
-      std::all_of(
-          output_shape.begin(),
-          output_shape.end(),
-          [](int64_t i) { return i > 0; }),
-      "[QConv",
-      kSpatialDim,
-      "D] each dimension of output tensor should be greater than 0");
-
+  if (N > 0) {
+    TORCH_CHECK(
+        std::all_of(
+            output_shape.begin(),
+            output_shape.end(),
+            [](int64_t i) { return i > 0; }),
+        "[QConv",
+        kSpatialDim,
+        "D] each dimension of output tensor should be greater than 0");
+  }
   at::Tensor output = kSpatialDim == 2
       ? at::_empty_affine_quantized(
             output_shape,

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -124,7 +124,7 @@ Tensor q_maxpool_2d(
   int64_t iW = qx.size(dimw);
   TORCH_CHECK(iC > 0 && iH > 0 && iW > 0, "input dimensions must be non-zero.");
   TORCH_CHECK(
-      qx.numel() > 0 && (ndim == 3 || ndim == 4),
+      (ndim == 3 || ndim == 4),
       "non-empty 3D or 4D input tensor is expected.");
   TORCH_CHECK(
       kH / 2 >= pH && kW / 2 >= pW,

--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -30,17 +30,15 @@ Tensor qnnpack_relu(Tensor input) {
 
   initQNNPACK();
 
-  size_t volume = input_contig.numel();
-
-  size_t num_elems_x = 1;
+  size_t num_elems = 1;
   for (int i = 1; i < input_contig.ndimension(); ++i) {
-    num_elems_x *= input_contig.size(i);
+    num_elems *= input_contig.size(i);
   }
 
   pytorch_qnnp_operator_t qnnpack_operator{nullptr};
 
   const pytorch_qnnp_status createStatus = pytorch_qnnp_create_clamp_nc_u8(
-      num_elems_x /* channels */,
+      num_elems /* channels */,
       zero_point /* output min */,
       std::numeric_limits<uint8_t>::max() /* output max */,
       0 /* flags */,
@@ -59,15 +57,13 @@ Tensor qnnpack_relu(Tensor input) {
       input_contig.q_scale(),
       input_contig.q_zero_point());
 
-  size_t num_elems_y = volume / qy.size(0);
-
   const pytorch_qnnp_status setupStatus = pytorch_qnnp_setup_clamp_nc_u8(
       qnnpack_operator, /* clamp */
       input_contig.size(0) /* batch size */,
       (uint8_t*)input_contig.data_ptr<c10::quint8>() /* input data */,
-      num_elems_x /* input stride */,
+      num_elems /* input stride */,
       (uint8_t*)qy.data_ptr<c10::quint8>() /* output data */,
-      num_elems_y /* output stride */);
+      num_elems /* output stride */);
   TORCH_INTERNAL_ASSERT(
       setupStatus == pytorch_qnnp_status_success,
       "failed to setup QNNPACK Relu operator");

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -29,7 +29,10 @@ Tensor qnnpack_sigmoid(Tensor input) {
   initQNNPACK();
 
   Tensor input_contig = input.contiguous();
-  size_t num_elems = input_contig.numel() / input_contig.size(0);
+  size_t num_elems = 1;
+  for (int i = 1; i < input_contig.ndimension(); ++i) {
+    num_elems *= input_contig.size(i);
+  }
 
   const auto zero_point = input_contig.q_zero_point();
   const auto scale = input_contig.q_scale();

--- a/aten/src/ATen/native/quantized/cpu/qtanh.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qtanh.cpp
@@ -28,8 +28,10 @@ Tensor qnnpack_tanh(Tensor input) {
   initQNNPACK();
 
   Tensor input_contig = input.contiguous();
-  size_t num_elems = input_contig.numel() / input_contig.size(0);
-
+  size_t num_elems = 1;
+  for (int i = 1; i < input_contig.ndimension(); ++i) {
+    num_elems *= input_contig.size(i);
+  }
   const auto zero_point = input_contig.q_zero_point();
   const auto scale = input_contig.q_scale();
 

--- a/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_bilinear2d.cpp
@@ -102,7 +102,7 @@ Tensor quantized_upsample_bilinear2d_cpu(
       output_size.size());
 
   TORCH_CHECK(
-      input.numel() != 0 && input.dim() == 4,
+      input.dim() == 4,
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 

--- a/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qupsample_nearest2d.cpp
@@ -106,7 +106,7 @@ Tensor quantized_upsample_nearest2d_cpu(
       output_size.size());
 
   TORCH_CHECK(
-      input.numel() != 0 && input.dim() == 4,
+      input.dim() == 4,
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -1899,13 +1899,13 @@ class TestQuantizedOps(TestCase):
         np.testing.assert_equal(qY.size(), (0, 2, 3, 3),
                                 "Quantized adaptive_avg_pool2d with batch size 0 failed.")
 
-        #max_pool
+        # max_pool
         dilation = (1, 1)
         qY = torch.ops.quantized.max_pool2d(qX, kernel, stride, padding, dilation, ceil_mode=False)
         oH = pool_output_shape(4, 2, 0, 1, 1)
         oW = pool_output_shape(4, 2, 0, 1, 1)
         np.testing.assert_equal(qY.size(), (0, 2, oH, oW),
-                                    "Quantized maxpool2d with batch size 0 failed.")
+                                "Quantized maxpool2d with batch size 0 failed.")
 
         # hardtanh
         qY = torch.nn.quantized.functional.hardtanh(qX, -1, 6)

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -1856,6 +1856,93 @@ class TestQuantizedOps(TestCase):
                     qy.int_repr().numpy(), quantize_ref.int_repr().numpy(),
                     message="{} vs {}".format(qy, quantize_ref))
 
+    @override_qengines
+    def test_empty_batch(self):
+        scale = 1.0
+        zero_point = 0
+        X = torch.ones((0, 2, 4, 4), dtype=torch.float32)
+        qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                       dtype=torch.quint8)
+        # relu
+        qY = torch.nn.functional.relu(qX)
+        np.testing.assert_equal(qY.size(), qX.size(),
+                                "Quantized relu with batch size 0 failed.")
+
+        # tanh
+        qY = torch.tanh(qX)
+        np.testing.assert_equal(qY.size(), qX.size(),
+                                "Quantized tanh with batch size 0 failed.")
+        # sigmoid
+        qY = torch.sigmoid(qX)
+        np.testing.assert_equal(qY.size(), qX.size(),
+                                "Quantized sigmoid with batch size 0 failed.")
+
+        # interpolate
+        op = torch.nn.quantized.functional.interpolate
+        for mode in ["nearest", "bilinear"]:
+            qY = op(qX, scale_factor=2, mode=mode)
+            np.testing.assert_equal(qY.size(), (0, 2, 8, 8),
+                                    "Quantized interpolate with batch size 0 failed.")
+
+        # avg_pool
+        kernel = (2, 2)
+        stride = (1, 1)
+        padding = (0, 0)
+        op = torch.nn.quantized.functional.avg_pool2d
+        qY = op(qX, kernel, stride, padding)
+        np.testing.assert_equal(qY.size(), (0, 2, 3, 3),
+                                "Quantized avg_pool2d with batch size 0 failed.")
+
+        # adaptive_avg_pool
+        op = torch.nn.quantized.functional.adaptive_avg_pool2d
+        qY = op(qX, (3, 3))
+        np.testing.assert_equal(qY.size(), (0, 2, 3, 3),
+                                "Quantized adaptive_avg_pool2d with batch size 0 failed.")
+
+        #max_pool
+        dilation = (1, 1)
+        qY = torch.ops.quantized.max_pool2d(qX, kernel, stride, padding, dilation, ceil_mode=False)
+        oH = pool_output_shape(4, 2, 0, 1, 1)
+        oW = pool_output_shape(4, 2, 0, 1, 1)
+        np.testing.assert_equal(qY.size(), (0, 2, oH, oW),
+                                    "Quantized maxpool2d with batch size 0 failed.")
+
+        # hardtanh
+        qY = torch.nn.quantized.functional.hardtanh(qX, -1, 6)
+        np.testing.assert_equal(qY.size(), qX.size(),
+                                "Quantized hardtanh with batch size 0 failed.")
+
+        # mul
+        qY = torch.ops.quantized.mul(qX, qX, 1.0, 0)
+        np.testing.assert_equal(qY.size(), qX.size(),
+                                "Quantized mul with batch size 0 failed.")
+        # add
+        qY = torch.ops.quantized.add(qX, qX, 1.0, 0)
+        np.testing.assert_equal(qY.size(), qX.size(),
+                                "Quantized addition with batch size 0 failed.")
+
+        # conv
+        w = torch.randn((2, 2, 2, 2), dtype=torch.float)
+        qw = torch.quantize_per_tensor(w, scale=1.0, zero_point=0, dtype=torch.qint8)
+        bias_float = torch.ones(2, dtype=torch.float)
+        strides = [1, 1]
+        pads = [0, 0]
+        dilations = [1, 1]
+
+        w_packed = torch.ops.quantized.conv2d_prepack(qw, bias_float, strides, pads, dilations, 1)
+        result = torch.ops.quantized.conv2d(qX, w_packed, 1.0, 0)
+        self.assertEqual(result.shape, (0, 2, 3, 3))
+
+        # linear
+        X = torch.ones((0, 2), dtype=torch.float32)
+        qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                       dtype=torch.quint8)
+        w = torch.randn((2, 2), dtype=torch.float)
+        qw = torch.quantize_per_tensor(w, scale=1.0, zero_point=0, dtype=torch.qint8)
+        w_packed = torch.ops.quantized.linear_prepack(qw, bias_float)
+        result = torch.ops.quantized.linear(qX, w_packed, 1.0, 0)
+        self.assertEqual(result.shape, (0, 2))
+
 class TestDynamicQuantizedLinear(TestCase):
     """Tests the correctness of the dynamic quantized linear and linear_relu op."""
     @given(
@@ -2897,13 +2984,6 @@ class TestQNNPackOps(TestCase):
             np.testing.assert_equal(qCrelu.int_repr().numpy(), qCrelu_hat.int_repr(),
                                     "Quantized addition with ReLU failed.")
 
-            A = torch.ones((0, 2), dtype=torch.float32)
-            qA = torch.quantize_per_tensor(A, scale=scale_A, zero_point=zero_point_A,
-                                           dtype=torch.quint8)
-            qC = torch.ops.quantized.add(qA, qA, scale_C, zero_point_C)
-            np.testing.assert_equal(qC.size(), qA.size(),
-                                    "Quantized addition with batch size 0 failed.")
-
     """Tests the correctness of quantized::qnnpack_maxpool2d op."""
     @given(A=hu.tensor(shapes=hu.array_shapes(4, 4, 3, 5),
                        qparams=hu.qparams(dtypes=torch.quint8)),
@@ -2951,15 +3031,6 @@ class TestQNNPackOps(TestCase):
 
             qa_pool_int = qa_pool.dequantize()
             np.testing.assert_equal(a_pool.numpy(), qa_pool_int.numpy())
-
-            A = torch.ones((0, 2, 4, 4), dtype=torch.float32)
-            qa = torch.quantize_per_tensor(A, scale=scale, zero_point=zero_point,
-                                           dtype=torch_type)
-            qc = q_max_pool(qa, k, s, p, d, ceil_mode=False)
-            oH = pool_output_shape(4, kernel, padding, stride, dilation)
-            oW = pool_output_shape(4, kernel, padding, stride, dilation)
-            np.testing.assert_equal(qc.size(), (0, 2, oH, oW),
-                                    "Quantized maxpool2d with batch size 0 failed.")
 
     @given(batch_size=st.integers(1, 5),
            channels=st.sampled_from([2, 4, 5, 8, 16, 32]),
@@ -3111,22 +3182,6 @@ class TestQNNPackOps(TestCase):
             self.assertEqual(
                 qY, qY_hat,
                 message="hardtanh failed:\nactual {}\nexpected {}".format(qY_hat, qY))
-
-    def test_qconv_empty_batch(self):
-        with override_quantized_engine('qnnpack'):
-            a = torch.ones((0, 2, 4, 4), dtype=torch.float32)
-            qa = torch.quantize_per_tensor(a, scale=1.0, zero_point=0,
-                                           dtype=torch.quint8)
-            w = torch.randn((2, 2, 2, 2), dtype=torch.float)
-            qw = torch.quantize_per_tensor(w, scale=1.0, zero_point=0, dtype=torch.qint8)
-            bias_float = torch.ones(2, dtype=torch.float)
-            strides = [1, 1]
-            pads = [0, 0]
-            dilations = [1, 1]
-
-            w_packed = torch.ops.quantized.conv2d_prepack(qw, bias_float, strides, pads, dilations, 1)
-            result = torch.ops.quantized.conv2d(qa, w_packed, 1.0, 0)
-            self.assertEqual(result.shape, (0, 2, 3, 3))
 
 """Tests the correctness of the tensor comparators."""
 class TestComparatorOps(TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38508 [quant] Support empty batch input for quantized ops**

Summary:

Test Plan:
python test/test_quantization.py TestQuantizedOps.test_empty_batch

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21581937](https://our.internmc.facebook.com/intern/diff/D21581937)