### PR TITLE
Fix bug on the backpropagation of LayerNorm when create_graph=True

### DIFF
--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -2553,7 +2553,7 @@ infinitely_differentiable_native_layer_norm_backward(
       const Tensor& a = rstd_tensor;
       const Tensor b = (db * mean_tensor - ds) * rstd_cube * s;
       const Tensor c = -b * mean_tensor - db * rstd_tensor * s;
-      dX = a * dY_tensor + b * X_tensor + c;
+      dX = a * dY_tensor * gamma_tensor + b * X_tensor + c;
       if (dmean.defined() && drstd.defined()) {
         dX += var_std_mean_backward(
             {dvar, dmean.view({M, 1})},

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -2553,7 +2553,11 @@ infinitely_differentiable_native_layer_norm_backward(
       const Tensor& a = rstd_tensor;
       const Tensor b = (db * mean_tensor - ds) * rstd_cube * s;
       const Tensor c = -b * mean_tensor - db * rstd_tensor * s;
-      dX = a * dY_tensor * gamma_tensor + b * X_tensor + c;
+      if (gamma.defined()) {
+        dX = a * dY_tensor * gamma_tensor + b * X_tensor + c;
+      } else {
+        dX = a * dY_tensor + b * X_tensor + c;
+      }
       if (dmean.defined() && drstd.defined()) {
         dX += var_std_mean_backward(
             {dvar, dmean.view({M, 1})},


### PR DESCRIPTION
Solve an issue #41332

I found the bug at #41332 is caused by LayerNorm.

Current implementations of LayerNorm have a disparity between 
1. [`create_graph=False` CUDA implementation](https://github.com/BIT-silence/pytorch/blob/dde3d5f4a8f713ecc4649d776565b68ca75ae5c8/aten/src/ATen/native/cuda/layer_norm_kernel.cu#L145)
2. [`create_graph=True` implementation](https://github.com/BIT-silence/pytorch/blob/dde3d5f4a8f713ecc4649d776565b68ca75ae5c8/tools/autograd/templates/Functions.cpp#L2536)

With this bug-fix, #41332 is solved.

@Ailing @BIT-silence

Signed-off-by: Vinnam Kim <vinnamkim@gmail.com>

