### PR TITLE
[TensorExpr] some cleanups / fixes for LoopOptions

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -127,6 +127,7 @@ namespace jit {
   _(HashEquivalenceAfterFolding)            \
   _(HashDifferenceTypes)                    \
   _(HashLargeExpression)                    \
+  _(HashForLoopOptions)                     \
   _(SimplifyAdd)                            \
   _(SimplifySub)                            \
   _(SimplifyMultiLayer)                     \

--- a/torch/csrc/jit/tensorexpr/hash_provider.cpp
+++ b/torch/csrc/jit/tensorexpr/hash_provider.cpp
@@ -205,6 +205,7 @@ void HashProvider::visit(const For* v) {
 
   SimplifierHashType hash = hash_combine(
       "for", hashOf(v->var()), hashOf(v->start()), hashOf(v->stop()));
+  hash = hash_combine(hash, v->loop_options().ToString());
   if (v->body()) {
     v->body()->accept(this);
     hash = hash_combine(hash, hashOf(v->body()));

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -62,6 +62,10 @@ class TORCH_API HashProvider : public IRVisitor {
     return exprToHash_.find(e) != exprToHash_.end();
   }
 
+  void clearCache() {
+    exprToHash_.clear();
+  }
+
   void visit(const Add* v) override;
   void visit(const Sub* v) override;
   void visit(const Mul* v) override;

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -438,9 +438,17 @@ class TORCH_API Cond : public StmtNode<Cond> {
 
 class TORCH_API LoopOptions {
  public:
+  enum {
+    IDX_UNSET = -1,
+    IDX_X = 0,
+    IDX_Y = 1,
+    IDX_Z = 2,
+    IDX_W = 3,
+    IDX_MAX = IDX_W,
+  };
   // GPU Block Index
   bool is_gpu_block_index() const {
-    return gpu_block_index_ != -1;
+    return gpu_block_index_ != IDX_UNSET;
   }
 
   int gpu_block_index() const {
@@ -459,7 +467,7 @@ class TORCH_API LoopOptions {
         "blockIdx.w",
     };
 
-    if (gpu_block_index_ < 0 || gpu_block_index_ >= 4) {
+    if (gpu_block_index_ < IDX_X || gpu_block_index_ > IDX_MAX) {
       throw malformed_input("invalid GPU block index");
     }
 
@@ -467,6 +475,10 @@ class TORCH_API LoopOptions {
   }
 
   void set_gpu_block_index(int index) {
+    if (index == IDX_UNSET) {
+      gpu_block_index_ = IDX_UNSET;
+    }
+
     if (is_gpu_thread_index()) {
       throw std::runtime_error("Cannot set both gpu block and thread index");
     }
@@ -478,7 +490,7 @@ class TORCH_API LoopOptions {
 
   // GPU Thread Index
   bool is_gpu_thread_index() const {
-    return gpu_thread_index() != -1;
+    return gpu_thread_index() != IDX_UNSET;
   }
 
   int gpu_thread_index() const {
@@ -493,7 +505,7 @@ class TORCH_API LoopOptions {
     static const char* kThreadIndexNames[] = {
         "threadIdx.x", "threadIdx.y", "threadIdx.z", "threadIdx.w"};
 
-    if (gpu_thread_index_ < 0 || gpu_thread_index_ >= 4) {
+    if (gpu_thread_index_ < IDX_X || gpu_thread_index_ > IDX_MAX) {
       throw malformed_input("invalid GPU thread index");
     }
 
@@ -501,6 +513,10 @@ class TORCH_API LoopOptions {
   }
 
   void set_gpu_thread_index(int index) {
+    if (index == IDX_UNSET) {
+      gpu_thread_index_ = IDX_UNSET;
+    }
+
     if (is_gpu_block_index()) {
       throw std::runtime_error("Cannot set both gpu thread and block index");
     }
@@ -521,12 +537,12 @@ class TORCH_API LoopOptions {
   }
 
   bool isDefault() const {
-    return gpu_block_index_ == -1 && gpu_thread_index_ == -1;
+    return gpu_block_index_ == IDX_UNSET && gpu_thread_index_ == IDX_UNSET;
   }
 
  private:
-  int gpu_block_index_ = -1;
-  int gpu_thread_index_ = -1;
+  int gpu_block_index_{IDX_UNSET};
+  int gpu_thread_index_{IDX_UNSET};
 };
 
 class TORCH_API For : public StmtNode<For> {


### PR DESCRIPTION
Mainly, fix a bug in the HashProvider where it would not include LoopOptions in the hash, meaning two loops would be seen as identical even if they were bound to different thread/block axes. Also added symbolic names for the different axis options.