### PR TITLE
To fix extra memory allocation when using circular padding

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3099,6 +3099,14 @@ class TestNN(NNTestCase):
         inputs = torch.randn(1, 2, 3, 4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.pad(x, (1, 1, 1, 1, 1, 1), mode='replicate'), (inputs,)))
 
+        # Assert assertion errors are raised for invalid circular padding values
+        inputs = torch.randn(1, 1, 4, requires_grad=True)
+        # Should raise error when trying to wrap around more than once
+        self.assertRaises(AssertionError, lambda: F.pad(inputs, (5, 4), mode='circular'))
+        self.assertRaises(AssertionError, lambda: F.pad(inputs, (3, 6), mode='circular'))
+        # Should raise error when negative padding results in negative output shape
+        self.assertRaises(AssertionError, lambda: F.pad(inputs, (-3, -2), mode='circular'))
+
         # assert that relfection padding errors when pad >= input size
         expected_err_msg = r"Padding size should be less than the corresponding input dimension"
         self.assertRaisesRegex(RuntimeError, expected_err_msg,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3094,6 +3094,7 @@ class TestNN(NNTestCase):
         _assertGradAndGradgradChecks(self, lambda x: F.pad(x, (-1, 1, -2, 1), value=2), (inputs,))
         self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='replicate'), (inputs,)))
         self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='reflect'), (inputs,)))
