### PR TITLE
[GradualGating] support better k value change

### DIFF
--- a/caffe2/python/operator_test/learning_rate_op_test.py
+++ b/caffe2/python/operator_test/learning_rate_op_test.py
@@ -82,6 +82,40 @@ class TestLearningRate(serial.SerializedTestCase):
         )
         self.assertReferenceChecks(gc, op, [iter], ref)
 
+    @given(**hu.gcs_cpu_only)
+    def test_slope_learning_rate_op(self, gc, dc):
+        iter = np.random.randint(low=1, high=1e5, size=1)
+
+        num_iter_1 = int(np.random.randint(low=1e2, high=1e3, size=1))
+        multiplier_1 = 1.0
+        num_iter_2 = num_iter_1 + int(np.random.randint(low=1e2, high=1e3, size=1))
+        multiplier_2 = 0.5
+        base_lr = float(np.random.random(1))
+
+        def ref(iter):
+            iter = float(iter)
+            if iter < num_iter_1:
+                lr = multiplier_1
+            else:
+                lr = max(
+                    multiplier_1 + (iter - num_iter_1) * (multiplier_2 - multiplier_1) / (num_iter_2 - num_iter_1),
+                    multiplier_2
+                )
+            return (np.array(base_lr * lr), )
+
+        op = core.CreateOperator(
+            'LearningRate',
+            'data',
+            'out',
+            policy="slope",
+            base_lr=base_lr,
+            num_iter_1=num_iter_1,
+            multiplier_1=multiplier_1,
+            num_iter_2=num_iter_2,
+            multiplier_2=multiplier_2,
+        )
+        self.assertReferenceChecks(gc, op, [iter], ref)
+
     @given(
         **hu.gcs_cpu_only
     )

--- a/caffe2/sgd/learning_rate_op.h
+++ b/caffe2/sgd/learning_rate_op.h
@@ -76,6 +76,20 @@ class LearningRateOp final : public Operator<Context> {
       DCHECK_LE(end_multiplier, 1);
       return new HillLearningRate<T>(
           num_iter, start_multiplier, gamma, power, end_multiplier);
+    } else if (policy == "slope") {
+      int64_t num_iter_1 =
+          this->template GetSingleArgument<int64_t>(arg_prefix + "num_iter_1", 0);
+      DCHECK_GT(num_iter_1, 0);
+      T multiplier_1 = this->template GetSingleArgument<float>(
+          arg_prefix + "multiplier_1", 0.);
+      int64_t num_iter_2 =
+          this->template GetSingleArgument<int64_t>(arg_prefix + "num_iter_2", 0);
+      DCHECK_GT(num_iter_1, 0);
+      T multiplier_2 = this->template GetSingleArgument<float>(
+          arg_prefix + "multiplier_2", 0.);
+      DCHECK_GT(num_iter_2, num_iter_1);
+      return new SlopeLearningRate<T>(
+          num_iter_1, multiplier_1, num_iter_2, multiplier_2);
     } else if (policy == "step") {
       int stepsize =
           this->template GetSingleArgument<int>(arg_prefix + "stepsize", 0);


### PR DESCRIPTION
Summary:
- add new learning rate functor "slope"
 - use "slope" learning rate in gated_sparse_feature module

Test Plan:
buck test dper3/dper3/modules/tests:core_modules_test -- test_gated_sparse_features_shape_num_warmup_tensor_k
buck test caffe2/caffe2/python/operator_test:learning_rate_op_test -- test_slope_learning_rate_op

Differential Revision: D22544628

