### PR TITLE
[JIT] Use GE optimizer guard in import

### DIFF
--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -151,7 +151,7 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
       auto obj = c10::ivalue::Object::create(type, n);
       // XXX: Do not optimize __setstate__, so that we don't try to
       // specialize the class before it is initialized.
-      setGraphExecutorOptimize(false);
+      GraphOptimizerEnabledGuard guard(false);
       Function& set_state = cls->getMethod("__setstate__");
       // since we are in the middle of unpickling we might still have lists and
       // dicts that do not have accurate tags (e.g. they report they are
@@ -163,7 +163,6 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
       restoreAccurateTypeTags(
           input, set_state.getSchema().arguments().at(1).type());
       set_state({obj, input});
-      setGraphExecutorOptimize(true);
       postSetStateValidate(obj);
       return obj;
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38578 [JIT] Remove import statement thing in serialization docs
* **#38575 [JIT] Use GE optimizer guard in import**

This will preserve the original value of that flag as well as provide more exception safety

Differential Revision: [D21603086](https://our.internmc.facebook.com/intern/diff/D21603086)