### PR TITLE
Add batching rule for torch.sum(tensor, dims)

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -1,0 +1,67 @@
+#include <torch/library.h>
+#include <ATen/BatchingArgTransforms.h>
+#include <ATen/ATen.h>
+
+namespace at {
+
+// NOTE: [What is a batching rule?]
+//
+// A *batching rule* implements the logic of how to call an operator on inputs
+// that have zero or more additional batch dimensions. When one does a vmap, the
+// dimension(s) being vmap'ed over get recorded as batch dimensions.
+//
+// For example, vmap(torch.add)(x, y)
+// 1. wraps `x` into batched_x = BatchedTensor(x, bdims=[(lvl=1, dim=0)];
+// 2. wraps `y` into batched_y = BatchedTensor(y, bdims=[(lvl=1, dim=0)];
+// 3. and then runs `torch.add(batched_x, batched_y)`.
+
+// NOTE: [When should I add a batching rule?]
+// When you are adding a new operator, you'll need to add a batching rule so
+// that vmap can work efficiently with said operator. If you do not, we'll attempt
+// to generate a slow fallback for the batching rule (this is not yet implemented).
+
+// NOTE: [How to write batching rules?]
+// The signature of a batching rule should look like exactly like the C++ signature
+// of its operator.
+//
+// At a high level, what a batching rule does is the following:
+// 1. Converts (logical) BatchedTensors to views on physical tensors.
+// 2. Converts logical arguments (e.g. dimension indexes, shapes) to physical
+//    arguments that correspond to the physical tensors.
+// 3. Calls at:: operations on the physical tensors and arguments to produce
+//    some physical results.
+// 4. Converts physical results back to BatchedTensors.
+//
+// Steps 1, 2, and 4 differ for operators with different batching behaviors. When
+// writing a new batching rule, please select an ArgTransform that matches the
+// batching behavior of your operation. The ArgTransform provides helper functions
+// to do steps (1), (2), and (4).
+// (see NOTE: [What is an ArgTransform?] in BatchingArgTransforms.h)
+
+// Note: [Future plans]
+// The API for writing a batching rule isn't stable. In the future, we'd like
+// to think about the problem of translating these batching rules to TorchScript.
+// Ideally batching rules in eager mode vs TorchScript would look pretty similar,
+// if not use the same mechanism. In order to accomplish that we might have to
+// do some refactoring.
+
+Tensor sum_batching_rule(const Tensor& self, IntArrayRef dims, bool keepdim, optional<ScalarType> dtype) {
+  auto self_physical = MultiBatchArgTransform::logicalToPhysical(self);
+  auto dims_physical = self_physical.getPhysicalDims(dims);
+  auto result = at::sum(self_physical.tensor(), dims_physical, keepdim, dtype);
+  return self_physical.newLogicalFromPhysical(result);
+}
+
+void batchedTensorFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
+  TORCH_CHECK(false, "NYI: Calling ", op.schema().name(), " inside of vmap");
+}
+
+TORCH_LIBRARY_IMPL(_, Batched, m) {
+  m.fallback(torch::CppFunction::makeFromBoxedFunction<&batchedTensorFallback>());
+}
+
+TORCH_LIBRARY_IMPL(aten, Batched, m) {
+  m.impl_UNBOXED("sum.dim_IntList", sum_batching_rule);
+}
+
+} // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39595 Add batching rule for torch.sum(tensor, dims)**
* #39594 Implement `PhysicalView::newLogicalFromPhysical(Tensor)`
* #39593 Implement mapping from logical dims to physical dims
* #39581 Introduce "ArgTransforms" abstractions for batching
* #39580 Impose maximum level restriction for BatchedTensors

The batching rule uses the ArgTransform abstraction introduced in the
other PRs in this stack.

Test Plan:
- `./build/bin/vmap_test`