### PR TITLE
Make needs_dynamic_casting multiple-complex-type aware.

### DIFF
--- a/aten/src/ATen/native/TensorIteratorDynamicCasting.h
+++ b/aten/src/ATen/native/TensorIteratorDynamicCasting.h
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <complex>
 #include <type_traits>
 #include <c10/core/ScalarType.h>
 #include <c10/util/C++17.h>
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/TensorIterator.h>
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#include <thrust/complex.h>
+#endif
+
 
 // This file includes utilties for dynamic_casting done by TensorIterator, see CUDALoops.cuh and Loops.h.
 
@@ -15,6 +21,58 @@
 
 namespace at { namespace native {
 
+// this extra namespace (cppmap) is to avoid conflicting with at::detail when at:: is
+// left off in native functions.
+namespace cppmap { namespace detail {
+
+// See [NOTE: Complex Operator Unification]
+// CPPTypeAndStdComplexToScalarType is equivalent to CPPTypeToScalarType, but also includes mappings
+// from all the complex types.
+template <typename>
+struct CPPTypeAndStdComplexToScalarType {
+};
+
+#define SPECIALIZE_CPPTypeAndStdComplexToScalarType(cpp_type, scalar_type)                  \
+  template <>                                                                               \
+  struct CPPTypeAndStdComplexToScalarType<cpp_type> {                                       \
+    constexpr static c10::ScalarType value() { return c10::ScalarType::scalar_type; }       \
+  };
+
+AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_CPPTypeAndStdComplexToScalarType)
+
+#undef SPECIALIZE_CPPTypeeAndStdComplexToScalarType
+
+template<>
+struct CPPTypeAndStdComplexToScalarType<std::complex<float>> {
+    constexpr static c10::ScalarType value() { return c10::ScalarType::ComplexFloat; }
+};
+
+template<>
+struct CPPTypeAndStdComplexToScalarType<std::complex<double>> {
+  constexpr static c10::ScalarType value() { return c10::ScalarType::ComplexDouble; }
+};
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+template<>
+struct CPPTypeAndStdComplexToScalarType<thrust::complex<float>> {
+  constexpr static c10::ScalarType value() { return c10::ScalarType::ComplexFloat; }
+};
+
+template<>
+struct CPPTypeAndStdComplexToScalarType<thrust::complex<double>> {
+  constexpr static c10::ScalarType value() { return c10::ScalarType::ComplexDouble; }
+};
+#endif
+
+// this shouldn't strictly be necessary, but needs some finagling to get to work
+// with "fake" C++17 if_constexpr.
+template<>
+struct CPPTypeAndStdComplexToScalarType<void> {
+  constexpr static c10::ScalarType value() { return c10::ScalarType::Undefined; }
+};
+
+}} //namespace cppmap::detail
+
 // `needs_dynamic_casting` compares the types expected by iterator
 // (i.e. dtypes of the operands) with the actual type of the arguments
 // (and returns) of func_t
@@ -22,7 +80,10 @@ template<typename func_t, int nargs=function_traits<func_t>::arity>
 struct needs_dynamic_casting {
   static bool check(TensorIterator& iter) {
     using traits = function_traits<func_t>;
-    if (iter.input_dtype(nargs-1) != c10::impl::CPPTypeToScalarType<typename traits::template arg<nargs - 1>::type>::value) {
+    using cpp_type = typename traits::template arg<nargs - 1>::type;
+    using cpp_map = cppmap::detail::CPPTypeAndStdComplexToScalarType<cpp_type>;
+
+    if (iter.input_dtype(nargs-1) != cpp_map::value()) {
       return true;
     }
     return needs_dynamic_casting<func_t, nargs - 1>::check(iter);
@@ -33,13 +94,16 @@ template<typename func_t>
 struct needs_dynamic_casting<func_t, 0> {
   static bool check(TensorIterator& iter) {
     using traits = function_traits<func_t>;
+    using cpp_type = typename traits::result_type;
+    using cpp_map = cppmap::detail::CPPTypeAndStdComplexToScalarType<cpp_type>;
 
     // we could assert output numbers are correct here, but checks
     // (including arity) are currently pushed outside of this struct.
-    return c10::guts::if_constexpr<std::is_void<typename traits::result_type>::value>(
-      [&]() { return false; },
-      [&]() { return iter.dtype(0) != c10::impl::CPPTypeToScalarType<typename traits::result_type>::value;}
-    );
+    return c10::guts::if_constexpr<std::is_void<cpp_type>::value>([]() {
+      return false;
+    }, /* else */ [&]() {
+      return iter.dtype(0) != cpp_map::value();
+    });
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39263 Kill CPPTypeToScalarType.  It's now subsumed by CPPTypeAndStdComplexToScalarType.
* #39261 Avoid defining bogus CPPTypeAndStdComplexToScalarType<void> by using some decltype tricks.
* #39258 Add dynamic_cast asserts to CPU Loops.
* **#39255 Make needs_dynamic_casting multiple-complex-type aware.**
* #39254 Loops: Separate out dynamic_casting concerns from complex overloads.
* #39246 Avoid a TensorIterator/Loops reinterpret_cast in a test.

We don't actually cast between these complex representations, but the prior implementation would indicate that we needed to dynamic_cast,
because we didn't have mappings for std::complex or thrust::complex.

This PR makes it so they all map to the same dtype.

Note that this has no functional change as all the use sites have already been changed to take this into account.

Differential Revision: [D21789694](https://our.internmc.facebook.com/intern/diff/D21789694)