### PR TITLE
Add a modified Cholesky decomposition

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -242,6 +242,7 @@ _(aten, chain_matmul) \
 _(aten, cholesky) \
 _(aten, cholesky_inverse) \
 _(aten, cholesky_solve) \
+_(aten, cholesky_mod) \
 _(aten, chunk) \
 _(aten, clamp) \
 _(aten, clamp_max) \

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -619,15 +619,12 @@ static void  apply_cholesky_mod(const Tensor& self, Tensor & out, const Tensor &
       // lapackCholesky failed. Copy current 2D matrix to out
       if (batch_size > 1) {
         outTag[i].copy_(selfTag[i]);
+        outTag[i].diagonal().add_(jitter_val);
         jitter_out[i] = jitter_val;
       } else {
         outTag.copy_(selfTag);
+        outTag.diagonal().add_(jitter_val);
         at::fill_(jitter_out, jitter_val);
-      }
-      for (int64_t mm=0; mm<m; mm++)
-      {
-        // Add err_val to the diagonal
-        out_working_ptr[(mm * m) + mm] += jitter_val;
       }
       lapackCholesky<scalar_t>(uplo, m, out_working_ptr, m, &info);
     }

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -901,7 +901,7 @@ Tensor _cholesky_helper_cuda(const Tensor& self, bool upper) {
   }
 }
 
