### PR TITLE
[TensorPipe] Silence some more harmless warnings

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -395,14 +395,21 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
       pipe,
       [this, pipe](
           const tensorpipe::Error& error, Message&& requestMessage) mutable {
-        // FIXME Find a way for the client to tell the server they are done with
-        // the pipe and are intentionally shutting it down. Perhaps sending an
-        // empty message?
         if (error) {
-          LOG(WARNING)
-              << "RPC agent for " << workerInfo_.name_
-              << " encountered error when reading incoming request from "
-              << pipe->getRemoteName() << ": " << error.what();
+          // FIXME This is not a correct way to check whether this error was
+          // "intentionally" caused by the remote end shutting down. We should
+          // find a better way, Perhaps sending an empty message?
+          if ((error.isOfType<tensorpipe::PipeClosedError>() &&
+               !rpcAgentRunning_.load()) ||
+              error.isOfType<tensorpipe::transport::EOFError>()) {
+            // This is expected.
+          } else {
+            LOG(WARNING)
+                << "RPC agent for " << workerInfo_.name_
+                << " encountered error when reading incoming request from "
+                << pipe->getRemoteName() << ": " << error.what()
+                << " (this is expected to happen during shutdown)";
+          }
           return;
         }
 
@@ -757,7 +764,6 @@ void TensorPipeAgent::shutdownImpl() {
   threadPool_.waitWorkComplete();
   VLOG(1) << "RPC agent for " << workerInfo_.name_
           << " done waiting for thread pool to complete work";
-
 }
 
 const WorkerInfo& TensorPipeAgent::getWorkerInfo(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40094 [TensorPipe] Silence some more harmless warnings**

In #39182 we already silenced a few warnings when they were caused by expected errors, but left one case out, namely errors on an incoming pipe. The idea was to introduce a "proper" way of detecting these, for example by having the remote end send an empty message to indicate an intentional shutdown. I don't know if we'll have time to do that in time for v1.6, so as a temporary solution I'm implementing some approximation which, although imperfect, should cover most errors. I also made the warning message less scary by adding a clarification.

Differential Revision: [D22067818](https://our.internmc.facebook.com/intern/diff/D22067818/)