### PR TITLE
[1.6] Fix dictConstruct ordering and enable dict mix in tracing/scripting

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1445,6 +1445,15 @@ class TestDict(JitTestCase):
 
         test_func(test_dict_constructor, ())
 
+        def test_dict_initializer_list():
+            a = {"1": torch.tensor(1), "2": torch.tensor(2)}
+            output_order = []
+            for key in a:
+                output_order.append(a[key])
+            return output_order
+
+        test_func(test_dict_initializer_list, ())
+
         def test_dict_error():
             a = dict()
             a[1] = 2

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -106,6 +106,18 @@ Value* TracingState::getValue(const IValue& var) {
             var.toTuple()->elements(),
             [&](const IValue& val) { return getValue(val); })))
         ->output();
+  } else if (var.isGenericDict()) {
+    auto dict = var.toGenericDict();
+    TypePtr key_type = dict.keyType();
+    TypePtr value_type = dict.valueType();
+    std::vector<Value*> keys;
+    std::vector<Value*> values;
+    for (const auto& entry : dict) {
+      keys.emplace_back(getValue(entry.key()));
+      values.emplace_back(getValue(entry.value()));
+    }
+    auto dict_node = graph->createDict(key_type, value_type, keys, values);
+    return graph->insertNode(dict_node)->output();
   }
   if (var.isTensor()) {
     auto ten = var.toTensor();

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -83,11 +83,15 @@ void dictConstruct(Stack& stack, at::DictTypePtr type, size_t num_inputs) {
   at::TypePtr value_type = type->getValueType();
   auto vals = c10::impl::GenericDict(key_type, value_type);
   vals.reserve(num_inputs / 2);
+  // loop from the bottom of the stack to ensure the dictConstruct preserve
+  // the inputs order.
+  auto inputs = last(stack, num_inputs);
   for (size_t i = 0; i < num_inputs; i += 2) {
-    auto val = pop(stack);
-    auto key = pop(stack);
+    auto key = inputs[i];
+    auto val = inputs[i + 1];
     vals.insert_or_assign(std::move(key), std::move(val));
   }
+  drop(stack, num_inputs);
   push(stack, std::move(vals));
 }
 


### PR DESCRIPTION
A combination of https://github.com/pytorch/pytorch/pull/39601 and
https://github.com/pytorch/pytorch/pull/40424 both are approved and
merged in master

