### PR TITLE
[torch.distributed.rpc] Install method docstrings from PyRRef to RRef

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -252,7 +252,7 @@ parameters during training. See :ref:`remote-reference-protocol` for more
 details.
 
 .. autoclass:: RRef
-    :inherited-members:
+    :members:
 
 
 .. toctree::

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -376,7 +376,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
                   to the creation of this RRef on the remote node has been recorded.
               )")
           // not releasing GIL to avoid context switch
-          .def("__str__", &PyRRef::str);
+          .def("__repr__", &PyRRef::str);
 
   shared_ptr_class_<ProcessGroupRpcBackendOptions>(
       module,

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -363,14 +363,13 @@ class RRef(GenericWithOneTypeVar):
     def __init__(self, *args, **kwargs):
         self._c = PyRRef(*args, **kwargs)
 
-    def __repr__(self):
-        return self._c.__repr__()
-
 
 # Install docstrings from `PyRRef` to `RRef`.
 #
-# This is for the fact that pybind11 generates the parameter types
-# for us.
+# This is for the fact that pybind11 generates the parameter
+# `self` as type `rpc.PyRRef`, so a `:inherited-members:`
+# under `.. autoclass:: RRef` does not work.
+# we have to do the following process to replacee `rpc.PyRRef` with `rpc.RRef`.
 #
 def method_factory(method_name, docstring):
     def method(self, *args, **kwargs):
@@ -381,18 +380,19 @@ def method_factory(method_name, docstring):
 
 
 for method_name, method in inspect.getmembers(PyRRef):
-    # Ignore magic methods from baseclasses.
-    if method_name.startswith("_"):
+    # Ignore magic methods, except "__str__".
+    if method_name.startswith("_") and method_name != "__str__":
         continue
 
     # Get pybind11 generated docstring.
     # It's like,
-    # >>> """to_here(self: torch.distributed.rpc.PyRRef, timeout: float=-1.0) -> object
-    # >>>
-    # >>>     Blocking call that copies the value of the RRef from the owner
-    # >>>     to the local node and returns it. If the current node is the
-    # >>>     owner, returns a reference to the local value.
-    # >>> """
+    """
+    to_here(self: torch.distributed.rpc.PyRRef, timeout: float=-1.0) -> object
+
+        Blocking call that copies the value of the RRef from the owner
+        to the local node and returns it. If the current node is the
+        owner, returns a reference to the local value.
+    """
     docstring = getattr(method, "__doc__", None)
     assert docstring is not None, "RRef user-facing methods should all have docstrings."
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -369,8 +369,8 @@ class RRef(GenericWithOneTypeVar):
 
 # Install docstrings from `PyRRef` to `RRef`.
 #
-# This is for the fact that `:inherited-members:` does not work.
-# See https://github.com/sphinx-doc/sphinx/issues/7867.
+# This is for the fact that pybind11 generates the parameter types
+# for us.
 #
 def method_factory(method_name, docstring):
     def method(self, *args, **kwargs):

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -385,9 +385,21 @@ for method_name, method in inspect.getmembers(PyRRef):
     if method_name.startswith("_"):
         continue
 
+    # Get pybind11 generated docstring.
+    # It's like,
+    # >>> """to_here(self: torch.distributed.rpc.PyRRef, timeout: float=-1.0) -> object
+    # >>>
+    # >>>     Blocking call that copies the value of the RRef from the owner
+    # >>>     to the local node and returns it. If the current node is the
+    # >>>     owner, returns a reference to the local value.
+    # >>> """
     docstring = getattr(method, "__doc__", None)
     assert docstring is not None, "RRef user-facing methods should all have docstrings."
 
+    # Do surgery on pybind11 generated docstrings.
+    docstring = docstring.replace("torch.distributed.rpc.PyRRef", "torch.distributed.rpc.RRef")
+
+    # Attach user-facing RRef method with modified docstring.
     new_method = method_factory(method_name, docstring)
     setattr(RRef, method_name, new_method)
 

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -50,12 +50,15 @@ class _InternalRPCPickler:
         return (_InternalRPCPickler._tensor_receiver, (tensor_index,))
 
     @classmethod
-    def _rref_receiver(cls, rref_fork_data):
-        return dist.rpc.RRef._deserialize(rref_fork_data)
+    def _py_rref_receiver(cls, rref_fork_data):
+        return dist.rpc.PyRRef._deserialize(rref_fork_data)
+
+    def _py_rref_reducer(self, py_rref):
+        rref_fork_data = py_rref._serialize()
+        return (_InternalRPCPickler._py_rref_receiver, (rref_fork_data,))
 
     def _rref_reducer(self, rref):
-        rref_fork_data = rref._serialize()
-        return (_InternalRPCPickler._rref_receiver, (rref_fork_data,))
+        return self._py_rref_reducer(rref._c)
 
     def serialize(self, obj):
         r"""
@@ -75,7 +78,7 @@ class _InternalRPCPickler:
         #
         # The return value of a `rpc.remote(..)` call is type of `rpc.PyRRef`.
         # The deserialized RRef object on an RPC receiver side is type of `rpc.PyRRef`.
-        p.dispatch_table[dist.rpc.PyRRef] = self._rref_reducer
+        p.dispatch_table[dist.rpc.PyRRef] = self._py_rref_reducer
         # An RRef created locally by RRef Python constructor is type of `rpc.RRef`.
         p.dispatch_table[dist.rpc.RRef] = self._rref_reducer
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40461 [torch.distributed.rpc] Install method docstrings from PyRRef to RRef**

It turned out `:inheried-members:` (see [doc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoclass)) is not really usable. 

Because pybind11 generates a docstring that writes `self` as parent class, `rpc.PyRRef`, type.

As a workaround, I am pulling docstrings on parent-class, `PyRRef` class, into subclass, `RRef`. And do surgery on the docstring generated by pybind11.

![image](https://user-images.githubusercontent.com/7608630/85462788-bd8c6400-b55a-11ea-9295-c245194f3580.png)


Differential Revision: [D7933834](https://our.internmc.facebook.com/intern/diff/D7933834/)