### PR TITLE
Remove unecessary copy within blob serialization

### DIFF
--- a/caffe2/core/blob_serialization.cc
+++ b/caffe2/core/blob_serialization.cc
@@ -485,7 +485,7 @@ Tensor EmptyTensorFromProto(const TensorProto& tensor_proto) {
 }
 
 void TensorDeserializer::Deserialize(const BlobProto& blob_proto, Blob* blob) {
-  auto tensor_proto = blob_proto.tensor();
+  const auto& tensor_proto = blob_proto.tensor();
   auto context = ContextFromProto(tensor_proto);
   context->SwitchToDevice();
   if (NumelFromTensorProto(tensor_proto) == 0 &&


### PR DESCRIPTION
Summary: Declaring `tensor_proto` to be of type `auto` means that it will copy the entire `TensorProto` instead of just keeping a reference. This changes it to just use a const reference instead.

Test Plan:
Using the model loader benchmark to measure model loading performance:

### `tensor_proto` is of type `const auto&`
```
============================================================================
caffe2/caffe2/fb/predictor/ModelLoaderBenchmark.cpprelative  time/iter  iters/s
============================================================================
BlobProtoInt32DeserializationFloat16                        11.08ms    90.27
BlobProtoByteDeserializationFloat16             1509.73%   733.73us    1.36K
----------------------------------------------------------------------------
BlobProtoInt32DeserializationUInt8                          10.48ms    95.45
BlobProtoByteDeserializationUInt8               2974.57%   352.22us    2.84K
============================================================================
```

### `tensor_proto` is of type `auto`
```
============================================================================
caffe2/caffe2/fb/predictor/ModelLoaderBenchmark.cpprelative  time/iter  iters/s
============================================================================
BlobProtoInt32DeserializationFloat16                        13.84ms    72.26
BlobProtoByteDeserializationFloat16              658.85%     2.10ms   476.08
----------------------------------------------------------------------------
BlobProtoInt32DeserializationUInt8                          17.09ms    58.51
BlobProtoByteDeserializationUInt8               3365.98%   507.80us    1.97K
============================================================================
```

Differential Revision: D21959644

