### PR TITLE
Removes assertAlmostEqual

### DIFF
--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -247,7 +247,7 @@ class TestObserver(QuantizationTestCase):
                     ref_scale = 0.0313725
                     ref_zero_point = -128 if qdtype is torch.qint8 else 0
             self.assertEqual(qparams[1].item(), ref_zero_point)
-            self.assertAlmostEqual(qparams[0].item(), ref_scale, delta=1e-5)
+            self.assertEqual(qparams[0].item(), ref_scale, atol=1e-5, rtol=0)
             state_dict = myobs.state_dict()
             b = io.BytesIO()
             torch.save(state_dict, b)
@@ -474,7 +474,7 @@ class TestRecordHistogramObserver(QuantizationTestCase):
                 ref_zero_point = -128 if qdtype is torch.qint8 else 0
 
         self.assertEqual(qparams[1].item(), ref_zero_point)
-        self.assertAlmostEqual(qparams[0].item(), ref_scale, delta=1e-5)
+        self.assertEqual(qparams[0].item(), ref_scale, atol=1e-5, rtol=0)
         # Test for serializability
         state_dict = myobs.state_dict()
         b = io.BytesIO()

--- a/test/test_bundled_inputs.py
+++ b/test/test_bundled_inputs.py
@@ -70,8 +70,8 @@ class TestBundledInputs(TestCase):
         # This tensor is random, but with 100,000 trials,
         # mean and std had ranges of (-0.0154, 0.0144) and (0.9907, 1.0105).
         self.assertEqual(inflated[5][0].shape, (1 << 16,))
-        self.assertAlmostEqual(inflated[5][0].mean().item(), 0, delta=0.025)
-        self.assertAlmostEqual(inflated[5][0].std().item(), 1, delta=0.02)
+        self.assertEqual(inflated[5][0].mean().item(), 0, atol=0.025, rtol=0)
+        self.assertEqual(inflated[5][0].std().item(), 1, atol=0.02, rtol=0)
 
 
     def test_large_tensor_with_inflation(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -998,8 +998,7 @@ class TestDistributions(TestCase):
             def ref_log_prob(idx, x, log_prob):
                 p = probs.view(-1)[idx].item()
                 expected = scipy.stats.binom(total_count, p).logpmf(x)
-                self.assertAlmostEqual(log_prob, expected, places=3)
-
+                self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
             self._check_log_prob(Binomial(total_count, probs), ref_log_prob)
             logits = probs_to_logits(probs, is_binary=True)
             self._check_log_prob(Binomial(total_count, logits=logits), ref_log_prob)
@@ -1023,7 +1022,7 @@ class TestDistributions(TestCase):
                                     (torch.tensor([1, 2, 10]), torch.tensor([0., 1., 9.]))]:
             log_prob = Binomial(total_count, probs).log_prob(sample)
             expected = scipy.stats.binom(total_count.cpu().numpy(), probs.cpu().numpy()).logpmf(sample)
-            self.assertAlmostEqual(log_prob, expected, places=4)
+            self.assertEqual(log_prob, expected, atol=1e-4, rtol=0)
 
     def test_binomial_enumerate_support(self):
         examples = [
@@ -1037,11 +1036,11 @@ class TestDistributions(TestCase):
         total_count = 100
         bin0 = Binomial(total_count, 0)
         self.assertEqual(bin0.sample(), 0)
-        self.assertAlmostEqual(bin0.log_prob(torch.tensor([0.]))[0], 0, places=3)
+        self.assertEqual(bin0.log_prob(torch.tensor([0.]))[0], 0, atol=1e-3, rtol=0)
         self.assertEqual(float(bin0.log_prob(torch.tensor([1.])).exp()), 0)
         bin1 = Binomial(total_count, 1)
         self.assertEqual(bin1.sample(), total_count)
-        self.assertAlmostEqual(bin1.log_prob(torch.tensor([float(total_count)]))[0], 0, places=3)
+        self.assertEqual(bin1.log_prob(torch.tensor([float(total_count)]))[0], 0, atol=1e-3, rtol=0)
         self.assertEqual(float(bin1.log_prob(torch.tensor([float(total_count - 1)])).exp()), 0)
         zero_counts = torch.zeros(torch.Size((2, 2)))
         bin2 = Binomial(zero_counts, 1)
@@ -1076,7 +1075,7 @@ class TestDistributions(TestCase):
             def ref_log_prob(idx, x, log_prob):
                 p = probs.view(-1)[idx].item()
                 expected = scipy.stats.nbinom(total_count, 1 - p).logpmf(x)
-                self.assertAlmostEqual(log_prob, expected, places=3)
+                self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
             self._check_log_prob(NegativeBinomial(total_count, probs), ref_log_prob)
             logits = probs_to_logits(probs, is_binary=True)
@@ -1089,7 +1088,7 @@ class TestDistributions(TestCase):
                                     (torch.tensor([1, 2, 10]), torch.tensor([0., 1., 9.]))]:
             log_prob = NegativeBinomial(total_count, probs).log_prob(sample)
             expected = scipy.stats.nbinom(total_count.cpu().numpy(), 1 - probs.cpu().numpy()).logpmf(sample)
