### PR TITLE
[ROCm][Caffe2] Skip the histogram test for HIP device.

### DIFF
--- a/caffe2/python/operator_test/histogram_test.py
+++ b/caffe2/python/operator_test/histogram_test.py
@@ -8,6 +8,7 @@ from hypothesis import given
 
 
 class TestHistogram(hu.HypothesisTestCase):
+    @unittest.skipIf(workspace.has_hip_support, "Histogram is not supported on HIP.")
     @given(rows=st.integers(1, 1000), cols=st.integers(1, 1000), **hu.gcs)
     def test_histogram__device_consistency(self, rows, cols, gc, dc):
         X = np.random.rand(rows, cols)


### PR DESCRIPTION
Skipping the test ```test_histogram__device_consistency``` for HIP that fails on caffe2 CI.

CC: @jeffdaily @ezyang 