### PR TITLE
Fix flaky test_stream_event_nogil due to missing event sync

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1025,7 +1025,8 @@ class TestCuda(TestCase):
         with torch.cuda.stream(s1):
             torch.cuda._sleep(10)
         s1.synchronize()
-        s1.record_event(e_tok)
+        e_tok.record()
+        e_tok.synchronize()
 
         self.assertTrue(s0.query())
         self.assertTrue(s1.query())


### PR DESCRIPTION
The test asserts that the stream is "ready" but doesn't wait for the
event to be "executed" which makes it fail on some platforms where the
`query` call occurs "soon enough".

Fixes #38807

