### PR TITLE
[1/N] Implement Enum JIT support

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -96,6 +96,9 @@ TypePtr IValue::type() const {
       return toTuple()->type();
     case Tag::Generator:
       return GeneratorType::get();
+    case Tag::Enum:
+      // TODO(gmagogsfm): Implement this.
+      TORCH_INTERNAL_ASSERT(false, "To be implemented");
   }
   // switch above is complete but this silences compiler warnings
   TORCH_INTERNAL_ASSERT(false, "unhandled case in IValue::type()");
@@ -264,6 +267,8 @@ IValue IValue::equals(const IValue& rhs) const {
     case Tag::Capsule:
     case Tag::Generator:
       return ptrEqual(lhs, rhs);
+    case Tag::Enum:
+      return lhs.toEnumHolder()->is(*rhs.toEnumHolder());
     case Tag::Uninitialized:
       // Unitialized ivalues show up in no-ops when the compiler can prove a
       // value will never be used. Just return false on any equality comparison.
@@ -501,6 +506,11 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       // print this out the way python would do it
       return out << "<" << obj->name() << " object at " << obj.get() << ">";
     }
+    case IValue::Tag::Enum:
+      auto enum_holder = v.toEnumHolder();
+      return out << "Enum<" << enum_holder->qualifiedClassName() << "." <<
+          enum_holder->name() << ">";
+
   }
   AT_ERROR("Tag not found: ", v.tagKind());
 }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -37,6 +37,7 @@ struct ConstantString;
 struct GenericDict;
 struct Object;
 struct PyObjectHolder;
+struct EnumHolder;
 }
 
 // This is an owning wrapper for a c10::optional<std::vector<T>>
