### PR TITLE
Remove unused exception handling

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -361,23 +361,13 @@ void RequestCallbackImpl::processRpc(
 
       auto& pythonRpcHandler = PythonRpcHandler::getInstance();
       IValue py_ivalue;
-      try {
-        {
-          py::gil_scoped_acquire acquire;
-          py_ivalue = jit::toIValue(
-              pythonRpcHandler.runPythonUdf(std::move(uprc).movePythonUdf()),
-              PyObjectType::get());
-        }
-        ownerRRef->setValue(std::move(py_ivalue));
-      } catch (py::error_already_set& e) {
-        // py::error_already_set requires GIL to destruct, take special care.
-        ownerRRef->setError(e.what());
+      {
         py::gil_scoped_acquire acquire;
-        e.restore();
-        PyErr_Clear();
-      } catch (std::exception& e) {
-        ownerRRef->setError(e.what());
+        py_ivalue = jit::toIValue(
+            pythonRpcHandler.runPythonUdf(std::move(uprc).movePythonUdf()),
+            PyObjectType::get());
       }
+      ownerRRef->setValue(std::move(py_ivalue));
 
       if (rrefId != forkId) {
         // Caller is a user and callee is the owner, add fork


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39486 Add @rpc.functions.async_execution for rpc.remote
* #39485 Make @rpc.functions.async_execution processing generic
* #38398 Explicitly decref in UnpickledPythonCall dtor
* #39489 Run clang-format for RPC code
* **#39469 Remove unused exception handling**
* #39267 Add rpc.functions.async_execution decorator for TorchScript functions

The exception has already been handled in `_run_function` in
`internal.py`. Hence, it is not necessary to do it again in
`request_callback_impl.cpp`.

Differential Revision: [D21868480](https://our.internmc.facebook.com/intern/diff/D21868480)