### PR TITLE
Re-enable Caffe2 test `RoiAlignTest.CheckCPUGPUEqual`

### DIFF
--- a/caffe2/operators/roi_align_op_gpu_test.cc
+++ b/caffe2/operators/roi_align_op_gpu_test.cc
@@ -195,8 +195,7 @@ void CreateAndRun(
 
 } // namespace
 
-// See https://github.com/pytorch/pytorch/issues/35547
-TEST(RoiAlignTest, DISABLED_ON_WINDOWS(CheckCPUGPUEqual)) {
+TEST(RoiAlignTest, CheckCPUGPUEqual) {
   if (!caffe2::HasCudaGPU())
     return;
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/35547.