### PR TITLE
If ninja is being used, force build_ext to run.

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -335,6 +335,11 @@ class BuildExtension(build_ext, object):
                 warnings.warn(msg.format('we could not find ninja.'))
                 self.use_ninja = False
 
+    def finalize_options(self):
+        super().finalize_options()
+        if self.use_ninja:
+            self.force = True
+
     def build_extensions(self):
         self._check_abi()
         for extension in self.extensions:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40837 If ninja is being used, force build_ext to run.**

As ninja has accurate dependency tracking, if there is nothing to do,
then we will very quickly noop.  But this is important for correctness:
if a change was made to a header that is not listed explicitly in
the distutils Extension, then distutils will come to the wrong
conclusion about whether or not recompilation is needed (but Ninja
will work it out.)

This caused https://github.com/pytorch/vision/issues/2367

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D22340930](https://our.internmc.facebook.com/intern/diff/D22340930)