### PR TITLE
Add internal assert that cpu Loops don't require dynamic_casting.

### DIFF
--- a/aten/src/ATen/native/TensorIteratorDynamicCasting.h
+++ b/aten/src/ATen/native/TensorIteratorDynamicCasting.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// This file includes utilties for dynamic_casting done by TensorIterator, see CUDALoops.cuh and Loops.h.
+
+// dynamic_casting handles when the types expected by the iterator do not match the types of the arguments
+// to the function that is being called.
+// On CUDA, the cast is currently pushed down into the kernel (for performance reasons).
+// On CPU, there is currently an internal assert that a dynamic_cast is not needed.
+
+namespace at { namespace native {
+
+// `needs_dynamic_casting` compares the types expected by iterator
+// (i.e. dtypes of the operands) with the actual type of the arguments
+// of func_t
+template<typename func_t, int nargs=function_traits<func_t>::arity>
+struct needs_dynamic_casting {
+  static bool check(TensorIterator& iter) {
+    using traits = function_traits<func_t>;
+    if (iter.dtype(nargs) != c10::impl::CPPTypeToScalarType<typename traits::template arg<nargs - 1>::type>::value) {
+      return true;
+    }
+    return needs_dynamic_casting<func_t, nargs - 1>::check(iter);
+  }
+};
+
+template<typename func_t>
+struct needs_dynamic_casting<func_t, 0> {
+  static bool check(TensorIterator& iter) {
+    using traits = function_traits<func_t>;
+    return iter.dtype(0) != c10::impl::CPPTypeToScalarType<typename traits::result_type>::value;
+  }
+};
+
+}} //namespace at::native

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -31,7 +31,9 @@
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/cpu/IsContiguous.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/TensorIteratorDynamicCasting.h>
 #include <ATen/cpu/vec256/vec256.h>
+
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
@@ -185,6 +187,7 @@ static inline void unroll_contiguous_scalar_checks(
 
 template <typename func_t>
 void cpu_kernel(TensorIterator& iter, func_t&& op) {
+  TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
   using traits = function_traits<func_t>;
   TORCH_INTERNAL_ASSERT(iter.ntensors() >= traits::arity + 1);
 
@@ -203,6 +206,7 @@ void cpu_kernel(TensorIterator& iter, func_t&& op) {
 
 template <typename func_t, typename vec_func_t>
 void cpu_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop) {
+  TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
   using traits = function_traits<func_t>;
   TORCH_INTERNAL_ASSERT(iter.ntensors() >= traits::arity + 1);
 
@@ -225,6 +229,7 @@ void cpu_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop) {
 
 template <typename func_t>
 void cpu_serial_kernel(TensorIterator& iter, func_t&& op, const Range& range) {
+  TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
   using traits = function_traits<func_t>;
   TORCH_INTERNAL_ASSERT((std::is_void<typename traits::result_type>::value &&
     iter.noutputs() == 0 && iter.ntensors() == traits::arity) || (iter.ntensors() >= traits::arity + 1));
@@ -249,6 +254,7 @@ void cpu_serial_kernel(TensorIterator& iter, func_t&& op) {
 
 template <typename func_t, typename vec_func_t>
 void cpu_serial_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop, const Range& range) {
+  TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
   using traits = function_traits<func_t>;
   TORCH_INTERNAL_ASSERT(iter.ntensors() >= traits::arity + 1);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38573 Add internal assert that cpu Loops don't require dynamic_casting.**
* #38565 Avoid double dispatch in logical_not for compilation speed reasons.
* #38505 Improve testing of logical_not.

On CUDA, dynamic_casting is handled automatically, but this doesn't happen on CPU (maybe it should).
As a safety measure, this PR just tests via TORCH_INTERNAL_ASSERT whether a dynamic_cast is actually needed.

This is intended to discover cases where we are currently writing incorrect CPU kernels.

Differential Revision: [D21602670](https://our.internmc.facebook.com/intern/diff/D21602670)