### PR TITLE
avoid division by 0 in div operator test

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -81,6 +81,9 @@ class ArithmeticOpsTest(serial.SerializedTestCase):
         for _ in range(num_iterations):
             A = np.random.uniform(low=-100.0, high=100.0, size=dims).astype(np.float32)
             B = np.random.uniform(low=-100.0, high=100.0, size=dims).astype(np.float32)
+            # Avoid dividing by 0
+            B[np.abs(B) < 1e-3] = 1e-3
+
             workspace.FeedBlob("A", A)
             workspace.FeedBlob("B", B)
             # Run caffe2 net


### PR DESCRIPTION
Summary: fix the div by 0 problem

Test Plan: ran tes_div test

Differential Revision: D22295934

