### PR TITLE
[JIT] Remove dead store in exit_transforms.cpp

### DIFF
--- a/torch/csrc/jit/frontend/exit_transforms.cpp
+++ b/torch/csrc/jit/frontend/exit_transforms.cpp
@@ -306,10 +306,7 @@ struct ExitTransformer {
   // Recursively transforms the With node.
   ExitPair transformWith(Node* node) {
     auto body_block = node->blocks().at(0);
-    auto exit_block = node->blocks().at(1);
-
     auto body_pair = transformExits(body_block);
-
     return body_pair;
   }
 


### PR DESCRIPTION
Summary: This commit removes a dead store in `transformWith` of exit_transforms.cpp.

Test Plan: Continuous integration.

Differential Revision: D22254136

