### PR TITLE
[JIT] Kill _cast_* operators

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1,37 +1,46 @@
 # See README.md in this directory for more guidance
 
-# Temporary type cast operators. These are needed to trace type-casts now since
-# Type's are not supported in the IR. Instead, we call down to these
-# specialized operators for each datatype.
-# TODO: remove when we have Type support in the IR
+# *********NB: _cast_* operators are DEPRECATED and will be removed
+# eventually. These were previously used before TorchScript IR supported
+# representing ScalarType's. They are now superseded by usage of
+# `aten::to()`. The ops remain here for backward compatibility purposes.
+
+# DEPRECATED. DO NOT USE
 - func: _cast_Byte(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function
 
+# DEPRECATED. DO NOT USE
 - func: _cast_Char(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function
 
+# DEPRECATED. DO NOT USE
 - func: _cast_Double(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function
 
+# DEPRECATED. DO NOT USE
 - func: _cast_Float(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function
 
+# DEPRECATED. DO NOT USE
 - func: _cast_Int(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function
 
+# DEPRECATED. DO NOT USE
 - func: _cast_Long(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function
 
+# DEPRECATED. DO NOT USE
 - func: _cast_Short(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function
 
+# DEPRECATED. DO NOT USE
 - func: _cast_Half(Tensor self, bool non_blocking=False) -> Tensor
   use_c10_dispatcher: full
   variants: function

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -32,14 +32,14 @@ std::shared_ptr<SugaredValue> PrintValue::call(
 static const std::unordered_map<std::string, at::ScalarType>&
 builtin_cast_method_to_scalar_type() {
   static std::unordered_map<std::string, at::ScalarType> mapping = {
-    {"byte", at::kByte},
-    {"char", at::kChar},
-    {"double", at::kDouble},
-    {"float", at::kFloat},
-    {"int", at::kInt},
-    {"long", at::kLong},
-    {"short", at::kShort},
-    {"half", at::kHalf}};
+      {"byte", at::kByte},
+      {"char", at::kChar},
+      {"double", at::kDouble},
+      {"float", at::kFloat},
+      {"int", at::kInt},
+      {"long", at::kLong},
+      {"short", at::kShort},
+      {"half", at::kHalf}};
   return mapping;
 }
 

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -29,18 +29,18 @@ std::shared_ptr<SugaredValue> PrintValue::call(
   return std::make_shared<NoneValue>();
 }
 
-static const std::unordered_map<std::string, std::string>&
-builtin_cast_methods() {
-  static std::unordered_map<std::string, std::string> builtin_cast_methods = {
-      {"byte", "_cast_Byte"},
-      {"char", "_cast_Char"},
-      {"double", "_cast_Double"},
-      {"float", "_cast_Float"},
-      {"int", "_cast_Int"},
-      {"long", "_cast_Long"},
-      {"short", "_cast_Short"},
-      {"half", "_cast_Half"}};
-  return builtin_cast_methods;
+static const std::unordered_map<std::string, at::ScalarType>&
+builtin_cast_method_to_scalar_type() {
+  static std::unordered_map<std::string, at::ScalarType> mapping = {
+    {"byte", at::kByte},
+    {"char", at::kChar},
+    {"double", at::kDouble},
+    {"float", at::kFloat},
+    {"int", at::kInt},
+    {"long", at::kLong},
+    {"short", at::kShort},
+    {"half", at::kHalf}};
+  return mapping;
 }
 
 std::shared_ptr<SugaredValue> BuiltinFunction::call(
@@ -85,9 +85,9 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     const std::string& field) {
   // Allow method-style casts on Tensor types. e.g. x.int()
   if (value_->type()->isSubtypeOf(TensorType::get())) {
-    if (builtin_cast_methods().count(field)) {
-      return std::make_shared<BuiltinFunction>(
-          Symbol::aten(builtin_cast_methods().at(field)),
+    if (builtin_cast_method_to_scalar_type().count(field)) {
+      return std::make_shared<TensorCastValue>(
+          builtin_cast_method_to_scalar_type().at(field),
           NamedValue(loc, "self", value_));
     }
   }

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -507,6 +507,39 @@ struct TORCH_API CastValue : public BuiltinFunction {
   TypePtr type_;
 };
 
+struct TORCH_API TensorCastValue : public SugaredValue {
+  TensorCastValue(at::ScalarType type, NamedValue self)
+    : dtype_(type),
+      self_(std::move(self)) {}
+
+  std::string kind() const override {
+    return "Cast";
+  }
+
+  std::shared_ptr<SugaredValue> call(
+      const SourceRange& loc,
+      Function& m,
+      at::ArrayRef<NamedValue> inputs,
+      at::ArrayRef<NamedValue> attributes,
+      size_t n_binders) override {
+    TORCH_INTERNAL_ASSERT(inputs.size() == 0 && attributes.size() == 0);
+    Value *dtype_const = m.graph()->insertConstant(dtype_, loc);
+    std::vector<NamedValue> kwargs {
+      self_,
+      NamedValue(loc, "dtype", dtype_const)
+    };
+    Value *casted_val = m.graph()->insert(
+      /*opname=*/Symbol::fromQualString("aten::to"),
+      /*args=*/inputs,
+      /*kwargs=*/kwargs,
+      /*range=*/loc);
+    return std::make_shared<SimpleValue>(casted_val);
+  }
+
+  at::ScalarType dtype_;
+  NamedValue self_;
+};
+
 // builtins operators and functions that call a method if it exists
 // on a class type, like 'len(x)' and 'x + y'
 struct TORCH_API MagicMethod : public SugaredValue {

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -509,8 +509,7 @@ struct TORCH_API CastValue : public BuiltinFunction {
 
 struct TORCH_API TensorCastValue : public SugaredValue {
   TensorCastValue(at::ScalarType type, NamedValue self)
-    : dtype_(type),
-      self_(std::move(self)) {}
+      : dtype_(type), self_(std::move(self)) {}
 
   std::string kind() const override {
     return "Cast";
@@ -523,16 +522,14 @@ struct TORCH_API TensorCastValue : public SugaredValue {
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
     TORCH_INTERNAL_ASSERT(inputs.size() == 0 && attributes.size() == 0);
-    Value *dtype_const = m.graph()->insertConstant(dtype_, loc);
-    std::vector<NamedValue> kwargs {
-      self_,
-      NamedValue(loc, "dtype", dtype_const)
-    };
-    Value *casted_val = m.graph()->insert(
-      /*opname=*/Symbol::fromQualString("aten::to"),
-      /*args=*/inputs,
-      /*kwargs=*/kwargs,
-      /*range=*/loc);
+    Value* dtype_const = m.graph()->insertConstant(dtype_, loc);
+    std::vector<NamedValue> kwargs{self_,
+                                   NamedValue(loc, "dtype", dtype_const)};
+    Value* casted_val = m.graph()->insert(
+        /*opname=*/Symbol::fromQualString("aten::to"),
+        /*args=*/inputs,
+        /*kwargs=*/kwargs,
+        /*range=*/loc);
     return std::make_shared<SimpleValue>(casted_val);
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39348 [JIT] Kill _cast_* operators**

Previously we didn't support ScalarType constants in the IR (in like 2017) so these ops were added as a hack. This patch kills emitting those ops 

Differential Revision: [D21824594](https://our.internmc.facebook.com/intern/diff/D21824594)