### PR TITLE
[v1.5.1 patch] Restore thread_local states in continuation thread on RPC servers

### DIFF
--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -208,6 +208,10 @@ int64_t DistAutogradContainer::getMaxId() {
   return max_id_;
 }
 
+void DistAutogradContainer::forceCurrentContextId(int64_t contextId) {
+  current_context_id_ = contextId;
+}
+
 void DistAutogradContainer::setCurrentContextId(int64_t contextId) {
   TORCH_INTERNAL_ASSERT(
       current_context_id_ == kInvalidContextId,
@@ -222,6 +226,10 @@ void DistAutogradContainer::clearCurrentContext() {
 size_t DistAutogradContainer::numAutogradContexts() const {
   std::lock_guard<std::mutex> guard(autograd_context_lock_);
   return autograd_context_.size();
+}
+
+int64_t DistAutogradContainer::currentContextId() {
+  return current_context_id_;
 }
 
 } // namespace autograd

--- a/torch/csrc/distributed/autograd/context/container.h
+++ b/torch/csrc/distributed/autograd/context/container.h
@@ -73,6 +73,11 @@ class TORCH_API DistAutogradContainer {
   // Retrieves the worker ID for this node
   rpc::worker_id_t getWorkerId() const;
 
+  // Forcibly sets the thread local current context id. Should only be used in
+  // cases where you know what you're doing and need to override the thread
+  // local. Otherwise, use setCurrentContextId instead.
+  static void forceCurrentContextId(int64_t contextId);
+
   // Can set current context id if there is no valid context yet
   void setCurrentContextId(int64_t contextId);
 
@@ -81,6 +86,9 @@ class TORCH_API DistAutogradContainer {
 
   // Returns the number of autograd contexts in the container.
   size_t numAutogradContexts() const;
+
+  // Returns the current thread local context id for this thread.
+  static int64_t currentContextId();
 
  private:
   DistAutogradContainer();

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -73,16 +73,18 @@ std::unique_ptr<RpcCommandBase> deserializePythonRpcCommand(
 // When request message has autograd info, processMessage() will set up valid
 // current context id properly. This struct is used to clean up current context
 // id after processMessage() is done.
-struct ClearAutogradContextGuard {
-  ClearAutogradContextGuard() = default;
-  ~ClearAutogradContextGuard() {
-    clear();
+struct DistAutogradContextGuard {
+  explicit DistAutogradContextGuard(int64_t ctxId) {
+    auto& container = DistAutogradContainer::getInstance();
+    prevCtxId_ = container.currentContextId();
+    container.forceCurrentContextId(ctxId);
+  }
+  ~DistAutogradContextGuard() {
+    auto& container = DistAutogradContainer::getInstance();
+    container.forceCurrentContextId(prevCtxId_);
   }
 
-  void clear() {
-    auto& autogradContainer = DistAutogradContainer::getInstance();
-    autogradContainer.clearCurrentContext();
-  }
+  int64_t prevCtxId_;
 };
 
 } // anonymous namespace
@@ -358,7 +360,8 @@ void RequestCallbackImpl::processRpc(
           autogradContext != nullptr,
           "autogradContext is nullptr, FORWARD_AUTOGRAD_REQ should always get "
           "or create valid autogradContext in addRecvRpcBackward.");
-      autogradContainer.setCurrentContextId(autogradContext->contextId());
+
+      DistAutogradContextGuard ctxGuard(autogradContext->contextId());
 
       // Process the original RPC.
       auto wrappedMessageType = rpcWithAutograd.wrappedMessageType();
@@ -376,9 +379,24 @@ void RequestCallbackImpl::processRpc(
       // The original future needs to be marked as completed when the wrapped
       // one completes, with the autograd context information wrapped.
       wrappedRpcResponseFuture->addCallback(
-          [responseFuture, messageId, fromWorkerId, wrappedRpcResponseFuture](
+          [responseFuture,
+           messageId,
+           fromWorkerId,
+           wrappedRpcResponseFuture,
+           ctxId = autogradContext->contextId()](
               const Message& /* unused */,
               const c10::optional<utils::FutureError>& error) {
+            // As this callback can be invoked by a different thread, we have to
+            // make sure that the thread_local states in the previous thread is
+            // correctly propagated.
+            // NB: The execution of TorchScript functions can also run on a
+            // different thread, which is addressed by
+            // https://github.com/pytorch/pytorch/pull/36395
+            // NB: when adding async UDF support, we should also propagate
+            // thread_local states there.
+            // TODO: Land on a general solution for RPC ThreadLocalState. See
+            // https://github.com/pytorch/pytorch/issues/38510
+            DistAutogradContextGuard cbCtxGuard(ctxId);
             if (error) {
               // Propagate error to responseFuture if we had one.
               responseFuture->setError(error->what());
@@ -473,9 +491,6 @@ std::shared_ptr<FutureMessage> RequestCallbackImpl::processMessage(
             const bool& /*unused*/,
             const c10::optional<utils::FutureError>& /*unused*/) {
           try {
-            // For a recv thread, current context id should be invalid outside
-            // processMessage().
-            ClearAutogradContextGuard guard;
             processRpc(*rpc, messageType, id, retFuture);
           } catch (py::error_already_set& e) {
             retFuture->markCompleted(handleError(e, messageType, id));


### PR DESCRIPTION
This is a commit to merge #38512 into the 1.5.1 release. Thread-local distributed autograd context propagation when it jumps across threads. #38512 is landed into master at f39222a.

---- Original Commit Description Follows ----

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/38512

As we gradually making the RPC non-blocking on server side, the
processing of the same request can yield-run on different threads.
Hence, we need to populate thread_local states (e.g., ctx id) in
the continuation thread.

Fixes #38439

Test Plan: Imported from OSS

Differential Revision: D21583642

Pulled By: mrshenli

fbshipit-source-id: a79bce1cb207fd11f1fa02b08465e49badda65fc

