### PR TITLE
[v1.5.1] Check illegal output dtype for torch.{min, max} (#38850)

### DIFF
--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -1,5 +1,4 @@
-#include <ATen/native/cpu/TensorCompareKernel.h>
-#include <ATen/native/cpu/Loops.h>
+#include <ATen/native/TensorCompare.h>
 
 #include <numeric>
 #include <iterator>
@@ -9,109 +8,156 @@
 #include <ATen/Parallel.h>
 #include <ATen/NumericUtils.h>
 #include <c10/util/Optional.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/cpu/zmath.h>
+#include <ATen/native/cpu/Loops.h>
 
 namespace at { namespace native { namespace {
 
-template <typename scalar_t, typename index_t>
-struct Reduction {
-  static void apply(
-      Tensor& res,
-      Tensor& res_indices,
-      const Tensor& self,
-      c10::optional<int64_t> dim,
-      bool greater) {
-    auto out_ = res.data_ptr<scalar_t>();
-    auto indices_ = res_indices.data_ptr<index_t>();
-    auto data_ = self.data_ptr<scalar_t>();
-    auto numel = self.numel();
-
-    int64_t n = self.size(*dim);
-    int64_t stride = self.stride(*dim);
-
-    if (n == 1) {
-      stride = 1;
-      for (int64_t i = self.ndimension() - 1; i > *dim; i--) {
-        stride *= self.size(i);
-      }
-    }
-    int64_t batch = numel / (n * stride);
-    using value_t = typename ztype<scalar_t>::value_t;
-    value_t (*zabs_)(scalar_t) = zabs<scalar_t, value_t>;
-    if (stride == 1) {
-      parallel_for(0, batch, 1, [=](int64_t begin, int64_t end) {
-        for (int64_t b = begin; b < end; b++) {
-          const scalar_t* data = &data_[b * n];
-          scalar_t result = data[0];
-          index_t result_index = 0;
-          for (int64_t k = 0; k < n; k++) {
-            scalar_t value = data[k];
-            bool cmp = greater ? (zabs_(result) > zabs_(value)) : (zabs_(result) < zabs_(value));
-            result = cmp ? result : value;
-            result_index = cmp ? result_index : k;
-            if (_isnan<scalar_t>(result)) {
-              break;
-            }
-          }
-          out_[b] = result;
-          indices_[b] = result_index;
-        }
-      });
-    } else {
-      parallel_for(0, batch * stride, 1, [=](int64_t begin, int64_t end) {
-        for (int64_t bi = begin; bi < end; bi++) {
-          int64_t b = bi / stride;
-          int64_t i = bi % stride;
-          const scalar_t* data = &data_[b * n * stride + i];
-          scalar_t result = data[0];
-          index_t result_index = 0;
-          for (int64_t k = 0; k < n; k++) {
-            scalar_t value = data[k * stride];
-            bool cmp = greater ? (zabs_(result) > zabs_(value)) : (zabs_(result) < zabs_(value));
-            result = cmp ? result : value;
-            result_index = cmp ? result_index : k;
-            if (_isnan<scalar_t>(result)) {
-              break;
-            }
-          }
-          out_[b * stride + i] = result;
-          indices_[b * stride + i] = result_index;
-        }
-      });
-    }
-  }
-};
-
-static void max_kernel_impl(
-    Tensor& max,
-    Tensor& max_indices,
+template <typename scalar_t, typename func_t>
+static inline void compare_base_kernel(Tensor& result, Tensor& indice,
     const Tensor& self,
-    c10::optional<int64_t> dim) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(ScalarType::Bool, self.scalar_type(), "max", [&] {
-    Reduction<scalar_t, int64_t>::apply(max, max_indices, self, dim, true);
-  });
+    int64_t dim,
+    bool keepdim,
+    const func_t& f) {
+  const int64_t input_ndim = self.dim();
+  auto self_sizes = ensure_nonempty_vec(self.sizes().vec());
+  self_sizes[dim] = 1;
+
+  // result and indice may be a empty tensor, if not,
+  // reshape them as self dims
+  if (0 == result.numel()) {
+    result.resize_(self_sizes);
+  } else {
+    //error out if result cannot be viewed as desired size
+    auto result_view = result.view(self_sizes);
+    result.set_(result_view);
+  }
+  if (0 == indice.numel()) {
+    indice.resize_(self_sizes);
+  } else {
+    auto indices_view = indice.view(self_sizes);
+    indice.set_(indices_view);
+  }
+
+  auto self_dim_stride = ensure_nonempty_stride(self, dim);
+
+  auto iter = TensorIterator();
+  iter.dont_compute_common_dtype();
+  iter.dont_resize_outputs();
+  iter.declare_static_shape(self.sizes(), /*squash_dim=*/dim);
+  iter.add_output(result);
+  iter.add_output(indice);
+  iter.add_input(self);
+  iter.build();
+
+  auto loop = [&](char** data, const int64_t* strides, int64_t n) {
+    auto* result_data_bytes = data[0];
+    auto* indice_data_bytes = data[1];
+    const auto* self_data_bytes = data[2];
+    for (int64_t i = 0; i < n; ++i) {
+      f(
+        (scalar_t*)result_data_bytes, (int64_t*)indice_data_bytes,
+        (scalar_t*)self_data_bytes, self_dim_stride
+      );
+      result_data_bytes += strides[0];
+      indice_data_bytes += strides[1];
+      self_data_bytes += strides[2];
+    }
+  };
+  iter.for_each(loop, /* grain_size */ 1);
+
+  if (!keepdim) {
+    result.squeeze_(dim);
+    indice.squeeze_(dim);
+  }
 }
 
 static void min_kernel_impl(
-    Tensor& min,
-    Tensor& min_indices,
+    Tensor& result,
+    Tensor& indice,
     const Tensor& self,
-    c10::optional<int64_t> dim) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(ScalarType::Bool, self.scalar_type(), "min", [&] {
-    Reduction<scalar_t, int64_t>::apply(min, min_indices, self, dim, false);
+    int64_t dim,
+    bool keepdim) {
+  auto wrap_dim = maybe_wrap_dim(dim, self.dim());
+  int64_t self_dim_size = ensure_nonempty_size(self, wrap_dim);
+
+  TORCH_CHECK(result.scalar_type() == self.scalar_type() && indice.scalar_type() == kLong,
+    "Expect dtype ", self.scalar_type(), "and torch.long, but got ", result.scalar_type(), "and", indice.scalar_type());
+
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(ScalarType::Bool, self.scalar_type(), "min_cpu", [&] {
+    compare_base_kernel<scalar_t>(result, indice, self, wrap_dim, keepdim, [&] (
+      scalar_t* result_data, int64_t* indice_data,
+      const scalar_t* self_data, auto self_dim_stride) {
+        using value_t = typename c10::scalar_value_type<scalar_t>::type;
+        value_t (*zabs_)(scalar_t) = zabs<scalar_t, value_t>;
+        scalar_t min_number = self_data[0];
+        int64_t index = 0;
+        for (int64_t i = 0; i < self_dim_size; ++i) {
+          scalar_t value = self_data[i * self_dim_stride];
+          if (!(zabs_(value) >= zabs_(min_number))) {
+            min_number = value;
+            index = i;
+            if (_isnan<scalar_t>(value)) {
+              break;
+            }
+          }
+        }
+        *result_data = min_number;
+        *indice_data = index;
+      }
+    );
+  });
+}
+
+static void max_kernel_impl(
+    Tensor& result,
+    Tensor& indice,
+    const Tensor& self,
+    int64_t dim,
+    bool keepdim) {
+  auto wrap_dim = maybe_wrap_dim(dim, self.dim());
+  int64_t self_dim_size = ensure_nonempty_size(self, wrap_dim);
+
+  TORCH_CHECK(result.scalar_type() == self.scalar_type() && indice.scalar_type() == kLong,
+    "Expect dtype ", self.scalar_type(), "and torch.long, but got ", result.scalar_type(), "and", indice.scalar_type());
+
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(ScalarType::Bool, self.scalar_type(), "max_cpu", [&] {
+    compare_base_kernel<scalar_t>(result, indice, self, wrap_dim, keepdim, [&] (
+      scalar_t* result_data, int64_t* indice_data,
+      const scalar_t* self_data, auto self_dim_stride) {
+        using value_t = typename c10::scalar_value_type<scalar_t>::type;
+        value_t (*zabs_)(scalar_t) = zabs<scalar_t, value_t>;
+        scalar_t max_number = self_data[0];
+        int64_t index = 0;
+        for (int64_t i = 0; i < self_dim_size; ++i) {
+          scalar_t value = self_data[i * self_dim_stride];
+          if (!(zabs_(value) <= zabs_(max_number))) {
+            max_number = value;
+            index = i;
+            if (_isnan<scalar_t>(value)) {
+              break;
+            }
+          }
+        }
+        *result_data = max_number;
+        *indice_data = index;
+      }
+    );
   });
 }
 
 static void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX(iter.dtype(), "where_cpu", [&] {
     if (condition_type == at::ScalarType::Byte) {
-      at::native::cpu_kernel(
+      cpu_kernel(
         iter,
         [=](uint8_t cond_val, scalar_t self_val, scalar_t other_val) -> scalar_t {
           return cond_val ? self_val : other_val;
         });
     } else {
-      at::native::cpu_kernel(
+      cpu_kernel(
         iter,
         [=](bool cond_val, scalar_t self_val, scalar_t other_val) -> scalar_t {
           return cond_val ? self_val : other_val;
@@ -122,8 +168,8 @@ static void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
 
 } // anonymous namespace
 
-REGISTER_DISPATCH(max_kernel, &max_kernel_impl);
-REGISTER_DISPATCH(min_kernel, &min_kernel_impl);
+REGISTER_DISPATCH(max_stub, &max_kernel_impl);
+REGISTER_DISPATCH(min_stub, &min_kernel_impl);
 REGISTER_DISPATCH(where_kernel, &where_kernel_impl);
 
 }} // namespace at::native

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8516,6 +8516,28 @@ class TestTorchDeviceType(TestCase):
         run_test((4, 4), (2, 1, 3, 4, 2))  # broadcasting A
         run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5))  # broadcasting A & b
 
+    def test_minmax_illegal_dtype(self, device):
+        x = torch.randn(5, 5, dtype=torch.float32, device=device)
+        valid_values = torch.empty(5, dtype=torch.float32, device=device)
+        valid_indices = torch.empty(5, dtype=torch.long, device=device)
+        illegal_values = torch.empty(5, dtype=torch.int, device=device)
+        illegal_indices = torch.empty(5, dtype=torch.double, device=device)
+        torch.max(x, dim=0, out=(valid_values, valid_indices))
+        torch.min(x, dim=0, out=(valid_values, valid_indices))
+        rmsg = r'scalar type|dtype'
+        with self.assertRaisesRegex(RuntimeError, rmsg):
+            torch.max(x, dim=0, out=(illegal_values, valid_indices))
+        with self.assertRaisesRegex(RuntimeError, rmsg):
+            torch.min(x, dim=0, out=(illegal_values, valid_indices))
+        with self.assertRaisesRegex(RuntimeError, rmsg):
+            torch.max(x, dim=0, out=(valid_values, illegal_indices))
+        with self.assertRaisesRegex(RuntimeError, rmsg):
+            torch.min(x, dim=0, out=(valid_values, illegal_indices))
+        with self.assertRaisesRegex(RuntimeError, rmsg):
+            torch.max(x, dim=0, out=(illegal_values, illegal_indices))
+        with self.assertRaisesRegex(RuntimeError, rmsg):
+            torch.min(x, dim=0, out=(illegal_values, illegal_indices))
+
     def test_dim_reduction(self, device):
         example = [[-1, 2, 1], [5, 3, 6]]
 


### PR DESCRIPTION
Summary:
The test is currently only enabled for CPU, and it will be enabled for CUDA after the migration of `min` and `max` from THC to ATen is done.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/38850

Differential Revision: D21819388

Pulled By: ngimel

fbshipit-source-id: 406343e96bccbf9139eb1f8f2d49ed530dd83d62

