### PR TITLE
[pytorch] fix CUDA_KERNEL_ASSERT macro for android build

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -212,7 +212,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // CUDA_KERNEL_ASSERT checks the assertion
 // even when NDEBUG is defined. This is useful for important assertions in CUDA
 // code that when building Release.
-#if defined(__APPLE__) || defined(__HIP_PLATFORM_HCC__)
+#if defined(__ANDROID__) || defined(__APPLE__) || defined(__HIP_PLATFORM_HCC__)
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)
 #elif defined(_MSC_VER)

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -211,7 +211,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 
 // CUDA_KERNEL_ASSERT checks the assertion
 // even when NDEBUG is defined. This is useful for important assertions in CUDA
-// code that when building Release.
+// code that would otherwise be suppressed when building Release.
 #if defined(__ANDROID__) || defined(__APPLE__) || defined(__HIP_PLATFORM_HCC__)
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40151 [pytorch] fix CUDA_KERNEL_ASSERT macro for android build**

Summary:
For debug android build it throws the following error:
```
  In file included from src/pytorch/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp:9:
  In file included from src/pytorch/android/pytorch_android/src/main/cpp/pytorch_jni_common.h:2:
  In file included from ../../../../src/main/cpp/libtorch_include/armeabi-v7a/torch/csrc/api/include/torch/types.h:3:
  In file included from ../../../../src/main/cpp/libtorch_include/armeabi-v7a/ATen/ATen.h:5:
  In file included from ../../../../src/main/cpp/libtorch_include/armeabi-v7a/ATen/Context.h:4:
  In file included from ../../../../src/main/cpp/libtorch_include/armeabi-v7a/ATen/Tensor.h:3:
  In file included from ../../../../src/main/cpp/libtorch_include/armeabi-v7a/ATen/core/TensorBody.h:7:
  In file included from ../../../../src/main/cpp/libtorch_include/armeabi-v7a/c10/core/Scalar.h:13:
  ../../../../src/main/cpp/libtorch_include/armeabi-v7a/c10/util/TypeCast.h:157:22: error: use of undeclared identifier '__assert_fail'
  AT_FORALL_QINT_TYPES(DEFINE_UNCASTABLE)
                       ^
```

Seems `__assert_fail()` isn't available on Android by default - in NDEBUG mode it forward declares the function and CI passes.

But CUDA_KERNEL_ASSERT() shouldn't be relevant for mobile build at all and we already bypass `__APPLE__` so the easiest fix is to add `__ANDROID__`.

Differential Revision: [D22095562](https://our.internmc.facebook.com/intern/diff/D22095562)