### PR TITLE
Use `ProgramFiles` environment variable on Windows

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -42,13 +42,14 @@ __all__ = [
 ################################################################################
 
 if sys.platform == 'win32':
+    pfiles_path = os.getenv('ProgramFiles', 'C:\\Program Files')
     py_dll_path = os.path.join(sys.exec_prefix, 'Library', 'bin')
     th_dll_path = os.path.join(os.path.dirname(__file__), 'lib')
 
     if not os.path.exists(os.path.join(th_dll_path, 'nvToolsExt64_1.dll')) and \
             not os.path.exists(os.path.join(py_dll_path, 'nvToolsExt64_1.dll')):
         nvtoolsext_dll_path = os.path.join(
-            os.getenv('NVTOOLSEXT_PATH', 'C:\\Program Files\\NVIDIA Corporation\\NvToolsExt'), 'bin', 'x64')
+            os.getenv('NVTOOLSEXT_PATH', os.path.join(pfiles_path, 'NVIDIA Corporation', 'NvToolsExt')), 'bin', 'x64')
     else:
         nvtoolsext_dll_path = ''
 
@@ -58,7 +59,7 @@ if sys.platform == 'win32':
             len(glob.glob(os.path.join(py_dll_path, 'cudart64*.dll'))) == 0:
         cuda_version_1 = cuda_version.replace('.', '_')
         cuda_path_var = 'CUDA_PATH_V' + cuda_version_1
-        default_path = 'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v' + cuda_version
+        default_path = os.path.join(pfiles_path, 'NVIDIA GPU Computing Toolkit', 'CUDA', 'v' + cuda_version)
         cuda_path = os.path.join(os.getenv(cuda_path_var, default_path), 'bin')
     else:
         cuda_path = ''


### PR DESCRIPTION
'Program Files' does not have to be on disk C (nor necesserily should
be called `Program Files`)

