### PR TITLE
Migrate `glu` from the TH to Aten (CUDA)

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5494,16 +5494,10 @@
 
 - func: glu.out(Tensor self, int dim=-1, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
-  dispatch:
-    CPU: glu_out
-    CUDA: legacy::cuda::_thnn_glu_forward_out
 
 - func: glu(Tensor self, int dim=-1) -> Tensor
   use_c10_dispatcher: full
   python_module: nn
-  dispatch:
-    CPU: glu
-    CUDA: legacy::cuda::_thnn_glu_forward
 
 - func: glu_backward.grad_input(Tensor grad_output, Tensor self, int dim, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn

--- a/aten/src/THCUNN/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/GatedLinearUnit.cu
@@ -5,18 +5,6 @@
 #include <THCUNN/common.h>
 #include <ATen/WrapDimUtils.h>
 
-template <typename Dtype, typename Acctype>
-struct gatedLinearCSigMul_functor
-{
-  __device__ void operator()(Dtype *target, const Dtype *sigTensor, const Dtype *mulTensor) const
-  {
-    const Acctype sigNum = Acctype(1)/(Acctype(1)+ exp(ScalarConvert<Dtype, Acctype>::to(-*sigTensor)));
-    const Dtype mulNum = *mulTensor;
-    *target = ScalarConvert<Acctype, Dtype>::to(sigNum * mulNum);
-  }
-};
-
-
 template<typename Dtype, typename Acctype>
 struct gatedLinearDerivative
 {

--- a/aten/src/THCUNN/generic/GatedLinearUnit.cu
+++ b/aten/src/THCUNN/generic/GatedLinearUnit.cu
@@ -2,35 +2,6 @@
 #define THC_GENERIC_FILE "THCUNN/generic/GatedLinearUnit.cu"
 #else
 
-void THNN_(GatedLinear_updateOutput)(
-           THCState *state,
-           THCTensor *input,
-           THCTensor *output,
-           int dim)
-{
-  THCUNN_assertSameGPU(state, 2, input, output);
-
-  dim = at::maybe_wrap_dim(dim, input);
-  // size output to half of input
-  const int64_t nIn = THCTensor_(sizeLegacyNoScalars)(state, input, dim);
-  THArgCheck(nIn % 2 == 0, 2, "Halving dimension must be even. Dim %d is size %ld",
-      dim, nIn);
-  const int64_t inputSize = THCTensor_(size)(state, input, dim) / 2;
-  std::vector<int64_t> newSizes = THTensor_sizesLegacyNoScalars(input);
-  newSizes[dim] = inputSize;
-  THCTensor_(resize)(state, output, newSizes, {});
-
-  // halve tensor
-  THCTensor *firstHalf = THCTensor_(newNarrow)(state, input, dim, 0, inputSize);
-  THCTensor *secondHalf = THCTensor_(newNarrow)(state, input, dim, inputSize, inputSize);
-
-  // x = x1:cmul( sigmoid(x2) )
-  THC_pointwiseApply3<scalar_t, scalar_t, scalar_t>(state, output, secondHalf, firstHalf, gatedLinearCSigMul_functor<scalar_t, accreal>());
-
-  THCTensor_(free)(state, firstHalf);
-  THCTensor_(free)(state, secondHalf);
-}
-
 void THNN_(GatedLinear_updateGradInput)(
            THCState *state,
            THCTensor *input,

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -26,12 +26,6 @@ THC_API void THNN_(ClassNLLCriterion_updateGradInput)(
                   THCTensor *total_weight,
                   int64_t ignore_index);
 
-THC_API void THNN_(GatedLinear_updateOutput)(
-                  THCState *state,
-                  THCTensor *input,
-                  THCTensor *output,
-                  int dim);
-
 THC_API void THNN_(GatedLinear_updateGradInput)(
                   THCState *state,
                   THCTensor *input,


### PR DESCRIPTION
Fix #24571

I tried to implement `glu_backward` in #39586 but encountered some performance issues, so this PR is opened only for the forward part. I'll clean up THCUNN in the PR for backward. 

# Benchmark

Built with `python setup.py develop`, running on a Tesla P100 GPU.

- Test script (modified from https://github.com/pytorch/pytorch/pull/33179):
```py
import torch
import torch.nn.functional as F
import time

torch.manual_seed(0)

def _time():
    if torch.cuda.is_available():
        torch.cuda.synchronize()
    return time.time()

device = "cuda"

#warm up
for n in [10, 100, 1000, 10000]:
    input = torch.randn(128, n, requires_grad=True, device=device)
    grad_output = torch.ones(128, n // 2, device=device)
    for i in range(1000):
        output = F.glu(input)
        output.backward(grad_output)

for n in [10, 100, 1000, 10000]:
    fwd_t = 0
    bwd_t = 0
    input = torch.randn(128, n, requires_grad=True, device=device)
    grad_output = torch.ones(128, n // 2, device=device)
    for i in range(10000):
        t1 = _time()
        output = F.glu(input)
        t2 = _time()
        output.backward(grad_output)
        t3 = _time()
        fwd_t = fwd_t + (t2 -t1)
        bwd_t = bwd_t + (t3 - t2)
    fwd_avg = fwd_t / 10000 * 1000
    bwd_avg = bwd_t / 10000 * 1000
    print("input size(128, %d) forward time is %.2f (ms); backwad avg time is %.2f (ms)."
          % (n, fwd_avg, bwd_avg))
```

- Before (as of commit [`9bfb91b50b53d332493d5179d3e17871f92efd2a`](https://github.com/pytorch/pytorch/tree/9bfb91b50b53d332493d5179d3e17871f92efd2a))
```
input size(128, 10) forward time is 0.08 (ms); backwad avg time is 0.17 (ms).
input size(128, 100) forward time is 0.08 (ms); backwad avg time is 0.17 (ms).
input size(128, 1000) forward time is 0.07 (ms); backwad avg time is 0.17 (ms).
input size(128, 10000) forward time is 0.07 (ms); backwad avg time is 0.17 (ms).
```

- After
```
input size(128, 10) forward time is 0.08 (ms); backwad avg time is 0.17 (ms).
input size(128, 100) forward time is 0.08 (ms); backwad avg time is 0.17 (ms).
input size(128, 1000) forward time is 0.08 (ms); backwad avg time is 0.17 (ms).
input size(128, 10000) forward time is 0.08 (ms); backwad avg time is 0.17 (ms).
```

cc: @VitalyFedyunin