### PR TITLE
Fix max_pool2d for returning wrong shape with return_indices=True on cuda

### DIFF
--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -106,18 +106,9 @@ max_pool2d_backward_shape_check(
   check_dim_size(gradOutput, ndim, ndim-2, outputHeight);
   check_dim_size(gradOutput, ndim, ndim-1, outputWidth);
 
-  // different CUDA/CPU behavior from TH
-  if (cuda) {
-    check_dim_size(indices, 4, 0, nbatch);
-    check_dim_size(indices, 4, 1, nOutputPlane);
-    check_dim_size(indices, 4, 2, outputHeight);
-    check_dim_size(indices, 4, 3, outputWidth);
-  }
-  else {
-    check_dim_size(indices, ndim, ndim-3, nOutputPlane);
-    check_dim_size(indices, ndim, ndim-2, outputHeight);
-    check_dim_size(indices, ndim, ndim-1, outputWidth);
-  }
+  check_dim_size(indices, ndim, ndim-3, nOutputPlane);
+  check_dim_size(indices, ndim, ndim-2, outputHeight);
+  check_dim_size(indices, ndim, ndim-1, outputWidth);
 }
 
 // AveragePool2d (backward)

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -445,6 +445,7 @@ void max_pool2d_with_indices_out_cuda_template(
 
   if(input.ndimension() == 3) {
     output.resize_({nInputPlane, outputHeight, outputWidth});
+    indices.resize_({nInputPlane, outputHeight, outputWidth});
   }
 }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9640,19 +9640,23 @@ class TestNNDeviceType(NNTestCase):
     def test_max_pool2d_indices(self, device):
         def helper(n, c, h, w, ks):
             if h is None:
-                x = torch.randn(n, c, w, device='cuda', dtype=torch.float)
+                x = torch.randn(n, c, w, device='cuda', dtype=torch.float, requires_grad=True)
             else:
-                x = torch.randn(n, c, h, w, device='cuda', dtype=torch.float)
+                x = torch.randn(n, c, h, w, device='cuda', dtype=torch.float, requires_grad=True)
 
-            ref_x = x.clone().cpu()
+            ref_x = x.detach().clone().cpu().requires_grad_()
 
             pool = torch.nn.MaxPool2d(kernel_size=ks, return_indices=True)
 
             y, idx = pool(x)
             ref_y, ref_idx = pool(ref_x)
 
+            y.sum().backward()
+            ref_y.sum().backward()
+
             self.assertEqual(y, ref_y)
             self.assertEqual(idx, ref_idx)  # assertEqual implicitly compares shape for tensors
+            self.assertEqual(x.grad, ref_x.grad)
 
         helper(2, 8, 4, 4, ks=2)
         helper(3, 50, None, 50, ks=5)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9636,6 +9636,27 @@ class TestNNDeviceType(NNTestCase):
         helper(10, 512, 31, 31, 3, stride=2)
         helper(1, 129, 8, 8, 3, stride=2)
 
+    @onlyCUDA
+    def test_max_pool2d_indices(self, device):
+        def helper(n, c, h, w, ks):
+            if n is None:
+                x = torch.randn(c, h, w, device='cuda', dtype=torch.float)
+            else:
+                x = torch.randn(n, c, h, w, device='cuda', dtype=torch.float)
+
+            ref_x = x.clone().cpu()
+
+            pool = torch.nn.MaxPool2d(kernel_size=ks, return_indices=True)
+
+            y, idx = pool(x)
+            ref_y, ref_idx = pool(ref_x)
+
+            self.assertEqual(y, ref_y)
+            self.assertEqual(idx, ref_idx) # assertEqual implicitly compares shape for tensors
+
+        helper(2, 8, 4, 4, ks=2)
+        helper(None, 3, 50, 50, ks=5)
+
     def test_embedding_dense_grad(self, device):
         embd = nn.Embedding(20, 20).to(device)
         weight = embd.weight

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9639,8 +9639,8 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     def test_max_pool2d_indices(self, device):
         def helper(n, c, h, w, ks):
-            if h is None:
-                x = torch.randn(n, c, w, device='cuda', dtype=torch.float, requires_grad=True)
+            if n is None:
+                x = torch.randn(c, h, w, device='cuda', dtype=torch.float, requires_grad=True)
             else:
                 x = torch.randn(n, c, h, w, device='cuda', dtype=torch.float, requires_grad=True)
 
@@ -9659,7 +9659,7 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(x.grad, ref_x.grad)
 
         helper(2, 8, 4, 4, ks=2)
-        helper(3, 50, None, 50, ks=5)
+        helper(None, 3, 50, 50, ks=5)
 
     def test_embedding_dense_grad(self, device):
         embd = nn.Embedding(20, 20).to(device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9639,8 +9639,8 @@ class TestNNDeviceType(NNTestCase):
     @onlyCUDA
     def test_max_pool2d_indices(self, device):
         def helper(n, c, h, w, ks):
-            if n is None:
-                x = torch.randn(c, h, w, device='cuda', dtype=torch.float)
+            if h is None:
+                x = torch.randn(n, c, w, device='cuda', dtype=torch.float)
             else:
                 x = torch.randn(n, c, h, w, device='cuda', dtype=torch.float)
 
@@ -9655,7 +9655,7 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(idx, ref_idx)  # assertEqual implicitly compares shape for tensors
 
         helper(2, 8, 4, 4, ks=2)
-        helper(None, 3, 50, 50, ks=5)
+        helper(3, 50, None, 50, ks=5)
 
     def test_embedding_dense_grad(self, device):
         embd = nn.Embedding(20, 20).to(device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9652,7 +9652,7 @@ class TestNNDeviceType(NNTestCase):
             ref_y, ref_idx = pool(ref_x)
 
             self.assertEqual(y, ref_y)
-            self.assertEqual(idx, ref_idx) # assertEqual implicitly compares shape for tensors
+            self.assertEqual(idx, ref_idx)  # assertEqual implicitly compares shape for tensors
 
         helper(2, 8, 4, 4, ks=2)
         helper(None, 3, 50, 50, ks=5)


### PR DESCRIPTION
Fix #38986

The current code only resizes pooling output but forget to resize indices as well. 