### PR TITLE
[TensorExpr] eliminate zero length Allocations in IRSimplifier

### DIFF
--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -2140,5 +2140,79 @@ void testSimplifyFlattenBlock() {
   }
 }
 
+void testSimplifyEliminateZeroLengthAlloc() {
+  KernelScope kernel_scope;
+
+  {
+    // Simple positive case.
+    VarHandle x("x", kInt);
+
+    Allocate* alloc = Allocate::make(x, kInt, {0});
+    Free* free_ = Free::make(x);
+
+    Block* block1 = new Block({alloc, free_});
+    ASSERT_EQ(block1->nstmts(), 2);
+
+    Stmt* simplified = IRSimplifier::simplify(block1);
+    IS_NODE_WITH_NAME(Block, simplified, block2);
+    ASSERT_EQ(block2->nstmts(), 0);
+  }
+
+  {
+    // Simple negative case.
+    VarHandle x("x", kInt);
+
+    Allocate* alloc = Allocate::make(x, kInt, {2});
+    Free* free_ = Free::make(x);
+
+    Block* block1 = new Block({alloc, free_});
+    ASSERT_EQ(block1->nstmts(), 2);
+
+    Stmt* simplified = IRSimplifier::simplify(block1);
+    IS_NODE_WITH_NAME(Block, simplified, block2);
+    ASSERT_EQ(block2->nstmts(), 2);
+  }
+
+  {
+    // Finds right Alloc/Free.
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+
+    Allocate* alloc1 = Allocate::make(x, kInt, {0});
+    Allocate* alloc2 = Allocate::make(y, kInt, {2});
+    Free* free2_ = Free::make(y);
+    Free* free1_ = Free::make(x);
+
+    Block* block1 = new Block({alloc1, alloc2, free2_, free1_});
+    ASSERT_EQ(block1->nstmts(), 4);
+
+    Stmt* simplified = IRSimplifier::simplify(block1);
+    IS_NODE_WITH_NAME(Block, simplified, block2);
+    ASSERT_EQ(block2->nstmts(), 2);
+    IS_NODE_WITH_NAME(Allocate, block2->stmts().front(), simplified_alloc);
+    IS_VAR_WITH_NAME(simplified_alloc->buffer_var(), "y");
+    IS_NODE_WITH_NAME(Free, block2->stmts().back(), simplified_free);
+    ASSERT_EQ(simplified_alloc->buffer_var(), simplified_free->buffer_var());
+  }
+
+  {
+    // Dynamic shape.
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    VarHandle z("z", kInt);
+
+    Allocate* alloc1 = Allocate::make(x, kInt, {0});
+    Allocate* alloc2 = Allocate::make(y, kInt, {z});
+    Free* free2_ = Free::make(y);
+    Free* free1_ = Free::make(x);
+
+    Block* block1 = new Block({alloc1, alloc2, free2_, free1_});
+    ASSERT_EQ(block1->nstmts(), 4);
+    Stmt* simplified = IRSimplifier::simplify(block1);
+    IS_NODE_WITH_NAME(Block, simplified, block2);
+    ASSERT_EQ(block2->nstmts(), 2);
+  }
+}
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -161,6 +161,7 @@ namespace jit {
   _(SimplifyForCleansUp)                    \
   _(SimplifyEliminateEmptyFor)              \
   _(SimplifyFlattenBlock)                   \
+  _(SimplifyEliminateZeroLengthAlloc)       \
   _(StmtClone)                              \
   _(BoundsInference_1)                      \
   _(BoundsInference_2)                      \

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1025,7 +1025,7 @@ const Expr* PolynomialTransformer::mutate(const IfThenElse* v) {
   return new IfThenElse(condition_new, true_value_new, false_value_new);
 }
 
-Stmt* PolynomialTransformer::mutate(const Cond* v) {
+Stmt* IRSimplifierBase::mutate(const Cond* v) {
   const Expr* cond_old = v->condition();
   Stmt* true_old = v->true_stmt();
   Stmt* false_old = v->false_stmt();
@@ -1063,7 +1063,7 @@ Stmt* PolynomialTransformer::mutate(const Cond* v) {
   return new Cond(cond_new, true_new, false_new);
 }
 
-Stmt* PolynomialTransformer::mutate(const For* v) {
+Stmt* IRSimplifierBase::mutate(const For* v) {
   const Expr* var = v->var();
   const Expr* start = v->start();
   const Expr* stop = v->stop();
@@ -1108,7 +1108,7 @@ Stmt* PolynomialTransformer::mutate(const For* v) {
   return new For(var_new, start_new, stop_new, body_new, loop_options);
 }
 
-Stmt* PolynomialTransformer::mutate(const Block* v) {
+Stmt* IRSimplifierBase::mutate(const Block* v) {
   auto vars = v->varBindings();
   std::vector<Stmt*> stmts;
   for (Stmt* stmt : *v) {
@@ -1474,6 +1474,53 @@ const Expr* TermExpander::mutate(const RoundOff* v) {
       new Div(v->lhs(), v->rhs()),
       v->rhs());
   return term->accept_mutator(this);
+}
+
+Stmt* TermExpander::mutate(const Allocate* v) {
+  const Var* buffer_var_old = v->buffer_var();
+  const Var* buffer_var_new =
+      dynamic_cast<const Var*>(buffer_var_old->accept_mutator(this));
+  bool any_change = buffer_var_new == buffer_var_old;
+
+  const Expr* flattened = getImmediateByType(kInt, 1);
+  std::vector<const Expr*> dims_old = v->dims();
+  std::vector<const Expr*> dims_new(dims_old.size());
+  for (size_t i = 0; i < dims_old.size(); i++) {
+    dims_new[i] = dims_old[i]->accept_mutator(this);
+    any_change |= (dims_new[i] == dims_old[i]);
+    flattened = new Mul(flattened, dims_new[i]);
+  }
+
+  // Safe to do this as there can't be an Allocate inside an Allocate:
+  flattened = IRSimplifier::simplify(flattened);
+
+  if (flattened->isConstant() && immediateEquals(flattened, 0)) {
+    eliminated_allocations_.insert(buffer_var_new);
+    return nullptr;
+  }
+
+  if (!any_change) {
+    return (Stmt*)v;
+  }
+
+  return new Allocate(buffer_var_new, v->dtype(), dims_new);
+}
+
+Stmt* TermExpander::mutate(const Free* v) {
+  const Expr* buffer_var_old = v->buffer_var();
+  const Var* buffer_var_new =
+      dynamic_cast<const Var*>(buffer_var_old->accept_mutator(this));
+
+  if (eliminated_allocations_.count(buffer_var_new)) {
+    eliminated_allocations_.erase(buffer_var_new);
+    return nullptr;
+  }
+
+  if (buffer_var_new == buffer_var_old) {
+    return (Stmt*)v;
+  }
+
+  return new Free(buffer_var_new);
 }
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -288,9 +288,28 @@ class RoundOff : public BinaryOpNode<RoundOff> {
       : BinaryOpNode(lhs, rhs, IRNodeType::kRoundOff) {}
 };
 
-// Simplify the IR by combining arithmetic expressions over common terms.
-class TORCH_API PolynomialTransformer : public IRMutator {
+// Stmt simplification should occur in both modes.
+class TORCH_API IRSimplifierBase : public IRMutator {
  public:
+  virtual ~IRSimplifierBase() {}
+  Stmt* mutate(const Block* v) override;
+
+  Stmt* mutate(const Cond* v) override;
+
+  Stmt* mutate(const For* v) override;
+
+  HashProvider& hasher() {
+    return hasher_;
+  }
+
+ protected:
+  HashProvider hasher_;
+};
+
+// Simplify the IR by combining arithmetic expressions over common terms.
+class TORCH_API PolynomialTransformer : public IRSimplifierBase {
+ public:
+  using IRSimplifierBase::mutate;
   // Inserts term into the provided map, in the case of a hash collision
   // combines the term with the existing and updates the map.
   void addOrUpdateTerm(
@@ -370,12 +389,6 @@ class TORCH_API PolynomialTransformer : public IRMutator {
 
   const Expr* mutate(const IfThenElse* v) override;
 
-  Stmt* mutate(const Cond* v) override;
-
-  Stmt* mutate(const For* v) override;
-
-  Stmt* mutate(const Block* v) override;
-
   template <typename Op>
   static const Expr* mutateBinaryOp(
       const BinaryOpNode<Op>* v,
@@ -400,25 +413,24 @@ class TORCH_API PolynomialTransformer : public IRMutator {
     return evaluateOp(node);
   }
 
-  HashProvider& hasher() {
-    return hasher_;
-  }
-
   static const Expr* simplify(const Expr* e);
   static ExprHandle simplify(const ExprHandle& e);
   static Stmt* simplify(Stmt* e);
 
- private:
-  HashProvider hasher_;
 }; // namespace tensorexpr
 
 // Expands Terms and Polynomial expressions into primitive operations.
 // Does some simple factorization and reordering.
-class TORCH_API TermExpander : public IRMutator {
+class TORCH_API TermExpander : public IRSimplifierBase {
   PolynomialTransformer* simplifier_;
+  std::set<const Var*> eliminated_allocations_;
 
  public:
+  using IRSimplifierBase::mutate;
   TermExpander(PolynomialTransformer* simplifier) : simplifier_(simplifier) {}
+  bool check_safe() {
+    return eliminated_allocations_.empty();
+  }
 
   // Expand Terms out to a series of Muls.
   const Expr* mutate(const Term* v) override;
@@ -431,6 +443,11 @@ class TORCH_API TermExpander : public IRMutator {
 
   // Expand RoundOff to it's component: Mul(Div(lhs, rhs), rhs).
   const Expr* mutate(const RoundOff* v) override;
+
+  // Eliminate zero length allocations.
+  Stmt* mutate(const Allocate* v) override;
+
+  Stmt* mutate(const Free* v) override;
 };
 
 class TORCH_API IRSimplifier {
@@ -442,6 +459,9 @@ class TORCH_API IRSimplifier {
     // There may be terms left in the IR, expand them.
     TermExpander expander(&simplifier);
     e = e->accept_mutator(&expander);
+    if (!expander.check_safe()) {
+      throw malformed_input("eliminated null Allocation without free");
+    }
 
     return e;
   }
@@ -457,6 +477,9 @@ class TORCH_API IRSimplifier {
     // There may be terms left in the IR, expand them.
     TermExpander expander(&simplifier);
     s = s->accept_mutator(&expander);
+    if (!expander.check_safe()) {
+      throw malformed_input("eliminated null Allocation without free");
+    }
 
     return s;
   }


### PR DESCRIPTION
If the size of a temporary buffer is reduced to zero via binding of a dynamic variable we still run the alloc, even though it is a no op. It's easy to strip these out during simplification, so the expr:
```
{
  Allocate(x, int, {0});
  // Stuff...
  Free(x);
}
```
becomes
```
{
  // Stuff...
}
```

I am assuming here that if the allocation size is zero then any usage of the buffer is also eliminated since theres no safe way to refer to a zero size buffer.