### PR TITLE
[RPC tests] Remove global TEST_CONFIG

### DIFF
--- a/test/distributed/rpc/test_tensorpipe_agent.py
+++ b/test/distributed/rpc/test_tensorpipe_agent.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import unittest
 
-from torch.testing._internal import dist_utils
 from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import TEST_WITH_ASAN, run_tests
 from torch.testing._internal.distributed.ddp_under_dist_autograd_test import (
@@ -16,11 +15,6 @@ from torch.testing._internal.distributed.rpc.rpc_test import TensorPipeAgentRpcT
 from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture import (
     TensorPipeRpcAgentTestFixture,
 )
-
-
-# FIXME This is needed to make some functions in dist_init work. Those functions
-# should be moved to methods of the fixture. When that is done, remove this.
-dist_utils.TEST_CONFIG.rpc_backend_name = "TENSORPIPE"
 
 
 @unittest.skipIf(

--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -14,16 +14,6 @@ if not dist.is_available():
     sys.exit(0)
 
 
-class TestConfig:
-    __slots__ = ["rpc_backend_name", "build_rpc_backend_options"]
-
-    def __init__(self, *args, **kwargs):
-        assert len(args) == 0, "TestConfig only takes kwargs."
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-
-
-TEST_CONFIG = TestConfig()
 INIT_METHOD_TEMPLATE = "file://{file_name}"
 
 
@@ -86,15 +76,6 @@ def dist_init(old_test_method=None, setup_rpc=True, clean_shutdown=True,
 
     return new_test_method
 
-
-# Set PROCESS_GROUP as the default RPC backend.
-TEST_CONFIG.rpc_backend_name = "PROCESS_GROUP"
-TEST_CONFIG.build_rpc_backend_options = lambda test_object: rpc.backend_registry.construct_rpc_backend_options(
-    test_object.rpc_backend,
-    init_method=test_object.init_method,
-    # Some tests need additional threads (ex: test_trainer_ps)
-    num_send_recv_threads=8,
-)
 
 def noop():
     pass

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test_faulty.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test_faulty.py
@@ -2,7 +2,6 @@ from typing import Dict, Tuple
 
 import torch
 import torch.distributed.rpc as rpc
-import torch.testing._internal.dist_utils as dist_utils
 from torch import Tensor
 from torch.testing._internal.dist_utils import (
     dist_init,
@@ -101,7 +100,6 @@ class JitFaultyAgentRpcTest(RpcAgentTestFixture):
             "second_kwarg": torch.tensor([3, 3]),
         }
         expected_error = self.get_timeout_error_regex()
-        print("Test config is {}".format(dist_utils.TEST_CONFIG.rpc_backend_name))
         # Ensure that we get a timeout if we override the default timeout and
         # the RPC takes longer to execute.
         with self.assertRaisesRegex(RuntimeError, expected_error):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40805 [RPC tests] Enroll TensorPipe in missing test suites
* **#40804 [RPC tests] Remove global TEST_CONFIG**
* #40781 [RPC tests] Enroll TensorPipe in missing test suites
* #40780 [RPC tests] Remove global TEST_CONFIG
* #40779 [RPC tests] Move some functions to methods of fixture
* #40778 [RPC tests] Make generic fixture an abstract base class
* #40777 [RPC tests] Avoid decorators to skip tests
* #40776 [RPC tests] Merge process group tests into single entry point
* #40773 [RPC tests] Align ddp_under_dist_autograd test with others
* #40772 [RPC tests] Remove world_size and init_method from TensorPipe fixture

Summary of the entire stack:
--

This diff is part of an attempt to refactor the RPC tests. They currently suffer from several problems:
- Several ways to specify the agent to use: there exists one "generic" fixture that uses the global variable TEST_CONFIG to look up the agent name, and is used for process group and Thrift, and then there are separate fixtures for the flaky agent and the TensorPipe one.
- These two ways lead to having two separate decorators (`@requires_process_group_agent` and `@_skip_if_tensorpipe_agent`) which must both be specified, making it unclear what the effect of each of them is and what happens if only one is given.
- Thrift must override the TEST_CONFIG global variable before any other import (in order for the `@requires_process_group_agent` decorator to work correctly) and for that it must use a "trap" file, which makes it even harder to track which agent is being used, and which is specific to Buck, and thus cannot be used in OSS by other agents.
- Even if the TensorPipe fixture doesn't use TEST_CONFIG, it still needs to set it to the right value for other parts of the code to work. (This is done in `@dist_init`).
- There are a few functions in dist_utils.py that return some properties of the agent (e.g., a regexp to match against the error it returns in case of shutdown). These functions are effectively chained if/elses on the various agents, which has the effect of "leaking" some part of the Thrift agent into OSS.
- Each test suite (RPC, dist autograd/dist optimizer, their JIT versions, remote module, ...) must be run on each agent (or almost; the faulty one is an exception) in both fork and spawn mode. Each of these combinations is a separate file, which leads to a proliferation of scripts.
- There is no "master list" of what combinations make sense and should be run. Therefore it has happened that when adding new tests or new agents we forgot to enroll them into the right tests. (TensorPipe is still missing a few tests, it turns out).
- All of these tiny "entry point" files contain almost the same duplicated boilerplate. This makes it very easy to get the wrong content into one of them due to a bad copy-paste.

This refactoring aims to address these problems by:
- Avoiding global state, defaults/override, traps, if/elses, ... and have a single way to specify the agent, based on an abstract base class and several concrete subclasses which can be "mixed in" to any test suite.
- Instead of enabling/disabling tests using decorators, the tests that are specific to a certain agent are now in a separate class (which is a subclass of the "generic" test suite) so that they are only picked up by the agent they apply to.
- Instead of having one separate entry point script for each combination, it uses one entry point for each agent, and in that script it provides a list of all the test suites it wants to run on that agent. And it does that by trying to deduplicate the boilerplate as much as possible. (In fact, the various agent-suite combinations could be grouped in any way, not necessarily by agent as I did here).

It provides further advantages:
- It puts all the agents on equal standing, by not having any of them be the default, making it thus easier to migrate from process group to TensorPipe.
- It will make it easier to add more versions of the TensorPipe tests (e.g., one that disables the same-machine backends in order to test the TCP-based ones) without a further duplication of entry points, of boilerplate, ...

Summary of this commit
--
This is the last step of removing TEST_CONFIG. As there was no one left using it, there is really not much to it.

Differential Revision: [D22307778](https://our.internmc.facebook.com/intern/diff/D22307778/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22307778/)!