### PR TITLE
[PyTorch Numeric Suite] Remove unnecessary Logger in input arguments …

### DIFF
--- a/torch/quantization/_numeric_suite.py
+++ b/torch/quantization/_numeric_suite.py
@@ -121,13 +121,12 @@ def compare_weights(float_dict, quantized_dict):
     return weight_dict
 
 
-def _get_logger_dict_helper(mod, target_dict, Logger, prefix=""):
+def _get_logger_dict_helper(mod, target_dict, prefix=""):
     r"""This is the helper function for get_logger_dict
 
     Args:
         mod: module we want to save all logger stats
         prefix: prefix for the current module
-        Logger: type of logger we want to get
         target_dict: the dictionary used to save all logger stats
     """
 
@@ -141,10 +140,10 @@ def _get_logger_dict_helper(mod, target_dict, Logger, prefix=""):
 
     for name, child in mod.named_children():
         module_prefix = get_prefix(prefix) + name if prefix else name
-        _get_logger_dict_helper(child, target_dict, Logger, module_prefix)
+        _get_logger_dict_helper(child, target_dict, module_prefix)
 
 
-def get_logger_dict(mod, Logger, prefix=""):
+def get_logger_dict(mod, prefix=""):
     r"""Traverse the modules and save all logger stats into target dict.
     This is mainly used for quantization accuracy debug.
 
@@ -156,14 +155,13 @@ def get_logger_dict(mod, Logger, prefix=""):
     Args:
         mod: module we want to save all logger stats
         prefix: prefix for the current module
-        Logger: type of logger we want to get
 
     Return:
         target_dict: the dictionary used to save all logger stats
     """
 
     target_dict = {}
-    _get_logger_dict_helper(mod, target_dict, Logger, prefix)
+    _get_logger_dict_helper(mod, target_dict, prefix)
     return target_dict
 
 
@@ -315,7 +313,7 @@ def prepare_model_with_stubs(float_module, q_module, module_swap_list, Logger):
     Example usage:
         prepare_model_with_stubs(float_model, q_model, module_swap_list, Logger)
         q_model(data)
-        ob_dict = get_logger_dict(q_model, Logger)
+        ob_dict = get_logger_dict(q_model)
 
     Args:
         float_module: float module used to generate the q_module
@@ -381,7 +379,7 @@ def compare_model_stub(
     """
     prepare_model_with_stubs(float_model, q_model, module_swap_list, Logger)
     q_model(*data)
-    ob_dict = get_logger_dict(q_model, Logger)
+    ob_dict = get_logger_dict(q_model)
     return ob_dict
 
 
@@ -398,8 +396,8 @@ def get_matching_activations(float_module, q_module, Logger):
         entry being a dictionary with two keys 'float' and 'quantized', containing
         the matching float and quantized activations
     """
-    float_dict = get_logger_dict(float_module, Logger)
-    quantized_dict = get_logger_dict(q_module, Logger)
+    float_dict = get_logger_dict(float_module)
+    quantized_dict = get_logger_dict(q_module)
     act_dict = {}
     for key in quantized_dict:
         match_key = _find_match(sorted(float_dict, reverse=True), key, "stats")


### PR DESCRIPTION
…(#40890)

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/40890

Remove unnecessary Logger in input arguments and simplify the API.
ghstack-source-id: 107110487

Test Plan:
buck test mode/dev caffe2/test:quantization -- 'test_compare_weights_lstm_dynamic'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_stub_lstm_dynamic'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_outputs_lstm_dynamic'
buck test mode/dev caffe2/test:quantization -- 'test_compare_weights_conv_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_weights_linear_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_weights_linear_dynamic'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_stub_conv_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_stub_linear_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_stub_submodule_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_stub_functional_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_stub_linear_dynamic'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_outputs_conv_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_outputs_linear_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_outputs_functional_static'
buck test mode/dev caffe2/test:quantization -- 'test_compare_model_outputs_linear_dynamic'

Differential Revision: D22345477

fbshipit-source-id: d8b4eb3d6cb3049aa3296dead8ba29bf5467bd1c

