### PR TITLE
[CUDA] max_pool2d NCHW performance improvement

### DIFF
--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -42,12 +42,10 @@ __global__ void max_pool_forward_nchw(const int nthreads, const scalar_t* bottom
     const int dilation_h, const int dilation_w, scalar_t* top_data,
     int64_t* top_mask) {
   CUDA_KERNEL_LOOP(index, nthreads) {
-    int n = index;
-    int temp = index / pooled_width;
-    const int pw = n - temp * pooled_width; n = temp; temp /= pooled_height;
-    const int ph = n - temp * pooled_height; n = temp; temp /= channels;
-    const int c = n - temp * channels; n = temp; // temp /= 1;
-
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
     int hstart = ph * stride_h - pad_h;
     int wstart = pw * stride_w - pad_w;
     int hend = min(hstart + (kernel_h - 1) * dilation_h + 1, height);


### PR DESCRIPTION
Fix the regression introduced in #38953.

Please see https://github.com/xwang233/code-snippet/blob/master/max-pool2d-nchw-perf/max-pool2d.ipynb for detailed before & after performance comparisons. 

Performance improvement (percentage) for backward max_pool2d before and after this PR (negative value means speed up)

![image](https://user-images.githubusercontent.com/24860335/88712204-363c8e00-d0ce-11ea-8586-057e09b16103.png)

Seems like the forward modulo doesn't benefit much from a similar change, so I did not change forward. https://github.com/pytorch/pytorch/pull/42182/commits/1718f0ccfd84ed33229b69826e8e1c53dc5725f7