### PR TITLE
Back out "Revert D22329069: Self binning histogram"

### DIFF
--- a/caffe2/operators/self_binning_histogram_op.cc
+++ b/caffe2/operators/self_binning_histogram_op.cc
@@ -1,0 +1,41 @@
+#include "caffe2/operators/self_binning_histogram_op.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(SelfBinningHistogram, SelfBinningHistogramOp<CPUContext>);
+OPERATOR_SCHEMA(SelfBinningHistogram)
+    .NumInputs(1, INT_MAX)
+    .NumOutputs(2)
+    .SetDoc(
+        R"DOC(
+            Computes a histogram for values in the given list of tensors.
+            For logging activation histograms for post-hoc analyses, consider using the
+            HistogramObserver observer.
+            For iteratively computing a histogram for all input tensors encountered through
+            history, consider using the AccumulateHistogram operator.
+            )DOC")
+    .Input(0, "X1, X2, ...", "*(type: Tensor`<float>`)* List of input tensors.")
+    .Output(
+        0,
+        "histogram_values",
+        "1D tensor of edges of the bins, of dimension [num_bins+1]."
+        " The range appears as: [first, ..., last), wherein the i-th element"
+        " expresses the start of a bin and i+1-th value represents the exclusive"
+        " end of that bin.")
+    .Output(
+        1,
+        "histogram_counts",
+        "1D tensor of counts of each bin, of dimension [num_bins+1]."
+        " It is guaranteed to end with a 0 since the last edge is exclusive.")
+    .Arg("num_bins", "Number of bins to use for the histogram. Must be >= 1.")
+    .Arg(
+        "bin_spacing",
+        "A string indicating 'linear' or 'logarithmic' spacing for the bins.")
+    .Arg(
+        "logspace_start",
+        "A float that's used as the starting point for logarithmic spacing. "
+        "Since logarithmic spacing cannot contain <=0 values this value will "
+        "be used to represent all such values.");
+
+SHOULD_NOT_DO_GRADIENT(SelfBinningHistogram);
+} // namespace caffe2

