### PR TITLE
remove use of the term "blacklist" from docs/cpp/source/Doxyfile

### DIFF
--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -74,7 +74,7 @@ CREATE_SUBDIRS         = NO
 FULL_PATH_NAMES        = YES
 # Nested folders will be ignored without this.
 RECURSIVE              = YES
-# Block certain file patterns from the INPUT section.
+# Exclude certain file patterns from the INPUT section.
 EXCLUDE = ../../../torch/csrc/api/include/torch/nn/pimpl-inl.h \
           ../../../torch/csrc/api/include/torch/detail
 # Increase the max node size for our large files

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -74,7 +74,7 @@ CREATE_SUBDIRS         = NO
 FULL_PATH_NAMES        = YES
 # Nested folders will be ignored without this.
 RECURSIVE              = YES
-# Blacklist certain file patterns from the INPUT section.
+# Block certain file patterns from the INPUT section.
 EXCLUDE = ../../../torch/csrc/api/include/torch/nn/pimpl-inl.h \
           ../../../torch/csrc/api/include/torch/detail
 # Increase the max node size for our large files


### PR DESCRIPTION
As requested in #41443 