### PR TITLE
Update uncompyle6 from 2.8.3 to 3.6.3

### DIFF
--- a/caffe2/contrib/nnpack/nnpack_ops_test.py
+++ b/caffe2/contrib/nnpack/nnpack_ops_test.py
@@ -175,7 +175,6 @@ class NNPackOpsTest(hu.HypothesisTestCase):
             atol=1e-4,
             rtol=1e-4)
 
-    @settings(timeout=3600)
     @unittest.skipIf(not os.environ.get("CAFFE2_BENCHMARK"), "Benchmark")
     @given(stride=st.integers(1, 1),
            pad=st.integers(0, 2),
@@ -213,7 +212,6 @@ class NNPackOpsTest(hu.HypothesisTestCase):
         print("Speedup for NNPACK: {:.2f}".format(
             times[""] / times["NNPACK"]))
 
-    @settings(timeout=3600)
     @unittest.skipIf(not os.environ.get("CAFFE2_BENCHMARK"), "Benchmark")
     @given(size=st.integers(30, 90),
            input_channels=st.sampled_from([3, 64, 256]),

--- a/caffe2/python/core_gradients_test.py
+++ b/caffe2/python/core_gradients_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from future.utils import bytes_to_native_str
-from hypothesis import given
+from hypothesis import given, settings
 import hypothesis.strategies as st
 import unittest
 
@@ -95,6 +95,7 @@ class TestGradientCalculation(test_util.TestCase):
                 del op.device_option.extra_info[:]
         self.assertEqual(operatorDefList1, operatorDefList2)
 
+    @settings(deadline=None)
     @given(device_option=st.sampled_from([
         None,
         core.DeviceOption(workspace.GpuDeviceType, 1)]))

--- a/caffe2/python/data_parallel_model_test.py
+++ b/caffe2/python/data_parallel_model_test.py
@@ -11,7 +11,7 @@ import tempfile
 import unittest
 import time
 from mock import Mock
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 import hypothesis.strategies as st
 
 from caffe2.proto import caffe2_pb2
@@ -579,6 +579,7 @@ class DataParallelModelTest(TestCase):
         _test_forward_pass(x, devices, device_type, scale, bias, epsilon)
         _test_backward_pass(x, devices, device_type, scale, tolerance)
 
+    @settings(deadline=None)
     @given(seed=st.integers(0, 65535), batch_size=st.integers(1, 20))
     def test_multi_device_bn_net_lvl_cpu(self, seed, batch_size):
         if batch_size % 2 == 1:

--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -74,7 +74,7 @@ def _test_binary(name, ref, filter_=None, gcs=hu.gcs,
                 elements=hu.elements_of_type(dtype, filter_=filter_))),
         out=st.sampled_from(('Y', 'X1', 'X2') if allow_inplace else ('Y',)),
         **gcs)
-    @settings(max_examples=3, timeout=100)
+    @settings(max_examples=3)
     def test_binary(self, inputs, out, gc, dc):
         op = core.CreateOperator(name, ["X1", "X2"], [out])
         X1, X2 = inputs
@@ -95,7 +95,7 @@ def _test_binary_broadcast(name, ref, filter_=None,
             elements=hu.elements_of_type(dtype, filter_=filter_))),
         in_place=(st.booleans() if allow_inplace else st.just(False)),
         **gcs)
-    @settings(max_examples=3, timeout=100)
+    @settings(max_examples=3)
     def test_binary_broadcast(self, inputs, in_place, gc, dc):
         op = core.CreateOperator(
             name, ["X1", "X2"], ["X1" if in_place else "Y"], broadcast=1)
@@ -456,7 +456,7 @@ class TestOperators(hu.HypothesisTestCase):
         self.assertReferenceChecks(gc, op, inputs, depth_concat_with_order)
 
     @given(X=hu.arrays(dims=[5, 2],
-                       elements=st.floats(min_value=1.0, max_value=10.0)),
+                       elements=hu.floats(min_value=1.0, max_value=10.0)),
            **hu.gcs_cpu_only)
     def test_last_n_windows(self, X, gc, dc):
         workspace.FeedBlob('input', X)
