### PR TITLE
[quant][graphmode] Support another use pattern of mean

### DIFF
--- a/test/quantization/test_quantize_script.py
+++ b/test/quantization/test_quantize_script.py
@@ -2306,7 +2306,9 @@ class TestQuantizeScriptPTSQOps(QuantizationTestCase):
                 x = F.adaptive_avg_pool2d(x, (1, 1))
                 x = F.adaptive_avg_pool3d(x, (1, 1, 1))
                 x = torch.mean(x)
+                x = torch.mean(x, [2, 3], False)
                 x = x.mean()
+                x = x.mean([2, 3], True)
                 # interpolate node will introduce 3 quantize_per_tensor ops
                 x = F.interpolate(x, 4, mode='nearest')  # interpolate node
                 x = F.upsample(x, (32, 32))  # interpolate node
@@ -2358,7 +2360,7 @@ class TestQuantizeScriptPTSQOps(QuantizationTestCase):
         # mapping from number of quant for the op to the number of these ops
         # for example, for `3` in the key means for this type of op
         # we'll have 3 quantize_per_tensor
-        num_op_by_num_quant = {1: 33, 2: 2, 3: 3}
+        num_op_by_num_quant = {1: 35, 2: 2, 3: 3}
         num_quantize_per_tensor = 1  # for output
         for num_quant, num_op in num_op_by_num_quant.items():
             num_quantize_per_tensor += num_op * num_quant

--- a/torch/csrc/jit/passes/quantization/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization/quantization_patterns.h
@@ -758,7 +758,9 @@ graph(%a_quant, %weight, %bias, %running_mean, %running_var, %use_input_stats, %
   auto adaptive_avg_pool3d = getInputTensorQParamOpFusionInfo(
       "aten::adaptive_avg_pool3d", {"%output_size"});
 
-  auto mean = getInputTensorQParamOpFusionInfo("aten::mean", {"%dim"});
+  auto mean1 = getInputTensorQParamOpFusionInfo("aten::mean", {"%dim"});
+
+  auto mean2 = getInputTensorQParamOpFusionInfo("aten::mean", {"%dim", "%keepdim", "%out"});
 
   auto upsample_nearest1d = getInputTensorQParamOpFusionInfo(
       "aten::upsample_nearest1d", {"%output_size", "%scales"});
@@ -915,7 +917,8 @@ graph(%a_quant, %weight, %bias, %running_mean, %running_var, %use_input_stats, %
       adaptive_avg_pool1d,
       adaptive_avg_pool2d,
       adaptive_avg_pool3d,
-      mean,
+      mean1,
+      mean2,
       upsample_nearest1d,
       upsample_nearest2d,
       upsample_nearest3d,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40038 [quant][graphmode] Support another use pattern of mean**
* #39919 [quant] Support general op modules with inplace options
* #39925 [quant][graphmode] Support quantizing `repeat`
* #39924 [quant][graphmode] Support squeeze/unsqueeze
* #39923 [quant][graphmode] Run RemoveRedundantDequantize in the end
* #39915 [quant][graphmode] Pass debug option into insert_quant_dequant pass
* #39911 [quant][graphmode] Use quantized::batch_norm in graph mode
* #39910 [quant] add quantized::batch_norm
* #39895 [quant][graphmode] Support prim::TupleUnpack and prim::TupleConstruct

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22055696](https://our.internmc.facebook.com/intern/diff/D22055696)