### PR TITLE
Add `generator=` kwarg for DataLoader & random samplers

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1204,10 +1204,12 @@ except RuntimeError as e:
         self.assertEqual(len(seeds), num_workers)
 
     def test_worker_seed_reproducibility(self):
+        def get_dataloader():
+            return DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, generator=torch.Generator().manual_seed(42))
+
         num_workers = 6
         batch_size = 1
         dataset = SynchronizedSeedDataset(num_workers, batch_size, num_workers)
-        get_dataloader = lambda: DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, generator=torch.Generator().manual_seed(42))
         self.assertEqual(set(int(batch) for batch in get_dataloader()), set(int(batch) for batch in get_dataloader()))
 
     def test_worker_init_fn(self):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1228,10 +1228,11 @@ except RuntimeError as e:
         self._test_shuffle(DataLoader(self.dataset, batch_size=2, shuffle=True))
 
     def test_shuffle_reproducibility(self):
-        self.assertEqual(
-            list(DataLoader(self.dataset, shuffle=True, generator=torch.Generator().manual_seed(42))),
-            list(DataLoader(self.dataset, shuffle=True, generator=torch.Generator().manual_seed(42)))
-        )
+        for fn in (
+            lambda: DataLoader(self.dataset, shuffle=True, num_workers=0, generator=torch.Generator().manual_seed(42)),
+            lambda: DataLoader(self.dataset, shuffle=True, num_workers=2, generator=torch.Generator().manual_seed(42)),
+        ):
+            self.assertEqual(list(fn()), list(fn()))
 
     def test_sequential_workers(self):
         self._test_sequential(DataLoader(self.dataset, num_workers=4))

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1203,6 +1203,15 @@ except RuntimeError as e:
             seeds.add(batch[0])
         self.assertEqual(len(seeds), num_workers)
 
+    def test_worker_seed_reproducibility(self):
+        num_workers = 6
+        batch_size = 1
+        dataset = SynchronizedSeedDataset(num_workers, batch_size, num_workers)
+        dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, generator=torch.Generator().manual_seed(42))
+        actual_seeds = set(int(batch) for batch in dataloader)
+        expected_seeds = set(6909045637428952499 + i for i in range(num_workers))
+        self.assertEqual(actual_seeds, expected_seeds)
+
     def test_worker_init_fn(self):
         dataset = SeedDataset(4)
         dataloader = DataLoader(dataset, batch_size=2, num_workers=2,

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1325,18 +1325,15 @@ except RuntimeError as e:
     def test_sampler_reproducibility(self):
         from torch.utils.data import RandomSampler, WeightedRandomSampler, SubsetRandomSampler
 
-        generator = torch.Generator().manual_seed(42)
-
+        weights = [0.1, 0.9, 0.4, 0.7, 3.0, 0.6]
         for fn in (
-            lambda: RandomSampler(self.dataset, num_samples=5, replacement=True, generator=generator),
-            lambda: RandomSampler(self.dataset, replacement=False, generator=generator),
-            lambda: WeightedRandomSampler(self.dataset, num_samples=5, replacement=True, generator=generator),
-            lambda: WeightedRandomSampler(self.dataset, replacement=False, generator=generator),
-            lambda: SubsetRandomSampler(range(10), generator=generator),
+            lambda: RandomSampler(self.dataset, num_samples=5, replacement=True, generator=torch.Generator().manual_seed(42)),
+            lambda: RandomSampler(self.dataset, replacement=False, generator=torch.Generator().manual_seed(42)),
+            lambda: WeightedRandomSampler(weights, num_samples=5, replacement=True, generator=torch.Generator().manual_seed(42)),
+            lambda: WeightedRandomSampler(weights, num_samples=5, replacement=False, generator=torch.Generator().manual_seed(42)),
+            lambda: SubsetRandomSampler(range(10), generator=torch.Generator().manual_seed(42)),
         ):
-            print(fn)
-            print(list(fn()))
-            assert(list(fn()) == list(fn()))
+            self.assertEqual(list(fn()), list(fn()))
 
 
     def _test_sampler(self, **kwargs):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1329,12 +1329,14 @@ except RuntimeError as e:
 
         for fn in (
             lambda: RandomSampler(self.dataset, num_samples=5, replacement=True, generator=generator),
-            lambda: RandomSampler(self.dataset, num_samples=5, replacement=False, generator=generator),
+            lambda: RandomSampler(self.dataset, replacement=False, generator=generator),
             lambda: WeightedRandomSampler(self.dataset, num_samples=5, replacement=True, generator=generator),
-            lambda: WeightedRandomSampler(self.dataset, num_samples=5, replacement=False, generator=generator),
+            lambda: WeightedRandomSampler(self.dataset, replacement=False, generator=generator),
             lambda: SubsetRandomSampler(range(10), generator=generator),
         ):
-            self.assertEqual(list(fn()), list(fn()))
+            print(fn)
+            print(list(fn()))
+            assert(list(fn()) == list(fn()))
 
 
     def _test_sampler(self, **kwargs):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1207,10 +1207,8 @@ except RuntimeError as e:
         num_workers = 6
         batch_size = 1
         dataset = SynchronizedSeedDataset(num_workers, batch_size, num_workers)
-        dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, generator=torch.Generator().manual_seed(42))
-        actual_seeds = set(int(batch) for batch in dataloader)
-        expected_seeds = set(6909045637428952499 + i for i in range(num_workers))
-        self.assertEqual(actual_seeds, expected_seeds)
+        get_dataloader = lambda: DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, generator=torch.Generator().manual_seed(42))
+        self.assertEqual(set(int(batch) for batch in get_dataloader()), set(int(batch) for batch in get_dataloader()))
 
     def test_worker_init_fn(self):
         dataset = SeedDataset(4)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -225,6 +225,7 @@ class DataLoader(object):
         self.drop_last = drop_last
         self.sampler = sampler
         self.batch_sampler = batch_sampler
