### PR TITLE
Stop running target bot on ci-all

### DIFF
--- a/.github/pytorch-circleci-labels.yml
+++ b/.github/pytorch-circleci-labels.yml
@@ -6,7 +6,6 @@ labels_to_circle_params:
     default_true_on:
       branches:
         - nightly
-        - ci-all/.*
         - release/.*
       tags:
         - v[0-9]+(\.[0-9]+)*-rc[0-9]+


### PR DESCRIPTION
So it can still be a useful way to get all the build configs that target specifier can't handle yet

