### PR TITLE
[JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py

### DIFF
--- a/tools/jit/gen_unboxing_wrappers.py
+++ b/tools/jit/gen_unboxing_wrappers.py
@@ -198,7 +198,7 @@ OPERATOR = CodeTemplate("""\
 """)
 
 
-blacklisted_types = {
+disallowed_types = {
     'Storage',
     'DimnameList?',
     'ConstQuantizerPtr',
@@ -211,7 +211,7 @@ default_only_types = {'Generator'}
 
 def is_jit_arg(i, arg):
     simple_type = arg['simple_type']
-    if simple_type in blacklisted_types:
+    if simple_type in disallowed_types:
         return False
     if simple_type in default_only_types and 'default' not in arg:
         return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41460 [JIT] Replace use of "whitelist" in lower_tuples pass
* #41459 [JIT] Remove use of "whitelist" in quantization/helper.cpp
* #41458 [JIT] Replace uses of "whitelist" in jit/_script.py
* #41457 [JIT] Replace uses of "blacklist" in jit/_recursive.py
* #41456 [JIT] Replace use of "blacklist" in python/init.cpp
* #41455 [JIT] Replace use of "blacklist" in xnnpack_rewrite
* **#41454 [JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py**
* #41453 [JIT] Replace "blacklist" in test_jit.py

**Test Plan**
Continuous integration (if this file is still used).

**Fixes**
This commit partially addresses #41443.

Differential Revision: [D22544271](https://our.internmc.facebook.com/intern/diff/D22544271)