### PR TITLE
`torch.nn.Module` Shape Inference

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -21,6 +21,8 @@ These are the basic building block for graphs
     :template: classtemplate.rst
 
     ~parameter.Parameter
+    ~parameter.UninitializedParameter
+    ~parameter.UninitializedBuffer
 
 Containers
 ----------------------------------

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11550,6 +11550,16 @@ class TestLazyModules(TestCase):
         module.load_state_dict(new_module.state_dict())
         self.assertEqual(module.test_param, torch.ones((5, 5))) 
 
+        # Uninitialized parameters are left unchanged
+        module = torch.nn.Module()
+        module.register_parameter('test_param', UninitializedParameter())
+        self.assertTrue(module.has_uninitialized_params_or_buffers())
+
+        new_module = torch.nn.Module()
+        new_module.register_parameter('test_param', UninitializedParameter())
+        module.load_state_dict(new_module.state_dict())
+        self.assertTrue(module.has_uninitialized_params_or_buffers())
+
     def test_lazy_module_buffer(self):
         module = torch.nn.Module()
         module.register_buffer('test_buffer', UninitializedBuffer())
@@ -11572,6 +11582,16 @@ class TestLazyModules(TestCase):
         new_module.register_buffer('test_buffer', torch.ones(5, 5))
         module.load_state_dict(new_module.state_dict())
         self.assertEqual(module.test_buffer, torch.ones((5, 5))) 
+
+        # Uninitialized parameters are left unchanged
+        module = torch.nn.Module()
+        module.register_buffer('test_buffer', UninitializedBuffer())
+        self.assertTrue(module.has_uninitialized_params_or_buffers())
+
+        new_module = torch.nn.Module()
+        new_module.register_buffer('test_buffer', UninitializedBuffer())
+        module.load_state_dict(new_module.state_dict())
+        self.assertTrue(module.has_uninitialized_params_or_buffers())
 
     def test_lazy_module_jit(self):
         module = torch.nn.Module()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11554,8 +11554,8 @@ class TestLazyModules(TestCase):
     def test_linear(self):
         module = nn.Linear(nn.parameter.ParameterMode.Infer, 10)
         self.assertIsInstance(module.weight, nn.parameter._UninitializedParameter)
-        # Do the forward pass
         input = torch.ones(5, 5)
+        module.initialize_parameters(input)
         y = module(input)
         self.assertTrue(module.weight.shape == (10, 5))
         self.assertTrue(torch.equal(torch.nn.functional.linear(input, module.weight, module.bias), y))
@@ -11563,6 +11563,7 @@ class TestLazyModules(TestCase):
     def test_conv(self):
         def conv_check(module, input, shape, check_fn):
             self.assertIsInstance(module.weight, nn.parameter._UninitializedParameter)
+            module.initialize_parameters(input)
             y = module(input)
             self.assertTrue(module.weight.shape == shape)
             self.assertTrue(torch.equal(check_fn(input, module.weight, module.bias), y))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11533,8 +11533,6 @@ class TestLazyModules(TestCase):
         module = torch.nn.Module()
         module.register_parameter('test_param', UninitializedParameter())
         self.assertTrue(module.has_uninitialized_params_or_buffers())
-        self.assertTrue(module.has_uninitialized_params_or_buffers())
-        self.assertTrue(module.has_uninitialized_params_or_buffers())
         with self.assertRaisesRegex(ValueError, 'uninitialized'):
             list(module.parameters())
 
@@ -11574,6 +11572,13 @@ class TestLazyModules(TestCase):
         new_module.register_buffer('test_buffer', torch.ones(5, 5))
         module.load_state_dict(new_module.state_dict())
         self.assertEqual(module.test_buffer, torch.ones((5, 5))) 
+
+    def test_lazy_module_jit(self):
+        module = torch.nn.Module()
+        module.register_parameter('test_param', UninitializedParameter())
+        self.assertTrue(module.has_uninitialized_params_or_buffers())
+        with self.assertRaisesRegex(RuntimeError, 'infer_parameters'):
+            torch.jit.script(module)
 
     def test_linear(self):
         module = nn.Linear(nn.parameter.ParameterMode.Infer, 10)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11540,10 +11540,16 @@ class TestLazyModules(TestCase):
         state_dict = module.state_dict()
         self.assertIsInstance(state_dict['test_param'], nn.parameter._UninitializedParameter)
         new_module = torch.nn.Module()
