### PR TITLE
[RPC tests] Enroll TensorPipe in missing test suites

### DIFF
--- a/test/distributed/rpc/test_tensorpipe_agent.py
+++ b/test/distributed/rpc/test_tensorpipe_agent.py
@@ -7,10 +7,17 @@ from torch.testing._internal.distributed.ddp_under_dist_autograd_test import (
     TestDdpComparison,
     TestDdpUnderDistAutograd,
 )
+from torch.testing._internal.distributed.nn.api.remote_module_test import (
+    RemoteModuleTest,
+)
 from torch.testing._internal.distributed.rpc.dist_autograd_test import DistAutogradTest
 from torch.testing._internal.distributed.rpc.dist_optimizer_test import (
     DistOptimizerTest,
 )
+from torch.testing._internal.distributed.rpc.jit.dist_autograd_test import (
+    JitDistAutogradTest,
+)
+from torch.testing._internal.distributed.rpc.jit.rpc_test import JitRpcTest
 from torch.testing._internal.distributed.rpc.rpc_test import TensorPipeAgentRpcTest
 from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture import (
     TensorPipeRpcAgentTestFixture,
@@ -35,6 +42,18 @@ class TensorPipeDistAutogradTestWithSpawn(DistAutogradTest, SpawnHelper):
 
 
 class TensorPipeDistOptimizerTestWithSpawn(DistOptimizerTest, SpawnHelper):
+    pass
+
+
+class TensorPipeJitRpcTestWithSpawn(JitRpcTest, SpawnHelper):
+    pass
+
+
+class TensorPipeJitDistAutogradTestWithSpawn(JitDistAutogradTest, SpawnHelper):
+    pass
+
+
+class TensorPipeRemoteModuleTestWithSpawn(RemoteModuleTest, SpawnHelper):
     pass
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40809 [RPC tests] Enroll TensorPipe in missing test suites**
* #40808 [RPC tests] Remove global TEST_CONFIG
* #40781 [RPC tests] Enroll TensorPipe in missing test suites
* #40780 [RPC tests] Remove global TEST_CONFIG
* #40779 [RPC tests] Move some functions to methods of fixture
* #40778 [RPC tests] Make generic fixture an abstract base class
* #40777 [RPC tests] Avoid decorators to skip tests
* #40776 [RPC tests] Merge process group tests into single entry point
* #40773 [RPC tests] Align ddp_under_dist_autograd test with others
* #40772 [RPC tests] Remove world_size and init_method from TensorPipe fixture

Summary of the entire stack:
--

This diff is part of an attempt to refactor the RPC tests. They currently suffer from several problems:
- Several ways to specify the agent to use: there exists one "generic" fixture that uses the global variable TEST_CONFIG to look up the agent name, and is used for process group and Thrift, and then there are separate fixtures for the flaky agent and the TensorPipe one.
- These two ways lead to having two separate decorators (`@requires_process_group_agent` and `@_skip_if_tensorpipe_agent`) which must both be specified, making it unclear what the effect of each of them is and what happens if only one is given.
- Thrift must override the TEST_CONFIG global variable before any other import (in order for the `@requires_process_group_agent` decorator to work correctly) and for that it must use a "trap" file, which makes it even harder to track which agent is being used, and which is specific to Buck, and thus cannot be used in OSS by other agents.
- Even if the TensorPipe fixture doesn't use TEST_CONFIG, it still needs to set it to the right value for other parts of the code to work. (This is done in `@dist_init`).
- There are a few functions in dist_utils.py that return some properties of the agent (e.g., a regexp to match against the error it returns in case of shutdown). These functions are effectively chained if/elses on the various agents, which has the effect of "leaking" some part of the Thrift agent into OSS.
- Each test suite (RPC, dist autograd/dist optimizer, their JIT versions, remote module, ...) must be run on each agent (or almost; the faulty one is an exception) in both fork and spawn mode. Each of these combinations is a separate file, which leads to a proliferation of scripts.
- There is no "master list" of what combinations make sense and should be run. Therefore it has happened that when adding new tests or new agents we forgot to enroll them into the right tests. (TensorPipe is still missing a few tests, it turns out).
- All of these tiny "entry point" files contain almost the same duplicated boilerplate. This makes it very easy to get the wrong content into one of them due to a bad copy-paste.

This refactoring aims to address these problems by:
- Avoiding global state, defaults/override, traps, if/elses, ... and have a single way to specify the agent, based on an abstract base class and several concrete subclasses which can be "mixed in" to any test suite.
- Instead of enabling/disabling tests using decorators, the tests that are specific to a certain agent are now in a separate class (which is a subclass of the "generic" test suite) so that they are only picked up by the agent they apply to.
- Instead of having one separate entry point script for each combination, it uses one entry point for each agent, and in that script it provides a list of all the test suites it wants to run on that agent. And it does that by trying to deduplicate the boilerplate as much as possible. (In fact, the various agent-suite combinations could be grouped in any way, not necessarily by agent as I did here).

It provides further advantages:
- It puts all the agents on equal standing, by not having any of them be the default, making it thus easier to migrate from process group to TensorPipe.
- It will make it easier to add more versions of the TensorPipe tests (e.g., one that disables the same-machine backends in order to test the TCP-based ones) without a further duplication of entry points, of boilerplate, ...

Summary of this commit
--
As it is now easier to spot that the TensorPipe agent wasn't being run on some test suite, we fix that. We keep this change for last so that if those tests turn out to be flaky and must be reverted this won't affect the rest of the stack.

Differential Revision: [D22309432](https://our.internmc.facebook.com/intern/diff/D22309432/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22309432/)!