### PR TITLE
Fix caffe2 import issues on Windows (v1.5.1)

### DIFF
--- a/caffe2/python/__init__.py
+++ b/caffe2/python/__init__.py
@@ -42,13 +42,20 @@ if platform.system() == 'Windows':
     else:
         cuda_path = ''
 
-    if not is_conda and sys.version_info >= (3, 8):
+    if sys.version_info >= (3, 8):
         dll_paths = list(filter(os.path.exists, [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]))
 
         for dll_path in dll_paths:
             os.add_dll_directory(dll_path)
-    else:
+
+    if is_conda or sys.version_info < (3, 8):
         dll_paths = [th_dll_path, py_dll_path, nvtoolsext_dll_path, cuda_path]
         dll_paths = list(filter(os.path.exists, dll_paths)) + [os.environ['PATH']]
 
         os.environ['PATH'] = ';'.join(dll_paths)
+
+    import ctypes
+    import glob
+    dlls = glob.glob(os.path.join(th_dll_path, '*.dll'))
+    for dll in dlls:
+        ctypes.CDLL(dll)


### PR DESCRIPTION
Like https://github.com/pytorch/pytorch/pull/35362 and https://github.com/pytorch/pytorch/pull/33856, but for caffe2. I think this is safe because those two PRs are already in v1.5.0.
Corresponding PR in master: https://github.com/pytorch/pytorch/pull/39513.