### PR TITLE
torch.gcd: Do not use std::abs() because it does not have an unsigned integer overload

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <cstdint>
 #include <cmath>
 #include <cfloat>
 #include <limits>
@@ -269,14 +270,24 @@ static inline float calc_digamma(float x) {
 inline c10::BFloat16 calc_erfinv(c10::BFloat16 a) { return calc_erfinv(float(a)); }
 
 template <typename T>
+static T abs_impl(T v) {
+  return std::abs(v);
+}
+
+template <>
+uint8_t abs_impl(uint8_t v) {
+  return v;
+}
+
+template <typename T>
 static inline typename std::enable_if<std::is_integral<T>::value, T>::type
 calc_gcd(T a, T b) {
-  a = std::abs(a);
-  b = std::abs(b);
+  a = abs_impl(a);
+  b = abs_impl(b);
   while (a != 0) {
     T c = a;
     a = b % a;
-    b = c; 
+    b = c;
   }
   return b;
 }

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -156,15 +156,6 @@ void logit_kernel(TensorIterator& iter, Scalar eps_scalar) {
       });
 }
 
-template<typename T>
-T abs_impl(T v) {
-  return std::abs(v);
-}
-template<>
-uint8_t abs_impl(uint8_t v) {
-  return v;
-}
-
 static void abs_kernel(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, iter.dtype(), "abs_cpu", [&]() {
     cpu_kernel_vec(

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16790,7 +16790,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         self.assertEqual(r.dtype, a.dtype)
 
     @onlyOnCPUAndCUDA
-    @dtypes(torch.int16, torch.int32, torch.int64)
+    @dtypes(torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_gcd(self, device, dtype):
         # Tests gcd(0, 0), gcd(0, a) cases
@@ -16800,12 +16800,19 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         expected = np.gcd([0, 10, 0], [0, 0, 10])
         self.assertEqual(actual, expected)
 
-        # Compares with NumPy
-        a = torch.randint(-20, 20, (1024,), device=device, dtype=dtype)
-        b = torch.randint(-20, 20, (1024,), device=device, dtype=dtype)
-        actual = torch.gcd(a, b)
-        expected = np.gcd(a.cpu().numpy(), b.cpu().numpy())
-        self.assertEqual(actual, expected)
+        if dtype == torch.uint8:
+            # Test unsigned integers with potential sign issues (i.e., uint8 with value >= 128)
+            a = torch.tensor([190, 210], device=device, dtype=dtype)
+            b = torch.tensor([190, 220], device=device, dtype=dtype)
+            actual = torch.gcd(a, b)
+            expected = torch.tensor([190, 10], device=device, dtype=dtype)
+        else:
+            # Compares with NumPy
+            a = torch.randint(-20, 20, (1024,), device=device, dtype=dtype)
+            b = torch.randint(-20, 20, (1024,), device=device, dtype=dtype)
+            actual = torch.gcd(a, b)
+            expected = np.gcd(a.cpu().numpy(), b.cpu().numpy())
+            self.assertEqual(actual, expected)
 
     @onlyOnCPUAndCUDA
     @dtypes(torch.int16, torch.int32, torch.int64)


### PR DESCRIPTION


`abs` doesn't have an signed overload across all compilers, so applying abs on uint8_t can be ambiguous: https://en.cppreference.com/w/cpp/numeric/math/abs

This may cause unexpected issue when the input is uint8 and is greater
than 128. For example, on MSVC, applying `std::abs` on an unsigned char
variable

```c++
#include <cmath>

unsigned char a(unsigned char x) {
    return std::abs(x);
}
```

gives the following warning:

    warning C4244: 'return': conversion from 'int' to 'unsigned char',
    possible loss of data
