### PR TITLE
Delete redundant device/dtype in TensorIterator add_input/add_output

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -246,7 +246,7 @@ static TensorIterator make_index_iterator(const AdvancedIndex& info) {
 static TensorIterator make_index_out_iterator(const AdvancedIndex& info, Tensor& result) {
   auto iter = TensorIterator();
   iter.check_all_same_dtype(false);
-  iter.add_output(result, info.src.device(), info.src.scalar_type());
+  iter.add_output(result);
   iter.add_input(info.src);
   for (auto& index : info.indices) {
     iter.add_input(index);

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -312,10 +312,6 @@ struct CAFFE2_API TensorIterator {
     operands_.emplace_back(input);
   }
 
-  void add_input(const Tensor& input, Device device, ScalarType dtype) {
-    operands_.emplace_back(input, device, dtype);
-  }
-
   void set_check_mem_overlap(bool check_mem_overlap) {
     config_check_mem_overlap_ = check_mem_overlap;
   }

--- a/aten/src/ATen/native/UnfoldBackward.h
+++ b/aten/src/ATen/native/UnfoldBackward.h
@@ -95,7 +95,7 @@ static TensorIterator _make_unfold_backward_iter_over_grad_out(
   iter.check_all_same_dtype(false);
   iter.dont_resize_outputs();
   iter.add_output(grad_out_restrided);
-  iter.add_input(grad_in_restrided, grad_in.device(), grad_in.scalar_type());
+  iter.add_input(grad_in_restrided);
   iter.add_input(idx_dim_restrided);
   iter.build();
 
@@ -166,7 +166,7 @@ static TensorIterator _make_unfold_backward_iter_over_grad_in(
   iter.check_all_same_dtype(false);
   iter.dont_resize_outputs();
   iter.add_output(grad_out_restrided);
-  iter.add_input(grad_in, grad_in.device(), grad_in.scalar_type());
+  iter.add_input(grad_in);
   iter.add_input(idx_dim_restrided);
   iter.add_input(idx_last_dim_restrided);
   iter.build();

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -66,7 +66,7 @@ struct cpu_scatter_gather_base_kernel {
     iter.dont_resize_outputs();
     iter.declare_static_shape(index.sizes(), /*squash_dim=*/dim);
     iter.add_output(self);
-    iter.add_input(src, src.device(), src.scalar_type());
+    iter.add_input(src);
     iter.add_input(index);
     iter.build();
 

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -144,7 +144,7 @@ struct cuda_scatter_gather_base_kernel {
     iter.check_all_same_dtype(false);
     iter.dont_resize_outputs();
     iter.add_output(self_restrided);
-    iter.add_input(src_restrided, src.device(), src.scalar_type());
+    iter.add_input(src_restrided);
     iter.add_input(index);
     iter.build();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39803 [WIP] Split TensorIteratorConfig out of TensorIterator
* #39800 Eliminate TensorIterator::add_output with explicit dtype.
* **#39798 Delete redundant device/dtype in TensorIterator add_input/add_output**
* #39792 Add documentation for properties in TensorIterator.
* #39789 Separate "configuration" properties in TensorIterator

add_input's device/dtype are 100% redundant, as compute_types will
always (internal) assert that this dtype matches the expected dtype.
add_output's device/dtype is redundant UNLESS you have an undefined
tensor (in which case it seems to be an indication what the output type
should be). The one add_output case I killed can never be exercised, see:

```
import torch
x = torch.randn(3, 4)
mask = x.ge(0.5)
torch.masked_select(x.cuda(), mask.cuda(), out=torch.zeros((0), dtype=torch.int64, device='cuda'))
```

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D21981742](https://our.internmc.facebook.com/intern/diff/D21981742)