### PR TITLE
Move the check on orig_weight sizes.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -485,11 +485,6 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
   const int W = act.size(3);
   const int M = out_ch; // output channels
 
-  TORCH_CHECK( M == orig_weight.size(0),
-      "Output channel size of weight and bias must match.");
-  TORCH_CHECK( C == groups_ * orig_weight.size(1),
-      "Output channel size of weight and bias must match.");
-
   const at::Tensor act_nhwc = act.contiguous(c10::MemoryFormat::ChannelsLast);
 
   auto output_min = kReluFused
@@ -505,6 +500,11 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl(
 
   // Re-quantizing the bias based on input scale and weight scale.
   if (!input_scale.has_value() || input_scale.value() != act_input_scale) {
+    TORCH_CHECK( M == orig_weight.size(0),
+        "Output channel size of weight and bias must match.");
+    TORCH_CHECK( C == groups_ * orig_weight.size(1),
+        "Output channel size of weight and bias must match.");
+
     // Get the original weight and adjust it to uint8 from int8
     auto weight_contig =
         orig_weight.contiguous(c10::MemoryFormat::ChannelsLast);


### PR DESCRIPTION
Summary:
Since original weights are removed by default in mobile build, the check must
be moved to a place where orig_weight is still valid.

Test Plan:
CI
Plus observed a model run crash which was resolved after this change.

Reviewed By: supriyar

Differential Revision: D22101562

