### PR TITLE
restore generic IndexToScatterGatherOffset specialization

### DIFF
--- a/aten/src/THC/THCTensorScatterGather.cu
+++ b/aten/src/THC/THCTensorScatterGather.cu
@@ -16,7 +16,7 @@ struct IndexToScatterGatherOffsets {
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t1, IndexType* t1Offset,
       const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {
-    static_assert(Dims>=0);
+    static_assert(Dims>=0, "this template only handles non-negative Dims");
     for (int d = Dims - 1; d >= 0; d--) {
       IndexType curDimIndex = linearId % index.sizes[d];
       *indexOffset += curDimIndex * index.strides[d];
@@ -32,7 +32,7 @@ struct IndexToScatterGatherOffsets {
       IndexType linearId, const int dim,
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {
-    static_assert(Dims>=0);
+    static_assert(Dims>=0, "this template only handles non-negative Dims");
     for (int d = Dims - 1; d >= 0; d--) {
       IndexType curDimIndex = linearId % index.sizes[d];
       *indexOffset += curDimIndex * index.strides[d];

--- a/aten/src/THC/THCTensorScatterGather.cu
+++ b/aten/src/THC/THCTensorScatterGather.cu
@@ -16,6 +16,7 @@ struct IndexToScatterGatherOffsets {
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t1, IndexType* t1Offset,
       const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {
+    static_assert(Dims>=0);
     for (int d = Dims - 1; d >= 0; d--) {
       IndexType curDimIndex = linearId % index.sizes[d];
       *indexOffset += curDimIndex * index.strides[d];
@@ -31,7 +32,42 @@ struct IndexToScatterGatherOffsets {
       IndexType linearId, const int dim,
       const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
       const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {
+    static_assert(Dims>=0);
     for (int d = Dims - 1; d >= 0; d--) {
+      IndexType curDimIndex = linearId % index.sizes[d];
+      *indexOffset += curDimIndex * index.strides[d];
+      if (d != dim) {
+        *t2Offset += curDimIndex * t2.strides[d];
+      }
+      linearId /= index.sizes[d];
+    }
+  }
+};
+
+// Same as above but using a dynamic number of dimensions.
+template <typename IndexType, typename Real>
+struct IndexToScatterGatherOffsets<IndexType, Real, -1> {
+  static __device__ void compute(
+      IndexType linearId, const int dim,
+      const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
+      const TensorInfo<Real, IndexType>& t1, IndexType* t1Offset,
+      const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {
+    for (int d = index.dims - 1; d >= 0; d--) {
+      IndexType curDimIndex = linearId % index.sizes[d];
+      *indexOffset += curDimIndex * index.strides[d];
+      *t1Offset += curDimIndex * t1.strides[d];
+      if (d != dim) {
+        *t2Offset += curDimIndex * t2.strides[d];
+      }
+      linearId /= index.sizes[d];
+    }
+  }
+
+  static __device__ void compute(
+      IndexType linearId, const int dim,
+      const TensorInfo<int64_t, IndexType>& index, IndexType* indexOffset,
+      const TensorInfo<Real, IndexType>& t2, IndexType* t2Offset) {
+    for (int d = index.dims - 1; d >= 0; d--) {
       IndexType curDimIndex = linearId % index.sizes[d];
       *indexOffset += curDimIndex * index.strides[d];
       if (d != dim) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14400,6 +14400,23 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(val, expect)
         self.assertEqual(idx, [5, 4, 3, 2])
 
+    def test_topk_4d(self, device):
+        x = torch.ones(2, 3072, 2, 2, device=device)
+        x[:, 1, :, :] *= 2.
+        x[:, 10, :, :] *= 1.5
+        val, ind = torch.topk(x, k=2, dim=1)
+        expected_ind = torch.ones(2, 2, 2, 2, dtype=torch.long, device=device)
+        expected_ind[:, 1, :, :] = 10
+        expected_val = torch.ones(2, 2, 2, 2, device=device)
+        expected_val[:, 0, :, :] *= 2.
+        expected_val[:, 1, :, :] *= 1.5
+        print(val, ind)
+        self.assertEqual(val, expected_val, atol=0, rtol=0)
+        self.assertEqual(ind, expected_ind, atol=0, rtol=0)
+
+
+
+
     def test_is_signed(self, device):
         self.assertEqual(torch.IntTensor(5).to(device).is_signed(), True)
         self.assertEqual(torch.ByteTensor(5).to(device).is_signed(), False)


### PR DESCRIPTION
#39963 erroneously removed template specialization to compute offsets, causing cases relying on this specialization (topk for 4d+ tensors with topk dimension >= 1024/2048 depending on the type) to produce bogus results.