### PR TITLE
Fix manual seed to unpack unsigned long

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2156,14 +2156,32 @@ class AbstractTestCases:
             torch.manual_seed(2)
             y = torch.randn(100)
             self.assertEqual(x, y)
-            largest_signed_long = 0x7fffffffffffffff
-            torch.manual_seed(largest_signed_long)
-            self.assertEqual(largest_signed_long, torch.initial_seed())
-            largest_unsigned_long = 0xffffffffffffffff
-            torch.manual_seed(largest_unsigned_long)
-            self.assertEqual(largest_unsigned_long, torch.initial_seed())
-            with self.assertRaisesRegex(OverflowError, r'int too big to convert'):
-                torch.manual_seed(largest_unsigned_long + 1)
+
+            max_int64 = 0x7fff_ffff_ffff_ffff
+            min_int64 = -max_int64 - 1
+            max_uint64 = 0xffff_ffff_ffff_ffff
+            # Check all boundary cases of valid seed value inputs
+            test_cases = [
+                # (seed, expected_initial_seed)
+                # Positive seeds should be unchanged
+                (max_int64, max_int64),
+                (max_int64 + 1, max_int64 + 1),
+                (max_uint64, max_uint64),
+                (0, 0),
+                # Negative seeds wrap around starting from the largest seed value
+                (-1, max_uint64),
+                (min_int64, max_int64 + 1)
+            ]
+            for seed, expected_initial_seed in test_cases:
+                torch.manual_seed(seed)
+                actual_initial_seed = torch.initial_seed()
+                msg = "expected initial_seed() = %x after calling manual_seed(%x), but got %x instead" % (
+                    expected_initial_seed, seed, actual_initial_seed)
+                self.assertEqual(expected_initial_seed, actual_initial_seed, msg=msg)
+            for invalid_seed in [min_int64 - 1, max_uint64 + 1]:
+                with self.assertRaisesRegex(RuntimeError, r'Overflow when unpacking long'):
+                    torch.manual_seed(invalid_seed)
+
             torch.set_rng_state(rng_state)
 
         def test_numel(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2163,7 +2163,7 @@ class AbstractTestCases:
             torch.manual_seed(largest_unsigned_long)
             self.assertEqual(largest_unsigned_long, torch.initial_seed())
             with self.assertRaisesRegex(OverflowError, r'int too big to convert'):
-                torch.manual_seed(largest_unsigned_long+1)
+                torch.manual_seed(largest_unsigned_long + 1)
             torch.set_rng_state(rng_state)
 
         def test_numel(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2156,6 +2156,14 @@ class AbstractTestCases:
             torch.manual_seed(2)
             y = torch.randn(100)
             self.assertEqual(x, y)
+            largest_signed_long = 0x7fffffffffffffff
+            torch.manual_seed(largest_signed_long)
+            self.assertEqual(largest_signed_long, torch.initial_seed())
+            largest_unsigned_long = 0xffffffffffffffff
+            torch.manual_seed(largest_unsigned_long)
+            self.assertEqual(largest_unsigned_long, torch.initial_seed())
+            with self.assertRaisesRegex(OverflowError, r'int too big to convert'):
+                torch.manual_seed(largest_unsigned_long+1)
             torch.set_rng_state(rng_state)
 
         def test_numel(self):

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8356,7 +8356,10 @@ It is recommended to set a large seed, i.e. a number that has a good balance of 
 and 1 bits. Avoid having many 0 bits in the seed.
 
 Arguments:
-    seed (int): The desired seed.
+    seed (int): The desired seed. Value must be within the inclusive range
+        `[-0x8000_0000_0000_0000, 0xffff_ffff_ffff_ffff]`. Otherwise, a RuntimeError
+        is raised. Negative inputs are remapped to positive values with the formula
+        `0xffff_ffff_ffff_ffff + seed`.
 
 Returns:
     Generator: An torch.Generator object.

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -125,7 +125,7 @@ static PyObject * THPGenerator_manualSeed(THPGenerator *self, PyObject *seed)
           "but got %s", THPUtils_typename(seed));
   // See Note [Acquire lock when using random generators]
   std::lock_guard<std::mutex> lock(generator.mutex());
-  generator.set_current_seed(THPUtils_unpackLong(seed));
+  generator.set_current_seed(THPUtils_unpackUInt64(seed));
   Py_INCREF(self);
   return (PyObject*)self;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -125,7 +125,23 @@ static PyObject * THPGenerator_manualSeed(THPGenerator *self, PyObject *seed)
           "but got %s", THPUtils_typename(seed));
   // See Note [Acquire lock when using random generators]
   std::lock_guard<std::mutex> lock(generator.mutex());
-  generator.set_current_seed(THPUtils_unpackUInt64(seed));
+  uint64_t seed_unpacked;
+  try {
+    // First try to interpret as unsigned long
+    seed_unpacked = THPUtils_unpackUInt64(seed);
+  } catch(...) {
+    if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+      // If an overflow happened, then the seed could be negative,
+      // so try to interpret it as signed long
+      PyErr_Clear();
+      int64_t seed_unpacked_signed = THPUtils_unpackLong(seed);
+      seed_unpacked = *(reinterpret_cast<uint64_t*>(&seed_unpacked_signed));
+    } else {
+      // If any other type of exception happened, rethrow it
+      throw;
+    }
+  }
+  generator.set_current_seed(seed_unpacked);
   Py_INCREF(self);
   return (PyObject*)self;
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -45,6 +45,14 @@ inline int64_t THPUtils_unpackLong(PyObject* obj) {
   return (int64_t)value;
 }
 
+inline uint64_t THPUtils_unpackUInt64(PyObject* obj) {
+  unsigned long long value = PyLong_AsUnsignedLongLong(obj);
+  if (PyErr_Occurred()) {
+    throw python_error();
+  }
+  return (uint64_t)value;
+}
+
 inline bool THPUtils_checkIndex(PyObject *obj) {
   if (PyBool_Check(obj)) {
     return false;

--- a/torch/random.py
+++ b/torch/random.py
@@ -24,7 +24,10 @@ def manual_seed(seed) -> torch._C.Generator:
     `torch.Generator` object.
 
     Args:
-        seed (int): The desired seed.
+        seed (int): The desired seed. Value must be within the inclusive range
+            `[-0x8000_0000_0000_0000, 0xffff_ffff_ffff_ffff]`. Otherwise, a RuntimeError
+            is raised. Negative inputs are remapped to positive values with the formula
+            `0xffff_ffff_ffff_ffff + seed`.
     """
     seed = int(seed)
     import torch.cuda


### PR DESCRIPTION
`torch.manual_seed` was unpacking its argument as an `int64_t`. This fix changes it to a `uint64_t`.

Fixes #33546
