### PR TITLE
Ignore error code from `apt-get purge`

### DIFF
--- a/.circleci/scripts/setup_linux_system_environment.sh
+++ b/.circleci/scripts/setup_linux_system_environment.sh
@@ -33,7 +33,7 @@ systemctl list-units --all | cat
 sudo pkill apt-get || true
 
 # For even better luck, purge unattended-upgrades
-sudo apt-get purge -y unattended-upgrades
+sudo apt-get purge -y unattended-upgrades || true
 
 cat /etc/apt/sources.list
 


### PR DESCRIPTION
This replicates the pattern of other "do for luck" commands.
Prep change to add RocM to CircleCI.

