### PR TITLE
add prefetch_factor for multiprocessing prefetching process

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -22,7 +22,7 @@ These options are configured by the constructor arguments of a
     DataLoader(dataset, batch_size=1, shuffle=False, sampler=None,
                batch_sampler=None, num_workers=0, collate_fn=None,
                pin_memory=False, drop_last=False, timeout=0,
-               worker_init_fn=None)
+               worker_init_fn=None, *, prefetch_factor=2)
 
 The sections below describe in details the effects and usages of these options.
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1059,36 +1059,39 @@ except RuntimeError as e:
         sizes_for_all_workers = [0, 4, 20]
         expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
-        dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
-        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=None,
-                                worker_init_fn=set_faulthander_if_available)
-        dataloader_iter = iter(dataloader)
-        fetched = sorted(dataloader_iter)
-        for a, b in zip(fetched, expected):
-            # non-batched should not convert ints into tensors
-            self.assertIsInstance(a, torch._six.int_classes)
-            self.assertEqual(a, b)
-        # DataLoader should match len of the iterable-style dataset (if implemented)
-        self.assertEqual(len(dataloader), len(dataset))
-        # When loading more than len(dataset) data, after accessing len(dataloader),
-        # we should get a warning. See NOTE [ IterableDataset and __len__ ].
-        dataset = CountingIterableDataset(20)
-        dataloader = DataLoader(dataset, num_workers=num_workers,
-                                worker_init_fn=set_faulthander_if_available)
-        it = iter(dataloader)
-        for _ in range(40):
-            self.assertNotWarn(lambda: next(it), "Should not warn before accessing len(dataloader)")
-        self.assertEqual(len(dataloader), len(dataset))
-        self.assertEqual(len(dataloader), 20)
-        it = iter(dataloader)
-        for _ in range(20):
-            self.assertNotWarn(lambda: next(it), "Should not warn before exceeding length")
-        for _ in range(3):
-            with self.assertWarnsRegex(
-                UserWarning,
-                r"but [0-9]+ samples have been fetched\. For multiprocessing data-loading, this",
-                    msg="Should always warn after exceeding length"):
-                next(it)
+        for prefetch_factor in [2, 3 ,4]:
+            dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
+            dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=None,
+                                    worker_init_fn=set_faulthander_if_available,
+                                    prefetch_factor=prefetch_factor)
+            dataloader_iter = iter(dataloader)
+            fetched = sorted(dataloader_iter)
+            for a, b in zip(fetched, expected):
+                # non-batched should not convert ints into tensors
+                self.assertIsInstance(a, torch._six.int_classes)
+                self.assertEqual(a, b)
+            # DataLoader should match len of the iterable-style dataset (if implemented)
+            self.assertEqual(len(dataloader), len(dataset))
+            # When loading more than len(dataset) data, after accessing len(dataloader),
+            # we should get a warning. See NOTE [ IterableDataset and __len__ ].
+            dataset = CountingIterableDataset(20)
+            dataloader = DataLoader(dataset, num_workers=num_workers,
+                                    worker_init_fn=set_faulthander_if_available,
+                                    prefetch_factor=prefetch_factor)
+            it = iter(dataloader)
+            for _ in range(40):
+                self.assertNotWarn(lambda: next(it), "Should not warn before accessing len(dataloader)")
+            self.assertEqual(len(dataloader), len(dataset))
+            self.assertEqual(len(dataloader), 20)
+            it = iter(dataloader)
+            for _ in range(20):
+                self.assertNotWarn(lambda: next(it), "Should not warn before exceeding length")
+            for _ in range(3):
+                with self.assertWarnsRegex(
+                    UserWarning,
+                    r"but [0-9]+ samples have been fetched\. For multiprocessing data-loading, this",
+                        msg="Should always warn after exceeding length"):
+                    next(it)
 
         # [no auto-batching] test that workers exit gracefully
         workers = dataloader_iter._workers
