### PR TITLE
Retry/skip test on URLError rather than on HTTPError

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,7 +15,7 @@ import torch.hub as hub
 from torch.autograd._functions.utils import check_onnx_broadcast
 from torch.onnx.symbolic_opset9 import _prepare_onnx_paddings
 from torch.testing._internal.common_utils import load_tests, retry, IS_SANDCASTLE
-from urllib.error import HTTPError
+from urllib.error import URLError
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -508,7 +508,7 @@ TORCHHUB_EXAMPLE_RELEASE_URL = 'https://github.com/ailzhang/torchhub_example/rel
 
 @unittest.skipIf(IS_SANDCASTLE, 'Sandcastle cannot ping external')
 class TestHub(TestCase):
-    @retry(HTTPError, tries=3, skip_after_retries=True)
+    @retry(URLError, tries=3, skip_after_retries=True)
     def test_load_from_github(self):
         hub_model = hub.load(
             'ailzhang/torchhub_example',
@@ -518,7 +518,7 @@ class TestHub(TestCase):
         self.assertEqual(sum_of_state_dict(hub_model.state_dict()),
                          SUM_OF_HUB_EXAMPLE)
 
-    @retry(HTTPError, tries=3, skip_after_retries=True)
+    @retry(URLError, tries=3, skip_after_retries=True)
     def test_load_from_branch(self):
         hub_model = hub.load(
             'ailzhang/torchhub_example:ci/test_slash',
@@ -528,7 +528,7 @@ class TestHub(TestCase):
         self.assertEqual(sum_of_state_dict(hub_model.state_dict()),
                          SUM_OF_HUB_EXAMPLE)
 
-    @retry(HTTPError, tries=3, skip_after_retries=True)
+    @retry(URLError, tries=3, skip_after_retries=True)
     def test_set_dir(self):
         temp_dir = tempfile.gettempdir()
         hub.set_dir(temp_dir)
@@ -542,12 +542,12 @@ class TestHub(TestCase):
         assert os.path.exists(temp_dir + '/ailzhang_torchhub_example_master')
         shutil.rmtree(temp_dir + '/ailzhang_torchhub_example_master')
 
-    @retry(HTTPError, tries=3, skip_after_retries=True)
+    @retry(URLError, tries=3, skip_after_retries=True)
     def test_list_entrypoints(self):
         entry_lists = hub.list('ailzhang/torchhub_example', force_reload=True)
         self.assertObjectIn('mnist', entry_lists)
 
-    @retry(HTTPError, tries=3, skip_after_retries=True)
+    @retry(URLError, tries=3, skip_after_retries=True)
     def test_download_url_to_file(self):
         temp_file = os.path.join(tempfile.gettempdir(), 'temp')
         hub.download_url_to_file(TORCHHUB_EXAMPLE_RELEASE_URL, temp_file, progress=False)
@@ -555,13 +555,13 @@ class TestHub(TestCase):
         self.assertEqual(sum_of_state_dict(loaded_state),
                          SUM_OF_HUB_EXAMPLE)
 
-    @retry(HTTPError, tries=3, skip_after_retries=True)
+    @retry(URLError, tries=3, skip_after_retries=True)
     def test_load_state_dict_from_url(self):
         loaded_state = hub.load_state_dict_from_url(TORCHHUB_EXAMPLE_RELEASE_URL)
         self.assertEqual(sum_of_state_dict(loaded_state),
                          SUM_OF_HUB_EXAMPLE)
 
-    @retry(HTTPError, tries=3, skip_after_retries=True)
+    @retry(URLError, tries=3, skip_after_retries=True)
     def test_load_zip_checkpoint(self):
         hub_model = hub.load(
             'ailzhang/torchhub_example',


### PR DESCRIPTION
`HTTPError` are raised when server is overloaded, while `URLError` is
raised when network is not available
And since `HTTPError` is an extension of `URLError`, `URLError` should catch both exceptions

