### PR TITLE
[WIP] Tracker for atomic operations regression

### DIFF
--- a/tools/cpp_nano_regression/README.md
+++ b/tools/cpp_nano_regression/README.md
@@ -1,0 +1,96 @@
+# Simple tracker of atomic instructions
+
+Atomic instructions are expensive and it's useful to track their number to avoid regression.
+
+This simple library provides such functionality with minimal intrusiveness to the main PyTorch build.
+
+## Instrumentation
+
+Basic approach is to compile target binary (e.g. libtorch.so) with hooks intercepting atomic accesses. This is done by preprocessor overrides of `__atomic_*` intrinsics used by gcc/clang. In particular `std::atomic` implementation also uses those intrinsics. Overrides are performed by passing `--include=prelude.h` in compiler options and thus forcing it to be included before any standard library headers in each compilation unit.
+
+With pytorch build instrumentation can be enabled without any CMake changes:
+
+```
+CXXFLAGS=--include=$(realpath tools/cpp_nano_regression/prelude.h) python setup.py develop
+```
+
+## Tracker
+
+By default instrumentation just attempts to call a weak symbol for every tracked event. This allows any binary to be runnable even without tracker installed. It comes handy in PyTorch build which produces many intermediate binaries (e.g. protoc and many shared libraries) and it's cumbersome to pass tracker's translation unit in the correct places.
+
+The tracker implementation can be installed at runtime using `LD_PRELOAD`. `tracker.cpp` provides the simplest tracker implementation which is not thread-safe:
+
+```
+$ pushd tools/cpp_nano_regression
+$ sh build.sh
+$ popd
+$ LD_PRELOAD=tools/cpp_nano_regression/tracker.so python -c 'import torch'
+NANO TRACKER {
+  __atomic_sub_fetch: 1232
+  __atomic_compare_exchange_n: 13022
+  __atomic_fetch_sub: 9343
+  __atomic_add_fetch: 1232
+  __atomic_fetch_add: 1239581
+  __atomic_load_n: 58610
+  __atomic_store_n: 6633
+  __atomic_load: 183
+  __atomic_store: 102
+}
+```
+
+It's also possible to access tracker from python using `ctypes` (building a python extension is left as a future exercise):
+
+```
+$ LD_PRELOAD=tools/cpp_nano_regression/tracker.so python
+>>> import torch
+>>> import ctypes
+>>> dll=ctypes.CDLL('./nano_tracker.so')
+>>> _=dll.nano_tracking_reset()
+>>> x=torch.tensor([1,2,3])
+>>> _=dll.nano_tracking_dump()
+NANO TRACKER {
+  __atomic_sub_fetch: 1
+  __atomic_fetch_add: 65
+  __atomic_fetch_sub: 4
+  __atomic_load_n: 8
+  __atomic_add_fetch: 7
+}
+>>> _=dll.nano_tracking_reset()
+>>> x=x+1
+>>> _=dll.nano_tracking_dump()
+NANO TRACKER {
+  __atomic_sub_fetch: 15
+  __atomic_compare_exchange_n: 1
+  __atomic_fetch_sub: 3
+  __atomic_load_n: 8
+  __atomic_add_fetch: 15
+  __atomic_fetch_add: 29
+}
+```
+
+## Standalone demo
+
+A simple example of how this works is available in this folder (independently of pytorch):
+
+```
+$ pushd tools/cpp_nano_regression
+$ sh build.sh
+
+$ ./test
+before atomics
+after atomics
+
+$ LD_PRELOAD=./tracker.so ./test
+before atomics
+after atomics
+NANO TRACKER {
+  __atomic_fetch_sub: 1
+  __atomic_fetch_add: 1
+}
+
+$ LD_PRELOAD=./printing_tracker.so ./test
+before atomics
+NANO TRACKER __atomic_fetch_add
+NANO TRACKER __atomic_fetch_sub
+after atomics
+```

--- a/tools/cpp_nano_regression/build.sh
+++ b/tools/cpp_nano_regression/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+g++ -o tracker.so -shared -fPIC tracker.cpp
+g++ -o printing_tracker.so -shared -fPIC printing_tracker.cpp
+g++ -o test_lib.so -shared -fPIC --std=c++11 --include=prelude.h test_lib.cpp
+g++ -o test -L`pwd` -Wl,-R`pwd` test_lib.so test.cpp

