### PR TITLE
Selective build on Training, query based.

### DIFF
--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -27,7 +27,7 @@ import os
 import yaml
 import re
 from collections import defaultdict
-from .utils import YamlLoader, split_name_params
+from .utils import YamlLoader, split_name_params, signature_without_args
 
 # See NOTE [ Autograd View Variables ] in variable.h for details.
 # If you update list VIEW_FUNCTIONS or RETURNS_VIEWS_OF_INPUT,
@@ -188,13 +188,23 @@ def load_deprecated_signatures(aten_decls, deprecated_path):
     return declarations
 
 
-def gen_autograd(aten_path, out, autograd_dir, disable_autograd=False):
-    aten_decls = load_aten_declarations(aten_path)
+def gen_autograd(aten_path, out, autograd_dir, disable_autograd=False, selected_op_list=None):
+    full_aten_decls = load_aten_declarations(aten_path)
+    def filter_decls(aten_decls, selected_op_list):
+        if selected_op_list is None:
+            return aten_decls
+        return [decl for decl in aten_decls if signature_without_args(decl) in selected_op_list]
+
+
+    aten_decls = filter_decls(full_aten_decls, selected_op_list)
+
+
+
 
     # Parse and load derivatives.yaml
     from .load_derivatives import load_derivatives
     autograd_functions = load_derivatives(
-        os.path.join(autograd_dir, 'derivatives.yaml'), aten_decls)
+        os.path.join(autograd_dir, 'derivatives.yaml'), full_aten_decls)
 
     template_path = os.path.join(autograd_dir, 'templates')
 

--- a/tools/autograd/utils.py
+++ b/tools/autograd/utils.py
@@ -73,3 +73,11 @@ def write(dirname, name, template, env):
 
 def is_tensor_method(declaration):
     return 'Tensor' in declaration['method_of']
+
+def is_out_variant(decl):
+    return decl['name'].endswith('_out')
+
+def signature_without_args(decl):
+    name = decl['name'] if not is_out_variant(decl) else decl['name'][:-4]
+    overload_name = '.' + decl['overload_name'] if not decl['overload_name'] == '' else ''
+    return 'aten::{}{}'.format(name, overload_name)

--- a/tools/jit/gen_unboxing_wrappers.py
+++ b/tools/jit/gen_unboxing_wrappers.py
@@ -20,10 +20,11 @@ torch/csrc/jit/generated/
 
 import argparse
 import re
+import yaml
 from itertools import groupby
 from ..autograd.gen_autograd import load_aten_declarations
 from ..autograd.gen_autograd import RETURNS_VIEWS_OF_INPUT
-from ..autograd.utils import CodeTemplate, write, is_out_variant, signature_without_args
+from ..autograd.utils import CodeTemplate, write, is_out_variant, signature_without_args, YamlLoader
 
 # JIT has a type system of
 # Scalar = int | float | bool # int is the largest int (int64_t),
@@ -272,12 +273,17 @@ def is_backward_op(decl):
 def argument_order(decl):
     return decl.get('jit_argument_order') or list(range(len(decl['arguments'])))
 
+def load_op_list(path):
+    with open(path, 'r') as f:
+        op_list = yaml.load(f, Loader=YamlLoader)
+    return op_list
 
 def gen_unboxing_wrappers(
     declarations,
     out,
     template_path,
     disable_autograd=False,
+    selected_op_list_path=None,
     selected_op_list=None,
     force_schema_registration=False,
 ):