-            self.assertAlmostEqual(log_prob, expected, places=4)
+            self.assertEqual(log_prob, expected, atol=1e-4, rtol=0)
 
     def test_multinomial_1d(self):
         total_count = 10
@@ -1238,7 +1237,7 @@ class TestDistributions(TestCase):
         def ref_log_prob(idx, x, log_prob):
             l = rate.view(-1)[idx].detach()
             expected = scipy.stats.poisson.logpmf(x, l)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         set_rng_seed(0)
         self._check_log_prob(Poisson(rate), ref_log_prob)
@@ -1500,7 +1499,7 @@ class TestDistributions(TestCase):
         def ref_log_prob(idx, x, log_prob):
             s = std.view(-1)[idx].detach()
             expected = scipy.stats.halfnorm(scale=s).logpdf(x)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(HalfNormal(std), ref_log_prob)
 
@@ -1550,7 +1549,7 @@ class TestDistributions(TestCase):
             m = mean.view(-1)[idx].detach()
             s = std.view(-1)[idx].detach()
             expected = scipy.stats.lognorm(s=s, scale=math.exp(m)).logpdf(x)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(LogNormal(mean, std), ref_log_prob)
 
@@ -1681,7 +1680,7 @@ class TestDistributions(TestCase):
             mix = scipy.stats.multinomial(1, p)
             comp = scipy.stats.norm(m, s)
             expected = scipy.special.logsumexp(comp.logpdf(x) + np.log(mix.p))
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(
             MixtureSameFamily(Categorical(probs=probs),
@@ -1754,7 +1753,7 @@ class TestDistributions(TestCase):
             s = scale.view(-1)[idx]
             expected = (math.exp(-(x - m) ** 2 / (2 * s ** 2)) /
                         math.sqrt(2 * math.pi * s ** 2))
-            self.assertAlmostEqual(log_prob, math.log(expected), places=3)
+            self.assertEqual(log_prob, math.log(expected), atol=1e-3, rtol=0)
 
         self._check_log_prob(Normal(loc, scale), ref_log_prob)
 
@@ -1828,7 +1827,7 @@ class TestDistributions(TestCase):
         x = dist1.sample((10,))
         expected = ref_dist.logpdf(x.numpy())
 
-        self.assertAlmostEqual(0.0, np.mean((dist1.log_prob(x).detach().numpy() - expected)**2), places=3)
+        self.assertEqual(0.0, np.mean((dist1.log_prob(x).detach().numpy() - expected)**2), atol=1e-3, rtol=0)
 
         # Double-check that batched versions behave the same as unbatched
         mean = torch.randn(5, 3, requires_grad=True)
@@ -1844,7 +1843,7 @@ class TestDistributions(TestCase):
         unbatched_prob = torch.stack([dist_unbatched[i].log_prob(x[:, i]) for i in range(5)]).t()
 
         self.assertEqual(batched_prob.shape, unbatched_prob.shape)
-        self.assertAlmostEqual(0.0, (batched_prob - unbatched_prob).abs().max(), places=3)
+        self.assertEqual(0.0, (batched_prob - unbatched_prob).abs().max(), atol=1e-3, rtol=0)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_lowrank_multivariate_normal_sample(self):
@@ -1965,9 +1964,9 @@ class TestDistributions(TestCase):
         x = dist1.sample((10,))
         expected = ref_dist.logpdf(x.numpy())
 
-        self.assertAlmostEqual(0.0, np.mean((dist1.log_prob(x).detach().numpy() - expected)**2), places=3)
-        self.assertAlmostEqual(0.0, np.mean((dist2.log_prob(x).detach().numpy() - expected)**2), places=3)
-        self.assertAlmostEqual(0.0, np.mean((dist3.log_prob(x).detach().numpy() - expected)**2), places=3)
+        self.assertEqual(0.0, np.mean((dist1.log_prob(x).detach().numpy() - expected)**2), atol=1e-3, rtol=0)
+        self.assertEqual(0.0, np.mean((dist2.log_prob(x).detach().numpy() - expected)**2), atol=1e-3, rtol=0)
+        self.assertEqual(0.0, np.mean((dist3.log_prob(x).detach().numpy() - expected)**2), atol=1e-3, rtol=0)
 
         # Double-check that batched versions behave the same as unbatched
         mean = torch.randn(5, 3, requires_grad=True)
@@ -1982,7 +1981,7 @@ class TestDistributions(TestCase):
         unbatched_prob = torch.stack([dist_unbatched[i].log_prob(x[:, i]) for i in range(5)]).t()
 
         self.assertEqual(batched_prob.shape, unbatched_prob.shape)
-        self.assertAlmostEqual(0.0, (batched_prob - unbatched_prob).abs().max(), places=3)
+        self.assertEqual(0.0, (batched_prob - unbatched_prob).abs().max(), atol=1e-3, rtol=0)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_multivariate_normal_sample(self):
@@ -2048,7 +2047,7 @@ class TestDistributions(TestCase):
         def ref_log_prob(idx, x, log_prob):
             m = rate.view(-1)[idx]
             expected = math.log(m) - m * x
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(Exponential(rate), ref_log_prob)
 
@@ -2099,7 +2098,7 @@ class TestDistributions(TestCase):
             m = loc.view(-1)[idx]
             s = scale.view(-1)[idx]
             expected = (-math.log(2 * s) - abs(x - m) / s)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(Laplace(loc, scale), ref_log_prob)
 
@@ -2128,7 +2127,7 @@ class TestDistributions(TestCase):
             a = alpha.view(-1)[idx].detach()
             b = beta.view(-1)[idx].detach()
             expected = scipy.stats.gamma.logpdf(x, a, scale=1 / b)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(Gamma(alpha, beta), ref_log_prob)
 
@@ -2150,7 +2149,7 @@ class TestDistributions(TestCase):
             a = alpha.view(-1)[idx].detach().cpu()
             b = beta.view(-1)[idx].detach().cpu()
             expected = scipy.stats.gamma.logpdf(x.cpu(), a, scale=1 / b)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(Gamma(alpha, beta), ref_log_prob)
 
@@ -2192,7 +2191,7 @@ class TestDistributions(TestCase):
             s = scale.view(-1)[idx].detach()
             a = alpha.view(-1)[idx].detach()
             expected = scipy.stats.pareto.logpdf(x, a, scale=s)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(Pareto(scale, alpha), ref_log_prob)
 
@@ -2221,7 +2220,7 @@ class TestDistributions(TestCase):
             l = loc.view(-1)[idx].detach()
             s = scale.view(-1)[idx].detach()
             expected = scipy.stats.gumbel_r.logpdf(x, loc=l, scale=s)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(Gumbel(loc, scale), ref_log_prob)
 
@@ -2252,7 +2251,7 @@ class TestDistributions(TestCase):
             f1 = df1.view(-1)[idx].detach()
             f2 = df2.view(-1)[idx].detach()
             expected = scipy.stats.f.logpdf(x, f1, f2)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(FisherSnedecor(df1, df2), ref_log_prob)
 
@@ -2279,7 +2278,7 @@ class TestDistributions(TestCase):
         def ref_log_prob(idx, x, log_prob):
             d = df.view(-1)[idx].detach()
             expected = scipy.stats.chi2.logpdf(x, d)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(Chi2(df), ref_log_prob)
 
@@ -2309,7 +2308,7 @@ class TestDistributions(TestCase):
         def ref_log_prob(idx, x, log_prob):
             d = df.view(-1)[idx].detach()
             expected = scipy.stats.t.logpdf(x, d)
-            self.assertAlmostEqual(log_prob, expected, places=3)
+            self.assertEqual(log_prob, expected, atol=1e-3, rtol=0)
 
         self._check_log_prob(StudentT(df), ref_log_prob)
 
@@ -2331,7 +2330,7 @@ class TestDistributions(TestCase):
             actual_log_prob = dist.log_prob(x)
             for i in range(num_samples):
                 expected_log_prob = scipy.stats.t.logpdf(x[i], df=df, loc=loc, scale=scale)
-                self.assertAlmostEqual(float(actual_log_prob[i]), float(expected_log_prob), places=3)
+                self.assertEqual(float(actual_log_prob[i]), float(expected_log_prob), atol=1e-3, rtol=0)
 
     def test_dirichlet_shape(self):
         alpha = torch.randn(2, 3).exp().requires_grad_()
@@ -2350,7 +2349,7 @@ class TestDistributions(TestCase):
         actual_log_prob = dist.log_prob(x)
         for i in range(num_samples):
             expected_log_prob = scipy.stats.dirichlet.logpdf(x[i].numpy(), alpha.numpy())
-            self.assertAlmostEqual(actual_log_prob[i], expected_log_prob, places=3)
+            self.assertEqual(actual_log_prob[i], expected_log_prob, atol=1e-3, rtol=0)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_dirichlet_sample(self):
@@ -2382,7 +2381,7 @@ class TestDistributions(TestCase):
             x = dist.sample()
             actual_log_prob = dist.log_prob(x).sum()
             expected_log_prob = scipy.stats.beta.logpdf(x, con1, con0)
-            self.assertAlmostEqual(float(actual_log_prob), float(expected_log_prob), places=3)
+            self.assertEqual(float(actual_log_prob), float(expected_log_prob), atol=1e-3, rtol=0)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_beta_sample(self):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -34,7 +34,7 @@ class TestScriptPy3(JitTestCase):
         with self.capture_stdout() as captured_script:
             out_script = func(x)
 
-        self.assertAlmostEqual(out, out_script)
+        self.assertEqual(out, out_script)
         self.assertEqual(captured, captured_script)
 
     @unittest.skipIf(sys.version_info[:2] < (3, 7), "`dataclasses` module not present on < 3.7")

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2917,7 +2917,7 @@ class TestNN(NNTestCase):
         _weight.data /= torch.dot(_u, torch.matmul(_weight_mat, _v))
         out_hat = torch.nn.functional.linear(input, _weight, _bias)
         expect_out = m(input)
-        self.assertAlmostEqual(expect_out, out_hat)
+        self.assertEqual(expect_out, out_hat)
 
     def test_spectral_norm_pickle(self):
         m = torch.nn.utils.spectral_norm(nn.Linear(5, 7))
@@ -4400,8 +4400,8 @@ class TestNN(NNTestCase):
             res_gpu = torch.nn.functional.ctc_loss(log_probs.cuda(), targets.cuda(), input_lengths, target_lengths,
                                                    reduction='sum', zero_infinity=True)
             grad_gpu, = torch.autograd.grad(res_gpu, log_probs, grad_out.cuda())
-        self.assertAlmostEqual(res_cpu, res_gpu, delta=1e-4)
-        self.assertAlmostEqual(grad_cpu, grad_gpu, delta=1e-4)
+        self.assertEqual(res_cpu, res_gpu, atol=1e-4, rtol=0)
+        self.assertEqual(grad_cpu, grad_gpu, atol=1e-4, rtol=0)
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_CTCLoss_zero_infinity(self):
@@ -4417,13 +4417,13 @@ class TestNN(NNTestCase):
         res_cpu = torch.nn.functional.ctc_loss(log_probs.cpu(), targets.cpu(), input_lengths, target_lengths,
                                                reduction='sum', zero_infinity=True)
 
-        self.assertAlmostEqual(res2, res, delta=1e-4)
-        self.assertAlmostEqual(res_cpu, res.cpu(), delta=1e-4)
+        self.assertEqual(res2, res, atol=1e-4, rtol=0)
+        self.assertEqual(res_cpu, res.cpu(), atol=1e-4, rtol=0)
         g1, = torch.autograd.grad(res, log_probs)
         g2, = torch.autograd.grad(res2, log_probs)
         g3, = torch.autograd.grad(res_cpu, log_probs)
-        self.assertAlmostEqual(g2, g3, delta=1e-4)
-        self.assertAlmostEqual(g1, g2, delta=1e-4)
+        self.assertEqual(g2, g3, atol=1e-4, rtol=0)
+        self.assertEqual(g1, g2, atol=1e-4, rtol=0)
         self.assertTrue((g1 == g1).all().item())  # check that we don't have NaN
 
     def test_RNN_cell_no_broadcasting(self):
@@ -6264,7 +6264,7 @@ class TestNN(NNTestCase):
             cudnn_input_grad = input.grad.data.clone()
             self.assertEqualTypeString(cudnn_output, input)
             self.assertEqual(cudnn_output, thnn_output)
-            self.assertAlmostEqual(cudnn_input_grad, thnn_input_grad, delta=1e-3)
+            self.assertEqual(cudnn_input_grad, thnn_input_grad, atol=1e-3, rtol=0)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_nonaffine_cuda_half_input(self):
@@ -8019,14 +8019,14 @@ class TestNN(NNTestCase):
                     gradient_o = torch.randn(output.shape)
                     gradient_w = torch.autograd.grad(output, input if (gradient == 'input') else weight, gradient_o)
 
-                    self.assertAlmostEqual(gradient_w[0],
-                                           func_backward(
-                                               input_shape if (gradient == 'input') else input,
-                                               weight_shape if (gradient == 'weight') else weight,
-                                               gradient_o,
-                                               stride=stride,
-                                               padding=padding,
-                                               dilation=dilation))
+                    self.assertEqual(gradient_w[0],
+                                     func_backward(
+                                     input_shape if (gradient == 'input') else input,
+                                     weight_shape if (gradient == 'weight') else weight,
+                                     gradient_o,
+                                     stride=stride,
+                                     padding=padding,
+                                     dilation=dilation))
 
     def test_grad_conv1d_input(self):
         self.run_grad_conv_test(F.conv1d, F.grad.conv1d_input, 1, 'input')
@@ -8065,14 +8065,14 @@ class TestNN(NNTestCase):
                         bias = torch.randn([chan_out], requires_grad=True, dtype=torch.float)
                     output = torch._nnpack_spatial_convolution(input, weight, stride=stride, padding=padding, bias=bias)
                     output_expected = torch.nn.functional.conv2d(input, weight, stride=stride, padding=padding, bias=bias)
-                    self.assertAlmostEqual(output, output_expected, delta=3e-4)
+                    self.assertEqual(output, output_expected, atol=3e-4, rtol=0)
 
                     gradient_o = torch.randn(output.shape, dtype=torch.float)
 
                     grads = torch.autograd.grad(output, [input, weight], gradient_o)
                     grads_expected = torch.autograd.grad(output_expected, [input, weight], gradient_o)
                     for gr, gr_expected in zip(grads, grads_expected):
-                        self.assertAlmostEqual(gr, gr_expected, delta=3e-4)
+                        self.assertEqual(gr, gr_expected, atol=3e-4, rtol=0)
 
     def test_fold_invalid_arg(self):
         # input wrong dimension
@@ -9185,8 +9185,8 @@ class TestNNDeviceType(NNTestCase):
         mean = out_reshaped.mean(1)
         var = out_reshaped.var(1, unbiased=False)
 
-        self.assertAlmostEqual(torch.abs(mean.data).mean(), 0, delta=1e-5)
-        self.assertAlmostEqual(torch.abs(var.data).mean(), 1, delta=1e-5)
+        self.assertEqual(torch.abs(mean.data).mean(), 0, atol=1e-5, rtol=0)
+        self.assertEqual(torch.abs(var.data).mean(), 1, atol=1e-5, rtol=0)
 
         # check that eval mode doesn't change behavior
         grad_out = torch.randn_like(output)
@@ -9215,8 +9215,8 @@ class TestNNDeviceType(NNTestCase):
         input_reshaped = input_var.transpose(1, 0).reshape(c, b, -1)
         var = input_reshaped.var(2, unbiased=True)[:, :]
 
-        self.assertAlmostEqual(torch.abs(mean.data - IN.running_mean).mean(), 0, delta=1e-5)
-        self.assertAlmostEqual(torch.abs(var.data.mean(1) - IN.running_var).mean(), 0, delta=1e-5)
+        self.assertEqual(torch.abs(mean.data - IN.running_mean).mean(), 0, atol=1e-5, rtol=0)
+        self.assertEqual(torch.abs(var.data.mean(1) - IN.running_var).mean(), 0, atol=1e-5, rtol=0)
 
         # in eval mode, adding X * std to a channel in input should make the
         # corresponding channel in output have mean X
@@ -9243,8 +9243,8 @@ class TestNNDeviceType(NNTestCase):
             cudnn_output.sum().backward()
             cudnn_input_grad = input.grad.data.clone()
             self.assertEqualTypeString(cudnn_output, input)
-            self.assertAlmostEqual(cudnn_output, thnn_output, delta=1e-4)
-            self.assertAlmostEqual(cudnn_input_grad, thnn_input_grad, delta=1e-3)
+            self.assertEqual(cudnn_output, thnn_output, atol=1e-4, rtol=0)
+            self.assertEqual(cudnn_input_grad, thnn_input_grad, atol=1e-3, rtol=0)
 
     def _test_LayerNorm_general(self, device, dtype=torch.float):
         for i in range(2, 6):
@@ -9264,8 +9264,8 @@ class TestNNDeviceType(NNTestCase):
             var = out_reshaped.var(-1, unbiased=False)
 
             delta = 1e-1 if dtype == torch.bfloat16 else 1e-5
-            self.assertAlmostEqual(torch.abs(mean.data).mean(), 0, delta=delta)
-            self.assertAlmostEqual(torch.abs(var.data).mean(), 1, delta=delta)
+            self.assertEqual(torch.abs(mean.data).mean(), 0, atol=delta, rtol=0)
+            self.assertEqual(torch.abs(var.data).mean(), 1, atol=delta, rtol=0)
 
             # test that LN applies weight and bias correctly
             scale, bias = torch.empty(2).uniform_(0.2, 2).tolist()
@@ -9275,8 +9275,8 @@ class TestNNDeviceType(NNTestCase):
             out_reshaped = output.view(*(unnormalized_shape + [-1]))
             mean = out_reshaped.mean(-1)
             var = out_reshaped.var(-1, unbiased=False)
-            self.assertAlmostEqual(torch.abs(mean.data).mean(), bias, delta=delta)
-            self.assertAlmostEqual(torch.abs(var.data).mean(), scale ** 2, delta=delta)
+            self.assertEqual(torch.abs(mean.data).mean(), bias, atol=delta, rtol=0)
+            self.assertEqual(torch.abs(var.data).mean(), scale ** 2, atol=delta, rtol=0)
 
         bad_norm_shape_input_shape = {
             (): (),
@@ -9318,8 +9318,8 @@ class TestNNDeviceType(NNTestCase):
             out_reshaped = output.view(b, g, -1)
             mean = out_reshaped.mean(-1)
             var = out_reshaped.var(-1, unbiased=False)
-            self.assertAlmostEqual(torch.abs(mean).mean(), 0, delta=1e-5)
-            self.assertAlmostEqual(torch.abs(var).mean(), 1, delta=1e-5)
+            self.assertEqual(torch.abs(mean).mean(), 0, atol=1e-5, rtol=0)
+            self.assertEqual(torch.abs(var).mean(), 1, atol=1e-5, rtol=0)
 
             # test that GN applies weight and bias correctly
             scale = torch.empty(c, device=device, dtype=dtype).uniform_(0.2, 2)
@@ -9332,8 +9332,8 @@ class TestNNDeviceType(NNTestCase):
             out_normed_reshaped = out_normed.view(b, g, -1)
             mean = out_normed_reshaped.mean(-1)
             var = out_normed_reshaped.var(-1, unbiased=False)
-            self.assertAlmostEqual(torch.abs(mean).mean(), 0, delta=1e-5)
-            self.assertAlmostEqual(torch.abs(var).mean(), 1, delta=1e-5)
+            self.assertEqual(torch.abs(mean).mean(), 0, atol=1e-5, rtol=0)
+            self.assertEqual(torch.abs(var).mean(), 1, atol=1e-5, rtol=0)
 
         bad_shape_g = {
             (1, 2, 3, 4): 3,
@@ -10122,7 +10122,7 @@ class TestNNDeviceType(NNTestCase):
 
         # 2eps = 1x addition + 1x subtraction.
         tol = 2 * torch.finfo(dtype).eps
-        self.assertAlmostEqual(logits_soft.grad, logits_hard.grad, delta=tol)
+        self.assertEqual(logits_soft.grad, logits_hard.grad, atol=tol, rtol=0)
 
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float, torch.double)
@@ -10930,8 +10930,8 @@ class TestNNDeviceType(NNTestCase):
         res4 = module(data2)
         self.assertEqual(res3, res1)
         self.assertEqual(res4, res2)
-        self.assertAlmostEqual(module.running_mean, (running_mean1 + running_mean2) / 2)
-        self.assertAlmostEqual(module.running_var, (running_var1 + running_var2) / 2)
+        self.assertEqual(module.running_mean, (running_mean1 + running_mean2) / 2)
+        self.assertEqual(module.running_var, (running_var1 + running_var2) / 2)
 
     @dtypes(torch.float)
     def test_batchnorm_simple_average(self, device, dtype):
@@ -11119,7 +11119,7 @@ class TestNNDeviceType(NNTestCase):
         log_probs = torch.randn(50, 3, 15, dtype=torch.double, device=device).log_softmax(2)
         loss = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
         self.assertTrue((loss >= 0).all().item())
-        self.assertAlmostEqual(-log_probs.sum(0)[:, 0], loss)
+        self.assertEqual(-log_probs.sum(0)[:, 0], loss)
 
         target_lengths = [0, 9, 0]
         input_lengths = [50, 50, 50]
@@ -11127,7 +11127,7 @@ class TestNNDeviceType(NNTestCase):
         log_probs = torch.randn(50, 3, 15, dtype=torch.double, device=device).log_softmax(2)
         loss = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
         self.assertTrue((loss >= 0).all().item())
-        self.assertAlmostEqual(-log_probs.sum(0)[[0, 2], 0], loss[[0, 2]])
+        self.assertEqual(-log_probs.sum(0)[[0, 2], 0], loss[[0, 2]])
 
     def test_empty_dropout(self, device):
         x = torch.Tensor([]).to(device)

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -719,7 +719,7 @@ class TestLRScheduler(TestCase):
         for _ in range(10):
             scheduler.step(2)
             l.append(self.opt.param_groups[0]['lr'])
-        self.assertAlmostEqual(min(l), max(l))
+        self.assertEqual(min(l), max(l))
 
     def test_step_lr_is_constant_for_constant_epoch(self):
         scheduler = StepLR(self.opt, 2)
@@ -1405,9 +1405,9 @@ class TestLRScheduler(TestCase):
     def _test_swalr(self, swa_scheduler, scheduler, targets, swa_start, epochs):
         for epoch in range(epochs):
             for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertAlmostEqual(target[epoch], param_group['lr'],
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, target[epoch], param_group['lr']), delta=1e-5)
+                self.assertEqual(target[epoch], param_group['lr'],
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, target[epoch], param_group['lr']), atol=1e-5, rtol=0)
             if epoch >= swa_start:
                 swa_scheduler.step()
             elif scheduler is not None:
@@ -1498,8 +1498,8 @@ class TestLRScheduler(TestCase):
         scheduler_copy.load_state_dict(scheduler.state_dict())
         for key in scheduler.__dict__.keys():
             if key != 'optimizer':
-                self.assertAlmostEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
-        self.assertAlmostEqual(scheduler.get_last_lr(), scheduler_copy.get_last_lr())
+                self.assertEqual(scheduler.__dict__[key], scheduler_copy.__dict__[key])
+        self.assertEqual(scheduler.get_last_lr(), scheduler_copy.get_last_lr())
 
     def _test_get_last_lr(self, schedulers, targets, epochs=10):
         if isinstance(schedulers, _LRScheduler):
@@ -1509,9 +1509,9 @@ class TestLRScheduler(TestCase):
             [scheduler.step() for scheduler in schedulers]
             target = [[t[epoch] for t in targets]] * len(schedulers)
             for t, r in zip(target, result):
-                self.assertAlmostEqual(target, result,
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, t, r), delta=1e-5)
+                self.assertEqual(target, result,
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, t, r), atol=1e-5, rtol=0)
 
     def _test_with_epoch(self, schedulers, targets, epochs=10):
         if isinstance(schedulers, _LRScheduler):
