### PR TITLE
More separate autograd tests for complex

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4190,13 +4190,14 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
 # test for these ops with 'complex' in variant should only run for complex and
 # the tests for these ops which do not have 'complex' in variant should not run for complex
 # and only run for floating point
-separate_complex_tests = ['log', 'log10', 'log1p', 'log2', 'reciprocal', 'tan', 'tanh', 'asin', 'acos']
+separate_complex_tests = ['log', 'log10', 'log1p', 'log2', 'reciprocal', 'tan', 'tanh', 'asin', 'acos',
+                          'div', '__rdiv__', 'contiguous', 'expand_as']
 
 # white list for complex
 complex_list = ['t', 'view', 'reshape', 'reshape_as', 'view_as', 'zero_', 'clone',
                 'tril', 'triu', 'fill_', 'eq_', 'ne_', 'permute', 'squeeze', 'unsqueeze',
                 'chunk', 'split', 'split_with_sizes', 'resize', 'resize_as', 'sin', 'cos',
-                '__rmul__', '__rdiv__', 'sum', 'transpose', 'round', 'add', 'roll',
+                '__rmul__', 'sum', 'transpose', 'round', 'add', 'roll',
                 '__radd__', 'repeat', 'expand', 'mul', 'unfold', 'addcdiv', 'addcmul', 'atan'] + separate_complex_tests
 
 def add_test(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38721 More separate autograd tests for complex**
* #38673 Add more autograd tests for complex
* #38672 [CUDA] addcmul and addcdiv for complex dtypes
* #38664 [CUDA] torch.roll for complex dtypes

