### PR TITLE
Error out of parameters() for replicated models

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -618,8 +618,7 @@ class TestDataParallel(TestCase):
         for devices in [(0, 1), [0, 1]]:
             replicas = dp.replicate(module, devices)
             for i, replica in enumerate(replicas):
-                for p in replica.parameters():
-                    self.assertEqual(p.get_device(), i)
+                self.assertRaises(RuntimeError, lambda: print(replica.parameters()))
                 replica_input = input.cuda(i)
                 self.assertEqual(replica(replica_input), expected_output)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -91,6 +91,7 @@ class Module(object):
         self._state_dict_hooks = OrderedDict()
         self._load_state_dict_pre_hooks = OrderedDict()
         self._modules = OrderedDict()
+        self.is_replicated = False
 
     def forward(self, *input):
         r"""Defines the computation performed at every call.
@@ -913,6 +914,10 @@ class Module(object):
             <class 'torch.Tensor'> (20L, 1L, 5L, 5L)
 
         """
+        # parameters replicated models are not populated to _parameters
+        if self.is_replicated:
+            raise RuntimeError("parameters() cannot be called on a replicated model")
+
         for name, param in self.named_parameters(recurse=recurse):
             yield param
 

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -97,6 +97,10 @@ class DataParallel(Module):
         See :ref:`pack-rnn-unpack-with-data-parallelism` section in FAQ for
         details.
 
+    .. warning::
+        Parameters on replicated models are not populated to :attr:`_parameters`,
+        as these parameters are not leaves. This means that ``parameters()``
+        cannot be called on replicated models.
 
     Args:
         module (Module): module to be parallelized

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -111,6 +111,7 @@ def replicate(network, devices, detach=False):
         module_indices[module] = i
         for j in range(num_replicas):
             replica = module._replicate_for_data_parallel()
+            replica.is_replicated = True
             # This is a temporary fix for DDP. DDP needs to access the 
             # replicated model parameters. It used to do so through 
             # `mode.parameters()`. The fix added in #33907 for DP stops the


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/38493.

Introduces a new attribute ```module.is_replicated``` to be made ```True``` when replica is created. This is then used to error out of ```parameters()``` for replicated models. I also added a warning int he docstrings and modified a test.