### PR TITLE
[quant][graphmode][fix] Make it work with CallMethod on non-Module objects

### DIFF
--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -563,6 +563,20 @@ Module getInvokedModule(Module& module, Node* n, Value* self) {
   return findChildModule(module, path);
 }
 
+c10::optional<Module> getInvokedModuleOpt(const Module& module, Node* n, Value* self) {
+  auto* instance = n->inputs()[0];
+  auto path = getModuleAccessPath(instance, self);
+  Module m = module;
+  for (const auto& p : path) {
+    if (m.attr(p).isModule()) {
+      m = m.attr(p).toModule();
+    } else {
+      return c10::nullopt;
+    }
+  }
+  return m;
+}
+
 // ==================== filter functions for matches ==============
 bool is_int_constant(
     const Match& match,

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -563,7 +563,10 @@ Module getInvokedModule(Module& module, Node* n, Value* self) {
   return findChildModule(module, path);
 }
 
-c10::optional<Module> getInvokedModuleOpt(const Module& module, Node* n, Value* self) {
+c10::optional<Module> getInvokedModuleOpt(
+    const Module& module,
+    Node* n,
+    Value* self) {
   auto* instance = n->inputs()[0];
   auto path = getModuleAccessPath(instance, self);
   Module m = module;

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -114,7 +114,13 @@ findChildModule(const Module& module, const std::vector<std::string>& path);
 
 // Given an CallMethod node, get the module instance corresponding
 // to the instance Value
+// TODO: refactor all current uses of this function to the Opt one
 TORCH_API Module getInvokedModule(Module& module, Node* n, Value* self);
+
+// Given an CallMethod node, get the module instance corresponding
+// to the instance Value if the instance is a module, otherwise return
+// c10::nullopt
+c10::optional<Module> getInvokedModuleOpt(const Module& module, Node* n, Value* self);
 
 // ==================== filter functions for matches ==============
 // filter to check Value `vname` is a constant of int value `value`

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -120,7 +120,10 @@ TORCH_API Module getInvokedModule(Module& module, Node* n, Value* self);
 // Given an CallMethod node, get the module instance corresponding
 // to the instance Value if the instance is a module, otherwise return
 // c10::nullopt
-c10::optional<Module> getInvokedModuleOpt(const Module& module, Node* n, Value* self);
+c10::optional<Module> getInvokedModuleOpt(
+    const Module& module,
+    Node* n,
+    Value* self);
 
 // ==================== filter functions for matches ==============
 // filter to check Value `vname` is a constant of int value `value`

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -176,10 +176,11 @@ class ModuleCloneHelper {
       // remapping type for module instance
       if (node->kind() == prim::CallMethod) {
         Value* instance = node->inputs()[0];
-        auto path = getModuleAccessPath(instance, self);
-        auto child = findChildModule(source, path);
-        auto qconfig = module_qconfig_map.at(child._ivalue());
-        instance->setType(type_remap_fn(instance->type(), qconfig));
+        auto child_opt = getInvokedModuleOpt(source, node, self);
+        if (child_opt.has_value()) {
+          auto qconfig = module_qconfig_map.at(child_opt->_ivalue());
+          instance->setType(type_remap_fn(instance->type(), qconfig));
+        }
       }
       // We don't remap output and the remapping of module type
       // will be done in CallMethod, we don't support type remapping
@@ -908,8 +909,11 @@ ModuleMethodVector InsertObserversHelper::getInvokedMethods(
         continue;
       }
       if (n->kind() == prim::CallMethod) {
-        invoked_methods.push_back(std::make_pair(
-            getInvokedModule(module, n, graph->inputs()[0]), n->s(attr::name)));
+        auto m_opt = getInvokedModuleOpt(module, n, graph->inputs()[0]);
+        if (m_opt.has_value()) {
+          invoked_methods.push_back(
+              std::make_pair(*m_opt, n->s(attr::name)));
+        }
       }
 
       for (Block* subblock : n->blocks()) {
@@ -1050,7 +1054,11 @@ void InsertObserversHelper::fillBoundaryValueMap(
         // for CallFunction start with actual input
         size_t input_offset;
         if (n->kind() == prim::CallMethod) {
-          auto m = getInvokedModule(module, n, self);
+          auto m_opt = getInvokedModuleOpt(module, n, self);
+          if (!m_opt.has_value()) {
+            continue;
+          }
+          auto m = *m_opt;
           g = m.get_method(n->s(attr::name)).graph();
           input_offset = 0;
         } else {
@@ -1365,7 +1373,11 @@ InsertObserversHelper::insertObserversFor(
         size_t input_offset;
         bool is_udf_for_subblock = is_user_defined_function;
         if (n->kind() == prim::CallMethod) {
-          m = getInvokedModule(module, n, self);
+          auto m_opt = getInvokedModuleOpt(module, n, self);
+          if (!m_opt.has_value()) {
+            continue;
+          }
+          m = *m_opt;
           g = m.get_method(n->s(attr::name)).graph();
           input_offset = 0;
         } else { // CallFunction

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -911,8 +911,7 @@ ModuleMethodVector InsertObserversHelper::getInvokedMethods(
       if (n->kind() == prim::CallMethod) {
         auto m_opt = getInvokedModuleOpt(module, n, graph->inputs()[0]);
         if (m_opt.has_value()) {
-          invoked_methods.push_back(
-              std::make_pair(*m_opt, n->s(attr::name)));
+          invoked_methods.push_back(std::make_pair(*m_opt, n->s(attr::name)));
         }
       }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41576 [quant][graphmode][fix] Make it work with CallMethod on non-Module objects**

Summary:
Previously we are assuming CallMethod only happens on module instances,
but it turns out this is not true, this PR fixes this issue.

Test Plan:
this is tested internally
Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22592789](https://our.internmc.facebook.com/intern/diff/D22592789)