### PR TITLE
[docs] fix formula `torch.logcumsumexp`

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1420,8 +1420,9 @@ elements of :attr:`input` in the dimension :attr:`dim`.
 
 For summation index :math:`j` given by `dim` and other indices :math:`i`, the result is
 
-.. math::
-    \text{{logcumsumexp}}(x)_{{i}} = \log \cumsum_j \exp(x_{{ij}})
+    .. math::
+        \text{{logcumsumexp}}(x)_{{ij}} = \log \sum\limits_{{j=0}}^{{i}} \exp(x_{{ij}})
+
 Args:
     {input}
     dim  (int): the dimension to do the operation over


### PR DESCRIPTION
Reference : https://github.com/pytorch/pytorch/pull/36308#issuecomment-632282641


After fix: 

![Screenshot from 2020-05-23 15-35-09](https://user-images.githubusercontent.com/19503980/82727956-4bcabb80-9d0b-11ea-85a8-81b35012abbc.png)
