### PR TITLE
Update concatdataset

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -312,6 +312,12 @@ class TestConcatDataset(TestCase):
         self.assertEqual((0, 0), result.get_idxs(0))
         self.assertEqual((0, 1), result.get_idxs(1))
 
+    def test_get_idxs_raises_index_error(self):
+        result = ConcatDataset([[0], [1]])
+        self.assertEqual((0, 2), result.get_idxs(2))
+        with self.assertRaises(IndexError):
+            sample_idx, dataset_idx = result.get_idxs(2)
+            result.datasets[dataset_idx][sample_idx]
 
 # takes in dummy var so this can also be used as a `worker_init_fn`
 def set_faulthander_if_available(_=None):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -306,6 +306,12 @@ class TestConcatDataset(TestCase):
         with self.assertRaisesRegex(AssertionError, "does not support IterableDataset"):
             ConcatDataset([it1, d1])
 
+    def test_get_idxs(self):
+        result = ConcatDataset([[0], [1]])
+        self.assertEqual(2, len(result))
+        self.assertEqual((0, 0), result.get_idxs(0))
+        self.assertEqual((0, 1), result.get_idxs(1))
+
 
 # takes in dummy var so this can also be used as a `worker_init_fn`
 def set_faulthander_if_available(_=None):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -195,6 +195,22 @@ class ConcatDataset(Dataset):
         return self.cumulative_sizes[-1]
 
     def get_idxs(self, idx):
+        r"""Derive dataset and sample indices from global index.
+
+        Arguments:
+            idx (int): global index used to compute dataset and sample index
+
+        Returns:
+            int: sample index inside current dataset
+            int: index to dataset containing current sample
+
+        Example:
+            >>> import torch
+            >>> foo = torch.utils.data.ConcatDataset([[0], [1]])
+            >>> foo.get_idxs(1)
+            (0, 1)
+        """
+
         dataset_idx = bisect.bisect_right(self.cumulative_sizes, idx)
         if dataset_idx == 0:
             sample_idx = idx

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -194,6 +194,15 @@ class ConcatDataset(Dataset):
     def __len__(self):
         return self.cumulative_sizes[-1]
 
+    def get_idxs(self, idx):
+        dataset_idx = bisect.bisect_right(self.cumulative_sizes, idx)
+        if dataset_idx == 0:
+            sample_idx = idx
+        else:
+            sample_idx = idx - self.cumulative_sizes[dataset_idx - 1]
+
+        return sample_idx, dataset_idx
+
     def __getitem__(self, idx):
         if idx < 0:
             if -idx > len(self):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -208,11 +208,7 @@ class ConcatDataset(Dataset):
             if -idx > len(self):
                 raise ValueError("absolute value of index should not exceed dataset length")
             idx = len(self) + idx
-        dataset_idx = bisect.bisect_right(self.cumulative_sizes, idx)
-        if dataset_idx == 0:
-            sample_idx = idx
-        else:
-            sample_idx = idx - self.cumulative_sizes[dataset_idx - 1]
+        sample_idx, dataset_idx = self.get_idxs(idx)
         return self.datasets[dataset_idx][sample_idx]
 
     @property


### PR DESCRIPTION
This PR restructures `ConcatDataset` as per the discussion in #32034, specifically according to [this comment](https://github.com/pytorch/pytorch/issues/32034#issuecomment-573016452)

It introduces a new `get_idxs` that returns the `dataset` and `sample` indices, which are then used by `__getitem__` to return the actual sample.

Resolves #32034