### PR TITLE
[RELAND] Change AccumulateGrad to yield `.grad`s that match weights' memory layout

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -54,6 +54,58 @@ Locally disabling gradient computation
 
 .. autoclass:: set_grad_enabled
 
+.. _default-grad-layouts:
+
+Default gradient layouts
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a non-sparse ``param`` receives a non-sparse gradient during
+:func:`torch.autograd.backward` or :func:`torch.Tensor.backward`
+``param.grad`` is accumulated as follows.
+
+If ``param.grad`` is initially ``None``:
+
+1. If ``param``'s memory is non-overlapping and dense, ``.grad`` is
+   created with strides matching ``param`` (thus matching ``param``'s
+   layout).
+2. Otherwise, ``.grad`` is created with rowmajor-contiguous strides.
+
+If ``param`` already has a non-sparse ``.grad`` attribute:
+
+3. If ``create_graph=False``, ``backward()`` accumulates into ``.grad``
+   in-place, which preserves its strides.
+4. If ``create_graph=True``, ``backward()`` replaces ``.grad`` with a
+   new tensor ``.grad + new grad``, which attempts (but does not guarantee)
+   matching the preexisting ``.grad``'s strides.
+
+The default behavior (letting ``.grad``\ s be ``None`` before the first
+``backward()``, such that their layout is created according to 1. or 2.,
+and retained over time according to 3. or 4) is recommended for best performance.
+Calls to ``model.zero_grad()`` or ``optimizer.zero_grad()`` will not affect ``.grad``
+layouts.
+
+In fact, resetting all ``.grad``\ s to ``None`` before each
+accumulation phase, e.g.::
+
+    for iterations...
+        ...
+        for param in model.parameters():
+            param.grad = None
+        loss.backward()
+
+such that they're recreated according to 1. or 2. every time,
+is a valid alternative to ``model.zero_grad()`` or ``optimizer.zero_grad()``
+that may improve performance for some networks.
+
+Manual gradient layouts
+-----------------------
+
+If you need manual control over ``.grad``'s strides,
+assign ``param.grad =`` a zeroed tensor with desired strides
+before the first ``backward()``, and never reset it to ``None``.
+3. guarantees your layout is preserved as long as ``create_graph=False``.
+4. indicates your layout is *likely* preserved even if ``create_graph=True``.
+
 In-place operations on Tensors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -13,7 +13,7 @@ import unittest
 from datetime import timedelta
 from sys import platform
 
-from itertools import groupby
+from itertools import groupby, product
 from functools import reduce
 import operator
 
@@ -1367,7 +1367,6 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                                     "Invalid function argument.*output_tensor_lists"):
             c10d.all_gather_coalesced(dummy_output_lists, dummy_input, pg)
 
-
     def test_reduce_checks(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
@@ -1888,6 +1887,24 @@ class QuadraGpuNet(nn.Module):
         return F.softmax(x, dim=1).to(dev0)
 
 
+class ConvNet(nn.Module):
+    def __init__(self, gpus, layouts, dtypes):
+        super(ConvNet, self).__init__()
+        self.gpus = gpus
+        self.dtypes = dtypes
+        self.conv0 = torch.nn.Conv2d(8, 16, (2, 2)).to(device=gpus[0], memory_format=layouts[0], dtype=dtypes[0])
+        self.conv1 = torch.nn.Conv2d(16, 32, (2, 2)).to(device=gpus[1], memory_format=layouts[1], dtype=dtypes[1])
+        self.conv2 = torch.nn.Conv2d(32, 16, (2, 2)).to(device=gpus[2], memory_format=layouts[2], dtype=dtypes[2])
+        self.conv3 = torch.nn.Conv2d(16, 8, (2, 2)).to(device=gpus[3], memory_format=layouts[3], dtype=dtypes[3])
+
+    def forward(self, x):
+        x = x.to(self.dtypes[0])
+        x = self.conv0(x).to(device=self.gpus[1], dtype=self.dtypes[1])
+        x = self.conv1(x).to(device=self.gpus[2], dtype=self.dtypes[2])
+        x = self.conv2(x).to(device=self.gpus[3], dtype=self.dtypes[3])
+        return self.conv3(x)
+
+
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class DistributedDataParallelTest(MultiProcessTestCase):
     def setUp(self):
@@ -2342,7 +2359,6 @@ class DistributedDataParallelTest(MultiProcessTestCase):
             self.assertIsNotNone(t1_p.grad)
             self.assertIsNone(task_unused_p.grad)
 
-
         store = c10d.FileStore(self.file_name, self.world_size)
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
 
@@ -2552,15 +2568,15 @@ class DistributedDataParallelTest(MultiProcessTestCase):
                 # Skip gradients sync without calling prepare_for_backward
                 step_model(
                     ddp_model.module,
-                    input[self.rank : (self.rank + 1)],
-                    target[self.rank : (self.rank + 1)])
+                    input[self.rank:(self.rank + 1)],
+                    target[self.rank:(self.rank + 1)])
                 for i, j in zip(model.parameters(), ddp_model.parameters()):
                     self.assertNotEqual(i.grad, j.grad)
             else:
                 step_model(
                     ddp_model,
-                    input[self.rank : (self.rank + 1)],
-                    target[self.rank : (self.rank + 1)])
+                    input[self.rank:(self.rank + 1)],
+                    target[self.rank:(self.rank + 1)])
                 for i, j in zip(model.parameters(), ddp_model.parameters()):
                     # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
                     self.assertEqualIgnoreType(i.grad, j.grad)
@@ -2762,6 +2778,130 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         ddp_parameter = next(ddp_model.parameters())
         self.assertEqual(vanilla_parameter.grad, ddp_parameter.grad)
 
+    def _test_grad_layout(self, replica_devices, layer_devs, local_batch_size):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        global_batch_size = local_batch_size * self.world_size
+
+        # Carry out some trials with small buckets and some with big buckets.
+        bucketsizes = (0.000001, 25)
+        # Tuples of lists.  Each list describes per-layer characteristics for one trial.
+        layer_formats = ([torch.contiguous_format] * 4,
+                         [torch.channels_last] * 2 + [torch.contiguous_format] * 2,
+                         [torch.channels_last] * 4)
+        layer_dtypes = ([torch.float] * 4,
+                        [torch.float] * 2 + [torch.half] * 2,
+                        [torch.half] * 4)
+
+        input = torch.randn(global_batch_size, 8, 8, 8).to(layer_devs[0])
+        target = torch.randn(global_batch_size, 8, 4, 4).to(layer_devs[-1])
+        local_batch_start = self.rank * local_batch_size
+        local_batch_end = (self.rank + 1) * local_batch_size
+
+        with torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False):
+            for formats, dtypes, bucketsize in product(layer_formats, layer_dtypes, bucketsizes):
+                model_msg = "rank = {} formats = {} dtypes = {} bucketsize = {} ".format(self.rank, formats,
+                                                                                         dtypes, bucketsize)
+                try:
+                    m = ConvNet(layer_devs, formats, dtypes)
+                    m_ddp = DistributedDataParallel(copy.deepcopy(m),
+                                                    device_ids=replica_devices,
+                                                    process_group=process_group,
+                                                    bucket_cap_mb=bucketsize)
+                    has_half = any(p.dtype is torch.half for p in m.parameters())
+                    tol = 1.e-3 if has_half else 1.e-5
+                except BaseException:
+                    # Prints case-specific debugging info to narrow down failing case.
+                    print("Caught exception during model creation for " + model_msg)
+                    raise
+                # 3 iters:  First iter creates grads, second iter retests after rebucketing,
+                # third iter tries zeroed grads.
+                for it in range(3):
+                    iter_msg = "iter = {} ".format(it) + model_msg
+                    try:
+                        F.mse_loss(m(input).float(), target).backward()
+                        F.mse_loss(m_ddp(input[local_batch_start: local_batch_end]).float(),
+                                   target[local_batch_start: local_batch_end]).backward()
+                        for i, ((layer_name, m_child), m_ddp_child) in enumerate(zip(m.named_children(),
+                                                                                     m_ddp.module.children())):
+                            named_msg = layer_name + ".weight" + " " + iter_msg
+                            self.assertTrue(m_child.weight.grad.is_contiguous(memory_format=formats[i]), named_msg)
+                            self.assertTrue(m_ddp_child.weight.grad.is_contiguous(memory_format=formats[i]), named_msg)
+                            for j, ((param_name, p), p_ddp) in enumerate(zip(m_child.named_parameters(),
+                                                                             m_ddp_child.parameters())):
+                                named_msg = layer_name + "." + param_name + " " + iter_msg
+                                self.assertEqual(p.grad, p_ddp.grad, msg=named_msg, rtol=tol, atol=tol)
+                                if it == 0:
+                                    p.grad = None
+                                    p_ddp.grad = None
+                                else:
+                                    m.zero_grad()
+                                    m_ddp.zero_grad()
+                    except BaseException:
+                        # Makes sure we still get info if an error occurred somewhere other than the asserts.
+                        print("Caught exception during iterations at " + iter_msg)
+                        raise
+
+    @requires_nccl()
+    @skip_if_not_multigpu
+    @skip_if_rocm
+    def test_grad_layout_1devicemodule_1replicaperprocess(self):
+        dev0 = torch.device("cuda:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
+        # Tells DDP to use just one device.
+        replica_devices = [dev0]
+        # Tells _test_grad_layout to construct ConvNet with all layers on this process's first assigned device.
+        layer_devs = [dev0] * 4
+        local_batch_size = 8
+        self._test_grad_layout(replica_devices, layer_devs, local_batch_size)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(4)
+    @skip_if_rocm
+    def test_grad_layout_1devicemodule_2replicaperprocess(self):
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
+        dev0 = torch.device("cuda:" + str(int_devices[0]))
+        dev1 = torch.device("cuda:" + str(int_devices[1]))
+        # Tells DDP to replicate the model to both of this process's devices.
+        replica_devices = [dev0, dev1]
+        # Tells _test_grad_layout to construct ConvNet with all layers on this process's first assigned device.
+        layer_devs = [dev0] * 4
+        local_batch_size = 16
+        self._test_grad_layout(replica_devices, layer_devs, local_batch_size)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(4)
+    @skip_if_rocm
+    def test_grad_layout_2devicemodule(self):
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
+        dev0 = torch.device("cuda:" + str(int_devices[0]))
+        dev1 = torch.device("cuda:" + str(int_devices[1]))
+        # DDP's default behavior for a multi-device module is "don't replicate."
+        replica_devices = None
+        # Tells _test_grad_layout to constructs this process's ConvNet on 2 devices, with 2 layers on each device.
+        layer_devs = [dev0] * 2 + [dev1] * 2
+        local_batch_size = 8
+        self._test_grad_layout(replica_devices, layer_devs, local_batch_size)
+
+    @requires_nccl()
+    @skip_if_not_multigpu
+    @skip_if_rocm
+    def test_layout_mismatch_error(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        dev0 = torch.device("cuda:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
+        layer_devs = [dev0] * 4
+        layer_formats = [torch.contiguous_format] * 4 if self.rank == 0 else [torch.channels_last] * 4
+        layer_dtypes = [torch.float] * 4
+
+        m = ConvNet(layer_devs, layer_formats, layer_dtypes)
+        if self.rank == 0:
+            m_ddp = DistributedDataParallel(m, device_ids=[dev0], process_group=process_group)
+        else:
+            with self.assertRaisesRegex(RuntimeError, ".* appears not to match strides of the same param in process 0"):
+                m_ddp = DistributedDataParallel(m, device_ids=[dev0], process_group=process_group)
+
 
 class ReducerModule(nn.Module):
     def __init__(self):
@@ -2943,6 +3083,7 @@ class ComputeBucketAssignmentTest(TestCase):
         result = dist._compute_bucket_assignment_by_size(tensors, [200, 400])
         self.assertEqual([[0], [1], [2, 4], [3, 5]], result)
 
+
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class NcclErrorHandlingTest(MultiProcessTestCase):
     def setUp(self):
@@ -3028,31 +3169,31 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
     @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_lt_x_gpu(3)
     def test_nccl_errors_blocking_clean_exit(self):
-        self._test_nccl_errors_blocking(lambda : sys.exit(0))
+        self._test_nccl_errors_blocking(lambda: sys.exit(0))
 
     @requires_nccl()
     @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_lt_x_gpu(3)
     def test_nccl_errors_blocking_nonzero_exit(self):
-        self._test_nccl_errors_blocking(lambda : sys.exit(1))
+        self._test_nccl_errors_blocking(lambda: sys.exit(1))
 
     @requires_nccl()
     @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_lt_x_gpu(3)
     def test_nccl_errors_blocking_abort(self):
-        self._test_nccl_errors_blocking(lambda : os.abort())
+        self._test_nccl_errors_blocking(lambda: os.abort())
 
     @requires_nccl()
     @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_lt_x_gpu(3)
     def test_nccl_errors_blocking_sigkill(self):
-        self._test_nccl_errors_blocking(lambda : os.kill(os.getpid(), signal.SIGKILL))
+        self._test_nccl_errors_blocking(lambda: os.kill(os.getpid(), signal.SIGKILL))
 
     @requires_nccl()
     @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_lt_x_gpu(3)
     def test_nccl_errors_blocking_sigterm(self):
-        self._test_nccl_errors_blocking(lambda : os.kill(os.getpid(), signal.SIGTERM))
+        self._test_nccl_errors_blocking(lambda: os.kill(os.getpid(), signal.SIGTERM))
 
     def _run_invalid_nccl_blocking_wait_env(self, val):
         os.environ["NCCL_BLOCKING_WAIT"] = val

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -3,6 +3,7 @@ import io
 import unittest
 from copy import deepcopy
 from collections import OrderedDict
+from itertools import product
 
 import torch
 from torch import nn
@@ -15,6 +16,7 @@ from torch.testing._internal.common_utils import skipIfRocm
 import torch.nn.functional as F
 
 torch.set_default_dtype(torch.double)
+
 
 class TestDataParallel(TestCase):
 
@@ -680,6 +682,69 @@ class TestDataParallel(TestCase):
         torch.save(dpm, data)
         dpm = torch.nn.parallel.replicate(module, devices=[0, 1], detach=True)
         torch.save(dpm, data)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    def test_strided_grad_layout(self):
+        class ConvNet(nn.Module):
+            def __init__(self, layouts, dtypes):
+                super(ConvNet, self).__init__()
+                self.dtypes = dtypes
+                self.conv0 = torch.nn.Conv2d(8, 16, (2, 2)).to(memory_format=layouts[0], dtype=dtypes[0])
+                self.conv1 = torch.nn.Conv2d(16, 32, (2, 2)).to(memory_format=layouts[1], dtype=dtypes[1])
+                self.conv2 = torch.nn.Conv2d(32, 16, (2, 2)).to(memory_format=layouts[2], dtype=dtypes[2])
+                self.conv3 = torch.nn.Conv2d(16, 8, (2, 2)).to(memory_format=layouts[3], dtype=dtypes[3])
+
+            def forward(self, x):
+                x = x.to(self.dtypes[0])
+                x = self.conv0(x).to(self.dtypes[1])
+                x = self.conv1(x).to(self.dtypes[2])
+                x = self.conv2(x).to(self.dtypes[3])
+                x = self.conv3(x)
+                return x
+
+        layer_formats = ([torch.contiguous_format] * 4,
+                         [torch.channels_last] * 2 + [torch.contiguous_format] * 2,
+                         [torch.channels_last] * 4,)
+        layer_dtypes = ([torch.float] * 4,
+                        [torch.float] * 2 + [torch.half] * 2,
+                        [torch.half] * 4,)
+
+        ndevs = torch.cuda.device_count()
+        input = torch.randn(ndevs * 8, 8, 8, 8, device="cuda:0", dtype=torch.float)
+        target = torch.randn(ndevs * 8, 8, 4, 4, device="cuda:0", dtype=torch.float)
+        device_ids = list(range(ndevs))
+
+        with torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False):
+            for formats, dtypes in product(layer_formats, layer_dtypes):
+                model_msg = "formats = {} dtypes = {}".format(formats, dtypes)
+                try:
+                    m = ConvNet(formats, dtypes).cuda(device="cuda:0")
+                    m_dp = dp.DataParallel(deepcopy(m), device_ids=device_ids)
+                    has_half = any(p.dtype is torch.half for p in m.parameters())
+                    tol = 1.e-3 if has_half else 1.e-5
+                except BaseException:
+                    # Prints case-specific debugging info to narrow down failing case.
+                    print("Caught exception during model creation for " + model_msg)
+                    raise
+                # 2 iters:  First iter creates grads, second iter tries zeroed grads.
+                for it in range(2):
+                    iter_msg = "iter = {} ".format(it) + model_msg
+                    try:
+                        F.mse_loss(m(input).float(), target).backward()
+                        F.mse_loss(m_dp(input).float(), target).backward()
+                        for i, ((layer_name, m_child), m_dp_child) in enumerate(zip(m.named_children(),
+                                                                                    m_dp.module.children())):
+                            named_msg = layer_name + ".weight " + iter_msg
+                            self.assertTrue(m_child.weight.grad.is_contiguous(memory_format=formats[i]), named_msg)
+                            self.assertTrue(m_dp_child.weight.grad.is_contiguous(memory_format=formats[i]), named_msg)
+                            for j, ((param_name, p), p_dp) in enumerate(zip(m_child.named_parameters(),
+                                                                            m_dp_child.parameters())):
+                                named_msg = layer_name + "." + param_name + " " + iter_msg
+                                self.assertEqual(p.grad, p_dp.grad, msg=named_msg, rtol=tol, atol=tol)
+                    except BaseException:
+                        # Makes sure we still get info if an error occurred somewhere other than the asserts.
+                        print("Caught exception during iterations at " + iter_msg)
+                        raise
 
 
 if __name__ == '__main__':

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -724,7 +724,7 @@ class TestDataParallel(TestCase):
                     tol = 1.e-3 if has_half else 1.e-5
                 except BaseException:
                     # Prints case-specific debugging info to narrow down failing case.
-                    print("Caught exception during model creation for " + model_msg)
+                    print("Caught exception during model creation for " + model_msg, flush=True)
                     raise
                 # 2 iters:  First iter creates grads, second iter tries zeroed grads.
                 for it in range(2):
@@ -743,7 +743,7 @@ class TestDataParallel(TestCase):
                                 self.assertEqual(p.grad, p_dp.grad, msg=named_msg, rtol=tol, atol=tol)
                     except BaseException:
                         # Makes sure we still get info if an error occurred somewhere other than the asserts.
-                        print("Caught exception during iterations at " + iter_msg)
+                        print("Caught exception during iterations at " + iter_msg, flush=True)
                         raise
 
 

--- a/test/expect/TestAutograd.test_function-x_grad_desc.expect
+++ b/test/expect/TestAutograd.test_function-x_grad_desc.expect
@@ -1,1 +1,1 @@
-CloneBackward(AddBackward0(ExpandBackward(AccumulateGrad()), MulBackward0(ExpandBackward(AccumulateGrad()), AccumulateGrad())))
+CopyBackwards(None, AddBackward0(ExpandBackward(AccumulateGrad()), MulBackward0(ExpandBackward(AccumulateGrad()), AccumulateGrad())))

--- a/test/expect/TestAutograd.test_function-y_grad_desc.expect
+++ b/test/expect/TestAutograd.test_function-y_grad_desc.expect
@@ -1,1 +1,1 @@
-CloneBackward(AddBackward0(MulBackward0(ExpandBackward(AccumulateGrad()), None), MulBackward0(ExpandBackward(AccumulateGrad()), AccumulateGrad())))
+CopyBackwards(None, AddBackward0(MulBackward0(ExpandBackward(AccumulateGrad()), None), MulBackward0(ExpandBackward(AccumulateGrad()), AccumulateGrad())))

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -141,9 +141,9 @@ class TestAutograd(TestCase):
 
         x, y = self._function_test(MyFunction)
         self.assertEqual(graph_desc(x.grad.grad_fn),
-                         'CloneBackward(Error(AccumulateGrad(), None, AccumulateGrad()))')
+                         'CopyBackwards(None, Error(AccumulateGrad(), None, AccumulateGrad()))')
         self.assertEqual(graph_desc(y.grad.grad_fn),
-                         'CloneBackward(Error(AccumulateGrad(), None, AccumulateGrad()))')
+                         'CopyBackwards(None, Error(AccumulateGrad(), None, AccumulateGrad()))')
 
     def test_function_returns_input(self):
         class MyFunction(Function):
