### PR TITLE
Remove __future__ imports from many files

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import argparse
 import datetime
 import re

--- a/test/backward_compatibility/dump_all_function_schemas.py
+++ b/test/backward_compatibility/dump_all_function_schemas.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import argparse
 import torch
 

--- a/test/distributed/rpc/test_dist_optimizer_spawn.py
+++ b/test/distributed/rpc/test_dist_optimizer_spawn.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from torch.testing._internal.distributed.rpc.dist_optimizer_test import DistOptimizerTest
 from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import TEST_WITH_ASAN, run_tests

--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import copy
 import math
 import os

--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import errno
 import fcntl

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import io
 import os
 import sys

--- a/test/quantization/test_qat_module.py
+++ b/test/quantization/test_qat_module.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import math
 import torch
 import torch.nn as nn

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from builtins import round
 
 import itertools

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 from datetime import datetime
 import modulefinder

--- a/test/simulate_nccl_errors.py
+++ b/test/simulate_nccl_errors.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch.distributed as c10d
 import torch
 import argparse

--- a/test/te_utils.py
+++ b/test/te_utils.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import torch
 
 class ExecutionCounter(object):

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch._C import parse_schema

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
 import torch
 
 # This is how we include tests located in test/jit/...

--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import unittest
 import torch
 import torch.nn as nn

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import unittest
 import torch
 import torch.nn as nn

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import unittest
 

--- a/test/test_multiprocessing_spawn.py
+++ b/test/test_multiprocessing_spawn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import random
 import signal

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import io
 import numpy as np
 import os

--- a/test/test_throughput_benchmark.py
+++ b/test/test_throughput_benchmark.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 import tempfile
 from torch.utils import ThroughputBenchmark

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests
 import tempfile

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import os
 import re

--- a/test/test_xnnpack_integration.py
+++ b/test/test_xnnpack_integration.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import unittest
 
 import torch

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import inspect
 

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import torch
 import types

--- a/torch/backends/xnnpack/__init__.py
+++ b/torch/backends/xnnpack/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import torch
 import types

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 
 

--- a/torch/distributed/autograd/__init__.py
+++ b/torch/distributed/autograd/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 import torch
 

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-
 r"""
 `torch.distributed.launch` is a module that spawns up multiple distributed
 training processes on each of the training nodes.

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numbers
 import sys
 

--- a/torch/distributed/rpc/_testing/__init__.py
+++ b/torch/distributed/rpc/_testing/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 
 

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import collections
 from datetime import timedelta
 import enum

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import errno
 import hashlib
 import os

--- a/torch/multiprocessing/_atfork.py
+++ b/torch/multiprocessing/_atfork.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import sys
 
 __all__ = ['register_after_fork']

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import multiprocessing
 import multiprocessing.connection
 import signal

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import math
 import warnings
 

--- a/torch/nn/intrinsic/modules/fused.py
+++ b/torch/nn/intrinsic/modules/fused.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 from torch.nn import Conv1d, Conv2d, Conv3d, ReLU, Linear, BatchNorm2d, BatchNorm3d
 

--- a/torch/nn/intrinsic/qat/__init__.py
+++ b/torch/nn/intrinsic/qat/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from .modules import LinearReLU
 from .modules import ConvReLU2d
 from .modules import ConvBn2d

--- a/torch/nn/intrinsic/qat/modules/__init__.py
+++ b/torch/nn/intrinsic/qat/modules/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from .linear_relu import LinearReLU
 from .conv_fused import ConvBn2d, ConvBnReLU2d, ConvReLU2d, update_bn_stats, freeze_bn_stats
 

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import math
 import torch
 import torch.nn as nn

--- a/torch/nn/intrinsic/qat/modules/linear_relu.py
+++ b/torch/nn/intrinsic/qat/modules/linear_relu.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.nn.qat as nnqat
 import torch.nn.intrinsic
 import torch.nn.functional as F

--- a/torch/nn/intrinsic/quantized/__init__.py
+++ b/torch/nn/intrinsic/quantized/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from .modules import LinearReLU
 from .modules import ConvReLU1d, ConvReLU2d, ConvReLU3d
 from .modules import BNReLU2d, BNReLU3d

--- a/torch/nn/intrinsic/quantized/modules/bn_relu.py
+++ b/torch/nn/intrinsic/quantized/modules/bn_relu.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 import torch.nn.intrinsic
 import torch.nn.intrinsic.qat

--- a/torch/nn/intrinsic/quantized/modules/conv_relu.py
+++ b/torch/nn/intrinsic/quantized/modules/conv_relu.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 import torch.nn.intrinsic
 import torch.nn.intrinsic.qat

--- a/torch/nn/intrinsic/quantized/modules/linear_relu.py
+++ b/torch/nn/intrinsic/quantized/modules/linear_relu.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.nn.quantized as nnq
 import torch.nn.intrinsic
 import torch

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import torch
 from ._functions import SyncBatchNorm as sync_batch_norm
 from .module import Module

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from typing import List, Optional
 
 from torch import Tensor

--- a/torch/nn/qat/__init__.py
+++ b/torch/nn/qat/__init__.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from .modules import *

--- a/torch/nn/qat/modules/conv.py
+++ b/torch/nn/qat/modules/conv.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.nn as nn
 from torch.nn.intrinsic import ConvReLU2d
 

--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.intrinsic import LinearReLU

--- a/torch/nn/quantized/__init__.py
+++ b/torch/nn/quantized/__init__.py
@@ -1,6 +1,1 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from .modules import *

--- a/torch/nn/quantized/dynamic/__init__.py
+++ b/torch/nn/quantized/dynamic/__init__.py
@@ -1,4 +1,1 @@
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from .modules import *

--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 from ....modules.linear import Linear as NNLinear
 import torch.nn.quantized as nnq

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numbers
 import warnings
 

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -1,9 +1,4 @@
 r""" Functional interface (quantized)."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from typing import List, Optional
 
 import torch

