### PR TITLE
Fix histc with empty tensor error

### DIFF
--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -206,6 +206,10 @@ bool CUDA_tensor_histogram(
   }
   auto totalElements = b.numel();
 
+  if (totalElements == 0) {
+    return false;
+  }
+
   const dim3 block = getApplyBlock();
   dim3 grid;
   int64_t curDevice = current_device();

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11410,6 +11410,10 @@ class TestTorchDeviceType(TestCase):
         # negative nbins throws
         with self.assertRaisesRegex(RuntimeError, 'bins must be > 0'):
             torch.histc(torch.tensor([1], dtype=torch.float, device=device), bins=-1)
+        # empty tensor
+        actual = torch.histc(torch.tensor([], device=device), min=0, max=3)
+        expected = torch.zeros(100, dtype=torch.float, device=device)
+        self.assertEqual(expected, actual)
 
         # without nbins
         actual = torch.histc(


### PR DESCRIPTION
Fix #38979

The error in mentioned #38979 is a [`cudaErrorInvalidConfiguration` error](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3f51e3575c2178246db0a94a430e0038): 
> This indicates that a kernel launch is requesting resources that can never be satisfied by the current device. Requesting more shared memory per block than the device supports will trigger this error, as will requesting too many threads or blocks. See cudaDeviceProp for more device limitations.

This is because we are trying to launch a kernel with block size 0. 