### PR TITLE
[android] gradle version update

### DIFF
--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -139,7 +139,7 @@ case "$image" in
     PROTOBUF=yes
     ANDROID=yes
     ANDROID_NDK_VERSION=r19c
-    GRADLE_VERSION=4.10.3
+    GRADLE_VERSION=6.5
     CMAKE_VERSION=3.7.0
     NINJA_VERSION=1.9.0
     ;;

--- a/.circleci/scripts/build_android_gradle.sh
+++ b/.circleci/scripts/build_android_gradle.sh
@@ -6,7 +6,7 @@ export ANDROID_HOME=/opt/android/sdk
 
 # Must be in sync with GRADLE_VERSION in docker image for android
 # https://github.com/pietern/pytorch-dockerfiles/blob/master/build.sh#L155
-export GRADLE_VERSION=4.10.3
+export GRADLE_VERSION=6.5
 export GRADLE_HOME=/opt/gradle/gradle-$GRADLE_VERSION
 export GRADLE_PATH=$GRADLE_HOME/bin/gradle
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ allprojects {
         }
 
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.3.2'
+            classpath 'com.android.tools.build:gradle:4.2.0-alpha01'
             classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${GRADLE_BINTRAY_PLUGIN_VERSION}"
             classpath "com.github.dcendents:android-maven-gradle-plugin:${ANDROID_MAVEN_GRADLE_PLUGIN_VERSION}"
             classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.9.8"

--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -97,7 +97,7 @@ afterEvaluate {
         if (f.name.endsWith(".aar")) {
           output.assemble.finalizedBy addFolderToAarTask(
               "addHeadersToAar" + variant.name,
-              f.path.replaceAll(variant.name, VERSION_NAME),
+              f.path,
               getLibtorchHeadersDir(),
               "headers")
         }

--- a/scripts/build_pytorch_android.sh
+++ b/scripts/build_pytorch_android.sh
@@ -105,9 +105,7 @@ done
 # systemProp.https.proxyPort=8080
 
 if [ "$CUSTOM_ABIS_LIST" = true ]; then
-  # Skipping clean task here as android gradle plugin 3.3.2 exteralNativeBuild has problems
-  # with it when abiFilters are specified.
-  $GRADLE_PATH -PABI_FILTERS=$ABIS_LIST -p $PYTORCH_ANDROID_DIR assembleRelease
+  $GRADLE_PATH -PABI_FILTERS=$ABIS_LIST -p $PYTORCH_ANDROID_DIR clean assembleRelease
 else
   $GRADLE_PATH -p $PYTORCH_ANDROID_DIR clean assembleRelease
 fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40015 [android] gradle version update**
* #39587 [android] test_app example linking to pytorch_android aar content
* #39588 [android] ANDROID_STL=c++_shared
* #39507 [android] Add libtorch headers to pytorch_android aar
* #39584 [android][cmake] Remove NO_EXPORT for libtorch mobile build

Upgrading gradle to 6.5 and android gradle plugin to the latest 4.2.0-alpha

And returning back clean operation that was removed in https://github.com/pytorch/pytorch/pull/39587 due to problems in android gradle plugin version 3.3.2