### PR TITLE
Fix zip serialization for file > 2GiB for Windows

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -675,9 +675,6 @@ class TestSerialization(TestCase, SerializationMixin):
         test(io.BytesIO())
 
     # Ensure large zip64 serialization works properly
-    @unittest.skipIf(IS_WINDOWS,
-                     '<built-in method read of BytesIOContext object at 0x0000022C21F2B468> returned a result'
-                     ' with an error set')
     def test_serialization_2gb_file(self):
         big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -748,7 +748,11 @@ void initJITBindings(PyObject* module) {
         auto res =
             PyObject_CallMethod(buffer_.ptr(), "readinto", "O", memview.get());
         if (res) {
-          int64_t i = PyInt_AsLong(res);
+#ifdef _MSC_VER
+          int64_t i = PyLong_AsLongLong(res);
+#else
+          int64_t i = PyLong_AsLong(res);
+#endif
           if (i > 0) {
             return i;
           }

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -748,11 +748,7 @@ void initJITBindings(PyObject* module) {
         auto res =
             PyObject_CallMethod(buffer_.ptr(), "readinto", "O", memview.get());
         if (res) {
-#ifdef _MSC_VER
-          int64_t i = PyLong_AsLongLong(res);
-#else
-          int64_t i = PyLong_AsLong(res);
-#endif
+          int64_t i = static_cast<int64_t>(PyLong_AsLongLong(res));
           if (i > 0) {
             return i;
           }


### PR DESCRIPTION
`long long == int64_t != long` in MSVC