### PR TITLE
add skipIfRocm to TestAutograd.test_memory_profiler

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2874,6 +2874,7 @@ class TestAutograd(TestCase):
             with tempfile.NamedTemporaryFile() as trace_file:
                 prof.export_chrome_trace(trace_file.name)
 
+    @skipIfRocm
     def test_memory_profiler(self):
         def run_profiler(tensor_creation_fn, metric):
             # collecting allocs / deallocs


### PR DESCRIPTION
CC @ezyang @xw285cornell @sunway513

Skip new test until triage of ROCm CI can be completed.

Test added by a94fb71b126001630d3d1e350347c20977f14ec0.