### PR TITLE
Fix CUDA jit codegen compilation with gcc-5.4

### DIFF
--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -172,8 +172,8 @@ class TORCH_CUDA_API ReductionOp : public Expr {
 
   std::vector<IterDomain*> getReductionDomains() const;
 
-  std::unordered_map<ParallelType, IterDomain*> getParallelReductionDomains()
-      const;
+  std::unordered_map<ParallelType, IterDomain*, TypeHash>
+  getParallelReductionDomains() const;
 
  private:
   const BinaryOpType reduction_op_type_;

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -276,9 +276,9 @@ std::vector<IterDomain*> ReductionOp::getReductionDomains() const {
   return vec_domain;
 }
 
-std::unordered_map<ParallelType, IterDomain*> ReductionOp::
+std::unordered_map<ParallelType, IterDomain*, TypeHash> ReductionOp::
     getParallelReductionDomains() const {
-  std::unordered_map<ParallelType, IterDomain*> parallel_domains;
+  std::unordered_map<ParallelType, IterDomain*, TypeHash> parallel_domains;
   for (auto d : getReductionDomains()) {
     if (d->isThread()) {
       parallel_domains.insert(std::make_pair(d->parallel_method(), d));


### PR DESCRIPTION
It's a known gcc-5.4 bug that enum class is not hasheable by default, so `std::unordered_map` needs 3rd explicit parameters to compute hash from the type.

Should fix regression caused by https://github.com/pytorch/pytorch/pull/40864


