### PR TITLE
Add a link in C10D doc page to point to PT Distributed overview

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -4,6 +4,10 @@
 Distributed communication package - torch.distributed
 =====================================================
 
+.. note ::
+    Please refer to `PyTorch Distributed Overview <https://pytorch.org/tutorials/beginner/dist_overview.html>`__
+    for a brief introduction to all features related to distributed training.
+
 .. automodule:: torch.distributed
 .. currentmodule:: torch.distributed
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41110 Add a link in C10D doc page to point to PT Distributed overview**
* #41109 Add a link in DDP doc page to point to PT Distributed overview
* #41108 Add a link in RPC doc page to point to PT Distributed overview

