### PR TITLE
Add a link in DDP doc page to point to PT Distributed overview

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -68,6 +68,10 @@ class DistributedDataParallel(Module):
     In order to spawn up multiple processes per node, you can use either
     ``torch.distributed.launch`` or ``torch.multiprocessing.spawn``
 
+    .. note ::
+        Please refer to `PyTorch Distributed Overview <https://pytorch.org/tutorials/beginner/dist_overview.html>`__
+        for a brief introduction to all features related to distributed training.
+
     .. note:: ``nccl`` backend is currently the fastest and
         highly recommended backend to be used with Multi-Process Single-GPU
         distributed training and this applies to both single-node and multi-node


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41110 Add a link in C10D doc page to point to PT Distributed overview
* **#41109 Add a link in DDP doc page to point to PT Distributed overview**
* #41108 Add a link in RPC doc page to point to PT Distributed overview

