### PR TITLE
Removes pickle deprecation warning

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -1,5 +1,4 @@
 import io
-import warnings
 
 import torch
 from ._utils import _type, _cuda
@@ -31,7 +30,6 @@ class _StorageBase(object):
         return new_storage
 
     def __reduce__(self):
-        warnings.warn("pickle support for Storage will be removed in 1.5. Use `torch.save` instead", FutureWarning)
         b = io.BytesIO()
         torch.save(self, b)
         return (_load_from_bytes, (b.getvalue(),))


### PR DESCRIPTION
As per [this issue](https://github.com/pytorch/pytorch/issues/38597), this is a one-line PR to remove the pickle deprecation warning.

cc @stsievert @driazati 