### PR TITLE
Move GLOG_ constants into c10 namespace

### DIFF
--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -209,7 +209,7 @@ void ShowLogInfoToStderr() {
 
 C10_DEFINE_int(
     caffe2_log_level,
-    ::google::GLOG_WARNING,
+    c10::GLOG_WARNING,
     "The minimum log level that caffe2 will output.");
 
 namespace c10 {
@@ -225,11 +225,11 @@ bool InitCaffeLogging(int* argc, char** argv) {
               << std::endl;
     return false;
   }
-  if (FLAGS_caffe2_log_level > ::google::GLOG_FATAL) {
+  if (FLAGS_caffe2_log_level > GLOG_FATAL) {
     std::cerr << "The log level of Caffe2 has to be no larger than GLOG_FATAL("
-              << ::google::GLOG_FATAL << "). Capping it to GLOG_FATAL."
+              << GLOG_FATAL << "). Capping it to GLOG_FATAL."
               << std::endl;
-    FLAGS_caffe2_log_level = ::google::GLOG_FATAL;
+    FLAGS_caffe2_log_level = GLOG_FATAL;
   }
   return true;
 }
@@ -237,7 +237,7 @@ bool InitCaffeLogging(int* argc, char** argv) {
 void UpdateLoggingLevelsFromFlags() {}
 
 void ShowLogInfoToStderr() {
-  FLAGS_caffe2_log_level = ::google::GLOG_INFO;
+  FLAGS_caffe2_log_level = GLOG_INFO;
 }
 
 MessageLogger::MessageLogger(const char* file, int line, int severity)
@@ -262,7 +262,7 @@ MessageLogger::MessageLogger(const char* file, int line, int severity)
   */
   stream_
       << "["
-      << CAFFE2_SEVERITY_PREFIX[std::min(4, ::google::GLOG_FATAL - severity_)]
+      << CAFFE2_SEVERITY_PREFIX[std::min(4, GLOG_FATAL - severity_)]
       //<< (timeinfo->tm_mon + 1) * 100 + timeinfo->tm_mday
       //<< std::setfill('0')
       //<< " " << std::setw(2) << timeinfo->tm_hour
@@ -290,12 +290,12 @@ MessageLogger::~MessageLogger() {
       ANDROID_LOG_VERBOSE, // VLOG(2) .. VLOG(N)
   };
   int android_level_index =
-      ::google::GLOG_FATAL - std::min(::google::GLOG_FATAL, severity_);
+      GLOG_FATAL - std::min(GLOG_FATAL, severity_);
   int level = android_log_levels[std::min(android_level_index, 5)];
   // Output the log string the Android log at the appropriate level.
   __android_log_print(level, tag_, "%s", stream_.str().c_str());
   // Indicate termination if needed.
-  if (severity_ == ::google::GLOG_FATAL) {
+  if (severity_ == GLOG_FATAL) {
     __android_log_print(ANDROID_LOG_FATAL, tag_, "terminating.\n");
   }
 #else // !ANDROID
@@ -305,12 +305,12 @@ MessageLogger::~MessageLogger() {
     // Simulating the glog default behavior: if the severity is above INFO,
     // we flush the stream so that the output appears immediately on std::cerr.
     // This is expected in some of our tests.
-    if (severity_ > ::google::GLOG_INFO) {
+    if (severity_ > GLOG_INFO) {
       std::cerr << std::flush;
     }
   }
 #endif // ANDROID
-  if (severity_ == ::google::GLOG_FATAL) {
+  if (severity_ == GLOG_FATAL) {
     DealWithFatal();
   }
 }

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -14,17 +14,16 @@
 
 #include <c10/util/Flags.h>
 
+const char CAFFE2_SEVERITY_PREFIX[] = "FEWIV";
+
+namespace c10 {
+
 // Log severity level constants.
-namespace google {
 const int GLOG_FATAL = 3;
 const int GLOG_ERROR = 2;
 const int GLOG_WARNING = 1;
 const int GLOG_INFO = 0;
-} // namespace google
 
-const char CAFFE2_SEVERITY_PREFIX[] = "FEWIV";
-
-namespace c10 {
 class C10_API MessageLogger {
  public:
   MessageLogger(const char* file, int line, int severity);
@@ -59,7 +58,7 @@ class C10_API LoggerVoidify {
 // Log a message and terminate.
 template <class T>
 void LogMessageFatal(const char* file, int line, const T& message) {
-  MessageLogger(file, line, ::google::GLOG_FATAL).stream() << message;
+  MessageLogger(file, line, GLOG_FATAL).stream() << message;
 }
 
 // Helpers for CHECK_NOTNULL(). Two are necessary to support both raw pointers
@@ -86,20 +85,20 @@ T& CheckNotNull(const char* file, int line, const char* names, T& t) {
 // ---------------------- Logging Macro definitions --------------------------
 
 static_assert(
-    CAFFE2_LOG_THRESHOLD <= ::google::GLOG_FATAL,
+    CAFFE2_LOG_THRESHOLD <= ::c10::GLOG_FATAL,
     "CAFFE2_LOG_THRESHOLD should at most be GLOG_FATAL.");
 // If n is under the compile time caffe log threshold, The _CAFFE_LOG(n)
 // should not generate anything in optimized code.
 #define LOG(n)                                    \
-  if (::google::GLOG_##n >= CAFFE2_LOG_THRESHOLD) \
-  ::c10::MessageLogger((char*)__FILE__, __LINE__, ::google::GLOG_##n).stream()
+  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD) \
+  ::c10::MessageLogger((char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
 #define VLOG(n)                   \
   if (-n >= CAFFE2_LOG_THRESHOLD) \
   ::c10::MessageLogger((char*)__FILE__, __LINE__, -n).stream()
 
 #define LOG_IF(n, condition)                                     \
-  if (::google::GLOG_##n >= CAFFE2_LOG_THRESHOLD && (condition)) \
-  ::c10::MessageLogger((char*)__FILE__, __LINE__, ::google::GLOG_##n).stream()
+  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD && (condition)) \
+  ::c10::MessageLogger((char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
 #define VLOG_IF(n, condition)                    \
   if (-n >= CAFFE2_LOG_THRESHOLD && (condition)) \
   ::c10::MessageLogger((char*)__FILE__, __LINE__, -n).stream()
@@ -109,15 +108,15 @@ static_assert(
 // Log with source location information override (to be used in generic
 // warning/error handlers implemented as functions, not macros)
 #define LOG_AT_FILE_LINE(n, file, line)           \
-  if (::google::GLOG_##n >= CAFFE2_LOG_THRESHOLD) \
-  ::c10::MessageLogger(file, line, ::google::GLOG_##n).stream()
+  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD) \
+  ::c10::MessageLogger(file, line, ::c10::GLOG_##n).stream()
 
 // Log only if condition is met.  Otherwise evaluates to void.
 #define FATAL_IF(condition)                                    \
   condition ? (void)0                                          \
             : ::c10::LoggerVoidify() &                         \
           ::c10::MessageLogger(                                \
-              (char*)__FILE__, __LINE__, ::google::GLOG_FATAL) \
+              (char*)__FILE__, __LINE__, ::c10::GLOG_FATAL) \
               .stream()
 
 // Check for a given boolean condition.


### PR DESCRIPTION
Declaring GLOG_ constants in google namespace causes a conflict in C++ project that uses GLOG and links with LibPyTorch compiled without GLOG.
For example, see https://github.com/facebookresearch/ReAgent/issues/288

