### PR TITLE
[TensorExpr] Fix IRPrinter for function calls with uniqued names

### DIFF
--- a/test/cpp/tensorexpr/test_ir_printer.cpp
+++ b/test/cpp/tensorexpr/test_ir_printer.cpp
@@ -1,9 +1,12 @@
 #include <stdexcept>
 #include "test/cpp/tensorexpr/test_base.h"
 
-#include "torch/csrc/jit/tensorexpr/expr.h"
-#include "torch/csrc/jit/tensorexpr/ir.h"
-#include "torch/csrc/jit/tensorexpr/ir_printer.h"
+#include <torch/csrc/jit/tensorexpr/expr.h>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_printer.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+#include <torch/csrc/jit/testing/file_check.h>
 
 #include <sstream>
 namespace torch {
@@ -44,6 +47,52 @@ void testIRPrinterCastTest() {
   std::stringstream ss;
   ss << body;
   ASSERT_EQ(ss.str(), "2.f + (float(x) * 3.f + 4.f * y)");
+}
+
+void testIRPrinterFunctionName() {
+  KernelScope kernel_scope;
+  int M = 4;
+  int N = 20;
+
+  Tensor* producer = Compute(
+      "producer",
+      {{M, "m"}, {N, "n"}},
+      [&](const ExprHandle& m, const ExprHandle& n) { return m * n; });
+
+  Tensor* chunk_0 = Compute(
+      "chunk",
+      {{M, "m"}, {N / 2, "n"}},
+      [&](const ExprHandle& m, const ExprHandle& n) {
+        return producer->call(m, n);
+      });
+
+  Tensor* chunk_1 = Compute(
+      "chunk",
+      {{M, "m"}, {N / 2, "n"}},
+      [&](const ExprHandle& m, const ExprHandle& n) {
+        return producer->call(m, n + ExprHandle(N / 2));
+      });
+
+  Tensor* consumer = Compute(
+      "consumer",
+      {{M, "i"}, {N / 2, "j"}},
+      [&](const ExprHandle& i, const ExprHandle& j) {
+        return i * chunk_1->call(i, j);
+      });
+
+  LoopNest l({chunk_0, chunk_1, consumer});
+  auto* body = l.root_stmt();
+
+  std::stringstream ss;
+  ss << *body;
+
+  const std::string& verification_pattern =
+      R"IR(
+ # CHECK:   for (int i
+ # CHECK:    for (int j
+ # CHECK:     consumer[i, j] = i * (chunk_1(i, j)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, ss.str());
 }
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -34,6 +34,7 @@ namespace jit {
   _(IRPrinterBasicValueTest)                \
   _(IRPrinterBasicValueTest02)              \
   _(IRPrinterCastTest)                      \
+  _(IRPrinterFunctionName)                  \
   _(ExprSimple01)                           \
   _(ExprLower01)                            \
   _(ExprSimple02)                           \

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -266,6 +266,17 @@ void IRPrinter::visit(const BaseCallNode* v) {
   os() << ")";
 }
 
+void IRPrinter::visit(const FunctionCall* v) {
+  os() << *v->tensor()->buf() << "(";
+  for (int i = 0; i < v->nparams(); i++) {
+    if (i > 0) {
+      os() << ", ";
+    }
+    os() << *v->param(i);
+  }
+  os() << ")";
+}
+
 void IRPrinter::visit(const Term* v) {
   os() << "Term(";
   v->scalar()->accept(this);

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -43,6 +43,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const Broadcast* v) override;
   void visit(const IfThenElse* v) override;
   void visit(const BaseCallNode* v) override;
+  void visit(const FunctionCall* v) override;
   void visit(const Term* v) override;
   void visit(const Polynomial* v) override;
   void visit(const RoundOff* v) override;


### PR DESCRIPTION
IRPrinter was using the name_hint rather than the uniqued name when printing FunctionCalls, leading to output that appeared incorrect.

E.g. for the following set of tensorexprs:
```
producer[M, N] = M * N;
chunk[M, N/2] = producer[M, N];
chunk_1[M, N/2] = producer[M, N + N/2];
consumer[M, N] = chunk_1[M, N];
```

Before fix:
```
{
  for (int m = 0; m < 4; m++) {
    for (int n = 0; n < 20; n++) {
      producer[m, n] = m * n;
    }
  }
  for (int m_1 = 0; m_1 < 4; m_1++) {
    for (int n_1 = 0; n_1 < 10; n_1++) {
      chunk[m_1, n_1] = producer(m_1, n_1);
    }
  }
  for (int m_2 = 0; m_2 < 4; m_2++) {
    for (int n_2 = 0; n_2 < 10; n_2++) {
      chunk_1[m_2, n_2] = producer(m_2, n_2 + 10);
    }
  }
  for (int i = 0; i < 4; i++) {
    for (int j = 0; j < 10; j++) {
      consumer[i, j] = i * (chunk(i, j));          <----- HERE!  
    }
  }
}
```

After fix:
```
{
  for (int m = 0; m < 4; m++) {
    for (int n = 0; n < 20; n++) {
      producer[m, n] = m * n;
    }
  }
  for (int m_1 = 0; m_1 < 4; m_1++) {
    for (int n_1 = 0; n_1 < 10; n_1++) {
      chunk[m_1, n_1] = producer(m_1, n_1);
    }
  }
  for (int m_2 = 0; m_2 < 4; m_2++) {
    for (int n_2 = 0; n_2 < 10; n_2++) {
      chunk_1[m_2, n_2] = producer(m_2, n_2 + 10);
    }
  }
  for (int i = 0; i < 4; i++) {
    for (int j = 0; j < 10; j++) {
      consumer[i, j] = i * (chunk_1(i, j));          <----- HERE!
    }
  }
}
```
