### PR TITLE
Option in DataLoader to move tensors to a device.

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -57,3 +57,19 @@ def pin_memory(data):
         return data.pin_memory()
     else:
         return data
+
+
+def move_to_device(data, device):
+    r"""Attempts to send tensors contained in data to device."""
+    if isinstance(data, torch.Tensor):
+        return data.to(device)
+    elif isinstance(data, string_classes):
+        return data
+    elif isinstance(data, container_abcs.Mapping):
+        return {k: move_to_device(sample, device) for k, sample in data.items()}
+    elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
+        return type(data)(*(move_to_device(sample, device) for sample in data))
+    elif isinstance(data, container_abcs.Sequence):
+        return [move_to_device(sample, device) for sample in data]
+    else:
+        return data

--- a/torch/utils/data/dataloader.pyi
+++ b/torch/utils/data/dataloader.pyi
@@ -2,6 +2,7 @@ from typing import Any, Callable, TypeVar, Generic, overload, Sequence, List, Op
 from . import Dataset, Sampler
 
 from torch.utils.data._utils.worker import get_worker_info as get_worker_info
+from torch.types import _device
 
 T_co = TypeVar('T_co', covariant=True)
 T = TypeVar('T')
@@ -26,11 +27,11 @@ class DataLoader(Generic[T_co]):
     def __init__(self, dataset: Dataset[T_co], batch_size: int=..., shuffle: bool=...,
                  sampler: Optional[Sampler[int]]=..., num_workers: int=..., collate_fn: _collate_fn_t=...,
                  pin_memory: bool=..., drop_last: bool=..., timeout: float=...,
-                 worker_init_fn: _worker_init_fn_t=...) -> None: ...
+                 worker_init_fn: _worker_init_fn_t=..., device: Optional[Union[_device, str]]=...) -> None: ...
     @overload
     def __init__(self, dataset: Dataset[T_co], batch_sampler: Optional[Sampler[Sequence[int]]]=...,
                  num_workers: int=..., collate_fn: _collate_fn_t=..., pin_memory: bool=..., timeout: float=...,
-                 worker_init_fn: _worker_init_fn_t=...) -> None: ...
+                 worker_init_fn: _worker_init_fn_t=..., device: Optional[Union[_device, str]]=...) -> None: ...
 
     def __len__(self) -> int: ...
     # We quote '_BaseDataLoaderIter' since it isn't defined yet and the definition can't be moved up
@@ -38,6 +39,13 @@ class DataLoader(Generic[T_co]):
     # analyzer is used that obviates the need for this but we leave the quoting in to support older
     # versions of mypy
     def __iter__(self) -> '_BaseDataLoaderIter':...
+
+    def to(self, device: Optional[Union[_device, str]]=..., pin_memory: Optional[bool]=...) -> DataLoader: ...
+
+    def cpu(self, pin_memory: Optional[bool]=False) -> DataLoader: ...
+
+    def cuda(self, pin_memory: Optional[bool]=True) -> DataLoader: ...
+
 
 class _BaseDataLoaderIter:
     def __init__(self, loader: DataLoader) -> None:...


### PR DESCRIPTION
Implemented the option in DataLoader to move the tensors inside the mini-batches to a specific device. Example:
```
loader = torch.utils.data.DataLoader(dataset, batch_size=30, device="cuda")
x, y = next(iter(loader))

assert x.device.type == "cuda"
```
Alternatively, one can use similar semantics to torch.tensor and nn.Module with `.to(device)`
`.cuda()` and `.cpu()` functions returning new DataLoader instances.

Specifying the device on a DataLoader is a convenient and intuitive functionality, particularly in interactive contexts, where it can be exhausting to move each tensor manually.

The code should be completely backwards compatible.
