### PR TITLE
[dper][pruning] add histogram op

### DIFF
--- a/caffe2/operators/histogram_op.cc
+++ b/caffe2/operators/histogram_op.cc
@@ -1,0 +1,30 @@
+#include "caffe2/operators/histogram_op.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(Histogram, HistogramOp<CPUContext>);
+OPERATOR_SCHEMA(Histogram)
+    .NumInputs(1, INT_MAX)
+    .NumOutputs(1)
+    .SetDoc(
+        R"DOC(
+            Computes a histogram for values in the given list of tensors.
+            For logging activation histograms for post-hoc analyses, consider using the
+            HistogramObserver observer.
+            For iteratively computing a histogram for all input tensors encountered through
+            history, consider using the AccumulateHistogram operator.
+            )DOC")
+    .Input(0, "X1, X2, ...", "*(type: Tensor`<float>`)* List of input tensors.")
+    .Output(
+        0,
+        "histogram",
+        "1D tensor of length k, wherein the i-th element expresses the count of tensor values "
+        "that fall within range [bin_edges[i], bin_edges[i + 1])")
+    .Arg(
+        "bin_edges",
+        "length-(k + 1) sequence of float values wherein the i-th element represents the inclusive "
+        "left boundary of the i-th bin for i in [0, k - 1] and the exclusive right boundary "
+        "of the (i-1)-th bin for i in [1, k].");
+
+SHOULD_NOT_DO_GRADIENT(Histogram);
+} // namespace caffe2

--- a/caffe2/operators/histogram_op.h
+++ b/caffe2/operators/histogram_op.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+template <class Context>
+class HistogramOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  template <class... Args>
+  explicit HistogramOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        bin_edges_(this->template GetRepeatedArgument<float>("bin_edges")) {
+    CAFFE_ENFORCE_GE(
+        bin_edges_.size(),
+        2,
+        "Number of bin edges must be greater than or equal to 2.");
+    for (int i = 1; i < bin_edges_.size(); i++) {
+      CAFFE_ENFORCE_GT(
+          bin_edges_[i],
+          bin_edges_[i - 1],
+          "bin_edges must be a strictly increasing sequence of values.");
+    }
+  }
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<float, double>>::call(this, Input(0));
+  }
+
+  template <typename T>
+  bool DoRunWithType() {
+    CheckInputs();
+
+    const auto* histogram = Output(HISTOGRAM);
+    histogram->Resize(bin_edges_.size() - 1);
+    auto* histogram_data = histogram->template mutable_data<int64_t>();
+    math::Set<int64_t, Context>(
+        bin_edges_.size() - 1, 0, histogram_data, &context_);
+
+    for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+      const auto& x = Input(input_idx);
+      const int64_t N = x.numel();
+      const auto* x_data = x.template data<T>();
+      for (int data_idx = 0; data_idx < N; data_idx++) {
+        const int bisection_idx = BisectBinEdges(x_data[data_idx]);
+        if (bisection_idx > 0 && bisection_idx < bin_edges_.size()) {
+          histogram_data[bisection_idx - 1]++;
+        }
+      }
+    }
+
+    return true;
+  }
+
+ protected:
+  OUTPUT_TAGS(HISTOGRAM);
+
+ private:
+  vector<float> bin_edges_;
+
+  void CheckInputs() {
+    const auto& input_zero = Input(0);
+    for (int i = 1; i < InputSize(); i++) {
+      CAFFE_ENFORCE_EQ(
+          Input(i).dtype(),
+          input_zero.dtype(),
+          "All inputs must have the same type; expected ",
+          input_zero.dtype().name(),
+          " but got ",
+          Input(i).dtype().name(),
+          " for input ",
+          i);
+    }
+  }
+
+  template <typename T>
+  int BisectBinEdges(const T& value) {
+    int hi = bin_edges_.size();
+    int lo = 0;
+    while (lo < hi) {
+      int mid = (hi + lo) / 2;
+      if (value < bin_edges_[mid]) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return lo;
+  }
+};
+
+} // namespace caffe2

--- a/caffe2/python/operator_test/histogram_test.py
+++ b/caffe2/python/operator_test/histogram_test.py
@@ -1,0 +1,68 @@
+import unittest
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, workspace
+from hypothesis import given
+
+
+class TestHistogram(hu.HypothesisTestCase):
+    @given(rows=st.integers(1, 1000), cols=st.integers(1, 1000), **hu.gcs)
+    def test_histogram__device_consistency(self, rows, cols, gc, dc):
+        X = np.random.rand(rows, cols)
+        bin_edges = list(np.linspace(-2, 10, num=10000))
+        op = core.CreateOperator("Histogram", ["X"], ["histogram"], bin_edges=bin_edges)
+        self.assertDeviceChecks(dc, op, [X], [0])
+
+    @given(num_tensors=st.integers(1, 5), num_bins=st.integers(2, 10000))
+    def test_histogram__valid_inputs(self, num_tensors, num_bins):
+        self._test_histogram(
+            [
+                np.random.rand(np.random.randint(1, 1000), np.random.randint(1, 1000))
+                for __ in range(num_tensors)
+            ],
+            list(np.logspace(-12, 5, num=num_bins)),
+        )
+
+    def test_histogram__empty_input_tensor(self):
+        self._test_histogram([np.array([])], list(np.linspace(-2, 2, num=10)))
+
+    def test_histogram__non_increasing_bin_edges(self):
+        with self.assertRaisesRegex(
+            RuntimeError, "bin_edges must be a strictly increasing sequence of values"
+        ):
+            self._test_histogram(
+                [np.random.rand(100), np.random.rand(98)], [0.0, 0.2, 0.1, 0.1]
+            )
+
+    def test_histogram__insufficient_bin_edges(self):
+        with self.assertRaisesRegex(
+            RuntimeError, "Number of bin edges must be greater than or equal to 2"
+        ):
+            self._test_histogram([np.random.rand(111)], [1.0])
+
+    def _test_histogram(self, tensors, bin_edges):
+        total_size = 0
+        input_blob_names = []
+
+        for idx, tensor in enumerate(tensors):
+            total_size += np.size(tensor)
+            tensor_blob_name = f"X{idx}"
+            workspace.FeedBlob(tensor_blob_name, tensor)
+            input_blob_names.append(tensor_blob_name)
+
+        output_name = "histogram"
+        net = core.Net("test_net")
+        net.Histogram(input_blob_names, [output_name], bin_edges=bin_edges)
+
+        workspace.RunNetOnce(net)
+        histogram_blob = workspace.FetchBlob(output_name)
+        assert np.size(histogram_blob) == len(bin_edges) - 1
+        assert np.sum(histogram_blob) == total_size
+
+
+if __name__ == "__main__":
+    global_options = ["caffe2"]
+    core.GlobalInit(global_options)
+    unittest.main()


### PR DESCRIPTION
Summary: this diff introduces the `Histogram` caffe2 op, which computes a histogram tensor for a list of input tensors. the bin edges of the histogram are defined by arg `bin_edges`.

Test Plan: tests

Differential Revision: D21553956

