### PR TITLE
cover nn.Conv1d in mkldnn model conversion logic

### DIFF
--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -104,6 +104,29 @@ class TestMkldnn(TestCase):
         self.assertTrue("layout=torch._mkldnn" in str(torch.randn((1, 2, 3, 4),
                                                                   dtype=torch.float, device=torch.device('cpu')).to_mkldnn()))
 
+    def test_conv1d(self):
+        for groups in [1, 4]:
+            N = torch.randint(3, 10, (1,)).item()
+            C = torch.randint(1, 3, (1,)).item() * groups
+            M = torch.randint(1, 3, (1,)).item() * groups
+            x = torch.randn(N, C, 224, dtype=torch.float32)
+            for bias in [True, False]:
+                conv1d = torch.nn.Conv1d(in_channels=C,
+                                         out_channels=M,
+                                         kernel_size=3,
+                                         stride=2,
+                                         padding=1,
+                                         bias=bias,
+                                         groups=groups).float()
+                mkldnn_conv1d = mkldnn_utils.to_mkldnn(copy.deepcopy(conv1d))
+                with torch.backends.mkldnn.flags(enabled=False):
+                    y_aten = conv1d(x)
+                y_mkldnn = mkldnn_conv1d(x.to_mkldnn()).to_dense()
+                self.assertEqual(y_aten, y_mkldnn)
+
+                self._test_serialization(mkldnn_conv1d, (x.to_mkldnn(),))
+                self._test_tracing(mkldnn_conv1d, (x.to_mkldnn(),))
+
     def test_conv2d(self):
         for groups in [1, 4]:
             N = torch.randint(3, 10, (1,)).item()


### PR DESCRIPTION
current `to_mkldnn` model conversion logic under `torch.utils.mkldnn` does not cover `nn.Conv1d`. This patch fills the gap, using similar logic to `nn.Conv2d`. The model conversion will remove unnecessary memory format reorders of input/output tensors and thus speedup the model.