### PR TITLE
[AMD] Fix broken test

### DIFF
--- a/caffe2/python/operator_test/histogram_test.py
+++ b/caffe2/python/operator_test/histogram_test.py
@@ -8,7 +8,7 @@ from hypothesis import given
 
 
 class TestHistogram(hu.HypothesisTestCase):
-    @given(rows=st.integers(1, 1000), cols=st.integers(1, 1000), **hu.gcs)
+    @given(rows=st.integers(1, 1000), cols=st.integers(1, 1000), **hu.gcs_cpu_only)
     def test_histogram__device_consistency(self, rows, cols, gc, dc):
         X = np.random.rand(rows, cols)
         bin_edges = list(np.linspace(-2, 10, num=10000))


### PR DESCRIPTION
Summary: histogram op doesn't have GPU implementation. It's breaking the CI GPU test. Make the test run cpu only.

Test Plan: CI

Differential Revision: D21800824

