### PR TITLE
Change len(DataLoader) for IterableDataset

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1589,12 +1589,18 @@ except RuntimeError as e:
 
         iterable_loader = DataLoader(IterableDataset(), batch_size=1)
         self.assertEqual(len(iterable_loader), 10)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=1, drop_last=True)
+        self.assertEqual(len(iterable_loader), 10)
 
         iterable_loader = DataLoader(IterableDataset(), batch_size=2)
+        self.assertEqual(len(iterable_loader), 5)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=2, drop_last=True)
         self.assertEqual(len(iterable_loader), 5)
 
         iterable_loader = DataLoader(IterableDataset(), batch_size=3)
         self.assertEqual(len(iterable_loader), 4)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=3, drop_last=True)
+        self.assertEqual(len(iterable_loader), 3)
 
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_numpy_scalars(self):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1579,6 +1579,20 @@ except RuntimeError as e:
         check_len(DataLoader(self.dataset, batch_size=2), 50)
         check_len(DataLoader(self.dataset, batch_size=3), 34)
 
+    def test_iterabledataset_len(self):
+        class IterableDataset(torch.utils.data.IterableDataset):
+            def __len__(self):
+                return 10
+
+            def __iter__(self):
+                return iter(range(10))
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=1)
+        self.assertEqual(len(iterable_loader), 10)
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=2)
+        self.assertEqual(len(iterable_loader), 5)
+
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_numpy_scalars(self):
         import numpy as np

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1593,6 +1593,9 @@ except RuntimeError as e:
         iterable_loader = DataLoader(IterableDataset(), batch_size=2)
         self.assertEqual(len(iterable_loader), 5)
 
+        iterable_loader = DataLoader(IterableDataset(), batch_size=3)
+        self.assertEqual(len(iterable_loader), 4)
+
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_numpy_scalars(self):
         import numpy as np

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -313,7 +313,7 @@ class DataLoader(object):
             # `DataLoader`, save the returned value in `self._len_called`, and warn
             # if the iterator ends up yielding more than this number of samples.
             length = self._IterableDataset_len_called = len(self.dataset)
-            return length
+            return length // self.batch_size
         else:
             return len(self._index_sampler)
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -313,7 +313,7 @@ class DataLoader(object):
             # `DataLoader`, save the returned value in `self._len_called`, and warn
             # if the iterator ends up yielding more than this number of samples.
             length = self._IterableDataset_len_called = len(self.dataset)
-            if self.batch_size is not None:
+            if self.batch_size is not None and not self.drop_last:
                 length = length // self.batch_size
             return length
         else:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -313,6 +313,8 @@ class DataLoader(object):
             # `DataLoader`, save the returned value in `self._len_called`, and warn
             # if the iterator ends up yielding more than this number of samples.
             length = self._IterableDataset_len_called = len(self.dataset)
+            if self.batch_size is not None:
+                length = length // self.batch_size
             return length
         else:
             return len(self._index_sampler)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -313,7 +313,9 @@ class DataLoader(object):
             # `DataLoader`, save the returned value in `self._len_called`, and warn
             # if the iterator ends up yielding more than this number of samples.
             length = self._IterableDataset_len_called = len(self.dataset)
-            return length // self.batch_size
+            if self.batch_size is not None:
+                length = length // self.batch_size
+            return length
         else:
             return len(self._index_sampler)
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -313,8 +313,12 @@ class DataLoader(object):
             # `DataLoader`, save the returned value in `self._len_called`, and warn
             # if the iterator ends up yielding more than this number of samples.
             length = self._IterableDataset_len_called = len(self.dataset)
-            if self.batch_size is not None and not self.drop_last:
-                length = length // self.batch_size
+            if self.batch_size is not None:
+                from math import ceil
+                if self.drop_last:
+                    length = length // self.batch_size
+                else:
+                    length = ceil(length / self.batch_size)
             return length
         else:
             return len(self._index_sampler)


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/36176

One-liner change to ensure that ```len(loader) == (len(dataset) // batch_size)``` for IterableDataset.