-        # Uninitialized paramaters in a state dict are ignored when the module has a valid one.
+        # An error is raised when there is an attempt to replace an existing parameter
+        # with an uninitialized one
         new_module.register_parameter('test_param', nn.Parameter(torch.ones(5, 5)))
-        new_module.load_state_dict(state_dict) 
-        self.assertNotIsInstance(new_module.test_param, nn.parameter._UninitializedParameter)
+        with self.assertRaisesRegex(ValueError, 'uninitialized'):
+            new_module.load_state_dict(state_dict)
+        # Uninitialized parameters are overriden when the state dict to be loaded contains a valid one
+        new_module = torch.nn.Module()
+        new_module.register_parameter('test_param', nn.Parameter(torch.ones(5, 5)))
+        module.load_state_dict(new_module.state_dict())
+        self.assertEqual(module.test_param, torch.ones((5, 5))) 
 
     def test_linear(self):
         module = nn.Linear(nn.parameter.ParameterMode.Infer, 10)
@@ -11568,7 +11574,7 @@ class TestLazyModules(TestCase):
         conv_check(module, input, (4, 4, 2), torch.nn.functional.conv_transpose1d)
         module = nn.Conv2d(nn.parameter.ParameterMode.Infer, 4, 2)
         input = torch.ones(4, 4, 4, 3)
-        conv_check(module, input, (4, 4, 4, 2), torch.nn.functional.conv2d)
+        conv_check(module, input, (4, 4, 2, 2), torch.nn.functional.conv2d)
 
 class TestModuleGlobalHooks(TestCase):
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11580,6 +11580,13 @@ class TestLazyModules(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'infer_parameters'):
             torch.jit.script(module)
 
+    def test_lazy_share_memory(self):
+        module = torch.nn.Module()
+        module.register_parameter('test_param', UninitializedParameter())
+        self.assertTrue(module.has_uninitialized_params_or_buffers())
+        with self.assertRaisesRegex(RuntimeError, 'initialize'):
+            module.share_memory()
+
     def test_linear(self):
         module = nn.Linear(nn.parameter.ParameterMode.Infer, 10)
         self.assertIsInstance(module.weight, UninitializedParameter)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11556,16 +11556,16 @@ class TestLazyModules(TestCase):
         self.assertIsInstance(module.weight, nn.parameter._UninitializedParameter)
         input = torch.ones(5, 5)
         module.initialize_parameters(input)
-        y = module(input)
         self.assertTrue(module.weight.shape == (10, 5))
+        y = module(input)
         self.assertTrue(torch.equal(torch.nn.functional.linear(input, module.weight, module.bias), y))
 
     def test_conv(self):
         def conv_check(module, input, shape, check_fn):
             self.assertIsInstance(module.weight, nn.parameter._UninitializedParameter)
             module.initialize_parameters(input)
-            y = module(input)
             self.assertTrue(module.weight.shape == shape)
+            y = module(input)
             self.assertTrue(torch.equal(check_fn(input, module.weight, module.bias), y))
 
         module = nn.Conv1d(nn.parameter.ParameterMode.Infer, 4, 2)

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -497,6 +497,10 @@ def check_module_initialized(mod):
     if not hasattr(mod, '_parameters'):
         raise RuntimeError("'{}' has not been initialized, did you forget to call 'super()'?"
                            .format(torch.typename(type(mod))))
