### PR TITLE
Back out "[pytorch][PR] [JIT] Infer NamedTuple type attributes of nn.Modules correctly"

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -486,27 +486,6 @@ class TestScriptPy3(JitTestCase):
                 if True:
                     x : Optional[int] = 7
 
-    def test_named_tuple_as_attribute(self):
-        """
-        Test named tuples as attributes of modules.
-        """
-        global Params
-
-        class Params(NamedTuple):
-            p1: float
-            p2: int
-
-        class MyModule(torch.nn.Module):
-            def __init__(self, params):
-                super().__init__()
-                self.params = params
-
-            def forward(self):
-                return self.params.p1
-
-        params = Params(1.0, 2)
-        self.checkModule(MyModule(params), ())
-
     def test_export_opnames_interface(self):
         global OneTwoModule
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -611,55 +611,6 @@ def is_tuple(ann):
         (getattr(ann, '__origin__', None) is Tuple or
             getattr(ann, '__origin__', None) is tuple)
 
-
-def is_named_tuple(ann):
-    return inspect.isclass(ann) and issubclass(ann, tuple) and hasattr(ann, "_fields")
-
-
-def try_make_named_tuple_type(ann, instance=None, loc=None):
-    if not is_named_tuple(ann):
-        return None
-
-    if hasattr(ann, "_field_defaults") and len(ann._field_defaults) > 0:
-        msg = """Default values are currently not supported on NamedTuple fields in TorchScript.
-                Fields with default values: ["""
-        first = True
-
-        # Print out all fields with default values
-        msg += ", ".join(ann._field_defaults.keys())
-
-        if loc:
-            error_report = torch._C.ErrorReport(loc)
-            msg += error_report.what().lstrip()
-
-        raise RuntimeError(msg)
-
-    # Bail if an instance is provided and its members are not JITable themselves.
-    if instance is not None:
-        for member in instance:
-            if not torch._C._jit_try_infer_type(member):
-                return None
-
-    qualified_name = torch.jit._qualified_name(ann)
-    props = torch.jit._get_named_tuple_properties(ann)
-    new_type = torch._C.TupleType.createNamed(qualified_name, props[1], props[2])
-    existing_type = torch.jit._python_cu.get_type(qualified_name)
-
-    if existing_type:
-        if existing_type.isSubtypeOf(new_type):
-            return existing_type
-        else:
-            msg = "Cannot redefine NamedTuple: " + str(existing_type)
-            if loc:
-                error_report = torch._C.ErrorReport(loc)
-                msg += error_report.what().lstrip()
-
-            raise RuntimeError(msg)
-
-    torch.jit._python_cu.register_type(new_type)
-    return new_type
-
-
 def is_list(ann):
     if not hasattr(ann, '__module__'):
         return False

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -203,10 +203,6 @@ struct TORCH_API CompilationUnit {
     return classes_[it->second];
   }
 
-  bool has_type(const c10::QualifiedName& name) const {
-    return classDict_.find(name) != classDict_.end();
-  }
-
   // For testing: clear all Python-defined classes to ensure that unit tests
   // have isolation.
   void _clear_python_cu() {

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -297,14 +297,6 @@ inline InferredType tryToInferType(py::handle input) {
       TORCH_INTERNAL_ASSERT(class_type);
       return InferredType(class_type);
     }
-
-    // Check if it is a NamedTuple.
-    auto named_tuple_type = py::cast<TupleTypePtr>(
-        py::module::import("torch._jit_internal")
-            .attr("try_make_named_tuple_type")(input.get_type(), input, true));
-    if (named_tuple_type) {
-      return InferredType(named_tuple_type);
-    }
   }
 
   if (py::isinstance<Object>(input)) {

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -710,14 +710,6 @@ void initPythonIRBindings(PyObject* module_) {
         return self->cast<InterfaceType>() != nullptr;
       });
 
-  using ::c10::NamedType;
-  py::class_<NamedType, Type, std::shared_ptr<NamedType>>(m, "NamedType")
-      .def("name", [](const NamedType& type) {
-        if (type.name().has_value()) {
-          return type.name().value().name();
-        }
-        return std::string();
-      });
   py::class_<AnyType, Type, std::shared_ptr<AnyType>>(m, "AnyType")
       .def_static("get", &AnyType::get);
   py::class_<NumberType, Type, std::shared_ptr<NumberType>>(m, "NumberType")
@@ -741,16 +733,9 @@ void initPythonIRBindings(PyObject* module_) {
   py::class_<NoneType, Type, std::shared_ptr<NoneType>>(m, "NoneType")
       .def_static("get", &NoneType::get);
 
-  py::class_<TupleType, NamedType, std::shared_ptr<TupleType>>(m, "TupleType")
+  py::class_<TupleType, Type, std::shared_ptr<TupleType>>(m, "TupleType")
       .def(
           py::init([](std::vector<TypePtr> a) { return TupleType::create(a); }))
-      .def_static(
-          "createNamed",
-          [](const std::string& name,
-             const std::vector<std::string>& field_names,
-             const std::vector<TypePtr>& types) {
-            return TupleType::createNamed(name, field_names, types);
-          })
       .def("elements", [](TupleType& self) {
         std::vector<TypePtr> types;
         for (const auto& type : self.elements()) {

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1083,17 +1083,7 @@ void initJitScriptBindings(PyObject* module) {
       .def(
           "get_interface",
           [](const std::shared_ptr<CompilationUnit>& self,
-             const std::string& name) { return self->get_interface(name); })
-      .def(
-          "get_type",
-          [](CompilationUnit& cu, const std::string& name) {
-            return cu.get_type(name);
-          })
-      .def(
-          "register_type",
-          [](CompilationUnit& cu, const c10::NamedTypePtr& type) {
-            cu.register_type(type);
-          });
+             const std::string& name) { return self->get_interface(name); });
 
   py::class_<StrongFunctionPtr>(m, "ScriptFunction", py::dynamic_attr())
       .def(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40270 Back out "[pytorch][PR] [JIT] Infer NamedTuple type attributes of nn.Modules correctly"**

Original commit changeset: 1227e243ab94

D22082806 broke the model generation of pyper models. We trace the namedtuple as input. To unblock the development of PyPer project, let's revert the diff first.

Sorry about the inconvenience, @meghanl

Differential Revision: [D22132960](https://our.internmc.facebook.com/intern/diff/D22132960/)