### PR TITLE
Remove unused Logger in get_matching_activations

### DIFF
--- a/torch/quantization/_numeric_suite.py
+++ b/torch/quantization/_numeric_suite.py
@@ -381,13 +381,12 @@ def compare_model_stub(
     return ob_dict
 
 
-def get_matching_activations(float_module, q_module, Logger):
+def get_matching_activations(float_module, q_module):
     r"""Find the matching activation between float and quantized modules.
 
     Args:
         float_module: float module used to generate the q_module
         q_module: module quantized from float_module
-        Logger: type of logger used to prepare float_module and q_module
 
     Return:
         act_dict: dict with key corresponding to quantized module names and each

--- a/torch/quantization/_numeric_suite.py
+++ b/torch/quantization/_numeric_suite.py
@@ -466,5 +466,5 @@ def compare_model_outputs(
     prepare_model_outputs(float_model, q_model, Logger, white_list)
     float_model(*data)
     q_model(*data)
-    act_compare_dict = get_matching_activations(float_model, q_model, Logger)
+    act_compare_dict = get_matching_activations(float_model, q_model)
     return act_compare_dict


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41023 Remove unused Logger in get_matching_activations**

Remove Logger in get_matching_activations since it's not used.

Differential Revision: [D22394957](https://our.internmc.facebook.com/intern/diff/D22394957/)