### PR TITLE
[TensorExpr] Eager reduction initialization & removal from ReduceOp

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -60,13 +60,16 @@ namespace jit {
   _(Reduce3DRfactor)                        \
   _(Reduce3DRfactor2)                       \
   _(Reduce3DRfactor3)                       \
+  _(Reduce3DRfactorWithOuter)               \
   _(Reduce3DRfactorRepeated)                \
   _(ReduceRfactorInsertionPoint)            \
   _(Reduce3DRfactorInsertionPoint)          \
   _(ReduceSplitTail)                        \
   _(ReduceSplitNoTail)                      \
+  _(ReduceOverSplitTail)                    \
   _(ReduceSplitMask)                        \
   _(ReduceSplitNoMask)                      \
+  _(ReduceOverSplitMask)                    \
   _(SplitReduceAxis)                        \
   _(SplitNonReduceAxis)                     \
   _(TypeTest01)                             \

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -797,14 +797,6 @@ class Intrinsics : public CallNode<Intrinsics> {
   IntrinsicsOp op_type_;
 };
 
-class NoOp : public ExprNode<NoOp> {
- public:
-  NoOp() : ExprNodeBase(kVoid) {}
-  static ExprHandle make() {
-    return ExprHandle(new NoOp());
-  }
-};
-
 class Polynomial;
 class Term;
 

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -216,10 +216,6 @@ const Expr* IRMutator::mutate(const FunctionCall* v) {
   return this->mutate(base);
 }
 
-const Expr* IRMutator::mutate(const NoOp* v) {
-  return v;
-}
-
 const Expr* IRMutator::mutate(const Term* v) {
   const Expr* newScalar = v->scalar()->accept_mutator(this);
 
@@ -248,7 +244,6 @@ const Expr* IRMutator::mutate(const RoundOff* v) {
 const Expr* IRMutator::mutate(const ReduceOp* v) {
   const Expr* buf_new_expr = v->accumulator()->accept_mutator(this);
   const Buf* buf_new = dynamic_cast<const Buf*>(buf_new_expr);
-  const Expr* init = v->initializer()->accept_mutator(this);
   auto body = v->body().node()->accept_mutator(this);
 
   std::vector<const Expr*> new_output_args;
@@ -262,7 +257,6 @@ const Expr* IRMutator::mutate(const ReduceOp* v) {
 
   return new ReduceOp(
       buf_new,
-      init,
       ExprHandle(body),
       v->interaction(),
       new_output_args,

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -49,7 +49,6 @@ class Polynomial;
 class RoundOff;
 class ReduceOp;
 class AtomicAdd;
-class NoOp;
 
 class TORCH_API IRMutator {
  public:
@@ -88,7 +87,6 @@ class TORCH_API IRMutator {
   virtual const Expr* mutate(const BaseCallNode* v);
   virtual const Expr* mutate(const Intrinsics* v);
   virtual const Expr* mutate(const FunctionCall* v);
-  virtual const Expr* mutate(const NoOp* v);
 
   virtual const Expr* mutate(const Term* v);
   virtual const Expr* mutate(const Polynomial* v);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -306,7 +306,6 @@ void IRPrinter::visit(const RoundOff* v) {
 void IRPrinter::visit(const ReduceOp* v) {
   os() << "ReduceOp(";
   os() << *v->accumulator() << ", ";
-  os() << *v->initializer() << ", ";
   os() << v->complete() << ", ";
 
   bool first = true;
@@ -330,10 +329,6 @@ void IRPrinter::visit(const ReduceOp* v) {
     first = false;
   }
   os() << "})";
-}
-
-void IRPrinter::visit(const NoOp* v) {
-  os() << "NoOp";
 }
 
 // === Stmt visitors below ===

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -47,7 +47,6 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const Polynomial* v) override;
   void visit(const RoundOff* v) override;
   void visit(const ReduceOp* v) override;
-  void visit(const NoOp* v) override;
 
   void visit(const AtomicAdd* v) override;
   void visit(const Store* v) override;

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -206,7 +206,6 @@ void IRVisitor::visit(const RoundOff* v) {
 
 void IRVisitor::visit(const ReduceOp* v) {
   v->accumulator()->accept(this);
-  v->initializer()->accept(this);
   v->body().node()->accept(this);
 
   for (auto* e : v->output_args()) {
@@ -215,10 +214,6 @@ void IRVisitor::visit(const ReduceOp* v) {
   for (auto* r : v->reduce_args()) {
     r->accept(this);
   }
-}
-
-void IRVisitor::visit(const NoOp* v) {
-  // do nothing
 }
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -46,7 +46,6 @@ class Polynomial;
 class RoundOff;
 class ReduceOp;
 class AtomicAdd;
-class NoOp;
 
 class TORCH_API IRVisitor {
  public:
@@ -98,7 +97,6 @@ class TORCH_API IRVisitor {
   virtual void visit(const RoundOff* v);
   virtual void visit(const ReduceOp* v);
   virtual void visit(const AtomicAdd* v);
-  virtual void visit(const NoOp* v);
 };
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -68,6 +68,8 @@ class TORCH_API LoopNest {
   std::unordered_set<Tensor*> output_tensors_;
   std::unordered_set<Tensor*> intermediate_tensors_;
   std::vector<const Buf*> temp_bufs_;
+  // Holds the initializer Expr of buffers that have been initialized.
+  std::unordered_map<const Buf*, const Expr*> buf_initializers_;
 };
 
 TORCH_API Stmt* FlattenIndexes(Stmt* s);

--- a/torch/csrc/jit/tensorexpr/var_substitutor.h
+++ b/torch/csrc/jit/tensorexpr/var_substitutor.h
@@ -53,7 +53,6 @@ class VarSubMutator : public IRMutator {
   }
 
   const Expr* mutate(const ReduceOp* var) override {
-    const Expr* init = var->initializer()->accept_mutator(this);
     auto body = var->body().node()->accept_mutator(this);
     std::vector<const Expr*> new_outer;
     std::vector<const Var*> new_inner;
@@ -75,7 +74,6 @@ class VarSubMutator : public IRMutator {
 
     return new ReduceOp(
         const_cast<Buf*>(var->accumulator()),
-        init,
         ExprHandle(body),
         var->interaction(),
         new_outer,


### PR DESCRIPTION
This PR removes the deferred initializer field from ReduceOp in favour of eagerly initializing buffers when they are created (either in the constructor of `LoopNest`, or in `rfactor()`). This allows a pretty good simplification of reduction logic, removing almost all of the reduction expander and the ReduceInitCleaner & unpopular NoOp node added in the last fix.

Eager initialization is better for us anyway because it allows more opportunities to transform the initialization loop. 

Added a few more tests, testReduceOverSplitWithTail failed before this change due to a bug in splitWithTail which now can't happen.