### PR TITLE
[test] Raise a specific error when python 32bit version try install pytorch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,9 @@ import sys
 if sys.version_info < (3,):
     raise Exception("Python 2 has reached end-of-life and is no longer supported by PyTorch.")
 
+if sys.maxsize < 2**32:
+    raise Exception("PyTorch requires 64-bit version of Python. Upgrade Python to 64-bit version.")
+
 from setuptools import setup, Extension, distutils, find_packages
 from collections import defaultdict
 from distutils import core


### PR DESCRIPTION
To solve issue like https://github.com/pytorch/pytorch/issues/37379, when user try to install PyTorch for python 32-bit version, will raise a error with specific message that only python 64-bit version supported by PyTorch. 