--- a/caffe2/operators/self_binning_histogram_op.h
+++ b/caffe2/operators/self_binning_histogram_op.h
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+template <class Context>
+class SelfBinningHistogramOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  template <class... Args>
+  explicit SelfBinningHistogramOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        num_bins_(this->template GetSingleArgument<int>("num_bins", 0)),
+        num_edges_(num_bins_ + 1),
+        bin_spacing_(this->template GetSingleArgument<std::string>(
+            "bin_spacing",
+            "linear")),
+        logspace_start_(this->template GetSingleArgument<float>("logspace_start", 1e-24))
+         {
+    CAFFE_ENFORCE_GE(
+        num_bins_, 1, "Number of bins must be greater than or equal to 1.");
+    CAFFE_ENFORCE(
+        bin_spacing_ == "linear" || bin_spacing_ == "logarithmic",
+        "Bin spacing can be one of 'linear' or 'logarithmic'."
+    );
+    CAFFE_ENFORCE_GT(
+      logspace_start_, 0,
+      "Logarithmic spacing base is a multiplier and is expected to be >1.");
+  }
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<float, double>>::call(this, Input(0));
+  }
+
+  template <typename T>
+  bool DoRunWithType() {
+    CheckInputs();
+
+    // Scale the range so that the last count is always 0.
+    const T RANGE_SCALING = 1.0001;
+
+    const auto* histogram_values = Output(HISTOGRAM_VALUES);
+    histogram_values->Resize(num_edges_);
+    auto* histogram_values_data = histogram_values->template mutable_data<T>();
+    const auto* histogram_counts = Output(HISTOGRAM_COUNTS);
+    histogram_counts->Resize(num_edges_);
+    auto* histogram_counts_data =
+        histogram_counts->template mutable_data<int64_t>();
+
+    // Calculate the max and min.
+    bool first_seen = false;
+    // 0 initialization is arbitrary here to suppress linter warnings.
+    // The actual initialization check happens through the first_seen variable.
+    T max = 0;
+    T min = 0;
+    int64_t total_count = 0;
+    for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+      const auto& x = Input(input_idx);
+      const int64_t N = x.numel();
+      total_count += N;
+      const auto* x_data = x.template data<T>();
+      for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+        if (!first_seen) {
+          max = x_data[data_idx];
+          min = x_data[data_idx];
+          first_seen = true;
+        } else {
+          max = std::max(x_data[data_idx], max);
+          min = std::min(x_data[data_idx], min);
+        }
+      }
+    }
+
+    if (!first_seen) {
+      math::Set<T, Context>(num_edges_, 0, histogram_values_data, &context_);
+      math::Set<int64_t, Context>(
+          num_edges_, 0, histogram_counts_data, &context_);
+      return true;
+    }
+
+    CAFFE_ENFORCE(min <= max, "Incorrect min-max computation");
+    T scaled_max = 0;  // this is set in both branches
+    if (bin_spacing_ == "linear") {
+      // Let's scale the range so that the last count is 0.
+      scaled_max = min + (max - min) * RANGE_SCALING;
+      T scaled_range = (scaled_max - min);
+      // Avoid underflow by calculating advancement through multiplication.
+      for (int i = 0; i < num_edges_; i++) {
+        T advancement_ratio = T(i) / num_bins_;
+        histogram_values_data[i] = min + advancement_ratio * scaled_range;
+      }
+    } else if (bin_spacing_ == "logarithmic") {
+      // First, we need to sanitize the range.
+      if (min < logspace_start_) {
+        min = logspace_start_;
+      }
+      if (max < logspace_start_) {
+        max = logspace_start_;
+      }
+      T linear_range = max - min;
+      linear_range = linear_range * RANGE_SCALING;
+      scaled_max = min + linear_range;
+      // Calculate base interval using geometric sum.
+      // Simply: multiplier = exp((log(max) - log(min))/N)
+      // Avoid underflow by delaying division and exp.
+      T log_multiplier_numerator =log(scaled_max) - log(min);
+      // Avoid underflow by:
+      // - Calculating each advancement separately for each i.
+      for (int i = 0; i < num_edges_; i++) {
+        T advancement_ratio = T(i)/num_bins_;
+        histogram_values_data[i] = min * exp(log_multiplier_numerator * advancement_ratio);
+      }
+    }
+
+    math::Set<int64_t, Context>(
+      num_edges_, 0, histogram_counts_data, &context_);
+    if (histogram_values_data[num_edges_-1] <= max) {
+      // In cases of min&max being equal (or any unexpected numerical underflow) we
+      // may not have a final edge larger than the max.
+      histogram_values_data[num_edges_-1] = scaled_max;
+      histogram_counts_data[0] = total_count;
+    }
+    else {
+      for (int input_idx = 0; input_idx < InputSize(); input_idx++) {
+        const auto& x = Input(input_idx);
+        const int64_t N = x.numel();
+        const auto* x_data = x.template data<T>();
+        for (int64_t data_idx = 0; data_idx < N; data_idx++) {
+          const auto bisection_it = std::upper_bound(
+              histogram_values_data,
+              histogram_values_data + num_edges_,
+              x_data[data_idx]);
+          const int bisection_idx = bisection_it - histogram_values_data;
+          if (bisection_idx > 0 && bisection_idx < num_edges_) {
+            histogram_counts_data[bisection_idx - 1]++;
+          }
+          if (bisection_idx == 0) {
+            histogram_counts_data[0]++;
+          }
+        }
+      }
+    }
+
+    return true;
+  }
+
+ protected:
+  OUTPUT_TAGS(HISTOGRAM_VALUES, HISTOGRAM_COUNTS);
+
+ private:
+  int num_bins_;
+  int num_edges_;
+  std::string bin_spacing_;
+  float logspace_start_;
+
+  void CheckInputs() {
+    const auto& input_zero = Input(0);
+    for (int i = 1; i < InputSize(); i++) {
+      CAFFE_ENFORCE_EQ(
+          Input(i).dtype(),
+          input_zero.dtype(),
+          "All inputs must have the same type; expected ",
+          input_zero.dtype().name(),
+          " but got ",
+          Input(i).dtype().name(),
+          " for input ",
+          i);
+    }
+  }
+};
+
+} // namespace caffe2

