### PR TITLE
.circleci: Prefer netrc for docs push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1356,21 +1356,19 @@ jobs:
     - attach_workspace:
         at: /tmp/workspace
     - run:
-        name: Install expect
+        name: Generate netrc
         command: |
-          sudo apt-get update && sudo apt-get install -y expect
+          # set credentials for https pushing
+          cat > ~/.netrc \<<DONE
+            machine github.com
+            login pytorchbot
+            password ${GITHUB_PYTORCHBOT_TOKEN}
+          DONE
     - run:
         name: Docs push
         command: |
           pushd /tmp/workspace
-          /usr/bin/expect \<<DONE
-            spawn git push -u origin master
-            expect "Username*"
-            send "pytorchbot\n"
-            expect "Password*"
-            send "$::env(GITHUB_PYTORCHBOT_TOKEN)\n"
-            expect eof
-          DONE
+          git push -u origin master
 
   pytorch_python_doc_build:
     environment:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -6,21 +6,19 @@
     - attach_workspace:
         at: /tmp/workspace
     - run:
-        name: Install expect
+        name: Generate netrc
         command: |
-          sudo apt-get update && sudo apt-get install -y expect
+          # set credentials for https pushing
+          cat > ~/.netrc \<<DONE
+            machine github.com
+            login pytorchbot
+            password ${GITHUB_PYTORCHBOT_TOKEN}
+          DONE
     - run:
         name: Docs push
         command: |
           pushd /tmp/workspace
-          /usr/bin/expect \<<DONE
-            spawn git push -u origin master
-            expect "Username*"
-            send "pytorchbot\n"
-            expect "Password*"
-            send "$::env(GITHUB_PYTORCHBOT_TOKEN)\n"
-            expect eof
-          DONE
+          git push -u origin master
 
   pytorch_python_doc_build:
     environment:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42136 .circleci: Prefer netrc for docs push**

Expect was giving weird issues so let's just use netrc since it doesn't
rely on janky expect behavior

Another follow up for: https://github.com/pytorch/pytorch/pull/41964

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D22778940](https://our.internmc.facebook.com/intern/diff/D22778940)