### PR TITLE
check pruned attributes before deleting

### DIFF
--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -233,7 +233,8 @@ class BasePruningMethod(ABC):
         weight = self.apply_mask(module)  # masked weights
 
         # delete and reset
-        delattr(module, self._tensor_name)
+        if hasattr(module, self._tensor_name):
+            delattr(module, self._tensor_name)
         orig = module._parameters[self._tensor_name + "_orig"]
         orig.data = weight.data
         del module._parameters[self._tensor_name + "_orig"]


### PR DESCRIPTION
I copyed a pruned model after deleteing the derived tensors. In order to be able to reparameter the model, we should check the existence of the tensors here. 