### PR TITLE
Fix NCCL 2.7.3 bug for zero byte send/recv

### DIFF
--- a/test/distributed/test_distributed.py
+++ b/test/distributed/test_distributed.py
@@ -1506,17 +1506,35 @@ class _DistTestBase(object):
         self._barrier()
 
     # AllToAll
-    def _test_all_to_all_single_equal_split_helper(self, group, group_id, rank):
+    def _test_all_to_all_single_equal_split_helper(
+        self,
+        group,
+        group_id,
+        rank,
+        cuda=False,
+        rank_to_GPU=None,
+    ):
         if group_id is not None:
             size = len(group)
             in_tensor = torch.ones([size, size]) * rank
             expected_tensor = torch.cat([torch.ones([1, size]) * i for i in group])
             out_tensor = torch.ones([size, size]) * -1
+            if cuda:
+                in_tensor = in_tensor.cuda(rank_to_GPU[rank][0])
+                expected_tensor = expected_tensor.cuda(rank_to_GPU[rank][0])
+                out_tensor = out_tensor.cuda(rank_to_GPU[rank][0])
             dist.all_to_all_single(out_tensor, in_tensor, group=group_id)
             self.assertEqual(out_tensor, expected_tensor)
         self._barrier()
 
-    def _test_all_to_all_single_unequal_split_helper(self, group, group_id, rank):
+    def _test_all_to_all_single_unequal_split_helper(
+        self,
+        group,
+        group_id,
+        rank,
+        cuda=False,
+        rank_to_GPU=None,
+    ):
         if group_id is not None:
             size = len(group)
             in_splits = [i + 1 for i in group]
@@ -1524,6 +1542,10 @@ class _DistTestBase(object):
             in_tensor = torch.ones([sum(in_splits), size]) * rank
             out_tensor = torch.ones([(rank + 1) * size, size])
             expected_tensor = torch.cat([torch.ones([rank + 1, size]) * i for i in group])
+            if cuda:
+                in_tensor = in_tensor.cuda(rank_to_GPU[rank][0])
+                expected_tensor = expected_tensor.cuda(rank_to_GPU[rank][0])
+                out_tensor = out_tensor.cuda(rank_to_GPU[rank][0])
             dist.all_to_all_single(
                 out_tensor, in_tensor, out_splits, in_splits, group=group_id)
             self.assertEqual(out_tensor, expected_tensor)
@@ -1543,32 +1565,106 @@ class _DistTestBase(object):
                 self.assertEqual(t1, t2)
         self._barrier()
 
