### PR TITLE
Add zero input support for batch permutation op

### DIFF
--- a/caffe2/operators/batch_permutation_op.cc
+++ b/caffe2/operators/batch_permutation_op.cc
@@ -61,13 +61,14 @@ bool BatchPermutationOp<float, CPUContext>::RunOnDevice() {
 
   auto* Y = Output(0, X.sizes(), at::dtype<float>());
 
-  CAFFE_ENFORCE_GT(X.dim32(0), 0);
-  batch_permutation_loop<true>(
-      X.dim32(0),
-      X.numel() / X.dim32(0),
-      X.data<float>(),
-      indices.data<int>(),
-      Y->mutable_data<float>());
+  if (X.dim32(0) > 0) {
+    batch_permutation_loop<true>(
+        X.dim32(0),
+        X.numel() / X.dim32(0),
+        X.data<float>(),
+        indices.data<int>(),
+        Y->mutable_data<float>());
+  }
   return true;
 }
 
@@ -78,13 +79,14 @@ bool BatchPermutationGradientOp<float, CPUContext>::RunOnDevice() {
 
   auto* dX = Output(0, dY.sizes(), at::dtype<float>());
 
-  CAFFE_ENFORCE_GT(dY.dim32(0), 0);
-  batch_permutation_loop<false>(
-      dY.dim32(0),
-      dY.numel() / dY.dim32(0),
-      dY.data<float>(),
-      indices.data<int>(),
-      dX->mutable_data<float>());
+  if (dY.dim32(0) > 0) {
+    batch_permutation_loop<false>(
+        dY.dim32(0),
+        dY.numel() / dY.dim32(0),
+        dY.data<float>(),
+        indices.data<int>(),
+        dX->mutable_data<float>());
+  }
   return true;
 }
 

--- a/caffe2/operators/batch_permutation_op.cu
+++ b/caffe2/operators/batch_permutation_op.cu
@@ -63,18 +63,18 @@ bool BatchPermutationOp<float, CUDAContext>::RunOnDevice() {
 
   auto* Y = Output(0, X.sizes(), at::dtype<float>());
 
-  CAFFE_ENFORCE_GT(X.dim32(0), 0);
-  BatchPermutationKernel<true>
-      <<<CAFFE_GET_BLOCKS(X.numel()),
-         CAFFE_CUDA_NUM_THREADS,
-         0,
-         context_.cuda_stream()>>>(
-          X.dim32(0),
-          X.numel() / X.dim32(0),
-          X.data<float>(),
-          indices.data<int>(),
-          Y->mutable_data<float>());
-
+  if (X.dim32(0) > 0) {
+    BatchPermutationKernel<true>
+        <<<CAFFE_GET_BLOCKS(X.numel()),
+          CAFFE_CUDA_NUM_THREADS,
+          0,
+          context_.cuda_stream()>>>(
+            X.dim32(0),
+            X.numel() / X.dim32(0),
+            X.data<float>(),
+            indices.data<int>(),
+            Y->mutable_data<float>());
+  }
   return true;
 }
 
@@ -84,18 +84,18 @@ bool BatchPermutationGradientOp<float, CUDAContext>::RunOnDevice() {
   auto& dY = Input(1);
   auto* dX = Output(0, dY.sizes(), at::dtype<float>());
 
-  CAFFE_ENFORCE_GT(dY.dim32(0), 0);
-  BatchPermutationKernel<false>
-      <<<CAFFE_GET_BLOCKS(dY.numel()),
-         CAFFE_CUDA_NUM_THREADS,
-         0,
-         context_.cuda_stream()>>>(
-          dY.dim32(0),
-          dY.numel() / dY.dim32(0),
-          dY.data<float>(),
-          indices.data<int>(),
-          dX->mutable_data<float>());
-
+  if (dY.dim32(0) > 0) {
+    BatchPermutationKernel<false>
+        <<<CAFFE_GET_BLOCKS(dY.numel()),
+          CAFFE_CUDA_NUM_THREADS,
+          0,
+          context_.cuda_stream()>>>(
+            dY.dim32(0),
+            dY.numel() / dY.dim32(0),
+            dY.data<float>(),
+            indices.data<int>(),
+            dX->mutable_data<float>());
+  }
   return true;
 }
 


### PR DESCRIPTION
Batch permutation op does not support zero input now, it can output a tensor the same as the input if the first dimension is zero. 

This can be solved: facebookresearch/detectron2#1580