+    if mod.has_uninitialized_params_or_buffers():
+        raise RuntimeError("'{}' has uninitialized parameters or buffers, did you forget to call 'infer_parameters()'?"
+                           .format(torch.typename(type(mod))))
+
 
 def infer_methods_to_compile(nn_module):
     """

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -690,6 +690,7 @@ if _enabled:
         "_tracing_name",
         "eval",
         "train",
+        "has_uninitialized_params_or_buffers",
     }
 
     def _make_fail(name):

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -4,7 +4,7 @@ import warnings
 
 import torch
 from torch import Tensor
-from torch.nn.parameter import Parameter, ParameterMode, _UninitializedParameter
+from torch.nn.parameter import Parameter, ParameterMode, UninitializedParameter
 from .. import functional as F
 from .. import init
 from .module import Module
@@ -70,7 +70,7 @@ class _ConvNd(Module):
         self._reversed_padding_repeated_twice = _reverse_repeat_tuple(self.padding, 2)
         if in_channels == ParameterMode.Infer:
             self.in_channels = None
-            self.weight = _UninitializedParameter()
+            self.weight = UninitializedParameter()
         else:
             if in_channels is not None:
                 if in_channels % groups != 0:
@@ -199,6 +199,10 @@ class Conv1d(_ConvNd):
         True``.
         Please see the notes on :doc:`/notes/randomness` for background.
 
+    Note:
+        `in_channels` can be inferred from the input size by passing a
+        `torch.nn.parameter.ParameterMode.Infer` value and calling
+        :func:`torch.nn.Module.infer_parameters` before the forward pass
 
     Args:
         in_channels (int): Number of channels in the input image
@@ -350,6 +354,10 @@ class Conv2d(_ConvNd):
         True``.
         Please see the notes on :doc:`/notes/randomness` for background.
 
+    Note:
+        `in_channels` can be inferred from the input size by passing a
+        `torch.nn.parameter.ParameterMode.Infer` value and calling
+        :func:`torch.nn.Module.infer_parameters` before the forward pass
 
     Args:
         in_channels (int): Number of channels in the input image
@@ -504,6 +512,10 @@ class Conv3d(_ConvNd):
         True``.
         Please see the notes on :doc:`/notes/randomness` for background.
 
+    Note:
+        `in_channels` can be inferred from the input size by passing a
+        `torch.nn.parameter.ParameterMode.Infer` value and calling
+        :func:`torch.nn.Module.infer_parameters` before the forward pass
 
     Args:
         in_channels (int): Number of channels in the input image
@@ -699,6 +711,11 @@ class ConvTranspose1d(_ConvTransposeNd):
         True``.
         Please see the notes on :doc:`/notes/randomness` for background.
 
+    Note:
+        `in_channels` can be inferred from the input size by passing a
+        `torch.nn.parameter.ParameterMode.Infer` value and calling
+        :func:`torch.nn.Module.infer_parameters` before the forward pass
+
     Args:
         in_channels (int): Number of channels in the input image
         out_channels (int): Number of channels produced by the convolution
@@ -838,6 +855,10 @@ class ConvTranspose2d(_ConvTransposeNd):
         True``.
         Please see the notes on :doc:`/notes/randomness` for background.
 
+    Note:
+        `in_channels` can be inferred from the input size by passing a
+        `torch.nn.parameter.ParameterMode.Infer` value and calling
+        :func:`torch.nn.Module.infer_parameters` before the forward pass
 
     Args:
         in_channels (int): Number of channels in the input image
@@ -1003,6 +1024,10 @@ class ConvTranspose3d(_ConvTransposeNd):
         True``.
         Please see the notes on :doc:`/notes/randomness` for background.
 
+    Note:
+        `in_channels` can be inferred from the input size by passing a
+        `torch.nn.parameter.ParameterMode.Infer` value and calling
+        :func:`torch.nn.Module.infer_parameters` before the forward pass
 
     Args:
         in_channels (int): Number of channels in the input image

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -129,7 +129,7 @@ class _ConvNd(Module):
                 else:
                     shape = (self.out_channels, self.in_channels // self.groups,
                              *self.kernel_size)
-                self.weight = torch.nn.Parameter(self.weight.new_empty(*shape))
+                self.weight = self.weight.materialize(shape)
                 self.reset_parameters()
 
 

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -120,8 +120,6 @@ class _ConvNd(Module):
             self.padding_mode = 'zeros'
 
     def initialize_parameters(self, input):
-        prev_mode = self.training
-        self.train(False)
         if self.in_channels is None:
             with torch.no_grad():
                 self.in_channels = input.shape[1]
@@ -133,7 +131,6 @@ class _ConvNd(Module):
                              *self.kernel_size)
                 self.weight = torch.nn.Parameter(self.weight.new_empty(*shape))
                 self.reset_parameters()
-        self.train(prev_mode)
 
 
 class Conv1d(_ConvNd):

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -69,18 +69,16 @@ class Linear(Module):
     out_features: int
     weight: Tensor
 
-    def __init__(self, in_features: int, out_features: int, bias: bool = True, param_mode: ParameterMode = ParameterMode.Explicit) -> None:
+    def __init__(self, in_features: int, out_features: int, bias: bool = True) -> None:
         super(Linear, self).__init__()
         self.in_features = in_features
         self.out_features = out_features
 
-        if param_mode == ParameterMode.Infer:
+        if self.in_features == ParameterMode.Infer:
             self.in_features = None
             self.weight = _UninitializedParameter()
-        elif param_mode == ParameterMode.Explicit:
-            self.weight = Parameter(torch.Tensor(out_features, in_features))
         else:
-            raise ValueError('Unknown parameter initialization mode')
+            self.weight = Parameter(torch.Tensor(out_features, in_features))
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_features))

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -95,15 +95,14 @@ class Linear(Module):
                 bound = 1 / math.sqrt(fan_in)
                 init.uniform_(self.bias, -bound, bound)
 
-    def initialize_parameters(self, input: Tensor):
-        previous_mode = self.training
-        self.train(False)
+    def initialize_parameters(self, input) -> None:
         if self.in_features is None:
             with torch.no_grad():
                 self.in_features = input.shape[-1]
-                self.weight = Parameter(torch.Tensor(self.out_features, self.in_features))
+                # self.weight = self.weight.materialize((self.out_features, self.in_features))
+                self.register_parameter('weight', Parameter(torch.Tensor(self.out_features, self.in_features)))
+                # self.weight = Parameter(torch.Tensor(self.out_features, self.in_features))
                 self.reset_parameters()
-        self.train(previous_mode)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.linear(input, self.weight, self.bias)

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -2,7 +2,7 @@ import math
 
 import torch
 from torch import Tensor
-from torch.nn.parameter import Parameter, _UninitializedParameter, ParameterMode
+from torch.nn.parameter import Parameter, UninitializedParameter, ParameterMode
 from .. import functional as F
 from .. import init
 from .module import Module
@@ -33,6 +33,11 @@ class Identity(Module):
 
 class Linear(Module):
     r"""Applies a linear transformation to the incoming data: :math:`y = xA^T + b`
