### PR TITLE
Remove table of contents at the top of rpc.rst

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -1,8 +1,3 @@
-:orphan:
-
-.. contents:: :local:
-    :depth: 2
-
 .. _distributed-rpc-framework:
 
 Distributed RPC Framework


### PR DESCRIPTION
@mattip - Can we remove the table of contents created by the `.. contents:: :local: :depth: 2` since this page isn't one of the large documentation pages (https://github.com/pytorch/pytorch/issues/38010) and is simply a landing page for the Distributed RPC Framework?

Changes made in this original PR: https://github.com/pytorch/pytorch/commit/f10fbcc820d1507121ed466f3dffc728ef559c5c#diff-250b9b23fd6f1a5c15aecdb72afb9d7d

cc @mrshenli

