### PR TITLE
[RPC] Perform final barrier in shutdown function rather than agent's join method

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -169,8 +169,6 @@ void ProcessGroupAgent::join() {
   std::unique_lock<std::mutex> lock(futureMutex_);
   futureCV_.wait(
       lock, [this] { return futures_.empty() && futureTimeouts_.empty(); });
-  lock.unlock();
-  pg_->barrier()->wait();
 }
 
 bool ProcessGroupAgent::hasPendingMessage() {

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -242,6 +242,7 @@ def shutdown(graceful=True):
         _wait_all_workers()
         _delete_all_user_rrefs()
         _get_current_rpc_agent().join()
+        _wait_all_workers()
     try:
         # This raises a `TORCH_CHECK()` exception on RRef leak detected.
         _destroy_rref_context(_ignore_rref_leak)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #38934 [TensorPipe] Close and join TP context at shutdown
* #38933 [TensorPipe] Implement join correctly
* **#38932 [RPC] Perform final barrier in shutdown function rather than agent's join method**
* #38931 [TensorPipe] Do not mark future messages as complete after they have timed out
* #38930 [TensorPipe] Always complete futures from thread pool
* #38929 [TensorPipe] Fix lock inversion upon response read error handling
* #38928 [TensorPipe] Fix timeout computation
* #38927 [TensorPipe] Add cases for TP in RPC test helpers
* #38926 [TensorPipe] Pass names of endpoints to context/pipe for easier debugging

This introduces no functional differences to the ProcessGroup agent, but it greatly helps the TensorPipe agent, which doesn't have a global view of the world and thus would have a very hard time implementing its own barrier mechanism.

Differential Revision: [D21703014](https://our.internmc.facebook.com/intern/diff/D21703014/)