+
+    Note:
+        `in_channels` can be inferred from the input size by passing a
+        `torch.nn.parameter.ParameterMode.Infer` value and calling
+        :func:`torch.nn.Module.infer_parameters` before the forward pass
 
     Args:
         in_features: size of each input sample
@@ -76,7 +81,7 @@ class Linear(Module):
 
         if self.in_features == ParameterMode.Infer:
             self.in_features = None
-            self.weight = _UninitializedParameter()
+            self.weight = UninitializedParameter()
         else:
             self.weight = Parameter(torch.Tensor(out_features, in_features))
 

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -95,12 +95,17 @@ class Linear(Module):
                 bound = 1 / math.sqrt(fan_in)
                 init.uniform_(self.bias, -bound, bound)
 
-    def forward(self, input: Tensor) -> Tensor:
-        # Inputs are reshaped on the first forward call
+    def initialize_parameters(self, input: Tensor):
+        previous_mode = self.training
+        self.train(False)
         if self.in_features is None:
-            self.in_features = input.shape[-1]
-            self.weight = Parameter(torch.Tensor(self.out_features, self.in_features))
-            self.reset_parameters()
+            with torch.no_grad():
+                self.in_features = input.shape[-1]
+                self.weight = Parameter(torch.Tensor(self.out_features, self.in_features))
+                self.reset_parameters()
+        self.train(previous_mode)
+
+    def forward(self, input: Tensor) -> Tensor:
         return F.linear(input, self.weight, self.bias)
 
     def extra_repr(self) -> str:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -99,9 +99,7 @@ class Linear(Module):
         if self.in_features is None:
             with torch.no_grad():
                 self.in_features = input.shape[-1]
