### PR TITLE
Revert "Updates assertEqual to use torch.isclose-like logic (#37294)"

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4065,13 +4065,13 @@ for shape in [(1,), ()]:
         b = torch.tensor([-1., 0., 1.], requires_grad=True)
         c = torch.sum(a**b)
         c.backward()
-        self.assertEqual(b.grad, torch.tensor([-inf, 0., 0.]))
+        self.assertEqual(b.grad, torch.tensor([-inf, 0., 0.]), allow_inf=True)
 
         s = 0
         b = torch.tensor([-1., 0., 1.], requires_grad=True)
         c = torch.sum(s**b)
         c.backward()
-        self.assertEqual(b.grad, torch.tensor([-inf, 0., 0.]))
+        self.assertEqual(b.grad, torch.tensor([-inf, 0., 0.]), allow_inf=True)
 
     def test_custom_function_error(self):
         class BadFw(Function):
@@ -5533,9 +5533,9 @@ class TestAutogradDeviceType(TestCase):
             f[0] = nan
             self.assertTrue(math.isnan(float(f)))
             f[0] = inf
-            self.assertEqual(float(f), inf)
+            self.assertEqual(float(f), inf, allow_inf=True)
             f[0] = -inf
-            self.assertEqual(float(f), -inf)
+            self.assertEqual(float(f), -inf, allow_inf=True)
 
             # integral -> floating point
             # check we can convert something that loses precision

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -866,9 +866,11 @@ class TestDistributions(TestCase):
                     self.assertEqual(expanded.batch_shape, expanded_shape)
                     try:
                         self.assertEqual(expanded.mean,
-                                         d.mean.expand(expanded_shape + d.event_shape))
+                                         d.mean.expand(expanded_shape + d.event_shape),
+                                         allow_inf=True)
                         self.assertEqual(expanded.variance,
-                                         d.variance.expand(expanded_shape + d.event_shape))
+                                         d.variance.expand(expanded_shape + d.event_shape),
+                                         allow_inf=True)
                     except NotImplementedError:
                         pass
 
@@ -938,7 +940,7 @@ class TestDistributions(TestCase):
         s = 0.3
         self.assertEqual(Geometric(p).sample((8,)).size(), (8, 3))
         self.assertEqual(Geometric(1).sample(), 0)
-        self.assertEqual(Geometric(1).log_prob(torch.tensor(1.)), -inf)
+        self.assertEqual(Geometric(1).log_prob(torch.tensor(1.)), -inf, allow_inf=True)
         self.assertEqual(Geometric(1).log_prob(torch.tensor(0.)), 0)
         self.assertFalse(Geometric(p).sample().requires_grad)
         self.assertEqual(Geometric(r).sample((8,)).size(), (8,))
@@ -1038,11 +1040,11 @@ class TestDistributions(TestCase):
         bin0 = Binomial(total_count, 0)
         self.assertEqual(bin0.sample(), 0)
         self.assertAlmostEqual(bin0.log_prob(torch.tensor([0.]))[0], 0, places=3)
-        self.assertEqual(float(bin0.log_prob(torch.tensor([1.])).exp()), 0)
+        self.assertEqual(float(bin0.log_prob(torch.tensor([1.])).exp()), 0, allow_inf=True)
         bin1 = Binomial(total_count, 1)
         self.assertEqual(bin1.sample(), total_count)
         self.assertAlmostEqual(bin1.log_prob(torch.tensor([float(total_count)]))[0], 0, places=3)
-        self.assertEqual(float(bin1.log_prob(torch.tensor([float(total_count - 1)])).exp()), 0)
+        self.assertEqual(float(bin1.log_prob(torch.tensor([float(total_count - 1)])).exp()), 0, allow_inf=True)
         zero_counts = torch.zeros(torch.Size((2, 2)))
         bin2 = Binomial(zero_counts, 1)
         self.assertEqual(bin2.sample(), zero_counts)
@@ -1373,8 +1375,8 @@ class TestDistributions(TestCase):
         uniform = Uniform(low_1d, high_1d)
         above_high = torch.tensor([4.0])
         below_low = torch.tensor([-1.0])
-        self.assertEqual(uniform.log_prob(above_high).item(), -inf)
-        self.assertEqual(uniform.log_prob(below_low).item(), -inf)
+        self.assertEqual(uniform.log_prob(above_high).item(), -inf, allow_inf=True)
+        self.assertEqual(uniform.log_prob(below_low).item(), -inf, allow_inf=True)
 
         # check cdf computation when value outside range
         self.assertEqual(uniform.cdf(below_low).item(), 0)
@@ -1418,7 +1420,7 @@ class TestDistributions(TestCase):
         loc_1d = torch.zeros(1, requires_grad=True)
         scale_1d = torch.ones(1, requires_grad=True)
         self.assertTrue(is_all_nan(Cauchy(loc_1d, scale_1d).mean))
-        self.assertEqual(Cauchy(loc_1d, scale_1d).variance, inf)
+        self.assertEqual(Cauchy(loc_1d, scale_1d).variance, inf, allow_inf=True)
         self.assertEqual(Cauchy(loc, scale).sample().size(), (5, 5))
         self.assertEqual(Cauchy(loc, scale).sample((7,)).size(), (7, 5, 5))
         self.assertEqual(Cauchy(loc_1d, scale_1d).sample().size(), (1,))
@@ -1444,7 +1446,7 @@ class TestDistributions(TestCase):
         scale = torch.ones(5, 5, requires_grad=True)
         scale_1d = torch.ones(1, requires_grad=True)
         self.assertTrue(is_all_nan(HalfCauchy(scale_1d).mean))
-        self.assertEqual(HalfCauchy(scale_1d).variance, inf)
+        self.assertEqual(HalfCauchy(scale_1d).variance, inf, allow_inf=True)
         self.assertEqual(HalfCauchy(scale).sample().size(), (5, 5))
         self.assertEqual(HalfCauchy(scale).sample((7,)).size(), (7, 5, 5))
         self.assertEqual(HalfCauchy(scale_1d).sample().size(), (1,))
@@ -2174,8 +2176,8 @@ class TestDistributions(TestCase):
         alpha = torch.randn(2, 3).abs().requires_grad_()
         scale_1d = torch.randn(1).abs().requires_grad_()
         alpha_1d = torch.randn(1).abs().requires_grad_()
-        self.assertEqual(Pareto(scale_1d, 0.5).mean, inf)
-        self.assertEqual(Pareto(scale_1d, 0.5).variance, inf)
+        self.assertEqual(Pareto(scale_1d, 0.5).mean, inf, allow_inf=True)
+        self.assertEqual(Pareto(scale_1d, 0.5).variance, inf, allow_inf=True)
         self.assertEqual(Pareto(scale, alpha).sample().size(), (2, 3))
         self.assertEqual(Pareto(scale, alpha).sample((5,)).size(), (5, 2, 3))
         self.assertEqual(Pareto(scale_1d, alpha_1d).sample((1,)).size(), (1, 1))
@@ -2292,7 +2294,7 @@ class TestDistributions(TestCase):
         df_1d = torch.randn(1).exp().requires_grad_()
         self.assertTrue(is_all_nan(StudentT(1).mean))
         self.assertTrue(is_all_nan(StudentT(1).variance))
-        self.assertEqual(StudentT(2).variance, inf)
+        self.assertEqual(StudentT(2).variance, inf, allow_inf=True)
         self.assertEqual(StudentT(df).sample().size(), (2, 3))
         self.assertEqual(StudentT(df).sample((5,)).size(), (5, 2, 3))
         self.assertEqual(StudentT(df_1d).sample((1,)).size(), (1, 1))
@@ -2377,7 +2379,7 @@ class TestDistributions(TestCase):
             x = dist.sample()
             actual_log_prob = dist.log_prob(x).sum()
             expected_log_prob = scipy.stats.beta.logpdf(x, con1, con0)
-            self.assertAlmostEqual(float(actual_log_prob), float(expected_log_prob), places=3)
+            self.assertAlmostEqual(float(actual_log_prob), float(expected_log_prob), places=3, allow_inf=True)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_beta_sample(self):
@@ -3867,7 +3869,7 @@ class TestNumericalStability(TestCase):
             log_pdf_prob_1 = categorical.log_prob(torch.tensor([0, 1], dtype=dtype))
             self.assertEqual(log_pdf_prob_1.item(), 0)
             log_pdf_prob_0 = categorical.log_prob(torch.tensor([1, 0], dtype=dtype))
-            self.assertEqual(log_pdf_prob_0.item(), -inf)
+            self.assertEqual(log_pdf_prob_0.item(), -inf, allow_inf=True)
 
     def test_multinomial_log_prob(self):
         for dtype in ([torch.float, torch.double]):
@@ -3884,7 +3886,7 @@ class TestNumericalStability(TestCase):
             log_pdf_prob_1 = multinomial.log_prob(torch.tensor([0, 10], dtype=dtype))
             self.assertEqual(log_pdf_prob_1.item(), 0)
             log_pdf_prob_0 = multinomial.log_prob(torch.tensor([10, 0], dtype=dtype))
