### PR TITLE
Skip `test_minmax_illegal_dtype` on XLA

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9154,6 +9154,8 @@ class TestTorchDeviceType(TestCase):
         run_test((4, 4), (2, 1, 3, 4, 2))  # broadcasting A
         run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5))  # broadcasting A & b
 
+    # Assert for illegal dtype would not be raised on XLA
+    @onlyOnCPUAndCUDA
     def test_minmax_illegal_dtype(self, device):
         x = torch.randn(5, 5, dtype=torch.float32, device=device)
         valid_values = torch.empty(5, dtype=torch.float32, device=device)


### PR DESCRIPTION
It's better to have skipping logic explicitly defined in test decorators rather than in some hard-to-find blacklists