### PR TITLE
[ROCm] Skip Conv2d, Conv3d transpose fp16 test for ROCm3.5

### DIFF
--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -69,8 +69,8 @@ class AutocastTestLists(object):
             ("conv3d", conv_args_fp32[2]),
             ("conv_tbc", conv_args_fp32[0] + bias_fp32),
             ("conv_transpose1d", conv_args_fp32[0]),
-            ("conv_transpose2d", conv_args_fp32[1]),
-            ("conv_transpose3d", conv_args_fp32[2]),
+            ("conv_transpose2d", conv_args_fp32[1], TEST_WITH_ROCM),
+            ("conv_transpose3d", conv_args_fp32[2], TEST_WITH_ROCM),
             ("convolution", conv_args_fp32[1] + bias_fp32 + ((1, 1), (0, 0), (1, 1), False, (0, 0), 1)),
             # cudnn_convolutions with bias
             ("cudnn_convolution", conv_args_fp32[1] + bias_fp32 + ((0, 0), (1, 1), (1, 1), 1, False, True), TEST_WITH_ROCM),


### PR DESCRIPTION
There's a regression in MIOpen in ROCm3.5 that results in failure of autocast tests. Skipping the tests for now and will re-enable once the fixes are in MIOpen.

@ezyang @jeffdaily @sunway513