### PR TITLE
[TensorExpr] Properly handle all dtypes in evaluation of CompareSelect exprs.

### DIFF
--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -255,6 +255,12 @@ void testExprCompareSelectEQ() {
 }
 
 void testExprCompareSelectDtypes() {
+  // LHS and RHS expressions should have the same dtype, but this dtype could
+  // differ from the dtype of the return values (but dtypes of true and false
+  // return values should be the same).
+  // This test constructs a CompareSelect expression where the input dtype is
+  // different from the output dtype and verifies that it works correctly:
+  //   result = ((int)lhs == (int)rhs) ? (float)retval1 : (float)retval2
   KernelScope kernel_scope;
   constexpr int N = 1024;
   Buffer a(BufHandle("A", {N}, kInt));
@@ -267,6 +273,8 @@ void testExprCompareSelectDtypes() {
 
   auto mask = IntImm::make(1);
   VarHandle i("i", kInt);
+  // C[i] = (A[i] == B[i]) ? 3.14f : 2.78f
+  // A and B are int, C is float.
   auto select_expr = For::make(
       i,
       0,

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -25,6 +25,7 @@ namespace jit {
   _(ExprDoubleTest)                         \
   _(ExprVectorAdd01)                        \
   _(ExprCompareSelectEQ)                    \
+  _(ExprCompareSelectDtypes)                \
   _(ExprSubstitute01)                       \
   _(ExprMath01)                             \
   _(ExprUnaryMath01)                        \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42495 [TensorExpr] Properly handle all dtypes of the condition in evaluation of IfThenElse exprs.
* #42494 [TensorExpr] Properly handle all dtypes in evaluation of Intrinsics exprs.
* **#42493 [TensorExpr] Properly handle all dtypes in evaluation of CompareSelect exprs.**

Differential Revision: [D22910754](https://our.internmc.facebook.com/intern/diff/D22910754)