### PR TITLE
Move _dummy_type to _utils.py

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -15,7 +15,7 @@ import traceback
 import warnings
 import threading
 from torch._six import raise_from
-from ._utils import _get_device_index
+from ._utils import _get_device_index, _dummy_type
 import torch._C
 
 try:
@@ -403,14 +403,6 @@ from .random import *
 
 
 from ..storage import _StorageBase
-
-
-def _dummy_type(name):
-    def init_err(self):
-        class_name = self.__class__.__name__
-        raise RuntimeError(
-            "Tried to instantiate dummy base class {}".format(class_name))
-    return type(storage_name, (object,), {"__init__": init_err})
 
 
 if not hasattr(torch._C, 'CudaDoubleStorageBase'):

--- a/torch/cuda/_utils.py
+++ b/torch/cuda/_utils.py
@@ -1,8 +1,9 @@
 import torch
 import torch._six
+from typing import Union
 
 
-def _get_device_index(device, optional=False):
+def _get_device_index(device: Union[str, torch.device, int, None], optional=False) -> int:
     r"""Gets the device index from :attr:`device`, which can be a torch.device
     object, a Python integer, or ``None``.
 
@@ -33,3 +34,11 @@ def _get_device_index(device, optional=False):
             raise ValueError('Expected a cuda device with a specified index '
                              'or an integer, but got: {}'.format(device))
     return device_idx
+
+
+def _dummy_type(name: str) -> type:
+    def init_err(self):
+        class_name = self.__class__.__name__
+        raise RuntimeError(
+            "Tried to instantiate dummy base class {}".format(class_name))
+    return type(name, (object,), {"__init__": init_err})

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -1,6 +1,13 @@
 import ctypes
 import torch
 
+from ._utils import _dummy_type
+
+
+if not hasattr(torch._C, '_CudaStreamBase'):
+    # Define dummy base classes
+    torch._C.__dict__['_CudaStreamBase'] = _dummy_type('_CudaStreamBase')
+    torch._C.__dict__['_CudaEventBase'] = _dummy_type('_CudaEventBase')
 
 class Stream(torch._C._CudaStreamBase):
     r"""Wrapper around a CUDA stream.


### PR DESCRIPTION
Use it from both __init__ and streams to define dummy types when CUDA is missing
Fix accidental reference of global `storage_name` from `_dummy_type`
Add type annotations

