### PR TITLE
[RPC tests] Align ddp_under_dist_autograd test with others

### DIFF
--- a/test/distributed/rpc/tensorpipe/test_ddp_under_dist_autograd.py
+++ b/test/distributed/rpc/tensorpipe/test_ddp_under_dist_autograd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import unittest
 
+from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import TEST_WITH_ASAN, run_tests
 from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture import (
     TensorPipeRpcAgentTestFixture,
@@ -8,13 +9,23 @@ from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture i
 from torch.testing._internal.dist_utils import (
     dist_init,
 )
-from torch.testing._internal.distributed import ddp_under_dist_autograd_test
+from torch.testing._internal.distributed.ddp_under_dist_autograd_test import (
+    TestDdpComparison,
+    TestDdpUnderDistAutograd,
+)
 import torch.distributed.rpc as rpc
 
 @unittest.skipIf(
     TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues"
 )
-class TestDdpUnderDistAutogradTensorPipe(TensorPipeRpcAgentTestFixture, ddp_under_dist_autograd_test.TestDdpUnderDistAutograd):
+class TestDdpUnderDistAutogradTensorPipe(
+    TestDdpUnderDistAutograd,
+    TensorPipeRpcAgentTestFixture,
+    MultiProcessTestCase,
+):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
 
     @dist_init
     def test_verify_backend_options(self):
@@ -23,7 +34,14 @@ class TestDdpUnderDistAutogradTensorPipe(TensorPipeRpcAgentTestFixture, ddp_unde
 @unittest.skipIf(
     TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues"
 )
-class TestDdpComparisonTensorPipe(TensorPipeRpcAgentTestFixture, ddp_under_dist_autograd_test.TestDdpComparison):
+class TestDdpComparisonTensorPipe(
+    TestDdpComparison,
+    TensorPipeRpcAgentTestFixture,
+    MultiProcessTestCase,
+):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
 
     @dist_init
     def test_verify_backend_options(self):

--- a/test/distributed/test_ddp_under_dist_autograd.py
+++ b/test/distributed/test_ddp_under_dist_autograd.py
@@ -1,15 +1,28 @@
 #!/usr/bin/env python3
+import unittest
 
-from torch.testing._internal.distributed import ddp_under_dist_autograd_test
-from torch.testing._internal.common_utils import (
-    run_tests,
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.distributed.ddp_under_dist_autograd_test import (
+    TestDdpComparison,
+    TestDdpUnderDistAutograd,
 )
+from torch.testing._internal.common_utils import TEST_WITH_ASAN, run_tests
 
-class TestDdpUnderDistAutogradWrapper(ddp_under_dist_autograd_test.TestDdpUnderDistAutograd):
-    pass
+@unittest.skipIf(
+    TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues"
+)
+class TestDdpUnderDistAutogradWrapper(TestDdpUnderDistAutograd, MultiProcessTestCase):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
 
-class TestDdpComparison(ddp_under_dist_autograd_test.TestDdpComparison):
-    pass
+@unittest.skipIf(
+    TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues"
+)
+class TestDdpComparison(TestDdpComparison, MultiProcessTestCase):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
@@ -11,19 +11,14 @@ import torch
 from torch.distributed import rpc
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_distributed import (
-    MultiProcessTestCase,
     requires_gloo,
     requires_nccl,
     skip_if_lt_x_gpu,
-)
-from torch.testing._internal.common_utils import (
-    TEST_WITH_ASAN,
 )
 from torch.testing._internal.dist_utils import dist_init
 import torch.distributed as dist
 import torch.distributed.autograd as dist_autograd
 import torch.nn as nn
-import unittest
 from torch.testing._internal.distributed.rpc.rpc_agent_test_fixture import (
     RpcAgentTestFixture,
 )
@@ -286,11 +281,7 @@ def set_shutdown_signal():
     with shutdown_signal:
         shutdown_signal.notify()
 
-@unittest.skipIf(
-    TEST_WITH_ASAN,
-    "Skip ASAN as torch + multiprocessing spawn have known issues",
-)
-class TestDdpUnderDistAutograd(MultiProcessTestCase, RpcAgentTestFixture):
+class TestDdpUnderDistAutograd(RpcAgentTestFixture):
 
     @property
     def world_size(self) -> int:
@@ -303,14 +294,6 @@ class TestDdpUnderDistAutograd(MultiProcessTestCase, RpcAgentTestFixture):
     def trainer_name(self, rank):
         # The name has to be consistent with that in 'dist_init' decorator.
         return f"worker{rank}"
-
-    def setUp(self):
-        super(TestDdpUnderDistAutograd, self).setUp()
-
-        self._spawn_processes()
-
-    def tearDown(self):
-        super(TestDdpUnderDistAutograd, self).tearDown()
 
     def _remote_worker_process(self):
         gLogger.info("The remote worker is running.")
@@ -447,11 +430,7 @@ class TestDdpUnderDistAutograd(MultiProcessTestCase, RpcAgentTestFixture):
         self._do_test(DdpMode.INSIDE)
 
 
-@unittest.skipIf(
-    TEST_WITH_ASAN,
-    "Skip ASAN as torch + multiprocessing spawn have known issues",
-)
-class TestDdpComparison(MultiProcessTestCase, RpcAgentTestFixture):
+class TestDdpComparison(RpcAgentTestFixture):
 
     @property
     def world_size(self) -> int:
@@ -460,14 +439,6 @@ class TestDdpComparison(MultiProcessTestCase, RpcAgentTestFixture):
     def trainer_name(self, rank):
         # The name has to be consistent with that in 'dist_init' decorator.
         return f"worker{rank}"
-
-    def setUp(self):
-        super(TestDdpComparison, self).setUp()
-
-        self._spawn_processes()
-
-    def tearDown(self):
-        super(TestDdpComparison, self).tearDown()
 
     @requires_gloo()
     @dist_init

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -67,10 +67,6 @@ class RemoteModuleTest(RpcAgentTestFixture):
     def world_size(self):  # Override setting in RpcAgentTestFixture
         return 2
 
-    def setUp(self):
-        super().setUp()
-        self._fork_processes()
-
     @staticmethod
     def _create_remote_module_iter(dst_worker_name, modes=None):
         if modes is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #40823 [RPC tests] Enroll TensorPipe in missing test suites
* #40822 [RPC tests] Remove global TEST_CONFIG
* #40821 [RPC tests] Move some functions to methods of fixture
* #40820 [RPC tests] Make generic fixture an abstract base class
* #40819 [RPC tests] Avoid decorators to skip tests
* #40818 [RPC tests] Merge process group tests into single entry point
* #40817 [RPC tests] Merge tests for faulty agent into single script
* #40816 [RPC tests] Merge TensorPipe tests into single entry point
* #40913 [RPC tests] Fix file descriptor leak
* **#40815 [RPC tests] Align ddp_under_dist_autograd test with others**
* #40814 [RPC tests] Remove world_size and init_method from TensorPipe fixture
* #40860 [RPC tests] Fix @_skip_if_tensorpipe always skipping for all agents

Summary of the entire stack:
--

This diff is part of an attempt to refactor the RPC tests. They currently suffer from several problems:
- Several ways to specify the agent to use: there exists one "generic" fixture that uses the global variable TEST_CONFIG to look up the agent name, and is used for process group and Thrift, and then there are separate fixtures for the flaky agent and the TensorPipe one.
- These two ways lead to having two separate decorators (`@requires_process_group_agent` and `@_skip_if_tensorpipe_agent`) which must both be specified, making it unclear what the effect of each of them is and what happens if only one is given.
- Thrift must override the TEST_CONFIG global variable before any other import (in order for the `@requires_process_group_agent` decorator to work correctly) and for that it must use a "trap" file, which makes it even harder to track which agent is being used, and which is specific to Buck, and thus cannot be used in OSS by other agents.
- Even if the TensorPipe fixture doesn't use TEST_CONFIG, it still needs to set it to the right value for other parts of the code to work. (This is done in `@dist_init`).
- There are a few functions in dist_utils.py that return some properties of the agent (e.g., a regexp to match against the error it returns in case of shutdown). These functions are effectively chained if/elses on the various agents, which has the effect of "leaking" some part of the Thrift agent into OSS.
- Each test suite (RPC, dist autograd/dist optimizer, their JIT versions, remote module, ...) must be run on each agent (or almost; the faulty one is an exception) in both fork and spawn mode. Each of these combinations is a separate file, which leads to a proliferation of scripts.
- There is no "master list" of what combinations make sense and should be run. Therefore it has happened that when adding new tests or new agents we forgot to enroll them into the right tests. (TensorPipe is still missing a few tests, it turns out).
- All of these tiny "entry point" files contain almost the same duplicated boilerplate. This makes it very easy to get the wrong content into one of them due to a bad copy-paste.

This refactoring aims to address these problems by:
- Avoiding global state, defaults/override, traps, if/elses, ... and have a single way to specify the agent, based on an abstract base class and several concrete subclasses which can be "mixed in" to any test suite.
- Instead of enabling/disabling tests using decorators, the tests that are specific to a certain agent are now in a separate class (which is a subclass of the "generic" test suite) so that they are only picked up by the agent they apply to.
- Instead of having one separate entry point script for each combination, it uses one entry point for each agent, and in that script it provides a list of all the test suites it wants to run on that agent. And it does that by trying to deduplicate the boilerplate as much as possible. (In fact, the various agent-suite combinations could be grouped in any way, not necessarily by agent as I did here).

It provides further advantages:
- It puts all the agents on equal standing, by not having any of them be the default, making it thus easier to migrate from process group to TensorPipe.
- It will make it easier to add more versions of the TensorPipe tests (e.g., one that disables the same-machine backends in order to test the TCP-based ones) without a further duplication of entry points, of boilerplate, ...

Summary of this commit
--
This prepares the stack by aligning the `ddp_under_dist_autograd` test to the other ones, so that later changes will be more consistent and thus easier to follow. It does so by moving the `@skipIf` decorators and the `setUp` methods from the base test suite to the entry point scripts.

Differential Revision: [D22287535](https://our.internmc.facebook.com/intern/diff/D22287535/)