### PR TITLE
Attempt to fix macos ci by pinning numba

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
 conda install -y six
-pip install -q hypothesis "librosa>=0.6.2" psutil
+pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil
 
 # TODO move this to docker
 pip install unittest-xml-reporting


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39875 Attempt to fix macos ci by pinning numba**

Numba released a new version (0.50) that is causing problems with
librosa (we use this as a test dependency). Try pinning the version of
numba to temporarily fix. I am not actually sure if this is going to
work because it is unclear when we actually install numba.

Test Plan:
- wait for CI.

Differential Revision: [D22005838](https://our.internmc.facebook.com/intern/diff/D22005838)