### PR TITLE
Avoid refcount bump in IValue::toStringRef()

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1019,7 +1019,8 @@ inline IValue::IValue(c10::intrusive_ptr<c10::RRefInterface> v)
   payload.as_intrusive_ptr = v.release();
 }
 inline const std::string& IValue::toStringRef() const {
-  return toString()->string();
+  AT_ASSERT(isString(), "Expected String but got ", tagKind());
+  return static_cast<const c10::ivalue::ConstantString*>(payload.as_intrusive_ptr)->string();
 }
 
 inline PyObject* IValue::toPyObject() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42019 Avoid refcount bump in IValue::toStringRef()**

According to benchmarks, this makes IValue::toStringRef() 3-4x as fast.

Differential Revision: [D22731354](https://our.internmc.facebook.com/intern/diff/D22731354/)