### PR TITLE
DOC: fix import error

### DIFF
--- a/torch/jit/supported_ops.py
+++ b/torch/jit/supported_ops.py
@@ -89,7 +89,7 @@ def _get_nn_functional_ops():
             pass
 
     # Iterate over modules that we know contain a lot of builtins
-    for mod in torch.jit._modules_containing_builtins:
+    for mod in torch.jit._builtins._modules_containing_builtins:
         name = mod.__name__
         for elem in dir(mod):
             builtin = torch.jit._find_builtin(getattr(mod, elem))
@@ -103,8 +103,13 @@ def _get_nn_functional_ops():
 
 def _get_builtins_helper():
     builtins = []
-    for fn, _builtin_name in torch.jit._builtin_ops:
+    for fn, _builtin_name in torch.jit._builtins._builtin_ops:
         mod = inspect.getmodule(fn)
+        if not hasattr(fn, '__name__'):
+            # typing classes
+            continue
+        if not mod:
+            continue
         if _hidden(fn.__name__) or _hidden(fn.__qualname__) or _hidden(mod.__name__):
             # skip internal-only methods
             continue


### PR DESCRIPTION
Fixes errors when importing the module. The import is used by sphinx in documentation builds.
