### PR TITLE
[JIT] Replace uses of "whitelist" in jit/_script.py

### DIFF
--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -668,7 +668,7 @@ if _enabled:
             cls, predicate=lambda x: inspect.isfunction(x) or inspect.ismethod(x)
         )
 
-    _compiled_methods_whitelist = {
+    _compiled_methods_allowlist = {
         "forward",
         "register_buffer",
         "register_parameter",
@@ -716,7 +716,7 @@ if _enabled:
             continue
         if (
             name not in RecursiveScriptModule.__dict__
-            and name not in _compiled_methods_whitelist
+            and name not in _compiled_methods_allowlist
         ):
             setattr(RecursiveScriptModule, method.__name__, _make_fail(name))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41460 [JIT] Replace use of "whitelist" in lower_tuples pass
* #41459 [JIT] Remove use of "whitelist" in quantization/helper.cpp
* **#41458 [JIT] Replace uses of "whitelist" in jit/_script.py**
* #41457 [JIT] Replace uses of "blacklist" in jit/_recursive.py
* #41456 [JIT] Replace use of "blacklist" in python/init.cpp
* #41455 [JIT] Replace use of "blacklist" in xnnpack_rewrite
* #41454 [JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py
* #41453 [JIT] Replace "blacklist" in test_jit.py

**Test Plan**
Continuous integration.

**Fixes**
This commit partially fixes #41443.

Differential Revision: [D22544273](https://our.internmc.facebook.com/intern/diff/D22544273)