### PR TITLE
Improve error message for Pad operator

### DIFF
--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -55,6 +55,16 @@ def skipIfUnsupportedMinOpsetVersion(min_opset_version):
         return wrapper
     return skip_dec
 
+# skips tests for all versions above min_opset_version.
+def skipIfUnsupportedMaxOpsetVersion(min_opset_version):
+    def skip_dec(func):
+        def wrapper(self):
+            if self.opset_version > min_opset_version:
+                raise unittest.SkipTest("Skip verify test for unsupported opset_version")
+            return func(self)
+        return wrapper
+    return skip_dec
+
 # Enables tests for scripting, instead of only tracing the model.
 def enableScriptTest():
     def script_dec(func):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -16,7 +16,8 @@ from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
 from model_defs.rnn_model_with_packed_sequence import RnnModelWithPackedSequence
 from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion, enableScriptTest,
-                                 skipIfUnsupportedOpsetVersion, skipIfNoLapack)
+                                 skipIfUnsupportedOpsetVersion, skipIfNoLapack,
+                                 skipIfUnsupportedMaxOpsetVersion)
 from test_pytorch_common import BATCH_SIZE
 from test_pytorch_common import RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 import model_defs.word_language_model as word_language_model
@@ -2980,6 +2981,24 @@ class TestONNXRuntime(unittest.TestCase):
         y = pad = (torch.tensor(2, dtype=torch.int64), torch.tensor(4, dtype=torch.int64))
         self.run_test(Pad(), (x, y))
 
+    @skipIfUnsupportedMaxOpsetVersion(10)
+    def test_unsupported_pad(self):
+        class Pad(torch.nn.Module):
+            def forward(self, x, pad):
+                return torch.nn.functional.pad(x, pad)
+        def run():
+            x = torch.randn(2, 2, 4, 4)
+            y = pad = (torch.tensor(2, dtype=torch.int32), torch.tensor(4, dtype=torch.int32))
+            p = Pad()
+            f = io.BytesIO()
+            torch.onnx._export(p, (x, y), f)
+
+        with self.assertRaises(RuntimeError) as cm:
+            run()
+
+        the_exception = cm.exception
+        self.assertEqual('Unsupported: ONNX export of Pad in opset 9. The sizes of the padding must be constant. Please try opset version 11.', the_exception.args[0])
+        
     def test_reflection_pad(self):
         model = torch.nn.ReflectionPad1d(2)
         x = torch.randn(2, 4, 4)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2998,7 +2998,8 @@ class TestONNXRuntime(unittest.TestCase):
             run()
 
         the_exception = cm.exception
-        self.assertEqual('Unsupported: ONNX export of Pad in opset 9. The sizes of the padding must be constant. Please try opset version 11.', the_exception.args[0])
+        self.assertEqual('Unsupported: ONNX export of Pad in opset 9. The sizes of the padding must be constant. ' +
+                         'Please try opset version 11.', the_exception.args[0])
 
     def test_reflection_pad(self):
         model = torch.nn.ReflectionPad1d(2)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2986,6 +2986,7 @@ class TestONNXRuntime(unittest.TestCase):
         class Pad(torch.nn.Module):
             def forward(self, x, pad):
                 return torch.nn.functional.pad(x, pad)
+
         def run():
             x = torch.randn(2, 2, 4, 4)
             y = pad = (torch.tensor(2, dtype=torch.int32), torch.tensor(4, dtype=torch.int32))
@@ -2998,7 +2999,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         the_exception = cm.exception
         self.assertEqual('Unsupported: ONNX export of Pad in opset 9. The sizes of the padding must be constant. Please try opset version 11.', the_exception.args[0])
