### PR TITLE
Update Adam documentation

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -7,7 +7,7 @@ class Adam(Optimizer):
     r"""Implements Adam algorithm.
 
     It has been proposed in `Adam: A Method for Stochastic Optimization`_.
-    Although this implementation applies L2 penalty, it is motivated by changes proposed in
+    The implementation of the L2 penalty follows changes proposed in
     `Decoupled Weight Decay Regularization`_.
 
     Arguments:

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -7,6 +7,8 @@ class Adam(Optimizer):
     r"""Implements Adam algorithm.
 
     It has been proposed in `Adam: A Method for Stochastic Optimization`_.
+    Although this implementation applies L2 penalty, it is motivated by changes proposed in
+    `Decoupled Weight Decay Regularization`_.
 
     Arguments:
         params (iterable): iterable of parameters to optimize or dicts defining
@@ -23,6 +25,8 @@ class Adam(Optimizer):
 
     .. _Adam\: A Method for Stochastic Optimization:
         https://arxiv.org/abs/1412.6980
+    .. _Decoupled Weight Decay Regularization:
+        https://arxiv.org/abs/1711.05101
     .. _On the Convergence of Adam and Beyond:
         https://openreview.net/forum?id=ryQu7f-RZ
     """


### PR DESCRIPTION
This PR fixes #41477

Adam implementation is doing L2 regularization and not decoupled weight decay. However, the change mentioned in #41477 was motivated by Line 12 of algorithm 2 in [Decoupled Weight Decay Regularization](https://arxiv.org/pdf/1711.05101.pdf) paper.

Please let me know if you have other suggestions about how to deliver this info in the docs.
cc @ezyang 