### PR TITLE
add eq.str op to lite interpreter

### DIFF
--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -483,7 +483,7 @@ int listSetItem(Stack& stack);
 
 #define DEFINE_STR_CMP_OP(aten_op, op)     \
   Operator(                                \
-      #aten_op "(str a, str b) -> bool",   \
+      #aten_op ".str(str a, str b) -> bool",   \
       [](Stack& stack) {                   \
         auto b = pop(stack).toStringRef(); \
         auto a = pop(stack).toStringRef(); \


### PR DESCRIPTION
Summary:
This error message indicates aten::eq expects different types

```
RUNNING 379 OP 76, aten::eq
terminate called after throwing an instance of 'c10::Error'
  what():  isInt() INTERNAL ASSERT FAILED at "buck-out/gen/68e83026/xplat/caffe2/aten_header#header-mode-symlink-tree-with-header-map,headers/ATen/core/ivalue.h":331, please report a bug to PyTorch.
```

It turns out that there are two aten::eq in lite interpreter (https://www.internalfb.com/intern/diffusion/FBS/browse/master/xplat/caffe2/torch/csrc/jit/runtime/register_prim_ops.cpp?lines=417)
aten::eq(int, int)
aten::eq(str, str)

This diff add overload name for str and it fixed the problem.

Test Plan: local test

Reviewed By: pengtxiafb

Differential Revision: D21681838

