### PR TITLE
Implement Enum sugared value and Enum constant support

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -54,6 +54,14 @@ TupleTypePtr Tuple::type() const {
   return type_;
 }
 
+bool operator==(const ivalue::EnumHolder& lhs, const ivalue::EnumHolder& rhs) {
+  return lhs.name() == rhs.name() && *rhs.type() == *lhs.type();
+}
+
+const std::string ivalue::EnumHolder::qualifiedClassName() const {
+  return type_->qualifiedClassName().name();
+}
+
 } // namespace ivalue
 
 TypePtr IValue::type() const {
@@ -97,8 +105,7 @@ TypePtr IValue::type() const {
     case Tag::Generator:
       return GeneratorType::get();
     case Tag::Enum:
-      // TODO(gmagogsfm): Implement this.
-      TORCH_INTERNAL_ASSERT(false, "To be implemented");
+      return toEnumHolder()->type();
   }
   // switch above is complete but this silences compiler warnings
   TORCH_INTERNAL_ASSERT(false, "unhandled case in IValue::type()");
@@ -439,9 +446,16 @@ std::ostream& IValue::repr(
     }
     case IValue::Tag::GenericDict:
       return printMaybeAnnotatedDict(out, v, formatter);
+    case IValue::Tag::Enum:
+      return out << v.toEnumHolder();
     default:
       TORCH_INTERNAL_ASSERT(false, "repr() not defined on: ", v.tagKind());
   }
+}
+
+std::ostream& operator<<(std::ostream& out, const ivalue::EnumHolder& v) {
+  out << v.qualifiedClassName() << "." << v.name();
+  return out;
 }
 
 std::ostream& operator<<(std::ostream & out, const IValue & v) {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1134,13 +1134,13 @@ struct CAFFE2_API EnumType : public NamedType {
   static const TypeKind Kind = TypeKind::EnumType;
 
   static EnumTypePtr create(
-      const c10::QualifiedName& qualified_name,
+      const c10::QualifiedName& qualified_class_name,
       TypePtr value, std::weak_ptr<::torch::jit::CompilationUnit> cu) {
     switch (value->kind()) {
       case TypeKind::IntType:
       case TypeKind::FloatType:
       case TypeKind::StringType:
-        return EnumTypePtr(new EnumType(qualified_name, value, cu));
+        return EnumTypePtr(new EnumType(qualified_class_name, std::move(value), std::move(cu)));
       default:
         AT_ERROR(
             "Cannot create Enum with value type '",
@@ -1177,9 +1177,13 @@ struct CAFFE2_API EnumType : public NamedType {
     return cu;
   }
 
+  const QualifiedName qualifiedClassName() const {
+    return name().value();
+  }
+
  private:
-  EnumType(c10::QualifiedName name, TypePtr value_type, std::weak_ptr<torch::jit::CompilationUnit> cu)
-      : NamedType(TypeKind::EnumType, std::move(name)),
+  EnumType(c10::QualifiedName qualified_class_name, TypePtr value_type, std::weak_ptr<torch::jit::CompilationUnit> cu)
+      : NamedType(TypeKind::EnumType, std::move(qualified_class_name)),
         value_type_(std::move(value_type)), cu_(cu) {}
 
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {

--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -260,39 +260,39 @@ TEST(IValueTest, ListNestedEquality) {
 }
 
 TEST(IValueTest, EnumEquality) {
+  auto cu = std::make_shared<CompilationUnit>();
+  auto int_enum_type1 = EnumType::create("enum_class_1", IntType::get(), cu);
+  auto int_enum_type2 = EnumType::create("enum_class_2", IntType::get(), cu);
+  auto string_enum_type = EnumType::create("enum_class_3", StringType::get(), cu);
+
   EXPECT_EQ(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", IValue(1))),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue(1)))
+          int_enum_type1, "enum_name_1", IValue(1)))
   );
 
   EXPECT_NE(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", IValue(1))),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_2", "enum_name_1", IValue(1)))
+          int_enum_type2, "enum_name_1", IValue(1)))
   );
 
   EXPECT_NE(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", IValue(1))),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_2", IValue(1)))
