### PR TITLE
Fix segfault in `THPGenerator_dealloc` (take 2)

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3411,6 +3411,9 @@ class AbstractTestCases:
             g2_normal = q.normal_(generator=g2)
             self.assertEqual(g1_normal, g2_normal)
 
+        def test_invalid_generator_raises(self):
+            self.assertRaises(RuntimeError, lambda: torch.Generator('opengl'))
+
         def test_sobolengine_unscrambled_lowdim(self):
             engine_1d = torch.quasirandom.SobolEngine(1)
             expected_1d = torch.tensor([0.5, 0.75, 0.25, 0.375, 0.875, 0.625, 0.125, 0.1875, 0.6875, 0.9375])

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -34,11 +34,14 @@ PyObject * THPGenerator_initDefaultGenerator(at::Generator cdata)
   return self.release();
 }
 
-static void THPGenerator_dealloc(THPGenerator* self)
+static void THPGenerator_dealloc(PyObject* _self)
 {
-  self->cdata.set_pyobj(nullptr);
-  self->cdata.~Generator();
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  auto self = reinterpret_cast<THPGenerator*>(_self);
+  if (self->cdata.defined()) {
+    self->cdata.set_pyobj(nullptr);
+    self->cdata.~Generator();
+  }
+  Py_TYPE(_self)->tp_free(_self);
 }
 
 static PyObject * THPGenerator_pynew(PyTypeObject *type, PyObject *args, PyObject *kwargs)
@@ -178,7 +181,7 @@ PyTypeObject THPGeneratorType = {
   "torch._C.Generator",                   /* tp_name */
   sizeof(THPGenerator),                        /* tp_basicsize */
   0,                                           /* tp_itemsize */
-  (destructor)THPGenerator_dealloc,            /* tp_dealloc */
+  THPGenerator_dealloc,                        /* tp_dealloc */
   0,                                           /* tp_vectorcall_offset */
   nullptr,                                     /* tp_getattr */
   nullptr,                                     /* tp_setattr */


### PR DESCRIPTION
Segfault happens when one tries to deallocate uninitialized generator.
Make `THPGenerator_dealloc` UBSAN-prone by moving implicit cast in the struct definition to reinterpret_cast

Add `TestTorch.test_invalid_generator_raises` that validates that Generator created on invalid device is handled correctly

Fixes https://github.com/pytorch/pytorch/issues/42281