### PR TITLE
[JIT] Replace use of "blacklist" in xnnpack_rewrite

### DIFF
--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -277,16 +277,16 @@ void FoldPrePackingOps(script::Module& m) {
 
 script::Module optimizeForMobile(
     const script::Module& m,
-    const std::set<MobileOptimizerType>& optimization_blacklist,
+    const std::set<MobileOptimizerType>& optimization_blocklist,
     const std::vector<std::string>& preserved_methods) {
   auto cloned_module = m.clone();
   cloned_module.eval();
 
-  if (!optimization_blacklist.count(MobileOptimizerType::CONV_BN_FUSION)) {
+  if (!optimization_blocklist.count(MobileOptimizerType::CONV_BN_FUSION)) {
     cloned_module = FoldConvBatchNorm(cloned_module);
   }
 
-  if (!optimization_blacklist.count(
+  if (!optimization_blocklist.count(
           MobileOptimizerType::INSERT_FOLD_PREPACK_OPS)) {
     insertPrePackedOps(cloned_module);
     cloned_module = freeze_module(cloned_module, preserved_methods);
@@ -299,11 +299,11 @@ script::Module optimizeForMobile(
   // will have to explicitly call Inlining pass.
   runCanonicalOptimizations(cloned_module);
 
-  if (!optimization_blacklist.count(MobileOptimizerType::REMOVE_DROPOUT)) {
+  if (!optimization_blocklist.count(MobileOptimizerType::REMOVE_DROPOUT)) {
     removeDropout(cloned_module);
   }
 
-  if (!optimization_blacklist.count(MobileOptimizerType::FUSE_ADD_RELU)) {
+  if (!optimization_blocklist.count(MobileOptimizerType::FUSE_ADD_RELU)) {
     FuseAddRelu(cloned_module);
   }
 
@@ -334,7 +334,7 @@ void FoldPrePackingOps(script::Module& m) {
 
 script::Module optimizeForMobile(
     const script::Module& module,
-    const std::set<MobileOptimizerType>& blacklist,
+    const std::set<MobileOptimizerType>& blocklist,
     const std::vector<std::string>& preserved_methods) {
   TORCH_INTERNAL_ASSERT(
       "Mobile optimizaiton only available with XNNPACK at the moment. "

--- a/torch/csrc/jit/passes/xnnpack_rewrite.h
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.h
@@ -19,7 +19,7 @@ TORCH_API void fusePrePackedLinearConvWithClamp(script::Module& module);
 TORCH_API void FoldPrePackingOps(script::Module& module);
 TORCH_API script::Module optimizeForMobile(
     const script::Module& module,
-    const std::set<MobileOptimizerType>& optimization_blacklist = {},
+    const std::set<MobileOptimizerType>& optimization_blocklist = {},
     const std::vector<std::string>& preserved_methods = {});
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41460 [JIT] Replace use of "whitelist" in lower_tuples pass
* #41459 [JIT] Remove use of "whitelist" in quantization/helper.cpp
* #41458 [JIT] Replace uses of "whitelist" in jit/_script.py
* #41457 [JIT] Replace uses of "blacklist" in jit/_recursive.py
* #41456 [JIT] Replace use of "blacklist" in python/init.cpp
* **#41455 [JIT] Replace use of "blacklist" in xnnpack_rewrite**
* #41454 [JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py
* #41453 [JIT] Replace "blacklist" in test_jit.py

**Test Plan**
Continuous integration.

**Fixes**
This commit partially addresses #41443.

Differential Revision: [D22544275](https://our.internmc.facebook.com/intern/diff/D22544275)