### PR TITLE
Add stats for allocation source

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -58,12 +58,22 @@ enum struct StatType : uint64_t {
   NUM_TYPES = 3  // remember to update this whenever a new stat type is added
 };
 
+enum struct AllocSource : uint64_t {
+  CUDAFREE,  // cuda_free
+  CUDAMALLOC,  // cuda_malloc
+  CUDAMALLOC_RETRY,  // cuda_malloc during retries
+  NUM_ALLOC_SOURCES
+};
+
 typedef std::array<Stat, static_cast<size_t>(StatType::NUM_TYPES)> StatArray;
+typedef std::array<uint64_t, static_cast<size_t>(AllocSource::NUM_ALLOC_SOURCES)> AllocSourceArray;
 
 // Struct containing memory allocator summary statistics for a device.
 struct DeviceStats {
   // COUNT: allocations requested by client code
   StatArray allocation;
+  // COUNT: total number of allocation requests satisfied from each source (histogram)
+  AllocSourceArray allocation_source = {0};
   // COUNT: number of allocated segments from cudaMalloc().
   StatArray segment;
   // COUNT: number of active memory blocks (allocated or used by stream)

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -461,6 +461,13 @@ def memory_summary(device=None, abbreviated=False):
             )
 
     lines.append("=" * 75)
+    lines.append("        Metric         | cudaFree   | cudaMalloc | cudaMalloc retries      ")
+    lines.append(" {:<21} | {} | {} | {}              ".format(
+        "Allocation Source",
+        _format_count(stats["allocation_source.cudafree"], stats["allocation_source.cudafree"]),
+        _format_count(stats["allocation_source.cudamalloc"], stats["allocation_source.cudamalloc"]),
+        _format_count(stats["allocation_source.cudamalloc_retry"], stats["allocation_source.cudamalloc_retry"])))
+    lines.append("=" * 75)
 
     fmt_dict = {"_": "", "device": device}
     for k, v in stats.items():


### PR DESCRIPTION
Users might be interested in this additional stats info.

Example output:

```
|===========================================================================|
|                  PyTorch CUDA memory summary, device ID 0                 |
|---------------------------------------------------------------------------|
|            CUDA OOMs: 0            |        cudaMalloc retries: 0         |
|===========================================================================|
|        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
|---------------------------------------------------------------------------|
| Allocated memory      |    1024 B  |  133632 B  |  273920 B  |  272896 B  |
|       from large pool |       0 B  |       0 B  |       0 B  |       0 B  |
|       from small pool |    1024 B  |  133632 B  |  273920 B  |  272896 B  |
|---------------------------------------------------------------------------|
| Active memory         |    1024 B  |  133632 B  |  273920 B  |  272896 B  |
|       from large pool |       0 B  |       0 B  |       0 B  |       0 B  |
|       from small pool |    1024 B  |  133632 B  |  273920 B  |  272896 B  |
|---------------------------------------------------------------------------|
| GPU reserved memory   |    2048 KB |    2048 KB |    2048 KB |       0 B  |
|       from large pool |       0 KB |       0 KB |       0 KB |       0 B  |
|       from small pool |    2048 KB |    2048 KB |    2048 KB |       0 B  |
|---------------------------------------------------------------------------|
| Non-releasable memory |    2047 KB |    2047 KB |    2314 KB |  273408 B  |
|       from large pool |       0 KB |       0 KB |       0 KB |       0 B  |
|       from small pool |    2047 KB |    2047 KB |    2314 KB |  273408 B  |
|---------------------------------------------------------------------------|
| Allocations           |       2    |       8    |      23    |      21    |
|       from large pool |       0    |       0    |       0    |       0    |
|       from small pool |       2    |       8    |      23    |      21    |
|---------------------------------------------------------------------------|
| Active allocs         |       2    |       8    |      23    |      21    |
|       from large pool |       0    |       0    |       0    |       0    |
|       from small pool |       2    |       8    |      23    |      21    |
|---------------------------------------------------------------------------|
| GPU reserved segments |       1    |       1    |       1    |       0    |
|       from large pool |       0    |       0    |       0    |       0    |
|       from small pool |       1    |       1    |       1    |       0    |
|---------------------------------------------------------------------------|
| Non-releasable allocs |       1    |       3    |       9    |       8    |
|       from large pool |       0    |       0    |       0    |       0    |
|       from small pool |       1    |       3    |       9    |       8    |
|===========================================================================|
|        Metric         | cudaFree   | cudaMalloc | cudaMalloc retries      |
| Allocation Source     |      22    |       1    |       0                 |
|===========================================================================|
```

Co-authored-by: Matt Brandyberry <mbrandy@us.ibm.com>

