### PR TITLE
[JIT] Replace "blacklist" in test_jit.py

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15166,7 +15166,7 @@ class TestJitGeneratedFunctional(JitTestCase):
 
 # UBSAN per-function exclusions don't seem to work with OpenMP pragmas,
 # and we have to disable the failing tests here instead.
-UBSAN_BLACKLISTED_TESTS = [
+UBSAN_DISABLED_TESTS = [
     "test___rdiv___constant",
     "test___rdiv___scalar_constant",
     "test_addcdiv",
@@ -15510,7 +15510,7 @@ def post_add_test(test_name, skipTestIf, do_test, test_class):
     for skip in skipTestIf:
         do_test = skip(do_test)
 
-    if not (TEST_WITH_UBSAN and test_name in UBSAN_BLACKLISTED_TESTS):
+    if not (TEST_WITH_UBSAN and test_name in UBSAN_DISABLED_TESTS):
         setattr(test_class, test_name, do_test)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41460 [JIT] Replace use of "whitelist" in lower_tuples pass
* #41459 [JIT] Remove use of "whitelist" in quantization/helper.cpp
* #41458 [JIT] Replace uses of "whitelist" in jit/_script.py
* #41457 [JIT] Replace uses of "blacklist" in jit/_recursive.py
* #41456 [JIT] Replace use of "blacklist" in python/init.cpp
* #41455 [JIT] Replace use of "blacklist" in xnnpack_rewrite
* #41454 [JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py
* **#41453 [JIT] Replace "blacklist" in test_jit.py**

**Test Plan**
`python test/test_jit.py`

**Fixes**
This commit partially addresses #41443.

Differential Revision: [D22544268](https://our.internmc.facebook.com/intern/diff/D22544268)