### PR TITLE
[NOT_FOR_LAND][android][ci] Fix CI packaging headers to aar

### DIFF
--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -86,7 +86,7 @@ task sourcesJar(type: Jar) {
 
 def getLibtorchHeadersDir() {
   def abi = ABI_FILTERS.split(",")[0]
-  return "$rootDir/../build_android_$abi/install/include";
+  return "$rootDir/pytorch_android/src/main/cpp/libtorch_include/$abi"
 }
 
 afterEvaluate {


### PR DESCRIPTION
ghstack-source-id: 587c494cb0b459162763d0efc310719fcff42ee5
Pull Request resolved: https://github.com/pytorch/pytorch/pull/40442

