### PR TITLE
Disable AT_ASSERTM everywhere except those files that are using it

### DIFF
--- a/aten/src/ATen/SparseTensorUtils.h
+++ b/aten/src/ATen/SparseTensorUtils.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <ATen/ATen.h>
 #include <ATen/SparseTensorImpl.h>

--- a/aten/src/ATen/core/blob.h
+++ b/aten/src/ATen/core/blob.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <cstddef>
 #include <sstream>

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <ATen/core/TensorBody.h>
 #include <ATen/core/functional.h>

--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>

--- a/aten/src/ATen/cuda/detail/KernelUtils.h
+++ b/aten/src/ATen/cuda/detail/KernelUtils.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <ATen/ATen.h>
 

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>

--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/native/TensorTransformations.h>
 
 #include <ATen/NamedTensorUtils.h>

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <c10/core/Backend.h>
 #include <c10/core/ScalarType.h>

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/AccumulateType.h>

--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/native/TensorTransformations.h>
 
 #include <ATen/NativeFunctions.h>

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/NativeFunctions.h>

--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/native/UnaryOps.h>
 
 #include <cmath>

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/native/TensorAdvancedIndexing.h>
 
 #include <ATen/ATen.h>

--- a/aten/src/ATen/native/cuda/RNN.cu
+++ b/aten/src/ATen/native/cuda/RNN.cu
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/TensorUtils.h>

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/TensorUtils.h>

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/native/RNN.h>
 #include <ATen/ATen.h>
 #include <ATen/Config.h>

--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/native/RNN.h>
 #include <ATen/ATen.h>
 #include <ATen/Config.h>

--- a/aten/src/ATen/native/mkldnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/mkldnn/BinaryOps.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
 #include <ATen/NativeFunctions.h>

--- a/aten/src/ATen/native/mkldnn/Normalization.cpp
+++ b/aten/src/ATen/native/mkldnn/Normalization.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
 #include <ATen/NativeFunctions.h>

--- a/aten/src/ATen/native/mkldnn/SoftMax.cpp
+++ b/aten/src/ATen/native/mkldnn/SoftMax.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
 #include <ATen/NativeFunctions.h>

--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <c10/core/Allocator.h>
 
 #include <c10/util/ThreadLocalDebugInfo.h>

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <c10/core/Allocator.h>
 #include <c10/core/ScalarType.h>

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <c10/core/DefaultDtype.h>
 #include <c10/core/Backend.h>

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <c10/cuda/CUDACachingAllocator.h>
 
 #include <c10/cuda/CUDAGuard.h>

--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <c10/cuda/CUDAStream.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAGuard.h>

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -433,20 +433,6 @@ inline void deprecated_AT_ASSERTM() {}
     C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(__VA_ARGS__)); \
   } while (false)
 
-// Deprecated alias, like AT_ASSERT.  The new TORCH_INTERNAL_ASSERT macro supports
-// both 0-ary and variadic calls, so having a separate message-accepting macro
-// is not necessary.
-//
-// NB: we MUST include cond explicitly here, as MSVC will miscompile the macro
-// expansion, shunting all of __VA_ARGS__ to cond.  An alternate workaround
-// can be seen at
-// https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
-#define AT_ASSERTM(cond, ...)                                                 \
-  do {                                                                        \
-    ::c10::detail::deprecated_AT_ASSERTM();                                   \
-    C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(cond, __VA_ARGS__));     \
-  } while (false)
-
 // Deprecated alias; this alias was deprecated because it represents extra API
 // surface that makes it hard for people to understand what macro to use.
 // Use TORCH_CHECK(false, ...) or TORCH_INTERNAL_ASSERT(false, ...) to
@@ -458,3 +444,19 @@ inline void deprecated_AT_ASSERTM() {}
   } while (false)
 
 #endif // C10_UTIL_EXCEPTION_H_
+
+#ifdef OBSOLETE_AT_ASSERTM
+// Deprecated alias, like AT_ASSERT.  The new TORCH_INTERNAL_ASSERT macro
+// supports both 0-ary and variadic calls, so having a separate
+// message-accepting macro is not necessary.
+//
+// NB: we MUST include cond explicitly here, as MSVC will miscompile the macro
+// expansion, shunting all of __VA_ARGS__ to cond.  An alternate workaround
+// can be seen at
+// https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
+#define AT_ASSERTM(cond, ...)                                             \
+  do {                                                                    \
+    ::c10::detail::deprecated_AT_ASSERTM();                               \
+    C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(cond, __VA_ARGS__)); \
+  } while (false)
+#endif

--- a/caffe2/core/context_base.h
+++ b/caffe2/core/context_base.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <array>
 #include <cstdlib>

--- a/caffe2/core/export_c10_op_to_caffe2.h
+++ b/caffe2/core/export_c10_op_to_caffe2.h
@@ -1,4 +1,6 @@
 #pragma once
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <c10/macros/Macros.h>
 #include <c10/util/Registry.h>

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -1,4 +1,6 @@
 #include "caffe2/core/operator.h"
+#define OBSOLETE_AT_ASSERTM // This is an obsolete exemption guard. We have
+                            // AT_ASSERTM in this file.
 
 #include <algorithm>
 

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/tensor_int8.h"
 

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #ifndef CAFFE2_CORE_TENSOR_H_
 #define CAFFE2_CORE_TENSOR_H_
 

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <cstdio>
 #include <cstring>
 #include <cerrno>

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 // NB: Must be at the top of file to avoid including the deprecated "math.h".
 // https://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio
 #ifdef _MSC_VER

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <torch/csrc/jit/ir/ir.h>
 
 #include <ATen/core/builtin_function.h>

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/frontend/lexer.h>
 #include <torch/csrc/jit/frontend/parse_string_literal.h>

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <torch/csrc/jit/passes/batch_mm.h>
 
 #include <ATen/core/functional.h>

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <torch/csrc/jit/passes/onnx.h>
 #include <ATen/core/functional.h>
 #include <c10/util/Exception.h>

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <torch/csrc/jit/passes/shape_analysis.h>
 
 #include <c10/util/Exception.h>

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <google/protobuf/util/json_util.h>
 #include <google/protobuf/util/type_resolver_util.h>
 

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -1,3 +1,4 @@
+#define OBSOLETE_AT_ASSERTM  // This is an obsolete exemption guard. We have AT_ASSERTM in this file.
 #include <torch/csrc/python_headers.h>
 #include <system_error>
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41876 Remove all AT_ASSERTM under ATen CPU kernels.
* **#41875 Disable AT_ASSERTM everywhere except those files that are using it**

Since there are too many AT_ASSERTM, this will give us some leeway to
gradually remove all AT_ASSERTM.

Also move ASSERTM out of the header guard to make sure that the macro
OBSOLETE_AT_ASSERTM will always take effects.