### PR TITLE
[vulkan] TensorConversions remove explicit vulkan ifs

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -29,13 +29,6 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
     return self;
   }
 
-  if (options.device().type() == DeviceType::Vulkan
-      || self.device().type() == DeviceType::Vulkan) {
-    auto r = at::empty(self.sizes(), options, c10::nullopt);
-    r.copy_(self, non_blocking);
-    return r;
-  }
-
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {
       // Copy all strides
@@ -68,13 +61,6 @@ Tensor to(
   TORCH_CHECK(options.requires_grad_opt() == c10::nullopt,
            "to(options) expects unset requires_grad flag, but got "
            "options.requires_grad set as ", options.requires_grad());
-
-  if (options.device().type() == DeviceType::Vulkan
-      || self.device().type() == DeviceType::Vulkan) {
-    auto r = at::empty(self.sizes(), options, c10::nullopt);
-    r.copy_(self, non_blocking);
-    return r;
-  }
 
   TORCH_CHECK(!options.has_layout() || self.layout() == options.layout(),
            "to(options) doesn't support converting to a different layout, "

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1228,6 +1228,7 @@
   dispatch:
     CPU: empty_strided_cpu
     CUDA: empty_strided_cuda
+    Vulkan: empty_strided_vulkan
 
 - func: erf(Tensor self) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/ATen/native/vulkan/VulkanAten.cpp
+++ b/aten/src/ATen/native/vulkan/VulkanAten.cpp
@@ -53,6 +53,13 @@ at::Tensor empty_vulkan(
   return new_with_vtensor_vulkan(std::move(vt), options);
 }
 
+at::Tensor empty_strided_vulkan(
+    IntArrayRef size,
+    IntArrayRef stride,
+    const TensorOptions& options) {
+  return empty_vulkan(size, options, c10::nullopt);
+}
+
 at::Tensor& copy_from_vulkan_(at::Tensor& self, const at::Tensor& src) {
   TORCH_INTERNAL_ASSERT(
       src.device().type() == DeviceType::Vulkan,


### PR DESCRIPTION
As a follow up for https://github.com/pytorch/pytorch/pull/36491 and last comments on it.

Vulkan uses Strided Layout (at the moment strides are not supported, but in plan)
empty_strided just forwards to empty_vulkan, ignoring strides params.

Removing explicit ifs in TensorConversions that were added before decision to use Strided layout and have not been cleaned after that :(