### PR TITLE
.circleci: Fix upload to backup directory

### DIFF
--- a/.circleci/scripts/binary_linux_upload.sh
+++ b/.circleci/scripts/binary_linux_upload.sh
@@ -44,5 +44,5 @@ fi
 
 if [[ -n "${CIRCLE_TAG:-}" ]]; then
   s3_dir="${BACKUP_BUCKET}/${CIRCLE_TAG}/${BACKUP_DIR}"
-  retry aws s3 cp "$(ls)" "$s3_dir"
+  retry aws s3 cp --recursive . "$s3_dir"
 fi

--- a/.circleci/scripts/binary_macos_upload.sh
+++ b/.circleci/scripts/binary_macos_upload.sh
@@ -44,5 +44,5 @@ fi
 
 if [[ -n "${CIRCLE_TAG:-}" ]]; then
   s3_dir="${BACKUP_BUCKET}/${CIRCLE_TAG}/${BACKUP_DIR}"
-  retry aws s3 cp "$(ls)" "$s3_dir"
+  retry aws s3 cp --recursive . "$s3_dir"
 fi

--- a/.circleci/scripts/binary_windows_upload.sh
+++ b/.circleci/scripts/binary_windows_upload.sh
@@ -43,5 +43,5 @@ fi
 
 if [[ -n "${CIRCLE_TAG:-}" ]]; then
   s3_dir="${BACKUP_BUCKET}/${CIRCLE_TAG}/${BACKUP_DIR}"
-  retry aws s3 cp "$(ls)" "$s3_dir"
+  retry aws s3 cp --recursive . "$s3_dir"
 fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40733 [JIT] Update type of the unsqueeze's output in shape analysis.
* **#40732 .circleci: Fix upload to backup directory**
* #40731 .circleci: Fix pip installation of awscli
* #40730 .circleci: Fix backup uploads

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>