### PR TITLE
[Onnxifi] Generic way of passing output shape/type hints

### DIFF
--- a/caffe2/opt/onnxifi_op.cc
+++ b/caffe2/opt/onnxifi_op.cc
@@ -164,7 +164,61 @@ void BlobToTensorDescriptor(
   }
 }
 
+uint64_t getOnnxifiDataType(caffe2::TensorProto::DataType t) {
+#define CAFFE2_TO_ONNXIFI_TYPE(x) \
+  case (caffe2::TensorProto::x):  \
+    return ONNXIFI_DATATYPE_##x
+  switch (t) {
+    CAFFE2_TO_ONNXIFI_TYPE(INT8);
+    CAFFE2_TO_ONNXIFI_TYPE(UINT8);
+    CAFFE2_TO_ONNXIFI_TYPE(UINT16);
+    CAFFE2_TO_ONNXIFI_TYPE(INT16);
+    CAFFE2_TO_ONNXIFI_TYPE(INT32);
+    CAFFE2_TO_ONNXIFI_TYPE(INT64);
+    CAFFE2_TO_ONNXIFI_TYPE(FLOAT16);
+    case (caffe2::TensorProto::FLOAT):
+      return ONNXIFI_DATATYPE_FLOAT32;
+    default:
+      LOG(WARNING) << "Unsupported Caffe2 tensor type: " << t;
+      return ONNXIFI_DATATYPE_UNDEFINED;
+  }
+#undef CAFFE2_TO_ONNXIFI_TYPE
+}
+
 } // namespace
+
+namespace details {
+TensorInfo::TensorInfo(const TensorProto& t)
+    : onnxifi_type(getOnnxifiDataType(t.data_type())),
+      quantized(false),
+      quantizationAxis(0),
+      quantizationParams(0) {
+  for (const auto d : t.dims()) {
+    dims.push_back(d);
+  }
+}
+
+TensorInfo::TensorInfo(const QTensorProto& t)
+    : onnxifi_type(getOnnxifiDataType(t.data_type())),
+      quantized(true),
+      quantizationAxis(t.has_axis() ? t.axis() : 0),
+      quantizationParams(t.scales_size() ? t.scales_size() : 1) {
+  for (const auto d : t.dims()) {
+    dims.push_back(d);
+  }
+  if (t.scales_size()) {
+    for (const auto d : t.scales()) {
+      scales.push_back(static_cast<float>(d));
+    }
+    for (const auto d : t.biases()) {
+      biases.push_back(static_cast<int32_t>(d));
+    }
+  } else {
+    scales.push_back(static_cast<float>(t.scale()));
+    biases.push_back(static_cast<int32_t>(t.bias()));
+  }
+}
+} // namespace details
 
 template <>
 std::vector<onnxTensorDescriptorV1>

--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -26,11 +26,17 @@ struct OutputReshapeInfo {
 };
 
 struct TensorInfo {
-  TensorInfo() {}
-  TensorInfo(TensorInfo&&) = default;
-  TensorInfo& operator=(TensorInfo&&) = default;
   std::vector<uint64_t> dims;
   uint64_t onnxifi_type;
+  bool quantized;
+  uint32_t quantizationAxis;
+  uint64_t quantizationParams;
+  std::vector<float> scales;
+  std::vector<int32_t> biases;
+  explicit TensorInfo(const TensorProto& t);
+  explicit TensorInfo(const QTensorProto& t);
+  TensorInfo(TensorInfo&&) = default;
+  TensorInfo& operator=(TensorInfo&&) = default;
 };
 } // namespace details
 
