### PR TITLE
match int8 quantization of nnpi

### DIFF
--- a/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
+++ b/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.h
@@ -17,6 +17,19 @@ namespace int8 {
 
 namespace {
 
+
+static float ClampScale(float s)
+{
+  const float MinScale(1e-10f);
+
+   if (std::fabs(s) < MinScale) {
+        LOG(WARNING) << "Too small scale detected: " << s << " clamping to +/-" << MinScale;
+        return std::signbit(s) ? -MinScale : MinScale;
+    } else {
+        return s;
+    }
+}
+
 void Int8QuantizeNNPI(
     const float* in,
     uint8_t* out,
@@ -26,31 +39,44 @@ void Int8QuantizeNNPI(
   const int32_t qmin = std::numeric_limits<uint8_t>::min();
   const int32_t qmax = std::numeric_limits<uint8_t>::max();
 
-  float inv_scale = 1 / Y_scale;
+  float inv_scale = ClampScale(1 / Y_scale);
   float inv_scale_fp16 = 0;
   fbgemm::RoundToFloat16(
-      &inv_scale, &inv_scale_fp16, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-  float offset_tmp = Y_offset;
+      &inv_scale, &inv_scale_fp16, 1, false /* no clamping */);
+  float offset_tmp = -Y_offset;
   fbgemm::RoundToFloat16(
-      &offset_tmp, &offset_tmp, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-
+      &offset_tmp, &offset_tmp, 1, false /* no clamping */);
   std::vector<float> in_fp16(N);
   fbgemm::RoundToFloat16(
-      in, in_fp16.data(), N, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+      in, in_fp16.data(), N, false /* no clamping */);
 
   std::vector<float> inv_scalev(N, inv_scale_fp16);
   std::vector<float> offsetv(N, offset_tmp);
-
   fake_fp16::fma_fp16(N, in_fp16.data(), inv_scalev.data(), offsetv.data());
-
   for (int i = 0; i < N; i++) {
-    float r = round(offsetv[i]);
-    int32_t int_result = static_cast<int32_t>(r);
-    int_result = std::max(int_result, qmin);
-    int_result = std::min(int_result, qmax);
-    out[i] = static_cast<uint8_t>(int_result);
+    offsetv[i] = round(offsetv[i]);
+  }
+  fbgemm::RoundToFloat16(
+      offsetv.data(), offsetv.data(), N, false /* no clamping */);
+  for (int i = 0; i < N; i++) {
+    float halfRes = offsetv[i];
+    if (std::isinf(halfRes)) {
+      if (halfRes > 0) {
+        halfRes = qmax;
+      } else {
+        halfRes = qmin;
+      }
+    }
+    if (halfRes > qmax) {
+      halfRes = qmax;
+    }
+    if (halfRes < qmin) {
+      halfRes = qmin;
+    }
+    out[i] = static_cast<uint8_t>(halfRes);
   }
 }
+
 } // namespace
 
 class Int8QuantizeNNPIOp final : public Operator<CPUContext> {


### PR DESCRIPTION
Summary:
mimic nnpi's quantization operations

removed redundant int8 test

Test Plan: ran FC with sizes up to 5, running bigger sizes

Differential Revision: D22420537

