### PR TITLE
Overload `__str__` & `__repr__ ` for `SourceRange`

### DIFF
--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -83,7 +83,8 @@ void initTreeViewBindings(PyObject* module) {
             self.highlight(stream);
             return stream.str();
           })
-      .def("__str__", [](const SourceRange& self) { return self.text(); })
+      .def("__str__", [](const SourceRange& self) { return self.str(); })
+      .def("__repr__", [](const SourceRange& self) { return self.str(); })
       .def_property_readonly("start", &SourceRange::start)
       .def_property_readonly("end", &SourceRange::end);
   py::class_<SourceRangeFactory>(m, "SourceRangeFactory")

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -83,11 +83,7 @@ void initTreeViewBindings(PyObject* module) {
             self.highlight(stream);
             return stream.str();
           })
-      .def(
-          "__str__",
-          [](const SourceRange& self) {
-            return self.text();
-          })
+      .def("__str__", [](const SourceRange& self) { return self.text(); })
       .def_property_readonly("start", &SourceRange::start)
       .def_property_readonly("end", &SourceRange::end);
   py::class_<SourceRangeFactory>(m, "SourceRangeFactory")

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -83,6 +83,11 @@ void initTreeViewBindings(PyObject* module) {
             self.highlight(stream);
             return stream.str();
           })
+      .def(
+          "__str__",
+          [](const SourceRange& self) {
+            return self.text();
+          })
       .def_property_readonly("start", &SourceRange::start)
       .def_property_readonly("end", &SourceRange::end);
   py::class_<SourceRangeFactory>(m, "SourceRangeFactory")


### PR DESCRIPTION
Fixes #38237

![image](https://user-images.githubusercontent.com/6421097/83145978-395dd280-a0bb-11ea-912d-f419ed33497b.png)

cc: @suo, @ezyang