### PR TITLE
[pytorch] fix (ProfiledType|TraceType)None.cpp

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -673,9 +673,8 @@ def gen_variable_type_shard(out, aten_declarations, template_path, suffix, heade
         write(out, 'VariableType.h', VARIABLE_TYPE_H, env)
     else:
         write(out, 'VariableType%s.cpp' % suffix, VARIABLE_TYPE_CPP, env)
-
-    write(out, 'ProfiledType%s.cpp' % suffix, PROFILED_TYPE_CPP, env)
-    write(out, 'TraceType%s.cpp' % suffix, TRACE_TYPE_CPP, env)
+        write(out, 'ProfiledType%s.cpp' % suffix, PROFILED_TYPE_CPP, env)
+        write(out, 'TraceType%s.cpp' % suffix, TRACE_TYPE_CPP, env)
 
 
 def emit_profiled_body(declaration):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#39934 [pytorch] fix (ProfiledType|TraceType)None.cpp**

Summary:
Shouldn't write .cpp file when it's called to produce header file.

Differential Revision: [D22016596](https://our.internmc.facebook.com/intern/diff/D22016596)