### PR TITLE
Improve random sampling & random generator docs

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -34,7 +34,7 @@ Creation Ops
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
-    Random sampling creation ops are listed under :ref:`random-sampling` and
+    Random sampling creation ops are listed under :ref:`random-sampling-creation` and
     include:
     :func:`torch.rand`
     :func:`torch.rand_like`
@@ -146,6 +146,8 @@ Random seeds
     get_rng_state
     set_rng_state
 
+
+.. _random-sampling-creation:
 
 Random sampling creation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -114,23 +114,16 @@ Generators
 
     Generator
 
-:data:`torch.default_generator` returns the default CPU :class:`Generator`
+:data:`torch.default_generator` returns the default CPU :class:`Generator`.
+:data:`torch.cuda.default_generators` returns a tuple of default CUDA :class:`Generator`-s if cuda is available. 
+The number of CUDA :class:`Generator`-s returned is equal to the number of GPUs available in the system.
 
 Example::
 
-    >>> g_cpu = torch.default_generator
-    >>> g_cpu.device
+    >>> torch.default_generator.device
     device(type='cpu')
-
-:data:`torch.cuda.default_generators` returns a tuple of default CUDA :class:`Generator`-s if cuda is available.
-                The number of CUDA :class:`Generator`-s returned is equal to the number of
-                GPUs available in the system.
-
-Example::
-
     >>> torch.cuda.init()
-    >>> g_cuda = torch.cuda.default_generators
-    >>> g_cuda[0].device
+    >>> torch.cuda.default_generators[0].device
     device(type='cuda', index=0)
 
 Random seeds

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -98,20 +98,44 @@ Indexing, Slicing, Joining, Mutating Ops
     unsqueeze
     where
 
+.. _random-sampling:
+
+Random sampling
+----------------------------------
+
 .. _generators:
 
 Generators
-----------------------------------
+~~~~~~~~~~
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     Generator
 
-.. _random-sampling:
+:data:`torch.default_generator` returns the default CPU :class:`Generator`
 
-Random sampling
-----------------------------------
+Example::
+
+    >>> g_cpu = torch.default_generator
+    >>> g_cpu.device
+    device(type='cpu')
+
+:data:`torch.cuda.default_generators` returns a tuple of default CUDA :class:`Generator`-s if cuda is available.
+                The number of CUDA :class:`Generator`-s returned is equal to the number of
+                GPUs available in the system.
+
+Example::
+
+    >>> torch.cuda.init()
+    >>> g_cuda = torch.cuda.default_generators
+    >>> g_cuda[0].device
+    device(type='cuda', index=0)
+
+Random Seeds
+~~~~~~~~~~~~
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -122,15 +146,10 @@ Random sampling
     get_rng_state
     set_rng_state
 
-.. autoattribute:: torch.default_generator
-   :annotation:  Returns the default CPU torch.Generator
 
-.. The following doesn't actually seem to exist.
-   https://github.com/pytorch/pytorch/issues/27780
-   .. autoattribute:: torch.cuda.default_generators
-      :annotation:  If cuda is available, returns a tuple of default CUDA torch.Generator-s.
-                    The number of CUDA torch.Generator-s returned is equal to the number of
-                    GPUs available in the system.
+Random Sampling Creation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. autosummary::
     :toctree: generated
     :nosignatures:

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -133,7 +133,7 @@ Example::
     >>> g_cuda[0].device
     device(type='cuda', index=0)
 
-Random Seeds
+Random seeds
 ~~~~~~~~~~~~
 
 .. autosummary::
@@ -147,7 +147,7 @@ Random Seeds
     set_rng_state
 
 
-Random Sampling Creation
+Random sampling creation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::


### PR DESCRIPTION
Fixes #27780 

# Motivation

The [docs for torch.default_generator](https://pytorch.org/docs/master/torch.html#torch.torch.default_generator) looks pretty odd in master and resides in between seeding functions and distribution functions instead of the "Generators" section.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6421097/82466172-ae128a80-9a85-11ea-9547-9ea72dc74b08.png) | ![image](https://user-images.githubusercontent.com/6421097/83138547-930ccf80-a0b0-11ea-8b10-ac3019d6d5c1.png) | 




# Changes in this PR

- Move "Generator" as a subsection of "Random sampling"
- Document `torch.cuda.default_generators` 
- Add examples for `torch.default_generator` and `torch.cuda.default_generators
- Move `torch.default_generator` and `torch.cuda.default_generators` to "Generators"
- Add subtitle "Random seeds" for `seed`, `manual_seed`, `initial_seed`, `get_rng_state`, `set_rng_state`
- Add subtitle `Random sampling creation` for a bunch of random creation ops. 
