### PR TITLE
DEBUG: SciPy pip DLL load issue

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -22,7 +22,7 @@ call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Minic
 if NOT "%BUILD_ENVIRONMENT%"=="" (
     :: We have to pin Python version to 3.6.7, until mkl supports Python 3.7
     :: Numba is pinned to 0.44.0 to avoid https://github.com/numba/numba/issues/4352
-    call conda install -y -q python=3.6.7 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0 scipy==1.5.0
+    call conda install -y -q python=3.6.7 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0
     if %errorlevel% neq 0 ( exit /b %errorlevel% )
     call conda install -y -q -c conda-forge cmake
     if %errorlevel% neq 0 ( exit /b %errorlevel% )
@@ -39,7 +39,7 @@ if %errorlevel% neq 0 ( exit /b %errorlevel% )
 popd
 
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
-pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow unittest-xml-reporting
+pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow unittest-xml-reporting https://anaconda.org/multibuild-wheels-staging/scipy/1.6.0.dev0+393a192/download/scipy-1.6.0.dev0+393a192-cp36-cp36m-win_amd64.whl
 if %errorlevel% neq 0 ( exit /b %errorlevel% )
 :: No need to install faulthandler since we only test Python >= 3.6 on Windows
 :: faulthandler is builtin since Python 3.3


### PR DESCRIPTION
@peterjc123 (this is related to your upstream report: https://github.com/scipy/scipy/issues/12400)

* do not merge--debug only! I tried to replicate
pytorch CI in my fork but this is a bit easier
if not too troublesome

* this is an attempt to check for the fix for
SciPy DLL load issue reported in pytorch CI
in issue #40366 with our `1.5.0` release; at the moment,
`pytorch` CI is using a conda install to avoid the DLL
load issue observed with our PyPI wheel for Windows
Python 3.6

* the specific wheel in use in this feature branch
contains a variety of attempted fixes--if they work,
I will aim to backport them to a `1.5.1` release
of SciPy

