### PR TITLE
Enable non-synchronizing cub scan for cum* operations

### DIFF
--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -460,9 +460,9 @@ struct ROCm_Bug {
 #endif
 
 template<typename scalar_t, typename BinaryFunction>
-void scan_thrust(const Tensor& self, Tensor& result, scalar_t init, BinaryFunction binary_op) {
-  auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
+void scan_thrust_or_cub(const Tensor& self, Tensor& result, scalar_t init, BinaryFunction binary_op) {
   #ifdef __HIP_PLATFORM_HCC__
+  auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
   using rocm_bug_t = ROCm_Bug<scalar_t>;
   thrust::device_ptr<rocm_bug_t> src_data(reinterpret_cast<rocm_bug_t *>(self.data_ptr<scalar_t>()));
   thrust::device_ptr<rocm_bug_t> dst_data(reinterpret_cast<rocm_bug_t *>(result.data_ptr<scalar_t>()));
@@ -537,7 +537,7 @@ void scan_dim(const Tensor& self, Tensor& result,
   result = result.contiguous();
 
   if (self.numel() == self.size(dim)) {
-    scan_thrust<scalar_t>(self_, result, init, binary_op);
+    scan_thrust_or_cub<scalar_t>(self_, result, init, binary_op);
   } else if (dim == ndim - 1) {
     scan_innermost_dim<scalar_t>(self_, result, init, binary_op);
   } else {

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -8,6 +8,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
+#include "cub/device/device_scan.cuh"
 
 
 namespace at { namespace native {
@@ -471,13 +472,79 @@ void scan_thrust(const Tensor& self, Tensor& result, scalar_t init, BinaryFuncti
       src_data, src_data + size, dst_data,
       rocm_bug_binary_op);
   #else
-  thrust::device_ptr<scalar_t> src_data(self.data_ptr<scalar_t>());
-  thrust::device_ptr<scalar_t> dst_data(result.data_ptr<scalar_t>());
-  ptrdiff_t size = self.numel();
-  thrust::inclusive_scan(
-      thrust::cuda::par(allocator).on(c10::cuda::getCurrentCUDAStream()),
-      src_data, src_data + size, dst_data,
-      binary_op);
+ //thrust::device_ptr<scalar_t> src_data(self.data_ptr<scalar_t>());
+ //thrust::device_ptr<scalar_t> dst_data(result.data_ptr<scalar_t>());
+  int64_t size = self.numel();
+  // thrust::inclusive_scan(
+  //     thrust::cuda::par(allocator).on(c10::cuda::getCurrentCUDAStream()),
+  //     src_data, src_data + size, dst_data,
+  //     binary_op);
+  // non synchronizing cub call for tensors < INT_MAX
+  int size_cub = std::min<int64_t>(size, (int64_t)std::numeric_limits<int>::max);
+  size_t temp_storage_bytes = 0;
+  AT_CUDA_CHECK(cub::DeviceScan::InclusiveScan(
+        nullptr,
+        temp_storage_bytes,
+        self.data_ptr<scalar_t>(),
+        result.data_ptr<scalar_t>(),
+        binary_op,
+        size_cub,
+        at::cuda::getCurrentCUDAStream()));
+  auto temp_storage = at::empty(
+  {static_cast<int64_t>(temp_storage_bytes)}, self.options().dtype(kByte));
+    AT_CUDA_CHECK(cub::DeviceScan::InclusiveScan(
+        temp_storage.data_ptr(),
+        temp_storage_bytes,
+        self.data_ptr<scalar_t>(),
+        result.data_ptr<scalar_t>(),
+        binary_op,
+        size_cub,
+        at::cuda::getCurrentCUDAStream()));
+  //all subsequent calls incur synchronization
+  //since we can do only exclusive scan, this effectively means that we are processing 1 fewer element
+   for (int64_t i = size_cub; i< size; i+= std::numeric_limits<int>::max()-1){
+     auto self_ptr = self.data_ptr<scalar_t>()+i;
+     //alas, this is unaligned, but unfortunately can only do exclusive_scan with init value
+     auto result_ptr = self.data_ptr<scalar_t>()+i-1;
+     auto result_view = at::_unsafe_view(result, -1); //need to access element, but result can be multi-d
+     size_cub = std::min<int64_t>(size-i, (int64_t)std::numeric_limits<int>::max);
+     if (size_cub > 1) {
+     scalar_t init = result[i-1].item().to<scalar_t>(); //synchronization happens here
+     AT_CUDA_CHECK(cub::DeviceScan::ExclusiveScan(
+      nullptr,
+      temp_storage_bytes,
+      self.data_ptr<scalar_t>(),
+      result.data_ptr<scalar_t>(),
+      binary_op,
+      init,
+      size_cub,
+      at::cuda::getCurrentCUDAStream()));
+      temp_storage = at::empty(
+     {static_cast<int64_t>(temp_storage_bytes)}, self.options().dtype(kByte));
+  AT_CUDA_CHECK(cub::DeviceScan::ExclusiveScan(
+      temp_storage.data_ptr(),
+      temp_storage_bytes,
+      self.data_ptr<scalar_t>(),
+      result.data_ptr<scalar_t>(),
+      binary_op,
+      init,
+      size_cub,
+      at::cuda::getCurrentCUDAStream()));
+     }
+
+   }
+   //need to fill in one last element
+   if (size > std::numeric_limits<int>::max()){
+     auto result_view = at::_unsafe_view(result, -1);
+     auto self_view = at::_unsafe_view(result, -1);
+     result_view[size-1] = result_view[size-2]+self_view[size-1];
+   }
+
+
+
+
+
+
   #endif
 }
 

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -7,7 +7,6 @@
 #include <THC/THCThrustAllocator.cuh>
 #include <thrust/execution_policy.h>
 #include <thrust/device_ptr.h>
-#include <thrust/transform.h>
 #include <thrust/scan.h>
 #include "cub/device/device_scan.cuh"
 

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -518,9 +518,11 @@ void scan_thrust(const Tensor& self, Tensor& result, scalar_t init, BinaryFuncti
         size_cub,
         at::cuda::getCurrentCUDAStream()));
     if (i > 0) {
-      // restore modified first element
-      auto self_view = at::_unsafe_view(self, -1);
-      self_view[i].copy_(first_elem, /*non_blocking=*/true);
+      if (self.data_ptr<scalar_t>() != result.data_ptr<scalar_t>()) {
+        // restore modified first element only if it's not an inplace operation
+        auto self_view = at::_unsafe_view(self, -1);
+        self_view[i].copy_(first_elem, /*non_blocking=*/true);
+      }
     }
   }
 

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -487,7 +487,7 @@ void scan_thrust_or_cub(const Tensor& self, Tensor& result, scalar_t init, Binar
     Tensor first_elem; // need to save it for all iterations other than first
     if (i > 0) {
       // need to temporarily transform first element of the range we are
-      // operating on self might be multi-d, but we need to index a single
+      // operating on; self might be multi-d, but we need to index a single
       // element
       auto self_view = at::_unsafe_view(self, -1);
       first_elem = self_view[i].clone();

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -8,7 +8,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
-#include "cub/device/device_scan.cuh"
+#include <cub/device/device_scan.cuh>
 
 
 namespace at { namespace native {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12002,7 +12002,6 @@ class TestTorchDeviceType(TestCase):
             torch.logcumsumexp(b, axis, out=inplace_out)
 
     def _test_large_cum_fn_helper(self, x, fn):
-        print(x.min(), x.max())
         x_cpu = x.cpu().float()
         expected = fn(x_cpu)
         actual = fn(x).cpu().float()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12001,6 +12001,33 @@ class TestTorchDeviceType(TestCase):
                 'expected scalar_type Double but found Float'):
             torch.logcumsumexp(b, axis, out=inplace_out)
 
+    def _test_large_cum_fn_helper(self, x, fn):
+        print(x.min(), x.max())
+        x_cpu = x.cpu().float()
+        expected = fn(x_cpu)
+        actual = fn(x).cpu().float()
+        self.assertEqual(expected, actual.cpu().float())
+
+    @onlyCUDA
+    @dtypesIfCUDA(torch.half)  #only small dtype not to get oom
+    def test_large_cumsum(self, device, dtype):
+        # initialization to avoid overflow and half caveats
+        x = torch.empty(2**30+200, device=device, dtype=dtype)
+        x[::3] = -3
+        x[1::3] = 2
+        x[2::3] = 1
+        self._test_large_cum_fn_helper(x, lambda x: torch.cumsum(x,0))
+
+    @onlyCUDA
+    @dtypesIfCUDA(torch.half)  #only small dtype not to get oom
+    def test_large_cumprod(self, device, dtype):
+        # initialization to avoid overflow and half caveats
+        x = torch.empty(2**30+200, device=device, dtype=dtype)
+        x[::3] = 8
+        x[1::3] = .25
+        x[2::3] = .5
+        self._test_large_cum_fn_helper(x, lambda x: torch.cumprod(x,0))
+
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)
         for dim in range(x.dim()):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12030,7 +12030,7 @@ class TestTorchDeviceType(TestCase):
 
     def test_discontiguous_out_cumsum(self, device):
         x = torch.randn(4, 8, device=device)
-        y = torch.empty(4, 16, device=device)[:,::2]
+        y = torch.empty(4, 16, device=device)[:, ::2]
         out = torch.cumsum(x, 0)
         torch.cumsum(x, 0, out=y)
         self.assertFalse(y.is_contiguous())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12028,6 +12028,14 @@ class TestTorchDeviceType(TestCase):
         x[2::3] = .5
         self._test_large_cum_fn_helper(x, lambda x: torch.cumprod(x, 0))
 
+    def test_discontiguous_out_cumsum(self, device):
+        x = torch.randn(4, 8, device=device)
+        y = torch.empty(4, 16, device=device)[:,::2]
+        out = torch.cumsum(x, 0)
+        torch.cumsum(x, 0, out=y)
+        self.assertFalse(y.is_contiguous())
+        self.assertEqual(out, y, atol=0., rtol=0.)
+
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)
         for dim in range(x.dim()):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12009,24 +12009,24 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(expected, actual.cpu().float())
 
     @onlyCUDA
-    @dtypesIfCUDA(torch.half)  #only small dtype not to get oom
+    @dtypesIfCUDA(torch.half)  # only small dtype not to get oom
     def test_large_cumsum(self, device, dtype):
         # initialization to avoid overflow and half caveats
-        x = torch.empty(2**30+200, device=device, dtype=dtype)
+        x = torch.empty(2**30 + 200, device=device, dtype=dtype)
         x[::3] = -3
         x[1::3] = 2
         x[2::3] = 1
-        self._test_large_cum_fn_helper(x, lambda x: torch.cumsum(x,0))
+        self._test_large_cum_fn_helper(x, lambda x: torch.cumsum(x, 0))
 
     @onlyCUDA
-    @dtypesIfCUDA(torch.half)  #only small dtype not to get oom
+    @dtypesIfCUDA(torch.half)  # only small dtype not to get oom
     def test_large_cumprod(self, device, dtype):
         # initialization to avoid overflow and half caveats
-        x = torch.empty(2**30+200, device=device, dtype=dtype)
+        x = torch.empty(2**30 + 200, device=device, dtype=dtype)
         x[::3] = 8
         x[1::3] = .25
         x[2::3] = .5
-        self._test_large_cum_fn_helper(x, lambda x: torch.cumprod(x,0))
+        self._test_large_cum_fn_helper(x, lambda x: torch.cumprod(x, 0))
 
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)


### PR DESCRIPTION
This uses cub for cum* operations, because, unlike thrust, cub is non-synchronizing. 
Cub does not support more than `2**31` element tensors out of the box (in fact, due to cub bugs the cutoff point is even smaller)
so to support that I split the tensor into `2**30` element chunks, and modify the first value of the second and subsequent chunks to contain the cumsum result of the previous chunks. Since modification is done inplace on the source tensor, if something goes wrong and we error out before the source tensor is reverted back to its original state, source tensor will be corrupted, but in most cases errors will invalidate the full coda context. 
