### PR TITLE
Use unbind for tensor.__iter__

### DIFF
--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -453,7 +453,7 @@ class Tensor(torch._C._TensorBase):
                           'Passing a tensor of different shape won\'t change the number of '
                           'iterations executed (and might lead to errors or silently give '
                           'incorrect results).', category=RuntimeWarning)
-        return iter(map(lambda i: self[i], range(self.size(0))))
+        return iter(self.unbind(0))
 
     def __hash__(self):
         return id(self)


### PR DESCRIPTION
Unbind, which has a special backward with cat, is arguably better than multiple selects, whose backward is creating & adding a bunch of tensors as big as `self`.

