### PR TITLE
[TensorExpr] Apply GenericIntrinsicExpander recursively.

### DIFF
--- a/test/cpp/tensorexpr/test_cuda.cpp
+++ b/test/cpp/tensorexpr/test_cuda.cpp
@@ -83,6 +83,65 @@ void testCudaTestVectorAdd01_impl() {
   cudaFree(c_dev);
 }
 
+float sigmoid(float x) {
+  return 1.0f / (1.0f + expf(-0.0f - x));
+}
+
+void testCudaSigmoid() {
+  KernelScope kernel_scope;
+  const int num_iter = 3;
+  const int block_count = 16;
+  const int block_size = 128;
+  Dtype dtype = ToDtype<float>();
+  Buffer a_buf("a", dtype, {num_iter, block_count, block_size});
+  Tensor* c = Compute(
+      "c",
+      {
+          {num_iter, "n"},
+          {block_count, "b_id"},
+          {block_size, "t_id"},
+      },
+      [&](const VarHandle& n, const VarHandle& b_id, const VarHandle& t_id) {
+        return sigmoid(sigmoid(a_buf(n, b_id, t_id)));
+      });
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(c);
+  l.setGPUBlockIndex(loops[1], 0);
+  l.setGPUThreadIndex(loops[2], 0);
+  l.prepareForCodegen();
+  Stmt* stmt = l.root_stmt();
+  CudaCodeGen cuda_cg(stmt, c, a_buf);
+  const int N = block_count * block_size * num_iter;
+  PaddedBuffer<float> a_v(N);
+  PaddedBuffer<float> c_v(N);
+  PaddedBuffer<float> c_ref(N);
+
+  for (int i = 0; i < N; i++) {
+    a_v(i) = float(i);
+    c_ref(i) = sigmoid(sigmoid(a_v(i)));
+  }
+
+  // TODO: move gpu support into PaddedBuffer
+  float* a_dev = nullptr;
+  cudaMalloc(&a_dev, N * sizeof(float));
+  float* c_dev = nullptr;
+  cudaMalloc(&c_dev, N * sizeof(float));
+  cudaMemcpy(a_dev, a_v.data(), N * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(c_dev, c_v.data(), N * sizeof(float), cudaMemcpyHostToDevice);
+  cudaDeviceSynchronize();
+
+  cuda_cg(c_dev, a_dev);
+
+  cudaDeviceSynchronize();
+  cudaMemcpy(c_v.data(), c_dev, N * sizeof(float), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+
+  ExpectAllNear(c_v, c_ref, 1e-5);
+
+  cudaFree(a_dev);
+  cudaFree(c_dev);
+}
+
 void testCudaTestVectorAdd01() {
   // floating types.
   testCudaTestVectorAdd01_impl<float>();

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -344,7 +344,8 @@ namespace jit {
   _(CudaNoThreadIdxWrite_1)                \
   _(CudaSharedMemReduce_1)                 \
   _(CudaLocalMemReduce_1)                  \
-  _(CudaTestRand01)
+  _(CudaTestRand01)                        \
+  _(CudaSigmoid)
 
 #define DECLARE_TENSOREXPR_TEST(name) void test##name();
 TH_FORALL_TENSOREXPR_TESTS(DECLARE_TENSOREXPR_TEST)

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -49,12 +49,12 @@ std::unique_ptr<CodeGen> CreateCodeGen(
 
 const Expr* GenericIntrinsicsExpander::mutate(const Intrinsics* v) {
   if (v->op_type() == kSigmoid) {
-    ExprHandle x{v->param(0)};
-    ExprHandle y =
-        ExprHandle(1.0f) / (ExprHandle(1.0f) + exp(ExprHandle(-0.0f) - x));
+    auto x = v->param(0)->accept_mutator(this);
+    ExprHandle y = ExprHandle(1.0f) /
+        (ExprHandle(1.0f) + exp(ExprHandle(-0.0f) - ExprHandle(x)));
     return y.node();
   }
-  return v;
+  return IRMutator::mutate(v);
 }
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -188,7 +188,7 @@ TORCH_API std::unique_ptr<CodeGen> CreateCodeGen(
 
 class TORCH_API GenericIntrinsicsExpander : public IRMutator {
  protected:
-  const Expr* mutate(const Intrinsics* v);
+  const Expr* mutate(const Intrinsics* v) override;
 };
 
 } // namespace tensorexpr


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42568 [TensorExpr] Disallow fallback to JIT interpreter from TensorExprKernel (flip the default).
* **#42567 [TensorExpr] Apply GenericIntrinsicExpander recursively.**
* #42566 [TensorExpr] Handle constant nodes in shape inference.
* #42387 [TensorExpr] Support shape inference in TE for aten::cat.

Before this change we didn't expand arguments, and thus in an expr
`sigmoid(sigmoid(x))` only the outer call was expanded.

Differential Revision: [D22936177](https://our.internmc.facebook.com/intern/diff/D22936177)