### PR TITLE
Fix misc docs typos and formatting

### DIFF
--- a/docs/source/jit_language_reference.rst
+++ b/docs/source/jit_language_reference.rst
@@ -119,7 +119,7 @@ TorchScript does not support all features and types of the :mod:`typing` module.
 are more fundamental things that are unlikely to be added in the future while others
 may be added if there is enough user demand to make it a priority.
 
-These types and features from the :mod:`typing` module are unavailble in TorchScript.
+These types and features from the :mod:`typing` module are unavailable in TorchScript.
 
 .. csv-table::
    :header: "Item", "Description"
@@ -138,7 +138,7 @@ These types and features from the :mod:`typing` module are unavailble in TorchSc
    "NewType", "Unlikely to be implemented"
    "Generics", "Unlikely to be implemented"
 
-Any other functionality from the :any:`typing` module not explitily listed in this documentation is unsupported.
+Any other functionality from the :any:`typing` module not explicitly listed in this documentation is unsupported.
 
 Default Types
 ^^^^^^^^^^^^^
@@ -843,7 +843,7 @@ available in TorchScript can be used as module attributes. Tensor attributes are
 semantically the same as buffers. The type of empty lists and dictionaries and ``None``
 values cannot be inferred and must be specified via
 `PEP 526-style <https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations>`_ class annotations.
-If a type cannot be inferred and is not explicilty annotated, it will not be added as an attribute
+If a type cannot be inferred and is not explicitly annotated, it will not be added as an attribute
 to the resulting :class:`ScriptModule`.
 
 Example:

--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -25,7 +25,7 @@ CPU and CUDA)::
 There are some PyTorch functions that use CUDA functions that can be a source
 of nondeterminism. One class of such CUDA functions are atomic operations,
 in particular :attr:`atomicAdd`, which can lead to the order of additions being
-nondetermnistic. Because floating-point addition is not perfectly associative
+nondeterministic. Because floating-point addition is not perfectly associative
 for floating-point operands, :attr:`atomicAdd` with floating-point operands can
 introduce different floating-point rounding errors on each evaluation, which
 introduces a source of nondeterministic variance (aka noise) in the result.

--- a/docs/source/notes/windows.rst
+++ b/docs/source/notes/windows.rst
@@ -82,7 +82,7 @@ object to make it build on Windows.
        libraries=['ATen', '_C'] # Append cuda libraries when necessary, like cudart
    )
 
-Second, here is a workground for "unresolved external symbol 
+Second, here is a workaround for "unresolved external symbol 
 state caused by ``extern THCState *state;``"
 
 Change the source code from C to C++. An example is listed below.

--- a/docs/source/tensor_view.rst
+++ b/docs/source/tensor_view.rst
@@ -26,7 +26,7 @@ Since views share underlying data with its base tensor, if you edit the data
 in the view, it will be reflected in the base tensor as well.
 
 Typically a PyTorch op returns a new tensor as output, e.g. :meth:`~torch.Tensor.add`.
