### PR TITLE
Override shape hints with real weight shape extracted from workspace

### DIFF
--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -123,7 +123,7 @@ ShapeInfoMap BackendTransformerBase::inferShapes(
     NetDef* pred_net,
     const ShapeInfoMap& shape_hints_mapped,
     const BoundShapeSpec& spec) {
-  ShapeInfoMap shape_map = shape_hints_mapped;
+  ShapeInfoMap shape_map;
 
   // Populate shapes from workplace
   const std::vector<std::string> ws_blobs = ws->Blobs();
@@ -132,6 +132,9 @@ ShapeInfoMap BackendTransformerBase::inferShapes(
     if (shape_info.dimTypeIsSet()) {
       shape_map.emplace(s, shape_info);
     }
+  }
+  for (const auto& s : shape_hints_mapped) {
+    shape_map.insert(s);
   }
   auto eng = BoundShapeInferencerRegistry()->Create("C10", spec);
   eng->InferBoundShapeAndType(*pred_net, shape_map, ws);

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -653,7 +653,7 @@ void BoundShapeInferencer::InferFC(const OperatorDef& op) {
     } else {
       w_data_type = w_shape.data_type();
     }
-    // Note: for FbFCPacked, weight is fp16 but actications are in fp32
+    // Note: for FbFCPacked, weight is fp16 but activations are in fp32
     CheckAndSetTensorBoundShape(
         op.input(0), dimTypes, dims, w_data_type, int8_fc ? true : false);
   } else {

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -1421,6 +1421,9 @@ void OnnxifiTransformer::transform(
     LOG(INFO) << "predictor net has been ssaRewritten, skip rewritting here";
     annotateOpIndex(pred_net);
     shape_hints_mapped = input_shape_hints;
+    for (const auto& w : weights) {
+      input_mapping_.emplace(w, w);
+    }
   } else {
     shape_hints_mapped = ssaRewriteAndMapNames(ws, pred_net, input_shape_hints);
   }


### PR DESCRIPTION
Summary: Shape hints as its name suggests, is hint. We should use real shape from workspace for the weights.

Differential Revision: D22337680