@@ -1115,28 +1118,29 @@ except RuntimeError as e:
         sizes_for_all_workers = [0, 4, 20]
         expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
-        dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
-        # worker 0 should return 0 batches
-        # worker 1 should return 1 batches
-        # worker 2 should return 3 batches
-        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=7)
-        dataloader_iter = iter(dataloader)
-        fetched = list(dataloader_iter)
-        self.assertEqual(len(fetched), 4)
-        fetched = set(tuple(t.tolist()) for t in fetched)
-        self.assertEqual(fetched, {tuple(range(4)), tuple(range(7)), tuple(range(7, 14)), tuple(range(14, 20))})
+        for prefetch_factor in [2, 3 ,4]:
+            dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
+            # worker 0 should return 0 batches
+            # worker 1 should return 1 batches
+            # worker 2 should return 3 batches
+            dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=7, prefetch_factor=prefetch_factor)
+            dataloader_iter = iter(dataloader)
+            fetched = list(dataloader_iter)
+            self.assertEqual(len(fetched), 4)
+            fetched = set(tuple(t.tolist()) for t in fetched)
+            self.assertEqual(fetched, {tuple(range(4)), tuple(range(7)), tuple(range(7, 14)), tuple(range(14, 20))})
 
-        # [auto-batching] test that workers exit gracefully
-        workers = dataloader_iter._workers
-        del dataloader_iter
-        try:
-            for w in workers:
-                w.join(JOIN_TIMEOUT)
-                self.assertFalse(w.is_alive())
-                self.assertEqual(w.exitcode, 0)
-        finally:
-            for w in workers:
-                w.terminate()
+            # [auto-batching] test that workers exit gracefully
+            workers = dataloader_iter._workers
+            del dataloader_iter
+            try:
+                for w in workers:
+                    w.join(JOIN_TIMEOUT)
+                    self.assertFalse(w.is_alive())
+                    self.assertEqual(w.exitcode, 0)
+            finally:
+                for w in workers:
+                    w.terminate()
 
         # [auto-batching & drop_last] single process loading
         dataset = CountingIterableDataset(20)
@@ -1150,29 +1154,30 @@ except RuntimeError as e:
         sizes_for_all_workers = [0, 4, 20]
         expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
-        dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
-        # worker 0 should return 0 batches
-        # worker 1 should return 1 batches
-        # worker 2 should return 3 batches
-        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=7, drop_last=True,
-                                worker_init_fn=set_faulthander_if_available)
-        dataloader_iter = iter(dataloader)
-        fetched = list(dataloader_iter)
-        self.assertEqual(len(fetched), 2)
-        fetched = set(tuple(t.tolist()) for t in fetched)
-        self.assertEqual(fetched, {tuple(range(7)), tuple(range(7, 14))})
+        for prefetch_factor in [2, 3 ,4]:
+            dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
+            # worker 0 should return 0 batches
+            # worker 1 should return 1 batches
+            # worker 2 should return 3 batches
+            dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=7, drop_last=True,
+                                    worker_init_fn=set_faulthander_if_available, prefetch_factor=prefetch_factor)
+            dataloader_iter = iter(dataloader)
+            fetched = list(dataloader_iter)
+            self.assertEqual(len(fetched), 2)
+            fetched = set(tuple(t.tolist()) for t in fetched)
+            self.assertEqual(fetched, {tuple(range(7)), tuple(range(7, 14))})
 
-        # [auto-batching & drop_last] test that workers exit gracefully
-        workers = dataloader_iter._workers
-        del dataloader_iter
-        try:
-            for w in workers:
-                w.join(JOIN_TIMEOUT)
-                self.assertFalse(w.is_alive())
-                self.assertEqual(w.exitcode, 0)
-        finally:
-            for w in workers:
-                w.terminate()
+            # [auto-batching & drop_last] test that workers exit gracefully
+            workers = dataloader_iter._workers
+            del dataloader_iter
+            try:
+                for w in workers:
+                    w.join(JOIN_TIMEOUT)
+                    self.assertFalse(w.is_alive())
+                    self.assertEqual(w.exitcode, 0)
+            finally:
+                for w in workers:
+                    w.terminate()
 
     def test_chain_iterable_style_dataset(self):
         # chaining (concatenation)
