### PR TITLE
Fix RocM resource class allocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5738,6 +5738,7 @@ workflows:
                 - /release\/.*/
           build_environment: "pytorch-linux-xenial-rocm3.5.1-py3.6-test1"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-rocm3.5.1-py3.6:ab1632df-fa59-40e6-8c23-98e004f61148"
+          resource_class: pytorch/amd-gpu
       - pytorch_linux_test:
           name: pytorch_linux_xenial_rocm3_5_1_py3_6_test2
           requires:
@@ -5750,6 +5751,7 @@ workflows:
                 - /release\/.*/
           build_environment: "pytorch-linux-xenial-rocm3.5.1-py3.6-test2"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-rocm3.5.1-py3.6:ab1632df-fa59-40e6-8c23-98e004f61148"
+          resource_class: pytorch/amd-gpu
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc5_4_build
           build_environment: "pytorch-linux-xenial-py3.6-gcc5.4-build"
@@ -5856,12 +5858,14 @@ workflows:
             - pytorch_linux_xenial_py3_clang5_asan_build
           build_environment: "pytorch-linux-xenial-py3-clang5-asan-test1"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:ab1632df-fa59-40e6-8c23-98e004f61148"
+          resource_class: large
       - pytorch_linux_test:
           name: pytorch_linux_xenial_py3_clang5_asan_test2
           requires:
             - pytorch_linux_xenial_py3_clang5_asan_build
           build_environment: "pytorch-linux-xenial-py3-clang5-asan-test2"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:ab1632df-fa59-40e6-8c23-98e004f61148"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
           filters:


### PR DESCRIPTION
Add Conf.is_test_stage() method to avoid duplicating state in ['test', 'test1', 'test2'] throughout the code

Test Plan: Make sure that in modified config.yml ROCM tests jobs are assigned `pytorch/amd-gpu` resource class

