### PR TITLE
[PATCH] [RPC tests] Remove world_size and init_method from TensorPipe fixture

### DIFF
--- a/test/distributed/rpc/tensorpipe/test_ddp_under_dist_autograd.py
+++ b/test/distributed/rpc/tensorpipe/test_ddp_under_dist_autograd.py
@@ -16,10 +16,6 @@ import torch.distributed.rpc as rpc
 )
 class TestDdpUnderDistAutogradTensorPipe(TensorPipeRpcAgentTestFixture, ddp_under_dist_autograd_test.TestDdpUnderDistAutograd):
 
-    @property
-    def world_size(self) -> int:
-        return ddp_under_dist_autograd_test.WORLD_SIZE
-
     @dist_init
     def test_verify_backend_options(self):
         self.assertEqual(self.rpc_backend, rpc.backend_registry.BackendType.TENSORPIPE)
@@ -28,10 +24,6 @@ class TestDdpUnderDistAutogradTensorPipe(TensorPipeRpcAgentTestFixture, ddp_unde
     TEST_WITH_ASAN, "Skip ASAN as torch + multiprocessing spawn have known issues"
 )
 class TestDdpComparisonTensorPipe(TensorPipeRpcAgentTestFixture, ddp_under_dist_autograd_test.TestDdpComparison):
-
-    @property
-    def world_size(self) -> int:
-        return ddp_under_dist_autograd_test.WORLD_SIZE
 
     @dist_init
     def test_verify_backend_options(self):

--- a/torch/testing/_internal/distributed/rpc/tensorpipe_rpc_agent_test_fixture.py
+++ b/torch/testing/_internal/distributed/rpc/tensorpipe_rpc_agent_test_fixture.py
@@ -1,5 +1,4 @@
 import torch.distributed.rpc as rpc
-import torch.testing._internal.dist_utils as dist_utils
 
 # In order to run the existing test RPC and Distributed Autograd test suites
 # with Tensorpipe, we introduce a new class in both rpc_test.py and
@@ -8,16 +7,6 @@ import torch.testing._internal.dist_utils as dist_utils
 # inherit from RpcAgentTestFixture, since this and the base test classes would
 # then have a common ancestor (RpcAgentTestFixture), which is not allowed.
 class TensorPipeRpcAgentTestFixture(object):
-    @property
-    def world_size(self):
-        return 4
-
-    @property
-    def init_method(self):
-        return dist_utils.INIT_METHOD_TEMPLATE.format(
-            file_name=self.file_name
-        )
-
     @property
     def rpc_backend(self):
         return rpc.backend_registry.BackendType[


### PR DESCRIPTION
Orignal message:

> This prepares the stack by simplifying the TensorPipe fixture. A comment says that the TensorPipe fixture cannot subclass the generic fixture class as that would lead to a diamond class hierarchy which Python doesn't support (whereas in fact it does), and therefore it copies over two properties that are defined on the generic fixture. However, each class that uses the TensorPipe fixture also inherits from the generic fixture, so there's no need to redefine those properties. And, in fact, by not redefining it we save ourselves some trouble when the TensorPipe fixture would end up overriding another override.

Backport of #40814

This fixes #41365