### PR TITLE
[docker][android] use aws instead of google repository

### DIFF
--- a/.circleci/docker/common/install_android.sh
+++ b/.circleci/docker/common/install_android.sh
@@ -52,7 +52,7 @@ _android_home=/opt/android/sdk
 
 rm -rf $_android_home
 sudo mkdir -p $_android_home
-curl --silent --show-error --location --fail --retry 3 --output /tmp/android-sdk-linux.zip $_https_amazon_aws/android-sdk-linux.zip
+curl --silent --show-error --location --fail --retry 3 --output /tmp/android-sdk-linux.zip $_https_amazon_aws/android-sdk-linux-tools3859397-build-tools2803-2902-platforms28-29.zip
 sudo unzip -q $_tmp_sdk_zip -d $_android_home
 rm $_tmp_sdk_zip
 

--- a/.circleci/docker/common/install_android.sh
+++ b/.circleci/docker/common/install_android.sh
@@ -70,7 +70,7 @@ _gradle_home=/opt/gradle
 sudo rm -rf $gradle_home
 sudo mkdir -p $_gradle_home
 
-curl -Os --retry 3 $_https_amazon_aws/gradle-${GRADLE_VERSION}-bin.zip
+curl --silent --output /tmp/gradle.zip --retry 3 $_https_amazon_aws/gradle-${GRADLE_VERSION}-bin.zip
 
 sudo unzip -q /tmp/gradle.zip -d $_gradle_home
 rm /tmp/gradle.zip

--- a/.circleci/docker/common/install_android.sh
+++ b/.circleci/docker/common/install_android.sh
@@ -10,7 +10,7 @@ apt-get autoclean && apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 pushd /tmp
-curl -Os --retry 3 https://ossci-android.s3.amazonaws.com/android-ndk-${ANDROID_NDK}-linux-x86_64.zip
+curl -Os --retry 3 $_https_amazon_aws/android-ndk-${ANDROID_NDK}-linux-x86_64.zip
 popd
 _ndk_dir=/opt/ndk
 mkdir -p "$_ndk_dir"
@@ -44,13 +44,14 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 # Installing android sdk
 # https://github.com/circleci/circleci-images/blob/staging/android/Dockerfile.m4
+_https_amazon_aws=https://s3.amazonaws.com/ossci-android/
 
 _tmp_sdk_zip=/tmp/android-sdk-linux.zip
 _android_home=/opt/android/sdk
 
 rm -rf $_android_home
 sudo mkdir -p $_android_home
-curl --silent --show-error --location --fail --retry 3 --output /tmp/android-sdk-linux.zip https://ossci-android.s3.amazonaws.com/android-sdk-linux.zip
+curl --silent --show-error --location --fail --retry 3 --output /tmp/android-sdk-linux.zip $_https_amazon_aws/android-sdk-linux.zip
 sudo unzip -q $_tmp_sdk_zip -d $_android_home
 rm $_tmp_sdk_zip
 
@@ -68,8 +69,7 @@ _gradle_home=/opt/gradle
 sudo rm -rf $gradle_home
 sudo mkdir -p $_gradle_home
 
-wget --no-verbose --output-document=/tmp/gradle.zip \
-"https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+curl -Os --retry 3 $_https_amazon_aws/gradle-${GRADLE_VERSION}-bin.zip
 
 sudo unzip -q /tmp/gradle.zip -d $_gradle_home
 rm /tmp/gradle.zip

--- a/.circleci/docker/common/install_android.sh
+++ b/.circleci/docker/common/install_android.sh
@@ -4,6 +4,8 @@ set -ex
 
 [ -n "${ANDROID_NDK}" ]
 
+_https_amazon_aws=https://ossci-android.s3.amazonaws.com
+
 apt-get update
 apt-get install -y --no-install-recommends autotools-dev autoconf unzip
 apt-get autoclean && apt-get clean
@@ -44,7 +46,6 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 # Installing android sdk
 # https://github.com/circleci/circleci-images/blob/staging/android/Dockerfile.m4
-_https_amazon_aws=https://s3.amazonaws.com/ossci-android/
 
 _tmp_sdk_zip=/tmp/android-sdk-linux.zip
 _android_home=/opt/android/sdk

--- a/.circleci/docker/common/install_android.sh
+++ b/.circleci/docker/common/install_android.sh
@@ -10,7 +10,7 @@ apt-get autoclean && apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 pushd /tmp
-curl -Os --retry 3 https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK}-linux-x86_64.zip
+curl -Os --retry 3 https://ossci-android.s3.amazonaws.com/android-ndk-${ANDROID_NDK}-linux-x86_64.zip
 popd
 _ndk_dir=/opt/ndk
 mkdir -p "$_ndk_dir"
@@ -45,43 +45,22 @@ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 # Installing android sdk
 # https://github.com/circleci/circleci-images/blob/staging/android/Dockerfile.m4
 
-_sdk_version=sdk-tools-linux-3859397.zip
+_tmp_sdk_zip=/tmp/android-sdk-linux.zip
 _android_home=/opt/android/sdk
 
 rm -rf $_android_home
 sudo mkdir -p $_android_home
-curl --silent --show-error --location --fail --retry 3 --output /tmp/$_sdk_version https://dl.google.com/android/repository/$_sdk_version
-sudo unzip -q /tmp/$_sdk_version -d $_android_home
-rm /tmp/$_sdk_version
+curl --silent --show-error --location --fail --retry 3 --output /tmp/android-sdk-linux.zip https://ossci-android.s3.amazonaws.com/android-sdk-linux.zip
+sudo unzip -q $_tmp_sdk_zip -d $_android_home
+rm $_tmp_sdk_zip
 
 sudo chmod -R 777 $_android_home
 
 export ANDROID_HOME=$_android_home
 export ADB_INSTALL_TIMEOUT=120
 
-export PATH="${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}"
+export PATH="${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}"
 echo "PATH:${PATH}"
-alias sdkmanager="$ANDROID_HOME/tools/bin/sdkmanager"
-
-sudo mkdir ~/.android && sudo echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
-sudo chmod -R 777 ~/.android
-
-yes | sdkmanager --licenses
-yes | sdkmanager --update
-
-sdkmanager \
-  "tools" \
-  "platform-tools" \
-  "emulator"
-
-sdkmanager \
-  "build-tools;28.0.3" \
-  "build-tools;29.0.2"
-
-sdkmanager \
-  "platforms;android-28" \
-  "platforms;android-29"
-sdkmanager --list
 
 # Installing Gradle
 echo "GRADLE_VERSION:${GRADLE_VERSION}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42393 [docker][android] use aws instead of google repository**
* #42392 Revert "Revert D22360735: .circleci: Build docker images as part of CI workflow"

