### PR TITLE
Let DDP.train() return self to stay consistent with nn.Module

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -602,6 +602,7 @@ class DistributedDataParallel(Module):
         super(DistributedDataParallel, self).train(mode)
         for module in self._module_copies[1:]:
             module.train(mode)
+        return self
 
     def _register_comm_hook(self, state: object, hook: callable):
         r"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42131 Let DDP.train() return self to stay consistent with nn.Module**

Differential Revision: [D22775311](https://our.internmc.facebook.com/intern/diff/D22775311)