### PR TITLE
test: Disable test_strided_grad_layout on ROCM

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -684,6 +684,7 @@ class TestDataParallel(TestCase):
         torch.save(dpm, data)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    @skipIfRocm
     def test_strided_grad_layout(self):
         class ConvNet(nn.Module):
             def __init__(self, layouts, dtypes):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42561 test: Disable test_strided_grad_layout on ROCM**

Regression was introduced as part of https://github.com/pytorch/pytorch/commit/5939d8a3e09b55a4889f6e43b15c1dc87c1f31ce, logs: https://app.circleci.com/pipelines/github/pytorch/pytorch/196558/workflows/9a2dd56e-86af-4d0f-9fb9-b205dcd12f93/jobs/6502042

Going to go ahead and disable the test to give rocm folks time to investigate what's going on

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D22932615](https://our.internmc.facebook.com/intern/diff/D22932615)