### PR TITLE
[JIT][to-backend] Fix compilation unit and name mangling of generated module

### DIFF
--- a/torch/csrc/jit/backends/backend.h
+++ b/torch/csrc/jit/backends/backend.h
@@ -60,7 +60,10 @@ class backend {
       auto any_dict_ty = DictType::create(StringType::get(), AnyType::get());
 
       // Generate LoweredModule.
-      Module loweredModule("torch.jit." + backend_name + "LoweredModule");
+      Module loweredModule(
+          "torch.jit." + backend_name + "LoweredModule",
+          get_python_cu(),
+          /*should_mangle=*/true);
 
       // Generate attributes.
       // This is the original cloned and preprocessed module.


### PR DESCRIPTION
**Summary**
This commit gets rid of the separate compilation unit that is currently
being created for every backend-specific module generated by
`jit::backend::generateToBackendFn` and mangles the name properly to
allow multiple backend-specific modules to coexist in the same
compilation unit.

**Test Plan**
`python test/test_jit.py TestBackends`

**Fixes**
This pull request fixes part of #37841.