-        
+
     def test_reflection_pad(self):
         model = torch.nn.ReflectionPad1d(2)
         x = torch.randn(2, 4, 4)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -187,7 +187,7 @@ def _onnx_opset_unsupported(op_name, current_opset, supported_opset):
 
 def _onnx_opset_unsupported_detailed(op_name, current_opset, supported_opset, reason):
     raise RuntimeError('Unsupported: ONNX export of {} in '
-                       'opset {}. {}. Please try opset version {}.'.format(op_name, reason, current_opset, supported_opset))
+                       'opset {}. {}. Please try opset version {}.'.format(op_name, current_opset, reason, supported_opset))
 
 
 def _black_list_in_opset(name):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -185,6 +185,10 @@ def _onnx_opset_unsupported(op_name, current_opset, supported_opset):
     raise RuntimeError('Unsupported: ONNX export of {} in '
                        'opset {}. Please try opset version {}.'.format(op_name, current_opset, supported_opset))
 
+def _onnx_opset_unsupported_detailed(op_name, current_opset, supported_opset, reason):
+    raise RuntimeError('Unsupported: ONNX export of {} in '
+                       'opset {}. {}. Please try opset version {}.'.format(op_name, reason, current_opset, supported_opset))
+
 
 def _black_list_in_opset(name):
     def symbolic_fn(*args, **kwargs):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -849,7 +849,7 @@ def _convert_padding_node(padding):
             if all_constant:
                 padding = [int(v.node()['value']) for v in padding.node().inputs()]
             else:
-                return sym_help._onnx_opset_unsupported('Pad', 9, 11)
+                return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The sizes of the padding must be constant')
     return padding
 
 def constant_pad_nd(g, input, padding, value):
@@ -859,7 +859,7 @@ def constant_pad_nd(g, input, padding, value):
             tval = value.node()['value']
             value = float(tval)
         else:
-            return sym_help._onnx_opset_unsupported('Pad', 9, 11)
+            return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The value for the padding must be constant')
 
     padding = _convert_padding_node(padding)
     paddings = _prepare_onnx_paddings(input.type().dim(), padding)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -849,7 +849,7 @@ def constant_pad_nd(g, input, padding, value):
     mode = "constant"
     try:
         value = sym_help._get_const(value, 'f', 'value')
-    except:
+    except Exception:
         return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The value for the padding must be constant')
 
     padding = _convert_padding_node(padding)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -859,7 +859,6 @@ def constant_pad_nd(g, input, padding, value):
     return g.op("Pad", input, pads_i=paddings, mode_s=mode, value_f=value)
 
 
-@parse_args('v', 'is')
 def reflection_pad(g, input, padding):
     mode = "reflect"
     padding = _convert_padding_node(padding)
@@ -867,7 +866,6 @@ def reflection_pad(g, input, padding):
     return g.op("Pad", input, pads_i=paddings, mode_s=mode)
 
 
-@parse_args('v', 'is')
 def replication_pad(g, input, padding):
     mode = "edge"
     padding = _convert_padding_node(padding)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -839,10 +839,10 @@ def _convert_padding_node(padding):
     padding = sym_help._maybe_get_const(padding, 'is')
     if sym_help._is_value(padding) and sym_help._is_packed_list(padding):
         input_list = sym_help._unpack_list(padding)
-        input_is_constant = [v.node().kind() == 'onnx::Constant' for v in input_list]
-        if not all(input_is_constant):
+        try:
+            padding = [sym_help._get_const(v, 'i', 'padding') for v in input_list]
+        except Exception:
             return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The sizes of the padding must be constant')
-        padding = [int(v.node()['value']) for v in padding.node().inputs()]
     return padding
 
 def constant_pad_nd(g, input, padding, value):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -847,12 +847,10 @@ def _convert_padding_node(padding):
 
 def constant_pad_nd(g, input, padding, value):
     mode = "constant"
-    if sym_help._is_value(value):
-        if value.node().kind() == 'onnx::Constant':
-            tval = value.node()['value']
-            value = float(tval)
-        else:
-            return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The value for the padding must be constant')
+    try:
+        value = sym_help._get_const(value, 'f', 'value')
+    except:
+        return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The value for the padding must be constant')
 
     padding = _convert_padding_node(padding)
     paddings = _prepare_onnx_paddings(input.type().dim(), padding)


### PR DESCRIPTION
In issue #36997 the user encountered a non-meaningful error message when trying to export the model to ONNX. The Pad operator in opset 9 requires the list of paddings to be constant. This PR tries to improve the error message given to the user when this is not the case.