### PR TITLE
[JIT] Replace uses of "blacklist" in jit/_recursive.py

### DIFF
--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -15,7 +15,7 @@ from torch._six import get_function_from_type, bind_method
 ScriptMethodStub = collections.namedtuple('ScriptMethodStub', ('resolution_callback', 'def_', 'original_method'))
 
 # TODO: there should be a more principled way of doing this.
-blacklist = [
+ignored_attributes = [
     "_version",
     "_parameters",
     "_buffers",
@@ -183,7 +183,7 @@ def infer_concrete_type_builder(nn_module):
         concrete_type_builder.add_overload(name, overloaded_names)
 
     for name, value in nn_module.__dict__.items():
-        if name in blacklist or name.startswith("__"):
+        if name in ignored_attributes or name.startswith("__"):
             # Python objects have lots of random attributes attached to them;
             # PyTorch adds a few more. Prevent these from getting compiled.
             continue


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41460 [JIT] Replace use of "whitelist" in lower_tuples pass
* #41459 [JIT] Remove use of "whitelist" in quantization/helper.cpp
* #41458 [JIT] Replace uses of "whitelist" in jit/_script.py
* **#41457 [JIT] Replace uses of "blacklist" in jit/_recursive.py**
* #41456 [JIT] Replace use of "blacklist" in python/init.cpp
* #41455 [JIT] Replace use of "blacklist" in xnnpack_rewrite
* #41454 [JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py
* #41453 [JIT] Replace "blacklist" in test_jit.py

**Test Plan**
Continuous integration.

**Fixes**
This commit partially addresses #41443.

Differential Revision: [D22544274](https://our.internmc.facebook.com/intern/diff/D22544274)