### PR TITLE
Add serializer and deserializer for Int8QuantSchemeBlob and Int8QuantParamsBlob

### DIFF
--- a/caffe2/quantization/server/int8_gen_quant_params.h
+++ b/caffe2/quantization/server/int8_gen_quant_params.h
@@ -56,6 +56,6 @@ class Int8GenQuantParamsOp final : public Operator<Context> {
     return true;
   }
 
-}; // class Int8QunatParamsOp
+}; // class Int8GenQuantParamsOp
 
 } // namespace caffe2


### PR DESCRIPTION
Summary: Add ser-de to support int8 quantization during online training

Test Plan:
```
buck test caffe2/caffe2/fb/fbgemm:int8_serializer_test
```

Differential Revision: D22273292

