### PR TITLE
Do not raise decorator

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -449,7 +449,7 @@ def largeTensorTest(size):
                          torch.cuda.get_device_properties(0).total_memory >= size)
             else:
                 if not HAS_PSUTIL:
-                    raise unittest.skip('Need psutil to determine if memory is sufficient')
+                    raise unittest.SkipTest('Need psutil to determine if memory is sufficient')
 
                 # The sanitizers have significant memory overheads
                 if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:


### PR DESCRIPTION
s/raise unittest.skip/raise unittest.SkipTest/
As `unittest.skip` is a decorator while `unittest.SkipTest` is an exception

