### PR TITLE
Pin numba version [1.5.1]

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
 conda install -y six
-pip install -q hypothesis "librosa>=0.6.2" psutil
+pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil
 
 # TODO move this to docker
 pip install unittest-xml-reporting


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/39875

Numba released a new version (0.50) that is causing problems with
librosa (we use this as a test dependency). Try pinning the version of
numba to temporarily fix. I am not actually sure if this is going to
work because it is unclear when we actually install numba.

Test Plan: - wait for CI.

Reviewed By: mruberry

Differential Revision: D22005838

Pulled By: zou3519

fbshipit-source-id: 4bccfa622c82533d85631052e4ad273617ea31d7

