### PR TITLE
Automatic update of fbcode/onnx to eae3eb8c61cf5ad27cc9a416dbdc5274982385a6

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -103,10 +103,13 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_less_equal.*'  # unsupported case
                      '|test_max_.*'  # unsupported case
                      '|test_min_.*'  # unsupported case
+                     '|test_.*momentum_.*'  # unsupported case
                      '|test_mean_square_distance_.*'  # unsupported case
                      '|test_softmax_cross_entropy.*'  # unsupported case
                      '|test_unfoldtodepth.*'  # unsupported case
                      '|test_.*gradient.*'  # no support for gradient op in c2-onnx
+                     '|test_.*adagrad.*'  # no support for gradient op in c2-onnx
+                     '|test_.*loss.*'  # no support for loss op in c2-onnx
                      ')')
 
 # Quick patch to unbreak master CI, is working on the debugging.
@@ -122,6 +125,7 @@ backend_test.exclude('(test_cast_.*'
 
 # Temporarily skip some ONNX backend tests with broadcasting.
 backend_test.exclude('(test_pow_bcast'
+                     '|test_pow_types.*'
                      ')')
 
 # Skip vgg to speed up CI


### PR DESCRIPTION
Summary:
Previous import was 79a7e0df7e86e0f32e7a05f563b24a566540c18b

Included changes:
- **[eae3eb8c](https://github.com/onnx/onnx/commit/eae3eb8c)**: Use cmake GNUInstallDirs (#2661) <Gustavo Alvarez>
- **[106821e9](https://github.com/onnx/onnx/commit/106821e9)**: Update sequence test case so input is not scalar and splits are specified (#2675) <Scott McKay>
- **[e094e101](https://github.com/onnx/onnx/commit/e094e101)**: Remove unnecessary copies and std::move (#2684) <Changming Sun>
- **[71145275](https://github.com/onnx/onnx/commit/71145275)**: Update Batchnorm test (#2674) <Lara Haidar>
- **[da13be2d](https://github.com/onnx/onnx/commit/da13be2d)**: Rename OPTIONAL to OPTIONAL_VALUE (#2682) <Changming Sun>
- **[2987fa06](https://github.com/onnx/onnx/commit/2987fa06)**: Adding CI for ONNX Debug mode (Linux, OSX) (#2651) <Vinitra Swamy>
- **[46fe392d](https://github.com/onnx/onnx/commit/46fe392d)**: Update Pow input types in Opset 12 (#2666) <Lara Haidar>
- **[ac1caf3b](https://github.com/onnx/onnx/commit/ac1caf3b)**: Change type of label tensor to int32/int64 in SoftmaxCrossEntropyLoss spec. (#2667) <M. Zeeshan Siddiqui>
- **[c2fefcbf](https://github.com/onnx/onnx/commit/c2fefcbf)**: [Training] SG with Momentum Optimizer (#1959) <Wei-Sheng Chin>
- **[8d15705e](https://github.com/onnx/onnx/commit/8d15705e)**: [Training] Add Adagrad optimizer operator (#1955) <Wei-Sheng Chin>
- **[94b01cdd](https://github.com/onnx/onnx/commit/94b01cdd)**: Suppress a warning in unsqueeze (#2637) <Hong Xu>
- **[0582d526](https://github.com/onnx/onnx/commit/0582d526)**: Fix Greater/LessOrEqual function definition (#2645) <Takeshi Watanabe>
- **[b852d819](https://github.com/onnx/onnx/commit/b852d819)**: Increment version number to 1.7.0 (#2639) <Chin Huang>
- **[ff4bb553](https://github.com/onnx/onnx/commit/ff4bb553)**: Regenerate Min test data (#2644) <Takeshi Watanabe>

Test Plan: ci

Differential Revision: D21750299

