### PR TITLE
[JIT] use python type resolver for all types

### DIFF
--- a/torch/csrc/jit/frontend/script_type_parser.h
+++ b/torch/csrc/jit/frontend/script_type_parser.h
@@ -18,6 +18,7 @@ class TORCH_API ScriptTypeParser {
   explicit ScriptTypeParser() {}
   explicit ScriptTypeParser(ResolverPtr resolver)
       : resolver_(std::move(resolver)) {}
+
   c10::TypePtr parseTypeFromExpr(const Expr& expr) const;
 
   c10::optional<std::pair<c10::TypePtr, int32_t>> parseBroadcastList(
@@ -30,6 +31,8 @@ class TORCH_API ScriptTypeParser {
   c10::IValue parseClassConstant(const Assign& assign);
 
  private:
+  c10::TypePtr parseTypeFromExprImpl(const Expr& expr) const;
+
   c10::optional<std::string> parseBaseTypeName(const Expr& expr) const;
   at::TypePtr subscriptToType(
       const std::string& typeName,


### PR DESCRIPTION
Follow up to https://github.com/pytorch/pytorch/pull/39269, use the python resolver for all type resolutions.