### PR TITLE
Fix flaky NCCL error handling tests.

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -3471,6 +3471,8 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
             # aborting nccl communicators before throwing Operation timed out
             a = torch.rand(10).cuda(self.rank)
         elif self.rank == 1:
+            # Clean up structures (ex: files for FileStore before going down)
+            del process_group
             func()
         else:
             # Wait for timeout
@@ -3552,7 +3554,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
                     return
                 else:
                     raise e
-            time.sleep(1)
+            time.sleep(0.1)
 
     @requires_nccl()
     @skip_if_lt_x_gpu(3)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42149 Fix flaky NCCL error handling tests.**

Some of these tests were flaky since we could kill the process in some
way without cleaning up the ProcessGroup. This resulted in issues where the
FileStore didn't clean up appropriately resulting in other processes in the
group to crash.

Fixed this by explicitly deleting the process_group before we bring a process
down forcibly.

Differential Revision: [D22785042](https://our.internmc.facebook.com/intern/diff/D22785042/)

#Closes: https://github.com/pytorch/pytorch/issues/31924