### PR TITLE
Fix 64-bit indexing in GridSampler

### DIFF
--- a/aten/src/ATen/cuda/detail/IndexUtils.cu
+++ b/aten/src/ATen/cuda/detail/IndexUtils.cu
@@ -70,35 +70,6 @@ bool maybeOverlappingIndices(const Tensor& t) {
   return false;
 }
 
-bool canUse32BitIndexMath(const Tensor& t, int64_t max_elem) {
-  int64_t elements = t.numel();
-  if (elements >= max_elem) {
-    return false;
-  } else if (elements == 0) {
-    return true;
-  }
-
-  if (t.numel() == 0) {
-    return max_elem > 0;
-  }
-
-  int64_t offset = 0;
-  int64_t linearId = elements - 1;
-
-  for (int i = t.dim() - 1; i >= 0; --i) {
-    int64_t curDimIndex = linearId % t.size(i);
-    int64_t curDimOffset = curDimIndex * t.stride(i);
-    offset += curDimOffset;
-    linearId /= t.size(i);
-  }
-
-  if (offset >= max_elem) {
-    return false;
-  }
-
-  return true;
-}
-
 } // detail
 } // cuda
 } // at

--- a/aten/src/ATen/cuda/detail/IndexUtils.cuh
+++ b/aten/src/ATen/cuda/detail/IndexUtils.cuh
@@ -2,14 +2,14 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/detail/TensorInfo.cuh>
-#include <limits>
+#include <ATen/native/IndexingUtils.h>
 
 namespace at {
 namespace cuda {
 namespace detail {
 
 TORCH_CUDA_API bool maybeOverlappingIndices(const at::Tensor& t);
-TORCH_CUDA_API bool canUse32BitIndexMath(const at::Tensor &t, int64_t max_elem=std::numeric_limits<int32_t>::max());
+using at::native::canUse32BitIndexMath;
 
 template <typename scalar, typename IndexType>
 TensorInfo<scalar, IndexType>

--- a/aten/src/ATen/cuda/detail/KernelUtils.h
+++ b/aten/src/ATen/cuda/detail/KernelUtils.h
@@ -14,9 +14,12 @@ namespace at { namespace cuda { namespace detail {
 // iteration of the loop where _i_n_d_e_x += blockDim.x * gridDim.x can be
 // greater than INT_MAX.  But in that case _i_n_d_e_x >= n, so there are no
 // further iterations and the overflowed value in i=_i_n_d_e_x is not used.
-#define CUDA_KERNEL_LOOP(i, n) \
-  int64_t _i_n_d_e_x = blockIdx.x * blockDim.x + threadIdx.x;                                \
-  for (int i=_i_n_d_e_x; _i_n_d_e_x < (n); _i_n_d_e_x+=blockDim.x * gridDim.x, i=_i_n_d_e_x)
+#define CUDA_KERNEL_LOOP_TYPE(i, n, index_type)                         \
+  int64_t _i_n_d_e_x = blockIdx.x * blockDim.x + threadIdx.x;           \
+  for (index_type i=_i_n_d_e_x; _i_n_d_e_x < (n); _i_n_d_e_x+=blockDim.x * gridDim.x, i=_i_n_d_e_x)
+
+#define CUDA_KERNEL_LOOP(i, n) CUDA_KERNEL_LOOP_TYPE(i, n, int)
+
 
 // Use 1024 threads per block, which requires cuda sm_2x or above
 constexpr int CUDA_NUM_THREADS = 1024;
@@ -26,6 +29,12 @@ inline int GET_BLOCKS(const int N)
 {
   AT_ASSERTM(N > 0, "CUDA kernel launch blocks must be positive, but got N=", N);
   return (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
+}
+
+inline int GET_BLOCKS(const int64_t N) {
+  AT_ASSERTM(N > 0, "CUDA kernel launch blocks must be positive, but got N=", N);
+  constexpr int64_t max_int = std::numeric_limits<int>::max();
+  return GET_BLOCKS(static_cast<int>(std::min(max_int, N)));
 }
 
 }}}  // namespace at::cuda::detail

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -5,6 +5,7 @@
 #include <ATen/Parallel.h>
 #include <c10/core/Layout.h>
 #include <ATen/cpu/vml.h>
+#include <ATen/native/IndexingUtils.h>
 #include <ATen/native/cpu/GridSamplerKernel.h>
 #include <c10/util/Exception.h>
 
@@ -756,8 +757,8 @@ Tensor grid_sampler(const Tensor& input, const Tensor& grid,
   // cudnn does not support inputs larger than 1024
   if (at::native::cudnn_is_acceptable(input) &&
       at::native::cudnn_is_acceptable(grid) &&
-      at::cuda::detail::canUse32BitIndexMath(input) &&
-      at::cuda::detail::canUse32BitIndexMath(grid) &&
+      at::native::canUse32BitIndexMath(input) &&
+      at::native::canUse32BitIndexMath(grid) &&
       static_cast<GridSamplerInterpolation>(interpolation_mode) == GridSamplerInterpolation::Bilinear &&
       static_cast<GridSamplerPadding>(padding_mode) == GridSamplerPadding::Zeros &&
       align_corners &&

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -381,254 +381,260 @@ namespace {
     return std::make_tuple(grad_input, grad_grid);
   }
 
-  template<typename scalar_t>
-  Tensor grid_sampler_2d_cpu_impl(const Tensor& input, const Tensor& grid,
-                                  GridSamplerInterpolation interpolation_mode,
-                                  GridSamplerPadding padding_mode,
-                                  bool align_corners) {
-    int64_t N = input.size(0);
-    int64_t C = input.size(1);
-    int64_t inp_H = input.size(2);
-    int64_t inp_W = input.size(3);
-    int64_t out_H = grid.size(1);
-    int64_t out_W = grid.size(2);
-    auto output = at::empty({N, C, out_H, out_W}, input.options());
-    int64_t inp_sN = input.stride(0);
-    int64_t inp_sC = input.stride(1);
-    int64_t inp_sH = input.stride(2);
-    int64_t inp_sW = input.stride(3);
-    int64_t grid_sN = grid.stride(0);
-    int64_t grid_sH = grid.stride(1);
-    int64_t grid_sW = grid.stride(2);
-    int64_t grid_sCoor = grid.stride(3);
-    int64_t out_sN = output.stride(0);
-    int64_t out_sC = output.stride(1);
-    int64_t out_sH = output.stride(2);
-    int64_t out_sW = output.stride(3);
-    scalar_t *inp_ptr = input.data_ptr<scalar_t>();
-    scalar_t *out_ptr = output.data_ptr<scalar_t>();
-    scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
-    // loop over each output pixel
-    at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
-      for (int64_t n = start; n < end; ++n) {
-        scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
-        scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
-        for (int64_t h = 0; h < out_H; ++h) {
-          for (int64_t w = 0; w < out_W; ++w) {
-            // get the corresponding input x, y, z co-ordinates from grid
-            scalar_t *grid_ptr_NDHW = grid_ptr_N + h * grid_sH + w * grid_sW;
-            scalar_t ix = *grid_ptr_NDHW;
-            scalar_t iy = grid_ptr_NDHW[grid_sCoor];
-
-            ix = grid_sampler_compute_source_index(ix, inp_W, padding_mode, align_corners);
-            iy = grid_sampler_compute_source_index(iy, inp_H, padding_mode, align_corners);
-
-            if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
-              // get corner pixel values from (x, y)
-              // for 4d, we use north-east-south-west
-              int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
-              int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
-
-              int64_t ix_ne = ix_nw + 1;
-              int64_t iy_ne = iy_nw;
-
-              int64_t ix_sw = ix_nw;
-              int64_t iy_sw = iy_nw + 1;
-
-              int64_t ix_se = ix_nw + 1;
-              int64_t iy_se = iy_nw + 1;
-
-
-              // get surfaces to each neighbor:
-              scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-              scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-              scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-              scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
-
-              // calculate bilinear weighted pixel value and set output pixel
-              scalar_t *inp_ptr_NC = inp_ptr_N;
-              scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
-              for (int64_t c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
-                auto res = static_cast<scalar_t>(0);
-                if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-                  res += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
-                }
-                if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-                  res += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
-                }
-                if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-                  res += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
-                }
-                if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-                  res += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
-                }
-                *out_ptr_NCHW = res;
-              }
-            } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-              int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
-              int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
-
-              // assign nearest neighor pixel value to output pixel
-              scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
-              scalar_t *inp_ptr_NC = inp_ptr_N;
-              for (int64_t c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
-                if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
-                  *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
-                } else {
-                  *out_ptr_NCHW = static_cast<scalar_t>(0);
-                }
-              }
-            }
-          }
-        }
-      }
-    });
-    return output;
-  }
-
-  template<typename scalar_t>
-  std::tuple<Tensor, Tensor>
-  grid_sampler_2d_backward_cpu_impl(const Tensor& grad_output,
-                                    const Tensor& input, const Tensor& grid,
-                                    GridSamplerInterpolation interpolation_mode,
-                                    GridSamplerPadding padding_mode,
-                                    bool align_corners) {
-    auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-    auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-    // If interpolation mode is Nearest, then grad_grid is not filled in the
-    // loop below.
-    if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-      grad_grid.zero_();
-    }
-    int64_t N = input.size(0);
-    int64_t C = input.size(1);
-    int64_t inp_H = input.size(2);
-    int64_t inp_W = input.size(3);
-    int64_t out_H = grid.size(1);
-    int64_t out_W = grid.size(2);
-    int64_t inp_sN = input.stride(0);
-    int64_t inp_sC = input.stride(1);
-    int64_t inp_sH = input.stride(2);
-    int64_t inp_sW = input.stride(3);
-    int64_t grid_sN = grid.stride(0);
-    int64_t grid_sH = grid.stride(1);
-    int64_t grid_sW = grid.stride(2);
-    int64_t grid_sCoor = grid.stride(3);
-    int64_t gOut_sN = grad_output.stride(0);
-    int64_t gOut_sC = grad_output.stride(1);
-    int64_t gOut_sH = grad_output.stride(2);
-    int64_t gOut_sW = grad_output.stride(3);
-    int64_t gInp_sN = grad_input.stride(0);
-    int64_t gInp_sC = grad_input.stride(1);
-    int64_t gInp_sH = grad_input.stride(2);
-    int64_t gInp_sW = grad_input.stride(3);
-    int64_t gGrid_sN = grad_grid.stride(0);
-    int64_t gGrid_sW = grad_grid.stride(2);
-    scalar_t *inp_ptr = input.data_ptr<scalar_t>();
-    scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
-    scalar_t *gOut_ptr = grad_output.data_ptr<scalar_t>();
-    scalar_t *gInp_ptr = grad_input.data_ptr<scalar_t>();
-    scalar_t *gGrid_ptr = grad_grid.data_ptr<scalar_t>();
-    // loop over each output pixel
-    at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
-      for (int64_t n = start; n < end; ++n) {
-        scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
-        scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
-        scalar_t *gGrid_ptr_NHW = gGrid_ptr + n * gGrid_sN;
-        for (int64_t h = 0; h < out_H; ++h) {
-          for (int64_t w = 0; w < out_W; ++w, gGrid_ptr_NHW += gGrid_sW /* grad_grid is contiguous */ ) {
-            // get the corresponding input x, y co-ordinates from grid
-            scalar_t *grid_ptr_NHW = grid_ptr_N + h * grid_sH + w * grid_sW;
-            scalar_t ix = *grid_ptr_NHW;
-            scalar_t iy = grid_ptr_NHW[grid_sCoor];
-
-            // multipliers for gradients on ix, iy
-            scalar_t gix_mult, giy_mult;
-            ix = grid_sampler_compute_source_index_set_grad(ix, inp_W, padding_mode, align_corners, &gix_mult);
-            iy = grid_sampler_compute_source_index_set_grad(iy, inp_H, padding_mode, align_corners, &giy_mult);
-
-            if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
-              // get corner pixel values from (x, y)
-              // for 4d, we use north-east-south-west
-              int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
-              int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
-
-              int64_t ix_ne = ix_nw + 1;
-              int64_t iy_ne = iy_nw;
-
-              int64_t ix_sw = ix_nw;
-              int64_t iy_sw = iy_nw + 1;
-
-              int64_t ix_se = ix_nw + 1;
-              int64_t iy_se = iy_nw + 1;
-
-              // get surfaces to each neighbor:
-              scalar_t nw = (ix_se - ix)    * (iy_se - iy);
-              scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
-              scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
-              scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
-
-              scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
-              scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-              scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-              scalar_t *inp_ptr_NC = inp_ptr_N;
-              // calculate bilinear weighted pixel value and set output pixel
-              for (int64_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
-                scalar_t gOut = *gOut_ptr_NCHW;
-
-                // calculate and set grad_input
-                safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
-                safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
-                safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
-                safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
-
-                // calculate grad_grid
-                if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
-                  scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
-                  gix -= nw_val * (iy_se - iy) * gOut;
-                  giy -= nw_val * (ix_se - ix) * gOut;
-                }
-                if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
-                  scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
-                  gix += ne_val * (iy_sw - iy) * gOut;
-                  giy -= ne_val * (ix - ix_sw) * gOut;
-                }
-                if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
-                  scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
-                  gix -= sw_val * (iy - iy_ne) * gOut;
-                  giy += sw_val * (ix_ne - ix) * gOut;
-                }
-                if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
-                  scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
-                  gix += se_val * (iy - iy_nw) * gOut;
-                  giy += se_val * (ix - ix_nw) * gOut;
-                }
-              }
-
-              // assuming grad_grid is contiguous
-              gGrid_ptr_NHW[0] = gix_mult * gix;
-              gGrid_ptr_NHW[1] = giy_mult * giy;
-            } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-              int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
-              int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
-
-              // assign nearest neighor pixel value to output pixel
-              scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
-              scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-              for (int64_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
-                // calculate and set grad_input
-                safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW,
-                            inp_H, inp_W, *gOut_ptr_NCHW);
-              }
-            }
-          }
-        }
-      }
-    });
-    return std::make_tuple(grad_input, grad_grid);
-  }
-
 }  // namespace
