### PR TITLE
Remove test_nccl from ROCM_BLACKLIST and enable only a couple of test_nccl tests

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -21,7 +21,6 @@ if not TEST_CUDA:
 
 class TestNCCL(TestCase):
 
-    @unittest.skipIf(TEST_WITH_ROCM, 'Skip NCCL tests for ROCm')
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     def test_unique_id(self):
         uid = nccl.unique_id()
@@ -56,7 +55,6 @@ class TestNCCL(TestCase):
 
         self.assertEqual(tensors[0], expected)
 
-    @unittest.skipIf(TEST_WITH_ROCM, 'Skip NCCL tests for ROCm')
     @unittest.skipIf(IS_WINDOWS, "NCCL doesn't support Windows")
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_all_reduce(self):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -100,7 +100,6 @@ ROCM_BLACKLIST = [
     'distributed/rpc/test_dist_autograd_spawn',
     'distributed/rpc/test_dist_optimizer_spawn',
     'distributed/rpc/test_rpc_spawn',
-    'distributed/test_nccl',
     'test_determination',
     'test_multiprocessing',
     'test_jit_simple',


### PR DESCRIPTION
All individual test_nccl unit tests have been disabled for ROCm in https://github.com/pytorch/pytorch/commit/bf9395438f5ccf0acfcdb2451c8745ec199c7237
test_nccl was also added to the ROCM_BLACKLIST in https://github.com/pytorch/pytorch/commit/87b198d309e00f52e098a533c22b087b36fc00e3
However, the issue only arises when running the test_nccl suite as a whole (as opposed to any one test individually). More details in comments here: https://github.com/pytorch/pytorch/pull/38689

This PR enables test_nccl suite with only two tests so as to workaround the as-yet unresolved issue above, while allowing at least one test_nccl collective test to run on ROCm. This is also needed as a precursor for: https://github.com/pytorch/pytorch/pull/38515

