### PR TITLE
fix input schema check for spatialbn

### DIFF
--- a/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/spatial_batch_norm_fp16_fake_op.cc
@@ -7,9 +7,9 @@
 namespace caffe2 {
 
 REGISTER_CPU_OPERATOR(SpatialBNFakeLoweredFp16NNPI, SpatialBNFakeLoweredFp16Op);
-OPERATOR_SCHEMA(SpatialBNFakeLoweredFp16NNPI).NumInputs({1, 3}).NumOutputs(1);
+OPERATOR_SCHEMA(SpatialBNFakeLoweredFp16NNPI).NumInputs({1, 5}).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(SpatialBNFakeFp16NNPI, SpatialBNFakeFp16Op);
-OPERATOR_SCHEMA(SpatialBNFakeFp16NNPI).NumInputs({1, 3}).NumOutputs(1);
+OPERATOR_SCHEMA(SpatialBNFakeFp16NNPI).NumInputs({1, 5}).NumOutputs(1);
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
we were restricting it to 3, but in training we set up to 5, even that
in practice we just need 3 since we don't recompute mean/var

Test Plan: contrib tests for fakelowp

Reviewed By: hl475

Differential Revision: D21905490

