### PR TITLE
Replaced black_listed_operators to blocked_operators and black_listed_op to blocked_op in symbolic_opset7.py

### DIFF
--- a/torch/onnx/symbolic_opset7.py
+++ b/torch/onnx/symbolic_opset7.py
@@ -15,7 +15,7 @@ import warnings
 #   MaxPool: added optional indices output.
 #   Scan
 
-black_listed_operators = [
+blocked_operators = [
     "scan", "expand", "expand_as", "meshgrid",
     "adaptive_max_pool1d", "adaptive_max_pool2d", "adaptive_max_pool3d",
     "max_pool1d_with_indices", "max_pool2d_with_indices", "max_pool3d_with_indices"
@@ -43,5 +43,5 @@ def min(g, self, dim_or_y=None, keepdim=None):
     return sym_opset9.min(g, self, dim_or_y, keepdim)
 
 
-for black_listed_op in black_listed_operators:
-    vars()[black_listed_op] = _black_list_in_opset(black_listed_op)
+for blocked_op in blocked_operators:
+    vars()[blocked_op] = _black_list_in_opset(blocked_op)


### PR DESCRIPTION
Replaced `black_listed_operators` to `blocked_operators` and `black_listed_op` to `blocked_op` in `symbolic_opset7.py`

Fixes #41737 