-            self.assertEqual(log_pdf_prob_0.item(), -inf)
+            self.assertEqual(log_pdf_prob_0.item(), -inf, allow_inf=True)
 
     def test_continuous_bernoulli_gradient(self):
 
@@ -4144,9 +4146,9 @@ class TestAgainstScipy(TestCase):
                 # Cauchy, HalfCauchy distributions' mean is nan, skipping check
                 continue
             elif isinstance(pytorch_dist, (LowRankMultivariateNormal, MultivariateNormal)):
-                self.assertEqual(pytorch_dist.mean, scipy_dist.mean, message=pytorch_dist)
+                self.assertEqual(pytorch_dist.mean, scipy_dist.mean, allow_inf=True, message=pytorch_dist)
             else:
-                self.assertEqual(pytorch_dist.mean, scipy_dist.mean(), message=pytorch_dist)
+                self.assertEqual(pytorch_dist.mean, scipy_dist.mean(), allow_inf=True, message=pytorch_dist)
 
     def test_variance_stddev(self):
         for pytorch_dist, scipy_dist in self.distribution_pairs:
@@ -4161,7 +4163,7 @@ class TestAgainstScipy(TestCase):
                 self.assertEqual(pytorch_dist.variance, np.diag(scipy_dist.cov), message=pytorch_dist)
                 self.assertEqual(pytorch_dist.stddev, np.diag(scipy_dist.cov) ** 0.5, message=pytorch_dist)
             else:
-                self.assertEqual(pytorch_dist.variance, scipy_dist.var(), message=pytorch_dist)
+                self.assertEqual(pytorch_dist.variance, scipy_dist.var(), allow_inf=True, message=pytorch_dist)
                 self.assertEqual(pytorch_dist.stddev, scipy_dist.var() ** 0.5, message=pytorch_dist)
 
     def test_cdf(self):
@@ -4883,7 +4885,7 @@ class TestJit(TestCase):
             actual = traced_f(*values)
             expected[expected == float('inf')] = 0.
             actual[actual == float('inf')] = 0.
-            self.assertEqual(expected, actual,
+            self.assertEqual(expected, actual, allow_inf=True,
                              message='{}\nExpected:\n{}\nActual:\n{}'.format(Dist.__name__, expected, actual))
 
     def test_variance(self):
@@ -4907,7 +4909,7 @@ class TestJit(TestCase):
             actual = traced_f(*values)
             expected[expected == float('inf')] = 0.
             actual[actual == float('inf')] = 0.
-            self.assertEqual(expected, actual,
+            self.assertEqual(expected, actual, allow_inf=True,
                              message='{}\nExpected:\n{}\nActual:\n{}'.format(Dist.__name__, expected, actual))
 
     def test_entropy(self):
@@ -4931,7 +4933,7 @@ class TestJit(TestCase):
             values, sample = self._perturb(Dist, keys, values, sample)
             expected = f(*values)
             actual = traced_f(*values)
-            self.assertEqual(expected, actual,
+            self.assertEqual(expected, actual, allow_inf=True,
                              message='{}\nExpected:\n{}\nActual:\n{}'.format(Dist.__name__, expected, actual))
 
     def test_cdf(self):
@@ -4952,7 +4954,7 @@ class TestJit(TestCase):
             values, sample = self._perturb(Dist, keys, values, sample)
             expected = f(sample, *values)
             actual = traced_f(sample, *values)
-            self.assertEqual(expected, actual,
+            self.assertEqual(expected, actual, allow_inf=True,
                              message='{}\nExpected:\n{}\nActual:\n{}'.format(Dist.__name__, expected, actual))
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10835,19 +10835,19 @@ class TestNNDeviceType(NNTestCase):
         t = torch.tensor([[[float("-inf")]]])
         m = nn.MaxPool1d(kernel_size=1, return_indices=True)
         output, indices = m(t)
-        self.assertEqual(output[0, 0, 0], float("-inf"))
+        self.assertEqual(output[0, 0, 0], float("-inf"), allow_inf=True)
         self.assertEqual(indices[0, 0, 0], 0)
 
         t = torch.tensor([[[float("-inf")]]])
         m = nn.MaxPool2d(kernel_size=1, return_indices=True)
         output, indices = m(t)
-        self.assertEqual(output[0, 0, 0], float("-inf"))
+        self.assertEqual(output[0, 0, 0], float("-inf"), allow_inf=True)
         self.assertEqual(indices[0, 0, 0], 0)
 
         t = torch.tensor([[[[float("-inf")]]]])
         m = nn.MaxPool3d(kernel_size=1, return_indices=True)
         output, indices = m(t)
-        self.assertEqual(output[0, 0, 0, 0], float("-inf"))
+        self.assertEqual(output[0, 0, 0, 0], float("-inf"), allow_inf=True)
         self.assertEqual(indices[0, 0, 0, 0], 0)
 
     @dtypesIfCUDA(*ALL_TENSORTYPES2)

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1450,7 +1450,7 @@ class TestLRScheduler(TestCase):
         scheduler_copy.load_state_dict(scheduler.state_dict())
         for key in scheduler.__dict__.keys():
             if key not in {'optimizer', 'is_better'}:
-                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key], allow_inf=True)
 
     def test_lambda_lr_state_dict_fn(self):
         scheduler = LambdaLR(self.opt, lr_lambda=lambda x: x)
@@ -1461,7 +1461,7 @@ class TestLRScheduler(TestCase):
         scheduler_copy.load_state_dict(state)
         for key in scheduler.__dict__.keys():
             if key not in {'optimizer', 'lr_lambdas'}:
-                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key], allow_inf=True)
 
     def test_lambda_lr_state_dict_obj(self):
         scheduler = LambdaLR(self.opt, lr_lambda=LambdaLRTestObject(10))
@@ -1472,7 +1472,7 @@ class TestLRScheduler(TestCase):
         scheduler_copy.load_state_dict(state)
         for key in scheduler.__dict__.keys():
             if key not in {'optimizer'}:
