### PR TITLE
[RPC docs] Remove mention of TensorPipe's SHM and CMA backends as they're not built

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -203,12 +203,8 @@ The TensorPipe backend has been introduced in PyTorch v1.6 and is being actively
 developed. At the moment, it only supports CPU tensors, with GPU support coming
 soon. It comes with a TCP-based transport, just like Gloo. It is also able to
 automatically chunk and multiplex large tensors over multiple sockets and
-threads in order to achieve very high bandwidths. In addition to that, it packs
-two Linux-specific transports for communication between processes on a same
-machine (one based on ringbuffers stored in shared memory, the other on the
-cross-memory attach syscalls) which can achieve lower latencies than TCP.
-The agent will be able to pick the best transport on its own, with no
-intervention required.
+threads in order to achieve very high bandwidths. The agent will be able to pick
+the best transport on its own, with no intervention required.
 
 Example::
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41200 [RPC docs] Remove mention of TensorPipe's SHM and CMA backends as they're not built**

In short, we messed up. The SHM and CMA backends of TensorPipe are Linux-specific and thus they are guarded by a #ifdef in the agent's code. Due to a mishap with CMake (due the fact that TensorPipe has two CMake files, one for PyTorch and a "standalone" one) we were not correctly propagating some flags and these #ifdefs were always false. This means that these two backends have always been disabled and have thus never been covered by our OSS CI. It would be irresponsible to enable them now in v1.6, so instead we remove any mention of them from the docs.

Note that this is perhaps not as bad as it sounds. These two backends were providing higher performance (latency) when the two endpoints were on the same machine. However, I suspect that most RPC users will only do transfers across machines, for which SHM and CMA wouldn't have played any role.

Differential Revision: [D22462158](https://our.internmc.facebook.com/intern/diff/D22462158/)