### PR TITLE
[quant] Enable per-channel quantization for LSTM Modules

### DIFF
--- a/test/quantization/test_quantize.py
+++ b/test/quantization/test_quantize.py
@@ -654,7 +654,7 @@ class TestPostTrainingDynamic(QuantizationTestCase):
             model = quantize_dynamic(NestedModel().eval(), qconfig_dict, dtype=dtype)
             checkQuantized(model)
 
-    def test_per_channel_quantize(self):
+    def test_per_channel_linear_quantize(self):
         r"""Test quantization for per_channel dynamic quantization
         """
         model = NestedModel().eval()
@@ -866,6 +866,49 @@ class TestPostTrainingDynamic(QuantizationTestCase):
 
                 y, (h, c) = cell_dq(x, (h, c))
 
+    def test_per_channel_lstm_quantize(self):
+        d_hid = 2
+        num_chunks = 4
+        model = LSTMDynamicModel().eval()
+        cell = model.lstm
+        vals = [[100, -155],
+                [100, -155],
+                [-155, 100],
+                [-155, 100],
+                [100, -155],
+                [-155, 100],
+                [-155, 100],
+                [100, -155]]
+
+        vals = vals[:d_hid * num_chunks]
+        cell.weight_ih_l0 = torch.nn.Parameter(
+            torch.tensor(vals, dtype=torch.float),
+            requires_grad=False)
+        cell.weight_hh_l0 = torch.nn.Parameter(
+            torch.tensor(vals, dtype=torch.float),
+            requires_grad=False)
+        ref = copy.deepcopy(cell)
+        qconfig_dict = {
+            torch.nn.LSTM : per_channel_dynamic_qconfig
+        }
+        model_quantized = quantize_dynamic(model=model, qconfig_spec=qconfig_dict, dtype=torch.qint8)
+
+        niter = 10
+
+        x = torch.tensor([[100, -155],
+                          [-155, 100],
+                          [100, -155]], dtype=torch.float).unsqueeze(0).repeat(niter, 1, 1)
+
+        h0_vals = [[-155, 100],
+                   [-155, 155],
+                   [100, -155]]
+        hx = torch.tensor(h0_vals, dtype=torch.float).unsqueeze(0)
+        cx = torch.tensor(h0_vals, dtype=torch.float).unsqueeze(0)
+        hiddens = (hx, cx)
+        quant_out, quant_hidden = model_quantized(x)
+        ref_out, ref_hidden = ref(x)
+
+        self.assertEqual(quant_out, ref_out)
 
 class TestQuantizationAwareTraining(QuantizationTestCase):
     def test_manual(self):

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -199,7 +199,7 @@ class QuantizationTestCase(TestCase):
         r"""Checks that mod has been swapped for an nnqd.LSTM type
             module, the bias is float.
         """
-        wt_dtype_map = {torch.qint8: 'quantized_dynamic_bc', torch.float16: 'quantized_fp16'}
+        wt_dtype_map = {torch.qint8: 'quantized_dynamic', torch.float16: 'quantized_fp16'}
         self.assertEqual(type(mod), reference_module_type)
         for packed_params in mod._all_weight_values:
             self.assertEqual(packed_params.param.__getstate__()[0][0], wt_dtype_map[dtype])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39666 [quant] Enable per-channel quantization for LSTM Modules**
* #39604 [quant] Add reduce_range params for quantized_lstm

Summary:

Test Plan:
python test/test_quantization.py TestPostTrainingDynamic.test_per_channel_lstm_quantize

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21977601](https://our.internmc.facebook.com/intern/diff/D21977601)