### PR TITLE
Reenable cusparse SpMM on cuda 10.2

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -88,32 +88,32 @@ cusparseOperation_t convertTransToCusparseOperation(char trans) {
 
 #if IS_SPMM_AVAILABLE()
 
-template<typename T> 
+template<typename T>
 void csrmm2(
-  char transa, char transb, 
-  int64_t m, int64_t n, int64_t k, int64_t nnz, 
-  T alpha, T *csrvala, int *csrrowptra, int *csrcolinda, 
+  char transa, char transb,
+  int64_t m, int64_t n, int64_t k, int64_t nnz,
+  T alpha, T *csrvala, int *csrrowptra, int *csrcolinda,
   T *b, int64_t ldb, T beta, T *c, int64_t ldc)
 {
-  static_assert(std::is_same<float, T>::value || std::is_same<double, T>::value, "csrmm2 only supports float and double value types"); 
-  constexpr auto cusparse_value_type = std::is_same<float, T>::value ? CUDA_R_32F : CUDA_R_64F; 
+  static_assert(std::is_same<float, T>::value || std::is_same<double, T>::value, "csrmm2 only supports float and double value types");
+  constexpr auto cusparse_value_type = std::is_same<float, T>::value ? CUDA_R_32F : CUDA_R_64F;
 
-  if (csrvala == nullptr || b == nullptr || c == nullptr) return; 
+  if (csrvala == nullptr || b == nullptr || c == nullptr) return;
 
   cusparseOperation_t opa = convertTransToCusparseOperation(transa);
   cusparseOperation_t opb = convertTransToCusparseOperation(transb);
 
-  // cusparseSpMM actually supports int64_t. 
-  // In order to support int64 here, index pointers csrrowptra, csrcolinda have to be passed as int64_t. 
+  // cusparseSpMM actually supports int64_t.
+  // In order to support int64 here, index pointers csrrowptra, csrcolinda have to be passed as int64_t.
   TORCH_CHECK((m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (nnz <= INT_MAX) && (ldb <= INT_MAX) && (ldc <= INT_MAX),
-    "At the moment, cusparseSpMM only supports m, n, k, nnz, ldb, ldc with the bound [val] <= ", INT_MAX, ".", 
+    "At the moment, cusparseSpMM only supports m, n, k, nnz, ldb, ldc with the bound [val] <= ", INT_MAX, ".",
     "If you need this, please file an issue on GitHub."
   );
 
-  int64_t ma = m, ka = k; 
-  if (transa != 'n') std::swap(ma, ka); 
+  int64_t ma = m, ka = k;
+  if (transa != 'n') std::swap(ma, ka);
 
-  cusparseSpMatDescr_t descA; 
+  cusparseSpMatDescr_t descA;
   TORCH_CUDASPARSE_CHECK(cusparseCreateCsr(
     &descA,                     /* output */
     ma, ka, nnz,                /* rows, cols, number of non zero elements */
@@ -124,77 +124,77 @@ void csrmm2(
     CUSPARSE_INDEX_32I,         /* data type of col indices */
     CUSPARSE_INDEX_BASE_ZERO,   /* base index of row offset and col indes */
     cusparse_value_type         /* data type of values */
-  )); 
+  ));
 
   int64_t kb = k, nb = n;
-  if (transb != 'n') std::swap(kb, nb); 
+  if (transb != 'n') std::swap(kb, nb);
 
-  cusparseDnMatDescr_t descB; 
+  cusparseDnMatDescr_t descB;
   TORCH_CUDASPARSE_CHECK(cusparseCreateDnMat(
     &descB,               /* output */
     kb, nb, ldb,          /* rows, cols, leading dimension */
     b,                    /* values */
     cusparse_value_type,  /* data type of values */
     CUSPARSE_ORDER_COL    /* memory layout, ONLY column-major is supported now */
-  )); 
+  ));
 
-  cusparseDnMatDescr_t descC; 
+  cusparseDnMatDescr_t descC;
   TORCH_CUDASPARSE_CHECK(cusparseCreateDnMat(
     &descC,               /* output */
     m, n, ldc,            /* rows, cols, leading dimension */
     c,                    /* values */ 
     cusparse_value_type,  /* data type of values */ 
     CUSPARSE_ORDER_COL    /* memory layout, ONLY column-major is supported now */
-  )); 
+  ));
 
 
   auto handle = at::cuda::getCurrentCUDASparseHandle();
 
   // cusparseSpMM_bufferSize returns the bufferSize that can be used by cusparseSpMM
-  size_t bufferSize; 
+  size_t bufferSize;
   TORCH_CUDASPARSE_CHECK(cusparseSpMM_bufferSize(
-    handle, opa, opb,     
-    &alpha,               
-    descA, descB, 
-    &beta, 
-    descC, 
+    handle, opa, opb,
+    &alpha,
+    descA, descB,
+    &beta,
+    descC,
     cusparse_value_type,  /* data type in which the computation is executed */
     CUSPARSE_CSRMM_ALG1,  /* default computing algorithm for CSR sparse matrix format */
     &bufferSize           /* output */
-  )); 
+  ));
 
   auto& allocator = *c10::cuda::CUDACachingAllocator::get();
   auto dataPtr = allocator.allocate(bufferSize);
 
   TORCH_CUDASPARSE_CHECK(cusparseSpMM(
-    handle, opa, opb, 
-    &alpha, 
-    descA, descB, 
-    &beta, 
-    descC, 
+    handle, opa, opb,
+    &alpha,
+    descA, descB,
+    &beta,
+    descC,
     cusparse_value_type,  /* data type in which the computation is executed */
     CUSPARSE_CSRMM_ALG1,  /* default computing algorithm for CSR sparse matrix format */
     dataPtr.get()         /* external buffer */
-  )); 
+  ));
 
