### PR TITLE
[Draft] Final subtask of DDP Communication Hook / An API that converts ProcessGroup::Work to utils::Future.

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupFuture.h
+++ b/torch/csrc/distributed/c10d/ProcessGroupFuture.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <condition_variable>
+#include <type_traits>
+
+#include <ATen/ATen.h>
+#include <c10d/ProcessGroup.hpp>
+#include <torch/csrc/jit/python/pybind_utils.h>
+
+namespace c10d {
+
+// template <typename T>
+class TORCH_API ProcessGroupFuture : public torch::jit::Future{
+ public:
+  explicit ProcessGroupFuture(std::shared_ptr<c10d::ProcessGroup::Work> work)
+      : torch::jit::Future(c10::ListType::create(c10::TensorType::get())),
+        work_(std::move(work)) {}
+
+  // Override the wait method of Future and wait until the c10d ProcessGroup
+  // work_ is completed. Once work_ has its result ready, copy the mark the
+  // Future completed with that result.
+  void wait() override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    work_->wait();
+    while (!work_->isCompleted()) {
+      finished_cv_.wait(lock);
+    }
+    markCompleted(torch::jit::IValue(work_->result()));
+  };
+
+ private:
+  std::shared_ptr<c10d::ProcessGroup::Work> work_;
+};
+
+} // namespace c10d

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -594,7 +594,7 @@ class DistributedDataParallel(Module):
 
         """
         self._check_comm_hook(hook)
-        dist.PythonHookBinder.register_comm_hook(self, state, hook)
+        dist.PythonHookHelper.register_comm_hook(self, state, hook)
 
     def _distributed_broadcast_coalesced(self, tensors, buffer_size):
         dist._broadcast_coalesced(self.process_group, tensors, buffer_size)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41339 [Draft] Final subtask of DDP Communication Hook / An API that converts ProcessGroup::Work to utils::Future.**
* #40848 DDP Communication Hook Main Structure

Not functional, just a draft.

Differential Revision: [D22503334](https://our.internmc.facebook.com/intern/diff/D22503334/)