### PR TITLE
[ROCm] skip test_streams on rocm.

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -790,6 +790,7 @@ class TestCuda(TestCase):
                                     "Expected a cuda device, but got: cpu"):
             torch.cuda.default_stream(torch.device('cpu'))
 
+    @skipIfRocm
     @skipCUDANonDefaultStreamIf(True)
     def test_streams(self):
         default_stream = torch.cuda.current_stream()


### PR DESCRIPTION
Skipping the test test_streams as it is flaky on rocm.
cc: @jeffdaily  @sunway513