### PR TITLE
Fixes type promotion for `cat`

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -139,6 +139,9 @@ Tensor & _cat_out_cpu(Tensor& result, TensorList tensors, int64_t dim) {
   // when the input tensors are of the same size and strides,
   // reuse the same iterator for all input tensors
   bool reuse_iterator = true;
+  bool no_type_promotion = true;
+  // Check the type of the result
+  no_type_promotion = result.dtype() == notSkippedTensor.dtype();
 
   // compute size of the result in the cat dimension
   int64_t cat_dim_size = 0;
@@ -157,12 +160,13 @@ Tensor & _cat_out_cpu(Tensor& result, TensorList tensors, int64_t dim) {
     }
 
     if (tensor.sizes() != notSkippedTensor.sizes() ||
-        tensor.strides() != notSkippedTensor.strides() ||
-        tensor.dtype() != notSkippedTensor.dtype()) {
+        tensor.strides() != notSkippedTensor.strides()) {
       reuse_iterator = false;
     }
+    if (tensor.dtype() != notSkippedTensor.dtype()) {
+      no_type_promotion = false;
+    }
   }
-
   // compute the size of the result
   auto result_size = notSkippedTensor.sizes().vec();
   result_size[dim] = cat_dim_size;
@@ -172,13 +176,13 @@ Tensor & _cat_out_cpu(Tensor& result, TensorList tensors, int64_t dim) {
   bool use_serial_kernel = result.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1;
   allContiguous = allContiguous && result.is_contiguous();
   ScalarType dtype = notSkippedTensor.scalar_type();
-  if (use_serial_kernel && allContiguous && (dtype == ScalarType::Double || dtype == ScalarType::Float)) {
+  if (use_serial_kernel && allContiguous && no_type_promotion && (dtype == ScalarType::Double || dtype == ScalarType::Float)) {
     cat_serial_stub(kCPU, result, tensors, dim);
     return result;
   }
 
   int64_t offset = 0;
-  if (reuse_iterator && result.is_contiguous()) {
+  if (reuse_iterator && result.is_contiguous() && no_type_promotion) {
     auto source_slice = notSkippedTensor;
     auto slice_dim_size = source_slice.size(dim);
     auto result_slice = result.narrow(dim, 0, slice_dim_size);

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -379,11 +379,11 @@ Tensor& cat_out_cuda(Tensor& out, TensorList inputs, int64_t dimension) {
       return !t.defined() || t.is_contiguous(memory_format);
     });
   ScalarType firstType = inputs[0].scalar_type();
-  const bool allSameType = std::all_of(inputs.begin(), inputs.end(),
+  bool allSameType = std::all_of(inputs.begin(), inputs.end(),
     [firstType](const Tensor& t) {
       return t.scalar_type() == firstType;
     });
-
+  allSameType = allSameType && (out.scalar_type() == firstType);
   if (inputs.size() > 1 &&
       !hasSkippedInput &&
       out.dim() <= CAT_ARRAY_MAX_INPUT_DIMS &&

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -797,39 +797,40 @@ class TestTypePromotion(TestCase):
 
     @onlyOnCPUAndCUDA
     def test_cat_different_dtypes(self, device):
-        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
-        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int32)
-        out = torch.cat([x, y])
-        self.assertEqual(out, expected_out, exact_dtype=True)
-        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
-                                    device=device, dtype=torch.int32)
-        out = torch.cat([x, y, z])
-        self.assertEqual(out, expected_out, exact_dtype=True)
+        dtypes = torch.testing.get_all_dtypes(include_bfloat16=False)
+        for x_dtype, y_dtype in itertools.product(dtypes, dtypes):
+            x_vals, y_vals = [1, 2, 3], [4, 5, 6]
+
+            x = torch.tensor(x_vals, device=device, dtype=x_dtype)
+            y = torch.tensor(y_vals, device=device, dtype=y_dtype)
+
+            if x_dtype is torch.bool:
+                x_vals = [1, 1, 1]
+            if y_dtype is torch.bool:
+                y_vals = [1, 1, 1]
+
+            res_dtype = torch.result_type(x, y)
+            expected_res = torch.tensor(x_vals + y_vals, device=device, dtype=res_dtype)
+            res = torch.cat([x, y])
+            self.assertEqual(res, expected_res, exact_dtype=True)
 
     @onlyOnCPUAndCUDA
     def test_cat_out_different_dtypes(self, device):
-        out = torch.zeros(6, device=device, dtype=torch.int16)
-        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int8)
-        y = torch.tensor([4, 5, 6], device=device, dtype=torch.int32)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=torch.int16)
-        torch.cat([x, y], out=out)
-        self.assertEqual(out, expected_out, exact_dtype=True)
-        z = torch.tensor([7, 8, 9], device=device, dtype=torch.int16)
-        out = torch.zeros(9, device=device, dtype=torch.int64)
-        expected_out = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9],
-                                    device=device, dtype=torch.int64)
-        torch.cat([x, y, z], out=out)
-        self.assertEqual(out, expected_out, exact_dtype=True)
-
-    @onlyOnCPUAndCUDA
-    def test_cat_invalid_dtype_promotion(self, device):
-        out = torch.zeros(6, device=device, dtype=torch.int16)
-        x = torch.tensor([1, 2, 3], device=device, dtype=torch.int16)
-        y = torch.tensor([4, 5, 6], device=device, dtype=torch.float)
-        with self.assertRaisesRegex(RuntimeError, 'can\'t be cast'):
-            torch.cat([x, y], out=out)
+        dtypes = torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False)
+        for x_dtype, y_dtype, out_dtype in itertools.product(dtypes, dtypes, dtypes):
+            out = torch.zeros(6, device=device, dtype=out_dtype)
+            x = torch.tensor([1, 2, 3], device=device, dtype=x_dtype)
+            y = torch.tensor([4, 5, 6], device=device, dtype=y_dtype)
+            expected_out = torch.tensor([1, 2, 3, 4, 5, 6], device=device, dtype=out_dtype)
+            if (((x_dtype.is_floating_point or y_dtype.is_floating_point) 
+                    and not (out_dtype.is_floating_point or out_dtype.is_complex))
+                    or ((x_dtype.is_complex or y_dtype.is_complex) and not out_dtype.is_complex)): 
+                # This combinations do not support type conversion to a different class out type
+                with self.assertRaises(RuntimeError):
+                    torch.cat([x, y], out=out)
+            else:
+                torch.cat([x, y], out=out)
+                self.assertEqual(out, expected_out, exact_dtype=True)
 
 
 instantiate_device_type_tests(TestTypePromotion, globals())


### PR DESCRIPTION
Fixes a bug introduced in  #35030 

Changes the test to do all the possible type combinations.