### PR TITLE
Updates serialization note to explain versioned symbols and dynamic versioning

### DIFF
--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -2,90 +2,317 @@
 Serialization semantics
 =======================
 
-Storage sharing is preserved in serialization
+This note describes how you can save and load PyTorch tensors and module states
+in Python, and how to serialize Python modules so they can be loaded in C++.
+
+.. contents:: Table of Contents
+
+Saving and loading tensors
+--------------------------
+
+.. _saving-loading-tensors:
+
+:func:`torch.save` and :func:`torch.load` let you easily save and load tensors:
+
+::
+
+    >>> t = torch.tensor([1., 2.])
+    >>> torch.save(t, 'tensor.pt')
+    >>> torch.load('tensor.pt')
+    tensor([1., 2.])
+
+By convention, PyTorch files are typically written with a ‘.pt’ or ‘.pth’ extension.
+
+:func:`torch.save` and :func:`torch.load` use Python’s pickle by default,
+so you can also save multiple tensors as part of Python objects like tuples,
+lists, and dicts:
+
+::
+
+    >>> d = {'a': torch.tensor([1., 2.]), 'b': torch.tensor([3., 4.])}
+    >>> torch.save(d, 'tensor_dict.pt')
+    >>> torch.load('tensor_dict.pt')
+    {'a': tensor([1., 2.]), 'b': tensor([3., 4.])}
+
+Custom data structures that include PyTorch tensors can also be saved if the
+data structure is pickle-able.
+
+Saving and loading tensors preserves views
 ---------------------------------------------
 
 .. _preserve-storage-sharing:
 
-PyTorch saves the underlying storages so that tensors sharing the same storage before :func:`torch.save`
-will still share storage after :func:`torch.load`.
+Saving tensors preserves their view relationships:
 
 ::
 
-    >>> tensor = torch.zeros(1000000)
-    >>> slice1 = tensor[:1000]
-    >>> slice2 = tensor[:10] # slice1 and slice2 share the same storage
-    >>> torch.save([slice1, slice2], 'share.pt')
-    >>> loaded_1, loaded_2 = torch.load('share.pt')
-    >>> loaded_1[0]
-    tensor(0.)
-    >>> loaded_2[0]
-    tensor(0.)
-    >>> loaded_2[0] = 1
-    >>> loaded_1[0] # loaded tensors still share storage
-    tensor(1.)
+    >>> numbers = torch.arange(1, 10)
+    >>> evens = numbers[1::2]
+    >>> torch.save([numbers, events], 'tensors.pt')
+    >>> loaded_numbers, loaded_evens = torch.load('tensors.pt')
+    >>> loaded_evens *= 2
+    >>> loaded_numbers
+    tensor([ 1,  4,  3,  8,  5, 12,  7, 16,  9])
 
-Note that saving storage instead of tensor itself means the serialized file size might not match tensor size.
-In the example above the whole `tensor`'s storage (of size 1000000) is serialized instead of only slices.
-When tensor is expanded from a smaller storage, serialized file size might be smaller than tensor size as well.
+`loaded_numbers` and `loaded_evens` share storage just like `numbers` and
+`evens` do.
+
+Behind the scenes, PyTorch saves storage objects and tensor metadata separately,
+and it reuses the storage object where possible. In the above case, for example,
+the values [1, 2, 3, 4, 5, 6, 7, 8, 9] are only saved once. This typically saves
+space, but if small views of a much larger storage are saved then size of
+the saved file may become prohibitively large, as in the following example:
 
 ::
 
-    >>> a = torch.zeros(4).expand(4, 4)
-    >>> a.size()
-    torch.Size([4, 4])
-    >>> a.storage() # All columns of `a` share the same storage
-     0.0
-     0.0
-     0.0
-     0.0
-    [torch.FloatStorage of size 4]
-    >>> torch.save(a, 'a.pt')  # Only 4 float numbers are serialized
-    >>> loaded = torch.load('a.pt')
-    >>> loaded.storage()  # All colums of `loaded` share the same storage
-     0.0
-     0.0
-     0.0
-     0.0
-    [torch.FloatStorage of size 4]
+    >>> numbers = torch.arange(1, 1e5)
+    >>> one_hand = numbers[0:5]
+    >>> two_hands = numbers[5:10]
+    >>> torch.save([one_hand, two_hands], 'tensors.pt')
 
