### PR TITLE
[pytorch][PR] Remove datatype from Storage and StorageImpl

### DIFF
--- a/aten/src/ATen/core/boxing/impl/test_helpers.h
+++ b/aten/src/ATen/core/boxing/impl/test_helpers.h
@@ -20,12 +20,11 @@ inline at::Tensor dummyTensor(c10::DispatchKeySet ks) {
   int64_t size_bytes = nelements * dtype.itemsize();
   auto storage_impl = c10::make_intrusive<c10::StorageImpl>(
       c10::StorageImpl::use_byte_size_t(),
-      dtype,
       size_bytes,
       allocator->allocate(size_bytes),
       allocator,
       /*resizable=*/true);
-  return at::detail::make_tensor<c10::TensorImpl>(storage_impl, ks);
+  return at::detail::make_tensor<c10::TensorImpl>(storage_impl, ks, dtype);
 }
 
 inline at::Tensor dummyTensor(c10::DispatchKey dispatch_key) {

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -311,17 +311,17 @@ CHECKED_USE_NULLABLE = CodeTemplate('${arg_name}_ ? ${usage} : NULL')
 
 ALLOC_NOARGS_WRAP = {
     'THTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                 '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(${ScalarName}), 0, allocator(), true),'
-                 'DispatchKey::${Backend}).release()',
+                 '(c10::Storage(c10::Storage::use_byte_size_t(), 0, allocator(), true),'
+                 'DispatchKey::${Backend}, scalarTypeToTypeMeta(${ScalarName})).release()',
     'THByteTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                     '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(ScalarType::Byte), 0, allocator(), true),'
-                     'DispatchKey::${Backend}).release()',
+                     '(c10::Storage(c10::Storage::use_byte_size_t(), 0, allocator(), true),'
+                     'DispatchKey::${Backend}, scalarTypeToTypeMeta(ScalarType::Byte)).release()',
     'THBoolTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                     '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(ScalarType::Bool), 0, allocator(), true),'
-                     'DispatchKey::${Backend}).release()',
+                     '(c10::Storage(c10::Storage::use_byte_size_t(), 0, allocator(), true),'
+                     'DispatchKey::${Backend}, scalarTypeToTypeMeta(ScalarType::Bool)).release()',
     'THIndexTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
-                     '(c10::Storage(c10::Storage::use_byte_size_t(), scalarTypeToTypeMeta(ScalarType::Long), 0, allocator(), true),'
-                     'DispatchKey::${Backend}).release()',
+                     '(c10::Storage(c10::Storage::use_byte_size_t(), 0, allocator(), true),'
+                     'DispatchKey::${Backend}, scalarTypeToTypeMeta(ScalarType::Long)).release()',
 }
 
 # Replacements for constants when calling into TH

--- a/aten/src/ATen/native/Memory.cpp
+++ b/aten/src/ATen/native/Memory.cpp
@@ -23,7 +23,6 @@ Tensor pin_memory(const Tensor& self) {
   auto* allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();
   auto storage = Storage(
       Storage::use_byte_size_t(),
-      self.dtype(),
       detail::computeStorageNbytes(
           self.sizes(), self.strides(), self.dtype().itemsize()),
       allocator,

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -122,13 +122,13 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options_, c10::optional<
   int64_t size_bytes = nelements * dtype.itemsize();
   auto storage_impl = c10::make_intrusive<StorageImpl>(
       c10::StorageImpl::use_byte_size_t(),
-      dtype,
       size_bytes,
       allocator->allocate(size_bytes),
       allocator,
       /*resizeable=*/true);
 
-  auto tensor = detail::make_tensor<TensorImpl>(std::move(storage_impl), at::DispatchKey::CPU);
+  auto tensor = detail::make_tensor<TensorImpl>(
+      std::move(storage_impl), at::DispatchKey::CPU, dtype);
   // Default TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);
@@ -984,13 +984,13 @@ Tensor from_file(std::string filename, c10::optional<bool> shared, c10::optional
     size_t size_bytes = my_size * dtype.itemsize();
     auto storage_impl = c10::make_intrusive<at::StorageImpl>(
         c10::StorageImpl::use_byte_size_t(),
-        dtype,
         size_bytes,
         THMapAllocator::makeDataPtr(
             filename.c_str(), flags, size_bytes, nullptr),
         /*allocator=*/nullptr,
         /*resizable=*/false);
-    auto tensor = detail::make_tensor<at::TensorImpl>(storage_impl, at::DispatchKey::CPU);
+    auto tensor = detail::make_tensor<at::TensorImpl>(
+        storage_impl, at::DispatchKey::CPU, dtype);
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous({my_size});
     return tensor;
 }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -66,13 +66,15 @@ Tensor& set_tensor_(Tensor& result, const Tensor& source) {
 // way of getting the allocator to use for a device (c10::GetAllocator is not
 // the same as at::cuda::getCUDADeviceAllocator().
 Tensor& set_cpu_(Tensor& result) {
+  caffe2::TypeMeta dtype = result.dtype();
   Storage storage(
       Storage::use_byte_size_t(),
-      result.dtype(),
       0,
       c10::GetAllocator(kCPU),
       true);
-  return result.set_(storage, 0, {0}, {});
+  result.set_(storage, 0, {0}, {});
+  TORCH_INTERNAL_ASSERT(dtype == result.dtype());
+  return result;
 }
 
 std::vector<Tensor> broadcast_tensors(TensorList tensors) {
@@ -617,14 +619,15 @@ Tensor sum_to_size(const Tensor& self, IntArrayRef size) {
 // TODO: Make this an aten function and replace as_strided_qtensorimpl once that is done.
 Tensor make_qtensor(const Tensor& self, IntArrayRef size, IntArrayRef stride, QuantizerPtr quantizer) {
   auto result = detail::make_tensor<QTensorImpl>(
-      Storage(self.storage()), self.key_set(), quantizer);
+      Storage(self.storage()), self.key_set(), self.dtype(), quantizer);
   setStrided(result, size, stride, self.storage_offset());
   return result;
 }
 
 Tensor as_strided_tensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_) {
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
-  auto result = detail::make_tensor<TensorImpl>(Storage(self.storage()), self.key_set());
+  auto result = detail::make_tensor<TensorImpl>(
+      Storage(self.storage()), self.key_set(), self.dtype());
   setStrided(result, size, stride, storage_offset);
   return result;
 }
@@ -636,7 +639,7 @@ Tensor as_strided_qtensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef 
       quantizer->qscheme() == QScheme::PER_TENSOR_AFFINE,
       "Setting strides is possible only on uniformly quantized tensor");
   auto result = detail::make_tensor<QTensorImpl>(
-      Storage(self.storage()), self.key_set(), quantizer);
+      Storage(self.storage()), self.key_set(), self.dtype(), quantizer);
   setStrided(result, size, stride, storage_offset);
   return result;
 }