-                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key], allow_inf=True)
 
     def test_CosineAnnealingWarmRestarts_lr_state_dict(self):
         self._check_scheduler_state_dict(

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1578,6 +1578,11 @@ class _TestTorchMixin(object):
         # storage to a single storage would cause RuntimeError to be thrown
         self.assertRaises(RuntimeError, lambda: torch.zeros(1, 6).expand(5, 6).copy_(torch.zeros(5, 6)))
 
+    def test_not_equal(self):
+        ones = torch.ones(10, dtype=torch.int)
+        self.assertRaisesRegex(AssertionError, "0 not greater than",
+                               lambda: self.assertNotEqual(ones, ones))
+
     def assertIsOrdered(self, order, x, mxx, ixx, task):
         SIZE = 4
         if order == 'descending':
@@ -5358,201 +5363,6 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(a.size(), deepcopy(a).size())
         self.assertEqual(a, deepcopy(a))
 
-    # Tests that when rtol or atol (including self.precision) is set, then
-    # the other is zeroed.
-    # TODO: this is legacy behavior and should be updated after test
-    # precisions are reviewed to be consistent with torch.isclose.
-    @onlyOnCPUAndCUDA
-    def test__comparetensors_legacy(self, device):
-        a = torch.tensor((10000000.,))
-        b = torch.tensor((10000002.,))
-
-        x = torch.tensor((1.,))
-        y = torch.tensor((1. + 1e-5,))
-
-        # Helper for reusing the tensor values as scalars
-        def _scalar_helper(a, b, rtol=None, atol=None):
-            return self._compareScalars(a.item(), b.item(), rtol=rtol, atol=atol)
-
-        for op in (self._compareTensors, _scalar_helper):
-            # Tests default
-            result, debug_msg = op(a, b)
-            self.assertTrue(result)
-
-            # Tests setting atol
-            result, debug_msg = op(a, b, atol=2)
-            self.assertTrue(result)
-
-            # Tests setting atol too small
-            result, debug_msg = op(a, b, atol=1)
-            self.assertFalse(result)
-
-            # Tests setting rtol too small
-            result, debug_msg = op(x, y, rtol=1.05e-5)
-            self.assertTrue(result)
-
-            # Tests setting rtol too small
-            result, debug_msg = op(x, y, rtol=1e-5)
-            self.assertFalse(result)
-
-    @onlyOnCPUAndCUDA
-    def test__comparescalars_debug_msg(self, device):
-        # float x float
-        result, debug_msg = self._compareScalars(4., 7.)
-        expected_msg = ("Comparing 4.0 and 7.0 gives a difference of 3.0, "
-                        "but the allowed difference with rtol=1.3e-06 and "
-                        "atol=1e-05 is only 1.9100000000000003e-05!")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # complex x complex, real difference
-        result, debug_msg = self._compareScalars(complex(1, 3), complex(3, 1))
-        expected_msg = ("Comparing the real part 1.0 and 3.0 gives a difference "
-                        "of 2.0, but the allowed difference with rtol=1.3e-06 "
-                        "and atol=1e-05 is only 1.39e-05!")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # complex x complex, imaginary difference
-        result, debug_msg = self._compareScalars(complex(1, 3), complex(1, 5.5))
-        expected_msg = ("Comparing the imaginary part 3.0 and 5.5 gives a "
-                        "difference of 2.5, but the allowed difference with "
-                        "rtol=1.3e-06 and atol=1e-05 is only 1.715e-05!")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # complex x int
-        result, debug_msg = self._compareScalars(complex(1, -2), 1)
-        expected_msg = ("Comparing the imaginary part -2.0 and 0.0 gives a "
-                        "difference of 2.0, but the allowed difference with "
-                        "rtol=1.3e-06 and atol=1e-05 is only 1e-05!")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # NaN x NaN, equal_nan=False
-        result, debug_msg = self._compareScalars(float('nan'), float('nan'), equal_nan=False)
-        expected_msg = ("Found nan and nan while comparing and either one is "
-                        "nan and the other isn't, or both are nan and equal_nan "
-                        "is False")
-        self.assertEqual(debug_msg, expected_msg)
-
-
-    # Checks that compareTensors provides the correct debug info
-    @onlyOnCPUAndCUDA
-    def test__comparetensors_debug_msg(self, device):
-        # Acquires atol that will be used
-        atol = max(1e-05, self.precision)
-
-        # Checks float tensor comparisons (2D tensor)
-        a = torch.tensor(((0, 6), (7, 9)), device=device, dtype=torch.float32)
-        b = torch.tensor(((0, 7), (7, 22)), device=device, dtype=torch.float32)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("With rtol=1.3e-06 and atol={0}, found 2 element(s) (out of 4) "
-                        "whose difference(s) exceeded the margin of error (including 0 nan comparisons). "
-                        "The greatest difference was 13.0 (9.0 vs. 22.0), "
-                        "which occurred at index (1, 1).").format(atol)
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks float tensor comparisons (with extremal values)
-        a = torch.tensor((float('inf'), 5), device=device, dtype=torch.float32)
-        b = torch.tensor((float('inf'), float('nan')), device=device, dtype=torch.float32)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("With rtol=1.3e-06 and atol={0}, found 1 element(s) (out of 2) "
-                        "whose difference(s) exceeded the margin of error (including 1 nan comparisons). "
-                        "The greatest difference was nan (5.0 vs. nan), "
-                        "which occurred at index 1.").format(atol)
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks float tensor comparisons (with finite vs nan differences)
-        a = torch.tensor((20, -6), device=device, dtype=torch.float32)
-        b = torch.tensor((-1, float('nan')), device=device, dtype=torch.float32)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("With rtol=1.3e-06 and atol={0}, found 2 element(s) (out of 2) "
-                        "whose difference(s) exceeded the margin of error (including 1 nan comparisons). "
-                        "The greatest difference was nan (-6.0 vs. nan), "
-                        "which occurred at index 1.").format(atol)
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks int tensor comparisons (1D tensor)
-        a = torch.tensor((1, 2, 3, 4), device=device)
-        b = torch.tensor((2, 5, 3, 4), device=device)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("Found 2 different element(s) (out of 4), "
-                        "with the greatest difference of 3 (2 vs. 5) "
-                        "occuring at index 1.")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks bool tensor comparisons (0D tensor)
-        a = torch.tensor((True), device=device)
-        b = torch.tensor((False), device=device)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("Found 1 different element(s) (out of 1), "
-                        "with the greatest difference of 1 (1 vs. 0) "
-                        "occuring at index 0.")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks complex tensor comparisons (real part)
-        a = torch.tensor((1 - 1j, 4 + 3j), device=device)
-        b = torch.tensor((1 - 1j, 1 + 3j), device=device)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("Real parts failed to compare as equal! "
-                        "With rtol=1.3e-06 and atol={0}, "
-                        "found 1 element(s) (out of 2) whose difference(s) exceeded the "
-                        "margin of error (including 0 nan comparisons). The greatest difference was "
-                        "3.0 (4.0 vs. 1.0), which occurred at index 1.").format(atol)
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks complex tensor comparisons (imaginary part)
-        a = torch.tensor((1 - 1j, 4 + 3j), device=device)
-        b = torch.tensor((1 - 1j, 4 - 21j), device=device)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("Imaginary parts failed to compare as equal! "
-                        "With rtol=1.3e-06 and atol={0}, "
-                        "found 1 element(s) (out of 2) whose difference(s) exceeded the "
-                        "margin of error (including 0 nan comparisons). The greatest difference was "
-                        "24.0 (3.0 vs. -21.0), which occurred at index 1.").format(atol)
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks size mismatch
-        a = torch.tensor((1, 2), device=device)
-        b = torch.tensor((3), device=device)
-        result, debug_msg = self._compareTensors(a, b)
-        expected_msg = ("Attempted to compare equality of tensors "
-                        "with different sizes. Got sizes torch.Size([2]) and torch.Size([]).")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks dtype mismatch
-        a = torch.tensor((1, 2), device=device, dtype=torch.long)
-        b = torch.tensor((1, 2), device=device, dtype=torch.float32)
-        result, debug_msg = self._compareTensors(a, b, exact_dtype=True)
-        expected_msg = ("Attempted to compare equality of tensors "
-                        "with different dtypes. Got dtypes torch.int64 and torch.float32.")
-        self.assertEqual(debug_msg, expected_msg)
-
-        # Checks device mismatch
-        if self.device_type == 'cuda':
-            a = torch.tensor((5), device='cpu')
-            b = torch.tensor((5), device=device)
-            result, debug_msg = self._compareTensors(a, b, exact_device=True)
-            expected_msg = ("Attempted to compare equality of tensors "
-                            "on different devices! Got devices cpu and cuda:0.")
-            self.assertEqual(debug_msg, expected_msg)
-
-    # Helper for testing _compareTensors and _compareScalars
-    # Works on single element tensors
-    def _comparetensors_helper(self, tests, device, dtype, equal_nan, exact_dtype=True, atol=1e-08, rtol=1e-05):
-        for test in tests:
-            a = torch.tensor((test[0],), device=device, dtype=dtype)
-            b = torch.tensor((test[1],), device=device, dtype=dtype)
-
-            # Tensor x Tensor comparison
-            compare_result, debug_msg = self._compareTensors(a, b, rtol=rtol, atol=atol,
-                                                             equal_nan=equal_nan,
-                                                             exact_dtype=exact_dtype)
-            self.assertEqual(compare_result, test[2])
-
-            # Scalar x Scalar comparison
-            compare_result, debug_msg = self._compareScalars(a.item(), b.item(),
-                                                             rtol=rtol, atol=atol,
-                                                             equal_nan=equal_nan)
-            self.assertEqual(compare_result, test[2])
-
     def _isclose_helper(self, tests, device, dtype, equal_nan, atol=1e-08, rtol=1e-05):
         for test in tests:
             a = torch.tensor((test[0],), device=device, dtype=dtype)
@@ -5564,7 +5374,7 @@ class TestTorchDeviceType(TestCase):
 
     # torch.close is not implemented for bool tensors
     # see https://github.com/pytorch/pytorch/issues/33048
-    def test_isclose_comparetensors_bool(self, device):
+    def test_isclose_bool(self, device):
         tests = (
             (True, True, True),
             (False, False, True),
@@ -5575,11 +5385,9 @@ class TestTorchDeviceType(TestCase):
         with self.assertRaises(RuntimeError):
             self._isclose_helper(tests, device, torch.bool, False)
 
-        self._comparetensors_helper(tests, device, torch.bool, False)
-
     @dtypes(torch.uint8,
             torch.int8, torch.int16, torch.int32, torch.int64)
-    def test_isclose_comparetensors_integer(self, device, dtype):
+    def test_isclose_integer(self, device, dtype):
         tests = (
             (0, 0, True),
             (0, 1, False),
@@ -5596,7 +5404,6 @@ class TestTorchDeviceType(TestCase):
         ]
 
         self._isclose_helper(tests, device, dtype, False, atol=.5, rtol=.5)
-        self._comparetensors_helper(tests, device, dtype, False, atol=.5, rtol=.5)
 
         if dtype is torch.uint8:
             tests = [
@@ -5610,11 +5417,9 @@ class TestTorchDeviceType(TestCase):
             ]
 
         self._isclose_helper(tests, device, dtype, False, atol=1.5, rtol=.5)
-        self._comparetensors_helper(tests, device, dtype, False, atol=1.5, rtol=.5)
 
-    @onlyOnCPUAndCUDA
     @dtypes(torch.float16, torch.float32, torch.float64)
-    def test_isclose_comparetensors_float(self, device, dtype):
+    def test_isclose_float(self, device, dtype):
         tests = (
             (0, 0, True),
             (0, -1, False),
@@ -5627,7 +5432,6 @@ class TestTorchDeviceType(TestCase):
         )
 
         self._isclose_helper(tests, device, dtype, False)
-        self._comparetensors_helper(tests, device, dtype, False)
 
         # atol and rtol tests
         eps = 1e-2 if dtype is torch.half else 1e-6
@@ -5644,7 +5448,6 @@ class TestTorchDeviceType(TestCase):
         )
 
         self._isclose_helper(tests, device, dtype, False, atol=.5, rtol=.5)
-        self._comparetensors_helper(tests, device, dtype, False, atol=.5, rtol=.5)
 
         # equal_nan = True tests
         tests = (
@@ -5655,14 +5458,10 @@ class TestTorchDeviceType(TestCase):
 
         self._isclose_helper(tests, device, dtype, True)
 
-        self._comparetensors_helper(tests, device, dtype, True)
-
     # torch.close with equal_nan=True is not implemented for complex inputs
     # see https://github.com/numpy/numpy/issues/15959
-    # Note: compareTensor will compare the real and imaginary parts of a
-    # complex tensors separately, unlike isclose.
     @dtypes(torch.complex64, torch.complex128)
-    def test_isclose_comparetensors_complex(self, device, dtype):
+    def test_isclose_complex(self, device, dtype):
         tests = (
             (complex(1, 1), complex(1, 1 + 1e-8), True),
             (complex(0, 1), complex(1, 1), False),
@@ -5678,7 +5477,6 @@ class TestTorchDeviceType(TestCase):
         )
 
         self._isclose_helper(tests, device, dtype, False)
-        self._comparetensors_helper(tests, device, dtype, False)
 
         # atol and rtol tests
 
@@ -5705,13 +5503,6 @@ class TestTorchDeviceType(TestCase):
             (complex(0, -.25 - eps), complex(0, .5), False),
             (complex(0, .25), complex(0, -.5), True),
             (complex(0, .25 + eps), complex(0, -.5), False),
-        )
-
-        self._isclose_helper(tests, device, dtype, False, atol=.5, rtol=.5)
-        self._comparetensors_helper(tests, device, dtype, False, atol=.5, rtol=.5)
-
-        # atol and rtol tests for isclose
-        tests = (
             # Complex-specific tests
             (complex(1, -1), complex(-1, 1), False),
             (complex(1, -1), complex(2, -2), True),
@@ -5721,19 +5512,9 @@ class TestTorchDeviceType(TestCase):
              complex(-math.sqrt(.501), math.sqrt(.499)), False),
             (complex(2, 4), complex(1., 8.8523607), True),
             (complex(2, 4), complex(1., 8.8523607 + eps), False),
-            (complex(1, 99), complex(4, 100), True),
         )
 
         self._isclose_helper(tests, device, dtype, False, atol=.5, rtol=.5)
