### PR TITLE
add eq.str, ne.str, and add.str ops

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -450,7 +450,22 @@ RegisterOperators reg(
            handler(ss.str());
          },
          aliasAnalysisSpecialCase()),
-     DEFINE_COMPARISON_OP(aten::eq, a == b),
+
+#define DEFINE_STRING_OP(op_name, string_op, result) \
+  Operator(                                          \
+      #op_name ".str(str a, str b) ->" #result,      \
+      [](Stack* stack) {                             \
+        auto b = pop(stack).toStringRef();           \
+        auto a = pop(stack).toStringRef();           \
+        push(stack, string_op);                      \
+      },                                             \
+      aliasAnalysisFromSchema())
+     DEFINE_STRING_OP(aten::eq, a == b, bool),
+     DEFINE_STRING_OP(aten::ne, a != b, bool),
+     DEFINE_STRING_OP(aten::add, a + b, str),
+ #undef DEFINE_STRING_OP
+
+    DEFINE_COMPARISON_OP(aten::eq, a == b),
      DEFINE_COMPARISON_OP(aten::ne, a != b),
      DEFINE_COMPARISON_OP(aten::lt, a < b),
      DEFINE_COMPARISON_OP(aten::gt, a > b),

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -690,20 +690,6 @@ void hashValue(Stack* stack) {
 
 RegisterOperators reg2({
 
-#define DEFINE_STRING_OP(op_name, string_op, result) \
-  Operator(                                          \
-      #op_name "(str a, str b) ->" #result,          \
-      [](Stack* stack) {                             \
-        auto b = pop(stack).toStringRef();           \
-        auto a = pop(stack).toStringRef();           \
-        push(stack, string_op);                      \
-      },                                             \
-      aliasAnalysisFromSchema())
-
-    DEFINE_STRING_OP(aten::eq, a == b, bool),
-    DEFINE_STRING_OP(aten::ne, a != b, bool),
-    DEFINE_STRING_OP(aten::add, a + b, str),
-#undef DEFINE_STRING_OP
     Operator(
         "aten::__getitem__.str(str s, int index) -> str",
         [](Stack* stack) {


### PR DESCRIPTION
Summary:
add 3 str operators to lite interpreter
eq.str
ne.str
add.str

Test Plan:
```
buck run //xplat/caffe2/fb/pytorch_predictor:converter /mnt/vol/gfsfblearner-altoona/flow/data/2020-06-29/1ca8a85f-dbd5-4181-b5fc-63d24465c1fc/201084299/2068673333/model.pt1 ~/model_f201084299.bc

buck run xplat/assistant/model_benchmark_tool/mobile/binary/:lite_predictor -- --model ~/model_f201084299.bc --input_file /tmp/gc_model_input.txt --model_input_args src_tokens,dict_feat,contextual_token_embedding --warmup 1 --iter 2

```

Reviewed By: pengtxiafb

Differential Revision: D22369579

