### PR TITLE
[v1.5.1] Fix conv non zero padding being applied in wrong dim (#37881)

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -33,7 +33,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
       options.out_channels() % options.groups() == 0,
       "out_channels must be divisible by groups");
 
-    _padding_repeated_twice = torch::nn::modules::utils::_repeat_vector(options.padding(), 2);
+    _reversed_padding_repeated_twice = torch::nn::modules::utils::_reverse_repeat_vector(options.padding(), 2);
 
     if (options.transposed()) {
       std::vector<int64_t> weight_sizes = {
@@ -111,7 +111,7 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
   Tensor bias;
 
  protected:
-  std::vector<int64_t> _padding_repeated_twice;
+  std::vector<int64_t> _reversed_padding_repeated_twice;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Conv1d ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/torch/csrc/api/include/torch/nn/modules/utils.h
+++ b/torch/csrc/api/include/torch/nn/modules/utils.h
@@ -10,16 +10,18 @@ namespace nn {
 namespace modules {
 namespace utils {
 
-// Repeat each element of `t` for `n` times.
+// Reverse the order of `t` and repeat each element for `n` times.
 // This can be used to translate padding arg used by Conv and Pooling modules
 // to the ones used by `F::pad`.
 //
-// This mirrors `_repeat_tuple` in `torch/nn/modules/utils.py`.
-inline std::vector<int64_t> _repeat_vector(at::ArrayRef<int64_t> t, int64_t n) {
+// This mirrors `_reverse_repeat_tuple` in `torch/nn/modules/utils.py`.
+inline std::vector<int64_t> _reverse_repeat_vector(at::ArrayRef<int64_t> t, int64_t n) {
+  TORCH_INTERNAL_ASSERT(n >= 0);
   std::vector<int64_t> ret;
-  for (int64_t elem : t) {
+  ret.reserve(t.size() * n);
+  for (auto rit = t.rbegin(); rit != t.rend(); ++rit) {
     for (int64_t i = 0; i < n; i++) {
-      ret.emplace_back(elem);
+      ret.emplace_back(*rit);
     }
   }
   return ret;

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -51,7 +51,7 @@ Conv1dImpl::Conv1dImpl(
 Tensor Conv1dImpl::forward(const Tensor& input) {
   if (!c10::get_if<enumtype::kZeros>(&options.padding_mode())) {
     return F::detail::conv1d(
-      F::pad(input, F::PadFuncOptions(_padding_repeated_twice).mode(_get_pad_mode_from_conv_padding_mode(options.padding_mode()))),
+      F::pad(input, F::PadFuncOptions(_reversed_padding_repeated_twice).mode(_get_pad_mode_from_conv_padding_mode(options.padding_mode()))),
       weight, bias,
       options.stride(),
       /*padding=*/0,
@@ -87,7 +87,7 @@ Conv2dImpl::Conv2dImpl(
 Tensor Conv2dImpl::_conv_forward(const Tensor& input, const Tensor& weight) {
   if (!c10::get_if<enumtype::kZeros>(&options.padding_mode())) {
     return F::detail::conv2d(
-      F::pad(input, F::PadFuncOptions(_padding_repeated_twice).mode(_get_pad_mode_from_conv_padding_mode(options.padding_mode()))),
+      F::pad(input, F::PadFuncOptions(_reversed_padding_repeated_twice).mode(_get_pad_mode_from_conv_padding_mode(options.padding_mode()))),
       weight, bias,
       options.stride(),
       /*padding=*/0,
@@ -127,7 +127,7 @@ Conv3dImpl::Conv3dImpl(
 Tensor Conv3dImpl::forward(const Tensor& input) {
   if (!c10::get_if<enumtype::kZeros>(&options.padding_mode())) {
     return F::detail::conv3d(
-      F::pad(input, F::PadFuncOptions(_padding_repeated_twice).mode(_get_pad_mode_from_conv_padding_mode(options.padding_mode()))),
+      F::pad(input, F::PadFuncOptions(_reversed_padding_repeated_twice).mode(_get_pad_mode_from_conv_padding_mode(options.padding_mode()))),
       weight, bias,
       options.stride(),
       /*padding=*/0,

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -6,7 +6,7 @@ from torch.nn.parameter import Parameter
 from .. import functional as F
 from .. import init
 from .module import Module
-from .utils import _single, _pair, _triple, _repeat_tuple
+from .utils import _single, _pair, _triple, _reverse_repeat_tuple
 from ..._jit_internal import List, Optional
 
 
@@ -39,7 +39,11 @@ class _ConvNd(Module):
         self.output_padding = output_padding
         self.groups = groups
         self.padding_mode = padding_mode
-        self._padding_repeated_twice = _repeat_tuple(self.padding, 2)
+        # `_reversed_padding_repeated_twice` is the padding to be passed to
+        # `F.pad` if needed (e.g., for non-zero padding types that are
+        # implemented as two ops: padding + conv). `F.pad` accepts paddings in
+        # reverse order than the dimension.
+        self._reversed_padding_repeated_twice = _reverse_repeat_tuple(self.padding, 2)
         if transposed:
             self.weight = Parameter(torch.Tensor(
                 in_channels, out_channels // groups, *kernel_size))
@@ -201,7 +205,7 @@ class Conv1d(_ConvNd):
 
     def forward(self, input):
         if self.padding_mode != 'zeros':
-            return F.conv1d(F.pad(input, self._padding_repeated_twice, mode=self.padding_mode),
+            return F.conv1d(F.pad(input, self._reversed_padding_repeated_twice, mode=self.padding_mode),
                             self.weight, self.bias, self.stride,
                             _single(0), self.dilation, self.groups)
         return F.conv1d(input, self.weight, self.bias, self.stride,
@@ -339,7 +343,7 @@ class Conv2d(_ConvNd):
 
     def _conv_forward(self, input, weight):
         if self.padding_mode != 'zeros':
-            return F.conv2d(F.pad(input, self._padding_repeated_twice, mode=self.padding_mode),
+            return F.conv2d(F.pad(input, self._reversed_padding_repeated_twice, mode=self.padding_mode),
                             weight, self.bias, self.stride,
                             _pair(0), self.dilation, self.groups)
         return F.conv2d(input, weight, self.bias, self.stride,
@@ -474,7 +478,7 @@ class Conv3d(_ConvNd):
 
     def forward(self, input):
         if self.padding_mode != 'zeros':
-            return F.conv3d(F.pad(input, self._padding_repeated_twice, mode=self.padding_mode),
+            return F.conv3d(F.pad(input, self._reversed_padding_repeated_twice, mode=self.padding_mode),
                             self.weight, self.bias, self.stride, _triple(0),
                             self.dilation, self.groups)
         return F.conv3d(input, self.weight, self.bias, self.stride,

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -15,13 +15,13 @@ _triple = _ntuple(3)
 _quadruple = _ntuple(4)
 
 
-def _repeat_tuple(t, n):
-    r"""Repeat each element of `t` for `n` times.
+def _reverse_repeat_tuple(t, n):
+    r"""Reverse the order of `t` and repeat each element for `n` times.
 
     This can be used to translate padding arg used by Conv and Pooling modules
     to the ones used by `F.pad`.
     """
-    return tuple(x for x in t for _ in range(n))
+    return tuple(x for x in reversed(t) for _ in range(n))
 
 
 def _list_with_default(out_size, defaults):

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3203,19 +3203,23 @@ for padding_mode, cpp_padding_mode in zip(
             # FIXME: remove after implementing reflection pad 3d
             #        https://github.com/pytorch/pytorch/issues/27655
             continue
+        padding = tuple(range(1, d + 1))
+        cpp_padding = '{' + ', '.join(map(str, padding)) + '}'
+        input_size = (2, 2) + (4,) * d
+        output_size = (2, 3) + tuple(p + 1 for p in padding)  # simplified from `(4 + 2 * p - 3) // 2 + 1`
         new_module_tests.append(
             dict(
                 module_name='Conv{}d'.format(d),
-                constructor_args=(3, 4, 3, 2, 2, 1, 1, True, padding_mode),
-                cpp_constructor_args='''torch::nn::Conv{}dOptions(3, 4, 3)
+                constructor_args=(2, 3, 3, 2, padding, 1, 1, True, padding_mode),
+                cpp_constructor_args='''torch::nn::Conv{}dOptions(2, 3, 3)
                                         .stride(2)
-                                        .padding(2)
+                                        .padding({})
                                         .dilation(1)
                                         .groups(1)
                                         .bias(true)
-                                        .padding_mode({})'''.format(d, cpp_padding_mode),
-                input_size=(2, 3) + (3,) * d,
-                output_size=(2, 4) + (3,) * d,
+                                        .padding_mode({})'''.format(d, cpp_padding, cpp_padding_mode),
+                input_size=input_size,
+                output_size=output_size,
                 cudnn=True,
                 desc='{}_stride2_pad2'.format(padding_mode),
             ),


### PR DESCRIPTION
Summary:
Turns out F.pad takes in dims in reverse order. Fixes https://github.com/pytorch/pytorch/issues/37844
Pull Request resolved: https://github.com/pytorch/pytorch/pull/37881

Differential Revision: D21554011

Pulled By: soumith

fbshipit-source-id: a85a7f6db9f981d915728965903c5c57b6617c93

