### PR TITLE
.circleci: Move ecr gc build job to ecr gc workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6782,7 +6782,6 @@ workflows:
               only:
                 - master
     jobs:
-      - docker_for_ecr_gc_build_job
       - docker_build_job:
           name: "pytorch-linux-bionic-cuda10.2-cudnn7-py3.8-gcc9"
           image_name: "pytorch-linux-bionic-cuda10.2-cudnn7-py3.8-gcc9"
@@ -6849,22 +6848,31 @@ workflows:
               only:
                 - master
     jobs:
+      - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_pytorch
             project: pytorch
             tags_to_keep: "271,262,256,278,282,291,300,323,327,347,389,401,402,403,405,a8006f9a-272d-4478-b137-d121c6f05c83,6e7b11da-a919-49e5-b2ba-da66e3d4bb0a,f990c76a-a798-42bb-852f-5be5006f8026,e43973a9-9d5a-4138-9181-a08a0fc55e2f,8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59,9a3986fa-7ce7-4a36-a001-3c9bef9892e2,1bc00f11-e0f3-4e5c-859f-15937dd938cd,209062ef-ab58-422a-b295-36c4eed6e906,07c4e7dc-5584-4093-ad15-ce98345eef9d"
+            requires:
+              - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_caffe2
             project: caffe2
             tags_to_keep: "376,373,369,348,345,336,325,324,315,306,301,287,283,276,273,266,253,248,238,230,213"
+            requires:
+              - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_translate
             project: translate
             tags_to_keep: "8"
+            requires:
+              - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_tensorcomp
             project: tensorcomp
             tags_to_keep: "34"
+            requires:
+              - docker_for_ecr_gc_build_job
       - docker_hub_index_job
   # Promotion workflow
   promote:

--- a/.circleci/verbatim-sources/workflows/workflows-docker-builder.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-docker-builder.yml
@@ -7,7 +7,6 @@
               only:
                 - master
     jobs:
-      - docker_for_ecr_gc_build_job
       - docker_build_job:
           name: "pytorch-linux-bionic-cuda10.2-cudnn7-py3.8-gcc9"
           image_name: "pytorch-linux-bionic-cuda10.2-cudnn7-py3.8-gcc9"

--- a/.circleci/verbatim-sources/workflows/workflows-ecr-gc.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-ecr-gc.yml
@@ -7,20 +7,29 @@
               only:
                 - master
     jobs:
+      - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_pytorch
             project: pytorch
             tags_to_keep: "271,262,256,278,282,291,300,323,327,347,389,401,402,403,405,a8006f9a-272d-4478-b137-d121c6f05c83,6e7b11da-a919-49e5-b2ba-da66e3d4bb0a,f990c76a-a798-42bb-852f-5be5006f8026,e43973a9-9d5a-4138-9181-a08a0fc55e2f,8fcf46ef-4a34-480b-a8ee-b0a30a4d3e59,9a3986fa-7ce7-4a36-a001-3c9bef9892e2,1bc00f11-e0f3-4e5c-859f-15937dd938cd,209062ef-ab58-422a-b295-36c4eed6e906,07c4e7dc-5584-4093-ad15-ce98345eef9d"
+            requires:
+              - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_caffe2
             project: caffe2
             tags_to_keep: "376,373,369,348,345,336,325,324,315,306,301,287,283,276,273,266,253,248,238,230,213"
+            requires:
+              - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_translate
             project: translate
             tags_to_keep: "8"
+            requires:
+              - docker_for_ecr_gc_build_job
       - ecr_gc_job:
             name: ecr_gc_job_for_tensorcomp
             project: tensorcomp
             tags_to_keep: "34"
+            requires:
+              - docker_for_ecr_gc_build_job
       - docker_hub_index_job


### PR DESCRIPTION
It didn't really make sense for it to be where it was and seeing how the
build only actually takes about 5 minutes to do it'd be best to just
move it into the garbage collection workflow.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