+
+Tensor _grid_sampler_2d_cpu_fallback(const Tensor& input, const Tensor& grid,
+                                     int64_t interpolation_mode_,
+                                     int64_t padding_mode_,
+                                     bool align_corners) {
+  auto interpolation_mode = static_cast<GridSamplerInterpolation>(interpolation_mode_);
+  auto padding_mode = static_cast<GridSamplerPadding>(padding_mode_);
+  using scalar_t = float;
+
+  int64_t N = input.size(0);
+  int64_t C = input.size(1);
+  int64_t inp_H = input.size(2);
+  int64_t inp_W = input.size(3);
+  int64_t out_H = grid.size(1);
+  int64_t out_W = grid.size(2);
+  auto output = at::empty({N, C, out_H, out_W}, input.options());
+  int64_t inp_sN = input.stride(0);
+  int64_t inp_sC = input.stride(1);
+  int64_t inp_sH = input.stride(2);
+  int64_t inp_sW = input.stride(3);
+  int64_t grid_sN = grid.stride(0);
+  int64_t grid_sH = grid.stride(1);
+  int64_t grid_sW = grid.stride(2);
+  int64_t grid_sCoor = grid.stride(3);
+  int64_t out_sN = output.stride(0);
+  int64_t out_sC = output.stride(1);
+  int64_t out_sH = output.stride(2);
+  int64_t out_sW = output.stride(3);
+  scalar_t *inp_ptr = input.data_ptr<scalar_t>();
+  scalar_t *out_ptr = output.data_ptr<scalar_t>();
+  scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
+  // loop over each output pixel
+  at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
+    for (int64_t n = start; n < end; ++n) {
+      scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
+      scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
+      for (int64_t h = 0; h < out_H; ++h) {
+        for (int64_t w = 0; w < out_W; ++w) {
+          // get the corresponding input x, y, z co-ordinates from grid
+          scalar_t *grid_ptr_NHW = grid_ptr_N + h * grid_sH + w * grid_sW;
+          scalar_t ix = *grid_ptr_NHW;
+          scalar_t iy = grid_ptr_NHW[grid_sCoor];
+
+          ix = grid_sampler_compute_source_index(ix, inp_W, padding_mode, align_corners);
+          iy = grid_sampler_compute_source_index(iy, inp_H, padding_mode, align_corners);
+
+          if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+            // get corner pixel values from (x, y)
+            // for 4d, we use north-east-south-west
+            int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
+            int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
+
+            int64_t ix_ne = ix_nw + 1;
+            int64_t iy_ne = iy_nw;
+
+            int64_t ix_sw = ix_nw;
+            int64_t iy_sw = iy_nw + 1;
+
+            int64_t ix_se = ix_nw + 1;
+            int64_t iy_se = iy_nw + 1;
+
+
+            // get surfaces to each neighbor:
+            scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+            scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+            scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+            scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+
+            // calculate bilinear weighted pixel value and set output pixel
+            scalar_t *inp_ptr_NC = inp_ptr_N;
+            scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
+            for (int64_t c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+              auto res = static_cast<scalar_t>(0);
+              if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+                res += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
+              }
+              if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+                res += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
+              }
+              if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+                res += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
+              }
+              if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+                res += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
+              }
+              *out_ptr_NCHW = res;
+            }
+          } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+            int64_t ix_nearest = static_cast<int64_t>(std::nearbyint(ix));
+            int64_t iy_nearest = static_cast<int64_t>(std::nearbyint(iy));
+
+            // assign nearest neighor pixel value to output pixel
+            scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
+            scalar_t *inp_ptr_NC = inp_ptr_N;
+            for (int64_t c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+              if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
+                *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
+              } else {
+                *out_ptr_NCHW = static_cast<scalar_t>(0);
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+  return output;
+}
+
+std::tuple<Tensor, Tensor>
+_grid_sampler_2d_cpu_fallback_backward(const Tensor& grad_output,
+                                       const Tensor& input, const Tensor& grid,
+                                       int64_t interpolation_mode_,
+                                       int64_t padding_mode_,
+                                       bool align_corners) {
+  const auto interpolation_mode = static_cast<GridSamplerInterpolation>(interpolation_mode_);
+  const auto padding_mode = static_cast<GridSamplerPadding>(padding_mode_);
+  using scalar_t = float;
+
+  auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  // If interpolation mode is Nearest, then grad_grid is not filled in the
+  // loop below.
+  if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+    grad_grid.zero_();
+  }
+  int64_t N = input.size(0);
+  int64_t C = input.size(1);
+  int64_t inp_H = input.size(2);
+  int64_t inp_W = input.size(3);
+  int64_t out_H = grid.size(1);
+  int64_t out_W = grid.size(2);
+  int64_t inp_sN = input.stride(0);
+  int64_t inp_sC = input.stride(1);
+  int64_t inp_sH = input.stride(2);
+  int64_t inp_sW = input.stride(3);
+  int64_t grid_sN = grid.stride(0);
+  int64_t grid_sH = grid.stride(1);
+  int64_t grid_sW = grid.stride(2);
+  int64_t grid_sCoor = grid.stride(3);
+  int64_t gOut_sN = grad_output.stride(0);
+  int64_t gOut_sC = grad_output.stride(1);
+  int64_t gOut_sH = grad_output.stride(2);
+  int64_t gOut_sW = grad_output.stride(3);
+  int64_t gInp_sN = grad_input.stride(0);
+  int64_t gInp_sC = grad_input.stride(1);
+  int64_t gInp_sH = grad_input.stride(2);
+  int64_t gInp_sW = grad_input.stride(3);
+  int64_t gGrid_sN = grad_grid.stride(0);
+  int64_t gGrid_sW = grad_grid.stride(2);
+  scalar_t *inp_ptr = input.data_ptr<scalar_t>();
+  scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
+  scalar_t *gOut_ptr = grad_output.data_ptr<scalar_t>();
+  scalar_t *gInp_ptr = grad_input.data_ptr<scalar_t>();
+  scalar_t *gGrid_ptr = grad_grid.data_ptr<scalar_t>();
+  // loop over each output pixel
+  at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
+    for (int64_t n = start; n < end; ++n) {
+      scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
+      scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
+      scalar_t *gGrid_ptr_NHW = gGrid_ptr + n * gGrid_sN;
+      for (int64_t h = 0; h < out_H; ++h) {
+        for (int64_t w = 0; w < out_W; ++w, gGrid_ptr_NHW += gGrid_sW /* grad_grid is contiguous */ ) {
+          // get the corresponding input x, y co-ordinates from grid
+          scalar_t *grid_ptr_NHW = grid_ptr_N + h * grid_sH + w * grid_sW;
+          scalar_t ix = *grid_ptr_NHW;
+          scalar_t iy = grid_ptr_NHW[grid_sCoor];
+
+          // multipliers for gradients on ix, iy
+          scalar_t gix_mult, giy_mult;
+          ix = grid_sampler_compute_source_index_set_grad(ix, inp_W, padding_mode, align_corners, &gix_mult);
+          iy = grid_sampler_compute_source_index_set_grad(iy, inp_H, padding_mode, align_corners, &giy_mult);
+
+          if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+            // get corner pixel values from (x, y)
+            // for 4d, we use north-east-south-west
+            int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
+            int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
+
+            int64_t ix_ne = ix_nw + 1;
+            int64_t iy_ne = iy_nw;
+
+            int64_t ix_sw = ix_nw;
+            int64_t iy_sw = iy_nw + 1;
+
+            int64_t ix_se = ix_nw + 1;
+            int64_t iy_se = iy_nw + 1;
+
+            // get surfaces to each neighbor:
+            scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+            scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+            scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+            scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+
+            scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
+            scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+            scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+            scalar_t *inp_ptr_NC = inp_ptr_N;
+            // calculate bilinear weighted pixel value and set output pixel
+            for (int64_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+              scalar_t gOut = *gOut_ptr_NCHW;
+
+              // calculate and set grad_input
+              safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
+              safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
+              safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
+              safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
+
+              // calculate grad_grid
+              if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+                scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
+                gix -= nw_val * (iy_se - iy) * gOut;
+                giy -= nw_val * (ix_se - ix) * gOut;
+              }
+              if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+                scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
+                gix += ne_val * (iy_sw - iy) * gOut;
+                giy -= ne_val * (ix - ix_sw) * gOut;
+              }
+              if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+                scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
+                gix -= sw_val * (iy - iy_ne) * gOut;
+                giy += sw_val * (ix_ne - ix) * gOut;
+              }
+              if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+                scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
+                gix += se_val * (iy - iy_nw) * gOut;
+                giy += se_val * (ix - ix_nw) * gOut;
+              }
+            }
+
+            // assuming grad_grid is contiguous
+            gGrid_ptr_NHW[0] = gix_mult * gix;
+            gGrid_ptr_NHW[1] = giy_mult * giy;
+          } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+            int64_t ix_nearest = static_cast<int64_t>(std::nearbyint(ix));
+            int64_t iy_nearest = static_cast<int64_t>(std::nearbyint(iy));
+
+            // assign nearest neighor pixel value to output pixel
+            scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+            scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+            for (int64_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+              // calculate and set grad_input
+              safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW,
+                          inp_H, inp_W, *gOut_ptr_NCHW);
+            }
+          }
+        }
+      }
+    }
+  });
+  return std::make_tuple(grad_input, grad_grid);
+}
 
 // No shape checking needed here. See # NOTE [ grid_sampler Native Functions ].
 Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
@@ -649,9 +655,8 @@ Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
       grid_sW * (vec256::Vec256<float>::size() - 1));
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
-      return grid_sampler_2d_cpu_impl<float>(
-        input, grid, static_cast<GridSamplerInterpolation>(interpolation_mode),
-        static_cast<GridSamplerPadding>(padding_mode), align_corners);
+      return native::_grid_sampler_2d_cpu_fallback(
+        input, grid, interpolation_mode, padding_mode, align_corners);
     }
   }
 
@@ -695,10 +700,8 @@ grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
       grid_sW * (vec256::Vec256<float>::size() - 1));
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
-      return grid_sampler_2d_backward_cpu_impl<float>(
-        grad_output, input, grid,
-        static_cast<GridSamplerInterpolation>(interpolation_mode),
-        static_cast<GridSamplerPadding>(padding_mode), align_corners);
+      return native::_grid_sampler_2d_cpu_fallback_backward(
+        grad_output, input, grid, interpolation_mode, padding_mode, align_corners);
     }
   }
 

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -380,12 +380,277 @@ namespace {
     return std::make_tuple(grad_input, grad_grid);
   }
 
