### PR TITLE
[ONNX] Updating input node removal in ONNX function_substitution pass.

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -780,6 +780,32 @@ class TestUtilityFuns(TestCase):
         ort_outs2 = ort_sess.run(None, ort_inputs)
         [np.testing.assert_allclose(ort_out1, ort_out2, atol=1e-7, rtol=0.001) for ort_out1, ort_out2 in zip(ort_outs1, ort_outs2)]
 
+    def test_onnx_function_substitution_pass(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+
+            @torch.jit.script
+            def f(x : torch.Tensor, y : torch.Tensor):
+                z = x - y
+                return x + z
+
+            def forward(self, x, y):
+                return self.f(x, y)
+
+        model = MyModule()
+        input_1 = torch.tensor(11)
+        input_2 = torch.tensor(12)
+        _set_opset_version(self.opset_version)
+        _set_operator_export_type(OperatorExportTypes.ONNX)
+        graph, _, __ = utils._model_to_graph(MyModule(), (input_1, input_2), do_constant_folding=True,
+                                            operator_export_type=OperatorExportTypes.ONNX)
+        # Check that the prim::Constant node in the graph for representing the
+        # scripted function `f` is removed and the following prim::CallFunction
+        # is replced by inline graph, with onnx::Sub and onnx::Add nodes.
+        for node in graph.nodes():
+            assert node.kind() != "prim::Constant"
+        assert len(list(graph.nodes())) == 2  # onnx::Sub and onnx::Add nodes only.
 
 # opset 10 tests
 TestUtilityFuns_opset10 = type(str("TestUtilityFuns_opset10"),
@@ -797,11 +823,6 @@ TestUtilityFuns_opset12 = type(str("TestUtilityFuns_opset12"),
                                (TestCase,),
                                dict(TestUtilityFuns.__dict__, opset_version=12))
 
-
-# opset 12tests
-TestUtilityFuns_opset12 = type(str("TestUtilityFuns_opset12"),
-                               (TestCase,),
-                               dict(TestUtilityFuns.__dict__, opset_version=12))
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/passes/onnx/function_substitution.cpp
+++ b/torch/csrc/jit/passes/onnx/function_substitution.cpp
@@ -20,7 +20,12 @@ void functionCallSubstitution(Block* block) {
                  "torch.nn.functional") != std::string::npos) &&
             (fun_type->function()->qualname().qualifiedName().find(
                  "interpolate") != std::string::npos)) {
+          // Remove input[0] and the node that feeds into it
+          auto input_node_0 = cur->input(0)->node();
           cur->removeInput(0);
+          if (!input_node_0->hasUses()) {
+            input_node_0->destroy();
+          }
           Node* interpolate_node = block->owningGraph()->create(
               Symbol::fromQualString("aten::__interpolate"),
               {cur->inputs()},
@@ -38,7 +43,12 @@ void functionCallSubstitution(Block* block) {
               "Function in ONNX function call substitution body: ",
               *fun_type->function()->optimized_graph());
         } else {
+          // Remove input[0] and the node that feeds into it
+          auto input_node_0 = cur->input(0)->node();
           cur->removeInput(0);
+          if (!input_node_0->hasUses()) {
+            input_node_0->destroy();
+          }
           functionCallSubstitution(fun_type->function()->graph()->block());
           inlineCallTo(cur, fun_type->function(), false);
         }


### PR DESCRIPTION
ONNX pass `torch._C._jit_pass_onnx_function_substitution(graph)` inlines the function with the compiled torch graph. But while it removes all connections with the compiled function node (e.g. see below - `%6 : Function = prim::Constant[name="f"]()`), it does not remove the function node itself. For example, if the input graph is:
```
graph(%0 : Long(requires_grad=0, device=cpu),
      %1 : Long(requires_grad=0, device=cpu)):
  %6 : Function = prim::Constant[name="f"]()
  %7 : Tensor = prim::CallFunction(%6, %0, %1)
  return (%7)
```
The output graph is: 
```
graph(%0 : Long(requires_grad=0, device=cpu),
      %1 : Long(requires_grad=0, device=cpu)):
  %6 : Function = prim::Constant[name="f"]()
  %8 : int = prim::Constant[value=1]()
  %z.1 : Tensor = aten::sub(%0, %1, %8) # test/onnx/test_utility_funs.py:790:20
  %10 : Tensor = aten::add(%0, %z.1, %8) # test/onnx/test_utility_funs.py:791:23
  return (%10)
```
Note that the `%6 : Function = prim::Constant[name="f"]()` has not been removed (though it is not being used).

This PR updates the pass to remove the function node completely. The updated graph looks as follows:
```
graph(%0 : Long(requires_grad=0, device=cpu),
      %1 : Long(requires_grad=0, device=cpu)):
  %8 : int = prim::Constant[value=1]()
  %z.1 : Tensor = aten::sub(%0, %1, %8) # test/onnx/test_utility_funs.py:790:20
  %10 : Tensor = aten::add(%0, %z.1, %8) # test/onnx/test_utility_funs.py:791:23
  return (%10)
```

A test point has also been added for this scenario.