@@ -77,24 +78,25 @@ struct OptionalArray {
 // retain/release calls.
 
 #define TORCH_FORALL_TAGS(_) \
-  _(None) \
-  _(Tensor) \
-  _(Double) \
-  _(Int) \
-  _(Bool) \
-  _(Tuple) \
-  _(String) \
-  _(Blob) \
-  _(GenericList) \
-  _(GenericDict) \
-  _(Future) \
-  _(Device) \
-  _(Object) \
-  _(PyObject) \
-  _(Uninitialized) \
-  _(Capsule) \
-  _(RRef) \
-  _(Generator) \
+  _(None)                    \
+  _(Tensor)                  \
+  _(Double)                  \
+  _(Int)                     \
+  _(Bool)                    \
+  _(Tuple)                   \
+  _(String)                  \
+  _(Blob)                    \
+  _(GenericList)             \
+  _(GenericDict)             \
+  _(Future)                  \
+  _(Device)                  \
+  _(Object)                  \
+  _(PyObject)                \
+  _(Uninitialized)           \
+  _(Capsule)                 \
+  _(RRef)                    \
+  _(Generator)               \
+  _(Enum)                    \
 
 // [doxygen private]
 // These methods are not actually private but we don't want to document them, so
@@ -407,13 +409,13 @@ struct CAFFE2_API IValue final {
   c10::List<bool> toBoolList() &&;
   c10::List<bool> toBoolList() const &;
 
-  //TensorList
+  // TensorList
   bool isTensorList() const;
   c10::List<at::Tensor> toTensorList() &&;
   c10::List<at::Tensor> toTensorList() const &;
   std::vector<at::Tensor> toTensorVector() const;
 
-  //GenericList
+  // GenericList
   IValue(c10::List<IValue> v);
   bool isList() const { return Tag::GenericList == tag; }
   c10::List<IValue> toList() &&;
@@ -478,6 +480,12 @@ struct CAFFE2_API IValue final {
   c10::intrusive_ptr<ivalue::PyObjectHolder> toPyObjectHolder() &&;
   c10::intrusive_ptr<ivalue::PyObjectHolder> toPyObjectHolder() const &;
   PyObject* toPyObject() const;
+
+  // Enum
+  explicit IValue(c10::intrusive_ptr<ivalue::EnumHolder> v);
+  bool isEnum() const { return tag == Tag::Enum; }
+  c10::intrusive_ptr<ivalue::EnumHolder> toEnumHolder() &&;
+  c10::intrusive_ptr<ivalue::EnumHolder> toEnumHolder() const &;
 
   // None
   IValue() : payload{0}, tag(Tag::None), is_intrusive_ptr(false) {}

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -8,8 +8,10 @@
 #include <c10/core/Scalar.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
+#include <c10/util/intrusive_ptr.h>
 #include <ATen/core/Dict.h>
 #include <ATen/core/List.h>
+#include <ATen/core/qualified_name.h>
 #include <ATen/core/rref_interface.h>
 
 namespace torch {
@@ -96,12 +98,20 @@ inline c10::intrusive_ptr<ivalue::Object> IValue::toObject() const & {
   return toIntrusivePtr<ivalue::Object>();
 }
 inline c10::intrusive_ptr<ivalue::PyObjectHolder> IValue::toPyObjectHolder() && {
-  TORCH_INTERNAL_ASSERT(isPyObject(), "Expected PyObject but got", tagKind());
+  TORCH_INTERNAL_ASSERT(isPyObject(), "Expected PyObject but got ", tagKind());
   return moveToIntrusivePtr<ivalue::PyObjectHolder>();
 }
 inline c10::intrusive_ptr<ivalue::PyObjectHolder> IValue::toPyObjectHolder() const & {
-  TORCH_INTERNAL_ASSERT(isPyObject(), "Expected PyObject but got", tagKind());
+  TORCH_INTERNAL_ASSERT(isPyObject(), "Expected PyObject but got ", tagKind());
   return toIntrusivePtr<ivalue::PyObjectHolder>();
+}
+inline c10::intrusive_ptr<ivalue::EnumHolder> IValue::toEnumHolder() && {
+  TORCH_INTERNAL_ASSERT(isEnum(), "Expected Enum but got ", tagKind());
+  return moveToIntrusivePtr<ivalue::EnumHolder>();
+}
+inline c10::intrusive_ptr<ivalue::EnumHolder> IValue::toEnumHolder() const & {
+  TORCH_INTERNAL_ASSERT(isEnum(), "Expected Enum but got ", tagKind());
+  return toIntrusivePtr<ivalue::EnumHolder>();
 }
 inline at::Tensor IValue::toTensor() && {
   AT_ASSERT(isTensor(), "Expected Tensor but got ", tagKind());
@@ -216,6 +226,7 @@ struct CAFFE2_API Tuple : c10::intrusive_ptr_target {
 
 struct Object;
 struct PyObjectHolder;
+struct EnumHolder;
 }
 
 // Future
@@ -522,6 +533,39 @@ struct ivalue::PyObjectHolder : c10::intrusive_ptr_target {
  public:
   virtual PyObject* getPyObject() = 0;
   virtual ~PyObjectHolder() {};
+};
+
+struct ivalue::EnumHolder : c10::intrusive_ptr_target {
+ public:
+  EnumHolder(c10::QualifiedName qualified_class_name, std::string name, IValue value)
+      : qualified_class_name_(std::move(qualified_class_name)),
+        name_(std::move(name)), value_(std::move(value)) {}
+
+  bool is(const ivalue::EnumHolder& rhs) {
+    return *this == rhs;
+  }
+
+  bool operator==(const ivalue::EnumHolder& o) const {
+    return qualified_class_name_ == o.qualifiedClassName() &&
+        name_ == o.name() && value_ == o.value();
+  }
+
+  const std::string& qualifiedClassName() const {
+    return qualified_class_name_.qualifiedName();
+  }
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  const IValue& value() const {
+    return value_;
+  }
+
+private:
+  c10::QualifiedName qualified_class_name_;
+  std::string name_;
+  IValue value_;
 };
 
 #undef TORCH_FORALL_TAGS
@@ -930,10 +974,17 @@ inline IValue::IValue(c10::intrusive_ptr<ivalue::Object> v)
 : tag(Tag::Object), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
+
 inline IValue::IValue(c10::intrusive_ptr<ivalue::PyObjectHolder> v)
 : tag(Tag::PyObject), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();
 }
+
+inline IValue::IValue(c10::intrusive_ptr<ivalue::EnumHolder> v)
+: tag(Tag::Enum), is_intrusive_ptr(true) {
+  payload.as_intrusive_ptr = v.release();
+}
+
 inline IValue IValue::make_capsule(intrusive_ptr<torch::CustomClassHolder> blob) {
   IValue iv;
   iv.tag = Tag::Capsule;
@@ -974,6 +1025,7 @@ inline const std::string& IValue::toStringRef() const {
 inline PyObject* IValue::toPyObject() const {
   return toPyObjectHolder()->getPyObject();
 }
+
 template<typename T>
 inline optional<T> IValue::toOptional() {
   if (this->isNone()) {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -193,6 +193,11 @@ AnyClassTypePtr AnyClassType::get() {
   return value;
 }
 
+AnyEnumTypePtr AnyEnumType::get() {
+  static auto value = AnyEnumType::create();
+  return value;
+}
+
 c10::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2) {
   // check direct subtyping relation
   if (t1->isSubtypeOf(t2)) {
@@ -1364,6 +1369,11 @@ SymbolicShape SymbolicShape::merge(const SymbolicShape& other) const {
     dims.push_back(merge_primitive((*dims_)[i], (*other.dims_)[i]));
   }
   return SymbolicShape(std::move(dims));
+}
+
+bool EnumType::isSubtypeOfExt(const TypePtr rhs, std::ostream* why_not) const {
+  return rhs->kind() == TypeKind::AnyType ||
+      rhs->kind() == TypeKind::AnyEnumType || *this == *rhs;
 }
 
 } // namespace c10

--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <gtest/gtest.h>
 #include <torch/torch.h>
+#include <c10/util/intrusive_ptr.h>
 
 namespace c10 {
 
@@ -256,5 +257,42 @@ TEST(IValueTest, ListNestedEquality) {
   EXPECT_EQ(c1, c2);
   EXPECT_NE(c1, c3);
   EXPECT_NE(c2, c3);
+}
+
+TEST(IValueTest, EnumEquality) {
+  EXPECT_EQ(
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue(1))),
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue(1)))
+  );
+
+  EXPECT_NE(
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue(1))),
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_2", "enum_name_1", IValue(1)))
+  );
+
+  EXPECT_NE(
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue(1))),
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_2", IValue(1)))
+  );
+
+  EXPECT_NE(
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue(1))),
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue(2)))
+  );
+
+  EXPECT_NE(
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue(1))),
+      IValue(c10::make_intrusive<ivalue::EnumHolder>(
+          "enum_class_1", "enum_name_1", IValue("1")))
+  );
 }
 } // namespace c10

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -139,6 +139,7 @@ white_list = [
 # The nightly will fail to parse newly added syntax to schema declarations
 # Add new schemas that will fail the nightly here
 dont_parse_list = [
+    ('aten::eq', datetime.date(2020, 7, 30)),
     ('aten::quantized_lstm', datetime.date(2020, 6, 1)),
     ('aten::quantized_gru', datetime.date(2020, 6, 1)),
     ('quantized::make_quantized_cell_params', datetime.date(2020, 6, 1)),

--- a/test/jit/test_enum.py
+++ b/test/jit/test_enum.py
@@ -1,0 +1,88 @@
+import os
+import sys
+
+import torch
+from enum import Enum
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestEnum(JitTestCase):
+    def setUp(self):
+        self.saved_enum_env_var = os.environ.get("EXPERIMENTAL_ENUM_SUPPORT", None)
+        os.environ["EXPERIMENTAL_ENUM_SUPPORT"] = "1"
+
+    def tearDown(self):
+        if self.saved_enum_env_var:
+            os.environ["EXPERIMENTAL_ENUM_SUPPORT"] = self.saved_enum_env_var
+
+    def test_enum_comp(self):
+        global Color
+
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+
+        def enum_comp(x: Color, y: Color) -> bool:
+            return x == y
+
+        # TODO(gmagogsfm): Re-anble hooks when serialization/deserialization
+        # is supported.
+        with torch._jit_internal._disable_emit_hooks():
+            scripted_enum_comp = torch.jit.script(enum_comp)
+
+        self.assertEqual(
+            scripted_enum_comp(Color.RED, Color.RED),
+            enum_comp(Color.RED, Color.RED))
+
+        self.assertEqual(
+            scripted_enum_comp(Color.RED, Color.GREEN),
+            enum_comp(Color.RED, Color.GREEN))
+
+    def test_heterogenous_value_type_enum_error(self):
+        global Color
+
+        class Color(Enum):
+            RED = 1
+            GREEN = "green"
+
+        def enum_comp(x: Color, y: Color) -> bool:
+            return x == y
+
+        # TODO(gmagogsfm): Re-anble hooks when serialization/deserialization
+        # is supported.
+        with self.assertRaisesRegex(RuntimeError, "Could not unify type list"):
+            scripted_enum_comp = torch.jit.script(enum_comp)
+
+
+# Tests that Enum support features are properly guarded before they are mature.
+class TestEnumFeatureGuard(JitTestCase):
+    def setUp(self):
+        self.saved_enum_env_var = os.environ.get("EXPERIMENTAL_ENUM_SUPPORT", None)
+        if self.saved_enum_env_var:
+            del os.environ["EXPERIMENTAL_ENUM_SUPPORT"]
+
+    def tearDown(self):
+        if self.saved_enum_env_var:
+            os.environ["EXPERIMENTAL_ENUM_SUPPORT"] = self.saved_enum_env_var
+
+    def test_enum_comp_disabled(self):
+        global Color
+
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+
+        def enum_comp(x: Color, y: Color) -> bool:
+            return x == y
+
+        with self.assertRaisesRegex(NotImplementedError,
+                                    "Enum support is work in progress"):
+            torch.jit.script(enum_comp)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -29,6 +29,7 @@ from jit.test_op_normalization import TestOpNormalization  # noqa: F401
 from jit.test_module_interface import TestModuleInterface  # noqa: F401
 from jit.test_onnx_export import TestONNXExport  # noqa: F401
 from jit.test_with import TestWith  # noqa: F401
+from jit.test_enum import TestEnum, TestEnumFeatureGuard  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -6,6 +6,7 @@ circular dependency problems
 
 import contextlib
 import collections
+import enum
 import inspect
 import weakref
 import warnings
@@ -724,7 +725,15 @@ def _qualified_name(obj):
     if isinstance(obj, torch._C.ScriptFunction):
         return obj.qualified_name
 
-    name = obj.__name__
+    if getattr(obj, "__name__", None):
+        name = obj.__name__
+    # Enum classes do not have `__name__` attr, instead they have `name`.
+    elif isinstance(obj, enum.Enum):
+        name = obj.name
+    else:
+        raise RuntimeError("Could not get name of python class object")
+
+
     if name == '<lambda>':
         name = '_lambda'  # make name a valid identifier
 

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -149,7 +149,8 @@ def get_ignored_functions():
         torch.nn.functional.hardswish,
         torch.is_vulkan_available,
         torch.is_deterministic,
-        torch.set_deterministic
+        torch.set_deterministic,
+        torch.unify_type_list
     )
 
 def get_testing_overrides():

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -55,6 +55,7 @@ TypePtr SchemaTypeParser::parseBaseType() {
       {"Capsule", CapsuleType::get()},
       {"Any", at::AnyType::get()},
       {"AnyClassType", at::AnyClassType::get()},
+      {"AnyEnumType", at::AnyEnumType::get()},
   };
   auto tok = L.cur();
   if (!L.nextIf(TK_NONE)) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -851,6 +851,14 @@ void initJITBindings(PyObject* module) {
     return graph;
   });
   m.def("parse_schema", parseSchema);
