### PR TITLE
Add 3D attention mask documentation to Transformer

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -891,13 +891,12 @@ class MultiheadAttention(Module):
           If a ByteTensor is provided, the non-zero positions will be ignored while the position
           with the zero positions will be unchanged. If a BoolTensor is provided, the positions with the
           value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
-        - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
-          3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
-          S is the source sequence length. attn_mask ensure that position i is allowed to attend the unmasked
-          positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
-          while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
-          is not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
-          is provided, it will be added to the attention weight.
+        - attn_mask: Either a 2D mask :math:`(L, S)` or a 3D mask :math:`(N*num\_heads, L, S)` where N is the
+          batch size, L is the target sequence length, S is the source sequence length. The attn_mask ensures
+          that position i is only allowed to attend to the unmasked positions. If a ByteTensor is provided, the
+          non-zero positions are not allowed to attend while the zero positions will be unchanged. If a
+          BoolTensor is provided, positions with ``True`` are not allowed to attend while ``False`` values
+          will be unchanged. If a FloatTensor is provided, it will be added to the attention weight.
 
         - Outputs:
         - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -84,9 +84,9 @@ class Transformer(Module):
         Shape:
             - src: :math:`(S, N, E)`.
             - tgt: :math:`(T, N, E)`.
-            - src_mask: :math:`(S, S)`.
-            - tgt_mask: :math:`(T, T)`.
-            - memory_mask: :math:`(T, S)`.
+            - src_mask: :math:`(S, S)` or :math:`(N*nhead, S, S)`.
+            - tgt_mask: :math:`(T, T)` or :math:`(N*nhead, T, T)`.
+            - memory_mask: :math:`(T, S)` or :math:`(N*nhead, T, S)`.
             - src_key_padding_mask: :math:`(N, S)`.
             - tgt_key_padding_mask: :math:`(N, T)`.
             - memory_key_padding_mask: :math:`(N, S)`.


### PR DESCRIPTION
In #31996 (committed in db02a4e4ceced885508991441ea68896d48fc369) we added support for 3-dimensional attention masks to the MultiheadAttention layer. This PR updates the Transformer documentation to reflect this. The Transformer{Encoder,Decoder,EncoderLayer,DecoderLayer} class documentation does not need any changes as they never referenced the shapes to begin with. I also fixed some wording and a LaTeX typo in the MultiheadAttention docs.

Here is some sample code demonstrating the newly documented functionality:

```
import torch
N = 3
S = 20
T = 1
E = 4
nhead = 2
transformer = torch.nn.Transformer(d_model=E, nhead=nhead)

src = torch.randn(S, N, E)
tgt = torch.randn(T, N, E)
src_mask = torch.randn(N*nhead, S, S)
tgt_mask = torch.randn(N*nhead, T, T)
memory_mask = torch.randn(N*nhead, T, S)

print(transformer(src, tgt, src_mask=src_mask, tgt_mask=tgt_mask, memory_mask=memory_mask))
```
```
tensor([[[ 1.2656,  0.0161,  0.2470, -1.5287],
         [-1.6573,  0.9786,  0.5202,  0.1585],
         [-0.8682,  1.5458,  0.2211, -0.8987]]],
       grad_fn=<NativeLayerNormBackward>)
```