### PR TITLE
Add polygamma where  n >= 2

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -113,6 +113,86 @@ Date:  February 1996
 
 #undef CENTRAL_RANGE
 
+/*
+ * The following function comes with the following copyright notice.
+ * It has been released under the BSD license.
+ *
+ * Cephes Math Library Release 2.8:  June, 2000
+ * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
+ */
+
+static inline double zeta(double x, double q) {
+  static double MACHEP = 1.11022302462515654042E-16;
+  static double A[] = {
+      12.0,
+      -720.0,
+      30240.0,
+      -1209600.0,
+      47900160.0,
+      -1.8924375803183791606e9, /*1.307674368e12/691*/
+      7.47242496e10,
+      -2.950130727918164224e12, /*1.067062284288e16/3617*/
+      1.1646782814350067249e14, /*5.109094217170944e18/43867*/
+      -4.5979787224074726105e15, /*8.028576626982912e20/174611*/
+      1.8152105401943546773e17, /*1.5511210043330985984e23/854513*/
+      -7.1661652561756670113e18 /*1.6938241367317436694528e27/236364091*/
+  };
+
+  int i = 0;
+  double a, b, k, s, t, w;
+  if (x == 1.0) {
+    return INFINITY;
+  }
+
+  if (x < 1.0) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  if (q <= 0.0) {
+    if (q == floor(q)) {
+      return INFINITY;
+    }
+    if (x != floor(x)) {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+  }
+
+  s = std::pow(q, -x);
+  a = q;
+  i = 0;
+  b = 0.0;
+  while ((i < 9) || (a <= 9.0)) {
+    i += 1;
+    a += 1.0;
+    b = std::pow(a, -x);
+    s += b;
+    if ((-MACHEP * s < b) && (b < MACHEP * s)) {
+      return s;
+    }
+  };
+
+  w = a;
+  s += b * w / (x - 1.0);
+  s -= 0.5 * b;
+  a = 1.0;
+  k = 0.0;
+  for (int i = 0; i < 12; i++) {
+    a *= x + k;
+    b /= w;
+    t = a * b / A[i];
+    s = s + t;
+    t = std::abs(t / s);
+    if (t < MACHEP) {
+      return s;
+    }
+    k += 1.0;
+    a *= x + k;
+    b /= w;
+    k += 1.0;
+  }
+  return s;
+}
+
 static inline double polevl(double x, double *A, size_t len) {
   double result = 0;
   for (size_t i = 0; i <= len; i++) {
@@ -171,6 +251,7 @@ static inline float trigamma(float x) {
  * Cephes Math Library Release 2.8:  June, 2000
  * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
  */
+
 static inline double calc_digamma(double x) {
   static double PSI_10 = 2.25175258906672110764;
   if (x == 0) {
@@ -265,6 +346,18 @@ static inline float calc_digamma(float x) {
     y = z * polevlf(z, A, 6);
   }
   return result + logf(x) - (0.5f / x) - y;
+}
+
+static inline double calc_polygamma(int64_t n, double x) {
+  // already blocked if n <= 1
+  return ((n % 2) ? 1.0 : -1.0) * std::exp(lgamma(double(n) + 1.0)) *
+      zeta(double(n + 1), x);
+}
+
+static inline float calc_polygamma(int64_t n, float x) {
+  // already blocked if n <= 1
+  return ((n % 2) ? 1.0f : -1.0f) * std::exp(lgamma(double(n) + 1.0)) *
+      zeta(double(n + 1), x);
 }
 
 inline c10::BFloat16 calc_erfinv(c10::BFloat16 a) { return calc_erfinv(float(a)); }

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -348,10 +348,15 @@ static void trigamma_kernel(TensorIterator& iter) {
 }
 
 static void polygamma_kernel(TensorIterator& iter, int64_t n) {
-  switch (n) {
-    case 0: digamma_kernel(iter); break;
-    case 1: trigamma_kernel(iter); break;
-    default: TORCH_CHECK(false, "polygamma(n,x) is not implemented for n>=2, but was ", n);
+  if (n == 0) {
+    digamma_kernel(iter);
+  } else if (n == 1) {
+    trigamma_kernel(iter);
+  } else {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "polygamma", [&]() {
+      cpu_kernel(
+          iter, [=](scalar_t a) -> scalar_t { return calc_polygamma(n, a); });
+    });
   }
 }
 

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -1,9 +1,97 @@
 #pragma once
+
 #include <ATen/AccumulateType.h>
 #include <c10/macros/Macros.h>
 
 namespace at {
 namespace native {
+
+/*
+* The following function was converted to CUDA form from code that comes
+* with the following copyright notice. It has been released under the BSD license.
+ *
+ * Cephes Math Library Release 2.8:  June, 2000
+ * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
+ */
+
+template <typename scalar_t>
+static inline __host__ __device__ scalar_t zeta(scalar_t _x, scalar_t _q) {
+  using accscalar_t = at::acc_type<scalar_t, true>;
+  static const accscalar_t MACHEP = 1.11022302462515654042E-16;
+  static accscalar_t A[] = {
+      12.0,
+      -720.0,
+      30240.0,
+      -1209600.0,
+      47900160.0,
+      -1.8924375803183791606e9, /*1.307674368e12/691*/
+      7.47242496e10,
+      -2.950130727918164224e12, /*1.067062284288e16/3617*/
+      1.1646782814350067249e14, /*5.109094217170944e18/43867*/
+      -4.5979787224074726105e15, /*8.028576626982912e20/174611*/
+      1.8152105401943546773e17, /*1.5511210043330985984e23/854513*/
+      -7.1661652561756670113e18 /*1.6938241367317436694528e27/236364091*/
+  };
+  accscalar_t x = static_cast<accscalar_t>(_x);
+  accscalar_t q = static_cast<accscalar_t>(_q);
+
+  int i = 0;
+  accscalar_t a, b, k, s, t, w;
+  if( x == 1.0 ) {
+    return static_cast<scalar_t>(INFINITY);
+  }
+
+  if( x < 1.0 ){
+    std::numeric_limits<scalar_t>::quiet_NaN();
+  }
+  bool q_is_integer = q == ::floor(q);
+
+  if(q <= 0.0) {
+    if(q_is_integer) {
+      return static_cast<scalar_t>(INFINITY);
+    }
+    else {
+      std::numeric_limits<scalar_t>::quiet_NaN();
+    }
+  }
+
+  s = ::pow(q, -x);
+  a = q;
+  i = 0;
+  b = 0.0;
+  while((i < 9) || (a <= 9.0)){
+    i += 1;
+    a += 1.0;
+    b = ::pow( a, -x );
+    s += b;
+    if((-MACHEP < (b / s)) && ((b / s) < MACHEP)) {
+      return static_cast<scalar_t>(s);
+    }
+  };
+  w = a;
+  s += b * w / (x - 1.0);
+  s -= 0.5 * b;
+  a = 1.0;
+  k = 0.0;
+  for(int i=0; i < 12; i++) {
+    a *= x + k;
+    b /= w;
+    t = a * b / A[i];
+    s = s + t;
+    t = t / s;
+    if(t < 0){
+      t = -t;
+    }
+    if((-MACHEP <t) && (t < MACHEP)){
+      return static_cast<scalar_t>(s);
+    }
+    k += 1.0;
+    a *= x + k;
+    b /= w;
+    k += 1.0;
+  }
+  return static_cast<scalar_t>(s);
+}
 
 /*
 * The following function was converted to CUDA form from code that comes
@@ -88,6 +176,13 @@ static inline __host__ __device__ scalar_t calc_trigamma(scalar_t in) {
   result += (1 + 1 / (2*x) + ixx * (one/6 - ixx * (one/30 - ixx * (one/42)))) / x;
   return static_cast<scalar_t>(sign * result);
 }
+
+template <typename scalar_t>
+static inline __host__ __device__ scalar_t calc_polygamma(int n, scalar_t x) {
+  // already blocked if n <= 1
+  return ((n % 2) ? 1.0 : -1.0) * ::exp(::lgamma(static_cast<scalar_t>(n) + 1.0)) * zeta(static_cast<scalar_t>(n + 1), x);
+}
+
 
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_gcd(scalar_t a_in, scalar_t b_in) {

--- a/aten/src/ATen/native/cuda/UnaryGammaKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryGammaKernels.cu
@@ -27,10 +27,16 @@ void trigamma_kernel_cuda(TensorIterator& iter) {
 }
 
 void polygamma_kernel_cuda(TensorIterator& iter, int64_t n) {
-  switch (n) {
-    case 0: digamma_kernel_cuda(iter); break;
-    case 1: trigamma_kernel_cuda(iter); break;
-    default: TORCH_CHECK(false, "polygamma(n,x) is not implemented for n>=2, but was ", n);
+  if (n == 0) {
+    digamma_kernel_cuda(iter);
+  } else if (n == 1) {
+    trigamma_kernel_cuda(iter);
+  } else {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "polygamma_cuda", [&]() {
+      gpu_kernel(iter, [=] GPU_LAMBDA(scalar_t a) -> scalar_t {
+        return calc_polygamma(int(n), a);
+      });
+    });
   }
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -18736,11 +18736,16 @@ class TestDevicePrecision(TestCase):
         cpu_tensor = torch.randn(10, 10, 10, dtype=dtype)
         device_tensor = cpu_tensor.to(device)
         zeros = torch.zeros(10, 10, 10, dtype=dtype)
-        for n in [0, 1]:
+        for n in [0, 1, 2, 3, 4, 5]:
             cpu_out = cpu_tensor.polygamma(n)
             device_out = device_tensor.polygamma(n)
             norm_errors = (device_out - cpu_out.to(device)) / device_out
             self.assertEqual(norm_errors, zeros)
+
+        cpu_tensor.requires_grad = True
+        for n in [0, 1, 2, 3, 4, 5]:
+            torch.autograd.gradcheck(lambda x: x.polygamma(n),
+                                     cpu_tensor)
 
     # Note: fails when using float tensors
     @dtypes(torch.double)
@@ -20203,6 +20208,9 @@ torch_op_tests = [_TorchMathTestMeta('sin'),
                                      ref_backend='scipy'),
                   _TorchMathTestMeta('polygamma', args=[1], substr='_1', reffn='polygamma',
                                      refargs=lambda x: (1, x.numpy()), input_fn=_generate_gamma_input, inputargs=[False],
+                                     ref_backend='scipy', rtol=0.0008, atol=1e-5),
+                  _TorchMathTestMeta('polygamma', args=[2], substr='_2', reffn='polygamma',
+                                     refargs=lambda x: (2, x.numpy()), input_fn=_generate_gamma_input, inputargs=[False],
                                      ref_backend='scipy', rtol=0.0008, atol=1e-5),
                   _TorchMathTestMeta('digamma',
                                      input_fn=_generate_gamma_input, inputargs=[True], ref_backend='scipy',

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4055,7 +4055,7 @@ add_docstr(torch.quantile,
            r"""
 quantile(input, q) -> Tensor
 
-Returns the q-th quantiles of all elements in the :attr:`input` tensor, doing a linear 
+Returns the q-th quantiles of all elements in the :attr:`input` tensor, doing a linear
 interpolation when the q-th quantile lies between two data.
 
 Args:
@@ -4074,16 +4074,16 @@ Example::
 .. function:: quantile(input, q, dim=None, keepdim=False, *, out=None) -> Tensor
 
 Returns the q-th quantiles of each row of the :attr:`input` tensor along the dimension
-:attr:`dim`, doing a linear interpolation when the q-th quantile lies between two 
+:attr:`dim`, doing a linear interpolation when the q-th quantile lies between two
 data points. By default, :attr:`dim` is `None` resulting in the :attr:`input` tensor
 beign flattened before computation.
 
-If :attr:`q` is a 1D tensor, the first dimension of the result corresponds to the quantiles 
+If :attr:`q` is a 1D tensor, the first dimension of the result corresponds to the quantiles
 and the remaining dimensions are what remains from the reduction of the :attr:`input` tensor.
 If :attr:`q` is a scalar or scalar tensor, the result is placed in the reduced dimension.
 
-If :attr:`keepdim` is ``True``, the remaining dimensions are of the same size as 
-:attr:`input` except in the dimension :attr:`dim` where it is size 1. Otherwise, 
+If :attr:`keepdim` is ``True``, the remaining dimensions are of the same size as
+:attr:`input` except in the dimension :attr:`dim` where it is size 1. Otherwise,
 the dimension :attr:`dim` is squeezed (see :func:`torch.squeeze`).
 
 Args:
@@ -4962,7 +4962,7 @@ Computes the :math:`n^{th}` derivative of the digamma function on :attr:`input`.
     \psi^{(n)}(x) = \frac{d^{(n)}}{dx^{(n)}} \psi(x)
 
 .. note::
-    This function is not implemented for :math:`n \geq 2`.
+    This function is implemented only for nonnegative integers :math:`n \geq 0`.
 """ + """
 Args:
     n (int): the order of the polygamma function
@@ -4973,6 +4973,12 @@ Example::
     >>> a = torch.tensor([1, 0.5])
     >>> torch.polygamma(1, a)
     tensor([1.64493, 4.9348])
+    >>> torch.polygamma(2, a)
+    tensor([ -2.4041, -16.8288])
+    >>> torch.polygamma(3, a)
+    tensor([ 6.4939, 97.4091])
+    >>> torch.polygamma(4, a)
+    tensor([ -24.8863, -771.4742])
 """.format(**common_args))
 
 add_docstr(torch.pow,


### PR DESCRIPTION
#40980 

I have a few questions during implementing Polygamma function...  
so, I made PR prior to complete it.

1. some code blocks brought from cephes library(and I did too)
```
/*
 * The following function comes with the following copyright notice.
 * It has been released under the BSD license.
 *
 * Cephes Math Library Release 2.8:  June, 2000
 * Copyright 1984, 1987, 1992, 2000 by Stephen L. Moshier
 */
```
is it okay for me to use cephes code with this same copyright notice(already in the Pytorch codebases)

2. There is no linting in internal Aten library. (as far as I know, I read https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md)
How do I'm sure my code will follow appropriate guidelines of this library..?


3. Actually, there's a digamma, trigamma function already
digamma is needed, however, trigamma function becomes redundant if  polygamma function is added.
it is okay for trigamma to be there or should be removed?

btw, CPU version works fine with 3-rd order polygamma(it's what we need to play with variational inference with beta/gamma distribution) now and I'm going to finish GPU version soon.