### PR TITLE
[TensorExpr] Fix two bugs in Rfactor

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -64,6 +64,7 @@ namespace jit {
   _(Reduce3DRfactorRepeated)                \
   _(ReduceRfactorInsertionPoint)            \
   _(Reduce3DRfactorInsertionPoint)          \
+  _(ReduceRepeatedInternalRfactor)          \
   _(ReduceSplitTail)                        \
   _(ReduceSplitNoTail)                      \
   _(ReduceOverSplitTail)                    \

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1528,18 +1528,18 @@ void LoopNest::rfactor(
                                       reduce_op->reduce_args().end()};
 
   // Store loops below the target point.
-  std::vector<const For*> init_loops;
+  std::vector<const For*> output_loops;
 
   while (st) {
     if (For* f = dynamic_cast<For*>(st)) {
       if (f->var() == reduction_var) {
         target_for = f;
-        init_loops.push_back(f);
+        output_loops.push_back(f);
       }
       if (reduce_args.count(f->var())) {
         reduce_args.erase(f->var());
       } else {
-        init_loops.push_back(f);
+        output_loops.push_back(f);
       }
 
       if (reduce_args.empty()) {
@@ -1658,11 +1658,11 @@ void LoopNest::rfactor(
         new Store(tmp_buf, new_outer, init_it->second, new IntImm(1));
 
     // Wrap it in any loops lower than the insertion point of the new reduction.
-    for (auto* il : init_loops) {
-      init_stmt = il->cloneWithNewBody(init_stmt);
+    for (auto* ol : output_loops) {
+      init_stmt = ol->cloneWithNewBody(init_stmt);
     }
 
-    parent_block->prepend_stmt(init_stmt);
+    parent_block->insert_stmt_before(init_stmt, new_root_for);
   } else {
     // We may support this but not possible now.
     throw std::runtime_error("can't rfactor reduction with no initializer\n");
@@ -1676,16 +1676,16 @@ void LoopNest::rfactor(
     insertion_point->append_stmt(
         new Store(second_buf, second_indices, second_reduce, new IntImm(1)));
   } else {
-    For* new_for = new For(
-        target_for->var(),
-        target_for->start(),
-        target_for->stop(),
-        new Store(second_buf, second_indices, second_reduce, new IntImm(1)),
-        target_for->loop_options());
+    Stmt* body_stmt =
+        new Store(second_buf, second_indices, second_reduce, new IntImm(1));
+
+    for (auto* il : output_loops) {
+      body_stmt = il->cloneWithNewBody(body_stmt);
+    }
     if (insertion_point) {
-      insertion_point->append_stmt(new_for);
+      insertion_point->append_stmt(body_stmt);
     } else {
-      parent_block->append_stmt(new_for);
+      parent_block->insert_stmt_after(body_stmt, new_root_for);
     }
   }
 

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -115,6 +115,21 @@ class TORCH_API Block : public StmtNode<Block> {
     set_parent(s, this);
   }
 
+  void insert_stmt_before(Stmt* s, Stmt* before) {
+    if (s->get_parent()) {
+      throw malformed_input("Block append Stmt with existing parent", s);
+    }
+
+    auto pos = std::find(stmts_.begin(), stmts_.end(), before);
+    if (pos == stmts_.end()) {
+      throw malformed_input(
+          "Inserting after statement that is not in block", s);
+    }
+
+    stmts_.insert(pos, s);
+    set_parent(s, this);
+  }
+
   void insert_stmt_after(Stmt* s, Stmt* after) {
     if (s->get_parent()) {
       throw malformed_input("Block append Stmt with existing parent", s);


### PR DESCRIPTION
The two bugs were:
* Non-reduction axes were not added when inserting the new ReduceOp, meaning if a reduction with non-reduce axes was rfactored we'd produce bad outputs. There were no tests of Rfactor with non-reduce axis so I modified a test to do this.
* The new statements were always prepended to the block, meaning writes to a buffer could be reordered after the usage of that buffer. This mostly happened in the case where we rfactor a previously rfactored reduction. There was a test of this, but since it only tested rfactoring the outer reduction axis there was never any other statements at the insertion point (the tests of the insertion point argument also do this). I added a new test which covers various rfactor-axis cases.

Also cleaned up tests, removed some helper code we don't need etc.