### PR TITLE
Fix flaky rref timeout test

### DIFF
--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -271,7 +271,8 @@ void RRefContext::delAllUsersAndUnforkedOwners(
       owners_.erase(iter);
     }
   }
-  // Wait for Owners to process all delete UserRRef messages.
+  // Wait for this node to process all delete UserRRef messages it may get for
+  // the OwnerRRefs that exist on this node.
   {
     std::unique_lock<std::mutex> lock(mutex_);
     bool noOwner = deleteAllUsersCV_.wait_for(

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test_faulty.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test_faulty.py
@@ -160,7 +160,7 @@ class JitFaultyAgentRpcTest(FaultyRpcAgentTestFixture):
         rpc._set_rpc_timeout(rpc.constants.DEFAULT_RPC_TIMEOUT_SEC)
 
     @dist_init(faulty_messages=["SCRIPT_REMOTE_CALL"])
-    def test_rref_timeout_to_here_in_jit(self):
+    def test_remote_timeout_to_here_in_jit(self):
         # Test that calling to_here() in JIT will raise timeout error if
         # rpc.remote failed.
         if self.rank != 0:
@@ -176,7 +176,7 @@ class JitFaultyAgentRpcTest(FaultyRpcAgentTestFixture):
         with self.assertRaisesRegex(RuntimeError, "RRef creation"):
             rref_to_here(rref)
 
-    @dist_init(messages_to_delay={"SCRIPT_RREF_FETCH_CALL": 1})
+    @dist_init(faulty_messages=[], messages_to_delay={"SCRIPT_RREF_FETCH_CALL": 1})
     def test_rref_to_here_timeout_in_jit(self):
         if self.rank != 0:
             return
@@ -191,6 +191,8 @@ class JitFaultyAgentRpcTest(FaultyRpcAgentTestFixture):
         )
         with self.assertRaisesRegex(RuntimeError, expected_error):
             rref_to_here_with_timeout(rref, 0.01)
+
+        rref_to_here_with_timeout(rref, 100)
 
     @dist_init(faulty_messages=["SCRIPT_REMOTE_CALL"])
     def test_rref_timeout_pickle_in_jit(self):

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -3224,6 +3224,8 @@ class FaultyAgentRpcTest(FaultyRpcAgentTestFixture):
         with self.assertRaisesRegex(RuntimeError, expected_error):
             rref.to_here(0.01)
 
+        rref.to_here()
+
     @dist_init(faulty_messages=[])
     def test_rpc_builtin_timeout(self):
         next_rank = (self.rank + 1) % self.world_size


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40141 Fix flaky rref timeout test**

This rref timeout test could be flaky because we could end up processing `RRefUserDelete` messages on the owner node before processing the to_here message. This would result in a hang in `ProcessGroupAgent::sync()` that eventually results in a timeout.

The rough sequence of what happens is:
0) Node 0 creates RRef on node 1 with rpc.remote() call
1) rref.to_here() is called with a timeout. Because of delay injection, the processing of this message can be delayed (this is also technically possible in applications without delay injection)
2) At some point, callbacks corresponding to rpc.remote() runs and confirms the rref, adding it as a confirmed user
3) RPC shutdown starts, as part of which we send out RRef user deletes. In this case, since 0 has a confirmed user, 0 sends an RRef user delete to 1, and node 1 removes the owner from the `owners_` field.
4) The `to_here()` message is finally processed by node 1. But since we have deleted the `owner_`, while processing this message we create a future that will be complete when the owner exists (this is to account for the case of to_here() arriving here rpc.remote). But this future will never complete, since the owner is already deleted, so we hang indefnitely

As a workaround for now, we can force `to_here()` to run before RPC shutdown by adding a blocking `to_here()` call with no timeout. As a result, since it's blocking, we are guaranteed that the remote end will process `to_here()` before the RRefUserDeletes. 

A more robust, longer-term fix would be to detect if an owner has been previously deleted (such as by an RRefUserDelete), and then error out when processing a `to_here()`.

Differential Revision: [D22084735](https://our.internmc.facebook.com/intern/diff/D22084735/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22084735/)!