### PR TITLE
[JIT] Add Type::repr_str to return human-readable str

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -75,7 +75,7 @@ struct Argument {
     }
     return c10::str(
         "Expected a value of type '",
-        type()->python_str(),
+        type()->repr_str(),
         "' for argument '",
         name(),
         "' but instead found type '",

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -190,7 +190,7 @@ inline void FunctionSchema::checkArg(
     TORCH_CHECK(
         false,
         formatTypeMismatchMsg(
-            argument, value.type()->python_str(), pos));
+            argument, value.type()->repr_str(), pos));
   }
 }
 

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -18,7 +18,7 @@ bool _fastEqualsForContainer(const IValue& lhs, const IValue& rhs) {
 
 namespace ivalue {
 
-// This is in ivalue.cpp because we need to access Type::python_str, which
+// This is in ivalue.cpp because we need to access Type::annotation_str, which
 // is declared in jit_type.h
 void checkCustomClassType(TypePtr expected_type, TypePtr actual_type) {
   // NB: doing pointer comparison here
@@ -26,9 +26,9 @@ void checkCustomClassType(TypePtr expected_type, TypePtr actual_type) {
   // Type's, this needs to be changed!
   TORCH_CHECK(actual_type == expected_type,
               "Tried to convert an IValue of type ",
-              actual_type->python_str(),
+              actual_type->repr_str(),
               " to custom class type ",
-              expected_type->python_str());
+              expected_type->repr_str());
 }
 
 CAFFE2_API c10::intrusive_ptr<ConstantString> ConstantString::create(
@@ -291,7 +291,7 @@ std::ostream& printMaybeAnnotatedList(
   auto list_elem_type = the_list.type()->expect<ListType>()->getElementType();
   if (the_list.toListRef().size() == 0 ||
       !elementTypeCanBeInferredFromMembers(list_elem_type)) {
-    out << "annotate(" << the_list.type()->python_str() << ", ";
+    out << "annotate(" << the_list.type()->annotation_str() << ", ";
     printList(out, the_list.toListRef(), "[", "]", formatter);
     out << ")";
     return out;
@@ -332,7 +332,7 @@ std::ostream& printMaybeAnnotatedDict(
   auto value_type = the_dict.type()->cast<DictType>()->getValueType();
   if (the_dict.toGenericDict().size() == 0 ||
       !elementTypeCanBeInferredFromMembers(value_type)) {
-    out << "annotate(" << the_dict.type()->python_str() << ",";
+    out << "annotate(" << the_dict.type()->annotation_str() << ",";
     printDict(out, the_dict.toGenericDict(), formatter) << ")";
   } else {
     return printDict(out, the_dict.toGenericDict(), formatter);

--- a/aten/src/ATen/test/type_test.cpp
+++ b/aten/src/ATen/test/type_test.cpp
@@ -19,12 +19,12 @@ TEST(TypeCustomPrinter, Basic) {
   // Tensor types should be rewritten
   torch::Tensor iv = torch::rand({2, 3});
   const auto type = TensorType::create(iv);
-  EXPECT_EQ(type->python_str(), "Tensor");
-  EXPECT_EQ(type->python_str(printer), "CustomTensor");
+  EXPECT_EQ(type->annotation_str(), "Tensor");
+  EXPECT_EQ(type->annotation_str(printer), "CustomTensor");
 
   // Unrelated types shoudl not be affected
   const auto intType = IntType::create();
-  EXPECT_EQ(intType->python_str(printer), intType->python_str());
+  EXPECT_EQ(intType->annotation_str(printer), intType->annotation_str());
 }
 
 TEST(TypeCustomPrinter, ContainedTypes) {
@@ -40,14 +40,14 @@ TEST(TypeCustomPrinter, ContainedTypes) {
 
   // Contained types should work
   const auto tupleType = TupleType::create({type, IntType::get(), type});
-  EXPECT_EQ(tupleType->python_str(), "Tuple[Tensor, int, Tensor]");
+  EXPECT_EQ(tupleType->annotation_str(), "Tuple[Tensor, int, Tensor]");
   EXPECT_EQ(
-      tupleType->python_str(printer), "Tuple[CustomTensor, int, CustomTensor]");
+      tupleType->annotation_str(printer), "Tuple[CustomTensor, int, CustomTensor]");
   const auto dictType = DictType::create(IntType::get(), type);
-  EXPECT_EQ(dictType->python_str(printer), "Dict[int, CustomTensor]");
+  EXPECT_EQ(dictType->annotation_str(printer), "Dict[int, CustomTensor]");
   const auto listType = ListType::create(tupleType);
   EXPECT_EQ(
-      listType->python_str(printer),
+      listType->annotation_str(printer),
       "List[Tuple[CustomTensor, int, CustomTensor]]");
 }
 
@@ -67,11 +67,11 @@ TEST(TypeCustomPrinter, NamedTuples) {
 
   const auto namedTupleType = TupleType::createNamed(
       "my.named.tuple", {"foo", "bar"}, {type, IntType::get()});
-  EXPECT_EQ(namedTupleType->python_str(printer), "Rewritten");
+  EXPECT_EQ(namedTupleType->annotation_str(printer), "Rewritten");
 
   // Put it inside another tuple, should still work
   const auto outerTupleType = TupleType::create({IntType::get(), namedTupleType});
-  EXPECT_EQ(outerTupleType->python_str(printer), "Tuple[int, Rewritten]");
+  EXPECT_EQ(outerTupleType->annotation_str(printer), "Tuple[int, Rewritten]");
 }
 
 static TypePtr importType(

--- a/test/cpp/jit/test_jit_type.cpp
+++ b/test/cpp/jit/test_jit_type.cpp
@@ -27,7 +27,7 @@ void testUnifyTypes() {
   TORCH_INTERNAL_ASSERT(out);
 
   std::stringstream ss;
-  ss << (*out)->python_str();
+  ss << (*out)->annotation_str();
   testing::FileCheck()
       .check("Optional[Tuple[Optional[int], Optional[int]]]")
       ->run(ss.str());

--- a/test/cpp/jit/test_mobile_type_parser.cpp
+++ b/test/cpp/jit/test_mobile_type_parser.cpp
@@ -14,20 +14,20 @@ void testMobileTypeParser() {
 
   std::string int_ps("int");
   auto int_tp = c10::parseType(int_ps);
-  std::string int_tps = int_tp->python_str();
+  std::string int_tps = int_tp->annotation_str();
   ASSERT_EQ(int_ps, int_tps);
 
   std::string tuple_ps(
       "Tuple[str, Optional[float], Dict[str, List[Tensor]], int]");
   auto tuple_tp = c10::parseType(tuple_ps);
-  std::string tuple_tps = tuple_tp->python_str();
+  std::string tuple_tps = tuple_tp->annotation_str();
   ASSERT_EQ(tuple_ps, tuple_tps);
 
   std::string tuple_space_ps(
       "Tuple[  str, Optional[float], Dict[str, List[Tensor ]]  , int]");
   auto tuple_space_tp = c10::parseType(tuple_space_ps);
   // tuple_space_tps should not have weird white spaces
-  std::string tuple_space_tps = tuple_space_tp->python_str();
+  std::string tuple_space_tps = tuple_space_tp->annotation_str();
   ASSERT_EQ(tuple_ps, tuple_space_tps);
 
   std::string typo_token("List[tensor]");

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17623,7 +17623,8 @@ a")
         def foo(a):
             return a
 
-        with self.assertRaisesRegex(RuntimeError, "Inferred \'a\' to be of type \'Tensor"):
+        with self.assertRaisesRegex(RuntimeError, (r"Expected a value of type \'Tensor \(inferred\)\'"
+                                                   r"[\S\s]*Inferred \'a\' to be of type \'Tensor\'")):
             foo(1)
 
     def test_type_comments_in_body(self):

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -70,7 +70,7 @@ TypePtr tryInferTypeWithTypeHint(
         type_hint_ptr != nullptr &&
             module.value().type()->isSubtypeOfExt(
                 type_hint_ptr, &subtype_check_msg),
-        module.value().type()->python_str(),
+        module.value().type()->repr_str(),
         " is not a subtype of the type hint: ",
         type_qualified_name.qualifiedName(),
         ", did you pass a valid interface type?\n",

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -336,12 +336,12 @@ c10::intrusive_ptr<OwnerRRef> RRefContext::getOrCreateOwnerRRef(
       TORCH_INTERNAL_ASSERT(
           ownerRRef->type()->isSubtypeOf(TensorType::get()),
           "Expect OwnerRRef to be a sub-type of TensorType, but got ",
-          ownerRRef->type()->python_str());
+          ownerRRef->type()->repr_str());
     } else {
       TORCH_INTERNAL_ASSERT(
           ownerRRef->type() == type,
           "OwnerRRef type is ",
-          ownerRRef->type()->python_str(),
+          ownerRRef->type()->repr_str(),
           ", expected type is ",
           type);
     }

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -40,11 +40,11 @@ struct TORCH_API Object {
       TORCH_CHECK(
           v.type()->isSubtypeOf(expected),
           "Expected a value of type '",
-          expected->python_str(),
+          expected->repr_str(),
           "' for field '",
           name,
           "', but found '",
-          v.type()->python_str(),
+          v.type()->repr_str(),
           "'");
       _ivalue()->setSlot(*slot, std::move(v));
     } else {
@@ -61,7 +61,7 @@ struct TORCH_API Object {
     }
     TORCH_CHECK(
         false,
-        _ivalue()->type()->python_str(),
+        _ivalue()->type()->repr_str(),
         " does not have a field with name '",
         name,
         "'");

--- a/torch/csrc/jit/frontend/concrete_module_type.cpp
+++ b/torch/csrc/jit/frontend/concrete_module_type.cpp
@@ -258,13 +258,13 @@ void ConcreteModuleType::dump() const {
   }
   std::cout << "\nAttributes: \n";
   for (const auto& pr : data_.attributes_) {
-    std::cout << "\t" << pr.key() << ": " << pr.value().type_->python_str()
+    std::cout << "\t" << pr.key() << ": " << pr.value().type_->annotation_str()
               << "\n";
   }
   std::cout << "\nSubmodules: \n";
   for (const auto& info : data_.modules_) {
     std::cout << "\t" << info.name_ << ": "
-              << info.meta_->getJitType()->python_str() << "\n";
+              << info.meta_->getJitType()->annotation_str() << "\n";
   }
   std::cout << "\nOverloads: \n";
   for (const auto& pr : data_.overloads_) {
@@ -273,7 +273,7 @@ void ConcreteModuleType::dump() const {
   std::string isPoisoned = data_.isPoisoned_ ? "true" : "false";
   std::cout << "isPoisoned: " << isPoisoned << "\n";
   if (jitType_) {
-    std::cout << "jit type: " << jitType_->python_str() << "\n";
+    std::cout << "jit type: " << jitType_->annotation_str() << "\n";
   }
 }
 

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -374,9 +374,9 @@ struct Environment {
       if (!as_simple_value->type()->isSubtypeOfExt(parent_type, &why_not)) {
         auto error = ErrorReport(loc);
         error << "Variable '" << name << "' previously has type "
-              << simple_parent->type()->python_str()
+              << simple_parent->type()->repr_str()
               << " but is now being assigned to a value of type "
-              << as_simple_value->type()->python_str();
+              << as_simple_value->type()->repr_str();
 
         // Special-cased error msg if we're trying to assign to a tensor list.
         if (simple_parent->type()->kind() == TypeKind::ListType &&
@@ -397,9 +397,9 @@ struct Environment {
       if (!as_simple_value->type()->isSubtypeOf(annotated_type)) {
         throw ErrorReport(loc)
             << "Variable '" << name << "' is annotated with type "
-            << annotated_type->python_str()
+            << annotated_type->repr_str()
             << " but is being assigned to a value of type "
-            << as_simple_value->type()->python_str();
+            << as_simple_value->type()->repr_str();
       }
       insertStore(name, loc, std::move(as_simple_value), annotated_type);
     } else {
@@ -972,8 +972,8 @@ struct to_ir {
       if (!result->type()->isSubtypeOf(result_type)) {
         throw ErrorReport(stmt.range())
             << "Return value was annotated as having type "
-            << result_type->python_str() << " but is actually of type "
-            << result->type()->python_str();
+            << result_type->repr_str() << " but is actually of type "
+            << result->type()->repr_str();
       }
     } else {
       result_type = def_stack_.back().merged_return_type_;
@@ -984,9 +984,9 @@ struct to_ir {
       if (!merged_result_type) {
         throw ErrorReport(stmt.range())
             << "Previous return statement returned a value of type "
-            << result_type->python_str()
+            << result_type->repr_str()
             << " but this return statement returns a value of type "
-            << result->type()->python_str();
+            << result->type()->repr_str();
       }
       result_type = merged_result_type.value();
     }
@@ -1208,7 +1208,7 @@ struct to_ir {
         throw ErrorReport(loc)
             << "Expected list type annotation for list comprehension"
                ", found "
-            << type_hint->python_str();
+            << type_hint->repr_str();
       }
       list_value->setType(type_hint);
       type_set = true;
@@ -1326,8 +1326,8 @@ struct to_ir {
     auto unified = unifyTypes(true_type, false_type);
     if (!unified) {
       throw ErrorReport(range)
-          << "if-expression's true branch has type " << true_type->python_str()
-          << " but false branch has type " << false_type->python_str();
+          << "if-expression's true branch has type " << true_type->repr_str()
+          << " but false branch has type " << false_type->repr_str();
     }
 
     // Add op outputs
@@ -1342,13 +1342,13 @@ struct to_ir {
       out = asSimple(bool_cast->call(loc, method, {v}, {}, 0));
     } catch (...) {
       throw ErrorReport(loc) << "Could not cast value of type "
-                             << v->type()->python_str() << " to bool";
+                             << v->type()->repr_str() << " to bool";
     }
     // cast value not response for checking output type
     if (!out->type()->isSubtypeOf(BoolType::get())) {
       throw ErrorReport(loc)
           << "expected a bool expression for condition but found "
-          << out->type()->python_str();
+          << out->type()->repr_str();
     }
     return out;
   }
@@ -1507,8 +1507,8 @@ struct to_ir {
       if (!unified) {
         ErrorReport error(loc);
         error << "Type mismatch: " << x << " is set to type "
-              << tv->type()->python_str() << " in the true branch"
-              << " and type " << fv->type()->python_str()
+              << tv->type()->repr_str() << " in the true branch"
+              << " and type " << fv->type()->repr_str()
               << " in the false branch";
         if (save_true->findInParentFrame(x) ||
             save_false->findInParentFrame(x)) {
@@ -1922,7 +1922,7 @@ struct to_ir {
         magic_method_name = out_of_place_method_name;
       } else {
         throw ErrorReport(stmt.range())
-            << "Cannot emit inplace op on " << type->python_str()
+            << "Cannot emit inplace op on " << type->repr_str()
             << " since it does not define an " << in_place_method_name << " or "
             << out_of_place_method_name << " method";
       }
@@ -1954,7 +1954,7 @@ struct to_ir {
     const TypePtr type = sliceable->type();
     if (subscriptExprs.size() != 1) {
       throw ErrorReport(subscriptExprs)
-          << "Sliced expression not yet supported for " << type->python_str()
+          << "Sliced expression not yet supported for " << type->repr_str()
           << " augmented assignment. "
           << "File a bug if you want this";
     }
@@ -1968,7 +1968,7 @@ struct to_ir {
 
     if (elemType == nullptr) {
       throw ErrorReport(lhs)
-          << type->python_str() << " does not support augmented assignment.";
+          << type->repr_str() << " does not support augmented assignment.";
     }
     const auto idxValue = emitExpr(subscriptExprs[0]);
     const auto containerArg =
@@ -2541,8 +2541,8 @@ struct to_ir {
         std::stringstream why_not;
         if (!expr->type()->isSubtypeOfExt(type, &why_not)) {
           throw ErrorReport(apply.inputs())
-              << "expected an expression of type " << type->python_str()
-              << " but found " << expr->type()->python_str() << "\n"
+              << "expected an expression of type " << type->repr_str()
+              << " but found " << expr->type()->repr_str() << "\n"
               << why_not.str();
         }
 
@@ -3050,7 +3050,7 @@ struct to_ir {
             // If the type hint was not a List[T] throw an error
             throw ErrorReport(tree)
                 << "Expected a List type hint but instead got "
-                << type_hint->python_str();
+                << type_hint->repr_str();
           }
         } else if (!values.empty()) {
           std::stringstream ss;
@@ -3068,8 +3068,8 @@ struct to_ir {
           if (!v->type()->isSubtypeOfExt(elem_type, &ss)) {
             throw ErrorReport(tree)
                 << "Lists must contain only a single type, expected: "
-                << elem_type->python_str() << " but found "
-                << v->type()->python_str() << " instead.\n"
+                << elem_type->repr_str() << " but found "
+                << v->type()->repr_str() << " instead.\n"
                 << ss.str();
           }
         }
@@ -3120,8 +3120,8 @@ struct to_ir {
               throw ErrorReport(trees[i])
                   << "Dict " << what
                   << " must contain only a single type, expected: "
-                  << type->python_str() << " but found "
-                  << values[i]->type()->python_str() << " instead.\n"
+                  << type->repr_str() << " but found "
+                  << values[i]->type()->repr_str() << " instead.\n"
                   << ss.str();
             }
           }
@@ -3329,7 +3329,7 @@ struct to_ir {
       } else {
         throw ErrorReport(loc)
             << "Unsupported operation: indexing tensor with unsupported index type '"
-            << index->type()->python_str()
+            << index->type()->repr_str()
             << "'. Only ints, slices, lists and tensors are supported";
       }
     };
@@ -3485,7 +3485,7 @@ struct to_ir {
       if (elems.size() == 0 ||
           !convertibleToList(tuple_typ, ListType::create(elems[0]))) {
         throw ErrorReport(loc)
-            << "Cannot index into a " << tuple_typ->python_str()
+            << "Cannot index into a " << tuple_typ->repr_str()
             << " with a non-integer literal because we cannot resolve the output type";
       }
       output_type = elems[0];

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -148,8 +148,8 @@ static Value* tryMatchArgument(
       matchTypeVariables(arg.type(), value->type(), type_env);
   if (!matched.success()) {
     if (failure_messages) {
-      err() << "Could not match type " << value->type()->python_str() << " to "
-            << arg.type()->python_str() << " in argument '" << arg.name()
+      err() << "Could not match type " << value->type()->repr_str() << " to "
+            << arg.type()->repr_str() << " in argument '" << arg.name()
             << "': " << matched.reason() << ".\n";
     }
     return nullptr;
@@ -157,9 +157,9 @@ static Value* tryMatchArgument(
   const auto concrete_type = tryEvalTypeVariables(arg.type(), type_env);
   if (!concrete_type) {
     if (failure_messages) {
-      err() << "Type variables in type " << arg.type()->python_str()
+      err() << "Type variables in type " << arg.type()->repr_str()
             << " could not be inferred from actual type "
-            << value->type()->python_str();
+            << value->type()->repr_str();
     }
     return nullptr;
   }
@@ -172,7 +172,7 @@ static Value* tryMatchArgument(
           concrete_type, /*why_not=*/(failure_messages) ? &ss : nullptr)) {
     if (failure_messages) {
       auto& ostream = err()
-          << arg.formatTypeMismatchMsg(value->type()->python_str());
+          << arg.formatTypeMismatchMsg(value->type()->repr_str());
 
       if (auto pt = value->type()->cast<TensorType>()) {
         if (pt->isInferredType()) {
@@ -414,7 +414,7 @@ static c10::optional<MatchedSchema> tryMatchSchema(
   auto return_types = fmap(returns, [&](const Argument& r) {
     TypePtr result = tryEvalTypeVariables(r.type(), type_env);
     TORCH_INTERNAL_ASSERT(
-        result, r.type()->python_str(), " has unbound type variables.");
+        result, r.type()->repr_str(), " has unbound type variables.");
     return result;
   });
   // Codegen does not support return of namedtuples with undefined field names.

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -70,7 +70,7 @@ bool SimpleValue::hasAttr(
   auto class_type = value_->type()->cast<ClassType>();
   if (!class_type) {
     throw ErrorReport(loc) << "hasattr's first argument must be an object, got "
-                           << value_->type()->python_str() << " instead";
+                           << value_->type()->repr_str() << " instead";
   }
 
   return class_type->hasMethod(field) || class_type->hasAttribute(field) ||
@@ -176,7 +176,7 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
 
   ErrorReport report(loc);
   report << "Tried to access nonexistent attribute or method '" << field
-         << "' of type '" << value_->type()->python_str() << "'.";
+         << "' of type '" << value_->type()->repr_str() << "'.";
   if (value_->type()->kind() == ClassType::Kind) {
     report << " Did you forget to initialize an attribute in __init__()?";
   }
@@ -205,7 +205,7 @@ std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(
         graph->insertNode(graph->createListUnpack(value_, *size_hint));
     return fmap(unpack->outputs(), make_simple_value);
   }
-  throw ErrorReport(loc) << value_->type()->python_str()
+  throw ErrorReport(loc) << value_->type()->repr_str()
                          << " cannot be used as a tuple";
 }
 
@@ -232,8 +232,7 @@ void SimpleValue::setAttr(
   const auto classType = value_->type()->cast<ClassType>();
   if (!classType) {
     throw ErrorReport(loc) << "Tried to set an attribute: " << field
-                           << " on a non-class: "
-                           << value_->type()->python_str();
+                           << " on a non-class: " << value_->type()->repr_str();
   }
   auto expectedType = classType->findAttribute(field);
   if (!expectedType) {
@@ -255,7 +254,7 @@ void SimpleValue::setAttr(
         throw ErrorReport(loc)
             << "Assignment to attribute '" << field
             << "' cannot be of a type that contains class "
-            << "'" << classType->python_str() << "'.\n"
+            << "'" << classType->repr_str() << "'.\n"
             << "Classes that recursively contain instances of themselves"
             << " are not yet supported";
       }
@@ -283,8 +282,8 @@ void SimpleValue::setAttr(
   const auto newType = newValue->type();
   if (!newType->isSubtypeOf(expectedType)) {
     throw ErrorReport(loc) << "Wrong type for attribute assignment. Expected "
-                           << expectedType->python_str() << " but got "
-                           << newType->python_str();
+                           << expectedType->repr_str() << " but got "
+                           << newType->repr_str();
   }
 
   auto& g = *m.graph();
@@ -341,7 +340,7 @@ Value* SimpleValue::len(const SourceRange& loc, Function& m) {
       val_type->isSubtypeOf(TensorType::get())) {
     return g.insert(aten::len, {val}, {}, loc);
   } else {
-    throw ErrorReport(loc) << "'" << val_type->python_str() << "'"
+    throw ErrorReport(loc) << "'" << val_type->repr_str() << "'"
                            << " object is not iterable";
   }
 }
@@ -367,7 +366,7 @@ SugaredValuePtr SimpleValue::getitem(
   } else if (auto class_type = val_type->cast<ClassType>()) {
     return attr(loc, m, "__getitem__")->call(loc, m, {idx}, {}, 1);
   } else {
-    throw ErrorReport(loc) << "'" << val_type->python_str() << "'"
+    throw ErrorReport(loc) << "'" << val_type->repr_str() << "'"
                            << " object is not subscriptable";
   }
 }
@@ -393,7 +392,7 @@ SugaredValuePtr SimpleValue::iter(const SourceRange& loc, Function& m) {
     }
     return std::make_shared<SugaredTupleValue>(tup_sugared);
   } else {
-    throw ErrorReport(loc) << "'" << type->python_str() << "'"
+    throw ErrorReport(loc) << "'" << type->repr_str() << "'"
                            << " object is not iterable";
   }
 }
@@ -407,7 +406,7 @@ RangeValue::RangeValue(
     auto typ = inputs[i]->type();
     if (!typ->cast<IntType>()) {
       throw ErrorReport(loc)
-          << "all inputs of range must be ints, found " << typ->python_str()
+          << "all inputs of range must be ints, found " << typ->repr_str()
           << " in argument " << c10::guts::to_string(i);
     }
   }

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -147,7 +147,7 @@ struct TORCH_API SimpleValue : public SugaredValue {
   SimpleValue(Value* value) : value_(value) {}
   std::string kind() const override {
     std::stringstream ss;
-    ss << "value of type '" << value_->type()->python_str() << "'";
+    ss << "value of type '" << value_->type()->annotation_str() << "'";
     return ss.str();
   }
   Value* asValue(const SourceRange& range, Function& m) override {

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -367,7 +367,7 @@ static IValue addInput(
     AT_ERROR(
         "Only tensors or (possibly nested) dict or tuples of tensors can be "
         "inputs to traced functions. Got ",
-        type->python_str());
+        type->repr_str());
   }
 }
 

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -1081,9 +1081,9 @@ void AliasDb::replaceWithNewValue(Value* existing, Value* new_value) {
       *unshapedType(existing->type()) == *unshapedType(new_value->type()),
       "Types must be strictly equal if you are replacing aliasing information. ",
       "Got existing: '",
-      existing->type()->python_str(),
+      existing->type()->repr_str(),
       "', new_value: '",
-      new_value->type()->python_str(),
+      new_value->type()->repr_str(),
       "'");
   if (!isMutableTypeInternal(existing)) {
     return;
@@ -1099,9 +1099,9 @@ void AliasDb::copyValue(Value* from, Value* to) {
       *unshapedType(from->type()) == *unshapedType(to->type()),
       "Types must be strictly equal if you are copying aliasing information. ",
       "Got from: '",
-      from->type()->python_str(),
+      from->type()->repr_str(),
       "', to: '",
-      to->type()->python_str(),
+      to->type()->repr_str(),
       "'");
   if (!isMutableTypeInternal(to)) {
     return;
@@ -1557,8 +1557,8 @@ void Lint(const AliasDb* db) {
     auto it = db->elementMap_.find(v);
     if (it == db->elementMap_.end()) {
       failed = true;
-      ss << "Value %" << v->debugName() << " of type "
-         << v->type()->python_str() << " wasn't found in the element map.\n"
+      ss << "Value %" << v->debugName() << " of type " << v->type()->repr_str()
+         << " wasn't found in the element map.\n"
          << "It was defined in " << *v->node();
     }
   }

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1599,9 +1599,9 @@ Node* Graph::createList(const TypePtr& elem_type, at::ArrayRef<Value*> values) {
     TORCH_CHECK(
         v->type()->isSubtypeOf(elem_type),
         "Expected a list element that subtypes '",
-        elem_type->python_str(),
+        elem_type->repr_str(),
         "' but got an element of type '",
-        v->type()->python_str(),
+        v->type()->repr_str(),
         "'");
   }
   n->output()->setType(ListType::create(elem_type));
@@ -1714,7 +1714,7 @@ Value* Graph::insertToList(Value* v, TypePtr type) {
   } else {
     TORCH_CHECK(
         false,
-        ptr->python_str(),
+        ptr->repr_str(),
         " is not one of the supported element types for tolist: int, float, bool");
   }
 

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -368,10 +368,9 @@ void IRParser::parseOperator(Block* b) {
         if (!schema_return_type->hasFreeVariables() &&
             !v.type->isSubtypeOf(schema_return_type)) {
           throw ErrorReport(source_range)
-              << "Annotated type " << v.type->python_str()
+              << "Annotated type " << v.type->repr_str()
               << " does not match schema type "
-              << schema_return_type->python_str() << " for operator "
-              << *schema;
+              << schema_return_type->repr_str() << " for operator " << *schema;
         }
         vmap[v.name]->setType(v.type);
       }

--- a/torch/csrc/jit/passes/lower_graph.cpp
+++ b/torch/csrc/jit/passes/lower_graph.cpp
@@ -136,7 +136,7 @@ static std::vector<IValue> loadTensors(const std::vector<Slot>& slots) {
                getCustomClass(
                    "__torch__.torch.classes.quantized.LinearPackedParamsBase")),
           "Unknown type ",
-          type->python_str(),
+          type->repr_str(),
           " encountered in graph lowering. This type is not supported in ONNX export.");
       result.emplace_back(
           script::Object(obj.toObject()).run_method("__getstate__"));

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -351,9 +351,9 @@ inline InferredType tryToInferContainerType(py::handle input) {
       if (!unified_key) {
         return InferredType(c10::str(
             "Dictionary inputs to traced functions must have consistent type. Found ",
-            key_type->python_str(),
+            key_type->repr_str(),
             " and ",
-            (entry_key_type_match.type())->python_str()));
+            (entry_key_type_match.type())->repr_str()));
       }
 
       // Try to infer the value type and unify it with the existing one
@@ -366,9 +366,9 @@ inline InferredType tryToInferContainerType(py::handle input) {
       if (!unified_value) {
         return InferredType(c10::str(
             "Dictionary inputs to traced functions must have consistent type. Found ",
-            value_type->python_str(),
+            value_type->repr_str(),
             " and ",
-            (entry_value_type_match.type())->python_str()));
+            (entry_value_type_match.type())->repr_str()));
       }
 
       key_type = *unified_key;
@@ -395,9 +395,9 @@ inline InferredType tryToInferContainerType(py::handle input) {
       if (!unified_type) {
         return InferredType(c10::str(
             "List inputs to traced functions must have consistent element type. Found ",
-            element_type->python_str(),
+            element_type->repr_str(),
             " and ",
-            (element_type_match.type())->python_str()));
+            (element_type_match.type())->repr_str()));
       }
       element_type = *unified_type;
     }
@@ -453,7 +453,7 @@ inline Stack toTraceableStack(const py::tuple& inputs) {
   TORCH_CHECK(
       isTraceableType(info.type()),
       "Type '",
-      info.type()->python_str(),
+      info.type()->repr_str(),
       "' cannot be traced. Only Tensors and (possibly nested) Lists, Dicts, and"
       " Tuples of Tensors can be traced");
   return info.toTuple()->elements();
@@ -542,7 +542,7 @@ inline IValue toIValue(
             "Object ",
             py::str(obj),
             " had a different number of elements than type ",
-            type->python_str()));
+            type->repr_str()));
       }
       std::vector<IValue> values;
       values.reserve(tuple_size);
@@ -669,7 +669,7 @@ inline IValue toIValue(
             "Object ",
             py::str(obj),
             " is not compatible with interface ",
-            interfaceType->python_str(),
+            interfaceType->repr_str(),
             "\n",
             why_not.str()));
       }
@@ -694,7 +694,7 @@ inline IValue toIValue(
         return py::cast<double>(obj);
       } else {
         throw py::cast_error(
-            c10::str("Cannot cast ", py::str(obj), " to ", type->python_str()));
+            c10::str("Cannot cast ", py::str(obj), " to ", type->repr_str()));
       }
     }
     case TypeKind::RRefType: {
@@ -726,7 +726,7 @@ inline IValue toIValue(
       break;
   }
   throw py::cast_error(c10::str(
-      "toIValue() cannot handle converting to type: ", type->python_str()));
+      "toIValue() cannot handle converting to type: ", type->repr_str()));
 }
 
 // Small wrapper around getting the type name string from Python to make

--- a/torch/csrc/jit/python/python_custom_class.cpp
+++ b/torch/csrc/jit/python/python_custom_class.cpp
@@ -18,7 +18,7 @@ py::object ScriptClass::__call__(py::args args, py::kwargs kwargs) {
       fmt::format(
           "Custom C++ class: '{}' does not have an '__init__' method bound. "
           "Did you forget to add '.def(torch::init<...>)' to its registration?",
-          instance.type()->python_str()));
+          instance.type()->repr_str()));
   Method init_method(instance._ivalue(), init_fn);
   invokeScriptMethodFromPython(init_method, std::move(args), std::move(kwargs));
   return py::cast(instance);

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -641,7 +641,7 @@ void initPythonIRBindings(PyObject* module_) {
 
   using ::c10::Type;
   py::class_<Type, std::shared_ptr<Type>>(m, "Type")
-      .def("__repr__", [](Type& t) { return t.python_str(); })
+      .def("__repr__", [](Type& t) { return t.annotation_str(); })
       .def(
           "str",
           [](Type& t) {

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -671,7 +671,7 @@ TypePtr registerNamedTuple(const py::object& obj, const SourceRange& loc) {
     TORCH_CHECK(
         type->isSubtypeOf(tt),
         "Can't to redefine NamedTuple: ",
-        tt->python_str());
+        tt->repr_str());
     return type;
   }
   get_python_cu()->register_type(tt);

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -260,7 +260,7 @@ FunctionSchema getSchemaWithNameAndDefaults(
       c10::optional<IValue> value = tryCalculateDefaultParam(arg, it->second);
       if (!value) {
         ErrorReport error(range);
-        error << "Expected a default value of type " << arg.type()->python_str()
+        error << "Expected a default value of type " << arg.type()->repr_str()
               << " on parameter \"" << arg.name() << "\".";
         if (arg.is_inferred_type()) {
           error << "Because \"" << arg.name()
@@ -799,7 +799,7 @@ void initJitScriptBindings(PyObject* module) {
                   TORCH_INTERNAL_ASSERT(
                       setstate_schema.arguments().size() == 2,
                       "__setstate__ method for class ",
-                      class_type->python_str(),
+                      class_type->repr_str(),
                       " must have exactly 2 arguments!");
                   auto state_type = setstate_schema.arguments().at(1).type();
                   (*setstate_method)(Stack{toIValue(state, state_type)});

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -158,7 +158,7 @@ IValue tensorToListRecursive(
     } else {
       TORCH_CHECK(
           false,
-          ty->python_str(),
+          ty->repr_str(),
           " is not one of the supported types for tolist: int, float, bool");
     }
   }

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -1319,16 +1319,16 @@ Function* checkSortSchema(const c10::TypePtr& list_element_type) {
         return method;
       }
     }
-    error_str << "To sort a list of " << class_type->python_str()
+    error_str << "To sort a list of " << class_type->repr_str()
               << " it must define a "
               << "__lt__ method with two inputs of type "
-              << class_type->python_str() << " that "
+              << class_type->repr_str() << " that "
               << "returns a bool";
   } else {
-    error_str << "To sort a list of " << list_element_type->python_str()
+    error_str << "To sort a list of " << list_element_type->repr_str()
               << " must be of Tensors, ints, floats, bools or "
               << "a User Defined Class that defines the __lt__ compare method"
-              << ", got list of " << list_element_type->python_str() << "\n";
+              << ", got list of " << list_element_type->repr_str() << "\n";
   }
   throw std::runtime_error(error_str.str());
 }

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -31,7 +31,7 @@ void checkListInputType(const c10::TypePtr& elem_type, bool empty_list) {
       elem_type != BoolType::get()) {
     std::stringstream error;
     error << "Input must be of ints, floats, or bools, "
-          << "got " << elem_type->python_str();
+          << "got " << elem_type->repr_str();
     // special case empty list torch.tensor([])
     if (elem_type->isSubtypeOf(TensorType::get())) {
       if (empty_list) {
@@ -220,11 +220,11 @@ int createTensorFromList(Stack& stack) {
       tensor.numel() == 0) {
     TORCH_WARN(
         "Creating a tensor from an empty ",
-        elem_type->python_str(),
+        elem_type->repr_str(),
         "list will create a tensor of default floating point type  (currently ",
         default_type,
         ") in python but a tensor of type ",
-        elem_type->python_str(),
+        elem_type->repr_str(),
         " in torchscript.\n",
         "Pass in a dtype argument to ensure consistent behavior");
   }

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -111,7 +111,7 @@ c10::IValue getFunctionTuple(const Function& func) {
   std::vector<IValue> types;
   types.reserve(code.type_table().size());
   for (const TypePtr& t : code.type_table()) {
-    types.emplace_back(t->python_str());
+    types.emplace_back(t->annotation_str());
   }
 
   // since the register location is embedded into the bytecode, pass the

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -50,7 +50,7 @@ void postSetStateValidate(const IValue& v) {
               "The field '{}' was left uninitialized after '__setstate__', "
               "but expected a value of type '{}'",
               attrName,
-              attrType->python_str()));
+              attrType->repr_str()));
     }
   }
 }

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -356,7 +356,7 @@ Module ScriptModuleDeserializer::LEGACY_convertModule(
           module_type->getAttributeName(i),
           "' was left unitialized after __setstate__, but expected a ",
           "value of type '",
-          v.type()->python_str(),
+          v.type()->repr_str(),
           "'");
     }
   }

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -497,7 +497,7 @@ void Pickler::endTypeTag(const IValue& ivalue) {
 
   // Push the dict type
   TORCH_INTERNAL_ASSERT(ivalue.type());
-  pushString(ivalue.type()->python_str());
+  pushString(ivalue.type()->annotation_str());
 
   // Pop the dict and type into a tuple
   push<PickleOpCode>(PickleOpCode::TUPLE2);
@@ -658,7 +658,7 @@ bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls) {
   TORCH_CHECK(
       set_schema.returns().at(0).type()->isSubtypeOf(NoneType::get()),
       "'__setstate__' must return None, but found value of type",
-      set_schema.returns().at(0).type()->python_str());
+      set_schema.returns().at(0).type()->annotation_str());
 
   // Check that the return type of __getstate__ matches the input to
   // __setstate__
@@ -668,9 +668,9 @@ bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls) {
   TORCH_CHECK(
       get_type->isSubtypeOf(set_type),
       "'__getstate__'s return type (",
-      get_type->python_str(),
+      get_type->annotation_str(),
       ") does not match '__setstate__'s argument type (",
-      set_type->python_str(),
+      set_type->annotation_str(),
       ")");
 
   return true;

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -149,7 +149,7 @@ void restoreContainerTypeTags(IValue& ivalue, TypePtr type) {
   } else if (auto list_type = type->cast<ListType>()) {
     ivalue.toList().unsafeSetElementType(list_type->getElementType());
   } else {
-    AT_ERROR("Unknown type for tag restoration: " + type->python_str());
+    AT_ERROR("Unknown type for tag restoration: " + type->annotation_str());
   }
 }
 

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -202,7 +202,7 @@ class class_ {
     TORCH_CHECK(
         *first_arg_type == *classTypePtr,
         "self argument of __getstate__ must be the custom class type. Got ",
-        first_arg_type->python_str());
+        first_arg_type->repr_str());
     TORCH_CHECK(
         getstate_schema.returns().size() == 1,
         "__getstate__ should return exactly one value for serialization. Got: ",
@@ -214,9 +214,9 @@ class class_ {
         (*arg_type == *ser_type),
         "__setstate__'s argument should be the same type as the "
         "return value of __getstate__. Got ",
-        arg_type->python_str(),
+        arg_type->repr_str(),
         " but expected ",
-        ser_type->python_str());
+        ser_type->repr_str());
 
     return *this;
   }


### PR DESCRIPTION
Clearly expressing a type is inferred by PyTorch instead of explicitly annotated by user makes many error messages more user-friendly

Currently Type has two string conversion methods. str() for IR printing and python_str() for serialization and error message generation. If we want to include more information in type printing while maintaining serialization/deserialization correctness, we need to split python_str() into annotation_str() and repr_str(). 

annotation_str is solely responsible for serialization, it strictly matches format of python type annotation. repr_str() is responsible for generating a human-readable error message that includes information like "this type is inferred, not explicitly annotated"

Closes #39449 