### PR TITLE
Refactor duplicated string literals

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -26,28 +26,28 @@ GENERATED_CPP = [
     "autograd/generated/python_variable_methods.cpp",
 ]
 
-libtorch_generated_sources = [
-    ":generate-code[autograd/generated/Functions.cpp]",
-    ":generate-code[jit/generated/generated_unboxing_wrappers_0.cpp]",
-    ":generate-code[jit/generated/generated_unboxing_wrappers_1.cpp]",
-    ":generate-code[jit/generated/generated_unboxing_wrappers_2.cpp]",
-    ":generate-code[autograd/generated/VariableType_0.cpp]",
-    ":generate-code[autograd/generated/VariableType_1.cpp]",
-    ":generate-code[autograd/generated/VariableType_2.cpp]",
-    ":generate-code[autograd/generated/VariableType_3.cpp]",
-    ":generate-code[autograd/generated/VariableType_4.cpp]",
-    ":generate-code[autograd/generated/ProfiledType_0.cpp]",
-    ":generate-code[autograd/generated/ProfiledType_1.cpp]",
-    ":generate-code[autograd/generated/ProfiledType_2.cpp]",
-    ":generate-code[autograd/generated/ProfiledType_3.cpp]",
-    ":generate-code[autograd/generated/ProfiledType_4.cpp]",
-    ":generate-code[autograd/generated/TraceType_0.cpp]",
-    ":generate-code[autograd/generated/TraceType_1.cpp]",
-    ":generate-code[autograd/generated/TraceType_2.cpp]",
-    ":generate-code[autograd/generated/TraceType_3.cpp]",
-    ":generate-code[autograd/generated/TraceType_4.cpp]",
-    "torch/csrc/autograd/VariableTypeManual.cpp",
-]
+def libtorch_generated_sources(gencode_pattern):
+    return [gencode_pattern.format(name) for name in [
+    "autograd/generated/Functions.cpp",
+    "jit/generated/generated_unboxing_wrappers_0.cpp",
+    "jit/generated/generated_unboxing_wrappers_1.cpp",
+    "jit/generated/generated_unboxing_wrappers_2.cpp",
+    "autograd/generated/VariableType_0.cpp",
+    "autograd/generated/VariableType_1.cpp",
+    "autograd/generated/VariableType_2.cpp",
+    "autograd/generated/VariableType_3.cpp",
+    "autograd/generated/VariableType_4.cpp",
+    "autograd/generated/ProfiledType_0.cpp",
+    "autograd/generated/ProfiledType_1.cpp",
+    "autograd/generated/ProfiledType_2.cpp",
+    "autograd/generated/ProfiledType_3.cpp",
+    "autograd/generated/ProfiledType_4.cpp",
+    "autograd/generated/TraceType_0.cpp",
+    "autograd/generated/TraceType_1.cpp",
+    "autograd/generated/TraceType_2.cpp",
+    "autograd/generated/TraceType_3.cpp",
+    "autograd/generated/TraceType_4.cpp",
+    ]] + ["torch/csrc/autograd/VariableTypeManual.cpp"]
 
 # copied from https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/CMakeLists.txt
 jit_core_headers = [
@@ -316,7 +316,8 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
     "torch/csrc/utils/byte_order.cpp",
 ]
 
-libtorch_sources = libtorch_generated_sources + libtorch_core_sources + libtorch_distributed_sources + libtorch_extra_sources
+def libtorch_sources(gencode_pattern=":generate-code[{}]"):
+    return libtorch_generated_sources(gencode_pattern) + libtorch_core_sources + libtorch_distributed_sources + libtorch_extra_sources
 
 libtorch_cuda_sources = [
     "torch/csrc/cuda/comm.cpp",
@@ -529,13 +530,13 @@ libtorch_python_distributed_sources = [
     "torch/csrc/jit/runtime/register_distributed_ops.cpp",
 ]
 
-def glob_libtorch_python_sources():
-    _libtorch_python_sources = [
-        ":generate-code[autograd/generated/python_functions.cpp]",
-        ":generate-code[autograd/generated/python_nn_functions.cpp]",
-        ":generate-code[autograd/generated/python_torch_functions.cpp]",
-        ":generate-code[autograd/generated/python_variable_methods.cpp]",
-    ]
+def glob_libtorch_python_sources(gencode_pattern=":generate-code[{}]"):
+    _libtorch_python_sources = [gencode_pattern.format(name) for name in [
+        "autograd/generated/python_functions.cpp",
+        "autograd/generated/python_nn_functions.cpp",
+        "autograd/generated/python_torch_functions.cpp",
+        "autograd/generated/python_variable_methods.cpp",
+    ]]
 
     _libtorch_python_sources.extend(libtorch_python_core_sources)
     _libtorch_python_sources.extend(libtorch_python_distributed_sources)


### PR DESCRIPTION
Summary: Avoid repeated the same `:gencode[foo/bar]` over and over again

Test Plan: CI

Reviewed By: EscapeZero

Differential Revision: D22271151

