### PR TITLE
Fix docstr get_device, about CPU tensors

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1320,14 +1320,15 @@ add_docstr_all('get_device',
 get_device() -> Device ordinal (Integer)
 
 For CUDA tensors, this function returns the device ordinal of the GPU on which the tensor resides.
-For CPU tensors, an error is thrown.
+For CPU tensors, returns -1.
 
 Example::
 
     >>> x = torch.randn(3, 4, 5, device='cuda:0')
     >>> x.get_device()
     0
-    >>> x.cpu().get_device()  # RuntimeError: get_device is not implemented for type torch.FloatTensor
+    >>> x.cpu().get_device()
+    -1
 """)
 
 add_docstr_all('values',


### PR DESCRIPTION
About [get_device doc](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.get_device)
The example is 
```
>>> x = torch.randn(3, 4, 5, device='cuda:0')
>>> x.get_device()
0
>>> x.cpu().get_device()  # RuntimeError: get_device is not implemented for type torch.FloatTensor
```

But the result on 1.5.0 release
```
Python 3.7.2 (default, May  7 2019, 17:23:57)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> torch.__version__
'1.5.0+cu101'
>>> x = torch.randn(3, 4, 5, device="cuda:0")
>>> x.get_device()
0
>>> x.cpu().get_device()
-1
```

So I changed `error throw` to `return -1`

Also I was check [CPUGuardImpl.h#L20](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/detail/CPUGuardImpl.h#L20)