### PR TITLE
[android][gradle] packaging headers in aars for publishing

### DIFF
--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -86,7 +86,7 @@ task sourcesJar(type: Jar) {
 
 def getLibtorchHeadersDir() {
   def abi = ABI_FILTERS.split(",")[0]
-  return "$rootDir/../build_android_$abi/include";
+  return "$rootDir/../build_android_$abi/install/include";
 }
 
 afterEvaluate {
@@ -102,6 +102,18 @@ afterEvaluate {
               "headers")
         }
       }
+    }
+  }
+}
+
+tasks.whenTaskAdded { task ->
+  if (task.name.startsWith("bundle") && task.name.endsWith("Aar")) {
+    task.doLast {
+      addFolderToAarTask(
+        "addHeadersTo" + task.name,
+        task.archivePath,
+        getLibtorchHeadersDir(),
+        "headers").execute()
     }
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40392 [android][gradle] packaging headers in aars for publishing**

Differential Revision: [D22167757](https://our.internmc.facebook.com/intern/diff/D22167757)

1. Before this diff headers were included only for `assemble` task, but nightly builds and maven publishing works with `bundle*Aar` tasks.
2. Also headers for release build are in `install/include` 

Tested:
Published fake 0.0.2 version on sonatype and checked that aar includes headers: 
https://oss.sonatype.org/service/local/repositories/snapshots/content/org/pytorch/pytorch_android/0.0.1-SNAPSHOT/pytorch_android-0.0.1-20200622.193212-21.aar