### PR TITLE
Updated assert to remove check on 3rd dim for MHA

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3947,7 +3947,8 @@ def multi_head_attention_forward(query,                           # type: Tensor
                 v_proj_weight=v_proj_weight, static_k=static_k, static_v=static_v)
     tgt_len, bsz, embed_dim = query.size()
     assert embed_dim == embed_dim_to_check
-    assert key.size() == value.size()
+    # allow MHA to have different sizes for the feature dimension
+    assert key.size(0) == value.size(0) and key.size(1) == value.size(1)
 
     head_dim = embed_dim // num_heads
     assert head_dim * num_heads == embed_dim, "embed_dim must be divisible by num_heads"


### PR DESCRIPTION
## Description
* Updated assert statement to remove check on 3rd dimension (features) for keys and values in MultiheadAttention / Transform 
* The feature dimension for keys and values can now be of different sizes
* Refer to #27623