@@ -464,6 +470,9 @@ def gen_unboxing_wrappers(
             reorder_out_args(decl)
 
     jit_decls.extend(additional_jit_decls)
+    if not selected_op_list:
+        selected_op_list = []
+    selected_op_list += load_op_list(selected_op_list_path) if selected_op_list_path else []
     jit_decls = filter_decls(jit_decls, disable_autograd, selected_op_list, force_schema_registration)
 
     # generation is deterministic

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -1,10 +1,17 @@
 import argparse
 import os
 import sys
+import yaml
+from ..autograd.utils import YamlLoader
 
 source_files = {'.py', '.cpp', '.h'}
 
 DECLARATIONS_PATH = 'torch/share/ATen/Declarations.yaml'
+
+def load_op_list(path):
+    with open(path, 'r') as f:
+        op_list = yaml.load(f, Loader=YamlLoader)
+    return op_list
 
 
 # TODO: This is a little inaccurate, because it will also pick
@@ -28,6 +35,9 @@ def generate_code(ninja_global=None,
                   selected_op_list_path=None,
                   selected_op_list=None,
                   force_schema_registration=False):
+    if not selected_op_list:
+        selected_op_list = []
+    selected_op_list += load_op_list(selected_op_list_path) if selected_op_list_path else []
     # cwrap depends on pyyaml, so we can't import it earlier
     root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     sys.path.insert(0, root)
@@ -50,19 +60,18 @@ def generate_code(ninja_global=None,
         gen_autograd_python(declarations_path or DECLARATIONS_PATH, autograd_gen_dir, autograd_dir)
 
     if subset == "libtorch" or not subset:
-        # TODO: add selected op mechanism in augotrad to save learning size
         gen_autograd(
             declarations_path or DECLARATIONS_PATH,
             autograd_gen_dir,
             autograd_dir,
             disable_autograd=disable_autograd,
+            selected_op_list=selected_op_list,
         )
         gen_unboxing_wrappers(
             declarations_path or DECLARATIONS_PATH,
             jit_gen_dir,
             tools_jit_templates,
             disable_autograd=disable_autograd,
-            selected_op_list_path=selected_op_list_path,
             selected_op_list=selected_op_list,
             force_schema_registration=force_schema_registration)
 

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -1,17 +1,10 @@
 import argparse
 import os
 import sys
-import yaml
-from ..autograd.utils import YamlLoader
 
 source_files = {'.py', '.cpp', '.h'}
 
 DECLARATIONS_PATH = 'torch/share/ATen/Declarations.yaml'
-
-def load_op_list(path):
-    with open(path, 'r') as f:
-        op_list = yaml.load(f, Loader=YamlLoader)
-    return op_list
 
 
 # TODO: This is a little inaccurate, because it will also pick
@@ -35,9 +28,6 @@ def generate_code(ninja_global=None,
                   selected_op_list_path=None,
                   selected_op_list=None,
                   force_schema_registration=False):
-    if not selected_op_list:
-        selected_op_list = []
-    selected_op_list += load_op_list(selected_op_list_path) if selected_op_list_path else []
     # cwrap depends on pyyaml, so we can't import it earlier
     root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     sys.path.insert(0, root)
@@ -65,13 +55,13 @@ def generate_code(ninja_global=None,
             autograd_gen_dir,
             autograd_dir,
             disable_autograd=disable_autograd,
-            selected_op_list=selected_op_list,
         )
         gen_unboxing_wrappers(
             declarations_path or DECLARATIONS_PATH,
             jit_gen_dir,
             tools_jit_templates,
             disable_autograd=disable_autograd,
+            selected_op_list_path=selected_op_list_path,
             selected_op_list=selected_op_list,
             force_schema_registration=force_schema_registration)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39452 Selective build on Training, query based.**

Selective build works on training.
* VariableType_?.cpp are now selectively generated based on the operator list.
* Add a flag in pt_operator_library, "train". If it's True, an extra flag of "pt_train_operator_library" will be added to the labels. A query for "pt_train_operator_library" will be done to aggregate the training operators. With this flag we limit the generated VariableType to used training operators only, to conserve the code size. The models for inference only have train = False by default.
* For testing purpose, caffe2/fb/pytorch_trainer is created. It's based on full jit but the operators are selectively built.
* smartkeyboard_debug_model is used for test. Since the static code analysis is not applied for VariableType yet, the operators are manually added based on debugging error messages.
* At build stage, make selective build optional for training code-gen library.
The reason is that to make fb4a built, the generated VariableType.cpp needs to depend on torch_mobile_train. Torch_mobile_train is not needed for apps with inference only. In those cases training can be turned off to remove the dependency on torch_mobile_train to save size. It can also be used as a switch to check size regression introduced by training.

Differential Revision: [D21459302](https://our.internmc.facebook.com/intern/diff/D21459302/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D21459302/)!