### PR TITLE
workaround segfault in deviceGuard construction

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
+#include <c10/cuda/CUDAGuard.h>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
@@ -47,7 +48,7 @@ void mul_kernel_cuda(TensorIterator& iter) {
             int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
             auto b = iter.scalar_value<accscalar_t>(scalar_arg);
             iter.remove_operand(scalar_arg);
-            const OptionalDeviceGuard device_guard(device_of(iter.tensor(1)));
+            const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
             gpu_kernel(iter, [b]GPU_LAMBDA(scalar_t a) -> scalar_t {
               return a * b;
             });


### PR DESCRIPTION
Summary:
Per title. In some situation, deviceGuard constructor in mul_kernel_cuda segfaults, so construct deviceGuard conditionally only when first argument is scalar.
This does not root cause why deviceGuard constructor segfaults, so the issue might come back.

Test Plan: pytorch oss CI

Differential Revision: D22616460