-
-        # atol and rtol tests for compareTensors
-        tests = (
-            (complex(1, -1), complex(-1, 1), False),
-            (complex(1, -1), complex(2, -2), True),
-            (complex(1, 99), complex(4, 100), False),
-        )
-
-        self._comparetensors_helper(tests, device, dtype, False, atol=.5, rtol=.5)
 
         # equal_nan = True tests
         tests = (
@@ -5745,10 +5526,7 @@ class TestTorchDeviceType(TestCase):
         with self.assertRaises(RuntimeError):
             self._isclose_helper(tests, device, dtype, True)
 
-        self._comparetensors_helper(tests, device, dtype, True)
-
-    # Tests that isclose with rtol or atol values less than zero throws a
-    #   RuntimeError
+    # Tests that rtol or atol values less than zero thow RuntimeErrors
     @dtypes(torch.bool, torch.uint8,
             torch.int8, torch.int16, torch.int32, torch.int64,
             torch.float16, torch.float32, torch.float64)
@@ -5885,19 +5663,19 @@ class TestTorchDeviceType(TestCase):
         else:
             if isinstance(base, torch.Tensor):
                 actual = base.pow(exponent)
-                self.assertEqual(actual, expected.to(actual))
+                self.assertEqual(actual, expected.to(actual), allow_inf=True)
 
                 actual = base.clone()
                 actual2 = actual.pow_(exponent)
-                self.assertEqual(actual, expected.to(actual))
-                self.assertEqual(actual2, expected.to(actual))
+                self.assertEqual(actual, expected.to(actual), allow_inf=True)
+                self.assertEqual(actual2, expected.to(actual), allow_inf=True)
 
             actual = torch.pow(base, exponent)
-            self.assertEqual(actual, expected.to(actual))
+            self.assertEqual(actual, expected.to(actual), allow_inf=True)
 
             actual2 = torch.pow(base, exponent, out=actual)
-            self.assertEqual(actual, expected.to(actual))
-            self.assertEqual(actual2, expected.to(actual))
+            self.assertEqual(actual, expected.to(actual), allow_inf=True)
+            self.assertEqual(actual2, expected.to(actual), allow_inf=True)
 
     def _select_broadcastable_dims(self, dims_full=None):
         # select full dimensionality
@@ -6162,6 +5940,7 @@ class TestTorchDeviceType(TestCase):
 
     # Uses mismatched arange out size to trigger a warning
     def test_cpp_warnings_have_python_context(self, device):
+        import inspect
         # Creates long string in advance to avoid a too-long Python line
         s = ".+Triggered internally at.+RangeFactories.+"
 
@@ -6527,7 +6306,6 @@ class TestTorchDeviceType(TestCase):
         expected_inv = torch.as_tensor(inv(matrices.cpu().numpy()))
         self.assertEqual(matrices_inverse, expected_inv.to(device))
 
-    @onlyOnCPUAndCUDA
     @dtypes(torch.int8, torch.int16, torch.int32, torch.int64)
     def test_signed_shift(self, device, dtype):
         "Ensure that signed integer bit shifting works as expected."
@@ -7471,11 +7249,11 @@ class TestTorchDeviceType(TestCase):
                 if fn == torch.slogdet:
                     sign_value = torch.stack([tup[0] for tup in expected_value], dim=0).reshape(batchdims)
                     expected_value = torch.stack([tup[1] for tup in expected_value], dim=0).reshape(batchdims)
-                    self.assertEqual(sign_value, actual_value[0])
-                    self.assertEqual(expected_value, actual_value[1])
+                    self.assertEqual(sign_value, actual_value[0], allow_inf=True)
+                    self.assertEqual(expected_value, actual_value[1], allow_inf=True)
                 else:
                     expected_value = torch.stack(expected_value, dim=0).reshape(batchdims)
-                    self.assertEqual(actual_value, expected_value)
+                    self.assertEqual(actual_value, expected_value, allow_inf=True)
 
         for matsize, batchdims in product([3, 5], [(3,), (5, 3)]):
             run_test(matsize, batchdims, mat_chars=['sym_pd'])
@@ -11153,7 +10931,7 @@ class TestTorchDeviceType(TestCase):
             # test inf and nan input
             x = torch.tensor([4, inf, 1.5, -inf, 0, nan, 1])
             xRes = op(x, 0)[0]
-            self.assertEqual(xRes, expected_output2)
+            self.assertEqual(xRes, expected_output2, allow_inf=True)
 
             # op shouldn't support values, indices with a dtype, device type or layout
             # different from that of input tensor
@@ -11680,7 +11458,7 @@ class TestTorchDeviceType(TestCase):
         # Check precision - start, stop and base are chosen to avoid overflow
         # steps is chosen so that step size is not subject to rounding error
         # a tolerance is needed for gpu tests due to differences in computation
-        tol = 0. if device == 'cpu' else None
+        tol = 0. if device == 'cpu' else self.precision
         self.assertEqual(torch.tensor([2. ** (i / 8.) for i in range(49)], device=device, dtype=dtype),
                          torch.logspace(0, 6, steps=49, base=2, device=device, dtype=dtype),
                          tol)
@@ -13722,7 +13500,7 @@ class TestTorchDeviceType(TestCase):
         for p in [1, 2, 3, 4, inf]:
             res = x.renorm(p, 1, 1)
             expected = x / x.norm(p, 0, keepdim=True).clamp(min=1)
-            self.assertEqual(res, expected, "renorm failed for {}-norm".format(p))
+            self.assertEqual(res.numpy(), expected.numpy(), "renorm failed for {}-norm".format(p))
 
     @onlyCUDA
     def test_topk_noncontiguous_gpu(self, device):
@@ -13748,12 +13526,12 @@ class TestTorchDeviceType(TestCase):
         x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device, dtype=dtype)
         val, idx = x.topk(4)
         expect = torch.tensor([float('nan'), float('inf'), 1e4, 0], device=device, dtype=dtype)
-        self.assertEqual(val, expect)
+        self.assertEqual(val, expect, allow_inf=True)
         self.assertEqual(idx, [0, 1, 2, 3])
 
         val, idx = x.topk(4, largest=False)
         expect = torch.tensor([-float('inf'), -1e4, 0, 1e4], device=device, dtype=dtype)
-        self.assertEqual(val, expect)
+        self.assertEqual(val, expect, allow_inf=True)
         self.assertEqual(idx, [5, 4, 3, 2])
 
     def test_is_signed(self, device):
@@ -15316,7 +15094,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
             for j in range(100):
                 res2[i] += m[i, j] * v[j]
 
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, atol=self.precision)
 
         # Test 0-strided
         t = torch.randn(1, device=device).to(dtype).expand(10)
