### PR TITLE
Add tags to torch.nn.Parameter

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15434,8 +15434,12 @@ a")
 
             m = TestModule()
             self.assertEqual(m.param.tags, expected_tags)
+
             m_traced = torch.jit.trace(m, torch.tensor(1.))
+            self.assertEqual(m.param.tags, expected_tags)
+
             m_scripted = torch.jit.script(m)
+            self.assertEqual(m.param.tags, expected_tags)
 
             def test_serialization(module):
                 with TemporaryFileName() as fname:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15437,26 +15437,14 @@ a")
             m_traced = torch.jit.trace(m, torch.tensor(1.))
             m_scripted = torch.jit.script(m)
 
-            def test_serialization_or_copy(module, support_deepcopy_and_torch_save):
-                module_unpickle = pickle.loads(pickle.dumps(module))
-                self.assertEqual(module_unpickle.param.tags, expected_tags)
-
+            def test_serialization(module):
                 with TemporaryFileName() as fname:
                     module.save(fname)
                     module_torch_jit_load = torch.jit.load(fname)
                     self.assertEqual(module_torch_jit_load.param.tags, expected_tags)
 
-                if support_deepcopy_and_torch_save:
-                    with TemporaryFileName() as fname:
-                        torch.save(module, fname)
-                        module_torch_load = torch.load(fname)
-                        self.assertEqual(module_torch_load.param.tags, expected_tags)
-
-                    module_copy = deepcopy(module)
-                    self.assertEqual(module_copy.param.tags, expected_tags)
-
-            test_serialization_or_copy(m_traced, support_deepcopy_and_torch_save=True)
-            test_serialization_or_copy(m_scripted, support_deepcopy_and_torch_save=False)
+            test_serialization(m_traced)
+            test_serialization(m_scripted)
 
         do_test(True, {"optimizer": "sparse"}, {"optimizer": "sparse"})
         do_test(True, None, {})

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15423,7 +15423,7 @@ a")
         def do_test(has_tags_arg, tags, expected_tags):
             class TestModule(nn.Module):
                 def __init__(self):
-                    super(Param, self).__init__()
+                    super(TestModule, self).__init__()
                     if has_tags_arg:
                         self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
                     else:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15419,6 +15419,8 @@ a")
             self.assertEqual(loaded.buffer1, torch.ones(2, 2) + 5)
             self.assertEqual(loaded.buffer2, torch.ones(2, 2) + 10)
 
+
+
     def test_string_slicing(self):
         def fn1(x):
             # type: (str) -> str

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15437,25 +15437,26 @@ a")
             m_traced = torch.jit.trace(m, torch.tensor(1.))
             m_scripted = torch.jit.script(m)
 
-            def test_serialization_or_copy(module):
+            def test_serialization_or_copy(module, support_deepcopy_and_torch_save):
                 module_unpickle = pickle.loads(pickle.dumps(module))
                 self.assertEqual(module_unpickle.param.tags, expected_tags)
-
-                with TemporaryFileName() as fname:
-                    torch.save(module, fname)
-                    module_torch_load = torch.load(fname)
-                    self.assertEqual(module_torch_load.param.tags, expected_tags)
 
                 with TemporaryFileName() as fname:
                     module.save(fname)
                     module_torch_jit_load = torch.jit.load(fname)
                     self.assertEqual(module_torch_jit_load.param.tags, expected_tags)
 
-                module_copy = deepcopy(module)
-                self.assertEqual(module_copy.param.tags, expected_tags)
+                if support_deepcopy_and_torch_save:
+                    with TemporaryFileName() as fname:
+                        torch.save(module, fname)
+                        module_torch_load = torch.load(fname)
+                        self.assertEqual(module_torch_load.param.tags, expected_tags)
 
-            test_serialization_or_copy(m_traced)
-            test_serialization_or_copy(m_scripted)
+                    module_copy = deepcopy(module)
+                    self.assertEqual(module_copy.param.tags, expected_tags)
+
+            test_serialization_or_copy(m_traced, support_deepcopy_and_torch_save=True)
+            test_serialization_or_copy(m_scripted, support_deepcopy_and_torch_save=False)
 
         do_test(True, {"optimizer": "sparse"}, {"optimizer": "sparse"})
         do_test(True, None, {})

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15433,7 +15433,7 @@ a")
                     return x
 
             m = TestModule()
