### PR TITLE
Avoid defining bogus CPPTypeAndStdComplexToScalarType<void> by using some decltype tricks.

### DIFF
--- a/aten/src/ATen/native/TensorIteratorDynamicCasting.h
+++ b/aten/src/ATen/native/TensorIteratorDynamicCasting.h
@@ -65,15 +65,6 @@ struct CPPTypeAndStdComplexToScalarType<thrust::complex<double>> {
 };
 #endif
 
-// this is needed to work around the lack of a real "constexpr if" -- this is used
-// to avoid/delay the computation of a type that isn't available in one of the if/else
-// clauses.  An alternative would be to define a <void> version of
-// CPPTypeAndStdComplexToScalarType with the downside risk of mistakenly matching on Undefined.
-template<typename T, typename U>
-struct throw_away_first_type {
-  using type = U;
-};
-
 }} //namespace cppmap::detail
 
 // `needs_dynamic_casting` compares the types expected by iterator
@@ -104,7 +95,7 @@ struct needs_dynamic_casting<func_t, 0> {
         using result_type = typename traits::result_type;
         using map  = typename cppmap::detail::CPPTypeAndStdComplexToScalarType<result_type>;
         // decltype(_) is used to delay computation
-        using dtype = typename cppmap::detail::throw_away_first_type<decltype(_), map>::type;
+        using dtype = typename decltype(_)::template type_identity<map>;
         return iter.dtype(0) != dtype::value();
       }
     );


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39071 Avoid defining bogus CPPTypeAndStdComplexToScalarType<void> by using some decltype tricks.**
* #38817 Add dynamic_cast asserts to CPU Loops.
* #38815 Support void return type in TensorIteratorDynamicCasting checks.
* #38813 Move needs_dynamic_casting to a non-CUDA specific file.
* #38810 Improve error checking of CUDALoops.
* #38809 Improve cpu/Loops.h arity asserts.

Differential Revision: [D21744142](https://our.internmc.facebook.com/intern/diff/D21744142)