### PR TITLE
Add C++-only `int dim` overloads to `std`-related operations

### DIFF
--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -22,6 +22,25 @@ using native::tensor;
 
 ${function_declarations}
 
+// Special C++ only overloads for std()-like functions (See gh-40287)
+// These are needed because int -> bool conversion takes precedence over int -> IntArrayRef
+// So, for example std(0) would select the std(unbiased=False) overload
+inline Tensor var(const Tensor& self, int dim) {
+  return at::native::var(self, IntArrayRef{dim});
+}
+
+inline std::tuple<Tensor,Tensor> var_mean(const Tensor& self, int dim) {
+  return at::native::var_mean(self, IntArrayRef{dim});
+}
+
+inline Tensor std(const Tensor& self, int dim) {
+  return at::native::std(self, IntArrayRef{dim});
+}
+
+inline std::tuple<Tensor,Tensor> std_mean(const Tensor& self, int dim) {
+  return at::native::std_mean(self, IntArrayRef{dim});
+}
+
 inline Tensor from_blob(
     void* data,
     IntArrayRef sizes,

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -545,6 +545,18 @@ class CAFFE2_API Tensor {
   //Tensor * add(Tensor & b);
   ${tensor_method_declarations}
 
+  // Special C++ only overloads for std()-like functions (See gh-40287)
+  // These are needed because int -> bool conversion takes precedence over int -> IntArrayRef
+  // So, for example std(0) would select the std(unbiased=False) overload
+
+  Tensor var(int dim) {
+    return var(IntArrayRef{dim});
+  }
+
+  Tensor std(int dim) {
+    return std(IntArrayRef{dim});
+  }
+
   // We changed .dtype() to return a TypeMeta in #12766. Ideally, we want the
   // at::kDouble and its friends to be TypeMeta's, but that hasn't happened yet.
   // Before that change, we make this method to maintain BC for C++ usage like

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -549,11 +549,11 @@ class CAFFE2_API Tensor {
   // These are needed because int -> bool conversion takes precedence over int -> IntArrayRef
   // So, for example std(0) would select the std(unbiased=False) overload
 
-  Tensor var(int dim) {
+  Tensor var(int dim) const {
     return var(IntArrayRef{dim});
   }
 
-  Tensor std(int dim) {
+  Tensor std(int dim) const {
     return std(IntArrayRef{dim});
   }
 

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -1046,3 +1046,25 @@ TEST(TensorTest, RequiresGradInplace) {
   ASSERT_THROWS_WITH(int_tensor.requires_grad_(true),
     "Only Tensors of floating point and complex dtype can require gradients");
 }
+
+TEST(TensorTest, StdDimension) {
+  // Test that std(0) doesn't select the std(unbiased=False) overload (gh-40287)
+  auto x = torch::randn({4, 3});
+  auto std = x.std(0);
+
+  ASSERT_EQ(x.var(0).numel(), 3);
+  ASSERT_EQ(x.std(0).numel(), 3);
+
+  ASSERT_EQ(x.var(0, /*unbiased=*/true).numel(), 3);
+  ASSERT_EQ(x.std(0, /*unbiased=*/true).numel(), 3);
+
+  ASSERT_EQ(torch::var(x, 0).numel(), 3);
+  ASSERT_EQ(std::get<0>(torch::var_mean(x, 0)).numel(), 3);
+  ASSERT_EQ(torch::std(x, 0).numel(), 3);
+  ASSERT_EQ(std::get<0>(torch::std_mean(x, 0)).numel(), 3);
+
+  ASSERT_EQ(torch::var(x, 0, /*unbiased=*/true).numel(), 3);
+  ASSERT_EQ(std::get<0>(torch::var_mean(x, 0, /*unbiased=*/true)).numel(), 3);
+  ASSERT_EQ(torch::std(x, 0, /*unbiased=*/true).numel(), 3);
+  ASSERT_EQ(std::get<0>(torch::std_mean(x, 0, /*unbiased=*/true)).numel(), 3);
+}


### PR DESCRIPTION
Fixes gh-40287

The `int -> bool` conversion takes higher precedence than `int -> IntArrayRef`. So, calling `std(0)` in C++ would select the `std(unbiased=False)` overload instead.