-            self.assertEqual(m.tags, expected_tags)
+            self.assertEqual(m.param.tags, expected_tags)
             m_traced = torch.jit.trace(m, torch.tensor(1.))
             m_scripted = torch.jit.script(m)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15419,41 +15419,6 @@ a")
             self.assertEqual(loaded.buffer1, torch.ones(2, 2) + 5)
             self.assertEqual(loaded.buffer2, torch.ones(2, 2) + 10)
 
-    def test_parameter_tags(self):
-        def do_test(has_tags_arg, tags, expected_tags):
-            class TestModule(nn.Module):
-                def __init__(self):
-                    super(TestModule, self).__init__()
-                    if has_tags_arg:
-                        self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
-                    else:
-                        self.param = nn.Parameter(torch.randn(5, 5))
-
-                def forward(self, x):
-                    return x
-
-            m = TestModule()
-            self.assertEqual(m.param.tags, expected_tags)
-
-            m_traced = torch.jit.trace(m, torch.tensor(1.))
-            self.assertEqual(m.param.tags, expected_tags)
-
-            m_scripted = torch.jit.script(m)
-            self.assertEqual(m.param.tags, expected_tags)
-
-            def test_serialization(module):
-                with TemporaryFileName() as fname:
-                    module.save(fname)
-                    module_torch_jit_load = torch.jit.load(fname)
-                    self.assertEqual(module_torch_jit_load.param.tags, expected_tags)
-
-            test_serialization(m_traced)
-            test_serialization(m_scripted)
-
-        do_test(True, {"optimizer": "sparse"}, {"optimizer": "sparse"})
-        do_test(True, None, {})
-        do_test(False, None, {})
-
     def test_string_slicing(self):
         def fn1(x):
             # type: (str) -> str

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3769,18 +3769,18 @@ class TestNN(NNTestCase):
         do_test(True, None, {})
         do_test(False, None, {})
 
-    class TestModule(nn.Module):
-        def __init__(self, has_tags_arg):
-            super(TestModule, self).__init__()
-            if has_tags_arg:
-                self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
-            else:
-                self.param = nn.Parameter(torch.randn(5, 5))
-
-        def forward(self, x):
-            return x
-
     def test_module_with_parameter_tags(self):
+        class TestModule(nn.Module):
+            def __init__(self, has_tags_arg):
+                super(TestModule, self).__init__()
+                if has_tags_arg:
+                    self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
+                else:
+                    self.param = nn.Parameter(torch.randn(5, 5))
+
+            def forward(self, x):
+                return x
+
         def do_test(has_tags_arg, tags, expected_tags):
             m = TestModule(has_tags_arg)
             self.assertEqual(m.param.tags, expected_tags)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3741,20 +3741,27 @@ class TestNN(NNTestCase):
         self.assertEqual(mm[0].sub.weight[0, 0].item(), 555)
 
     def test_parameter_tags(self):
-        tags = {"optimizer": "sparse"}
-        new_param = Parameter(torch.randn(5, 5), tags=tags)
-        self.assertEqual(new_param.tags, tags)
+        def do_test(has_tags_arg, tags):
+            if has_tags_arg:
+                param = Parameter(torch.randn(5, 5), tags=tags)
+            else:
+                param = Parameter(torch.randn(5, 5))
+            self.assertEqual(param.tags, tags)
 
-        new_param_unpickle = pickle.loads(pickle.dumps(new_param))
-        self.assertEqual(new_param_unpickle.tags, tags)
+            param_unpickle = pickle.loads(pickle.dumps(param))
+            self.assertEqual(param_unpickle.tags, tags)
 
-        with TemporaryFileName() as fname:
-            torch.save(new_param, fname)
-            new_param_torch_load = torch.load(fname)
-            self.assertEqual(new_param_torch_load.tags, tags)
+            with TemporaryFileName() as fname:
+                torch.save(param, fname)
+                param_torch_load = torch.load(fname)
+                self.assertEqual(param_torch_load.tags, tags)
 
