### PR TITLE
Updates to Learnable Fake Quantize Module and Kernel to Correctly Calculate dX, dScale, dZeroPoint

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2061,16 +2061,16 @@ void fake_quantize_learnable_scale_grad_tensor_kernel(
   float grad_big = quant_max - zero_point;
   auto iter_scale = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per tensor version for the learnable backprop kernel on scale.
-  cpu_kernel(iter_scale, [&](float x, float dx) -> float {
+  cpu_kernel(iter_scale, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     if (xq == quant_min) {
-      return dx * grad_small;
+      return dy * grad_small;
     } else if (xq == quant_max) {
-      return dx * grad_big;
+      return dy * grad_big;
     }
     float x_fq = static_cast<float>((xq - zero_point) * scale);
-    return dx * (x_fq - x) * inv_scale;
+    return dy * (x_fq - x) * inv_scale;
   });
 }
 
@@ -2085,11 +2085,11 @@ void fake_quantize_learnable_zero_point_grad_tensor_kernel(
   float inv_scale = 1.0f / scale;
   auto iter_scale = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per tensor version for the learnable backprop kernel on zero point.
-  cpu_kernel(iter_scale, [&](float x, float dx) -> float {
+  cpu_kernel(iter_scale, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     if (xq == quant_min || xq == quant_max) {
-      return dx * (-1) * scale;
+      return dy * (-1) * scale;
     }
     return 0;
   });
@@ -2138,16 +2138,16 @@ void fake_quantize_learnable_scale_grad_channel_kernel(
   float grad_big = quant_max - zero_point;
   auto iter_scale = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per channel version for the learnable backprop kernel on scale.
-  cpu_kernel(iter_scale, [&](float x, float dx) -> float {
+  cpu_kernel(iter_scale, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     float x_fq = static_cast<float>((xq - zero_point) * scale);
     if (xq == quant_min) {
-      return dx * grad_small;
+      return dy * grad_small;
     } else if (xq == quant_max) {
-      return dx * grad_big;
+      return dy * grad_big;
     }
-    return dx * (x_fq - x) * inv_scale;
+    return dy * (x_fq - x) * inv_scale;
   });
 }
 
@@ -2162,11 +2162,11 @@ void fake_quantize_learnable_zero_point_grad_channel_kernel(
   float inv_scale = 1.0f / scale;
   auto iter_zero_point = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per channel version for the learnable backprop kernel on zero point.
-  cpu_kernel(iter_zero_point, [&](float x, float dx) -> float {
+  cpu_kernel(iter_zero_point, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     if (xq == quant_min || xq == quant_max) {
-      return dx * (-1) * scale;
+      return dy * (-1) * scale;
     }
     return 0;
   });

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -84,16 +84,16 @@ void _fake_quantize_grad_learnable_scale_tensor_kernel_cuda(
 
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       if (xq == quant_min) {
-        return dx * grad_small;
+        return dy * grad_small;
       } else if (xq == quant_max) {
-        return dx * grad_big;
+        return dy * grad_big;
       }
       float x_fq = static_cast<float>((xq - zero_point) * scale);
-      return dx * (x_fq - x) * inv_scale;
+      return dy * (x_fq - x) * inv_scale;
     });
 }
 
@@ -109,11 +109,11 @@ void _fake_quantize_grad_learnable_zero_point_tensor_kernel_cuda(
   float inv_scale = 1.0f / scale;
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       if (xq == quant_min || xq == quant_max) {
-        return dx * (-1) * scale;
+        return dy * (-1) * scale;
       }
       return 0;
     });
@@ -165,16 +165,16 @@ void _fake_quantize_grad_learnable_scale_channel_kernel_cuda(
 
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       float x_fq = static_cast<float>((xq - zero_point) * scale);
       if (xq == quant_min) {
-        return dx * grad_small;
+        return dy * grad_small;
       } else if (xq == quant_max) {
-        return dx * grad_big;
+        return dy * grad_big;
       }
-      return dx * (x_fq - x) * inv_scale;
+      return dy * (x_fq - x) * inv_scale;
     });
 }
 
@@ -190,11 +190,11 @@ void _fake_quantize_grad_learnable_zero_point_channel_kernel_cuda(
   float inv_scale = 1.0f / scale;
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       if (xq == quant_min || xq == quant_max) {
-        return dx * (-1) * scale;
+        return dy * (-1) * scale;
       }
       return 0;
     });

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -193,7 +193,7 @@ Tensor _get_rounded_zero_point(
 }
 
 std::tuple<Tensor, Tensor> _get_scale_zero_point_per_channel_iter_grads(
-    const Tensor& dX,
+    const Tensor& dY,
     const Tensor& X,
     const Tensor& scale,
     const Tensor& zero_point,
@@ -203,23 +203,23 @@ std::tuple<Tensor, Tensor> _get_scale_zero_point_per_channel_iter_grads(
 
   int64_t axis_size = X.size(axis);
   std::vector<Tensor> X_flattened = at::unbind(X, axis);
-  std::vector<Tensor> dX_flattened = at::unbind(dX, axis);
+  std::vector<Tensor> dY_flattened = at::unbind(dY, axis);
 
   Tensor dScale = at::zeros({scale.sizes()[0]});
   Tensor dZeroPoint = at::zeros({zero_point.sizes()[0]});
 
   for (int i = 0; i < X_flattened.size(); ++i) {
     Tensor X_i = X_flattened[i];
-    Tensor dX_i = dX_flattened[i];
+    Tensor dY_i = dY_flattened[i];
     auto dScale_item_vec = at::empty_like(X_i, X_i.options(), MemoryFormat::Preserve);
     auto dZeroPoint_item_vec = at::empty_like(X_i, X_i.options(), MemoryFormat::Preserve);
 
     float scale_i = scale[i].item<float>();
     int64_t zero_point_i = static_cast<int64_t>(std::min(std::max(zero_point[i].item<float>() + 0.5f, quant_min), quant_max));
     fake_quant_grad_learnable_scale_channel_stub(
-      scale.device().type(), dScale_item_vec, X_i, dX_i, scale_i, zero_point_i, quant_min, quant_max);
+      scale.device().type(), dScale_item_vec, X_i, dY_i, scale_i, zero_point_i, quant_min, quant_max);
     fake_quant_grad_learnable_zero_point_channel_stub(
-      zero_point.device().type(), dZeroPoint_item_vec, X_i, dX_i, scale_i, zero_point_i, quant_min, quant_max);
+      zero_point.device().type(), dZeroPoint_item_vec, X_i, dY_i, scale_i, zero_point_i, quant_min, quant_max);
     float scale_item = dScale_item_vec.sum().unsqueeze(0).item<float>();
     float zero_point_item = dZeroPoint_item_vec.sum().unsqueeze(0).item<float>();
 
@@ -310,7 +310,7 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_channel_affine_b
   fake_quant_grad_per_channel_stub(iter_X.device_type(), iter_X, quant_min, quant_max);
 
   std::tuple<Tensor, Tensor> dScaleZeroPoints = native::_get_scale_zero_point_per_channel_iter_grads(
-    dX, X, scale, zero_point, axis, quant_min, quant_max);
+    dY, X, scale, zero_point, axis, quant_min, quant_max);
 
   Tensor dScale = std::get<0>(dScaleZeroPoints).to(scale.device());
   Tensor dZeroPoint = std::get<1>(dScaleZeroPoints).to(zero_point.device());

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -169,11 +169,11 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_tensor_affine_ba
 
   auto dScale_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
   fake_quant_grad_learnable_scale_tensor_stub(
-    scale.device().type(), dScale_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+    scale.device().type(), dScale_vec, X, dY, scale_val, zero_point_val, quant_min, quant_max);
 
   auto dZeroPoint_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
   fake_quant_grad_learnable_zero_point_tensor_stub(
-    zero_point.device().type(), dZeroPoint_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+    zero_point.device().type(), dZeroPoint_vec, X, dY, scale_val, zero_point_val, quant_min, quant_max);
 
   // The total sums over the scale and zero point gradient vectors are what will be returned in the end.
   auto dScale = dScale_vec.sum().unsqueeze(0).to(scale.device());

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -15,6 +15,12 @@ from torch.quantization import (
     get_observer_dict,
     prepare,
 )
