### PR TITLE
[caffe2] Fix of initializing ATen's CUDA before using caching allocator

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -825,6 +825,11 @@ class THCCachingAllocator {
 
   /** allocates a block which is safe to use from the provided stream */
   void malloc(void** devPtr, int device, size_t size, cudaStream_t stream) {
+    TORCH_INTERNAL_ASSERT(
+        0 <= device && device < device_allocator.size(),
+        "Allocator not initialized for device ",
+        device,
+        ": did you call init?");
     Block* block = device_allocator[device]->malloc(device, size, stream);
     add_allocated_block(block);
     *devPtr = (void*)block->ptr;

--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 
+#include <ATen/Context.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include "cub/util_allocator.cuh"
 
@@ -279,6 +280,8 @@ static void Caffe2SetCUDAMemoryPool() {
     SetUpCub();
   } else if (FLAGS_caffe2_cuda_memory_pool == "thc") {
     g_cuda_memory_pool_type = CudaMemoryPoolType::THC;
+    // Initialize caching allocator
+    at::globalContext().lazyInitCUDA();
   } else {
     CAFFE_THROW(
         "Unrecognized cuda memory pool type: ", FLAGS_caffe2_cuda_memory_pool);

--- a/caffe2/python/test/gpu_context_test.py
+++ b/caffe2/python/test/gpu_context_test.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+import torch
+from caffe2.python import core, workspace
+
+# This is a standalone test that doesn't use test_util as we're testing
+# initialization and thus we should be the ones calling GlobalInit
+@unittest.skipIf(not workspace.has_gpu_support, "No gpu support.")
+class TestGPUInit(unittest.TestCase):
+    def testTHCAllocator(self):
+        core.GlobalInit(['caffe2', '--caffe2_cuda_memory_pool=thc'])
+        # just run one operator
+        # it's importantant to not call anything here from Torch API
+        # even torch.cuda.memory_allocated would initialize CUDA context
+        workspace.RunOperatorOnce(core.CreateOperator(
+            'ConstantFill', [], ["x"], shape=[5, 5], value=1.0,
+            device_option=core.DeviceOption(workspace.GpuDeviceType)
+        ))
+        # make sure we actually used THC allocator
+        self.assertGreater(torch.cuda.memory_allocated(), 0)


### PR DESCRIPTION
Summary:
Caffe2 has a mode where it uses PT's caching allocator. Somehow we were not calling the initialization explicitly.

The problem was introduced in #37567 and Caffe2+THCAllocator combination wasn't tested anywhere.

Differential Revision: D21962331