### PR TITLE
Let torch.futures.wait_all re-throw errors

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -991,8 +991,16 @@ void initJITBindings(PyObject* module) {
         return std::make_shared<jit::PythonFutureWrapper>(
             c10::collectAll(asList),
             /* unwrap_func */ [futures](const py::object& /*unused*/) {
-              // throw errors when calling wait() on the returned Future if
+              // Throw errors when calling wait() on the returned Future if
               // any of the original futures would throw.
+              // NB: PythonFutureWrapper takes an unwrap_func which serves as a
+              // callback to evalute the value in the Future. RPC uses this
+              // unwrap_func to check whether the returned py::object is a
+              // RemoteException object, and re-throw the exception if it is.
+              // By extracting the c10::ivalue::Future from PythonFutureWrapper
+              // the unwrap_func on the original PythonFutureWrapper objects are
+              // discarded, and hence it will return the RemoteException as an
+              // object instead of re-throwing it.
               for (auto& fut : futures) {
                 fut->wait();
               }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40309 Add a warning to mention that async_execution does not work with autograd profiler
* #40305 Minor RPC doc improvements
* #40300 Fix RRef to_here() docs
* #40299 Fix RPC API doc links
* #40298 Improve docs for init_rpc
* #40296 Improve RPC documents
* **#40291 Let torch.futures.wait_all re-throw errors**

Differential Revision: [D22141702](https://our.internmc.facebook.com/intern/diff/D22141702)