### PR TITLE
[release/1.6] .circleci: Don't use SCCACHE for windows release builds

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -5,7 +5,6 @@ source "/c/w/env"
 mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
-export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache-windows
 export NIGHTLIES_PYTORCH_ROOT="$PYTORCH_ROOT"
 


### PR DESCRIPTION
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>