### PR TITLE
Remove unnecessary atomic ops in DispatchStub

### DIFF
--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -68,12 +68,12 @@ struct CAFFE2_API DispatchStub<rT (*)(Args...), T> {
     if (device_type == DeviceType::CPU) {
       // Use memory_order_relaxed here since even if two threads race,
       // they will still compute the same value for cpu_dispatch_ptr.
-      if (!cpu_dispatch_ptr.load(std::memory_order_relaxed)) {
-        FnPtr tmp_cpu_dispatch_ptr = nullptr;
-        while(!cpu_dispatch_ptr.compare_exchange_weak(
-            tmp_cpu_dispatch_ptr, choose_cpu_impl(), std::memory_order_relaxed));
+      auto fptr = cpu_dispatch_ptr.load(std::memory_order_relaxed);
+      if (!fptr) {
+        fptr = choose_cpu_impl();
+        cpu_dispatch_ptr.store(fptr, std::memory_order_relaxed);
       }
-      return (*cpu_dispatch_ptr)(std::forward<ArgTypes>(args)...);
+      return (*fptr)(std::forward<ArgTypes>(args)...);
     } else if (device_type == DeviceType::CUDA) {
       AT_ASSERTM(cuda_dispatch_ptr, "DispatchStub: missing CUDA kernel");
       return (*cuda_dispatch_ptr)(std::forward<ArgTypes>(args)...);


### PR DESCRIPTION
I noticed this very unusual use of atomics in `at::native::DispatchStub`. The comment asserts that `choose_cpu_impl()` will always return the same value on every thread, yet for some reason it uses a CAS loop to exchange the value instead of a simple store? That makes no sense considering it doesn't even read the exchanged value.

This replaces the CAS loop with a simple store and also improves the non-initializing case to a single atomic load instead of two.

For reference, the `compare_exchange` was added in #32148 and the while loop added in #35794.
