### PR TITLE
Assert that kernels are called with the right signature

### DIFF
--- a/aten/src/ATen/core/boxing/impl/test_helpers.h
+++ b/aten/src/ATen/core/boxing/impl/test_helpers.h
@@ -40,14 +40,12 @@ inline std::vector<c10::IValue> callOp(const c10::OperatorHandle& op, Args... ar
 
 template<class Result, class... Args>
 inline Result callOpUnboxed(const c10::OperatorHandle& op, Args... args) {
-  return c10::Dispatcher::singleton()
-      .template call<Result, Args...>(op, std::forward<Args>(args)...);
+  return op.typed<Result(Args...)>().call(std::forward<Args>(args)...);
 }
 
 template<class Result, class... Args>
 inline Result callOpUnboxedWithDispatchKey(const c10::OperatorHandle& op, c10::DispatchKey dispatchKey, Args... args) {
-  return c10::Dispatcher::singleton()
-      .template callWithDispatchKey<Result, Args...>(op, dispatchKey, std::forward<Args>(args)...);
+  return op.typed<Result(Args...)>().callWithDispatchKey(dispatchKey, std::forward<Args>(args)...);
 }
 
 inline void expectDoesntFindKernel(const char* op_name, c10::DispatchKey dispatch_key) {

--- a/aten/src/ATen/core/dispatch/CppSignature.h
+++ b/aten/src/ATen/core/dispatch/CppSignature.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <typeindex>
+#include <c10/macros/Macros.h>
+#include <c10/util/Metaprogramming.h>
+#include <c10/util/Type.h>
+
+namespace c10 {
+namespace impl {
+
+// A CppSignature object holds RTTI information about a C++ function signature at runtime
+// and can compare them or get a debug-printable name.
+class CAFFE2_API CppSignature final {
+public:
+    CppSignature(const CppSignature&) = default;
+    CppSignature(CppSignature&&) noexcept = default;
+    CppSignature& operator=(const CppSignature&) = default;
+    CppSignature& operator=(CppSignature&&) noexcept = default;
+
+    template<class FuncType>
+    static CppSignature make() {
+        // Normalize functors, lambdas, function pointers, etc. into the plain function type
+        using decayed_function_type = typename guts::infer_function_traits_t<std::decay_t<FuncType>>::func_type;
+
+        return CppSignature(std::type_index(typeid(decayed_function_type)));
+    }
+
+    std::string name() const {
+        return c10::demangle(signature_.name());
+    }
+
+    friend bool operator==(const CppSignature& lhs, const CppSignature& rhs) {
+        if (lhs.signature_ == rhs.signature_) {
+            return true;
+        }
+        // Without RTLD_GLOBAL, the type_index comparison could yield false because
+        // they point to different instances of the RTTI data, but the types would
+        // still be the same. Let's check for that case too.
+        // Note that there still is a case where this might not work, i.e. when
+        // linking libraries of different compilers together, they might have
+        // different ways to serialize a type name. That, together with a missing
+        // RTLD_GLOBAL, would still fail this.
+        if (lhs.name() == rhs.name()) {
+            return true;
+        }
+
+        return false;
+    }
+
+private:
+    explicit CppSignature(std::type_index signature): signature_(std::move(signature)) {}
+    std::type_index signature_;
+};
+
+inline bool operator!=(const CppSignature& lhs, const CppSignature& rhs) {
+    return !(lhs == rhs );
+}
+
+}
+}

--- a/aten/src/ATen/core/dispatch/CppSignature_test.cpp
+++ b/aten/src/ATen/core/dispatch/CppSignature_test.cpp
@@ -1,0 +1,38 @@
+#include <ATen/core/dispatch/CppSignature.h>
+#include <gtest/gtest.h>
+#include <string>
+
+using c10::impl::CppSignature;
+
+namespace {
+
+TEST(CppSignatureTest, given_equalSignature_then_areEqual) {
+    EXPECT_EQ(CppSignature::make<void()>(), CppSignature::make<void()>());
+    EXPECT_EQ(CppSignature::make<int64_t(std::string, int64_t)>(), CppSignature::make<int64_t(std::string, int64_t)>());
+}
+
+TEST(CppSignatureTest, given_differentSignature_then_areDifferent) {
+    EXPECT_NE(CppSignature::make<void()>(), CppSignature::make<int64_t()>());
+    EXPECT_NE(CppSignature::make<int64_t(std::string)>(), CppSignature::make<int64_t(std::string, int64_t)>());
+    EXPECT_NE(CppSignature::make<std::string(std::string)>(), CppSignature::make<int64_t(std::string)>());
+}
+
+TEST(CppSignatureTest, given_equalFunctorAndFunction_then_areEqual) {
+    struct Functor final {
+        int64_t operator()(std::string) {return 0;}
+    };
+    EXPECT_EQ(CppSignature::make<Functor>(), CppSignature::make<int64_t(std::string)>());
+}
+
+TEST(CppSignatureTest, given_differentFunctorAndFunction_then_areDifferent) {
+    struct Functor final {
+        int64_t operator()(std::string) {return 0;}
+    };
+    EXPECT_NE(CppSignature::make<Functor>(), CppSignature::make<int64_t(std::string, int64_t)>());
+}
+
+TEST(CppSignatureTest, given_cppSignature_then_canQueryNameWithoutCrashing) {
+    CppSignature::make<void(int64_t, const int64_t&)>().name();
+}
+
+}

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -198,6 +198,7 @@ RegistrationHandleRAII Dispatcher::registerImpl(
   OperatorName op_name,
   c10::optional<DispatchKey> dispatch_key,
   KernelFunction kernel,
+  c10::optional<impl::CppSignature> cpp_signature,
   std::unique_ptr<FunctionSchema> inferred_function_schema,
   std::string debug
 ) {
@@ -205,7 +206,7 @@ RegistrationHandleRAII Dispatcher::registerImpl(
 
   auto op = findOrRegisterName_(op_name);
 
-  auto handle = op.operatorIterator_->op.registerKernel(dispatch_key, std::move(kernel), std::move(inferred_function_schema), std::move(debug));
+  auto handle = op.operatorIterator_->op.registerKernel(dispatch_key, std::move(kernel), std::move(cpp_signature), std::move(inferred_function_schema), std::move(debug));
 
   ++op.operatorIterator_->def_and_impl_count;
 

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/dispatch/OperatorEntry.h>
+#include <ATen/core/dispatch/CppSignature.h>
 #include <ATen/core/dispatch/RegistrationHandleRAII.h>
 #include <c10/util/Exception.h>
 #include <c10/util/LeftRight.h>
@@ -10,6 +11,7 @@
 namespace c10 {
 
 class CAFFE2_API OperatorHandle;
+template<class FuncType> class TypedOperatorHandle;
 
 /**
  * Implement this interface and register your instance with the dispatcher
@@ -59,6 +61,7 @@ private:
     size_t def_and_impl_count = 0;
   };
   friend class OperatorHandle;
+  template<class> friend class TypedOperatorHandle;
 
 public:
   ~Dispatcher();
@@ -107,12 +110,12 @@ public:
   // ------------------------------------------------------------------------
 
   template<class Return, class... Args>
-  Return call(const OperatorHandle& op, Args... args) const;
+  Return call(const TypedOperatorHandle<Return (Args...)>& op, Args... args) const;
 
   // Like call, but override the default DispatchKey calculation code,
   // instead dispatching straight to the provided DispatchKey
   template<class Return, class... Args>
-  Return callWithDispatchKey(const OperatorHandle& op, DispatchKey dispatchKey, Args... args) const;
+  Return callWithDispatchKey(const TypedOperatorHandle<Return (Args...)>& op, DispatchKey dispatchKey, Args... args) const;
 
   // Like call, but intended for use in a redispatch: you are currently
   // in some currentDispatchKey, you have finished processing the key and
@@ -120,7 +123,7 @@ public:
   // This will mask out the current key *and all previous keys* from the
   // eligible set, and reinvoke the dispatcher.
   template<class Return, class... Args>
-  Return redispatch(const OperatorHandle& op, DispatchKey currentDispatchKey, Args... args) const;
+  Return redispatch(const TypedOperatorHandle<Return (Args...)>& op, DispatchKey currentDispatchKey, Args... args) const;
 
   // Invoke an operator via the boxed calling convention using an IValue stack
   void callBoxed(const OperatorHandle& op, Stack* stack) const;
@@ -148,7 +151,7 @@ public:
    */
   // NB: steals the inferred function schema, as we may need to hold on to
   // it for a bit until the real schema turns up
-  RegistrationHandleRAII registerImpl(OperatorName op_name, c10::optional<DispatchKey> dispatch_key, KernelFunction kernel, std::unique_ptr<FunctionSchema> inferred_function_schema, std::string debug);
+  RegistrationHandleRAII registerImpl(OperatorName op_name, c10::optional<DispatchKey> dispatch_key, KernelFunction kernel, c10::optional<impl::CppSignature> cpp_signature, std::unique_ptr<FunctionSchema> inferred_function_schema, std::string debug);
 
   /**
    * Register a new operator by name.
@@ -232,7 +235,7 @@ private:
  * This handle can be used to register kernels with the dispatcher or
  * to lookup a kernel for a certain set of arguments.
  */
-class CAFFE2_API OperatorHandle final {
+class CAFFE2_API OperatorHandle {
 public:
   OperatorHandle(OperatorHandle&&) noexcept = default;
   OperatorHandle& operator=(OperatorHandle&&) noexcept = default;
@@ -263,14 +266,10 @@ public:
     return operatorIterator_->op.checkInvariants();
   }
 
-  template<class Return, class... Args>
-  Return call(Args... args) const {
-    return c10::Dispatcher::singleton().call<Return, Args...>(*this, std::forward<Args>(args)...);
-  }
-
-  template<class Return, class... Args>
-  Return callWithDispatchKey(DispatchKey dispatchKey, Args... args) const {
-    return c10::Dispatcher::singleton().callWithDispatchKey<Return, Args...>(*this, dispatchKey, std::forward<Args>(args)...);
+  template<class FuncType>
+  TypedOperatorHandle<FuncType> typed() const {
+    operatorIterator_->op.assertSignatureIsCorrect<FuncType>();
+    return TypedOperatorHandle<FuncType>(operatorIterator_);
   }
 
   void callBoxed(Stack* stack) const {
@@ -281,8 +280,41 @@ private:
   explicit OperatorHandle(std::list<Dispatcher::OperatorDef>::iterator operatorIterator)
   : operatorIterator_(std::move(operatorIterator)) {}
   friend class Dispatcher;
+  template<class> friend class TypedOperatorHandle;
 
   std::list<Dispatcher::OperatorDef>::iterator operatorIterator_;
+};
+
+/**
+ * This is a handle to an operator schema registered with the dispatcher.
+ * It holds the same information as an OperatorHandle, but it is templated
+ * on the operator arguments and allows calling the operator in an
+ * unboxed way.
+ */
+template<class FuncType>
+class TypedOperatorHandle final {
+  static_assert(guts::false_t<FuncType>(), "FuncType in OperatorHandle::typed<FuncType> was not a valid function type");
+};
+template<class Return, class... Args>
+class TypedOperatorHandle<Return (Args...)> final : public OperatorHandle {
+public:
+  TypedOperatorHandle(TypedOperatorHandle&&) noexcept = default;
+  TypedOperatorHandle& operator=(TypedOperatorHandle&&) noexcept = default;
+  TypedOperatorHandle(const TypedOperatorHandle&) = default;
+  TypedOperatorHandle& operator=(const TypedOperatorHandle&) = default;
+
+  Return call(Args... args) const {
+    return c10::Dispatcher::singleton().call<Return, Args...>(*this, std::forward<Args>(args)...);
+  }
+
+  Return callWithDispatchKey(DispatchKey dispatchKey, Args... args) const {
+    return c10::Dispatcher::singleton().callWithDispatchKey<Return, Args...>(*this, dispatchKey, std::forward<Args>(args)...);
+  }
+
+private:
+  explicit TypedOperatorHandle(std::list<Dispatcher::OperatorDef>::iterator operatorIterator)
+  : OperatorHandle(std::move(operatorIterator)) {}
+  friend class OperatorHandle;
 };
 
 namespace detail {
@@ -290,7 +322,7 @@ template<class... Args> inline void unused_arg_(const Args&...) {}
 }
 
 template<class Return, class... Args>
-inline Return Dispatcher::callWithDispatchKey(const OperatorHandle& op, DispatchKey dispatchKey, Args... args) const {
+inline Return Dispatcher::callWithDispatchKey(const TypedOperatorHandle<Return(Args...)>& op, DispatchKey dispatchKey, Args... args) const {
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
   const auto& dispatchTable = op.operatorIterator_->op.dispatch_table();
   const KernelFunction& kernel = dispatch_(dispatchTable, dispatchKey);
@@ -298,18 +330,18 @@ inline Return Dispatcher::callWithDispatchKey(const OperatorHandle& op, Dispatch
 }
 
 template<class Return, class... Args>
-inline Return Dispatcher::call(const OperatorHandle& op, Args... args) const {
+inline Return Dispatcher::call(const TypedOperatorHandle<Return(Args...)>& op, Args... args) const {
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
   const auto& dispatchTable = op.operatorIterator_->op.dispatch_table();
-  auto dispatchKey = dispatchTable.dispatchKeyExtractor().getDispatchKeyUnboxed<Args...>(backendsWithoutFallthrough_, DispatchKeySet::FULL, args...);
+  auto dispatchKey = dispatchTable.dispatchKeyExtractor().template getDispatchKeyUnboxed<Args...>(backendsWithoutFallthrough_, DispatchKeySet::FULL, args...);
   return callWithDispatchKey<Return, Args...>(op, dispatchKey, args...);
 }
 
 template<class Return, class... Args>
-inline Return Dispatcher::redispatch(const OperatorHandle& op, DispatchKey currentDispatchKey, Args... args) const {
+inline Return Dispatcher::redispatch(const TypedOperatorHandle<Return (Args...)>& op, DispatchKey currentDispatchKey, Args... args) const {
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
   const auto& dispatchTable = op.operatorIterator_->op.dispatch_table();
-  auto dispatchKey = dispatchTable.dispatchKeyExtractor().getDispatchKeyUnboxed<Args...>(
+  auto dispatchKey = dispatchTable.dispatchKeyExtractor().template getDispatchKeyUnboxed<Args...>(
     backendsWithoutFallthrough_,
     DispatchKeySet(DispatchKeySet::FULL_AFTER, currentDispatchKey),
     args...);

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -33,8 +33,9 @@ namespace {
   }
 }
 
-CppFunction::CppFunction(c10::KernelFunction func, std::unique_ptr<c10::FunctionSchema> schema)
+CppFunction::CppFunction(c10::KernelFunction func, c10::optional<c10::impl::CppSignature> cpp_signature, std::unique_ptr<c10::FunctionSchema> schema)
   : func_(std::move(func))
+  , cpp_signature_(std::move(cpp_signature))
   , schema_(std::move(schema))
   , debug_()
   {}
@@ -153,6 +154,7 @@ Library& Library::_def(c10::either<c10::OperatorName, c10::FunctionSchema>&& nam
       std::move(name),
       dispatch_key,
       std::move(f.func_),
+      std::move(f.cpp_signature_),
       std::move(f.schema_),
       debugString(std::move(f.debug_), file_, line_)
     )
@@ -197,6 +199,7 @@ Library& Library::_impl(const char* name_str, CppFunction&& f) & {
       std::move(name),
       dispatch_key,
       std::move(f.func_),
+      std::move(f.cpp_signature_),
       std::move(f.schema_),
       debugString(std::move(f.debug_), file_, line_)
     )

--- a/aten/src/ATen/core/op_registration/op_registration.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration.cpp
@@ -99,7 +99,7 @@ void RegisterOperators::registerOp_(Options&& options) {
 
   for (auto& kernel : options.kernels) {
     registrars_.emplace_back(
-      Dispatcher::singleton().registerImpl(op_name, kernel.dispatch_key, std::move(kernel.func), std::move(kernel.inferred_function_schema), "registered by RegisterOperators")
+      Dispatcher::singleton().registerImpl(op_name, kernel.dispatch_key, std::move(kernel.func), std::move(kernel.cpp_signature), std::move(kernel.inferred_function_schema), "registered by RegisterOperators")
     );
   }
 }

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -702,7 +702,7 @@ TEST(OperatorRegistrationTest, whenRegisteringMismatchingKernelsInSameOpCall_the
     auto registrar1 = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
       .kernel<DummyKernelWithIntParam>(c10::DispatchKey::CPU)
       .kernel<MockKernel>(c10::DispatchKey::CUDA, &called_kernel));
-  }, "In registration for _test::dummy: expected schema");
+  }, "mismatched with a previous kernel that had the signature");
 }
 
 void backend_fallback_kernel(const c10::OperatorHandle& op, c10::Stack* stack) {
@@ -813,7 +813,7 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernel_thenCanCallAutograd
   ASSERT_TRUE(op.has_value());
 
   called_autograd = false;
-  c10::Dispatcher::singleton().call<void, Tensor>(*op, dummyTensor(DispatchKey::CPU)); // note: all tensors have VariableTypeId set
+  op->typed<void(Tensor)>().call(dummyTensor(DispatchKey::CPU)); // note: all tensors have VariableTypeId set
   EXPECT_TRUE(called_autograd);
 }
 
@@ -826,7 +826,7 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernelWithRegularKernel_th
   ASSERT_TRUE(op.has_value());
 
   called_nonautograd = called_autograd = false;
-  c10::Dispatcher::singleton().call<void, Tensor>(*op, dummyTensor(DispatchKey::CPU)); // note: all tensors have VariableTypeId set
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU)); // note: all tensors have VariableTypeId set
   EXPECT_FALSE(called_nonautograd);
   EXPECT_TRUE(called_autograd);
 }
@@ -841,7 +841,7 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernelWithRegularKernel_th
 
   called_nonautograd = called_autograd = false;
   at::AutoNonVariableTypeMode _var_guard(true);
-  c10::Dispatcher::singleton().call<void, Tensor>(*op, dummyTensor(DispatchKey::CPU));
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU));
   EXPECT_TRUE(called_nonautograd);
   EXPECT_FALSE(called_autograd);
 }
@@ -855,7 +855,7 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernelWithCatchAllKernel_t
   ASSERT_TRUE(op.has_value());
 
   called_nonautograd = called_autograd = false;
-  c10::Dispatcher::singleton().call<void, Tensor>(*op, dummyTensor(DispatchKey::CPU));  // note: all tensors have VariableTypeId set
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU));  // note: all tensors have VariableTypeId set
   EXPECT_FALSE(called_nonautograd);
   EXPECT_TRUE(called_autograd);
 }