+
+from torch.quantization._learnable_fake_quantize import (
+    _LearnableFakeQuantizePerTensorOp,
+    _LearnableFakeQuantizePerChannelOp,
+)
+
 import torch.nn as nn
 
 # Standard library
@@ -64,7 +70,8 @@ def _fake_quantize_learnable_per_tensor_affine_grad_reference(dY, X, scale, zero
     - https://arxiv.org/pdf/1903.08066.pdf
     """
     zero_point_rounded = int((zero_point + 0.5).clamp(quant_min, quant_max).item())
-    Xq = torch.round(X * (1.0 / scale) + zero_point_rounded).clamp(quant_min, quant_max)
+    Xq_unclamped = torch.round(X * (1.0 / scale) + zero_point_rounded)
+    Xq = Xq_unclamped.clamp(quant_min, quant_max)
     Xfq = (Xq - zero_point_rounded) * scale
 
     indicate_small_scale = (Xq == quant_min).float().to(device)
@@ -73,26 +80,28 @@ def _fake_quantize_learnable_per_tensor_affine_grad_reference(dY, X, scale, zero
         indicate_small_scale - indicate_big_scale
 
     indicate_saturate_zp = ((Xq == quant_min).float() + (Xq == quant_max).float()).to(device)
-    indicate_unsaturate_zp = torch.ones(indicate_saturate_zp.shape).to(device) - indicate_saturate_zp
+    indicate_unsaturate_zp = torch.ones(indicate_saturate_zp.shape, device=device) - indicate_saturate_zp
 
-    grad_small_scale = quant_min - zero_point_rounded
-    grad_big_scale = quant_max - zero_point_rounded
-    grad_middle_scale = ((Xfq - X) / scale).to(device)
+    dScale_small = quant_min - zero_point_rounded
+    dScale_big = quant_max - zero_point_rounded
+    dScale_middle = ((Xfq - X) / scale).to(device)
 
-    grad_saturate_zp = -scale.to(device)
-    grad_unsaturate_zp = 0
+    dZeroPoint_saturate = -scale.to(device)
+    dZeroPoint_unsaturate = 0
 
-    grad_scale = indicate_small_scale * grad_small_scale + \
-        indicate_big_scale * grad_big_scale + \
-        indicate_middle_scale * grad_middle_scale
-    grad_zp = indicate_saturate_zp * grad_saturate_zp + \
-        indicate_unsaturate_zp * grad_unsaturate_zp
-    grad_X = _fake_quantize_per_tensor_affine_grad_reference(
-        dY, X, scale, zero_point, quant_min, quant_max).to(device)
+    dX_mask = (Xq_unclamped >= quant_min) * (Xq_unclamped <= quant_max)
+    dX = torch.zeros_like(dY, device=device)
+    dX[dX_mask] = dY[dX_mask]
 
-    grad_scale = (grad_scale * grad_X).sum().unsqueeze(dim=0)
-    grad_zp = (grad_zp * grad_X).sum().unsqueeze(dim=0)
-    return grad_X, grad_scale, grad_zp
+    dScale = indicate_small_scale * dScale_small + \
+        indicate_big_scale * dScale_big + \
+        indicate_middle_scale * dScale_middle
+    dZeroPoint = indicate_saturate_zp * dZeroPoint_saturate + \
+        indicate_unsaturate_zp * dZeroPoint_unsaturate
+
+    dScale = (dScale * dY).sum().unsqueeze(dim=0)
+    dZeroPoint = (dZeroPoint * dY).sum().unsqueeze(dim=0)
+    return dX, dScale, dZeroPoint
 
 # Helper function used to simulate per-channel fake-quant against any axis
 def _permute_to_axis_zero(X, axis):
@@ -113,6 +122,18 @@ def _fake_quantize_per_channel_affine_reference(X, per_channel_scale, per_channe
 
     out = res.permute(tuple(permute_axis_list))
     return out
+
+# Reference method for the forward path of the learnable fake quantize per channel operator
+def _fake_quantize_learnable_per_channel_affine_reference(X, per_channel_scale, per_channel_zero_point, axis, quant_min, quant_max):
+    axis_mask = [1] * X.ndim
+    axis_mask[axis] = X.shape[axis]
+
+    scale_vec = per_channel_scale.detach().type(torch.float32)
+    zp_vec = ((per_channel_zero_point.detach() + 0.5).clamp(quant_min, quant_max)).type(torch.int64)
+
+    scale_remasked = scale_vec.reshape(axis_mask)
+    zp_remasked = zp_vec.reshape(axis_mask)
+    return ((X / scale_remasked + zp_remasked).round().clamp(quant_min, quant_max) - zp_remasked) * scale_remasked
 
 # Reference method for the gradient of the fake quantize operator
 def _fake_quantize_per_channel_affine_grad_reference(dY, X, per_channel_scale, per_channel_zero_point, axis, quant_min, quant_max):
@@ -139,60 +160,52 @@ def _fake_quantize_learnable_per_channel_affine_grad_reference(
     """
     grad_X = _fake_quantize_per_channel_affine_grad_reference(
         dY, X, per_channel_scale, per_channel_zero_point, axis, quant_min, quant_max).to(device)
-    per_channel_scale = per_channel_scale.detach().type(torch.float)
-    per_channel_zero_point = ((per_channel_zero_point.detach() + 0.5).clamp(quant_min, quant_max)).type(torch.int64)
 
-    Xq = torch.stack([
-        _quantize_per_tensor(
-            X_i, per_channel_scale[i], per_channel_zero_point[i], quant_min, quant_max) for i, X_i in
-        enumerate(torch.unbind(X, dim=axis), 0)
-    ], dim=axis)
-    Xfq = _fake_quantize_per_channel_affine_reference(
-        X, per_channel_scale, per_channel_zero_point, axis, quant_min, quant_max)
+    axis_mask = [1] * X.ndim
+    axis_mask[axis] = X.shape[axis]
 
-    grad_scale = torch.zeros([per_channel_scale.size(0)]).to(device)
-    grad_zero_point = torch.zeros([per_channel_zero_point.size(0)]).to(device)
+    scale_vec = per_channel_scale.detach().type(torch.float32).reshape(axis_mask)
+    zp_vec = ((per_channel_zero_point.detach() + 0.5).clamp(quant_min, quant_max)).type(torch.int64).reshape(axis_mask)
 
-    Xfq_flattened = torch.unbind(Xfq, dim=axis)
-    X_flattened = torch.unbind(X, dim=axis)
-    grad_X_flattened = torch.unbind(grad_X, dim=axis)
+    scale_remasked = scale_vec.reshape(axis_mask).to(device)
+    zp_remasked = zp_vec.reshape(axis_mask).to(device)
+    Xq = (X / scale_remasked + zp_remasked).round().to(device)
 
-    for i, Xq_i in enumerate(torch.unbind(Xq, dim=axis), 0):
-        indicate_small_scale_i = (Xq_i == quant_min).float().to(device)
-        indicate_big_scale_i = (Xq_i == quant_max).float().to(device)
-        indicate_middle_scale_i = torch.ones(indicate_small_scale_i.shape).to(device) - \
-            indicate_small_scale_i - indicate_big_scale_i
+    dX_mask = (Xq >= quant_min) * (Xq <= quant_max)
+    dX = torch.zeros_like(dY, device=device)
+    dX[dX_mask] = dY[dX_mask]
 
-        indicate_saturate_zp_i = ((Xq_i == quant_min).float() +
-                                  (Xq_i == quant_max).float()).to(device)
-        indicate_unsaturate_zp_i = torch.ones(indicate_saturate_zp_i.shape).to(device) - \
-            indicate_saturate_zp_i
+    Xq = Xq.clamp(quant_min, quant_max)
+    Xfq = (Xq - zp_vec) * scale_vec
+    indicate_small_scale = (Xq == quant_min).float().to(device)
+    indicate_big_scale = (Xq == quant_max).float().to(device)
+    indicate_middle_scale = torch.ones(indicate_small_scale.shape).to(device) - \
+        indicate_small_scale - indicate_big_scale
 
-        scale_i = per_channel_scale[i]
-        zero_point_i = per_channel_zero_point[i]
-        Xfq_i = Xfq_flattened[i]
-        X_i = X_flattened[i]
-        grad_X_i = grad_X_flattened[i]
+    indicate_saturate_zp = ((Xq == quant_min).float() + (Xq == quant_max).float()).to(device)
+    indicate_unsaturate_zp = torch.ones(indicate_saturate_zp.shape, device=device) - indicate_saturate_zp
 
-        grad_small_scale_i = quant_min - zero_point_i
-        grad_big_scale_i = quant_max - zero_point_i
-        grad_middle_scale_i = ((Xfq_i - X_i) / scale_i).to(device)
+    dScale_small = quant_min - zp_vec
+    dScale_big = quant_max - zp_vec
+    dScale_middle = ((Xfq - X) / scale_vec).to(device)
 
-        grad_saturate_zp_i = -scale_i.to(device)
-        grad_unsaturate_zp_i = 0
+    dZeroPoint_saturate = -scale_vec.to(device)
+    dZeroPoint_unsaturate = 0
 
-        grad_scale_i = indicate_small_scale_i * grad_small_scale_i + \
-            indicate_middle_scale_i * grad_middle_scale_i + \
-            indicate_big_scale_i * grad_big_scale_i
-        grad_zp_i = indicate_saturate_zp_i * grad_saturate_zp_i + \
-            indicate_unsaturate_zp_i * grad_unsaturate_zp_i
+    dScale = indicate_small_scale * dScale_small + \
+        indicate_big_scale * dScale_big + \
+        indicate_middle_scale * dScale_middle
+    dZeroPoint = indicate_saturate_zp * dZeroPoint_saturate + \
+        indicate_unsaturate_zp * dZeroPoint_unsaturate
 
-        grad_scale_i = (grad_scale_i * grad_X_i).sum().unsqueeze(dim=0)
-        grad_zp_i = (grad_zp_i * grad_X_i).sum().unsqueeze(dim=0)
+    axis_for_reduction = set(range(Xfq.ndim))
+    axis_for_reduction.remove(axis)
+    axis_for_reduction = tuple(axis_for_reduction)
 
-        grad_scale[i] = grad_scale_i
-        grad_zero_point[i] = grad_zp_i
-    return grad_X, grad_scale, grad_zero_point
+    dScale = (dScale * dY).sum(axis_for_reduction).to(device)
+    dZeroPoint = (dZeroPoint * dY).sum(axis_for_reduction).to(device)
+
+    return dX, dScale, dZeroPoint
 
 def to_tensor(X, device):
     return torch.tensor(X).to(device=torch.device(device), dtype=torch.float32)
@@ -558,6 +571,71 @@ class TestFakeQuantizePerTensor(TestCase):
             dout, X, scale, zero_point, quant_min, quant_max)
         Y_prime.backward(dout)
         np.testing.assert_allclose(dX.cpu(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
+
+
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
+           X=hu.tensor(shapes=hu.array_shapes(1, 5,),
+                       elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+                       qparams=hu.qparams(dtypes=torch.quint8)))
+    def test_learnable_py_module_forward_per_tensor(self, device, X):
+        r"""Tests the forward path of the _LearnableFakeQuantize module per tensor op.
+        """
+        X, (scale, zero_point, torch_type) = X
+        scale = torch.tensor([scale]).to(device)
+        zero_point = torch.tensor([zero_point]).to(device)
+        quant_min = torch.iinfo(torch_type).min
+        quant_max = torch.iinfo(torch_type).max
+
+        X = to_tensor(X, device)
+        Y = _fake_quantize_per_tensor_affine_reference(
+            X, scale, zero_point, quant_min, quant_max).to(device)
+        Y_prime = _LearnableFakeQuantizePerTensorOp.apply(
+            X, scale, zero_point, quant_min, quant_max, 1.).to(device)
+        self.assertTrue(
+            torch.allclose(Y, Y_prime, rtol=tolerance, atol=tolerance),
+            "Expected _LearnableFakeQuantizePerTensorOp to have results match the reference forward function")
+
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
+           X=hu.tensor(shapes=hu.array_shapes(1, 5,),
+                       elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+                       qparams=hu.qparams(dtypes=torch.quint8)))
+    def test_learnable_py_module_backward_per_tensor(self, device, X):
+        X, (scale, zero_point, torch_type) = X
+        scale = torch.tensor([scale]).float().to(device)
+        zero_point = torch.tensor([zero_point]).float().to(device)
+        quant_min = torch.iinfo(torch_type).min
+        quant_max = torch.iinfo(torch_type).max
+
+        X = to_tensor(X, device)
+        X.requires_grad_()
+        scale.requires_grad_()
+        zero_point.requires_grad_()
+        Y_prime = _LearnableFakeQuantizePerTensorOp.apply(
+            X, scale, zero_point, quant_min, quant_max, 1.)
+        dout = torch.rand(X.shape, dtype=torch.float).to(device)
+        dX, dScale, dZeroPoint = _fake_quantize_learnable_per_tensor_affine_grad_reference(
+            dout, X, scale, zero_point, quant_min, quant_max, device)
+        Y_prime.backward(dout)
+
+        expected_dX = dX.to(device).detach()
+        actual_dX = X.grad.to(device).detach()
+        expected_dScale = dScale.to(device).detach()
+        actual_dScale = scale.grad.to(device).detach()
+        expected_dZeroPoint = dZeroPoint.to(device).detach()
+        actual_dZeroPoint = zero_point.grad.to(device).detach()
+
+        self.assertTrue(
+            torch.allclose(
+                expected_dX, actual_dX, rtol=tolerance, atol=tolerance),
+            "Expected dX to match X.grad")
+        self.assertTrue(
+            torch.allclose(
+                expected_dScale, actual_dScale, rtol=tolerance, atol=tolerance),
+            "Expected dScale to match scale.grad")
+        self.assertTrue(
+            torch.allclose(
+                expected_dZeroPoint, actual_dZeroPoint, rtol=tolerance, atol=tolerance),
+            "Expected dZeroPoint to match zero_point.grad")
 
     def _test_learnable_forward_per_tensor(self, X, device, scale_base, zero_point_base):
         X_base = torch.tensor(X).to(device)