-  TORCH_CUDASPARSE_CHECK(cusparseDestroySpMat(descA)); 
-  TORCH_CUDASPARSE_CHECK(cusparseDestroyDnMat(descB)); 
-  TORCH_CUDASPARSE_CHECK(cusparseDestroyDnMat(descC)); 
+  TORCH_CUDASPARSE_CHECK(cusparseDestroySpMat(descA));
+  TORCH_CUDASPARSE_CHECK(cusparseDestroyDnMat(descB));
+  TORCH_CUDASPARSE_CHECK(cusparseDestroyDnMat(descC));
 
   // TODO: Proper fix is to create real descriptor classes
 }
 template void csrmm2<float>(
-  char transa, char transb, 
-  int64_t m, int64_t n, int64_t k, int64_t nnz, 
-  float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, 
-  float *b, int64_t ldb, float beta, float *c, int64_t ldc); 
+  char transa, char transb,
+  int64_t m, int64_t n, int64_t k, int64_t nnz,
+  float alpha, float *csrvala, int *csrrowptra, int *csrcolinda,
+  float *b, int64_t ldb, float beta, float *c, int64_t ldc);
 template void csrmm2<double>(
-  char transa, char transb, 
-  int64_t m, int64_t n, int64_t k, int64_t nnz, 
-  double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, 
-  double *b, int64_t ldb, double beta, double *c, int64_t ldc); 
+  char transa, char transb,
+  int64_t m, int64_t n, int64_t k, int64_t nnz,
+  double alpha, double *csrvala, int *csrrowptra, int *csrcolinda,
+  double *b, int64_t ldb, double beta, double *c, int64_t ldc);
 
-#else 
+#else
 
 void adjustLd(char transb, int64_t m, int64_t n, int64_t k, int64_t *ldb, int64_t *ldc)
 {
@@ -262,32 +262,33 @@ void Dcsrmm2(char transa, char transb, int64_t m, int64_t n, int64_t k, int64_t 
 }
 
 // T can only be float or double
-template<typename T> 
+template<typename T>
 void csrmm2(
-  char transa, char transb, 
-  int64_t m, int64_t n, int64_t k, int64_t nnz, 
-  T alpha, T *csrvala, int *csrrowptra, int *csrcolinda, 
+  char transa, char transb,
+  int64_t m, int64_t n, int64_t k, int64_t nnz,
+  T alpha, T *csrvala, int *csrrowptra, int *csrcolinda,
   T *b, int64_t ldb, T beta, T *c, int64_t ldc)
 {
   TORCH_INTERNAL_ASSERT(false, "cusparse csr MM only supports data type of float and double.");
 }
 
 template<> void csrmm2<float>(
-  char transa, char transb, 
-  int64_t m, int64_t n, int64_t k, int64_t nnz, 
-  float alpha, float *csrvala, int *csrrowptra, int *csrcolinda, 
+  char transa, char transb,
+  int64_t m, int64_t n, int64_t k, int64_t nnz,
+  float alpha, float *csrvala, int *csrrowptra, int *csrcolinda,
   float *b, int64_t ldb, float beta, float *c, int64_t ldc)
 {
   Scsrmm2(transa, transb, m, n, k, nnz, alpha, csrvala, csrrowptra, csrcolinda, b, ldb, beta, c, ldc);
-} 
+}
+
 template<> void csrmm2<double>(
-  char transa, char transb, 
-  int64_t m, int64_t n, int64_t k, int64_t nnz, 
-  double alpha, double *csrvala, int *csrrowptra, int *csrcolinda, 
+  char transa, char transb,
+  int64_t m, int64_t n, int64_t k, int64_t nnz,
+  double alpha, double *csrvala, int *csrrowptra, int *csrcolinda,
   double *b, int64_t ldb, double beta, double *c, int64_t ldc)
 {
-  Dcsrmm2(transa, transb, m, n, k, nnz, alpha, csrvala, csrrowptra, csrcolinda, b, ldb, beta, c, ldc); 
-} 
+  Dcsrmm2(transa, transb, m, n, k, nnz, alpha, csrvala, csrrowptra, csrcolinda, b, ldb, beta, c, ldc);
+}
 
 #endif
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -9,7 +9,17 @@
 
 #include <cusparse.h>
 
-#if defined(__CUDACC__) && CUSPARSE_VERSION >= 11000
+// LIMITATION (cusparseSpMM):
+// The generic APIs are available on all platforms on CUDA 11.0
+// For CUDA 10.1+ it is available for all platforms except Windows.
+// Using these APIs in any other systems will result in compile-time or run-time failures.
+// Their support will be extended in the next releases.
+
+#define IS_SPMM_AVAILABLE() (defined(__CUDACC__) &&                              \
+                             (CUSPARSE_VERSION >= 11000 ||                       \
+                              (!defined(_MSC_VER) && CUSPARSE_VERSION >= 10301)))
+
+#if IS_SPMM_AVAILABLE()
 #include <library_types.h>
 #endif
 
@@ -76,7 +86,7 @@ cusparseOperation_t convertTransToCusparseOperation(char trans) {
   }
 }
 
-#if defined(__CUDACC__) && CUSPARSE_VERSION >= 11000
+#if IS_SPMM_AVAILABLE()
 
 template<typename T> 
 void csrmm2(


### PR DESCRIPTION
This fixes feature regression introduced by #42412 which limited all the use of the API to CUDA-11.0+
