### PR TITLE
Fix assertNotEqual error reporting

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1109,8 +1109,8 @@ class TestCase(expecttest.TestCase):
         self.assertEqual(x, y, msg=msg, atol=prec, rtol=rtol)
 
     def assertNotEqual(self, x, y, *, msg=None, atol=None, rtol=None):
-        with self.assertRaises(AssertionError):
-            self.assertEqual(x, y, msg=msg, atol=atol, rtol=rtol)
+        with self.assertRaises(AssertionError, msg=msg):
+            self.assertEqual(x, y, atol=atol, rtol=rtol)
 
     def assertEqualTypeString(self, x, y):
         # This API is used simulate deprecated x.type() == y.type()


### PR DESCRIPTION
`msg` argument must be passed to `assertRaises`, because its exception is passed upstream (with custom error message) if `assertEquals` succeedes.

