### PR TITLE
Add non zero offset test cases for Quantize and Dequantize Ops.

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -22,15 +22,21 @@ class Int8OpsTest(serial.SerializedTestCase):
 
     @given(
         n=st.integers(2, 1024),
-        rand_seed=st.integers(0, 65534)
+        rand_seed=st.integers(0, 65534),
+        non_zero_offset=st.booleans()
     )
     @settings(max_examples=100)
-    def test_int8_quantize(self, n, rand_seed):
+    def test_int8_quantize(self, n, rand_seed, non_zero_offset):
         print("n={}, rand_seed={}".format(n, rand_seed))
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
 
-        X_fp32 = np.random.rand(n, n).astype(np.float16).astype(np.float32)
+        if non_zero_offset:
+            X_fp32 = np.random.uniform(-1, 1, size=(n, n)).astype(np.float16) \
+                .astype(np.float32)
+        else:
+            X_fp32 = np.random.rand(n, n).astype(np.float16).astype(np.float32)
+
         W_fp32 = np.identity(n, dtype=np.float32)
         b_fp32 = np.zeros((n,), dtype=np.float32)
 


### PR DESCRIPTION
Summary: Add non zero offset test cases for Quantize and Dequantize Ops.

Test Plan: Added new test case test_int8_non_zero_offset_quantize part of the test_int8_ops_nnpi.py test file.

Differential Revision: D22633796

