### PR TITLE
.circleci: Output binary sizes, store binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,6 +1016,11 @@ jobs:
         command: |
             source "/pytorch/.circleci/scripts/binary_linux_build.sh"
     - run:
+        name: Output binary sizes
+        no_output_timeout: "1m"
+        command: |
+            ls -lah /final_pkgs
+    - run:
         name: save binary size
         no_output_timeout: "5m"
         command: |
@@ -1028,6 +1033,9 @@ jobs:
     - persist_to_workspace:
         root: /
         paths: final_pkgs
+
+    - store_artifacts:
+        path: /final_pkgs
 
     # This should really just be another step of the binary_linux_build job above.
     # This isn't possible right now b/c the build job uses the docker executor

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -42,6 +42,11 @@
         command: |
             source "/pytorch/.circleci/scripts/binary_linux_build.sh"
     - run:
+        name: Output binary sizes
+        no_output_timeout: "1m"
+        command: |
+            ls -lah /final_pkgs
+    - run:
         name: save binary size
         no_output_timeout: "5m"
         command: |
@@ -54,6 +59,9 @@
     - persist_to_workspace:
         root: /
         paths: final_pkgs
+
+    - store_artifacts:
+        path: /final_pkgs
 
     # This should really just be another step of the binary_linux_build job above.
     # This isn't possible right now b/c the build job uses the docker executor


### PR DESCRIPTION
We need an easy to way to quickly visually grep binary sizes from builds
and then have a way to test out those binaries quickly.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

