### PR TITLE
[JIT] Add support for saving/loading of lowered modules

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1770,7 +1770,6 @@ struct CAFFE2_API ClassType : public NamedType {
       const std::string& name,
       const TypePtr& type,
       bool is_parameter = false,
-      bool allow_any = false,
       bool is_buffer = false);
 
   // [Internal Only] Remove attribute from the ClassType,
@@ -1787,11 +1786,10 @@ struct CAFFE2_API ClassType : public NamedType {
       const std::string& name,
       TypePtr ty,
       bool is_parameter = false,
-      bool allow_any = false,
       bool is_buffer = false) {
     auto slot_idx = findAttributeSlot(name);
     if (!slot_idx) {
-      return addAttribute(name, ty, is_parameter, allow_any, is_buffer);
+      return addAttribute(name, ty, is_parameter, is_buffer);
     }
 
     TORCH_CHECK(

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -974,7 +974,7 @@ ClassTypePtr ClassType::refine(at::ArrayRef<TypePtr> refined_slots) const {
   AT_ASSERT(numAttributes() == refined_slots.size());
   for (size_t i = 0; i < attributes_.size(); ++i) {
     AT_ASSERT(refined_slots[i]->isSubtypeOf(attributes_[i].getType()));
-    ptr->addAttribute(attributes_[i].getName(), refined_slots[i], (attributes_[i].getKind() == AttributeKind::PARAMETER), false,
+    ptr->addAttribute(attributes_[i].getName(), refined_slots[i], (attributes_[i].getKind() == AttributeKind::PARAMETER),
     (attributes_[i].getKind() == AttributeKind::BUFFER));
   }
   // Copy methods over
@@ -1155,7 +1155,6 @@ size_t ClassType::addAttribute(
     const std::string& name,
     const TypePtr& type,
     bool is_parameter,
-    bool allow_any,
     bool is_buffer) {
   if (is_parameter && is_buffer){
     TORCH_INTERNAL_ASSERT(false, "Attribute cannot be both a parameter and a buffer!");
@@ -1164,9 +1163,6 @@ size_t ClassType::addAttribute(
   std::string what = is_parameter ? "parameter" : "attribute";
   what += (is_buffer? "buffer" : "not buffer");
   checkNotExist(name, what);
-  if (!allow_any) {
-    checkNoAny(*this, what.c_str(), name, type);
-  }
 
   size_t slot = attributes_.size();
 

--- a/test/jit/test_backends.py
+++ b/test/jit/test_backends.py
@@ -1,4 +1,5 @@
 from torch.testing._internal.jit_utils import JitTestCase
+import io
 import os
 import sys
 
@@ -38,35 +39,72 @@ class MyModule(torch.nn.Module):
 
 
 class TestBackends(JitTestCase):
-    def test_simple(self):
-        module = MyModule()
-        scripted_module = torch.jit.script(MyModule())
+    def setUp(self):
+        super().setUp()
+        # Create Python, JIT and backend versions of MyModule.
+        self.module = MyModule()
+        self.scripted_module = torch.jit.script(MyModule())
+        self.lowered_module = to_test_backend_multi(
+            self.scripted_module._c, {"accum": {"": ""}, "sub_accum": {"": ""}, "forward": {"": ""}})
 
-        # Test compile.
-        lowered_module = to_test_backend_multi(
-            scripted_module._c, {"accum": {"": ""}, "sub_accum": {"": ""}, "forward": {"": ""}})
+    def compare_py_jit_backend(self, name, input):
+        """
+        This is a helper function for comparing the outputs of self.module (Python), self.scripted_module (JIT)
+        and self.lowered_module (backend) when the method named 'name' is invoked using 'input'.
+        """
+        # Get handles for Python, JIT and backend methods.
+        python_method = self.module.__getattribute__(name)
+        jit_method = self.scripted_module.__getattr__(name)
+        backend_method = self.lowered_module.__getattr__(name)
+
+        # Run methods.
+        python_output = python_method(input, input)
+        jit_output = jit_method(input, input)
+        backend_output = backend_method(input, input)
+
+        # The answers returned by Python, JIT and to_backend should all match.
+        self.assertEqual(python_output, backend_output)
+        self.assertEqual(jit_output, backend_output)
+
+    def test_simple(self):
+        """
+        This is a simple test that compiles MyModule for the test backend and ensures it produces the correct
+        answers for each method.
+        """
+        # Test execution with backend against Python and JIT.
+        input = torch.randn(5)
+
+        # Test all three module methods.
+        self.compare_py_jit_backend("accum", input)
+        self.compare_py_jit_backend("sub_accum", input)
+        self.compare_py_jit_backend("forward", input)
+
+    def test_save_load(self):
+        """
+        This method tests that a lowered module till produces the same output as a Python module and ScriptModule after
+        saving and loading.
+        """
+        # Save the lowered module.
+        buffer = io.BytesIO()
+        torch.jit.save(self.lowered_module, buffer)
+
+        # Save the compile spec to compare against the version retrieved after loading.
+        pre_compile_spec = self.lowered_module.__getattr__("__method_compile_spec")
+
+        # Load the lowered module.
+        buffer.seek(0)
+        self.lowered_module = torch.jit.load(buffer)
+
+        # Get the compile spec after loading.
+        post_compile_spec = self.lowered_module.__getattr__("__method_compile_spec")
+
+        # Compile specs should match.
+        self.assertEqual(pre_compile_spec, post_compile_spec)
 
         # Test execution with backend against Python and JIT.
         input = torch.randn(5)
 
-        def compare_py_jit_backend(name, input):
-            # Get handles for Python, JIT and backend methods.
-            python_method = module.__getattribute__(name)
-            jit_method = scripted_module.__getattr__(name)
-            backend_method = lowered_module._get_method(name)
-
-            # Run methods.
-            python_output = python_method(input, input)
-            jit_output = jit_method(input, input)
-            backend_output = backend_method(input, input)
-
-            # The answers returned by Python, JIT and to_backend should all match.
-            self.assertEqual(python_output, backend_output)
-            self.assertEqual(jit_output, backend_output)
-
         # Test all three module methods.
-        compare_py_jit_backend("accum", input)
-        compare_py_jit_backend("sub_accum", input)
-        compare_py_jit_backend("forward", input)
-
-        # TODO: Test save and load.
+        self.compare_py_jit_backend("accum", input)
+        self.compare_py_jit_backend("sub_accum", input)
+        self.compare_py_jit_backend("forward", input)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8349,17 +8349,6 @@ a")
         self.assertEqual(any_refinement2(3), torch.tensor(3))
         self.assertEqual(any_refinement2(torch.tensor(5)), torch.tensor(5))
 
-    def test_any_in_class_fails(self):
-        with self.assertRaisesRegex(RuntimeError, "contains an Any"):
-            @torch.jit.script
-            class Foo(object):
-                def __init__(self, a):
-                    # type: (Tuple[int,Any]) -> None
-                    self.a = a
-
-                def hi(self):
-                    pass
-
     def test_isinstance(self):
         # test isinstance operator for static type checking
         template = dedent('''

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.testing import FileCheck
-from typing import NamedTuple, List, Optional, Any, Dict, Tuple
+from typing import NamedTuple, List, Optional, Dict, Tuple
 from jit.test_module_interface import TestModuleInterface  # noqa: F401
 import unittest
 import sys
@@ -421,17 +421,6 @@ class TestScriptPy3(JitTestCase):
                 x = 5
                 if True:
                     x : Optional[int] = 7
-
-    def test_any_in_class_fails(self):
-        class MyCoolNamedTuple(NamedTuple):
-            a : Any
-            b : float
-            c : List[int]
-        with self.assertRaisesRegex(RuntimeError, "contains an Any"):
-            @torch.jit.script
-            def foo():
-                return MyCoolNamedTuple(4, 5.5, [3])
-            print(foo.graph)
 
     def test_export_opnames_interface(self):
         global OneTwoModule

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -119,8 +119,7 @@ struct TORCH_API Module : public Object {
   void register_buffer(const std::string& name, at::Tensor v) {
     bool is_param = false;
     bool is_buffer = true;
-    type()->addOrCheckAttribute(
-        name, TensorType::get(), is_param, false, is_buffer);
+    type()->addOrCheckAttribute(name, TensorType::get(), is_param, is_buffer);
     _ivalue()->setAttr(name, std::move(v));
   }
 
@@ -128,8 +127,7 @@ struct TORCH_API Module : public Object {
       const std::string& name,
       at::Tensor v,
       bool is_buffer) {
-    type()->addOrCheckAttribute(
-        name, TensorType::get(), !is_buffer, false, is_buffer);
+    type()->addOrCheckAttribute(name, TensorType::get(), !is_buffer, is_buffer);
     _ivalue()->setAttr(name, std::move(v));
   }
 
@@ -138,9 +136,8 @@ struct TORCH_API Module : public Object {
       const TypePtr t,
       IValue v,
       bool is_param = false,
-      bool allow_any = false,
       bool is_buffer = false) {
-    type()->addOrCheckAttribute(name, t, is_param, allow_any, is_buffer);
+    type()->addOrCheckAttribute(name, t, is_param, is_buffer);
     _ivalue()->setAttr(name, std::move(v));
   }
 

--- a/torch/csrc/jit/backends/backend.h
+++ b/torch/csrc/jit/backends/backend.h
@@ -71,8 +71,7 @@ class backend {
           "__processed_module",
           AnyType::get(),
           cloned_module._ivalue(),
-          /*is_param=*/false,
-          /*allow_any=*/true);
+          /*is_param=*/false);
 
       // This is for the method_compile_spec passed in to to_<backend> or
       // loaded from an exported model.
@@ -80,8 +79,7 @@ class backend {
           "__method_compile_spec",
           any_dict_ty,
           toIValue(method_compile_spec, any_dict_ty).toGenericDict(),
-          /*is_param=*/false,
-          /*allow_any=*/true);
+          /*is_param=*/false);
 
       // This is a pointer to a backend instance that is used to access
       // compile and execute functions.
@@ -98,8 +96,7 @@ class backend {
           any_dict_ty,
           c10::impl::GenericDict(
               any_dict_ty->getKeyType(), any_dict_ty->getValueType()),
-          /*is_param=*/false,
-          /*allow_any=*/true);
+          /*is_param=*/false);
 
       // Methods.
 

--- a/torch/csrc/jit/frontend/concrete_module_type.cpp
+++ b/torch/csrc/jit/frontend/concrete_module_type.cpp
@@ -25,7 +25,7 @@ ClassTypePtr ConcreteModuleTypeBuilder::createTypeFromThis() const {
     const auto& type = pr.value().type_;
     const auto& isParameter = pr.value().isParam_;
     const auto& isBuffer = pr.value().isBuffer_;
-    cls->addAttribute(name, type, isParameter, false, isBuffer);
+    cls->addAttribute(name, type, isParameter, isBuffer);
   }
 
   for (const auto& pr : constants_) {

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -449,7 +449,7 @@ struct SourceImporterImpl : public Resolver,
           const auto type = type_parser.parseTypeFromExpr(assign.type().get());
           const bool is_parameter = parameter_names.count(name);
           const bool is_buffer = buffer_names.count(name);
-          class_type->addAttribute(name, type, is_parameter, false, is_buffer);
+          class_type->addAttribute(name, type, is_parameter, is_buffer);
         } break;
         case TK_SUBSCRIPT: {
           const auto name =
@@ -458,7 +458,7 @@ struct SourceImporterImpl : public Resolver,
           const auto type = type_parser.parseTypeFromExpr(assign.rhs().get());
           const bool is_parameter = parameter_names.count(name);
           const bool is_buffer = buffer_names.count(name);
-          class_type->addAttribute(name, type, is_parameter, false, is_buffer);
+          class_type->addAttribute(name, type, is_parameter, is_buffer);
         }
       }
     }

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -70,20 +70,12 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
       case LayoutType::Kind:
       case ScalarTypeType::Kind:
       case RRefType::Kind:
-        // no op, there is nothing to tag
-        break;
       case AnyType::Kind:
       case AnyListType::Kind:
       case AnyTupleType::Kind:
       case AnyClassType::Kind:
-        // if Any type does show up, we no longer have a way to precisely
-        // recover the type information since the w.value may be an untagged
-        // List/Dict. We should prevent objects being serialized from having the
-        // Any type and if we do allow it in functions limit it to non-heap
-        // locations.
-        TORCH_INTERNAL_ASSERT(
-            false,
-            "AnyType, AnyTupleType, AnyListType, and AnyClassType should not show up in the static type of objects");
+        // no op, there is nothing to tag
+        break;
       case TupleType::Kind: {
         auto t = w.value.toTuple();
         auto ttype = w.static_type->expect<TupleType>();


### PR DESCRIPTION
**Summary**
This commit adds support for seralization and deserialization of
`ScriptModules` that have been lowered to a specific backend. Nothing
special was required to accomplish this, other than removing some code
in `unpickler.cpp` that guarded against the deserialization of `Any`
type objects. Now that lists and dicts are tagged with their types
during serialization, this check is no longer necessary.

**Test Plan**
This commit adds a unit test for testing that a lowered module still
produces the same results as Python and regular JIT after saving and
loading.

**Fixes**
This pull request fixes part of #37841. 

