### PR TITLE
Change BCELoss size mismatch warning into an error

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6011,6 +6011,13 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'between 0 and 1'):
             loss_too_positive = bceloss(output_too_positive, target)
 
+    def test_bce_loss_size_mismatch(self):
+        bceloss = nn.BCELoss()
+        a = torch.rand(25)
+        b = torch.rand(25, 1)
+        with self.assertRaisesRegex(ValueError, 'Using a target size \('):
+            bceloss(a, b)
+
     def test_bce_with_logits_gives_same_result_as_sigmoid_and_bce_loss_large_tensors_with_grad(self):
         x_size = 1024
         y_size = 256

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6015,7 +6015,7 @@ class TestNN(NNTestCase):
         bceloss = nn.BCELoss()
         a = torch.rand(25)
         b = torch.rand(25, 1)
-        with self.assertRaisesRegex(ValueError, 'Using a target size \('):
+        with self.assertRaisesRegex(ValueError, r'Using a target size \('):
             bceloss(a, b)
 
     def test_bce_with_logits_gives_same_result_as_sigmoid_and_bce_loss_large_tensors_with_grad(self):

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -157,15 +157,11 @@ inline Tensor binary_cross_entropy(
   auto reduction_enum = enumtype::reduction_get_enum(reduction);
 
   if (target.sizes() != input.sizes()) {
-    TORCH_WARN("Using a target size (", target.sizes(), ") ",
-               "that is different to the input size (", input.sizes(), ") is deprecated. ",
-               "Please ensure they have the same size.");
-  }
-  if (input.numel() != target.numel()) {
     TORCH_CHECK(
       false,
-      "Target and input must have the same number of elements. target nelement (", target.numel(), ") "
-      "!= input nelement (", input.numel(), ")");
+      "Using a target size (", target.sizes(), ") ",
+      "that is different to the input size (", input.sizes(), ") is deprecated. ",
+      "Please ensure they have the same size.");
   }
 
   auto weight_ = weight;

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2492,12 +2492,8 @@ def binary_cross_entropy(input, target, weight=None, size_average=None,
     else:
         reduction_enum = _Reduction.get_enum(reduction)
     if target.size() != input.size():
-        warnings.warn("Using a target size ({}) that is different to the input size ({}) is deprecated. "
-                      "Please ensure they have the same size.".format(target.size(), input.size()),
-                      stacklevel=2)
-    if input.numel() != target.numel():
-        raise ValueError("Target and input must have the same number of elements. target nelement ({}) "
-                         "!= input nelement ({})".format(target.numel(), input.numel()))
+        raise ValueError("Using a target size ({}) that is different to the input size ({}) is deprecated. "
+                         "Please ensure they have the same size.".format(target.size(), input.size()))
 
     if weight is not None:
         new_size = _infer_size(target.size(), weight.size())


### PR DESCRIPTION
BCELoss currently uses different broadcasting semantics than numpy. Since previous versions of PyTorch have thrown a warning in these cases telling the user that input sizes should match, and since the CUDA and CPU results differ when sizes do not match, it makes sense to upgrade the size mismatch warning to an error.

We can consider supporting numpy broadcasting semantics in BCELoss in the future if needed.

Closes #40023