+        self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='circular'), (inputs,)))
 
         inputs = torch.randn(1, 2, 3, 4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.pad(x, (1, 1, 1, 1, 1, 1), mode='replicate'), (inputs,)))

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3872,16 +3872,17 @@ def _pad_circular(input, padding):
         >>> print(z.shape)  # torch.Size([1, 1, 6, 5])
     """
     shape = input.shape
-    ndim = len(shape[2:])
+    paddable_shape = shape[2:]
+    ndim = len(paddable_shape)
 
     # Only supports wrapping around once
-    for a, size in enumerate(shape[2:]):
+    for a, size in enumerate(paddable_shape):
         assert padding[-(a * 2 + 1)] <= size
         assert padding[-(a * 2 + 2)] <= size
 
     # Get shape of padded array
     padded_shape = shape[:2]
-    for a, size in enumerate(shape[2:]):
+    for a, size in enumerate(paddable_shape):
         padded_shape += (size + padding[-(a * 2 + 1)] + padding[-(a * 2 + 2)],)
 
     out = torch.empty(padded_shape, dtype=input.dtype, layout=input.layout,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3929,37 +3929,76 @@ def _pad_circular(input, padding):
         out[..., out_d[0]:out_d[1], out_h[0]:out_h[1], out_w[0]:out_w[1]] = \
             input[..., in_d[0]:in_d[1], in_h[0]:in_h[1], in_w[0]:in_w[1]]
 
-    # The following steps first pad the left side, then pad the right side
-    # Note: Corners will be written more than once when ndim > 1
+    # The following steps first pad the beginning of the tensor (left side),
+    # and then pad the end of the tensor (right side).
+    # Note: Corners will be written more than once when ndim > 1.
 
     # Only in cases where padding values are > 0 are when additional copying
-    # is required
+    # is required.
 
-    # Pad first conv dim (depth-wise)
+    def calc_pad_begin(size, padding):
+        """Calculates indices for padding the beginning of the tensor.
+
+        Args:
+            size (int): Size of dimension of padded tensor.
+            padding (tuple): Length 2 tuple containing padding values for
+                beginning and end of tensor.
+
+        Returns:
+            src_idx (tuple): Start and end indices for slicing source.
+            dest_idx (tuple): Start and end indices for slicing destination.
+        """
+        padding1 = max(padding[1], 0)
+        src_idx = (size - padding[0] - padding1, size - padding1)
+        dest_idx = (0, padding[0])
+        return src_idx, dest_idx
+
+    def calc_pad_end(size, padding):
+        """Calculates indices for padding the end of the tensor.
+
+        Args:
+            size (int): Size of dimension of padded tensor.
+            padding (tuple): Length 2 tuple containing padding values for
+                beginning and end of tensor.
+
+        Returns:
+            src_idx (tuple): Start and end indices for slicing source.
+            dest_idx (tuple): Start and end indices for slicing destination.
+        """
+        padding0 = max(padding[0], 0)
+        src_idx = (padding0, padding0 + padding[1])
+        dest_idx = (size - padding[1], size)
+        return src_idx, dest_idx
+
+    # Pad first dimension (depth)
     if padding[-2] > 0:
-        out[:, :, :padding[-2]] = \
-            out[:, :, -(padding[-2] + padding[-1]):-padding[-1]]
+        src_idx, dest_idx = calc_pad_begin(out_shape[2], padding[-2:])
+        out[:, :, dest_idx[0]:dest_idx[1]] = out[:, :, src_idx[0]:src_idx[1]]
     if padding[-1] > 0:
-        out[:, :, (out_shape[2] - padding[-1]):] = \
-            out[:, :, padding[-2]:(padding[-2] + padding[-1])]
+        src_idx, dest_idx = calc_pad_end(out_shape[2], padding[-2:])
+        out[:, :, dest_idx[0]:dest_idx[1]] = out[:, :, src_idx[0]:src_idx[1]]
 
-    # Pad second conv dim (height-wise)
+    # Pad second dimension (height)
     if len(padding) > 2:
         if padding[-4] > 0:
-            out[:, :, :, :padding[-4]] = \
-                out[:, :, :, -(padding[-4] + padding[-3]):-padding[-3]]
+            src_idx, dest_idx = calc_pad_begin(out_shape[3], padding[-4:-2])
+            out[:, :, :, dest_idx[0]:dest_idx[1]] = \
+                out[:, :, :, src_idx[0]:src_idx[1]]
         if padding[-3] > 0:
-            out[:, :, :, (out_shape[3] - padding[-3]):] = \
-                out[:, :, :, padding[-4]:(padding[-4] + padding[-3])]
+            src_idx, dest_idx = calc_pad_end(out_shape[3], padding[-4:-2])
+            out[:, :, :, dest_idx[0]:dest_idx[1]] = \
+                out[:, :, :, src_idx[0]:src_idx[1]]
 
-    # Pad third conv dim (width-wise)
+    # Pad third dimension (width)
     if len(padding) > 4:
         if padding[-6] > 0:
-            out[:, :, :, :, :padding[-6]] = \
-                out[:, :, :, :, -(padding[-6] + padding[-5]):-padding[-5]]
+            src_idx, dest_idx = calc_pad_begin(out_shape[4], padding[-6:-4])
+            out[:, :, :, :, dest_idx[0]:dest_idx[1]] = \
+                out[:, :, :, :, src_idx[0]:src_idx[1]]
         if padding[-5] > 0:
-            out[:, :, :, :, (out_shape[4] - padding[-5]):] = \
-                out[:, :, :, :, padding[-6]:(padding[-6] + padding[-5])]
+            src_idx, dest_idx = calc_pad_end(out_shape[4], padding[-6:-4])
+            out[:, :, :, :, dest_idx[0]:dest_idx[1]] = \
+                out[:, :, :, :, src_idx[0]:src_idx[1]]
 
     return out
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3872,13 +3872,13 @@ def _pad_circular(input, padding):
 
     # Only supports wrapping around once
     for a, size in enumerate(shape[2:]):
-        assert padding[-(a*2+1)] <= size
-        assert padding[-(a*2+2)] <= size
+        assert padding[-(a * 2 + 1)] <= size
+        assert padding[-(a * 2 + 2)] <= size
 
     # Get shape of padded array
     padded_shape = shape[:2]
     for a, size in enumerate(shape[2:]):
-        padded_shape += (size + padding[-(a*2+1)] + padding[-(a*2+2)],)
+        padded_shape += (size + padding[-(a * 2 + 1)] + padding[-(a * 2 + 2)],)
 
     out = torch.empty(padded_shape, dtype=input.dtype, layout=input.layout,
                       device=input.device)
@@ -3909,21 +3909,21 @@ def _pad_circular(input, padding):
     # Pad first conv dim (depth-wise)
     out[:, :, :padding[-2]] = \
         out[:, :, -(padding[-2] + padding[-1]):-padding[-1]]
-    out[:, :, (padded_shape[2]-padding[-1]):] = \
+    out[:, :, (padded_shape[2] - padding[-1]):] = \
         out[:, :, padding[-2]:(padding[-2] + padding[-1])]
 
     if len(padding) > 2:
         # Pad second conv dim (height-wise)
         out[:, :, :, :padding[-4]] = \
             out[:, :, :, -(padding[-4] + padding[-3]):-padding[-3]]
-        out[:, :, :, (padded_shape[3]-padding[-3]):] = \
+        out[:, :, :, (padded_shape[3] - padding[-3]):] = \
             out[:, :, :, padding[-4]:(padding[-4] + padding[-3])]
 
     if len(padding) > 4:
         # Pad third conv dim (width-wise)
         out[:, :, :, :, :padding[-6]] = \
             out[:, :, :, :, -(padding[-6] + padding[-5]):-padding[-5]]
-        out[:, :, :, :, (padded_shape[4]-padding[-5]):] = \
+        out[:, :, :, :, (padded_shape[4] - padding[-5]):] = \
             out[:, :, :, :, padding[-6]:(padding[-6] + padding[-5])]
 
     return out

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3883,17 +3883,17 @@ def _pad_circular(input, padding):
         assert (padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)] + size) >= 0
 
     # Get shape of padded array
-    padded_shape = shape[:2]
+    out_shape = shape[:2]
     for idx, size in enumerate(paddable_shape):
-        padded_shape += (size + padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)],)
+        out_shape += (size + padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)],)
 
-    out = torch.empty(padded_shape, dtype=input.dtype, layout=input.layout,
+    out = torch.empty(out_shape, dtype=input.dtype, layout=input.layout,
                       device=input.device)
 
     # Put original array in padded array
     if ndim == 1:
         out_d0 = max(padding[-2], 0)
-        out_d1 = padded_shape[2] - max(padding[-1], 0)
+        out_d1 = out_shape[2] - max(padding[-1], 0)
 
         in_d0 = max(-padding[-2], 0)
         in_d1 = shape[2] - max(-padding[-1], 0)
@@ -3901,10 +3901,10 @@ def _pad_circular(input, padding):
         out[..., out_d0:out_d1] = input[..., in_d0:in_d1]
     elif ndim == 2:
         out_d0 = max(padding[-2], 0)
-        out_d1 = padded_shape[2] - max(padding[-1], 0)
+        out_d1 = out_shape[2] - max(padding[-1], 0)
 
         out_h0 = max(padding[-4], 0)
-        out_h1 = padded_shape[3] - max(padding[-3], 0)
+        out_h1 = out_shape[3] - max(padding[-3], 0)
 
         in_d0 = max(-padding[-2], 0)
         in_d1 = shape[2] - max(-padding[-1], 0)
@@ -3916,13 +3916,13 @@ def _pad_circular(input, padding):
             input[..., in_d0:in_d1, in_h0:in_h1]
     elif ndim == 3:
         out_d0 = max(padding[-2], 0)
-        out_d1 = padded_shape[2] - max(padding[-1], 0)
+        out_d1 = out_shape[2] - max(padding[-1], 0)
 
         out_h0 = max(padding[-4], 0)
-        out_h1 = padded_shape[3] - max(padding[-3], 0)
+        out_h1 = out_shape[3] - max(padding[-3], 0)
 
         out_w0 = max(padding[-6], 0)
-        out_w1 = padded_shape[4] - max(padding[-5], 0)
+        out_w1 = out_shape[4] - max(padding[-5], 0)
 
         in_d0 = max(-padding[-2], 0)
         in_d1 = shape[2] - max(-padding[-1], 0)
@@ -3947,7 +3947,7 @@ def _pad_circular(input, padding):
         out[:, :, :padding[-2]] = \
             out[:, :, -(padding[-2] + padding[-1]):-padding[-1]]
     if padding[-1] > 0:
-        out[:, :, (padded_shape[2] - padding[-1]):] = \
+        out[:, :, (out_shape[2] - padding[-1]):] = \
             out[:, :, padding[-2]:(padding[-2] + padding[-1])]
 
     # Pad second conv dim (height-wise)
@@ -3956,7 +3956,7 @@ def _pad_circular(input, padding):
             out[:, :, :, :padding[-4]] = \
                 out[:, :, :, -(padding[-4] + padding[-3]):-padding[-3]]
         if padding[-3] > 0:
-            out[:, :, :, (padded_shape[3] - padding[-3]):] = \
+            out[:, :, :, (out_shape[3] - padding[-3]):] = \
                 out[:, :, :, padding[-4]:(padding[-4] + padding[-3])]
 
     # Pad third conv dim (width-wise)
@@ -3965,7 +3965,7 @@ def _pad_circular(input, padding):
             out[:, :, :, :, :padding[-6]] = \
                 out[:, :, :, :, -(padding[-6] + padding[-5]):-padding[-5]]
         if padding[-5] > 0:
-            out[:, :, :, :, (padded_shape[4] - padding[-5]):] = \
+            out[:, :, :, :, (out_shape[4] - padding[-5]):] = \
                 out[:, :, :, :, padding[-6]:(padding[-6] + padding[-5])]
 
     return out

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3885,46 +3885,81 @@ def _pad_circular(input, padding):
 
     # Put original array in padded array
     if ndim == 1:
-        d0 = padding[-2]
-        d1 = padded_shape[2] - padding[-1]
-        out[..., d0:d1] = input
+        out_d0 = max(padding[-2], 0)
+        out_d1 = padded_shape[2] - max(padding[-1], 0)
+
+        in_d0 = max(-padding[-2], 0)
+        in_d1 = shape[2] - max(-padding[-1], 0)
+
+        out[..., out_d0:out_d1] = input[..., in_d0:in_d1]
     elif ndim == 2:
-        d0 = padding[-2]
-        d1 = padded_shape[2] - padding[-1]
-        h0 = padding[-4]
-        h1 = padded_shape[3] - padding[-3]
-        out[..., d0:d1, h0:h1] = input
+        out_d0 = max(padding[-2], 0)
+        out_d1 = padded_shape[2] - max(padding[-1], 0)
+
+        out_h0 = max(padding[-4], 0)
+        out_h1 = padded_shape[3] - max(padding[-3], 0)
+
+        in_d0 = max(-padding[-2], 0)
+        in_d1 = shape[2] - max(-padding[-1], 0)
+
+        in_h0 = max(-padding[-4], 0)
+        in_h1 = shape[3] - max(-padding[-3], 0)
+
+        out[..., out_d0:out_d1, out_h0:out_h1] = \
+            input[..., in_d0:in_d1, in_h0:in_h1]
     elif ndim == 3:
-        d0 = padding[-2]
-        d1 = padded_shape[2] - padding[-1]
-        h0 = padding[-4]
-        h1 = padded_shape[3] - padding[-3]
-        w0 = padding[-6]
-        w1 = padded_shape[4] - padding[-5]
-        out[..., d0:d1, h0:h1, w0:w1] = input
+        out_d0 = max(padding[-2], 0)
+        out_d1 = padded_shape[2] - max(padding[-1], 0)
+
+        out_h0 = max(padding[-4], 0)
+        out_h1 = padded_shape[3] - max(padding[-3], 0)
+
+        out_w0 = max(padding[-6], 0)
+        out_w1 = padded_shape[4] - max(padding[-5], 0)
+
+        in_d0 = max(-padding[-2], 0)
+        in_d1 = shape[2] - max(-padding[-1], 0)
+
+        in_h0 = max(-padding[-4], 0)
+        in_h1 = shape[3] - max(-padding[-3], 0)
+
+        in_w0 = max(-padding[-6], 0)
+        in_w1 = shape[4] - max(-padding[-5], 0)
+
+        out[..., out_d0:out_d1, out_h0:out_h1, out_w0:out_w1] = \
+            input[..., in_d0:in_d1, in_h0:in_h1, in_w0:in_w1]
 
     # The following steps first pad the left side, then pad the right side
     # Note: Corners will be written more than once when ndim > 1
 
+    # Only in cases where padding values are > 0 are when additional copying
+    # is required
+
     # Pad first conv dim (depth-wise)
-    out[:, :, :padding[-2]] = \
-        out[:, :, -(padding[-2] + padding[-1]):-padding[-1]]
-    out[:, :, (padded_shape[2] - padding[-1]):] = \
-        out[:, :, padding[-2]:(padding[-2] + padding[-1])]
+    if padding[-2] > 0:
+        out[:, :, :padding[-2]] = \
+            out[:, :, -(padding[-2] + padding[-1]):-padding[-1]]
+    if padding[-1] > 0:
+        out[:, :, (padded_shape[2] - padding[-1]):] = \
+            out[:, :, padding[-2]:(padding[-2] + padding[-1])]
 
+    # Pad second conv dim (height-wise)
     if len(padding) > 2:
-        # Pad second conv dim (height-wise)
-        out[:, :, :, :padding[-4]] = \
-            out[:, :, :, -(padding[-4] + padding[-3]):-padding[-3]]
-        out[:, :, :, (padded_shape[3] - padding[-3]):] = \
-            out[:, :, :, padding[-4]:(padding[-4] + padding[-3])]
+        if padding[-4] > 0:
+            out[:, :, :, :padding[-4]] = \
+                out[:, :, :, -(padding[-4] + padding[-3]):-padding[-3]]
+        if padding[-3] > 0:
+            out[:, :, :, (padded_shape[3] - padding[-3]):] = \
+                out[:, :, :, padding[-4]:(padding[-4] + padding[-3])]
 
+    # Pad third conv dim (width-wise)
     if len(padding) > 4:
-        # Pad third conv dim (width-wise)
-        out[:, :, :, :, :padding[-6]] = \
-            out[:, :, :, :, -(padding[-6] + padding[-5]):-padding[-5]]
-        out[:, :, :, :, (padded_shape[4] - padding[-5]):] = \
-            out[:, :, :, :, padding[-6]:(padding[-6] + padding[-5])]
+        if padding[-6] > 0:
+            out[:, :, :, :, :padding[-6]] = \
+                out[:, :, :, :, -(padding[-6] + padding[-5]):-padding[-5]]
+        if padding[-5] > 0:
+            out[:, :, :, :, (padded_shape[4] - padding[-5]):] = \
+                out[:, :, :, :, padding[-6]:(padding[-6] + padding[-5])]
 
     return out
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3895,10 +3895,13 @@ def _pad_circular(input, padding):
 
     for idx, size in enumerate(paddable_shape):
         # Only supports wrapping around once
-        assert padding[-(idx * 2 + 1)] <= size
-        assert padding[-(idx * 2 + 2)] <= size
+        assert padding[-(idx * 2 + 1)] <= size, \
+            "Padding value causes wrapping around more than once."
+        assert padding[-(idx * 2 + 2)] <= size, \
+            "Padding value causes wrapping around more than once."
         # Negative padding should not result in negative sizes
-        assert (padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)] + size) >= 0
+        assert padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)] + size >= 0, \
+            "Negative padding value is resulting in an empty dimension."
 
     # Get shape of padded tensor
     out_shape = in_shape[:2]

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3845,31 +3845,49 @@ def _pad_circular(input, padding):
     """Circularly pads tensor.
 
     Tensor values at the beginning are used to pad the end, and values at the
