### PR TITLE
Fix parsing of subscript expressions using python resolver

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -440,7 +440,13 @@ class TestScriptPy3(JitTestCase):
 
     def test_unimported_type_resolution(self):
         # verify fallback from the python resolver to the c++ resolver
-        assert False, "TODO implement me, maybe in a new file?"
+
+        @ torch.jit.script
+        def fn(x):
+            # type (number) -> number
+            return x + 1
+
+        FileCheck().check('number').run(fn.graph)
 
     def test_parser_bug(self):
         def parser_bug(o: Optional[torch.Tensor]):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -403,6 +403,33 @@ class TestScriptPy3(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, "Lists must contain only a single type"):
             torch.jit.script(wrong_type)
 
+    def test_subexpression_List_Future(self):
+        from typing import List
+        @torch.jit.script
+        def fn(x: List[torch.jit.Future[int]]):
+            return x
+
+        g = fn.graph
+        assert "Future" in repr(g)
+
+    def test_subexpression_Tuple_int_int_Future(self):
+        from typing import Tuple
+        @torch.jit.script
+        def fn(x: Tuple[int, int, torch.jit.Future[int]]):
+            return x
+
+        g = fn.graph
+        assert "Future" in repr(g)
+
+    def test_subexpression_Dict_int_Future(self):
+        from typing import Tuple
+        @torch.jit.script
+        def fn(x: Dict[int, torch.jit.Future[int]]):
+            return x
+
+        g = fn.graph
+        assert "Future" in repr(g)
+
     def test_parser_bug(self):
         def parser_bug(o: Optional[torch.Tensor]):
             pass

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -407,7 +407,7 @@ class TestScriptPy3(JitTestCase):
 
         @torch.jit.script
         def fn(x: List[torch.jit.Future[int]]):
-            return x
+            return x[0]
 
         g = fn.graph
         assert "Future" in repr(g)
@@ -416,7 +416,7 @@ class TestScriptPy3(JitTestCase):
 
         @torch.jit.script
         def fn(x: Tuple[int, int, torch.jit.Future[int]]):
-            return x
+            return x[0], x[2]
 
         g = fn.graph
         assert "Future" in repr(g)
@@ -424,14 +424,21 @@ class TestScriptPy3(JitTestCase):
     def test_subexpression_Dict_int_Future(self):
 
         @torch.jit.script
-        def fn(x: Dict[int, torch.jit.Future[int]]):
-            return x
+        def fn(x: Dict[int, torch.jit.Future[int]], y: int):
+            return x[y]
 
         g = fn.graph
         assert "Future" in repr(g)
 
     def test_subexpression_Optional(self):
-        assert False, "TODO implement me"
+
+        @torch.jit.script
+        def fn(x: Optional[Dict[int, torch.jit.Future[int]]]):
+            if x is not None:
+                return x[0]
+            else:
+                return None
+
 
     def test_unimported_type_resolution(self):
         # verify fallback from the python resolver to the c++ resolver

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -404,7 +404,7 @@ class TestScriptPy3(JitTestCase):
             torch.jit.script(wrong_type)
 
     def test_subexpression_List_Future(self):
-        from typing import List
+
         @torch.jit.script
         def fn(x: List[torch.jit.Future[int]]):
             return x
@@ -413,7 +413,7 @@ class TestScriptPy3(JitTestCase):
         assert "Future" in repr(g)
 
     def test_subexpression_Tuple_int_int_Future(self):
-        from typing import Tuple
+
         @torch.jit.script
         def fn(x: Tuple[int, int, torch.jit.Future[int]]):
             return x
@@ -422,13 +422,20 @@ class TestScriptPy3(JitTestCase):
         assert "Future" in repr(g)
 
     def test_subexpression_Dict_int_Future(self):
-        from typing import Tuple
+
         @torch.jit.script
         def fn(x: Dict[int, torch.jit.Future[int]]):
             return x
 
         g = fn.graph
         assert "Future" in repr(g)
+
+    def test_subexpression_Optional(self):
+        assert False, "TODO implement me"
+
+    def test_unimported_type_resolution(self):
+        # verify fallback from the python resolver to the c++ resolver
+        assert False, "TODO implement me, maybe in a new file?"
 
     def test_parser_bug(self):
         def parser_bug(o: Optional[torch.Tensor]):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -443,10 +443,10 @@ class TestScriptPy3(JitTestCase):
 
         @ torch.jit.script
         def fn(x):
-            # type (number) -> number
+            # type: (number) -> number
             return x + 1
 
