### PR TITLE
Fix RPC API doc links

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -650,7 +650,7 @@ def rpc_sync(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
                                    indicates an infinite timeout, i.e. a timeout
                                    error will never be raised. If not provided,
                                    the default value set during initialization
-                                   or with `_set_rpc_timeout` is used.
+                                   or with ``_set_rpc_timeout`` is used.
 
     Returns:
         Returns the result of running ``func`` with ``args`` and ``kwargs``.
@@ -711,8 +711,8 @@ def rpc_async(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     r"""
     Make a non-blocking RPC call to run function ``func`` on worker ``to``. RPC
     messages are sent and received in parallel to execution of Python code. This
-    method is thread-safe. This method will immediately return a Future that can
-    be awaited on.
+    method is thread-safe. This method will immediately return a
+    :class:`~torch.futures.Future` that can be awaited on.
 
     Arguments:
         to (str or WorkerInfo): id or name of the destination worker.
@@ -729,13 +729,14 @@ def rpc_async(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
                                    indicates an infinite timeout, i.e. a timeout
                                    error will never be raised. If not provided,
                                    the default value set during initialization
-                                   or with `_set_rpc_timeout` is used.
+                                   or with ``_set_rpc_timeout`` is used.
 
 
     Returns:
-        Returns a Future object that can be waited
+        Returns a :class:`~torch.futures.Future` object that can be waited
         on. When completed, the return value of ``func`` on ``args`` and
-        ``kwargs`` can be retrieved from the Future object.
+        ``kwargs`` can be retrieved from the :class:`~torch.futures.Future`
+        object.
 
     .. warning ::
         Using GPU tensors as arguments or return values of ``func`` is not
@@ -747,8 +748,8 @@ def rpc_async(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
         The ``rpc_async`` API does not copy storages of argument tensors until
         sending them over the wire, which could be done by a different thread
         depending on the RPC backend type. The caller should make sure that the
-        contents of those tensors stay intact until the returned Future
-        completes.
+        contents of those tensors stay intact until the returned
+        :class:`~torch.futures.Future` completes.
 
     Example::
         Make sure that ``MASTER_ADDR`` and ``MASTER_PORT`` are set properly

--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -4,15 +4,16 @@ import functools
 def async_execution(fn):
     r"""
     A decorator for a function indicating that the return value of the function
-    is guaranteed to be a ``torch.futures.Future`` object and this function can
-    run asynchronously on the RPC callee. More specifically, the callee extracts
-    the ``torch.futures.Future`` returned by the wrapped function and installs
-    subsequent processing steps as a callback to that ``Future``. The installed
-    callback will read the value from the ``Future`` when completed and send the
+    is guaranteed to be a :class:`~torch.futures.Future` object and this
+    function can run asynchronously on the RPC callee. More specifically, the
+    callee extracts the :class:`~torch.futures.Future` returned by the wrapped
+    function and installs subsequent processing steps as a callback to that
+    :class:`~torch.futures.Future`. The installed callback will read the value
+    from the :class:`~torch.futures.Future` when completed and send the
     value back as the RPC response. That also means the returned
-    ``torch.futures.Future`` only exists on the callee side and is never sent
-    through RPC. This decorator is useful when the wrapped function's (``fn``)
-    execution needs to pause and resume due to, e.g., containing
+    :class:`~torch.futures.Future` only exists on the callee side and is never
+    sent through RPC. This decorator is useful when the wrapped function's
+    (``fn``) execution needs to pause and resume due to, e.g., containing
     :meth:`~torch.distributed.rpc.rpc_async` or waiting for other signals.
 
     .. note:: This decorator must be the outmost one when combined with other
@@ -20,10 +21,10 @@ def async_execution(fn):
         installed by this decorator.
 
     Example::
-        The returned ``torch.futures.Future`` object can come from
-        ``rpc.rpc_async``, ``Future.then(cb)``, or ``torch.futures.Future``
-        constructor. The example below shows directly using the ``Future``
-        returned by ``Future.then(cb)``.
+        The returned :class:`~torch.futures.Future` object can come from
+        ``rpc.rpc_async``, ``Future.then(cb)``, or :class:`~torch.futures.Future`
+        constructor. The example below shows directly using the
+        :class:`~torch.futures.Future` returned by ``Future.then(cb)``.
 
         >>> from torch.distributed import rpc
         >>>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40309 Add a warning to mention that async_execution does not work with autograd profiler
* #40305 Minor RPC doc improvements
* #40300 Fix RRef to_here() docs
* **#40299 Fix RPC API doc links**
* #40298 Improve docs for init_rpc
* #40296 Improve RPC documents
* #40291 Let torch.futures.wait_all re-throw errors

Differential Revision: [D22143156](https://our.internmc.facebook.com/intern/diff/D22143156)