### PR TITLE
Disable inlining an opaque tensor into a constant

### DIFF
--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -70,6 +70,11 @@ c10::optional<Value*> tryInsertConstant(
   Node* n = g.create(prim::Constant);
   if (val.isTensor()) {
     at::Tensor ref = val.toTensor();
+    if (!ref.has_storage()) {
+      // bail if tensor has no storage i.e. opaque tensor used in MKLdnn.
+      n->destroy();
+      return c10::nullopt;
+    }
     if (!ref.defined()) {
       n->destroy();
       return g.insertNode(g.createNone())->output();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40368 torch.jit.freeze API
* **#40367 Disable inlining an opaque tensor into a constant**

If the tensor has no storage then do not inline as a constant. This
situation when Mkldnn tensors are used.

Differential Revision: [D22158240](https://our.internmc.facebook.com/intern/diff/D22158240)