### PR TITLE
always resize_ min/max outputs

### DIFF
--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -10,7 +10,6 @@
 #include <c10/util/Optional.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/ReduceOpsUtils.h>
-#include <ATen/native/cpu/zmath.h>
 #include <ATen/native/cpu/Loops.h>
 
 namespace at { namespace native { namespace {
@@ -21,7 +20,6 @@ static inline void compare_base_kernel(Tensor& result, Tensor& indices,
     int64_t dim,
     bool keepdim,
     const func_t& f) {
-  const int64_t input_ndim = self.dim();
   auto self_sizes = ensure_nonempty_vec(self.sizes().vec());
   self_sizes[dim] = 1;
 


### PR DESCRIPTION
Resubmit of #36474. Addresses the comment in #35591, and makes behavior with `out` kwarg consistent with other functions that `resize_` their passed out.