### PR TITLE
[quant][graphmode] Test weight observer for dynamic quant

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -2559,13 +2559,54 @@ class TestQuantizeDynamicScript(QuantizationTestCase):
         qconfig_dict = {'': default_dynamic_qconfig}
         m1 = quantize_dynamic_script(model, qconfig_dict)
         out_graph = m1(data)
-
-        m2 = prepare_dynamic_script(model, qconfig_dict)
-        m2(data)
-        m2 = convert_dynamic_script(m2)
-        out_ref = m2(data)
-        self.assertEqual(out_graph, out_ref)
-
         FileCheck().check_count("quantized::linear_dynamic(", 2, exactly=True) \
                    .check_not("aten::_choose_qparams_per_tensor") \
                    .run(m1.graph)
+
+        # Check to make sure weight observers run correctly
+        ref_qparams = []
+        qconfig = script_qconfig(default_dynamic_qconfig)
+        for wt in [model.res1.weight, model.res2.weight]:
+            get_forward(qconfig.weight)(wt)
+            qparams = qconfig.weight._get_method('calculate_qparams')()
+            ref_qparams.append((qparams[0].item(), qparams[1].item()))
+
+        m2 = prepare_dynamic_script(model, qconfig_dict)
+        m2 = convert_dynamic_script(m2, debug=True)
+        print(m2.graph)
+        graph_params = []
+        for x, obs in model._modules._c.items():
+            if x == 'res1':
+                graph_params.append((obs.getattr('6_scale_0'), obs.getattr('6_zero_point_0')))
+            elif x == 'res2':
+                graph_params.append((obs.getattr('10_scale_0'), obs.getattr('10_zero_point_0')))
+        print(graph_params)
+        self.assertEqual(ref_qparams, graph_params)
+
+    def test_dynamic_weight_observer(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.fc = torch.nn.Linear(5, 5).float()
+                self.fc2 = torch.nn.Linear(5, 5).float()
+
+            def forward(self, x):
+                x = self.fc(x)
+                return self.fc2(x)
+
+        qconfig_dict = {'': default_dynamic_qconfig}
+        model = torch.jit.script(M()).eval()
+        qconfig = script_qconfig(default_dynamic_qconfig)
+        ref_qparams = []
+        for wt in [model.fc.weight, model.fc2.weight]:
+            get_forward(qconfig.weight)(wt)
+            qparams = qconfig.weight._get_method('calculate_qparams')()
+            ref_qparams.append((qparams[0].item(), qparams[1].item()))
+        model = prepare_dynamic_script(model, qconfig_dict)
+        model = convert_dynamic_script(model, debug=True)
+        print(model.graph)
+        graph_params = []
+        for x, obs in model._modules._c.items():
+            graph_params.append((obs.getattr('3_scale_0'), obs.getattr('3_zero_point_0')))
+
+        self.assertEqual(ref_qparams, graph_params)

--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -2573,14 +2573,12 @@ class TestQuantizeDynamicScript(QuantizationTestCase):
 
         m2 = prepare_dynamic_script(model, qconfig_dict)
         m2 = convert_dynamic_script(m2, debug=True)
-        print(m2.graph)
         graph_params = []
-        for x, obs in model._modules._c.items():
+        for x, obs in m2._modules._c.items():
             if x == 'res1':
                 graph_params.append((obs.getattr('6_scale_0'), obs.getattr('6_zero_point_0')))
             elif x == 'res2':
                 graph_params.append((obs.getattr('10_scale_0'), obs.getattr('10_zero_point_0')))
-        print(graph_params)
         self.assertEqual(ref_qparams, graph_params)
 
     def test_dynamic_weight_observer(self):
@@ -2604,7 +2602,6 @@ class TestQuantizeDynamicScript(QuantizationTestCase):
             ref_qparams.append((qparams[0].item(), qparams[1].item()))
         model = prepare_dynamic_script(model, qconfig_dict)
         model = convert_dynamic_script(model, debug=True)
-        print(model.graph)
         graph_params = []
         for x, obs in model._modules._c.items():
             graph_params.append((obs.getattr('3_scale_0'), obs.getattr('3_zero_point_0')))

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -274,6 +274,7 @@ class MinMaxObserver(_ObserverBase):
     def forward(self, x_orig):
         r"""Records the running minimum and maximum of ``x``."""
         x = x_orig.detach()  # avoid keeping autograd tape
+        print("Called forward with tensor ", x)
         x = x.to(self.min_val.dtype)
         min_val = self.min_val
         max_val = self.max_val

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -274,7 +274,6 @@ class MinMaxObserver(_ObserverBase):
     def forward(self, x_orig):
         r"""Records the running minimum and maximum of ``x``."""
         x = x_orig.detach()  # avoid keeping autograd tape
-        print("Called forward with tensor ", x)
         x = x.to(self.min_val.dtype)
         min_val = self.min_val
         max_val = self.max_val


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39687 [quant][graphmode] Test weight observer for dynamic quant**

Summary:
Run the observer on the weight values and compare it with the calculated attributes in the graph

Test Plan:
python test/test_quantization.py test_dynamic_weight_observer

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D21961907](https://our.internmc.facebook.com/intern/diff/D21961907)