### PR TITLE
[v1.6.0 patch] Install method docstrings from PyRRef to RRef

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -247,7 +247,7 @@ parameters during training. See :ref:`remote-reference-protocol` for more
 details.
 
 .. autoclass:: RRef
-    :inherited-members:
+    :members:
 
 
 .. toctree::

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -376,7 +376,7 @@ PyObject* rpc_init(PyObject* /* unused */) {
                   to the creation of this RRef on the remote node has been recorded.
               )")
           // not releasing GIL to avoid context switch
-          .def("__str__", &PyRRef::str);
+          .def("__repr__", &PyRRef::str);
 
   shared_ptr_class_<ProcessGroupRpcBackendOptions>(
       module,

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -1,6 +1,7 @@
 import collections
 import contextlib
 import functools
+import inspect
 import logging
 import numbers
 import threading
@@ -359,8 +360,8 @@ GenericWithOneTypeVar = Generic[T]
 
 
 try:
+    # Combine the implementation class and the type class.
     class RRef(PyRRef, GenericWithOneTypeVar):
-        # Combine the implementation class and the type class.
         pass
 except TypeError as exc:
     # TypeError: metaclass conflict: the metaclass of a derived class
@@ -368,9 +369,49 @@ except TypeError as exc:
     class RRefMeta(PyRRef.__class__, GenericWithOneTypeVar.__class__):
         pass
 
+    # Combine the implementation class and the type class.
     class RRef(PyRRef, GenericWithOneTypeVar, metaclass=RRefMeta):
-        # Combine the implementation class and the type class.
         pass
+
+
+# Install docstrings from `PyRRef` to `RRef`.
+#
+# This is for the fact that pybind11 generates the parameter
+# `self` as type `rpc.PyRRef`, so a `:inherited-members:`
+# under `.. autoclass:: RRef` does not work.
+# we have to do the following process to replacee `rpc.PyRRef` with `rpc.RRef`.
+#
+def method_factory(method_name, docstring):
+    def method(self, *args, **kwargs):
+        return getattr(super(RRef, self), method_name)(*args, **kwargs)
+
+    method.__doc__ = docstring
+    return method
+
+
+for method_name, method in inspect.getmembers(PyRRef):
+    # Ignore magic methods, except "__str__".
+    if method_name.startswith("_") and method_name != "__str__":
+        continue
+
+    # Get pybind11 generated docstring.
+    # It's like,
+    """
+    to_here(self: torch.distributed.rpc.PyRRef, timeout: float=-1.0) -> object
+
+        Blocking call that copies the value of the RRef from the owner
+        to the local node and returns it. If the current node is the
+        owner, returns a reference to the local value.
+    """
+    docstring = getattr(method, "__doc__", None)
+    assert docstring is not None, "RRef user-facing methods should all have docstrings."
+
+    # Do surgery on pybind11 generated docstrings.
+    docstring = docstring.replace("torch.distributed.rpc.PyRRef", "torch.distributed.rpc.RRef")
+
+    # Attach user-facing RRef method with modified docstring.
+    new_method = method_factory(method_name, docstring)
+    setattr(RRef, method_name, new_method)
 
 
 @_require_initialized


### PR DESCRIPTION
Summary:

Note: This PR has been merged into master after the 1.6.0 branch cut at
 7c07c39 (see original PR: #40461). This PR is to cherry pick it into 1.6.0.

---- Original Commit Description Follows ---

Pull Request resolved: https://github.com/pytorch/pytorch/pull/40461

It turned out `:inheried-members:` (see [doc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoclass)) is not really usable.

Because pybind11 generates a docstring that writes `self` as parent class, `rpc.PyRRef`, type.

As a workaround, I am pulling docstrings on parent-class, `PyRRef` class, into subclass, `RRef`. And do surgery on the docstring generated by pybind11.

{F241283111}

ghstack-source-id: 106472496

P134031188

Differential Revision: D7933834

fbshipit-source-id: c03a8a4c9d98888b64492a8caba1591595bfe247