+        self.generator = generator
 
         if collate_fn is None:
             if self._auto_collation:
@@ -338,7 +339,7 @@ class _BaseDataLoaderIter(object):
         self._timeout = loader.timeout
         self._collate_fn = loader.collate_fn
         self._sampler_iter = iter(self._index_sampler)
-        self._base_seed = torch.empty((), dtype=torch.int64).random_().item()
+        self._base_seed = torch.empty((), dtype=torch.int64).random_(generator=loader.generator).item()
         self._num_yielded = 0
 
     def __iter__(self):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -122,7 +122,8 @@ class DataLoader(object):
     def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None,
                  batch_sampler=None, num_workers=0, collate_fn=None,
                  pin_memory=False, drop_last=False, timeout=0,
-                 worker_init_fn=None, multiprocessing_context=None):
+                 worker_init_fn=None, multiprocessing_context=None,
+                 generator=None):
         torch._C._log_api_usage_once("python.data_loader")
 
         if num_workers < 0:
@@ -212,7 +213,7 @@ class DataLoader(object):
                 sampler = _InfiniteConstantSampler()
             else:  # map-style
                 if shuffle:
-                    sampler = RandomSampler(dataset)
+                    sampler = RandomSampler(dataset, generator=generator)
                 else:
                     sampler = SequentialSampler(dataset)
 

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -74,12 +74,14 @@ class RandomSampler(Sampler):
         replacement (bool): samples are drawn with replacement if ``True``, default=``False``
         num_samples (int): number of samples to draw, default=`len(dataset)`. This argument
             is supposed to be specified only when `replacement` is ``True``.