-                # self.weight = self.weight.materialize((self.out_features, self.in_features))
-                self.register_parameter('weight', Parameter(torch.Tensor(self.out_features, self.in_features)))
-                # self.weight = Parameter(torch.Tensor(self.out_features, self.in_features))
+                self.weight = self.weight.materialize((self.out_features, self.in_features))
                 self.reset_parameters()
 
     def forward(self, input: Tensor) -> Tensor:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -980,19 +980,21 @@ class Module:
                     if not isinstance(param, UninitializedParameter):
                         raise ValueError('Can\'t load an uninitialized Parameter {} into an initialized one'.format(name))
                 elif isinstance(input_param, UninitializedBuffer):
-                    if not isinstance(param, UninitializedParameter):
+                    if not isinstance(param, UninitializedBuffer):
                         raise ValueError('Can\'t load an uninitialized Buffer {} into an initialized one'.format(name))
                 if isinstance(param, UninitializedParameter): 
                     # The current parameter is not initialized but the one being loaded one is
                     # create a new parameter based on the uninitialized one
-                    with torch.no_grad():
-                        param = param.materialize(input_param.shape)
+                    if not isinstance(input_param, UninitializedParameter):
+                        with torch.no_grad():
+                            param = param.materialize(input_param.shape)
                     self.register_parameter(name, param)
                 elif isinstance(param, UninitializedBuffer): 
                     # The current buffer is not initialized but the being loaded one is
                     # create a new buffer based on the existing one
-                    with torch.no_grad():
-                        param = param.materialize(input_param.shape)
+                    if not isinstance(input_param, UninitializedBuffer):
+                        with torch.no_grad():
+                            param = param.materialize(input_param.shape)
                     self.register_buffer(name, param)
 
                 # Backward compatibility: loading 1-dim tensor from 0.3.* to version 0.4+

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -962,6 +962,12 @@ class Module:
             key = prefix + name
             if key in state_dict:
                 input_param = state_dict[key]
+                if isinstance(param, _UninitializedParameter):
+                    if not isinstance(input_param, _UninitializedParameter):
+                        # We override the parameter with a new one if it was already 
+                        # Initialized
+                        self.register_parameter(name, torch.nn.Parameter(state_dict[key]))
+                    continue
 
                 # Backward compatibility: loading 1-dim tensor from 0.3.* to version 0.4+
                 if len(param.shape) == 0 and len(input_param.shape) == 1:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -4,7 +4,7 @@ import itertools
 import warnings
 
 import torch
-from ..parameter import Parameter
+from ..parameter import Parameter, _UninitializedParameter
 import torch.utils.hooks as hooks
 
 from torch import Tensor, device, dtype
@@ -1084,6 +1084,8 @@ class Module:
 
         """
         for name, param in self.named_parameters(recurse=recurse):
+            if isinstance(param, _UninitializedParameter):
+                raise ValueError('Can\'t retrieve an unitialized parameter {}'.format(name))
             yield param
 
     def named_parameters(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, Tensor]]:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -967,8 +967,8 @@ class Module:
             if key in state_dict:
                 input_param = state_dict[key]
                 # Detect Unitialized parameters or buffers
-                if isinstance(param, _UninitializedParameter):
-                    if not isinstance(input_param, _UninitializedParameter):
+                if not isinstance(param, _UninitializedParameter):
+                    if isinstance(input_param, _UninitializedParameter):
                         # We override the parameter with a new one if it was already 
                         # Initialized
                         self.register_parameter(name, torch.nn.Parameter(input_param))

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -373,6 +373,8 @@ class Module:
 
         for key, param in self._parameters.items():
             if param is not None:
+                if isinstance(param, _UninitializedParameter):
+                    raise ValueError('Can\'t apply a function to an uninitialized parameter {}'.format(key))
                 # Tensors stored in modules are graph leaves, and we don't want to
                 # track autograd history of `param_applied`, so we have to use
                 # `with torch.no_grad():`
@@ -397,6 +399,8 @@ class Module:
                         self._parameters[key].grad = grad_applied.requires_grad_(param.grad.requires_grad)
 
         for key, buf in self._buffers.items():
+            if isinstance(buf, _UninitializedBuffer):
+                raise ValueError('Can\'t apply a function to an uninitialized buffer {}'.format(key))
             if buf is not None:
                 self._buffers[key] = fn(buf)
 
@@ -1096,7 +1100,7 @@ class Module:
         """
         for name, param in self.named_parameters(recurse=recurse):
             if isinstance(param, _UninitializedParameter):
