### PR TITLE
Fix typo CXX_FLAGS -> CXXFLAGS in ASAN script and docu

### DIFF
--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -32,7 +32,7 @@ export ASAN_OPTIONS=detect_leaks=0:symbolize=1:detect_odr_violation=0
 # TODO: Make the ASAN flags a centralized env var and unify with USE_ASAN option
 CC="clang" CXX="clang++" LDSHARED="clang --shared" \
   CFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -shared-libasan -pthread" \
-  CXX_FLAGS="-pthread" \
+  CXXFLAGS="-pthread" \
   USE_ASAN=1 USE_CUDA=0 USE_MKLDNN=0 \
   python setup.py install
 

--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -32,7 +32,7 @@ export ASAN_OPTIONS=detect_leaks=0:symbolize=1:detect_odr_violation=0
 # TODO: Make the ASAN flags a centralized env var and unify with USE_ASAN option
 CC="clang" CXX="clang++" LDSHARED="clang --shared" \
   CFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -shared-libasan -pthread" \
-  CXXFLAGS="-pthread" \
+  CXXFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -shared-libasan -pthread" \
   USE_ASAN=1 USE_CUDA=0 USE_MKLDNN=0 \
   python setup.py install
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -857,7 +857,7 @@ build_with_asan()
   LDSHARED="clang --shared" \
   LDFLAGS="-stdlib=libstdc++" \
   CFLAGS="-fsanitize=address -fno-sanitize-recover=all -shared-libasan -pthread" \
-  CXX_FLAGS="-pthread" \
+  CXXFLAGS="-pthread" \
   USE_CUDA=0 USE_OPENMP=0 BUILD_CAFFE2_OPS=0 USE_DISTRIBUTED=0 DEBUG=1 \
   python setup.py develop
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -857,7 +857,7 @@ build_with_asan()
   LDSHARED="clang --shared" \
   LDFLAGS="-stdlib=libstdc++" \
   CFLAGS="-fsanitize=address -fno-sanitize-recover=all -shared-libasan -pthread" \
-  CXXFLAGS="-pthread" \
+  CXXFLAGS="-fsanitize=address -fno-sanitize-recover=all -shared-libasan -pthread" \
   USE_CUDA=0 USE_OPENMP=0 BUILD_CAFFE2_OPS=0 USE_DISTRIBUTED=0 DEBUG=1 \
   python setup.py develop
 }


### PR DESCRIPTION
The correct environment variable is CXXFLAGS not CXX_FLAGS which likely was influenced by CMakes naming: `CMAKE_CXX_FLAGS`. See e.g. https://en.wikipedia.org/wiki/CFLAGS