### PR TITLE
Add type-hint check for default arguments in TorchScript C++ frontend

### DIFF
--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1594,7 +1594,6 @@ void testAutogradSymbols() {
 }
 
 void testDefaultArgTypeHinting() {
-
   const auto text_non_hinted = R"(
 
 def a(x, y=1):
@@ -1619,6 +1618,6 @@ def a(x, y:int=1):
 
   auto cu = compile(text_hinted);
 }
- 
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1593,5 +1593,32 @@ void testAutogradSymbols() {
   TORCH_CHECK(!canRunWithAutograd(node));
 }
 
+void testDefaultArgTypeHinting() {
+
+  const auto text_non_hinted = R"(
+
+def a(x, y=1):
+    print("a1")
+    print("a2")
+    return x
+  )";
+
+  const auto text_hinted = R"(
+
+def a(x, y:int=1):
+    print("a1")
+    print("a2")
+    return x
+  )";
+
+  try {
+    compile(text_non_hinted);
+    ASSERT_TRUE(0);
+  } catch (const std::exception& c) {
+  }
+
+  auto cu = compile(text_hinted);
+}
+ 
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -81,6 +81,7 @@ namespace jit {
   _(LiteInterpreterUpsampleNearest2d)  \
   _(CommonAncestor)                    \
   _(AutogradSymbols)                   \
+  _(DefaultArgTypeHinting)             \
   _(MobileTypeParser)                  \
   _(LiteInterpreterBuiltinFunction)    \
   _(LiteInterpreterPrim)               \

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -253,6 +253,17 @@ std::vector<Argument> ScriptTypeParser::parseArgsFromDecl(
     auto param = *it;
     auto def = param.defaultValue();
     if (def.present()) {
+      if (!param.type().present()) {
+        // We require explicit type-hints for default expressions.
+        // If param doesn't have a type, we could default to "Tensor",
+        // just like what happens in the Python frontend.
+        // However here things are a bit more complicated, because
+        // default expressions are evaluated using a custom-built
+        // graph, and error messages coming out of that in case
+        // the type doesn't match the value are quite obscure.
+        throw ErrorReport(param.range())
+            << "Keyword arguments with defaults need to be type-hinted (TorchScript C++ frontend)";
+      }
       default_types.emplace_back(param.type().get());
       default_exprs.emplace_back(def.get());
     }


### PR DESCRIPTION
This PR fixes #39020 by requiring users to type-hint default arguments to a TorchScript when using the C++ frontend (the Python frontend will insert those automatically).

Since this is a bit of a niche use case, I opted for the simpler solution of making type-hints mandatory for default arguments, as opposed to trying to type-infer them. I left a comment in the code justifying this choice.

Test is included.

/cc @t-vi 