### PR TITLE
Optimize grouped conv2d by unfold -> bmm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4041,6 +4041,38 @@ class TestNN(NNTestCase):
                              atol=1e-1 if dtype == torch.half else dtype2prec_DONTUSE[dtype], rtol=0)
 
     # Almost identical to the above `test_Conv2d_naive_groups`
+    # Turns off mkldnn to hit the fast slow_conv2d path.
+    def test_Conv2d_groups_nobias_mklnn_off(self):
+        torch._C._set_mkldnn_enabled(False)
+        dev_dtypes = [("cpu", torch.float)]
+        for device, dtype in dev_dtypes:
+            m = nn.Conv2d(4, 4, kernel_size=3, groups=2, bias=False).to(device, dtype)
+            i = torch.randn(2, 4, 6, 6, device=device, dtype=dtype, requires_grad=True)
+            output = m(i)
+            grad_output = torch.randn(2, 4, 4, 4, device=device, dtype=dtype)
+            output.backward(grad_output)
+
+            m1 = nn.Conv2d(2, 2, kernel_size=3, bias=False).to(device, dtype)
+            m1.weight.data.copy_(m.weight.data[:2])
+            i1 = i.data[:, :2].contiguous().requires_grad_(True)
+            output1 = m1(i1)
+            output1.backward(grad_output[:, :2].contiguous())
+
+            m2 = nn.Conv2d(2, 2, kernel_size=3, bias=False).to(device, dtype)
+            m2.weight.data.copy_(m.weight.data[2:])
+            i2 = i.data[:, 2:].contiguous().requires_grad_(True)
+            output2 = m2(i2)
+            output2.backward(grad_output[:, 2:].contiguous())
+
+            self.assertEqual(output, torch.cat([output1, output2], 1))
+            self.assertEqual(i.grad.data,
+                             torch.cat([i1.grad.data, i2.grad.data], 1),
+                             atol=dtype2prec_DONTUSE[dtype], rtol=0)
+            self.assertEqual(m.weight.grad.data,
+                             torch.cat([m1.weight.grad.data, m2.weight.grad.data], 0),
+                             atol=1e-1 if dtype == torch.half else dtype2prec_DONTUSE[dtype], rtol=0)
+
+    # Almost identical to the above `test_Conv2d_naive_groups`
     # Covering special case when group > 1, input-channel / group < 16 and output-channel is multiple of 16
     # See also https://github.com/pytorch/pytorch/pull/18463#issuecomment-476563686
     # and https://github.com/pytorch/pytorch/pull/18463#issuecomment-477001024


### PR DESCRIPTION
Summary: The current implementation of group conv2d loops over group. This change batches all the groups for a more efficient computation. 

* supporting grouped conv2d in slow_conv2d
* adding a fast path in __convolution to call slow_conv2d when running grouped_conv2d on CPU

Test Plan:
Added the following test case  in test_nn.py, testing both forward and backward pass:
* test_Conv2d_groups_nobias_mklnn_off

```
PyTorch built with:
  - GCC 4.2
  - C++ Version: 201703
  - clang 8.0.20181009
  - Intel(R) Math Kernel Library Version 2017.0.3 Product Build 20170413 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v1.2.1 (Git Hash N/A)
  - OpenMP 201511 (a.k.a. OpenMP 4.5)
  - CPU capability usage: AVX2
  - Build settings: 
```

```
from timeit import Timer

import numpy as np
import torch


num = 50
S = [
    [1, 1024, 14, 14, 512, 1, 1, 0, 0],
    [1, 1024, 14, 14, 512, 3, 3, 0, 0],
    [1, 1024, 14, 14, 512, 5, 5, 0, 0],
]

for g in [2, 4, 8]:
    for padding in [0, 1]:
        for x in range(len(S)):
            P = S[x]
            (N, C, H, W) = P[0:4]
            M = P[4]
            (kernel_h, kernel_w) = P[5:7]
            (stride_h, stride_w) = P[7:9]
            (padding_h, padding_w) = (padding, padding)

            X_np = np.random.randn(N, C, H, W).astype(np.float32)
            W_np = np.random.randn(M, C, kernel_h, kernel_w).astype(np.float32)
            X = torch.from_numpy(X_np)
            print(
                (
                    "N: {N}, C: {C}, H: {H}, W: {W}, M: {M}, kernel_h: {kernel_h}, kernel_w: {kernel_w},"
                    "stride_h: {stride_h}, stride_w: {stride_w}, padding_h: {padding_h}, "
                    "padding_w: {padding_w} groups: {groups}"
                ).format(
                    N=N,
                    C=C,
                    H=H,
                    W=W,
                    M=M,
                    kernel_h=kernel_h,
                    kernel_w=kernel_w,
                    stride_h=stride_h,
                    stride_w=stride_w,
                    padding_h=padding_h,
                    padding_w=padding_w,
                    groups=g,
                )
            )
            conv2d_pt = torch.nn.Conv2d(
                C,
                M,
                (kernel_h, kernel_w),
                stride=(stride_h, stride_w),
                padding=(padding_h, padding_w),
                groups=g,
                bias=True,
            )

            class ConvNet(torch.nn.Module):
                def __init__(self):
                    super(ConvNet, self).__init__()
                    self.conv2d = conv2d_pt

                def forward(self, x):
                    return self.conv2d(x)

            model = ConvNet()

            def pt_forward():
                with torch.no_grad():
                    model(X)

            torch._C._set_mkldnn_enabled(True)
            t = Timer("pt_forward()", "from __main__ import pt_forward, X")
            print("MKLDNN pt time = {}".format(t.timeit(num) / num * 1000.0))
            torch._C._set_mkldnn_enabled(False)
            t = Timer("pt_forward()", "from __main__ import pt_forward, X")
            print("TH pt time = {}".format(t.timeit(num) / num * 1000.0))
            print("\n")
```
Command:
OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 buck run @mode/opt experimental/piyushmh:group_conv2d_perf

