### PR TITLE
Adding LpNorm regularization for sparse features in DPER3

### DIFF
--- a/caffe2/operators/sparse_lp_regularizer_op.cc
+++ b/caffe2/operators/sparse_lp_regularizer_op.cc
@@ -1,0 +1,97 @@
+#include "caffe2/operators/sparse_lp_regularizer_op.h"
+#include "caffe2/core/tensor.h"
+#include "caffe2/utils/eigen_utils.h"
+#include "common/logging/logging.h"
+
+namespace caffe2 {
+
+template <>
+bool SparseLpRegularizerOp<float, CPUContext>::RunOnDevice() {
+  return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
+      this, Input(INDICES));
+}
+
+template <>
+template <typename SIndex>
+bool SparseLpRegularizerOp<float, CPUContext>::DoRunWithType() {
+  const auto* indices = Input(INDICES).template data<SIndex>();
+  const auto* paramIn = Input(PARAM).template data<float>();
+  auto* paramOut = Output(OUTPUT_PARAM)->template mutable_data<float>();
+
+  // n: number of sparse embeddings to be normalized
+  auto n = Input(INDICES).numel();
+  if (n == 0) {
+    return true;
+  }
+
+  // embedding length, e.g. 32, 64, 128
+  auto block_size = Input(PARAM).size_from_dim(1);
+
+  if (p_ == 2.0) { // L2 regularization
+    LOG_FIRST_N(VERBOSE, 3)
+        << "Applying sparse L2 regularization with reg_lambda = "
+        << reg_lambda_;
+    LOG_FIRST_N(VERBOSE, 3)
+        << "L2 regularization input " << paramOut[indices[0] * block_size];
+    for (int i = 0; i < n; ++i) {
+      auto idx = indices[i];
+      auto offsetIdx = idx * block_size;
+      // Should probably be rewritten using Eigen.
+      for (int j = 0; j < block_size; j++) {
+        paramOut[offsetIdx + j] = paramOut[offsetIdx + j] * (1 - reg_lambda_);
+      }
+    }
+    LOG_FIRST_N(VERBOSE, 3)
+        << "L2 regularization output " << paramOut[indices[0] * block_size];
+  } else if (p_ == 1.0) { // L1 regularization
+    LOG_FIRST_N(VERBOSE, 3)
+        << "Applying sparse L1 regularization with reg_lambda = "
+        << reg_lambda_;
+    LOG_FIRST_N(VERBOSE, 3)
+        << "L1 regularization input " << paramOut[indices[0] * block_size];
+    for (int i = 0; i < n; ++i) {
+      auto idx = indices[i];
+      auto offsetIdx = idx * block_size;
+
+      for (int j = 0; j < block_size; j++) {
+        // I assume this can be sped up significantly.
+        if (paramOut[offsetIdx + j] < -reg_lambda_)
+          paramOut[offsetIdx + j] += reg_lambda_;
+        else if (paramOut[offsetIdx + j] > reg_lambda_)
+          paramOut[offsetIdx + j] -= reg_lambda_;
+        else
+          paramOut[offsetIdx + j] = 0.0;
+      }
+    }
+    LOG_FIRST_N(VERBOSE, 3)
+        << "L1 regularization output " << paramOut[indices[0] * block_size];
+  } else // Currently only handling L1 and L2 regularization.
+    return false;
+  return true;
+}
+
+REGISTER_CPU_OPERATOR(
+    SparseLpRegularizer,
+    SparseLpRegularizerOp<float, CPUContext>);
+OPERATOR_SCHEMA(SparseLpRegularizer)
+    .NumInputs(2, 3)
+    .NumOutputs(1)
+    .Input(0, "param", "Parameters to be regularized")
+    .Input(1, "indices", "Sparse indices")
+    .Input(
+        2,
+        "grad",
+        "Gradient computed (optional - not used, this argument is for backwards compatibility)")
+    .Output(0, "output_param", "Regularized parameters")
+    .EnforceOneToOneInplace()
+    .Arg("p", "Value of p in the Lp regularization to use. The default is 2.0.")
+    .Arg(
+        "reg_lambda",
+        "Value of lambda (multiplier for the regularization term). The default is 1e-5.")
+    .SetDoc(R"DOC(
+Given a sparse matrix, apply Lp regularization.  Currently only L1 and L2 are implemented.
+)DOC");
+
+SHOULD_NOT_DO_GRADIENT(SparseLpNorm);
+
+} // namespace caffe2

