### PR TITLE
Fix Tensorboard `add_hparams` method

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -301,11 +301,7 @@ class SummaryWriter(object):
             raise TypeError('hparam_dict and metric_dict should be dictionary.')
         exp, ssi, sei = hparams(hparam_dict, metric_dict)
 
-        logdir = os.path.join(
-            self._get_file_writer().get_logdir(),
-            str(time.time())
-        )
-        with SummaryWriter(log_dir=logdir) as w_hp:
+        with SummaryWriter(log_dir=self._get_file_writer().get_logdir()) as w_hp:
             w_hp.file_writer.add_summary(exp)
             w_hp.file_writer.add_summary(ssi)
             w_hp.file_writer.add_summary(sei)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/32651

Initial `add_hparams` commit (https://github.com/pytorch/pytorch/pull/23134) added creation of additional subfolder for hyperparameters. 

As a result, Tensorboard loads them as separate runs which very quickly leads to chaos when trying to distinguish different training sessions

![image](https://user-images.githubusercontent.com/14337581/85771915-098b0480-b725-11ea-86a5-5604db4a1ace.png)

This PR removes such undesired behavior.  
