### PR TITLE
Remove AllGatherTestWithTimeout

### DIFF
--- a/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
@@ -254,17 +254,6 @@ class AllgatherNCCLTest : public NCCLTest {
   }
 };
 
-class AllgatherNCCLTestWithTimeout : public AllgatherNCCLTest {
- public:
-  AllgatherNCCLTestWithTimeout(const std::string& path, int worldSize)
-      : AllgatherNCCLTest(path, worldSize) {}
-
-  std::shared_ptr<c10d::ProcessGroup::Work> run() {
-    std::this_thread::sleep_for(kWorkDelayTime);
-    return AllgatherNCCLTest::run();
-  }
-};
-
 struct ReduceScatterNCCLTest : NCCLTest {
   ReduceScatterNCCLTest(const std::string& path, int worldSize)
       : NCCLTest(path, worldSize) {}
@@ -403,45 +392,6 @@ void testAllgather(const std::string& path, int rank, int size) {
   std::cout << "Allgather test successful" << std::endl;
 }
 
-void testAllgatherWithTimeout(const std::string& path, int rank, int size) {
-  // First we must set NCCL_BLOCKING_WAIT to 1 for timeouts to work in
-  // ProcessGroupNCCL.
-  auto originalBlockingWait = getenv(c10d::NCCL_BLOCKING_WAIT);
-  setenv(c10d::NCCL_BLOCKING_WAIT, "1", 1);
-  auto test = AllgatherNCCLTestWithTimeout(path, size);
-  test.initialize(rank, size);
-  auto work = test.run();
-
-  // Wait for work to finish
-  try {
-    test.wait(work, kWorkTimeout);
-  } catch (const std::runtime_error& e) {
-    // First we reset the NCCL_BLOCKING_WAIT environment variable to prevent
-    // any unwanted side-effects. We must do this at all exit-points for this
-    // function.
-    setenv(c10d::NCCL_BLOCKING_WAIT, originalBlockingWait, 1);
-    // We are expecting the operation to timeout and throw a runtime_error
-    std::string errorMsg = e.what();
-    if (errorMsg.find(kTimeoutErrorString) != std::string::npos) {
-      // If the runtime_error message is the same one thrown in wait::timeout,
-      // the test is successful
-      std::cout << "Allgather test with timeouts was successful" << std::endl;
-      return;
-    } else {
-      // Other runtime errors indicates a test failure
-      throw std::runtime_error("BOOM!");
-    }
-  } catch (...) {
-    setenv(c10d::NCCL_BLOCKING_WAIT, originalBlockingWait, 1);
-    // Any other exception indicates a test failure
-    throw std::runtime_error("BOOM!");
-  }
-  setenv(c10d::NCCL_BLOCKING_WAIT, originalBlockingWait, 1);
-  // If no exception, that is also an error since we expect the test.wait call
-  // to timeout and throw.
-  throw std::runtime_error("BOOM!");
-}
-
 void testReduceScatter(const std::string& path, int rank, int size) {
   auto test = ReduceScatterNCCLTest(path, size);
   test.initialize(rank, size);
@@ -495,7 +445,6 @@ int main(int argc, char** argv) {
   testBroadcast(file.path, rank, size);
   testReduce(file.path, rank, size);
   testAllgather(file.path, rank, size);
-  testAllgatherWithTimeout(file.path, rank, size);
   testReduceScatter(file.path, rank, size);
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

This test previously did a thread sleep before launching the allgather operation, and then waited on the work object. Since the sleep was done before the work object was created, it did not affect the allgather call, and thus, did not test work-level timeouts as intended.

I am removing this test for now. In the future we can add this test back, but would need to somehow inject a `cudaSleep` call before the  allgather (so the collective operation itself is delayed). This may require overriding the `ProcessGroupNCCL::collective`, so it's a bit more heavy-weight.

In the meantime, we can remove this test - work-level timeouts are still thoroughly tested with Gloo.

Differential Revision: [D22702291](https://our.internmc.facebook.com/intern/diff/D22702291/)