### PR TITLE
Workarounds to fix VS2017 installation failures

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -103,7 +103,7 @@ class VcSpec:
 
 
 WORKFLOW_DATA = [
-    WindowsJob(None, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1)),
+    WindowsJob(None, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1), run_on_prs_pred=lambda x: False),
     WindowsJob(1, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1)),
     WindowsJob(2, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1)),
     WindowsJob(None, VcSpec(2017, ["14", "16"]), CudaVersion(10, 1)),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,14 @@ executors:
   windows-with-nvidia-gpu:
     machine:
       resource_class: windows.gpu.nvidia.medium
-      image: windows-server-2019-nvidia:stable
+      image: windows-server-2019-nvidia:201908-06
       shell: bash.exe
 
   windows-cpu-with-nvidia-cuda:
     machine:
       # we will change to CPU host when it's ready
       resource_class: windows.xlarge
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2019-vs2019:201908-06
       shell: bash.exe
 commands:
   # NB: This command must be run as the first command in a job. It

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2096,12 +2096,6 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2017-14-11-cuda10-cudnn7-py3
           cuda_version: "10"
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           name: pytorch_windows_vs2017_14.11_py36_cuda10.1_build
           python_version: "3.6"
           requires:

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -18,12 +18,12 @@ executors:
   windows-with-nvidia-gpu:
     machine:
       resource_class: windows.gpu.nvidia.medium
-      image: windows-server-2019-nvidia:stable
+      image: windows-server-2019-nvidia:201908-06
       shell: bash.exe
 
   windows-cpu-with-nvidia-cuda:
     machine:
       # we will change to CPU host when it's ready
       resource_class: windows.xlarge
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2019-vs2019:201908-06
       shell: bash.exe


### PR DESCRIPTION
Also, enable verbose logs

