### PR TITLE
Add `generator=` kwarg for all `torch.rand*`

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -494,6 +494,14 @@ Tensor& rand_out(Tensor& result, IntArrayRef size, c10::optional<Generator> gene
 Tensor rand_like(
     const Tensor& self,
     const TensorOptions& options,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto result = at::empty_like(self, options, optional_memory_format);
+  return result.uniform_(0, 1, c10::nullopt);
+}
+
+Tensor rand_like(
+    const Tensor& self,
+    const TensorOptions& options,
     c10::optional<Generator>& generator,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
@@ -563,10 +571,29 @@ Tensor randint_like(
     const Tensor& self,
     int64_t high,
     const TensorOptions& options,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto result = at::empty_like(self, options, optional_memory_format);
+  return result.random_(0, high, c10::nullopt);
+}
+
+Tensor randint_like(
+    const Tensor& self,
+    int64_t high,
+    const TensorOptions& options,
     c10::optional<Generator>& generator,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.random_(0, high, generator);
+}
+
+Tensor randint_like(
+    const Tensor& self,
+    int64_t low,
+    int64_t high,
+    const TensorOptions& options,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto result = at::empty_like(self, options, optional_memory_format);
+  return result.random_(low, high, c10::nullopt);
 }
 
 Tensor randint_like(
@@ -610,6 +637,14 @@ Tensor& normal_out(Tensor& result, double mean, double std,
                    IntArrayRef size, c10::optional<Generator> generator) {
   result.resize_(size);
   return result.normal_(mean, std, generator);
+}
+
+Tensor randn_like(
+    const Tensor& self,
+    const TensorOptions& options,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto result = at::empty_like(self, options, optional_memory_format);
+  return result.normal_(0, 1, c10::nullopt);
 }
 
 Tensor randn_like(

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -494,9 +494,10 @@ Tensor& rand_out(Tensor& result, IntArrayRef size, c10::optional<Generator> gene
 Tensor rand_like(
     const Tensor& self,
     const TensorOptions& options,
+    c10::optional<Generator> generator,
     c10::optional<c10::MemoryFormat> optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
-  return result.uniform_(0, 1, c10::nullopt);
+  return result.uniform_(0, 1, generator);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randint ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -494,8 +494,8 @@ Tensor& rand_out(Tensor& result, IntArrayRef size, c10::optional<Generator> gene
 Tensor rand_like(
     const Tensor& self,
     const TensorOptions& options,
-    c10::optional<Generator> generator,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
+    c10::optional<Generator>& generator,
+    c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.uniform_(0, 1, generator);
 }
@@ -563,9 +563,10 @@ Tensor randint_like(
     const Tensor& self,
     int64_t high,
     const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
+    c10::optional<Generator>& generator,
+    c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
-  return result.random_(0, high, c10::nullopt);
+  return result.random_(0, high, generator);
 }
 
 Tensor randint_like(
@@ -573,9 +574,10 @@ Tensor randint_like(
     int64_t low,
     int64_t high,
     const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
+    c10::optional<Generator>& generator,
+    c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
-  return result.random_(low, high, c10::nullopt);
+  return result.random_(low, high, generator);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randn ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -615,9 +615,10 @@ Tensor& normal_out(Tensor& result, double mean, double std,
 Tensor randn_like(
     const Tensor& self,
     const TensorOptions& options,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
+    c10::optional<Generator>& generator,
+    c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
-  return result.normal_(0, 1, c10::nullopt);
+  return result.normal_(0, 1, generator);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ randperm ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -501,7 +501,7 @@ Tensor rand_like(
 
 Tensor rand_like(
     const Tensor& self,
-    c10::optional<Generator>& generator,
+    c10::optional<Generator> generator,
     const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
@@ -579,7 +579,7 @@ Tensor randint_like(
 Tensor randint_like(
     const Tensor& self,
     int64_t high,
-    c10::optional<Generator>& generator,
+    c10::optional<Generator> generator,
     const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
@@ -600,7 +600,7 @@ Tensor randint_like(
     const Tensor& self,
     int64_t low,
     int64_t high,
-    c10::optional<Generator>& generator,
+    c10::optional<Generator> generator,
     const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
@@ -649,7 +649,7 @@ Tensor randn_like(
 
 Tensor randn_like(
     const Tensor& self,
-    c10::optional<Generator>& generator,
+    c10::optional<Generator> generator,
     const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -503,7 +503,7 @@ Tensor rand_like(
     const Tensor& self,
     c10::optional<Generator> generator,
     const TensorOptions& options,
-    c10::optional<c10::MemoryFormat>& optional_memory_format) {
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.uniform_(0, 1, generator);
 }
@@ -581,7 +581,7 @@ Tensor randint_like(
     int64_t high,
     c10::optional<Generator> generator,
     const TensorOptions& options,
-    c10::optional<c10::MemoryFormat>& optional_memory_format) {
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.random_(0, high, generator);
 }
@@ -602,7 +602,7 @@ Tensor randint_like(
     int64_t high,
     c10::optional<Generator> generator,
     const TensorOptions& options,
-    c10::optional<c10::MemoryFormat>& optional_memory_format) {
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.random_(low, high, generator);
 }
@@ -651,7 +651,7 @@ Tensor randn_like(
     const Tensor& self,
     c10::optional<Generator> generator,
     const TensorOptions& options,
-    c10::optional<c10::MemoryFormat>& optional_memory_format) {
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.normal_(0, 1, generator);
 }

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -501,8 +501,8 @@ Tensor rand_like(
 
 Tensor rand_like(
     const Tensor& self,
-    const TensorOptions& options,
     c10::optional<Generator>& generator,
+    const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.uniform_(0, 1, generator);
@@ -579,8 +579,8 @@ Tensor randint_like(
 Tensor randint_like(
     const Tensor& self,
     int64_t high,
-    const TensorOptions& options,
     c10::optional<Generator>& generator,
+    const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.random_(0, high, generator);
@@ -600,8 +600,8 @@ Tensor randint_like(
     const Tensor& self,
     int64_t low,
     int64_t high,
-    const TensorOptions& options,
     c10::optional<Generator>& generator,
+    const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.random_(low, high, generator);
@@ -649,8 +649,8 @@ Tensor randn_like(
 
 Tensor randn_like(
     const Tensor& self,
-    const TensorOptions& options,
     c10::optional<Generator>& generator,
+    const TensorOptions& options,
     c10::optional<c10::MemoryFormat>& optional_memory_format) {
   auto result = at::empty_like(self, options, optional_memory_format);
   return result.normal_(0, 1, generator);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2196,7 +2196,7 @@
 
 - func: rand.generator_out(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: rand_like(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
 
 - func: randint(int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -2214,9 +2214,9 @@
 
 - func: randint.low_generator_out(int low, int high, int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: randint_like(Tensor self, int high, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: randint_like(Tensor self, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
 
-- func: randint_like.low_dtype(Tensor self, int low, int high, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: randint_like.low_dtype(Tensor self, int low, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
 
 - func: randn(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -2232,7 +2232,7 @@
 
 - func: randn.generator_out(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: randn_like(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
 
 - func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2240,7 +2240,7 @@
 
 - func: randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randn_like(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: randn_like.generator(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2214,9 +2214,9 @@
 
 - func: randint.low_generator_out(int low, int high, int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: randint_like(Tensor self, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: randint_like(Tensor self, int high, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randint_like.low_dtype(Tensor self, int low, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: randint_like.low_dtype(Tensor self, int low, int high, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randn(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2196,7 +2196,7 @@
 
 - func: rand.generator_out(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: rand_like(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randint(int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2232,7 +2232,7 @@
 
 - func: randn.generator_out(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+- func: randn_like(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2196,7 +2196,9 @@
 
 - func: rand.generator_out(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
+- func: rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+
+- func: rand_like.generator(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randint(int high, int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -2214,9 +2216,13 @@
 
 - func: randint.low_generator_out(int low, int high, int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: randint_like(Tensor self, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
+- func: randint_like(Tensor self, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randint_like.low_dtype(Tensor self, int low, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
+- func: randint_like.generator(Tensor self, int high, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+
+- func: randint_like.low_dtype(Tensor self, int low, int high, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+
+- func: randint_like.low_dtype_generator(Tensor self, int low, int high, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randn(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -2232,7 +2238,9 @@
 
 - func: randn.generator_out(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None, Generator? generator) -> Tensor
+- func: randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
+
+- func: randn_like(Tensor self, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
 - func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1963,6 +1963,17 @@ class AbstractTestCases:
                 self.assertTrue((res1 < 6).all().item())
                 self.assertTrue((res1 >= 0).all().item())
 
+        def test_rand_reproducibility_with_generator(self):
+            def get_gen():
+                return torch.Generator().manual_seed(42)
+
+            self.assertEqual(torch.rand(1, generator=get_gen()), 0.8823)
+            self.assertEqual(torch.rand_like(torch.empty(1), generator=get_gen()), 0.8823)
+            self.assertEqual(torch.randn(1, generator=get_gen()), 0.3367)
+            self.assertEqual(torch.randn_like(torch.empty(1), generator=get_gen()), 0.3367)
+            self.assertEqual(torch.randint(1, 100, (1,), generator=get_gen()), 7)
+            self.assertEqual(torch.randperm(10, generator=get_gen()), torch.tensor([2, 6, 1, 8, 4, 5, 0, 9, 3, 7]))
+
         def test_slice(self):
             empty = torch.empty(0, 4)
             x = torch.arange(0., 16).view(4, 4)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1972,7 +1972,7 @@ class AbstractTestCases:
                 lambda: torch.rand_like(torch.empty(1), generator=get_gen()),
                 lambda: torch.randn(1, generator=get_gen()),
                 lambda: torch.randn_like(torch.empty(1), generator=get_gen()),
-                lambda: torch.randint(1, 100, (1,),
+                lambda: torch.randint(1, 100, (1,)),
                 lambda: torch.randperm(10, generator=get_gen()),
             ):
                 self.assertEqual(fn(), fn())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1963,16 +1963,19 @@ class AbstractTestCases:
                 self.assertTrue((res1 < 6).all().item())
                 self.assertTrue((res1 >= 0).all().item())
 
-        def test_rand_reproducibility_with_generator(self):
+        def test_rand_reproducibility(self):
             def get_gen():
                 return torch.Generator().manual_seed(42)
 
-            self.assertEqual(torch.rand(1, generator=get_gen()), 0.8823)
-            self.assertEqual(torch.rand_like(torch.empty(1), generator=get_gen()), 0.8823)
-            self.assertEqual(torch.randn(1, generator=get_gen()), 0.3367)
-            self.assertEqual(torch.randn_like(torch.empty(1), generator=get_gen()), 0.3367)
-            self.assertEqual(torch.randint(1, 100, (1,), generator=get_gen()), 7)
-            self.assertEqual(torch.randperm(10, generator=get_gen()), torch.tensor([2, 6, 1, 8, 4, 5, 0, 9, 3, 7]))
+            for fn in (
+                lambda: torch.rand(1, generator=get_gen()),
+                lambda: torch.rand_like(torch.empty(1), generator=get_gen()),
+                lambda: torch.randn(1, generator=get_gen()),
+                lambda: torch.randn_like(torch.empty(1), generator=get_gen()),
+                lambda: torch.randint(1, 100, (1,),
+                lambda: torch.randperm(10, generator=get_gen()),
+            ):
+                self.assertEqual(fn(), fn())
 
         def test_slice(self):
             empty = torch.empty(0, 4)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1972,7 +1972,7 @@ class AbstractTestCases:
                 lambda: torch.rand_like(torch.empty(1), generator=get_gen()),
                 lambda: torch.randn(1, generator=get_gen()),
                 lambda: torch.randn_like(torch.empty(1), generator=get_gen()),
-                lambda: torch.randint(1, 100, (1,)),
+                lambda: torch.randint(1, 100, (1,), generator=get_gen()),
                 lambda: torch.randperm(10, generator=get_gen()),
             ):
                 self.assertEqual(fn(), fn())

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4827,7 +4827,7 @@ The shape of the tensor is defined by the variable argument :attr:`size`.
 Args:
     size (int...): a sequence of integers defining the shape of the output tensor.
         Can be a variable number of arguments or a collection like a list or tuple.
-        
+
 Keyword arguments:
     {generator}
     {out}
@@ -4846,9 +4846,10 @@ Example::
 """.format(**factory_common_args))
 
 add_docstr(torch.rand_like,
-           r"""
-rand_like(input, generator=None, dtype=None, layout=None, device=None, requires_grad=False, memory_format=torch.preserve_format) -> Tensor
-
+           """
+rand_like(input, generator=None, dtype=None, layout=None, device=None, \
+requires_grad=False, memory_format=torch.preserve_format) -> Tensor
+""" + r"""
 Returns a tensor with the same size as :attr:`input` that is filled with
 random numbers from a uniform distribution on the interval :math:`[0, 1)`.
 ``torch.rand_like(input)`` is equivalent to
@@ -4885,7 +4886,7 @@ Args:
     low (int, optional): Lowest integer to be drawn from the distribution. Default: 0.
     high (int): One above the highest integer to be drawn from the distribution.
     size (tuple): a tuple defining the shape of the output tensor.
-    
+
 Keyword arguments:
     {generator}
     {out}
@@ -4929,7 +4930,7 @@ Args:
     {input}
     low (int, optional): Lowest integer to be drawn from the distribution. Default: 0.
     high (int): One above the highest integer to be drawn from the distribution.
-    
+
 Keyword arguments:
     {generator}
     {dtype}
@@ -4986,7 +4987,7 @@ random numbers from a normal distribution with mean 0 and variance 1.
 
 Args:
     {input}
-    
+
 Keyword arguments:
     {generator}
     {dtype}
@@ -5006,7 +5007,7 @@ Returns a random permutation of integers from ``0`` to ``n - 1``.
 
 Args:
     n (int): the upper bound (exclusive)
-    
+
 Keyword arguments:
     {generator}
     {out}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -73,7 +73,7 @@ factory_common_args = merge_dicts(common_args, parse_kwargs("""
         returned Tensor. Default: ``torch.contiguous_format``.
 """))
 
-factory_like_common_args = parse_kwargs("""
+factory_like_common_args = merge_dicts(common_args, parse_kwargs("""
     input (Tensor): the size of :attr:`input` will determine size of the output tensor.
     layout (:class:`torch.layout`, optional): the desired layout of returned tensor.
         Default: if ``None``, defaults to the layout of :attr:`input`.
@@ -87,7 +87,7 @@ factory_like_common_args = parse_kwargs("""
         the pinned memory. Works only for CPU tensors. Default: ``False``.
     memory_format (:class:`torch.memory_format`, optional): the desired memory format of
         returned Tensor. Default: ``torch.preserve_format``.
-""")
+"""))
 
 factory_data_common_args = parse_kwargs("""
     data (array_like): Initial data for the tensor. Can be a list, tuple,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4817,7 +4817,7 @@ Example::
 
 add_docstr(torch.rand,
            r"""
-rand(*size, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
+rand(*size, generator=None, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
 
 Returns a tensor filled with random numbers from a uniform distribution
 on the interval :math:`[0, 1)`
@@ -4827,6 +4827,9 @@ The shape of the tensor is defined by the variable argument :attr:`size`.
 Args:
     size (int...): a sequence of integers defining the shape of the output tensor.
         Can be a variable number of arguments or a collection like a list or tuple.
+        
+Keyword arguments:
+    {generator}
     {out}
     {dtype}
     {layout}
@@ -4844,7 +4847,7 @@ Example::
 
 add_docstr(torch.rand_like,
            r"""
-rand_like(input, dtype=None, layout=None, device=None, requires_grad=False, memory_format=torch.preserve_format) -> Tensor
+rand_like(input, generator=None, dtype=None, layout=None, device=None, requires_grad=False, memory_format=torch.preserve_format) -> Tensor
 
 Returns a tensor with the same size as :attr:`input` that is filled with
 random numbers from a uniform distribution on the interval :math:`[0, 1)`.
@@ -4853,6 +4856,9 @@ random numbers from a uniform distribution on the interval :math:`[0, 1)`.
 
 Args:
     {input}
+
+Keyword arguments:
+    {generator}
     {dtype}
     {layout}
     {device}
@@ -4879,6 +4885,8 @@ Args:
     low (int, optional): Lowest integer to be drawn from the distribution. Default: 0.
     high (int): One above the highest integer to be drawn from the distribution.
     size (tuple): a tuple defining the shape of the output tensor.
+    
+Keyword arguments:
     {generator}
     {out}
     {dtype}
@@ -4906,7 +4914,7 @@ Example::
 
 add_docstr(torch.randint_like,
            """
-randint_like(input, low=0, high, dtype=None, layout=torch.strided, device=None, requires_grad=False, \
+randint_like(input, low=0, high, generator=None, dtype=None, layout=torch.strided, device=None, requires_grad=False, \
 memory_format=torch.preserve_format) -> Tensor
 
 Returns a tensor with the same shape as Tensor :attr:`input` filled with
@@ -4921,6 +4929,9 @@ Args:
     {input}
     low (int, optional): Lowest integer to be drawn from the distribution. Default: 0.
     high (int): One above the highest integer to be drawn from the distribution.
+    
+Keyword arguments:
+    {generator}
     {dtype}
     {layout}
     {device}
@@ -4931,7 +4942,7 @@ Args:
 
 add_docstr(torch.randn,
            r"""
-randn(*size, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
+randn(*size, out=None, generator=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
 
 Returns a tensor filled with random numbers from a normal distribution
 with mean `0` and variance `1` (also called the standard normal
@@ -4945,6 +4956,9 @@ The shape of the tensor is defined by the variable argument :attr:`size`.
 Args:
     size (int...): a sequence of integers defining the shape of the output tensor.
         Can be a variable number of arguments or a collection like a list or tuple.
+
+Keyword arguments:
+    {generator}
     {out}
     {dtype}
     {layout}
@@ -4961,9 +4975,10 @@ Example::
 """.format(**factory_common_args))
 
 add_docstr(torch.randn_like,
-           r"""
-randn_like(input, dtype=None, layout=None, device=None, requires_grad=False, memory_format=torch.preserve_format) -> Tensor
-
+           """
+randn_like(input, generator=None, dtype=None, layout=None, device=None, \
+requires_grad=False, memory_format=torch.preserve_format) -> Tensor
+""" + r"""
 Returns a tensor with the same size as :attr:`input` that is filled with
 random numbers from a normal distribution with mean 0 and variance 1.
 ``torch.randn_like(input)`` is equivalent to
@@ -4971,6 +4986,9 @@ random numbers from a normal distribution with mean 0 and variance 1.
 
 Args:
     {input}
+    
+Keyword arguments:
+    {generator}
     {dtype}
     {layout}
     {device}
@@ -4980,13 +4998,17 @@ Args:
 """.format(**factory_like_common_args))
 
 add_docstr(torch.randperm,
-           r"""
-randperm(n, out=None, dtype=torch.int64, layout=torch.strided, device=None, requires_grad=False) -> LongTensor
-
+           """
+randperm(n, generator=None, out=None, dtype=torch.int64, layout=torch.strided, \
+device=None, requires_grad=False) -> LongTensor
+""" + r"""
 Returns a random permutation of integers from ``0`` to ``n - 1``.
 
 Args:
     n (int): the upper bound (exclusive)
+    
+Keyword arguments:
+    {generator}
     {out}
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
         Default: ``torch.int64``.


### PR DESCRIPTION
Fix #29692

This PR makes sure that all `torch.rand*` functions support `generator=` and are properly documented. 


FYI, here is a summary of what we have on the master: 

| | Supported | Documented | 
| --- | --- | --- |
| rand | Yes | [No](https://pytorch.org/docs/master/generated/torch.rand.html) | 
| rand_like | No | [No](https://pytorch.org/docs/master/generated/torch.rand_like.html) | 
| randint | Yes | Yes | 
| randint_like |  No |  [No](https://pytorch.org/docs/master/generated/torch.randint_like.html) | 
| randn | Yes | [No](https://pytorch.org/docs/master/generated/torch.randn.html) | 
| randn_like | No | [No](https://pytorch.org/docs/master/generated/torch.randn_like.html) |
| randperm |  Yes | [No](https://pytorch.org/docs/master/generated/torch.randperm.html) |

The new docs are listed below: 

https://5826492-65600975-gh.circle-artifacts.com/0/docs/generated/torch.rand.html
https://5826492-65600975-gh.circle-artifacts.com/0/docs/generated/torch.rand_like.html
https://5826492-65600975-gh.circle-artifacts.com/0/docs/generated/torch.randint.html
https://5826492-65600975-gh.circle-artifacts.com/0/docs/generated/torch.randint_like.html
https://5826492-65600975-gh.circle-artifacts.com/0/docs/generated/torch.randn.html
https://5826492-65600975-gh.circle-artifacts.com/0/docs/generated/torch.randn_like.html
https://5826492-65600975-gh.circle-artifacts.com/0/docs/generated/torch.randperm.html




cc: @SsnL, @albanD