### PR TITLE
Proposed behavior change for DataLoader with IterableDataset

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1900,6 +1900,8 @@ class SimpleCustomBatch(object):
     def is_pinned(self):
         return self.inp.is_pinned() and self.tgt.is_pinned()
 
+    def __len__(self):
+        return len(self.inp)
 
 def collate_wrapper(batch):
     return SimpleCustomBatch(batch)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1070,6 +1070,8 @@ except RuntimeError as e:
             self.assertEqual(a, b)
         # DataLoader should match len of the iterable-style dataset (if implemented)
         self.assertEqual(len(dataloader), len(dataset))
+
+        # [no auto-batching] test len warning
         # When loading more than len(dataset) data, after accessing len(dataloader),
         # we should get a warning. See NOTE [ IterableDataset and __len__ ].
         dataset = CountingIterableDataset(20)
@@ -1079,7 +1081,7 @@ except RuntimeError as e:
         for _ in range(40):
             self.assertNotWarn(lambda: next(it), "Should not warn before accessing len(dataloader)")
         self.assertEqual(len(dataloader), len(dataset))
-        self.assertEqual(len(dataloader), 20)
+        self.assertEqual(len(dataset), 20)
         it = iter(dataloader)
         for _ in range(20):
             self.assertNotWarn(lambda: next(it), "Should not warn before exceeding length")
@@ -1125,6 +1127,29 @@ except RuntimeError as e:
         self.assertEqual(len(fetched), 4)
         fetched = set(tuple(t.tolist()) for t in fetched)
         self.assertEqual(fetched, {tuple(range(4)), tuple(range(7)), tuple(range(7, 14)), tuple(range(14, 20))})
+
+        # [auto-batching] test len warning
+        # When loading more than len(dataset) data, after accessing len(dataloader),
+        # we should get a warning. See NOTE [ IterableDataset and __len__ ].
+        batch_size = 2
+        dataset = CountingIterableDataset(20)
+        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=2,
+                                worker_init_fn=set_faulthander_if_available)
+        it = iter(dataloader)
+        expected_dataloader_len = (len(dataset) + batch_size - 1) // batch_size
+        for _ in range(expected_dataloader_len * 2):
+            self.assertNotWarn(lambda: next(it), "Should not warn before accessing len(dataloader)")
+        self.assertEqual(len(dataloader), expected_dataloader_len)
+        self.assertEqual(len(dataset), 20)
+        it = iter(dataloader)
+        for _ in range(expected_dataloader_len):
+            self.assertNotWarn(lambda: next(it), "Should not warn before exceeding length")
+        for _ in range(3):
+            with self.assertWarnsRegex(
+                UserWarning,
+                r"but [0-9]+ samples have been fetched\. For multiprocessing data-loading, this",
+                    msg="Should always warn after exceeding length"):
+                next(it)
 
         # [auto-batching] test that workers exit gracefully
         workers = dataloader_iter._workers

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -177,12 +177,13 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                 # processing steps.
                 continue
             idx, index = r
+            num_samples = 0
             if init_exception is not None:
                 data = init_exception
                 init_exception = None
             else:
                 try:
-                    data = fetcher.fetch(index)
+                    data, num_samples = fetcher.fetch(index)
                 except Exception as e:
                     if isinstance(e, StopIteration) and dataset_kind == _DatasetKind.Iterable:
                         data = _IterableDatasetStopIteration(worker_id)
@@ -196,7 +197,7 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                         # See NOTE [ Python Traceback Reference Cycle Problem ]
                         data = ExceptionWrapper(
                             where="in DataLoader worker process {}".format(worker_id))
-            data_queue.put((idx, data))
+            data_queue.put((idx, data, num_samples))
             del data, idx, index, r  # save memory
     except KeyboardInterrupt:
         # Main process will raise KeyboardInterrupt anyways.

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -377,7 +377,11 @@ class _BaseDataLoaderIter(object):
 
     def __next__(self) -> Any:
         data = self._next_data()
