### PR TITLE
Get rid of global constructors in cuda codegen

### DIFF
--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -31,292 +31,451 @@ ValType promote_type(const ValType& t1, const ValType& t2) {
   return t1 < t2 ? t1 : t2;
 }
 
-template <typename T>
-struct _enum_class_hash {
-  size_t operator()(T v) const {
-    return static_cast<size_t>(v);
+static const char* data_type2string(DataType t) {
+  switch (t) {
+    case DataType::Bool:
+      return "bool";
+    case DataType::Float:
+      return "float";
+    case DataType::Half:
+      return "__half";
+    case DataType::Int:
+      return "size_t";
+    case DataType::Null:
+      return "nullptr";
+    default:
+      break;
   }
-};
-template <typename KeyType, typename ValType>
-using _enum_unordered_map =
-    std::unordered_map<KeyType, ValType, _enum_class_hash<KeyType>>;
-static _enum_unordered_map<DataType, std::string> data_type_string_map{
-    {DataType::Bool, "bool"},
-    {DataType::Float, "float"},
-    {DataType::Half, "__half"},
-    {DataType::Int, "size_t"}};
-static _enum_unordered_map<ValType, std::string> val_type_string_map{
-    {ValType::TensorIndex, "TensorIndex"},
-    {ValType::TensorView, "TensorView"},
-    {ValType::TensorDomain, "TensorDomain"},
-    {ValType::IterDomain, "IterDomain"},
-    {ValType::Scalar, "Scalar"},
-    {ValType::NamedScalar, "NamedScalar"}};
+  TORCH_INTERNAL_ASSERT(false, "No string found for data type.");
+  return nullptr;
+}
 
-static _enum_unordered_map<ExprType, std::string> expr_type_string_map{
-    {ExprType::UnaryOp, "UnaryOp"},
-    {ExprType::BinaryOp, "BinaryOp"},
-    {ExprType::TernaryOp, "TernaryOp"},
-    {ExprType::ReductionOp, "ReductionOp"},
-    {ExprType::BroadcastOp, "BroadcastOp"},
-    {ExprType::ForLoop, "ForLoop"},
-    {ExprType::IfThenElse, "IfThenElse"},
-    {ExprType::Allocate, "Allocate"},
-    {ExprType::Split, "Split"},
-    {ExprType::Merge, "Merge"},
-};
+static const char* val_type2string(ValType t) {
+  switch (t) {
+    case ValType::TensorIndex:
+      return "TensorIndex";
+    case ValType::TensorView:
+      return "TensorView";
+    case ValType::TensorDomain:
+      return "TensorDomain";
+    case ValType::IterDomain:
+      return "IterDomain";
+    case ValType::Scalar:
+      return "Scalar";
+    case ValType::NamedScalar:
+      return "NamedScalar";
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "No string found for val type.");
+  return nullptr;
+}
 
-static _enum_unordered_map<UnaryOpType, std::string> unary_op_type_string_map{
-    {UnaryOpType::Abs, "fabs"},
-    {UnaryOpType::Acos, "acosf"},
-    {UnaryOpType::Asin, "asinf"},
-    {UnaryOpType::Atan, "atanf"},
-    {UnaryOpType::Atanh, "atanhf"},
-    {UnaryOpType::Cast, "cast"},
-    {UnaryOpType::Ceil, "ceilf"},
-    {UnaryOpType::Cos, "cosf"},
-    {UnaryOpType::Cosh, "coshf"},
-    {UnaryOpType::Exp, "expf"},
-    {UnaryOpType::Expm1, "expm1f"},
-    {UnaryOpType::Erf, "erff"},
-    {UnaryOpType::Erfc, "erfcf"},
-    {UnaryOpType::Floor, "floorf"},
-    {UnaryOpType::Frac, "frac"},
-    {UnaryOpType::Gelu, "gelu"},
-    {UnaryOpType::Lgamma, "lgammaf"},
-    {UnaryOpType::Log, "logf"},
-    {UnaryOpType::Log10, "log10f"},
-    {UnaryOpType::Log1p, "log1pf"},
-    {UnaryOpType::Log2, "log2f"},
-    {UnaryOpType::Neg, "neg"},
-    {UnaryOpType::RandLike, "randLike"},
-    {UnaryOpType::Reciprocal, "reciprocal"},
-    {UnaryOpType::Relu, "relu"},
-    {UnaryOpType::Rsqrt, "rsqrtf"},
-    {UnaryOpType::Round, "roundf"},
-    {UnaryOpType::Set, "set"},
-    {UnaryOpType::Sigmoid, "sigmoid"},
-    {UnaryOpType::Sin, "sinf"},
-    {UnaryOpType::Sinh, "sinhf"},
-    {UnaryOpType::Sqrt, "sqrtf"},
-    {UnaryOpType::Tan, "tanf"},
-    {UnaryOpType::Tanh, "tanhf"},
-    {UnaryOpType::Trunc, "truncf"}};
-static _enum_unordered_map<UnaryOpType, std::string>
-    unary_op_type_inline_op_string_map{{UnaryOpType::Neg, "-"},
-                                       {UnaryOpType::Set, ""}};
-static _enum_unordered_map<BinaryOpType, std::string> binary_op_type_string_map{
-    {BinaryOpType::Add, "add"},
-    {BinaryOpType::Atan2, "atan2f"},
-    {BinaryOpType::Div, "div"},
-    {BinaryOpType::Fmod, "fmodf"},
-    {BinaryOpType::Max, "fmaxf"},
-    {BinaryOpType::Min, "fminf"},
-    {BinaryOpType::Mul, "mul"},
-    {BinaryOpType::Pow, "powf"},
-    {BinaryOpType::Remainder, "remainder"},
-    {BinaryOpType::Sub, "sub"},
-    //{BinaryOpType::TypeAs,
+static const char* expr_type2string(ExprType t) {
+  switch (t) {
+    case ExprType::UnaryOp:
+      return "UnaryOp";
+    case ExprType::BinaryOp:
+      return "BinaryOp";
+    case ExprType::TernaryOp:
+      return "TernaryOp";
+    case ExprType::ReductionOp:
+      return "ReductionOp";
+    case ExprType::BroadcastOp:
+      return "BroadcastOp";
+    case ExprType::ForLoop:
+      return "ForLoop";
+    case ExprType::IfThenElse:
+      return "IfThenElse";
+    case ExprType::Allocate:
+      return "Allocate";
+    case ExprType::Split:
+      return "Split";
+    case ExprType::Merge:
+      return "Merge";
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "No string found for expr type.");
+  return nullptr;
+}
+
+static const char* unary_op_type2string(UnaryOpType t) {
+  switch (t) {
+    case UnaryOpType::Abs:
+      return "fabs";
+    case UnaryOpType::Acos:
+      return "acosf";
+    case UnaryOpType::Asin:
+      return "asinf";
+    case UnaryOpType::Atan:
+      return "atanf";
+    case UnaryOpType::Atanh:
+      return "atanhf";
+    case UnaryOpType::Cast:
+      return "cast";
+    case UnaryOpType::Ceil:
+      return "ceilf";
+    case UnaryOpType::Cos:
+      return "cosf";
+    case UnaryOpType::Cosh:
+      return "coshf";
+    case UnaryOpType::Exp:
+      return "expf";
+    case UnaryOpType::Expm1:
+      return "expm1f";
+    case UnaryOpType::Erf:
+      return "erff";
+    case UnaryOpType::Erfc:
+      return "erfcf";
+    case UnaryOpType::Floor:
+      return "floorf";
+    case UnaryOpType::Frac:
+      return "frac";
+    case UnaryOpType::Gelu:
+      return "gelu";
+    case UnaryOpType::Lgamma:
+      return "lgammaf";
+    case UnaryOpType::Log:
+      return "logf";
+    case UnaryOpType::Log10:
+      return "log10f";
+    case UnaryOpType::Log1p:
+      return "log1pf";
+    case UnaryOpType::Log2:
+      return "log2f";
+    case UnaryOpType::Neg:
+      return "neg";
+    case UnaryOpType::RandLike:
+      return "randLike";
+    case UnaryOpType::Reciprocal:
+      return "reciprocal";
+    case UnaryOpType::Relu:
+      return "relu";
+    case UnaryOpType::Rsqrt:
+      return "rsqrtf";
+    case UnaryOpType::Round:
+      return "roundf";
+    case UnaryOpType::Set:
+      return "set";
+    case UnaryOpType::Sigmoid:
+      return "sigmoid";
+    case UnaryOpType::Sin:
+      return "sinf";
+    case UnaryOpType::Sinh:
+      return "sinhf";
+    case UnaryOpType::Sqrt:
+      return "sqrtf";
+    case UnaryOpType::Tan:
+      return "tanf";
+    case UnaryOpType::Tanh:
+      return "tanhf";
+    case UnaryOpType::Trunc:
+      return "truncf";
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "No string found for unary op type.");
+  return nullptr;
+}
+
+static const char* unary_op_type_inline_op2string(UnaryOpType t) {
+  switch (t) {
+    case UnaryOpType::Neg:
+      return "-";
+    case UnaryOpType::Set:
+      return "";
+    default:
+      break;
+  }
+  return nullptr;
+}
+
+static const char* binary_op_type2string(BinaryOpType t) {
+  switch (t) {
+    case BinaryOpType::Add:
+      return "add";
+    case BinaryOpType::Atan2:
+      return "atan2f";
+    case BinaryOpType::Div:
+      return "div";
+    case BinaryOpType::Fmod:
+      return "fmodf";
+    case BinaryOpType::Max:
+      return "fmaxf";
+    case BinaryOpType::Min:
+      return "fminf";
+    case BinaryOpType::Mul:
+      return "mul";
+    case BinaryOpType::Pow:
+      return "powf";
+    case BinaryOpType::Remainder:
+      return "remainder";
+    case BinaryOpType::Sub:
+      return "sub";
 
     // Logical Ops
-    {BinaryOpType::Mod, "mod"},
-    {BinaryOpType::CeilDiv, "ceilDiv"},
-    {BinaryOpType::And, "and"},
-    {BinaryOpType::Eq, "equal"},
-    {BinaryOpType::GE, "greaterThanOrEqual"},
-    {BinaryOpType::GT, "greaterThan"},
-    {BinaryOpType::LE, "lessThanOrEqual"},
-    {BinaryOpType::LT, "lessThan"},
-    {BinaryOpType::NE, "notEqual"}};
-
-static _enum_unordered_map<BinaryOpType, std::string>
-    binary_op_type_inline_op_string_map{{BinaryOpType::Add, "+"},
-                                        {BinaryOpType::Div, "/"},
-                                        {BinaryOpType::Mod, "%"},
-                                        {BinaryOpType::Mul, "*"},
-                                        {BinaryOpType::Sub, "-"},
-
-                                        // Logical Ops
-                                        {BinaryOpType::And, "&&"},
-                                        {BinaryOpType::Eq, "=="},
-                                        {BinaryOpType::GE, ">="},
-                                        {BinaryOpType::GT, ">"},
-                                        {BinaryOpType::LE, "<="},
-                                        {BinaryOpType::LT, "<"},
-                                        {BinaryOpType::NE, "!="}};
-static _enum_unordered_map<TernaryOpType, std::string>
-    ternary_op_type_string_map{{TernaryOpType::Clamp, "clamp"},
-                               {TernaryOpType::Threshold, "threshold"},
-                               {TernaryOpType::Where, "where"}};
-
-static _enum_unordered_map<ParallelType, std::string> parallel_type_string_map{
-    {ParallelType::BIDz, "blockIdx.z"},
-    {ParallelType::BIDy, "blockIdx.y"},
-    {ParallelType::BIDx, "blockIdx.x"},
-    {ParallelType::TIDz, "threadIdx.z"},
-    {ParallelType::TIDy, "threadIdx.y"},
-    {ParallelType::TIDx, "threadIdx.x"},
-    {ParallelType::Vectorize, "Vectorize"},
-    {ParallelType::Unroll, "Unroll"},
-    {ParallelType::Serial, "Serial"}};
-
-static _enum_unordered_map<MemoryType, std::string> memory_type_string_map{
-    {MemoryType::Local, "register"},
-    {MemoryType::Shared, "shared"},
-    {MemoryType::Global, "global"}};
-
-static _enum_unordered_map<at::ScalarType, DataType> at_type_map{
-    {at::ScalarType::Bool, DataType::Bool},
-    {at::ScalarType::Float, DataType::Float},
-    {at::ScalarType::Half, DataType::Half},
-    {at::ScalarType::Int, DataType::Int}};
-
-static _enum_unordered_map<ParallelType, std::string> thread_size_string_map{
-    {ParallelType::BIDz, "gridDim.z"},
-    {ParallelType::BIDy, "gridDim.y"},
-    {ParallelType::BIDx, "gridDim.x"},
-    {ParallelType::TIDz, "blockDim.z"},
-    {ParallelType::TIDy, "blockDim.y"},
-    {ParallelType::TIDx, "blockDim.x"}};
-
-static std::unordered_set<BinaryOpType, _enum_class_hash<BinaryOpType>>
-    logical_binary_ops{BinaryOpType::And,
-                       BinaryOpType::Eq,
-                       BinaryOpType::GE,
-                       BinaryOpType::GT,
-                       BinaryOpType::LE,
-                       BinaryOpType::LT,
-                       BinaryOpType::NE};
-
-template <typename T>
-struct _enum_pair_hash {
-  size_t operator()(std::pair<T, T> p) const {
-    return static_cast<size_t>(p.first) ^ static_cast<size_t>(p.second);
+    case BinaryOpType::Mod:
+      return "mod";
+    case BinaryOpType::CeilDiv:
+      return "ceilDiv";
+    case BinaryOpType::And:
+      return "and";
+    case BinaryOpType::Eq:
+      return "equal";
+    case BinaryOpType::GE:
+      return "greaterThanOrEqual";
+    case BinaryOpType::GT:
+      return "greaterThan";
+    case BinaryOpType::LE:
+      return "lessThanOrEqual";
+    case BinaryOpType::LT:
+      return "lessThan";
+    case BinaryOpType::NE:
+      return "notEqual";
+    default:
+      break;
   }
-};
-template <typename KeyType, typename ValType>
-using _enum_pair_unordered_map = std::unordered_map<
-    std::pair<KeyType, KeyType>,
-    ValType,
-    _enum_pair_hash<KeyType>>;
-static _enum_pair_unordered_map<DataType, std::string> supported_casts{
-    {{DataType::Float, DataType::Half}, "__float2half"},
-    {{DataType::Half, DataType::Float}, "__half2float"}};
+  TORCH_INTERNAL_ASSERT(false, "No string found for binary op type.");
+  return nullptr;
+}
+
+static const char* binary_op_type_inline_op2string(BinaryOpType t) {
+  switch (t) {
+    case BinaryOpType::Add:
+      return "+";
+    case BinaryOpType::Div:
+      return "/";
+    case BinaryOpType::Mod:
+      return "%";
+    case BinaryOpType::Mul:
+      return "*";
+    case BinaryOpType::Sub:
+      return "-";
+
+    // Logical Ops
+    case BinaryOpType::And:
+      return "&&";
+    case BinaryOpType::Eq:
+      return "==";
+    case BinaryOpType::GE:
+      return ">=";
+    case BinaryOpType::GT:
+      return ">";
+    case BinaryOpType::LE:
+      return "<=";
+    case BinaryOpType::LT:
+      return "<";
+    case BinaryOpType::NE:
+      return "!=";
+    default:
+      break;
+  }
+  return nullptr;
+}
+
+static const char* ternary_op_type2string(TernaryOpType t) {
+  switch (t) {
+    case TernaryOpType::Clamp:
+      return "clamp";
+    case TernaryOpType::Threshold:
+      return "threshold";
+    case TernaryOpType::Where:
+      return "where";
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "No string found for ternary op type.");
+  return nullptr;
+}
+
+static const char* parallel_type2string(ParallelType t) {
+  switch (t) {
+    case ParallelType::BIDz:
+      return "blockIdx.z";
+    case ParallelType::BIDy:
+      return "blockIdx.y";
+    case ParallelType::BIDx:
+      return "blockIdx.x";
+    case ParallelType::TIDz:
+      return "threadIdx.z";
+    case ParallelType::TIDy:
+      return "threadIdx.y";
+    case ParallelType::TIDx:
+      return "threadIdx.x";
+    case ParallelType::Vectorize:
+      return "Vectorize";
+    case ParallelType::Unroll:
+      return "Unroll";
+    case ParallelType::Serial:
+      return "Serial";
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "No string found for parallel type.");
+  return nullptr;
+}
+
+static const char* memory_type2string(MemoryType t) {
+  switch (t) {
+    case MemoryType::Local:
+      return "register";
+    case MemoryType::Shared:
+      return "shared";
+    case MemoryType::Global:
+      return "global";
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "No string found for memory type.");
+  return nullptr;
+}
+
+static DataType at_type2data_type(at::ScalarType t) {
+  switch (t) {
+    case at::ScalarType::Bool:
+      return DataType::Bool;
+    case at::ScalarType::Float:
+      return DataType::Float;
+    case at::ScalarType::Half:
+      return DataType::Half;
+    case at::ScalarType::Int:
+      return DataType::Int;
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "No data type found for scalar type.");
+  return DataType::Null;
+}
+
+static const char* thread_size2string(ParallelType t) {
+  switch (t) {
+    case ParallelType::BIDz:
+      return "gridDim.z";
+    case ParallelType::BIDy:
+      return "gridDim.y";
+    case ParallelType::BIDx:
+      return "gridDim.x";
+    case ParallelType::TIDz:
+      return "blockDim.z";
+    case ParallelType::TIDy:
+      return "blockDim.y";
+    case ParallelType::TIDx:
+      return "blockDim.x";
+    default:
+      break;
+  }
+  TORCH_INTERNAL_ASSERT(false, "Could not find size of the thread type ", t);
+  return nullptr;
+}
+
+const unsigned int _WORD_SHIFT = 16;
+constexpr unsigned int supported_switch_pair(DataType t1, DataType t2) {
+  return ((unsigned int)t1 << _WORD_SHIFT) + (unsigned int)t2;
+}
+static const char* supported_casts2string(
+    const std::pair<DataType, DataType>& t) {
+  switch (supported_switch_pair(std::get<0>(t), std::get<1>(t))) {
+    case supported_switch_pair(DataType::Float, DataType::Half):
+      return "__float2half";
+    case supported_switch_pair(DataType::Half, DataType::Float):
+      return "__half2float";
+    default:
+      break;
+  }
+  return nullptr;
+}
 
 bool is_logical_op(const BinaryOpType& bot) {
-  return logical_binary_ops.count(bot) > 0;
+  switch (bot) {
+    case BinaryOpType::And:
+    case BinaryOpType::Eq:
+    case BinaryOpType::GE:
+    case BinaryOpType::GT:
+    case BinaryOpType::LE:
+    case BinaryOpType::LT:
+    case BinaryOpType::NE:
+      return true;
+    default:
+      return false;
+  }
 }
 
 DataType aten_to_data_type(const at::ScalarType& scalar_type) {
-  TORCH_INTERNAL_ASSERT(
-      at_type_map.count(scalar_type) != 0, "No string found for scalar type.");
-  return at_type_map[scalar_type];
+  return at_type2data_type(scalar_type);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const ValType vtype) {
-  TORCH_INTERNAL_ASSERT(
-      val_type_string_map.count(vtype) != 0, "No string found for val type.");
-  return out << val_type_string_map[vtype];
+  return out << val_type2string(vtype);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const DataType dtype) {
-  TORCH_INTERNAL_ASSERT(
-      data_type_string_map.count(dtype) != 0, "No string found for data type.");
-  return out << data_type_string_map[dtype];
+  return out << data_type2string(dtype);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const ExprType etype) {
-  TORCH_INTERNAL_ASSERT(
-      expr_type_string_map.count(etype) != 0, "No string found for expr type.");
-  return out << expr_type_string_map[etype];
+  return out << expr_type2string(etype);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const UnaryOpType uotype) {
-  TORCH_INTERNAL_ASSERT(
-      unary_op_type_string_map.count(uotype) != 0,
-      "No string found for UnaryOp type.");
-  return out << unary_op_type_string_map[uotype];
+  return out << unary_op_type2string(uotype);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const BinaryOpType botype) {
-  TORCH_INTERNAL_ASSERT(
-      binary_op_type_string_map.count(botype) != 0,
-      "No string found for BinaryOp type.");
-  return out << binary_op_type_string_map[botype];
+  return out << binary_op_type2string(botype);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const TernaryOpType totype) {
-  TORCH_INTERNAL_ASSERT(
-      ternary_op_type_string_map.count(totype) != 0,
-      "No string found for TernaryOp type.");
-  return out << ternary_op_type_string_map[totype];
+  return out << ternary_op_type2string(totype);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const ParallelType ptype) {
-  TORCH_INTERNAL_ASSERT(
-      parallel_type_string_map.count(ptype) != 0,
-      "No string found for provided parallel type.");
-  return out << parallel_type_string_map[ptype];
+  return out << parallel_type2string(ptype);
 }
 
 TORCH_CUDA_API std::ostream& operator<<(
     std::ostream& out,
     const MemoryType mtype) {
-  TORCH_INTERNAL_ASSERT(
-      memory_type_string_map.count(mtype) != 0,
-      "No string found for provided memory type.");
-  return out << memory_type_string_map[mtype];
+  return out << memory_type2string(mtype);
 }
 
 TORCH_CUDA_API c10::optional<std::string> inline_op_str(
     const UnaryOpType uotype) {
-  if (unary_op_type_inline_op_string_map.find(uotype) ==
-      unary_op_type_inline_op_string_map.end()) {
-    return c10::nullopt;
-  } else {
-    return unary_op_type_inline_op_string_map[uotype];
-  }
+  const char* str = unary_op_type_inline_op2string(uotype);
+  return str != nullptr ? c10::optional<std::string>(std::string(str))
+                        : c10::nullopt;
 }
 
 TORCH_CUDA_API c10::optional<std::string> inline_op_str(
     const BinaryOpType botype) {
-  if (binary_op_type_inline_op_string_map.find(botype) ==
-      binary_op_type_inline_op_string_map.end()) {
-    return c10::nullopt;
-  } else {
-    return binary_op_type_inline_op_string_map[botype];
-  }
+  const char* str = binary_op_type_inline_op2string(botype);
+  return str != nullptr ? c10::optional<std::string>(std::string(str))
+                        : c10::nullopt;
 }
 
 std::string stringifyThreadSize(const ParallelType ptype) {
-  TORCH_INTERNAL_ASSERT(
-      thread_size_string_map.find(ptype) != thread_size_string_map.end(),
-      "Could not find size of the thread type ",
-      ptype);
-  return thread_size_string_map[ptype];
+  return thread_size2string(ptype);
 }
 
 TORCH_CUDA_API c10::optional<std::string> cast_func_str(
     const std::pair<DataType, DataType>& cast) {
-  if (supported_casts.count(cast) == 0) {
-    return c10::nullopt;
-  } else {
-    return supported_casts[cast];
-  }
+  const char* str = supported_casts2string(cast);
+  return str != nullptr ? c10::optional<std::string>(std::string(str))
+                        : c10::nullopt;
 }
 
 } // namespace fuser


### PR DESCRIPTION
Use switch instead of look ups in global std::unordered_maps<> to do enum-to-name conversions.