### PR TITLE
Fix argmin/max bug

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -782,6 +782,12 @@ Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
       "tensor with no elements because the operation does not have an identity");
   Tensor in;
   if (dim) {
+    if (self.sizes()[dim.value()] == 1) {
+      auto sizes = self.sizes().vec();
+      sizes.erase(sizes.begin() + dim.value());
+      result = at::zeros(sizes, self.options());
+      return result;
+    }
     in = self;
   } else {
     in = self.reshape({-1});
@@ -803,6 +809,12 @@ Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
       "tensor with no elements because the operation does not have an identity");
   Tensor in;
   if (dim) {
+    if (self.sizes()[dim.value()] == 1) {
+      auto sizes = self.sizes().vec();
+      sizes.erase(sizes.begin() + dim.value());
+      result = at::zeros(sizes, self.options());
+      return result;
+    }
     in = self;
   } else {
     in = self.reshape({-1});

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -782,10 +782,15 @@ Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
       "tensor with no elements because the operation does not have an identity");
   Tensor in;
   if (dim) {
-    if (self.sizes()[dim.value()] == 1) {
-      auto sizes = self.sizes().vec();
-      sizes.erase(sizes.begin() + dim.value());
-      result = at::zeros(sizes, self.options().dtype(at::kLong));
+    auto sizes = self.sizes();
+    if (sizes[dim.value()] == 1) {
+      if (keepdim) {
+        result = at::zeros(sizes, self.options().dtype(at::kLong));
+      } else {
+        auto sizes_vec = sizes.vec();
+        sizes_vec.erase(sizes_vec.begin() + dim.value());
+        result = at::zeros(sizes_vec, self.options().dtype(at::kLong));
+      }
       return result;
     }
     in = self;
@@ -809,10 +814,15 @@ Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
       "tensor with no elements because the operation does not have an identity");
   Tensor in;
   if (dim) {
-    if (self.sizes()[dim.value()] == 1) {
-      auto sizes = self.sizes().vec();
-      sizes.erase(sizes.begin() + dim.value());
-      result = at::zeros(sizes, self.options().dtype(at::kLong));
+    auto sizes = self.sizes();
+    if (sizes[dim.value()] == 1) {
+      if (keepdim) {
+        result = at::zeros(sizes, self.options().dtype(at::kLong));
+      } else {
+        auto sizes_vec = sizes.vec();
+        sizes_vec.erase(sizes_vec.begin() + dim.value());
+        result = at::zeros(sizes_vec, self.options().dtype(at::kLong));
+      }
       return result;
     }
     in = self;

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -785,7 +785,7 @@ Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
     if (self.sizes()[dim.value()] == 1) {
       auto sizes = self.sizes().vec();
       sizes.erase(sizes.begin() + dim.value());
-      result = at::zeros(sizes, self.options());
+      result = at::zeros(sizes, self.options().dtype(at::kLong));
       return result;
     }
     in = self;
@@ -812,7 +812,7 @@ Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
     if (self.sizes()[dim.value()] == 1) {
       auto sizes = self.sizes().vec();
       sizes.erase(sizes.begin() + dim.value());
-      result = at::zeros(sizes, self.options());
+      result = at::zeros(sizes, self.options().dtype(at::kLong));
       return result;
     }
     in = self;

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -375,7 +375,7 @@ void TensorIterator::propagate_names_to_outputs() {
 }
 
 void TensorIterator::coalesce_dimensions() {
-  if (!resize_outputs_) {
+  if (is_reduction_) {
     return;
   }
   
@@ -643,7 +643,7 @@ void TensorIterator::narrow(int dim, int64_t start, int64_t size) {
   for (auto& op : operands_) {
     op.data = ((char*)op.data) + op.stride_bytes[dim] * start;
   }
-  if (size == 1 && !is_reduction_) {
+  if (size == 1) {
     coalesce_dimensions();
   }
 }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -375,6 +375,10 @@ void TensorIterator::propagate_names_to_outputs() {
 }
 
 void TensorIterator::coalesce_dimensions() {
+  if (!resize_outputs_) {
+    return;
+  }
+  
   if (ndim() <= 1) {
     return;
   }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -375,10 +375,6 @@ void TensorIterator::propagate_names_to_outputs() {
 }
 
 void TensorIterator::coalesce_dimensions() {
-  if (is_reduction_) {
-    return;
-  }
-  
   if (ndim() <= 1) {
     return;
   }
@@ -643,7 +639,7 @@ void TensorIterator::narrow(int dim, int64_t start, int64_t size) {
   for (auto& op : operands_) {
     op.data = ((char*)op.data) + op.stride_bytes[dim] * start;
   }
-  if (size == 1) {
+  if (size == 1 && !is_reduction_) {
     coalesce_dimensions();
   }
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9323,6 +9323,9 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(x.argmax(dim=0), torch.zeros(n, dtype=torch.int64))
         self.assertEqual(x.argmin(dim=0), torch.zeros(n, dtype=torch.int64))
 
+        self.assertEqual(x.argmax(dim=0, keepdim=True), torch.zeros(1, n, dtype=torch.int64))
+        self.assertEqual(x.argmin(dim=0, keepdim=True), torch.zeros(1, n, dtype=torch.int64))
+
     def test_remainder_overflow(self, device):
         # Check Integer Overflows
         x = torch.tensor(23500, dtype=torch.int64, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9317,7 +9317,7 @@ class TestTorchDeviceType(TestCase):
             raise
 
     def test_argminmax_axis_with_dim_one(self, device):
-        # Regression test for gh-38922
+        # See: https://github.com/pytorch/pytorch/issues/38922
         n = 32768
         x = torch.zeros(1, n)
         self.assertEqual(x.argmax(dim=0), torch.zeros(n, dtype=torch.int64))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9316,6 +9316,12 @@ class TestTorchDeviceType(TestCase):
                 raise unittest.SkipTest('Insufficient memory')
             raise
 
+    def test_argminmax_axis_with_dim_one(self, device):
+        # Regression test for gh-38922
+        x = torch.zeros(1, 32768)
+        self.assertEqual(x.argmax(dim=0), torch.zeros(32768, dtype=torch.int64))
+        self.assertEqual(x.argmin(dim=0), torch.zeros(32768, dtype=torch.int64))
+
     def test_remainder_overflow(self, device):
         # Check Integer Overflows
         x = torch.tensor(23500, dtype=torch.int64, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9318,9 +9318,10 @@ class TestTorchDeviceType(TestCase):
 
     def test_argminmax_axis_with_dim_one(self, device):
         # Regression test for gh-38922
-        x = torch.zeros(1, 32768)
-        self.assertEqual(x.argmax(dim=0), torch.zeros(32768, dtype=torch.int64))
-        self.assertEqual(x.argmin(dim=0), torch.zeros(32768, dtype=torch.int64))
+        n = 32768
+        x = torch.zeros(1, n)
+        self.assertEqual(x.argmax(dim=0), torch.zeros(n, dtype=torch.int64))
+        self.assertEqual(x.argmin(dim=0), torch.zeros(n, dtype=torch.int64))
 
     def test_remainder_overflow(self, device):
         # Check Integer Overflows


### PR DESCRIPTION
Fix #38922

# Reproduction 

-  This is correct
```py
>>> torch.zeros(1, 32767).argmax(dim=0) 
tensor([0, 0, 0,  ..., 0, 0, 0])
```

- But this is not
```py
>>> torch.zeros(1, 32768).argmax(dim=0)
tensor([    0,     0,     0,  ..., 31141, 31141, 31141])
```

- Only occurs when the size of the reduced dimension is 1

```py
>>> torch.zeros(2, 327680).argmax(dim=0)
tensor([1, 1, 1,  ..., 1, 1, 1])
>>> torch.zeros(3, 327680).argmax(dim=0)
tensor([2, 2, 2,  ..., 2, 2, 2])
```

- Has something to do with the rest of the dims
```py
>>> torch.zeros(1, 327680).argmax(dim=0)
tensor([     0,      0,      0,  ..., 311296, 311296, 311296])
```
```py
>>> torch.zeros(1, 32768, 10).argmax(dim=0)
tensor([[     0,      0,      0,  ...,      0,      0,      0],
        [     0,      0,      0,  ...,      0,      0,      0],
        [     0,      0,      0,  ...,      0,      0,      0],
        ...,
        [311296, 311296, 311296,  ..., 311296, 311296, 311296],
        [311296, 311296, 311296,  ..., 311296, 311296, 311296],
        [311296, 311296, 311296,  ..., 311296, 311296, 311296]])
```

# Reason

- `resize_outputs_` is set to `false` in `reduce_op`, but the dimension is still coalesced during `TensorIterator::build()`

https://github.com/pytorch/pytorch/blob/899a075b25300460614169394588b22937a900f4/aten/src/ATen/native/TensorIterator.cpp#L703-L715