### PR TITLE
Python/C++ API Parity: Add impl and tests for ParameterDict

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/module.cpp
   ${TORCH_API_TEST_DIR}/modulelist.cpp
   ${TORCH_API_TEST_DIR}/modules.cpp
+  ${TORCH_API_TEST_DIR}/parameterdict.cpp
   ${TORCH_API_TEST_DIR}/namespace.cpp
   ${TORCH_API_TEST_DIR}/nn_utils.cpp
   ${TORCH_API_TEST_DIR}/optim.cpp

--- a/test/cpp/api/parameterdict.cpp
+++ b/test/cpp/api/parameterdict.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include <test/cpp/api/support.h>
+
+using namespace torch::nn;
+using namespace torch::test;
+
+struct ParameterDictTest : torch::test::SeedingFixture {};
+
+TEST_F(ParameterDictTest, ConstructFromTensor) {
+  ParameterDict dict;
+  torch::Tensor ta = torch::randn({1, 2}, torch::requires_grad(true));
+  torch::Tensor tb = torch::randn({1, 2}, torch::requires_grad(false));
+  torch::Tensor tc = torch::randn({1, 2});
+  ASSERT_TRUE(ta.requires_grad());
+  ASSERT_FALSE(tb.requires_grad());
+  dict->insert("A", ta);
+  dict->insert("B", tb);
+  dict->insert("C", tc);
+  ASSERT_EQ(dict->size(), 3);
+  ASSERT_TRUE(torch::all(torch::eq(dict["A"], ta)).item<bool>());
+  ASSERT_TRUE(dict["A"].requires_grad());
+  ASSERT_TRUE(torch::all(torch::eq(dict["B"], tb)).item<bool>());
+  ASSERT_FALSE(dict["B"].requires_grad());
+}
+
+TEST_F(ParameterDictTest, ConstructFromOrderedDict) {
+  torch::Tensor ta = torch::randn({1, 2}, torch::requires_grad(true));
+  torch::Tensor tb = torch::randn({1, 2}, torch::requires_grad(false));
+  torch::Tensor tc = torch::randn({1, 2});
+  torch::OrderedDict<std::string, torch::Tensor> params = {
+      {"A", ta}, {"B", tb}, {"C", tc}};
+  auto dict = torch::nn::ParameterDict(params);
+  ASSERT_EQ(dict->size(), 3);
+  ASSERT_TRUE(torch::all(torch::eq(dict["A"], ta)).item<bool>());
+  ASSERT_TRUE(dict["A"].requires_grad());
+  ASSERT_TRUE(torch::all(torch::eq(dict["B"], tb)).item<bool>());
+  ASSERT_FALSE(dict["B"].requires_grad());
+}
+
+TEST_F(ParameterDictTest, InsertAndContains) {
+  ParameterDict dict;
+  dict->insert("A", torch::tensor({1.0}));
+  ASSERT_EQ(dict->size(), 1);
+  ASSERT_TRUE(dict->contains("A"));
+  ASSERT_FALSE(dict->contains("C"));
+}
+
+TEST_F(ParameterDictTest, InsertAndClear) {
+  ParameterDict dict;
+  dict->insert("A", torch::tensor({1.0}));
+  ASSERT_EQ(dict->size(), 1);
+  dict->clear();
+  ASSERT_EQ(dict->size(), 0);
+}
+
+TEST_F(ParameterDictTest, InsertAndPop) {
+  ParameterDict dict;
+  dict->insert("A", torch::tensor({1.0}));
+  ASSERT_EQ(dict->size(), 1);
+  ASSERT_THROWS_WITH(
+      dict->pop("B"), "Parameter 'B' is not defined");
+  torch::Tensor p = dict->pop("A");
+  ASSERT_EQ(dict->size(), 0);
+  ASSERT_TRUE(torch::eq(p, torch::tensor({1.0})).item<bool>());
+}
+
+TEST_F(ParameterDictTest, SimpleUpdate) {
+  ParameterDict dict;
+  ParameterDict wrongDict;
+  ParameterDict rightDict;
+  dict->insert("A", torch::tensor({1.0}));
+  dict->insert("B", torch::tensor({2.0}));
+  dict->insert("C", torch::tensor({3.0}));
+  wrongDict->insert("A", torch::tensor({5.0}));
+  wrongDict->insert("D", torch::tensor({5.0}));
+  ASSERT_THROWS_WITH(dict->update(*wrongDict), "Parameter 'D' is not defined");
+  rightDict->insert("A", torch::tensor({5.0}));
+  dict->update(*rightDict);
+  ASSERT_EQ(dict->size(), 3);
+  ASSERT_TRUE(torch::eq(dict["A"], torch::tensor({5.0})).item<bool>());
+}
+
+TEST_F(ParameterDictTest, Keys) {
+  torch::OrderedDict<std::string, torch::Tensor> params = {
+      {"a", torch::tensor({1.0})},
+      {"b", torch::tensor({2.0})},
+      {"c", torch::tensor({1.0, 2.0})}};
+  auto dict = torch::nn::ParameterDict(params);
+  std::vector<std::string> keys = dict->keys();
+  std::vector<std::string> true_keys{"a", "b", "c"};
+  ASSERT_EQ(keys, true_keys);
+}
+
+TEST_F(ParameterDictTest, Values) {
+  torch::Tensor ta = torch::randn({1, 2}, torch::requires_grad(true));
+  torch::Tensor tb = torch::randn({1, 2}, torch::requires_grad(false));
+  torch::Tensor tc = torch::randn({1, 2});
+  torch::OrderedDict<std::string, torch::Tensor> params = {
+      {"a", ta}, {"b", tb}, {"c", tc}};
+  auto dict = torch::nn::ParameterDict(params);
+  std::vector<torch::Tensor> values = dict->values();
+  std::vector<torch::Tensor> true_values{ta, tb, tc};
+  for (auto i = 0; i < values.size(); i += 1) {
+    ASSERT_TRUE(torch::all(torch::eq(values[i], true_values[i])).item<bool>());
+  }
+}
+
+TEST_F(ParameterDictTest, Get) {
+  ParameterDict dict;
+  torch::Tensor ta = torch::randn({1, 2}, torch::requires_grad(true));
+  torch::Tensor tb = torch::randn({1, 2}, torch::requires_grad(false));
+  torch::Tensor tc = torch::randn({1, 2});
+  ASSERT_TRUE(ta.requires_grad());
+  ASSERT_FALSE(tb.requires_grad());
+  dict->insert("A", ta);
+  dict->insert("B", tb);
+  dict->insert("C", tc);
+  ASSERT_EQ(dict->size(), 3);
+  ASSERT_TRUE(torch::all(torch::eq(dict->get("A"), ta)).item<bool>());
+  ASSERT_TRUE(dict->get("A").requires_grad());
+  ASSERT_TRUE(torch::all(torch::eq(dict->get("B"), tb)).item<bool>());
+  ASSERT_FALSE(dict->get("B").requires_grad());
+}
+
+TEST_F(ParameterDictTest, PrettyPrintParameterDict) {
+  torch::OrderedDict<std::string, torch::Tensor> params = {
+      {"a", torch::tensor({1.0})},
+      {"b", torch::tensor({2.0, 1.0})},
+      {"c", torch::tensor({{3.0}, {2.1}})},
+      {"d", torch::tensor({{3.0, 1.3}, {1.2, 2.1}})}};
+  auto dict = torch::nn::ParameterDict(params);
+  ASSERT_EQ(
+      c10::str(dict),
+      "torch::nn::ParameterDict(\n"
+      "(a): Parameter containing: [Float of size [1]]\n"
+      "(b): Parameter containing: [Float of size [2]]\n"
+      "(c): Parameter containing: [Float of size [2, 1]]\n"
+      "(d): Parameter containing: [Float of size [2, 2]]\n"
+      ")");
+}

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -538,6 +538,10 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
       "`FORWARD_HAS_DEFAULT_ARGS` macro to do so.");
   }
 
