### PR TITLE
Add Block-wise Pruning function

### DIFF
--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -731,7 +731,6 @@ class RandomStructured(BasePruningMethod):
 
     PRUNING_TYPE = "structured"
 
-# def random_structured(module, name, amount, dim):
     def __init__(self, amount, dim=-1):
         # Check range of validity of amount
         _validate_pruning_amount_init(amount)


### PR DESCRIPTION
Provides the implementation for feature request issue #39765.

One of the main-stream pruning techniques is "Block-wise Pruning", 
which eliminate weights such that the number of non-zero weights in each block is equal. 

For example, the following papers use block-wise pruning
- (Block-size) Conference Paper name
- (Layer)NIPS15 Learning both Weights and Connections for Efficient
Neural Networks
- (Vector-Inch)FPGA19, Efficient and Effective Sparse LSTM on FPGA with
Bank-Balanced Sparsity
- (Vector-Inch)IEEE Trans. on Circuits and Systems for Video Technology, Accelerator-aware pruning for convolutional neural networks

The block-wise pruning improve imbalanced loading problem occurred by pruning without constraints, 
and I believe the block-wise pruning might be helpful. 
Thus, I have developed the block-wise pruning function and class, 
"blockwise_unstructured", "BlockwiseUnstructured". 
Supporting block sizes are as follows:
- layer
- filter
- kernel
- vector(inch, kernel y-axis, kernel x-axis)

How to use is shown as following: 
```
>>> from torch import nn
>>> import torch.nn.utils.prune as prune
>>> module = nn.Conv2d(4, 6, 3)
>>> print(list(module.named_buffers()))
[]
>>> prune.blockwise_unstructured(module, name="weight", amount=0.5, block_type="vector-inch", block_size=2)
Conv2d(4, 6, kernel_size=(3, 3), stride=(1, 1))
>>> list(module.named_buffers())[0][1].sum(1)
tensor([[[2, 2, 2],
         [2, 2, 2],
         [2, 2, 2]],

        [[2, 2, 2],
         [2, 2, 2],
         [2, 2, 2]],

        [[2, 2, 2],
         [2, 2, 2],
         [2, 2, 2]],

        [[2, 2, 2],
         [2, 2, 2],
         [2, 2, 2]],

        [[2, 2, 2],
         [2, 2, 2],
         [2, 2, 2]],

        [[2, 2, 2],
         [2, 2, 2],
         [2, 2, 2]]])
```