### PR TITLE
[caffe2] Fix the issues when using CUB RadixSort

### DIFF
--- a/caffe2/sgd/adagrad_fused_op_gpu.cu
+++ b/caffe2/sgd/adagrad_fused_op_gpu.cu
@@ -60,7 +60,7 @@ void sort_pairs_wrapper(
       sorted_seg_id_buffer_->template mutable_data<int>(),
       num_indices,
       0,
-      int(log2(num_indices) + 1),
+      int(log2(float(num_indices)) + 1),
       context_->cuda_stream(),
       false);
 
@@ -79,7 +79,7 @@ void sort_pairs_wrapper(
       sorted_seg_id_buffer_->template mutable_data<int>(),
       num_indices,
       0,
-      int(log2(num_indices) + 1),
+      int(log2(float(num_indices)) + 1),
       context_->cuda_stream(),
       false);
 }


### PR DESCRIPTION
Summary:
When using `cub::DeviceRadixSort::SortPairs` (https://nvlabs.github.io/cub/structcub_1_1_device_radix_sort.html), the `end_bit` argument, or the most-significant bit index (exclusive) needed for key comparison, should be passed with  `int(log2(float(num_rows)) + 1)` instead of `int(log2(float(num_indice)) + 1)`. This is because all the values in indices array are guaranteed to be less than num_rows (hash_size), not num_indices. Thanks @ngimel  for pointing this point and thanks @malfet  for quickly fixing the log2() compilation issues.

Note:
An optional bit subrange [begin_bit, end_bit) of differentiating key bits can be specified. This can reduce overall sorting overhead and yield a corresponding performance improvement.

Test Plan:
```
buck test mode/dev-nosan //caffe2/caffe2/fb/net_transforms/tests:fuse_sparse_ops_test -- 'test_fuse_sparse_adagrad_with_sparse_lengths_sum_gradient \(caffe2\.caffe2\.fb\.net_transforms\.tests\.fuse_sparse_ops_test\.TestFuseSparseOps\)' --print-passing-details
```

Differential Revision: D22491662

