### PR TITLE
rename the LayerNorm operator and add it to the replacement map

### DIFF
--- a/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.cc
@@ -136,7 +136,7 @@ void LayerNormFakeFp16Op<CPUContext>::calcMeanStd(
   }
 }
 
-REGISTER_CPU_OPERATOR(LayerNormFakeFP16, LayerNormFakeFp16Op<CPUContext>);
-OPERATOR_SCHEMA(LayerNormFakeFP16).NumInputs({1, 3}).NumOutputs(3);
+REGISTER_CPU_OPERATOR(LayerNormFakeFP16NNPI, LayerNormFakeFp16Op<CPUContext>);
+OPERATOR_SCHEMA(LayerNormFakeFP16NNPI).NumInputs({1, 3}).NumOutputs(3);
 
 } // namespace caffe2

--- a/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
@@ -63,7 +63,7 @@ class LayerNorm(serial.SerializedTestCase):
         pred_net_ref.external_output.extend(["Y", "mean", "rstd"])
         pred_net_ref.op.add().CopyFrom(
             core.CreateOperator(
-                "LayerNormFakeFP16",
+                "LayerNormFakeFP16NNPI",
                 ["X", "gamma", "beta"],
                 ["Y", "mean", "rstd"],
                 axis=1,

--- a/caffe2/opt/custom/fakefp16_transform.cc
+++ b/caffe2/opt/custom/fakefp16_transform.cc
@@ -25,6 +25,7 @@ std::unordered_map<std::string, std::string> getFakeFp16OpMapping(
       {"Int8FC", "Int8FCFakeAcc32NNPI"},
       {"Int8Quantize", "Int8QuantizeNNPI"},
       {"Int8Dequantize", "Int8DequantizeNNPI"},
+      {"LayerNorm", "LayerNormFakeFP16NNPI"},
       {"FbFCPacked", "Fp16FCAcc32NNPI"},
       {"SparseLengthsSum", "SparseLengthsSumFakeFP16AccFP16"},
       {"SparseLengthsWeightedSum", "SparseLengthsWeightedSumFakeFP16AccFP16"},


### PR DESCRIPTION
Summary:
rename layernom fakefp16 to the right naming convention
add it to the map of replacement ops

this can be done even if the operator is not complete because we are blacklisting anyways

Test Plan: net_runner and inspected the log that replacement happened

Differential Revision: D22145900

