### PR TITLE
[quant][graphmode][fix] dequantize propagation for {add/mul}_scalar + aten::repeat

### DIFF
--- a/test/quantization/test_quantize_jit.py
+++ b/test/quantization/test_quantize_jit.py
@@ -2250,11 +2250,12 @@ class TestQuantizeJitOps(QuantizationTestCase):
                 self.maxpool2d = torch.nn.MaxPool2d(kernel_size=3)
                 self.maxpool3d = torch.nn.MaxPool3d(kernel_size=3)
                 self.dropout = torch.nn.Dropout()
-                self.conv = torch.nn.Conv2d(3, 3, 3)
+                self.conv1 = torch.nn.Conv2d(3, 3, 3)
+                self.conv2 = torch.nn.Conv2d(3, 3, 3)
                 self.relu = torch.nn.ReLU()
 
             def forward(self, x):
-                x = self.conv(x)
+                x = self.conv1(x)
                 # add_scalar
                 x = x + 3
                 # mul_scalar
@@ -2315,7 +2316,7 @@ class TestQuantizeJitOps(QuantizationTestCase):
                 y = []
                 y.append(x)
                 x, _ = y
-                x = self.conv(x)
+                x = self.conv2(x)
                 return x
 
         data = torch.rand(1, 3, 10, 10)
@@ -2335,14 +2336,18 @@ class TestQuantizeJitOps(QuantizationTestCase):
         # observers and also successfully fused two quantized::conv2d
         # patterns
         # one quantize_per_tensor for input
-        # TODO: the checks are problematic, we need to split all checks
         FileCheck().check_count("aten::quantize_per_tensor", 1, exactly=True) \
-                   .check_count("quantized::conv2d", 2, exactly=True) \
-                   .check("aten::dequantize") \
+                   .run(m.graph)
+
+        FileCheck().check_count("quantized::conv2d(", 2, exactly=True) \
+                   .run(m.graph)
+
+        FileCheck().check_count("aten::dequantize", 1, exactly=True) \
                    .run(m.graph)
 
         FileCheck().check("quantized::add_scalar") \
                    .check("quantized::mul_scalar") \
+                   .check("aten::append(") \
                    .run(m.graph)
 
     def test_general_value_ops(self):

--- a/torch/csrc/jit/passes/quantization/finalize.cpp
+++ b/torch/csrc/jit/passes/quantization/finalize.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/passes/quantization/finalize.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/graph_rewrite_helper.h>
 #include <torch/csrc/jit/passes/prepack_folding.h>
 #include <torch/csrc/jit/passes/quantization/quantization_patterns.h>
 