--- a/tools/cpp_nano_regression/prelude.h
+++ b/tools/cpp_nano_regression/prelude.h
@@ -1,0 +1,41 @@
+// override functions from here: https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
+
+// generated with the script:
+// for i in $(with-proxy curl https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html | grep -oP '\<strong\>\K__atomic[^<]*'); do echo "#define $i(...) (_nano_tracking_log(\"$i\"), $i(__VA_ARGS__))"; done
+
+extern "C" {
+void __attribute__((weak)) nano_tracking_log(const char* event);
+}
+
+static inline void _nano_tracking_log(const char* event) {
+  if (&nano_tracking_log) {
+    nano_tracking_log(event);
+  }
+}
+
+#define __atomic_load_n(...) (_nano_tracking_log("__atomic_load_n"), __atomic_load_n(__VA_ARGS__))
+#define __atomic_load(...) (_nano_tracking_log("__atomic_load"), __atomic_load(__VA_ARGS__))
+#define __atomic_store_n(...) (_nano_tracking_log("__atomic_store_n"), __atomic_store_n(__VA_ARGS__))
+#define __atomic_store(...) (_nano_tracking_log("__atomic_store"), __atomic_store(__VA_ARGS__))
+#define __atomic_exchange_n(...) (_nano_tracking_log("__atomic_exchange_n"), __atomic_exchange_n(__VA_ARGS__))
+#define __atomic_exchange(...) (_nano_tracking_log("__atomic_exchange"), __atomic_exchange(__VA_ARGS__))
+#define __atomic_compare_exchange_n(...) (_nano_tracking_log("__atomic_compare_exchange_n"), __atomic_compare_exchange_n(__VA_ARGS__))
+#define __atomic_compare_exchange(...) (_nano_tracking_log("__atomic_compare_exchange"), __atomic_compare_exchange(__VA_ARGS__))
+#define __atomic_add_fetch(...) (_nano_tracking_log("__atomic_add_fetch"), __atomic_add_fetch(__VA_ARGS__))
+#define __atomic_sub_fetch(...) (_nano_tracking_log("__atomic_sub_fetch"), __atomic_sub_fetch(__VA_ARGS__))
+#define __atomic_and_fetch(...) (_nano_tracking_log("__atomic_and_fetch"), __atomic_and_fetch(__VA_ARGS__))
+#define __atomic_xor_fetch(...) (_nano_tracking_log("__atomic_xor_fetch"), __atomic_xor_fetch(__VA_ARGS__))
+#define __atomic_or_fetch(...) (_nano_tracking_log("__atomic_or_fetch"), __atomic_or_fetch(__VA_ARGS__))
+#define __atomic_nand_fetch(...) (_nano_tracking_log("__atomic_nand_fetch"), __atomic_nand_fetch(__VA_ARGS__))
+#define __atomic_fetch_add(...) (_nano_tracking_log("__atomic_fetch_add"), __atomic_fetch_add(__VA_ARGS__))
+#define __atomic_fetch_sub(...) (_nano_tracking_log("__atomic_fetch_sub"), __atomic_fetch_sub(__VA_ARGS__))
+#define __atomic_fetch_and(...) (_nano_tracking_log("__atomic_fetch_and"), __atomic_fetch_and(__VA_ARGS__))
+#define __atomic_fetch_xor(...) (_nano_tracking_log("__atomic_fetch_xor"), __atomic_fetch_xor(__VA_ARGS__))
+#define __atomic_fetch_or(...) (_nano_tracking_log("__atomic_fetch_or"), __atomic_fetch_or(__VA_ARGS__))
+#define __atomic_fetch_nand(...) (_nano_tracking_log("__atomic_fetch_nand"), __atomic_fetch_nand(__VA_ARGS__))
+#define __atomic_test_and_set(...) (_nano_tracking_log("__atomic_test_and_set"), __atomic_test_and_set(__VA_ARGS__))
+#define __atomic_clear(...) (_nano_tracking_log("__atomic_clear"), __atomic_clear(__VA_ARGS__))
+#define __atomic_thread_fence(...) (_nano_tracking_log("__atomic_thread_fence"), __atomic_thread_fence(__VA_ARGS__))
+#define __atomic_signal_fence(...) (_nano_tracking_log("__atomic_signal_fence"), __atomic_signal_fence(__VA_ARGS__))
+#define __atomic_always_lock_free(...) (_nano_tracking_log("__atomic_always_lock_free"), __atomic_always_lock_free(__VA_ARGS__))
+#define __atomic_is_lock_free(...) (_nano_tracking_log("__atomic_is_lock_free"), __atomic_is_lock_free(__VA_ARGS__))

