### PR TITLE
fix `torch.jit.trace_module` documentation

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1006,9 +1006,9 @@ def trace_module(mod,
 
     Arguments:
         mod (torch.nn.Module):  A ``torch.nn.Module`` containing methods whose names are
-                                specified in ``example_inputs``. The given methods will be compiled
+                                specified in ``inputs``. The given methods will be compiled
                                 as a part of a single `ScriptModule`.
-        example_inputs (dict):  A dict containing sample inputs indexed by method names in ``mod``.
+        inputs (dict):  A dict containing sample inputs indexed by method names in ``mod``.
                                 The inputs will be passed to methods whose names correspond to inputs'
                                 keys while tracing.
                                 ``{ 'forward' : example_forward_input, 'method2': example_method2_input}``


### PR DESCRIPTION
This should fix #39328 

Before:

![image](https://user-images.githubusercontent.com/24580222/85076992-4720e800-b18f-11ea-9c6e-19bcf3f1cb7d.png)

After:

![image](https://user-images.githubusercontent.com/24580222/85077064-6ddf1e80-b18f-11ea-9274-e8cee6909baa.png)
