### PR TITLE
[ONNX] Update ONNX export of torch.where to support ByteTensor as input.

### DIFF
--- a/test/onnx/expect/TestOperators.test_expand.expect
+++ b/test/onnx/expect/TestOperators.test_expand.expect
@@ -17,7 +17,7 @@ graph {
     }
   }
   node {
-    input: "10"
+    input: "11"
     output: "3"
     name: "ConstantOfShape_1"
     op_type: "ConstantOfShape"
@@ -74,24 +74,35 @@ graph {
   }
   node {
     input: "7"
+    output: "8"
+    name: "Cast_6"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 9
+      type: INT
+    }
+  }
+  node {
+    input: "8"
     input: "3"
     input: "1"
-    output: "8"
-    name: "Where_6"
+    output: "9"
+    name: "Where_7"
     op_type: "Where"
   }
   node {
     input: "0"
-    input: "8"
-    output: "9"
-    name: "Expand_7"
+    input: "9"
+    output: "10"
+    name: "Expand_8"
     op_type: "Expand"
   }
   name: "torch-jit-export"
   initializer {
     dims: 1
     data_type: 7
-    name: "10"
+    name: "11"
     raw_data: "\003\000\000\000\000\000\000\000"
   }
   input {
@@ -111,7 +122,7 @@ graph {
     }
   }
   output {
-    name: "9"
+    name: "10"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3574,6 +3574,7 @@ class TestONNXRuntime(unittest.TestCase):
         mat2 = torch.randn(3, 3)
         self.run_test(M(), input=(mat1, mat2))
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because where op is not supported for opset < 9.
     def test_where_with_bool_tensor(self):
         class M(torch.nn.Module):
             def forward(self, mat1, mat2):
@@ -3584,6 +3585,7 @@ class TestONNXRuntime(unittest.TestCase):
         mat2 = torch.ones(2, 3)
         self.run_test(M(), input=(mat1, mat2))
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # Because where op is not supported for opset < 9.
     def test_where_with_byte_tensor(self):
         class M(torch.nn.Module):
             def forward(self, cond, mat1, mat2):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3574,6 +3574,28 @@ class TestONNXRuntime(unittest.TestCase):
         mat2 = torch.randn(3, 3)
         self.run_test(M(), input=(mat1, mat2))
 
+    def test_where_with_bool_tensor(self):
+        class M(torch.nn.Module):
+            def forward(self, mat1, mat2):
+                out = torch.where(mat1 > 0, mat1, mat2)
+                return out
+
+        mat1 = torch.randn(2, 3)
+        mat2 = torch.ones(2, 3)
+        self.run_test(M(), input=(mat1, mat2))
+
+    def test_where_with_byte_tensor(self):
+        class M(torch.nn.Module):
+            def forward(self, cond, mat1, mat2):
+                out = torch.where(cond, mat1, mat2)
+                return out
+
+        cond = torch.ones(2, 3, dtype=torch.uint8)
+        cond[1, 2] = 0
+        mat1 = torch.randn(2, 3)
+        mat2 = torch.ones(2, 3)
+        self.run_test(M(), input=(cond, mat1, mat2))
+
     def test_dropout(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1038,6 +1038,9 @@ def __lshift_(g, self, other):
 
 
 def where(g, condition, self, other):
+    # Assumes that torch.where's first argument takes only Bool and Byte tensors.
+    if condition.type().scalarType() != 'Bool': 
+        condition = g.op("Cast", condition, to_i=sym_help.cast_pytorch_to_onnx['Bool'])
     return g.op("Where", condition, self, other)
 
 


### PR DESCRIPTION
`torch.where` supports `ByteTensor` and `BoolTensor` types for the first input argument (`condition` predicate). Currently, ONNX exporter assumes that the first argument is `BoolTensor`. This PR updates the export for `torch.where` to correctly support export when first argument is a `ByteTensor`.