### PR TITLE
Allow slice indexing of Sequential container for iteration only

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10462,8 +10462,10 @@ a")
                 self.layers = nn.Sequential(*self.layers)
 
             def forward(self, input):
-                x = layers[0].forward(input)
-                for layer in layers[1:3]:
+                x = self.layers[0].forward(input)
+                for layer in self.layers[1:3]:
+                    x = layer.forward(x)
+                for layer in self.layers[2:]:
                     x = layer.forward(x)
                 return x
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10469,17 +10469,9 @@ a")
                     x = layer.forward(x)
                 return x
 
-        input = torch.tensor([-2, 1, -1, 2])
         seq = seq_mod()
         with torch.jit._disable_emit_hooks():
-            traced = torch.jit.script(seq, input)
-        o = traced(input)
-        graph = traced.graph
-        FileCheck().check("ReLU") \
-            .check("ReLU") \
-            .check("ReLU") \
-            .run(graph)
-        self.assertEqual(o, torch.tensor([0, 1, 0, 2]))
+            self.checkModule(seq, [torch.tensor([-2, 1, -1, 2])])
 
     def test_script_sequential_orderdict(self):
         class M(torch.jit.ScriptModule):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10471,7 +10471,8 @@ a")
 
         input = torch.tensor([-2, 1, -1, 2])
         seq = seq_mod()
-        traced = torch.jit.script(seq, input)
+        with torch.jit._disable_emit_hooks():
+            traced = torch.jit.script(seq, input)
         o = traced(input)
         graph = traced.graph
         FileCheck().check("ReLU") \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10471,7 +10471,7 @@ a")
 
         input = torch.tensor([-2, 1, -1, 2])
         seq = seq_mod()
