### PR TITLE
[doc] fix typo in formula of MarginRankingLoss

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1050,10 +1050,10 @@ class MarginRankingLoss(_Loss):
     If :math:`y = 1` then it assumed the first input should be ranked higher
     (have a larger value) than the second input, and vice-versa for :math:`y = -1`.
 
-    The loss function for each sample in the mini-batch is:
+    The loss function for each pair of samples in the mini-batch is:
 
     .. math::
-        \text{loss}(x, y) = \max(0, -y * (x1 - x2) + \text{margin})
+        \text{loss}(x1, x2, y) = \max(0, -y * (x1 - x2) + \text{margin})
 
     Args:
         margin (float, optional): Has a default value of :math:`0`.


### PR DESCRIPTION
This is just a minor doc fix:

the `MarginRankingLoss` takes 2 input samples `x1` and `x2`, not just `x`