@@ -236,30 +236,36 @@ class TestAutograd(TestCase):
         self.assertEqual(x_grad, x_grad_clone)
 
     def test_accumulate_grad_tensor_reference(self):
-        def _test_grad_tensor(params_grad_tensor, backward_grad_tensor, should_preserve_reference):
+        def _test_grad_tensor(params_grad_tensor, backward_grad_tensor, should_preserve_reference, create_graph):
             params = torch.tensor([1.5, 1.5]).requires_grad_()
             params.grad = params_grad_tensor
             grad_saved = params.grad
-            params.backward(backward_grad_tensor)
+            params.backward(backward_grad_tensor, create_graph=create_graph)
             self.assertEqual(id(grad_saved) == id(params.grad), should_preserve_reference)
 
-        # Accumulate dense gradient to sparse gradient will change the `params.grad` reference
-        _test_grad_tensor(
-            torch.sparse_coo_tensor(torch.tensor([[1, 1]]).long(), torch.tensor([1., 1.])),
-            torch.tensor([1.5, 1.5]),
-            False)
+        for create_graph in (False, True):
+            # Accumulate dense gradient to sparse gradient will change the `params.grad` reference
+            _test_grad_tensor(
+                torch.sparse_coo_tensor(torch.tensor([[1, 1]]).long(), torch.tensor([1., 1.])),
+                torch.tensor([1.5, 1.5]),
+                False,  # never accumulates in-place
+                create_graph)
 
