### PR TITLE
add_observer: respect device affinity for ReLU

### DIFF
--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -823,10 +823,14 @@ class TestDistributed(QuantizationTestCase):
 
             def __init__(self):
                 super(Model, self).__init__()
-                self.linear = nn.Linear(2, 2)
+                self.conv = nn.Conv2d(1, 1, 1)
+                self.bn = nn.BatchNorm2d(1)
+                self.relu = nn.ReLU()
 
             def forward(self, x):
-                x = self.linear(x)
+                x = self.conv(x)
+                x = self.bn(x)
+                x = self.relu(x)
                 return x
 
         model = Model()
@@ -841,5 +845,5 @@ class TestDistributed(QuantizationTestCase):
         self.assertEqual(model_device, device)
 
         # ensure that running an input on CUDA works without any needed changes
-        input = torch.randn(2, device=device)
+        input = torch.randn(4, 1, 4, 4, device=device)
         model(input)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39360 observer bench: add CUDA
* **#39337 add_observer: respect device affinity for ReLU**
* #39031 fake_quantize: respect device affinity

Summary:

In #39031 we made fake quantize respect device affinity of the
original module. However, that PR only handled modules with parameters
or buffers, and did not work properly for `ReLU`.

Fixing the logic to also work for `ReLU` by passing the parent's
device when adding observers.

Test Plan:

```
python test/test_quantization.py TestDistributed.test_device_affinity
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21821243](https://our.internmc.facebook.com/intern/diff/D21821243)