### PR TITLE
Remove java documentation index

### DIFF
--- a/docs/source/packages.rst
+++ b/docs/source/packages.rst
@@ -1,7 +1,0 @@
-Javadoc
-=======
-
-.. toctree::
-   :maxdepth: 2
-
-   org/pytorch/package-index


### PR DESCRIPTION
Follow up of https://github.com/pytorch/pytorch/pull/38920#issuecomment-634325460

cc: @jlin27, @mattip