### PR TITLE
[Caffe2] Move in-header virtual function implementation to .cc files

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -480,70 +480,13 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   virtual void CancelAsyncCallback() {}
 
-  // RunAsync, if implemenented by the specific operators, will schedule the
+  // RunAsync, if implemented by the specific operators, will schedule the
   // computation on the corresponding context and record the event in its
   // event_ member object. If the specific operator does not support RunAsync,
   // it will simply be synchronous as a fallback.
-  virtual bool RunAsync(int stream_id = 0) {
-    try {
-      auto result = Run(stream_id);
-      if (result) {
-        if (HasAsyncPart()) {
-          RecordEvent();
-        } else {
-          SetEventFinished();
-        }
-      } else {
-        SetEventFinished(getErrorMsg().c_str());
-      }
-      return result;
-    } catch (EnforceNotMet& err) {
-      SetEventFinishedWithException(err.what());
-      throw;
-    } catch (const std::exception& err) {
-      SetEventFinishedWithException(err.what());
-      throw;
-    } catch (...) {
-      SetEventFinishedWithException(getErrorMsg().c_str());
-      throw;
-    }
-  }
+  virtual bool RunAsync(int stream_id = 0);
 
-  virtual void AddRelatedBlobInfo(EnforceNotMet* err) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "AddRelatedBlobInfo(err) not supported for operators exported to c10.");
-
-    if (!has_debug_def()) {
-      return;
-    }
-
-    bool found_input = false;
-    bool found_output = false;
-    if (err->caller() != nullptr) {
-      std::ostringstream oss;
-      for (size_t i = 0; i < inputs_.size(); i++) {
-        if (inputs_[i]->GetRaw() == err->caller()) {
-          found_input = true;
-          oss << "while accessing input: " << debug_def().input(i);
-          break;
-        }
-      }
-      for (size_t i = 0; i < outputs_.size(); i++) {
-        if (outputs_[i]->GetRaw() == err->caller()) {
-          found_output = true;
-          if (found_input) {
-            oss << " OR ";
-          }
-          oss << "while accessing output: " << debug_def().output(i);
-          break;
-        }
-      }
-      if (found_input || found_output) {
-        err->add_context(oss.str());
-      }
-    }
-  }
+  virtual void AddRelatedBlobInfo(EnforceNotMet* err);
 
   virtual std::string debug_info_string() const {
     return "";

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -39,9 +39,8 @@ constexpr int kCannotComputeNumOutputs = -1;
  */
 class CAFFE2_API OpSchema {
  public:
-  OpSchema() : type_("unknown"), file_("unknown"), line_(0) {}
-  OpSchema(const string& type, const string& file, const int line)
-      : type_(type), file_(file), line_(line) {}
+  OpSchema() : OpSchema("unknown", "unknown", 0) {}
+  OpSchema(const string& type, const string& file, const int line);
 
   /**
    * @brief Returns the file that the op schema is registered from.
@@ -443,25 +442,9 @@ class CAFFE2_API OpSchema {
   std::function<bool(int, int)> inplace_enforced_ = [](int, int) {
     return false;
   };
-  TensorInferenceFunctionType tensor_inference_function_ =
-      [](const OperatorDef& def, const vector<TensorShape>&) {
-        vector<TensorShape> out;
-        for (int i = 0; i < def.output_size(); i++) {
-          TensorShape ts;
-          ts.set_unknown_shape(true);
-          out.push_back(ts);
-        }
-        return out;
-      };
+  TensorInferenceFunctionType tensor_inference_function_;
   std::unique_ptr<CostInferenceFunctionType> cost_inference_function_ = nullptr;
-  DeviceInferenceFunctionType device_inference_function_ =
-      [](const OperatorDef& def) {
-        auto op_device =
-            def.has_device_option() ? def.device_option() : DeviceOption();
-        vector<DeviceOption> in_dev(def.input_size(), op_device);
-        vector<DeviceOption> out_dev(def.output_size(), op_device);
-        return std::make_pair(in_dev, out_dev);
-      };
+  DeviceInferenceFunctionType device_inference_function_;
 
   std::function<std::vector<TensorFiller>(
       const std::vector<std::vector<int64_t>>&)>


### PR DESCRIPTION
This is a cherry-pick of #40844 and #40845 into 1.6
If virtual function is implemented in header file, it's implementation will be included as a weak symbol to every shared library that includes this header along with all of it's dependencies.
    
This is the reason why size of `libcaffe2_module_test_dynamic.so` increase to 500Kb (AddRelatedBlobInfo implementation pulled a quarter of libprotobuf.a with it) from the usual 50Kb