### PR TITLE
[iOS] Bump up the cocoapods version

### DIFF
--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '1.5.0'
+    s.version          = '1.6.0'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41895 [iOS] Bump up the cocoapods version**

### Summary

The iOS binary for 1.6.0 has been uploaded to AWS. This PR bumps up the version for cocoapods.

### Test Plan

- Check CI

Differential Revision: [D22683787](https://our.internmc.facebook.com/intern/diff/D22683787)