--- a/caffe2/operators/sparse_lp_regularizer_op.h
+++ b/caffe2/operators/sparse_lp_regularizer_op.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <typename T, class Context>
+class CAFFE2_API SparseLpRegularizerOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  template <class... Args>
+  explicit SparseLpRegularizerOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        p_(this->template GetSingleArgument<float>("p", 2.0)),
+        reg_lambda_(
+            this->template GetSingleArgument<float>("reg_lambda", 1e-5)) {
+    CAFFE_ENFORCE(
+        p_ == 1.0 || p_ == 2.0,
+        "Sparse Lp regularizer only implemented for p=1 or p=2.");
+    CAFFE_ENFORCE_GT(
+        reg_lambda_,
+        0.0,
+        "Lambda for sparse Lp regularizer must be greater than 0.");
+    CAFFE_ENFORCE_LT(
+        reg_lambda_,
+        1.0,
+        "Lambda for sparse Lp regularizer must be less than 1.");
+  }
+
+  bool RunOnDevice() override;
+
+  template <typename SIndex>
+  bool DoRunWithType();
+
+ protected:
+  float p_;
+  float reg_lambda_;
+  INPUT_TAGS(PARAM, INDICES);
+  OUTPUT_TAGS(OUTPUT_PARAM);
+};
+
+} // namespace caffe2

--- a/caffe2/operators/sparse_lp_regularizer_op_gpu.cu
+++ b/caffe2/operators/sparse_lp_regularizer_op_gpu.cu
@@ -1,0 +1,7 @@
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/operator_fallback_gpu.h"
+#include "caffe2/operators/sparse_lp_regularizer_op.h"
+
+namespace caffe2 {
+REGISTER_CUDA_OPERATOR(SparseLpRegularizer, GPUFallbackOp);
+}

--- a/caffe2/python/operator_test/sparse_lp_regularizer_test.py
+++ b/caffe2/python/operator_test/sparse_lp_regularizer_test.py
@@ -26,10 +26,6 @@ class TestSparseLpNorm(hu.HypothesisTestCase):
             return param_out
         raise ValueError
 
-    # @staticmethod
-    # def ref_lpnorm_gradient(param_in, norm):
-    #     return norm * (param_in ** (norm - 1))
-
     # Suppress filter_too_much health check.
     # Likely caused by `assume` call falling through too often.
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
@@ -40,7 +36,6 @@ class TestSparseLpNorm(hu.HypothesisTestCase):
            **hu.gcs_cpu_only)
     def test_sparse_lpnorm(self, inputs, p, reg_lambda, data_strategy, gc, dc):
 
-        # param, grad = inputs
         param, = inputs
         param += 0.02 * np.sign(param)
         param[param == 0.0] += 0.02