-        new_param_copy = deepcopy(new_param)
-        self.assertEqual(new_param_copy.tags, tags)
+            param_copy = deepcopy(param)
+            self.assertEqual(param_copy.tags, tags)
+
+        do_test(True, {"optimizer": "sparse"})
+        do_test(True, None)
+        do_test(False, None)
 
     def test_parameter_assignment(self):
         l = nn.Linear(5, 5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -365,6 +365,9 @@ class TestNN(NNTestCase):
             m = torch.load(path)
         input = torch.randn(2, 3, dtype=torch.float)
         self.assertEqual(m(input).size(), (2, 5))
+        # Legacy module should have their parameters' tags populated with empty dict
+        for p in m.parameters():
+            self.assertEqual(p.tags, {})
 
     def test_conv_backcompat(self):
         from torch.serialization import SourceChangeWarning
@@ -382,6 +385,9 @@ class TestNN(NNTestCase):
             m = torch.load(path, encoding='utf-8')
         input = torch.randn((1, 1, 1, 1), dtype=torch.float)
         self.assertEqual(m(input).size(), (1, 1, 1, 1))
+        # Legacy module should have their parameters' tags populated with empty dict
+        for p in m.parameters():
+            self.assertEqual(p.tags, {})
 
     def test_share_memory(self):
         class Net(nn.Module):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3771,7 +3771,7 @@ class TestNN(NNTestCase):
 
     def test_module_with_parameter_tags(self):
         class TestModule(nn.Module):
-            def __init__(self, has_tags_arg):
+            def __init__(self, has_tags_arg, tags):
                 super(TestModule, self).__init__()
                 if has_tags_arg:
                     self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
@@ -3782,7 +3782,7 @@ class TestNN(NNTestCase):
                 return x
 
         def do_test(has_tags_arg, tags, expected_tags):
-            m = TestModule(has_tags_arg)
+            m = TestModule(has_tags_arg, tags)
             self.assertEqual(m.param.tags, expected_tags)
 
             m_unpickle = pickle.loads(pickle.dumps(m))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3741,27 +3741,27 @@ class TestNN(NNTestCase):
         self.assertEqual(mm[0].sub.weight[0, 0].item(), 555)
 
     def test_parameter_tags(self):
-        def do_test(has_tags_arg, tags):
+        def do_test(has_tags_arg, tags, expected_tags):
             if has_tags_arg:
                 param = Parameter(torch.randn(5, 5), tags=tags)
             else:
                 param = Parameter(torch.randn(5, 5))
-            self.assertEqual(param.tags, tags)
+            self.assertEqual(param.tags, expected_tags)
 
             param_unpickle = pickle.loads(pickle.dumps(param))
-            self.assertEqual(param_unpickle.tags, tags)
+            self.assertEqual(param_unpickle.tags, expected_tags)
 
             with TemporaryFileName() as fname:
                 torch.save(param, fname)
                 param_torch_load = torch.load(fname)
-                self.assertEqual(param_torch_load.tags, tags)
+                self.assertEqual(param_torch_load.tags, expected_tags)
 
             param_copy = deepcopy(param)
-            self.assertEqual(param_copy.tags, tags)
+            self.assertEqual(param_copy.tags, expected_tags)
 
-        do_test(True, {"optimizer": "sparse"})
-        do_test(True, None)
-        do_test(False, None)
+        do_test(True, {"optimizer": "sparse"}, {"optimizer": "sparse"})
+        do_test(True, None, {})
+        do_test(False, None, {})
 
     def test_parameter_assignment(self):
         l = nn.Linear(5, 5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3740,6 +3740,22 @@ class TestNN(NNTestCase):
         self.assertEqual(mm[0].param[0].item(), 10)
         self.assertEqual(mm[0].sub.weight[0, 0].item(), 555)
 
+    def test_parameter_tags(self):
+        tags = {"optimizer": "sparse"}
+        new_param = Parameter(torch.randn(5, 5), tags=tags)
+        self.assertEqual(new_param.tags, tags)
+
+        new_param_unpickle = pickle.loads(pickle.dumps(new_param))
+        self.assertEqual(new_param_unpickle.tags, tags)
+
+        with TemporaryFileName() as fname:
+            torch.save(new_param, fname)
+            new_param_torch_load = torch.load(fname)
+            self.assertEqual(new_param_torch_load.tags, tags)
+
+        new_param_copy = deepcopy(new_param)
+        self.assertEqual(new_param_copy.tags, tags)
+
     def test_parameter_assignment(self):
         l = nn.Linear(5, 5)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3769,20 +3769,20 @@ class TestNN(NNTestCase):
         do_test(True, None, {})
         do_test(False, None, {})
 
+    class TestModule(nn.Module):
+        def __init__(self, has_tags_arg):
+            super(TestModule, self).__init__()
+            if has_tags_arg:
+                self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
+            else:
+                self.param = nn.Parameter(torch.randn(5, 5))
+
+        def forward(self, x):
+            return x
+
     def test_module_with_parameter_tags(self):
         def do_test(has_tags_arg, tags, expected_tags):
-            class TestModule(nn.Module):
-                def __init__(self):
-                    super(TestModule, self).__init__()
-                    if has_tags_arg:
-                        self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
-                    else:
-                        self.param = nn.Parameter(torch.randn(5, 5))
-
-                def forward(self, x):
-                    return x
-
-            m = TestModule()
+            m = TestModule(has_tags_arg)
             self.assertEqual(m.param.tags, expected_tags)
 
             m_unpickle = pickle.loads(pickle.dumps(m))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3791,13 +3791,11 @@ class TestNN(NNTestCase):
                 # Parameter tags should not be exported in `Module.state_dict()`
                 self.assertFalse(hasattr(m_state_dict["param"], "tags"))
 
+                # Loading a state dict does not affect a module's parameter tags
                 torch.save(m_state_dict, fname)
                 m2 = torch.nn.Linear(4, 5)
                 m2_tags = {"optimizer": "dense"}
-                if has_tags_arg:
-                    m2.param = Parameter(torch.randn(5, 5), tags=m2_tags)
-                else:
-                    m2.param = Parameter(torch.randn(5, 5))
+                m2.param = Parameter(torch.randn(5, 5), tags=m2_tags)
                 m2.load_state_dict(torch.load(fname))
                 self.assertEqual(m2.param.tags, m2_tags)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3786,6 +3786,13 @@ class TestNN(NNTestCase):
                 m_torch_load = torch.load(fname)
                 self.assertEqual(m_torch_load.param.tags, expected_tags)
 
+            with TemporaryFileName() as fname:
+                torch.save(m.state_dict(), fname)
+                m2 = torch.nn.Linear(4, 5)
+                m2.param = Parameter(torch.randn(5, 5))
+                m2.load_state_dict(torch.load(fname))
+                self.assertEqual(m2.param.tags, expected_tags)
+
             m_copy = deepcopy(m)
             self.assertEqual(m_copy.param.tags, expected_tags)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3770,19 +3770,12 @@ class TestNN(NNTestCase):
         do_test(False, None, {})
 
     def test_module_with_parameter_tags(self):
-        class TestModule(nn.Module):
-            def __init__(self, has_tags_arg, tags):
-                super(TestModule, self).__init__()
-                if has_tags_arg:
-                    self.param = nn.Parameter(torch.randn(5, 5), tags=tags)
-                else:
-                    self.param = nn.Parameter(torch.randn(5, 5))
-
-            def forward(self, x):
-                return x
-
         def do_test(has_tags_arg, tags, expected_tags):
-            m = TestModule(has_tags_arg, tags)
+            m = torch.nn.Linear(4, 5)
+            if has_tags_arg:
+                m.param = Parameter(torch.randn(5, 5), tags=tags)
+            else:
+                m.param = Parameter(torch.randn(5, 5))
             self.assertEqual(m.param.tags, expected_tags)
 
             m_unpickle = pickle.loads(pickle.dumps(m))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3788,7 +3788,7 @@ class TestNN(NNTestCase):
 
             with TemporaryFileName() as fname:
                 m_state_dict = m.state_dict()
-                # Parameter tags should not be exported in `Module.state_dict()`
+                # Parameter tags should not be included in `Module.state_dict()`
                 self.assertFalse(hasattr(m_state_dict["param"], "tags"))
 
                 # Loading a state dict does not affect a module's parameter tags

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3789,7 +3789,10 @@ class TestNN(NNTestCase):
             with TemporaryFileName() as fname:
                 torch.save(m.state_dict(), fname)
                 m2 = torch.nn.Linear(4, 5)
-                m2.param = Parameter(torch.randn(5, 5))
+                if has_tags_arg:
+                    m2.param = Parameter(torch.randn(5, 5), tags=tags)
+                else:
+                    m2.param = Parameter(torch.randn(5, 5))
                 m2.load_state_dict(torch.load(fname))
                 self.assertEqual(m2.param.tags, expected_tags)
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -176,7 +176,7 @@ def _rebuild_qtensor(storage, storage_offset, size, stride, quantizer_params, re
     tensor._backward_hooks = backward_hooks
     return tensor
 
-def _rebuild_parameter(data, requires_grad, backward_hooks, tags):
+def _rebuild_parameter(data, requires_grad, backward_hooks, tags={}):
     param = torch.nn.Parameter(data, requires_grad, tags)
     # NB: This line exists only for backwards compatibility; the
     # general expectation is that backward_hooks is an empty

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -176,8 +176,8 @@ def _rebuild_qtensor(storage, storage_offset, size, stride, quantizer_params, re
     tensor._backward_hooks = backward_hooks
     return tensor
 
-def _rebuild_parameter(data, requires_grad, backward_hooks):
-    param = torch.nn.Parameter(data, requires_grad)
+def _rebuild_parameter(data, requires_grad, backward_hooks, tags):
+    param = torch.nn.Parameter(data, requires_grad, tags)
     # NB: This line exists only for backwards compatibility; the
     # general expectation is that backward_hooks is an empty
     # OrderedDict.  See Note [Don't serialize hooks]

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -176,7 +176,7 @@ def _rebuild_qtensor(storage, storage_offset, size, stride, quantizer_params, re
     tensor._backward_hooks = backward_hooks
     return tensor
 
-def _rebuild_parameter(data, requires_grad, backward_hooks, tags={}):
+def _rebuild_parameter(data, requires_grad, backward_hooks, tags=None):
     param = torch.nn.Parameter(data, requires_grad, tags)
     # NB: This line exists only for backwards compatibility; the
     # general expectation is that backward_hooks is an empty

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -790,9 +790,6 @@ class Module(object):
         local_state = {k: v for k, v in local_name_params if v is not None}
 
         for name, param in local_state.items():
-            if name == "param":
-                print(param.tags)
-
             key = prefix + name
             if key in state_dict:
                 input_param = state_dict[key]

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -790,6 +790,9 @@ class Module(object):
         local_state = {k: v for k, v in local_name_params if v is not None}
 
         for name, param in local_state.items():
+            if name == "param":
+                print(param.tags)
+
             key = prefix + name
             if key in state_dict:
                 input_param = state_dict[key]

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -712,7 +712,7 @@ class Module(object):
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         r"""Returns a dictionary containing a whole state of the module.
 
-        Both parameters and persistent buffers (e.g. running averages) are
+        Both parameters (without tags) and persistent buffers (e.g. running averages) are
         included. Keys are corresponding parameter and buffer names.
 
         Returns:

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -20,16 +20,18 @@ class Parameter(torch.Tensor):
             :ref:`excluding-subgraphs` for more details. Default: `True`
     """
 
-    def __new__(cls, data=None, requires_grad=True):
+    def __new__(cls, data=None, requires_grad=True, tags={}):
         if data is None:
             data = torch.Tensor()
-        return torch.Tensor._make_subclass(cls, data, requires_grad)
+        instance = torch.Tensor._make_subclass(cls, data, requires_grad)
+        instance.tags = tags
+        return instance
 
     def __deepcopy__(self, memo):
         if id(self) in memo:
             return memo[id(self)]
         else:
-            result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.requires_grad)
+            result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.requires_grad, self.tags)
             memo[id(self)] = result
             return result
 
@@ -40,5 +42,5 @@ class Parameter(torch.Tensor):
         # See Note [Don't serialize hooks]
         return (
             torch._utils._rebuild_parameter,
-            (self.data, self.requires_grad, OrderedDict())
+            (self.data, self.requires_grad, OrderedDict(), self.tags)
         )

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -20,11 +20,11 @@ class Parameter(torch.Tensor):
             :ref:`excluding-subgraphs` for more details. Default: `True`
     """
 
-    def __new__(cls, data=None, requires_grad=True, tags={}):
+    def __new__(cls, data=None, requires_grad=True, tags=None):
         if data is None:
             data = torch.Tensor()
         instance = torch.Tensor._make_subclass(cls, data, requires_grad)
-        instance.tags = tags
+        instance.tags = {} if tags is None else tags
         return instance
 
     def __deepcopy__(self, memo):

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -27,7 +27,7 @@ class Parameter(torch.Tensor):
         if data is None:
             data = torch.Tensor()
         instance = torch.Tensor._make_subclass(cls, data, requires_grad)
-        if tags is None
+        if tags is None:
             instance.tags = {}
         else:
             assert isinstance(tags, dict)

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -19,7 +19,7 @@ class Parameter(torch.Tensor):
         requires_grad (bool, optional): if the parameter requires gradient. See
             :ref:`excluding-subgraphs` for more details. Default: `True`
         tags (dict, optional): special information about this parameter (e.g.
-            which optimizer to use). Note that `tags` are not exported in
+            which optimizer to use). Note that `tags` are not included in
             the parameter's containing module's `.state_dict()`. Default: `None`
     """
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -38,6 +38,7 @@ class Parameter(torch.Tensor):
     def __repr__(self):
         return 'Parameter containing:\n' + super(Parameter, self).__repr__()
 
+    # yf225 TODO: we can make this forward compat by checking whether tags is None / {} before serialization
     def __reduce_ex__(self, proto):
         # See Note [Don't serialize hooks]
         return (

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -49,7 +49,7 @@ class Parameter(torch.Tensor):
                 (self.data, self.requires_grad, OrderedDict(), self.tags)
             )
         else:
-            # This ensures parameter without tags can be deserialized
+            # This ensures that parameter without tags can be deserialized
             # by older version of PyTorch (i.e. forward compatibility)
             return (
                 torch._utils._rebuild_parameter,

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -27,7 +27,11 @@ class Parameter(torch.Tensor):
         if data is None:
             data = torch.Tensor()
         instance = torch.Tensor._make_subclass(cls, data, requires_grad)
-        instance.tags = {} if tags is None else tags
+        if tags is None
+            instance.tags = {}
+        else:
+            assert isinstance(tags, dict)
+            instance.tags = tags
         return instance
 
     def __deepcopy__(self, memo):

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -18,6 +18,9 @@ class Parameter(torch.Tensor):
         data (Tensor): parameter tensor.
         requires_grad (bool, optional): if the parameter requires gradient. See
             :ref:`excluding-subgraphs` for more details. Default: `True`
+        tags (dict, optional): special information about this parameter (e.g.
+            which optimizer to use). Note that `tags` are not exported in
+            the parameter's containing module's `.state_dict()`. Default: `None`
     """
 
     def __new__(cls, data=None, requires_grad=True, tags=None):

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -41,10 +41,17 @@ class Parameter(torch.Tensor):
     def __repr__(self):
         return 'Parameter containing:\n' + super(Parameter, self).__repr__()
 
-    # yf225 TODO: we can make this forward compat by checking whether tags is None / {} before serialization
     def __reduce_ex__(self, proto):
         # See Note [Don't serialize hooks]
-        return (
-            torch._utils._rebuild_parameter,
-            (self.data, self.requires_grad, OrderedDict(), self.tags)
-        )
+        if self.tags:
+            return (
+                torch._utils._rebuild_parameter,
+                (self.data, self.requires_grad, OrderedDict(), self.tags)
+            )
+        else:
+            # This ensures parameter without tags can be deserialized
+            # by older version of PyTorch (i.e. forward compatibility)
+            return (
+                torch._utils._rebuild_parameter,
+                (self.data, self.requires_grad, OrderedDict())
+            )


### PR DESCRIPTION
Currently, if some parameters in a module should be optimized in a different way (i.e. use `RowWiseAdagrad` for sparse parameters, `Adagrad` for dense parameters), such training config info has to be stored somewhere else, detached from the parameters. Here is a downside to this approach:
- If the same parameter is registered in multiple modules, it's hard to make sure all modules have the same training config info for this parameter.
  - If training config info is stored at module _instance_ level, we don't have logic that copies the training config info along with the parameter.
  - If training config info is stored at module _class_ level (e.g. as a class variable), these info won't persist after pickle/unpickle.
  - If training config info is stored in a separate object, then we need to make sure this object is serialized _along with_ the module, adding an extra step after the familiar `torch.save` API.

Ideally, information about a parameter should be stored _within_ the parameter. DPER3 (Facebook's internal ranking/personalization framework) `PyTorchParameterInfo` class takes this approach by subclassing `torch.nn.Parameter` and add `tags` and `optimizer` fields to tag the parameters with training config info. However, `PyTorchParameterInfo` is a DPER3-specific construct, and vanilla PyTorch modules still don't have the ability to add `tags` to parameters. This prevents DPER3 module from taking PyTorch module as submodules, limiting PyTorch module's usefulness in ranking use cases.

In this PR I propose that we add `tags` of dict type to `torch.nn.Parameter`. DPER3 can then store necessary training config info into `tags`, and thus be able to use PyTorch module as submodules.

cc. @kennyhorror @volkhin @lupesko @henryoier @alyssawangqq @(Benjamin Au)