### PR TITLE
add test_openmp to ROCM_BLACKLIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -126,6 +126,7 @@ ROCM_BLACKLIST = [
     'test_jit_fuser_legacy',
     'test_tensorexpr',
     'test_type_hints',
+    'test_openmp',
 ]
 
 RUN_PARALLEL_BLACKLIST = [


### PR DESCRIPTION
This test is flaky for rocm platform.  Add to blacklist until it can be further reviewed.

CC @ezyang @xw285cornell @sunway513 