### PR TITLE
fix #36801

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,6 +543,7 @@ jobs:
         no_output_timeout: "90m"
         command: |
           set -e
+          export PYTHONUNBUFFERED=1
           # See Note [Special build images]
           output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           if [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -81,6 +81,7 @@ jobs:
         no_output_timeout: "90m"
         command: |
           set -e
+          export PYTHONUNBUFFERED=1
           # See Note [Special build images]
           output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           if [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then


### PR DESCRIPTION
unittest actually did stdout testname like (test_accumulate_grad (__main__.TestAutograd) ... ) first befor test start running. export PYTHONUNBUFFERED=1 or python -u could record this msg. @ezyang 