### PR TITLE
Improve RPC documents

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -97,7 +97,11 @@ applications can always explicitly move the input tensors to CPU on the caller
 and move it to the desired devices on the callee if necessary.
 
 .. warning::
-  TorchScript support in RPC is experimental and subject to change.
+  TorchScript support in RPC is experimental and subject to change. Since
+  v1.5.0, ``torch.distributed.rpc`` supports calling TorchScript functions as
+  RPC target functions, and this will help improve parallelism on the callee
+  side as executing TorchScript functions does not require GIL. However, support
+  for calling RPC APIs within a TorchScript function is very limited.
 
 .. autofunction:: rpc_sync
 .. autofunction:: rpc_async
@@ -298,3 +302,4 @@ Tutorials
 The RPC tutorial introduces users to the RPC framework and provides two example applications using :ref:`torch.distributed.rpc<distributed-rpc-framework>` APIs.
 
 -  `Getting started with Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_tutorial.html>`__
+-  `Implementing a Parameter Server using Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_param_server_tutorial.html>`__

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -100,8 +100,7 @@ and move it to the desired devices on the callee if necessary.
   TorchScript support in RPC is experimental and subject to change. Since
   v1.5.0, ``torch.distributed.rpc`` supports calling TorchScript functions as
   RPC target functions, and this will help improve parallelism on the callee
-  side as executing TorchScript functions does not require GIL. However, support
-  for calling RPC APIs within a TorchScript function is very limited.
+  side as executing TorchScript functions does not require GIL.
 
 .. autofunction:: rpc_sync
 .. autofunction:: rpc_async


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40309 Add a warning to mention that async_execution does not work with autograd profiler
* #40305 Minor RPC doc improvements
* #40300 Fix RRef to_here() docs
* #40299 Fix RPC API doc links
* #40298 Improve docs for init_rpc
* **#40296 Improve RPC documents**
* #40291 Let torch.futures.wait_all re-throw errors

1. Added a link to parameter server tutorial
2. Explained current states for TorchScript support

Differential Revision: [D22142647](https://our.internmc.facebook.com/intern/diff/D22142647)