### PR TITLE
[quant][graphmode][fix] Remove assert for uses == 1 in remove dequantize pass

### DIFF
--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -370,9 +370,10 @@ void RemoveRedundantDequantize(std::shared_ptr<Graph>& graph) {
     const auto& match_vmap = match.values_map;
     auto dequant_node = match_vmap.at(vmap.at("a_dequant"))->node();
     Value* dequant_out = dequant_node->output();
-    TORCH_CHECK(
-        dequant_out->uses().size() == 1,
-        "Expect dequant output to have single use");
+    // Values can be used multiple times in a single node
+    if (dequant_out->uses().size() != 1) {
+      return false;
+    }
     Node* user = dequant_out->uses()[0].user;
     return isTensorInfoNode(user);
   };
@@ -396,9 +397,10 @@ void RemoveRedundantQuantizationOps(std::shared_ptr<Graph>& graph) {
     const auto& match_vmap = match.values_map;
     auto dequant_node = match_vmap.at(vmap.at("a_dequant"))->node();
     Value* dequant_out = dequant_node->output();
-    TORCH_CHECK(
-        dequant_out->uses().size() == 1,
-        "Expect dequant output to have single use");
+    // Values can be used multiple times in a single node
+    if (dequant_out->uses().size() != 1) {
+      return false;
+    }
     Node* user = dequant_out->uses()[0].user;
     return !nodeQuantizable(user, QuantType::DYNAMIC);
   };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41859 [quant][graphmode][fix] Remove assert for uses == 1 in remove dequantize pass**

Summary:
A value can be used multiple times in the same node, we don't really need to assert uses of dequantize == 1

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22673525](https://our.internmc.facebook.com/intern/diff/D22673525)