### PR TITLE
Add option to allow loading state dict with mismatching shapes.

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3792,7 +3792,7 @@ class TestNN(NNTestCase):
 
             def _load_from_state_dict(self, state_dict, prefix, local_metadata,
                                       strict, missing_keys, unexpected_keys,
-                                      error_msgs):
+                                      error_msgs, tensor_check_fn):
                 # skip some of the error handling
                 self.param.data.copy_(state_dict[prefix + "serialized"] - 1)
 

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -130,7 +130,9 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
     #        |--- running_mean : Tensor (moved from v1.self.running_mean)
     #        |--- running_var : Tensor (moved from v1.self.running_var)
     #        |--- num_batches_tracked : Tensor (moved from v1.self.num_batches_tracked)
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         version = local_metadata.get('version', None)
         if version is None or version == 1:
             # BN related parameters and buffers were moved into the BN module for v2
@@ -159,7 +161,8 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
                     missing_keys.append(prefix + v2_name)
 
         super(_ConvBnNd, self)._load_from_state_dict(
-            state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
+            state_dict, prefix, local_metadata, strict, missing_keys,
+            unexpected_keys, error_msgs, tensor_check_fn)
 
     @classmethod
     def from_float(cls, mod):

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -72,7 +72,8 @@ class _NormBase(Module):
                'track_running_stats={track_running_stats}'.format(**self.__dict__)
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         version = local_metadata.get('version', None)
 
         if (version is None or version < 2) and self.track_running_stats:
@@ -84,7 +85,8 @@ class _NormBase(Module):
 
         super(_NormBase, self)._load_from_state_dict(
             state_dict, prefix, local_metadata, strict,
-            missing_keys, unexpected_keys, error_msgs)
+            missing_keys, unexpected_keys, error_msgs,
+            tensor_check_fn)
 
 
 class _BatchNorm(_NormBase):

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -20,7 +20,8 @@ class _InstanceNorm(_NormBase):
         raise NotImplementedError
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         version = local_metadata.get('version', None)
         # at version 1: removed running_mean and running_var when
         # track_running_stats=False (default)
@@ -47,7 +48,8 @@ class _InstanceNorm(_NormBase):
 
         super(_InstanceNorm, self)._load_from_state_dict(
             state_dict, prefix, local_metadata, strict,
-            missing_keys, unexpected_keys, error_msgs)
+            missing_keys, unexpected_keys, error_msgs,
+            tensor_check_fn)
 
     def forward(self, input: Tensor) -> Tensor:
         self._check_input_dim(input)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -980,7 +980,7 @@ class Module:
                     input_param = input_param[0]
 
                 # check to see if the user wants to load this param
-                if not tensor_check_fn(param, input_param, error_msgs):
+                if not tensor_check_fn(key, param, input_param, error_msgs):
                     continue
 
                 try:
@@ -1005,7 +1005,7 @@ class Module:
 
     def load_state_dict(self, state_dict: Union[Dict[str, Tensor], Dict[str, Tensor]],
                         strict: bool = True,
-                        tensor_check_fn: Optional[Callable[[Tensor, Tensor, List[str]], bool]] = None):
+                        tensor_check_fn: Optional[Callable[[str, Tensor, Tensor, List[str]], bool]] = None):
         r"""Copies parameters and buffers from :attr:`state_dict` into
         this module and its descendants. If :attr:`strict` is ``True``, then
         the keys of :attr:`state_dict` must exactly match the keys returned
@@ -1019,12 +1019,12 @@ class Module:
                 :meth:`~torch.nn.Module.state_dict` function. Default: ``True``
             tensor_check_fn (function, optional): Function used to check that
                 the value from the dict is valid compared to the current one.
-                It takes as input the current param, the new one and the list
-                of errors that you can append to notify of an error. It should
-                return True when the current param can be updated by the new
-                one and False when that param should be ignored. The user
-                should make sure that the custom function never raises errors
-                but append them to the given list.
+                It takes as input the key of the param, the current param, the
+                new one and the list of errors that you can append to notify of
+                an error. It should return True when the current param can be
+                updated by the new one and False when that param should be
+                ignored. The user should make sure that the custom function
+                never raises errors but append them to the given list.
 
         Returns:
             ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
@@ -1042,12 +1042,12 @@ class Module:
             state_dict._metadata = metadata
 
         if tensor_check_fn is None:
-            def tensor_check_fn(param, input_param, error_msgs):
+            def tensor_check_fn(key, param, input_param, error_msgs):
                 if input_param.shape != param.shape:
                     # local shape should match the one in checkpoint
                     error_msgs.append('size mismatch for {}: copying a param with shape {} from checkpoint, '
                                       'the shape in current model is {}.'
-                                      .format(param, input_param.shape, param.shape))
+                                      .format(key, input_param.shape, param.shape))
                     return False
                 return True
 

--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -66,11 +66,13 @@ class Linear(nnq.Linear):
         return extra_repr_str
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         version = local_metadata.get('version', None)
         self.version = version
         super(Linear, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                  missing_keys, unexpected_keys, error_msgs)
+                                                  missing_keys, unexpected_keys, error_msgs,
+                                                  tensor_check_fn)
 
     @classmethod
     def from_float(cls, mod):

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -21,10 +21,12 @@ class PackedParameter(torch.nn.Module):
         destination[prefix + 'param'] = self.param
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         self.param = state_dict[prefix + 'param']
         super(PackedParameter, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                           missing_keys, unexpected_keys, error_msgs)
+                                                           missing_keys, unexpected_keys, error_msgs,
+                                                           tensor_check_fn)
 
 class RNNBase(torch.nn.Module):
 
@@ -189,11 +191,13 @@ class RNNBase(torch.nn.Module):
         return apply_permutation(hx, permutation)
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         version = local_metadata.get('version', None)
         self.version = version
         super(RNNBase, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                   missing_keys, unexpected_keys, error_msgs)
+                                                   missing_keys, unexpected_keys, error_msgs,
+                                                   tensor_check_fn)
 
     @classmethod
     def from_float(cls, mod):
@@ -589,11 +593,13 @@ class RNNCellBase(torch.nn.Module):
 
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         self._packed_weight_ih = state_dict.pop(prefix + '_packed_weight_ih')
         self._packed_weight_hh = state_dict.pop(prefix + '_packed_weight_hh')
         super(RNNCellBase, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                       missing_keys, unexpected_keys, error_msgs)
+                                                       missing_keys, unexpected_keys, error_msgs,
+                                                       tensor_check_fn)
 
 class RNNCell(RNNCellBase):
     r"""An Elman RNN cell with tanh or ReLU non-linearity.

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -114,7 +114,8 @@ class _ConvNd(nn.Module):
     # Counterpart to the serialization methods, we must pack the serialized
     # QTensor weight into its packed format for use by the FBGEMM ops.
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         self.set_weight_bias(
             state_dict[prefix + 'weight'], state_dict[prefix + 'bias'])
         state_dict.pop(prefix + 'weight')
@@ -125,7 +126,7 @@ class _ConvNd(nn.Module):
         state_dict.pop(prefix + 'zero_point')
         super(_ConvNd, self)._load_from_state_dict(
             state_dict, prefix, local_metadata, False, missing_keys,
-            unexpected_keys, error_msgs)
+            unexpected_keys, error_msgs, tensor_check_fn)
 
     @torch.jit.export
     def __setstate__(self, state):

--- a/torch/nn/quantized/modules/embedding_ops.py
+++ b/torch/nn/quantized/modules/embedding_ops.py
@@ -51,7 +51,8 @@ class EmbeddingPackedParams(torch.nn.Module):
         destination[prefix + '_packed_weight'] = self._weight()
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         version = local_metadata.get('version', None)
         self.dtype = state_dict[prefix + 'dtype']
         state_dict.pop(prefix + 'dtype')
@@ -61,7 +62,8 @@ class EmbeddingPackedParams(torch.nn.Module):
         self.set_weight(weight)
 
         super(EmbeddingPackedParams, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                                 missing_keys, unexpected_keys, error_msgs)
+                                                                 missing_keys, unexpected_keys, error_msgs,
+                                                                 tensor_check_fn)
 
     def __repr__(self):
         return self._weight().__repr__()

--- a/torch/nn/quantized/modules/functional_modules.py
+++ b/torch/nn/quantized/modules/functional_modules.py
@@ -121,12 +121,14 @@ class QFunctional(torch.nn.Module):
         destination[prefix + 'zero_point'] = torch.tensor(self.zero_point)
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
 
         self.scale = float(state_dict.pop(prefix + 'scale'))
         self.zero_point = int(state_dict.pop(prefix + 'zero_point'))
         super(QFunctional, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                       missing_keys, unexpected_keys, error_msgs)
+                                                       missing_keys, unexpected_keys, error_msgs,
+                                                       tensor_check_fn)
 
     def _get_name(self):
         return 'QFunctional'

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -61,7 +61,8 @@ class LinearPackedParams(torch.nn.Module):
         destination[prefix + '_packed_params'] = self._weight_bias()
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         version = local_metadata.get('version', None)
         if version is None or version < 2:
             self.dtype = torch.qint8
@@ -80,7 +81,8 @@ class LinearPackedParams(torch.nn.Module):
             self.set_weight_bias(weight, bias)
 
         super(LinearPackedParams, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                              missing_keys, unexpected_keys, error_msgs)
+                                                              missing_keys, unexpected_keys, error_msgs,
+                                                              tensor_check_fn)
 
     @torch.jit.export
     def __getstate__(self):

--- a/torch/quantization/_learnable_fake_quantize.py
+++ b/torch/quantization/_learnable_fake_quantize.py
@@ -343,7 +343,8 @@ class _LearnableFakeQuantize(nn.Module):
         destination[prefix + 'zero_point'] = self.zero_point
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         local_state = ['scale', 'zero_point']
         for name in local_state:
             key = prefix + name
@@ -357,6 +358,6 @@ class _LearnableFakeQuantize(nn.Module):
                 missing_keys.append(key)
         super(_LearnableFakeQuantize, self)._load_from_state_dict(
             state_dict, prefix, local_metadata, strict, missing_keys,
-            unexpected_keys, error_msgs)
+            unexpected_keys, error_msgs, tensor_check_fn)
 
     with_args = classmethod(_with_args)

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -129,7 +129,8 @@ class FakeQuantize(Module):
         destination[prefix + 'zero_point'] = self.zero_point
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+                              missing_keys, unexpected_keys, error_msgs,
+                              tensor_check_fn):
         # Removing this function throws an error that the the size of the loaded tensor does not match the original size
         # i.e., These buffers start out with numel 0 and become numel 1 once they have their first forward pass.
         local_state = ['scale', 'zero_point']
@@ -141,7 +142,8 @@ class FakeQuantize(Module):
             elif strict:
                 missing_keys.append(key)
         super(FakeQuantize, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                        missing_keys, unexpected_keys, error_msgs)
+                                                        missing_keys, unexpected_keys, error_msgs,
+                                                        tensor_check_fn)
 
 default_fake_quant = FakeQuantize.with_args(observer=MovingAverageMinMaxObserver, quant_min=0, quant_max=255,
                                             dtype=torch.quint8, qscheme=torch.per_tensor_affine, reduce_range=True)

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -571,7 +571,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
     def _load_from_state_dict(self, state_dict: Union[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], prefix: str,
                               local_metadata: Dict[str, torch.Tensor], strict: bool,
                               missing_keys: List[str], unexpected_keys: List[str], error_msgs: List[str],
-                              tensor_check_fn: Callable[[Tensor, Tensor, List[str]], bool]):
+                              tensor_check_fn: Callable[[torch.Tensor, torch.Tensor, List[str]], bool]):
         local_state = ['min_vals', 'max_vals']
         for name in local_state:
             key = prefix + name
@@ -604,7 +604,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
     def _load_from_state_dict_script(self, state_dict: Union[Dict[str, torch.Tensor], Dict[str, torch.Tensor]],
                                      prefix: str, local_metadata: Dict[str, torch.Tensor], strict: bool,
                                      missing_keys: List[str], unexpected_keys: List[str], error_msgs: List[str],
-                                     tensor_check_fn: Callable[[Tensor, Tensor, List[str]], bool]):
+                                     tensor_check_fn: Callable[[torch.Tensor, torch.Tensor, List[str]], bool]):
 
         self._load_from_state_dict(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs,
                                    tensor_check_fn)
@@ -1043,7 +1043,6 @@ class RecordingObserver(_ObserverBase):
     @torch.jit.export
     def get_tensor_value(self):
         return self.tensor_val
-tensor_check_fn
 
 class NoopObserver(ObserverBase):
     r"""


### PR DESCRIPTION
This PR adds an option to override the choice of loading weights or not and optionally to produce an error. This can be very useful if you want to do transfer learning, transferring weights from model A to model B where A and B have a different output (number of classes, for example).

Example usage:

```python
import torch

# Base model.
a = torch.nn.Sequential(
    torch.nn.Conv2d(7, 5, 1),
    torch.nn.Conv2d(5, 3, 1)
)

# Model with an additional layer, requires `strict=False`.
b = torch.nn.Sequential(
    torch.nn.Conv2d(7, 5, 1),
    torch.nn.Conv2d(5, 3, 1),
    torch.nn.Conv2d(3, 3, 1)
)

# Model with an additional layer and one of the layers has a different shape of weights,
# requires `strict=False` and the optional callback introduced in this PR: `tensor_check_fn`.
c = torch.nn.Sequential(
    torch.nn.Conv2d(7, 5, 1),
    torch.nn.Conv2d(3, 3, 1),
    torch.nn.Conv2d(3, 3, 1)
)

# This line works without this PR.
b.load_state_dict(a.state_dict(), strict=False)

# The next part doesn't work without this PR, because c has a layer that is of different shape.
def tensor_check_fn(param, input_param, error_msgs):
	if param.shape != input_param.shape:
		return False
	return True

c.load_state_dict(a.state_dict(), strict=False, tensor_check_fn=tensor_check_fn)
```

This change should be backwards compatible, unless some custom layer implements the `_load_from_state_dict` method, because an argument has been added there.