@@ -1519,18 +1519,18 @@ class TestLRScheduler(TestCase):
         for epoch in range(epochs):
             [scheduler.step(epoch) for scheduler in schedulers]  # step before assert: skip initial lr
             for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertAlmostEqual(target[epoch], param_group['lr'],
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, target[epoch], param_group['lr']), delta=1e-5)
+                self.assertEqual(target[epoch], param_group['lr'],
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, target[epoch], param_group['lr']), atol=1e-5, rtol=0)
 
     def _test(self, schedulers, targets, epochs=10):
         if isinstance(schedulers, _LRScheduler):
             schedulers = [schedulers]
         for epoch in range(epochs):
             for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertAlmostEqual(target[epoch], param_group['lr'],
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, target[epoch], param_group['lr']), delta=1e-5)
+                self.assertEqual(target[epoch], param_group['lr'],
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, target[epoch], param_group['lr']), atol=1e-5, rtol=0)
             [scheduler.step() for scheduler in schedulers]
 
     def _test_CosineAnnealingWarmRestarts(self, scheduler, targets, epochs=10):
@@ -1538,17 +1538,17 @@ class TestLRScheduler(TestCase):
             epoch = round(epoch.item(), 1)
             scheduler.step(epoch)
             for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertAlmostEqual(target[index], param_group['lr'],
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, target[index], param_group['lr']), delta=1e-5)
+                self.assertEqual(target[index], param_group['lr'],
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, target[index], param_group['lr']), atol=1e-5, rtol=0)
 
     def _test_interleaved_CosineAnnealingWarmRestarts(self, scheduler, targets, epochs):
         for index, epoch in enumerate(epochs):
             scheduler.step(epoch)
             for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertAlmostEqual(target[index], param_group['lr'],
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, target[index], param_group['lr']), delta=1e-5)
+                self.assertEqual(target[index], param_group['lr'],
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, target[index], param_group['lr']), atol=1e-5, rtol=0)
 
     def _test_against_closed_form(self, scheduler, closed_form_scheduler, epochs=10):
         self.setUp()
