### PR TITLE
Add typing_extensions as a dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you are building for NVIDIA's Jetson platforms (Jetson Nano, TX1, TX2, AGX Xa
 
 Common
 ```bash
-conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi
+conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests
 ```
 
 On Linux

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 requests
 setuptools
 six
+typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -357,7 +357,7 @@ def build_deps():
 ################################################################################
 
 # the list of runtime dependencies required by this built package
-install_requires = ['future']
+install_requires = ['future', 'typing_extensions']
 
 missing_pydep = '''
 Missing build dependency: Unable to `import {importname}`.


### PR DESCRIPTION
Closes gh-38221.

The related pytorch/builder PR: https://github.com/pytorch/builder/pull/475
