### PR TITLE
[TensorPipe] Add options for agent, including backend killswitches

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -475,7 +475,15 @@ PyObject* rpc_init(PyObject* /* unused */) {
   py::class_<TensorPipeRpcBackendOptions>(
       module, "TensorPipeRpcBackendOptions", rpcBackendOptions)
       .def(
-          py::init<float, std::string>(),
+          py::init<
+              int,
+              optional<std::vector<std::string>>,
+              optional<std::vector<std::string>>,
+              float,
+              std::string>(),
+          py::arg("num_worker_threads") = kDefaultNumWorkerThreads,
+          py::arg("_transports") = optional<std::vector<std::string>>(),
+          py::arg("_channels") = optional<std::vector<std::string>>(),
           py::arg("rpc_timeout") = kDefaultRpcTimeoutSeconds,
           py::arg("init_method") = kDefaultInitMethod);
 

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -485,7 +485,12 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::arg("_transports") = optional<std::vector<std::string>>(),
           py::arg("_channels") = optional<std::vector<std::string>>(),
           py::arg("rpc_timeout") = kDefaultRpcTimeoutSeconds,
-          py::arg("init_method") = kDefaultInitMethod);
+          py::arg("init_method") = kDefaultInitMethod)
+      .def_readwrite(
+          "num_worker_threads", &TensorPipeRpcBackendOptions::numWorkerThreads);
+
+  module.attr("_DEFAULT_NUM_WORKER_THREADS") =
+      py::cast(kDefaultNumWorkerThreads);
 
   shared_ptr_class_<TensorPipeAgent>(module, "TensorPipeAgent", rpcAgent)
       .def(

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -191,12 +191,13 @@ TensorPipeAgent::TensorPipeAgent(
           std::make_unique<RequestCallbackImpl>(),
           std::chrono::milliseconds(
               (long)(opts.rpcTimeoutSeconds * kToMilliseconds))),
+      opts_(std::move(opts)),
+      threadPool_(opts_.numWorkerThreads),
       context_(std::make_shared<tensorpipe::Context>(
           tensorpipe::ContextOptions().name(workerInfo_.name_))),
       rankToNameStore_("names", store),
       nameToAddressStore_("addrs", store),
       worldSize_(worldSize),
-      opts_(std::move(opts)),
       processGroup_(std::move(processGroup)) {
   collectNames();
 
@@ -217,22 +218,51 @@ void TensorPipeAgent::startImpl() {
   std::string lowestPriorityTransport;
 
   for (auto& key : TensorPipeTransportRegistry()->Keys()) {
+    int64_t priority = -1;
+    if (opts_.transports.has_value()) {
+      auto iter =
+          std::find(opts_.transports->begin(), opts_.transports->end(), key);
+      if (iter == opts_.transports->end()) {
+        continue;
+      }
+      // Assign priorities in reverse order of occurrence in the vector, so that
+      // a transport that comes before another receives a higher priority.
+      priority =
+          opts_.transports->size() - 1 - (iter - opts_.transports->begin());
+    }
     std::unique_ptr<TransportRegistration> reg =
         TensorPipeTransportRegistry()->Create(key);
-    if (reg->priority < lowestPriority) {
-      lowestPriority = reg->priority;
+    if (priority == -1) {
+      priority = reg->priority;
+    }
+    if (priority < lowestPriority) {
+      lowestPriority = priority;
       lowestPriorityTransport = key;
     }
     addresses.push_back(c10::str(key, "://", reg->address));
     context_->registerTransport(
-        reg->priority, std::move(key), std::move(reg->transport));
+        priority, std::move(key), std::move(reg->transport));
   }
 
   for (auto& key : TensorPipeChannelRegistry()->Keys()) {
+    int64_t priority = -1;
+    if (opts_.channels.has_value()) {
+      auto iter =
+          std::find(opts_.channels->begin(), opts_.channels->end(), key);
+      if (iter == opts_.channels->end()) {
+        continue;
+      }
+      // Assign priorities in reverse order of occurrence in the vector, so that
+      // a channel that comes before another receives a higher priority.
+      priority = opts_.channels->size() - 1 - (iter - opts_.channels->begin());
+    }
     std::unique_ptr<ChannelRegistration> reg =
         TensorPipeChannelRegistry()->Create(key);
+    if (priority == -1) {
+      priority = reg->priority;
+    }
     context_->registerChannel(
-        reg->priority, std::move(key), std::move(reg->channel));
+        priority, std::move(key), std::move(reg->channel));
   }
 
   listener_ = context_->listen(addresses);

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -18,9 +18,61 @@ namespace rpc {
 using steady_clock_time_point =
     std::chrono::time_point<std::chrono::steady_clock>;
 
+struct TransportRegistration {
+  std::shared_ptr<tensorpipe::transport::Context> transport;
+  int64_t priority;
+  std::string address;
+};
+
+C10_DECLARE_REGISTRY(TensorPipeTransportRegistry, TransportRegistration);
+
+struct ChannelRegistration {
+  std::shared_ptr<tensorpipe::channel::Context> channel;
+  int64_t priority;
+};
+
+C10_DECLARE_REGISTRY(TensorPipeChannelRegistry, ChannelRegistration);
+
+constexpr auto kDefaultNumWorkerThreads = 16;
+
 struct TensorPipeRpcBackendOptions : public RpcBackendOptions {
-  TensorPipeRpcBackendOptions(float rpc_timeout, std::string init_method)
-      : RpcBackendOptions(rpc_timeout, init_method) {}
+  TensorPipeRpcBackendOptions(
+      int numWorkerThreads,
+      optional<std::vector<std::string>> transports,
+      optional<std::vector<std::string>> channels,
+      float rpc_timeout,
+      std::string init_method)
+      : RpcBackendOptions(rpc_timeout, init_method),
+        numWorkerThreads(numWorkerThreads),
+        transports(std::move(transports)),
+        channels(std::move(channels)) {
+    TORCH_CHECK(
+        numWorkerThreads > 0,
+        "num_worker_threads must be positive, got ",
+        numWorkerThreads);
+
+    if (transports.has_value()) {
+      for (const std::string& transportName : transports.value()) {
+        TORCH_CHECK(
+            TensorPipeTransportRegistry()->Has(transportName),
+            "Unknwon transport: ",
+            transportName);
+      }
+    }
+
+    if (channels.has_value()) {
+      for (const std::string& channelName : channels.value()) {
+        TORCH_CHECK(
+            TensorPipeChannelRegistry()->Has(channelName),
+            "Unknwon channel: ",
+            channelName);
+      }
+    }
+  }
+
+  int numWorkerThreads;
+  optional<std::vector<std::string>> transports;
+  optional<std::vector<std::string>> channels;
 };
 
 // Struct to track the network source metrics
@@ -36,21 +88,6 @@ struct AggregatedNetworkData {
   uint64_t totalRecvBytes{0};
   uint64_t totalErrors{0};
 };
-
-struct TransportRegistration {
-  std::shared_ptr<tensorpipe::transport::Context> transport;
-  int64_t priority;
-  std::string address;
-};
-
-C10_DECLARE_REGISTRY(TensorPipeTransportRegistry, TransportRegistration);
-
-struct ChannelRegistration {
-  std::shared_ptr<tensorpipe::channel::Context> channel;
-  int64_t priority;
-};
-
-C10_DECLARE_REGISTRY(TensorPipeChannelRegistry, ChannelRegistration);
 
 // TensorPipeAgent leverages TensorPipe (https://github.com/pytorch/tensorpipe)
 // to transparently move tensors and payloads through the fastest available
@@ -174,8 +211,9 @@ class TensorPipeAgent : public RpcAgent {
         pendingResponseMessage_;
   };
 
-  // TODO: configure thread pool size through RpcBackendOptions.
-  ThreadPool threadPool_{16};
+  const TensorPipeRpcBackendOptions opts_;
+
+  ThreadPool threadPool_;
   std::shared_ptr<tensorpipe::Context> context_;
   std::shared_ptr<tensorpipe::Listener> listener_;
   std::unordered_map<worker_id_t, ClientPipe> connectedPipes_;
@@ -188,7 +226,6 @@ class TensorPipeAgent : public RpcAgent {
   ::c10d::PrefixStore rankToNameStore_;
   ::c10d::PrefixStore nameToAddressStore_;
   const int worldSize_;
-  const TensorPipeRpcBackendOptions opts_;
 
   // The join method is required to behave like a barrier and perform collective
   // operations. For simplicity and reliability, we offload this to a process

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -55,7 +55,7 @@ struct TensorPipeRpcBackendOptions : public RpcBackendOptions {
       for (const std::string& transportName : transports.value()) {
         TORCH_CHECK(
             TensorPipeTransportRegistry()->Has(transportName),
-            "Unknwon transport: ",
+            "Unknown transport: ",
             transportName);
       }
     }
@@ -64,7 +64,7 @@ struct TensorPipeRpcBackendOptions : public RpcBackendOptions {
       for (const std::string& channelName : channels.value()) {
         TORCH_CHECK(
             TensorPipeChannelRegistry()->Has(channelName),
-            "Unknwon channel: ",
+            "Unknown channel: ",
             channelName);
       }
     }

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -71,8 +71,8 @@ struct TensorPipeRpcBackendOptions : public RpcBackendOptions {
   }
 
   int numWorkerThreads;
-  optional<std::vector<std::string>> transports;
-  optional<std::vector<std::string>> channels;
+  const optional<std::vector<std::string>> transports;
+  const optional<std::vector<std::string>> channels;
 };
 
 // Struct to track the network source metrics

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -145,14 +145,20 @@ register_backend(
 def _tensorpipe_construct_rpc_backend_options_handler(
     rpc_timeout,
     init_method,
+    num_worker_threads=rpc_constants.DEFAULT_NUM_WORKER_THREADS,
+    _transports=None,
+    _channels=None,
     **kwargs
 ):
     from . import TensorPipeRpcBackendOptions
 
-    rpc_backend_options = TensorPipeRpcBackendOptions()
-    rpc_backend_options.rpc_timeout = rpc_timeout
-    rpc_backend_options.init_method = init_method
-    return rpc_backend_options
+    return TensorPipeRpcBackendOptions(
+        rpc_timeout=rpc_timeout,
+        init_method=init_method,
+        num_worker_threads=num_worker_threads,
+        _transports=_transports,
+        _channels=_channels,
+    )
 
 
 def _tensorpipe_init_backend_handler(store, name, rank, world_size, rpc_backend_options):

--- a/torch/distributed/rpc/constants.py
+++ b/torch/distributed/rpc/constants.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from . import (
     _DEFAULT_INIT_METHOD,
     _DEFAULT_NUM_SEND_RECV_THREADS,
+    _DEFAULT_NUM_WORKER_THREADS,
     _DEFAULT_RPC_TIMEOUT_SEC,
     _UNSET_RPC_TIMEOUT,
 )
@@ -14,6 +15,8 @@ DEFAULT_INIT_METHOD = _DEFAULT_INIT_METHOD
 
 # For ProcessGroupAgent.
 DEFAULT_NUM_SEND_RECV_THREADS = _DEFAULT_NUM_SEND_RECV_THREADS
+# For TensorPipeAgent.
+DEFAULT_NUM_WORKER_THREADS = _DEFAULT_NUM_WORKER_THREADS
 # Ensure that we don't time out when there are long periods of time without
 # any operations against the underlying ProcessGroup.
 DEFAULT_PROCESS_GROUP_TIMEOUT = timedelta(milliseconds=2 ** 31 - 1)

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -437,15 +437,6 @@ class RpcTest(RpcAgentTestFixture):
 
         return decorator
 
-    def _skip_unless_tensorpipe_agent(old_func):  # noqa: B902
-        def decorator(self):
-            return unittest.skipUnless(
-                self.rpc_backend == rpc.backend_registry.BackendType.TENSORPIPE,
-                "This test is only supported in the Tensorpipe Agent"
-            )(old_func)
-
-        return decorator
-
     @dist_init
     def test_worker_id(self):
         n = self.rank + 1
@@ -2221,27 +2212,6 @@ class RpcTest(RpcAgentTestFixture):
         self.assertEqual(int(info["agent.thread_pool_size"]), NUM_THREADS)
         rpc.shutdown()
 
-    # FIXME Merge this test and the previous one
-    @dist_init(setup_rpc=False)
-    @_skip_unless_tensorpipe_agent
-    def test_set_and_get_num_worker_threads(self):
-        NUM_THREADS = 27
-        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
-            init_method=self.rpc_backend_options.init_method,
-            num_worker_threads=NUM_THREADS
-        )
-        rpc.init_rpc(
-            name=worker_name(self.rank),
-            backend=self.rpc_backend,
-            rank=self.rank,
-            world_size=self.world_size,
-            rpc_backend_options=rpc_backend_options,
-        )
-
-        info = rpc.api._get_current_rpc_agent().get_debug_info()
-        self.assertEqual(int(info["agent.thread_pool_size"]), NUM_THREADS)
-        rpc.shutdown()
-
     @dist_init(setup_rpc=False)
     @requires_process_group_agent("PROCESS_GROUP rpc backend specific test, skip")
     @_skip_if_tensorpipe_agent
@@ -2250,28 +2220,6 @@ class RpcTest(RpcAgentTestFixture):
         rpc_backend_options = rpc.ProcessGroupRpcBackendOptions(
             init_method=self.rpc_backend_options.init_method,
             num_send_recv_threads=self.rpc_backend_options.num_send_recv_threads,
-            rpc_timeout=timeout
-        )
-        rpc.init_rpc(
-            name=worker_name(self.rank),
-            backend=self.rpc_backend,
-            rank=self.rank,
-            world_size=self.world_size,
-            rpc_backend_options=rpc_backend_options,
-        )
-
-        default_timeout = rpc.get_rpc_timeout()
-        self.assertEqual(default_timeout, timeout)
-        rpc.shutdown()
-
-    # FIXME Merge this test and the previous one
-    @dist_init(setup_rpc=False)
-    @_skip_unless_tensorpipe_agent
-    def test_tensorpipe_set_default_timeout(self):
-        timeout = 0.5
-        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
-            init_method=self.rpc_backend_options.init_method,
-            num_worker_threads=self.rpc_backend_options.num_worker_threads,
             rpc_timeout=timeout
         )
         rpc.init_rpc(
@@ -2296,21 +2244,6 @@ class RpcTest(RpcAgentTestFixture):
         # Ensure that constructing ProcessGroupRpcBackendOptions with timedelta fails
         with self.assertRaisesRegex(TypeError, "incompatible constructor arguments"):
             rpc_backend_options = rpc.ProcessGroupRpcBackendOptions(
-                init_method=self.rpc_backend_options.init_method,
-                num_send_recv_threads=self.rpc_backend_options.num_send_recv_threads,
-                rpc_timeout=timeout,
-            )
-
-    # FIXME Merge this test and the previous one
-    @dist_init(setup_rpc=False)
-    @_skip_unless_tensorpipe_agent
-    def test_tensorpipe_options_throw_on_timedelta_timeout(self):
-        from datetime import timedelta
-
-        timeout = timedelta()
-        # Ensure that constructing TensorPipeRpcBackendOptions with timedelta fails
-        with self.assertRaisesRegex(TypeError, "incompatible constructor arguments"):
-            rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
                 init_method=self.rpc_backend_options.init_method,
                 num_send_recv_threads=self.rpc_backend_options.num_send_recv_threads,
                 rpc_timeout=timeout,
@@ -3380,3 +3313,58 @@ class TensorPipeAgentRpcTest(TensorPipeRpcAgentTestFixture, RpcTest):
     @dist_init
     def test_verify_backend_options(self):
         self.assertEqual(self.rpc_backend, rpc.backend_registry.BackendType.TENSORPIPE)
+
+    # FIXME Merge this test with the corresponding one in RpcTest.
+    @dist_init(setup_rpc=False)
+    def test_set_and_get_num_worker_threads(self):
+        NUM_THREADS = 27
+        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
+            init_method=self.rpc_backend_options.init_method,
+            num_worker_threads=NUM_THREADS
+        )
+        rpc.init_rpc(
+            name=worker_name(self.rank),
+            backend=self.rpc_backend,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=rpc_backend_options,
+        )
+
+        info = rpc.api._get_current_rpc_agent().get_debug_info()
+        self.assertEqual(int(info["agent.thread_pool_size"]), NUM_THREADS)
+        rpc.shutdown()
+
+    # FIXME Merge this test with the corresponding one in RpcTest.
+    @dist_init(setup_rpc=False)
+    def test_tensorpipe_set_default_timeout(self):
+        timeout = 0.5
+        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
+            init_method=self.rpc_backend_options.init_method,
+            num_worker_threads=self.rpc_backend_options.num_worker_threads,
+            rpc_timeout=timeout
+        )
+        rpc.init_rpc(
+            name=worker_name(self.rank),
+            backend=self.rpc_backend,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=rpc_backend_options,
+        )
+
+        default_timeout = rpc.get_rpc_timeout()
+        self.assertEqual(default_timeout, timeout)
+        rpc.shutdown()
+
+    # FIXME Merge this test with the corresponding one in RpcTest.
+    @dist_init(setup_rpc=False)
+    def test_tensorpipe_options_throw_on_timedelta_timeout(self):
+        from datetime import timedelta
+
+        timeout = timedelta()
+        # Ensure that constructing TensorPipeRpcBackendOptions with timedelta fails
+        with self.assertRaisesRegex(TypeError, "incompatible constructor arguments"):
+            rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
+                init_method=self.rpc_backend_options.init_method,
+                num_worker_threads=self.rpc_backend_options.num_worker_threads,
+                rpc_timeout=timeout,
+            )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40162 [TensorPipe] Add options for agent, including backend killswitches**

The only public option is `num_worker_threads`. The other ones are private (as indicated by the leading underscore, is that enough?) and allow to specify a different set and order of transports/channels. These can thus be used to disable a backend (by not specifying it) or by forcing one (by raising its priority). They can therefore be used to work around defective backends, in case we'll find any post-release.

Differential Revision: [D22090661](https://our.internmc.facebook.com/intern/diff/D22090661/)