### PR TITLE
[nnpi fake ops] bug fix int8QuantizeNNPI

### DIFF
--- a/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
+++ b/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
@@ -30,7 +30,7 @@ void Int8QuantizeNNPI(
   float inv_scale_fp16 = 0;
   fbgemm::RoundToFloat16(
       &inv_scale, &inv_scale_fp16, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-  float offset_tmp = -Y_offset;
+  float offset_tmp = Y_offset;
   fbgemm::RoundToFloat16(
       &offset_tmp, &offset_tmp, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
@@ -46,7 +46,6 @@ void Int8QuantizeNNPI(
   for (int i = 0; i < N; i++) {
     float r = round(offsetv[i]);
     int32_t int_result = static_cast<int32_t>(r);
-
     int_result = std::max(int_result, qmin);
     int_result = std::min(int_result, qmax);
     out[i] = static_cast<uint8_t>(int_result);


### PR DESCRIPTION
Summary: Caused 10% NE loss. Bug in emulation itself and NNPI is fine.

Test Plan: mobile_cvr has no NE loss after this fix: https://fburl.com/mlhub/z6hd8rhn

Differential Revision: D21793205

