### PR TITLE
Do not use "buffer" in reentrant autograd err msg

### DIFF
--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -101,8 +101,8 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
 }
 
 const char* ERR_BACKWARD_TWICE =
-    "Trying to backward through the graph a second time, but the buffers have "
-    "already been freed. Specify retain_graph=True when calling backward "
-    "the first time.";
+    "Trying to backward through the graph a second time, but the saved intermediate "
+    "results have already been freed. Specify retain_graph=True when calling "
+    "backward the first time.";
 
 }} // namespace torch::autograd


### PR DESCRIPTION
`buffer` is also used to refer to `nn.Module`'s buffer. Wording is changed to reduce confusion between the two.