+  m.def("unify_type_list", [](const std::vector<TypePtr>& types) {
+    std::ostringstream s;
+    auto type = unifyTypeList(types, s);
+    if (!type) {
+      throw std::runtime_error(s.str());
+    }
+    return type.value();
+  });
 
   py::class_<FunctionSchema>(m, "FunctionSchema")
       .def_property_readonly(

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -723,7 +723,20 @@ inline IValue toIValue(
     case TypeKind::AnyListType:
     case TypeKind::AnyTupleType:
     case TypeKind::AnyClassType:
+    case TypeKind::AnyEnumType:
       break;
+    case TypeKind::EnumType:
+      py::object py_obj = py::reinterpret_borrow<py::object>(obj);
+      std::string qualified_class_name_str =
+          py::cast<std::string>(py::module::import("torch._jit_internal")
+                                    .attr("_qualified_name")(py_obj));
+      c10::QualifiedName qualified_class_name(qualified_class_name_str);
+      std::string name = py::cast<std::string>(obj.attr("name"));
+      IValue value = toIValue(
+          obj.attr("value"), type->cast<EnumType>()->getValueType(), {});
+      auto enum_holder = c10::make_intrusive<c10::ivalue::EnumHolder>(
+          qualified_class_name, name, value);
+      return IValue(enum_holder);
   }
   throw py::cast_error(c10::str(
       "toIValue() cannot handle converting to type: ", type->repr_str()));

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -786,6 +786,13 @@ void initPythonIRBindings(PyObject* module_) {
         return get_python_cu()->get_class(c10::QualifiedName(qualified_name));
       }))
       .def("name", [](ClassType& self) { return self.name()->name(); });
