### PR TITLE
[NNPI] Support fp32 bias in NNPI Backend

### DIFF
--- a/caffe2/opt/custom/glow_net_transform.cc
+++ b/caffe2/opt/custom/glow_net_transform.cc
@@ -63,6 +63,10 @@ std::unordered_set<int> ParseNetPositionList(const std::string& str) {
   }
   auto tokens = caffe2::split(',', str);
   for (const auto& token : tokens) {
+    if (token == "-1") {
+      net_position_list.emplace(-1);
+      continue;
+    }
     auto range = caffe2::split('-', token);
     if (range.size() == 1) {
       net_position_list.emplace(std::stoi(range[0]));

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -327,8 +327,9 @@ void mergeFp32InputsAndConvertToFp16(
     }
 
     for (auto& op : ops) {
-      if (!op.device_option().node_name().empty() &&
-          op.device_option().node_name() == partition) {
+      if ((!op.device_option().node_name().empty() &&
+           op.device_option().node_name() == partition) ||
+          (op.device_option().node_name().empty() && partition == "default")) {
         for (auto& i : *op.mutable_input()) {
           if (user_input_set.count(i)) {
             i = partition + "_" + i + "_split";

--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -182,7 +182,7 @@ fbgemm::CompressedSparseColumn* ExtractOutlierMatrix(
 }
 
 // FIXME: code duplication with ConvDNNLowPOp::QuantizeBias_
-static void QuantizeConvBias(
+void QuantizeConvBias(
     const Blob& blob,
     int M,
     const TensorQuantizationParams& in_qparams,

--- a/caffe2/quantization/server/fbgemm_pack_op.h
+++ b/caffe2/quantization/server/fbgemm_pack_op.h
@@ -10,6 +10,13 @@ namespace caffe2 {
 
 using FCFp32Op = FullyConnectedOp<CPUContext>;
 
+void QuantizeConvBias(
+    const Blob& blob,
+    int M,
+    const dnnlowp::TensorQuantizationParams& in_qparams,
+    const vector<dnnlowp::TensorQuantizationParams>& filter_qparams,
+    std::vector<int32_t>& b_quantized);
+
 class FullyConnectedDNNLowPPackWeightOp final
     : public DNNLowPOp<std::uint8_t, FCFp32Op> {
  public:


### PR DESCRIPTION
Summary: ATT. NNPI is supporting it yet.

Test Plan:
unittests in the diff
```
buck test mode/dev //glow/fb/test/numerics:test_fc_nnpi_int8nnpi -- 'test_int8_fc_simple_fp32_bias \(glow\.fb\.test\.numerics\.test_fc_nnpi_int8\.Int8FCTest\)'
```

Failing with error:
```
I0407 17:13:45.174736 1553353 NNPIOptions.cpp:49] [NNPI_LOG][E] [GT] fully_connected.cpp(457): GTException raised: ICE-Layers exception: Data type mismatch between
                 tensor1: 'input' and tensor2: 'biases'
 at : /home/engshare/third-party2/fb-nnpi-sw/0.5.1.5/src/nnpi-sw/src/compiler/nnpi_compiler/src/ice_layers/src/fully_connected.cpp:457
```

Reviewed By: jackm321

Differential Revision: D20474831

