### PR TITLE
fix quantized elu benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/qactivation_test.py
+++ b/benchmarks/operator_benchmark/pt/qactivation_test.py
@@ -84,7 +84,7 @@ class QActivationBenchmarkBase(op_bench.TorchBenchmarkBase):
         self.qop = op_func
 
     def forward(self):
-        if self.qop == nnq.functional.hardswish:
+        if self.qop in (nnq.functional.hardswish, nnq.functional.elu):
             return self.qop(self.q_input, scale=self.scale, zero_point=self.zero_point)
         return self.qop(self.q_input)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42318 fix quantized elu benchmark**

Summary:

We forgot to update this benchmark when quantized elu's signature
changed to require observation, fixing.

Test Plan:

```
cd benchmarks/operator_benchmark
python -m pt.qactivation_test
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22845251](https://our.internmc.facebook.com/intern/diff/D22845251)