### PR TITLE
Implementing NumPy-like function torch.signbit()

### DIFF
--- a/aten/src/ATen/core/NamedRegistrations.cpp
+++ b/aten/src/ATen/core/NamedRegistrations.cpp
@@ -373,6 +373,9 @@ TORCH_LIBRARY_IMPL(aten, Named, m) {
   m.impl("sign", CppFunction::makeFallthrough());
   m.impl("sign.out", CppFunction::makeFallthrough());
   m.impl("sign_", CppFunction::makeFallthrough());
+  m.impl("signbit", CppFunction::makeFallthrough());
+  m.impl("signbit.out", CppFunction::makeFallthrough());
+  m.impl("signbit_", CppFunction::makeFallthrough());
   m.impl("sin", CppFunction::makeFallthrough());
   m.impl("sin.out", CppFunction::makeFallthrough());
   m.impl("sin_", CppFunction::makeFallthrough());

--- a/aten/src/ATen/core/NamedRegistrations.cpp
+++ b/aten/src/ATen/core/NamedRegistrations.cpp
@@ -375,7 +375,6 @@ TORCH_LIBRARY_IMPL(aten, Named, m) {
   m.impl("sign_", CppFunction::makeFallthrough());
   m.impl("signbit", CppFunction::makeFallthrough());
   m.impl("signbit.out", CppFunction::makeFallthrough());
-  m.impl("signbit_", CppFunction::makeFallthrough());
   m.impl("sin", CppFunction::makeFallthrough());
   m.impl("sin.out", CppFunction::makeFallthrough());
   m.impl("sin_", CppFunction::makeFallthrough());

--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -617,6 +617,7 @@ _(aten, selu) \
 _(aten, set) \
 _(aten, sigmoid) \
 _(aten, sign) \
+_(aten, signbit) \
 _(aten, silu) \
 _(aten, sin) \
 _(aten, sinh) \

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -367,7 +367,8 @@ Tensor& logical_not_out(Tensor& result, const Tensor& self) {
 }
 
 Tensor& signbit_out(Tensor& result, const Tensor& self) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
+  TORCH_CHECK(!self.is_complex(), "signbit is not implemented for complex tensors.");
+  TORCH_CHECK(result.scalar_type() == at::kBool, "signbit does not support non-boolean outputs.");
   result.resize_(self.sizes());
 
   if (self.dtype() == at::kBool) {
@@ -378,8 +379,6 @@ Tensor& signbit_out(Tensor& result, const Tensor& self) {
       .set_check_mem_overlap(true)
       .add_output(result)
       .add_input(self)
-      .promote_inputs_to_common_dtype(true)
-      .cast_common_dtype_to_outputs(true)
       .build();
     signbit_stub(iter.device_type(), iter);
   }

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -366,6 +366,28 @@ Tensor& logical_not_out(Tensor& result, const Tensor& self) {
   return result;
 }
 
+Tensor& signbit_out(Tensor& result, const Tensor& self) {
+  TensorIterator iter = TensorIteratorConfig()
+    .check_all_same_dtype(false)
+    .set_check_mem_overlap(true)
+    .add_output(result)
+    .add_input(self)
+    .promote_inputs_to_common_dtype(true)
+    .cast_common_dtype_to_outputs(true)
+    .build();
+  signbit_stub(iter.device_type(), iter);
+  return result;
+}
+
+Tensor signbit(const Tensor& self) {
+  Tensor result = at::empty({0}, self.options().dtype(kBool));
+  return at::signbit_out(result, self);
+}
+
+Tensor& signbit_(Tensor& self) {
+  return at::signbit_out(self, self);
+}
+
 Tensor& clamp_out(Tensor& result, const Tensor& self, optional<Scalar> min, optional<Scalar> max) {
   TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
   if (min && max) {
@@ -543,6 +565,7 @@ DEFINE_DISPATCH(rsqrt_stub);
 DEFINE_DISPATCH(sigmoid_stub);
 DEFINE_DISPATCH(logit_stub);
 DEFINE_DISPATCH(sign_stub);
+DEFINE_DISPATCH(signbit_stub);
 DEFINE_DISPATCH(sin_stub);
 DEFINE_DISPATCH(sinh_stub);
 DEFINE_DISPATCH(sqrt_stub);

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -367,25 +367,28 @@ Tensor& logical_not_out(Tensor& result, const Tensor& self) {
 }
 
 Tensor& signbit_out(Tensor& result, const Tensor& self) {
-  TensorIterator iter = TensorIteratorConfig()
-    .check_all_same_dtype(false)
-    .set_check_mem_overlap(true)
-    .add_output(result)
-    .add_input(self)
-    .promote_inputs_to_common_dtype(true)
-    .cast_common_dtype_to_outputs(true)
-    .build();
-  signbit_stub(iter.device_type(), iter);
+  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
+  result.resize_(self.sizes());
+
+  if (self.dtype() == at::kBool) {
+    return result.fill_(false);
+  } else {
+    TensorIterator iter = TensorIteratorConfig()
+      .check_all_same_dtype(false)
+      .set_check_mem_overlap(true)
+      .add_output(result)
+      .add_input(self)
+      .promote_inputs_to_common_dtype(true)
+      .cast_common_dtype_to_outputs(true)
+      .build();
+    signbit_stub(iter.device_type(), iter);
+  }
   return result;
 }
 
 Tensor signbit(const Tensor& self) {
   Tensor result = at::empty({0}, self.options().dtype(kBool));
   return at::signbit_out(result, self);
-}
-
-Tensor& signbit_(Tensor& self) {
-  return at::signbit_out(self, self);
 }
 
 Tensor& clamp_out(Tensor& result, const Tensor& self, optional<Scalar> min, optional<Scalar> max) {

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -50,6 +50,7 @@ DECLARE_DISPATCH(unary_fn, rsqrt_stub);
 DECLARE_DISPATCH(unary_fn, sigmoid_stub);
 DECLARE_DISPATCH(unary_fn_with_scalar, logit_stub);
 DECLARE_DISPATCH(unary_fn, sign_stub);
+DECLARE_DISPATCH(unary_fn, signbit_stub);
 DECLARE_DISPATCH(unary_fn, sin_stub);
 DECLARE_DISPATCH(unary_fn, sinh_stub);
 DECLARE_DISPATCH(unary_fn, sqrt_stub);

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -292,6 +292,29 @@ static void sign_kernel(TensorIterator& iter){
   }
 }
 
+static void signbit_kernel(TensorIterator& iter){
+  if (iter.dtype() == ScalarType::Bool) {
+    if (iter.input_dtype() == ScalarType::Bool) {
+      cpu_kernel(iter, [](bool a) -> bool { return a; });
+    } else {
+      AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cpu", [&]() {
+        cpu_kernel(iter, [](scalar_t a) -> bool { return a < 0; });
+      });
+    }
+  } else {
+    if (iter.input_dtype() == ScalarType::Bool) {
+      AT_DISPATCH_INTEGRAL_TYPES_AND(at::ScalarType::Bool, iter.input_dtype(), "signbit_cpu", [&]() {
+        cpu_kernel(iter, [](bool a) -> scalar_t { return a; });
+      });
+    } else {
+      AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cpu", [&]() {
+        cpu_kernel(iter, [](scalar_t a) -> scalar_t { return a < 0; });
+      });
+    }
+  }
+}
+
+
 static void sinh_kernel(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(iter.dtype(), "sinh_cpu", [&]() {
     cpu_kernel_vec(
@@ -615,6 +638,7 @@ REGISTER_DISPATCH(frac_stub, &frac_kernel);
 REGISTER_DISPATCH(reciprocal_stub, &reciprocal_kernel);
 REGISTER_DISPATCH(neg_stub, &neg_kernel);
 REGISTER_DISPATCH(sign_stub, &sign_kernel);
+REGISTER_DISPATCH(signbit_stub, &signbit_kernel);
 REGISTER_DISPATCH(sinh_stub, &sinh_kernel);
 REGISTER_DISPATCH(cosh_stub, &cosh_kernel);
 REGISTER_DISPATCH(acosh_stub, &acosh_kernel);

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -293,27 +293,10 @@ static void sign_kernel(TensorIterator& iter){
 }
 
 static void signbit_kernel(TensorIterator& iter){
-  if (iter.dtype() == ScalarType::Bool) {
-    if (iter.input_dtype() == ScalarType::Bool) {
-      cpu_kernel(iter, [](bool a) -> bool { return a; });
-    } else {
-      AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cpu", [&]() {
-        cpu_kernel(iter, [](scalar_t a) -> bool { return a < 0; });
-      });
-    }
-  } else {
-    if (iter.input_dtype() == ScalarType::Bool) {
-      AT_DISPATCH_INTEGRAL_TYPES_AND(at::ScalarType::Bool, iter.input_dtype(), "signbit_cpu", [&]() {
-        cpu_kernel(iter, [](bool a) -> scalar_t { return a; });
-      });
-    } else {
-      AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cpu", [&]() {
-        cpu_kernel(iter, [](scalar_t a) -> scalar_t { return a < 0; });
-      });
-    }
-  }
+  AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cpu", [&]() {
+    cpu_kernel(iter, [](scalar_t a) -> scalar_t { return a < 0; });
+  });
 }
-
 
 static void sinh_kernel(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(iter.dtype(), "sinh_cpu", [&]() {

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -294,7 +294,7 @@ static void sign_kernel(TensorIterator& iter){
 
 static void signbit_kernel(TensorIterator& iter){
   AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cpu", [&]() {
-    cpu_kernel(iter, [](scalar_t a) -> scalar_t { return a < 0; });
+    cpu_kernel(iter, [](scalar_t a) -> bool { return a < 0; });
   });
 }
 

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -46,15 +46,9 @@ void sign_kernel_cuda(TensorIterator& iter){
 }
 
 void signbit_kernel_cuda(TensorIterator& iter){
-  if (iter.input_dtype() == ScalarType::Bool) {
-    AT_DISPATCH_INTEGRAL_TYPES_AND(at::ScalarType::Bool, iter.input_dtype(), "signbit_cuda", [&]() {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return a; });
-    });
-  } else {
-    AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return a < 0; });
-    });
-  }
+  AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t { return a < 0; });
+  });
 }
 
 REGISTER_DISPATCH(logical_not_stub, &logical_not_kernel_cuda);

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -45,8 +45,21 @@ void sign_kernel_cuda(TensorIterator& iter){
   }
 }
 
+void signbit_kernel_cuda(TensorIterator& iter){
+  if (iter.input_dtype() == ScalarType::Bool) {
+    AT_DISPATCH_INTEGRAL_TYPES_AND(at::ScalarType::Bool, iter.input_dtype(), "signbit_cuda", [&]() {
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return a; });
+    });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
+      gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return a < 0; });
+    });
+  }
+}
+
 REGISTER_DISPATCH(logical_not_stub, &logical_not_kernel_cuda);
 REGISTER_DISPATCH(neg_stub, &neg_kernel_cuda);
 REGISTER_DISPATCH(sign_stub, &sign_kernel_cuda);
