### PR TITLE
[JIT] Dump 'requires_grad' and 'device' as a part of type info.

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -37,6 +37,12 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
           out << ":" << *value->strides()[i];
         }
       }
+      if (value->requiresGrad()) {
+        out << ", requires_grad=" << *value->requiresGrad();
+      }
+      if (value->device()) {
+        out << ", device=" << *value->device();
+      }
       out << ")";
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41352 TE changes.
* #41351 Disable backwards pass in RNN benchmarks.
* #41350 Pass pipelines changes.
* #41349 Add prim::TypeCheck op.
* #41348 Subgraph-utils: return merged node in mergeNodeIntoSubgraph (questionable change).
* #41347 LoopUnroll: ignore profile nodes in the cost model.
* #41346 CSE changes.
* #41345 BatchMM changes.
* **#41344 [JIT] Dump 'requires_grad' and 'device' as a part of type info.**

