### PR TITLE
[DDP Note] Remove refs to RoundRobin PG until we officially support it

### DIFF
--- a/docs/source/notes/ddp.rst
+++ b/docs/source/notes/ddp.rst
@@ -1,4 +1,4 @@
-. _ddp:
+.. _ddp:
 
 Distributed Data Parallel
 =========================

--- a/docs/source/notes/ddp.rst
+++ b/docs/source/notes/ddp.rst
@@ -1,4 +1,4 @@
-.. _ddp:
+. _ddp:
 
 Distributed Data Parallel
 =========================
@@ -145,14 +145,11 @@ ProcessGroup
 
 - `ProcessGroup.hpp <https://github.com/pytorch/pytorch/blob/v1.4.0/torch/lib/c10d/ProcessGroup.hpp>`__:
   contains the abstract API of all process group implementations. The ``c10d``
-  library provides 4 implementations out of the box, namely,
-  `ProcessGroupGloo`, `ProcessGroupNCCL`, `ProcessGroupMPI`, and
-  `ProcessGroupRoundRobin`, where `ProcessGroupRoundRobin` is a composition of
-  multiple process group instances and launches collective communications in a
-  round-robin manner. ``DistributedDataParallel`` uses
-  ``ProcessGroup::broadcast()`` to send model states from the process with rank
-  0 to others during initialization and ``ProcessGroup::allreduce()`` to sum
-  gradients.
+  library provides 3 implementations out of the box, namely,
+  `ProcessGroupGloo`, `ProcessGroupNCCL`, and `ProcessGroupMPI`. 
+  ``DistributedDataParallel`` uses ``ProcessGroup::broadcast()`` to send  
+  model states from the process with rank 0 to others during initialization  
+  and ``ProcessGroup::allreduce()`` to sum gradients.
 
 
 - `Store.hpp <https://github.com/pytorch/pytorch/blob/v1.4.0/torch/lib/c10d/Store.hpp>`__:


### PR DESCRIPTION
Removes line mentioning `ProcessGroupRoundRobin` since we don't intend it to be used as a public API just yet. We can add this back when we officially support the API