### PR TITLE
[quant][graphmode] Add FP16 quant support - Insert Noop Observers

### DIFF
--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -63,7 +63,7 @@ class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight'])):
 
 default_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_observer,
                                          weight=default_weight_observer)
-float16_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_observer,
+float16_dynamic_qconfig = QConfigDynamic(activation=NoopObserver.with_args(dtype=torch.float16),
                                          weight=NoopObserver.with_args(dtype=torch.float16))
 per_channel_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_observer,
                                              weight=default_per_channel_weight_observer)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40710 [quant][graphmode] FP16 quant support - Operator Fusion
* #40709 [quant][graphmode] FP16 quant support - Insert cast operators
* **#40708 [quant][graphmode] Add FP16 quant support - Insert Noop Observers**

Summary:
Insert NoopObservers for activations and weight tensors for FP16

Test Plan:
python test/test_quantization.py test_prepare_dynamic

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22335976](https://our.internmc.facebook.com/intern/diff/D22335976)