### PR TITLE
Add DefaultBackend as a place to put "backend" implementations that are "generic"

### DIFF
--- a/aten/src/ATen/core/Registrations.cpp
+++ b/aten/src/ATen/core/Registrations.cpp
@@ -1,0 +1,17 @@
+#include <torch/library.h>
+
+#include <ATen/core/boxing/KernelFunction.h>
+
+using torch::CppFunction;
+
+TORCH_LIBRARY_IMPL(_, CPU,    m) { m.fallback(CppFunction::makeFallthrough()); }
+TORCH_LIBRARY_IMPL(_, CUDA,   m) { m.fallback(CppFunction::makeFallthrough()); }
+TORCH_LIBRARY_IMPL(_, HIP,    m) { m.fallback(CppFunction::makeFallthrough()); }
+TORCH_LIBRARY_IMPL(_, FPGA,   m) { m.fallback(CppFunction::makeFallthrough()); }
+TORCH_LIBRARY_IMPL(_, MSNPU,  m) { m.fallback(CppFunction::makeFallthrough()); }
+TORCH_LIBRARY_IMPL(_, XLA,    m) { m.fallback(CppFunction::makeFallthrough()); }
+TORCH_LIBRARY_IMPL(_, Vulkan, m) { m.fallback(CppFunction::makeFallthrough()); }
+
+// For now, not including the more exotic backends like QuantizedCPU or
+// ComplexCPU.  Maybe they should be included; if so, just add them to this
+// list.

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -46,6 +46,16 @@ enum class DispatchKey : uint8_t {
   // backend; e.g., CPU and SparseCPU (sparse must have
   // higher priority).
 
+  // The "default" backend is a generic backend which could be used
+  // by any backend by lowering an operation into other operations (think of it
+  // like "default methods" in Haskell type classes or Rust traits).
+  // If you provide an actual implementation for your backend specifically,
+  // it will be preferred over this implementation, but these implementations
+  // may be of use for backend implementors who don't have time to
+  // implement everything.  Order matters: the DefaultBackend must
+  // be tested after we have checked for everything else.
+  DefaultBackend,
+
   // Here are backends which you think of as traditionally specifying
   // how to implement operations on some device.
   CPU, // registered at build/aten/src/ATen/CPUType.cpp

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -61,7 +61,7 @@ TensorImpl::TensorImpl(Storage&& storage, DispatchKeySet key_set, const caffe2::
       numel_(0),
       data_type_(data_type),
       device_opt_(device_opt),
-      key_set_(key_set) {
+      key_set_(key_set.add(DispatchKey::DefaultBackend)) {
   if (!key_set.empty()) {
     AT_ASSERT(data_type.id() ==  caffe2::TypeIdentifier::uninitialized() ||
               device_opt_.has_value());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40192 Add DefaultBackend as a place to put "backend" implementations that are "generic"**
* #40184 Delete requires_tensor
* #40182 Add some syntax sugar for when backends use the same function.

Sometimes, we have functions which:

1. Have explicit derivatives,
2. But are written in a backend generic way (because they defer to some
   other functions to actually do the dirty work)

Classically, we have registered these functions at both CPU and CUDA
keys, but this is a little dorky because often these functions will
also work for other backends like XLA.  With DefaultBackend, you can
put these registrations

There is a broader question about what ought to be done for backend
generic functions that don't have specific derivatives.  Those are
left to future work.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>