### PR TITLE
Add `torch.utils.cmake_prefix_path` pointing to `share/cmake` folder

### DIFF
--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -2,8 +2,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from .throughput_benchmark import ThroughputBenchmark
 
+import os.path as _osp
+
 # Set the module for a given object for nicer printing
 def set_module(obj, mod):
     if not isinstance(mod, str):
         raise TypeError("The mod argument should be a string")
     obj.__module__ = mod
+
+#: Path to folder containing CMake definitions for Torch package
+cmake_prefix_path = _osp.join(_osp.dirname(_osp.dirname(__file__)), 'share', 'cmake')


### PR DESCRIPTION
Test Plan: Make sure that `cmake path/to/CMakeLists.txt -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` succeeds for CMake projects which depends on Torch package

