### PR TITLE
Fix compilation error for CUDA supported

### DIFF
--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -72,7 +72,7 @@ class CudaFusionManager {
       graph_cache_[repr] = kernel_id;
 
       // create entry for cached kernel;
-      kernel_cache_.insert({kernel_id, CudaKernelCache()});
+      kernel_cache_.insert(std::make_pair(std::move(kernel_id), CudaKernelCache()));
 
       // TODO: we should compile here using profiled information:
       //       size (range) / stride (contiguity)


### PR DESCRIPTION
Following the latest README #38977, illegal `unique-ptr` copy error occurs when I am trying to compile pytorch from source with CUDA 10.2 supported.
The new line is more compatible.
The code has passed with CUDA 10.2, GCC-5.4, C++14, Ubuntu 16.04.

