### PR TITLE
[WIP] Restore profiler state in RPC server thread continuation

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -561,7 +561,12 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processMessage(
          // a shared_ptr here.
          rpc = (std::shared_ptr<RpcCommandBase>)std::move(rpc),
          messageType = request.type(),
-         id = request.id()]() {
+         id = request.id(),
+         threadLocalState = ThreadLocalState()]() {
+          // The following execution possibly on another thread includes
+          // tensor functions, so profiler state should be transferred.
+          ThreadLocalStateGuard stateGuard(threadLocalState);
+
           try {
             // For a recv thread, current context id should be invalid outside
             // processMessage().


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38556 Restore profiler state in RPC continuation**

If an RPC request takes any RRef as arguments and the RRefs are not ready, thread switch happens and profiler state is lost, causing the following tensor operations not recorded by profiler.

Differential Revision: [D5591234](https://our.internmc.facebook.com/intern/diff/D5591234/)