### PR TITLE
[TensorPipe] Guess IP addr in separate function

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -91,11 +91,6 @@ class TensorPipeAgent : public RpcAgent {
   std::string createUniqueShmAddr();
 #endif
 
-  // Retrieve IP address for a given network device for corss-hosts
-  // to set up tensorpipe connection. For now we default the device
-  // name eth0.
-  static std::string getDefaultIPAddress();
-
   // TensorPipe read function that could be used to read response messages
   // by client, and read request messages by server.
   void pipeRead(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39398 [TensorPipe] Acquire lock when adding message to timeout map
* **#39397 [TensorPipe] Guess IP addr in separate function**

I said I'd do it in a previous diff, but then I forgot, so here it is.

Differential Revision: [D21838464](https://our.internmc.facebook.com/intern/diff/D21838464/)