@@ -1560,9 +1560,9 @@ class TestLRScheduler(TestCase):
         for epoch in range(epochs):
             scheduler.step()
             for i, param_group in enumerate(self.opt.param_groups):
-                self.assertAlmostEqual(targets[epoch][i], param_group['lr'],
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, targets[epoch][i], param_group['lr']), delta=1e-5)
+                self.assertEqual(targets[epoch][i], param_group['lr'],
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, targets[epoch][i], param_group['lr']), atol=1e-5, rtol=0)
 
     def _test_reduce_lr_on_plateau(self, schedulers, targets, metrics, epochs=10, verbose=False):
         if isinstance(schedulers, _LRScheduler) or isinstance(schedulers, ReduceLROnPlateau):
@@ -1576,9 +1576,9 @@ class TestLRScheduler(TestCase):
             if verbose:
                 print('epoch{}:\tlr={}'.format(epoch, self.opt.param_groups[0]['lr']))
             for param_group, target in zip(self.opt.param_groups, targets):
-                self.assertAlmostEqual(target[epoch], param_group['lr'],
-                                       msg='LR is wrong in epoch {}: expected {}, got {}'.format(
-                                           epoch, target[epoch], param_group['lr']), delta=1e-5)
+                self.assertEqual(target[epoch], param_group['lr'],
+                                 msg='LR is wrong in epoch {}: expected {}, got {}'.format(
+                                     epoch, target[epoch], param_group['lr']), atol=1e-5, rtol=0)
 
     def _test_cycle_lr(self, scheduler, lr_targets, momentum_targets, batch_iterations, verbose=False, use_beta1=False):
         for batch_num in range(batch_iterations):
