### PR TITLE
Overload bitwise NOT, AND, OR, XOR operators for `at::Tensor`

### DIFF
--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -17,6 +17,9 @@ inline Tensor & Tensor::operator=(Tensor && rhs) && {
 inline Tensor & Tensor::operator=(Scalar v) && {
   return fill_(v);
 }
+inline Tensor Tensor::operator~() const {
+  return bitwise_not();
+}
 inline Tensor Tensor::operator-() const {
   return neg();
 }
@@ -43,6 +46,15 @@ inline Tensor& Tensor::operator/=(const Tensor & other) {
 }
 inline Tensor& Tensor::operator/=(Scalar other) {
   return div_(other);
+}
+inline Tensor& Tensor::operator&=(const Tensor & other) {
+  return bitwise_and_(other);
+}
+inline Tensor& Tensor::operator|=(const Tensor & other) {
+  return bitwise_or_(other);
+}
+inline Tensor& Tensor::operator^=(const Tensor & other) {
+  return bitwise_xor_(other);
 }
 inline Tensor Tensor::operator[](Scalar index) const {
   if (!index.isIntegral(false)) {
@@ -73,6 +85,9 @@ _(*,x.mul(y), y.mul(x)) \
 _(-,x.sub(y), ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).sub_(y)) \
 _(/,x.div(y), ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).div_(y)) \
 _(%,x.remainder(y), ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).remainder_(y)) \
+_(&,x.bitwise_and(y), y.bitwise_and(x)) \
+_(|,x.bitwise_or(y), y.bitwise_or(x)) \
+_(^,x.bitwise_xor(y), y.bitwise_xor(x)) \
 _(<,x.lt(y), y.gt(x)) \
 _(<=,x.le(y), y.ge(x)) \
 _(>,x.gt(y),y.lt(x)) \

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -401,6 +401,7 @@ class CAFFE2_API Tensor {
   C10_DEPRECATED_MESSAGE("packed_accessor is deprecated, use packed_accessor32 or packed_accessor64 instead")
   GenericPackedTensorAccessor<T,N,PtrTraits,index_t> packed_accessor() && = delete;
 
+  Tensor operator~() const;
   Tensor operator-() const;
   Tensor& operator+=(const Tensor & other);
   Tensor& operator+=(Scalar other);
@@ -410,6 +411,9 @@ class CAFFE2_API Tensor {
   Tensor& operator*=(Scalar other);
   Tensor& operator/=(const Tensor & other);
   Tensor& operator/=(Scalar other);
+  Tensor& operator&=(const Tensor & other);
+  Tensor& operator|=(const Tensor & other);
+  Tensor& operator^=(const Tensor & other);
   Tensor operator[](Scalar index) const;
   Tensor operator[](Tensor index) const;
   Tensor operator[](int64_t index) const;

--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -20,6 +20,19 @@ void trace() {
   ASSERT_FLOAT_EQ(foo.trace().item<float>(), trace);
 }
 
+TEST(atest, operators) {
+  int a = 0b10101011;
+  int b = 0b01111011;
+
+  auto a_tensor = tensor({a});
+  auto b_tensor = tensor({b});
+
+  ASSERT_TRUE(tensor({~a}).equal(~a_tensor));
+  ASSERT_TRUE(tensor({a | b}).equal(a_tensor | b_tensor));
+  ASSERT_TRUE(tensor({a & b}).equal(a_tensor & b_tensor));
+  ASSERT_TRUE(tensor({a ^ b}).equal(a_tensor ^ b_tensor));
+}
+
 // TEST_CASE( "atest", "[]" ) {
 TEST(atest, atest) {
   manual_seed(123);


### PR DESCRIPTION
Fix #38546