### PR TITLE
print position of the operator that failed to onnxifi

### DIFF
--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -1230,7 +1230,8 @@ bool OnnxifiTransformer::supportOpC2(
     auto ret = lib_->onnxGetBackendCompatibility(
         backend_id, c2_model_str.size(), c2_model_str.c_str());
     if (ret != ONNXIFI_STATUS_SUCCESS) {
-      LOG(INFO) << "Don't support c2 op " << op.type() << " (" << ret << ")";
+      LOG(INFO) << "Don't support c2 op " << op.type() << " at pos " << pos
+                << " (" << ret << ")";
       return false;
     } else {
       return true;


### PR DESCRIPTION
Summary: if an operator failed to onnxifi due to lack of support (not because of missing shapes), print out the position of such op, which can be used to feed net runner

Test Plan: I0618 09:25:06.299002 1570804 onnxifi_transformer.cc:1232] Don't support c2 op SparseLengthsSumFused4BitRowwise at pos 246 (1030)

Differential Revision: D22120055

