### PR TITLE
Add __all__ to torch/_C/_VariableFunctions.pyi

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 import os
 import collections
+from pprint import pformat
+
 import yaml
 import re
 import argparse
@@ -640,6 +642,14 @@ def gen_pyi(declarations_path, out):
                           'complex32', 'complex64', 'cfloat', 'complex128', 'cdouble',
                           'quint8', 'qint8', 'qint32', 'bool']]
 
+    # Generate __all__ directive
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    hinted_function_names = [name for name, hint in unsorted_function_hints.items() if hint]
+    all_symbols = sorted(list(namedtuples.keys()) + hinted_function_names)
+    all_directive = pformat(all_symbols, width=100, compact=True).split('\n')
+    all_directive[0] = '__all__ = {}'.format(all_directive[0])
+
     # Write out the stub
     # ~~~~~~~~~~~~~~~~~~
 
@@ -650,6 +660,7 @@ def gen_pyi(declarations_path, out):
         'legacy_class_hints': legacy_class_hints,
         'legacy_storage_base_hints': legacy_storage_base_hints,
         'dtype_class_hints': dtype_class_hints,
+        'all_directive': all_directive
     }
     TORCH_C_TYPE_STUBS = CodeTemplate.from_file(os.path.join('torch', '_C', '__init__.pyi.in'))
     TORCH_C_VARIABLE_FUNCTIONS_TYPE_STUBS = \

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -645,6 +645,8 @@ def gen_pyi(declarations_path, out):
     # Generate __all__ directive
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+    # Include only the functions that contain hints, to prevent undefined
+    # symbols to be included in the `__all__` directive.
     hinted_function_names = [name for name, hint in unsorted_function_hints.items() if hint]
     all_symbols = sorted(list(namedtuples.keys()) + hinted_function_names)
     all_directive = pformat(all_symbols, width=100, compact=True).split('\n')

--- a/torch/_C/_VariableFunctions.pyi.in
+++ b/torch/_C/_VariableFunctions.pyi.in
@@ -12,3 +12,5 @@ import builtins
 ${namedtuple_defs}
 
 ${function_hints}
+
+${all_directive}


### PR DESCRIPTION
Related to #40397

### Summary

Inspired by ezyang's comment at https://github.com/pytorch/pytorch/issues/40397#issuecomment-648233001, this PR attempts to leverage using `__all__` to explicitly export private functions from `_VariableFunctions.pyi` in order to make `mypy` aware of them after:

```
if False:
    from torch._C._VariableFunctions import *
``` 

The generation of the `__all__` template variable excludes some items from `unsorted_function_hints`, as it seems that those without hints end up not being explicitly included in the `.pyi` file: I leaned on the side of caution and opted for having `__all__` consistent with the definitions inside the file. Additionally, added some pretty-printing to avoid having an extremely long line.

