### PR TITLE
optimize upsample bicubic mode performance on CPU

### DIFF
--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -68,6 +68,7 @@ using upsampling_nearest3d = void(*)(Tensor& output, const Tensor& input, scale_
 using upsampling_linear1d = void(*)(Tensor& output, const Tensor& input, bool align_corners, scale_t scales_w);
 using upsampling_bilinear2d = void(*)(Tensor& output, const Tensor& input, bool align_corners, scale_t scales_h, scale_t scales_w);
 using upsampling_trilinear3d = void(*)(Tensor& output, const Tensor& input, bool align_corners, scale_t scales_d, scale_t scales_h, scale_t scales_w);
+using upsampling_bicubic2d = void(*)(Tensor& output, const Tensor& input, bool align_corners, scale_t scales_h, scale_t scales_w);
 DECLARE_DISPATCH(upsampling_nearest1d, upsample_nearest1d_kernel);
 DECLARE_DISPATCH(upsampling_nearest2d, upsample_nearest2d_kernel);
 DECLARE_DISPATCH(upsampling_nearest3d, upsample_nearest3d_kernel);
@@ -80,6 +81,7 @@ DECLARE_DISPATCH(upsampling_trilinear3d, upsample_trilinear3d_kernel);
 DECLARE_DISPATCH(upsampling_linear1d, upsample_linear1d_backward_kernel);
 DECLARE_DISPATCH(upsampling_bilinear2d, upsample_bilinear2d_backward_kernel);
 DECLARE_DISPATCH(upsampling_trilinear3d, upsample_trilinear3d_backward_kernel);
+DECLARE_DISPATCH(upsampling_bicubic2d, upsample_bicubic2d_kernel);
 
 static inline void upsample_1d_shape_check(
     const Tensor& input,

--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -82,6 +82,7 @@ DECLARE_DISPATCH(upsampling_linear1d, upsample_linear1d_backward_kernel);
 DECLARE_DISPATCH(upsampling_bilinear2d, upsample_bilinear2d_backward_kernel);
 DECLARE_DISPATCH(upsampling_trilinear3d, upsample_trilinear3d_backward_kernel);
 DECLARE_DISPATCH(upsampling_bicubic2d, upsample_bicubic2d_kernel);
+DECLARE_DISPATCH(upsampling_bicubic2d, upsample_bicubic2d_backward_kernel);
 
 static inline void upsample_1d_shape_check(
     const Tensor& input,

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -36,7 +36,7 @@ static void upsample_bicubic2d_out_cpu_template(
       output_height,
       output_width);
 
-  output.resize_({nbatch, channels, output_height, output_width});
+  output.resize_({nbatch, channels, output_height, output_width}, input.suggest_memory_format());
 
   AT_ASSERT(
       input_height > 0 && input_width > 0 && output_height > 0 &&

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -7,88 +7,6 @@ namespace native {
 namespace {
 
 template <typename scalar_t>
-static void upsample_bicubic2d_out_frame(
-    scalar_t* odata,
-    scalar_t* idata,
-    int64_t input_height,
-    int64_t input_width,
-    int64_t output_height,
-    int64_t output_width,
-    int64_t nbatch,
-    int64_t channels,
-    bool align_corners,
-    c10::optional<double> scales_h,
-    c10::optional<double> scales_w) {
-  // Special case: input/output same size, just copy
-  if (input_height == output_height && input_width == output_width) {
-    for (int64_t output_y = 0; output_y < output_height; output_y++) {
-      for (int64_t output_x = 0; output_x < output_width; output_x++) {
-        const scalar_t* in = &idata[output_y * input_width + output_x];
-        scalar_t* out = &odata[output_y * output_width + output_x];
-
-        for (int64_t c = 0; c < channels; ++c) {
-          out[0] = in[0];
-          in += input_width * input_height;
-          out += output_width * output_height;
-        }
-      }
-    }
-    return;
-  }
-
-  // Bicubic interpolation
-  const scalar_t height_scale = area_pixel_compute_scale<scalar_t>(
-      input_height, output_height, align_corners, scales_h);
-  const scalar_t width_scale = area_pixel_compute_scale<scalar_t>(
-      input_width, output_width, align_corners, scales_w);
-
-  for (int64_t output_y = 0; output_y < output_height; output_y++) {
-    for (int64_t output_x = 0; output_x < output_width; output_x++) {
-      scalar_t* in = idata;
-      scalar_t* out = odata;
-
-      const scalar_t real_x = area_pixel_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
-      int64_t input_x = floorf(real_x);
-      const scalar_t t_x = real_x - input_x;
-
-      const scalar_t real_y = area_pixel_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
-      int64_t input_y = floorf(real_y);
-      const scalar_t t_y = real_y - input_y;
-
-      for (int64_t c = 0; c < channels * nbatch; c++) {
-        scalar_t coefficients[4];
-
-        // Interpolate 4 times in the x direction
-        for (int64_t i = 0; i < 4; i++) {
-          coefficients[i] = cubic_interp1d<scalar_t>(
-              upsample_get_value_bounded<scalar_t>(
-                  in, input_width, input_height, input_x - 1, input_y - 1 + i),
-              upsample_get_value_bounded<scalar_t>(
-                  in, input_width, input_height, input_x + 0, input_y - 1 + i),
-              upsample_get_value_bounded<scalar_t>(
-                  in, input_width, input_height, input_x + 1, input_y - 1 + i),
-              upsample_get_value_bounded<scalar_t>(
-                  in, input_width, input_height, input_x + 2, input_y - 1 + i),
-              t_x);
-        }
-
-        // Interpolate in the y direction using x interpolations
-        out[output_y * output_width + output_x] = cubic_interp1d<scalar_t>(
-            coefficients[0],
-            coefficients[1],
-            coefficients[2],
-            coefficients[3],
-            t_y);
-
-        // Move to next channel
-        in += input_width * input_height;
-        out += output_width * output_height;
-      }
-    }
-  }
-}
-
-template <typename scalar_t>
 static void upsample_bicubic2d_backward_out_frame(
     scalar_t* odata,
     scalar_t* idata,
@@ -167,7 +85,7 @@ static void upsample_bicubic2d_backward_out_frame(
 
 static void upsample_bicubic2d_out_cpu_template(
     Tensor& output,
-    const Tensor& input_,
+    const Tensor& input,
     IntArrayRef output_size,
     bool align_corners,
     c10::optional<double> scales_h,
@@ -180,13 +98,13 @@ static void upsample_bicubic2d_out_cpu_template(
   int64_t output_height = output_size[0];
   int64_t output_width = output_size[1];
 
-  int64_t nbatch = input_.size(0);
-  int64_t channels = input_.size(1);
-  int64_t input_height = input_.size(2);
-  int64_t input_width = input_.size(3);
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_height = input.size(2);
+  int64_t input_width = input.size(3);
 
   upsample_2d_shape_check(
-      input_,
+      input,
       Tensor(),
       nbatch,
       channels,
@@ -195,28 +113,13 @@ static void upsample_bicubic2d_out_cpu_template(
       output_height,
       output_width);
 
-  auto input = input_.contiguous();
-
   output.resize_({nbatch, channels, output_height, output_width});
-  output.zero_();
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "upsample_bicubic2d", [&] {
-    auto* idata = input.data_ptr<scalar_t>();
-    auto* odata = output.data_ptr<scalar_t>();
+  AT_ASSERT(
+      input_height > 0 && input_width > 0 && output_height > 0 &&
+      output_width > 0);
 
-    upsample_bicubic2d_out_frame<scalar_t>(
-        odata,
-        idata,
-        input_height,
-        input_width,
-        output_height,
-        output_width,
-        nbatch,
-        channels,
-        align_corners,
-        scales_h,
-        scales_w);
-  });
+  upsample_bicubic2d_kernel(kCPU, output, input, align_corners, scales_h, scales_w);
 }
 
 static void upsample_bicubic2d_backward_out_cpu_template(
@@ -361,6 +264,8 @@ Tensor upsample_bicubic2d_backward_cpu(
       grad_input, grad_output, osize, input_size, align_corners, scale_h, scale_w);
   return grad_input;
 }
+
+DEFINE_DISPATCH(upsample_bicubic2d_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cpu/UpSampleEvenMoreKernels.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleEvenMoreKernels.cpp
@@ -199,14 +199,9 @@ void upsample_bicubic2d_kernel_impl(
     bool align_corners,
     c10::optional<double> scales_h,
     c10::optional<double> scales_w) {
-  auto memory_format = input.suggest_memory_format();
-  if (memory_format == at::MemoryFormat::ChannelsLast) {
-    std::cout << " TODO: cl path... " << std::endl;
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Byte, input.scalar_type(), "upsample_bicubic2d", [&] {
-      cpu_upsample_bicubic<scalar_t, scale_t>(output, input, align_corners, {scales_h, scales_w});
-    });
-  }
+  AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Byte, input.scalar_type(), "upsample_bicubic2d", [&] {
+    cpu_upsample_bicubic<scalar_t, scale_t>(output, input, align_corners, {scales_h, scales_w});
+  });
 }
 
 void upsample_bicubic2d_backward_kernel_impl(

--- a/aten/src/ATen/native/cpu/UpSampleEvenMoreKernels.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleEvenMoreKernels.cpp
@@ -1,0 +1,133 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/native/UpSample.h>
+#include <ATen/Parallel.h>
+
+namespace at {
+namespace native {
+namespace {
+
+template <typename scalar_t>
+static inline void compute_source_index_and_lambda(
+    int64_t& input_index,
+    scalar_t& lambda,
+    scalar_t ratio,
+    int64_t output_index,
+    int64_t input_size,
+    int64_t output_size,
+    bool align_corners) {
+  const scalar_t real_input_index = area_pixel_compute_source_index<scalar_t>(
+    ratio, output_index, align_corners, /*cubic=*/true);
+  input_index = floorf(real_input_index);
+  lambda = real_input_index - input_index;
+}
+
+
+template <typename scalar_t, typename scale_type>
+void cpu_upsample_bicubic(
+    Tensor& output_,
+    const Tensor& input_,
+    bool align_corners,
+    const scale_type& scales) {
+  TORCH_CHECK(input_.dtype() == output_.dtype(), "expected dtype ", input_.dtype(),
+              " for `output` but got dtype ", output_.dtype());
+  auto input = input_.contiguous();
+  auto output = output_.contiguous();
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+  auto input_sizes = input.sizes().vec();
+  auto output_sizes = output.sizes().vec();
+  auto ndim = input_sizes.size();
+
+  // treat nbatch and channels as one dimension
+  int64_t channels = input_sizes[0] * input_sizes[1];
+  int64_t input_height = input_sizes[2];
+  int64_t output_height = output_sizes[2];
+  int64_t input_width = input_sizes[3];
+  int64_t output_width = output_sizes[3];
+
+  int64_t output_slice_size = output_height * output_width;
+
+  // Special case: input/output same size, just copy
+  if (input_height == output_height && input_width == output_width) {
+    output_.copy_(input_);
+    return;
+  }
+
+  auto loop2d = [&](int64_t begin, int64_t end) {
+    const scalar_t height_scale = area_pixel_compute_scale<scalar_t>(
+        input_height, output_height, align_corners, scales[0]);
+    const scalar_t width_scale = area_pixel_compute_scale<scalar_t>(
+        input_width, output_width, align_corners, scales[1]);
+
+    int64_t ih, iw;
+    scalar_t hlambda, wlambda;
+    for (int64_t c = begin; c < end; c++) {
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        compute_source_index_and_lambda(
+            ih, hlambda, height_scale, oh, input_height, output_height, align_corners);
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          compute_source_index_and_lambda(
+              iw, wlambda, width_scale, ow, input_width, output_width, align_corners);
+
+          scalar_t* input_ptr = input_data + c * input_height * input_width;
+
+          // Interpolate 4 times in the x direction
+          scalar_t coefficients[4];
+          for (int64_t i = 0; i < 4; i++) {
+            coefficients[i] = cubic_interp1d<scalar_t>(
+                upsample_get_value_bounded<scalar_t>(
+                    input_ptr, input_width, input_height, iw - 1, ih - 1 + i),
+                upsample_get_value_bounded<scalar_t>(
+                    input_ptr, input_width, input_height, iw + 0, ih - 1 + i),
+                upsample_get_value_bounded<scalar_t>(
+                    input_ptr, input_width, input_height, iw + 1, ih - 1 + i),
+                upsample_get_value_bounded<scalar_t>(
+                    input_ptr, input_width, input_height, iw + 2, ih - 1 + i),
+                wlambda);
+          }
+          
+          // Interpolate in the y direction using x interpolations
+          int64_t output_offset = c * output_slice_size + oh * output_width + ow;
+          output_data[output_offset] = cubic_interp1d<scalar_t>(
+              coefficients[0],
+              coefficients[1],
+              coefficients[2],
+              coefficients[3],
+              hlambda);
+        }
+      }
+    }
+  };
+
+  at::parallel_for(0, channels, at::internal::GRAIN_SIZE / output_slice_size / 4, loop2d);
+
+  if (!output_.is_contiguous()) {
+    output_.copy_(output);
+  }
+}
+
+using scale_t = std::vector<c10::optional<double>>;
+void upsample_bicubic2d_kernel_impl(
+    Tensor& output,
+    const Tensor& input,
+    bool align_corners,
+    c10::optional<double> scales_h,
+    c10::optional<double> scales_w) {
+  auto memory_format = input.suggest_memory_format();
+  if (memory_format == at::MemoryFormat::ChannelsLast) {
+    std::cout << " TODO: cl path... " << std::endl;
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Byte, input.scalar_type(), "upsample_bicubic2d", [&] {
+      cpu_upsample_bicubic<scalar_t, scale_t>(output, input, align_corners, {scales_h, scales_w});
+    });
+  }
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(upsample_bicubic2d_kernel, &upsample_bicubic2d_kernel_impl);
+
+} // namespace native
+} // namespace at


### PR DESCRIPTION
This PR aims at improving upsample bicubic mode performance on CPU. This patch simply parallel the outer loop on CPU, but sitll have performance improvement for single thread case since the original code has non-contigous memory access pattern which is not efficient. On my test machine single thread and single socket achieve 7x and 117x speedup respectively.
Related work: https://github.com/pytorch/pytorch/pull/31452, https://github.com/pytorch/pytorch/pull/34864

Result on Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz, 20 cores per socket, dual socket.

```bash
before:
### using OMP_NUM_THREADS=20
### using numactl --physcpubind=0-19 --membind=0

input.is_contiguous(memory_format=torch.channels_last):  False
input.is_contiguous():  True
forward time per iteration: 10105.570 ms
upsample_bilinear_cl: memory format: nhwc, input size:  torch.Size([32, 128, 64, 64])
input.is_contiguous(memory_format=torch.channels_last):  True
input.is_contiguous():  False
forward time per iteration: 10092.228 ms

### using OMP_NUM_THREADS=1
### using numactl --physcpubind=0 --membind=0

upsample_bilinear: memory format: nchw, input size:  torch.Size([32, 128, 64, 64])
input.is_contiguous(memory_format=torch.channels_last):  False
input.is_contiguous():  True
forward time per iteration: 10167.732 ms
upsample_bilinear_cl: memory format: nhwc, input size:  torch.Size([32, 128, 64, 64])
input.is_contiguous(memory_format=torch.channels_last):  True
input.is_contiguous():  False
forward time per iteration: 10199.118 ms


after:
### using OMP_NUM_THREADS=20
### using numactl --physcpubind=0-19 --membind=0

upsample_bilinear: memory format: nchw, input size:  torch.Size([32, 128, 64, 64])
input.is_contiguous(memory_format=torch.channels_last):  False
input.is_contiguous():  True
forward time per iteration: 86.109 ms
upsample_bilinear_cl: memory format: nhwc, input size:  torch.Size([32, 128, 64, 64])
input.is_contiguous(memory_format=torch.channels_last):  True
input.is_contiguous():  False
forward time per iteration: 139.421 ms

### using OMP_NUM_THREADS=1
### using numactl --physcpubind=0 --membind=0

upsample_bilinear: memory format: nchw, input size:  torch.Size([32, 128, 64, 64])
input.is_contiguous(memory_format=torch.channels_last):  False
input.is_contiguous():  True
forward time per iteration: 1449.662 ms
upsample_bilinear_cl: memory format: nhwc, input size:  torch.Size([32, 128, 64, 64])
input.is_contiguous(memory_format=torch.channels_last):  True
input.is_contiguous():  False
forward time per iteration: 2072.506 ms
```