### PR TITLE
[WIP][JIT] Add ScriptModule._reconstruct

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -486,6 +486,53 @@ class TestScriptPy3(JitTestCase):
                 if True:
                     x : Optional[int] = 7
 
+    def test_module_inplace_construct(self):
+        class M(nn.Module):
+            def __init__(self, start: int):
+                super().__init__()
+                self.linear = nn.Linear(3, 3)
+                self.attribute = start
+                self.parameter = nn.Parameter(torch.tensor(3, dtype=torch.float))
+
+            def method(self) -> int:
+                return self.attribute
+
+            @torch.jit.unused
+            def unused_method(self):
+                return self.attribute + self.attribute
+
+            def forward(self, x):
+                return self.linear(self.linear(x))
+
+
+        class N(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(4, 4)
+
+            @torch.jit.ignore
+            def ignored_method(self, x):
+                return x
+
+            def forward(self, x):
+                return self.linear(x)
+
+        m = torch.jit.script(M(3))
+        n = torch.jit.script(N())
+
+        n._reconstruct(m._c)
+
+        inp = torch.rand((3))
+
+        # Check that both modules produce the same output.
+        with torch.no_grad():
+            m_out = m(inp)
+            n_out = n(inp)
+            self.assertEqual(m_out, n_out)
+
+        # Check that ignored method is still intact.
+        self.assertEqual(inp, n.ignored_method(inp))
+
     def test_export_opnames_interface(self):
         global OneTwoModule
 

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1029,6 +1029,7 @@ void initJitScriptBindings(PyObject* module) {
             return Module(
                 pyIValueDeepcopy(IValue(self._ivalue()), memo).toObject());
           })
+      .def("children", &Module::children)
       .def_property_readonly("qualified_name", [](const Module& self) {
         return self.type()->name()->qualifiedName();
       });

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -4,7 +4,7 @@ import torch.jit.annotations
 import torch.testing
 import torch.jit._recursive
 
-from torch.jit._recursive import ScriptMethodStub
+from torch.jit._recursive import ScriptMethodStub, wrap_cpp_module
 from torch.jit._builtins import _find_builtin, _get_builtin_table, _register_builtin  # noqa
 from torch._jit_internal import Future, _qualified_name
 from torch.autograd import Variable, function
@@ -1743,6 +1743,32 @@ if _enabled:
             script_module._initializing = False
             return script_module
 
+        def _reconstruct(self, cpp_module):
+            """
+            Re-construct an instance of RecursiveScriptModule using an instance of a C++ module.
+
+            Arguments:
+                cpp_module: The C++ module that this RecursiveScriptModule will be rebuilt around.
+            """
+            self.__init__(cpp_module)
+
+            # Copy the concrete type from the C++ module to this ScriptModule.
+            self._concrete_type = torch._C.ConcreteModuleType.from_jit_type(self._c._type())
+
+            # Copy submodules from the C++ module to this ScriptModule.
+            modules = {}
+            for name, cpp_module in torch._C.ModuleDict(self._c).items():
+                modules[name] = wrap_cpp_module(cpp_module)
+            self._modules = OrderedModuleDict(self._c, modules)
+
+            # Copy parameters and buffers.
+            self._parameters = OrderedDictWrapper(torch._C.ParameterDict(self._c))
+            self._buffers = OrderedDictWrapper(torch._C.BufferDict(self._c))
+
+            # Get rid of the functions from the old C++ module.
+            self.__dict__ = {k: v for k, v in self.__dict__.items() if not isinstance(v, torch._C.ScriptMethod)}
+            self.__dict__['_initializing'] = False
+
         @property
         def graph(self):
             r"""
@@ -2075,6 +2101,16 @@ class TracedModule(ScriptModule):
 if _enabled:
     class TopLevelTracedModule(TracedModule):
         forward = _CachedForward()
+
+        def _reconstruct(self, cpp_module):
+            """
+            Re-construct an instance of TopLevelTracedModule using an instance of a C++ module.
+
+            Arguments:
+                cpp_module: The C++ module that this TopLevelTracedModule will be rebuilt around.
+            """
+            self.__dict__['_actual_script_module']._reconstruct(cpp_module)
+
 
 def is_scripting():
     r"""


### PR DESCRIPTION
**Summary**
This commit adds an instance method `_reconstruct` that permits users
to reconstruct a `ScriptModule` from a given C++ `Module` instance.

**Testing**
This commit adds a unit test for `_reconstruct`.

**Fixes**
This pull request fixes #33912.

