### PR TITLE
[experiment] IValues cannot be created from undefined tensors

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -248,22 +248,16 @@ struct CAFFE2_API IValue final {
   // While some of these accessors could be generated through templates,
   // we prefer to write them manually for clarity
 
-  IValue(at::Tensor t) {
-    if (t.defined()) {
-      tag = Tag::Tensor;
-      is_intrusive_ptr = true;
-      // Note: the undefined tensor is not refcounted, so while it
-      // is tagged as a tensor, is_intrusive_ptr is set to false.
-      // This is not an optional optimization: our incref call
-      // *will not* do the right thing when called on an
-      // undefined tensor.
-      payload.as_intrusive_ptr = t.unsafeReleaseTensorImpl();
-    } else {
-      // If the tensor was undefined, set the IValue to None instead
-      tag = Tag::None;
-      is_intrusive_ptr = false;
-      payload = {0};
-    }
+  IValue(at::Tensor t)
+  : tag(Tag::Tensor), is_intrusive_ptr(t.defined())  {
+    AT_ASSERT(t.defined(), "Tried to use an undefined tensor where it should have been defined. Please don't pass uninitialized Tensor objects to PyTorch APIs.");
+
+    // Note: the undefined tensor is not refcounted, so while it
+    // is tagged as a tensor, is_intrusive_ptr is set to false.
+    // This is not an optional optimization: our incref call
+    // *will not* do the right thing when called on an
+    // undefined tensor.
+    payload.as_intrusive_ptr = t.unsafeReleaseTensorImpl();
   }
   bool isTensor() const { return Tag::Tensor == tag; }
   at::Tensor toTensor() &&;

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -114,20 +114,10 @@ inline c10::intrusive_ptr<ivalue::EnumHolder> IValue::toEnumHolder() const & {
   return toIntrusivePtr<ivalue::EnumHolder>();
 }
 inline at::Tensor IValue::toTensor() && {
-  if (isNone()) {
-    // Undefined Tensors are represented by IValue as None, so we need to
-    // map back to undefined tensor.
-    return at::Tensor();
-  }
   AT_ASSERT(isTensor(), "Expected Tensor but got ", tagKind());
   return at::Tensor(moveToIntrusivePtr<at::TensorImpl, at::UndefinedTensorImpl>());
 }
 inline at::Tensor IValue::toTensor() const & {
-  if (isNone()) {
-    // Undefined Tensors are represented by IValue as None, so we need to
-    // map back to undefined tensor.
-    return at::Tensor();
-  }
   AT_ASSERT(isTensor(), "Expected Tensor but got ", tagKind());
   return at::Tensor(toIntrusivePtr<at::TensorImpl, at::UndefinedTensorImpl>());
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42028 [experiment] IValues cannot be created from undefined tensors**
* #42025 IValue stores undefined tensor as None
* #41947 Change C++ frontend to take optional<Tensor> arguments
* #41610 Make operators with optional Tensor? arguments c10-full

github.com/pytorch/pytorch/pull/42025 make sure that IValues store None and undefined tensor in the same way.
This PR reverts that and instead errors when somebody tries to create an IValue from an undefined tensor.
This is an experiment to see what breaks.

Differential Revision: [D22733347](https://our.internmc.facebook.com/intern/diff/D22733347/)