### PR TITLE
Prevent clobbering of docker images by parallelnative/paralleltbb builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,9 +482,9 @@ jobs:
           elif [[ ${BUILD_ENVIRONMENT} == *"libtorch"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-libtorch
           elif [[ ${BUILD_ENVIRONMENT} == *"paralleltbb"* ]]; then
-            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+            export COMMIT_DOCKER_IMAGE=$output_image-paralleltbb
           elif [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
-            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+            export COMMIT_DOCKER_IMAGE=$output_image-parallelnative
           else
             export COMMIT_DOCKER_IMAGE=$output_image
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,6 +442,10 @@ jobs:
               export COMMIT_DOCKER_IMAGE=$output_image-xla
             elif [[ ${BUILD_ENVIRONMENT} == *"libtorch"* ]]; then
               export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+            elif [[ ${BUILD_ENVIRONMENT} == *"paralleltbb"* ]]; then
+              export COMMIT_DOCKER_IMAGE=$output_image-paralleltbb
+            elif [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
+              export COMMIT_DOCKER_IMAGE=$output_image-parallelnative
             elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-x86_64"* ]]; then
               export COMMIT_DOCKER_IMAGE=$output_image-android-x86_64
             elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-arm-v7a"* ]]; then
@@ -476,6 +480,10 @@ jobs:
           if [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-xla
           elif [[ ${BUILD_ENVIRONMENT} == *"libtorch"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+          elif [[ ${BUILD_ENVIRONMENT} == *"paralleltbb"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+          elif [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-libtorch
           else
             export COMMIT_DOCKER_IMAGE=$output_image

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -46,6 +46,10 @@ jobs:
               export COMMIT_DOCKER_IMAGE=$output_image-xla
             elif [[ ${BUILD_ENVIRONMENT} == *"libtorch"* ]]; then
               export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+            elif [[ ${BUILD_ENVIRONMENT} == *"paralleltbb"* ]]; then
+              export COMMIT_DOCKER_IMAGE=$output_image-paralleltbb
+            elif [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
+              export COMMIT_DOCKER_IMAGE=$output_image-parallelnative
             elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-x86_64"* ]]; then
               export COMMIT_DOCKER_IMAGE=$output_image-android-x86_64
             elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-arm-v7a"* ]]; then
@@ -80,6 +84,10 @@ jobs:
           if [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-xla
           elif [[ ${BUILD_ENVIRONMENT} == *"libtorch"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+          elif [[ ${BUILD_ENVIRONMENT} == *"paralleltbb"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+          elif [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-libtorch
           else
             export COMMIT_DOCKER_IMAGE=$output_image

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -86,9 +86,9 @@ jobs:
           elif [[ ${BUILD_ENVIRONMENT} == *"libtorch"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-libtorch
           elif [[ ${BUILD_ENVIRONMENT} == *"paralleltbb"* ]]; then
-            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+            export COMMIT_DOCKER_IMAGE=$output_image-paralleltbb
           elif [[ ${BUILD_ENVIRONMENT} == *"parallelnative"* ]]; then
-            export COMMIT_DOCKER_IMAGE=$output_image-libtorch
+            export COMMIT_DOCKER_IMAGE=$output_image-parallelnative
           else
             export COMMIT_DOCKER_IMAGE=$output_image
           fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39863 Prevent clobbering of docker images by parallelnative/paralleltbb builds**

The paralleltbb and parallelnative builds use the same docker image as
pytorch-linux-trusty-py3.6-gcc5.4-build
(https://github.com/pytorch/pytorch/blob/da3073e9b1db503f106842339f50f522d973be84/.circleci/config.yml#L6752)

Therefore they should push to a different intermediate docker image for
the next phase (testing), according to
(https://github.com/pytorch/pytorch/blob/da3073e9b1db503f106842339f50f522d973be84/.circleci/config.yml#L434-L439).

However, they're not actually included in that list.

We've found evidence of what looks like clobbering in recent CI jobs
(https://circleci.com/gh/pytorch/pytorch/5787534?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link),
(https://circleci.com/gh/pytorch/pytorch/5787763?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

This PR adds parallelnative and paralleltbb to the list to prevent
clobbering.

Test Plan:
- Wait for CI tests to pass on this PR.
- The paralleltbb and parallelnative builds don't actually run on PRs.
So I think the plan here is to yolo land and hope it works.

Differential Revision: [D22002279](https://our.internmc.facebook.com/intern/diff/D22002279)