### PR TITLE
Refactor unittests for activation functions relu, elu, and sigmoid

### DIFF
--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -118,68 +118,164 @@ def _get_random_tensor_and_q_params(shapes, rand_scale, torch_type):
 
 class TestQuantizedOps(TestCase):
 
+    """Helper function to test quantized activation functions."""
+    def _test_activation_function(self, X, fn_name, test_configs):
+        r"""
+            When writing a unit test for the activation function,
+            instead of specifying the test routines only applicable to the activation function itself,
+            you utilize the _test_activation_function that provides general testing.
+            To utilize the helper function, a test config must be provided.
+            A test config is a list that contains metadata about the quantized activation
+            functions that will be tested and how the tests need to be set up; it allows simpler and
+            more concise unit tests to be written by specifying the configurations needed
+            and calling the provided helper function _test_activation_function.
+            Inside the list, each config (as a dictionary) represents a suite of tests that assert the
+            correctness of various quantization functions.
+            You can check out the test_qrelu, test_qrelu6, test_qsigmoid, and test_qhardsigmoid for
+            how their test configs are specified.
+            Here's a list of the fields that can be included in a test config:
+            quantized_fn: a list of the quantized functions to be tested
+            reference_fn: the original reference function to be called on the
+            the dequantized X
+            inplace_kwarg: the additional inplace keyword argument to test in-place
+            for each test entry in ops_under_test, it must have at least the fields
+            for quantized_fn and reference_fn. If inplace_kwarg is missing, the
+            quantized function is assumed to be either inplace by default or the
+            test is not testing an inplace function.
+            output_range: the output range the operator will map to. By default, if it is
+            no specified, the range will not be controlled and depend on Xmin and Xmax.
+            change_zero_point: a boolean flag indicating if the zero point parameter should
+            be determined based on torch_type during quantization (see sigmoid/hardsigmoid for
+            examples). By default, if it is not specified, change_zero_point is assumed to be
+            False and zero point will just take on the default value from X.
+        """
+        # Retrives the default parameters from X.
+        X, (scale, zero_point, torch_type) = X
+        X = torch.from_numpy(X)
+        # Quantizes the reference to account for max error.
+        # q_min and q_max only depend on the initial torch_type.
+        q_min, q_max = torch.iinfo(torch_type).min, torch.iinfo(torch_type).max
+
+        for op_group in test_configs:
+            ref_op = op_group['reference_fn']
+            for q_op in op_group['quantized_fn']:
+                # Quantizes and dequantizes to account for max error.
+                qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                               dtype=torch_type)
+                dqX = qX.dequantize()
+                dqY_hat = ref_op(dqX.clone())
+
+                # Retrieves the inplace keyword arguments
+                # some functions require inplace=True to test in-place.
+                inplace_kwarg = op_group.get('inplace_kwarg', dict())
+
+                # Adjusts output_scale if needed.
+                # The output_scale determines the quantization scale for functions that
+                # have a constrained output range. e.x. sigmoid ranges from 0 to 1.
+                output_scale = scale
+                if 'output_range' in op_group:
+                    (f_min, f_max) = op_group['output_range']
+                    output_scale = (f_max - f_min) / (q_max - q_min + 1.0)
+
+                # Adjusts output_zero_point if needed (see explanation for the
+                # change_zero_point parameter above).
+                # output_zero_point determines the additional offset that will be
+                # added to a scaled value during quantization.
+                if op_group.get('change_zero_point', False):
+                    output_zero_point = 0 if torch_type == torch.qint32 else q_min
+                else:
+                    output_zero_point = zero_point
+
+                # Quantizes the dequantized version of Y_hat.
+                qY_hat = torch.quantize_per_tensor(dqY_hat, scale=output_scale,
+                                                   zero_point=output_zero_point,
+                                                   dtype=torch_type)
+
+                # Finds qY using in-place or non-in-place quantized operators.
+                qY = q_op(qX, **inplace_kwarg)
+
+                self.assertEqual(qY, qY_hat, msg='{} - {} failed: ({} vs. {})'.format(
+                    fn_name, q_op, qY, qY_hat
+                ))
+
     """Tests the correctness of the quantized::relu op."""
+    @override_qengines
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
                        qparams=hu.qparams()))
     def test_qrelu(self, X):