@@ -799,7 +799,7 @@ class TestOperators(hu.HypothesisTestCase):
         self.assertValidationChecks(gc, op, [input], unique_valid)
 
     @given(prediction=hu.arrays(dims=[10, 3],
-                                elements=st.floats(allow_nan=False,
+                                elements=hu.floats(allow_nan=False,
                                                    allow_infinity=False,
                                                    min_value=0,
                                                    max_value=1)),
@@ -844,7 +844,7 @@ class TestOperators(hu.HypothesisTestCase):
             reference=op_ref)
 
     @given(target_probabilities=hu.arrays(
-        dims=[10], elements=st.floats(allow_nan=False,
+        dims=[10], elements=hu.floats(allow_nan=False,
                                       allow_infinity=False,
                                       min_value=0.01,
                                       max_value=1)),
@@ -965,7 +965,7 @@ class TestOperators(hu.HypothesisTestCase):
             reference=op_ref)
 
     @given(prediction=hu.arrays(dims=[10, 3],
-                                elements=st.floats(allow_nan=False,
+                                elements=hu.floats(allow_nan=False,
                                                    allow_infinity=False,
                                                    min_value=0,
                                                    max_value=1)),
@@ -1080,7 +1080,7 @@ class TestOperators(hu.HypothesisTestCase):
             reference=lengths_to_weights)
 
     @given(input_tensor=hu.arrays(
-        dims=[10], elements=st.floats(allow_nan=False,
+        dims=[10], elements=hu.floats(allow_nan=False,
                                       allow_infinity=False)),
            **hu.gcs)
     def test_abs(self, input_tensor, gc, dc):
@@ -1100,7 +1100,7 @@ class TestOperators(hu.HypothesisTestCase):
             reference=abs_ref)
 
     @given(input_tensor=hu.arrays(
-        dims=[10], elements=st.floats(min_value=-10,
+        dims=[10], elements=hu.floats(min_value=-10,
                                       max_value=10)),
            **hu.gcs)
     def test_cos(self, input_tensor, gc, dc):
@@ -1120,7 +1120,7 @@ class TestOperators(hu.HypothesisTestCase):
             reference=cos_ref)
 
     @given(input_tensor=hu.arrays(
-        dims=[10], elements=st.floats(min_value=-10,
+        dims=[10], elements=hu.floats(min_value=-10,
                                       max_value=10)),
            **hu.gcs)
     def test_sin(self, input_tensor, gc, dc):
@@ -1140,7 +1140,7 @@ class TestOperators(hu.HypothesisTestCase):
             reference=sin_ref)
 
     @given(input_tensor=hu.arrays(
-        dims=[10], elements=st.floats(allow_nan=False,
+        dims=[10], elements=hu.floats(allow_nan=False,
                                       allow_infinity=False)),
            **hu.gcs)
     def test_exp(self, input_tensor, gc, dc):
@@ -1160,7 +1160,7 @@ class TestOperators(hu.HypothesisTestCase):
             reference=exp_ref)
 
     @given(input_tensor=hu.arrays(
-        dims=[10], elements=st.floats(min_value=1,
+        dims=[10], elements=hu.floats(min_value=1,
                                       max_value=10000)),
            **hu.gcs_cpu_only)
     def test_log(self, input_tensor, gc, dc):
@@ -1824,7 +1824,7 @@ class TestOperators(hu.HypothesisTestCase):
 
     @given(a=hu.tensor(),
            eps=st.floats(min_value=1e-4, max_value=1e-2),
-           a_grad=hu.tensor(elements=st.floats(min_value=0.01, max_value=0.99)),
+           a_grad=hu.tensor(elements=hu.floats(min_value=0.01, max_value=0.99)),
            eps_grad=st.floats(min_value=1e-4, max_value=1e-3),
            **hu.gcs)
     def test_logit(self, a, eps, a_grad, eps_grad, gc, dc):
@@ -1847,7 +1847,7 @@ class TestOperators(hu.HypothesisTestCase):
         self.assertGradientChecks(gc, op_grad, [a_grad], 0, [0],
                                   threshold=0.04, stepsize=2e-3)
 
-    @given(a=hu.tensor(elements=st.floats(allow_nan=True)),
+    @given(a=hu.tensor(elements=hu.floats(allow_nan=True)),
            value=st.floats(min_value=-10, max_value=10),
            **hu.gcs)
     def test_replace_nan(self, a, value, gc, dc):
@@ -2222,7 +2222,7 @@ class TestOperators(hu.HypothesisTestCase):
             np.testing.assert_array_equal(ws.blobs[blob].fetch(), arr)
 
     @given(inp=_dtypes().flatmap(lambda dt: _tensor_and_indices(
-        elements=st.floats(min_value=0, max_value=1), dtype=dt)),
+        elements=hu.floats(min_value=0, max_value=1) if dt is np.float32 else st.integers(min_value=-65535, max_value=65535), dtype=dt)),
         **hu.gcs)
     def test_sparse_to_dense(self, inp, gc, dc):
         first_dim, X, I = inp

--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -51,6 +51,7 @@ import logging
 import numpy as np
 import os
 import six
+import struct
 
 
 def is_sandcastle():
@@ -65,57 +66,63 @@ def is_travis():
     return 'TRAVIS' in os.environ
 
 
-#  "min_satisfying_examples" setting has been deprecated in hypythesis
+def to_float32(x):
+    return struct.unpack("f", struct.pack("f", float(x)))[0]
+
+#  "min_satisfying_examples" setting has been deprecated in hypothesis
 #  3.56.0 and removed in hypothesis 4.x
-if hypothesis.version.__version_info__ >= (3, 56, 0):
-    hypothesis.settings.register_profile(
-        "sandcastle",
-        hypothesis.settings(
-            derandomize=True,
-            suppress_health_check=[hypothesis.HealthCheck.too_slow],
-            database=None,
-            max_examples=100,
-            verbosity=hypothesis.Verbosity.verbose))
-    hypothesis.settings.register_profile(
-        "dev",
-        hypothesis.settings(
-            suppress_health_check=[hypothesis.HealthCheck.too_slow],
-            database=None,
-            max_examples=10,
-            verbosity=hypothesis.Verbosity.verbose))
-    hypothesis.settings.register_profile(
-        "debug",
-        hypothesis.settings(
-            suppress_health_check=[hypothesis.HealthCheck.too_slow],
-            database=None,
-            max_examples=1000,
-            verbosity=hypothesis.Verbosity.verbose))
-else:
-    hypothesis.settings.register_profile(
-        "sandcastle",
-        hypothesis.settings(
-            derandomize=True,
-            suppress_health_check=[hypothesis.HealthCheck.too_slow],
-            database=None,
-            max_examples=100,
-            min_satisfying_examples=1,
-            verbosity=hypothesis.Verbosity.verbose))
-    hypothesis.settings.register_profile(
-        "dev",
-        hypothesis.settings(
-            suppress_health_check=[hypothesis.HealthCheck.too_slow],
-            database=None,
-            max_examples=10,
-            min_satisfying_examples=1,
-            verbosity=hypothesis.Verbosity.verbose))
-    hypothesis.settings.register_profile(
-        "debug",
-        hypothesis.settings(
-            suppress_health_check=[hypothesis.HealthCheck.too_slow],
-            database=None,
-            max_examples=1000,
-            min_satisfying_examples=1,
-            verbosity=hypothesis.Verbosity.verbose))
+def settings(*args, **kwargs):
+    if 'min_satisfying_examples' in kwargs and hypothesis.version.__version_info__ >= (3, 56, 0):
+        kwargs.pop('min_satisfying_examples')
+
+    if 'deadline' in kwargs and hypothesis.version.__version_info__ < (3, 56, 0):
+        kwargs.pop('deadline')
+
+    return hypothesis.settings(*args, **kwargs)
+
+# This wrapper wraps around `st.floats` and 
+# sets width parameters to 32 if version is newer than 3.67.0
+def floats(*args, **kwargs):
+
+    width_supported = hypothesis.version.__version_info__ >= (3, 67, 0)
+    if 'width' in kwargs and not width_supported:
+        kwargs.pop('width')
+
+    if 'width' not in kwargs and width_supported:
+        kwargs['width'] = 32
+        if kwargs.get('min_value', None) is not None:
+            kwargs['min_value'] = to_float32(kwargs['min_value'])
+        if kwargs.get('max_value', None) is not None:
+            kwargs['max_value'] = to_float32(kwargs['max_value'])
+
+    return st.floats(*args, **kwargs)
+
+
+hypothesis.settings.register_profile(
+    "sandcastle",
+    settings(
+        derandomize=True,
+        suppress_health_check=[hypothesis.HealthCheck.too_slow],
+        database=None,
+        deadline=None,
+        max_examples=100,
+        verbosity=hypothesis.Verbosity.verbose))
+hypothesis.settings.register_profile(
+    "dev",
+    settings(
+        suppress_health_check=[hypothesis.HealthCheck.too_slow],
+        database=None,
+        deadline=None,
+        max_examples=10,
+        verbosity=hypothesis.Verbosity.verbose))
+hypothesis.settings.register_profile(
+    "debug",
+    settings(
+        suppress_health_check=[hypothesis.HealthCheck.too_slow],
+        database=None,
+        deadline=None,
+        max_examples=1000,
+        verbosity=hypothesis.Verbosity.verbose))
 
 hypothesis.settings.load_profile(
     'sandcastle' if is_sandcastle() else os.getenv('CAFFE2_HYPOTHESIS_PROFILE',
@@ -129,8 +136,12 @@ def dims(min_value=1, max_value=5):
 
 def elements_of_type(dtype=np.float32, filter_=None):
     elems = None
-    if dtype in (np.float16, np.float32, np.float64):
-        elems = st.floats(min_value=-1.0, max_value=1.0)
+    if dtype is np.float16:
+        elems = floats(min_value=-1.0, max_value=1.0, width=16)
+    elif dtype is np.float32:
+        elems = floats(min_value=-1.0, max_value=1.0, width=32)
+    elif dtype is np.float64:
+        elems = floats(min_value=-1.0, max_value=1.0, width=64)
     elif dtype is np.int32:
         elems = st.integers(min_value=0, max_value=2 ** 31 - 1)
     elif dtype is np.int64:

--- a/caffe2/python/ideep/adam_op_test.py
+++ b/caffe2/python/ideep/adam_op_test.py
@@ -16,13 +16,13 @@ import caffe2.python.ideep_test_util as mu
 class TestAdamOps(hu.HypothesisTestCase):
     @given(inputs=hu.tensors(n=4),
            ITER=st.integers(min_value=0, max_value=10000),
-           LR=st.floats(min_value=0.01, max_value=0.99,
+           LR=hu.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
-           beta1=st.floats(min_value=0.01, max_value=0.99,
+           beta1=hu.floats(min_value=0.01, max_value=0.99,
                            allow_nan=False, allow_infinity=False),
-           beta2=st.floats(min_value=0.01, max_value=0.99,
+           beta2=hu.floats(min_value=0.01, max_value=0.99,
                            allow_nan=False, allow_infinity=False),
-           epsilon=st.floats(min_value=0.01, max_value=0.99,
+           epsilon=hu.floats(min_value=0.01, max_value=0.99,
                              allow_nan=False, allow_infinity=False),
            **mu.gcs)
     def test_adam(self, inputs, ITER, LR, beta1, beta2, epsilon, gc, dc):
@@ -47,13 +47,13 @@ class TestAdamOps(hu.HypothesisTestCase):
 
     @given(inputs=hu.tensors(n=4),
            ITER=st.integers(min_value=0, max_value=10000),
-           LR=st.floats(min_value=0.01, max_value=0.99,
+           LR=hu.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
-           beta1=st.floats(min_value=0.01, max_value=0.99,
+           beta1=hu.floats(min_value=0.01, max_value=0.99,
                            allow_nan=False, allow_infinity=False),
-           beta2=st.floats(min_value=0.01, max_value=0.99,
+           beta2=hu.floats(min_value=0.01, max_value=0.99,
                            allow_nan=False, allow_infinity=False),
-           epsilon=st.floats(min_value=0.01, max_value=0.99,
+           epsilon=hu.floats(min_value=0.01, max_value=0.99,
                              allow_nan=False, allow_infinity=False),
            **mu.gcs)
     def test_adam_output_grad(self, inputs, ITER, LR, beta1, beta2, epsilon, gc, dc):

--- a/caffe2/python/ideep/conv_transpose_test.py
+++ b/caffe2/python/ideep/conv_transpose_test.py
@@ -26,7 +26,7 @@ class ConvTransposeTest(hu.HypothesisTestCase):
            training_mode=st.booleans(),
            compute_dX=st.booleans(),
            **mu.gcs)
-    @settings(max_examples=2, timeout=100)
+    @settings(max_examples=2)
     def test_convolution_transpose_gradients(self, stride, pad, kernel, adj,
                                              size, input_channels,
                                              output_channels, batch_size,

--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -38,7 +38,7 @@ class MemongerTest(hu.HypothesisTestCase):
            batch_size=st.integers(min_value=1, max_value=10),
            do=st.sampled_from(hu.device_options),
            algo=st.sampled_from(memonger.AssignmentAlgorithm))
-    @settings(max_examples=5, timeout=120)
+    @settings(max_examples=5)
     def test_simple_memonger(self, input_dim, output_dim, batch_size, do, algo):
         m = model_helper.ModelHelper()
         fc1 = brew.fc(m, "data", "fc1", dim_in=input_dim, dim_out=output_dim)
@@ -91,7 +91,7 @@ class MemongerTest(hu.HypothesisTestCase):
            output_dim=st.integers(min_value=1, max_value=10),
            batch_size=st.integers(min_value=1, max_value=10),
            do=st.sampled_from(hu.device_options))
-    @settings(max_examples=5, timeout=120)
+    @settings(max_examples=5)
     def test_fast_memonger(self, input_dim, output_dim, batch_size, do):
         m = model_helper.ModelHelper()
         fc1 = brew.fc(m, "data", "fc1", dim_in=input_dim, dim_out=output_dim)

--- a/caffe2/python/mkl/mkl_pool_op_test.py
+++ b/caffe2/python/mkl/mkl_pool_op_test.py
@@ -23,7 +23,7 @@ class MKLPoolTest(hu.HypothesisTestCase):
            batch_size=st.integers(1, 3),
            method=st.sampled_from(["MaxPool", "AveragePool"]),
            **mu.gcs)
-    @settings(max_examples=2, timeout=100)
+    @settings(max_examples=2)
     def test_mkl_pooling(self, stride, pad, kernel, size,
                          input_channels, batch_size,
                          method, gc, dc):

--- a/caffe2/python/models/resnet_test.py
+++ b/caffe2/python/models/resnet_test.py
@@ -14,7 +14,7 @@ import caffe2.python.models.imagenet_trainer_test_utils as utils
 class ResnetMemongerTest(hu.HypothesisTestCase):
 
     @given(with_shapes=st.booleans(), **hu.gcs_cpu_only)
-    @settings(max_examples=2, timeout=120)
+    @settings(max_examples=2)
     def test_resnet_shared_grads(self, with_shapes, gc, dc):
         results = utils.test_shared_grads(
             with_shapes,

--- a/caffe2/python/models/shufflenet_test.py
+++ b/caffe2/python/models/shufflenet_test.py
@@ -14,7 +14,7 @@ import caffe2.python.models.imagenet_trainer_test_utils as utils
 
 class ShufflenetMemongerTest(hu.HypothesisTestCase):
     @given(with_shapes=st.booleans(), **hu.gcs_cpu_only)
-    @settings(max_examples=2, timeout=120)
+    @settings(max_examples=2)
     def test_shufflenet_shared_grads(self, with_shapes, gc, dc):
         results = utils.test_shared_grads(
             with_shapes,

--- a/caffe2/python/operator_test/activation_ops_test.py
+++ b/caffe2/python/operator_test/activation_ops_test.py
@@ -97,7 +97,7 @@ class TestActivations(serial.SerializedTestCase):
             output_to_grad="X" if in_place else "Y",
             grad_reference=relu_grad_ref)
 
-    @serial.given(X=hu.tensor(elements=st.floats(-3.0, 3.0)),
+    @serial.given(X=hu.tensor(elements=hu.floats(-3.0, 3.0)),
                   n=st.floats(min_value=0.5, max_value=2.0),
                   in_place=st.booleans(), **hu.gcs)
     def test_relu_n(self, X, n, in_place, gc, dc):

--- a/caffe2/python/operator_test/apmeter_test.py
+++ b/caffe2/python/operator_test/apmeter_test.py
@@ -26,7 +26,7 @@ def calculate_ap(predictions, labels):
 
 class TestAPMeterOps(hu.HypothesisTestCase):
     @given(predictions=hu.arrays(dims=[10, 3],
-           elements=st.floats(allow_nan=False,
+           elements=hu.floats(allow_nan=False,
                               allow_infinity=False,
                               min_value=0.1,
                               max_value=1)),
@@ -54,7 +54,7 @@ class TestAPMeterOps(hu.HypothesisTestCase):
             reference=op_ref)
 
     @given(predictions=hu.arrays(dims=[10, 3],
-           elements=st.floats(allow_nan=False,
+           elements=hu.floats(allow_nan=False,
                               allow_infinity=False,
                               min_value=0.1,
                               max_value=1)),

--- a/caffe2/python/operator_test/batch_bucketize_op_test.py
+++ b/caffe2/python/operator_test/batch_bucketize_op_test.py
@@ -42,7 +42,7 @@ class TestBatchBucketize(serial.SerializedTestCase):
     @given(
         x=hu.tensor(
             min_dim=2, max_dim=2, dtype=np.float32,
-            elements=st.floats(min_value=0, max_value=5),
+            elements=hu.floats(min_value=0, max_value=5),
             min_value=5),
         seed=st.integers(min_value=2, max_value=1000),
         **hu.gcs_cpu_only)

--- a/caffe2/python/operator_test/boolean_mask_test.py
+++ b/caffe2/python/operator_test/boolean_mask_test.py
@@ -14,7 +14,7 @@ import numpy as np
 class TestBooleanMaskOp(serial.SerializedTestCase):
     @given(x=hu.tensor1d(min_len=1,
                          max_len=100,
-                         elements=st.floats(min_value=0.5, max_value=1.0)),
+                         elements=hu.floats(min_value=0.5, max_value=1.0)),
            **hu.gcs_cpu_only)
     def test_boolean_mask_gradient(self, x, gc, dc):
         op = core.CreateOperator("BooleanMask",
@@ -28,7 +28,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor1d(min_len=1,
                          max_len=5,
-                         elements=st.floats(min_value=0.5, max_value=1.0)),
+                         elements=hu.floats(min_value=0.5, max_value=1.0)),
            **hu.gcs)
     def test_boolean_mask(self, x, gc, dc):
         op = core.CreateOperator("BooleanMask",
@@ -43,7 +43,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor1d(min_len=1,
                          max_len=5,
-                         elements=st.floats(min_value=0.5, max_value=1.0)),
+                         elements=hu.floats(min_value=0.5, max_value=1.0)),
            **hu.gcs)
     def test_boolean_mask_indices(self, x, gc, dc):
         op = core.CreateOperator("BooleanMask",
@@ -68,7 +68,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor(min_dim=2,
                        max_dim=5,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
+                       elements=hu.floats(min_value=0.5, max_value=1.0)),
            dtype=st.sampled_from([np.float32, np.float16]),
            **hu.gcs)
     def test_sequence_mask_with_lengths(self, x, dtype, gc, dc):
@@ -101,7 +101,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor(min_dim=2,
                        max_dim=5,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
+                       elements=hu.floats(min_value=0.5, max_value=1.0)),
            dtype=st.sampled_from([np.float32, np.float16]),
            **hu.gcs)
     def test_sequence_mask_with_window(self, x, dtype, gc, dc):
@@ -142,7 +142,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor(min_dim=2,
                        max_dim=5,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
+                       elements=hu.floats(min_value=0.5, max_value=1.0)),
            mode=st.sampled_from(['upper', 'lower', 'upperdiag', 'lowerdiag']),
            dtype=st.sampled_from([np.float32, np.float16]),
            **hu.gcs)
@@ -194,7 +194,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor(min_dim=2,
                        max_dim=5,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
+                       elements=hu.floats(min_value=0.5, max_value=1.0)),
            dtype=st.sampled_from([np.float32, np.float16]),
            **hu.gcs)
     def test_sequence_mask_batching_lengths(self, x, dtype, gc, dc):
@@ -246,7 +246,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor(min_dim=4,
                        max_dim=4,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
+                       elements=hu.floats(min_value=0.5, max_value=1.0)),
            dtype=st.sampled_from([np.float32, np.float16]),
            **hu.gcs)
     def test_sequence_mask_batching_window(self, x, dtype, gc, dc):
@@ -300,7 +300,7 @@ class TestBooleanMaskOp(serial.SerializedTestCase):
 
     @given(x=hu.tensor(min_dim=3,
                        max_dim=5,
-                       elements=st.floats(min_value=0.5, max_value=1.0)),
+                       elements=hu.floats(min_value=0.5, max_value=1.0)),
            mode=st.sampled_from(['upper', 'lower', 'upperdiag', 'lowerdiag']),
            dtype=st.sampled_from([np.float32, np.float16]),
            **hu.gcs)

--- a/caffe2/python/operator_test/bucketize_op_test.py
+++ b/caffe2/python/operator_test/bucketize_op_test.py
@@ -13,7 +13,7 @@ class TestBucketizeOp(hu.HypothesisTestCase):
     @given(
         x=hu.tensor(
             min_dim=1, max_dim=2, dtype=np.float32,
-            elements=st.floats(min_value=-5, max_value=5)),
+            elements=hu.floats(min_value=-5, max_value=5)),
         **hu.gcs)
     def test_bucketize_op(self, x, gc, dc):
         length = np.random.randint(low=1, high=5)

--- a/caffe2/python/operator_test/conv_transpose_test.py
+++ b/caffe2/python/operator_test/conv_transpose_test.py
@@ -241,7 +241,7 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
            use_bias=st.booleans(),
            compute_dX=st.booleans(),
            **hu.gcs)
-    @settings(max_examples=2, timeout=100)
+    @settings(max_examples=2)
     def test_convolution_transpose_gradients(self, stride, pad, kernel, adj,
                                              size, input_channels,
                                              output_channels, batch_size,
@@ -309,7 +309,7 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
            use_bias=st.booleans(),
            compute_dX=st.booleans(),
            **hu.gcs)
-    @settings(max_examples=2, timeout=100)
+    @settings(max_examples=2)
     def test_convolution_transpose_separate_stride_pad_adj_gradient(
             self, stride_h, stride_w, pad_t, pad_l, pad_b, pad_r, kernel,
             adj_h, adj_w, size, input_channels, output_channels, batch_size,

--- a/caffe2/python/operator_test/elementwise_ops_test.py
+++ b/caffe2/python/operator_test/elementwise_ops_test.py
@@ -142,7 +142,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
 
     @given(
         X=hu.tensor(
-            elements=st.floats(0.1, 10),
+            elements=hu.floats(0.1, 10),
             # allow empty tensor
             min_value=0),
         inplace=st.booleans(),
@@ -196,7 +196,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
                 ensure_outputs_are_inferred=True,
             )
 
-    @given(X=hu.tensor(elements=st.floats(0.1, 10.0), dtype=np.float32),
+    @given(X=hu.tensor(elements=hu.floats(0.1, 10.0), dtype=np.float32),
            inplace=st.booleans(), **hu.gcs)
     def test_rsqrt(self, X, inplace, gc, dc):
         op = core.CreateOperator(
@@ -267,7 +267,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
             ensure_outputs_are_inferred=True,
         )
 
-    @given(X=hu.tensor(elements=st.floats(1.0, 10.0), dtype=np.float32),
+    @given(X=hu.tensor(elements=hu.floats(1.0, 10.0), dtype=np.float32),
            in_place=st.booleans(), **hu.gcs)
     def test_cbrt_grad(self, X, in_place, gc, dc):
         op = core.CreateOperator(
@@ -689,7 +689,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         self._test_bitwise_binary_op(
             "BitwiseXor", np.bitwise_xor, n, m, k, t, gc, dc)
 
-    @given(X=hu.tensor(elements=st.floats(0.5, 2), dtype=np.float32),
+    @given(X=hu.tensor(elements=hu.floats(0.5, 2), dtype=np.float32),
            inplace=st.booleans(), **hu.gcs)
     def test_reciprocal(self, X, inplace, gc, dc):
         def reciprocal_op(X):

--- a/caffe2/python/operator_test/enforce_finite_op_test.py
+++ b/caffe2/python/operator_test/enforce_finite_op_test.py
@@ -16,7 +16,7 @@ class TestEnforceFinite(hu.HypothesisTestCase):
         X=hu.tensor(
             # allow empty
             min_value=0,
-            elements=st.floats(allow_nan=True, allow_infinity=True),
+            elements=hu.floats(allow_nan=True, allow_infinity=True),
         ),
         **hu.gcs
     )
@@ -40,7 +40,7 @@ class TestEnforceFinite(hu.HypothesisTestCase):
 
     @given(
         X=hu.tensor(
-            elements=st.floats(min_value=0, max_value=10, allow_nan=False, allow_infinity=False),
+            elements=hu.floats(min_value=0, max_value=10, allow_nan=False, allow_infinity=False),
         ),
         **hu.gcs
     )

--- a/caffe2/python/operator_test/ensure_clipped_test.py
+++ b/caffe2/python/operator_test/ensure_clipped_test.py
@@ -10,7 +10,7 @@ from hypothesis import given
 
 class TestEnsureClipped(hu.HypothesisTestCase):
     @given(
-        X=hu.arrays(dims=[5, 10], elements=st.floats(min_value=-1.0, max_value=1.0)),
+        X=hu.arrays(dims=[5, 10], elements=hu.floats(min_value=-1.0, max_value=1.0)),
         in_place=st.booleans(),
         sparse=st.booleans(),
         indices=hu.arrays(dims=[5], elements=st.booleans()),

--- a/caffe2/python/operator_test/erf_op_test.py
+++ b/caffe2/python/operator_test/erf_op_test.py
@@ -17,7 +17,7 @@ import unittest
 
 class TestErfOp(serial.SerializedTestCase):
     @serial.given(
-        X=hu.tensor(elements=st.floats(min_value=-0.7, max_value=0.7)),
+        X=hu.tensor(elements=hu.floats(min_value=-0.7, max_value=0.7)),
         **hu.gcs)
     def test_erf(self, X, gc, dc):
         op = core.CreateOperator('Erf', ["X"], ["Y"])

--- a/caffe2/python/operator_test/gather_ops_test.py
+++ b/caffe2/python/operator_test/gather_ops_test.py
@@ -177,7 +177,7 @@ def _inputs(draw):
         draw(hnp.arrays(
             np.float32,
             (batch_size, rows_num, block_size),
-            elements=st.floats(-10.0, 10.0),
+            elements=hu.floats(-10.0, 10.0),
         )),
         draw(hnp.arrays(
             np.int32,

--- a/caffe2/python/operator_test/group_conv_test.py
+++ b/caffe2/python/operator_test/group_conv_test.py
@@ -30,7 +30,7 @@ class TestGroupConvolution(hu.HypothesisTestCase):
            engine=st.sampled_from(["", "CUDNN", "EIGEN"]),
            use_bias=st.booleans(),
            **hu.gcs)
-    @settings(max_examples=2, timeout=100)
+    @settings(max_examples=2)
     def test_group_convolution(
             self, stride, pad, kernel, size, group,
             input_channels_per_group, output_channels_per_group, batch_size,

--- a/caffe2/python/operator_test/mkl_conv_op_test.py
+++ b/caffe2/python/operator_test/mkl_conv_op_test.py
@@ -23,7 +23,7 @@ class MKLConvTest(hu.HypothesisTestCase):
            output_channels=st.integers(1, 3),
            batch_size=st.integers(1, 3),
            **mu.gcs)
-    @settings(max_examples=2, timeout=100)
+    @settings(max_examples=2)
     def test_mkl_convolution(self, stride, pad, kernel, size,
                              input_channels, output_channels,
                              batch_size, gc, dc):

--- a/caffe2/python/operator_test/normalize_op_test.py
+++ b/caffe2/python/operator_test/normalize_op_test.py
@@ -15,7 +15,7 @@ import copy
 class TestNormalizeOp(hu.HypothesisTestCase):
     @given(
         X=hu.tensor(
-            min_dim=1, max_dim=5, elements=st.floats(min_value=0.5, max_value=1.0)
+            min_dim=1, max_dim=5, elements=hu.floats(min_value=0.5, max_value=1.0)
         ),
         **hu.gcs
     )
@@ -37,7 +37,7 @@ class TestNormalizeOp(hu.HypothesisTestCase):
 
     @given(
         X=hu.tensor(
-            min_dim=1, max_dim=5, elements=st.floats(min_value=0.5, max_value=1.0)
+            min_dim=1, max_dim=5, elements=hu.floats(min_value=0.5, max_value=1.0)
         ),
         **hu.gcs
     )

--- a/caffe2/python/operator_test/pooling_test.py
+++ b/caffe2/python/operator_test/pooling_test.py
@@ -218,7 +218,7 @@ class TestPooling(hu.HypothesisTestCase):
            engine=st.sampled_from(["", "CUDNN"]),
            op_type=st.sampled_from(["AveragePool", "AveragePool2D"]),
            **hu.gcs)
-    @settings(max_examples=3, timeout=10)
+    @settings(max_examples=3)
     def test_global_avg_pool_nchw(self, op_type, sz, batch_size, engine, gc, dc):
         ''' Special test to stress the fast path of NCHW average pool '''
         op = core.CreateOperator(
@@ -242,7 +242,7 @@ class TestPooling(hu.HypothesisTestCase):
            engine=st.sampled_from(["", "CUDNN"]),
            op_type=st.sampled_from(["MaxPool", "MaxPool2D"]),
            **hu.gcs)
-    @settings(max_examples=3, timeout=10)
+    @settings(max_examples=3)
     def test_global_max_pool_nchw(self, op_type, sz,
                                   batch_size, engine, gc, dc):
         ''' Special test to stress the fast path of NCHW max pool '''

--- a/caffe2/python/operator_test/rank_loss_operator_test.py
+++ b/caffe2/python/operator_test/rank_loss_operator_test.py
@@ -13,7 +13,7 @@ import numpy as np
 
 class TestPairWiseLossOps(serial.SerializedTestCase):
     @given(X=hu.arrays(dims=[2, 1],
-                       elements=st.floats(min_value=0.0, max_value=10.0)),
+                       elements=hu.floats(min_value=0.0, max_value=10.0)),
            label=hu.arrays(dims=[2, 1],
                            elements=st.integers(min_value=0, max_value=1),
                            dtype=np.float32),
@@ -48,12 +48,12 @@ class TestPairWiseLossOps(serial.SerializedTestCase):
         self.assertAlmostEqual(output, new_output)
 
     @given(X=hu.arrays(dims=[2, 1],
-                       elements=st.floats(min_value=0.0, max_value=10.0)),
+                       elements=hu.floats(min_value=0.0, max_value=10.0)),
            label=hu.arrays(dims=[2, 1],
                            elements=st.integers(min_value=0, max_value=1),
                            dtype=np.float32),
            dY=hu.arrays(dims=[1],
-                        elements=st.floats(min_value=1, max_value=10)),
+                        elements=hu.floats(min_value=1, max_value=10)),
            **hu.gcs_cpu_only)
     def test_pair_wise_loss_gradient(self, X, label, dY, gc, dc):
         workspace.FeedBlob('X', X)

--- a/caffe2/python/operator_test/rebatching_queue_test.py
+++ b/caffe2/python/operator_test/rebatching_queue_test.py
@@ -8,7 +8,7 @@ from caffe2.python.test_util import TestCase
 import numpy as np
 import numpy.testing as npt
 
-from hypothesis import given
+from hypothesis import given, settings
 import hypothesis.strategies as st
 
 import functools
@@ -25,7 +25,6 @@ def primefac(n):
     if n > 1:
         ret.append(n)
     return ret
-
 
 class TestReBatchingQueue(TestCase):
     def test_rebatching_queue_single_enqueue_dequeue(self):
@@ -165,6 +164,7 @@ class TestReBatchingQueue(TestCase):
                 workspace.FetchBlob(tensors[idx])[:5]
             )
 
+    @settings(deadline=None)
     @given(
         num_producers=st.integers(1, 5),
         num_consumers=st.integers(1, 5),

--- a/caffe2/python/operator_test/sequence_ops_test.py
+++ b/caffe2/python/operator_test/sequence_ops_test.py
@@ -210,7 +210,7 @@ class TestSequenceOps(serial.SerializedTestCase):
             reference=partial(_gather_padding_ref, start_pad_width, end_pad_width))
 
     @serial.given(data=hu.tensor(min_dim=3, max_dim=3, dtype=np.float32,
-                          elements=st.floats(min_value=-np.inf,
+                          elements=hu.floats(min_value=-np.inf,
                                              max_value=np.inf),
                           min_value=1, max_value=10),
                           **hu.gcs)
@@ -244,7 +244,7 @@ class TestSequenceOps(serial.SerializedTestCase):
             grad_reference=op_grad_ref)
 
     @serial.given(data=hu.tensor(min_dim=1, max_dim=3, dtype=np.float32,
-                          elements=st.floats(min_value=-np.inf,
+                          elements=hu.floats(min_value=-np.inf,
                                              max_value=np.inf),
                           min_value=10, max_value=10),
            indices=st.lists(st.integers(min_value=0, max_value=9),

--- a/caffe2/python/operator_test/square_root_divide_op_test.py
+++ b/caffe2/python/operator_test/square_root_divide_op_test.py
@@ -30,7 +30,7 @@ def _data_and_scale(
             hu.arrays([param_[0], param_[1]], dtype=dtype),
             hu.arrays(
                 [param_[0]], dtype=param_[2],
-                elements=(st.floats(0.0, 10000.0) if param_[2] in [np.float32]
+                elements=(hu.floats(0.0, 10000.0) if param_[2] in [np.float32]
                           else st.integers(0, 10000)),
             ),
         )

--- a/caffe2/python/operator_test/trigonometric_op_test.py
+++ b/caffe2/python/operator_test/trigonometric_op_test.py
@@ -15,25 +15,25 @@ import unittest
 
 class TestTrigonometricOp(serial.SerializedTestCase):
     @serial.given(
-        X=hu.tensor(elements=st.floats(min_value=-0.7, max_value=0.7)),
+        X=hu.tensor(elements=hu.floats(min_value=-0.7, max_value=0.7)),
         **hu.gcs)
     def test_acos(self, X, gc, dc):
         self.assertTrigonometricChecks("Acos", X, lambda x: (np.arccos(X),), gc, dc)
 
     @serial.given(
-        X=hu.tensor(elements=st.floats(min_value=-0.7, max_value=0.7)),
+        X=hu.tensor(elements=hu.floats(min_value=-0.7, max_value=0.7)),
         **hu.gcs)
     def test_asin(self, X, gc, dc):
         self.assertTrigonometricChecks("Asin", X, lambda x: (np.arcsin(X),), gc, dc)
 
     @serial.given(
-        X=hu.tensor(elements=st.floats(min_value=-100, max_value=100)),
+        X=hu.tensor(elements=hu.floats(min_value=-100, max_value=100)),
         **hu.gcs)
     def test_atan(self, X, gc, dc):
         self.assertTrigonometricChecks("Atan", X, lambda x: (np.arctan(X),), gc, dc)
 
     @serial.given(
-        X=hu.tensor(elements=st.floats(min_value=-0.5, max_value=0.5)),
+        X=hu.tensor(elements=hu.floats(min_value=-0.5, max_value=0.5)),
         **hu.gcs)
     def test_tan(self, X, gc, dc):
         self.assertTrigonometricChecks("Tan", X, lambda x: (np.tan(X),), gc, dc)

--- a/caffe2/python/test/executor_test_util.py
+++ b/caffe2/python/test/executor_test_util.py
@@ -18,14 +18,12 @@ from hypothesis import settings
 
 
 CI_MAX_EXAMPLES = 2
-CI_TIMEOUT = 600
 
 
 def executor_test_settings(func):
     if hu.is_sandcastle() or hu.is_travis():
         return settings(
             max_examples=CI_MAX_EXAMPLES,
-            timeout=CI_TIMEOUT
         )(func)
     else:
         return func
@@ -65,7 +63,7 @@ def executor_test_model_names():
     if hu.is_sandcastle() or hu.is_travis():
         return ["MLP"]
     else:
-        return conv_model_generators().keys()
+        return sorted(conv_model_generators().keys())
 
 
 def build_conv_model(model_name, batch_size):


### PR DESCRIPTION
Summary:
`buck run //python/wheel:add uncompyle6`
Also, update hypothesis to hypothesis-5.x and modify test cases accordingly
Most notable, introduce `floats()` strategy in `caffe2/python/hypothesis_test_util.py` that sets default width to float32 and amends upper/lower bounds accordingly.

Test Plan: `buck test //python/wheel/uncompyle6:'

Reviewed By: seemethere

Differential Revision: D21580553

