### PR TITLE
Fix qobserver test

### DIFF
--- a/benchmarks/operator_benchmark/pt/qobserver_test.py
+++ b/benchmarks/operator_benchmark/pt/qobserver_test.py
@@ -11,8 +11,8 @@ import torch.quantization.observer as obs
 qobserver_short_configs_dict = {
     'attr_names': ('C', 'M', 'N', 'dtype', 'device'),
     'attrs': (
-        (3, 512, 512, torch.quint8, torch.device('cpu')),
-        (3, 512, 512, torch.quint8, torch.device('cuda')),
+        (3, 512, 512, torch.quint8, 'cpu'),
+        (3, 512, 512, torch.quint8, 'cuda'),
     ),
     'tags': ('short',),
 }


### PR DESCRIPTION
Summary: Change the device config in qobserver test to a string to honor --device flag.

Test Plan: buck run caffe2/benchmarks/operator_benchmark/pt:qobserver_test  -- --iterations 1 --device cpu

Reviewed By: ngimel

Differential Revision: D22536379

