### PR TITLE
add check for duplicated op registration in JIT

### DIFF
--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -34,6 +34,12 @@ struct OperatorRegistry {
   std::unordered_map<const char*, std::shared_ptr<Operator>>
       operators_by_sig_literal;
 
+  // Remember all registered operator names to check that they aren't
+  // registered a second time. Registering an op multiple times is
+  // fragile because it might depend on static initialization order
+  // which one is picked at runtime.
+  std::unordered_set<c10::OperatorName> registered_operator_names;
+
   // XXX - caller must be holding lock
   void registerPendingOperators() {
     for (const auto& op : to_register) {
@@ -47,6 +53,14 @@ struct OperatorRegistry {
  public:
   void registerOperator(Operator&& op) {
     std::lock_guard<std::mutex> guard(lock);
+
+    TORCH_INTERNAL_ASSERT(
+        0 == registered_operator_names.count(op.schema().operator_name()),
+        "Tried to register operator \"",
+        op.schema(),
+        "\" to JIT but the operator name was already registered before. Please add or change the overload name.");
+    registered_operator_names.insert(op.schema().operator_name());
+
     to_register.push_back(std::make_shared<Operator>(std::move(op)));
   }
 
@@ -55,6 +69,14 @@ struct OperatorRegistry {
     auto sig = canonicalSchemaString(schema);
 
     std::lock_guard<std::mutex> guard(lock);
+
+    TORCH_INTERNAL_ASSERT(
+        1 == registered_operator_names.count(schema.operator_name()),
+        "Tried to remove operator ",
+        schema,
+        " from JIT but it wasn't found.");
+    registered_operator_names.erase(schema.operator_name());
+
     // Try removing from pending operators list first
     auto pending_it = to_register.begin();
     while (pending_it != to_register.end() && (*pending_it)->schema() != schema)


### PR DESCRIPTION
Summary: Same as D21032976, add check for duplicated op name in JIT

Test Plan:
run full JIT predictor
also
buck test pytorch-playground

Differential Revision: D22467871