-std::tuple<Tensor, Tensor> _cholesky_mod_helper_cuda(const Tensor& self, const Tensor& err, bool upper) {
+std::tuple<Tensor, Tensor> _cholesky_mod_helper_cuda(const Tensor& self, bool upper) {
   std::vector<int64_t> infos(batchCount(self), 0);
   Tensor self_working_copy;
   if (upper) {
@@ -909,6 +909,10 @@ std::tuple<Tensor, Tensor> _cholesky_mod_helper_cuda(const Tensor& self, const T
   } else {
     self_working_copy = cloneBatchedColumnMajor(self);
   }
+  auto req_size = self.sizes().vec();
+  req_size.pop_back();
+  req_size.pop_back();
+  auto err = at::zeros(req_size, self.options().dtype(ScalarType::Double));
 
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "cholesky_mod_cuda", [&]{
     apply_cholesky<scalar_t>(self_working_copy, false, infos);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4897,7 +4897,7 @@
 # is self.size[:-2]
 # - func: cholesky_mod.out(Tensor self, bool upper=False, *, Tensor(a!) out, Tensor? jitter=None) -> (Tensor(a!) out, Tensor jitter)
 
-- func: cholesky_mod(Tensor self, bool upper=False, *, Tensor? jitter=None) -> (Tensor result, Tensor jitter)
+- func: cholesky_mod(Tensor self, bool upper=False, *, Tensor? jitter=None) -> (Tensor result, Tensor jitter_out)
   use_c10_dispatcher: with_codegenerated_unboxing_wrapper
   variants: method, function
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4892,6 +4892,17 @@
     CPU: _cholesky_helper_cpu
     CUDA: _cholesky_helper_cuda
 
+- func: cholesky_mod(Tensor self, bool upper=False) -> (Tensor result, Tensor err)
+  use_c10_dispatcher: full
+  variants: method, function
+
+- func: _cholesky_mod_helper(Tensor self, Tensor err, bool upper) -> (Tensor, Tensor)
+  use_c10_dispatcher: full
+  variants: function
+  dispatch:
+    CPU: _cholesky_mod_helper_cpu
+    CUDA: _cholesky_mod_helper_cuda
+
 - func: cholesky_solve.out(Tensor self, Tensor input2, bool upper=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4896,7 +4896,7 @@
   use_c10_dispatcher: full
   variants: method, function
 
-- func: _cholesky_mod_helper(Tensor self, Tensor err, bool upper) -> (Tensor, Tensor)
+- func: _cholesky_mod_helper(Tensor self, bool upper) -> (Tensor, Tensor)
   use_c10_dispatcher: full
   variants: function
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4892,11 +4892,16 @@
     CPU: _cholesky_helper_cpu
     CUDA: _cholesky_helper_cuda
 
-- func: cholesky_mod(Tensor self, bool upper=False) -> (Tensor result, Tensor err)
-  use_c10_dispatcher: full
+# This signature doesn't work. The parser wants each of the output arguments to
+# be present in the input arguments, but input `jitter` is 1d and output jitter
+# is self.size[:-2]
+# - func: cholesky_mod.out(Tensor self, bool upper=False, *, Tensor(a!) out, Tensor? jitter=None) -> (Tensor(a!) out, Tensor jitter)
+
+- func: cholesky_mod(Tensor self, bool upper=False, *, Tensor? jitter=None) -> (Tensor result, Tensor jitter)
+  use_c10_dispatcher: with_codegenerated_unboxing_wrapper
   variants: method, function
 
-- func: _cholesky_mod_helper(Tensor self, bool upper) -> (Tensor, Tensor)
+- func: _cholesky_mod_helper(Tensor self, bool upper, Tensor jitter) -> (Tensor, Tensor)
   use_c10_dispatcher: full
   variants: function
   dispatch:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2383,6 +2383,7 @@ class TestAutograd(TestCase):
     @skipIfNoLapack
     def test_cholesky_mod(self):
         jitter_tensor = torch.as_tensor([0, 1e-8], dtype=torch.float64)
+
         def func(root, upper):
             x = torch.matmul(root, root.transpose(-1, -2)) + 1e-05
             ret = torch.cholesky_mod(x, upper, jitter=jitter_tensor)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8115,7 +8115,6 @@ class TestTorchDeviceType(TestCase):
         # default
         jitter = torch.as_tensor([1e-8, 1e-6, 1e-4, 1e-2, 1, 100], dtype=torch.float64)
         C, e = torch.cholesky_mod(A, jitter=jitter)
-        print(e)
 
         B = (C @ C.transpose(-2, -1)) - make_batch_eye(n, e)
         self.assertEqual(A, B, atol=1e-14, rtol=0)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8038,6 +8038,11 @@ class TestTorchDeviceType(TestCase):
         B = torch.mm(C, C.t())
         self.assertEqual(A, B, atol=1e-14, rtol=0)
 
+        # cholesky_mod
+        C, e = torch.cholesky_mod(A)
+        B = torch.mm(C, C.t())
+        self.assertEqual(A, B, atol=1e-14+torch.max(e), rtol=0)
+
         # test Upper Triangular
         U = torch.cholesky(A, True)
         B = torch.mm(U.t(), U)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -297,7 +297,7 @@
 - name: cholesky(Tensor self, bool upper=False) -> Tensor
   self: cholesky_backward(grad, upper, result)
 
-- name: cholesky_mod(Tensor self, bool upper=False) -> (Tensor result, Tensor err)
+- name: cholesky_mod(Tensor self, bool upper=False, *, Tensor? jitter=None) -> (Tensor result, Tensor jitter)
   self: cholesky_backward(grad, upper, result)
 
 - name: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -297,6 +297,9 @@
 - name: cholesky(Tensor self, bool upper=False) -> Tensor
   self: cholesky_backward(grad, upper, result)
 
+- name: cholesky_mod(Tensor self, bool upper=False) -> (Tensor result, Tensor err)
+  self: cholesky_backward(grad, upper, result)
+
 - name: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor
   self, input2: cholesky_solve_backward(grad, self, input2, result, upper)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -298,7 +298,8 @@
   self: cholesky_backward(grad, upper, result)
 
 - name: cholesky_mod(Tensor self, bool upper=False, *, Tensor? jitter=None) -> (Tensor result, Tensor jitter_out)
-  self: cholesky_mod_backward(grad, upper, result, jitter_out)
+  jitter: non_differentiable
+  self: cholesky_backward(grad, upper, result)
 
 - name: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor
   self, input2: cholesky_solve_backward(grad, self, input2, result, upper)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -297,8 +297,8 @@
 - name: cholesky(Tensor self, bool upper=False) -> Tensor
   self: cholesky_backward(grad, upper, result)
 
-- name: cholesky_mod(Tensor self, bool upper=False, *, Tensor? jitter=None) -> (Tensor result, Tensor jitter)
-  self: cholesky_backward(grad, upper, result)
+- name: cholesky_mod(Tensor self, bool upper=False, *, Tensor? jitter=None) -> (Tensor result, Tensor jitter_out)
+  self: cholesky_mod_backward(grad, upper, result, jitter_out)
 
 - name: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor
   self, input2: cholesky_solve_backward(grad, self, input2, result, upper)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -852,23 +852,6 @@ Tensor cholesky_backward(Tensor grad, bool upper, Tensor L) {
   return grad_input.add(grad_input.transpose(-1, -2)).mul_(0.5);  // Symmetrizing the gradient
 }
 
-Tensor cholesky_mod_backward(Tensor grad, bool upper, Tensor L, Tensor jitter) {
-  // L_tag = L - I * jiter[0], then use cholesky_backward
-  Tensor L_tag = L;
-  if (jitter.defined()) {
-    L_tag.copy_(L);
-    if (jitter.dim() > 0) {
-        std::cout << "jitter dim " << jitter.dim() << ", size[0] " << jitter.size(0) << std::endl;
-        L_tag.diagonal().add_(jitter[0]);
-    }
-    else {
-        L_tag.diagonal().add_(jitter);
-    }
-
-  }
-  return cholesky_backward(grad, upper, L_tag);
-}
-
 Tensor cholesky_inverse_backward(Tensor grad, Tensor L, bool upper, Tensor inverse) {
   Tensor grad_L;
   if (grad.defined()) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -852,6 +852,23 @@ Tensor cholesky_backward(Tensor grad, bool upper, Tensor L) {
   return grad_input.add(grad_input.transpose(-1, -2)).mul_(0.5);  // Symmetrizing the gradient
 }
 
+Tensor cholesky_mod_backward(Tensor grad, bool upper, Tensor L, Tensor jitter) {
+  // L_tag = L - I * jiter[0], then use cholesky_backward
+  Tensor L_tag = L;
+  if (jitter.defined()) {
+    L_tag.copy_(L);
+    if (jitter.dim() > 0) {
+        std::cout << "jitter dim " << jitter.dim() << ", size[0] " << jitter.size(0) << std::endl;
+        L_tag.diagonal().add_(jitter[0]);
+    }
+    else {
+        L_tag.diagonal().add_(jitter);
+    }
+
+  }
+  return cholesky_backward(grad, upper, L_tag);
+}
+
 Tensor cholesky_inverse_backward(Tensor grad, Tensor L, bool upper, Tensor inverse) {
   Tensor grad_L;
   if (grad.defined()) {

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -761,7 +761,7 @@ See :func:`torch.cholesky`
 
 add_docstr_all('cholesky_mod',
                r"""
-cholesky_mod(upper=False) -> (Tensor, Tensor)
+cholesky_mod(upper=False, jitter=None) -> (Tensor, Tensor)
 
 See :func:`torch.cholesky_mod`
 """)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -759,6 +759,13 @@ cholesky(upper=False) -> Tensor
 See :func:`torch.cholesky`
 """)
 
+add_docstr_all('cholesky_mod',
+               r"""
+cholesky_mod(upper=False) -> (Tensor, Tensor)
+
+See :func:`torch.cholesky_mod`
+""")
+
 add_docstr_all('cholesky_solve',
                r"""
 cholesky_solve(input2, upper=False) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1325,6 +1325,70 @@ Example::
     tensor(2.3842e-07)
 """)
 
+add_docstr(torch.cholesky_mod, r"""
+cholesky_mod(input, upper=False, out=None) -> (Tensor, Tensor)
+
+Computes the modified Cholesky decomposition of a symmetric positive-semidefinite
+matrix :math:`A` or for batches of symmetric positive-semidefinite matrices.
+
+If :attr:`upper` is ``True``, the returned matrix ``U`` is upper-triangular, and
+the decomposition has the form:
+
+.. math::
+
+  A + I*e = U^TU
+
+If :attr:`upper` is ``False``, the returned matrix ``L`` is lower-triangular, and
+the decomposition has the form:
+
+.. math::
+
+    A + I*e = LL^T
+
+If :attr:`upper` is ``True``, and :math:`A` is a batch of symmetric positive-semidefinite
+matrices, then the returned tensor will be composed of upper-triangular Cholesky factors
+of each of the individual matrices. Similarly, when :attr:`upper` is ``False``, the returned
+tensor will be composed of lower-triangular Cholesky factors of each of the individual
+matrices.
+
+Args:
+    input (Tensor): the input tensor :math:`A` of size :math:`(*, n, n)` where `*` is zero or more
+                batch dimensions consisting of symmetric positive-definite matrices.
+    upper (bool, optional): flag that indicates whether to return a
+                            upper or lower triangular matrix. Default: ``False``
+    out (Tensor, optional): the output matrix
+
+Returns:
+    out (Tensor): the output matrix
+    err (Tensor): the minimal error, that when added to `A` will make it positive-definite
+
+Example::
+
+    >>> a = torch.randn(3, 3)
+    >>> a = torch.mm(a, a.t()) # make symmetric positive-definite
+    >>> l, e = torch.cholesky_mod(a)
+    >>> a
+    tensor([[ 2.4112, -0.7486,  1.4551],
+            [-0.7486,  1.3544,  0.1294],
+            [ 1.4551,  0.1294,  1.6724]])
+    >>> l
+    tensor([[ 1.5528,  0.0000,  0.0000],
+            [-0.4821,  1.0592,  0.0000],
+            [ 0.9371,  0.5487,  0.7023]])
+    >>> e
+    tensor([0., 0., 0.])
+    >>> torch.mm(l, l.t())
+    tensor([[ 2.4112, -0.7486,  1.4551],
+            [-0.7486,  1.3544,  0.1294],
+            [ 1.4551,  0.1294,  1.6724]])
+    >>> a = torch.randn(3, 2, 2)
+    >>> a = torch.matmul(a, a.transpose(-1, -2))
+    >>> l = torch.cholesky_mod(a)
+    >>> z = torch.matmul(l, l.transpose(-1, -2))
+    >>> torch.max(torch.abs(z - a)) # Max non-zero
+    tensor(2.3842e-07)
+""")
+
 add_docstr(torch.cholesky_solve, r"""
 cholesky_solve(input, input2, upper=False, out=None) -> Tensor
 


### PR DESCRIPTION
Fixes #25785 by adding a modified Cholesky decomposition.

The idea is to add a "small" constant `e`  to the diagonal of the input so that instead of solving for `L` in  `A = L @ L.transpose(-2, -1)`, we solve for `A + (D * e) = L @ L.transpose(-2, -1)` where `D = torch.eye(A.shape[-1])`. The function call becomes `L, e = torch.cholesky_mod(A, upper=True)`. 

The problems I see in this implementation so far are:
- The values of `e` are hard-coded: starting at `e = 1e-8` and increasing by `e *= 100` for 8 tries. Should the value be based on some multiple of the largest eigenvector?
- The code runs sequentially, even on GPU. I could use `magmaCholeskyBatched` but then would need to somehow weed out and "rebatch" the matrices that fail with that value of `e` for the next iteration.
- There are places in the code where I used constructs like `at::fill_` (to assign to a scalar) and `Tensor.copy_`. These do the job, but is there a better way?

I did not touch the problem pointed out in #34272 where raising an error when `info != 0` is slow. One approach would be to return a value in `e` that indicates a failure, maybe negative values?