### PR TITLE
[pytorch] deprecate PYTORCH_DISABLE_TRACING macro

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -302,7 +302,6 @@ op_name = jit::Symbol::fromQualString("aten::${trace_name}");
 """)
 
 PRE_RECORD_TRACE = CodeTemplate("""\
-#if !defined(PYTORCH_DISABLE_TRACING)
 torch::jit::Node* node = nullptr;
 std::shared_ptr<jit::tracer::TracingState> tracer_state;
 if (jit::tracer::isTracing()) {
@@ -316,7 +315,6 @@ if (jit::tracer::isTracing()) {
   ${inplace_guard}
   jit::tracer::setTracingState(nullptr);
 }
-#endif
 """)
 
 INPLACE_GUARD = CodeTemplate("""\
@@ -326,12 +324,10 @@ jit::tracer::ensureUniqueIfOutOfPlaced("${name}", ${mutable_input});
 ADD_TRACE_INPUT = CodeTemplate("""jit::tracer::addInputs(node, "${name}", ${input});""")
 
 POST_RECORD_TRACE = CodeTemplate("""\
-#if !defined(PYTORCH_DISABLE_TRACING)
 if (tracer_state) {
   jit::tracer::setTracingState(std::move(tracer_state));
   ${add_trace_outputs}
 }
-#endif
 """)
 
 RUN_ONLY_IN_DEBUG_MODE = CodeTemplate("""\

--- a/torch/csrc/autograd/TraceTypeManual.cpp
+++ b/torch/csrc/autograd/TraceTypeManual.cpp
@@ -14,7 +14,6 @@ namespace {
 
 Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
   jit::Value* output = nullptr;
-#if !defined(PYTORCH_DISABLE_TRACING)
   if(torch::jit::tracer::isTracing()) {
     const jit::tracer::TracingState& state = *jit::tracer::getTracingState();
     auto& graph = state.graph;
@@ -34,18 +33,15 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
     }
     jit::tracer::ensureUniqueIfOutOfPlaced("copy_ (possibly due to an assignment)", self);
   }
-#endif
 
   {
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
     self.copy_(src, non_blocking);
   }
 
-#if !defined(PYTORCH_DISABLE_TRACING)
   if(torch::jit::tracer::isTracing()) {
     jit::tracer::setOutput(output, self);
   }
-#endif
   return self;
 }
 
@@ -53,13 +49,11 @@ Tensor& resize_(
     Tensor& self,
     IntArrayRef size,
     c10::optional<MemoryFormat> optional_memory_format) {
-#if !defined(PYTORCH_DISABLE_TRACING)
   if (torch::jit::tracer::isTracing()) {
     jit::tracer::ArgumentStash::popIntArrayRef("size");
     jit::tracer::warn("resize_", jit::tracer::WARN_RESIZE);
     jit::tracer::delValueTrace(self);
   }
-#endif
 
   {
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
@@ -72,12 +66,10 @@ Tensor& resize_as_(
     Tensor& self,
     const Tensor& the_template,
     c10::optional<MemoryFormat> optional_memory_format) {
-#if !defined(PYTORCH_DISABLE_TRACING)
   if (torch::jit::tracer::isTracing()) {
     jit::tracer::warn("resize_as_", jit::tracer::WARN_RESIZE);
     jit::tracer::delValueTrace(self);
   }
-#endif
 
   {
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
@@ -87,7 +79,6 @@ Tensor& resize_as_(
 }
 
 Tensor detach(const Tensor & self) {
-#if !defined(PYTORCH_DISABLE_TRACING)
   torch::jit::Node* node = nullptr;
   if (jit::tracer::isTracing()) {
     auto& graph = jit::tracer::getTracingState()->graph;
@@ -96,23 +87,19 @@ Tensor detach(const Tensor & self) {
     jit::tracer::addInputs(node, "self", self);
     graph->insertNode(node);
   }
-#endif
 
   auto result = [&]() {
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
     return self.detach();
   }();
 
-#if !defined(PYTORCH_DISABLE_TRACING)
   if (jit::tracer::isTracing()) {
     jit::tracer::addOutput(node, result);
   }
-#endif
   return result;
 }
 
 Tensor & detach_(Tensor & self) {
-#if !defined(PYTORCH_DISABLE_TRACING)
   torch::jit::Node* node = nullptr;
   if (jit::tracer::isTracing()) {
     auto& graph = jit::tracer::getTracingState()->graph;
@@ -122,18 +109,15 @@ Tensor & detach_(Tensor & self) {
     graph->insertNode(node);
     jit::tracer::ensureUniqueIfOutOfPlaced("detach_", self);
   }
-#endif
 
   {
     at::tracer::impl::NoTracerDispatchMode tracer_guard;
     self.detach_();
   }
 
-#if !defined(PYTORCH_DISABLE_TRACING)
   if (jit::tracer::isTracing()) {
     jit::tracer::addOutput(node, self);
   }
-#endif
   return self;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41004 [pytorch] deprecate PYTORCH_DISABLE_TRACING macro**
* #40903 [pytorch] add manual registration for trace type

Tracing has been moved into separate files. Now we can disable it by not compiling the source files for xplat mobile build.

Differential Revision: [D22372615](https://our.internmc.facebook.com/intern/diff/D22372615/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22372615/)!