-        # Accumulate dense gradient to dense gradient will preserve the `params.grad` reference
-        _test_grad_tensor(
-            torch.tensor([1.5, 1.5]),
-            torch.tensor([1.5, 1.5]),
-            True)
+            # Accumulate dense gradient to dense gradient will preserve the `params.grad` reference,
+            # but only if create_graph=False.
+            _test_grad_tensor(
+                torch.tensor([1.5, 1.5]),
+                torch.tensor([1.5, 1.5]),
+                not create_graph,
+                create_graph)
 
-        # Accumulate sparse gradient to sparse gradient will preserve the `params.grad` reference
-        _test_grad_tensor(
-            torch.sparse_coo_tensor(torch.tensor([[1, 1]]).long(), torch.tensor([1., 1.])),
-            torch.sparse_coo_tensor(torch.tensor([[1, 1]]).long(), torch.tensor([1., 1.])),
-            True)
+            # Accumulate sparse gradient to sparse gradient will preserve the `params.grad` reference,
+            # but only if create_graph=False.
+            _test_grad_tensor(
+                torch.sparse_coo_tensor(torch.tensor([[1, 1]]).long(), torch.tensor([1., 1.])),
+                torch.sparse_coo_tensor(torch.tensor([[1, 1]]).long(), torch.tensor([1., 1.])),
+                not create_graph,
+                create_graph)
 
     @skipIfNoLapack
     def test_slogdet_sign(self):
@@ -6296,6 +6302,38 @@ class TestAutogradDeviceType(TestCase):
         gradcheck(lambda x: x.logcumsumexp(2), a)
         gradgradcheck(lambda x: x.logcumsumexp(2), a)
 
+    def test_strided_leaf_grad_layout(self, device):
+        # (1) If leaf is non-overlapping and dense, grad's layout should match its leaf.
+        for fmt_a in (torch.contiguous_format, torch.channels_last):
+            for fmt_b in (torch.contiguous_format, torch.channels_last):
+                a = torch.rand((2, 3, 4, 5), device=device).to(memory_format=fmt_a)
+                b = torch.rand((2, 3, 4, 5), device=device).to(memory_format=fmt_b)
+                a.requires_grad_()
+                b.requires_grad_()
+                # checks (1) for broadcasted gradients
+                a.sum().backward()
+                self.assertEqual(a.grad.stride(), a.stride())
+                b.sum().backward()
+                self.assertEqual(b.grad.stride(), b.stride())
+                # checks (1) for non-broadcasted gradients
+                a.grad = None
+                b.grad = None
+                (a * b).sum().backward()
+                self.assertEqual(a.grad.stride(), a.stride())
+                self.assertEqual(b.grad.stride(), b.stride())
+
+        # (2) If leaf isn't dense, checks that grads are rowmajor contiguous.
+        c = torch.empty_strided((2, 2), (4, 2), device=device).copy_(torch.rand((2, 2), device=device))
+        c.requires_grad_()
+        d = torch.rand((2, 2), device=device)
+        # checks (2) for broadcasted gradients
+        c.sum().backward()
+        self.assertEqual(c.grad.stride(), (2, 1))
+        # checks (2) for non-broadcasted gradients
+        c.grad = None
+        (c * d).sum().backward()
+        self.assertEqual(c.grad.stride(), (2, 1))
+
 
 class TestMultithreadAutograd(TestCase):
     def _run_py_multithread_fn(self, fn, args=(), num_threads=10, kwargs=None):
@@ -6318,7 +6356,6 @@ class TestMultithreadAutograd(TestCase):
             self.assertEqual(x.grad, x + 3.5)
 
         self._run_py_multithread_fn(train_fn)
-
 
     def test_simple_backward_same_input(self):
         # simple multithreaded backward with only shared inputs (i.e. This is common
@@ -6345,7 +6382,6 @@ class TestMultithreadAutograd(TestCase):
         # since we use functional grad() api, gradients will not
         # be accumulate to the same place and should be the same
         self._run_py_multithread_fn(train_fn_grad, (x,))
-
 
     def test_python_thread_in_middle(self):
         # User might write a network that starts on one CPU thread, then runs its second half
@@ -6385,7 +6421,6 @@ class TestMultithreadAutograd(TestCase):
         self._run_py_multithread_fn(train_fn_retain_graph, (y_retain,), num_threads=5)
         # result should equal to num_thread * gradients
         self.assertEqual(x_retain.grad, 5 * (4 * x_retain ** 3 + 6 * (x_retain ** 2) + 4 * x_retain + 1))
-
 
     def test_fork_join_in_middle(self):
         # multiple backward with jit threads (fork/join primitive)
@@ -6431,7 +6466,6 @@ class TestMultithreadAutograd(TestCase):
         grad, grad1, grad2 = train_fn_fork_join_calls_retain(torch.randn(5, 5, requires_grad=True))
         self.assertEqual(grad, grad1)
         self.assertEqual(grad, grad2)
-
 
 
 for test in method_tests():

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2644,7 +2644,7 @@ t2.start()
 
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     def test_autocast_torch_fp16(self):
-        with torch.backends.cudnn.flags(deterministic=True):
+        with torch.backends.cudnn.flags(enabled=True, deterministic=True):
             for op_with_args in self.autocast_lists.torch_fp16:
                 skip_test = False
                 op, args = op_with_args[0], op_with_args[1]
@@ -2671,7 +2671,7 @@ t2.start()
 
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     def test_autocast_nn_fp16(self):
-        with torch.backends.cudnn.flags(deterministic=True):
+        with torch.backends.cudnn.flags(enabled=True, deterministic=True):
             for op, args in self.autocast_lists.nn_fp16:
                 self._run_autocast_outofplace(op, args, torch.float16, module=torch._C._nn)
 
