### PR TITLE
Fix the bug in THCTensor_(baddbmm) and ATen's addmm_cuda for strided views input

### DIFF
--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -34,11 +34,12 @@ Tensor bmm_cuda(const Tensor& self, const Tensor& mat2) {
 Tensor prepare_matrix_for_cublas(Tensor& tensor, bool& transpose_tensor) {
   Tensor tensor_;
   IntArrayRef tensor_strides = tensor.strides();
+  IntArrayRef tensor_sizes = tensor.sizes();
 
-  if ((tensor_strides[0] == 1) && (tensor_strides[1] != 0)) {
+  if ((tensor_strides[0] == 1) && (tensor_strides[1] >= std::max<int64_t>(1, tensor_sizes[0]))) {
     tensor_ = tensor;
     transpose_tensor = false;
-  } else if ((tensor_strides[1] == 1) && (tensor_strides[0] != 0)) {
+  } else if ((tensor_strides[1] == 1) && (tensor_strides[0] >= std::max<int64_t>(1, tensor_sizes[1]))) {
     tensor_ = tensor;
     transpose_tensor = true;
   } else {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -17065,11 +17065,11 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         new_stride = [3, 1, 1]
         sx = torch.as_strided(x, size=new_shape, stride=new_stride)
 
-        torch_fn = lambda x: torch.bmm(x, x)
-        np_fn = lambda x: np.matmul(x, x)
+        torch_fn = lambda x: torch.bmm(x, x)  # noqa: E731
+        np_fn = lambda x: np.matmul(x, x)  # noqa: E731
         self.compare_with_numpy(torch_fn, np_fn, sx)
 
-        torch_fn = lambda x: torch.mm(x, x)
+        torch_fn = lambda x: torch.mm(x, x)  # noqa: E731
         self.compare_with_numpy(torch_fn, np_fn, sx[0])
 
     @onlyCPU

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -17064,22 +17064,13 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         new_shape = [2, 2, 2]
         new_stride = [3, 1, 1]
         sx = torch.as_strided(x, size=new_shape, stride=new_stride)
-        res_bmm = torch.bmm(sx, sx)
-        res_mm = []
-        for i in range(sx.shape[0]):
-            r = torch.mm(sx[i], sx[i])
-            res_mm.append(r)
-            self.assertEqual(r, res_bmm[i])
 
-        # Compares with NumPy
-        nx = x.cpu().numpy()
-        numpy_strides = np.array(new_stride) * nx.itemsize
-        nc = np.lib.stride_tricks.as_strided(nx, shape=new_shape, strides=numpy_strides)
-        expected1 = np.matmul(nc, nc)
-        expected2 = [np.matmul(m, m) for m in nc]
-        self.assertEqual(res_bmm, expected1)
-        for i in range(sx.shape[0]):
-            self.assertEqual(res_mm[i], expected2[i])
+        torch_fn = lambda x: torch.bmm(x, x)
+        np_fn = lambda x: np.matmul(x, x)
+        self.compare_with_numpy(torch_fn, np_fn, sx)
+
+        torch_fn = lambda x: torch.mm(x, x)
+        self.compare_with_numpy(torch_fn, np_fn, sx[0])
 
     @onlyCPU
     @dtypes(torch.float)


### PR DESCRIPTION
Fixes #42418. 

The problem was that the non-contiguous batched matrices were passed to `gemmStridedBatched`.

The following code fails on master and works with the proposed patch:
```python
import torch
x = torch.tensor([[1., 2, 3], [4., 5, 6]], device='cuda:0')
c = torch.as_strided(x, size=[2, 2, 2], stride=[3, 1, 1])
torch.einsum('...ab,...bc->...ac', c, c)
```