### PR TITLE
Reverts running clang-tidy on ATen

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -154,7 +154,7 @@ jobs:
           # caffe2_pb.h, otherwise we'd have to build protos as part of this CI job.
           python tools/clang_tidy.py                               \
             --verbose                                              \
-            --paths torch/csrc/ aten/src/ATen/                     \
+            --paths torch/csrc/                                    \
             --diff "$MERGE_BASE"                                   \
             -g"-torch/csrc/jit/serialization/export.cpp"           \
             -g"-torch/csrc/jit/serialization/import.cpp"           \

--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -8,7 +8,7 @@ if [ $(which clang-tidy) ]
 then
   echo "Running pre-commit clang-tidy"
   python tools/clang_tidy.py \
-    --paths torch/csrc aten/src/ATen/ \
+    --paths torch/csrc \
     --diff HEAD \
     -g"-torch/csrc/jit/serialization/export.cpp" \
     -g"-torch/csrc/jit/serialization/import.cpp" \


### PR DESCRIPTION
Reverts https://github.com/pytorch/pytorch/pull/39713.

We are seeing CUDA-related clang-tidy failures on multiple PRs after the above change. The cause of these failures is unclear. Example error message:

```
2020-06-26T18:45:10.9763273Z + python tools/clang_tidy.py --verbose --paths torch/csrc/ aten/src/ATen/ --diff 5036c94a6e868963e0354fc04c92e204d8d77677 -g-torch/csrc/jit/serialization/export.cpp -g-torch/csrc/jit/serialization/import.cpp -g-torch/csrc/jit/serialization/import_legacy.cpp -g-torch/csrc/onnx/init.cpp '-g-torch/csrc/cuda/nccl.*' -g-torch/csrc/cuda/python_nccl.cpp
2020-06-26T18:45:11.1990578Z Error while processing /home/runner/work/pytorch/pytorch/aten/src/ATen/native/cuda/UnaryOpsKernel.cu.
2020-06-26T18:45:11.1992832Z Found compiler error(s).
2020-06-26T18:45:11.2286995Z Traceback (most recent call last):
2020-06-26T18:45:11.2288334Z   File "tools/clang_tidy.py", line 55, in run_shell_command
2020-06-26T18:45:11.2288607Z     output = subprocess.check_output(arguments).decode().strip()
2020-06-26T18:45:11.2289053Z   File "/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/subprocess.py", line 411, in check_output
2020-06-26T18:45:11.2289337Z     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
2020-06-26T18:45:11.2289786Z   File "/opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/subprocess.py", line 512, in run
2020-06-26T18:45:11.2290038Z     raise CalledProcessError(retcode, process.args,
2020-06-26T18:45:11.2292206Z subprocess.CalledProcessError: Command '['clang-tidy', '-p', 'build', '-config', '{"Checks": "-*, bugprone-*, -bugprone-forward-declaration-namespace, -bugprone-macro-parentheses, -bugprone-lambda-function-name, cppcoreguidelines-*, -cppcoreguidelines-interfaces-global-init, -cppcoreguidelines-owning-memory, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -cppcoreguidelines-pro-bounds-constant-array-index, -cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-type-cstyle-cast, -cppcoreguidelines-pro-type-reinterpret-cast, -cppcoreguidelines-pro-type-static-cast-downcast, -cppcoreguidelines-pro-type-union-access, -cppcoreguidelines-pro-type-vararg, -cppcoreguidelines-special-member-functions, hicpp-exception-baseclass, hicpp-avoid-goto, modernize-*, -modernize-return-braced-init-list, -modernize-use-auto, -modernize-use-default-member-init, -modernize-use-using, -modernize-use-trailing-return-type, performance-*, -performance-noexcept-move-constructor, ", "HeaderFilterRegex": "torch/csrc/.*", "AnalyzeTemporaryDtors": false, "CheckOptions": null}', '-line-filter', '[{"name": "aten/src/ATen/native/cuda/UnaryOpsKernel.cu", "lines": [[10, 11], [29, 30]]}]', 'aten/src/ATen/native/cuda/UnaryOpsKernel.cu']' returned non-zero exit status 1.
2020-06-26T18:45:11.2292551Z 
2020-06-26T18:45:11.2292684Z During handling of the above exception, another exception occurred:
2020-06-26T18:45:11.2292775Z 
2020-06-26T18:45:11.2292894Z Traceback (most recent call last):
2020-06-26T18:45:11.2293208Z   File "tools/clang_tidy.py", line 306, in <module>
2020-06-26T18:45:11.2293364Z     main()
2020-06-26T18:45:11.2293817Z   File "tools/clang_tidy.py", line 298, in main
2020-06-26T18:45:11.2293980Z     clang_tidy_output = run_clang_tidy(options, line_filters, files)
2020-06-26T18:45:11.2294282Z   File "tools/clang_tidy.py", line 191, in run_clang_tidy
2020-06-26T18:45:11.2294439Z     output = run_shell_command(command)
2020-06-26T18:45:11.2294703Z   File "tools/clang_tidy.py", line 59, in run_shell_command
2020-06-26T18:45:11.2294931Z     raise RuntimeError("Error executing {}: {}".format(" ".join(arguments), error_output))
2020-06-26T18:45:11.2296875Z RuntimeError: Error executing clang-tidy -p build -config {"Checks": "-*, bugprone-*, -bugprone-forward-declaration-namespace, -bugprone-macro-parentheses, -bugprone-lambda-function-name, cppcoreguidelines-*, -cppcoreguidelines-interfaces-global-init, -cppcoreguidelines-owning-memory, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -cppcoreguidelines-pro-bounds-constant-array-index, -cppcoreguidelines-pro-bounds-pointer-arithmetic, -cppcoreguidelines-pro-type-cstyle-cast, -cppcoreguidelines-pro-type-reinterpret-cast, -cppcoreguidelines-pro-type-static-cast-downcast, -cppcoreguidelines-pro-type-union-access, -cppcoreguidelines-pro-type-vararg, -cppcoreguidelines-special-member-functions, hicpp-exception-baseclass, hicpp-avoid-goto, modernize-*, -modernize-return-braced-init-list, -modernize-use-auto, -modernize-use-default-member-init, -modernize-use-using, -modernize-use-trailing-return-type, performance-*, -performance-noexcept-move-constructor, ", "HeaderFilterRegex": "torch/csrc/.*", "AnalyzeTemporaryDtors": false, "CheckOptions": null} -line-filter [{"name": "aten/src/ATen/native/cuda/UnaryOpsKernel.cu", "lines": [[10, 11], [29, 30]]}] aten/src/ATen/native/cuda/UnaryOpsKernel.cu: error: cannot find libdevice for sm_20. Provide path to different CUDA installation via --cuda-path, or pass -nocudalib to build without linking with libdevice. [clang-diagnostic-error]
2020-06-26T18:45:11.2313329Z error: unable to handle compilation, expected exactly one compiler job in ' "/usr/bin/c++" "-cc1" "-triple" "x86_64-pc-linux-gnu" "-aux-triple" "nvptx64-nvidia-cuda" "-fsyntax-only" "-disable-free" "-disable-llvm-verifier" "-discard-value-names" "-main-file-name" "UnaryOpsKernel.cu" "-mrelocation-model" "pic" "-pic-level" "2" "-mthread-model" "posix" "-fno-trapping-math" "-masm-verbose" "-mconstructor-aliases" "-munwind-tables" "-fuse-init-array" "-target-cpu" "x86-64" "-dwarf-column-info" "-debugger-tuning=gdb" "-momit-leaf-frame-pointer" "-resource-dir" "/usr/lib/llvm-8/bin/../lib/clang/8.0.1" "-internal-isystem" "/usr/lib/llvm-8/bin/../lib/clang/8.0.1/include/cuda_wrappers" "-internal-isystem" "/usr/local/cuda/include" "-include" "__clang_cuda_runtime_wrapper.h" "-isystem" "/home/runner/work/pytorch/pytorch/build/third_party/gloo" "-isystem" "/home/runner/work/pytorch/pytorch/cmake/../third_party/gloo" "-isystem" 
```

My guess is that our clang-tidy build is improperly configured to handle CUDA code. Until that issue is resolved this stops running clang-tidy on ATen. 