### PR TITLE
retain undefined tensors in backward pass

### DIFF
--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -303,16 +303,7 @@ variable_list CppNode<T>::apply(variable_list&& inputs) {
       }
       continue;
     }
-    if (!outputs[i].defined()) {
-      auto& info = input_info_[results.size()];
-      if (info.requires_grad) {
-        results.emplace_back(info.zeros(_device_guard));
-      } else {
-        results.emplace_back();
-      }
-    } else {
-      results.emplace_back(outputs[i]);
-    }
+    results.emplace_back(outputs[i]);
   }
   return results;
 }

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -171,12 +171,7 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
       continue;
     }
     if (output == Py_None) {
-      auto& info = input_info[results.size()];
-      if (info.requires_grad) {
-        results.emplace_back(info.zeros(_device_guard));
-      } else {
-        results.emplace_back();
-      }
+      results.emplace_back();
     } else {
       if (!THPVariable_Check(output)) {
         std::string msg("expected Variable or None (got ");
@@ -779,8 +774,6 @@ PyObject * THPFunction_do_backward(THPFunction *self, PyObject *args)
         "gradient tensors (expected %d, but got %d)", THPUtils_typename(self),
         num_outputs, num_grads);
 
-    // If any of the remaining grad_inputs are None, zero them.
-    _prepare_grads(self, grad_input, false);
     return grad_input.release();
 
   } catch (python_error& e) {


### PR DESCRIPTION
Leave undefined tensors / None returned from custom backward functions as undefined/None instead of creating a tensor full of zeros. This change improves performance in some cases.

**This is BC-Breaking:** Custom backward functions that return None will now see it potentially being propagated all the way up to AccumulateGrad nodes. Potential impact is that .grad field of leaf tensors as well as the result of autograd.grad may be undefined/None where it used to be a tensor full of zeros. Also, autograd.grad may raise an error, if so, consider using allow_unused=True ([see doc](https://pytorch.org/docs/stable/autograd.html?highlight=autograd%20grad#torch.autograd.grad)) if it applies to your case.