### PR TITLE
Cuda Support for Learnable Fake Quantize Per Channel (GPU)

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -69,8 +69,60 @@ void fake_quantize_grad_tensor_kernel_cuda(
     });
 }
 
+void _fake_quantize_grad_learnable_scale_tensor_kernel_cuda(
+    Tensor& input_grad,
+    const Tensor& input,
+    const Tensor& output_grad,
+    float scale,
+    int64_t zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  // scalar type of this function is guaranteed to be float
+  float inv_scale = 1.0f / scale;
+  float grad_small = quant_min - zero_point;
+  float grad_big = quant_max - zero_point;
+
+  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
+  gpu_kernel(iter,
+    [=] GPU_LAMBDA (float x, float dx) -> float {
+      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
+      xq = std::max(std::min(xq, quant_max), quant_min);
+      if (xq == quant_min) {
+        return dx * grad_small;
+      } else if (xq == quant_max) {
+        return dx * grad_big;
+      }
+      float x_fq = static_cast<float>((xq - zero_point) * scale);
+      return dx * (x_fq - x) * inv_scale;
+    });
+}
+
+void _fake_quantize_grad_learnable_zero_point_tensor_kernel_cuda(
+    Tensor& input_grad,
+    const Tensor& input,
+    const Tensor& output_grad,
+    float scale,
+    int64_t zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  // scalar type of this function is guaranteed to be float
+  float inv_scale = 1.0f / scale;
+  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
+  gpu_kernel(iter,
+    [=] GPU_LAMBDA (float x, float dx) -> float {
+      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
+      xq = std::max(std::min(xq, quant_max), quant_min);
+      if (xq == quant_min || xq == quant_max) {
+        return dx * (-1) * scale;
+      }
+      return 0;
+    });
+}
+
 REGISTER_DISPATCH(fake_quant_tensor_stub, &fake_quantize_tensor_kernel_cuda);
 REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_learnable_scale_tensor_stub, &_fake_quantize_grad_learnable_scale_tensor_kernel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_learnable_zero_point_tensor_stub, &_fake_quantize_grad_learnable_zero_point_tensor_kernel_cuda);
 
 // Fake quantize per channel
 

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -150,8 +150,60 @@ void fake_quant_grad_per_channel_cuda(TensorIterator &iter, int64_t quant_min, i
     });
 }
 
+void _fake_quantize_grad_learnable_scale_channel_kernel_cuda(
+    Tensor& input_grad,
+    const Tensor& input,
+    const Tensor& output_grad,
+    float scale,
+    int64_t zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  // scalar type of this function is guaranteed to be float
+  float inv_scale = 1.0f / scale;
+  float grad_small = quant_min - zero_point;
+  float grad_big = quant_max - zero_point;
+
+  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
+  gpu_kernel(iter,
+    [=] GPU_LAMBDA (float x, float dx) -> float {
+      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
+      xq = std::max(std::min(xq, quant_max), quant_min);
+      float x_fq = static_cast<float>((xq - zero_point) * scale);
+      if (xq == quant_min) {
+        return dx * grad_small;
+      } else if (xq == quant_max) {
+        return dx * grad_big;
+      }
+      return dx * (x_fq - x) * inv_scale;
+    });
+}
+
+void _fake_quantize_grad_learnable_zero_point_channel_kernel_cuda(
+    Tensor& input_grad,
+    const Tensor& input,
+    const Tensor& output_grad,
+    float scale,
+    int64_t zero_point,
+    int64_t quant_min,
+    int64_t quant_max) {
+  // scalar type of this function is guaranteed to be float
+  float inv_scale = 1.0f / scale;
+  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
+  gpu_kernel(iter,
+    [=] GPU_LAMBDA (float x, float dx) -> float {
+      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
+      xq = std::max(std::min(xq, quant_max), quant_min);
+      if (xq == quant_min || xq == quant_max) {
+        return dx * (-1) * scale;
+      }
+      return 0;
+    });
+}
+
 REGISTER_DISPATCH(fake_quant_per_channel_stub, &fake_quant_per_channel_cuda);
 REGISTER_DISPATCH(fake_quant_grad_per_channel_stub, &fake_quant_grad_per_channel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_learnable_scale_channel_stub, &_fake_quantize_grad_learnable_scale_channel_kernel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_learnable_zero_point_channel_stub, &_fake_quantize_grad_learnable_zero_point_channel_kernel_cuda);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -176,8 +176,8 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_tensor_affine_ba
     zero_point.device().type(), dZeroPoint_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
 
   // The total sums over the scale and zero point gradient vectors are what will be returned in the end.
-  auto dScale = dScale_vec.sum().unsqueeze(0);
-  auto dZeroPoint = dZeroPoint_vec.sum().unsqueeze(0);
+  auto dScale = dScale_vec.sum().unsqueeze(0).to(scale.device());
+  auto dZeroPoint = dZeroPoint_vec.sum().unsqueeze(0).to(zero_point.device());
 
   return std::make_tuple(dX, dScale, dZeroPoint);
 }


### PR DESCRIPTION
Summary: In this diff, implementation is provided to support the GPU kernel running the learnable fake quantize per tensor kernels.

Test Plan: On a devvm, run `buck test //caffe2/test:quantization -- learnable` to test both the forward and backward for the learnable per tensor fake quantize kernels. The test will test the `cuda` version if a gpu is available.

Differential Revision: D22478832

