### PR TITLE
Migrate Windows build jobs to VS 2019 for CUDA >= 10.1

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -5,10 +5,15 @@ source "/c/w/env"
 mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
-export VC_YEAR=2017
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
+
+if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+  export VC_YEAR=2017
+else
+  export VC_YEAR=2019
+fi
 
 set +x
 export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}

--- a/.circleci/scripts/binary_windows_test.sh
+++ b/.circleci/scripts/binary_windows_test.sh
@@ -5,6 +5,12 @@ source "/c/w/env"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 
+if [[ "$CUDA_VERSION" == "92" || "$CUDA_VERSION" == "100" ]]; then
+  export VC_YEAR=2017
+else
+  export VC_YEAR=2019
+fi
+
 pushd "$BUILDER_ROOT"
 
 ./windows/internal/smoke_test.bat


### PR DESCRIPTION
This PR relies on https://github.com/pytorch/pytorch/pull/38957 and https://github.com/pytorch/builder/pull/445.
Tested with pytorch/pytorch#38949 and pytorch/pytorch#38956.
Will need a rebase after the dependent commits go in