### PR TITLE
Fix the autograd codegen for repeat function

### DIFF
--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -310,6 +310,11 @@ def saved_variables(formula, args):
             'suffix': '_scalar_type',
             'type': 'ScalarType',
         }),
+        # replace self.dim() with self_dim
+        (r'{}.dim\(\)', {
+            'suffix': '_dim',
+            'type': 'int64_t',
+        }),
     ]
 
     for arg in args:


### PR DESCRIPTION
Fix #40701

A new special case is added to let `dim()` save an int instead of self.


