### PR TITLE
[pytorch] tweak code analyzer script to handle new namespaces

### DIFF
--- a/tools/code_analyzer/run_analyzer.sh
+++ b/tools/code_analyzer/run_analyzer.sh
@@ -14,7 +14,7 @@ echo "Analyze: ${INPUT}"
 # only _def and _impl are retained).  But the inliner isn't guaranteed
 # to operate, so for safety we match a more expansive set.
 "${ANALYZER_BIN}" \
-  -op_schema_pattern="^(_aten|_prim|aten|quantized|profiler|_test)::[a-zA-Z0-9_.]+(\(.*)?$" \
+  -op_schema_pattern="^(_aten|_prim|aten|quantized|_quantized|prepacked|profiler|_test)::[a-zA-Z0-9_.]+(\(.*)?$" \
   -op_register_pattern="c10::RegisterOperators::(op|checkSchemaAndRegisterOp_)|c10::Module::(_?def|_?impl|impl_UNBOXED)|torch::Library::(_?def|_?impl|_?impl_UNBOXED)" \
   -op_invoke_pattern="c10::Dispatcher::findSchema" \
   -root_symbol_pattern="torch::jit::[^(]" \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40276 [pytorch] tweak code analyzer script to handle new namespaces**

Summary:
- add a couple new namespaces;
- handle the case where both contextual namespace and opreator namespace
  are set (BackendSelectRegister.cpp and #39401);
- improve error message;

Differential Revision: [D22135686](https://our.internmc.facebook.com/intern/diff/D22135686)