-                raise ValueError('Can\'t retrieve an unitialized parameter {}'.format(name))
+                raise ValueError('Can\'t retrieve an uninitialized parameter {}'.format(name))
             yield param
 
     def named_parameters(self, prefix: str = '', recurse: bool = True) -> Iterator[Tuple[str, Tensor]]:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -399,7 +399,7 @@ class Module:
         for key, buf in self._buffers.items():
             if buf is not None:
                 if isinstance(buf, UninitializedBuffer):
-                    self._buffers[key].data = fn(buf)
+                    self._buffers[key] = UninitializedBuffer(fn(buf))
                 else:
                     self._buffers[key] = fn(buf)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1441,9 +1441,9 @@ class Module:
         """
         # This is to avoid the JIT to track this parameter and force
         # custom modules __setstate__ to add it
-        params_and_buffers = dict(self.named_parameters(recurse=False))
-        params_and_buffers.update(self.named_buffers(recurse=False))
-        for name, param in params_and_buffers.items():
+        params = self._parameters.values()
+        buffers = self._buffers.values()
+        for param in itertools.chain(params, buffers):
             if isinstance(param, (UninitializedParameter, UninitializedBuffer)):
                 return True
         return False

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -92,8 +92,9 @@ class UninitializedParameter(Parameter):
 class UninitializedBuffer(torch.Tensor):
     r"""A buffer that is not yet initialized for shape inference support.
     """
-    def __new__(cls):
-        data = torch.Tensor()
+    def __new__(cls, data=None):
+        if data is None:
+            data = torch.Tensor()
         requires_grad = False
         return torch.Tensor._make_subclass(cls, data, requires_grad)
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -3,8 +3,7 @@ import torch
 from collections import OrderedDict
 
 class ParameterMode(enum.Enum):
-    Explicit = 1
-    Infer = 2
+    Infer = -1
 
 
 class Parameter(torch.Tensor):

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -48,7 +48,7 @@ class Parameter(torch.Tensor):
         )
 
 
-class _UninitializedParameter(Parameter):
+class UninitializedParameter(Parameter):
     r"""A parameter that is not yet initialized for shape inference support.
 
     Uninitialized Parameters holds empty tensors that can be moved
@@ -77,19 +77,39 @@ class _UninitializedParameter(Parameter):
             device = self.data.device
         if dtype is None:
             dtype = self.data.dtype
-        return Parameter(torch.empty(shape, device=device, dtype=dtype))
+        return Parameter(torch.empty(shape, device=device, dtype=dtype), requires_grad=self.requires_grad)
 
     def __repr__(self):
         return 'Uninitialized parameter'
 
 
-class _UninitializedBuffer(torch.Tensor):
+class UninitializedBuffer(torch.Tensor):
     r"""A buffer that is not yet initialized for shape inference support.
     """
     def __new__(cls):
         data = torch.Tensor()
         requires_grad = False
         return torch.Tensor._make_subclass(cls, data, requires_grad)
+
+    def materialize(self, shape, device=None, dtype=None):
+        r"""Create a Buffer with the same properties of the uninitialized one.
+
+        Given a shape, it materializes a buffer in the same device
+        and with the same `dtype` as the current one or the specified ones in the 
+        arguments
+
+        Args:
+            shape : (tuple): the shape for the materialized tensor.
+            device (:class:`torch.device`): the desired device of the parameters
+                and buffers in this module. Optional.
+            dtype (:class:`torch.dtype`): the desired floating point type of
+                the floating point parameters and buffers in this module. Optional.
+        """
+        if device is None:
+            device = self.data.device
+        if dtype is None:
+            dtype = self.data.dtype
+        return torch.empty(shape, device=device, dtype=dtype)
 
     def __repr__(self):
         return 'Uninitialized buffer'

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -50,14 +50,29 @@ class Parameter(torch.Tensor):
 
 class _UninitializedParameter(Parameter):
     r"""A parameter that is not yet initialized for shape inference support.
+
+    Uninitialized Parameters holds empty tensors that can be moved
+    to different devices and change their type so when they are materialized,
+    they do it directly with the right configuration.
     """
     def __new__(cls, requires_grad=True):
         data = torch.Tensor()
         return torch.Tensor._make_subclass(cls, data, requires_grad)
 
     def materialize(self, shape, device=None, dtype=None):
