### PR TITLE
(1.6) Update docs feature classifications

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -17,7 +17,7 @@ Functional higher level API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::
-    This API is experimental. Even though the function signatures are very unlikely to change, major
+    This API is in beta. Even though the function signatures are very unlikely to change, major
     improvements to performances are planned before we consider this stable.
 
 This section contains the higher level API for the autograd that builds on the basic API above

--- a/docs/source/named_tensor.rst
+++ b/docs/source/named_tensor.rst
@@ -316,4 +316,4 @@ operators, see :ref:`name_inference_reference-doc`.
           (('N', 'features'), torch.Size([32, 49152]))
 
       .. warning::
-          The named tensor API is experimental and subject to change.
+          The named tensor API is a prototype feature and subject to change.

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -3,6 +3,10 @@
 Quantization
 ============
 
+.. warning ::
+     Quantization is in beta and subject to change.
+
+
 Introduction to Quantization
 ----------------------------
 

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -97,7 +97,7 @@ applications can always explicitly move the input tensors to CPU on the caller
 and move it to the desired devices on the callee if necessary.
 
 .. warning::
-  TorchScript support in RPC is experimental and subject to change. Since
+  TorchScript support in RPC is a prototype feature and subject to change. Since
   v1.5.0, ``torch.distributed.rpc`` supports calling TorchScript functions as
   RPC target functions, and this will help improve parallelism on the callee
   side as executing TorchScript functions does not require GIL.
@@ -115,7 +115,7 @@ The RPC package also provides decorators which allow applications to specify
 how a given function should be treated on the callee side.
 
 .. warning::
-  The ``rpc.functions`` package is experimental and subject to change.
+  The ``rpc.functions`` package is a prototype feature and subject to change.
 
 .. autofunction:: torch.distributed.rpc.functions.async_execution
 

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -7,7 +7,7 @@ torch.sparse
 
 .. warning::
 
-    This API is currently experimental and may change in the near future.
+    This API is in beta and may change in the near future.
 
 Torch supports sparse tensors in COO(rdinate) format, which can
 efficiently store and process tensors for which the majority of elements

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -208,7 +208,7 @@ torch.layout
 
 A :class:`torch.layout` is an object that represents the memory layout of a
 :class:`torch.Tensor`. Currently, we support ``torch.strided`` (dense Tensors)
-and have experimental support for ``torch.sparse_coo`` (sparse COO Tensors).
+and have beta support for ``torch.sparse_coo`` (sparse COO Tensors).
 
 ``torch.strided`` represents dense Tensors and is the memory layout that
 is most commonly used. Each strided tensor has an associated


### PR DESCRIPTION
PR in master: https://github.com/pytorch/pytorch/pull/39966

------

Update the following feature classifications in docs to align with the changes:
1. [High Level Autograd APIs](https://pytorch.org/docs/stable/autograd.html#functional-higher-level-api): Beta (was experimental) 
2. [Eager Mode Quantization](https://pytorch.org/docs/stable/quantization.html): Beta (was experimental)
3. [Named Tensors](https://pytorch.org/docs/stable/named_tensor.html): Prototype (was experimental)
4. [TorchScript/RPC](https://pytorch.org/docs/stable/rpc.html#rpc): Prototype (was experimental)
5. [Channels Last Memory Layout](https://pytorch.org/docs/stable/tensor_attributes.html#torch-memory-format): Beta (was experimental)
6. [Custom C++ Classes](https://pytorch.org/docs/stable/cpp_index.html): Beta (was experimental)
7. [Torch.Sparse](https://pytorch.org/docs/stable/sparse.html): Beta (was experimental)