### PR TITLE
Add %= support in TorchScript

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -332,6 +332,7 @@ _(aten, flatten) \
 _(aten, flip) \
 _(aten, floor) \
 _(aten, fmod) \
+_(aten, fmod_) \
 _(aten, frac) \
 _(aten, fractional_max_pool2d) \
 _(aten, fractional_max_pool2d_backward) \

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1237,6 +1237,7 @@ class TestDict(JitTestCase):
             a['b'] -= 12
             a['c'] *= 122
             a['c'] /= 2
+            a['c'] %= 2
             return a
 
         def aug_assign_dict_prim(a):
@@ -1245,6 +1246,7 @@ class TestDict(JitTestCase):
             a['b'] -= 2.4
             a['c'] *= 3.0
             a['c'] /= 2.0
+            a['c'] %= 2.0
             return a
 
         self.checkScript(aug_assign_dict_tensor, (self.dict(),))

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1826,6 +1826,8 @@ struct to_ir {
         return use_inplace_op ? aten::div_ : aten::div;
       case '*':
         return use_inplace_op ? aten::mul_ : aten::mul;
+      case '%':
+        return use_inplace_op ? aten::fmod_ : aten::fmod;
       default:
         throw ErrorReport(stmt)
             << "Unknown augmented assignment: " << kindToString(stmt.aug_op());
@@ -1846,6 +1848,8 @@ struct to_ir {
             std::string("__itruediv__"), std::string("__truediv__"));
       case '*':
         return std::make_pair(std::string("__imul__"), std::string("__mul__"));
+      case '%':
+        return std::make_pair(std::string("__imod__"), std::string("__mod__"));
       default:
         throw ErrorReport(stmt)
             << "Unknown augmented assignment: " << kindToString(stmt.aug_op());

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -79,6 +79,7 @@ namespace jit {
   _(TK_MINUS_EQ, "-=", "-=")                     \
   _(TK_TIMES_EQ, "*=", "*=")                     \
   _(TK_DIV_EQ, "/=", "/=")                       \
+  _(TK_MOD_EQ, "%=", "%=")                       \
   _(TK_GLOBAL, "global", "global")               \
   _(TK_BUILT_IN, "built-in", "")                 \
   _(TK_SUBSCRIPT, "subscript", "")               \

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -73,6 +73,7 @@ struct ParserImpl {
       case TK_MINUS_EQ:
       case TK_TIMES_EQ:
       case TK_DIV_EQ:
+      case TK_MOD_EQ:
       case TK_NEWLINE:
       case '=':
       case ')':
@@ -191,7 +192,8 @@ struct ParserImpl {
       case TK_PLUS_EQ:
       case TK_MINUS_EQ:
       case TK_TIMES_EQ:
-      case TK_DIV_EQ: {
+      case TK_DIV_EQ:
+      case TK_MOD_EQ: {
         int modifier = L.next().text()[0];
         return create_compound(modifier, r, {});
       } break;

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -83,6 +83,7 @@ namespace jit {
 //            | Sub()                                                   TK_MINUS_EQ
 //            | Mul()                                                   TK_TIMES_EQ
 //            | Div()                                                   TK_DIV_EQ
+//            | Mod()                                                   TK_MOD_EQ
 //
 
 // Each subclass of TreeView should provide:
@@ -562,6 +563,7 @@ struct AugAssignKind : public TreeView {
       case '-':
       case '*':
       case '/':
+      case '%':
         return;
       default:
         throw ErrorReport(tree) << "is not a valid AugAssignKind";

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -265,6 +265,7 @@ class StmtBuilder(Builder):
         ast.Sub: '-',
         ast.Mult: '*',
         ast.Div: '/',
+        ast.Mod: '%',
     }
 
     @staticmethod


### PR DESCRIPTION
Fix #38336

Add %= support in TorchScript. It's now possible to do something like:
```py
@torch.jit.script
def mm(a,b):
    a %= b
    return a
```