### PR TITLE
[tensorexpr][trivial] Remove debug printing from test

### DIFF
--- a/test/cpp/tensorexpr/test_te_fuser_pass.cpp
+++ b/test/cpp/tensorexpr/test_te_fuser_pass.cpp
@@ -53,7 +53,6 @@ void testFuserPass_2() {
 
   g->lint();
   FuseTensorExprs(g);
-  std::cerr << *g << "\n";
 
   // We should not be able to fuse across the in-place operation here.
   testing::FileCheck()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41806 [tensorexpr][trivial] Remove debug printing from test**

Summary: Generally a good practice not to have tests spew output.

Test Plan: `build/bin/test_tensorexpr`

Reviewers: mvz, zhengxq

Subscribers:

Tasks:

Tags:

Differential Revision: [D22646833](https://our.internmc.facebook.com/intern/diff/D22646833)