### PR TITLE
Add CUDA support for combined min/max

### DIFF
--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -394,6 +394,37 @@ struct MaxOps :
   public detail::MinMaxReductionOps<detail::GreaterOrNan<scalar_t>> {
 };
 
+template <typename scalar_t, typename acc_scalar_t, typename index_t>
+struct MinMaxOps {
+  using acc_t = detail::pair<acc_scalar_t, acc_scalar_t>;
+  inline C10_DEVICE acc_t reduce(acc_t acc, scalar_t data, index_t /*idx*/) const {
+    return combine(acc, {data, data});
+  }
+
+  inline C10_DEVICE acc_t combine(acc_t a, acc_t b) const {
+    auto min_val = (at::_isnan(a.first) || a.first < b.first) ? a.first : b.first;
+    auto max_val = (at::_isnan(a.second) || a.second > b.second) ? a.second : b.second;
+
+    return {min_val, max_val};
+  }
+
+  inline C10_DEVICE acc_t project(acc_t acc) const {
+    return acc;
+  }
+
+  static C10_DEVICE acc_t translate_idx(acc_t acc, int64_t /*base_idx*/) {
+    return acc;
+  }
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  inline __device__ acc_t warp_shfl_down(acc_t acc, int offset) const {
+    return {
+      WARP_SHFL_DOWN(acc.first, offset), WARP_SHFL_DOWN(acc.second, offset)
+    };
+  }
+#endif
+};
+
 }} // namespace at::native
 
 #undef MAX

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5059,7 +5059,7 @@
   use_c10_dispatcher: full
   variants: function
   dispatch:
-    CPU: _min_max
+    CPU, CUDA: _min_max
 
 - func: median(Tensor self) -> Tensor
   use_c10_dispatcher: full


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41805 Added CUDA support for combined min/max**
* #41804 add max_and_min function and cpu kernel to speed up observers

Differential Revision: [D22671780](https://our.internmc.facebook.com/intern/diff/D22671780)