### PR TITLE
Add Unflatten Module

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -355,6 +355,7 @@ Utility functions in other modules
     nn.utils.rnn.pack_sequence
 
     nn.Flatten
+    nn.Unflatten
 
 Quantized Functions
 --------------------

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8326,6 +8326,43 @@ class TestNN(NNTestCase):
             torch.nn.grad._grad_input_padding(torch.rand(1, 2, 3), [1, 2, 5], (1,), (0,), (3,))
         self.assertEqual(len(w), 1)
 
+    def test_unflatten(self):
+        tensor_input = torch.randn(32, 49152)
+
+        # Unflatten Tensor
+
+        unflatten = nn.Unflatten(dim=1, unflattened_size=(3, 128, 128))
+        tensor_output = unflatten(tensor_input)
+        self.assertEqual(tensor_output.size(), torch.Size([32, 3, 128, 128]))
+
+        # Unflatten NamedTensor
+
+        unflatten = nn.Unflatten(dim='features', unflattened_size=(('C', 3), ('H', 128), ('W', 128)))
+        named_tensor_input = tensor_input.refine_names('N', 'features')
+        named_tensor_output = unflatten(named_tensor_input)
+        self.assertEqual(tensor_output.size(), torch.Size([32, 3, 128, 128]))
+
+    def test_unflatten_invalid_arg(self):
+        # Wrong type for unflattened_size (tuple of floats)
+
+        with self.assertRaisesRegex(TypeError, r"unflattened_size must be tuple of ints, but found element of type float at pos 2"):
+            nn.Unflatten(dim=1, unflattened_size=(3, 128, 128.3))
+
+        # Wrong type for unflattened_size (tuple of lists)
+
+        with self.assertRaisesRegex(TypeError, r"unflattened_size must be tuple of tuples, but found element of type list at pos 0"):
+            nn.Unflatten(dim='features', unflattened_size=(['C', 3], ['W', 128], ['H', 128]))
+
+        # Wrong type for unflattened_size (list of ints)
+
+        with self.assertRaisesRegex(TypeError, r"unflattened_size must be a tuple of ints, but found type list"):
+            nn.Unflatten(dim=1, unflattened_size=[3, 128, 128])
+
+        # Wrong type for unflattened_size (list of lists)
+
+        with self.assertRaisesRegex(TypeError, r"unflattened_size must be a tuple of tuples, but found type list"):
+            nn.Unflatten(dim='features', unflattened_size=[['C', 3], ['W', 128], ['H', 128]])
+
 
 class TestNNInit(TestCase):
     def setUp(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8345,22 +8345,30 @@ class TestNN(NNTestCase):
     def test_unflatten_invalid_arg(self):
         # Wrong type for unflattened_size (tuple of floats)
 
-        with self.assertRaisesRegex(TypeError, r"unflattened_size must be tuple of ints, but found element of type float at pos 2"):
+        with self.assertRaisesRegex(
+                TypeError,
+                r"unflattened_size must be tuple of ints, but found element of type float at pos 2"):
             nn.Unflatten(dim=1, unflattened_size=(3, 128, 128.3))
 
         # Wrong type for unflattened_size (tuple of lists)
 
-        with self.assertRaisesRegex(TypeError, r"unflattened_size must be tuple of tuples, but found element of type list at pos 0"):
+        with self.assertRaisesRegex(
+                TypeError,
+                r"unflattened_size must be tuple of tuples, but found element of type list at pos 0"):
             nn.Unflatten(dim='features', unflattened_size=(['C', 3], ['W', 128], ['H', 128]))
 
         # Wrong type for unflattened_size (list of ints)
 
-        with self.assertRaisesRegex(TypeError, r"unflattened_size must be a tuple of ints, but found type list"):
+        with self.assertRaisesRegex(
+                TypeError,
+                r"unflattened_size must be a tuple of ints, but found type list"):
             nn.Unflatten(dim=1, unflattened_size=[3, 128, 128])
 
         # Wrong type for unflattened_size (list of lists)
 
-        with self.assertRaisesRegex(TypeError, r"unflattened_size must be a tuple of tuples, but found type list"):
+        with self.assertRaisesRegex(
+                TypeError,
+                r"unflattened_size must be a tuple of tuples, but found type list"):
             nn.Unflatten(dim='features', unflattened_size=[['C', 3], ['W', 128], ['H', 128]])
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8327,20 +8327,20 @@ class TestNN(NNTestCase):
         self.assertEqual(len(w), 1)
 
     def test_unflatten(self):
-        tensor_input = torch.randn(32, 49152)
+        tensor_input = torch.randn(2, 50)
 
         # Unflatten Tensor
 
-        unflatten = nn.Unflatten(dim=1, unflattened_size=(3, 128, 128))
+        unflatten = nn.Unflatten(dim=1, unflattened_size=(2, 5, 5))
         tensor_output = unflatten(tensor_input)
-        self.assertEqual(tensor_output.size(), torch.Size([32, 3, 128, 128]))
+        self.assertEqual(tensor_output.size(), torch.Size([2, 2, 5, 5]))
 
         # Unflatten NamedTensor
 
-        unflatten = nn.Unflatten(dim='features', unflattened_size=(('C', 3), ('H', 128), ('W', 128)))
+        unflatten = nn.Unflatten(dim='features', unflattened_size=(('C', 2), ('H', 5), ('W', 5)))
         named_tensor_input = tensor_input.refine_names('N', 'features')
         named_tensor_output = unflatten(named_tensor_input)
-        self.assertEqual(tensor_output.size(), torch.Size([32, 3, 128, 128]))
+        self.assertEqual(tensor_output.size(), torch.Size([2, 2, 5, 5]))
 
     def test_unflatten_invalid_arg(self):
         # Wrong type for unflattened_size (tuple of floats)
@@ -8348,28 +8348,28 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(
                 TypeError,
                 r"unflattened_size must be tuple of ints, but found element of type float at pos 2"):
-            nn.Unflatten(dim=1, unflattened_size=(3, 128, 128.3))
+            nn.Unflatten(dim=1, unflattened_size=(2, 5, 5.0))
 
         # Wrong type for unflattened_size (tuple of lists)
 
         with self.assertRaisesRegex(
                 TypeError,
                 r"unflattened_size must be tuple of tuples, but found element of type list at pos 0"):
-            nn.Unflatten(dim='features', unflattened_size=(['C', 3], ['W', 128], ['H', 128]))
+            nn.Unflatten(dim='features', unflattened_size=(['C', 2], ['W', 5], ['H', 5]))
 
         # Wrong type for unflattened_size (list of ints)
 
         with self.assertRaisesRegex(
                 TypeError,
                 r"unflattened_size must be a tuple of ints, but found type list"):
-            nn.Unflatten(dim=1, unflattened_size=[3, 128, 128])
+            nn.Unflatten(dim=1, unflattened_size=[2, 5, 5])
 
         # Wrong type for unflattened_size (list of lists)
 
         with self.assertRaisesRegex(
                 TypeError,
                 r"unflattened_size must be a tuple of tuples, but found type list"):
-            nn.Unflatten(dim='features', unflattened_size=[['C', 3], ['W', 128], ['H', 128]])
+            nn.Unflatten(dim='features', unflattened_size=[['C', 2], ['W', 5], ['H', 5]])
 
 
 class TestNNInit(TestCase):

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -30,7 +30,7 @@ from .fold import Fold, Unfold
 from .adaptive import AdaptiveLogSoftmaxWithLoss
 from .transformer import TransformerEncoder, TransformerDecoder, \
     TransformerEncoderLayer, TransformerDecoderLayer, Transformer
-from .flatten import Flatten
+from .flatten import Flatten, Unflatten
 
 __all__ = [
     'Module', 'Identity', 'Linear', 'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d',
@@ -54,5 +54,5 @@ __all__ = [
     'ConstantPad3d', 'Bilinear', 'CosineSimilarity', 'Unfold', 'Fold',
     'AdaptiveLogSoftmaxWithLoss', 'TransformerEncoder', 'TransformerDecoder',
     'TransformerEncoderLayer', 'TransformerDecoderLayer', 'Transformer',
-    'Flatten', 'Hardsigmoid', 'Hardswish', 'SiLU',
+    'Flatten', 'Unflatten', 'Hardsigmoid', 'Hardswish', 'SiLU',
 ]

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -43,26 +43,46 @@ class Flatten(Module):
 
 class Unflatten(Module):
     r"""
-    Unflattens a tensor into another tensor of shape (N, C, H, W). For use with :class:`~nn.Sequential`.
-    Args:
-        dim: tensor dimension to be unflattened
-        unflattened_size: shape of the output tensor
+    Unflattens a tensor into another tensor of a desired shape. For use with :class:`~nn.Sequential`.
+
+    * :attr:`dim` specifies the dimension of the input tensor to be flattened, and it can 
+    be either `str` or `int` when `NamedTensor` or `Tensor` is used, respectively.
+
+    * :attr:`unflattened_size` is the size of the unflattened dimension of the tensor and it can be a
+    `namedshape` (`tuple` of tuples) if :attr:`dim` is `str` or a `tuple` of ints as well as `torch.Size` if
+    :attr:`dim` is an `int`.
 
     Shape:
         - Input: :math:`(N, *dims)`
         - Output: :math:`(N, C_out, H_out, W_out)`
 
+    Args:
+        dim (Union[int, str]): Dimension to be flattened
+        unflattened_size (Union[tuple, torch.Size]): Size of the output tensor
 
     Examples::
+        >>> input = torch.randn(2, 50)
         >>> m = nn.Sequential(
-        >>>     nn.Linear(49152, 49152),
-        >>>     nn.Unflatten(1, (3, 128, 128))
+        >>>     nn.Linear(50, 50),
+        >>>     nn.Unflatten(1, (2, 5, 5))
         >>> )
-
+        >>> output = m(output)
+        >>> output.size()
+        torch.Size([2, 2, 5, 5])
         >>> m = nn.Sequential(
-        >>>     nn.Linear(49152, 49152),
-        >>>     nn.Unflatten('features', (('C', 3), ('H', 128), ('W',128)))
+        >>>     nn.Linear(50, 50),
+        >>>     nn.Unflatten(1, torch.Size([2, 5, 5]))
         >>> )
+        >>> output = m(output)
+        >>> output.size()
+        torch.Size([2, 2, 5, 5])
+        >>> m = nn.Sequential(
+        >>>     nn.Linear(50, 50),
+        >>>     nn.Unflatten('features', (('C', 2), ('H', 50), ('W',50)))
+        >>> )
+        >>> output = m(output)
+        >>> output.size()
+        torch.Size([2, 2, 5, 5])
     """
     __constants__ = ['dim', 'unflattened_size']
     dim: Union[int, str]

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -60,7 +60,7 @@ class Unflatten(Module):
         dim (Union[int, str]): Dimension to be flattened
         unflattened_size (Union[tuple, torch.Size]): Size of the output tensor
 
-    Examples::
+    Examples:
         >>> input = torch.randn(2, 50)
         >>> m = nn.Sequential(
         >>>     nn.Linear(50, 50),

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -45,9 +45,8 @@ class Unflatten(Module):
     r"""
     Unflattens a tensor into another tensor of shape (N, C, H, W). For use with :class:`~nn.Sequential`.
     Args:
-        channels: numbers of channels or depth of the output tensor
-        height: dimension corresponding to the height of the output tensor.
-        width: dimension corresponding to the width of the output tensor.
+        dim: tensor dimension to be unflattened
+        unflattened_size: shape of the output tensor
 
     Shape:
         - Input: :math:`(N, *dims)`
@@ -57,13 +56,17 @@ class Unflatten(Module):
     Examples::
         >>> m = nn.Sequential(
         >>>     nn.Linear(49152, 49152),
-        >>>     nn.Unflatten(3, 128, 128)
+        >>>     nn.Unflatten(1, (3, 128, 128))
+        >>> )
+
+        >>> m = nn.Sequential(
+        >>>     nn.Linear(49152, 49152),
+        >>>     nn.Unflatten('features', (('C', 3), ('H', 128), ('W',128)))
         >>> )
     """
-    __constants__ = ['channels', 'height', 'width']
-    channels: int
-    height: int
-    width: int
+    __constants__ = ['dim', 'unflattened_size']
+    dim: Union[int, str]
+    unflattened_size: Union[tuple, Size]
 
     def __init__(self, dim: Union[int, str], unflattened_size: Union[tuple, Size]) -> None:
         super(Unflatten, self).__init__()
@@ -81,17 +84,18 @@ class Unflatten(Module):
         if (isinstance(input, tuple)):
             for idx, elem in enumerate(input):
                 if not isinstance(elem, tuple):
-                    raise TypeError("unflattened_size must be tuple of tuples, but found element of type {} at pos {}".format(
-                        type(elem).__name__, idx))
+                    raise TypeError("unflattened_size must be tuple of tuples, " + 
+                                    "but found element of type {} at pos {}".format(type(elem).__name__, idx))
             return
-        raise TypeError("unflattened_size must be a tuple of tuples, but found type {}".format(type(input).__name__))
+        raise TypeError("unflattened_size must be a tuple of tuples, " +
+                        "but found type {}".format(type(input).__name__))
 
     def _require_tuple_int(self, input):
         if (isinstance(input, tuple)):
             for idx, elem in enumerate(input):
                 if not isinstance(elem, int):
-                    raise TypeError("unflattened_size must be tuple of ints, but found element of type {} at pos {}".format(
-                        type(elem).__name__, idx))
+                    raise TypeError("unflattened_size must be tuple of ints, " + 
+                                    "but found element of type {} at pos {}".format(type(elem).__name__, idx))
             return
         raise TypeError("unflattened_size must be a tuple of ints, but found type {}".format(type(input).__name__))
 

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -62,6 +62,7 @@ class Unflatten(Module):
 
     Examples:
         >>> input = torch.randn(2, 50)
+        >>> # With tuple of ints
         >>> m = nn.Sequential(
         >>>     nn.Linear(50, 50),
         >>>     nn.Unflatten(1, (2, 5, 5))
@@ -69,6 +70,7 @@ class Unflatten(Module):
         >>> output = m(output)
         >>> output.size()
         torch.Size([2, 2, 5, 5])
+        >>> # With torch.Size
         >>> m = nn.Sequential(
         >>>     nn.Linear(50, 50),
         >>>     nn.Unflatten(1, torch.Size([2, 5, 5]))
@@ -76,6 +78,7 @@ class Unflatten(Module):
         >>> output = m(output)
         >>> output.size()
         torch.Size([2, 2, 5, 5])
+        >>> # With namedshape (tuple of tuples)
         >>> m = nn.Sequential(
         >>>     nn.Linear(50, 50),
         >>>     nn.Unflatten('features', (('C', 2), ('H', 50), ('W',50)))

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -2,6 +2,7 @@ from .module import Module
 
 from torch import Tensor
 
+
 class Flatten(Module):
     r"""
     Flattens a contiguous range of dims into a tensor. For use with :class:`~nn.Sequential`.
@@ -31,3 +32,48 @@ class Flatten(Module):
 
     def forward(self, input: Tensor) -> Tensor:
         return input.flatten(self.start_dim, self.end_dim)
+
+    def extra_repr(self) -> str:
+        return 'start_dim={}, end_dim={}'.format(
+            self.start_dim, self.end_dim
+        )
+
+
+class Unflatten(Module):
+    r"""
+    Unflattens a tensor into another tensor of shape (N, C, H, W). For use with :class:`~nn.Sequential`.
+    Args:
+        channels: numbers of channels or depth of the output tensor
+        height: dimension corresponding to the height of the output tensor.
+        width: dimension corresponding to the width of the output tensor.
+
+    Shape:
+        - Input: :math:`(N, *dims)`
+        - Output: :math:`(N, C_out, H_out, W_out)`
+
+
+    Examples::
+        >>> m = nn.Sequential(
+        >>>     nn.Linear(49152, 49152),
+        >>>     nn.Unflatten(3, 128, 128)
+        >>> )
+    """
+    __constants__ = ['channels', 'height', 'width']
+    channels: int
+    height: int
+    width: int
+
+    def __init__(self, channels: int, height: int, width: int) -> None:
+        super(Unflatten, self).__init__()
+        self.channels = channels
+        self.height = height
+        self.width = width
+
+    def forward(self, input: Tensor) -> Tensor:
+        input = input.refine_names('N', 'features')
+        return input.unflatten('features', (('C', self.channels), ('H', self.height), ('W', self.width)))
+
+    def extra_repr(self) -> str:
+        return 'channels={}, height={}, width={}'.format(
+            self.channels, self.height, self.width
+        )

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -103,9 +103,9 @@ class Unflatten(Module):
         if self.named:
             return input.unflatten(self.dim, self.unflattened_size)
         else:
-            dim = self.dim
-            if self.dim < 0:
-                dim += input.ndim()
+            dim = int(self.dim)
+            if dim < 0:
+                dim += input.dim()
             inp_size = list(input.size())
             new_size = inp_size[:dim] + list(self.unflattened_size) + inp_size[dim + 1:]
             return input.view(new_size)


### PR DESCRIPTION
This PR implements a feature extension discussed in #41516.

I followed this other PR #22245 to add this other module. While I was at it, I also added `extra_repr()` method in `Flatten` which was missing.

I see there are no unit tests for these modules. Should I add those too? If so, what is the best place I should place these?



