### PR TITLE
[JIT] Fix append schema

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -21,7 +21,7 @@ white_list = [
     # We export some functions and classes for test_jit.py directly from libtorch.so,
     # it's not important to have BC for them
     ('_TorchScriptTesting.*', datetime.date(9999, 1, 1)),
-    ('aten::append*', datetime.date(2020, 7, 1)),
+    ('profiler::_call_end_callbacks_on_jit_fut*', datetime.date(9999, 1, 1)),
     ('aten::_min', datetime.date(2020, 9, 9)),
     ('aten::_max', datetime.date(2020, 9, 9)),
     ('aten::real*', datetime.date(2020, 4, 15)),
@@ -86,7 +86,7 @@ white_list = [
     ('_prim::*', datetime.date(2020, 6, 1)),
 ]
 
-white_list.append(('profiler::_call_end_callbacks_on_jit_fut*', datetime.date(9999, 1, 1)))
+white_list.append(('aten::append*', datetime.date(2020, 7, 1)))
 
 # The nightly will fail to parse newly added syntax to schema declarations
 # Add new schemas that will fail the nightly here

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -21,8 +21,7 @@ white_list = [
     # We export some functions and classes for test_jit.py directly from libtorch.so,
     # it's not important to have BC for them
     ('_TorchScriptTesting.*', datetime.date(9999, 1, 1)),
-    ('profiler::_call_end_callbacks_on_jit_fut*', datetime.date(9999, 1, 1)),
-    ('aten::append*', datetime.date(2020, 4, 15)),
+    ('aten::append*', datetime.date(2020, 7, 1)),
     ('aten::_min', datetime.date(2020, 9, 9)),
     ('aten::_max', datetime.date(2020, 9, 9)),
     ('aten::real*', datetime.date(2020, 4, 15)),
@@ -87,6 +86,7 @@ white_list = [
     ('_prim::*', datetime.date(2020, 6, 1)),
 ]
 
+white_list.append(('profiler::_call_end_callbacks_on_jit_fut*', datetime.date(9999, 1, 1)))
 
 # The nightly will fail to parse newly added syntax to schema declarations
 # Add new schemas that will fail the nightly here

--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -752,7 +752,7 @@ graph():
   %32 : int[] = prim::ListConstruct(%0, %1)
   %fresh : Tensor = prim::MakeTestTensor()
   %foo : Tensor[] = prim::ListConstruct(%x, %y)
-  %43 : Tensor[] = aten::append(%foo, %z)
+  %43 : None = aten::append(%foo, %z)
   return ()
 )IR",
         graph.get(),

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -319,7 +319,7 @@ RegisterOperators reg(
          listSelect,
          aliasAnalysisFromSchema()),
      Operator(
-         "aten::append.t(t[](a!) self, t(c -> *) el) -> t[](a!)",
+         "aten::append.t(t[](a!) self, t(c -> *) el) -> None",
          listAppend,
          aliasAnalysisFromSchema()),
      Operator(


### PR DESCRIPTION
`[].append(1)` returns None in python.  I don't think this will break BC because the return value is always unused. As is, the schema causes confusion.