### PR TITLE
[caffe2] Fix spatial_batch_norm_op dividision-by-zero crash

### DIFF
--- a/caffe2/operators/spatial_batch_norm_op.h
+++ b/caffe2/operators/spatial_batch_norm_op.h
@@ -57,6 +57,7 @@ class SpatialBNOp : public Operator<Context> {
     const int C =
         (order_ == StorageOrder::NCHW ? X.dim32(1) : X.dim32(ndim - 1));
     const std::vector<int> X_dims(X.sizes().cbegin(), X.sizes().cend());
+    CAFFE_ENFORCE_NE(C, 0);
     const int HxW =
         std::accumulate(
             X_dims.cbegin() + 1, X_dims.cend(), 1, std::multiplies<int>()) /


### PR DESCRIPTION
Summary:
When the input is empty, the operator will crash on "runtime error: division by zero". This has been causing Inference platform server crashes.

Example crash logs:

{P134526683}

Test Plan:
Unit test

See reproducing steps in the Test Plan of D22300135

Differential Revision: D22302089

