### PR TITLE
Add strict mypy type checking and update code_template.py

### DIFF
--- a/aten/src/ATen/code_template.py
+++ b/aten/src/ATen/code_template.py
@@ -1,16 +1,17 @@
 import re
+from typing import Match, Union, List, Dict, Optional
 
 # match $identifier or ${identifier} and replace with value in env
 # If this identifier is at the beginning of whitespace on a line
 # and its value is a list then it is treated as
-# block subsitution by indenting to that depth and putting each element
+# block substitution by indenting to that depth and putting each element
 # of the list on its own line
 # if the identifier is on a line starting with non-whitespace and a list
 # then it is comma separated ${,foo} will insert a comma before the list
 # if this list is not empty and ${foo,} will insert one after.
 
 
-class CodeTemplate(object):
+class CodeTemplate:
     # Python 2.7.5 has a bug where the leading (^[^\n\S]*)? does not work,
     # workaround via appending another [^\n\S]? inside
 
@@ -22,28 +23,32 @@ class CodeTemplate(object):
 
     substitution_str = substitution_str.replace(r'\w', r'[a-zA-Z0-9_]')
 
-    subtitution = re.compile(substitution_str, re.MULTILINE)
+    substitution = re.compile(substitution_str, re.MULTILINE)
+
+    pattern: str
+    filename: str
 
     @staticmethod
-    def from_file(filename):
+    def from_file(filename: str) -> 'CodeTemplate':
         with open(filename, 'r') as f:
             return CodeTemplate(f.read(), filename)
 
-    def __init__(self, pattern, filename=""):
+    def __init__(self, pattern: str, filename: str = "") -> None:
         self.pattern = pattern
         self.filename = filename
 
-    def substitute(self, env=None, **kwargs):
+    def substitute(self, env: Optional[Dict[str, object]] = None, **kwargs: object) -> str:
         if env is None:
             env = {}
 
-        def lookup(v):
+        def lookup(v: str) -> object:
+            assert env is not None
             return kwargs[v] if v in kwargs else env[v]
 
-        def indent_lines(indent, v):
+        def indent_lines(indent: str, v: List[object]) -> str:
             return "".join([indent + l + "\n" for e in v for l in str(e).splitlines()]).rstrip()
 
-        def replace(match):
+        def replace(match: Match[str]) -> str:
             indent = match.group(1)
             key = match.group(2)
             comma_before = ''
@@ -68,7 +73,7 @@ class CodeTemplate(object):
                 return comma_before + middle + comma_after
             else:
                 return str(v)
-        return self.subtitution.sub(replace, self.pattern)
+        return self.substitution.sub(replace, self.pattern)
 
 
 if __name__ == "__main__":

--- a/aten/src/ATen/code_template.py
+++ b/aten/src/ATen/code_template.py
@@ -1,5 +1,14 @@
 import re
-from typing import Match, Union, List, Dict, Optional
+from typing import Match, Optional, Sequence, TypeVar, Generic
+from typing_extensions import Protocol
+
+K = TypeVar('K', contravariant=True)
+V = TypeVar('V', covariant=True)
+
+# Impoverished Mapping protocol, so nested_dict can stay simple
+class SupportsGetItem(Generic[K, V], Protocol):
+    def __getitem__(self, x: K) -> V:
+        ...
 
 # match $identifier or ${identifier} and replace with value in env
 # If this identifier is at the beginning of whitespace on a line
@@ -37,7 +46,7 @@ class CodeTemplate:
         self.pattern = pattern
         self.filename = filename
 
-    def substitute(self, env: Optional[Dict[str, object]] = None, **kwargs: object) -> str:
+    def substitute(self, env: Optional[SupportsGetItem[str, object]] = None, **kwargs: object) -> str:
         if env is None:
             env = {}
 
@@ -45,7 +54,7 @@ class CodeTemplate:
             assert env is not None
             return kwargs[v] if v in kwargs else env[v]
 
-        def indent_lines(indent: str, v: List[object]) -> str:
+        def indent_lines(indent: str, v: Sequence[object]) -> str:
             return "".join([indent + l + "\n" for e in v for l in str(e).splitlines()]).rstrip()
 
         def replace(match: Match[str]) -> str:

--- a/aten/src/ATen/code_template.py
+++ b/aten/src/ATen/code_template.py
@@ -1,14 +1,5 @@
 import re
-from typing import Match, Optional, Sequence, TypeVar, Generic
-from typing_extensions import Protocol
-
-K = TypeVar('K', contravariant=True)
-V = TypeVar('V', covariant=True)
-
-# Impoverished Mapping protocol, so nested_dict can stay simple
-class SupportsGetItem(Generic[K, V], Protocol):
-    def __getitem__(self, x: K) -> V:
-        ...
+from typing import Match, Optional, Sequence, Mapping
 
 # match $identifier or ${identifier} and replace with value in env
 # If this identifier is at the beginning of whitespace on a line
