### PR TITLE
[ROCm] update hip library name

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -175,11 +175,18 @@ if(HIP_FOUND)
   find_package_and_print_version(hipcub REQUIRED)
   find_package_and_print_version(rocthrust REQUIRED)
   
+  if(HIP_COMPILER STREQUAL clang)
+    set(hip_library_name amdhip64)
+  else()
+    set(hip_library_name hip_hcc)
+  endif()
+  message("HIP library name: ${hip_library_name}")
+
   # TODO: hip_hcc has an interface include flag "-hc" which is only
   # recognizable by hcc, but not gcc and clang. Right now in our
   # setup, hcc is only used for linking, but it should be used to
   # compile the *_hip.cc files as well.
-  find_library(PYTORCH_HIP_HCC_LIBRARIES hip_hcc HINTS ${HIP_PATH}/lib)
+  find_library(PYTORCH_HIP_HCC_LIBRARIES ${hip_library_name} HINTS ${HIP_PATH}/lib)
   # TODO: miopen_LIBRARIES should return fullpath to the library file,
   # however currently it's just the lib name
   find_library(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES} HINTS ${MIOPEN_PATH}/lib)
@@ -187,7 +194,7 @@ if(HIP_FOUND)
   # however currently it's just the lib name
   find_library(PYTORCH_RCCL_LIBRARIES ${rccl_LIBRARIES} HINTS ${RCCL_PATH}/lib)
   # hiprtc is part of HIP
-  find_library(ROCM_HIPRTC_LIB hiprtc HINTS ${HIP_PATH}/lib)
+  find_library(ROCM_HIPRTC_LIB ${hip_library_name} HINTS ${HIP_PATH}/lib)
   # roctx is part of roctracer
   find_library(ROCM_ROCTX_LIB roctx64 HINTS ${ROCTRACER_PATH}/lib)
   set(roctracer_INCLUDE_DIRS ${ROCTRACER_PATH}/include)

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -118,17 +118,17 @@ def is_hip_clang():
 
 # TODO Remove once gloo submodule is recent enough to contain upstream fix.
 if is_hip_clang():
-    gloo_cmake_file="third_party/gloo/cmake/Hip.cmake"
+    gloo_cmake_file = "third_party/gloo/cmake/Hip.cmake"
     do_write = False
     with open(gloo_cmake_file, "r") as sources:
         lines = sources.readlines()
-    newlines = [line.replace(' hip_hcc ', ' amdhip64 ' ) for line in lines]
+    newlines = [line.replace(' hip_hcc ', ' amdhip64 ') for line in lines]
     if lines == newlines:
         print("%s skipped" % gloo_cmake_file)
     else:
         with open(gloo_cmake_file, "w") as sources:
-          for line in newlines:
-              sources.write(line)
+            for line in newlines:
+                sources.write(line)
         print("%s updated" % gloo_cmake_file)
 
 hipify_python.hipify(

--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -116,6 +116,21 @@ def is_hip_clang():
     except IOError:
         return False
 
+# TODO Remove once gloo submodule is recent enough to contain upstream fix.
+if is_hip_clang():
+    gloo_cmake_file="third_party/gloo/cmake/Hip.cmake"
+    do_write = False
+    with open(gloo_cmake_file, "r") as sources:
+        lines = sources.readlines()
+    newlines = [line.replace(' hip_hcc ', ' amdhip64 ' ) for line in lines]
+    if lines == newlines:
+        print("%s skipped" % gloo_cmake_file)
+    else:
+        with open(gloo_cmake_file, "w") as sources:
+          for line in newlines:
+              sources.write(line)
+        print("%s updated" % gloo_cmake_file)
+
 hipify_python.hipify(
     project_directory=proj_dir,
     output_directory=out_dir,


### PR DESCRIPTION
With transition to hipclang, the HIP runtime library name was changed.  A symlink was added to ease the transition, but is going to be removed.  Conditionally set library name based on HIP compiler used.  Patch gloo submodule as part of build_amd.py script until its associated fix is available.

CC @ezyang @xw285cornell @sunway513 