### PR TITLE
Remove device guard codegen on TypeDefault.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -63,7 +63,6 @@ ${return_type} ${type_wrapper_name}(${formals});
 
 NATIVE_DISPATCH_DEFINITION_DEFAULT = CodeTemplate("""\
 ${return_type} ${type_wrapper_name}(${formals}) {
-    ${device_guard_declaration}
     ${return_call} at::native::${native_type_method_dispatch}(${actuals});
 }
 """)

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -4,6 +4,7 @@
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
+#include <c10/cuda/CUDAGuard.h>
 
 namespace at { namespace native {
 
@@ -76,6 +77,7 @@ namespace at { namespace native {
 
 template <typename func_t>
 void gpu_kernel(TensorIterator& iter, const func_t& f) {
+  c10::cuda::CUDAGuard g(iter.device());
   ASSERT_HOST_DEVICE_LAMBDA(func_t);
 
   for (int arg = 0; arg < iter.ntensors(); arg++) {
@@ -98,6 +100,7 @@ void gpu_kernel(TensorIterator& iter, const func_t& f) {
 
 template <typename func_t>
 void gpu_kernel_with_scalars(TensorIterator& iter, const func_t& f) {
+  c10::cuda::CUDAGuard g(iter.device());
   ASSERT_HOST_DEVICE_LAMBDA(func_t);
   TORCH_INTERNAL_ASSERT(iter.ntensors() == 3);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38808 Remove device guard codegen on TypeDefault.**
* #38806 Don't generate DeviceGuard for CPU wrapping code.
* #38739 Remove supports_named_tensor from codegen entirely.
* #38725 Enforce that named_tensor_meta_ is non-null only if there is a non-wildcard name

The intent is for downstream crossing into libtorch_cuda to
be responsible for setting the guard properly.  This probably
needs updates to TensorIterator too.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>