### PR TITLE
Use a temporary file during ReducerTest

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -2782,7 +2782,8 @@ class ReducerModule(nn.Module):
 @requires_gloo()
 class ReducerTest(TestCase):
     def setUp(self):
-        self.store = c10d.FileStore("/dev/null", 1)
+        self.file = tempfile.NamedTemporaryFile(delete=False)
+        self.store = c10d.FileStore(self.file.name, 1)
         self.process_group = c10d.ProcessGroupGloo(self.store, 0, 1)
 
     def test_single_dtype_single_bucket(self):


### PR DESCRIPTION
Fixes #37558

Use a temporary file instead of `/dev/null` in `ReducerTest`, to prevent the chance of unintended deletion when running as root. It seemed that there were no strong side-effects (running time?) by fixing it at the test level, compared to other solutions that involved modifying the behaviour of `FileStore` (for example, adding an optional flag to avoid auto-deleting the file upon destruction).

Please note this is my first contribution - I have done my best to read the contributing guide and checked for duplicate PRs with no luck, but apologies in advance for any oversights and lack of familiarity with the procedures.

