### PR TITLE
.cirlceci: Setup nvidia runtime for cu as well

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -2,7 +2,7 @@
 set -ex -o pipefail
 
 # Set up NVIDIA docker repo
-if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]] || [[ "${BUILD_ENVIRONMENT}" == *cu* ]]; then
   curl -s -L --retry 3 https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
   echo "deb https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
   echo "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
@@ -42,7 +42,7 @@ sudo apt-get -y remove linux-image-generic linux-headers-generic linux-generic d
 # Using 'retry' here as belt-and-suspenders even though we are
 # presumably retrying at the single-package level via the
 # apt.conf.d/80-retries technique.
-if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]] || [[ "${BUILD_ENVIRONMENT}" == *cu* ]]; then
   retry sudo apt-get -y install \
     linux-headers-$(uname -r) \
     linux-image-generic \

--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -2,7 +2,7 @@
 set -ex -o pipefail
 
 # Set up NVIDIA docker repo
-if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]] || [[ "${BUILD_ENVIRONMENT}" == *cu* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *cu* ]]; then
   curl -s -L --retry 3 https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
   echo "deb https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
   echo "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
@@ -42,7 +42,7 @@ sudo apt-get -y remove linux-image-generic linux-headers-generic linux-generic d
 # Using 'retry' here as belt-and-suspenders even though we are
 # presumably retrying at the single-package level via the
 # apt.conf.d/80-retries technique.
-if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]] || [[ "${BUILD_ENVIRONMENT}" == *cu* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *cu* ]]; then
   retry sudo apt-get -y install \
     linux-headers-$(uname -r) \
     linux-image-generic \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41268 .cirlceci: Setup nvidia runtime for cu as well**

We also want nvidia runtime packages to get installed when the
BUILD_ENVIRONMENT also includes "*cu*"

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D22505885](https://our.internmc.facebook.com/intern/diff/D22505885)