### PR TITLE
syncronize docker tags across the workflow

### DIFF
--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -13,7 +13,9 @@ retry () {
 
 #until we find a way to reliably reuse previous build, this last_tag is not in use
 # last_tag="$(( CIRCLE_BUILD_NUM - 1 ))"
-tag="${CIRCLE_WORKFLOW_ID}"
+
+# DOCKER_TAG is computed in verbatim-sources/job-specs/docker_jobs.yml
+tag="$(DOCKER_TAG)"
 
 
 registry="308535385114.dkr.ecr.us-east-1.amazonaws.com"


### PR DESCRIPTION
xref issue gh-37855
xref PR gh-40827 (which had [this exact change](https://github.com/pytorch/pytorch/pull/40827/files#diff-8c89e5adbd6a94d9054a2066d12f1dcbR16) but was reverted)
xref PR ~gh-37584~ gh-38796 (which ran into the inconsistency between the tags)

Before this PR, the situation is that `.circleci/docker/build_docker.sh` uses `CIRCLE_WORKFLOW_ID` to tag images, but the test whether to build an image in `.circleci/verbatim-sources/job-specs/docker_jobs.yml` uses `DOCKER_TAG` calculated from `git log --oneline --pretty='%H'`. Somehow PR ~gh-37584~ gh-38796 hit a situation where the `pytorch_linux_xenial_py3_clang5_android_ndk_r19c` image build failed, but an image with the `DOCKER_TAG` formatted-tag appeared on http://docker.pytorch.org/pytorch.html. So the `DOCKER_TAG` image is the one checked  in the "Check if image should be built" step, not the `CIRCLE_WORKFLOW_ID` one.