### PR TITLE
Added OpenCL DispatchKey, DeviceType, Backend

### DIFF
--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -34,6 +34,7 @@ enum class Backend {
   SparseHIP,
   MSNPU,
   XLA,
+  OpenCL,
   QuantizedCPU,
   QuantizedCUDA,
   Undefined,
@@ -72,6 +73,8 @@ static inline Backend toDense(Backend b) {
       return Backend::MSNPU;
     case Backend::XLA:
       return Backend::XLA;
+    case Backend::OpenCL:
+      return Backend::OpenCL;
     case Backend::SparseCPU:
       return Backend::CPU;
     case Backend::SparseCUDA:
@@ -98,6 +101,8 @@ static inline Backend dispatchKeyToBackend(DispatchKey t) {
     return Backend::MSNPU;
   } else if (t == DispatchKey::XLA || t == DispatchKey::XLAPreAutograd) {
     return Backend::XLA;
+  } else if (t == DispatchKey::OpenCL) {
+    return Backend::OpenCL;
   } else if (t == DispatchKey::SparseCPU) {
     return Backend::SparseCPU;
   } else if (t == DispatchKey::SparseCUDA) {
@@ -129,6 +134,8 @@ static inline DispatchKey backendToDispatchKey(Backend b) {
       return DispatchKey::MSNPU;
     case Backend::XLA:
       return DispatchKey::XLA;
+    case Backend::OpenCL:
+      return DispatchKey::OpenCL;
     case Backend::SparseCPU:
       return DispatchKey::SparseCPU;
     case Backend::SparseCUDA:
@@ -160,6 +167,8 @@ static inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::MSNPU;
     case Backend::XLA:
       return DeviceType::XLA;
+    case Backend::OpenCL:
+      return DeviceType::OPENCL;
     case Backend::SparseCPU:
       return DeviceType::CPU;
     case Backend::SparseCUDA:
@@ -194,6 +203,7 @@ static inline Backend backendToCPU(Backend b) {
       return Backend::SparseCPU;
     case Backend::MSNPU:
     case Backend::XLA:
+    case Backend::OpenCL:
       return Backend::CPU;
     case Backend::MkldnnCPU:
       return Backend::MkldnnCPU;
@@ -215,6 +225,7 @@ static inline Backend backendToCUDA(Backend b) {
     case Backend::HIP:
     case Backend::MSNPU:
     case Backend::XLA:
+    case Backend::OpenCL:
       return Backend::CUDA;
     case Backend::SparseCPU:
     case Backend::SparseCUDA:
@@ -234,6 +245,7 @@ static inline Backend backendToHIP(Backend b) {
     case Backend::HIP:
     case Backend::MSNPU:
     case Backend::XLA:
+    case Backend::OpenCL:
       return Backend::HIP;
     case Backend::SparseCPU:
     case Backend::SparseCUDA:
@@ -259,6 +271,8 @@ static inline const char* toString(Backend b) {
       return "MSNPU";
     case Backend::XLA:
       return "XLA";
+    case Backend::OpenCL:
+      return "OPENCL";
     case Backend::SparseCPU:
       return "SparseCPU";
     case Backend::SparseCUDA:

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -36,6 +36,7 @@ constexpr DeviceType kCUDA = DeviceType::CUDA;
 constexpr DeviceType kHIP = DeviceType::HIP;
 constexpr DeviceType kMSNPU = DeviceType::MSNPU;
 constexpr DeviceType kXLA = DeviceType::XLA;
+constexpr DeviceType kOPENCL = DeviceType::OPENCL;
 
 // define explicit int constant
 constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -55,6 +55,7 @@ enum class DispatchKey : uint8_t {
   MSNPU, // unused externally, but tested at
          // test/cpp_extensions/msnpu_extension.cpp
   XLA, // lives out of tree at https://github.com/pytorch/xla
+  OpenCL, //out-of-tree example at https://gitlab.com/pytorch-complex/vitis_kernels
 
   // These are Caffe2 device types which we grandfathered into
   // DispatchKey.
@@ -62,7 +63,6 @@ enum class DispatchKey : uint8_t {
   // and just simply be undispatchable.
   MKLDNN, // (MKLDNN is treated as another "device" in Caffe2)
   OpenGL,
-  OpenCL,
   IDEEP,
 
   // Here are backends which specify more specialized operators


### PR DESCRIPTION
@ezyang,

This PR adds out-of-tree support for OpenCL devices.
- DispatchKey::OpenCL
- DeviceType::OPENCL
- Backend::OpenCL.

Thanks for your help.