### PR TITLE
[1.5.1] Change len(DataLoader) for IterableDataset (#38925)

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1505,6 +1505,29 @@ class TestDataLoader(TestCase):
         check_len(DataLoader(self.dataset, batch_size=2), 50)
         check_len(DataLoader(self.dataset, batch_size=3), 34)
 
+    def test_iterabledataset_len(self):
+        class IterableDataset(torch.utils.data.IterableDataset):
+            def __len__(self):
+                return 10
+
+            def __iter__(self):
+                return iter(range(10))
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=1)
+        self.assertEqual(len(iterable_loader), 10)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=1, drop_last=True)
+        self.assertEqual(len(iterable_loader), 10)
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=2)
+        self.assertEqual(len(iterable_loader), 5)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=2, drop_last=True)
+        self.assertEqual(len(iterable_loader), 5)
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=3)
+        self.assertEqual(len(iterable_loader), 4)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=3, drop_last=True)
+        self.assertEqual(len(iterable_loader), 3)
+
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_numpy_scalars(self):
         import numpy as np

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -311,6 +311,12 @@ class DataLoader(object):
             # `DataLoader`, save the returned value in `self._len_called`, and warn
             # if the iterator ends up yielding more than this number of samples.
             length = self._IterableDataset_len_called = len(self.dataset)
+            if self.batch_size is not None:
+                from math import ceil
+                if self.drop_last:
+                    length = length // self.batch_size
+                else:
+                    length = ceil(length / self.batch_size)
             return length
         else:
             return len(self._index_sampler)


### PR DESCRIPTION
Summary:
Fix https://github.com/pytorch/pytorch/issues/36176

One-liner change to ensure that ```len(loader) == (len(dataset) // batch_size)``` for IterableDataset.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/38925

Differential Revision: D21731587

Pulled By: ezyang

fbshipit-source-id: 59a086165a004c0c1c8a1ee0776b1444bd26de23

