### PR TITLE
[TensorExpr] (trivial) unique Kernel input names

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1318,7 +1318,7 @@ void TensorExprKernel::bindInput(const torch::jit::Value* input) {
       tensors_.emplace(
           input->unique(),
           Compute(
-              "input",
+              "input" + c10::to_string(tensors_.size() + 1),
               inputTensorDims,
               [&](const std::vector<VarHandle>& axes) {
                 ExprHandle idx = 0;


### PR DESCRIPTION
We have a bug where Function names are not uniqued which produces bad printed output, e.g:
```
{
  for (int i0 = 0; i0 < 1024; i0++) {
    input[i0] = t0[0 + i0 * 1];
  }
  for (int i0_1 = 0; i0_1 < 1024; i0_1++) {
    input_1[i0_1] = t1[0 + i0_1 * 1];
  }
  for (int v = 0; v < 1024; v++) {
    aten_add[v] = (input(v)) + float(1) * (input(v));
  }
  for (int v_1 = 0; v_1 < 1024; v_1++) {
    aten_sub[v_1] = (aten_add(v_1)) - float(1) * (input(v_1));
  }
}
```

Notice the names of the vars in the `aten_add` line which make it appear as though input_1 isn't used. This is because the Buf names are uniqued by the unique_name_manager but the FunctionCall names are not.

Not fixing this right now, but working around it by reducing the number of Tensors that are created with the same name ("input") in kernel.cpp. That example now looks like:
```
{
  for (int i0 = 0; i0 < 1024; i0++) {
    input1[i0] = t0[0 + i0 * 1];
  }
  for (int i0_1 = 0; i0_1 < 1024; i0_1++) {
    input2[i0_1] = t1[0 + i0_1 * 1];
  }
  for (int v = 0; v < 1024; v++) {
    aten_add[v] = (input1(v)) + float(1) * (input2(v));
  }
  for (int v_1 = 0; v_1 < 1024; v_1++) {
    aten_sub[v_1] = (aten_add(v_1)) - float(1) * (input1(v_1));
  }
}
```

To be clear, the bug still exists but it's not blocking what I'm trying to do right now 😄 