### PR TITLE
[iOS] Add nonVarTypeModeGuard to fix the unit test

### DIFF
--- a/ios/TestApp/TestAppTests/TestAppTests.mm
+++ b/ios/TestApp/TestAppTests/TestAppTests.mm
@@ -28,6 +28,7 @@
   std::vector<c10::IValue> inputs;
   inputs.push_back(torch::ones({1, 3, 224, 224}, at::ScalarType::Float));
   torch::autograd::AutoGradMode guard(false);
+  at::AutoNonVariableTypeMode nonVarTypeModeGuard(true);
   auto outputTensor = _module.forward(inputs).toTensor();
   float* outputBuffer = outputTensor.data_ptr<float>();
   XCTAssertTrue(outputBuffer != nullptr, @"");


### PR DESCRIPTION
### Summary

Still need this RAII guard for full JIT

### Test Plan

- CI checks

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39743 [iOS] Add nonVarTypeModeGuard to fix the unit test**

Differential Revision: [D21968256](https://our.internmc.facebook.com/intern/diff/D21968256)