### PR TITLE
misc updates to fake fp16 tests

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
@@ -13,7 +13,6 @@ from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
 from hypothesis import given, settings
 import hypothesis.strategies as st
-# import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
@@ -28,10 +27,9 @@ class TestBatchMatMul(serial.SerializedTestCase):
         rand_seed=st.integers(0, 65534),
         trans_a=st.booleans(),
         trans_b=st.booleans(),
-        run_ints=st.booleans()#,
-        # **hu.gcs
+        run_ints=st.booleans()
     )
-    def test_batch_matmul(self, M, K, N, rand_seed, trans_a, trans_b, run_ints):#, gc, dc):
+    def test_batch_matmul(self, M, K, N, rand_seed, trans_a, trans_b, run_ints):
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
         C = 0  # TODO

--- a/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
@@ -13,7 +13,7 @@ from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
 from hypothesis import given, settings
 import hypothesis.strategies as st
-import caffe2.python.hypothesis_test_util as hu
+# import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
@@ -28,10 +28,10 @@ class TestBatchMatMul(serial.SerializedTestCase):
         rand_seed=st.integers(0, 65534),
         trans_a=st.booleans(),
         trans_b=st.booleans(),
-        run_ints=st.booleans(),
-        **hu.gcs
+        run_ints=st.booleans()#,
+        # **hu.gcs
     )
-    def test_batch_matmul(self, M, K, N, rand_seed, trans_a, trans_b, run_ints, gc, dc):
+    def test_batch_matmul(self, M, K, N, rand_seed, trans_a, trans_b, run_ints):#, gc, dc):
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
         C = 0  # TODO

--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -16,6 +16,7 @@ from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.onnx.tests.test_utils import TestCase
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
+import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--glow_global_fp16=1",
                       "--glow_global_fused_scale_offset_fp16=1",

--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -8,12 +8,12 @@ from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from hypothesis import given, note, strategies as st, settings
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
-
+import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
 
 
-class Int8OpsTest(unittest.TestCase):
+class Int8OpsTest(serial.SerializedTestCase):
     def _get_scale_zp(self, tensor):
         tensor_max = np.max(tensor)
         tensor_min = min(0, np.min(tensor))

--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -9,8 +9,9 @@ import os
 
 import caffe2.python.fakelowp.init_shared_libs  # noqa
 
-import caffe2.python.hypothesis_test_util as hu
+# import caffe2.python.hypothesis_test_util as hu
 from hypothesis import given
+from hypothesis import strategies as st
 
 
 from caffe2.proto import caffe2_pb2
@@ -18,16 +19,18 @@ from caffe2.python import dyndep
 from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.onnx.tests.test_utils import TestCase
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
+import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
 
 kEpsilon = 1e-8
 
 
-class ArithmeticOpsTest(TestCase):
-    def _test_binary_op_graph(self, name):
+class ArithmeticOpsTest(serial.SerializedTestCase):
+    @given(seed=st.integers(0, 65534))
+    def _test_binary_op_graph(self, name, seed):
+        np.random.seed(seed)
         workspace.ResetWorkspace()
         # First dimension is the batch size
         dims = np.concatenate((np.array([1]), np.random.randint(1, 20, size=3)))
@@ -108,8 +111,10 @@ class ArithmeticOpsTest(TestCase):
         self._test_binary_op_graph("Div")
 
 
-class UnaryOpTest(TestCase):
-    def _test_unary_op(self, opname):
+class UnaryOpTest(serial.SerializedTestCase):
+    @given(seed=st.integers(0, 65534))
+    def _test_unary_op(self, opname, seed):
+        np.random.seed(seed)
         workspace.ResetWorkspace()
         n = 1
         m = 10000
@@ -174,9 +179,12 @@ class UnaryOpTest(TestCase):
         self._test_unary_op("Tanh")
 
 