@@ -1593,21 +1593,21 @@ class TestLRScheduler(TestCase):
                     print('batch{}:\tlr={}'.format(batch_num, self.opt.param_groups[0]['lr']))
 
             for param_group, lr_target, momentum_target in zip(self.opt.param_groups, lr_targets, momentum_targets):
-                self.assertAlmostEqual(
+                self.assertEqual(
                     lr_target[batch_num], param_group['lr'],
                     msg='LR is wrong in batch_num {}: expected {}, got {}'.format(
-                        batch_num, lr_target[batch_num], param_group['lr']), delta=1e-5)
+                        batch_num, lr_target[batch_num], param_group['lr']), atol=1e-5, rtol=0)
 
                 if use_beta1 and 'betas' in param_group.keys():
-                    self.assertAlmostEqual(
+                    self.assertEqual(
                         momentum_target[batch_num], param_group['betas'][0],
                         msg='Beta1 is wrong in batch_num {}: expected {}, got {}'.format(
-                            batch_num, momentum_target[batch_num], param_group['betas'][0]), delta=1e-5)
+                            batch_num, momentum_target[batch_num], param_group['betas'][0]), atol=1e-5, rtol=0)
                 elif 'momentum' in param_group.keys():
-                    self.assertAlmostEqual(
+                    self.assertEqual(
                         momentum_target[batch_num], param_group['momentum'],
                         msg='Momentum is wrong in batch_num {}: expected {}, got {}'.format(
-                            batch_num, momentum_target[batch_num], param_group['momentum']), delta=1e-5)
+                            batch_num, momentum_target[batch_num], param_group['momentum']), atol=1e-5, rtol=0)
             scheduler.step()
 
     def test_cosine_then_cyclic(self):