@@ -949,7 +1027,7 @@ class TestFakeQuantizePerChannel(TestCase):
                 torch.allclose(dZeroPoint_expected, dZeroPoint_actual, rtol=tolerance, atol=tolerance),
                 "Expected dZeroPoint to match zero_point.grad")
 
-    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(2, 5,),
                                    qparams=hu.qparams(dtypes=torch.quint8)))
     def test_learnable_backward_per_channel_cpu(self, X):
         torch.random.manual_seed(NP_RANDOM_SEED)
@@ -961,7 +1039,7 @@ class TestFakeQuantizePerChannel(TestCase):
         self._test_learnable_backward_per_channel(
             X_base, 'cpu', scale_base, zero_point_base, axis)
 
-    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(2, 5,),
                                    qparams=hu.qparams(dtypes=torch.quint8)))
     @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
     def test_learnable_backward_per_channel_cuda(self, X):
@@ -973,6 +1051,75 @@ class TestFakeQuantizePerChannel(TestCase):
         zero_point_base = torch.normal(mean=0, std=128, size=(channel_size,))
         self._test_learnable_backward_per_channel(
             X_base, 'cuda', scale_base, zero_point_base, axis)
+
+
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
+           X=hu.per_channel_tensor(shapes=hu.array_shapes(2, 5,),
+                                   elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+                                   qparams=hu.qparams(dtypes=torch.quint8)))
+    def test_learnable_py_module_forward_per_channel(self, device, X):
+        r"""Tests the forward path of the _LearnableFakeQuantizePerChannel op.
+        """
+        X, (scale, zero_point, axis, torch_type) = X
+        quant_min = torch.iinfo(torch_type).min
+        quant_max = torch.iinfo(torch_type).max
+
+        X = to_tensor(X, device)
+        scale = to_tensor(scale, device)
+        zero_point = torch.tensor(zero_point).to(dtype=torch.int64, device=device)
+        Y = _fake_quantize_learnable_per_channel_affine_reference(
+            X, scale, zero_point, axis, quant_min, quant_max).to(device)
+        Y_prime = _LearnableFakeQuantizePerChannelOp.apply(
+            X, scale, zero_point, axis, quant_min, quant_max, 1.).to(device)
+        self.assertTrue(
+            torch.allclose(Y, Y_prime, rtol=tolerance, atol=tolerance),
+            "Expected _LearnableFakeQuantizePerChannelOp to have results match the reference forward function" +
+            "Y: {}, Y_prime: {}, X: {}, scale: {}, zero_point: {}".format(Y, Y_prime, X, scale, zero_point))
+
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
+           X=hu.per_channel_tensor(shapes=hu.array_shapes(2, 5,),
+                                   elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+                                   qparams=hu.qparams(dtypes=torch.quint8)))
+    def test_learnable_py_module_backward_per_channel(self, device, X):
+        r"""Tests the forward path of the _LearnableFakeQuantizePerChannel op.
+        """
+        X, (scale, zero_point, axis, torch_type) = X
+        quant_min = torch.iinfo(torch_type).min
+        quant_max = torch.iinfo(torch_type).max
+
+        X = to_tensor(X, device).float()
+        X.requires_grad_()
+        scale = to_tensor(scale, device).float()
+        scale.requires_grad_()
+        zero_point = torch.tensor(zero_point).to(device).float()
+        zero_point.requires_grad_()
+
+        Y_prime = _LearnableFakeQuantizePerChannelOp.apply(
+            X, scale, zero_point, axis, quant_min, quant_max, 1.).to(device)
+
+        dout = torch.rand(X.shape, dtype=torch.float).to(device)
+        dX, dScale, dZeroPoint = _fake_quantize_learnable_per_channel_affine_grad_reference(
+            dout, X, scale, zero_point, axis, quant_min, quant_max, device)
+        Y_prime.backward(dout)
+
+        dX_expected = dX.to(device).detach()
+        dX_actual = X.to(device).grad.detach()
+        dScale_expected = dScale.to(device).detach()
+        dScale_actual = scale.to(device).grad.detach()
+        dZeroPoint_expected = dZeroPoint.to(device).detach()
+        dZeroPoint_actual = zero_point.to(device).grad.detach()
+
+        self.assertTrue(
+            torch.allclose(dX_expected, dX_actual, rtol=tolerance, atol=tolerance),
+            "Expected dX to match X.grad")
+        self.assertTrue(
+            torch.allclose(dScale_expected, dScale_actual, rtol=tolerance, atol=tolerance),
+            "Expected dScale to match scale.grad" +
+            "Expected: {}, Actual: {}, X: {}, scale: {}, zero_point: {}"
+            .format(dScale_expected, dScale_actual, X, scale, zero_point))
+        self.assertTrue(
+            torch.allclose(dZeroPoint_expected, dZeroPoint_actual, rtol=tolerance, atol=tolerance),
+            "Expected dZeroPoint to match zero_point.grad")
 
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),