-If saving storages causes issues like saved file contains a lot of unwanted data,
-you can break the storage sharing before saving using :meth:`~torch.Tensor.clone`. But it might
-produce different results compared to the original storage sharing version.
 
-Best practices
---------------
+`one_hand` and `two_hands` are both (tiny) views of `numbers`, and when saved
+their storage, `numbers`, is saved. So instead of saving ten numbers
+([1, 2, 3, 4, 5], [6, 7, 8, 9, 10]) PyTorch will save 99,999!
 
-.. _recommend-saving-models:
+Tensors cloned using :meth:`~torch.Tensor.clone` have their own storage, so
+cloning a tensor before saving it will avoid this latter issue at the cost of
+losing the view relationships of the original tensors.
 
-Recommended approach for saving a model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Saving and loading Python modules
+---------------------------------
 
-There are two main approaches for serializing and restoring a model.
+.. _saving-loading-python-modules:
 
-The first (recommended) saves and loads only the model parameters::
+See also: `Tutorial: Saving and loading modules <https://pytorch.org/tutorials/beginner/saving_loading_models.html>`_
 
-    torch.save(the_model.state_dict(), PATH)
+In PyTorch, a module’s state is frequently serialized using a ‘state dict.’
+A module’s state dict contains all of its parameters and persistent buffers:
 
-Then later::
+::
 
-    the_model = TheModelClass(*args, **kwargs)
-    the_model.load_state_dict(torch.load(PATH))
+    >>> bn = torch.nn.BatchNorm1d(3, track_running_stats=True)
+    >>> list(bn.named_parameters())
+    [('weight', Parameter containing: tensor([1., 1., 1.], requires_grad=True)),
+     ('bias', Parameter containing: tensor([0., 0., 0.], requires_grad=True))]
 
-The second saves and loads the entire model::
+    >>> list(bn.named_buffers())
+    [('running_mean', tensor([0., 0., 0.])),
+     ('running_var', tensor([1., 1., 1.])),
+     ('num_batches_tracked', tensor(0))]
 
-    torch.save(the_model, PATH)
+    >>> bn.state_dict()
+    OrderedDict([('weight', tensor([1., 1., 1.])),
+                 ('bias', tensor([0., 0., 0.])),
+                 ('running_mean', tensor([0., 0., 0.])),
+                 ('running_var', tensor([1., 1., 1.])),
+                 ('num_batches_tracked', tensor(0))])
 
-Then later::
+Instead of saving a module directly, for compatibility reasons it is recommended
+to instead save only its state dict. Python modules even have a function,
+:meth:`~torch.nn.Module.load_state_dict`, to restore their states from a state dict:
 
-    the_model = torch.load(PATH)
+::
 
-However in this case, the serialized data is bound to the specific classes
-and the exact directory structure used, so it can break in various ways when
-used in other projects, or after some serious refactors.
+    >>> torch.save(bn.state_dict(), 'bn.pt')
+    >>> bn_state_dict = torch.load('bn.pt')
+    >>> new_bn = torch.nn.BatchNorm1d(3, track_running_stats=True)
+    >>> new_bn.load_state_dict(bn_state_dict)
+    <All keys matched successfully>
 
