### PR TITLE
move aten::ord, aten::__getitem__.str, aten::exp to lite interpreter

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -26,11 +26,33 @@ namespace {
 
 RegisterOperators reg(
     {Operator(
+         "aten::__getitem__.str(str s, int index) -> str",
+         [](Stack* stack) {
+           auto index = pop(stack).toInt();
+           auto string = pop(stack).toStringRef();
+           auto norm_index = normalizeIndex(index, string.size());
+           char c = string.at(norm_index);
+           push(stack, std::string(&c, 1));
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          "aten::len.str(str s) -> int",
          [](Stack& stack) {
            auto string = pop(stack).toStringRef();
            push(stack, static_cast<int64_t>(string.size()));
            return 0;
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
+         "aten::ord(str string) -> int",
+         [](Stack* stack) {
+           auto string = pop(stack).toStringRef();
+           TORCH_CHECK(
+               string.size() == 1,
+               "String for ord() must be 1 character, found ",
+               string.size());
+           uint8_t ord = string.at(0);
+           push(stack, int64_t(ord));
          },
          aliasAnalysisFromSchema()),
      Operator(

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -474,6 +474,7 @@ RegisterOperators reg(
      DEFINE_UNARY_OP(aten::floor, floor(a), int, int),
      DEFINE_UNARY_OP(aten::ceil, ceil(a), int, int),
      DEFINE_UNARY_OP(aten::neg, -a, int, float),
+     DEFINE_UNARY_OP(aten::exp, std::exp(a), float, float),
      // Pass in two ops for handling int and float separately as % in C++ only
      // works for int The modulus calculation is different between C++ and
      // Python (on negative), we preserve the python behavior as it's more

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -673,17 +673,6 @@ void hashValue(Stack* stack) {
 
 RegisterOperators reg2({
 
-    Operator(
-        "aten::__getitem__.str(str s, int index) -> str",
-        [](Stack* stack) {
-          auto index = pop(stack).toInt();
-          auto string = pop(stack).toStringRef();
-          auto norm_index = normalizeIndex(index, string.size());
-          char c = string.at(norm_index);
-          push(stack, std::string(&c, 1));
-        },
-        aliasAnalysisFromSchema()),
-
     // registered as Any[] so that heterogenous tuples can be called with len()
     Operator(
         "aten::len.any(Any[] a) -> int",
@@ -836,18 +825,6 @@ RegisterOperators reg2({
           auto norm_index = normalizeIndex(index, string.size());
           char c = string.at(norm_index);
           push(stack, std::string(&c, 1));
-        },
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::ord(str string) -> int",
-        [](Stack* stack) {
-          auto string = pop(stack).toStringRef();
-          TORCH_CHECK(
-              string.size() == 1,
-              "String for ord() must be 1 character, found ",
-              string.size());
-          uint8_t ord = string.at(0);
-          push(stack, int64_t(ord));
         },
         aliasAnalysisFromSchema()),
     Operator(

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -911,7 +911,6 @@ RegisterOperators reg2({
         float),
     DEFINE_UNARY_OP(aten::log1p, std::log1p(a), float, float),
     DEFINE_UNARY_OP(aten::log10, std::log10(a), float, float),
-    DEFINE_UNARY_OP(aten::exp, std::exp(a), float, float),
     DEFINE_UNARY_OP(aten::sqrt, std::sqrt(a), float, float),
     DEFINE_UNARY_OP(aten::acos, std::acos(a), float, float),
     DEFINE_UNARY_OP(aten::asin, std::asin(a), float, float),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41408 move aten::ord, aten::__getitem__.str, aten::exp to lite interpreter**

Differential Revision: [D22527503](https://our.internmc.facebook.com/intern/diff/D22527503)