### PR TITLE
Updates torchvision version

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -140,7 +140,7 @@ pip install --user pytest-sugar
 # torchvision tests #
 #####################
 if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
-  pip install -q --user git+https://github.com/pytorch/vision.git@v0.5.0
+  pip install -q --user git+https://github.com/pytorch/vision.git@ba63fbdb595f41901f074883abc0084145877cf5
   pip install -q --user ninja
   # JIT C++ extensions require ninja, so put it into PATH.
   export PATH="/var/lib/jenkins/.local/bin:$PATH"


### PR DESCRIPTION
In PyTorch 1.6 integer division using torch.div will throw a runtime error. When PyTorch Master adopts this behavior some of our ONNX tests would break if we continued to import torchvision v0.5, since v0.5 uses torch.div to perform integer division. @fmassa and I recently updated Torchvision to use torch.floor_divide for integer division (at least on paths covered by the PyTorch OSS CI tests), and this PR updates our torchvision test version to include those changes. This will prevent the PyTorch OSS CI from breaking when PyTorch Master adopts the 1.6 integer division behavior. 
