### PR TITLE
move __range_length and __derive_index to lite interpreter

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -308,6 +308,34 @@ RegisterOperators reg(
            return 0;
          },
          aliasAnalysisFromSchema()),
+      // only used internally in range() translation
+     Operator(
+         "aten::__range_length(int lo, int hi, int step) -> int",
+         [](Stack& stack) {
+           int64_t lo, hi, step;
+           pop(stack, lo, hi, step);
+           // error handling when step_val = 0 during runtime
+           if (step == 0) {
+             throw std::runtime_error("range() arg 3 must not be zero");
+           }
+           if (step > 0 && lo < hi)
+             push(stack, 1 + (hi - 1 - lo) / step);
+           else if (step < 0 && lo > hi)
+             push(stack, 1 + (lo - 1 - hi) / (0 - step));
+           else
+             push(stack, 0);
+           return 0;
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
+         "aten::__derive_index(int index, int start, int step) -> int",
+         [](Stack& stack) {
+           int64_t index, start, step;
+           pop(stack, index, start, step);
+           push(stack, start + index * step);
+           return 0;
+         },
+         aliasAnalysisFromSchema()),
      // these ops are generic over the list element type.
      // CREATING GENERIC_LIST_OPS
      Operator(

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -1003,34 +1003,6 @@ RegisterOperators reg2({
     // only used in loop unrolling, not exposed to end users
     DEFINE_INT_OP(aten::__round_to_zero_floordiv, a / b),
 
-    // only used internally in range() translation
-    Operator(
-        "aten::__range_length(int lo, int hi, int step) -> int",
-        [](Stack& stack) {
-          int64_t lo, hi, step;
-          pop(stack, lo, hi, step);
-          // error handling when step_val = 0 during runtime
-          if (step == 0) {
-            throw std::runtime_error("range() arg 3 must not be zero");
-          }
-          if (step > 0 && lo < hi)
-            push(stack, 1 + (hi - 1 - lo) / step);
-          else if (step < 0 && lo > hi)
-            push(stack, 1 + (lo - 1 - hi) / (0 - step));
-          else
-            push(stack, 0);
-          return 0;
-        },
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::__derive_index(int index, int start, int step) -> int",
-        [](Stack& stack) {
-          int64_t index, start, step;
-          pop(stack, index, start, step);
-          push(stack, start + index * step);
-          return 0;
-        },
-        aliasAnalysisFromSchema()),
     Operator(
         "aten::modf(float a) -> (float, float)",
         [](Stack& stack) {


### PR DESCRIPTION
Summary: These ops are required by the demucs denoiser model

Test Plan: build

Differential Revision: D22216217

