### PR TITLE
Document default dim for cross being None

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1541,7 +1541,7 @@ and :attr:`other`.
 :attr:`dim` dimension should be 3.
 
 If :attr:`dim` is not given, it defaults to the first dimension found with the
-size 3.
+size 3. Note that this might be unexpected.
 
 Args:
     {input}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1531,7 +1531,7 @@ Example::
 
 add_docstr(torch.cross,
            r"""
-cross(input, other, dim=-1, out=None) -> Tensor
+cross(input, other, dim=None, out=None) -> Tensor
 
 
 Returns the cross product of vectors in dimension :attr:`dim` of :attr:`input`


### PR DESCRIPTION
The function torch.cross is a bit confusing, in particular the defaulting of the dim argument.

The default `dim` has been documented as -1 but it is actually `None`. This increases the confusion, in two possible ways depending on how carefully you read the rest. I also add a final warning to the final sentence.

This partially addresses https://github.com/pytorch/pytorch/issues/39310. 