+        generator (Generator): Generator used in sampling.
     """
 
-    def __init__(self, data_source, replacement=False, num_samples=None):
+    def __init__(self, data_source, replacement=False, num_samples=None, generator=None):
         self.data_source = data_source
         self.replacement = replacement
         self._num_samples = num_samples
+        self.generator = generator
 
         if not isinstance(self.replacement, bool):
             raise TypeError("replacement should be a boolean value, but got "
@@ -103,8 +105,9 @@ class RandomSampler(Sampler):
     def __iter__(self):
         n = len(self.data_source)
         if self.replacement:
-            return iter(torch.randint(high=n, size=(self.num_samples,), dtype=torch.int64).tolist())
-        return iter(torch.randperm(n).tolist())
+            rand_tensor = torch.randint(high=n, size=(self.num_samples,), dtype=torch.int64, generator=self.generator)
+            return iter(rand_tensor.tolist())
+        return iter(torch.randperm(n, generator=self.generator).tolist())
 
     def __len__(self):
         return self.num_samples
@@ -115,13 +118,15 @@ class SubsetRandomSampler(Sampler):
 
     Arguments:
         indices (sequence): a sequence of indices
+        generator (Generator): Generator used in sampling.
     """
 
-    def __init__(self, indices):
+    def __init__(self, indices, generator=None):
         self.indices = indices
+        self.generator = generator
 
     def __iter__(self):
-        return (self.indices[i] for i in torch.randperm(len(self.indices)))
+        return (self.indices[i] for i in torch.randperm(len(self.indices), generator=self.generator))
 
     def __len__(self):
         return len(self.indices)
@@ -136,6 +141,7 @@ class WeightedRandomSampler(Sampler):
         replacement (bool): if ``True``, samples are drawn with replacement.
             If not, they are drawn without replacement, which means that when a
             sample index is drawn for a row, it cannot be drawn again for that row.
+        generator (Generator): Generator used in sampling.
 
     Example:
         >>> list(WeightedRandomSampler([0.1, 0.9, 0.4, 0.7, 3.0, 0.6], 5, replacement=True))
@@ -144,8 +150,13 @@ class WeightedRandomSampler(Sampler):
         [0, 1, 4, 3, 2]
     """
 
+<<<<<<< Updated upstream
     def __init__(self, weights, num_samples, replacement=True):
         if not isinstance(num_samples, _int_classes) or isinstance(num_samples, bool) or \
+=======
+    def __init__(self, weights, num_samples, replacement=True, generator=None):
+        if not isinstance(num_samples, int) or isinstance(num_samples, bool) or \
+>>>>>>> Stashed changes
                 num_samples <= 0:
             raise ValueError("num_samples should be a positive integer "
                              "value, but got num_samples={}".format(num_samples))
@@ -155,9 +166,11 @@ class WeightedRandomSampler(Sampler):
         self.weights = torch.as_tensor(weights, dtype=torch.double)
         self.num_samples = num_samples
         self.replacement = replacement
+        self.generator = generator
 
     def __iter__(self):
-        return iter(torch.multinomial(self.weights, self.num_samples, self.replacement).tolist())
+        rand_tensor = torch.multinomial(self.weights, self.num_samples, self.replacement, generator=self.generator)
+        return iter(rand_tensor.tolist())
 
     def __len__(self):
         return self.num_samples

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -150,13 +150,8 @@ class WeightedRandomSampler(Sampler):
         [0, 1, 4, 3, 2]
     """
 
-<<<<<<< Updated upstream
-    def __init__(self, weights, num_samples, replacement=True):
-        if not isinstance(num_samples, _int_classes) or isinstance(num_samples, bool) or \
-=======
     def __init__(self, weights, num_samples, replacement=True, generator=None):
-        if not isinstance(num_samples, int) or isinstance(num_samples, bool) or \
->>>>>>> Stashed changes
+        if not isinstance(num_samples, _int_classes) or isinstance(num_samples, bool) or \
                 num_samples <= 0:
             raise ValueError("num_samples should be a positive integer "
                              "value, but got num_samples={}".format(num_samples))


### PR DESCRIPTION
Fix #39572

Add `generator=` kwarg for DataLoader & random samplers

cc: @SsnL, @deeppatel4557, @albanD, @mitar 