### PR TITLE
Fix missing code in 'Installing C++ distribution of Pytorch'

### DIFF
--- a/docs/cpp/source/installing.rst
+++ b/docs/cpp/source/installing.rst
@@ -93,6 +93,7 @@ distribution. If PyTorch was installed via conda or pip, `CMAKE_PREFIX_PATH` can
 using `torch.utils.cmake_prefix_path` variable. In that case CMake configuration step would look something like follows:
 
 .. code-block:: sh
+
   cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
 
 If all goes well, it will look something like this:


### PR DESCRIPTION
Fix #39236

- Before: 

![image](https://user-images.githubusercontent.com/6421097/83250998-8e0e5580-a16e-11ea-863e-ed4d9e060bdf.png)



- After:

![image](https://user-images.githubusercontent.com/6421097/83250933-73d47780-a16e-11ea-86d3-c5a77d9fa6d1.png)
