### PR TITLE
Ampere has CUDA_MAX_THREADS_PER_SM == 2048

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -161,7 +161,7 @@ namespace at { namespace cuda { using namespace c10::hip; }}
 // The maximum number of threads per multiprocessor is 1024 for Turing architecture (7.5)
 // but 2048 for previous architectures. You'll get warnings if you exceed these constants.
 // Hence, the following macros adjust the input values from the user to resolve potential warnings.
-#if __CUDA_ARCH__ >= 750
+#if __CUDA_ARCH__ == 750
 constexpr uint32_t CUDA_MAX_THREADS_PER_SM = 1024;
 #else
 constexpr uint32_t CUDA_MAX_THREADS_PER_SM = 2048;


### PR DESCRIPTION
See: https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/nvidia-ampere-architecture-whitepaper.pdf
page 44, table 5
![image](https://user-images.githubusercontent.com/1032377/86958633-56051580-c111-11ea-94da-c726a61dc00a.png)
