### PR TITLE
BugFix for function sparse_coo_tensor_ctor

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1746,6 +1746,16 @@ class TestSparse(TestCase):
         x = self.sparse_tensor(i, v, torch.Size([3, 0]), device=1)
         check_device(x, 1)
 
+        i = self.index_tensor([[2]]).cuda(1)
+        v = self.value_tensor([5]).cuda(1)
+        x = torch.sparse_coo_tensor(i, v, torch.Size([3]))
+        check_device(x, 1)
+
+        i = self.index_tensor([[2]]).cuda(1)
+        v = self.value_empty(1, 0).cuda(1)
+        x = torch.sparse_coo_tensor(i, v, torch.Size([3, 0]))
+        check_device(x, 1)
+
         x = self.sparse_empty(3, device=1)
         check_device(x, 1)
 
@@ -1978,6 +1988,12 @@ class TestSparse(TestCase):
             for values_device in ['cuda', 'cpu']:
                 for sparse_device in ['cuda', 'cpu', None]:
                     for test_empty_tensor in [True, False]:
+                        if sparse_device is None and indices_device != values_device:
+                            self.assertRaises(RuntimeError, lambda: torch.sparse_coo_tensor(
+                                torch.tensor(([0], [2]), device=indices_device),
+                                self.value_empty(1, 0).to(values_device),
+                                (1, 3, 0), device=sparse_device))
+                            continue
                         if test_empty_tensor:
                             t = torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
                                                         self.value_empty(1, 0).to(values_device),

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5710,7 +5710,9 @@ Args:
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
         Default: if None, infers data type from :attr:`values`.
     device (:class:`torch.device`, optional): the desired device of returned tensor.
-        Default: if None, the device of indices must match device of values, otherwise an exception is raised. 
+        Default: if None, the device is inferred from values and is used to represent the values, the indices,
+         and the sparse tensor itself. Moreover, if None, the device of indices must match the device of values, 
+         otherwise, an exception is raised. 
     {requires_grad}
 
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5710,9 +5710,7 @@ Args:
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
         Default: if None, infers data type from :attr:`values`.
     device (:class:`torch.device`, optional): the desired device of returned tensor.
-        Default: if None, uses the current device for the default tensor type
-        (see :func:`torch.set_default_tensor_type`). :attr:`device` will be the CPU
-        for CPU tensor types and the current CUDA device for CUDA tensor types.
+        Default: if None, the device of indices must match device of values, otherwise an exception is raised. 
     {requires_grad}
 
 


### PR DESCRIPTION
This PR solves a bug when the user does not specify the device for the sparse tensor using the `sparse_coo_tensor` function but the values and indices tensor are in different CUDA device than default. 

Ex:
`sparse_tensor = torch.sparse_coo_tensor(sp_ind, sp_val, sp_shape)`.

This was solved by using the same device_index from values Tensor for  indices Tensor at `sparse_coo_tensor_ctor` function 

Resolves bug #[28500](https://github.com/pytorch/pytorch/issues/28500).

Note that `torch.sparse.FloatTensor` constructor worked as expected because it uses  the `legacy_sparse_tensor_ctor`.  This function uses the same device information of the original Tensor PyThon object. In this fix we replicated this behavior in the new   constructor `sparse_coo_tensor_ctor` function. 

So now this works!
```
import torch
sp_val = torch.rand(10).to('cuda:1')
print(sp_val, sp_val.device)

sp_ind = torch.tensor([[0,1,2,3,4,5,6,7,8,9], [0,1,2,3,4,5,6,7,8,9]], device='cuda:1')
print(sp_ind)

x = torch.sparse_coo_tensor(sp_ind, sp_val, (10, 10))
```