### PR TITLE
Updates to Scale and Zero Point Gradient Calculation

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2061,16 +2061,16 @@ void fake_quantize_learnable_scale_grad_tensor_kernel(
   float grad_big = quant_max - zero_point;
   auto iter_scale = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per tensor version for the learnable backprop kernel on scale.
-  cpu_kernel(iter_scale, [&](float x, float dx) -> float {
+  cpu_kernel(iter_scale, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     if (xq == quant_min) {
-      return dx * grad_small;
+      return dy * grad_small;
     } else if (xq == quant_max) {
-      return dx * grad_big;
+      return dy * grad_big;
     }
     float x_fq = static_cast<float>((xq - zero_point) * scale);
-    return dx * (x_fq - x) * inv_scale;
+    return dy * (x_fq - x) * inv_scale;
   });
 }
 
@@ -2085,11 +2085,11 @@ void fake_quantize_learnable_zero_point_grad_tensor_kernel(
   float inv_scale = 1.0f / scale;
   auto iter_scale = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per tensor version for the learnable backprop kernel on zero point.
-  cpu_kernel(iter_scale, [&](float x, float dx) -> float {
+  cpu_kernel(iter_scale, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     if (xq == quant_min || xq == quant_max) {
-      return dx * (-1) * scale;
+      return dy * (-1) * scale;
     }
     return 0;
   });
@@ -2138,16 +2138,16 @@ void fake_quantize_learnable_scale_grad_channel_kernel(
   float grad_big = quant_max - zero_point;
   auto iter_scale = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per channel version for the learnable backprop kernel on scale.
-  cpu_kernel(iter_scale, [&](float x, float dx) -> float {
+  cpu_kernel(iter_scale, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     float x_fq = static_cast<float>((xq - zero_point) * scale);
     if (xq == quant_min) {
-      return dx * grad_small;
+      return dy * grad_small;
     } else if (xq == quant_max) {
-      return dx * grad_big;
+      return dy * grad_big;
     }
-    return dx * (x_fq - x) * inv_scale;
+    return dy * (x_fq - x) * inv_scale;
   });
 }
 
@@ -2162,11 +2162,11 @@ void fake_quantize_learnable_zero_point_grad_channel_kernel(
   float inv_scale = 1.0f / scale;
   auto iter_zero_point = TensorIterator::binary_op(input_grad, input, output_grad);
   // TODO: Implement the vectorized per channel version for the learnable backprop kernel on zero point.
-  cpu_kernel(iter_zero_point, [&](float x, float dx) -> float {
+  cpu_kernel(iter_zero_point, [&](float x, float dy) -> float {
     int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
     xq = std::max(std::min(xq, quant_max), quant_min);
     if (xq == quant_min || xq == quant_max) {
-      return dx * (-1) * scale;
+      return dy * (-1) * scale;
     }
     return 0;
   });

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -84,16 +84,16 @@ void _fake_quantize_grad_learnable_scale_tensor_kernel_cuda(
 
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       if (xq == quant_min) {
-        return dx * grad_small;
+        return dy * grad_small;
       } else if (xq == quant_max) {
-        return dx * grad_big;
+        return dy * grad_big;
       }
       float x_fq = static_cast<float>((xq - zero_point) * scale);
-      return dx * (x_fq - x) * inv_scale;
+      return dy * (x_fq - x) * inv_scale;
     });
 }
 
@@ -109,11 +109,11 @@ void _fake_quantize_grad_learnable_zero_point_tensor_kernel_cuda(
   float inv_scale = 1.0f / scale;
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       if (xq == quant_min || xq == quant_max) {
-        return dx * (-1) * scale;
+        return dy * (-1) * scale;
       }
       return 0;
     });
@@ -165,16 +165,16 @@ void _fake_quantize_grad_learnable_scale_channel_kernel_cuda(
 
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       float x_fq = static_cast<float>((xq - zero_point) * scale);
       if (xq == quant_min) {
-        return dx * grad_small;
+        return dy * grad_small;
       } else if (xq == quant_max) {
-        return dx * grad_big;
+        return dy * grad_big;
       }
-      return dx * (x_fq - x) * inv_scale;
+      return dy * (x_fq - x) * inv_scale;
     });
 }
 
@@ -190,11 +190,11 @@ void _fake_quantize_grad_learnable_zero_point_channel_kernel_cuda(
   float inv_scale = 1.0f / scale;
   auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
   gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dx) -> float {
+    [=] GPU_LAMBDA (float x, float dy) -> float {
       int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
       xq = std::max(std::min(xq, quant_max), quant_min);
       if (xq == quant_min || xq == quant_max) {
-        return dx * (-1) * scale;
+        return dy * (-1) * scale;
       }
       return 0;
     });

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -310,7 +310,7 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_channel_affine_b
   fake_quant_grad_per_channel_stub(iter_X.device_type(), iter_X, quant_min, quant_max);
 
   std::tuple<Tensor, Tensor> dScaleZeroPoints = native::_get_scale_zero_point_per_channel_iter_grads(
-    dX, X, scale, zero_point, axis, quant_min, quant_max);
+    dY, X, scale, zero_point, axis, quant_min, quant_max);
 
   Tensor dScale = std::get<0>(dScaleZeroPoints).to(scale.device());
   Tensor dZeroPoint = std::get<1>(dScaleZeroPoints).to(zero_point.device());

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -169,11 +169,11 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_tensor_affine_ba
 
   auto dScale_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
   fake_quant_grad_learnable_scale_tensor_stub(
-    scale.device().type(), dScale_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+    scale.device().type(), dScale_vec, X, dY, scale_val, zero_point_val, quant_min, quant_max);
 
   auto dZeroPoint_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
   fake_quant_grad_learnable_zero_point_tensor_stub(
-    zero_point.device().type(), dZeroPoint_vec, X, dX, scale_val, zero_point_val, quant_min, quant_max);
+    zero_point.device().type(), dZeroPoint_vec, X, dY, scale_val, zero_point_val, quant_min, quant_max);
 
   // The total sums over the scale and zero point gradient vectors are what will be returned in the end.
   auto dScale = dScale_vec.sum().unsqueeze(0).to(scale.device());

