### PR TITLE
ROCm thunk work-around for future transition to ROCm 3.5.1

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -173,6 +173,23 @@ if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
     export MAX_JOBS=$(($(nproc) - 1))
   fi
 
+  # TODO: Remove this once ROCm CI images are >= ROCm 3.5
+  # ROCm 3.5 required a backwards-incompatible change; the kernel and thunk must match.
+  # Detect kernel version and upgrade thunk if this is a ROCm 3.3 container running on a 3.5 kernel.
+  ROCM_ASD_FW_VERSION=$(/opt/rocm/bin/rocm-smi --showfwinfo -d 1 | grep ASD |  awk '{print $6}')
+  if [[ $ROCM_ASD_FW_VERSION = 553648174 && "$BUILD_ENVIRONMENT" == *rocm3.3* ]]; then
+    # upgrade thunk to 3.5
+    mkdir rocm3.5-thunk
+    pushd rocm3.5-thunk
+    wget http://repo.radeon.com/rocm/apt/3.5/pool/main/h/hsakmt-roct3.5.0/hsakmt-roct3.5.0_1.0.9-347-gd4b224f_amd64.deb
+    wget http://repo.radeon.com/rocm/apt/3.5/pool/main/h/hsakmt-roct-dev3.5.0/hsakmt-roct-dev3.5.0_1.0.9-347-gd4b224f_amd64.deb
+    dpkg-deb -vx hsakmt-roct3.5.0_1.0.9-347-gd4b224f_amd64.deb .
+    dpkg-deb -vx hsakmt-roct-dev3.5.0_1.0.9-347-gd4b224f_amd64.deb .
+    sudo cp -r opt/rocm-3.5.0/* /opt/rocm-3.3.0/
+    popd
+    rm -rf rocm3.5-thunk
+  fi
+
   ########## HIPIFY Caffe2 operators
   ${PYTHON} "${ROOT_DIR}/tools/amd_build/build_amd.py"
 fi

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -136,8 +136,9 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     wget http://repo.radeon.com/rocm/apt/3.5/pool/main/h/hsakmt-roct-dev3.5.0/hsakmt-roct-dev3.5.0_1.0.9-347-gd4b224f_amd64.deb
     dpkg-deb -vx hsakmt-roct3.5.0_1.0.9-347-gd4b224f_amd64.deb .
     dpkg-deb -vx hsakmt-roct-dev3.5.0_1.0.9-347-gd4b224f_amd64.deb .
-    cp -r opt/rocm-3.5.0/* /opt/rocm-3.3.0/
+    sudo cp -r opt/rocm-3.5.0/* /opt/rocm-3.3.0/
     popd
+    rm -rf rocm3.5-thunk
   fi
 
   # ROCm CI is using Caffe2 docker images, which needs these wrapper

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -124,6 +124,22 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export MAX_JOBS=$(($(nproc) - 1))
   fi
 
+  # TODO: Remove this once ROCm CI images are >= ROCm 3.5
+  # ROCm 3.5 required a backwards-incompatible change; the kernel and thunk must match.
+  # Detect kernel version and upgrade thunk if this is a ROCm 3.3 container running on a 3.5 kernel.
+  ROCM_ASD_FW_VERSION=$(/opt/rocm/bin/rocm-smi --showfwinfo -d 1 | grep ASD |  awk '{print $6}')
+  if [[ $ROCM_ASD_FW_VERSION = 553648174 && "$BUILD_ENVIRONMENT" == *rocm3.3* ]]; then
+    # upgrade thunk to 3.5
+    mkdir rocm3.5-thunk
+    pushd rocm3.5-thunk
+    wget http://repo.radeon.com/rocm/apt/3.5/pool/main/h/hsakmt-roct3.5.0/hsakmt-roct3.5.0_1.0.9-347-gd4b224f_amd64.deb
+    wget http://repo.radeon.com/rocm/apt/3.5/pool/main/h/hsakmt-roct-dev3.5.0/hsakmt-roct-dev3.5.0_1.0.9-347-gd4b224f_amd64.deb
+    dpkg-deb -vx hsakmt-roct3.5.0_1.0.9-347-gd4b224f_amd64.deb .
+    dpkg-deb -vx hsakmt-roct-dev3.5.0_1.0.9-347-gd4b224f_amd64.deb .
+    cp -r opt/rocm-3.5.0/* /opt/rocm-3.3.0/
+    popd
+  fi
+
   # ROCm CI is using Caffe2 docker images, which needs these wrapper
   # scripts to correctly use sccache.
   if [ -n "${SCCACHE_BUCKET}" ]; then


### PR DESCRIPTION
ROCm CI hosts will have their kernels upgraded first to ROCm 3.5.1.  CI images will follow soon after.  Due to the thunk/kernel mismatch during the interim, this PR will detect the mismatch and upgrade the thunk during the build.  This PR will be reverted once migration to ROCm 3.5.1 images is complete.

CC @ezyang @xw285cornell 