### PR TITLE
.circleci: Have python docs always push to site

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -137,14 +137,16 @@ class HiddenConf(object):
         return self.name
 
 class DocPushConf(object):
-    def __init__(self, name, parent_build=None):
+    def __init__(self, name, parent_build=None, branch="master"):
         self.name = name
         self.parent_build = parent_build
+        self.branch = branch
 
     def gen_workflow_job(self, phase):
         return {
             "pytorch_doc_push": {
                 "name": self.name,
+                "branch": self.branch,
                 "requires": [self.parent_build],
                 "context": "org-member",
                 "filters": gen_filter_dict(branches_list=["nightly"])
@@ -183,12 +185,40 @@ def gen_dependent_configs(xenial_parent_config):
 def gen_docs_configs(xenial_parent_config):
     configs = []
 
-    for x in ["pytorch_python_doc_build", "pytorch_cpp_doc_build"]:
-        conf = HiddenConf(x, parent_build=xenial_parent_config)
-        configs.append(conf)
-        configs.append(DocPushConf(x.replace("build", "push"), x))
+    configs.append(
+        HiddenConf(
+            "pytorch_python_doc_build",
+            parent_build=xenial_parent_config
+        )
+    )
+    configs.append(
+        DocPushConf(
+            "pytorch_python_doc_push",
+            parent_build="pytorch_python_doc_build",
+            branch="site",
+        )
+    )
 
-    configs.append(HiddenConf("pytorch_doc_test", parent_build=xenial_parent_config))
+    configs.append(
+        HiddenConf(
+            "pytorch_cpp_doc_build",
+            parent_build=xenial_parent_config
+        )
+    )
+    configs.append(
+        DocPushConf(
+            "pytorch_cpp_doc_push",
+            parent_build="pytorch_cpp_doc_build",
+            branch="master",
+        )
+    )
+
+    configs.append(
+        HiddenConf(
+            "pytorch_doc_test",
+            parent_build=xenial_parent_config
+        )
+    )
     return configs
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1352,6 +1352,10 @@ jobs:
     resource_class: medium
     machine:
       image: ubuntu-1604:201903-01
+    parameters:
+      branch:
+        type: string
+        default: "master"
     steps:
     - attach_workspace:
         at: /tmp/workspace
@@ -1368,7 +1372,7 @@ jobs:
         name: Docs push
         command: |
           pushd /tmp/workspace
-          git push -u origin master
+          git push -u origin "<< parameters.branch >>"
 
   pytorch_python_doc_build:
     environment:
@@ -5473,6 +5477,7 @@ workflows:
           requires:
             - pytorch_linux_xenial_py3_6_gcc5_4_build
       - pytorch_doc_push:
+          branch: site
           context: org-member
           filters:
             branches:
@@ -5485,6 +5490,7 @@ workflows:
           requires:
             - pytorch_linux_xenial_py3_6_gcc5_4_build
       - pytorch_doc_push:
+          branch: master
           context: org-member
           filters:
             branches:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -2,6 +2,10 @@
     resource_class: medium
     machine:
       image: ubuntu-1604:201903-01
+    parameters:
+      branch:
+        type: string
+        default: "master"
     steps:
     - attach_workspace:
         at: /tmp/workspace
@@ -18,7 +22,7 @@
         name: Docs push
         command: |
           pushd /tmp/workspace
-          git push -u origin master
+          git push -u origin "<< parameters.branch >>"
 
   pytorch_python_doc_build:
     environment:


### PR DESCRIPTION
Was getting an error when attempting to push to master for
pytorch/pytorch.github.io since the main branch on that repository is
actually site and not master.

Get rid of the loop too since the loop wasn't going to work with a
conditional and conditionals on a two variable loop just isn't worth the
readability concerns

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>