### PR TITLE
Remove obsolete warning message from DDP

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -360,9 +360,6 @@ class DistributedDataParallel(Module):
                 "Please consider using one DDP instance per device or per "
                 "module replica by explicitly setting device_ids or "
                 "CUDA_VISIBLE_DEVICES. "
-                "NB: There is a known issue in nn.parallel.replicate that "
-                "prevents a single DDP instance to operate on multiple model "
-                "replicas."
             )
 
             # only create replicas for single-device CUDA modules


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40190 Remove obsolete warning message from DDP**
* #40051 Adding torch.futures to API docs

Fixed by #36503

Differential Revision: [D22101516](https://our.internmc.facebook.com/intern/diff/D22101516)