### PR TITLE
Delete duplicate `with-gil` key from FunctionOption

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -513,7 +513,6 @@ FunctionOption = TypedDict('FunctionOption', {
     'type_definition_body': List[str],
     'type_method_definition_dispatch': str,
     'variants': str,
-    'with_gil': bool,
 })
 
 OutputDeclaration = NamedTuple('OutputDeclaration', [


### PR DESCRIPTION
This triggers `aten/src/ATen/function_wrapper.py:553: error: Duplicate TypedDict key "with_gil"` error during mypy typecheck

Not sure why it passes quick-checks on master but fails in 1.5.0 branch.
From https://github.com/pytorch/pytorch/pull/39547/checks#step:9:17
```
Collecting mypy
  Downloading mypy-0.780-cp38-cp38-manylinux1_x86_64.whl (21.1 MB)
Collecting mypy-extensions
  Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
Collecting typing-extensions>=3.7.4
  Downloading typing_extensions-3.7.4.2-py3-none-any.whl (22 kB)
Collecting typed-ast<1.5.0,>=1.4.0
  Downloading typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl (768 kB)
Installing collected packages: typing-extensions, typed-ast, mypy-extensions, mypy
Successfully installed mypy-0.780 mypy-extensions-0.4.3 typed-ast-1.4.1 typing-extensions-3.7.4.2
aten/src/ATen/function_wrapper.py:553: error: Duplicate TypedDict key "with_gil"
Found 1 error in 1 file (checked 1 source file)
```

