### PR TITLE
[JIT] Remove use of "whitelist" in quantization/helper.cpp

### DIFF
--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -14,7 +14,7 @@ struct FuncArg {
 using AtenFuncArgs = std::vector<FuncArg>;
 using CallFuncArgs = std::vector<FuncArg>;
 
-// White lists for quantizable operators
+// Lists of allowed quantizable operators
 std::vector<std::string> _static_quantizable_call_funcs = {
     "conv2d",
     "linear",

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -14,7 +14,7 @@ struct FuncArg {
 using AtenFuncArgs = std::vector<FuncArg>;
 using CallFuncArgs = std::vector<FuncArg>;
 
-// Lists of allowed quantizable operators
+// Lists of supported quantizable operators
 std::vector<std::string> _static_quantizable_call_funcs = {
     "conv2d",
     "linear",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41460 [JIT] Replace use of "whitelist" in lower_tuples pass
* **#41459 [JIT] Remove use of "whitelist" in quantization/helper.cpp**
* #41458 [JIT] Replace uses of "whitelist" in jit/_script.py
* #41457 [JIT] Replace uses of "blacklist" in jit/_recursive.py
* #41456 [JIT] Replace use of "blacklist" in python/init.cpp
* #41455 [JIT] Replace use of "blacklist" in xnnpack_rewrite
* #41454 [JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py
* #41453 [JIT] Replace "blacklist" in test_jit.py

**Test Plan**
Continuous integration.

**Fixes**
This commit partially addresses #41443.

Differential Revision: [D22544269](https://our.internmc.facebook.com/intern/diff/D22544269)