### PR TITLE
[TensorPipe] Add guards against transferring GPU tensors

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -2448,7 +2448,6 @@ class RpcTest(RpcAgentTestFixture):
 
     @skip_if_lt_x_gpu(2)
     @dist_init
-    @_skip_if_tensorpipe_agent
     def test_cuda(self):
         dst = worker_name((self.rank + 1) % self.world_size)
         t1 = torch.rand(3, 3).cuda(0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40167 [TensorPipe] Add guards against transferring GPU tensors**

In v1.6 TensorPipe will not support transferring GPU tensors so, just like other agents, it should raise the appropriate errors when the user attempts to do so. One such error is when sending the arguments, another is when sending the result.

Differential Revision: [D22091737](https://our.internmc.facebook.com/intern/diff/D22091737/)