### PR TITLE
[Caffe2] Remove explicitly divide by zero in SpatialBN training mode

### DIFF
--- a/caffe2/operators/spatial_batch_norm_op.h
+++ b/caffe2/operators/spatial_batch_norm_op.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -249,8 +250,9 @@ class SpatialBNOp : public Operator<Context> {
       T* beta) {
     const T a = T(1) - static_cast<T>(momentum_);
     const T b = static_cast<T>(momentum_);
-    const T unbias_scale =
-        static_cast<T>(reduce_size) / static_cast<T>(reduce_size - 1);
+    const T unbias_scale = reduce_size == 1
+        ? std::numeric_limits<T>::infinity()
+        : static_cast<T>(reduce_size) / static_cast<T>(reduce_size - 1);
     math::Axpby<T, T, Context>(C, a, mean, b, running_mean, &context_);
     math::Axpby<T, T, Context>(
         C, a * unbias_scale, var, b, running_var, &context_);

--- a/caffe2/python/operator_test/spatial_bn_op_test.py
+++ b/caffe2/python/operator_test/spatial_bn_op_test.py
@@ -216,10 +216,14 @@ class TestSpatialBN(serial.SerializedTestCase):
             reduce_size = batch_size * size * size
             saved_mean = np.mean(X, (0, 2, 3))
             saved_var = np.var(X, (0, 2, 3))
+            if reduce_size == 1:
+                unbias_scale = float('inf')
+            else:
+                unbias_scale = reduce_size / (reduce_size - 1)
             running_mean = momentum * running_mean + (
                 1.0 - momentum) * saved_mean
-            running_var = momentum * running_var + (1.0 - momentum) * (
-                reduce_size / (reduce_size - 1)) * saved_var
+            running_var = momentum * running_var + (
+                1.0 - momentum) * unbias_scale * saved_var
             std = np.sqrt(saved_var + epsilon)
             broadcast_shape = (1, C, 1, 1)
             Y = (X - np.reshape(saved_mean, broadcast_shape)) / np.reshape(


### PR DESCRIPTION
Summary: [Caffe2] Remove explicitly divide by zero in SpatialBN training mode

Test Plan: buck test mode/dev-nosan //caffe2/caffe2/python/operator_test:spatial_bn_op_test

Differential Revision: D22873214