-But in case of view ops, outputs are views of input tensors to avoid unncessary data copy.
+But in case of view ops, outputs are views of input tensors to avoid unnecessary data copy.
 No data movement occurs when creating a view, view tensor just changes the way
 it interprets the same data. Taking a view of contiguous tensor could potentially produce a non-contiguous tensor.
 Users should be pay additional attention as contiguity might have implicit performance impact.

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -58,7 +58,7 @@ def lobpcg(A,                   # type: Tensor
       A (Tensor): the input tensor of size :math:`(*, m, m)`
 
       B (Tensor, optional): the input tensor of size :math:`(*, m,
-                  m)`. When not specified, `B` is interpereted as
+                  m)`. When not specified, `B` is interpreted as
                   identity matrix.
 
       X (tensor, optional): the input tensor of size :math:`(*, m, n)`
@@ -76,7 +76,7 @@ def lobpcg(A,                   # type: Tensor
       n (integer, optional): if :math:`X` is not specified then `n`
                   specifies the size of the generated random
                   approximation of eigenvectors. Default value for `n`
-                  is `k`. If :math:`X` is specifed, the value of `n`
+                  is `k`. If :math:`X` is specified, the value of `n`
                   (when specified) must be the number of :math:`X`
                   columns.
 

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -30,7 +30,7 @@ __all__ = [
 
 class Transform(object):
     """
-    Abstract class for invertable transformations with computable log
+    Abstract class for invertible transformations with computable log
     det jacobians. They are primarily used in
     :class:`torch.distributions.TransformedDistribution`.
 

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -230,7 +230,7 @@ def get_dir():
     If :func:`~torch.hub.set_dir` is not called, default path is ``$TORCH_HOME/hub`` where
     environment variable ``$TORCH_HOME`` defaults to ``$XDG_CACHE_HOME/torch``.
     ``$XDG_CACHE_HOME`` follows the X Design Group specification of the Linux
-    filesytem layout, with a default value ``~/.cache`` if the environment
+    filesystem layout, with a default value ``~/.cache`` if the environment
     variable is not set.
     """
     # Issue warning to move data if old env is set

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -658,7 +658,7 @@ def trace(
         strict (``bool``, optional): run the tracer in a strict mode or not
             (default: ``True``). Only turn this off when you want the tracer to
             record your mutable container types (currently ``list``/``dict``)
-            and you are sure that the containuer you are using in your
+            and you are sure that the container you are using in your
             problem is a ``constant`` structure and does not get used as
             control flow (if, for) conditions.
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2270,7 +2270,7 @@ def poisson_nll_loss(input, target, log_input=True, full=False, size_average=Non
             is set to ``False``, the losses are instead summed for each minibatch. Ignored
             when reduce is ``False``. Default: ``True``
         eps (float, optional): Small value to avoid evaluation of :math:`\log(0)` when
-            :attr:`log_input`=``False``. Default: 1e-8
+            :attr:`log_input` is ``False``. Default: 1e-8
         reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
             losses are averaged or summed over observations for each minibatch depending
             on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
@@ -3412,7 +3412,7 @@ def affine_grid(theta, size, align_corners=None):
         Up to version 1.2.0, all grid points along a unit dimension were
         considered arbitrarily to be at ``-1``.
         From version 1.3.0, under ``align_corners = True`` all grid points
-        along a unit dimension are condsidered to be at ```0``
+        along a unit dimension are considered to be at ``0``
         (the center of the input image).
     """
     if not torch.jit.is_scripting():

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1096,7 +1096,7 @@ class Softmax(Module):
     .. math::
         \text{Softmax}(x_{i}) = \frac{\exp(x_i)}{\sum_j \exp(x_j)}
 
-    When the input Tensor is a sparse tensor then the unspecifed
+    When the input Tensor is a sparse tensor then the unspecified
     values are treated as ``-inf``.
 
     Shape:

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -194,23 +194,23 @@ class DistributedDataParallel(Module):
         >>>     dist_optim.step()
 
     .. warning::
-        Using DistributedDataParallel in conjuction with the
+        Using DistributedDataParallel in conjunction with the
         :ref:`distributed-rpc-framework` is experimental and subject to change.
 
     Args:
         module (Module): module to be parallelized
         device_ids (list of int or torch.device): CUDA devices. This should
                    only be provided when the input module resides on a single
-                   CUDA device. For single-device modules, the ``i``th
+                   CUDA device. For single-device modules, the ``i``\ th 
                    :attr:`module` replica is placed on ``device_ids[i]``. For
-                   multi-device modules and CPU modules, device_ids must be None
+                   multi-device modules and CPU modules, :attr:`device_ids` must be ``None``
                    or an empty list, and input data for the forward pass must be
                    placed on the correct device. (default: all devices for
                    single-device modules)
         output_device (int or torch.device): device location of output for
                       single-device CUDA modules. For multi-device modules and
-                      CPU modules, it must be None, and the module itself
-                      dictates the output location. (default: device_ids[0] for
+                      CPU modules, it must be ``None``, and the module itself
+                      dictates the output location. (default: ``device_ids[0]`` for
                       single-device modules)
         broadcast_buffers (bool): flag that enables syncing (broadcasting) buffers of
                           the module at beginning of the forward function.


### PR DESCRIPTION
Some small typo fixes and formatting in various rst files and py docstrings