### PR TITLE
[Onnxifi] Support running with quantized int8 inputs

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_int8_quant.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_quant.py
@@ -18,6 +18,48 @@ workspace.GlobalInit(
 )
 
 class QuantTest(serial.SerializedTestCase):
+    def test_dequantize(self):
+        pred_net = caffe2_pb2.NetDef()
+        pred_net.name = "pred"
+        pred_net.external_input.append("X")
+        pred_net.external_output.append("Y")
+        x_scale = 0.10000000149011612
+        pred_net.op.add().CopyFrom(
+            core.CreateOperator(
+                "Int8Quantize", ["X"], ["I"], Y_scale=x_scale, Y_zero_point=0
+            )
+        )
+        pred_net.op.add().CopyFrom(
+            core.CreateOperator(
+                "Int8Dequantize", ["I"], ["Y"],
+            )
+        )
+        print(pred_net)
+        X = np.asarray([[1, 0], [0, 1]]).astype(np.float32)
+        workspace.FeedBlob("X", X)
+        workspace.CreateNet(pred_net)
+        workspace.RunNet(pred_net.name)
+        Y_ref = workspace.FetchBlob("Y")
+        workspace.ResetWorkspace()
+        pred_net_onnxified = onnxifi_caffe2_net(
+            pred_net,
+            {"X": [5, 2]},
+            debug=True,
+            adjust_batch=True,
+            black_list=[0],
+            use_onnx=False,
+        )
+        num_onnxified_ops = sum(
+            1 if o.type == "Onnxifi" else 0 for o in pred_net_onnxified.op
+        )
+        np.testing.assert_equal(len(pred_net_onnxified.op), 2)
+        np.testing.assert_equal(num_onnxified_ops, 1)
+        workspace.FeedBlob("X", X)
+        workspace.CreateNet(pred_net_onnxified)
+        workspace.RunNet(pred_net_onnxified.name)
+        Y_glow = workspace.FetchBlob("Y")
+        np.testing.assert_equal(Y_ref, Y_glow)
+
     def test_quantize(self):
         pred_net = caffe2_pb2.NetDef()
         pred_net.name = "pred"
@@ -51,5 +93,3 @@ class QuantTest(serial.SerializedTestCase):
         workspace.RunNet(pred_net_onnxified.name)
         Y_glow = workspace.FetchInt8Blob("Y")
         np.testing.assert_equal(Y_ref.data, Y_glow.data)
-        np.testing.assert_allclose(Y_ref.scale, Y_glow.scale)
-        np.testing.assert_equal(Y_ref.zero_point, Y_glow.zero_point)

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -226,16 +226,18 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorBoundShape(
     std::vector<int64_t> bound_dims,
     TensorProto::DataType type,
     bool is_quantized,
-    bool allow_existing_shape) {
+    bool allow_existing_shape,
+    float scale,
+    int offset) {
   auto rt = shape_info_.emplace(name, ShapeInfo());
   ShapeInfo& shape_info = rt.first->second;
   TensorShape& shape = shape_info.shape;
   if (is_quantized) {
     shape_info.is_quantized = true;
     shape_info.q_info.scale.clear();
-    shape_info.q_info.scale.push_back(1);
+    shape_info.q_info.scale.push_back(scale);
     shape_info.q_info.offset.clear();
-    shape_info.q_info.offset.push_back(0);
+    shape_info.q_info.offset.push_back(offset);
     shape_info.q_info.axis = 1;
   }
   // If the shape information exists in shape_info_ already
@@ -810,6 +812,8 @@ void BoundShapeInferencer::InferCommonOp(const OperatorDef& op) {
     output_shapes = schema->InferTensor(op, input_shapes);
     bool is_quantized =
         !(op.type().compare(0, 4, "Int8")) && (op.type() != "Int8Dequantize");
+    float scale = 1;
+    int offset = 0;
     TensorProto::DataType infered_data_type = TensorProto::UNDEFINED;
     if (is_quantized) {
       const static std::map<std::string, int> type_info_from_input = {
@@ -831,6 +835,11 @@ void BoundShapeInferencer::InferCommonOp(const OperatorDef& op) {
         CAFFE_ENFORCE(target < input_shapes.size());
         infered_data_type = input_shapes[target].data_type();
       }
+
+      // Extract output scale and offset
+      ArgumentHelper helper(op);
+      scale = helper.GetSingleArgument<float>("Y_scale", 1);
+      offset = helper.GetSingleArgument<int>("Y_zero_point", 0);
     } else if (op.type() == "Int8Dequantize") {
       infered_data_type = TensorProto::FLOAT;
     }
@@ -848,7 +857,7 @@ void BoundShapeInferencer::InferCommonOp(const OperatorDef& op) {
           setDimTypeWithFirst(current_dim_type_, shape.dims().size()),
           ConvertToVec(shape.dims()),
           infered_data_type,
-          is_quantized);
+          is_quantized, false, scale, offset);
     }
   } catch (const caffe2::EnforceNotMet& e) {
     LOG(ERROR) << "Enforce not met while inferring shapes for " << op.type()

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -105,7 +105,9 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
       std::vector<int64_t> bound_dims,
       TensorProto::DataType type,
       bool is_quantized,
-      bool allow_existing_shape = false);
+      bool allow_existing_shape = false,
+      float scale = 1,
+      int offset = 0);
 
   TensorShape& SetTensorBoundShapeIfNotExist(
       const std::string& name,


### PR DESCRIPTION
Summary:
In order to support int8 quantized tensor as an input to OnnxifiOp, we need to
- Add support to recognize and extract shape meta from int8 tensor at input of OnnxifiOp
- Make a copy of the input data and shift by 128 in Glow if input data is uint8 quantized tensor to get correct result because Glow uses int8 to represent the quantized data regardless.
- Propagate correct quantization parameters to through shape info in C2.

This diff implements the above.

Test Plan:
```
buck test caffe2/caffe2/contrib/fakelowp/test:test_int8_quantnnpi
```

Differential Revision: D22650584

