### PR TITLE
correct some cpp extension code usages and documents

### DIFF
--- a/docs/source/cpp_extension.rst
+++ b/docs/source/cpp_extension.rst
@@ -10,3 +10,4 @@ torch.utils.cpp_extension
 .. autofunction:: include_paths
 .. autofunction:: check_compiler_abi_compatibility
 .. autofunction:: verify_ninja_availability
+.. autofunction:: is_ninja_available

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -330,7 +330,7 @@ class BuildExtension(build_ext, object):
             # Test if we can use ninja. Fallback otherwise.
             msg = ('Attempted to use ninja as the BuildExtension backend but '
                    '{}. Falling back to using the slow distutils backend.')
-            if not _is_ninja_available():
+            if not is_ninja_available():
                 warnings.warn(msg.format('we could not find ninja.'))
                 self.use_ninja = False
 
@@ -1273,7 +1273,11 @@ def _write_ninja_file_and_build_library(
         error_prefix="Error building extension '{}'".format(name))
 
 
-def _is_ninja_available():
+def is_ninja_available():
+    r'''
+    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
+    available on the system, ``False`` otherwise.
+    '''
     with open(os.devnull, 'wb') as devnull:
         try:
             subprocess.check_call('ninja --version'.split(), stdout=devnull)
@@ -1285,10 +1289,10 @@ def _is_ninja_available():
 
 def verify_ninja_availability():
     r'''
-    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
-    available on the system.
+    Raises ``RuntimeError`` if `ninja <https://ninja-build.org/>`_ build system is not
+    available on the system, does nothing otherwise.
     '''
-    if not _is_ninja_available():
+    if not is_ninja_available():
         raise RuntimeError("Ninja is required to load C++ extensions")
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39766 correct some cpp extension code usages and documents**

Per #39436, 2 changes are made here.
1. verify_ninja_availability has a wrong document, corrected. 
2. From above issue, It seems to me that user does need a true/false public api to check whether ninja is available, so I renamed _is_ninja_available to is_ninja_available and added it into the cpp extension doc.

The new doc page demo is here:
https://glaringlee.github.io/cpp_extension.html (see bottom)


Differential Revision: [D21967284](https://our.internmc.facebook.com/intern/diff/D21967284)