### PR TITLE
[JIT] Fix (?) type resolution for class names used as type expressions

### DIFF
--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -286,7 +286,7 @@ def try_ann_to_type(ann, loc):
         if hasattr(ann, "__torch_script_class__"):
             return ClassType(_qualified_name(ann))
         ignored_builtin_classes = (torch.nn.Module, tuple, list)
-        if torch._jit_internal.can_compile_class(ann) and not issubclass(ann, ignored_builtin_classes):
+        if torch._jit_internal.can_compile_class(ann):
             torch.jit._recursive_compile_class(ann, loc)
             return ClassType(_qualified_name(ann))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40598 [JIT] Fix (?) type resolution for class names used as type expressions**

User reported the following pattern breaks when the spurious attribute access is deleted:

```
import torch

class Foo(torch.nn.Module):
    pass

class Abc(torch.nn.Module):
    def forward(self):
        # If you comment the following line, compilation fails because it can't resolve Foo
        Foo.__class__
        if isinstance(self, Foo):
            return torch.zeros(1)
        else:
            return torch.ones(1)

scr = torch.jit.script(Abc())
```

With error:

```
RuntimeError: 
Unknown type name 'Foo':
  File "main.py", line 11
        # resolve Foo
        #Foo.__class__
        if isinstance(self, Foo):
                            ~~~ <--- HERE
            return torch.zeros(1)
        else:
```

In investigating this I found that there's an inconsistency between the two sites where we do recursive class compilation:

Type annotation context: https://github.com/pytorch/pytorch/blob/b05c34259b5e3ff9b55fba5a24d7c5f2f2036471/torch/jit/annotations.py#L289

Value context: https://github.com/pytorch/pytorch/blob/b05c34259b5e3ff9b55fba5a24d7c5f2f2036471/torch/csrc/jit/python/python_sugared_value.cpp#L816

I deleted the second expression in the former case to make them match. Not sure if this is going to break something, though.

Differential Revision: [D22248678](https://our.internmc.facebook.com/intern/diff/D22248678)