+REGISTER_DISPATCH(signbit_stub, &signbit_kernel_cuda);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -47,7 +47,7 @@ void sign_kernel_cuda(TensorIterator& iter){
 
 void signbit_kernel_cuda(TensorIterator& iter){
   AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t { return a < 0; });
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return a < 0; });
   });
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4973,9 +4973,6 @@
   use_c10_dispatcher: full
   variants: function, method
 
-- func: signbit_(Tensor(a!) self) -> Tensor(a!)
-  variants: method
-
 - func: signbit.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: signbit_out

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4969,6 +4969,15 @@
   dispatch:
     CPU, CUDA: sign_out
 
+- func: signbit(Tensor self, *) -> Tensor
+  use_c10_dispatcher: full
+  variants: function, method
+
+- func: signbit_(Tensor(a!) self) -> Tensor(a!)
+  variants: method
+
+- func: signbit.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+
 - func: dist(Tensor self, Tensor other, Scalar p=2) -> Tensor
   use_c10_dispatcher: full
   variants: method, function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4969,7 +4969,7 @@
   dispatch:
     CPU, CUDA: sign_out
 
-- func: signbit(Tensor self, *) -> Tensor
+- func: signbit(Tensor self) -> Tensor
   use_c10_dispatcher: full
   variants: function, method
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4977,6 +4977,9 @@
   variants: method
 
 - func: signbit.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU: signbit_out
+    CUDA: signbit_out
 
 - func: dist(Tensor self, Tensor other, Scalar p=2) -> Tensor
   use_c10_dispatcher: full

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -487,7 +487,6 @@ view of a storage and defines numeric operations on it.
    .. automethod:: sign
    .. automethod:: sign_
    .. automethod:: signbit
-   .. automethod:: signbit_
    .. automethod:: sin
    .. automethod:: sin_
    .. automethod:: sinh

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -486,6 +486,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: sigmoid_
    .. automethod:: sign
    .. automethod:: sign_
+   .. automethod:: signbit
+   .. automethod:: signbit_
    .. automethod:: sin
    .. automethod:: sin_
    .. automethod:: sinh

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -303,6 +303,7 @@ Pointwise Ops
     rsqrt
     sigmoid
     sign
+    signbit
     sin
     sinh
     sqrt

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11394,6 +11394,15 @@ class TestTorchDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'signbit is not implemented for complex tensors.'):
             torch.signbit(t, out=out)
 
