### PR TITLE
[nnpi eval] enable int8 eval with emulation Int8FC

### DIFF
--- a/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
+++ b/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
@@ -59,7 +59,6 @@ class Int8QuantizeNNPIOp final : public Operator<CPUContext> {
   using Operator<CPUContext>::Operator;
 
   bool RunOnDevice() override {
-    LOG(INFO) << "In int8Quantize op";
     const auto& X = Input(0);
     auto* Y = Outputs()[0]->template GetMutable<Int8TensorCPU>();
     Y->t.ResizeLike(X);

--- a/caffe2/opt/custom/fakefp16_transform.cc
+++ b/caffe2/opt/custom/fakefp16_transform.cc
@@ -23,6 +23,8 @@ std::unordered_map<std::string, std::string> getFakeFp16OpMapping(
   std::unordered_map<std::string, std::string> fake_fp16_op_conversion_map = {
       {"FC", "Fp16FCAcc32NNPI"},
       {"Int8FC", "Int8FCFakeAcc32NNPI"},
+      {"Int8Quantize", "Int8QuantizeNNPI"},
+      {"Int8Dequantize", "Int8DequantizeNNPI"},
       {"FbFCPacked", "Fp16FCAcc32NNPI"},
       {"SparseLengthsSum", "SparseLengthsSumFakeFP16AccFP16"},
       {"SparseLengthsWeightedSum", "SparseLengthsWeightedSumFakeFP16AccFP16"},


### PR DESCRIPTION
Summary: Allow int8 packed weights in int8 model to deserialize to original format. Set default deserialization behavior in eval workflows to original format.

Test Plan: Tested with workflow: f192797187

Differential Revision: D21737940