-.. note::
-    The 1.6 release of PyTorch switched ``torch.save`` to use a new
-    zipfile-based file format. ``torch.load`` still retains the ability to
-    load files in the old format. If for any reason you want ``torch.save``
-    to use the old format, pass the kwarg ``_use_new_zipfile_serialization=False``.
+Note that the state dict is first loaded from its file with func:`torch.load`
+and the state then restored with :meth:`~torch.nn.Module.load_state_dict`.
+
+Even custom modules and modules containing other modules have state dicts and
+can use this pattern:
+
+::
+
+    >>> class MyModule(torch.nn.Module):
+      def __init__(self):
+        super(MyModule, self).__init__()
+        self.l0 = torch.nn.Linear(4, 2)
+        self.l1 = torch.nn.Linear(2, 1)
+
+      def forward(self, input):
+        out0 = self.l0(input)
+        out0_relu = torch.nn.functional.relu(out0)
+        return self.l1(out0_relu)
+
+    >>> m = MyModule()
+    >>> m.state_dict()
+    OrderedDict([('l0.weight', tensor([[ 0.1400, 0.4563, -0.0271, -0.4406],
+                                       [-0.3289, 0.2827, 0.4588, 0.2031]])),
+                 ('l0.bias', tensor([ 0.0300, -0.1316])),
+                 ('l1.weight', tensor([[0.6533, 0.3413]])),
+                 ('l1.bias', tensor([-0.1112]))])
+
+    >>> torch.save(m.state_dict(), 'mymodule.pt')
+    >>> m_state_dict = torch.load('mymodule.pt')
+    >>> new_m = MyModule()
+    >>> new_m.load_state_dict(m_state_dict)
+    <All keys matched successfully>
+
+Serializing Python modules and loading them in C++
+--------------------------------------------------
+
+.. _serializing-python-modules:
+
+See also: `Tutorial: Loading a TorchScript Model in C++ <https://pytorch.org/tutorials/advanced/cpp_export.html>`_
+
+ScriptModules can be serialized as a TorchScript program using and loaded
+using :func:`torch.jit.load`.
+This serialization encodes all the modules’ methods, submodules, parameters,
+and attributes, and it allows the serialized program to be loaded in C++
+(i.e. without Python).
+
+The distinction between :func:`torch.jit.save` and :func:`torch.save` may not
+be immediately clear. :func:`torch.save` saves Python objects with pickle.
+This is especially useful for prototyping, researching, and training.
+:func:`torch.jit.save`, on the other hand, serializes modules to a format that
+can be loaded in Python or C++. This is useful when saving and loading C++
+modules or for running modules trained in Python with C++, a common practice
+when deploying PyTorch models.
+
+To script, serialize and load a module in Python:
+
+::
+
+    >>> scripted_module = torch.jit.script(MyModule())
+    >>> torch.jit.save(scripted_module, 'mymodule.pt')
+    >>> torch.jit.load('mymodule.pt')
+    RecursiveScriptModule( original_name=MyModule
+                          (l0): RecursiveScriptModule(original_name=Linear)
+                          (l1): RecursiveScriptModule(original_name=Linear) )
+
+
+Traced modules can also be saved with :func:`torch.jit.save`, with the caveat
+that only the traced code path is serialized. The following example demonstrates
+this:
+
+::
+
+    >>> class ControlFlowModule(torch.nn.Module):
+      def __init__(self):
+        super(ControlFlowModule, self).__init__()
+        self.l0 = torch.nn.Linear(4, 2)
+        self.l1 = torch.nn.Linear(2, 1)
+
+      def forward(self, input):
+        if input.dim() > 1:
+        return torch.tensor(0)
+
+        out0 = self.l0(input)
+        out0_relu = torch.nn.functional.relu(out0)
+        return self.l1(out0_relu)
+
+    >>> traced_module = torch.jit.trace(ControlFlowModule(), torch.randn(4))
+    >>> torch.jit.save(traced_module, 'controlflowmodule_traced.pt')
+    >>> loaded = torch.jit.load('controlflowmodule_traced.pt')
+    >>> loaded(torch.randn(2, 4)))
+    tensor([[-0.1571], [-0.3793]], grad_fn=<AddBackward0>)
+
+    >>> scripted_module = torch.jit.script(ControlFlowModule(), torch.randn(4))
+    >>> torch.jit.save(scripted_module, 'controlflowmodule_scripted.pt')
+    >>> loaded = torch.jit.load('controlflowmodule_scripted.pt')
+    >> loaded(torch.randn(2, 4))
+    tensor(0)
+
+The above module has an if statement that is not triggered by the traced inputs,
+and so is not part of the traced module and not serialized with it.
+The scripted module, however, contains the if statement and is serialized with it.
+See the `TorchScript documentation <https://pytorch.org/docs/stable/jit.html>`_
+for more on scripting and tracing.
+
+Finally, to load the module in C++:
+
+::
+
+    >>> torch::jit::script::Module module;
+    >>> module = torch::jit::load('controlflowmodule_scripted.pt');
+
+See the `PyTorch C++ API documentation <https://pytorch.org/cppdocs/>`_
+for details about how to use PyTorch modules in C++.
+
+Saving and loading scripted modules across PyTorch versions
+-----------------------------------------------------------
+
+.. _saving-loading-across-versions:
+
+The PyTorch Team recommends saving and loading modules with the same version of
+PyTorch. Older versions of PyTorch may not support newer modules, and newer
+versions may have removed or modified older behavior. These changes are
+explicitly described in
+PyTorch’s `release notes <https://github.com/pytorch/pytorch/releases>`_,
+and modules relying on functionality that has changed may need to be updated
+to continue working properly. In limited cases, detailed below, PyTorch will
+preserve the historic behavior of serialized modules so they do not require an
+update.
+
+torch.div performing integer division
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In PyTorch 1.5 and earlier :func:`torch.div` would perform floor division when
+given two integer inputs:
+
+::
+
+    # PyTorch 1.5 (and earlier)
+    >>> b = torch.tensor(3)
+    >>> a / b
+    tensor(1)
+
+In PyTorch 1.7, however, :func:`torch.div` will always perform a true division
+of its inputs, just like division in Python 3:
+
+::
+
+    # PyTorch 1.7
+    >>> a = torch.tensor(5)
+    >>> b = torch.tensor(3)
+    >>> a / b
+    tensor(1.6667)
+
+The behavior of :func:`torch.div` is preserved in serialized modules.
+That is, modules serialized with versions of PyTorch before 1.6 will continue
+to see :func:`torch.div` perform floor division when given two integer inputs
+even when loaded with newer versions of PyTorch. Modules using :func:`torch.div`
+and serialized on PyTorch 1.6 and later cannot be loaded in earlier versions of
+PyTorch, however, since those earlier versions do not understand the new behavior.
+
+torch.full always inferring a float dtype
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In PyTorch 1.5 and earlier :func:`torch.full` always returned a float tensor,
+regardless of the fill value it’s given:
+
+::
+
+    # PyTorch 1.5 and earlier
+    >>> torch.full((3,), 1)  # Note the integer fill value...
+    tensor([1., 1., 1.])     # ...but float tensor!
+
+In PyTorch 1.7, however, :func:`torch.full` will infer the returned tensor’s
+dtype from the fill value:
+
+::
+
+    # PyTorch 1.7
+    >>> torch.full((3,), 1)
+    tensor([1, 1, 1])
+
+    >>> torch.full((3,), True)
+    tensor([True, True, True])
+
+    >>> torch.full((3,), 1.)
+    tensor([1., 1., 1.])
+
+    >>> torch.full((3,), 1 + 1j)
+    tensor([1.+1.j, 1.+1.j, 1.+1.j])
+
+The behavior of :func:`torch.full` is preserved in serialized modules. That is,
+modules serialized with versions of PyTorch before 1.6 will continue to see
+torch.full return float tensors by default, even when given bool or
+integer fill values. Modules using :func:`torch.full` and serialized on PyTorch 1.6
+and later cannot be loaded in earlier versions of PyTorch, however, since those
+earlier versions do not understand the new behavior.

