### PR TITLE
Add the missing `resource_class` key in the update_s3_htmls job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1950,6 +1950,7 @@ jobs:
   update_s3_htmls: &update_s3_htmls
     machine:
       image: ubuntu-1604:201903-01
+    resource_class: medium
     steps:
     - checkout
     - setup_linux_system_environment

--- a/.circleci/verbatim-sources/job-specs/binary_update_htmls.yml
+++ b/.circleci/verbatim-sources/job-specs/binary_update_htmls.yml
@@ -9,6 +9,7 @@
   update_s3_htmls: &update_s3_htmls
     machine:
       image: ubuntu-1604:201903-01
+    resource_class: medium
     steps:
     - checkout
     - setup_linux_system_environment


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/40998.

Actually I don't know why it is needed. But without it, the build won't start. See my rerun of the update_s3_html3 job: https://app.circleci.com/pipelines/github/pytorch/pytorch/187926/workflows/432dbe98-ca2f-484d-acc7-0482cb3fd01f/jobs/6121551/steps.