### PR TITLE
Fix Windows binary jobs after migrating to the new circleci image

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -20,8 +20,11 @@ export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}
 export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_S3_BUCKET_V4:-}
 set -x
 
-if [[ "$CIRCLECI" == 'true' && -d "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019" ]]; then
-  rm -rf "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019"
+if [[ "$CIRCLECI" == 'true' && -d "C:\\ProgramData\\Microsoft\\VisualStudio\\Packages\\_Instances" ]]; then
+  mv "C:\\ProgramData\\Microsoft\\VisualStudio\\Packages\\_Instances" .
+  rm -rf "C:\\ProgramData\\Microsoft\\VisualStudio\\Packages"
+  mkdir -p "C:\\ProgramData\\Microsoft\\VisualStudio\\Packages"
+  mv _Instances "C:\\ProgramData\\Microsoft\\VisualStudio\\Packages"
 fi
 
 echo "Free space on filesystem before build:"


### PR DESCRIPTION
We cannot remove the VS2019 installation anymore because `VS 2019 BuildTools` is installed in the new image. So alternatively for getting more disk space, we could just remove the cached packages. But be careful that we need to preserve `_Instances`, otherwise, vswhere won't be able to detect installed vs builds.