+  template<typename scalar_t>
+  Tensor grid_sampler_2d_cpu_impl(const Tensor& input, const Tensor& grid,
+                                  GridSamplerInterpolation interpolation_mode,
+                                  GridSamplerPadding padding_mode,
+                                  bool align_corners) {
+    int64_t N = input.size(0);
+    int64_t C = input.size(1);
+    int64_t inp_H = input.size(2);
+    int64_t inp_W = input.size(3);
+    int64_t out_H = grid.size(1);
+    int64_t out_W = grid.size(2);
+    auto output = at::empty({N, C, out_H, out_W}, input.options());
+    int64_t inp_sN = input.stride(0);
+    int64_t inp_sC = input.stride(1);
+    int64_t inp_sH = input.stride(2);
+    int64_t inp_sW = input.stride(3);
+    int64_t grid_sN = grid.stride(0);
+    int64_t grid_sH = grid.stride(1);
+    int64_t grid_sW = grid.stride(2);
+    int64_t grid_sCoor = grid.stride(3);
+    int64_t out_sN = output.stride(0);
+    int64_t out_sC = output.stride(1);
+    int64_t out_sH = output.stride(2);
+    int64_t out_sW = output.stride(3);
+    scalar_t *inp_ptr = input.data_ptr<scalar_t>();
+    scalar_t *out_ptr = output.data_ptr<scalar_t>();
+    scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
+    // loop over each output pixel
+    at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
+      for (int64_t n = start; n < end; ++n) {
+        scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
+        scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
+        for (int64_t h = 0; h < out_H; ++h) {
+          for (int64_t w = 0; w < out_W; ++w) {
+            // get the corresponding input x, y, z co-ordinates from grid
+            scalar_t *grid_ptr_NDHW = grid_ptr_N + h * grid_sH + w * grid_sW;
+            scalar_t ix = *grid_ptr_NDHW;
+            scalar_t iy = grid_ptr_NDHW[grid_sCoor];
+
+            ix = grid_sampler_compute_source_index(ix, inp_W, padding_mode, align_corners);
+            iy = grid_sampler_compute_source_index(iy, inp_H, padding_mode, align_corners);
+
+            if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+              // get corner pixel values from (x, y, z)
+              // for 4d, we used north-east-south-west
+              int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
+              int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
+
+              int64_t ix_ne = ix_nw + 1;
+              int64_t iy_ne = iy_nw;
+
+              int64_t ix_sw = ix_nw;
+              int64_t iy_sw = iy_nw + 1;
+
+              int64_t ix_se = ix_nw + 1;
+              int64_t iy_se = iy_nw + 1;
+
+
+              // get surfaces to each neighbor:
+              scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+              scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+              scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+              scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+
+              // calculate bilinear weighted pixel value and set output pixel
+              scalar_t *inp_ptr_NC = inp_ptr_N;
+              scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
+              for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+                auto res = static_cast<scalar_t>(0);
+                if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+                  res += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
+                }
+                if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+                  res += inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW] * ne;
+                }
+                if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+                  res += inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW] * sw;
+                }
+                if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+                  res += inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW] * se;
+                }
+                *out_ptr_NCHW = res;
+              }
+            } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+              int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
+              int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
+
+              // assign nearest neighor pixel value to output pixel
+              scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
+              scalar_t *inp_ptr_NC = inp_ptr_N;
+              for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+                if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
+                  *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
+                } else {
+                  *out_ptr_NCHW = static_cast<scalar_t>(0);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+    return output;
+  }
+
+  template<typename scalar_t>
+  std::tuple<Tensor, Tensor>
+  grid_sampler_2d_backward_cpu_impl(const Tensor& grad_output,
+                                    const Tensor& input, const Tensor& grid,
+                                    GridSamplerInterpolation interpolation_mode,
+                                    GridSamplerPadding padding_mode,
+                                    bool align_corners) {
+    auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    // If interpolation mode is Nearest, then grad_grid is not filled in the
+    // loop below.
+    if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+      grad_grid.zero_();
+    }
+    int64_t N = input.size(0);
+    int64_t C = input.size(1);
+    int64_t inp_H = input.size(2);
+    int64_t inp_W = input.size(3);
+    int64_t out_H = grid.size(1);
+    int64_t out_W = grid.size(2);
+    int64_t inp_sN = input.stride(0);
+    int64_t inp_sC = input.stride(1);
+    int64_t inp_sH = input.stride(2);
+    int64_t inp_sW = input.stride(3);
+    int64_t grid_sN = grid.stride(0);
+    int64_t grid_sH = grid.stride(1);
+    int64_t grid_sW = grid.stride(2);
+    int64_t grid_sCoor = grid.stride(3);
+    int64_t gOut_sN = grad_output.stride(0);
+    int64_t gOut_sC = grad_output.stride(1);
+    int64_t gOut_sH = grad_output.stride(2);
+    int64_t gOut_sW = grad_output.stride(3);
+    int64_t gInp_sN = grad_input.stride(0);
+    int64_t gInp_sC = grad_input.stride(1);
+    int64_t gInp_sH = grad_input.stride(2);
+    int64_t gInp_sW = grad_input.stride(3);
+    int64_t gGrid_sN = grad_grid.stride(0);
+    int64_t gGrid_sW = grad_grid.stride(2);
+    scalar_t *inp_ptr = input.data_ptr<scalar_t>();
+    scalar_t *grid_ptr = grid.data_ptr<scalar_t>();
+    scalar_t *gOut_ptr = grad_output.data_ptr<scalar_t>();
+    scalar_t *gInp_ptr = grad_input.data_ptr<scalar_t>();
+    scalar_t *gGrid_ptr = grad_grid.data_ptr<scalar_t>();
+    // loop over each output pixel
+    at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
+      for (int64_t n = start; n < end; ++n) {
+        scalar_t *grid_ptr_N = grid_ptr + n * grid_sN;
+        scalar_t *inp_ptr_N = inp_ptr + n * inp_sN;
+        scalar_t *gGrid_ptr_NHW = gGrid_ptr + n * gGrid_sN;
+        for (int64_t h = 0; h < out_H; ++h) {
+          for (int64_t w = 0; w < out_W; ++w, gGrid_ptr_NHW += gGrid_sW /* grad_grid is contiguous */ ) {
+            // get the corresponding input x, y co-ordinates from grid
+            scalar_t *grid_ptr_NHW = grid_ptr_N + h * grid_sH + w * grid_sW;
+            scalar_t ix = *grid_ptr_NHW;
+            scalar_t iy = grid_ptr_NHW[grid_sCoor];
+
+            // multipliers for gradients on ix, iy
+            scalar_t gix_mult, giy_mult;
+            ix = grid_sampler_compute_source_index_set_grad(ix, inp_W, padding_mode, align_corners, &gix_mult);
+            iy = grid_sampler_compute_source_index_set_grad(iy, inp_H, padding_mode, align_corners, &giy_mult);
+
+            if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
+              // get corner pixel values from (x, y, z)
+              // for 4d, we used north-east-south-west
+              // for 5d, we add top-bottom
+              int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
+              int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
+
+              int64_t ix_ne = ix_nw + 1;
+              int64_t iy_ne = iy_nw;
+
+              int64_t ix_sw = ix_nw;
+              int64_t iy_sw = iy_nw + 1;
+
+              int64_t ix_se = ix_nw + 1;
+              int64_t iy_se = iy_nw + 1;
+
+              // get surfaces to each neighbor:
+              scalar_t nw = (ix_se - ix)    * (iy_se - iy);
+              scalar_t ne = (ix    - ix_sw) * (iy_sw - iy);
+              scalar_t sw = (ix_ne - ix)    * (iy    - iy_ne);
+              scalar_t se = (ix    - ix_nw) * (iy    - iy_nw);
+
+              scalar_t gix = static_cast<scalar_t>(0), giy = static_cast<scalar_t>(0);
+              scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+              scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+              scalar_t *inp_ptr_NC = inp_ptr_N;
+              // calculate bilinear weighted pixel value and set output pixel
+              for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+                scalar_t gOut = *gOut_ptr_NCHW;
+
+                // calculate and set grad_input
+                safe_add_2d(gInp_ptr_NC, iy_nw, ix_nw, gInp_sH, gInp_sW, inp_H, inp_W, nw * gOut);
+                safe_add_2d(gInp_ptr_NC, iy_ne, ix_ne, gInp_sH, gInp_sW, inp_H, inp_W, ne * gOut);
+                safe_add_2d(gInp_ptr_NC, iy_sw, ix_sw, gInp_sH, gInp_sW, inp_H, inp_W, sw * gOut);
+                safe_add_2d(gInp_ptr_NC, iy_se, ix_se, gInp_sH, gInp_sW, inp_H, inp_W, se * gOut);
+
+                // calculate grad_grid
+                if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
+                  scalar_t nw_val = inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW];
+                  gix -= nw_val * (iy_se - iy) * gOut;
+                  giy -= nw_val * (ix_se - ix) * gOut;
+                }
+                if (within_bounds_2d(iy_ne, ix_ne, inp_H, inp_W)) {
+                  scalar_t ne_val = inp_ptr_NC[iy_ne * inp_sH + ix_ne * inp_sW];
+                  gix += ne_val * (iy_sw - iy) * gOut;
+                  giy -= ne_val * (ix - ix_sw) * gOut;
+                }
+                if (within_bounds_2d(iy_sw, ix_sw, inp_H, inp_W)) {
+                  scalar_t sw_val = inp_ptr_NC[iy_sw * inp_sH + ix_sw * inp_sW];
+                  gix -= sw_val * (iy - iy_ne) * gOut;
+                  giy += sw_val * (ix_ne - ix) * gOut;
+                }
+                if (within_bounds_2d(iy_se, ix_se, inp_H, inp_W)) {
+                  scalar_t se_val = inp_ptr_NC[iy_se * inp_sH + ix_se * inp_sW];
+                  gix += se_val * (iy - iy_nw) * gOut;
+                  giy += se_val * (ix - ix_nw) * gOut;
+                }
+              }
+
+              // assuming grad_grid is contiguous
+              gGrid_ptr_NHW[0] = gix_mult * gix;
+              gGrid_ptr_NHW[1] = giy_mult * giy;
+            } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
+              int64_t ix_nearest = static_cast<int64_t>(std::round(ix));
+              int64_t iy_nearest = static_cast<int64_t>(std::round(iy));
+
+              // assign nearest neighor pixel value to output pixel
+              scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
+              scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
+              for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+                // calculate and set grad_input
+                safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW,
+                            inp_H, inp_W, *gOut_ptr_NCHW);
+              }
+            }
+          }
+        }
+      }
+    });
+    return std::make_tuple(grad_input, grad_grid);
+  }
+
 }  // namespace
 
 // No shape checking needed here. See # NOTE [ grid_sampler Native Functions ].
 Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
                            int64_t interpolation_mode, int64_t padding_mode,
                            bool align_corners) {
+  // AVX gather instructions use signed 32-bit offsets to gather float values.
+  // Check for possible overflow and fallback to scalar implementation
+  if (input.scalar_type() != kDouble) {
+    TORCH_CHECK(input.scalar_type() == kFloat,
+                "grid_sampler_2d_cpu not implemented for ", input.scalar_type());
+    auto sizes = input.sizes();
+    auto strides = input.strides();
+    // NOTE: Gather offsets are only used for the height and width dimensions
+    auto max_gather_offset = sizes[2] * std::abs(strides[2]) + sizes[3] * std::abs(strides[3]);
+
+    if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
+      return grid_sampler_2d_cpu_impl<float>(
+        input, grid, static_cast<GridSamplerInterpolation>(interpolation_mode),
+        static_cast<GridSamplerPadding>(padding_mode), align_corners);
+    }
+  }
+
   return grid_sampler_2d_cpu_kernel(
     kCPU, input, grid, interpolation_mode, padding_mode, align_corners);
 }
@@ -408,6 +673,28 @@ Tensor grid_sampler_3d_cpu(const Tensor& input, const Tensor& grid,
 std::tuple<Tensor, Tensor>
 grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, const Tensor& grid,
                              int64_t interpolation_mode, int64_t padding_mode, bool align_corners) {
+  // AVX gather instructions use signed 32-bit offsets to gather float values.
+  // Check for possible overflow and fallback to scalar implementation
+  if (input.scalar_type() != kDouble) {
+    TORCH_CHECK(input.scalar_type() == kFloat,
+                "grid_sampler_2d_backward_cpu not implemented for ", input.scalar_type());
+    auto isizes = input.sizes();
+    auto istrides = input.strides();
+    auto gsizes = grad_output.sizes();
+    auto gstrides = grad_output.strides();
+    // NOTE: Gather offsets are only used for the height and width dimensions
+    auto max_gather_offset = std::max(
+      isizes[2] * std::abs(istrides[2]) + isizes[3] * std::abs(istrides[3]),
+      gsizes[2] * std::abs(gstrides[2]) + gsizes[3] * std::abs(gstrides[3]));
+
+    if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
+      return grid_sampler_2d_backward_cpu_impl<float>(
+        grad_output, input, grid,
+        static_cast<GridSamplerInterpolation>(interpolation_mode),
+        static_cast<GridSamplerPadding>(padding_mode), align_corners);
+    }
+  }
+
   return grid_sampler_2d_backward_cpu_kernel(
     kCPU, grad_output, input, grid, interpolation_mode, padding_mode, align_corners);
 }
