### PR TITLE
disable mkl for expm1

### DIFF
--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -183,8 +183,8 @@ static_assert(
   IMPLEMENT_VML_MKL_STUB(op, mklop, float, s) \
   IMPLEMENT_VML_MKL_STUB(op, mklop, double, d)
 
-// NB: abs, cosh and sinh were temporarily disabled due to issues with Apple clang
-
+// NB: abs, cosh and sinh were temporarily disabled due to issues with Apple
+// NB: expm1 is disabled because on some configs it produces expm1(nan)=-1
 IMPLEMENT_VML_MKL(abs, Abs)
 IMPLEMENT_VML_MKL(acos, Acos)
 IMPLEMENT_VML_MKL(asin, Asin)
@@ -195,7 +195,7 @@ IMPLEMENT_VML_MKL(erf, Erf)
 IMPLEMENT_VML_MKL(erfc, Erfc)
 IMPLEMENT_VML_MKL(erfinv, ErfInv)
 IMPLEMENT_VML_MKL(exp, Exp)
-IMPLEMENT_VML_MKL(expm1, Expm1)
+// IMPLEMENT_VML_MKL(expm1, Expm1)
 IMPLEMENT_VML_MKL(log, Ln)
 IMPLEMENT_VML_MKL(log10, Log10)
 IMPLEMENT_VML_MKL(log1p, Log1p)


### PR DESCRIPTION
On some systems/mkl versions it produces expm1(nan)=-1