### PR TITLE
Rename `_reset_parameters` to `reset_parameters`

### DIFF
--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -461,6 +461,11 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
       std::string name,
       std::shared_ptr<ModuleType> module);
 
+
+  /// Resets the parameters of the children modules
+  virtual void reset_parameters();
+
+
   /// Registers a submodule with this `Module`.
   ///
   /// This method deals with `ModuleHolder`s.

--- a/torch/csrc/api/include/torch/nn/modules/activation.h
+++ b/torch/csrc/api/include/torch/nn/modules/activation.h
@@ -787,7 +787,7 @@ class TORCH_API MultiheadAttentionImpl
  public:
   void reset() override;
 
-  void _reset_parameters();
+  void reset_parameters();
 
   /// The options with which this `Module` was constructed.
   MultiheadAttentionOptions options;

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -192,6 +192,13 @@ std::vector<std::shared_ptr<Module>> Module::modules(bool include_self) const {
   return result;
 }
 
+void Module::reset_parameters() {
+  for (auto& child : children_) {
+    child.value()->reset_parameters();
+  }
+}
+
+
 OrderedDict<std::string, std::shared_ptr<Module>> Module::named_modules(
     const std::string& name_prefix,
     bool include_self) const {

--- a/torch/csrc/api/src/nn/modules/activation.cpp
+++ b/torch/csrc/api/src/nn/modules/activation.cpp
@@ -481,10 +481,10 @@ void MultiheadAttentionImpl::reset() {
     bias_k = {};
     bias_v = {};
   }
-  _reset_parameters();
+  reset_parameters();
 }
 
-void MultiheadAttentionImpl::_reset_parameters() {
+void MultiheadAttentionImpl::reset_parameters() {
   using namespace torch::nn::init;
   if (_qkv_same_embed_dim) {
     xavier_uniform_(in_proj_weight);

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -802,9 +802,9 @@ class MultiheadAttention(Module):
 
         self.add_zero_attn = add_zero_attn
 
-        self._reset_parameters()
+        self.reset_parameters()
 
-    def _reset_parameters(self):
+    def reset_parameters(self):
         if self._qkv_same_embed_dim:
             xavier_uniform_(self.in_proj_weight)
         else:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -990,6 +990,12 @@ class Module(object):
         for elem in gen:
             yield elem
 
+    def reset_parameters(self):
+        r"""Resets the parameters of the submodules
+        """
+        for name in self._modules:
+            self._modules[name].reset_parameters()
+
     def children(self):
         r"""Returns an iterator over immediate children modules.
 

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -61,7 +61,7 @@ class Transformer(Module):
             decoder_norm = LayerNorm(d_model)
             self.decoder = TransformerDecoder(decoder_layer, num_decoder_layers, decoder_norm)
 
-        self._reset_parameters()
+        self.reset_parameters()
 
         self.d_model = d_model
         self.nhead = nhead
@@ -135,7 +135,7 @@ class Transformer(Module):
         mask = mask.float().masked_fill(mask == 0, float('-inf')).masked_fill(mask == 1, float(0.0))
         return mask
 
-    def _reset_parameters(self):
+    def reset_parameters(self):
         r"""Initiate parameters in the transformer model."""
 
         for p in self.parameters():


### PR DESCRIPTION
When working on a feature that relies on parameter resetting, most of the modules expose a function called `reset_parameters`, however the multi head attention one had it defined as `_reset_parameters` causing a consistency issue.

Is this intentional?

Also should we define an explicit `reset_parameters` in `torch.nn.Module`? so that it provides a well-known API to do such a thing.

This PR adds a basic `reset_parameters` to `torch.nn.Module` that just resets parameters of children modules (thanks @kmaehashi!)