### PR TITLE
Replace import cpp_benchmark with `torch.utils.cpp_benchmark`

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -12,9 +12,8 @@ import copy
 import ast
 
 # needs to be imported after torch
-import cpp_extension # noqa
+import torch.utils.cpp_extension as cpp_extension # noqa
 
-import cpp_extension # noqa
 import benchmark_utils
 from collections import namedtuple
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import time
 import json
 import torch
-import cpp_extension # noqa
+import torch.utils.cpp_extension as cpp_extension # noqa
 
 
 """PyTorch performance microbenchmarks.


### PR DESCRIPTION
Otherwise, I don't understand how those could have been invoked

Also, what is the benefit of importing the same module twice?

