### PR TITLE
Enable SLS FP32 accumulation SparseLengthsWeightedSumFused8BitRowwiseFakeFP32NNPI Op.

### DIFF
--- a/caffe2/contrib/fakelowp/fp16_fma.cc
+++ b/caffe2/contrib/fakelowp/fp16_fma.cc
@@ -117,4 +117,13 @@ void fma_fp16(int N, const float* A, const float* B, float* Out) {
   }
 }
 
+float fmafp32_avx_emulation(float v1, float v2, float v3) {
+  __m256 v1Vec = _mm256_set1_ps(v1);
+  __m256 v2Vec = _mm256_set1_ps(v2);
+  __m256 v3Vec = _mm256_set1_ps(v3);
+  __m256 resVec = _mm256_fmadd_ps(v1Vec, v2Vec, v3Vec);
+  float *result = (float *)&resVec;
+  return *result;
+}
+
 } // namespace fake_fp16

--- a/caffe2/contrib/fakelowp/fp16_fma.h
+++ b/caffe2/contrib/fakelowp/fp16_fma.h
@@ -11,4 +11,6 @@ void fma_fp16_slow(int N, const float* A, const float* B, float* Out);
 
 float fma_fp16_slow(const float A, const float B, float Out);
 
+float fmafp32_avx_emulation(float v1, float v2, float v3);
+
 } // namespace fake_fp16

--- a/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
@@ -240,8 +240,14 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
               FLAGS_caffe2_fbgemm_fake_fp16_clamp);
         } else if (use_acc_fp32) {
           for (int j = 0; j < block_size; ++j) {
-            float deqVal = scale * input_rounded[j] + bias;
-            rowTempSums[accIdx][j] += deqVal * weight;
+            float deqVal = fake_fp16::fmafp32_avx_emulation(
+                scale,
+                input_rounded[j],
+                bias);
+            rowTempSums[accIdx][j] = fake_fp16::fmafp32_avx_emulation(
+                deqVal,
+                weight,
+                rowTempSums[accIdx][j]);
           }
         } else {
           bias *= weight;

--- a/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
@@ -5,7 +5,7 @@ import unittest
 # Must happen before importing caffe2.python.*
 import caffe2.python.fakelowp.init_shared_libs  # noqa
 import numpy as np
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
@@ -32,10 +32,10 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
         batch_size=st.integers(1, 5),
         max_weight=st.integers(0, 100),
     )
-    @unittest.skip(
-        reason="This test fails with Intel NNPI 0.5.2.5 release"
-    )
-    def test_slws_fused_8bit_rowwise_acc32_nnpi(self, seed, num_rows, embedding_dim, batch_size, max_weight):
+    @settings(max_examples=100)
+    def test_slws_fused_8bit_rowwise_acc32_nnpi(
+        self, seed, num_rows, embedding_dim, batch_size, max_weight
+    ):
         workspace.GlobalInit(
             [
                 "caffe2",
@@ -92,7 +92,9 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
         workspace.FeedBlob("data", data)
         workspace.RunOperatorOnce(
             core.CreateOperator(
-                "FloatToFused8BitRowwiseQuantized", ["data"], ["quantized_data"]
+                "FloatToFused8BitRowwiseQuantized",
+                ["data"],
+                ["quantized_data"]
             )
         )
         onnxified_net = onnxifi_caffe2_net(
@@ -124,6 +126,10 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
             print_test_debug_info(
                 "test_slws_fused_8bit_rowwise_acc32_nnpi",
                 {
+                    "seed": seed,
+                    "num_rows": num_rows,
+                    "embedding_dim": embedding_dim,
+                    "batch_size": batch_size,
                     "indices": indices,
                     "data": data.shape,
                     "lengths": lengths,
@@ -138,9 +144,7 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
 
 
     @given(seed=st.integers(0, 65535))
-    @unittest.skip(
-        reason="This test fails with Intel NNPI 0.5.2.5 release"
-    )
+    @settings(max_examples=100)
     def test_small_sls_acc32(self, seed):
         workspace.GlobalInit(
             [
@@ -235,6 +239,9 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
                 "test_small_sls_acc32",
                 {
                     "seed": seed,
+                    "num_rows": num_rows,
+                    "embedding_dim": embedding_dim,
+                    "batch_size": batch_size,
                     "indices": indices,
                     "data": data,
                     "quantized_data": quantized_data,


### PR DESCRIPTION
Summary:
* Remove skipping test
* Use fma_avx_emulation
* Increase test examples to 100

Test Plan: Tests are covered in test_sls_8bit_nnpi.py

Reviewed By: hyuen

Differential Revision: D22585742

