### PR TITLE
[1.5.1] Make torch.unique_consecutive compatible

### DIFF
--- a/docs/source/jit_unsupported.rst
+++ b/docs/source/jit_unsupported.rst
@@ -25,7 +25,6 @@ are not bound on `torch` or because Python expects a different schema than
 TorchScript.
 
   * :func:`torch.tensordot`
-  * :func:`torch.unique_consecutive`
   * :func:`torch.nn.init.calculate_gain`
   * :func:`torch.nn.init.eye_`
   * :func:`torch.nn.init.dirac_`

--- a/test/jit/test_unsupported_ops.py
+++ b/test/jit/test_unsupported_ops.py
@@ -57,12 +57,6 @@ class TestUnsupportedOps(JitTestCase):
             print(torch.jit.script(foo).graph)
 
     def test_ops_bound_in_functional(self):
-        def unique_consec():
-            x = torch.tensor([1])
-            return torch.unique_consecutive(x, return_inverse=False, return_counts=True, dim=0)
-
-        self.assertNotEqual(unique_consec(), torch.jit.script(unique_consec)())
-
         def tensordot():
             a = torch.arange(60.).reshape(3, 4, 5)
             b = torch.arange(24.).reshape(4, 3, 2)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10837,6 +10837,17 @@ a")
         self.checkScript(torch_unique, (None,))
         self.checkScript(torch_unique, (0,))
 
