### PR TITLE
Set C++14 compatibility flag in torch_compile_options

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -820,7 +820,7 @@ if(USE_OPENMP AND OPENMP_FOUND)
   message(STATUS "pytorch is compiling with OpenMP. \n"
     "OpenMP CXX_FLAGS: ${OpenMP_CXX_FLAGS}. \n"
     "OpenMP libraries: ${OpenMP_CXX_LIBRARIES}.")
-  target_compile_options(torch_cpu INTERFACE ${OpenMP_CXX_FLAGS})
+  target_compile_options(torch_cpu PRIVATE ${OpenMP_CXX_FLAGS})
   target_link_libraries(torch_cpu PRIVATE ${OpenMP_CXX_LIBRARIES})
 endif()
 

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -250,7 +250,7 @@ function(torch_compile_options libname)
         )
     else()
       target_compile_options(${libname} PUBLIC
-        #    -std=c++14
+        $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>
         -Wall
         -Wextra
         -Wno-unused-parameter

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -251,6 +251,8 @@ function(torch_compile_options libname)
     else()
       target_compile_options(${libname} PUBLIC
         $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>
+        )
+      target_compile_options(${libname} PRIVATE
         -Wall
         -Wextra
         -Wno-unused-parameter


### PR DESCRIPTION
Also mark warning modifiers as private options (i.e. libraries depending on `torch_cpu` do not have to be compiled with `-Wall`)
Closes #31283 