### PR TITLE
Back out "Install HugePagesArena to optimize pytorch prediction performance"

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -19,13 +19,9 @@ at::DataPtr InefficientStdFunctionContext::makeDataPtr(
 }
 
 C10_API at::Allocator* allocator_array[at::COMPILE_TIME_MAX_DEVICE_TYPES];
-C10_API uint8_t allocator_priority[at::COMPILE_TIME_MAX_DEVICE_TYPES] = {0};
 
-void SetAllocator(at::DeviceType t, at::Allocator* alloc, uint8_t priority) {
-  if (priority >= allocator_priority[static_cast<int>(t)]) {
-    allocator_array[static_cast<int>(t)] = alloc;
-    allocator_priority[static_cast<int>(t)] = priority;
-  }
+void SetAllocator(at::DeviceType t, at::Allocator* alloc) {
+  allocator_array[static_cast<int>(t)] = alloc;
 }
 
 at::Allocator* GetAllocator(const at::DeviceType& t) {

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -199,13 +199,8 @@ struct C10_API InefficientStdFunctionContext {
  *
  *  Also note that this is not thread-safe, and we assume this function will
  *  only be called during initialization.
- *
- *  The 'priority' flag is introduced when we want to overwrite the default
- *  allocator, since the allocators are set statically. The default priority
- *  is 0, which means the lowest. Only higher or equal priority can overwrite
- *  existing ones.
  */
-C10_API void SetAllocator(DeviceType t, Allocator* alloc, uint8_t priority = 0);
+C10_API void SetAllocator(DeviceType t, Allocator* alloc);
 C10_API Allocator* GetAllocator(const DeviceType& t);
 
 template <DeviceType t>

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -189,8 +189,8 @@ at::Allocator* GetCPUAllocator() {
   return GetAllocator(DeviceType::CPU);
 }
 
-void SetCPUAllocator(at::Allocator* alloc, uint8_t priority) {
-  SetAllocator(DeviceType::CPU, alloc, priority);
+void SetCPUAllocator(at::Allocator* alloc) {
+  SetAllocator(DeviceType::CPU, alloc);
 }
 
 // The Mobile CPU allocator must always be present even on non-mobile builds

--- a/c10/core/CPUAllocator.h
+++ b/c10/core/CPUAllocator.h
@@ -57,7 +57,7 @@ C10_API ProfiledCPUMemoryReporter& profiledCPUMemoryReporter();
 C10_API at::Allocator* GetCPUAllocator();
 // Sets the CPU allocator to the given allocator: the caller gives away the
 // ownership of the pointer.
-C10_API void SetCPUAllocator(at::Allocator* alloc, uint8_t priority = 0);
+C10_API void SetCPUAllocator(at::Allocator* alloc);
 
 // Get the Default CPU Allocator
 C10_API at::Allocator* GetDefaultCPUAllocator();


### PR DESCRIPTION
Summary:
Original commit changeset: c006f8b94f28

Original diff: D21258581 had caused regression in ads remote/sigrid predictor service where we observed large number of stuck shards in our canary tiers. Prod wasn't affected as much, but the prod-prospector tier was, which caused us to revert our push to these tiers.

See https://fb.workplace.com/groups/1020366734765818/permalink/2296424243997455/ for more context on how we came about to suspect this diff, especially the part around decay_ms set to a default value of 10 seconds.

I am reverting this entire diff, and not making piecemeal changes here because
- this is a pretty big diff, and I don't want to introduce another bug while making small changes.
- we need to push predictor next week to unblock some critical changes for e2e testing, and predictor push is already a pretty challenging process, so don't want to introduce more uncertainities.

## How did we root cause it to this diff ?

- predictor v100 that was pushed to prod/canary tiers last week had this regression. Reverting to v98 in 1 region immediately got rid of it
- lnyng pointed to this diff in the diff list as a suspect diff
- I built a eph pkg with this diff, and installed it in the PNB canary tier and observed that the tier's metrics recovered.
  - See cumulative shard memory recovering: https://fburl.com/ods/0z7j9qi5 https://pxl.cl/17K9v
  -  and  `tw mem used` to `system mem used` ratio recovering to 1: https://fburl.com/ods/28j9sv8w https://pxl.cl/17K9D

Test Plan: - contbuild

Differential Revision: D21700955

