### PR TITLE
Assert valid inner type for OptionalType creation

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -277,6 +277,7 @@ using OptionalTypePtr = std::shared_ptr<OptionalType>;
 struct CAFFE2_API OptionalType
     : public SingleElementType<TypeKind::OptionalType, OptionalType> {
   static OptionalTypePtr create(TypePtr element) {
+    TORCH_INTERNAL_ASSERT(element, "OptionalType requires valid TypePtr");
     // Optional is a union of [None, T], so Optional[[Optional[T]]] ->
     // Optional[T]
     if (auto opt_ptr = element->cast<OptionalType>()) {

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -257,9 +257,11 @@ def try_ann_to_type(ann, loc):
         return DictType(key, value)
     if is_optional(ann):
         if issubclass(ann.__args__[1], type(None)):
-            return OptionalType(try_ann_to_type(ann.__args__[0], loc))
+            valid_type = try_ann_to_type(ann.__args__[0], loc)
         else:
-            return OptionalType(try_ann_to_type(ann.__args__[1], loc))
+            valid_type = try_ann_to_type(ann.__args__[1], loc)
+        assert valid_type, "Unsupported annotation {} could not be resolved.".format(repr(ann))
+        return OptionalType(valid_type)
     if torch.distributed.rpc.is_available() and is_rref(ann):
         return RRefType(try_ann_to_type(ann.__args__[0], loc))
     if is_future(ann):

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -260,7 +260,7 @@ def try_ann_to_type(ann, loc):
             valid_type = try_ann_to_type(ann.__args__[0], loc)
         else:
             valid_type = try_ann_to_type(ann.__args__[1], loc)
-        assert valid_type, "Unsupported annotation {} could not be resolved.".format(repr(ann))
+        assert valid_type, "Unsupported annotation '{}' could not be resolved.".format(repr(ann))
         return OptionalType(valid_type)
     if torch.distributed.rpc.is_available() and is_rref(ann):
         return RRefType(try_ann_to_type(ann.__args__[0], loc))


### PR DESCRIPTION
Assert in OptionalType::create for valid TypePtr to catch all uses, as well as in python resolver to propagate slightly more helpful error message.

Closes #40713. 