### PR TITLE
If we don't collect tracing, always free the trace data

### DIFF
--- a/caffe2/opt/onnxifi_op.cc
+++ b/caffe2/opt/onnxifi_op.cc
@@ -550,6 +550,8 @@ bool OnnxifiOp<CPUContext>::RunOnDevice() {
             delete p;
           });
       traces_->numEvents = 0;
+    } else {
+      traces_.reset();
     }
     CAFFE_ENFORCE_EQ(
         (*onnxSetIOAndRunGraphPointer_)(


### PR DESCRIPTION
Summary: We toggle trace on with a certain probablility. In the case of 3 inferences with trace on/off/on. We leak the trace from the first inference. Always clean up the trace will fix it.

Test Plan: predictor

Differential Revision: D22768382

