### PR TITLE
Fix HTTP links in documentation to HTTPS

### DIFF
--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -127,7 +127,7 @@ the best entrance point are great places to start.
 Adding Tutorials
 ~~~~~~~~~~~~~~~~
 
-A great deal of the tutorials on `pytorch.org <http://pytorch.org/>`__
+A great deal of the tutorials on `pytorch.org <https://pytorch.org/>`__
 come from the community itself and we welcome additional contributions.
 To learn more about how to contribute a new tutorial you can learn more
 here: `PyTorch.org Tutorial Contribution Guide on
@@ -305,12 +305,12 @@ Python Docs
 ~~~~~~~~~~~
 
 PyTorch documentation is generated from python source using
-`Sphinx <http://www.sphinx-doc.org/en/master/>`__. Generated HTML is
+`Sphinx <https://www.sphinx-doc.org/en/master/>`__. Generated HTML is
 copied to the docs folder in the master branch of
 `pytorch.github.io <https://github.com/pytorch/pytorch.github.io/tree/master/docs>`__,
 and is served via GitHub pages.
 
--  Site: http://pytorch.org/docs
+-  Site: https://pytorch.org/docs
 -  GitHub: https://github.com/pytorch/pytorch/tree/master/docs
 -  Served from:
    `https://github.com/pytorch/pytorch.github.io/tree/master/doc <https://github.com/pytorch/pytorch.github.io/tree/master/docs>`__
@@ -323,7 +323,7 @@ are built on a special server and the resulting files are copied to the
 https://github.com/pytorch/cppdocs repo, and are served from GitHub
 pages.
 
--  Site: http://pytorch.org/cppdocs
+-  Site: https://pytorch.org/cppdocs
 -  GitHub: https://github.com/pytorch/pytorch/tree/master/docs/cpp
 -  Served from: https://github.com/pytorch/cppdocs
 
@@ -337,8 +337,8 @@ Tutorials are built using
 from executable python sources files, or from restructured-text (rst)
 files.
 
--  Site: http://pytorch.org/tutorials
--  GitHub: http://github.com/pytorch/tutorials
+-  Site: https://pytorch.org/tutorials
+-  GitHub: https://github.com/pytorch/tutorials
 
 Tutorials Build Overview
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -119,7 +119,7 @@ necessary synchronization when data is moved around, as explained above.
 However, when using non-default streams, it is the user's responsibility to
 ensure proper synchronization.
 
-.. _CUDA stream: http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#streams
+.. _CUDA stream: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#streams
 
 .. _cuda-memory-management:
 

--- a/torch/_lowrank.py
+++ b/torch/_lowrank.py
@@ -120,7 +120,7 @@ def svd_lowrank(A, q=6, niter=2, M=None):
           structure with randomness: probabilistic algorithms for
           constructing approximate matrix decompositions,
           arXiv:0909.4061 [math.NA; math.PR], 2009 (available at
-          `arXiv <http://arxiv.org/abs/0909.4061>`_).
+          `arXiv <https://arxiv.org/abs/0909.4061>`_).
 
     """
     if not torch.jit.is_scripting():

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -41,7 +41,7 @@ class Stream(torch._C._CudaStreamBase):
            operations are affected.
 
         .. _CUDA Stream documentation:
-           http://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html
+           https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html
         """
         event.wait(self)
 

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -93,7 +93,7 @@ class Dropout2d(_DropoutNd):
         >>> output = m(input)
 
     .. _Efficient Object Localization Using Convolutional Networks:
-       http://arxiv.org/abs/1411.4280
+       https://arxiv.org/abs/1411.4280
     """
 
     def forward(self, input: Tensor) -> Tensor:
@@ -135,7 +135,7 @@ class Dropout3d(_DropoutNd):
         >>> output = m(input)
 
     .. _Efficient Object Localization Using Convolutional Networks:
-       http://arxiv.org/abs/1411.4280
+       https://arxiv.org/abs/1411.4280
     """
 
     def forward(self, input: Tensor) -> Tensor:
@@ -226,7 +226,7 @@ class FeatureAlphaDropout(_DropoutNd):
 
     .. _Self-Normalizing Neural Networks: https://arxiv.org/abs/1706.02515
     .. _Efficient Object Localization Using Convolutional Networks:
-       http://arxiv.org/abs/1411.4280
+       https://arxiv.org/abs/1411.4280
     """
 
     def forward(self, input: Tensor) -> Tensor:

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -714,7 +714,7 @@ class FractionalMaxPool2d(Module):
         >>> output = m(input)
 
     .. _Fractional MaxPooling:
-        http://arxiv.org/abs/1412.6071
+        https://arxiv.org/abs/1412.6071
     """
     __constants__ = ['kernel_size', 'return_indices', 'output_size',
                      'output_ratio']
@@ -778,7 +778,7 @@ class FractionalMaxPool3d(Module):
         >>> output = m(input)
 
     .. _Fractional MaxPooling:
-        http://arxiv.org/abs/1412.6071
+        https://arxiv.org/abs/1412.6071
     """
     __constants__ = ['kernel_size', 'return_indices', 'output_size',
                      'output_ratio']

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -19,7 +19,7 @@ class ASGD(Optimizer):
         weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
 
     .. _Acceleration of stochastic approximation by averaging:
-        http://dl.acm.org/citation.cfm?id=131098
+        https://dl.acm.org/citation.cfm?id=131098
     """
 
     def __init__(self, params, lr=1e-2, lambd=1e-4, alpha=0.75, t0=1e6, weight_decay=0):

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -6,7 +6,7 @@ class RMSprop(Optimizer):
     r"""Implements RMSprop algorithm.
 
     Proposed by G. Hinton in his
-    `course <http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
+    `course <https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
 
     The centered version first appears in `Generating Sequences
     With Recurrent Neural Networks <https://arxiv.org/pdf/1308.0850v5.pdf>`_.

--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -10,7 +10,7 @@ class SobolEngine(object):
     This implementation of an engine for Sobol sequences is capable of
     sampling sequences up to a maximum dimension of 1111. It uses direction
     numbers to generate these sequences, and these numbers have been adapted
-    from `here <http://web.maths.unsw.edu.au/~fkuo/sobol/joe-kuo-old.1111>`_.
+    from `here <https://web.maths.unsw.edu.au/~fkuo/sobol/joe-kuo-old.1111>`_.
 
     References:
       - Art B. Owen. Scrambling Sobol and Niederreiter-Xing points.


### PR DESCRIPTION
I ran `make linkcheck` using `sphinx.builders.linkcheck` on the documentation and noticed a few links weren't using HTTPS so I quickly updated them all. 