### PR TITLE
[TensorExpr] Use couldMoveBefore instead of couldMoveAfter checks in the fuser pass, add CPP tests.

### DIFF
--- a/test/cpp/tensorexpr/test_te_fuser_pass.cpp
+++ b/test/cpp/tensorexpr/test_te_fuser_pass.cpp
@@ -1,0 +1,66 @@
+#include <test/cpp/tensorexpr/test_base.h>
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/passes/tensorexpr_fuser.h>
+#include <torch/csrc/jit/tensorexpr/mem_arena.h>
+#include <torch/csrc/jit/testing/file_check.h>
+#include <sstream>
+
+namespace torch {
+namespace jit {
+
+using namespace torch::jit::tensorexpr;
+
+void testFuserPass_1() {
+  KernelScope kernel_scope;
+  const auto graph_string = R"IR(
+    graph(%0 : Float(128:1),
+          %1 : Float(128:1)):
+      %12 : int = prim::Constant[value=1]()
+      %2.1 : Float(128:1) = aten::mul(%0, %1)
+      %2 : Float(128:1) = aten::mul(%2.1, %1)
+      %3 : Float(128:1) = aten::add_(%2, %1, %12)
+      %4 : Float(128:1) = aten::mul(%2, %1)
+      %5 : Float(128:1) = aten::add(%2, %4, %12)
+      return (%5))IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+
+  g->lint();
+  FuseTensorExprs(g);
+
+  // We should not be able to fuse across the in-place operation here.
+  testing::FileCheck()
+      .check("tensorexpr::Group_0")
+      ->check("aten::add_")
+      ->check("tensorexpr::Group_1")
+      ->run(*g);
+}
+
+void testFuserPass_2() {
+  KernelScope kernel_scope;
+  const auto graph_string = R"IR(
+    graph(%0 : Float(128:1),
+          %1 : Float(128:1)):
+      %12 : int = prim::Constant[value=1]()
+      %a : Float(128:1) = aten::mul(%0, %1)
+      %b : Float(128:1) = aten::add(%0, %1, %12)
+      %c : Float(128:1) = aten::add_(%b, %1, %12)
+      %d : Float(128:1) = aten::mul(%c, %a)
+      return (%d))IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+
+  g->lint();
+  FuseTensorExprs(g);
+  std::cerr << *g << "\n";
+
+  // We should not be able to fuse across the in-place operation here.
+  testing::FileCheck()
+      .check("aten::add_")
+      ->check("tensorexpr::Group_0")
+      ->run(*g);
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -174,7 +174,9 @@ namespace jit {
   _(OuterLoopVectorization)                 \
   _(Kernel_1)                               \
   _(Kernel_2)                               \
-  _(Kernel_3)
+  _(Kernel_3)                               \
+  _(FuserPass_1)                            \
+  _(FuserPass_2)
 
 #define TH_FORALL_TENSOREXPR_TESTS_LLVM(_) \
   _(LLVMByteImmTest)                       \

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -208,7 +208,7 @@ bool canMerge(Node* consumer, Node* producer, AliasDb& aliasDb) {
        consumer->kind() == getTensorExprSymbol()));
 
   // Alias checks
-  REQ(aliasDb.couldMoveAfterTopologically(consumer, producer));
+  REQ(aliasDb.couldMoveBeforeTopologically(producer, consumer));
 
   // Ops that return aliases can only be folded if this is the only use.
   if (producer->kind() == aten::slice || producer->kind() == aten::unsqueeze ||
@@ -274,17 +274,17 @@ c10::optional<Node*> tryMerge(
   if (producer->kind() == aten::cat) {
     Node* listconstruct = producer->inputs()[0]->node();
 
-    aliasDb.moveAfterTopologicallyValid(consumer, producer);
+    aliasDb.moveBeforeTopologicallyValid(producer, consumer);
     GRAPH_UPDATE(
         "Merging ", getHeader(producer), " into ", getHeader(consumer));
     SubgraphUtils::mergeNodeIntoSubgraph(producer, consumer);
 
-    aliasDb.moveAfterTopologicallyValid(consumer, listconstruct);
+    aliasDb.moveBeforeTopologicallyValid(listconstruct, consumer);
     GRAPH_UPDATE(
         "Merging ", getHeader(listconstruct), " into ", getHeader(consumer));
     SubgraphUtils::mergeNodeIntoSubgraph(listconstruct, consumer);
   } else {
-    aliasDb.moveAfterTopologicallyValid(consumer, producer);
+    aliasDb.moveBeforeTopologicallyValid(producer, consumer);
     GRAPH_UPDATE(
         "Merging ", getHeader(producer), " into ", getHeader(consumer));
     SubgraphUtils::mergeNodeIntoSubgraph(producer, consumer);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38592 [TensorExpr] Use couldMoveBefore instead of couldMoveAfter checks in the fuser pass, add CPP tests.**

I'm not sure that using couldMoveAfter was incorrect, but using
couldMoveBefore is more consistent with other subgraph-extraction
passes (old fuser, create autodiff graphs, etc.), so it would make it
easier to unify their implementations after this change.

Differential Revision: [D21607856](https://our.internmc.facebook.com/intern/diff/D21607856)