### PR TITLE
Fix torch.cuda.check_error type errors

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -303,6 +303,13 @@ class TestCuda(TestCase):
                 torch.cuda.caching_allocator_delete(mem)
                 self.assertEqual(torch.cuda.memory_allocated(), prev)
 
+    def test_check_error(self):
+        # Assert this call doesn't raise.
+        torch.cuda.check_error(0)
+
+        with self.assertRaisesRegex(torch.cuda.CudaError, "device not ready"):
+            torch.cuda.check_error(34)
+
     def test_cuda_get_device_name(self):
         # Testing the behaviour with None as an argument
         current_device = torch.cuda.current_device()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -307,7 +307,8 @@ class TestCuda(TestCase):
         # Assert this call doesn't raise.
         torch.cuda.check_error(0)
 
-        with self.assertRaisesRegex(torch.cuda.CudaError, "out of memory"):
+        with self.assertRaisesRegex(torch.cuda.CudaError,
+                                    "out of memory|hipErrorOutOfMemory"):
             torch.cuda.check_error(2)
 
     def test_cuda_get_device_name(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -307,8 +307,8 @@ class TestCuda(TestCase):
         # Assert this call doesn't raise.
         torch.cuda.check_error(0)
 
-        with self.assertRaisesRegex(torch.cuda.CudaError, "device not ready"):
-            torch.cuda.check_error(34)
+        with self.assertRaisesRegex(torch.cuda.CudaError, "out of memory"):
+            torch.cuda.check_error(2)
 
     def test_cuda_get_device_name(self):
         # Testing the behaviour with None as an argument

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -31,10 +31,10 @@ void initCudartBindings(PyObject* module) {
   cudart.def("cudaProfilerInitialize", cudaProfilerInitialize);
 #endif
 
-  // The HIP rewrite rules mean that the functions defined above will have their
-  // names changed when built with HIP. To provide a consistent interface, we
-  // also define some versions that won't be touched by the rewrite (but will
-  // still correctly resolve to CUDA and HIP). We leave the ones above there for
+  // The HIP rewrite rules will change the names of the functions defined above
+  // when building with HIP. To provide a consistent interface, we also define
+  // versions of those functions that won't be touched by the rewrite (but will
+  // still correctly resolve to CUDA and HIP). We leave the ones above for
   // backwards compatibility.
   cudart.def("getErrorString", cudaGetErrorString);
   cudart.def("profilerStart", cudaProfilerStart);

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -30,6 +30,16 @@ void initCudartBindings(PyObject* module) {
 #ifndef __HIP_PLATFORM_HCC__
   cudart.def("cudaProfilerInitialize", cudaProfilerInitialize);
 #endif
+
+  // The HIP rewrite rules mean that the functions defined above will have their
+  // names changed when built with HIP. To provide a consistent interface, we
+  // also define some versions that won't be touched by the rewrite (but will
+  // still correctly resolve to CUDA and HIP). We leave the ones above there for
+  // backwards compatibility.
+  cudart.def("getErrorString", cudaGetErrorString);
+  cudart.def("profilerStart", cudaProfilerStart);
+  cudart.def("profilerStop", cudaProfilerStop);
+  cudart.def("hostRegister", cudaHostRegister);
 }
 
 } // namespace shared

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -14,32 +14,25 @@ void initCudartBindings(PyObject* module) {
 
   auto cudart = m.def_submodule("_cudart", "libcudart.so bindings");
 
+  // By splitting the names of these objects into two literals we prevent the
+  // HIP rewrite rules from changing these names when building with HIP.
+
 #ifndef __HIP_PLATFORM_HCC__
-  py::enum_<cudaOutputMode_t>(cudart, "cudaOutputMode")
+  py::enum_<cudaOutputMode_t>(cudart, "cuda" "OutputMode")
       .value("KeyValuePair", cudaKeyValuePair)
       .value("CSV", cudaCSV);
 #endif
 
-  py::enum_<cudaError_t>(cudart, "cudaError")
+  py::enum_<cudaError_t>(cudart, "cuda" "Error")
       .value("success", cudaSuccess);
 
-  cudart.def("cudaGetErrorString", cudaGetErrorString);
-  cudart.def("cudaProfilerStart", cudaProfilerStart);
-  cudart.def("cudaProfilerStop", cudaProfilerStop);
-  cudart.def("cudaHostRegister", cudaHostRegister);
+  cudart.def("cuda" "GetErrorString", cudaGetErrorString);
+  cudart.def("cuda" "ProfilerStart", cudaProfilerStart);
+  cudart.def("cuda" "ProfilerStop", cudaProfilerStop);
+  cudart.def("cuda" "HostRegister", cudaHostRegister);
 #ifndef __HIP_PLATFORM_HCC__
-  cudart.def("cudaProfilerInitialize", cudaProfilerInitialize);
+  cudart.def("cuda" "ProfilerInitialize", cudaProfilerInitialize);
 #endif
-
-  // The HIP rewrite rules will change the names of the functions defined above
-  // when building with HIP. To provide a consistent interface, we also define
-  // versions of those functions that won't be touched by the rewrite (but will
-  // still correctly resolve to CUDA and HIP). We leave the ones above for
-  // backwards compatibility.
-  cudart.def("getErrorString", cudaGetErrorString);
-  cudart.def("profilerStart", cudaProfilerStart);
-  cudart.def("profilerStop", cudaProfilerStop);
-  cudart.def("hostRegister", cudaHostRegister);
 }
 
 } // namespace shared

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -216,7 +216,7 @@ class cudaStatus(object):
 
 class CudaError(RuntimeError):
     def __init__(self, code: int) -> None:
-        msg = _cudart.cudaGetErrorString(code).decode('utf-8')
+        msg = _cudart.cudaGetErrorString(torch._C._cudart.cudaError(code))
         super(CudaError, self).__init__('{0} ({1})'.format(msg, code))
 
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -216,7 +216,7 @@ class cudaStatus(object):
 
 class CudaError(RuntimeError):
     def __init__(self, code: int) -> None:
-        msg = _cudart.getErrorString(_cudart.cudaError(code))
+        msg = _cudart.cudaGetErrorString(_cudart.cudaError(code))
         super(CudaError, self).__init__('{0} ({1})'.format(msg, code))
 
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -216,7 +216,7 @@ class cudaStatus(object):
 
 class CudaError(RuntimeError):
     def __init__(self, code: int) -> None:
-        msg = _cudart.cudaGetErrorString(torch._C._cudart.cudaError(code))
+        msg = _cudart.getErrorString(_cudart.cudaError(code))
         super(CudaError, self).__init__('{0} ({1})'.format(msg, code))
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41330 Fix torch.cuda.check_error type errors**

`torch.cuda.check_error` is annotated as taking an `int` as argument but when running `torch.cuda.check_error(34)` one would get:
```
TypeError: cudaGetErrorString(): incompatible function arguments. The following argument types are supported:
    1. (arg0: torch._C._cudart.cudaError) -> str

Invoked with: 34
```
Even if one explicitly casted the argument, running `torch.cuda.check_error(torch._C._cudart.cudaError(34))` would give:
```
AttributeError: 'str' object has no attribute 'decode'
```

This PR fixes both issues (thus allowing `check_error` to be called with a un-casted int) and adds a test.

Differential Revision: [D22500549](https://our.internmc.facebook.com/intern/diff/D22500549/)