### PR TITLE
Fix init-shutdown race condition in autograd engine

### DIFF
--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -318,7 +318,11 @@ struct TORCH_API Engine {
   // start device threads (CUDA, XLA, etc.) in Engine,
   // note that it does NOT start CPU thread.
   void start_device_threads();
-  virtual void thread_init(int device, const std::shared_ptr<ReadyQueue>& ready_queue);
+  void increment_non_reentrant_thread_count();
+  virtual void thread_init(
+      int device,
+      const std::shared_ptr<ReadyQueue>& ready_queue,
+      bool should_increment = true);
   virtual void thread_main(
       const std::shared_ptr<GraphTask>& task,
       bool reentrant_thread);
@@ -327,7 +331,7 @@ struct TORCH_API Engine {
 
   // Ensures device_ready_queues_ are initialized only once
   std::once_flag start_device_threads_flag_;
-  // Safe to read device_ready_queues_ without synchronization after intialization
+  // Safe to read device_ready_queues_ without synchronization after initialization
   std::vector<std::shared_ptr<ReadyQueue>> device_ready_queues_;
 
   std::vector<std::function<void()>> final_callbacks_;
@@ -364,8 +368,8 @@ private:
   // Number of non-reentrant threads
   std::atomic<uint32_t> non_reentrant_device_thread_count_;
   // Destructor will wait for non-reentrant threads to finish
-  std::condition_variable non_reentrant_device_thread_finish_;
-  std::mutex non_reentrant_device_thread_finish_mutex_;
+  std::condition_variable non_reentrant_device_thread_condvar_;
+  std::mutex non_reentrant_device_thread_mutex_;
 
 };
 

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -46,13 +46,17 @@ Engine& PythonEngine::get_python_engine() {
   return engine;
 }
 
-void PythonEngine::thread_init(int device, const std::shared_ptr<ReadyQueue>& ready_queue) {
+void PythonEngine::thread_init(int device, const std::shared_ptr<ReadyQueue>& ready_queue, bool should_increment) {
+  // Increment thread usage count before acquiring the GIL
+  if (should_increment) {
+    increment_non_reentrant_thread_count();
+  }
   // Create a PyThreadState, but release the GIL. This lets pybind11::gil_scoped_acquire calls
   // inside thread_main acquire the GIL without having to create a new
   // PyThreadState each time.
   pybind11::gil_scoped_acquire gil;
   pybind11::gil_scoped_release no_gil;
-  Engine::thread_init(device, ready_queue);
+  Engine::thread_init(device, ready_queue, false);
 }
 
 void PythonEngine::thread_on_exception(

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -11,7 +11,9 @@ namespace torch { namespace autograd { namespace python {
 
 struct PythonEngine : public Engine {
   static Engine& get_python_engine();
-  void thread_init(int device, const std::shared_ptr<ReadyQueue>& ready_queue) override;
+  void thread_init(int device,
+      const std::shared_ptr<ReadyQueue>& ready_queue,
+      bool should_increment) override;
   void thread_on_exception(
       std::shared_ptr<GraphTask> graph_task,
       const std::shared_ptr<Node>& fn,


### PR DESCRIPTION
If Engine is created shortly before application exits, then non-reentrant thread might not have a chance to spawn which would result in an infinite wait in `Engine::~Engine()`
Prevent this by actually waiting for threads to spawn before returning from `Engine::start_device_threads()`
Make sure that thread count is incremented before GIL is acquired in PythonThread

