### PR TITLE
DDP communication hook: skip dividing grads by world_size if hook registered.

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -3099,7 +3099,8 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         def allreduce_hook(state: object, bucket: dist._GradBucket) -> torch._C.Future:
-            return process_group.allreduce(bucket.get_tensors()).get_future()
+            tensors = [t / self.world_size for t in bucket.get_tensors()]
+            return process_group.allreduce(tensors).get_future()
 
         # Get GPU model with allreduce_hook registered.
         gpu_model = self._gpu_model_with_ddp_comm_hook(process_group, allreduce_hook)
@@ -3118,7 +3119,8 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         def allreduce_then_mult_hook(state: object, bucket: dist._GradBucket) -> torch._C.Future:
-            fut = process_group.allreduce(bucket.get_tensors()).get_future()
+            tensors = [t / self.world_size for t in bucket.get_tensors()]
+            fut = process_group.allreduce(tensors).get_future()
 
             def mult(fut):
                 # Multiply result by 10.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -175,7 +175,8 @@ Reducer::Reducer(
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~
 // If DDP communication hook is not registered, the reducer reduces the buckets
 // by just calling allreduce. If registered, it calls the hook and uses future
-// work handle.
+// work handle. If registered, reducer also skips dividing grads by world size.
+//
 // DDP communication hook is an enhancement that provides a hook which can be
 // used to override how DDP communicates gradients across ranks, this can be
 // used for algorithms like Gradient Compression/GossipGrad. This hook can be
@@ -351,12 +352,17 @@ void Reducer::mark_variable_ready_dense(VariableIndex index) {
             ", strides() = ",
             bucket_view.strides());
       }
-      // imitates wrapped_scalar_tensor in ATen/native/BinaryOps.cpp
-      auto wrapped =
-          c10::scalar_to_tensor(double(1.) / process_group_->getSize());
-      wrapped.unsafeGetTensorImpl()->set_wrapped_number(true);
-      // Divides while copying into the bucket view.
-      at::native::mul_out(bucket_view, grad, wrapped);
+      // See Note [DDP Communication Hook]
+      if (comm_hook_ == nullptr) {
+        // imitates wrapped_scalar_tensor in ATen/native/BinaryOps.cpp
+        auto wrapped =
+            c10::scalar_to_tensor(double(1.) / process_group_->getSize());
+        wrapped.unsafeGetTensorImpl()->set_wrapped_number(true);
+        // Divides while copying into the bucket view.
+        at::native::mul_out(bucket_view, grad, wrapped);
+      } else {
+        bucket_view.copy_(grad);
+      }
     } else {
       bucket_view.zero_();
     }
@@ -385,7 +391,10 @@ void Reducer::mark_variable_ready_sparse(VariableIndex index) {
     // struct are empty, and there is no pre-existing accumulation tensor.
     // Directly assign the sparse tensor to the `contents` field.
     replica.contents = grad;
-    replica.contents.div_(process_group_->getSize());
+    // See Note [DDP Communication Hook]
+    if (comm_hook_ == nullptr) {
+      replica.contents.div_(process_group_->getSize());
+    }
     // The grad is modified in place and needs to be written back.
     return true;
   });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

@mcarilli spotted that in the original DDP communication hook design described in [39272](https://github.com/pytorch/pytorch/issues/39272), the hooks receive grads that are already predivided by world size.

It makes sense to skip the divide completely if hook registered. The hook is meant for the user to completely override DDP communication. For example, if the user would like to implement something like GossipGrad, always dividing by the world_size would not be a good idea.

We also included a warning in the register_comm_hook API as:
> GradBucket bucket's tensors will not be predivided by world_size. User is responsible to divide by the world_size in case of operations like allreduce.

Differential Revision: [D22883905](https://our.internmc.facebook.com/intern/diff/D22883905/)