### PR TITLE
[JIT] Fix torch.jit.is_tracing()

### DIFF
--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -974,7 +974,7 @@ def is_tracing():
     Returns ``True`` in tracing (if a function is called during the tracing of
     code with ``torch.jit.trace``) and ``False`` otherwise.
     """
-    return torch._C._is_tracing
+    return torch._C._is_tracing()
 
 
 class TracedModule(ScriptModule):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42486 [JIT] Fix torch.jit.is_tracing()**

**Summary**
This commit fixes a small bug in which `torch.jit.is_tracing()` returns
`torch._C.is_tracing`, the function object, instead of calling the
function and returning the result.

**Test Plan**
Continuous integration?

**Fixes**
This commit fixes #42448.

Differential Revision: [D22911062](https://our.internmc.facebook.com/intern/diff/D22911062)