### PR TITLE
test for multi-processing support of optimisers

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -36,7 +36,8 @@ def drosenbrock(tensor):
 def _update(optimizer, x):
     """ Simple update function for multi-processing test. """
     optimizer.zero_grad()
-    val = x.sum().backward()
+    val = x.sum()
+    val.backward()
     optimizer.step()
     return val.item()
 

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -33,6 +33,14 @@ def drosenbrock(tensor):
     return torch.Tensor((-400 * x * (y - x ** 2) - 2 * (1 - x), 200 * (y - x ** 2)))
 
 
+def _update(optimizer, x):
+    """ Simple update function for multi-processing test. """
+    optimizer.zero_grad()
+    val = x.sum().backward()
+    optimizer.step()
+    return val.item()
+
+
 class TestOptim(TestCase):
     exact_dtype = True
 
@@ -244,12 +252,6 @@ class TestOptim(TestCase):
         )
 
     def _test_multi_processing(self, constructor):
-        def _update(optimizer, x):
-            optimizer.zero_grad()
-            val = x.sum().backward()
-            optimizer.step()
-            return val.item()
-
         # multi-processing
         p_multi = torch.zeros(10).requires_grad_(True).share_memory_()
         opt_multi = constructor([p_multi])

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -427,6 +427,7 @@ class TestOptim(TestCase):
             [lambda opt: ReduceLROnPlateau(opt),
              lambda opt: ExponentialLR(opt, gamma=0.99)]
         )
+        self._test_multi_processing(optim.Adagrad)
         with self.assertRaisesRegex(ValueError, "Invalid lr_decay value: -0.5"):
             optim.Adagrad(None, lr=1e-2, lr_decay=-0.5)
 

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -256,7 +256,7 @@ class TestOptim(TestCase):
         p_multi = torch.zeros(10).requires_grad_(True).share_memory_()
         opt_multi = constructor([p_multi])
         opt_multi.share_memory()
-        pool = mp.Pool(1)
+        pool = mp.get_context('spawn').Pool(1)
         res_multi = pool.apply(_update, args=(opt_multi, p_multi))
 
         # reference solution


### PR DESCRIPTION
This is an answer to [this request](https://github.com/pytorch/pytorch/pull/32903#issuecomment-583491882) from @vincentqb to add tests for detecting an issue that occurs when the state of an optimiser is not correctly updated when it is shared among processes (using shared memory).

The idea of the test is to make sure that the state of the optimiser progresses in the same way, independent of whether multi-processing is used or not. The following code snippet should bring this idea across:
```python
def update(optimizer, x):
    optimizer.zero_grad()
    x.sum().backward()
    optimizer.step()

p = torch.zeros(10).requires_grad_(True).share_memory_() 
optim_multi = torch.optim.Adagrad([p]) 
optim_multi.share_memory() 
pool = torch.multiprocessing.Pool(1) 
pool.apply(update, (optim_multi, p))
print(optim_multi.state[p])

p = torch.zeros(10).requires_grad_(True)
optim_ref = torch.optim.Adagrad([p])
update(optim_ref, p)
print(optim_ref.state[p])
```
If the printed states (`dict`s) are the same, then the state was shared correctly. In its current state, Adagrad does seem to correctly share its `'sum'` state, but does does not update its `'step'` state correctly when using multi-processing.