### PR TITLE
Revert "Use old circleci windows image for both CPU and CUDA (#38909)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,14 @@ executors:
   windows-with-nvidia-gpu:
     machine:
       resource_class: windows.gpu.nvidia.medium
-      image: windows-server-2019-nvidia:temporary
+      image: windows-server-2019-nvidia:stable
       shell: bash.exe
 
   windows-cpu-with-nvidia-cuda:
     machine:
       # we will change to CPU host when it's ready
       resource_class: windows.xlarge
-      image: windows-server-2019-vs2019:temporary
+      image: windows-server-2019-vs2019:stable
       shell: bash.exe
 commands:
   # NB: This command must be run as the first command in a job. It

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -18,12 +18,12 @@ executors:
   windows-with-nvidia-gpu:
     machine:
       resource_class: windows.gpu.nvidia.medium
-      image: windows-server-2019-nvidia:temporary
+      image: windows-server-2019-nvidia:stable
       shell: bash.exe
 
   windows-cpu-with-nvidia-cuda:
     machine:
       # we will change to CPU host when it's ready
       resource_class: windows.xlarge
-      image: windows-server-2019-vs2019:temporary
+      image: windows-server-2019-vs2019:stable
       shell: bash.exe


### PR DESCRIPTION
This reverts commit f3f3097a4c54d426cf4a54ba80a9a6f66cdafa17.

