### PR TITLE
Raise error for duplicate params in param group #40967

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -493,8 +493,11 @@ class TestOptim(TestCase):
 
     def test_duplicate_params_in_param_group(self):
         param = Variable(torch.randn(5, 5))
-        with self.assertRaises(ValueError):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             optim.SGD([param, param], lr=0.1)
+            self.assertEqual(len(w), 1)
+            self.assertIn('a parameter group with duplicate parameters', str(w[0].message))
 
 
 class SchedulerTestNet(torch.nn.Module):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -491,6 +491,11 @@ class TestOptim(TestCase):
         with self.assertRaises(TypeError):
             optim.SGD(Variable(torch.randn(5, 5)), lr=3)
 
+    def test_duplicate_params_in_param_group(self):
+        param = Variable(torch.randn(5, 5))
+        with self.assertRaises(ValueError):
+            optim.SGD([param, param], lr=0.1)
+
 
 class SchedulerTestNet(torch.nn.Module):
     def __init__(self):

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -4,6 +4,7 @@ from torch._six import container_abcs
 import torch
 from copy import deepcopy
 from itertools import chain
+import warnings
 
 
 class _RequiredParameter(object):
@@ -221,7 +222,9 @@ class Optimizer(object):
 
         params = param_group['params']
         if len(params) != len(set(params)):
-            raise ValueError("optimizer contains a parameter group with duplicate parameters")
+            warnings.warn("optimizer contains a parameter group with duplicate parameters; "
+                          "in future, this will cause an error; "
+                          "see github.com/pytorch/pytorch/issues/40967 for more information", stacklevel=3)
 
         param_set = set()
         for group in self.param_groups:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -219,6 +219,10 @@ class Optimizer(object):
             else:
                 param_group.setdefault(name, default)
 
+        params = param_group['params']
+        if len(params) != len(set(params)):
+            raise ValueError("optimizer contains a parameter group with duplicate parameters")
+
         param_set = set()
         for group in self.param_groups:
             param_set.update(set(group['params']))


### PR DESCRIPTION
This PR fixes an issue in #40967 where duplicate parameters across different parameter groups are not allowed, but duplicates inside the same parameter group are accepted. After this PR, both cases are treated equally and raise `ValueError`.