@@ -469,6 +756,8 @@ Tensor grid_sampler(const Tensor& input, const Tensor& grid,
   // cudnn does not support inputs larger than 1024
   if (at::native::cudnn_is_acceptable(input) &&
       at::native::cudnn_is_acceptable(grid) &&
+      at::cuda::detail::canUse32BitIndexMath(input) &&
+      at::cuda::detail::canUse32BitIndexMath(grid) &&
       static_cast<GridSamplerInterpolation>(interpolation_mode) == GridSamplerInterpolation::Bilinear &&
       static_cast<GridSamplerPadding>(padding_mode) == GridSamplerPadding::Zeros &&
       align_corners &&

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -644,7 +644,7 @@ Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
     auto strides = input.strides();
     // NOTE: Gather offsets are only used for the height and width dimensions
     auto max_gather_offset =
-      (sizes[2] - 1) * std::abs(strides[2]) + (sizes[3] - 1) * std::abs(strides[3]);
+      (sizes[2] - 1) * strides[2] + (sizes[3] - 1) * strides[3];
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
       return grid_sampler_2d_cpu_impl<float>(
@@ -686,8 +686,8 @@ grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
     auto gstrides = grad_output.strides();
     // NOTE: Gather offsets are only used for the height and width dimensions
     auto max_gather_offset = std::max(
-      (isizes[2] - 1) * std::abs(istrides[2]) + (isizes[3] - 1) * std::abs(istrides[3]),
-      (gsizes[2] - 1) * std::abs(gstrides[2]) + (gsizes[3] - 1) * std::abs(gstrides[3]));
+      (isizes[2] - 1) * istrides[2] + (isizes[3] - 1) * istrides[3],
+      (gsizes[2] - 1) * gstrides[2] + (gsizes[3] - 1) * gstrides[3]);
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
       return grid_sampler_2d_backward_cpu_impl<float>(

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -643,7 +643,8 @@ Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
     auto sizes = input.sizes();
     auto strides = input.strides();
     // NOTE: Gather offsets are only used for the height and width dimensions
-    auto max_gather_offset = sizes[2] * std::abs(strides[2]) + sizes[3] * std::abs(strides[3]);
+    auto max_gather_offset =
+      (sizes[2] - 1) * std::abs(strides[2]) + (sizes[3] - 1) * std::abs(strides[3]);
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
       return grid_sampler_2d_cpu_impl<float>(
@@ -685,8 +686,8 @@ grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
     auto gstrides = grad_output.strides();
     // NOTE: Gather offsets are only used for the height and width dimensions
     auto max_gather_offset = std::max(
-      isizes[2] * std::abs(istrides[2]) + isizes[3] * std::abs(istrides[3]),
-      gsizes[2] * std::abs(gstrides[2]) + gsizes[3] * std::abs(gstrides[3]));
+      (isizes[2] - 1) * std::abs(istrides[2]) + (isizes[3] - 1) * std::abs(istrides[3]),
+      (gsizes[2] - 1) * std::abs(gstrides[2]) + (gsizes[3] - 1) * std::abs(gstrides[3]));
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
       return grid_sampler_2d_backward_cpu_impl<float>(

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -115,7 +115,7 @@ namespace {
                 // calculate bilinear weighted pixel value and set output pixel
                 scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
                 scalar_t *inp_ptr_NC = inp_ptr_N;
-                for (int c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
+                for (int64_t c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
                   //   (c, iz_tnw, iy_tnw, ix_tnw) * tnw + (c, iz_tne, iy_tne, ix_tne) * tne
                   // + (c, iz_tsw, iy_tsw, ix_tsw) * tsw + (c, iz_tse, iy_tse, ix_tse) * tse
                   // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
@@ -154,7 +154,7 @@ namespace {
                 // assign nearest neighor pixel value to output pixel
                 scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
                 scalar_t *inp_ptr_NC = inp_ptr_N;
-                for (int c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
+                for (int64_t c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
                   if (within_bounds_3d(iz_nearest, iy_nearest, ix_nearest, inp_D, inp_H, inp_W)) {
                     *out_ptr_NCDHW = inp_ptr_NC[iz_nearest * inp_sD + iy_nearest * inp_sH + ix_nearest * inp_sW];
                   } else {
@@ -291,7 +291,7 @@ namespace {
                 scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
                 scalar_t *inp_ptr_NC = inp_ptr_N;
                 // calculate bilinear weighted pixel value and set output pixel
-                for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+                for (int64_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
                   scalar_t gOut = *gOut_ptr_NCDHW;
 
                   // calculate and set grad_input
@@ -367,7 +367,7 @@ namespace {
                 // assign nearest neighor pixel value to output pixel
                 scalar_t *gOut_ptr_NCDHW = gOut_ptr + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
                 scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-                for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+                for (int64_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
                   // calculate and set grad_input
                   safe_add_3d(gInp_ptr_NC, iz_nearest, iy_nearest, ix_nearest,
                               gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, *gOut_ptr_NCDHW);
@@ -424,8 +424,8 @@ namespace {
             iy = grid_sampler_compute_source_index(iy, inp_H, padding_mode, align_corners);
 
             if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
-              // get corner pixel values from (x, y, z)
-              // for 4d, we used north-east-south-west
+              // get corner pixel values from (x, y)
+              // for 4d, we use north-east-south-west
               int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
               int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
 
@@ -448,7 +448,7 @@ namespace {
               // calculate bilinear weighted pixel value and set output pixel
               scalar_t *inp_ptr_NC = inp_ptr_N;
               scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
-              for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+              for (int64_t c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
                 auto res = static_cast<scalar_t>(0);
                 if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
                   res += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
@@ -471,7 +471,7 @@ namespace {
               // assign nearest neighor pixel value to output pixel
               scalar_t *out_ptr_NCHW = out_ptr + n * out_sN + h * out_sH + w * out_sW;
               scalar_t *inp_ptr_NC = inp_ptr_N;
-              for (int c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
+              for (int64_t c = 0; c < C; ++c, out_ptr_NCHW += out_sC, inp_ptr_NC += inp_sC) {
                 if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
                   *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
                 } else {
@@ -548,9 +548,8 @@ namespace {
             iy = grid_sampler_compute_source_index_set_grad(iy, inp_H, padding_mode, align_corners, &giy_mult);
 
             if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
-              // get corner pixel values from (x, y, z)
-              // for 4d, we used north-east-south-west
-              // for 5d, we add top-bottom
+              // get corner pixel values from (x, y)
+              // for 4d, we use north-east-south-west
               int64_t ix_nw = static_cast<int64_t>(std::floor(ix));
               int64_t iy_nw = static_cast<int64_t>(std::floor(iy));
 
@@ -574,7 +573,7 @@ namespace {
               scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
               scalar_t *inp_ptr_NC = inp_ptr_N;
               // calculate bilinear weighted pixel value and set output pixel
-              for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+              for (int64_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
                 scalar_t gOut = *gOut_ptr_NCHW;
 
                 // calculate and set grad_input
@@ -616,7 +615,7 @@ namespace {
               // assign nearest neighor pixel value to output pixel
               scalar_t *gOut_ptr_NCHW = gOut_ptr + n * gOut_sN + h * gOut_sH + w * gOut_sW;
               scalar_t *gInp_ptr_NC = gInp_ptr + n * gInp_sN;
-              for (int c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+              for (int64_t c = 0; c < C; ++c, gOut_ptr_NCHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
                 // calculate and set grad_input
                 safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW,
                             inp_H, inp_W, *gOut_ptr_NCHW);
@@ -642,9 +641,12 @@ Tensor grid_sampler_2d_cpu(const Tensor& input, const Tensor& grid,
                 "grid_sampler_2d_cpu not implemented for ", input.scalar_type());
     auto sizes = input.sizes();
     auto strides = input.strides();
-    // NOTE: Gather offsets are only used for the height and width dimensions
-    auto max_gather_offset =
-      (sizes[2] - 1) * strides[2] + (sizes[3] - 1) * strides[3];
+    const auto grid_sW = grid.strides()[2];
+    // NOTE: Gather offsets are only used for the input H, W dimensions
+    //       or only for strided access to the grid tensor
+    auto max_gather_offset = std::max(
+      (sizes[2] - 1) * strides[2] + (sizes[3] - 1) * strides[3],
+      grid_sW * (vec256::Vec256<float>::size() - 1));
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
       return grid_sampler_2d_cpu_impl<float>(
@@ -684,10 +686,13 @@ grid_sampler_2d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
     auto istrides = input.strides();
     auto gsizes = grad_output.sizes();
     auto gstrides = grad_output.strides();
+    const auto grid_sW = grid.strides()[2];
     // NOTE: Gather offsets are only used for the height and width dimensions
     auto max_gather_offset = std::max(
-      (isizes[2] - 1) * istrides[2] + (isizes[3] - 1) * istrides[3],
-      (gsizes[2] - 1) * gstrides[2] + (gsizes[3] - 1) * gstrides[3]);
+      std::max(
+        (isizes[2] - 1) * istrides[2] + (isizes[3] - 1) * istrides[3],
+        (gsizes[2] - 1) * gstrides[2] + (gsizes[3] - 1) * gstrides[3]),
+      grid_sW * (vec256::Vec256<float>::size() - 1));
 
     if (max_gather_offset > std::numeric_limits<int32_t>::max()) {
       return grid_sampler_2d_backward_cpu_impl<float>(

--- a/aten/src/ATen/native/IndexingUtils.cpp
+++ b/aten/src/ATen/native/IndexingUtils.cpp
@@ -1,0 +1,32 @@
+
+#include <ATen/native/IndexingUtils.h>
+
+namespace at { namespace native {
+
+bool canUse32BitIndexMath(const Tensor& t, int64_t max_elem) {
+  int64_t elements = t.numel();
+  if (elements >= max_elem) {
+    return false;
+  }
+  if (elements == 0) {
+    return max_elem > 0;
+  }
+
+  int64_t offset = 0;
+  int64_t linearId = elements - 1;
+
+  for (int i = t.dim() - 1; i >= 0; --i) {
+    int64_t curDimIndex = linearId % t.size(i);
+    int64_t curDimOffset = curDimIndex * t.stride(i);
+    offset += curDimOffset;
+    linearId /= t.size(i);
+  }
+
+  if (offset >= max_elem) {
+    return false;
+  }
+
+  return true;
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/IndexingUtils.cpp
+++ b/aten/src/ATen/native/IndexingUtils.cpp
@@ -15,6 +15,7 @@ bool canUse32BitIndexMath(const Tensor& t, int64_t max_elem) {
   int64_t offset = 0;
   int64_t linearId = elements - 1;
 
+  // NOTE: Assumes all strides are positive, which is true for now
   for (int i = t.dim() - 1; i >= 0; --i) {
     int64_t curDimIndex = linearId % t.size(i);
     int64_t curDimOffset = curDimIndex * t.stride(i);

--- a/aten/src/ATen/native/IndexingUtils.cpp
+++ b/aten/src/ATen/native/IndexingUtils.cpp
@@ -1,4 +1,3 @@
-
 #include <ATen/native/IndexingUtils.h>
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -1,7 +1,12 @@
+#pragma once
 #include <ATen/ExpandUtils.h>
 #include <ATen/native/TensorIterator.h>
 
+#include <limits>
+
 namespace at { namespace native {
+
+TORCH_API bool canUse32BitIndexMath(const at::Tensor &t, int64_t max_elem=std::numeric_limits<int32_t>::max());
 
 [[noreturn]]
 static void invalid_mask(const Tensor & self, int64_t idx, const Tensor & mask, int64_t maskIdx) {

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -714,7 +714,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest,
     #ifndef _MSC_VER
     # pragma unroll
     #endif
-    for (int c = 0; c < C; ++c, out_ptr += out_sC, inp_slice_ptr += inp_sC) {
+    for (int64_t c = 0; c < C; ++c, out_ptr += out_sC, inp_slice_ptr += inp_sC) {
       // mask_gather zeros out the mask, so we need to make a copy
       auto mask_copy = mask;
       auto inp_val = mask_gather<sizeof(scalar_t)>(Vec(0), inp_slice_ptr, i_offset, mask_copy);
@@ -853,8 +853,8 @@ static inline void grid_sample_2d_grid_slice_iterator(
     // General case.
     // Strategy: Do a for-loop over H, for each W slice, use
     //           at::vec256::gather to load the x and y vectors.
-    auto spatial_offset = 0;
-    auto i_offsets_delta = iVec(grid_sW * step);
+    int64_t spatial_offset = 0;
+    const int64_t i_offset_delta = grid_sW * step;
 
     #ifndef _MSC_VER
     # pragma unroll
@@ -876,7 +876,8 @@ static inline void grid_sample_2d_grid_slice_iterator(
                  vec256::gather<sizeof(scalar_t)>(grid_ptr_y, i_offsets),
                  spatial_offset, len);
 
-        i_offsets = i_offsets + i_offsets_delta;
+        grid_ptr_x += i_offset_delta;
+        grid_ptr_y += i_offset_delta;
         spatial_offset += len;
       }
     }

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -652,7 +652,8 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
   int64_t count = N * D * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_cuda", [&] {
-      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
+      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
+          canUse32BitIndexMath(output)) {
         grid_sampler_3d_kernel<scalar_t>
           <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),
@@ -740,7 +741,8 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   int64_t count = N * D * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_3d_backward_cuda", [&] {
-      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
+      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
+          canUse32BitIndexMath(grad_output)) {
         grid_sampler_3d_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -15,40 +15,39 @@ using at::native::detail::GridSamplerInterpolation;
 using at::native::detail::GridSamplerPadding;
 
 namespace {
-  template <typename scalar_t>
+  template <typename scalar_t, typename index_t>
   C10_LAUNCH_BOUNDS_1(1024)
   __global__ void grid_sampler_2d_kernel(
-      const int nthreads,
-      TensorInfo<scalar_t, int> input,
-      TensorInfo<scalar_t, int> grid,
-      TensorInfo<scalar_t, int> output,
+      const index_t nthreads,
+      TensorInfo<scalar_t, index_t> input,
+      TensorInfo<scalar_t, index_t> grid,
+      TensorInfo<scalar_t, index_t> output,
       const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode,
       bool align_corners) {
+    index_t C = input.sizes[1];
+    index_t inp_H = input.sizes[2];
+    index_t inp_W = input.sizes[3];
+    index_t out_H = grid.sizes[1];
+    index_t out_W = grid.sizes[2];
+    index_t inp_sN = input.strides[0];
+    index_t inp_sC = input.strides[1];
+    index_t inp_sH = input.strides[2];
+    index_t inp_sW = input.strides[3];
+    index_t grid_sN = grid.strides[0];
+    index_t grid_sH = grid.strides[1];
+    index_t grid_sW = grid.strides[2];
+    index_t grid_sCoor = grid.strides[3];
+    index_t out_sN = output.strides[0];
+    index_t out_sC = output.strides[1];
+    index_t out_sH = output.strides[2];
+    index_t out_sW = output.strides[3];
 
-    int C = input.sizes[1];
-    int inp_H = input.sizes[2];
-    int inp_W = input.sizes[3];
-    int out_H = grid.sizes[1];
-    int out_W = grid.sizes[2];
-    int inp_sN = input.strides[0];
-    int inp_sC = input.strides[1];
-    int inp_sH = input.strides[2];
-    int inp_sW = input.strides[3];
-    int grid_sN = grid.strides[0];
-    int grid_sH = grid.strides[1];
-    int grid_sW = grid.strides[2];
-    int grid_sCoor = grid.strides[3];
-    int out_sN = output.strides[0];
-    int out_sC = output.strides[1];
-    int out_sH = output.strides[2];
-    int out_sW = output.strides[3];
-
-    CUDA_KERNEL_LOOP(index, nthreads) {
-      const int w = index % out_W;
-      const int h = (index / out_W) % out_H;
-      const int n = index / (out_H * out_W);
-      const int grid_offset = n * grid_sN + h * grid_sH + w * grid_sW;
+    CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
+      const index_t w = index % out_W;
+      const index_t h = (index / out_W) % out_H;
+      const index_t n = index / (out_H * out_W);
+      const index_t grid_offset = n * grid_sN + h * grid_sH + w * grid_sW;
 
       // get the corresponding input x, y co-ordinates from grid
       scalar_t ix = grid.data[grid_offset];
@@ -59,14 +58,14 @@ namespace {
 
       if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
         // get NE, NW, SE, SW pixel values from (x, y)
-        int ix_nw = static_cast<int>(::floor(ix));
-        int iy_nw = static_cast<int>(::floor(iy));
-        int ix_ne = ix_nw + 1;
-        int iy_ne = iy_nw;
-        int ix_sw = ix_nw;
-        int iy_sw = iy_nw + 1;
-        int ix_se = ix_nw + 1;
-        int iy_se = iy_nw + 1;
+        index_t ix_nw = static_cast<index_t>(::floor(ix));
+        index_t iy_nw = static_cast<index_t>(::floor(iy));
+        index_t ix_ne = ix_nw + 1;
+        index_t iy_ne = iy_nw;
+        index_t ix_sw = ix_nw;
+        index_t iy_sw = iy_nw + 1;
+        index_t ix_se = ix_nw + 1;
+        index_t iy_se = iy_nw + 1;
 
         // get surfaces to each neighbor:
         scalar_t nw = (ix_se - ix)    * (iy_se - iy);
@@ -77,7 +76,7 @@ namespace {
         // calculate bilinear weighted pixel value and set output pixel
         auto inp_ptr_NC = input.data + n * inp_sN;
         auto out_ptr_NCHW = output.data + n * out_sN + h * out_sH + w * out_sW;
-        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
+        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
           *out_ptr_NCHW = static_cast<scalar_t>(0);
           if (within_bounds_2d(iy_nw, ix_nw, inp_H, inp_W)) {
             *out_ptr_NCHW += inp_ptr_NC[iy_nw * inp_sH + ix_nw * inp_sW] * nw;
@@ -93,13 +92,13 @@ namespace {
           }
         }
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        int ix_nearest = static_cast<int>(::round(ix));
-        int iy_nearest = static_cast<int>(::round(iy));
+        index_t ix_nearest = static_cast<index_t>(::round(ix));
+        index_t iy_nearest = static_cast<index_t>(::round(iy));
 
         // assign nearest neighor pixel value to output pixel
         auto inp_ptr_NC = input.data + n * inp_sN;
         auto out_ptr_NCHW = output.data + n * out_sN + h * out_sH + w * out_sW;
-        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
+        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCHW += out_sC) {
           if (within_bounds_2d(iy_nearest, ix_nearest, inp_H, inp_W)) {
             *out_ptr_NCHW = inp_ptr_NC[iy_nearest * inp_sH + ix_nearest * inp_sW];
           } else {
@@ -110,46 +109,46 @@ namespace {
     }
   }
 
-  template <typename scalar_t>
+  template <typename scalar_t, typename index_t>
   C10_LAUNCH_BOUNDS_1(1024)
   __global__ void grid_sampler_3d_kernel(
-      const int nthreads,
-      TensorInfo<scalar_t, int> input,
-      TensorInfo<scalar_t, int> grid,
-      TensorInfo<scalar_t, int> output,
+      const index_t nthreads,
+      TensorInfo<scalar_t, index_t> input,
+      TensorInfo<scalar_t, index_t> grid,
+      TensorInfo<scalar_t, index_t> output,
       const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode,
       bool align_corners) {
 
-    int C = input.sizes[1];
-    int inp_D = input.sizes[2];
-    int inp_H = input.sizes[3];
-    int inp_W = input.sizes[4];
-    int out_D = grid.sizes[1];
-    int out_H = grid.sizes[2];
-    int out_W = grid.sizes[3];
-    int inp_sN = input.strides[0];
-    int inp_sC = input.strides[1];
-    int inp_sD = input.strides[2];
-    int inp_sH = input.strides[3];
-    int inp_sW = input.strides[4];
-    int grid_sN = grid.strides[0];
-    int grid_sD = grid.strides[1];
-    int grid_sH = grid.strides[2];
-    int grid_sW = grid.strides[3];
-    int grid_sCoor = grid.strides[4];
-    int out_sN = output.strides[0];
-    int out_sC = output.strides[1];
-    int out_sD = output.strides[2];
-    int out_sH = output.strides[3];
-    int out_sW = output.strides[4];
+    index_t C = input.sizes[1];
+    index_t inp_D = input.sizes[2];
+    index_t inp_H = input.sizes[3];
+    index_t inp_W = input.sizes[4];
+    index_t out_D = grid.sizes[1];
+    index_t out_H = grid.sizes[2];
+    index_t out_W = grid.sizes[3];
+    index_t inp_sN = input.strides[0];
+    index_t inp_sC = input.strides[1];
+    index_t inp_sD = input.strides[2];
+    index_t inp_sH = input.strides[3];
+    index_t inp_sW = input.strides[4];
+    index_t grid_sN = grid.strides[0];
+    index_t grid_sD = grid.strides[1];
+    index_t grid_sH = grid.strides[2];
+    index_t grid_sW = grid.strides[3];
+    index_t grid_sCoor = grid.strides[4];
+    index_t out_sN = output.strides[0];
+    index_t out_sC = output.strides[1];
+    index_t out_sD = output.strides[2];
+    index_t out_sH = output.strides[3];
+    index_t out_sW = output.strides[4];
 
-    CUDA_KERNEL_LOOP(index, nthreads) {
-      const int w = index % out_W;
-      const int h = (index / out_W) % out_H;
-      const int d = (index / (out_H * out_W)) % out_D;
-      const int n = index / (out_D * out_H * out_W);
-      const int grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
+    CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
+      const index_t w = index % out_W;
+      const index_t h = (index / out_W) % out_H;
+      const index_t d = (index / (out_H * out_W)) % out_D;
+      const index_t n = index / (out_D * out_H * out_W);
+      const index_t grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
 
       // get the corresponding input x, y, z co-ordinates from grid
       scalar_t ix = grid.data[grid_offset];
@@ -164,37 +163,37 @@ namespace {
         // get corner pixel values from (x, y, z)
         // for 4d, we used north-east-south-west
         // for 5d, we add top-bottom
-        int ix_tnw = static_cast<int>(::floor(ix));
-        int iy_tnw = static_cast<int>(::floor(iy));
-        int iz_tnw = static_cast<int>(::floor(iz));
+        index_t ix_tnw = static_cast<index_t>(::floor(ix));
+        index_t iy_tnw = static_cast<index_t>(::floor(iy));
+        index_t iz_tnw = static_cast<index_t>(::floor(iz));
 
-        int ix_tne = ix_tnw + 1;
-        int iy_tne = iy_tnw;
-        int iz_tne = iz_tnw;
+        index_t ix_tne = ix_tnw + 1;
+        index_t iy_tne = iy_tnw;
+        index_t iz_tne = iz_tnw;
 
-        int ix_tsw = ix_tnw;
-        int iy_tsw = iy_tnw + 1;
-        int iz_tsw = iz_tnw;
+        index_t ix_tsw = ix_tnw;
+        index_t iy_tsw = iy_tnw + 1;
+        index_t iz_tsw = iz_tnw;
 
-        int ix_tse = ix_tnw + 1;
-        int iy_tse = iy_tnw + 1;
-        int iz_tse = iz_tnw;
+        index_t ix_tse = ix_tnw + 1;
+        index_t iy_tse = iy_tnw + 1;
+        index_t iz_tse = iz_tnw;
 
-        int ix_bnw = ix_tnw;
-        int iy_bnw = iy_tnw;
-        int iz_bnw = iz_tnw + 1;
+        index_t ix_bnw = ix_tnw;
+        index_t iy_bnw = iy_tnw;
+        index_t iz_bnw = iz_tnw + 1;
 
-        int ix_bne = ix_tnw + 1;
-        int iy_bne = iy_tnw;
-        int iz_bne = iz_tnw + 1;
+        index_t ix_bne = ix_tnw + 1;
+        index_t iy_bne = iy_tnw;
+        index_t iz_bne = iz_tnw + 1;
 
-        int ix_bsw = ix_tnw;
-        int iy_bsw = iy_tnw + 1;
-        int iz_bsw = iz_tnw + 1;
+        index_t ix_bsw = ix_tnw;
+        index_t iy_bsw = iy_tnw + 1;
+        index_t iz_bsw = iz_tnw + 1;
 
-        int ix_bse = ix_tnw + 1;
-        int iy_bse = iy_tnw + 1;
-        int iz_bse = iz_tnw + 1;
+        index_t ix_bse = ix_tnw + 1;
+        index_t iy_bse = iy_tnw + 1;
+        index_t iz_bse = iz_tnw + 1;
 
         // get surfaces to each neighbor:
         scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
@@ -208,7 +207,7 @@ namespace {
 
         auto inp_ptr_NC = input.data + n * inp_sN;
         auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
-        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
+        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
           //   (c, iz_tnw, iy_tnw, ix_tnw) * tnw + (c, iz_tne, iy_tne, ix_tne) * tne
           // + (c, iz_tsw, iy_tsw, ix_tsw) * tsw + (c, iz_tse, iy_tse, ix_tse) * tse
           // + (c, iz_bnw, iy_bnw, ix_bnw) * bnw + (c, iz_bne, iy_bne, ix_bne) * bne
@@ -240,14 +239,14 @@ namespace {
           }
         }
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        int ix_nearest = static_cast<int>(::round(ix));
-        int iy_nearest = static_cast<int>(::round(iy));
-        int iz_nearest = static_cast<int>(::round(iz));
+        index_t ix_nearest = static_cast<index_t>(::round(ix));
+        index_t iy_nearest = static_cast<index_t>(::round(iy));
+        index_t iz_nearest = static_cast<index_t>(::round(iz));
 
         // assign nearest neighor pixel value to output pixel
         auto inp_ptr_NC = input.data + n * inp_sN;
         auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
-        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
+        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
           if (within_bounds_3d(iz_nearest, iy_nearest, ix_nearest, inp_D, inp_H, inp_W)) {
             *out_ptr_NCDHW = inp_ptr_NC[iz_nearest * inp_sD + iy_nearest * inp_sH + ix_nearest * inp_sW];
           } else {
@@ -258,47 +257,47 @@ namespace {
     }
   }
 
-  template <typename scalar_t>
+  template <typename scalar_t, typename index_t>
   C10_LAUNCH_BOUNDS_1(1024)
   __global__ void grid_sampler_2d_backward_kernel(
-      const int nthreads,
-      TensorInfo<scalar_t, int> grad_output,
-      TensorInfo<scalar_t, int> input,
-      TensorInfo<scalar_t, int> grid,
-      TensorInfo<scalar_t, int> grad_input,  // initialized to zeros
-      TensorInfo<scalar_t, int> grad_grid,   // initialized to empty
+      const index_t nthreads,
+      TensorInfo<scalar_t, index_t> grad_output,
+      TensorInfo<scalar_t, index_t> input,
+      TensorInfo<scalar_t, index_t> grid,
+      TensorInfo<scalar_t, index_t> grad_input,  // initialized to zeros
+      TensorInfo<scalar_t, index_t> grad_grid,   // initialized to empty
       const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode,
       bool align_corners) {
 
-    int C = input.sizes[1];
-    int inp_H = input.sizes[2];
-    int inp_W = input.sizes[3];
-    int out_H = grid.sizes[1];
-    int out_W = grid.sizes[2];
-    int inp_sN = input.strides[0];
-    int inp_sC = input.strides[1];
-    int inp_sH = input.strides[2];
-    int inp_sW = input.strides[3];
-    int grid_sN = grid.strides[0];
-    int grid_sH = grid.strides[1];
-    int grid_sW = grid.strides[2];
-    int grid_sCoor = grid.strides[3];
-    int gOut_sN = grad_output.strides[0];
-    int gOut_sC = grad_output.strides[1];
-    int gOut_sH = grad_output.strides[2];
-    int gOut_sW = grad_output.strides[3];
-    int gInp_sN = grad_input.strides[0];
-    int gInp_sC = grad_input.strides[1];
-    int gInp_sH = grad_input.strides[2];
-    int gInp_sW = grad_input.strides[3];
-    int gGrid_sW = grad_grid.strides[2];
+    index_t C = input.sizes[1];
+    index_t inp_H = input.sizes[2];
+    index_t inp_W = input.sizes[3];
+    index_t out_H = grid.sizes[1];
+    index_t out_W = grid.sizes[2];
+    index_t inp_sN = input.strides[0];
+    index_t inp_sC = input.strides[1];
+    index_t inp_sH = input.strides[2];
+    index_t inp_sW = input.strides[3];
+    index_t grid_sN = grid.strides[0];
+    index_t grid_sH = grid.strides[1];
+    index_t grid_sW = grid.strides[2];
+    index_t grid_sCoor = grid.strides[3];
+    index_t gOut_sN = grad_output.strides[0];
+    index_t gOut_sC = grad_output.strides[1];
+    index_t gOut_sH = grad_output.strides[2];
+    index_t gOut_sW = grad_output.strides[3];
+    index_t gInp_sN = grad_input.strides[0];
+    index_t gInp_sC = grad_input.strides[1];
+    index_t gInp_sH = grad_input.strides[2];
+    index_t gInp_sW = grad_input.strides[3];
+    index_t gGrid_sW = grad_grid.strides[2];
 
-    CUDA_KERNEL_LOOP(index, nthreads) {
-      const int w = index % out_W;
-      const int h = (index / out_W) % out_H;
-      const int n = index / (out_H * out_W);
-      const int grid_offset = n * grid_sN + h * grid_sH + w * grid_sW;
+    CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
+      const index_t w = index % out_W;
+      const index_t h = (index / out_W) % out_H;
+      const index_t n = index / (out_H * out_W);
+      const auto grid_offset = n * grid_sN + h * grid_sH + w * grid_sW;
 
       // get the corresponding input x, y co-ordinates from grid
       scalar_t ix = grid.data[grid_offset];
@@ -311,14 +310,14 @@ namespace {
 
       if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
         // get NE, NW, SE, SW pixel values from (x, y)
-        int ix_nw = static_cast<int>(::floor(ix));
-        int iy_nw = static_cast<int>(::floor(iy));
-        int ix_ne = ix_nw + 1;
-        int iy_ne = iy_nw;
-        int ix_sw = ix_nw;
-        int iy_sw = iy_nw + 1;
-        int ix_se = ix_nw + 1;
-        int iy_se = iy_nw + 1;
+        index_t ix_nw = static_cast<index_t>(::floor(ix));
+        index_t iy_nw = static_cast<index_t>(::floor(iy));
+        index_t ix_ne = ix_nw + 1;
+        index_t iy_ne = iy_nw;
+        index_t ix_sw = ix_nw;
+        index_t iy_sw = iy_nw + 1;
+        index_t ix_se = ix_nw + 1;
+        index_t iy_se = iy_nw + 1;
 
         // get surfaces to each neighbor:
         scalar_t nw = (ix_se - ix)    * (iy_se - iy);
@@ -330,7 +329,7 @@ namespace {
         scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
         scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
         scalar_t *inp_ptr_NC = input.data + n * inp_sN;
-        for (int c = 0; c < C; ++c, inp_ptr_NC += inp_sC, gInp_ptr_NC += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
+        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, gInp_ptr_NC += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
           scalar_t gOut = *gOut_ptr_NCHW;
 
           // calculate and set grad_input
@@ -370,13 +369,13 @@ namespace {
         gGrid_ptr_NHW[0] = gix_mult * gix;
         gGrid_ptr_NHW[1] = giy_mult * giy;
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        int ix_nearest = static_cast<int>(::round(ix));
-        int iy_nearest = static_cast<int>(::round(iy));
+        index_t ix_nearest = static_cast<index_t>(::round(ix));
+        index_t iy_nearest = static_cast<index_t>(::round(iy));
 
         // assign nearest neighor pixel value to output pixel
         scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
         scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
-        for (int c = 0; c < C; ++c, gInp_ptr_NC += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
+        for (index_t c = 0; c < C; ++c, gInp_ptr_NC += gInp_sC, gOut_ptr_NCHW += gOut_sC) {
           // calculate and set grad_input
           safe_add_2d(gInp_ptr_NC, iy_nearest, ix_nearest, gInp_sH, gInp_sW, inp_H, inp_W, *gOut_ptr_NCHW);
         }
@@ -392,54 +391,54 @@ namespace {
     }
   }
 
-  template <typename scalar_t>
+  template <typename scalar_t, typename index_t>
   C10_LAUNCH_BOUNDS_1(1024)
   __global__ void grid_sampler_3d_backward_kernel(
-      const int nthreads,
-      TensorInfo<scalar_t, int> grad_output,
-      TensorInfo<scalar_t, int> input,
-      TensorInfo<scalar_t, int> grid,
-      TensorInfo<scalar_t, int> grad_input,  // initialized to zeros
-      TensorInfo<scalar_t, int> grad_grid,   // initialized to empty
+      const index_t nthreads,
+      TensorInfo<scalar_t, index_t> grad_output,
+      TensorInfo<scalar_t, index_t> input,
+      TensorInfo<scalar_t, index_t> grid,
+      TensorInfo<scalar_t, index_t> grad_input,  // initialized to zeros
+      TensorInfo<scalar_t, index_t> grad_grid,   // initialized to empty
       const GridSamplerInterpolation interpolation_mode,
       const GridSamplerPadding padding_mode,
       bool align_corners) {
 
-    int C = input.sizes[1];
-    int inp_D = input.sizes[2];
-    int inp_H = input.sizes[3];
-    int inp_W = input.sizes[4];
-    int out_D = grid.sizes[1];
-    int out_H = grid.sizes[2];
-    int out_W = grid.sizes[3];
-    int inp_sN = input.strides[0];
-    int inp_sC = input.strides[1];
-    int inp_sD = input.strides[2];
-    int inp_sH = input.strides[3];
-    int inp_sW = input.strides[4];
-    int grid_sN = grid.strides[0];
-    int grid_sD = grid.strides[1];
-    int grid_sH = grid.strides[2];
-    int grid_sW = grid.strides[3];
-    int grid_sCoor = grid.strides[4];
-    int gOut_sN = grad_output.strides[0];
-    int gOut_sC = grad_output.strides[1];
-    int gOut_sD = grad_output.strides[2];
-    int gOut_sH = grad_output.strides[3];
-    int gOut_sW = grad_output.strides[4];
-    int gInp_sN = grad_input.strides[0];
-    int gInp_sC = grad_input.strides[1];
-    int gInp_sD = grad_input.strides[2];
-    int gInp_sH = grad_input.strides[3];
-    int gInp_sW = grad_input.strides[4];
-    int gGrid_sW = grad_grid.strides[3];
+    index_t C = input.sizes[1];
+    index_t inp_D = input.sizes[2];
+    index_t inp_H = input.sizes[3];
+    index_t inp_W = input.sizes[4];
+    index_t out_D = grid.sizes[1];
+    index_t out_H = grid.sizes[2];
+    index_t out_W = grid.sizes[3];
+    index_t inp_sN = input.strides[0];
+    index_t inp_sC = input.strides[1];
+    index_t inp_sD = input.strides[2];
+    index_t inp_sH = input.strides[3];
+    index_t inp_sW = input.strides[4];
+    index_t grid_sN = grid.strides[0];
+    index_t grid_sD = grid.strides[1];
+    index_t grid_sH = grid.strides[2];
+    index_t grid_sW = grid.strides[3];
+    index_t grid_sCoor = grid.strides[4];
+    index_t gOut_sN = grad_output.strides[0];
+    index_t gOut_sC = grad_output.strides[1];
+    index_t gOut_sD = grad_output.strides[2];
+    index_t gOut_sH = grad_output.strides[3];
+    index_t gOut_sW = grad_output.strides[4];
+    index_t gInp_sN = grad_input.strides[0];
+    index_t gInp_sC = grad_input.strides[1];
+    index_t gInp_sD = grad_input.strides[2];
+    index_t gInp_sH = grad_input.strides[3];
+    index_t gInp_sW = grad_input.strides[4];
+    index_t gGrid_sW = grad_grid.strides[3];
 
-    CUDA_KERNEL_LOOP(index, nthreads) {
-      const int w = index % out_W;
-      const int h = (index / out_W) % out_H;
-      const int d = (index / (out_H * out_W)) % out_D;
-      const int n = index / (out_D * out_H * out_W);
-      const int grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
+    CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
+      const index_t w = index % out_W;
+      const index_t h = (index / out_W) % out_H;
+      const index_t d = (index / (out_H * out_W)) % out_D;
+      const index_t n = index / (out_D * out_H * out_W);
+      const auto grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
 
       // get the corresponding input x, y, z co-ordinates from grid
       scalar_t ix = grid.data[grid_offset];
@@ -456,37 +455,37 @@ namespace {
         // get corner pixel values from (x, y, z)
         // for 4d, we used north-east-south-west
         // for 5d, we add top-bottom
-        int ix_tnw = static_cast<int>(::floor(ix));
-        int iy_tnw = static_cast<int>(::floor(iy));
-        int iz_tnw = static_cast<int>(::floor(iz));
+        index_t ix_tnw = static_cast<index_t>(::floor(ix));
+        index_t iy_tnw = static_cast<index_t>(::floor(iy));
+        index_t iz_tnw = static_cast<index_t>(::floor(iz));
 
-        int ix_tne = ix_tnw + 1;
-        int iy_tne = iy_tnw;
-        int iz_tne = iz_tnw;
+        index_t ix_tne = ix_tnw + 1;
+        index_t iy_tne = iy_tnw;
+        index_t iz_tne = iz_tnw;
 
-        int ix_tsw = ix_tnw;
-        int iy_tsw = iy_tnw + 1;
-        int iz_tsw = iz_tnw;
+        index_t ix_tsw = ix_tnw;
+        index_t iy_tsw = iy_tnw + 1;
+        index_t iz_tsw = iz_tnw;
 
-        int ix_tse = ix_tnw + 1;
-        int iy_tse = iy_tnw + 1;
-        int iz_tse = iz_tnw;
+        index_t ix_tse = ix_tnw + 1;
+        index_t iy_tse = iy_tnw + 1;
+        index_t iz_tse = iz_tnw;
 
-        int ix_bnw = ix_tnw;
-        int iy_bnw = iy_tnw;
-        int iz_bnw = iz_tnw + 1;
+        index_t ix_bnw = ix_tnw;
+        index_t iy_bnw = iy_tnw;
+        index_t iz_bnw = iz_tnw + 1;
 
-        int ix_bne = ix_tnw + 1;
-        int iy_bne = iy_tnw;
-        int iz_bne = iz_tnw + 1;
+        index_t ix_bne = ix_tnw + 1;
+        index_t iy_bne = iy_tnw;
+        index_t iz_bne = iz_tnw + 1;
 
-        int ix_bsw = ix_tnw;
-        int iy_bsw = iy_tnw + 1;
-        int iz_bsw = iz_tnw + 1;
+        index_t ix_bsw = ix_tnw;
+        index_t iy_bsw = iy_tnw + 1;
+        index_t iz_bsw = iz_tnw + 1;
 
-        int ix_bse = ix_tnw + 1;
-        int iy_bse = iy_tnw + 1;
-        int iz_bse = iz_tnw + 1;
+        index_t ix_bse = ix_tnw + 1;
+        index_t iy_bse = iy_tnw + 1;
+        index_t iz_bse = iz_tnw + 1;
 
         // get surfaces to each neighbor:
         scalar_t tnw = (ix_bse - ix)    * (iy_bse - iy)    * (iz_bse - iz);
@@ -503,7 +502,7 @@ namespace {
         scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
         scalar_t *inp_ptr_NC = input.data + n * inp_sN;
         // calculate bilinear weighted pixel value and set output pixel
-        for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+        for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC, inp_ptr_NC += inp_sC) {
           scalar_t gOut = *gOut_ptr_NCDHW;
 
           // calculate and set grad_input
@@ -576,14 +575,14 @@ namespace {
         gGrid_ptr_NDHW[1] = giy_mult * giy;
         gGrid_ptr_NDHW[2] = giz_mult * giz;
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        int ix_nearest = static_cast<int>(::round(ix));
-        int iy_nearest = static_cast<int>(::round(iy));
-        int iz_nearest = static_cast<int>(::round(iz));
+        auto ix_nearest = static_cast<index_t>(::round(ix));
+        auto iy_nearest = static_cast<index_t>(::round(iy));
+        auto iz_nearest = static_cast<index_t>(::round(iz));
 
         // assign nearest neighor pixel value to output pixel
         scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
         scalar_t *gInp_ptr_NC = grad_input.data + n * gInp_sN;
-        for (int c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
+        for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, gInp_ptr_NC += gInp_sC) {
           // calculate and set grad_input
           safe_add_3d(gInp_ptr_NC, iz_nearest, iy_nearest, ix_nearest,
                       gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, *gOut_ptr_NCDHW);
@@ -607,21 +606,34 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
                             int64_t interpolation_mode, int64_t padding_mode,
                             bool align_corners) {
   auto N = input.size(0);
+  auto C = input.size(1);
   auto H = grid.size(1);
   auto W = grid.size(2);
-  auto output = at::empty({N, input.size(1), H, W}, input.options());
-  int count = static_cast<int>(N * H * W);
+  auto output = at::empty({N, C, H, W}, input.options());
+  int64_t count = N * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_cuda", [&] {
-      grid_sampler_2d_kernel<scalar_t>
-        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-          count,
-          getTensorInfo<scalar_t, int>(input),
-          getTensorInfo<scalar_t, int>(grid),
-          getTensorInfo<scalar_t, int>(output),
-          static_cast<GridSamplerInterpolation>(interpolation_mode),
-          static_cast<GridSamplerPadding>(padding_mode),
-          align_corners);
+        if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
+          grid_sampler_2d_kernel<scalar_t>
+            <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+              static_cast<int>(count),
+              getTensorInfo<scalar_t, int>(input),
+              getTensorInfo<scalar_t, int>(grid),
+              getTensorInfo<scalar_t, int>(output),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners);
+        } else {
+          grid_sampler_2d_kernel<scalar_t>
+            <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+              getTensorInfo<scalar_t, int64_t>(input),
+              getTensorInfo<scalar_t, int64_t>(grid),
+              getTensorInfo<scalar_t, int64_t>(output),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners);
+        }
     });
   }
   return output;
@@ -636,19 +648,30 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
   auto H = grid.size(2);
   auto W = grid.size(3);
   auto output = at::empty({N, input.size(1), D, H, W}, input.options());
-  int count = static_cast<int>(N * D * H * W);
+  int64_t count = N * D * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_cuda", [&] {
+      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
+        grid_sampler_3d_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            static_cast<int>(count),
+            getTensorInfo<scalar_t, int>(input),
+            getTensorInfo<scalar_t, int>(grid),
+            getTensorInfo<scalar_t, int>(output),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+      } else {
       grid_sampler_3d_kernel<scalar_t>
         <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
           count,
-          getTensorInfo<scalar_t, int>(input),
-          getTensorInfo<scalar_t, int>(grid),
-          getTensorInfo<scalar_t, int>(output),
+          getTensorInfo<scalar_t, int64_t>(input),
+          getTensorInfo<scalar_t, int64_t>(grid),
+          getTensorInfo<scalar_t, int64_t>(output),
           static_cast<GridSamplerInterpolation>(interpolation_mode),
           static_cast<GridSamplerPadding>(padding_mode),
           align_corners);
-    });
+    }});
   }
   return output;
 }
@@ -665,20 +688,34 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   auto W = grid.size(2);
   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  int count = static_cast<int>(N * H * W);
+  int64_t count = N * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_backward_cuda", [&] {
-      grid_sampler_2d_backward_kernel<scalar_t>
-        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-          count,
-          getTensorInfo<scalar_t, int>(grad_output),
-          getTensorInfo<scalar_t, int>(input),
-          getTensorInfo<scalar_t, int>(grid),
-          getTensorInfo<scalar_t, int>(grad_input),
-          getTensorInfo<scalar_t, int>(grad_grid),
-          static_cast<GridSamplerInterpolation>(interpolation_mode),
-          static_cast<GridSamplerPadding>(padding_mode),
-          align_corners);
+      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
+        grid_sampler_2d_backward_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            static_cast<int>(count),
+            getTensorInfo<scalar_t, int>(grad_output),
+            getTensorInfo<scalar_t, int>(input),
+            getTensorInfo<scalar_t, int>(grid),
+            getTensorInfo<scalar_t, int>(grad_input),
+            getTensorInfo<scalar_t, int>(grad_grid),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+      } else {
+        grid_sampler_2d_backward_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            count,
+            getTensorInfo<scalar_t, int64_t>(grad_output),
+            getTensorInfo<scalar_t, int64_t>(input),
+            getTensorInfo<scalar_t, int64_t>(grid),
+            getTensorInfo<scalar_t, int64_t>(grad_input),
+            getTensorInfo<scalar_t, int64_t>(grad_grid),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+      }
     });
   }
   return std::make_tuple(grad_input, grad_grid);
@@ -697,20 +734,34 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   auto W = grid.size(3);
   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto grad_grid = at::empty_like(grid, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  int count = static_cast<int>(N * D * H * W);
+  int64_t count = N * D * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_3d_backward_cuda", [&] {
-      grid_sampler_3d_backward_kernel<scalar_t>
-        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-          count,
-          getTensorInfo<scalar_t, int>(grad_output),
-          getTensorInfo<scalar_t, int>(input),
-          getTensorInfo<scalar_t, int>(grid),
-          getTensorInfo<scalar_t, int>(grad_input),
-          getTensorInfo<scalar_t, int>(grad_grid),
-          static_cast<GridSamplerInterpolation>(interpolation_mode),
-          static_cast<GridSamplerPadding>(padding_mode),
-          align_corners);
+      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
+        grid_sampler_3d_backward_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            static_cast<int>(count),
+            getTensorInfo<scalar_t, int>(grad_output),
+            getTensorInfo<scalar_t, int>(input),
+            getTensorInfo<scalar_t, int>(grid),
+            getTensorInfo<scalar_t, int>(grad_input),
+            getTensorInfo<scalar_t, int>(grad_grid),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+      } else {
+        grid_sampler_3d_backward_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            count,
+            getTensorInfo<scalar_t, int64_t>(grad_output),
+            getTensorInfo<scalar_t, int64_t>(input),
+            getTensorInfo<scalar_t, int64_t>(grid),
+            getTensorInfo<scalar_t, int64_t>(grad_input),
+            getTensorInfo<scalar_t, int64_t>(grad_grid),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+      }
     });
   }
   return std::make_tuple(grad_input, grad_grid);

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -613,27 +613,28 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
   int64_t count = N * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_cuda", [&] {
-        if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
-          grid_sampler_2d_kernel<scalar_t>
-            <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-              static_cast<int>(count),
-              getTensorInfo<scalar_t, int>(input),
-              getTensorInfo<scalar_t, int>(grid),
-              getTensorInfo<scalar_t, int>(output),
-              static_cast<GridSamplerInterpolation>(interpolation_mode),
-              static_cast<GridSamplerPadding>(padding_mode),
-              align_corners);
-        } else {
-          grid_sampler_2d_kernel<scalar_t>
-            <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-              count,
-              getTensorInfo<scalar_t, int64_t>(input),
-              getTensorInfo<scalar_t, int64_t>(grid),
-              getTensorInfo<scalar_t, int64_t>(output),
-              static_cast<GridSamplerInterpolation>(interpolation_mode),
-              static_cast<GridSamplerPadding>(padding_mode),
-              align_corners);
-        }
+      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
+          canUse32BitIndexMath(output)) {
+        grid_sampler_2d_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            static_cast<int>(count),
+            getTensorInfo<scalar_t, int>(input),
+            getTensorInfo<scalar_t, int>(grid),
+            getTensorInfo<scalar_t, int>(output),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+      } else {
+        grid_sampler_2d_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            count,
+            getTensorInfo<scalar_t, int64_t>(input),
+            getTensorInfo<scalar_t, int64_t>(grid),
+            getTensorInfo<scalar_t, int64_t>(output),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+      }
     });
   }
   return output;
@@ -671,7 +672,8 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
           static_cast<GridSamplerInterpolation>(interpolation_mode),
           static_cast<GridSamplerPadding>(padding_mode),
           align_corners);
-    }});
+      }
+    });
   }
   return output;
 }
@@ -691,7 +693,8 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   int64_t count = N * H * W;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_backward_cuda", [&] {
-      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid)) {
+      if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
+          canUse32BitIndexMath(grad_output)) {
         grid_sampler_2d_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             static_cast<int>(count),

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1406,6 +1406,10 @@
 # has the corresponding backward defined as native functions as well. Therefore,
 # in these functions and their backwards, no more shape checking is done.
 #
+# There is also _grid_sampler_2d_backward_cpu_fallback which is an
+# implementation detail of grid_sampler_2d and is only exposed here for testing
+# purposes.
+#
 # Additionally, arguments `padding_mode` and `interpolation_mode` are cast to
 # enums defined in `native/GridSampler.h`. `cudnn_grid_sampler` doesn't take in
 # `interpolation_mode` because it only supports Bilinear interpolation mode.
@@ -1425,6 +1429,12 @@
   dispatch:
     CPU: grid_sampler_2d_backward_cpu
     CUDA: grid_sampler_2d_backward_cuda
+
+- func: _grid_sampler_2d_cpu_fallback(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
+  use_c10_dispatcher: full
+
+- func: _grid_sampler_2d_cpu_fallback_backward(Tensor grad_output, Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> (Tensor, Tensor)
+  use_c10_dispatcher: full
 
 - func: grid_sampler_3d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1430,6 +1430,7 @@
     CPU: grid_sampler_2d_backward_cpu
     CUDA: grid_sampler_2d_backward_cuda
 
+# See NOTE [ grid_sample CPU fallback ]
 - func: _grid_sampler_2d_cpu_fallback(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
   use_c10_dispatcher: full
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10161,45 +10161,9 @@ class TestNNDeviceType(NNTestCase):
 
     @dtypes(torch.float, torch.double)
     @largeTensorTest(lambda self, device, dtype:
-                     32769 * (65536 + 65536 / 128) *
-                     torch.tensor([], dtype=dtype).element_size())
-    def test_grid_sample_large_index_2d(self, device, dtype):
-        # Test 64-bit indexing with grid_sample (gh-41656)
-        # Try accessing the corners, there should be no segfault
-        coords = torch.tensor([[[-1., -1.],
-                                [+1., -1.]],
-
-                               [[-1., +1.],
-                                [+1., +1.]]], device=device, dtype=dtype)
-        coords = coords.expand(1, 2, 2, 2)
-        im = torch.zeros([1, 1, 32769, 65536], device=device, dtype=dtype)
-
-        result = F.grid_sample(im, coords, align_corners=False)
-        self.assertEqual(result, torch.zeros((1, 1, 2, 2), device=device, dtype=dtype))
-
-        # Compare sampling with large strides to the same op on a contiguous tensor
-        coords = torch.rand(1, 4, 4, 2, device=device, dtype=dtype)
-        large_view = im[..., 127::128]
-        small_image = torch.rand_like(large_view)
-        large_view[...] = small_image
-        self.assertTrue(
-            sum(i * s for i, s in zip(large_view.size(), large_view.stride())) >= 2 ** 31,
-            msg="View must use 64-bit indexing")
-        for mode, padding_mode, align_corners in itertools.product(
-                ('nearest', 'bilinear'), ('zeros', 'border', 'reflection'), (True, False)):
-            expect = F.grid_sample(
-                small_image, coords, mode=mode,
-                padding_mode=padding_mode, align_corners=align_corners)
-            actual = F.grid_sample(
-                large_view, coords, mode=mode,
-                padding_mode=padding_mode, align_corners=align_corners)
-            self.assertEqual(expect, actual)
-
-    @dtypes(torch.float, torch.double)
-    @largeTensorTest(lambda self, device, dtype:
                      32769 * (65536 + 3 * 65536 / 128) *
                      torch.tensor([], dtype=dtype).element_size())
-    def test_grid_sample_backward_large_index_2d(self, device, dtype):
+    def test_grid_sample_large_index_2d(self, device, dtype):
         # Test 64-bit indexing with grid_sample (gh-41656)
         # Try accessing the corners, there should be no segfault
         coords = torch.tensor([[[-1., -1.],
@@ -10239,40 +10203,9 @@ class TestNNDeviceType(NNTestCase):
 
     @dtypes(torch.float, torch.double)
     @largeTensorTest(lambda self, device, dtype:
-                     2 * 32769 * (32768 + 32768 / 128) *
-                     torch.tensor([], dtype=dtype).element_size())
-    def test_grid_sample_large_index_3d(self, device, dtype):
-        # Test 64-bit indexing with grid_sample (gh-41656)
-        # Try accessing the corners, there should be no segfault
-        coords = torch.full((1, 2, 2, 2, 3), 1., device=device, dtype=dtype)
-        im = torch.zeros([1, 1, 2, 32769, 32768], device=device, dtype=dtype)
-
-        result = F.grid_sample(im, coords, align_corners=False)
-        self.assertEqual(result, torch.zeros((1, 1, 2, 2, 2), device=device, dtype=dtype))
-
-        # Compare sampling with large strides to the same op on a contiguous tensor
-        coords = torch.rand(1, 1, 4, 4, 3, device=device, dtype=dtype)
-        large_view = im[..., 127::128]
-        small_image = torch.rand_like(large_view)
-        large_view[...] = small_image
-        self.assertTrue(
-            sum(i * s for i, s in zip(large_view.size(), large_view.stride())) >= 2 ** 31,
-            msg="View must use 64-bit indexing")
-        for mode, padding_mode, align_corners in itertools.product(
-                ('nearest', 'bilinear'), ('zeros', 'border', 'reflection'), (True, False)):
-            expect = F.grid_sample(
-                small_image, coords, mode=mode,
-                padding_mode=padding_mode, align_corners=align_corners)
-            actual = F.grid_sample(
-                large_view, coords, mode=mode,
-                padding_mode=padding_mode, align_corners=align_corners)
-            self.assertEqual(expect, actual)
-
-    @dtypes(torch.float, torch.double)
-    @largeTensorTest(lambda self, device, dtype:
                      2 * 32769 * (32768 + 3 * 32768 / 128) *
                      torch.tensor([], dtype=dtype).element_size())
-    def test_grid_sample_backward_large_index_3d(self, device, dtype):
+    def test_grid_sample_large_index_3d(self, device, dtype):
         # Test 64-bit indexing with grid_sample (gh-41656)
         # Try accessing the corners, there should be no segfault
         coords = torch.full((1, 2, 2, 2, 3), 1., device=device, dtype=dtype)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10116,6 +10116,53 @@ class TestNNDeviceType(NNTestCase):
         output = F.grid_sample(input, grid, align_corners=False)
         output.sum().backward()
 
+    @dtypes(torch.float, torch.double)
+    def test_grid_sample_large_index_2d(self, device, dtype):
+        # Test 64-bit indexing with grid_sample (gh-41656)
+        # Try accessing the corners, there should be no segfault
+        coords = torch.tensor([[[-1., -1.],
+                                [ 1., -1.]],
+
+                               [[-1.,  1.],
+                                [ 1.,  1.]]], device=device, dtype=dtype)
+        coords = coords.expand(1, 2, 2, 2)
+        im = torch.zeros([1, 1, 32769, 65536], device=device, dtype=dtype)
+
+        result = F.grid_sample(im, coords, align_corners=False)
+        self.assertEqual(result, torch.zeros((1, 1, 2, 2), device=device, dtype=dtype))
+
+        # Compare sampling with large strides to the same op on a contiguous tensor
+        coords = torch.rand(1, 4, 4, 2, device=device, dtype=dtype)
+        large_view = im[..., 127::128]
+        small_image = torch.rand_like(large_view)
+        large_view[...] = small_image
+        for mode in ('nearest', 'bilinear'):
+            for align_corners in (True, False):
+                expect = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
+                actual = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
+                self.assertEqual(expect, actual)
+
+    @dtypes(torch.float, torch.double)
+    def test_grid_sample_large_index_3d(self, device, dtype):
+        # Test 64-bit indexing with grid_sample (gh-41656)
+        # Try accessing the corners, there should be no segfault
+        coords = torch.full((1, 2, 2, 2, 3), 1., device=device, dtype=dtype)
+        im = torch.zeros([1, 1, 2, 32769, 32768], device=device, dtype=dtype)
+
+        result = F.grid_sample(im, coords, align_corners=False)
+        self.assertEqual(result, torch.zeros((1, 1, 2, 2, 2), device=device, dtype=dtype))
+
+        # Compare sampling with large strides to the same op on a contiguous tensor
+        coords = torch.rand(1, 1, 4, 4, 3, device=device, dtype=dtype)
+        large_view = im[..., 127::128]
+        small_image = torch.rand_like(large_view)
+        large_view[...] = small_image
+        for mode in ('nearest', 'bilinear'):
+            for align_corners in (True, False):
+                expect = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
+                actual = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
+                self.assertEqual(expect, actual)
+
     @largeCUDATensorTest('12GB')
     def test_conv_transposed_large(self, device):
         dtype = torch.half if self.device_type == 'cuda' else torch.float

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10139,11 +10139,13 @@ class TestNNDeviceType(NNTestCase):
         large_view = im[..., 127::128]
         small_image = torch.rand_like(large_view)
         large_view[...] = small_image
-        for mode in ('nearest', 'bilinear'):
-            for align_corners in (True, False):
-                expect = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
-                actual = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
-                self.assertEqual(expect, actual)
+        self.assertTrue(
+            sum(i * s for i, s in zip(large_view.size(), large_view.stride())) >= 2 ** 31,
+            msg="View must use 64-bit indexing")
+        for mode, align_corners in itertools.product(('nearest', 'bilinear'), (True, False)):
+            expect = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
+            actual = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
+            self.assertEqual(expect, actual)
 
     @dtypes(torch.float, torch.double)
     @largeTensorTest(lambda self, device, dtype:
@@ -10163,11 +10165,13 @@ class TestNNDeviceType(NNTestCase):
         large_view = im[..., 127::128]
         small_image = torch.rand_like(large_view)
         large_view[...] = small_image
-        for mode in ('nearest', 'bilinear'):
-            for align_corners in (True, False):
-                expect = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
-                actual = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
-                self.assertEqual(expect, actual)
+        self.assertTrue(
+            sum(i * s for i, s in zip(large_view.size(), large_view.stride())) >= 2 ** 31,
+            msg="View must use 64-bit indexing")
+        for mode, align_corners in itertools.product(('nearest', 'bilinear'), (True, False)):
+            expect = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
+            actual = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
+            self.assertEqual(expect, actual)
 
     @largeCUDATensorTest('12GB')
     def test_conv_transposed_large(self, device):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -44,7 +44,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, NewCrit
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, \
     skipCUDAIfRocm, skipCUDAIf, skipCUDAIfNotRocm, largeCUDATensorTest, onlyOnCPUAndCUDA, \
-    deviceCountAtLeast, expectedAlertNondeterministic
+    deviceCountAtLeast, expectedAlertNondeterministic, largeTensorTest
 from torch.nn import MultiheadAttention
 
 from hypothesis import given
@@ -10117,6 +10117,9 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
 
     @dtypes(torch.float, torch.double)
+    @largeTensorTest(lambda self, device, dtype:
+                     32769 * (65536 + 3 * 65536 / 128) *
+                     torch.tensor([], dtype=dtype).element_size())
     def test_grid_sample_large_index_2d(self, device, dtype):
         # Test 64-bit indexing with grid_sample (gh-41656)
         # Try accessing the corners, there should be no segfault
@@ -10143,6 +10146,9 @@ class TestNNDeviceType(NNTestCase):
                 self.assertEqual(expect, actual)
 
     @dtypes(torch.float, torch.double)
+    @largeTensorTest(lambda self, device, dtype:
+                     2 * 32769 * (32768 + 3 * 32768 / 128) *
+                     torch.tensor([], dtype=dtype).element_size())
     def test_grid_sample_large_index_3d(self, device, dtype):
         # Test 64-bit indexing with grid_sample (gh-41656)
         # Try accessing the corners, there should be no segfault

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10121,10 +10121,10 @@ class TestNNDeviceType(NNTestCase):
         # Test 64-bit indexing with grid_sample (gh-41656)
         # Try accessing the corners, there should be no segfault
         coords = torch.tensor([[[-1., -1.],
-                                [ 1., -1.]],
+                                [+1., -1.]],
 
-                               [[-1.,  1.],
-                                [ 1.,  1.]]], device=device, dtype=dtype)
+                               [[-1., +1.],
+                                [+1., +1.]]], device=device, dtype=dtype)
         coords = coords.expand(1, 2, 2, 2)
         im = torch.zeros([1, 1, 32769, 65536], device=device, dtype=dtype)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8,6 +8,7 @@ import unittest.mock as mock
 import itertools
 import warnings
 import pickle
+import gc
 from copy import deepcopy
 from itertools import repeat, product
 from functools import reduce
@@ -3735,8 +3736,6 @@ class TestNN(NNTestCase):
 
     def test_load_state_dict_ref_cycle(self):
         # load_state_dict shouldn't cause a reference cycle involving Tensors
-        import gc
-
         m = torch.nn.LSTM(16, 16, bidirectional=True)
 
         gc.collect()
@@ -10149,6 +10148,48 @@ class TestNNDeviceType(NNTestCase):
 
     @dtypes(torch.float, torch.double)
     @largeTensorTest(lambda self, device, dtype:
+                     32769 * (65536 + 6 * 65536 / 128) *
+                     torch.tensor([], dtype=dtype).element_size())
+    def test_grid_sample_backward_large_index_2d(self, device, dtype):
+        # Test 64-bit indexing with grid_sample (gh-41656)
+        # Try accessing the corners, there should be no segfault
+        coords = torch.tensor([[[-1., -1.],
+                                [+1., -1.]],
+
+                               [[-1., +1.],
+                                [+1., +1.]]], device=device, dtype=dtype)
+        coords = coords.expand(1, 2, 2, 2)
+        im = torch.zeros([1, 1, 32769, 65536], device=device, dtype=dtype)
+
+        # Compare sampling with large strides to the same op on a contiguous tensor
+        coords = torch.rand(1, 4, 4, 2, device=device, dtype=dtype)
+        large_view = im[..., 127::128]
+        small_image = torch.rand_like(large_view)
+        large_view[...] = small_image
+        large_view.requires_grad, small_image.requires_grad = True, True
+        self.assertTrue(
+            sum(i * s for i, s in zip(large_view.size(), large_view.stride())) >= 2 ** 31,
+            msg="View must use 64-bit indexing")
+        for mode, align_corners in itertools.product(('nearest', 'bilinear'), (True, False)):
+            a = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
+            a.sum().backward()
+
+            b = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
+            b.sum().backward()
+
+            self.assertEqual(a, b)
+            self.assertEqual(small_image.grad, large_view.grad)
+
+            # Cleanup memory
+            del a
+            del b
+            gc.collect()
+
+            small_image.grad.zero_()
+            large_view.grad.zero_()
+
+    @dtypes(torch.float, torch.double)
+    @largeTensorTest(lambda self, device, dtype:
                      2 * 32769 * (32768 + 3 * 32768 / 128) *
                      torch.tensor([], dtype=dtype).element_size())
     def test_grid_sample_large_index_3d(self, device, dtype):
@@ -10172,6 +10213,46 @@ class TestNNDeviceType(NNTestCase):
             expect = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
             actual = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
             self.assertEqual(expect, actual)
+
+    @dtypes(torch.float, torch.double)
+    @largeTensorTest(lambda self, device, dtype:
+                     2 * 32769 * (32768 + 6 * 32768 / 128) *
+                     torch.tensor([], dtype=dtype).element_size())
+    def test_grid_sample_backward_large_index_3d(self, device, dtype):
+        # Test 64-bit indexing with grid_sample (gh-41656)
+        # Try accessing the corners, there should be no segfault
+        coords = torch.full((1, 2, 2, 2, 3), 1., device=device, dtype=dtype)
+        im = torch.zeros([1, 1, 2, 32769, 32768], device=device, dtype=dtype)
+
+        result = F.grid_sample(im, coords, align_corners=False)
+        self.assertEqual(result, torch.zeros((1, 1, 2, 2, 2), device=device, dtype=dtype))
+
+        # Compare sampling with large strides to the same op on a contiguous tensor
+        coords = torch.rand(1, 1, 4, 4, 3, device=device, dtype=dtype)
+        large_view = im[..., 127::128]
+        small_image = torch.rand_like(large_view)
+        large_view[...] = small_image
+        small_image.requires_grad, large_view.requires_grad = True, True
+        self.assertTrue(
+            sum(i * s for i, s in zip(large_view.size(), large_view.stride())) >= 2 ** 31,
+            msg="View must use 64-bit indexing")
+        for mode, align_corners in itertools.product(('nearest', 'bilinear'), (True, False)):
+            a = F.grid_sample(small_image, coords, mode=mode, align_corners=align_corners)
+            a.sum().backward()
+
+            b = F.grid_sample(large_view, coords, mode=mode, align_corners=align_corners)
+            b.sum().backward()
+
+            self.assertEqual(a, b)
+            self.assertEqual(small_image.grad, large_view.grad)
+
+            # Cleanup memory
+            del a
+            del b
+            gc.collect()
+
+            small_image.grad.zero_()
+            large_view.grad.zero_()
 
     @largeCUDATensorTest('12GB')
     def test_conv_transposed_large(self, device):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -498,6 +498,7 @@
 - name: grid_sampler_3d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
   input, grid: "grad.defined() ? grid_sampler_3d_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners) : std::tuple<Tensor, Tensor>()"
 
+# See NOTE [ grid_sample CPU fallback ]
 - name: _grid_sampler_2d_cpu_fallback(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
   input, grid: "grad.defined() ? _grid_sampler_2d_cpu_fallback_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners) : std::tuple<Tensor, Tensor>()"
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -498,6 +498,9 @@
 - name: grid_sampler_3d(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
   input, grid: "grad.defined() ? grid_sampler_3d_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners) : std::tuple<Tensor, Tensor>()"
 
+- name: _grid_sampler_2d_cpu_fallback(Tensor input, Tensor grid, int interpolation_mode, int padding_mode, bool align_corners) -> Tensor
+  input, grid: "grad.defined() ? _grid_sampler_2d_cpu_fallback_backward(grad, input, grid, interpolation_mode, padding_mode, align_corners) : std::tuple<Tensor, Tensor>()"
+
 - name: gt_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   self: zeros_like(self)
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -435,8 +435,31 @@ def largeCUDATensorTest(size):
     return unittest.skipIf(not valid, "No CUDA or Has CUDA but GPU RAM is not large enough")
 
 
+def _has_sufficient_memory(device, size):
+    if device.startswith('cuda'):
+        return (torch.cuda.is_available() and
+                torch.cuda.get_device_properties(0).total_memory >= size)
+
+    # Assume CPU
+    if not HAS_PSUTIL:
+        raise unittest.SkipTest('Need psutil to determine if memory is sufficient')
+
+    # The sanitizers have significant memory overheads
+    if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
+        effective_size = size * 10
+    else:
+        effective_size = size
+
+    if psutil.virtual_memory().available < effective_size:
+        gc.collect()
+    return psutil.virtual_memory().available >= effective_size
+
+
 def largeTensorTest(size):
-    """Skip test if the device has insufficient memory to run the test"""
+    """Skip test if the device has insufficient memory to run the test
+
+    size may be a number of bytes, a string of the form "N GB", or a callable
+    """
     if isinstance(size, str):
         assert size.endswith("GB") or size.endswith("gb"), "only bytes or GB supported"
         size = 1024 ** 3 * int(size[:-2])
@@ -444,24 +467,8 @@ def largeTensorTest(size):
     def inner(fn):
         @wraps(fn)
         def dep_fn(self, *args, **kwargs):
-            if self.device_type == 'cuda':
-                valid = (torch.cuda.is_available() and
-                         torch.cuda.get_device_properties(0).total_memory >= size)
-            else:
-                if not HAS_PSUTIL:
-                    raise unittest.SkipTest('Need psutil to determine if memory is sufficient')
-
-                # The sanitizers have significant memory overheads
-                if TEST_WITH_ASAN or TEST_WITH_TSAN or TEST_WITH_UBSAN:
-                    effective_size = size * 10
-                else:
-                    effective_size = size
-
-                if psutil.virtual_memory().available < effective_size:
-                    gc.collect()
-                valid = psutil.virtual_memory().available >= effective_size
-
-            if not valid:
+            size_bytes = size(self, *args, **kwargs) if callable(size) else size
+            if not _has_sufficient_memory(self.device_type, size_bytes):
                 raise unittest.SkipTest('Insufficient {} memory'.format(self.device_type))
 
             return fn(self, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -439,8 +439,13 @@ def _has_sufficient_memory(device, size):
     if device.startswith('cuda'):
         return (torch.cuda.is_available() and
                 torch.cuda.get_device_properties(0).total_memory >= size)
+    if device == 'xla':
+        raise unittest.SkipTest('TODO: Memory availability checks for XLA?')
 
-    # Assume CPU
+    if device != 'cpu':
+        raise unittest.SkipTest('Unknown device type')
+
+    # CPU
     if not HAS_PSUTIL:
         raise unittest.SkipTest('Need psutil to determine if memory is sufficient')
 


### PR DESCRIPTION
Fixes #41656

For the CPU version, this is a regression introduced in #10980 which vectorized the `grid_sampler_2d` implementation. It uses the AVX2 gather intrinsic which for `float` requires 32-bit indexing to match the number of floats in the AVX register. There is also an `i64gather_ps` variant but this only utilizes half of the vector width so would be expected to give worse performance in the more likely case where 32-bit indexing is acceptable. So, I've left the optimised AVX version as-is and reinstated the old non-vectorized version as a fallback.

For the CUDA version, this operation has never supported 32-bit indexing so this isn't a regression. I've templated the kernel on index type and added 64-bit variants. Although I gather in some places a simple `TORCH_CHECK(canUse32BitIndexMath(...))` is used instead. So, there is a decision to be made here.