--- a/torch/quantization/_learnable_fake_quantize.py
+++ b/torch/quantization/_learnable_fake_quantize.py
@@ -5,22 +5,40 @@ import torch.nn as nn
 from torch.nn.parameter import Parameter
 
 
-def _quantize(x, scale, zp, q_min, q_max):
-    r"""Reference function for quantizing x.
+def _quantize(x, scale, zp):
+    r"""Reference function for quantizing x (non-clamped).
     """
-    return ((x / scale) + zp).round().clamp(q_min, q_max)
+    return (x * (1.0 / scale) + zp).round()
 
-def _quantize_vectorized(x, ch_axis, scale, zp, q_min, q_max):
-    r"""Reference function for quantizing a vectorized vesion of x;
+def _quantize_vectorized(x, ch_axis, scale, zp):
+    r"""Reference function for quantizing a vectorized vesion of x (non_clamped);
     applies to per channel fake quantization.
     """
     axis_mask = [1] * x.ndim
     axis_mask[ch_axis] = x.shape[ch_axis]
     scale_remasked = scale.reshape(axis_mask)
     zp_remasked = zp.reshape(axis_mask)
-    return (x / scale_remasked + zp_remasked).round().clamp(q_min, q_max)
+    return (x / scale_remasked + zp_remasked).round()
 
