### PR TITLE
Add batching rule for Tensor.permute

### DIFF
--- a/aten/src/ATen/test/vmap_test.cpp
+++ b/aten/src/ATen/test/vmap_test.cpp
@@ -816,4 +816,38 @@ TEST(VmapTest, TestBatchedTensorTranspose) {
   }
 }
 
+// Basic test for BatchedTensor::permute
+TEST(VmapTest, TestBatchedTensorPermute) {
+  {
+    // Basic test
+    auto tensor = at::randn({2, 3, 5});
+    auto batched = makeBatched(tensor, {{/*lvl*/0, /*dim*/0}});
+
+    auto batched_out = batched.permute({1, 0});
+    const auto& out = maybeGetBatched(batched_out)->value();
+    ASSERT_EQ(out.data_ptr(), tensor.data_ptr());
+    ASSERT_TRUE(at::allclose(out, tensor.permute({0, 2, 1})));
+  }
+  {
+    // Test with multiple levels
+    auto tensor = at::randn({2, 3, 5, 7, 11});
+    auto batched = makeBatched(tensor, {{0, 0}, {1, 1}});
+
+    auto batched_out = batched.permute({2, 1, 0});
+    const auto& out = maybeGetBatched(batched_out)->value();
+    ASSERT_EQ(out.data_ptr(), tensor.data_ptr());
+    ASSERT_TRUE(at::allclose(out, tensor.permute({0, 1, 4, 3, 2})));
+  }
+  {
+    // Negative dims
+    auto tensor = at::randn({2, 3, 5, 7});
+    auto batched = makeBatched(tensor, {{/*lvl*/0, /*dim*/0}});
+
+    auto batched_out = batched.permute({-1, -2, -3});
+    const auto& out = maybeGetBatched(batched_out)->value();
+    ASSERT_EQ(out.data_ptr(), tensor.data_ptr());
+    ASSERT_TRUE(at::allclose(out, tensor.permute({0, -1, -2, -3})));
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40518 Disallow passing functions that don't return Tensors to vmap
* **#40517 Add batching rule for Tensor.permute**
* #40455 Add batching rule for unsqueeze, squeeze, and transpose

This is necessary for implementing the vmap frontend API's out_dims
functionality.

Test Plan:
- `./build/bin/vmap_test`. The vmap python API can't accept inputs that
aren't integers right now. There are workarounds around that (use a
lambda) but that doesn't look too nice. In the future we'll test all
batching rules in Python.

Differential Revision: [D22216168](https://our.internmc.facebook.com/intern/diff/D22216168)