### PR TITLE
Subgraph-utils: return merged node in mergeNodeIntoSubgraph (questionable change).

### DIFF
--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -96,10 +96,11 @@ std::unordered_set<Value*> closedOverValues(
   return closed_over_values;
 }
 
-void mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode) {
+Node* mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode) {
   AT_ASSERT(hasSubgraph(subgraphNode) && toMerge != subgraphNode);
   if (hasSubgraph(toMerge)) {
-    return mergeSubgraph(subgraphNode, toMerge);
+    mergeSubgraph(subgraphNode, toMerge);
+    return nullptr;
   }
 
   auto subgraph = getSubgraph(subgraphNode);
@@ -195,6 +196,7 @@ void mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode) {
   }
   // Remove the original node now that the merge is complete
   toMerge->destroy();
+  return mergedNode;
 }
 
 Node* createSingletonSubgraph(Node* n, Symbol subgraphKind) {

--- a/torch/csrc/jit/passes/utils/subgraph_utils.h
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.h
@@ -23,7 +23,7 @@ TORCH_API Node* createSingletonSubgraph(Node* n, Symbol subgraphKind);
 // Merge a node into a subgraph node. If `toMerge` is also a subgraph, the
 // subgraphs are merged.
 // `toMerge` is destroyed.
-TORCH_API void mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode);
+TORCH_API Node* mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode);
 
 // Move nodes from a subgraph node to the outer graph.
 // `subgraphNode` is destroyed.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41352 TE changes.
* #41351 Disable backwards pass in RNN benchmarks.
* #41350 Pass pipelines changes.
* #41349 Add prim::TypeCheck op.
* **#41348 Subgraph-utils: return merged node in mergeNodeIntoSubgraph (questionable change).**
* #41347 LoopUnroll: ignore profile nodes in the cost model.
* #41346 CSE changes.
* #41345 BatchMM changes.
* #41344 [JIT] Dump 'requires_grad' and 'device' as a part of type info.

