### PR TITLE
Return atomic

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -24,7 +24,7 @@ struct AtomicAddIntegerImpl<T, 1> {
     do {
       assumed = old;
       old_byte = (old >> shift) & 0xff;
-      // preserve size in initial cast. Casting directly to uint32_t pads 
+      // preserve size in initial cast. Casting directly to uint32_t pads
       // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
       newval = static_cast<uint8_t>(THCNumerics<T>::add(val, old_byte));
       newval = (old & ~(0x000000ff << shift)) | (newval << shift);
@@ -47,7 +47,7 @@ struct AtomicAddIntegerImpl<T, 2> {
     do {
       assumed = old;
       old_bytes = is_32_align ? old >> 16 : old & 0xffff;
-      // preserve size in initial cast. Casting directly to uint32_t pads 
+      // preserve size in initial cast. Casting directly to uint32_t pads
       // negative signed values with 1's (e.g. signed -1 = unsigned ~0).
       newval = static_cast<uint16_t>(THCNumerics<T>::add(val, old_bytes));
       newval = is_32_align ? (old & 0xffff) | (newval << 16) : (old & 0xffff0000) | newval;
@@ -100,8 +100,8 @@ static inline  __device__ void gpuAtomicAdd(int16_t *address, int16_t val) {
   AtomicAddIntegerImpl<int16_t, sizeof(int16_t)>()(address, val);
 }
 
-static inline __device__ void gpuAtomicAdd(int32_t *address, int32_t val) {
-  atomicAdd(address, val);
+static inline __device__ int32_t gpuAtomicAdd(int32_t *address, int32_t val) {
+  return atomicAdd(address, val);
 }
 
 static inline __device__ void gpuAtomicAdd(int64_t *address, int64_t val) {
@@ -116,46 +116,50 @@ static inline __device__ void gpuAtomicAdd(bool *address, bool val) {
   *address = address && val;
 }
 
-static inline  __device__ void gpuAtomicAdd(at::Half *address, at::Half val) {
+static inline  __device__ at::Half gpuAtomicAdd(at::Half *address, at::Half val) {
   #if ((CUDA_VERSION < 10000) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
     unsigned int * address_as_ui =
       (unsigned int *) ((char *)address - ((size_t)address & 2));
     unsigned int old = *address_as_ui;
     unsigned int assumed;
 
+    at::Half hsum;
     do {
       assumed = old;
-      at::Half hsum;
       hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
       hsum = THCNumerics<at::Half>::add(hsum, val);
       old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16) : (old & 0xffff0000) | hsum.x;
       old = atomicCAS(address_as_ui, assumed, old);
     } while (assumed != old);
+    hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    return hsum;
   #else
-    atomicAdd(reinterpret_cast<__half*>(address), val);
+    return atomicAdd(reinterpret_cast<__half*>(address), val);
   #endif
 
 }
 
-static inline __device__ void gpuAtomicAdd(at::BFloat16 *address, at::BFloat16 val) {
+static inline __device__ at::BFloat16 gpuAtomicAdd(at::BFloat16 *address, at::BFloat16 val) {
     unsigned int * address_as_ui =
       (unsigned int *) ((char *)address - ((size_t)address & 2));
     unsigned int old = *address_as_ui;
     unsigned int assumed;
 
+    at::BFloat16 bsum;
     do {
       assumed = old;
-      at::BFloat16 bsum;
       bsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
       bsum = THCNumerics<at::BFloat16>::add(bsum, val);
       old = (size_t)address & 2 ? (old & 0xffff) | (bsum.x << 16) : (old & 0xffff0000) | bsum.x;
       old = atomicCAS(address_as_ui, assumed, old);
     } while (assumed != old);
+    bsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    return bsum.x;
 }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600 || CUDA_VERSION < 8000)
 // from CUDA C Programmic Guide
-static inline __device__ void atomicAdd(double* address, double val)
+static inline __device__ double atomicAdd(double* address, double val)
 #if defined(__clang__) && defined(__CUDA__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wgcc-compat"
@@ -174,7 +178,8 @@ static inline __device__ void atomicAdd(double* address, double val)
                     __longlong_as_double(assumed)));
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
-} while (assumed != old);
+  } while (assumed != old);
+  return __longlong_as_double(old);
 }
 #elif !defined(__CUDA_ARCH__) && (CUDA_VERSION < 8000) || defined(__HIP_PLATFORM_HCC__)
 
@@ -190,16 +195,16 @@ static inline __device__ void atomicAdd(double* address, double val)
 
 #if defined(__HIP_PLATFORM_HCC__) && __hcc_workweek__ < 18312 && !__HIP__
   // This needs to be defined for the host side pass
-  static inline  __device__  void atomicAdd(double *address, double val) { }
+  static inline  __device__  double atomicAdd(double *address, double val) { }
 #endif
 #endif
 
-static inline __device__ void gpuAtomicAdd(double *address, double val) {
-  atomicAdd(address, val);
+static inline __device__ double gpuAtomicAdd(double *address, double val) {
+  return atomicAdd(address, val);
 }
 
-static inline __device__ void gpuAtomicAdd(float *address, float val) {
-  atomicAdd(address, val);
+static inline __device__ float gpuAtomicAdd(float *address, float val) {
+  return atomicAdd(address, val);
 }
 
 template<typename T>
@@ -214,13 +219,13 @@ static inline __device__ void gpuAtomicAdd(c10::complex<T> *address, c10::comple
  * without a return. These may either be resolved through library functions or
  * implemented internally. Some extensions such as torchvision call atomicAdd()
  * directly and require non-library provided data type support. Only for these, we
- * continue to provide atomicAdd overloads. 
+ * continue to provide atomicAdd overloads.
  */
-static inline __device__ void atomicAdd(at::Half *address, at::Half val) {
+static inline __device__ at::Half atomicAdd(at::Half *address, at::Half val) {
   gpuAtomicAdd(address, val);
 }
 
-static inline __device__ void atomicAdd(at::BFloat16 *address, at::BFloat16 val) {
+static inline __device__ at::BFloat16 atomicAdd(at::BFloat16 *address, at::BFloat16 val) {
   gpuAtomicAdd(address, val);
 }
 

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -215,18 +215,16 @@ static inline __device__ void gpuAtomicAdd(c10::complex<T> *address, c10::comple
 
 /* Note [gpuAtomicAdd vs atomicAdd]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * We are trying to standardize inside the PyTorch backend on using gpuAtomicAdd()
- * without a return. These may either be resolved through library functions or
- * implemented internally. Some extensions such as torchvision call atomicAdd()
+ * Some extensions such as torchvision call atomicAdd()
  * directly and require non-library provided data type support. Only for these, we
  * continue to provide atomicAdd overloads.
  */
 static inline __device__ at::Half atomicAdd(at::Half *address, at::Half val) {
-  gpuAtomicAdd(address, val);
+  return gpuAtomicAdd(address, val);
 }
 
 static inline __device__ at::BFloat16 atomicAdd(at::BFloat16 *address, at::BFloat16 val) {
-  gpuAtomicAdd(address, val);
+  return gpuAtomicAdd(address, val);
 }
 
 static inline __device__ void atomicAdd(uint8_t *address, uint8_t val) {


### PR DESCRIPTION
Per title. This is not used currently in the pytorch codebase, but it is a legitimate usecase, and we have extensions that want to do that and are forced to roll their own atomic implementations for non-standard types. Whether atomic op returns old value or not should not affect performance, compiler is able to generate correct code depending on whether return value is used. https://godbolt.org/z/DBU_UW. 
Atomic operations for non-standard integer types (1,2 and 8 byte-width) are left as is, with void return. 