### PR TITLE
[papaya][aten] Fix compiler error: loop variable 'tensor' is always a copy because the range of type 'c10::List<at::Tensor>' does not return a reference.

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -128,7 +128,7 @@ public:
         // no safe toTensorRef method, alas)
         ks = ks | ivalue.unsafeToTensorImpl()->key_set();
       } else if (C10_UNLIKELY(ivalue.isTensorList())) {
-        for (const at::Tensor& tensor : ivalue.toTensorList()) {
+        for (const at::Tensor tensor : ivalue.toTensorList()) {
           ks = ks | tensor.key_set();
         }
       }


### PR DESCRIPTION
Summary: .

Test Plan: CI

Reviewed By: smessmer

Differential Revision: D22246106

