### PR TITLE
update tests to run back-compat check using new binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ test/cpp/api/mnist
 test/custom_operator/model.pt
 test/data/legacy_modules.t7
 test/data/*.pt
-test/backward_compatibility/new_schemas.txt
+test/backward_compatibility/nightly_schemas.txt
 dropout_model.pt
 test/generated_type_hints_smoketest.py
 test/htmlcov

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -298,10 +298,15 @@ test_xla() {
 test_backward_compatibility() {
   set -x
   pushd test/backward_compatibility
-  python dump_all_function_schemas.py --filename new_schemas.txt
-  pip_uninstall torch
+  python -m venv venv
+  . venv/bin/activate
   pip_install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-  python check_backward_compatibility.py --new-schemas new_schemas.txt
+  pip show torch
+  python dump_all_function_schemas.py --filename nightly_schemas.txt
+  deactivate
+  rm -r venv
+  pip show torch
+  python check_backward_compatibility.py --existing-schemas nightly_schemas.txt
   popd
   set +x
   assert_git_not_dirty

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -4,6 +4,8 @@ import argparse
 import datetime
 import re
 import sys
+from collections import defaultdict
+
 import torch
 from torch._C import parse_schema
 
@@ -17,159 +19,43 @@ from torch._C import parse_schema
 #
 # Allowlist entries can be removed after the date listed on them passes.
 allow_list = [
-    ('c10_experimental', datetime.date(2222, 1, 1)),
+    ("c10_experimental", datetime.date(2222, 1, 1)),
     # We export some functions and classes for test_jit.py directly from libtorch.so,
     # it's not important to have BC for them
-    ('_TorchScriptTesting.*', datetime.date(9999, 1, 1)),
+    ("_TorchScriptTesting.*", datetime.date(9999, 1, 1)),
     # Internal, profiler-specific ops
-    ('profiler::_call_end_callbacks_on_jit_fut*', datetime.date(9999, 1, 1)),
-    ('profiler::_record_function_enter', datetime.date(9999, 1, 1)),
-    ('aten::append*', datetime.date(2020, 4, 15)),
-    ('aten::_min', datetime.date(2020, 9, 9)),
-    ('aten::_max', datetime.date(2020, 9, 9)),
-    ('aten::real*', datetime.date(2020, 7, 15)),
-    ('aten::imag*', datetime.date(2020, 7, 15)),
-    ('aten::quantize_per_tensor', datetime.date(2020, 4, 15)),
-    ('aten::index_put', datetime.date(2020, 4, 10)),
-    ('aten::index', datetime.date(2020, 4, 10)),
-    ('aten::_index_put_impl', datetime.date(2020, 4, 10)),
-    ('aten::index_put_', datetime.date(2020, 4, 10)),
-    ('aten::quantize_per_tensor', datetime.date(2020, 4, 15)),
-    ('aten::requires_grad_', datetime.date(2020, 4, 30)),
-    ('aten::sizes', datetime.date(2020, 4, 30)),
-    ('aten::strides', datetime.date(2020, 4, 30)),
-    ('aten::backward', datetime.date(2020, 4, 30)),
-    ('quantized::conv_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::conv_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::conv', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d_relu', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d_relu', datetime.date(2020, 5, 1)),
-    ('_quantized::conv2d_relu', datetime.date(2020, 6, 1)),
-    ('_quantized::conv2d', datetime.date(2020, 6, 1)),
-    ('aten::batch_norm_gather_stats_with_counts', datetime.date(2020, 6, 30)),
-    ('aten::quantized_lstm', datetime.date(2020, 6, 1)),
-    ('aten::quantized_gru', datetime.date(2020, 6, 1)),
-    ('quantized::make_quantized_cell_params', datetime.date(2020, 6, 1)),
-    ('quantized::make_quantized_cell_params_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::make_quantized_cell_params_dynamic', datetime.date(2020, 6, 1)),
-    ('aten::len', datetime.date(2020, 6, 30)),
-    ('aten::keys', datetime.date(2020, 6, 30)),
-    ('aten::values', datetime.date(2020, 6, 30)),
-    ('aten::__getitem__', datetime.date(2020, 6, 30)),
-    ('aten::get', datetime.date(2020, 6, 30)),
-    ('aten::setdefault', datetime.date(2020, 6, 30)),
-    ('aten::Delete', datetime.date(2020, 6, 30)),
-    ('aten::pop', datetime.date(2020, 6, 30)),
-    ('aten::popitem', datetime.date(2020, 6, 30)),
-    ('aten::clear', datetime.date(2020, 6, 30)),
-    ('aten::update', datetime.date(2020, 6, 30)),
-    ('aten::items', datetime.date(2020, 6, 30)),
-    ('aten::copy', datetime.date(2020, 6, 30)),
-    ('aten::__contains__', datetime.date(2020, 6, 30)),
-    ('aten::_set_item', datetime.date(2020, 6, 30)),
-    ('aten::dict', datetime.date(2020, 6, 30)),
-    ('aten::tensor', datetime.date(2020, 6, 30)),
-    ('aten::as_tensor', datetime.date(2020, 6, 30)),
-    ('aten::split_with_sizes', datetime.date(2020, 7, 29)),
-    ('quantized::linear_unpack_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::linear_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::linear_prepack_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::linear_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::linear_dynamic_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::linear_relu_dynamic', datetime.date(2020, 6, 1)),
-    ('quantized::linear_dynamic', datetime.date(2020, 6, 1)),
-    ('quantized::linear_relu', datetime.date(2020, 6, 1)),
-    ('quantized::linear', datetime.date(2020, 6, 1)),
-    ('aten::quantized_layer_norm', datetime.date(2020, 6, 30)),
-    ('aten::quantized_group_norm', datetime.date(2020, 6, 30)),
-    ('aten::quantized_instance_norm', datetime.date(2020, 6, 30)),
-    ('_aten::*', datetime.date(2020, 6, 1)),
-    ('_prim::*', datetime.date(2020, 6, 1)),
-    ('aten::eq', datetime.date(2020, 7, 30)),
-    ('aten::nq', datetime.date(2020, 6, 30)),
-    ('aten::lt', datetime.date(2020, 6, 30)),
-    ('aten::gt', datetime.date(2020, 6, 30)),
-    ('aten::le', datetime.date(2020, 6, 30)),
-    ('aten::ge', datetime.date(2020, 6, 30)),
-    ('aten::pow', datetime.date(2020, 6, 30)),
-    ('prim::min', datetime.date(2020, 6, 30)),
-    ('prim::max', datetime.date(2020, 6, 30)),
-    ('aten::view_as', datetime.date(2020, 6, 30)),
-    ('aten::reshape_as', datetime.date(2020, 6, 30)),
-    ('aten::pin_memory', datetime.date(2020, 6, 30)),
-    ('aten::reshape', datetime.date(2020, 6, 30)),
-    ('aten::detach', datetime.date(2020, 6, 30)),
-    ('aten::expand_as', datetime.date(2020, 6, 30)),
-    ('aten::flatten.*', datetime.date(2020, 6, 30)),
-    ('aten::contiguous', datetime.date(2020, 6, 30)),
-    ('aten::to_here', datetime.date(2020, 6, 30)),
-    ('aten::to_here(RRef(t) self, double timeout*)', datetime.date(2020, 6, 30)),
-    ('aten::local_value', datetime.date(2020, 6, 30)),
-    ('aten::log', datetime.date(2020, 7, 30)),
-    ('aten::__and__', datetime.date(2020, 7, 30)),
-    ('aten::__or__', datetime.date(2020, 7, 30)),
-    ('aten::__xor__', datetime.date(2020, 7, 30)),
-    ('aten::split', datetime.date(2020, 6, 30)),
-    ('aten::add', datetime.date(2020, 7, 30)),
-    ('aten::__upsample_bilinear', datetime.date(2020, 7, 30)),
-    ('aten::hash', datetime.date(2020, 7, 30)),
-    ('aten::divmod', datetime.date(2020, 7, 30)),
-    ('aten::sorted', datetime.date(2020, 7, 30)),
-    ('aten::__contains__', datetime.date(2020, 7, 30)),
-    ('aten::ne', datetime.date(2020, 7, 30)),
-    ('aten::index', datetime.date(2020, 7, 30)),
-    ('aten::isnan', datetime.date(2020, 7, 30)),
-    ('aten::pow', datetime.date(2020, 7, 30)),
-    ('aten::atan2', datetime.date(2020, 7, 30)),
-    ('aten::copy_', datetime.date(2020, 7, 30)),
-    ('aten::sort', datetime.date(2020, 7, 30)),
-    ('aten::_cudnn_init_dropout_state', datetime.date(2020, 7, 30)),
-    ('aten::sparse_coo_tensor', datetime.date(2020, 7, 30)),
-    ('aten::_sparse_coo_tensor_with_dims', datetime.date(2020, 7, 30)),
-    ('aten::_sparse_coo_tensor_with_dims_and_tensors', datetime.date(2020, 7, 30)),
-    ('aten::to', datetime.date(2020, 7, 15)),
-    ('aten::__lshift__', datetime.date(2020, 7, 30)),
-    ('aten::__rshift__', datetime.date(2020, 7, 30)),
-    ('aten::__round_to_zero_floordiv', datetime.date(2020, 7, 30)),
-    ('aten::gcd', datetime.date(2020, 7, 30)),
-]
-
-
-# The nightly will fail to parse newly added syntax to schema declarations
-# Add new schemas that will fail the nightly here
-dont_parse_list = [
-    ('aten::eq', datetime.date(2020, 7, 30)),
-    ('aten::quantized_lstm', datetime.date(2020, 6, 1)),
-    ('aten::quantized_gru', datetime.date(2020, 6, 1)),
-    ('quantized::make_quantized_cell_params', datetime.date(2020, 6, 1)),
-    ('quantized::make_quantized_cell_params_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::make_quantized_cell_params_dynamic', datetime.date(2020, 6, 1)),
-    ('quantized::conv_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::conv_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::conv', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d', datetime.date(2020, 6, 1)),
-    ('quantized::conv2d_relu', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d', datetime.date(2020, 6, 1)),
-    ('quantized::conv3d_relu', datetime.date(2020, 6, 1)),
-    ('quantized::linear_unpack_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::linear_unpack', datetime.date(2020, 6, 1)),
-    ('quantized::linear_prepack_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::linear_prepack', datetime.date(2020, 6, 1)),
-    ('quantized::linear_dynamic_fp16', datetime.date(2020, 6, 1)),
-    ('quantized::linear_relu_dynamic', datetime.date(2020, 6, 1)),
-    ('quantized::linear_dynamic', datetime.date(2020, 6, 1)),
-    ('quantized::linear_relu', datetime.date(2020, 6, 1)),
-    ('quantized::linear', datetime.date(2020, 6, 1)),
+    ("profiler::_call_end_callbacks_on_jit_fut*", datetime.date(9999, 1, 1)),
+    ("profiler::_record_function_enter", datetime.date(9999, 1, 1)),
+    ("aten::append*", datetime.date(2020, 4, 15)),
+    ("aten::_min", datetime.date(2020, 9, 9)),
+    ("aten::_max", datetime.date(2020, 9, 9)),
+    ("aten::split_with_sizes", datetime.date(2020, 7, 29)),
+    ("aten::eq", datetime.date(2020, 7, 30)),
+    ("aten::log", datetime.date(2020, 7, 30)),
+    ("aten::__and__", datetime.date(2020, 7, 30)),
+    ("aten::__or__", datetime.date(2020, 7, 30)),
+    ("aten::__xor__", datetime.date(2020, 7, 30)),
+    ("aten::add", datetime.date(2020, 7, 30)),
+    ("aten::__upsample_bilinear", datetime.date(2020, 7, 30)),
+    ("aten::hash", datetime.date(2020, 7, 30)),
+    ("aten::divmod", datetime.date(2020, 7, 30)),
+    ("aten::sorted", datetime.date(2020, 7, 30)),
+    ("aten::__contains__", datetime.date(2020, 7, 30)),
+    ("aten::ne", datetime.date(2020, 7, 30)),
+    ("aten::index", datetime.date(2020, 7, 30)),
+    ("aten::isnan", datetime.date(2020, 7, 30)),
+    ("aten::pow", datetime.date(2020, 7, 30)),
+    ("aten::atan2", datetime.date(2020, 7, 30)),
+    ("aten::copy_", datetime.date(2020, 7, 30)),
+    ("aten::sort", datetime.date(2020, 7, 30)),
+    ("aten::_cudnn_init_dropout_state", datetime.date(2020, 7, 30)),
+    ("aten::sparse_coo_tensor", datetime.date(2020, 7, 30)),
+    ("aten::_sparse_coo_tensor_with_dims", datetime.date(2020, 7, 30)),
+    ("aten::_sparse_coo_tensor_with_dims_and_tensors", datetime.date(2020, 7, 30)),
+    ("aten::__lshift__", datetime.date(2020, 7, 30)),
+    ("aten::__rshift__", datetime.date(2020, 7, 30)),
+    ("aten::__round_to_zero_floordiv", datetime.date(2020, 7, 30)),
+    ("aten::gcd", datetime.date(2020, 7, 30)),
 ]
 
 
@@ -193,62 +79,67 @@ def dont_parse(schema_line):
     return False
 
 
-def check_bc(new_schema_dict):
-    existing_schemas = torch._C._jit_get_all_schemas()
-    existing_schemas += torch._C._jit_get_custom_class_schemas()
+def check_bc(existing_schemas):
+    new_schemas = torch._C._jit_get_all_schemas()
+    new_schemas += torch._C._jit_get_custom_class_schemas()
+    new_schema_dict = defaultdict(list)
+    for s in new_schemas:
+        new_schema_dict[s.name].append(s)
+
     is_bc = True
     broken_ops = []
     for existing_schema in existing_schemas:
         if allow_listed(existing_schema, allow_list):
-            print("Black list, skipping schema: ", str(existing_schema))
+            print("schema: ", str(existing_schema), " found on allowlist, skipping")
             continue
         print("processing existing schema: ", str(existing_schema))
-        new_schemas = new_schema_dict.get(existing_schema.name, [])
+        matching_new_schemas = new_schema_dict.get(existing_schema.name, [])
         found = False
-        for new_schema in new_schemas:
-            if new_schema.is_backward_compatible_with(existing_schema):
+        for matching_new_schema in matching_new_schemas:
+            if matching_new_schema.is_backward_compatible_with(existing_schema):
                 found = True
                 break
         if not found:
-            print('Can NOT find backward compatible schemas after changes '
-                  'for schema {} from the following candidates:\n[\n{}\n]'
-                  .format(
-                      str(existing_schema),
-                      "\n\t".join(str(s) for s in new_schemas)))
+            print(
+                "Can NOT find backward compatible schemas after changes "
+                "for schema {} from the following candidates:\n[\n{}\n]".format(
+                    str(existing_schema),
+                    "\n\t".join(str(s) for s in matching_new_schemas),
+                )
+            )
             # TODO Print out more details about why candidates don't match.
             broken_ops.append(str(existing_schema))
             is_bc = False
     if is_bc:
-        print('Found backward compatible schemas for all existing schemas')
+        print("Found backward compatible schemas for all existing schemas")
     else:
-        print('The PR is introducing backward incompatible changes to the '
-              'operator library. Please contact PyTorch team to confirm '
-              'whether this change is wanted or not. \n\nBroken ops: '
-              '[\n\t{}\n]'.format("\n\t".join(broken_ops)))
+        print(
+            "The PR is introducing backward incompatible changes to the "
+            "operator library. Please contact PyTorch team to confirm "
+            "whether this change is wanted or not. \n\nBroken ops: "
+            "[\n\t{}\n]".format("\n\t".join(broken_ops))
+        )
     return is_bc
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Process some integers.')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Process some integers.")
     parser.add_argument(
-        '--new-schemas',
-        help='filename to load new schemas',
+        "--existing-schemas",
+        help="filename to load existing schemas",
         type=str,
-        default='schemas.txt')
+        default="schemas.txt",
+    )
     args = parser.parse_args()
-    new_schema_dict = dict()
-    with open(args.new_schemas, 'r') as f:
+    existing_schema_dict = dict()
+    slist = []
+    with open(args.existing_schemas, "r") as f:
         while True:
             line = f.readline()
             if not line:
                 break
-            if dont_parse(line.strip()):
-                print("Not parsing schema line: ", line.strip())
-                continue
             s = parse_schema(line.strip())
-            slist = new_schema_dict.get(s.name, [])
             slist.append(s)
-            new_schema_dict[s.name] = slist
 
-    if not check_bc(new_schema_dict):
+    if not check_bc(slist):
         sys.exit(1)


### PR DESCRIPTION
instead exporting schemas using the current binary being tested, install nightly and export its schemas to use in a back-compat test run by the current binary being tested.