### PR TITLE
[cherry-pick 1.6 fix]shape inference of undefined for prim::grad

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -188,6 +188,7 @@ namespace c10 {
   _(prim, unchecked_unwrap_optional) \
   _(aten, __contains__)              \
   _(prim, BailoutTemplate)           \
+  _(prim, grad)                      \
   _(aten, zero_)                     \
   _(aten, fill_)                     \
   FORALL_ATEN_BASE_SYMBOLS(_)        \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4017,6 +4017,20 @@ def foo(xyz):
         self.checkScript(f_grad, (x,))
         self.checkScript(f_grad, (y,))
 
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.LEGACY, "shape analysis is only enabled in Legacy")
+    def test_prim_grad_undefined(self):
+
+        x = torch.ones(2)
+
+        def f_grad(x):
+            return x.grad
+
+        scripted = self.checkScript(f_grad, (x,))
+        g = scripted.graph_for(x)
+
+        prim_grad_node = g.findNode("prim::grad")
+        self.assertTrue(next(prim_grad_node.outputs()).type().undefined() is None)
+
     def test_tensor_data(self):
         x = torch.randn(3, 4, requires_grad=True)
         y = torch.randn(4, 5)

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -664,6 +664,14 @@ class ShapePropagator {
         }
         return;
       }
+      case prim::grad: {
+        auto tt = node->input()->type()->expect<TensorType>();
+        // grad may be undefined
+        // requires_grad may be required
+        auto grad_type = TensorType::get()->withPossiblyUndefined();
+        node->output()->setType(grad_type);
+        return;
+      }
       case prim::CallFunction:
       case prim::CallMethod:
       case prim::AutogradZero: {

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -658,6 +658,14 @@ void initPythonIRBindings(PyObject* module_) {
                                  : py::cast<py::none>(Py_None);
           })
       .def(
+          "undefined",
+          [](Type& t) {
+            auto undef =
+                t.shared_from_this()->expect<TensorType>()->undefined();
+            return undef.has_value() ? py::cast(*undef)
+                                     : py::cast<py::none>(Py_None);
+          })
+      .def(
           "sizes",
           [](Type& t) -> py::object {
             if (auto ptt = t.expect<TensorType>()) {


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/40866

Reviewed By: pbelevich

Differential Revision: D22358988

Pulled By: Krovatkin

fbshipit-source-id: 7118d7f8d4eaf056cfb71dc0d588d38b1dfb0fc7

