### PR TITLE
[TensorPipe] Use PrefixStore to avoid conflicting keys

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -49,7 +49,7 @@ void TensorPipeAgent::collectNames() {
   std::vector<uint8_t> selfNameVector(
       (uint8_t*)selfName.c_str(),
       (uint8_t*)selfName.c_str() + selfName.length());
-  addressStore_->set("names/" + c10::to_string(selfId), selfNameVector);
+  rankToNameStore_.set(c10::to_string(selfId), selfNameVector);
 
   workerIdToInfo_.emplace(selfId, WorkerInfo(selfName, selfId));
   workerNameToInfo_.emplace(selfName, WorkerInfo(selfName, selfId));
@@ -58,7 +58,7 @@ void TensorPipeAgent::collectNames() {
       continue;
     }
     std::vector<uint8_t> workerNameVector =
-        addressStore_->get("names/" + c10::to_string(workerId));
+        rankToNameStore_.get(c10::to_string(workerId));
     std::string workerName(
         (char*)workerNameVector.data(), workerNameVector.size());
 
@@ -74,7 +74,7 @@ void TensorPipeAgent::collectNames() {
 }
 
 TensorPipeAgent::TensorPipeAgent(
-    std::shared_ptr<::c10d::Store> addressStore,
+    std::shared_ptr<::c10d::Store> store,
     std::string selfName,
     worker_id_t selfId,
     int worldSize,
@@ -87,7 +87,8 @@ TensorPipeAgent::TensorPipeAgent(
               (long)(opts.rpcTimeoutSeconds * kToMilliseconds))),
       context_(std::make_shared<tensorpipe::Context>(
           tensorpipe::ContextOptions().name(workerInfo_.name_))),
-      addressStore_(std::move(addressStore)),
+      rankToNameStore_("names", store),
+      nameToAddressStore_("addrs", store),
       worldSize_(worldSize),
       opts_(std::move(opts)),
       processGroup_(std::move(processGroup)) {
@@ -146,11 +147,11 @@ void TensorPipeAgent::startImpl() {
   // Store our own url.
   const auto address = listener_->url("tcp");
   const std::vector<uint8_t> selfAddrData(address.begin(), address.end());
-  addressStore_->set(workerInfo_.name_, selfAddrData);
+  nameToAddressStore_.set(workerInfo_.name_, selfAddrData);
 
   for (const auto& p : workerNameToInfo_) {
     const auto& name = p.first;
-    auto nodeAddrData = addressStore_->get(name);
+    auto nodeAddrData = nameToAddressStore_.get(name);
     auto nodeAddrStr =
         std::string((const char*)nodeAddrData.data(), nodeAddrData.size());
     workerNameToURL_.insert({name, nodeAddrStr});
@@ -685,7 +686,7 @@ TensorPipeAgent::NetworkDataDict TensorPipeAgent::getNetworkData() {
 NetworkSourceInfo TensorPipeAgent::getNetworkSourceInfo() {
   NetworkSourceInfo info = {
       RpcAgent::getWorkerInfo().id_,
-      addressStore_->get(RpcAgent::getWorkerInfo().name_)};
+      nameToAddressStore_.get(RpcAgent::getWorkerInfo().name_)};
 
   return info;
 }

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/thread_pool.h>
+#include <c10d/PrefixStore.hpp>
 #include <c10d/ProcessGroup.hpp>
 #include <c10d/Store.hpp>
 #include <tensorpipe/core/context.h>
@@ -44,7 +45,7 @@ struct AggregatedNetworkData {
 class TensorPipeAgent : public RpcAgent {
  public:
   TensorPipeAgent(
-      std::shared_ptr<::c10d::Store> addressStore,
+      std::shared_ptr<::c10d::Store> store,
       std::string selfName,
       worker_id_t selfId,
       int worldSize,
@@ -168,7 +169,8 @@ class TensorPipeAgent : public RpcAgent {
   std::unordered_map<std::string, WorkerInfo> workerNameToInfo_;
   std::unordered_map<std::string, std::string> workerNameToURL_;
 
-  const std::shared_ptr<::c10d::Store> addressStore_;
+  ::c10d::PrefixStore rankToNameStore_;
+  ::c10d::PrefixStore nameToAddressStore_;
   const int worldSize_;
   const TensorPipeRpcBackendOptions opts_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39185 [TensorPipe] Use PrefixStore to avoid conflicting keys**
* #39184 [TensorPipe] Bind to hostname's IP address instead of localhost
* #39183 [TensorPipe] Don't use separate heap allocation for metrics
* #39182 [TensorPipe] Ignore expected errors

The TP agent used the store for two things: mapping ranks to names, and mapping names to addresses. The former was prefixed, the latter wasn't. So, if a worker had a name which was `names/0` this would lead to a conflict. We should prefix both usages, and we can do so easily with the `PrefixStore`.

Differential Revision: [D21767862](https://our.internmc.facebook.com/intern/diff/D21767862/)