### PR TITLE
[JIT] Shape analysis fix

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1481,7 +1481,7 @@ inline TypePtr TensorType::fromBoolType() {
 
 inline c10::optional<c10::ScalarType> tryScalarTypeFromJitType(const c10::TypePtr & type) {
   if (type == FloatType::get()) {
-    return at::ScalarType::Double;
+    return at::typeMetaToScalarType(c10::get_default_dtype());
   } else if (type == IntType::get()) {
     return at::ScalarType::Long;
   } else if (type == BoolType::get()) {

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6770,15 +6770,15 @@ a")
             return torch.tensor(s), torch.tensor([s, s])
 
         # need to clear function cache so we re run shape analysis
+        foo.__disable_jit_function_caching__ = True
+
         with set_default_dtype(torch.double):
             self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
             FileCheck().check("Double").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
         with set_default_dtype(torch.float):
-            del torch.jit._jit_caching_layer[foo]
             self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
             FileCheck().check("Float").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
         with set_default_dtype(torch.half):
-            del torch.jit._jit_caching_layer[foo]
             self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
             FileCheck().check("Half").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6770,17 +6770,21 @@ a")
             return torch.tensor(s), torch.tensor([s, s])
 
         # need to clear function cache so we re run shape analysis
-        foo.__disable_jit_function_caching__ = True
-
+        # foo.__disable_jit_function_caching__ = True
         with set_default_dtype(torch.double):
             self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
-            FileCheck().check("Double").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
+            if GRAPH_EXECUTOR == ProfilingMode.LEGACY:
+                FileCheck().check("Double").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
         with set_default_dtype(torch.float):
+            del torch.jit._jit_caching_layer[foo]
             self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
-            FileCheck().check("Float").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
+            if GRAPH_EXECUTOR == ProfilingMode.LEGACY:
+                FileCheck().check("Float").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
         with set_default_dtype(torch.half):
+            del torch.jit._jit_caching_layer[foo]
             self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
-            FileCheck().check("Half").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
+            if GRAPH_EXECUTOR == ProfilingMode.LEGACY:
+                FileCheck().check("Half").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
 
 
     def test_empty_like_memory_format_bc(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6769,13 +6769,19 @@ a")
         def foo(s: float):
             return torch.tensor(s), torch.tensor([s, s])
 
-        scripted_foo = torch.jit.script(foo)
-        with set_default_dtype(torch.float):
-            self.assertEqual(scripted_foo(1.), foo(1.), exact_dtype=True)
+        # need to clear function cache so we re run shape analysis
         with set_default_dtype(torch.double):
-            self.assertEqual(scripted_foo(1.), foo(1.), exact_dtype=True)
+            self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
+            FileCheck().check("Double").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
+        with set_default_dtype(torch.float):
+            del torch.jit._jit_caching_layer[foo]
+            self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
+            FileCheck().check("Float").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
         with set_default_dtype(torch.half):
-            self.assertEqual(scripted_foo(1.), foo(1.), exact_dtype=True)
+            del torch.jit._jit_caching_layer[foo]
+            self.assertEqual(torch.jit.script(foo)(1.), foo(1.), exact_dtype=True)
+            FileCheck().check("Half").check_same("aten::tensor").run(torch.jit.last_executed_optimized_graph())
+
 
     def test_empty_like_memory_format_bc(self):
         def f(x):


### PR DESCRIPTION
We should be using the current default dtype in shape analysis, instead of always using kDouble. This fixes an issue with aten::tensor analysis and maybe others. 