### PR TITLE
Improve docs for init_rpc

### DIFF
--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -33,9 +33,7 @@ if is_available():
     ):
         r"""
         Initializes RPC primitives such as the local RPC agent
-        and distributed autograd.
-
-        Initializes the local RPC agent which immediately makes the current
+        and distributed autograd, which immediately makes the current
         process ready to send and receive RPCs.
 
         Arguments:
@@ -46,8 +44,8 @@ if is_available():
                 information.
             name (str): a globally unique name of this node. (e.g.,
                 ``Trainer3``, ``ParameterServer2``, ``Master``, ``Worker1``)
-                Name can only contain number, alphabet, underscore, and/or dash,
-                and must be shorter than 128 characters.
+                Name can only contain number, alphabet, underscore, colon,
+                and/or dash, and must be shorter than 128 characters.
             rank (int): a globally unique id/rank of this node.
             world_size (int): The number of workers in the group.
             rpc_backend_options (RpcBackendOptions, optional): The options
@@ -58,7 +56,7 @@ if is_available():
                 seconds and performs the rendezvous with an underlying process
                 group initialized using ``init_method = "env://"``,
                 meaning that environment variables ``MASTER_ADDR`` and
-                ``MASTER_PORT`` needs to be set properly. See
+                ``MASTER_PORT`` need to be set properly. See
                 :ref:`rpc-backends` for more information and find which options
                 are available.
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40309 Add a warning to mention that async_execution does not work with autograd profiler
* #40305 Minor RPC doc improvements
* #40300 Fix RRef to_here() docs
* #40299 Fix RPC API doc links
* **#40298 Improve docs for init_rpc**
* #40296 Improve RPC documents
* #40291 Let torch.futures.wait_all re-throw errors

Differential Revision: [D22143155](https://our.internmc.facebook.com/intern/diff/D22143155)