### PR TITLE
[RPC] Use leaky singleton for current RPC agent global

### DIFF
--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 
+#include <c10/util/Logging.h>
+
 namespace torch {
 namespace distributed {
 namespace rpc {
@@ -237,6 +239,9 @@ const WorkerInfo& RpcAgent::getWorkerInfo() const {
 }
 
 std::shared_ptr<RpcAgent>& getRefToCurrentRpcAgent() {
+  #ifdef C10_USE_GLOG
+    google::base::GetLogger(google::GLOG_ERROR);
+  #endif
   static std::shared_ptr<RpcAgent> currentRpcAgent = nullptr;
   return currentRpcAgent;
 }

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -268,7 +268,6 @@ class TORCH_API RpcAgent {
   std::atomic<bool> rpcAgentRunning_;
 
  private:
-  static std::shared_ptr<RpcAgent> currentRpcAgent_;
   // Add GIL wait time data point to metrics
   virtual void addGilWaitTime(const std::chrono::microseconds gilWaitTime) = 0;
   friend class PythonRpcHandler;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41591 [RPC] Use leaky singleton for current RPC agent global**

This allows to delay its construction until it's first used and, therefore, ensure its destruction before all global static objects. In particular, if we didn't do this, and if the user forgot to explicitly call `rpc.shutdown()`, then the static destruction order could first destroy the glog mutexes and only then destroy the global static shared_ptr holding the RPC agent, which would only shut down at that moment, and if it were to encounter an error and attempt to log it would fail and crash the process.

Differential Revision: [D22597100](https://our.internmc.facebook.com/intern/diff/D22597100/)