### PR TITLE
Disable backwards pass in RNN benchmarks.

### DIFF
--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -69,14 +69,14 @@ def trainbench(name, rnn_creator, nloops=100, warmup=10,
         gc.collect()
 
         bwd_start_event.record()
-        if modeldef.backward is not None:
-            modeldef.backward(*backward_input)
+#         if modeldef.backward is not None:
+#             modeldef.backward(*backward_input)
         bwd_end_event.record()
 
-        if modeldef.backward is not None:
-            for param in modeldef.params:
-                assert param.grad is not None
-                param.grad.data.zero_()
+#         if modeldef.backward is not None:
+#             for param in modeldef.params:
+#                 assert param.grad is not None
+#                 param.grad.data.zero_()
 
         torch.cuda.synchronize()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41352 TE changes.
* **#41351 Disable backwards pass in RNN benchmarks.**
* #41350 Pass pipelines changes.
* #41349 Add prim::TypeCheck op.
* #41348 Subgraph-utils: return merged node in mergeNodeIntoSubgraph (questionable change).
* #41347 LoopUnroll: ignore profile nodes in the cost model.
* #41346 CSE changes.
* #41345 BatchMM changes.
* #41344 [JIT] Dump 'requires_grad' and 'device' as a part of type info.

