### PR TITLE
Fix module dict key ordering

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1203,7 +1203,7 @@ class TestNN(NNTestCase):
             'fc4': nn.Linear(5, 5),
             'act3': nn.Sigmoid()
         }
-        modules.update(sorted(next_modules.items()))
+        modules.update(next_modules.items())
         module_dict.update(next_modules)
         check()
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -243,12 +243,14 @@ class ModuleDict(Module):
 
     * the order of insertion, and
 
-    * in :meth:`~torch.nn.ModuleDict.update`, the order of the merged ``OrderedDict``
-      or another :class:`~torch.nn.ModuleDict` (the argument to :meth:`~torch.nn.ModuleDict.update`).
+    * in :meth:`~torch.nn.ModuleDict.update`, the order of the merged 
+      ``OrderedDict``, ``dict`` (started from Python 3.6) or another
+      :class:`~torch.nn.ModuleDict` (the argument to 
+      :meth:`~torch.nn.ModuleDict.update`).
 
     Note that :meth:`~torch.nn.ModuleDict.update` with other unordered mapping
-    types (e.g., Python's plain ``dict``) does not preserve the order of the
-    merged mapping.
+    types (e.g., Python's plain ``dict`` before Python verision 3.6) does not 
+    preserve the order of the merged mapping.
 
     Arguments:
         modules (iterable, optional): a mapping (dictionary) of (string: module)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -351,11 +351,8 @@ class ModuleDict(Module):
                             "iterable of key/value pairs, but got " +
                             type(modules).__name__)
 
-        if isinstance(modules, (OrderedDict, ModuleDict)):
+        if isinstance(modules, (OrderedDict, ModuleDict, container_abcs.Mapping)):
             for key, module in modules.items():
-                self[key] = module
-        elif isinstance(modules, container_abcs.Mapping):
-            for key, module in sorted(modules.items()):
                 self[key] = module
         else:
             for j, m in enumerate(modules):


### PR DESCRIPTION
fix #40227
Removed the sorting operation both in ModuleDict class, updated the docstring.
Also remove a sort operation in corresponding unit test, which will lead to unit test fail.

BC Note: Python version after 3.6, the plain dict will preserve the order of keys.
example:
For a python 3.6+ user, if he is initial a ModuleDict instance using plain python dict:
{
"b": torch.nn.MaxPool2d(3),
"a": torch.nn.MaxPool2d(3)
}
, he will get a ModuleDict which preserve the order:
ModuleDict(
(b): MaxPool2d(kernel_size=3, stride=3, padding=0, dilation=1, ceil_mode=False)
(a): MaxPool2d(kernel_size=3, stride=3, padding=0, dilation=1, ceil_mode=False)
)

For a python 3.5 user, if we maintain the same input, then the output ModuleDict could be:
ModuleDict(
(a): MaxPool2d(kernel_size=3, stride=3, padding=0, dilation=1, ceil_mode=False)
(b): MaxPool2d(kernel_size=3, stride=3, padding=0, dilation=1, ceil_mode=False)
)