@@ -1691,7 +1691,7 @@ class TestSWAUtils(TestCase):
             averaged_dnn.update_parameters(dnn)
 
         for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
-            self.assertAlmostEqual(p_avg, p_swa)
+            self.assertEqual(p_avg, p_swa)
             # Check that AveragedModel is on the correct device
             self.assertTrue(p_swa.device == swa_device)
             self.assertTrue(p.device == net_device)
@@ -1725,7 +1725,7 @@ class TestSWAUtils(TestCase):
             averaged_dnn.update_parameters(dnn)
 
         for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
-            self.assertAlmostEqual(p_avg, p_swa)
+            self.assertEqual(p_avg, p_swa)
             # Check that AveragedModel is on the correct device
             self.assertTrue(p_avg.device == p_swa.device)
 
@@ -1743,7 +1743,7 @@ class TestSWAUtils(TestCase):
             averaged_dnn.update_parameters(dnn)
         averaged_dnn2.load_state_dict(averaged_dnn.state_dict())
         for p_swa, p_swa2 in zip(averaged_dnn.parameters(), averaged_dnn2.parameters()):
-            self.assertAlmostEqual(p_swa, p_swa2)
+            self.assertEqual(p_swa, p_swa2)
         self.assertTrue(averaged_dnn.n_averaged == averaged_dnn2.n_averaged)
 
     def test_averaged_model_exponential(self):
