### PR TITLE
Add __main__ entrypoint to test_futures.py

### DIFF
--- a/test/test_futures.py
+++ b/test/test_futures.py
@@ -1,8 +1,9 @@
 import threading
 import time
 import torch
+import unittest
 from torch.futures import Future
-from torch.testing._internal.common_utils import TestCase, TemporaryFileName
+from torch.testing._internal.common_utils import IS_WINDOWS, TestCase, TemporaryFileName, run_tests
 
 
 def add_one(fut):
@@ -115,6 +116,7 @@ class TestFuture(TestCase):
         self.assertEqual(res[1].wait(), 2)
         t.join()
 
+    @unittest.skipIf(IS_WINDOWS, "TODO: need to fix this testcase for Windows")
     def test_wait_all(self):
         fut1 = Future()
         fut2 = Future()
@@ -132,3 +134,6 @@ class TestFuture(TestCase):
         fut3 = fut1.then(raise_in_fut)
         with self.assertRaisesRegex(RuntimeError, "Expected error"):
             torch.futures.wait_all([fut3, fut2])
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Per comment in run_test.py, every test module must have a __main__ entrypoint:
https://github.com/pytorch/pytorch/blob/60e2baf5e056b63414a31e40ac7a1024ed0b0ce0/test/run_test.py#L237-L238
Also disable test_wait_all on Windows, as it fails with an uncaught exception: 
```
  test_wait_all (__main__.TestFuture) ... Traceback (most recent call last):
  File "run_test.py", line 744, in <module>
    main()
  File "run_test.py", line 733, in main
    raise RuntimeError(err)
RuntimeError: test_futures failed!
```