@@ -870,7 +870,7 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernelWithCatchAllKernel_t
 
   called_nonautograd = called_autograd = false;
   at::AutoNonVariableTypeMode _var_guard(true);
-  c10::Dispatcher::singleton().call<void, Tensor>(*op, dummyTensor(DispatchKey::CPU));
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU));
   EXPECT_TRUE(called_nonautograd);
   EXPECT_FALSE(called_autograd);
 }
@@ -884,14 +884,87 @@ TEST(OperatorRegistrationTest, xlaPreAutogradOverridesAutogradKernel) {
   ASSERT_TRUE(op.has_value());
 
   called_nonautograd = called_autograd = false;
-  c10::Dispatcher::singleton().call<void, Tensor>(*op, dummyTensor(c10::DispatchKeySet{DispatchKey::XLA, DispatchKey::XLAPreAutograd}));
+  op->typed<void (Tensor)>().call(dummyTensor(c10::DispatchKeySet{DispatchKey::XLA, DispatchKey::XLAPreAutograd}));
   EXPECT_TRUE(called_nonautograd);
   EXPECT_FALSE(called_autograd);
 
   called_nonautograd = called_autograd = false;
-  c10::Dispatcher::singleton().call<void, Tensor>(*op, dummyTensor(DispatchKey::CPU));
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU));
   EXPECT_TRUE(called_autograd);
   EXPECT_FALSE(called_nonautograd);
