### PR TITLE
Back out "Revert D22072830: [wip] Upgrade msvc to 14.13"

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -120,8 +120,8 @@ def TruePred(_):
 
 WORKFLOW_DATA = [
     # VS2017 CUDA-10.1
-    WindowsJob(None, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1), master_only_pred=FalsePred),
-    WindowsJob(1, VcSpec(2017, ["14", "11"]), CudaVersion(10, 1)),
+    WindowsJob(None, VcSpec(2017, ["14", "13"]), CudaVersion(10, 1), master_only_pred=FalsePred),
+    WindowsJob(1, VcSpec(2017, ["14", "13"]), CudaVersion(10, 1)),
     # VS2017 no-CUDA (builds only)
     WindowsJob(None, VcSpec(2017, ["14", "16"]), CudaVersion(10, 1)),
     WindowsJob(None, VcSpec(2017, ["14", "16"]), None),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ pytorch_windows_params: &pytorch_windows_params
       default: "3.6"
     vc_version:
       type: string
-      default: "14.11"
+      default: "14.13"
     vc_year:
       type: string
       default: "2017"
@@ -596,7 +596,7 @@ jobs:
         default: "3.6"
       vc_version:
         type: string
-        default: "14.11"
+        default: "14.13"
       vc_year:
         type: string
         default: "2017"
@@ -667,7 +667,7 @@ jobs:
         default: "3.6"
       vc_version:
         type: string
-        default: "14.11"
+        default: "14.13"
       vc_year:
         type: string
         default: "2017"
@@ -7776,16 +7776,16 @@ workflows:
           requires:
             - nightly_pytorch_linux_xenial_py3_clang5_android_ndk_r19c_android_gradle_build
       - pytorch_windows_build:
-          build_environment: pytorch-win-vs2017-14-11-cuda10-cudnn7-py3
+          build_environment: pytorch-win-vs2017-14-13-cuda10-cudnn7-py3
           cuda_version: "10"
-          name: pytorch_windows_vs2017_14.11_py36_cuda10.1_build
+          name: pytorch_windows_vs2017_14.13_py36_cuda10.1_build
           python_version: "3.6"
           use_cuda: "1"
           vc_product: BuildTools
-          vc_version: "14.11"
+          vc_version: "14.13"
           vc_year: "2017"
       - pytorch_windows_test:
-          build_environment: pytorch-win-vs2017-14-11-cuda10-cudnn7-py3
+          build_environment: pytorch-win-vs2017-14-13-cuda10-cudnn7-py3
           cuda_version: "10"
           executor: windows-with-nvidia-gpu
           filters:
@@ -7794,14 +7794,14 @@ workflows:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2017_14.11_py36_cuda10.1_test1
+          name: pytorch_windows_vs2017_14.13_py36_cuda10.1_test1
           python_version: "3.6"
           requires:
-            - pytorch_windows_vs2017_14.11_py36_cuda10.1_build
+            - pytorch_windows_vs2017_14.13_py36_cuda10.1_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
-          vc_version: "14.11"
+          vc_version: "14.13"
           vc_year: "2017"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2017-14-16-cuda10-cudnn7-py3

--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -1,7 +1,7 @@
 $VS_DOWNLOAD_LINK = "https://aka.ms/vs/15/release/vs_buildtools.exe"
 $COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"
 $VS_INSTALL_ARGS = @("--nocache","--quiet","--wait", "--add Microsoft.VisualStudio.Workload.VCTools",
-                                                     "--add Microsoft.VisualStudio.Component.VC.Tools.14.11",
+                                                     "--add Microsoft.VisualStudio.Component.VC.Tools.14.13",
                                                      "--add Microsoft.Component.MSBuild",
                                                      "--add Microsoft.VisualStudio.Component.Roslyn.Compiler",
                                                      "--add Microsoft.VisualStudio.Component.TextTemplating",

--- a/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
+++ b/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
@@ -61,7 +61,7 @@ pytorch_windows_params: &pytorch_windows_params
       default: "3.6"
     vc_version:
       type: string
-      default: "14.11"
+      default: "14.13"
     vc_year:
       type: string
       default: "2017"

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -181,7 +181,7 @@ jobs:
         default: "3.6"
       vc_version:
         type: string
-        default: "14.11"
+        default: "14.13"
       vc_year:
         type: string
         default: "2017"
@@ -252,7 +252,7 @@ jobs:
         default: "3.6"
       vc_version:
         type: string
-        default: "14.11"
+        default: "14.13"
       vc_year:
         type: string
         default: "2017"

--- a/README.md
+++ b/README.md
@@ -210,12 +210,12 @@ Each CUDA version only supports one particular XCode version. The following comb
 
 On Windows
 
-At least Visual Studio 2017 Update 3 (version 15.3.3 with the toolset 14.11) and [NVTX](https://docs.nvidia.com/gameworks/content/gameworkslibrary/nvtx/nvidia_tools_extension_library_nvtx.htm) are needed.
+At least Visual Studio 2017 version 15.6 with the toolset 14.13 and [NVTX](https://docs.nvidia.com/gameworks/content/gameworkslibrary/nvtx/nvidia_tools_extension_library_nvtx.htm) are needed.
 
-If the version of Visual Studio 2017 is higher than 15.4.5, installing of "VC++ 2017 version 15.4 v14.11 toolset" is strongly recommended.
-<br/> If the version of Visual Studio 2017 is lesser than 15.3.3, please update Visual Studio 2017 to the latest version along with installing "VC++ 2017 version 15.4 v14.11 toolset".
-<br/> There is no guarantee of the correct building with VC++ 2017 toolsets, others than version 15.4 v14.11.
-<br/> "VC++ 2017 version 15.4 v14.11 toolset" might be installed onto already installed Visual Studio 2017 by running its installation once again and checking the corresponding checkbox under "Individual components"/"Compilers, build tools, and runtimes".
+If the version of Visual Studio 2017 is higher than 15.6, installing of "VC++ 2017 version 15.6 v14.13 toolset" is strongly recommended.
+<br/> If the version of Visual Studio 2017 is lesser than 15.6, please update Visual Studio 2017 to the latest version along with installing "VC++ 2017 version 15.6 v14.13 toolset".
+<br/> There is no guarantee of the correct building with VC++ 2017 toolsets, others than version 15.6 v14.13.
+<br/> "VC++ 2017 version 15.6 v14.13 toolset" might be installed onto already installed Visual Studio 2017 by running its installation once again and checking the corresponding checkbox under "Individual components"/"Compilers, build tools, and runtimes".
 
 NVTX is a part of CUDA distributive, where it is called "Nsight Compute". To install it onto already installed CUDA run CUDA installation once again and check the corresponding checkbox.
 Be sure that CUDA with Nsight Compute is installed after Visual Studio 2017.

--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -72,9 +72,8 @@ template <typename... Types>
 static inline void pop(Stack& stack, Types&... args) {
   size_t i = 0;
   constexpr size_t N = sizeof...(args);
-  int result[N] = {
+  (void)std::initializer_list<int>{
       (args = std::move(peek(stack, i++, N)).template to<Types>(), 0)...};
-  (void)result;
   drop(stack, N);
 }
 template <typename Type>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40595 Back out "Revert D21581908: Move TensorOptions ops to c10"
* **#40594 Back out "Revert D22072830: [wip] Upgrade msvc to 14.13"**

Original commit changeset: 901de185e607

Differential Revision: [D22247269](https://our.internmc.facebook.com/intern/diff/D22247269/)