### PR TITLE
Wrap Caffe2's SparseLengthsSum into a PyTorch op

### DIFF
--- a/caffe2/operators/segment_reduction_op_gpu.cuh
+++ b/caffe2/operators/segment_reduction_op_gpu.cuh
@@ -1,0 +1,78 @@
+#include <cub/block/block_reduce.cuh>
+#include <cub/device/device_reduce.cuh>
+#include <cub/device/device_scan.cuh>
+#include "caffe2/core/context_gpu.h"
+
+
+#ifdef __HIP_PLATFORM_HCC__
+#define SEGREDUCE_MINBLOCKS 8
+#else
+#define SEGREDUCE_MINBLOCKS 16
+#endif
+
+namespace caffe2{
+
+template <
+    typename T,
+    typename IndexType,
+    bool ExactBlock = false,
+    bool Average = false>
+#ifdef __HIP_PLATFORM_HCC__
+C10_LAUNCH_BOUNDS_2(1024,SEGREDUCE_MINBLOCKS)
+#endif
+__global__ void sparse_length_sum_kernel(
+    const T* __restrict__ in,
+    T* __restrict__ out,
+    const int* __restrict__ prefix_sum_length_data,
+    const IndexType* __restrict__ indices,
+    int N,
+    int post,
+    int len_length,
+    int len_indices) {
+  // len_length blocks
+  int group = blockIdx.x;
+
+  int start = group == 0 ? 0 : prefix_sum_length_data[group - 1];
+  int end = prefix_sum_length_data[group];
+  CUDA_KERNEL_ASSERT(start <= len_indices);
+  CUDA_KERNEL_ASSERT(end <= len_indices);
+
+  extern __shared__ T reduceVals[];
+
+  if (ExactBlock) {
+    T sum = (T)0;
+
+    in += threadIdx.x;
+    for (int line = start + threadIdx.y; line < end; line += blockDim.y) {
+      sum += in[indices[line] * post];
+    }
+
+    reduceVals[threadIdx.y * blockDim.x + threadIdx.x] = sum;
+    __syncthreads();
+
+    if (threadIdx.y == 0) {
+      sum = (T)0;
+      for (int i = 0; i < blockDim.y; ++i) {
+        sum += reduceVals[i * blockDim.x + threadIdx.x];
+      }
+      if (Average && (end - start) > 1) {
+        sum /= (end - start);
+      }
+
+      out[group * post + threadIdx.x] = sum;
+    }
+  } else {
+    for (int i = threadIdx.x; i < post; i += blockDim.x) {
+      T sum = (T)0;
+      for (int line = start; line < end; ++line) {
+        sum += in[indices[line] * post + i];
+      }
+      if (Average && (end - start) > 1) {
+        sum /= (end - start);
+      }
+      out[group * post + i] = sum;
+    }
+  }
+}
+
+} //namespace caffe2

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -7995,6 +7995,7 @@ CAFFE2_SPECIFIC_MAPPINGS = collections.OrderedDict(
         ("/GpuBitonicSort", ("/hip/GpuBitonicSort", API_CAFFE2)),
         ("/math/reduce.cuh", ("/math/hip/reduce.cuh", API_CAFFE2)),
         ("/sgd/adagrad_fused_op_gpu.cuh", ("/sgd/hip/adagrad_fused_op_gpu.cuh", API_CAFFE2)),
+        ("/operators/segment_reduction_op_gpu.cuh", ("/operators/hip/segment_reduction_op_gpu.cuh", API_CAFFE2)),
         ("/gather_op.cuh", ("/hip/gather_op.cuh", API_CAFFE2)),
         ("caffe2/core/common_cudnn.h", ("caffe2/core/hip/common_miopen.h", API_CAFFE2)),
         ("REGISTER_CUDA_OPERATOR", ("REGISTER_HIP_OPERATOR", API_CAFFE2)),


### PR DESCRIPTION
Summary: This diff wraps Caffe2's SparseLengthsSum on GPU as a PT op.

Differential Revision: D21895309

