### PR TITLE
Skip DataIO tests relying on LevelDB if compiled without it

### DIFF
--- a/caffe2/python/dataio_test.py
+++ b/caffe2/python/dataio_test.py
@@ -381,6 +381,7 @@ class TestDBFileReader(TestCase):
 
         return ws.blobs[str(dst_ds.content().label())].fetch()
 
+    @unittest.skipIf("LevelDB" not in core.C.registered_dbs(), "Need LevelDB")
     def test_cached_reader(self):
         ws = workspace.C.Workspace()
         session = LocalSession(ws)
@@ -420,6 +421,7 @@ class TestDBFileReader(TestCase):
 
         self._delete_path(db_path)
 
+    @unittest.skipIf("LevelDB" not in core.C.registered_dbs(), "Need LevelDB")
     def test_db_file_reader(self):
         ws = workspace.C.Workspace()
         session = LocalSession(ws)

--- a/caffe2/python/operator_test/checkpoint_test.py
+++ b/caffe2/python/operator_test/checkpoint_test.py
@@ -14,6 +14,7 @@ class CheckpointTest(test_util.TestCase):
     """A simple test case to make sure that the checkpoint behavior is correct.
     """
 
+    @unittest.skipIf("LevelDB" not in core.C.registered_dbs(), "Need LevelDB")
     def testCheckpoint(self):
         temp_root = tempfile.mkdtemp()
         net = core.Net("test_checkpoint")


### PR DESCRIPTION
Found while trying to get RocM Caffe2 job green
