### PR TITLE
Remove __future__ import from torch.nn.functional

### DIFF
--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -124,7 +124,6 @@ def get_ignored_functions():
         torch.zeros,
         torch.nn.functional.assert_int_or_pair,
         torch.nn.functional.boolean_dispatch,
-        torch.nn.functional.division,
         torch.nn.functional.upsample,
         torch.nn.functional.upsample_bilinear,
         torch.nn.functional.upsample_nearest,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,6 +1,4 @@
 r"""Functional interface"""
-from __future__ import division
-
 import warnings
 import math
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38778 Remove __future__ imports from many files
* **#38777 Remove __future__ import from torch.nn.functional**

Summary:
No longer needed for Python 3.  Also need to remove it from the override
blacklist.

Test Plan:
CI