### PR TITLE
Fix one error message format of torch.dot()

### DIFF
--- a/aten/src/ATen/native/Blas.cpp
+++ b/aten/src/ATen/native/Blas.cpp
@@ -99,10 +99,11 @@ Tensor dot(const Tensor &self, const Tensor &other){
 
   TORCH_CHECK(
       self.dim() == 1 && other.dim() == 1,
-      "1D tensors expected, got, ",
-      self.dim(), ", ",
+      "1D tensors expected, but got ",
+      self.dim(),
+      "D and ",
       other.dim(),
-      " tensors");
+      "D tensors");
 
   TORCH_CHECK(
       self.scalar_type() == other.scalar_type(),

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -349,11 +349,11 @@ Tensor dot_cuda(const Tensor& self, const Tensor& other) {
 
   TORCH_CHECK(
       self.dim() == 1 && other.dim() == 1,
-      "1D tensors expected, got, ",
+      "1D tensors expected, but got ",
       self.dim(),
-      ", ",
+      "D and ",
       other.dim(),
-      " tensors");
+      "D tensors");
   TORCH_CHECK(
       self.scalar_type() == other.scalar_type(),
       "dot : expected both vectors to have same dtype, but found ",


### PR DESCRIPTION
Summary: the error message of dot(CUDA) was copied from dot(CPU), however, they both are easy to cause confusion

Test Plan: wait for unittests

Differential Revision: D22710822