-    end are used to pad the beginning. The first and second axes of the tensor
-    are not padded.
+    end are used to pad the beginning. For example, consider a single dimension
+    with values [0, 1, 2, 3]. With circular padding of (1, 1) it would be
+    padded to [3, 0, 1, 2, 3, 0], and with padding (1, 2) it would be padded to
+    [3, 0, 1, 2, 3, 0, 1]. If negative padding is applied then the ends of the
+    tensor get removed. With circular padding of (-1, -1) the previous example
+    would become [1, 2]. Circular padding of (-1, 1) would produce
+    [1, 2, 3, 1].
+
+    The first and second dimensions of the tensor are not padded.
 
     Args:
         input: Tensor with shape :math:`(N, C, D[, H, W])`.
         padding: Tuple containing the number of elements to pad each side of
             the tensor. The length of padding must be twice the number of
-            paddable axes. For example, the length of padding should be 4 for a
-            tensor of shape :math:`(N, C, H, W)`, and the length should be 6
-            for a tensor of shape :math:`(N, C, D, H, W)`.
+            paddable dimensions. For example, the length of padding should be 4
+            for a tensor of shape :math:`(N, C, H, W)`, and the length should
+            be 6 for a tensor of shape :math:`(N, C, D, H, W)`.
 
     Examples::
 
