### PR TITLE
[caffe2] compute r_correction only for radam to avoid sqrt(negative)

### DIFF
--- a/caffe2/sgd/adam_op.h
+++ b/caffe2/sgd/adam_op.h
@@ -295,8 +295,9 @@ class SparseAdamOp final : public Operator<Context> {
     const auto rho_inf = T(2.) / (T(1.) - beta2_) - T(1.);
     const auto rho_t = rho_inf -
         T(2.) * t * std::pow(beta2_, t) / (T(1.) - std::pow(beta2_, t));
-    const auto r_correction =
-        std::sqrt(rho_inf / ((rho_inf - T(4.)) * (rho_inf - T(2.))));
+    const T r_correction = enableRAdam_
+        ? std::sqrt(rho_inf / ((rho_inf - T(4.)) * (rho_inf - T(2.))))
+        : 0;
 
     auto block_size = Input(PARAM).numel() / Input(PARAM).size(0);
     auto n = Input(GRAD).numel() / block_size;


### PR DESCRIPTION
Summary: Computing r_correction should be done only for radam . Otherwise can generate floating-point exceptions.

Test Plan:
buck test caffe2/caffe2/python/operator_test:adam_test -- test_sparse_adam
with --caffe2_operator_throw_if_fp_exceptions=1 gflags option

Differential Revision: D21834296

