### PR TITLE
Unify libtorch_python_cuda_core_sources filelists between CMakeList, fbcode and bazel

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -398,19 +398,22 @@ torch_cpp_srcs = [
     "torch/csrc/api/src/serialize/output-archive.cpp",
 ]
 
-libtorch_python_cuda_sources = [
+libtorch_python_cuda_core_sources = [
     "torch/csrc/cuda/Event.cpp",
     "torch/csrc/cuda/Module.cpp",
+    "torch/csrc/cuda/python_comm.cpp",
     "torch/csrc/cuda/Storage.cpp",
     "torch/csrc/cuda/Stream.cpp",
-    "torch/csrc/cuda/Tensor.cpp",
-    "torch/csrc/cuda/python_comm.cpp",
-    "torch/csrc/cuda/python_nccl.cpp",
     "torch/csrc/cuda/serialization.cpp",
-    "torch/csrc/cuda/utils.cpp",
     "torch/csrc/cuda/shared/cudart.cpp",
-    "torch/csrc/cuda/shared/cudnn.cpp",
     "torch/csrc/cuda/shared/nvtx.cpp",
+    "torch/csrc/cuda/utils.cpp",
+]
+
+libtorch_python_cuda_sources = libtorch_python_cuda_core_sources + [
+    "torch/csrc/cuda/python_nccl.cpp",
+    "torch/csrc/cuda/shared/cudnn.cpp",
+    "torch/csrc/cuda/Tensor.cpp",
 ]
 
 libtorch_python_core_sources = [

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -111,18 +111,9 @@ else()
 endif()
 
 if(USE_CUDA)
-    list(APPEND TORCH_PYTHON_SRCS
-      ${TORCH_SRC_DIR}/csrc/cuda/Module.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/Storage.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/Stream.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/Event.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/utils.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/python_comm.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/serialization.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/shared/cudart.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/shared/nvtx.cpp
-      ${GENERATED_THNN_CXX_CUDA}
-      )
+    append_filelist("libtorch_python_cuda_core_sources" TORCH_PYTHON_SRCS)
+    list(APPEND TORCH_PYTHON_SRCS ${GENERATED_THNN_CXX_CUDA})
+
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_CUDA)
     if(USE_CUDNN)
         list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_CUDNN)
@@ -141,18 +132,8 @@ if(USE_CUDA)
 endif()
 
 if(USE_ROCM)
-    list(APPEND TORCH_PYTHON_SRCS
-      ${TORCH_SRC_DIR}/csrc/cuda/Module.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/Storage.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/Stream.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/Event.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/utils.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/python_comm.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/serialization.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/shared/cudart.cpp
-      ${TORCH_SRC_DIR}/csrc/cuda/shared/nvtx.cpp
-      ${GENERATED_THNN_CXX_CUDA}
-      )
+    append_filelist("libtorch_python_cuda_core_sources" TORCH_PYTHON_SRCS)
+    list(APPEND TORCH_PYTHON_SRCS ${GENERATED_THNN_CXX_CUDA})
 
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS
       USE_ROCM


### PR DESCRIPTION
Summary:
Get a sublist of `libtorch_python_cuda_sources` named `libtorch_python_cuda_core_sources`. Use it to replace the list which has the same content in `CMakeList.txt`.
This is a change to make consistency between CMakeList and bazel.

Test Plan: CI

Differential Revision: D22223207

