### PR TITLE
add overload name for min/max with list input

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -85,8 +85,13 @@ white_list = [
     ('quantized::linear', datetime.date(2020, 6, 1)),
     ('_aten::*', datetime.date(2020, 6, 1)),
     ('_prim::*', datetime.date(2020, 6, 1)),
+    ('aten::eq', datetime.date(2020, 6, 30)),
+    ('aten::nq', datetime.date(2020, 6, 30)),
+    ('aten::lt', datetime.date(2020, 6, 30)),
+    ('aten::gt', datetime.date(2020, 6, 30)),
+    ('aten::le', datetime.date(2020, 6, 30)),
+    ('aten::ge', datetime.date(2020, 6, 30)),
 ]
-
 
 # The nightly will fail to parse newly added syntax to schema declarations
 # Add new schemas that will fail the nightly here

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -91,7 +91,9 @@ white_list = [
     ('aten::gt', datetime.date(2020, 6, 30)),
     ('aten::le', datetime.date(2020, 6, 30)),
     ('aten::ge', datetime.date(2020, 6, 30)),
+    ('aten::pow', datetime.date(2020, 6, 30)),
 ]
+
 
 # The nightly will fail to parse newly added syntax to schema declarations
 # Add new schemas that will fail the nightly here

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -92,6 +92,8 @@ white_list = [
     ('aten::le', datetime.date(2020, 6, 30)),
     ('aten::ge', datetime.date(2020, 6, 30)),
     ('aten::pow', datetime.date(2020, 6, 30)),
+    ('aten::min', datetime.date(2020, 6, 30)),
+    ('aten::max', datetime.date(2020, 6, 30)),
 ]
 
 

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1083,10 +1083,11 @@ void testRecordFunction() {
 
   // test set ids
   bool has_ids = false;
-  addGlobalCallback(RecordFunctionCallback(
-      [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
-      [](const RecordFunction&) {})
-      .needsIds(true));
+  addGlobalCallback(
+      RecordFunctionCallback(
+          [&has_ids](const RecordFunction& fn) { has_ids = fn.handle() > 0; },
+          [](const RecordFunction&) {})
+          .needsIds(true));
   { RECORD_USER_SCOPE("test"); }
   TORCH_CHECK(has_ids);
   clearCallbacks();

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -37,9 +37,9 @@ bool InterpreterState::run(Stack& stack) {
       case OP: {
         if (at::hasGlobalCallbacks()) {
           if (auto debug_info = c10::ThreadLocalDebugInfo::get(
-                c10::DebugInfoKind::MOBILE_RUNTIME_INFO)) {
+                  c10::DebugInfoKind::MOBILE_RUNTIME_INFO)) {
             if (auto* mobile_debug_info =
-                dynamic_cast<MobileDebugInfo*>(debug_info.get())) {
+                    dynamic_cast<MobileDebugInfo*>(debug_info.get())) {
               mobile_debug_info->setOpIdx(pc);
             }
           }

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -40,8 +40,7 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   auto debug_info = std::make_shared<MobileDebugInfo>();
   debug_info->setModelName(name());
   debug_info->setMethodName(method_name);
-  at::DebugInfoGuard guard(
-      at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
+  at::DebugInfoGuard guard(at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
 
   auto m = find_method(method_name);
   if (m == nullptr) {

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -481,15 +481,15 @@ int listSetItem(Stack& stack);
       },                                                    \
       aliasAnalysisFromSchema())
 
-#define DEFINE_STR_CMP_OP(aten_op, op)     \
-  Operator(                                \
-      #aten_op "(str a, str b) -> bool",   \
-      [](Stack& stack) {                   \
-        auto b = pop(stack).toStringRef(); \
-        auto a = pop(stack).toStringRef(); \
-        push(stack, op);                   \
-        return 0;                          \
-      },                                   \
+#define DEFINE_STR_CMP_OP(aten_op, op)       \
+  Operator(                                  \
+      #aten_op ".str(str a, str b) -> bool", \
+      [](Stack& stack) {                     \
+        auto b = pop(stack).toStringRef();   \
+        auto a = pop(stack).toStringRef();   \
+        push(stack, op);                     \
+        return 0;                            \
+      },                                     \
       aliasAnalysisFromSchema())
 
 // define a primitive op over Scalar operands.

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -481,8 +481,14 @@ RegisterOperators reg(
          static_cast<double>(pow(a, b)),
          static_cast<double>(pow(a, b)),
          float),
-
-     DEFINE_BINARY_OP(aten::pow, pow(a, b)),
+     DEFINE_SCALAR_BINARY_OP(
+         aten::pow.Scalar,
+         static_cast<double>(pow(a, b)),
+         static_cast<double>(pow(a, b)),
+         Scalar),
+    DEFINE_INT_OP(
+         aten::pow.int_to_int,
+         pow(a, b)),
      // min and max are in prim:: because there is a difference between
      // the python builtin 'min' and 'torch.min'
      DEFINE_BINARY_OP(prim::min, a < b ? a : b),

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -486,9 +486,7 @@ RegisterOperators reg(
          static_cast<double>(pow(a, b)),
          static_cast<double>(pow(a, b)),
          Scalar),
-    DEFINE_INT_OP(
-         aten::pow.int_to_int,
-         pow(a, b)),
+     DEFINE_INT_OP(aten::pow.int_to_int, pow(a, b)),
      // min and max are in prim:: because there is a difference between
      // the python builtin 'min' and 'torch.min'
      DEFINE_BINARY_OP(prim::min, a < b ? a : b),
@@ -623,12 +621,12 @@ RegisterOperators reg(
 // these ops are not defined for Tensor
 #define CREATE_COMPARATOR_LIST_OPS_SPECIALIZED(decl_type, value_type)         \
   Operator(                                                                   \
-      "prim::min." decl_type "(" decl_type "[] l, " decl_type                 \
+      "prim::min." decl_type "_list(" decl_type "[] l, " decl_type            \
       "[] r) -> " decl_type "[]",                                             \
       minList<value_type>,                                                    \
       aliasAnalysisFromSchema()),                                             \
       Operator(                                                               \
-          "prim::max." decl_type "(" decl_type "[] l, " decl_type             \
+          "prim::max." decl_type "_list(" decl_type "[] l, " decl_type        \
           "[] r) -> " decl_type "[]",                                         \
           maxList<value_type>,                                                \
           aliasAnalysisFromSchema()),                                         \


### PR DESCRIPTION
Summary:
add overload name to differentiate

prim::min.int(int a, int b) -> (int)
prim::min.int(int[] l, int[] r) -> (int[])

Test Plan:
verified op names for aten::min and aten::max are different

before
```
prim::min.int(int a, int b) -> (int)
prim::min.float(float a, float b) -> (float)
prim::min.int_float(int a, float b) -> (float)
prim::min.float_int(float a, int b) -> (float)
prim::min(Scalar a, Scalar b) -> (Scalar)
prim::max.int(int a, int b) -> (int)
prim::max.float(float a, float b) -> (float)
prim::max.int_float(int a, float b) -> (float)
prim::max.float_int(float a, int b) -> (float)
prim::max(Scalar a, Scalar b) -> (Scalar)

prim::min.int(int[] l, int[] r) -> (int[])
prim::max.int(int[] l, int[] r) -> (int[])
prim::min.self_int(int[] self) -> (int)
prim::max.self_int(int[] self) -> (int)
prim::min.float(float[] l, float[] r) -> (float[])
prim::max.float(float[] l, float[] r) -> (float[])
prim::min.self_float(float[] self) -> (float)
prim::max.self_float(float[] self) -> (float)
prim::min.bool(bool[] l, bool[] r) -> (bool[])
prim::max.bool(bool[] l, bool[] r) -> (bool[])
prim::min.self_bool(bool[] self) -> (bool)
prim::max.self_bool(bool[] self) -> (bool)
```

after
```
prim::min.int(int a, int b) -> (int)
prim::min.float(float a, float b) -> (float)
prim::min.int_float(int a, float b) -> (float)
prim::min.float_int(float a, int b) -> (float)
prim::min(Scalar a, Scalar b) -> (Scalar)
prim::max.int(int a, int b) -> (int)
prim::max.float(float a, float b) -> (float)
prim::max.int_float(int a, float b) -> (float)
prim::max.float_int(float a, int b) -> (float)
prim::max(Scalar a, Scalar b) -> (Scalar)

prim::min.int_list(int[] l, int[] r) -> (int[])
prim::max.int_list(int[] l, int[] r) -> (int[])
prim::min.self_int(int[] self) -> (int)
prim::max.self_int(int[] self) -> (int)
prim::min.float_list(float[] l, float[] r) -> (float[])
prim::max.float_list(float[] l, float[] r) -> (float[])
prim::min.self_float(float[] self) -> (float)
prim::max.self_float(float[] self) -> (float)
prim::min.bool_list(bool[] l, bool[] r) -> (bool[])
prim::max.bool_list(bool[] l, bool[] r) -> (bool[])
prim::min.self_bool(bool[] self) -> (bool)
prim::max.self_bool(bool[] self) -> (bool)
```

Reviewed By: iseeyuan

Differential Revision: D21914844

