### PR TITLE
remove double registered ops

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -92,6 +92,8 @@ white_list = [
     ('aten::le', datetime.date(2020, 6, 30)),
     ('aten::ge', datetime.date(2020, 6, 30)),
     ('aten::pow', datetime.date(2020, 6, 30)),
+    ('aten::min', datetime.date(2020, 6, 30)),
+    ('aten::max', datetime.date(2020, 6, 30)),
 
 
 # The nightly will fail to parse newly added syntax to schema declarations

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -85,7 +85,12 @@ white_list = [
     ('quantized::linear', datetime.date(2020, 6, 1)),
     ('_aten::*', datetime.date(2020, 6, 1)),
     ('_prim::*', datetime.date(2020, 6, 1)),
-]
+    ('aten::eq', datetime.date(2020, 6, 30)),
+    ('aten::nq', datetime.date(2020, 6, 30)),
+    ('aten::lt', datetime.date(2020, 6, 30)),
+    ('aten::gt', datetime.date(2020, 6, 30)),
+    ('aten::le', datetime.date(2020, 6, 30)),
+    ('aten::ge', datetime.date(2020, 6, 30)),
 
 
 # The nightly will fail to parse newly added syntax to schema declarations

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -91,6 +91,7 @@ white_list = [
     ('aten::gt', datetime.date(2020, 6, 30)),
     ('aten::le', datetime.date(2020, 6, 30)),
     ('aten::ge', datetime.date(2020, 6, 30)),
+    ('aten::pow', datetime.date(2020, 6, 30)),
 
 
 # The nightly will fail to parse newly added syntax to schema declarations

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1083,10 +1083,11 @@ void testRecordFunction() {
 
   // test set ids
   bool has_ids = false;
-  addGlobalCallback(RecordFunctionCallback(
-      [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
-      [](const RecordFunction&) {})
-      .needsIds(true));
+  addGlobalCallback(
+      RecordFunctionCallback(
+          [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
+          [](const RecordFunction&) {})
+          .needsIds(true));
   { RECORD_USER_SCOPE("test"); }
   TORCH_CHECK(has_ids);
   clearCallbacks();

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -37,9 +37,9 @@ bool InterpreterState::run(Stack& stack) {
       case OP: {
         if (at::hasGlobalCallbacks()) {
           if (auto debug_info = c10::ThreadLocalDebugInfo::get(
-                c10::DebugInfoKind::MOBILE_RUNTIME_INFO)) {
+                  c10::DebugInfoKind::MOBILE_RUNTIME_INFO)) {
             if (auto* mobile_debug_info =
-                dynamic_cast<MobileDebugInfo*>(debug_info.get())) {
+                    dynamic_cast<MobileDebugInfo*>(debug_info.get())) {
               mobile_debug_info->setOpIdx(pc);
             }
           }

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -40,8 +40,7 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   auto debug_info = std::make_shared<MobileDebugInfo>();
   debug_info->setModelName(name());
   debug_info->setMethodName(method_name);
-  at::DebugInfoGuard guard(
-      at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
+  at::DebugInfoGuard guard(at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
 
   auto m = find_method(method_name);
   if (m == nullptr) {

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -481,15 +481,15 @@ int listSetItem(Stack& stack);
       },                                                    \
       aliasAnalysisFromSchema())
 
-#define DEFINE_STR_CMP_OP(aten_op, op)     \
-  Operator(                                \
-      #aten_op "(str a, str b) -> bool",   \
-      [](Stack& stack) {                   \
-        auto b = pop(stack).toStringRef(); \
-        auto a = pop(stack).toStringRef(); \
-        push(stack, op);                   \
-        return 0;                          \
-      },                                   \
+#define DEFINE_STR_CMP_OP(aten_op, op)       \
+  Operator(                                  \
+      #aten_op ".str(str a, str b) -> bool", \
+      [](Stack& stack) {                     \
+        auto b = pop(stack).toStringRef();   \
+        auto a = pop(stack).toStringRef();   \
+        push(stack, op);                     \
+        return 0;                            \
+      },                                     \
       aliasAnalysisFromSchema())
 
 // define a primitive op over Scalar operands.

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -481,8 +481,14 @@ RegisterOperators reg(
          static_cast<double>(pow(a, b)),
          static_cast<double>(pow(a, b)),
          float),
-
-     DEFINE_BINARY_OP(aten::pow, pow(a, b)),
+     DEFINE_SCALAR_BINARY_OP(
+         aten::pow.Scalar,
+         static_cast<double>(pow(a, b)),
+         static_cast<double>(pow(a, b)),
+         Scalar),
+    DEFINE_INT_OP(
+         aten::pow.int_to_int,
+         pow(a, b)),
      // min and max are in prim:: because there is a difference between
      // the python builtin 'min' and 'torch.min'
      DEFINE_BINARY_OP(prim::min, a < b ? a : b),

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -623,12 +623,12 @@ RegisterOperators reg(
 // these ops are not defined for Tensor
 #define CREATE_COMPARATOR_LIST_OPS_SPECIALIZED(decl_type, value_type)         \
   Operator(                                                                   \
-      "prim::min." decl_type "(" decl_type "[] l, " decl_type                 \
+      "prim::min." decl_type "_list(" decl_type "[] l, " decl_type            \
       "[] r) -> " decl_type "[]",                                             \
       minList<value_type>,                                                    \
       aliasAnalysisFromSchema()),                                             \
       Operator(                                                               \
-          "prim::max." decl_type "(" decl_type "[] l, " decl_type             \
+          "prim::max." decl_type "_list(" decl_type "[] l, " decl_type        \
           "[] r) -> " decl_type "[]",                                         \
           maxList<value_type>,                                                \
           aliasAnalysisFromSchema()),                                         \

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -250,34 +250,6 @@ RegisterOperators reg({
           return 0;
         },
         aliasAnalysisFromSchema()),
-    Operator(
-        "aten::_infer_size(int[] a, int[] b) -> int[]",
-        [](Stack& stack) {
-          auto a = pop(stack);
-          auto b = pop(stack);
-          push(stack, at::infer_size(a.toIntVector(), b.toIntVector()));
-          return 0;
-        },
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::_no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> Tensor",
-        [](Stack& stack) {
-          at::Tensor weight;
-          at::Tensor input;
-          double max_norm;
-          double norm_type;
-          pop(stack, weight, input, max_norm, norm_type);
-
-          // TODO: remove when script supports setting grad mode
-          torch::NoGradGuard no_grad;
-
-          at::Tensor result =
-              at::embedding_renorm_(weight, input, max_norm, norm_type);
-          push(stack, std::move(result));
-
-          return 0;
-        },
-        aliasAnalysisFromSchema()),
 
 #define DEFINE_TORCH_TENSOR_OP(operator_type, c_type, tensor_creation_op)  \
   Operator(                                                                \


### PR DESCRIPTION
Summary:
These two ops are registered twice in the same file

duplicated op: aten::_infer_size(int[] a, int[] b) -> (int[])
duplicated op: aten::_no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> (Tensor)

Test Plan: compile

Differential Revision: D21915104