--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -80,9 +80,9 @@ the saved tensor is written to a file:
 Instead of saving only the five values in the `small` tensor to 'small.pt,'
 the 999 values in the storage shared with `large` were saved and loaded.
 
-In cases like the above, the size of the saved file can be reduced by first
-cloning the tensors to be saved. Cloning a tensor produces a new tensor with a
-new storage containing only its values:
+When saving tensors smaller than their storage(s), the size of the saved file
+can be reduced by first cloning the tensors to be saved. Cloning a tensor
+produces a new tensor with a new storage containing only its values:
 
 ::
 
@@ -95,8 +95,9 @@ new storage containing only its values:
 
 Since the cloned tensors are independent of each other, however, they have
 none of the view relationships the original tensors did. If both file size and
-view relationships are important then care must be taken to construct and view
-the appropriate storages before saving.
+view relationships are important when saving tensors smaller than their
+storage(s), then care must be taken to construct new storages and tensors with
+the desired relationships before saving.
 
 Saving and loading Python modules
 ---------------------------------
@@ -188,8 +189,8 @@ and attributes, and it allows the serialized program to be loaded in C++
 The distinction between :func:`torch.jit.save` and :func:`torch.save` may not
 be immediately clear. :func:`torch.save` saves Python objects with pickle.
 This is especially useful for prototyping, researching, and training.
