### PR TITLE
Refactor CUDA bernoulli_kernel by using uniform_and_transform

### DIFF
--- a/aten/src/ATen/core/DistributionsHelper.h
+++ b/aten/src/ATen/core/DistributionsHelper.h
@@ -187,9 +187,9 @@ struct normal_distribution {
 };
 
 template <typename T>
-struct BernoulliType { using type = float; };
+struct DiscreteDistributionType { using type = float; };
 
-template <> struct BernoulliType<double> { using type = double; };
+template <> struct DiscreteDistributionType<double> { using type = double; };
 
 /**
  * Samples a bernoulli distribution given a probability input
@@ -211,11 +211,6 @@ struct bernoulli_distribution {
   private:
     T p;
 };
-
-template <typename T>
-struct GeometricType { using type = float; };
-
-template <> struct GeometricType<double> { using type = double; };
 
 /**
  * Samples a geometric distribution given a probability input

--- a/aten/src/ATen/core/DistributionsHelper.h
+++ b/aten/src/ATen/core/DistributionsHelper.h
@@ -186,21 +186,26 @@ struct normal_distribution {
     T stdv;
 };
 
+template <typename T>
+struct BernoulliType { using type = float; };
+
+template <> struct BernoulliType<double> { using type = double; };
+
 /**
  * Samples a bernoulli distribution given a probability input
  */
 template <typename T>
 struct bernoulli_distribution {
 
-  inline bernoulli_distribution(T p_in) {
-    TORCH_CHECK(p_in >= 0 && p_in <= 1);
+  C10_HOST_DEVICE inline bernoulli_distribution(T p_in) {
+    TORCH_CHECK_IF_NOT_ON_CUDA(p_in >= 0 && p_in <= 1);
     p = p_in;
   }
 
   template <typename RNG>
-  inline int operator()(RNG generator) {
+  C10_HOST_DEVICE inline T operator()(RNG generator) {
     uniform_real_distribution<T> uniform(0.0, 1.0);
-    return uniform(generator) < p;
+    return transformation::bernoulli<T>(uniform(generator), p);
   }
 
   private:

--- a/aten/src/ATen/core/TransformationHelper.h
+++ b/aten/src/ATen/core/TransformationHelper.h
@@ -132,7 +132,7 @@ C10_HOST_DEVICE inline T log_normal(T val) {
 }
 
 /**
- * Transforms bernoulli distributed `val` between 0.0 and 1.0 to
+ * Transforms uniformly distributed `val` between 0.0 and 1.0 to
  * bernoulli distributed with success probability `p`.
  */
 template <typename T>

--- a/aten/src/ATen/core/TransformationHelper.h
+++ b/aten/src/ATen/core/TransformationHelper.h
@@ -131,4 +131,13 @@ C10_HOST_DEVICE inline T log_normal(T val) {
   return at::exp(val);
 }
 
+/**
+ * Transforms bernoulli distributed `val` between 0.0 and 1.0 to
+ * bernoulli distributed with success probability `p`.
+ */
+template <typename T>
+C10_HOST_DEVICE inline T bernoulli(T val, T p) {
+  return val < p;
+}
+
 }} // namespace at::transformation

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -522,7 +522,7 @@ struct LogNormalKernel {
 template<typename RNG>
 void geometric_kernel(TensorIterator& iter, double p, RNG gen) {
   AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "geometric_cuda", [&] {
-    using accscalar_t = at::GeometricType<scalar_t>::type;
+    using accscalar_t = at::DiscreteDistributionType<scalar_t>::type;
     // define lambda for geometric transformation
     auto geometric_func = [p] __device__ (accscalar_t rand) {
       return static_cast<scalar_t>(transformation::geometric<accscalar_t>(rand, p));
@@ -658,7 +658,7 @@ template<typename RNG>
 void bernoulli_kernel(TensorIterator& iter, double p, RNG gen) {
   AT_DISPATCH_ALL_TYPES_AND3(
     at::ScalarType::Half, at::ScalarType::BFloat16, at::ScalarType::Bool, iter.dtype(), "bernoulli_scalar_cuda_", [&] {
-      using accscalar_t = at::BernoulliType<scalar_t>::type;
+      using accscalar_t = at::DiscreteDistributionType<scalar_t>::type;
       // define lambda for bernoulli transformation
       auto bernoulli_func = [p] __device__ (accscalar_t rand) {
         return static_cast<scalar_t>(transformation::bernoulli<accscalar_t>(rand, p));

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -655,35 +655,22 @@ void bernoulli_kernel(Tensor& self, const Tensor& p_, RNG gen) {
 }
 
 template<typename RNG>
-void bernoulli_kernel(TensorIterator& iter, double p_, RNG gen) {
+void bernoulli_kernel(TensorIterator& iter, double p, RNG gen) {
   AT_DISPATCH_ALL_TYPES_AND3(
     at::ScalarType::Half, at::ScalarType::BFloat16, at::ScalarType::Bool, iter.dtype(), "bernoulli_scalar_cuda_", [&] {
-      if (std::is_same<scalar_t, double>::value) {
+      using accscalar_t = at::BernoulliType<scalar_t>::type;
       // define lambda for bernoulli transformation
-      auto bernoulli_func = [p_] __device__ (double rand) {
-        return static_cast<scalar_t>(rand <= p_);
+      auto bernoulli_func = [p] __device__ (accscalar_t rand) {
+        return static_cast<scalar_t>(transformation::bernoulli<accscalar_t>(rand, p));
       };
-      distribution_nullary_kernel<scalar_t, double, curand4_engine_calls/2>(iter,
-        gen,
-        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform2_double(state); },
-        bernoulli_func);
-    } else {
-      auto p = static_cast<float>(p_);
-      auto bernoulli_func = [p] __device__ (float rand) {
-        return static_cast<scalar_t>(rand <= p);
-      };
-      distribution_nullary_kernel<scalar_t, float, curand4_engine_calls>(iter,
-        gen,
-        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform4(state); },
-        bernoulli_func);
-    }
+      uniform_and_transform<scalar_t, accscalar_t, curand4_engine_calls>(iter, gen, bernoulli_func);
    });
 }
 
 template<typename RNG>
 struct BernoulliKernel {
-  void operator()(TensorIterator& iter, double p_, c10::optional<Generator> gen) {
-    bernoulli_kernel(iter, p_, check_generator<RNG>(gen));
+  void operator()(TensorIterator& iter, double p, c10::optional<Generator> gen) {
+    bernoulli_kernel(iter, p, check_generator<RNG>(gen));
   }
   void operator()(Tensor& self, const Tensor& p_, c10::optional<Generator> gen) {
     bernoulli_kernel(self, p_, check_generator<RNG>(gen));


### PR DESCRIPTION
- Fixes #39557 .
- Related #38558 .
- Simplifed `void bernoulli_kernel(TensorIterator& iter, double p_, RNG gen)` in `cuda/DistributionTemplates.h` by using `uniform_and_transform`.
- Unified `void bernoulli_kernel(TensorIterator& iter, double p_, RNG gen)` with other kernels in `cuda/DistributionTemplates.h`.