### PR TITLE
[caffe2] Fix a performance bug in Dedup SparseAdagrad op

### DIFF
--- a/caffe2/sgd/adagrad_fused_op_gpu.cu
+++ b/caffe2/sgd/adagrad_fused_op_gpu.cu
@@ -267,7 +267,7 @@ __global__ void linear_index_weight_offsets_dedup_kernel(
       : prefix_sum_length_data[group - 1]; // start offset of the segment
   int end = prefix_sum_length_data[group]; // end offset of the segment
 
-  for (int line = start; line < end; ++line) {
+  for (int line = start; line < end; line += threadIdx.x) {
     // line: the idx in the indices
     seg_id_data[line] = group;
   }
@@ -1163,7 +1163,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp final
 
     linear_index_weight_offsets_dedup_kernel<IndexType>
         <<<num_lengths,
-           std::min(maxThreads, block_size),
+           32,
            0,
            context_.cuda_stream()>>>(
             indices,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42287 [caffe2] Fix a performance bug in Dedup SparseAdagrad op**

We shouldn't use block_size for thread dimensions in linear_index_weight_offsets_dedup_kernel, since the kernel doesn't iterate the embedding dimensions.

Differential Revision: [D22800959](https://our.internmc.facebook.com/intern/diff/D22800959/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D22800959/)!