-        >>> x = torch.arange(6).view(1, 1, 2, 3)  # Create tensor
+        >>> x = torch.tensor([[[[0, 1, 2], [3, 4, 5]]]])  # Create tensor
         >>> # Example 1
         >>> padding = (1, 1, 1, 1)
         >>> y = F.pad(x, padding, mode='circular')
-        >>> print(x)
         >>> print(y)
-        >>> print(y.shape)  # torch.Size([1, 1, 4, 5])
+        tensor([[[[5, 3, 4, 5, 3],
+                  [2, 0, 1, 2, 0],
+                  [5, 3, 4, 5, 3],
+                  [2, 0, 1, 2, 0]]]])
+        >>> print(y.shape)
+        torch.Size([1, 1, 4, 5])
         >>> # Example 2
         >>> padding = (1, 1, 2, 2)
         >>> z = F.pad(x, padding, mode='circular')
         >>> print(z)
-        >>> print(z.shape)  # torch.Size([1, 1, 6, 5])
+        tensor([[[[2, 0, 1, 2, 0],
+                  [5, 3, 4, 5, 3],
+                  [2, 0, 1, 2, 0],
+                  [5, 3, 4, 5, 3],
+                  [2, 0, 1, 2, 0],
+                  [5, 3, 4, 5, 3]]]])
+        >>> print(z.shape)
+        torch.Size([1, 1, 6, 5])
     """
     in_shape = input.shape
     paddable_shape = in_shape[2:]

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3876,37 +3876,55 @@ def _pad_circular(input, padding):
         assert padding[-(a*2+2)] <= size
 
     # Get shape of padded array
-    new_shape = shape[:2]
+    padded_shape = shape[:2]
     for a, size in enumerate(shape[2:]):
-        new_shape += (size + padding[-(a*2+1)] + padding[-(a*2+2)],)
+        padded_shape += (size + padding[-(a*2+1)] + padding[-(a*2+2)],)
 
-    out = torch.empty(new_shape, dtype=input.dtype, layout=input.layout,
+    out = torch.empty(padded_shape, dtype=input.dtype, layout=input.layout,
                       device=input.device)
 
     # Put original array in padded array
     if ndim == 1:
-        out[..., padding[-2]:-padding[-1]] = input
+        d0 = padding[-2]
+        d1 = padded_shape[2] - padding[-1]
+        out[..., d0:d1] = input
     elif ndim == 2:
-        out[..., padding[-2]:-padding[-1], padding[-4]:-padding[-3]] = input
+        d0 = padding[-2]
+        d1 = padded_shape[2] - padding[-1]
+        h0 = padding[-4]
+        h1 = padded_shape[3] - padding[-3]
+        out[..., d0:d1, h0:h1] = input
     elif ndim == 3:
-        out[..., padding[-2]:-padding[-1], padding[-4]:-padding[-3], padding[-6]:-padding[-5]] = input
+        d0 = padding[-2]
+        d1 = padded_shape[2] - padding[-1]
+        h0 = padding[-4]
+        h1 = padded_shape[3] - padding[-3]
+        w0 = padding[-6]
+        w1 = padded_shape[4] - padding[-5]
+        out[..., d0:d1, h0:h1, w0:w1] = input
 
-    # Pad right side, then left side.
-    # Corners will be written more than once when ndim > 1
+    # The following steps first pad the left side, then pad the right side
+    # Note: Corners will be written more than once when ndim > 1
 
-    # Pad first conv dim
-    out[:, :, :padding[-2]] = out[:, :, -(padding[-2] + padding[-1]):-padding[-1]]
-    out[:, :, -padding[-1]:] = out[:, :, padding[-2]:(padding[-2] + padding[-1])]
+    # Pad first conv dim (depth-wise)
+    out[:, :, :padding[-2]] = \
+        out[:, :, -(padding[-2] + padding[-1]):-padding[-1]]
+    out[:, :, (padded_shape[2]-padding[-1]):] = \
+        out[:, :, padding[-2]:(padding[-2] + padding[-1])]
 
     if len(padding) > 2:
-        # Pad second conv dim
-        out[:, :, :, :padding[-4]] = out[:, :, :, -(padding[-4] + padding[-3]):-padding[-3]]
-        out[:, :, :, -padding[-3]:] = out[:, :, :, padding[-4]:(padding[-4] + padding[-3])]
+        # Pad second conv dim (height-wise)
+        out[:, :, :, :padding[-4]] = \
+            out[:, :, :, -(padding[-4] + padding[-3]):-padding[-3]]
+        out[:, :, :, (padded_shape[3]-padding[-3]):] = \
+            out[:, :, :, padding[-4]:(padding[-4] + padding[-3])]
 
     if len(padding) > 4:
-        # Pad third conv dim
-        out[:, :, :, :, :padding[-6]] = out[:, :, :, :, -(padding[-6] + padding[-5]):-padding[-5]]
-        out[:, :, :, :, -padding[-5]:] = out[:, :, :, :, padding[-6]:(padding[-6] + padding[-5])]
+        # Pad third conv dim (width-wise)
+        out[:, :, :, :, :padding[-6]] = \
+            out[:, :, :, :, -(padding[-6] + padding[-5]):-padding[-5]]
+        out[:, :, :, :, (padded_shape[4]-padding[-5]):] = \
+            out[:, :, :, :, padding[-6]:(padding[-6] + padding[-5])]
 
     return out
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3875,17 +3875,17 @@ def _pad_circular(input, padding):
     paddable_shape = shape[2:]
     ndim = len(paddable_shape)
 
-    for a, size in enumerate(paddable_shape):
+    for idx, size in enumerate(paddable_shape):
         # Only supports wrapping around once
-        assert padding[-(a * 2 + 1)] <= size
-        assert padding[-(a * 2 + 2)] <= size
+        assert padding[-(idx * 2 + 1)] <= size
+        assert padding[-(idx * 2 + 2)] <= size
         # Negative padding should not result in negative sizes
-        assert (padding[-(a * 2 + 1)] + padding[-(a * 2 + 2)] + size) >= 0
+        assert (padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)] + size) >= 0
 
     # Get shape of padded array
     padded_shape = shape[:2]
-    for a, size in enumerate(paddable_shape):
-        padded_shape += (size + padding[-(a * 2 + 1)] + padding[-(a * 2 + 2)],)
+    for idx, size in enumerate(paddable_shape):
+        padded_shape += (size + padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)],)
 
     out = torch.empty(padded_shape, dtype=input.dtype, layout=input.layout,
                       device=input.device)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3908,44 +3908,51 @@ def _pad_circular(input, padding):
     out = torch.empty(out_shape, dtype=input.dtype, layout=input.layout,
                       device=input.device)
 
-    # Put original tensor in padded tensor
-
-    def calc_indices(in_size, out_size, padding):
-        """Calculates indices for placing original tensor into new tensor.
-
-        Args:
-            in_size (int): Size of dimension of input tensor.
-            out_size (int): Size of dimension of output tensor.
-            padding (tuple): Length 2 tuple containing padding values for
-                beginning and end of tensor.
-
-        Returns:
-            in_idx (tuple): Start and end indices for slicing input tensor.
-            out_idx (tuple): Start and end indices for slicing output tensor.
-        """
-        in_idx = (max(-padding[0], 0),
-                  in_size - max(-padding[1], 0))
-        out_idx = (max(padding[0], 0),
-                   out_size - max(padding[1], 0))
-        return in_idx, out_idx
-
+    # Put original array in padded array
     if ndim == 1:
-        in_d, out_d = calc_indices(in_shape[2], out_shape[2], padding[-2:])
+        out_d0 = max(padding[-2], 0)
+        out_d1 = out_shape[2] - max(padding[-1], 0)
 
-        out[..., out_d[0]:out_d[1]] = input[..., in_d[0]:in_d[1]]
+        in_d0 = max(-padding[-2], 0)
+        in_d1 = in_shape[2] - max(-padding[-1], 0)
+
+        out[..., out_d0:out_d1] = input[..., in_d0:in_d1]
     elif ndim == 2:
-        in_d, out_d = calc_indices(in_shape[2], out_shape[2], padding[-2:])
-        in_h, out_h = calc_indices(in_shape[3], out_shape[3], padding[-4:-2])
+        out_d0 = max(padding[-2], 0)
+        out_d1 = out_shape[2] - max(padding[-1], 0)
 
-        out[..., out_d[0]:out_d[1], out_h[0]:out_h[1]] = \
-            input[..., in_d[0]:in_d[1], in_h[0]:in_h[1]]
+        out_h0 = max(padding[-4], 0)
+        out_h1 = out_shape[3] - max(padding[-3], 0)
+
+        in_d0 = max(-padding[-2], 0)
+        in_d1 = in_shape[2] - max(-padding[-1], 0)
+
+        in_h0 = max(-padding[-4], 0)
+        in_h1 = in_shape[3] - max(-padding[-3], 0)
+
+        out[..., out_d0:out_d1, out_h0:out_h1] = \
+            input[..., in_d0:in_d1, in_h0:in_h1]
     elif ndim == 3:
-        in_d, out_d = calc_indices(in_shape[2], out_shape[2], padding[-2:])
-        in_h, out_h = calc_indices(in_shape[3], out_shape[3], padding[-4:-2])
-        in_w, out_w = calc_indices(in_shape[4], out_shape[4], padding[-6:-4])
+        out_d0 = max(padding[-2], 0)
+        out_d1 = out_shape[2] - max(padding[-1], 0)
 
-        out[..., out_d[0]:out_d[1], out_h[0]:out_h[1], out_w[0]:out_w[1]] = \
-            input[..., in_d[0]:in_d[1], in_h[0]:in_h[1], in_w[0]:in_w[1]]
+        out_h0 = max(padding[-4], 0)
+        out_h1 = out_shape[3] - max(padding[-3], 0)
+
+        out_w0 = max(padding[-6], 0)
+        out_w1 = out_shape[4] - max(padding[-5], 0)
+
+        in_d0 = max(-padding[-2], 0)
+        in_d1 = in_shape[2] - max(-padding[-1], 0)
+
+        in_h0 = max(-padding[-4], 0)
+        in_h1 = in_shape[3] - max(-padding[-3], 0)
+
+        in_w0 = max(-padding[-6], 0)
+        in_w1 = in_shape[4] - max(-padding[-5], 0)
+
+        out[..., out_d0:out_d1, out_h0:out_h1, out_w0:out_w1] = \
+            input[..., in_d0:in_d1, in_h0:in_h1, in_w0:in_w1]
 
     # The following steps first pad the beginning of the tensor (left side),
     # and then pad the end of the tensor (right side).

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3891,50 +3891,43 @@ def _pad_circular(input, padding):
                       device=input.device)
 
     # Put original array in padded array
+
+    def calc_indices(in_size, out_size, padding):
+        """Calculates indices for placing original tensor into new tensor.
+
+        Args:
+            in_size (int): Size of dimension of input tensor.
+            out_size (int): Size of dimension of output tensor.
+            padding (tuple): Length 2 tuple containing padding values for
+                beginning and end of tensor.
+
+        Returns:
+            in_idx (tuple): Start and end indices for slicing input tensor.
+            out_idx (tuple): Start and end indices for slicing output tensor.
+        """
+        in_idx = (max(-padding[0], 0),
+                  in_size - max(-padding[1], 0))
+        out_idx = (max(padding[0], 0),
+                   out_size - max(padding[1], 0))
+        return in_idx, out_idx
+
     if ndim == 1:
-        out_d0 = max(padding[-2], 0)
-        out_d1 = out_shape[2] - max(padding[-1], 0)
+        in_d, out_d = calc_indices(in_shape[2], out_shape[2], padding[-2:])
 
-        in_d0 = max(-padding[-2], 0)
-        in_d1 = in_shape[2] - max(-padding[-1], 0)
-
-        out[..., out_d0:out_d1] = input[..., in_d0:in_d1]
+        out[..., out_d[0]:out_d[1]] = input[..., in_d[0]:in_d[1]]
     elif ndim == 2:
-        out_d0 = max(padding[-2], 0)
-        out_d1 = out_shape[2] - max(padding[-1], 0)
+        in_d, out_d = calc_indices(in_shape[2], out_shape[2], padding[-2:])
+        in_h, out_h = calc_indices(in_shape[3], out_shape[3], padding[-4:-2])
 
-        out_h0 = max(padding[-4], 0)
-        out_h1 = out_shape[3] - max(padding[-3], 0)
-
-        in_d0 = max(-padding[-2], 0)
-        in_d1 = in_shape[2] - max(-padding[-1], 0)
-
-        in_h0 = max(-padding[-4], 0)
-        in_h1 = in_shape[3] - max(-padding[-3], 0)
-
-        out[..., out_d0:out_d1, out_h0:out_h1] = \
-            input[..., in_d0:in_d1, in_h0:in_h1]
+        out[..., out_d[0]:out_d[1], out_h[0]:out_h[1]] = \
+            input[..., in_d[0]:in_d[1], in_h[0]:in_h[1]]
     elif ndim == 3:
-        out_d0 = max(padding[-2], 0)
-        out_d1 = out_shape[2] - max(padding[-1], 0)
+        in_d, out_d = calc_indices(in_shape[2], out_shape[2], padding[-2:])
+        in_h, out_h = calc_indices(in_shape[3], out_shape[3], padding[-4:-2])
+        in_w, out_w = calc_indices(in_shape[4], out_shape[4], padding[-6:-4])
 
-        out_h0 = max(padding[-4], 0)
-        out_h1 = out_shape[3] - max(padding[-3], 0)
-
-        out_w0 = max(padding[-6], 0)
-        out_w1 = out_shape[4] - max(padding[-5], 0)
-
-        in_d0 = max(-padding[-2], 0)
-        in_d1 = in_shape[2] - max(-padding[-1], 0)
-
-        in_h0 = max(-padding[-4], 0)
-        in_h1 = in_shape[3] - max(-padding[-3], 0)
-
-        in_w0 = max(-padding[-6], 0)
-        in_w1 = in_shape[4] - max(-padding[-5], 0)
-
-        out[..., out_d0:out_d1, out_h0:out_h1, out_w0:out_w1] = \
-            input[..., in_d0:in_d1, in_h0:in_h1, in_w0:in_w1]
+        out[..., out_d[0]:out_d[1], out_h[0]:out_h[1], out_w[0]:out_w[1]] = \
+            input[..., in_d[0]:in_d[1], in_h[0]:in_h[1], in_w[0]:in_w[1]]
 
     # The following steps first pad the left side, then pad the right side
     # Note: Corners will be written more than once when ndim > 1

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3875,10 +3875,12 @@ def _pad_circular(input, padding):
     paddable_shape = shape[2:]
     ndim = len(paddable_shape)
 
-    # Only supports wrapping around once
     for a, size in enumerate(paddable_shape):
+        # Only supports wrapping around once
         assert padding[-(a * 2 + 1)] <= size
         assert padding[-(a * 2 + 2)] <= size
+        # Negative padding should not result in negative sizes
+        assert (padding[-(a * 2 + 1)] + padding[-(a * 2 + 2)] + size) >= 0
 
     # Get shape of padded array
     padded_shape = shape[:2]

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3882,7 +3882,7 @@ def _pad_circular(input, padding):
         # Negative padding should not result in negative sizes
         assert (padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)] + size) >= 0
 
-    # Get shape of padded array
+    # Get shape of padded tensor
     out_shape = in_shape[:2]
     for idx, size in enumerate(paddable_shape):
         out_shape += (size + padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)],)
@@ -3890,7 +3890,7 @@ def _pad_circular(input, padding):
     out = torch.empty(out_shape, dtype=input.dtype, layout=input.layout,
                       device=input.device)
 
-    # Put original array in padded array
+    # Put original tensor in padded tensor
 
     def calc_indices(in_size, out_size, padding):
         """Calculates indices for placing original tensor into new tensor.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3842,30 +3842,34 @@ def fold(input, output_size, kernel_size, dilation=1, padding=0, stride=1):
 
 def _pad_circular(input, padding):
     # type: (Tensor, List[int]) -> Tensor
