### PR TITLE
[android][fbjni] Test_app and Readme update with the recent fbjni dep state

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.pytorch:pytorch_android:1.3.0'
-    implementation 'org.pytorch:pytorch_android_torchvision:1.3.0'
+    implementation 'org.pytorch:pytorch_android:1.5.0'
+    implementation 'org.pytorch:pytorch_android_torchvision:1.5.0'
 }
 ```
 
@@ -79,7 +79,6 @@ After successful build you should see the result as aar file:
 $ find pytorch_android/build/ -type f -name *aar
 pytorch_android/build/outputs/aar/pytorch_android.aar
 pytorch_android_torchvision/build/outputs/aar/pytorch_android.aar
-libs/fbjni_local/build/outputs/aar/pytorch_android_fbjni.aar
 ```
 
 It can be used directly in android projects, as a gradle dependency:
@@ -92,34 +91,20 @@ allprojects {
     }
 }
 
-android {
-    ...
-    packagingOptions {
-        pickFirst "**/libfbjni.so"
-    }
-    ...
-}
-
 dependencies {
     implementation(name:'pytorch_android', ext:'aar')
     implementation(name:'pytorch_android_torchvision', ext:'aar')
-    implementation(name:'pytorch_android_fbjni', ext:'aar')
     ...
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.facebook.soloader:nativeloader:0.8.0'
+    implementation 'com.facebook.fbjni:fbjni-java-only:0.0.3'
 }
 ```
 We also have to add all transitive dependencies of our aars.
-As `pytorch_android` [depends](https://github.com/pytorch/pytorch/blob/master/android/pytorch_android/build.gradle#L62-L63) on `'com.android.support:appcompat-v7:28.0.0'` and `'com.facebook.soloader:nativeloader:0.8.0'`, we need to add them.
+As `pytorch_android` [depends](https://github.com/pytorch/pytorch/blob/master/android/pytorch_android/build.gradle#L62-L63) on `'com.android.support:appcompat-v7:28.0.0'`, `'com.facebook.soloader:nativeloader:0.8.0'` and 'com.facebook.fbjni:fbjni-java-only:0.0.3', we need to add them.
 (In case of using maven dependencies they are added automatically from `pom.xml`).
 
-
-At the moment for the case of using aar files directly we need additional configuration due to packaging specific (`libfbjni.so` is packaged in both `pytorch_android_fbjni.aar` and `pytorch_android.aar`).
-```
-packagingOptions {
-    pickFirst "**/libfbjni.so"
-}
-```
+You can check out [test app example](https://github.com/pytorch/pytorch/blob/master/android/test_app/app/build.gradle) that uses aars directly.
 
 ## More Details
 

--- a/android/test_app/app/build.gradle
+++ b/android/test_app/app/build.gradle
@@ -5,6 +5,9 @@ repositories {
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots"
     }
+    flatDir {
+        dirs 'aars'
+    }
 }
 
 android {
@@ -55,6 +58,9 @@ android {
         nightly {
             dimension "build"
         }
+        aar {
+            dimension "build"
+        }
         camera {
             dimension "activity"
             addManifestPlaceholders([MAIN_ACTIVITY: "org.pytorch.testapp.CameraActivity"])
@@ -73,14 +79,15 @@ android {
     }
     packagingOptions {
         doNotStrip '**.so'
-        pickFirst '**/libfbjni.so'
     }
 
     // Filtering for CI
     if (!testAppAllVariantsEnabled.toBoolean()) {
         variantFilter { variant ->
             def names = variant.flavors*.name
-            if (names.contains("nightly") || names.contains("camera")) {
+            if (names.contains("nightly")
+                || names.contains("camera")
+                || names.contains("aar")) {
                 setIgnore(true)
             }
         }
@@ -94,6 +101,11 @@ dependencies {
     localImplementation project(':pytorch_android_torchvision')
     nightlyImplementation 'org.pytorch:pytorch_android:1.6.0-SNAPSHOT'
     nightlyImplementation 'org.pytorch:pytorch_android_torchvision:1.6.0-SNAPSHOT'
+
+    aarImplementation(name:'pytorch_android', ext:'aar')
+    aarImplementation(name:'pytorch_android_torchvision', ext:'aar')
+    aarImplementation 'com.facebook.soloader:nativeloader:0.8.0'
+    aarImplementation 'com.facebook.fbjni:fbjni-java-only:0.0.3'
 
     def camerax_version = "1.0.0-alpha05"
     cameraImplementation "androidx.camera:camera-core:$camerax_version"

--- a/android/test_app/app/src/main/java/org/pytorch/testapp/MainActivity.java
+++ b/android/test_app/app/src/main/java/org/pytorch/testapp/MainActivity.java
@@ -11,6 +11,7 @@ import androidx.annotation.UiThread;
 import androidx.annotation.WorkerThread;
 import androidx.appcompat.app.AppCompatActivity;
 import java.nio.FloatBuffer;
+import java.util.Arrays;
 import org.pytorch.IValue;
 import org.pytorch.Module;
 import org.pytorch.PyTorchAndroid;
@@ -101,7 +102,7 @@ public class MainActivity extends AppCompatActivity {
     final long moduleForwardDuration = SystemClock.elapsedRealtime() - moduleForwardStartTime;
     final float[] scores = outputTensor.getDataAsFloatArray();
     final long analysisDuration = SystemClock.elapsedRealtime() - startTime;
-
+    Log.i(TAG, "XXX scores:" + Arrays.toString(scores));
     return new Result(scores, moduleForwardDuration, analysisDuration);
   }
 
@@ -121,7 +122,7 @@ public class MainActivity extends AppCompatActivity {
   @UiThread
   protected void handleResult(Result result) {
     String message = String.format("forwardDuration:%d", result.moduleForwardDuration);
-    Log.i(TAG, message);
+    Log.i(TAG, "XXX:" + message);
     mTextViewStringBuilder.insert(0, '\n').insert(0, message);
     if (mTextViewStringBuilder.length() > TEXT_TRIM_SIZE) {
       mTextViewStringBuilder.delete(TEXT_TRIM_SIZE, mTextViewStringBuilder.length());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40058 [android][fbjni] Test_app and Readme update with the recent fbjni dep state**
* #39691 [android] Remove android fbjni subproject

Differential Revision: [D22054574](https://our.internmc.facebook.com/intern/diff/D22054574)

Since pytorch_android switched from using fbjni gradle subproject to using gradle dependency `'com.facebook.fbjni:fbjni-java-only:0.0.3'` we do not need to build aar and add it to the build that uses aars directly.

As a result we 
1. Do not need handling multiple fbjni.so
```
    packagingOptions {
        pickFirst "**/libfbjni.so"
    }
```
2. Dep on '`'com.facebook.fbjni:fbjni-java-only:0.0.3'`' 

Added dimension 'aar' to test_app and  link it with `android/README.md` to have  full example in the same repo.