+}
+
+TEST(OperatorRegistrationTest, givenLambdaKernel_whenRegisteringWithMismatchingCppSignatures_thenFails) {
+  auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+    .kernel(DispatchKey::CPU, [] (int64_t) {}));
+  expectThrows<c10::Error>([] {
+    auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+      .kernel(DispatchKey::CPU, [] (const int64_t&) {}));
+  }, "mismatched with a previous kernel that had the signature");
+}
+
+TEST(OperatorRegistrationTest, givenLambdaKernel_whenRegisteringCatchAllAndBackendWithMismatchingCppSignatures_thenFails) {
+  auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+    .catchAllKernel([] (int64_t) {}));
+  expectThrows<c10::Error>([] {
+    auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+      .kernel(DispatchKey::CPU, [] (const int64_t&) {}));
+  }, "mismatched with a previous kernel that had the signature");
+}
+
+TEST(OperatorRegistrationTest, givenLambdaKernel_whenRegisteringBackendAndCatchAllWithMismatchingCppSignatures_thenFails) {
+  auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+    .kernel(DispatchKey::CPU, [] (int64_t) {}));
+  expectThrows<c10::Error>([] {
+    auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+      .catchAllKernel([] (const int64_t&) {}));
+  }, "mismatched with a previous kernel that had the signature");
+}
+
+TEST(OperatorRegistrationTest, givenLambdaKernel_whenAccessingWithMismatchingCppSignatures_thenFails) {
+  auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+    .kernel(DispatchKey::CPU, [] (int64_t) {}));
+  expectThrows<c10::Error>([] {
+    c10::Dispatcher::singleton().findSchemaOrThrow("_test::dummy", "")
+      .typed<void(const int64_t&)>();
+  }, "Tried to access operator _test::dummy with a wrong signature");
+}
+
+TEST(OperatorRegistrationTest, givenLambdaKernel_whenAccessingCatchAllWithMismatchingCppSignatures_thenFails) {
+  auto registrar = c10::RegisterOperators().op("_test::dummy", c10::RegisterOperators::options()
+    .catchAllKernel([] (int64_t) {}));
+  expectThrows<c10::Error>([] {
+    c10::Dispatcher::singleton().findSchemaOrThrow("_test::dummy", "")
+      .typed<void(const int64_t&)>();
+  }, "Tried to access operator _test::dummy with a wrong signature");
+}
+
+TEST(OperatorRegistrationTest, givenTorchLibrary_whenRegisteringWithMismatchingCppSignatures_thenFails) {
+  auto m = MAKE_TORCH_LIBRARY(_test);
+  m.def("dummy(int a) -> ()");
+  m.impl("dummy", DispatchKey::CPU, [] (int64_t) {});
+  expectThrows<c10::Error>([&] {
+    m.impl("dummy", DispatchKey::CUDA, [] (const int64_t&) {});
+  }, "mismatched with a previous kernel that had the signature");
+}
+
+TEST(OperatorRegistrationTest, givenTorchLibrary_whenAccessingWithMismatchingCppSignatures_thenFails) {
+  auto m = MAKE_TORCH_LIBRARY(_test);
+  m.def("dummy(int a) -> ()");
+  m.impl("dummy", DispatchKey::CPU, [] (int64_t) {});
+  expectThrows<c10::Error>([] {
+    c10::Dispatcher::singleton().findSchemaOrThrow("_test::dummy", "")
+      .typed<void(const int64_t&)>();
+  }, "Tried to access operator _test::dummy with a wrong signature");
+}
+
+TEST(OperatorRegistrationTest, givenTorchLibrary_whenAccessingCatchAllWithMismatchingCppSignatures_thenFails) {
+  auto m = MAKE_TORCH_LIBRARY(_test);
+  m.def("dummy(int a) -> ()", [] (int64_t) {});
+  expectThrows<c10::Error>([] {
+    c10::Dispatcher::singleton().findSchemaOrThrow("_test::dummy", "")
+      .typed<void(const int64_t&)>();
+  }, "Tried to access operator _test::dummy with a wrong signature");
 }
 
 /**
@@ -1566,8 +1639,8 @@ TEST(NewOperatorRegistrationTest, BackendSelectRedispatchesToCPU) {
   m.impl("fn", c10::kCPU, [&](const Tensor& x) { cpu_called = true; return x; });
   m.impl("fn", c10::DispatchKey::BackendSelect, [&](const Tensor& x) {
      backend_generic_called = true;
-     auto op = c10::Dispatcher::singleton().findSchema({"test::fn", ""});
-     return c10::Dispatcher::singleton().redispatch<Tensor, const Tensor&>(*op, c10::DispatchKey::BackendSelect, x);
+     auto op = c10::Dispatcher::singleton().findSchema({"test::fn", ""}).value().typed<Tensor (const Tensor&)>();
+     return c10::Dispatcher::singleton().redispatch<Tensor, const Tensor&>(op, c10::DispatchKey::BackendSelect, x);
    });
 
   auto op = Dispatcher::singleton().findSchema({"test::fn", ""});

--- a/aten/src/ATen/gen_backend_select_register.py
+++ b/aten/src/ATen/gen_backend_select_register.py
@@ -31,9 +31,11 @@ FUNCTION_REGISTRATION = CodeTemplate("""\
 FUNCTION_DEFINITION = CodeTemplate("""\
 // ${schema_string}
 Tensor ${function_name}(${method_formals}) {
-  static OperatorHandle OP = c10::Dispatcher::singleton().findSchemaOrThrow("aten::${name}", "${overload_name}");
+  static auto op = c10::Dispatcher::singleton()
+    .findSchemaOrThrow("aten::${name}", "${overload_name}")
+    .typed<${cpp_signature}>();
   ${dispatch_key_init}
-  return OP.callWithDispatchKey<${formals_types}>(_dk, ${actuals});
+  return op.callWithDispatchKey(_dk, ${actuals});
 }
 """)
 
@@ -74,7 +76,7 @@ def register_backend_select_methods(declarations, template_path, file_manager):
                                                             name=option['name'],
                                                             overload_name=option['overload_name'],
                                                             dispatch_key_init=dispatch_key_init,
-                                                            formals_types=option['formals_types_with_return'],
+                                                            cpp_signature=option['cpp_signature'],
                                                             actuals=option['actuals'])
 
                 backend_select_function_registrations.append(func_reg)

--- a/test/cpp_extensions/msnpu_extension.cpp
+++ b/test/cpp_extensions/msnpu_extension.cpp
@@ -20,7 +20,7 @@ Tensor get_tensor(caffe2::TypeMeta dtype, IntArrayRef size) {
   return Tensor(std::move(tensor_impl));
 }
 
-Tensor empty_override(IntArrayRef size, const TensorOptions & options) {
+Tensor empty_override(IntArrayRef size, const TensorOptions& options, c10::optional<c10::MemoryFormat> optional_memory_format) {
   test_int = 0;
   return get_tensor(options.dtype(), size);
 }

--- a/test/mobile/op_deps/main.cc
+++ b/test/mobile/op_deps/main.cc
@@ -13,9 +13,9 @@ int main() {
   at::call_DD_op(input);
   at::call_EE_op(input);
   at::call_FF_op(input);
-  const c10::OperatorHandle t_add = c10::Dispatcher::singleton().findSchema({"quantized::t_add", ""}).value();
-  const c10::OperatorHandle t_add_relu = c10::Dispatcher::singleton().findSchema({"quantized::t_add_relu", ""}).value();
-  t_add.call<at::Tensor, at::Tensor, at::Tensor, double, int64_t>(input, input, 1.0, 0);
-  t_add_relu.call<at::Tensor, at::Tensor, at::Tensor, double, int64_t>(input, input, 1.0, 0);
+  const auto t_add = c10::Dispatcher::singleton().findSchemaOrThrow("quantized::t_add", "").typed<at::Tensor(at::Tensor, at::Tensor, double, int64_t)>();
+  const auto t_add_relu = c10::Dispatcher::singleton().findSchemaOrThrow("quantized::t_add_relu", "").typed<at::Tensor (at::Tensor, at::Tensor, double, int64_t)>();
+  t_add.call(input, input, 1.0, 0);
+  t_add_relu.call(input, input, 1.0, 0);
   return 0;
 }

--- a/test/mobile/op_deps/quantized_ops.cpp
+++ b/test/mobile/op_deps/quantized_ops.cpp
@@ -18,16 +18,16 @@ Tensor _add_out(Tensor& out, const Tensor& self, const Tensor& other);
 template <>
 Tensor _add_out<false>(Tensor& out, const Tensor& self, const Tensor& other) {
   constexpr auto kName = "quantized::t_helper1";
-  static const c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({kName, ""}).value();
-  op.call<Tensor, Tensor>(self);
+  static const auto op = c10::Dispatcher::singleton().findSchemaOrThrow(kName, "").typed<Tensor(Tensor)>();;
+  op.call(self);
   return out;
 }
 
 template <>
 Tensor _add_out<true>(Tensor& out, const Tensor& self, const Tensor& other) {
   constexpr auto kName = "quantized::t_helper2";
-  static const c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({kName, ""}).value();
-  op.call<Tensor, Tensor>(self);
+  static const auto op = c10::Dispatcher::singleton().findSchemaOrThrow(kName, "").typed<Tensor(Tensor)>();
+  op.call(self);
   return out;
 }
 
@@ -45,8 +45,8 @@ Tensor QHelper(Tensor qa) {
   std::cout << "Op: " << opName << std::endl;
   if (callOpName != nullptr) {
     std::cout << "Call op: " << callOpName << std::endl;
-    static const c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({callOpName, ""}).value();
-    op.call<Tensor, Tensor>(qa);
+    static const auto op = c10::Dispatcher::singleton().findSchemaOrThrow(callOpName, "").typed<Tensor(Tensor)>();
+    op.call(qa);
   }
   return qa;
 }

--- a/test/mobile/op_deps/simple_ops.h
+++ b/test/mobile/op_deps/simple_ops.h
@@ -6,45 +6,45 @@
 namespace at {
 
 static inline Tensor call_AA_op(const Tensor& self) {
-  static c10::OperatorHandle op = c10::Dispatcher::singleton()
-      .findSchema({"_test::AA", ""}).value();
-  return c10::Dispatcher::singleton().call<Tensor, const Tensor&>(
-      op, self, self);
+  static const auto op = c10::Dispatcher::singleton()
+      .findSchemaOrThrow("_test::AA", "")
+      .typed<Tensor(const Tensor&)>();
+  return op.call(self);
 }
 
 static inline Tensor call_BB_op(const Tensor& self) {
-  static c10::OperatorHandle op = c10::Dispatcher::singleton()
-      .findSchema({"_test::BB", ""}).value();
-  return c10::Dispatcher::singleton().call<Tensor, const Tensor&>(
-      op, self, self);
+  static const auto op = c10::Dispatcher::singleton()
+      .findSchemaOrThrow("_test::BB", "")
+      .typed<Tensor(const Tensor&)>();
+  return op.call(self);
 }
 
 static inline Tensor call_CC_op(const Tensor& self) {
-  static c10::OperatorHandle op = c10::Dispatcher::singleton()
-      .findSchema({"_test::CC", ""}).value();
-  return c10::Dispatcher::singleton().call<Tensor, const Tensor&>(
-      op, self, self);
+  static const auto op = c10::Dispatcher::singleton()
+      .findSchemaOrThrow("_test::CC", "")
+      .typed<Tensor(const Tensor&)>();
+  return op.call(self);
 }
 
 static inline Tensor call_DD_op(const Tensor& self) {
-  static c10::OperatorHandle op = c10::Dispatcher::singleton()
-      .findSchema({"_test::DD", ""}).value();
-  return c10::Dispatcher::singleton().call<Tensor, const Tensor&>(
-      op, self, self);
+  static const auto op = c10::Dispatcher::singleton()
+      .findSchemaOrThrow("_test::DD", "")
+      .typed<Tensor(const Tensor&)>();
+  return op.call(self);
 }
 
 static inline Tensor call_EE_op(const Tensor& self) {
-  static c10::OperatorHandle op = c10::Dispatcher::singleton()
-      .findSchema({"_test::EE", ""}).value();
-  return c10::Dispatcher::singleton().call<Tensor, const Tensor&>(
-      op, self, self);
+  static const auto op = c10::Dispatcher::singleton()
+      .findSchemaOrThrow("_test::EE", "")
+      .typed<Tensor(const Tensor&)>();
+  return op.call(self);
 }
 
 static inline Tensor call_FF_op(const Tensor& self) {
-  static c10::OperatorHandle op = c10::Dispatcher::singleton()
-      .findSchema({"_test::FF", ""}).value();
-  return c10::Dispatcher::singleton().call<Tensor, const Tensor&>(
-      op, self, self);
+  static const auto op = c10::Dispatcher::singleton()
+      .findSchemaOrThrow("_test::FF", "")
+      .typed<Tensor(const Tensor&)>();
+  return op.call(self);
 }
 
 } // namespace at

--- a/test/mobile/op_deps/utils.cpp
+++ b/test/mobile/op_deps/utils.cpp
@@ -25,10 +25,10 @@ Tensor global_helper_call_AA_op_2(const Tensor& self) {
 
 Tensor global_helper_call_AA_op_3(const Tensor& self) {
   auto lambda = [&]() {
-    static c10::OperatorHandle op = c10::Dispatcher::singleton()
-        .findSchema({"_test::AA", ""}).value();
-    return c10::Dispatcher::singleton().call<Tensor, const Tensor&>(
-        op, self, self);
+    static const auto op = c10::Dispatcher::singleton()
+        .findSchemaOrThrow("_test::AA", "")
+        .typed<Tensor (const Tensor&)>();
+    return op.call(self);
   };
   return lambda();
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39611 Unify TensorOptions signatures
* #39492 Move TensorOptions ops to c10
* **#40251 Assert that kernels are called with the right signature**

This re-lands the reverted PR https://github.com/pytorch/pytorch/pull/38361.

Rather than segfaulting, we should show a good error message when in op.call<Return, Args...>(...) the Return type or Args types mismatch the kernel.

This adds an assertion comparing two std::type_index to the call path, but that should be fast. Hashing the function signature is also in the call path and not strictly constexpr, but I checked on godbolt that GCC >=5 and Clang >=3.8 optimize it away and make it constexpr, i.e. it's not part of the assembly.

Differential Revision: [D22126701](https://our.internmc.facebook.com/intern/diff/D22126701/)