### PR TITLE
Fix target determination file diffing

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -187,7 +187,7 @@ function file_diff_from_base() {
   set +e
   git fetch origin master --quiet
   set -e
-  git diff --name-only "$(git merge-base origin master HEAD)" > "$1"
+  git diff --name-only "$(git merge-base origin/master HEAD)" > "$1"
 }
 
 function get_bazel() {


### PR DESCRIPTION
It seems like all this time this was accidentally doing a 3-way merge-base, oops.

Test plan:

```
$ git checkout gh/mohammadmahdijavanmard/1/head
$ git merge-base origin master HEAD --all
8292742ba020fcff90f14418c18741ebf606103b
$ git merge-base origin/master HEAD --all
324dc1623e2f91892038fb1b151450a7c6529dd9
```