-    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @unittest.skipIf(
+        BACKEND != "mpi", "Only MPI supports CPU all_to_all_single"
+    )
     def test_all_to_all_single_equal_split(self):
         group, group_id, rank = self._init_global_test()
         self._test_all_to_all_single_equal_split_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @unittest.skipIf(
+        BACKEND != "nccl", "Only Nccl supports CUDA all_to_all_single"
+    )
+    @skip_if_no_gpu
+    @skip_if_rocm
+    def test_all_to_all_single_equal_split_cuda(self):
+        group, group_id, rank = self._init_global_test()
+        rank_to_GPU = self._init_multigpu_helper()
+        self._test_all_to_all_single_equal_split_helper(
+            group,
+            group_id,
+            rank,
+            True,
+            rank_to_GPU,
+        )
+
+    @unittest.skipIf(
+        BACKEND != "mpi", "Only MPI supports CPU all_to_all_single"
+    )
     def test_all_to_all_single_unequal_split(self):
         group, group_id, rank = self._init_global_test()
         self._test_all_to_all_single_unequal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(
+        BACKEND != "nccl", "Only Nccl supports CUDA all_to_all_single"
+    )
+    @skip_if_no_gpu
+    @skip_if_rocm
+    def test_all_to_all_single_unequal_split_cuda(self):
+        group, group_id, rank = self._init_global_test()
+        rank_to_GPU = self._init_multigpu_helper()
+        self._test_all_to_all_single_unequal_split_helper(
+            group,
+            group_id,
+            rank,
+            True,
+            rank_to_GPU,
+        )
 
     @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all")
     def test_all_to_all(self):
         group, group_id, rank = self._init_global_test()
         self._test_all_to_all_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @unittest.skipIf(
+        BACKEND != "mpi", "Only MPI supports CPU all_to_all_single"
+    )
     @skip_if_small_worldsize
     def test_all_to_all_single_equal_split_group(self):
         group, group_id, rank = self._init_group_test()
         self._test_all_to_all_single_equal_split_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @unittest.skipIf(
+        BACKEND != "nccl", "Only Nccl supports CUDA all_to_all_single"
+    )
+    @skip_if_no_gpu
+    @skip_if_rocm
+    @skip_if_small_worldsize
+    def test_all_to_all_single_equal_split_group_cuda(self):
+        group, group_id, rank = self._init_group_test()
+        rank_to_GPU = self._init_multigpu_helper()
+        self._test_all_to_all_single_equal_split_helper(
+            group,
+            group_id,
+            rank,
+            True,
+            rank_to_GPU,
+        )
+
+    @unittest.skipIf(
+        BACKEND != "mpi", "Only MPI supports CPU all_to_all_single"
+    )
     @skip_if_small_worldsize
     def test_all_to_all_single_unequal_split_group(self):
         group, group_id, rank = self._init_group_test()
         self._test_all_to_all_single_unequal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(
+        BACKEND != "nccl", "Only Nccl supports CUDA all_to_all_single"
+    )
+    @skip_if_no_gpu
+    @skip_if_rocm
+    @skip_if_small_worldsize
+    def test_all_to_all_single_unequal_split_group_cuda(self):
+        group, group_id, rank = self._init_global_test()
+        rank_to_GPU = self._init_multigpu_helper()
+        self._test_all_to_all_single_unequal_split_helper(
+            group,
+            group_id,
+            rank,
+            True,
+            rank_to_GPU,
+        )
 
     @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all")
     @skip_if_small_worldsize
@@ -1576,15 +1672,51 @@ class _DistTestBase(object):
         group, group_id, rank = self._init_group_test()
         self._test_all_to_all_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @unittest.skipIf(
+        BACKEND != "mpi", "Only MPI supports CPU all_to_all_single"
+    )
     def test_all_to_all_single_equal_split_full_group(self):
         group, group_id, rank = self._init_full_group_test()
         self._test_all_to_all_single_equal_split_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all_single")
+    @unittest.skipIf(
+        BACKEND != "nccl", "Only Nccl supports CUDA all_to_all_single"
+    )
+    @skip_if_no_gpu
+    @skip_if_rocm
+    def test_all_to_all_single_equal_split_full_group_cuda(self):
+        group, group_id, rank = self._init_full_group_test()
+        rank_to_GPU = self._init_multigpu_helper()
+        self._test_all_to_all_single_equal_split_helper(
+            group,
+            group_id,
+            rank,
+            True,
+            rank_to_GPU,
+        )
+
+    @unittest.skipIf(
+        BACKEND != "mpi", "Only MPI supports CPU all_to_all_single"
+    )
     def test_all_to_all_single_unequal_split_full_group(self):
         group, group_id, rank = self._init_full_group_test()
         self._test_all_to_all_single_unequal_split_helper(group, group_id, rank)
+
+    @unittest.skipIf(
+        BACKEND != "nccl", "Only Nccl supports CUDA all_to_all_single"
+    )
+    @skip_if_no_gpu
+    @skip_if_rocm
+    def test_all_to_all_single_unequal_split_full_group_cuda(self):
+        group, group_id, rank = self._init_full_group_test()
+        rank_to_GPU = self._init_multigpu_helper()
+        self._test_all_to_all_single_unequal_split_helper(
+            group,
+            group_id,
+            rank,
+            True,
+            rank_to_GPU,
+        )
 
     @unittest.skipIf(BACKEND != "mpi", "Only MPI supports all_to_all")
     def test_all_to_all_full_group(self):

