### PR TITLE
Updates torch.tensor, torch.as_tensor, and sparse ctors to use the device of inputs tensors they're given, by default

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1973,35 +1973,28 @@ class TestSparse(TestCase):
     @cuda_only
     def test_factory_device_type_inference(self):
         # both indices/values are CUDA
-        shape = (1, 3)
-        for indices_device in ['cuda', 'cpu']:
-            for values_device in ['cuda', 'cpu']:
-                for sparse_device in ['cuda', 'cpu', None]:
-                    for test_empty_tensor in [True, False]:
-                        if test_empty_tensor:
-                            if indices_device != values_device and sparse_device is None:
-                                with self.assertRaises(RuntimeError):
-                                    torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
-                                                            self.value_empty(1, 0).to(values_device),
-                                                            (1, 3, 0), device=sparse_device)
-                                continue
-                            else:
-                                t = torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
-                                                            self.value_empty(1, 0).to(values_device),
-                                                            (1, 3, 0), device=sparse_device)
-                        else:
-                            if indices_device != values_device and sparse_device is None:
-                                with self.assertRaises(RuntimeError):
-                                    torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
-                                                            self.value_empty(1, 0).to(values_device),
-                                                            (1, 3, 0), device=sparse_device)
-                                continue
-                            else:
-                                t = torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
-                                                            torch.tensor([1.], device=values_device),
-                                                            (1, 3), device=sparse_device)
-                        should_be_cuda = sparse_device == 'cuda' or (sparse_device is None and values_device == 'cuda')
-                        self.assertEqual(should_be_cuda, t.is_cuda)
+
+        cpu_cuda = ('cpu', 'cuda')
+        cpu_cuda_none = cpu_cuda + (None,)
+        for indices_device, values_device, device in itertools.product(cpu_cuda,
+                                                                       cpu_cuda,
+                                                                       cpu_cuda_none):
+            indices = torch.tensor(([0], [2]), device=indices_device)
+            values = torch.tensor([1.], device=values_device)
+            empty_values = self.value_empty(1, 0).to(values_device)
+            shape = (1, 3)
+            empty_shape = (1, 3, 0)
+            if device is None and indices_device != values_device:
+                with self.assertRaises(RuntimeError):
+                    torch.sparse_coo_tensor(indices, values, shape, device=device)
+                with self.assertRaises(RuntimeError):
+                    torch.sparse_coo_tensor(indices, empty_values, empty_shape, device=device)
+            else:
+                t = torch.sparse_coo_tensor(indices, values, shape, device=device)
+                t_empty = torch.sparse_coo_tensor(indices, empty_values, empty_shape, device=device)
+                should_be_cuda = (device == 'cuda' or (device is None and values_device == 'cuda'))
+                self.assertEqual(should_be_cuda, t.is_cuda)
+                self.assertEqual(t.is_cuda, t_empty.is_cuda)
 
     @cpu_only
     def test_factory_copy(self):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1979,13 +1979,27 @@ class TestSparse(TestCase):
                 for sparse_device in ['cuda', 'cpu', None]:
                     for test_empty_tensor in [True, False]:
                         if test_empty_tensor:
-                            t = torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
-                                                        self.value_empty(1, 0).to(values_device),
-                                                        (1, 3, 0), device=sparse_device)
+                            if indices_device != values_device and sparse_device is None:
+                                with self.assertRaises(RuntimeError):
+                                    torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
+                                                            self.value_empty(1, 0).to(values_device),
+                                                            (1, 3, 0), device=sparse_device)
+                                continue
+                            else:
+                                t = torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
+                                                            self.value_empty(1, 0).to(values_device),
+                                                            (1, 3, 0), device=sparse_device)
                         else:
-                            t = torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
-                                                        torch.tensor([1.], device=values_device),
-                                                        (1, 3), device=sparse_device)
+                            if indices_device != values_device and sparse_device is None:
+                                with self.assertRaises(RuntimeError):
+                                    torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
+                                                            self.value_empty(1, 0).to(values_device),
+                                                            (1, 3, 0), device=sparse_device)
+                                continue
+                            else:
+                                t = torch.sparse_coo_tensor(torch.tensor(([0], [2]), device=indices_device),
+                                                            torch.tensor([1.], device=values_device),
+                                                            (1, 3), device=sparse_device)
                         should_be_cuda = sparse_device == 'cuda' or (sparse_device is None and values_device == 'cuda')
                         self.assertEqual(should_be_cuda, t.is_cuda)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5497,6 +5497,32 @@ def add_neg_dim_tests():
 class TestTorchDeviceType(TestCase):
     exact_dtype = True
 
