### PR TITLE
Add `module.training` to docs

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -181,6 +181,10 @@ class Module:
 
     Submodules assigned in this way will be registered, and will have their
     parameters converted too when you call :meth:`to`, etc.
+
+    :ivar training: Boolean represents whether this module is in training or
+                    evaluation mode.
+    :vartype training: bool
     """
 
     dump_patches: bool = False


### PR DESCRIPTION
A lot of people ask https://discuss.pytorch.org/t/check-if-model-is-eval-or-train/9395/3

