### PR TITLE
Implement mapping from logical dims to physical dims

### DIFF
--- a/aten/src/ATen/BatchingArgTransforms.cpp
+++ b/aten/src/ATen/BatchingArgTransforms.cpp
@@ -3,6 +3,15 @@
 
 namespace at {
 
+// Creates a bitset for all of the levels present in `bdims`.
+std::bitset<kVmapNumLevels> createLevelsBitset(BatchDimsRef bdims) {
+  std::bitset<kVmapNumLevels> result;
+  for (const auto& bdim : bdims) {
+    result.set(bdim.level());
+  }
+  return result;
+}
+
 // Checks if the batch dims in `bdims` appear at the front of the tensor.
 static bool areBdimsAtFrontInOrder(BatchDimsRef bdims) {
   for (int64_t idx = 0; idx < bdims.size(); idx++) {
@@ -43,12 +52,35 @@ PhysicalView MultiBatchArgTransform::logicalToPhysical(const Tensor& logical_ten
   TORCH_INTERNAL_ASSERT(
       batched,
       "logicalToPhysical(tensor) should only be passed a BatchedTensor");
-  return { permuteBatchDimsToFront(batched) };
+  return { permuteBatchDimsToFront(batched), createLevelsBitset(batched->bdims()) };
 }
 
 std::vector<PhysicalView>
 MultiBatchArgTransform::logicalToPhysical(TensorList logical_tensors) {
   TORCH_INTERNAL_ASSERT(false, "NYI");
 }
+
+int64_t PhysicalView::numBatchDims() {
+  return levels_.count();
+}
+
+int64_t PhysicalView::numLogicalDims() {
+  return /*physical*/tensor_.dim() - numBatchDims();
+}
+
+std::vector<int64_t> PhysicalView::getPhysicalDims(IntArrayRef logical_dims) {
+  auto logical_ndim = numLogicalDims();
+  return fmap(
+      logical_dims,
+      [&](int64_t dim) -> int64_t {
+          return maybe_wrap_dim(dim, logical_ndim) + numBatchDims();
+      });
+}
+
+int64_t PhysicalView::getPhysicalDim(int64_t logical_dim) {
+  auto logical_ndim = numLogicalDims();
+  return maybe_wrap_dim(logical_dim, logical_ndim) + numBatchDims();
+}
+
 
 } // namespace at

--- a/aten/src/ATen/test/vmap_test.cpp
+++ b/aten/src/ATen/test/vmap_test.cpp
@@ -183,5 +183,31 @@ TEST(VmapTest, TestMultiBatchArgTransform) {
     ASSERT_TRUE(at::allclose(result.tensor(), tensor.permute({1, 2, 0})));
   }
 }
+TEST(VmapTest, TestPhysicalViewGetPhysicalDim) {
+  PhysicalView physical_view(ones({2, 3, 4, 5, 6}), 1 | 4);
+
+  // Positive dims
+  ASSERT_EQ(physical_view.getPhysicalDim(0), 2);
+  ASSERT_EQ(physical_view.getPhysicalDim(1), 3);
+  ASSERT_EQ(physical_view.getPhysicalDim(2), 4);
+  ASSERT_THROW(physical_view.getPhysicalDim(3), c10::Error);
+
+  // Negative dims (testing wrap dim behavior)
+  ASSERT_EQ(physical_view.getPhysicalDim(-1), 4);
+  ASSERT_EQ(physical_view.getPhysicalDim(-2), 3);
+  ASSERT_EQ(physical_view.getPhysicalDim(-3), 2);
+  ASSERT_THROW(physical_view.getPhysicalDim(-4), c10::Error);
+}
+TEST(VmapTest, TestPhysicalViewGetPhysicalDims) {
+  PhysicalView physical_view(ones({2, 3, 4, 5, 6}), 2 | 8 | 16);
+
+  ASSERT_EQ(
+      physical_view.getPhysicalDims({0, 1, -1, -2}),
+      std::vector<int64_t>({3, 4, 4, 3}));
+
+  ASSERT_THROW(physical_view.getPhysicalDims({2, 0}), c10::Error);
+  ASSERT_THROW(physical_view.getPhysicalDims({0, -3}), c10::Error);
+}
+
 
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39595 Add batching rule for torch.sum(tensor, dims)
* #39594 Implement `PhysicalView::newLogicalFromPhysical(Tensor)`
* **#39593 Implement mapping from logical dims to physical dims**
* #39581 Introduce "ArgTransforms" abstractions for batching
* #39580 Impose maximum level restriction for BatchedTensors

This is implemented as `PhysicalView::getPhysicalDim(logical_dim)`
and `PhysicalView::getPhysicalDims(logical_dims)`.

Test Plan:
- `./build/bin/vmap_test`