-def _calculate_scale_grad(grad_X, X, X_fq, X_q, scale, zero_point, q_min, q_max):
+def _calculate_X_grad(dY, Xq, q_min, q_max):
+    r"""Reference function for calculating the gradient per tensor for the input.
+    The gradient for input is calculated as below.
+
+    Let Xq be the quantized version of X (clamped at qmin and qmax).
+
+    :math:
+        \frac{dy}{dx} =
+            \begin{cases}
+                dy& \text{ if } q_{\min} \le X_q \le q_{\max} \\
+                0& \text{ else }
+            \end{cases}
+    """
+    mask = (Xq >= q_min) * (Xq <= q_max)
+    dX = torch.zeros_like(dY)
+    dX[mask] = dY[mask]
+    return dX
+
+def _calculate_scale_grad(dY, X, X_fq, X_q, scale, zero_point, q_min, q_max, grad_factor, device):
     r"""Reference function for calculating the gradient for scale.
     The gradient for scale is calculated as below:
 
@@ -29,29 +47,29 @@ def _calculate_scale_grad(grad_X, X, X_fq, X_q, scale, zero_point, q_min, q_max)
     Let Delta and z be the scale and the zero point.
 
     :math:
-        \frac{d\Delta }{dx} =
+        \frac{dy}{d\Delta} =
             \begin{cases}
                 q_{\min} - z& \text{ if } X_q= q_{\min} \\
                 q_{\max} - z& \text{ if } X_q= q_{\max} \\
                 (X_{fq} - X) / \Delta & \text{ else }
             \end{cases}
     """
