### PR TITLE
Reduce instability in runCleanUpPasses by reordering passes.

### DIFF
--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -12,6 +12,7 @@ set(JIT_TEST_SRCS
   ${JIT_TEST_ROOT}/test_class_type.cpp
   ${JIT_TEST_ROOT}/test_code_template.cpp
   ${JIT_TEST_ROOT}/test_constant_pooling.cpp
+  ${JIT_TEST_ROOT}/test_cleanup_passes.cpp
   ${JIT_TEST_ROOT}/test_create_autodiff_subgraphs.cpp
   ${JIT_TEST_ROOT}/test_custom_class.cpp
   ${JIT_TEST_ROOT}/test_custom_operators.cpp

--- a/test/cpp/jit/test_cleanup_passes.cpp
+++ b/test/cpp/jit/test_cleanup_passes.cpp
@@ -1,0 +1,50 @@
+#include <torch/csrc/jit/frontend/ir_emitter.h>
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/testing/file_check.h>
+#include "test/cpp/jit/test_base.h"
+
+namespace torch {
+namespace jit {
+
+void testCleanUpPasses() {
+  // Tests stability of clean up passes when dealing with constant pooling
+  // and constant propagation.
+  {
+    auto graph = std::make_shared<Graph>();
+    parseIR(
+        R"IR(
+graph(%cond.1 : Tensor,
+      %suffix.1 : str):
+  %3 : bool = aten::Bool(%cond.1) # o.py:6:7
+  %25 : str = prim::If(%3) # o.py:6:4
+    block0():
+      %a.1 : str = prim::Constant[value="same string"]()
+      %b.1 : str = prim::Constant[value=" with a twist"]()
+      %7 : str = aten::add(%a.1, %b.1)
+      %11 : str = aten::add(%7, %suffix.1) # o.py:10:15
+      -> (%11)
+    block1():
+      %c.1 : str = prim::Constant[value="same string"]()
+      %d.1 : str = prim::Constant[value=" with a twist"]()
+      %12 : str = aten::add(%c.1, %d.1)
+      -> (%12)
+  return (%25)
+  )IR",
+        &*graph);
+    runCleanupPasses(graph);
+    testing::FileCheck()
+        .check_count(
+            "prim::Constant[value=\"same string with a twist\"]",
+            1,
+            /*exactly=*/true)
+        ->run(*graph);
+
+    auto graph_after_pass_once = graph->toString();
+    runCleanupPasses(graph);
+    auto graph_after_pass_twice = graph->toString();
+    ASSERT_EQ(graph_after_pass_once, graph_after_pass_twice);
+  }
+}
+} // namespace jit
+} // namespace torch

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -41,6 +41,7 @@ namespace jit {
   _(MemoryDAG)                         \
   _(IRParser)                          \
   _(ConstantPooling)                   \
+  _(CleanUpPasses)                     \
   _(THNNConv)                          \
   _(ATenNativeBatchNorm)               \
   _(NoneSchemaMatch)                   \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1861,6 +1861,7 @@ graph(%Ra, %Rb):
         self.run_pass('constant_propagation', graph)
         self.assertTrue(graph.findNode("prim::Loop").outputsSize() == 2)
 
+    # TODO(gmagogsfm): Refactor this test to reduce complexity.
     def test_constant_insertion(self):
         funcs_template = dedent('''
         def func():
@@ -1954,11 +1955,10 @@ graph(%Ra, %Rb):
             execWrapper(funcs_str, globals(), scope)
             cu = torch.jit.CompilationUnit(funcs_str)
             f_script = cu.func
-            self.run_pass('constant_propagation', f_script.graph)
-            num_constants = 3  # input constant twice, None once
-            FileCheck().check_count("prim::Constant", num_constants, exactly=True).run(f_script.graph)
+            self.run_pass('constant_propagation_immutable_types', f_script.graph)
+            num_constants = str(f_script.graph).count("prim::Constant")
             self.run_pass('cse', f_script.graph)
-            FileCheck().check_count("prim::Constant", num_constants - 1, exactly=True).run(f_script.graph)
+            FileCheck().check_count("prim::Constant", num_constants, exactly=True).run(f_script.graph)
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     def test_cuda_export_restore(self):

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -3816,9 +3816,10 @@ void runCleanupPasses(std::shared_ptr<Graph>& to_clean) {
   if (getInlineEverythingMode()) {
     Inline(*to_clean);
   }
+
   // remove any uses of tuples that we inserted that are not needed
   LowerSimpleTuples(to_clean);
-  ConstantPooling(to_clean);
+
   // full constant propagation runs ops with mutable inputs if it can
   // prove that the inputs are not mutated anywhere in the graph.
   // if a mutating node is removed in the graph (e.g. constant prop inlined a
@@ -3827,6 +3828,11 @@ void runCleanupPasses(std::shared_ptr<Graph>& to_clean) {
   // (jitter) So we run only constant prop w immutable types here bc
   // successive runs of immutable constant prop does not change the graph
   ConstantPropagationImmutableTypes(to_clean);
+
+  // Constant Pooling pass must be after ConstantPropogation, which can create
+  // new constants that needs to be pooled.
+  ConstantPooling(to_clean);
+
   // For jitter
   CanonicalizeOutputs(to_clean);
 }

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -345,6 +345,11 @@ void initJITBindings(PyObject* module) {
           })
       .def("_jit_pass_loop_unrolling", UnrollLoops)
       .def(
+          "_jit_pass_constant_propagation_immutable_types",
+          [](std::shared_ptr<Graph>& g) {
+            return ConstantPropagationImmutableTypes(g);
+          })
+      .def(
           "_jit_pass_constant_propagation",
           [](std::shared_ptr<Graph>& g) { return ConstantPropagation(g); })
       .def("_jit_pass_erase_shape_information", EraseShapeInformation)


### PR DESCRIPTION
Currently constant pooling runs before const propagation, which can create more constants that need pooling. This can get in the way of serialization/deserialization stability because each time user serializes and deserializes a module, runCleanUpPasses is called upon it. Doing so multiple times would lead to different saved module.

This PR moves constant pooling after const propagation, which may slow down const propagation a little bit, but would otherwise side-step aforementioned problem.

test_constant_insertion in test_jit.py is also updated because after fixing the pass ordering, the number of constants is no longer a constant and it is extremely difficult to get the exact number with the current convoluted test structure. So for now, I changed the test to check only that CSE doesn't change number of "prim::constant" rather than comparing against a known number. Also left a TODO to improve this test.

ConstantPropagation pass is replaced by ConstantPropagationImmutableTypes because the latter is used in runCleanUpPasses. If not replaced, the former would create new CSE opportunities by folding more constants. This voids the purpose of the test case.