### PR TITLE
Add benchmark for calculate_qparams

### DIFF
--- a/benchmarks/operator_benchmark/pt/qobserver_test.py
+++ b/benchmarks/operator_benchmark/pt/qobserver_test.py
@@ -70,6 +70,13 @@ qobserver_per_channel_list = op_bench.op_list(
     ]
 )
 
+qobserver_calculate_qparams_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['HistogramObserverCalculateQparams', obs.HistogramObserver],
+    ]
+)
+
 
 class QObserverBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, C, M, N, dtype, qscheme, op_func, device):
@@ -78,6 +85,15 @@ class QObserverBenchmark(op_bench.TorchBenchmarkBase):
 
     def forward(self):
         return self.op_func(self.f_input)
+
+class QObserverBenchmarkCalculateQparams(op_bench.TorchBenchmarkBase):
+    def init(self, C, M, N, dtype, qscheme, op_func, device):
+        self.f_input = torch.rand(C, M, N, device=device)
+        self.q_observer = op_func(dtype=dtype, qscheme=qscheme).to(device)
+        self.q_observer(self.f_input)
+
+    def forward(self):
+        return self.q_observer.calculate_qparams()
 
 
 op_bench.generate_pt_tests_from_op_list(
@@ -89,6 +105,11 @@ op_bench.generate_pt_tests_from_op_list(
     qobserver_per_channel_list,
     qobserver_per_channel_configs_short + qobserver_per_channel_configs_long,
     QObserverBenchmark)
+
+op_bench.generate_pt_tests_from_op_list(
+    qobserver_calculate_qparams_list,
+    qobserver_per_tensor_configs_short + qobserver_per_tensor_configs_long,
+    QObserverBenchmarkCalculateQparams)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a benchmark for HistogramObserver.calculate_qparams to the quantized op benchmarks. The next PR in this stack (#41041) adds a ~15x speedup for this benchmark.

While in the folder `benchmarks/operator_benchmark`, the benchmark can be run using `python -m benchmark_all_quantized_test --operators HistogramObserverCalculateQparams`.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #41041 Speed up HistogramObserver by vectorizing critical path
* **#42138 Add benchmark for calculate_qparams**

Differential Revision: [D22779291](https://our.internmc.facebook.com/intern/diff/D22779291)