### PR TITLE
[quant] Use PlaceholderObserver instead of Fp16Observer and NoopObserver

### DIFF
--- a/test/quantization/test_quantize_jit.py
+++ b/test/quantization/test_quantize_jit.py
@@ -2510,7 +2510,7 @@ class TestQuantizeDynamicJitPasses(QuantizationTestCase):
             assert len(attrs_with_prefix(m.fc, '_observer_')) == 1
 
             if qconfig == float16_dynamic_qconfig:
-                observer_name = 'Fp16Observer = prim::GetAttr[name="_observer_'
+                observer_name = 'PlaceholderObserver = prim::GetAttr[name="_observer_'
                 FileCheck().check(observer_name) \
                            .run(m.fc.graph)
             else:
@@ -2843,13 +2843,13 @@ class TestQuantizeDynamicJitOps(QuantizationTestCase):
         indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
         offsets = torch.tensor([0, 19, 20, 28, 28, 32])
 
-        from torch.quantization import QConfigDynamic, NoopObserver
-        int4_dynamic_qconfig = QConfigDynamic(activation=NoopObserver.with_args(dtype=torch.float,
-                                                                                custom_op_name="embedding_bag_4bit"),
-                                              weight=NoopObserver.with_args(custom_op_name="embedding_bag_4bit"))
-        int8_dynamic_qconfig = QConfigDynamic(activation=NoopObserver.with_args(dtype=torch.float,
-                                                                                custom_op_name="embedding_bag_byte"),
-                                              weight=NoopObserver.with_args(custom_op_name="embedding_bag_byte"))
+        from torch.quantization import QConfigDynamic, PlaceholderObserver
+        int4_dynamic_qconfig = QConfigDynamic(activation=PlaceholderObserver.with_args(dtype=torch.float,
+                                                                                       custom_op_name="embedding_bag_4bit"),
+                                              weight=PlaceholderObserver.with_args(custom_op_name="embedding_bag_4bit"))
+        int8_dynamic_qconfig = QConfigDynamic(activation=PlaceholderObserver.with_args(dtype=torch.float,
+                                                                                       custom_op_name="embedding_bag_byte"),
+                                              weight=PlaceholderObserver.with_args(custom_op_name="embedding_bag_byte"))
         m = quantize_dynamic_jit(m, {'embedding1' : int4_dynamic_qconfig, 'embedding2' : int8_dynamic_qconfig})
         FileCheck().check("quantized::embedding_bag_4bit_rowwise_offsets") \
                    .check_next("quantized::embedding_bag_byte_rowwise_offsets") \

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -63,8 +63,8 @@ class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight'])):
 
 default_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_observer,
                                          weight=default_weight_observer)
-float16_dynamic_qconfig = QConfigDynamic(activation=NoopObserver.with_args(dtype=torch.float16),
-                                         weight=Fp16Observer.with_args(dtype=torch.float16))
+float16_dynamic_qconfig = QConfigDynamic(activation=PlaceholderObserver.with_args(dtype=torch.float16),
+                                         weight=PlaceholderObserver.with_args(dtype=torch.float16))
 per_channel_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_observer,
                                              weight=default_per_channel_weight_observer)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42348 [quant] Use PlaceholderObserver instead of Fp16Observer and NoopObserver**
* #42222 [quant][graph] Add support for FP16 dynamic quant
* #42221 [quant] Add FP16Observer for fp16 quant support
* #42147 [quant] Add saturate_to_fp16 op for FP16 quant support

Summary:
Use the dtype info in placeholderObserver to decide what ops to insert in the graph
In the next PR we can delete NoopObserver

Test Plan:
python test/test_quantization.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D22859457](https://our.internmc.facebook.com/intern/diff/D22859457)