--- a/torch/lib/c10d/NCCLUtils.hpp
+++ b/torch/lib/c10d/NCCLUtils.hpp
@@ -17,6 +17,15 @@
 #define ENABLE_NCCL_ERROR_CHECKING
 #endif
 
+// P2P is enabled only for NCCL versions 2.7+ since ncclSend()
+// and ncclRecv() are not supported in earlier versions.
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
+    (NCCL_MINOR >= 7)
+#define ENABLE_NCCL_P2P_SUPPORT
+#elif defined(NCCL_MAJOR) && (NCCL_MAJOR >= 3)
+#define ENABLE_NCCL_P2P_SUPPORT
+#endif
+
 // Macro to throw on a non-successful NCCL return value.
 #define C10D_NCCL_CHECK(cmd)                                                 \
   do {                                                                       \

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -204,6 +204,22 @@ class ProcessGroup {
       const BarrierOptions& opts = BarrierOptions()) = 0;
 
  protected:
+  void checkSplitSizes(
+      const std::vector<int64_t>& split_sizes,
+      const at::Tensor& tensor,
+      int group_size);
+
+  int64_t computeLengthsAndOffsets(
+      const std::vector<int64_t>& split_sizes,
+      const at::Tensor& tensor,
+      std::vector<int>* lengths,
+      std::vector<int>* offsets);
+
+  int64_t computeLengthsAndOffsets(
+      const std::vector<at::Tensor>& tensors,
+      std::vector<int>* lengths,
+      std::vector<int>* offsets);
+
   const int rank_;
   const int size_;
 };

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -92,72 +92,6 @@ void checkSameSizeAndType(
   }
 }
 
-void checkSplitSizes(
-    const std::vector<int64_t>& split_sizes,
-    const at::Tensor& tensor,
-    int group_size) {
-  if (split_sizes.size() == 0) {
-    TORCH_CHECK(
-        tensor.size(0) % group_size == 0,
-        "Tensor's dim 0 does not divide equally across group size");
-  } else {
-    TORCH_CHECK(
-        split_sizes.size() == group_size,
-        "Number of tensor splits not equal to group size");
-    int sum = std::accumulate(split_sizes.begin(), split_sizes.end(), 0);
-    TORCH_CHECK(
-        sum == tensor.size(0), "Split sizes doesn't match total dim 0 size");
-  }
-}
-
-int64_t computeLengthsAndOffsets(
-    const std::vector<int64_t>& split_sizes,
-    const at::Tensor& tensor,
-    std::vector<int>* lengths,
-    std::vector<int>* offsets) {
-  int64_t group_size = lengths->size();
-  bool equal_splits = false;
-  int64_t dim0_size = tensor.size(0);
-  int64_t row_size = (dim0_size ? tensor.numel() / dim0_size : 1);
-  int64_t split_size = 0;
-  int64_t offset = 0;
-
-  if (split_sizes.size() == 0) {
-    equal_splits = true;
-    split_size = tensor.size(0) / group_size;
-  }
-  for (int i = 0; i < group_size; i++) {
-    int64_t length = row_size * (equal_splits ? split_size : split_sizes[i]);
-    TORCH_INTERNAL_ASSERT(
-        length <= std::numeric_limits<int>::max() &&
-            offset <= std::numeric_limits<int>::max(),
-        "Length or offset larger than INT_MAX not supported");
-    (*lengths)[i] = length;
-    (*offsets)[i] = offset;
-    offset += length;
-  }
-  return offset;
-}
-
-int64_t computeLengthsAndOffsets(
-    const std::vector<at::Tensor>& tensors,
-    std::vector<int>* lengths,
-    std::vector<int>* offsets) {
-  int64_t group_size = lengths->size();
-  int64_t offset = 0;
-  for (int i = 0; i < group_size; i++) {
-    int64_t length = tensors[i].numel();
-    TORCH_INTERNAL_ASSERT(
-        length <= std::numeric_limits<int>::max() &&
-            offset <= std::numeric_limits<int>::max(),
-        "Length or offset larger than INT_MAX not supported");
-    (*lengths)[i] = length;
-    (*offsets)[i] = offset;
-    offset += length;
-  }
-  return offset;
-}
-
 } // namespace
 
 ProcessGroupMPI::AsyncWork::AsyncWork(at::Tensor tensor, MPI_Request request)
