### PR TITLE
deepcopy() of Objects should call __g/setstate__

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -1,10 +1,10 @@
 #include <ATen/core/ivalue.h>
-#include <ATen/core/jit_type.h>
+#include <ATen/core/Dict.h>
 #include <ATen/core/Formatting.h>
+#include <ATen/core/function.h>
+#include <ATen/core/jit_type.h>
 #include <c10/util/StringUtil.h>
 #include <cmath>
-#include <ATen/core/Dict.h>
-#include <ATen/core/function.h>
 
 namespace c10 {
 bool _fastEqualsForContainer(const IValue& lhs, const IValue& rhs) {
@@ -518,10 +518,10 @@ IValue IValue::deepcopy(
       break;
     case IValue::Tag::Object: {
       auto class_type = type()->expect<ClassType>();
-      if (class_type->hasMethod("__getstate__") && class_type->hasMethod("__setstate__")) {
-        copy = ivalue::Object::create(c10::StrongTypePtr(
-              class_type->compilation_unit(),
-              type()),
+      if (class_type->hasMethod("__getstate__") &&
+          class_type->hasMethod("__setstate__")) {
+        copy = ivalue::Object::create(
+            c10::StrongTypePtr(class_type->compilation_unit(), type()),
             class_type->numAttributes());
         auto state = class_type->getMethod("__getstate__")({*this});
         class_type->getMethod("__setstate__")({copy, std::move(state)});
@@ -594,7 +594,6 @@ c10::intrusive_ptr<ivalue::Object> ivalue::Object::deepcopy(IValue::HashAliasedI
     object->setSlot(i, slots_[i].deepcopy(memo));
   }
   return object;
-
 }
 
 StrongTypePtr::StrongTypePtr(

--- a/test/jit/test_torchbind.py
+++ b/test/jit/test_torchbind.py
@@ -176,6 +176,23 @@ class TestTorchbind(JitTestCase):
             assert eic.f.pop() == expected
 
     @skipIfRocm
+    def test_torchbind_deepcopy(self):
+        class FooBar4321(torch.nn.Module):
+            def __init__(self):
+                super(FooBar4321, self).__init__()
+                self.f = torch.classes._TorchScriptTesting._PickleTester([3, 4])
+
+            def forward(self):
+                return self.f.top()
+
+        inst = FooBar4321()
+        scripted = torch.jit.script(inst)
+        copied = scripted._c.deepcopy()
+        assert copied.forward() == 7
+        for expected in [7, 3, 3, 1]:
+            assert copied.f.pop() == expected
+
+    @skipIfRocm
     def test_torchbind_tracing(self):
         class TryTracing(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39500 deepcopy() of Objects should call __g/setstate__**

The presence of a `__getstate__`/`__setstate__` pair on an Object indicates that the user has explicitly defined the serialization/deserialization behavior, and it is thus *not* valid to do a simple slot-wise deepcopy. We should delegate to these methods to instantiate a new object.

Differential Revision: [D21875091](https://our.internmc.facebook.com/intern/diff/D21875091)