### PR TITLE
Remove dead named_tensors_unsupported_error definitions.

### DIFF
--- a/aten/src/ATen/templates/LegacyTHFunctions.cpp
+++ b/aten/src/ATen/templates/LegacyTHFunctions.cpp
@@ -10,13 +10,6 @@
 ${th_headers}
 ${extra_cuda_headers}
 
-namespace {
-static const char* named_tensors_unsupported_error =
-  " is not yet supported with named tensors. Please drop names via "
-  "`tensor = tensor.rename(None)`, call the op with an unnamed tensor, "
-  "and set names on the result of the operation.";
-}
-
 namespace at {
 namespace native {
 namespace legacy {

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -28,13 +28,6 @@
 #include <ATen/Config.h>
 $extra_cuda_headers
 
-namespace {
-static const char* named_tensors_unsupported_error =
-  " is not yet supported with named tensors. Please drop names via "
-  "`tensor = tensor.rename(None)`, call the op with an unnamed tensor, "
-  "and set names on the result of the operation.";
-}
-
 namespace at {
 
 namespace ${Type} {

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -16,13 +16,6 @@
 #include <ATen/core/op_registration/hacky_wrapper_for_legacy_signatures.h>
 #include <torch/library.h>
 
-namespace {
-static const char* named_tensors_unsupported_error =
-  " is not yet supported with named tensors. Please drop names via "
-  "`tensor = tensor.rename(None)`, call the op with an unnamed tensor, "
-  "and set names on the result of the operation.";
-}
-
 namespace at {
 namespace TypeDefault {
 

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -34,13 +34,6 @@ $storage_tensor_headers
 $extra_cuda_headers
 $legacy_th_headers
 
-namespace {
-static const char* named_tensors_unsupported_error =
-  " is not yet supported with named tensors. Please drop names via "
-  "`tensor = tensor.rename(None)`, call the op with an unnamed tensor, "
-  "and set names on the result of the operation.";
-}
-
 namespace at {
 
 /* example


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42171 Remove dead named_tensors_unsupported_error definitions.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D22794980](https://our.internmc.facebook.com/intern/diff/D22794980)