### PR TITLE
fix autodoc for torch.distributed.launch

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-
 r"""
 `torch.distributed.launch` is a module that spawns up multiple distributed
 training processes on each of the training nodes.
@@ -139,6 +136,7 @@ will not pass ``--local_rank`` when you specify this flag.
 
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import subprocess


### PR DESCRIPTION
The doc for `torch.distributed.launch` is missing since v1.2.0 (see issue #36386) because PR #22501 added some imports at the first line.
https://github.com/pytorch/pytorch/blob/542ac74987141c81b6326b9e7d5c6a1d00fc3701/torch/distributed/launch.py#L1-L5
I move it below the docstring to make the autodoc in Sphinx work normally.