### PR TITLE
Fix demangle 't' issue in profiler

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -803,7 +803,10 @@ class FunctionEventAvg(FormattedTimesMixin):
 
 class StringTable(defaultdict):
     def __missing__(self, key):
-        self[key] = torch._C._demangle(key)
+        # manage cases like 't' (demangled to 'unsigned short') separately,
+        # for now simply check the length to avoid unexpected results for
+        # the short sequences
+        self[key] = torch._C._demangle(key) if len(key) > 1 else key
         return self[key]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40416 Fix demangle 't' issue in profiler**

Summary:
Fix demangle 't' that produces 'unsigned short'

Test Plan:
>>> import torch
>>> from torch.autograd.profiler import profile
>>>
>>> t = torch.rand(4, 5)
>>> with profile() as prof:
...     t.t()
>>> print(prof.key_averages().table())

Differential Revision: [D22179508](https://our.internmc.facebook.com/intern/diff/D22179508)