### PR TITLE
[jit] Fix value association with dictionaries in the tracer

### DIFF
--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -511,8 +511,7 @@ void TracingState::setValue(const IValue& v, Value* value) {
     TypePtr value_type = dict.valueType();
     for (const auto& entry : dict) {
       auto static_key = graph->insertConstant(entry.key());
-      auto static_value =
-          graph->insert(aten::__getitem__, {value, static_key});
+      auto static_value = graph->insert(aten::__getitem__, {value, static_key});
       setValue(entry.value(), static_value);
     }
   } else {

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -509,28 +509,11 @@ void TracingState::setValue(const IValue& v, Value* value) {
     auto dict = v.toGenericDict();
     TypePtr key_type = dict.keyType();
     TypePtr value_type = dict.valueType();
-    auto dict_size = dict.size();
-    auto handle_unpack = [&](Symbol opname) {
-      auto unpack_to_list = graph->insert(opname, {value});
-      auto list_unpack = graph->createListUnpack(unpack_to_list, dict_size);
-      auto unpack_node = graph->insertNode(list_unpack);
-      auto elem_values = unpack_node->outputs();
-      AT_ASSERT(dict.size() == elem_values.size());
-      size_t i = 0;
-      for (const auto& entry : dict) {
-        if (opname == aten::keys) {
-          setValue(entry.key(), elem_values[i]);
-        } else {
-          setValue(entry.value(), elem_values[i]);
-        }
-        ++i;
-      }
-    };
-    if (key_type->cast<TensorType>()) {
-      handle_unpack(aten::keys);
-    }
-    if (value_type->cast<TensorType>()) {
-      handle_unpack(aten::values);
+    for (const auto& entry : dict) {
+      auto static_key = graph->insertConstant(entry.key());
+      auto static_value =
+          graph->insert(aten::__getitem__, {value, static_key});
+      setValue(entry.value(), static_value);
     }
   } else {
     std::ostringstream os;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#40885 [jit] Fix value association with dictionaries in the tracer**

`TracingState::setValue` associates a concrete IValue in the traced
program with a `Value*` symbolic. Previously, the logic for how
GenericDicts worked was special cased to only work for very simple cases
and silently eat other cases.

This PR generalizes the logic to reflect the same behavior as using
dictionaries on input: whenever we encounter a dictionary in the system,
we completely "burn in" all the keys into the graph, and then
recursively call `setValue` on the associated value.

This has the effect of requiring that any dictionary structure you are
creating in a traced program be of fixed structure, similar to how any
dictionary used as input must be static as well.

Differential Revision: [D22342490](https://our.internmc.facebook.com/intern/diff/D22342490)