### PR TITLE
[JIT] Interface for overriding object conversion during script compilation

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -496,6 +496,10 @@ inline IValue toIValue(
     py::handle obj,
     const TypePtr& type,
     c10::optional<int32_t> N) {
+  if (py::hasattr(obj, "__to_ivalue__")) {
+    auto method = obj.attr("__to_ivalue__");
+    return toTypeInferredIValue(method());
+  }
   switch (type->kind()) {
     case TypeKind::TensorType: {
       auto var = py::cast<autograd::Variable>(obj);

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -498,7 +498,11 @@ inline IValue toIValue(
     c10::optional<int32_t> N) {
   if (py::hasattr(obj, "__to_ivalue__")) {
     auto method = obj.attr("__to_ivalue__");
-    return toTypeInferredIValue(method());
+    // Precondition here is that `type` has already been set up to refer to the
+    // type of the result of `__to_ivalue__` instead of the type of `obj`
+    //
+    // Currently, this is done in the recursive scripting API on the frontend
+    return toIValue(method(), type, N);
   }
   switch (type->kind()) {
     case TypeKind::TensorType: {

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -229,6 +229,13 @@ def infer_concrete_type_builder(nn_module):
 
         # If we got here, this is a regular "data" attribute, Add it to the concrete type
         attr_type = infer_type(name, value)
+        if attr_type is None and hasattr(value, '__to_ivalue__'):
+            # Manual override of what the JIT conversion should do.
+            #
+            # Kinda a hack: convert the attribute just to get the type. It would
+            # be better if we didnt have to do this, but oh well
+            converted_value = value.__to_ivalue__()
+            attr_type = infer_type(name, converted_value)
         if attr_type is not None:
             concrete_type_builder.add_attribute(name, attr_type, False, False)
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42244 [JIT] Interface for overriding object conversion during script compilation**

Given any object undergoing conversion during TorchScript compilation, if the object exposes that method and it returns an object that is convertible to IValue, TorchScript will use that object in place of the original object

This can help facilitate use cases like in the TorchText Vocab/Vector classes, where potentially we want to have different objects in Python and TorchScript to--for example--avoid FFI overhead of moving between types in a given runtime

Differential Revision: [D22823202](https://our.internmc.facebook.com/intern/diff/D22823202)