### PR TITLE
Insert parentheses around kernel name argument to hipLaunchKernelGGL

### DIFF
--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -338,6 +338,8 @@ def processKernelLaunches(string, stats):
         # Extract cuda kernel
         cuda_kernel = string[params[0]["start"]:parenthesis + 1]
         kernel_string = string[kernel['start']:kernel['end']]
+        end_param_index = 0 if params[1]['end']==-1 else 1
+        kernel_name_with_template = string[params[0]['start']:params[end_param_index]['end'] + 1]
         cuda_kernel_dim3 = add_dim3(kernel_string, cuda_kernel)
         # Keep number of kernel launch params consistent (grid dims, group dims, stream, dynamic shared size)
         num_klp = len(extract_arguments(0, kernel["group"].replace("<<<", "(").replace(">>>", ")")))
@@ -347,6 +349,7 @@ def processKernelLaunches(string, stats):
 
         # Replace cuda kernel with hip kernel
         output_string = output_string.replace(cuda_kernel, hip_kernel)
+        output_string = output_string.replace(kernel_name_with_template, "(" + kernel_name_with_template + ")")
 
         # Update the statistics
         stats["kernel_launches"].append(hip_kernel)

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -338,7 +338,7 @@ def processKernelLaunches(string, stats):
         # Extract cuda kernel
         cuda_kernel = string[params[0]["start"]:parenthesis + 1]
         kernel_string = string[kernel['start']:kernel['end']]
-        end_param_index = 0 if params[1]['end']==-1 else 1
+        end_param_index = 0 if params[1]['end'] == -1 else 1
         kernel_name_with_template = string[params[0]['start']:params[end_param_index]['end'] + 1]
         cuda_kernel_dim3 = add_dim3(kernel_string, cuda_kernel)
         # Keep number of kernel launch params consistent (grid dims, group dims, stream, dynamic shared size)

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -345,11 +345,11 @@ def processKernelLaunches(string, stats):
         num_klp = len(extract_arguments(0, kernel["group"].replace("<<<", "(").replace(">>>", ")")))
 
         hip_kernel = "hipLaunchKernelGGL(" + cuda_kernel_dim3[0:-1].replace(
-            ">>>", ", 0" * (4 - num_klp) + ">>>").replace("<<<", ", ").replace(">>>", ", ")
+            ">>>", ", 0" * (4 - num_klp) + ">>>").replace("<<<", ", ").replace(">>>", ", "
+            ).replace(kernel_name_with_template, "(" + kernel_name_with_template + ")")
 
         # Replace cuda kernel with hip kernel
         output_string = output_string.replace(cuda_kernel, hip_kernel)
-        output_string = output_string.replace(kernel_name_with_template, "(" + kernel_name_with_template + ")")
 
         # Update the statistics
         stats["kernel_launches"].append(hip_kernel)

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -345,8 +345,8 @@ def processKernelLaunches(string, stats):
         num_klp = len(extract_arguments(0, kernel["group"].replace("<<<", "(").replace(">>>", ")")))
 
         hip_kernel = "hipLaunchKernelGGL(" + cuda_kernel_dim3[0:-1].replace(
-            ">>>", ", 0" * (4 - num_klp) + ">>>").replace("<<<", ", ").replace(">>>", ", "
-            ).replace(kernel_name_with_template, "(" + kernel_name_with_template + ")")
+            ">>>", ", 0" * (4 - num_klp) + ">>>").replace("<<<", ", ").replace(
+            ">>>", ", ").replace(kernel_name_with_template, "(" + kernel_name_with_template + ")")
 
         # Replace cuda kernel with hip kernel
         output_string = output_string.replace(cuda_kernel, hip_kernel)


### PR DESCRIPTION
This is to workaround an issue in hipclang wrt templated kernel name arguments to hipLaunchKernelGGL.