### PR TITLE
Implement `PhysicalView::newLogicalFromPhysical(Tensor)`

### DIFF
--- a/aten/src/ATen/BatchingArgTransforms.h
+++ b/aten/src/ATen/BatchingArgTransforms.h
@@ -81,6 +81,10 @@ struct TORCH_API PhysicalView {
   std::vector<int64_t> getPhysicalDims(IntArrayRef logical_dims);
   int64_t getPhysicalDim(int64_t logical_dim);
 
+  // Maps a physical tensor to a new logical tensor (BatchedTensor),
+  // using the mapping info stored in this PhysicalView.
+  Tensor newLogicalFromPhysical(const Tensor& physical);
+
  private:
   int64_t numLogicalDims();
   int64_t numBatchDims();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39595 Add batching rule for torch.sum(tensor, dims)
* **#39594 Implement `PhysicalView::newLogicalFromPhysical(Tensor)`**
* #39593 Implement mapping from logical dims to physical dims
* #39581 Introduce "ArgTransforms" abstractions for batching
* #39580 Impose maximum level restriction for BatchedTensors

PhysicalView holds a physical Tensor and some metadata to map between
"physical" and "logical" arguments.

`physical_view.newLogicalFromPhysical(tensor)` transforms the (physical)
`tensor` into a logical Tensor (aka BatchedTensor), performing a
physical->logical map.

The map is not very difficult; we:
1. assume that `tensor` has its batch dimensions at the front
2. check that the batch dimensions are the same as
`physical_view.tensor()`'s batch dimensions
3. wrap `tensor` in a BatchedTensor and return it.

Test Plan:
- `./build/bin/vmap_test`