### PR TITLE
Use workspace to persist and restore images for Windows CI build and …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,8 +640,12 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-build.sh
+      - persist_to_workspace:
+          root: "C:/w"
+          paths: build-results
       - store_artifacts:
-          path: build-results
+          path: C:/w/build-results 
+
   pytorch_windows_test:
     <<: *pytorch_windows_params
     parameters:
@@ -675,6 +679,8 @@ jobs:
     executor: <<parameters.executor>>
     steps:
       - checkout
+      - attach_workspace:
+          at: c:/users/circleci/workspace
       - run:
           name: Install VS2017
           command: |

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -239,8 +239,12 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-build.sh
+      - persist_to_workspace:
+          root: "C:/w"
+          paths: build-results
       - store_artifacts:
-          path: build-results
+          path: C:/w/build-results 
+
   pytorch_windows_test:
     <<: *pytorch_windows_params
     parameters:
@@ -274,6 +278,8 @@ jobs:
     executor: <<parameters.executor>>
     steps:
       - checkout
+      - attach_workspace:
+          at: c:/users/circleci/workspace
       - run:
           name: Install VS2017
           command: |

--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -23,6 +23,10 @@ fi
 
 export TMP_DIR="${PWD}/build/win_tmp"
 export TMP_DIR_WIN=$(cygpath -w "${TMP_DIR}")
+export PYTORCH_FINAL_PACKAGE_DIR="/c/w/build-results"
+if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
+    mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
+fi
 
 # This directory is used only to hold "pytorch_env_restore.bat", called via "setup_pytorch_env.bat"
 CI_SCRIPTS_DIR=$TMP_DIR/ci_scripts
@@ -33,7 +37,6 @@ if [ -n "$(ls $CI_SCRIPTS_DIR/*)" ]; then
 fi
 
 export SCRIPT_HELPERS_DIR=$SCRIPT_PARENT_DIR/win-test-helpers
-
 
 $SCRIPT_HELPERS_DIR/build_pytorch.bat
 

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -121,7 +121,7 @@ python setup.py install --cmake && sccache --show-stats && (
   if "%BUILD_ENVIRONMENT%"=="" (
     echo NOTE: To run `import torch`, please make sure to activate the conda environment by running `call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3` in Command Prompt before running Git Bash.
   ) else (
-    7z a %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\torch %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\caffe2 && python %SCRIPT_HELPERS_DIR%\upload_image.py %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z
+    7z a %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\torch %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\caffe2 && copy /Y "%TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z" "%PYTORCH_FINAL_PACKAGE_DIR%\"
   )
 )
 

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -74,7 +74,7 @@ set PYTHONPATH=%TMP_DIR_WIN%\build;%PYTHONPATH%
 
 if NOT "%BUILD_ENVIRONMENT%"=="" (
     pushd %TMP_DIR_WIN%\build
-    python %SCRIPT_HELPERS_DIR%\download_image.py %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z
+    copy /Y %PYTORCH_FINAL_PACKAGE_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z %TMP_DIR_WIN%\
     :: 7z: -aos skips if exists because this .bat can be called multiple times
     7z x %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z -aos
     popd

--- a/.jenkins/pytorch/win-test-helpers/test_python_nn.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_nn.bat
@@ -6,6 +6,8 @@ pushd test
 echo Some smoke tests
 "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe" /i python.exe +sls
 python %SCRIPT_HELPERS_DIR%\run_python_nn_smoketests.py
+if ERRORLEVEL 1 exit /b 1
+
 "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe" /i python.exe -sls
 if ERRORLEVEL 1 exit /b 1
 

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -14,7 +14,8 @@ fi
 
 export TMP_DIR="${PWD}/build/win_tmp"
 export TMP_DIR_WIN=$(cygpath -w "${TMP_DIR}")
-
+export PYTORCH_FINAL_PACKAGE_DIR="/c/users/circleci/workspace/build-results"
+export PYTORCH_FINAL_PACKAGE_DIR_WIN=$(cygpath -w "${PYTORCH_FINAL_PACKAGE_DIR}")
 
 mkdir -p $TMP_DIR/build/torch
 


### PR DESCRIPTION
Inspired by @malfet 

> By the way, once we have build_artifacts property, can someone try if its faster to use it as mean of transferring images between build and test instead of using AWS (i.e. use artifacts instead of jenkins/pytorch/win-test-helpers/upload_image.py /download_image.py pair)

Use CircleCI to store intermediate binaries and make them available to be downloaded as artifacts instead of uploading to S3. 