--- a/caffe2/python/operator_test/self_binning_histogram_test.py
+++ b/caffe2/python/operator_test/self_binning_histogram_test.py
@@ -1,0 +1,206 @@
+import unittest
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, workspace
+from hypothesis import given
+
+
+class TestSelfBinningHistogramBase(object):
+    def __init__(self, bin_spacing, dtype):
+        self.bin_spacing = bin_spacing
+        self.dtype = dtype
+
+    def _check_histogram(self, arrays, num_bins, expected_values=None, expected_counts=None):
+        # Check that sizes match and counts add up.
+        values = workspace.FetchBlob("histogram_values")
+        counts = workspace.FetchBlob("histogram_counts")
+        self.assertTrue(np.size(values) == num_bins)
+        self.assertTrue(np.size(counts) == num_bins)
+        self.assertTrue(np.sum(counts) == sum([np.size(array) for array in arrays]))
+
+
+        if expected_counts is None:
+            # Check that counts are correct for the returned values if expected_counts is not given.
+            expected_counts = np.zeros(num_bins, dtype='i')
+            for array in arrays:
+                for i in array:
+                    found = False
+                    for pos in range(np.size(values)):
+                        if values[pos] > i:
+                            found = True
+                            break
+                    self.assertTrue(found, "input array must fit inside values array")
+                    if self.bin_spacing == "linear":
+                        self.assertTrue(pos > 0, "first value should be the smallest")
+                    if pos == 0:
+                        self.assertEqual(self.bin_spacing, "logarithmic")
+                        expected_counts[pos] += 1
+                    else:
+                        expected_counts[pos - 1] += 1
+        self.assertTrue(np.array_equal(expected_counts, counts), f"expected:{expected_counts}\ncounts:{counts}")
+        if expected_values is not None:
+            self.assertTrue(np.array_equal(expected_values, values), f"expected:{expected_values}\ncounts:{values}")
+
+
+    def _run_single_op_net(self, arrays, num_bins, logspacing_start=None):
+        for i in range(len(arrays)):
+            workspace.FeedBlob(
+                "X{}".format(i), arrays[i]
+            )
+        net = core.Net("test_net")
+        if logspacing_start is not None:
+            net.SelfBinningHistogram(
+                ["X{}".format(i) for i in range(len(arrays))],
+                ["histogram_values", "histogram_counts"],
+                num_bins=num_bins,
+                bin_spacing=self.bin_spacing,
+                logspacing_start=logspacing_start,
+            )
+        else:
+            net.SelfBinningHistogram(
+                ["X{}".format(i) for i in range(len(arrays))],
+                ["histogram_values", "histogram_counts"],
+                num_bins=num_bins,
+                bin_spacing=self.bin_spacing,
+            )
+        workspace.RunNetOnce(net)
+
+    @given(rows=st.integers(1, 1000), cols=st.integers(1, 1000), **hu.gcs_cpu_only)
+    def test_histogram_device_consistency(self, rows, cols, gc, dc):
+        X = np.random.rand(rows, cols)
+        op = core.CreateOperator(
+            "SelfBinningHistogram",
+            ["X"],
+            ["histogram_values", "histogram_counts"],
+            num_bins=1000,
+            bin_spacing=self.bin_spacing,
+        )
+        self.assertDeviceChecks(dc, op, [X], [0])
+
+    def test_histogram_bin_to_fewer(self):
+        X = np.array([-2.0, -2.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 9.0], dtype=self.dtype)
+        self._run_single_op_net([X], 5)
+        self._check_histogram(
+            [X],
+            6,
+        )
+
+    def test_histogram_bin_to_more(self):
+        X = np.array([-2.0, -2.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 9.0], dtype=self.dtype)
+        self._run_single_op_net([X], 100)
+        self._check_histogram(
+            [X],
+            101,
+        )
+
+    def test_histogram_bin_to_two(self):
+        """This test roughly tests [min,max+EPSILON] and [N,0]"""
+        X = np.array([-2.0, -2.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 9.0], dtype=self.dtype)
+        self._run_single_op_net([X], 1)
+        self._check_histogram(
+            [X],
+            2,
+        )
+
+    def test_histogram_min_max_equal(self):
+        """This test uses exact value match, so is only relevant for float type."""
+        X = np.array([0., 0., 0., 0., 0.], dtype='f')
+        logspacing_start = np.float(1e-24)
+        self._run_single_op_net([X], 3, logspacing_start)
+        if self.bin_spacing == "linear":
+            self._check_histogram(
+                [X],
+                4,
+                expected_values=np.array([0., 0., 0., 0.], dtype='f'),
+                expected_counts=[5, 0, 0, 0]
+            )
+        else:
+            self.assertEqual(self.bin_spacing, "logarithmic")
+            self._check_histogram(
+                [X],
+                4,
+                expected_values=np.array([logspacing_start] * 4, dtype='f'),
+                expected_counts=[5, 0, 0, 0],
+            )
+
+    def test_histogram_min_max_equal_nonzero(self):
+        X = np.array([1., 1., 1., 1., 1.], dtype=self.dtype)
+        logspacing_start = 1e-24
+        self._run_single_op_net([X], 3, 1e-24)
+        self._check_histogram(
+            [X],
+            4,
+            expected_values=[1., 1., 1., 1.],
+            expected_counts=[5, 0, 0, 0]
+        )
+
+    def test_histogram_empty_input_tensor(self):
+        X = np.array([], dtype=self.dtype)
+        self._run_single_op_net([X], 1)
+        self._check_histogram(
+            [X],
+            2,
+        )
+        self._run_single_op_net([X], 10)
+        self._check_histogram(
+            [X],
+            11,
+        )
+
+    def test_histogram_multi_input(self):
+        X1 = np.array([-2.0, -2.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 9.0], dtype=self.dtype)
+        X2 = np.array([-5.0, -3.0, 7, 7, 0.0, 1.0, 2.0, -3.0, 4.0, 6.0, 9.0], dtype=self.dtype)
+        self._run_single_op_net([X1, X2], 5)
+        self._check_histogram(
+            [X1, X2],
+            6,
+        )
+
+    def test_histogram_very_small_range_for_stride_underflow(self):
+        """Tests a large number of bins for a very small range of values.
+
+        This test uses float type. 1-e38 is very small, and with 1M bins, it
+        causes numeric underflow. This test is to show that this is handled.
+        """
+        X = np.array([0, 1e-38], dtype='f')
+        self._run_single_op_net([X], 1000000)
+        self._check_histogram(
+            [X],
+            1000001,
+        )
+
+
+    def test_histogram_insufficient_bins(self):
+        with self.assertRaisesRegex(
+            RuntimeError, "Number of bins must be greater than or equal to 1."
+        ):
+            self._run_single_op_net([np.random.rand(111)], 0)
+
+
+class TestSelfBinningHistogramLinear(TestSelfBinningHistogramBase, hu.HypothesisTestCase):
+    def __init__(self, *args, **kwargs):
+        TestSelfBinningHistogramBase.__init__(self, bin_spacing="linear", dtype='d')
+        hu.HypothesisTestCase.__init__(self, *args, **kwargs)
+
+class TestSelfBinningHistogramLogarithmic(TestSelfBinningHistogramBase, hu.HypothesisTestCase):
+    def __init__(self, *args, **kwargs):
+        TestSelfBinningHistogramBase.__init__(self, bin_spacing="logarithmic", dtype='d')
+        hu.HypothesisTestCase.__init__(self, *args, **kwargs)
+
+class TestSelfBinningHistogramLinearFloat(TestSelfBinningHistogramBase, hu.HypothesisTestCase):
+    def __init__(self, *args, **kwargs):
+        TestSelfBinningHistogramBase.__init__(self, bin_spacing="linear", dtype='f')
+        hu.HypothesisTestCase.__init__(self, *args, **kwargs)
+
+class TestSelfBinningHistogramLogarithmicFloat(TestSelfBinningHistogramBase, hu.HypothesisTestCase):
+    def __init__(self, *args, **kwargs):
+        TestSelfBinningHistogramBase.__init__(self, bin_spacing="logarithmic", dtype='f')
+        hu.HypothesisTestCase.__init__(self, *args, **kwargs)
+
+
+if __name__ == "__main__":
+    global_options = ["caffe2"]
+    core.GlobalInit(global_options)
+    unittest.main()


### PR DESCRIPTION
Summary:
This diff backs out the backout diff.  The failure was due to C++ `or`
not being supported in MSVC. This is now replaced with ||

Original commit changeset: fc7f3f8c968d

Test Plan: Existing unit tests, check github CI.

Differential Revision: D22494777

