### PR TITLE
Fix segfault in `THPGenerator_dealloc`

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3411,6 +3411,9 @@ class AbstractTestCases:
             g2_normal = q.normal_(generator=g2)
             self.assertEqual(g1_normal, g2_normal)
 
+        def test_invalid_generator_raises(self):
+            self.assertRaises(RuntimeError, lambda: torch.Generator('opengl'))
+
         def test_sobolengine_unscrambled_lowdim(self):
             engine_1d = torch.quasirandom.SobolEngine(1)
             expected_1d = torch.tensor([0.5, 0.75, 0.25, 0.375, 0.875, 0.625, 0.125, 0.1875, 0.6875, 0.9375])

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -36,8 +36,10 @@ PyObject * THPGenerator_initDefaultGenerator(at::Generator cdata)
 
 static void THPGenerator_dealloc(THPGenerator* self)
 {
-  self->cdata.set_pyobj(nullptr);
-  self->cdata.~Generator();
+  if (self->cdata.defined()) {
+    self->cdata.set_pyobj(nullptr);
+    self->cdata.~Generator();
+  }
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 


### PR DESCRIPTION
Segfault happens when one tries to deallocate unintialized generator

Add `TestTorch.test_invalid_generator_raises` that validates that Generator created on invalid device is handled correctly

Fixes https://github.com/pytorch/pytorch/issues/42281

