### PR TITLE
[JIT] Improve error message when type annotation Future without a contained type

### DIFF
--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -536,6 +536,12 @@ class TestAsync(JitTestCase):
             extra_files['bar'] = ''
             torch.jit.load(buffer, _extra_files=extra_files)
 
+    def test_no_future_subtype_message(self):
+        with self.assertRaisesRegex(RuntimeError, 'Future without a contained type'):
+            @torch.jit.script
+            def forward(self, x):
+                futs = torch.jit.annotate(List[torch.jit.Future], [])
+
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -629,6 +629,10 @@ class RRef(Generic[T]):
         self.__args__ = types
 
 def is_future(ann):
+    if ann is Future:
+        raise RuntimeError('Attempted to use torch.jit.Future without a '
+                           'contained type. Please add a contained type, e.g. '
+                           'torch.jit.Future[int]')
     return getattr(ann, "__origin__", None) is Future
 
 def is_rref(ann):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39761 [JIT] Resolve fully-qualified Future name in script type parser
* **#39751 [JIT] Improve error message when type annotation Future without a contained type**

Before it would complain about not being able to get the source code for `torch.jit.Future`. I think this is a much more actionable error message

Differential Revision: [D21960368](https://our.internmc.facebook.com/intern/diff/D21960368)