### PR TITLE
Enable RRef timeout for tensorpipe

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/distributed/rpc/tensorpipe_agent.h>
 
+#include <fmt/format.h>
 #include <torch/csrc/distributed/rpc/request_callback_impl.h>
 #include <torch/csrc/distributed/rpc/utils.h>
 
@@ -23,6 +24,8 @@ const std::string kNumIdleThreads = "agent.num_idle_threads";
 const std::string kClientActiveCalls = "agent.client_active_calls";
 const std::string kServerActiveCalls = "agent.server_active_calls";
 const std::string kServerActiveAsyncCalls = "agent.server_active_async_calls";
+const std::string kTensorPipeRPCTimeoutErrorStr =
+    "RPC ran for more than set timeout ({} ms) and will now be marked with an error";
 
 std::string guessAddress(tensorpipe::transport::uv::Context& uvContext) {
   tensorpipe::Error error;
@@ -418,7 +421,8 @@ std::shared_ptr<FutureMessage> TensorPipeAgent::send(
     {
       std::unique_lock<std::mutex> lock(timeoutMapMutex_);
       auto& timeoutFuturesVector = timeoutMap_[expirationTime];
-      timeoutFuturesVector.emplace_back(futureResponseMessage);
+      timeoutFuturesVector.emplace_back(
+          std::make_pair(futureResponseMessage, timeout));
     }
     timeoutThreadCV_.notify_one();
   }
@@ -533,8 +537,10 @@ void TensorPipeAgent::pollTimeoutRpcs() {
 
     // Move all these futures to a separate vector so we can process them
     // outside the lock.
-    std::vector<std::shared_ptr<AtomicFutureMessage>> timedOutFutures =
-        std::move(timeoutMap_.begin()->second);
+    std::vector<std::pair<
+        std::shared_ptr<AtomicFutureMessage>,
+        std::chrono::milliseconds>>
+        timedOutFutures = std::move(timeoutMap_.begin()->second);
     // We can safely remove this key from the timeoutMap_ since all these
     // futures will be processed.
     timeoutMap_.erase(timeoutMap_.begin());
@@ -543,11 +549,12 @@ void TensorPipeAgent::pollTimeoutRpcs() {
 
     // Set an error on futures added to the timedOutFutures vector. We do this
     // outside the lock to prevent potential lock-order-inversions by callbacks
-    // triggered by the serError call.
-    for (auto& future : timedOutFutures) {
-      std::string errorMsg = c10::str(
-          "RPC ran for more than set timeout and will now be marked with an error");
-      markFutureWithError(std::move(future), std::move(errorMsg));
+    // triggered by the setError call.
+    for (auto& futureTimeoutPair : timedOutFutures) {
+      std::string errorMsg = fmt::format(
+          kTensorPipeRPCTimeoutErrorStr, futureTimeoutPair.second.count());
+      auto err = makeRPCError(errorMsg, RPCErrorType::TIMEOUT);
+      markFutureWithError(std::move(futureTimeoutPair.first), std::move(err));
     }
   }
 }

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -546,7 +546,7 @@ void TensorPipeAgent::pollTimeoutRpcs() {
 
     lock.unlock();
 
-    // Set an error on futures added to the t\imedOutFutures vector. We do this
+    // Set an error on futures added to the timedOutFutures vector. We do this
     // outside the lock to prevent potential lock-order-inversions by callbacks
     // triggered by the setError call.
     for (auto& futureTimeoutPair : timedOutFutures) {

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -179,7 +179,9 @@ class TensorPipeAgent : public RpcAgent {
   // Map to store the expiration times for each message.
   std::map<
       steady_clock_time_point,
-      std::vector<std::shared_ptr<AtomicFutureMessage>>>
+      std::vector<std::pair<
+          std::shared_ptr<AtomicFutureMessage>,
+          std::chrono::milliseconds>>>
       timeoutMap_;
 
   // Thread that will poll the timeoutMap_ for timed out messages and mark them

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -2833,7 +2833,6 @@ class RpcTest(RpcAgentTestFixture):
                 return_future,
             )
 
-    @_skip_if_tensorpipe_agent
     @dist_init
     def test_rref_timeout(self):
         # This test is similar to ones in FaultyProcessGroupTest, but is meant to be


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39531 Enable RRef timeout for tensorpipe**
* #39530 Cleanup rref_impl

Enables RRef timeout support in TP agent by having TP agent mark
timeout errors with `makeRPCError` API. Also does some refactoring so TP agent
can print out the timeout for each future that has timed out.

Differential Revision: [D21881475](https://our.internmc.facebook.com/intern/diff/D21881475/)