### PR TITLE
DOC: fix two build warnings

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx==2.4.4
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib
+tensorboard

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,7 +68,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
 
    torchaudio <https://pytorch.org/audio>
    torchtext <https://pytorch.org/text>
-   torchvision/index
+   torchvision <https://pytorch.org/vision>
    TorchElastic <https://pytorch.org/elastic/>
    TorchServe <https://pytorch.org/serve>
    PyTorch on XLA Devices <http://pytorch.org/xla/>


### PR DESCRIPTION
xref gh-38011.

Fixes two warnings when building documentation by
- using the external link to torchvision
- install tensorboard before building documentation