### PR TITLE
Disallow passing functions that don't return Tensors to vmap

### DIFF
--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -63,6 +63,31 @@ class TestVmap(TestCase):
         self.assertEqual(outputs[0], x * x)
         self.assertEqual(outputs[1], x * x * x)
 
+    def test_multiple_outputs_error_cases(self):
+        # This is the same thing as
+        # def returns_tuple_of_tensors(x):
+        #     return x, x
+        def returns_tuple_of_tensors(x):
+            return (x, x)
+
+        def returns_list_of_two_tensors(x):
+            return [x, x]
+
+        def returns_list_of_one_tensor(x):
+            return [x]
+
+        x = torch.randn(3)
+
+        # should not throw
+        vmap(returns_tuple_of_tensors)(x)
+
+        # jax supports these, but we don't yet
+        msg = "must only return Tensors, got type <class 'list'>"
+        with self.assertRaisesRegex(ValueError, msg):
+            vmap(returns_list_of_two_tensors)(x)
+        with self.assertRaisesRegex(ValueError, msg):
+            vmap(returns_list_of_one_tensor)(x)
+
     def test_nested_with_same_map_dim(self):
         x = torch.randn(2, 3, 5)
         y = torch.randn(2, 3, 5)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40518 Disallow passing functions that don't return Tensors to vmap**
* #40517 Add batching rule for Tensor.permute
* #40455 Add batching rule for unsqueeze, squeeze, and transpose

I overlooked this in the initial vmap frontend api PR. Right now we
want to restrict vmap to taking in functions that only return Tensors.
A function that only return tensors can look like one of the following:
```
def fn1(x):
    ...
    return y

def fn2(x):
    ...
    return y, z
```
fn1 returns a Tensor, while fn2 returns a tuple of Tensors. So we add a
check that the output of the function passed to vmap returns either a
single tensor or a tuple of tensors.

NB: These checks allow passing a function that returns a tuple with a
single-element tensor from vmap. That seems OK to me.

Test Plan:
- `python test/test_vmap.py -v`

Differential Revision: [D22216166](https://our.internmc.facebook.com/intern/diff/D22216166)