-    indicate_small_scale = (X_q == q_min).float()
-    indicate_big_scale = (X_q == q_max).float()
-    indicate_middle_scale = torch.ones(indicate_small_scale.shape) - \
+    indicate_small_scale = (X_q == q_min).float().to(device)
+    indicate_big_scale = (X_q == q_max).float().to(device)
+    indicate_middle_scale = torch.ones(indicate_small_scale.shape, device=device) - \
         indicate_small_scale - indicate_big_scale
 
-    grad_small_scale = q_min - zero_point
-    grad_big_scale = q_max - zero_point
-    grad_middle_scale = (X_fq - X) / scale
+    dScale_small = q_min - zero_point
+    dScale_big = q_max - zero_point
+    dScale_middle = (X_fq - X) / scale
 
-    grad_scale = indicate_small_scale * grad_small_scale + \
-        indicate_big_scale * grad_big_scale + \
-        indicate_middle_scale * grad_middle_scale
+    dScale = indicate_small_scale * dScale_small + \
+        indicate_big_scale * dScale_big + \
+        indicate_middle_scale * dScale_middle
 
-    return grad_scale * grad_X
+    return dScale * dY * grad_factor
 
-def _calculate_zero_point_grad(grad_X, X, X_fq, X_q, scale, zero_point, q_min, q_max):
+def _calculate_zero_point_grad(dY, X, X_fq, X_q, scale, zero_point, q_min, q_max, grad_factor, device):
     r"""Reference function for calculating the gradient for zero point.
     The gradient for zero point is calculated as below:
 
@@ -60,23 +78,23 @@ def _calculate_zero_point_grad(grad_X, X, X_fq, X_q, scale, zero_point, q_min, q
     Let Delta and z be the scale and the zero point.
 
     :math:
-        \frac{dz }{dx} =
+        \frac{dy}{dz} =
             \begin{cases}
                 -\Delta& \text{ if } X_q= q_{\min} \text{ or } X_q = q_{\max} \\
                 0 & \text{ else }
             \end{cases}
     """
