### PR TITLE
[TensorExpr] Disallow fallback to JIT interpreter from TensorExprKernel (flip the default).

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -17,7 +17,7 @@ namespace tensorexpr {
 static int te_cuda_pointwise_loop_levels = -1;
 static int te_cuda_pointwise_block_count = -1;
 static int te_cuda_pointwise_block_size = -1;
-static bool fallback_allowed = true;
+static bool fallback_allowed = false;
 
 bool setFallbackAllowed(bool value) {
   bool old_value = fallback_allowed;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42568 [TensorExpr] Disallow fallback to JIT interpreter from TensorExprKernel (flip the default).**
* #42567 [TensorExpr] Apply GenericIntrinsicExpander recursively.
* #42566 [TensorExpr] Handle constant nodes in shape inference.
* #42387 [TensorExpr] Support shape inference in TE for aten::cat.

Differential Revision: [D22936175](https://our.internmc.facebook.com/intern/diff/D22936175)