### PR TITLE
Move OperatorSchema default inference function implementations to .cc…

### DIFF
--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -39,9 +39,8 @@ constexpr int kCannotComputeNumOutputs = -1;
  */
 class CAFFE2_API OpSchema {
  public:
-  OpSchema() : type_("unknown"), file_("unknown"), line_(0) {}
-  OpSchema(const string& type, const string& file, const int line)
-      : type_(type), file_(file), line_(line) {}
+  OpSchema() : OpSchema("unknown", "unknown", 0) {}
+  OpSchema(const string& type, const string& file, const int line);
 
   /**
    * @brief Returns the file that the op schema is registered from.
@@ -443,25 +442,9 @@ class CAFFE2_API OpSchema {
   std::function<bool(int, int)> inplace_enforced_ = [](int, int) {
     return false;
   };
-  TensorInferenceFunctionType tensor_inference_function_ =
-      [](const OperatorDef& def, const vector<TensorShape>&) {
-        vector<TensorShape> out;
-        for (int i = 0; i < def.output_size(); i++) {
-          TensorShape ts;
-          ts.set_unknown_shape(true);
-          out.push_back(ts);
-        }
-        return out;
-      };
+  TensorInferenceFunctionType tensor_inference_function_;
   std::unique_ptr<CostInferenceFunctionType> cost_inference_function_ = nullptr;
-  DeviceInferenceFunctionType device_inference_function_ =
-      [](const OperatorDef& def) {
-        auto op_device =
-            def.has_device_option() ? def.device_option() : DeviceOption();
-        vector<DeviceOption> in_dev(def.input_size(), op_device);
-        vector<DeviceOption> out_dev(def.output_size(), op_device);
-        return std::make_pair(in_dev, out_dev);
-      };
+  DeviceInferenceFunctionType device_inference_function_;
 
   std::function<std::vector<TensorFiller>(
       const std::vector<std::vector<int64_t>>&)>


### PR DESCRIPTION
… file

This prevents implementation of those functions(as lambdas) to be embedded as weak symbol into every shared library that includes this header.

Combination of this and https://github.com/pytorch/pytorch/pull/40844 reduces size of `libcaffe2_module_test_dynamic.so` from 500kb to 50Kb.