+    def test_tensor_ctor_device_inference(self, device):
+        torch_device = torch.device(device)
+        values = torch.tensor((1, 2, 3), device=device)
+
+        # Tests tensor (suppresses warnings)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertEqual(torch.tensor(values).device, torch_device)
+            self.assertEqual(torch.tensor(values, dtype=torch.float64).device, torch_device)
+
+        # Tests as_tensor
+        self.assertEqual(torch.as_tensor(values).device, torch_device)
+        self.assertEqual(torch.as_tensor(values, dtype=torch.float64).device, torch_device)
+
+        # Tests sparse ctor
+        indices = torch.tensor([[0, 1, 1],
+                                [2, 0, 1],
+                                [2, 1, 0]], device=device)
+        sparse_size = (3, 3, 3)
+
+        sparse_default = torch.sparse_coo_tensor(indices, values, sparse_size)
+        self.assertEqual(sparse_default.device, torch_device)
+
+        sparse_with_dtype = torch.sparse_coo_tensor(indices, values, sparse_size, dtype=torch.float64)
+        self.assertEqual(sparse_with_dtype.device, torch_device)
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @dtypes(torch.complex64, torch.complex128)
     def test_abs_angle_complex_to_float(self, device, dtype):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5497,6 +5497,7 @@ def add_neg_dim_tests():
 class TestTorchDeviceType(TestCase):
     exact_dtype = True
 
