### PR TITLE
Update weight init to general use cases

### DIFF
--- a/docs/source/nn.init.rst
+++ b/docs/source/nn.init.rst
@@ -21,3 +21,4 @@ torch.nn.init
 .. autofunction:: kaiming_normal_
 .. autofunction:: orthogonal_
 .. autofunction:: sparse_
+.. autofunction:: use_init_version

--- a/test/test_init_version.py
+++ b/test/test_init_version.py
@@ -30,7 +30,7 @@ class InitVersionTest(TestCase):
     def test_init_version_remains_same(self):
         # _init_version should remain same before and after using init_version
         before = _init_version
-        with init_version(use_master=True) as v:
+        with init_version() as v:
             l = nn.Linear(2, 3)
         after = _init_version
 

--- a/test/test_init_version.py
+++ b/test/test_init_version.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from torch.nn.init import init_version, _init_version, _parse_version
+from torch.nn.init import parse_version, init_version, use_init_version
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 
@@ -11,7 +11,7 @@ class InitVersionTest(TestCase):
     def test_pre_1_7_0_linear(self):
         # uniform init is used
         torch.manual_seed(4)
-        with init_version('1.6.1') as v:
+        with use_init_version('1.6.1') as v:
             l = nn.Linear(2, 3)
 
         x = l.bias.mean().item()
@@ -20,7 +20,7 @@ class InitVersionTest(TestCase):
 
     def test_1_7_0_linear(self):
         # zero bias is used
-        with init_version('1.7.0') as v:
+        with use_init_version('1.7.0') as v:
             l = nn.Linear(2, 3)
 
         x = l.bias.data
@@ -29,10 +29,10 @@ class InitVersionTest(TestCase):
 
     def test_init_version_remains_same(self):
         # _init_version should remain same before and after using init_version
-        before = _init_version
-        with init_version() as v:
+        before = init_version
+        with use_init_version() as v:
             l = nn.Linear(2, 3)
-        after = _init_version
+        after = init_version
 
         x = torch.tensor(before)
         y = torch.tensor(after)
@@ -40,11 +40,11 @@ class InitVersionTest(TestCase):
 
     def test_version_greater_than_torch(self):
         # cannot pass version greater than torch.__version__ in init_version
-        current_torch_version = _parse_version(torch.__version__)
+        current_torch_version = parse_version(torch.__version__)
         new_torch_version = (current_torch_version[0], current_torch_version[1] + 1, current_torch_version[2])
 
         try:
-            with init_version(new_torch_version) as v:
+            with use_init_version(new_torch_version) as v:
                 l = nn.Linear(2, 3)
             raise ValueError(
                 f'Cannot pass version number {new_torch_version} greater than torch.__version__ ',

--- a/test/test_init_version.py
+++ b/test/test_init_version.py
@@ -39,7 +39,7 @@ class InitVersionTest(TestCase):
         self.assertEqual(x, y)
 
     def test_version_greater_than_torch(self):
-        # cannot pass version greater than torch.__version__ in init_version
+        # cannot pass version greater than torch.__version__ in use_init_version
         current_torch_version = parse_version(torch.__version__)
         new_torch_version = (current_torch_version[0], current_torch_version[1] + 1, current_torch_version[2])
 

--- a/test/test_init_version.py
+++ b/test/test_init_version.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from torch.nn.init import parse_version, init_version, use_init_version
+from torch.nn.init import init_version, _torch_version, use_init_version
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 
@@ -8,23 +8,22 @@ class InitVersionTest(TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def test_pre_1_7_0_linear(self):
-        # uniform init is used
+    def test_linear(self):
+        # >= 1.7.0
+        with use_init_version('1.7.0') as v:
+            l = nn.Linear(2, 3)
+
+        x = l.bias.data
+        y = torch.zeros(3, dtype=torch.float32)
+        self.assertEqual(x, y)
+
+        # < 1.7.0
         torch.manual_seed(4)
         with use_init_version('1.6.1') as v:
             l = nn.Linear(2, 3)
 
         x = l.bias.mean().item()
         y = 0.48299
-        self.assertEqual(x, y)
-
-    def test_1_7_0_linear(self):
-        # zero bias is used
-        with use_init_version('1.7.0') as v:
-            l = nn.Linear(2, 3)
-
-        x = l.bias.data
-        y = torch.zeros(3, dtype=torch.float32)
         self.assertEqual(x, y)
 
     def test_init_version_remains_same(self):
@@ -40,24 +39,12 @@ class InitVersionTest(TestCase):
 
     def test_version_greater_than_torch(self):
         # cannot pass version greater than torch.__version__ in use_init_version
-        current_torch_version = parse_version(torch.__version__)
+        current_torch_version = _torch_version
         new_torch_version = (current_torch_version[0], current_torch_version[1] + 1, current_torch_version[2])
 
-        try:
-            with use_init_version(new_torch_version) as v:
+        with self.assertRaises(ValueError):
+            with use_init_version(new_torch_version) as version:
                 l = nn.Linear(2, 3)
-            raise ValueError(
-                f'Cannot pass version number {new_torch_version} greater than torch.__version__ ',
-                f'{current_torch_version} in nn.init.init_version'
-            )
-        except ValueError as e:
-            error_message = e.args[0]
-            expected_error_message = f'version {new_torch_version} should be less than torch version {current_torch_version}'
-            if error_message != expected_error_message:
-                raise ValueError(
-                    f'Cannot pass version number {new_torch_version} greater than torch.__version__ ',
-                    f'{current_torch_version} in nn.init.init_version'
-                )
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_init_version.py
+++ b/test/test_init_version.py
@@ -1,0 +1,57 @@
+import torch
+import torch.nn as nn
+from torch.nn.init import init_version, _init_version, _parse_version
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+class InitVersionTest(TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def test_pre_1_7_0_linear(self):
+        # uniform init is used
+        torch.manual_seed(4)
+        with init_version('1.6.1') as v:
+            l = nn.Linear(2, 3)
+
+        x = l.bias.mean().item()
+        y = 0.48299
+        self.assertEqual(x, y)
+
+    def test_1_7_0_linear(self):
+        # zero bias is used
+        with init_version('1.7.0') as v:
+            l = nn.Linear(2, 3)
+
+        x = l.bias.data
+        y = torch.zeros(3, dtype=torch.float32)
+        self.assertEqual(x, y)
+
+    def test_init_version_remains_same(self):
+        # _init_version should remain same before and after using init_version
+        before = _init_version
+        with init_version(use_master=True) as v:
+            l = nn.Linear(2, 3)
+        after = _init_version
+
+        x = torch.tensor(before)
+        y = torch.tensor(after)
+        self.assertEqual(x, y)
+
+    def test_version_greater_than_torch(self):
+        # cannot pass version greater than torch.__version__ in init_version
+        current_torch_version = _parse_version(torch.__version__)
+        new_torch_version = (current_torch_version[0], current_torch_version[1] + 1, current_torch_version[2])
+
+        try:
+            with init_version(new_torch_version) as v:
+                l = nn.Linear(2, 3)
+            raise ValueError(f'Cannot pass version number {new_torch_version} greater than torch.__version__ {current_torch_version} in nn.init.init_version')
+        except ValueError as e:
+            error_message = e.args[0]
+            expected_error_message = f'version {new_torch_version} should be less than torch version {current_torch_version}'
+            if error_message != expected_error_message:
+                raise ValueError(f'Cannot pass version number {new_torch_version} greater than torch.__version__ {current_torch_version} in nn.init.init_version')
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_init_version.py
+++ b/test/test_init_version.py
@@ -46,12 +46,18 @@ class InitVersionTest(TestCase):
         try:
             with init_version(new_torch_version) as v:
                 l = nn.Linear(2, 3)
-            raise ValueError(f'Cannot pass version number {new_torch_version} greater than torch.__version__ {current_torch_version} in nn.init.init_version')
+            raise ValueError(
+                f'Cannot pass version number {new_torch_version} greater than torch.__version__ ',
+                f'{current_torch_version} in nn.init.init_version'
+            )
         except ValueError as e:
             error_message = e.args[0]
             expected_error_message = f'version {new_torch_version} should be less than torch version {current_torch_version}'
             if error_message != expected_error_message:
-                raise ValueError(f'Cannot pass version number {new_torch_version} greater than torch.__version__ {current_torch_version} in nn.init.init_version')
+                raise ValueError(
+                    f'Cannot pass version number {new_torch_version} greater than torch.__version__ ',
+                    f'{current_torch_version} in nn.init.init_version'
+                )
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -533,6 +533,7 @@ sparse = _make_deprecate(sparse_)
 GET_SEMANTIC_VERSION = re.compile(r'\d+\.\d+\.\d+')
 
 def _get_semantic_version_from_string(version: str) -> Tuple[int, int, int]:
+    """version: should be 'major.minor.micro'"""
     v = GET_SEMANTIC_VERSION.findall(version)
 
     if len(v) != 1:
@@ -541,15 +542,13 @@ def _get_semantic_version_from_string(version: str) -> Tuple[int, int, int]:
     v = v[0].split('.')
     return (int(v[0]), int(v[1]), int(v[2]))
 
+
 # Use "init_version" to handle "_init_version". This value corresponds to the last pytorch version that
 # did not have 'init_version' context manager.
 _init_version = (1, 6, 1)
 _torch_version = _get_semantic_version_from_string(torch.__version__)
 
-def _parse_version(version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> Tuple[int, int, int]:
-    if use_master:
-        return _torch_version
-
+def _parse_version(version: Union[Tuple[int, int, int], str] = None) -> Tuple[int, int, int]:
     if version is None:
         return _init_version
 
@@ -569,7 +568,7 @@ def _parse_version(version: Union[Tuple[int, int, int], str] = None, use_master:
 
 
 @contextlib.contextmanager
-def init_version(version=None, use_master=False):
+def init_version(version=None):
     r"""Context manager to use a specific version of initialization for `nn.modules`.
     By default, the pytorch initialization used till version 1.6.1 is used.
 
@@ -577,17 +576,11 @@ def init_version(version=None, use_master=False):
         version : Union[Tuple[int, int, int], str], which pytorch version to use for initializing nn.modules.
             The format should be a version string (major,minor,micro) or a tuple of integers. Examples of valid
             version are (1,7,0), '1.7.1'.
-        use_master : bool, If True, then the latest initialization scheme is used ignoring the value of `version`
-            (default=False)
 
     Examples:
         >>> with nn.init.init_version() as version:
         >>>     # use the default pytorch initialization used till pytorch version 1.6.1
         >>>     # This is the default behaviour.
-        >>>     model = nn.Sequential(...)
-        >>>
-        >>> with nn.init.init_version(use_master=True) as version:
-        >>>     # use latest initialization
         >>>     model = nn.Sequential(...)
         >>>
         >>> with nn.init.init_version(version='1.7.1') as version:
@@ -619,7 +612,7 @@ def init_version(version=None, use_master=False):
     """
     global _init_version
 
-    version = _parse_version(version, use_master)
+    version = _parse_version(version)
 
     old_init_version = _init_version
     _init_version = version

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -534,12 +534,12 @@ GET_SEMANTIC_VERSION = re.compile(r'\d+\.\d+\.\d+')
 
 def _get_version_as_tuple_from_string(version: str) -> Tuple[int, int, int]:
     """version: should be 'major.minor.patch'"""
-    v = GET_SEMANTIC_VERSION.match(version).group(0)
+    v = GET_SEMANTIC_VERSION.match(version)
 
     if v is None:
         raise TypeError("Invalid version, not a valid semantic version (e.g. of correct input, 1.7.1)")
 
-    v = v.split('.')
+    v = v.group(0).split('.')
     return (int(v[0]), int(v[1]), int(v[2]))
 
 _torch_version = _get_version_as_tuple_from_string(torch.__version__)

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -550,13 +550,20 @@ def _parse_version(version: Union[Tuple[int, int, int], str] = None, use_master:
     elif isinstance(version, str):
         if version.count('.') != 2:
             raise ValueError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
-        for x in version:
-            if not ((x >= '0' and x <= '9') or x == '.'):
-                raise ValueError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
+        v = version.split('.')
+        v = (v[0], v[1], v[2][0])
+        for version_type in v:
+            for char in version_type:
+                if not ((char >= '0' and char <= '9') or char == '.'):
+                    raise ValueError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
         v = version.split('.')
         version = (int(v[0]), int(v[1]), int(v[2][0]))
     else:
         raise TypeError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
+
+    # version, should be less than torch.__version__
+    if version > _torch_version:
+        raise ValueError(f"version {version} should be less than torch version {_torch_version}")
     return version
 
 
@@ -612,10 +619,6 @@ def init_version(version=None, use_master=False) -> ContextManager[int]:
     global _init_version
 
     version = _parse_version(version, use_master)
-
-    # version, should be less than torch.__version__
-    if version > _torch_version:
-        raise ValueError(f"version {version} should be less than torch version {_torch_version}")
 
     old_init_version = _init_version
     _init_version = version

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -3,7 +3,7 @@ from __future__ import division
 import math
 import warnings
 import contextlib
-from typing import Tuple, Union, ContextManager
+from typing import Tuple, Union
 
 import torch
 from torch import Tensor
@@ -551,10 +551,10 @@ def _parse_version(version: Union[Tuple[int, int, int], str] = None, use_master:
         if version.count('.') != 2:
             raise ValueError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
         v = version.split('.')
-        v = (v[0], v[1], v[2][0])
+        v = [v[0], v[1], v[2][0]]
         for version_type in v:
             for char in version_type:
-                if not ((char >= '0' and char <= '9') or char == '.'):
+                if not ((str(char) >= '0' and str(char) <= '9') or str(char) == '.'):
                     raise ValueError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
         v = version.split('.')
         version = (int(v[0]), int(v[1]), int(v[2][0]))
@@ -568,7 +568,7 @@ def _parse_version(version: Union[Tuple[int, int, int], str] = None, use_master:
 
 
 @contextlib.contextmanager
-def init_version(version=None, use_master=False) -> ContextManager[int]:
+def init_version(version=None, use_master=False):
     r"""Context manager to use a specific version of initialization for `nn.modules`.
     By default, the pytorch initialization used till version 1.6.1 is used.
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -532,7 +532,7 @@ sparse = _make_deprecate(sparse_)
 
 GET_SEMANTIC_VERSION = re.compile(r'\d+\.\d+\.\d+')
 
-def _get_semantic_version_from_string(version: str) -> Tuple[int, int, int]:
+def _get_version_as_tuple_from_string(version: str) -> Tuple[int, int, int]:
     """version: should be 'major.minor.micro'"""
     v = GET_SEMANTIC_VERSION.findall(version)
 
@@ -544,7 +544,7 @@ def _get_semantic_version_from_string(version: str) -> Tuple[int, int, int]:
 
 
 init_version = (1, 6, 1)
-_torch_version = _get_semantic_version_from_string(torch.__version__)
+_torch_version = _get_version_as_tuple_from_string(torch.__version__)
 
 def parse_version(version: Union[Tuple[int, int, int], str] = None) -> Tuple[int, int, int]:
     if version is None:
@@ -555,7 +555,7 @@ def parse_version(version: Union[Tuple[int, int, int], str] = None) -> Tuple[int
             if not isinstance(x, int):
                 raise ValueError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
     elif isinstance(version, str):
-        version = _get_semantic_version_from_string(version)
+        version = _get_version_as_tuple_from_string(version)
     else:
         raise TypeError("Invalid version, must be a version string (e.g. '1.7.0') or tuple of integers")
 
@@ -576,11 +576,6 @@ def use_init_version(version=None):
             version are (1,7,0), '1.7.1'.
 
     Examples:
-        >>> with nn.init.use_init_version() as version:
-        >>>     # use the default pytorch initialization used till pytorch version 1.6.1
-        >>>     # This is the default behaviour.
-        >>>     model = nn.Sequential(...)
-        >>>
         >>> with nn.init.use_init_version(version='1.7.1') as version:
         >>>     model = nn.Sequential(...)
         >>>

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import re
 import math
 import warnings
 import contextlib
@@ -529,9 +530,15 @@ orthogonal = _make_deprecate(orthogonal_)
 sparse = _make_deprecate(sparse_)
 
 
-v = torch.__version__.split('.')
-# These can also be used as global flags
-_torch_version = (int(v[0]), int(v[1]), int(v[2][0]))
+def _get_torch_version():
+    """Returns torch.__version__ as Tuple(int,int,int)"""
+    GET_TORCH_VERSION = re.compile(r'\d+\.\d+\.\d+')
+    v = GET_TORCH_VERSION.findall(torch.__version__)
+    assert len(v) == 1, "GET_TORCH_VERSION failed to find torch version"
+    v = v[0].split('.')
+    return (int(v[0]), int(v[1]), int(v[2]))
+
+_torch_version = _get_torch_version()
 # Use "init_version" to handle "_init_version". This value corresponds to the last pytorch version that
 # did not have 'init_version' context manager.
 _init_version = (1, 6, 1)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -82,7 +82,7 @@ class _ConvNd(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str, None] = None) -> None:
         with init.use_init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -83,7 +83,7 @@ class _ConvNd(Module):
         self.reset_parameters()
 
     def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
-        with init.init_version(version) as version:
+        with init.use_init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
                 if self.bias is not None:

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -11,7 +11,7 @@ from .module import Module
 from .utils import _single, _pair, _triple, _reverse_repeat_tuple
 
 from ..common_types import _size_1_t, _size_2_t, _size_3_t
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Union
 
 
 class _ConvNd(Module):

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -82,8 +82,8 @@ class _ConvNd(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
-        with init.init_version(version, use_master) as version:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
+        with init.init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
                 if self.bias is not None:

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -82,12 +82,18 @@ class _ConvNd(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self) -> None:
-        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
-        if self.bias is not None:
-            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
-            bound = 1 / math.sqrt(fan_in)
-            init.uniform_(self.bias, -bound, bound)
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
+        with init.init_version(version, use_master) as version:
+            if version >= (1, 7, 0):
+                init.kaiming_normal_(self.weight, mode='fan_out')
+                if self.bias is not None:
+                    init.zeros_(self.bias)
+            else:
+            init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+            if self.bias is not None:
+                fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+                bound = 1 / math.sqrt(fan_in)
+                init.uniform_(self.bias, -bound, bound)
 
     def extra_repr(self):
         s = ('{in_channels}, {out_channels}, kernel_size={kernel_size}'

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -89,11 +89,11 @@ class _ConvNd(Module):
                 if self.bias is not None:
                     init.zeros_(self.bias)
             else:
-            init.kaiming_uniform_(self.weight, a=math.sqrt(5))
-            if self.bias is not None:
-                fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
-                bound = 1 / math.sqrt(fan_in)
-                init.uniform_(self.bias, -bound, bound)
+                init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+                if self.bias is not None:
+                    fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+                    bound = 1 / math.sqrt(fan_in)
+                    init.uniform_(self.bias, -bound, bound)
 
     def extra_repr(self):
         s = ('{in_channels}, {out_channels}, kernel_size={kernel_size}'

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -80,12 +80,18 @@ class Linear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self) -> None:
-        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
-        if self.bias is not None:
-            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
-            bound = 1 / math.sqrt(fan_in)
-            init.uniform_(self.bias, -bound, bound)
+    def reset_parameters(self, version=None) -> None:
+        with init.init_version(version) as version:
+            if version >= (1, 7, 0):
+                init.kaiming_normal_(self.weight, mode='fan_out')
+                if self.bias is not None:
+                    init.zeros_(self.bias)
+            else:
+                init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+                if self.bias is not None:
+                    fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+                    bound = 1 / math.sqrt(fan_in)
+                    init.uniform_(self.bias, -bound, bound)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.linear(input, self.weight, self.bias)

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -81,8 +81,8 @@ class Linear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
-        with init.init_version(version, use_master) as version:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
+        with init.init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
                 if self.bias is not None:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -1,4 +1,5 @@
 import math
+from typing import Union, Tuple
 
 import torch
 from torch import Tensor
@@ -80,8 +81,8 @@ class Linear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self, version=None) -> None:
-        with init.init_version(version) as version:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
+        with init.init_version(version, use_master) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
                 if self.bias is not None:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -169,8 +169,8 @@ class Bilinear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
-        with init.init_version(version, use_master) as version:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
+        with init.init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
                 if self.bias is not None:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -49,11 +49,28 @@ class Linear(Module):
 
     Attributes:
         weight: the learnable weights of the module of shape
-            :math:`(\text{out\_features}, \text{in\_features})`. The values are
-            initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`, where
-            :math:`k = \frac{1}{\text{in\_features}}`
-        bias:   the learnable bias of the module of shape :math:`(\text{out\_features})`.
-                If :attr:`bias` is ``True``, the values are initialized from
+            :math:`(\text{out\_features}, \text{in\_features})`. The following
+            initializations are available:
+
+            1. PyTorch >= 1.7.0
+
+                :math:`\mathcal{N}(0, std^2)`, where 
+                :math:`std = \frac{2}{\text{out\_features}}`
+
+            2. PyTorch < 1.7.0 (default)
+
+                :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`, where
+                :math:`k = \frac{1}{\text{in\_features}}`
+
+        bias: the learnable bias of the module of shape :math:`(\text{out\_features})`.
+            The following initializations are available:
+
+            1. PyTorch >= 1.7.0
+
+                :math:`\text{vector of 0's}`
+
+            2. PyTorch < 1.7.0 (default)
+
                 :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})` where
                 :math:`k = \frac{1}{\text{in\_features}}`
 
@@ -81,7 +98,7 @@ class Linear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str, None] = None) -> None:
         with init.use_init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
@@ -169,7 +186,7 @@ class Bilinear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str, None] = None) -> None:
         with init.use_init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -82,7 +82,7 @@ class Linear(Module):
         self.reset_parameters()
 
     def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
-        with init.init_version(version) as version:
+        with init.use_init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
                 if self.bias is not None:
@@ -170,7 +170,7 @@ class Bilinear(Module):
         self.reset_parameters()
 
     def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None) -> None:
-        with init.init_version(version) as version:
+        with init.use_init_version(version) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')
                 if self.bias is not None:

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -169,7 +169,7 @@ class Bilinear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(sself, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
+    def reset_parameters(self, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
         with init.init_version(version, use_master) as version:
             if version >= (1, 7, 0):
                 init.kaiming_normal_(self.weight, mode='fan_out')

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -169,11 +169,17 @@ class Bilinear(Module):
             self.register_parameter('bias', None)
         self.reset_parameters()
 
-    def reset_parameters(self) -> None:
-        bound = 1 / math.sqrt(self.weight.size(1))
-        init.uniform_(self.weight, -bound, bound)
-        if self.bias is not None:
-            init.uniform_(self.bias, -bound, bound)
+    def reset_parameters(sself, version: Union[Tuple[int, int, int], str] = None, use_master: bool = False) -> None:
+        with init.init_version(version, use_master) as version:
+            if version >= (1, 7, 0):
+                init.kaiming_normal_(self.weight, mode='fan_out')
+                if self.bias is not None:
+                    init.zeros_(self.bias)
+            else:
+                bound = 1 / math.sqrt(self.weight.size(1))
+                init.uniform_(self.weight, -bound, bound)
+                if self.bias is not None:
+                    init.uniform_(self.bias, -bound, bound)
 
     def forward(self, input1: Tensor, input2: Tensor) -> Tensor:
         return F.bilinear(input1, input2, self.weight, self.bias)


### PR DESCRIPTION
Fixes #18182 

### Usage example
```python
l = nn.Linear(2,3)
l.bias.data
# tensor([0., 0., 0.])

with nn.init.init_version('1.6.1') as version:
    l = nn.Linear(2,3)
l.bias.data
# tensor([-0.6192, -0.2009, -0.6798])
```

cc @t-vi @apaszke @gchanan @soumith @colesbury 