### PR TITLE
Remove `MultiheadAttention` weights from constants

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -763,7 +763,6 @@ class MultiheadAttention(Module):
         'bias_k': torch._jit_internal.Optional[torch.Tensor],
         'bias_v': torch._jit_internal.Optional[torch.Tensor],
     }
-    __constants__ = ['q_proj_weight', 'k_proj_weight', 'v_proj_weight', 'in_proj_weight']
 
     def __init__(self, embed_dim, num_heads, dropout=0., bias=True, add_bias_kv=False, add_zero_attn=False, kdim=None, vdim=None):
         super(MultiheadAttention, self).__init__()


### PR DESCRIPTION
The weights of the `MultiheadAttention` were incorrectly listed as constants, which produced warnings when converting to a TorchScript module.

```py
import torch
import torch.nn as nn

multihead_attn = nn.MultiheadAttention(256, 4)

torch.jit.script(multihead_attn)
```

Warnings:

```
/home/michael/.local/lib/python3.8/site-packages/torch/jit/_recursive.py:151: UserWarning: 'q_proj_weight' was found in ScriptModule constants,  but it is a non-constant parameter. Consider removing it.
  warnings.warn("'{}' was found in ScriptModule constants, "
/home/michael/.local/lib/python3.8/site-packages/torch/jit/_recursive.py:151: UserWarning: 'k_proj_weight' was found in ScriptModule constants,  but it is a non-constant parameter. Consider removing it.
  warnings.warn("'{}' was found in ScriptModule constants, "
/home/michael/.local/lib/python3.8/site-packages/torch/jit/_recursive.py:151: UserWarning: 'v_proj_weight' was found in ScriptModule constants,  but it is a non-constant parameter. Consider removing it.
  warnings.warn("'{}' was found in ScriptModule constants, "
/home/michael/.local/lib/python3.8/site-packages/torch/jit/_recursive.py:151: UserWarning: 'in_proj_weight' was found in ScriptModule constants,  but it is a non-constant parameter. Consider removing it.
  warnings.warn("'{}' was found in ScriptModule constants, "
```