### PR TITLE
[vulkan] batch_norm no-op

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -435,14 +435,18 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
              std::make_tuple(1));
   }
 
+  Tensor reserve = at::empty({0}, input.options().dtype(kByte));
+
   bool use_vulkan = input.is_vulkan();
   if (use_vulkan) {
     return std::tuple_cat(
-              at::native::vulkan_batch_norm_noop(input, weight, bias, running_mean, running_var, momentum, eps),
+              at::native::batch_norm_vulkan(
+                input, weight, bias,
+                running_mean, running_var,
+                training, momentum, eps),
+              std::tuple<Tensor>(reserve),
               std::make_tuple(3));
   }
-
-  Tensor reserve = at::empty({0}, input.options().dtype(kByte));
 
   bool use_miopen = (input.is_cuda()
                && input.dim() <= MIOPEN_DIM_MAX

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2191,6 +2191,7 @@
     CPU: batch_norm_cpu
     CUDA: batch_norm_cuda
     MkldnnCPU: mkldnn_batch_norm
+    Vulkan: batch_norm_vulkan
 
 - func: native_batch_norm.out(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, *, Tensor(a!) out, Tensor(b!) save_mean, Tensor(c!) save_invstd) -> (Tensor(a!), Tensor(b!), Tensor(c!))
   dispatch:

--- a/aten/src/ATen/native/vulkan/VulkanAten.cpp
+++ b/aten/src/ATen/native/vulkan/VulkanAten.cpp
@@ -315,5 +315,19 @@ Tensor mean_vulkan(
   return new_with_vtensor_vulkan(std::move(output), self.options());
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+vulkan_batch_norm_noop(
+    const at::Tensor& input,
+    const at::Tensor& weight /* optional */,
+    const at::Tensor& bias /* optional */,
+    const at::Tensor& running_mean /* optional */,
+    const at::Tensor& running_var /* optional */,
+    double momentum,
+    double eps) {
+  at::Tensor save_mean, save_var;
+  auto reserve = at::empty({0}, input.options().dtype(kByte));
+  return std::make_tuple(input, save_mean, save_var, reserve);
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/vulkan/VulkanAten.cpp
+++ b/aten/src/ATen/native/vulkan/VulkanAten.cpp
@@ -315,18 +315,17 @@ Tensor mean_vulkan(
   return new_with_vtensor_vulkan(std::move(output), self.options());
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
-vulkan_batch_norm_noop(
-    const at::Tensor& input,
-    const at::Tensor& weight /* optional */,
-    const at::Tensor& bias /* optional */,
-    const at::Tensor& running_mean /* optional */,
-    const at::Tensor& running_var /* optional */,
+std::tuple<Tensor, Tensor, Tensor> batch_norm_vulkan(
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    const Tensor& running_mean,
+    const Tensor& running_var,
+    bool train,
     double momentum,
     double eps) {
-  at::Tensor save_mean, save_var;
-  auto reserve = at::empty({0}, input.options().dtype(kByte));
-  return std::make_tuple(input, save_mean, save_var, reserve);
+  Tensor save_mean, save_var;
+  return std::make_tuple(input, save_mean, save_var);
 }
 
 } // namespace native

--- a/aten/src/ATen/native/vulkan/VulkanAten.h
+++ b/aten/src/ATen/native/vulkan/VulkanAten.h
@@ -27,5 +27,17 @@ at::Tensor vulkan_convolution_prepacked(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups);
+
+// No-op batch norm at the moment to be able to profile models with batch_norm
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+vulkan_batch_norm_noop(
+    const at::Tensor& input,
+    const at::Tensor& weight /* optional */,
+    const at::Tensor& bias /* optional */,
+    const at::Tensor& running_mean /* optional */,
+    const at::Tensor& running_var /* optional */,
+    double momentum,
+    double eps);
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/vulkan/VulkanAten.h
+++ b/aten/src/ATen/native/vulkan/VulkanAten.h
@@ -29,13 +29,13 @@ at::Tensor vulkan_convolution_prepacked(
     int64_t groups);
 
 // No-op batch norm at the moment to be able to profile models with batch_norm
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
-vulkan_batch_norm_noop(
-    const at::Tensor& input,
-    const at::Tensor& weight /* optional */,
-    const at::Tensor& bias /* optional */,
-    const at::Tensor& running_mean /* optional */,
-    const at::Tensor& running_var /* optional */,
+std::tuple<Tensor, Tensor, Tensor> batch_norm_vulkan(
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    const Tensor& running_mean,
+    const Tensor& running_var,
+    bool train,
     double momentum,
     double eps);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39115 [vulkan] Conv2d with optional clamp
* **#39079 [vulkan] batch_norm no-op**
* #39078 [vulkan] addmm support non-vulkan inputs
* #39077 [vulkan] VulkanTensor, add strides in interface
* #39076 [vulkan] speed_becnhmark_torch add vulkan arg to use Vulkan backend

The plan for Vulkan and batch_norm - to fuse it inside models as linear op, it is not done yet.

For profiling and working on torchscript mobilenetV2 on Vulkan backend we need stub for batch_norm.
This is noop - input goes to output.