-class ReluTest(hu.HypothesisTestCase):
-    @given(inputs=hu.tensors(n=1, min_dim=1, max_dim=3, dtype=np.float32))
-    def relu_test(self, inputs, gc, dc):
+class ReluTest(serial.SerializedTestCase):
+    @given(#inputs=hu.tensors(n=1, min_dim=1, max_dim=3, dtype=np.float32),
+           seed=st.integers(0, 65534))
+    def relu_test(self, inputs, gc, dc, seed):
+        np.random.seed(seed)
+        inputs = np.random.rand(1).astype(np.float32)
         X = inputs[0]
         # First dimension is the batch size
         print(X.shape)
@@ -231,6 +239,6 @@ class ReluTest(hu.HypothesisTestCase):
         if not np.allclose(Y_c2, Y_glow):
             diff = np.abs((Y_glow - Y_c2) / (Y_c2 + kEpsilon))
             print_test_debug_info("Relu", {
-                "X": X,
+                "seed":seed, "X": X,
                 "Y_glow": Y_glow, "Y_c2": Y_c2, "diff": diff})
             assert(0)

--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -9,7 +9,6 @@ import os
 
 import caffe2.python.fakelowp.init_shared_libs  # noqa
 
-# import caffe2.python.hypothesis_test_util as hu
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -180,8 +179,7 @@ class UnaryOpTest(serial.SerializedTestCase):
 
 
 class ReluTest(serial.SerializedTestCase):
-    @given(#inputs=hu.tensors(n=1, min_dim=1, max_dim=3, dtype=np.float32),
-           seed=st.integers(0, 65534))
+    @given(seed=st.integers(0, 65534))
     def relu_test(self, inputs, gc, dc, seed):
         np.random.seed(seed)
         inputs = np.random.rand(1).astype(np.float32)

--- a/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
@@ -15,13 +15,14 @@ from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
+import caffe2.python.serialized_test.serialized_test_util as serial
 
 workspace.GlobalInit(["caffe2", "--glow_global_fp16=1",
                       "--glow_global_fused_scale_offset_fp16=1",
                       "--glow_global_force_sls_fp16_accum=1"])
 
 
-class SparseLengthsSum4BitFakeNNPIFp16Test(unittest.TestCase):
+class SparseLengthsSum4BitFakeNNPIFp16Test(serial.SerializedTestCase):
     @given(seed=st.integers(0, 65535))
     def test_slws_fused_4bit_rowwise_all_same(self, seed):
         np.random.seed(seed)

--- a/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp16.py
@@ -11,7 +11,7 @@ from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
-
+import caffe2.python.serialized_test.serialized_test_util as serial
 
 workspace.GlobalInit(
     [
@@ -25,7 +25,7 @@ GLOW_MATMUL_ATOL = 1e-5
 GLOW_MATMUL_RTOL = 1e-3
 
 
-class SparseLengthsSum8BitFakeNNPIFp16Test(unittest.TestCase):
+class SparseLengthsSum8BitFakeNNPIFp16Test(serial.SerializedTestCase):
     def Skip_test_SLS_NonQuantized_fp16(self):
         N = 20000
         DIM = 64

--- a/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
@@ -11,7 +11,7 @@ from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
-
+import caffe2.python.serialized_test.serialized_test_util as serial
 
 workspace.GlobalInit(
     [
@@ -24,7 +24,7 @@ workspace.GlobalInit(
 GLOW_MATMUL_ATOL = 1e-5
 GLOW_MATMUL_RTOL = 1e-3
 
-class SparseLengthsSum8BitFakeNNPIFp32Test(unittest.TestCase):
+class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
     @given(
         seed=st.integers(0, 65535),
         num_rows=st.integers(2, 20),


### PR DESCRIPTION
Misc updates to the fake FP16 tests.
1. seeding numpy with a random seed
2. test base class changed from unittest.TestCase=>serial.SerializedTestCase
3. Removed the hypothesis_test_util import
Reviewer: Hector Yuen
Test plan: Fake FP16 test