@@ -15329,7 +15107,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
             for j in range(100):
                 res2[i] += m[i, j] * v[j]
 
-        self.assertEqual(res1, res2)
+        self.assertEqual(res1, res2, atol=self.precision)
 
     @dtypesIfCUDA(*([torch.half, torch.float, torch.double]
                     + ([torch.bfloat16] if TEST_WITH_ROCM else [])))
@@ -16602,7 +16380,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     # dtype's dynamic range. This can (and should) cause undefined behavior
     # errors with UBSAN. These casts are deliberate in PyTorch, however, and
     # NumPy has the same behavior.
-    @onlyOnCPUAndCUDA
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @dtypes(torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_float_to_int_conversion_finite(self, device, dtype):
@@ -16892,7 +16669,7 @@ class TestDevicePrecision(TestCase):
     def _test_linspace(self, device, dtype, steps):
         a = torch.linspace(0, 10, steps=steps, dtype=dtype, device=device)
         b = torch.linspace(0, 10, steps=steps)
-        self.assertEqual(a, b, exact_dtype=False)
+        self.assertEqual(a, b, atol=self.precision, exact_dtype=False)
 
     # See NOTE [Linspace+Logspace precision override]
     @precisionOverride({torch.half: 0.0039 + LINSPACE_LOGSPACE_EXTRA_EPS})
@@ -16910,22 +16687,22 @@ class TestDevicePrecision(TestCase):
     def _test_logspace(self, device, dtype, steps):
         a = torch.logspace(1, 1.1, steps=steps, dtype=dtype, device=device)
         b = torch.logspace(1, 1.1, steps=steps)
-        self.assertEqual(a, b, exact_dtype=False)
+        self.assertEqual(a, b, atol=self.precision, exact_dtype=False)
 
     def _test_logspace_base2(self, device, dtype, steps):
         a = torch.logspace(1, 1.1, steps=steps, base=2, dtype=dtype, device=device)
         b = torch.logspace(1, 1.1, steps=steps, base=2)
-        self.assertEqual(a, b, exact_dtype=False)
+        self.assertEqual(a, b, atol=self.precision, exact_dtype=False)
 
     # See NOTE [Linspace+Logspace precision override]
-    @precisionOverride({torch.half: 0.025 + LINSPACE_LOGSPACE_EXTRA_EPS})
+    @precisionOverride({torch.half: 0.0157 + LINSPACE_LOGSPACE_EXTRA_EPS})
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float, torch.double)
     def test_logspace(self, device, dtype):
         self._test_logspace(device, dtype, steps=10)
 
     # See NOTE [Linspace+Logspace precision override]
-    @precisionOverride({torch.half: 0.0201 + LINSPACE_LOGSPACE_EXTRA_EPS})
+    @precisionOverride({torch.half: 0.00201 + LINSPACE_LOGSPACE_EXTRA_EPS})
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float, torch.double)
     def test_logspace_base2(self, device, dtype):
