### PR TITLE
Collect and upload error logs if VisualStudio installation fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,6 +640,8 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-build.sh
+      - store_artifacts:
+          path: build-results
   pytorch_windows_test:
     <<: *pytorch_windows_params
     parameters:

--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -1,4 +1,5 @@
 $VS_DOWNLOAD_LINK = "https://aka.ms/vs/15/release/vs_buildtools.exe"
+$COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"
 $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStudio.Workload.VCTools",
                                                      "--add Microsoft.VisualStudio.Component.VC.Tools.14.11",
                                                      "--add Microsoft.Component.MSBuild",
@@ -21,5 +22,13 @@ Remove-Item -Path vs_installer.exe -Force
 $exitCode = $process.ExitCode
 if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     echo "VS 2017 installer exited with code $exitCode, which should be one of [0, 3010]."
+    curl.exe --retry 3 -kL $COLLECT_DOWNLOAD_LINK --output Collect.exe
+    if ($LASTEXITCODE -ne 0) {
+        echo "Download of the VS Collect tool failed."
+        exit 1
+    }
+    Start-Process "${PWD}\Collect.exe" -NoNewWindow -Wait -PassThru
+    New-Item -Path "C:\Users\circleci\project" -Name "build-results" -ItemType "directory"
+    Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\Users\circleci\project\build-results\"
     exit 1
 }

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -239,6 +239,8 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-build.sh
+      - store_artifacts:
+          path: build-results
   pytorch_windows_test:
     <<: *pytorch_windows_params
     parameters:


### PR DESCRIPTION
Add `store_artifacts` attribtue to Windows build jobs
In `vs_install.ps1` add logic to download vscollect tool and upload collected results as build artifacts

