### PR TITLE
[CircleCI] Add RocM build/test jobs

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -6,6 +6,11 @@ CONFIG_TREE_DATA = [
         (None, [
             X("nightly"),
         ]),
+        ("rocm", [
+            ("3.3", [
+                X("3.6"),
+            ]),
+        ]),
         ("gcc", [
             ("5.4", [  # All this subtree rebases to master and then build
                 XImportant("3.6"),

--- a/.circleci/cimodel/data/simple/util/docker_constants.py
+++ b/.circleci/cimodel/data/simple/util/docker_constants.py
@@ -4,12 +4,14 @@ AWS_DOCKER_HOST = "308535385114.dkr.ecr.us-east-1.amazonaws.com"
 # TOP OF .circleci/config.yml
 DOCKER_IMAGE_TAG = "fff7795428560442086f7b2bb6004b65245dc11a"
 
+DOCKER_IMAGE_TAG_ROCM = "be76e8fd-44e2-484d-b090-07e0cc3a56f0"
 
-def gen_docker_image_path(container_type):
+
+def gen_docker_image_path(container_type, container_tag=DOCKER_IMAGE_TAG):
     return "/".join([
         AWS_DOCKER_HOST,
         "pytorch",
-        container_type + ":" + DOCKER_IMAGE_TAG,
+        container_type + ":" + container_tag,
     ])
 
 
@@ -18,7 +20,6 @@ DOCKER_IMAGE_BASIC = gen_docker_image_path("pytorch-linux-xenial-py3.6-gcc5.4")
 DOCKER_IMAGE_CUDA_10_2 = gen_docker_image_path("pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7")
 
 DOCKER_IMAGE_GCC7 = gen_docker_image_path("pytorch-linux-xenial-py3.6-gcc7")
-
 
 def gen_mobile_docker_name(specifier):
     container_type = "pytorch-linux-xenial-py3-clang5-" + specifier

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7132,6 +7132,30 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:fff7795428560442086f7b2bb6004b65245dc11a"
           resource_class: large
       - pytorch_linux_build:
+          name: pytorch_linux_xenial_rocm3_3_py3_6_build
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
+          build_environment: "pytorch-linux-xenial-rocm3.3-py3.6-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-rocm3.3-py3.6:be76e8fd-44e2-484d-b090-07e0cc3a56f0"
+          resource_class: xlarge
+      - pytorch_linux_test:
+          name: pytorch_linux_xenial_rocm3_3_py3_6_test
+          requires:
+            - pytorch_linux_xenial_rocm3_3_py3_6_build
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
+          build_environment: "pytorch-linux-xenial-rocm3.3-py3.6-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-rocm3.3-py3.6:be76e8fd-44e2-484d-b090-07e0cc3a56f0"
+          resource_class: pytorch/amd-gpu
+      - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-linux-xenial-py3.6-gcc5.4-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:fff7795428560442086f7b2bb6004b65245dc11a"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -150,6 +150,12 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export PATH="$CACHE_WRAPPER_DIR:$PATH"
   fi
 
+  # Set ROCM_ARCH to gtx900 and gtx906
+  if [[ -n "$CIRCLECI" ]]; then
+      echo "Limiting PYTORCH_ROCM_ARCH to gfx90[06] for CircleCI builds"
+      export PYTORCH_ROCM_ARCH="gfx900;gfx906"
+  fi
+
   python tools/amd_build/build_amd.py
   python setup.py install --user
 


### PR DESCRIPTION
Set PYTORCH_ROCM_ARCH to `gfx900;gfx906` if `CIRCLECI` environment variable is defined
Add RocM build test jobs and schedule them on `xlarge` and `amd-gpu` resource classes respectively.