### PR TITLE
add distributed/test_nccl to ROCM_BLACKLIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -101,6 +101,7 @@ ROCM_BLACKLIST = [
     'distributed/rpc/test_dist_autograd_spawn',
     'distributed/rpc/test_dist_optimizer_spawn',
     'distributed/rpc/test_rpc_spawn',
+    'distributed/test_nccl',
     'test_determination',
     'test_multiprocessing',
     'test_jit_simple',


### PR DESCRIPTION
CC @ezyang @xw285cornell @sunway513

Work-around for recent ROCm CI failures due to 9cfc10d52e0d0a8576b0a5a347fa6fa8da86244a (#37294).  Replaces full revert suggested by PR #38689.