### PR TITLE
Run clang-format for RPC code

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -155,25 +155,23 @@ void RequestCallbackImpl::processRpc(
         jitFuture->addCallback([responseFuture, messageId, jitFuture]() {
           try {
             auto valueJitFuture = jitFuture->value().toFuture();
-            valueJitFuture->addCallback([responseFuture,
-                                         messageId,
-                                         valueJitFuture]() {
-              try {
-                Message m = ScriptResp(valueJitFuture->value()).toMessage();
-                m.setId(messageId);
-                responseFuture->markCompleted(std::move(m));
-              } catch (const std::exception& e) {
-                responseFuture->setError(e.what());
-              }
-            });
+            valueJitFuture->addCallback(
+                [responseFuture, messageId, valueJitFuture]() {
+                  try {
+                    Message m = ScriptResp(valueJitFuture->value()).toMessage();
+                    m.setId(messageId);
+                    responseFuture->markCompleted(std::move(m));
+                  } catch (const std::exception& e) {
+                    responseFuture->setError(e.what());
+                  }
+                });
           } catch (const std::exception& e) {
             responseFuture->setError(e.what());
           }
         });
       } else {
         if (jitFuture->completed()) {
-          markComplete(
-              std::move(ScriptResp(jitFuture->value())).toMessage());
+          markComplete(std::move(ScriptResp(jitFuture->value())).toMessage());
           return;
         }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39486 Add @rpc.functions.async_execution for rpc.remote
* #39485 Make @rpc.functions.async_execution processing generic
* #38398 Explicitly decref in UnpickledPythonCall dtor
* **#39489 Run clang-format for RPC code**
* #39267 Add rpc.functions.async_execution decorator for TorchScript functions

Differential Revision: [D21872545](https://our.internmc.facebook.com/intern/diff/D21872545)