### PR TITLE
Correct Javadoc link to master

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    :caption: Language Bindings
 
    cpp_index
-   packages
+   Javadoc <https://pytorch.org/javadoc/>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Correct Javadoc link to match the 1.4 version: https://github.com/pytorch/pytorch/blob/release/1.4/docs/source/index.rst

