### PR TITLE
Fix variable type

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1380,7 +1380,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         auto dim_ = dim();
         strides_.resize(dim_);
         if (dim_ > 0) {
-          int last_idx = dim_ - 1;
+          auto last_idx = dim_ - 1;
           strides_[last_idx] = 1;
           for (auto i = last_idx - 1; i >= 0; --i) {
             strides_[i] = strides_[i + 1] * std::max<int64_t>(sizes_[i + 1], 1);


### PR DESCRIPTION
`dim_` and `last_idx` should be of the same type.
Fixing it, some annoying warnings are fixed

Fixes #{issue number}
