### PR TITLE
[jit] fix tuple alias analysis

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -794,9 +794,6 @@ class TestFreezing(JitTestCase):
         expected = m_s.forward(inp)
         self.assertEqual(out, expected)
 
-    # Check attribute a is preserved. Alias analysis detects that 'a' has output writers.
-    # In this example, 'a' is not mutated. However, we do not track which sub
-    # values of a composite ivalue is mutated.
     def test_freeze_module_with_aliased_attr2(self):
         class FreezeMe(nn.Module):
             def __init__(self):
@@ -815,7 +812,6 @@ class TestFreezing(JitTestCase):
         m_s = torch.jit.script(m)
         m_s.eval()
         m_f = torch._C._freeze_module(m_s._c)
-        self.assertTrue(m_f.hasattr('a'))
         inp = torch.tensor([5])
         out = m_f.forward(inp)
         expected = m.forward(inp)

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -194,6 +194,7 @@ class AliasDb {
   void analyzeSetAttr(Node* node);
   void analyzeConservative(Node* node);
   void analyzeContainerConstruct(Node* node);
+  void analyzeTupleConstruct(Node* node);
   bool tryRegisteredAnalysis(Node* node);
 
   /**


### PR DESCRIPTION
This is a cherry-pick of https://github.com/pytorch/pytorch/pull/41990 into release/1.6

Previously when analyzing a TupleConstruct, we ignored the aliasing
information of the inputs and simply marked all elements of the returned
tuple as wildcards. But since we can fully reason about the contents of
a tuple statically, we should be able to assign them aliasing
information.

This analysis was not only incomplete but produced incorrect results,
since if `a` is not a wildcard, `a noalias wilcard`. So if we looked at
`tuple(a)` and reported the aliasing info as `tuple(wildcard)`, then
`tuple[0] noalias a`, which is...wrong.