### PR TITLE
Clean up cast from c10::complex<T> to thrust::complex<T>, and update the workaround CUDA version to <10.2

### DIFF
--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -2,16 +2,10 @@ namespace std {
 
 // Exponential functions
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION < 10000)
-#define CUDA92_BUG(x) thrust::complex<T>(x.real(), x.imag())
-#else
-#define CUDA92_BUG(x) x
-#endif
-
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> exp(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::exp(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::exp(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::exp(static_cast<std::complex<T>>(x)));
 #endif
@@ -20,7 +14,7 @@ C10_HOST_DEVICE inline c10::complex<T> exp(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> log(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::log(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::log(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::log(static_cast<std::complex<T>>(x)));
 #endif
@@ -29,7 +23,7 @@ C10_HOST_DEVICE inline c10::complex<T> log(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> log10(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::log10(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::log10(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::log10(static_cast<std::complex<T>>(x)));
 #endif
@@ -40,7 +34,7 @@ C10_HOST_DEVICE inline c10::complex<T> log10(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> sqrt(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::sqrt(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::sqrt(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::sqrt(static_cast<std::complex<T>>(x)));
 #endif
@@ -49,7 +43,8 @@ C10_HOST_DEVICE inline c10::complex<T> sqrt(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> pow(const c10::complex<T> &x, const c10::complex<T> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
+  return static_cast<c10::complex<T>>(thrust::pow(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x),
+                                                  c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(y)));
 #else
   return static_cast<c10::complex<T>>(std::pow(static_cast<std::complex<T>>(x), static_cast<std::complex<T>>(y)));
 #endif
@@ -58,7 +53,7 @@ C10_HOST_DEVICE inline c10::complex<T> pow(const c10::complex<T> &x, const c10::
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> pow(const c10::complex<T> &x, const T &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), y));
+  return static_cast<c10::complex<T>>(thrust::pow(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x), y));
 #else
   return static_cast<c10::complex<T>>(std::pow(static_cast<std::complex<T>>(x), y));
 #endif
@@ -67,7 +62,7 @@ C10_HOST_DEVICE inline c10::complex<T> pow(const c10::complex<T> &x, const T &y)
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> pow(const T &x, const c10::complex<T> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::pow(x, static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
+  return static_cast<c10::complex<T>>(thrust::pow(x, c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(y)));
 #else
   return static_cast<c10::complex<T>>(std::pow(x, static_cast<std::complex<T>>(y)));
 #endif
@@ -76,7 +71,8 @@ C10_HOST_DEVICE inline c10::complex<T> pow(const T &x, const c10::complex<T> &y)
 template<typename T, typename U>
 C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const c10::complex<T> &x, const c10::complex<U> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
+  return static_cast<c10::complex<T>>(thrust::pow(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x),
+                                                  c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(y)));
 #else
   return static_cast<c10::complex<T>>(std::pow(static_cast<std::complex<T>>(x), static_cast<std::complex<T>>(y)));
 #endif
@@ -85,7 +81,7 @@ C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const c10::complex<
 template<typename T, typename U>
 C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const c10::complex<T> &x, const U &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::pow(static_cast<thrust::complex<T>>(CUDA92_BUG(x)), y));
+  return static_cast<c10::complex<T>>(thrust::pow(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x), y));
 #else
   return static_cast<c10::complex<T>>(std::pow(static_cast<std::complex<T>>(x), y));
 #endif
@@ -94,7 +90,7 @@ C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const c10::complex<
 template<typename T, typename U>
 C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const T &x, const c10::complex<U> &y) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::pow(x, static_cast<thrust::complex<T>>(CUDA92_BUG(y))));
+  return static_cast<c10::complex<T>>(thrust::pow(x, c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(y)));
 #else
   return static_cast<c10::complex<T>>(std::pow(x, static_cast<std::complex<T>>(y)));
 #endif
@@ -105,7 +101,7 @@ C10_HOST_DEVICE inline c10::complex<decltype(T() * U())> pow(const T &x, const c
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> sin(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::sin(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::sin(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::sin(static_cast<std::complex<T>>(x)));
 #endif
@@ -114,7 +110,7 @@ C10_HOST_DEVICE inline c10::complex<T> sin(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> cos(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::cos(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::cos(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::cos(static_cast<std::complex<T>>(x)));
 #endif
@@ -123,7 +119,7 @@ C10_HOST_DEVICE inline c10::complex<T> cos(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> tan(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::tan(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::tan(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::tan(static_cast<std::complex<T>>(x)));
 #endif
@@ -132,7 +128,7 @@ C10_HOST_DEVICE inline c10::complex<T> tan(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> asin(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::asin(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::asin(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::asin(static_cast<std::complex<T>>(x)));
 #endif
@@ -141,7 +137,7 @@ C10_HOST_DEVICE inline c10::complex<T> asin(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> acos(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::acos(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::acos(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::acos(static_cast<std::complex<T>>(x)));
 #endif
@@ -150,7 +146,7 @@ C10_HOST_DEVICE inline c10::complex<T> acos(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> atan(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::atan(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::atan(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::atan(static_cast<std::complex<T>>(x)));
 #endif
@@ -161,7 +157,7 @@ C10_HOST_DEVICE inline c10::complex<T> atan(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> sinh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::sinh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::sinh(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::sinh(static_cast<std::complex<T>>(x)));
 #endif
@@ -170,7 +166,7 @@ C10_HOST_DEVICE inline c10::complex<T> sinh(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> cosh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::cosh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::cosh(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::cosh(static_cast<std::complex<T>>(x)));
 #endif
@@ -179,7 +175,7 @@ C10_HOST_DEVICE inline c10::complex<T> cosh(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> tanh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::tanh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::tanh(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::tanh(static_cast<std::complex<T>>(x)));
 #endif
@@ -188,7 +184,7 @@ C10_HOST_DEVICE inline c10::complex<T> tanh(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> asinh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::asinh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::asinh(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::asinh(static_cast<std::complex<T>>(x)));
 #endif
@@ -197,7 +193,7 @@ C10_HOST_DEVICE inline c10::complex<T> asinh(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> acosh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::acosh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::acosh(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::acosh(static_cast<std::complex<T>>(x)));
 #endif
@@ -206,12 +202,10 @@ C10_HOST_DEVICE inline c10::complex<T> acosh(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> atanh(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return static_cast<c10::complex<T>>(thrust::atanh(static_cast<thrust::complex<T>>(CUDA92_BUG(x))));
+  return static_cast<c10::complex<T>>(thrust::atanh(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
 #else
   return static_cast<c10::complex<T>>(std::atanh(static_cast<std::complex<T>>(x)));
 #endif
 }
-
-#undef CUDA92_BUG
 
 } // namespace std

--- a/c10/util/complex_type.h
+++ b/c10/util/complex_type.h
@@ -491,22 +491,29 @@ constexpr T imag(const c10::complex<T>& z) {
   return z.imag();
 }
 
-#if defined(CUDA_VERSION) && (CUDA_VERSION < 10000)
-#define CUDA92_BUG(x) thrust::complex<T>(x.real(), x.imag())
+#if defined(__CUDACC__) || defined(__HIPCC__)
+namespace c10_internal {
+  template<typename T>
+  C10_HOST_DEVICE constexpr thrust::complex<T> cuda101bug_cast_c10_complex_to_thrust_complex(const c10::complex<T>& x) {
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 10200)
+    // This is to circumvent a CUDA compilation bug. See https://github.com/pytorch/pytorch/pull/38941 .
+    // When the bug is fixed, we should do static_cast directly.
+    return thrust::complex<T>(x.real(), x.imag());
 #else
-#define CUDA92_BUG(x) x
+    return static_cast<thrust::complex<T>>(x);
+#endif
+  }
+} // namespace c10_internal
 #endif
 
 template<typename T>
 C10_HOST_DEVICE T abs(const c10::complex<T>& z) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
-  return thrust::abs(static_cast<thrust::complex<T>>(CUDA92_BUG(z)));
+  return thrust::abs(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(z));
 #else
   return std::abs(static_cast<std::complex<T>>(z));
 #endif
 }
-
-#undef CUDA92_BUG
 
 #ifdef __HIP_PLATFORM_HCC__
 #define ROCm_Bug(x)


### PR DESCRIPTION
I'm using CUDA 10.1 on Debian buster but I can still experience
compilation issues:

```
/usr/include/thrust/detail/complex/complex.inl(64): error: no suitable conversion function from "const c10::complex<float>" to "float" exists
          detected during:
            instantiation of "thrust::complex<T>::complex(const R &) [with T=float, R=c10::complex<float>]"
/home/hong/xusrc/pytorch/c10/util/complex_type.h(503): here
            instantiation of "T std::abs(const c10::complex<T> &) [with T=float]"
/home/hong/xusrc/pytorch/aten/src/ATen/native/cuda/AbsKernel.cu(17): here
            instantiation of "c10::complex<T> at::native::abs_wrapper(c10::complex<T>) [with T=float]"
/home/hong/xusrc/pytorch/aten/src/ATen/native/cuda/AbsKernel.cu(29): here

/usr/include/thrust/detail/complex/complex.inl(64): error: no suitable conversion function from "const c10::complex<double>" to "double" exists
          detected during:
            instantiation of "thrust::complex<T>::complex(const R &) [with T=double, R=c10::complex<double>]"
/home/hong/xusrc/pytorch/c10/util/complex_type.h(503): here
            instantiation of "T std::abs(const c10::complex<T> &) [with T=double]"
/home/hong/xusrc/pytorch/aten/src/ATen/native/cuda/AbsKernel.cu(17): here
            instantiation of "c10::complex<T> at::native::abs_wrapper(c10::complex<T>) [with T=double]"
/home/hong/xusrc/pytorch/aten/src/ATen/native/cuda/AbsKernel.cu(29): here

2 errors detected in the compilation of "/tmp/hong/tmpxft_00005893_00000000-6_AbsKernel.cpp1.ii".
CMake Error at torch_cuda_generated_AbsKernel.cu.o.Debug.cmake:281 (message):
  Error generating file
  /home/hong/xusrc/pytorch/build/caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/./torch_cuda_generated_AbsKernel.cu.o
```

`nvcc --version`:

```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Wed_Apr_24_19:10:27_PDT_2019
Cuda compilation tools, release 10.1, V10.1.168
```

