### PR TITLE
Avoid initializing unnecessary tensors in nccl.reduce

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -71,8 +71,9 @@ ArrayRef<ncclComm_t> get_communicators(TensorList inputs) {
   return it->second.ref();
 }
 
+inline
 ncclDataType_t get_data_type(const Tensor& t) {
-  if (t.type().backend() != Backend::CUDA) {
+  if (!t.is_cuda()) {
     throw std::runtime_error("Unconvertible NCCL type");
   }
   switch (t.scalar_type()) {
@@ -92,6 +93,54 @@ ncclDataType_t get_data_type(const Tensor& t) {
       return ncclChar;
     default:
       throw std::runtime_error("Unconvertible NCCL type");
+  }
+}
+
+static inline
+void check_tensor(
+    const at::Tensor& input,
+    const at::optional<at::Tensor>& output,
+    int input_multiplier,
+    int output_multiplier,
+    int64_t ref_numel,
+    ScalarType ref_dtype) {
+
+  auto check_one = [&](const at::Tensor &tensor) {
+    if (!tensor.is_cuda() || tensor.is_sparse()) {
+      throw std::runtime_error(
+          "input and output elements have to be cuda dense Tensors");
+    }
+
+    if (ref_dtype != tensor.scalar_type()) {
+      throw std::runtime_error(
+          "all inputs and outputs must be of the same Tensor dtype");
+    }
+
+    if (!tensor.is_contiguous()) {
+      throw std::runtime_error("all inputs and outputs have to be contiguous");
+    }
+  };
+
+  check_one(input);
+
+  // all inputs must be same size
+  if (input.numel() != ref_numel) {
+    throw std::runtime_error(
+        "all inputs must have the same number of elements");
+  }
+
+  if (output) {
+    check_one(*output);
+
+    // inputs and outputs must be on same device respectively
+    if (input.get_device() != output->get_device()) {
+      throw std::runtime_error("input and output must be on the same device");
+    }
+
+    if (output->numel() * output_multiplier != ref_numel * input_multiplier) {
+      throw std::runtime_error(
+          "output must be of size input_size * size_multiplier");
+    }
   }
 }
 
@@ -116,26 +165,13 @@ void check_inputs(
 
   device_set devices;
   int64_t numel = inputs[0].numel();
-  auto type = inputs[0].type();
+  auto dtype = inputs[0].scalar_type();
 
   for (size_t i = 0; i < len; i++) {
     auto input = inputs[i];
     auto output = outputs[i];
 
-    if (!(input.is_cuda() && !input.is_sparse() &&
-          output.is_cuda() && !output.is_sparse())) {
-      throw std::runtime_error(
-          "input and output elements have to be cuda dense Tensors");
-    }
-
-    if (!(type == input.type() && type == output.type())) {
-      throw std::runtime_error(
-          "all inputs and outputs must be of the same Tensor type");
-    }
-
-    if (!input.is_contiguous() || !output.is_contiguous()) {
-      throw std::runtime_error("all inputs and outputs have to be contiguous");
-    }
+    check_tensor(input, output, input_multiplier, output_multiplier, numel, dtype);
 
     auto input_device = input.get_device();
     // inputs must be on unique devices
@@ -143,22 +179,40 @@ void check_inputs(
       throw std::runtime_error("inputs must be on unique devices");
     }
     devices.set(input_device);
+  }
+}
 
-    // inputs and outputs must be on same device respectively
-    if (input_device != output.get_device()) {
-      throw std::runtime_error("input and output must be on the same device");
-    }
+void check_inputs(
+    TensorList inputs,
+    const at::Tensor& output,
+    int root,
+    int input_multiplier,
+    int output_multiplier) {
+  // len(inputs) == len(outputs)
+  size_t len = inputs.size();
 
-    // all inputs must be same size
-    if (input.numel() != numel) {
-      throw std::runtime_error(
-          "all inputs must have the same number of elements");
-    }
+  if (len <= 0) {
+    throw std::runtime_error("input sequence can't be empty");
+  }
 
-    if (output.numel() * output_multiplier != numel * input_multiplier) {
-      throw std::runtime_error(
-          "output must be of size input_size * size_multiplier");
+  device_set devices;
+  int64_t numel = inputs[0].numel();
+  auto dtype = inputs[0].scalar_type();
+
+  for (size_t i = 0; i < len; i++) {
+    auto input = inputs[i];
+
+    check_tensor(
+      input,
+      i == root ? at::optional<at::Tensor>{output} : at::nullopt,
+      input_multiplier, output_multiplier, numel, dtype);
+
+    auto input_device = input.get_device();
+    // inputs must be on unique devices
+    if (devices.test(input_device)) {
+      throw std::runtime_error("inputs must be on unique devices");
     }
+    devices.set(input_device);
   }
 }
 
@@ -168,8 +222,7 @@ bool is_available(TensorList tensors) {
 #ifdef USE_NCCL
   device_set devices;
   for (auto& tensor : tensors) {
-    auto type = tensor.type();
-    if (!type.is_cuda() || type.is_sparse())
+    if (!tensor.is_cuda() || tensor.is_sparse())
       return false;
     if (!tensor.is_contiguous())
       return false;
@@ -295,7 +348,7 @@ void broadcast(
 
 void reduce(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    at::Tensor& output,
     int32_t root,
     int32_t op,
     const stream_list& streams,
@@ -305,7 +358,7 @@ void reduce(
   TORCH_CHECK(
       root >= 0 && static_cast<size_t>(root) < inputs.size(), "invalid root");
 
-  check_inputs(inputs, outputs, 1, 1);
+  check_inputs(inputs, output, root, 1, 1);
   const auto len = inputs.size();
 
   ncclDataType_t data_type = get_data_type(inputs[0]);
@@ -326,7 +379,7 @@ void reduce(
 
     NCCL_CHECK(ncclReduce(
         inputs[i].data_ptr(),
-        outputs[i].data_ptr(),
+        root == i ? output.data_ptr() : nullptr,
         count,
         data_type,
         (ncclRedOp_t)op,
@@ -345,7 +398,7 @@ void reduce(
     int32_t op,
     const stream_list& streams,
     const comm_list& user_comms) {
-  reduce(inputs, /*outputs=*/inputs, root, op, streams, user_comms);
+  reduce(inputs, /*output=*/inputs[root], root, op, streams, user_comms);
 }
 
 void all_reduce(

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -188,7 +188,6 @@ void check_inputs(
     int root,
     int input_multiplier,
     int output_multiplier) {
-  // len(inputs) == len(outputs)
   size_t len = inputs.size();
 
   if (len <= 0) {

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -48,6 +48,12 @@ TORCH_CUDA_API void check_inputs(
     at::TensorList outputs,
     int input_multiplier,
     int output_multiplier);
+TORCH_CUDA_API void check_inputs(
+    at::TensorList inputs,
+    const at::Tensor& output,
+    int root,
+    int input_multiplier,
+    int output_multiplier);
 TORCH_CUDA_API ncclDataType_t get_data_type(const at::Tensor& t);
 
 } // namespace detail
@@ -72,7 +78,7 @@ size_t get_max_count();
 
 TORCH_CUDA_API void reduce(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    at::Tensor& output,
     int32_t root = 0,
     int32_t op = ncclSum,
     const stream_list& streams = {},

--- a/torch/cuda/comm.py
+++ b/torch/cuda/comm.py
@@ -76,14 +76,10 @@ def reduce_add(inputs, destination=None):
         result = torch.empty_like(inputs[root_index])
         nccl.reduce(inputs, output=result, root=root_index)
     else:
-        # clone inputs[root_index] and accuimulate into the copy
         nonroot = [t for i, t in enumerate(inputs) if i != root_index]
-        result = inputs[root_index]
-        for i, other in enumerate(nonroot):
-            if i == 0:
-                result = result.add(other.cuda(destination, non_blocking=True))  # make a new tensor
-            else:
-                result.add_(other.cuda(destination, non_blocking=True))
+        result = inputs[root_index] + nonroot[0].cuda(destination, non_blocking=True)  # make a new tensor w/o clone
+        for other in nonroot[1:]:
+            result.add_(other.cuda(destination, non_blocking=True))
     return result
 
 

--- a/torch/cuda/comm.py
+++ b/torch/cuda/comm.py
@@ -42,7 +42,8 @@ def broadcast_coalesced(tensors, devices, buffer_size=10485760):
 def reduce_add(inputs, destination=None):
     """Sums tensors from multiple GPUs.
 
-    All inputs should have matching shapes.
+    All inputs should have matching shapes, dtype, and layout. The output tensor
+    will be of the same shape, dtype, and layout.
 
     Arguments:
         inputs (Iterable[Tensor]): an iterable of tensors to add.
@@ -51,34 +52,38 @@ def reduce_add(inputs, destination=None):
 
     Returns:
         A tensor containing an elementwise sum of all inputs, placed on the
-        ``destination`` device.
+        :attr:`destination` device.
     """
-    # TODO: try to find an input on another gpu, copy it,
-    # and accumulate into the copy
-    if destination is None:
-        destination = torch.cuda.current_device()
+    destination = torch.cuda._utils._get_device_index(destination, optional=True)
     input_size = inputs[0].size()
-    nccl_root = None
+    root_index = None  # index of input tensor that already is on the correct device
     for i, inp in enumerate(inputs):
         assert inp.is_cuda, "reduce_add expects all inputs to be on GPUs"
         if inp.get_device() == destination:
-            nccl_root = i
+            root_index = i
         if inp.size() != input_size:
             got = 'x'.join(str(x) for x in inp.size())
             expected = 'x'.join(str(x) for x in input_size)
             raise ValueError("input {} has invalid size: got {}, but expected "
                              "{}".format(i, got, expected))
-    if nccl_root is None:
+    if root_index is None:
         raise RuntimeError("reduce_add expects destination to be on the same GPU with one of the tensors")
-    result = inp.new(device=destination).resize_as_(inp).zero_()
 
-    if nccl.is_available(inputs) and inputs[0].get_device() == destination:
-        outputs = [result] + [t.new(t.size()) for t in inputs[1:]]
-        nccl.reduce(inputs, outputs, root=nccl_root)
-        return result
-    for inp in inputs:
-        input_correct_gpu = inp.cuda(result.get_device())
-        result.add_(input_correct_gpu)
+    if len(inputs) == 1:
+        return inputs[0]
+
+    if nccl.is_available(inputs):
+        result = torch.empty_like(inputs[root_index])
+        nccl.reduce(inputs, output=result, root=root_index)
+    else:
+        # clone inputs[root_index] and accuimulate into the copy
+        nonroot = [t for i, t in enumerate(inputs) if i != root_index]
+        result = inputs[root_index]
+        for i, other in enumerate(nonroot):
+            if i == 0:
+                result = result.add(other.cuda(destination, non_blocking=True))  # make a new tensor
+            else:
+                result.add_(other.cuda(destination, non_blocking=True))
     return result
 
 
@@ -107,7 +112,7 @@ def reduce_add_coalesced(inputs, destination=None, buffer_size=10485760):
     # process sparse ones first since they may have different sizes on different gpus
     for tensor_at_gpus in zip(*inputs):
         if all(t.is_sparse for t in tensor_at_gpus):
-            result = reduce_add(tensor_at_gpus, destination)
+            result = reduce_add(tensor_at_gpus, destination)  # this will be sparse too
             output.append(result)
             ref_order.append(tensor_at_gpus[0])
         else:
@@ -117,7 +122,7 @@ def reduce_add_coalesced(inputs, destination=None, buffer_size=10485760):
     itrs = [_take_tensors(tensors, buffer_size) for tensors in dense_tensors]
     # now the dense ones, which have consistent sizes
     for chunks in zip(*itrs):
-        flat_tensors = [_flatten_dense_tensors(chunk) for chunk in chunks]
+        flat_tensors = [_flatten_dense_tensors(chunk) for chunk in chunks]  # (num_gpus,)
         flat_result = reduce_add(flat_tensors, destination)
         for t in _unflatten_dense_tensors(flat_result, chunks[0]):
             # The unflattened tensors do not share storage, and we don't expose

--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -1,5 +1,8 @@
 import warnings
+
+import torch._six
 import torch.cuda
+
 
 __all__ = ['all_reduce', 'reduce', 'broadcast', 'all_gather', 'reduce_scatter']
 
@@ -7,6 +10,10 @@ SUM = 0  # ncclRedOp_t
 
 
 def is_available(tensors):
+    if not hasattr(torch._C, '_nccl_all_reduce'):
+        warnings.warn('PyTorch is not compiled with NCCL support')
+        return False
+
     devices = set()
     for tensor in tensors:
         if tensor.is_sparse:
@@ -19,10 +26,6 @@ def is_available(tensors):
         if device in devices:
             return False
         devices.add(device)
-
-    if not hasattr(torch._C, '_nccl_all_reduce'):
-        warnings.warn('PyTorch is not compiled with NCCL support')
-        return False
 
     return True
 
@@ -45,10 +48,27 @@ def all_reduce(inputs, outputs=None, op=SUM, streams=None, comms=None):
     torch._C._nccl_all_reduce(inputs, outputs, op, streams, comms)
 
 
-def reduce(inputs, outputs=None, root=0, op=SUM, streams=None, comms=None):
-    if outputs is None:
-        outputs = inputs
-    torch._C._nccl_reduce(inputs, outputs, root, op, streams, comms)
+# `output` used to be `outputs`, taking in a list of tensors. So we have two
+# arguments for BC reasons.
+def reduce(inputs, output=None, root=0, op=SUM, streams=None, comms=None, *, outputs=None):
+    if not isinstance(output, torch.Tensor) and isinstance(output, torch._six.container_abcs.Sequence):
+        # User called old API with positional arguments of list of output tensors.
+        if outputs is not None:
+            raise ValueError(
+                "'output' and 'outputs' can not be both specified. "
+                "'outputs' is deprecated in favor of 'output'.")
+        warnings.warn(
+            "nccl.reduce with an output tensor list is deprecated. "
+            "Please specify a single output tensor.")
+        output = output[root]
+    elif outputs is not None:
+        warnings.warn(
+            "nccl.reduce with an output tensor list is deprecated. "
+            "Please specify a single output tensor with argument 'output' instead instead.")
+        output = outputs[root]
+    elif output is None:
+        output = inputs[root]
+    torch._C._nccl_reduce(inputs, output, root, op, streams, comms)
 
 
 def broadcast(inputs, root=0, streams=None, comms=None):


### PR DESCRIPTION
While working on https://github.com/pytorch/pytorch/issues/38911, I realized that `nccl.reduce` only needs a single output tensor, while our current implementation requires a list of output tensors. This, along with a TODO I fixed in reduce_add, should have some speed up for data parallel.