### PR TITLE
[TB] Support custom run_name in add_hparams

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -268,7 +268,7 @@ class SummaryWriter(object):
         """Returns the directory where event files will be written."""
         return self.log_dir
 
-    def add_hparams(self, hparam_dict, metric_dict):
+    def add_hparams(self, hparam_dict, metric_dict, run_name=None):
         """Add a set of hyperparameters to be compared in TensorBoard.
 
         Args:
@@ -281,6 +281,8 @@ class SummaryWriter(object):
               here should be unique in the tensorboard record. Otherwise the value
               you added by ``add_scalar`` will be displayed in hparam plugin. In most
               cases, this is unwanted.
+            run_name (str): Name of the run, to be included as part of the logdir.
+              If unspecified, will use current timestamp.
 
         Examples::
 
@@ -301,10 +303,9 @@ class SummaryWriter(object):
             raise TypeError('hparam_dict and metric_dict should be dictionary.')
         exp, ssi, sei = hparams(hparam_dict, metric_dict)
 
-        logdir = os.path.join(
-            self._get_file_writer().get_logdir(),
-            str(time.time())
-        )
+        if not run_name:
+            run_name = str(time.time())
+        logdir = os.path.join(self._get_file_writer().get_logdir(), run_name)
         with SummaryWriter(log_dir=logdir) as w_hp:
             w_hp.file_writer.add_summary(exp)
             w_hp.file_writer.add_summary(ssi)


### PR DESCRIPTION
Summary: Support custom run_name since using timestamp as run_name can be confusing to people

Test Plan:
hp = {"lr": 0.1, "bool_var": True, "string_var": "hi"}
  mt = {"accuracy": 0.1}
  writer.add_hparams(hp, mt, run_name="run1")
  writer.flush()

Reviewed By: edward-io

Differential Revision: D22157749

