### PR TITLE
Minor RPC doc improvements

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -287,7 +287,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
               },
               py::call_guard<py::gil_scoped_release>(),
               R"(
-                  Create a helper proxy to easily launch an ``remote`` using
+                  Create a helper proxy to easily launch a ``remote`` using
                   the owner of the RRef as the destination to run functions on
                   the object referenced by this RRef. More specifically,
                   ``rref.remote().func_name(*args, **kwargs)`` is the same as

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -211,7 +211,9 @@ def shutdown(graceful=True):
     RPC processes to reach this method.
 
     .. warning::
-        Warning, ``future.wait()`` should not be called after ``shutdown()``.
+        Warning, for :class:`~torch.futures.Future` objects returned by
+        :meth:`~torch.distributed.rpc.rpc_async`, ``future.wait()`` should not
+        be called after ``shutdown()``.
 
     Arguments:
         graceful (bool): Whether to do a graceful shutdown or not. If True,

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -211,7 +211,7 @@ def shutdown(graceful=True):
     RPC processes to reach this method.
 
     .. warning::
-        Warning, for :class:`~torch.futures.Future` objects returned by
+        For :class:`~torch.futures.Future` objects returned by
         :meth:`~torch.distributed.rpc.rpc_async`, ``future.wait()`` should not
         be called after ``shutdown()``.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40309 Add a warning to mention that async_execution does not work with autograd profiler
* **#40305 Minor RPC doc improvements**
* #40300 Fix RRef to_here() docs
* #40299 Fix RPC API doc links
* #40298 Improve docs for init_rpc
* #40296 Improve RPC documents
* #40291 Let torch.futures.wait_all re-throw errors

Differential Revision: [D22144304](https://our.internmc.facebook.com/intern/diff/D22144304)