### PR TITLE
Remove duplicate 'with_gil' declaration.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -513,7 +513,6 @@ FunctionOption = TypedDict('FunctionOption', {
     'type_definition_body': List[str],
     'type_method_definition_dispatch': str,
     'variants': str,
-    'with_gil': bool,
 })
 
 OutputDeclaration = NamedTuple('OutputDeclaration', [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39540 Remove duplicate 'with_gil' declaration.**

This gets picked up by mypy as an error in 1.5.1, not sure if it's a different version or setting, but might as well fix.

Differential Revision: [D21891772](https://our.internmc.facebook.com/intern/diff/D21891772)