### PR TITLE
optimize layernorm fp16

### DIFF
--- a/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.cc
@@ -5,37 +5,42 @@
 namespace caffe2 {
 
 template <>
-template <typename T>
 void LayerNormFakeFp16Op<CPUContext>::calcY(
     const int M,
     const int N,
-    const T* X,
-    const T* mean,
-    const T* std,
-    const T* gamma,
-    const T* beta,
-    T* Y) {
-  ConstEigenArrayMap<T> X_arr(X, N, M);
-  ConstEigenVectorArrayMap<T> mean_arr(mean, M);
-  ConstEigenVectorArrayMap<T> std_arr(std, M);
-  EigenArrayMap<T> Y_arr(Y, N, M);
-  T tmp = T(0);
+    const float* X,
+    const float* mean,
+    const float* std,
+    const float* gamma,
+    const float* beta,
+    float* Y) {
+  ConstEigenArrayMap<float> X_arr(X, N, M);
+  ConstEigenVectorArrayMap<float> mean_arr(mean, M);
+  ConstEigenVectorArrayMap<float> std_arr(std, M);
+  EigenArrayMap<float> Y_arr(Y, N, M);
+  float tmp = 0.0;
 
+  std::vector<float> normalized(N);
   for (int i = 0; i < M; ++i) {
-    T normFactor = T(T(1) / std_arr[i]);
+    float normFactor = 1.0f / std_arr[i];
     fp16_wrap(&normFactor);
+
     for (int j = 0; j < N; ++j) {
-      T normalized = T(X_arr.col(i)[j] - mean[i]);
-      fp16_wrap(&normalized);
-      normalized *= normFactor;
-      fp16_wrap(&normalized);
-      Y_arr.col(i)[j] = normalized;
+      normalized[j] = X_arr.col(i)[j] - mean[i];
+    }
+    fbgemm::RoundToFloat16(normalized.data(), normalized.data(), N, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+    for (int j = 0; j < N; ++j) {
+      normalized[j] *= normFactor;
+    }
+    fbgemm::RoundToFloat16(normalized.data(), normalized.data(), N, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+    for (int j = 0; j < N; ++j) {
+      Y_arr.col(i)[j] = normalized[j];
     }
   }
 
   if (gamma != nullptr && beta != nullptr) {
-    ConstEigenVectorArrayMap<T> gamma_arr(gamma, N);
-    ConstEigenVectorArrayMap<T> beta_arr(beta, N);
+    ConstEigenVectorArrayMap<float> gamma_arr(gamma, N);
+    ConstEigenVectorArrayMap<float> beta_arr(beta, N);
 
     for (int i = 0; i < M; ++i) {
       vector<float> res(N);
@@ -51,21 +56,22 @@ void LayerNormFakeFp16Op<CPUContext>::calcY(
 }
 
 template <>
-template <typename T>
-T LayerNormFakeFp16Op<CPUContext>::ReducedAdd(const std::vector<T>& vec) {
+float LayerNormFakeFp16Op<CPUContext>::ReducedAdd(const std::vector<float>& vec) {
   constexpr int VEC_SIZE = 32;
-  std::vector<T> v(VEC_SIZE, T(0));
+  std::vector<float> v(VEC_SIZE, 0.0);
   for (int i = 0; i < VEC_SIZE; ++i) { // 32
     v[i] = vec[i];
   }
   for (int i = 0; i < VEC_SIZE / 2; ++i) { // 16
     v[i] = v[2 * i] + v[2 * i + 1];
-    fp16_wrap(&v[i]);
   }
+  fbgemm::RoundToFloat16(v.data(), v.data(), VEC_SIZE / 2, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+
   for (int i = 0; i < VEC_SIZE / 4; ++i) { // 8
     v[i] = v[2 * i] + v[2 * i + 1];
-    fp16_wrap(&v[i]);
   }
+  fbgemm::RoundToFloat16(v.data(), v.data(), VEC_SIZE / 4, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+
   for (int i = 0; i < VEC_SIZE / 8; ++i) { // 4
     v[i] = v[2 * i] + v[2 * i + 1];
     fp16_wrap(&v[i]);
@@ -80,37 +86,36 @@ T LayerNormFakeFp16Op<CPUContext>::ReducedAdd(const std::vector<T>& vec) {
 }
 
 template <>
-template <typename T>
 void LayerNormFakeFp16Op<CPUContext>::calcMeanStd(
     const int M,
     const int N,
     const float eps,
-    const T* X,
-    T* mean,
-    T* std) {
-  ConstEigenArrayMap<T> X_arr(X, N, M);
+    const float* X,
+    float* mean,
+    float* std) {
+  ConstEigenArrayMap<float> X_arr(X, N, M);
 
-  T sqr[M];
-  T var[M];
-  T inv_N_val = T(1) / N;
+  float sqr[M];
+  float var[M];
+  float inv_N_val = 1.0f / N;
   fp16_wrap(&inv_N_val);
-  T tmp = T(0);
+  float tmp = 0.0f;
 
   constexpr int VEC_SIZE = 32;
-  std::vector<T> inv_N_vec(VEC_SIZE, inv_N_val);
-  std::vector<T> inv_N_prod_vec(VEC_SIZE, 0);
-  std::vector<T> avgVec(VEC_SIZE, T(0));
-  std::vector<T> sqrVec(VEC_SIZE, T(0));
+  std::vector<float> inv_N_vec(VEC_SIZE, inv_N_val);
+  std::vector<float> inv_N_prod_vec(VEC_SIZE, 0);
+  std::vector<float> avgVec(VEC_SIZE, 0.0);
+  std::vector<float> sqrVec(VEC_SIZE, 0.0);
   int numVecs = N / VEC_SIZE;
   int tailSize = N - (numVecs * VEC_SIZE);
 
-  vector<T> X_fp16(M * N);
+  vector<float> X_fp16(M * N);
   fbgemm::RoundToFloat16(
       X, X_fp16.data(), M * N, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
   for (int i = 0; i < M; ++i) {
-    std::fill(avgVec.begin(), avgVec.end(), T(0));
-    std::fill(sqrVec.begin(), sqrVec.end(), T(0));
+    std::fill(avgVec.begin(), avgVec.end(), 0.0);
+    std::fill(sqrVec.begin(), sqrVec.end(), 0.0);
     for (int j = 0; j < numVecs; ++j) {
       fake_fp16::fma_fp16(
           VEC_SIZE,

--- a/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.h
@@ -34,27 +34,26 @@ class LayerNormFakeFp16Op final : public Operator<Context> {
   ~LayerNormFakeFp16Op() noexcept override {}
 
   bool RunOnDevice() override {
-    return DoRunWithType<float>();
+    return DoRunWithType();
   }
 
-  template <typename T>
   bool DoRunWithType() {
     const auto& X = Input(INPUT);
-    auto* Y = Output(OUTPUT, X.sizes(), at::dtype<T>());
+    auto* Y = Output(OUTPUT, X.sizes(), at::dtype<float>());
     CAFFE_ENFORCE_GE(X.dim(), 2, "LayerNorm requires input dim >=2.");
     const int canonical_axis = X.canonical_axis_index(axis_);
     std::vector<int64_t> moments_dims(
         X.sizes().cbegin(), X.sizes().cbegin() + canonical_axis);
     moments_dims.push_back(1);
-    auto* mean = Output(MEAN, moments_dims, at::dtype<T>());
-    auto* sigma = Output(STD, moments_dims, at::dtype<T>());
+    auto* mean = Output(MEAN, moments_dims, at::dtype<float>());
+    auto* sigma = Output(STD, moments_dims, at::dtype<float>());
     const int M = X.size_to_dim(canonical_axis);
     const int N = X.size_from_dim(canonical_axis);
     Y->ResizeLike(X);
-    const T* X_data = X.template data<T>();
-    T* Y_data = Y->template mutable_data<T>();
-    T* mean_data = mean->template mutable_data<T>();
-    T* sigma_data = sigma->template mutable_data<T>();
+    const float* X_data = X.template data<float>();
+    float* Y_data = Y->template mutable_data<float>();
+    float* mean_data = mean->template mutable_data<float>();
+    float* sigma_data = sigma->template mutable_data<float>();
 
     std::vector<float> X_rounded(X.numel());
     fbgemm::RoundToFloat16(
@@ -66,10 +65,10 @@ class LayerNormFakeFp16Op final : public Operator<Context> {
     X_data = X_rounded.data();
 
     // Mean and Standard Deviation computation for the input data
-    calcMeanStd<T>(M, N, epsilon_, X_data, mean_data, sigma_data);
+    calcMeanStd(M, N, epsilon_, X_data, mean_data, sigma_data);
 
-    const T* gamma_data = nullptr;
-    const T* beta_data = nullptr;
+    const float* gamma_data = nullptr;
+    const float* beta_data = nullptr;
     std::vector<float> gamma_rounded(N);
     std::vector<float> beta_rounded(N);
 
@@ -80,7 +79,7 @@ class LayerNormFakeFp16Op final : public Operator<Context> {
       CAFFE_ENFORCE_EQ(gamma.numel(), N);
       CAFFE_ENFORCE_EQ(beta.numel(), N);
 
-      gamma_data = gamma.template data<T>();
+      gamma_data = gamma.template data<float>();
       fbgemm::RoundToFloat16(
           gamma_data,
           gamma_rounded.data(),
@@ -89,7 +88,7 @@ class LayerNormFakeFp16Op final : public Operator<Context> {
           false /*USE_ACC_FP16*/);
       gamma_data = gamma_rounded.data();
 
-      beta_data = beta.template data<T>();
+      beta_data = beta.template data<float>();
       fbgemm::RoundToFloat16(
           beta_data,
           beta_rounded.data(),
@@ -100,35 +99,32 @@ class LayerNormFakeFp16Op final : public Operator<Context> {
     }
 
     // Layer Normalized Output computation
-    calcY<T>(
+    calcY(
         M, N, X_data, mean_data, sigma_data, gamma_data, beta_data, Y_data);
 
     return true;
   }
 
  private:
-  template <typename T>
   void calcY(
       const int M,
       const int N,
-      const T* X,
-      const T* mean,
-      const T* std,
-      const T* gamma,
-      const T* beta,
-      T* Y);
+      const float* X,
+      const float* mean,
+      const float* std,
+      const float* gamma,
+      const float* beta,
+      float* Y);
 
-  template <typename T>
   void calcMeanStd(
       const int M,
       const int N,
       const float eps,
-      const T* X,
-      T* mean,
-      T* std);
+      const float* X,
+      float* mean,
+      float* std);
 
-  template <typename T>
-  T ReducedAdd(const std::vector<T>& vec);
+  float ReducedAdd(const std::vector<float>& vec);
 
   const int axis_;
   const float epsilon_;


### PR DESCRIPTION
Summary:
remove templates since we only use the float version
for the hot paths use RoundToFloat16 which take vectors

Test Plan: fakelowp tests

Reviewed By: venkatacrc

Differential Revision: D22516885