@@ -1274,11 +1279,17 @@ except RuntimeError as e:
     def test_seqential_batch_workers(self):
         self._test_sequential(DataLoader(self.dataset, batch_size=2, num_workers=4))
 
+    def test_seqential_batch_workers_prefetch(self):
+        self._test_sequential(DataLoader(self.dataset, batch_size=2, num_workers=4, prefetch_factor=3))
+
     def test_shuffle_workers(self):
         self._test_shuffle(DataLoader(self.dataset, shuffle=True, num_workers=4))
 
     def test_shuffle_batch_workers(self):
         self._test_shuffle(DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4))
+
+    def test_shuffle_batch_workers_prefetch(self):
+        self._test_shuffle(DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4, prefetch_factor=3))
 
     def test_random_sampler(self):
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1154,7 +1154,7 @@ except RuntimeError as e:
         sizes_for_all_workers = [0, 4, 20]
         expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
-        for prefetch_factor in [2, 3 ,4]:
+        for prefetch_factor in [2, 3, 4]:
             dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
             # worker 0 should return 0 batches
             # worker 1 should return 1 batches

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1059,7 +1059,7 @@ except RuntimeError as e:
         sizes_for_all_workers = [0, 4, 20]
         expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
-        for prefetch_factor in [2, 3 ,4]:
+        for prefetch_factor in [2, 3, 4]:
             dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
             dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=None,
                                     worker_init_fn=set_faulthander_if_available,
@@ -1118,7 +1118,7 @@ except RuntimeError as e:
         sizes_for_all_workers = [0, 4, 20]
         expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
-        for prefetch_factor in [2, 3 ,4]:
+        for prefetch_factor in [2, 3, 4]:
             dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
             # worker 0 should return 0 batches
             # worker 1 should return 1 batches

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1032,7 +1032,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
     def _try_put_index(self):
         assert self._tasks_outstanding < self._prefetch_factor * self._num_workers
-        
+
         try:
             index = self._next_index()
         except StopIteration:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -165,6 +165,11 @@ class DataLoader(Generic[T_co]):
         if timeout < 0:
             raise ValueError('timeout option should be non-negative')
 
+        if num_workers == 0 and prefetch_factor != 2:
+            raise ValueError('prefetch_factor option could only be specified in multiprocessing.'
+                             'let num_workers > 0 to enable multiprocessing.')
+        assert prefetch_factor > 0
+        
         self.dataset = dataset
         self.num_workers = num_workers
         self.prefetch_factor = prefetch_factor

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -93,9 +93,6 @@ class DataLoader(Generic[T_co]):
         num_workers (int, optional): how many subprocesses to use for data
             loading. ``0`` means that the data will be loaded in the main process.
             (default: ``0``)
-        prefetch_factor (int, optional): Number of sample loaded in advance by each worker.
-            ``2`` means there will be a total of 2 * num_workers samples prefetched 
-            across all workers. (default: ``2``)
         collate_fn (callable, optional): merges a list of samples to form a
             mini-batch of Tensor(s).  Used when using batched loading from a
             map-style dataset.
@@ -112,6 +109,9 @@ class DataLoader(Generic[T_co]):
         worker_init_fn (callable, optional): If not ``None``, this will be called on each
             worker subprocess with the worker id (an int in ``[0, num_workers - 1]``) as
             input, after seeding and before data loading. (default: ``None``)
+        prefetch_factor (int, optional, keyword-only arg): Number of sample loaded 
+            in advance by each worker. ``2`` means there will be a total of 
+            2 * num_workers samples prefetched across all workers. (default: ``2``)
 
 
     .. warning:: If the ``spawn`` start method is used, :attr:`worker_init_fn`
