### PR TITLE
[v1.6.0] Update gather documentation to allow index.shape[k] <= input.shape[k]…

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2447,11 +2447,9 @@ For a 3-D tensor the output is specified by::
     out[i][j][k] = input[i][index[i][j][k]][k]  # if dim == 1
     out[i][j][k] = input[i][j][index[i][j][k]]  # if dim == 2
 
-If :attr:`input` is an n-dimensional tensor with size
-:math:`(x_0, x_1..., x_{i-1}, x_i, x_{i+1}, ..., x_{n-1})`
-and ``dim = i``, then :attr:`index` must be an :math:`n`-dimensional tensor with
-size :math:`(x_0, x_1, ..., x_{i-1}, y, x_{i+1}, ..., x_{n-1})` where :math:`y \geq 1`
-and :attr:`out` will have the same size as :attr:`index`.
+:attr:`input` and :attr:`index` must have the same number of dimensions.
+It is also required that ``index.size(d) <= input.size(d)`` for all
+dimensions ``d != dim``.  :attr:`out` will have the same shape as :attr:`index`.
 """ + r"""
 Args:
     input (Tensor): the source tensor


### PR DESCRIPTION
… rather than ==.

ghstack-source-id: 7bd43ecdee0c0dfab309b6216c07e0c0f5907776
Pull Request resolved: https://github.com/pytorch/pytorch/pull/41887

