### PR TITLE
Expose a generic shape info struct for ONNXIFI Python interface

### DIFF
--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -36,6 +36,82 @@ ShapeInfo getShapeInfoFromBlob(const Blob* blob) {
   return shape_info;
 }
 
+void modifyTensorShapeDimSize(
+    TensorShape* tensor_shape,
+    int dim_index,
+    const int64_t old_size,
+    const int64_t new_size) {
+  CAFFE_ENFORCE(
+      old_size > 0, "Old size should be non-zero, old_size: ", old_size);
+  CAFFE_ENFORCE(
+      tensor_shape->dims(dim_index) % old_size == 0,
+      "tensor_shape->dims[",
+      dim_index,
+      "] = ",
+      tensor_shape->dims(dim_index),
+      " cannot be divided by old_size ",
+      old_size);
+  int64_t modified_size = (tensor_shape->dims(dim_index) * new_size) / old_size;
+  tensor_shape->set_dims(dim_index, modified_size);
+}
+
+void changeTensorBoundShapes(
+    TensorBoundShape& tensor_shape_and_type,
+    const int64_t old_batch_size,
+    const int64_t old_seq_size,
+    const int64_t new_batch_size,
+    const int64_t new_seq_size) {
+  CAFFE_ENFORCE(
+      tensor_shape_and_type.dim_type().size() ==
+      tensor_shape_and_type.shape().dims().size());
+
+  for (int i = 0; i < tensor_shape_and_type.dim_type().size(); i++) {
+    TensorBoundShape_DimType dim_type = tensor_shape_and_type.dim_type(i);
+    // Need to change max_batch_size
+    if (dim_type == TensorBoundShape_DimType_BATCH ||
+        dim_type == TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX ||
+        dim_type == TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT) {
+      TensorShape* tensor_shape = tensor_shape_and_type.mutable_shape();
+      modifyTensorShapeDimSize(tensor_shape, i, old_batch_size, new_batch_size);
+    }
+    // Need to change max_seq_size
+    if (dim_type == TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT ||
+        dim_type == TensorBoundShape_DimType_FEATURE_MAX_DEFAULT) {
+      TensorShape* tensor_shape = tensor_shape_and_type.mutable_shape();
+      modifyTensorShapeDimSize(tensor_shape, i, old_seq_size, new_seq_size);
+    }
+  }
+}
+
+ShapeInfoMap extractShapeInfoFromTensorBoundShapes(
+    TensorBoundShapes tensor_bound_shapes,
+    int64_t new_max_batch_size,
+    int64_t new_max_feature_len) {
+  ShapeInfoMap shape_info_map;
+  if (new_max_batch_size == -1) {
+    new_max_batch_size = tensor_bound_shapes.max_batch_size();
+  }
+  if (new_max_feature_len == -1) {
+    new_max_feature_len = tensor_bound_shapes.max_feature_len();
+  }
+  for (auto& tensor_bound_shape : *(tensor_bound_shapes.mutable_shapes())) {
+    std::vector<TensorBoundShape::DimType> dim_types;
+    dim_types.reserve(tensor_bound_shape.shape().dims_size());
+    for (auto dim_type : tensor_bound_shape.dim_type()) {
+      dim_types.emplace_back(TensorBoundShape::DimType(dim_type));
+    }
+    changeTensorBoundShapes(
+        tensor_bound_shape,
+        tensor_bound_shapes.max_batch_size(),
+        tensor_bound_shapes.max_feature_len(),
+        new_max_batch_size,
+        new_max_feature_len);
+    shape_info_map[tensor_bound_shape.name()] =
+        ShapeInfo(dim_types, std::move(tensor_bound_shape.shape()));
+  }
+  return shape_info_map;
+}
+
 bool operator==(const ShapeInfo& lhs, const ShapeInfo& rhs) {
   return lhs.getDimType() == rhs.getDimType() &&
       lhs.shape.SerializeAsString() == rhs.shape.SerializeAsString();

--- a/caffe2/opt/shape_info.h
+++ b/caffe2/opt/shape_info.h
@@ -129,4 +129,26 @@ CAFFE2_API ShapeInfo constructShapeInfoWithDefaultDimType(
 
 CAFFE2_API void parseShapeInfoMapFromString(const std::string&, ShapeInfoMap&);
 
+// Extract shape info from tensorBoundShapes to a ShapeInfoMap.
+// Change shape according to new max_batch_size and max_feature_len
+// at the same time if necessary.
+CAFFE2_API ShapeInfoMap extractShapeInfoFromTensorBoundShapes(
+    TensorBoundShapes tensor_bound_shapes,
+    int64_t new_max_batch_size = -1,
+    int64_t new_max_feature_len = -1);
+
+// In-place modify TensorBoundShape to change shape size based on type
+CAFFE2_API void changeTensorBoundShapes(
+    TensorBoundShape& tensor_shape_and_type,
+    const int64_t old_batch_size,
+    const int64_t old_seq_size,
+    const int64_t new_batch_size,
+    const int64_t new_seq_size);
+
+// In-place modify TensorShape's shape at a specific dimension
+CAFFE2_API void modifyTensorShapeDimSize(
+    TensorShape* tensor_shape,
+    int dim_index,
+    const int64_t old_size,
+    const int64_t new_size);
 } // namespace caffe2

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -27,15 +27,27 @@ def onnxifi_caffe2_net(
         adjust_batch=True,
         black_list=None,
         weight_names=None,
+        net_ssa_rewritten=False,
         timeout=0):
     """
     Transform the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
     """
-    shape_hints = {}
-    for k, v in input_shapes.items():
-        shape_hints[k] = v
+    shape_hints = caffe2_pb2.TensorBoundShapes()
+    if type(input_shapes) is caffe2_pb2.TensorBoundShapes:
+        shape_hints = input_shapes
+    elif type(input_shapes) is dict:
+        for k, v in input_shapes.items():
+            tbs = caffe2_pb2.TensorBoundShape()
+            tbs.name = k
+            tbs.shape.dims.extend(v)
+            tbs.dim_type.extend([caffe2_pb2.TensorBoundShape.CONSTANT] * len(tbs.shape.dims))
+            tbs.dim_type[0] = caffe2_pb2.TensorBoundShape.BATCH
+            shape_hints.shapes.extend([tbs])
+        shape_hints.max_batch_size = max_batch_size
+        shape_hints.max_feature_len = max_seq_size
+    print(shape_hints)
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
-                             shape_hints,
+                             shape_hints.SerializeToString(),
                              black_list if black_list else [],
                              weight_names if weight_names is not None else [],
                              max_batch_size,
@@ -44,6 +56,7 @@ def onnxifi_caffe2_net(
                              adjust_batch,
                              debug,
                              merge_fp32_inputs_into_fp16,
+                             net_ssa_rewritten,
                              use_onnx)
     pred_net_cut = caffe2_pb2.NetDef()
     pred_net_cut.ParseFromString(pred_net_str)


### PR DESCRIPTION
Summary: Previously, we can only feed shape info from Python with float dtype, and batch based dim type when we do onnxifi from Python. This diff removes this limitation and uses TensorBoundShapes protobuf as a generic shape info struct. This will make the onnxifi interface in Python more flexible.

Differential Revision: D22889781

