### PR TITLE
[JIT] Add selective backend lowering API

### DIFF
--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -785,7 +785,19 @@ void initPythonIRBindings(PyObject* module_) {
       .def(py::init([](const std::string& qualified_name) {
         return get_python_cu()->get_class(c10::QualifiedName(qualified_name));
       }))
-      .def("name", [](ClassType& self) { return self.name()->name(); });
+      .def("name", [](ClassType& self) { return self.name()->name(); })
+      .def(
+          "add_attribute",
+          [](const std::shared_ptr<ClassType>& self,
+             const std::string& name,
+             const std::shared_ptr<ClassType>& other) {
+            return self->addAttribute(name, other);
+          })
+      .def(
+          "unsafe_remove_attribute",
+          [](const std::shared_ptr<ClassType>& self, const std::string& name) {
+            self->unsafeRemoveAttribute(name);
+          });
   py::class_<EnumType, Type, std::shared_ptr<EnumType>>(m, "EnumType")
       .def(py::init([](const std::string& qualified_name, TypePtr value) {
         return EnumType::create(

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -12,6 +12,9 @@ from torch._jit_internal import (
     export,
     unused,
 )
+from torch.jit._backends import (
+    selective_to_jit_backend,
+)
 from torch.jit._script import (
     script,
     Attribute,

--- a/torch/jit/_backends.py
+++ b/torch/jit/_backends.py
@@ -1,0 +1,47 @@
+"""Backend API
+This module contains helper functions and utilities for the JIT backend
+API.
+"""
+
+from torch.jit._script import (
+    RecursiveScriptModule,
+)
+from typing import Callable
+
+
+# Type for functions that lower RecursiveScriptModules to JIT backends.
+ToBackendFnTy = Callable[
+    [RecursiveScriptModule], RecursiveScriptModule
+]
+
+def selective_to_jit_backend(
+    module: RecursiveScriptModule, to_backend_fn: ToBackendFnTy
+) -> RecursiveScriptModule:
+    """
+    Selectively lower modules in a module hierarchy to a JIT backend.
+
+
+    Arguments:
+        module: The RecursiveScriptModule at the root of the module hierachy that
+                    is to be lowered.
+        to_backend_fn:  Function that should will be called on each submodule to
+                            lower it to a JIT backend. Logic to include/exclude
+                            submodules from lowering should be implemented inside
+                            this function.
+    """
+    # Get the JIT type of module. This will need to be adjusted as its submodules
+    # are lowered.
+    module_jit_type = module._c._type()
+
+    # For each submodule:
+    for name, submodule in module._modules.items():
+        # Recursively process the submodule.
+        lowered_submodule = selective_to_jit_backend(submodule, to_backend_fn)
+        # Modify the corresponding attribute on the owning module's type.
+        module_jit_type.unsafe_remove_attribute(name)
+        module_jit_type.add_attribute(name, lowered_submodule._c._type())
+        # Set the attribute of module to point to the lowered module.
+        setattr(module, name, lowered_submodule)
+
+    # Now, lower module and return it.
+    return to_backend_fn(module)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42261 [JIT] Add selective backend lowering API**
* #42260 [JIT] Modify to_backend API so that it accepts wrapped modules

**Summary**
This commit adds a helper/utility to faciliate the selective lowering of
specific submodules within a module hierarchy to a JIT backend. The reason
that this is needed is that lowering a submodule of a scripted
module to a backend after the module has been scripted requires
adjusting its JIT type.

**Test Plan**
This commit refactors `NestedModuleTest` in `jit/test_backends.py` to
use this new selective lowering API.

**Fixes**
This commit fixes ##41432.

Differential Revision: [D22830223](https://our.internmc.facebook.com/intern/diff/D22830223)