### PR TITLE
[v1.5.1][JIT] make torch.unique compilable (#38156)

### DIFF
--- a/docs/source/jit_unsupported.rst
+++ b/docs/source/jit_unsupported.rst
@@ -25,7 +25,6 @@ are not bound on `torch` or because Python expects a different schema than
 TorchScript.
 
   * :func:`torch.tensordot`
-  * :func:`torch.unique`
   * :func:`torch.unique_consecutive`
   * :func:`torch.nn.init.calculate_gain`
   * :func:`torch.nn.init.eye_`

--- a/test/jit/test_unsupported_ops.py
+++ b/test/jit/test_unsupported_ops.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from textwrap import dedent
 
 import torch
 import unittest
@@ -8,7 +7,7 @@ import unittest
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
-from torch.testing._internal.jit_utils import JitTestCase, execWrapper
+from torch.testing._internal.jit_utils import JitTestCase
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -58,20 +57,6 @@ class TestUnsupportedOps(JitTestCase):
             print(torch.jit.script(foo).graph)
 
     def test_ops_bound_in_functional(self):
-        ops_bound_in_functional = "unique",
-        tensor = torch.tensor([2])
-        funcs_template = dedent('''
-        def func():
-            return torch.{op}()
-        ''')
-        for op in ops_bound_in_functional:
-            funcs_str = funcs_template.format(op=op)
-            scope = {}
-            execWrapper(funcs_str, globals(), scope)
-            f = scope['func']
-            with self.assertRaisesRegex(Exception, "Unknown builtin op"):
-                cu = torch.jit.CompilationUnit(funcs_str)
-
         def unique_consec():
             x = torch.tensor([1])
             return torch.unique_consecutive(x, return_inverse=False, return_counts=True, dim=0)

--- a/test/onnx/expect/TestOperators.test_unique.expect
+++ b/test/onnx/expect/TestOperators.test_unique.expect
@@ -3,7 +3,7 @@ producer_name: "pytorch"
 producer_version: "1.5"
 graph {
   node {
-    input: "x"
+    input: "input"
     output: "1"
     output: "2"
     output: "3"
@@ -23,7 +23,7 @@ graph {
   }
   name: "torch-jit-export"
   input {
-    name: "x"
+    name: "input"
     type {
       tensor_type {
         elem_type: 1

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10826,6 +10826,17 @@ a")
 
         self.checkScript(norm, ())
 
+        def torch_unique(dim: Optional[int]):
+            ten = torch.unique(torch.tensor([[1, 3], [2, 3]], dtype=torch.long))
+            a = torch.unique(ten, dim=dim)
+            b = torch.unique(ten, return_counts=True, dim=dim)
+            c = torch.unique(ten, return_inverse=True, dim=dim)
+            d = torch.unique(ten, return_counts=True, return_inverse=True, dim=dim)
+            return a, b, c, d
+
+        self.checkScript(torch_unique, (None,))
+        self.checkScript(torch_unique, (0,))
+
     def test_missing_getstate(self):
         class Foo(torch.nn.Module):
             def __init__(self):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -433,7 +433,8 @@ def stft(input, n_fft, hop_length=None, win_length=None, window=None,
 del torch.unique_dim
 
 
-def unique(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
+def _unique_impl(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor, Tensor]
     r"""Returns the unique elements of the input tensor.
 
     .. note:: This function is different from :func:`torch.unique_consecutive` in the sense that
@@ -497,6 +498,7 @@ def unique(input, sorted=True, return_inverse=False, return_counts=False, dim=No
             return handle_torch_function(
                 unique, (input,), input, sorted=sorted, return_inverse=return_inverse,
                 return_counts=return_counts, dim=dim)
+
     if dim is not None:
         output, inverse_indices, counts = _VF.unique_dim(
             input,
@@ -512,14 +514,69 @@ def unique(input, sorted=True, return_inverse=False, return_counts=False, dim=No
             return_inverse=return_inverse,
             return_counts=return_counts,
         )
-    if return_inverse and return_counts:
-        return output, inverse_indices, counts
-    elif return_inverse:
-        return output, inverse_indices
-    elif return_counts:
-        return output, counts
-    else:
-        return output
+    return output, inverse_indices, counts
+
+
+def _return_counts(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+
+    if not torch.jit.is_scripting():
+        if type(input) is not Tensor and has_torch_function((input,)):
+            return _unique_impl(input, sorted, return_inverse, return_counts, dim)
+
+    output, _, counts = _unique_impl(input, sorted, return_inverse, return_counts, dim)
+    return output, counts
+
+def _return_output(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tensor
+
+    if not torch.jit.is_scripting():
+        if type(input) is not Tensor and has_torch_function((input,)):
+            return _unique_impl(input, sorted, return_inverse, return_counts, dim)
+
+    output, _, _ = _unique_impl(input, sorted, return_inverse, return_counts, dim)
+    return output
+
+def _return_inverse(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+
+    if not torch.jit.is_scripting():
+        if type(input) is not Tensor and has_torch_function((input,)):
+            return _unique_impl(input, sorted, return_inverse, return_counts, dim)
+
+    output, inverse_indices, _ = _unique_impl(input, sorted, return_inverse, return_counts, dim)
+    return output, inverse_indices
+
+_return_inverse_false = boolean_dispatch(
+    arg_name='return_counts',
+    arg_index=3,
+    default=False,
+    if_true=_return_counts,
+    if_false=_return_output,
+    module_name=__name__,
+    func_name='unique')
+
+_return_inverse_true = boolean_dispatch(
+    arg_name='return_counts',
+    arg_index=3,
+    default=False,
+    if_true=_unique_impl,
+    if_false=_return_inverse,
+    module_name=__name__,
+    func_name='unique')
+
+# The return type of unique depends on `return_inverse`, and `return_counts` so in order to
+# resolve the output type in TorchScript we need to statically know the value of both parameters
+
+unique = boolean_dispatch(
+    arg_name='return_inverse',
+    arg_index=2,
+    default=False,
+    if_true=_return_inverse_true,
+    if_false=_return_inverse_false,
+    module_name=__name__,
+    func_name='unique')
+unique.__doc__ = _unique_impl.__doc__
 
 
 def unique_consecutive(input, return_inverse=False, return_counts=False, dim=None):

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -80,20 +80,21 @@ _builtin_ops = [
     (torch._VF.stft, "aten::stft"),
     (torch._VF.cdist, "aten::cdist"),
     (torch._VF.norm, "aten::norm"),
+    (torch._VF.unique_dim, "aten::unique_dim"),
     (torch._VF.nuclear_norm, "aten::nuclear_norm"),
     (torch._VF.frobenius_norm, "aten::frobenius_norm"),
 ]
 
-# ops in torch.functional are bound to torch 
-# in these cases, we want to resolve the function to their python implementation 
+# ops in torch.functional are bound to torch
+# in these cases, we want to resolve the function to their python implementation
 # instead looking up a builtin "aten::" schema
 
 def _gen_torch_functional_registered_ops():
-    # eventually ops should encompass all of torch/functional.py, (torch.functional.__all__) 
-    # but we are currently only able to compile some of the functions. additionally, 
-    # some functions directly map to their aten:: implementations. 
+    # eventually ops should encompass all of torch/functional.py, (torch.functional.__all__)
+    # but we are currently only able to compile some of the functions. additionally,
+    # some functions directly map to their aten:: implementations.
     # TODO: add support for more ops
-    ops = ["stft", "lu", "lu_unpack", "cdist", "norm"]
+    ops = ["stft", "lu", "lu_unpack", "cdist", "norm", "unique"]
     return set(getattr(torch.functional, name) for name in ops)
 
 _functional_registered_ops = _gen_torch_functional_registered_ops()


### PR DESCRIPTION
Summary:
Fix for https://github.com/pytorch/pytorch/issues/37986

Follows the stack in https://github.com/pytorch/pytorch/pull/33783 stack to make functions in `torch/functional.py` resolve to their python implementations. Because the return type of `torch.unique` depends on `return_inverse` and `return_counts` I had to refactor the implementation to use our boolean_dispatch mechanism.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/38156

Differential Revision: D21504449

Pulled By: eellison

fbshipit-source-id: 7efb1dff3b5c00655da10168403ac4817286ff59

