### PR TITLE
Fake Quantization Per Channel Kernel Core Implementation (CPU)

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -497,7 +497,7 @@ Tensor batch_norm(
     auto out = input.clone();
     if (weight.defined()) out = out * weight[0];
     if (bias.defined()) out = out + bias[0];
-    return out; 
+    return out;
   }
   return std::get<0>(at::_batch_norm_impl_index(input, weight, bias, running_mean, running_var,
                                                 training, momentum, eps, cudnn_enabled));

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3662,6 +3662,14 @@
   use_c10_dispatcher: full
   variants: function
 
+- func: _fake_quantize_learnable_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
+  use_c10_dispatcher: full
+  variants: function
+
+- func: _fake_quantize_learnable_per_channel_affine_backward(Tensor grad, Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> (Tensor, Tensor, Tensor)
+  use_c10_dispatcher: full
+  variants: function
+
 - func: _choose_qparams_per_tensor(Tensor self, bool reduce_range=False) -> (float, int)
   use_c10_dispatcher: full
   variants: function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3646,6 +3646,14 @@
   use_c10_dispatcher: full
   variants: function
 
+- func: _fake_quantize_learnable_per_tensor_affine(Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> Tensor
+  use_c10_dispatcher: full
+  variants: function
+
+- func: _fake_quantize_learnable_per_tensor_affine_backward(Tensor grad, Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> (Tensor, Tensor, Tensor)
+  use_c10_dispatcher: full
+  variants: function
+
 - func: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
   use_c10_dispatcher: full
   variants: function

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -28,6 +28,8 @@ using fake_quant_grad_tensor_fn = void (*)(
 
 DECLARE_DISPATCH(fake_quant_tensor_fn, fake_quant_tensor_stub);
 DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_tensor_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_scale_tensor_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_zero_point_tensor_stub);
 
 using fake_quant_per_channel_fn = void (*)(
     TensorIterator &iter,

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -38,6 +38,8 @@ using fake_quant_per_channel_fn = void (*)(
 
 DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_per_channel_stub);
 DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_grad_per_channel_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_scale_channel_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_zero_point_channel_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -12,6 +12,8 @@ namespace native {
 // Use REGISTER_DISPATCH to run CPU and CUDA backend.
 DEFINE_DISPATCH(fake_quant_per_channel_stub);
 DEFINE_DISPATCH(fake_quant_grad_per_channel_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_scale_channel_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_zero_point_channel_stub);
 
 /* Per channel fake-quantizes the 'inputs' tensor.
 Args:
@@ -151,6 +153,161 @@ Tensor fake_quantize_per_channel_affine_backward(
   fake_quant_grad_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);
 
   return dX;
+}
+
+TensorIterator _build_iterator(
+    const Tensor& dX,
+    const Tensor& X,
+    const Tensor& dY,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    std::vector<int64_t> expected_shape) {
+  TensorIterator iter = TensorIteratorConfig()
+    .check_all_same_dtype(false)
+    .add_output(dX)
+    .add_input(X)
+    .add_input(dY)
+    .add_input(native::_unsafe_view(scale, expected_shape))
+    .add_input(native::_unsafe_view(zero_point, expected_shape))
+    .build();
+  return iter;
+}
+
+Tensor _get_rounded_zero_point(
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  // This assumes the per channel zero point vector is single-dimensioned.
+  for (int i = 0; i < zero_point.sizes()[0]; ++i) {
+    zero_point[i] = static_cast<int64_t>(zero_point[i].item<float>() + 0.5);
+  }
+  return zero_point.clamp(quant_min, quant_max).to(at::kLong);
+}
+
+std::tuple<Tensor, Tensor> _get_scale_zero_point_per_channel_iter_grads(
+    const Tensor& dX,
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t axis,
+    int64_t quant_min,
+    int64_t quant_max) {
+
+  int64_t axis_size = X.size(axis);
+  std::vector<Tensor> X_flattened = at::unbind(X, axis);
+  std::vector<Tensor> dX_flattened = at::unbind(dX, axis);
+
+  Tensor dScale = at::zeros({scale.sizes()[0]});
+  Tensor dZeroPoint = at::zeros({zero_point.sizes()[0]});
+
+  for (int i = 0; i < X_flattened.size(); ++i) {
+    Tensor X_i = X_flattened[i];
+    Tensor dX_i = dX_flattened[i];
+    auto dScale_item_vec = at::empty_like(X_i, X_i.options(), MemoryFormat::Preserve);
+    auto dZeroPoint_item_vec = at::empty_like(X_i, X_i.options(), MemoryFormat::Preserve);
+
+    float scale_i = scale[i].item<float>();
+    int64_t zero_point_i = zero_point[i].item<int64_t>();
+    fake_quant_grad_learnable_scale_channel_stub(
+      scale.device().type(), dScale_item_vec, X_i, dX_i, scale_i, zero_point_i, quant_min, quant_max);
+    fake_quant_grad_learnable_zero_point_channel_stub(
+      zero_point.device().type(), dZeroPoint_item_vec, X_i, dX_i, scale_i, zero_point_i, quant_min, quant_max);
+    float scale_item = dScale_item_vec.sum().unsqueeze(0).item<float>();
+    float zero_point_item = dZeroPoint_item_vec.sum().unsqueeze(0).item<float>();
+
+    dScale[i] = scale_item;
+    dZeroPoint[i] = zero_point_item;
+  }
+  return std::make_tuple(dScale, dZeroPoint);
+}
+
+Tensor _fake_quantize_learnable_per_channel_affine(
+    const Tensor& self,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t axis,
+    int64_t quant_min,
+    int64_t quant_max) {
+  Tensor zero_point_rounded = zero_point.to(at::kLong);
+  return native::fake_quantize_per_channel_affine(
+    self, scale, zero_point_rounded, axis, quant_min, quant_max);
+}
+
+std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_channel_affine_backward(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t axis,
+    int64_t quant_min,
+    int64_t quant_max) {
+  /* The gradients for scale and zero point are calculated as below:
+     Let Xfq be the fake quantized version of X.
+     Let Xq be the quantized version of X (clamped at qmin and qmax).
+     Let Delta and z be the scale and the zero point.
+     :math:
+      \frac{d\Delta }{dx} =
+        \begin{cases}
+          q_{\min} - z& \text{ if } X_q= q_{\min} \\
+          q_{\max} - z& \text{ if } X_q= q_{\max} \\
+          (X_{fq} - X) / \Delta & \text{ else }
+        \end{cases}
+
+      \frac{dz }{dx} =
+        \begin{cases}
+          -\Delta& \text{ if } X_q= q_{\min} \text{ or } X_q = q_{\max} \\
+          0 & \text{ else }
+        \end{cases}
+  */
+  TORCH_CHECK(dY.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(scale.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(zero_point.scalar_type() == ScalarType::Float);
+
+  TORCH_CHECK(X.sizes() == dY.sizes(), "`X` and `dY` are not the same size");
+  TORCH_CHECK(
+      quant_min <= 0 && quant_max >= 0,
+      "Expecting `quant_min` <= 0 and `quant_max` >= 0");
+  TORCH_CHECK(scale.dim() == 1, "scale should be a 1-D tensor");
+  TORCH_CHECK(zero_point.dim() == 1, "zero point should be a 1-D tensor");
+  TORCH_CHECK(
+      scale.numel() == zero_point.numel(),
+      "scale and zero-point need to have the same dimensions");
+  TORCH_CHECK(
+      scale.numel() == X.size(axis),
+      "dimensions of scale and zero-point are not consistent with input tensor")
+
+  TORCH_CHECK(
+      at::min(zero_point).item().toLong() >= quant_min &&
+          at::max(zero_point).item().toLong() <= quant_max,
+      "`zero_point` must be between `quant_min` and `quant_max`.");
+
+  TORCH_CHECK(
+      axis >= 0 && axis < X.dim(),
+      "`axis` must be between 0 and number of dimensions of input");
+
+  if (X.numel() <= 0) {
+    return std::make_tuple(X, scale, zero_point);
+  }
+
+  auto zero_point_rounded = _get_rounded_zero_point(zero_point, quant_min, quant_max);
+  auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+
+  std::vector<int64_t> expected_shape_X(X.dim(), 1);
+  expected_shape_X[axis] = X.size(axis);
+
+  TensorIterator iter_X = native::_build_iterator(
+    dX, X, dY, scale, zero_point_rounded, expected_shape_X);
+
+  fake_quant_grad_per_channel_stub(iter_X.device_type(), iter_X, quant_min, quant_max);
+
+  std::tuple<Tensor, Tensor> dScaleZeroPoints = native::_get_scale_zero_point_per_channel_iter_grads(
+    dX, X, scale, zero_point, axis, quant_min, quant_max);
+
+  Tensor dScale = std::get<0>(dScaleZeroPoints);
+  Tensor dZeroPoint = std::get<1>(dScaleZeroPoints);
+
+  return std::make_tuple(dX, dScale, dZeroPoint);
 }
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -12,6 +12,8 @@ namespace native {
 // Use REGISTER_DISPATCH to run CPU and CUDA backend.
 DEFINE_DISPATCH(fake_quant_tensor_stub);
 DEFINE_DISPATCH(fake_quant_grad_tensor_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_scale_tensor_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_zero_point_tensor_stub);
 
 /* Fake-quantizes the 'inputs' tensor.
 Args:
@@ -92,6 +94,92 @@ Tensor fake_quantize_per_tensor_affine_backward(
   fake_quant_grad_tensor_stub(
       X.device().type(), dX, X, dY, scale, zero_point, quant_min, quant_max);
   return dX;
+}
+
+int64_t _get_zero_point_from_tensor(
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max,
+    bool is_forward) {
+  float zero_point_fp = zero_point[0].item<float>();
+  zero_point_fp = is_forward ? std::nearbyint(zero_point_fp) : zero_point_fp + 0.5f;
+  float zero_point_clamped = std::min(std::max(zero_point_fp, quant_min), quant_max);
+  return static_cast<int64_t>(zero_point_clamped);
+}
+
+Tensor _fake_quantize_learnable_per_tensor_affine(
+    const Tensor& self,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  float scale_val = scale[0].item<float>();
+  int64_t zero_point_val = native::_get_zero_point_from_tensor(zero_point, quant_min, quant_max, true);
+  return native::fake_quantize_per_tensor_affine(
+    self, scale_val, zero_point_val, quant_min, quant_max);
+}
+
+std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_tensor_affine_backward(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  /* The gradients for scale and zero point are calculated as below:
+     Let Xfq be the fake quantized version of X.
+     Let Xq be the quantized version of X (clamped at qmin and qmax).
+     Let Delta and z be the scale and the zero point.
+     :math:
+      \frac{d\Delta }{dx} =
+        \begin{cases}
+          q_{\min} - z& \text{ if } X_q= q_{\min} \\
+          q_{\max} - z& \text{ if } X_q= q_{\max} \\
+          (X_{fq} - X) / \Delta & \text{ else }
+        \end{cases}
+
+      \frac{dz }{dx} =
+        \begin{cases}
+          -\Delta& \text{ if } X_q= q_{\min} \text{ or } X_q = q_{\max} \\
+          0 & \text{ else }
+        \end{cases}
+  */
+  float scale_val = scale[0].item<float>();
+  int64_t zero_point_val = native::_get_zero_point_from_tensor(zero_point, quant_min, quant_max, false);
+
+  TORCH_CHECK(dY.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(scale.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(zero_point.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.numel() == dY.numel(), "`X` and `dY` are not the same size");
+  TORCH_CHECK(
+      quant_min <= 0 && quant_max >= 0,
+      "`quant_min` should be less than or \
+        equal to `quant_max`, and the quantization range should include 0.");
+  TORCH_CHECK(
+      zero_point_val >= quant_min && zero_point_val <= quant_max,
+      "`zero_point` must be between `quant_min` and `quant_max`.");
+  if (X.numel() <= 0) {
+    return std::make_tuple(X, scale, zero_point);
+  }
+
+  auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_tensor_stub(
+    X.device().type(), dX, X, dY, scale_val, zero_point_val, quant_min, quant_max);
+
+  auto dScale_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_learnable_scale_tensor_stub(
+    scale.device().type(), dScale_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+
+  auto dZeroPoint_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_learnable_zero_point_tensor_stub(
+    zero_point.device().type(), dZeroPoint_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+
+  // The total sums over the scale and zero point gradient vectors are what will be returned in the end.
+  auto dScale = dScale_vec.sum().unsqueeze(0);
+  auto dZeroPoint = dZeroPoint_vec.sum().unsqueeze(0);
+
+  return std::make_tuple(dX, dScale, dZeroPoint);
 }
 
 } // namespace native

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -436,6 +436,9 @@
 - name: fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max)
 
+- name: _fake_quantize_learnable_per_tensor_affine(Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> Tensor
+  self, scale, zero_point: "grad.defined() ? _fake_quantize_learnable_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max) : std::tuple<Tensor, Tensor, Tensor>()"
+
 - name: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -442,6 +442,9 @@
 - name: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max)
 
+- name: _fake_quantize_learnable_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
+  self, scale, zero_point: "grad.defined() ? _fake_quantize_learnable_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max) : std::tuple<Tensor, Tensor, Tensor>()"
+
 - name: fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)
   self: zeros_like(grad, at::MemoryFormat::Preserve)
 


### PR DESCRIPTION
Summary: This diff contains the core implementation for the fake quantizer per channel kernel that supports back propagation on the scale and zero point.

Test Plan: <In Progress>

Differential Revision: D22395665

