### PR TITLE
Adjust bound_shape_inferencer to take 4 inputs for FCs

### DIFF
--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -632,6 +632,8 @@ TEST(BoundShapeInference, FC) {
       CreateOperatorDef("FC", "", {"X0", "W0", "B0"}, {"Out0"}, {}));
   net.add_op()->CopyFrom(
       CreateOperatorDef("FCTransposed", "", {"X1", "W1", "B1"}, {"Out1"}, {}));
+  net.add_op()->CopyFrom(CreateOperatorDef(
+      "Int8FC", "", {"X2", "W2", "B2", "quant_param"}, {"Out2"}, {}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
       "W0",
@@ -649,6 +651,18 @@ TEST(BoundShapeInference, FC) {
           {16, 1024}));
   shape_map.emplace(
       "B1", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {1024}));
+
+  shape_map.emplace(
+      "W2",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {16, 1024}));
+  shape_map.emplace(
+      "B2", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {16}));
+  shape_map.emplace(
+      "quant_param", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {1}));
+
   BoundShapeSpec spec(20, 1000);
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(net, shape_map, nullptr);
@@ -673,6 +687,20 @@ TEST(BoundShapeInference, FC) {
       "Out1",
       {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 1024});
+  verifyShapeInfo(
+      out_shape,
+      "X2",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 1024},
+      TensorProto_DataType_UINT8,
+      true);
+  verifyShapeInfo(
+      out_shape,
+      "Out2",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 16},
+      TensorProto_DataType_UINT8,
+      true);
 }
 
 TEST(BoundShapeInference, FC3D) {

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -603,7 +603,7 @@ void BoundShapeInferencer::InferConcat(const OperatorDef& op) {
 }
 
 void BoundShapeInferencer::InferFC(const OperatorDef& op) {
-  CAFFE_ENFORCE_EQ(op.input_size(), 3, "FC has to have 3 inputs");
+  CAFFE_ENFORCE(op.input_size() == 3 || op.input_size() == 4, "FC has to have 3 or 4 inputs");
   const auto w_it = shape_info_.find(op.input(1));
   CAFFE_ENFORCE(
       w_it != shape_info_.end(),
@@ -668,6 +668,16 @@ void BoundShapeInferencer::InferFC(const OperatorDef& op) {
   // Standard shape inference for outputs
   std::vector<TensorShape> input_shapes{
       shape_info_[op.input(0)].shape, w_shape_info.shape, b_shape_info.shape};
+  if(op.input_size() == 4) {
+    const auto quant_param_it = shape_info_.find(op.input(3));
+    CAFFE_ENFORCE(
+        quant_param_it != shape_info_.end(),
+        "Shape of quant_param input of FC ",
+        op.input(3),
+        " needs to be presented");
+    const ShapeInfo& quant_param_shape_info = quant_param_it->second;
+    input_shapes.emplace_back(quant_param_shape_info.shape);
+  }
   std::vector<TensorShape> output_shapes = InferOutput(op, input_shapes);
   CAFFE_ENFORCE_EQ(output_shapes.size(), 1);
   TensorProto::DataType output_data_type;

--- a/caffe2/quantization/server/int8_quant_scheme_blob_fill.cc
+++ b/caffe2/quantization/server/int8_quant_scheme_blob_fill.cc
@@ -12,6 +12,16 @@ REGISTER_CPU_OPERATOR(
 OPERATOR_SCHEMA(Int8QuantSchemeBlobFill)
     .NumInputs(0)
     .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out;
+      TensorShape X = in[0];
+      X.clear_dims();
+      X.add_dims(1);
+      out.emplace_back(std::move(X));
+      out[0].set_data_type(TensorProto_DataType_STRING);
+      return out;
+    })
     .Arg(
         "quantization_kind",
         "The kind of quant scheme that would be used to generate quant param")


### PR DESCRIPTION
Summary: The model exported from online training workflow with int8 quantization contains FCs with 4 inputs. The extra input is the quant_param blob. This diff is to adjust the bound_shape_inferencer to get shape info for the quant_param input.

Test Plan:
```
buck test caffe2/caffe2/opt:bound_shape_inference_test
```

Differential Revision: D22543215

