### PR TITLE
Int8 PTQ ops for online training

### DIFF
--- a/caffe2/quantization/server/int8_gen_quant_params.cc
+++ b/caffe2/quantization/server/int8_gen_quant_params.cc
@@ -1,0 +1,21 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+#include "int8_gen_quant_params.h"
+#include <functional>
+
+namespace caffe2 {
+using namespace std;
+using namespace dnnlowp;
+// Expilictly register TypeMeta
+CAFFE_KNOWN_TYPE(unique_ptr<Int8QuantSchemeBlob>);
+CAFFE_KNOWN_TYPE(unique_ptr<Int8QuantParamsBlob>);
+
+REGISTER_CPU_OPERATOR(
+    Int8GenQuantParams,
+    Int8GenQuantParamsOp<CPUContext, DefaultEngine>);
+OPERATOR_SCHEMA(Int8GenQuantParams)
+    .NumInputs(2)
+    .NumOutputs(1)
+    .SetDoc(
+        R"DOC(Operator wrapper for generating int8 tensor quantization parameters given the input data and quant scheme)DOC");
+
+} // namespace caffe2

--- a/caffe2/quantization/server/int8_gen_quant_params.h
+++ b/caffe2/quantization/server/int8_gen_quant_params.h
@@ -1,0 +1,63 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+#include "caffe2_dnnlowp_utils.h"
+#include "dnnlowp.h"
+#include "dynamic_histogram.h"
+
+namespace caffe2 {
+using namespace std;
+using dnnlowp::TensorQuantizationParams;
+
+struct Int8QuantSchemeBlob {
+ public:
+  Int8QuantSchemeBlob(std::string quantization_kind, bool preserve_sparsity)
+      : quantization_kind_(quantization_kind),
+        preserve_sparsity_(preserve_sparsity) {}
+  std::string quantization_kind_;
+  bool preserve_sparsity_;
+};
+struct Int8QuantParamsBlob {
+ public:
+  Int8QuantParamsBlob(float scale, int zero_point) {
+    qparam.scale = scale;
+    qparam.zero_point = zero_point;
+  }
+  dnnlowp::TensorQuantizationParams qparam;
+};
+
+template <class Context, class Engine = DefaultEngine>
+class Int8GenQuantParamsOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  Int8GenQuantParamsOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws) {}
+  ~Int8GenQuantParamsOp() {}
+  bool RunOnDevice() override {
+    // Generate Int8 quant params based on the input data (last N samples of the
+    // activations) and the quant scheme
+    const auto& input_data = Input(0);
+    const auto* quant_scheme =
+        this->template Input<unique_ptr<Int8QuantSchemeBlob>>(1).get();
+    CAFFE_ENFORCE(input_data.dim() > 0);
+    CAFFE_ENFORCE(quant_scheme);
+    std::string quant_kind = quant_scheme->quantization_kind_;
+    bool preserve_sparsity = quant_scheme->preserve_sparsity_;
+    dnnlowp::QuantizationFactory* qfactory =
+        dnnlowp::QuantizationFactory::GetDefaultInstance();
+    TensorQuantizationParams qparam = qfactory->ChooseQuantizationParams(
+        input_data.template data<float>(),
+        input_data.numel(),
+        dnnlowp::StringToKind(quant_kind),
+        8,
+        preserve_sparsity);
+    auto* output_qparam =
+        this->template Output<unique_ptr<Int8QuantParamsBlob>>(0);
+    output_qparam->reset(
+        new Int8QuantParamsBlob(qparam.scale, qparam.zero_point));
+    return true;
+  }
+
+}; // class Int8QunatParamsOp
+
+} // namespace caffe2

