### PR TITLE
Fix SyncBatchNorm forward pass for non-default process group

### DIFF
--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -24,7 +24,7 @@ class SyncBatchNorm(Function):
             torch.empty_like(combined) for k in range(world_size)
         ]
         # Use allgather instead of allreduce since I don't trust in-place operations ..
-        dist.all_gather(combined_list, combined, async_op=False)
+        dist.all_gather(combined_list, combined, process_group, async_op=False)
         combined = torch.stack(combined_list, dim=0)
         # world_size * (2C + 1) -> world_size * C, world_size * C, world_size * 1
         mean_all, invstd_all, count_all = torch.split(combined, num_channels, dim=1)


### PR DESCRIPTION
In forward pass of SyncBN, the all_gather call ignores process_group, leading to failure if any non-default process group is used,

Seems to be introduced quite recently by #38246.