### PR TITLE
Add shape inference functions for int8 quantization related ops

### DIFF
--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -860,6 +860,14 @@ REGISTER_CPU_OPERATOR_WITH_ENGINE(
 OPERATOR_SCHEMA(Int8FCPackWeight)
     .NumInputs(1, 2)
     .NumOutputs(1, 2)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape W = in[0];
+      out.emplace_back(std::move(W));
+      out[0].set_data_type(TensorProto_DataType_INT8);
+      return out;
+    })
     .SetDoc(R"DOC(Prepack weight for Int8FC)DOC")
     .Input(0, "W", "Weight tensor in KRSC layout")
     .Input(1, "b", "Bias tensor")
@@ -896,6 +904,14 @@ REGISTER_CPU_OPERATOR_WITH_ENGINE(
 OPERATOR_SCHEMA(Int8ConvPackWeight)
     .NumInputs(1, 2)
     .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape W = in[0];
+      out.emplace_back(std::move(W));
+      out[0].set_data_type(TensorProto_DataType_INT8);
+      return out;
+    })
     .SetDoc(R"DOC(Prepack weight for Int8Conv)DOC")
     .Input(0, "W", "Weight tensor in KRSC layout")
     .Input(1, "b", "Bias tensor")

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
@@ -257,4 +257,24 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                     )
                 np.testing.assert_equal(bias_int32[0].dtype, np.int32)
 
+            shapes, types = workspace.InferShapesAndTypes(
+                [init_net, net],
+                blob_dimensions={
+                    "X": [batch_size, input_channels],
+                    "W": [output_channels, input_channels],
+                    "b": [output_channels],
+                    "quant_param": [1],
+                },
+                blob_types={
+                    "X": core.DataType.FLOAT,
+                    "W": core.DataType.FLOAT,
+                    "b": core.DataType.FLOAT,
+                    "quant_param": core.DataType.FLOAT,
+                },
+            )
+            assert (
+                "Y" in shapes and "Y" in types
+            ), "Failed to infer the shape or type of Y"
+            self.assertEqual(shapes["Y"], [batch_size, output_channels])
+            self.assertEqual(types["Y"], core.DataType.FLOAT)
         check_quantized_results_close(outputs, symmetric=preserve_activation_sparsity)

--- a/caffe2/quantization/server/int8_gen_quant_params.cc
+++ b/caffe2/quantization/server/int8_gen_quant_params.cc
@@ -15,6 +15,16 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(Int8GenQuantParams)
     .NumInputs(2)
     .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.clear_dims();
+      X.add_dims(1);
+      out.emplace_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_FLOAT);
+      return out;
+    })
     .Input(
         0,
         "X",

--- a/caffe2/quantization/server/int8_gen_quant_params_test.py
+++ b/caffe2/quantization/server/int8_gen_quant_params_test.py
@@ -78,6 +78,13 @@ class TestInt8GenQuantParamsOperator(hu.HypothesisTestCase):
             gen_quant_params_net
         ), "Failed to run the gen_quant_params net"
         scale, zero_point = dnnlowp_pybind11.ObserveInt8QuantParamsBlob("quant_param")
+        shapes, types = workspace.InferShapesAndTypes(
+            [gen_quant_params_net],
+            blob_dimensions={"X": [n, m, k], "quant_scheme": [1]},
+            blob_types={"X": core.DataType.FLOAT, "quant_scheme": core.DataType.STRING}
+        )
+        self.assertEqual(shapes["quant_param"], [1])
+        self.assertEqual(types["quant_param"], core.DataType.FLOAT)
 
         np.testing.assert_equal(scale, X_qparam.scale)
         np.testing.assert_equal(zero_point, X_qparam.zero_point)


### PR DESCRIPTION
Summary: To unblock int8 model productization on accelerators, we need the shape and type info for all the blobs after int8 quantization. This diff added shape inference functions for int8 quantization related ops.

Test Plan:
```
buck test caffe2/caffe2/quantization/server:int8_gen_quant_params_test
buck test caffe2/caffe2/quantization/server:fully_connected_dnnlowp_op_test
```

Differential Revision: D22467487

