### PR TITLE
Enable C++ stacktraces in CI

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -52,6 +52,8 @@ if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   cd /tmp/libtorch
 fi
 
+export TORCH_SHOW_CPP_STACKTRACES=1
+
 # Test the package
 /builder/check_binary.sh
 

--- a/.circleci/scripts/binary_macos_test.sh
+++ b/.circleci/scripts/binary_macos_test.sh
@@ -25,6 +25,8 @@ else
   pip install "$pkg" --no-index --no-dependencies -v
 fi
 
+export TORCH_SHOW_CPP_STACKTRACES=1
+
 # Test
 if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   $workdir/builder/check_binary.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40638 Inject an exception
* **#40637 Enable C++ stacktraces in CI**
* #40636 Don't drop backtrace from exceptions in _jit_get_operation

Summary:
Might make debugging a bit easier.

Test Plan:
Stack a diff on top of this that injects an exception.  Hopefully see
stack traces in CI.