@@ -18122,9 +17899,9 @@ def generate_test_function(cls,
         # Compares CPU and device inputs and outputs
         precision = dtype2precision.get(dtype, float_precision)
 
-        self.assertEqual(cpu_tensor, device_tensor, atol=precision, exact_dtype=False)
-        self.assertEqual(cpu_args, device_args, atol=precision, exact_dtype=False)
-        self.assertEqual(cpu_result, device_result, atol=precision, exact_dtype=False)
+        self.assertEqual(cpu_tensor, device_tensor, atol=precision, exact_dtype=False, allow_inf=True)
+        self.assertEqual(cpu_args, device_args, atol=precision, exact_dtype=False, allow_inf=True)
+        self.assertEqual(cpu_result, device_result, atol=precision, exact_dtype=False, allow_inf=True)
 
     test_name = "test_" + op_str + subtest_str
     assert not hasattr(cls, test_name), "{0} already in TestDevicePrecision".format(test_name)

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -4,7 +4,6 @@ The testing package contains testing-specific utilities.
 
 import torch
 import random
-import math
 
 FileCheck = torch._C.FileCheck
 
@@ -15,185 +14,6 @@ __all__ = [
 rand_like = torch.rand_like
 randn_like = torch.randn_like
 
-# Helper function that returns True when the dtype is an integral dtype,
-# False otherwise.
-# TODO: implement numpy-like issubdtype
-def is_integral(dtype):
-    # Skip complex/quantized types
-    dtypes = [x for x in get_all_dtypes() if x not in get_all_complex_dtypes()]
-    return dtype in dtypes and not dtype.is_floating_point
-
-# Helper function that maps a flattened index back into the given shape
-# TODO: consider adding torch.unravel_index
-def _unravel_index(flat_index, shape):
-    res = []
-
-    # Short-circuits on zero dim tensors
-    if shape == torch.Size([]):
-        return 0
-
-    for size in shape[::-1]:
-        res.append(int(flat_index % size))
-        flat_index = int(flat_index // size)
-
-    if len(res) == 1:
-        return res[0]
-
-    return tuple(res[::-1])
-
-# Compares two tensors with the same size on the same device and with the same
-# dtype for equality.
-# Returns a tuple (bool, msg). The bool value returned is True when the tensors
-# are "equal" and False otherwise.
-# The msg value is a debug string, and is None if the tensors are "equal."
-# NOTE: Test Framework Tensor 'Equality'
-#   Two tensors are "equal" if they are "close", in the sense of torch.allclose.
-#   The only exceptions are complex tensors and bool tensors.
-#
-#   Complex tensors are "equal" if both the
-#   real and complex parts (separately) are close. This is divergent from
-#   torch.allclose's behavior, which compares the absolute values of the
-#   complex numbers instead.
-#
-#   Using torch.allclose would be a less strict
-#   comparison that would allow large complex values with
-#   significant real or imaginary differences to be considered "equal,"
-#   and would make setting rtol and atol for complex tensors distinct from
-#   other tensor types.
-#
-#   Bool tensors are equal only if they are identical, regardless of
-#   the rtol and atol values.
-def _compare_tensors_internal(a, b, *, rtol, atol, equal_nan):
-    # Integer (including bool) comparisons are identity comparisons
-    # when rtol is zero and atol is less than one
-    if (is_integral(a.dtype) and rtol == 0 and atol < 1) or a.dtype is torch.bool:
-        if (a == b).all().item():
-            return (True, None)
-
-        # Gathers debug info for failed integer comparison
-        # NOTE: converts to long to correctly represent differences
-        # (especially between uint8 tensors)
-        identity_mask = a != b
-        a_flat = a.to(torch.long).flatten()
-        b_flat = b.to(torch.long).flatten()
-        count_non_identical = torch.sum(identity_mask, dtype=torch.long)
-        diff = torch.abs(a_flat - b_flat)
-        greatest_diff_index = torch.argmax(diff)
-        debug_msg = ("Found {0} different element(s) (out of {1}), with the greatest "
-                     "difference of {2} ({3} vs. {4}) occuring at index "
-                     "{5}.".format(count_non_identical.item(),
-                                   a.numel(),
-                                   diff[greatest_diff_index],
-                                   a_flat[greatest_diff_index],
-                                   b_flat[greatest_diff_index],
-                                   _unravel_index(greatest_diff_index, a.shape)))
-        return (False, debug_msg)
-
-    # Compares complex tensors' real and imaginary parts separately.
-    # (see NOTE Test Framework Tensor "Equality")
-    if a.is_complex():
-        float_dtype = torch.float32 if a.dtype == torch.complex64 else torch.float64
-        a_real = a.copy_real().to(float_dtype)
-        b_real = b.copy_real().to(float_dtype)
-        real_result, debug_msg = _compare_tensors_internal(a_real, b_real,
-                                                           rtol=rtol, atol=atol,
-                                                           equal_nan=equal_nan)
-
-        if not real_result:
-            debug_msg = "Real parts failed to compare as equal! " + debug_msg
-            return (real_result, debug_msg)
-
-        a_imag = a.copy_imag().to(float_dtype)
-        b_imag = b.copy_imag().to(float_dtype)
-        imag_result, debug_msg = _compare_tensors_internal(a_imag, b_imag,
-                                                           rtol=rtol, atol=atol,
-                                                           equal_nan=equal_nan)
-
-        if not imag_result:
-            debug_msg = "Imaginary parts failed to compare as equal! " + debug_msg
-            return (imag_result, debug_msg)
-
-        return (True, None)
-
-    # All other comparisons use torch.allclose directly
-    if torch.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan):
-        return (True, None)
-
-    # Gathers debug info for failed float tensor comparison
-    # NOTE: converts to float64 to best represent differences
-    a_flat = a.to(torch.float64).flatten()
-    b_flat = b.to(torch.float64).flatten()
-    diff = torch.abs(a_flat - b_flat)
-
-    # Masks close values
-    # NOTE: this avoids (inf - inf) oddities when computing the difference
-    close = torch.isclose(a_flat, b_flat, rtol, atol, equal_nan)
-    diff[close] = 0
-    nans = torch.isnan(diff)
-    num_nans = nans.sum()
-
-    outside_range = diff > (atol + rtol * torch.abs(b_flat))
-    count_outside_range = torch.sum(outside_range, dtype=torch.long)
-    greatest_diff_index = torch.argmax(diff)
-    debug_msg = ("With rtol={0} and atol={1}, found {2} element(s) (out of {3}) whose "
-                 "difference(s) exceeded the margin of error (including {4} nan comparisons). "
-                 "The greatest difference was {5} ({6} vs. {7}), which "
-                 "occurred at index {8}.".format(rtol, atol,
-                                                 count_outside_range + num_nans,
-                                                 a.numel(),
-                                                 num_nans,
-                                                 diff[greatest_diff_index],
-                                                 a_flat[greatest_diff_index],
-                                                 b_flat[greatest_diff_index],
-                                                 _unravel_index(greatest_diff_index, a.shape)))
-    return (False, debug_msg)
-
-# Checks if two scalars are equal(-ish), returning (True, None)
-# when they are and (False, debug_msg) when they are not.
-def _compare_scalars_internal(a, b, *, rtol, atol, equal_nan):
-    def _helper(a, b, s):
-        # Short-circuits on identity
-        if a == b or (equal_nan and a != a and b != b):
-            return (True, None)
-
-        # Special-case for NaN comparisions when equal_nan=False
-        if not equal_nan and (a != a or b != b):
-            msg = ("Found {0} and {1} while comparing" + s + "and either one "
-                   "is nan and the other isn't, or both are nan and "
-                   "equal_nan is False").format(a, b)
-            return (False, msg)
-
-        diff = abs(a - b)
-        allowed_diff = atol + rtol * abs(b)
-        result = diff <= allowed_diff
-
-        # Special-case for infinity comparisons
-        # NOTE: if b is inf then allowed_diff will be inf when rtol is not 0
-        if ((math.isinf(a) or math.isinf(b)) and a != b):
-            result = False
-
-        msg = None
-        if not result:
-            msg = ("Comparing" + s + "{0} and {1} gives a "
-                   "difference of {2}, but the allowed difference "
-                   "with rtol={3} and atol={4} is "
-                   "only {5}!").format(a, b, diff,
-                                       rtol, atol, allowed_diff)
-
-        return result, msg
-
-    if isinstance(a, complex) or isinstance(b, complex):
-        a = complex(a)
-        b = complex(b)
-
-        result, msg = _helper(a.real, b.real, " the real part ")
-
-        if not result:
-            return (False, msg)
-
-        return _helper(a.imag, b.imag, " the imaginary part ")
-
-    return _helper(a, b, " ")
 
 def assert_allclose(actual, expected, rtol=None, atol=None, equal_nan=True, msg=''):
     if not isinstance(actual, torch.Tensor):
@@ -207,15 +27,35 @@ def assert_allclose(actual, expected, rtol=None, atol=None, equal_nan=True, msg=
             raise ValueError("rtol and atol must both be specified or both be unspecified")
         rtol, atol = _get_default_tolerance(actual, expected)
 
-    result, debug_msg = _compare_tensors_internal(actual, expected,
-                                                  rtol=rtol, atol=atol,
-                                                  equal_nan=equal_nan)
-
-    if result:
+    close = torch.isclose(actual, expected, rtol, atol, equal_nan)
+    if close.all():
         return
 
-    if msg is None or msg == '':
-        msg = debug_msg
+    # Find the worst offender
+    error = (expected - actual).abs()
+    expected_error = atol + rtol * expected.abs()
+    delta = error - expected_error
+    delta[close] = 0  # mask out NaN/inf
+    _, index = delta.reshape(-1).max(0)
+
+    # TODO: consider adding torch.unravel_index
+    def _unravel_index(index, shape):
+        res = []
+        for size in shape[::-1]:
+            res.append(int(index % size))
+            index = int(index // size)
+        return tuple(res[::-1])
+
+    index = _unravel_index(index.item(), actual.shape)
+
+    # Count number of offenders
+    count = (~close).long().sum()
+    if msg == '' or msg is None:
+        msg = ('Not within tolerance rtol={} atol={} at input{} ({} vs. {}) and {}'
+               ' other locations ({:2.2f}%)')
+        msg = msg.format(
+            rtol, atol, list(index), actual[index].item(), expected[index].item(),
+            count - 1, 100 * count / actual.numel())
 
     raise AssertionError(msg)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -31,16 +31,18 @@ from numbers import Number
 import tempfile
 import json
 from urllib.request import urlopen
+
 import __main__
 import errno
 
 from torch.testing._internal import expecttest
-from torch.testing import _compare_tensors_internal, _compare_scalars_internal
+from torch.testing import get_all_dtypes
+from torch.testing import get_all_complex_dtypes
 
 import torch
 import torch.cuda
 from torch._utils_internal import get_writable_path
-from torch._six import string_classes
+from torch._six import string_classes, inf
 import torch.backends.cudnn
 import torch.backends.mkl
 from enum import Enum
@@ -716,40 +718,12 @@ def check_disabled(test_name):
             "Test is disabled because an issue exists disabling it: {}".format(disabled_test_from_issues[test_name]) +
             " To enable set the environment variable PYTORCH_RUN_DISABLED_TESTS=1")
 
-# Acquires the comparison dtype, required since isclose
-# requires both inputs have the same dtype, and isclose is not supported
-# for some device x dtype combinations.
-# NOTE: Remaps bfloat16 to float32 since neither the CPU or CUDA device types
-#  support needed bfloat16 comparison methods.
-# NOTE: Remaps float16 to float32 on CPU since the CPU device type doesn't
-#   support needed float16 comparison methods.
-# TODO: Update this once bfloat16 and float16 are better supported.
-def get_comparison_dtype(a, b):
-    # TODO: update this when promote_types supports bfloat16 and/or
-    # isclose supports bfloat16.
-    a_dtype = torch.float32 if a.dtype is torch.bfloat16 else a.dtype
-    b_dtype = torch.float32 if b.dtype is torch.bfloat16 else b.dtype
-
-    compare_dtype = torch.promote_types(a_dtype, b_dtype)
-
-    # non-CUDA (CPU, for example) float16 -> float32
-    # TODO: update this when isclose is implemented for CPU float16
-    if (compare_dtype is torch.float16 and
-        (a.device != b.device or a.device.type != 'cuda' or
-            b.device.type != 'cuda')):
-        compare_dtype = torch.float32
-
-    return compare_dtype
-
 class TestCase(expecttest.TestCase):
-    # NOTE: "precision" lets classes and generated tests set minimum
-    # atol values when comparing tensors. Used by @precisionOverride, for
-    # example.
-    # TODO: provide a better mechanism for generated tests to set rtol/atol.
-    precision = 0
-
+    precision = 1e-5
+    maxDiff = None
     _do_cuda_memory_leak_check = False
     _do_cuda_non_default_stream = False
+    exact_dtype = False
 
     def __init__(self, method_name='runTest'):
         super().__init__(method_name)
@@ -885,202 +859,151 @@ class TestCase(expecttest.TestCase):
     # in https://github.com/pytorch/pytorch/pull/32538.
     # dtype name : (rtol, atol)
     dtype_precisions = {
-        torch.float16    : (0.001, 1e-5),
-        torch.bfloat16   : (0.016, 1e-5),
-        torch.float32    : (1.3e-6, 1e-5),
-        torch.float64    : (1e-7, 1e-7),
-        torch.complex32  : (0.001, 1e-5),
-        torch.complex64  : (1.3e-6, 1e-5),
-        torch.complex128 : (1e-7, 1e-7),
+        'float16': (0.001, 1e-5),
+        'bfloat16': (0.016, 1e-5),
+        'float32': (1.3e-6, 1e-5),
+        'float64': (1e-7, 1e-7),
+        'complex32': (0.001, 1e-5),
+        'complex64': (1.3e-6, 1e-5),
+        'complex128': (1e-7, 1e-7),
     }
 
-    # Returns the "default" rtol and atol for comparing scalars or
-    # tensors of the given dtypes.
-    def _getDefaultRtolAndAtol(self, dtype0, dtype1):
-        rtol = max(self.dtype_precisions.get(dtype0, (0, 0))[0],
-                   self.dtype_precisions.get(dtype1, (0, 0))[0])
-        atol = max(self.dtype_precisions.get(dtype0, (0, 0))[1],
-                   self.dtype_precisions.get(dtype1, (0, 0))[1])
+    # todo: implement numpy-like issubdtype
+    def is_integral(self, dtype):
+        # Skip complex/quantized types
+        dtypes = [x for x in get_all_dtypes() if x not in get_all_complex_dtypes()]
+        return dtype in dtypes and not dtype.is_floating_point
 
-        return rtol, atol
+    # accepts tensors, dtypes, or np.ndarrays
+    def get_default_tolerance(self, a, b=None):
+        if b is None:
+            dtype = torch.float
+            if isinstance(a, torch.Tensor):
+                dtype = a.dtype
+            elif isinstance(a, torch.dtype):
+                dtype = a
+            elif TEST_NUMPY and isinstance(a, numpy.ndarray):
+                # Some tests call assertEqual with numpy Unicode.
+                if numpy.issubdtype(a.dtype, numpy.dtype('U')):
+                    dtype = torch.float
+                else:
+                    dtype = torch.from_numpy(a).dtype
+            if self.is_integral(dtype):
+                return (0, 0)
+            dtype = str(dtype).split('.')[-1]
+            return self.dtype_precisions.get(dtype, (self.precision, self.precision))
 
-    # Checks if two dense tensors are equal(-ish), returning (True, None)
-    #   when they are and (False, debug_msg) when they are not.
-    # If exact_dtype is true both tensors must have the same dtype.
-    # If exact_device is true both tensors must be on the same device.
-    # See the "Test Framework Tensor 'Equality'" note for more details.
-    # NOTE: tensors on different devices are moved to the CPU to be compared when
-    #   exact_device is False.
-    # NOTE: this function checks the tensors' devices, sizes, and dtypes
-    #  and acquires the appropriate device, dtype, rtol and atol to compare
-    #  them with. It then calls _compare_tensors_internal.
-    def _compareTensors(self, a, b, *, rtol=None, atol=None, equal_nan=True,
-                        exact_dtype=True, exact_device=False):
-        if not isinstance(a, torch.Tensor):
-            return (False, "argument a, {0}, to _compareTensors is not a tensor!".format(a))
-        if not isinstance(b, torch.Tensor):
-            return (False, "argument b, {0}, to _compareTensors is not a tensor!".format(b))
-
-        # Validates tensors are on the same device
-        if exact_device and a.device != b.device:
-            return (False, ("Attempted to compare equality of tensors on "
-                            "different devices! Got devices {0} and "
-                            "{1}.".format(a.device, b.device)))
-
-        # Compares tensors of different devices on the CPU
-        if a.device != b.device:
-            a = a.cpu()
-            b = b.cpu()
-
-        # Checks size matches
-        if a.size() != b.size():
-            return (False, ("Attempted to compare equality of tensors with "
-                            "different sizes. Got sizes {0} and {1}.").format(a.size(), b.size()))
-
-        # Checks dtype (if exact_dtype)
-        if exact_dtype and a.dtype is not b.dtype:
-            return (False, ("Attempted to compare equality of tensors with "
-                            "different dtypes. Got dtypes {0} and {1}.").format(a.dtype, b.dtype))
-
-        # Acquires rtol and atol
-        if rtol is None and atol is None and self.precision == 0:
-            rtol, atol = self._getDefaultRtolAndAtol(a.dtype, b.dtype)
-        else:
-            # TODO: for legacy reasons when only rtol or atol is set then the other
-            #   is zeroed. In the future they should be acquired independently,
-            #   but this will require updating the precision values in all tests
-            #   that explicitly set them.
-            rtol = rtol if rtol is not None else 0
-            atol = atol if atol is not None else 0
-            atol = max(atol, self.precision)
-
-        # Converts to comparison dtype
-        dtype = get_comparison_dtype(a, b)
-        a = a.to(dtype)
-        b = b.to(dtype)
-
-        return _compare_tensors_internal(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
-
-    # Checks if two scalars are equal(-ish), returning (True, None)
-    #   when they are and (False, debug_msg) when they are not.
-    # NOTE: this function just acquires rtol and atol
-    #   before calling _compare_scalars_internal.
-    def _compareScalars(self, a, b, *, rtol=None, atol=None, equal_nan=True):
-        # Acquires rtol and atol
-        if rtol is None and atol is None and self.precision == 0:
-            if isinstance(a, complex) or isinstance(b, complex):
-                rtol, atol = self._getDefaultRtolAndAtol(torch.complex64, torch.complex64)
-            elif isinstance(a, float) or isinstance(b, float):
-                rtol, atol = self._getDefaultRtolAndAtol(torch.float32, torch.float32)
-            else:
-                rtol = 0
-                atol = 0
-        else:
-            # TODO: for legacy reasons when only rtol or atol is set then the other
-            #   is zeroed. In the future they should be acquired independently,
-            #   but this will require updating the precision values in all tests
-            #   that explicitly set them.
-            rtol = rtol if rtol is not None else 0
-            atol = atol if atol is not None else 0
-            atol = max(atol, self.precision)
-
-        return _compare_scalars_internal(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+        a_tol = self.get_default_tolerance(a)
+        b_tol = self.get_default_tolerance(b)
+        return (max(a_tol[0], b_tol[0]), max(a_tol[1], b_tol[1]))
 
     def assertEqualIgnoreType(self, *args, **kwargs):
         # If you are seeing this function used, that means test is written wrongly
         # and deserves detailed investigation
         return self.assertEqual(*args, exact_dtype=False, **kwargs)
 
-    # Compares x and y
-    # TODO: make message kwarg-only
-    # TODO: default exact_device to True
-    def assertEqual(self, x, y, message=None, *, atol=None, rtol=None, equal_nan=True,
-                    exact_dtype=True, exact_device=False):
+    def assertEqual(self, x, y, message='', *, atol=None, rtol=None, allow_inf=False, exact_dtype=True):
         # we allow setting an absolute tolerance as a positional arg for BC with legacy testing behavior.
         if isinstance(message, Number):
             self.assertIsNone(atol, "don't combine positional prec and atol")
             self.assertIsNone(rtol, "don't combine positionial prec and rtol")
             atol = message
-            message = None
+            message = ''
+            rtol = 0
+        elif atol is None and rtol is None:
+            # if both are None, use defaults per-dtype
+            (rtol, atol) = self.get_default_tolerance(x, y)
+        else:
+            if rtol is None:
+                rtol = 0
+            if atol is None:
+                atol = 0
 
-        # Tensor x Number and Number x Tensor comparisons
+        if exact_dtype is None:
+            exact_dtype = self.exact_dtype
+
         if isinstance(x, torch.Tensor) and isinstance(y, Number):
             self.assertEqual(x.item(), y, atol=atol, rtol=rtol, message=message,
-                             exact_dtype=exact_dtype, exact_device=exact_device)
+                             allow_inf=allow_inf, exact_dtype=exact_dtype)
         elif isinstance(y, torch.Tensor) and isinstance(x, Number):
             self.assertEqual(x, y.item(), atol=atol, rtol=rtol, message=message,
-                             exact_dtype=exact_dtype, exact_device=exact_device)
-        # Tensor x np.bool
+                             allow_inf=allow_inf, exact_dtype=exact_dtype)
         elif isinstance(x, torch.Tensor) and isinstance(y, numpy.bool_):
             self.assertEqual(x.item(), y, atol=atol, rtol=rtol, message=message,
-                             exact_dtype=exact_dtype, exact_device=exact_device)
+                             allow_inf=allow_inf, exact_dtype=exact_dtype)
         elif isinstance(y, torch.Tensor) and isinstance(x, numpy.bool_):
             self.assertEqual(x, y.item(), atol=atol, rtol=rtol, message=message,
-                             exact_dtype=exact_dtype, exact_device=exact_device)
-        # Tensor x Tensor
+                             allow_inf=allow_inf, exact_dtype=exact_dtype)
         elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
+            def assertTensorsEqual(a, b):
+                super(__class__, self).assertEqual(a.size(), b.size(), message)
+                if exact_dtype:
+                    self.assertEqual(a.dtype, b.dtype)
+                if a.numel() > 0:
+                    if (a.device.type == 'cpu' and (a.dtype == torch.float16 or a.dtype == torch.bfloat16)):
+                        # CPU half and bfloat16 tensors don't have the methods we need below
+                        a = a.to(torch.float32)
+                    if (a.device.type == 'cuda' and a.dtype == torch.bfloat16):
+                        # CUDA bfloat16 tensors don't have the methods we need below
+                        a = a.to(torch.float32)
+                    b = b.to(a)
+
+                    if (a.dtype == torch.bool) != (b.dtype == torch.bool):
+                        raise TypeError("Was expecting both tensors to be bool type.")
+                    else:
+                        if a.dtype == torch.bool and b.dtype == torch.bool:
+                            # we want to respect precision but as bool doesn't support subtraction,
+                            # boolean tensor has to be converted to int
+                            a = a.to(torch.int)
+                            b = b.to(torch.int)
+
+                        if a.is_complex():
+                            # todo: assert_allclose should handle complex types directly.
+                            float_dtype = torch.float if a.dtype == torch.complex64 else torch.double
+                            self.assertEqual(a.copy_real().to(float_dtype), b.copy_real().to(float_dtype),
+                                             atol=atol, rtol=rtol, message=message)
+                            self.assertEqual(a.copy_imag().to(float_dtype), b.copy_imag().to(float_dtype),
+                                             atol=atol, rtol=rtol, message=message)
+                        elif a.is_floating_point():
+                            torch.testing.assert_allclose(a, b, atol=atol, rtol=rtol, equal_nan=True, msg=message)
+                        else:
+                            diff = a - b
+                            # TODO: implement abs on CharTensor (int8)
+                            if diff.is_signed() and diff.dtype != torch.int8:
+                                diff = diff.abs()
+                            max_err = diff.max()
+                            self.assertLessEqual(max_err, atol, message)
+
             super().assertEqual(x.is_sparse, y.is_sparse, message)
             super().assertEqual(x.is_quantized, y.is_quantized, message)
             if x.is_sparse:
                 x = self.safeCoalesce(x)
                 y = self.safeCoalesce(y)
-                indices_result, debug_msg = self._compareTensors(x._indices(), y._indices(),
-                                                                 rtol=rtol, atol=atol,
-                                                                 equal_nan=equal_nan, exact_dtype=exact_dtype,
-                                                                 exact_device=exact_device)
-
-                if not indices_result and message is None:
-                    message = "Sparse tensor indices failed to compare as equal! " + debug_msg
-                self.assertTrue(indices_result, msg=message)
-
-                values_result, debug_msg = self._compareTensors(x._values(), y._values(),
-                                                                rtol=rtol, atol=atol,
-                                                                equal_nan=equal_nan, exact_dtype=exact_dtype,
-                                                                exact_device=exact_device)
-
-                if not values_result and message is None:
-                    message = "Sparse tensor values failed to compare as equal! " + debug_msg
-                self.assertTrue(values_result, msg=message)
+                assertTensorsEqual(x._indices(), y._indices())
+                assertTensorsEqual(x._values(), y._values())
             elif x.is_quantized and y.is_quantized:
                 self.assertEqual(x.qscheme(), y.qscheme(), atol=atol, rtol=rtol,
-                                 message=message, exact_dtype=exact_dtype,
-                                 exact_device=exact_device)
-
+                                 message=message, allow_inf=allow_inf, exact_dtype=exact_dtype)
                 if x.qscheme() == torch.per_tensor_affine:
                     self.assertEqual(x.q_scale(), y.q_scale(), atol=atol, rtol=rtol,
-                                     message=message, exact_dtype=exact_dtype,
-                                     exact_device=exact_device)
+                                     message=message, allow_inf=allow_inf, exact_dtype=exact_dtype)
                     self.assertEqual(x.q_zero_point(), y.q_zero_point(),
                                      atol=atol, rtol=rtol, message=message,
-                                     exact_dtype=exact_dtype, exact_device=exact_device)
+                                     allow_inf=allow_inf, exact_dtype=exact_dtype)
                 elif x.qscheme() == torch.per_channel_affine:
                     self.assertEqual(x.q_per_channel_scales(), y.q_per_channel_scales(), atol=atol, rtol=rtol,
-                                     message=message, exact_dtype=exact_dtype,
-                                     exact_device=exact_device)
+                                     message=message, allow_inf=allow_inf, exact_dtype=exact_dtype)
                     self.assertEqual(x.q_per_channel_zero_points(), y.q_per_channel_zero_points(),
                                      atol=atol, rtol=rtol, message=message,
-                                     exact_dtype=exact_dtype, exact_device=exact_device)
+                                     allow_inf=allow_inf, exact_dtype=exact_dtype)
                     self.assertEqual(x.q_per_channel_axis(), y.q_per_channel_axis(),
-                                     atol=atol, rtol=rtol, message=message,
-                                     exact_dtype=exact_dtype, exact_device=exact_device)
-
-                result, debug_msg = self._compareTensors(x.int_repr().to(torch.int32),
-                                                         y.int_repr().to(torch.int32),
-                                                         atol=atol, rtol=rtol,
-                                                         exact_dtype=exact_dtype,
-                                                         exact_device=exact_device)
-
-                if not result and message is None:
-                    message = "Quantized representations failed to compare as equal! " + debug_msg
-                self.assertTrue(result, msg=message)
+                                     atol=atol, rtol=rtol, message=message)
+                self.assertEqual(x.dtype, y.dtype)
+                self.assertEqual(x.int_repr().to(torch.int32),
+                                 y.int_repr().to(torch.int32), atol=atol, rtol=rtol,
+                                 message=message, allow_inf=allow_inf, exact_dtype=exact_dtype)
             else:
-                result, debug_msg = self._compareTensors(x, y, rtol=rtol, atol=atol,
-                                                         equal_nan=equal_nan, exact_dtype=exact_dtype,
-                                                         exact_device=exact_device)
-
-                if not result and message is None:
-                    message = "Tensors failed to compare as equal! " + debug_msg
-                self.assertTrue(result, msg=message)
+                assertTensorsEqual(x, y)
         elif isinstance(x, string_classes) and isinstance(y, string_classes):
             super().assertEqual(x, y, message)
         elif type(x) == set and type(y) == set:
@@ -1088,44 +1011,72 @@ class TestCase(expecttest.TestCase):
         elif isinstance(x, dict) and isinstance(y, dict):
             if isinstance(x, OrderedDict) and isinstance(y, OrderedDict):
                 self.assertEqual(x.items(), y.items(), atol=atol, rtol=rtol,
-                                 message=message, exact_dtype=exact_dtype,
-                                 exact_device=exact_device)
+                                 message=message, allow_inf=allow_inf, exact_dtype=exact_dtype)
             else:
                 self.assertEqual(set(x.keys()), set(y.keys()), atol=atol, rtol=rtol,
-                                 message=message, exact_dtype=exact_dtype,
-                                 exact_device=exact_device)
+                                 message=message, allow_inf=allow_inf, exact_dtype=exact_dtype)
                 key_list = list(x.keys())
                 self.assertEqual([x[k] for k in key_list],
                                  [y[k] for k in key_list],
                                  atol=atol, rtol=rtol, message=message,
-                                 exact_dtype=exact_dtype, exact_device=exact_device)
+                                 allow_inf=allow_inf, exact_dtype=exact_dtype)
         elif is_iterable(x) and is_iterable(y):
             super().assertEqual(len(x), len(y), message)
             for x_, y_ in zip(x, y):
                 self.assertEqual(x_, y_, atol=atol, rtol=rtol, message=message,
-                                 exact_dtype=exact_dtype, exact_device=exact_device)
+                                 allow_inf=allow_inf, exact_dtype=exact_dtype)
         elif isinstance(x, bool) and isinstance(y, bool):
-            self.assertTrue(x == y, msg=message)
-
-        # Scalar x Scalar
+            super().assertEqual(x, y, message)
         elif isinstance(x, Number) and isinstance(y, Number):
-            result, debug_msg = self._compareScalars(x, y, rtol=rtol, atol=atol,
-                                                     equal_nan=equal_nan)
-            if not result and message is None:
-                message = "Scalars failed to compare as equal! " + debug_msg
-            self.assertTrue(result, msg=message)
+            if abs(x) == inf or abs(y) == inf:
+                if allow_inf:
+                    super().assertEqual(x, y, message)
+                else:
+                    self.fail("Expected finite numeric values - x={}, y={}".format(x, y))
+                return
+            super().assertLessEqual(abs(x - y), atol, message)
         else:
-            super().assertEqual(x, y, msg=message)
+            super().assertEqual(x, y, message)
 
-    def assertAlmostEqual(self, x, y, places=None, msg=None, delta=None):
+    def assertAlmostEqual(self, x, y, places=None, msg='', delta=None, allow_inf=None):
         prec = delta
         if places:
             prec = 10**(-places)
-        self.assertEqual(x, y, message=msg, atol=prec)
+        self.assertEqual(x, y, msg, atol=prec, allow_inf=allow_inf)
 
-    def assertNotEqual(self, x, y, message=None, *, atol=None):
-        with self.assertRaises(AssertionError):
-            self.assertEqual(x, y, message=message, atol=atol)
+    def assertNotEqual(self, x, y, message='', *, atol=None):
+        if not isinstance(message, str):
+            raise Error("fix this test, message should be a string")
+        if atol is None:
+            (_, atol) = self.get_default_tolerance(x, y)
+
+        if isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
+            if x.size() != y.size():
+                super().assertNotEqual(x.size(), y.size())
+            self.assertGreater(x.numel(), 0)
+            y = y.type_as(x)
+            y = y.cuda(device=x.get_device()) if x.is_cuda else y.cpu()
+            nan_mask = x != x
+            if torch.equal(nan_mask, y != y):
+                diff = x - y
+                if diff.is_signed():
+                    diff = diff.abs()
+                diff[nan_mask] = 0
+                # Use `item()` to work around:
+                # https://github.com/pytorch/pytorch/issues/22301
+                max_err = diff.max().item()
+                self.assertGreater(max_err, atol, message)
+        elif type(x) == str and type(y) == str:
+            super().assertNotEqual(x, y)
+        elif is_iterable(x) and is_iterable(y):
+            super().assertNotEqual(x, y)
+        else:
+            try:
+                self.assertGreater(abs(x - y), atol, message)
+                return
+            except (TypeError, AssertionError):
+                pass
+            super().assertNotEqual(x, y, message)
 
     def assertEqualTypeString(self, x, y):
         # This API is used simulate deprecated x.type() == y.type()


### PR DESCRIPTION
This reverts commit 9cfc10d52e0d0a8576b0a5a347fa6fa8da86244a.

This is breaking ROCm CI. Notably, TestNCCL.

@mruberry @ezyang @xw285cornell 