### PR TITLE
Restore the contiguity preprocessing of linspace

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -23,8 +23,12 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
   } else if (steps == 1) {
     result.fill_(start);
   } else {
-    auto iter = TensorIterator::nullary_op(result);
+    Tensor r = result.is_contiguous() ? result : result.contiguous();
+    auto iter = TensorIterator::nullary_op(r);
     linspace_stub(iter.device_type(), iter, start, end, steps);
+    if (!result.is_contiguous()) {
+      result.copy_(r);
+    }
   }
 
   return result;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12475,6 +12475,13 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(torch.linspace(10, 2000, 1991, device=device, dtype=dtype),
                              torch.tensor(list(range(10, 2001)), device=device, dtype=dtype))
 
+        # Vectorization on non-contiguous tensors
+        if dtype != torch.int8:  # int8 is too small for this test
+            res = torch.rand(3, 3, 1000, device=device).to(dtype)
+            res = res.permute(2, 0, 1)
+            torch.linspace(0, 1000 * 3 * 3, 1000 * 3 * 3, out=res)
+            self.assertEqual(res.flatten(), torch.linspace(0, 1000 * 3 * 3, 1000 * 3 * 3, device=device, dtype=dtype))
+
         self.assertRaises(RuntimeError, lambda: torch.linspace(0, 1, -1, device=device, dtype=dtype))
         # steps = 1
         self.assertEqual(torch.linspace(0, 1, 1, device=device, dtype=dtype),


### PR DESCRIPTION
The contiguity preprocessing was mistakenly removed in
cd48fb503088af2c00884f1619db571fffbcdafa . It causes erroneous output
when the output tensor is not contiguous. Here we restore this
preprocessing.

