### PR TITLE
Add JIT fusion pass to fuse quantized add and relu.

### DIFF
--- a/test/quantization/test_fusion_passes.py
+++ b/test/quantization/test_fusion_passes.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# torch
+import torch
+from torch.testing import FileCheck
+from torch.testing._internal.common_quantization import QuantizationTestCase
+
+class TestFusionPasses(QuantizationTestCase):
+    def test_quantized_add_relu_fusion(self):
+        class MAdd(torch.nn.Module):
+            def __init__(self):
+                super(MAdd, self).__init__()
+
+            def forward(self, x, y):
+                a = torch.ops.quantized.add(x, y, 1., 0)
+                relu_out = torch.relu(a)
+                return relu_out
+
+        A = torch.arange(-128, 130, dtype=torch.float)
+        B = torch.arange(-128, 130, dtype=torch.float)
+        scale = 2.0
+        zero_point = 127
+        qA = torch.quantize_per_tensor(A, scale=scale, zero_point=zero_point,
+                                       dtype=torch.quint8)
+        qB = torch.quantize_per_tensor(B, scale=scale, zero_point=zero_point,
+                                       dtype=torch.quint8)
+
+        # Check quantized add + relu fusion
+        m = MAdd()
+        scripted_m = torch.jit.script(m)
+        ref_output = scripted_m(qA, qB)
+
+        # Must inline the graph.
+        # In this test case since we are directly calling ops
+        # it does not matter, however if we are calling nn
+        # modules we have to inline graph.
+        torch._C._jit_pass_inline(scripted_m.graph)
+        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        FileCheck().check_not("aten::relu") \
+                   .check("quantized::add_relu") \
+                   .run(scripted_m.graph)
+        output = scripted_m(qA, qB)
+        self.assertEqual(ref_output, output)
+
+        class MAddOut(torch.nn.Module):
+            def __init__(self):
+                super(MAddOut, self).__init__()
+
+            def forward(self, x, y, z):
+                a = torch.ops.quantized.add_out(x, y, z)
+                relu_out = torch.relu(a)
+                return relu_out
+
+        qC = torch._empty_affine_quantized(qA.shape,
+                                           scale=scale,
+                                           zero_point=zero_point,
+                                           dtype=torch.quint8)
+        # Check quantized add + relu fusion
+        m = MAddOut()
+        scripted_m = torch.jit.script(m)
+        ref_output = scripted_m(qA, qB, qC)
+        # Must inline the graph.
+        # In this test case since we are directly calling ops
+        # it does not matter, however if we are calling nn
+        # modules we have to inline graph.
+        torch._C._jit_pass_inline(scripted_m.graph)
+        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        FileCheck().check_not("aten::relu") \
+                   .check_not("quantized::add_out") \
+                   .check("quantized::add_relu_out") \
+                   .run(scripted_m.graph)
+        output = scripted_m(qA, qB, qC)
+        self.assertEqual(ref_output, output)
+
+        class MAddScalar(torch.nn.Module):
+            def __init__(self):
+                super(MAddScalar, self).__init__()
+
+            def forward(self, x, y : float):
+                a = torch.ops.quantized.add_scalar(x, y)
+                relu_out = torch.relu(a)
+                return relu_out
+
+        # Check quantized add + relu fusion
+        m = MAddScalar()
+        scripted_m = torch.jit.script(m)
+        ref_output = scripted_m(qA, 3.)
+        torch._C._jit_pass_inline(scripted_m.graph)
+        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        FileCheck().check_not("aten::relu") \
+                   .check_not("quantized::add_scalar(") \
+                   .check("quantized::add_scalar_relu") \
+                   .run(scripted_m.graph)
+        output = scripted_m(qA, 3.)
+        self.assertEqual(ref_output, output)
+
+        class MAddScalarOut(torch.nn.Module):
+            def __init__(self):
+                super(MAddScalarOut, self).__init__()
+
+            def forward(self, x, y : float, z):
+                a = torch.ops.quantized.add_scalar_out(x, y, z)
+                relu_out = torch.relu(a)
+                return relu_out
+
+        qC = torch._empty_affine_quantized(qA.shape,
+                                           scale=scale,
+                                           zero_point=zero_point,
+                                           dtype=torch.quint8)
+        m = MAddScalarOut()
+        scripted_m = torch.jit.script(m)
+        ref_output = scripted_m(qA, 3., qC)
+        torch._C._jit_pass_inline(scripted_m.graph)
+        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        FileCheck().check_not("aten::relu") \
+                   .check_not("quantized::add_scalar_out") \
+                   .check("quantized::add_scalar_relu_out") \
+                   .run(scripted_m.graph)
+        output = scripted_m(qA, 3., qC)
+        self.assertEqual(ref_output, output)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -24,6 +24,9 @@ from quantization.test_quantized_module import TestDynamicQuantizedModule  # noq
 # Quantization Aware Training
 from quantization.test_qat_module import TestQATModule  # noqa: F401
 
