### PR TITLE
Update clang code coverage option in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ option(BUILD_JNI "Build JNI bindings" OFF)
 cmake_dependent_option(
     INSTALL_TEST "Install test binaries if BUILD_TEST is on" ON
     "BUILD_TEST" OFF)
-option(CLANG_CODE_COVERAGE "Compile C/C++ with clang code coverage flags" OFF)
+option(CLANG_CODE_COVERAGE "Compile C++ with clang code coverage flags" OFF)
 option(COLORIZE_OUTPUT "Colorize output during compilation" ON)
 option(USE_ASAN "Use Address Sanitizer" OFF)
 option(USE_TSAN "Use Thread Sanitizer" OFF)
@@ -598,8 +598,7 @@ endif()
 
 # invoke clang code coverage flags
 if(CLANG_CODE_COVERAGE)
-  list(APPEND CMAKE_C_FLAGS  -fprofile-instr-generate -fcoverage-mapping)
-  list(APPEND CMAKE_CXX_FLAGS  -fprofile-instr-generate -fcoverage-mapping)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 endif()
 
 if(APPLE)


### PR DESCRIPTION
Summary:
Made some mistakes last time
1. Should use Set(...) instead of List(Append ...).
Reason:  1) in this CMakeList.txt, when it comes to CMAKE_CXX_FLAGS, it all show with set(...).
         2) list(Append) doesn't seem to work here. When I revise code to this style, a build error says
clang-10: error: no input files
/bin/sh: -fprofile-instr-generate: command not found
/bin/sh: -fcoverage-mapping: command not found

2. Delete C code coverage compiler option.
Reason: in this CMakeList.txt, we hardly see "CMAKE_C_FLAGS" but a lot of "CMAKE_CXX_FLAGS". Therefore we also don't "C_FLAGS" here.

Test Plan: Download Pytorch from github, add these options and test it as last time.

Differential Revision: D22543853

