### PR TITLE
[quant][graphmode] Add warning for prim::Loop

### DIFF
--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -1291,6 +1291,10 @@ InsertObserversHelper::insertObserversFor(
             block_observed_values.insert(n->output(i));
           }
         }
+      } else if (n->kind() == prim::Loop) {
+        TORCH_WARN_ONCE("prim::Loop is not yet supported in quantization, "
+                        "please make sure nothing needs to be quantized in the "
+                        "loop");
       }
       for (Value* v : n->outputs()) {
         propagateObservedProperty(v, block_observed_values);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40198 [quant][api] Expose graph mode quantization API in `torch.quantization`
* #40197 [quant][graphmode] Add support for detach
* #40196 [quant][graphmode] Clean up and add more logging
* **#40195 [quant][graphmode] Add warning for prim::Loop**

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22106543](https://our.internmc.facebook.com/intern/diff/D22106543)