### PR TITLE
add eq.str, ne.str, and add.str ops

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -90,8 +90,6 @@ white_list = [
     ('aten::quantized_instance_norm', datetime.date(2020, 6, 30)),
     ('_aten::*', datetime.date(2020, 6, 1)),
     ('_prim::*', datetime.date(2020, 6, 1)),
-    ('aten::eq', datetime.date(2020, 6, 30)),
-    ('aten::nq', datetime.date(2020, 6, 30)),
     ('aten::lt', datetime.date(2020, 6, 30)),
     ('aten::gt', datetime.date(2020, 6, 30)),
     ('aten::le', datetime.date(2020, 6, 30)),
@@ -115,6 +113,9 @@ white_list = [
     ('aten::__or__', datetime.date(2020, 6, 30)),
     ('aten::__xor__', datetime.date(2020, 6, 30)),
     ('aten::split', datetime.date(2020, 6, 30)),
+    ('aten::eq', datetime.date(2020, 7, 30)),
+    ('aten::nq', datetime.date(2020, 7, 30)),
+    ('aten::add', datetime.date(2020, 7, 30)),
 ]
 
 

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -450,6 +450,19 @@ RegisterOperators reg(
            handler(ss.str());
          },
          aliasAnalysisSpecialCase()),
+#define DEFINE_STRING_OP(op_name, string_op, result) \
+  Operator(                                          \
+      #op_name ".str(str a, str b) ->" #result,      \
+      [](Stack* stack) {                             \
+        auto b = pop(stack).toStringRef();           \
+        auto a = pop(stack).toStringRef();           \
+        push(stack, string_op);                      \
+      },                                             \
+      aliasAnalysisFromSchema())
+     DEFINE_STRING_OP(aten::eq, a == b, bool),
+     DEFINE_STRING_OP(aten::ne, a != b, bool),
+     DEFINE_STRING_OP(aten::add, a + b, str),
+#undef DEFINE_STRING_OP
      DEFINE_COMPARISON_OP(aten::eq, a == b),
      DEFINE_COMPARISON_OP(aten::ne, a != b),
      DEFINE_COMPARISON_OP(aten::lt, a < b),

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -690,20 +690,6 @@ void hashValue(Stack* stack) {
 
 RegisterOperators reg2({
 
-#define DEFINE_STRING_OP(op_name, string_op, result) \
-  Operator(                                          \
-      #op_name "(str a, str b) ->" #result,          \
-      [](Stack* stack) {                             \
-        auto b = pop(stack).toStringRef();           \
-        auto a = pop(stack).toStringRef();           \
-        push(stack, string_op);                      \
-      },                                             \
-      aliasAnalysisFromSchema())
-
-    DEFINE_STRING_OP(aten::eq, a == b, bool),
-    DEFINE_STRING_OP(aten::ne, a != b, bool),
-    DEFINE_STRING_OP(aten::add, a + b, str),
-#undef DEFINE_STRING_OP
     Operator(
         "aten::__getitem__.str(str s, int index) -> str",
         [](Stack* stack) {


### PR DESCRIPTION
Summary: move eq.str, ne.str, and add.str ops to lite interpreter. They are needed for NLU model.

Test Plan:
```
buck run //xplat/caffe2/fb/pytorch_predictor:converter /mnt/vol/gfsfblearner-altoona/flow/data/2020-06-29/1ca8a85f-dbd5-4181-b5fc-63d24465c1fc/201084299/2068673333/model.pt1 ~/model_f201084299.bc

buck run xplat/assistant/model_benchmark_tool/mobile/binary/:lite_predictor -- --model ~/model_f201084299.bc --input_file /tmp/gc_model_input.txt --model_input_args src_tokens,dict_feat,contextual_token_embedding --warmup 1 --iter 2
```

Differential Revision: D22395604

