### PR TITLE
Add MSFT Owners to the Windows Maintainership

### DIFF
--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -138,6 +138,8 @@ Windows
 ~~~~~~~
 
 -  Peter Johnson (`peterjc123 <https://github.com/peterjc123>`__)
+-  Guoliang Hua (`nbcsm <https://github.com/nbcsm>`__)
+-  Teng Gao (`smartcat2010 <https://github.com/smartcat2010>`__)
 
 PowerPC
 ~~~~~~~


### PR DESCRIPTION
Fixes #{issue number}
