### PR TITLE
respect lite proto debug string constraints

### DIFF
--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -997,7 +997,7 @@ std::string pretty_print_onnx(
       false,
       std::string());
   if (google_printer) {
-    return graph_encoder.get_model_proto().DebugString();
+    return onnx::ProtoDebugString(graph_encoder.get_model_proto());
   }
   return prettyPrint(graph_encoder.get_model_proto());
 }


### PR DESCRIPTION
Summary:
`DebugString()` string is only available when `onnx` is compiled with full protobuf. In the lite case (default) this function does not exist.

`export.cpp` seems to unconditionally use this function. alternative could be to `#ifdef` based on `ONNX_USE_LITE_PROTO`.

Test Plan:
CI passes.
Are there regression tests already setup to make sure the export layout/format does not change accidentally?

Differential Revision: D22362972

