### PR TITLE
Update profiler.py

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -577,19 +577,20 @@ def format_time_share(time_us, total_time_us):
         return "NaN"
     return '{:.2f}%'.format(time_us * 100.0 / total_time_us)
 
+KB = 1024
+MB = 1024 * KB
+GB = 1024 * MB
+
 def format_memory(nbytes):
     """Returns a formatted memory size string"""
-    KB = 1024
-    MB = 1024 * KB
-    GB = 1024 * MB
-    if (abs(nbytes) >= GB):
-        return '{:.2f} Gb'.format(nbytes * 1.0 / GB)
-    elif (abs(nbytes) >= MB):
-        return '{:.2f} Mb'.format(nbytes * 1.0 / MB)
-    elif (abs(nbytes) >= KB):
-        return '{:.2f} Kb'.format(nbytes * 1.0 / KB)
-    else:
-        return str(nbytes) + ' b'
+    nbytes = float(abs(nbytes))
+    if (nbytes >= GB):
+        return '{:.2f} Gb'.format(nbytes / GB)
+    if (nbytes >= MB):
+        return '{:.2f} Mb'.format(nbytes / MB)
+    if (nbytes >= KB):
+        return '{:.2f} Kb'.format(nbytes / KB)
+    return str(int(nbytes)) + ' b'
 
 def attr_formatter(name):
     return property(lambda self: format_time(getattr(self, name)))


### PR DESCRIPTION
refactored code overlaping -> (nbytes * 1.0, abs(nbytes)) by changing nbyte's value as float(abs(nbytes)). so I changed str(nbytes) to int(str(nbytes)) for same result and refactored code pattern as correct early-return pattern. replaced if-elif-elif-else pattern to if-if-if-return pattern. finally, to reduce computational cost, placed KB, MB, GB as Global variable which will be initialized only once when the module is imported. 
