### PR TITLE
[TensorPipe] Ignore expected errors

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -3,14 +3,7 @@
 #include <torch/csrc/distributed/rpc/request_callback_impl.h>
 #include <torch/csrc/distributed/rpc/utils.h>
 
-#include <tensorpipe/channel/basic/context.h>
-#ifdef TP_ENABLE_CMA
-#include <tensorpipe/channel/cma/context.h>
-#endif
-#ifdef TP_ENABLE_SHM
-#include <tensorpipe/transport/shm/context.h>
-#endif
-#include <tensorpipe/transport/uv/context.h>
+#include <tensorpipe/tensorpipe.h>
 
 #include <arpa/inet.h>
 #include <ifaddrs.h>
@@ -163,7 +156,14 @@ void TensorPipeAgent::onListenerAccepted(
     const tensorpipe::Error& error,
     std::shared_ptr<tensorpipe::Pipe>& pipe) {
   if (error) {
-    LOG(WARNING) << "got error from listener: " << error.what();
+    if (error.isOfType<tensorpipe::ListenerClosedError>() &&
+        !rpcAgentRunning_.load()) {
+      // This is expected.
+    } else {
+      LOG(WARNING) << "RPC agent for " << workerInfo_.name_
+                   << " encountered error when accepting incoming pipe: "
+                   << error.what();
+    }
     return;
   }
 
@@ -251,9 +251,14 @@ void TensorPipeAgent::sendCompletedResponseMessage(
   responseMessage.setId(messageId);
   if (!error) {
     pipeWrite(
-        pipe, std::move(responseMessage), [](const tensorpipe::Error& error) {
+        pipe,
+        std::move(responseMessage),
+        [this](const tensorpipe::Error& error) {
           if (error) {
-            LOG(WARNING) << "sending response failed: " << error.what();
+            LOG(WARNING)
+                << "RPC agent for " << workerInfo_.name_
+                << " encountered error when writing outgoing response: "
+                << error.what();
             return;
           }
         });
@@ -261,9 +266,12 @@ void TensorPipeAgent::sendCompletedResponseMessage(
     pipeWrite(
         pipe,
         createExceptionResponse(error->what(), responseMessage.id()),
-        [](const tensorpipe::Error& error) {
+        [this](const tensorpipe::Error& error) {
           if (error) {
-            LOG(WARNING) << "sending error response failed: " << error.what();
+            LOG(WARNING)
+                << "RPC agent for " << workerInfo_.name_
+                << " encountered error when writing outgoing response: "
+                << error.what();
             return;
           }
         });
@@ -275,9 +283,13 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
       pipe,
       [this, pipe](
           const tensorpipe::Error& error, Message&& requestMessage) mutable {
-        // TODO: Handle server pipe read error
+        // FIXME Find a way for the client to tell the server they are done with
+        // the pipe and are intentionally shutting it down. Perhaps sending an
+        // empty message?
         if (error) {
-          LOG(WARNING) << "Server read message: " << error.what();
+          LOG(WARNING) << "RPC agent for " << workerInfo_.name_
+                       << " encountered error when reading incoming request: "
+                       << error.what();
           return;
         }
 
@@ -393,7 +405,14 @@ std::shared_ptr<FutureMessage> TensorPipeAgent::send(
       [this, &clientPipe, futureResponseMessage](
           const tensorpipe::Error& error) mutable {
         if (error) {
-          LOG(WARNING) << "client write error: " << error.what();
+          if (error.isOfType<tensorpipe::PipeClosedError>() &&
+              !rpcAgentRunning_.load()) {
+            // This is expected.
+          } else {
+            LOG(WARNING) << "RPC agent for " << workerInfo_.name_
+                         << " encountered error when writing outgoing request: "
+                         << error.what();
+          }
           markFutureWithError(std::move(futureResponseMessage), error.what());
           return;
         }
@@ -403,7 +422,15 @@ std::shared_ptr<FutureMessage> TensorPipeAgent::send(
             [this, &clientPipe](
                 const tensorpipe::Error& error, Message&& responseMessage) {
               if (error) {
-                LOG(WARNING) << "Read response error: " << error.what();
+                if (error.isOfType<tensorpipe::PipeClosedError>() &&
+                    !rpcAgentRunning_.load()) {
+                  // This is expected.
+                } else {
+                  LOG(WARNING)
+                      << "RPC agent for " << workerInfo_.name_
+                      << " encountered error when reading incoming request: "
+                      << error.what();
+                }
                 // We may get garbage content in responseMessage upon error.
                 // Flushing all future messages belonging to this pipe due to
                 // error state.

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -3,8 +3,6 @@
 #include <torch/csrc/distributed/rpc/request_callback_impl.h>
 #include <torch/csrc/distributed/rpc/utils.h>
 
-#include <tensorpipe/tensorpipe.h>
-
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <netdb.h>

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -1,15 +1,14 @@
 #pragma once
 
+#include <atomic>
+#include <thread>
+
+#include <tensorpipe/tensorpipe.h>
+
 #include <c10/core/thread_pool.h>
 #include <c10d/ProcessGroup.hpp>
 #include <c10d/Store.hpp>
-#include <tensorpipe/core/context.h>
-#include <tensorpipe/core/listener.h>
-#include <tensorpipe/core/pipe.h>
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
-
-#include <atomic>
-#include <thread>
 
 namespace torch {
 namespace distributed {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39185 [TensorPipe] Use PrefixStore to avoid conflicting keys
* #39184 [TensorPipe] Bind to hostname's IP address instead of localhost
* #39183 [TensorPipe] Don't use separate heap allocation for metrics
* **#39182 [TensorPipe] Ignore expected errors**

When the TensorPipe context is closed and joined, all pending callbacks are invoked with an error of type PipeClosedError. This is normal and expected, and should not be logged.

There is still one log that should be addressed, namely when an incoming pipe from a remote worker dies after we have joined, which I still need to address. That will require some type of "signal" from the remote worker that the shutdown is intentional, for example sending an empty packet?

Differential Revision: [D21703036](https://our.internmc.facebook.com/intern/diff/D21703036/)