### PR TITLE
Test case:test_fc_num0 fixed 

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
@@ -239,6 +239,7 @@ class FCTest(unittest.TestCase):
                 assert(0)
 
     @given(seed=st.integers(0, 65535))
+    @settings(deadline=400, max_examples=10)
     def test_fc_num0(self, seed):
         """ Test numerics, fix a dimension and determine the ranges of error.
             Use Fp16FCAcc16 as a reference.


### PR DESCRIPTION
Summary: 
Test case:test_fc_num0 fixed 
* Increased the test duration from 200=>400 ms
* setting the max_examples=10

Test case: test_fc_nnpi_fp16.py
