### PR TITLE
[c10] remove attribute __visibility__ does not apply here warning

### DIFF
--- a/c10/macros/Export.h
+++ b/c10/macros/Export.h
@@ -54,7 +54,7 @@
 #define C10_IMPORT
 #endif
 #else // _WIN32
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__NVCC__)
 #define C10_EXPORT __attribute__((__visibility__("default")))
 #define C10_HIDDEN __attribute__((__visibility__("hidden")))
 #else // defined(__GNUC__)


### PR DESCRIPTION
Summary: Related to https://discuss.pytorch.org/t/tons-of-compiler-warnings-since-pytorch-1-3-0/73670

Test Plan: CI

Differential Revision: D21711682

