### PR TITLE
Add index number to THArgCheck error message

### DIFF
--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -118,7 +118,7 @@ __global__ void CatArrayBatchedCopy(
 }
 
 void check_shape_except_dim(const Tensor &first, const Tensor &second,
-                            int dimension)
+                            int dimension, int index)
 {
   int first_dims = first.dim();
   int second_dims = second.dim();
@@ -134,7 +134,8 @@ void check_shape_except_dim(const Tensor &first, const Tensor &second,
     TORCH_CHECK(first_dim_size == second_dim_size,
         "Sizes of tensors must match except in dimension ", dim, ". Got ",
         static_cast<long long>(first_dim_size), " and ",
-        static_cast<long long>(second_dim_size));
+        static_cast<long long>(second_dim_size), " (The offending index is ",
+        index, ")");
   }
 }
 
@@ -349,7 +350,7 @@ Tensor& cat_out_cuda(Tensor& out, TensorList inputs, int64_t dimension) {
     if (should_skip(tensor)) {
       continue;
     }
-    check_shape_except_dim(*notSkippedTensor, tensor, dimension);
+    check_shape_except_dim(*notSkippedTensor, tensor, dimension, i);
     cat_dim_size += at::native::size(tensor, dimension);
   }
 

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -45,9 +45,9 @@ THCTensor_(numel)(THCState *state, THCTensor *t)
 }
 
 void THCTensor_(check_shape_except_dim)(THCState *state,
-    THCTensor *first, THCTensor *second, int dimension);
+    THCTensor *first, THCTensor *second, int dimension, int index);
 inline void THCTensor_(check_shape_except_dim)(THCState *state,
-    THCTensor *first, THCTensor *second, int dimension)
+    THCTensor *first, THCTensor *second, int dimension, int index)
 {
   int first_dims = first->dim();
   int second_dims = second->dim();
@@ -61,8 +61,8 @@ inline void THCTensor_(check_shape_except_dim)(THCState *state,
     int64_t first_dim_size = THCTensor_(size)(state, first, dim);
     int64_t second_dim_size = THCTensor_(size)(state, second, dim);
     THArgCheck(first_dim_size == second_dim_size, 0,
-        "Sizes of tensors must match except in dimension %d. Got %lld and %lld in dimension %d",
-        dimension, (long long)first_dim_size, (long long)second_dim_size, dim);
+        "Sizes of tensors must match except in dimension %d. Got %lld and %lld in dimension %d (The offending index is %d)",
+        dimension, (long long)first_dim_size, (long long)second_dim_size, dim, index);
   }
 }
 


### PR DESCRIPTION
- Resolving the feature introduced in #38652 
- Since the iteration will be terminated once the error occurred, perhaps we can only give the current index which caused the error.