### PR TITLE
[jit] preserve keys on dictionary input tracing

### DIFF
--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -570,30 +570,70 @@ class TestTracer(JitTestCase):
         with self.assertRaises(RuntimeError):
             self.checkTrace(test, {})
 
-    def test_input_dict_flattens(self):
-        class Test(torch.nn.Module):
-            def forward(self, d):
-                return d['x'] + d['y']
+    def test_input_dict_remembers_keys(self):
+        """Check that the trace remembers which keys were in a dict input"""
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
 
-        inputs = {'x': torch.rand(3, 4), 'y': torch.rand(3, 4)}
-        module = torch.jit.trace(Test(), inputs)
+            def forward(self, dict_input):
+                return dict_input['x']
 
-        FileCheck().check('aten::values').check('prim::ListUnpack').run(str(module.graph))
+        input_1 = {'x': torch.tensor(1)}
+        m = TestModule()
+        m_traced = torch.jit.trace(m, (input_1, ))
+        self.assertEqual(m_traced(input_1), torch.tensor(1))
 
-    def test_input_dict_flattens_recursive(self):
-        class Test(torch.nn.Module):
-            def forward(self, d):
-                # Use both to avoid getting optimized away
-                a = d['x'][0]
-                b, c = d['y']
-                return a + b
+        # should work to change the values and not the keys
+        input_same_key_different_value = {'x': torch.tensor(2)}
+        self.assertEqual(m_traced(input_same_key_different_value), torch.tensor(2))
 
-        inputs = {'x': (torch.rand(2, 2), torch.rand(2, 2)), 'y': (torch.ones(1, 1), torch.ones(2, 1))}
-        module = torch.jit.trace(Test(), inputs)
-        FileCheck().check('aten::values') \
-                   .check('prim::ListUnpack') \
-                   .check_count('prim::TupleUnpack', 2) \
-                   .run(str(module.graph))
+        # error to use something that doesn't have `x`
+        input_different_key = {'y': torch.tensor(3)}
+        with self.assertRaises(RuntimeError):
+            m_traced(input_different_key)
+
+        # it's okay to have additional elements in the dictionary, so long as 'x' is there
+        input_additional_key = {'x': torch.tensor(4), 'y': torch.tensor(3)}
+        self.assertEqual(m_traced(input_additional_key), torch.tensor(4))
+
+    def test_input_dict_insertion_order(self):
+        """Check that dictionary access doesn't care about insertion order"""
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+
+            def forward(self, dict_input):
+                return dict_input['x'], dict_input['y']
+        input_x_then_y = {}
+        input_x_then_y['x'] = torch.tensor(1)
+        input_x_then_y['y'] = torch.tensor(2)
+
+        m = TestModule()
+        m_traced = torch.jit.trace(m, (input_x_then_y, ))
+
+        self.assertEqual(m_traced(input_x_then_y), (torch.tensor(1), torch.tensor(2)))
+
+        input_y_then_x = {}
+        input_y_then_x['y'] = torch.tensor(4)
+        input_y_then_x['x'] = torch.tensor(3)
+
+        self.assertEqual(m_traced(input_y_then_x), (torch.tensor(3), torch.tensor(4)))
+
+    def test_input_dict_recursive(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+
+            def forward(self, dict_input):
+                return dict_input['x'][1]
+
+        input_1 = {'x': {1: torch.tensor(1)}}
+        m = TestModule()
+        m_traced = torch.jit.trace(m, (input_1, ))
+
+        input_2 = {'x': {1: torch.tensor(2)}}
+        self.assertEqual(m_traced(input_2), torch.tensor(2))
 
     def test_input_dict_checkTrace_mut(self):
         def test(d):
@@ -2074,8 +2114,5 @@ class TestMixTracingScripting(JitTestCase):
         input_map = {"1" : [torch.rand(2, 2), torch.rand(2, 2)], "3" : [torch.rand(2, 2), torch.rand(2, 2)]}
         model = testA()
         traced_model = torch.jit.trace(model, input_map)
-        # the dict should not be inlined as constants in the IR
-        self.assertFalse("CONSTANTS" in str(traced_model.code))
-
-        new_input_map = {"new1" : [torch.rand(2, 2), torch.randn(2, 2)], "new3" : [torch.rand(2, 2), torch.rand(2, 2)]}
+        new_input_map = {"1" : [torch.rand(2, 2), torch.randn(2, 2)], "3" : [torch.rand(2, 2), torch.rand(2, 2)]}
         self.assertEqual(model(new_input_map), traced_model(new_input_map))

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -329,7 +329,8 @@ static IValue addInput(
     for (const auto& entry : dict) {
       IValue key = entry.key();
       auto static_key = state->graph->insertConstant(key);
-      auto static_value = state->graph->insert(aten::__getitem__, {value, static_key});
+      auto static_value =
+          state->graph->insert(aten::__getitem__, {value, static_key});
       recordSourceLocation(static_value->node());
       dict.insert_or_assign(
           entry.key(),

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -325,24 +325,16 @@ static IValue addInput(
   } else if (auto dict_type = type->cast<DictType>()) {
     auto dict = input.toGenericDict();
 
-    auto dict_size = dict.size();
-    auto unpack_to_list = state->graph->insert(aten::values, {value});
-    auto list_unpack =
-        state->graph->createListUnpack(unpack_to_list, dict_size);
-    auto unpack_node = state->graph->insertNode(list_unpack);
-    auto elem_values = unpack_node->outputs();
-
-    AT_ASSERT(dict.size() == elem_values.size());
-
-    size_t i = 0;
+    // Unpack the list values statically
     for (const auto& entry : dict) {
+      IValue key = entry.key();
+      auto static_key = state->graph->insertConstant(key);
+      auto static_value = state->graph->insert(aten::__getitem__, {value, static_key});
+      recordSourceLocation(static_value->node());
       dict.insert_or_assign(
           entry.key(),
           addInput(
-              state,
-              entry.value(),
-              dict_type->getValueType(),
-              elem_values[i++]));
+              state, entry.value(), dict_type->getValueType(), static_value));
     }
 
     return dict;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40807 [jit] move private implementation out of `jit/__init__.py`
* **#40792 [jit] preserve keys on dictionary input tracing**

Fixes https://github.com/pytorch/pytorch/issues/40529.

One followup should be to produce a better error message when a new
dictionary has different keys than the traced input. Right now it
presents as a fairly opaque `KeyError`.

Differential Revision: [D22311731](https://our.internmc.facebook.com/intern/diff/D22311731)