### PR TITLE
Environment variable for controlling type verbosity in debug output

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1540,6 +1540,16 @@ private:
   : Type(TypeKind::PyObjectType) {}
 };
 
+enum class TypeVerbosity {
+  None,
+  Type,
+  TypeAndStride,
+  Full,
+  Default = Full,
+};
+
+CAFFE2_API TypeVerbosity type_verbosity();
+
 CAFFE2_API std::ostream& operator<<(std::ostream& out, const Type& t);
 template <typename T>
 CAFFE2_API std::ostream& operator<<(

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -9,6 +9,13 @@
 
 namespace c10 {
 
+TypeVerbosity type_verbosity() {
+  static const char* c_verbosity = std::getenv("PYTORCH_JIT_TYPE_VERBOSITY");
+  static TypeVerbosity verbosity = c_verbosity ?
+    static_cast<TypeVerbosity>(std::stoi(c_verbosity)) : TypeVerbosity::Default;
+  return verbosity;
+}
+
 std::ostream& operator<<(std::ostream & out, const Type & t) {
   if (auto value = t.cast<TensorType>()) {
     if  (value->scalarType().has_value()) {
@@ -34,21 +41,24 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
         } else {
           out << "*";
         }
-        if (has_valid_strides_info) {
+        if (has_valid_strides_info &&
+            type_verbosity() >= TypeVerbosity::TypeAndStride) {
           out << ":" << *value->strides()[i];
         }
       }
-      if (value->requiresGrad()) {
-        if (i++ > 0) {
-          out << ", ";
+      if (type_verbosity() >= TypeVerbosity::Full) {
+        if (value->requiresGrad()) {
+          if (i++ > 0) {
+            out << ", ";
+          }
+          out << "requires_grad=" << *value->requiresGrad();
         }
-        out << "requires_grad=" << *value->requiresGrad();
-      }
-      if (value->device()) {
-        if (i++ > 0) {
-          out << ", ";
+        if (value->device()) {
+          if (i++ > 0) {
+            out << ", ";
+          }
+          out << "device=" << *value->device();
         }
-        out << "device=" << *value->device();
       }
       out << ")";
     }

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -93,8 +93,10 @@ std::ostream& operator<<(
       out << l.delim;
     }
     printValueRef(out, n);
-    out << " : ";
-    out << *n->type();
+    if (c10::type_verbosity() >= c10::TypeVerbosity::Type) {
+      out << " : ";
+      out << *n->type();
+    }
   }
   return out;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41906 Environment variable for controlling type verbosity in debug output**

Summary:

Fixes #41770

Test Plan:
Example:
```
import torch
def bar():
    def test(a):
        return a
    x = torch.ones(10,10, device='cpu')
    print(torch.jit.trace(test, (x)).graph)
bar()
```

Bash:
```
for i in 0 1 2 3; do
  PYTORCH_JIT_TYPE_VERBOSITY=$i python test.py
done
```

Output:
```
graph(%0):
  return (%0)

graph(%0 : Float(10, 10)):
  return (%0)

graph(%0 : Float(10:10, 10:1)):
  return (%0)

graph(%0 : Float(10:10, 10:1, requires_grad=0, device=cpu)):
  return (%0)
```

Reviewers: mvz, villedepommes, eellison

Subscribers:

Tasks:

Tags:

Differential Revision: [D22687966](https://our.internmc.facebook.com/intern/diff/D22687966)