### PR TITLE
Kill CPPTypeToScalarType.  It's now subsumed by CPPTypeAndStdComplexToScalarType.

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -94,24 +94,6 @@ AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_ScalarTypeToCPPType)
 
 #undef SPECIALIZE_ScalarTypeToCPPType
 
-
-// These are used to map C++ types to ScalarTypes.
-
-template <typename>
-struct CPPTypeToScalarType {
-  constexpr static c10::ScalarType value = c10::ScalarType::Undefined;
-};
-
-#define SPECIALIZE_CPPTypeToScalarType(cpp_type, scalar_type)                  \
-  template <>                                                                  \
-  struct CPPTypeToScalarType<cpp_type> {                                       \
-    constexpr static c10::ScalarType value = c10::ScalarType::scalar_type;     \
-  };
-
-AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_CPPTypeToScalarType)
-
-#undef SPECIALIZE_CPPTypeToScalarType
-
 }
 
 #define AT_FORALL_SCALAR_TYPES(_) \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39263 Kill CPPTypeToScalarType.  It's now subsumed by CPPTypeAndStdComplexToScalarType.**
* #39261 Avoid defining bogus CPPTypeAndStdComplexToScalarType<void> by using some decltype tricks.
* #39258 Add dynamic_cast asserts to CPU Loops.
* #39255 Make needs_dynamic_casting multiple-complex-type aware.
* #39254 Loops: Separate out dynamic_casting concerns from complex overloads.
* #39246 Avoid a TensorIterator/Loops reinterpret_cast in a test.

CPPTypeToScalarType is confusing because it doesn't handle the different complex types and it maps everything that it doesn't know about to Undefined, which is error prone.

Differential Revision: [D21790515](https://our.internmc.facebook.com/intern/diff/D21790515)