### PR TITLE
Make `run_binary_ops_test` function generic and Add tests to add_kernel function

### DIFF
--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -6,6 +6,67 @@
 using namespace std;
 using namespace at;
 
+class atest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    x_tensor = tensor({10, -1, 0, 1, -10});
+    y_tensor = tensor({-10, 1, 0, -1, 10});
+    x_logical = tensor({1, 1, 0, 1, 0});
+    y_logical = tensor({0, 1, 0, 1, 1});
+  }
+
+  Tensor x_tensor, y_tensor;
+  Tensor x_logical, y_logical;
+  const int FLOAT = 2;
+  const int INTBOOL = 5;
+  const int INTBOOLFLOAT = 7;
+};
+
+/*
+  template function for running binary operator test
+  - exp: expected output
+  - func: function to be tested
+  - option: 3 bits,
+    - 1st bit: Test op over integer tensors
+    - 2nd bit: Test op over float tensors
+    - 3rd bit: Test op over boolean tensors
+    For example, if function should be tested over integer/boolean but not for
+    float, option will be 1 * 1 + 0 * 2 + 1 * 4 = 5. If tested over all the
+    type, option should be 7.
+*/
+template <typename T, typename... Args>
+void run_binary_ops_test(
+    T func,
+    const Tensor& x_tensor,
+    const Tensor& y_tensor,
+    const Tensor& exp,
+    int option,
+    Args... args) {
+  // Test op over integer tensors
+  if (option & 1) {
+    auto out_tensor = empty({5}, kInt);
+    func(out_tensor, x_tensor, y_tensor, args...);
+    ASSERT_EQ(out_tensor.dtype(), kInt);
+    ASSERT_TRUE(exp.equal(out_tensor));
+  }
+
+  // Test op over float tensors
+  if (option & 2) {
+    auto out_tensor = empty({5}, kFloat);
+    func(out_tensor, x_tensor.to(kFloat), y_tensor.to(kFloat), args...);
+    ASSERT_EQ(out_tensor.dtype(), kFloat);
+    ASSERT_TRUE(out_tensor.equal(exp.to(kFloat)));
+  }
+
+  // Test op over boolean tensors
+  if (option & 4) {
+    auto out_tensor = empty({5}, kBool);
+    func(out_tensor, x_tensor.to(kBool), y_tensor.to(kBool), args...);
+    ASSERT_EQ(out_tensor.dtype(), kBool);
+    ASSERT_TRUE(out_tensor.equal(exp.to(kBool)));
+  }
+}
+
 void trace() {
   Tensor foo = rand({12, 12});
 
@@ -20,7 +81,7 @@ void trace() {
   ASSERT_FLOAT_EQ(foo.trace().item<float>(), trace);
 }
 
-TEST(atest, operators) {
+TEST_F(atest, operators) {
   int a = 0b10101011;
   int b = 0b01111011;
 
@@ -33,70 +94,82 @@ TEST(atest, operators) {
   ASSERT_TRUE(tensor({a ^ b}).equal(a_tensor ^ b_tensor));
 }
 
-template <typename T>
-void run_logical_op_test(const Tensor& exp, T func) {
-  auto x_tensor = tensor({1, 1, 0, 1, 0});
-  auto y_tensor = tensor({0, 1, 0, 1, 1});
-  // Test op over integer tensors
-  auto out_tensor = empty({5}, kInt);
-  func(out_tensor, x_tensor, y_tensor);
-  ASSERT_EQ(out_tensor.dtype(), kInt);
-  ASSERT_TRUE(exp.equal(out_tensor));
-  // Test op over boolean tensors
-  out_tensor = empty({5}, kBool);
-  func(out_tensor, x_tensor.to(kBool), y_tensor.to(kBool));
-  ASSERT_EQ(out_tensor.dtype(), kBool);
-  ASSERT_TRUE(out_tensor.equal(exp.to(kBool)));
+TEST_F(atest, logical_and_operators) {
+  auto exp_tensor = tensor({0, 1, 0, 1, 0});
+  run_binary_ops_test(
+      logical_and_out, x_logical, y_logical, exp_tensor, INTBOOL);
 }
 
-TEST(atest, logical_and_operators) {
-  run_logical_op_test(tensor({0, 1, 0, 1, 0}), logical_and_out);
-}
-TEST(atest, logical_or_operators) {
-  run_logical_op_test(tensor({1, 1, 0, 1, 1}), logical_or_out);
-}
-TEST(atest, logical_xor_operators) {
-  run_logical_op_test(tensor({1, 0, 0, 0, 1}), logical_xor_out);
+TEST_F(atest, logical_or_operators) {
+  auto exp_tensor = tensor({1, 1, 0, 1, 1});
+  run_binary_ops_test(
+      logical_or_out, x_logical, y_logical, exp_tensor, INTBOOL);
 }
 
-TEST(atest, lt_operators) {
-  run_logical_op_test<
+TEST_F(atest, logical_xor_operators) {
+  auto exp_tensor = tensor({1, 0, 0, 0, 1});
+  run_binary_ops_test(
+      logical_xor_out, x_logical, y_logical, exp_tensor, INTBOOL);
+}
+
+TEST_F(atest, lt_operators) {
+  auto exp_tensor = tensor({0, 0, 0, 0, 1});
+  run_binary_ops_test<
       at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
-      tensor({0, 0, 0, 0, 1}), lt_out);
+      lt_out, x_logical, y_logical, exp_tensor, INTBOOL);
 }
 
-TEST(atest, le_operators) {
-  run_logical_op_test<
+TEST_F(atest, le_operators) {
+  auto exp_tensor = tensor({0, 1, 1, 1, 1});
+  run_binary_ops_test<
       at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
-      tensor({0, 1, 1, 1, 1}), le_out);
+      le_out, x_logical, y_logical, exp_tensor, INTBOOL);
 }
 
-TEST(atest, gt_operators) {
-  run_logical_op_test<
+TEST_F(atest, gt_operators) {
+  auto exp_tensor = tensor({1, 0, 0, 0, 0});
+  run_binary_ops_test<
       at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
-      tensor({1, 0, 0, 0, 0}), gt_out);
+      gt_out, x_logical, y_logical, exp_tensor, INTBOOL);
 }
 
-TEST(atest, ge_operators) {
-  run_logical_op_test<
+TEST_F(atest, ge_operators) {
+  auto exp_tensor = tensor({1, 1, 1, 1, 0});
+  run_binary_ops_test<
       at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
-      tensor({1, 1, 1, 1, 0}), ge_out);
+      ge_out, x_logical, y_logical, exp_tensor, INTBOOL);
 }
 
-TEST(atest, eq_operators) {
-  run_logical_op_test<
+TEST_F(atest, eq_operators) {
+  auto exp_tensor = tensor({0, 1, 1, 1, 0});
+  run_binary_ops_test<
       at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
-      tensor({0, 1, 1, 1, 0}), eq_out);
+      eq_out, x_logical, y_logical, exp_tensor, INTBOOL);
 }
 
-TEST(atest, ne_operators) {
-  run_logical_op_test<
+TEST_F(atest, ne_operators) {
+  auto exp_tensor = tensor({1, 0, 0, 0, 1});
+  run_binary_ops_test<
       at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
-      tensor({1, 0, 0, 0, 1}), ne_out);
+      ne_out, x_logical, y_logical, exp_tensor, 5);
+}
+
+TEST_F(atest, add_operators) {
+  auto exp_tensor = tensor({-10, 1, 0, -1, 10});
+  run_binary_ops_test(add_out, x_tensor, y_tensor, exp_tensor, INTBOOL, 2);
+}
+
+      at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
+}
+
+      at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
+}
+
+      at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
 }
 
 // TEST_CASE( "atest", "[]" ) {
-TEST(atest, atest) {
+TEST_F(atest, atest) {
   manual_seed(123);
 
   auto foo = rand({12, 6});


### PR DESCRIPTION
Summary:
1. Add test fixture `atest class` to store global variables
2. Make `run_binary_ops_test` function generic: can dispose different dtypes and different numbers of parameters
3. add test to `add_kernel`

Test Plan:
Run locally to check cover the corresponding code part in `BinaryOpsKernel.cpp`.
CI

Differential Revision: D22759942

