### PR TITLE
[PyTorch Error Logging][1/N] Adding Error Logging for Run_Method

### DIFF
--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/jit/mobile/interpreter.h>
 #include <torch/csrc/jit/mobile/observer.h>
 #include <torch/csrc/jit/runtime/jit_exception.h>
+#include <exception>
 
 #include <ATen/record_function.h>
 
@@ -34,7 +35,7 @@ Function* CompilationUnit::find_function(const c10::QualifiedName& qn) {
 c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   auto observer = torch::observerConfig().getModuleObserver();
   if (observer) {
-    observer->onEnter(name(), method_name);
+    observer->onEnterRunMethod(name(), method_name);
   }
 
   auto debug_info = std::make_shared<MobileDebugInfo>();
@@ -44,16 +45,32 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
 
   auto m = find_method(method_name);
   if (m == nullptr) {
+    if (observer) {
+      std::string cancellation_reason = "Method '" + method_name + "' is not defined";
+      observer->onCancelRunMethod(cancellation_reason);
+    }
     AT_ERROR("Method '", method_name, "' is not defined.");
   }
-  stack.insert(stack.begin(), object_);
-  m->run(stack);
-  c10::IValue result = stack.front();
-
-  if (observer) {
-    observer->onExit();
+  try {
+    stack.insert(stack.begin(), object_);
+    m->run(stack);
+    c10::IValue result = stack.front();
+    if (observer) {
+      observer->onExitRunMethod();
+    }
+    return result;
+  } catch (const std::exception &ex) {
+    if (observer) {
+      std::string failure_reason = "Error occured during model running entry point: " + (std::string) ex.what();
+      observer->onFailRunMethod(failure_reason);
+    }
+    TORCH_CHECK(false, ex.what());
+  } catch (...) {
+    if (observer) {
+      observer->onFailRunMethod("unknown exception");
+    }
+    TORCH_CHECK(false, "unknown exception");
   }
-  return result;
 }
 
 Function* Module::find_method(const std::string& basename) const {

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -61,7 +61,7 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
     return result;
   } catch (const std::exception &ex) {
     if (observer) {
-      observer->onFailRunMethod("Error occured during model running entry point: " + (std::string) ex.what(););
+      observer->onFailRunMethod("Error occured during model running entry point: " + (std::string) ex.what());
     }
     TORCH_CHECK(false, ex.what());
   } catch (...) {

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -61,8 +61,7 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
     return result;
   } catch (const std::exception &ex) {
     if (observer) {
-      std::string failure_reason = "Error occured during model running entry point: " + (std::string) ex.what();
-      observer->onFailRunMethod(failure_reason);
+      observer->onFailRunMethod("Error occured during model running entry point: " + (std::string) ex.what(););
     }
     TORCH_CHECK(false, ex.what());
   } catch (...) {

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -46,7 +46,8 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   auto m = find_method(method_name);
   if (m == nullptr) {
     if (observer) {
-      std::string cancellation_reason = "Method '" + method_name + "' is not defined";
+      std::string cancellation_reason =
+          "Method '" + method_name + "' is not defined";
       observer->onCancelRunMethod(cancellation_reason);
     }
     AT_ERROR("Method '", method_name, "' is not defined.");
@@ -59,9 +60,11 @@ c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
       observer->onExitRunMethod();
     }
     return result;
-  } catch (const std::exception &ex) {
+  } catch (const std::exception& ex) {
     if (observer) {
-      observer->onFailRunMethod("Error occured during model running entry point: " + (std::string) ex.what());
+      observer->onFailRunMethod(
+          "Error occured during model running entry point: " +
+          (std::string)ex.what());
     }
     TORCH_CHECK(false, ex.what());
   } catch (...) {

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -43,10 +43,12 @@ class MobileModuleObserver {
  public:
   virtual ~MobileModuleObserver() = default;
 
-  virtual void onEnter(
-      const std::string& model_name,
-      const std::string& method_name) {}
-  virtual void onExit() {}
+  virtual void onEnterRunMethod(
+      const std::string& ,
+      const std::string& ) {}
+  virtual void onExitRunMethod() {}
+  virtual void onCancelRunMethod(const std::string&) {}
+  virtual void onFailRunMethod(const std::string&) {}
 };
 
 class MobileObserverConfig {

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -43,9 +43,7 @@ class MobileModuleObserver {
  public:
   virtual ~MobileModuleObserver() = default;
 
-  virtual void onEnterRunMethod(
-      const std::string& ,
-      const std::string& ) {}
+  virtual void onEnterRunMethod(const std::string&, const std::string&) {}
   virtual void onExitRunMethod() {}
   virtual void onCancelRunMethod(const std::string&) {}
   virtual void onFailRunMethod(const std::string&) {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40537 [PyTorch Error Logging][2/N] Adding Error Logging for Loading Model
* **#40535 [PyTorch Error Logging][1/N] Adding Error Logging for Run_Method**

Adding error logging for run_method.
Adding CANCEL(the method cannot be found) and FAIL status(error occurred when running the method)

Differential Revision: [D22097857](https://our.internmc.facebook.com/intern/diff/D22097857/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22097857/)!