### PR TITLE
[pytorch] disable per-op profiling for internal mobile build

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -340,7 +340,7 @@ inline Return Dispatcher::callWithDispatchKey(const TypedOperatorHandle<Return(A
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
   const KernelFunction& kernel = op.operatorIterator_->op.lookup(dispatchKey);
 
-#ifndef PYTORCH_DISABLE_PROFILER
+#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
   // Check if we need to run callbacks registered with RecordFunction
   // If true and callbacks need inputs, we box the arguments and pass
   // them into the callbacks and also into the kernel call
@@ -366,7 +366,7 @@ inline Return Dispatcher::callWithDispatchKey(const TypedOperatorHandle<Return(A
       }
     }
   }
-#endif  // PYTORCH_DISABLE_PROFILER
+#endif  // PYTORCH_DISABLE_PER_OP_PROFILING
   return kernel.template call<Return, Args...>(op, std::forward<Args>(args)...);
 }
 
@@ -400,7 +400,7 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
   auto dispatchKey = entry.dispatchKeyExtractor().getDispatchKeyBoxed(stack);
   const auto& kernel = entry.lookup(dispatchKey);
 
-#ifndef PYTORCH_DISABLE_PROFILER
+#ifndef PYTORCH_DISABLE_PER_OP_PROFILING
   // using already existing stack to record function execution in observers
   at::RecordFunction guard(at::RecordScope::FUNCTION);
   if (C10_UNLIKELY(guard.active)) {
@@ -412,7 +412,7 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
       }
     }
   }
-#endif  // PYTORCH_DISABLE_PROFILER
+#endif  // PYTORCH_DISABLE_PER_OP_PROFILING
   kernel.callBoxed(op, stack);
 }
 

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -340,6 +340,7 @@ inline Return Dispatcher::callWithDispatchKey(const TypedOperatorHandle<Return(A
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
   const KernelFunction& kernel = op.operatorIterator_->op.lookup(dispatchKey);
 
+#ifndef PYTORCH_DISABLE_PROFILER
   // Check if we need to run callbacks registered with RecordFunction
   // If true and callbacks need inputs, we box the arguments and pass
   // them into the callbacks and also into the kernel call
@@ -365,6 +366,7 @@ inline Return Dispatcher::callWithDispatchKey(const TypedOperatorHandle<Return(A
       }
     }
   }
+#endif  // PYTORCH_DISABLE_PROFILER
   return kernel.template call<Return, Args...>(op, std::forward<Args>(args)...);
 }
 
@@ -398,6 +400,7 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
   auto dispatchKey = entry.dispatchKeyExtractor().getDispatchKeyBoxed(stack);
   const auto& kernel = entry.lookup(dispatchKey);
 
+#ifndef PYTORCH_DISABLE_PROFILER
   // using already existing stack to record function execution in observers
   at::RecordFunction guard(at::RecordScope::FUNCTION);
   if (C10_UNLIKELY(guard.active)) {
@@ -409,6 +412,7 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
       }
     }
   }
+#endif  // PYTORCH_DISABLE_PROFILER
   kernel.callBoxed(op, stack);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41825 [pytorch] disable per-op profiling for internal mobile build**



Add flag to gate D21374246 to mitigate mobile size regression.

Differential Revision: [D22650708](https://our.internmc.facebook.com/intern/diff/D22650708/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22650708/)!

Differential Revision: [D22650708](https://our.internmc.facebook.com/intern/diff/D22650708)