### PR TITLE
Add dynamic_cast asserts to CPU Loops.

### DIFF
--- a/aten/src/ATen/native/cpu/FillKernel.cpp
+++ b/aten/src/ATen/native/cpu/FillKernel.cpp
@@ -17,7 +17,7 @@ static void fill_non_native_type(TensorIterator& iter, Scalar value_scalar) {
   using H = typename std::make_signed<decltype(value)>::type;  // Signed type has more acceleration
   // Reserve the representation of value. static_cast<H>(value) is implementation defined.
   H val = *reinterpret_cast<H*>(std::addressof(value));
-  cpu_kernel_vec(
+  cpu_kernel_vec</*check_dynamic_cast=*/false>(
       iter,
       [val]() -> H { return val; },
       [val]() { return Vec256<H>(val); });

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -31,6 +31,7 @@
 #include <ATen/detail/FunctionTraits.h>
 #include <ATen/native/cpu/IsContiguous.h>
 #include <ATen/native/TensorIterator.h>
+#include <ATen/native/TensorIteratorDynamicCasting.h>
 #include <ATen/cpu/vec256/vec256.h>
 
 #ifndef _MSC_VER
@@ -189,6 +190,8 @@ void cpu_kernel(TensorIterator& iter, func_t&& op) {
   // this could be extended to work with void return types
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity);
   TORCH_INTERNAL_ASSERT(iter.noutputs() == 1);
+  // dynamic casting not currently supported on CPU
+  TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
 
   iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
     if (is_contiguous<traits>(strides)) {
@@ -203,12 +206,17 @@ void cpu_kernel(TensorIterator& iter, func_t&& op) {
   iter.cast_outputs();
 }
 
-template <typename func_t, typename vec_func_t>
+template <bool check_dynamic_cast=true, typename func_t, typename vec_func_t>
 void cpu_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop) {
   using traits = function_traits<func_t>;
   // this could be extended to work with void return types
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity);
   TORCH_INTERNAL_ASSERT(iter.noutputs() == 1);
+  // dynamic casting not currently supported on CPU, but some kernels (like Fill)
+  // explicitly dynamic_cast, so we give the opt-out of checking.
+  c10::guts::if_constexpr<check_dynamic_cast>([&] {
+    TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
+  });
 
   iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
     if (is_contiguous<traits>(strides)) {
@@ -233,6 +241,8 @@ void cpu_serial_kernel(TensorIterator& iter, func_t&& op, const Range& range) {
   constexpr bool result_void = std::is_void<typename traits::result_type>::value;
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity &&
                         ((result_void && iter.noutputs() == 0) || (!result_void && iter.noutputs() == 1)));
+  // dynamic casting not currently supported on CPU
+  TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
 
   iter.serial_for_each([&](char** data, const int64_t* strides, int64_t n) {
     if (is_contiguous<traits>(strides)) {
@@ -258,6 +268,8 @@ void cpu_serial_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop, 
   // this could be extended to work with void return types
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity);
   TORCH_INTERNAL_ASSERT(iter.noutputs() == 1);
+  // dynamic casting not currently supported on CPU
+  TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
 
   iter.serial_for_each([&](char** data, const int64_t* strides, int64_t n) {
     if (is_contiguous<traits>(strides)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39263 Kill CPPTypeToScalarType.  It's now subsumed by CPPTypeAndStdComplexToScalarType.
* #39261 Avoid defining bogus CPPTypeAndStdComplexToScalarType<void> by using some decltype tricks.
* **#39258 Add dynamic_cast asserts to CPU Loops.**
* #39255 Make needs_dynamic_casting multiple-complex-type aware.
* #39254 Loops: Separate out dynamic_casting concerns from complex overloads.
* #39246 Avoid a TensorIterator/Loops reinterpret_cast in a test.

On CUDA, we currently support casting loops dynamically (i.e. when the argument or return types of the lamba don't match the dtypes of the TensorIterator).
On CPU, before this change we would essentially reinterpret_cast, now we internal assert. We could add dynamic_casting support in the future on CPU.

Differential Revision: [D21790020](https://our.internmc.facebook.com/intern/diff/D21790020)