### PR TITLE
Add a ctx manager to ignore RRefs when saving TorchScript modules

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -693,6 +693,13 @@ PyObject* rpc_init(PyObject* /* unused */) {
       "_disable_server_process_global_profiler",
       &profiler::processglobal::disableServer);
 
+  module.def(
+      "_enable_skip_jit_rref_pickle",
+      &enableSkipJitRRefPickle);
+  module.def(
+      "_disable_skip_jit_rref_pickle",
+      &disableSkipJitRRefPickle);
+
   Py_RETURN_TRUE;
 }
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -693,12 +693,8 @@ PyObject* rpc_init(PyObject* /* unused */) {
       "_disable_server_process_global_profiler",
       &profiler::processglobal::disableServer);
 
-  module.def(
-      "_enable_skip_jit_rref_pickle",
-      &enableSkipJitRRefPickle);
-  module.def(
-      "_disable_skip_jit_rref_pickle",
-      &disableSkipJitRRefPickle);
+  module.def("_enable_skip_jit_rref_pickle", &enableSkipJitRRefPickle);
+  module.def("_disable_skip_jit_rref_pickle", &disableSkipJitRRefPickle);
 
   Py_RETURN_TRUE;
 }

--- a/torch/csrc/distributed/rpc/types.cpp
+++ b/torch/csrc/distributed/rpc/types.cpp
@@ -9,8 +9,22 @@ namespace rpc {
 // saved by calling torch.save(), rref is not allowed to be pickled directly.
 static thread_local bool allowJitRRefPickle = false;
 
+static thread_local bool skipJitRRefPickle = false;
+
 bool getAllowJitRRefPickle() {
   return allowJitRRefPickle;
+}
+
+bool getSkipJitRRefPickle() {
+  return skipJitRRefPickle;
+}
+
+void enableSkipJitRRefPickle() {
+  skipJitRRefPickle = true;
+}
+
+void disableSkipJitRRefPickle() {
+  skipJitRRefPickle = false;
 }
 
 static_assert(

--- a/torch/csrc/distributed/rpc/types.h
+++ b/torch/csrc/distributed/rpc/types.h
@@ -12,6 +12,10 @@ using local_id_t = int64_t;
 
 bool getAllowJitRRefPickle();
 
+bool getSkipJitRRefPickle();
+TORCH_API void enableSkipJitRRefPickle();
+TORCH_API void disableSkipJitRRefPickle();
+
 struct TORCH_API JitRRefPickleGuard {
   JitRRefPickleGuard();
   ~JitRRefPickleGuard();

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -131,10 +131,12 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
     AT_ERROR(err.str());
   } else if (ivalue.isRRef()) {
 #ifdef USE_DISTRIBUTED
-    TORCH_CHECK(
-        torch::distributed::rpc::getAllowJitRRefPickle() == true,
-        "RRef jit pickling is only allowed inside RPC calls.");
-    pushRRef(ivalue);
+    if (!torch::distributed::rpc::getSkipJitRRefPickle()) {
+      TORCH_CHECK(
+          torch::distributed::rpc::getAllowJitRRefPickle() == true,
+          "RRef jit pickling is only allowed inside RPC calls.");
+      pushRRef(ivalue);
+    }
 #else
     TORCH_CHECK(
         false, "RRef pickling is only supported with the distributed package");

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -18,6 +18,9 @@ if is_available() and not torch._C._rpc_init():
 if is_available():
     from . import api, backend_registry, functions
     from .api import *  # noqa: F401
+    from .api import (
+        _skip_jit_rref_pickle,
+    )
     from .server_process_global_profiler import (
         _server_process_global_profile,
     )

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -28,6 +28,11 @@ from . import (
     backend_registry,
 )
 
+from . import (
+    _enable_skip_jit_rref_pickle,
+    _disable_skip_jit_rref_pickle,
+)
+
 from .internal import (
     PythonUDF,
     RPCExecMode,
@@ -65,6 +70,19 @@ def _use_rpc_pickler(rpc_pickler):
         yield
     finally:
         _default_pickler = _internal_rpc_pickler
+
+
+@contextlib.contextmanager
+def _skip_jit_rref_pickle():
+    r"""
+    If wrapped with this context, ``torch.jit.save(script_module)`` will ignore
+    all RRefs in ``script_module``.
+    """
+    _enable_skip_jit_rref_pickle()
+    try:
+        yield
+    finally:
+        _disable_skip_jit_rref_pickle()
 
 
 def _require_initialized(func):

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -1,5 +1,5 @@
 import io
-import typing
+import time
 from typing import Dict, Tuple
 
 import torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40011 Add a ctx manager to ignore RRefs when saving TorchScript modules**

Differential Revision: [D22043640](https://our.internmc.facebook.com/intern/diff/D22043640)