### PR TITLE
Refactor c10::complex and cleanup c10::Scalar

### DIFF
--- a/aten/src/ATen/cuda/DeviceUtils.cuh
+++ b/aten/src/ATen/cuda/DeviceUtils.cuh
@@ -82,11 +82,11 @@ __device__ __forceinline__ c10::complex<T> WARP_SHFL_DOWN(c10::complex<T> value,
 {
 #ifndef __HIP_PLATFORM_HCC__
     return c10::complex<T>(
-        __shfl_down_sync(mask, value.storage[0], delta, width),
-        __shfl_down_sync(mask, value.storage[1], delta, width));
+        __shfl_down_sync(mask, value.real_, delta, width),
+        __shfl_down_sync(mask, value.imag_, delta, width));
 #else
     return c10::complex<T>(
-        __shfl_down(value.storage[0], delta, width),
-        __shfl_down(value.storage[1], delta, width));
+        __shfl_down(value.real_, delta, width),
+        __shfl_down(value.imag_, delta, width));
 #endif
 }

--- a/c10/core/Scalar.cpp
+++ b/c10/core/Scalar.cpp
@@ -7,7 +7,7 @@ Scalar Scalar::operator-() const {
   if (isFloatingPoint()) {
     return Scalar(-v.d);
   } else if (isComplex()) {
-    return Scalar(c10::complex<double>(-v.z[0], -v.z[1]));
+    return Scalar(-v.z);
   } else {
     return Scalar(-v.i);
   }

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -29,6 +29,7 @@ class C10_API Scalar {
   Scalar(type vv) : Scalar(vv, true) { }
 
   AT_FORALL_SCALAR_TYPES_AND2(Half, BFloat16, DEFINE_IMPLICIT_CTOR)
+  AT_FORALL_COMPLEX_TYPES(DEFINE_IMPLICIT_CTOR)
 
 #undef DEFINE_IMPLICIT_CTOR
 
@@ -43,27 +44,13 @@ class C10_API Scalar {
     v.i = convert<int64_t, bool>(vv);
   }
 
-#define DEFINE_IMPLICIT_COMPLEX_CTOR(type, name, member) \
-  Scalar(type vv) : tag(Tag::HAS_##member) {             \
-    v.member[0] = c10::convert<double>(vv.real());       \
-    v.member[1] = c10::convert<double>(vv.imag());       \
-  }
-
-  DEFINE_IMPLICIT_COMPLEX_CTOR(c10::complex<c10::Half>, ComplexHalf, z)
-  DEFINE_IMPLICIT_COMPLEX_CTOR(std::complex<float>, ComplexFloat, z)
-  DEFINE_IMPLICIT_COMPLEX_CTOR(std::complex<double>, ComplexDouble, z)
-  DEFINE_IMPLICIT_COMPLEX_CTOR(c10::complex<float>, ComplexFloat, z)
-  DEFINE_IMPLICIT_COMPLEX_CTOR(c10::complex<double>, ComplexDouble, z)
-
-#undef DEFINE_IMPLICIT_COMPLEX_CTOR
-
 #define DEFINE_ACCESSOR(type, name)                       \
   type to##name() const {                                 \
     if (Tag::HAS_d == tag) {                              \
       return checked_convert<type, double>(v.d, #type);   \
     } else if (Tag::HAS_z == tag) {                       \
       return checked_convert<type, c10::complex<double>>( \
-          {v.z[0], v.z[1]}, #type);                       \
+          v.z, #type);                                    \
     } if (Tag::HAS_b == tag) {                            \
       return checked_convert<type, bool>(v.i, #type);     \
     } else {                                              \
@@ -123,9 +110,16 @@ class C10_API Scalar {
     }
 
     template<typename T,
-             typename std::enable_if<!std::numeric_limits<T>::is_integer, bool>::type* =
+             typename std::enable_if<!std::numeric_limits<T>::is_integer && !c10::is_complex_t<T>::value, bool>::type* =
                  nullptr>
     Scalar(T vv, bool) : tag(Tag::HAS_d) {
+      v.d = convert<decltype(v.d), T>(vv);
+    }
+
+    template<typename T,
+             typename std::enable_if<c10::is_complex_t<T>::value, bool>::type* =
+                 nullptr>
+    Scalar(T vv, bool) : tag(Tag::HAS_z) {
       v.d = convert<decltype(v.d), T>(vv);
     }
 
@@ -134,14 +128,11 @@ class C10_API Scalar {
 
   enum class Tag { HAS_d, HAS_i, HAS_z, HAS_b };
   Tag tag;
-  union {
+  union v_t {
     double d;
     int64_t i;
-    // Can't do put std::complex in the union, because it triggers
-    // an nvcc bug:
-    //    error: designator may not specify a non-POD subobject
-    // TODO: can we put c10::complex to it?
-    double z[2];
+    c10::complex<double> z;
+    v_t(){}  // default constructor
   } v;
 };
 

--- a/c10/util/LegacyComplex.h
+++ b/c10/util/LegacyComplex.h
@@ -11,9 +11,6 @@ class numeric_limits<std::complex<float>> : public numeric_limits<float>  {};
 template <>
 class numeric_limits<std::complex<double>> : public numeric_limits<double>  {};
 
-template <>
-class numeric_limits<c10::complex<at::Half>> : public numeric_limits<c10::Half>  {};
-
 #define COMPLEX_INTEGER_OP_TEMPLATE_CONDITION \
   typename std::enable_if_t<std::is_floating_point<fT>::value && std::is_integral<iT>::value, int> = 0
 

--- a/c10/util/complex_type.h
+++ b/c10/util/complex_type.h
@@ -284,83 +284,83 @@ constexpr complex<double> operator"" _id(unsigned long long imag) {
 
 
 template<typename T>
-constexpr c10::complex<T> operator+(const c10::complex<T>& val) {
+constexpr complex<T> operator+(const complex<T>& val) {
   return val;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator-(const c10::complex<T>& val) {
-  return c10::complex<T>(-val.real(), -val.imag());
+constexpr complex<T> operator-(const complex<T>& val) {
+  return complex<T>(-val.real(), -val.imag());
 }
 
 template<typename T>
-constexpr c10::complex<T> operator+(const c10::complex<T>& lhs, const c10::complex<T>& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) {
+  complex<T> result = lhs;
   return result += rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator+(const c10::complex<T>& lhs, const T& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator+(const complex<T>& lhs, const T& rhs) {
+  complex<T> result = lhs;
   return result += rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator+(const T& lhs, const c10::complex<T>& rhs) {
-  return c10::complex<T>(lhs + rhs.real(), rhs.imag());
+constexpr complex<T> operator+(const T& lhs, const complex<T>& rhs) {
+  return complex<T>(lhs + rhs.real(), rhs.imag());
 }
 
 template<typename T>
-constexpr c10::complex<T> operator-(const c10::complex<T>& lhs, const c10::complex<T>& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) {
+  complex<T> result = lhs;
   return result -= rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator-(const c10::complex<T>& lhs, const T& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator-(const complex<T>& lhs, const T& rhs) {
+  complex<T> result = lhs;
   return result -= rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator-(const T& lhs, const c10::complex<T>& rhs) {
-  c10::complex<T> result = -rhs;
+constexpr complex<T> operator-(const T& lhs, const complex<T>& rhs) {
+  complex<T> result = -rhs;
   return result += lhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator*(const c10::complex<T>& lhs, const c10::complex<T>& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) {
+  complex<T> result = lhs;
   return result *= rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator*(const c10::complex<T>& lhs, const T& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator*(const complex<T>& lhs, const T& rhs) {
+  complex<T> result = lhs;
   return result *= rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator*(const T& lhs, const c10::complex<T>& rhs) {
-  c10::complex<T> result = rhs;
+constexpr complex<T> operator*(const T& lhs, const complex<T>& rhs) {
+  complex<T> result = rhs;
   return result *= lhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator/(const c10::complex<T>& lhs, const c10::complex<T>& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) {
+  complex<T> result = lhs;
   return result /= rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator/(const c10::complex<T>& lhs, const T& rhs) {
-  c10::complex<T> result = lhs;
+constexpr complex<T> operator/(const complex<T>& lhs, const T& rhs) {
+  complex<T> result = lhs;
   return result /= rhs;
 }
 
 template<typename T>
-constexpr c10::complex<T> operator/(const T& lhs, const c10::complex<T>& rhs) {
-  c10::complex<T> result(lhs, T());
+constexpr complex<T> operator/(const T& lhs, const complex<T>& rhs) {
+  complex<T> result(lhs, T());
   return result /= rhs;
 }
 
@@ -415,42 +415,42 @@ constexpr c10::complex<fT> operator/(const iT& a, const c10::complex<fT>& b) {
 
 
 template<typename T>
-constexpr bool operator==(const c10::complex<T>& lhs, const c10::complex<T>& rhs) {
+constexpr bool operator==(const complex<T>& lhs, const complex<T>& rhs) {
   return (lhs.real() == rhs.real()) && (lhs.imag() == rhs.imag());
 }
 
 template<typename T>
-constexpr bool operator==(const c10::complex<T>& lhs, const T& rhs) {
+constexpr bool operator==(const complex<T>& lhs, const T& rhs) {
   return (lhs.real() == rhs) && (lhs.imag() == T());
 }
 
 template<typename T>
-constexpr bool operator==(const T& lhs, const c10::complex<T>& rhs) {
+constexpr bool operator==(const T& lhs, const complex<T>& rhs) {
   return (lhs == rhs.real()) && (T() == rhs.imag());
 }
 
 template<typename T>
-constexpr bool operator!=(const c10::complex<T>& lhs, const c10::complex<T>& rhs) {
+constexpr bool operator!=(const complex<T>& lhs, const complex<T>& rhs) {
   return !(lhs == rhs);
 }
 
 template<typename T>
-constexpr bool operator!=(const c10::complex<T>& lhs, const T& rhs) {
+constexpr bool operator!=(const complex<T>& lhs, const T& rhs) {
   return !(lhs == rhs);
 }
 
 template<typename T>
-constexpr bool operator!=(const T& lhs, const c10::complex<T>& rhs) {
+constexpr bool operator!=(const T& lhs, const complex<T>& rhs) {
   return !(lhs == rhs);
 }
 
 template <typename T, typename CharT, typename Traits>
-std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, const c10::complex<T>& x) {
+std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, const complex<T>& x) {
   return (os << static_cast<std::complex<T>>(x));
 }
 
 template <typename T, typename CharT, typename Traits>
-std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>& is, c10::complex<T>& x) {
+std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>& is, complex<T>& x) {
   std::complex<T> tmp;
   is >> tmp;
   x = tmp;
@@ -534,11 +534,11 @@ constexpr c10::complex<T> conj(const c10::complex<T>& z) {
 namespace c10 {
 
 template<typename T>
-C10_HOST_DEVICE c10::complex<T> polar(const T& r, const T& theta = T()) {
+C10_HOST_DEVICE complex<T> polar(const T& r, const T& theta = T()) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::polar(r, theta));
+  return static_cast<complex<T>>(thrust::polar(r, theta));
 #else
-  return static_cast<c10::complex<T>>(std::polar(r, theta));
+  return static_cast<complex<T>>(std::polar(r, theta));
 #endif
 }
 

--- a/c10/util/complex_type.h
+++ b/c10/util/complex_type.h
@@ -136,15 +136,11 @@ struct alignas(sizeof(T) * 2) complex {
 
   // Use SFINAE to specialize casting constructor for c10::complex<float> and c10::complex<double>
   template<typename U = T>
-  explicit constexpr complex(const std::enable_if_t<std::is_same<U, float>::value, complex<double>> &other) {
-    real_ = other.real_;
-    imag_ = other.imag_;
-  }
+  explicit constexpr complex(const std::enable_if_t<std::is_same<U, float>::value, complex<double>> &other):
+    real_(other.real_), imag_(other.imag_) {}
   template<typename U = T>
-  constexpr complex(const std::enable_if_t<std::is_same<U, double>::value, complex<float>> &other) {
-    real_ = other.real_;
-    imag_ = other.imag_;
-  };
+  constexpr complex(const std::enable_if_t<std::is_same<U, double>::value, complex<float>> &other):
+    real_(other.real_), imag_(other.imag_) {}
 
   constexpr complex<T> &operator =(T re) {
     real_ = re;

--- a/c10/util/complex_utils.h
+++ b/c10/util/complex_utils.h
@@ -1,3 +1,5 @@
+#include <limits>
+
 namespace c10 {
 
 template <typename T>
@@ -24,5 +26,12 @@ template <typename T>
 struct scalar_value_type<c10::complex<T>> {
   using type = T;
 };
+
+}
+
+namespace std {
+
+template <typename T>
+class numeric_limits<c10::complex<T>> : public numeric_limits<T>  {};
 
 }


### PR DESCRIPTION
**Main:**
- `c10::complex` is refactored: it no longer uses inheritance to specialize constructors, but using SFINAE instead. This implementation is cleaner and avoids some compiler bugs.
- `c10::Scalar` is cleaned up: it no longer needs to store complex as `double z[2]`, `c10::complex<double>` will work.

**Other cleanups:**
- `numeric_limits` of `c10::complex` is moved to `complex_utils.h`
- the variable in `c10::complex` storing real and imag is changed from `storage[2]` to `real_` and `imag_`
- remove the `c10::` before `complex` when in `c10` namespace