@@ -1772,7 +1772,7 @@ class TestSWAUtils(TestCase):
             averaged_params = updated_averaged_params
 
         for p_avg, p_swa in zip(averaged_params, averaged_dnn.parameters()):
-            self.assertAlmostEqual(p_avg, p_swa)
+            self.assertEqual(p_avg, p_swa)
 
     def _test_update_bn(self, dnn, dl_x, dl_xy, cuda):
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15209,8 +15209,8 @@ class TestTorchDeviceType(TestCase):
         if dtype == torch.double:
             # double precision
             a = torch.tensor([0.5, 0.8], dtype=torch.double, device=device).erfinv()
-            self.assertAlmostEqual(a[0].item(), 0.47693627620447, places=13)
-            self.assertAlmostEqual(a[1].item(), 0.90619380243682, places=13)
+            self.assertEqual(a[0].item(), 0.47693627620447, atol=1e-13, rtol=0)
+            self.assertEqual(a[1].item(), 0.90619380243682, atol=1e-13, rtol=0)
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_ctor_with_numpy_array(self, device):
@@ -16588,11 +16588,11 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         input_tensor = torch.tensor(inputValues, dtype=dtype, device=device)
         expected_output_tensor = torch.tensor(expectedOutput, dtype=dtype, device=device)
 
