### PR TITLE
[JIT] script if tracing fix

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2858,19 +2858,19 @@ def foo(x):
             return x + 1
 
         @torch.jit._script_if_tracing
-        def fee():
-            return foo(1)
+        def fee(x: int = 2):
+            return foo(1) + x
 
         # test directly compiling function
         fee_compiled = torch.jit.script(fee)
-        self.assertEqual(fee_compiled(), 2)
+        self.assertEqual(fee_compiled(), fee())
 
         # test compiling it within another function
         @torch.jit.script
         def hum():
-            return fee()
+            return fee(x=3)
 
-        self.assertEqual(hum(), 2)
+        self.assertEqual(hum(), 5)
 
     def test_big_int_literals(self):
         def ok():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2854,6 +2854,24 @@ def foo(x):
 
         FileCheck().check("goodbye").run(traced.graph)
 
+        def foo(x: int):
+            return x + 1
+
+        @torch.jit._script_if_tracing
+        def fee():
+            return foo(1)
+
+        # test directly compiling function
+        fee_compiled = torch.jit.script(fee)
+        self.assertEqual(fee_compiled(), 2)
+
+        # test compiling it within another function
+        @torch.jit.script
+        def hum():
+            return fee()
+
+        self.assertEqual(hum(), 2)
+
     def test_big_int_literals(self):
         def ok():
             # signed 64 bit max

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1374,9 +1374,10 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         _compile_and_register_class(obj, _rcb, qualified_name)
         return obj
     else:
-        # need to unwrap fn here so that direction compilation of decorated functions work
         if hasattr(obj, "__script_if_tracing_wrapper"):
             obj = obj.__original_fn
+            # rcb must be from the wrapped function, not the wrapper
+            _rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
 
         _check_directly_compile_overloaded(obj)
         maybe_already_compiled_fn = _try_get_jit_cached_function(obj)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1374,6 +1374,10 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         _compile_and_register_class(obj, _rcb, qualified_name)
         return obj
     else:
+        # need to unwrap fn here so that direction compilation of decorated functions work
+        if hasattr(obj, "__script_if_tracing_wrapper"):
+            obj = obj.__original_fn
+
         _check_directly_compile_overloaded(obj)
         maybe_already_compiled_fn = _try_get_jit_cached_function(obj)
         if maybe_already_compiled_fn:
@@ -1424,19 +1428,17 @@ def _script_if_tracing(fn):
     ``@torch.jit._script_if_tracing`` to substitute for
     ``torch.jit.script``.
     """
-    # You can't modify closed-over variables in Python 2, so make this a dict and
-    # mutate it
-    compiled_fn = {}
-
     @functools.wraps(fn)
-    def wrapper(*args):
+    def wrapper(*args, **kwargs):
         if not is_tracing():
             # Not tracing, don't do anything
-            return fn(*args)
+            return fn(*args, **kwargs)
 
-        if 'fn' not in compiled_fn:
-            compiled_fn['fn'] = script(fn, _frames_up=1)
-        return compiled_fn['fn'](*args)
+        compiled_fn = script(wrapper.__original_fn)
+        return compiled_fn(*args, **kwargs)
+
+    wrapper.__original_fn = fn
+    wrapper.__script_if_tracing_wrapper = True
 
     return wrapper
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1374,9 +1374,9 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         _compile_and_register_class(obj, _rcb, qualified_name)
         return obj
     else:
+        # this is a decorated fn, and we need to the underlying fn and its rcb
         if hasattr(obj, "__script_if_tracing_wrapper"):
             obj = obj.__original_fn
-            # rcb must be from the wrapped function, not the wrapper
             _rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
 
         _check_directly_compile_overloaded(obj)

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -576,10 +576,6 @@ def try_compile_fn(fn, loc):
                            "Python functions or methods currently.\n"
                            "Consider manually annotating `{}` with @torch.jit.script.".format(fn, fn))
 
-    # need to access wrapped fn before creating rcb
-    if hasattr(fn, "__script_if_tracing_wrapper"):
-        fn = fn.__original_fn
-
     # We don't have the actual scope where the function was defined, but we can
     # extract the necessary info from the closed over variables on the function
     # object

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -576,6 +576,10 @@ def try_compile_fn(fn, loc):
                            "Python functions or methods currently.\n"
                            "Consider manually annotating `{}` with @torch.jit.script.".format(fn, fn))
 
+    # need to access wrapped fn before creating rcb
+    if hasattr(fn, "__script_if_tracing_wrapper"):
+        fn = fn.__original_fn
+
     # We don't have the actual scope where the function was defined, but we can
     # extract the necessary info from the closed over variables on the function
     # object


### PR DESCRIPTION
Currently, torchvision annotates `batched_nms` with `torch.jit.script` so the function gets compiled when it is traced and ONNX will work. Unfortunately, this means we are eagerly compiling batched_nms, which fails if torchvision isn't built with `torchvision.ops.nms`. As a result, torchvision doesn't work on torch hub right now.

`_script_if_tracing` could solve our problem here, but right now it does not correctly interact with recursive compilation. This PR fixes that bug. 