### PR TITLE
Add a new op for converting the dense feature to sparse representation

### DIFF
--- a/caffe2/operators/feature_maps_ops.cc
+++ b/caffe2/operators/feature_maps_ops.cc
@@ -42,6 +42,23 @@ const std::string doc = R"DOC(
 )DOC";
 
 REGISTER_CPU_OPERATOR(
+    MergeDenseFeatureTensors,
+    MergeDenseFeatureTensorsOp<CPUContext>);
+OPERATOR_SCHEMA(MergeDenseFeatureTensors)
+    .SetDoc(
+        "Merge given multi-feature dense tensors  into one "
+        "multi-feature tensor." +
+        doc)
+    .NumInputs(2)
+    .NumOutputs(3)
+    .Input(0, "in1", "")
+    .Input(1, "in1_presence", ".presence")
+    .Output(0, "out_lengths", ".lengths")
+    .Output(1, "out_keys", ".keys")
+    .Output(2, "out_values", ".values")
+    .Arg("feature_ids", "feature ids");
+
+REGISTER_CPU_OPERATOR(
     MergeSingleScalarFeatureTensors,
     MergeSingleScalarFeatureTensorsOp<CPUContext>);
 OPERATOR_SCHEMA(MergeSingleScalarFeatureTensors)

--- a/caffe2/python/operator_test/feature_maps_ops_test.py
+++ b/caffe2/python/operator_test/feature_maps_ops_test.py
@@ -9,6 +9,43 @@ import numpy as np
 
 class TestFeatureMapsOps(TestCase):
 
+    def test_merge_dense_feature_tensors(self):
+        op = core.CreateOperator(
+            "MergeDenseFeatureTensors",
+            [
+                "in1", "in1_presence",
+            ],
+            [
+                "out_lengths", "out_keys", "out_values",
+            ],
+            feature_ids=[11, 12, 13, 14]
+        )
+        # Input 1.
+        workspace.FeedBlob(
+            "in1",
+            np.array([[11.1, 12.1, 13.1, 14.1], [11.2, 12.2, 13.2, 14.2]], dtype=np.float)
+        )
+        workspace.FeedBlob(
+            "in1_presence",
+            np.array([[True, False, False, True], [False, True, True, False]], dtype=np.bool)
+        )
+
+        workspace.RunOperatorOnce(op)
+
+        np.testing.assert_array_equal(
+            workspace.FetchBlob("out_lengths"),
+            np.array([2, 2], dtype=np.int32)
+        )
+        np.testing.assert_array_equal(
+            workspace.FetchBlob("out_keys"),
+            np.array([11, 14, 12, 13], dtype=np.int64)
+        )
+        np.testing.assert_array_equal(
+            workspace.FetchBlob("out_values"),
+            np.array([11.1, 14.1, 12.2, 13.2], dtype=np.float)
+        )
+
+
     def test_merge_single_scalar_feature_tensors(self):
         op = core.CreateOperator(
             "MergeSingleScalarFeatureTensors",


### PR DESCRIPTION
Summary: we need this op to avoid the splicing of a dense tensor and then use the Mergesinglescaler op

Test Plan: integrated test with dper2

Differential Revision: D22677523

