### PR TITLE
Remove Int8FC diff restriction.

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -94,8 +94,8 @@ class Int8OpsTest(serial.SerializedTestCase):
         workspace.RunNet(net_onnxified.name)
         Y_glow = workspace.FetchBlob("Y")
 
-        diff = Y_fbgemm - Y_glow
-        if np.count_nonzero(diff) * 10 > diff.size:
+        if not np.allclose(Y_glow, Y_fbgemm):
+            diff_Y = np.abs(Y_glow - Y_fbgemm)
             print_test_debug_info(
                 "int8_fc",
                 {
@@ -197,8 +197,8 @@ class Int8OpsTest(serial.SerializedTestCase):
         workspace.RunNet(net_onnxified.name)
         Y_glow = workspace.FetchBlob("Y")
 
-        diff = Y_fbgemm - Y_glow
-        if np.count_nonzero(diff) * 10 > diff.size:
+        if not np.allclose(Y_glow, Y_fbgemm):
+            diff_Y = np.abs(Y_glow - Y_fbgemm)
             print_test_debug_info(
                 "int8_fc",
                 {


### PR DESCRIPTION
Summary: Remove Int8FC diff restriction.

Test Plan: test_int8_ops_nnpi.py

Reviewed By: hyuen

Differential Revision: D22353200

