### PR TITLE
[xplat] Add Windows specific ATen build definitions

### DIFF
--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -1,16 +1,16 @@
 #include <TH/THAllocator.h>
 
-/* stuff for mapped files */
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #include <atomic>
 #if ATOMIC_INT_LOCK_FREE == 2
 #define TH_ATOMIC_IPC_REFCOUNT 1
 #endif
 
 #include <c10/core/CPUAllocator.h>
+
+/* stuff for mapped files */
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #if defined(HAVE_MMAP)
 #include <sys/types.h>


### PR DESCRIPTION
Summary: Move <windows.h> include in THAllocator after header that might include glog is included

Test Plan: buck build xplat/mode/arstudio/windows //xplat/caffe2:aten_cpuWindows

Reviewed By: nlutsenko

Differential Revision: D22061135

