### PR TITLE
Fake Quantization Per Tensor Kernel Core Implementation (CPU)

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3646,6 +3646,14 @@
   use_c10_dispatcher: full
   variants: function
 
+- func: _fake_quantize_learnable_per_tensor_affine(Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> Tensor
+  use_c10_dispatcher: full
+  variants: function
+
+- func: _fake_quantize_learnable_per_tensor_affine_backward(Tensor grad, Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> (Tensor, Tensor, Tensor)
+  use_c10_dispatcher: full
+  variants: function
+
 - func: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
   use_c10_dispatcher: full
   variants: function

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -28,6 +28,8 @@ using fake_quant_grad_tensor_fn = void (*)(
 
 DECLARE_DISPATCH(fake_quant_tensor_fn, fake_quant_tensor_stub);
 DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_tensor_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_scale_tensor_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_zero_point_tensor_stub);
 
 using fake_quant_per_channel_fn = void (*)(
     TensorIterator &iter,

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -12,6 +12,8 @@ namespace native {
 // Use REGISTER_DISPATCH to run CPU and CUDA backend.
 DEFINE_DISPATCH(fake_quant_tensor_stub);
 DEFINE_DISPATCH(fake_quant_grad_tensor_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_scale_tensor_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_zero_point_tensor_stub);
 
 /* Fake-quantizes the 'inputs' tensor.
 Args:
@@ -92,6 +94,92 @@ Tensor fake_quantize_per_tensor_affine_backward(
   fake_quant_grad_tensor_stub(
       X.device().type(), dX, X, dY, scale, zero_point, quant_min, quant_max);
   return dX;
+}
+
+int64_t _get_zero_point_from_tensor(
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max,
+    bool is_forward) {
+  float zero_point_fp = zero_point[0].item<float>();
+  zero_point_fp = is_forward ? std::nearbyint(zero_point_fp) : zero_point_fp + 0.5f;
+  float zero_point_clamped = std::min(std::max(zero_point_fp, quant_min), quant_max);
+  return static_cast<int64_t>(zero_point_clamped);
+}
+
+Tensor _fake_quantize_learnable_per_tensor_affine(
+    const Tensor& self,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  float scale_val = scale[0].item<float>();
+  int64_t zero_point_val = native::_get_zero_point_from_tensor(zero_point, quant_min, quant_max, true);
+  return native::fake_quantize_per_tensor_affine(
+    self, scale_val, zero_point_val, quant_min, quant_max);
+}
+
+std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_tensor_affine_backward(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  /* The gradients for scale and zero point are calculated as below:
+     Let Xfq be the fake quantized version of X.
+     Let Xq be the quantized version of X (clamped at qmin and qmax).
+     Let Delta and z be the scale and the zero point.
+     :math:
+      \frac{d\Delta }{dx} =
+        \begin{cases}
+          q_{\min} - z& \text{ if } X_q= q_{\min} \\
+          q_{\max} - z& \text{ if } X_q= q_{\max} \\
+          (X_{fq} - X) / \Delta & \text{ else }
+        \end{cases}
+
+      \frac{dz }{dx} =
+        \begin{cases}
+          -\Delta& \text{ if } X_q= q_{\min} \text{ or } X_q = q_{\max} \\
+          0 & \text{ else }
+        \end{cases}
+  */
+  float scale_val = scale[0].item<float>();
+  int64_t zero_point_val = native::_get_zero_point_from_tensor(zero_point, quant_min, quant_max, false);
+
+  TORCH_CHECK(dY.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(scale.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(zero_point.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.numel() == dY.numel(), "`X` and `dY` are not the same size");
+  TORCH_CHECK(
+      quant_min <= 0 && quant_max >= 0,
+      "`quant_min` should be less than or \
+        equal to `quant_max`, and the quantization range should include 0.");
+  TORCH_CHECK(
+      zero_point_val >= quant_min && zero_point_val <= quant_max,
+      "`zero_point` must be between `quant_min` and `quant_max`.");
+  if (X.numel() <= 0) {
+    return std::make_tuple(X, scale, zero_point);
+  }
+
+  auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_tensor_stub(
+    X.device().type(), dX, X, dY, scale_val, zero_point_val, quant_min, quant_max);
+
+  auto dScale_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_learnable_scale_tensor_stub(
+    scale.device().type(), dScale_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+
+  auto dZeroPoint_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_learnable_zero_point_tensor_stub(
+    zero_point.device().type(), dZeroPoint_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+
+  // The total sums over the scale and zero point gradient vectors are what will be returned in the end.
+  auto dScale = dScale_vec.sum().unsqueeze(0);
+  auto dZeroPoint = dZeroPoint_vec.sum().unsqueeze(0);
+
+  return std::make_tuple(dX, dScale, dZeroPoint);
 }
 
 } // namespace native

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -436,6 +436,9 @@
 - name: fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max)
 
+- name: _fake_quantize_learnable_per_tensor_affine(Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> Tensor
+  self, scale, zero_point: "grad.defined() ? _fake_quantize_learnable_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max) : std::tuple<Tensor, Tensor, Tensor>()"
+
 - name: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max)
 


### PR DESCRIPTION
Summary: This diff contains the core implementation for the fake quantizer per tensor kernel that supports back propagation on the scale and zero point.

Test Plan: <In Progress>

Differential Revision: D22394145

