### PR TITLE
Freeze dynamic (re)quantizaiton ops into standard ones

### DIFF
--- a/caffe2/opt/custom/freeze_quantization_params.cc
+++ b/caffe2/opt/custom/freeze_quantization_params.cc
@@ -1,0 +1,60 @@
+#include <caffe2/quantization/server/int8_gen_quant_params.h>
+#include <caffe2/utils/proto_utils.h>
+#include "freeze_quantization_params.h"
+
+namespace caffe2 {
+void freezeQuantizationParams(NetDef* net, Workspace* ws) {
+  for (auto& op : *net->mutable_op()) {
+    if ((op.type() == "Int8Quantize" && op.input_size() == 2) ||
+        (op.type() == "Int8FC" && op.input_size() == 4)) {
+      int lastPos = op.input_size() - 1;
+      const auto& paramName = op.input(lastPos);
+      auto* b = ws->GetBlob(paramName);
+      if (!b) {
+        LOG(WARNING)
+            << "ParamBlob " << paramName
+            << "does not exist in the workspace. Skip freezing current op.";
+        continue;
+      }
+      if (!b->template IsType<caffe2::unique_ptr<Int8QuantParamsBlob>>()) {
+        LOG(WARNING)
+            << "ParamBlob " << paramName
+            << "is not of caffe2::unique_ptr<Int8QuantParamsBlob> type. Skip freezing current op.";
+        continue;
+      }
+
+      // Extract and set scale and zero point for the op
+      const auto* param =
+          b->template Get<caffe2::unique_ptr<Int8QuantParamsBlob>>().get();
+      CAFFE_ENFORCE(param);
+      const float scale = param->qparam.scale;
+      const int zero_point = param->qparam.zero_point;
+      bool argSet = false;
+      for (auto& arg : *op.mutable_arg()) {
+        if (arg.name() == "Y_scale") {
+          arg.set_f(scale);
+          argSet = true;
+          break;
+        }
+      }
+      if (!argSet) {
+        op.add_arg()->CopyFrom(MakeArgument<float>("Y_scale", scale));
+      }
+      argSet = false;
+      for (auto& arg : *op.mutable_arg()) {
+        if (arg.name() == "Y_zero_point") {
+          arg.set_i(zero_point);
+          argSet = true;
+          break;
+        }
+      }
+      if (!argSet) {
+        op.add_arg()->CopyFrom(MakeArgument<int>("Y_zero_point", zero_point));
+      }
+
+      // Remove last input of the op
+      op.mutable_input()->RemoveLast();
+    }
+  }
+}
+} // namespace caffe2

--- a/caffe2/opt/custom/freeze_quantization_params.h
+++ b/caffe2/opt/custom/freeze_quantization_params.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <caffe2/core/workspace.h>
+#include <caffe2/proto/caffe2_pb.h>
+
+namespace caffe2 {
+/// We have a variant of 2-input Int8Quantize and 4-input Int8FC where the last
+/// input points to a blob which contains the y_scale and y_zero_point. It's
+/// orginated from online snapshot update but is creating complications for
+/// onnxifi flow. Hence this pass is just to absorb the quantization params into
+/// the op itself and remove the last input.
+void freezeQuantizationParams(NetDef* net, Workspace* ws);
+} // namespace caffe2

--- a/caffe2/opt/custom/glow_net_transform.h
+++ b/caffe2/opt/custom/glow_net_transform.h
@@ -14,12 +14,11 @@ C10_DECLARE_string(onnxifi_blacklist_ops);
 
 namespace caffe2 {
 namespace glow {
-
-// Onnxifi transformation on the net and workspace.  We also
-// needed the input data/shape to populate the shape. In addition, we take a \p
-// blacklist to control and mask what ops we want to consider in onnxifi
-// process. We can also set whether to use ONNX proto or C2 proto through
-// ONNXIFI interface.
+/// Onnxifi transformation on the net and workspace.  We also
+/// needed the input data/shape to populate the shape. In addition, we take a \p
+/// blacklist to control and mask what ops we want to consider in onnxifi
+/// process. We can also set whether to use ONNX proto or C2 proto through
+/// ONNXIFI interface.
 void onnxifi(
     NetDef* net,
     Workspace* ws,

--- a/caffe2/quantization/server/pybind.cc
+++ b/caffe2/quantization/server/pybind.cc
@@ -4,6 +4,7 @@
 #include <pybind11/stl.h>
 #include "activation_distribution_observer.h"
 #include "caffe2/opt/custom/fakefp16_transform.h"
+#include "caffe2/opt/custom/freeze_quantization_params.h"
 #include "caffe2/quantization/server/caffe2_dnnlowp_utils.h"
 #include "caffe2/quantization/server/fbgemm_pack_blob.h"
 #include "caffe2/quantization/server/int8_gen_quant_params.h"
@@ -273,6 +274,18 @@ PYBIND11_MODULE(dnnlowp_pybind11, m) {
   m.def("get_fakefp16_mapping", [](bool use_fp16_acc, bool use_nnpi) {
     return caffe2::opt::getFakeFp16OpMapping(use_fp16_acc, use_nnpi);
   });
+  m.def("freeze_quantization_params",
+      [](const pybind11::bytes& net_def_bytes){
+        NetDef def;
+        CAFFE_ENFORCE(
+            ParseProtoFromLargeString(net_def_bytes.cast<string>(), &def));
+        string protob;
+        Workspace* gWorkspace = caffe2::python::GetCurrentWorkspace();
+        CAFFE_ENFORCE(gWorkspace);
+        freezeQuantizationParams(&def, gWorkspace);
+        CAFFE_ENFORCE(def.SerializeToString(&protob));
+        return pybind11::bytes(protob);
+      });
   m.def(
       "ChooseStaticQuantizationParams",
       [](float min,

--- a/caffe2/quantization/server/quantize_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/quantize_dnnlowp_op_test.py
@@ -13,8 +13,11 @@ workspace.GlobalInit(["caffe2", "--caffe2_omp_num_threads=11"])
 
 
 class DNNLowPQuantizeOpTest(hu.HypothesisTestCase):
-    @given(size=st.integers(1024, 2048), is_empty=st.booleans(), **hu.gcs_cpu_only)
-    def test_dnnlowp_quantize(self, size, is_empty, gc, dc):
+    @given(size=st.integers(1024, 2048),
+        is_empty=st.booleans(),
+        absorb=st.booleans(),
+        **hu.gcs_cpu_only)
+    def test_dnnlowp_quantize(self, size, is_empty, absorb, gc, dc):
         if is_empty:
             size = 0
         min_ = -10.0
@@ -47,7 +50,10 @@ class DNNLowPQuantizeOpTest(hu.HypothesisTestCase):
                 device_option=gc,
             )
             net.Proto().op.extend([quantize_2])
-
+            if absorb:
+                net_str = dnnlowp_pybind11.freeze_quantization_params(
+                    net.Proto().SerializeToString())
+                net.Proto().ParseFromString(net_str)
             workspace.FeedBlob("X", X, device_option=gc)
             workspace.RunNetOnce(net)
             X_q = workspace.FetchInt8Blob("X_q")[0]


### PR DESCRIPTION
Summary: We don't support lowering with 2-input Int8Quantize and 4-input Int8FC. Just do a conversion to absorb the quantization params into the op itself.

Test Plan:
```
buck test caffe2/caffe2/quantization/server:quantize_dnnlowp_op_test
```

Differential Revision: D22942673