@@ -72,20 +78,32 @@ class OnnxifiOp final : public Operator<Context> {
     input_shapes_.resize(input_names_.size());
     output_shapes_.resize(output_names_.size());
     int output_idx = 0;
+    ArgumentHelper helper(operator_def);
+    auto output_shape_info =
+        helper.GetRepeatedArgument<TensorProto>("output_shape_info");
+    auto output_qshape_info =
+        helper.GetRepeatedArgument<QTensorProto>("output_qshape_info");
+    std::unordered_map<std::string, TensorProto> output_shape_map;
+    for (const auto& info : output_shape_info) {
+      output_shape_map.emplace(info.name(), info);
+    }
+    std::unordered_map<std::string, QTensorProto> output_qshape_map;
+    for (const auto& info : output_qshape_info) {
+      output_qshape_map.emplace(info.name(), info);
+    }
     for (const auto& output : output_names_) {
       output_desc_.push_back(onnxTensorDescriptorV1());
       output_desc_.back().name = output.c_str();
 
       // For output, we try to get its output size hint
-      const std::string key = c10::str("output_shape_hint_", output_idx);
-      auto output_shape_hint = this->template GetRepeatedArgument<int>(key);
-      if (!output_shape_hint.empty()) {
-        details::TensorInfo info;
-        info.onnxifi_type = output_shape_hint.front();
-        for (size_t i = 1; i < output_shape_hint.size(); ++i) {
-          info.dims.push_back(output_shape_hint[i]);
+      const auto it = output_shape_map.find(output);
+      if (it != output_shape_map.end()) {
+        output_shape_hints_.emplace(output_idx, it->second);
+      } else {
+        const auto qit = output_qshape_map.find(output);
+        if (qit != output_qshape_map.end()) {
+          output_shape_hints_.emplace(output_idx, qit->second);
         }
-        output_shape_hints_.emplace(output_idx, std::move(info));
       }
       ++output_idx;
     }
@@ -263,9 +281,9 @@ class OnnxifiOp final : public Operator<Context> {
   void getExtFunctionPointers() {
 #ifdef ONNXIFI_ENABLE_EXT
     union {
-       onnxExtensionFunctionPointer p;
-       decltype(onnxSetIOAndRunGraphPointer_) set;
-       decltype(onnxReleaseTraceEventsPointer_) release;
+      onnxExtensionFunctionPointer p;
+      decltype(onnxSetIOAndRunGraphPointer_) set;
+      decltype(onnxReleaseTraceEventsPointer_) release;
     } u;
     if (lib_->onnxGetExtensionFunctionAddress(
             backend_id_, "onnxSetIOAndRunGraphFunction", &u.p) !=

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -676,7 +676,6 @@ OnnxifiTransformer::~OnnxifiTransformer() {
 
 OperatorDef OnnxifiTransformer::buildOnnxifiOp(
     const std::string& onnx_model_str,
-    const std::unordered_map<std::string, TensorShape>& output_shape_hints,
     const std::unordered_set<std::string>& initialization_list,
     const std::vector<std::string>& external_inputs,
     const std::vector<std::string>& external_outputs,
@@ -734,9 +733,9 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
   // Add output size hints
   for (int i = 0; i < op.output_size(); ++i) {
     const auto& o = op.output(i);
-    const auto it = output_shape_hints.find(o);
-    if (it != output_shape_hints.end()) {
-      const auto& shape = it->second;
+    const auto it = shape_hints.find(o);
+    if (it != shape_hints.end()) {
+      const auto& shape = it->second.shape;
       auto* output_shape_hint_arg = op.add_arg();
       output_shape_hint_arg->set_name(c10::str("output_shape_hint_", i));
       output_shape_hint_arg->add_ints(onnxifiDataType(shape.data_type()));
@@ -861,16 +860,6 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaC2(
     }
   }
 
-  // Compute output shape hints
-  std::unordered_map<std::string, TensorShape> output_shape_hints;
-  for (const auto& o : onnxifi_net.external_output()) {
-    const auto it = shape_hints.find(o);
-    CAFFE_ENFORCE(
-        it != shape_hints.end(), "Cannot find shape info for output ", o);
-    const auto& shape = it->second.shape;
-    output_shape_hints.emplace(o, shape);
-  }
-
   // Rewrite the net into a dummy in loop test mode
   ShapeInfoMap new_shape_hints;
   if (opts_.loop_test) {
@@ -905,7 +894,6 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaC2(
       onnxifi_net.external_output().end());
   auto onnxifi_op = buildOnnxifiOp(
       model_str,
-      output_shape_hints,
       initialization_list,
       onnxifi_net_inputs,
       onnxifi_net_outputs,
@@ -999,16 +987,8 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaOnnx(
       onnxifi_net_outputs,
       shape_hints_onnx_,
       std::unordered_map<std::string, ::ONNX_NAMESPACE::TypeProto>());
-  std::unordered_map<std::string, TensorShape> output_shape_hints;
   for (const auto& i : io_vec) {
     onnx_model.mutable_graph()->add_output()->CopyFrom(i);
-    const auto it = shape_hints_onnx_.find(i.name());
-    CAFFE_ENFORCE(
-        it != shape_hints_onnx_.end(),
-        "Cannot find shape info for output ",
-        i.name());
-    const auto& shape = it->second;
-    output_shape_hints.emplace(i.name(), shape);
   }
 
   // Convert inputs and figure out weights
@@ -1033,7 +1013,6 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaOnnx(
   onnx_model.SerializeToString(&model_str);
   auto onnxifi_op = buildOnnxifiOp(
       model_str,
-      output_shape_hints,
       initialization_list,
       onnxifi_net_inputs,
       onnxifi_net_outputs,

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -77,7 +77,6 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
   // We already have all the ops and external inputs and outputs!
   OperatorDef buildOnnxifiOp(
       const std::string& onnx_model_str,
-      const std::unordered_map<std::string, TensorShape>& output_size_hints,
       const std::unordered_set<std::string>& initialization_list,
       const std::vector<std::string>& external_inputs,
       const std::vector<std::string>& external_outputs,


### PR DESCRIPTION
Summary: Previously we have a ad-hoc way of passing output shape/type hints which is very limited and doesn't support quantized output. We actually have all the shape_info/qshape_info so we pass them as TensorProto and QTensorProto directly. This will pave the way for us to set output to quantized type in OnnxifiOp.

Test Plan:
```
buck test glow/fb/test:net_runner
```

Differential Revision: D21781515

