### PR TITLE
Separate "configuration" properties in TensorIterator

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -38,7 +38,7 @@ void TensorIterator::reorder_dimensions() {
       }
       int64_t stride0 = operands_[arg].stride_bytes[dim0];
       int64_t stride1 = operands_[arg].stride_bytes[dim1];
-      if (is_reduction_ && operands_[arg].is_output) {
+      if (is_reduction() && operands_[arg].is_output) {
         // move reduced dimensions to the front
         if ((stride0 == 0) != (stride1 == 0)) {
           return stride1 == 0 ? 1 : -1;
@@ -122,7 +122,7 @@ void TensorIterator::compute_types() {
     //   the device it should be allocated on.
     if (!op.is_type_defined()) {
       TORCH_INTERNAL_ASSERT(op.is_output, "Found type undefined input tensor!");
-      TORCH_INTERNAL_ASSERT(check_all_same_device_);
+      TORCH_INTERNAL_ASSERT(check_all_same_device());
       has_undefined_outputs = true;
       continue;
     }
@@ -158,12 +158,12 @@ void TensorIterator::compute_types() {
   }
 
   // Checks that either the computation type is computable or unneeded
-  TORCH_INTERNAL_ASSERT(!(has_different_input_dtypes && !promote_inputs_to_common_dtype_ &&
-                        (has_undefined_outputs || enforce_safe_casting_to_output_ ||
-                        cast_common_dtype_to_outputs_)));
+  TORCH_INTERNAL_ASSERT(!(has_different_input_dtypes && !promote_inputs_to_common_dtype() &&
+                        (has_undefined_outputs || enforce_safe_casting_to_output() ||
+                        cast_common_dtype_to_outputs())));
 
   // Checks that all inputs and defined outputs are the same dtype, if requested
-  if (check_all_same_dtype_ &&
+  if (check_all_same_dtype() &&
       (has_different_input_dtypes || has_different_output_dtypes ||
       (common_dtype_ != output_dtype && output_dtype != ScalarType::Undefined))) {
     // Throws an informative error message
@@ -178,16 +178,16 @@ void TensorIterator::compute_types() {
   }
 
   // Short-circuits if no additional work required
-  if (!has_undefined_outputs && !check_all_same_device_ &&
-      !promote_inputs_to_common_dtype_ && !cast_common_dtype_to_outputs_ &&
-      !enforce_safe_casting_to_output_) {
+  if (!has_undefined_outputs && !check_all_same_device() &&
+      !promote_inputs_to_common_dtype() && !cast_common_dtype_to_outputs() &&
+      !enforce_safe_casting_to_output()) {
     // Invalidates common_dtype_ if it could not be inferred
     common_dtype_ = has_different_input_dtypes ? ScalarType::Undefined : common_dtype_;
     return;
   }
 
   // Computes a common dtype, if needed
-  if (has_different_input_dtypes && promote_inputs_to_common_dtype_) {
+  if (has_different_input_dtypes && promote_inputs_to_common_dtype()) {
     common_dtype_ = compute_common_dtype();
   }
 
@@ -196,7 +196,7 @@ void TensorIterator::compute_types() {
   //   - checks that all tensors are on the same device, if requested
   //   - checks that the common dtype can safely cast to each output, if requested
   //   - creates temporaries for CPU operations, if needed and requested
-  int max_cpu_scalars_on_cuda = allow_cpu_scalars_ ? 1 : 0;
+  int max_cpu_scalars_on_cuda = allow_cpu_scalars() ? 1 : 0;
   int current_cpu_scalars_on_cuda = 0;
   for (auto& op : operands_) {
     if (!op.is_type_defined()) {
@@ -211,7 +211,7 @@ void TensorIterator::compute_types() {
     }
 
     // Checks all tensors are on the same device, if requested
-    if (check_all_same_device_) {
+    if (check_all_same_device()) {
       // Handles CPU scalars on CUDA kernels that support them
       if (common_device.is_cuda() && op.tensor.dim() == 0 && op.tensor.device().is_cpu()) {
         TORCH_CHECK(current_cpu_scalars_on_cuda < max_cpu_scalars_on_cuda,
@@ -225,7 +225,7 @@ void TensorIterator::compute_types() {
     }
 
     // Checks safe casting, if requested
-    if (enforce_safe_casting_to_output_ && op.is_output && op.current_dtype != common_dtype_) {
+    if (enforce_safe_casting_to_output() && op.is_output && op.current_dtype != common_dtype_) {
       TORCH_CHECK(canCast(common_dtype_, op.current_dtype),
                   "result type ", common_dtype_, " can't be cast to the "
                   "desired output type ", op.current_dtype);
@@ -235,7 +235,7 @@ void TensorIterator::compute_types() {
     // TODO: reuse temporaries when possible (e.g. for inplace operations)
     if (common_device == kCPU) {
       // Casts to outputs by creating temporaries of the correct dtype (if needed)
-      if (cast_common_dtype_to_outputs_ && op.is_output && op.current_dtype != common_dtype_) {
+      if (cast_common_dtype_to_outputs() && op.is_output && op.current_dtype != common_dtype_) {
         op.original_tensor = op.tensor;
         op.tensor = at::empty_like(op.tensor,
                                    op.tensor.options().dtype(common_dtype_),
@@ -244,7 +244,7 @@ void TensorIterator::compute_types() {
     }
 
     // Promotes inputs by creating temporaries of the correct dtype
-      if (promote_inputs_to_common_dtype_ && !op.is_output && op.current_dtype != common_dtype_) {
+      if (promote_inputs_to_common_dtype() && !op.is_output && op.current_dtype != common_dtype_) {
         op.original_tensor = op.tensor;
         op.tensor = op.tensor.to(common_dtype_);
         op.current_dtype = common_dtype_;
@@ -347,7 +347,7 @@ void TensorIterator::compute_names() {
   for (auto& op : operands_) {
     if (!op.tensor.defined()) continue;
     // don't include output tensors that are not also input tensors.
-    if (resize_outputs_ && op.is_output && !op.is_read_write) continue;
+    if (resize_outputs() && op.is_output && !op.is_read_write) continue;
     // perform name inference
     if (names_.empty()) {
       names_ = op.tensor.names();
@@ -652,7 +652,7 @@ void TensorIterator::narrow(int dim, int64_t start, int64_t size) {
   for (auto& op : operands_) {
     op.data = ((char*)op.data) + op.stride_bytes[dim] * start;
   }
-  if (size == 1 && !is_reduction_) {
+  if (size == 1 && !is_reduction()) {
     coalesce_dimensions();
   }
 }
@@ -674,7 +674,7 @@ TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a,
   iter.add_output(out);
   iter.add_input(a);
   iter.add_input(b);
-  iter.allow_cpu_scalars_ = true;
+  iter.config_allow_cpu_scalars_ = true;
   iter.promote_inputs_to_common_dtype(true);
   iter.cast_common_dtype_to_outputs(true);
   iter.enforce_safe_casting_to_output(true);
@@ -689,7 +689,7 @@ TensorIterator TensorIterator::comparison_op(Tensor& out, const Tensor& a,
   iter.add_output(out);
   iter.add_input(a);
   iter.add_input(b);
-  iter.allow_cpu_scalars_ = true;
+  iter.config_allow_cpu_scalars_ = true;
   iter.promote_inputs_to_common_dtype(true);
   iter.build();
   return iter;
@@ -713,7 +713,7 @@ TensorIterator TensorIterator::nullary_op(Tensor& out) {
   iter.check_all_same_dtype(false);
   iter.add_output(out);
   // FIXME: workaround for bug: https://github.com/pytorch/pytorch/issues/20342
-  iter.resize_outputs_ = false;
+  iter.config_resize_outputs_ = false;
   iter.build();
   return iter;
 }
@@ -723,8 +723,8 @@ TensorIterator TensorIterator::reduce_op(Tensor& out, const Tensor& a) {
   auto iter = TensorIterator();
   iter.add_output(out);
   iter.add_input(a);
-  iter.resize_outputs_ = false;
-  iter.is_reduction_ = true;
+  iter.config_resize_outputs_ = false;
+  iter.config_is_reduction_ = true;
   // TODO: not supporting casting to outputs is only really necessary for arg{min,max}
   iter.promote_inputs_to_common_dtype(true);
   iter.build();
@@ -747,8 +747,8 @@ TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tenso
   iter.add_output(out1);
   iter.add_output(out2);
   iter.add_input(a);
-  iter.resize_outputs_ = false;
-  iter.is_reduction_ = true;
+  iter.config_resize_outputs_ = false;
+  iter.config_is_reduction_ = true;
   iter.check_all_same_dtype(false);
   iter.build();
   return iter;
@@ -770,8 +770,8 @@ void TensorIterator::mark_outputs() {
   }
 }
 
-void TensorIterator::check_mem_overlaps() {
-  if (!check_mem_overlap_) {
+void TensorIterator::compute_mem_overlaps() {
+  if (!check_mem_overlap()) {
     return;
   }
   for (int i = 0; i < num_outputs_; i++) {
@@ -786,7 +786,7 @@ void TensorIterator::check_mem_overlaps() {
 }
 
 void TensorIterator::compute_shape() {
-  if (static_shape_) return;
+  if (static_shape()) return;
 
   all_ops_same_shape_ = true;
   bool has_scalars = false;
@@ -797,7 +797,7 @@ void TensorIterator::compute_shape() {
     // For now, don't include output tensors that are not also input tensors.
     // This preserves the legacy behavior where torch.add(..., out=dst) resizes
     // the destination tensor.
-    if (resize_outputs_ && op.is_output && !op.is_read_write) continue;
+    if (resize_outputs() && op.is_output && !op.is_read_write) continue;
     auto shape = op.tensor.sizes();
     if (shape.size() == 0) {
       has_scalars = true;
@@ -821,7 +821,7 @@ void TensorIterator::compute_shape() {
   for (int i = 0; i < num_outputs_; i++) {
     auto& tensor = operands_[i].tensor;
     if (tensor.defined() && !tensor.sizes().equals(shape_)) {
-      if (resize_outputs_ && !operands_[i].is_read_write) {
+      if (resize_outputs() && !operands_[i].is_read_write) {
         // Preserve legacy resizing behavior of out=... arguments
         // TODO: issue warning
         tensor.resize_(shape_);
@@ -835,7 +835,7 @@ void TensorIterator::compute_shape() {
         }
         continue;
       }
-      TORCH_CHECK(is_reduction_, "output with shape ", tensor.sizes(), " doesn't match the broadcast shape ",
+      TORCH_CHECK(is_reduction(), "output with shape ", tensor.sizes(), " doesn't match the broadcast shape ",
                  shape_);
     }
   }
@@ -844,7 +844,7 @@ void TensorIterator::compute_shape() {
 void TensorIterator::compute_strides() {
   for (auto& op : operands_) {
     if (op.tensor.defined()) {
-      IntArrayRef original_shape = static_shape_ ? shape_ : op.tensor.sizes();
+      IntArrayRef original_shape = static_shape() ? shape_ : op.tensor.sizes();
       auto original_stride = op.tensor.strides();
       auto element_size_in_bytes = op.tensor.element_size();
       auto offset = ndim() - original_shape.size();
@@ -981,7 +981,7 @@ bool TensorIterator::fast_set_up() {
             op.tensor = at::empty_strided(shape_, operands_[i_defined].tensor.strides(), op.options());
             op.current_dtype = op.target_dtype;
           }
-          else if (resize_outputs_ && !op.is_read_write) {
+          else if (resize_outputs() && !op.is_read_write) {
             // Note: This restride logic is for some of the tensor types, eg. qtensor.
             //       These tensor class allocate a contigious output tensor directly no matter
             //       what memory format the input tensors are. So we need to restride output here for fast setup.
@@ -1018,7 +1018,7 @@ bool TensorIterator::fast_set_up() {
 }
 
 FastSetupType TensorIterator::compute_fast_setup_type() {
-  if (is_reduction_ || !all_ops_same_shape_) {
+  if (is_reduction() || !all_ops_same_shape_) {
     return FastSetupType::NONE;
   }
 
@@ -1052,7 +1052,7 @@ FastSetupType TensorIterator::compute_fast_setup_type() {
           continue;
         }
         if (!operands_[prev].tensor.strides().equals(op.tensor.strides())) {
-          if (!resize_outputs_ || !op.is_output || op.is_read_write) {
+          if (!resize_outputs() || !op.is_output || op.is_read_write) {
             return FastSetupType::NONE;
           }
         }
@@ -1070,7 +1070,7 @@ void TensorIterator::build() {
   mark_outputs();
   // Check that the outputs have no internal overlap
   // and do not share memory with inputs.
-  check_mem_overlaps();
+  compute_mem_overlaps();
   // Check that input dimensions are aligned correctly & compute outnames.
   compute_names();
   // compute the broadcasted shape


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39800 Eliminate TensorIterator::add_output with explicit dtype.
* #39798 Delete redundant device/dtype in TensorIterator add_input/add_output
* #39792 Add documentation for properties in TensorIterator.
* **#39789 Separate "configuration" properties in TensorIterator**

Some properties on TensorIterator are only set prior to build() by the
user and then immutable during the build process.  I've renamed all such
properties so that they have a config_ prefix, gave them an explicit
accessor and audited every site to ensure they are only written once.

I also renamed check_mem_overlaps to compute_mem_overlaps to avoid
confusion with the accessor check_mem_overlap.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D21981741](https://our.internmc.facebook.com/intern/diff/D21981741)