### PR TITLE
Reducing size of docker Linux image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ jobs:
           fi
           echo "Parallel backend flags: "${PARALLEL_FLAGS}
 
-          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find /var/lib/jenkins/workspace -type f -name "*.a" -exec rm {} \; && find /var/lib/jenkins/workspace -type f -name "*.o" -exec rm {} \;") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -525,6 +525,7 @@ jobs:
             else
               export COMMIT_DOCKER_IMAGE=$output_image
             fi
+            echo "COMMIT_DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
             docker commit "$id" ${COMMIT_DOCKER_IMAGE}
             time docker push ${COMMIT_DOCKER_IMAGE}
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,7 +525,6 @@ jobs:
             else
               export COMMIT_DOCKER_IMAGE=$output_image
             fi
-            echo "COMMIT_DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
             docker commit "$id" ${COMMIT_DOCKER_IMAGE}
             time docker push ${COMMIT_DOCKER_IMAGE}
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ jobs:
           fi
           echo "Parallel backend flags: "${PARALLEL_FLAGS}
 
-          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find /var/lib/jenkins/workspace -type f -name "*.a" -exec rm {} \; && find /var/lib/jenkins/workspace -type f -name "*.o" -exec rm {} \;") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find /var/lib/jenkins/workspace/build -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -31,7 +31,7 @@ jobs:
           fi
           echo "Parallel backend flags: "${PARALLEL_FLAGS}
 
-          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find /var/lib/jenkins/workspace -type f -name "*.a" -exec rm {} \; && find /var/lib/jenkins/workspace -type f -name "*.o" -exec rm {} \;") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find /var/lib/jenkins/workspace/build -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -63,7 +63,6 @@ jobs:
             else
               export COMMIT_DOCKER_IMAGE=$output_image
             fi
-            echo "COMMIT_DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
             docker commit "$id" ${COMMIT_DOCKER_IMAGE}
             time docker push ${COMMIT_DOCKER_IMAGE}
           fi

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -31,7 +31,7 @@ jobs:
           fi
           echo "Parallel backend flags: "${PARALLEL_FLAGS}
 
-          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$PARALLEL_FLAGS"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find /var/lib/jenkins/workspace -type f -name "*.a" -exec rm {} \; && find /var/lib/jenkins/workspace -type f -name "*.o" -exec rm {} \;") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -63,6 +63,7 @@ jobs:
             else
               export COMMIT_DOCKER_IMAGE=$output_image
             fi
+            echo "COMMIT_DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
             docker commit "$id" ${COMMIT_DOCKER_IMAGE}
             time docker push ${COMMIT_DOCKER_IMAGE}
           fi


### PR DESCRIPTION
# Description
The goal is to reduce the size of the docker image. I checked a few things:
* Docker layer overlaps 
* Removing .git folder
* Removing intermediate build artifacts (*.o and *.a)

The only one that gave satisfying result was the 3rd approach, removing *.o and *.a. The final image went from 10 GB to 9.7 GB.

I used Dive (https://github.com/wagoodman/dive) to inspect the Docker image manually.

# Test:
* Check the image size was reduced
* No test failures in CI