### PR TITLE
fix typo in GradScaler docstring

### DIFF
--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -93,7 +93,7 @@ class GradScaler(object):
     Arguments:
         init_scale (float, optional, default=2.**16):  Initial scale factor.
         growth_factor (float, optional, default=2.0):  Factor by which the scale is multiplied during
-            :meth:`update` if no inf/NaN gradients occur for ``growth_factor`` consecutive iterations.
+            :meth:`update` if no inf/NaN gradients occur for ``growth_interval`` consecutive iterations.
         backoff_factor (float, optional, default=0.5):  Factor by which the scale is multiplied during
             :meth:`update` if inf/NaN gradients occur in an iteration.
         growth_interval (int, optional, default=2000):  Number of consecutive iterations without inf/NaN gradients


### PR DESCRIPTION
Closes https://github.com/pytorch/pytorch/issues/42226.
