### PR TITLE
Add finishAndThrow function to ProcessGroup::Work, and use with Gloo

### DIFF
--- a/torch/lib/c10d/ProcessGroup.cpp
+++ b/torch/lib/c10d/ProcessGroup.cpp
@@ -56,6 +56,15 @@ void ProcessGroup::Work::finish(std::exception_ptr exception) {
   cv_.notify_all();
 }
 
+void ProcessGroup::Work::finishAndThrow(std::exception_ptr exception) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  completed_ = true;
+  exception_ = exception;
+  if (exception_) {
+    std::rethrow_exception(exception_);
+  }
+}
+
 ProcessGroup::ProcessGroup(int rank, int size) : rank_(rank), size_(size) {
   C10_LOG_API_USAGE_ONCE("c10d.process_group");
 }

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -94,7 +94,7 @@ class ProcessGroup {
 
     // Similar to finish, but throws an exception if one is already set or
     // provided by the user.
-    void finishAndThrow(std::exception_ptr exception = nullptr);
+    void finishAndThrow(std::exception_ptr exception);
 
     mutable std::mutex mutex_;
     std::condition_variable cv_;

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -92,6 +92,10 @@ class ProcessGroup {
     // manner. Notifies all waiting condition variables as well.
     void finish(std::exception_ptr exception = nullptr);
 
+    // Similar to finish, but throws an exception if one is already set or
+    // provided by the user.
+    void finishAndThrow(std::exception_ptr exception = nullptr);
+
     mutable std::mutex mutex_;
     std::condition_variable cv_;
     bool completed_ = false;

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -341,14 +341,10 @@ bool ProcessGroupGloo::SendWork::wait() {
   } catch (...) {
     exception = std::current_exception();
   }
+
   // Lock to write completed_ and exception_, and throw if there is an
   // exception.
-  std::lock_guard<std::mutex> lock(mutex_);
-  completed_ = true;
-  exception_ = exception;
-  if (exception_) {
-    std::rethrow_exception(exception_);
-  }
+  finishAndThrow(exception);
   return sendCompleted;
 }
 
@@ -374,14 +370,10 @@ bool ProcessGroupGloo::RecvWork::wait() {
   } catch (...) {
     exception = std::current_exception();
   }
+
   // Lock to write completed_ and exception_, and throw if there is an
   // exception.
-  std::lock_guard<std::mutex> lock(mutex_);
-  completed_ = true;
-  exception_ = exception;
-  if (exception_) {
-    std::rethrow_exception(exception_);
-  }
+  finishAndThrow(exception);
   return recvCompleted;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40405 Add finishAndThrow function to ProcessGroup::Work, and use with Gloo**
* #40404 [NCCL Docs] Adding Comments for Work-level Finish in ProcessGroup

This adds a finishAndThrow function that completes the work object,
sets an exception if one is provided by the user, and throws an exception (if
it is already set or passed by the caller). This is now done by grabbing the
lock just once and simplifies the wait functions in ProcessGroupGloo.

Differential Revision: [D22174890](https://our.internmc.facebook.com/intern/diff/D22174890/)