--- a/tools/cpp_nano_regression/printing_tracker.cpp
+++ b/tools/cpp_nano_regression/printing_tracker.cpp
@@ -1,0 +1,7 @@
+#include <cstdio>
+
+extern "C" {
+void nano_tracking_log(const char* event) {
+  printf("NANO TRACKER %s\n", event);
+}
+}

--- a/tools/cpp_nano_regression/test.cpp
+++ b/tools/cpp_nano_regression/test.cpp
@@ -1,0 +1,18 @@
+// Standalone demo. Compile with:
+// g++ -o test --include=prelude.h test.cpp
+// LD_PRELOAD=./tracker.so ./test
+
+#include <atomic>
+#include <iostream>
+#include <unordered_map>
+
+using namespace std;
+
+void foo();
+
+int main() {
+  cout << "before atomics" << endl;
+  foo();
+  cout << "after atomics" << endl;
+  return 0;
+}

--- a/tools/cpp_nano_regression/test_lib.cpp
+++ b/tools/cpp_nano_regression/test_lib.cpp
@@ -1,0 +1,8 @@
+#include <atomic>
+
+std::atomic<int> x{0};
+
+void foo() {
+  x++;
+  x--;
+}

--- a/tools/cpp_nano_regression/tracker.cpp
+++ b/tools/cpp_nano_regression/tracker.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <unordered_map>
+
+using namespace std;
+
+// map is ok - perf doesn't really matter :)
+unordered_map<string, int> events;
+
+extern "C" {
+void nano_tracking_log(const char* event) {
+  ++events[string(event)];
+}
+
+void nano_tracking_dump() {
+  cout << "NANO TRACKER {" << endl;
+  for (const auto& it : events) {
+    cout << "  " << it.first << ": " << it.second << endl;
+  }
+  cout << "}" << endl;
+}
+
+void nano_tracking_reset() {
+  events.clear();
+}
+
+int nano_tracking_get_event(const char* event) {
+  auto it = events.find(string(event));
+  return it == events.end() ? 0 : it->second;
+}
+}
+
+struct Finalizer {
+  ~Finalizer() {
+    nano_tracking_dump();
+  }
+};
+
+static Finalizer _instance;


### PR DESCRIPTION
Atomic instructions are relatively expensive and we had regressions in PyTorch in the past due to accidental increase in refcount bump number. Measuring walltime is noisy, so it's useful to track some deterministic number to avoid regression. This PR shows an experiments of how to do it for any std::atomic operations.

I'm not yet sure whether it's a good idea to integrate it into PyTorch build or whether we can just keep it separately as a debugging tool.

Also the current implementation is very naive (e.g. not thread safe), I probably need to solidify it.

Along these lines we can also add more instrumentation to PyTorch, e.g. for TensorImpl/StorageImpl allocations. But that likely would require adding some hooks to the main PyTorch codebase.

## Results for previous versions

| version | `x=torch.tensor([1,2,3])` | `x=x+1` |
| --- | --- | --- |
| master | 85 | 71 |
| v1.4.0 | 110 | 127 |
| v1.2.0 | 60 | 127 |

I sadly couldn't build versions 1.0 or prior.

Types of atomic operations change with version, I just summed them up.

We do know that 1.4 was bad and it's reflected in this benchmark.

