### PR TITLE
Add missing file to BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1264,6 +1264,7 @@ filegroup(
         "caffe2/quantization/server/fully_connected_dnnlowp_op.cc",
         "caffe2/quantization/server/fully_connected_fake_lowp_op.cc",
         "caffe2/quantization/server/group_norm_dnnlowp_op.cc",
+        "caffe2/quantization/server/int8_gen_quant_params.cc",
         "caffe2/quantization/server/kl_minimization.cc",
         "caffe2/quantization/server/lstm_unit_dnnlowp_op.cc",
         "caffe2/quantization/server/norm_minimization.cc",


### PR DESCRIPTION
Add `int8_gen_quant_params.cc` added by
https://github.com/pytorch/pytorch/pull/40494/ to bazel build rules

