### PR TITLE
Add a warning to mention that async_execution does not work with autograd profiler

### DIFF
--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -20,6 +20,9 @@ def async_execution(fn):
         decorators. Otherwise, RPC will not be able to detect the attributes
         installed by this decorator.
 
+    .. warning:: `autograd profiler <https://pytorch.org/docs/stable/autograd.html#profiler>`_
+        does not work with ``async_execution`` functions.
+
     Example::
         The returned :class:`~torch.futures.Future` object can come from
         ``rpc.rpc_async``, ``Future.then(cb)``, or :class:`~torch.futures.Future`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40309 Add a warning to mention that async_execution does not work with autograd profiler**
* #40305 Minor RPC doc improvements
* #40300 Fix RRef to_here() docs
* #40299 Fix RPC API doc links
* #40298 Improve docs for init_rpc
* #40296 Improve RPC documents
* #40291 Let torch.futures.wait_all re-throw errors

Differential Revision: [D22145130](https://our.internmc.facebook.com/intern/diff/D22145130)