@@ -143,19 +143,19 @@ class DataLoader(Generic[T_co]):
     pin_memory: bool
     drop_last: bool
     timeout: float
-    prefetch_factor: int
     sampler: Sampler
+    prefetch_factor: int
 
     __initialized = False
 
     def __init__(self, dataset: Dataset[T_co], batch_size: Optional[int] = 1,
                  shuffle: bool = False, sampler: Optional[Sampler[int]] = None,
                  batch_sampler: Optional[Sampler[Sequence[int]]] = None,
-                 num_workers: int = 0, prefetch_factor: int = 2, 
-                 collate_fn: _collate_fn_t = None, pin_memory: bool = False, 
-                 drop_last: bool = False, timeout: float = 0, 
-                 worker_init_fn: _worker_init_fn_t = None,
-                 multiprocessing_context=None, generator=None):
+                 num_workers: int = 0, collate_fn: _collate_fn_t = None,
+                 pin_memory: bool = False, drop_last: bool = False, 
+                 timeout: float = 0, worker_init_fn: _worker_init_fn_t = None,
+                 multiprocessing_context=None, generator=None, 
+                 *, prefetch_factor: int = 2):
         torch._C._log_api_usage_once("python.data_loader")  # type: ignore
 
         if num_workers < 0:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -94,8 +94,8 @@ class DataLoader(Generic[T_co]):
             loading. ``0`` means that the data will be loaded in the main process.
             (default: ``0``)
         prefetch_factor (int, optional): Number of sample loaded in advance by each worker.
-            ``2`` means there will be ``2 * num_workers`` get prefetched. 
-            (default: ``2``)
+            ``2`` means there will be a total of 2 * num_workers samples prefetched 
+            across all workers. (default: ``2``)
         collate_fn (callable, optional): merges a list of samples to form a
             mini-batch of Tensor(s).  Used when using batched loading from a
             map-style dataset.

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -93,9 +93,9 @@ class DataLoader(Generic[T_co]):
         num_workers (int, optional): how many subprocesses to use for data
             loading. ``0`` means that the data will be loaded in the main process.
             (default: ``0``)
-        prefetch_factor (int, optional): multiply factor to affect how many samples
-            will be prefethed. ``2`` means there will be ``2 * num_workers`` get
-            prefetched. (default: ``2``)
+        prefetch_factor (int, optional): Number of sample loaded in advance by each worker.
+            ``2`` means there will be ``2 * num_workers`` get prefetched. 
+            (default: ``2``)
         collate_fn (callable, optional): merges a list of samples to form a
             mini-batch of Tensor(s).  Used when using batched loading from a
             map-style dataset.

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -169,7 +169,7 @@ class DataLoader(Generic[T_co]):
             raise ValueError('prefetch_factor option could only be specified in multiprocessing.'
                              'let num_workers > 0 to enable multiprocessing.')
         assert prefetch_factor > 0
-        
+
         self.dataset = dataset
         self.num_workers = num_workers
         self.prefetch_factor = prefetch_factor
@@ -1031,7 +1031,6 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                 return self._process_data(data)
 
     def _try_put_index(self):
-        assert self._tasks_outstanding < 2 * self._num_workers
         try:
             index = self._next_index()
         except StopIteration:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1031,6 +1031,8 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                 return self._process_data(data)
 
     def _try_put_index(self):
+        assert self._tasks_outstanding < self._prefetch_factor * self._num_workers
+        
         try:
             index = self._next_index()
         except StopIteration:


### PR DESCRIPTION
fix #40604
Add parameter to Dataloader to configure the per-worker prefetch number.
Before this edit, the prefetch process always prefetch 2 * num_workers data items, this commit help us make this configurable, e.x. you can specify to prefetch 10 * num_workers data items.