### PR TITLE
Add CHECK-SOURCE-HIGHLIGHTED to file check utils.

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1034,14 +1034,17 @@ class TestList(JitTestCase):
             li = torch.jit.annotate(List[float], x.tolist())
             return li
 
-        with self.assertRaisesRegex(
-            RuntimeError, r"Expected type hint for result of tolist()"
+        with self.assertRaisesRegexWithHighlight(
+            RuntimeError,
+            r"Expected type hint for result of tolist()",
+            "x.tolist("
         ):
             self.checkScript(to_list_missing_type_annotation, (torch.randn(5),))
 
-        with self.assertRaisesRegex(
+        with self.assertRaisesRegexWithHighlight(
             RuntimeError,
             r"Return value was annotated as having type List\[float\] but is actually of type float",
+            "return li"
         ):
             self.checkScript(to_list_incorrect_type_annotation, (torch.randn(5),))
 

--- a/torch/csrc/jit/frontend/source_range.h
+++ b/torch/csrc/jit/frontend/source_range.h
@@ -46,6 +46,11 @@ struct Source {
     return line_starting_offsets_.at(line);
   }
 
+  // Returns number of lines present.
+  size_t num_lines() const {
+    return line_starting_offsets_.size();
+  }
+
   // Calculate the line (within the code segment) on which `offset` resides.
   size_t lineno_for_offset(size_t offset) const {
     return std::upper_bound(

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1398,7 +1398,9 @@ void initJitScriptBindings(PyObject* module) {
       .def("check_next", &testing::FileCheck::check_next)
       .def("check_count", &testing::FileCheck::check_count)
       .def("check_dag", &testing::FileCheck::check_dag)
-      .def("check_count", &testing::FileCheck::check_count)
+      .def(
+          "check_source_highlighted",
+          &testing::FileCheck::check_source_highlighted)
       .def(
           "check_count",
           [](testing::FileCheck& f,

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -34,6 +34,7 @@ enum CheckType {
   CHECK_NOT,
   CHECK_COUNT,
   CHECK_DAG,
+  CHECK_SOURCE_HIGHLIGHTED,
 };
 
 struct Check {
@@ -71,6 +72,9 @@ std::ostream& operator<<(std::ostream& out, const Check& c) {
       break;
     case CHECK_COUNT:
       out << "CHECK-COUNT-" << *c.count_;
+      break;
+    case CHECK_SOURCE_HIGHLIGHTED:
+      out << "CHECK-SOURCE-HIGHLIGHTED";
       break;
   }
   out << ": " << c.search_str_;
@@ -198,6 +202,7 @@ struct FileCheckImpl {
         {CHECK_NOT, "-NOT: "},
         {CHECK_DAG, "-DAG: "},
         {CHECK_COUNT, "-COUNT-"}, // needs special parsing
+        {CHECK_SOURCE_HIGHLIGHTED, "-SOURCE-HIGHLIGHTED: "},
     };
 
     for (const auto& check_pair : check_pairs) {
@@ -293,6 +298,60 @@ struct FileCheckImpl {
     }
   }
 
+  // Checks that source token is highlighted, does not advance search range.
+  void doCheckSourceHighlighted(
+      const Check& check,
+      const std::shared_ptr<Source>& source,
+      size_t start_offset) {
+    auto pos = source->text().find(check.search_str_, start_offset);
+    if (pos == std::string::npos) {
+      // Guaranteed to fail to generate error message.
+      assertFind(source, check.search_str_, start_offset, check);
+      return;
+    }
+
+    auto lineno = source->lineno_for_offset(pos);
+    auto col = pos - source->offset_for_line(lineno);
+    auto highlight_lineno = lineno + 1;
+
+    auto construct_error_and_throw = [&]() {
+      SourceRange error_range(source, pos, check.search_str_.size());
+      std::stringstream ss;
+      ss << "Expected to find ";
+      c10::printQuotedString(ss, check.search_str_);
+      ss << "highlighted but it is not." << std::endl;
+      error_range.highlight(ss);
+      throw std::runtime_error(ss.str());
+    };
+
+    if (highlight_lineno >= source->num_lines()) {
+      construct_error_and_throw();
+    }
+
+    auto highlight_start_offset =
+        source->offset_for_line(highlight_lineno) + col;
+    auto highlight_end_offset = std::min(
+        highlight_start_offset + check.search_str_.size(),
+        source->text().size());
+
+    if (highlight_end_offset >= source->text().size()) {
+      construct_error_and_throw();
+    }
+
+    SourceRange highlight_range(
+        source, highlight_start_offset, highlight_end_offset);
+    assertFind(highlight_range, std::string(highlight_range.size(), '~'));
+
+    assertNotFind(
+        SourceRange(source, highlight_start_offset - 1, highlight_start_offset),
+        "~",
+        check);
+    assertNotFind(
+        SourceRange(source, highlight_end_offset, highlight_end_offset + 1),
+        "~",
+        check);
+  }
+
   SourceRange matchDagGroup(
       const std::vector<Check>& group,
       const std::shared_ptr<Source>& source,
@@ -358,6 +417,10 @@ struct FileCheckImpl {
         }
         start_range = group_start_range;
       } break;
+      case CHECK_SOURCE_HIGHLIGHTED: {
+        doCheckSourceHighlighted(check, source, start_range);
+        break;
+      }
       case CHECK_DAG: {
         AT_ERROR();
       } break;
@@ -473,6 +536,12 @@ FileCheck* FileCheck::check_dag(const std::string& str) {
   fcImpl->addCheck(CHECK_DAG, str);
   return this;
 }
+
+FileCheck* FileCheck::check_source_highlighted(const std::string& str) {
+  fcImpl->addCheck(CHECK_SOURCE_HIGHLIGHTED, str);
+  return this;
+}
+
 } // namespace testing
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/testing/file_check.h
+++ b/torch/csrc/jit/testing/file_check.h
@@ -62,6 +62,9 @@ struct FileCheck {
   // individual checks.
   TORCH_API FileCheck* check_dag(const std::string& str);
 
+  // Checks that source token is highlighted in str (usually an error message).
+  TORCH_API FileCheck* check_source_highlighted(const std::string& str);
+
   // reset checks
   TORCH_API void reset();
 


### PR DESCRIPTION
Enhance FileCheck util to check for highlighted source ranges. This is useful when writing tests regarding generated error messages that require source code highlighting.

Here is how the error looks like in different cases:

- In case of needed source code token not found at all in input string:
```
RuntimeError: Expected to find "invalid_token" but did not find it
Searched string:

...  <--- HERE
def to_list_missing_type_annotation(x):
    # type: (torch.Tensor) -> List[float]
From CHECK-SOURCE-HIGHLIGHTED: invalid_token
```

- In case of source code token not highlighted:
```
Traceback (most recent call last):
  File "test_range.py", line 11, in <module>
    FileCheck().check_source_highlighted("x.tolist()").run(s)
RuntimeError: Expected to find "~~~~~~~~~~" but did not find it
Searched string:
    # type: (torch.Tensor) -> List[float]
    li = x.tolist()
         ~~~~~~~~~ <--- HERE
         ~~~~~~~~~~~~~~~~~~~...  <--- HERE
    return li
```

It is a bit confusing since both input text (usually an error message) and generated error messages have their highlighted portions, but this is consistent of previous behavior. Another option is to generate plain error messages without additional range highlighting on input text.

Test Plan:
Added unit test.

Closes #38698 
