### PR TITLE
fixes scatter_add backward wrt src.

### DIFF
--- a/aten/src/ATen/native/ScatterGatherShapeChecks.h
+++ b/aten/src/ATen/native/ScatterGatherShapeChecks.h
@@ -10,7 +10,7 @@ namespace {
 
 // Used for `gather`-like methods
 // Test:
-// 1. index.size(d) == self.size(d) for all d != dim
+// 1. index.size(d) <= self.size(d) for all d != dim
 // 2. index.size(d) <= src.size(d) for all d != dim
 static void gather_shape_check(const Tensor& self, int64_t dim,
   const Tensor& index, const Tensor& src
@@ -24,17 +24,18 @@ static void gather_shape_check(const Tensor& self, int64_t dim,
   for (int64_t i = 0; i < self_dims; ++i) {
     if (i != dim) {
       TORCH_CHECK(
-        ensure_nonempty_size(index, i) == ensure_nonempty_size(self, i),
+        ensure_nonempty_size(index, i) <= ensure_nonempty_size(self, i),
         "Size does not match at dimension ", i,
-        " get ", ensure_nonempty_size(self, i),
-        " vs ", ensure_nonempty_size(index, i)
+        " expected index ", index.sizes(),
+        " to be smaller or equal than self ", self.sizes(),
+        " apart from dimension ", dim
       );
 
       TORCH_CHECK(
         ensure_nonempty_size(index, i) <= ensure_nonempty_size(src, i),
         "Size does not match at dimension ", i,
         " expected index ", index.sizes(),
-        " to be smaller than src ", src.sizes(),
+        " to be smaller or equal than src ", src.sizes(),
         " apart from dimension ", dim
       );
     }

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -565,6 +565,17 @@ Tensor scatter_add(const Tensor & self, int64_t dim, const Tensor & index, const
   return self.clone(at::MemoryFormat::Preserve).scatter_add_(dim, index, source);
 }
 
+Tensor scatter_add_src_backward(
+  const Tensor& grad, int64_t dim, const Tensor& index,
+  IntArrayRef src_sizes, bool sparse_grad
+) {
+  auto grad_src = at::zeros(src_sizes, grad.options());
+  gather_stub(grad_src.device().type(), grad_src, grad, dim, index);
+
+  return grad_src;
+}
+
+
 Tensor masked_scatter(const Tensor & self, const Tensor & mask, const Tensor & source) {
   Tensor _mask, _self;
   std::tie(_mask, _self) = expand_outplace(mask, self);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4257,6 +4257,9 @@
 - func: scatter_add.dimname(Tensor self, Dimname dim, Tensor index, Tensor src) -> Tensor
   variants: function, method
 
+- func: scatter_add_src_backward(Tensor self, int dim, Tensor index, int[] src_sizes, *, bool sparse_grad=False) -> Tensor
+  use_c10_dispatcher: full
+
 - func: lt_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -789,7 +789,14 @@
 - name: scatter_add_(Tensor(a!) self, int dim, Tensor index, Tensor src) -> Tensor(a!)
   self: grad
   index: non_differentiable
-  src: grad.gather(dim, index)
+# previously it used to be: grad.gather(dim, index),
+# but the result of gather is of shape index.shape, not src.shape
+  src: scatter_add_src_backward(grad, dim, index, src.sizes())
+
+- name: scatter_add_src_backward(Tensor self, int dim, Tensor index, int[] src_sizes, *, bool sparse_grad=False) -> Tensor
+  self: "sparse_grad ? at::_gather_sparse_backward(self, dim, index, grad) : at::zeros(self.sizes(), grad.options()).scatter_add_(dim, index, grad)"
+  index: non_differentiable
+
 
 - name: select.int(Tensor(a) self, int dim, int index) -> Tensor(a)
   self: select_backward(grad, self.sizes(), dim, index)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -857,6 +857,8 @@ def method_tests():
         ('scatter', (), (0, torch.tensor(0, dtype=torch.int64), 2.5), 'scalar_all_dim0', (), [0]),
         ('scatter_add', (M, S), (0, gather_variable((S, S), 1, M), (S, S)), 'dim0', (), [0]),
         ('scatter_add', (M, S), (1, gather_variable((M, S // 2), 0, S), (M, S // 2)), 'dim1', (), [0]),
+        ('scatter_add', (M, S), (0, gather_variable((S, S), 1, M), (M, S)), 'dim0_src_size_ge_index', (), [0]),
+        ('scatter_add', (M, S), (1, gather_variable((M, S // 2), 0, S), (M, S)), 'dim1_src_size_ge_index', (), [0]),
         ('scatter_add', (), (0, torch.tensor(0, dtype=torch.int64), ()), 'scalar_all_dim0', (), [0]),
         ('masked_select', (M, M), (mask_not_all_zeros((M, M)),)),
         ('masked_select', (M, M), (mask_not_all_zeros((M,)),), 'broadcast_rhs'),


### PR DESCRIPTION
As per title. Fixes [#27614](https://github.com/pytorch/pytorch/issues/27614).
Backward expression is derived [in this comment](https://github.com/pytorch/pytorch/issues/27614#issuecomment-564648819).