### PR TITLE
During inbatch broadcast, move Tile op after Fused8BitRowwiseQuantizedToFloat if applicable

### DIFF
--- a/caffe2/operators/tile_op.cc
+++ b/caffe2/operators/tile_op.cc
@@ -8,6 +8,7 @@ template <>
 bool TileOp<CPUContext>::RunOnDevice() {
   return DispatchHelper<TensorTypes<
       at::Half,
+      std::uint8_t,
       std::int32_t,
       std::int64_t,
       float,

--- a/caffe2/opt/custom/in_batch_broadcast.cc
+++ b/caffe2/opt/custom/in_batch_broadcast.cc
@@ -9,14 +9,94 @@ const std::string kTILE_SUFFIX = "_tile";
 
 void inBatchBroadcast(
     NetDef* net,
-    std::unordered_set<std::string>& to_broadcast_blobs,
+    const std::unordered_set<std::string>& to_broadcast_blobs,
     int32_t batch_size,
     ShapeInfoMap& shape_hints) {
   int current_pos = net->op_size();
   caffe2::NetDef broadcast_net;
   broadcast_net.CopyFrom(*net);
   broadcast_net.clear_op();
-  for (auto& blob : to_broadcast_blobs) {
+  std::vector<OperatorDef> pre_ops;
+  std::vector<OperatorDef> post_ops;
+
+  // Heuristic: if any of to_broadcast_blobs is connected to
+  // Fused8BitRowwiseQuantizedToFloat only, we move Tile after
+  // Fused8BitRowwiseQuantizedToFloat to save some compute.
+  std::unordered_map<std::string, int> consumers;
+  for (const auto& op : net->op()) {
+    for (const auto& i : op.input()) {
+      if (to_broadcast_blobs.count(i)) {
+        consumers[i] += 1;
+      }
+    }
+  }
+  std::unordered_map<std::string, std::string> to_broadcast_replace;
+  for (const auto& op : net->op()) {
+    bool match = false;
+    if (op.type() == "Fused8BitRowwiseQuantizedToFloat") {
+      CAFFE_ENFORCE_EQ(
+          op.input_size(),
+          1,
+          "Fused8BitRowwiseQuantizedToFloat can only have 1 input");
+      CAFFE_ENFORCE_EQ(
+          op.output_size(),
+          1,
+          "Fused8BitRowwiseQuantizedToFloat can only have 1 output");
+      const auto it = consumers.find(op.input(0));
+      if (it != consumers.end() && it->second == 1) {
+        match = true;
+      }
+    }
+    if (match) {
+      to_broadcast_replace.emplace(op.input(0), op.output(0));
+      pre_ops.emplace_back(op);
+    } else {
+      post_ops.emplace_back(op);
+    }
+  }
+  // Build a reverse mapping. Not that such mapping is bijective, because if it
+  // is not, some key will have multiple consumers, which violates the single
+  // consumer condition above.
+  std::unordered_map<std::string, std::string> reversed;
+  for (const auto& kv : to_broadcast_replace) {
+    reversed.emplace(kv.second, kv.first);
+  }
+
+  std::unordered_set<std::string> to_broadcast_copy;
+  for (const auto& b : to_broadcast_blobs) {
+    const auto it = to_broadcast_replace.find(b);
+    if (it != to_broadcast_replace.end()) {
+      to_broadcast_copy.emplace(it->second);
+    } else {
+      to_broadcast_copy.emplace(b);
+    }
+  }
+  for (const auto& op : pre_ops) {
+    broadcast_net.add_op()->CopyFrom(op);
+  }
+
+  auto setShape = [&shape_hints, batch_size](
+                      const std::string& blob,
+                      const std::string& new_blob) mutable {
+    auto it = shape_hints.find(blob);
+    CAFFE_ENFORCE(it != shape_hints.end(), "Cannot find shape info for ", blob);
+    auto& shape = it->second;
+    CAFFE_ENFORCE(shape.shape.dims_size(), "Dim size for ", blob, " is 0");
+    if (!new_blob.empty()) {
+      shape_hints.emplace(new_blob, shape);
+    }
+    CAFFE_ENFORCE_EQ(
+        shape.shape.dims(0) % batch_size,
+        0,
+        "Dims(0) for ",
+        blob,
+        ": ",
+        shape.shape.dims(0),
+        " cannot be divided by batch_size ");
+    shape.shape.set_dims(0, shape.shape.dims(0) / batch_size);
+    shape.setDimType(0, TensorBoundShape_DimType_CONSTANT);
+  };
+  for (const auto& blob : to_broadcast_copy) {
     auto new_blob = blob + kTILE_SUFFIX;
     auto* op = broadcast_net.add_op();
     op->CopyFrom(CreateOperatorDef(
@@ -29,26 +109,17 @@ void inBatchBroadcast(
          // Indicating that we are tiling to max_batch_size
          MakeArgument<int>("dynamic", 1),
          MakeArgument<int>("net_pos", current_pos++)}));
-    auto it = shape_hints.find(blob);
-    CAFFE_ENFORCE(it != shape_hints.end(), "Cannot find shape info for ", blob);
-    auto& shape = it->second;
-    CAFFE_ENFORCE(shape.shape.dims_size(), "Dim size for ", blob, " is 0");
-    shape_hints.emplace(new_blob, shape);
-    CAFFE_ENFORCE_EQ(
-        shape.shape.dims(0) % batch_size,
-        0,
-        "Dims(0) for ",
-        blob,
-        ": ",
-        shape.shape.dims(0),
-        " cannot be divided by batch_size ");
-    shape.shape.set_dims(0, shape.shape.dims(0) / batch_size);
-    shape.setDimType(0, TensorBoundShape_DimType_CONSTANT);
+    setShape(blob, new_blob);
+    const auto rit = reversed.find(blob);
+    if (rit != reversed.end()) {
+      const auto& orignal_input = rit->second;
+      setShape(orignal_input, "");
+    }
   }
 
-  for (auto op : net->op()) {
+  for (auto& op : post_ops) {
     for (int j = 0; j < op.input_size(); j++) {
-      if (to_broadcast_blobs.count(op.input(j))) {
+      if (to_broadcast_copy.count(op.input(j))) {
         *op.mutable_input(j) = op.input(j) + kTILE_SUFFIX;
       }
     }

--- a/caffe2/opt/custom/in_batch_broadcast.h
+++ b/caffe2/opt/custom/in_batch_broadcast.h
@@ -15,7 +15,7 @@ namespace opt {
 // Add Tile ops for some input tensors
 void inBatchBroadcast(
     NetDef* net,
-    std::unordered_set<std::string>& to_broadcast_blobs,
+    const std::unordered_set<std::string>& to_broadcast_blobs,
     int32_t batch_size,
     ShapeInfoMap& shape_hints);
 

--- a/caffe2/opt/custom/in_batch_broadcast_test.cc
+++ b/caffe2/opt/custom/in_batch_broadcast_test.cc
@@ -112,4 +112,59 @@ TEST(InBatchBroadcast, main) {
   checkShapeInfo(shape_map, expected_shape_map);
 }
 
+TEST(InBatchBroadcast, fuse8bit) {
+  NetDef net;
+  net.add_op()->CopyFrom(CreateOperatorDef(
+      "Fused8BitRowwiseQuantizedToFloat", "", {"blob_int8"}, {"blob"}, {}));
+  ShapeInfoMap shape_map;
+  shape_map.emplace(
+      "blob_int8",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 24},
+          TensorProto_DataType_UINT8));
+  shape_map.emplace(
+      "blob",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 16}));
+  std::unordered_set<std::string> transform_blob({"blob_int8"});
+  opt::inBatchBroadcast(&net, transform_blob, 32, shape_map);
+  NetDef expected_net;
+  auto* op1 = expected_net.add_op();
+  op1->CopyFrom(CreateOperatorDef(
+      "Fused8BitRowwiseQuantizedToFloat", "", {"blob_int8"}, {"blob"}, {}));
+  op1->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
+  auto* op2 = expected_net.add_op();
+  op2->CopyFrom(CreateOperatorDef(
+      "Tile",
+      "",
+      {"blob"},
+      {"blob_tile"},
+      {MakeArgument<int>("tiles", 32),
+       MakeArgument<int>("axis", 0),
+       MakeArgument<int>("dynamic", 1)}));
+  op2->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
+  ShapeInfoMap expected_shape_map;
+  expected_shape_map.emplace(
+      "blob_int8",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 24},
+          TensorProto_DataType_UINT8));
+  expected_shape_map.emplace(
+      "blob",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 16}));
+  expected_shape_map.emplace(
+      "blob_tile",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 16}));
+  checkNet(net, expected_net);
+  checkShapeInfo(shape_map, expected_shape_map);
+}
 } // namespace


### PR DESCRIPTION
Summary:
If input is int8 rowwise quantized, currently we cannot low it to Glow. And previously, we had some error when running with inbatch broadcast. The main issue is that Tile op doesn't support uint8_t type, which is very easily added here. However, this will result in non-ideal situation that we will leave Tile -> Fused8BitRowwiseQuantizedToFloat on host side, which probably hurt the memory bw a lot. Even we later add the support to Fused8BitRowwiseQuantizedToFloat in Glow, it's still not ideal because we are doing redudant compute on identical columns. So the solution here is to swap the order of Fused8BitRowwiseQuantizedToFloat and Tile to make it Tile -> Fused8BitRowwiseQuantizedToFloat. In this way, it will resolve the error we saw immediately. For the short term, we can still run Tile in card. And for longer term, things runs faster on card.

The optimization is a heuristic. If in the net, there isn't such pattern, inbatch broadcast will work as it was before.

Test Plan:
```
buck test caffe2/caffe2/opt/custom:in_batch_broadcast_test
```

Differential Revision: D22544162

