### PR TITLE
lint cleanup and renamed TestGraphModePostTrainingStatic to TestQuantizeScript

### DIFF
--- a/test/quantization/test_quantize.py
+++ b/test/quantization/test_quantize.py
@@ -1,4 +1,3 @@
-import unittest
 import torch
 import torch.nn as nn
 import torch.nn.quantized as nnq
@@ -7,42 +6,25 @@ import torch.nn.intrinsic.quantized as nniq
 import torch.nn.intrinsic.qat as nniqat
 from torch.nn.utils.rnn import PackedSequence
 from torch.quantization import (
-    quantize, # remove?
+    quantize,
     prepare,
     convert,
     prepare_qat,
     quantize_qat,
     fuse_modules,
-    quantize_dynamic, # remove?
+    quantize_dynamic,
     QuantWrapper,
     QConfig,
     default_qconfig,
-    default_per_channel_qconfig, # remove?
     default_qat_qconfig,
     default_dynamic_qconfig,
     per_channel_dynamic_qconfig,
-    default_eval_fn,
     float16_dynamic_qconfig,
-    default_observer,
-    default_weight_observer, # remove?
-    default_per_channel_weight_observer,
-    default_histogram_observer,
-)
-
-from torch.quantization.quantize_script import (
-    quantize_script,
-    quantize_dynamic_script
 )
 
 from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
-    AnnotatedSingleLayerLinearModel, # remove?
-    SingleLayerLinearModel, # remove?
-    AnnotatedConvModel, # remove?
-    ConvModel, # remove?
-    AnnotatedConvBnModel,
-    ConvBnModel,
-    SkipQuantModel, # remove?
+    AnnotatedSingleLayerLinearModel,
     QuantStubModel,
     ModelForFusion,
     ModelWithSequentialFusion,
@@ -53,14 +35,14 @@ from torch.testing._internal.common_quantization import (
     ModelMultipleOpsNoAvgPool,
     SingleLayerLinearDynamicModel,
     TwoLayerLinearModel,
-    NestedModel, #remove?
+    NestedModel,
     ResNetBase,
     LSTMDynamicModel,
     ModelForFusionWithBias,
     ActivationsTestModel,
     ActivationsQATTestModel,
     NormalizationTestModel,
-    test_only_eval_fn, # remove?
+    test_only_eval_fn,
     test_only_train_fn,
     prepare_dynamic,
     convert_dynamic,

--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -2382,7 +2382,7 @@ class TestQuantizeDynamicScript(QuantizationTestCase):
                    .check_not("aten::_choose_qparams_per_tensor") \
                    .run(model.graph)
 
-class TestGraphModePostTrainingStatic(QuantizationTestCase):
+class TestQuantizeScript(QuantizationTestCase):
     def test_single_linear(self):
         r"""Compare the result of quantizing single linear layer in
         eager mode and graph mode

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -52,7 +52,7 @@ from quantization.test_quantize import TestModelNumerics  # noqa: F401
 from quantization.test_quantize_script import TestQuantizeScriptJitPasses  # noqa: F401
 from quantization.test_quantize_script import TestQuantizeScriptPTSQOps  # noqa: F401
 from quantization.test_quantize_script import TestQuantizeDynamicScript  # noqa: F401
-from quantization.test_quantize_script import TestGraphModePostTrainingStatic  # noqa: F401
+from quantization.test_quantize_script import TestQuantizeScript  # noqa: F401
 
 
 # Tooling: numric_suite


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39583 lint cleanup and renamed TestGraphModePostTrainingStatic to TestQuantizeScript**
* #39538 test refactoring T67625393

Differential Revision: [D21905148](https://our.internmc.facebook.com/intern/diff/D21905148)