### PR TITLE
Fix and reenable threaded QNNPACK linear

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -343,7 +343,7 @@ at::Tensor PackedLinearWeightsQnnp::apply_impl(
       rows_w /* output_stride */,
       // TODO (Ashkan): Disabling temporarily.
       // Throws a floating point exception with OSS pthreadpool.
-      nullptr);
+      caffe2::pthreadpool_() /* threadpool */);
 
   TORCH_INTERNAL_ASSERT(
       runStatus == pytorch_qnnp_status_success,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/fc-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/fc-run.cc
@@ -98,6 +98,12 @@ enum pytorch_qnnp_status qnnpackLinear(
       .ukernel = pytorch_qnnp_params.q8conv.gemm,
   };
 
+  if (output_size == 0) {
+      // pthreadpool can tolerate a range of 0, but not a tile of 0.
+      // We use output_size as a tile size, so bail here if it's 0.
+      return pytorch_qnnp_status_success;
+  }
+
   pthreadpool_compute_4d_tiled(
       threadpool,
       (pthreadpool_function_4d_tiled_t) compute_q8gemm,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40588 Fix batch size zero for QNNPACK linear_dynamic
* **#40587 Fix and reenable threaded QNNPACK linear**

Summary:
Previously, this was causing divide-by-zero only in the multithreaded
empty-batch case, while calculating tiling parameters for the threads.
In my opinion, the bug here is using a value that is allowed to be zero
(batch size) for an argument that should not be zero (tile size), so I
fixed the bug by bailing out right before the call to
pthreadpool_compute_4d_tiled.

Test Plan:
TestQuantizedOps.test_empty_batch

Differential Revision: [D22264414](https://our.internmc.facebook.com/intern/diff/D22264414)