### PR TITLE
[Easy] Replace other outstanding static thread tasks in pipe()

### DIFF
--- a/caffe2/python/cached_reader.py
+++ b/caffe2/python/cached_reader.py
@@ -114,7 +114,7 @@ class CachedReader(DBFileReader):
         init_net = core.Net('init')
         self._init_field_blobs_as_empty(init_net)
         with Cluster(), core.NameScope(self.name), TaskGroup() as copy_tg:
-            pipe(self.original_reader, self.ds.writer(), num_threads=16)
+            pipe(self.original_reader, self.ds.writer(), num_runtime_threads=16)
             copy_step = copy_tg.to_task().get_step()
         save_net = core.Net('save')
         self._save_field_blobs_to_db_file(save_net)


### PR DESCRIPTION
Summary: This diff is a follow-up of D21584401 (see diff comments) that aims to solve other places where we're still using static thread task that leads to flattened nets (longer build time and larger in size)

Test Plan: Given how stable runtime thread task is in our production, i wouldn't expect regression or anything broken -- so just relying on integration tests.

Differential Revision: D21841203

