### PR TITLE
Change __CUDACC__ and __HIPCC__ to __CUDA_ARCH__ and __HIP_ARCH__ in NumericUtils.h

### DIFF
--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -54,7 +54,7 @@ inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
 template <typename T>
 C10_HOST_DEVICE inline T exp(T x) {
   static_assert(!std::is_same<T, double>::value, "this template must be used with float or less precise type");
-#if defined(__CUDACC__) || defined(__HIPCC__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __expf fast approximation for peak bandwidth
   return __expf(x);
 #else
@@ -70,7 +70,7 @@ C10_HOST_DEVICE inline double exp<double>(double x) {
 template <typename T>
 C10_HOST_DEVICE inline T log(T x) {
   static_assert(!std::is_same<T, double>::value, "this template must be used with float or less precise type");
-#if defined(__CUDACC__) || defined(__HIPCC__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __logf fast approximation for peak bandwidth
   return __logf(x);
 #else
@@ -86,7 +86,7 @@ C10_HOST_DEVICE inline double log<double>(double x) {
 template <typename T>
 C10_HOST_DEVICE inline T tan(T x) {
   static_assert(!std::is_same<T, double>::value, "this template must be used with float or less precise type");
-#if defined(__CUDACC__) || defined(__HIPCC__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __tanf fast approximation for peak bandwidth
   return __tanf(x);
 #else


### PR DESCRIPTION
This PR fixes the problem that [__expf/__logf/__tanf](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__INTRINSIC__SINGLE.html) are "intrinsic functions that are only supported in device code", so nvcc doesn't recognize them if it compiles host code. So `__CUDACC__ ` should be replaced with `__CUDA_ARCH__ `

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39213 Change __CUDACC__ and __HIPCC__ to __CUDA_ARCH__ and __HIP_ARCH__ in NumericUtils.h**

Differential Revision: [D21779132](https://our.internmc.facebook.com/intern/diff/D21779132)