-    """
+    """Circularly pads tensor.
+
+    Tensor values at the beginning are used to pad the end, and values at the
+    end are used to pad the beginning. The first and second axes of the tensor
+    are not padded.
+
     Args:
-        input: Tensor that follows the formatting of the input to convolution
-            layers.
-        padding: Tuple with length two times the degree of the convolution. The
-            order of the integers in the tuple are shown in the following
-            example:
+        input: Tensor with shape :math:`(N, C, D[, H, W])`.
+        padding: Tuple containing the number of elements to pad each side of
+            the tensor. The length of padding must be twice the number of
+            paddable axes. For example, the length of padding should be 4 for a
+            tensor of shape :math:`(N, C, H, W)`, and the length should be 6
+            for a tensor of shape :math:`(N, C, D, H, W)`.
 
-            For 3D convolutions:
-                padding[-2] is the amount of padding applied to the beginning
-                    of the depth dimension.
-                padding[-1] is the amount of padding applied to the end of the
-                    depth dimension.
-                padding[-4] is the amount of padding applied to the beginning
-                    of the height dimension.
-                padding[-3] is the amount of padding applied to the end of the
-                    height dimension.
-                padding[-6] is the amount of padding applied to the beginning
-                    of the width dimension.
-                padding[-5] is the amount of padding applied to the end of the
-                    width dimension.
+    Examples::
 