@@ -696,8 +630,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall_base(
     return enqueue(std::move(entry));
   } else {
     // Need alltoallv
-    checkSplitSizes(inputSplitSizes, inputTensor, size_);
-    checkSplitSizes(outputSplitSizes, outputTensor, size_);
+    ProcessGroup::checkSplitSizes(inputSplitSizes, inputTensor, size_);
+    ProcessGroup::checkSplitSizes(outputSplitSizes, outputTensor, size_);
     std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
         [opts, this, inputSplitSizes, outputSplitSizes](
             std::unique_ptr<WorkEntry>& entry) {
@@ -707,9 +641,9 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall_base(
           std::vector<int> recv_lengths(size_);
           std::vector<int> send_offsets(size_);
           std::vector<int> recv_offsets(size_);
-          computeLengthsAndOffsets(
+          ProcessGroup::computeLengthsAndOffsets(
               inputSplitSizes, srcdata, &send_lengths, &send_offsets);
-          computeLengthsAndOffsets(
+          ProcessGroup::computeLengthsAndOffsets(
               outputSplitSizes, dstdata, &recv_lengths, &recv_offsets);
           c10::DeviceGuard guard(srcdata.device());
           std::unique_lock<std::mutex> globalLock(pgGlobalMutex_);
@@ -750,9 +684,9 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall(
         auto srcdata = entry->src;
         auto dstdata = entry->dst;
         int64_t src_len =
-            computeLengthsAndOffsets(srcdata, &send_lengths, &send_offsets);
+            ProcessGroup::computeLengthsAndOffsets(srcdata, &send_lengths, &send_offsets);
         int64_t dst_len =
-            computeLengthsAndOffsets(dstdata, &recv_lengths, &recv_offsets);
+            ProcessGroup::computeLengthsAndOffsets(dstdata, &recv_lengths, &recv_offsets);
         std::vector<int64_t> send_lengthsL(
             send_lengths.begin(), send_lengths.end());
         std::vector<int64_t> recv_lengthsL(

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -141,6 +141,64 @@ std::string getNcclAbortedCommStoreKey(const std::string ncclIdStr) {
   return std::string(kNCCLAbortedCommStoreKey) + ":" + ncclIdStr;
 }
 
+#ifdef ENABLE_NCCL_P2P_SUPPORT
+ncclResult_t ncclAlltoall(
+    void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    size_t size,
+    ncclDataType_t type,
+    ncclComm_t comm,
+    cudaStream_t stream) {
+  int numranks;
+  size_t rankdiff = count * size;
+  C10D_NCCL_CHECK(ncclCommCount(comm, &numranks));
+  C10D_NCCL_CHECK(ncclGroupStart());
+  for (int r = 0; r < numranks; r++) {
+    C10D_NCCL_CHECK(ncclSend(
+        ((char*)sendbuff) + r * rankdiff, count, type, r, comm, stream));
+    C10D_NCCL_CHECK(ncclRecv(
+        ((char*)recvbuff) + r * rankdiff, count, type, r, comm, stream));
+  }
+  C10D_NCCL_CHECK(ncclGroupEnd());
+  return ncclSuccess;
+}
+
+ncclResult_t ncclAlltoallv(
+    void* sendbuff,
+    const int* sendcounts,
+    const int* senddispls,
+    void* recvbuff,
+    const int* recvcounts,
+    const int* recvdispls,
+    size_t size,
+    ncclDataType_t type,
+    ncclComm_t comm,
+    cudaStream_t stream) {
+  int numranks;
+  C10D_NCCL_CHECK(ncclCommCount(comm, &numranks));
+  C10D_NCCL_CHECK(ncclGroupStart());
+  for (int r = 0; r < numranks; r++) {
+    C10D_NCCL_CHECK(ncclSend(
+        ((char*)sendbuff) + senddispls[r] * size,
+        sendcounts[r],
+        type,
+        r,
+        comm,
+        stream));
+    C10D_NCCL_CHECK(ncclRecv(
+        ((char*)recvbuff) + recvdispls[r] * size,
+        recvcounts[r],
+        type,
+        r,
+        comm,
+        stream));
+  }
+  C10D_NCCL_CHECK(ncclGroupEnd());
+  return ncclSuccess;
+}
+#endif
+
 } // namespace
 
 const int64_t ProcessGroupNCCL::kWatchdogThreadSleepMillis = 10000;
@@ -583,6 +641,16 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
 
 namespace {
 
+// Check validity of tensor
+void check_gpu_single_tensor(const at::Tensor& tensor) {
+  if (!tensor.is_cuda() || tensor.is_sparse()) {
+    throw std::runtime_error("Tensors must be CUDA and dense");
+  }
+  if (!tensor.is_contiguous()) {
+    throw std::runtime_error("Tensors must be contiguous");
+  }
+}
+
 // Check that all `tensors' have the same type and shape and are distributed
 // across distinct GPUs.
 void check_gpu_tensors(const std::vector<at::Tensor>& tensors) {
@@ -601,9 +669,7 @@ void check_gpu_tensors(const std::vector<at::Tensor>& tensors) {
   usedDevices.reserve(tensors.size());
 
   for (const auto& t : tensors) {
-    if (!t.is_cuda() || t.is_sparse()) {
-      throw std::runtime_error("Tensors must be CUDA and dense");
-    }
+    check_gpu_single_tensor(t);
     if (t.scalar_type() != first.scalar_type()) {
       throw std::runtime_error("Tensors must have identical type");
     }
@@ -958,6 +1024,80 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier(
   ncclWork->barrierTensors_ = std::move(barrierTensors);
 
   return work;
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::alltoall_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    std::vector<int64_t>& outputSplitSizes,
+    std::vector<int64_t>& inputSplitSizes,
+    const AllToAllOptions& /* unused */) {
+#ifdef ENABLE_NCCL_P2P_SUPPORT
+  check_gpu_single_tensor(outputTensor);
+  check_gpu_single_tensor(inputTensor);
+  if (outputSplitSizes.size() == 0 && inputSplitSizes.size() == 0) {
+    std::vector<at::Tensor> inputTensors = {inputTensor};
+    std::vector<at::Tensor> outputTensors = {outputTensor};
+    return collective(
+        inputTensors,
+        outputTensors,
+        [&](at::Tensor& input,
+            at::Tensor& output,
+            ncclComm_t comm,
+            at::cuda::CUDAStream& stream) {
+          return ncclAlltoall(
+              input.data_ptr(),
+              output.data_ptr(),
+              input.numel() / size_,
+              input.element_size(),
+              getNcclDataType(input.scalar_type()),
+              comm,
+              stream.stream());
+        });
+  } else {
+    ProcessGroup::checkSplitSizes(inputSplitSizes, inputTensor, size_);
+    ProcessGroup::checkSplitSizes(outputSplitSizes, outputTensor, size_);
+    std::vector<at::Tensor> inputTensors = {inputTensor};
+    std::vector<at::Tensor> outputTensors = {outputTensor};
+    return collective(
+        inputTensors,
+        outputTensors,
+        [&](at::Tensor& input,
+            at::Tensor& output,
+            ncclComm_t comm,
+            at::cuda::CUDAStream& stream) {
+          std::vector<int> send_lengths(size_);
+          std::vector<int> recv_lengths(size_);
+          std::vector<int> send_offsets(size_);
+          std::vector<int> recv_offsets(size_);
+          ProcessGroup::computeLengthsAndOffsets(
+              inputSplitSizes, input, &send_lengths, &send_offsets);
+          ProcessGroup::computeLengthsAndOffsets(
+              outputSplitSizes, output, &recv_lengths, &recv_offsets);
+          return ncclAlltoallv(
+              input.data_ptr(),
+              send_lengths.data(),
+              send_offsets.data(),
+              output.data_ptr(),
+              recv_lengths.data(),
+              recv_offsets.data(),
+              input.element_size(),
+              getNcclDataType(input.scalar_type()),
+              comm,
+              stream.stream());
+        });
+  }
+#else
+  throw std::runtime_error(
+      "ProcessGroupNCCL only supports alltoall* for NCCL lib version >= 2.7.0");
+#endif
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::alltoall(
+    std::vector<at::Tensor>& /* unused */,
+    std::vector<at::Tensor>& /* unused */,
+    const AllToAllOptions& /* unused */) {
+  throw std::runtime_error("ProcessGroupNCCL does not support alltoall");
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::gather(

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -203,6 +203,18 @@ class ProcessGroupNCCL : public ProcessGroup {
   std::shared_ptr<ProcessGroup::Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 
+  std::shared_ptr<ProcessGroup::Work> alltoall_base(
+      at::Tensor& outputTensor,
+      at::Tensor& inputTensor,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> alltoall(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
+
   // Unsupported Ops
   std::shared_ptr<ProcessGroup::Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,

--- a/torch/lib/c10d/ProcessGroupRoundRobin.cpp
+++ b/torch/lib/c10d/ProcessGroupRoundRobin.cpp
@@ -76,6 +76,16 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::reduce_scatter(
   return next()->reduce_scatter(outputs, inputs, opts);
 };
 
+std::shared_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::alltoall_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    std::vector<int64_t>& outputSplitSizes,
+    std::vector<int64_t>& inputSplitSizes,
+    const AllToAllOptions& opts) {
+  return next()->alltoall_base(
+      outputTensor, inputTensor, outputSplitSizes, inputSplitSizes, opts);
+};
+
 std::shared_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::send(
     std::vector<at::Tensor>& /* unused */,
     int /* unused */,

--- a/torch/lib/c10d/ProcessGroupRoundRobin.hpp
+++ b/torch/lib/c10d/ProcessGroupRoundRobin.hpp
@@ -72,6 +72,13 @@ class ProcessGroupRoundRobin final : public ProcessGroup {
       std::vector<std::vector<at::Tensor>>& inputs,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
+  std::shared_ptr<ProcessGroup::Work> alltoall_base(
+      at::Tensor& outputTensor,
+      at::Tensor& inputTensor,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
+
   std::shared_ptr<ProcessGroup::Work> send(
       std::vector<at::Tensor>& tensors,
       int dstRank,


### PR DESCRIPTION
Summary:
This diff fixes a critical bug in NCCL 2.7.3 for zero byte send/recv.

NCCL checks if (recvbuff==NULL) then it considers it's a send: https://github.com/NVIDIA/nccl/blob/master/src/enqueue.cc#L497

NVIDIA suggested one of the two options until they provide a patch or release a new version. When size of send/recv is zero:
1. set buffers to a non-NULL pointer (tempbuff in this diff)
2. set buffers to 0x1

Test Plan:
buck build  mode/opt  //experimental/ssrinivas/test:nccl_repro

MASTER_PORT=12345 ./nccl_repro
[0] Init start
[1] Init start
[2] Init start
[3] Init start
[0] Init done
[1] Init done
[2] Init done
[3] Init done
[0] Running zero repro
[0] Iter 0
[1] Running zero repro
[1] Iter 0
[2] Running zero repro
[2] Iter 0
[3] Running zero repro
[3] Iter 0
...
[0] zero repro done
[1] zero repro done
[2] zero repro done
[3] zero repro done

Differential Revision: D22749935