+# Quantization specific fusion passes
+from quantization.test_fusion_passes import TestFusionPasses  # noqa: F401
+
 # Module
 # TODO: merge the fake quant per tensor and per channel test cases
 # TODO: some of the tests are actually operator tests, e.g. test_forward_per_tensor, and

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -172,6 +172,7 @@ libtorch_core_sources = [
     "torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp",
     "torch/csrc/jit/passes/quantization/dedup_module_uses.cpp",
     "torch/csrc/jit/passes/quantization/finalize.cpp",
+    "torch/csrc/jit/passes/quantization/fusion_passes.cpp",
     "torch/csrc/jit/python/update_graph_executor_opt.cpp",
     "torch/csrc/jit/runtime/argument_spec.cpp",
     "torch/csrc/jit/runtime/autodiff.cpp",

--- a/torch/csrc/jit/passes/quantization/fusion_passes.cpp
+++ b/torch/csrc/jit/passes/quantization/fusion_passes.cpp
@@ -1,0 +1,63 @@
+#include <torch/csrc/jit/passes/quantization/fusion_passes.h>
+#include <torch/csrc/jit/passes/subgraph_rewrite.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+void fuseQuantizeAddReluImpl(std::shared_ptr<Graph>& graph) {
+  SubgraphRewriter fused_add_relu_rewriter;
+  std::string quantized_add_relu_pattern = R"(
+    graph(%a_quant, %b_quant, %scale, %zero_point):
+         %add_out = quantized::add(%a_quant, %b_quant, %scale, %zero_point)
+         %r = aten::relu(%add_out)
+         return (%r) )";
+  std::string fused_add_relu_pattern = R"(
+    graph(%a_quant, %b_quant, %scale, %zero_point):
+         %r = quantized::add_relu(%a_quant, %b_quant, %scale, %zero_point)
+         return (%r) )";
+  fused_add_relu_rewriter.RegisterRewritePattern(
+      quantized_add_relu_pattern, fused_add_relu_pattern);
+  std::string quantized_add_out_relu_pattern = R"(
+    graph(%a_quant, %b_quant, %out_quant):
+         %add_out = quantized::add_out(%a_quant, %b_quant, %out_quant)
+         %r = aten::relu(%add_out)
+         return (%r) )";
+  std::string fused_add_out_relu_pattern = R"(
+    graph(%a_quant, %b_quant, %out_quant):
+         %r = quantized::add_relu_out(%a_quant, %b_quant, %out_quant)
+         return (%r) )";
+  fused_add_relu_rewriter.RegisterRewritePattern(
+      quantized_add_out_relu_pattern, fused_add_out_relu_pattern);
+  std::string quantized_add_scalar_relu_pattern = R"(
+    graph(%a_quant, %b_scalar):
+         %add_out = quantized::add_scalar(%a_quant, %b_scalar)
+         %r = aten::relu(%add_out)
+         return (%r) )";
+  std::string fused_add_scalar_relu_pattern = R"(
+    graph(%a_quant, %b_scalar):
+         %r = quantized::add_scalar_relu(%a_quant, %b_scalar)
+         return (%r) )";
+  fused_add_relu_rewriter.RegisterRewritePattern(
+      quantized_add_scalar_relu_pattern, fused_add_scalar_relu_pattern);
+  std::string quantized_add_scalar_out_relu_pattern = R"(
+    graph(%a_quant, %b_scalar, %out_quant):
+         %add_out = quantized::add_scalar_out(%a_quant, %b_scalar, %out_quant)
+         %r = aten::relu(%add_out)
+         return (%r) )";
+  std::string fused_add_scalar_out_relu_pattern = R"(
+    graph(%a_quant, %b_scalar, %out_quant):
+         %r = quantized::add_scalar_relu_out(%a_quant, %b_scalar, %out_quant)
+         return (%r) )";
+  fused_add_relu_rewriter.RegisterRewritePattern(
+      quantized_add_scalar_out_relu_pattern, fused_add_scalar_out_relu_pattern);
+  fused_add_relu_rewriter.runOnGraph(graph);
+}
+} // namespace
+
+void FuseQuantizedAddRelu(std::shared_ptr<Graph>& graph) {
+  fuseQuantizeAddReluImpl(graph);
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/quantization/fusion_passes.h
+++ b/torch/csrc/jit/passes/quantization/fusion_passes.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+TORCH_API void FuseQuantizedAddRelu(std::shared_ptr<Graph>& graph);
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -42,6 +42,7 @@
 #include <torch/csrc/jit/passes/peephole.h>
 #include <torch/csrc/jit/passes/quantization/dedup_module_uses.h>
 #include <torch/csrc/jit/passes/quantization/finalize.h>
+#include <torch/csrc/jit/passes/quantization/fusion_passes.h>
 #include <torch/csrc/jit/passes/quantization/insert_observers.h>
 #include <torch/csrc/jit/passes/quantization/insert_quant_dequant.h>
 #include <torch/csrc/jit/passes/remove_dropout.h>
@@ -177,6 +178,11 @@ void initJITBindings(PyObject* module) {
           "_jit_pass_cse",
           [](std::shared_ptr<Graph>& g) {
             return EliminateCommonSubexpression(g); // overload resolution
+          })
+      .def(
+          "_jit_pass_fuse_quantized_add_relu",
+          [](std::shared_ptr<Graph>& g) {
+            return FuseQuantizedAddRelu(g); // overload resolution
           })
       .def(
           "_jit_pass_insert_observers",


### PR DESCRIPTION
Summary:
Quantized ops support add_relu. This pass enables finding quantized add + relu
pattern and fuse them to add_relu.

Test Plan: buck run caffe2/test:quantization -- test_quantization.TestFusionPasses

Reviewed By: jerryzh168

Differential Revision: D21690909

