### PR TITLE
Add Mish to Caffee2 and Dper3

### DIFF
--- a/caffe2/operators/mish_op.cc
+++ b/caffe2/operators/mish_op.cc
@@ -1,0 +1,100 @@
+#include "caffe2/operators/mish_op.h"
+
+#include <math.h>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "caffe2/core/types.h"
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <>
+template <typename T>
+bool MishFunctor<CPUContext>::
+operator()(const int N, const T* X, T* Y, CPUContext* /* context */) const {
+  ConstEigenVectorArrayMap<T> X_arr(X, N);
+  EigenVectorArrayMap<T>(Y, N) = X_arr * ((T(1) + (X_arr).exp()).log()).tanh();
+  return true;
+}
+
+template <>
+template <typename T>
+bool MishGradientOp<CPUContext>::DoRunWithType() {
+  auto& Xin = Input(X);
+  auto& Yin = Input(Y);
+  auto& DYin = Input(DY);
+
+  CAFFE_ENFORCE_EQ(Xin.numel(), Yin.numel());
+  CAFFE_ENFORCE_EQ(DYin.numel(), Yin.numel());
+  auto* DXout = Output(DX, Yin.sizes(), at::dtype<float>());
+
+  const float* Xdata = Xin.template data<float>();
+  const float* Ydata = Yin.template data<float>();
+  const float* dYdata = DYin.template data<float>();
+  float* dXdata = DXout->template mutable_data<float>();
+
+  EigenVectorArrayMap<float> dXvec(dXdata, DXout->numel());
+  ConstEigenVectorArrayMap<float> Xvec(Xdata, Xin.numel());
+  ConstEigenVectorArrayMap<float> Yvec(Ydata, Yin.numel());
+  ConstEigenVectorArrayMap<float> dYvec(dYdata, DYin.numel());
+
+  // dx = dy * exp(x) * (exp(3*x) + 4*exp(2*x) + exp(x)*(6+4x) + 4*(1+x)) /
+  // ((exp(x) + 1)^2 + 1)^2
+  dXvec = dYvec * Xvec.exp() *
+      ((T(3) * Xvec).exp() + T(4) * ((T(2) * Xvec).exp()) +
+       (T(6) + T(4) * Xvec) * Xvec.exp() + T(4) * (T(1) + Xvec)) /
+      ((Xvec.exp() + T(1)).square() + T(1)).square();
+  return true;
+}
+
+REGISTER_CPU_OPERATOR(
+    Mish,
+    UnaryElementwiseOp<
+        TensorTypes<float>,
+        CPUContext,
+        MishFunctor<CPUContext>>);
+REGISTER_CPU_OPERATOR(MishGradient, MishGradientOp<CPUContext>);
+
+// Input: X, output: Y
+OPERATOR_SCHEMA(Mish)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .IdenticalTypeAndShape()
+    .SetDoc(R"DOC(
+Mish takes one input data (Tensor) and produces one output data
+(Tensor) where the mish function, y = x * tanh(ln(1 + exp(x))), is applied to the
+tensor elementwise.
+)DOC")
+    .Input(0, "X", "1D input tensor")
+    .Output(0, "Y", "1D output tensor");
+// Input: X, Y, dY, output: dX
+OPERATOR_SCHEMA(MishGradient)
+    .NumInputs(3)
+    .NumOutputs(1)
+    .AllowInplace({{2, 0}})
+    .SetDoc(R"DOC(
+MishGradient takes X, Y and dY and uses this to update dX according to the
+chain rule and derivatives of the mish function.
+)DOC");
+
+namespace {
+
+class GetMishGradient : public GradientMakerBase {
+  using GradientMakerBase::GradientMakerBase;
+  std::vector<OperatorDef> GetGradientDefs() override {
+    return SingleGradientDef(
+        "MishGradient",
+        "",
+        std::vector<std::string>{I(0), O(0), GO(0)},
+        std::vector<std::string>{GI(0)});
+  }
+};
+
+} // namespace
+
+REGISTER_GRADIENT(Mish, GetMishGradient);
+
+} // namespace caffe2

