### PR TITLE
Make TensorIteratorConfig take Tensor by reference

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -126,11 +126,13 @@ Tensor binary_cross_entropy_cpu(const Tensor& input, const Tensor& target, const
 
 Tensor& binary_cross_entropy_out_cpu(Tensor& loss, const Tensor& input, const Tensor& target, const Tensor& weight, int64_t reduction) {
     Tensor loss_squeezed = at::squeeze(loss);
+    Tensor input_squeezed = at::squeeze(input);
+    Tensor target_squeezed = at::squeeze(target);
 
     auto iter = TensorIteratorConfig()
       .add_output(loss_squeezed)
-      .add_input(at::squeeze(input))
-      .add_input(at::squeeze(target))
+      .add_input(input_squeezed)
+      .add_input(target_squeezed)
       .build();
 
     AT_DISPATCH_FLOATING_TYPES(loss.scalar_type(), "binary_cross_entropy", [&] {
@@ -167,12 +169,15 @@ Tensor binary_cross_entropy_backward_cpu(const Tensor& grad, const Tensor& input
 
 Tensor& binary_cross_entropy_backward_out_cpu(Tensor& grad_input, const Tensor& grad, const Tensor& input, const Tensor& target, const Tensor& weight, int64_t reduction) {
     Tensor grad_input_squeezed = at::squeeze(grad_input);
+    Tensor grad_squeezed = at::squeeze(grad);
+    Tensor input_squeezed = at::squeeze(input);
+    Tensor target_squeezed = at::squeeze(target);
 
     auto iter = TensorIteratorConfig()
       .add_output(grad_input_squeezed)
-      .add_input(at::squeeze(grad))
-      .add_input(at::squeeze(input))
-      .add_input(at::squeeze(target))
+      .add_input(grad_squeezed)
+      .add_input(input_squeezed)
+      .add_input(target_squeezed)
       .build();
 
     AT_DISPATCH_FLOATING_TYPES(grad_input.scalar_type(), "binary_cross_entropy_backward", [&] {

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -232,9 +232,10 @@ static TensorIterator make_index_put_iterator(const AdvancedIndex& info, const T
 
 static TensorIterator make_index_iterator(const AdvancedIndex& info) {
   TensorIteratorConfig config;
+  Tensor output;
   config.check_all_same_dtype(false)
         .declare_static_dtype_and_device(info.src.scalar_type(), info.src.device())
-        .add_output(Tensor())
+        .add_output(output)
         .add_input(info.src);
   for (auto& index : info.indices) {
     config.add_input(index);

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -749,9 +749,9 @@ TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tenso
     .build();
 }
 
-void TensorIterator::populate_operands(TensorIteratorConfig& config) {
+void TensorIterator::populate_operands(const TensorIteratorConfig& config) {
   for (int i = 0; i < config.tensors_.size(); i++) {
-    operands_.emplace_back(std::move(config.tensors_[i]));
+    operands_.emplace_back(*config.tensors_[i]);
   }
   num_outputs_ = config.num_outputs_;
 }

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -77,11 +77,13 @@ Tensor binary_cross_entropy_cuda(const Tensor& input, const Tensor& target, cons
 
 Tensor& binary_cross_entropy_out_cuda(Tensor& loss, const Tensor& input, const Tensor& target, const Tensor& weight, int64_t reduction) {
   Tensor loss_squeezed = at::squeeze(loss);
+  Tensor input_squeezed = at::squeeze(input);
+  Tensor target_squeezed = at::squeeze(target);
 
   TensorIterator iter = TensorIteratorConfig()
       .add_output(loss_squeezed)
-      .add_input(at::squeeze(input))
-      .add_input(at::squeeze(target))
+      .add_input(input_squeezed)
+      .add_input(target_squeezed)
       .build();
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "binary_cross_entropy_out_cuda", [&]() {
     AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "binary_cross_entropy_out_cuda", [&] {

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -63,12 +63,14 @@ Tensor fake_quantize_per_channel_affine(
   std::vector<int64_t> expected_shape(self.dim(), 1);
   expected_shape[axis] = self.size(axis);
 
+  Tensor scale_view = native::_unsafe_view(scale, expected_shape);
+  Tensor zero_point_view = native::_unsafe_view(zero_point, expected_shape);
   TensorIterator iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
     .add_output(Y)
     .add_input(self)
-    .add_input(native::_unsafe_view(scale, expected_shape))
-    .add_input(native::_unsafe_view(zero_point, expected_shape))
+    .add_input(scale_view)
+    .add_input(zero_point_view)
     .build();
 
   fake_quant_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);
@@ -139,13 +141,15 @@ Tensor fake_quantize_per_channel_affine_backward(
   std::vector<int64_t> expected_shape(X.dim(), 1);
   expected_shape[axis] = X.size(axis);
 
+  Tensor scale_view = native::_unsafe_view(scale, expected_shape);
+  Tensor zero_point_view = native::_unsafe_view(zero_point, expected_shape);
   TensorIterator iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
     .add_output(dX)
     .add_input(X)
     .add_input(dY)
-    .add_input(native::_unsafe_view(scale, expected_shape))
-    .add_input(native::_unsafe_view(zero_point, expected_shape))
+    .add_input(scale_view)
+    .add_input(zero_point_view)
     .build();
 
   fake_quant_grad_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);

--- a/aten/src/ATen/test/tensor_iterator_test.cpp
+++ b/aten/src/ATen/test/tensor_iterator_test.cpp
@@ -166,11 +166,14 @@ TEST(TensorIteratorTest, SerialLoopSingleThread) {
 }
 
 TEST(TensorIteratorTest, InputDType) {
+  Tensor output = at::ones({1, 1}, at::dtype(at::kBool));
+  Tensor input1 = at::ones({1, 1}, at::dtype(at::kFloat));
+  Tensor input2 = at::ones({1, 1}, at::dtype(at::kDouble));
   auto iter = at::TensorIteratorConfig()
       .check_all_same_dtype(false)
-      .add_output(at::ones({1, 1}, at::dtype(at::kBool)))
-      .add_input(at::ones({1, 1}, at::dtype(at::kFloat)))
-      .add_input(at::ones({1, 1}, at::dtype(at::kDouble)))
+      .add_output(output)
+      .add_input(input1)
+      .add_input(input2)
       .build();
   EXPECT_TRUE(iter.input_dtype() == at::kFloat);
   EXPECT_TRUE(iter.input_dtype(0) == at::kFloat);
@@ -178,10 +181,13 @@ TEST(TensorIteratorTest, InputDType) {
 }
 
 TEST(TensorIteratorTest, ComputeCommonDTypeInputOnly) {
+  Tensor output = at::ones({1, 1}, at::dtype(at::kBool));
+  Tensor input1 = at::ones({1, 1}, at::dtype(at::kFloat));
+  Tensor input2 = at::ones({1, 1}, at::dtype(at::kDouble));
   auto iter = at::TensorIteratorConfig()
-      .add_output(at::ones({1, 1}, at::dtype(at::kBool)))
-      .add_input(at::ones({1, 1}, at::dtype(at::kFloat)))
-      .add_input(at::ones({1, 1}, at::dtype(at::kDouble)))
+      .add_output(output)
+      .add_input(input1)
+      .add_input(input2)
       .promote_inputs_to_common_dtype(true)
       .build();
   EXPECT_TRUE(iter.dtype(0) == at::kBool);
@@ -191,11 +197,14 @@ TEST(TensorIteratorTest, ComputeCommonDTypeInputOnly) {
 }
 
 TEST(TensorIteratorTest, DoNotComputeCommonDTypeInputOnly) {
+  Tensor output = at::ones({1, 1}, at::dtype(at::kLong));
+  Tensor input1 = at::ones({1, 1}, at::dtype(at::kFloat));
+  Tensor input2 = at::ones({1, 1}, at::dtype(at::kDouble));
   auto iter = at::TensorIteratorConfig()
       .check_all_same_dtype(false)
-      .add_output(at::ones({1, 1}, at::dtype(at::kLong)))
-      .add_input(at::ones({1, 1}, at::dtype(at::kFloat)))
-      .add_input(at::ones({1, 1}, at::dtype(at::kDouble)))
+      .add_output(output)
+      .add_input(input1)
+      .add_input(input2)
       .build();
   EXPECT_TRUE(iter.dtype(0) == at::kLong);
   EXPECT_TRUE(iter.dtype(1) == at::kFloat);
@@ -204,9 +213,11 @@ TEST(TensorIteratorTest, DoNotComputeCommonDTypeInputOnly) {
 
 TEST(TensorIteratorTest, FailNonPromotingBinaryOp) {
   Tensor out;
+  Tensor input1 = at::ones({1,1}, at::dtype(at::kDouble));
+  Tensor input2 = at::ones({1,1}, at::dtype(at::kInt));
   at::TensorIteratorConfig config;
   config.add_output(out);
-  config.add_input(at::ones({1,1}, at::dtype(at::kDouble)));
-  config.add_input(at::ones({1,1}, at::dtype(at::kInt)));
+  config.add_input(input1);
+  config.add_input(input2);
   ASSERT_ANY_THROW(config.build());
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40180 Make TensorIteratorConfig take Tensor by reference**

This is an attempt to fix a modest performance regression
from the previous refactor PR.  This should return the net
number of refcount bumps to what it was before the previous
refactor.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D22098625](https://our.internmc.facebook.com/intern/diff/D22098625)