### PR TITLE
Add operators for LiteLMLSTM to Lite Interpreter

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -672,18 +672,6 @@ void hashValue(Stack* stack) {
 }
 
 RegisterOperators reg2({
-
-    Operator(
-        "aten::__getitem__.str(str s, int index) -> str",
-        [](Stack* stack) {
-          auto index = pop(stack).toInt();
-          auto string = pop(stack).toStringRef();
-          auto norm_index = normalizeIndex(index, string.size());
-          char c = string.at(norm_index);
-          push(stack, std::string(&c, 1));
-        },
-        aliasAnalysisFromSchema()),
-
     // registered as Any[] so that heterogenous tuples can be called with len()
     Operator(
         "aten::len.any(Any[] a) -> int",
@@ -728,10 +716,6 @@ RegisterOperators reg2({
     Operator(
         "aten::__contains__.float_list(float[] l, float item) -> bool",
         listContains<double>,
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::__contains__.str_list(str[] l, str item) -> bool",
-        listContains<std::string>,
         aliasAnalysisFromSchema()),
     Operator(
         "aten::sort.int(int[](a!) self, bool reverse=False) -> ()",
@@ -839,18 +823,6 @@ RegisterOperators reg2({
         },
         aliasAnalysisFromSchema()),
     Operator(
-        "aten::ord(str string) -> int",
-        [](Stack* stack) {
-          auto string = pop(stack).toStringRef();
-          TORCH_CHECK(
-              string.size() == 1,
-              "String for ord() must be 1 character, found ",
-              string.size());
-          uint8_t ord = string.at(0);
-          push(stack, int64_t(ord));
-        },
-        aliasAnalysisFromSchema()),
-    Operator(
         "aten::chr(int i) -> str",
         [](Stack* stack) {
           auto i = pop(stack).toInt();
@@ -934,7 +906,6 @@ RegisterOperators reg2({
         float),
     DEFINE_UNARY_OP(aten::log1p, std::log1p(a), float, float),
     DEFINE_UNARY_OP(aten::log10, std::log10(a), float, float),
-    DEFINE_UNARY_OP(aten::exp, std::exp(a), float, float),
     DEFINE_UNARY_OP(aten::sqrt, std::sqrt(a), float, float),
     DEFINE_UNARY_OP(aten::acos, std::acos(a), float, float),
     DEFINE_UNARY_OP(aten::asin, std::asin(a), float, float),


### PR DESCRIPTION
Summary: The Smart Keyboard model for Oculus requires operators previously not in the lite interpreter: aten::exp (for floats), aten::ord, aten::lower, aten::__contains__.str_list, aten::slice.str, aten::strip, aten::split.str, and aten::__getitem__.str.

Test Plan:
Verify smart keyboard model can be used:
Check out next diff in stack and follow test instructions there

Differential Revision: D22289812

