### PR TITLE
Add rpc.async_execution support for rpc.remote on script functions

### DIFF
--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -349,6 +349,7 @@ PyRRef pyRemoteTorchscript(
     const std::string& dstWorkerName,
     const std::string& qualifiedNameStr,
     const float rpcTimeoutSeconds,
+    const bool isAsyncExecuion,
     const py::args& args,
     const py::kwargs& kwargs) {
   DCHECK(!PyGILState_Check());
@@ -366,7 +367,12 @@ PyRRef pyRemoteTorchscript(
   }
   DCHECK(!PyGILState_Check());
   auto rrefPtr = remoteTorchscript(
-      dstWorkerName, qualifiedName, functionSchema, stack, rpcTimeoutSeconds);
+      dstWorkerName,
+      qualifiedName,
+      functionSchema,
+      stack,
+      rpcTimeoutSeconds,
+      isAsyncExecuion);
   return PyRRef(rrefPtr);
 }
 

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -349,7 +349,7 @@ PyRRef pyRemoteTorchscript(
     const std::string& dstWorkerName,
     const std::string& qualifiedNameStr,
     const float rpcTimeoutSeconds,
-    const bool isAsyncExecuion,
+    const bool isAsyncExecution,
     const py::args& args,
     const py::kwargs& kwargs) {
   DCHECK(!PyGILState_Check());
@@ -372,7 +372,7 @@ PyRRef pyRemoteTorchscript(
       functionSchema,
       stack,
       rpcTimeoutSeconds,
-      isAsyncExecuion);
+      isAsyncExecution);
   return PyRRef(rrefPtr);
 }
 

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -61,6 +61,7 @@ PyRRef pyRemoteTorchscript(
     const std::string& dstWorkerName,
     const std::string& qualifiedNameStr,
     const float rpcTimeoutSeconds,
+    const bool isAsyncExecuion,
     const py::args& args,
     const py::kwargs& kwargs);
 

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -61,7 +61,7 @@ PyRRef pyRemoteTorchscript(
     const std::string& dstWorkerName,
     const std::string& qualifiedNameStr,
     const float rpcTimeoutSeconds,
-    const bool isAsyncExecuion,
+    const bool isAsyncExecution,
     const py::args& args,
     const py::kwargs& kwargs);
 

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -345,7 +345,8 @@ void RequestCallbackImpl::processRpc(
       }
 
       auto setRRefValue = [ownerRRef, postProcessing](
-          const c10::intrusive_ptr<c10::ivalue::Future>& jitFuture) mutable {
+                              const c10::intrusive_ptr<c10::ivalue::Future>&
+                                  jitFuture) mutable {
         try {
           ownerRRef->setValue(jitFuture->value());
         } catch (const std::exception& e) {
@@ -355,11 +356,12 @@ void RequestCallbackImpl::processRpc(
       };
 
       auto isAsyncExecution = scriptRemoteCall.isAsyncExecution();
-      auto asyncPostProcessing = [ownerRRef,
-                                  postProcessing,
-                                  setRRefValue{std::move(setRRefValue)},
-                                  isAsyncExecution](
-          const c10::intrusive_ptr<c10::ivalue::Future>& jitFuture) mutable {
+      auto asyncPostProcessing =
+          [ownerRRef,
+           postProcessing,
+           setRRefValue{std::move(setRRefValue)},
+           isAsyncExecution](const c10::intrusive_ptr<c10::ivalue::Future>&
+                                 jitFuture) mutable {
             if (isAsyncExecution) {
               // The user function will return a JIT future, install
               // setRRefValue and postProcessing to that valueFuture
@@ -367,7 +369,7 @@ void RequestCallbackImpl::processRpc(
                 auto valueJitFuture = jitFuture->value().toFuture();
                 valueJitFuture->addCallback(
                     [valueJitFuture,
-                  setRRefValue{std::move(setRRefValue)}]() mutable {
+                     setRRefValue{std::move(setRRefValue)}]() mutable {
                       setRRefValue(valueJitFuture);
                     });
               } catch (const std::exception& e) {

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -21,8 +21,9 @@ ScriptRemoteCall::ScriptRemoteCall(
     const c10::QualifiedName& qualifiedName,
     std::vector<at::IValue>&& stack,
     const RRefId& retRRefId,
-    const ForkId& retForkId)
-    : ScriptCall(qualifiedName, std::move(stack)),
+    const ForkId& retForkId,
+    const bool isAsyncExecution)
+    : ScriptCall(qualifiedName, std::move(stack), isAsyncExecution),
       retRRefId_(retRRefId),
       retForkId_(retForkId) {}
 
@@ -44,7 +45,8 @@ std::unique_ptr<ScriptRemoteCall> ScriptRemoteCall::fromIValues(
         scriptCallPtr->qualifiedName(),
         std::move(ivalues),
         retRRefId,
-        retForkId);
+        retForkId,
+        scriptCallPtr->isAsyncExecution());
   }
 }
 

--- a/torch/csrc/distributed/rpc/script_remote_call.h
+++ b/torch/csrc/distributed/rpc/script_remote_call.h
@@ -30,7 +30,8 @@ class TORCH_API ScriptRemoteCall final : public ScriptCall {
       const c10::QualifiedName& qualifiedName,
       std::vector<at::IValue>&& stack,
       const RRefId& retRRefId,
-      const ForkId& retForkId);
+      const ForkId& retForkId,
+      const bool isAsyncExecution);
 
   inline const RRefId& retRRefId() const {
     return retRRefId_;

--- a/torch/csrc/distributed/rpc/torchscript_functions.cpp
+++ b/torch/csrc/distributed/rpc/torchscript_functions.cpp
@@ -17,9 +17,9 @@ c10::intrusive_ptr<c10::ivalue::Future> rpcTorchscript(
     const c10::FunctionSchema& functionSchema,
     std::vector<c10::IValue>& stack,
     const float rpcTimeoutSeconds,
-    const bool asyncFunction) {
+    const bool isAsyncFunction) {
   auto scriptCall = std::make_unique<ScriptCall>(
-      qualifiedName, std::move(stack), asyncFunction);
+      qualifiedName, std::move(stack), isAsyncFunction);
   auto rpcAgentPtr = RpcAgent::getCurrentRpcAgent();
   auto futMessage = autograd::sendMessageWithAutograd(
       *rpcAgentPtr,
@@ -57,7 +57,8 @@ c10::intrusive_ptr<RRef> remoteTorchscript(
     const c10::QualifiedName& qualifiedName,
     const c10::FunctionSchema& functionSchema,
     std::vector<c10::IValue>& stack,
-    const float rpcTimeoutSeconds) {
+    const float rpcTimeoutSeconds,
+    const bool isAsyncExecution) {
   auto rpcAgentPtr = RpcAgent::getCurrentRpcAgent();
   auto dstWorkerInfo = rpcAgentPtr->getWorkerInfo(dstWorkerName);
   auto& ctx = RRefContext::getInstance();
@@ -79,7 +80,8 @@ c10::intrusive_ptr<RRef> remoteTorchscript(
         qualifiedName,
         std::move(stack),
         userRRefPtr->rrefId(),
-        userRRefPtr->forkId());
+        userRRefPtr->forkId(),
+        isAsyncExecution);
 
     auto fm = torch::distributed::autograd::sendMessageWithAutograd(
         *rpcAgentPtr,
@@ -105,7 +107,8 @@ c10::intrusive_ptr<RRef> remoteTorchscript(
         qualifiedName,
         std::move(stack),
         ownerRRefPtr->rrefId(),
-        ownerRRefPtr->rrefId());
+        ownerRRefPtr->rrefId(),
+        isAsyncExecution);
 
     auto fm = torch::distributed::autograd::sendMessageWithAutograd(
         *rpcAgentPtr,

--- a/torch/csrc/distributed/rpc/torchscript_functions.cpp
+++ b/torch/csrc/distributed/rpc/torchscript_functions.cpp
@@ -17,9 +17,9 @@ c10::intrusive_ptr<c10::ivalue::Future> rpcTorchscript(
     const c10::FunctionSchema& functionSchema,
     std::vector<c10::IValue>& stack,
     const float rpcTimeoutSeconds,
-    const bool isAsyncFunction) {
+    const bool isAsyncExecution) {
   auto scriptCall = std::make_unique<ScriptCall>(
-      qualifiedName, std::move(stack), isAsyncFunction);
+      qualifiedName, std::move(stack), isAsyncExecution);
   auto rpcAgentPtr = RpcAgent::getCurrentRpcAgent();
   auto futMessage = autograd::sendMessageWithAutograd(
       *rpcAgentPtr,

--- a/torch/csrc/distributed/rpc/torchscript_functions.h
+++ b/torch/csrc/distributed/rpc/torchscript_functions.h
@@ -26,14 +26,15 @@ c10::intrusive_ptr<c10::ivalue::Future> TORCH_API rpcTorchscript(
     const c10::FunctionSchema& functionSchema,
     std::vector<c10::IValue>& stack,
     const float rpcTimeoutSeconds = torch::distributed::rpc::kUnsetRpcTimeout,
-    const bool asyncFunction = false);
+    const bool isAsyncExecution = false);
 
 c10::intrusive_ptr<RRef> TORCH_API remoteTorchscript(
     const std::string& dstWorkerName,
     const c10::QualifiedName& qualifiedName,
     const c10::FunctionSchema& functionSchema,
     std::vector<c10::IValue>& stack,
-    const float rpcTimeoutSeconds = torch::distributed::rpc::kUnsetRpcTimeout);
+    const float rpcTimeoutSeconds = torch::distributed::rpc::kUnsetRpcTimeout,
+    const bool isAsyncExecution = false);
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -489,6 +489,11 @@ def remote(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
 
         is_async_exec = hasattr(func, "_wrapped_async_rpc_function")
 
+        if is_async_exec:
+            wrapped = func._wrapped_async_rpc_function
+            if isinstance(wrapped, torch.jit.ScriptFunction):
+                func = wrapped
+
         if qualified_name is not None:
             rref = _invoke_remote_builtin(dst_worker_info, qualified_name, timeout, *args, **kwargs)
         elif isinstance(func, torch.jit.ScriptFunction):
@@ -496,6 +501,7 @@ def remote(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
                 dst_worker_info.name,
                 torch._jit_internal._qualified_name(func),
                 timeout,
+                is_async_exec,
                 *args,
                 **kwargs,
             )

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -1105,3 +1105,46 @@ class JitRpcTest(RRefAPITest, RRefTypingTest, LocalRRefTest, JitRpcAsyncOpTest, 
             def async_wrong_decorator_order(to, x, y):
                 # type: (str, Tensor, Tensor) -> Future[Tensor]
                 return rpc.rpc_async(to, script_add, (x, y))
+
+    @dist_init
+    def test_async_function_remote(self):
+        dst1 = worker_name((self.rank + 1) % self.world_size)
+        dst2 = worker_name((self.rank + 2) % self.world_size)
+
+        rref = rpc.remote(
+            dst1,
+            async_add,
+            args=(dst2, torch.ones(2, 2), torch.ones(2, 2))
+        )
+        self.assertEqual(rref.to_here(), torch.ones(2, 2) + 1)
+
+    @dist_init
+    def test_async_function_remote_multi(self):
+        dst1 = worker_name((self.rank + 1) % self.world_size)
+        dst2 = worker_name((self.rank + 2) % self.world_size)
+
+        num = 20
+        rrefs = []
+        for i in range(num):
+            rrefs.append(
+                rpc.remote(
+                    dst1,
+                    async_add,
+                    args=(dst2, torch.ones(2, 2), torch.ones(2, 2) * i)
+                )
+            )
+
+        for i in range(num):
+            self.assertEqual(rrefs[i].to_here(), torch.ones(2, 2) + i)
+
+    @dist_init
+    def test_async_function_wrong_return_type_remote(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected Future but got Tensor"
+        ):
+            rref = rpc.remote(
+                worker_name((self.rank + 1) % self.world_size),
+                async_wrong_type
+            )
+            rref.to_here()

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -1139,12 +1139,13 @@ class JitRpcTest(RRefAPITest, RRefTypingTest, LocalRRefTest, JitRpcAsyncOpTest, 
 
     @dist_init
     def test_async_function_wrong_return_type_remote(self):
+        rref = rpc.remote(
+            worker_name((self.rank + 1) % self.world_size),
+            async_wrong_type
+        )
+
         with self.assertRaisesRegex(
             RuntimeError,
             "Expected Future but got Tensor"
         ):
-            rref = rpc.remote(
-                worker_name((self.rank + 1) % self.world_size),
-                async_wrong_type
-            )
             rref.to_here()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39758 Add rpc.async_execution support for rpc.remote on script functions**

Differential Revision: [D21963789](https://our.internmc.facebook.com/intern/diff/D21963789)