+  py::class_<EnumType, Type, std::shared_ptr<EnumType>>(m, "EnumType")
+      .def(py::init([](const std::string& qualified_name, TypePtr value) {
+        return EnumType::create(
+            c10::QualifiedName(qualified_name),
+            std::move(value),
+            get_python_cu());
+      }));
   py::class_<InterfaceType, Type, std::shared_ptr<InterfaceType>>(
       m, "InterfaceType")
       .def(py::init([](const std::string& qualified_name) {

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -520,6 +520,14 @@ RegisterOperators reg(
          },
          aliasAnalysisSpecialCase()),
      Operator(
+         "aten::eq(AnyEnumType a, AnyEnumType b) -> bool",
+         [](Stack* stack) {
+           IValue x = pop(stack);
+           IValue y = pop(stack);
+           push(stack, x == y);
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          "aten::dequantize.tensor(Tensor qtensor) -> Tensor",
          [](Stack* stack) {
            at::Tensor qtensor;

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -74,8 +74,12 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
       case AnyListType::Kind:
       case AnyTupleType::Kind:
       case AnyClassType::Kind:
+      case AnyEnumType::Kind:
         // no op, there is nothing to tag
         break;
+      case EnumType::Kind:
+        // TODO(gmagogsfm): Implement serialization/deserialization of Enum.
+        AT_ASSERT(false);
       case TupleType::Kind: {
         auto t = w.value.toTuple();
         auto ttype = w.static_type->expect<TupleType>();

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -1,5 +1,7 @@
 import ast
+import enum
 import inspect
+import os
 import re
 import torch
 from .._jit_internal import List, BroadcastingList1, BroadcastingList2, \
@@ -7,7 +9,8 @@ from .._jit_internal import List, BroadcastingList1, BroadcastingList2, \
     is_optional, _qualified_name, Any, Future, is_future, is_ignored_fn
 from torch._C import TensorType, TupleType, FloatType, IntType, \
     ListType, StringType, DictType, BoolType, OptionalType, ClassType, InterfaceType, AnyType, NoneType, \
-    DeviceObjType, FutureType
+    DeviceObjType, FutureType, EnumType
+
 
 from textwrap import dedent
 from torch._six import builtins
@@ -242,6 +245,29 @@ def try_real_annotations(fn, loc):
     return arg_types, return_type
 
 
+# Finds common type for enum values belonging to an Enum class. If not all
+# values have the same type, AnyType is returned.
+def get_enum_value_type(e: enum.Enum, loc):
+    enum_values = list(e)
+    if not enum_values:
+        raise ValueError("No enum values defined for: '{}'".format(e.__class__))
+
+    types = set([type(v.value) for v in enum_values])
+    ir_types = [try_ann_to_type(t, loc) for t in types]
+
+    # If Enum values are of different types, an exception will be raised here.
+    # Even though Python supports this case, we chose to not implement it to
+    # avoid overcomplicate logic here for a rare use case. Please report a
+    # feature request if you find it necessary.
+    return torch._C.unify_type_list(ir_types)
+
+
+# Guards against using Enum support in JIT before the feature is complete.
+# TODO(gmagogsfm): remove this check once Enum support is complete.
+def is_enum_support_enabled() -> bool:
+    return os.environ.get('EXPERIMENTAL_ENUM_SUPPORT', "0") == "1"
+
+
 def try_ann_to_type(ann, loc):
     if ann is None:
         return TensorType.get()
@@ -286,6 +312,11 @@ def try_ann_to_type(ann, loc):
         return DeviceObjType.get()
     if ann is torch.dtype:
         return IntType.get()  # dtype not yet bound in as its own type
+    if inspect.isclass(ann) and issubclass(ann, enum.Enum):
+        if not is_enum_support_enabled():
+            raise NotImplementedError(
+                "Enum support is work in progress, please do not use it now")
+        return EnumType(_qualified_name(ann), get_enum_value_type(ann, loc))
     if inspect.isclass(ann):
         if hasattr(ann, "__torch_script_class__"):
             return ClassType(_qualified_name(ann))


### PR DESCRIPTION
* Add EnumType and AnyEnumType as first-class jit type
* Add Enum-typed IValue
* Enhanced aten::eq to support Enum

Supported:
Enum-typed function targuments
using Enum type and comparing them

TODO:
Add PyThon sugared value for Enum
Support getting name/value attrs of enums
Support Enum-typed return values
Support enum values of different types in same Enum class
Support serialization and deserialization