+          int_enum_type1, "enum_name_2", IValue(1)))
   );
 
   EXPECT_NE(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", IValue(1))),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue(2)))
-  );
-
-  EXPECT_NE(
-      IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue(1))),
-      IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          "enum_class_1", "enum_name_1", IValue("1")))
+          string_enum_type, "enum_name_1", IValue("1")))
   );
 }
+
+// TODO(gmagogsfm): Add type conversion test?
 } // namespace c10

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -20,7 +20,8 @@ bool insertableTensor(const at::Tensor& ten) {
 
 bool insertableIValue(const IValue& ivalue) {
   if (ivalue.isInt() || ivalue.isNone() || ivalue.isBool() ||
-      ivalue.isDouble() || ivalue.isString() || ivalue.isDevice()) {
+      ivalue.isDouble() || ivalue.isString() || ivalue.isDevice() ||
+      ivalue.isEnum()) {
     return true;
   }
   if (ivalue.isTensor()) {
@@ -37,7 +38,6 @@ bool insertableIValue(const IValue& ivalue) {
       return insertableIValue(tup_elem);
     });
   }
-
   if (ivalue.isGenericDict()) {
     const auto& dict = ivalue.toGenericDict();
     return std::all_of(dict.begin(), dict.end(), [](const auto& entry) {
@@ -123,6 +123,9 @@ c10::optional<Value*> tryInsertConstant(
   } else if (val.isGenericDict() && insertableIValue(val)) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());
+  } else if (val.isEnum()) {
+    n->ival_(attr::value, val);
+    n->output()->setType(val.type());
   } else {
     n->destroy();
     return c10::nullopt;
@@ -178,6 +181,9 @@ c10::optional<IValue> toIValue(const Value* v) {
     return d;
   } else if (node->mustBeNone()) {
     return IValue();
+  } else if (type->cast<EnumType>()) {
+    const auto& enum_val = node->ival(attr::value);
+    return enum_val;
   } else {
     std::stringstream ss;
     ss << "constant literal not supported for: " << type->str();

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/jit/python/python_sugared_value.h>
+#include <pybind11/pytypes.h>
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/Layout.h>
 #include <torch/csrc/MemoryFormat.h>
@@ -403,6 +404,44 @@ std::shared_ptr<SugaredValue> SugaredDict::attr(
   TORCH_INTERNAL_ASSERT(false);
 }
 
+std::shared_ptr<SugaredEnumClass> SugaredEnumClass::create(
+    const py::object& obj,
+    Function& m,
+    const SourceRange& loc) {
+  auto annotation_type = py::module::import("torch.jit.annotations")
+                             .attr("try_ann_to_type")(obj, loc);
+  TORCH_INTERNAL_ASSERT(!annotation_type.is_none());
+  auto type = py::cast<TypePtr>(annotation_type);
+  auto enum_type = type->expect<EnumType>();
+
+  std::map<std::string, SugaredValuePtr> enum_values;
+  auto enum_values_list = py::cast<py::list>(obj);
+  for (auto enum_value : enum_values_list) {
+    auto enum_name = enum_value.attr("name").cast<std::string>();
+    auto enum_sugared_value =
+        toSugaredValue(py::reinterpret_steal<py::object>(enum_value), m, loc);
+    enum_values.insert(std::make_pair(enum_name, enum_sugared_value));
+  }
+  return std::make_shared<SugaredEnumClass>(enum_values, enum_type);
+}
+
+std::shared_ptr<SugaredValue> SugaredEnumClass::attr(
+    const SourceRange& loc,
+    Function& /*m*/,
+    const std::string& field) {
+  auto it = enum_values_.find(field);
+  if (it == enum_values_.end()) {
+    throw ErrorReport(loc) << enum_type_->repr_str() << "'"
+                           << " has no attribute '" << field << "'";
+  }
+  return it->second;
+}
+
+SugaredValuePtr SugaredEnumClass::iter(const SourceRange& loc, Function& m) {
+  // TODO(gmagogsfm): Implement getting iterator.
+  TORCH_INTERNAL_ASSERT(false);
+}
+
 // helper function for instantiating a SugaredValue from an IValue
 std::shared_ptr<SugaredValue> toSugaredValue(
     const IValue& v,
@@ -708,6 +747,30 @@ TypePtr registerNamedTuple(const py::object& obj, const SourceRange& loc) {
   return tt;
 }
 
+bool isEnumClass(py::object obj) {
+  py::bool_ is_class = py::module::import("inspect").attr("isclass")(obj);
+  if (!py::cast<bool>(is_class)) {
+    return false;
+  }
+
+  auto enum_type_obj =
+      py::cast<py::object>(py::module::import("enum").attr("Enum"));
+  int ret = PyObject_IsSubclass(obj.ptr(), enum_type_obj.ptr());
+  return ret == 1;
+}
+
+std::shared_ptr<SugaredValue> createSimpleEnumValue(
+    const py::object& obj,
+    Function& m,
+    const SourceRange& loc) {
+  auto enum_class = obj.attr("__class__");
+  auto enum_type =
+      py::cast<TypePtr>(py::module::import("torch.jit.annotations")
+                            .attr("try_ann_to_type")(enum_class, loc));
+  auto enum_ivalue = toIValue(obj, enum_type);
+  return toSimple(m.graph()->insertConstant(enum_ivalue, loc));
+}
+
 std::shared_ptr<SugaredValue> toSugaredValue(
     py::object obj,
     Function& m,
@@ -820,12 +883,23 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     return std::make_shared<NamedTupleConstructor>(tuple_type);
   }
 
-  py::bool_ isClass = py::module::import("inspect").attr("isclass")(obj);
-  if (py::cast<bool>(isClass)) {
+  if (isEnumClass(obj)) {
+    return SugaredEnumClass::create(obj, m, loc);
+  }
+
+  auto enum_type = py::module::import("enum").attr("Enum");
+  py::bool_ is_enum_value = py::isinstance(obj, enum_type);
+  if (py::cast<bool>(is_enum_value)) {
+    return createSimpleEnumValue(obj, m, loc);
+  }
+
+  py::bool_ is_class = py::module::import("inspect").attr("isclass")(obj);
+  if (py::cast<bool>(is_class)) {
     py::str qualifiedName =
         py::module::import("torch._jit_internal").attr("_qualified_name")(obj);
     auto pyCu = get_python_cu();
     auto qualname = c10::QualifiedName(qualifiedName);
+
     if (auto classType = pyCu->get_class(qualname)) {
       return std::make_shared<PythonClassValue>(classType, obj);
     } else {

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -249,6 +249,36 @@ struct VISIBILITY_HIDDEN SugaredDict : public SugaredValue {
   std::shared_ptr<SugaredTupleValue> modules_;
 };
 
+struct VISIBILITY_HIDDEN SugaredEnumClass : public SugaredValue {
+  explicit SugaredEnumClass(
+      std::map<std::string, SugaredValuePtr> enum_values,
+      EnumTypePtr enum_type)
+      : enum_values_(std::move(enum_values)),
+        enum_type_(std::move(enum_type)) {}
+
+  static std::shared_ptr<SugaredEnumClass> create(
+      const py::object& obj,
+      Function& m,
+      const SourceRange& loc);
+
+  std::string kind() const override {
+    return "EnumClass";
+  }
+
+  SugaredValuePtr attr(
+      const SourceRange& loc,
+      Function& m,
+      const std::string& field) override;
+
+  SugaredValuePtr iter(const SourceRange& loc, Function& m) override;
+
+ private:
+  // Using ordered map here to ensure ordering of enum values is deterministic
+  // when iterating through them.
+  std::map<std::string, SugaredValuePtr> enum_values_;
+  EnumTypePtr enum_type_;
+};
+
 struct VISIBILITY_HIDDEN BooleanDispatchValue : public SugaredValue {
   BooleanDispatchValue(py::dict dispatched_fn)
       : dispatched_fn_(std::move(dispatched_fn)) {}


### PR DESCRIPTION
[3/N] Implement Enum JIT support

* Add enum value as constant support
* Add sugared value for EnumClass

Supported:
Enum-typed function arguments
using Enum type and comparing them
Support getting name/value attrs of enums
Using Enum value as constant

TODO:
Add PyThon sugared value for Enum
Support Enum-typed return values
Support serialization and deserialization