### PR TITLE
Use `C10_API_ENUM` to fix invalid attribute warnings

### DIFF
--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -10,12 +10,7 @@
 namespace at {
 
 // Kind of record function scope;
-// workaround for the older GCC versions:
-#ifndef _MSC_VER
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wattributes"
-#endif
-enum class TORCH_API RecordScope : uint8_t {
+enum class C10_API_ENUM RecordScope : uint8_t {
   // c10/ATen ops, autograd nodes
   FUNCTION = 0,
   // TorchScript functions, methods
@@ -24,9 +19,6 @@ enum class TORCH_API RecordScope : uint8_t {
   USER_SCOPE,
   NUM_SCOPES, // must be the last in the list
 };
-#ifndef _MSC_VER
-#  pragma GCC diagnostic pop
-#endif
 
 } // namespace at
 

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -88,13 +88,7 @@ inline int64_t getTime() {
 #endif
 }
 
-// Old GCC versions generate warnings incorrectly
-// see https://stackoverflow.com/questions/2463113/g-c0x-enum-class-compiler-warnings
-#ifndef _MSC_VER
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wattributes"
-#endif
-enum class TORCH_API ProfilerState {
+enum class C10_API_ENUM ProfilerState {
     Disabled,
     CPU, // CPU-only profiling
     CUDA, // CPU + CUDA events
@@ -123,15 +117,12 @@ struct TORCH_API ProfilerConfig {
 
 };
 
-enum class TORCH_API EventKind : uint16_t {
+enum class C10_API_ENUM EventKind : uint16_t {
   Mark,
   PushRange,
   PopRange,
   MemoryAlloc,
 };
-#ifndef _MSC_VER
-#  pragma GCC diagnostic pop
-#endif
 
 struct TORCH_API Event final {
   Event(

--- a/torch/csrc/jit/tensorexpr/bounds_inference.h
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.h
@@ -14,7 +14,7 @@ class Expr;
 class Buf;
 class Stmt;
 
-enum TORCH_API TensorAccessKind { kLoad, kStore };
+enum C10_API_ENUM TensorAccessKind { kLoad, kStore };
 
 struct TORCH_API TensorAccessBoundsInfo {
   TensorAccessKind kind;


### PR DESCRIPTION
Using the macro added in #38988 to fix more attribute warnings.