### PR TITLE
Set RecordFunction id only when needed

### DIFF
--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -87,8 +87,10 @@ class CallbackManager {
     auto scope = rec_fn.scope();
     bool found_active_cb = false;
     bool found_needs_inputs = false;
-    auto init_handles = [scope, &found_active_cb, &found_needs_inputs](
-        CallbackHandles& handles, RecordFunctionCallbacks& cbs) {
+    bool found_needs_ids = false;
+    auto init_handles = [
+        scope, &found_active_cb, &found_needs_inputs, &found_needs_ids](
+          CallbackHandles& handles, RecordFunctionCallbacks& cbs) {
       handles.clear();
       for (const auto& cb : cbs) {
         if (cb.first.shouldRun(scope)) {
@@ -96,6 +98,9 @@ class CallbackManager {
           found_active_cb = true;
           if (cb.first.needsInputs()) {
             found_needs_inputs = true;
+          }
+          if (cb.first.needsIds()) {
+            found_needs_ids = true;
           }
         }
       }
@@ -105,7 +110,9 @@ class CallbackManager {
     init_handles(rec_fn.sorted_active_global_handles_, sorted_global_callbacks_);
     rec_fn.active = found_active_cb;
     rec_fn.needs_inputs = found_needs_inputs;
-    rec_fn.setHandle(next_unique_record_function_handle());
+    if (found_needs_ids && found_active_cb) {
+      rec_fn.setHandle(next_unique_record_function_handle());
+    }
   }
 
   void runStartCallbacks(RecordFunction& rf) {

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -234,6 +234,11 @@ class TORCH_API RecordFunctionCallback {
     return *this;
   }
 
+  RecordFunctionCallback& needsIds(bool needs_ids) {
+    needs_ids_ = needs_ids;
+    return *this;
+  }
+
   RecordFunctionCallback& samplingProb(double sampling_prob) {
     TORCH_CHECK(sampling_prob >= 0.0 && sampling_prob_ <= 1.0,
         "Invalid sampling probability");
@@ -262,6 +267,10 @@ class TORCH_API RecordFunctionCallback {
 
   inline bool needsInputs() const {
     return needs_inputs_;
+  }
+
+  inline bool needsIds() const {
+    return needs_ids_;
   }
 
   inline double samplingProb() const {
@@ -303,6 +312,7 @@ class TORCH_API RecordFunctionCallback {
   std::function<void(const RecordFunction&)> end_;
   std::function<bool(const RecordFunctionCallback&)> should_run_;
   bool needs_inputs_ = false;
+  bool needs_ids_ = false;
   double sampling_prob_ = 1.0;
   std::array<bool, static_cast<size_t>(RecordScope::NUM_SCOPES)> scopes_ = {};
 

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1079,6 +1079,24 @@ void testRecordFunction() {
     removeCallback(handle);
   });
   t.join();
+  clearCallbacks();
+
+  // test set ids
+  bool has_ids = false;
+  addGlobalCallback(RecordFunctionCallback(
+      [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
+      [](const RecordFunction&) {})
+      .needsIds(true));
+  { RECORD_USER_SCOPE("test"); }
+  TORCH_CHECK(has_ids);
+  clearCallbacks();
+  has_ids = false;
+  addGlobalCallback(RecordFunctionCallback(
+      [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
+      [](const RecordFunction&) {}));
+  { RECORD_USER_SCOPE("test"); }
+  TORCH_CHECK(!has_ids);
+  clearCallbacks();
 }
 
 class TestThreadLocalDebugInfo : public c10::DebugInfoBase {

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -335,7 +335,8 @@ void pushProfilingCallbacks() {
         }
         state_ptr->popRange(fn.getStartCallbacksThreadId(), fn.handle());
       })
-    .needsInputs(state_ptr->config().report_input_shapes));
+    .needsInputs(state_ptr->config().report_input_shapes)
+    .needsIds(true));
   state_ptr->setCallbackHandle(handle);
 }
 


### PR DESCRIPTION
Summary:
In this PR we set id of RecordFunction only when callbacks need them and when
there's at least one active callback

Test Plan:
testRecordFunction unit test in test_misc.cpp


Differential Revision: D21790421

