### PR TITLE
Add skipCUDAIfRocm to test_nn test_softmax_results.

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9724,6 +9724,8 @@ class TestNNDeviceType(NNTestCase):
                 embedding.zero_grad()
                 self.assertEqual(after, pre)
 
+    # test is flaky on ROCm CI
+    @skipCUDAIfRocm
     @dtypesIfCUDA(torch.half, torch.float)
     @dtypes(torch.float)
     def test_softmax_results(self, device, dtype):


### PR DESCRIPTION
CC @ezyang @xw285cornell @sunway513

Commit 59d92e442b88eae51b84adc4e902e36e8f12a4db (#38557) has caused this test to regularly fail on ROCm CI gfx900 hosts.  Skipping test until root cause analysis can complete.