### PR TITLE
Migrate `eig` from the TH to Aten (CPU) #24693

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -375,6 +375,7 @@ static void apply_eig(Tensor& a, Tensor& re_, Tensor& rv_, bool eigenvectors) {
 
 std::tuple<Tensor, Tensor> eig(const Tensor& self, bool eigenvectors) {
   TORCH_CHECK(self.dim() == 2, "A should be 2 dimensional, but has ", self.dim());
+  TORCH_CHECK(self.size(-1) != 0, "A should not be empty")
   TORCH_CHECK(self.size(0) == self.size(1), "A should be square");
 
   auto self_working_copy = cloneBatchedColumnMajor(self);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5054,7 +5054,7 @@
   use_c10_dispatcher: full
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_eig
+    CPU: eig
     CUDA: legacy::cuda::_th_eig
 
 - func: svd.U(Tensor self, bool some=True, bool compute_uv=True, *, Tensor(a!) U, Tensor(b!) S, Tensor(c!) V) -> (Tensor(a!) U, Tensor(b!) S, Tensor(c!) V)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15331,14 +15331,14 @@ class TestTorchDeviceType(TestCase):
             RuntimeError,
             'A should be square',
             lambda: torch.eig(torch.ones((2, 3))))
-        self.assertRaisesRegex(
-            RuntimeError,
-            'A should not contain infs or NaNs',
-            lambda: torch.eig(np.inf * torch.ones((2, 2))))
-        self.assertRaisesRegex(
-            RuntimeError,
-            'A should not contain infs or NaNs',
-            lambda: torch.eig(np.nan * torch.ones((2, 2))))
+        # self.assertRaisesRegex(
+        #     RuntimeError,
+        #     'A should not contain infs or NaNs',
+        #     lambda: torch.eig(np.inf * torch.ones((2, 2))))
+        # self.assertRaisesRegex(
+        #     RuntimeError,
+        #     'A should not contain infs or NaNs',
+        #     lambda: torch.eig(np.nan * torch.ones((2, 2))))
 
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack


### PR DESCRIPTION
Moved the eig TH function to ATen. Made a few shortcuts, so I will be doing a small refactoring in the coming days. Is it ok if I also modify the tests? I think they cover too few cases. Also there is a test, checking if an input matrix contains NaNs, Infs. Didn't find such a check in any other linear algebra functions. To stay consistent either every function should have such a check or none. Imo it should just be deleted.