-        FileCheck().check('number').run(fn.graph)
+        FileCheck().check('Scalar').run(fn.graph)
 
     def test_parser_bug(self):
         def parser_bug(o: Optional[torch.Tensor]):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -406,39 +406,37 @@ class TestScriptPy3(JitTestCase):
     def test_subexpression_List_Future(self):
 
         @torch.jit.script
-        def fn(x: List[torch.jit.Future[int]]):
+        def fn(x: List[torch.jit.Future[int]]) -> torch.jit.Future[int]:
             return x[0]
 
-        g = fn.graph
-        assert "Future" in repr(g)
+        FileCheck().check('Future[int]').check('Future[int]').run(fn.graph)
 
     def test_subexpression_Tuple_int_int_Future(self):
 
         @torch.jit.script
-        def fn(x: Tuple[int, int, torch.jit.Future[int]]):
+        def fn(x: Tuple[int, int, torch.jit.Future[int]]) -> Tuple[int, torch.jit.Future[int]]:
             return x[0], x[2]
 
-        g = fn.graph
-        assert "Future" in repr(g)
+        FileCheck().check('(int, int, Future[int])').check('(int, Future[int])').run(fn.graph)
 
     def test_subexpression_Dict_int_Future(self):
 
         @torch.jit.script
-        def fn(x: Dict[int, torch.jit.Future[int]], y: int):
+        def fn(x: Dict[int, torch.jit.Future[int]], y: int) -> torch.jit.Future[int]:
             return x[y]
 
-        g = fn.graph
-        assert "Future" in repr(g)
+        FileCheck().check('Dict(int, Future(int))').check('Future[int]').run(fn.graph)
 
     def test_subexpression_Optional(self):
 
         @torch.jit.script
-        def fn(x: Optional[Dict[int, torch.jit.Future[int]]]):
+        def fn(x: Optional[Dict[int, torch.jit.Future[int]]]) -> Optional[torch.jit.Future[int]]:
             if x is not None:
                 return x[0]
             else:
                 return None
 
+        FileCheck().check('Dict(int, Future(int))?').run(fn.graph)
 
     def test_unimported_type_resolution(self):
         # verify fallback from the python resolver to the c++ resolver

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -37,7 +37,7 @@ def createResolutionCallbackFromEnv(lookup_base):
             base_mod = env(base, module)
 
             # intentional bailout, e.g. base == "Tuple" but wasn't imported in Module
-            if not base_mod:
+            if not base_mod or isinstance(base_mod, type):
                 return None
 
             # assume only subexp (between []) could contain ','
@@ -51,7 +51,10 @@ def createResolutionCallbackFromEnv(lookup_base):
                     if c == '[':
                         nest_level += 1
                     elif c == ']':
-                        assert nest_level > 0
+
+                        # fall back to c++ for unit test legacy behavior
+                        if nest_level == 0:
+                            return None
                         nest_level -= 1
                     elif c == ',' and nest_level == 0:
                         splits.append(i)

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -58,9 +58,9 @@ def createResolutionCallbackFromEnv(lookup_base):
         elif '.' in qualified_name:
             parts = qualified_name.split('.')
             base = parts[0]
-            remainding_pieces = '.'.join(parts[1:])
+            remaining_pieces = '.'.join(parts[1:])
             module_value = getattr(module, base)
-            return env(remainding_pieces, module_value)
+            return env(remaining_pieces, module_value)
         elif 'int' == qualified_name:
             return int
         elif 'float' == qualified_name:

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -65,6 +65,12 @@ def createResolutionCallbackFromEnv(lookup_base):
             assert len_parsed == len(expr), "whole expression was not parsed, falling back to c++ parser"
             return value
         except Exception as e:
+            """
+            The python resolver fails in several cases in known unit tests, and is intended
+            to fall back gracefully to the c++ resolver in general.  For example, python 2 style
+            annotations which are frequent in our unit tests often fail with types e.g. int not
+            resolvable from the calling frame.
+            """
             return None
 
     return lambda expr: parseExpr(expr, lookup_base)

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -26,55 +26,6 @@ def createResolutionCallbackFromEnv(lookup_base):
     You should not use this directly, it should only be used from the other
     createResolutionCallbackFrom* functions.
     """
-    def try_build_type(base_mod, subexp_mod):
-        if subexp_mod is None:
-            return None
-        try:
-            return base_mod[subexp_mod]
-        except TypeError:
-            # intentional bailout, fall back to c++ parser
-            return None
-
-    def subexpression(subexp, base_mod, module):
-        if ',' in subexp:
-            subexp = "".join(subexp.split())
-            splits = []
-            nest_level = 0
-            for i, c in enumerate(subexp):
-                if c == '[':
-                    nest_level += 1
-                elif c == ']':
-
-                    # fall back to c++ for unit test legacy behavior
-                    if nest_level == 0:
-                        return None
-                    nest_level -= 1
-                elif c == ',' and nest_level == 0:
-                    splits.append(i)
-
-            parts = []
-            if len(splits):
-                last_idx = 0
-                for idx in splits:
-                    parts.append(subexp[last_idx:idx])
-                    last_idx = idx + 1
-                parts.append(subexp[last_idx:])
-
-                types = [env(p, module) for p in parts]
-                if None in types:
-                    return None
-                return try_build_type(base_mod, tuple(types))
-
-            else:
-                subexp_mod = env(subexp, module)
-                return try_build_type(base_mod, subexp_mod)
-        else:
-            # either base or subexp could include '.' or '['
-            if 'Tensor' == subexp:
-                subexp = 'torch.Tensor'
-            subexp_mod = env(subexp, module)
-            return try_build_type(base_mod, subexp_mod)
-
     def lookupInModule(qualified_name, module):
         if '.' in qualified_name:
             parts = qualified_name.split('.')
@@ -85,14 +36,6 @@ def createResolutionCallbackFromEnv(lookup_base):
         else:
             return getattr(module, qualified_name)
 
-    """
-    Issues:
-    - first while loop missing ']' case to stop? or should be this way?
-    - return returns length of just the validly constructed expr, not the ',' or '[' after it?
-        - bottom while needs +1 to skip over the delimiter, does this also kill the ']'?
-            - maybe ']' is never a delimiter and that solves both while questions...
-
-    """
     def parseNestedExpr(expr, module) -> Tuple[Any, int]:
         i = 0
         while i < len(expr) and expr[i] not in (',', '[', ']'):
@@ -122,25 +65,6 @@ def createResolutionCallbackFromEnv(lookup_base):
             return value
         except Exception as e:
             return None
-
-
-    def env(qualified_name, module):
-        # We may need to resolve a qualified name, something like `torch.device`
-        # or `a.b.c.d`. We first look up `torch` or `a` in the function's closed
-        # over scope, then proceed to use the looked-up value to go down the
-        # chain.
-        if '[' in qualified_name:
-            first, last = qualified_name.find('['), qualified_name.rfind(']')
-            base = qualified_name[:first]
-            base_mod = env(base, module)
-
-            # assume only subexp (between []) could contain ','
-            # but allow each element of the list to be any type hence recursive env()
-            subexp = qualified_name[first + 1: last]
-            return subexpression(subexp, base_mod, module)
-
-        else:
-            return lookupInModule(qualified_name, module)
 
     return lambda expr: parseExpr(expr, lookup_base)
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -94,14 +94,13 @@ def createResolutionCallbackFromEnv(lookup_base):
 
     """
     def parseNestedExpr(expr, module) -> Tuple[Any, int]:
-        print("parseNest, ", expr)
         i = 0
         while i < len(expr) and expr[i] not in (',', '[', ']'):
             i += 1
 
         base = lookupInModule(expr[:i].strip(), module)
+        assert base is not None, "Unresolvable type {}".format(expr[:i])
         if i == len(expr) or expr[i] != '[':
-            print("   ret ", base, i)
             return base, i
 
         assert expr[i] == '['
@@ -112,24 +111,16 @@ def createResolutionCallbackFromEnv(lookup_base):
             part, part_len = parseNestedExpr(expr[i:], module)
             parts.append(part)
             i += part_len
-            print(i, expr[i])
-            if part_len == 0:
-                break
-
         if len(parts) > 1:
-            print("ret ", base, parts)
-            return base[tuple(parts)], i
+            return base[tuple(parts)], i + 1
         else:
-            print("ret ", base, parts[0])
-            return base[parts[0]], i
+            return base[parts[0]], i + 1
 
     def parseExpr(expr, module):
-        # import pdb; pdb.set_trace()
         try:
             value, _ = parseNestedExpr(expr, module)
             return value
         except Exception as e:
-            print(e)
             return None
 
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -61,7 +61,8 @@ def createResolutionCallbackFromEnv(lookup_base):
 
     def parseExpr(expr, module):
         try:
-            value, _ = parseNestedExpr(expr, module)
+            value, len_parsed = parseNestedExpr(expr, module)
+            assert len_parsed == len(expr), "whole expression was not parsed, falling back to c++ parser"
             return value
         except Exception as e:
             return None

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -48,21 +48,11 @@ def createResolutionCallbackFromEnv(lookup_base):
                 no_whitespace = "".join(subexp.split())
                 parts = no_whitespace.split(',')
                 types = [env(p, module) for p in parts]
