### PR TITLE
[JIT] handle specially mapped ops

### DIFF
--- a/test/jit/test_remove_mutation.py
+++ b/test/jit/test_remove_mutation.py
@@ -162,6 +162,19 @@ class TestRemoveMutation(JitTestCase):
         FileCheck().check_not("aten::zero_").check_not("aten::fill_").run(graph)
         self.assertEqual(test_successful(), fn())
 
+        # full_like is not implemented for a tensor fill value
+
+        def test_unsuccessful():
+            x = torch.tensor([2, 2])
+            y = torch.tensor([2, 4])
+            x.fill_(y)
+            return x + x
+
+        fn = torch.jit.script(test_unsuccessful)
+        graph = fn.graph
+        self.run_pass('remove_mutation', graph)
+        FileCheck().check('aten::fill_').run(graph)
+
     def test_lists_append(self):
         def successful_remove():
             return [i for i in range(5)]  # noqa: C416

--- a/test/jit/test_remove_mutation.py
+++ b/test/jit/test_remove_mutation.py
@@ -148,6 +148,20 @@ class TestRemoveMutation(JitTestCase):
         self.run_pass('remove_mutation', foo.graph)
         FileCheck().check("aten::add_").run(foo.graph)
 
+    def test_special_mapped_op(self):
+        def test_successful():
+            x = torch.tensor([2, 2])
+            y = torch.tensor([2, 4])
+            x.zero_()
+            y.fill_(3)
+            return x, y
+
+        fn = torch.jit.script(test_successful)
+        graph = fn.graph
+        self.run_pass('remove_mutation', graph)
+        FileCheck().check_not("aten::zero_").check_not("aten::fill_").run(graph)
+        self.assertEqual(test_successful(), fn())
+
     def test_lists_append(self):
         def successful_remove():
             return [i for i in range(5)]  # noqa: C416

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -41,9 +41,8 @@ struct MutationRemover {
             "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)");
   }
 
-  Node* replaceSpecialMappedOp(Node* n) {
+  Node* createSpecialMappedOp(Node* n) {
     WithInsertPoint guard(n);
-    TORCH_INTERNAL_ASSERT(isSpecialMappedOp(n));
     auto inputs = n->inputs();
     Node* new_node;
     if (n->matches(
@@ -213,7 +212,7 @@ struct MutationRemover {
 
       Node* new_node;
       if (isSpecialMappedOp(node)) {
-        new_node = replaceSpecialMappedOp(node);
+        new_node = createSpecialMappedOp(node);
       } else {
         auto schema_name = node->schema().name();
         auto new_schema = schema_name.substr(0, schema_name.size() - 1);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41503 [JIT] handle specially mapped ops**
* #41502 [JIT] move remove mutation to its own test file

Fix for https://github.com/pytorch/pytorch/issues/41192

We can map fill_ and zero_ to their functional equivalents full_like and zeros_like

Differential Revision: [D22629269](https://our.internmc.facebook.com/intern/diff/D22629269)