### PR TITLE
Fix broken windows build due per channel quantization stack land.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -240,7 +240,6 @@ Tensor qnnpack_avg_pool2d(
 } // qnnp_avgpool_helper
 } // namespace native
 } // namespace at
-#endif
 
 namespace {
 std::vector<float> generate_requantization_scales(
@@ -311,5 +310,6 @@ std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scales_tensor(
   }
   return {weight_zp, weight_scales};
 }
-
 } // namespace
+
+#endif


### PR DESCRIPTION
Summary: Move newly introduced functions in qnnpack_utils.h inside the ifdef.

Test Plan: CI.

Differential Revision: D21672942