-    Returns:
-        out: Tensor with padded shape.
+        >>> x = torch.arange(6).view(1, 1, 2, 3)  # Create tensor
+        >>> # Example 1
+        >>> padding = (1, 1, 1, 1)
+        >>> y = F.pad(x, padding, mode='circular')
+        >>> print(x)
+        >>> print(y)
+        >>> print(y.shape)  # torch.Size([1, 1, 4, 5])
+        >>> # Example 2
+        >>> padding = (1, 1, 2, 2)
+        >>> z = F.pad(x, padding, mode='circular')
+        >>> print(z)
+        >>> print(z.shape)  # torch.Size([1, 1, 6, 5])
     """
     shape = input.shape
     ndim = len(shape[2:])

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3961,69 +3961,53 @@ def _pad_circular(input, padding):
     # Only in cases where padding values are > 0 are when additional copying
     # is required.
 
-    def calc_pad_begin(size, padding):
-        """Calculates indices for padding the beginning of the tensor.
-
-        Args:
-            size (int): Size of dimension of padded tensor.
-            padding (tuple): Length 2 tuple containing padding values for
-                beginning and end of tensor.
-
-        Returns:
-            src_idx (tuple): Start and end indices for slicing source.
-            dest_idx (tuple): Start and end indices for slicing destination.
-        """
-        padding1 = max(padding[1], 0)
-        src_idx = (size - padding[0] - padding1, size - padding1)
-        dest_idx = (0, padding[0])
-        return src_idx, dest_idx
-
-    def calc_pad_end(size, padding):
-        """Calculates indices for padding the end of the tensor.
-
-        Args:
-            size (int): Size of dimension of padded tensor.
-            padding (tuple): Length 2 tuple containing padding values for
-                beginning and end of tensor.
-
-        Returns:
-            src_idx (tuple): Start and end indices for slicing source.
-            dest_idx (tuple): Start and end indices for slicing destination.
-        """
-        padding0 = max(padding[0], 0)
-        src_idx = (padding0, padding0 + padding[1])
-        dest_idx = (size - padding[1], size)
-        return src_idx, dest_idx
-
     # Pad first dimension (depth)
     if padding[-2] > 0:
-        src_idx, dest_idx = calc_pad_begin(out_shape[2], padding[-2:])
-        out[:, :, dest_idx[0]:dest_idx[1]] = out[:, :, src_idx[0]:src_idx[1]]
+        i0 = out_shape[2] - padding[-2] - max(padding[-1], 0)
+        i1 = out_shape[2] - max(padding[-1], 0)
+        o0 = 0
+        o1 = padding[-2]
+        out[:, :, o0:o1] = out[:, :, i0:i1]
     if padding[-1] > 0:
-        src_idx, dest_idx = calc_pad_end(out_shape[2], padding[-2:])
-        out[:, :, dest_idx[0]:dest_idx[1]] = out[:, :, src_idx[0]:src_idx[1]]
+        i0 = max(padding[-2], 0)
+        i1 = max(padding[-2], 0) + padding[-1]
+        o0 = out_shape[2] - padding[-1]
+        o1 = out_shape[2]
+        out[:, :, o0:o1] = out[:, :, i0:i1]
 
     # Pad second dimension (height)
     if len(padding) > 2:
         if padding[-4] > 0:
-            src_idx, dest_idx = calc_pad_begin(out_shape[3], padding[-4:-2])
-            out[:, :, :, dest_idx[0]:dest_idx[1]] = \
-                out[:, :, :, src_idx[0]:src_idx[1]]
+            i0 = out_shape[3] - padding[-4] - max(padding[-3], 0)
+            i1 = out_shape[3] - max(padding[-3], 0)
+            o0 = 0
+            o1 = padding[-4]
+            out[:, :, :, o0:o1] = \
+                out[:, :, :, i0:i1]
         if padding[-3] > 0:
-            src_idx, dest_idx = calc_pad_end(out_shape[3], padding[-4:-2])
-            out[:, :, :, dest_idx[0]:dest_idx[1]] = \
-                out[:, :, :, src_idx[0]:src_idx[1]]
+            i0 = max(padding[-4], 0)
+            i1 = max(padding[-4], 0) + padding[-3]
+            o0 = out_shape[3] - padding[-3]
+            o1 = out_shape[3]
+            out[:, :, :, o0:o1] = \
+                out[:, :, :, i0:i1]
 
     # Pad third dimension (width)
     if len(padding) > 4:
         if padding[-6] > 0:
-            src_idx, dest_idx = calc_pad_begin(out_shape[4], padding[-6:-4])
-            out[:, :, :, :, dest_idx[0]:dest_idx[1]] = \
-                out[:, :, :, :, src_idx[0]:src_idx[1]]
+            i0 = out_shape[4] - padding[-6] - max(padding[-5], 0)
+            i1 = out_shape[4] - max(padding[-5], 0)
+            o0 = 0
+            o1 = padding[-6]
+            out[:, :, :, :, o0:o1] = \
+                out[:, :, :, :, i0:i1]
         if padding[-5] > 0:
-            src_idx, dest_idx = calc_pad_end(out_shape[4], padding[-6:-4])
-            out[:, :, :, :, dest_idx[0]:dest_idx[1]] = \
-                out[:, :, :, :, src_idx[0]:src_idx[1]]
+            i0 = max(padding[-6], 0)
+            i1 = max(padding[-6], 0) + padding[-5]
+            o0 = out_shape[4] - padding[-5]
+            o1 = out_shape[4]
+            out[:, :, :, :, o0:o1] = \
+                out[:, :, :, :, i0:i1]
 
     return out
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3871,8 +3871,8 @@ def _pad_circular(input, padding):
         >>> print(z)
         >>> print(z.shape)  # torch.Size([1, 1, 6, 5])
     """
