### PR TITLE
Relax cusparse windows guard on cuda 11

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -9,16 +9,11 @@
 
 #include <cusparse.h>
 
-#if !defined(_MSC_VER) && defined(__CUDACC__) && CUSPARSE_VERSION >= 10301 // CUDA release >= 10.2 and not windows
+#if defined(__CUDACC__) && CUSPARSE_VERSION >= 11000
 #include <library_types.h>
 #endif
 
-// LIMITATION (cusparseSpMM): 
-// The generic APIs are currently (CUDA 10.1) available for all platforms except Windows. 
-// Using these APIs in any other systems will result in compile-time or run-time failures. 
-// Their support will be extended in the next releases. 
-
-#if !defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 10200)
+#if !defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 11000)
 const char* cusparseGetErrorString(cusparseStatus_t status) {
   switch(status)
   {
@@ -81,7 +76,7 @@ cusparseOperation_t convertTransToCusparseOperation(char trans) {
   }
 }
 
-#if !defined(_MSC_VER) && defined(__CUDACC__) && CUSPARSE_VERSION >= 10301 // CUDA release >= 10.2 and not windows
+#if defined(__CUDACC__) && CUSPARSE_VERSION >= 11000
 
 template<typename T> 
 void csrmm2(

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -13,7 +13,7 @@
 #include <library_types.h>
 #endif
 
-#if !defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 11000)
+#if !defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 10100)
 const char* cusparseGetErrorString(cusparseStatus_t status) {
   switch(status)
   {

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -817,9 +817,9 @@ Tensor& bmm_out_sparse_cuda(Tensor& result, const SparseTensor& self, const Tens
 Tensor& _bmm_out_sparse_cuda(Tensor& result, const SparseTensor& self, const Tensor& mat2, bool deterministic) {
 #if defined __HIP_PLATFORM_HCC__
   TORCH_CHECK(false, "bmm sparse-dense is not supported on HIP");
-#elif defined(_WIN32) || defined(_WIN64)
-  TORCH_CHECK(false, "bmm sparse-dense CUDA is not supported on Windows");
-#elif defined(CUDART_VERSION) && (CUDART_VERSION >= 10010)
+#elif defined(_MSC_VER) && (CUSPARSE_VERSION < 11000)
+  TORCH_CHECK(false, "bmm sparse-dense CUDA is not supported on Windows with cuda before 11.0");
+#elif defined(CUDART_VERSION) && (CUDART_VERSION >= 10010)  // linux cuda >= 10.1 or windows cuda >= 11.0
 
   TORCH_CHECK(!mat2.is_sparse(), "bmm_sparse: Tensor 'mat2' must be dense");
   TORCH_CHECK(self.dense_dim() == 0, "bmm_sparse: Tensor 'self' must have 0 dense dims, but has ", self.dense_dim());

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -817,9 +817,9 @@ Tensor& bmm_out_sparse_cuda(Tensor& result, const SparseTensor& self, const Tens
 Tensor& _bmm_out_sparse_cuda(Tensor& result, const SparseTensor& self, const Tensor& mat2, bool deterministic) {
 #if defined __HIP_PLATFORM_HCC__
   TORCH_CHECK(false, "bmm sparse-dense is not supported on HIP");
-#elif defined(_MSC_VER) && (CUSPARSE_VERSION < 11000)
-  TORCH_CHECK(false, "bmm sparse-dense CUDA is not supported on Windows with cuda before 11.0");
-#elif defined(CUDART_VERSION) && (CUDART_VERSION >= 10010)  // linux cuda >= 10.1 or windows cuda >= 11.0
+#elif defined(_WIN32) || defined(_WIN64)
+  TORCH_CHECK(false, "bmm sparse-dense CUDA is not supported on Windows");
+#elif defined(CUDART_VERSION) && (CUDART_VERSION >= 10010)
 
   TORCH_CHECK(!mat2.is_sparse(), "bmm_sparse: Tensor 'mat2' must be dense");
   TORCH_CHECK(self.dense_dim() == 0, "bmm_sparse: Tensor 'self' must have 0 dense dims, but has ", self.dense_dim());


### PR DESCRIPTION
Fixes #42406 

### cusparse Xcsrmm2 API: 

(#37202)

- new: https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-spmm
- old (deprecated in cuda 11): https://docs.nvidia.com/cuda/archive/10.2/cusparse/index.html#csrmm2

Before:

|cuda ver | windows | linux |
|--|--|--|
| 10.1 | old api | old api  |
| 10.2 | old api | new api |
| 11    | old api (build error claimed in #42406) | new api |

After:

|cuda ver | windows | linux |
|--|--|--|
| 10.1 | old api | old api  |
| 10.2 | old api | **old api** |
| 11    | **new api** | new api |

### cusparse bmm-sparse-dense API

<details><summary>reverted, will be revisited in the future</summary>
(cc @kurtamohler #33430)

- new: https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-spmm

Before:

|cuda ver | windows | linux |
|--|--|--|
| 10.1 | not supported | new api  |
| 10.2 | not supported | new api |
| 11    | not supported | new api |

After:

|cuda ver | windows | linux |
|--|--|--|
| 10.1 | not supported | new api  |
| 10.2 | not supported | new api |
| 11    | **new api** | new api |

</details>