### PR TITLE
add tests to BinaryOpsKernel -- max/min kernel

### DIFF
--- a/aten/src/ATen/test/atest.cpp
+++ b/aten/src/ATen/test/atest.cpp
@@ -170,6 +170,20 @@ TEST_F(atest, add_operators) {
   run_binary_ops_test(add_out, x_tensor, y_tensor, exp_tensor, INTBOOL, 2);
 }
 
+TEST_F(atest, max_operators) {
+  auto exp_tensor = tensor({10, 1, 0, 1, 10});
+  run_binary_ops_test<
+      at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
+      max_out, x_tensor, y_tensor, exp_tensor, INTBOOLFLOAT);
+}
+
+TEST_F(atest, min_operators) {
+  auto exp_tensor = tensor({-10, -1, 0, -1, -10});
+  run_binary_ops_test<
+      at::Tensor& (*)(at::Tensor&, const at::Tensor&, const at::Tensor&)>(
+      min_out, x_tensor, y_tensor, exp_tensor, INTBOOLFLOAT);
+}
+
 // TEST_CASE( "atest", "[]" ) {
 TEST_F(atest, atest) {
   manual_seed(123);


### PR DESCRIPTION
Summary:
1. add tests to max/min kernel
2. format BinaryOpsKernels.cpp: There's a typo "max_lementwise_cpu". When I revise it and save the file, VScode automatically adjust its format to standard format. It's better to read by this format, especially in diffusion.

Test Plan:
1. Run locally to check cover the corresponding code part in BinaryOpsKernel.cpp.
2. CI

Differential Revision: D22796019

