### PR TITLE
Switch executor from simple to legacy in OSS builds.

### DIFF
--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -39,7 +39,7 @@ namespace jit {
 static std::atomic<bool> executor_mode{true};
 static std::atomic<bool> profiling_mode{false};
 #else
-static std::atomic<bool> executor_mode{true};
+static std::atomic<bool> executor_mode{false};
 static std::atomic<bool> profiling_mode{false};
 #endif
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40230 Switch executor from simple to legacy in OSS builds.**

