### PR TITLE
Make `_C` extension a thin C wrapper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -591,7 +591,6 @@ def configure_extension_build():
     else:
         extra_link_args = []
         extra_compile_args = [
-            '-std=c++14',
             '-Wall',
             '-Wextra',
             '-Wno-strict-overflow',
@@ -616,9 +615,9 @@ def configure_extension_build():
     library_dirs.append(lib_path)
 
     main_compile_args = []
-    main_libraries = ['shm', 'torch_python']
+    main_libraries = ['torch_python']
     main_link_args = []
-    main_sources = ["torch/csrc/stub.cpp"]
+    main_sources = ["torch/csrc/stub.c"]
 
     if cmake_cache_vars['USE_CUDA']:
         library_dirs.append(
@@ -659,7 +658,7 @@ def configure_extension_build():
     C = Extension("torch._C",
                   libraries=main_libraries,
                   sources=main_sources,
-                  language='c++',
+                  language='c',
                   extra_compile_args=main_compile_args + extra_compile_args,
                   include_dirs=[],
                   library_dirs=library_dirs,
@@ -673,7 +672,7 @@ def configure_extension_build():
         extensions.append(DL)
 
     # These extensions are built by cmake and copied manually in build_extensions()
-    # inside the build_ext implementaiton
+    # inside the build_ext implementation
     extensions.append(
         Extension(
             name=str('caffe2.python.caffe2_pybind11_state'),

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -613,6 +613,7 @@ static void LogAPIUsageOnceFromPython(const std::string& event) {
   }
 }
 
+extern "C"
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/torch/csrc/stub.c
+++ b/torch/csrc/stub.c
@@ -3,15 +3,15 @@
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-extern PyObject* initModule();
+extern PyObject* initModule(void);
 
 #if PY_MAJOR_VERSION == 2
-PyMODINIT_FUNC init_C()
+PyMODINIT_FUNC init_C(void)
 {
   initModule();
 }
 #else
-PyMODINIT_FUNC PyInit__C()
+PyMODINIT_FUNC PyInit__C(void)
 {
   return initModule();
 }


### PR DESCRIPTION
Summary:
It just depends on a single `torch_python` library.
C library does not depend on standard C++ library and as result it closes https://github.com/pytorch/pytorch/issues/36941
This is a cherry-pick of https://github.com/pytorch/pytorch/pull/39375 into release/1.5 branch

