### PR TITLE
[JIT] Add property support to TorchScript classes

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1866,6 +1866,14 @@ using ::torch::jit::CompilationUnit;
 
 // This represents a class in TorchScript.
 struct CAFFE2_API ClassType : public NamedType {
+  // This represents an attribute of a class; a name associated with an attribute, and a
+  // getter and (optional) setter for that attribute.
+  struct Property {
+    std::string name;
+    const torch::jit::Function* getter;
+    const torch::jit::Function* setter;
+  };
+
   // Create a class type with name `name` and its methods stored in `cu`.
   static ClassTypePtr create(
       c10::optional<QualifiedName> qualifiedName,
@@ -2010,6 +2018,11 @@ struct CAFFE2_API ClassType : public NamedType {
       "'");
     return *slot_idx;
   }
+
+  // Get the property with the given \p name, if it exists on the class.
+  c10::optional<ClassType::Property> getProperty(const std::string& name);
+  // Add a property named \p name with \p getter and \p setter as its getter and setter.
+  void addProperty(const std::string& name, torch::jit::Function* getter, torch::jit::Function* setter);
 
   bool hasConstant(const std::string& name) const {
     return std::find_if(
@@ -2177,6 +2190,9 @@ struct CAFFE2_API ClassType : public NamedType {
 
   // List of methods associated with this class.
   std::vector<torch::jit::Function*> methods_;
+
+  // List of properties exposed by this class.
+  std::vector<Property> properties_;
 
   bool isModule_ = false;
 };

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -1341,6 +1341,21 @@ std::shared_ptr<const CompilationUnit> ClassType::compilation_unit() const {
   return cu;
 }
 
+c10::optional<ClassType::Property> ClassType::getProperty(const std::string& name) {
+  for (auto& prop : properties_) {
+    if (name == prop.name) {
+      return prop;
+    }
+  }
+
+  return c10::nullopt;
+}
+
+void ClassType::addProperty(const std::string& name, torch::jit::Function* getter, torch::jit::Function* setter) {
+  properties_.push_back({name, getter, setter});
+}
+
+
 static bool containsAny(const TypePtr& type) {
   std::vector<TypePtr> to_scan = { type };
   while (!to_scan.empty()) {

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -1027,3 +1027,63 @@ class TestClassType(JitTestCase):
             new_list : List[Tuple[float, int, int]] = [(1.0, 1, 1)]
             y.my_list = new_list
             return y
+
+    def test_properties(self):
+        """
+        Test that a scripted class can make use of the @property decorator.
+        """
+        @torch.jit.script
+        class Properties(object):
+            def __init__(self, a: int):
+                self.a = a
+
+            @property
+            def attr(self) -> int:
+                return self.a
+
+            @attr.setter
+            def attr(self, value: int):
+                self.a = value
+
+        @torch.jit.script
+        class NoSetter(object):
+            def __init__(self, a: int):
+                self.a = a
+
+            @property
+            def attr(self) -> int:
+                return self.a
+
+        @torch.jit.script
+        class MethodThatUsesProperty(object):
+            def __init__(self, a: int):
+                self.a = a
+
+            @property
+            def attr(self) -> int:
+                return self.a
+
+            @attr.setter
+            def attr(self, value: int):
+                self.a = value
+
+            def forward(self):
+                return self.attr
+
+        class ModuleWithProperties(torch.nn.Module):
+            def __init__(self, a: int):
+                super().__init__()
+                self.props = Properties(a)
+
+            def forward(self, a: int, b: int, c: int, d: int):
+                self.props.attr = a
+                props = Properties(b)
+                no_setter = NoSetter(c)
+                method_uses_property = MethodThatUsesProperty(a + b)
+
+                props.attr = c
+                method_uses_property.attr = d
+
+                return self.props.attr + no_setter.attr + method_uses_property.forward()
+
+        self.checkModule(ModuleWithProperties(5), (5, 6, 7, 8,))

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -607,24 +607,6 @@ class TestRecursiveScript(JitTestCase):
         m = M()
         self.checkModule(m, (torch.randn(5, 5), ))
 
-    def test_property(self):
-        class M(nn.Module):
-            def __init__(self):
-                super(M, self).__init__()
-                self.x = 0
-
-            @property
-            def x_and_1(self):
-                return self.x + 1
-
-            def forward(self, new_x):
-                # type: (int) -> int
-                self.x = new_x
-                return self.x_and_1
-
-        with self.assertRaisesRegex(RuntimeError, "property"):
-            torch.jit.script(M())
-
     def test_inner_traced_module(self):
         class Dummy(nn.Module):
             def forward(self, x):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -533,6 +533,30 @@ class TestScriptPy3(JitTestCase):
         # Check that ignored method is still intact.
         self.assertEqual(inp, n.ignored_method(inp))
 
+    def test_module_properties(self):
+        class ModuleWithProperties(torch.nn.Module):
+            def __init__(self, a: int):
+                super().__init__()
+                self.a = a
+
+            def forward(self, a: int, b: int):
+                self.attr = a + b
+                return self.attr
+
+            @property
+            def attr(self):
+                return self.a
+
+            @attr.setter
+            def attr(self, a: int):
+                if a > 0:
+                    self.a = a
+                else:
+                    self.a = 0
+
+        self.checkModule(ModuleWithProperties(5), (5, 6,))
+        self.checkModule(ModuleWithProperties(5), (-5, -6,))
+
     def test_export_opnames_interface(self):
         global OneTwoModule
 

--- a/torch/csrc/jit/api/compilation_unit.h
+++ b/torch/csrc/jit/api/compilation_unit.h
@@ -27,6 +27,7 @@ namespace torch {
 namespace jit {
 
 struct Def;
+struct Property;
 struct ClassDef;
 struct SugaredValue;
 struct Resolver;
@@ -82,6 +83,16 @@ struct TORCH_API CompilationUnit {
         "Please use getGraphExecutorOptimize()");
     return true;
   }
+
+  // Version of define but with support for properties.
+  std::vector<Function*> define(
+      const c10::optional<c10::QualifiedName>& prefix,
+      const std::vector<Property>& properties,
+      const std::vector<ResolverPtr>& propResolvers,
+      const std::vector<Def>& definitions,
+      const std::vector<ResolverPtr>& defResolvers,
+      const Self* self,
+      bool shouldMangle = false);
 
   // for historic reasons, these are defined in ir_emitter.cpp
   // Returns the list of Function's just defined.
@@ -257,6 +268,14 @@ struct TORCH_API CompilationUnit {
   std::unique_ptr<Function> define(
       const c10::optional<c10::QualifiedName>& prefix,
       const Def& def,
+      const ResolverPtr& resolver,
+      const Self* self,
+      const std::unordered_map<std::string, Function*>& function_table,
+      bool shouldMangle = false) const;
+
+  std::pair<std::unique_ptr<Function>, std::unique_ptr<Function>> define(
+      const c10::optional<c10::QualifiedName>& prefix,
+      const Property& prop,
       const ResolverPtr& resolver,
       const Self* self,
       const std::unordered_map<std::string, Function*>& function_table,

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -110,7 +110,8 @@ namespace jit {
   _(TK_IMPORT, "import", "import")               \
   _(TK_WITH, "with", "with")                     \
   _(TK_WITH_ITEM, "withitem", "")                \
-  _(TK_AS, "as", "as")
+  _(TK_AS, "as", "as")                           \
+  _(TK_PROP, "property", "")
 
 enum TokenKind {
   // we use characters to represent themselves so skip all valid characters

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -424,6 +424,30 @@ struct Def : public TreeView {
   }
 };
 
+// Property represents a named attribute combined with a getter and setter
+// method to access and mutate that attribute.
+struct Property : public TreeView {
+  explicit Property(const TreeRef& tree) : TreeView(tree) {
+    tree->match(TK_PROP);
+  }
+  Ident name() const {
+    return Ident(subtree(0));
+  }
+  Def getter() const {
+    return Def(subtree(1));
+  }
+  Maybe<Def> setter() const {
+    return Maybe<Def>(subtree(2));
+  }
+  static Property create(
+      const SourceRange& range,
+      const Ident& name,
+      const Def& getter,
+      const Maybe<Def>& setter) {
+    return Property(Compound::create(TK_PROP, range, {name, getter, setter}));
+  }
+};
+
 struct ClassDef : public TreeView {
   explicit ClassDef(const TreeRef& tree) : TreeView(tree) {
     tree->match(TK_CLASS_DEF);
@@ -441,13 +465,20 @@ struct ClassDef : public TreeView {
   List<Stmt> body() const {
     return List<Stmt>(subtree(2));
   }
+  Maybe<List<Property>> properties() const {
+    return Maybe<List<Property>>(subtree(3));
+  }
   static ClassDef create(
       const SourceRange& range,
       const Ident& name,
       const Maybe<Expr>& superclass,
-      const List<Stmt>& body) {
+      const List<Stmt>& body,
+      c10::optional<const List<Property>> properties = {}) {
+    auto props = properties.has_value()
+        ? Maybe<List<Property>>::create(range, properties.value())
+        : Maybe<List<Property>>::create(range);
     return ClassDef(
-        Compound::create(TK_CLASS_DEF, range, {name, superclass, body}));
+        Compound::create(TK_CLASS_DEF, range, {name, superclass, body, props}));
   }
 };
 

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -550,6 +550,14 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
     return attr;
   }
 
+  // Check if it's a property.
+  auto prop =
+      concreteType_->getJitType()->expect<ClassType>()->getProperty(field);
+  if (prop) {
+    return MethodValue(self_, prop->getter->name())
+        .call(loc, m, {}, {}, /*n_binders=*/1);
+  }
+
   // We don't define this attr. Bailout with a hint to the user.
   std::string hint;
   if (auto failureReason = concreteType_->findFailedAttribute(field)) {

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -156,11 +156,36 @@ void initTreeViewBindings(PyObject* module) {
           }))
       .def("decl", [](const Def& def) { return def.decl(); })
       .def("name", [](const Def& def) { return def.name(); });
+  py::class_<Property, TreeView>(m, "Property")
+      .def(py::init([](const SourceRange& r,
+                       const Ident& name,
+                       const Def& getter,
+                       Def* setter) {
+        return Property::create(r, name, getter, wrap_maybe(r, setter));
+      }))
+      .def("name", [](const Property& property) { return property.name(); })
+      .def(
+          "getter_name",
+          [](const Property& property) { return property.getter().name(); })
+      .def("setter_name", [](const Property& property) {
+        if (property.setter().present()) {
+          return property.setter().get().name();
+        }
+
+        return Ident::create(property.range(), "");
+      });
+
   py::class_<ClassDef, TreeView>(m, "ClassDef")
-      .def(py::init([](const Ident& name, std::vector<Stmt> body) {
+      .def(py::init([](const Ident& name,
+                       std::vector<Stmt> body,
+                       std::vector<Property> props) {
         const auto& r = name.range();
         return ClassDef::create(
-            r, name, Maybe<Expr>::create(r), wrap_list(r, std::move(body)));
+            r,
+            name,
+            Maybe<Expr>::create(r),
+            wrap_list(r, std::move(body)),
+            wrap_list(r, std::move(props)));
       }));
   py::class_<Decl, TreeView>(m, "Decl").def(py::init(
       [](const SourceRange& r, std::vector<Param> params, Expr* return_type) {

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1293,8 +1293,10 @@ void initJitScriptBindings(PyObject* module) {
         const auto classname = c10::QualifiedName(qualifiedName);
         auto classType = ClassType::create(classname, cu);
         cu->register_type(classType);
-        std::vector<ResolverPtr> rcbs;
+        std::vector<ResolverPtr> methodRcbs, propRcbs;
         std::vector<Def> methodDefs;
+        std::vector<Property> props;
+
         for (const auto& def : classDef.body()) {
           if (def.kind() != TK_DEF) {
             throw ErrorReport(def.range())
@@ -1303,11 +1305,21 @@ void initJitScriptBindings(PyObject* module) {
                    "something else!";
           }
           methodDefs.emplace_back(Def(def));
-          rcbs.push_back(
+          methodRcbs.push_back(
               pythonResolver(rcb, classDef.name().name(), classType));
         }
+
+        // Compile getters and setters for properties as regular methods.
+        if (classDef.properties().present()) {
+          for (const auto& prop : classDef.properties().get()) {
+            props.emplace_back(prop);
+            propRcbs.push_back(
+                pythonResolver(rcb, classDef.name().name(), classType));
+          }
+        }
+
         const auto self = SimpleSelf(classType);
-        cu->define(classname, methodDefs, rcbs, &self);
+        cu->define(classname, props, propRcbs, methodDefs, methodRcbs, &self);
       });
   m.def(
       "_jit_script_interface_compile",
@@ -1547,27 +1559,43 @@ void initJitScriptBindings(PyObject* module) {
             return self.equals(other);
           })
       .def(
-          "_create_methods",
+          "_create_methods_and_properties",
           [](std::shared_ptr<ConcreteModuleType> concreteType,
-             const std::vector<Def>& defs,
-             const std::vector<ResolutionCallback>& rcbs,
+             const std::vector<Property>& properties,
+             const std::vector<ResolutionCallback>& propertyRcbs,
+             const std::vector<Def>& methodDefs,
+             const std::vector<ResolutionCallback>& methodRcbs,
              const std::vector<FunctionDefaults>& defaults) {
-            TORCH_INTERNAL_ASSERT(defs.size() == rcbs.size());
-            std::vector<ResolverPtr> resolvers;
-            resolvers.reserve(rcbs.size());
-            for (auto& callback : rcbs) {
-              resolvers.push_back(pythonResolver(callback));
+            TORCH_INTERNAL_ASSERT(methodDefs.size() == methodRcbs.size());
+            TORCH_INTERNAL_ASSERT(properties.size() == propertyRcbs.size());
+
+            std::vector<ResolverPtr> methodResolvers, propertyResolvers;
+            methodResolvers.reserve(methodRcbs.size());
+            for (auto& callback : methodRcbs) {
+              methodResolvers.push_back(pythonResolver(callback));
             }
+
+            propertyResolvers.reserve(propertyRcbs.size());
+            for (auto& callback : propertyRcbs) {
+              propertyResolvers.push_back(pythonResolver(callback));
+            }
+
             const auto& selfType =
                 concreteType->getJitType()->expect<ClassType>();
             const auto& prefix = selfType->name().value();
             const auto self = ModuleSelf(std::move(concreteType));
             auto cu = selfType->compilation_unit();
-            cu->define(prefix, defs, resolvers, &self);
+            cu->define(
+                prefix,
+                properties,
+                propertyResolvers,
+                methodDefs,
+                methodResolvers,
+                &self);
             // Stitch in default arguments for each Def if provided
             auto defaults_it = defaults.begin();
-            auto defs_it = defs.begin();
-            while (defs_it != defs.end()) {
+            auto defs_it = methodDefs.begin();
+            while (defs_it != methodDefs.end()) {
               const auto method_name =
                   QualifiedName(prefix, (*defs_it).name().name());
               auto& method = cu->get_function(method_name);


### PR DESCRIPTION
**Summary**
This commit adds support for properties to TorchScript classes,
specifically for getters and setters. They are implemented essentially
as pointers to the methods that the corresponding decorators decorate,
which are treated like regular class methods. Deleters for properties
are considered to be out of scope (and probably useless for TorchScript
anyway).

**Test Plan**
This commit adds a unit test for getter and setter properties.

