### PR TITLE
Redundant schema registration Prevention for Manually Boxed Wrappers

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -151,6 +151,11 @@ public:
   RegistrationHandleRAII registerImpl(OperatorName op_name, c10::optional<DispatchKey> dispatch_key, KernelFunction kernel, std::unique_ptr<FunctionSchema> inferred_function_schema, std::string debug);
 
   /**
+   * Register a new operator by name.
+   */
+  RegistrationHandleRAII registerName(OperatorName op_name);
+
+  /**
    * Register a fallback kernel for a backend.
    * If an operator is called but there is no concrete kernel for the dispatch
    * key of the given operator arguments, it will check if there is such a
@@ -199,6 +204,7 @@ private:
     const OperatorName& op_name,
     c10::optional<DispatchKey> dispatch_key,
     std::list<impl::OperatorEntry::KernelEntry>::iterator kernel_handle);
+  void deregisterName_(const OperatorHandle& op, const OperatorName& op_name);
   void deregisterFallback_(DispatchKey dispatchKey);
   void deregisterLibrary_(const std::string& ns);
   void cleanup(const OperatorHandle& op, const OperatorName& op_name);

--- a/tools/jit/templates/generated_unboxing_wrappers.cpp
+++ b/tools/jit/templates/generated_unboxing_wrappers.cpp
@@ -105,8 +105,8 @@ public:
     auto schema = parseSchema(schemaStr);
     schema.setAliasAnalysis(AliasAnalysisKind::FROM_SCHEMA);
     c10::OperatorName name = schema.operator_name();
-    RegistrationHandleRAII registration = dispatcher.registerDef(std::move(schema), "registered by JIT");
-    auto op = dispatcher.findSchema(name).value();
+    RegistrationHandleRAII registration = dispatcher.registerName(name);
+    auto op = dispatcher.findOp(name).value();
     registrationHandles_.push_back(std::move(registration));
     dispatcher.setManuallyBoxedKernelFor_(op, boxed_kernel_wrapper);
     return std::move(*this);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38588 Redundant schema registration Prevention for Manually Boxed Wrappers**

(Fixes #37879) Declared/defined functions registerName(...) and deregisterName_(...) in the Dispatcher class. Replaced the function call registerDef(...) with the newly defined function registerName(...) in op(...) function of Registerer class in tools/jit/templates/generated_unboxing_wrappers.c

Differential Revision: [D21508186](https://our.internmc.facebook.com/intern/diff/D21508186/)