### PR TITLE
Bumps supported file format in anticipation of torch.div changes

### DIFF
--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -91,12 +91,16 @@ namespace caffe2 {
 namespace serialize {
 
 constexpr uint64_t kMinSupportedFileFormatVersion = 0x1L;
-constexpr uint64_t kMaxSupportedFileFormatVersion = 0x3L;
+constexpr uint64_t kMaxSupportedFileFormatVersion = 0x4L;
 
 // Versions (i.e. why was the version number bumped?)
 // 1. Initial version
 // 2. Removed op_version_set version numbers
 // 3. Added type tags to pickle serialization of container types
+// 4. (Currently read-only) Will change torch.div to throw a runtime error
+//      when it would have performed floor division. Bumping the version counter
+//      will let us presever torch.div's historic behavior for programs
+//      serialized with file formats 1--3.
 constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 
 // Writer-specific constants


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/pull/38620 for additional context.

When PyTorch begins producing file format 4 with the updated div behavior it's safe for older PyTorch versions to consume it, since file format 4 only prohibits functionality. Bumping the supported file format version now gives PyTorch users on Master some leeway on updating their services that consume vs. produce PyTorch.