### PR TITLE
[ONNX] Support large attribute and subgraph for large model

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -197,6 +197,27 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_model_test_with_external_data(model, x, rtol=1e-3, atol=1e-5,
                                                ort_optim_on=False)
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because external data format was released with Opset 9.
+    def test_attribute_with_external_data(self):
+        class LargeModel(torch.nn.Module):
+            def forward(self, x):
+                return x + torch.ones(2, 1024)
+
+        x = torch.randn(2, 1)
+        self.run_model_test_with_external_data(LargeModel(), x)
+
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because external data format was released with Opset 9.
+    @unittest.skip("Enable this once large model with subgraph is supported in ORT")
+    def test_subgraph_with_external_data(self):
+        class LargeModel(torch.nn.Module):
+            def forward(self, x):
+                for i in range(x.size(0)):
+                    x = x + torch.ones(2, 1024)
+                return x
+
+        x = torch.randn(2, 1)
+        self.run_model_test_with_external_data(torch.jit.script(LargeModel()), x)
+
     # Export Torchvision models
 
     def test_alexnet(self):

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -585,15 +585,11 @@ void EncoderBase::AddAttribute(
       attr->set_type(onnx::AttributeProto_AttributeType_TENSOR);
       auto t = attr->mutable_t();
       if (use_external_data_format && !t->has_name()) {
-        t->set_name(createAttributeTensorName(
-            node_proto, t, name, num_external_data_));
+        t->set_name(
+            createAttributeTensorName(node_proto, t, name, num_external_data_));
       }
       EncodeTensor(
-          t,
-          node->t(name),
-          {},
-          use_external_data_format,
-          onnx_file_path);
+          t, node->t(name), {}, use_external_data_format, onnx_file_path);
     } break;
     case AttributeKind::ts:
       attr->set_type(onnx::AttributeProto_AttributeType_TENSORS);

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -532,12 +532,17 @@ void EncoderBase::AddAttribute(
     const jit::Symbol name,
     const bool use_external_data_format,
     const std::string& onnx_file_path) {
-  auto createAttributeTensorName = [](const onnx::NodeProto* node_proto, onnx::TensorProto* tensor_proto, const jit::Symbol attr_name, size_t& num_external_data) -> std::string {
+  auto createAttributeTensorName =
+      [](const onnx::NodeProto* node_proto,
+         onnx::TensorProto* tensor_proto,
+         const jit::Symbol attr_name,
+         size_t& num_external_data) -> std::string {
     if (tensor_proto->has_name()) {
       return tensor_proto->name();
     }
     if (!node_proto->has_name()) {
-      auto name = node_proto->op_type() + "_" + attr_name.toDisplayString() + "_" + std::to_string(num_external_data);
+      auto name = node_proto->op_type() + "_" + attr_name.toDisplayString() +
+          "_" + std::to_string(num_external_data);
       num_external_data++;
       return name;
     } else {
@@ -581,7 +586,8 @@ void EncoderBase::AddAttribute(
       auto t = attr->mutable_t();
       if (use_external_data_format) {
         if (!t->has_name()) {
-          t->set_name(createAttributeTensorName(node_proto, t, name, num_external_data_));
+          t->set_name(createAttributeTensorName(
+              node_proto, t, name, num_external_data_));
         }
       }
       EncodeTensor(
@@ -597,7 +603,8 @@ void EncoderBase::AddAttribute(
         auto t = attr->add_tensors();
         if (use_external_data_format) {
           if (!t->has_name()) {
-            t->set_name(createAttributeTensorName(node_proto, t, name, num_external_data_));
+            t->set_name(createAttributeTensorName(
+                node_proto, t, name, num_external_data_));
           }
         }
         EncodeTensor(t, v, t->name(), use_external_data_format, onnx_file_path);

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -450,7 +450,8 @@ void EncoderBase::EncodeBlock(
       num_op_nodes_++;
     }
     for (auto attr_name : node->attributeNames()) {
-      AddAttribute(p_n, node, attr_name, use_external_data_format, onnx_file_path);
+      AddAttribute(
+          p_n, node, attr_name, use_external_data_format, onnx_file_path);
     }
     if (is_raw_export && node->blocks().size() > 0) {
       auto blocks = p_n->add_attribute();
@@ -468,7 +469,15 @@ void EncoderBase::EncodeBlock(
       body->set_name("body");
       body->set_type(onnx::AttributeProto_AttributeType_GRAPH);
       auto g = body->mutable_g();
-      EncodeBlock(g, node->blocks()[0], {}, {}, true, true, use_external_data_format, onnx_file_path);
+      EncodeBlock(
+          g,
+          node->blocks()[0],
+          {},
+          {},
+          true,
+          true,
+          use_external_data_format,
+          onnx_file_path);
     }
     if (node->kind() == ::c10::onnx::If) {
       AT_ASSERT(node->blocks().size() == 2);
@@ -477,13 +486,29 @@ void EncoderBase::EncodeBlock(
       true_branch->set_name("then_branch");
       true_branch->set_type(onnx::AttributeProto_AttributeType_GRAPH);
       auto true_g = true_branch->mutable_g();
-      EncodeBlock(true_g, node->blocks()[0], {}, {}, true, true, use_external_data_format, onnx_file_path);
+      EncodeBlock(
+          true_g,
+          node->blocks()[0],
+          {},
+          {},
+          true,
+          true,
+          use_external_data_format,
+          onnx_file_path);
 
       auto false_branch = p_n->add_attribute();
       false_branch->set_name("else_branch");
       false_branch->set_type(onnx::AttributeProto_AttributeType_GRAPH);
       auto false_g = false_branch->mutable_g();
-      EncodeBlock(false_g, node->blocks()[1], {}, {}, true, true, use_external_data_format, onnx_file_path);
+      EncodeBlock(
+          false_g,
+          node->blocks()[1],
+          {},
+          {},
+          true,
+          true,
+          use_external_data_format,
+          onnx_file_path);
     }
   }
   AT_ASSERT(block->inputs().size() >= initializers.size());
@@ -542,7 +567,12 @@ void EncoderBase::AddAttribute(
       TORCH_INTERNAL_ASSERT(node_proto->has_name());
       auto tensor_name = node_proto->name() + "_" + name.toDisplayString();
       t->set_name(tensor_name);
-      EncodeTensor(t, node->t(name), tensor_name, use_external_data_format, onnx_file_path);
+      EncodeTensor(
+          t,
+          node->t(name),
+          tensor_name,
+          use_external_data_format,
+          onnx_file_path);
     } break;
     case AttributeKind::ts:
       attr->set_type(onnx::AttributeProto_AttributeType_TENSORS);
@@ -554,13 +584,22 @@ void EncoderBase::AddAttribute(
     case AttributeKind::g: {
       attr->set_type(onnx::AttributeProto_AttributeType_GRAPH);
       auto g = attr->mutable_g();
-      EncodeGraph(g, node->g(name), {}, {}, true, true, use_external_data_format, onnx_file_path);
+      EncodeGraph(
+          g,
+          node->g(name),
+          {},
+          {},
+          true,
+          true,
+          use_external_data_format,
+          onnx_file_path);
     } break;
     case AttributeKind::gs:
       attr->set_type(onnx::AttributeProto_AttributeType_GRAPHS);
       for (auto& v : node->gs(name)) {
         auto g = attr->add_graphs();
-        EncodeGraph(g, v, {}, {}, true, true, use_external_data_format, onnx_file_path);
+        EncodeGraph(
+            g, v, {}, {}, true, true, use_external_data_format, onnx_file_path);
       }
       break;
     default:


### PR DESCRIPTION
Previously large tensor data in attributes and subgraphs are not stored externally. ONNX won't be able to serialize the model for cases where the total size sums up to >= 2GB. This PR enables that.