-
-                # HACK for now - must be a better way to approximate base_mod[*types]
-                if len(types) == 1:
-                    return base_mod[types[0]]
-                elif len(types) == 2:
-                    return base_mod[types[0], types[1]]
-                elif len(types) == 3:
-                    return base_mod[types[0], types[1], types[2]]
-                elif len(types) == 4:
-                    return base_mod[types[0], types[1], types[2], types[3]]
-                else:
-                    raise ValueError("tuples beyond length 4 not supported yet.")
-
+                return base_mod[tuple(types)]
             else:
                 # either base or subexp could include '.' or '['
+                if 'Tensor' == subexp:
+                    subexp = 'torch.Tensor'
                 subexp_mod = env(subexp, module)
                 return base_mod[subexp_mod]
         elif '.' in qualified_name:

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -66,6 +66,10 @@ def createResolutionCallbackFromEnv(lookup_base):
             remainding_pieces = '.'.join(parts[1:])
             module_value = getattr(module, base)
             return env(remainding_pieces, module_value)
+        elif 'int' == qualified_name:
+            return int
+        elif 'float' == qualified_name:
+            return float
         else:
             return getattr(module, qualified_name)
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -36,10 +36,15 @@ def createResolutionCallbackFromEnv(lookup_base):
             base = qualified_name[:first]
             base_mod = env(base, module)
 
+            # intentional bailout, e.g. base == "Tuple" but wasn't imported in Module
+            if not base_mod:
+                return None
+
             # assume only subexp (between []) could contain ','
             # but allow each element of the list to be any type hence recursive env()
             subexp = qualified_name[first + 1: last]
-            if ',' in subexp:
+            if ',' in subexp and (subexp.find('[') == -1 or
+                                  subexp.find('[') > subexp.find(',')):
                 no_whitespace = "".join(subexp.split())
                 parts = no_whitespace.split(',')
                 types = [env(p, module) for p in parts]

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -31,7 +31,16 @@ def createResolutionCallbackFromEnv(lookup_base):
         # or `a.b.c.d`. We first look up `torch` or `a` in the function's closed
         # over scope, then proceed to use the looked-up value to go down the
         # chain.
