### PR TITLE
Make test case precision property

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -164,7 +164,7 @@ class DeviceTypeTestBase(TestCase):
 
     # Precision is a thread-local setting since it may be overridden per test
     _tls = threading.local()
-    _tls.precision = TestCase.precision
+    _tls.precision = TestCase._precision
 
     @property
     def precision(self):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -718,7 +718,15 @@ class TestCase(expecttest.TestCase):
     # atol values when comparing tensors. Used by @precisionOverride, for
     # example.
     # TODO: provide a better mechanism for generated tests to set rtol/atol.
-    precision = 0
+    _precision: float = 0
+
+    @property
+    def precision(self) -> float:
+        return self._precision
+
+    @precision.setter
+    def precision(self, prec: float) -> None:
+        self._precision = prec
 
     _do_cuda_memory_leak_check = False
     _do_cuda_non_default_stream = False


### PR DESCRIPTION
Make `common_utils.TestCase.precision` a property, because it is overriden as such in `common_device_type`.