### PR TITLE
[TensorExpr] Make inlining eager and make it work in more cases

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -371,6 +371,80 @@ void testScheduleFunctionCall01() {
   ExpectAllNear(d_v, d_ref, 1e-5);
 }
 
+void testScheduleInlineSimple() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+  Buffer a_buf("a", kFloat, {M, N});
+  Buffer b_buf("b", kFloat, {N, K});
+  Buffer c_buf("c", kFloat, {M, N});
+  Buffer d_buf("d", kFloat, {M, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n) * b_buf(n, k);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return c_buf(m, n) * d_buf(m, k) + x->call(m, n, k);
+      });
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, c_buf, d_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, c_buf, d_buf, y);
+
+  PaddedBuffer<float> a_v(M, N);
+  PaddedBuffer<float> b_v(N, K);
+  PaddedBuffer<float> c_v(M, N);
+  PaddedBuffer<float> d_v(M, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      a_v(i, j) = i * i;
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < K; j++) {
+      b_v(i, j) = j * j;
+    }
+  }
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      c_v(i, j) = i + j;
+    }
+  }
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < K; j++) {
+      d_v(i, j) = i * j;
+    }
+  }
+
+  PaddedBuffer<float> y_1(M, N, K);
+  PaddedBuffer<float> y_2(M, N, K);
+
+  eval1(a_v, b_v, c_v, d_v, y_1);
+  eval2(a_v, b_v, c_v, d_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
+}
+
 static std::string remove_space(const std::string& str) {
   std::string str_new = str;
   str_new.erase(
@@ -410,15 +484,15 @@ void InlineFunc01Helper(const std::vector<std::string>& inline_order) {
   LoopNest l({z});
   for (const std::string& order : inline_order) {
     if (order == "x") {
-      l.computeInline(l.getLoopBodyFor(x));
+      l.computeInline(x->buf());
     } else if (order == "y") {
-      l.computeInline(l.getLoopBodyFor(y));
+      l.computeInline(y->buf());
     } else {
       throw std::runtime_error("Invalid order: " + order);
     }
   }
   l.prepareForCodegen();
-  Stmt* stmt = l.root_stmt();
+  Stmt* stmt = IRSimplifier::simplify(l.root_stmt());
 
   std::ostringstream oss;
   oss << *stmt;
@@ -437,7 +511,7 @@ void InlineFunc01Helper(const std::vector<std::string>& inline_order) {
     }
     for (int i = 0; i < N; i++) {
       for (int j = 0; j < K; j++) {
-        a_v(i, j) = j * j;
+        b_v(i, j) = j * j;
       }
     }
     for (int i = 0; i < M; i++) {
@@ -476,7 +550,7 @@ void InlineFunc01Helper(const std::vector<std::string>& inline_order) {
         });
     LoopNest l2({z2});
     l2.prepareForCodegen();
-    Stmt* stmt2 = l2.root_stmt();
+    Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
 
     std::ostringstream oss2;
     oss2 << *stmt2;
@@ -493,6 +567,448 @@ void testScheduleInlineFunc01() {
   InlineFunc01Helper({"x"});
   InlineFunc01Helper({"y"});
   InlineFunc01Helper({});
+}
+
+// Make sure we cache random vars if we should.
+void testScheduleInlineRandom() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Mod::make(Intrinsics::make(kRand, kInt), 5);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return x->call(m, n, k) + x->call(m, n, k);
+      });
+
+  LoopNest l1({y});
+  l1.computeInline(x->buf());
+
+  // would normally compare results but Rand isn't implemented in the
+  // SimpleIREvaluator, even if we could seed it.
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  std::ostringstream oss;
+  oss << *stmt1;
+
+  // Check the IR we produced
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: for (int m2 = 0; m2 < 4; m2++)
+# CHECK:   int x = rand();
+# CHECK:   for (int n2 = 0; n2 < 5; n2++)
+# CHECK:     for (int k2 = 0; k2 < 6; k2++)
+# CHECK:     y[m2, n2, k2] = 2 * (x % 5);)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Make sure we don't screw up intrinsics thinking they're rand.
+void testScheduleInlineIntrinsics() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+  Buffer a_buf("a", kFloat, {M, N});
+  Buffer b_buf("b", kFloat, {N, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n) * b_buf(n, k);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Intrinsics::make(kSqrt, x->call(m, n, k));
+      });
+
+  PaddedBuffer<float> a_v(M, N);
+  PaddedBuffer<float> b_v(N, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      a_v(i, j) = i * i;
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < K; j++) {
+      b_v(i, j) = j * j;
+    }
+  }
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, y);
+
+  PaddedBuffer<float> y_1(M, N, K);
+  PaddedBuffer<float> y_2(M, N, K);
+
+  eval1(a_v, b_v, y_1);
+  eval2(a_v, b_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
+}
+
+// Make sure we can handle rand and non-rand intrinsics.
+void testScheduleInlineRandWithIntrinsics() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Intrinsics::make(kRand, kFloat);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Intrinsics::make(kSqrt, x->call(m, n, k));
+      });
+
+  LoopNest l1({y});
+  l1.computeInline(x->buf());
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+
+  std::ostringstream oss;
+  oss << *stmt1;
+
+  // Check the IR we produced
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: for (int m2 = 0; m2 < 4; m2++)
+# CHECK:   float x = rand();
+# CHECK:   for (int n2 = 0; n2 < 5; n2++)
+# CHECK:     for (int k2 = 0; k2 < 6; k2++)
+# CHECK:     y[m2, n2, k2] = sqrt(x);)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Split a Compute then inline it into another compute.
+void testScheduleSplitAThenInline() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{2, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  l.computeInline(a->buf());
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+
+  std::vector<int> output(2, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  ASSERT_EQ(output[0], 64);
+  ASSERT_EQ(output[1], 81);
+}
+
+// Split a Compute then inline another Compute into it.
+void testScheduleSplitBThenInline() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(b);
+  l.splitWithMask(loops[0], 3, &i_outer, &i_inner);
+  l.computeInline(a->buf());
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+
+  std::vector<int> output(6, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_EQ(output[i], (i + 8) * (i + 8));
+  }
+}
+
+// Split a Compute twice then inline it.
+void testScheduleSplitTwiceThenInline() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{2, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  l.splitWithMask(i_inner, 2, &i_outer, &i_inner);
+  l.computeInline(a->buf());
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(2, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  ASSERT_EQ(output[0], 64);
+  ASSERT_EQ(output[1], 81);
+}
+
+// Inline a Compute, then split.
+void testScheduleInlineThenSplit() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  l.computeInline(a->buf());
+
+  std::vector<For*> loops = NodeFinder<For>::find(l.root_stmt());
+  l.splitWithMask(loops.back(), 3, &i_outer, &i_inner);
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(6, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_EQ(output[i], (i + 8) * (i + 8));
+  }
+}
+
+// Split a Compute, inline it, then split the result.
+void testScheduleSplitInlineThenSplit() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{16, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  auto loops = NodeFinder<For>::find(l.root_stmt());
+  l.splitWithMask(loops.back(), 2, &i_outer, &i_inner);
+  l.computeInline(a->buf());
+
+  loops = NodeFinder<For>::find(l.root_stmt());
+  l.splitWithMask(loops.front(), 2, &i_outer, &i_inner);
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(16, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  for (int i = 0; i < 16; ++i) {
+    ASSERT_EQ(output[i], (i + 8) * (i + 8));
+  }
+}
+
+// Oversplit a loop that is simplified out after inlining.
+void testScheduleSplitInlineSimplify() {
+  KernelScope kernel_scope;
+  Tensor* a = Compute("a", {{18, "i"}}, [&](const VarHandle& i) {
+    return ExprHandle(4) * i - ExprHandle(2) * i;
+  });
+  Tensor* b = Compute("b", {{2, "j"}}, [&](const VarHandle& j) {
+    return a->call(j) - ExprHandle(1);
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  l.computeInline(a->buf());
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(2, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  ASSERT_EQ(output[0], -1);
+  ASSERT_EQ(output[1], 1);
+}
+
+// Inline a Compute with two consumers.
+void testScheduleInlineThreeMixedOnce() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.computeInline(a->buf());
+  l.prepareForCodegen();
+
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(4 * 3, 0);
+  SimpleIREvaluator eval(s, c);
+  eval(output);
+
+  for (int k = 0; k < 4; ++k) {
+    for (int l = 0; l < 3; ++l) {
+      ASSERT_EQ(output[k * 3 + l], (k) * (k) * (l + 8) * (l + 8));
+    }
+  }
+}
+
+// Inline Compute A into B, then inline B into C.
+void testScheduleInlineThreeMixedTwice() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.computeInline(a->buf());
+  l.computeInline(b->buf());
+  l.prepareForCodegen();
+
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(4 * 3, 0);
+  SimpleIREvaluator eval(s, c);
+  eval(output);
+
+  for (int k = 0; k < 4; ++k) {
+    for (int l = 0; l < 3; ++l) {
+      ASSERT_EQ(output[k * 3 + l], (k) * (k) * (l + 8) * (l + 8));
+    }
+  }
+}
+
+// Inline a Compute that is both a producer and consumer.
+void testScheduleInlineThreeMixedInner() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.computeInline(b->buf());
+  l.prepareForCodegen();
+
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(4 * 3, 0);
+  SimpleIREvaluator eval(s, c);
+  eval(output);
+
+  for (int k = 0; k < 4; ++k) {
+    for (int l = 0; l < 3; ++l) {
+      ASSERT_EQ(output[k * 3 + l], (k) * (k) * (l + 8) * (l + 8));
+    }
+  }
+}
+
+// Split 3 Computes, then inline the first two into the last.
+void testScheduleInlineThreeMixedSplit() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  For* i_outer;
+  For* i_inner;
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  loops = l.getLoopStmtsFor(b);
+  l.splitWithMask(loops[0], 3, &i_outer, &i_inner);
+  loops = l.getLoopStmtsFor(c);
+  l.splitWithMask(loops[0], 2, &i_outer, &i_inner);
+
+  l.computeInline(a->buf());
+  l.computeInline(b->buf());
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(4 * 3, 0);
+  SimpleIREvaluator eval(s, c);
+  eval(output);
+
+  for (int k = 0; k < 4; ++k) {
+    for (int l = 0; l < 3; ++l) {
+      ASSERT_EQ(output[k * 3 + l], (k) * (k) * (l + 8) * (l + 8));
+    }
+  }
 }
 
 void testScheduleFuserStyle() {
@@ -550,8 +1066,8 @@ void testScheduleFuserThreeArg() {
   });
 
   LoopNest l({g});
