### PR TITLE
[PyTorch Mobile] Modularize the autograd source files shared by mobile and full-jit

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -106,7 +106,7 @@ jit_sources_common = [
 
 libtorch_sources_common = core_sources_common + jit_sources_common
 
-core_sources_full = [
+core_autograd_sources = [
     "torch/csrc/autograd/anomaly_mode.cpp",
     "torch/csrc/autograd/autograd.cpp",
     "torch/csrc/autograd/cpp_hook.cpp",
@@ -122,6 +122,9 @@ core_sources_full = [
     "torch/csrc/autograd/record_function_ops.cpp",
     "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/variable.cpp",
+]
+
+core_sources_full = [
     "torch/csrc/jit/api/function_impl.cpp",
     "torch/csrc/jit/api/module.cpp",
     "torch/csrc/jit/api/object.cpp",
@@ -254,7 +257,7 @@ core_sources_full = [
     "torch/csrc/utils/variadic.cpp",
 ]
 
-libtorch_core_sources = sorted(core_sources_common + core_sources_full)
+libtorch_core_sources = sorted(core_sources_common + core_sources_full + core_autograd_sources)
 
 libtorch_distributed_sources = [
     "torch/csrc/distributed/autograd/autograd.cpp",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41430 [PyTorch Mobile] Modularize the autograd source files shared by mobile and full-jit**

To avoid duplication at compile time, modularize the common autograd files used by both mobile and full-jit.

Differential Revision: [D22531358](https://our.internmc.facebook.com/intern/diff/D22531358/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22531358/)!