### PR TITLE
[WIP] Fix cpp grad accessor API

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -530,8 +530,8 @@ class CAFFE2_API Tensor {
 
   /// Return a mutable reference to the gradient. This is conventionally
   /// used as `t.grad() = x` to set a gradient to a completely new tensor.
-  Tensor& grad() {
-    return impl_->grad();
+  Tensor& mutable_grad() {
+    return impl_->mutable_grad();
   }
 
   /// This function returns an undefined tensor by default and returns a defined tensor

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -530,6 +530,8 @@ class CAFFE2_API Tensor {
 
   /// Return a mutable reference to the gradient. This is conventionally
   /// used as `t.grad() = x` to set a gradient to a completely new tensor.
+  /// Note that this function work with a non-const Tensor and is not
+  /// thread safe.
   Tensor& mutable_grad() {
     return impl_->mutable_grad();
   }

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -28,9 +28,9 @@ const char * const TensorImpl::err_msg_tensor_metadata_change_not_allowed =
     "    with torch.no_grad():\n"
     "        x.set_(y)";
 
-at::Tensor& TensorImpl::grad() {
+at::Tensor& TensorImpl::mutable_grad() {
   if (!autograd_meta_) autograd_meta_ = impl::GetAutogradMetaFactory()->make();
-  return autograd_meta_->grad();
+  return autograd_meta_->mutable_grad();
 }
 
 const at::Tensor& TensorImpl::grad() const {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -134,7 +134,7 @@ struct TensorImpl;
 struct C10_API AutogradMetaInterface {
   virtual void set_requires_grad(bool requires_grad, at::TensorImpl* self_impl) = 0;
   virtual bool requires_grad() const = 0;
-  virtual at::Tensor& grad() = 0;
+  virtual at::Tensor& mutable_grad() = 0;
   virtual const at::Tensor& grad() const = 0;
   virtual ~AutogradMetaInterface();
 };
@@ -575,7 +575,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * It is only valid to call this method on a Variable.
    * See Note [Tensor versus Variable in C++].
    */
-  at::Tensor& grad();
+  at::Tensor& mutable_grad();
 
   /**
    * Return the accumulated gradient of a tensor.  This gradient is written

--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -41,7 +41,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
     for (int i = 0; i < grads.size(); i++) {
       auto param = l->parameters()[i];
       auto grad = grads[i];
-      p_scale.push_back(param.grad().data().div(grad).view(-1));
+      p_scale.push_back(param.mutable_grad().data().div(grad).view(-1));
     }
     auto scale = torch::cat(p_scale);
     return scale; // need to assert std is 0.
@@ -60,7 +60,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   };
   for (auto norm_type : norm_types) {
     for (int i = 0; i < grads.size(); i++) {
-      l->parameters()[i].grad() =
+      l->parameters()[i].mutable_grad() =
           grads[i].clone().view_as(l->parameters()[i].data());
     }
     auto norm_before = compute_norm(norm_type);
@@ -79,7 +79,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   };
   for (auto norm_type : norm_types) {
     for (int i = 0; i < grads.size(); i++) {
-      l->parameters()[i].grad().data().copy_(grads[i]);
+      l->parameters()[i].mutable_grad().data().copy_(grads[i]);
     }
     auto norm_before = compute_norm(norm_type);
     auto norm = utils::clip_grad_norm_(l->parameters(), max_norm, norm_type);
@@ -95,8 +95,8 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   auto p1 = torch::randn({10, 10});
   auto p2 = torch::randn({10, 10});
   auto g = torch::arange(1., 101).view({10, 10});
-  p1.grad() = g.clone();
-  p2.grad() = g.clone();
+  p1.mutable_grad() = g.clone();
+  p2.mutable_grad() = g.clone();
   for (const auto norm_type : norm_types) {
     utils::clip_grad_norm_(p1, max_norm, norm_type);
     utils::clip_grad_norm_({p2}, max_norm, norm_type);
@@ -116,7 +116,7 @@ TEST_F(NNUtilsTest, ClipGradValue) {
     for (int i = 0; i < grad_list.size(); i++) {
       auto p = l->parameters()[i];
       auto g = grad_list[i];
-      p.grad() = g.defined() ? g.clone().view_as(p.data()) : g;
+      p.mutable_grad() = g.defined() ? g.clone().view_as(p.data()) : g;
     }
 
     utils::clip_grad_value_(l->parameters(), clip_value);
@@ -134,8 +134,8 @@ TEST_F(NNUtilsTest, ClipGradValue) {
   auto p1 = torch::randn({10, 10});
   auto p2 = torch::randn({10, 10});
   auto g = torch::arange(-50., 50).view({10, 10}).div_(5);
-  p1.grad() = g.clone();
-  p2.grad() = g.clone();
+  p1.mutable_grad() = g.clone();
+  p2.mutable_grad() = g.clone();
   utils::clip_grad_value_(p1, clip_value);
   utils::clip_grad_value_({p2}, clip_value);
   ASSERT_TRUE(torch::allclose(p1.grad(), p2.grad()));

--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -41,7 +41,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
     for (int i = 0; i < grads.size(); i++) {
       auto param = l->parameters()[i];
       auto grad = grads[i];
-      p_scale.push_back(param.mutable_grad().data().div(grad).view(-1));
+      p_scale.push_back(param.grad().data().div(grad).view(-1));
     }
     auto scale = torch::cat(p_scale);
     return scale; // need to assert std is 0.
@@ -79,7 +79,7 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
   };
   for (auto norm_type : norm_types) {
     for (int i = 0; i < grads.size(); i++) {
-      l->parameters()[i].mutable_grad().data().copy_(grads[i]);
+      l->parameters()[i].grad().data().copy_(grads[i]);
     }
     auto norm_before = compute_norm(norm_type);
     auto norm = utils::clip_grad_norm_(l->parameters(), max_norm, norm_type);

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -422,7 +422,7 @@ TEST(OptimTest, ExternalVectorOfParameters) {
 
   // Set all gradients to one
   for (auto& parameter : parameters) {
-    parameter.grad() = torch::ones_like(parameter);
+    parameter.mutable_grad() = torch::ones_like(parameter);
   }
 
   SGD optimizer(parameters, 1.0);
@@ -442,7 +442,7 @@ TEST(OptimTest, AddParameter_LBFGS) {
 
   // Set all gradients to one
   for (auto& parameter : parameters) {
-    parameter.grad() = torch::ones_like(parameter);
+    parameter.mutable_grad() = torch::ones_like(parameter);
   }
 
   LBFGS optimizer(std::vector<torch::Tensor>{}, 1.0);

--- a/test/custom_operator/test_custom_ops.cpp
+++ b/test/custom_operator/test_custom_ops.cpp
@@ -66,8 +66,8 @@ void get_autograd_operator_from_registry_and_execute() {
   TORCH_INTERNAL_ASSERT(torch::allclose(y.grad(), x + torch::ones({5,5})*2));
 
   // Test with optional argument.
-  at::zero_(x.grad());
-  at::zero_(y.grad());
+  at::zero_(x.mutable_grad());
+  at::zero_(y.mutable_grad());
   output = helpers::get_operator_from_registry_and_execute<torch::Tensor>(
       "custom::op_with_autograd", x, 2, y, z);
 

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -255,7 +255,7 @@ void Module::zero_grad() {
     child.value()->zero_grad();
   }
   for (auto& parameter : named_parameters(/*recurse=*/false)) {
-    auto& grad = parameter->grad();
+    auto& grad = parameter->mutable_grad();
     if (grad.defined()) {
       grad = grad.detach();
       grad.zero_();

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -170,12 +170,12 @@ void retain_grad(const Tensor & self) {
       auto var = weak_self.lock();
       if (!var->grad().defined()) {
         if (grad.is_sparse()) {
-          var->grad() = grad.clone();
+          var->mutable_grad() = grad.clone();
         } else {
-          var->grad() = grad.clone(at::MemoryFormat::Contiguous);
+          var->mutable_grad() = grad.clone(at::MemoryFormat::Contiguous);
         }
       } else {
-        var->grad() = var->grad() + grad;
+        var->mutable_grad() = var->grad() + grad;
       }
     }
   });

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -73,7 +73,7 @@ variable_list _wrap_outputs(const variable_list &input_vars,
 
       // If the input was modified, transplant the grad_fn in the graph:
       // grad_fn <- variable <- self  ==>  grad_fn <- self <- variable
-      var.grad().reset();
+      var.mutable_grad().reset();
       impl::clear_hooks(var);
       if (auto grad_acc_fn = impl::try_get_grad_accumulator(var)) {
         auto grad_acc = dynamic_cast<AccumulateGrad*>(grad_acc_fn.get());

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -33,8 +33,6 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
   if (!variable.requires_grad())
     return {};
 
-  at::Tensor& grad = variable.mutable_grad();
-
   // std::move(grads[0]) to avoid bumping up refcount
   at::Tensor new_grad = callHooks(variable, std::move(grads[0]));
 
@@ -44,6 +42,8 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
   // and rely on user to provide thread safe hooks
   // see Note [Thread Safety on Autograd Node]
   std::lock_guard<std::mutex> lock(mutex_);
+
+  at::Tensor& grad = variable.mutable_grad();
 
   // If the function has post hooks (for example, a DDP allreduce hook),
   // call_function in Engine.cpp will temporarily bump the expected refcount

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -33,7 +33,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
   if (!variable.requires_grad())
     return {};
 
-  at::Tensor& grad = variable.grad();
+  at::Tensor& grad = variable.mutable_grad();
 
   // std::move(grads[0]) to avoid bumping up refcount
   at::Tensor new_grad = callHooks(variable, std::move(grads[0]));

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -275,7 +275,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad, void *unused)
   HANDLE_TH_ERRORS
   auto& var = self->cdata;
   if (!py_grad || py_grad == Py_None) {
-    var.grad().reset();
+    var.mutable_grad().reset();
     return 0;
   }
 
@@ -297,7 +297,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad, void *unused)
   THPUtils_assertRet(-1, grad.sizes().equals(var.sizes()),
       "assigned grad has data of a different size");
 
-  var.grad() = grad;
+  var.mutable_grad() = grad;
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
 }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -230,7 +230,7 @@ struct TORCH_API AutogradMeta : public c10::AutogradMetaInterface {
   }
 
   /// Accesses the gradient `Variable` of this `Variable`.
-  Variable& grad() override {
+  Variable& mutable_grad() override {
     return grad_;
   }
 

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -958,7 +958,7 @@ void Reducer::runGradCallbackForVariable(
     GradCallback&& cb) {
   auto context_ptr = rpc_context_.context_ptr.load();
   if (context_ptr == nullptr) {
-    cb(variable.grad());
+    cb(variable.mutable_grad());
   } else {
     // Under distributed autograd
     context_ptr->runGradCallbackForVariable(variable, std::move(cb));


### PR DESCRIPTION
Update the API to access grad in cpp to avoid unexpected thread safety issues.
In particular, with the current API, a check like `t.grad().defined()` is not thread safe.

- This introduces `t.mutable_grad()` that should be used when getting a mutable version of the saved gradient. This function is **not** thread safe.
- The `Tensor& grad()` API is now removed. We could not do a deprecation cycle as most of our call side use non-const Tensors that use the non-const overload. This would lead to most calls hitting the warning. This would be too verbose for all the users.