### PR TITLE
[JIT] fix broadcasting lists of ints

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11175,6 +11175,14 @@ a")
                     return x  # noqa: T484
             ''')
 
+        @torch.jit.script
+        def f(x: BroadcastingList2[int]):
+            return x
+
+        out = f(1)
+        self.assertTrue(isinstance(out[0], int))
+        self.assertEqual(out, [1, 1])
+
     def test_ntuple_builtins(self):
         from torch.nn.modules.utils import _single, _pair, _triple, _quadruple
 

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -559,8 +559,8 @@ inline IValue toIValue(
           if (!N || !py::isinstance<py::int_>(obj)) {
             return IValue(py::cast<std::vector<int64_t>>(obj));
           } else {
-            double value = py::cast<int64_t>(obj);
-            c10::List<double> repeated;
+            int64_t value = py::cast<int64_t>(obj);
+            c10::List<int64_t> repeated;
             repeated.reserve(*N);
             for (int i = 0; i < *N; ++i) {
               repeated.push_back(value);


### PR DESCRIPTION
Previously, on conversion from python -> c++ it was casted to double list through bad copy pasta. It's pretty unusual for someone to script a broadcasting list function directly since it's an internal api, so it was unlikely to affect anyone. 

Fix for https://github.com/pytorch/pytorch/issues/39450