### PR TITLE
Avoid Releasing, Reacquiring lock per iteration in RPC Retry Thread

### DIFF
--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -148,6 +148,12 @@ void RpcAgent::retryExpiredRpcs() {
       it = earliestRpcList.erase(it);
     }
 
+    // If there are no more RPC's set to be retried at the current timepoint,
+    // we can remove the corresponsing unordered_set from the retry map.
+    if (earliestRpcList.empty()) {
+      rpcRetryMap_.erase(earliestTimeout);
+    }
+
     lock.unlock();
     // We attach callbacks to the futures outside of the lock to prevent
     // potential deadlocks.
@@ -178,15 +184,6 @@ void RpcAgent::retryExpiredRpcs() {
       errorFuture->setError(errorMsg);
     }
     errorFutures.clear();
-
-    // If there are no more RPC's set to be retried at the current timepoint,
-    // we can remove the corresponsing unordered_set from the retry map.
-    {
-      std::lock_guard<std::mutex> retryMapLock(rpcRetryMutex_);
-      if (earliestRpcList.empty()) {
-        rpcRetryMap_.erase(earliestTimeout);
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38521 Avoid Releasing, Reacquiring lock per iteration in RPC Retry Thread**

In the RPC Retry Thread, we add retriable futures to a list under the lock, release the lock, add callbacks/set errors to those futures, then re-acquire the lock to clean up the retry map. We can simply clean up the retry map before releasing the lock and not acquire it again - this would be cleaner and may results in better perf if this reduces context switching between threads looking to acquire the retryMapLock.

Differential Revision: [D21563085](https://our.internmc.facebook.com/intern/diff/D21563085/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D21563085/)!