### PR TITLE
.circleci: Remove pynightly jobs

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -3,9 +3,6 @@ from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 
 CONFIG_TREE_DATA = [
     ("xenial", [
-        (None, [
-            X("nightly"),
-        ]),
         ("rocm", [
             ("3.3", [
                 X("3.6"),

--- a/.circleci/cimodel/data/simple/docker_definitions.py
+++ b/.circleci/cimodel/data/simple/docker_definitions.py
@@ -26,7 +26,6 @@ IMAGE_NAMES = [
     "pytorch-linux-xenial-py3.6-gcc5.4",
     "pytorch-linux-xenial-py3.6-gcc7.2",
     "pytorch-linux-xenial-py3.6-gcc7",
-    "pytorch-linux-xenial-pynightly",
     "pytorch-linux-xenial-rocm3.3-py3.6",
     "pytorch-linux-xenial-rocm3.5.1-py3.6",
 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7158,29 +7158,6 @@ workflows:
   build:
     jobs:
       - pytorch_linux_build:
-          name: pytorch_linux_xenial_pynightly_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          build_environment: "pytorch-linux-xenial-pynightly-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:ab1632df-fa59-40e6-8c23-98e004f61148"
-      - pytorch_linux_test:
-          name: pytorch_linux_xenial_pynightly_test
-          requires:
-            - pytorch_linux_xenial_pynightly_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          build_environment: "pytorch-linux-xenial-pynightly-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:ab1632df-fa59-40e6-8c23-98e004f61148"
-          resource_class: large
-      - pytorch_linux_build:
           name: pytorch_linux_xenial_rocm3_3_py3_6_build
           filters:
             branches:
@@ -8130,9 +8107,6 @@ workflows:
       - docker_build_job:
           name: "pytorch-linux-xenial-py3.6-gcc7"
           image_name: "pytorch-linux-xenial-py3.6-gcc7"
-      - docker_build_job:
-          name: "pytorch-linux-xenial-pynightly"
-          image_name: "pytorch-linux-xenial-pynightly"
       - docker_build_job:
           name: "pytorch-linux-xenial-rocm3.3-py3.6"
           image_name: "pytorch-linux-xenial-rocm3.3-py3.6"

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -71,13 +71,6 @@ case "$image" in
     DB=yes
     VISION=yes
     ;;
-  pytorch-linux-xenial-pynightly)
-    TRAVIS_PYTHON_VERSION=nightly
-    GCC_VERSION=7
-    PROTOBUF=yes
-    DB=yes
-    VISION=yes
-    ;;
   pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4)
     CUDA_VERSION=9.2
     CUDNN_VERSION=7


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41134 .circleci: Remove pynightly jobs**

These jobs didn't really fulfill the intended purpose that they had once
had since the travis python versions were basically locked to 3.7.

Going to go ahead and remove these along with its docker jobs as well
since we don't actively need them anymore.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D22441250](https://our.internmc.facebook.com/intern/diff/D22441250)