+    @dtypes(*(torch.testing.get_all_dtypes(include_bool=False)))
+    def test_signbit_non_boolean_output(self, device, dtype):
+        # test non-boolean tensors as the `out=` parameters
+        # boolean outputs are tested in the above testcases
+        t = torch.randn(5, 5)
+        out = torch.empty_like(t, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, 'does not support non-boolean outputs'):
+            torch.signbit(t, out=out)
+
     def test_logical_any(self, device):
         x = torch.zeros([2, 3, 400], dtype=torch.uint8, device=device)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11389,9 +11389,9 @@ class TestTorchDeviceType(TestCase):
         t = torch.tensor(vals, device=device, dtype=dtype)
         out = torch.empty_like(t).real.bool()
 
-        with self.assertRaisesRegex(RuntimeError, 'clamp is not yet implemented for complex tensors.'):
+        with self.assertRaisesRegex(RuntimeError, 'signbit is not implemented for complex tensors.'):
             torch.signbit(t)
-        with self.assertRaisesRegex(RuntimeError, 'clamp is not yet implemented for complex tensors.'):
+        with self.assertRaisesRegex(RuntimeError, 'signbit is not implemented for complex tensors.'):
             torch.signbit(t, out=out)
 
     def test_logical_any(self, device):

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -633,6 +633,7 @@ def get_testing_overrides():
         torch.selu: lambda input, inplace=False: -1,
         torch.sigmoid: lambda input, out=None: -1,
         torch.sign: lambda input, out=None: -1,
+        torch.signbit: lambda input, out=None: -1,
         torch.sin: lambda input, out=None: -1,
         torch.sinh: lambda input, out=None: -1,
         torch.slogdet: lambda input: -1,

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2832,6 +2832,20 @@ sign_() -> Tensor
 In-place version of :meth:`~Tensor.sign`
 """)
 
+add_docstr_all('signbit',
+               r"""
+signbit() -> Tensor
+
+See :func:`torch.signbit`
+""")
+
+add_docstr_all('signbit_',
+               r"""
+signbit_() -> Tensor
+
+In-place version of :meth:`~Tensor.signbit`
+""")
+
 add_docstr_all('sin',
                r"""
 sin() -> Tensor

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2839,13 +2839,6 @@ signbit() -> Tensor
 See :func:`torch.signbit`
 """)
 
-add_docstr_all('signbit_',
-               r"""
-signbit_() -> Tensor
-
-In-place version of :meth:`~Tensor.signbit`
-""")
-
 add_docstr_all('sin',
                r"""
 sin() -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5704,6 +5704,28 @@ Example::
     tensor([ 1., -1.,  0.,  1.])
 """.format(**common_args))
 
+add_docstr(torch.signbit,
+           r"""
+signbit(input, out=None) -> Tensor
+
+Returns a new tensor with the signbits of the elements of :attr:`input`.
+
+.. math::
+    \text{out}_{i} = \operatorname{sgn}(\text{input}_{i})
+""" + r"""
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> a = torch.tensor([0.7, -1.2, 0., 2.3])
+    >>> a
+    tensor([ 0.7000, -1.2000,  0.0000,  2.3000])
+    >>> torch.signbit(a)
+    tensor([ False, True,  False,  False])
+""".format(**common_args))
+
 add_docstr(torch.sin,
            r"""
 sin(input, out=None) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5706,22 +5706,23 @@ Example::
 
 add_docstr(torch.signbit,
            r"""
-signbit(input, out=None) -> Tensor
+signbit(input, *, out=None) -> Tensor
 
-Returns a new tensor with the signbits of the elements of :attr:`input`.
+Tests if each element of :attr:`input` has its sign bit set (is less than zero) or not.
 
 .. math::
     \text{out}_{i} = \operatorname{sgn}(\text{input}_{i})
 """ + r"""
+
 Args:
-    {input}
-    {out}
+  {input}
+
+Keyword args:
+  {out}
 
 Example::
 
     >>> a = torch.tensor([0.7, -1.2, 0., 2.3])
-    >>> a
-    tensor([ 0.7000, -1.2000,  0.0000,  2.3000])
     >>> torch.signbit(a)
     tensor([ False, True,  False,  False])
 """.format(**common_args))

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5710,10 +5710,6 @@ signbit(input, *, out=None) -> Tensor
 
 Tests if each element of :attr:`input` has its sign bit set (is less than zero) or not.
 
-.. math::
-    \text{out}_{i} = \operatorname{sgn}(\text{input}_{i})
-""" + r"""
-
 Args:
   {input}
 


### PR DESCRIPTION
- Related with #38349 
- Implementing the NumPy-like function `torch.signbit()` .