### PR TITLE
[TensorExpr] Properly handle all dtypes in evaluation of Intrinsics exprs.

### DIFF
--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -294,6 +294,37 @@ void testExprCompareSelectDtypes() {
   ExpectAllNear(c_buffer, c_ref, 1e-7);
 }
 
+void testExprIntrinsicsDtypes() {
+  KernelScope kernel_scope;
+  constexpr int N = 256;
+  Buffer a(BufHandle("A", {N}, kDouble));
+  Buffer b(BufHandle("B", {N}, kDouble));
+  std::vector<double> a_buffer(N, -10.0);
+  std::vector<double> b_buffer(N, 0.0);
+  std::vector<double> b_ref(N, 10.0);
+
+  auto mask = IntImm::make(1);
+  VarHandle i("i", kInt);
+  auto fabs_expr = For::make(
+      i,
+      0,
+      N,
+      Store::make(
+          b,
+          {i},
+          fabs(Load::make(a, {i}, mask)),
+          mask));
+
+  SimpleIREvaluator ir_eval(fabs_expr, a, b);
+  ir_eval(a_buffer, b_buffer);
+
+  ASSERT_EQ(a_buffer.size(), N);
+  ASSERT_EQ(b_buffer.size(), N);
+
+  assertAllEqual(a_buffer, -10.0);
+  ExpectAllNear(b_buffer, b_ref, 1e-7);
+}
+
 void testExprSubstitute01() {
   KernelScope kernel_scope;
   const Var* x = new Var("x", kFloat);

--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -306,14 +306,7 @@ void testExprIntrinsicsDtypes() {
   auto mask = IntImm::make(1);
   VarHandle i("i", kInt);
   auto fabs_expr = For::make(
-      i,
-      0,
-      N,
-      Store::make(
-          b,
-          {i},
-          fabs(Load::make(a, {i}, mask)),
-          mask));
+      i, 0, N, Store::make(b, {i}, fabs(Load::make(a, {i}, mask)), mask));
 
   SimpleIREvaluator ir_eval(fabs_expr, a, b);
   ir_eval(a_buffer, b_buffer);

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -26,6 +26,7 @@ namespace jit {
   _(ExprVectorAdd01)                        \
   _(ExprCompareSelectEQ)                    \
   _(ExprCompareSelectDtypes)                \
+  _(ExprIntrinsicsDtypes)                   \
   _(ExprSubstitute01)                       \
   _(ExprMath01)                             \
   _(ExprUnaryMath01)                        \

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -661,7 +661,7 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
   }
 
   template <typename T>
-  TORCH_API void visit_intrinsics_helper(const Intrinsics* v) {
+  void visit_intrinsics_helper(const Intrinsics* v) {
     std::vector<Value> values(v->nparams());
     for (int i = 0; i < v->nparams(); i++) {
       v->param(i)->accept(this);
@@ -686,11 +686,11 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
     std::vector<T> result(v1.size(), -1);
     if (values.size() == 1ULL) {
       for (size_t i = 0; i < v1.size(); i++) {
-        result[i] = compute_intrinsics(v->op_type(), v1[i]);
+        result[i] = compute_intrinsics<T>(v->op_type(), v1[i]);
       }
     } else {
       for (size_t i = 0; i < v1.size(); i++) {
-        result[i] = compute_intrinsics(v->op_type(), v1[i], v2[i]);
+        result[i] = compute_intrinsics<T>(v->op_type(), v1[i], v2[i]);
       }
     }
     value_ = Value(result);
@@ -698,15 +698,12 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
 
   TORCH_API void visit(const Intrinsics* v) override {
     auto ty = v->dtype().scalar_type();
-    switch (ty) {
-#define TYPE_CASE(Type, Name)         \
-  case ScalarType::Name:              \
-    visit_intrinsics_helper<Type>(v); \
-    break;
-      AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, TYPE_CASE);
-#undef TYPE_CASE
-      default:
-        throw unsupported_dtype();
+    if (ty == ScalarType::Float) {
+      visit_intrinsics_helper<float>(v);
+    } else if (ty == ScalarType::Double) {
+      visit_intrinsics_helper<double>(v);
+    } else {
+      throw unsupported_dtype();
     }
   }
 
@@ -764,7 +761,8 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
     apply_mutator(&intrinsics_expander);
   }
 
-  static float compute_intrinsics(IntrinsicsOp op_type, float v) {
+  template <typename T>
+  static T compute_intrinsics(IntrinsicsOp op_type, T v) {
     switch (op_type) {
       case kSin:
         return std::sin(v);
@@ -817,14 +815,15 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
       case kLgamma:
         return std::lgamma(v);
       case kFrac:
-        float intpart;
+        T intpart;
         return std::modf(v, &intpart);
       default:
         throw std::runtime_error("Invalid op_type: " + c10::to_string(op_type));
     }
   }
 
-  static float compute_intrinsics(IntrinsicsOp op_type, float v1, float v2) {
+  template <typename T>
+  static T compute_intrinsics(IntrinsicsOp op_type, T v1, T v2) {
     switch (op_type) {
       case kPow:
         return std::pow(v1, v2);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42495 [TensorExpr] Properly handle all dtypes of the condition in evaluation of IfThenElse exprs.
* **#42494 [TensorExpr] Properly handle all dtypes in evaluation of Intrinsics exprs.**
* #42493 [TensorExpr] Properly handle all dtypes in evaluation of CompareSelect exprs.

Note that we're currently assuming that dtypes of all the arguments and
the return value is the same.

Differential Revision: [D22910755](https://our.internmc.facebook.com/intern/diff/D22910755)