### PR TITLE
Follow up on Fix race condition when creating build dir

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1451,11 +1451,14 @@ def _get_build_directory(name, verbose):
             root_extensions_directory))
 
     build_directory = os.path.join(root_extensions_directory, name)
-    if not os.path.exists(build_directory):
-        if verbose:
-            print('Creating extension directory {}...'.format(build_directory))
+    try:
         # This is like mkdir -p, i.e. will also create parent directories.
         os.makedirs(build_directory, exist_ok=True)
+        if verbose:
+            print('Creating extension directory {}...'.format(build_directory))
+    except FileExistsError:
+        if verbose:
+            print('Using existing directory {}...'.format(build_directory))
 
     return build_directory
 


### PR DESCRIPTION
This reverts commit 9c9d3cd5506b6f75632ceb6cd2cb9b5c9a83c62f.

 (see #30956 for the context)
