### PR TITLE
LayerNorm Test case dimension changes

### DIFF
--- a/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.h
@@ -51,14 +51,10 @@ class LayerNormFakeFp16Op final : public Operator<Context> {
     const int M = X.size_to_dim(canonical_axis);
     const int N = X.size_from_dim(canonical_axis);
     Y->ResizeLike(X);
-    scale_.Resize(M);
-    bias_.Resize(M);
     const T* X_data = X.template data<T>();
     T* Y_data = Y->template mutable_data<T>();
     T* mean_data = mean->template mutable_data<T>();
     T* sigma_data = sigma->template mutable_data<T>();
-    T* scale_data = scale_.template mutable_data<T>();
-    T* bias_data = bias_.template mutable_data<T>();
 
     std::vector<float> X_rounded(X.numel());
     fbgemm::RoundToFloat16(
@@ -137,9 +133,6 @@ class LayerNormFakeFp16Op final : public Operator<Context> {
   const int axis_;
   const float epsilon_;
   const bool elementwise_affine_;
-
-  Tensor scale_{Context::GetDeviceType()};
-  Tensor bias_{Context::GetDeviceType()};
 
   INPUT_TAGS(INPUT);
   OUTPUT_TAGS(OUTPUT, MEAN, STD);

--- a/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
@@ -25,19 +25,19 @@ GLOW_LOWERED_BATCHNORM = False
 # Test the lowered LayerNorm op
 class LayerNorm(serial.SerializedTestCase):
 
-    @given(seed=st.integers(0, 65535))
+    @given(seed=st.integers(0, 65535),
+           batch_size=st.integers(min_value=1, max_value=50),
+           size=st.integers(min_value=2, max_value=128),
+           epsilon=st.floats(min_value=1e-4, max_value=1e-3),
+           elementwise_affine=st.booleans())
     @settings(max_examples=10)
-    def test_layernorm(self, seed):
+    def test_layernorm(self, seed, batch_size, size, epsilon, elementwise_affine):
         np.random.seed(seed)
         # Reset the workspace
-        size = 4
-        input_channels = 4
-        batch_size = 1
-        axis = 1
-        epsilon = 1e-4
         workspace.ResetWorkspace()
+        axis = 1
 
-        dims = np.array(([batch_size, input_channels, size, size]))
+        dims = np.array(([batch_size, size]))
         X = np.random.uniform(size=dims).astype(np.float32) - 0.5
         gamma = np.random.randn(*X.shape[axis:]).astype(np.float32)
         beta = np.random.randn(*X.shape[axis:]).astype(np.float32)
@@ -49,11 +49,11 @@ class LayerNorm(serial.SerializedTestCase):
         pred_net.op.add().CopyFrom(
             core.CreateOperator(
                 "LayerNorm",
-                ["X", "gamma", "beta"],
+                ["X", "gamma", "beta"] if elementwise_affine else ["X"],
                 ["Y", "mean", "rstd"],
-                axis=1,
+                axis=axis,
                 epsilon=epsilon,
-                elementwise_affine=True
+                elementwise_affine=elementwise_affine
             )
         )
 
@@ -64,11 +64,11 @@ class LayerNorm(serial.SerializedTestCase):
         pred_net_ref.op.add().CopyFrom(
             core.CreateOperator(
                 "LayerNormFakeFP16NNPI",
-                ["X", "gamma", "beta"],
+                ["X", "gamma", "beta"] if elementwise_affine else ["X"],
                 ["Y", "mean", "rstd"],
-                axis=1,
+                axis=axis,
                 epsilon=epsilon,
-                elementwise_affine=True
+                elementwise_affine=elementwise_affine
             )
         )
 
@@ -94,6 +94,10 @@ class LayerNorm(serial.SerializedTestCase):
         workspace.RunNet(pred_net_ref.name)
         Y_c2 = workspace.FetchBlob("Y")
 
+        dims1 = np.array(([1, *dims]))
+        X_glow = X.reshape(dims1)
+        workspace.FeedBlob("X", X_glow)
+
         workspace.RunNet(pred_net_onnxified.name)
         Y_glow = workspace.FetchBlob("Y")
 
@@ -104,10 +108,9 @@ class LayerNorm(serial.SerializedTestCase):
                 {
                     "seed": seed,
                     "size": size,
-                    "input_channels": input_channels,
                     "batch_size": batch_size,
                     "epsilon": epsilon,
-                    "axis": axis,
+                    "elementwise_affine": elementwise_affine,
                     "X": X,
                     "Y_glow": Y_glow,
                     "Y_c2": Y_c2,


### PR DESCRIPTION
Summary:
LayerNorm Test case dimension changes
1. Prepend 1 dim to X for running Glow Net
2. Code Cleanup removed unused _scale and _bias
3. calcY code refactoring

Test Plan: test_layernorm_nnpi_fp16.py with hypothesis strategies to sweep different values.

Differential Revision: D22171748

