### PR TITLE
Fix zip serialization for file > 2GiB

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -674,6 +674,7 @@ class TestSerialization(TestCase, SerializationMixin):
         test(io.BytesIO())
 
     # Ensure large zip64 serialization works properly
+    @unittest.skipIf(IS_WINDOWS, '<built-in method read of BytesIOContext object at 0x0000022C21F2B468> returned a result with an error set')
     def test_serialization_2gb_file(self):
         big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -673,6 +673,15 @@ class TestSerialization(TestCase, SerializationMixin):
 
         test(io.BytesIO())
 
+    # Ensure large zip64 serialization works properly
+    def test_serialization_2gb_file(self):
+        big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
+
+        with BytesIOContext() as f:
+            torch.save(big_model, f)
+            f.seek(0)
+            state = torch.load(f)
+
     def run(self, *args, **kwargs):
         with serialization_method(use_zip=True):
             return super(TestSerialization, self).run(*args, **kwargs)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -674,7 +674,8 @@ class TestSerialization(TestCase, SerializationMixin):
         test(io.BytesIO())
 
     # Ensure large zip64 serialization works properly
-    @unittest.skipIf(IS_WINDOWS, '<built-in method read of BytesIOContext object at 0x0000022C21F2B468> returned a result with an error set')
+    @unittest.skipIf(IS_WINDOWS,
+        '<built-in method read of BytesIOContext object at 0x0000022C21F2B468> returned a result with an error set')
     def test_serialization_2gb_file(self):
         big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -675,7 +675,8 @@ class TestSerialization(TestCase, SerializationMixin):
 
     # Ensure large zip64 serialization works properly
     @unittest.skipIf(IS_WINDOWS,
-        '<built-in method read of BytesIOContext object at 0x0000022C21F2B468> returned a result with an error set')
+                     '<built-in method read of BytesIOContext object at 0x0000022C21F2B468> returned a result'
+                     ' with an error set')
     def test_serialization_2gb_file(self):
         big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -759,7 +759,7 @@ void initJITBindings(PyObject* module) {
         auto res =
             PyObject_CallMethod(buffer_.ptr(), "readinto", "O", memview.get());
         if (res) {
-          int i = PyInt_AsLong(res);
+          int64_t i = PyInt_AsLong(res);
           if (i > 0) {
             return i;
           }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40723 Support Pathlike for zipfile serialization
* **#40722 Fix zip serialization for file > 2GiB**

This narrowing conversion caused wrap-around of the value returned by python `readinto`, and thus everything went haywire since miniz thought that we weren't able to read enough data

Differential Revision: [D22294016](https://our.internmc.facebook.com/intern/diff/D22294016)