### PR TITLE
Loops: Separate out dynamic_casting concerns from complex overloads.

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -99,11 +99,7 @@ struct uses_non_c10_complex<func_t, 0> {
         || std::is_same<thrust::complex<float>, type>::value
         || std::is_same<thrust::complex<double>, type>::value;
 
-    return c10::guts::if_constexpr<non_c10_complex>([]() {
-      return true;
-    }, /* else */ []() {
-      return false;
-    });
+    return non_c10_complex;
   }
 };
 

--- a/aten/src/ATen/native/cuda/ROCmLoops.cuh
+++ b/aten/src/ATen/native/cuda/ROCmLoops.cuh
@@ -62,6 +62,49 @@ static constexpr int launch_bound2 = 4;
 
 namespace at { namespace native {
 
+// See [NOTE: Complex Operator Unification]
+// std::complex and thrust::complex don't work with some !needs_dynamic_casting optimizations.
+// They always currently map to !needs_dynamic_casting even though we sometimes rely on the ability
+// to reinterpret_cast between these representations.
+// In order to separate these concerns, we have a check for non-c10 complex separately.
+template<typename func_t, int nargs=function_traits<func_t>::arity>
+struct uses_non_c10_complex {
+  constexpr static bool check() {
+    using traits = function_traits<func_t>;
+    using type = typename traits::template arg<nargs - 1>::type;
+    constexpr bool non_c10_complex =
+        std::is_same<std::complex<float>, type>::value
+        || std::is_same<std::complex<double>, type>::value
+        || std::is_same<thrust::complex<float>, type>::value
+        || std::is_same<thrust::complex<double>, type>::value;
+
+    return c10::guts::if_constexpr<non_c10_complex>([]() {
+      return true;
+    }, /* else */ []() {
+      return uses_non_c10_complex<func_t, nargs - 1>::check();
+    });
+  }
+};
+
+template<typename func_t>
+struct uses_non_c10_complex<func_t, 0> {
+  constexpr static bool check() {
+    using traits = function_traits<func_t>;
+    using type = typename traits::result_type;
+    constexpr bool non_c10_complex =
+        std::is_same<std::complex<float>, type>::value
+        || std::is_same<std::complex<double>, type>::value
+        || std::is_same<thrust::complex<float>, type>::value
+        || std::is_same<thrust::complex<double>, type>::value;
+
+    return c10::guts::if_constexpr<non_c10_complex>([]() {
+      return true;
+    }, /* else */ []() {
+      return false;
+    });
+  }
+};
+
 // NOTE: @zasdfgbnm is currently working on rewriting the gpu loops.
 // Some of the old codes has been moved to namespace legacy, and
 // new codes will be put into namespace modern. These two namespaces
@@ -274,6 +317,7 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
 
   TORCH_INTERNAL_ASSERT(iter.can_use_32bit_indexing());
   TORCH_INTERNAL_ASSERT(iter.ntensors() == traits::arity + 1);
+  bool non_c10_complex = uses_non_c10_complex<func_t>::check();
 
   at::detail::Array<char*, ntensors> data;
   for (int i = 0; i < ntensors; i++) {
@@ -293,7 +337,8 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
       strides[i] = inner_strides[i];
     }
 
-    if (needs_dynamic_casting<func_t>::check(iter)) {
+    // TODO: can non_c10_complex go through the other path?  Need to verify.
+    if (needs_dynamic_casting<func_t>::check(iter) || non_c10_complex) {
       legacy::launch_kernel<launch_size_1d, 1>(numel, [=]GPU_LAMBDA(int idx) {
         void* out = data[0] + strides[0] * idx;
         arg0_t result = legacy::invoke(f, &data.data[1], &strides.data[1], &dtypes.data[1], idx);
@@ -309,7 +354,8 @@ void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
     }
   } else {
     auto offset_calc = ::make_offset_calculator<traits::arity + 1>(iter);
-    if (needs_dynamic_casting<func_t>::check(iter)) {
+    // TODO: can non_c10_complex go through the other path?  Need to verify.
+    if (needs_dynamic_casting<func_t>::check(iter) || non_c10_complex) {
       legacy::launch_kernel<launch_size_nd, launch_bound2>(numel, [=]GPU_LAMBDA(int idx) {
         auto offsets = offset_calc.get(idx);
         void* out = data[0] + offsets[0];

--- a/aten/src/ATen/native/cuda/ROCmLoops.cuh
+++ b/aten/src/ATen/native/cuda/ROCmLoops.cuh
@@ -97,11 +97,7 @@ struct uses_non_c10_complex<func_t, 0> {
         || std::is_same<thrust::complex<float>, type>::value
         || std::is_same<thrust::complex<double>, type>::value;
 
-    return c10::guts::if_constexpr<non_c10_complex>([]() {
-      return true;
-    }, /* else */ []() {
-      return false;
-    });
+    return non_c10_complex;
   }
 };
 

--- a/c10/util/complex_type.h
+++ b/c10/util/complex_type.h
@@ -25,12 +25,12 @@ namespace c10 {
 // Since C++14, all constructors are constexpr in std::complex
 //
 // There are three types of constructors:
-// - initializing from real and imag: 
+// - initializing from real and imag:
 //     `constexpr complex( const T& re = T(), const T& im = T() );`
 // - implicitly-declared copy constructor
 // - converting constructors
 //
-// Converting constructors: 
+// Converting constructors:
 // - std::complex defines converting constructor between float/double/long double,
 //   while we define converting constructor between float/double.
 // - For these converting constructors, upcasting is implicit, downcasting is
@@ -99,18 +99,22 @@ namespace c10 {
 // - real + complex
 //
 // [Operator ==, !=]
-// 
+//
 // Each operator has three versions (taking == as example):
 // - complex == complex
 // - complex == real
 // - real == complex
-// 
+//
 // Some of them are removed on C++20, but we decide to keep them
 //
 // [Operator <<, >>]
 //
 // These are implemented by casting to std::complex
 //
+// [NOTE: Complex Operator Unification]
+// Operators currently use a mix of std::complex, thrust::complex, and c10::complex internally.
+// The end state is that all operators will use c10::complex internally.  Until then, there may
+// be some hacks to support all variants.
 //
 //
 //

--- a/c10/util/complex_type.h
+++ b/c10/util/complex_type.h
@@ -17,6 +17,12 @@ namespace c10 {
 // Most of the APIs duplicates std::complex
 // Reference: https://en.cppreference.com/w/cpp/numeric/complex
 //
+// [NOTE: Complex Operator Unification]
+// Operators currently use a mix of std::complex, thrust::complex, and c10::complex internally.
+// The end state is that all operators will use c10::complex internally.  Until then, there may
+// be some hacks to support all variants.
+//
+//
 // [Note on Constructors]
 //
 // The APIs of constructors are mostly copied from C++ standard:
@@ -110,11 +116,6 @@ namespace c10 {
 // [Operator <<, >>]
 //
 // These are implemented by casting to std::complex
-//
-// [NOTE: Complex Operator Unification]
-// Operators currently use a mix of std::complex, thrust::complex, and c10::complex internally.
-// The end state is that all operators will use c10::complex internally.  Until then, there may
-// be some hacks to support all variants.
 //
 //
 //


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39263 Kill CPPTypeToScalarType.  It's now subsumed by CPPTypeAndStdComplexToScalarType.
* #39261 Avoid defining bogus CPPTypeAndStdComplexToScalarType<void> by using some decltype tricks.
* #39258 Add dynamic_cast asserts to CPU Loops.
* #39255 Make needs_dynamic_casting multiple-complex-type aware.
* **#39254 Loops: Separate out dynamic_casting concerns from complex overloads.**
* #39246 Avoid a TensorIterator/Loops reinterpret_cast in a test.

dynamic_casting is meant to handle CUDA kernels when the operand dtypes don't match the C++ kernel function types.
This is made more complicated by the current state of complex, which uses thrust::complex, std::complex, c10::complex.

Currently, thrust::complex and std::complex map to need dynamic casting even though we don't actually cast them.
But, making them not need dynamic_cast doesn't work either because certain dynamic_casting optimizations don't work with thrust::complex and (maybe) std::complex.

So, we separate out these concerns so we can iterate on dynamic_casting checks, in particular by applying them to CPU.

This PR should have no functional change.

Differential Revision: [D21788870](https://our.internmc.facebook.com/intern/diff/D21788870)