### PR TITLE
Small clarification of torch.cuda.amp multi-model example

### DIFF
--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -254,6 +254,8 @@ after all optimizers used this iteration have been stepped::
                 loss0 = loss_fn(2 * output0 + 3 * output1, target)
                 loss1 = loss_fn(3 * output0 - 5 * output1, target)
 
+            # (retain_graph here is unrelated to amp, it's present because in this
+            # example, both backward() calls share some sections of forward graph.)
             scaler.scale(loss0).backward(retain_graph=True)
             scaler.scale(loss1).backward()
 

--- a/docs/source/notes/amp_examples.rst
+++ b/docs/source/notes/amp_examples.rst
@@ -255,7 +255,7 @@ after all optimizers used this iteration have been stepped::
                 loss1 = loss_fn(3 * output0 - 5 * output1, target)
 
             # (retain_graph here is unrelated to amp, it's present because in this
-            # example, both backward() calls share some sections of forward graph.)
+            # example, both backward() calls share some sections of graph.)
             scaler.scale(loss0).backward(retain_graph=True)
             scaler.scale(loss1).backward()
 


### PR DESCRIPTION
cherry pick of https://github.com/pytorch/pytorch/pull/41203.

some people have been confused by `retain_graph` in the snippet, they thought it was an additional requirement imposed by amp.