+    @onlyOnCPUAndCUDA
     def test_tensor_ctor_device_inference(self, device):
         torch_device = torch.device(device)
         values = torch.tensor((1, 2, 3), device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5502,15 +5502,17 @@ class TestTorchDeviceType(TestCase):
         torch_device = torch.device(device)
         values = torch.tensor((1, 2, 3), device=device)
 
-        # Tests tensor (suppresses warnings)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self.assertEqual(torch.tensor(values).device, torch_device)
-            self.assertEqual(torch.tensor(values, dtype=torch.float64).device, torch_device)
+        # Tests tensor and as_tensor
+        # Note: warnings are suppressed (suppresses warnings)
+        for op in (torch.tensor, torch.as_tensor):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self.assertEqual(op(values).device, torch_device)
+                self.assertEqual(op(values, dtype=torch.float64).device, torch_device)
 
-        # Tests as_tensor
-        self.assertEqual(torch.as_tensor(values).device, torch_device)
-        self.assertEqual(torch.as_tensor(values, dtype=torch.float64).device, torch_device)
+                if self.device_type == 'cuda':
+                    with torch.cuda.device(device):
+                        self.assertEqual(op(values.cpu()).device, torch.device('cpu'))
 
         # Tests sparse ctor
         indices = torch.tensor([[0, 1, 1],
@@ -5523,6 +5525,12 @@ class TestTorchDeviceType(TestCase):
 
         sparse_with_dtype = torch.sparse_coo_tensor(indices, values, sparse_size, dtype=torch.float64)
         self.assertEqual(sparse_with_dtype.device, torch_device)
+
+        if self.device_type == 'cuda':
+            with torch.cuda.device(device):
+                sparse_with_dtype = torch.sparse_coo_tensor(indices.cpu(), values.cpu(),
+                                                            sparse_size, dtype=torch.float64)
+                self.assertEqual(sparse_with_dtype.device, torch.device('cpu'))
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @dtypes(torch.complex64, torch.complex128)

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -251,7 +251,7 @@ Tensor internal_new_from_data(
     // infer the scalar type and device type; it's not expected to infer the layout since these constructors
     // are defined per-layout-type (e.g. tensor vs sparse_coo_tensor).
     const auto& inferred_scalar_type = type_inference ? var.scalar_type() : scalar_type;
-    auto device = device_opt.has_value() ? *device_opt : (type_inference ? var.device() : at::Device(computeDeviceType(dispatch_key)));
+    auto device = device_opt.has_value() ? *device_opt : var.device();
     pybind11::gil_scoped_release no_gil;
     maybe_initialize_cuda(device);
     return var.to(device, inferred_scalar_type, /*non_blocking=*/false, /*copy=*/copy_variables);
@@ -312,7 +312,9 @@ Tensor new_from_data_copy(
     at::ScalarType scalar_type,
     c10::optional<Device> device,
     PyObject* data) {
-  return internal_new_from_data(dispatch_key, scalar_type, std::move(device), data, true, true, false);
+  return internal_new_from_data(dispatch_key, scalar_type, std::move(device), data,
+                                /*copy_variables=*/true, /*copy_numpy=*/true,
+                                /*type_inference=*/false);
 }
 
 Tensor legacy_new_from_sequence(
@@ -323,7 +325,9 @@ Tensor legacy_new_from_sequence(
   if (!PySequence_Check(data)) {
     throw TypeError("new(): data must be a sequence (got %s)", Py_TYPE(data)->tp_name);
   }
-  return internal_new_from_data(dispatch_key, scalar_type, std::move(device), data, false, false, false);
+  return internal_new_from_data(dispatch_key, scalar_type, std::move(device), data,
+                                /*copy_variables=*/false, /*copy_numpy=*/false,
+                                /*type_inference=*/false);
 }
 
 // "base" here refers to the Tensor type on which the function was invoked, e.g.:
@@ -589,9 +593,13 @@ Tensor indexing_tensor_from_data(
   // indexing tensor (type Byte or Long)
   ScalarType inferred_scalar_type = infer_scalar_type(data);
   if (inferred_scalar_type == ScalarType::Byte || inferred_scalar_type == ScalarType::Bool) {
-    return internal_new_from_data(dispatch_key, inferred_scalar_type, std::move(device), data, false, false, false);
+    return internal_new_from_data(dispatch_key, inferred_scalar_type, std::move(device), data,
+                                  /*copy_variables=*/false, /*copy_numpy=*/false,
+                                  /*type_inference=*/false);
   } else {
-    return internal_new_from_data(dispatch_key, scalar_type, std::move(device), data, false, false, false);
+    return internal_new_from_data(dispatch_key, scalar_type, std::move(device), data,
+                                  /*copy_variables=*/false, /*copy_numpy=*/false,
+                                  /*type_inference=*/false);
   }
 }
 
@@ -610,16 +618,24 @@ Tensor sparse_coo_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scal
     const auto inferred_scalar_type = r.scalartypeWithDefault(2, scalar_type);
     at::OptionalDeviceGuard device_guard(r.deviceOptional(3));
     // if no dtype provided, infer type based on value type.
-    Tensor values = internal_new_from_data(inferred_dispatch_key, inferred_scalar_type, r.deviceOptional(3), r.pyobject(1), false, true, type_inference);
-    Tensor indices = internal_new_from_data(legacyExtractDispatchKey(values.key_set()), kLong, r.deviceOptional(3), r.pyobject(0), false, true, false);
+    Tensor values = internal_new_from_data(inferred_dispatch_key, inferred_scalar_type, r.deviceOptional(3), r.pyobject(1),
+                                           /*copy_variables=*/false, /*copy_numpy=*/true,
+                                           /*type_inference=*/type_inference);
+    Tensor indices = internal_new_from_data(legacyExtractDispatchKey(values.key_set()), kLong, r.deviceOptional(3), r.pyobject(0),
+                                            /*copy_variables=*/false, /*copy_numpy=*/true,
+                                            /*type_inference=*/false);
     return at::sparse_coo_tensor(indices, values, values.options().layout(at::kSparse)).set_requires_grad(r.toBool(4));
   } else if (r.idx == 1) {
     bool type_inference = r.isNone(3);
     const auto inferred_dispatch_key = denseTypeIdWithDefault(r, 4, dispatch_key);
     const auto inferred_scalar_type = r.scalartypeWithDefault(3, scalar_type);
     at::OptionalDeviceGuard device_guard(r.deviceOptional(4));
-    Tensor values = internal_new_from_data(inferred_dispatch_key, inferred_scalar_type, r.deviceOptional(4), r.pyobject(1), false, true, type_inference);
-    Tensor indices = internal_new_from_data(legacyExtractDispatchKey(values.key_set()), kLong, r.deviceOptional(4), r.pyobject(0), false, true, false);
+    Tensor values = internal_new_from_data(inferred_dispatch_key, inferred_scalar_type, r.deviceOptional(4), r.pyobject(1),
+                                           /*copy_variables=*/false, /*copy_numpy=*/true,
+                                           /*type_inference=*/type_inference);
+    Tensor indices = internal_new_from_data(legacyExtractDispatchKey(values.key_set()), kLong, r.deviceOptional(4), r.pyobject(0),
+                                            /*copy_variables=*/false, /*copy_numpy=*/true,
+                                            /*type_inference=*/false);
     return at::sparse_coo_tensor(indices, values, r.intlist(2), values.options().layout(at::kSparse)).set_requires_grad(r.toBool(5));
   } else if (r.idx == 2) {
     const auto inferred_dispatch_key = typeIdWithDefault(r, 2, dispatch_key);
@@ -650,8 +666,12 @@ Tensor _sparse_coo_tensor_unsafe_ctor(c10::DispatchKey dispatch_key, at::ScalarT
   const auto inferred_dispatch_key = denseTypeIdWithDefault(r, ARG_DEVICE, dispatch_key);
   const auto inferred_scalar_type = r.scalartypeWithDefault(ARG_TYPE, scalar_type);
   at::OptionalDeviceGuard device_guard(r.deviceOptional(ARG_DEVICE));
-  Tensor values = internal_new_from_data(inferred_dispatch_key, inferred_scalar_type, r.deviceOptional(ARG_DEVICE), r.pyobject(ARG_VALUES), false, true, type_inference);
-  Tensor indices = internal_new_from_data(legacyExtractDispatchKey(values.key_set()), kLong, r.deviceOptional(ARG_DEVICE), r.pyobject(ARG_INDICES), false, true, false);
+  Tensor values = internal_new_from_data(inferred_dispatch_key, inferred_scalar_type, r.deviceOptional(ARG_DEVICE), r.pyobject(ARG_VALUES),
+                                         /*copy_variables=*/false, /*copy_numpy=*/true,
+                                         /*type_inference=*/type_inference);
+  Tensor indices = internal_new_from_data(legacyExtractDispatchKey(values.key_set()), kLong, r.deviceOptional(ARG_DEVICE), r.pyobject(ARG_INDICES),
+                                          /*copy_variables=*/false, /*copy_numpy=*/true,
+                                          /*type_inference=*/false);
   return at::_sparse_coo_tensor_unsafe(indices, values, r.intlist(ARG_SIZE), values.options().layout(at::kSparse)).set_requires_grad(r.toBool(ARG_REQUIRES_GRAD));
 }
 
@@ -663,11 +683,11 @@ void _validate_sparse_coo_tensor_args(c10::DispatchKey dispatch_key, at::ScalarT
   ParsedArgs<3> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   Tensor values = internal_new_from_data(
-      dispatch_key, scalar_type, c10::nullopt,
-      r.pyobject(1), false, true, true);
+      dispatch_key, scalar_type, c10::nullopt, r.pyobject(1),
+      /*copy_variables=*/false, /*copy_numpy=*/true, /*type_inference=*/true);
   Tensor indices = internal_new_from_data(
-      legacyExtractDispatchKey(values.key_set()), kLong, c10::nullopt,
-      r.pyobject(0), false, true, false);
+      legacyExtractDispatchKey(values.key_set()), kLong, c10::nullopt, r.pyobject(0),
+      /*copy_variables=*/false, /*copy_numpy=*/true, /*type_inference=*/false);
   at::native::_validate_sparse_coo_tensor_args(indices, values, r.intlist(2));
 }
 
@@ -695,9 +715,9 @@ Tensor tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, Py
                r.scalartypeWithDefault(1, scalar_type),
                r.deviceOptional(2),
                data,
-               true,
-               true,
-               type_inference,
+               /*copy_variables=*/true,
+               /*copy_numpy=*/true,
+               /*type_inference=*/type_inference,
                pin_memory);
     auto names = r.toDimnameListOptional(5);
     if (names) {
@@ -725,9 +745,9 @@ Tensor as_tensor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyOb
         r.scalartypeWithDefault(1, scalar_type),
         r.deviceOptional(2),
         r.pyobject(0),
-        false,
-        false,
-        type_inference);
+        /*copy_variables=*/false,
+        /*copy_numpy=*/false,
+        /*type_inference=*/type_inference);
   }
   throw std::runtime_error("tensor(): invalid arguments");
 }


