### PR TITLE
Fix several quantization documentation typos

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -397,7 +397,7 @@ quantization output parameters)
 * :func:`~torch.nn.quantized.functional.hardtanh` — Hardtanh
 * :func:`~torch.nn.quantized.functional.upsample` — Upsampler. Will be
   deprecated in favor of :func:`~torch.nn.quantized.functional.interpolate`
-* :func:`~torch.nn.quantized.functional.upsample_bilinear` — Bilenear
+* :func:`~torch.nn.quantized.functional.upsample_bilinear` — Bilinear
   upsampler. Will be deprecated in favor of
 * :func:`~torch.nn.quantized.functional.interpolate`
 * :func:`~torch.nn.quantized.functional.upsample_nearest` — Nearest neighbor
@@ -648,7 +648,7 @@ LinearReLU
 .. autoclass:: LinearReLU
     :members:
 
-torch.nn.instrinsic.qat
+torch.nn.intrinsic.qat
 --------------------------------
 
 This module implements the versions of those fused operations needed for

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -82,7 +82,7 @@ def adaptive_avg_pool2d(input, output_size):
     Applies a 2D adaptive average pooling over a quantized input signal composed
     of several quantized input planes.
 
-    .. note:: The input quantization paramteres propagate to the output.
+    .. note:: The input quantization parameters propagate to the output.
 
     See :class:`~torch.nn.quantized.AdaptiveAvgPool2d` for details and output shape.
 

--- a/torch/nn/quantized/modules/functional_modules.py
+++ b/torch/nn/quantized/modules/functional_modules.py
@@ -6,7 +6,7 @@ from torch._ops import ops
 
 
 class FloatFunctional(torch.nn.Module):
-    r"""State collector class for float operatitons.
+    r"""State collector class for float operations.
 
     The instance of this class can be used instead of the ``torch.`` prefix for
     some operations. See example usage below.
@@ -84,7 +84,7 @@ class FloatFunctional(torch.nn.Module):
 
 
 class QFunctional(torch.nn.Module):
-    r"""Wrapper class for quantized operatitons.
+    r"""Wrapper class for quantized operations.
 
     The instance of this class can be used instead of the
     ``torch.ops.quantized`` prefix. See example usage below.

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -354,7 +354,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
     The scale and zero point are then computed as in
     :class:`~torch.quantization.observer.MinMaxObserver`.
 
-    .. note:: Only works with ``torch.per_tensor_affine`` quantization shceme.
+    .. note:: Only works with ``torch.per_tensor_affine`` quantization scheme.
 
     .. note:: If the running minimum equals to the running maximum, the scale
               and zero_point are set to 1.0 and 0.

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -41,7 +41,7 @@ default_per_channel_qconfig = QConfig(activation=default_observer,
 class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight'])):
     """
     Describes how to dynamically quantize a layer or a part of the network by providing
-    settings (observer classe) for weights.
+    settings (observer classes) for weights.
 
     It's like QConfig, but for dynamic quantization.
 

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -237,7 +237,7 @@ def quantize_dynamic(model, qconfig_spec=None, dtype=torch.qint8,
               need to be QConfigDynamic instances.
 
             - A set of types and/or submodule names to apply dynamic quantization to,
-              in which case the `dtype` argument is used to specifiy the bit-width
+              in which case the `dtype` argument is used to specify the bit-width
 
         inplace: carry out model transformations in-place, the original module is mutated
         mapping: maps type of a submodule to a type of corresponding dynamically quantized version
@@ -289,7 +289,7 @@ def quantize_dynamic(model, qconfig_spec=None, dtype=torch.qint8,
 def prepare_qat(model, mapping=None, inplace=False):
     r"""
     Prepares a copy of the model for quantization calibration or
-    quantization-aware training and convers it to quantized version.
+    quantization-aware training and converts it to quantized version.
 
     Quantization configuration should be assigned preemptively
     to individual submodules in `.qconfig` attribute.
@@ -335,7 +335,7 @@ def convert(module, mapping=None, inplace=False):
     Args:
         module: calibrated module with observers
         mapping: a dictionary that maps from float module type to quantized
-                 module type, can be overwrritten to allow swapping user defined
+                 module type, can be overwritten to allow swapping user defined
                  Modules
         inplace: carry out model transformations in-place, the original module
                  is mutated


### PR DESCRIPTION
This PR fixes several typos I noticed in the docs here: https://pytorch.org/docs/master/quantization.html. In one case there was a misspelled module [torch.nn.instrinsic.qat](https://pytorch.org/docs/master/quantization.html#torch-nn-instrinsic-qat) which I corrected and am including screenshots of below just in case. 

<img width="1094" alt="before" src="https://user-images.githubusercontent.com/54918401/85766765-5cdd6280-b6e5-11ea-93e6-4944cf820b71.png">

<img width="1093" alt="after" src="https://user-images.githubusercontent.com/54918401/85766769-5d75f900-b6e5-11ea-8850-0d1f5ed67b16.png">
