### PR TITLE
[JIT] Allow self-referential annotations in classes

### DIFF
--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -145,6 +145,9 @@ c10::optional<std::string> ScriptTypeParser::parseBaseTypeName(
     case TK_NONE: {
       return "None";
     }
+    case TK_STRINGLITERAL: {
+      return StringLiteral(expr).text();
+    }
     case '.': {
       auto select = Select(expr);
       const std::string& name = select.selector().name();


### PR DESCRIPTION
**Summary**
This commit adds support for annotations in method signatures of a
TorchScript class types that refer to the class being defined itself.

**Test Plan**
This commit adds a unit test to check that a method that uses
self-referential type annotations can be defined and produces the same
results in Python and TorchScript.

