### PR TITLE
[jit] fix dictConstruct order issue

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1445,6 +1445,15 @@ class TestDict(JitTestCase):
 
         test_func(test_dict_constructor, ())
 
+        def test_dict_initializer_list():
+            a = {"1": torch.tensor(1), "2": torch.tensor(2)}
+            output_order = []
+            for key in a:
+                output_order.append(a[key])
+            return output_order
+
+        test_func(test_dict_initializer_list, ())
+
         def test_dict_error():
             a = dict()
             a[1] = 2

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -83,11 +83,15 @@ void dictConstruct(Stack& stack, at::DictTypePtr type, size_t num_inputs) {
   at::TypePtr value_type = type->getValueType();
   auto vals = c10::impl::GenericDict(key_type, value_type);
   vals.reserve(num_inputs / 2);
+  // loop from the bottom of the stack to ensure the dictConstruct preserve
+  // the inputs order.
+  auto inputs = last(stack, num_inputs);
   for (size_t i = 0; i < num_inputs; i += 2) {
-    auto val = pop(stack);
-    auto key = pop(stack);
+    auto key = inputs[i];
+    auto val = inputs[i + 1];
     vals.insert_or_assign(std::move(key), std::move(val));
   }
+  drop(stack, num_inputs);
   push(stack, std::move(vals));
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #39601 [jit] allow dict to be mixed between tracing and scripting
* **#40424 [jit] fix dictConstruct order issue**

dictConstruct should preserve the inputs order

Differential Revision: [D22202690](https://our.internmc.facebook.com/intern/diff/D22202690)