### PR TITLE
Make `torch_cpu` compileable when `USE_TENSORPIPE` is not set.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -853,6 +853,13 @@ if(USE_DISTRIBUTED)
   target_compile_definitions(torch_cpu PRIVATE
     USE_DISTRIBUTED
   )
+  # Pass USE_TENSORPIPE to torch_cpu as some parts of rpc/utils.cpp
+  # can only be compiled with USE_TENSORPIPE is set.
+  if(USE_TENSORPIPE)
+    target_compile_definitions(torch_cpu PRIVATE
+      USE_TENSORPIPE
+    )
+  endif()
 endif()
 
 if(NOT INTERN_BUILD_MOBILE OR BUILD_CAFFE2_MOBILE)

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -21,6 +21,10 @@
 #include <torch/csrc/jit/serialization/pickler.h>
 #include <torch/csrc/jit/serialization/unpickler.h>
 
+#ifdef USE_TENSORPIPE
+#include <tensorpipe/core/message.h>
+#endif
+
 namespace torch {
 namespace distributed {
 namespace rpc {
@@ -448,6 +452,7 @@ std::pair<std::vector<char>, std::vector<at::Tensor>> wireDeserialize(
   return {std::move(payload), std::move(tensors)};
 }
 
+#ifdef USE_TENSORPIPE
 namespace {
 
 // The TensorPipe agent splits the RPC message's information across multiple
@@ -607,6 +612,7 @@ Message tensorpipeDeserialize(
       *buffers.type,
       *buffers.id);
 }
+#endif /* USE_TENSORPIPE */
 
 void writeWrappedPayload(
     std::vector<char>& originalPayload,
@@ -616,7 +622,7 @@ void writeWrappedPayload(
       additionalPayload.begin(),
       additionalPayload.end());
 
-  // Add size of the additional pyaload
+  // Add size of the additional payload
   int64_t indexToWrite = originalPayload.size();
   originalPayload.resize(originalPayload.size() + sizeof(int64_t));
   const int64_t additionalPayloadSize = additionalPayload.size();

--- a/torch/csrc/distributed/rpc/utils.h
+++ b/torch/csrc/distributed/rpc/utils.h
@@ -1,9 +1,12 @@
 #pragma once
 
-#include <tensorpipe/core/message.h>
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 #include <torch/csrc/jit/serialization/pickle.h>
 #include <torch/csrc/utils/byte_order.h>
+
+namespace tensorpipe {
+class Message;
+} // namespace tensorpipe
 
 namespace torch {
 namespace distributed {


### PR DESCRIPTION
Forward-declare `tensorpipe::Message` class in utils.h
Guard TensorPipe specific methods in utils.cpp with `#ifdef USE_TENSORPIPE`
Pass `USE_TENSORPIPE` as private flag to `torch_cpu` library

