### PR TITLE
pytorch | Fix linking of qnnpack params on windows.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
@@ -245,7 +245,7 @@ static void compute_dwconv_multiipass(
   const size_t output_height = context->output_height;
   PYTORCH_QNNP_ALIGN(16)
 #ifdef _MSC_VER
-  int32_t* multipass_acc = _malloca(sizeof(int32_t) * context->group_stride);
+  int32_t* multipass_acc = (int32_t*)_malloca(sizeof(int32_t) * context->group_stride);
 #else
   int32_t multipass_acc[context->group_stride];
 #endif

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/init.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/init.c
@@ -36,7 +36,7 @@
 
 #ifdef _MSC_VER
 static INIT_ONCE init_guard;
-BOOL CALLBACK init_win(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* lpContex);
+BOOL CALLBACK pytorch_qnnp_init_win(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* lpContex);
 #else
 static pthread_once_t init_guard = PTHREAD_ONCE_INIT;
 #endif
@@ -262,7 +262,7 @@ enum pytorch_qnnp_status pytorch_qnnp_initialize(void) {
     return pytorch_qnnp_status_out_of_memory;
   }
 #ifdef _MSC_VER
-  InitOnceExecuteOnce(&init_guard, init_win, NULL, NULL);
+  InitOnceExecuteOnce(&init_guard, pytorch_qnnp_init_win, NULL, NULL);
 #else
   pthread_once(&init_guard, &init);
 #endif
@@ -279,7 +279,7 @@ enum pytorch_qnnp_status pytorch_qnnp_deinitialize(void) {
 }
 
 #ifdef _MSC_VER
-BOOL CALLBACK init_win(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* lpContex) {
+BOOL CALLBACK pytorch_qnnp_init_win(PINIT_ONCE InitOnce, PVOID Parameter, PVOID* lpContex) {
   init();
   return TRUE;
 }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/params.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/params.h
@@ -573,4 +573,12 @@ struct pytorch_qnnp_parameters {
   bool initialized;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern PYTORCH_QNNP_INTERNAL struct pytorch_qnnp_parameters pytorch_qnnp_params;
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Summary: Pytorch depends on this from both C and C++ source files, so unify linking so it's fully fixed.

Test Plan: Build it on Windows

Differential Revision: D22348247

