### PR TITLE
[quant] aten::repeat work for quantized tensor

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -762,7 +762,12 @@ Tensor repeat(const Tensor& self, IntArrayRef repeats) {
 
   Tensor xtensor = self.expand(padded_size);
 
-  Tensor result = at::empty(target_size, self.options());
+  Tensor result;
+  if (self.is_quantized()) {
+    result = at::empty_quantized(target_size, self);
+  } else {
+    result = at::empty(target_size, self.options());
+  }
 
   // return an empty tensor if one of the repeat dimensions is zero
   if (zero_tensor) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1099,6 +1099,11 @@
   variants: method
   device_guard: False
 
+- func: empty_quantized(int[] size, Tensor original) -> Tensor
+  variants: function
+  dispatch:
+    QuantizedCPU, QuantizedCUDA: empty_quantized
+
 - func: empty.out(int[] size, *, MemoryFormat? memory_format=None, Tensor(a!) out) -> Tensor(a!)
   device_guard: False
 
@@ -4890,6 +4895,7 @@
   device_guard: False
   dispatch:
     CPU, CUDA: unfold
+    QuantizedCPU, QuantizedCUDA: unfold
 
 - func: unfold_backward(Tensor grad_in, int[] input_sizes, int dim, int size, int step) -> Tensor
   variants: function

--- a/aten/src/ATen/native/quantized/TensorFactories.cpp
+++ b/aten/src/ATen/native/quantized/TensorFactories.cpp
@@ -76,5 +76,28 @@ Tensor empty_per_channel_affine_quantized_other_backends_stub(
   TORCH_CHECK(false, "Creation of quantized tensor requires quantized dtype like torch.quint8");
 }
 
+// Create an empty quantized Tensor with size, based on the configs
+// of the input Tensor
+Tensor empty_quantized(IntArrayRef size, const Tensor& original) {
+  Tensor output;
+  if (original.qscheme() == kPerTensorAffine) {
+    output = at::_empty_affine_quantized(size, original.options(),
+                                         original.q_scale(),
+                                         original.q_zero_point());
+  } else if (original.qscheme() == kPerChannelAffine) {
+    output = at::_empty_per_channel_affine_quantized(
+        size,
+        original.q_per_channel_scales(),
+        original.q_per_channel_zero_points(),
+        original.q_per_channel_axis(),
+        original.options());
+  } else {
+    TORCH_CHECK(false,
+                "QScheme not supported by empty_quantized:",
+                toString(original.qscheme()));
+  }
+  return output;
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/TensorFactories.cpp
+++ b/aten/src/ATen/native/quantized/TensorFactories.cpp
@@ -76,8 +76,8 @@ Tensor empty_per_channel_affine_quantized_other_backends_stub(
   TORCH_CHECK(false, "Creation of quantized tensor requires quantized dtype like torch.quint8");
 }
 
-// Create an empty quantized Tensor with size, based on the configs
-// of the input Tensor
+// Create an empty quantized Tensor with size, based on the options
+// and quantization parameters of the input quantized Tensor
 Tensor empty_quantized(IntArrayRef size, const Tensor& qtensor) {
   Tensor output;
   if (qtensor.qscheme() == kPerTensorAffine) {

--- a/test/quantization/test_quantized_tensor.py
+++ b/test/quantization/test_quantized_tensor.py
@@ -526,6 +526,17 @@ class TestQuantizedTensor(TestCase):
         with self.assertRaisesRegex(RuntimeError, "Squeeze is only possible on non-axis dimension for Per-Channel"):
             qz = qy.squeeze()
 
+    def test_repeat(self):
+        scale, zero_point, dtype = 1.0, 2, torch.uint8
+        for device in get_supported_device_types():
+            q_int = torch.randint(0, 100, [3], dtype=dtype, device=device)
+            q_int_repeat = q_int.repeat(4, 2)
+            q_ref = torch._make_per_tensor_quantized_tensor(q_int_repeat, scale=scale, zero_point=zero_point)
+
+            q = torch._make_per_tensor_quantized_tensor(q_int, scale=scale, zero_point=zero_point)
+            q_repeat = q.repeat(4, 2)
+            self.assertEqual(q_ref, q_repeat)
+
     def test_qscheme_pickle(self):
         f = Foo()
         buf = io.BytesIO()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40653 [quant][graphmode][fix] remove unsupported ops in the list
* **#40644 [quant] aten::repeat work for quantized tensor**
* #40624 [quant][graphmode][fix] cloning schema in insert_observers

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22268558](https://our.internmc.facebook.com/intern/diff/D22268558)