### PR TITLE
Log incorrect device in ProcessGroupGloo

### DIFF
--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -732,7 +732,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::broadcast(
 #endif
       break;
     default:
-      invalidArgument("unsupported device type");
+      invalidArgument(c10::str("unsupported device type ", device.type()));
   }
 
   std::shared_ptr<AsyncBroadcastWork> work;
@@ -1255,7 +1255,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce(
 #endif
       break;
     default:
-      invalidArgument("unsupported device type");
+      invalidArgument(c10::str("unsupported device type ", device.type()));
   }
 
   const auto& layout = inputs[0].layout();
@@ -1331,7 +1331,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce_coalesced(
     case c10::kCPU:
       break;
     default:
-      invalidArgument("unsupported device type");
+      invalidArgument(c10::str("unsupported device type ", device.type()));
   }
 
   switch (layout) {
@@ -1493,7 +1493,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::reduce(
 #endif
       break;
     default:
-      invalidArgument("unsupported device type");
+      invalidArgument(c10::str("unsupported device type ", device.type()));
   }
 
   std::shared_ptr<AsyncReduceWork> work;
@@ -1700,7 +1700,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allgather(
 #endif
       break;
     default:
-      invalidArgument("unsupported device type");
+      invalidArgument(c10::str("unsupported device type ", device.type()));
   }
 
   std::shared_ptr<AsyncAllgatherWork> work;
@@ -2032,7 +2032,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::gather(
 #endif
       break;
     default:
-      invalidArgument("unsupported device type");
+      invalidArgument(c10::str("unsupported device type ", device.type()));
   }
 
   std::shared_ptr<AsyncGatherWork> work;
@@ -2218,7 +2218,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
 #endif
       break;
     default:
-      invalidArgument("unsupported device type");
+      invalidArgument(c10::str("unsupported device type ", device.type()));
   }
 
   std::shared_ptr<AsyncScatterWork> work;

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -32,6 +32,7 @@
 #include <gloo/config.h>
 #include <gloo/rendezvous/context.h>
 #include <gloo/rendezvous/prefix_store.h>
+#include <c10/util/StringUtil.h>
 
 #define GENERATE_ALL_TYPES(type, func, args...)        \
   switch (type) {                                      \

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -29,10 +29,10 @@
 #include <c10/cuda/CUDAStream.h>
 #endif
 
+#include <c10/util/StringUtil.h>
 #include <gloo/config.h>
 #include <gloo/rendezvous/context.h>
 #include <gloo/rendezvous/prefix_store.h>
-#include <c10/util/StringUtil.h>
 
 #define GENERATE_ALL_TYPES(type, func, args...)        \
   switch (type) {                                      \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38844 Log incorrect device in ProcessGroupGloo**

Enhances error message in ProcessGroupGloo to log the unsupported
device. Been seeing a few issues with this and this will provide more debug
information.

Differential Revision: [D21676881](https://our.internmc.facebook.com/intern/diff/D21676881/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D21676881/)!