### PR TITLE
change BuildExtension.with_options to return a class not a c-tor

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -319,8 +319,8 @@ class BuildExtension(build_ext, object):
             def __init__(self, *args, **kwargs):
                 kwargs = kwargs.copy()
                 kwargs.update(options)
-                super(cls_with_options, self).__init__(*args, **kwargs)
-            pass
+                super().__init__(*args, **kwargs)
+
         return cls_with_options
 
     def __init__(self, *args, **kwargs):

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -317,7 +317,6 @@ class BuildExtension(build_ext, object):
         '''
         class cls_with_options(cls):
             def __init__(self, *args, **kwargs):
-                kwargs = kwargs.copy()
                 kwargs.update(options)
                 super().__init__(*args, **kwargs)
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -312,14 +312,16 @@ class BuildExtension(build_ext, object):
     @classmethod
     def with_options(cls, **options):
         r'''
-        Returns an alternative constructor that extends any original keyword
+        Returns a subclass with alternative constructor that extends any original keyword
         arguments to the original constructor with the given options.
         '''
-        def init_with_options(*args, **kwargs):
-            kwargs = kwargs.copy()
-            kwargs.update(options)
-            return cls(*args, **kwargs)
-        return init_with_options
+        class cls_with_options(cls):
+            def __init__(self, *args, **kwargs):
+                kwargs = kwargs.copy()
+                kwargs.update(options)
+                super(cls_with_options, self).__init__(*args, **kwargs)
+            pass
+        return cls_with_options
 
     def __init__(self, *args, **kwargs):
         super(BuildExtension, self).__init__(*args, **kwargs)


### PR DESCRIPTION
If you 1) [use BuildExtension.with_options](https://github.com/pytorch/vision/blob/c2e8a00885e68ae1200eb6440f540e181d9125de/setup.py#L254) and 2) call the command from command line (e.g. `python setp.py build_ext`) if will fail with:
```
$ python setup.py build_ext
Building wheel torchvision-0.7.0a0+c2e8a00
Traceback (most recent call last):
  File "setup.py", line 255, in <module>
    'clean': clean,
  File "/private/home/pbelevich/miniconda3/envs/pytorch-py3.7_new2/lib/python3.7/site-packages/setuptools/__init__.py", line 144, in setup
    return distutils.core.setup(**attrs)
  File "/private/home/pbelevich/miniconda3/envs/pytorch-py3.7_new2/lib/python3.7/distutils/core.py", line 134, in setup
    ok = dist.parse_command_line()
  File "/private/home/pbelevich/miniconda3/envs/pytorch-py3.7_new2/lib/python3.7/distutils/dist.py", line 483, in parse_command_line
    args = self._parse_command_opts(parser, args)
  File "/private/home/pbelevich/miniconda3/envs/pytorch-py3.7_new2/lib/python3.7/site-packages/setuptools/dist.py", line 925, in _parse_command_opts
    nargs = _Distribution._parse_command_opts(self, parser, args)
  File "/private/home/pbelevich/miniconda3/envs/pytorch-py3.7_new2/lib/python3.7/distutils/dist.py", line 545, in _parse_command_opts
    if not issubclass(cmd_class, Command):
TypeError: issubclass() arg 1 must be a class
```
because setup tools calls python distutils that [checks](https://github.com/python/cpython/blob/c4862e333ab405dd5789b4061222db1982147de4/Lib/distutils/dist.py#L545) that the command is a class, but BuildExtension.with_options returns a c-tor!

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40122 [Reland #3] Include AT_PARALLEL_OPENMP/AT_PARALLEL_NATIVE/AT_PARALLEL_NATIVE_TBB to ATen/Config.h
* **#40121 change BuildExtension.with_options to return a class not a c-tor**

Differential Revision: [D22076634](https://our.internmc.facebook.com/intern/diff/D22076634)