### PR TITLE
Support  torch.Tensor subclass (like Parameter) input.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17636,6 +17636,17 @@ a")
         input = torch.ones(2, 2)
         self.assertEqual(input, sm(input))
 
+    # Tests the case where a torch.Tensor subclass (like Parameter) is used as
+    # input.
+    def test_script_module_tensor_subclass_argument(self):
+        @torch.jit.script
+        def parameter_script(x: torch.nn.Parameter):
+            return x
+
+        input = torch.ones(2, 2)
+        self.assertEqual(input, parameter_script(input))
+
+
 # known to be failing in tracer
 EXCLUDE_TRACED = {
     # The following fail due to #12024.

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -244,7 +244,7 @@ def try_real_annotations(fn, loc):
 def try_ann_to_type(ann, loc):
     if ann is None:
         return TensorType.get()
-    if ann is torch.Tensor:
+    if inspect.isclass(ann) and issubclass(ann, torch.Tensor):
         return TensorType.get()
     if is_tuple(ann):
         return TupleType([try_ann_to_type(a, loc) for a in ann.__args__])


### PR DESCRIPTION
Currently torch.Tensor subclasses (like torch.nn.Parameter) isn't a supported type annotation to torch script inputs. This PR allows it to be treated like torch.Tensor for compilation.

Closes #38235 