### PR TITLE
Rename `torch._C.Generator` to `torch.Generator`

### DIFF
--- a/docs/source/jit_unsupported.rst
+++ b/docs/source/jit_unsupported.rst
@@ -90,4 +90,4 @@ we suggest using :meth:`torch.jit.trace`.
   * :class:`torch.autograd.Function`
   * :class:`torch.autograd.no_grad`
   * :class:`torch.autograd.enable_grad`
-  * :class:`torch._C.Generator`
+  * :class:`torch.Generator`

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -106,7 +106,7 @@ Generators
     :toctree: generated
     :nosignatures:
 
-    _C.Generator
+    Generator
 
 .. _random-sampling:
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7670,7 +7670,7 @@ Example::
             [100, 200]], dtype=torch.uint8)
 """)
 
-add_docstr(torch._C.Generator,
+add_docstr(torch.Generator,
            r"""
 Generator(device='cpu') -> Generator
 
@@ -7691,7 +7691,7 @@ Example::
 """)
 
 
-add_docstr(torch._C.Generator.set_state,
+add_docstr(torch.Generator.set_state,
            r"""
 Generator.set_state(new_state) -> void
 
@@ -7708,7 +7708,7 @@ Example::
 """)
 
 
-add_docstr(torch._C.Generator.get_state,
+add_docstr(torch.Generator.get_state,
            r"""
 Generator.get_state() -> Tensor
 
@@ -7725,7 +7725,7 @@ Example::
 """)
 
 
-add_docstr(torch._C.Generator.manual_seed,
+add_docstr(torch.Generator.manual_seed,
            r"""
 Generator.manual_seed(seed) -> Generator
 
@@ -7746,7 +7746,7 @@ Example::
 """)
 
 
-add_docstr(torch._C.Generator.initial_seed,
+add_docstr(torch.Generator.initial_seed,
            r"""
 Generator.initial_seed() -> int
 
@@ -7760,7 +7760,7 @@ Example::
 """)
 
 
-add_docstr(torch._C.Generator.seed,
+add_docstr(torch.Generator.seed,
            r"""
 Generator.seed() -> int
 
@@ -7775,7 +7775,7 @@ Example::
 """)
 
 
-add_docstr(torch._C.Generator.device,
+add_docstr(torch.Generator.device,
            r"""
 Generator.device -> device
 


### PR DESCRIPTION
Fix #26528