### PR TITLE
Augmenting Concrete Observer Constructors to Support Dynamic Quantization Range; Modifying Utility Functions in _LearnableFakeQuantize Module for Better Logging and Baseline Construction.

### DIFF
--- a/torch/quantization/_learnable_fake_quantize.py
+++ b/torch/quantization/_learnable_fake_quantize.py
@@ -240,13 +240,13 @@ class _LearnableFakeQuantize(nn.Module):
             .toggle_observer_update(enabled=True)
 
     @torch.jit.export
-    def enable_static_observeration(self):
+    def enable_static_observation(self):
         r"""Enables static observer accumulating data from input but doesn't
         update the quantization parameters. Forward path returns the original X.
         """
         self.toggle_qparam_learning(enabled=False) \
             .toggle_fake_quant(enabled=False) \
-            .toggle_observer_update(enabled=False)
+            .toggle_observer_update(enabled=True)
 
     @torch.jit.export
     def toggle_observer_update(self, enabled=True):
@@ -266,9 +266,9 @@ class _LearnableFakeQuantize(nn.Module):
         return self
 
     @torch.jit.export
-    def print_quantization_params(self):
-        print('Scale: {:.6f}, Zero Point: {}'
-              .format(float(self.scale), int(self.zero_point)))
+    def observe_quant_params(self):
+        print('_LearnableFakeQuantize Scale: {}'.format(self.scale.detach()))
+        print('_LearnableFakeQuantize Zero Point: {}'.format(self.zero_point.detach()))
 
     @torch.jit.export
     def calculate_qparams(self):


### PR DESCRIPTION
Summary:
The constructors of MinMaxObserver, MovingAverageMinMaxObserver, PerChannelMinMaxObserver, and MovingAveragePerChannelMinMaxObserver are augmented so they can utilize the dynamic quantization range support in the _ObserverBase class.

In addition, minor adjustments are made to the enable_static_observation function that allow observer to update parameters but do not fake quantize on the output (for constructing baseline).

Test Plan:
To ensure this modification is still backward compatible with past usages, numerics are verified by running the quantization unit test suite, which contains various observer tests. The following command executes the test suite, which also verifies the observer numerics:
```
buck test //caffe2/test:quantization -- observer
```

Differential Revision: D22649128

