### PR TITLE
[JIT] Fix JIT triage workflow

### DIFF
--- a/.github/workflows/jit_triage.yml
+++ b/.github/workflows/jit_triage.yml
@@ -2,7 +2,7 @@ name: jit-triage
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 jobs:
   welcome:
@@ -20,27 +20,33 @@ jobs:
 
             // Check if issue has a JIT label.
             const kJitLabel = "jit";
-            const hasJitLabel = context.issue.labels.filter(label => label.name == kJitLabel).length > 0;
+
+            issue = await github.issues.get({
+              owner: context.issue.owner,
+              repo: context.issue.repo,
+              issue_number: context.issue.number,
+            })
+
+            const hasJitLabel = issue.data.labels.filter(label => label.name == kJitLabel).length > 0;
 
             if (!hasJitLabel) {
-              core.info("Issue " + context.issue.title + " does not have JIT label");
+              core.debug("Issue " + issue.data.title + " does not have JIT label");
               return;
             }
 
             // Get project column ID.
             const kProjectName = "JIT Triage";
             const kColumnName = "Need triage";
-            const kPyTorch = "pytorch";
 
             // Query all projects in the repository.
             // TODO: Support pagination once there are > 30 projects.
             const projects = await github.projects.listForRepo({
-              owner: kPyTorch,
-              repo: kPyTorch,
+              owner: context.issue.owner,
+              repo: context.issue.repo,
             });
 
             // Filter out unwanted projects and get the ID for the JIT Triage project.
-            const filteredProjects = projects.filter(project => project.name == kProjectName);
+            const filteredProjects = projects.data.filter(project => project.name == kProjectName);
 
             if (filteredProjects.length != 1) {
               core.setFailed("Unable to find a project named " + kProjectName);
@@ -48,7 +54,6 @@ jobs:
             }
 
             const projectId = filteredProjects[0].id;
-
             // First, query all columns in the project.
             // TODO: Support pagination once there are > 30 columns.
             const columns = await github.projects.listColumns({
@@ -56,9 +61,9 @@ jobs:
             });
 
             // Filter out unwanted projects and get the ID for the Need triage column.
-            const filteredColumns = columns.filter(column => column.name == kColumnName);
+            const filteredColumns = columns.data.filter(column => column.name == kColumnName);
 
-            if (filteredColumns != 1) {
+            if (filteredColumns.length != 1) {
               core.setFailed("Unable to find a column named " + kColumnName);
               return;
             }
@@ -66,8 +71,8 @@ jobs:
             const columnId = filteredColumns[0].id;
 
             // Create a project card for this new issue.
-            await octokit.projects.createCard({
+            await github.projects.createCard({
               column_id: columnId,
-              content_id: context.issue.id,
+              content_id: issue.data.id,
               content_type: "Issue",
             })


### PR DESCRIPTION
**Summary**
This commit fixes the JIT triage workflow based on testing done in my
own fork.

**Test Plan**
This commit has been tested against my own fork. This commit is
currently at the tip of my master branch, and if you open an issue in my
fork and label it JIT, it will be added to the Triage Review project in
that fork under the Needs triage column.

*Old issue that is labelled JIT later*

<img width="700" alt="Captura de Pantalla 2020-07-08 a la(s) 6 59 42 p  m" src="https://user-images.githubusercontent.com/4392003/86988551-5b805100-c14d-11ea-9de3-072916211f24.png">

*New issue that is opened with the JIT label*
<img width="725" alt="Captura de Pantalla 2020-07-08 a la(s) 6 59 17 p  m" src="https://user-images.githubusercontent.com/4392003/86988560-60dd9b80-c14d-11ea-94f0-fac01a0d239b.png">

