### PR TITLE
ROCm: Use correct device type when exporting tensors to DLPack

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -71,10 +71,26 @@ DLDataType getDLDataType(const Tensor& t) {
 DLContext getDLContext(const Tensor& tensor, const int64_t& device_id) {
   DLContext ctx;
   ctx.device_id = device_id;
-  if (tensor.is_cuda()) {
-    ctx.device_type = DLDeviceType::kDLGPU;
-  } else {
-    ctx.device_type = DLDeviceType::kDLCPU;
+  switch (tensor.device().type()) {
+    case DeviceType::CPU:
+      ctx.device_type = DLDeviceType::kDLCPU;
+      break;
+    case DeviceType::CUDA:
+#ifdef __HIP_PLATFORM_HCC__
+      // while it is cuda to us, everyone else says HIP
+      ctx.device_type = DLDeviceType::kDLROCM;
+#else
+      ctx.device_type = DLDeviceType::kDLGPU;
+#endif
+      break;
+    case DeviceType::OPENCL:
+      ctx.device_type = DLDeviceType::kDLOpenCL;
+      break;
+    case DeviceType::HIP:
+      ctx.device_type = DLDeviceType::kDLROCM;
+      break;
+    default:
+      throw std::logic_error("Cannot pack tensors on " + tensor.device().str());
   }
   return ctx;
 }
@@ -83,12 +99,20 @@ static Device getATenDevice(const DLContext& ctx) {
   switch (ctx.device_type) {
     case DLDeviceType::kDLCPU:
       return at::Device(DeviceType::CPU);
+#ifndef __HIP_PLATFORM_HCC__
+    // if we are compiled under HIP, we cannot do cuda
     case DLDeviceType::kDLGPU:
       return at::Device(DeviceType::CUDA, ctx.device_id);
+#endif
     case DLDeviceType::kDLOpenCL:
       return at::Device(DeviceType::OPENCL, ctx.device_id);
     case DLDeviceType::kDLROCM:
+#ifdef __HIP_PLATFORM_HCC__
+      // this looks funny, we need to return CUDA here to masquerade
+      return at::Device(DeviceType::CUDA, ctx.device_id);
+#else
       return at::Device(DeviceType::HIP, ctx.device_id);
+#endif
     default:
       throw std::logic_error(
           "Unsupported device_type: " + c10::to_string(ctx.device_type));

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -58,6 +58,20 @@ if(CAFFE2_USE_CUDNN)
     ${CMAKE_CURRENT_SOURCE_DIR}/cuda_cudnn_test.cpp)
 endif()
 
+list(APPEND ATen_HIP_TEST_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_math_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_integer_divider_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_apply_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_stream_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_half_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_distributions_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_optional_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_packedtensoraccessor_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_tensor_interop_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_vectorized_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_generator_test.cu)
+
 list(APPEND ATen_VULKAN_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/vulkan_test.cpp)
 

--- a/aten/src/ATen/test/dlconvertor_test.cpp
+++ b/aten/src/ATen/test/dlconvertor_test.cpp
@@ -25,6 +25,7 @@ TEST(TestDlconvertor, TestDlconvertorNoStrides) {
   Tensor a = rand({3, 4});
   DLManagedTensor* dlMTensor = toDLPack(a);
   dlMTensor->dl_tensor.strides = nullptr;
+  std::cout << "###test device id" << dlMTensor->dl_tensor.ctx.device_type << "\n";
 
   Tensor b = fromDLPack(dlMTensor);
 

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -11,7 +11,7 @@
 #include "torch/csrc/autograd/utils/error_messages.h"
 #include "torch/csrc/autograd/utils/wrap_outputs.h"
 #include "torch/csrc/jit/frontend/tracer.h"
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 #include "torch/csrc/cuda/Stream.h"
 #include "torch/csrc/cuda/Event.h"
 #endif
@@ -569,12 +569,12 @@ static PyObject * THPVariable_numpy(PyObject* self, PyObject* arg)
 static PyObject * THPVariable_record_stream(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   if (!THCPStream_Check(arg)) {
     return PyErr_Format(PyExc_TypeError, "expected Stream object");
   }
-  c10::cuda::CUDACachingAllocator::recordStream(self_.storage().data_ptr(), at::cuda::CUDAStream::unpack(((THCPStream*)arg)->cdata));
+  c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(self_.storage().data_ptr(), at::hip::HIPStreamMasqueradingAsCUDA::unpack(((THCPStream*)arg)->cdata));
   Py_RETURN_NONE;
 #else
   throw std::runtime_error("PyTorch compiled without CUDA support");

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -1,12 +1,12 @@
 #pragma once
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 #include <c10/core/Allocator.h>
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAException.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
+#include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
+#include <c10/hip/HIPException.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 #include <c10/util/Logging.h>
-#include <cuda_runtime_api.h>
+#include <hip/hip_runtime_api.h>
 #include <cstddef>
 
 namespace torch {
@@ -24,7 +24,7 @@ struct CudaIPCSentData final {
   int64_t offset_;
   int64_t* counter_ptr_; // Reference counter shared memory block
   at::DataPtr original_ptr_; // Original mem allocation
-  cudaEvent_t event_; // Sync cuEventDestroy
+  hipEvent_t event_; // Sync cuEventDestroy
   bool event_sync_required_;
   at::Device device_;
 

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -19,8 +19,8 @@
 #include <unordered_map>
 #include <vector>
 
-#ifdef USE_CUDA
-#include <THC/THC.h>
+#ifdef USE_ROCM
+#include <THH/THH.h>
 #endif
 
 namespace torch {

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -14,8 +14,8 @@
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
 
-#ifdef USE_CUDA
-#include <THC/THCTensorRandom.h>
+#ifdef USE_ROCM
+#include <THH/THHTensorRandom.h>
 #include <ATen/CUDAGeneratorImpl.h>
 #endif
 
@@ -52,7 +52,7 @@ static PyObject * THPGenerator_pynew(PyTypeObject *type, PyObject *args, PyObjec
   auto device = r.deviceWithDefault(0, at::Device(at::kCPU));
 
   THPGeneratorPtr self((THPGenerator *)type->tp_alloc(type, 0));
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   if (device.type() == at::kCPU) {
     self->cdata = make_generator<CPUGeneratorImpl>();
   } else if (device.type() == at::kCUDA){
@@ -79,7 +79,7 @@ static PyObject * THPGenerator_getState(THPGenerator *self, PyObject *noargs)
   if (self->cdata.device().type() == at::kCPU) {
     THByteTensor_getRNGState(self->cdata, (THByteTensor*)(var.unsafeGetTensorImpl()));
   } else {
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     TORCH_INTERNAL_ASSERT(self->cdata.device().type() == at::kCUDA);
     THCRandom_getRNGState(self->cdata, (THByteTensor*)(var.unsafeGetTensorImpl()));
 #else 
@@ -105,7 +105,7 @@ static PyObject * THPGenerator_setState(THPGenerator *self, PyObject *_new_state
   if (self->cdata.device().type() == at::kCPU) {
     THByteTensor_setRNGState(self->cdata, (THByteTensor*)tensor.unsafeGetTensorImpl());
   } else {
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     TORCH_INTERNAL_ASSERT(self->cdata.device().type() == at::kCUDA);
     THCRandom_setRNGState(self->cdata, (THByteTensor*)tensor.unsafeGetTensorImpl());
 #else 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -565,7 +565,7 @@ bool THCPComplexFloatStorage_init(PyObject *module);
 void THCPStream_init(PyObject *module);
 void THCPEvent_init(PyObject *module);
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 PyMethodDef* THCPModule_methods();
 namespace torch { namespace cuda {
 
@@ -617,7 +617,7 @@ PyObject* initModule() {
   THPUtils_addPyMethodDefs(methods, DataLoaderMethods);
   THPUtils_addPyMethodDefs(methods, torch::autograd::python_functions());
   THPUtils_addPyMethodDefs(methods, torch::multiprocessing::python_functions());
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   THPUtils_addPyMethodDefs(methods, THCPModule_methods());
 #endif
 #ifdef USE_DISTRIBUTED
@@ -661,7 +661,7 @@ PyObject* initModule() {
   torch::autograd::initNNFunctions(module);
   torch::autograd::init_legacy_variable(module);
   torch::python::init_bindings(module);
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   torch::cuda::initModule(module);
 #endif
   ASSERT_TRUE(THPDoubleStorage_init(module));
@@ -680,7 +680,7 @@ PyObject* initModule() {
   ASSERT_TRUE(THPComplexDoubleStorage_init(module));
   ASSERT_TRUE(THPComplexFloatStorage_init(module));
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   // This will only initialise base classes and attach them to library namespace
   // They won't be ready for real usage until importing cuda module, that will
   // complete the process (but it defines Python classes before calling back into
@@ -751,7 +751,7 @@ Call this whenever a new thread is created in order to propagate values from
   ASSERT_TRUE(set_module_attr("has_mkl", at::hasMKL() ? Py_True : Py_False));
   ASSERT_TRUE(set_module_attr("has_lapack", at::hasLAPACK() ? Py_True : Py_False));
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   PyObject *has_cuda = Py_True;
 #else
   PyObject *has_cuda = Py_False;

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -24,7 +24,7 @@ namespace torch {
 namespace nn {
 
 /// These must line up with the CUDNN mode codes:
-/// https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#cudnnRNNMode_t
+/// https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#miopenRNNMode_t
 enum class CuDNNMode { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
 
 CuDNNMode get_cudnn_mode_for_rnn(detail::RNNOptionsBase::rnn_options_base_mode_t mode) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -568,7 +568,7 @@ void set_device(int device) {
   // as in some settings we compile with cuda, but
   // have lazy stubs for CUDA functionality (so actually
   // attempting to setup a guard(CPU_DEVICE) will cause an
-  // error, because it will still query cudaGetDevice).
+  // error, because it will still query hipGetDevice).
   //
   // Don't use DeviceGuard here because its destructor may be called before the
   // device is reset. This is fine because the device is thread local.

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -7,7 +7,7 @@
 #include <ATen/core/functional.h>
 
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
+#include <ATen/hip/HIPContext.h>
 #include <c10/util/Optional.h>
 
 #include <cstddef>
@@ -20,7 +20,7 @@ Scatter::Scatter(
     std::vector<at::Device> devices,
     const c10::optional<std::vector<int64_t>>& chunk_sizes,
     int64_t dim,
-    const c10::optional<std::vector<c10::optional<at::cuda::CUDAStream>>>& streams,
+    const c10::optional<std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>>>& streams,
     bool unsqueeze_scalars)
     : devices_(std::move(devices)),
       chunk_sizes_(chunk_sizes),

--- a/torch/csrc/autograd/functions/comm.h
+++ b/torch/csrc/autograd/functions/comm.h
@@ -5,8 +5,8 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/ATenCUDAGeneral.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/ATenHIPGeneral.h>
 
 #include <cstddef>
 #include <vector>
@@ -19,7 +19,7 @@ struct TORCH_CUDA_API Scatter : public Node {
       std::vector<at::Device> devices,
       const c10::optional<std::vector<int64_t>>& chunk_sizes = c10::nullopt,
       int64_t dim = 0,
-      const c10::optional<std::vector<c10::optional<at::cuda::CUDAStream>>>& streams =
+      const c10::optional<std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>>>& streams =
           c10::nullopt,
       bool unsqueeze_scalars = false);
   ~Scatter() override;
@@ -29,7 +29,7 @@ struct TORCH_CUDA_API Scatter : public Node {
   std::vector<at::Device> devices_;
   c10::optional<std::vector<int64_t>> chunk_sizes_;
   int64_t dim_;
-  c10::optional<std::vector<c10::optional<at::cuda::CUDAStream>>> streams_;
+  c10::optional<std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>>> streams_;
   bool unsqueeze_scalars_;
 };
 

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -149,7 +149,7 @@ struct ProfilerThreadLocalState
       return;
     }
     if (config_.state == ProfilerState::NVTX) {
-      cuda_stubs->nvtxMarkA(name.c_str());
+      cuda_stubs->roctxMarkA(name.c_str());
     } else {
       getEventList().record(
           EventKind::Mark,
@@ -169,7 +169,7 @@ struct ProfilerThreadLocalState
       return;
     }
     if (config_.state == ProfilerState::NVTX) {
-      cuda_stubs->nvtxRangePushA(getNvtxStr(
+      cuda_stubs->roctxRangePushA(getNvtxStr(
           name, msg, sequence_nr, shapes).c_str());
     } else {
       getEventList().record(
@@ -187,7 +187,7 @@ struct ProfilerThreadLocalState
       return;
     }
     if (config_.state == ProfilerState::NVTX) {
-      cuda_stubs->nvtxRangePop();
+      cuda_stubs->roctxRangePop();
     } else {
       // In some cases RecordFunction (and popRange) may be
       // called on a different thread than pushRange

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -20,7 +20,7 @@
 
 #include <ATen/record_function.h>
 
-typedef struct CUevent_st* CUDAEventStub;
+typedef struct ihipEvent_t* CUDAEventStub;
 
 namespace torch { namespace autograd {
 
@@ -36,13 +36,13 @@ struct TORCH_API CUDAStubs {
     fail();
     return 0.f;
   }
-  virtual void nvtxMarkA(const char* name) {
+  virtual void roctxMarkA(const char* name) {
     fail();
   }
-  virtual void nvtxRangePushA(const char* name) {
+  virtual void roctxRangePushA(const char* name) {
     fail();
   }
-  virtual void nvtxRangePop() {
+  virtual void roctxRangePop() {
     fail();
   }
   virtual bool enabled() {
@@ -206,7 +206,7 @@ private:
   int64_t cpu_memory_usage_ = 0;
   int64_t cuda_memory_usage_ = 0;
   int device_ = -1;
-  struct CUevent_st* cuda_event = nullptr;
+  struct ihipEvent_t* cuda_event = nullptr;
 };
 
 // a linked-list of fixed sized vectors, to avoid

--- a/torch/csrc/autograd/profiler_cuda.cpp
+++ b/torch/csrc/autograd/profiler_cuda.cpp
@@ -1,6 +1,6 @@
 #include <torch/csrc/autograd/profiler.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <nvToolsExt.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <roctx.h>
 
 #include <sstream>
 
@@ -8,11 +8,11 @@ namespace torch { namespace autograd { namespace profiler {
 
 namespace {
 
-static inline void cudaCheck(cudaError_t result, const char * file, int line) {
-  if(result != cudaSuccess) {
+static inline void cudaCheck(hipError_t result, const char * file, int line) {
+  if(result != hipSuccess) {
     std::stringstream ss;
     ss << file << ":" << line << ": ";
-    if (result == cudaErrorInitializationError) {
+    if (result == hipErrorInitializationError) {
       // It is common for users to use DataLoader with multiple workers
       // and the autograd profiler. Throw a nice error message here.
       ss << "CUDA initialization error. "
@@ -24,7 +24,7 @@ static inline void cudaCheck(cudaError_t result, const char * file, int line) {
          << "of your code. https://github.com/pytorch/pytorch/issues/6313 "
          << "tracks profiler support for multi-worker DataLoader.";
     } else {
-      ss << cudaGetErrorString(result);
+      ss << hipGetErrorString(result);
     }
     throw std::runtime_error(ss.str());
   }
@@ -33,30 +33,30 @@ static inline void cudaCheck(cudaError_t result, const char * file, int line) {
 
 struct CUDAMethods : public CUDAStubs {
   void record(int* device, CUDAEventStub* event, int64_t* cpu_ns) override {
-    TORCH_CUDA_CHECK(cudaGetDevice(device));
-    TORCH_CUDA_CHECK(cudaEventCreate(event));
-    auto stream = at::cuda::getCurrentCUDAStream();
+    TORCH_CUDA_CHECK(hipGetDevice(device));
+    TORCH_CUDA_CHECK(hipEventCreate(event));
+    auto stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA();
     *cpu_ns = getTime();
-    TORCH_CUDA_CHECK(cudaEventRecord(*event, stream));
+    TORCH_CUDA_CHECK(hipEventRecord(*event, stream));
   }
   float elapsed(CUDAEventStub event, CUDAEventStub event2) override {
-    TORCH_CUDA_CHECK(cudaEventSynchronize(event));
-    TORCH_CUDA_CHECK(cudaEventSynchronize(event2));
+    TORCH_CUDA_CHECK(hipEventSynchronize(event));
+    TORCH_CUDA_CHECK(hipEventSynchronize(event2));
     float ms;
-    TORCH_CUDA_CHECK(cudaEventElapsedTime(&ms, event, event2));
+    TORCH_CUDA_CHECK(hipEventElapsedTime(&ms, event, event2));
     return ms*1000.0;
   }
-  void nvtxMarkA(const char* name) override {
-    ::nvtxMark(name);
+  void roctxMarkA(const char* name) override {
+    ::roctxMark(name);
   }
-  void nvtxRangePushA(const char* name) override {
-    ::nvtxRangePushA(name);
+  void roctxRangePushA(const char* name) override {
+    ::roctxRangePushA(name);
   }
-  void nvtxRangePop() override {
-    ::nvtxRangePop();
+  void roctxRangePop() override {
+    ::roctxRangePop();
   }
   void onEachDevice(std::function<void(int)> op) override {
-    at::cuda::OptionalCUDAGuard device_guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
     int count = at::cuda::device_count();
     for(int i = 0; i < count; i++) {
       device_guard.set_index(i);
@@ -64,7 +64,7 @@ struct CUDAMethods : public CUDAStubs {
     }
   }
   void synchronize() override {
-    cudaDeviceSynchronize();
+    hipDeviceSynchronize();
   }
   bool enabled() override {
     return true;

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -6,10 +6,10 @@
 #include <torch/csrc/THP.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 
 #include <structmember.h>
-#include <cuda_runtime_api.h>
+#include <hip/hip_runtime_api.h>
 
 PyObject *THCPEventClass = nullptr;
 
@@ -34,9 +34,9 @@ static PyObject * THCPEvent_pynew(
 
   THCPEvent* self = (THCPEvent *)ptr.get();
   unsigned int flags =
-    (blocking ? cudaEventBlockingSync : cudaEventDefault) |
-    (enable_timing ? cudaEventDefault : cudaEventDisableTiming) |
-    (interprocess ? cudaEventInterprocess : cudaEventDefault);
+    (blocking ? hipEventBlockingSync : hipEventDefault) |
+    (enable_timing ? hipEventDefault : hipEventDisableTiming) |
+    (interprocess ? hipEventInterprocess : hipEventDefault);
 
   new (&self->cuda_event) at::cuda::CUDAEvent(flags);
 
@@ -57,9 +57,9 @@ static PyObject * THCPEvent_from_ipc_handle(
   at::Device device = r.device(0);
   std::string handle_string = r.string(1);
 
-  TORCH_CHECK(handle_string.size() == sizeof(cudaIpcEventHandle_t),
-    "cudaIpcEventHandle_t expects byte-like object of size ",
-    sizeof(cudaIpcEventHandle_t), ", but got ", handle_string.size());
+  TORCH_CHECK(handle_string.size() == sizeof(hipIpcEventHandle_t),
+    "hipIpcEventHandle_t expects byte-like object of size ",
+    sizeof(hipIpcEventHandle_t), ", but got ", handle_string.size());
   TORCH_CHECK(device.type() == at::kCUDA, "Event can only be created on "
     "CUDA devices, but got device type ", device.type())
 
@@ -69,7 +69,7 @@ static PyObject * THCPEvent_from_ipc_handle(
   }
   THCPEvent* self = (THCPEvent *)ptr.get();
 
-  cudaIpcEventHandle_t handle;
+  hipIpcEventHandle_t handle;
   std::memcpy(&handle, handle_string.c_str(), handle_string.size());
   new (&self->cuda_event) at::cuda::CUDAEvent(device.index(), &handle);
 
@@ -139,7 +139,7 @@ static PyObject * THCPEvent_synchronize(THCPEvent *self, PyObject *noargs) {
 
 static PyObject * THCPEvent_ipc_handle(THCPEvent *self, PyObject *noargs) {
   HANDLE_TH_ERRORS
-  cudaIpcEventHandle_t handle;
+  hipIpcEventHandle_t handle;
   self->cuda_event.ipc_handle(&handle);
   return PyBytes_FromStringAndSize((const char *)&handle, sizeof(handle));
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/cuda/Event.h
+++ b/torch/csrc/cuda/Event.h
@@ -1,9 +1,9 @@
 #ifndef THCP_EVENT_INC
 #define THCP_EVENT_INC
 
-#include <ATen/cuda/CUDAEvent.h>
+#include <ATen/hip/HIPEvent.h>
 #include <torch/csrc/python_headers.h>
-#include <THC/THC.h>
+#include <THH/THH.h>
 
 struct THCPEvent {
   PyObject_HEAD

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -5,10 +5,10 @@
 #include <sstream>
 #include <TH/TH.h>
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
+#include <ATen/hip/HIPContext.h>
 #include <ATen/CUDAGeneratorImpl.h>
-#include <c10/cuda/CUDAFunctions.h>
-#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/hip/HIPFunctions.h>
+#include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
 #ifdef USE_NCCL
 #include <torch/csrc/cuda/python_nccl.h>
 #endif
@@ -56,7 +56,7 @@ static void poison_fork() {
 
 void THCPModule_setDevice(int device)
 {
-  THCudaCheck(cudaSetDevice(device));
+  THCudaCheck(hipSetDevice(device));
 }
 
 PyObject * THCPModule_setDevice_wrap(PyObject *self, PyObject *arg)
@@ -77,7 +77,7 @@ PyObject * THCPModule_getDevice_wrap(PyObject *self, PyObject *noargs)
   HANDLE_TH_ERRORS
   int device;
   torch::utils::cuda_lazy_init();
-  THCudaCheck(cudaGetDevice(&device));
+  THCudaCheck(hipGetDevice(&device));
   return PyLong_FromLong(device);
   END_HANDLE_TH_ERRORS
 }
@@ -103,7 +103,7 @@ PyObject * THCPModule_getCurrentStream_wrap(
     THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
   int64_t device = THPUtils_unpackLong(device_index);
   return PyLong_FromUnsignedLongLong(
-    at::cuda::getCurrentCUDAStream(device).pack());
+    at::hip::getCurrentHIPStreamMasqueradingAsCUDA(device).pack());
   END_HANDLE_TH_ERRORS
 }
 
@@ -114,7 +114,7 @@ PyObject * THCPModule_getDefaultStream_wrap(
     THPUtils_checkLong(device_index), "invalid argument to getDefaultStream");
   int64_t device = THPUtils_unpackLong(device_index);
   return PyLong_FromUnsignedLongLong(
-    at::cuda::getDefaultCUDAStream(device).pack());
+    at::hip::getDefaultHIPStreamMasqueradingAsCUDA(device).pack());
   END_HANDLE_TH_ERRORS
 }
 
@@ -126,13 +126,13 @@ PyObject * THCPModule_setStream_wrap(PyObject *self, PyObject *obj)
   if (bits == static_cast<uint64_t>(-1) && PyErr_Occurred()) {
     throw python_error();
   }
-  auto stream = at::cuda::CUDAStream::unpack(bits);
+  auto stream = at::hip::HIPStreamMasqueradingAsCUDA::unpack(bits);
   int device;
-  THCudaCheck(cudaGetDevice(&device));
+  THCudaCheck(hipGetDevice(&device));
   if (device != stream.device_index()) {
     THCPModule_setDevice(stream.device_index());
   }
-  at::cuda::setCurrentCUDAStream(stream);
+  at::hip::setCurrentHIPStreamMasqueradingAsCUDA(stream);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -140,8 +140,8 @@ PyObject * THCPModule_setStream_wrap(PyObject *self, PyObject *obj)
 PyObject * THCPModule_isDriverSufficient(PyObject *self, PyObject *noargs)
 {
   int count;
-  cudaError_t err = cudaGetDeviceCount(&count);
-  if (err == cudaErrorInsufficientDriver) {
+  hipError_t err = hipGetDeviceCount(&count);
+  if (err == hipErrorInsufficientDriver) {
     return PyBool_FromLong(0);
   }
   return PyBool_FromLong(1);
@@ -150,11 +150,11 @@ PyObject * THCPModule_isDriverSufficient(PyObject *self, PyObject *noargs)
 PyObject * THCPModule_getDriverVersion(PyObject *self, PyObject *noargs)
 {
   int driverVersion = -1;
-  cudaError_t err = cudaDriverGetVersion(&driverVersion);
-  if (err != cudaSuccess) {
+  hipError_t err = hipDriverGetVersion(&driverVersion);
+  if (err != hipSuccess) {
     PyErr_Format(PyExc_RuntimeError,
-                    "Error calling cudaDriverGetVersion: %d %s",
-                    err, cudaGetErrorString(err));
+                    "Error calling hipDriverGetVersion: %d %s",
+                    err, hipGetErrorString(err));
     return nullptr;
   }
   return PyLong_FromLong((int64_t) driverVersion);
@@ -162,7 +162,7 @@ PyObject * THCPModule_getDriverVersion(PyObject *self, PyObject *noargs)
 
 PyObject * THCPModule_getCompiledVersion(PyObject *self, PyObject *noargs)
 {
-  return PyLong_FromLong((long) CUDA_VERSION);
+  return PyLong_FromLong((long) HIP_VERSION);
 }
 
 PyObject * THCPModule_cudaHostAllocator(PyObject *_unused, PyObject *noargs)
@@ -187,8 +187,8 @@ PyObject * THCPModule_cudaCachingAllocator_raw_alloc(PyObject *_unused, PyObject
     return nullptr;
   }
   ssize_t size = PyLong_AsSsize_t(size_o);
-  cudaStream_t stream = static_cast<cudaStream_t>(PyLong_AsVoidPtr(stream_o));
-  void* mem = c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(size, stream);
+  hipStream_t stream = static_cast<hipStream_t>(PyLong_AsVoidPtr(stream_o));
+  void* mem = c10::hip::HIPCachingAllocator::raw_alloc_with_stream(size, stream);
   return PyLong_FromVoidPtr(mem);
   END_HANDLE_TH_ERRORS
 }
@@ -196,7 +196,7 @@ PyObject * THCPModule_cudaCachingAllocator_raw_alloc(PyObject *_unused, PyObject
 PyObject * THCPModule_cudaCachingAllocator_raw_delete(PyObject *_unused, PyObject *obj){
   HANDLE_TH_ERRORS
   void* mem_ptr = PyLong_AsVoidPtr(obj);
-  c10::cuda::CUDACachingAllocator::raw_delete(mem_ptr);
+  c10::hip::HIPCachingAllocator::raw_delete(mem_ptr);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -204,7 +204,7 @@ PyObject * THCPModule_cudaCachingAllocator_raw_delete(PyObject *_unused, PyObjec
 PyObject * THCPModule_cudaSynchronize(PyObject *_unused, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
-  THCudaCheck(cudaDeviceSynchronize());
+  THCudaCheck(hipDeviceSynchronize());
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -235,7 +235,7 @@ static PyGILState_STATE cudaMutexGILState;
 
 PyObject * THCPModule_cudaLockMutex(PyObject *module, PyObject *noargs)
 {
-  auto mutex = c10::cuda::CUDACachingAllocator::getFreeMutex();
+  auto mutex = c10::hip::HIPCachingAllocator::getFreeMutex();
   // This has to be a busy loop because we **absolutely need to** hold the GIL
   // or it's a recipe for a deadlock otherwise (if we let other Python threads
   // run while we have the cudaMutex, but not the GIL, they might try to e.g.
@@ -256,7 +256,7 @@ PyObject * THCPModule_cudaLockMutex(PyObject *module, PyObject *noargs)
 
 PyObject * THCPModule_cudaUnlockMutex(PyObject *module, PyObject *noargs)
 {
-  auto mutex = c10::cuda::CUDACachingAllocator::getFreeMutex();
+  auto mutex = c10::hip::HIPCachingAllocator::getFreeMutex();
   PyGILState_Release(cudaMutexGILState);
   mutex->unlock();
   Py_RETURN_NONE;
@@ -278,7 +278,7 @@ PyObject * THCPModule_hasPrimaryContext(PyObject *_unused, PyObject *arg)
 PyObject * THCPModule_emptyCache(PyObject *_unused, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
-  c10::cuda::CUDACachingAllocator::emptyCache();
+  c10::hip::HIPCachingAllocator::emptyCache();
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -289,10 +289,10 @@ PyObject * THCPModule_memoryStats(PyObject *_unused, PyObject *arg)
   THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to memory_allocated");
   const int device = (int) THPUtils_unpackLong(arg);
 
-  using c10::cuda::CUDACachingAllocator::StatType;
-  using c10::cuda::CUDACachingAllocator::Stat;
-  using c10::cuda::CUDACachingAllocator::StatArray;
-  using c10::cuda::CUDACachingAllocator::DeviceStats;
+  using c10::hip::HIPCachingAllocator::StatType;
+  using c10::hip::HIPCachingAllocator::Stat;
+  using c10::hip::HIPCachingAllocator::StatArray;
+  using c10::hip::HIPCachingAllocator::DeviceStats;
 
   const auto statToDict = [](const Stat& stat) {
     py::dict dict;
@@ -315,7 +315,7 @@ PyObject * THCPModule_memoryStats(PyObject *_unused, PyObject *arg)
     return dict;
   };
 
-  const DeviceStats stats = c10::cuda::CUDACachingAllocator::getDeviceStats(device);
+  const DeviceStats stats = c10::hip::HIPCachingAllocator::getDeviceStats(device);
 
   py::dict result;
   result["num_alloc_retries"] = stats.num_alloc_retries;
@@ -338,7 +338,7 @@ PyObject * THCPModule_resetAccumulatedMemoryStats(PyObject *_unused, PyObject *a
   HANDLE_TH_ERRORS
   THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to reset_accumulated_memory_stats");
   const int device = (int) THPUtils_unpackLong(arg);
-  c10::cuda::CUDACachingAllocator::resetAccumulatedStats(device);
+  c10::hip::HIPCachingAllocator::resetAccumulatedStats(device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -348,7 +348,7 @@ PyObject * THCPModule_resetPeakMemoryStats(PyObject *_unused, PyObject *arg)
   HANDLE_TH_ERRORS
   THPUtils_assert(THPUtils_checkLong(arg), "invalid argument to reset_peak_memory_stats");
   const int device = (int) THPUtils_unpackLong(arg);
-  c10::cuda::CUDACachingAllocator::resetPeakStats(device);
+  c10::hip::HIPCachingAllocator::resetPeakStats(device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -357,8 +357,8 @@ PyObject * THCPModule_memorySnapshot(PyObject *_unused, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
 
-  using c10::cuda::CUDACachingAllocator::SegmentInfo;
-  using c10::cuda::CUDACachingAllocator::BlockInfo;
+  using c10::hip::HIPCachingAllocator::SegmentInfo;
+  using c10::hip::HIPCachingAllocator::BlockInfo;
 
   const auto segmentInfoToDict = [](const SegmentInfo& segmentInfo) {
     py::dict segmentDict;
@@ -381,7 +381,7 @@ PyObject * THCPModule_memorySnapshot(PyObject *_unused, PyObject *noargs)
     return segmentDict;
   };
 
-  const std::vector<SegmentInfo>& snapshot = c10::cuda::CUDACachingAllocator::snapshot();
+  const std::vector<SegmentInfo>& snapshot = c10::hip::HIPCachingAllocator::snapshot();
   py::list result;
 
   for (const auto& segmentInfo : snapshot) {
@@ -399,22 +399,22 @@ PyObject * THCPModule_memorySnapshot(PyObject *_unused, PyObject *noargs)
 static void bindCudaDeviceProperties(PyObject* module) {
   // Add class and method to torch.cuda
   auto m = py::handle(module).cast<py::module>();
-  py::class_<cudaDeviceProp>(m, "_CudaDeviceProperties")
-    .def_readonly("name", &cudaDeviceProp::name)
-    .def_readonly("major", &cudaDeviceProp::major)
-    .def_readonly("minor", &cudaDeviceProp::minor)
-    .def_readonly("is_multi_gpu_board", &cudaDeviceProp::isMultiGpuBoard)
-    .def_readonly("is_integrated", &cudaDeviceProp::integrated)
-    .def_readonly("multi_processor_count", &cudaDeviceProp::multiProcessorCount)
-    .def_readonly("total_memory", &cudaDeviceProp::totalGlobalMem)
-    .def("__repr__", [](const cudaDeviceProp &prop) {
+  py::class_<hipDeviceProp_t>(m, "_CudaDeviceProperties")
+    .def_readonly("name", &hipDeviceProp_t::name)
+    .def_readonly("major", &hipDeviceProp_t::major)
+    .def_readonly("minor", &hipDeviceProp_t::minor)
+    .def_readonly("is_multi_gpu_board", &hipDeviceProp_t::isMultiGpuBoard)
+    .def_readonly("is_integrated", &hipDeviceProp_t::integrated)
+    .def_readonly("multi_processor_count", &hipDeviceProp_t::multiProcessorCount)
+    .def_readonly("total_memory", &hipDeviceProp_t::totalGlobalMem)
+    .def("__repr__", [](const hipDeviceProp_t &prop) {
       std::ostringstream stream;
       stream << "_CudaDeviceProperties(name='" << prop.name << "', major=" << prop.major
              << ", minor=" << prop.minor << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
       return stream.str();
     });
-  m.def("_get_device_properties", [](int device) -> cudaDeviceProp * {
+  m.def("_get_device_properties", [](int device) -> hipDeviceProp_t * {
     return at::cuda::getDeviceProperties(device);
   }, py::return_value_policy::reference);
 }
@@ -460,7 +460,7 @@ static PyObject * THCPModule_initExtension(PyObject *self, PyObject *noargs)
   if (!_state_cdata) throw python_error();
   set_module_attr("_state_cdata", _state_cdata.get());
 
-  auto num_gpus = c10::cuda::device_count();
+  auto num_gpus = c10::hip::device_count();
   auto default_cuda_generators = PyTuple_New(static_cast<Py_ssize_t>(num_gpus));
   for(int i = 0; i < num_gpus; i++) {
     auto gen = at::cuda::detail::getDefaultCUDAGenerator(i);
@@ -479,7 +479,7 @@ static PyObject * THCPModule_initExtension(PyObject *self, PyObject *noargs)
 PyObject * THCPModule_getCurrentBlasHandle_wrap(PyObject *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
-  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  rocblas_handle handle = at::cuda::getCurrentCUDABlasHandle();
   return PyLong_FromVoidPtr(handle);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/cuda/Storage.cpp
+++ b/torch/csrc/cuda/Storage.cpp
@@ -6,7 +6,7 @@
 // See Note [TH abstraction violation]
 //    - Used to get at allocator from storage
 #include <TH/THTensor.hpp>
-#include <THC/THCTensor.hpp>
+#include <THH/THHTensor.hpp>
 #include <torch/csrc/cuda/THCP.h>
 
 #include <torch/csrc/cuda/override_macros.h>
@@ -17,13 +17,13 @@
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.cpp"
-#include <THC/THCGenerateAllTypes.h>
+#include <THH/THHGenerateAllTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.cpp"
-#include <THC/THCGenerateComplexTypes.h>
+#include <THH/THHGenerateComplexTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.cpp"
-#include <THC/THCGenerateBoolType.h>
+#include <THH/THHGenerateBoolType.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.cpp"
-#include <THC/THCGenerateBFloat16Type.h>
+#include <THH/THHGenerateBFloat16Type.h>

--- a/torch/csrc/cuda/Storage.h
+++ b/torch/csrc/cuda/Storage.h
@@ -48,15 +48,15 @@
 #include <torch/csrc/cuda/override_macros.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.h"
-#include <THC/THCGenerateAllTypes.h>
+#include <THH/THHGenerateAllTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.h"
-#include <THC/THCGenerateComplexTypes.h>
+#include <THH/THHGenerateComplexTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.h"
-#include <THC/THCGenerateBoolType.h>
+#include <THH/THHGenerateBoolType.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/Storage.h"
-#include <THC/THCGenerateBFloat16Type.h>
+#include <THH/THHGenerateBFloat16Type.h>
 
 #endif

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -4,10 +4,10 @@
 #include <torch/csrc/Device.h>
 #include <torch/csrc/THP.h>
 
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 
 #include <structmember.h>
-#include <cuda_runtime_api.h>
+#include <hip/hip_runtime_api.h>
 
 PyObject *THCPStreamClass = nullptr;
 
@@ -16,7 +16,7 @@ static PyObject * THCPStream_pynew(
   HANDLE_TH_ERRORS
 
   int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
+  THCudaCheck(hipGetDevice(&current_device));
 
   int priority = 0;
   uint64_t cdata = 0;
@@ -32,22 +32,22 @@ static PyObject * THCPStream_pynew(
     return nullptr;
   }
 
-  at::cuda::CUDAStream stream =
+  at::hip::HIPStreamMasqueradingAsCUDA stream =
     cdata ?
-    at::cuda::CUDAStream::unpack(cdata) :
-    at::cuda::getStreamFromPool(
+    at::hip::HIPStreamMasqueradingAsCUDA::unpack(cdata) :
+    at::hip::getStreamFromPoolMasqueradingAsCUDA(
       /* isHighPriority */ priority < 0 ? true : false);
 
   THCPStream* self = (THCPStream *)ptr.get();
   self->cdata = stream.pack();
-  new (&self->cuda_stream) at::cuda::CUDAStream(stream);
+  new (&self->cuda_stream) at::hip::HIPStreamMasqueradingAsCUDA(stream);
 
   return (PyObject *)ptr.release();
   END_HANDLE_TH_ERRORS
 }
 
 static void THCPStream_dealloc(THCPStream *self) {
-  self->cuda_stream.~CUDAStream();
+  self->cuda_stream.~HIPStreamMasqueradingAsCUDA();
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -73,7 +73,7 @@ static PyObject * THCPStream_priority_range() {
   HANDLE_TH_ERRORS
   int least_priority, greatest_priority;
   std::tie(least_priority, greatest_priority) =
-    at::cuda::CUDAStream::priority_range();
+    at::hip::HIPStreamMasqueradingAsCUDA::priority_range();
   return Py_BuildValue("(ii)", least_priority, greatest_priority);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/cuda/Stream.h
+++ b/torch/csrc/cuda/Stream.h
@@ -1,14 +1,14 @@
 #ifndef THCP_STREAM_INC
 #define THCP_STREAM_INC
 
-#include <c10/cuda/CUDAStream.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 #include <torch/csrc/python_headers.h>
-#include <THC/THC.h>
+#include <THH/THH.h>
 
 struct THCPStream {
   PyObject_HEAD
   uint64_t cdata;
-  at::cuda::CUDAStream cuda_stream;
+  at::hip::HIPStreamMasqueradingAsCUDA cuda_stream;
 };
 extern PyObject *THCPStreamClass;
 

--- a/torch/csrc/cuda/THCP.h
+++ b/torch/csrc/cuda/THCP.h
@@ -3,9 +3,9 @@
 
 #include <torch/csrc/python_headers.h>
 #include <TH/TH.h>
-#include <THC/THC.h>
+#include <THH/THH.h>
 #include <TH/THHalf.h>
-#include <THC/THCTensor.hpp>
+#include <THH/THHTensor.hpp>
 
 #include <torch/csrc/THP.h>
 #include <torch/csrc/cuda/serialization.h>

--- a/torch/csrc/cuda/comm.h
+++ b/torch/csrc/cuda/comm.h
@@ -2,8 +2,8 @@
 
 #include <ATen/ATen.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
-#include <ATen/cuda/ATenCUDAGeneral.h>
-#include <ATen/cuda/CUDAContext.h>
+#include <ATen/hip/ATenHIPGeneral.h>
+#include <ATen/hip/HIPContext.h>
 #include <c10/util/Optional.h>
 
 #include <cstddef>
@@ -22,7 +22,7 @@ TORCH_CUDA_API std::vector<at::Tensor> scatter(
     at::IntArrayRef devices,
     const c10::optional<std::vector<int64_t>>& chunk_sizes = c10::nullopt,
     int64_t dim = 0,
-    const c10::optional<std::vector<c10::optional<at::cuda::CUDAStream>>>& streams =
+    const c10::optional<std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>>>& streams =
         c10::nullopt);
 
 TORCH_CUDA_API at::Tensor gather(

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -4,10 +4,10 @@
 #include <torch/csrc/utils/hash.h>
 
 #include <ATen/ATen.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <c10/util/Exception.h>
 
-#include <THC/THC.h>
+#include <THH/THH.h>
 
 #include <limits>
 #include <sstream>
@@ -40,7 +40,7 @@ struct NcclCommList {
     if (comms) {
       for (int i = 0; i < ndevices; i++) {
         int dummy_var;
-        if (cudaGetDevice(&dummy_var) != cudaSuccess) {
+        if (hipGetDevice(&dummy_var) != hipSuccess) {
           /* there are cases when this destructor is called after the
            CUDA driver is already unloaded from the process.
            In these cases, skip ncclCommDestroy */
@@ -269,13 +269,13 @@ void broadcast(
                                         : ArrayRef<ncclComm_t>(user_comms);
 
   AutoNcclGroup nccl_group_guard;
-  at::cuda::OptionalCUDAGuard device_guard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
   for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; i++) {
     int device = tensors[i].get_device();
     device_guard.set_index(device);
     // Default to the current stream
     const auto stream = (streams.empty() || !streams[i])
-        ? at::cuda::getCurrentCUDAStream(device).stream()
+        ? at::hip::getCurrentHIPStreamMasqueradingAsCUDA(device).stream()
         : streams[i]->stream();
     TORCH_CHECK(
         static_cast<uint64_t>(numel) <= static_cast<uint64_t>(count_max),
@@ -315,13 +315,13 @@ void reduce(
                                       : ArrayRef<ncclComm_t>(user_comms);
 
   AutoNcclGroup nccl_group_guard;
-  at::cuda::OptionalCUDAGuard device_guard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
   for (size_t i = 0; i < len; i++) {
     int device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
     const auto stream = (streams.empty() || !streams[i])
-        ? at::cuda::getCurrentCUDAStream(device).stream()
+        ? at::hip::getCurrentHIPStreamMasqueradingAsCUDA(device).stream()
         : streams[i]->stream();
 
     NCCL_CHECK(ncclReduce(
@@ -366,13 +366,13 @@ void all_reduce(
                                       : ArrayRef<ncclComm_t>(user_comms);
 
   AutoNcclGroup nccl_group_guard;
-  at::cuda::OptionalCUDAGuard device_guard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
   for (size_t i = 0; i < len; i++) {
     int device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
     const auto stream = (streams.empty() || !streams[i])
-        ? at::cuda::getCurrentCUDAStream(device).stream()
+        ? at::hip::getCurrentHIPStreamMasqueradingAsCUDA(device).stream()
         : streams[i]->stream();
 
     NCCL_CHECK(ncclAllReduce(
@@ -407,13 +407,13 @@ void reduce_scatter(
                                       : ArrayRef<ncclComm_t>(user_comms);
 
   AutoNcclGroup nccl_group_guard;
-  at::cuda::OptionalCUDAGuard device_guard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
   for (size_t i = 0; i < len; i++) {
     int device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
     const auto stream = (streams.empty() || !streams[i])
-        ? at::cuda::getCurrentCUDAStream(device).stream()
+        ? at::hip::getCurrentHIPStreamMasqueradingAsCUDA(device).stream()
         : streams[i]->stream();
 
     NCCL_CHECK(ncclReduceScatter(
@@ -447,13 +447,13 @@ void all_gather(
                                       : ArrayRef<ncclComm_t>(user_comms);
 
   AutoNcclGroup nccl_group_guard;
-  at::cuda::OptionalCUDAGuard device_guard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
   for (size_t i = 0; i < len; i++) {
     int device = inputs[i].device().index();
     device_guard.set_index(device);
     // Default to the current stream
     const auto stream = (streams.empty() || !streams[i])
-        ? at::cuda::getCurrentCUDAStream(device).stream()
+        ? at::hip::getCurrentHIPStreamMasqueradingAsCUDA(device).stream()
         : streams[i]->stream();
 
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <THC/THC.h>
-#include <c10/cuda/CUDACachingAllocator.h>
+#include <ATen/hip/HIPContext.h>
+#include <THH/THH.h>
+#include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
 #include <c10/util/Optional.h>
 
-#include <nccl.h>
+#include <rccl.h>
 
 #include <cstddef>
 #include <vector>
@@ -29,7 +29,7 @@ static inline void NCCL_CHECK(ncclResult_t status) {
 
 struct AutoNcclGroup {
   AutoNcclGroup() {
-    (c10::cuda::CUDACachingAllocator::getFreeMutex())->lock();
+    (c10::hip::HIPCachingAllocator::getFreeMutex())->lock();
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
     NCCL_CHECK(ncclGroupStart());
 #endif
@@ -38,7 +38,7 @@ struct AutoNcclGroup {
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
     NCCL_CHECK(ncclGroupEnd());
 #endif
-    (c10::cuda::CUDACachingAllocator::getFreeMutex())->unlock();
+    (c10::hip::HIPCachingAllocator::getFreeMutex())->unlock();
   }
 };
 
@@ -53,7 +53,7 @@ TORCH_CUDA_API ncclDataType_t get_data_type(const at::Tensor& t);
 } // namespace detail
 
 using comm_list = std::vector<ncclComm_t>;
-using stream_list = std::vector<c10::optional<at::cuda::CUDAStream>>;
+using stream_list = std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>>;
 
 TORCH_CUDA_API std::uint64_t version();
 

--- a/torch/csrc/cuda/python_comm.cpp
+++ b/torch/csrc/cuda/python_comm.cpp
@@ -7,7 +7,7 @@
 
 #include <ATen/ATen.h>
 
-#include <THC/THC.h>
+#include <THH/THH.h>
 
 #include <cstddef>
 #include <vector>
@@ -39,7 +39,7 @@ void initCommMethods(PyObject *module) {
              c10::optional<std::vector<int64_t>> chunk_sizes,
              int64_t dim,
              c10::optional<py::object> py_streams) {
-            c10::optional<std::vector<c10::optional<at::cuda::CUDAStream>>> streams;
+            c10::optional<std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>>> streams;
             if (py_streams) {
               py::handle handle = *py_streams;
               streams = THPUtils_PySequence_to_CUDAStreamList(handle.ptr());

--- a/torch/csrc/cuda/python_nccl.cpp
+++ b/torch/csrc/cuda/python_nccl.cpp
@@ -10,9 +10,9 @@
 #include <torch/csrc/cuda/nccl.h>
 #include <ATen/core/functional.h>
 
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 
-#include <nccl.h>
+#include <rccl.h>
 
 #include <sstream>
 #include <unordered_map>
@@ -54,9 +54,9 @@ static void destroy_nccl_comm(PyObject* capsule) {
   END_HANDLE_TH_ERRORS_RET()
 }
 
-static std::vector<c10::optional<at::cuda::CUDAStream>> unpack_streams(PyObject* obj, size_t size) {
+static std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>> unpack_streams(PyObject* obj, size_t size) {
   if (obj == Py_None) {
-    return std::vector<c10::optional<at::cuda::CUDAStream>>(size, c10::nullopt);
+    return std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>>(size, c10::nullopt);
   }
   auto streams = THPUtils_PySequence_to_CUDAStreamList(obj);
   if (streams.size() != size) {
@@ -146,7 +146,7 @@ PyObject* THCPModule_nccl_reduce(PyObject* self, PyObject* args) {
 
   std::vector<at::Tensor> inputs = extract_tensors(_inputs);
   std::vector<at::Tensor> outputs = extract_tensors(_outputs);
-  std::vector<c10::optional<at::cuda::CUDAStream>> streams = unpack_streams(_streams, inputs.size());
+  std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>> streams = unpack_streams(_streams, inputs.size());
   auto user_comms = unpack_comms(_comms, inputs.size());
 
   {

--- a/torch/csrc/cuda/serialization.cpp
+++ b/torch/csrc/cuda/serialization.cpp
@@ -8,13 +8,13 @@
 #include <memory>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.cpp"
-#include <THC/THCGenerateAllTypes.h>
+#include <THH/THHGenerateAllTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.cpp"
-#include <THC/THCGenerateComplexTypes.h>
+#include <THH/THHGenerateComplexTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.cpp"
-#include <THC/THCGenerateBoolType.h>
+#include <THH/THHGenerateBoolType.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.cpp"
-#include <THC/THCGenerateBFloat16Type.h>
+#include <THH/THHGenerateBFloat16Type.h>

--- a/torch/csrc/cuda/serialization.h
+++ b/torch/csrc/cuda/serialization.h
@@ -4,15 +4,15 @@
 #include <torch/csrc/cuda/override_macros.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.h"
-#include <THC/THCGenerateAllTypes.h>
+#include <THH/THHGenerateAllTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.h"
-#include <THC/THCGenerateComplexTypes.h>
+#include <THH/THHGenerateComplexTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.h"
-#include <THC/THCGenerateBoolType.h>
+#include <THH/THHGenerateBoolType.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/serialization.h"
-#include <THC/THCGenerateBFloat16Type.h>
+#include <THH/THHGenerateBFloat16Type.h>
 
 #endif

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -1,6 +1,6 @@
 #include <torch/csrc/utils/pybind.h>
-#include <cuda.h>
-#include <cuda_runtime.h>
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime.h>
 #ifndef __HIP_PLATFORM_HCC__
 #include <cuda_profiler_api.h>
 #else
@@ -15,20 +15,20 @@ void initCudartBindings(PyObject* module) {
   auto cudart = m.def_submodule("_cudart", "libcudart.so bindings");
 
 #ifndef __HIP_PLATFORM_HCC__
-  py::enum_<cudaOutputMode_t>(cudart, "cudaOutputMode")
-      .value("KeyValuePair", cudaKeyValuePair)
-      .value("CSV", cudaCSV);
+  py::enum_<cudaOutputMode_t>(cudart, "hipOutputMode")
+      .value("KeyValuePair", hipKeyValuePair)
+      .value("CSV", hipCSV);
 #endif
 
-  py::enum_<cudaError_t>(cudart, "cudaError")
-      .value("success", cudaSuccess);
+  py::enum_<hipError_t>(cudart, "cudaError")
+      .value("success", hipSuccess);
 
-  cudart.def("cudaGetErrorString", cudaGetErrorString);
-  cudart.def("cudaProfilerStart", cudaProfilerStart);
-  cudart.def("cudaProfilerStop", cudaProfilerStop);
-  cudart.def("cudaHostRegister", cudaHostRegister);
+  cudart.def("hipGetErrorString", hipGetErrorString);
+  cudart.def("hipProfilerStart", hipProfilerStart);
+  cudart.def("hipProfilerStop", hipProfilerStop);
+  cudart.def("hipHostRegister", hipHostRegister);
 #ifndef __HIP_PLATFORM_HCC__
-  cudart.def("cudaProfilerInitialize", cudaProfilerInitialize);
+  cudart.def("hipProfilerInitialize", hipProfilerInitialize);
 #endif
 }
 

--- a/torch/csrc/cuda/shared/cudnn.cpp
+++ b/torch/csrc/cuda/shared/cudnn.cpp
@@ -71,11 +71,11 @@ void initCudnnBindings(PyObject* module) {
 
   auto cudnn = m.def_submodule("_cudnn", "libcudnn.so bindings");
 
-  py::enum_<cudnnRNNMode_t>(cudnn, "RNNMode")
-    .value("rnn_relu", CUDNN_RNN_RELU)
-    .value("rnn_tanh", CUDNN_RNN_TANH)
-    .value("lstm", CUDNN_LSTM)
-    .value("gru", CUDNN_GRU);
+  py::enum_<miopenRNNMode_t>(cudnn, "RNNMode")
+    .value("rnn_relu", miopenRNNRELU)
+    .value("rnn_tanh", miopenRNNTANH)
+    .value("lstm", miopenLSTM)
+    .value("gru", miopenGRU);
 
   // The runtime version check in python needs to distinguish cudnn from miopen
 #ifdef USE_CUDNN

--- a/torch/csrc/cuda/shared/nvtx.cpp
+++ b/torch/csrc/cuda/shared/nvtx.cpp
@@ -1,5 +1,5 @@
 #include <torch/csrc/utils/pybind.h>
-#include <nvToolsExt.h>
+#include <roctx.h>
 
 namespace torch { namespace cuda { namespace shared {
 
@@ -7,9 +7,9 @@ void initNvtxBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
   auto nvtx = m.def_submodule("_nvtx", "libNvToolsExt.so bindings");
-  nvtx.def("rangePushA", nvtxRangePushA);
-  nvtx.def("rangePop", nvtxRangePop);
-  nvtx.def("markA", nvtxMarkA);
+  nvtx.def("rangePushA", roctxRangePushA);
+  nvtx.def("rangePop", roctxRangePop);
+  nvtx.def("markA", roctxMarkA);
 }
 
 } // namespace shared

--- a/torch/csrc/cuda/utils.cpp
+++ b/torch/csrc/cuda/utils.cpp
@@ -6,21 +6,21 @@
 #include <torch/csrc/cuda/override_macros.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.cpp"
-#include <THC/THCGenerateAllTypes.h>
+#include <THH/THHGenerateAllTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.cpp"
-#include <THC/THCGenerateComplexTypes.h>
+#include <THH/THHGenerateComplexTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.cpp"
-#include <THC/THCGenerateBoolType.h>
+#include <THH/THHGenerateBoolType.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.cpp"
-#include <THC/THCGenerateBFloat16Type.h>
+#include <THH/THHGenerateBFloat16Type.h>
 
-#ifdef USE_CUDA
-// NB: It's a list of *optional* CUDAStream; when nullopt, that means to use
+#ifdef USE_ROCM
+// NB: It's a list of *optional* HIPStreamMasqueradingAsCUDA; when nullopt, that means to use
 // whatever the current stream of the device the input is associated with was.
-std::vector<c10::optional<at::cuda::CUDAStream>> THPUtils_PySequence_to_CUDAStreamList(PyObject *obj) {
+std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>> THPUtils_PySequence_to_CUDAStreamList(PyObject *obj) {
   if (!PySequence_Check(obj)) {
     throw std::runtime_error("Expected a sequence in THPUtils_PySequence_to_CUDAStreamList");
   }
@@ -29,14 +29,14 @@ std::vector<c10::optional<at::cuda::CUDAStream>> THPUtils_PySequence_to_CUDAStre
     throw std::runtime_error("expected PySequence, but got " + std::string(THPUtils_typename(obj)));
   }
 
-  std::vector<c10::optional<at::cuda::CUDAStream>> streams;
+  std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>> streams;
   Py_ssize_t length = PySequence_Fast_GET_SIZE(seq.get());
   for (Py_ssize_t i = 0; i < length; i++) {
     PyObject *stream = PySequence_Fast_GET_ITEM(seq.get(), i);
 
     if (PyObject_IsInstance(stream, THCPStreamClass)) {
       // Spicy hot reinterpret cast!!
-      streams.emplace_back( at::cuda::CUDAStream::unpack((reinterpret_cast<THCPStream*>(stream))->cdata) );
+      streams.emplace_back( at::hip::HIPStreamMasqueradingAsCUDA::unpack((reinterpret_cast<THCPStream*>(stream))->cdata) );
     } else if (stream == Py_None) {
       streams.emplace_back();
     } else {

--- a/torch/csrc/cuda/utils.h
+++ b/torch/csrc/cuda/utils.h
@@ -14,14 +14,14 @@
 #include <torch/csrc/cuda/override_macros.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.h"
-#include <THC/THCGenerateAllTypes.h>
+#include <THH/THHGenerateAllTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.h"
-#include <THC/THCGenerateComplexTypes.h>
+#include <THH/THHGenerateComplexTypes.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.h"
-#include <THC/THCGenerateBoolType.h>
+#include <THH/THHGenerateBoolType.h>
 
 #define THC_GENERIC_FILE "torch/csrc/generic/utils.h"
-#include <THC/THCGenerateBFloat16Type.h>
+#include <THH/THHGenerateBFloat16Type.h>
 #endif

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 
-#ifdef USE_CUDA
-#include <cuda_runtime.h>
+#ifdef USE_ROCM
+#include <hip/hip_runtime.h>
 #endif
 
 #ifdef _MSC_VER
@@ -34,7 +34,7 @@ static PyObject * THPStorage_(copy_)(PyObject *self, PyObject *args, PyObject *k
 static PyObject * THPStorage_(isPinned)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
-#if defined(USE_CUDA)
+#if defined(USE_ROCM)
   return PyBool_FromLong(at::globalContext().isPinnedPtr(THWStorage_(data)(LIBRARY_STATE self->cdata)));
 #else
   Py_RETURN_FALSE;

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -1,7 +1,7 @@
-#ifdef USE_CUDA
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <c10/cuda/CUDAGuard.h>
+#ifdef USE_ROCM
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #endif
 
 #include <random>
@@ -240,13 +240,13 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self, PyObject *noargs)
   Py_INCREF(Py_None);
   if (THWStorage_(data)(LIBRARY_STATE storage)) {
     size_t base_size;
-    void *base_ptr = c10::cuda::CUDACachingAllocator::getBaseAllocation(THWStorage_(data)(LIBRARY_STATE storage), &base_size);
+    void *base_ptr = c10::hip::HIPCachingAllocator::getBaseAllocation(THWStorage_(data)(LIBRARY_STATE storage), &base_size);
     ptrdiff_t offset_bytes = (char*)storage->data<scalar_t>() - (char*)base_ptr;
 
-    cudaIpcMemHandle_t handle;
-    THCudaCheck(cudaIpcGetMemHandle(&handle, base_ptr));
+    hipIpcMemHandle_t handle;
+    THCudaCheck(hipIpcGetMemHandle(&handle, base_ptr));
 
-    _handle = PyBytes_FromStringAndSize((char *)&handle, CUDA_IPC_HANDLE_SIZE);
+    _handle = PyBytes_FromStringAndSize((char *)&handle, HIP_IPC_HANDLE_SIZE);
     _offset_bytes = PyLong_FromSsize_t((Py_ssize_t)offset_bytes);
 
     // Put Storage Data behind new ref counting context
@@ -259,17 +259,17 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self, PyObject *noargs)
     _ref_counter_offset = PyLong_FromLong(sent_data->offset());
 
 
-    cudaIpcEventHandle_t ipc_event_handle;
+    hipIpcEventHandle_t ipc_event_handle;
 
 #ifndef __HIP_PLATFORM_HCC__
     if (sent_data->event_sync_required_) {
-      THCudaCheck(cudaIpcGetEventHandle(&ipc_event_handle, sent_data->event_));
+      THCudaCheck(hipIpcGetEventHandle(&ipc_event_handle, sent_data->event_));
     }
 #else
     // ipc_event_handle unused in storage receiver, we can leave it uninitialized.
 #endif
 
-    _event_handle = PyBytes_FromStringAndSize((char *)&ipc_event_handle, CUDA_IPC_HANDLE_SIZE);
+    _event_handle = PyBytes_FromStringAndSize((char *)&ipc_event_handle, HIP_IPC_HANDLE_SIZE);
     _event_sync_required = PyBool_FromLong(sent_data->event_sync_required_);
 
   }
@@ -278,7 +278,7 @@ static PyObject * THPStorage_(shareCuda)(THPStorage *self, PyObject *noargs)
     return nullptr;
   }
   PyTuple_SET_ITEM(tuple.get(), 0, device.release());
-  // cudaIpcMemHandle_t(of basePtr)
+  // hipIpcMemHandle_t(of basePtr)
   PyTuple_SET_ITEM(tuple.get(), 1, _handle.release());
   // Size(in bytes) of the real storage, note this is not the size of basePtr memory block.
   PyTuple_SET_ITEM(tuple.get(), 2, size_bytes.release());
@@ -340,7 +340,7 @@ static std::string THPStorage_(bytesAsHandleString)(PyObject *handle) {
     return nullptr;
   }
   THPUtils_assert(
-      handle_size == CUDA_IPC_HANDLE_SIZE, "incorrect handle size");
+      handle_size == HIP_IPC_HANDLE_SIZE, "incorrect handle size");
   return std::string(buffer, handle_size);
 }
 
@@ -373,26 +373,26 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
   ptrdiff_t storage_offset_bytes = (ptrdiff_t)THPUtils_unpackLong(_offset_bytes);
 
   int64_t device = THPUtils_unpackLong(_device);
-  at::cuda::CUDAGuard device_guard(device);
+  at::hip::HIPGuardMasqueradingAsCUDA device_guard(device);
 
 #ifndef __HIP_PLATFORM_HCC__
   if (PyObject_IsTrue(_event_sync_required)) {
     // Ensure that producer prepared all tensor's data
     std::string s_ipc_event_handle =
         THPStorage_(bytesAsHandleString)(_event_handle);
-    auto ipc_event_handle = reinterpret_cast<const cudaIpcEventHandle_t*>(
+    auto ipc_event_handle = reinterpret_cast<const hipIpcEventHandle_t*>(
         s_ipc_event_handle.c_str());
-    cudaEvent_t event;
-    cudaIpcOpenEventHandle(&event, *ipc_event_handle);
+    hipEvent_t event;
+    hipIpcOpenEventHandle(&event, *ipc_event_handle);
     AT_CUDA_CHECK(
-        cudaStreamWaitEvent(c10::cuda::getCurrentCUDAStream(device), event, 0));
+        hipStreamWaitEvent(c10::hip::getCurrentHIPStreamMasqueradingAsCUDA(device), event, 0));
   }
 #else
   // Already synchronized inside producer stream
 #endif
 
   std::string s_handle = THPStorage_(bytesAsHandleString)(_handle);
-  std::shared_ptr<void> basePtr = c10::cuda::CUDACachingAllocator::getIpcDevPtr(s_handle);
+  std::shared_ptr<void> basePtr = c10::hip::HIPCachingAllocator::getIpcDevPtr(s_handle);
 
   // Offset the basePtr to reconstruct the real storage
   // devPtr = basePtr + storage_offset
@@ -416,9 +416,9 @@ static PyObject * THPStorage_(newSharedCuda)(PyObject *_unused, PyObject *args)
         // does not support the creation of untriggered events and performance
         // impact of having thousands of shared events is unknown.
 
-        // TODO: Instead of cudaStreamSynchronize it is possible to add Stream
+        // TODO: Instead of hipStreamSynchronize it is possible to add Stream
         // Callback and release counter inside of it (need to check performance impact)
-        cudaStreamSynchronize(c10::cuda::getCurrentCUDAStream(device));
+        hipStreamSynchronize(c10::hip::getCurrentHIPStreamMasqueradingAsCUDA(device));
 
         // We don't want to break existing code, so resource deletion is best
         // effort basis. Exception expected if producer process terminated

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.cpp
@@ -1,3 +1,4 @@
+#include "hip/hip_runtime.h"
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>

--- a/torch/csrc/jit/codegen/cuda/kernel.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel.cpp
@@ -1,8 +1,8 @@
 #include <ATen/CUDAGeneratorImpl.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/nvrtc_stub/ATenNVRTC.h>
 #include <c10/core/ScalarType.h>
-#include <c10/cuda/CUDACachingAllocator.h>
+#include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
 #include <c10/util/ArrayRef.h>
 
 #include <torch/csrc/jit/codegen/cuda/kernel.h>
@@ -194,21 +194,21 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
   // vvv NVRTC COMPILATION vvv
 
   // lazily construct context if non-existing yet;
-  CUcontext pctx = nullptr;
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuCtxGetCurrent(&pctx));
+  hipCtx_t pctx = nullptr;
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipCtxGetCurrent(&pctx));
   if (!pctx) {
     std::unique_lock<std::mutex> cudaFreeMutexLock(
-        *(c10::cuda::CUDACachingAllocator::getFreeMutex()));
-    cudaFree(nullptr);
+        *(c10::hip::HIPCachingAllocator::getFreeMutex()));
+    hipFree(nullptr);
   }
 
   // set device for the operation;
-  at::cuda::set_device(entry->device_);
+  at::hip::set_device(entry->device_);
   entry->has_random_ = fusion.hasRNG();
 
   const auto prop = at::cuda::getCurrentDeviceProperties();
   int nvrtc_major, nvrtc_minor;
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcVersion(&nvrtc_major, &nvrtc_minor));
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcVersion(&nvrtc_major, &nvrtc_minor));
 
   // Short-circuits if NVRTC version too low
   TORCH_INTERNAL_ASSERT(nvrtc_major >= 6);
@@ -218,11 +218,11 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
   int major, minor;
   major = prop->major;
   minor = prop->minor;
-  nvrtcProgram program;
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcCreateProgram(
+  hiprtcProgram program;
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcCreateProgram(
       &program, code.c_str(), nullptr, 0, nullptr, nullptr));
   ResourceGuard holdProgram(
-      [&] { AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcDestroyProgram(&program)); });
+      [&] { AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcDestroyProgram(&program)); });
 
   const std::string compute = "--gpu-architecture=compute_" +
       std::to_string(major) + std::to_string(minor);
@@ -230,27 +230,27 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
   const std::vector<const char*> args = {
       "--std=c++14", compute.c_str(), "-default-device"};
 
-  nvrtc().nvrtcAddNameExpression(program, func_name.c_str());
+  nvrtc().hiprtcAddNameExpression(program, func_name.c_str());
   const auto result =
-      nvrtc().nvrtcCompileProgram(program, args.size(), args.data());
-  if (result != NVRTC_SUCCESS) {
+      nvrtc().hiprtcCompileProgram(program, args.size(), args.data());
+  if (result != HIPRTC_SUCCESS) {
     size_t logsize;
-    nvrtc().nvrtcGetProgramLogSize(program, &logsize);
+    nvrtc().hiprtcGetProgramLogSize(program, &logsize);
     std::vector<char> log(logsize);
-    nvrtc().nvrtcGetProgramLog(program, log.data());
+    nvrtc().hiprtcGetProgramLog(program, log.data());
 
     TORCH_INTERNAL_ASSERT(
         false, code.c_str(), "\nCUDA NVRTC compile error: ", log.data());
   }
   const char* lowered_kernel_name;
-  nvrtc().nvrtcGetLoweredName(program, func_name.c_str(), &lowered_kernel_name);
+  nvrtc().hiprtcGetLoweredName(program, func_name.c_str(), &lowered_kernel_name);
 
   AT_CUDA_NVRTC_CHECK(result);
   size_t ptx_size;
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetPTXSize(program, &ptx_size));
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcGetCodeSize(program, &ptx_size));
   std::vector<char> ptx;
   ptx.resize(ptx_size);
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetPTX(program, ptx.data()));
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcGetCode(program, ptx.data()));
 
   // TODO: We do go through different code path, should investigate whether this
   // has an impact on generated binary.
@@ -267,10 +267,10 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
 
     CUlinkState linkState;
 
-    AT_CUDA_DRIVER_CHECK(nvrtc().cuLinkCreate(0, nullptr, nullptr, &linkState));
-    AT_CUDA_DRIVER_CHECK(nvrtc().cuLinkAddData(
+    AT_CUDA_DRIVER_CHECK(nvrtc().hipLinkCreate(0, nullptr, nullptr, &linkState));
+    AT_CUDA_DRIVER_CHECK(nvrtc().hipLinkAddData(
         linkState,
-        CU_JIT_INPUT_PTX,
+        hipJitInputTypePtx,
         ptx.data(),
         ptx_size,
         "compiling PTX",
@@ -279,7 +279,7 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
         nullptr));
     size_t cubinSize;
     void* cubin;
-    AT_CUDA_DRIVER_CHECK(nvrtc().cuLinkComplete(linkState, &cubin, &cubinSize));
+    AT_CUDA_DRIVER_CHECK(nvrtc().hipLinkComplete(linkState, &cubin, &cubinSize));
 
     // Output binary file
     std::stringstream cubin_file_name;
@@ -292,13 +292,13 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
     }
 
     // load compiled cubin
-    AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleLoadData(&(entry->module_), cubin));
+    AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleLoadData(&(entry->module_), cubin));
   } else {
     // load ptx directly
     AT_CUDA_DRIVER_CHECK(
-        nvrtc().cuModuleLoadData(&(entry->module_), ptx.data()));
+        nvrtc().hipModuleLoadData(&(entry->module_), ptx.data()));
   }
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleGetFunction(
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleGetFunction(
       &(entry->function_), entry->module_, lowered_kernel_name));
 #if defined(__HIP_PLATFORM_HCC__) && HIP_VERSION < 305
   // HIP function signature is not compatible yet
@@ -307,7 +307,7 @@ void compileKernel(Fusion& fusion, CudaKernel* entry) {
       &max_blocks, entry->function_, 128, 0));
   entry->max_blocks_ = max_blocks;
 #else
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuOccupancyMaxActiveBlocksPerMultiprocessor(
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleOccupancyMaxActiveBlocksPerMultiprocessor(
       &entry->max_blocks_, entry->function_, 128, 0));
 #endif
   entry->max_blocks_ *= prop->multiProcessorCount;
@@ -317,9 +317,9 @@ void runKernel(
     CudaKernel* entry,
     const at::ArrayRef<IValue> inputs,
     std::vector<at::Tensor> outputs) {
-  const auto prior_device = at::cuda::current_device();
-  at::cuda::set_device(entry->device_);
-  auto stream = at::cuda::getCurrentCUDAStream();
+  const auto prior_device = at::hip::current_device();
+  at::hip::set_device(entry->device_);
+  auto stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA();
 
   // TODO: Proper API to establish reasonable launch configurations;
   // Naive launch config;
@@ -365,7 +365,7 @@ void runKernel(
   }
 
   // launch kernel;
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuLaunchKernel(
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleLaunchKernel(
       entry->function_,
       nBlocks,
       1,
@@ -379,7 +379,7 @@ void runKernel(
       nullptr));
 
   // Resets device (see at::DeviceGuard notes above)
-  at::cuda::set_device(prior_device);
+  at::hip::set_device(prior_device);
 }
 
 // WARNING:
@@ -388,9 +388,9 @@ void runTestKernel(
     CudaKernel* entry,
     const at::ArrayRef<IValue> inputs,
     std::vector<at::Tensor> outputs) {
-  const auto prior_device = at::cuda::current_device();
-  at::cuda::set_device(entry->device_);
-  auto stream = at::cuda::getCurrentCUDAStream();
+  const auto prior_device = at::hip::current_device();
+  at::hip::set_device(entry->device_);
+  auto stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA();
 
   // TODO: Proper API to establish reasonable launch configurations;
   // Naive launch config;
@@ -449,7 +449,7 @@ void runTestKernel(
   }
 
   // launch kernel;
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuLaunchKernel(
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleLaunchKernel(
       entry->function_,
       entry->grid_.x,
       entry->grid_.y,
@@ -463,7 +463,7 @@ void runTestKernel(
       nullptr));
 
   // Resets device (see at::DeviceGuard notes above)
-  at::cuda::set_device(prior_device);
+  at::hip::set_device(prior_device);
 }
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/kernel.h
+++ b/torch/csrc/jit/codegen/cuda/kernel.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
-#include <ATen/cuda/CUDAContext.h>
+#include <ATen/hip/HIPContext.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
@@ -47,17 +47,17 @@ class CudaKernel {
 
   CudaKernel() = default;
 
-  CUmodule& getModule() {
+  hipModule_t& getModule() {
     return module_;
   }
 
-  CUfunction& getFunction() {
+  hipFunction_t& getFunction() {
     return function_;
   }
 
   int16_t device_;
-  CUmodule module_;
-  CUfunction function_;
+  hipModule_t module_;
+  hipFunction_t function_;
   int max_blocks_;
   int unroll_factor_ = 1;
 

--- a/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_resource_strings.h
@@ -1,3 +1,4 @@
+#include "hip/hip_runtime.h"
 namespace torch {
 namespace jit {
 namespace fuser {

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -3,13 +3,13 @@
 
 #include <ATen/ATen.h>
 #include <ATen/CUDAGeneratorImpl.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
-#include <THC/THC.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/nvrtc_stub/ATenNVRTC.h>
+#include <THH/THH.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <torch/csrc/jit/resource_guard.h>
 
-#include <cuda_runtime.h>
+#include <hip/hip_runtime.h>
 
 #include <algorithm>
 #include <cmath>
@@ -29,11 +29,11 @@ const at::cuda::NVRTC& nvrtc() {
 }
 
 static void getMajorMinor(
-    const cudaDeviceProp* const prop,
+    const hipDeviceProp_t* const prop,
     int& major,
     int& minor) {
   int nvrtc_major, nvrtc_minor;
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcVersion(&nvrtc_major, &nvrtc_minor));
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcVersion(&nvrtc_major, &nvrtc_minor));
 
   // Short-circuits if NVRTC version too low
   AT_ASSERT(nvrtc_major >= 6);
@@ -84,18 +84,18 @@ FusedKernelCUDA::FusedKernelCUDA(
           has_random),
       device_(device) {
   // Initializes driver's API context (if necessary)
-  CUcontext pctx = 0;
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuCtxGetCurrent(&pctx));
+  hipCtx_t pctx = 0;
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipCtxGetCurrent(&pctx));
   if (!pctx) {
     std::unique_lock<std::mutex> cudaFreeMutexLock(
-        *(c10::cuda::CUDACachingAllocator::getFreeMutex()));
-    cudaFree(0);
+        *(c10::hip::HIPCachingAllocator::getFreeMutex()));
+    hipFree(0);
   }
 
   // Note: hacked at::DeviceGuard since at::DeviceGuard was failing to work
   // properly in some scenarios
-  const auto prior_device = at::cuda::current_device();
-  at::cuda::set_device(device_);
+  const auto prior_device = at::hip::current_device();
+  at::hip::set_device(device_);
 
   // Acquires device and NVRTC properties (for compile arch and occupancy
   // calculations)
@@ -104,8 +104,8 @@ FusedKernelCUDA::FusedKernelCUDA(
   getMajorMinor(prop_, major, minor);
 
   // Creates the NVRTC program
-  nvrtcProgram program;
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcCreateProgram(
+  hiprtcProgram program;
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcCreateProgram(
       &program, code_.c_str(), nullptr, 0, nullptr, nullptr));
 
 #ifdef __HIP_PLATFORM_HCC__
@@ -117,27 +117,27 @@ FusedKernelCUDA::FusedKernelCUDA(
       "--std=c++14", compute.c_str(), "-default-device"};
 #endif
   const auto result =
-      nvrtc().nvrtcCompileProgram(program, args.size(), args.data());
-  if (result != NVRTC_SUCCESS) {
+      nvrtc().hiprtcCompileProgram(program, args.size(), args.data());
+  if (result != HIPRTC_SUCCESS) {
     size_t logsize;
-    AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLogSize(program, &logsize));
+    AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcGetProgramLogSize(program, &logsize));
     std::vector<char> log(logsize);
-    AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLog(program, log.data()));
+    AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcGetProgramLog(program, log.data()));
     std::stringstream cu;
     cu << log.data();
     throw std::runtime_error(cu.str());
   }
   ResourceGuard holdProgram(
-      [&] { AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcDestroyProgram(&program)); });
+      [&] { AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcDestroyProgram(&program)); });
   AT_CUDA_NVRTC_CHECK(result);
   size_t ptx_size;
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetPTXSize(program, &ptx_size));
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcGetCodeSize(program, &ptx_size));
   ptx_.resize(ptx_size);
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetPTX(program, ptx_.data()));
+  AT_CUDA_NVRTC_CHECK(nvrtc().hiprtcGetCode(program, ptx_.data()));
 
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleLoadData(&module_, ptx_.data()));
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleLoadData(&module_, ptx_.data()));
   AT_CUDA_DRIVER_CHECK(
-      nvrtc().cuModuleGetFunction(&function_, module_, name_.c_str()));
+      nvrtc().hipModuleGetFunction(&function_, module_, name_.c_str()));
 
   // Computes max blocks
 #if defined(__HIP_PLATFORM_HCC__) && HIP_VERSION < 305
@@ -147,13 +147,13 @@ FusedKernelCUDA::FusedKernelCUDA(
       &max_blocks, function_, 128, 0));
   maxBlocks_ = max_blocks;
 #else
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuOccupancyMaxActiveBlocksPerMultiprocessor(
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleOccupancyMaxActiveBlocksPerMultiprocessor(
       &maxBlocks_, function_, 128, 0));
 #endif
   maxBlocks_ *= prop_->multiProcessorCount;
 
   // Resets device (end of hacked at::DeviceGuard)
-  at::cuda::set_device(prior_device);
+  at::hip::set_device(prior_device);
 }
 
 static int ceilDiv(const int a, const int b) {
@@ -163,10 +163,10 @@ static int ceilDiv(const int a, const int b) {
 void FusedKernelCUDA::launch_raw(
     const uint32_t numel,
     std::vector<void*>& arguments) const {
-  at::cuda::CUDAGuard{device_};
+  at::hip::HIPGuardMasqueradingAsCUDA{device_};
   // Hacked at::DeviceGuard (see note above)
-  const auto prior_device = at::cuda::current_device();
-  at::cuda::set_device(device_);
+  const auto prior_device = at::hip::current_device();
+  at::hip::set_device(device_);
 
   const auto nBlocks = std::min(maxBlocks_, ceilDiv(numel, kBlockSize));
 
@@ -190,8 +190,8 @@ void FusedKernelCUDA::launch_raw(
   }
 
   // Launches kernel on current stream (device was set by executor)
-  auto stream = at::cuda::getCurrentCUDAStream();
-  AT_CUDA_DRIVER_CHECK(nvrtc().cuLaunchKernel(
+  auto stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA();
+  AT_CUDA_DRIVER_CHECK(nvrtc().hipModuleLaunchKernel(
       function_,
       nBlocks,
       1,
@@ -205,11 +205,11 @@ void FusedKernelCUDA::launch_raw(
       nullptr));
 
   // Resets device (see at::DeviceGuard notes above)
-  at::cuda::set_device(prior_device);
+  at::hip::set_device(prior_device);
 }
 
 FusedKernelCUDA::~FusedKernelCUDA() {
-  nvrtc().cuModuleUnload(module_);
+  nvrtc().hipModuleUnload(module_);
 }
 
 static std::shared_ptr<FusedKernel> createFusionKernel(

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.h
@@ -4,9 +4,9 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/codegen/fuser/fused_kernel.h>
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <nvrtc.h>
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime.h>
+#include <hip/hiprtc.h>
 
 #include <cstdint>
 #include <string>
@@ -47,10 +47,10 @@ struct TORCH_CUDA_API FusedKernelCUDA
   //  Acquiring these values at launch time would be too slow
   int16_t device_;
   int maxBlocks_;
-  cudaDeviceProp* prop_;
+  hipDeviceProp_t* prop_;
   std::vector<char> ptx_;
-  CUmodule module_;
-  CUfunction function_;
+  hipModule_t module_;
+  hipFunction_t function_;
 };
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
@@ -62,8 +62,8 @@ struct TensorInfo<T, 0> {
 )");
 #endif
 
-// We rewrite the code for philox RNG from curand as nvrtc couldn't resolve the
-// curand header correctly.
+// We rewrite the code for philox RNG from hiprand as nvrtc couldn't resolve the
+// hiprand header correctly.
 constexpr auto rand_support_literal = R"(
 
   class Philox {
@@ -230,7 +230,7 @@ constexpr auto half_support_literal =
   };
 
   /* All intrinsic functions are only available to nvcc compilers */
-  #if defined(__CUDACC__)
+  #if defined(__HIPCC__)
     /* Definitions of intrinsics */
     __device__ __half __float2half(const float f) {
       __half val;
@@ -252,7 +252,7 @@ constexpr auto half_support_literal =
     // This workaround uses string-pasting to separate the " and the #endif into
     // different strings
     R"(
-  #endif /* defined(__CUDACC__) */
+  #endif /* defined(__HIPCC__) */
 #endif /* defined(__cplusplus) */
 #undef __HALF_TO_US
 #undef __HALF_TO_CUS

--- a/torch/csrc/jit/codegen/fuser/fused_kernel.h
+++ b/torch/csrc/jit/codegen/fuser/fused_kernel.h
@@ -37,7 +37,7 @@ struct FusedKernel {
   // arguments is a list of pointers to the arguments for the compiled CUDA/CPU
   // code.
   // The format of arguments is suitable for directly passing to a call to
-  // cuLaunchKernel as the kernel arguments.
+  // hipModuleLaunchKernel as the kernel arguments.
   // Currently the first argument is a pointer to numel (for passing to
   // CUDA code), and the remainder are pointers to the TensorInfo<T> structs
   // that compiled code uses to load Tensor data.

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -4,10 +4,10 @@
 #include <unordered_set>
 
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/nvrtc_stub/ATenNVRTC.h>
+#include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <torch/csrc/jit/resource_guard.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
@@ -95,14 +95,14 @@ class TORCH_CUDA_API CudaCodeGen : public CodeGen {
       : CodeGen(
             stmt,
             std::vector<BufferArg>({BufferArg(ts)...}),
-            at::Device(at::kCUDA, at::cuda::current_device())) {
+            at::Device(at::kCUDA, at::hip::current_device())) {
     Initialize();
   }
 
   CudaCodeGen(
       Stmt* stmt,
       const std::vector<BufferArg>& buffer_args,
-      at::Device device = at::Device(at::kCUDA, at::cuda::current_device()))
+      at::Device device = at::Device(at::kCUDA, at::hip::current_device()))
       : CodeGen(stmt, buffer_args, device) {
     Initialize();
   }
@@ -135,7 +135,7 @@ class TORCH_CUDA_API CudaCodeGen : public CodeGen {
   std::ostringstream oss_;
   std::unique_ptr<CudaPrinter> printer_;
   std::unique_ptr<CudaAnalysis> cuda_analysis_;
-  CUfunction function_;
+  hipFunction_t function_;
   bool has_random_ = false;
 
   std::string GetUniqueFuncName(const std::string& func_prefix);

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -9,9 +9,9 @@
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_compat.h>
 
-#ifdef USE_CUDA
-#include <THC/THC.h>
-#include <c10/cuda/CUDAStream.h>
+#ifdef USE_ROCM
+#include <THH/THH.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 #endif
 
 #define THPUtils_(NAME) TH_CONCAT_4(THP,Real,Utils_,NAME)
@@ -188,8 +188,8 @@ bool getBackCompatKeepdimWarn();
 bool maybeThrowBackCompatKeepdimWarn(char *func);
 
 // NB: This is in torch/csrc/cuda/utils.cpp, for whatever reason
-#ifdef USE_CUDA
-std::vector<c10::optional<at::cuda::CUDAStream>> THPUtils_PySequence_to_CUDAStreamList(PyObject *obj);
+#ifdef USE_ROCM
+std::vector<c10::optional<at::hip::HIPStreamMasqueradingAsCUDA>> THPUtils_PySequence_to_CUDAStreamList(PyObject *obj);
 #endif
 
 #endif

--- a/torch/csrc/utils/cuda_enabled.h
+++ b/torch/csrc/utils/cuda_enabled.h
@@ -4,7 +4,7 @@ namespace torch {
 namespace utils {
 
 static inline bool cuda_enabled() {
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   return true;
 #else
   return false;

--- a/torch/lib/c10d/NCCLUtils.hpp
+++ b/torch/lib/c10d/NCCLUtils.hpp
@@ -6,7 +6,7 @@
 #include <memory>
 #include <mutex>
 
-#include <nccl.h>
+#include <rccl.h>
 
 // Error checking is enabled only for NCCL versions 2.4+ since ncclCommAbort()
 // and ncclCommGetAsyncError() are not supported in earlier versions.

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -20,13 +20,13 @@
 
 #include <ATen/SparseTensorUtils.h>
 
-#ifdef USE_CUDA
-#include <ATen/cuda/CUDAEvent.h>
-#include <ATen/cuda/Exceptions.h>
-#include <ATen/cuda/PinnedMemoryAllocator.h>
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
+#ifdef USE_ROCM
+#include <ATen/hip/HIPEvent.h>
+#include <ATen/hip/Exceptions.h>
+#include <ATen/hip/PinnedMemoryAllocator.h>
+#include <ATen/hip/impl/HIPCachingAllocatorMasqueradingAsCUDA.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 #endif
 
 #include <c10/util/StringUtil.h>
@@ -218,7 +218,7 @@ void setOutput(O& opts, at::Tensor& tensor, std::vector<size_t>& counts) {
   opts.setOutput(getDataPointer<T>(tensor), counts);
 }
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 
 at::Tensor pinnedLike(at::Tensor& tensor) {
   auto* allocator = at::cuda::getPinnedMemoryAllocator();
@@ -239,19 +239,19 @@ at::Tensor pinnedLike(at::Tensor& tensor) {
 // on the tensors.
 void initializeStreamsEvents(
     std::vector<at::Tensor>& tensors,
-    std::vector<at::cuda::CUDAStream>& streams,
+    std::vector<at::hip::HIPStreamMasqueradingAsCUDA>& streams,
     std::vector<at::cuda::CUDAEvent>& events) {
-  at::cuda::OptionalCUDAGuard guard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
   streams.reserve(tensors.size());
   events.resize(tensors.size());
   for (size_t i = 0; i < tensors.size(); i++) {
     guard.set_index(tensors[i].device().index());
     // Record event on current stream
-    events[i].record(at::cuda::getCurrentCUDAStream());
+    events[i].record(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     // Get a non-default stream to execute asynchronous CUDA operations
     // on for this device. This ensures that the default stream used
     // by the caller is not occupied by c10d related operations.
-    streams.push_back(at::cuda::getStreamFromPool(
+    streams.push_back(at::hip::getStreamFromPoolMasqueradingAsCUDA(
         /* isHighPriority */ true, tensors[i].device().index()));
     // Ensure the new stream is synchronized with the current stream.
     events[i].block(streams[i]);
@@ -260,9 +260,9 @@ void initializeStreamsEvents(
     // new streams in this Work to prevent being freed before the Work finishes.
     if (tensors[i].is_sparse()) {
       if (tensors[i].is_coalesced()) {
-        c10::cuda::CUDACachingAllocator::recordStream(
+        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
             tensors[i].indices().storage().data_ptr(), streams[i]);
-        c10::cuda::CUDACachingAllocator::recordStream(
+        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
             tensors[i].values().storage().data_ptr(), streams[i]);
       } else {
         // We will need to coalesce first, which means new tensors will
@@ -270,7 +270,7 @@ void initializeStreamsEvents(
         // is no need to record them separately.
       }
     } else {
-      c10::cuda::CUDACachingAllocator::recordStream(
+      c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
           tensors[i].storage().data_ptr(), streams[i]);
     }
   }
@@ -282,7 +282,7 @@ void initializeStreamsEvents(
 // on the same device.
 void initializeStreamsEvents(
     std::vector<std::vector<at::Tensor>>& tensors,
-    std::vector<at::cuda::CUDAStream>& streams,
+    std::vector<at::hip::HIPStreamMasqueradingAsCUDA>& streams,
     std::vector<at::cuda::CUDAEvent>& events) {
   // Ensure that the tensors in the nested tensor vectors are on the same
   // device.
@@ -297,17 +297,17 @@ void initializeStreamsEvents(
     }
   }
 
-  at::cuda::OptionalCUDAGuard guard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
   streams.reserve(tensors.size());
   events.resize(tensors.size());
   for (size_t i = 0; i < tensors.size(); i++) {
     guard.set_index(tensors[i][0].device().index());
     // Record event on current stream
-    events[i].record(at::cuda::getCurrentCUDAStream());
+    events[i].record(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     // Get a non-default stream to execute asynchronous CUDA operations
     // on for this output. This ensures that the default stream used
     // by the caller is not occupied by c10d related operations.
-    streams.push_back(at::cuda::getStreamFromPool(
+    streams.push_back(at::hip::getStreamFromPoolMasqueradingAsCUDA(
         /* isHighPriority */ true, tensors[i][0].device().index()));
     // Ensure the new stream is synchronized with the current stream.
     events[i].block(streams[i]);
@@ -316,7 +316,7 @@ void initializeStreamsEvents(
       // `tensors` are created on a different stream. Hence, they must record
       // new streams in this Work to prevent being freed before the Work
       // finishes.
-      c10::cuda::CUDACachingAllocator::recordStream(
+      c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
           tensor.storage().data_ptr(), streams[i]);
     }
   }
@@ -651,7 +651,7 @@ class AsyncBroadcastWork : public ProcessGroupGloo::AsyncWork {
   }
 };
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 
 class AsyncBroadcastCUDAWork : public AsyncBroadcastWork {
  public:
@@ -666,7 +666,7 @@ class AsyncBroadcastCUDAWork : public AsyncBroadcastWork {
 
     // Create pinned host side tensors.
     tmp = pinnedLike(inputs[rootTensor]);
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
     if (context->rank == rootRank) {
       guard.reset_stream(streams[rootTensor]);
       tmp.copy_(inputs[rootTensor], /* non_blocking */ true);
@@ -674,12 +674,12 @@ class AsyncBroadcastCUDAWork : public AsyncBroadcastWork {
   }
 
   void run() override {
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
 
     // Synchronize with copy operation if applicable.
     if (context->rank == rootRank) {
       guard.reset_stream(streams[rootTensor]);
-      AT_CUDA_CHECK(cudaStreamSynchronize(streams[rootTensor]));
+      AT_CUDA_CHECK(hipStreamSynchronize(streams[rootTensor]));
     }
 
     // Run broadcast on host side tensors.
@@ -694,17 +694,17 @@ class AsyncBroadcastCUDAWork : public AsyncBroadcastWork {
   }
 
   void synchronize() override {
-    at::cuda::OptionalCUDAGuard guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
 
     // Synchronize with the copy back to CUDA tensors.
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.set_index(inputs[i].device().index());
-      events[i].block(at::cuda::getCurrentCUDAStream());
+      events[i].block(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     }
   }
 
   at::Tensor tmp;
-  std::vector<at::cuda::CUDAStream> streams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> streams;
   std::vector<at::cuda::CUDAEvent> events;
 };
 
@@ -727,7 +727,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::broadcast(
   const auto& device = inputs[0].device();
   switch (device.type()) {
     case at::kCPU:
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     case at::kCUDA:
 #endif
       break;
@@ -741,7 +741,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::broadcast(
   if (device.type() == at::kCPU) {
     work = std::make_shared<AsyncBroadcastWork>(
         std::move(context), inputs, opts.rootRank, opts.rootTensor, tag);
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   } else if (device.type() == at::kCUDA) {
     work = std::make_shared<AsyncBroadcastCUDAWork>(
         std::move(context), inputs, opts.rootRank, opts.rootTensor, tag);
@@ -1112,7 +1112,7 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
   }
 };
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 
 class AsyncAllreduceCUDAWork : public AsyncAllreduceWork {
  public:
@@ -1126,7 +1126,7 @@ class AsyncAllreduceCUDAWork : public AsyncAllreduceWork {
 
     // Kick off copy from CUDA tensors to pinned CPU tensors.
     tmp.reserve(inputs.size());
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.reset_stream(streams[i]);
       tmp.push_back(pinnedLike(inputs[i]).copy_(inputs[i], true));
@@ -1135,10 +1135,10 @@ class AsyncAllreduceCUDAWork : public AsyncAllreduceWork {
 
   void run() override {
     // Synchronize with copy operations.
-    at::cuda::OptionalCUDAGuard device_guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       device_guard.set_index(inputs[i].device().index());
-      AT_CUDA_CHECK(cudaStreamSynchronize(streams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(streams[i]));
     }
 
     // Run allreduce on host side tensors.
@@ -1149,7 +1149,7 @@ class AsyncAllreduceCUDAWork : public AsyncAllreduceWork {
     // See https://github.com/facebookincubator/gloo/issues/152.
     // The contents is the same for every entry in the tensor list, so
     // we can use the first entry as the source of the copy below.
-    at::cuda::OptionalCUDAStreamGuard stream_guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA stream_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       stream_guard.reset_stream(streams[i]);
       inputs[i].copy_(tmp[0], /* non_blocking */ true);
@@ -1159,15 +1159,15 @@ class AsyncAllreduceCUDAWork : public AsyncAllreduceWork {
 
   void synchronize() override {
     // Synchronize with the copy back to CUDA tensors.
-    at::cuda::OptionalCUDAGuard guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.set_index(inputs[i].device().index());
-      events[i].block(at::cuda::getCurrentCUDAStream());
+      events[i].block(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     }
   }
 
   std::vector<at::Tensor> tmp;
-  std::vector<at::cuda::CUDAStream> streams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> streams;
   std::vector<at::cuda::CUDAEvent> events;
 };
 
@@ -1184,7 +1184,7 @@ class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
     // Note that both coalescing the sparse tensor and copying it to CPU
     // memory must be performed asynchronously, or we block the caller.
     tmp.reserve(inputs.size());
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.reset_stream(streams[i]);
       tmp.push_back(
@@ -1194,17 +1194,17 @@ class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
 
   void run() override {
     // Synchronize with copy operations.
-    at::cuda::OptionalCUDAGuard device_guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       device_guard.set_index(inputs[i].device().index());
-      AT_CUDA_CHECK(cudaStreamSynchronize(streams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(streams[i]));
     }
 
     // Run allreduce on host side tensors.
     auto output = allreduce(tmp);
 
     // Kick off copy back to the CUDA tensors.
-    at::cuda::OptionalCUDAStreamGuard stream_guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA stream_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       stream_guard.reset_stream(streams[i]);
       outputs.push_back(output.to(inputs[i].device(), /*non_blocking=*/true));
@@ -1214,10 +1214,10 @@ class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
 
   void synchronize() override {
     // Synchronize with the copy back to CUDA tensors.
-    at::cuda::OptionalCUDAGuard guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.set_index(inputs[i].device().index());
-      events[i].block(at::cuda::getCurrentCUDAStream());
+      events[i].block(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     }
 
     // Copy outputs back to inputs after synchronization, so that users can
@@ -1228,7 +1228,7 @@ class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
   }
 
   std::vector<at::Tensor> tmp;
-  std::vector<at::cuda::CUDAStream> streams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> streams;
   std::vector<at::cuda::CUDAEvent> events;
 };
 
@@ -1250,7 +1250,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce(
   const auto& device = inputs[0].device();
   switch (device.type()) {
     case at::kCPU:
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     case at::kCUDA:
 #endif
       break;
@@ -1278,7 +1278,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce(
     } else {
       invalidArgument("unsupported layout");
     }
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   } else if (device.type() == at::kCUDA) {
     if (layout == c10::kStrided) {
       work = std::make_shared<AsyncAllreduceCUDAWork>(
@@ -1412,7 +1412,7 @@ class AsyncReduceWork : public ProcessGroupGloo::AsyncWork {
   }
 };
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 
 class AsyncReduceCUDAWork : public AsyncReduceWork {
  public:
@@ -1428,7 +1428,7 @@ class AsyncReduceCUDAWork : public AsyncReduceWork {
 
     // Kick off copy from CUDA tensors to pinned CPU tensors.
     tmp.reserve(inputs.size());
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.reset_stream(streams[i]);
       tmp.push_back(pinnedLike(inputs[i]).copy_(inputs[i], true));
@@ -1437,17 +1437,17 @@ class AsyncReduceCUDAWork : public AsyncReduceWork {
 
   void run() override {
     // Synchronize with copy operations.
-    at::cuda::OptionalCUDAGuard device_guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       device_guard.set_index(inputs[i].device().index());
-      AT_CUDA_CHECK(cudaStreamSynchronize(streams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(streams[i]));
     }
 
     // Run reduce on host side tensors.
     reduce(tmp);
 
     // Kick off copy back to the CUDA tensors.
-    at::cuda::OptionalCUDAStreamGuard stream_guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA stream_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       stream_guard.reset_stream(streams[i]);
       inputs[i].copy_(tmp[i], /* non_blocking */ true);
@@ -1457,15 +1457,15 @@ class AsyncReduceCUDAWork : public AsyncReduceWork {
 
   void synchronize() override {
     // Synchronize with the copy back to CUDA tensors.
-    at::cuda::OptionalCUDAGuard guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.set_index(inputs[i].device().index());
-      events[i].block(at::cuda::getCurrentCUDAStream());
+      events[i].block(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     }
   }
 
   std::vector<at::Tensor> tmp;
-  std::vector<at::cuda::CUDAStream> streams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> streams;
   std::vector<at::cuda::CUDAEvent> events;
 };
 
@@ -1488,7 +1488,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::reduce(
   const auto& device = inputs[0].device();
   switch (device.type()) {
     case at::kCPU:
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     case at::kCUDA:
 #endif
       break;
@@ -1507,7 +1507,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::reduce(
         opts.rootTensor,
         opts.reduceOp,
         tag);
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   } else if (device.type() == at::kCUDA) {
     work = std::make_shared<AsyncReduceCUDAWork>(
         std::move(context),
@@ -1571,7 +1571,7 @@ class AsyncAllgatherWork : public ProcessGroupGloo::AsyncWork {
   }
 };
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 
 // Note: current CUDA implementation holds the assumption that the
 // tensors in the nested output tensor vectors are on the same device.
@@ -1588,7 +1588,7 @@ class AsyncAllgatherCUDAWork : public AsyncAllgatherWork {
 
     // Kick off copy from CUDA tensors to pinned CPU tensors.
     tmpInputs.reserve(inputs.size());
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.reset_stream(inputStreams[i]);
       tmpInputs.push_back(pinnedLike(inputs[i]).copy_(inputs[i], true));
@@ -1605,22 +1605,22 @@ class AsyncAllgatherCUDAWork : public AsyncAllgatherWork {
 
   void run() override {
     // Synchronize with copy operations.
-    at::cuda::OptionalCUDAGuard device_guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       device_guard.set_index(inputs[i].device().index());
-      AT_CUDA_CHECK(cudaStreamSynchronize(inputStreams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(inputStreams[i]));
     }
 
     for (size_t i = 0; i < outputs.size(); i++) {
       device_guard.set_index(outputs[i][0].device().index());
-      AT_CUDA_CHECK(cudaStreamSynchronize(outputStreams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(outputStreams[i]));
     }
 
     // Run allgather on host side tensors.
     allgather(tmpOutputs, tmpInputs);
 
     // Kick off copy back to the CUDA tensors.
-    at::cuda::OptionalCUDAStreamGuard stream_guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA stream_guard;
     for (size_t i = 0; i < outputs.size(); i++) {
       stream_guard.reset_stream(outputStreams[i]);
       for (size_t j = 0; j < outputs[i].size(); j++) {
@@ -1632,19 +1632,19 @@ class AsyncAllgatherCUDAWork : public AsyncAllgatherWork {
 
   void synchronize() override {
     // Synchronize with the copy back to CUDA tensors.
-    at::cuda::OptionalCUDAGuard guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < outputs.size(); i++) {
       guard.set_index(outputs[i][0].device().index());
-      outputEvents[i].block(at::cuda::getCurrentCUDAStream());
+      outputEvents[i].block(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     }
   }
 
   std::vector<at::Tensor> tmpInputs;
-  std::vector<at::cuda::CUDAStream> inputStreams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> inputStreams;
   std::vector<at::cuda::CUDAEvent> inputEvents;
 
   std::vector<std::vector<at::Tensor>> tmpOutputs;
-  std::vector<at::cuda::CUDAStream> outputStreams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> outputStreams;
   std::vector<at::cuda::CUDAEvent> outputEvents;
 };
 
@@ -1695,7 +1695,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allgather(
   const auto& device = inputs[0].device();
   switch (device.type()) {
     case at::kCPU:
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     case at::kCUDA:
 #endif
       break;
@@ -1709,7 +1709,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::allgather(
   if (device.type() == at::kCPU) {
     work = std::make_shared<AsyncAllgatherWork>(
         std::move(context), outputs, inputs, tag);
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   } else if (device.type() == at::kCUDA) {
     work = std::make_shared<AsyncAllgatherCUDAWork>(
         std::move(context), outputs, inputs, tag);
@@ -1904,7 +1904,7 @@ class AsyncGatherWork : public ProcessGroupGloo::AsyncWork {
   }
 };
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 
 // Note: current CUDA implementation holds the assumptions:
 //     - inputs.size() is 1
@@ -1925,7 +1925,7 @@ class AsyncGatherCUDAWork : public AsyncGatherWork {
 
     // Kick off copy from CUDA tensors to pinned CPU tensors.
     tmpInputs.reserve(inputs.size());
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.reset_stream(inputStreams[i]);
       tmpInputs.push_back(pinnedLike(inputs[i]).copy_(inputs[i], true));
@@ -1942,22 +1942,22 @@ class AsyncGatherCUDAWork : public AsyncGatherWork {
 
   void run() override {
     // Synchronize with copy operations.
-    at::cuda::OptionalCUDAGuard device_guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       device_guard.set_index(inputs[i].get_device());
-      AT_CUDA_CHECK(cudaStreamSynchronize(inputStreams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(inputStreams[i]));
     }
 
     for (size_t i = 0; i < outputs.size(); i++) {
       device_guard.set_index(outputs[i][0].get_device());
-      AT_CUDA_CHECK(cudaStreamSynchronize(outputStreams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(outputStreams[i]));
     }
 
     // Run gather on host side tensors.
     gather(tmpOutputs, tmpInputs);
 
     // Kick off copy back to the CUDA tensors.
-    at::cuda::OptionalCUDAStreamGuard stream_guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA stream_guard;
     for (size_t i = 0; i < outputs.size(); i++) {
       stream_guard.reset_stream(outputStreams[i]);
       for (size_t j = 0; j < outputs[i].size(); j++) {
@@ -1969,19 +1969,19 @@ class AsyncGatherCUDAWork : public AsyncGatherWork {
 
   void synchronize() override {
     // Synchronize with the copy back to CUDA tensors.
-    at::cuda::OptionalCUDAGuard guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < outputs.size(); i++) {
       guard.set_index(static_cast<at::DeviceIndex>(outputs[i][0].get_device()));
-      outputEvents[i].block(at::cuda::getCurrentCUDAStream());
+      outputEvents[i].block(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     }
   }
 
   std::vector<at::Tensor> tmpInputs;
-  std::vector<at::cuda::CUDAStream> inputStreams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> inputStreams;
   std::vector<at::cuda::CUDAEvent> inputEvents;
 
   std::vector<std::vector<at::Tensor>> tmpOutputs;
-  std::vector<at::cuda::CUDAStream> outputStreams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> outputStreams;
   std::vector<at::cuda::CUDAEvent> outputEvents;
 };
 
@@ -2027,7 +2027,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::gather(
   const auto& device = inputs[0].device();
   switch (device.type()) {
     case at::kCPU:
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     case at::kCUDA:
 #endif
       break;
@@ -2041,7 +2041,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::gather(
   if (device.type() == at::kCPU) {
     work = std::make_shared<AsyncGatherWork>(
         std::move(context), outputs, inputs, opts.rootRank, tag);
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   } else if (device.type() == at::kCUDA) {
     work = std::make_shared<AsyncGatherCUDAWork>(
         std::move(context), outputs, inputs, opts.rootRank, tag);
@@ -2098,7 +2098,7 @@ class AsyncScatterWork : public ProcessGroupGloo::AsyncWork {
   }
 };
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 
 class AsyncScatterCUDAWork : public AsyncScatterWork {
  public:
@@ -2114,7 +2114,7 @@ class AsyncScatterCUDAWork : public AsyncScatterWork {
 
     // Kick off copy from CUDA tensors to pinned CPU tensors.
     tmpInputs.resize(inputs.size());
-    at::cuda::OptionalCUDAStreamGuard guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       guard.reset_stream(inputStreams[i]);
       tmpInputs[i].reserve(inputs[i].size());
@@ -2132,21 +2132,21 @@ class AsyncScatterCUDAWork : public AsyncScatterWork {
 
   void run() override {
     // Synchronize with copy operations.
-    at::cuda::OptionalCUDAGuard device_guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard;
     for (size_t i = 0; i < inputs.size(); i++) {
       device_guard.set_index(inputs[i][0].get_device());
-      AT_CUDA_CHECK(cudaStreamSynchronize(inputStreams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(inputStreams[i]));
     }
     for (size_t i = 0; i < outputs.size(); i++) {
       device_guard.set_index(outputs[i].get_device());
-      AT_CUDA_CHECK(cudaStreamSynchronize(outputStreams[i]));
+      AT_CUDA_CHECK(hipStreamSynchronize(outputStreams[i]));
     }
 
     // Run scatter on host side tensors.
     scatter(tmpOutputs, tmpInputs);
 
     // Kick off copy back to the CUDA tensors.
-    at::cuda::OptionalCUDAStreamGuard stream_guard;
+    at::hip::OptionalHIPStreamGuardMasqueradingAsCUDA stream_guard;
     for (size_t i = 0; i < outputs.size(); i++) {
       stream_guard.reset_stream(outputStreams[i]);
       outputs[i].copy_(tmpOutputs[i], /* non_blocking */ true);
@@ -2156,19 +2156,19 @@ class AsyncScatterCUDAWork : public AsyncScatterWork {
 
   void synchronize() override {
     // Synchronize with the copy back to CUDA tensors.
-    at::cuda::OptionalCUDAGuard guard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA guard;
     for (size_t i = 0; i < outputs.size(); i++) {
       guard.set_index(static_cast<at::DeviceIndex>(outputs[i].get_device()));
-      outputEvents[i].block(at::cuda::getCurrentCUDAStream());
+      outputEvents[i].block(at::hip::getCurrentHIPStreamMasqueradingAsCUDA());
     }
   }
 
   std::vector<at::Tensor> tmpOutputs;
-  std::vector<at::cuda::CUDAStream> outputStreams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> outputStreams;
   std::vector<at::cuda::CUDAEvent> outputEvents;
 
   std::vector<std::vector<at::Tensor>> tmpInputs;
-  std::vector<at::cuda::CUDAStream> inputStreams;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> inputStreams;
   std::vector<at::cuda::CUDAEvent> inputEvents;
 };
 
@@ -2213,7 +2213,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
   const auto& device = outputs[0].device();
   switch (device.type()) {
     case at::kCPU:
-#ifdef USE_CUDA
+#ifdef USE_ROCM
     case at::kCUDA:
 #endif
       break;
@@ -2227,7 +2227,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupGloo::scatter(
   if (device.type() == at::kCPU) {
     work = std::make_shared<AsyncScatterWork>(
         std::move(context), outputs, inputs, opts.rootRank, tag);
-#ifdef USE_CUDA
+#ifdef USE_ROCM
   } else if (device.type() == at::kCUDA) {
     work = std::make_shared<AsyncScatterCUDAWork>(
         std::move(context), outputs, inputs, opts.rootRank, tag);

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -15,9 +15,9 @@
 
 #include <torch/csrc/utils/hash.h>
 
-#ifdef USE_CUDA
-#include <ATen/cuda/CUDAEvent.h>
-#include <c10/cuda/CUDAStream.h>
+#ifdef USE_ROCM
+#include <ATen/hip/HIPEvent.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 #endif
 
 #include <c10d/ProcessGroup.hpp>

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -4,10 +4,10 @@
 #include <tuple>
 #include <unordered_set>
 
-#include <THC/THC.h>
+#include <THH/THH.h>
 
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 
 #include <c10d/Utils.hpp>
 
@@ -22,7 +22,7 @@ namespace {
 // manages group and lock lifetimes.
 struct AutoNcclGroup {
   AutoNcclGroup() {
-    (c10::cuda::CUDACachingAllocator::getFreeMutex())->lock();
+    (c10::hip::HIPCachingAllocator::getFreeMutex())->lock();
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
     C10D_NCCL_CHECK(ncclGroupStart());
 #endif
@@ -31,7 +31,7 @@ struct AutoNcclGroup {
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
     C10D_NCCL_CHECK(ncclGroupEnd());
 #endif
-    (c10::cuda::CUDACachingAllocator::getFreeMutex())->unlock();
+    (c10::hip::HIPCachingAllocator::getFreeMutex())->unlock();
   }
 };
 
@@ -95,18 +95,18 @@ std::vector<at::Device> getDeviceList(const std::vector<at::Tensor>& tensors) {
 //
 // The synchronization above alone is not enough. We also need to make sure
 // input tensors are not freed before their usages on ncclStreams finish. This
-// can be achieved by calling c10::cuda::CUDACachingAllocator::recordStream,
+// can be achieved by calling c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA,
 // which remembers the usage stream (ncclStream), creates an event on the usage
 // stream when GC attempts to free the input tensor, and delays GC until that
 // event is done.
 void syncStreams(
     const std::vector<at::Device>& devices,
     std::vector<at::cuda::CUDAEvent>& ncclEvents,
-    std::vector<at::cuda::CUDAStream>& ncclStreams) {
+    std::vector<at::hip::HIPStreamMasqueradingAsCUDA>& ncclStreams) {
   for (size_t i = 0; i < devices.size(); ++i) {
-    at::cuda::CUDAStream& ncclStream = ncclStreams[i];
+    at::hip::HIPStreamMasqueradingAsCUDA& ncclStream = ncclStreams[i];
     at::cuda::CUDAEvent& ncclEvent = ncclEvents[i];
-    ncclEvent.record(at::cuda::getCurrentCUDAStream(devices[i].index()));
+    ncclEvent.record(at::hip::getCurrentHIPStreamMasqueradingAsCUDA(devices[i].index()));
     ncclEvent.block(ncclStream);
   }
 }
@@ -137,7 +137,7 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(const std::vector<at::Device>& devices)
     : devices_(devices), workStartTime_(std::chrono::steady_clock::now()) {
   // Creates the CUDA event wrappers
   // Note: The actual events are lazily created when first recorded to with
-  // DEFAULT_FLAGS = cudaEventDisableTiming.
+  // DEFAULT_FLAGS = hipEventDisableTiming.
   cudaEvents_.resize(devices.size());
   ncclComms_.resize(devices.size());
 }
@@ -178,11 +178,11 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecution() {
 bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
   for (size_t i = 0; i < devices_.size(); ++i) {
     // Checking the work's corresponding CUDA events' status
-    auto ret = cudaEventQuery(cudaEvents_[i]);
-    if (ret != cudaSuccess && ret != cudaErrorNotReady) {
+    auto ret = hipEventQuery(cudaEvents_[i]);
+    if (ret != hipSuccess && ret != hipErrorNotReady) {
       AT_CUDA_CHECK(ret);
     }
-    if (ret == cudaErrorNotReady) {
+    if (ret == hipErrorNotReady) {
       return false;
     }
   }
@@ -202,13 +202,13 @@ void ProcessGroupNCCL::WorkNCCL::checkAndThrowException() {
 // Waiting on the work's corresponding CUDA events
 void ProcessGroupNCCL::WorkNCCL::synchronize() {
   for (size_t i = 0; i < devices_.size(); ++i) {
-    auto currentStream = at::cuda::getCurrentCUDAStream(devices_[i].index());
+    auto currentStream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA(devices_[i].index());
     // Block the current stream on the NCCL stream
     cudaEvents_[i].block(currentStream);
     // If we use the work to do barrier, we should block here
     if (!barrierTensors_.empty()) {
-      at::cuda::CUDAGuard gpuGuard(devices_[i]);
-      AT_CUDA_CHECK(cudaDeviceSynchronize());
+      at::hip::HIPGuardMasqueradingAsCUDA gpuGuard(devices_[i]);
+      AT_CUDA_CHECK(hipDeviceSynchronize());
     }
   }
 
@@ -491,9 +491,9 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
   // Broadcast so that each process can have a unique NCCL ID
   broadcastUniqueNCCLID(&ncclID);
 
-  at::cuda::OptionalCUDAGuard gpuGuard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA gpuGuard;
 
-  std::vector<at::cuda::CUDAStream> streamVal;
+  std::vector<at::hip::HIPStreamMasqueradingAsCUDA> streamVal;
   streamVal.reserve(devices.size());
 
   // Create the NCCL communicators for each GPU
@@ -508,16 +508,16 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     ncclComms[i] = NCCLComm::create(numRanks, rank, ncclID);
 
     // Creates the NCCL streams
-    streamVal.push_back(at::cuda::getStreamFromPool());
+    streamVal.push_back(at::hip::getStreamFromPoolMasqueradingAsCUDA());
   }
 
   C10D_NCCL_CHECK(ncclGroupEnd());
 
   ncclStreams_.emplace(devicesKey, std::move(streamVal));
 
-  // Note: these events are created with the (default) cudaEventDisableTiming
+  // Note: these events are created with the (default) hipEventDisableTiming
   // flag This flag provides the best performance when used with
-  // cudaStreamWaitEvent() and cudaEventQuery(). Since we here don't measure the
+  // hipStreamWaitEvent() and hipEventQuery(). Since we here don't measure the
   // performance using cudaEvent, this should be set.
   ncclEvents_.emplace(
       std::piecewise_construct,
@@ -640,13 +640,13 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
   // Work itself will create the CUDA events on all GPUs of tensors
   auto work = initWork(devices);
 
-  at::cuda::OptionalCUDAGuard gpuGuard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA gpuGuard;
 
   pre(ncclStreams_[key]);
 
   for (size_t i = 0; i < inputs.size(); ++i) {
     gpuGuard.set_index(devices[i].index());
-    at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
+    at::hip::HIPStreamMasqueradingAsCUDA& ncclStream = ncclStreams_[key][i];
 
     // Both `inputs' and `outputs' are created on a worker stream and used in
     // different ncclStreams.  Hence, both must record the ncclStream to
@@ -656,7 +656,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
     // operations where `inputs' and `outputs' are not the same.
     //
     // See [Sync Streams].
-    c10::cuda::CUDACachingAllocator::recordStream(
+    c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
         inputs[i].storage().data_ptr(), ncclStream);
   }
 
@@ -664,7 +664,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
     AutoNcclGroup nccl_group_guard;
     for (size_t i = 0; i < inputs.size(); ++i) {
       gpuGuard.set_index(devices[i].index());
-      at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
+      at::hip::HIPStreamMasqueradingAsCUDA& ncclStream = ncclStreams_[key][i];
       C10D_NCCL_CHECK(
           fn(inputs[i], outputs[i], ncclComms[i]->getNcclComm(), ncclStream));
     }
@@ -674,7 +674,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
 
   // Event should only be recorded after the ncclGroupEnd()
   for (size_t i = 0; i < inputs.size(); ++i) {
-    at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
+    at::hip::HIPStreamMasqueradingAsCUDA& ncclStream = ncclStreams_[key][i];
     work->cudaEvents_[i].record(ncclStream);
     work->ncclComms_[i] = ncclComms[i];
     work->blockingWait_ = blockingWait_;
@@ -694,8 +694,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
       inputs,
       outputs,
       fn,
-      [](std::vector<at::cuda::CUDAStream>&) {},
-      [](std::vector<at::cuda::CUDAStream>&) {});
+      [](std::vector<at::hip::HIPStreamMasqueradingAsCUDA>&) {},
+      [](std::vector<at::hip::HIPStreamMasqueradingAsCUDA>&) {});
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
@@ -709,7 +709,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
       [&](at::Tensor& input,
           at::Tensor& output,
           ncclComm_t comm,
-          at::cuda::CUDAStream& stream) {
+          at::hip::HIPStreamMasqueradingAsCUDA& stream) {
         return ncclAllReduce(
             input.data_ptr(),
             output.data_ptr(),
@@ -739,7 +739,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
       [&](at::Tensor& input,
           at::Tensor& output,
           ncclComm_t comm,
-          at::cuda::CUDAStream& stream) {
+          at::hip::HIPStreamMasqueradingAsCUDA& stream) {
         const auto root = opts.rootRank * tensors.size() + opts.rootTensor;
         return ncclBcast(
             input.data_ptr(),
@@ -762,7 +762,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce(
       [&](at::Tensor& input,
           at::Tensor& output,
           ncclComm_t comm,
-          at::cuda::CUDAStream& stream) {
+          at::hip::HIPStreamMasqueradingAsCUDA& stream) {
         const auto root = opts.rootRank * tensors.size() + opts.rootTensor;
         return ncclReduce(
             input.data_ptr(),
@@ -792,8 +792,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
       [&](at::Tensor& input,
           at::Tensor& output,
           ncclComm_t comm,
-          at::cuda::CUDAStream& stream) {
-        c10::cuda::CUDACachingAllocator::recordStream(
+          at::hip::HIPStreamMasqueradingAsCUDA& stream) {
+        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
             output.storage().data_ptr(), stream);
         return ncclAllGather(
             input.data_ptr(),
@@ -803,14 +803,14 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
             comm,
             stream.stream());
       },
-      [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {},
-      [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {
+      [&](std::vector<at::hip::HIPStreamMasqueradingAsCUDA>& ncclStreams) {},
+      [&](std::vector<at::hip::HIPStreamMasqueradingAsCUDA>& ncclStreams) {
         // Copy the flattened output tensors to the outputs.
         for (size_t i = 0; i < outputTensors.size(); ++i) {
-          at::cuda::CUDAStreamGuard guard(ncclStreams[i]);
+          at::hip::HIPStreamGuardMasqueradingAsCUDA guard(ncclStreams[i]);
           for (size_t j = 0; j < outputTensors[0].size(); ++j) {
             // See [Sync Streams].
-            c10::cuda::CUDACachingAllocator::recordStream(
+            c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
                 outputTensors[i][j].storage().data_ptr(), ncclStreams[i]);
 
             outputTensors[i][j].copy_(outputFlattened[i][j], true);
@@ -843,8 +843,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
       [&](at::Tensor& input,
           at::Tensor& output,
           ncclComm_t comm,
-          at::cuda::CUDAStream& stream) {
-        c10::cuda::CUDACachingAllocator::recordStream(
+          at::hip::HIPStreamMasqueradingAsCUDA& stream) {
+        c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
             output.storage().data_ptr(), stream);
         return ncclReduceScatter(
             input.data_ptr(),
@@ -855,20 +855,20 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
             comm,
             stream.stream());
       },
-      [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {
+      [&](std::vector<at::hip::HIPStreamMasqueradingAsCUDA>& ncclStreams) {
         // Copy the input tensors to the flattened inputs.
         for (size_t i = 0; i < inputTensors.size(); ++i) {
-          at::cuda::CUDAStreamGuard guard(ncclStreams[i]);
+          at::hip::HIPStreamGuardMasqueradingAsCUDA guard(ncclStreams[i]);
           for (size_t j = 0; j < inputTensors[0].size(); ++j) {
             // See [Sync Streams].
-            c10::cuda::CUDACachingAllocator::recordStream(
+            c10::hip::HIPCachingAllocatorMasqueradingAsCUDA::recordStreamMasqueradingAsCUDA(
                 inputTensors[i][j].storage().data_ptr(), ncclStreams[i]);
 
             inputFlattened[i][j].copy_(inputTensors[i][j], true);
           }
         }
       },
-      [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {});
+      [&](std::vector<at::hip::HIPStreamMasqueradingAsCUDA>& ncclStreams) {});
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier(
@@ -892,7 +892,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier(
   std::vector<at::Tensor> barrierTensors;
   barrierTensors.reserve(devices.size());
 
-  at::cuda::OptionalCUDAGuard gpuGuard;
+  at::hip::OptionalHIPGuardMasqueradingAsCUDA gpuGuard;
   for (auto& device : devices) {
     gpuGuard.set_index(device.index());
     barrierTensors.push_back(at::empty(

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -8,8 +8,8 @@
 #include <c10d/ProcessGroup.hpp>
 #include <c10d/Store.hpp>
 
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/CUDAEvent.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/HIPEvent.h>
 
 namespace c10d {
 
@@ -250,8 +250,8 @@ class ProcessGroupNCCL : public ProcessGroup {
   // primitives.  The callbacks have the following signatures:
   //
   //    ncclResult_t fn(at::Tensor& input, at::Tensor& output,
-  //                    ncclComm_t, at::cuda::CUDAStream&);
-  //    void {pre,post}(std::vector<at::cuda::CUDAStream&>);
+  //                    ncclComm_t, at::hip::HIPStreamMasqueradingAsCUDA&);
+  //    void {pre,post}(std::vector<at::hip::HIPStreamMasqueradingAsCUDA&>);
   template <typename Fn>
   std::shared_ptr<ProcessGroup::Work> collective(
       std::vector<at::Tensor>& input,
@@ -336,7 +336,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   std::mutex watchdogCVMutex_;
 
   // The CUDA steams used by NCCL kernels
-  std::unordered_map<std::string, std::vector<at::cuda::CUDAStream>>
+  std::unordered_map<std::string, std::vector<at::hip::HIPStreamMasqueradingAsCUDA>>
       ncclStreams_;
 
   // The CUDA events used to sync NCCL streams

--- a/torch/lib/c10d/test/CUDATest.cu
+++ b/torch/lib/c10d/test/CUDATest.cu
@@ -1,5 +1,6 @@
+#include "hip/hip_runtime.h"
 #include <c10d/test/CUDATest.hpp>
-#include <ATen/cuda/Exceptions.h>
+#include <ATen/hip/Exceptions.h>
 
 namespace c10d {
 namespace test {
@@ -15,13 +16,13 @@ __global__ void waitClocks(const uint64_t count) {
 
 } // namespace
 
-void cudaSleep(at::cuda::CUDAStream& stream, uint64_t clocks) {
-  waitClocks<<<1, 1, 0, stream.stream()>>>(clocks);
+void cudaSleep(at::hip::HIPStreamMasqueradingAsCUDA& stream, uint64_t clocks) {
+ hipLaunchKernelGGL( waitClocks, dim3(1), dim3(1), 0, stream.stream(), clocks);
 }
 
 int cudaNumDevices() {
   int n = 0;
-  AT_CUDA_CHECK(cudaGetDeviceCount(&n));
+  AT_CUDA_CHECK(hipGetDeviceCount(&n));
   return n;
 }
 

--- a/torch/lib/c10d/test/CUDATest.hpp
+++ b/torch/lib/c10d/test/CUDATest.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <c10/cuda/CUDAStream.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
 
 namespace c10d {
 namespace test {
 
-void cudaSleep(at::cuda::CUDAStream& stream, uint64_t clocks);
+void cudaSleep(at::hip::HIPStreamMasqueradingAsCUDA& stream, uint64_t clocks);
 
 int cudaNumDevices();
 

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -410,7 +410,7 @@ TEST(ProcessGroupGlooTest, testRecv) {
   }
 }
 
-#ifdef USE_CUDA
+#ifdef USE_ROCM
 // CUDA-only tests
 TEST(ProcessGroupGlooTest, testAllReduceCUDA) {
   {

--- a/torch/lib/c10d/test/ProcessGroupNCCLErrorsTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLErrorsTest.cpp
@@ -142,7 +142,7 @@ class ProcessGroupNCCLErrorsTest : public ::testing::Test {
     TemporaryFile file;
     store_ = std::make_shared<::c10d::FileStore>(file.path, 1);
 
-    at::cuda::OptionalCUDAGuard deviceGuard;
+    at::hip::OptionalHIPGuardMasqueradingAsCUDA deviceGuard;
     tensors_.resize(numDevices);
     for (auto i = 0; i < numDevices; ++i) {
       deviceGuard.set_index(i);


### PR DESCRIPTION
Before this PR, DLPack export was tricked by the CUDA masquerading of the HIP backend into thinking that it was exporting a CUDA tensor. We change that to use the ROCM device type instead.

I haven't found a way to get CMake to build the tests in aten/src/ATen/test/hip. If you have a hint, I could see to add a test of a roundtrip. (I currently test in Python by passing to TVM and round-tripping.)