### PR TITLE
Add timeout to TestBottleneck

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -332,13 +332,17 @@ class TestFFI(TestCase):
 
 @unittest.skipIf('SKIP_TEST_BOTTLENECK' in os.environ.keys(), 'SKIP_TEST_BOTTLENECK is set')
 class TestBottleneck(TestCase):
-    def _run(self, command):
+    def _run(self, command, timeout=30):
         """Returns (return-code, stdout, stderr)"""
         import subprocess
 
         p = subprocess.Popen(command, stdout=subprocess.PIPE,  # noqa
                              stderr=subprocess.PIPE, shell=True)
-        output, err = p.communicate()
+        try:
+            output, err = p.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            output, err = p.communicate()
         rc = p.returncode
         output = output.decode("ascii")
         err = err.decode("ascii")


### PR DESCRIPTION
Invoke `Popen.communicate` with `timeout` argument and kill the process in `TimeoutExpired` handler