-        traced = torch.jit.script(seq)
+        traced = torch.jit.script(seq, input)
         o = traced(input)
         graph = traced.graph
         FileCheck().check("ReLU") \

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -3546,7 +3546,7 @@ struct to_ir {
           range, sv->asValue(val_range, method), subscript_exprs));
     }
     if (subscript_exprs[0].kind() == TK_SLICE_EXPR) {
-      if(sv->kind() == "module") {
+      if (sv->kind() == "module") {
         auto vec_sv_ptr = sv->asTuple(val_range, method);
         auto vals = fmap(vec_sv_ptr, [&](const SugaredValuePtr& svptr) {
           return svptr->asValue(val_range, method);

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -3547,17 +3547,24 @@ struct to_ir {
     }
     if (subscript_exprs[0].kind() == TK_SLICE_EXPR) {
       if(sv->kind() == "module") {
-        // TODO Special case for Sequential only, make sure not other modules
         auto s_tuple_val = sv->asTupleValue(val_range, method);
 
         const SliceExpr& slice = SliceExpr(subscript_exprs[0]);
-        auto tupleSliceValue = emitTupleSlice(
-            val_range,
-            s_tuple_val->asValue(val_range, method),
-            NamedValue(val_range, "begin", emitExpr(Expr(slice.startOr(0)))),
-            NamedValue(val_range, "end", emitExpr(Expr(slice.end().get()))));
-        return std::make_shared<SimpleValue>(tupleSliceValue);
-
+        if (slice.end().present()) {
+          auto tupleSliceValue = emitTupleSlice(
+              val_range,
+              s_tuple_val->asValue(val_range, method),
+              NamedValue(val_range, "begin", emitExpr(Expr(slice.startOr(0)))),
+              NamedValue(val_range, "end", emitExpr(Expr(slice.end().get()))));
+          return std::make_shared<SimpleValue>(tupleSliceValue);
+        } else {
+          auto tupleSliceValue = emitTupleSlice(
+              val_range,
+              s_tuple_val->asValue(val_range, method),
+              NamedValue(val_range, "begin", emitExpr(Expr(slice.startOr(0)))),
+              c10::nullopt);
+          return std::make_shared<SimpleValue>(tupleSliceValue);
+        }
       } else {
         return std::make_shared<SimpleValue>(emitBasicSlice(
             range, sv->asValue(val_range, method), subscript_exprs));

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -3556,7 +3556,7 @@ struct to_ir {
             s_tuple_val->asValue(val_range, method),
             NamedValue(val_range, "begin", emitExpr(Expr(slice.startOr(0)))),
             NamedValue(val_range, "end", emitExpr(Expr(slice.end().get()))));
-          return std::make_shared<SimpleValue>(tupleSliceValue);
+        return std::make_shared<SimpleValue>(tupleSliceValue);
 
       } else {
         return std::make_shared<SimpleValue>(emitBasicSlice(

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -3547,32 +3547,24 @@ struct to_ir {
     }
     if (subscript_exprs[0].kind() == TK_SLICE_EXPR) {
       if(sv->kind() == "module") {
-        // auto s_tuple_val = sv->asTupleValue(val_range, method);
-        auto s_tuple = sv->asTuple(val_range, method);
-        // ArrayRef<std::shared_ptr<SugaredValue>> vals(s_tuple);
-        auto vals = fmap(s_tuple, [&](const SugaredValuePtr& sv) {
-          return sv->asValue(val_range, method);
+        auto vec_sv_ptr = sv->asTuple(val_range, method);
+        auto vals = fmap(vec_sv_ptr, [&](const SugaredValuePtr& svptr) {
+          return svptr->asValue(val_range, method);
         });
-        auto s_tuple_node = graph->createTuple(vals)->output();
+        auto tuple_val = graph->createTuple(vals)->output();
 
         const SliceExpr& slice = SliceExpr(subscript_exprs[0]);
-        auto begin = NamedValue(val_range, "begin", emitExpr(Expr(slice.startOr(0))));
-        auto end = NamedValue(val_range, "end", emitExpr(Expr(slice.end().get())));
+        auto begin =
+            NamedValue(val_range, "begin", emitExpr(Expr(slice.startOr(0))));
         if (slice.end().present()) {
-          auto tupleSliceValue = emitTupleSlice(
-              val_range,
-              // s_tuple_val->asValue(val_range, method),
-              s_tuple_node,
-              begin,
-              end);
+          auto end =
+              NamedValue(val_range, "end", emitExpr(Expr(slice.end().get())));
+          auto tupleSliceValue =
+              emitTupleSlice(val_range, tuple_val, begin, end);
           return std::make_shared<SimpleValue>(tupleSliceValue);
         } else {
-          auto tupleSliceValue = emitTupleSlice(
-              val_range,
-              // s_tuple_val->asValue(val_range, method),
-              s_tuple_node,
-              begin,
-              c10::nullopt);
+          auto tupleSliceValue =
+              emitTupleSlice(val_range, tuple_val, begin, c10::nullopt);
           return std::make_shared<SimpleValue>(tupleSliceValue);
         }
       } else {

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -67,9 +67,7 @@ struct TORCH_API SugaredValue
     throw ErrorReport(loc) << kind() << " cannot be used as a tuple";
   }
 
-  virtual SugaredValuePtr asTupleValue(
-      const SourceRange& loc,
-      Function& m) {
+  virtual SugaredValuePtr asTupleValue(const SourceRange& loc, Function& m) {
     throw ErrorReport(loc) << kind() << " cannot be used as a tuplevalue";
   }
 

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -67,10 +67,6 @@ struct TORCH_API SugaredValue
     throw ErrorReport(loc) << kind() << " cannot be used as a tuple";
   }
 
-  virtual SugaredValuePtr asTupleValue(const SourceRange& loc, Function& m) {
-    throw ErrorReport(loc) << kind() << " cannot be used as a tuplevalue";
-  }
-
   virtual std::vector<std::shared_ptr<SugaredValue>> asType(
       const SourceRange& loc,
       Method& m) {

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -67,6 +67,12 @@ struct TORCH_API SugaredValue
     throw ErrorReport(loc) << kind() << " cannot be used as a tuple";
   }
 
+  virtual SugaredValuePtr asTupleValue(
+      const SourceRange& loc,
+      Function& m) {
+    throw ErrorReport(loc) << kind() << " cannot be used as a tuplevalue";
+  }
+
   virtual std::vector<std::shared_ptr<SugaredValue>> asType(
       const SourceRange& loc,
       Method& m) {

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -219,10 +219,7 @@ Value* ModuleValue::asValue(const SourceRange& loc, Function& m) {
   return self_;
 }
 
-SugaredValuePtr ModuleValue::asTupleValue(
-    const SourceRange& loc,
-    Function& m) {
-
+SugaredValuePtr ModuleValue::asTupleValue(const SourceRange& loc, Function& m) {
   auto dict = getSugaredDict(loc, m);
   auto mods = dict->getModules();
   return mods;

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -219,10 +219,13 @@ Value* ModuleValue::asValue(const SourceRange& loc, Function& m) {
   return self_;
 }
 
-SugaredValuePtr ModuleValue::asTupleValue(const SourceRange& loc, Function& m) {
+std::vector<std::shared_ptr<SugaredValue>> ModuleValue::asTuple(
+    const SourceRange& loc,
+    Function& m,
+    const c10::optional<size_t>& size_hint) {
   auto dict = getSugaredDict(loc, m);
   auto mods = dict->getModules();
-  return mods;
+  return mods->asTuple(loc, m);
 }
 
 SugaredValuePtr ModuleValue::getitem(

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -223,9 +223,13 @@ std::vector<std::shared_ptr<SugaredValue>> ModuleValue::asTuple(
     const SourceRange& loc,
     Function& m,
     const c10::optional<size_t>& size_hint) {
-  auto dict = getSugaredDict(loc, m);
-  auto mods = dict->getModules();
-  return mods->asTuple(loc, m);
+  if (concreteType_->getIterableModuleKind() == IterableModuleKind::LIST) {
+    auto dict = getSugaredDict(loc, m);
+    auto mods = dict->getModules();
+    return mods->asTuple(loc, m);
+  }
+  throw ErrorReport(loc)
+      << "Only ModuleList, Sequential, and ModuleDict modules are valid as Tuple";
 }
 
 SugaredValuePtr ModuleValue::getitem(

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -219,6 +219,15 @@ Value* ModuleValue::asValue(const SourceRange& loc, Function& m) {
   return self_;
 }
 
+SugaredValuePtr ModuleValue::asTupleValue(
+    const SourceRange& loc,
+    Function& m) {
+
+  auto dict = getSugaredDict(loc, m);
+  auto mods = dict->getModules();
+  return mods;
+}
+
 SugaredValuePtr ModuleValue::getitem(
     const SourceRange& loc,
     Function& m,

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -145,6 +145,10 @@ struct VISIBILITY_HIDDEN ModuleValue : public SugaredValue {
 
   Value* asValue(const SourceRange& loc, Function& m) override;
 
+  SugaredValuePtr asTupleValue(
+      const SourceRange& loc,
+      Function& m) override;
+
   // select an attribute on it, e.g. `this.field`
   std::shared_ptr<SugaredValue> tryGetAttr(
       const SourceRange& loc,

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -114,7 +114,7 @@ struct VISIBILITY_HIDDEN ModuleDictMethod : public SugaredValue {
       Function& f,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
-      size_t n_binders) override {
+      size_t n_binders) {
     if (inputs.size() || attributes.size()) {
       throw ErrorReport(loc)
           << name_ << " method does not accept any arguments";
@@ -143,9 +143,12 @@ struct VISIBILITY_HIDDEN ModuleValue : public SugaredValue {
     return "module";
   }
 
-  Value* asValue(const SourceRange& loc, Function& m) override;
+  std::vector<std::shared_ptr<SugaredValue>> asTuple(
+      const SourceRange& loc,
+      Function& m,
+      const c10::optional<size_t>& size_hint = {}) override;
 
-  SugaredValuePtr asTupleValue(const SourceRange& loc, Function& m) override;
+  Value* asValue(const SourceRange& loc, Function& m) override;
 
   // select an attribute on it, e.g. `this.field`
   std::shared_ptr<SugaredValue> tryGetAttr(

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -114,7 +114,7 @@ struct VISIBILITY_HIDDEN ModuleDictMethod : public SugaredValue {
       Function& f,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
-      size_t n_binders) {
+      size_t n_binders) override {
     if (inputs.size() || attributes.size()) {
       throw ErrorReport(loc)
           << name_ << " method does not accept any arguments";

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -145,9 +145,7 @@ struct VISIBILITY_HIDDEN ModuleValue : public SugaredValue {
 
   Value* asValue(const SourceRange& loc, Function& m) override;
 
-  SugaredValuePtr asTupleValue(
-      const SourceRange& loc,
-      Function& m) override;
+  SugaredValuePtr asTupleValue(const SourceRange& loc, Function& m) override;
 
   // select an attribute on it, e.g. `this.field`
   std::shared_ptr<SugaredValue> tryGetAttr(


### PR DESCRIPTION
Allows scripted code that slices a Sequential before iterating through the layers of the slice e.g. to manually invoke .forward on each. Does not support directly calling the resulting sliced sequential. 