### PR TITLE
Don't drop backtrace from exceptions in _jit_get_operation

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -812,28 +812,24 @@ void initJITBindings(PyObject* module) {
   m.def(
       "_jit_get_operation",
       [](const std::string& op_name) {
-        try {
-          auto symbol = Symbol::fromQualString(op_name);
-          auto operations = getAllOperatorsFor(symbol);
-          TORCH_CHECK(!operations.empty(), "No such operator ", op_name);
-          std::ostringstream docstring;
-          docstring << "Automatically bound operator '" << op_name
-                    << "' with schema(s):\n";
+        auto symbol = Symbol::fromQualString(op_name);
+        auto operations = getAllOperatorsFor(symbol);
+        TORCH_CHECK(!operations.empty(), "No such operator ", op_name);
+        std::ostringstream docstring;
+        docstring << "Automatically bound operator '" << op_name
+                  << "' with schema(s):\n";
 
-          for (const auto& op : operations) {
-            docstring << "  " << op->schema() << "\n";
-          }
-
-          return py::cpp_function(
-              [operations](py::args args, py::kwargs kwargs) {
-                return invokeOperatorFromPython(
-                    operations, std::move(args), std::move(kwargs));
-              },
-              py::name(symbol.toUnqualString()),
-              py::doc(docstring.str().c_str()));
-        } catch (const c10::Error& error) {
-          throw std::runtime_error(error.what_without_backtrace());
+        for (const auto& op : operations) {
+          docstring << "  " << op->schema() << "\n";
         }
+
+        return py::cpp_function(
+            [operations](py::args args, py::kwargs kwargs) {
+              return invokeOperatorFromPython(
+                  operations, std::move(args), std::move(kwargs));
+            },
+            py::name(symbol.toUnqualString()),
+            py::doc(docstring.str().c_str()));
       },
       py::arg("qualified_name"));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40638 Inject an exception
* #40637 Enable C++ stacktraces in CI
* **#40636 Don't drop backtrace from exceptions in _jit_get_operation**

Summary:
This codepath gets taken for custom-registered ops.  Backtraces are
already suppressed by default, but removing this makes it possible to
see them with TORCH_SHOW_CPP_STACKTRACES=1 .

Test Plan:
- Injected a `TORCH_CHECK(false)` into a quantized op.
- Ran a test.  Saw no change in output.
- Ran the test with TORCH_SHOW_CPP_STACKTRACES=1 .  Saw backtrace.