### PR TITLE
Remove unboxed only from AMP registrations for cat.

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -402,7 +402,7 @@ TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   KERNEL(ADD_NS(addbmm), "addbmm", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar, Scalar), fp16)
   KERNEL(ADD_NS(baddbmm), "baddbmm", Tensor (const Tensor &, const Tensor &, const Tensor &, Scalar, Scalar), fp16)
   KERNEL(ADD_NS(bmm), "bmm", Tensor (const Tensor &, const Tensor &), fp16)
-  KERNEL_UNBOXED_ONLY(ADD_NS(chain_matmul), "chain_matmul", Tensor (TensorList), fp16)
+  KERNEL(ADD_NS(chain_matmul), "chain_matmul", Tensor (TensorList), fp16)
   // fp32
   KERNEL(ADD_NS(acos), "acos", Tensor (const Tensor &), fp32)
   KERNEL(ADD_NS(asin), "asin", Tensor (const Tensor &), fp32)
@@ -490,7 +490,7 @@ TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   KERNEL(ADD_NS(cat), "cat", Tensor (TensorList, int64_t), promote)
   KERNEL_UNBOXED_ONLY(ADD_NS(cat), "cat.names", Tensor (TensorList, Dimname), promote)
   KERNEL(ADD_NS(_cat), "_cat", Tensor (TensorList, int64_t), promote)
-  KERNEL_UNBOXED_ONLY(ADD_NS(stack), "stack", Tensor (TensorList, int64_t), promote)
+  KERNEL(ADD_NS(stack), "stack", Tensor (TensorList, int64_t), promote)
 
   m.impl_UNBOXED("binary_cross_entropy", &at::autocast::binary_cross_entropy_banned);
 }

--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -487,9 +487,9 @@ TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   KERNEL_UNBOXED_ONLY(ADD_NS(tensordot), "tensordot", Tensor (const Tensor &, const Tensor &, IntArrayRef, IntArrayRef), promote)
   KERNEL_UNBOXED_ONLY(ADD_NS(dot), "dot", Tensor (const Tensor &, const Tensor &), promote)
   KERNEL(ADD_NS(equal), "equal", bool (const Tensor &, const Tensor &), promote)
-  KERNEL_UNBOXED_ONLY(ADD_NS(cat), "cat", Tensor (TensorList, int64_t), promote)
+  KERNEL(ADD_NS(cat), "cat", Tensor (TensorList, int64_t), promote)
   KERNEL_UNBOXED_ONLY(ADD_NS(cat), "cat.names", Tensor (TensorList, Dimname), promote)
-  KERNEL_UNBOXED_ONLY(ADD_NS(_cat), "_cat", Tensor (TensorList, int64_t), promote)
+  KERNEL(ADD_NS(_cat), "_cat", Tensor (TensorList, int64_t), promote)
   KERNEL_UNBOXED_ONLY(ADD_NS(stack), "stack", Tensor (TensorList, int64_t), promote)
 
   m.impl_UNBOXED("binary_cross_entropy", &at::autocast::binary_cross_entropy_banned);

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2828,19 +2828,20 @@ t2.start()
     def test_autocast_cat_jit(self):
         # Reported at https://github.com/pytorch/pytorch/issues/38958
 
-        class Model(nn.Module):
+        class Model(torch.nn.Module):
             def forward(self):
                 a = torch.randn(1)
                 b = torch.randn(1)
                 c = torch.cat((a, b), 0)
-                return c
+                d = torch.stack([c, c], 0)
+                return d
 
         # The JIT here doesn't really matter, we just need to call
         # cat via the boxed API
         model = Model()
         model_jit_script = torch.jit.script(model)
 
-        with amp.autocast(True):
+        with torch.cuda.amp.autocast(True):
             model()
             model_jit_script()
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2825,6 +2825,25 @@ t2.start()
             loss = output.sum()
         loss.backward()
 
+    def test_autocast_cat_jit(self):
+        # Reported at https://github.com/pytorch/pytorch/issues/38958
+
+        class Model(nn.Module):
+            def forward(self):
+                a = torch.randn(1)
+                b = torch.randn(1)
+                c = torch.cat((a, b), 0)
+                return c
+
+        # The JIT here doesn't really matter, we just need to call
+        # cat via the boxed API
+        model = Model()
+        model_jit_script = torch.jit.script(model)
+
+        with amp.autocast(True):
+            model()
+            model_jit_script()
+
     @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     def test_max_large_axis(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39156 Remove unboxed only from AMP registrations for cat.**

TensorList is now supported for boxing, so we can remove
unboxed only from it.  I didn't check if there were other
operators that were incorrectly classified.

Fixes https://github.com/pytorch/pytorch/issues/38958

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D21819821](https://our.internmc.facebook.com/intern/diff/D21819821)