### PR TITLE
[PT] add check for duplicated op names in JIT

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -111,9 +111,9 @@ white_list = [
     ('aten::to_here(RRef(t) self, double timeout*)', datetime.date(2020, 6, 30)),
     ('aten::local_value', datetime.date(2020, 6, 30)),
     ('aten::log', datetime.date(2020, 7, 30)),
-    ('aten::__and__', datetime.date(2020, 6, 30)),
-    ('aten::__or__', datetime.date(2020, 6, 30)),
-    ('aten::__xor__', datetime.date(2020, 6, 30)),
+    ('aten::__and__', datetime.date(2020, 7, 30)),
+    ('aten::__or__', datetime.date(2020, 7, 30)),
+    ('aten::__xor__', datetime.date(2020, 7, 30)),
     ('aten::split', datetime.date(2020, 6, 30)),
     ('aten::add', datetime.date(2020, 7, 30)),
     ('aten::__upsample_bilinear', datetime.date(2020, 7, 30)),
@@ -133,6 +133,10 @@ white_list = [
     ('aten::_sparse_coo_tensor_with_dims', datetime.date(2020, 7, 30)),
     ('aten::_sparse_coo_tensor_with_dims_and_tensors', datetime.date(2020, 7, 30)),
     ('aten::to', datetime.date(2020, 7, 15)),
+    ('aten::__lshift__', datetime.date(2020, 7, 30)),
+    ('aten::__rshift__', datetime.date(2020, 7, 30)),
+    ('aten::__round_to_zero_floordiv', datetime.date(2020, 7, 30)),
+    ('aten::gcd', datetime.date(2020, 7, 30)),
 ]
 
 

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -34,6 +34,12 @@ struct OperatorRegistry {
   std::unordered_map<const char*, std::shared_ptr<Operator>>
       operators_by_sig_literal;
 
+  // Remember all registered operator names to check that they aren't
+  // registered a second time. Registering an op multiple times is
+  // fragile because it might depend on static initialization order
+  // which one is picked at runtime.
+  std::unordered_set<c10::OperatorName> registered_operator_names;
+
   // XXX - caller must be holding lock
   void registerPendingOperators() {
     for (const auto& op : to_register) {
@@ -47,6 +53,14 @@ struct OperatorRegistry {
  public:
   void registerOperator(Operator&& op) {
     std::lock_guard<std::mutex> guard(lock);
+
+    TORCH_INTERNAL_ASSERT(
+        0 == registered_operator_names.count(op.schema().operator_name()),
+        "Tried to register operator \"",
+        op.schema(),
+        "\" to JIT but the operator name was already registered before. Please add or change the overload name.");
+    registered_operator_names.insert(op.schema().operator_name());
+
     to_register.push_back(std::make_shared<Operator>(std::move(op)));
   }
 
@@ -55,6 +69,14 @@ struct OperatorRegistry {
     auto sig = canonicalSchemaString(schema);
 
     std::lock_guard<std::mutex> guard(lock);
+
+    TORCH_INTERNAL_ASSERT(
+        1 == registered_operator_names.count(schema.operator_name()),
+        "Tried to remove operator ",
+        schema,
+        " from JIT but it wasn't found.");
+    registered_operator_names.erase(schema.operator_name());
+
     // Try removing from pending operators list first
     auto pending_it = to_register.begin();
     while (pending_it != to_register.end() && (*pending_it)->schema() != schema)

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -475,7 +475,7 @@ void listSetItem(Stack* stack);
 
 #define DEFINE_INT_OP(aten_op, op)                          \
   Operator(                                                 \
-      #aten_op "(int a, int b) -> int",                     \
+      #aten_op ".int(int a, int b) -> int",                 \
       [](Stack* stack) {                                    \
         int64_t a, b;                                       \
         pop(stack, a, b);                                   \

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -602,7 +602,14 @@ RegisterOperators reg(
          static_cast<double>(pow(a, b)),
          static_cast<double>(pow(a, b)),
          float),
-     DEFINE_INT_OP(aten::pow.int_to_int, pow(a, b)),
+     Operator(
+         "aten::pow.int_to_int(int a, int b) -> int",
+         [](Stack* stack) {
+           int64_t a, b;
+           pop(stack, a, b);
+           push(stack, pow(a, b));
+         },
+         aliasAnalysisFromSchema()),
      // min and max are in prim:: because there is a difference between
      // the python builtin 'min' and 'torch.min'
      DEFINE_BINARY_OP(prim::min, a < b ? a : b),


### PR DESCRIPTION
Summary:
D22467871 (https://github.com/pytorch/pytorch/commit/a548c6b18ff5a337b6329ed7b2381cfb4d3da2ed) was reverted due to double linking torch_mobile_train.
Re-do this change after D22531358 (https://github.com/pytorch/pytorch/commit/7a33d8b001b1f8dc59c07d0701d615093a81a741).

Test Plan:
buck install fb4a
Train mnist in Internal Settings.

Reviewed By: iseeyuan

Differential Revision: D22533824

