### PR TITLE
caffe2: add PIPELINE tag

### DIFF
--- a/caffe2/python/layers/tags.py
+++ b/caffe2/python/layers/tags.py
@@ -59,6 +59,7 @@ class Tags(object):
     parameter server.
     """
     COMPONENT = 'component:'
+    PIPELINE = 'pipeline:'
     """
     Valid tag prefixes for distributed training framework.
     """


### PR DESCRIPTION
Summary: This adds a new tag for use with pipeline parallelism.

Test Plan: CI

Differential Revision: D22551487