-        X, (scale, zero_point, torch_type) = X
+        relu_test_configs = [
+            {
+                'quantized_fn': [
+                    torch.relu,
+                    torch.relu_,
+                    torch.nn.functional.relu,
+                    torch.nn.quantized.functional.relu,
+                ],
+                'reference_fn': torch.nn.functional.relu
+            },
+            {
+                'quantized_fn': [
+                    torch.nn.functional.relu,
+                    torch.nn.quantized.functional.relu,
+                ],
+                'reference_fn': torch.nn.functional.relu,
+                'inplace_kwarg': {
+                    'inplace': True
+                }
+            }
+        ]
+        self._test_activation_function(X, 'relu', relu_test_configs)
 
-        Y = X.copy()
-        Y[Y < 0] = 0
-        qY = torch.quantize_per_tensor(torch.from_numpy(Y), scale=scale,
-                                       zero_point=zero_point, dtype=torch_type)
-        X = torch.from_numpy(X)
-        qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type)
-
-        ops_under_test = {
-            'native': torch.relu,
-            'nn.functional': torch.nn.functional.relu,
-        }
-
-        for name, op in ops_under_test.items():
-            qY_hat = op(qX)
-            self.assertEqual(qY, qY_hat, msg="{} relu failed".format(name))
-
-        ops_under_test_inplace = {
-            'inplace native': torch.relu_,
-            'inplace nn.functional': torch.nn.functional.relu_,
-        }
-
-        for name, op_ in ops_under_test_inplace.items():
-            qY_hat = qX.clone()
-            op_(qY_hat)
-            self.assertEqual(qY, qY_hat, msg="{} relu failed".format(name))
-
-    """Tests the correctness of the quantized::relu op."""
+    """Tests the correctness of the quantized::relu6 op."""
+    @override_qengines
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
                        qparams=hu.qparams()))
     def test_qrelu6(self, X):
-        X, (scale, zero_point, torch_type) = X
+        relu6_test_configs = [
+            {
+                'quantized_fn': [
+                    torch.ops.quantized.relu6,
+                    torch.nn.quantized.ReLU6(inplace=False),
+                    torch.nn.quantized.ReLU6(inplace=True)
+                ],
+                'reference_fn': torch.nn.functional.relu6
+            }
+        ]
+        self._test_activation_function(X, 'relu6', relu6_test_configs)
 
-        Y = X.copy()
-        Y[Y < 0] = 0
-        Y[Y > 6.0] = 6.0
-        qY = torch.quantize_per_tensor(torch.from_numpy(Y), scale=scale,
-                                       zero_point=zero_point, dtype=torch_type)
-        X = torch.from_numpy(X)
-        qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type)
+    """Tests the correctness of the quantized::sigmoid op."""
+    @override_qengines
+    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
+                       qparams=hu.qparams()))
+    def test_qsigmoid(self, X):
+        sigmoid_test_configs = [
+            {
+                'quantized_fn': [
+                    torch.sigmoid
+                ],
+                'reference_fn': torch.sigmoid,
+                'output_range': (0.0, 1.0),
+                'change_zero_point': True
+            }
+        ]
+        self._test_activation_function(X, 'sigmoid', sigmoid_test_configs)
 
-        ops_under_test = {
-            'ops.quantized': torch.ops.quantized.relu6,
-            'module': torch.nn.quantized.ReLU6(),
-        }
-
-        for name, op in ops_under_test.items():
-            for inplace in (True, False):
-                if hasattr(op, 'inplace'):
-                    op.inplace = inplace
-                    qY_hat = op(qX)
-                else:
-                    qY_hat = op(qX, inplace=inplace)
-                self.assertEqual(qY, qY_hat,
-                                 msg="{} relu failed".format(name))
+    """Tests the correctness of the quantized::hardsigmoid op."""
+    @override_qengines
+    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
+                       qparams=hu.qparams()))
+    def test_qhardsigmoid(self, X):
+        hardsigmoid_test_configs = [
+            {
+                'quantized_fn': [
+                    torch.nn.quantized.functional.hardsigmoid
+                ],
+                'reference_fn': torch.nn.functional.hardsigmoid,
+                'output_range': (0.0, 1.0),
+                'change_zero_point': True
+            }
+        ]
+        self._test_activation_function(X, 'hardsigmoid', hardsigmoid_test_configs)
 
     """Tests the correctness of the quantized::relu op."""
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
@@ -237,74 +333,6 @@ class TestQuantizedOps(TestCase):
         qYout = op(qX, alpha=alpha, scale=scale, zero_point=zero_point)
         self.assertEqual(qYout, qY_hat,
                          msg="F.elu.out failed ({} vs {})".format(qY, qY_hat))
