### PR TITLE
[TensorExpr] Fix propagation of loop options when splitting loops (#40035)

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -41,6 +41,8 @@ namespace jit {
   _(ExprSplitWithTail)                      \
   _(ExprSplitWithTailNone)                  \
   _(ExprSplitWithMask01)                    \
+  _(SplitWithTailWithLoopOptions)           \
+  _(SplitWithMaskWithLoopOptions)           \
   _(ScheduleBroadcastAddBuffer)             \
   _(ScheduleFunctionCall01)                 \
   _(ScheduleInlineFunc01)                   \

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -946,7 +946,8 @@ void LoopNest::splitWithTail(
       Substitute(Stmt::clone(f->body()), {{f->var(), combined_index1}});
 
   *inner = new For(i_inner, new IntImm(0), factor_expr, body_inner);
-  *outer = new For(i_outer, new IntImm(0), split_count, *inner);
+  *outer =
+      new For(i_outer, new IntImm(0), split_count, *inner, f->loop_options());
 
   // TODO: cleanup API for adding/removing statements
   p->replace_stmt(f, *outer);
@@ -1020,7 +1021,8 @@ void LoopNest::splitWithMask(For* f, int factor, For** outer, For** inner) {
   body_inner = Substitute(body_inner, {{f->var(), combined_index}});
 
   *inner = new For(i_inner, new IntImm(0), factor_expr, body_inner);
-  *outer = new For(i_outer, new IntImm(0), split_count, *inner);
+  *outer =
+      new For(i_outer, new IntImm(0), split_count, *inner, f->loop_options());
 
   // TODO: cleanup API for adding/removing statements
   p->replace_stmt(f, *outer);

--- a/torch/quantization/adaround.py
+++ b/torch/quantization/adaround.py
@@ -1,0 +1,56 @@
+import torch
+
+class adaroundObeserver(torch.quantization.observer.MinMaxObserver):
+    def __init__(self):
+        super(MinMaxObserver, self).__init__()
+        self.V = torch.zeros(i,j)
+        self.beta = 2
+        self._lambda = .9
+
+    def forward(self, x):
+        pass
+
+def loss_function(model, input):
+    # model should contain its scaling parameters
+    # its activation_post_process should have an observer with V
+    scale = something
+    weights = something
+    beta = something
+    _lambda = something
+    V = something
+
+    W_over_s = torch.floor_divide(weights, scale)
+    W_plus_H = W_over_s + h_V(V)
+    soft_quantized_weights = scale * torch.clamp(W_plus_H, 0, 255)
+    soft_model = copy.deepcopy(model)
+    soft_model.weights = soft_quantized_weights
+
+    # Frobenius_norm = torch.norm(weights - soft_quantized_weights)
+    Frobenius_norm = torch.norm(model.forward(input) - soft_model.forward(input))
+
+    spreading_range = 2*V -1
+    one_minus_beta = 1- (spreading_range ** beta)  # torch.exp
+    f_reg = torch.sum(one_minus_beta)
+
+    return Frobenius_norm + _lambda*f_reg
+
+def h_V(V):
+    sig_applied = torch.sigmoid(V)
+    # scale_n_add = torch.add(torch.mul(V, 1.2), -0.1)
+    scale_n_add = (V* 1.2) -0.1 #broadcast should work?
+    clip = torch.clamp(scale_n_add, 0, 255)
+    return clip
+
+
+def train_one_epoch(model, criterion, optimizer, data_loader, device, ntrain_batches):
+    model.train()
+
+    for image, target in data_loader:
+        start_time = time.time()
+        image, target = image.to(device), target.to(device)
+        output = model(image)
+        loss = criterion(output, target)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+    return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41881 Adaround Implementation
* #41879 Revert "[TensorExpr] Fix propagation of loop options when splitting loops (#40035)"
* **#41878 [TensorExpr] Fix propagation of loop options when splitting loops (#40035)**

Summary:
Fix a bug in SplitWithTail and SplitWithMask where loop_options such as Cuda block/thread bindings are overwritten by the split. This PR fixes this bug by propagating the loop options to the outer loop, which for axis bindings should be equivalent.

Reviewed By: ZolotukhinM

Differential Revision: D22080263

Pulled By: nickgg

fbshipit-source-id: b8a9583fd90f69319fc4bb4db644e91f6ffa8e67