--- a/torch/quantization/_learnable_fake_quantize.py
+++ b/torch/quantization/_learnable_fake_quantize.py
@@ -128,9 +128,9 @@ class _LearnableFakeQuantizePerTensorOp(torch.autograd.Function):
 
         X_q = X_q.clamp(q_min, q_max)
         dScale = _calculate_scale_grad(
-            dX, X, X_fq, X_q, scale, zero_point, q_min, q_max, device).sum().unsqueeze(0)
+            dY, X, X_fq, X_q, scale, zero_point, q_min, q_max, device).sum().unsqueeze(0)
         dZeroPoint = _calculate_zero_point_grad(
-            dX, X, X_fq, X_q, scale, zero_point, q_min, q_max, device).sum().unsqueeze(0)
+            dY, X, X_fq, X_q, scale, zero_point, q_min, q_max, device).sum().unsqueeze(0)
 
         dScale *= grad_factor
         dZeroPoint *= grad_factor
@@ -178,9 +178,9 @@ class _LearnableFakeQuantizePerChannelOp(torch.autograd.Function):
 
         X_q = X_q.clamp(q_min, q_max)
         dScale = _calculate_scale_grad(
-            dX, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max, device).sum(axis_for_reduction)
+            dY, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max, device).sum(axis_for_reduction)
         dZeroPoint = _calculate_zero_point_grad(
-            dX, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max, device).sum(axis_for_reduction)
+            dY, X, X_fq, X_q, scale_vec, zp_vec, q_min, q_max, device).sum(axis_for_reduction)
 
         dScale *= grad_factor
         dZeroPoint *= grad_factor


### PR DESCRIPTION
Summary: In this diff, scale and zero point gradient calculations are updated to correctly reflect the actual backpropagation equation (instead of `dScale * dX`, the near-final output should be `dScale * dY`; the same applies to zero point).

Test Plan:
To execute the unit tests for all affected learnable fake quantize modules and kernels, on a devvm, execute the following command:

`buck test //caffe2/test:quantization -- learnable`

To enable the `cuda` tests, execute the following command:

`buck test mode/dev-nosan //caffe2/test:quantization -- learnable`

Differential Revision: D22735668

