### PR TITLE
[Onnxifi] Allow adding timeout for OnnxifOp run

### DIFF
--- a/caffe2/opt/custom/glow_net_transform.cc
+++ b/caffe2/opt/custom/glow_net_transform.cc
@@ -28,6 +28,11 @@ C10_DEFINE_int32(
     1,
     "Minimum number of ops for a subgraph to be lowered to backend");
 
+C10_DEFINE_int32(
+    onnxifi_timeout_ms,
+    0,
+    "Timeout limit for onnxifi inference in milliseconds. 0 means no timeout");
+
 C10_DEFINE_string(
     onnxifi_shape_hints,
     "",
@@ -137,6 +142,7 @@ void onnxifi(
   opts.merge_fp32_inputs_into_fp16 = FLAGS_merge_fp32_inputs_into_fp16;
   opts.loop_test = FLAGS_onnxifi_loop_test_mode;
   opts.predictor_net_ssa_rewritten = predictor_net_ssa_rewritten;
+  opts.timeout = FLAGS_onnxifi_timeout_ms;
 
   ShapeInfoMap more_shape_hints = shape_hints;
   if (!FLAGS_onnxifi_shape_hints.empty()) {

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -768,6 +768,7 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
   }
   AddArgument("max_batch_size", opts_.bound_shape_spec.max_batch_size, &op);
   AddArgument("max_seq_size", opts_.bound_shape_spec.max_seq_size, &op);
+  AddArgument("timeout", opts_.timeout, &op);
   AddArgument("nominal_batch_idx", nominal_batch_idx, &op);
 
   return op;

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -41,6 +41,9 @@ struct OnnxifiTransformerOptions final : public BackendTransformOptions {
 
   // Whether the net has been ssaRewritten
   bool predictor_net_ssa_rewritten{false};
+
+  // Inference timeout
+  int timeout{0};
 };
 
 class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -26,7 +26,8 @@ def onnxifi_caffe2_net(
         merge_fp32_inputs_into_fp16=False,
         adjust_batch=True,
         black_list=None,
-        weight_names=None):
+        weight_names=None,
+        timeout=0):
     """
     Transform the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
     """
@@ -39,6 +40,7 @@ def onnxifi_caffe2_net(
                              weight_names if weight_names is not None else [],
                              max_batch_size,
                              max_seq_size,
+                             timeout,
                              adjust_batch,
                              debug,
                              merge_fp32_inputs_into_fp16,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1736,6 +1736,7 @@ void addGlobalMethods(py::module& m) {
          const std::vector<std::string>& weight_names,
          int max_batch_size,
          int max_seq_size,
+         int timeout,
          bool adjust_batch,
          bool debug_builder,
          bool merge_fp32_inputs_into_fp16,
@@ -1758,6 +1759,7 @@ void addGlobalMethods(py::module& m) {
         OnnxifiTransformerOptions opts;
         opts.bound_shape_spec.max_batch_size = max_batch_size;
         opts.bound_shape_spec.max_seq_size = max_seq_size;
+        opts.timeout = timeout;
         opts.adjust_batch = adjust_batch;
         opts.debug = debug_builder;
         opts.merge_fp32_inputs_into_fp16 = merge_fp32_inputs_into_fp16;


### PR DESCRIPTION
Summary: Adding the functionality to enable timeout of OnnxifiOp run. In the case of backend hanging, it can error out quickly.

Test Plan:
```
 buck test glow/fb/test:test_onnxifinnpi -- test_timeout
```

Differential Revision: D22064533

