### PR TITLE
Fix weight quantization in RNNs

### DIFF
--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -267,15 +267,15 @@ class RNNBase(torch.nn.Module):
             mod, 'qconfig'), 'Input float module must have qconfig defined'
 
         if mod.qconfig is not None and mod.qconfig.weight is not None:
-            weight_observer = mod.qconfig.weight()
+            weight_observer_method = mod.qconfig.weight
         else:
             # We have the circular import issues if we import the qconfig in the beginning of this file:
             # https://github.com/pytorch/pytorch/pull/24231. The current workaround is to postpone the
             # import until we need it.
             from torch.quantization.qconfig import default_dynamic_qconfig
-            weight_observer = default_dynamic_qconfig.weight()
+            weight_observer_method = default_dynamic_qconfig.weight
 
-        dtype = weight_observer.dtype
+        dtype = weight_observer_method().dtype
         supported_scalar_types = [torch.qint8, torch.float16]
         if dtype not in supported_scalar_types:
             raise RuntimeError('Unsupported dtype for dynamic RNN quantization: {}'.format(dtype))
@@ -308,6 +308,7 @@ class RNNBase(torch.nn.Module):
                         # weights and pack parameters in this order:
                         #
                         #   w_ih, w_hh
+                        weight_observer = weight_observer_method()
                         weight_observer(weight)
                         wt_scale, wt_zp = weight_observer.calculate_qparams()
                         qweight = torch.quantize_per_tensor(


### PR DESCRIPTION
Weight quantization was done incorrectly for LSTMs, the statistics for all weights (across layers) were combined in the observer. This meant that weights for later layers in a LSTM would use sub-optimal scales impacting accuracy. The problem gets worse as the number of layers increases.

Differential Revision: [D20842145](https://our.internmc.facebook.com/intern/diff/D20842145/)

[ghstack-poisoned]

