### PR TITLE
NaN masking in multihead attention

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3429,11 +3429,12 @@ class TestNN(NNTestCase):
         attn_equiv = copy.deepcopy(attn_orig)
 
         def forward_helper(attn, x, attn_mask, key_padding_mask):
-            o, _ = multi_head_attention_forward(x, x, x, emb_dim, num_heads, attn.in_proj_weight, attn.in_proj_bias,
-                                                attn.bias_k, attn.bias_v, attn.add_zero_attn, attn.dropout,
-                                                attn.out_proj.weight, attn.out_proj.bias, training=True,
-                                                key_padding_mask=key_padding_mask,
-                                                attn_mask=attn_mask)
+            o, _ = torch.nn.functional.multi_head_attention_forward(x, x, x, emb_dim, num_heads, attn.in_proj_weight,
+                                                                    attn.in_proj_bias, attn.bias_k, attn.bias_v,
+                                                                    attn.add_zero_attn, attn.dropout,
+                                                                    attn.out_proj.weight, attn.out_proj.bias,
+                                                                    training=True, key_padding_mask=key_padding_mask,
+                                                                    attn_mask=attn_mask)
             loss = o[:seq_len-1, :].sum()
             loss.backward()
             return loss

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3422,6 +3422,39 @@ class TestNN(NNTestCase):
             # output_2d in shape of [T, 1, D]
             self.assertEqual(output_3d[i].unsqueeze(0).transpose(0, 1), output_2d)
 
+    def test_multihead_self_attn(self):
+        import copy
+        seq_len, bsz, emb_dim, num_heads = 3, 2, 4, 2
+        attn_orig = torch.nn.MultiheadAttention(embed_dim=emb_dim, num_heads=num_heads)
+        attn_equiv = copy.deepcopy(attn_orig)
+
+        def forward_helper(attn, x, attn_mask, key_padding_mask):
+            o, _ = multi_head_attention_forward(x, x, x, emb_dim, num_heads, attn.in_proj_weight, attn.in_proj_bias,
+                                                attn.bias_k, attn.bias_v, attn.add_zero_attn, attn.dropout,
+                                                attn.out_proj.weight, attn.out_proj.bias, training=True,
+                                                key_padding_mask=key_padding_mask,
+                                                attn_mask=attn_mask)
+            loss = o[:seq_len-1, :].sum()
+            loss.backward()
+            return loss
+
+        # Last step of second sequence cannot attend to anything, but is not used in loss calculation
+        key_padding_mask = torch.as_tensor([[False, False, False], [False, True, True]])
+        attn_mask = torch.as_tensor([[False, True, True], [False, False, True], [True, False, False]])
+        x = torch.rand(seq_len, bsz, emb_dim)
+        loss_orig = forward_helper(attn_orig, x, attn_mask, key_padding_mask)
+
+        # Remove last step both sequences as they are not used in loss calculation - equivalent to orig
+        key_padding_mask = torch.as_tensor([[False, False], [False, True]])
+        attn_mask = torch.as_tensor([[False, True], [False, False]])
+        x = x[:seq_len-1, :, :]
+        loss_equiv = forward_helper(attn_equiv, x, attn_mask, key_padding_mask)
+
+        self.assertEqual(loss_orig, loss_equiv)
+        for (orig_p, equiv_p) in zip(attn_orig.parameters(), attn_equiv.parameters()):
+            self.assertEqual(orig_p, equiv_p)
+            self.assertEqual(orig_p.grad, equiv_p.grad)
+
     def test_normalize(self):
         inputs = torch.randn(1, 3, 4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.normalize(x, p=1, dim=-1), (inputs,)))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3190,22 +3190,6 @@ class TestNN(NNTestCase):
             X_fc_w = X_weight.detach().numpy()
             return np.matmul(X, np.transpose(X_fc_w)) + X_fc_b
 
-        def _create_src_lengths_mask(batch_size, src_lengths):
-            """
-            Generate boolean mask to prevent attention beyond the end of source
-            Inputs:
-              batch_size : int
-              src_lengths : [batch_size] of sentence lengths
-            Outputs:
-              [batch_size, max_src_len]
-            """
-            max_srclen = src_lengths.max()
-            src_indices = torch.arange(0, max_srclen).unsqueeze(0).to(src_lengths)
-            src_indices = src_indices.expand(batch_size, max_srclen)
-            src_lengths = src_lengths.unsqueeze(dim=1).expand(batch_size, max_srclen)
-            # returns [batch_size, max_seq_len]
-            return (src_indices < src_lengths).int().detach()
-
         def _multihead_attn_test_helper(add_key_padding_mask=False, add_bias_kv=False, add_zero_attn=False,
                                         saved_kv=False, same_embed_dim=False, byte_mask=False):
             for _ in range(100):


### PR DESCRIPTION
Fixes #41508

### Summary:
Using key_padding_mask and attn_mask with nn.MultiheadAttention causes gradients to become NaN under some valid use cases, including bucketed attention. The NaNs are produced by the softmax function and need to be masked before the matmul to prevent NaN gradients being introduced during the backwards pass. Removing the padding/NaNs later in the forward pass does not work as going backwards through the indexing/slicing creates a 0 grad for the pruned elements (0*NaN=NaN).
This PR masks NaNs under the following conditions:
- attn_mask and key_padding_mask are both used
- attn_mask is a boolean mask (additive mask might just be an offset, so considered user error)
- first element of src is masked in attn_mask (limited context)
- last element of src is masked in key_padding_mask (padding)

The NaNs are masked based on these conditions (instead of checking for NaN) as it's more efficient. This should cover all the (non-user error) cases in which Multihead Attention will fail. It could be simplified further, but that will reduce performance for most use cases. 