### PR TITLE
[JIT] Replace use of "whitelist" in lower_tuples pass

### DIFF
--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -12,7 +12,7 @@ namespace {
 // operators where we expect to find tuples as inputs/outputs
 // this is to assert we are only doing modifications when we know
 // we can flatten tuples
-std::unordered_set<Symbol> white_list = {
+std::unordered_set<Symbol> supported_ops = {
     prim::If,
     prim::Loop,
     prim::TupleUnpack,
@@ -128,7 +128,7 @@ static void VisitNode(Node* n, Node* insert_point) {
     auto input = n->inputs()[i];
     if (TupleTypePtr tt = input->type()->cast<TupleType>()) {
       TORCH_CHECK(
-          white_list.count(n->kind()) > 0,
+          supported_ops.count(n->kind()) > 0,
           "tuple appears in op that does not forward tuples, ",
           "unsupported kind: ",
           n->kind().toQualString());
@@ -163,7 +163,7 @@ static void VisitNode(Node* n, Node* insert_point) {
     // is placed at the current insertion point
     if (TupleTypePtr tt = output->type()->cast<TupleType>()) {
       TORCH_CHECK(
-          white_list.count(n->kind()) > 0,
+          supported_ops.count(n->kind()) > 0,
           "tuple appears in op that does not forward tuples, ",
           "unsupported kind: ",
           n->kind().toQualString());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41460 [JIT] Replace use of "whitelist" in lower_tuples pass**
* #41459 [JIT] Remove use of "whitelist" in quantization/helper.cpp
* #41458 [JIT] Replace uses of "whitelist" in jit/_script.py
* #41457 [JIT] Replace uses of "blacklist" in jit/_recursive.py
* #41456 [JIT] Replace use of "blacklist" in python/init.cpp
* #41455 [JIT] Replace use of "blacklist" in xnnpack_rewrite
* #41454 [JIT] Replace uses of "blacklist" in gen_unboxing_wrappers.py
* #41453 [JIT] Replace "blacklist" in test_jit.py

**Test Plan**
Continuous integration.

**Fixes**
This commit partially addresses #41443.

Differential Revision: [D22544272](https://our.internmc.facebook.com/intern/diff/D22544272)