### PR TITLE
[JIT] Remove import statement thing in serialization docs

### DIFF
--- a/torch/csrc/jit/docs/serialization.md
+++ b/torch/csrc/jit/docs/serialization.md
@@ -120,11 +120,6 @@ the current code object depends on. For example, if we are printing a
 `Module`, it will depend on its submodules, as well as any classes used in
 its methods or attributes.
 
-This information is used to write an `import` statement at the top of the
-printed source, which tells the importer that they need to go compile those
-dependencies (covered more in the "Code layout and qualified naming" section
-below).
-
 **Uses of tensor constants**. Most constants are inlined as literals, like
 strings or ints. But since tensors are potentially very large, when
 `PythonPrint` encouters a constant tensor it will emit a reference to a


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38578 [JIT] Remove import statement thing in serialization docs**
* #38575 [JIT] Use GE optimizer guard in import

We don't do that here

Differential Revision: [D21603383](https://our.internmc.facebook.com/intern/diff/D21603383)