### PR TITLE
[TensorExpr] Properly handle all dtypes of the condition in evaluation of IfThenElse exprs.

### DIFF
--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -527,6 +527,18 @@ void testIfThenElse02() {
   ASSERT_EQ(eval.value<float>(), 2.0f);
 }
 
+void testIfThenElse03() {
+  KernelScope kernel_scope;
+  ExprHandle v = ifThenElse(BoolImm::make(false), ExprHandle(1.0f), ExprHandle(2.0f));
+
+  std::ostringstream oss;
+  oss << v;
+  ASSERT_EQ(oss.str(), "IfThenElse(0, 1.f, 2.f)");
+
+  SimpleIRExprEval eval(v);
+  ASSERT_EQ(eval.value<float>(), 2.0f);
+}
+
 void testStmtClone() {
   KernelScope kernel_scope;
   const int N = 16;

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -85,6 +85,7 @@ namespace jit {
   _(Cond01)                                 \
   _(IfThenElse01)                           \
   _(IfThenElse02)                           \
+  _(IfThenElse03)                           \
   _(ATen_cast_Float)                        \
   _(ATennegInt)                             \
   _(ATennegFloat)                           \

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -582,6 +582,8 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
   } break;
       AT_FORALL_SCALAR_TYPES_AND(Bool, TYPE_CASE);
 #undef TYPE_CASE
+      case ScalarType::Half:
+        throw unsupported_dtype("IfThenElse condition can't have Half dtype");
       default:
         throw unsupported_dtype();
     }

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -574,7 +574,19 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
 
   TORCH_API void visit(const IfThenElse* v) override {
     v->condition()->accept(this);
-    if (value_.as<int>()) {
+    bool cond_v;
+    switch (value_.dtype().scalar_type()) {
+#define TYPE_CASE(Type, Name) \
+  case ScalarType::Name: {    \
+    cond_v = value_.as<Type>(); \
+  } break;
+      AT_FORALL_SCALAR_TYPES_AND(Bool, TYPE_CASE);
+#undef TYPE_CASE
+      default:
+        throw unsupported_dtype();
+    }
+
+    if (cond_v) {
       v->true_value()->accept(this);
     } else {
       v->false_value()->accept(this);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42495 [TensorExpr] Properly handle all dtypes of the condition in evaluation of IfThenElse exprs.**
* #42494 [TensorExpr] Properly handle all dtypes in evaluation of Intrinsics exprs.
* #42493 [TensorExpr] Properly handle all dtypes in evaluation of CompareSelect exprs.

Differential Revision: [D22910753](https://our.internmc.facebook.com/intern/diff/D22910753)