### PR TITLE
Fix index overflow in ConvTranspose3d [attempt 2]

### DIFF
--- a/aten/src/ATen/native/cuda/vol2col.cuh
+++ b/aten/src/ATen/native/cuda/vol2col.cuh
@@ -133,68 +133,65 @@ void vol2col(
 
 template <typename T, typename accT>
 __global__ void vol2im_kernel(
-    const int n,
+    const unsigned n,
     const T* data_col,
-    const int depth,
-    const int height,
-    const int width,
-    const int channels,
-    const int kernel_t,
-    const int kernel_h,
-    const int kernel_w,
-    const int pad_t,
-    const int pad_h,
-    const int pad_w,
-    const int stride_t,
-    const int stride_h,
-    const int stride_w,
-    const int dilation_t,
-    const int dilation_h,
-    const int dilation_w,
-    const int depth_col,
-    const int height_col,
-    const int width_col,
+    const unsigned depth,
+    const unsigned height,
+    const unsigned width,
+    const unsigned channels,
+    const unsigned kernel_t,
+    const unsigned kernel_h,
+    const unsigned kernel_w,
+    const unsigned pad_t,
+    const unsigned pad_h,
+    const unsigned pad_w,
+    const unsigned stride_t,
+    const unsigned stride_h,
+    const unsigned stride_w,
+    const unsigned dilation_t,
+    const unsigned dilation_h,
+    const unsigned dilation_w,
+    const unsigned depth_col,
+    const unsigned height_col,
+    const unsigned width_col,
     T* data_vol) {
   CUDA_KERNEL_LOOP(index, n) {
     accT val = static_cast<accT>(0);
-    const int w_im = index % width + pad_w;
-    const int h_im = (index / width) % height + pad_h;
-    const int t_im = (index / width / height) % depth + pad_t;
-    const int c_im = index / (width * height * depth);
-    int kernel_extent_w = (kernel_w - 1) * dilation_w + 1;
-    int kernel_extent_h = (kernel_h - 1) * dilation_h + 1;
-    int kernel_extent_t = (kernel_t - 1) * dilation_t + 1;
+    const unsigned w_im = index % width + pad_w;
+    const unsigned h_im = (index / width) % height + pad_h;
+    const unsigned t_im = (index / width / height) % depth + pad_t;
+    const unsigned c_im = index / (width * height * depth);
+    unsigned kernel_extent_w = (kernel_w - 1) * dilation_w + 1;
+    unsigned kernel_extent_h = (kernel_h - 1) * dilation_h + 1;
+    unsigned kernel_extent_t = (kernel_t - 1) * dilation_t + 1;
     // compute the start and end of the output
-    const int w_col_start =
+    const unsigned w_col_start =
         (w_im < kernel_extent_w) ? 0 : (w_im - kernel_extent_w) / stride_w + 1;
-    const int w_col_end = ::min(w_im / stride_w + 1, width_col);
-    const int h_col_start =
+    const unsigned w_col_end = std::min(w_im / stride_w + 1, width_col);
+    const unsigned h_col_start =
         (h_im < kernel_extent_h) ? 0 : (h_im - kernel_extent_h) / stride_h + 1;
-    const int h_col_end = ::min(h_im / stride_h + 1, height_col);
-    const int t_col_start =
+    const unsigned h_col_end = std::min(h_im / stride_h + 1, height_col);
+    const unsigned t_col_start =
         (t_im < kernel_extent_t) ? 0 : (t_im - kernel_extent_t) / stride_t + 1;
-    const int t_col_end = ::min(t_im / stride_t + 1, depth_col);
+    const unsigned t_col_end = std::min(t_im / stride_t + 1, depth_col);
     // TODO: use LCM of stride and dilation to avoid unnecessary loops
-    for (int t_col = t_col_start; t_col < t_col_end; t_col += 1) {
-      for (int h_col = h_col_start; h_col < h_col_end; h_col += 1) {
-        for (int w_col = w_col_start; w_col < w_col_end; w_col += 1) {
-          int t_k = (t_im - t_col * stride_t);
-          int h_k = (h_im - h_col * stride_h);
-          int w_k = (w_im - w_col * stride_w);
+    for (unsigned t_col = t_col_start; t_col < t_col_end; t_col += 1) {
+      for (unsigned h_col = h_col_start; h_col < h_col_end; h_col += 1) {
+        for (unsigned w_col = w_col_start; w_col < w_col_end; w_col += 1) {
+          unsigned t_k = (t_im - t_col * stride_t);
+          unsigned h_k = (h_im - h_col * stride_h);
+          unsigned w_k = (w_im - w_col * stride_w);
           if (t_k % dilation_t == 0 && h_k % dilation_h == 0 &&
               w_k % dilation_w == 0) {
             t_k /= dilation_t;
             h_k /= dilation_h;
             w_k /= dilation_w;
-            int data_col_index =
-                (((((c_im * kernel_t + t_k) * kernel_h + h_k) * kernel_w +
-                   w_k) *
-                      depth_col +
-                  t_col) *
-                     height_col +
-                 h_col) *
-                    width_col +
-                w_col;
+            const int64_t idx_k =
+                ((c_im * kernel_t + t_k) * kernel_h + h_k * kernel_w + w_k);
+            const int64_t data_col_index =
+                ((idx_k * depth_col + t_col) *
+                    height_col + h_col) *
+                  width_col + w_col;
             val += data_col[data_col_index];
           }
         }
@@ -208,27 +205,38 @@ template <typename T, typename accT>
 void col2vol(
     cudaStream_t stream,
     const T* data_col,
-    const int channels,
-    const int depth,
-    const int height,
-    const int width,
-    const int output_depth,
-    const int output_height,
-    const int output_width,
-    const int patch_t,
-    const int patch_h,
-    const int patch_w,
-    const int pad_t,
-    const int pad_h,
-    const int pad_w,
-    const int stride_t,
-    const int stride_h,
-    const int stride_w,
-    const int dilation_t,
-    const int dilation_h,
-    const int dilation_w,
+    const int64_t channels,
+    const int64_t depth,
+    const int64_t height,
+    const int64_t width,
+    const int64_t output_depth,
+    const int64_t output_height,
+    const int64_t output_width,
+    const int64_t patch_t,
+    const int64_t patch_h,
+    const int64_t patch_w,
+    const int64_t pad_t,
+    const int64_t pad_h,
+    const int64_t pad_w,
+    const int64_t stride_t,
+    const int64_t stride_h,
+    const int64_t stride_w,
+    const int64_t dilation_t,
+    const int64_t dilation_h,
+    const int64_t dilation_w,
     T* data_vol) {
-  int num_kernels = channels * depth * height * width;
+  const auto num_kernels = channels * depth * height * width;
+
+  auto check_fits_in_unsigned =
+    [](int64_t val, const char * name) {
+      constexpr auto umax = std::numeric_limits<unsigned>::max();
+      TORCH_CHECK(val >= 0 && val <= umax,
+                  name, " must fit in a 32-bit unsigned value");
+    };
+  check_fits_in_unsigned(num_kernels, "input size");
+  check_fits_in_unsigned(
+      channels * patch_t * patch_h * patch_w, "channels x kernel size");
+
   // To avoid involving atomic operations, we will launch one kernel per
   // bottom dimension, and then in the kernel add up the top dimensions.
   vol2im_kernel<T, accT>

--- a/aten/src/ATen/native/cuda/vol2col.cuh
+++ b/aten/src/ATen/native/cuda/vol2col.cuh
@@ -187,7 +187,7 @@ __global__ void vol2im_kernel(
             h_k /= dilation_h;
             w_k /= dilation_w;
             const int64_t idx_k =
-                ((c_im * kernel_t + t_k) * kernel_h + h_k * kernel_w + w_k);
+                ((c_im * kernel_t + t_k) * kernel_h + h_k) * kernel_w + w_k;
             const int64_t data_col_index =
                 ((idx_k * depth_col + t_col) *
                     height_col + h_col) *

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6382,6 +6382,18 @@ class TestTorchDeviceType(TestCase):
         input_ = layer_norm(input_.transpose(1, 2).contiguous()).contiguous()
         input_.sum().backward()
 
+    def test_conv_transposed_large(self, device):
+        in_channels = 64
+        out_channels = 128
+        kernel_size = 5
+
+        conv = torch.nn.ConvTranspose3d(
+            in_channels, out_channels, kernel_size=kernel_size,
+            stride=2, padding=2, output_padding=1).to(device)
+
+        x = torch.rand([1, 64, 8, 128, 172]).to(device)
+        y = conv(x)
+
     @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
     @onlyCPU
     @dtypes(torch.float)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -31,7 +31,7 @@ from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, \
     skipCPUIfNoLapack, skipCPUIfNoMkl, skipCUDAIfNoMagma, skipCUDAIfRocm, skipCUDAIfNotRocm, onlyCUDA, onlyCPU, \
     dtypes, dtypesIfCUDA, dtypesIfCPU, deviceCountAtLeast, skipCUDAIf, precisionOverride, \
-    PYTORCH_CUDA_MEMCHECK, largeCUDATensorTest, onlyOnCPUAndCUDA
+    PYTORCH_CUDA_MEMCHECK, largeCUDATensorTest, largeTensorTest, onlyOnCPUAndCUDA
 import torch.backends.quantized
 import torch.testing._internal.data
 
@@ -6382,7 +6382,8 @@ class TestTorchDeviceType(TestCase):
         input_ = layer_norm(input_.transpose(1, 2).contiguous()).contiguous()
         input_.sum().backward()
 
-    @skipIfRocm
+    @skipCUDAIfRocm
+    @largeTensorTest('12GB')
     def test_conv_transposed_large(self, device):
         # ConvTranspose3d works for large input tensors (gh-32866)
         in_channels = 64

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6382,7 +6382,9 @@ class TestTorchDeviceType(TestCase):
         input_ = layer_norm(input_.transpose(1, 2).contiguous()).contiguous()
         input_.sum().backward()
 
+    @skipIfRocm
     def test_conv_transposed_large(self, device):
+        # ConvTranspose3d works for large input tensors (gh-32866)
         in_channels = 64
         out_channels = 128
         kernel_size = 5

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1,4 +1,5 @@
 import copy
+import gc
 import inspect
 import runpy
 import threading
@@ -8,6 +9,12 @@ import os
 import torch
 from torch.testing._internal.common_utils import TestCase, TEST_WITH_ROCM, TEST_MKL, \
     skipCUDANonDefaultStreamIf
+
+try:
+    import psutil
+    HAS_PSUTIL = True
+except ImportError:
+    HAS_PSUTIL = False
 
 # Note: Generic Device-Type Testing
 #
@@ -426,6 +433,34 @@ def largeCUDATensorTest(size):
         size = 1024 ** 3 * int(size[:-2])
     valid = torch.cuda.is_available() and torch.cuda.get_device_properties(0).total_memory >= size
     return unittest.skipIf(not valid, "No CUDA or Has CUDA but GPU RAM is not large enough")
+
+
+def largeTensorTest(size):
+    """Skip test if the device has insufficient memory to run the test"""
+    if isinstance(size, str):
+        assert size.endswith("GB") or size.endswith("gb"), "only bytes or GB supported"
+        size = 1024 ** 3 * int(size[:-2])
+
+    def inner(fn):
+        @wraps(fn)
+        def dep_fn(self, *args, **kwargs):
+            if self.device_type == 'cuda':
+                valid = (torch.cuda.is_available() and
+                         torch.cuda.get_device_properties(0).total_memory >= size)
+            else:
+                if not HAS_PSUTIL:
+                    raise unittest.skip('Need psutil to determine if memory is sufficient')
+
+                if psutil.virtual_memory().available < size:
+                    gc.collect()
+                valid = psutil.virtual_memory().available >= size
+
+            if not valid:
+                raise unittest.SkipTest('Insufficient {} memory'.format(self.device_type))
+
+            return fn(self, *args, **kwargs)
+        return dep_fn
+    return inner
 
 
 class expectedFailure(object):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -8,7 +8,7 @@ import unittest
 import os
 import torch
 from torch.testing._internal.common_utils import TestCase, TEST_WITH_ROCM, TEST_MKL, \
-    skipCUDANonDefaultStreamIf
+    skipCUDANonDefaultStreamIf, TEST_WITH_ASAN, TEST_WITH_UBSAN, TEST_WITH_TSAN
 
 try:
     import psutil
@@ -450,6 +450,10 @@ def largeTensorTest(size):
             else:
                 if not HAS_PSUTIL:
                     raise unittest.skip('Need psutil to determine if memory is sufficient')
+
+                # The sanitizers have significant memory overheads
+                if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+                    size *= 10
 
                 if psutil.virtual_memory().available < size:
                     gc.collect()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -453,11 +453,13 @@ def largeTensorTest(size):
 
                 # The sanitizers have significant memory overheads
                 if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
-                    size *= 10
+                    effective_size = size * 10
+                else:
+                    effective_size = size
 
-                if psutil.virtual_memory().available < size:
+                if psutil.virtual_memory().available < effective_size:
                     gc.collect()
-                valid = psutil.virtual_memory().available >= size
+                valid = psutil.virtual_memory().available >= effective_size
 
             if not valid:
                 raise unittest.SkipTest('Insufficient {} memory'.format(self.device_type))


### PR DESCRIPTION
Fixes #32866, resubmit of #38970

The memory error in the issue is caused by int overflowing in col2vol. This version using mixed 32-bit and 64-bit indexing calculation lifts the maximum indexing possible without compromising the performance of ConvTranspose3d. vs 20-30% regression with pure 64-bit indexing.

This requires that input.numel() <= UINT_MAX, and channels * kernel.numel() <= UINT_MAX otherwise it raises an error. Previously, the code would crash or give incorrect results unless input.numel() * kernel.numel() <= INT_MAX.

Note that the test is a minimised reproducer for the issue.