### PR TITLE
Fix torch.hub.hub_dir inconsistencies

### DIFF
--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -48,9 +48,9 @@ You can see the full script in
 - Docstring of the function works as a help message. It explains what does the model do and what
   are the allowed positional/keyword arguments. It's highly recommended to add a few examples here.
 - Entrypoint function can either return a model(nn.module), or auxiliary tools to make the user workflow smoother, e.g. tokenizers.
-- Callables prefixed with underscore are considered as helper functions which won't show up in ``torch.hub.list()``.
+- Callables prefixed with underscore are considered as helper functions which won't show up in :func:`torch.hub.list()`.
 - Pretrained weights can either be stored locally in the github repo, or loadable by
-  ``torch.hub.load_state_dict_from_url()``. If less than 2GB, it's recommended to attach it to a `project release <https://help.github.com/en/articles/distributing-large-binaries>`_
+  :func:`torch.hub.load_state_dict_from_url()`. If less than 2GB, it's recommended to attach it to a `project release <https://help.github.com/en/articles/distributing-large-binaries>`_
   and use the url from the release.
   In the example above ``torchvision.models.resnet.resnet18`` handles ``pretrained``, alternatively you can put the following logic in the entrypoint definition.
 
@@ -96,7 +96,7 @@ show docstring and examples through ``torch.hub.help()`` and load the pre-traine
 Running a loaded model:
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Note that ``*args, **kwargs`` in ``torch.load()`` are used to **instantiate** a model.
+Note that ``*args, **kwargs`` in :func:`torch.load()` are used to **instantiate** a model.
 After you loaded a model, how can you find out what you can do with the model?
 A suggested workflow is
 
@@ -117,12 +117,15 @@ The locations are used in the order of
 - ``$XDG_CACHE_HOME/torch/hub``, if environment variable ``XDG_CACHE_HOME`` is set.
 - ``~/.cache/torch/hub``
 
+.. autofunction:: get_dir
+
 .. autofunction:: set_dir
 
 Caching logic
 ^^^^^^^^^^^^^
 
-By default, we don't clean up files after loading it. Hub uses the cache by default if it already exists in ``hub_dir``.
+By default, we don't clean up files after loading it. Hub uses the cache by default if it already exists in the
+directory returned by :func:`~torch.hub.get_dir()`.
 
 Users can force a reload by calling ``hub.load(..., force_reload=True)``. This will delete
 the existing github folder and downloaded weights, reinitialize a fresh download. This is useful

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -571,7 +571,7 @@ class TestHub(TestCase):
     def test_hub_dir(self):
         with tempfile.TemporaryDirectory('hub_dir') as dirname:
             torch.hub.set_dir(dirname)
-            self.assertEqual(torch.hub._get_torch_home(), dirname)
+            self.assertEqual(torch.hub.get_dir(), dirname)
 
 
 class TestHipify(TestCase):


### PR DESCRIPTION
Fixes #38401

* `torch.hub.load_state_dict_from_url()` now also downloads to `$TORCH_HOME/hub/checkpoints` instead of `$TORCH_HOME/checkpoints` like `torch.hub.load()` and others.
* Make `hub_dir` private, add and use `get_dir()` instead.

Also updated docs. Did not see a need for additional unit tests.

