### PR TITLE
vec256_qint: Pass arguments by reference

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec256/vec256_qint.h
@@ -284,7 +284,7 @@ struct Vec256<c10::qint32> : public Vec256qi {
       return retval;
     }
 
-    Vec256<c10::qint32> maximum(Vec256<c10::qint32> b) const {
+    Vec256<c10::qint32> maximum(const Vec256<c10::qint32>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_max_epi32(vals, b.vals);
 #else
@@ -302,7 +302,7 @@ struct Vec256<c10::qint32> : public Vec256qi {
 #endif
     }
 
-    Vec256<c10::qint32> minimum(Vec256<c10::qint32> b) const {
+    Vec256<c10::qint32> minimum(const Vec256<c10::qint32>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_min_epi32(vals, b.vals);
 #else
@@ -320,13 +320,13 @@ struct Vec256<c10::qint32> : public Vec256qi {
 #endif
     }
 
-    Vec256<c10::qint32> relu(Vec256<c10::qint32> zero_point) const {
+    Vec256<c10::qint32> relu(const Vec256<c10::qint32>& zero_point) const {
         return maximum(zero_point);
     }
 
     Vec256<c10::qint32> relu6(
-        Vec256<c10::qint32> zero_point,
-        Vec256<c10::qint32> q_six) {
+        const Vec256<c10::qint32>& zero_point,
+        const Vec256<c10::qint32>& q_six) {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_min_epi32(
           _mm256_max_epi32(vals, zero_point.vals), q_six.vals);
@@ -348,7 +348,7 @@ struct Vec256<c10::qint32> : public Vec256qi {
 #endif
     }
 
-    int_vec_return_type widening_subtract(Vec256<c10::qint32> b) const {
+    int_vec_return_type widening_subtract(const Vec256<c10::qint32>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       return {_mm256_sub_epi32(vals, b)};
 #else
@@ -604,7 +604,7 @@ struct Vec256<c10::qint8> : public Vec256qi {
     return Vec256<c10::qint8>::loadu(quantized_values);
   }
 
-  Vec256<c10::qint8> maximum(Vec256<c10::qint8> b) const {
+  Vec256<c10::qint8> maximum(const Vec256<c10::qint8>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_max_epi8(vals, b.vals);
 #else
@@ -622,7 +622,7 @@ struct Vec256<c10::qint8> : public Vec256qi {
 #endif
     }
 
-  Vec256<c10::qint8> minimum(Vec256<c10::qint8> b) const {
+  Vec256<c10::qint8> minimum(const Vec256<c10::qint8>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_min_epi8(vals, b.vals);
 #else
@@ -640,13 +640,13 @@ struct Vec256<c10::qint8> : public Vec256qi {
 #endif
     }
 
-    Vec256<c10::qint8> relu(Vec256<c10::qint8> zero_point) const {
+    Vec256<c10::qint8> relu(const Vec256<c10::qint8>& zero_point) const {
         return maximum(zero_point);
     }
 
     Vec256<c10::qint8> relu6(
-        Vec256<c10::qint8> zero_point,
-        Vec256<c10::qint8> q_six) {
+        const Vec256<c10::qint8>& zero_point,
+        const Vec256<c10::qint8>& q_six) {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_min_epi8(
           _mm256_max_epi8(vals, zero_point.vals), q_six.vals);
@@ -668,7 +668,7 @@ struct Vec256<c10::qint8> : public Vec256qi {
 #endif
     }
 
-    int_vec_return_type widening_subtract(Vec256<c10::qint8> b) const {
+    int_vec_return_type widening_subtract(const Vec256<c10::qint8>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       __m128i int_val0 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 0));
       __m128i int_val1 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 1));
@@ -875,7 +875,7 @@ struct Vec256<c10::quint8> : public Vec256qi {
     return Vec256<c10::quint8>::loadu(quantized_values);
   }
 
-  Vec256<c10::quint8> maximum(Vec256<c10::quint8> b) const {
+  Vec256<c10::quint8> maximum(const Vec256<c10::quint8>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_max_epu8(vals, b.vals);
 #else
@@ -893,7 +893,7 @@ struct Vec256<c10::quint8> : public Vec256qi {
 #endif
     }
 
-  Vec256<c10::quint8> minimum(Vec256<c10::quint8> b) const {
+  Vec256<c10::quint8> minimum(const Vec256<c10::quint8>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_min_epu8(vals, b.vals);
 #else
@@ -911,13 +911,13 @@ struct Vec256<c10::quint8> : public Vec256qi {
 #endif
     }
 
-    Vec256<c10::quint8> relu(Vec256<c10::quint8> zero_point) const {
+    Vec256<c10::quint8> relu(const Vec256<c10::quint8>& zero_point) const {
         return maximum(zero_point);
     }
 
     Vec256<c10::quint8> relu6(
-        Vec256<c10::quint8> zero_point,
-        Vec256<c10::quint8> q_six) {
+        const Vec256<c10::quint8>& zero_point,
+        const Vec256<c10::quint8>& q_six) {
 #ifdef CPU_CAPABILITY_AVX2
       return _mm256_min_epu8(
           _mm256_max_epu8(vals, zero_point.vals), q_six.vals);
@@ -939,7 +939,7 @@ struct Vec256<c10::quint8> : public Vec256qi {
 #endif
     }
 
-    int_vec_return_type widening_subtract(Vec256<c10::quint8> b) const {
+    int_vec_return_type widening_subtract(const Vec256<c10::quint8>& b) const {
 #ifdef CPU_CAPABILITY_AVX2
       __m128i int_val0 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 0));
       __m128i int_val1 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 1));
@@ -1163,7 +1163,7 @@ struct Vec256<c10::qint32> : public Vec256QuantizedConverter<
     return Vec256<c10::qint32>::loadu(qvals.data());
   }
 
-  Vec256<c10::qint32> maximum(Vec256<c10::qint32> b) const {
+  Vec256<c10::qint32> maximum(const Vec256<c10::qint32>& b) const {
     Vec256<c10::qint32> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::max<value_type>(vals[i], b.vals[i]);
@@ -1171,7 +1171,7 @@ struct Vec256<c10::qint32> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  Vec256<c10::qint32> minimum(Vec256<c10::qint32> b) const {
+  Vec256<c10::qint32> minimum(const Vec256<c10::qint32>& b) const {
     Vec256<c10::qint32> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::min<value_type>(vals[i], b.vals[i]);
@@ -1179,14 +1179,14 @@ struct Vec256<c10::qint32> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  Vec256<c10::qint32> relu(Vec256<c10::qint32> zero_point) const  {
+  Vec256<c10::qint32> relu(const Vec256<c10::qint32>& zero_point) const  {
     return maximum(zero_point);
   }
 
 
   Vec256<c10::qint32> relu6(
-      Vec256<c10::qint32> zero_point,
-      Vec256<c10::qint32> q_six) {
+      const Vec256<c10::qint32>& zero_point,
+      const Vec256<c10::qint32>& q_six) {
     Vec256<c10::qint32> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::min<value_type>(
@@ -1195,7 +1195,7 @@ struct Vec256<c10::qint32> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  int_vec_return_type widening_subtract(Vec256<c10::qint32> b) const {
+  int_vec_return_type widening_subtract(const Vec256<c10::qint32>& b) const {
     int_vec_return_type retval;
     for (size_t i = 0; i < size(); ++i) {
       retval[0].vals[i] = vals[i] - b.vals[i];
@@ -1295,7 +1295,7 @@ struct Vec256<c10::qint8> : public Vec256QuantizedConverter<
     return Vec256<c10::qint8>::loadu(qvals.data());
   }
 
-  Vec256<c10::qint8> maximum(Vec256<c10::qint8> b) const {
+  Vec256<c10::qint8> maximum(const Vec256<c10::qint8>& b) const {
     Vec256<c10::qint8> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::max<value_type>(vals[i], b.vals[i]);
@@ -1303,7 +1303,7 @@ struct Vec256<c10::qint8> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  Vec256<c10::qint8> minimum(Vec256<c10::qint8> b) const {
+  Vec256<c10::qint8> minimum(const Vec256<c10::qint8>& b) const {
     Vec256<c10::qint8> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::min<value_type>(vals[i], b.vals[i]);
@@ -1311,13 +1311,13 @@ struct Vec256<c10::qint8> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  Vec256<c10::qint8> relu(Vec256<c10::qint8> zero_point) const {
+  Vec256<c10::qint8> relu(const Vec256<c10::qint8>& zero_point) const {
     return maximum(zero_point);
   }
 
   Vec256<c10::qint8> relu6(
-      Vec256<c10::qint8> zero_point,
-      Vec256<c10::qint8> q_six) {
+      const Vec256<c10::qint8>& zero_point,
+      const Vec256<c10::qint8>& q_six) {
     Vec256<c10::qint8> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::min<value_type>(
@@ -1326,7 +1326,7 @@ struct Vec256<c10::qint8> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  int_vec_return_type widening_subtract(Vec256<c10::qint8> b) const {
+  int_vec_return_type widening_subtract(const Vec256<c10::qint8>& b) const {
     int_vec_return_type retval;
     constexpr int elem_per_int_vec = size() / int_num_vecs();
     for (size_t i = 0; i < int_num_vecs(); ++i) {
@@ -1415,7 +1415,7 @@ struct Vec256<c10::quint8> : public Vec256QuantizedConverter<
     return Vec256<c10::quint8>::loadu(qvals.data());
   }
 
-  Vec256<c10::quint8> maximum(Vec256<c10::quint8> b) const {
+  Vec256<c10::quint8> maximum(const Vec256<c10::quint8>& b) const {
     Vec256<c10::quint8> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::max<value_type>(vals[i], b.vals[i]);
@@ -1423,7 +1423,7 @@ struct Vec256<c10::quint8> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  Vec256<c10::quint8> minimum(Vec256<c10::quint8> b) const {
+  Vec256<c10::quint8> minimum(const Vec256<c10::quint8>& b) const {
     Vec256<c10::quint8> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::min<value_type>(vals[i], b.vals[i]);
@@ -1431,14 +1431,14 @@ struct Vec256<c10::quint8> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  Vec256<c10::quint8> relu(Vec256<c10::quint8> zero_point) const {
+  Vec256<c10::quint8> relu(const Vec256<c10::quint8>& zero_point) const {
     return maximum(zero_point);
   }
 
 
   Vec256<c10::quint8> relu6(
-      Vec256<c10::quint8> zero_point,
-      Vec256<c10::quint8> q_six) {
+      const Vec256<c10::quint8>& zero_point,
+      const Vec256<c10::quint8>& q_six) {
     Vec256<c10::quint8> retval;
     for (size_t i = 0; i < size(); ++i) {
       retval.vals[i] = std::min<value_type>(
@@ -1447,7 +1447,7 @@ struct Vec256<c10::quint8> : public Vec256QuantizedConverter<
     return retval;
   }
 
-  int_vec_return_type widening_subtract(Vec256<c10::quint8> b) const {
+  int_vec_return_type widening_subtract(const Vec256<c10::quint8>& b) const {
     int_vec_return_type retval;
     constexpr int elem_per_int_vec = size() / int_num_vecs();
     for (size_t i = 0; i < int_num_vecs(); ++i) {


### PR DESCRIPTION
Avoid unnecessary copies by passing  maximum/minimum methods arguments by reference.
Benchmark results do not demonstrate much change one way or another:
`python -m pt.qcat_test --test_name qcat_M128_N128_K2_L7_dim2_contigone_dtypetorch.quint8 --num_runs 10 --iterations 3000`
Before:
```
# Benchmarking PyTorch: qcat
# Mode: Eager
# Name: qcat_M128_N128_K2_L7_dim2_contigone_dtypetorch.quint8
# Input: M: 128, N: 128, K: 2, L: 7, dim: 2, contig: one, dtype: torch.quint8
Run: 0, Forward Execution Time (us) : 227.261
Run: 1, Forward Execution Time (us) : 226.665
Run: 2, Forward Execution Time (us) : 226.522
Run: 3, Forward Execution Time (us) : 228.322
Run: 4, Forward Execution Time (us) : 226.462
Run: 5, Forward Execution Time (us) : 225.998
Run: 6, Forward Execution Time (us) : 225.049
Run: 7, Forward Execution Time (us) : 226.198
Run: 8, Forward Execution Time (us) : 227.405
Run: 9, Forward Execution Time (us) : 227.357
```
After:
```
# Benchmarking PyTorch: qcat
# Mode: Eager
# Name: qcat_M128_N128_K2_L7_dim2_contigone_dtypetorch.quint8
# Input: M: 128, N: 128, K: 2, L: 7, dim: 2, contig: one, dtype: torch.quint8
Run: 0, Forward Execution Time (us) : 227.637
Run: 1, Forward Execution Time (us) : 226.748
Run: 2, Forward Execution Time (us) : 225.344
Run: 3, Forward Execution Time (us) : 225.937
Run: 4, Forward Execution Time (us) : 225.716
Run: 5, Forward Execution Time (us) : 225.525
Run: 6, Forward Execution Time (us) : 225.186
Run: 7, Forward Execution Time (us) : 224.521
Run: 8, Forward Execution Time (us) : 224.431
Run: 9, Forward Execution Time (us) : 230.458

```