--- a/torch/nn/quantized/modules/activation.py
+++ b/torch/nn/quantized/modules/activation.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import torch
 import torch.nn.quantized.functional
 

--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import torch
 import torch.nn.quantized.functional
 import torch.nn.intrinsic as nni

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -1,11 +1,6 @@
 # coding=utf-8
 r"""Quantized convolution modules."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from typing import Optional, List
 
 import torch

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 
 from torch._jit_internal import Optional  # noqa: F401

--- a/torch/nn/utils/fusion.py
+++ b/torch/nn/utils/fusion.py
@@ -1,6 +1,3 @@
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import copy
 import torch
 

--- a/torch/quantization/__init__.py
+++ b/torch/quantization/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from .quantize import *
 from .observer import *
 from .qconfig import *

--- a/torch/quantization/_quantize_script.py
+++ b/torch/quantization/_quantize_script.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 from .qconfig import QConfig
 from torch.jit._recursive import wrap_cpp_module

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 from torch.nn import Module
 from .observer import MovingAverageMinMaxObserver, HistogramObserver, MovingAveragePerChannelMinMaxObserver, _with_args

--- a/torch/quantization/fuse_modules.py
+++ b/torch/quantization/fuse_modules.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 import copy
 

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import math
 import warnings
 from abc import ABCMeta, abstractmethod

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import namedtuple
 from .observer import *
 from .fake_quantize import *

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import copy
 import itertools
 import warnings

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import sys
 import tempfile

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 r"""Importing this file includes common utility methods and base clases for
 checking quantization api and properties of resulting modules.
 """

--- a/torch/testing/_internal/common_quantized.py
+++ b/torch/testing/_internal/common_quantized.py
@@ -1,7 +1,6 @@
 r"""Importing this file includes common utility methods for checking quantized
 tensors and modules.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import torch
 from contextlib import contextmanager

--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import time
 from functools import partial, wraps
 import re

--- a/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import threading
 import unittest
 

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from .throughput_benchmark import ThroughputBenchmark
 
 import os.path as _osp

--- a/torch/utils/_cpp_extension_versioner.py
+++ b/torch/utils/_cpp_extension_versioner.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import collections
 
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import warnings
 

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -1,6 +1,5 @@
 # This script outputs relevant system environment info
 # Run it with `python collect_env.py`.
-from __future__ import absolute_import, division, print_function, unicode_literals
 import locale
 import re
 import subprocess

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import glob
 import imp

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 
 from torch._C import _from_dlpack as from_dlpack

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import sys
 import time

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 import weakref
 import warnings

--- a/torch/utils/mkldnn.py
+++ b/torch/utils/mkldnn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 
 

--- a/torch/utils/throughput_benchmark.py
+++ b/torch/utils/throughput_benchmark.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch._C
 
 def format_time(time_us=None, time_ms=None, time_s=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38778 Remove __future__ imports from many files**
* #38777 Remove __future__ import from torch.nn.functional

Summary:
Python 2 has reached end-of-life and is no longer supported by PyTorch.
These future imports are already implied in Python 3.

Test Plan:
CI