### PR TITLE
Use Gtest assertions instead of manually throwing exceptions in error cases

### DIFF
--- a/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLTest.cpp
@@ -295,12 +295,9 @@ void testAllreduce(const std::string& path, int rank, int size) {
     auto& tensor = tensors[j];
     auto data = tensor.data_ptr<float>();
     for (auto k = 0; k < tensor.numel(); k++) {
-      if (data[k] != expected) {
-        throw std::runtime_error("BOOM!");
-      }
+      EXPECT_EQ(data[k], expected);
     }
   }
-  std::cout << "Allreduce test successful" << std::endl;
 }
 
 void testBroadcast(const std::string& path, int rank, int size) {
@@ -323,14 +320,11 @@ void testBroadcast(const std::string& path, int rank, int size) {
         auto& tensor = tensors[j];
         auto data = tensor.data_ptr<float>();
         for (auto k = 0; k < tensor.numel(); k++) {
-          if (data[k] != expected) {
-            throw std::runtime_error("BOOM!");
-          }
+          EXPECT_EQ(data[k], expected);
         }
       }
     }
   }
-  std::cout << "Broadcast test successful" << std::endl;
 }
 
 void testReduce(const std::string& path, int rank, int size) {
@@ -354,14 +348,11 @@ void testReduce(const std::string& path, int rank, int size) {
         auto& tensor = tensors[rootTensor];
         auto data = tensor.data_ptr<float>();
         for (auto k = 0; k < tensor.numel(); k++) {
-          if (data[k] != expected) {
-            throw std::runtime_error("BOOM!");
-          }
+          EXPECT_EQ(data[k], expected);
         }
       }
     }
   }
-  std::cout << "Reduce test successful" << std::endl;
 }
 
 void testAllgather(const std::string& path, int rank, int size) {
@@ -381,13 +372,10 @@ void testAllgather(const std::string& path, int rank, int size) {
       auto& tensor = tensors[i][j];
       auto data = tensor.data_ptr<float>();
       for (auto k = 0; k < tensor.numel(); k++) {
-        if (data[k] != expected) {
-          throw std::runtime_error("BOOM!");
-        }
+        EXPECT_EQ(data[k], expected);
       }
     }
   }
-  std::cout << "Allgather test successful" << std::endl;
 }
 
 void testReduceScatter(const std::string& path, int rank, int size) {
@@ -409,12 +397,9 @@ void testReduceScatter(const std::string& path, int rank, int size) {
     auto& tensor = tensors[i];
     auto data = tensor.data_ptr<float>();
     for (auto j = 0; j < tensor.numel(); j++) {
-      if (data[j] != expected) {
-        throw std::runtime_error("BOOM!");
-      }
+      EXPECT_EQ(data[j], expected);
     }
   }
-  std::cout << "Reduce-scatter test successful" << std::endl;
 }
 
 class ProcessGroupNCCLTest: public ::testing::Test {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42211 Clean up CUDA Sleep and Tensor Initialization in ProcessGroupNCCLTest
* **#42210 Use Gtest assertions instead of manually throwing exceptions in error cases**
* #42209 TearDown function for ProcessGroupNCCLTest Initializer
* #42208 Moving ProcessGroupNCCLTest to Gtest

This PR replaces random exceptions thrown/logging with Gtest assertions when testing for the correctness of NCCL collectives.

Differential Revision: [D22782674](https://our.internmc.facebook.com/intern/diff/D22782674/)