### PR TITLE
Don't clear the rest of the properties while merging in an undefined tensor

### DIFF
--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -135,7 +135,14 @@ void ProfilingRecord::insertShapeProfile(Node* n, Value* i) {
           profiled_types[pno] = pttp;
         }
       } else {
-        profiled_types[pno] = TensorType::get()->withUndefined();
+        if (profiled_types.count(pno) == 0) {
+          profiled_types[pno] = TensorType::get()->withUndefined();
+        } else {
+          // we would like to preserve the accumulated properties
+          // for cases where a tensor was defined
+          auto actual = profiled_types[pno]->withUndefined();
+          profiled_types[pno] = profiled_types[pno]->merge(actual);
+        }
       }
     }
     // passing t through

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -139,7 +139,7 @@ void ProfilingRecord::insertShapeProfile(Node* n, Value* i) {
           profiled_types[pno] = TensorType::get()->withUndefined();
         } else {
           // we would like to preserve the accumulated properties
-          // for cases where a tensor was defined
+          // of the cases when a tensor was defined
           auto actual = profiled_types[pno]->withUndefined();
           profiled_types[pno] = profiled_types[pno]->merge(actual);
         }


### PR DESCRIPTION
Since `undefined` tensors don't possess properties such as shape, scalar type, etc, we shouldn't clear them in a merged profiled `TensorTypePtr`