--- a/caffe2/quantization/server/int8_gen_quant_params_test.py
+++ b/caffe2/quantization/server/int8_gen_quant_params_test.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, workspace
+from caffe2.quantization.server import dnnlowp_pybind11
+from hypothesis import given, settings
+
+
+class TestInt8GenQuantParamsOperator(hu.HypothesisTestCase):
+    @settings(max_examples=50)
+    @given(
+        n=st.integers(10, 100),
+        m=st.integers(1, 128),
+        k=st.integers(64, 1024),
+        quantization_kind=st.sampled_from(["min_max", "l2_approx", "l2"]),
+        preserve_sparsity=st.booleans(),
+        rnd_seed=st.integers(1, 5),
+        **hu.gcs_cpu_only
+    )
+    def test_int8_gen_quant_params_op(
+        self, n, m, k, quantization_kind, preserve_sparsity, rnd_seed, gc, dc
+    ):
+        assert n > 0, "Zero samples in the input data"
+        X_min = 0 if preserve_sparsity else -77
+        X_max = X_min + 255
+        np.random.seed(rnd_seed)
+        X = np.round(np.random.rand(n, m, k) * (X_max - X_min) + X_min).astype(
+            np.float32
+        )
+        # Calculate X_qparam
+        hist, bin_edges = np.histogram(X.flatten(), bins=2048)
+        X_qparam = dnnlowp_pybind11.ChooseStaticQuantizationParams(
+            X_min, X_max, hist, preserve_sparsity, 8, quantization_kind
+        )
+
+        # Build a net to generate X's qparam using the Int8GenQuantParams op
+        workspace.FeedBlob("X", X, device_option=gc)
+        dnnlowp_pybind11.CreateInt8QuantSchemeBlob(
+            "quant_scheme", quantization_kind, preserve_sparsity
+        )
+        assert workspace.HasBlob(
+            "quant_scheme"
+        ), "Failed to create the quant_scheme blob in current workspace"
+
+        gen_quant_params_net = core.Net("gen_quant_params")
+        gen_quant_params_op = core.CreateOperator(
+            "Int8GenQuantParams",
+            ["X", "quant_scheme"],
+            ["quant_param"],
+            device_option=gc,
+        )
+        gen_quant_params_net.Proto().op.extend([gen_quant_params_op])
+        assert workspace.RunNetOnce(
+            gen_quant_params_net
+        ), "Failed to run the gen_quant_params net"
+        scale, zero_point = dnnlowp_pybind11.ObserveInt8QuantParamsBlob("quant_param")
+
+        np.testing.assert_allclose(scale, X_qparam.scale, rtol=0.01)
+        np.testing.assert_allclose(zero_point, X_qparam.zero_point, rtol=0.02)

--- a/caffe2/quantization/server/pybind.cc
+++ b/caffe2/quantization/server/pybind.cc
@@ -6,6 +6,7 @@
 #include "caffe2/opt/custom/fakefp16_transform.h"
 #include "caffe2/quantization/server/fbgemm_pack_blob.h"
 #include "caffe2_dnnlowp_utils.h"
+#include "int8_gen_quant_params.h"
 #include "quantization_error_minimization.h"
 
 namespace caffe2 {
@@ -411,4 +412,37 @@ PYBIND11_MODULE(dnnlowp_pybind11, m) {
       },
       pybind11::arg("blob_name"),
       pybind11::arg("weights_out_file"));
+  m.def(
+      "CreateInt8QuantSchemeBlob",
+      [](std::string quant_scheme_blob_name,
+         std::string quantization_kind,
+         bool preserve_sparsity) {
+        Workspace* gWorkspace = caffe2::python::GetCurrentWorkspace();
+        CAFFE_ENFORCE(gWorkspace);
+        auto* quant_scheme_blob = gWorkspace->GetBlob(quant_scheme_blob_name);
+        if (quant_scheme_blob == nullptr) {
+          quant_scheme_blob = gWorkspace->CreateBlob(quant_scheme_blob_name);
+        }
+        auto* quant_scheme_blob_data =
+            quant_scheme_blob->GetMutable<unique_ptr<Int8QuantSchemeBlob>>();
+        quant_scheme_blob_data->reset(
+            new Int8QuantSchemeBlob(quantization_kind, preserve_sparsity));
+      },
+      pybind11::arg("quant_scheme_blob_name"),
+      pybind11::arg("quantization_kind"),
+      pybind11::arg("preserve_sparsity"));
+  m.def(
+      "ObserveInt8QuantParamsBlob",
+      [](std::string quant_params_blob_name) {
+        Workspace* gWorkspace = caffe2::python::GetCurrentWorkspace();
+        CAFFE_ENFORCE(gWorkspace);
+        auto* quant_params_blob = gWorkspace->GetBlob(quant_params_blob_name);
+        CAFFE_ENFORCE(quant_params_blob);
+        auto* quant_params_blob_data =
+            quant_params_blob->Get<unique_ptr<Int8QuantParamsBlob>>().get();
+        return std::tuple<float, int>(
+            quant_params_blob_data->qparam.scale,
+            quant_params_blob_data->qparam.zero_point);
+      },
+      pybind11::arg("quant_params_blob_name"));
 }


### PR DESCRIPTION
Summary:
Add histogram collection and qparam update support for Int8 PTQ during online training
Add caffe2 wrappers for generating int8 quant params based on output activation samples from the LastNWindowCollector op.

Test Plan:
```
buck test mode/opt caffe2/caffe2/quantization/server:int8_gen_quant_params_test
```

Differential Revision: D21984455

