### PR TITLE
[caffe2] Update shape info delimiter

### DIFF
--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -55,7 +55,7 @@ ShapeInfo constructShapeInfoWithDefaultDimType(
 void parseShapeInfoMapFromString(
     const std::string& input,
     ShapeInfoMap& shape_hints) {
-  auto hints = caffe2::split('|', input);
+  auto hints = caffe2::split('#', input);
   for (const auto& hint : hints) {
     auto kv = caffe2::split(',', hint);
     CAFFE_ENFORCE_GE(kv.size(), 2, "Cannot parse shape hint: ", hint);


### PR DESCRIPTION
Summary: Replace delimiter '|' with '#' because '|' could appear in the tensor names.

Test Plan:
```
buck test //caffe2/caffe2/fb/opt:shape_info_utils_test
```

AI/AF canary:
https://our.intern.facebook.com/intern/ads/canary/427007822162345576
https://our.intern.facebook.com/intern/ads/canary/427007917016548180

Reviewed By: yinghai

Differential Revision: D21781037