-    shape = input.shape
-    paddable_shape = shape[2:]
+    in_shape = input.shape
+    paddable_shape = in_shape[2:]
     ndim = len(paddable_shape)
 
     for idx, size in enumerate(paddable_shape):
@@ -3883,7 +3883,7 @@ def _pad_circular(input, padding):
         assert (padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)] + size) >= 0
 
     # Get shape of padded array
-    out_shape = shape[:2]
+    out_shape = in_shape[:2]
     for idx, size in enumerate(paddable_shape):
         out_shape += (size + padding[-(idx * 2 + 1)] + padding[-(idx * 2 + 2)],)
 
@@ -3896,7 +3896,7 @@ def _pad_circular(input, padding):
         out_d1 = out_shape[2] - max(padding[-1], 0)
 
         in_d0 = max(-padding[-2], 0)
-        in_d1 = shape[2] - max(-padding[-1], 0)
+        in_d1 = in_shape[2] - max(-padding[-1], 0)
 
         out[..., out_d0:out_d1] = input[..., in_d0:in_d1]
     elif ndim == 2:
@@ -3907,10 +3907,10 @@ def _pad_circular(input, padding):
         out_h1 = out_shape[3] - max(padding[-3], 0)
 
         in_d0 = max(-padding[-2], 0)
