### PR TITLE
Unit Tests for Fake Quantize Per Tensor (CPU) Kernel

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -497,7 +497,7 @@ Tensor batch_norm(
     auto out = input.clone();
     if (weight.defined()) out = out * weight[0];
     if (bias.defined()) out = out + bias[0];
-    return out; 
+    return out;
   }
   return std::get<0>(at::_batch_norm_impl_index(input, weight, bias, running_mean, running_var,
                                                 training, momentum, eps, cudnn_enabled));

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3609,6 +3609,14 @@
   use_c10_dispatcher: full
   variants: function
 
+- func: fake_quantize_learnable_per_tensor_affine(Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> Tensor
+  use_c10_dispatcher: full
+  variants: function
+
+- func: fake_quantize_learnable_per_tensor_affine_backward(Tensor grad, Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> (Tensor, Tensor, Tensor)
+  use_c10_dispatcher: full
+  variants: function
+
 - func: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
   use_c10_dispatcher: full
   variants: function

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -28,6 +28,8 @@ using fake_quant_grad_tensor_fn = void (*)(
 
 DECLARE_DISPATCH(fake_quant_tensor_fn, fake_quant_tensor_stub);
 DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_tensor_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_sc_tensor_stub);
+DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_z_point_tensor_stub);
 
 using fake_quant_per_channel_fn = void (*)(
     TensorIterator &iter,

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -38,6 +38,8 @@ using fake_quant_per_channel_fn = void (*)(
 
 DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_per_channel_stub);
 DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_grad_per_channel_stub);
+DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_grad_learnable_sc_channel_stub);
+DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_grad_learnable_z_point_channel_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -12,6 +12,8 @@ namespace native {
 // Use REGISTER_DISPATCH to run CPU and CUDA backend.
 DEFINE_DISPATCH(fake_quant_per_channel_stub);
 DEFINE_DISPATCH(fake_quant_grad_per_channel_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_sc_channel_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_z_point_channel_stub);
 
 /* Per channel fake-quantizes the 'inputs' tensor.
 Args:
@@ -151,6 +153,105 @@ Tensor fake_quantize_per_channel_affine_backward(
   fake_quant_grad_per_channel_stub(iter.device_type(), iter, quant_min, quant_max);
 
   return dX;
+}
+
+TensorIterator build_iterator(
+    const Tensor& dX,
+    const Tensor& X,
+    const Tensor& dY,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    std::vector<int64_t> expected_shape) {
+  TensorIterator iter = TensorIteratorConfig()
+    .check_all_same_dtype(false)
+    .add_output(dX)
+    .add_input(X)
+    .add_input(dY)
+    .add_input(native::_unsafe_view(scale, expected_shape))
+    .add_input(native::_unsafe_view(zero_point, expected_shape))
+    .build();
+  return iter;
+}
+
+Tensor fake_quantize_learnable_per_channel_affine(
+    const Tensor& self,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t axis,
+    int64_t quant_min,
+    int64_t quant_max) {
+  return native::fake_quantize_per_channel_affine(
+    self, scale, zero_point, axis, quant_min, quant_max);
+}
+
+std::tuple<Tensor, Tensor, Tensor> fake_quantize_learnable_per_channel_affine_backward(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t axis,
+    int64_t quant_min,
+    int64_t quant_max) {
+  TORCH_CHECK(dY.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(scale.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(zero_point.scalar_type() == ScalarType::Float);
+
+  TORCH_CHECK(X.sizes() == dY.sizes(), "`X` and `dY` are not the same size");
+  TORCH_CHECK(
+      quant_min <= 0 && quant_max >= 0,
+      "`quant_min` should be less than or \
+        equal to `quant_max`, and the quantization range should include 0.");
+  TORCH_CHECK(scale.dim() == 1, "scale should be a 1-D tensor");
+  TORCH_CHECK(zero_point.dim() == 1, "zero point should be a 1-D tensor");
+  TORCH_CHECK(
+      scale.numel() == zero_point.numel(),
+      "scale and zero-point need to have the same dimensions");
+  TORCH_CHECK(
+    at::min(zero_point).item().toLong() >= 0,
+    "`zero_point` must be at least 0 or greater.");
+  TORCH_CHECK(
+      scale.numel() == X.size(axis),
+      "dimensions of scale and zero-point are not consistent with input tensor")
+
+  TORCH_CHECK(
+      at::min(zero_point).item().toLong() >= quant_min &&
+          at::max(zero_point).item().toLong() <= quant_max,
+      "`zero_point` must be between `quant_min` and `quant_max`.");
+
+  TORCH_CHECK(
+      axis >= 0 && axis <= X.dim(),
+      "`axis` must be between 0 and number of dimensions of input");
+
+  if (X.numel() <= 0) {
+    return std::make_tuple(X, scale, zero_point);
+  }
+
+  auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+
+  std::vector<int64_t> expected_shape_X(X.dim(), 1);
+  expected_shape_X[axis] = X.size(axis);
+
+  TensorIterator iter_X = native::build_iterator(
+    dX, X, dY, scale, zero_point, expected_shape_X);
+
+  fake_quant_grad_per_channel_stub(iter_X.device_type(), iter_X, quant_min, quant_max);
+
+  auto dScale = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+
+  TensorIterator iter_Scale = native::build_iterator(
+    dScale, X, dY, scale, zero_point, expected_shape_X);
+
+  fake_quant_grad_learnable_sc_channel_stub(iter_Scale.device_type(), iter_Scale, quant_min, quant_max);
+
+  auto dZeroPoint = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+
+  TensorIterator iter_ZeroPoint = native::build_iterator(
+    dZeroPoint, X, dY, scale, zero_point, expected_shape_X);
+
+  fake_quant_grad_learnable_z_point_channel_stub(iter_ZeroPoint.device_type(), iter_ZeroPoint, quant_min, quant_max);
+
+  return std::make_tuple(dX, dScale, dZeroPoint);
 }
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -145,7 +145,7 @@ std::tuple<Tensor, Tensor, Tensor> fake_quantize_learnable_per_tensor_affine_bac
 
   auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
   fake_quant_grad_tensor_stub(
-    X.device().type(), dX, X, dY, scale, zero_point, quant_min, quant_max);
+    X.device().type(), dX, X, dY, scale_val, zero_point_val, quant_min, quant_max);
 
   auto dScale_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
   fake_quant_grad_learnable_sc_tensor_stub(

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -12,6 +12,8 @@ namespace native {
 // Use REGISTER_DISPATCH to run CPU and CUDA backend.
 DEFINE_DISPATCH(fake_quant_tensor_stub);
 DEFINE_DISPATCH(fake_quant_grad_tensor_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_sc_tensor_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_z_point_tensor_stub);
 
 /* Fake-quantizes the 'inputs' tensor.
 Args:
@@ -92,6 +94,72 @@ Tensor fake_quantize_per_tensor_affine_backward(
   fake_quant_grad_tensor_stub(
       X.device().type(), dX, X, dY, scale, zero_point, quant_min, quant_max);
   return dX;
+}
+
+int64_t get_zero_point_from_tensor(
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  float zero_point_fp = std::nearbyint(zero_point[0].item<float>());
+  float zero_point_clamped = std::fmin(std::fmax(zero_point_fp, quant_min), quant_max);
+  return static_cast<int64_t>(zero_point_clamped);
+}
+
+Tensor fake_quantize_learnable_per_tensor_affine(
+    const Tensor& self,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  float scale_val = scale[0].item<float>();
+  int64_t zero_point_val = native::get_zero_point_from_tensor(zero_point, quant_min, quant_max);
+  return native::fake_quantize_per_tensor_affine(
+    self, scale_val, zero_point_val, quant_min, quant_max);
+}
+
+std::tuple<Tensor, Tensor, Tensor> fake_quantize_learnable_per_tensor_affine_backward(
+    const Tensor& dY,
+    const Tensor& X,
+    const Tensor& scale,
+    const Tensor& zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  float scale_val = scale[0].item<float>();
+  int64_t zero_point_val = native::get_zero_point_from_tensor(zero_point, quant_min, quant_max);
+
+  TORCH_CHECK(dY.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(scale.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(zero_point.scalar_type() == ScalarType::Float);
+  TORCH_CHECK(X.numel() == dY.numel(), "`X` and `dY` are not the same size");
+  TORCH_CHECK(
+      quant_min <= 0 && quant_max >= 0,
+      "`quant_min` should be less than or \
+        equal to `quant_max`, and the quantization range should include 0.");
+  TORCH_CHECK(
+      zero_point_val >= quant_min && zero_point_val <= quant_max,
+      "`zero_point` must be between `quant_min` and `quant_max`.");
+  if (X.numel() <= 0) {
+    return std::make_tuple(X, scale, zero_point);
+  }
+
+  auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_tensor_stub(
+    X.device().type(), dX, X, dY, scale, zero_point, quant_min, quant_max);
+
+  auto dScale_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_learnable_sc_tensor_stub(
+    scale.device().type(), dScale_vec, X, dY, scale_val, zero_point_val, quant_min, quant_max);
+
+  auto dZeroPoint_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  fake_quant_grad_learnable_z_point_tensor_stub(
+    zero_point.device().type(), dZeroPoint_vec, X, dY, scale_val, zero_point_val, quant_min, quant_max);
+
+  // The total sums over the scale and zero point gradient vectors are what will be returned in the end.
+  auto dScale = at::mul(dScale_vec, dX).sum().unsqueeze(0);
+  auto dZeroPoint = at::mul(dZeroPoint_vec, dX).sum().unsqueeze(0);
+
+  return std::make_tuple(dX, dScale, dZeroPoint);
 }
 
 } // namespace native

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -436,6 +436,9 @@
 - name: fake_quantize_per_tensor_affine(Tensor self, float scale, int zero_point, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max)
 
+- name: fake_quantize_learnable_per_tensor_affine(Tensor self, Tensor scale, Tensor zero_point, int quant_min, int quant_max) -> Tensor
+  self, scale, zero_point: "grad.defined() ? fake_quantize_learnable_per_tensor_affine_backward(grad, self, scale, zero_point, quant_min, quant_max) : std::tuple<Tensor, Tensor, Tensor>()"
+
 - name: fake_quantize_per_channel_affine(Tensor self, Tensor scale, Tensor zero_point, int axis, int quant_min, int quant_max) -> Tensor
   self: fake_quantize_per_channel_affine_backward(grad, self, scale, zero_point, axis, quant_min, quant_max)
 


### PR DESCRIPTION
Summary:
This diff contains the unit tests for asserting the functionality of the learnable per tensor fake quantizer that provides back propagation support for both the scale and the zero point (as tensors).

The diff mainly consists of a ground-truth reference function that correctly calculates the gradients, and 2 sets of Hypothesis-backed test suites. One asserts the forward pass, and the other asserts the backward pass.

Test Plan:
On a devvm, run the commands:
 - `buck test mode/dev //caffe2/test -- test_forward_learnable_per_tensor`
 - `buck test mode/dev //caffe2/test -- test_learnable_backward_per_tensor`

Differential Revision: D22406667

