### PR TITLE
Fix merge_fp32_inputs_into_fp16 with no partition

### DIFF
--- a/caffe2/opt/custom/glow_net_transform.cc
+++ b/caffe2/opt/custom/glow_net_transform.cc
@@ -63,6 +63,10 @@ std::unordered_set<int> ParseNetPositionList(const std::string& str) {
   }
   auto tokens = caffe2::split(',', str);
   for (const auto& token : tokens) {
+    if (token == "-1") {
+      net_position_list.emplace(-1);
+      continue;
+    }
     auto range = caffe2::split('-', token);
     if (range.size() == 1) {
       net_position_list.emplace(std::stoi(range[0]));

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -327,8 +327,9 @@ void mergeFp32InputsAndConvertToFp16(
     }
 
     for (auto& op : ops) {
-      if (!op.device_option().node_name().empty() &&
-          op.device_option().node_name() == partition) {
+      if ((!op.device_option().node_name().empty() &&
+           op.device_option().node_name() == partition) ||
+          (op.device_option().node_name().empty() && partition == "default")) {
         for (auto& i : *op.mutable_input()) {
           if (user_input_set.count(i)) {
             i = partition + "_" + i + "_split";


### PR DESCRIPTION
Summary: By default, we don't have parition name, so previous impl will fail to rewire the input into the split-convert output. It's usually a hidden perf issue instead of a correctness issue.

Test Plan:
Enhanced
```
buck test glow/fb/test:test_merge_inputs_nnpi_fp16nnpi
```

Differential Revision: D21608439

