### PR TITLE
.circleci: Make sure to install expect for docs push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1356,6 +1356,10 @@ jobs:
     - attach_workspace:
         at: /tmp/workspace
     - run:
+        name: Install expect
+        command: |
+          sudo apt-get update && sudo apt-get install -y expect
+    - run:
         name: Docs push
         command: |
           pushd /tmp/workspace

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -6,6 +6,10 @@
     - attach_workspace:
         at: /tmp/workspace
     - run:
+        name: Install expect
+        command: |
+          sudo apt-get update && sudo apt-get install -y expect
+    - run:
         name: Docs push
         command: |
           pushd /tmp/workspace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#41964 .circleci: Make sure to install expect for docs push**

Since we're not executing this in a docker container we should go ahead
an install expect explicitly

This is a follow up PR to #41871 

This should resolve issues related to failed nightly docs pushes

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D22736738](https://our.internmc.facebook.com/intern/diff/D22736738)