### PR TITLE
Fix __STDC_FORMAT_MACROS redefinition issue for TypeDerived

### DIFF
--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -1,7 +1,9 @@
 // required for old g++ to compile PRId64 macros, see
 // https://github.com/pytorch/pytorch/issues/3571
 // for context
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include <ATen/${Type}.h>
 


### PR DESCRIPTION
Summary: As title. When adding a new build mode TypeDerived failed to compile due to macro redefinition. Conditional define fixes this issue.

Test Plan: Tests pass.

Differential Revision: D21914975

