### PR TITLE
[Selective build] Query based build mode support for android_binary_for_automation

### DIFF
--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -1,7 +1,9 @@
 // required for old g++ to compile PRId64 macros, see
 // https://github.com/pytorch/pytorch/issues/3571
 // for context
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include <ATen/${Type}.h>
 


### PR DESCRIPTION
Summary: As title. This diff adds an additional parameter enable_pt_codegen to android_binary_for_automation so it supports generating selective build operators for Pytorch mobile by executing a deps query at the binary level. This is done so that only required operators in the dependency tree are included in the build. This includes both forward operators used for inference and backward operators used for training.

Test Plan:
buck install -c pt.selective_build=0 -c pt.build_from_deps_query=1 -c pt.static_dispatch=0 fb4a
buck install fb4a

Reviewed By: iseeyuan

Differential Revision: D21446010

