### PR TITLE
[TensorPipe] Don't use separate heap allocation for metrics

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -96,8 +96,7 @@ TensorPipeAgent::TensorPipeAgent(
   collectNames();
 
   // Initialize the time-series metrics tracking map
-  timeSeriesMetrics_[kGilAverageWaitTime] =
-      std::make_unique<TimeSeriesMetricsTracker>();
+  timeSeriesMetrics_.emplace(kGilAverageWaitTime, TimeSeriesMetricsTracker());
 }
 
 TensorPipeAgent::~TensorPipeAgent() {
@@ -648,7 +647,7 @@ std::unordered_map<std::string, std::string> TensorPipeAgent::getMetrics() {
       // Include the averages for each time series metric. This is just the GIL
       // Wait Time for now.
       auto averageGilWaitTime =
-          timeSeriesMetrics_[kGilAverageWaitTime]->computeAverage();
+          timeSeriesMetrics_[kGilAverageWaitTime].computeAverage();
       lock.unlock();
       metrics[kGilAverageWaitTime] = c10::to_string(averageGilWaitTime);
     }
@@ -660,7 +659,7 @@ std::unordered_map<std::string, std::string> TensorPipeAgent::getMetrics() {
 void TensorPipeAgent::addGilWaitTime(
     const std::chrono::microseconds gilWaitTime) {
   std::lock_guard<std::mutex> lock(metricsMutex_);
-  timeSeriesMetrics_[kGilAverageWaitTime]->addData(gilWaitTime.count());
+  timeSeriesMetrics_[kGilAverageWaitTime].addData(gilWaitTime.count());
 }
 
 TensorPipeAgent::NetworkDataDict TensorPipeAgent::getNetworkData() {

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -230,8 +230,7 @@ class TensorPipeAgent : public RpcAgent {
   };
 
   // Map of Time-Series metrics tracked by the RPC Agent
-  std::unordered_map<std::string, std::unique_ptr<TimeSeriesMetricsTracker>>
-      timeSeriesMetrics_;
+  std::unordered_map<std::string, TimeSeriesMetricsTracker> timeSeriesMetrics_;
   // Mutex to guard timeSeriesMetrics_
   std::mutex metricsMutex_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39185 [TensorPipe] Use PrefixStore to avoid conflicting keys
* #39184 [TensorPipe] Bind to hostname's IP address instead of localhost
* **#39183 [TensorPipe] Don't use separate heap allocation for metrics**
* #39182 [TensorPipe] Ignore expected errors

I didn't see any reason behind it, and it seems to work even after removing the unique_ptrs. (Well, it compiles...)

Differential Revision: [D21767863](https://our.internmc.facebook.com/intern/diff/D21767863/)