### PR TITLE
Avoid initializing `new_group` in test_backward_no_ddp.

### DIFF
--- a/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
@@ -190,7 +190,7 @@ class Trainer:
         rank: int,
     ):
         self.rank = rank
-        self.trainer_group = dist.new_group(TRAINER_RANKS)
+        self.trainer_group = dist.new_group(TRAINER_RANKS) if ddp_mode in (DdpMode.INSIDE, DdpMode.OUTSIDE) else None
         self.remote_em_rref = remote_em_rref
         self.remote_net_rref = remote_net_rref
         self.hybrid_module = HybridModel(
@@ -220,7 +220,8 @@ class Trainer:
         )
 
     def destroy_pg(self):
-        dist.destroy_process_group(self.trainer_group)
+        if self.trainer_group:
+            dist.destroy_process_group(self.trainer_group)
 
     def train_batch(self, mini_batch: FeatureSet):
         grads_dict = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40727 Avoid initializing `new_group` in test_backward_no_ddp.**

This unit test doesn't need to initialize a PG, as a result avoiding
initializing a process group.

#Closes: https://github.com/pytorch/pytorch/issues/40292

Differential Revision: [D22295131](https://our.internmc.facebook.com/intern/diff/D22295131/)