### PR TITLE
[jit] Fix type annotations in select assignments

### DIFF
--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -1021,7 +1021,7 @@ class TestClassType(JitTestCase):
         @torch.jit.script
         def foo():
             y = CompetitiveLinkingTokenReplacementUtils()
-            new_dict : Dict[int, int] = {1:1, 2:2}
+            new_dict : Dict[int, int] = {1: 1, 2: 2}
             y.my_dict = new_dict
 
             new_list : List[Tuple[float, int, int]] = [(1.0, 1, 1)]

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -1007,3 +1007,23 @@ class TestClassType(JitTestCase):
                 return new_obj.a
 
         self.checkModule(ModuleWithMeta(5), ())
+
+    def test_type_annotation(self):
+        """
+        Test that annotating container attributes with types works correctly
+        """
+        @torch.jit.script
+        class CompetitiveLinkingTokenReplacementUtils:
+            def __init__(self):
+                self.my_list : List[Tuple[float, int, int]] = []
+                self.my_dict : Dict[int, int] = {}
+
+        @torch.jit.script
+        def foo():
+            y = CompetitiveLinkingTokenReplacementUtils()
+            new_dict : Dict[int, int] = {1:1, 2:2}
+            y.my_dict = new_dict
+
+            new_list : List[Tuple[float, int, int]] = [(1.0, 1, 1)]
+            y.my_list = new_list
+            return y

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2404,9 +2404,14 @@ struct to_ir {
     if (!stmt.rhs().present()) {
       throw ErrorReport(stmt.range()) << "Expected RHS for assignment";
     }
+
+    TypePtr type_hint = nullptr;
+    if (stmt.type().present()) {
+      type_hint = typeParser_.parseTypeFromExpr(stmt.type().get());
+    }
     const auto lhs = Select(stmt.lhs());
     auto lhsObject = emitSugaredExpr(lhs.value(), 1);
-    const auto rhsValue = emitSugaredExpr(stmt.rhs().get(), 1)
+    const auto rhsValue = emitSugaredExpr(stmt.rhs().get(), 1, type_hint)
                               ->asValue(stmt.rhs().range(), method);
     lhsObject->setAttr(stmt.range(), method, lhs.selector().name(), rhsValue);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40528 [jit] Fix type annotations in select assignments**

Previously, an assignment like `self.foo : List[int] = []` would ignore
the type hint.

Differential Revision: [D22222927](https://our.internmc.facebook.com/intern/diff/D22222927)