-    indicate_saturate_zp = (X_q == q_min).float() + (X_q == q_max).float()
-    indicate_unsaturate_zp = torch.ones(indicate_saturate_zp.shape) - \
+    indicate_saturate_zp = ((X_q == q_min).float() + (X_q == q_max).float()).to(device)
+    indicate_unsaturate_zp = torch.ones(indicate_saturate_zp.shape, device=device) - \
         indicate_saturate_zp
 
-    grad_saturate_zp = -scale
-    grad_unsaturate_zp = 0
+    dZeroPoint_saturate = -scale
+    dZeroPoint_unsaturate = 0
 
-    grad_zp = indicate_saturate_zp * grad_saturate_zp + \
-        indicate_unsaturate_zp * grad_unsaturate_zp
+    dZeroPoint = indicate_saturate_zp * dZeroPoint_saturate + \
+        indicate_unsaturate_zp * dZeroPoint_unsaturate
 
-    return grad_zp * grad_X
+    return dZeroPoint * dY * grad_factor
 
 class _LearnableFakeQuantizePerTensorOp(torch.autograd.Function):
     r"""A helper class to perform the necessary per tensor fake quantization on
@@ -98,22 +116,23 @@ class _LearnableFakeQuantizePerTensorOp(torch.autograd.Function):
         return X_fq
 
     @staticmethod
-    def backward(ctx, grad_X):
+    def backward(ctx, dY):
         X, scale, zero_point = ctx.saved_tensors
+        device = X.device
+        dY = dY.to(device)
         q_min, q_max, X_fq, grad_factor = ctx.other
-
         zero_point = int((zero_point + 0.5).clamp(q_min, q_max).item())
-        X_q = _quantize(X, scale, zero_point, q_min, q_max)
 
-        grad_scale = _calculate_scale_grad(
-            grad_X, X, X_fq, X_q, scale, zero_point, q_min, q_max).sum().unsqueeze(0)
-        grad_zp = _calculate_zero_point_grad(
-            grad_X, X, X_fq, X_q, scale, zero_point, q_min, q_max).sum().unsqueeze(0)
+        X_q = _quantize(X, scale, zero_point).to(device)
+        dX = _calculate_X_grad(dY, X_q, q_min, q_max).to(device)
 
-        grad_scale *= grad_factor
-        grad_zp *= grad_factor
+        X_q = X_q.clamp(q_min, q_max)
+        dScale = _calculate_scale_grad(
+            dY, X, X_fq, X_q, scale, zero_point, q_min, q_max, grad_factor, device).sum().unsqueeze(0)
+        dZeroPoint = _calculate_zero_point_grad(
+            dY, X, X_fq, X_q, scale, zero_point, q_min, q_max, grad_factor, device).sum().unsqueeze(0)
 
-        return grad_X, grad_scale, grad_zp, None, None, None
+        return dX, dScale, dZeroPoint, None, None, None
 
 
 class _LearnableFakeQuantizePerChannelOp(torch.autograd.Function):
@@ -132,37 +151,32 @@ class _LearnableFakeQuantizePerChannelOp(torch.autograd.Function):
         return X_fq
 
     @staticmethod
-    def backward(ctx, grad_X):
+    def backward(ctx, dY):
         X, scale, zero_point = ctx.saved_tensors
+        device = X.device
+        dY = dY.to(device)
         q_min, q_max, X_fq, ch_axis, grad_factor = ctx.other
 
         axis_mask = [1] * X.ndim
         axis_mask[ch_axis] = X.shape[ch_axis]
 
-        scale_vec = scale.detach().type(torch.float32)
-        zp_vec = ((zero_point.detach() + 0.5).clamp(q_min, q_max)).type(torch.int64)
+        scale_vec = scale.detach().type(torch.float32).reshape(axis_mask).to(device)
+        zp_vec = ((zero_point.detach() + 0.5).clamp(q_min, q_max)).type(torch.int64).reshape(axis_mask).to(device)
 
-        grad_scale = torch.zeros([scale_vec.size(0)])
-        grad_zp = torch.zeros([zp_vec.size(0)])
-
-        scale_vec = scale_vec.reshape(axis_mask)
-        zp_vec = zp_vec.reshape(axis_mask)
-
-        X_q = _quantize_vectorized(X, ch_axis, scale_vec, zp_vec, q_min, q_max)
+        X_q = _quantize_vectorized(X, ch_axis, scale_vec, zp_vec).to(device)
+        dX = _calculate_X_grad(dY, X_q, q_min, q_max).to(device)
 
         axis_for_reduction = set(range(X_fq.ndim))
         axis_for_reduction.remove(ch_axis)
         axis_for_reduction = tuple(axis_for_reduction)
 
-        grad_scale = _calculate_scale_grad(
-            grad_X, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max).sum(axis_for_reduction)
-        grad_zp = _calculate_zero_point_grad(
-            grad_X, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max).sum(axis_for_reduction)
+        X_q = X_q.clamp(q_min, q_max)
+        dScale = _calculate_scale_grad(
+            dY, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max, grad_factor, device).sum(axis_for_reduction)
+        dZeroPoint = _calculate_zero_point_grad(
+            dY, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max, grad_factor, device).sum(axis_for_reduction)
 
-        grad_scale *= grad_factor
-        grad_zp *= grad_factor
-
-        return grad_X, grad_scale, grad_zp, None, None, None, None
+        return dX, dScale, dZeroPoint, None, None, None, None
 
 
 class _LearnableFakeQuantize(nn.Module):


### PR DESCRIPTION
Summary: In this diff, naming and expressions are corrected to reflect the proper way of calculating gradients during the backpropagation process for the learnable fake quantizer. Specifically, for a received gradient dY, this diff fixes an issue in the past where dScale and dZeroPoint rely not directly on dY but on dX, and dX is passed through directly as dY.

Test Plan:
To test the correctness of the updated learnable fake quantize module/kernel, on a devvm, use the following command:
```
buck test //caffe2/test:quantization -- test_learnable
```

Differential Revision: D22715468

