### PR TITLE
LoopUnroll: ignore profile nodes in the cost model.

### DIFF
--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -36,6 +36,9 @@ int64_t limitedBlockSize(Block* body, int64_t limit) {
   auto it = body->nodes().begin();
   auto end = body->nodes().end();
   for (int64_t i = 0; i < limit; ++i, ++it) {
+    if (it->kind() == prim::profile) {
+      i--;
+    }
     for (Block* subblock : it->blocks()) {
       i += limitedBlockSize(subblock, limit - i);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41352 TE changes.
* #41351 Disable backwards pass in RNN benchmarks.
* #41350 Pass pipelines changes.
* #41349 Add prim::TypeCheck op.
* #41348 Subgraph-utils: return merged node in mergeNodeIntoSubgraph (questionable change).
* **#41347 LoopUnroll: ignore profile nodes in the cost model.**
* #41346 CSE changes.
* #41345 BatchMM changes.
* #41344 [JIT] Dump 'requires_grad' and 'device' as a part of type info.

