### PR TITLE
`torch._six.PY37` should be true for Python-3.8 as well

### DIFF
--- a/torch/_six.py
+++ b/torch/_six.py
@@ -34,7 +34,7 @@ FileNotFoundError = builtins.FileNotFoundError
 StringIO = io.StringIO
 container_abcs = collections.abc
 PY3 = sys.version_info[0] == 3
-PY37 = sys.version_info[0] == 3 and sys.version_info[1] == 7
+PY37 = sys.version_info[0] == 3 and sys.version_info[1] >= 7
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""


### PR DESCRIPTION
This is a cherry-pick of #40868 into release/1.6

Right now it is used to check whether `math.remainder` exists, which is the case for both Python-3.7 and 3.8

