### PR TITLE
move min/max tests to TestTorchDeviceType

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -275,85 +275,6 @@ class AbstractTestCases:
             self.assertIsNotNone(torch.Tensor([0, 0, 0]).nonzero().storage())
             self.assertIsNotNone(torch.Tensor().new().storage())
 
-        def _testSelection(self, torchfn, mathfn, skip_indices=False):
-            # contiguous
-            m1 = torch.randn(100, 100)
-            res1 = torchfn(m1)
-            res2 = m1[0, 0]
-            for i, j in iter_indices(m1):
-                res2 = mathfn(res2, m1[i, j])
-            self.assertEqual(res1, res2)
-
-            # non-contiguous
-            m1 = torch.randn(10, 10, 10)
-            m2 = m1[:, 4]
-            res1 = torchfn(m2)
-            res2 = m2[0, 0]
-            for i, j in iter_indices(m2):
-                res2 = mathfn(res2, m2[i][j])
-            self.assertEqual(res1, res2)
-
-            # with indices
-            if not skip_indices:
-                m1 = torch.randn(100, 100)
-                res1val, res1ind = torchfn(m1, 1, False)
-                res2val = m1[:, 0:1].clone().squeeze()
-                res2ind = res1ind.clone().fill_(0)
-                for i, j in iter_indices(m1):
-                    if mathfn(res2val[i], m1[i, j]) != res2val[i]:
-                        res2val[i] = m1[i, j]
-                        res2ind[i] = j
-
-                maxerr = 0
-                for i in range(res1val.size(0)):
-                    maxerr = max(maxerr, abs(res1val[i] - res2val[i]))
-                    self.assertEqual(res1ind[i], res2ind[i])
-                self.assertLessEqual(abs(maxerr), 1e-5)
-
-            # NaNs
-            for index in (0, 4, 99):
-                m1 = torch.randn(100)
-                m1[index] = nan
-                res1val, res1ind = torch.max(m1, 0)
-                self.assertTrue(math.isnan(res1val))
-                self.assertEqual(res1ind, index)
-                res1val = torchfn(m1)
-                self.assertTrue(math.isnan(res1val))
-
-            # Bool
-            m1 = torch.tensor([True, False, True], dtype=torch.bool)
-            res1 = torchfn(m1)
-            res2 = m1[0]
-            for i in iter_indices(m1):
-                res2 = mathfn(res2, m1[i])
-            self.assertEqual(res1, res2)
-
-            # Long
-            m1 = torch.LongTensor(100).random_(-1000, 1000)
-            res1 = torchfn(m1)
-            res2 = m1[0]
-            for i in iter_indices(m1):
-                res2 = mathfn(res2, m1[i])
-            self.assertEqual(res1, res2)
-
-
-        def test_max(self):
-            self._testSelection(torch.max, max)
-
-        def test_min(self):
-            self._testSelection(torch.min, min)
-
-        def test_min_max(self):
-            # TODO: implement indices, in a future PR
-            # min correctness
-            self._testSelection(lambda x: torch._min_max(x)[0],
-                                lambda x, y: min(x, y),
-                                skip_indices=True)
-            # max correctness
-            self._testSelection(lambda x: torch._min_max(x)[1],
-                                lambda x, y: max(x, y),
-                                skip_indices=True)
-
         def test_dim_reduction_uint8_overflow(self):
             example = [[-1, 2, 1], [5, 3, 6]]
             x = torch.tensor(example, dtype=torch.uint8)
@@ -15456,6 +15377,56 @@ class TestTorchDeviceType(TestCase):
         a = torch.tensor([[-inf, -inf, inf, 3], [inf, inf, -inf, -1]], dtype=dtype, device=device)
         self.assertTrue(torch.all(torch.min(a, dim=1)[0] == (-inf)).item())
         self.assertTrue(torch.min(a).item() == -inf)
