### PR TITLE
Refactor lite serializer dependencies from full jit

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -106,7 +106,7 @@ jit_sources_common = [
 
 libtorch_sources_common = core_sources_common + jit_sources_common
 
-core_autograd_sources = [
+core_trainer_sources = [
     "torch/csrc/autograd/anomaly_mode.cpp",
     "torch/csrc/autograd/autograd.cpp",
     "torch/csrc/autograd/cpp_hook.cpp",
@@ -122,6 +122,10 @@ core_autograd_sources = [
     "torch/csrc/autograd/record_function_ops.cpp",
     "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/variable.cpp",
+    "torch/csrc/jit/frontend/name_mangler.cpp",
+    "torch/csrc/jit/ir/type_hashing.cpp",
+    "torch/csrc/jit/serialization/pickler.cpp",
+    "torch/csrc/jit/serialization/type_name_uniquer.cpp",
 ]
 
 core_sources_full = [
@@ -143,7 +147,6 @@ core_sources_full = [
     "torch/csrc/jit/frontend/exit_transforms.cpp",
     "torch/csrc/jit/frontend/inline_loop_condition.cpp",
     "torch/csrc/jit/frontend/ir_emitter.cpp",
-    "torch/csrc/jit/frontend/name_mangler.cpp",
     "torch/csrc/jit/frontend/parser.cpp",
     "torch/csrc/jit/frontend/schema_matching.cpp",
     "torch/csrc/jit/frontend/script_type_parser.cpp",
@@ -157,7 +160,6 @@ core_sources_full = [
     "torch/csrc/jit/ir/node_hashing.cpp",
     "torch/csrc/jit/ir/scope.cpp",
     "torch/csrc/jit/ir/subgraph_matcher.cpp",
-    "torch/csrc/jit/ir/type_hashing.cpp",
     "torch/csrc/jit/jit_log.cpp",
     "torch/csrc/jit/passes/bailout_graph.cpp",
     "torch/csrc/jit/passes/batch_mm.cpp",
@@ -228,10 +230,8 @@ core_sources_full = [
     "torch/csrc/jit/serialization/import_export_helpers.cpp",
     "torch/csrc/jit/serialization/import_source.cpp",
     "torch/csrc/jit/serialization/pickle.cpp",
-    "torch/csrc/jit/serialization/pickler.cpp",
     "torch/csrc/jit/serialization/python_print.cpp",
     "torch/csrc/jit/serialization/source_range_serialization.cpp",
-    "torch/csrc/jit/serialization/type_name_uniquer.cpp",
     "torch/csrc/jit/tensorexpr/bounds_inference.cpp",
     "torch/csrc/jit/tensorexpr/codegen.cpp",
     "torch/csrc/jit/tensorexpr/eval.cpp",
@@ -257,7 +257,7 @@ core_sources_full = [
     "torch/csrc/utils/variadic.cpp",
 ]
 
-libtorch_core_sources = sorted(core_sources_common + core_sources_full + core_autograd_sources)
+libtorch_core_sources = sorted(core_sources_common + core_sources_full + core_trainer_sources)
 
 libtorch_distributed_sources = [
     "torch/csrc/distributed/autograd/autograd.cpp",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42127 Refactor lite serializer dependencies from full jit**

This diff renames core_autograd_sources to core_trainer_sources and moves/adds dependencies for the lite trainer in order to build the serializer functionality internally.

Differential Revision: [D22738293](https://our.internmc.facebook.com/intern/diff/D22738293/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22738293/)!