### PR TITLE
DOC: fix rpc reference in top-level index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    onnx
    optim
    quantization
-   rpc/index.rst
+   rpc
    torch.random <random>
    sparse
    storage


### PR DESCRIPTION
Fixes gh-40046

PR gh-37419 refactored the content of `docs/source/rpc/index.rst` into `docs/source/rpc.rst` but did not link to the latter from `doc/source/index.rst` so the top-level RPC documentation is missing from https://pytorch.org/docs/master/.