-        self._num_yielded += 1
+        # num_yielded and the value of _IterableDataset_len_called are in units of "samples" rather than
+        # batches, so when using auto_collation, we need to increment by the length of the batch we're
+        # yielding
+        self._num_yielded += len(data) if self._auto_collation else 1
+
         if self._dataset_kind == _DatasetKind.Iterable and \
                 self._IterableDataset_len_called is not None and \
                 self._num_yielded > self._IterableDataset_len_called:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -8,7 +8,7 @@ in `./_utils/worker.py`.
 import threading
 import itertools
 import warnings
-from typing import Any, Callable, TypeVar, Generic, Sequence, List, Optional
+from typing import Any, Tuple, Callable, TypeVar, Generic, Sequence, List, Optional
 
 import multiprocessing as python_multiprocessing
 import torch
@@ -364,7 +364,7 @@ class _BaseDataLoaderIter(object):
         self._collate_fn = loader.collate_fn
         self._sampler_iter = iter(self._index_sampler)
         self._base_seed = torch.empty((), dtype=torch.int64).random_(generator=loader.generator).item()
-        self._num_yielded = 0
+        self._num_samples_yielded = 0
 
     def __iter__(self) -> '_BaseDataLoaderIter':
         return self
@@ -372,30 +372,28 @@ class _BaseDataLoaderIter(object):
     def _next_index(self):
         return next(self._sampler_iter)  # may raise StopIteration
 
-    def _next_data(self):
+    def _next_data(self) -> Tuple[Any, int]:  # returns (data, num_samples), and may raise StopIteration
         raise NotImplementedError
 
     def __next__(self) -> Any:
-        data = self._next_data()
+        data, num_samples = self._next_data()
         # num_yielded and the value of _IterableDataset_len_called are in units of "samples" rather than
         # batches, so when using auto_collation, we need to increment by the length of the batch we're
         # yielding
-        self._num_yielded += len(data) if self._auto_collation else 1
+        self._num_samples_yielded += num_samples
 
         if self._dataset_kind == _DatasetKind.Iterable and \
                 self._IterableDataset_len_called is not None and \
-                self._num_yielded > self._IterableDataset_len_called:
+                self._num_samples_yielded > self._IterableDataset_len_called:
             warn_msg = ("Length of IterableDataset {} was reported to be {} (when accessing len(dataloader)), but {} "
                         "samples have been fetched. ").format(self._dataset, self._IterableDataset_len_called,
-                                                              self._num_yielded)
+                                                              self._num_samples_yielded)
             if self._num_workers > 0:
                 warn_msg += ("For multiprocessing data-loading, this could be caused by not properly configuring the "
                              "IterableDataset replica at each worker. Please see "
                              "https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset for examples.")
             warnings.warn(warn_msg)
         return data
-
-    next = __next__  # Python 2 compatibility
 
     def __len__(self) -> int:
         return len(self._index_sampler)
@@ -420,10 +418,10 @@ class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
 
     def _next_data(self):
         index = self._next_index()  # may raise StopIteration
-        data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
+        data, num_samples = self._dataset_fetcher.fetch(index)  # may raise StopIteration
         if self._pin_memory:
             data = _utils.pin_memory.pin_memory(data)
-        return data
+        return data, num_samples
 
 
 class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
@@ -726,8 +724,8 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         self._send_idx = 0  # idx of the next task to be sent to workers
         self._rcvd_idx = 0  # idx of the next task to be returned in __next__
         # information about data not yet yielded, i.e., tasks w/ indices in range [rcvd_idx, send_idx).
-        # map: task idx => - (worker_id,)        if data isn't fetched (outstanding)
-        #                  \ (worker_id, data)   if data is already fetched (out-of-order)
+        # map: task idx => - (worker_id,)                     if data isn't fetched (outstanding)
+        #                  \ (worker_id, data, num_samples)   if data is already fetched (out-of-order)
         self._task_info = {}
         self._tasks_outstanding = 0  # always equal to count(v for v in task_info.values() if len(v) == 1)
         self._workers_done_event = multiprocessing_context.Event()
@@ -978,7 +976,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             while self._rcvd_idx < self._send_idx:
                 info = self._task_info[self._rcvd_idx]
                 worker_id = info[0]
