### PR TITLE
[TensorExpr] Handle constant nodes in shape inference.

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -150,6 +150,14 @@ std::vector<ExprHandle> TensorExprKernel::sizesForValue(
     }
   }
 
+  if (v->type()->isSubtypeOf(FloatType::get()) ||
+      v->type()->isSubtypeOf(IntType::get())) {
+    return {1};
+  }
+  if (v->type()->isSubtypeOf(NoneType::get())) {
+    return {};
+  }
+
   known_sizes_[v] = inferSizesForValue(v);
   return known_sizes_.at(v);
 }
@@ -301,6 +309,8 @@ std::vector<ExprHandle> TensorExprKernel::inferSizesForValue(
           "Shape info is not implemented for this kind of node");
 
     default: {
+      GRAPH_DEBUG("Can't infer sizes for the node: ", *v->node());
+      GRAPH_DEBUG("Full fusion group graph:\n", *v->node()->owningGraph());
       throw std::runtime_error("Unhandled node kind");
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42568 [TensorExpr] Disallow fallback to JIT interpreter from TensorExprKernel (flip the default).
* #42567 [TensorExpr] Apply GenericIntrinsicExpander recursively.
* **#42566 [TensorExpr] Handle constant nodes in shape inference.**
* #42387 [TensorExpr] Support shape inference in TE for aten::cat.

Differential Revision: [D22936176](https://our.internmc.facebook.com/intern/diff/D22936176)