### PR TITLE
Add prim::EnumName and prim::EnumValue ops

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -66,6 +66,8 @@ namespace c10 {
   _(prim, ListConstruct)             \
   _(prim, ListUnpack)                \
   _(prim, DictConstruct)             \
+  _(prim, EnumName)                  \
+  _(prim, EnumValue)                 \
   _(prim, StringIndex)               \
   _(prim, NumToTensor)               \
   _(prim, Uninitialized)             \

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1145,7 +1145,7 @@ struct CAFFE2_API EnumType : public NamedType {
         AT_ERROR(
             "Cannot create Enum with value type '",
             value->str(),
-            "', only int, float, Tensor and string keys are supported");
+            "', only int, float and string are supported");
     }
   }
 

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -162,6 +162,19 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     if (auto schema = iface->getMethod(field)) {
       return std::make_shared<MethodValue>(getValue(), field);
     }
+  } else if (auto enum_type = value_->type()->cast<EnumType>()) {
+    // Handle access to Enum's `name` and `value` attribute.
+    auto& g = *m.graph();
+
+    if (field == "name") {
+      auto n = g.insertNode(g.createEnumName(value_));
+      return std::make_shared<SimpleValue>(n->output());
+    }
+
+    if (field == "value") {
+      auto n = g.insertNode(g.createEnumValue(value_));
+      return std::make_shared<SimpleValue>(n->output());
+    }
   }
 
   // none of the more-specific cases worked, so see if this is a builtin method

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1595,6 +1595,21 @@ Node* Graph::createTupleSlice(Value* tup, int64_t beg, int64_t end) {
   return n;
 }
 
+Node* Graph::createEnumName(Value* e) {
+  e->type()->expect<EnumType>();
+  assert(e->type()->cast<EnumType>());
+  auto n = create(prim::EnumName, {e});
+  n->output()->setType(StringType::get());
+  return n;
+}
+
+Node* Graph::createEnumValue(Value* e) {
+  auto enum_type = e->type()->expect<EnumType>();
+  auto n = create(prim::EnumValue, {e});
+  n->output()->setType(enum_type->getValueType());
+  return n;
+}
+
 Node* Graph::createList(const TypePtr& elem_type, at::ArrayRef<Value*> values) {
   auto n = create(prim::ListConstruct, values);
   for (const auto& v : values) {

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1115,6 +1115,8 @@ struct Graph {
       Value* idx,
       const TypePtr& output_type);
   TORCH_API Node* createTupleSlice(Value* tup, int64_t beg, int64_t end);
+  TORCH_API Node* createEnumName(Value* e);
+  TORCH_API Node* createEnumValue(Value* e);
   TORCH_API Node* createList(
       const TypePtr& elem_type,
       at::ArrayRef<Value*> values);

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -312,6 +312,34 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      Operator(
+         "prim::EnumName(AnyEnumType enum) -> str",
+         [](Stack* stack) {
+           IValue e = pop(stack);
+           push(stack, e.toEnumHolder()->name());
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
+         "prim::EnumValue.int(AnyEnumType enum) -> int",
+         [](Stack* stack) {
+           IValue e = pop(stack);
+           push(stack, e.toEnumHolder()->value());
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
+         "prim::EnumValue.float(AnyEnumType enum) -> float",
+         [](Stack* stack) {
+           IValue e = pop(stack);
+           push(stack, e.toEnumHolder()->value());
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
+         "prim::EnumValue.str(AnyEnumType enum) -> str",
+         [](Stack* stack) {
+           IValue e = pop(stack);
+           push(stack, e.toEnumHolder()->value());
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          // note the compiler knows to type TupleIndex more accurately than it
          // is listed here.
          "prim::TupleIndex(Any tup, int i) -> Any",


### PR DESCRIPTION
[2/N] Implement Enum JIT support
 
Add prim::EnumName and prim::EnumValue and their lowerings to support getting `name` and `value` attribute of Python enums.

Supported:
Enum-typed function targuments
using Enum type and comparing them
Support getting name/value attrs of enums

TODO:
Add PyThon sugared value for Enum
Support Enum-typed return values
Support enum values of different types in same Enum class
Support serialization and deserialization