--- a/caffe2/operators/mish_op.cu
+++ b/caffe2/operators/mish_op.cu
@@ -1,0 +1,96 @@
+#include "caffe2/operators/mish_op.h"
+
+#include "caffe2/core/context_gpu.h"
+
+namespace caffe2 {
+
+namespace {
+
+template <typename T>
+__global__ void MishCUDAKernel(const int N, const T* X, T* Y) {
+  CUDA_1D_KERNEL_LOOP(i, N) {
+#if __CUDA_ARCH__ >= 350
+    Y[i] = __ldg(X + i) * tanh(log(T(1) + exp(__ldg(X + i))));
+#else
+    Y[i] = X[i] * tanh(log(T(1) + exp(X[i])));
+#endif
+  }
+}
+
+template <typename T>
+__global__ void MishGradientCUDAKernel(
+    const int N,
+    const T* X,
+    const T* Y,
+    const T* dY,
+    T* dX) {
+  CUDA_1D_KERNEL_LOOP(i, N) {
+#if __CUDA_ARCH__ >= 350
+    dX[i] = __ldg(dY + i) * exp(__ldg(X + i)) *
+        (exp(T(3) * __ldg(X + i)) + T(4) * exp(T(2) * __ldg(X + i)) +
+         (T(6) + T(4) * __ldg(X + i)) * exp(__ldg(X + i)) +
+         T(4) * (T(1) + __ldg(X + i))) /
+        (((exp(__ldg(X + i)) + T(1)) * (exp(__ldg(X + i)) + T(1)) + T(1)) *
+         ((exp(__ldg(X + i)) + T(1)) * (exp(__ldg(X + i)) + T(1)) + T(1)));
+#else
+    dX[i] = dY[i] * exp(X[i]) *
+        (exp(T(3) * X[i]) + T(4) * exp(T(2) * X[i]) +
+         (T(6) + T(4) * X[i]) * exp(X[i]) + T(4) * (T(1) + X[i])) /
+        (((exp(X[i]) + T(1)) * (exp(X[i]) + T(1)) + T(1)) *
+         ((exp(X[i]) + T(1)) * (exp(X[i]) + T(1)) + T(1)));
+#endif
+  }
+}
+
+} // namespace
+
+template <>
+template <typename T>
+bool MishFunctor<CUDAContext>::
+operator()(const int N, const T* X, T* Y, CUDAContext* context) const {
+  MishCUDAKernel<T>
+      <<<CAFFE_GET_BLOCKS(N),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context->cuda_stream()>>>(N, X, Y);
+  return true;
+}
+
+template <>
+template <typename T>
+bool MishGradientOp<CUDAContext>::DoRunWithType() {
+  auto& Xin = Input(X);
+  auto& Yin = Input(Y);
+  auto& DYin = Input(DY);
+  auto* DXout = Output(DX);
+  CAFFE_ENFORCE_EQ(Xin.size(), Yin.size());
+  CAFFE_ENFORCE_EQ(DYin.size(), Yin.size());
+  DXout->ResizeLike(Yin);
+
+  const int n = Xin.size();
+  const T* x = Xin.template data<T>();
+  const T* y = Yin.template data<T>();
+  const T* dy = DYin.template data<T>();
+  T* dx = DXout->template mutable_data<T>();
+  MishGradientCUDAKernel<T>
+      <<<CAFFE_GET_BLOCKS(n),
+         CAFFE_CUDA_NUM_THREADS,
+         0,
+         context_.cuda_stream()>>>(n, x, y, dy, dx);
+  return true;
+}
+
+template <>
+bool MishGradientOp<CUDAContext>::RunOnDevice() {
+  return DispatchHelper<TensorTypes<float, double>>::call(this, Input(X));
+}
+
+REGISTER_CUDA_OPERATOR(
+    Mish,
+    UnaryElementwiseOp<
+        TensorTypes<float, double>,
+        CUDAContext,
+        MishFunctor<CUDAContext>>);
+REGISTER_CUDA_OPERATOR(MishGradient, MishGradientOp<CUDAContext>);
+
+} // namespace caffe2

--- a/caffe2/operators/mish_op.h
+++ b/caffe2/operators/mish_op.h
@@ -1,0 +1,35 @@
+#ifndef CAFFE2_OPERATORS_MISH_OP_H_
+#define CAFFE2_OPERATORS_MISH_OP_H_
+
+#include "caffe2/operators/elementwise_ops.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Context>
+struct MishFunctor {
+  template <typename T>
+  bool operator()(const int N, const T* X, T* Y, Context* context) const;
+};
+
+template <class Context>
+class MishGradientOp final : public Operator<Context> {
+ public:
+  USE_SIMPLE_CTOR_DTOR(MishGradientOp)
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  template <typename T>
+  bool DoRunWithType();
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<float, double>>::call(this, Input(X));
+  }
+
+ protected:
+  INPUT_TAGS(X, Y, DY);
+  OUTPUT_TAGS(DX);
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_MISH_OP_H_


### PR DESCRIPTION
Summary: Add a new activation function - Mish: A Self Regularized Non-Monotonic Neural Activation Function https://arxiv.org/abs/1908.08681

Test Plan:
## unit test caffe2
buck test //caffe2/caffe2/python/operator_test:elementwise_ops_test -- 'test_mish'
{F240972678}

## Unit test for activation.py, advanced_mlp, attention_fm, dot_compress_pp, gating_network, linear_compress_embedding, linear_projection_when_mismatch
buck test //dper3/dper3/modules/tests:core_modules_test

{F241257125}

## Unit test for specialized_arch
buck test dper3/dper3_models/ads_ranking/model_impl/sparse_nn/tests:sparse_nn_lib_test -- specialized_module_test
{F240980021}

## Unit test for split_mlp
buck test dper3/dper3_models/ads_ranking/model_impl/sparse_nn/tests:sparse_nn_lib_test -- test_dense_arch
{F240980903}

## Workflow test
f199212608
f199592445

Differential Revision: D22128217

