### PR TITLE
Avoid a TensorIterator/Loops reinterpret_cast in a test.

### DIFF
--- a/aten/src/ATen/test/tensor_iterator_test.cpp
+++ b/aten/src/ATen/test/tensor_iterator_test.cpp
@@ -161,7 +161,7 @@ AT_FORALL_SCALAR_TYPES_AND(Bool, COMPARISON_TEST_ITER_FOR_TYPE)
 TEST(TensorIteratorTest, SerialLoopSingleThread) {
   std::thread::id thread_id = std::this_thread::get_id();
   Tensor out;
-  auto x = at::zeros({50000}, kCPU);
+  auto x = at::zeros({50000}, at::TensorOptions(kCPU).dtype(kInt));
   auto iter = TensorIterator::unary_op(out, x);
   at::native::cpu_serial_kernel(iter, [=](int a) -> int {
     std::thread::id lambda_thread_id = std::this_thread::get_id();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39263 Kill CPPTypeToScalarType.  It's now subsumed by CPPTypeAndStdComplexToScalarType.
* #39261 Avoid defining bogus CPPTypeAndStdComplexToScalarType<void> by using some decltype tricks.
* #39258 Add dynamic_cast asserts to CPU Loops.
* #39255 Make needs_dynamic_casting multiple-complex-type aware.
* #39254 Loops: Separate out dynamic_casting concerns from complex overloads.
* **#39246 Avoid a TensorIterator/Loops reinterpret_cast in a test.**

This was found by adding some error checking in https://github.com/pytorch/pytorch/pull/38817, but that needs more work to be able to merge, so we just do a one-off fix here.

Differential Revision: [D21786761](https://our.internmc.facebook.com/intern/diff/D21786761)