### PR TITLE
Fix attribute warning on gcc

### DIFF
--- a/c10/macros/Export.h
+++ b/c10/macros/Export.h
@@ -113,4 +113,11 @@
 #define TORCH_HIP_API C10_IMPORT
 #endif
 
+// Enums only need to be exported on windows
+#ifdef _WIN32
+#define C10_API_ENUM C10_API
+#else
+#define C10_API_ENUM
+#endif
+
 #endif // C10_MACROS_MACROS_H_

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -9,11 +9,10 @@
 
 namespace c10 {
 
-#ifndef _MSC_VER
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wattributes"
+#ifdef _MSC_VER
+  C10_API
 #endif
-enum class C10_API DebugInfoKind : uint8_t {
+enum class DebugInfoKind : uint8_t {
   PRODUCER_INFO = 0,
   MOBILE_RUNTIME_INFO,
   PROFILER_STATE,
@@ -21,9 +20,6 @@ enum class C10_API DebugInfoKind : uint8_t {
   TEST_INFO, // used only in tests
   TEST_INFO_2, // used only in tests
 };
-#ifndef _MSC_VER
-#  pragma GCC diagnostic pop
-#endif
 
 class C10_API DebugInfoBase {
  public:

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -9,10 +9,7 @@
 
 namespace c10 {
 
-#ifdef _MSC_VER
-  C10_API
-#endif
-enum class DebugInfoKind : uint8_t {
+enum class C10_API_ENUM DebugInfoKind : uint8_t {
   PRODUCER_INFO = 0,
   MOBILE_RUNTIME_INFO,
   PROFILER_STATE,


### PR DESCRIPTION
When building, my log was being spammed with:
```
warning: attribute "__visibility__" does not apply here
```

Which, at least on gcc 7.4 isn't covered by silencing `-Wattribute`. The warning suggests `enum`s don't need to be exported on linux, so I just `ifdef` it out instead.

