### PR TITLE
Sphinx parallel build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyTorch
 SOURCEDIR     = source

--- a/docs/cpp/Makefile
+++ b/docs/cpp/Makefile
@@ -1,7 +1,7 @@
 # Minimal makefile for Sphinx documentation
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyTorch
 SOURCEDIR     = source

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -10,6 +10,7 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR=source
 set BUILDDIR=build
 set SPHINXPROJ=PyTorch
+set SPHINXOPTS=-j auto
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
See https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j

> Distribute the build over N processes in parallel, to make building on multiprocessor machines more effective. Note that not all parts and not all builders of Sphinx can be parallelized. If auto argument is given, Sphinx uses the number of CPUs as N.

- Timing results
  - Python doc build on a 40-core machine: 9:34 down to 1:29
  - pytorch_cpp_doc_push: ~1h 10m down to 47m
  - pytorch_python_doc_push: 34m down to 32m

