### PR TITLE
[v1.5.1] Remove duplicate 'with_gil' declaration.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -550,7 +550,6 @@ FunctionOption = TypedDict('FunctionOption', {
     'type_method_definition_dispatch': str,
     'type_method_formals': List[str],
     'variants': str,
-    'with_gil': bool,
     'zero_dim_dispatch_when_scalar': str,
 })
 


### PR DESCRIPTION
This gets picked up by mypy as an error in 1.5.1, not sure if it's a different version or setting, but might as well fix.

ghstack-source-id: 016f8d4bdb0444dd8285f1f29bdc8f2db2265c12
Pull Request resolved: https://github.com/pytorch/pytorch/pull/39540