-:func:`torch.jit.save`, on the other hand, serializes modules to a format that
-can be loaded in Python or C++. This is useful when saving and loading C++
+:func:`torch.jit.save`, on the other hand, serializes ScriptModules to a format
+that can be loaded in Python or C++. This is useful when saving and loading C++
 modules or for running modules trained in Python with C++, a common practice
 when deploying PyTorch models.
 

--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -56,17 +56,17 @@ Saving tensors preserves their view relationships:
 
 Behind the scenes, these tensors share the same "storage." See
 `Tensor Views <https://pytorch.org/docs/master/tensor_view.html>`_ for more
-on views and storages.
+on views and storage.
 
-When PyTorch saves one or more tensors it saves their storages and tensor
+When PyTorch saves tensors it saves their storage objects and tensor
 metadata separately. This is an implementation detail that may change in the
 future, but it typically saves space and lets PyTorch easily
 reconstruct the view relationships between the loaded tensors. In the above
 snippet, for example, only a single storage is written to 'tensors.pt'.
 
-In some cases, however, saving storages may be unecessary and create
-prohibitively large files. In the following snippet a storage much larger than
-the saved tensor is written to a file:
+In some cases, however, saving the current storage objects may be unnecessary
+and create prohibitively large files. In the following snippet a storage much
+larger than the saved tensor is written to a file:
 
 ::
 
@@ -78,11 +78,12 @@ the saved tensor is written to a file:
     999
 
 Instead of saving only the five values in the `small` tensor to 'small.pt,'
-the 999 values in the storage shared with `large` were saved and loaded.
+the 999 values in the storage it shares with `large` were saved and loaded.
 
-When saving tensors smaller than their storage(s), the size of the saved file
-can be reduced by first cloning the tensors to be saved. Cloning a tensor
-produces a new tensor with a new storage containing only its values:
+When saving tensors with fewer elements than their storage objects, the size of
+the saved file can be reduced by first cloning the tensors. Cloning a tensor
+produces a new tensor with a new storage object containing only the values
+in the tensor:
 
 ::
 
@@ -96,8 +97,8 @@ produces a new tensor with a new storage containing only its values:
 Since the cloned tensors are independent of each other, however, they have
 none of the view relationships the original tensors did. If both file size and
 view relationships are important when saving tensors smaller than their
-storage(s), then care must be taken to construct new storages and tensors with
-the desired relationships before saving.
+storage objects, then care must be taken to construct new storage objects and
+tensors with the desired view relationships before saving.
 
 Saving and loading Python modules
 ---------------------------------


### PR DESCRIPTION
Doc update intended to clarify and expand our current serialization behavior, including explaining the difference between torch.save/torch.load, torch.nn.Module.state_dict/torch.nn.Module.load_state_dict, and torch.jit.save/torch.jit.load. Also explains, for the time, when historic serialized Torchscript behavior is preserved and our recommendation for preserving behavior (using the same PyTorch version to consume a model as produced it). 