-  l.computeInline(l.getLoopBodyFor(e));
-  l.computeInline(l.getLoopBodyFor(f));
+  l.computeInline(e->buf());
+  l.computeInline(f->buf());
   l.prepareForCodegen();
   Stmt* s = l.root_stmt();
 

--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -465,6 +465,99 @@ void testReduceRfactorLike() {
   ASSERT_EQ(out[0], 99 * 50);
 }
 
+void testReduceAsProducer() {
+  KernelScope kernel_scope;
+
+  const int M = 10;
+  VarHandle m("m", kInt);
+
+  Buffer a(BufHandle("a", {2, 3}, kFloat));
+  Buffer b(BufHandle("b", {2, 3, m}, kFloat));
+
+  Tensor* c = Reduce("sum", {{2, "l1"}, {3, "n1"}}, Sum(), b, {{m, "m1"}});
+  Tensor* d = Compute(
+      "scale",
+      {{2, "l2"}, {3, "n1"}},
+      [&](const VarHandle& l, const VarHandle& n) {
+        return c->call(l, n) * a(l, n);
+      });
+  LoopNest loop({d});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {a, b, d, m});
+
+  std::vector<float> aData(2 * 3, 0);
+  std::vector<float> bData(2 * 3 * M, 0);
+  std::vector<float> dData(2 * 3, 6.0f);
+
+  for (int i = 0; i < 2 * 3; ++i) {
+    aData[i] = 6 - i;
+    for (int j = 0; j < M; ++j) {
+      bData[i * M + j] = j;
+    }
+  }
+
+  cg.call({aData, bData, dData, M});
+  float expected = 0;
+  for (int i = 0; i < M; ++i) {
+    expected += i;
+  }
+  for (int i = 0; i < 2 * 3; ++i) {
+    ASSERT_EQ(dData[i], expected * (6 - i));
+  }
+}
+
+void testReduceAsConsumer() {
+  KernelScope kernel_scope;
+
+  const int M = 10;
+  VarHandle m("m", kInt);
+
+  Buffer a(BufHandle("a", {2, 3, m}, kFloat));
+  Buffer b(BufHandle("b", {2, 3, m}, kFloat));
+
+  Tensor* c = Compute(
+      "scale",
+      {{2, "l2"}, {3, "n1"}, {m, "m1"}},
+      [&](const VarHandle& l, const VarHandle& n, const VarHandle& m) {
+        return b(l, n, m) * a(l, n, m);
+      });
+  Tensor* d = Reduce("sum", {{2, "l1"}}, Sum(), c, {{3, "n1"}, {m, "m1"}});
+  LoopNest loop({d});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {a, b, d, m});
+
+  std::vector<float> aData(2 * 3 * M, 0);
+  std::vector<float> bData(2 * 3 * M, 0);
+  std::vector<float> dData(2, 6.0f);
+
+  for (int i = 0; i < 2 * 3; ++i) {
+    for (int j = 0; j < M; ++j) {
+      bData[i * M + j] = j + 1;
+      aData[i * M + j] = 6 - i;
+    }
+  }
+
+  cg.call({aData, bData, dData, M});
+  float expected[2] = {0, 0};
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < M; ++k) {
+        expected[i] += (k + 1) * (6 - (i * 3 + j));
+      }
+    }
+  }
+
+  for (int i = 0; i < 2; ++i) {
+    ASSERT_EQ(dData[i], expected[i]);
+  }
+}
+
 void testSplitReduceAxis() {
   KernelScope kernel_scope;
 
@@ -1199,6 +1292,151 @@ void testReduceOverSplitRfactor() {
 # CHECK: Free(tmp_buf);)IR";
   // TODO: rfactor output is not consistent yet, will fix (@nickg).
   // torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+void testReduceInlineReduction() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Buffer a_buf("a", kFloat, {M});
+  Buffer b_buf("b", kFloat, {M, N, K});
+
+  Tensor* x = Reduce("x", {{M, "m1"}}, Sum(), b_buf, {{N, "n1"}, {K, "k1"}});
+  Tensor* y = Compute("y", {{M, "m2"}}, [&](const VarHandle& m) {
+    return a_buf(m) + x->call(m);
+  });
+
+  PaddedBuffer<float> a_v(M);
+  PaddedBuffer<float> b_v(M, N, K);
+
+  for (int i = 0; i < M; i++) {
+    a_v(i) = i * i;
+  }
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < K; k++) {
+        b_v(i, j, k) = j * j * k;
+      }
+    }
+  }
+
+  LoopNest l1({y});
+  ASSERT_THROWS_WITH(
+      l1.computeInline(x->buf()), "cannot inline a reduction computation");
+}
+
+void testReduceInlineConsumer() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Buffer a_buf("a", kFloat, {M, N, K});
+  Buffer b_buf("b", kFloat, {M, N, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n, k) + b_buf(m, n, k);
+      });
+  Tensor* y = Reduce("y", {{M, "m2"}}, Sum(), x, {{N, "n2"}, {K, "k2"}});
+
+  PaddedBuffer<float> a_v(M, N, K);
+  PaddedBuffer<float> b_v(M, N, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < K; k++) {
+        a_v(i, j, k) = i * i + k;
+        b_v(i, j, k) = j * j + k;
+      }
+    }
+  }
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, y);
+
+  PaddedBuffer<float> y_1(M);
+  PaddedBuffer<float> y_2(M);
+
+  eval1(a_v, b_v, y_1);
+  eval2(a_v, b_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
+}
+
+void testReduceInlineReducerInternal() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Buffer a_buf("a", kFloat, {M, N, K});
+  Buffer b_buf("b", kFloat, {M, N, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n, k) + b_buf(m, n, k);
+      });
+
+  Reducer minimum(ExprHandle(0.f), [&](ExprHandle a, ExprHandle b) {
+    return Add::make(ExprHandle(1.f), Min::make(a, b, false));
+  });
+  Tensor* y = Reduce("y", {{M, "m2"}}, minimum, x, {{N, "n2"}, {K, "k2"}});
+
+  PaddedBuffer<float> a_v(M, N, K);
+  PaddedBuffer<float> b_v(M, N, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < K; k++) {
+        a_v(i, j, k) = i * i + k;
+        b_v(i, j, k) = j * j + k;
+      }
+    }
+  }
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, y);
+
+  PaddedBuffer<float> y_1(M);
+  PaddedBuffer<float> y_2(M);
+
+  eval1(a_v, b_v, y_1);
+  eval2(a_v, b_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
 }
 
 } // namespace jit

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -42,7 +42,21 @@ namespace jit {
   _(ExprSplitWithMask01)                    \
   _(ScheduleBroadcastAddBuffer)             \
   _(ScheduleFunctionCall01)                 \
+  _(ScheduleInlineSimple)                   \
   _(ScheduleInlineFunc01)                   \
+  _(ScheduleInlineRandom)                   \
+  _(ScheduleInlineIntrinsics)               \
+  _(ScheduleInlineRandWithIntrinsics)       \
+  _(ScheduleSplitAThenInline)               \
+  _(ScheduleSplitBThenInline)               \
+  _(ScheduleSplitTwiceThenInline)           \
+  _(ScheduleInlineThenSplit)                \
+  _(ScheduleSplitInlineThenSplit)           \
+  _(ScheduleSplitInlineSimplify)            \
+  _(ScheduleInlineThreeMixedOnce)           \
+  _(ScheduleInlineThreeMixedTwice)          \
+  _(ScheduleInlineThreeMixedInner)          \
+  _(ScheduleInlineThreeMixedSplit)          \
   _(ScheduleFuserStyle)                     \
   _(ScheduleFuserThreeArg)                  \
   _(ScheduleDynamicShape2D)                 \
@@ -56,6 +70,11 @@ namespace jit {
   _(ReduceAnyAll)                           \
   _(ReduceMatmul2D)                         \
   _(ReduceRfactorLike)                      \
+  _(ReduceAsProducer)                       \
+  _(ReduceAsConsumer)                       \
+  _(SplitReduceAxis)                        \
+  _(SplitNonReduceAxis)                     \
+  _(ReorderedReductionInitializer)          \
   _(ReduceRfactor)                          \
   _(Reduce3DRfactor)                        \
   _(Reduce3DRfactor2)                       \
@@ -72,8 +91,9 @@ namespace jit {
   _(ReduceOverSplitMask)                    \
   _(ReduceSplitRfactor)                     \
   _(ReduceOverSplitRfactor)                 \
-  _(SplitReduceAxis)                        \
-  _(SplitNonReduceAxis)                     \
+  _(ReduceInlineReduction)                  \
+  _(ReduceInlineConsumer)                   \
+  _(ReduceInlineReducerInternal)            \
   _(TypeTest01)                             \
   _(TypePropagation)                        \
   _(Cond01)                                 \

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -263,8 +263,15 @@ class VarHandle : public ExprHandle {
 
 template <class Op, class Base>
 const Expr* ExprNode<Op, Base>::accept_mutator(IRMutator* mutator) const {
-  ExprNode* this_mutable = const_cast<ExprNode*>(this);
-  return mutator->mutate(static_cast<Op*>(this_mutable));
+  const Expr* this_pre = mutator->pre_mutate(this);
+  if (!this_pre) {
+    return nullptr;
+  }
+  const Op* this_op = dynamic_cast<const Op*>(this_pre);
+  if (this_op == nullptr) {
+    return this_pre->accept_mutator(mutator);
+  }
+  return mutator->mutate(const_cast<Op*>(this_op));
 }
 
 inline bool same_node(const ExprHandle& expr1, const ExprHandle& expr2) {

--- a/torch/csrc/jit/tensorexpr/function.cpp
+++ b/torch/csrc/jit/tensorexpr/function.cpp
@@ -125,6 +125,20 @@ Tensor* Reduce(
       reduce_args);
 }
 
+Tensor* Reduce(
+    const std::string& func_name,
+    const std::vector<DimArg>& dim_args,
+    const Reducer& reducer,
+    Tensor* tensor,
+    const std::vector<DimArg>& reduce_args) {
+  return Reduce(
+      func_name,
+      dim_args,
+      reducer,
+      [&](ParameterList& p) { return tensor->call(p); },
+      reduce_args);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -519,6 +519,7 @@ class BaseCallNode : public Expr {
   template <class U, class B>
   friend class ExprNode;
   friend class IRMutator;
+  friend class IRCloner;
 
   CallType call_type_;
   std::vector<const Expr*> params_;
@@ -577,13 +578,6 @@ class TORCH_API CompareSelect : public ExprNode<CompareSelect> {
         lhs.node(), rhs.node(), ret_val1.node(), ret_val2.node(), cmp_op));
   }
 
- private:
-  const Expr* lhs_;
-  const Expr* rhs_;
-  const Expr* ret_val1_;
-  const Expr* ret_val2_;
-  CompareSelectOperation compare_op_;
-
   CompareSelect(
       const Expr* lhs,
       const Expr* rhs,
@@ -600,6 +594,13 @@ class TORCH_API CompareSelect : public ExprNode<CompareSelect> {
       throw malformed_input("bad dtype in CompareSelect");
     }
   }
+
+ private:
+  const Expr* lhs_;
+  const Expr* rhs_;
+  const Expr* ret_val1_;
+  const Expr* ret_val2_;
+  CompareSelectOperation compare_op_;
 };
 
 enum IntrinsicsOp {

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -53,6 +53,14 @@ class AtomicAdd;
 class TORCH_API IRMutator {
  public:
   virtual ~IRMutator() {}
+
+  virtual Stmt* pre_mutate(Stmt* s) {
+    return s;
+  }
+  virtual const Expr* pre_mutate(const Expr* e) {
+    return e;
+  }
+
   virtual const Expr* mutate(const Add* v);
   virtual const Expr* mutate(const Sub* v);
   virtual const Expr* mutate(const Mul* v);

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -254,10 +254,10 @@ const Expr* PolynomialTransformer::mutate(const Add* v) {
   const Expr* scalar = nullptr;
   const Expr* variable = nullptr;
   if (lhs_new->isConstant()) {
-    scalar = evaluateOp(lhs_new);
+    scalar = lhs_new;
     variable = rhs_new;
   } else if (rhs_new->isConstant()) {
-    scalar = evaluateOp(rhs_new);
+    scalar = rhs_new;
     variable = lhs_new;
   }
 
@@ -1047,6 +1047,15 @@ Stmt* PolynomialTransformer::mutate(const Cond* v) {
   if (true_new && false_new &&
       hasher_.hash(true_new) == hasher_.hash(false_new)) {
     return Stmt::clone(true_new);
+  }
+
+  Block* true_block = dynamic_cast<Block*>(true_new);
+  Block* false_block = dynamic_cast<Block*>(false_new);
+  bool true_empty = !true_new || (true_block && true_block->nstmts() == 0);
+  bool false_empty = !false_new || (false_block && false_block->nstmts() == 0);
+
+  if (true_empty && false_empty) {
+    return new Block({});
   }
 
   if (cond_old == cond_new && true_old == true_new && false_old == false_new) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1033,12 +1033,7 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
     if (!l.hasLoopBodyFor(p.second)) {
       continue;
     }
-    Stmt* loop = l.getLoopBodyFor(p.second);
-    if (torch::jit::tensorexpr::HasRand(loop).has_rand()) {
-      l.computeInlineWithRandom(loop);
-    } else {
-      l.computeInline(loop);
-    }
+    l.computeInline(p.second->buf());
   }
   if (backendType == kCudaCodeGen) {
     for (size_t i = 0; i < flatTensorOutputs_.size(); i++) {
@@ -1046,7 +1041,7 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
 
       // For every output tensor we've created a flattened 1D tensor - let's
       // mark the original output tensor with computeInline
-      l.computeInline(l.getLoopBodyFor(tensorOutputs_[i]));
+      l.computeInline(tensorOutputs_[i]->buf());
 
       int loopLevels = getTECudaPointwiseLoopLevels();
       const int kDefaultLoopLevels = 2;

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -8,6 +8,7 @@
 
 #include <c10/util/Logging.h>
 #include <c10/util/string_utils.h>
+#include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/bounds_inference.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
@@ -364,248 +365,6 @@ class Flattener : public IRMutator {
   }
 };
 
-class FunctionInliner : public IRMutator {
- public:
-  FunctionInliner(const std::vector<Function*>& funcs) : funcs_(funcs) {
-    for (Function* func : funcs) {
-      // TODO: Support multiple-output functions
-      if (func->func_vars().size() != 1) {
-        throw unimplemented_lowering();
-      }
-      func_var_set_.insert(func->func_var(0)->base_handle());
-    }
-  }
-
- protected:
-  bool should_inline(Function* func) const {
-    return func_var_set_.count(func->func_var(0)->base_handle()) > 0;
-  }
-
-  // For the target function, insert the caller/callee pair into the replacement
-  // mapping.
-  const Expr* mutate(const FunctionCall* v) override {
-    Function* func = v->tensor()->function();
-    const Buf* buf = v->tensor()->buf();
-    // TODO: Support multiple-output functions
-    if (func->func_vars().size() != 1) {
-      throw unimplemented_lowering();
-    }
-
-    if (should_inline(func)) {
-      // Insert the caller/callee pair into the mapping.
-      for (size_t i = 0; i < buf->ndim(); i++) {
-        const Var* func_callee_arg = dynamic_cast<const Var*>(func->arg(i));
-        const Expr* func_caller_param = v->param(i);
-        auto iter = inline_mapping_.find(func_callee_arg);
-        if (iter != inline_mapping_.end()) {
-          throw std::runtime_error(
-              "Duplicated variables: " + func_callee_arg->name_hint());
-        }
-        inline_mapping_[func_callee_arg] = func_caller_param;
-      }
-
-      // Call the actual replacement.
-      const Expr* body = func->body(v->tensor()->output_index());
-      const Expr* result = body->accept_mutator(this);
-
-      // Remove the caller/callee relationship.
-      for (size_t i = 0; i < buf->ndim(); i++) {
-        const Var* func_callee_arg = dynamic_cast<const Var*>(func->arg(i));
-        auto iter = inline_mapping_.find(func_callee_arg);
-        if (iter == inline_mapping_.end()) {
-          throw std::runtime_error(
-              "Var already removed: " + func_callee_arg->name_hint());
-        }
-        inline_mapping_.erase(iter);
-      }
-      return result;
-    } else {
-      return IRMutator::mutate(v);
-    }
-  }
-
-  // Replace the target variable with the caller expressions.
-  const Expr* mutate(const Var* v) override {
-    auto iter = inline_mapping_.find(v);
-    if (iter == inline_mapping_.end()) {
-      return IRMutator::mutate(v);
-    } else {
-      const Expr* expr = iter->second;
-      // Continue to transform the value from the lookup table.
-      return expr->accept_mutator(this);
-    }
-  }
-
-  // Remove the buffer write the inlined function.
-  Stmt* mutate(const Store* v) override {
-    if (func_var_set_.count(v->base_handle()) > 0) {
-      return nullptr;
-    } else {
-      return IRMutator::mutate(v);
-    }
-  }
-
- private:
-  std::unordered_map<const Var*, const Expr*> inline_mapping_;
-  std::vector<Function*> funcs_;
-  std::unordered_set<const Var*> func_var_set_;
-};
-
-// Inlining for functions containing rand().  Since rand() is stateful we can't
-// simply inline it everywhere, or else we may generate new randoms where we
-// should us a previously generated one.  As a contrived example:
-//   %1 = rand()
-//   %2 = %1 + 1
-//   %3 = %1 - 1
-//   %4 = %2 - %3
-// Fully inlining this expr would, incorrectly, yield:
-//   %4 = (rand() + 1) - (rand() - 1)
-// when in fact the two uses of %1 should cancel.  To avoid this issue, we
-// instead generate:
-//   %4 = (let x = rand(); (x + 1) - (x - 1))
-//
-// The overall approach is to replace every rand() intrinsic with a newly
-// generated variable, and then bind those variables to rand() calls in the
-// body of the innermost control structure.
-class RandomInliner : public FunctionInliner {
- public:
-  explicit RandomInliner(const std::vector<Function*>& funcs)
-      : FunctionInliner(funcs) {}
-
-  using FunctionInliner::mutate;
-
-  // Bind random vars in the true and false branches of a conditional.
-  Stmt* mutate(const Cond* v) override {
-    const Expr* cond = v->condition();
-    Stmt* true_stmt = v->true_stmt();
-    Stmt* false_stmt = v->false_stmt();
-
-    const Expr* cond_new = cond->accept_mutator(this);
-    Stmt* true_new = true_stmt ? true_stmt->accept_mutator(this) : true_stmt;
-    true_new = bind_random_vars(true_new);
-    Stmt* false_new =
-        false_stmt ? false_stmt->accept_mutator(this) : false_stmt;
-    false_new = bind_random_vars(false_new);
-
-    if (cond_new == cond && true_new == true_stmt && false_new == false_stmt) {
-      return const_cast<Cond*>(v); // NOLINT
-    }
-    return new Cond(cond_new, true_new, false_new);
-  }
-
-  // Bind random vars in the innermost loop where they are used.
-  Stmt* mutate(const For* v) override {
-    const Var* var = v->var();
-    const Expr* start = v->start();
-    const Expr* stop = v->stop();
-    Stmt* body = v->body();
-    LoopOptions loop_options = v->loop_options();
-
-    Stmt* orig_body = Stmt::clone(body);
-    Stmt* new_body = orig_body->accept_mutator(this);
-    new_body = bind_random_vars(new_body);
-    if (new_body == orig_body) {
-      return const_cast<For*>(v); // NOLINT
-    }
-    if (new_body == nullptr) {
-      return nullptr;
-    }
-    return new For(var, start, stop, new_body, loop_options);
-  }
-
-  // Inline calls containing rand().  Create a new random variable for each
-  // call being inlined, and remember which function is currently being inlined
-  // so we can look up the right variable to replace it with.
-  const Expr* mutate(const FunctionCall* v) override {
-    if (!should_inline(v->tensor()->function())) {
-      return v;
-    }
-    Function* prev_func = current_func_;
-    current_func_ = v->tensor()->function();
-
-    // Remember the calling args; if we find another call with different args,
-    // bail out because this case is too complicated.
-    auto it = call_args_.find(current_func_);
-    if (it == call_args_.end()) {
-      call_args_.emplace(current_func_, std::cref(v->params()));
-    } else {
-      if (v->params() != it->second.get()) {
-        throw std::runtime_error("Complex indexing pattern in rand() tensor");
-      }
-    }
-
-    // Assign a new random variable for this function, if needed.
-    if (!random_vars_.count(current_func_)) {
-      const std::string& name = current_func_->func_var(0)->name_hint();
-      random_vars_.emplace(current_func_, new Var(name, v->dtype()));
-    }
-    const Expr* result = FunctionInliner::mutate(v);
-    current_func_ = prev_func;
-    return result;
-  }
-
-  // Replace rand() intrinsics.
-  const Expr* mutate(const Intrinsics* v) override {
-    if (v->op_type() != kRand) {
-      return v;
-    }
-    if (!current_func_) {
-      return v;
-    }
-    auto it = random_vars_.find(current_func_);
-    if (it == random_vars_.end()) {
-      return v;
-    }
-    return it->second;
-  }
-
- private:
-  // Emit let statements for all encountered random vars, thenclear them.
-  Stmt* bind_random_vars(Stmt* s) {
-    if (random_vars_.empty()) {
-      return s;
-    }
-
-    Block* b = dynamic_cast<Block*>(s);
-    if (!b) {
-      b = new Block({s});
-    }
-
-    for (auto const& p : random_vars_) {
-      Var* v = p.second;
-      b->add_var_binding(v, new Intrinsics(kRand, v->dtype()));
-    }
-    random_vars_.clear();
-    return b;
-  }
-
-  // Track the function currently being inlined.
-  Function* current_func_ = nullptr;
-
-  // Map functions being inlined to the generated random variable.
-  std::unordered_map<Function*, Var*> random_vars_;
-
-  // Remember arguments of calls containing rand, and force all calls to have
-  // the same argument list.  We use pointer equality of Exprs, which is
-  // extremely strict but works for simple cases.
-  using ArgVec = std::reference_wrapper<const std::vector<const Expr*>>;
-  std::unordered_map<Function*, ArgVec> call_args_;
-};
-
-static Stmt* InjectInlines(
-    Stmt* stmt,
-    const std::vector<Function*>& inlined_funcs) {
-  FunctionInliner inliner(inlined_funcs);
-  Stmt* stmt_old = stmt;
-  Stmt* stmt_new = stmt_old->accept_mutator(&inliner);
-  return stmt_new;
-}
-
-static Stmt* InlineRandom(Stmt* stmt, const std::vector<Function*>& funcs) {
-  RandomInliner inliner(funcs);
-  return stmt->accept_mutator(&inliner);
-}
-
 class DepTracker : public IRVisitor {
  public:
   std::vector<Tensor*> findUsedTensors(Tensor* tensor) {
@@ -737,13 +496,188 @@ Stmt* LoopNest::lowerToStmt(Tensor* t) {
   return body;
 }
 
-void LoopNest::computeInline(Stmt* s) {
-  // TODO: check if `s` is a body of a loop
-  inlined_functions_.insert(stmt_to_tensor_.at(s)->function());
-}
+class FunctionInliner : public IRMutator {
+ public:
+  FunctionInliner(Store* producer)
+      : buf_(producer->buf()), producer_(producer) {}
 
-void LoopNest::computeInlineWithRandom(Stmt* s) {
-  inlined_random_functions_.insert(stmt_to_tensor_.at(s)->function());
+  const Expr* pre_mutate(const Expr* e) override {
+    auto hash = hasher_.hash(e);
+    auto it = outline_mapping_.find(hash);
+    if (it != outline_mapping_.end()) {
+      return it->second;
+    }
+    return e;
+  }
+
+ protected:
+  // For the target function, insert the caller/callee pair into the replacement
+  // mapping.
+  const Expr* mutate(const FunctionCall* v) override {
+    Function* func = v->tensor()->function();
+    const Buf* buf = v->tensor()->buf();
+    // TODO: Support multiple-output functions
+    if (func->func_vars().size() != 1) {
+      throw unimplemented_lowering();
+    }
+
+    if (buf == buf_) {
+      // Insert the caller/callee pair into the mapping.
+      for (size_t i = 0; i < buf->ndim(); i++) {
+        auto hash = hasher_.hash(producer_->indices()[i]);
+        const Var* func_callee_arg = dynamic_cast<const Var*>(func->arg(i));
+        const Expr* func_caller_param = v->param(i);
+        auto iter = inline_mapping_.find(func_callee_arg);
+        if (iter != inline_mapping_.end()) {
+          throw std::runtime_error(
+              "Duplicated variables: " + func_callee_arg->name_hint());
+        }
+        inline_mapping_[func_callee_arg] = func_caller_param;
+        outline_mapping_[hash] = func_caller_param;
+      }
+
+      // Call the actual replacement.
+      const Expr* body = producer_->value();
+      const Expr* result = body->accept_mutator(this);
+
+      // Remove the caller/callee relationship.
+      for (size_t i = 0; i < buf->ndim(); i++) {
+        auto hash = hasher_.hash(producer_->indices()[i]);
+        const Var* func_callee_arg = dynamic_cast<const Var*>(func->arg(i));
+        auto iter = inline_mapping_.find(func_callee_arg);
+        if (iter == inline_mapping_.end()) {
+          throw std::runtime_error(
+              "Var already removed: " + func_callee_arg->name_hint());
+        }
+        inline_mapping_.erase(iter);
+        outline_mapping_.erase(hash);
+      }
+      return result;
+    } else {
+      return IRMutator::mutate(v);
+    }
+  }
+
+  // Replace the target variable with the caller expressions.
+  const Expr* mutate(const Var* v) override {
+    auto iter = inline_mapping_.find(v);
+    if (iter == inline_mapping_.end()) {
+      return v;
+    } else {
+      const Expr* expr = iter->second;
+      // Continue to transform the value from the lookup table.
+      return expr->accept_mutator(this);
+    }
+  }
+
+  // Handle random intrinsics which should be cached.
+  const Expr* mutate(const Intrinsics* v) override {
+    if (v->op_type() != kRand) {
+      return IRMutator::mutate(v);
+    }
+
+    const std::string& name = buf_->name_hint();
+    Var* new_var = new Var(name, v->dtype());
+    random_vars_.emplace_back(new_var, v);
+    return new_var;
+  }
+
+  // Remove the buffer write the inlined function.
+  Stmt* mutate(const Store* v) override {
+    if (v == producer_) {
+      producer_ = dynamic_cast<const Store*>(IRMutator::mutate(v));
+      return nullptr;
+    } else {
+      return IRMutator::mutate(v);
+    }
+  }
+
+  // Any Random Instrinsics that were turned into vars must be inserted here.
+  Stmt* mutate(const Block* v) override {
+    Block::VarMapping varMapping;
+    for (const auto& pair : v->varBindings()) {
+      const Var* new_var =
+          static_cast<const Var*>(pair.first->accept_mutator(this));
+      const Expr* new_val = pair.second->accept_mutator(this);
+      varMapping.push_back({new_var, new_val});
+    }
+
+    varMapping.insert(
+        varMapping.end(), random_vars_.begin(), random_vars_.end());
+    random_vars_.clear();
+
+    std::vector<Stmt*> stmts;
+    for (Stmt* stmt : *v) {
+      Stmt* stmt_new = stmt->accept_mutator(this);
+      if (!stmt_new) {
+        continue;
+      }
+      if (stmt == stmt_new) {
+        stmt_new = Stmt::clone(stmt);
+      }
+
+      stmts.push_back(stmt_new);
+    }
+
+    return Block::make(varMapping, stmts);
+  }
+
+ private:
+  const Buf* buf_;
+  const Store* producer_;
+
+  std::unordered_map<const Var*, const Expr*> inline_mapping_;
+  std::unordered_map<SimplifierHashType, const Expr*> outline_mapping_;
+
+  Block::VarMapping random_vars_;
+  HashProvider hasher_;
+};
+
+void LoopNest::computeInline(const Buf* b) {
+  for (auto* t : output_tensors_) {
+    if (b == t->buf()) {
+      throw std::logic_error("Can't inline producers of output Tensors");
+    }
+  }
+
+  // Find producers.
+  Store* relevant_store{nullptr};
+  auto stores = NodeFinder<Store>::find(root_stmt_);
+  for (auto* s : stores) {
+    if (s->buf() == b) {
+      auto reductions = NodeFinder<ReduceOp>::find(s);
+      if (!reductions.empty()) {
+        throw std::logic_error("cannot inline a reduction computation");
+        return;
+      }
+      if (relevant_store != nullptr) {
+        throw std::logic_error("cannot inline Buf with multiple Tensors");
+      }
+      relevant_store = s;
+    }
+  }
+
+  try {
+    FunctionInliner inliner(relevant_store);
+    root_stmt_ = root_stmt_->accept_mutator(&inliner);
+  } catch (std::exception& e) {
+    std::cout << "inlining threw: " << e.what() << "\n";
+  }
+
+  // No longer computing this intermediate tensor, so don't alloc it.
+  for (auto* t : intermediate_tensors_) {
+    if (b == t->buf()) {
+      intermediate_tensors_.erase(t);
+      break;
+    }
+  }
+
+  for (auto it = temp_bufs_.begin(); it != temp_bufs_.end(); ++it) {
+    if (b == *it) {
+      temp_bufs_.erase(it);
+      break;
+    }
+  }
 }
 
 // TODO: Unify with DepTracker
@@ -853,11 +787,6 @@ Stmt* LoopNest::insertAllocFree(Stmt* stmt) {
 
   // TODO: Fix the traversal, currently the order is non-deterministic
   for (Tensor* tensor : intermediate_tensors_) {
-    if (inlined_functions_.count(tensor->function()) ||
-        inlined_random_functions_.count(tensor->function())) {
-      // No need to allocate memory for intermediate tensors.
-      continue;
-    }
     if (output_tensors_.count(tensor) > 0) {
       // No need to allocate memory if the tensors are given as input/output.
       continue;
@@ -885,13 +814,6 @@ Stmt* LoopNest::insertAllocFree(Stmt* stmt) {
 }
 
 void LoopNest::prepareForCodegen() {
-  std::vector<Function*> inlined_functions_vec(
-      inlined_functions_.begin(), inlined_functions_.end());
-  std::vector<Function*> inlined_randoms_vec(
-      inlined_random_functions_.begin(), inlined_random_functions_.end());
-  root_stmt_ = InjectInlines(root_stmt_, inlined_functions_vec);
-  root_stmt_ = InlineRandom(root_stmt_, inlined_randoms_vec);
-
   // Expand reduction ops.
   ReductionExpander reduceExpander;
   root_stmt_ = reduceExpander.expand(root_stmt_);
@@ -1631,7 +1553,6 @@ void LoopNest::rfactor(
   // buffer input with the temporary output buffer and removing other reductions
   // variables.
   SwapReduce sr(reduce_op, first_reduce);
-  auto root_block = dynamic_cast<Block*>(root_stmt());
   auto parent_block = dynamic_cast<Block*>(root_for->get_parent());
   if (!parent_block) {
     std::cerr << "Cannot rfactor a loop whose parent is not a block.\n";

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -28,13 +28,14 @@ class TORCH_API LoopNest {
     return root_stmt_;
   }
 
+  // These Tensor-based loop/stmt accessors are valid only as long as no
+  // transformations have been made.
   std::vector<For*> getLoopStmtsFor(Tensor*) const;
   Stmt* getLoopBodyFor(Tensor*) const;
   bool hasLoopBodyFor(Tensor*) const;
 
   void vectorize(Stmt*);
-  void computeInline(Stmt* s);
-  void computeInlineWithRandom(Stmt* s);
+  void computeInline(const Buf* b);
   void prepareForCodegen();
   void splitWithTail(For* f, int factor, For** outer, For** inner, For** tail);
   void splitWithMask(For* f, int factor, For** outer, For** inner);
@@ -59,8 +60,6 @@ class TORCH_API LoopNest {
   Stmt* lowerToStmt(Tensor* t);
   Stmt* insertAllocFree(Stmt* stmt);
 
-  std::unordered_set<Function*> inlined_functions_;
-  std::unordered_set<Function*> inlined_random_functions_;
   std::unordered_map<Tensor*, Stmt*> tensor_to_stmt_;
   std::unordered_map<Stmt*, Tensor*> stmt_to_tensor_;
   Stmt* root_stmt_;

--- a/torch/csrc/jit/tensorexpr/mem_arena.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_arena.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/jit/tensorexpr/mem_arena.h>
+#include <iostream>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -54,8 +54,15 @@ class StmtNode : public Stmt {
 
 template <class Op>
 Stmt* StmtNode<Op>::accept_mutator(IRMutator* mutator) {
-  StmtNode* this_mutable = const_cast<StmtNode*>(this);
-  return mutator->mutate(static_cast<Op*>(this_mutable));
+  StmtNode* this_pre = static_cast<StmtNode*>(mutator->pre_mutate(this));
+  if (!this_pre) {
+    return nullptr;
+  }
+  if (dynamic_cast<Op*>(this_pre) == nullptr) {
+    return this_pre->accept_mutator(mutator);
+  }
+
+  return mutator->mutate(static_cast<Op*>(this_pre));
 }
 
 // Concrete Stmt classes

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -167,6 +167,15 @@ TORCH_API Tensor* Reduce(
     const Buffer& buffer,
     const std::vector<DimArg>& reduce_args);
 
+// Overload for the common case of all dimensions of a prevously Computed
+// Tensor.
+TORCH_API Tensor* Reduce(
+    const std::string& func_name,
+    const std::vector<DimArg>& dim_args,
+    const Reducer& reducer,
+    Tensor* tensor,
+    const std::vector<DimArg>& reduce_args);
+
 class FunctionCall : public CallNode<FunctionCall> {
  public:
   using BaseClass = CallNode<FunctionCall>;


### PR DESCRIPTION
A rework of `computeInline` which makes it work a bit better, particularly when combined with other transformations. Previously we stored Functions that were inlined and then deferred the actual inlining of the function body until `prepareForCodgen` was called. This has an issue when transformations are applied to the LoopNest: the function body can be different from what appears in the root_stmt and result in inlining that a) fails, b) reverses other transformations or c) a weird unpredictable combination of the two.

This PR changes that behaviour so that the inlining occurs in the root stmt immediately, which means it reflects any previous transformations and any future transformations have a true view of the internal IR. It also has the benefit that inspecting the root statement gives an accurate view of it without needing to call prepareForCodgen.

`computeInline` previously took a `Stmt*` to inline (which implicitly had to be a body stmt) and attempted to map that back to a Tensor/Function pair. Unfortunately this only works if the Function body is present in the current root_stmt (so not after many transformations, and essentially never after simplification). I've changed this to `Buf*` with the abstraction of inlining production of Buf into consumption of Buf.

Did not intend such a large change but kept running into issues on the way, most of which I've addressed: inlining previously had to be done in one shot, had to specify whether there was a Rand inside the producer, and neither worked nor produced an error if called on a reduction. Added some tests of these cases.