### PR TITLE
Expose VC_YEAR in Windows binary test jobs

### DIFF
--- a/.circleci/scripts/binary_windows_test.sh
+++ b/.circleci/scripts/binary_windows_test.sh
@@ -4,6 +4,7 @@ set -eux -o pipefail
 source "/c/w/env"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
+export VC_YEAR=2017
 
 pushd "$BUILDER_ROOT"
 


### PR DESCRIPTION
To make it configurable  in https://github.com/pytorch/builder/pull/445.