--- a/caffe2/python/operator_test/sparse_lp_regularizer_test.py
+++ b/caffe2/python/operator_test/sparse_lp_regularizer_test.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import hypothesis
+from hypothesis import given, settings, HealthCheck
+import hypothesis.strategies as st
+import numpy as np
+
+from caffe2.python import core
+import caffe2.python.hypothesis_test_util as hu
+
+
+class TestSparseLpNorm(hu.HypothesisTestCase):
+
+    @staticmethod
+    def ref_lpnorm(param_in, p, reg_lambda):
+        """Reference function that should be matched by the Caffe2 operator."""
+        if p == 2.0:
+            return param_in * (1 - reg_lambda)
+        if p == 1.0:
+            reg_term = np.ones_like(param_in) * reg_lambda * np.sign(param_in)
+            param_out = param_in - reg_term
+            param_out[np.abs(param_in) <= reg_lambda] = 0.
+            return param_out
+        raise ValueError
+
+    # @staticmethod
+    # def ref_lpnorm_gradient(param_in, norm):
+    #     return norm * (param_in ** (norm - 1))
+
+    # Suppress filter_too_much health check.
+    # Likely caused by `assume` call falling through too often.
+    @settings(suppress_health_check=[HealthCheck.filter_too_much])
+    @given(inputs=hu.tensors(n=1, min_dim=2, max_dim=2),
+           p=st.integers(min_value=1, max_value=2),
+           reg_lambda=st.floats(min_value=1e-4, max_value=1e-1),
+           data_strategy=st.data(),
+           **hu.gcs_cpu_only)
+    def test_sparse_lpnorm(self, inputs, p, reg_lambda, data_strategy, gc, dc):
+
+        # param, grad = inputs
+        param, = inputs
+        param += 0.02 * np.sign(param)
+        param[param == 0.0] += 0.02
+
+        # Create an indexing array containing values that are lists of indices,
+        # which index into param
+        indices = data_strategy.draw(
+            hu.tensor(dtype=np.int64, min_dim=1, max_dim=1,
+                      elements=st.sampled_from(np.arange(param.shape[0]))),
+        )
+        hypothesis.note('indices.shape: %s' % str(indices.shape))
+
+        # For now, the indices must be unique
+        hypothesis.assume(np.array_equal(np.unique(indices.flatten()),
+                                         np.sort(indices.flatten())))
+
+        op = core.CreateOperator(
+            "SparseLpRegularizer",
+            ["param", "indices"],
+            ["param"],
+            p=float(p),
+            reg_lambda=reg_lambda,
+        )
+
+        def ref_sparse_lp_regularizer(param, indices, grad=None):
+            param_out = np.copy(param)
+            for _, index in enumerate(indices):
+                param_out[index] = self.ref_lpnorm(
+                    param[index],
+                    p=p,
+                    reg_lambda=reg_lambda,
+                )
+            return (param_out,)
+
+        self.assertReferenceChecks(
+            gc, op, [param, indices],
+            ref_sparse_lp_regularizer
+        )

--- a/caffe2/python/regularizer.py
+++ b/caffe2/python/regularizer.py
@@ -318,6 +318,36 @@ class ConstantNorm(Regularizer):
             )
 
 
+class SparseLpNorm(Regularizer):
+    def __init__(self, p, reg_lambda):
+        super(SparseLpNorm, self).__init__()
+        assert p in (1.0, 2.0), "Sparse Lp regularization only implemented for p = 1.0 and p = 2.0."
+        assert reg_lambda > 0, "factor ahead of regularization should be greater than 0."
+        self.p = p
+        self.reg_lambda = reg_lambda
+
+    def _run_after_optimizer(self, net, param_init_net, param, grad):
+        if isinstance(grad, core.GradientSlice):
+            net.SparseLpRegularizer(
+                [param, grad.indices],
+                [param],
+                p=self.p,
+                reg_lambda=self.reg_lambda,
+            )
+        else:
+            raise NotImplementedError("SparseLpNorm is not supported for dense parameters")
+
+
+class SparseL1Norm(SparseLpNorm):
+    def __init__(self, reg_lambda):
+        super(SparseL1Norm, self).__init__(p=1.0, reg_lambda=reg_lambda)
+
+
+class SparseL2Norm(SparseLpNorm):
+    def __init__(self, reg_lambda):
+        super(SparseL2Norm, self).__init__(p=2.0, reg_lambda=reg_lambda)
+
+
 class LogBarrier(Regularizer):
     """
     Wright, S., & Nocedal, J. (1999). Numerical optimization. Springer Science,


### PR DESCRIPTION
Summary:
Adding LpNorm regularization for sparse features in DPER3.  This is done using a sparse regularization op with run_after_optimizer (see D21003029).

* Added code calling new caffe2 operator from D21003029 to caffe2/python/regularizer.py
* Added l1norm and l2norm to sparse regularizer thrift definition.
* Added the new regularization references to test utils.
* Added a new file for unit tests "sparse_nn_sparse_reg_test.py"

Test Plan:
buck test mode/dev //caffe2/caffe2/fb/dper/layer_models/tests:sparse_nn_sparse_reg_test
buck test mode/dev //caffe2/caffe2/fb/dper/layer_models/tests:sparse_nn_reg_test

Differential Revision: D20704248

