### PR TITLE
libtorch_python should not make any calls to CUDA runtime API

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -54,6 +54,10 @@ static void poison_fork() {
 // CUDA management methods
 ////////////////////////////////////////////////////////////////////////////////
 
+void CaffeCudaGetDeviceWithTHCudaCheck(int& device_id) {
+  device_id = caffe2::CaffeCudaGetDevice();
+}
+
 void THCPModule_setDevice(int device)
 {
   THCudaCheck(caffe2::CaffeCudaSetDevice(device));
@@ -77,7 +81,7 @@ PyObject * THCPModule_getDevice_wrap(PyObject *self, PyObject *noargs)
   HANDLE_TH_ERRORS
   int device;
   torch::utils::cuda_lazy_init();
-  device = THCudaCheck(caffe2::CaffeCudaGetDevice());
+  THCudaCheck(CaffeCudaGetDeviceWithTHCudaCheck(device));
   return PyLong_FromLong(device);
   END_HANDLE_TH_ERRORS
 }
@@ -141,7 +145,7 @@ PyObject * THCPModule_setStream_wrap(PyObject *self, PyObject *obj)
   }
   auto stream = at::cuda::CUDAStream::unpack(bits);
   int device;
-  device = THCudaCheck(caffe2::CaffeCudaGetDevice());
+  THCudaCheck(CaffeCudaGetDeviceWithTHCudaCheck(device));
   if (device != stream.device_index()) {
     THCPModule_setDevice(stream.device_index());
   }

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -56,7 +56,7 @@ static void poison_fork() {
 
 void THCPModule_setDevice(int device)
 {
-  caffe2::CaffeCudaSetDevice(device);
+  THCudaCheck(caffe2::CaffeCudaSetDevice(device));
 }
 
 PyObject * THCPModule_setDevice_wrap(PyObject *self, PyObject *arg)
@@ -77,7 +77,7 @@ PyObject * THCPModule_getDevice_wrap(PyObject *self, PyObject *noargs)
   HANDLE_TH_ERRORS
   int device;
   torch::utils::cuda_lazy_init();
-  device = caffe2::CaffeCudaGetDevice();
+  device = THCudaCheck(caffe2::CaffeCudaGetDevice());
   return PyLong_FromLong(device);
   END_HANDLE_TH_ERRORS
 }
@@ -141,7 +141,7 @@ PyObject * THCPModule_setStream_wrap(PyObject *self, PyObject *obj)
   }
   auto stream = at::cuda::CUDAStream::unpack(bits);
   int device;
-  device = caffe2::CaffeCudaGetDevice();
+  device = THCudaCheck(caffe2::CaffeCudaGetDevice());
   if (device != stream.device_index()) {
     THCPModule_setDevice(stream.device_index());
   }

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -56,7 +56,7 @@ static void poison_fork() {
 
 void THCPModule_setDevice(int device)
 {
-  THCudaCheck(cudaSetDevice(device));
+  CaffeCudaSetDevice(device);
 }
 
 PyObject * THCPModule_setDevice_wrap(PyObject *self, PyObject *arg)
@@ -77,7 +77,7 @@ PyObject * THCPModule_getDevice_wrap(PyObject *self, PyObject *noargs)
   HANDLE_TH_ERRORS
   int device;
   torch::utils::cuda_lazy_init();
-  THCudaCheck(cudaGetDevice(&device));
+  device = CaffeCudaGetDevice();
   return PyLong_FromLong(device);
   END_HANDLE_TH_ERRORS
 }
@@ -141,7 +141,7 @@ PyObject * THCPModule_setStream_wrap(PyObject *self, PyObject *obj)
   }
   auto stream = at::cuda::CUDAStream::unpack(bits);
   int device;
-  THCudaCheck(cudaGetDevice(&device));
+  device = CaffeCudaGetDevice();
   if (device != stream.device_index()) {
     THCPModule_setDevice(stream.device_index());
   }

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -56,7 +56,7 @@ static void poison_fork() {
 
 void THCPModule_setDevice(int device)
 {
-  CaffeCudaSetDevice(device);
+  caffe2::CaffeCudaSetDevice(device);
 }
 
 PyObject * THCPModule_setDevice_wrap(PyObject *self, PyObject *arg)
@@ -77,7 +77,7 @@ PyObject * THCPModule_getDevice_wrap(PyObject *self, PyObject *noargs)
   HANDLE_TH_ERRORS
   int device;
   torch::utils::cuda_lazy_init();
-  device = CaffeCudaGetDevice();
+  device = caffe2::CaffeCudaGetDevice();
   return PyLong_FromLong(device);
   END_HANDLE_TH_ERRORS
 }
@@ -141,7 +141,7 @@ PyObject * THCPModule_setStream_wrap(PyObject *self, PyObject *obj)
   }
   auto stream = at::cuda::CUDAStream::unpack(bits);
   int device;
-  device = CaffeCudaGetDevice();
+  device = caffe2::CaffeCudaGetDevice();
   if (device != stream.device_index()) {
     THCPModule_setDevice(stream.device_index());
   }


### PR DESCRIPTION
Replaced calls "cudaSetDevice" and "cudaGetDevice" with thin wrappers in libtorch_cuda library (CaffeCudsSetDevice and CaffeCudaGetDevice).