### PR TITLE
Fix unordered-map-over-enum for GCC 5.4

### DIFF
--- a/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_thread_predicate.cpp
@@ -8,7 +8,7 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
-const static std::unordered_map<ParallelType, int> pt_to_offset{
+const static std::unordered_map<ParallelType, int, TypeHash> pt_to_offset{
     {ParallelType::BIDx, 0},
     {ParallelType::BIDy, 1},
     {ParallelType::BIDz, 2},


### PR DESCRIPTION
Forgot to add this to https://github.com/pytorch/pytorch/pull/41055