### PR TITLE
Add option to preserve certain methods during optimize_for_mobile.

### DIFF
--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -276,7 +276,8 @@ void FoldPrePackingOps(script::Module& m) {
 
 script::Module optimizeForMobile(
     const script::Module& m,
-    const std::set<MobileOptimizerType>& optimization_blacklist) {
+    const std::set<MobileOptimizerType>& optimization_blacklist,
+    const std::vector<std::string>& preserved_methods) {
   auto cloned_module = m.clone();
   cloned_module.eval();
 
@@ -287,7 +288,7 @@ script::Module optimizeForMobile(
   if (!optimization_blacklist.count(
           MobileOptimizerType::INSERT_FOLD_PREPACK_OPS)) {
     insertPrePackedOps(cloned_module);
-    cloned_module = freeze_module(cloned_module);
+    cloned_module = freeze_module(cloned_module, preserved_methods);
     fusePrePackedLinearConvWithClamp(cloned_module);
     FoldPrePackingOps(cloned_module);
   }
@@ -328,7 +329,8 @@ void FoldPrePackingOps(script::Module& m) {
 
 script::Module optimizeForMobile(
     const script::Module& module,
-    const std::set<MobileOptimizerType>& blacklist) {
+    const std::set<MobileOptimizerType>& blacklist,
+    const std::vector<std::string>& preserved_methods) {
   TORCH_INTERNAL_ASSERT(
       "Mobile optimizaiton only available with XNNPACK at the moment. "
       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");

--- a/torch/csrc/jit/passes/xnnpack_rewrite.h
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.h
@@ -18,6 +18,7 @@ TORCH_API void fusePrePackedLinearConvWithClamp(script::Module& module);
 TORCH_API void FoldPrePackingOps(script::Module& module);
 TORCH_API script::Module optimizeForMobile(
     const script::Module& module,
-    const std::set<MobileOptimizerType>& optimization_blacklist = {});
+    const std::set<MobileOptimizerType>& optimization_blacklist = {},
+    const std::vector<std::string>& preserved_methods = {});
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -550,8 +550,10 @@ void initJITBindings(PyObject* module) {
       .def(
           "_jit_pass_optimize_for_mobile",
           [](script::Module& module,
-             std::set<MobileOptimizerType>& optimization_blacklist) {
-            return optimizeForMobile(module, optimization_blacklist);
+             std::set<MobileOptimizerType>& optimization_blacklist,
+             std::vector<std::string>& preserved_methods) {
+            return optimizeForMobile(
+                module, optimization_blacklist, preserved_methods);
           })
       .def(
           "_jit_pass_vulkan_insert_prepacked_ops",

--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -5,7 +5,7 @@ This module contains utility method for mobile model optimization and lint.
 import torch
 from enum import Enum
 from torch._C import MobileOptimizerType
-from typing import Set
+from typing import Set, List, AnyStr
 
 class LintCode(Enum):
     BUNDLED_INPUT = 1
@@ -13,7 +13,10 @@ class LintCode(Enum):
     DROPOUT = 3
     BATCHNORM = 4
 
-def optimize_for_mobile(script_module, optimization_blacklist: Set[MobileOptimizerType] = None):
+def optimize_for_mobile(
+        script_module,
+        optimization_blacklist: Set[MobileOptimizerType] = None,
+        preserved_methods: List[AnyStr] = None):
     """
     Args:
         script_module: An instance of torch script module with type of ScriptModule
@@ -30,7 +33,10 @@ def optimize_for_mobile(script_module, optimization_blacklist: Set[MobileOptimiz
     if optimization_blacklist is None:
         optimization_blacklist = set()
 
-    optimized_cpp_module = torch._C._jit_pass_optimize_for_mobile(script_module._c, optimization_blacklist)
+    if preserved_methods is None:
+        preserved_methods = []
+
+    optimized_cpp_module = torch._C._jit_pass_optimize_for_mobile(script_module._c, optimization_blacklist, preserved_methods)
     return torch.jit._recursive.wrap_cpp_module(optimized_cpp_module)
 
 


### PR DESCRIPTION
Summary:
By default freeze_module pass, invoked from optimize_for_mobile,
preserves only forward method. There is an option to specify a list of
methods that can be preserved during freeze_module. This PR exposes that
to optimize_for_module pass.

Test Plan:
python test/test_mobile_optimizer.py

Reviewers:

Subscribers:

Tasks:

Tags:

