### PR TITLE
Add warning to distributed autograd about CPU only support.

### DIFF
--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -143,6 +143,10 @@ Arguments:
                   in a much more efficient way. Usually, you need to set this
                   to True to run backward multiple times.
 
+.. warning::
+    Distributed autograd does not support autograd graphs consisting of GPU
+    operations, only CPU operations are supported currently.
+
 Example::
     >>> import torch.distributed.autograd as dist_autograd
     >>> with dist_autograd.context() as context_id:


### PR DESCRIPTION

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40261 Add warning to distributed autograd about CPU only support.**

With DDP+RPC, its likely users might try to use this feature on GPUs
considering DDP is widely used on GPUs. However, distributed autograd does not
support GPU operations in the autograd graph currently:
https://github.com/pytorch/pytorch/issues/40255.

As a result, I'm adding this warning to our docs.

![Screen Shot 2020-06-18 at 6 18 49 PM](https://user-images.githubusercontent.com/9958665/85087468-78e77e00-b192-11ea-8f63-2d44e6bb5bbf.png)

Differential Revision: [D22130190](https://our.internmc.facebook.com/intern/diff/D22130190/)