### PR TITLE
Augment inlined call stack with module type/instance info.

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -552,11 +552,8 @@ void testLiteInterpreterDuplicatedClassTypeModuleInfo() {
     }
   }
 
-  // The current approach is not able to distinguish between A0 and A1,
-  // which have the same class type. Hence, it only records module
-  // information for A1.
   std::unordered_set<std::string> expected_result(
-      {"top(B).forward", "top(B).A1(A).forward"});
+      {"top(B).forward", "top(B).A0(A).forward", "top(B).A1(A).forward"});
   AT_ASSERT(module_debug_info_set == expected_result);
 }
 

--- a/test/jit/test_scope_with_inlined_callstack.py
+++ b/test/jit/test_scope_with_inlined_callstack.py
@@ -1,0 +1,206 @@
+import unittest
+import re
+
+import torch
+from torch.testing._internal.jit_utils import JitTestCase
+
+from torch.testing import FileCheck
+
+class D(torch.nn.Module):
+    def __init__(self, x):
+        super(D, self).__init__()
+        self.x = x
+
+    def forward(self, y):
+        return self.x + y
+
+class B(torch.nn.Module):
+    def __init__(self, x):
+        super(B, self).__init__()
+        self.d = D(x)
+
+    def forward(self, y):
+        return self.d(y)
+
+    def named_method(self, y):
+        return self.d(y)
+
+class C(torch.nn.Module):
+    def __init__(self, x):
+        super(C, self).__init__()
+        self.d = D(x)
+
+    def forward(self, y):
+        return self.d(y)
+
+    def named_method(self, y):
+        return self.d(y)
+
+class A(torch.nn.Module):
+    def __init__(self, x):
+        super(A, self).__init__()
+        self.b0 = B(x)
+        self.b1 = B(x)
+        self.c0 = C(x)
+        self.c1 = C(x)
+        self.x = x
+
+    def forward(self, y):
+        return self.b0(y) + self.b1(y) + self.c0(y) + self.c1(y)
+
+    def named_method(self, y):
+        return self.b0.named_method(y) + \
+            self.b1.named_method(y) + \
+            self.c0.named_method(y) + \
+            self.c1.named_method(y) + \
+            self.x
+
+class TOP(torch.nn.Module):
+    def __init__(self, x):
+        super(TOP, self).__init__()
+        self.a0 = A(x)
+        self.a1 = A(x)
+
+    def forward(self, y):
+        return self.a0(y) + self.a1(y)
+
+class TOPWithNamedMethods(torch.nn.Module):
+    def __init__(self, x):
+        super(TOPWithNamedMethods, self).__init__()
+        self.a0 = A(x)
+        self.a1 = A(x)
+
+    def forward(self, y):
+        return self.a0.named_method(y) + self.a1.named_method(y)
+
+def func_foo(object: A, arg):
+    return object.forward(arg)
+
+class TOPWithFreeFunction(torch.nn.Module):
+    def __init__(self, x):
+        super(TOPWithFreeFunction, self).__init__()
+        self.a0 = A(x)
+        self.a1 = A(x)
+
+    def forward(self, y):
+        return func_foo(self.a0, y) + func_foo(self.a1, y)
+
+def get_add_lines(graph):
+    graph_str = str(graph)
+    graph_str_lines = graph_str.splitlines()
+    add_op_lines = []
+    for line in graph_str_lines:
+        if re.match('(.*)aten::add(.*)', line):
+            add_op_lines.append(line)
+    add_op_lines = '\n'.join(add_op_lines)
+    return add_op_lines
+
+class TestScopeWithInlinedCallSTack(JitTestCase):
+    def test_scope_info(self):
+        m = torch.jit.script(TOP(10))
+        torch._C._jit_pass_inline(m.graph)
+        torch._C._jit_pass_reconstruct_scope_from_inlined_callstack(m.graph)
+        add_op_lines = get_add_lines(m.graph)
+        FileCheck().check_count("aten::add(", 15, exactly=True).run(add_op_lines)
+        # A does 3 adds and hence 4 operands.
+        # Each operand of the add inturn does one add.
+        FileCheck().check_count("A(a0)::forward", 7, exactly=True).run(add_op_lines)
+        FileCheck().check_count("A(a1)::forward", 7, exactly=True).run(add_op_lines)
+        # One b0 instance from a0, and one from a1
+        FileCheck().check_count("B(b0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("B(b1)::forward", 2, exactly=True).run(add_op_lines)
+        # One c0 instance from a0, and one from a1
+        FileCheck().check_count("C(c0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("C(c1)::forward", 2, exactly=True).run(add_op_lines)
+        # 4 d instances from a0, and 4 from a1
+        FileCheck().check_count("D(d)::forward", 8, exactly=True).run(add_op_lines)
+
+        m = torch.jit.trace(TOP(10), torch.zeros((1)))
+        torch._C._jit_pass_inline(m.graph)
+        torch._C._jit_pass_reconstruct_scope_from_inlined_callstack(m.graph)
+        add_op_lines = get_add_lines(m.graph)
+        FileCheck().check_count("aten::add(", 15, exactly=True).run(add_op_lines)
+        # A does 3 adds and hence 4 operands.
+        # Each operand of the add inturn does one add.
+        FileCheck().check_count("A(a0)::forward", 7, exactly=True).run(add_op_lines)
+        FileCheck().check_count("A(a1)::forward", 7, exactly=True).run(add_op_lines)
+        # One b0 instance from a0, and one from a1
+        FileCheck().check_count("B(b0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("B(b1)::forward", 2, exactly=True).run(add_op_lines)
+        # One c0 instance from a0, and one from a1
+        FileCheck().check_count("C(c0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("C(c1)::forward", 2, exactly=True).run(add_op_lines)
+        # 4 d instances from a0, and 4 from a1
+        FileCheck().check_count("D(d)::forward", 8, exactly=True).run(add_op_lines)
+
+    def test_scope_info_with_named_method(self):
+        m = torch.jit.script(TOPWithNamedMethods(10))
+        torch._C._jit_pass_inline(m.graph)
+        torch._C._jit_pass_reconstruct_scope_from_inlined_callstack(m.graph)
+        add_op_lines = get_add_lines(m.graph)
+        FileCheck().check_count("aten::add(", 17, exactly=True).run(add_op_lines)
+        # A does 3 adds and hence 4 operands.
+        # Each operand of the add inturn does one add.
+        FileCheck().check_count("A(a0)::named_method", 8, exactly=True).run(add_op_lines)
+        FileCheck().check_count("A(a1)::named_method", 8, exactly=True).run(add_op_lines)
+        # One b0 instance from a0, and one from a1
+        FileCheck().check_count("B(b0)::named_method", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("B(b1)::named_method", 2, exactly=True).run(add_op_lines)
+        # One c0 instance from a0, and one from a1
+        FileCheck().check_count("C(c0)::named_method", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("C(c1)::named_method", 2, exactly=True).run(add_op_lines)
+        # 4 d instances from a0, and 4 from a1
+        FileCheck().check_count("D(d)::forward", 8, exactly=True).run(add_op_lines)
+
+        m = torch.jit.trace(TOPWithNamedMethods(10), torch.zeros((1)))
+        torch._C._jit_pass_inline(m.graph)
+        torch._C._jit_pass_reconstruct_scope_from_inlined_callstack(m.graph)
+        add_op_lines = get_add_lines(m.graph)
+        # Tracing seems to remove optimize and inline a bunch of stuff so that only
+        # CallMethods that remain are for D module. Rest are inlined.
+        # Note sure if checking for D is meanigful even, since that might be inlined
+        # too. It is just so that right now it is not.
+        FileCheck().check_count("aten::add(", 17, exactly=True).run(add_op_lines)
+        FileCheck().check_count("D(d)::forward", 8, exactly=True).run(add_op_lines)
+
+    def test_scope_info_with_free_function(self):
+        m = torch.jit.script(TOPWithFreeFunction(10))
+        torch._C._jit_pass_inline(m.graph)
+        torch._C._jit_pass_reconstruct_scope_from_inlined_callstack(m.graph)
+        add_op_lines = get_add_lines(m.graph)
+        FileCheck().check_count("aten::add(", 15, exactly=True).run(add_op_lines)
+        # Call func_foo method twice
+        FileCheck().check_count("FreeFunction::func_foo", 14, exactly=True).run(add_op_lines)
+        # A does 3 adds and hence 4 operands.
+        # Each operand of the add inturn does one add.
+        # Here instance name cannot be extracted for the two calls to func_foo
+        FileCheck().check_count("A(INSTANCE_NAME_UNKNOWN)::forward", 14, exactly=True).run(add_op_lines)
+        # One b0 instance from a0, and one from a1
+        FileCheck().check_count("B(b0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("B(b1)::forward", 2, exactly=True).run(add_op_lines)
+        # One c0 instance from a0, and one from a1
+        FileCheck().check_count("C(c0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("C(c1)::forward", 2, exactly=True).run(add_op_lines)
+        # 4 d instances from a0, and 4 from a1
+        FileCheck().check_count("D(d)::forward", 8, exactly=True).run(add_op_lines)
+
+        # Tracing is retaining only some modules and much is inlined.
+        m = torch.jit.trace(TOPWithFreeFunction(10), torch.zeros((1)))
+        torch._C._jit_pass_inline(m.graph)
+        torch._C._jit_pass_reconstruct_scope_from_inlined_callstack(m.graph)
+        add_op_lines = get_add_lines(m.graph)
+        FileCheck().check_count("aten::add(", 15, exactly=True).run(add_op_lines)
+        # func_foo is inlined during tracing and so is A's forward methods.
+        # One b0 instance from a0, and one from a1
+        FileCheck().check_count("B(b0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("B(b1)::forward", 2, exactly=True).run(add_op_lines)
+        # One c0 instance from a0, and one from a1
+        FileCheck().check_count("C(c0)::forward", 2, exactly=True).run(add_op_lines)
+        FileCheck().check_count("C(c1)::forward", 2, exactly=True).run(add_op_lines)
+        # 4 d instances from a0, and 4 from a1
+        FileCheck().check_count("D(d)::forward", 8, exactly=True).run(add_op_lines)
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -21,6 +21,7 @@ from jit.test_class_type import TestClassType  # noqa: F401
 from jit.test_builtins import TestBuiltins, TestTensorBuiltins  # noqa: F401
 from jit.test_unsupported_ops import TestUnsupportedOps  # noqa: F401
 from jit.test_freezing import TestFreezing  # noqa: F401
+from jit.test_scope_with_inlined_callstack import TestScopeWithInlinedCallSTack # noqa: F401
 from jit.test_save_load import TestSaveLoad  # noqa: F401
 from jit.test_python_ir import TestPythonIr  # noqa: F401
 from jit.test_functional_blocks import TestFunctionalBlocks  # noqa: F401

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1875,6 +1875,22 @@ std::vector<Value*> inlineCallTo(
   std::unordered_map<InlinedCallStack*, InlinedCallStackPtr>
       new_callstack_entries;
 
+  c10::optional<ModuleInstanceInfo> module_instance_info = c10::nullopt;
+  if (to_replace->kind() == prim::CallMethod) {
+    auto class_type_ptr = to_replace->input(0)->type()->cast<c10::ClassType>();
+    if (to_replace->input(0)->node()->kind() == prim::GetAttr) {
+      module_instance_info =
+        c10::make_optional(
+            ModuleInstanceInfo(
+              class_type_ptr, to_replace->input(0)->node()->s(attr::name)));
+    } else {
+      std::string instance_name_unknown("INSTANCE_NAME_UNKNOWN");
+      module_instance_info =
+        c10::make_optional(
+            ModuleInstanceInfo(class_type_ptr, instance_name_unknown));
+    }
+  }
+
   // TODO: We might need to use nodes_map instead of value_map. Otherwise, we
   // are missing nodes without outputs (e.g. prim::Print).
   std::unordered_set<Node*> updated_nodes;
@@ -1893,11 +1909,11 @@ std::vector<Value*> inlineCallTo(
       if (new_node_cs) {
         new_callstack_entries[raw_callstack_ptr] =
             c10::make_intrusive<InlinedCallStack>(
-                *new_node_cs, callee, to_replace->sourceRange());
+                *new_node_cs, callee, to_replace->sourceRange(), module_instance_info);
       } else {
         new_callstack_entries[raw_callstack_ptr] =
             c10::make_intrusive<InlinedCallStack>(
-                callee, to_replace->sourceRange());
+                callee, to_replace->sourceRange(), module_instance_info);
       }
     }
     new_node->setCallStack(new_callstack_entries.at(raw_callstack_ptr));

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1879,15 +1879,12 @@ std::vector<Value*> inlineCallTo(
   if (to_replace->kind() == prim::CallMethod) {
     auto class_type_ptr = to_replace->input(0)->type()->cast<c10::ClassType>();
     if (to_replace->input(0)->node()->kind() == prim::GetAttr) {
-      module_instance_info =
-        c10::make_optional(
-            ModuleInstanceInfo(
-              class_type_ptr, to_replace->input(0)->node()->s(attr::name)));
+      module_instance_info = c10::make_optional(ModuleInstanceInfo(
+          class_type_ptr, to_replace->input(0)->node()->s(attr::name)));
     } else {
       std::string instance_name_unknown("INSTANCE_NAME_UNKNOWN");
-      module_instance_info =
-        c10::make_optional(
-            ModuleInstanceInfo(class_type_ptr, instance_name_unknown));
+      module_instance_info = c10::make_optional(
+          ModuleInstanceInfo(class_type_ptr, instance_name_unknown));
     }
   }
 
@@ -1909,7 +1906,10 @@ std::vector<Value*> inlineCallTo(
       if (new_node_cs) {
         new_callstack_entries[raw_callstack_ptr] =
             c10::make_intrusive<InlinedCallStack>(
-                *new_node_cs, callee, to_replace->sourceRange(), module_instance_info);
+                *new_node_cs,
+                callee,
+                to_replace->sourceRange(),
+                module_instance_info);
       } else {
         new_callstack_entries[raw_callstack_ptr] =
             c10::make_intrusive<InlinedCallStack>(

--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -90,12 +90,30 @@ InlinedCallStack::InlinedCallStack(Function* fn, SourceRange source_range)
     : fn_(fn), source_range_(std::move(source_range)) {}
 
 InlinedCallStack::InlinedCallStack(
+    Function* fn,
+    SourceRange source_range,
+    c10::optional<ModuleInstanceInfo> module_instance_info)
+    : fn_(fn),
+      source_range_(std::move(source_range)),
+      module_instance_info_(std::move(module_instance_info)){}
+
+InlinedCallStack::InlinedCallStack(
     InlinedCallStackPtr callee,
     Function* fn,
     SourceRange source_range)
     : callee_(std::move(callee)),
       fn_(fn),
       source_range_(std::move(source_range)) {}
+
+InlinedCallStack::InlinedCallStack(
+    InlinedCallStackPtr callee,
+    Function* fn,
+    SourceRange source_range,
+    c10::optional<ModuleInstanceInfo> module_instance_info)
+    : callee_(std::move(callee)),
+      fn_(fn),
+      source_range_(std::move(source_range)),
+      module_instance_info_(std::move(module_instance_info)){}
 
 c10::optional<InlinedCallStackPtr> InlinedCallStack::callee() const {
   return callee_;
@@ -110,5 +128,26 @@ std::vector<InlinedCallStackEntry> InlinedCallStack::vec() {
   }
   return r;
 }
+
+std::vector<InlinedCallStackWithModuleInfo>
+  InlinedCallStack::vec_with_module_info() {
+  std::vector<InlinedCallStackWithModuleInfo> r;
+  c10::optional<InlinedCallStackPtr> current = intrusive_from_this();
+  while (current) {
+    r.emplace_back(
+        std::make_tuple((*current)->fn_,
+          (*current)->source_range_,
+          (*current)->module_instance_info_));
+    current = (*current)->callee_;
+  }
+  return r;
+}
+
+ModuleInstanceInfo::ModuleInstanceInfo(
+    c10::ClassTypePtr module_type,
+    std::string instance_name)
+    : module_type_(module_type),
+      instance_name_(std::move(instance_name)) {}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -95,7 +95,7 @@ InlinedCallStack::InlinedCallStack(
     c10::optional<ModuleInstanceInfo> module_instance_info)
     : fn_(fn),
       source_range_(std::move(source_range)),
-      module_instance_info_(std::move(module_instance_info)){}
+      module_instance_info_(std::move(module_instance_info)) {}
 
 InlinedCallStack::InlinedCallStack(
     InlinedCallStackPtr callee,
@@ -113,7 +113,7 @@ InlinedCallStack::InlinedCallStack(
     : callee_(std::move(callee)),
       fn_(fn),
       source_range_(std::move(source_range)),
-      module_instance_info_(std::move(module_instance_info)){}
+      module_instance_info_(std::move(module_instance_info)) {}
 
 c10::optional<InlinedCallStackPtr> InlinedCallStack::callee() const {
   return callee_;
@@ -129,15 +129,15 @@ std::vector<InlinedCallStackEntry> InlinedCallStack::vec() {
   return r;
 }
 
-std::vector<InlinedCallStackWithModuleInfo>
-  InlinedCallStack::vec_with_module_info() {
+std::vector<InlinedCallStackWithModuleInfo> InlinedCallStack::
+    vec_with_module_info() {
   std::vector<InlinedCallStackWithModuleInfo> r;
   c10::optional<InlinedCallStackPtr> current = intrusive_from_this();
   while (current) {
-    r.emplace_back(
-        std::make_tuple((*current)->fn_,
-          (*current)->source_range_,
-          (*current)->module_instance_info_));
+    r.emplace_back(std::make_tuple(
+        (*current)->fn_,
+        (*current)->source_range_,
+        (*current)->module_instance_info_));
     current = (*current)->callee_;
   }
   return r;
@@ -146,8 +146,7 @@ std::vector<InlinedCallStackWithModuleInfo>
 ModuleInstanceInfo::ModuleInstanceInfo(
     c10::ClassTypePtr module_type,
     std::string instance_name)
-    : module_type_(module_type),
-      instance_name_(std::move(instance_name)) {}
+    : module_type_(module_type), instance_name_(std::move(instance_name)) {}
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/ir/scope.h
+++ b/torch/csrc/jit/ir/scope.h
@@ -72,7 +72,6 @@ struct ModuleInstanceInfo {
   }
 };
 
-
 /**
  * InlinedCallStack is an element in a list representing callstack of functions
  * that have been inlined.
@@ -104,7 +103,7 @@ struct ModuleInstanceInfo {
 using InlinedCallStackPtr = c10::intrusive_ptr<InlinedCallStack>;
 using InlinedCallStackEntry = std::pair<Function*, SourceRange>;
 using InlinedCallStackWithModuleInfo =
-  std::tuple<Function*, SourceRange, c10::optional<ModuleInstanceInfo>>;
+    std::tuple<Function*, SourceRange, c10::optional<ModuleInstanceInfo>>;
 
 struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
  private:

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -19,19 +19,18 @@ void pushScopeInfo(Node* node) {
     const auto opt_module_instance_info = std::get<2>(tup);
     if (opt_module_instance_info) {
       const auto& module_instance_info = opt_module_instance_info.value();
-      if(module_instance_info.class_type()) {
+      if (module_instance_info.class_type()) {
         const auto& class_type = module_instance_info.class_type();
         const auto& instance_name = module_instance_info.instance_name();
         auto type_name = class_type->name()->qualifiedName();
-        type_name = type_name.substr(type_name.find_last_of(".")+1);
+        type_name = type_name.substr(type_name.find_last_of(".") + 1);
         std::string module_fn_name = type_name + "(" + instance_name + ")::";
         module_fn_name += std::get<0>(tup)->name();
         sc = sc->push(Symbol::scope(module_fn_name));
       } else {
         sc = sc->push(Symbol::scope("TYPE_INFO_UNKNOWN::"));
       }
-    }
-    else {
+    } else {
       std::string free_fn = "FreeFunction::" + std::get<0>(tup)->name();
       sc = sc->push(Symbol::scope(free_fn));
     }
@@ -40,7 +39,7 @@ void pushScopeInfo(Node* node) {
 }
 
 void ReconstructScopeFromInlinedCallStackHelper(Block* block) {
-  for(auto node : block->nodes()) {
+  for (auto node : block->nodes()) {
     if (node->callstack()) {
       pushScopeInfo(node);
     }

--- a/torch/csrc/jit/passes/inliner.h
+++ b/torch/csrc/jit/passes/inliner.h
@@ -8,5 +8,8 @@ namespace jit {
 // Inline function and method calls.
 TORCH_API void Inline(Graph& graph);
 
+// Resconstruct scope from inlined call stack
+TORCH_API void ReconstructScopeFromInlinedCallStack(torch::jit::Graph& g);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -378,6 +378,9 @@ void initJITBindings(PyObject* module) {
       .def("_jit_pass_erase_number_types", EraseNumberTypes)
       .def("_jit_pass_inline_fork_wait", InlineForkWait)
       .def("_jit_pass_inline", Inline)
+      .def(
+          "_jit_pass_reconstruct_scope_from_inlined_callstack",
+          ReconstructScopeFromInlinedCallStack)
       .def("_jit_pass_prepare_division_for_onnx", PrepareDivisionForONNX)
       .def(
           "_jit_pass_lower_graph",

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -20,6 +20,7 @@
 
 #include <ATen/core/jit_type.h>
 #include <ATen/core/qualified_name.h>
+#include <stack>
 #include <string>
 #include <vector>
 
@@ -53,6 +54,69 @@ static IValue Table(
   return Tup(std::move(ivalue_entries));
 }
 
+std::string getModuleTypeName(const Module& module, const std::string& prefix) {
+  std::string moduleType = module.type()->str();
+  size_t lastDotIndex = moduleType.rfind('.');
+  if (lastDotIndex != std::string::npos) {
+    moduleType = moduleType.substr(lastDotIndex + 1);
+  }
+  return prefix + "(" + moduleType + ")";
+}
+
+void pushScopeInfo(Node* node, const std::string& root_scope_string) {
+  ScopePtr sc = c10::make_intrusive<Scope>();
+  if (!node->callstack()) {
+    sc = sc->push(Symbol::scope(root_scope_string + ".forward"));
+  } else {
+    std::string module_info = root_scope_string;
+    auto callstack_ptr = *(node->callstack());
+    const auto& vec = callstack_ptr->vec_with_module_info();
+
+    for (size_t i = 0; i < vec.size(); ++i) {
+      const auto& tup = vec[i];
+      const auto opt_module_instance_info = std::get<2>(tup);
+      if (opt_module_instance_info) {
+        const auto& module_instance_info = opt_module_instance_info.value();
+        if (module_instance_info.class_type()) {
+          const auto& class_type = module_instance_info.class_type();
+          const auto& instance_name = module_instance_info.instance_name();
+          auto type_name = class_type->name()->qualifiedName();
+          type_name = type_name.substr(type_name.find_last_of(".") + 1);
+          module_info += "." + instance_name + "(" + type_name + ")";
+          if (i == vec.size() - 1) {
+            module_info += "." + std::get<0>(tup)->name();
+          }
+        } else {
+          module_info += ".(UNKNOWN_INSTANCE(UNKNOWN_TYPE)";
+        }
+      } else {
+        module_info += ".(UNKNOWN_INSTANCE(UNKNOWN_TYPE)";
+      }
+    }
+
+    sc = sc->push(Symbol::scope(module_info));
+  }
+  node->setScope(sc);
+}
+
+void reconstructScopes(
+    std::shared_ptr<Graph> graph,
+    const std::string& root_scope_string) {
+  std::stack<Block*> blocks_to_visit;
+  blocks_to_visit.push(graph->block());
+  while (!blocks_to_visit.empty()) {
+    Block* block = blocks_to_visit.top();
+    blocks_to_visit.pop();
+    for (Node* node : block->nodes()) {
+      pushScopeInfo(node, root_scope_string);
+      std::cout << "Scope: " << node->scopeName() << std::endl;
+      for (Block* subblock : node->blocks()) {
+        blocks_to_visit.push(subblock);
+      }
+    }
+  }
+}
+
 std::string getModulePath(Node* node) {
   std::string modulePath = node->scopeName();
   size_t end = modulePath.size();
@@ -78,7 +142,8 @@ std::pair<IValue, c10::optional<IValue>> getFunctionTuple(
 
   Inline(*graph);
   if (save_mobile_debug_info) {
-    ReconstructScopes(module, *graph, "top");
+    std::string root_scope_string = getModuleTypeName(module, "top");
+    reconstructScopes(graph, root_scope_string);
   }
 
   torch::jit::Code code(graph, func.name());


### PR DESCRIPTION
Summary:
Motivation:
During inlinng we lose information about where the node/op is coming from in module
hierarchy. The SourceDebug info is useful in providing where in the
source code the definition of the node exist. One can follow the
callstack to find the relevant module hierarchy. However, this is less
accessible, particularly in the context of aggregating node level op
latencies to produce module level latencies. Facilitiating this
enables identifying which module might be expensive and can be
targeted either for optimization or redesign. This also aids network
architecture search approaches.
Approach:
This PR adds module type/instance information to inlined call stack
during inlining. During inlining where the subsequent CallMethods are
being replaced with their corresponding graph, we find the module
instance information corresponding to the CallMethod following the
GetAttr node that produces the module type input to CallMethod.
This approach has limitations in that such information will not be
avaiable to CallFunctions and hence we will only be able to annotate
type information and not instance information.
But the intuition is that, it should cover majority of the cases. And we
should be able to address this in another way.

Test Plan:
python test/test_jit.py TestScopeWithInlinedCallSTack

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #{issue number}
