### PR TITLE
Remove constexpr for NVCC on Windows

### DIFF
--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -480,7 +480,7 @@ struct TORCH_API ModulePolicy {
   }
   // are we going to return everything? If so, we can optimize the calculate
   // of the size of the list.
-  static constexpr bool all_slots = false;
+  static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = false;
 };
 
 struct TORCH_API ParameterPolicy {
@@ -493,7 +493,7 @@ struct TORCH_API ParameterPolicy {
   static bool valid(const ClassTypePtr& typ, size_t i, const IValue& v) {
     return typ->is_parameter(i) && v.isTensor();
   }
-  static constexpr bool all_slots = false;
+  static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = false;
 };
 
 struct TORCH_API BufferPolicy {
@@ -507,7 +507,7 @@ struct TORCH_API BufferPolicy {
     return typ->getAttribute(i)->isSubtypeOf(TensorType::get()) &&
         !typ->is_parameter(i);
   }
-  static constexpr bool all_slots = false;
+  static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = false;
 };
 
 struct TORCH_API AttributePolicy {
@@ -520,7 +520,7 @@ struct TORCH_API AttributePolicy {
   static bool valid(const ClassTypePtr& typ, size_t i, const IValue& v) {
     return true;
   }
-  static constexpr bool all_slots = true;
+  static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = true;
 };
 
 // take a Policy object, and make a version of it that returns the slot.


### PR DESCRIPTION
They are not well supported. Fixes https://github.com/pytorch/pytorch/issues/40393 and https://github.com/pytorch/pytorch/issues/39394.