### PR TITLE
Move TensorPipeAgent implementation to libtorch

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -288,6 +288,7 @@ libtorch_distributed_sources = [
     "torch/csrc/distributed/rpc/torchscript_functions.cpp",
     "torch/csrc/distributed/rpc/types.cpp",
     "torch/csrc/distributed/rpc/utils.cpp",
+    "torch/csrc/distributed/rpc/tensorpipe_agent.cpp",
     "torch/csrc/distributed/rpc/metrics/registry.cpp",
 ]
 
@@ -531,7 +532,6 @@ libtorch_python_distributed_sources = [
     "torch/csrc/distributed/rpc/python_functions.cpp",
     "torch/csrc/distributed/rpc/python_rpc_handler.cpp",
     "torch/csrc/distributed/rpc/request_callback_impl.cpp",
-    "torch/csrc/distributed/rpc/tensorpipe_agent.cpp",
     "torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp",
     "torch/csrc/distributed/rpc/testing/init.cpp",
     "torch/csrc/distributed/rpc/unpickled_python_call.cpp",

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_TENSORPIPE
 #include <torch/csrc/distributed/rpc/tensorpipe_agent.h>
 
 #include <limits>
@@ -1025,3 +1026,4 @@ void TensorPipeAgent::markFutureWithError(
 } // namespace rpc
 } // namespace distributed
 } // namespace torch
+#endif /* USE_TENSORPIPE*/

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -93,7 +93,7 @@ struct AggregatedNetworkData {
 // to transparently move tensors and payloads through the fastest available
 // transport or channel. It acts like a hybrid RPC transport, providing shared
 // memory (linux) and TCP (linux & mac) support. CUDA support is in progress.
-class TensorPipeAgent : public RpcAgent {
+class TORCH_API TensorPipeAgent : public RpcAgent {
  public:
   TensorPipeAgent(
       const std::shared_ptr<::c10d::Store>& store,


### PR DESCRIPTION
Similary to rpc_agent it should be part of libtorch rather than libtorch_python, so that:
 - C++ developers can use it
 - libtorch would be the only library that depends on libprotobuf
Add TORCH_API decorator to TensorPipeAgent
Guard all method implementation in tensorpipe_agent.cpp with `#ifdef USE_TENSORPIPE`