@@ -46,7 +37,7 @@ class CodeTemplate:
         self.pattern = pattern
         self.filename = filename
 
-    def substitute(self, env: Optional[SupportsGetItem[str, object]] = None, **kwargs: object) -> str:
+    def substitute(self, env: Optional[Mapping[str, object]] = None, **kwargs: object) -> str:
         if env is None:
             env = {}
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1536,10 +1536,15 @@ def create_derived(backend_type_env, declarations):
             env = nested_dict(option, backend_type_env)
             body = emit_body(env, option, option['backend_types'][backend])  # type: ignore
             option['type_definition_body'] = body
+            # These type ignores arise from the fact that a nested_dict
+            # technically isn't a Mapping, as it doesn't implement
+            # enough methods.  I could fix this with a Protocol but
+            # then I need typing_extensions which isn't currently
+            # a build dep.
             legacy_th_declarations.append(
-                LEGACY_TH_DECLARATION.substitute(env))
+                LEGACY_TH_DECLARATION.substitute(env))  # type: ignore
             legacy_th_definitions.append(
-                LEGACY_TH_DEFINITION.substitute(env))
+                LEGACY_TH_DEFINITION.substitute(env))  # type: ignore
 
     def process_native(option):
         # type: (FunctionOption) -> None

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -1,0 +1,33 @@
+# This is a MyPy config file but unlike mypy.ini, it enforces very strict typing
+# rules.  The intention is for this config file to be used to ENFORCE that
+# people are using mypy on codegen files.
+#
+# For now, only code_template.py is covered this way
+
+[mypy]
+python_version = 3.6
+
+strict_optional = True
+show_column_numbers = True
+warn_no_return = True
+disallow_any_unimported = True
+
+# Across versions of mypy, the flags toggled by --strict vary.  To ensure
+# we have reproducible type check, we instead manualy specify the flags
+warn_unused_configs = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+strict_equality = True
+
+files =
+    aten/src/ATen/code_template.py

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -13,7 +13,7 @@ warn_no_return = True
 disallow_any_unimported = True
 
 # Across versions of mypy, the flags toggled by --strict vary.  To ensure
-# we have reproducible type check, we instead manualy specify the flags
+# we have reproducible type check, we instead manually specify the flags
 warn_unused_configs = True
 disallow_any_generics = True
 disallow_subclassing_any = True
@@ -26,7 +26,7 @@ no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 warn_return_any = True
-no_implicit_reexport = True
+implicit_reexport = False
 strict_equality = True
 
 files =

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -204,12 +204,38 @@ class TestTypeHints(TestCase):
             self.skipTest("Typeannotations in numpy-1.20.0-dev are broken")
 
         cwd = os.getcwd()
+        # TODO: Would be better not to chdir here, this affects the entire
+        # process!
         os.chdir(repo_rootdir)
-        (stdout, stderr, result) = mypy.api.run([
-            '--check-untyped-defs',
-            '--follow-imports', 'silent',
-        ])
-        os.chdir(cwd)
+        try:
+            (stdout, stderr, result) = mypy.api.run([
+                '--check-untyped-defs',
+                '--follow-imports', 'silent',
+            ])
+        finally:
+            os.chdir(cwd)
+        if result != 0:
+            self.fail("mypy failed: {}".format(stdout))
+
+    @unittest.skipIf(not HAVE_MYPY, "need mypy")
+    def test_run_mypy_strict(self):
+        """
+        Runs mypy over all files specified in mypy-strict.ini
+        """
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        repo_rootdir = os.path.join(test_dir, '..')
+        mypy_inifile = os.path.join(repo_rootdir, 'mypy-strict.ini')
+        if not os.path.exists(mypy_inifile):
+            self.skipTest("Can't find PyTorch MyPy strict config file")
+
+        cwd = os.getcwd()
+        os.chdir(repo_rootdir)
+        try:
+            (stdout, stderr, result) = mypy.api.run([
+                '--config', mypy_inifile,
+            ])
+        finally:
+            os.chdir(cwd)
         if result != 0:
             self.fail("mypy failed: {}".format(stdout))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42322 Add strict mypy type checking and update code_template.py**

Our current type checking rules are rather lax, and for
example don't force users to make sure they annotate all functions
with types.  For code generation code, it would be better to force
100% typing.  This PR introduces a new mypy configuration
mypy-strict.ini which applies rules from --strict.  We extend
test_type_hints.py to test for this case.  It only covers
code_template.py, which I have made strict clean in this PR.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D22846120](https://our.internmc.facebook.com/intern/diff/D22846120)