+
+    def _test_minmax_helper(self, torchfn, reffn, device, dtype, skip_indices=False):
+        def create_input(shape, device, dtype):
+            if dtype.is_floating_point:
+                return torch.randn(*shape, device=device, dtype=dtype)
+            else:
+                low = 0 if dtype == torch.bool else -1000
+                high = 2 if dtype == torch.bool else 1000
+                return torch.randint(low, high, shape, device=device, dtype=dtype)
+        x = create_input((100, 100), device, dtype)
+        self.compare_with_numpy(torchfn, reffn, x)
+        # non contiguous
+        x = create_input((10, 10, 10), device, dtype)
+        x = x[:, 4]
+        self.compare_with_numpy(torchfn, reffn, x)
+        # indices
+        if not skip_indices:
+            size = 100
+            x = create_input((size, size), device, dtype)
+            self.compare_with_numpy(lambda x: torchfn(x, 1, False)[0], lambda x: reffn(x, 1, keepdims=False), x)
+            v, i = torchfn(x, 1, False)
+            self.assertEqual(x[torch.arange(size), i], v, atol=0, rtol=0)
+        # nan
+        if dtype.is_floating_point:
+            for index in (0, 4, 99):
+                x = create_input((100,), device, dtype)
+                x[index] = nan
+                if not skip_indices:
+                    v, i = torchfn(x, 0)
+                    self.assertEqual(v, nan)
+                    self.assertEqual(i, index)
+                self.assertEqual(torchfn(x), nan)
+
+    @dtypesIfCPU(torch.float, torch.double, torch.long, torch.bool)
+    @dtypesIfCUDA(torch.half, torch.float, torch.long, torch.bool)
+    @dtypes(torch.float, torch.double)
+    def test_max0(self, device, dtype):
+        self._test_minmax_helper(torch.max, np.amax, device, dtype)
+
+    @dtypesIfCPU(torch.float, torch.double, torch.long, torch.bool)
+    @dtypesIfCUDA(torch.half, torch.float, torch.long, torch.bool)
+    @dtypes(torch.float, torch.double)
+    def test_min0(self, device, dtype):
+        self._test_minmax_helper(torch.min, np.amin, device, dtype)
+
+    @onlyCPU
+    @dtypesIfCPU(torch.float, torch.double)
+    def test_minmax(self, device, dtype):
+        self._test_minmax_helper(lambda x: torch._min_max(x)[0], np.min, device, dtype, skip_indices=True)
+        self._test_minmax_helper(lambda x: torch._min_max(x)[1], np.max, device, dtype, skip_indices=True)
 
     def test_bincount(self, device):
         # negative input throws

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15413,13 +15413,13 @@ class TestTorchDeviceType(TestCase):
     @dtypesIfCPU(torch.float, torch.double, torch.long, torch.bool)
     @dtypesIfCUDA(torch.half, torch.float, torch.long, torch.bool)
     @dtypes(torch.float, torch.double)
-    def test_max0(self, device, dtype):
+    def test_max(self, device, dtype):
         self._test_minmax_helper(torch.max, np.amax, device, dtype)
 
     @dtypesIfCPU(torch.float, torch.double, torch.long, torch.bool)
     @dtypesIfCUDA(torch.half, torch.float, torch.long, torch.bool)
     @dtypes(torch.float, torch.double)
-    def test_min0(self, device, dtype):
+    def test_min(self, device, dtype):
         self._test_minmax_helper(torch.min, np.amin, device, dtype)
 
     @onlyCPU

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15430,10 +15430,17 @@ class TestTorchDeviceType(TestCase):
     def test_min(self, device, dtype):
         self._test_minmax_helper(torch.min, np.amin, device, dtype)
 
-    @onlyCPU
+    @onlyOnCPUAndCUDA
     @dtypesIfCPU(torch.float, torch.double)
+    @dtypesIfCUDA(torch.half, torch.float)
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_minmax(self, device, dtype):
+        if self.device_type == "cuda":
+            # FIXME when minmax is implemented on cuda
+            with self.assertRaises(RuntimeError):
+                self._test_minmax_helper(lambda x: torch._min_max(x)[0], np.min, device, dtype, skip_indices=True)
+            return
+
         self._test_minmax_helper(lambda x: torch._min_max(x)[0], np.min, device, dtype, skip_indices=True)
         self._test_minmax_helper(lambda x: torch._min_max(x)[1], np.max, device, dtype, skip_indices=True)
 


### PR DESCRIPTION
so that testing _min_max on the different devices is easier, and min/max operations have better CUDA test coverage. 
