### PR TITLE
[JIT] Resolve fully-qualified Future name in script type parser

### DIFF
--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -542,6 +542,16 @@ class TestAsync(JitTestCase):
             def forward(self, x):
                 futs = torch.jit.annotate(List[torch.jit.Future], [])
 
+    def test_annotate(self):
+        @torch.jit.script
+        def foo(x):
+            return torch.neg(x)
+
+        @torch.jit.script
+        def forward(self, x):
+            futs = torch.jit.annotate(List[torch.jit.Future[torch.Tensor]], [])
+            return [torch.jit._wait(fut) for fut in futs]
+
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -48,8 +48,10 @@ TypePtr ScriptTypeParser::subscriptToType(
     }
     auto elem_type = parseTypeFromExpr(*subscript.subscript_exprs().begin());
     return OptionalType::create(elem_type);
-
-  } else if (typeName == "Future") {
+    // !!! HACK: matching explicitly on the fully-qualified `torch.jit.Future`
+    // here. We should really be using the resolver infrastructure to resolve
+    // the base type expression.
+  } else if (typeName == "Future" || typeName == "torch.jit.Future") {
     if (subscript.subscript_exprs().size() != 1) {
       throw ErrorReport(subscript)
           << " expected exactly one element type but found "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39761 [JIT] Resolve fully-qualified Future name in script type parser**
* #39751 [JIT] Improve error message when type annotation Future without a contained type

Previously `torch.jit.Future` wouldn't resolve to a type. This is a hack to make that work, in the long term we should really use the resolver infrastructure to resolve base types on subscript expressions

Differential Revision: [D21965432](https://our.internmc.facebook.com/intern/diff/D21965432)