### PR TITLE
Adding epsilon input argument to the Logit Op

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -124,10 +124,8 @@ class UnaryOpTest(serial.SerializedTestCase):
         workspace.ResetWorkspace()
         n = 1
         m = 10001
-        if opname == "Logit":
-            X = np.linspace(0, value, num=m, dtype=np.float32)
-        else:
-            X = np.linspace(-value, value, num=m, dtype=np.float32)
+
+        X = np.linspace(-value, value, num=m, dtype=np.float32)
         pred_net = caffe2_pb2.NetDef()
         pred_net.name = "pred"
         pred_net.external_input.append("X")
@@ -194,9 +192,68 @@ class UnaryOpTest(serial.SerializedTestCase):
     def test_swish(self):
         self._test_unary_op("Swish", value=20, atol=0.008)
 
-    def _test_logit(self):
-        self._test_unary_op("Logit", value=1)
+    @settings(max_examples=1)
+    def test_logit(self):
+        workspace.ResetWorkspace()
+        n = 1
+        m = 15361
+        X = np.linspace(0, 1, num=m, dtype=np.float32)
 
+        pred_net = caffe2_pb2.NetDef()
+        pred_net.name = "pred"
+        pred_net.external_input.append("X")
+        pred_net.external_output.append("Y")
+        pred_net.op.add().CopyFrom(
+            core.CreateOperator(
+                'Logit',
+                ['X'],
+                ['Y'],
+                eps=1e-8)
+        )
+        ref_net = caffe2_pb2.NetDef()
+        ref_net.name = "ref"
+        ref_net.external_input.append("X")
+        ref_net.external_output.append("Y")
+        ref_net.op.add().CopyFrom(
+            core.CreateOperator(
+                'LogitFakeFp16NNPI',
+                ['X'],
+                ['Y'],
+                eps=1e-8)
+        )
+        print("REF NET = {}".format(ref_net))
+
+        shape_hints = {"X": (n, m)}
+        pred_net_onnxified = onnxifi_caffe2_net(pred_net,
+                                                shape_hints,
+                                                debug=True,
+                                                adjust_batch=False,
+                                                use_onnx=False)
+        num_onnxified_ops = sum(
+            1 if o.type == "Onnxifi" else 0 for o in pred_net_onnxified.op)
+        np.testing.assert_equal(num_onnxified_ops, 1)
+        workspace.SwitchWorkspace("glow_test_ws", True)
+        workspace.FeedBlob("X", X)
+        workspace.CreateNet(ref_net)
+        workspace.CreateNet(pred_net_onnxified)
+        # Run Glow net
+        workspace.RunNet(pred_net_onnxified.name)
+        Y_glow = workspace.FetchBlob('Y')
+        # Run caffe2 reference net
+        workspace.RunNet(ref_net.name)
+        Y_c2 = workspace.FetchBlob('Y')
+
+        diff = np.abs(Y_c2 - Y_glow)
+        if np.nanmax(diff) > 9e-3:
+            np.save('/tmp/logit_diff', diff)
+            np.save('/tmp/logit_result', Y_c2)
+            print_test_debug_info('Logit', {
+                "X": X,
+                "Y_c2": Y_c2,
+                "Y_glow": Y_glow,
+                "diff": diff
+            })
+            assert(0)
 
 class ReluTest(serial.SerializedTestCase):
     @given(seed=st.integers(0, 65534))

--- a/caffe2/contrib/fakelowp/unary_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/unary_fp16_fake_op.cc
@@ -3,6 +3,9 @@
 #include <fbgemm/FbgemmConvert.h>
 #include "caffe2/utils/eigen_utils.h"
 #include "caffe2/contrib/fakelowp/fp16_fma.h"
+#include "caffe2/core/operator.h"
+
+C10_DECLARE_bool(caffe2_fbgemm_fake_fp16_clamp);
 
 namespace caffe2 {
 
@@ -529,8 +532,7 @@ at::Half CalcSwishByLUT(at::Half x) {
   return at::Half(res1 + res2);
 }
 
-at::Half CalcLogit(at::Half input) {
-  float eps = at::Half(1e-6); //default eps value
+at::Half CalcLogit(at::Half input, float eps) {
   float x = clamp(at::Half(input), at::Half(eps), at::Half(1 - eps));
   if (x < 0.0f || x > 1.0f) {
     return at::Half(NAN);
@@ -836,17 +838,39 @@ struct SwishEmulatorFunctor {
   }
 };
 
-struct LogitEmulatorFunctor {
-  bool operator()(
-      const int N,
-      const float* X,
-      float* Y,
-      CPUContext* /* unused */) const {
+template <class Context>
+class LogitEmulatorFunctor final : public Operator<Context> {
+public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  template <class... Args>
+  explicit LogitEmulatorFunctor(Args&&... args)
+      : Operator<CPUContext>(std::forward<Args>(args)...),
+        OP_SINGLE_ARG(float, "eps", eps_, 1e-6f) {}
+  ~LogitEmulatorFunctor() noexcept override {}
+
+  bool RunOnDevice() override {
+    const auto& X = Input(0);
+    const int N = X.numel();
+    auto* Y = Output(0, X.sizes(), at::dtype<float>());
+    Y->ResizeLike(X);
+    const float* X_data = X.template data<float>();
+    float* Y_data = Y->template mutable_data<float>();
+    std::vector<float> X_rounded(N);
+    fbgemm::RoundToFloat16(
+        X_data,
+        X_rounded.data(),
+        N,
+        FLAGS_caffe2_fbgemm_fake_fp16_clamp);
+    X_data = X_rounded.data();
     for (int i = 0; i < N; i++) {
-      Y[i] = CalcLogit((at::Half)X[i]);
+      Y_data[i] = CalcLogit((at::Half)X_data[i], eps_);
     }
     return true;
   }
+
+private:
+  const float eps_;
 };
 
 REGISTER_CPU_OPERATOR(
@@ -877,7 +901,7 @@ The input and output of this operator are converted to fp16 precision.
 
 REGISTER_CPU_OPERATOR(
     LogitFakeFp16NNPI,
-    UnaryElementwiseOp<TensorTypes<float>, CPUContext, LogitEmulatorFunctor>);
+    LogitEmulatorFunctor<CPUContext>);
 
 OPERATOR_SCHEMA(LogitFakeFp16NNPI)
     .NumInputs(1)


### PR DESCRIPTION
Summary: Adding epsilon input argument to the Logit Op

Test Plan: Added test_logit test case.

Reviewed By: hyuen

Differential Revision: D22537133