@@ -2682,7 +2682,7 @@ t2.start()
 
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     def test_autocast_methods_fp16(self):
-        with torch.backends.cudnn.flags(deterministic=True):
+        with torch.backends.cudnn.flags(enabled=True, deterministic=True):
             for op, args in self.autocast_lists.methods_fp16:
                 self._run_autocast_outofplace(op, args, torch.float16, module=None)
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -73,7 +73,9 @@ def backward(
     all tensors that don't need gradient tensors).
 
     This function accumulates gradients in the leaves - you might need to zero
-    them before calling it.
+    ``.grad`` attributes or set them to ``None`` before calling it.
+    See :ref:`Default gradient layouts<default-grad-layouts>`
+    for details on the memory layout of accumulated gradients.
 
     .. note::
         Using this method with ``create_graph=True`` will create a reference cycle

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -2,11 +2,24 @@
 
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
+#include <torch/csrc/autograd/utils/grad_layout_contract.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <mutex>
 
 namespace torch { namespace autograd {
+
+#define CHECK_RESULT(RESULT, VAR) \
+  if (!(RESULT.is_sparse() || VAR.is_sparse())) { \
+    if (!utils::obeys_layout_contract(RESULT, VAR)) { \
+      TORCH_WARN_ONCE("grad and param do not obey the gradient layout contract. " \
+                      "This is not an error, but may impair performance.\n" \
+                      "grad.sizes() = ", RESULT.sizes(), \
+                      ", strides() = ", RESULT.strides(), "\n", \
+                      "param.sizes() = ", VAR.sizes(), \
+                      ", strides() = ", VAR.strides()); \
+    } \
+  }
 
 struct TORCH_API AccumulateGrad : public Node {
   explicit AccumulateGrad(Variable variable_);
@@ -26,6 +39,45 @@ struct TORCH_API AccumulateGrad : public Node {
   // new_grad into variable_grad if in place accumulation is possible.
   // Otherwise, uses 'update_grad' to update the grad for the variable.
 
+  // "Gradient Layout Contract"
+  //
+  // AccumulateGrad tries to stash strided (non-sparse) grads with memory layout
+  // (strides) such that variables and grads interact efficiently in later
+  // optimizer kernels, and grads interact efficiently with c10d::Reducer.cpp.
+  //
+  // Specifically, AccumulateGrad tries to ensure the following
+  // (cf torch/csrc/autograd/utils/grad_layout_contract.h):
+  //   (1) if variable.is_non_overlapping_and_dense(), the stashed grad's
+  //       strides match variable.
+  //   (2) else, stashed grad is rowmajor contiguous.
+  // If variable's grad does not exist (!variable_grad.defined())
+  // AccumulateGrad steals new_grad if it's stealable and obeys the contract
+  // already, otherwise it deep copies new_grad into an obedient clone.
+  //
+  // If variable's grad already exists (variable_grad.defined()), new_grad must
+  // be added to variable_grad.  If we aren't setting up for double backward
+  // (!GradMode::is_enabled()), AccumulateGrad performs "variable_grad += new_grad"
+  // in-place, which keeps variable_grad's layout. We assume (hope) variable_grad
+  // was created obeying (1) or (2) at some point in the past.
+  //
+  // If we are setting up for double backward, AccumulateGrad updates the grad
+  // out-of-place via "variable_grad + new_grad."  TensorIterator operator+ decides
+  // result's layout.  Typically TensorIterator matches strides of the first arg,
+  // so we once again assume (hope) variable_grad was originally created obeying
+  // (1) or (2).
+  //
+  // AccumulateGrad does not enforce the contract with 100% certainty.  Examples:
+  //  - If a user manually permutes a param or its grad, then runs a fwd+bwd,
+  //    variable_grad += new_grad keeps variable_grad's layout without rechecking
+  //    the contract.
+  //  - If TensorIterator changes its corner cases about operator+'s result
+  //    (for example, giving more or less priority to channels_last inputs, see
+  //    https://github.com/pytorch/pytorch/pull/37968) the result may not obey.
+  //
+  // Fortunately, if a given grad doesn't satisfy (1) or (2), the penalty is
+  // degraded performance in Reducer.cpp or optimizer kernels, not death by
+  // assert or silently bad numerics.
+
   // variable: the variable whose grad we're accumulating.
   // variable_grad: the current grad for the variable.
   // new_grad: new grad we want to acummulate for the variable.
@@ -44,18 +96,15 @@ struct TORCH_API AccumulateGrad : public Node {
       size_t num_expected_refs,
       const T& update_grad) {
     if (!variable_grad.defined()) {
-      // under following condition, we can avoid clone()
-      if (!GradMode::is_enabled() && !new_grad.is_sparse() &&
-          new_grad.is_contiguous() &&
-          new_grad.use_count() <= num_expected_refs) {
-        // first check it is in first-order grad only mode
-        // then check not sparse before is_contiguous
-        // then check contiguous, otherwise later in place accumulation may fail
-        // and lastly, check if the use_count is less than or equal to the
-        // number of references we expect before grabbing it. The number of
-        // references we expect is basically internal structures that are
-        // holding references to the Tensor and that is fine since these are not
-        // exposed to the user.
+      if (!GradMode::is_enabled() &&
+          !new_grad.is_sparse() &&
+          new_grad.use_count() <= num_expected_refs &&
+          utils::obeys_layout_contract(new_grad, variable)) {
+        // we aren't setting up for double-backward
+        // not sparse
+        // no other user-visible tensor references new_grad
+        // new_grad obeys the "Gradient Layout Contract"
+        // Under these conditions, we can steal new_grad without a deep copy.
         update_grad(new_grad.detach());
       } else if (
           !GradMode::is_enabled() && new_grad.is_sparse() &&
@@ -84,7 +133,8 @@ struct TORCH_API AccumulateGrad : public Node {
         if (new_grad.is_sparse()) {
           update_grad(new_grad.clone());
         } else {
-          update_grad(new_grad.clone(at::MemoryFormat::Contiguous));
+          // Deep copies new_grad according to the "Gradient Layout Contract."
+          update_grad(utils::clone_obey_contract(new_grad, variable));
         }
       }
     } else if (!GradMode::is_enabled()) {
@@ -96,7 +146,9 @@ struct TORCH_API AccumulateGrad : public Node {
         // `variable_grad` for it to store the result. However, changing the
         // TensorImpl type of a tensor requires changing the tensor itself, and
         // thus in this case we have to change the grad tensor.
-        update_grad(new_grad + variable_grad);
+        auto result = new_grad + variable_grad;
+        CHECK_RESULT(result, variable);
+        update_grad(std::move(result));
       } else {
         // In this case we can avoid changing the grad tensor. There are three
         // scenarios when we'll hit this case:
@@ -110,14 +162,54 @@ struct TORCH_API AccumulateGrad : public Node {
         // place. `variable_grad` is thus still referring to the same tensor
         // after the operation.
         variable_grad += new_grad;
+        CHECK_RESULT(variable_grad, variable);
+        // ^ We could enforce the contract more aggressively here by writing:
+        // if (variable_grad.is_sparse() || new_grad.is_sparse()) {
+        //   variable_grad += new_grad;
+        // } else if (obeys_layout_contract(variable_grad, variable)) {
+        //   variable_grad += new_grad;
+        // } else {
+        //   result = at::empty_strided(variable.sizes(), variable.strides(),
+        //                              variable.options().memory_format(c10::nullopt));
+        //   update_grad(at::native::add_out(result, variable_grad, new_grad, 1.0);
+        // }
+        // However, that accumulation is sometimes in place and sometimes not,
+        // which may break user code.
       }
     } else {
-      update_grad(variable_grad + new_grad);
+      at::Tensor result;
+      if (variable_grad.is_sparse() && !new_grad.is_sparse()) {
+        // CPU backend throws an error on sparse + dense, so prefer dense + sparse here.
+        result = new_grad + variable_grad;
+      } else {
+        // Assumes operator+ result typically matches strides of first arg,
+        // and hopes variable_grad was originally created obeying layout contract.
+        result = variable_grad + new_grad;
+      }
+      CHECK_RESULT(result, variable);
+      update_grad(std::move(result));
+      // ^ We could enforce the contract more aggressively here by saying
+      // if (obeys_layout_contract(new_grad, variable)) {
+      //   update_grad(new_grad + variable_grad);
+      // } else {
+      //   update_grad(variable_grad + new_grad);
+      // }
+      // such that the stashed grad is likely to have the right strides if
+      // either variable_grad or new_grad already has the right strides.
+      // We could enforce the contract with certainty by saying
+      // auto result = variable_grad + new_grad (or vice versa), checking result's
+      // layout, and copying to an obedient clone if necessary before update_grad.
+      // The copy would require another gmem pass.  We can't create empty result with
+      // the right layout then add_out into it with a single kernel, because GradMode
+      // is enabled in this branch, and add_out isn't differentiable.
+      // Maybe more trouble than it's worth.
     }
   }
 
   Variable variable;
 };
+
+#undef CHECK_RESULT
 
 } // namespace autograd
 } // namespace torch

--- a/torch/csrc/autograd/utils/grad_layout_contract.h
+++ b/torch/csrc/autograd/utils/grad_layout_contract.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+
+namespace torch {
+namespace autograd {
+namespace utils {
+
+// Helper functions to enforce the "Gradient Layout Contract" described in
+// torch/csrc/autograd/AccumulateGrad.h.
+
+// Checks if grad obeys the contract with variable.
+inline bool obeys_layout_contract(const at::Tensor& grad, const at::Tensor& variable) {
+  TORCH_INTERNAL_ASSERT(!grad.is_sparse());
+  TORCH_INTERNAL_ASSERT(!variable.is_sparse());
+  return variable.is_non_overlapping_and_dense() ?
+         (grad.strides() == variable.strides()) :
+         grad.is_contiguous(at::MemoryFormat::Contiguous);
+}
+
+// Creates a clone of new_grad that obeys the contract with variable.
+// The clone should attach to new_grad's history if GradMode::is_enabled().
+inline at::Tensor clone_obey_contract(const at::Tensor& new_grad, const at::Tensor& variable) {
+  if (variable.is_non_overlapping_and_dense()) {
+    // (1)
+    // Does this dicey-looking sequence attach the result to new_grad's
+    // history if GradMode::is_enabled()?  Yes, and @alband says it should.
+    return std::move(at::empty_strided(variable.sizes(), variable.strides(),
+                                       variable.options().memory_format(c10::nullopt))
+                     .copy_(new_grad));
+  } else {
+    // (2)
+    return new_grad.clone(at::MemoryFormat::Contiguous);
+  }
+}
+
+} // namespace utils
+} // namespace autograd
+} // namespace torch

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/autograd/function_hook.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/profiler.h>
+#include <torch/csrc/autograd/utils/grad_layout_contract.h>
 #include <torch/csrc/autograd/utils/lambda_post_hook.h>
 #include <torch/csrc/distributed/c10d/comm.h>
 #include <torch/csrc/utils/hash.h>
@@ -51,42 +52,11 @@ Reducer::Reducer(
   }
   TORCH_INTERNAL_ASSERT(expect_sparse_gradients_.size() == replicas_.size());
 
-  // Verify that all specified variables require gradients,
-  // and that they have the same size across replicas.
-  {
-    const auto replica_count = replicas_.size();
-    for (size_t replica_index = 0; replica_index < replica_count;
-         replica_index++) {
-      const auto variable_count = replicas_[replica_index].size();
-      TORCH_CHECK(
-          replicas_[replica_index].size() == replicas_[0].size(),
-          "Model replicas must have an equal number of parameters.");
-      TORCH_CHECK(
-          expect_sparse_gradients_[replica_index].size() ==
-              expect_sparse_gradients_[0].size(),
-          "Expected number of entries in expect_sparse_gradients ",
-          "to be equal across replicas.");
-      for (size_t variable_index = 0; variable_index < variable_count;
-           variable_index++) {
-        TORCH_CHECK(
-            replicas_[replica_index][variable_index].requires_grad(),
-            "Variables must require gradients (have `requires_grad` set).");
-        TORCH_CHECK(
-            replicas_[replica_index][variable_index].sizes() ==
-                replicas_[0][variable_index].sizes(),
-            "Variables across model replicas must have identical sizes.");
-        TORCH_CHECK(
-            replicas_[replica_index][variable_index].dtype() ==
-                replicas_[0][variable_index].dtype(),
-            "Variables across model replicas must have identical dtype.");
-        TORCH_CHECK(
-            expect_sparse_gradients_[replica_index][variable_index] ==
-                expect_sparse_gradients_[0][variable_index],
-            "Expected the same variables across replicas to either both ",
-            "or neither expect a sparse gradient.");
-      }
-    }
-  }
+  // Corresponding params' layouts (strides) must match across
+  // replicas within this process and across processes.
+  // (see Note:  "Gradient Layout Contract" in initialize_buckets).
+  verify_replicas_within_process();
+  verify_replica0_across_processes();
 
   // Initialize variable bucketing.
   // This can be reinitialized later after capturing runtime information.
@@ -165,7 +135,7 @@ Reducer::Reducer(
     local_used_maps_dev_.resize(replica_count);
 
     for (size_t i = 0; i < replica_count; i++) {
-      at::TensorOptions options, options_host;
+      at::TensorOptions options;
       options = options.dtype(at::kInt);
 
       if (replicas_[i][0].is_cuda()) {
@@ -201,6 +171,101 @@ Reducer::~Reducer() noexcept(false) {
   }
 }
 
+// Verifies replicas in this process treat the same number of params,
+// all params require grad, and corresponding params across replicas
+// have the same dtype/size/layout.
+void Reducer::verify_replicas_within_process() {
+  const auto replica_count = replicas_.size();
+  for (size_t replica_index = 0; replica_index < replica_count;
+       replica_index++) {
+    const auto variable_count = replicas_[replica_index].size();
+    TORCH_CHECK(
+        replicas_[replica_index].size() == replicas_[0].size(),
+        "Model replicas must have an equal number of parameters.");
+    TORCH_CHECK(
+        expect_sparse_gradients_[replica_index].size() ==
+            expect_sparse_gradients_[0].size(),
+        "Expected number of entries in expect_sparse_gradients ",
+        "to be equal across replicas.");
+    for (size_t variable_index = 0; variable_index < variable_count;
+         variable_index++) {
+      TORCH_CHECK(
+          replicas_[replica_index][variable_index].requires_grad(),
+          "Variables must require gradients (have `requires_grad` set).");
+      TORCH_CHECK(
+          replicas_[replica_index][variable_index].sizes() ==
+              replicas_[0][variable_index].sizes(),
+          "Variables across model replicas must have identical sizes.");
+      TORCH_CHECK(
+          replicas_[replica_index][variable_index].strides() ==
+              replicas_[0][variable_index].strides(),
+          "Variables across model replicas must have identical strides.");
+      TORCH_CHECK(
+          replicas_[replica_index][variable_index].dtype() ==
+              replicas_[0][variable_index].dtype(),
+          "Variables across model replicas must have identical dtype.");
+      TORCH_CHECK(
+          expect_sparse_gradients_[replica_index][variable_index] ==
+              expect_sparse_gradients_[0][variable_index],
+          "Expected the same variables across replicas to either both ",
+          "or neither expect a sparse gradient.");
+    }
+  }
+}
+
+// Verifies corresponding params in replica 0 have the same sizes/strides
+// across processes.
+void Reducer::verify_replica0_across_processes() {
+  size_t i = 0;
+  for (const auto& t : replicas_[0]) {
+    i += 2*t.dim();
+  }
+  at::TensorOptions options;
+  options = options.dtype(at::kLong);
+  auto metadata = at::empty({static_cast<long>(i)}, options);
+
+  // Technically, process 0 is the broadcast source, so only process 0 needs
+  // to populate metadata.  But no harm keeping work aligned across processes.
+  auto metadata_accessor = metadata.accessor<int64_t, 1>();
+  i = 0;
+  for (const auto& t : replicas_[0]) {
+    for (const auto& sz : t.sizes()) {
+      metadata_accessor[i++] = sz;
+    }
+    for (const auto& str : t.strides()) {
+      metadata_accessor[i++] = str;
+    }
+  }
+
+  auto metadata_dev = metadata.clone().to(replicas_[0][0].device());
+  std::vector<at::Tensor> vec{metadata_dev};
+  process_group_->broadcast(vec)->wait();
+
+  // Technically, process 0 doesn't need to double-check metadata, because it
+  // was the source.  But no harm keeping work aligned.
+  auto control = at::empty({static_cast<long>(i)}, options);
+  control.copy_(metadata_dev, /*non_blocking=*/false);
+  auto control_accessor = control.accessor<int64_t, 1>();
+  i = 0;
+  for (size_t p = 0; p < replicas_[0].size(); p++) {
+    const auto& t = replicas_[0][p];
+    // I'd like to include which process we are in the message,
+    // but ProcessGroup::getRank is not public!
+    for (const auto& sz : t.sizes()) {
+      TORCH_CHECK(sz == control_accessor[i++],
+                  "replicas[0][", p, "] in this process"
+                  " with sizes ", t.sizes(),
+                  " appears not to match sizes of the same param in process 0.");
+    }
+    for (const auto& str : t.strides()) {
+      TORCH_CHECK(str == control_accessor[i++],
+                  "replicas[0][", p, "] in this process"
+                  " with strides ", t.strides(),
+                  " appears not to match strides of the same param in process 0.");
+    }
+  }
+}
+
 void Reducer::mark_variable_ready_dense(VariableIndex index) {
   const auto replica_index = index.replica_index;
   const auto variable_index = index.variable_index;
@@ -210,12 +275,12 @@ void Reducer::mark_variable_ready_dense(VariableIndex index) {
   auto& variable = replica.variables[bucket_index.intra_bucket_index];
   const auto offset = replica.offsets[bucket_index.intra_bucket_index];
   const auto length = replica.lengths[bucket_index.intra_bucket_index];
+  auto& bucket_view = replica.bucket_views[bucket_index.intra_bucket_index];
 
   // Copy contents of gradient tensor to bucket tensor.
   // If the gradient is not set, we assume it wasn't computed
   // as part of the current backwards pass, and zero the part
   // of the bucket it would otherwise hold.
-  auto bucket_view = replica.contents.narrow(0, offset, length);
   runGradCallbackForVariable(variable, [&](auto& grad) {
     if (grad.defined()) {
       // Ensure that the gradient type matches the bucket type.
@@ -232,7 +297,25 @@ void Reducer::mark_variable_ready_dense(VariableIndex index) {
       TORCH_INTERNAL_ASSERT(!grad.is_alias_of(bucket_view));
       TORCH_INTERNAL_ASSERT(grad.device() == bucket_view.device());
       TORCH_INTERNAL_ASSERT(grad.numel() == bucket_view.numel());
-      bucket_view.copy_(grad.view({-1}), /* non_blocking */ true);
+      // AccumulateGrad doesn't HAVE to obey the grad layout contract.
+      // The penalty for disobedience is reduced performance, not numerical death.
+      // Warnings here help diagnose poor DDP performance.
+      if (grad.strides() != bucket_view.strides()) {
+        TORCH_WARN_ONCE("Grad strides do not match bucket view strides. "
+                        "This may indicate grad was not created according to the "
+                        "gradient layout contract, or that the param's strides "
+                        "changed since DDP was constructed.  This is not an error, "
+                        "but may impair performance.\n"
+                        "grad.sizes() = ", grad.sizes(),
+                        ", strides() = ", grad.strides(), "\n",
+                        "bucket_view.sizes() = ", bucket_view.sizes(),
+                        ", strides() = ", bucket_view.strides());
+      }
+      // imitates wrapped_scalar_tensor in ATen/native/BinaryOps.cpp
+      auto wrapped = c10::scalar_to_tensor(double(1.)/process_group_->getSize());
+      wrapped.unsafeGetTensorImpl()->set_wrapped_number(true);
+      // Divides while copying into the bucket view.
+      at::native::mul_out(bucket_view, grad, wrapped);
     } else {
       bucket_view.zero_();
     }
@@ -248,6 +331,7 @@ void Reducer::mark_variable_ready_sparse(VariableIndex index) {
   auto& bucket = buckets_[bucket_index.bucket_index];
   auto& replica = bucket.replicas[replica_index];
   auto& variable = replica.variables[bucket_index.intra_bucket_index];
+
   runGradCallbackForVariable(variable, [&](auto& grad) {
     TORCH_CHECK(grad.defined(), "Expected sparse gradient to be defined.");
     TORCH_CHECK(
@@ -260,8 +344,9 @@ void Reducer::mark_variable_ready_sparse(VariableIndex index) {
     // struct are empty, and there is no pre-existing accumulation tensor.
     // Directly assign the sparse tensor to the `contents` field.
     replica.contents = grad;
-    // The grad is not modified and dosesn't need to be written back.
-    return false;
+    replica.contents.div_(process_group_->getSize());
+    // The grad is modified in place and needs to be written back.
+    return true;
   });
 }
 
@@ -381,8 +466,6 @@ void Reducer::mark_variable_ready(VariableIndex index) {
 
   // Check if this was the final gradient for this bucket.
   if (--replica.pending == 0) {
-    // Prescale bucket contents to turn the global sum into the global average.
-    replica.contents.div_(process_group_->getSize());
     // Kick off reduction if all replicas for this bucket are ready.
     if (--bucket.pending == 0) {
       mark_bucket_ready(bucket_index.bucket_index);
@@ -537,6 +620,58 @@ void Reducer::initialize_buckets(
 
         // Allocate bucket contents tensor.
         replica.contents = at::empty({static_cast<long>(offset)}, options);
+
+        // Note:  "Gradient Layout Contract"
+        //
+        // Here, create views into the contents tensor for each variable's grad.
+        // Views serve as entry points to copy_ each grad's data in/out of the
+        // flat contents tensor.
+        //
+        // Gradients may have dense memory but non-row-major-contiguous strides
+        // (e.g. channels_last or channels_last_3d). For coalesced accesses during
+        // copy_s, it's beneficial for each view's layout to match its grad's layout.
+        //
+        // Specifically, we expect torch/csrc/autograd/AccumulateGrad.h produces grads
+        // that obey there "Gradient Layout Contract":
+        //   (1) if variable.is_non_overlapping_and_dense(), the stashed grad's
+        //       strides match variable.
+        //   (2) else, stashed grad is rowmajor contiguous.
+        // and create views to match.
+        //
+        // If AccumulateGrad breaks the contract, and produces a grad with an
+        // unexpected layout, performance will degrade due to poor memory access
+        // patterns when copy_ing grad data in and out of its bucket view.
+        // However, numerics remain correct, because the bucket view is the same on
+        // either end of the raw allreduce.  bucket_view.copy(grad) tranposes (+ densifies)
+        // to the bucket view's layout, the data is allreduced, then grad.copy_(bucket_view)
+        // transposes it back to grad's layout.
+        //
+        // The only way the numerics can go haywire is if the bucket views themselves have
+        // different layouts across processes (or replicas).  Bucket views' sizes and strides are set
+        // based on param layouts, using the same logic that (we expect) AccumulateGrad uses
+        // for their grads.  Therefore, the only way a bucket view could have different layouts
+        // in different processes is if its param has a different layout in different processes.
+        // We can check that param layouts match across processes and replicas in Reducer's
+        // constructor by allreducing some metadata.  Checking just once won't catch if someone
+        // messes with param layouts over time, but not messing with params after DDP construction
+        // is already a documented constraint.
+        for (size_t i = 0; i < replica.variables.size(); i++) {
+          const auto& v = replica.variables[i];
+          const auto offset = replica.offsets[i];
+          const auto length = replica.lengths[i];
+          if (v.is_non_overlapping_and_dense()) {
+            // If the param's memory is dense, match its layout, anticipating the autograd engine
+            // (AccumulateGrad) will also create gradients matching its layout.
+            replica.bucket_views.push_back(replica.contents
+                                           .as_strided(v.sizes(), v.strides(), offset));
+          } else {
+            // Fall back to a C-style contiguous view, again anticipating AccumulateGrad will do
+            // the same when stashing grads for non-dense params.
+            replica.bucket_views.push_back(replica.contents
+                                           .narrow(0, offset, length)
+                                           .view(v.sizes()));
+          }
+        }
       }
 
       // Add bucket replica to enclosing bucket.
@@ -700,15 +835,17 @@ void Reducer::finalize_bucket_dense(Bucket& bucket) {
         local_used_maps_reduced_ = true;
       }
 
-      auto bucket_view =
-          replica.contents.narrow(0, offset, length).view(variable.sizes());
+      const auto& bucket_view = replica.bucket_views[intra_bucket_index];
       runGradCallbackForVariable(variable, [&](auto& grad) {
         // If a parameter is globally unused, we keep its grad untouched.
         if (!global_unused) {
           if (!grad.defined()) {
-            grad = at::empty(bucket_view.sizes(), bucket_view.options());
+            // Creates grad according to the "Gradient Layout Contract"
+            // (see torch/csrc/grad/AccumulateGrad.h)
+            grad = torch::autograd::utils::clone_obey_contract(bucket_view, variable);
+          } else {
+            grad.copy_(bucket_view);
           }
-          grad.copy_(bucket_view);
           // The grad is modified and needs to be written back.
           return true;
         }
@@ -827,10 +964,10 @@ void Reducer::sync_bucket_indices(
   // Copy CPU tensor to device tensor, as the process_group_ could be NCCL and
   // it can only broadcast device tensors.
   auto indices_tensor_device = at::empty({total_size + 1}, options);
-  indices_tensor_device.copy_(indices_tensor, true);
+  indices_tensor_device.copy_(indices_tensor, /*non_blocking=*/true);
   std::vector<at::Tensor> indices_tensor_list = {indices_tensor_device};
   process_group_->broadcast(indices_tensor_list)->wait();
-  indices_tensor.copy_(indices_tensor_list.front());
+  indices_tensor.copy_(indices_tensor_list.front(), /*non_blocking=*/false);
 
   // Update num_buckets after receiving it from rank 0
   num_buckets = indices_accessor[indices_accessor_Index];
@@ -845,11 +982,11 @@ void Reducer::sync_bucket_indices(
         bucket_sizes.at(std::min(i, (bucket_sizes.size() - 1)));
   }
   auto bucket_sizes_tensor_device = at::empty({(int64_t)num_buckets}, options);
-  bucket_sizes_tensor_device.copy_(bucket_sizes_tensor, true);
+  bucket_sizes_tensor_device.copy_(bucket_sizes_tensor, /*non_blocking=*/true);
   std::vector<at::Tensor> bucket_sizes_tensor_list = {
       bucket_sizes_tensor_device};
   process_group_->broadcast(bucket_sizes_tensor_list)->wait();
-  bucket_sizes_tensor.copy_(bucket_sizes_tensor_list.front());
+  bucket_sizes_tensor.copy_(bucket_sizes_tensor_list.front(), /*non_blocking=*/false);
 
   // Clear bucket_indices first, and then update bucket_indices using received
   // num_buckets, bucket_sizes_tensor and indices_tensor from rank 0

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -564,8 +564,11 @@ void check_gpu_tensors(const std::vector<at::Tensor>& tensors) {
     if (t.sizes() != first.sizes()) {
       throw std::runtime_error("Tensors must have identical size");
     }
-    if (!t.is_contiguous()) {
-      throw std::runtime_error("Tensors must be contiguous");
+    if (t.strides() != first.strides()) {
+      throw std::runtime_error("Tensors must have identical strides");
+    }
+    if (!t.is_non_overlapping_and_dense()) {
+      throw std::runtime_error("Tensors must be non-overlapping and dense");
     }
     const auto inserted = usedDevices.insert(t.get_device()).second;
     if (!inserted) {
@@ -605,9 +608,13 @@ std::vector<at::Tensor> flatten_for_scatter_gather(
     }
 
     for (const auto& t : tensor_lists[i]) {
-      if (t.numel() != other[i].numel()) {
+      if (t.sizes() != other[i].sizes()) {
         throw std::runtime_error(
             "All tensor operands to scatter/gather must have the same size");
+      }
+      if (t.strides() != other[i].strides()) {
+        throw std::runtime_error(
+            "All tensor operands to scatter/gather must have the same layout (strides)");
       }
     }
     // Flatten the tensors (from all ranks) into a single big tensor.

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -300,8 +300,10 @@ inline at::Tensor newLikeFlat(
   }
   at::DeviceGuard gpuGuard(device);
   std::vector<int64_t> sizes{static_cast<int64_t>(tensors[deviceIdx].size())};
+  std::vector<int64_t> strides{static_cast<int64_t>(t.numel())};
   sizes.insert(sizes.end(), t.sizes().begin(), t.sizes().end());
-  return at::empty(sizes, t.options());
+  strides.insert(strides.end(), t.strides().begin(), t.strides().end());
+  return at::empty_strided(sizes, strides, t.options().memory_format(c10::nullopt));
 }
 
 inline at::Tensor newLikeFlat(std::vector<at::Tensor>& tensors) {

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -109,7 +109,12 @@ class DistributedDataParallel(Module):
         same model and thus the exact same parameter registration order.
 
     .. warning::
-        This module assumes all buffers and gradients are dense.
+        This module allows parameters with non-rowmajor-contiguous strides.
+        For example, your model may contain some parameters whose
+        :class:`torch.memory_format` is ``torch.contiguous_format``
+        and others whose format is ``torch.channels_last``.  However,
+        corresponding parameters in different processes must have the
+        same strides.
 
     .. warning::
         This module doesn't work with :func:`torch.autograd.grad` (i.e. it will

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -161,8 +161,10 @@ class Tensor(torch._C._TensorBase):
         It should be a tensor of matching type and location, that contains
         the gradient of the differentiated function w.r.t. ``self``.
 
-        This function accumulates gradients in the leaves - you might need to
-        zero them before calling it.
+        This function accumulates gradients in the leaves - you might need to zero
+        ``.grad`` attributes or set them to ``None`` before calling it.
+        See :ref:`Default gradient layouts<default-grad-layouts>`
+        for details on the memory layout of accumulated gradients.
 
         Arguments:
             gradient (Tensor or None): Gradient w.r.t. the


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/34904 was reverted because it had a misconfigured 4 GPU test that for some reason wasn't caught by external CI ([example failure](https://app.circleci.com/pipelines/github/pytorch/pytorch/181719/workflows/cfb37cd9-9a0c-4738-898b-d683934cd308/jobs/5868948/steps)).

This PR reverts the revert, and adds diffs that should repair the misconfigured test.