@@ -8,6 +9,9 @@ namespace torch {
 namespace jit {
 
 namespace {
+
+using graph_rewrite_helper::PatternInfo;
+
 void insertPrepackUnpackForLinear(std::shared_ptr<Graph>& graph) {
   std::string linear_with_quant = R"(
 graph(%a_dequant, %w_quant, %b):
@@ -84,6 +88,50 @@ graph(%a_dequant, %w_quant, %b, %stride, %padding, %dilation, %groups):
   }
 }
 
+void rewriteListAddToAppend(std::shared_ptr<Graph>& graph) {
+  GRAPH_DUMP("Before restore append", graph);
+  std::string list_add = R"IR(
+graph(%list, %x):
+    %x_list : Tensor[]  = prim::ListConstruct(%x)
+    %result : Tensor[] = aten::add(%list, %x_list)
+    return (%result) )IR";
+
+  /* Rewrite the above pattern to
+  std::string append = R"IR(
+graph(%list, %x):
+    %ignore : Tensor[] = aten::append(%list, %x)
+    return (%list) )IR";
+   this is not supported by subgraph rewriter, so we'll do
+   this manually.
+  */
+
+  const PatternInfo& list_add_pattern_info =
+      PatternInfo::parse_from_str(list_add);
+  const Graph& list_add_graph = *list_add_pattern_info.pattern_graph;
+  const auto& list_add_vmap = list_add_pattern_info.vmap;
+  const auto& matches = findPatternMatches(list_add_graph, *graph);
+  for (const auto& match : matches) {
+    Value* result = match.values_map.at(list_add_vmap.at("result"));
+    Node* list_add_node = result->node();
+    Value* list = list_add_node->input(0);
+    Value* x_list = list_add_node->input(1);
+
+    Node* x_list_node = x_list->node();
+    Value* x = x_list_node->input(0);
+
+    result->replaceAllUsesWith(list);
+    WithInsertPoint ins(list_add_node);
+    Node* append_node = graph->create(Symbol::aten("append"), {list, x});
+    append_node->output()->setType(ListType::ofTensors());
+    graph->insertNode(append_node);
+    for (Node* n : {list_add_node, x_list_node}) {
+      n->removeAllInputs();
+      n->destroy();
+    }
+  }
+  GRAPH_DUMP("After restore append", graph);
+}
+
 } // namespace
 
 void QuantFusion(std::shared_ptr<Graph>& graph, QuantType quant_type) {
@@ -128,6 +176,8 @@ void FoldQuantizedPrepackingOps(Module& module) {
 
 Module Finalize(Module& module, QuantType quant_type) {
   auto graph = module.get_method("forward").graph();
+  GRAPH_DUMP("Before rewrite list add to append:", graph);
+  rewriteListAddToAppend(graph);
   InsertPrepackUnpack(graph);
   GRAPH_DUMP("Before QuantFusion:", graph);
   QuantFusion(graph, quant_type);

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -353,8 +353,13 @@ bool isFunctionNode(
   return is_func_node;
 }
 
+bool isSingleInputGeneralShapeAtenFunction(Node* n) {
+  return isAtenFunc(n, _single_input_general_shape_aten_funcs);
+}
+
 bool isSingleInputGeneralValueAtenFunction(Node* n) {
-  return isAtenFunc(n, _single_input_general_value_aten_funcs);
+  return isAtenFunc(n, _single_input_general_value_aten_funcs) ||
+      isBinaryOpWithScalarInput(n);
 }
 
 bool isSingleInputGeneralCallFunction(Node* n) {
@@ -381,8 +386,8 @@ bool isSingleInputGeneralAtenFunction(Node* n) {
       std::back_inserter(fixed_qparams_aten_funcs),
       [](auto pair) { return pair.first; });
 
-  return isAtenFunc(n, _single_input_general_shape_aten_funcs) ||
-      isAtenFunc(n, _single_input_general_value_aten_funcs) ||
+  return isSingleInputGeneralValueAtenFunction(n) ||
+      isSingleInputGeneralShapeAtenFunction(n) ||
       isAtenFunc(n, fixed_qparams_aten_funcs);
 }
 
@@ -404,6 +409,10 @@ bool isPropagateQuantBinaryOp(Node* n) {
 
 bool isPropagateQuantOp(Node* n) {
   return isPropagateQuantSingleInputOp(n) || isPropagateQuantBinaryOp(n);
+}
+
+bool isBinaryOpWithScalarInput(Node* n) {
+  return isPropagateQuantBinaryOp(n) && isScalar(n->input(1));
 }
 
 c10::optional<std::tuple<c10::QScheme, QParamVector>> getFixedQParams(Node* n) {

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -193,7 +193,7 @@ AtenFuncArgs _observe_inputs_aten_func = {};
 CallFuncArgs _observe_inputs_call_func = {{"batch_norm", 1}};
 
 // Aten functions for getting tensor information
-std::vector<std::string> _tensor_info_funcs = {"size", "len", "dim"};
+std::vector<std::string> _tensor_info_funcs = {"size", "len", "dim", "numel"};
 
 // Aten functions whose output will be quantized or not quantized depending
 // on input tensor
@@ -311,10 +311,16 @@ std::vector<Value*> getPassThroughInputs(Value* v) {
       inputs.push_back(v);
     }
     return inputs;
-  } else if (n->kind() == Symbol::aten("append")) {
-    // notice that append is an op that changes input inplace
-    return {n->input(0), n->input(1)};
+  } else if (isListAdd(n)) {
+    // We need to propagate dequantize of n->input(0) if it is
+    // not an empty list
+    if (isEmptyList(n->input(0)->node())) {
+      return {n->input(1)};
+    } else {
+      return {n->input(0), n->input(1)};
+    }
   }
+
   return {};
 }
 
@@ -413,6 +419,28 @@ bool isPropagateQuantOp(Node* n) {
 
 bool isBinaryOpWithScalarInput(Node* n) {
   return isPropagateQuantBinaryOp(n) && isScalar(n->input(1));
+}
+
+bool isListAdd(Node* n) {
+  return n->kind() == Symbol::aten("add") && n->inputs().size() == 2 &&
+      n->outputs().size() == 1 &&
+      n->output()->type()->isSubtypeOf(ListType::ofTensors()) &&
+      n->input(0)->type()->isSubtypeOf(ListType::ofTensors()) &&
+      n->input(1)->type()->isSubtypeOf(ListType::ofTensors());
+}
+
+bool isEmptyList(Node* n) {
+  if (n->outputs().size() != 1) {
+    return false;
+  }
+  bool is_empty_tensor_list_node = n->kind() == prim::ListConstruct &&
+      n->inputs().size() == 0 &&
+      n->output()->type()->isSubtypeOf(ListType::ofTensors());
+  auto iv = toIValue(n->output());
+  bool is_empty_tensor_list_constant = iv.has_value() && iv->isList() &&
+      iv->toList().size() == 0 &&
+      n->output()->type()->isSubtypeOf(ListType::ofTensors());
+  return is_empty_tensor_list_node || is_empty_tensor_list_constant;
 }
 
 c10::optional<std::tuple<c10::QScheme, QParamVector>> getFixedQParams(Node* n) {

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -45,6 +45,8 @@ TORCH_API bool isScalar(Value* v);
 TORCH_API bool hitGraphInput(Value* value);
 
 // =========== helper functions for Node =========
+TORCH_API bool isSingleInputGeneralShapeAtenFunction(Node* n);
+
 TORCH_API bool isSingleInputGeneralValueAtenFunction(Node* n);
 
 TORCH_API bool isSingleInputGeneralCallFunction(Node* n);
@@ -66,6 +68,11 @@ TORCH_API bool isPropagateQuantBinaryOp(Node* n);
 // Check if this is the node that we'll quantize or not quantize depending on
 // whether the input of the node is quantized, example: aten::cat
 TORCH_API bool isPropagateQuantOp(Node* n);
+
+// Check if the node is a binary op like aten::add and aten::mul and
+// if the input 1 is a scalar, these ops will be quantized to
+// quantized::{op}_scalar
+TORCH_API bool isBinaryOpWithScalarInput(Node* n);
 
 TORCH_API c10::optional<std::tuple<c10::QScheme, QParamVector>> getFixedQParams(
     Node* n);

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -74,6 +74,12 @@ TORCH_API bool isPropagateQuantOp(Node* n);
 // quantized::{op}_scalar
 TORCH_API bool isBinaryOpWithScalarInput(Node* n);
 
+// Check if the node is a aten::add with list inputs
+bool isListAdd(Node* n);
+
+// Check if the node is a empty list construct node
+bool isEmptyList(Node* n);
+
 TORCH_API c10::optional<std::tuple<c10::QScheme, QParamVector>> getFixedQParams(
     Node* n);
 

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -1094,6 +1094,46 @@ void InsertObserversHelper::fillBoundaryValueMap(
   }
 }
 
+void makeAppendNonInplace(std::shared_ptr<Graph>& graph) {
+  std::string append_pattern = R"IR(
+graph(%list, %x):
+    %ignore : Tensor[] = aten::append(%list, %x)
+    return (%ignore) )IR";
+
+  /* Rewrite the above pattern to
+  std::string append_replacement = R"IR(
+graph(%list, %x):
+    %x_list : Tensor[]  = prim::ListConstruct(%x)
+    %result : Tensor[] = aten::add(%list, %x_list)
+    return (%result) )IR";
+   this is not supported by subgraph rewriter, so we'll do
+   this manually.
+  */
+
+  GRAPH_DUMP("Before replace append", graph);
+  const PatternInfo& append_pattern_info =
+      PatternInfo::parse_from_str(append_pattern);
+  const Graph& append_graph = *append_pattern_info.pattern_graph;
+  const auto& append_vmap = append_pattern_info.vmap;
+  const auto& matches = findPatternMatches(append_graph, *graph);
+  for (const auto& match : matches) {
+    auto append_node = match.values_map.at(append_vmap.at("ignore"))->node();
+    Value* list_val = append_node->input(0);
+    Value* x = append_node->input(1);
+    WithInsertPoint ins(append_node);
+    Node* x_list_node = graph->createList(TensorType::get(), {x});
+    graph->insertNode(x_list_node);
+    Node* add_node =
+        graph->create(Symbol::aten("add"), {list_val, x_list_node->output()});
+    graph->insertNode(add_node);
+    add_node->output()->setType(ListType::ofTensors());
+    list_val->replaceAllUsesAfterNodeWith(add_node, add_node->output());
+    append_node->removeAllInputs();
+    append_node->destroy();
+  }
+  GRAPH_DUMP("After replace append", graph);
+}
+
 void InsertObserversHelper::preprocess(
     Module& module,
     const std::string& method_name) {
@@ -1110,6 +1150,7 @@ void InsertObserversHelper::preprocess(
   // fuse decomposed linear into aten::linear
   FuseLinear(graph);
   replaceConvolutionWithAtenConv(graph);
+  makeAppendNonInplace(graph);
 }
 
 void InsertObserversHelper::analyze(
@@ -1514,6 +1555,7 @@ void InsertObserversHelper::propagateObservedProperty(
           observed_values_.count(v) || block_observed_values.count(v);
     }
     if (all_observed) {
+      GRAPH_DEBUG("Pass through observed property in node:", *output->node());
       // This is to propagate observed property through
       // all ops that doesn't require observation
       block_observed_values.insert(output);

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -970,6 +970,12 @@ c10::optional<std::vector<Value*>> getDequantizedInputs(Value* output) {
     // point
     bool is_dequantized = true;
     for (auto* input : inputs) {
+      GRAPH_DEBUG(
+          "checking if input:",
+          input->debugName(),
+          " in node:",
+          *input->node(),
+          "is quantized");
       is_dequantized &= input->node()->kind() == Symbol::aten("dequantize");
     }
     if (is_dequantized) {


### PR DESCRIPTION
…#40596)

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/40596

Previously the fusion patterns for {add/mul}_scalar is inconsistent since the op pattern
produces a non-quantized tensor and the op replacement graph produces a quantized tensor

Test Plan: Imported from OSS

Differential Revision: D22251072

fbshipit-source-id: e16eb92cf6611578cca1ed8ebde961f8d0610137