+  /// The registered parameters of this `Module`.
+  /// Inorder to access parameters_ in ParameterDict and ParameterList
+  OrderedDict<std::string, Tensor> parameters_;
+
  private:
   // Friend classes.
 
@@ -582,9 +586,6 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
 
   /// Returns a shared_ptr to `this` in a safe (checked) way.
   std::shared_ptr<Module> shared_from_this_checked() const;
-
-  /// The registered parameters of this `Module`.
-  OrderedDict<std::string, Tensor> parameters_;
 
   /// The registered buffers of this `Module`.
   OrderedDict<std::string, Tensor> buffers_;

--- a/torch/csrc/api/include/torch/nn/modules.h
+++ b/torch/csrc/api/include/torch/nn/modules.h
@@ -9,6 +9,7 @@
 #include <torch/nn/modules/container/modulelist.h>
 #include <torch/nn/modules/container/named_any.h>
 #include <torch/nn/modules/container/sequential.h>
+#include <torch/nn/modules/container/parameterdict.h>
 
 // Layers
 #include <torch/nn/modules/adaptive.h>

--- a/torch/csrc/api/include/torch/nn/modules/container/parameterdict.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/parameterdict.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <torch/nn/cloneable.h>
+#include <torch/nn/pimpl.h>
+#include <torch/ordered_dict.h>
+#include <vector>
+
+namespace torch {
+namespace nn {
+
+class ParameterDictImpl : public Cloneable<ParameterDictImpl> {
+ public:
+  using Iterator = OrderedDict<std::string, Tensor>::Iterator;
+  using ConstIterator = OrderedDict<std::string, Tensor>::ConstIterator;
+
+  ParameterDictImpl() = default;
+
+  explicit ParameterDictImpl(
+      const torch::OrderedDict<std::string, torch::Tensor>& params) {
+    parameters_ = params;
+  }
+
+  /// `reset()` is empty for `ParameterDict`, since it does not have
+  /// parameters of its own.
+  void reset() override {}
+
+  /// Pretty prints the `ParameterDict` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override {
+    stream << "torch::nn::ParameterDict(" << std::endl;
+    for (const auto& pair : parameters_) {
+      stream << "(" << pair.key() << ")"
+             << ": Parameter containing: [" << pair.value().scalar_type()
+             << " of size " << pair.value().sizes() << "]";
+      ;
+      stream << std::endl;
+    }
+    stream << ")";
+  }
+
+  /// Insert the parameter along with the key into ParameterDict
+  /// The parameter is set to be require grad by default
+  Tensor& insert(std::string key, Tensor param) {
+    return register_parameter(key, param, param.requires_grad());
+  }
+
+  /// Remove key from the ParameterDict and return its value, throw exception
+  /// if the key is not contained. Please check contains(key) before for a
+  /// non-throwing access.
+  Tensor pop(const std::string& key) {
+    torch::Tensor v = parameters_[key];
+    parameters_.erase(key);
+    return v;
+  }
+
+  /// Return the keys in the dict
+  ::std::vector<std::string> keys() const {
+    return parameters_.keys();
+  }
+
+  /// Return the Values in the dict
+  ::std::vector<torch::Tensor> values() const {
+    return parameters_.values();
+  }
+
+  /// Return an iterator to the start of ParameterDict
+  Iterator begin() {
+    return parameters_.begin();
+  }
+
+  /// Return a const iterator to the start of ParameterDict
+  ConstIterator begin() const {
+    return parameters_.begin();
+  }
+
+  /// Return an iterator to the end of ParameterDict
+  Iterator end() {
+    return parameters_.end();
+  }
+
+  /// Return a const iterator to the end of ParameterDict
+  ConstIterator end() const {
+    return parameters_.end();
+  }
+
+  /// Return the number of items currently stored in the ParameterDict
+  size_t size() const noexcept {
+    return parameters_.size();
+  }
+
+  /// Return true if the ParameterDict is empty, otherwise return false
+  bool empty() const noexcept {
+    return parameters_.is_empty();
+  }
+
+  /// Update the ParameterDict with the key-value pairs from
+  /// another ParameterDict, overwriting existing key
+  template <typename Container>
+  void update(const Container& container) {
+    for (auto& item : container) {
+      parameters_[item.key()] = item.value();
+    }
+  }
+
+  /// Remove all parameters in the ParameterDict
+  void clear() {
+    parameters_.clear();
+  }
+
+  /// Check if the centain parameter with the key in the ParameterDict
+  bool contains(const std::string& key) const noexcept {
+    return parameters_.contains(key);
+  }
+
+  /// Returns the value associated with the given `key`. Throws an exception if
+  /// no such key is stored in the `ParameterDict`. Check contains(key) before 
+  /// for a non-throwing way of access
+  const Tensor& get(const std::string& key) const {
+    return parameters_[key];
+  }
+
+  /// Returns the value associated with the given `key`. Throws an exception if
+  /// no such key is stored in the `ParameterDict`. Check contains(key) before 
+  /// for a non-throwing way of access
+  Tensor& get(const std::string& key) {
+    return parameters_[key];
+  }
+
+  /// Returns the value associated with the given `key`. Throws an exception if
+  /// no such key is stored in the `ParameterDict`. Check contains(key) before 
+  /// for a non-throwing way of access
+  Tensor& operator[](const std::string& key) {
+    return parameters_[key];
+  }
+
+  /// Returns the value associated with the given `key`. Throws an exception if
+  /// no such key is stored in the `ParameterDict`. Check contains(key) before 
+  /// for a non-throwing way of access
+  const Tensor& operator[](const std::string& key) const {
+    return parameters_[key];
+  }
+};
+
+TORCH_MODULE(ParameterDict);
+
+} // namespace nn
+} // namespace torch


### PR DESCRIPTION
Summary: This diff contains the implementation of C++ api for ParameterDict from #25883, refer to  #36904 and #28652 

Test Plan: Add unit test in this diff

Reviewers:

Subscribers:

Tasks: #25883

Tags: