### PR TITLE
[1.6.0] Mark `torch.set_deterministic` and `torch.is_deterministic` a…

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -116,16 +116,16 @@ class AbstractTestCases:
             dir(torch)
 
         def test_deterministic_flag(self):
-            deterministic_restore = torch.is_deterministic()
+            deterministic_restore = torch._is_deterministic()
 
             for deterministic in [True, False]:
-                torch.set_deterministic(deterministic)
-                self.assertEqual(deterministic, torch.is_deterministic())
+                torch._set_deterministic(deterministic)
+                self.assertEqual(deterministic, torch._is_deterministic())
 
             with self.assertRaisesRegex(RuntimeError, r"set_deterministic expects a bool, but got int"):
-                torch.set_deterministic(1)
+                torch._set_deterministic(1)
 
-            torch.set_deterministic(deterministic_restore)
+            torch._set_deterministic(deterministic_restore)
 
         def test_type_conversion_via_dtype_name(self):
             x = torch.tensor([1])

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -34,7 +34,7 @@ __all__ = [
     'ShortStorage', 'CharStorage', 'ByteStorage', 'BoolStorage',
     'DoubleTensor', 'FloatTensor', 'LongTensor', 'IntTensor',
     'ShortTensor', 'CharTensor', 'ByteTensor', 'BoolTensor', 'Tensor',
-    'lobpcg', 'set_deterministic', 'is_deterministic'
+    'lobpcg', '_set_deterministic', '_is_deterministic'
 ]
 
 ################################################################################
@@ -290,7 +290,7 @@ def set_default_dtype(d):
     """
     _C._set_default_dtype(d)
 
-def set_deterministic(d):
+def _set_deterministic(d):
     r"""Sets a global flag to force all operations to use a deterministic
     implementation if available. If an operation that does not have a
     deterministic implementation is called while this setting is True, the
@@ -302,12 +302,24 @@ def set_deterministic(d):
     Args:
         d (:class:`bool`): If True, force operations to be deterministic.
                            If False, allow non-deterministic operations.
+
+    .. warning::
+        This feature is experimental and not complete. The above docstring
+        represents what the future behavior is intended to be. Right now,
+        `_set_deterministic` will only affect `torch.bmm` and convolution
+        operators.
     """
     _C._set_deterministic(d)
 
-def is_deterministic():
+def _is_deterministic():
     r"""Returns True if the global deterministic flag is turned on and
     operations are being forced to use a deterministic implementation.
+
+    .. warning::
+        This feature is experimental and not complete. The above docstring
+        represents what the future behavior is intended to be. Right now,
+        the global deterministic flag will only affect `torch.bmm` and
+        convolution operators.
     """
     return _C._get_deterministic()
 

--- a/torch/_overrides.py
+++ b/torch/_overrides.py
@@ -142,8 +142,8 @@ def get_ignored_functions():
         torch.autocast_decrement_nesting,
         torch.nn.functional.hardswish,
         torch.is_vulkan_available,
-        torch.is_deterministic,
-        torch.set_deterministic
+        torch._is_deterministic,
+        torch._set_deterministic
     )
 
 def get_testing_overrides():


### PR DESCRIPTION
…s experimental

This PR:
- renames `torch.set_deterministic` to `torch._set_deterministic`
- renames `torch.is_deterministic` to `torch._is_deterministic`
- Modifies the docstrings for both to indicate that the feature is not
yet complete.

We would like to do this because this feature is experimental and the
docstrings before this PR are misleading.

This PR does not have an accompanying change in master. That is because
there still is discussion over what the eventual state of the feature
should be: https://github.com/pytorch/pytorch/issues/15359. I expect
that there will be a better plan for this once 1.7 rolls around.

Test Plan:
- wait for CI

