### PR TITLE
Accelerated 3D depthwise convolution implementation

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -298,7 +298,7 @@ auto ConvParams::is_depthwise(
         const at::Tensor& input, const at::Tensor& weight) const -> bool {
   return input.is_cuda() &&
          !transposed &&
-         input.ndimension() == 4 &&
+         (input.ndimension() == 4 || input.ndimension() == 5) &&
          input.size(1) == groups &&
          groups > 1 && // no point if there is only a single group
          weight.size(0) % input.size(1) == 0; // output channels must be a multiple of input channels
@@ -426,7 +426,7 @@ auto ConvParams::use_cudnn_depthwise(
                          use_cudnn(input, weight) &&
                          input.scalar_type() == kHalf && // only for FP16
                          weight.scalar_type() == kHalf &&
-                         is_depthwise(input, weight) &&
+                         is_depthwise(input, weight) && input.ndimension() == 4 &&
                          weight.size(2) == weight.size(3) && // only square kernels
                          input.size(2) >= 7 && // min width/height 7
                          !is_dilated() && // no dilation supported
@@ -696,7 +696,13 @@ at::Tensor _convolution(
             params.padding, params.stride, params.dilation, params.groups);
 #endif
       } else {
-          output = at::thnn_conv_depthwise2d(input.contiguous(), weight, kernel_size, bias, stride, padding, dilation);
+          if (input.ndimension() == 4) {
+              output = at::thnn_conv_depthwise2d(input.contiguous(), weight, kernel_size, bias, stride, padding, dilation);
+          }
+          else { 
+              TORCH_CHECK(input.ndimension() == 5);
+              output = at::conv_depthwise3d(input.contiguous(), weight, kernel_size, bias, stride, padding, dilation);
+          }
       }
   } else if (params.use_cudnn(input, weight)) {
     TORCH_CHECK(input.options().type_equal(weight.options()),

--- a/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
@@ -1,0 +1,655 @@
+#include <ATen/cuda/detail/KernelUtils.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include <algorithm>
+#include <tuple>
+#include <limits>
+
+namespace at {
+namespace native {
+namespace {
+
+template <typename scalar_t, 
+         int kKnownKernelT, int kKnownKernelH, int kKnownKernelW,
+         int kKnownDilationT, int kKnownDilationH, int kKnownDilationW>
+__global__ void conv_depthwise3d_cuda_kernel(
+    const PackedTensorAccessor32<scalar_t, 5> input,
+    PackedTensorAccessor32<scalar_t, 5> output,
+    const PackedTensorAccessor32<scalar_t, 5> kernel,
+    const scalar_t* bias,
+    int dT, int dH, int dW,
+    int pT, int pH, int pW,
+    int dilationT_, int dilationH_, int dilationW_)
+{
+  const int kT = kKnownKernelT > 0 ? kKnownKernelT : kernel.size(2);
+  const int kH = kKnownKernelH > 0 ? kKnownKernelH : kernel.size(3);
+  const int kW = kKnownKernelW > 0 ? kKnownKernelW : kernel.size(4);
+  const int oC = output.size(1);
+  const int oT = output.size(2);
+  const int oH = output.size(3);
+  const int oW = output.size(4);
+  const int iC = input.size(1);
+  const int iT = input.size(2);
+  const int iH = input.size(3);
+  const int iW = input.size(4);
+  const int channel_multiplier = oC / iC;
+  const int dilationT = kKnownDilationT > 0 ? kKnownDilationT : dilationT_;
+  const int dilationH = kKnownDilationH > 0 ? kKnownDilationH : dilationH_;
+  const int dilationW = kKnownDilationW > 0 ? kKnownDilationW : dilationW_;
+  const int num_output = output.size(0) * output.stride(0);
+
+  CUDA_KERNEL_LOOP(index, num_output) {
+    const int out_col = index % oW;
+    const int out_row = (index / oW) % oH;
+    const int out_frame = (index / oW / oH) % oT;
+    const int out_channel = (index / oW / oH / oT) % oC;
+    const int batch = index / oW / oH / oT / oC;
+
+    const int in_channel = out_channel / channel_multiplier;
+    
+    const int in_col_start = out_col * dW - pW;
+    const int in_row_start = out_row * dH - pH;
+    const int in_frame_start = out_frame * dT - pT;
+
+    scalar_t sum = (scalar_t)0;
+    const scalar_t *kernel_ptr = kernel[out_channel].data();
+    const scalar_t *input_ptr = 
+      &input[batch][in_channel][in_frame_start][in_row_start][in_col_start];
+    for (int k_frame = 0; k_frame < kT; ++k_frame) {
+      const int in_frame = in_frame_start + k_frame * dilationT;
+      for (int k_row = 0; k_row < kH; ++k_row) {
+        const int in_row = in_row_start + k_row * dilationH;
+        for (int k_col = 0; k_col < kW; ++k_col) {
+          const scalar_t op1 = __ldg(kernel_ptr++);
+          const int in_col = in_col_start + k_col * dilationW;
+          if (in_frame >= 0 && in_row >= 0 && in_col >= 0 &&
+              in_frame < iT && in_row < iH && in_col < iW) {
+            sum += op1 * __ldg(input_ptr);
+          }
+          input_ptr += dilationW;
+        }
+        input_ptr += iW * dilationH - kW * dilationW;
+      }
+      input_ptr += iW * (iH * dilationT - kH * dilationH);
+    }
+    if (bias != NULL) {
+      sum += bias[out_channel];
+    }
+
+    output[batch][out_channel][out_frame][out_row][out_col] = sum;
+  }
+}
+
+template <typename scalar_t,
+         int kKnownKernelT, int kKnownKernelH, int kKnownKernelW,
+         int kKnownDilationT, int kKnownDilationH, int kKnownDilationW,
+         int kKnownStrideT, int kKnownStrideH, int kKnownStrideW>
+__global__ void 
+conv_depthwise3d_cuda_backward_input_kernel(
+    const PackedTensorAccessor32<scalar_t, 5> grad_output,
+    PackedTensorAccessor32<scalar_t, 5> grad_input,
+    const PackedTensorAccessor32<scalar_t, 5> kernel,
+    int dT_, int dH_, int dW_,
+    int pT, int pH, int pW, 
+    int dilationT_, int dilationH_, int dilationW_) {
+  const int kT = kKnownKernelT > 0 ? kKnownKernelT : kernel.size(2);
+  const int kH = kKnownKernelH > 0 ? kKnownKernelH : kernel.size(3);
+  const int kW = kKnownKernelW > 0 ? kKnownKernelW : kernel.size(4);
+  const int oC = grad_output.size(1);
+  const int oT = grad_output.size(2);
+  const int oH = grad_output.size(3);
+  const int oW = grad_output.size(4);
+  const int iC = grad_input.size(1);
+  const int iT = grad_input.size(2);
+  const int iH = grad_input.size(3);
+  const int iW = grad_input.size(4);
+  const int channel_multiplier = oC / iC;
+  const int dilationT = kKnownDilationT > 0 ? kKnownDilationT : dilationT_;
+  const int dilationH = kKnownDilationH > 0 ? kKnownDilationH : dilationH_;
+  const int dilationW = kKnownDilationW > 0 ? kKnownDilationW : dilationW_;
+  const int dT = kKnownStrideT > 0 ? kKnownStrideT : dT_;
+  const int dH = kKnownStrideH > 0 ? kKnownStrideH : dH_;
+  const int dW = kKnownStrideW > 0 ? kKnownStrideW : dW_;
+  const int num_input = grad_input.size(0) * grad_input.stride(0);
+
+  CUDA_KERNEL_LOOP(index, num_input) {
+    const int in_col = index % iW;
+    const int in_row = (index / iW) % iH;
+    const int in_frame = (index / iW / iH) % iT;
+    const int in_channel = (index / iW / iH / iT) % iC;
+    const int batch = index / iW / iH / iT / iC;
+
+    const int out_col_end = in_col + pW;
+    const int out_row_end = in_row + pH;
+    const int out_frame_end = in_frame + pT;
+
+    const scalar_t* kernel_ptr = kernel[in_channel * channel_multiplier].data();
+    scalar_t sum = (scalar_t)0;
+
+    for (int k_chn = in_channel * channel_multiplier;
+        k_chn < (in_channel + 1) * channel_multiplier;
+        ++k_chn) {
+      const scalar_t* gout_ptr = grad_output[batch][k_chn].data();
+
+      for (int k_frame = 0; k_frame < kT; ++k_frame) {
+        const int out_frame_raw = out_frame_end - k_frame * dilationT;
+        const int out_frame = out_frame_raw / dT;
+        for (int k_row = 0; k_row < kH; ++k_row) {
+          const int out_row_raw = out_row_end - k_row * dilationH;
+          const int out_row = out_row_raw / dH;
+          for (int k_col = 0; k_col < kW; ++k_col) {
+            const scalar_t op1 = __ldg(kernel_ptr++);
+            const int out_col_raw = out_col_end - k_col * dilationW;
+            const int out_col = out_col_raw / dW;
+
+            const int out_offs = (out_frame * oH + out_row) * oW + out_col;
+
+            scalar_t op2 = (scalar_t)0;
+            if (out_col >= 0 && out_row >= 0 && out_frame >= 0 &&
+                out_col < oW && out_row < oH && out_frame < oT) {
+              op2 = __ldg(gout_ptr + out_offs);
+            }
+            if (out_frame * dT == out_frame_raw &&
+                out_row * dH == out_row_raw &&
+                out_col * dW == out_col_raw) {
+              sum += op1 * op2;
+            }
+          }
+        }
+      }
+    }
+
+    grad_input[batch][in_channel][in_frame][in_row][in_col] = sum;
+  }
+}
+
+template <typename scalar_t,
+         int kKnownStrideH, int kKnownStrideW>
+__global__ void 
+conv_depthwise3d_cuda_backward_weight_kernel(
+    const PackedTensorAccessor32<scalar_t, 5> grad_output,
+    const PackedTensorAccessor32<scalar_t, 5> input,
+    PackedTensorAccessor32<scalar_t, 5> grad_kernel,
+    int dT, int dH_, int dW_,
+    int pT, int pH, int pW, 
+    int dilationT, int dilationH, int dilationW) {
+  const int kC = grad_kernel.size(0);
+  const int kT = grad_kernel.size(2);
+  const int kH = grad_kernel.size(3);
+  const int kW = grad_kernel.size(4);
+  
+  const int dH = kKnownStrideH > 0 ? kKnownStrideH : dH_;
+  const int dW = kKnownStrideW > 0 ? kKnownStrideW : dW_;
+
+  const int k_col = blockIdx.x % kW;
+  const int k_row = (blockIdx.x / kW) % kH;
+  const int k_frame = (blockIdx.x / kW / kH) % kT;
+  const int k_channel = blockIdx.x / kW / kH / kT;
+  scalar_t *result = &grad_kernel[k_channel][0][k_frame][k_row][k_col];
+
+  const int oT = grad_output.size(2);
+  const int oH = grad_output.size(3);
+  const int oW = grad_output.size(4);
+  const int iT = input.size(2);
+  const int iH = input.size(3);
+  const int iW = input.size(4);
+  const int channel_multiplier = grad_output.size(1) / input.size(1);
+  const int in_channel = k_channel / channel_multiplier;
+
+  extern __shared__ int sdata_raw[];
+  scalar_t* sdata = reinterpret_cast<scalar_t*>(sdata_raw);
+
+  if (k_channel >= kC) {
+    return;
+  }
+
+  const int laneid = threadIdx.x % C10_WARP_SIZE;
+  const int warpid = threadIdx.x / C10_WARP_SIZE;
+  const int nwarps = blockDim.x / C10_WARP_SIZE;
+
+  scalar_t grad = (scalar_t)0;
+  int batch = warpid / oT;
+  int gout_frame = warpid - batch * oT;
+  for (int outer_pos = warpid; outer_pos < input.size(0) * oT; 
+      outer_pos += nwarps, gout_frame += nwarps) {
+    while (gout_frame >= oT) { gout_frame -= oT; batch ++; }
+
+    const int in_frame = (gout_frame * dT) + (k_frame * dilationT) - pT;
+
+    if (in_frame < 0 || in_frame >= iT) {
+      continue;
+    }
+
+    const scalar_t* gout_ptr = grad_output[batch][k_channel][gout_frame].data() + laneid;
+    const scalar_t* input_ptr = input[batch][in_channel][in_frame].data();
+
+    int gout_row = laneid / oW;
+    int gout_col = laneid - gout_row * oW;
+
+    for (; gout_row < oH; ) {
+      const scalar_t op1 = __ldg(gout_ptr);
+      gout_ptr += C10_WARP_SIZE;
+
+      const int in_col = (gout_col * dW) + (k_col * dilationW) - pW;
+      const int in_row = (gout_row * dH) + (k_row * dilationH) - pH;
+      const int in_pos = in_row * iW + in_col;
+
+      scalar_t op2 = (scalar_t)0;
+      if (in_col >= 0 && in_col < iW && in_row >= 0 && in_row < iH) {
+        op2 = __ldg(input_ptr + in_pos);
+      }
+
+      gout_col += C10_WARP_SIZE;
+      while (gout_col >= oW) {
+        gout_col -= oW; gout_row ++;
+      }
+
+      grad += op1 * op2;
+    }
+  }
+  
+  sdata[threadIdx.x] = grad;
+  __syncthreads();
+ 
+  assert(__popc(blockDim.x) == 1);
+#pragma unroll
+  for (int i = blockDim.x / 2; i >= 1; i >>= 1) {
+    if (threadIdx.x < i) {
+      sdata[threadIdx.x] += sdata[threadIdx.x + i];
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    *result = sdata[0];
+  }
+}
+
+template <int dim>
+std::vector<int64_t> get_output_size(
+    const Tensor &input,
+    const Tensor &weight,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation) {
+  std::vector<int64_t> output_size;
+  
+  if (input.dim() == dim + 2 /* is_batch */) {
+    output_size.push_back(input.size(0));
+  }
+  output_size.push_back(weight.size(0));
+  for (int i = 0; i < dim; ++i) {
+    int64_t dim_ksize = weight.size(i + 2);
+    int64_t dim_isize = input.size(-dim + i);
+    int64_t dim_stride = stride[i];
+    int64_t dim_padding = padding[i];
+    int64_t dim_dilation = dilation[i];
+
+    int64_t dim_kspan = (dim_ksize - 1) * dim_dilation + 1;
+    output_size.push_back(
+        (dim_isize + dim_padding * 2 - dim_kspan + 1 - 1) / dim_stride + 1);
+  }
+
+  return output_size;
+}
+
+template <int dim>
+void conv_depthwise_shape_check(
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    const Tensor& grad_output,
+    IntArrayRef kernel_size,
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation) {
+  TORCH_CHECK(kernel_size.size() == dim,
+      "kernel size length should be ", dim, ", but got ", kernel_size.size());
+  TORCH_CHECK(stride.size() == dim,
+      "stride length should be ", dim, ", but got ", stride.size());
+  TORCH_CHECK(padding.size() == dim,
+      "padding length should be ", dim, ", but got ", padding.size());
+  TORCH_CHECK(dilation.size() == dim,
+      "dilation length should be ", dim, ", but got ", dilation.size());
+
+  TORCH_CHECK(input.defined(),
+      "Input must be defined.");
+  TORCH_CHECK(weight.defined(),
+      "Weight must be defined.");
+  TORCH_CHECK(input.dim() == dim + 1 || input.dim() == dim + 2,
+      "Input dimension should be ", 
+      dim + 1, "D or ", dim + 2, "D, got ",
+      input.dim(), "D");
+  TORCH_CHECK(weight.dim() == dim + 2,
+      "Weight dimension should be ", dim + 2, "D, got ", weight.dim(), "D");
+  TORCH_CHECK(weight.size(1) == 1,
+      "Depthwise weight should have in_channels=1, got ", weight.size(1));
+  TORCH_CHECK(weight.size(0) % input.size(-dim - 1) == 0,
+      "Depthwise out channels should be a multiple of in channels, got ",
+      weight.size(0), " and ", input.size(-dim - 1));
+  for (int i = 0; i < dim; ++i) {
+    TORCH_CHECK(weight.size(i + 2) == kernel_size[i],
+        "kernel size and weight size mismatch, got ",
+        kernel_size, " and ", weight.sizes());
+    TORCH_CHECK(stride[i] >= 1, 
+        "stride should be at least 1, got ", stride);
+    TORCH_CHECK(padding[i] >= 0,
+        "padding should be non-negative, got ", padding);
+    TORCH_CHECK(dilation[i] >= 1,
+        "dilation should be at least 1, got ", dilation);
+  }
+
+  if (bias.defined()) {
+    TORCH_CHECK(bias.dim() == 1,
+        "Bias should be 1D tensor, got ", bias.dim(), "D");
+    TORCH_CHECK(bias.size(0) == weight.size(0),
+        "Bias length should be equal to out_channels, got ",
+        bias.size(0), " and ", weight.size(0));
+  }
+
+  if (grad_output.defined()) {
+    auto expected_output_size = get_output_size<dim>(input, weight,
+        stride, padding, dilation);
+    TORCH_CHECK(grad_output.dim() == expected_output_size.size(),
+        "Expect grad_output to be ",
+        expected_output_size.size(), "D, got ",
+        grad_output.dim(), "D.");
+    for (int i = 0; i < grad_output.dim(); ++i) {
+      TORCH_CHECK(grad_output.size(i) == expected_output_size[i],
+          "Expect grad_output to be of same shape as output, got ",
+          grad_output.size(i), " and ", expected_output_size[i],
+          " at dimension ", i);
+    }
+  }
+}
+
+}
+
+#define TENSOR_ARG(name, idx) TensorArg name##_arg{ name, #name, idx };
+
+#define NODEF_OR_EQUAL(x, y) ((y) < 0 || (x) == (y))
+#define NODEF_OR_EQUAL_3(x, y1, y2, y3) \
+  (NODEF_OR_EQUAL(x[0], y1) && \
+   NODEF_OR_EQUAL(x[1], y2) && \
+   NODEF_OR_EQUAL(x[1], y3))
+
+#define DWCONV3D_FORWARD_DISPATCH_SPECIALIZATION(kt, kh, kw, dilt, dilh, dilw) \
+  if (NODEF_OR_EQUAL_3(kernel_size, (kt), (kh), (kw)) &&                    \
+      NODEF_OR_EQUAL_3(dilation, (dilt), (dilh), (dilw))) {                 \
+    conv_depthwise3d_cuda_kernel                                            \
+    <scalar_t, (kt), (kh), (kw), (dilt), (dilh), (dilw)>                    \
+      <<<grid, block, (smem), at::cuda::getCurrentCUDAStream()>>>(          \
+        input_.packed_accessor32<scalar_t, 5>(),                            \
+        output_.packed_accessor32<scalar_t, 5>(),                           \
+        weight_.packed_accessor32<scalar_t, 5>(),                           \
+        bias_ptr,                                                           \
+        stride[0], stride[1], stride[2],                                    \
+        padding[0], padding[1], padding[2],                                 \
+        dilation[0], dilation[1], dilation[2]);                             \
+  } else
+
+#define DWCONV3D_FORWARD_DISPATCH_OTHERS \
+  {                                                                         \
+    conv_depthwise3d_cuda_kernel                                            \
+    <scalar_t, -1, -1, -1, -1, -1, -1>                                      \
+      <<<grid, block, (smem), at::cuda::getCurrentCUDAStream()>>>(          \
+        input_.packed_accessor32<scalar_t, 5>(),                            \
+        output_.packed_accessor32<scalar_t, 5>(),                           \
+        weight_.packed_accessor32<scalar_t, 5>(),                           \
+        bias_ptr,                                                           \
+        stride[0], stride[1], stride[2],                                    \
+        padding[0], padding[1], padding[2],                                 \
+        dilation[0], dilation[1], dilation[2]);                             \
+  }
+
+Tensor conv_depthwise3d_cuda(
+    const Tensor& input,
+    const Tensor& weight,
+    IntArrayRef kernel_size,
+    const Tensor& bias,
+    IntArrayRef stride, 
+    IntArrayRef padding,
+    IntArrayRef dilation) { 
+  TENSOR_ARG(input, 1);
+  TENSOR_ARG(weight, 2);
+
+  checkAllSameGPU("conv_depthwise3d_cuda", {input_arg, weight_arg});
+  if (bias.defined()) {
+    TENSOR_ARG(bias, 4);
+    checkAllSameGPU("conv_depthwise3d_cuda", {input_arg, bias_arg});
+  }
+
+  conv_depthwise_shape_check<3>(input, weight, bias, Tensor() /* undefined */, 
+      kernel_size, stride, padding, dilation);
+  
+  auto output_size = get_output_size<3>(input, weight, 
+      stride, padding, dilation);
+  for (size_t i = 0; i < output_size.size(); ++i) {
+    TORCH_CHECK(output_size[i] > 0,
+        "Output size should be positive, got ", output_size[i], " at dim ", i);
+  }
+  Tensor output = at::empty(output_size, input.options());
+  
+  Tensor input_ = input;
+  Tensor output_ = output;
+  if (input.dim() == 4 /* no batch */) {
+    input_ = input.unsqueeze(0);
+    output_ = output.unsqueeze(0);
+  }
+  Tensor weight_ = weight.contiguous();
+  Tensor bias_ = bias.defined() ? bias.contiguous() : bias;
+
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+      input.scalar_type(),
+      "conv_depthwise3d",
+      [&]{
+        int64_t num_outputs = output_.numel();
+        int64_t block = 256;
+        int64_t grid = std::min((num_outputs - 1) / block + 1, (int64_t)65536);
+        int64_t smem = 0;
+
+        const scalar_t* bias_ptr = 
+          bias_.defined() ? bias_.data_ptr<scalar_t>() : NULL;
+
+        // Range check to avoid overflow in CUDA kernels.
+        TORCH_CHECK(input_.numel() <= std::numeric_limits<int32_t>::max(),
+            "Input tensor is too large.");
+        TORCH_CHECK(output_.numel() <= std::numeric_limits<int32_t>::max(),
+            "Output tensor is too large.");
+        TORCH_CHECK(weight_.numel() <= std::numeric_limits<int32_t>::max(),
+            "Weight tensor is too large.");
+        for (int i = 0; i < 3; ++i) {
+          TORCH_CHECK(padding[i] * 2 + input.size(i + 2) <= std::numeric_limits<int32_t>::max(),
+              "Padded input tensor is too large.");
+        }
+
+        DWCONV3D_FORWARD_DISPATCH_SPECIALIZATION(3, 3, 3, 1, 1, 1)
+        DWCONV3D_FORWARD_DISPATCH_SPECIALIZATION(-1, -1, -1, 1, 1, 1)
+        DWCONV3D_FORWARD_DISPATCH_OTHERS
+      }
+  );
+
+  return output;
+}
+
+#undef DWCONV3D_FORWARD_DISPATCH_SPECIALIZATION
+#undef DWCONV3D_FORWARD_DISPATCH_OTHERS
+
+#define DWCONV3D_BACKWARD_INPUT_DISPATCH_SPECIALIZATION( \
+    kt, kh, kw, dilt, dilh, dilw, dt, dh, dw) \
+  if (NODEF_OR_EQUAL_3(kernel_size, (kt), (kh), (kw)) &&                    \
+      NODEF_OR_EQUAL_3(dilation, (dilt), (dilh), (dilw)) &&                 \
+      NODEF_OR_EQUAL_3(stride, (dt), (dh), (dw))) {                         \
+    conv_depthwise3d_cuda_backward_input_kernel                             \
+    <scalar_t, (kt), (kh), (kw), (dilt), (dilh), (dilw), (dt), (dh), (dw)>  \
+      <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(               \
+        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
+        grad_input_.packed_accessor32<scalar_t, 5>(),                       \
+        weight_.packed_accessor32<scalar_t, 5>(),                           \
+        stride[0], stride[1], stride[2],                                    \
+        padding[0], padding[1], padding[2],                                 \
+        dilation[0], dilation[1], dilation[2]);                             \
+  } else
+
+#define DWCONV3D_BACKWARD_INPUT_DISPATCH_OTHERS \
+  {                                                                         \
+    conv_depthwise3d_cuda_backward_input_kernel                             \
+    <scalar_t, -1, -1, -1, -1, -1, -1, -1, -1, -1>                          \
+      <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(               \
+        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
+        grad_input_.packed_accessor32<scalar_t, 5>(),                       \
+        weight_.packed_accessor32<scalar_t, 5>(),                           \
+        stride[0], stride[1], stride[2],                                    \
+        padding[0], padding[1], padding[2],                                 \
+        dilation[0], dilation[1], dilation[2]);                             \
+  }
+
+#define DWCONV3D_BACKWARD_WEIGHT_DISPATCH_SPECIALIZATION(dh, dw) \
+  if (NODEF_OR_EQUAL_3(stride, -1, (dh), (dw))) {                           \
+    conv_depthwise3d_cuda_backward_weight_kernel                            \
+    <scalar_t, (dh), (dw)>                                                  \
+      <<<grid, block, smem, at::cuda::getCurrentCUDAStream()>>>(            \
+        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
+        input_.packed_accessor32<scalar_t, 5>(),                            \
+        grad_weight.packed_accessor32<scalar_t, 5>(),                       \
+        stride[0], stride[1], stride[2],                                    \
+        padding[0], padding[1], padding[2],                                 \
+        dilation[0], dilation[1], dilation[2]);                             \
+  } else
+
+#define DWCONV3D_BACKWARD_WEIGHT_DISPATCH_OTHERS \
+  {                                                                         \
+    conv_depthwise3d_cuda_backward_weight_kernel                            \
+    <scalar_t, -1, -1>                                                      \
+      <<<grid, block, smem, at::cuda::getCurrentCUDAStream()>>>(            \
+        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
+        input_.packed_accessor32<scalar_t, 5>(),                            \
+        grad_weight.packed_accessor32<scalar_t, 5>(),                       \
+        stride[0], stride[1], stride[2],                                    \
+        padding[0], padding[1], padding[2],                                 \
+        dilation[0], dilation[1], dilation[2]);                             \
+  }
+
+std::tuple<Tensor, Tensor, Tensor> conv_depthwise3d_backward_cuda(
+    const Tensor& grad_output,
+    const Tensor& input,
+    const Tensor& weight,
+    IntArrayRef kernel_size, 
+    IntArrayRef stride,
+    IntArrayRef padding,
+    IntArrayRef dilation,
+    const std::array<bool, 3> output_mask) {
+  TENSOR_ARG(grad_output, 1);
+  TENSOR_ARG(input, 2);
+  TENSOR_ARG(weight, 3);
+
+  checkAllSameGPU("conv_depthwise3d_backward_cuda",
+      {grad_output_arg, input_arg, weight_arg});
+
+  conv_depthwise_shape_check<3>(
+      input, weight, Tensor() /* undefined */, grad_output,
+      kernel_size, stride, padding, dilation);
+
+  bool is_batch = input.dim() == 5;
+  auto options = grad_output.options();
+
+  const Tensor grad_output_ = 
+    (is_batch ? grad_output.contiguous() 
+              : grad_output.contiguous().unsqueeze(0));
+  const Tensor input_ =
+    (is_batch ? input.contiguous() : input.contiguous().unsqueeze(0));
+  const Tensor weight_ = weight.contiguous();
+
+  Tensor grad_input = 
+    (output_mask[0] ? at::empty(input.sizes(), options) : Tensor());
+  Tensor grad_weight = 
+    (output_mask[1] ? at::empty(weight.sizes(), options) : Tensor());
+  Tensor grad_bias; /* undefined temporarily */
+
+  Tensor grad_input_ = 
+    (output_mask[0] ? (is_batch ? grad_input : grad_input.unsqueeze(0))
+                    : Tensor());
+
+  if (output_mask[0]) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        grad_output.scalar_type(),
+        "conv_depthwise3d",
+        [&] {
+          int64_t num_inputs = grad_input_.numel();
+          int64_t block = 256;
+          int64_t grid = std::min((num_inputs - 1) / block + 1, (int64_t)65536);
+
+          // Range check to avoid overflow in CUDA kernels.
+          TORCH_CHECK(grad_input_.numel() <= std::numeric_limits<int32_t>::max(),
+              "Input tensor is too large.");
+          TORCH_CHECK(grad_output_.numel() <= std::numeric_limits<int32_t>::max(),
+              "Output tensor is too large.");
+          TORCH_CHECK(weight_.numel() <= std::numeric_limits<int32_t>::max(),
+              "Weight tensor is too large.");
+          for (int i = 0; i < 3; ++i) {
+            TORCH_CHECK(padding[i] * 2 + input.size(i + 2) <= std::numeric_limits<int32_t>::max(),
+                "Padded input tensor is too large.");
+          }
+  
+          DWCONV3D_BACKWARD_INPUT_DISPATCH_SPECIALIZATION(
+            3, 3, 3, 1, 1, 1, 1, 1, 1)
+          DWCONV3D_BACKWARD_INPUT_DISPATCH_SPECIALIZATION(
+            3, 3, 3, 1, 1, 1, -1, -1, -1)
+          DWCONV3D_BACKWARD_INPUT_DISPATCH_SPECIALIZATION(
+            3, 3, 3, -1, -1, -1, 1, 1, 1)
+          DWCONV3D_BACKWARD_INPUT_DISPATCH_SPECIALIZATION(
+            3, 3, 3, -1, -1, -1, -1, -1, -1)
+          DWCONV3D_BACKWARD_INPUT_DISPATCH_OTHERS
+        }
+    );
+  }
+
+  if (output_mask[1]) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        grad_output.scalar_type(),
+        "conv_depthwise3d",
+        [&] {
+          int64_t grid = grad_weight.numel();
+          int64_t block = 256;
+          int64_t smem = sizeof(scalar_t) * block;
+
+          const int64_t int_max = std::numeric_limits<int32_t>::max();
+          TORCH_CHECK(grad_input_.numel() <= int_max,
+              "Input tensor is too large.");
+          TORCH_CHECK(grad_output_.numel() <= int_max,
+              "Output tensor is too large.");
+          TORCH_CHECK(weight_.numel() <= int_max,
+              "Weight tensor is too large.");
+          for (int i = 0; i < 3; ++i) {
+            TORCH_CHECK(padding[i] * 2 + input.size(i + 2) <= int_max,
+                "Padded input tensor is too large.");
+          }
+          TORCH_CHECK(grad_output_.size(0) * grad_output_.size(2) < int_max - block / C10_WARP_SIZE &&
+            grad_output_.size(3) <= int_max - C10_WARP_SIZE &&
+            grad_output_.size(4) <= int_max - C10_WARP_SIZE, 
+            "Output size is too large.");
+
+          DWCONV3D_BACKWARD_WEIGHT_DISPATCH_SPECIALIZATION(1, 1)
+          DWCONV3D_BACKWARD_WEIGHT_DISPATCH_SPECIALIZATION(2, 2)
+          DWCONV3D_BACKWARD_WEIGHT_DISPATCH_OTHERS
+        }
+    );
+  }
+
+  if (output_mask[2]) {
+    grad_bias = grad_output.sum({0, 2, 3, 4});
+  }
+
+  return std::tie(grad_input, grad_weight, grad_bias);
+}
+
+#undef DWCONV3D_BACKWARD_INPUT_DISPATCH_SPECIALIZATION
+#undef DWCONV3D_BACKWARD_INPUT_DISPATCH_OTHERS
+
+#undef NODEF_OR_EQUAL_3
+#undef NODEF_OR_EQUAL
+
+#undef TENSOR_ARG
+
+}
+}

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6269,6 +6269,16 @@
   dispatch:
     CUDA: thnn_conv_depthwise2d_backward
 
