### PR TITLE
Add inplace option for torch.nn.Hardsigmoid and torch.nn.Hardswish layers

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -309,6 +309,8 @@ class Hardsigmoid(Module):
             x / 6 + 1 / 2 & \text{otherwise}
         \end{cases}
 
+    Args:
+        inplace: can optionally do the operation in-place. Default: ``False``
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
@@ -321,9 +323,16 @@ class Hardsigmoid(Module):
         >>> input = torch.randn(2)
         >>> output = m(input)
     """
+    __constants__ = ['inplace']
+
+    inplace: bool
+
+    def __init__(self, inplace : bool = False) -> None:
+        super(Hardsigmoid, self).__init__()
+        self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
-        return F.hardsigmoid(input)
+        return F.hardsigmoid(input, self.inplace)
 
 
 class Tanh(Module):
@@ -400,6 +409,9 @@ class Hardswish(Module):
             x \cdot (x + 3) /6 & \text{otherwise}
         \end{cases}
 
+    Args:
+        inplace: can optionally do the operation in-place. Default: ``False``
+
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
@@ -414,9 +426,16 @@ class Hardswish(Module):
     .. _`Searching for MobileNetV3`:
         https://arxiv.org/abs/1905.02244
     """
+    __constants__ = ['inplace']
+
+    inplace: bool
+
+    def __init__(self, inplace : bool = False) -> None:
+        super(Hardswish, self).__init__()
+        self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
-        return F.hardswish(input)
+        return F.hardswish(input, self.inplace)
 
 
 class ELU(Module):


### PR DESCRIPTION
**`torch.nn.Hardsigmoid`** and **`torch.nn.Hardswish`** classes currently do not support `inplace` operations as it uses `torch.nn.functional.hardsigmoid` and `torch.nn.functional.hardswish` functions with their default inplace argument which is `False`.

So, I added `inplace` argument for `torch.nn.Hardsigmoid` and `torch.nn.Hardswish` classes so that forward operation can be done inplace as well while using these layers.