### PR TITLE
Fix CUDA device guard usage when first arg of kernel is scalar

### DIFF
--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -90,6 +90,7 @@ void gpu_kernel_with_scalars(TensorIterator& iter, const func_t& f) {
     using arg2_t = typename traits::template arg<1>::type;
     auto a = iter.scalar_value<arg1_t>(1);
     iter.remove_operand(1);
+    const OptionalDeviceGuard device_guard(device_of(iter.tensor(1)));
     gpu_kernel(iter, [=]GPU_LAMBDA(arg2_t b) {
       return f(a, b);
     });

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14131,6 +14131,24 @@ class TestTorchDeviceType(TestCase):
                 with self.assertRaisesRegex(RuntimeError, "Expected all tensors.+"):
                     op(cpu_tensor, a)
 
+    # This test ensures that a scalar Tensor can be safely used
+    # in a binary operation in conjuction with a Tensor on all
+    # available CUDA devices
+    @deviceCountAtLeast(2)
+    @onlyCUDA
+    def test_binary_op_scalar_device_unspecified(self, devices):
+        scalar_val = torch.tensor(1.)
+        for default_device in devices:
+            torch.cuda.set_device(default_device)
+            for device in devices:
+                device_obj = torch.device(device)
+                x = torch.rand(3, device=device)
+                y0 = x * scalar_val
+                self.assertEqual(y0.device, device_obj)
+                y1 = scalar_val * x
+                self.assertEqual(y1.device, device_obj)
+                self.assertEqual(y0, y1)
+
     # Tests that CPU scalars (including zero dim tensors) can be used in
     # binary operations with CUDA tensors.
     @onlyCUDA


### PR DESCRIPTION
Add an OptionalDeviceGuard for second arg in gpu_kernel_with_scalars when first arg is scalar

Closes #38889

