### PR TITLE
topk tensor k support

### DIFF
--- a/caffe2/operators/filler_op.cc
+++ b/caffe2/operators/filler_op.cc
@@ -40,7 +40,7 @@ REGISTER_CPU_OPERATOR(RangeFill, RangeFillOp<float, CPUContext>);
 REGISTER_CPU_OPERATOR(LengthsRangeFill, LengthsRangeFillOp<CPUContext>);
 
 OPERATOR_SCHEMA(ConstantFill)
-    .NumInputs(0, 1)
+    .NumInputs(0, 2)
     .NumOutputs(1)
     .AllowInplace({{0, 0}})
     .TensorInferenceFunction(FillerTensorInference<>)
@@ -64,6 +64,8 @@ provided, a shape argument should not be set)
 - If `input_as_shape` is set to True, the input should be a 1D tensor
 containing the desired output shape (the dimensions specified in `extra_shape`
 will also be appended)
+
+- If a second input V is passed, fill the output with the first element of V
 
 When specifying `dtype` argument, use the integer keys from the *DataType* enum
 in TensorProto:

--- a/caffe2/operators/filler_op.h
+++ b/caffe2/operators/filler_op.h
@@ -77,9 +77,14 @@ class FillerOp : public Operator<Context> {
               "data type int64_t");
           CAFFE_ENFORCE(input.numel() > 0);
           auto* shape_data = input.template data<int64_t>();
-          std::unique_ptr<int64_t[]> shape_data_copy = std::make_unique<int64_t[]>(input.dim32(0));
-          context_.template CopyToCPU<int64_t>(input.dim32(0), shape_data, shape_data_copy.get());
-          shape.insert(shape.end(), shape_data_copy.get(), shape_data_copy.get() + input.dim32(0));
+          std::unique_ptr<int64_t[]> shape_data_copy =
+              std::make_unique<int64_t[]>(input.dim32(0));
+          context_.template CopyToCPU<int64_t>(
+              input.dim32(0), shape_data, shape_data_copy.get());
+          shape.insert(
+              shape.end(),
+              shape_data_copy.get(),
+              shape_data_copy.get() + input.dim32(0));
         }
       } else {
         auto& input = Input(0);
@@ -295,6 +300,15 @@ class ConstantFillOp final : public FillerOp<Context> {
   template <typename T>
   bool FillWithType(Tensor* output) {
     T value = this->template GetSingleArgument<T>("value", 0);
+    if (InputSize() == 2) {
+      auto& value_vec = Input(1);
+      if (value_vec) {
+        CAFFE_ENFORCE_EQ(
+            value_vec.size(), 1, "value vector must have 1 element");
+        value = value_vec.template data<T>()[0];
+      }
+    }
+
     auto* data = output->template mutable_data<T>();
     if (output->numel()) {
       math::Set<T, Context>(output->numel(), value, data, &context_);
@@ -303,6 +317,8 @@ class ConstantFillOp final : public FillerOp<Context> {
   }
 
   bool FillWithString(Tensor* output) {
+    CAFFE_ENFORCE_LT(
+        InputSize(), 2, "constant fill string from tensor is not supported");
     auto value = this->template GetSingleArgument<std::string>("value", "");
     auto* data = output->template mutable_data<std::string>();
     for (int i = 0; i < output->numel(); ++i) {

--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -1906,6 +1906,34 @@ class TestOperators(hu.HypothesisTestCase):
         out, = self.assertReferenceChecks(gc, op, inputs, ref)
         self.assertEqual(dtype, out.dtype)
 
+    @given(data=_dtypes(dtypes=[np.int32, np.int64, np.float32, np.bool]).
+        flatmap(lambda dtype: hu.tensor(
+            min_dim=1, dtype=dtype, elements=hu.elements_of_type(dtype))),
+        **hu.gcs)
+    def test_constant_fill_from_tensor(self, data, gc, dc):
+        dtype = data.dtype.type
+        if data.dtype == np.dtype(np.bool):
+            dtype = np.bool
+
+        value = np.array([data.item(0)], dtype=dtype)
+        inputs = [data, value]
+        enum_type = _NUMPY_TYPE_TO_ENUM[dtype]
+
+        op = core.CreateOperator(
+            'ConstantFill',
+            ["X", "V"],
+            ["Y"],
+            dtype=enum_type,
+        )
+
+        def ref(x, v):
+            outputs = np.full(shape=data.shape, fill_value=value[0], dtype=dtype)
+            return [outputs]
+
+        self.assertDeviceChecks(dc, op, inputs, [0])
+        out, = self.assertReferenceChecks(gc, op, inputs, ref)
+        self.assertEqual(dtype, out.dtype)
+
     @given(t=st.integers(1, 5),
            n=st.integers(1, 5),
            d=st.integers(1, 5))


### PR DESCRIPTION
Summary:
- support passing a single element tensor as k for topk module
 - support passing a single element tensor to constant fill output

Test Plan:
buck test dper3/dper3/modules/tests:core_modules_test -- test_topk_gating_without_split_examples_tensor_k
buck test caffe2/caffe2/python:hypothesis_test -- test_constant_fill_from_tensor

Differential Revision: D21843739

