### PR TITLE
[quant][graphmode] FP16 quant support - Insert cast operators

### DIFF
--- a/test/quantization/test_quantize_jit.py
+++ b/test/quantization/test_quantize_jit.py
@@ -2710,6 +2710,27 @@ class TestQuantizeDynamicJitPasses(QuantizationTestCase):
                 graph_params.append((obs.getattr('3_scale_0'), obs.getattr('3_zero_point_0')))
             self.assertEqual(ref_qparams, graph_params)
 
+    def test_convert_dynamic_fp16(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.fc = torch.nn.Linear(5, 5)
+
+            def forward(self, x):
+                return self.fc(x)
+
+        m = torch.jit.script(M())
+        m = prepare_dynamic_jit(m, {'': float16_dynamic_qconfig})
+        m = convert_dynamic_jit(m, debug=True)
+        data = torch.randn(5, 5)
+        m(data)
+        FileCheck().check("aten::to") \
+                   .check_next("aten::to") \
+                   .check("aten::linear") \
+                   .check_not("aten::dequantize") \
+                   .check_not("aten::quantize") \
+                   .run(m.graph)
+
 class TestQuantizeDynamicJitOps(QuantizationTestCase):
     """ Test graph mode post training dynamic quantization works
     for individual ops end to end.

--- a/test/quantization/test_quantize_jit.py
+++ b/test/quantization/test_quantize_jit.py
@@ -2721,8 +2721,6 @@ class TestQuantizeDynamicJitPasses(QuantizationTestCase):
 
         m = torch.jit.script(M())
         m = quantize_dynamic_jit(m, {'': float16_dynamic_qconfig}, debug=True)
-        data = torch.randn(5, 5)
-        m(data)
         FileCheck().check("aten::to") \
                    .check_next("aten::to") \
                    .check("aten::linear") \

--- a/test/quantization/test_quantize_jit.py
+++ b/test/quantization/test_quantize_jit.py
@@ -2720,8 +2720,7 @@ class TestQuantizeDynamicJitPasses(QuantizationTestCase):
                 return self.fc(x)
 
         m = torch.jit.script(M())
-        m = prepare_dynamic_jit(m, {'': float16_dynamic_qconfig})
-        m = convert_dynamic_jit(m, debug=True)
+        m = quantize_dynamic_jit(m, {'': float16_dynamic_qconfig}, debug=True)
         data = torch.randn(5, 5)
         m(data)
         FileCheck().check("aten::to") \

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -570,6 +570,17 @@ bool is_functional(
   return v->type()->cast<FunctionType>() && getFuncName(v) == functional;
 }
 
+c10::optional<std::string> get_module_name(Value* value) {
+  auto type = value->type()->cast<ClassType>();
+  if (type && type->name()) {
+    static std::regex mangle_re("\\.___torch_mangle_\\d+");
+    auto qualified_name =
+        std::regex_replace(type->name()->qualifiedName(), mangle_re, "");
+    return qualified_name;
+  }
+  return c10::nullopt;
+}
+
 bool is_module(
     const Match& match,
     const std::unordered_map<std::string, Value*>& vmap,
@@ -578,11 +589,9 @@ bool is_module(
   const auto& match_vmap = match.values_map;
   Value* relu = match_vmap.at(vmap.at(vname));
   auto type = relu->type()->cast<ClassType>();
-  if (type && type->name()) {
-    static std::regex mangle_re("\\.___torch_mangle_\\d+");
-    auto qualified_name =
-        std::regex_replace(type->name()->qualifiedName(), mangle_re, "");
-    return qualified_name == module_qualified_name;
+  auto module_name = get_module_name(relu);
+  if (module_name.has_value()) {
+    return module_name.value() == module_qualified_name;
   }
   return false;
 };

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -570,7 +570,7 @@ bool is_functional(
   return v->type()->cast<FunctionType>() && getFuncName(v) == functional;
 }
 
-c10::optional<std::string> get_module_name(Value* value) {
+c10::optional<std::string> getModuleName(Value* value) {
   auto type = value->type()->cast<ClassType>();
   if (type && type->name()) {
     static std::regex mangle_re("\\.___torch_mangle_\\d+");
@@ -587,9 +587,8 @@ bool is_module(
     const std::string& vname,
     const std::string& module_qualified_name) {
   const auto& match_vmap = match.values_map;
-  Value* relu = match_vmap.at(vmap.at(vname));
-  auto type = relu->type()->cast<ClassType>();
-  auto module_name = get_module_name(relu);
+  Value* v = match_vmap.at(vmap.at(vname));
+  auto module_name = getModuleName(v);
   if (module_name.has_value()) {
     return module_name.value() == module_qualified_name;
   }

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -44,6 +44,9 @@ TORCH_API bool isScalar(Value* v);
 // Check if value is the input of the graph
 TORCH_API bool hitGraphInput(Value* value);
 
+// Return the module name that corresponds to the value.
+TORCH_API c10::optional<std::string> get_module_name(Value* value);
+
 // =========== helper functions for Node =========
 TORCH_API bool isSingleInputGeneralShapeAtenFunction(Node* n);
 

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -45,7 +45,7 @@ TORCH_API bool isScalar(Value* v);
 TORCH_API bool hitGraphInput(Value* value);
 
 // Return the module name that corresponds to the value.
-TORCH_API c10::optional<std::string> get_module_name(Value* value);
+TORCH_API c10::optional<std::string> getModuleName(Value* value);
 
 // =========== helper functions for Node =========
 TORCH_API bool isSingleInputGeneralShapeAtenFunction(Node* n);

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -190,6 +190,43 @@ DynamicQuantOps insertChooseQParamQuantDequant(
   return std::make_tuple(choose_qparams, quant, dequant);
 }
 
+Node* insertFP16CastOps(Graph* graph, Value* observer_out) {
+  auto default_false = graph->insertConstant(false);
+  Value* none = graph->insertConstant(IValue());
+  Value* fp16_dtype = graph->insertConstant(IValue(c10::kHalf));
+  Value* float_dtype = graph->insertConstant(IValue(c10::kFloat));
+
+  std::vector<Value*> input_to_fp16 = {observer_out,
+                                       fp16_dtype,
+                                       /* non_blocking */ default_false,
+                                       /* copy */ default_false,
+                                       /* memory_format */ none};
+  Node* cast_to_fp16 = graph->create(Symbol::aten("to"), input_to_fp16);
+  graph->insertNode(cast_to_fp16);
+
+  auto fp16_out = cast_to_fp16->output();
+  std::vector<Value*> input_to_fp32 = {fp16_out,
+                                       float_dtype,
+                                       /* non_blocking */ default_false,
+                                       /* copy */ default_false,
+                                       /* memory_format */ none};
+  Node* cast_to_fp32 = graph->create(Symbol::aten("to"), input_to_fp32);
+  graph->insertNode(cast_to_fp32);
+  graph->lint();
+
+  return cast_to_fp32;
+}
+
+bool isNoopObserver(Value* observer) {
+  if (get_module_name(observer).has_value()) {
+    auto name = get_module_name(observer).value();
+    if (name == "__torch__.torch.quantization.observer.NoopObserver") {
+      return true;
+    }
+  }
+  return false;
+}
+
 void insertQuantizationOps(
     Module& module,
     Value* self,
@@ -211,7 +248,10 @@ void insertQuantizationOps(
   }
   Value* original_val = observer->input(1);
   Node *quant, *choose_qparams, *dequant;
-  if (quant_type == QuantType::DYNAMIC && !isWeight(module, observer_out)) {
+  if (quant_type == QuantType::DYNAMIC && isNoopObserver(observer->input(0))) {
+    dequant = insertFP16CastOps(g, observer_out);
+  } else if (
+      quant_type == QuantType::DYNAMIC && !isWeight(module, observer_out)) {
     Value* dtype = g->insertGetAttr(self, qparam_names.back());
     std::tie(choose_qparams, quant, dequant) = insertChooseQParamQuantDequant(
         g, observer_out, dtype, at::Symbol::aten(quantize_func));
@@ -231,12 +271,15 @@ void insertQuantizationOps(
   observer_out->replaceAllUsesWith(original_val);
   std::vector<Use> uses = original_val->uses();
   // TODO: use replaceAllUsesAfterNodeWith?
+  original_val->replaceAllUsesAfterNodeWith(dequant, dequant->output());
+  /*
   for (const auto& use : uses) {
     auto* user = use.user;
     if (user != quant && user != observer && user != choose_qparams) {
-      user->replaceInputWith(original_val, dequant->output());
+      //user->replaceInputWith(original_val, dequant->output());
+      user->replaceAllUsesAfterNodeWith(dequant, dequant->output());
     }
-  }
+  }*/
 }
 
 // find the observer for Value `v` and return the name of the observer
@@ -795,6 +838,12 @@ std::tuple<c10::QScheme, QParamVector> InsertQuantDeQuantHelper::
       "getQSchemeAndParamMap expects the corresponding observer for ",
       v->debugName(),
       " exists.");
+  QParamVector qparams;
+  c10::QScheme qscheme;
+
+  if (isNoopObserver(n->input(0))) {
+    return std::make_tuple(qscheme, qparams);
+  }
   auto observer_module = module.attr(observer_name.value()).toModule();
   auto calculate_qparams = observer_module.get_method("calculate_qparams");
   IValue result = calculate_qparams(std::vector<IValue>());
@@ -808,8 +857,8 @@ std::tuple<c10::QScheme, QParamVector> InsertQuantDeQuantHelper::
   at::Tensor zero_point = tp->elements()[1].toTensor().to(at::kInt);
   // quantization parameters should appear in the same order as
   // the argument for quantize_per_tensor/quantize_per_channel function
-  QParamVector qparams;
-  auto qscheme = observer_module.attr("qscheme").toQScheme();
+
+  qscheme = observer_module.attr("qscheme").toQScheme();
   if (isPerChannel(qscheme)) {
     auto axis = observer_module.attr("ch_axis");
     qparams.push_back(std::make_pair("_scale", scale));
@@ -1127,7 +1176,6 @@ void InsertQuantDeQuantHelper::run(
 
   Method method = module.get_method(method_name);
   auto graph = method.graph();
-
   // We only need to register new parameters if the graph has
   // been quantized before
   // TODO: dedup this part with code in quantizeTensors

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -218,8 +218,8 @@ Node* insertFP16CastOps(Graph* graph, Value* observer_out) {
 }
 
 bool isNoopObserver(Value* observer) {
-  if (get_module_name(observer).has_value()) {
-    auto name = get_module_name(observer).value();
+  if (getModuleName(observer).has_value()) {
+    auto name = getModuleName(observer).value();
     if (name == "__torch__.torch.quantization.observer.NoopObserver") {
       return true;
     }
@@ -256,6 +256,8 @@ void insertQuantizationOps(
     std::tie(choose_qparams, quant, dequant) = insertChooseQParamQuantDequant(
         g, observer_out, dtype, at::Symbol::aten(quantize_func));
   } else {
+    // Else branch is executed for dynamic weight observers and all observers
+    // for static quant.
     std::vector<Value*> inputs = {observer_out};
     // Insert GetAttr nodes for quantization parameters
     for (const auto& qparam_name : qparam_names) {

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -199,8 +199,7 @@ Node* insertFP16CastOps(Graph* graph, Value* observer_out) {
   std::vector<Value*> input_to_fp16 = {observer_out,
                                        fp16_dtype,
                                        /* non_blocking */ default_false,
-                                       /* copy */ default_false,
-                                       /* memory_format */ none};
+                                       /* copy */ default_false};
   Node* cast_to_fp16 = graph->create(Symbol::aten("to"), input_to_fp16);
   graph->insertNode(cast_to_fp16);
 
@@ -208,8 +207,7 @@ Node* insertFP16CastOps(Graph* graph, Value* observer_out) {
   std::vector<Value*> input_to_fp32 = {fp16_out,
                                        float_dtype,
                                        /* non_blocking */ default_false,
-                                       /* copy */ default_false,
-                                       /* memory_format */ none};
+                                       /* copy */ default_false};
   Node* cast_to_fp32 = graph->create(Symbol::aten("to"), input_to_fp32);
   graph->insertNode(cast_to_fp32);
   graph->lint();

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -269,17 +269,8 @@ void insertQuantizationOps(
     dequant = insertDeQuant(g, quant->output(), original_val);
   }
   observer_out->replaceAllUsesWith(original_val);
-  std::vector<Use> uses = original_val->uses();
-  // TODO: use replaceAllUsesAfterNodeWith?
+
   original_val->replaceAllUsesAfterNodeWith(dequant, dequant->output());
-  /*
-  for (const auto& use : uses) {
-    auto* user = use.user;
-    if (user != quant && user != observer && user != choose_qparams) {
-      //user->replaceInputWith(original_val, dequant->output());
-      user->replaceAllUsesAfterNodeWith(dequant, dequant->output());
-    }
-  }*/
 }
 
 // find the observer for Value `v` and return the name of the observer


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40710 [quant][graphmode] FP16 quant support - Operator Fusion
* **#40709 [quant][graphmode] FP16 quant support - Insert cast operators**
* #40708 [quant][graphmode] Add FP16 quant support - Insert Noop Observers

Summary:
Cast to kHalf and back to kFloat before the linear operator to mimic FP16 quant support

Test Plan:
python test/test_quantization.py test_convert_dynamic_fp16

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22335977](https://our.internmc.facebook.com/intern/diff/D22335977)