### PR TITLE
Remove condition for depthwise conv from stateless xnnpack integration.

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -264,7 +264,7 @@ auto ConvParams::use_xnnpack(
 // TODO:T66297472 remove `!defined(__APPLE__)` once we figure out the root cause of the crash.
 #if defined(C10_MOBILE) && !defined(__APPLE__)
   if (!transposed) {
-    return (input.size(1) == groups) &&
+    return (input.size(1) != groups) &&
             xnnpack::use_convolution2d(
                 input,
                 weight,


### PR DESCRIPTION
Summary:
Probably due to typo we had a condition for stateless xnnpack that forces
xnnpack use only for depthwise conv. This is resulting bad perf for some models
which could otherwise use xnnpack conv.

Test Plan: CI

Differential Revision: D22081924

