### PR TITLE
Adds torch.testing.fixtures, TestCase.compare_with_numpy

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -345,21 +345,21 @@ TEST_WITH_SLOW = os.getenv('PYTORCH_TEST_WITH_SLOW', '0') == '1'
 TEST_SKIP_FAST = os.getenv('PYTORCH_TEST_SKIP_FAST', '0') == '1'
 
 if TEST_NUMPY:
-    import numpy
+    import numpy as np
 
     # Dict of NumPy dtype -> torch dtype (when the correspondence exists)
     numpy_to_torch_dtype_dict = {
-        numpy.bool       : torch.bool,
-        numpy.uint8      : torch.uint8,
-        numpy.int8       : torch.int8,
-        numpy.int16      : torch.int16,
-        numpy.int32      : torch.int32,
-        numpy.int64      : torch.int64,
-        numpy.float16    : torch.float16,
-        numpy.float32    : torch.float32,
-        numpy.float64    : torch.float64,
-        numpy.complex64  : torch.complex64,
-        numpy.complex128 : torch.complex128
+        np.bool       : torch.bool,
+        np.uint8      : torch.uint8,
+        np.int8       : torch.int8,
+        np.int16      : torch.int16,
+        np.int32      : torch.int32,
+        np.int64      : torch.int64,
+        np.float16    : torch.float16,
+        np.float32    : torch.float32,
+        np.float64    : torch.float64,
+        np.complex64  : torch.complex64,
+        np.complex128 : torch.complex128
     }
 
     # Dict of torch dtype -> NumPy dtype
@@ -398,7 +398,7 @@ def skipIfCompiledWithoutNumpy(fn):
         try:
             # The numpy module is present, verify that PyTorch is compiled with
             # numpy support
-            torch.from_numpy(numpy.array([2, 2]))
+            torch.from_numpy(np.array([2, 2]))
         except RuntimeError:
             numpy_support = False
 
@@ -532,7 +532,7 @@ def set_rng_seed(seed):
     torch.manual_seed(seed)
     random.seed(seed)
     if TEST_NUMPY:
-        numpy.random.seed(seed)
+        np.random.seed(seed)
 
 
 @contextlib.contextmanager
@@ -881,6 +881,40 @@ class TestCase(expecttest.TestCase):
 
         return tg
 
+    # Compares the given Torch and NumPy functions on the given tensor-like object.
+    #   if copy_np_result is True then NumPy arrays will be copied before being
+    #     compared with the torch tensor. This is useful if the NumPy array has
+    #     negative strides, which would cause the import to PyTorch to fail.
+    # TODO: support bfloat16 comparisons
+    def compare_with_numpy(self, torch_fn, np_fn, tensor_like, device, dtype, *,
+                           copy_np_result=False):
+        assert TEST_NUMPY
+        assert dtype is not torch.bfloat16
+
+        a = None
+        t = None
+        if isinstance(tensor_like, torch.Tensor):
+            a = tensor_like.detach().cpu().numpy()
+            t = tensor_like
+        else:
+            a = np.array(tensor_like, dtype=torch_to_numpy_dtype_dict[dtype])
+            t = torch.tensor(tensor_like, device=device, dtype=dtype)
+
+        torch_result = torch_fn(t).cpu()
+        np_result = np_fn(a)
+
+        # Coerces NumPy results (where appropriate)
+        if isinstance(torch_result, torch.Tensor) and not isinstance(np_result, np.ndarray):
+            np_result = np.array(np_result)
+        if isinstance(np_result, np.ndarray):
+            np_result = torch.from_numpy(np_result)
+
+        # Copies the NumPy result (if requested)
+        if copy_np_result and isinstance(np_result, np.ndarray):
+            np_result = np_result.copy()
+
+        self.assertEqual(np_result, torch_result)
+
     # Some analysis of tolerance by logging tests from test_torch.py can be found
     # in https://github.com/pytorch/pytorch/pull/32538.
     # dtype name : (rtol, atol)
@@ -1011,10 +1045,10 @@ class TestCase(expecttest.TestCase):
             self.assertEqual(x, y.item(), atol=atol, rtol=rtol, message=message,
                              exact_dtype=exact_dtype, exact_device=exact_device)
         # Tensor x np.bool
-        elif isinstance(x, torch.Tensor) and isinstance(y, numpy.bool_):
+        elif isinstance(x, torch.Tensor) and isinstance(y, np.bool_):
             self.assertEqual(x.item(), y, atol=atol, rtol=rtol, message=message,
                              exact_dtype=exact_dtype, exact_device=exact_device)
-        elif isinstance(y, torch.Tensor) and isinstance(x, numpy.bool_):
+        elif isinstance(y, torch.Tensor) and isinstance(x, np.bool_):
             self.assertEqual(x, y.item(), atol=atol, rtol=rtol, message=message,
                              exact_dtype=exact_dtype, exact_device=exact_device)
         # Tensor x Tensor


### PR DESCRIPTION
This PR adds torch.testing.fixtures, a test helper function for generating interesting input tensors. The eventual goal of this function is to replace most ad-hoc and existing tensor generation methods, like _make_tensor and _make_tensors in test_torch.py, although it's currently missing some necessary functionality to do so. test_isfinite_isinf_isnan in test_torch is updated to make use of the new function and demonstrate its utility. 

The PR also takes _np_compare, an increasingly popular helper, improves upon it and makes it suitable for use in more tests. This should facilitate OSS PRs that compare with NumPy. 