### PR TITLE
[PT] add overload name for int prim ops

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -111,9 +111,9 @@ white_list = [
     ('aten::to_here(RRef(t) self, double timeout*)', datetime.date(2020, 6, 30)),
     ('aten::local_value', datetime.date(2020, 6, 30)),
     ('aten::log', datetime.date(2020, 7, 30)),
-    ('aten::__and__', datetime.date(2020, 6, 30)),
-    ('aten::__or__', datetime.date(2020, 6, 30)),
-    ('aten::__xor__', datetime.date(2020, 6, 30)),
+    ('aten::__and__', datetime.date(2020, 7, 30)),
+    ('aten::__or__', datetime.date(2020, 7, 30)),
+    ('aten::__xor__', datetime.date(2020, 7, 30)),
     ('aten::split', datetime.date(2020, 6, 30)),
     ('aten::add', datetime.date(2020, 7, 30)),
     ('aten::__upsample_bilinear', datetime.date(2020, 7, 30)),
@@ -133,6 +133,10 @@ white_list = [
     ('aten::_sparse_coo_tensor_with_dims', datetime.date(2020, 7, 30)),
     ('aten::_sparse_coo_tensor_with_dims_and_tensors', datetime.date(2020, 7, 30)),
     ('aten::to', datetime.date(2020, 7, 15)),
+    ('aten::__lshift__', datetime.date(2020, 7, 30)),
+    ('aten::__rshift__', datetime.date(2020, 7, 30)),
+    ('aten::__round_to_zero_floordiv', datetime.date(2020, 7, 30)),
+    ('aten::gcd', datetime.date(2020, 7, 30)),
 ]
 
 

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -475,7 +475,7 @@ void listSetItem(Stack* stack);
 
 #define DEFINE_INT_OP(aten_op, op)                          \
   Operator(                                                 \
-      #aten_op "(int a, int b) -> int",                     \
+      #aten_op ".int(int a, int b) -> int",                 \
       [](Stack* stack) {                                    \
         int64_t a, b;                                       \
         pop(stack, a, b);                                   \

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -602,7 +602,14 @@ RegisterOperators reg(
          static_cast<double>(pow(a, b)),
          static_cast<double>(pow(a, b)),
          float),
-     DEFINE_INT_OP(aten::pow.int_to_int, pow(a, b)),
+     Operator(
+         "aten::pow.int_to_int(int a, int b) -> int",
+         [](Stack* stack) {
+           int64_t a, b;
+           pop(stack, a, b);
+           push(stack, pow(a, b));
+         },
+         aliasAnalysisFromSchema()),
      // min and max are in prim:: because there is a difference between
      // the python builtin 'min' and 'torch.min'
      DEFINE_BINARY_OP(prim::min, a < b ? a : b),


### PR DESCRIPTION
Summary:
A new op aten::gcd(Tensor...) was added while the duplicated op name check was disabled. It's not a prime op, but it has the same name with one prime op aten::gcd(int, int).

It will be safer to enforce all prim ops have overload name, even there is no duplicated name right now. Since people may add tensor ops without overload name in the future. This diff added the overload name for all ops defined using "DEFINE_INT_OP".

Test Plan: run full JIT predictor

Differential Revision: D22593689

