### PR TITLE
Add a link in RPC doc page to point to PT Distributed overview

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -4,6 +4,10 @@
 Distributed communication package - torch.distributed
 =====================================================
 
+.. note ::
+    Please refer to `PyTorch Distributed Overview <https://pytorch.org/tutorials/beginner/dist_overview.html>`__
+    for a brief introduction to all features related to distributed training.
+
 .. automodule:: torch.distributed
 .. currentmodule:: torch.distributed
 

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -12,6 +12,9 @@ machines.
      APIs in the RPC package are stable. There are multiple ongoing work items
      to improve performance and error handling, which will ship in future releases.
 
+.. note ::
+    Please refer to `PyTorch Distributed Overview <https://pytorch.org/tutorials/beginner/dist_overview.html>`__
+    for a brief introduction to all features related to distributed training.
 
 Basics
 ------

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -68,6 +68,10 @@ class DistributedDataParallel(Module):
     In order to spawn up multiple processes per node, you can use either
     ``torch.distributed.launch`` or ``torch.multiprocessing.spawn``
 
+    .. note ::
+        Please refer to `PyTorch Distributed Overview <https://pytorch.org/tutorials/beginner/dist_overview.html>`__
+        for a brief introduction to all features related to distributed training.
+
     .. note:: ``nccl`` backend is currently the fastest and
         highly recommended backend to be used with Multi-Process Single-GPU
         distributed training and this applies to both single-node and multi-node


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41108 Add a link in RPC doc page to point to PT Distributed overview**

Differential Revision: [D22440751](https://our.internmc.facebook.com/intern/diff/D22440751)