### PR TITLE
disable autograd while preparing Tensor for printing

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -263,8 +263,7 @@ def get_summarized_data(self):
     else:
         return torch.stack([get_summarized_data(x) for x in self])
 
-
-def _str(self):
+def _str_intern(self):
     prefix = 'tensor('
     indent = len(prefix)
     suffixes = []
@@ -347,3 +346,7 @@ def _str(self):
         suffixes.append('names={}'.format(self.names))
 
     return _add_suffixes(prefix + tensor_str, suffixes, indent, force_newline=self.is_sparse)
+
+def _str(self):
+    with torch.no_grad():
+        _str_intern(self)

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -349,4 +349,4 @@ def _str_intern(self):
 
 def _str(self):
     with torch.no_grad():
-        _str_intern(self)
+        return _str_intern(self)


### PR DESCRIPTION
Minor speed up when printing.
Also allows you to print Tensors that you cannot perform autograd ops on.