### PR TITLE
Add C++ standard version check to top level headers

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if !defined(_MSC_VER) && __cplusplus < 201402L
+#error C++14 or later compatible compiler is required to use ATen.
+#endif
+
 #include <c10/core/Allocator.h>
 #include <ATen/core/ATenGeneral.h>
 #include <ATen/Context.h>

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -249,9 +249,6 @@ function(torch_compile_options libname)
         /bigobj
         )
     else()
-      target_compile_options(${libname} PUBLIC
-        $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>
-        )
       target_compile_options(${libname} PRIVATE
         -Wall
         -Wextra

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if !defined(_MSC_VER) && __cplusplus < 201402L
+#error C++14 or later compatible compiler is required to use PyTorch.
+#endif
+
 #include <torch/cuda.h>
 #include <torch/data.h>
 #include <torch/enum.h>


### PR DESCRIPTION
Remove `-std=c++14` flag from `utils.cmake`, since PyTorch C++ API can be invoked by any compiler compliant with C++14 standard or later

