### PR TITLE
[JIT] Allow @torch.jit.unused to be used on TS classes

### DIFF
--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -16,7 +16,7 @@ from torch._C._jit_tree_views import (
 )
 from torch._utils_internal import get_source_lines_and_file
 
-from torch._jit_internal import SourceContext
+from torch._jit_internal import SourceContext, should_drop
 
 # Borrowed from cPython implementation
 # https://github.com/python/cpython/blob/561612d8456cfab5672c9b445521113b847bd6b3/Lib/textwrap.py#L411#
@@ -165,7 +165,14 @@ def get_jit_def(fn, def_name, self_name=None):
     leading_whitespace_len = len(source.split('\n', 1)[0]) - len(dedent_src.split('\n', 1)[0])
     type_line = torch.jit.annotations.get_type_line(source)
     ctx = SourceContext(source, filename, file_lineno, leading_whitespace_len, True)
-    return build_def(ctx, py_ast.body[0], type_line, def_name, self_name=self_name)
+    fn_def = py_ast.body[0]
+
+    # Swap out the function body if it is unused
+    if should_drop(fn):
+        unused_fn_def = ast.parse("def unused_fn(self):\n\traise RuntimeError(\"Cannot call @unused methods\")").body[0]
+        fn_def.body = unused_fn_def.body
+
+    return build_def(ctx, fn_def, type_line, def_name, self_name=self_name)
 
 
 class Builder(object):


### PR DESCRIPTION
**Summary**
This commit enables the use of `@torch.jit.unused` on methods of TorchScript classes.
This attribute is honoured by replacing the body of any method
marked as unused in the parsed AST for the class with `raise Exception(...)`.

**Test Plan**
This commit adds a unit test `TestClassType.test_unused_method` that
tests this feature.

