### PR TITLE
Add SymbolicShape and replace all uses of VaryingShape<ShapeSymbol> with it

### DIFF
--- a/torch/csrc/jit/runtime/profiling_record.h
+++ b/torch/csrc/jit/runtime/profiling_record.h
@@ -165,7 +165,7 @@ struct ShapeSymbolTable {
   // the dimension value from `new_sizes`
   bool bindSymbolicShapes(
       at::IntArrayRef new_sizes,
-      const c10::VaryingShape<c10::ShapeSymbol>& sym_shapes);
+      const c10::SymbolicShape& sym_shapes);
 };
 
 struct ProfilingRecord {
@@ -187,10 +187,11 @@ struct ProfilingRecord {
 
   // A thin wrapper around `partitionSetByDimension` to ensure
   // `new_sizes` and `sym_shapes` are of the same rank
-  std::vector<c10::optional<c10::ShapeSymbol>> mergeSymbolicShapes(
-      const c10::VaryingShape<c10::ShapeSymbol>& new_sizes,
-      const c10::VaryingShape<c10::ShapeSymbol>& sym_shapes,
-      SetPartitioningHelper& symbol_table);
+
+  c10::SymbolicShape mergeSymbolicShapes(
+      const c10::SymbolicShape& new_sizes,
+      const c10::SymbolicShape& sym_shapes,
+      SetPartitioningHelper& partition_helper);
 
   bool ready() const {
     return profiling_count_ == 0;


### PR DESCRIPTION
Adding a SymbolicShape class to represent a generic tensor shape with ShapeSymbols.

Its core data structure is c10::optional<std::vector<ShapeSymbol>>. If has_value() == false, it represents an unranked tensor shape. At any dimension ShapeSymbol can contain dynamic size, checkable with ShapeSymbol::IsStatic method.

SymbolicShape now replaces all uses of VaryingShape<ShapeSymbol>, ie c10::optional<std::vector<c10::optional<ShapeSymbol>>>. The inner c10::optional wrapper around ShapeSymbol used to indicate dynamic shape, which overlaps with part of ShapeSymbol's representation.