### PR TITLE
[pt] Add incude_last_offset option to EmbeddingBag mean and max

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -357,7 +357,6 @@ static Tensor apply_bag_size_backward(const Tensor &offsets,
   return output;
 }
 
-
 template <typename scalar_t>
 std::tuple<Tensor, Tensor, Tensor, Tensor> embedding_bag_cpu_max(
     const Tensor& weight,
@@ -365,43 +364,55 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> embedding_bag_cpu_max(
     const Tensor& offset2bag,
     const Tensor& output,
     const Tensor& bag_size,
-    const Tensor& offsets) {
+    const Tensor& offsets,
+    bool include_last_offset) {
+  int64_t numIndices = indices.numel();
+  int64_t numBags = offsets.size(0);
+  int64_t featureSize = weight.size(1);
+  if (include_last_offset) {
+    // Check https://github.com/pytorch/pytorch/issues/29019
+    // We plan to add one more element in offsets, which is equal to the size of
+    // indices. Currently for cuda devices, we still use the legacy
+    // implementation even this flag is enabled.
+    TORCH_CHECK(
+        numBags >= 1, "include_last_offset: numBags should be at least 1");
+    numBags -= 1;
+  }
+  auto max_indices =
+      at::zeros({numBags, featureSize}, indices.options());
 
-    auto max_indices = at::zeros({offsets.size(0), weight.size(1)}, indices.options());
+  auto* indices_data = indices.data_ptr<int64_t>();
+  auto* offset2bag_data = offset2bag.data_ptr<int64_t>();
 
-    int64_t numel = indices.numel();
-    int64_t dims = weight.size(1);
-    auto* indices_data = indices.data_ptr<int64_t>();
-    auto* offset2bag_data = offset2bag.data_ptr<int64_t>();
+  auto* max_indices_data = max_indices.data_ptr<int64_t>();
+  auto max_indices_stride = max_indices.stride(0);
 
-    auto* max_indices_data = max_indices.data_ptr<int64_t>();
-    auto max_indices_stride = max_indices.stride(0);
+  auto* weight_data = weight.data_ptr<scalar_t>();
+  auto* output_data = output.data_ptr<scalar_t>();
+  auto weight_stride0 = weight.stride(0);
+  auto weight_stride1 = weight.stride(1);
+  auto output_stride = output.stride(0);
 
-    auto* weight_data = weight.data_ptr<scalar_t>();
-    auto* output_data = output.data_ptr<scalar_t>();
-    auto weight_stride0 = weight.stride(0);
-    auto weight_stride1 = weight.stride(1);
-    auto output_stride = output.stride(0);
+  for (int i = 0; i < numIndices; i++) {
+    auto bag = offset2bag_data[i];
+    auto word_idx = indices_data[i];
 
-    for (int i = 0; i < numel; i++) {
-      auto bag = offset2bag_data[i];
-      auto word_idx = indices_data[i];
+    for (int dim = 0; dim < featureSize; dim++) {
+      auto& current_item = output_data[output_stride * bag + dim];
+      auto weight_item =
+          weight_data[weight_stride0 * word_idx + dim * weight_stride1];
+      bool is_first_for_bag = (i == 0) || offset2bag_data[i - 1] != bag;
 
-      for (int dim = 0; dim < dims; dim++) {
-        auto& current_item = output_data[output_stride * bag + dim];
-        auto weight_item = weight_data[weight_stride0 * word_idx + dim * weight_stride1];
-        bool is_first_for_bag = (i == 0) || offset2bag_data[i - 1] != bag;
-
-        if (is_first_for_bag || weight_item > current_item) {
-          current_item = weight_item;
-          max_indices_data[max_indices_stride * bag + dim] = word_idx;
-        }
+      if (is_first_for_bag || weight_item > current_item) {
+        current_item = weight_item;
+        max_indices_data[max_indices_stride * bag + dim] = word_idx;
       }
     }
+  }
 
-    return std::tuple<Tensor, Tensor, Tensor, Tensor>(output, offset2bag, bag_size, max_indices);
+  return std::tuple<Tensor, Tensor, Tensor, Tensor>(
+      output, offset2bag, bag_size, max_indices);
 }
-
 
 // Assumes all input tensors except for `weight` are contiguous.
 // See NOTE [ embedding_bag Native Functions ] in native_functions.yaml for details
@@ -438,7 +449,13 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_cpu_impl(
     TORCH_CHECK(per_sample_weights.numel() == indices.numel());
   }
 
-  auto bag_size = make_bag_size(offsets, indices, mode, requires_grad);
+
+  at::Tensor bag_size;
+  if (include_last_offset) {
+    bag_size = make_bag_size(offsets.slice(0, 0, offsets.size(0) - 1, 1), indices, mode, requires_grad);
+  } else {
+    bag_size = make_bag_size(offsets, indices, mode, requires_grad);
+  }
 
   if (include_last_offset) {
     TORCH_CHECK(
@@ -501,7 +518,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_cpu_impl(
     return AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       weight.scalar_type(), "embedding_bag_cpu_max", [&]() {
         return embedding_bag_cpu_max<scalar_t>(
-            weight, indices, offset2bag, output, bag_size, offsets);
+            weight, indices, offset2bag, output, bag_size, offsets, include_last_offset);
       }
     );
   }

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -452,6 +452,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_cpu_impl(
 
   at::Tensor bag_size;
   if (include_last_offset) {
+    // TODO: make_bag_size can be optimized to do less temporary tensors (with
+    // include_last_offset).
     bag_size = make_bag_size(offsets.slice(0, 0, offsets.size(0) - 1, 1), indices, mode, requires_grad);
   } else {
     bag_size = make_bag_size(offsets, indices, mode, requires_grad);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10416,7 +10416,9 @@ class TestNNDeviceType(NNTestCase):
         assert mode == 'sum' or per_sample_weights is None
         assert offsets is not None
         if per_sample_weights is None:
-            per_sample_weights = torch.ones(input.size()).to(weight.dtype)
+            per_sample_weights = torch.ones(input.size()).to(
+                dtype=weight.dtype, device=weight.device
+            )
         assert input.numel() == per_sample_weights.numel()
 
         bags = []
@@ -10427,7 +10429,11 @@ class TestNNDeviceType(NNTestCase):
                 next_offset = offsets[index + 1]
                 length = next_offset - offset
                 if length == 0:
-                    bags.append(torch.Tensor([0] * weight.size(1)).to(embeddings.dtype))
+                    bags.append(
+                        torch.Tensor([0] * weight.size(1)).to(
+                            dtype=embeddings.dtype, device=embeddings.device
+                        )
+                    )
                 else:
                     if mode == 'sum':
                         bags.append(embeddings.narrow(0, offset, length).sum(0))
@@ -10444,7 +10450,11 @@ class TestNNDeviceType(NNTestCase):
                     next_offset = len(input)
                 length = next_offset - offset
                 if length == 0:
-                    bags.append(torch.Tensor([0] * weight.size(1)).to(embeddings.dtype))
+                    bags.append(
+                        torch.Tensor([0] * weight.size(1)).to(
+                            dtype=embeddings.dtype, device=embeddings.device
+                        )
+                    )
                 else:
                     if mode == 'sum':
                         bags.append(embeddings.narrow(0, offset, length).sum(0))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10534,8 +10534,12 @@ class TestNNDeviceType(NNTestCase):
         trainable_scale = (True, False)
         include_last_offset = (True, False)
         modes = (('sum', False), ('sum', True), ('max', False), ('mean', False))
-        for dtype, (mode, has_weight), trainable, include_last_offset in itertools.product(dtypes, modes, trainable_scale, include_last_offset):
-            test_per_sample_weights_new_offsets(mode, dtype, trainable, include_last_offset, has_weight)
+        for dtype, (mode, has_weight), trainable, include_last_offset in itertools.product(
+            dtypes, modes, trainable_scale, include_last_offset
+        ):
+            test_per_sample_weights_new_offsets(
+                mode, dtype, trainable, include_last_offset, has_weight
+            )
 
     def _test_EmbeddingBag_vs_Embedding(self, N, D, B, L, max_norm=None,
                                         mode='mean',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10413,10 +10413,10 @@ class TestNNDeviceType(NNTestCase):
 
     def _embedding_bag_reference_impl(self, input, weight, offsets=None, mode='sum',
                                       per_sample_weights=None, include_last_offset=False):
-        assert mode == 'sum'
+        assert mode == 'sum' or per_sample_weights == None
         assert offsets is not None
         if per_sample_weights is None:
-            per_sample_weights = torch.ones(input.size())
+            per_sample_weights = torch.ones(input.size()).to(weight.dtype)
         assert input.numel() == per_sample_weights.numel()
 
         bags = []
@@ -10426,7 +10426,16 @@ class TestNNDeviceType(NNTestCase):
                 offset = offsets[index]
                 next_offset = offsets[index + 1]
                 length = next_offset - offset
-                bags.append(embeddings.narrow(0, offset, length).sum(0))
+                if length == 0:
+                    bags.append(torch.Tensor([0] * weight.size(1)).to(embeddings.dtype))
+                else:
+                    if mode == 'sum':
+                        bags.append(embeddings.narrow(0, offset, length).sum(0))
+                    elif mode == 'mean':
+                        bags.append(embeddings.narrow(0, offset, length).sum(0).div(length))
+                    else:
+                        assert mode == 'max'
+                        bags.append(embeddings.narrow(0, offset, length).max(0)[0])
         else:
             for index, offset in enumerate(offsets):
                 if index + 1 < len(offsets):
@@ -10434,7 +10443,16 @@ class TestNNDeviceType(NNTestCase):
                 else:
                     next_offset = len(input)
                 length = next_offset - offset
-                bags.append(embeddings.narrow(0, offset, length).sum(0))
+                if length == 0:
+                    bags.append(torch.Tensor([0] * weight.size(1)).to(embeddings.dtype))
+                else:
+                    if mode == 'sum':
+                        bags.append(embeddings.narrow(0, offset, length).sum(0))
+                    elif mode == 'mean':
+                        bags.append(embeddings.narrow(0, offset, length).sum(0).div(length))
+                    else:
+                        assert mode == 'max'
+                        bags.append(embeddings.narrow(0, offset, length).max(0)[0])
         return torch.stack(bags)
 
     def test_EmbeddingBag_per_sample_weights_and_offsets(self, device):
@@ -10474,20 +10492,25 @@ class TestNNDeviceType(NNTestCase):
             test_per_sample_weights(mode, dtype, trainable)
 
     def test_EmbeddingBag_per_sample_weights_and_new_offsets(self, device):
-        def test_per_sample_weights_new_offsets(mode, dtype, trainable_scale, include_last_offset):
+        def test_per_sample_weights_new_offsets(mode, dtype, trainable_scale, include_last_offset, has_weight=True):
             es = nn.EmbeddingBag(5, 2, mode=mode, include_last_offset=include_last_offset).to(dtype=dtype, device=device)
             es.weight.data.copy_(
                 torch.arange(1, 11, device=device, dtype=dtype).view_as(es.weight))
             input = torch.tensor([3, 1, 1, 1, 4, 0], device=device, dtype=torch.long)
             offsets = torch.tensor([0, 0, 3, 3, 6], device=device, dtype=torch.long)
 
-            if include_last_offset is True and mode == 'sum':
+            if include_last_offset is True:
                 offsets = torch.cat((offsets, torch.tensor([input.size(0)], device=device, dtype=torch.long)), 0)
 
-            per_sample_weights = torch.randn_like(input, device=device, dtype=dtype) \
-                                      .requires_grad_(trainable_scale)
-            ref_per_sample_weights = \
-                per_sample_weights.detach().requires_grad_(trainable_scale)
+            if has_weight:
+                per_sample_weights = torch.randn_like(input, device=device, dtype=dtype) \
+                                          .requires_grad_(trainable_scale)
+                ref_per_sample_weights = \
+                    per_sample_weights.detach().requires_grad_(trainable_scale)
+            else:
+                per_sample_weights = None
+                ref_per_sample_weights = None
+
             reference_weights = es.weight.detach().requires_grad_()
 
             expected = self._embedding_bag_reference_impl(
@@ -10500,7 +10523,7 @@ class TestNNDeviceType(NNTestCase):
             expected.backward(grad)
             self.assertEqual(es.weight.grad, reference_weights.grad,
                              atol=dtype2prec_DONTUSE[dtype], rtol=0)
-            if trainable_scale:
+            if has_weight and trainable_scale:
                 self.assertEqual(per_sample_weights.grad, ref_per_sample_weights.grad,
                                  atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
@@ -10508,11 +10531,14 @@ class TestNNDeviceType(NNTestCase):
             dtypes = (torch.float, torch.double, torch.half)
         else:
             dtypes = (torch.float, torch.double)
-        modes = ('sum',)
+        modes = ('sum', 'max', 'mean')
         trainable_scale = (True, False)
         include_last_offset = (True, False)
+        has_weight = (True, False)
         for dtype, mode, trainable, include_last_offset in itertools.product(dtypes, modes, trainable_scale, include_last_offset):
-            test_per_sample_weights_new_offsets(mode, dtype, trainable, include_last_offset)
+            if mode != 'sum':
+                has_weight = False
+            test_per_sample_weights_new_offsets(mode, dtype, trainable, include_last_offset, has_weight)
 
     def _test_EmbeddingBag_vs_Embedding(self, N, D, B, L, max_norm=None,
                                         mode='mean',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10413,7 +10413,7 @@ class TestNNDeviceType(NNTestCase):
 
     def _embedding_bag_reference_impl(self, input, weight, offsets=None, mode='sum',
                                       per_sample_weights=None, include_last_offset=False):
-        assert mode == 'sum' or per_sample_weights == None
+        assert mode == 'sum' or per_sample_weights is None
         assert offsets is not None
         if per_sample_weights is None:
             per_sample_weights = torch.ones(input.size()).to(weight.dtype)
@@ -10499,7 +10499,7 @@ class TestNNDeviceType(NNTestCase):
             input = torch.tensor([3, 1, 1, 1, 4, 0], device=device, dtype=torch.long)
             offsets = torch.tensor([0, 0, 3, 3, 6], device=device, dtype=torch.long)
 
-            if include_last_offset is True:
+            if include_last_offset:
                 offsets = torch.cat((offsets, torch.tensor([input.size(0)], device=device, dtype=torch.long)), 0)
 
             if has_weight:
@@ -10531,13 +10531,10 @@ class TestNNDeviceType(NNTestCase):
             dtypes = (torch.float, torch.double, torch.half)
         else:
             dtypes = (torch.float, torch.double)
-        modes = ('sum', 'max', 'mean')
         trainable_scale = (True, False)
         include_last_offset = (True, False)
-        has_weight = (True, False)
-        for dtype, mode, trainable, include_last_offset in itertools.product(dtypes, modes, trainable_scale, include_last_offset):
-            if mode != 'sum':
-                has_weight = False
+        modes = (('sum', False), ('sum', True), ('max', False), ('mean', False))
+        for dtype, (mode, has_weight), trainable, include_last_offset in itertools.product(dtypes, modes, trainable_scale, include_last_offset):
             test_per_sample_weights_new_offsets(mode, dtype, trainable, include_last_offset, has_weight)
 
     def _test_EmbeddingBag_vs_Embedding(self, N, D, B, L, max_norm=None,

--- a/torch/csrc/api/include/torch/nn/options/embedding.h
+++ b/torch/csrc/api/include/torch/nn/options/embedding.h
@@ -113,8 +113,7 @@ struct TORCH_API EmbeddingBagOptions {
   /// The learnable weights of the module of shape (num_embeddings, embedding_dim)
   TORCH_ARG(torch::Tensor, _weight) = Tensor();
   /// If ``true``, `offsets` has one additional element, where the last element
-  /// is equivalent to the size of `indices`. This matches the CSR format. Note:
-  /// this option is currently only supported when ``mode="sum"``.
+  /// is equivalent to the size of `indices`. This matches the CSR format.
   TORCH_ARG(bool, include_last_offset) = false;
 };
 

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -219,8 +219,7 @@ class EmbeddingBag(Module):
                                  Notes for more details regarding sparse gradients. Note: this option is not
                                  supported when ``mode="max"``.
         include_last_offset (bool, optional): if ``True``, :attr:`offsets` has one additional element, where the last element
-                                      is equivalent to the size of `indices`. This matches the CSR format. Note:
-                                      this option is currently only supported when ``mode="sum"``.
+                                      is equivalent to the size of `indices`. This matches the CSR format.
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape `(num_embeddings, embedding_dim)`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42215 [pt] Add incude_last_offset option to EmbeddingBag mean and max**

Specifically on https://github.com/pytorch/pytorch/pull/27477#discussion_r371402079

We would like to supported with include_last=True overall for other reduction types like mean and max. It now causes further code fragmentation in DPER (https://www.internalfb.com/intern/diff/D22794469/)

Differential Revision: [D22801881](https://our.internmc.facebook.com/intern/diff/D22801881/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22801881/)!