### PR TITLE
Don't materialize output grads

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -2,6 +2,8 @@
 
 #include <torch/torch.h>
 
+#include <torch/csrc/autograd/functions/basic_ops.h>
+
 #include <test/cpp/api/support.h>
 
 using namespace torch::autograd;
@@ -221,6 +223,39 @@ TEST(CustomAutogradTest, FunctionReturnsUndefined) {
 
   ASSERT_FALSE(torch::autograd::grad(
     {MyFunction::apply(x)}, {x}, {}, false, false, true)[0].defined());
+}
+
+TEST(CustomAutogradTest, MaterializeGrads) {
+  struct MyFunction : public Function<MyFunction> {
+    static Variable forward(AutogradContext *ctx, Variable var) {
+      return var;
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      EXPECT_VARIABLE_EQ(grad_output[0], torch::zeros(1));
+      return grad_output;
+    }
+  };
+
+  auto x = torch::ones(1, torch::requires_grad());
+  UndefinedGrad().apply({MyFunction::apply(x)})[0].backward();
+}
+
+TEST(CustomAutogradTest, DontMaterializeGrads) {
+  struct MyFunction : public Function<MyFunction> {
+    static Variable forward(AutogradContext *ctx, Variable var) {
+      ctx->set_materialize_grads(false);
+      return var;
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      EXPECT_FALSE(grad_output[0].defined());
+      return grad_output;
+    }
+  };
+
+  auto x = torch::ones(1, torch::requires_grad());
+  UndefinedGrad().apply({MyFunction::apply(x)})[0].backward();
 }
 
 TEST(CustomAutogradTest, NoGradCustomFunction) {

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -59,6 +59,15 @@ class _ContextMethodMixin(object):
         """
         self.non_differentiable = args
 
+    def set_materialize_grads(self, value):
+        r"""Sets whether to materialize output grad tensors. Default is true.
+
+        **This should be called only from inside the** :func:`forward` **method**
+
+        If true, undefined output grad tensors will be expanded to tensors full
+        of zeros prior to calling the :func:`backward` method.
+        """
+        self.materialize_grads = value
 
 class _HookMixin(object):
 

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -234,6 +234,10 @@ void AutogradContext::mark_non_differentiable(const variable_list &outputs) {
   }
 }
 
+void AutogradContext::set_materialize_grads(bool value) {
+  materialize_grads_ = value;
+}
+
 const std::unordered_set<at::TensorImpl*>& AutogradContext::get_and_bump_dirty() const {
   for (auto& var : dirty_inputs_) {
     var->bump_version();

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -90,7 +90,7 @@ struct TORCH_API Function {
 /// Context to save information during `forward` that can be accessed in `backward`
 /// in custom autograd operations (see `torch::autograd::Function` for details).
 struct TORCH_API AutogradContext {
-  AutogradContext() = default;
+  AutogradContext() : materialize_grads_(true) {}
   AutogradContext(const AutogradContext &other) = delete;
   AutogradContext& operator=(const AutogradContext& other) = delete;
 
@@ -107,6 +107,9 @@ struct TORCH_API AutogradContext {
   /// Marks outputs in the list as not requiring gradients. This should be called
   /// at most once from inside of `forward` and all arguments should be outputs.
   void mark_non_differentiable(const variable_list &outputs);
+  // Sets whether undefined output grad tensors should be expanded to tensors
+  // full of zeros before calling backward function. Default value is true.
+  void set_materialize_grads(bool value);
 
   /// Get the list of variables that were saved in `forward` using
   /// `save_for_backward()`. Before returning them to the user, a check is made to
@@ -120,6 +123,7 @@ private:
   std::unordered_set<at::TensorImpl*> dirty_inputs_;
   std::vector<torch::autograd::SavedVariable> saved_variables_;
   variable_list to_save_;
+  bool materialize_grads_;
 
   // The CppNode in the autograd graph that owns this AutogradContext. We need a
   // weak_ptr to avoid a refcycle. Since grad_fn_ owns this AutogradContext, it
@@ -253,7 +257,7 @@ variable_list CppNode<T>::apply(variable_list&& inputs) {
   variable_list backward_inputs;
   backward_inputs.reserve(num_inputs);
   for (int i = 0 ; i < num_inputs; ++i) {
-    if (inputs[i].defined()) {
+    if (inputs[i].defined() || !ctx_.materialize_grads_) {
       backward_inputs.emplace_back(inputs[i]);
     } else {
       backward_inputs.emplace_back(output_info_[i].zeros(_device_guard));

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -89,6 +89,11 @@ struct THPFunction {
     // modified inplace.
     PyObject *dirty_tensors;
 
+    // boolean indicating whether to materialize undefined output grad tensors 
+    // into tensors full of zeros. Set by Python with 'set_materialize_grads'.
+    // Default is true.
+    bool materialize_grads;
+
     std::vector<torch::autograd::VariableInfo> output_info;
     std::vector<torch::autograd::VariableInfo> input_info;
     std::vector<torch::autograd::SavedVariable> saved_variables;


### PR DESCRIPTION
Added a new option in AutogradContext to tell autograd to not materialize output grad tensors, that is, don't expand undefined/None tensors into tensors full of zeros before passing them as input to the backward function.

This PR is the second part that closes https://github.com/pytorch/pytorch/issues/41359. The first PR is https://github.com/pytorch/pytorch/pull/41490.