-                if len(info) == 2 or self._workers_status[worker_id]:  # has data or is still active
+                if len(info) > 1 or self._workers_status[worker_id]:  # has data or is still active
                     break
                 del self._task_info[self._rcvd_idx]
                 self._rcvd_idx += 1
@@ -990,12 +988,12 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             # Now `self._rcvd_idx` is the batch index we want to fetch
 
             # Check if the next sample has already been generated
-            if len(self._task_info[self._rcvd_idx]) == 2:
-                data = self._task_info.pop(self._rcvd_idx)[1]
-                return self._process_data(data)
+            if len(self._task_info[self._rcvd_idx]) > 1:
+                data, num_samples = self._task_info.pop(self._rcvd_idx)[1:]
+                return self._process_data(data), num_samples
 
             assert not self._shutdown and self._tasks_outstanding > 0
-            idx, data = self._get_data()
+            idx, data, num_samples = self._get_data()
             self._tasks_outstanding -= 1
 
             if self._dataset_kind == _DatasetKind.Iterable:
@@ -1007,10 +1005,10 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
             if idx != self._rcvd_idx:
                 # store out-of-order samples
-                self._task_info[idx] += (data,)
+                self._task_info[idx] += (data, num_samples)
             else:
                 del self._task_info[idx]
-                return self._process_data(data)
+                return self._process_data(data), num_samples
 
     def _try_put_index(self):
         assert self._tasks_outstanding < 2 * self._num_workers
@@ -1082,7 +1080,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                     self._pin_memory_thread_done_event.set()
                     # Send something to pin_memory_thread in case it is waiting
                     # so that it can wake up and check `pin_memory_thread_done_event`
-                    self._worker_result_queue.put((None, None))
+                    self._worker_result_queue.put((None, None, None))
                     self._pin_memory_thread.join()
                     self._worker_result_queue.cancel_join_thread()
                     self._worker_result_queue.close()


### PR DESCRIPTION
See recent comments on #38925 for more context, but I'll reproduce a synthesis here.

## Background
While well intentioned, the `__len__` function of `DataLoader` is inaccurate when used with multi-process data loading and data is being sharded across workers. This is due to the fact that there is no way to know exactly how data is being sharded amongst workers (evenly, or slightly unevenly) and thus one cannot know how `batch_size` will divide into the number of examples for which each worker ends up being responsible. This results is an often mis-calculated number of batches that are expected from the `DataLoader`, and this often ends up producing warnings [here](https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py#L353).

It is *probably* fine for `__len__` to provide a coarse estimate of the number of batches that will be yielded from the loader, but I suppose it's hard to know if that is a brittle assumption. However, this function plays a roll in the warnings the `DataLoader` produces if an `IterableDataset` produces more data than expected based on its length because it is setting `self._IterableDataset_len_called`.

## Proposal
This proposed modification changes how this potential bug is monitored by instead looking at the *number of samples* yielded by iterating over the `DataLoader` rather than the *number of batches*. This is helpful because regardless of how the user chooses to shard data amongst workers, how the data aligns into batches, or whether `drop_last` is on or off, the number of samples returned by the loader can be properly monitored and compared with `len(dataset)` in order to identify potential bugs with poorly sharded data.

The plan (as revised by @SsnL) is to have the the `_BaseDatasetFetcher` (and subclasses) return the number of samples in addition to the fetched data for each call to `fetch`. This `num_samples` is propagated up from the "fetcher" back to the `DataLoader`, which -- like before -- will track the total number of samples it has returned. However, now it can do so by accumulating the `num_samples` the fetcher (and/or workers) are giving it rather than assuming it understands exactly the right number of samples that have been returned.

## Discussion
The main advantage of this change is that the warning (alerting users to potential duplicated data and sharding issues when using `IterableDataset`) can be accurately monitored and provide helpful feedback to the user regardless of how they've implemented sharding of their data.

cc @SsnL 

(P.S. #40281 is at odds with this change and the two should be considered mutually exclusive, that PR does not fix these issues)

