### PR TITLE
Better THGeneric.h generation rules in bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -566,7 +566,10 @@ template_rule(
     src = "aten/src/TH/THGeneral.h.in",
     out = "aten/src/TH/THGeneral.h",
     substitutions = {
-        "cmakedefine": "define",
+        "#cmakedefine USE_BLAS": "#define USE_BLAS",
+        "#cmakedefine USE_LAPACK": "#define USE_LAPACK",
+        "#cmakedefine BLAS_F2C": "/* #undef BLAS_F2C */",
+        "#cmakedefine BLAS_USE_CBLAS_DOT": "#define BLAS_USE_CBLAS_DOT",
     },
 )
 


### PR DESCRIPTION
It  doesn't do a good job of checking BLAS library capabilities, so hardcode the undef of BLAS_F2C

