### PR TITLE
[v1.5.1] add dtype checks for scatter/gather family of functions

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2877,6 +2877,20 @@ class _TestTorchMixin(object):
                         expected[tuple(ii)] = src
         self.assertEqual(actual, expected, 0)
 
+        # should throw an error when self.dtype != src.dtype.
+        # we ignore the case when src is Scalar, as it gets
+        # cast via src.to<scalar_t>.
+        if not is_scalar:
+            with self.assertRaisesRegex(RuntimeError, 'Expected self.dtype to be equal to src.dtype'):
+                getattr(base.clone().type(torch.int), method)(dim, idx, src)
+
+            with self.assertRaisesRegex(RuntimeError, 'Expected self.dtype to be equal to src.dtype'):
+                getattr(base.clone(), method)(dim, idx, src.type(torch.int))
+
+        # should throw an error when index dtype is not long
+        with self.assertRaisesRegex(RuntimeError, 'Expected dtype int64 for index'):
+            getattr(base.clone(), method)(dim, idx.type(torch.int), src)
+
         if test_bounds:
             idx[0][0][0] = 34
             with self.assertRaises(RuntimeError):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2881,14 +2881,16 @@ class _TestTorchMixin(object):
         # we ignore the case when src is Scalar, as it gets
         # cast via src.to<scalar_t>.
         if not is_scalar:
-            with self.assertRaisesRegex(RuntimeError, 'Expected self.dtype to be equal to src.dtype'):
+            err_pattern = 'Expected (self.dtype to be equal to src.dtype|object of scalar type Int but got scalar type \\w+)'
+            with self.assertRaisesRegex(RuntimeError, err_pattern):
                 getattr(base.clone().type(torch.int), method)(dim, idx, src)
 
-            with self.assertRaisesRegex(RuntimeError, 'Expected self.dtype to be equal to src.dtype'):
+            err_pattern = 'Expected (self.dtype to be equal to src.dtype|object of scalar type \\w+ but got scalar type Int)'
+            with self.assertRaisesRegex(RuntimeError, err_pattern):
                 getattr(base.clone(), method)(dim, idx, src.type(torch.int))
 
         # should throw an error when index dtype is not long
-        with self.assertRaisesRegex(RuntimeError, 'Expected dtype int64 for index'):
+        with self.assertRaisesRegex(RuntimeError, 'Expected (dtype int64|object of scalar type Long)'):
             getattr(base.clone(), method)(dim, idx.type(torch.int), src)
 
         if test_bounds:


### PR DESCRIPTION
Adds additional dtype checks for scatter/gather family of functions, namely:

Checks whether index is of type Long
Checks whether src.dtype == self.dtype.

This is a rather involved rework of #38646