+- func: conv_depthwise3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] dilation) -> Tensor
+  python_module: nn
+  dispatch:
+    CUDA: conv_depthwise3d_cuda
+
+- func: conv_depthwise3d_backward(Tensor grad_output, Tensor input, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
+  python_module: nn
+  dispatch:
+    CUDA: conv_depthwise3d_backward_cuda
+
 - func: slow_conv3d.out(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1349,6 +1349,9 @@
 - name: thnn_conv_depthwise2d_backward.output_mask(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool[2] output_mask) -> (Tensor grad_input, Tensor grad_weight)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], {}, grad_output, weight, self, stride, padding, dilation, false, {{0, 0}}, self.size(1), false, false, false, grad_input_mask)
 
+- name: conv_depthwise3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] dilation) -> Tensor
+  self, weight, bias: conv_depthwise3d_backward(grad.contiguous(), self, weight, kernel_size, stride, padding, dilation, grad_input_mask)
+
 - name: slow_conv3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding) -> (Tensor output, Tensor finput, Tensor fgrad_input)
   self, weight, bias: "grad.defined() ? slow_conv3d_backward(grad, self, weight, kernel_size, stride, padding, finput, fgrad_input, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
 


### PR DESCRIPTION
This is another attempt to resolve the slow 3D depthwise (a.k.a. channel-wise) convolution of cuDNN (previously at #31885). 3D depthwise convolutions are seeing increasing use in various recent works (e.g. <https://arxiv.org/abs/2004.04730>, <https://arxiv.org/abs/1904.02811>), but currently, cuDNN 3D depthwise convolution is usually even slower than the regular dense convolutions, making it practically very time consuming to train such models.

I have tried to implement a CUDA kernel and found it bringing well noticeable performance gain. It is taking as reference the 2D implementations (PyTorch: <https://github.com/pytorch/pytorch/blob/master/aten/src/THCUNN/SpatialDepthwiseConvolution.cu>TensorFlow: <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/depthwise_conv_op_gpu.h>) and existing attempts (#31885), and further tuned with nvidia profiler. The acceleration of forward+backward, according to my tests, is at least 2.5x and in many cases 5x~20x. The timing results are attached in the end. They are intended to cover some most common use cases, but due to the limitation of time and access to different devices, it may still be some way from being complete. Any further tests with different configurations or different devices are certainly welcomed.

Although it has already been used internally for some time, I'm aware that it might need some further refinement for dealing with some less common cases and better following general PyTorch coding principles. I've listed some TODO points I've come up with till now, some of which may include questions I'm now not very clear about:

1. Test cases. Since this is a change of implementation of an existing algorithm, is the existing test cases sufficient to cover, or do I need to add new test cases specific to this implementation?
2. Handling of extreme tensor size/configuration. Currently any input/output/weight tensor greater than 2^31-1 is rejected. And very large padding/dilation may not be considered carefully yet. My question here is if there are general rules about how much we shall tolerate these cases? (I guess that a 8GB tensor is actually not that rare, a sample in a batch, i.e. c * t * h * w volume of >8GB is less common, and 2 billion padding is almost nothing useful...)
3. Some functionalities (e.g. ROCm support, double backward) have not been considered yet.

Any other suggestions are also appreciated. I'm likely able to spend some more time on this PR. Feel free to tag it as WIP if found necessary.

Below is timing results. Timing results are in ms. Kernel size is always (3, 3, 3). The test code will do a 50-iteration warm-up and then another 50-iteration for timing. Timing code is after the table.

| gpu / precision | input                | stride  | cudnn8000 | cudnn7605 | cudnn7603 | ours   | acceleration   vs. 8000 | acceleration   vs. 7605 | acceleration   vs. 7603 |
| --------------- | -------------------- | ------- | --------- | --------- | --------- | ------ | ----------------------- | ----------------------- | ----------------------- |
| 1080ti-fp32     | 8, 64, 32, 56, 56    | 1, 1, 1 | 211.766   | 369.786   | 393.02    | 24.028 | 8.8133011               | 15.389795               | 16.35675                |
|                 | 8, 128, 32, 28, 28   | 1, 1, 1 | 110.243   | 196.788   | 195.203   | 12.98  | 8.4932974               | 15.160863               | 15.038752               |
|                 | 8,   256, 32, 14, 14 | 1, 1, 1 | 54.098    | 82.065    | 75.956    | 7.67   | 7.0531943               | 10.699478               | 9.9029987               |
|                 | 8,   512, 32, 7, 7   | 1, 1, 1 | 27.191    | 54.001    | 56.504    | 5.693  | 4.7762164               | 9.4855085               | 9.9251713               |
|                 | 8,   54, 13, 40, 40  | 1, 1, 1 | 38.147    | 68.127    | 78.681    | 4.27   | 8.9337237               | 15.954801               | 18.426464               |
|                 | 8,   108, 13, 20, 20 | 1, 1, 1 | 19.541    | 35.042    | 35.33     | 2.38   | 8.2105042               | 14.723529               | 14.844538               |
|                 | 8,   216, 13, 10, 10 | 1, 1, 1 | 10.105    | 17.961    | 18.492    | 1.673  | 6.0400478               | 10.735804               | 11.053198               |
|                 | 8,   432, 13, 5, 5   | 1, 1, 1 | 8.575     | 19.642    | 20.937    | 1.433  | 5.9839498               | 13.706909               | 14.610607               |
|                 | 8,   54, 16, 56, 56  | 1, 1, 1 | 91.91     | 166.328   | 187.786   | 10.285 | 8.936315                | 16.171901               | 18.25824                |
|                 | 8,   108, 16, 28, 28 | 1, 1, 1 | 47.853    | 85.573    | 84.938    | 5.515  | 8.6768812               | 15.51641                | 15.401269               |
|                 | 8,   216, 16, 14, 14 | 1, 1, 1 | 23.441    | 35.784    | 36.467    | 3.279  | 7.1488259               | 10.913083               | 11.121378               |
|                 | 8,   432, 16, 7, 7   | 1, 1, 1 | 13.715    | 33.371    | 36.416    | 2.496  | 5.4947917               | 13.369792               | 14.589744               |
|                 | 8,   54, 16, 78, 78  | 1, 1, 1 | 356.101   | 319.873   | 372.093   | 19.842 | 17.94683                | 16.121006               | 18.752797               |
|                 | 8,   108, 16, 39, 39 | 1, 1, 1 | 91.41     | 156.656   | 172.973   | 10.101 | 9.0495991               | 15.50896                | 17.124344               |
|                 | 8,   216, 16, 20, 20 | 1, 1, 1 | 48.876    | 70.286    | 71.632    | 5.844  | 8.3634497               | 12.027036               | 12.257358               |
|                 | 8.   432, 16, 10, 10 | 1, 1, 1 | 25.06     | 46.684    | 49.695    | 4.068  | 6.1602753               | 11.47591                | 12.216077               |
|                 | 8, 64, 32, 56, 56    | 1, 2, 2 | 56.704    | 185.966   | 189.643   | 15.74  | 3.6025413               | 11.814867               | 12.048475               |
|                 | 8, 128, 32, 28, 28   | 1, 2, 2 | 28.973    | 94.386    | 95.99     | 8.28   | 3.4991546               | 11.399275               | 11.592995               |
|                 | 8,   256, 32, 14, 14 | 1, 2, 2 | 14.337    | 48.659    | 49.301    | 5.041  | 2.8440786               | 9.6526483               | 9.780004                |
|                 | 8,   512, 32, 7, 7   | 1, 2, 2 | 12.321    | 41.55     | 43.374    | 4.602  | 2.6773142               | 9.0286832               | 9.4250326               |
|                 | 8,   54, 13, 40, 40  | 1, 2, 2 | 10.231    | 33.715    | 34.126    | 2.807  | 3.6448165               | 12.011044               | 12.157463               |
|                 | 8,   108, 13, 20, 20 | 1, 2, 2 | 5.381     | 17.291    | 17.544    | 1.636  | 3.2891198               | 10.569071               | 10.723716               |
|                 | 8,   216, 13, 10, 10 | 1, 2, 2 | 4.555     | 9.572     | 10.596    | 1.126  | 4.0452931               | 8.5008881               | 9.410302                |
|                 | 8,   432, 13, 5, 5   | 1, 2, 2 | 8.127     | 13.533    | 15.155    | 1.533  | 5.3013699               | 8.8277887               | 9.8858447               |
|                 | 8,   54, 16, 56, 56  | 1, 2, 2 | 24.532    | 80.964    | 82.475    | 6.766  | 3.6257759               | 11.966302               | 12.189625               |
|                 | 8,   108, 16, 28, 28 | 1, 2, 2 | 12.524    | 41.091    | 42.633    | 3.545  | 3.5328632               | 11.591255               | 12.026234               |
|                 | 8,   216, 13, 10, 10 | 1, 2, 2 | 6.927     | 24.788    | 26.079    | 2.21   | 3.1343891               | 11.21629                | 11.800452               |
|                 | 8,   432, 16, 7, 7   | 1, 2, 2 | 8.082     | 18.693    | 20.099    | 2.038  | 3.9656526               | 9.1722277               | 9.8621197               |
|                 | 8,   54, 16, 78, 78  | 1, 2, 2 | 48.927    | 164.085   | 167.044   | 13.031 | 3.754662                | 12.591896               | 12.81897                |
|                 | 8,   108, 16, 39, 39 | 1, 2, 2 | 24.772    | 81.949    | 84.012    | 6.722  | 3.6852127               | 12.191163               | 12.498066               |
|                 | 8,   216, 16, 20, 20 | 1, 2, 2 | 12.78     | 51.02     | 46.551    | 3.953  | 3.2329876               | 12.906653               | 11.776119               |
|                 | 8.   432, 16, 10, 10 | 1, 2, 2 | 9.666     | 35.868    | 34.658    | 2.685  | 3.6                     | 13.358659               | 12.908007               |

V100 results (these machines are not fully under my control so I can't upgrade their drivers. 7.6.3 is highest possible cuDNN version come with an official build)

| gpu / precision | input                | stride  | cudnn7603 | ours   | acceleration vs. 7603 |
| --------------- | -------------------- | ------- | --------- | ------ | --------------------- |
| v100-fp32       | 8, 64, 32, 56, 56    | 1, 1, 1 | 133.224   | 14.221 | 9.3681176             |
|                 | 8, 128, 32, 28, 28   | 1, 1, 1 | 65.583    | 7.206  | 9.1011657             |
|                 | 8,   256, 32, 14, 14 | 1, 1, 1 | 39.154    | 3.994  | 9.8032048             |
|                 | 8,   512, 32, 7, 7   | 1, 1, 1 | 46.064    | 2.739  | 16.817817             |
|                 | 8,   54, 13, 40, 40  | 1, 1, 1 | 19.906    | 2.575  | 7.7304854             |
|                 | 8,   108, 13, 20, 20 | 1, 1, 1 | 14.82     | 1.317  | 11.252847             |
|                 | 8,   216, 13, 10, 10 | 1, 1, 1 | 18.46     | 0.835  | 22.107784             |
|                 | 8,   432, 13, 5, 5   | 1, 1, 1 | 22.707    | 0.669  | 33.941704             |
|                 | 8,   54, 16, 56, 56  | 1, 1, 1 | 54.22     | 6.228  | 8.7058446             |
|                 | 8,   108, 16, 28, 28 | 1, 1, 1 | 26.819    | 3.087  | 8.6877227             |
|                 | 8,   216, 13, 10, 10 | 1, 1, 1 | 23.091    | 1.718  | 13.440629             |
|                 | 8,   432, 16, 7, 7   | 1, 1, 1 | 33.519    | 1.206  | 27.793532             |
|                 | 8,   54, 16, 78, 78  | 1, 1, 1 | 110.881   | 12.216 | 9.0767027             |
|                 | 8,   108, 16, 39, 39 | 1, 1, 1 | 54.419    | 5.787  | 9.4036634             |
|                 | 8,   216, 16, 20, 20 | 1, 1, 1 | 33.329    | 3.192  | 10.441416             |
|                 | 8.   432, 16, 10, 10 | 1, 1, 1 | 39.03     | 1.998  | 19.534535             |
|                 | 8, 64, 32, 56, 56    | 1, 2, 2 | 75.172    | 11.596 | 6.4825802             |
|                 | 8, 128, 32, 28, 28   | 1, 2, 2 | 42.357    | 5.946  | 7.1236125             |
|                 | 8,   256, 32, 14, 14 | 1, 2, 2 | 29.265    | 3.331  | 8.78565               |
|                 | 8,   512, 32, 7, 7   | 1, 2, 2 | 50.152    | 2.44   | 20.554098             |
|                 | 8,   54, 13, 40, 40  | 1, 2, 2 | 15.439    | 2.1    | 7.3519048             |
|                 | 8,   108, 13, 20, 20 | 1, 2, 2 | 13.267    | 1.118  | 11.866726             |
|                 | 8,   216, 13, 10, 10 | 1, 2, 2 | 7.29      | 0.69   | 10.565217             |
|                 | 8,   432, 13, 5, 5   | 1, 2, 2 | 13.66     | 0.712  | 19.185393             |
|                 | 8,   54, 16, 56, 56  | 1, 2, 2 | 31.91     | 4.997  | 6.3858315             |
|                 | 8,   108, 16, 28, 28 | 1, 2, 2 | 21.3      | 2.555  | 8.3365949             |
|                 | 8,   216, 13, 10, 10 | 1, 2, 2 | 13.554    | 1.439  | 9.419041              |
|                 | 8,   432, 16, 7, 7   | 1, 2, 2 | 13.84     | 1.078  | 12.83859              |
|                 | 8,   54, 16, 78, 78  | 1, 2, 2 | 61.626    | 12.163 | 5.0666776             |
|                 | 8,   108, 16, 39, 39 | 1, 2, 2 | 35.228    | 4.865  | 7.24111               |
|                 | 8,   216, 16, 20, 20 | 1, 2, 2 | 25.296    | 2.696  | 9.3827893             |
|                 | 8.   432, 16, 10, 10 | 1, 2, 2 | 15.249    | 1.643  | 9.2811929             |
| v100-fp16       | 8, 64, 32, 56, 56    | 1, 1, 1 | 113.862   | 15.68  | 7.2616071             |
|                 | 8, 128, 32, 28, 28   | 1, 1, 1 | 55.282    | 8.139  | 6.7922349             |
|                 | 8,   256, 32, 14, 14 | 1, 1, 1 | 37.496    | 4.534  | 8.2699603             |
|                 | 8,   512, 32, 7, 7   | 1, 1, 1 | 43.379    | 6.245  | 6.946197              |
|                 | 8,   54, 13, 40, 40  | 1, 1, 1 | 19.6      | 2.885  | 6.7937608             |
|                 | 8,   108, 13, 20, 20 | 1, 1, 1 | 14.869    | 1.498  | 9.9259012             |
|                 | 8,   216, 13, 10, 10 | 1, 1, 1 | 18.018    | 0.937  | 19.229456             |
|                 | 8,   432, 13, 5, 5   | 1, 1, 1 | 22.801    | 0.725  | 31.449655             |
|                 | 8,   54, 16, 56, 56  | 1, 1, 1 | 46.43     | 6.916  | 6.7134182             |
|                 | 8,   108, 16, 28, 28 | 1, 1, 1 | 25.588    | 3.512  | 7.285877              |
|                 | 8,   216, 13, 10, 10 | 1, 1, 1 | 22.608    | 1.95   | 11.593846             |
|                 | 8,   432, 16, 7, 7   | 1, 1, 1 | 35.111    | 1.336  | 26.280689             |
|                 | 8,   54, 16, 78, 78  | 1, 1, 1 | 91.14     | 13.196 | 6.9066384             |
|                 | 8,   108, 16, 39, 39 | 1, 1, 1 | 45.84     | 6.481  | 7.0729826             |
|                 | 8,   216, 16, 20, 20 | 1, 1, 1 | 32.115    | 3.612  | 8.891196              |
|                 | 8.   432, 16, 10, 10 | 1, 1, 1 | 42.731    | 2.252  | 18.974689             |
|                 | 8, 64, 32, 56, 56    | 1, 2, 2 | 71.966    | 12.484 | 5.7646588             |
|                 | 8, 128, 32, 28, 28   | 1, 2, 2 | 41.712    | 6.518  | 6.3995091             |
|                 | 8,   256, 32, 14, 14 | 1, 2, 2 | 34.252    | 3.67   | 9.33297               |
|                 | 8,   512, 32, 7, 7   | 1, 2, 2 | 52.537    | 2.642  | 19.885314             |
|                 | 8,   54, 13, 40, 40  | 1, 2, 2 | 15.432    | 2.282  | 6.762489              |
|                 | 8,   108, 13, 20, 20 | 1, 2, 2 | 13.468    | 1.235  | 10.905263             |
|                 | 8,   216, 13, 10, 10 | 1, 2, 2 | 13.817    | 0.754  | 18.324934             |
|                 | 8,   432, 13, 5, 5   | 1, 2, 2 | 14.453    | 0.759  | 19.042161             |
|                 | 8,   54, 16, 56, 56  | 1, 2, 2 | 31.771    | 5.424  | 5.8574853             |
|                 | 8,   108, 16, 28, 28 | 1, 2, 2 | 21.357    | 2.8    | 7.6275                |
|                 | 8,   216, 13, 10, 10 | 1, 2, 2 | 22.819    | 1.585  | 14.396845             |
|                 | 8,   432, 16, 7, 7   | 1, 2, 2 | 21.691    | 1.167  | 18.586975             |
|                 | 8,   54, 16, 78, 78  | 1, 2, 2 | 65.296    | 10.269 | 6.3585549             |
|                 | 8,   108, 16, 39, 39 | 1, 2, 2 | 35.04     | 5.276  | 6.641395              |
|                 | 8,   216, 16, 20, 20 | 1, 2, 2 | 29.13     | 2.978  | 9.7817327             |
|                 | 8.   432, 16, 10, 10 | 1, 2, 2 | 33.362    | 1.795  | 18.586072             |

Timing code:

```python
#!/usr/bin/env python

import os, sys
import time
import torch
print(torch)
torch.backends.cudnn.benchmark = True
print(torch.backends.cudnn.version())
import torch.nn as nn

feat_size = [
    (8, 64, 32, 56, 56),
    (8, 128, 32, 28, 28),
    (8, 256, 32, 14, 14),
    (8, 512, 32, 7, 7),
    (8, 54, 13, 40, 40),
    (8, 108, 13, 20, 20),
    (8, 216, 13, 10, 10),
    (8, 432, 13, 5, 5),
    (8, 54, 16, 56, 56),
    (8, 108, 16, 28, 28),
    (8, 216, 16, 14, 14),
    (8, 432, 16, 7, 7),
    (8, 54, 16, 78, 78),
    (8, 108, 16, 39, 39),
    (8, 216, 16, 20, 20),
    (8, 432, 16, 10, 10),
    ]
max_iter = 50

print('Running %d times for each config.' % max_iter)
for tcase, size in enumerate(feat_size):
  data = torch.randn(size, requires_grad=True, device='cuda')
  conv = nn.Conv3d(data.size(1), data.size(1),
      kernel_size=(3, 3, 3),
      padding=(1, 1, 1),
      #stride=(1, 2, 2), # may use stride 1 or stride 2
      stride=(1, 1, 1),
      groups=data.size(1),
      bias=False)
  nn.init.kaiming_normal_(conv.weight)
  conv.cuda()

  #data = data.half() # may or may not use fp16.
  #conv.half()

  with torch.backends.cudnn.flags(enabled=True):
    for i in range(50):
      conv(data).sum().backward() # warmup
    torch.cuda.synchronize()
    time_st = time.time()
    for i in range(max_iter):
      conv(data).sum().backward()
    torch.cuda.synchronize()
  time_ed = time.time()
  print('Input size: %s, total_time: %.6f s, avg_time: %.6f s' % (
    str(size), time_ed - time_st, (time_ed - time_st) / max_iter))
```

