### PR TITLE
[quant] Support for fused ConvBn1d and ConvBnRelu1d modules (#38452)

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -208,7 +208,9 @@ accuracy
 * ``torch.nn.intrinsic`` — float versions of the modules, can be swapped with
   quantized version 1 to 1:
 
+  * :class:`~torch.nn.intrinsic.ConvBn1d` — Conv1d + BatchNorm1d
   * :class:`~torch.nn.intrinsic.ConvBn2d` — Conv2d + BatchNorm
+  * :class:`~torch.nn.intrinsic.ConvBnReLU1d` — Conv1d + BatchNorm1d + ReLU
   * :class:`~torch.nn.intrinsic.ConvBnReLU2d` — Conv2d + BatchNorm + ReLU
   * :class:`~torch.nn.intrinsic.ConvReLU1d` — Conv1d + ReLU
   * :class:`~torch.nn.intrinsic.ConvReLU2d` — Conv2d + ReLU
@@ -584,9 +586,19 @@ then quantized.
 
 .. automodule:: torch.nn.intrinsic
 
+ConvBn1d
+~~~~~~~~~~~~~~~
+.. autoclass:: ConvBn1d
+    :members:
+
 ConvBn2d
 ~~~~~~~~~~~~~~~
 .. autoclass:: ConvBn2d
+    :members:
+
+ConvBnReLU1d
+~~~~~~~~~~~~~~~
+.. autoclass:: ConvBnReLU1d
     :members:
 
 ConvBnReLU2d

--- a/torch/nn/intrinsic/__init__.py
+++ b/torch/nn/intrinsic/__init__.py
@@ -1,6 +1,8 @@
 
+from .modules import ConvBn1d
 from .modules import ConvBn2d
 from .modules import ConvBn3d
+from .modules import ConvBnReLU1d
 from .modules import ConvBnReLU2d
 from .modules import ConvBnReLU3d
 from .modules import ConvReLU1d
@@ -11,9 +13,11 @@ from .modules import BNReLU2d
 from .modules import BNReLU3d
 
 __all__ = [
+    'ConvBn1d',
     'ConvBn2d',
     'ConvBn3d',
     'ConvBnReLU2d',
+    'ConvBnReLU1d',
     'ConvBnReLU3d',
     'ConvReLU1d',
     'ConvReLU2d',

--- a/torch/nn/intrinsic/modules/__init__.py
+++ b/torch/nn/intrinsic/modules/__init__.py
@@ -1,6 +1,8 @@
 
+from .fused import ConvBn1d
 from .fused import ConvBn2d
 from .fused import ConvBn3d
+from .fused import ConvBnReLU1d
 from .fused import ConvBnReLU2d
 from .fused import ConvBnReLU3d
 from .fused import ConvReLU1d
@@ -12,8 +14,10 @@ from .fused import BNReLU3d
 
 
 __all__ = [
+    'ConvBn1d',
     'ConvBn2d',
     'ConvBn3d',
+    'ConvBnReLU1d',
     'ConvBnReLU2d',
     'ConvBnReLU3d',
     'ConvReLU1d',

--- a/torch/nn/intrinsic/modules/fused.py
+++ b/torch/nn/intrinsic/modules/fused.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
-from torch.nn import Conv1d, Conv2d, Conv3d, ReLU, Linear, BatchNorm2d, BatchNorm3d
+from torch.nn import Conv1d, Conv2d, Conv3d, ReLU, Linear, BatchNorm1d, BatchNorm2d, BatchNorm3d
 
 class ConvReLU1d(torch.nn.Sequential):
     r"""This is a sequential container which calls the Conv 1d and ReLU modules.
@@ -38,6 +38,15 @@ class LinearReLU(torch.nn.Sequential):
                 type(linear), type(relu))
         super(LinearReLU, self).__init__(linear, relu)
 
+class ConvBn1d(torch.nn.Sequential):
+    r"""This is a sequential container which calls the Conv 1d and Batch Norm 1d modules.
+    During quantization this will be replaced with the corresponding fused module."""
+    def __init__(self, conv, bn):
+        assert type(conv) == Conv1d and type(bn) == BatchNorm1d, \
+            'Incorrect types for input modules{}{}'.format(
+                type(conv), type(bn))
+        super(ConvBn1d, self).__init__(conv, bn)
+
 class ConvBn2d(torch.nn.Sequential):
     r"""This is a sequential container which calls the Conv 2d and Batch Norm 2d modules.
     During quantization this will be replaced with the corresponding fused module."""
@@ -46,6 +55,15 @@ class ConvBn2d(torch.nn.Sequential):
             'Incorrect types for input modules{}{}'.format(
                 type(conv), type(bn))
         super(ConvBn2d, self).__init__(conv, bn)
+
+class ConvBnReLU1d(torch.nn.Sequential):
+    r"""This is a sequential container which calls the Conv 1d, Batch Norm 1d, and ReLU modules.
+    During quantization this will be replaced with the corresponding fused module."""
+    def __init__(self, conv, bn, relu):
+        assert type(conv) == Conv1d and type(bn) == BatchNorm1d and \
+            type(relu) == ReLU, 'Incorrect types for input modules{}{}{}' \
+            .format(type(conv), type(bn), type(relu))
+        super(ConvBnReLU1d, self).__init__(conv, bn, relu)
 
 class ConvBnReLU2d(torch.nn.Sequential):
     r"""This is a sequential container which calls the Conv 2d, Batch Norm 2d, and ReLU modules.

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -321,7 +321,9 @@ def convert(module, mapping=None, inplace=False):
                          nni.LinearReLU,
                          nni.BNReLU2d,
                          nni.BNReLU3d,
+                         nni.ConvBn1d,
                          nni.ConvReLU1d,
+                         nni.ConvBnReLU1d,
                          nni.ConvReLU2d,
                          nni.ConvReLU3d)
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -632,6 +632,7 @@ class ModelForFusion(nn.Module):
         self.bn2 = nn.BatchNorm3d(2).to(dtype=torch.float)
         self.relu3 = nn.ReLU(inplace=True).to(dtype=torch.float)
         self.conv3 = nn.Conv1d(3, 3, 2).to(dtype=torch.float)
+        self.bn3 = nn.BatchNorm1d(3).to(dtype=torch.float)
         self.relu4 = nn.ReLU(inplace=True).to(dtype=torch.float)
         # don't quantize sub2
         self.sub2.qconfig = None
@@ -641,6 +642,7 @@ class ModelForFusion(nn.Module):
         x = x.squeeze(2)
         x = self.quant(x)
         x = self.conv3(x)
+        x = self.bn3(x)
         x = self.relu4(x)
         x = x.unsqueeze(2)
         y = x.unsqueeze(2)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38749 [quant] Support for fused ConvBn1d and ConvBnRelu1d modules (#38452)**

Summary:

Test Plan:
python test/test_quantization.py TestFused

Differential Revision: [D21654659](https://our.internmc.facebook.com/intern/diff/D21654659)