### PR TITLE
Fix destructor ordering for cuda handle pools

### DIFF
--- a/aten/src/ATen/cuda/CuSparseHandlePool.cpp
+++ b/aten/src/ATen/cuda/CuSparseHandlePool.cpp
@@ -21,14 +21,12 @@ void destroyCusparseHandle(cusparseHandle_t handle) {
 #endif
 }
 
-auto pool = std::make_shared<DeviceThreadHandlePool<cusparseHandle_t, createCusparseHandle, destroyCusparseHandle>>();
+using CuSparsePoolType = DeviceThreadHandlePool<cusparseHandle_t, createCusparseHandle, destroyCusparseHandle>;
 
-// Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
-// to avoid initialization issues that caused hangs on Windows.
-// See: https://github.com/pytorch/pytorch/pull/22405
-// This thread local unique_ptrs will be destroyed when the thread terminates,
-// releasing its reserved handles back to the pool.
-thread_local std::unique_ptr<decltype(pool)::element_type::PoolWindow> myPoolWindow;
+CuSparsePoolType &getPool() {
+  static auto pool = std::make_shared<CuSparsePoolType>();
+  return *pool;
+}
 
 } // namespace
 
@@ -36,8 +34,13 @@ cusparseHandle_t getCurrentCUDASparseHandle() {
   int device;
   AT_CUDA_CHECK(cudaGetDevice(&device));
 
-  if (!myPoolWindow)
-    myPoolWindow.reset(pool->newPoolWindow());
+  // Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
+  // to avoid initialization issues that caused hangs on Windows.
+  // See: https://github.com/pytorch/pytorch/pull/22405
+  // This thread local unique_ptrs will be destroyed when the thread terminates,
+  // releasing its reserved handles back to the pool.
+  thread_local std::unique_ptr<CuSparsePoolType::PoolWindow> myPoolWindow(
+      getPool().newPoolWindow());
 
   auto handle = myPoolWindow->reserve(device);
   cusparseSetStream(handle, c10::cuda::getCurrentCUDAStream());

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -23,25 +23,20 @@ void destroyCublasHandle(cublasHandle_t handle) {
 
 using CuBlasPoolType = DeviceThreadHandlePool<cublasHandle_t, createCublasHandle, destroyCublasHandle>;
 
-CuBlasPoolType &getPool()
-{
-  static auto pool = std::make_shared<CuBlasPoolType>();
-  return *pool;
-}
-
 } // namespace
 
 cublasHandle_t getCurrentCUDABlasHandle() {
   int device;
   AT_CUDA_CHECK(cudaGetDevice(&device));
 
-  // Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
+  // Thread local PoolWindows are lazily-initialized
   // to avoid initialization issues that caused hangs on Windows.
   // See: https://github.com/pytorch/pytorch/pull/22405
   // This thread local unique_ptrs will be destroyed when the thread terminates,
   // releasing its reserved handles back to the pool.
+  static auto pool = std::make_shared<CuBlasPoolType>();
   thread_local std::unique_ptr<CuBlasPoolType::PoolWindow> myPoolWindow(
-      getPool().newPoolWindow());
+      pool->newPoolWindow());
 
   auto handle = myPoolWindow->reserve(device);
   auto stream = c10::cuda::getCurrentCUDAStream();

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -21,14 +21,13 @@ void destroyCublasHandle(cublasHandle_t handle) {
 #endif
 }
 
-auto pool = std::make_shared<DeviceThreadHandlePool<cublasHandle_t, createCublasHandle, destroyCublasHandle>>();
+using CuBlasPoolType = DeviceThreadHandlePool<cublasHandle_t, createCublasHandle, destroyCublasHandle>;
 
-// Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
-// to avoid initialization issues that caused hangs on Windows.
-// See: https://github.com/pytorch/pytorch/pull/22405
-// This thread local unique_ptrs will be destroyed when the thread terminates,
-// releasing its reserved handles back to the pool.
-thread_local std::unique_ptr<decltype(pool)::element_type::PoolWindow> myPoolWindow;
+CuBlasPoolType &getPool()
+{
+  static auto pool = std::make_shared<CuBlasPoolType>();
+  return *pool;
+}
 
 } // namespace
 
@@ -36,8 +35,14 @@ cublasHandle_t getCurrentCUDABlasHandle() {
   int device;
   AT_CUDA_CHECK(cudaGetDevice(&device));
 
-  if (!myPoolWindow)
-    myPoolWindow.reset(pool->newPoolWindow());
+  // Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
+  // to avoid initialization issues that caused hangs on Windows.
+  // See: https://github.com/pytorch/pytorch/pull/22405
+  // This thread local unique_ptrs will be destroyed when the thread terminates,
+  // releasing its reserved handles back to the pool.
+  thread_local std::unique_ptr<CuBlasPoolType::PoolWindow> myPoolWindow(
+      getPool().newPoolWindow());
+
   auto handle = myPoolWindow->reserve(device);
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUDABLAS_CHECK(cublasSetStream(handle, stream));

--- a/aten/src/ATen/cudnn/Handle.cpp
+++ b/aten/src/ATen/cudnn/Handle.cpp
@@ -24,24 +24,20 @@ void destroyCuDNNHandle(cudnnHandle_t handle) {
 
 using CudnnPoolType = at::cuda::DeviceThreadHandlePool<cudnnHandle_t, createCuDNNHandle, destroyCuDNNHandle>;
 
-CudnnPoolType &getPool() {
-  static auto pool = std::make_shared<CudnnPoolType>();
-  return *pool;
-}
-
 } // namespace
 
 cudnnHandle_t getCudnnHandle() {
   int device;
   AT_CUDA_CHECK(cudaGetDevice(&device));
 
-  // Thread local PoolWindows are wrapped by unique_ptrs and lazily-initialized
+  // Thread local PoolWindows are lazily-initialized
   // to avoid initialization issues that caused hangs on Windows.
   // See: https://github.com/pytorch/pytorch/pull/22405
   // This thread local unique_ptrs will be destroyed when the thread terminates,
   // releasing its reserved handles back to the pool.
+  static auto pool = std::make_shared<CudnnPoolType>();
   thread_local std::unique_ptr<CudnnPoolType::PoolWindow> myPoolWindow(
-    getPool().newPoolWindow());
+      pool->newPoolWindow());
 
   auto handle = myPoolWindow->reserve(device);
   AT_CUDNN_CHECK(cudnnSetStream(handle, c10::cuda::getCurrentCUDAStream()));


### PR DESCRIPTION
Possible fix for gh-38385. Unfortunately, I haven't been able to reproduce the issue reliably, so can't say for certain.

Since this appears to be a destruction ordering issue, I've focused on making the destructor calls well-ordered:
- Each pool is now a function-local `static` instead of a global variable. This ensures the destructor happens before any relevant pytorch global state is destroyed.
- Each pool window now only stores a `std::weak_ptr` to the global pool. This means it can't extend the lifetime of the pool outside of the normal destructor ordering. That does also mean that if the `weak_ptr` is invalid, the handles will get leaked. However, that shouldn't happen under normal use.