### PR TITLE
.circleci: Remove executor from windows uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1250,14 +1250,6 @@ jobs:
 
   binary_windows_upload:
     <<: *binary_windows_params
-    parameters:
-      build_environment:
-        type: string
-        default: ""
-      executor:
-        type: string
-        default: "windows-medium-cpu-with-nvidia-cuda"
-    executor: <<parameters.executor>>
     docker:
       - image: continuumio/miniconda
     steps:

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -326,14 +326,6 @@
 
   binary_windows_upload:
     <<: *binary_windows_params
-    parameters:
-      build_environment:
-        type: string
-        default: ""
-      executor:
-        type: string
-        default: "windows-medium-cpu-with-nvidia-cuda"
-    executor: <<parameters.executor>>
     docker:
       - image: continuumio/miniconda
     steps:


### PR DESCRIPTION
This wasn't needed and broke nightly builds

Fixes some issues introduced in https://github.com/pytorch/pytorch/pull/40592/files

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

