### PR TITLE
[JIT] Infer NamedTuple type attributes of nn.Modules correctly

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -486,6 +486,27 @@ class TestScriptPy3(JitTestCase):
                 if True:
                     x : Optional[int] = 7
 
+    def test_named_tuple_as_attribute(self):
+        """
+        Test named tuples as attributes of modules.
+        """
+        global Params
+
+        class Params(NamedTuple):
+            p1: float
+            p2: int
+
+        class MyModule(torch.nn.Module):
+            def __init__(self, params):
+                super().__init__()
+                self.params = params
+
+            def forward(self):
+                return self.params.p1
+
+        params = Params(1.0, 2)
+        self.checkModule(MyModule(params), ())
+
     def test_export_opnames_interface(self):
         global OneTwoModule
 

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -203,6 +203,10 @@ struct TORCH_API CompilationUnit {
     return classes_[it->second];
   }
 
+  bool has_type(const c10::QualifiedName& name) const {
+    return classDict_.find(name) != classDict_.end();
+  }
+
   // For testing: clear all Python-defined classes to ensure that unit tests
   // have isolation.
   void _clear_python_cu() {

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -297,6 +297,14 @@ inline InferredType tryToInferType(py::handle input) {
       TORCH_INTERNAL_ASSERT(class_type);
       return InferredType(class_type);
     }
+
+    // Check if it is a NamedTuple.
+    auto named_tuple_type = py::cast<TupleTypePtr>(
+        py::module::import("torch._jit_internal")
+            .attr("try_make_named_tuple_type")(input.get_type(), input, true));
+    if (named_tuple_type) {
+      return InferredType(named_tuple_type);
+    }
   }
 
   if (py::isinstance<Object>(input)) {

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -628,54 +628,15 @@ std::shared_ptr<SugaredValue> BooleanDispatchValue::call(
 }
 
 bool isNamedTupleClass(const py::object& obj) {
-  auto tuple_type = reinterpret_cast<PyObject*>(&PyTuple_Type);
-  return PyObject_IsSubclass(obj.ptr(), tuple_type) &&
-      py::hasattr(obj, "_fields");
+  return py::cast<bool>(
+      py::module::import("torch._jit_internal").attr("is_named_tuple")(obj));
 }
 
 TypePtr registerNamedTuple(const py::object& obj, const SourceRange& loc) {
   TORCH_INTERNAL_ASSERT(isNamedTupleClass(obj));
-  auto qualifiedName = c10::QualifiedName(py::cast<std::string>(
-      py::module::import("torch.jit").attr("_qualified_name")(obj)));
-  // Currently don't support default values
-  if (py::hasattr(obj, "_field_defaults")) {
-    auto default_dict = py::cast<std::map<std::string, py::object>>(
-        py::getattr(obj, "_field_defaults"));
-    if (default_dict.size()) {
-      std::string error_msg =
-          "Default values are currently not supported"
-          " on NamedTuple fields in TorchScript. Fields "
-          "with default values: [";
-      bool first = true;
-      for (const auto& kv : default_dict) {
-        if (!first) {
-          error_msg += ", ";
-        }
-        error_msg += kv.first;
-      }
-      error_msg += "]";
-      throw ErrorReport(loc) << error_msg;
-    }
-  }
-
-  py::object props =
-      py::module::import("torch.jit").attr("_get_named_tuple_properties")(obj);
-  std::string unqualName;
-  std::vector<std::string> fields;
-  std::vector<TypePtr> annotations;
-  std::tie(unqualName, fields, annotations) = py::cast<
-      std::tuple<std::string, decltype(fields), decltype(annotations)>>(props);
-
-  auto tt = TupleType::createNamed(qualifiedName, fields, annotations);
-  if (auto type = get_python_cu()->get_type(qualifiedName)) {
-    TORCH_CHECK(
-        type->isSubtypeOf(tt),
-        "Can't to redefine NamedTuple: ",
-        tt->repr_str());
-    return type;
-  }
-  get_python_cu()->register_type(tt);
-  return tt;
+  return py::cast<TypePtr>(
+      py::module::import("torch._jit_internal")
+          .attr("try_make_named_tuple_type")(obj, nullptr, loc));
 }
 
 std::shared_ptr<SugaredValue> toSugaredValue(

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1066,7 +1066,17 @@ void initJitScriptBindings(PyObject* module) {
       .def(
           "get_interface",
           [](const std::shared_ptr<CompilationUnit>& self,
-             const std::string& name) { return self->get_interface(name); });
+             const std::string& name) { return self->get_interface(name); })
+      .def(
+          "get_type",
+          [](CompilationUnit& cu, const std::string& name) {
+            return cu.get_type(name);
+          })
+      .def(
+          "register_type",
+          [](CompilationUnit& cu, const c10::NamedTypePtr& type) {
+            cu.register_type(type);
+          });
 
   py::class_<StrongFunctionPtr>(m, "ScriptFunction", py::dynamic_attr())
       .def(


### PR DESCRIPTION
**Summary**
This commit modifies type inference for `nn.Module` instance attributes
such that the type of a `NamedTuple` attribute is inferred correctly and
such that the field names of this `NamedTuple` instance can be used in
scripted methods. At present, the type of this attribute is inferred to be
`Tuple[T, U, ..., V]`, so the field must be referred to by index and
cannot be referred to by name.

**Test Plan**
This commit adds a unit test to test that a field of a `NamedTuple`
attribute can be referred to by name in a scripted method.

**Fixes**
This commit fixes #37668.