-        r"""Given a shape, it materializes a parameter in the same device
-        as the current one"""
+        r"""Create a Parameter with the same properties of the uninitialized one.
+
+        Given a shape, it materializes a parameter in the same device
+        and with the same `dtype` as the current one or the specified ones in the 
+        arguments
+
+        Args:
+            shape : (tuple): the shape for the materialized tensor.
+            device (:class:`torch.device`): the desired device of the parameters
+                and buffers in this module. Optional.
+            dtype (:class:`torch.dtype`): the desired floating point type of
+                the floating point parameters and buffers in this module. Optional.
+        """
         if device is None:
             device = self.data.device
         if dtype is None:

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -55,6 +55,15 @@ class _UninitializedParameter(Parameter):
         data = torch.Tensor()
         return torch.Tensor._make_subclass(cls, data, requires_grad)
 
+    def materialize(self, shape, device=None, dtype=None):
+        r"""Given a shape, it materializes a parameter in the same device
+        as the current one"""
+        if device is None:
+            device = self.data.device
+        if dtype is None:
+            dtype = self.data.dtype
+        return Parameter(torch.empty(shape, device=device, dtype=dtype))
+
     def __repr__(self):
         return 'Uninitialized parameter'
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -1,5 +1,10 @@
+import enum
 import torch
 from collections import OrderedDict
+
+class ParameterMode(enum.Enum):
+    Explicit = 1
+    Infer = 2
 
 
 class Parameter(torch.Tensor):
@@ -42,3 +47,12 @@ class Parameter(torch.Tensor):
             torch._utils._rebuild_parameter,
             (self.data, self.requires_grad, OrderedDict())
         )
+
+
+class _UninitializedParameter(Parameter):
+    r"""A parameter that is not yet initialized for lazy modules support.
+
+    UninitializedParameters are detected by the optimizer ...
+    """
+    def __repr__(self):
+        return 'Uninitialized lazy parameter'

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -79,6 +79,12 @@ class UninitializedParameter(Parameter):
             dtype = self.data.dtype
         return Parameter(torch.empty(shape, device=device, dtype=dtype), requires_grad=self.requires_grad)
 
+    def share_memory_(self):
+        raise RuntimeError(
+            'Can\'t share memory on an uninitialized parameter. '
+            'Run forward to initialize the network before calling '
+            '`module.share_memory()`.')
+
     def __repr__(self):
         return 'Uninitialized parameter'
 
@@ -110,6 +116,12 @@ class UninitializedBuffer(torch.Tensor):
         if dtype is None:
             dtype = self.data.dtype
         return torch.empty(shape, device=device, dtype=dtype)
+
+    def share_memory_(self):
+        raise RuntimeError(
+            'Can\'t share memory on an uninitialized buffer. '
+            'Run forward to initialize the network before calling '
+            '`module.share_memory()`.')
 
     def __repr__(self):
         return 'Uninitialized buffer'


### PR DESCRIPTION
cc @albanD @gchanan @soumith 

Hello, we would like to contribute our shape inference mechanism that we use in https://github.com/pfnet/pytorch-pfn-extras
The original implementation was done by @corochann

This PR tries to adapt it to the requirements specified by @soumith in  #23352 & #17448

I would like to get feedback on this approach and keep working until the majority is satisfied with it :).

Thanks!

To discuss:
- Behavior in `load_state_dict` -> when a parameter is initialized, and we load a state dict where that parameter wasn't initialized, keeping the actual parameter is a valid approach?
- Raising errors in JIT. I have no idea where the parameters are accessed in the JIT right now. (I hand't look at it so much, I left it for a latter stage) 
- libtorch. Should we add support for this in the C++ layer in this PR or a different one.