### PR TITLE
Fix freeze_module pass for sharedtype

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -4,6 +4,10 @@ import torch.nn as nn
 from torch.testing._internal.jit_utils import JitTestCase
 
 from torch.testing import FileCheck
+from torch.testing._internal.common_quantized import override_quantized_engine
+from torch.testing._internal.common_quantization import skipIfNoFBGEMM
+
+from torch.jit._recursive import wrap_cpp_module
 
 import io
 
@@ -1026,3 +1030,55 @@ class TestFreezing(JitTestCase):
         fm = torch._C._freeze_module(m._c, ["modify_a"])
         FileCheck().check('prim::GetAttr[name="a"]').run(fm.forward.graph)
         FileCheck().check('prim::GetAttr[name="b"]').run(fm.modify_a.graph)
+
+    @skipIfNoFBGEMM
+    def test_module_with_shared_type_instances(self):
+        class Child(nn.Module):
+            def __init__(self):
+                super(Child, self).__init__()
+                self.conv1 = nn.Conv2d(1, 1, 1).to(dtype=torch.float32)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                return x
+
+        class Parent(nn.Module):
+            def __init__(self):
+                super(Parent, self).__init__()
+                self.quant = torch.quantization.QuantStub()
+                self.conv1 = nn.Conv2d(1, 1, 1).to(dtype=torch.float32)
+                self.child = Child()
+                self.child2 = Child()
+                self.dequant = torch.quantization.DeQuantStub()
+
+            def forward(self, x):
+                x = self.quant(x)
+                x = self.conv1(x)
+                x = self.child(x)
+                x = self.child2(x)
+                x = self.dequant(x)
+                return x
+
+        def _static_quant(model):
+            qModel = torch.quantization.QuantWrapper(model)
+            qModel.qconfig = torch.quantization.default_qconfig
+            torch.quantization.prepare(qModel, inplace=True)
+            qModel(torch.rand(4, 1, 4, 4, dtype=torch.float32))
+            torch.quantization.convert(qModel, inplace=True)
+            return model
+
+        with override_quantized_engine('fbgemm'):
+            data = torch.randn(4, 1, 4, 4, dtype=torch.float32)
+            m = Parent().to(torch.float32)
+            m = _static_quant(m)
+            m = torch.jit.script(m)
+            m.eval()
+            torch._C._jit_pass_inline(m.graph)
+            m_frozen = wrap_cpp_module(torch._C._freeze_module(m._c))
+            # Earlier bug resulted in _packed_params set to false.
+            FileCheck().check_not('_packed_params = False').run(m_frozen._c.dump_to_str(True, True, False))
+
+            m_res = m(data)
+            # It used to segfault while running frozen module.
+            m_frozen_res = m_frozen(data)
+            self.assertEqual(m_res, m_frozen_res)

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -11,6 +11,25 @@ namespace torch {
 namespace jit {
 
 namespace {
+ModulePtr getModulePtrForGetAttrNode(
+    const Node* node,
+    const std::shared_ptr<Graph>& graph,
+    const Module& graph_input_module) {
+  std::vector<std::string> names;
+  names.clear();
+  while (!(node->outputs()[0]->type() == graph->inputs()[0]->type())) {
+    TORCH_INTERNAL_ASSERT(
+        node->kind() == prim::GetAttr, "Expected prim::GetAttr nodes");
+    names.insert(names.begin(), node->s(attr::name));
+    node = node->inputs()[0]->node();
+  }
+  // Copy/paste from quantization/helper.h
+  Module m = graph_input_module;
+  for (const auto& p : names) {
+    m = m.attr(p).toModule();
+  }
+  return m._ivalue();
+}
 
 class AttributePropagator {
  public:
@@ -433,17 +452,12 @@ class AttributePropagator {
         }
         if (n->kind() == prim::GetAttr) {
           auto& name = n->s(attr::name);
-          for (auto& mptr : modules) {
-            auto module = Module(mptr);
-            if (module.type() == n->inputs()[0]->type() &&
-                module.hasattr(name)) {
-              auto attr = module.attr(name);
-              insertMutableAttr(name, attr, mptr);
-              if (attr.isModule()) {
-                modules.insert(attr.toModule()._ivalue());
-              }
-              break;
-            }
+          auto mptr =
+              getModulePtrForGetAttrNode(n->input(0)->node(), graph, module_);
+          auto module = Module(mptr);
+          if (module.type() == n->inputs()[0]->type() && module.hasattr(name)) {
+            auto attr = module.attr(name);
+            insertMutableAttr(name, attr, mptr);
           }
         } else if (n->kind() == prim::fork) {
           applyToForkSubgraph(


### PR DESCRIPTION
Summary:
During cleanup phase, calling recordReferencedAttrs would record
the attributes which are referenced and hence kept.
However, if you have two instances of the same type which are preserved
through freezing process, as the added testcase shows, then during
recording the attributes which are referenced, we iterate through the
type INSTANCES that we have seen so far and record those ones.
Thus if we have another instance of the same type, we will just look at
the first instance in the list, and record that instances.
This PR fixes that by traversing the getattr chains and getting the
actual instance of the getattr output.

Test Plan:
python test/test_jit.py TestFreezing

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #{issue number}
