### PR TITLE
Optimization of Backward Implementation of Learnable Fake Quantize Per Tensor Kernel (GPU)

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/quantized/fake_quant_affine.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
+#include <thrust/tuple.h>
 #include <cmath>
 
 /* Fake quantize a tensor
@@ -69,58 +70,36 @@ void fake_quantize_grad_tensor_kernel_cuda(
     });
 }
 
-void _fake_quantize_grad_learnable_scale_tensor_kernel_cuda(
-    Tensor& input_grad,
-    const Tensor& input,
-    const Tensor& output_grad,
+void _fake_quantize_grad_learnable_tensor_kernel_cuda(
+    TensorIterator& iter,
     float scale,
+    float inv_scale,
     int64_t zero_point,
     int64_t quant_min,
     int64_t quant_max) {
-  // scalar type of this function is guaranteed to be float
-  float inv_scale = 1.0f / scale;
-  float grad_small = quant_min - zero_point;
-  float grad_big = quant_max - zero_point;
-
-  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
-  gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dy) -> float {
-      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
+  float dscale_small = quant_min - zero_point;
+  float dscale_big = quant_max - zero_point;
+  gpu_kernel_multiple_outputs(
+    iter, [=] GPU_LAMBDA (float XInput, float dYInput) -> thrust::tuple<float, float, float> {
+      float dXOutput, dZeroPointOutput, dScaleOutput;
+      int64_t xq = std::nearbyint(zero_point + XInput * inv_scale);
+      dXOutput = dYInput * (xq >= quant_min && xq <= quant_max);
       xq = std::max(std::min(xq, quant_max), quant_min);
-      if (xq == quant_min) {
-        return dy * grad_small;
-      } else if (xq == quant_max) {
-        return dy * grad_big;
-      }
-      float x_fq = static_cast<float>((xq - zero_point) * scale);
-      return dy * (x_fq - x) * inv_scale;
-    });
-}
-
-void _fake_quantize_grad_learnable_zero_point_tensor_kernel_cuda(
-    Tensor& input_grad,
-    const Tensor& input,
-    const Tensor& output_grad,
-    float scale,
-    int64_t zero_point,
-    int64_t quant_min,
-    int64_t quant_max) {
-  // scalar type of this function is guaranteed to be float
-  float inv_scale = 1.0f / scale;
-  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
-  gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dy) -> float {
-      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
-      xq = std::max(std::min(xq, quant_max), quant_min);
+      float xfq = static_cast<float>((xq - zero_point) * scale);
       if (xq == quant_min || xq == quant_max) {
-        return dy * (-1) * scale;
+        dZeroPointOutput = (dYInput) * (-1) * scale;
+        dScaleOutput = (xq == quant_min) ? (dYInput * dscale_small) : (dYInput * dscale_big);
+      } else {
+        dZeroPointOutput = 0;
+        dScaleOutput = (dYInput) * (xfq - (XInput)) * inv_scale;
       }
-      return 0;
-    });
+      return {dXOutput, dScaleOutput, dZeroPointOutput};
+  });
 }
 
 REGISTER_DISPATCH(fake_quant_tensor_stub, &fake_quantize_tensor_kernel_cuda);
 REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_learnable_tensor_stub, &_fake_quantize_grad_learnable_tensor_kernel_cuda);
 
 // Fake quantize per channel
 

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -121,8 +121,6 @@ void _fake_quantize_grad_learnable_zero_point_tensor_kernel_cuda(
 
 REGISTER_DISPATCH(fake_quant_tensor_stub, &fake_quantize_tensor_kernel_cuda);
 REGISTER_DISPATCH(fake_quant_grad_tensor_stub, &fake_quantize_grad_tensor_kernel_cuda);
-REGISTER_DISPATCH(fake_quant_grad_learnable_scale_tensor_stub, &_fake_quantize_grad_learnable_scale_tensor_kernel_cuda);
-REGISTER_DISPATCH(fake_quant_grad_learnable_zero_point_tensor_stub, &_fake_quantize_grad_learnable_zero_point_tensor_kernel_cuda);
 
 // Fake quantize per channel
 

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -26,10 +26,17 @@ using fake_quant_grad_tensor_fn = void (*)(
     int64_t quant_min,
     int64_t quant_max);
 
+using fake_quant_learnable_grad_tensor_fn = void (*)(
+    TensorIterator& iter,
+    float scale,
+    float inv_scale,
+    int64_t zero_point,
+    int64_t quant_min,
+    int64_t quant_max);
+
 DECLARE_DISPATCH(fake_quant_tensor_fn, fake_quant_tensor_stub);
 DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_tensor_stub);
-DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_scale_tensor_stub);
-DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_zero_point_tensor_stub);
+DECLARE_DISPATCH(fake_quant_learnable_grad_tensor_fn, fake_quant_grad_learnable_tensor_stub);
 
 using fake_quant_per_channel_fn = void (*)(
     TensorIterator &iter,


### PR DESCRIPTION
Summary:
In this diff, the original backward pass implementation is sped up by merging the 3 iterations computing dX, dScale, and dZeroPoint separately using the `gpu_kernel_multiple_outputs`  function that utilizes `thrust::tuple`. In this case, a native loop is directly used on a byte-wise level (referenced by `strides`).

In the benchmark test on the operators, for an input of shape `3x3x256x256`, we have observed the following improvement in performance:
- **Speedup from python operator**: ~5x
- **Speedup from original learnable kernel**: ~1.15x

Test Plan:
To assert correctness of the new kernel, on a devvm, enter the command

`buck test //caffe2/test:quantization -- learnable_backward_per_channel`

To benchmark the operators, on a devvm, enter the command
1. Set the kernel size to 3x3x256x256 or a reasonable input size.
2. Run `buck test mode/dev-nosan //caffe2/benchmarks/operator_benchmark/pt:quantization_test`
3. The relevant outputs are as follows:

```
# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typepy_module
# Input: N: 3, C: 3, H: 256, W: 256, device: cuda, op_type: py_module
Backward Execution Time (us) : 6548.350

# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typelearnable_kernel
# Input: N: 3, C: 3, H: 256, W: 256, device: cuda, op_type: learnable_kernel
Backward Execution Time (us) : 1340.724

# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typeoriginal_kernel
# Input: N: 3, C: 3, H: 256, W: 256, device: cuda, op_type: original_kernel
Backward Execution Time (us) : 656.863

Differential Revision: D22947765

