### PR TITLE
[resubmit] Kill thrust::complex from log kernels

### DIFF
--- a/aten/src/ATen/native/cuda/UnaryLogKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryLogKernels.cu
@@ -7,49 +7,24 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Math.cuh>
-#include <ATen/native/cuda/zmath.cuh>
 
 namespace at { namespace native {
-
-// We manually overload log because std::log does not work with thrust::complex types.
-template<typename scalar_t>
-__host__ __device__ static inline scalar_t log_wrapper(scalar_t v) {
-  return ::log(v);
-}
-
-template<typename T>
-__host__ __device__ static inline thrust::complex<T> log_wrapper(thrust::complex<T> v) {
-  return thrust::log(v);
-}
 
 void log_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "log_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "log_cuda", [&] {
-      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-      gpu_kernel(iter, []GPU_LAMBDA(thrust_t a) -> thrust_t {
-        return log_wrapper(a);
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+        return std::log(a);
       });
     });
   });
 }
 
-// We manually overload log10 because std::log10 does not work with thrust::complex types.
-template<typename scalar_t>
-__host__ __device__ static inline scalar_t log10_wrapper(scalar_t v) {
-  return ::log10(v);
-}
-
-template<typename T>
-__host__ __device__ static inline thrust::complex<T> log10_wrapper(thrust::complex<T> v) {
-  return thrust::log10(v);
-}
-
 void log10_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "log10_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "log10_cuda", [&] {
-      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-      gpu_kernel(iter, []GPU_LAMBDA(thrust_t a) -> thrust_t {
-        return log10_wrapper(a);
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+        return std::log10(a);
       });
     });
   });
@@ -65,24 +40,11 @@ void log1p_kernel_cuda(TensorIterator& iter) {
   });
 }
 
-// We manually overload log2 because std::log2 does not work with thrust::complex types.
-template<typename scalar_t>
-__host__ __device__ static inline scalar_t log2_wrapper(scalar_t v) {
-  return ::log2(v);
-}
-
-template<typename T>
-__host__ __device__ static inline thrust::complex<T> log2_wrapper(thrust::complex<T> v) {
-  const thrust::complex<T> log2 = thrust::complex<T>(::log(2.0), 0.0);
-  return thrust::log(v)/log2;
-}
-
 void log2_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "log2_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "log2_cuda", [&] {
-      using thrust_t = typename ztype_cuda<scalar_t>::thrust_t;
-      gpu_kernel(iter, []GPU_LAMBDA(thrust_t a) -> thrust_t {
-        return log2_wrapper(a);
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+        return std::log2(a);
       });
     });
   });

--- a/aten/src/ATen/native/cuda/UnaryLogKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryLogKernels.cu
@@ -14,7 +14,7 @@ void log_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "log_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "log_cuda", [&] {
       gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-        return std::log(a);
+        return ::log(a);
       });
     });
   });
@@ -24,7 +24,7 @@ void log10_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "log10_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "log10_cuda", [&] {
       gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-        return std::log10(a);
+        return ::log10(a);
       });
     });
   });
@@ -44,7 +44,7 @@ void log2_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "log2_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "log2_cuda", [&] {
       gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-        return std::log2(a);
+        return ::log2(a);
       });
     });
   });

--- a/c10/test/util/complex_math_test_common.h
+++ b/c10/test/util/complex_math_test_common.h
@@ -146,8 +146,20 @@ C10_DEFINE_TEST(TestLog2, Rev) {
   C10_ASSERT_NEAR(l.imag(), float(1.2), tol);
   }
   {
+  c10::complex<float> x(0.1, 1.2);
+  c10::complex<float> l = ::log2(std::pow(float(2), x));
+  C10_ASSERT_NEAR(l.real(), float(0.1), tol);
+  C10_ASSERT_NEAR(l.imag(), float(1.2), tol);
+  }
+  {
   c10::complex<double> x(0.1, 1.2);
   c10::complex<double> l = std::log2(std::pow(double(2), x));
+  C10_ASSERT_NEAR(l.real(), double(0.1), tol);
+  C10_ASSERT_NEAR(l.imag(), double(1.2), tol);
+  }
+  {
+  c10::complex<double> x(0.1, 1.2);
+  c10::complex<double> l = ::log2(std::pow(double(2), x));
   C10_ASSERT_NEAR(l.real(), double(0.1), tol);
   C10_ASSERT_NEAR(l.imag(), double(1.2), tol);
   }

--- a/c10/test/util/complex_math_test_common.h
+++ b/c10/test/util/complex_math_test_common.h
@@ -137,6 +137,22 @@ C10_DEFINE_TEST(TestLog10, Rev) {
   }
 }
 
+C10_DEFINE_TEST(TestLog2, Rev) {
+  // log2(2^x) = x
+  {
+  c10::complex<float> x(0.1, 1.2);
+  c10::complex<float> l = std::log2(std::pow(float(2), x));
+  C10_ASSERT_NEAR(l.real(), float(0.1), tol);
+  C10_ASSERT_NEAR(l.imag(), float(1.2), tol);
+  }
+  {
+  c10::complex<double> x(0.1, 1.2);
+  c10::complex<double> l = std::log2(std::pow(double(2), x));
+  C10_ASSERT_NEAR(l.real(), double(0.1), tol);
+  C10_ASSERT_NEAR(l.imag(), double(1.2), tol);
+  }
+}
+
 // Power functions
 
 C10_DEFINE_TEST(TestPowSqrt, Equal) {

--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -34,6 +34,12 @@ C10_HOST_DEVICE inline c10::complex<T> log10(const c10::complex<T> &x) {
 #endif
 }
 
+template<typename T>
+C10_HOST_DEVICE inline c10::complex<T> log2(const c10::complex<T> &x) {
+  const c10::complex<T> log2 = c10::complex<T>(::log(2.0), 0.0);
+  return std::log(x) / log2;
+}
+
 // Power functions
 
 template<typename T>

--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -224,6 +224,7 @@ C10_HOST_DEVICE inline c10::complex<T> atanh(const c10::complex<T> &x) {
 using c10_complex_math::exp;
 using c10_complex_math::log;
 using c10_complex_math::log10;
+using c10_complex_math::log2;
 using c10_complex_math::sqrt;
 using c10_complex_math::pow;
 using c10_complex_math::sin;
@@ -244,6 +245,7 @@ namespace std {
 using c10_complex_math::exp;
 using c10_complex_math::log;
 using c10_complex_math::log10;
+using c10_complex_math::log2;
 using c10_complex_math::sqrt;
 using c10_complex_math::pow;
 using c10_complex_math::sin;

--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -37,7 +37,7 @@ C10_HOST_DEVICE inline c10::complex<T> log10(const c10::complex<T> &x) {
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> log2(const c10::complex<T> &x) {
   const c10::complex<T> log2 = c10::complex<T>(::log(2.0), 0.0);
-  return std::log(x) / log2;
+  return c10_complex_math::log(x) / log2;
 }
 
 // Power functions


### PR DESCRIPTION
Use `::log` instead of `std::log` for better ROCm support.