-
-    """Tests the correctness of the quantized::qnnpack_sigmoid op."""
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
-                       qparams=hu.qparams()))
-    def test_qsigmoid(self, X):
-        # Note: QNNPACK is tested separately in TestQNNPackOps
-        X, (scale, zero_point, torch_type) = X
-
-        X = torch.from_numpy(X)
-        Y = torch.sigmoid(X)
-
-        qX = torch.quantize_per_tensor(X, scale=scale,
-                                       zero_point=zero_point,
-                                       dtype=torch_type)
-
-        # Quantize the reference to account for max error.
-        # Note that the output scale has +1, because we use scale of 1.0/2^BITS
-        # in the implementations.
-        f_min, f_max = 0.0, 1.0
-        q_min, q_max = torch.iinfo(torch_type).min, torch.iinfo(torch_type).max
-        output_scale = (f_max - f_min) / (q_max - q_min + 1.0)
-        output_zero_point = output_zero_point = 0 if torch_type == torch.qint32 else q_min
-        qY = torch.quantize_per_tensor(Y, scale=output_scale,
-                                       zero_point=output_zero_point,
-                                       dtype=torch_type)
-        qY_hat = torch.sigmoid(qX)
-        self.assertEqual(qY, qY_hat,
-                         msg="Sigmoid failed: {} vs. {}".format(qY, qY_hat))
-
-    """Tests the correctness of the quantized::qhardsigmoid op."""
-    @override_qengines
-    def test_qhardsigmoid(self):
-        max_sides = (3, 5)
-        side_lens = (1, 7, 8)
-        torch_types = (torch.quint8, torch.qint8)
-        combined = [max_sides, side_lens, torch_types]
-        test_cases = itertools.product(*combined)
-        for test_case in test_cases:
-            max_side, side_len, torch_type = test_case
-
-            if torch.backends.quantized.engine == 'qnnpack' and torch_type != torch.quint8:
-                continue
-
-            shapes = [side_len] * max_side
-            X, X_scale, X_zero_point = \
-                _get_random_tensor_and_q_params(shapes, 2.0, torch_type)
-            qX = torch.quantize_per_tensor(X, scale=X_scale,
-                                           zero_point=X_zero_point,
-                                           dtype=torch_type)
-            dqX = qX.dequantize()
-
-
-            # Quantize the reference to account for max error.
-            # Note that the output scale has +1, because we use scale of 1.0/2^BITS
-            # in the implementations.
-            f_min, f_max = 0.0, 1.0
-            q_min, q_max = torch.iinfo(torch_type).min, torch.iinfo(torch_type).max
-            output_scale = (f_max - f_min) / (q_max - q_min + 1.0)
-            output_zero_point = 0 if torch_type == torch.qint32 else q_min
-            dqY_hat = F.hardsigmoid(dqX)
-            qY_hat = torch.quantize_per_tensor(dqY_hat, scale=output_scale,
-                                               zero_point=output_zero_point,
-                                               dtype=torch_type)
-
-            qY = torch.nn.quantized.functional.hardsigmoid(qX)
-            self.assertEqual(qY, qY_hat,
-                             msg="Hardsigmoid failed: {} vs. {}, {}".format(qY, qY_hat, torch.backends.quantized.engine))
-
 
     """Tests the correctness of the quantized::qlayer_norm op."""
     @skipIfNoFBGEMM


### PR DESCRIPTION
Summary: The tests covered previously by test_qrelu, test_qelu, and test_qsigmoid are now merged into one test to ensure conciseness and reduce redundancy.

Test Plan:
1. On a devserver, build PyTorch from source by running the command "buck build mode/dev //caffe2:torch"
 2. Run the merged unit test throught the command "buck test mode/dev //caffe2/test:quantization -- test_qrelu_elu_sigmoid

Differential Revision: D21755690

