### PR TITLE
Make setup.py Python-2 syntactically correct

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,11 +162,14 @@
 #      When turned on, the following cmake variables will be toggled as well:
 #        USE_SYSTEM_CPUINFO=ON USE_SYSTEM_SLEEF=ON BUILD_CUSTOM_PROTOBUF=OFF
 
+from __future__ import print_function
 import sys
 if sys.version_info < (3,):
-    raise Exception("Python 2 has reached end-of-life and is no longer supported by PyTorch.")
+    print("Python 2 has reached end-of-life and is no longer supported by PyTorch.")
+    sys.exit(-1)
 if sys.platform == 'win32' and sys.maxsize.bit_length() == 31:
-    raise Exception("32-bit Windows Python runtime is not supported. Please switch to 64-bit Python.")
+    print("32-bit Windows Python runtime is not supported. Please switch to 64-bit Python.")
+    sys.exit(-1)
 
 from setuptools import setup, Extension, distutils, find_packages
 from collections import defaultdict


### PR DESCRIPTION
Import __future__ to make `print(*args)` a syntactically correct statement under Python-2
Otherwise, if once accidentally invokes setup.py using Python-2 interpreter they will be greeted by:
```
  File "setup.py", line 229
    print(*args)
          ^
SyntaxError: invalid syntax
```
instead of:
```
Python 2 has reached end-of-life and is no longer supported by PyTorch.
```

