### PR TITLE
remove duplicated op schema for aten::pow

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -85,8 +85,13 @@ white_list = [
     ('quantized::linear', datetime.date(2020, 6, 1)),
     ('_aten::*', datetime.date(2020, 6, 1)),
     ('_prim::*', datetime.date(2020, 6, 1)),
+    ('aten::eq', datetime.date(2020, 6, 30)),
+    ('aten::nq', datetime.date(2020, 6, 30)),
+    ('aten::lt', datetime.date(2020, 6, 30)),
+    ('aten::gt', datetime.date(2020, 6, 30)),
+    ('aten::le', datetime.date(2020, 6, 30)),
+    ('aten::ge', datetime.date(2020, 6, 30)),
 ]
-
 
 # The nightly will fail to parse newly added syntax to schema declarations
 # Add new schemas that will fail the nightly here

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -91,7 +91,9 @@ white_list = [
     ('aten::gt', datetime.date(2020, 6, 30)),
     ('aten::le', datetime.date(2020, 6, 30)),
     ('aten::ge', datetime.date(2020, 6, 30)),
+    ('aten::pow', datetime.date(2020, 6, 30)),
 ]
+
 
 # The nightly will fail to parse newly added syntax to schema declarations
 # Add new schemas that will fail the nightly here

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1083,10 +1083,11 @@ void testRecordFunction() {
 
   // test set ids
   bool has_ids = false;
-  addGlobalCallback(RecordFunctionCallback(
-      [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
-      [](const RecordFunction&) {})
-      .needsIds(true));
+  addGlobalCallback(
+      RecordFunctionCallback(
+          [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
+          [](const RecordFunction&) {})
+          .needsIds(true));
   { RECORD_USER_SCOPE("test"); }
   TORCH_CHECK(has_ids);
   clearCallbacks();

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -37,9 +37,9 @@ bool InterpreterState::run(Stack& stack) {
       case OP: {
         if (at::hasGlobalCallbacks()) {
           if (auto debug_info = c10::ThreadLocalDebugInfo::get(
-                c10::DebugInfoKind::MOBILE_RUNTIME_INFO)) {
+                  c10::DebugInfoKind::MOBILE_RUNTIME_INFO)) {
             if (auto* mobile_debug_info =
-                dynamic_cast<MobileDebugInfo*>(debug_info.get())) {
+                    dynamic_cast<MobileDebugInfo*>(debug_info.get())) {
               mobile_debug_info->setOpIdx(pc);
             }
           }

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -40,8 +40,7 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   auto debug_info = std::make_shared<MobileDebugInfo>();
   debug_info->setModelName(name());
   debug_info->setMethodName(method_name);
-  at::DebugInfoGuard guard(
-      at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
+  at::DebugInfoGuard guard(at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
 
   auto m = find_method(method_name);
   if (m == nullptr) {

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -481,15 +481,15 @@ int listSetItem(Stack& stack);
       },                                                    \
       aliasAnalysisFromSchema())
 
-#define DEFINE_STR_CMP_OP(aten_op, op)     \
-  Operator(                                \
-      #aten_op "(str a, str b) -> bool",   \
-      [](Stack& stack) {                   \
-        auto b = pop(stack).toStringRef(); \
-        auto a = pop(stack).toStringRef(); \
-        push(stack, op);                   \
-        return 0;                          \
-      },                                   \
+#define DEFINE_STR_CMP_OP(aten_op, op)       \
+  Operator(                                  \
+      #aten_op ".str(str a, str b) -> bool", \
+      [](Stack& stack) {                     \
+        auto b = pop(stack).toStringRef();   \
+        auto a = pop(stack).toStringRef();   \
+        push(stack, op);                     \
+        return 0;                            \
+      },                                     \
       aliasAnalysisFromSchema())
 
 // define a primitive op over Scalar operands.

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -481,8 +481,14 @@ RegisterOperators reg(
          static_cast<double>(pow(a, b)),
          static_cast<double>(pow(a, b)),
          float),
-
-     DEFINE_BINARY_OP(aten::pow, pow(a, b)),
+     DEFINE_SCALAR_BINARY_OP(
+         aten::pow.Scalar,
+         static_cast<double>(pow(a, b)),
+         static_cast<double>(pow(a, b)),
+         Scalar),
+    DEFINE_INT_OP(
+         aten::pow.int_to_int,
+         pow(a, b)),
      // min and max are in prim:: because there is a difference between
      // the python builtin 'min' and 'torch.min'
      DEFINE_BINARY_OP(prim::min, a < b ? a : b),


### PR DESCRIPTION
Summary: Removed duplicated schema for aten::pow

Test Plan:
Previously there are many duplicated aten::pow

```
aten::pow.int(int a, int b) -> (float)
aten::pow.float(float a, float b) -> (float)
aten::pow.int_float(int a, float b) -> (float)
aten::pow.float_int(float a, int b) -> (float)
aten::pow(Scalar a, Scalar b) -> (float)
aten::pow.int(int a, int b) -> (int)  // duplicated name!
aten::pow.float(float a, float b) -> (float) // duplicated schema!
aten::pow.int_float(int a, float b) -> (float) // duplicated schema!
aten::pow.float_int(float a, int b) -> (float) // duplicated schema!
aten::pow(Scalar a, Scalar b) -> (Scalar) // duplicated name!
```

After this diff, there are only 7 overloaded ops:
```
aten::pow.int(int a, int b) -> (float)
aten::pow.float(float a, float b) -> (float)
aten::pow.int_float(int a, float b) -> (float)
aten::pow.float_int(float a, int b) -> (float)
aten::pow(Scalar a, Scalar b) -> (float)
aten::pow.Scalar(Scalar a, Scalar b) -> (Scalar)
aten::pow.int_to_int(int a, int b) -> (int)
```

Reviewed By: iseeyuan

Differential Revision: D21914441