-        in_d1 = shape[2] - max(-padding[-1], 0)
+        in_d1 = in_shape[2] - max(-padding[-1], 0)
 
         in_h0 = max(-padding[-4], 0)
-        in_h1 = shape[3] - max(-padding[-3], 0)
+        in_h1 = in_shape[3] - max(-padding[-3], 0)
 
         out[..., out_d0:out_d1, out_h0:out_h1] = \
             input[..., in_d0:in_d1, in_h0:in_h1]
@@ -3925,13 +3925,13 @@ def _pad_circular(input, padding):
         out_w1 = out_shape[4] - max(padding[-5], 0)
 
         in_d0 = max(-padding[-2], 0)
-        in_d1 = shape[2] - max(-padding[-1], 0)
+        in_d1 = in_shape[2] - max(-padding[-1], 0)
 
         in_h0 = max(-padding[-4], 0)
-        in_h1 = shape[3] - max(-padding[-3], 0)
+        in_h1 = in_shape[3] - max(-padding[-3], 0)
 
         in_w0 = max(-padding[-6], 0)
-        in_w1 = shape[4] - max(-padding[-5], 0)
+        in_w1 = in_shape[4] - max(-padding[-5], 0)
 
         out[..., out_d0:out_d1, out_h0:out_h1, out_w0:out_w1] = \
             input[..., in_d0:in_d1, in_h0:in_h1, in_w0:in_w1]


### PR DESCRIPTION
**BC-breaking Note:**

This PR changes the behavior of circular padding when using negative or zero values. Previously these cases would not work properly, with negative circular padding not reducing the sizes of the input tensor properly, and with zero circular padding sometimes causing dimensions not to be padded at all. This PR corrects circular padding's behavior. 

**Original PR Summary**

For fixing https://github.com/pytorch/pytorch/issues/39256