-        self.assertEqual(torch.nn.functional.silu(input_tensor), 
+        self.assertEqual(torch.nn.functional.silu(input_tensor),
                          expected_output_tensor,
                          atol=precision_4dps, rtol=0)
 
-        self.assertEqual(torch.nn.functional.silu(input_tensor, inplace=True), 
+        self.assertEqual(torch.nn.functional.silu(input_tensor, inplace=True),
                          expected_output_tensor,
                          atol=precision_4dps, rtol=0)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1123,13 +1123,6 @@ class TestCase(expecttest.TestCase):
         else:
             super().assertEqual(x, y, msg=msg)
 
-    def assertAlmostEqual(self, x, y, *, places=None, msg=None, delta=None):
-        prec = delta
-        if places:
-            prec = 10**(-places)
-        rtol = None if prec is None else 0
-        self.assertEqual(x, y, msg=msg, atol=prec, rtol=rtol)
-
     def assertNotEqual(self, x, y, msg: Optional[str] = None, *,
                        atol: Optional[float] = None, rtol: Optional[float] = None, **kwargs) -> None:
         with self.assertRaises(AssertionError, msg=msg):


### PR DESCRIPTION
This test function is confusing since our `assertEqual` behavior allows for tolerance to be specified, and this is a redundant mechanism.