### PR TITLE
Use cascade-summation for floats to avoid numerical instability

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -714,6 +714,32 @@ inline Vec256<T> operator^(const Vec256<T>& a, const Vec256<T>& b) {
 #endif
 
 template <typename T>
+inline Vec256<T>& operator += (Vec256<T>& a, const Vec256<T>& b) {
+  a = a + b;
+  return a;
+}
+template <typename T>
+inline Vec256<T>& operator -= (Vec256<T>& a, const Vec256<T>& b) {
+  a = a - b;
+  return a;
+}
+template <typename T>
+inline Vec256<T>& operator /= (Vec256<T>& a, const Vec256<T>& b) {
+  a = a / b;
+  return a;
+}
+template <typename T>
+inline Vec256<T>& operator %= (Vec256<T>& a, const Vec256<T>& b) {
+  a = a % b;
+  return a;
+}
+template <typename T>
+inline Vec256<T>& operator *= (Vec256<T>& a, const Vec256<T>& b) {
+  a = a * b;
+  return a;
+}
+
+template <typename T>
 inline Vec256<T> fmadd(const Vec256<T>& a, const Vec256<T>& b, const Vec256<T>& c) {
   return a * b + c;
 }

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -124,15 +124,6 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
   });
 }
 
-static void sum_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-      ScalarType::BFloat16, ScalarType::Half, ScalarType::Bool, iter.dtype(), "sum_cpu", [&] {
-        binary_kernel_reduce_vec(
-            iter, [=](scalar_t a, scalar_t b) -> scalar_t { return a + b; },
-            [=](Vec256<scalar_t> a, Vec256<scalar_t> b) { return a + b; });
-      });
-}
-
 static void mean_kernel_impl(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX(iter.dtype(), "mean_cpu", [&] {
     scalar_t factor = scalar_t(iter.num_output_elements()) / scalar_t(iter.numel());
@@ -304,7 +295,6 @@ static void argmin_kernel_impl(TensorIterator &iter) {
 
 }  // anonymous namespace
 
-REGISTER_DISPATCH(sum_stub, &sum_kernel_impl);
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_impl);
 REGISTER_DISPATCH(prod_stub, &prod_kernel_impl);
 REGISTER_DISPATCH(mean_stub, &mean_kernel_impl);

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -1,0 +1,115 @@
+#include <ATen/Dispatch.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/ReduceOps.h>
+#include <ATen/native/cpu/Reduce.h>
+
+
+namespace at {
+namespace native {
+
+namespace {
+
+template <typename scalar_t>
+scalar_t &dereference(char * C10_RESTRICT data, int64_t stride, int64_t index) {
+  auto * ptr = data + index * stride;
+  return *reinterpret_cast<scalar_t*>(ptr);
+}
+
+template <typename scalar_t>
+const scalar_t &dereference(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+  auto * ptr = data + index * stride;
+  return *reinterpret_cast<const scalar_t*>(ptr);
+}
+
+
+template <typename scalar_t>
+scalar_t row_sum(const char * C10_RESTRICT in_data, const int64_t in_stride, const int64_t size) {
+  constexpr int64_t num_levels = 4;
+  constexpr int64_t ilp_factor = 1;
+
+  const int64_t level_power = std::max(4l, std::lround(std::floor(std::log2(size) / num_levels)));
+  const int64_t level_step = (1 << level_power);
+  const int64_t level_mask = level_step - 1;
+
+  scalar_t acc[num_levels][ilp_factor] = {0};
+
+  int64_t i = 0;
+  for (; i + level_step * ilp_factor < size;) {
+    for (int64_t j = 0; j < level_step; ++j, i += ilp_factor) {
+      #pragma unroll
+      for (int64_t k = 0; k < ilp_factor; ++k) {
+        acc[0][k] += dereference<scalar_t>(in_data, in_stride, i + k);
+      }
+    }
+
+    for (int64_t j = 1; j < num_levels; ++j) {
+      #pragma unroll
+      for (int64_t k = 0; k < ilp_factor; ++k) {
+        acc[j][k] += acc[j-1][k];
+        acc[j-1][k] = 0;
+      }
+
+      const auto mask = (level_mask << (j * level_power));
+      if ((i & mask) != mask) {
+        break;
+      }
+    }
+  }
+
+  for (; i + ilp_factor < size; i += ilp_factor) {
+    #pragma unroll
+    for (int64_t k = 0; k < ilp_factor; ++k) {
+      acc[0][k] += dereference<scalar_t>(in_data, in_stride, i + k);
+    }
+  }
+
+  for (; i < size; ++i) {
+    acc[0][0] += dereference<scalar_t>(in_data, in_stride, i);
+  }
+
+  for (int64_t i = 1; i < ilp_factor; ++i) {
+    for (int64_t j = 0; j < num_levels; ++j) {
+      acc[j][0] += acc[j][i];
+    }
+  }
+
+  scalar_t acc_sum = acc[0][0];
+  for (int64_t j = 1; j < num_levels; ++j) {
+    acc_sum += acc[j][0];
+  }
+
+  return acc_sum;
+}
+
+void sum_kernel_impl(TensorIterator &iter) {
+  if (isIntegralType(iter.dtype(), /*includeBool=*/ true)) {
+    AT_DISPATCH_INTEGRAL_TYPES_AND(ScalarType::Bool, iter.dtype(), "sum_cpu",
+      [&] {
+        binary_kernel_reduce_vec(
+            iter, [=](scalar_t a, scalar_t b) -> scalar_t { return a + b; },
+            [=](Vec256<scalar_t> a, Vec256<scalar_t> b) { return a + b; });
+      });
+    return;
+  }
+
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+    ScalarType::BFloat16, ScalarType::Half, iter.dtype(), "sum_cpu",
+    [&] {
+      iter.output().fill_(scalar_t(0));
+      iter.parallel_reduce(
+        [&](char** data, const int64_t* strides, int64_t size0, int64_t size1) {
+          // Reduction is always over the 1st dim
+          TORCH_INTERNAL_ASSERT(strides[0] == 0);
+          for (int64_t j = 0; j < size1; ++j) {
+            auto ans = row_sum<scalar_t>(data[1] + j * strides[3], strides[1], size0);
+            dereference<scalar_t>(data[0], strides[2], j) += ans;
+          }
+        });
+    });
+}
+
+}  // namespace (anonymous)
+
+REGISTER_DISPATCH(sum_stub, &sum_kernel_impl);
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -43,7 +43,8 @@ scalar_t row_sum(const char * C10_RESTRICT in_data, const int64_t in_stride, con
   constexpr int64_t num_levels = 4;
   constexpr int64_t ilp_factor = 4;
 
-  const int64_t level_power = std::max(4l, std::lround(std::floor(std::log2(size) / num_levels)));
+  const int64_t level_power =
+    std::max(4l, std::lround(std::ceil(std::log2(size) / (num_levels + 1))));
   const int64_t level_step = (1 << level_power);
   const int64_t level_mask = level_step - 1;
 

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -125,7 +125,7 @@ std::array<scalar_t, nrows> multi_row_sum(
       }
 
       const auto mask = (level_mask << (j * level_power));
-      if ((i & mask) != mask) {
+      if ((i & mask) != 0) {
         break;
       }
     }

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -3,6 +3,8 @@
 #include <ATen/native/ReduceOps.h>
 #include <ATen/native/cpu/Reduce.h>
 
+#include <algorithm>
+
 
 namespace at {
 namespace native {
@@ -10,35 +12,50 @@ namespace native {
 namespace {
 
 template <typename scalar_t>
-scalar_t &dereference(char * C10_RESTRICT data, int64_t stride, int64_t index) {
-  auto * ptr = data + index * stride;
-  return *reinterpret_cast<scalar_t*>(ptr);
+struct LoadImpl {
+  static scalar_t load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+    auto *ptr = reinterpret_cast<const scalar_t*>(data + index * stride);
+    return *ptr;
+  }
+};
+
+template <typename scalar_t>
+struct LoadImpl<Vec256<scalar_t>> {
+  static Vec256<scalar_t> load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+    auto *ptr = data + index * stride;
+    return Vec256<scalar_t>::loadu(ptr);
+  }
+};
+
+template <typename T>
+T load(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
+  return LoadImpl<T>::load(data, stride, index);
 }
 
 template <typename scalar_t>
-const scalar_t &dereference(const char * C10_RESTRICT data, int64_t stride, int64_t index) {
-  auto * ptr = data + index * stride;
-  return *reinterpret_cast<const scalar_t*>(ptr);
+void store_result(char * C10_RESTRICT data, int64_t stride, int64_t index, scalar_t value) {
+  auto * ptr = reinterpret_cast<scalar_t*>(data + index * stride);
+  *ptr += value;
 }
-
 
 template <typename scalar_t>
 scalar_t row_sum(const char * C10_RESTRICT in_data, const int64_t in_stride, const int64_t size) {
   constexpr int64_t num_levels = 4;
-  constexpr int64_t ilp_factor = 8;
+  constexpr int64_t ilp_factor = 4;
 
   const int64_t level_power = std::max(4l, std::lround(std::floor(std::log2(size) / num_levels)));
   const int64_t level_step = (1 << level_power);
   const int64_t level_mask = level_step - 1;
 
-  scalar_t acc[num_levels][ilp_factor] = {0};
+  scalar_t acc[num_levels][ilp_factor];
+  std::fill_n(&acc[0][0], num_levels * ilp_factor, scalar_t(0));
 
   int64_t i = 0;
   for (; i + level_step * ilp_factor < size;) {
     for (int64_t j = 0; j < level_step; ++j, i += ilp_factor) {
       #pragma unroll
       for (int64_t k = 0; k < ilp_factor; ++k) {
-        acc[0][k] += dereference<scalar_t>(in_data, in_stride, i + k);
+        acc[0][k] += load<scalar_t>(in_data, in_stride, i + k);
       }
     }
 
@@ -46,7 +63,7 @@ scalar_t row_sum(const char * C10_RESTRICT in_data, const int64_t in_stride, con
       #pragma unroll
       for (int64_t k = 0; k < ilp_factor; ++k) {
         acc[j][k] += acc[j-1][k];
-        acc[j-1][k] = 0;
+        acc[j-1][k] = scalar_t(0);
       }
 
       const auto mask = (level_mask << (j * level_power));
@@ -59,12 +76,12 @@ scalar_t row_sum(const char * C10_RESTRICT in_data, const int64_t in_stride, con
   for (; i + ilp_factor < size; i += ilp_factor) {
     #pragma unroll
     for (int64_t k = 0; k < ilp_factor; ++k) {
-      acc[0][k] += dereference<scalar_t>(in_data, in_stride, i + k);
+      acc[0][k] += load<scalar_t>(in_data, in_stride, i + k);
     }
   }
 
   for (; i < size; ++i) {
-    acc[0][0] += dereference<scalar_t>(in_data, in_stride, i);
+    acc[0][0] += load<scalar_t>(in_data, in_stride, i);
   }
 
   for (int64_t i = 1; i < ilp_factor; ++i) {
@@ -80,6 +97,60 @@ scalar_t row_sum(const char * C10_RESTRICT in_data, const int64_t in_stride, con
 
   return acc_sum;
 }
+
+template <typename scalar_t>
+void vectorized_inner_sum(
+    char * C10_RESTRICT data[2], int64_t outer_stride, int64_t out_stride,
+    int64_t size0, int64_t size1) {
+  using vec_t = Vec256<scalar_t>;
+  constexpr int64_t vec_stride = vec_t::size() * sizeof(scalar_t);
+  const int64_t vec_size = size0 / vec_t::size();
+
+  // Input is contiguous over the first (reduced) dimension
+  for (int64_t j = 0; j < size1; ++j) {
+    const auto *row_in = data[1] + j * outer_stride;
+    auto vec_acc = row_sum<vec_t>(row_in, vec_stride, vec_size);
+
+    scalar_t final_acc = 0;
+    for (int64_t k = vec_size * vec_t::size(); k < size0; ++k) {
+      final_acc += load<scalar_t>(row_in, sizeof(scalar_t), k);
+    }
+
+    scalar_t partials[vec_t::size()];
+    vec_acc.store(partials);
+    for (int64_t k = 0; k < vec_t::size(); ++k) {
+      final_acc += partials[k];
+    }
+    store_result(data[0], out_stride, j, final_acc);
+  }
+}
+
+template <typename scalar_t>
+void vectorized_outer_sum(
+    char * C10_RESTRICT data[2], int64_t inner_stride, int64_t out_stride,
+    int64_t size0, int64_t size1) {
+  using vec_t = Vec256<scalar_t>;
+  constexpr int64_t vec_stride = vec_t::size() * sizeof(scalar_t);
+  const int64_t vec_size = size1 / vec_t::size();
+
+  // Input is contiguous over the second (non-reduced) dimension
+  for (int64_t j = 0; j < vec_size; ++j) {
+    const auto *row_in = data[1] + j * vec_stride;
+    auto vec_acc = row_sum<vec_t>(row_in, inner_stride, size0);
+
+    scalar_t ans[vec_t::size()];
+    vec_acc.store(ans);
+    for (int64_t k = 0; k < vec_t::size(); ++k) {
+      store_result(data[0], out_stride, j * vec_t::size() + k, ans[k]);
+    }
+  }
+
+  for (int64_t j = vec_size * vec_t::size(); j < size1; ++j) {
+    auto ans = row_sum<scalar_t>(data[1] + j * sizeof(scalar_t), inner_stride, size0);
+    store_result(data[0], out_stride, j, ans);
+  }
+}
+
 
 void sum_kernel_impl(TensorIterator &iter) {
   if (isIntegralType(iter.dtype(), /*includeBool=*/ true)) {
@@ -121,9 +192,19 @@ void sum_kernel_impl(TensorIterator &iter) {
 
           const int64_t out_stride = out_strides[1];
           TORCH_INTERNAL_ASSERT(out_strides[0] == 0);
-          for (int64_t j = 0; j < size1; ++j) {
-            auto ans = row_sum<scalar_t>(data[1] + j * in_strides[1], in_strides[0], size0);
-            dereference<scalar_t>(data[0], out_stride, j) += ans;
+
+          if (in_strides[0] == sizeof(scalar_t) && size0 >= Vec256<scalar_t>::size()) {
+            // Contiguous inner reduction
+            vectorized_inner_sum<scalar_t>(data, in_strides[1], out_stride, size0, size1);
+          } else if (in_strides[1] == sizeof(scalar_t) && size1 >= Vec256<scalar_t>::size()) {
+            // Contiguous outer reduction
+            vectorized_outer_sum<scalar_t>(data, in_strides[0], out_stride, size0, size1);
+          } else {
+            // Generic reduction
+            for (int64_t j = 0; j < size1; ++j) {
+              auto ans = row_sum<scalar_t>(data[1] + j * in_strides[1], in_strides[0], size0);
+              store_result(data[0], out_stride, j, ans);
+            }
           }
         });
     });

--- a/benchmarks/operator_benchmark/pt/sum_test.py
+++ b/benchmarks/operator_benchmark/pt/sum_test.py
@@ -1,0 +1,45 @@
+import operator_benchmark as op_bench
+import torch
+
+"""Microbenchmarks for sum reduction operator."""
+
+# Configs for PT add operator
+sum_configs = op_bench.cross_product_configs(
+    R=[64, 256],  # Length of reduced dimension
+    V=[32, 512],  # Length of other dimension
+    dim=[0, 1],
+    contiguous=[True, False],
+    device=['cpu', 'cuda'],
+    tags=['short']
+) + op_bench.cross_product_configs(
+    R=[1024, 8192],
+    V=[512, 1024],
+    dim=[0, 1],
+    contiguous=[True, False],
+    device=['cpu', 'cuda'],
+    tags=['long']
+)
+
+
+class SumBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, R, V, dim, contiguous, device):
+        shape = (R, V) if dim == 0 else (V, R)
+        tensor = torch.rand(shape, device=device)
+
+        if not contiguous:
+            storage = torch.empty([s * 2 for s in shape], device=device)
+            storage[::2, ::2] = tensor
+            self.input_tensor = storage[::2, ::2]
+        else:
+            self.input_tensor = tensor
+
+        self.dim = dim
+        self.set_module_name("sum")
+
+    def forward(self):
+        return self.input_tensor.sum(dim=self.dim)
+
+op_bench.generate_pt_test(sum_configs, SumBenchmark)
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -67,7 +67,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
     auto norm = utils::clip_grad_norm_(l->parameters(), max_norm, norm_type);
     auto norm_after = compute_norm(norm_type);
     ASSERT_FLOAT_EQ(norm, norm_before);
-    ASSERT_FLOAT_EQ(norm_after, max_norm);
+    ASSERT_NEAR(norm_after, max_norm, 1e-6);
     ASSERT_LE(norm_after, max_norm);
     auto scaled = compare_scaling(grads);
     ASSERT_NEAR(0, scaled.std().item().toFloat(), 1e-7);


### PR DESCRIPTION
Fixes #38716, fixes #37234

This uses a variant of pairwise-summation to calculate sums of long lists without noticable loss of precison. It uses with multiple "levels" of accumulator along each axis, each of which is designed to hold the sum of an order of magnitude more values than the previous. 

e.g. if there are 2^16 elements, the first level will hold the sum of 2^4 elements, and so on in increasing powers of 2: 2^4, 2^8, 2^12 and finally 2^16.

This limits the differences in magnitude of the partial results being added together, and so we don't lose accuracy as the axis length increases.

Ref: https://en.wikipedia.org/wiki/Pairwise_summation