### PR TITLE
[WIP] Improve docs and autocomplete for `default_generator`

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -109,6 +109,13 @@ Generators
     _C.Generator
     default_generator
 
+.. The following doesn't actually seem to exist.
+   https://github.com/pytorch/pytorch/issues/27780
+   .. autoattribute:: torch.cuda.default_generators
+      :annotation:  If cuda is available, returns a tuple of default CUDA torch.Generator-s.
+                    The number of CUDA torch.Generator-s returned is equal to the number of
+                    GPUs available in the system.
+
 .. _random-sampling:
 
 Random sampling
@@ -122,16 +129,6 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
-
-.. The following doesn't actually seem to exist.
-   https://github.com/pytorch/pytorch/issues/27780
-   .. autoattribute:: torch.cuda.default_generators
-      :annotation:  If cuda is available, returns a tuple of default CUDA torch.Generator-s.
-                    The number of CUDA torch.Generator-s returned is equal to the number of
-                    GPUs available in the system.
-.. autosummary::
-    :toctree: generated
-    :nosignatures:
 
     bernoulli
     multinomial

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -107,6 +107,7 @@ Generators
     :nosignatures:
 
     _C.Generator
+    default_generator
 
 .. _random-sampling:
 
@@ -121,9 +122,6 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
-
-.. autoattribute:: torch.default_generator
-   :annotation:  Returns the default CPU torch.Generator
 
 .. The following doesn't actually seem to exist.
    https://github.com/pytorch/pytorch/issues/27780

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -27,7 +27,7 @@ from typing import Set, Type
 
 __all__ = [
     'typename', 'is_tensor', 'is_storage', 'set_default_tensor_type',
-    'set_rng_state', 'get_rng_state', 'manual_seed', 'initial_seed', 'seed',
+    'set_rng_state', 'get_rng_state', 'manual_seed', 'initial_seed', 'seed', 'default_generator'
     'save', 'load', 'set_printoptions', 'chunk', 'split', 'stack', 'matmul',
     'no_grad', 'enable_grad', 'rand', 'randn',
     'DoubleStorage', 'FloatStorage', 'LongStorage', 'IntStorage',
@@ -270,6 +270,10 @@ def set_default_dtype(d):
 from .random import set_rng_state, get_rng_state, manual_seed, initial_seed, seed
 from .serialization import save, load
 from ._tensor_str import set_printoptions
+
+from torch._C import _default_generator
+default_generator = _default_generator
+"""Returns the default CPU torch.Generator"""
 
 ################################################################################
 # Define Storage and Tensor classes

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -221,8 +221,6 @@ bool THPGenerator_init(PyObject *module)
     return false;
   Py_INCREF(&THPGeneratorType);
   PyModule_AddObject(module, "Generator", (PyObject *)&THPGeneratorType);
-  auto defaultGenerator = at::detail::getDefaultCPUGenerator();
-  PyModule_AddObject(module, "default_generator", (PyObject *)THPGenerator_initDefaultGenerator(defaultGenerator));
   return true;
 }
 

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -221,6 +221,8 @@ bool THPGenerator_init(PyObject *module)
     return false;
   Py_INCREF(&THPGeneratorType);
   PyModule_AddObject(module, "Generator", (PyObject *)&THPGeneratorType);
+  auto defaultGenerator = at::detail::getDefaultCPUGenerator();
+  PyModule_AddObject(module, "Generator", (PyObject *)THPGenerator_initDefaultGenerator(defaultGenerator));
   return true;
 }
 

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -222,7 +222,7 @@ bool THPGenerator_init(PyObject *module)
   Py_INCREF(&THPGeneratorType);
   PyModule_AddObject(module, "Generator", (PyObject *)&THPGeneratorType);
   auto defaultGenerator = at::detail::getDefaultCPUGenerator();
-  PyModule_AddObject(module, "Generator", (PyObject *)THPGenerator_initDefaultGenerator(defaultGenerator));
+  PyModule_AddObject(module, "default_generator", (PyObject *)THPGenerator_initDefaultGenerator(defaultGenerator));
   return true;
 }
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -789,7 +789,7 @@ Call this whenever a new thread is created in order to propagate values from
   auto defaultGenerator = at::detail::getDefaultCPUGenerator();
   THPDefaultCPUGenerator = (THPGenerator*)THPGenerator_initDefaultGenerator(defaultGenerator);
   // This reference is meant to be given away, so no need to incref here.
-  ASSERT_TRUE(set_module_attr("default_generator", (PyObject*)THPDefaultCPUGenerator, /* incref= */ false));
+  ASSERT_TRUE(set_module_attr("_default_generator", (PyObject*)THPDefaultCPUGenerator, /* incref= */ false));
 
 #ifdef USE_NUMPY
   if (_import_array() < 0) return nullptr;

--- a/torch/random.py
+++ b/torch/random.py
@@ -1,7 +1,7 @@
 import contextlib
 import warnings
 
-from torch._C import default_generator
+from torch._C import _default_generator as default_generator
 
 
 def set_rng_state(new_state):


### PR DESCRIPTION
The [docs for torch.default_generator](https://pytorch.org/docs/master/torch.html#torch.torch.default_generator) looks pretty odd in master and resides in between seeding functions and distribution functions instead of the "Generators" section.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6421097/82466172-ae128a80-9a85-11ea-9547-9ea72dc74b08.png) | ![image](https://user-images.githubusercontent.com/6421097/82467967-e74bfa00-9a87-11ea-8168-74549d663796.png) | 


Also, there is no autocomplete for `default_generator`: 
| Before | After |
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/6421097/82466869-8a037900-9a86-11ea-8017-b6a2ff8fb31f.png) | ![image](https://user-images.githubusercontent.com/6421097/82468271-3a25b180-9a88-11ea-9730-2d1a2b5c10c4.png) |