Raw data:
```
master ===============

NANO TRACKER {
  __atomic_sub_fetch: 1
  __atomic_fetch_add: 65
  __atomic_fetch_sub: 4
  __atomic_load_n: 8
  __atomic_add_fetch: 7
}
85
NANO TRACKER {
  __atomic_sub_fetch: 15
  __atomic_compare_exchange_n: 1
  __atomic_fetch_sub: 3
  __atomic_load_n: 8
  __atomic_add_fetch: 15
  __atomic_fetch_add: 29
}
71


1.4 ===============

NANO TRACKER {
  __atomic_sub_fetch: 10
  __atomic_add_fetch: 16
  __atomic_load_n: 28
  __atomic_fetch_add: 56
}
110
NANO TRACKER {
  __atomic_sub_fetch: 28
  __atomic_load_n: 41
  __atomic_add_fetch: 28
  __atomic_fetch_add: 30
}
127


1.2 ===============

NANO TRACKER {
  __atomic_sub_fetch: 2
  __atomic_add_fetch: 8
  __atomic_load_n: 3
  __atomic_fetch_add: 47
}
60
NANO TRACKER {
  __atomic_sub_fetch: 33
  __atomic_add_fetch: 37
  __atomic_load_n: 30
  __atomic_fetch_add: 27
}
127
```


--- 
From README.md:

# Simple tracker of atomic instructions

Atomic instructions are expensive and it's useful to track their number to avoid regression.

This simple library provides such functionality with minimal intrusiveness to the main PyTorch build.

## Instrumentation

Basic approach is to compile target binary (e.g. libtorch.so) with hooks intercepting atomic accesses. This is done by preprocessor overrides of `__atomic_*` intrinsics used by gcc/clang. In particular `std::atomic` implementation also uses those intrinsics. Overrides are performed by passing `--include=prelude.h` in compiler options and thus forcing it to be included before any standard library headers in each compilation unit.

With pytorch build instrumentation can be enabled without any CMake changes:

```
CXXFLAGS=--include=$(realpath tools/cpp_nano_regression/prelude.h) python setup.py develop
```

## Tracker

By default instrumentation just attempts to call a weak symbol for every tracked event. This allows any binary to be runnable even without tracker installed. It comes handy in PyTorch build which produces many intermediate binaries (e.g. protoc and many shared libraries) and it's cumbersome to pass tracker's translation unit in the correct places.

The tracker implementation can be installed at runtime using `LD_PRELOAD`. `tracker.cpp` provides the simplest tracker implementation which is not thread-safe:

```
$ pushd tools/cpp_nano_regression
$ sh build.sh
$ popd
$ LD_PRELOAD=tools/cpp_nano_regression/tracker.so python -c 'import torch'
NANO TRACKER {
  __atomic_sub_fetch: 1232
  __atomic_compare_exchange_n: 13022
  __atomic_fetch_sub: 9343
  __atomic_add_fetch: 1232
  __atomic_fetch_add: 1239581
  __atomic_load_n: 58610
  __atomic_store_n: 6633
  __atomic_load: 183
  __atomic_store: 102
}
```

It's also possible to access tracker from python using `ctypes` (building a python extension is left as a future exercise):

```
$ LD_PRELOAD=tools/cpp_nano_regression/tracker.so python
>>> import torch
>>> import ctypes
>>> dll=ctypes.CDLL('tools/cpp_nano_regression/tracker.so')
>>> _=dll.nano_tracking_reset()
>>> x=torch.tensor([1,2,3])
>>> _=dll.nano_tracking_dump()
NANO TRACKER {
  __atomic_sub_fetch: 1
  __atomic_fetch_add: 65
  __atomic_fetch_sub: 4
  __atomic_load_n: 8
  __atomic_add_fetch: 7
}
>>> _=dll.nano_tracking_reset()
>>> x=x+1
>>> _=dll.nano_tracking_dump()
NANO TRACKER {
  __atomic_sub_fetch: 15
  __atomic_compare_exchange_n: 1
  __atomic_fetch_sub: 3
  __atomic_load_n: 8
  __atomic_add_fetch: 15
  __atomic_fetch_add: 29
}
```

## Standalone demo

A simple example of how this works is available in this folder (independently of pytorch):

```
$ pushd tools/cpp_nano_regression
$ sh build.sh
$ ./test
before atomics
after atomics
$ LD_PRELOAD=./tracker.so ./test
before atomics
after atomics
NANO TRACKER {
  __atomic_fetch_sub: 1
  __atomic_fetch_add: 1
}
$ LD_PRELOAD=./printing_tracker.so ./test
before atomics
NANO TRACKER __atomic_fetch_add
NANO TRACKER __atomic_fetch_sub
after atomics
```