-        if '.' in qualified_name:
+        if '[' in qualified_name:
+            first, last = qualified_name.find('['), qualified_name.rfind(']')
+            base = qualified_name[:first]
+            subexp = qualified_name[first + 1: last]
+
+            # either base or subexp could include '.' or '['
+            base_mod = env(base, module)
+            subexp_mod = env(subexp, module)
+            return base_mod[subexp_mod]
+        elif '.' in qualified_name:
             parts = qualified_name.split('.')
             base = parts[0]
             remainding_pieces = '.'.join(parts[1:])

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -94,31 +94,42 @@ def createResolutionCallbackFromEnv(lookup_base):
 
     """
     def parseNestedExpr(expr, module) -> Tuple[Any, int]:
+        print("parseNest, ", expr)
         i = 0
         while i < len(expr) and expr[i] not in (',', '[', ']'):
             i += 1
 
-        base = lookupInModule(expr[:i], module)
+        base = lookupInModule(expr[:i].strip(), module)
         if i == len(expr) or expr[i] != '[':
+            print("   ret ", base, i)
             return base, i
 
         assert expr[i] == '['
-        i += 1
         parts = []
         while expr[i] != ']':
-            part, part_len = parseNestedExpr(expr[i:].strip(), module)
+            part_len = 0
+            i += 1
+            part, part_len = parseNestedExpr(expr[i:], module)
             parts.append(part)
             i += part_len
-            i += 1
+            print(i, expr[i])
+            if part_len == 0:
+                break
 
-        return base[tuple(parts)], i
+        if len(parts) > 1:
+            print("ret ", base, parts)
+            return base[tuple(parts)], i
+        else:
+            print("ret ", base, parts[0])
+            return base[parts[0]], i
 
     def parseExpr(expr, module):
         # import pdb; pdb.set_trace()
         try:
             value, _ = parseNestedExpr(expr, module)
             return value
-        except:
+        except Exception as e:
+            print(e)
             return None
 
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -37,7 +37,7 @@ def createResolutionCallbackFromEnv(lookup_base):
             base_mod = env(base, module)
 
             # intentional bailout, e.g. base == "Tuple" but wasn't imported in Module
-            if not base_mod or isinstance(base_mod, type):
+            if not base_mod:
                 return None
 
             # assume only subexp (between []) could contain ','

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -385,7 +385,9 @@ struct ParserImpl {
     auto subscript_exprs =
         parseList('[', ',', ']', &ParserImpl::parseSubscriptExp);
 
-    return Subscript::create(range, Expr(value), subscript_exprs);
+    const auto whole_range =
+        SourceRange(range.source(), range.start(), L.cur().range.start());
+    return Subscript::create(whole_range, Expr(value), subscript_exprs);
   }
 
   Maybe<Expr> maybeParseTypeAnnotation() {

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -162,14 +162,6 @@ c10::optional<std::string> ScriptTypeParser::parseBaseTypeName(
 
 TypePtr ScriptTypeParser::parseTypeFromExpr(const Expr& expr) const {
   if (expr.kind() == TK_SUBSCRIPT) {
-
-    if (resolver_) {
-      if (auto typePtr =
-              resolver_->resolveType(expr.range().text(), expr.range())) {
-        return typePtr;
-      }
-    }
-
     auto subscript = Subscript(expr);
     auto value_name = parseBaseTypeName(subscript.value());
     if (!value_name) {
@@ -288,7 +280,13 @@ std::vector<Argument> ScriptTypeParser::parseArgsFromDecl(
         type = maybe_broad_list->first;
         N = maybe_broad_list->second;
       } else {
-        type = parseTypeFromExpr(decl_arg.type().get());
+        if (resolver_) {
+          type = resolver_->resolveType(
+              type_expr.range().text(), type_expr.range());
+        }
+        if (!type) {
+          type = parseTypeFromExpr(decl_arg.type().get());
+        }
       }
     }
     c10::optional<IValue> default_value = c10::nullopt;
@@ -319,7 +317,16 @@ std::vector<Argument> ScriptTypeParser::parseReturnFromDecl(const Decl& decl) {
   if (parseBroadcastList(decl.return_type().get()))
     throw ErrorReport(decl.return_type().range())
         << "Broadcastable lists cannot appear as a return type";
-  auto parsed_type = parseTypeFromExpr(decl.return_type().get());
+
+  TypePtr parsed_type;
+  Expr type_expr = decl.return_type().get();
+  if (resolver_) {
+    parsed_type =
+        resolver_->resolveType(type_expr.range().text(), type_expr.range());
+  }
+  if (!parsed_type) {
+    parsed_type = parseTypeFromExpr(type_expr);
+  }
   return {Argument(
       "",
       parsed_type,

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -162,22 +162,21 @@ c10::optional<std::string> ScriptTypeParser::parseBaseTypeName(
 
 TypePtr ScriptTypeParser::parseTypeFromExpr(const Expr& expr) const {
   if (expr.kind() == TK_SUBSCRIPT) {
+
     if (resolver_) {
-      if (auto typePtr = resolver_->resolveType("List[torch.jit.Future[int]]", expr.range())) {
+      if (auto typePtr =
+              resolver_->resolveType(expr.range().text(), expr.range())) {
         return typePtr;
-      } else {
-        throw ErrorReport(expr) << "Failed to resolve type (FUTURE)'";
       }
-    } else {
-      auto subscript = Subscript(expr);
-      auto value_name = parseBaseTypeName(subscript.value());
-      if (!value_name) {
-        throw ErrorReport(subscript.value().range())
-            << "Subscripted type must be a type identifier";
-      }
-      return subscriptToType(*value_name, subscript);
     }
 
+    auto subscript = Subscript(expr);
+    auto value_name = parseBaseTypeName(subscript.value());
+    if (!value_name) {
+      throw ErrorReport(subscript.value().range())
+          << "Subscripted type must be a type identifier";
+    }
+    return subscriptToType(*value_name, subscript);
 
   } else if (auto name = parseBaseTypeName(expr)) {
     auto itr = string_to_type_lut().find(*name);

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -937,8 +937,10 @@ struct Subscript : public Expr {
       const SourceRange& range,
       const Expr& value,
       const List<Expr>& subscript_exprs) {
+    auto whole_range = SourceRange(
+        range.source(), range.start(), subscript_exprs.range().end() + 1);
     return Subscript(
-        Compound::create(TK_SUBSCRIPT, range, {value, subscript_exprs}));
+        Compound::create(TK_SUBSCRIPT, whole_range, {value, subscript_exprs}));
   }
 };
 


### PR DESCRIPTION
- add call out to python resolver in parseArgsFromDecl, parserReturnFromDecl
- add support in python resolver for nested subexpressions
- wrap python resolver call in exception handling to fall back to c++ path
- add tests for newly resolvable types 
- closes #38728

Fixes bug where SourceRange objects did not include the final closing ']' for a subscript expression.  E.g. range for 'List[int]' previously included only 'List[int'.