@@ -772,13 +775,14 @@ Tensor alias_with_sizes_and_strides(
     auto impl = c10::make_intrusive<QTensorImpl>(
         Storage(self.storage()),
         self.key_set(),
+        self.dtype(),
         get_qtensorimpl(self)->quantizer());
     impl->set_storage_offset(self.storage_offset());
     impl->set_sizes_and_strides(sizes, strides);
     self_ = Tensor(std::move(impl));
   } else {
     auto impl = c10::make_intrusive<TensorImpl>(
-        Storage(self.storage()), self.key_set());
+        Storage(self.storage()), self.key_set(), self.dtype());
     impl->set_storage_offset(self.storage_offset());
     impl->set_sizes_and_strides(sizes, strides);
     self_ = Tensor(std::move(impl));

--- a/aten/src/ATen/native/cuda/MiscUtils.h
+++ b/aten/src/ATen/native/cuda/MiscUtils.h
@@ -81,7 +81,6 @@ static inline Storage pin_memory(int64_t size) {
   int64_t adjusted_size = size * sizeof(T);
   return Storage(
       Storage::use_byte_size_t(),
-      caffe2::TypeMeta::Make<uint8_t>(),
       adjusted_size,
       allocator,
       /*resizable=*/false);

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -55,13 +55,13 @@ Tensor empty_cuda(IntArrayRef size, const TensorOptions& options, c10::optional<
   int64_t size_bytes = nelements * dtype.itemsize();
   auto storage_impl = c10::make_intrusive<StorageImpl>(
       c10::StorageImpl::use_byte_size_t(),
-      dtype,
       size_bytes,
       allocator->allocate(size_bytes),
       allocator,
       /*resizeable=*/true);
 
-  auto tensor = detail::make_tensor<TensorImpl>(storage_impl, DispatchKey::CUDA);
+  auto tensor =
+      detail::make_tensor<TensorImpl>(storage_impl, DispatchKey::CUDA, dtype);
   // Default TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);

--- a/aten/src/ATen/native/cuda/TensorShapeCUDA.cpp
+++ b/aten/src/ATen/native/cuda/TensorShapeCUDA.cpp
@@ -11,13 +11,15 @@ namespace native {
 // way of getting the allocator to use for a device (c10::GetAllocator is not
 // the same as at::cuda::getCUDADeviceAllocator().
 Tensor& set_cuda_(Tensor& result) {
+  caffe2::TypeMeta dtype = result.dtype();
   Storage storage(
       Storage::use_byte_size_t(),
-      result.dtype(),
       0,
       at::cuda::getCUDADeviceAllocator(),
       true);
-  return result.set_(storage, 0, {0}, {});
+  result.set_(storage, 0, {0}, {});
+  TORCH_INTERNAL_ASSERT(dtype == result.dtype());
+  return result;
 }
 
 // unify with cuda implementation?  This is not done to avoid a dispatch in resize_impl_cpu_

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -122,7 +122,7 @@ Tensor& set_storage_quantized_(
     IntArrayRef sizes,
     IntArrayRef strides) {
   auto* self_ = self.unsafeGetTensorImpl();
-  self_->set_storage(storage);
+  self_->set_storage_keep_dtype(storage);
   self_->set_storage_offset(storage_offset);
   self_->set_sizes_and_strides(sizes, strides);
   return self;

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -122,7 +122,6 @@ Tensor MakeStridedQTensorCPU(
   int64_t size_bytes = nelements * dtype.itemsize();
   auto storage = c10::make_intrusive<StorageImpl>(
       StorageImpl::use_byte_size_t(),
-      dtype,
       size_bytes,
       allocator->allocate(size_bytes),
       allocator,
@@ -130,6 +129,7 @@ Tensor MakeStridedQTensorCPU(
   auto tensor = detail::make_tensor<QTensorImpl>(
       storage,
       at::DispatchKeySet(at::DispatchKey::QuantizedCPU),
+      dtype,
       quantizer);
   get_qtensorimpl(tensor)->set_sizes_and_strides(sizes, strides);
   return tensor;

--- a/aten/src/ATen/native/xnnpack/Factory.cpp
+++ b/aten/src/ATen/native/xnnpack/Factory.cpp
@@ -21,13 +21,13 @@ Tensor empty_with_tail_padding(
   Tensor tensor(c10::make_intrusive<c10::TensorImpl>(
       c10::Storage{
           c10::Storage::use_byte_size_t(),
-          dtype,
           size_bytes,
           allocator_ptr->allocate(size_bytes),
           allocator_ptr,
           /*resizable=*/true,
       },
-      DispatchKeySet{DispatchKey::CPU}));
+      DispatchKeySet{DispatchKey::CPU},
+      dtype));
 
   return namedinference::propagate_names_if_nonempty(
       tensor.resize_(size, memory_format),

--- a/aten/src/ATen/quantized/QTensorImpl.cpp
+++ b/aten/src/ATen/quantized/QTensorImpl.cpp
@@ -5,8 +5,9 @@ namespace at {
 QTensorImpl::QTensorImpl(
     Storage&& storage,
     DispatchKeySet key_set,
+    const caffe2::TypeMeta& data_type,
     QuantizerPtr quantizer)
-    : TensorImpl(std::move(storage), key_set),
+    : TensorImpl(std::move(storage), key_set, data_type),
       quantizer_(quantizer) {}
 
 } // namespace at

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -18,6 +18,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
   QTensorImpl(
       Storage&& storage,
       DispatchKeySet key_set,
+      const caffe2::TypeMeta& data_type,
       QuantizerPtr quantizer);
 
   // TODO: Expose in PyTorch Frontend
@@ -39,7 +40,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<QTensorImpl>(
-        Storage(storage()), key_set(), quantizer_);
+        Storage(storage()), key_set(), data_type_, quantizer_);
     copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -84,13 +84,12 @@ inline Tensor new_qtensor(
   int64_t size_bytes = nelements * dtype.itemsize();
   auto storage = c10::make_intrusive<StorageImpl>(
       StorageImpl::use_byte_size_t(),
-      dtype,
       size_bytes,
       allocator->allocate(size_bytes),
       allocator,
       /*resizable=*/true);
   auto tensor = detail::make_tensor<QTensorImpl>(
-      storage, at::DispatchKeySet(tensorDispatchKey), quantizer);
+      storage, at::DispatchKeySet(tensorDispatchKey), dtype, quantizer);
   get_qtensorimpl(tensor)->set_sizes_contiguous(sizes);
   get_qtensorimpl(tensor)->empty_tensor_restride(memory_format);
   return tensor;

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -39,7 +39,6 @@ inline Tensor from_blob(
   }
   auto storage = Storage(
       Storage::use_byte_size_t(),
-      options.dtype(),
       detail::computeStorageNbytes(sizes, strides, options.dtype().itemsize()),
       InefficientStdFunctionContext::makeDataPtr(data, deleter, device),
       /*allocator=*/nullptr,
@@ -70,7 +69,6 @@ inline Tensor from_blob(
   }
   auto storage = Storage(
       Storage::use_byte_size_t(),
-      options.dtype(),
       detail::computeStorageNbytes(sizes, strides, options.dtype().itemsize()),
       DataPtr(data, nullptr, [](void*) {}, device),
       /*allocator=*/nullptr,

--- a/aten/src/ATen/test/extension_backend_test.cpp
+++ b/aten/src/ATen/test/extension_backend_test.cpp
@@ -15,12 +15,12 @@ Tensor empty_override(IntArrayRef size, const TensorOptions & options, c10::opti
   auto tensor_impl = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
       Storage(
           Storage::use_byte_size_t(),
-          caffe2::TypeMeta::Make<float>(),
           0,
           at::DataPtr(nullptr, Device(DeviceType::MSNPU, 1)),
           nullptr,
           false),
-      DispatchKey::MSNPU);
+      DispatchKey::MSNPU,
+      caffe2::TypeMeta::Make<float>());
   return Tensor(std::move(tensor_impl));
 }
 

--- a/aten/src/TH/THStorageFunctions.cpp
+++ b/aten/src/TH/THStorageFunctions.cpp
@@ -39,10 +39,9 @@
 #include <TH/generic/THStorageCopy.cpp>
 #include <TH/THGenerateBFloat16Type.h>
 
-THStorage* THStorage_new(caffe2::TypeMeta data_type) {
+THStorage* THStorage_new() {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
-                           data_type,
                            0,
                            getTHDefaultAllocator(),
                            true)

--- a/aten/src/TH/THStorageFunctions.hpp
+++ b/aten/src/TH/THStorageFunctions.hpp
@@ -31,7 +31,7 @@
 //    If it is not, you must report that the storage is dead.
 //
 
-TH_CPP_API THStorage* THStorage_new(caffe2::TypeMeta data_type);
+TH_CPP_API THStorage* THStorage_new();
 
 TH_API void THStorage_retain(THStorage *storage);
 TH_API void THStorage_resizeBytes(THStorage* storage, ptrdiff_t size_bytes);

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -60,8 +60,6 @@ void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage) {
   // Caffe2 might have tensors whose storages are null, but we
   // don't allow it in PyTorch.
   AT_ASSERT(storage);
-  // Caffe2 also has uninitialized dtype states, which we disallow here
-  AT_ASSERT(tensor->storage().dtype() == storage->dtype());
 
   // We used to allow this, but this breaks device caching.
   // Let's put an actual error message for this one.
@@ -69,5 +67,6 @@ void THTensor_stealAndSetStoragePtr(THTensor* tensor, THStorage* storage) {
             "Attempted to set the storage of a tensor on device \"", tensor->storage().device(),
              "\" to a storage on different device \"", storage->device(),
             "\".  This is no longer allowed; the devices must match.");
-  tensor->set_storage(at::Storage(c10::intrusive_ptr<THStorage>::reclaim(storage)));
+  tensor->set_storage_keep_dtype(
+      at::Storage(c10::intrusive_ptr<THStorage>::reclaim(storage)));
 }

--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -20,11 +20,7 @@ size_t THStorage_(elementSize)()
 
 THStorage* THStorage_(new)(void)
 {
-#ifdef THQUANTIZED
-  return THStorage_new(caffe2::TypeMeta::Make<quantized_t>());
-#else
-  return THStorage_new(caffe2::TypeMeta::Make<scalar_t>());
-#endif
+  return THStorage_new();
 }
 
 THStorage* THStorage_(newWithSize)(ptrdiff_t size)
@@ -32,10 +28,8 @@ THStorage* THStorage_(newWithSize)(ptrdiff_t size)
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
 #ifdef THQUANTIZED
-                           caffe2::TypeMeta::Make<quantized_t>(),
                            size * sizeof(quantized_t),
 #else
-                           caffe2::TypeMeta::Make<scalar_t>(),
                            size * sizeof(scalar_t),
 #endif
                            getTHDefaultAllocator(),
@@ -50,10 +44,8 @@ THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
 #ifdef THQUANTIZED
-                           caffe2::TypeMeta::Make<quantized_t>(),
                            size * sizeof(quantized_t),
 #else
-                           caffe2::TypeMeta::Make<scalar_t>(),
                            size * sizeof(scalar_t),
 #endif
                            allocator,
@@ -65,15 +57,13 @@ THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
 
 THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t size, int flags)
 {
-  auto type_meta = caffe2::TypeMeta::Make<scalar_t>();
   size_t actual_size = -1;
   THStorage* storage =
       c10::make_intrusive<at::StorageImpl>(
           c10::StorageImpl::use_byte_size_t(),
-          type_meta,
-          size * type_meta.itemsize(),
+          size * sizeof(scalar_t),
           THMapAllocator::makeDataPtr(
-              filename, flags, size * type_meta.itemsize(), &actual_size),
+              filename, flags, size * sizeof(scalar_t), &actual_size),
           /* allocator */ nullptr,
           false)
           .release();
@@ -108,10 +98,8 @@ THStorage* THStorage_(newWithDataAndAllocator)(at::DataPtr&& data, ptrdiff_t siz
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
 #ifdef THQUANTIZED
-                           caffe2::TypeMeta::Make<quantized_t>(),
                            size * sizeof(quantized_t),
 #else
-                           caffe2::TypeMeta::Make<scalar_t>(),
                            size * sizeof(scalar_t),
 #endif
                            std::move(data),

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -58,9 +58,15 @@ scalar_t *THTensor_(data)(const THTensor *self) {
 THTensor *THTensor_(new)(void)
 {
   return c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(THStorage_(new)()),
-    at::DispatchKey::CPU
-  ).release();
+             c10::intrusive_ptr<at::StorageImpl>::reclaim(THStorage_(new)()),
+             at::DispatchKey::CPU,
+#ifdef THQUANTIZED
+             caffe2::TypeMeta::Make<quantized_t>()
+#else
+             caffe2::TypeMeta::Make<scalar_t>()
+#endif
+                 )
+      .release();
 }
 
 /* Pointer-copy init */
@@ -73,10 +79,16 @@ THTensor *THTensor_(newWithStorage1d)(THStorage *storage, ptrdiff_t storageOffse
                                int64_t size0, int64_t stride0)
 {
   c10::raw::intrusive_ptr::incref(storage);
-  THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(storage),
-    at::DispatchKey::CPU
-  ).release();
+  THTensor* self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
+                       c10::intrusive_ptr<at::StorageImpl>::reclaim(storage),
+                       at::DispatchKey::CPU,
+#ifdef THQUANTIZED
+                       caffe2::TypeMeta::Make<quantized_t>()
+#else
+                       caffe2::TypeMeta::Make<scalar_t>()
+#endif
+                           )
+                       .release();
   THTensor_(setStorage)(self, storage, storageOffset,  {size0}, {stride0});
 
   return self;
@@ -85,10 +97,12 @@ THTensor *THTensor_(newWithStorage1d)(THStorage *storage, ptrdiff_t storageOffse
 THTensor *THTensor_(newWithSize1d)(int64_t size0)
 {
   THStorage *new_storage = THStorage_(new)();
-  THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(new_storage),
-    at::DispatchKey::CPU
-  ).release();
+  THTensor* self =
+      c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
+          c10::intrusive_ptr<at::StorageImpl>::reclaim(new_storage),
+          at::DispatchKey::CPU,
+          caffe2::TypeMeta::Make<scalar_t>())
+          .release();
   THTensor_(setStorage)(self, new_storage, 0, {size0}, {});
 
   return self;

--- a/aten/src/THC/THCStorage.cpp
+++ b/aten/src/THC/THCStorage.cpp
@@ -59,12 +59,9 @@ int THCStorage_getDevice(THCState* state, const THCStorage* storage) {
   return storage->device().index();
 }
 
-THCStorage* THCStorage_new(
-    THCState* state,
-    caffe2::TypeMeta data_type) {
+THCStorage* THCStorage_new(THCState* state) {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
-                           data_type,
                            0,
                            c10::cuda::CUDACachingAllocator::get(),
                            true)

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -13,7 +13,7 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
-THC_API THCStorage* THCStorage_new(THCState* state, caffe2::TypeMeta);
+THC_API THCStorage* THCStorage_new(THCState* state);
 
 THC_API void THCStorage_retain(THCState *state, THCStorage *storage);
 
@@ -24,6 +24,7 @@ THC_API void THCStorage_resizeBytes(
 THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 
 THC_API THCStorage* THCStorage_newWithDataAndAllocator(
-  THCState *state, at::ScalarType scalar_type,
-  at::DataPtr&& data, ptrdiff_t size,
-  at::Allocator* allocator);
+    THCState* state,
+    at::DataPtr&& data,
+    ptrdiff_t size,
+    at::Allocator* allocator);

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -61,7 +61,6 @@ THCStorage* THCStorage_(new)(THCState *state)
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
-                           caffe2::TypeMeta::Make<scalar_t>(),
                            0,
                            c10::cuda::CUDACachingAllocator::get(),
                            true)
@@ -73,7 +72,6 @@ THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size)
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
-                           caffe2::TypeMeta::Make<scalar_t>(),
                            size * sizeof(scalar_t),
                            c10::cuda::CUDACachingAllocator::get(),
                            true)
@@ -86,7 +84,6 @@ THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
 {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
-                           caffe2::TypeMeta::Make<scalar_t>(),
                            size * sizeof(scalar_t),
                            allocator,
                            true)
@@ -114,7 +111,6 @@ THCStorage* THCStorage_(newWithDataAndAllocator)(
     at::Allocator* allocator) {
   THStorage* storage = c10::make_intrusive<at::StorageImpl>(
                            c10::StorageImpl::use_byte_size_t(),
-                           caffe2::TypeMeta::Make<scalar_t>(),
                            size * sizeof(scalar_t),
                            std::move(data),
                            allocator,

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -65,9 +65,11 @@ scalar_t *THCTensor_(data)(THCState *state, const THCTensor *self)
 THCTensor *THCTensor_(new)(THCState *state)
 {
   return c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(THCStorage_(new)(state)),
-    at::DispatchKey::CUDA
-  ).release();
+             c10::intrusive_ptr<at::StorageImpl>::reclaim(
+                 THCStorage_(new)(state)),
+             at::DispatchKey::CUDA,
+             caffe2::TypeMeta::Make<scalar_t>())
+      .release();
 }
 
 /* Pointer-copy init */
@@ -80,10 +82,11 @@ THCTensor *THCTensor_(newWithStorage1d)(THCState *state, THCStorage *storage, pt
                                int64_t size0, int64_t stride0)
 {
   c10::raw::intrusive_ptr::incref(storage);
-  THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(storage),
-    at::DispatchKey::CUDA
-  ).release();
+  THTensor* self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
+                       c10::intrusive_ptr<at::StorageImpl>::reclaim(storage),
+                       at::DispatchKey::CUDA,
+                       caffe2::TypeMeta::Make<scalar_t>())
+                       .release();
   THCTensor_(setStorage)(state, self, storage, storageOffset, {size0}, {stride0});
 
   return self;
@@ -97,10 +100,12 @@ THCTensor *THCTensor_(newWithSize)(THCState *state, at::IntArrayRef size, at::In
 THCTensor *THCTensor_(newWithSize1d)(THCState *state, int64_t size0)
 {
   THCStorage *new_storage = THCStorage_(new)(state);
-  THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    c10::intrusive_ptr<at::StorageImpl>::reclaim(new_storage),
-    at::DispatchKey::CUDA
-  ).release();
+  THCTensor* self =
+      c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
+          c10::intrusive_ptr<at::StorageImpl>::reclaim(new_storage),
+          at::DispatchKey::CUDA,
+          caffe2::TypeMeta::Make<scalar_t>())
+          .release();
   THCTensor_(setStorage)(state, self, new_storage, 0, {size0}, {});
 
   return self;

--- a/aten/src/THC/generic/THCTensorCopy.cu
+++ b/aten/src/THC/generic/THCTensorCopy.cu
@@ -12,7 +12,8 @@ void THCTensor_(copy)(THCState* state, THCTensor* dst, THCTensor* src) {
 template <>
 THCTensor *THCTensor_newClone<scalar_t>(THCState *state, THCTensor *self) {
   THCTensor* tensor =
-      THCTensor_new(state, THTensor_getStoragePtr(self)->dtype());
+      // THCTensor_new(state, THTensor_getStoragePtr(self)->dtype());
+      THCTensor_new(state, self->dtype());
   THCTensor_resizeAs(state, tensor, self);
   at::Tensor tensor_wrap = THTensor_wrap(tensor);
   at::Tensor self_wrap = THTensor_wrap(self);

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -44,8 +44,11 @@ const at::Tensor& TensorImpl::grad() const {
   return autograd_meta_->grad();
 }
 
-TensorImpl::TensorImpl(Storage&& storage, DispatchKeySet key_set)
-    : TensorImpl(std::move(storage), key_set, storage.dtype(), storage.device()) {}
+TensorImpl::TensorImpl(
+    Storage&& storage,
+    DispatchKeySet key_set,
+    const caffe2::TypeMeta& data_type)
+    : TensorImpl(std::move(storage), key_set, data_type, storage.device()) {}
 
 TensorImpl::TensorImpl(DispatchKeySet key_set, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt)
     : TensorImpl({}, key_set, data_type, std::move(device_opt)) {}

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -319,7 +319,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Construct a 1-dim 0-size tensor backed by the given storage.
    */
-  TensorImpl(Storage&& storage, DispatchKeySet);
+  TensorImpl(
+      Storage&& storage,
+      DispatchKeySet,
+      const caffe2::TypeMeta& data_type);
 
   /**
    * Construct a 1-dim 0 size tensor that doesn't have a storage.
@@ -328,8 +331,14 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   // Legacy constructors so I don't have to go update call sites.
   // TODO: When Variable is added, delete these constructors
-  TensorImpl(Storage&& storage, DispatchKey dispatch_key)
-    : TensorImpl(std::move(storage), DispatchKeySet(dispatch_key)) {}
+  TensorImpl(
+      Storage&& storage,
+      DispatchKey dispatch_key,
+      const caffe2::TypeMeta& data_type)
+      : TensorImpl(
+            std::move(storage),
+            DispatchKeySet(dispatch_key),
+            data_type) {}
   TensorImpl(DispatchKey dispatch_key, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt)
     : TensorImpl(DispatchKeySet(dispatch_key), data_type, device_opt) {}
 
@@ -591,7 +600,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         "Caffe2 uses a lazy allocation, so you will need to call "
         "mutable_data() or raw_mutable_data() to actually allocate memory.");
     TORCH_CHECK(
-        storage_.IsType<T>(),
+        data_type_.Match<T>(),
         "Tensor type mismatch, caller expects elements to be ",
         caffe2::TypeMeta::TypeName<T>(),
         ", while tensor contains ",
@@ -901,7 +910,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   virtual c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const {
-    auto impl = c10::make_intrusive<TensorImpl>(Storage(storage()), key_set_);
+    auto impl = c10::make_intrusive<TensorImpl>(
+        Storage(storage()), key_set_, data_type_);
     copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),
@@ -1150,7 +1160,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   inline void FreeMemory() {
     // We'll detach from the old Storage and create a new one
-    storage_ = Storage::create_legacy(storage_.device(), data_type_);
+    storage_ = Storage::create_legacy(storage_.device());
     storage_offset_ = 0;
   }
 
@@ -1210,7 +1220,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     }
     if (storage_.unique()) {
       storage_.UniqueStorageShareExternalPointer(
-          std::move(data_ptr), data_type, size_bytes);
+          std::move(data_ptr), size_bytes);
       data_type_ = data_type;
       device_opt_ = storage_.device();
       storage_offset_ = 0;
@@ -1218,7 +1228,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       // Create a new Storage
       storage_ = Storage(
           Storage::use_byte_size_t(),
-          data_type,
           size_bytes,
           std::move(data_ptr),
           /*allocator=*/nullptr,
@@ -1247,13 +1256,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     } else {
       bool had_special_dtor = data_type_.placementDelete() != nullptr;
       storage_offset_ = 0;
-      if (storage_.unique()) {
-        storage_.set_dtype(meta);
-      } else {
-        if (data_type_ != meta) {
-          storage_ = Storage::create_legacy(storage_.device(), meta);
-        }
-      }
       data_type_ = meta;
       // NB: device is not changed
 
@@ -1304,7 +1306,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   template <typename T>
   inline T* mutable_data() {
-    if (storage_initialized() && storage_.IsType<T>()) {
+    if (storage_initialized() && data_type_.Match<T>()) {
       return static_cast<T*>(storage_.data()) + storage_offset_;
     }
     // Check it here statically - otherwise TypeMeta would throw the runtime
@@ -1333,11 +1335,17 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return data_type_ != caffe2::TypeMeta();
   }
 
-  void set_storage(at::Storage storage) {
+  void set_storage_keep_dtype(at::Storage storage) {
     TORCH_CHECK(allow_tensor_metadata_change(), "set_storage ", err_msg_tensor_metadata_change_not_allowed);
     storage_ = std::move(storage);
-    data_type_ = storage_.dtype();
     device_opt_ = storage_.device();
+  }
+
+  void set_storage_and_dtype(
+      at::Storage storage,
+      const caffe2::TypeMeta& data_type) {
+    set_storage_keep_dtype(storage);
+    data_type_ = data_type;
   }
 
   /**

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -246,8 +246,8 @@ void Tensor::CopyFrom(const Tensor& src, bool async) {
   if (impl_->dtype() != src.impl_->dtype()) {
     // NB: copy preserves device_type
     // This storage will get initialized by the mutable_data call below.
-    impl_->set_storage(
-        at::Storage::create_legacy(impl_->device_type(), src.impl_->dtype()));
+    impl_->set_storage_and_dtype(
+        at::Storage::create_legacy(impl_->device_type()), src.impl_->dtype());
   }
   impl_->Resize(src.impl_->sizes());
 

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -69,9 +69,9 @@ class CAFFE2_API Tensor final {
    */
   explicit Tensor(at::Device device)
       : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
-            Storage::create_legacy(device, TypeMeta()),
-            c10::computeDispatchKey(at::device(device).layout(at::kStrided)))) {
-  }
+            Storage::create_legacy(device),
+            c10::computeDispatchKey(at::device(device).layout(at::kStrided)),
+            TypeMeta())) {}
 
   /**
    * @brief Creates a tensor of the given dimension.
@@ -153,7 +153,7 @@ class CAFFE2_API Tensor final {
         storage_initialized(),
         "Cloning a tensor that has no content and has size > 0");
     // set_storage already sets data_type_ of TensorImpl
-    x.impl_->set_storage(storage());
+    x.impl_->set_storage_and_dtype(storage(), impl_->dtype());
     x.impl_->set_storage_offset(impl_->storage_offset());
     x.impl_->set_sizes_and_strides(sizes(), strides());
     return x;
@@ -463,7 +463,7 @@ class CAFFE2_API Tensor final {
    */
   template <typename T>
   inline bool IsType() const {
-    return impl_->storage().IsType<T>();
+    return impl_->dtype().Match<T>();
   }
 
   /**

--- a/caffe2/onnx/offline_tensor.h
+++ b/caffe2/onnx/offline_tensor.h
@@ -15,8 +15,8 @@ struct OfflineTensor {
       const std::vector<int>& sizes,
       at::Device device,
       caffe2::TypeMeta data_type) {
-    shape_tensor.unsafeGetTensorImpl()->set_storage(
-        at::Storage::create_legacy(device, data_type));
+    shape_tensor.unsafeGetTensorImpl()->set_storage_and_dtype(
+        at::Storage::create_legacy(device), data_type);
     shape_tensor.Resize(sizes);
     CHECK(!shape_tensor.storage_initialized());
     CHECK(shape_tensor.dtype_initialized());

--- a/test/cpp_extensions/msnpu_extension.cpp
+++ b/test/cpp_extensions/msnpu_extension.cpp
@@ -9,12 +9,12 @@ Tensor get_tensor(caffe2::TypeMeta dtype, IntArrayRef size) {
   auto tensor_impl = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
       Storage(
           Storage::use_byte_size_t(),
-          dtype,
           0,
           at::DataPtr(nullptr, Device(DeviceType::MSNPU, 0)),
           nullptr,
           false),
-      DispatchKey::MSNPU);
+      DispatchKey::MSNPU,
+      dtype);
   // This is a hack to workaround the shape checks in _convolution.
   tensor_impl->set_sizes_contiguous(size);
   return Tensor(std::move(tensor_impl));

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -71,7 +71,7 @@ SKIP_PYTHON_BINDINGS = [
     'set_quantizer_',  # return types not supported yet
     'set_data',
     '.*_overrideable',  # overrideable functions for backend extension
-    'data', 'is_leaf', 'output_nr', '_version', 'requires_grad_', 'retain_grad'
+    'data', 'is_leaf', 'output_nr', '_version', 'requires_grad_', 'retain_grad', 'set_'
 ]
 
 # These function signatures are not exposed to Python. Note that this signature

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -712,7 +712,7 @@ static PyObject * THPVariable_storage(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  return createPyObject(self_.storage());
+  return createPyObject(self_.storage(), self_.dtype());
   END_HANDLE_TH_ERRORS
 }
 
@@ -720,7 +720,7 @@ static PyObject * THPVariable_storage_type(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  auto storage = THPObjectPtr(createPyObject(self_.storage()));
+  auto storage = THPObjectPtr(createPyObject(self_.storage(), self_.dtype()));
   auto storage_type = (PyObject*)Py_TYPE(storage);
   Py_INCREF(storage_type);
   return storage_type;
@@ -837,6 +837,83 @@ static PyObject * TypeError_to_NotImplemented_(PyObject* self, PyObject* args, P
     ret = Py_NotImplemented;
   }
   return ret;
+}
+
+// set_ has to be defined in the template because the c10::Storage object
+// does not have a type, and we need to make sure the Python storage object's
+// type matches the tensor's type
+static PyObject* THPVariable_set_(
+    PyObject* self_,
+    PyObject* args,
+    PyObject* kwargs) {
+  HANDLE_TH_ERRORS
+  Tensor& self = reinterpret_cast<THPVariable*>(self_)->cdata;
+  static PythonArgParser parser(
+      {
+          "set_()",
+          "set_(Storage source)",
+          "set_(Storage source, int64_t storage_offset, IntArrayRef size, IntArrayRef stride=None)",
+          "set_(Tensor source)",
+      },
+      /*traceable=*/false);
+
+  ParsedArgs<4> parsed_args;
+  auto _r = parser.parse(args, kwargs, parsed_args);
+
+  switch (_r.idx) {
+    case 0: {
+      // aten::set_(Tensor(a!) self) -> Tensor(a!)
+      auto dispatch_set_ = [](Tensor& self) -> Tensor {
+        pybind11::gil_scoped_release no_gil;
+        return self.set_();
+      };
+      return wrap(dispatch_set_(self));
+    }
+    case 1: {
+      // aten::set_.source_Storage(Tensor(a!) self, Storage source) ->
+      // Tensor(a!)
+      THPObjectPtr dtype_attr(PyObject_GetAttrString(_r.pyobject(0), "dtype"));
+      if (!dtype_attr) throw python_error();
+      at::ScalarType storage_scalar_type = reinterpret_cast<THPDtype*>(
+        dtype_attr.get())->scalar_type;
+      TORCH_INTERNAL_ASSERT(storage_scalar_type == self.dtype());
+      auto dispatch_set_ = [](Tensor& self, Storage source) -> Tensor {
+        pybind11::gil_scoped_release no_gil;
+        return self.set_(source);
+      };
+      return wrap(dispatch_set_(self, _r.storage(0)));
+    }
+    case 2: {
+      // aten::set_.source_Storage_storage_offset(Tensor(a!) self, Storage
+      // source, int storage_offset, int[] size, int[] stride=[]) -> Tensor(a!)
+      THPObjectPtr dtype_attr(PyObject_GetAttrString(_r.pyobject(0), "dtype"));
+      if (!dtype_attr) throw python_error();
+      at::ScalarType storage_scalar_type = reinterpret_cast<THPDtype*>(
+        dtype_attr.get())->scalar_type;
+      TORCH_INTERNAL_ASSERT(storage_scalar_type == self.dtype());
+      auto dispatch_set_ = [](Tensor& self,
+                              Storage source,
+                              int64_t storage_offset,
+                              IntArrayRef size,
+                              IntArrayRef stride) -> Tensor {
+        pybind11::gil_scoped_release no_gil;
+        return self.set_(source, storage_offset, size, stride);
+      };
+      return wrap(dispatch_set_(
+          self, _r.storage(0), _r.toInt64(1), _r.intlist(2), _r.intlist(3)));
+    }
+    case 3: {
+      // aten::set_.source_Tensor(Tensor(a!) self, Tensor source) -> Tensor(a!)
+      auto dispatch_set_ = [](Tensor& self, const Tensor& source) -> Tensor {
+        TORCH_INTERNAL_ASSERT(source.dtype() == self.dtype());
+        pybind11::gil_scoped_release no_gil;
+        return self.set_(source);
+      };
+      return wrap(dispatch_set_(self, _r.tensor(0)));
+    }
+  }
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
 }
 
 // XXX: ops that are bound here are not exposed to the C++ api nor the JIT.

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -977,6 +977,7 @@ PyMethodDef variable_methods[] = {
   {"numpy", (PyCFunction)THPVariable_numpy, METH_NOARGS, NULL},
   {"record_stream", (PyCFunction)THPVariable_record_stream, METH_O, NULL},
   {"requires_grad_", (PyCFunction)(void(*)(void))THPVariable_requires_grad_, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"set_", (PyCFunction)(void (*)(void))THPVariable_set_, METH_VARARGS | METH_KEYWORDS, NULL},
   {"short", (PyCFunction)(void(*)(void))THPVariable_short, METH_VARARGS | METH_KEYWORDS, NULL},
   {"size", (PyCFunction)(void(*)(void))THPVariable_size, METH_VARARGS | METH_KEYWORDS, NULL},
   {"storage", (PyCFunction)THPVariable_storage, METH_NOARGS, NULL},

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -57,9 +57,10 @@ at::DeprecatedTypeProperties* get_type(at::Backend backend, at::ScalarType scala
   return &at::getDeprecatedTypeProperties(backend, scalarType);
 }
 
-PyTypeObject* getPyTypeObject(const at::Storage& storage)
-{
-  at::ScalarType scalarType = at::typeMetaToScalarType(storage.dtype());
+PyTypeObject* getPyTypeObject(
+    const at::Storage& storage,
+    const caffe2::TypeMeta& dtype) {
+  at::ScalarType scalarType = at::typeMetaToScalarType(dtype);
   at::TensorOptions options = at::TensorOptions(storage.device_type()).dtype(scalarType);
   auto attype = &at::getDeprecatedTypeProperties(
       at::dispatchKeyToBackend(at::computeDispatchKey(options)),
@@ -104,9 +105,10 @@ THPLayout* getTHPLayout(at::Layout layout) {
   return thp_layout;
 }
 
-PyObject* createPyObject(const at::Storage& storage)
-{
-  auto type = getPyTypeObject(storage);
+PyObject* createPyObject(
+    const at::Storage& storage,
+    const caffe2::TypeMeta& data_type) {
+  auto type = getPyTypeObject(storage, data_type);
   auto obj = THPObjectPtr(type->tp_alloc(type, 0));
   if (!obj) throw python_error();
   ((THPVoidStorage*)obj.get())->cdata = (THVoidStorage *)at::Storage(/* copy */ storage).unsafeReleaseStorageImpl();

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -27,7 +27,9 @@ void registerStoragePyTypeObject(
 void registerDtypeObject(THPDtype *dtype, at::ScalarType scalarType);
 void registerLayoutObject(THPLayout *thp_layout, at::Layout layout);
 
-PyObject* createPyObject(const at::Storage& storage);
+PyObject* createPyObject(
+    const at::Storage& storage,
+    const caffe2::TypeMeta& data_type);
 at::Storage createStorage(PyObject* obj);
 bool isStorage(PyObject* obj);
 

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -179,7 +179,6 @@ at::Tensor ScriptModuleDeserializer::LEGACY_loadTensor(
     std::tie(storage_ptr, record_size) = reader_->getRecord(record_key);
     auto cpu_storage = at::Storage(
         c10::Storage::use_byte_size_t(),
-        at::CPU(type).typeMeta(),
         record_size,
         std::move(storage_ptr),
         /*allocator=*/nullptr,

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -413,7 +413,6 @@ PickleOpCode Unpickler::readInstruction() {
       caffe2::TypeMeta dtype = at::CPU(type).typeMeta();
       at::Storage storage(
           c10::Storage::use_byte_size_t(),
-          dtype,
           numel * dtype.itemsize(),
           std::move(storage_ptr),
           /*allocator=*/nullptr,
@@ -648,7 +647,7 @@ void Unpickler::rebuildTensor(bool quantized) {
     bool requires_grad = elements.at(idx++).toBool();
     // elements[idx++] is empty backwards hooks
     at::TensorImpl* impl = result.unsafeGetTensorImpl();
-    impl->set_storage(storage_tensor.storage());
+    impl->set_storage_keep_dtype(storage_tensor.storage());
     impl->set_storage_offset(storage_offset);
     impl->set_sizes_and_strides(size, stride);
     result = autograd::make_variable(result, requires_grad);

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -488,6 +488,17 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
     at::OptionalDeviceGuard device_guard(deviceOptional);
     return at::empty({0}, options(dispatch_key, scalar_type));
   } else if (r.idx == 1) {
+    THPObjectPtr dtype_attr(PyObject_GetAttrString(r.pyobject(0), "dtype"));
+    if (!dtype_attr) throw python_error();
+    at::ScalarType storage_scalar_type = reinterpret_cast<THPDtype*>(
+        dtype_attr.get())->scalar_type;
+    TORCH_CHECK(
+        storage_scalar_type == scalar_type,
+        "Expected Storage of type ",
+        scalar_type,
+        " but got type ",
+        storage_scalar_type,
+        " for argument 1 'storage'");
     return new_with_storage(dispatch_key, scalar_type, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
@@ -535,6 +546,17 @@ Tensor legacy_tensor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_ty
     at::OptionalDeviceGuard device_guard(deviceOptional);
     return at::empty({0}, options(dispatch_key, scalar_type));
   } else if (r.idx == 1) {
+    THPObjectPtr dtype_attr(PyObject_GetAttrString(r.pyobject(0), "dtype"));
+    if (!dtype_attr) throw python_error();
+    at::ScalarType storage_scalar_type = reinterpret_cast<THPDtype*>(
+        dtype_attr.get())->scalar_type;
+    TORCH_CHECK(
+        storage_scalar_type == scalar_type,
+        "Expected Storage of type ",
+        scalar_type,
+        " but got type ",
+        storage_scalar_type,
+        " for argument 1 'storage'");
     return new_with_storage(dispatch_key, scalar_type, r.storage(0));
   } else if (r.idx == 2) {
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -223,7 +223,6 @@ at::Tensor pinnedLike(at::Tensor& tensor) {
   auto* allocator = at::cuda::getPinnedMemoryAllocator();
   auto storage = c10::Storage(
       c10::Storage::use_byte_size_t(),
-      tensor.dtype(),
       at::detail::computeStorageNbytes(
           tensor.sizes(), tensor.strides(), tensor.dtype().itemsize()),
       allocator,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#38870 [pytorch][PR] Remove datatype from Storage and StorageImpl**

* Removed dtype data member from StorageImpl
* Removed any methods or method arguments in Storage/StorageImpl that deal with dtypes
* Update all callers of the changed API

Part of issue https://github.com/pytorch/pytorch/issues/33950
Original PR: https://github.com/pytorch/pytorch/pull/38038

Differential Revision: [D21549645](https://our.internmc.facebook.com/intern/diff/D21549645/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D21549645/)!