### PR TITLE
.circleci: Explicitly remove nvidia apt repos

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -7,6 +7,9 @@ if [[ "${BUILD_ENVIRONMENT}" == *cu* ]]; then
   echo "deb https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
   echo "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
   echo "deb https://nvidia.github.io/nvidia-docker/ubuntu16.04/amd64 /" | sudo tee -a /etc/apt/sources.list.d/nvidia-docker.list
+else
+  # Explicitly remove nvidia docker apt repositories if not building for cuda
+  sudo rm -rf /etc/apt/sources.list.d/nvidia-docker.list
 fi
 
 # Remove unnecessary sources


### PR DESCRIPTION
The nvidia apt repositories seem to be left over on the amd nodes so
let's just go ahead and remove them explicitly if we're not testing for
CUDA

Example: https://app.circleci.com/pipelines/github/pytorch/pytorch/190222/workflows/8f75b5cd-1afd-43dc-9fa7-f7b058f07b46/jobs/6223743/steps

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