### PR DESCRIPTION
**BC-Breaking Note**

This PR changes the behavior of the torch.tensor, torch.as_tensor, and sparse constructors. When given a tensor as input and a device is not explicitly specified, these constructors now always infer their device from the tensor. Historically, if the optional dtype kwarg was provided then these constructors would not infer their device from tensor inputs. Additionally, for the sparse ctor a runtime error is now thrown if the indices and values tensors are on different devices and the device kwarg is not specified.

**PR Summary**
This PR's functional change is a single line:

```
auto device = device_opt.has_value() ? *device_opt : (type_inference ? var.device() : at::Device(computeDeviceType(dispatch_key)));
```
=>
```
auto device = device_opt.has_value() ? *device_opt : var.device();
```

in `internal_new_from_data`. This line entangled whether the function was performing type inference with whether it inferred its device from an input tensor, and in practice meant that

```
t = torch.tensor((1, 2, 3), device='cuda')
torch.tensor(t, dtype=torch.float64)
```

would return a tensor on the CPU, not the default CUDA device, while 

```
t = torch.tensor((1, 2, 3), device='cuda')
torch.tensor(t)
```

would return a tensor on the device of `t`!

This behavior is niche and odd, but came up while @aocsa was fixing #40648. 

An additional side affect of this change is that the indices and values tensors given to a sparse constructor must be on the same device, or the sparse ctor must specify the dtype kwarg. The tests in test_sparse.py have been updated to reflect this behavior. 