### PR TITLE
Remove duplicated entries in `random.rst`

### DIFF
--- a/docs/source/random.rst
+++ b/docs/source/random.rst
@@ -5,16 +5,3 @@ torch.random
 
 .. automodule:: torch.random
    :members:
-
-Random Number Generator
--------------------------
-.. FIXME: We're missing torch.random.cuda docs.
-   https://github.com/pytorch/pytorch/issues/27778
-
-.. autofunction:: get_rng_state
-.. autofunction:: set_rng_state
-.. autofunction:: manual_seed
-.. autofunction:: seed
-.. autofunction:: initial_seed
-.. autofunction:: fork_rng
-


### PR DESCRIPTION
In the current master doc, every function under [`torch.random`](https://pytorch.org/docs/master/random.html) appears twice because the function docs are generated by both `automodule` and `autofunction`. 

This PR removes the parts generated by `autofunction`. 


See changed docs at https://5751500-65600975-gh.circle-artifacts.com/0/docs/random.html: 

![image](https://user-images.githubusercontent.com/6421097/84165823-bf720580-aa39-11ea-9149-c428d43260f8.png)