+        def torch_unique_consecutive(dim: Optional[int]):
+            ten = torch.unique(torch.tensor([[1, 3], [3, 2], [3, 2], [2, 3]], dtype=torch.long))
+            a = torch.unique_consecutive(ten, dim=dim)
+            b = torch.unique_consecutive(ten, return_counts=True, dim=dim)
+            c = torch.unique_consecutive(ten, return_inverse=True, dim=dim)
+            d = torch.unique_consecutive(ten, return_counts=True, return_inverse=True, dim=dim)
+            return a, b, c, d
+
+        self.checkScript(torch_unique_consecutive, (None,))
+        self.checkScript(torch_unique_consecutive, (0,))
+
     def test_missing_getstate(self):
         class Foo(torch.nn.Module):
             def __init__(self):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -517,6 +517,67 @@ def _unique_impl(input, sorted=True, return_inverse=False, return_counts=False, 
     return output, inverse_indices, counts
 
 
+def _unique_consecutive_impl(input, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor, Tensor]
+    r"""Eliminates all but the first element from every consecutive group of equivalent elements.
+
+    .. note:: This function is different from :func:`torch.unique` in the sense that this function
+        only eliminates consecutive duplicate values. This semantics is similar to `std::unique`
+        in C++.
+
+    Arguments:
+        input (Tensor): the input tensor
+        return_inverse (bool): Whether to also return the indices for where
+            elements in the original input ended up in the returned unique list.
+        return_counts (bool): Whether to also return the counts for each unique
+            element.
+        dim (int): the dimension to apply unique. If ``None``, the unique of the
+            flattened input is returned. default: ``None``
+
+    Returns:
+        (Tensor, Tensor (optional), Tensor (optional)): A tensor or a tuple of tensors containing
+
+            - **output** (*Tensor*): the output list of unique scalar elements.
+            - **inverse_indices** (*Tensor*): (optional) if
+              :attr:`return_inverse` is True, there will be an additional
+              returned tensor (same shape as input) representing the indices
+              for where elements in the original input map to in the output;
+              otherwise, this function will only return a single tensor.
+            - **counts** (*Tensor*): (optional) if
+              :attr:`return_counts` is True, there will be an additional
+              returned tensor (same shape as output or output.size(dim),
+              if dim was specified) representing the number of occurrences
+              for each unique value or tensor.
+
+    Example::
+
+        >>> x = torch.tensor([1, 1, 2, 2, 3, 1, 1, 2])
+        >>> output = torch.unique_consecutive(x)
+        >>> output
+        tensor([1, 2, 3, 1, 2])
+
+        >>> output, inverse_indices = torch.unique_consecutive(x, return_inverse=True)
+        >>> output
+        tensor([1, 2, 3, 1, 2])
+        >>> inverse_indices
+        tensor([0, 0, 1, 1, 2, 3, 3, 4])
+
+        >>> output, counts = torch.unique_consecutive(x, return_counts=True)
+        >>> output
+        tensor([1, 2, 3, 1, 2])
+        >>> counts
+        tensor([2, 2, 1, 2, 1])
+    """
+    if not torch.jit.is_scripting():
+        if type(input) is not Tensor and has_torch_function((input,)):
+            return handle_torch_function(
+                unique_consecutive, (input,), input, return_inverse=return_inverse,
+                return_counts=return_counts, dim=dim)
+    output, inverse_indices, counts = _VF.unique_consecutive(
+        input, return_inverse=return_inverse, return_counts=return_counts, dim=dim)
+    return output, inverse_indices, counts
+
+
 def _return_counts(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
     # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
 
@@ -579,70 +640,66 @@ unique = boolean_dispatch(
 unique.__doc__ = _unique_impl.__doc__
 
 
-def unique_consecutive(input, return_inverse=False, return_counts=False, dim=None):
-    r"""Eliminates all but the first element from every consecutive group of equivalent elements.
+def _consecutive_return_counts(input, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
 
-    .. note:: This function is different from :func:`torch.unique` in the sense that this function
-        only eliminates consecutive duplicate values. This semantics is similar to `std::unique`
-        in C++.
-
-    Arguments:
-        input (Tensor): the input tensor
-        return_inverse (bool): Whether to also return the indices for where
-            elements in the original input ended up in the returned unique list.
-        return_counts (bool): Whether to also return the counts for each unique
-            element.
-        dim (int): the dimension to apply unique. If ``None``, the unique of the
-            flattened input is returned. default: ``None``
-
-    Returns:
-        (Tensor, Tensor (optional), Tensor (optional)): A tensor or a tuple of tensors containing
-
-            - **output** (*Tensor*): the output list of unique scalar elements.
-            - **inverse_indices** (*Tensor*): (optional) if
-              :attr:`return_inverse` is True, there will be an additional
-              returned tensor (same shape as input) representing the indices
-              for where elements in the original input map to in the output;
-              otherwise, this function will only return a single tensor.
-            - **counts** (*Tensor*): (optional) if
-              :attr:`return_counts` is True, there will be an additional
-              returned tensor (same shape as output or output.size(dim),
-              if dim was specified) representing the number of occurrences
-              for each unique value or tensor.
-
-    Example::
-
-        >>> x = torch.tensor([1, 1, 2, 2, 3, 1, 1, 2])
-        >>> output = torch.unique_consecutive(x)
-        >>> output
-        tensor([1, 2, 3, 1, 2])
-
-        >>> output, inverse_indices = torch.unique_consecutive(x, return_inverse=True)
-        >>> output
-        tensor([1, 2, 3, 1, 2])
-        >>> inverse_indices
-        tensor([0, 0, 1, 1, 2, 3, 3, 4])
-
-        >>> output, counts = torch.unique_consecutive(x, return_counts=True)
-        >>> output
-        tensor([1, 2, 3, 1, 2])
-        >>> counts
-        tensor([2, 2, 1, 2, 1])
-    """
     if not torch.jit.is_scripting():
         if type(input) is not Tensor and has_torch_function((input,)):
-            return handle_torch_function(
-                unique_consecutive, (input,), input, return_inverse=return_inverse,
-                return_counts=return_counts, dim=dim)
-    output, inverse_indices, counts = _VF.unique_consecutive(
-        input, return_inverse=return_inverse, return_counts=return_counts, dim=dim)
-    if return_inverse and return_counts:
-        return output, inverse_indices, counts
-    if return_inverse:
-        return output, inverse_indices
-    if return_counts:
-        return output, counts
+            return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
+
+    output, _, counts = _unique_consecutive_impl(input, return_inverse, return_counts, dim)
+    return output, counts
+
+def _consecutive_return_output(input, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, Optional[int]) -> Tensor
+
+    if not torch.jit.is_scripting():
+        if type(input) is not Tensor and has_torch_function((input,)):
+            return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
+
+    output, _, _ = _unique_consecutive_impl(input, return_inverse, return_counts, dim)
     return output
+
+def _consecutive_return_inverse(input, return_inverse=False, return_counts=False, dim=None):
+    # type: (Tensor, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+
+    if not torch.jit.is_scripting():
+        if type(input) is not Tensor and has_torch_function((input,)):
+            return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
+
+    output, inverse_indices, _ = _unique_consecutive_impl(input, return_inverse, return_counts, dim)
+    return output, inverse_indices
+
+_consecutive_return_inverse_false = boolean_dispatch(
+    arg_name='return_counts',
+    arg_index=1,
+    default=False,
+    if_true=_consecutive_return_counts,
+    if_false=_consecutive_return_output,
+    module_name=__name__,
+    func_name='unique_consecutive')
+
+_consecutive_return_inverse_true = boolean_dispatch(
+    arg_name='return_counts',
+    arg_index=1,
+    default=False,
+    if_true=_unique_consecutive_impl,
+    if_false=_consecutive_return_inverse,
+    module_name=__name__,
+    func_name='unique_consecutive')
+
+# The return type of unique depends on `return_inverse`, and `return_counts` so in order to
+# resolve the output type in TorchScript we need to statically know the value of both parameters
+
+unique_consecutive = boolean_dispatch(
+    arg_name='return_inverse',
+    arg_index=2,
+    default=False,
+    if_true=_consecutive_return_inverse_true,
+    if_false=_consecutive_return_inverse_false,
+    module_name=__name__,
+    func_name='unique_consecutive')
+unique_consecutive.__doc__ = _unique_consecutive_impl.__doc__
 
 
 def tensordot(a, b, dims=2):

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -81,6 +81,7 @@ _builtin_ops = [
     (torch._VF.cdist, "aten::cdist"),
     (torch._VF.norm, "aten::norm"),
     (torch._VF.unique_dim, "aten::unique_dim"),
+    (torch._VF.unique_consecutive, "aten::unique_consecutive"),
     (torch._VF.nuclear_norm, "aten::nuclear_norm"),
     (torch._VF.frobenius_norm, "aten::frobenius_norm"),
 ]
@@ -94,7 +95,7 @@ def _gen_torch_functional_registered_ops():
     # but we are currently only able to compile some of the functions. additionally,
     # some functions directly map to their aten:: implementations.
     # TODO: add support for more ops
-    ops = ["stft", "lu", "lu_unpack", "cdist", "norm", "unique"]
+    ops = ["stft", "lu", "lu_unpack", "cdist", "norm", "unique", "unique_consecutive"]
     return set(getattr(torch.functional, name) for name in ops)
 
 _functional_registered_ops = _gen_torch_functional_registered_ops()


### PR DESCRIPTION
Cherry pick of #39339

Summary:
A `unique_consecutive` version of https://github.com/pytorch/pytorch/pull/38156
Pull Request resolved: https://github.com/pytorch/pytorch/pull/39339

Differential Revision: D21823997

Pulled By: eellison

fbshipit-source-id: d14596a36ba36497e296da5a344e0376cef56f1b

