### PR TITLE
run single-threaded gradgradcheck in test_nn

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14738,7 +14738,6 @@ class TestTorchDeviceType(TestCase):
         expected_val = torch.ones(2, 2, 2, 2, device=device)
         expected_val[:, 0, :, :] *= 2.
         expected_val[:, 1, :, :] *= 1.5
-        print(val, ind)
         self.assertEqual(val, expected_val, atol=0, rtol=0)
         self.assertEqual(ind, expected_ind, atol=0, rtol=0)
 

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -2000,18 +2000,18 @@ new_module_tests = [
     ),
     dict(
         module_name='Conv3d',
-        constructor_args=(3, 4, (2, 3, 4)),
-        cpp_constructor_args='torch::nn::Conv3dOptions(3, 4, {2, 3, 4})',
-        input_size=(2, 3, 3, 4, 5),
+        constructor_args=(2, 3, (2, 3, 2)),
+        cpp_constructor_args='torch::nn::Conv3dOptions(2, 3, {2, 3, 2})',
+        input_size=(1, 2, 4, 5, 4),
         cudnn=True,
         check_with_long_tensor=True,
     ),
     dict(
         module_name='Conv3d',
-        constructor_args=(3, 4, (2, 3, 4), 1, 0, 1, 1, False),
-        cpp_constructor_args='''torch::nn::Conv3dOptions(3, 4, {2, 3, 4})
+        constructor_args=(2, 3, (2, 3, 4), 1, 0, 1, 1, False),
+        cpp_constructor_args='''torch::nn::Conv3dOptions(2, 3, {2, 3, 4})
                                 .stride(1).padding(0).dilation(1).groups(1).bias(false)''',
-        input_size=(2, 3, 3, 4, 5),
+        input_size=(1, 2, 3, 4, 5),
         cudnn=True,
         desc='no_bias',
         check_with_long_tensor=True,
@@ -2046,9 +2046,9 @@ new_module_tests = [
     ),
     dict(
         fullname='Conv3d_groups',
-        constructor=lambda: nn.Conv3d(4, 6, kernel_size=3, groups=2),
+        constructor=lambda: nn.Conv3d(2, 4, kernel_size=3, groups=2),
         cpp_constructor_args='torch::nn::Conv3dOptions(4, 6, 3).groups(2)',
-        input_size=(2, 4, 4, 5, 4),
+        input_size=(1, 2, 3, 3, 3),
         cudnn=True,
         check_with_long_tensor=True,
     ),
@@ -2199,9 +2199,9 @@ new_module_tests = [
     ),
     dict(
         module_name='ReplicationPad3d',
-        constructor_args=((1, 2, 3, 4, 5, 6),),
-        cpp_constructor_args='torch::nn::ReplicationPad3dOptions({1, 2, 3, 4, 5, 6})',
-        input_size=(2, 3, 5, 5, 5),
+        constructor_args=((1, 2, 3, 3, 2, 1),),
+        cpp_constructor_args='torch::nn::ReplicationPad3dOptions({1, 2, 3, 3, 2, 1})',
+        input_size=(2, 3, 2, 2, 2),
     ),
     dict(
         module_name='Embedding',
@@ -4662,8 +4662,9 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
         self.skip_double = kwargs.get('skip_double', False)
 
     def _do_test(self, test_case, module, input):
+        num_threads = torch.get_num_threads()
+        torch.set_num_threads(1)
         test_case.check_jacobian(module, input, self.jacobian_input)
-
         if self.check_gradgrad:
             # could probably unify check_jacobian above with this.
             params = tuple(x for x in module.parameters())
@@ -4796,6 +4797,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
                 for p in module.parameters():
                     test_case.assertIsInstance(p, torch.cuda.HalfTensor)
                     test_case.assertEqual(p.get_device(), 0)
+        torch.set_num_threads(num_threads)
 
     def _get_target(self):
         return self._get_arg('target', False)


### PR DESCRIPTION
Most time-consuming tests in test_nn (taking about half the time) were gradgradchecks on Conv3d. Reduce their sizes, and, most importantly, run gradgradcheck single-threaded, because that cuts the time of conv3d tests by an order of magnitude, and barely affects other tests. 
These changes bring test_nn time down from 1200 s to ~550 s on my machine. 