Results:
```
N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 1, kernel_w: 1,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 2
MKLDNN pt time = 2.396249941084534
TH pt time = 1.6212143609300256
New implementation TH pt time = 4.276635500136763


N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 3, kernel_w: 3,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 2
MKLDNN pt time = 14.524029481690377
TH pt time = 6.749001618009061
New implementation TH pt time = 6.981048060115427

N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 5, kernel_w: 5,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 2
MKLDNN pt time = 33.35205713985488
TH pt time = 17.04349328065291
New implementation TH pt time = 23.01782624097541

N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 1, kernel_w: 1,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 2
MKLDNN pt time = 2.1534182014875114
TH pt time = 1.6464285389520228
New implementation TH pt time = 1.6756533994339406


N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 3, kernel_w: 3,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 2
MKLDNN pt time = 14.301151898689568
TH pt time = 9.977071180474013
New implementation TH pt time = 11.18448490044102



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 5, kernel_w: 5,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 2
MKLDNN pt time = 37.25171020021662
TH pt time = 25.08984894026071
New implementation TH pt time = 28.640052361879498



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 1, kernel_w: 1,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 4
MKLDNN pt time = 1.214240558911115
TH pt time = 0.8866383391432464
New implementation TH pt time = 0.7292797393165529



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 3, kernel_w: 3,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 4
MKLDNN pt time = 4.446479140315205
TH pt time = 3.8826309191063046
New implementation TH pt time = 3.8437813404016197


N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 5, kernel_w: 5,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 4
MKLDNN pt time = 17.763572039548308
TH pt time = 10.842112661339343
New implementation TH pt time = 14.842092178296298


N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 1, kernel_w: 1,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 4
MKLDNN pt time = 1.4290818781591952
TH pt time = 1.2468176404945552
New implementation TH pt time = 1.1342144012451172


N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 3, kernel_w: 3,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 4
MKLDNN pt time = 6.148020739201456
TH pt time = 6.651792719494551
New implementation TH pt time = 6.367272478528321


N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 5, kernel_w: 5,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 4
MKLDNN pt time = 19.79779327986762
TH pt time = 11.329268079716712
New implementation TH pt time = 20.390679300762713



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 1, kernel_w: 1,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 8
MKLDNN pt time = 0.8378969598561525
TH pt time = 0.7001999602653086
New implementation TH pt time = 0.5394901405088603



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 3, kernel_w: 3,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 8
MKLDNN pt time = 2.4611629196442664
TH pt time = 2.8066396596841514
New implementation TH pt time = 2.6308178016915917



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 5, kernel_w: 5,stride_h: 1, stride_w: 1, padding_h: 0, padding_w: 0 groups: 8
MKLDNN pt time = 4.467485479544848
TH pt time = 6.293305980507284
New implementation TH pt time = 12.03830363927409

N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 1, kernel_w: 1,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 8
MKLDNN pt time = 1.1003097402863204
TH pt time = 1.0144947399385273
New implementation TH pt time = 0.7655130396597087



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 3, kernel_w: 3,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 8
MKLDNN pt time = 3.037271238863468
TH pt time = 4.349836420733482
New implementation TH pt time = 3.942242639604956



N: 1, C: 1024, H: 14, W: 14, M: 512, kernel_h: 5, kernel_w: 5,stride_h: 1, stride_w: 1, padding_h: 1, padding_w: 1 groups: 8
MKLDNN pt time = 5.924453181214631
TH pt time = 8.270565180573612
New implementation TH pt time = 14.920658320188522
```

Differential Revision: D22344476

