### PR TITLE
Fix max_pool2d perf regression

### DIFF
--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -184,12 +184,10 @@ __global__ void max_pool_backward_nchw(const int nthreads, const scalar_t* top_d
       for (int c = blockIdx.z; c < channels; c+= gridDim.z) {
         accscalar_t gradient = accscalar_t(0);
         int offset = (n * channels + c) * pooled_height * pooled_width;
-        const scalar_t* ptr_top_diff = top_diff + offset;
-        const int64_t* ptr_top_mask = top_mask + offset;
         for (int ph = phstart; ph < phend; ++ph) {
           for (int pw = pwstart; pw < pwend; ++pw) {
-            if (ptr_top_mask[ph * pooled_width + pw] == h * width + w) {
-              gradient += ScalarConvert<scalar_t, accscalar_t>::to(ptr_top_diff[ph * pooled_width + pw]);
+            if (top_mask[ph * pooled_width + pw + offset] == h * width + w) {
+              gradient += ScalarConvert<scalar_t, accscalar_t>::to(top_diff[ph * pooled_width + pw + offset]);
             }
           }
         }


### PR DESCRIPTION
The two pointer variables `ptr_top_diff` and `ptr_top_mask` were introduced in #38953. Some end-to-end tests showed training performance regression due to this change. The performance is restored after removing the two pointer variables, and adding offset directly below in the indexing [ ] calculations. 

See PR change https://github.com/pytorch/pytorch/pull/38953/files#diff-8085d370f4e98295074a51b8a1f829e9R187-R188

https://github.com/pytorch/pytorch/blob/e4a3c584d51662d4c14060fc8517464fe3c12142/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu#L186-L195