### PR TITLE
[TensorExpr] Fix a bug in Rfactor when there are multiple reductions

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -70,6 +70,8 @@ namespace jit {
   _(ReduceSplitMask)                        \
   _(ReduceSplitNoMask)                      \
   _(ReduceOverSplitMask)                    \
+  _(ReduceSplitRfactor)                     \
+  _(ReduceOverSplitRfactor)                 \
   _(SplitReduceAxis)                        \
   _(SplitNonReduceAxis)                     \
   _(TypeTest01)                             \

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -28,6 +28,23 @@ class HasRand : public IRVisitor {
   Stmt* stmt_;
   bool has_rand_ = false;
 };
+
+template <typename Node>
+class NodeFinder : public IRVisitor {
+ public:
+  virtual void visit(const Node* v) override {
+    nodes.push_back((Node*)v);
+    IRVisitor::visit(v);
+  }
+
+  static std::vector<Node*> find(Stmt* s) {
+    NodeFinder<Node> nf;
+    s->accept(&nf);
+    return nf.nodes;
+  }
+
+  std::vector<Node*> nodes;
+};
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
In `LoopNest::rfactor` we assume that there is only a single reduction below the insertion point, and when replacing the reduction we recursively replace all reductions below that point. This is not a safe assumption, as a number of transformations can introduce additional ReduceOps - most directly a `splitWithTail` on the innermost reduce axis.

This PR fixes that bug, and adds some unit tests covering the case.