### PR TITLE
[JIT] Remove debug print statement added in #37994

### DIFF
--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -127,7 +127,6 @@ def get_jit_class_def(cls, self_name):
     # TODO: proper overriding analysis when implementing class inheritance
     methods = inspect.getmembers(
         cls, predicate=lambda m: (inspect.ismethod(m) or inspect.isfunction(m)) and m.__name__ in cls.__dict__)
-    print(methods)
 
     method_defs = [get_jit_def(method[1],
                                method[0],


### PR DESCRIPTION
**Summary**
This commit removes a print statement added in #37994 that appears to
be for debugging and was most likely not intended to be commited.

**Test Plan**
Continuous integration.

