### PR TITLE
Replacing _black_list_in_opset to _block_list_in_opset in symbolic_helper.py

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -190,7 +190,7 @@ def _onnx_opset_unsupported_detailed(op_name, current_opset, supported_opset, re
                        'opset {}. {}. Please try opset version {}.'.format(op_name, current_opset, reason, supported_opset))
 
 
-def _black_list_in_opset(name):
+def _block_list_in_opset(name):
     def symbolic_fn(*args, **kwargs):
         raise RuntimeError("ONNX export failed on {}, which is not implemented for opset {}. "
                            "Try exporting with other opset versions."

--- a/torch/onnx/symbolic_opset7.py
+++ b/torch/onnx/symbolic_opset7.py
@@ -1,4 +1,4 @@
-from torch.onnx.symbolic_helper import _black_list_in_opset
+from torch.onnx.symbolic_helper import _block_list_in_opset
 
 import torch.onnx.symbolic_opset9 as sym_opset9
 
@@ -44,4 +44,4 @@ def min(g, self, dim_or_y=None, keepdim=None):
 
 
 for black_listed_op in black_listed_operators:
-    vars()[black_listed_op] = _black_list_in_opset(black_listed_op)
+    vars()[black_listed_op] = _block_list_in_opset(black_listed_op)

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -4,7 +4,7 @@ import torch
 import torch.onnx.symbolic_helper as sym_help
 import torch.onnx.symbolic_opset9 as sym_opset9
 
-from torch.onnx.symbolic_helper import parse_args, _unimplemented, _black_list_in_opset, _try_get_scalar_type
+from torch.onnx.symbolic_helper import parse_args, _unimplemented, _block_list_in_opset, _try_get_scalar_type
 from torch.onnx.symbolic_opset9 import _cast_Float
 
 import warnings
@@ -46,7 +46,7 @@ black_listed_operators = [
 ]
 
 for black_listed_op in black_listed_operators:
-    vars()[black_listed_op] = _black_list_in_opset(black_listed_op)
+    vars()[black_listed_op] = _block_list_in_opset(black_listed_op)
 
 
 def _interpolate(name, dim, interpolate_mode):


### PR DESCRIPTION
Replaced `_black_list_in_opset(name) `to `_block_list_in_opset(name) `in `symbolic_helper.py`.

This function is used in `symbolic_opset7.py` and `symbolic_opset8.py`. Made the changes there as well.

Fixes #41736