### PR TITLE
Clearer Semantics and Naming for Customized Quantization Range Initialization in Observer

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -80,9 +80,8 @@ class _ObserverBase(ObserverBase):
         qscheme: Quantization scheme to be used.
         reduce_range: Reduces the range of the quantized data type by 1 bit.
                       This is sometimes required to avoid instruction overflow.
-        initial_dynamic_qrange: Nullable tuple containing the initial qmin and qmax values
-                                to support dynamic quantization range. If unspecified,
-                                the initialization of qmin and qmax follows the 8-bit setup.
+        quant_min: Minimum quantization value. If unspecified, it will follow the 8-bit setup.
+        quant_max: Maximum quantization value. If unspecified, it will follow the 8-bit setup.
 
     .. warning::
 
@@ -98,9 +97,14 @@ class _ObserverBase(ObserverBase):
         - ``torch.per_channel_symmetric``
     """
     def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine,
-                 reduce_range=False, initial_dynamic_qrange=None):
+                 reduce_range=False, quant_min=None, quant_max=None):
         super(_ObserverBase, self).__init__(dtype=dtype)
         self.qscheme = qscheme
+        if reduce_range:
+            warnings.warn(
+                "Please use quant_min and quant_max to specify the range for observers. \
+                    reduce_range will be deprecated in a future release of PyTorch."
+            )
         self.reduce_range = reduce_range
         self.eps = torch.finfo(torch.float32).eps
         assert self.qscheme in (
@@ -116,15 +120,16 @@ class _ObserverBase(ObserverBase):
             torch.qint8,
             torch.quint8,
         ), "Default Observer only works for qint8 and quint8 data type"
-        self.is_dynamic_qrange = initial_dynamic_qrange is not None
-        if self.is_dynamic_qrange:
-            self._validate_dynamic_range_init(initial_dynamic_qrange)
-        self.initial_dynamic_qrange = initial_dynamic_qrange
+        self.has_customized_qrange = (quant_min is not None) and (quant_max is not None)
+        if self.has_customized_qrange:
+            self._validate_qmin_qmax(quant_min, quant_max)
+        self.quant_min = quant_min
+        self.quant_max = quant_max
 
     @torch.jit.export
-    def _validate_dynamic_range_init(self, initial_dynamic_qrange):
-        # type: (Tuple[int, int]) -> None
-        r"""Validates that the dynamic quantization range is properly initialized
+    def _validate_qmin_qmax(self, quant_min, quant_max):
+        # type: (int, int) -> None
+        r"""Validates that the user-specified quantization range is properly initialized
         and within the given bound supported by the observer dtype.
 
         To accommodate lower-bit quantization with respect to the existing torch.qint8 and
@@ -139,9 +144,8 @@ class _ObserverBase(ObserverBase):
         """
         # The variable names are prefixed with "initial" because their values (qmin and qmax) might be adjusted
         # based on whether quantization range is reduced and the datatype (signed/unsigned) used by the observer.
-        initial_qmin, initial_qmax = initial_dynamic_qrange
-        assert initial_qmin <= 0 <= initial_qmax, "Dynamic quantization range must include 0."
-        assert initial_qmin < initial_qmax, "qmin must be strictly less than qmax for dynamic quantization range."
+        assert quant_min <= 0 <= quant_max, "Used-specified quantization range must include 0."
+        assert quant_min < quant_max, "qmin must be strictly less than qmax for user-specified quantization range."
 
     @torch.jit.export
     def _calculate_qmin_qmax(self):
@@ -149,39 +153,39 @@ class _ObserverBase(ObserverBase):
         r"""Calculates actual qmin and qmax based on the quantization range,
         observer datatype and if range is reduced.
         """
-        if self.is_dynamic_qrange:
+        if self.has_customized_qrange:
             # This initialization here is to be resolve TorchScript compilation issues and allow
             # using of refinement to decouple initial_qmin and initial_qmax from quantization range.
             # The actual values of initial_qmin and initial_qmax will be reset below.
-            initial_qmin, initial_qmax = 0, 255
-            # The following assignment of initial_qrange to a local variable and the if check refine the
-            # attribute from Optional to a valid tuple for use, based on TorchScript's requirements.
-            initial_dynamic_qrange = self.initial_dynamic_qrange
-            if initial_dynamic_qrange is not None:
-                initial_qmin, initial_qmax = initial_dynamic_qrange
+            initial_quant_min, initial_quant_max = 0, 255
+            # The following assignment of self.qmin and self.qmax to the local variables and the if check refine the
+            # attribute from Optional valid integers for use, based on TorchScript's requirements.
+            custom_quant_min, custom_quant_max = self.quant_min, self.quant_max
+            if custom_quant_min is not None and custom_quant_max is not None:
+                initial_quant_min, initial_quant_max = custom_quant_min, custom_quant_max
 
-            qrange_len = initial_qmax - initial_qmin + 1
+            qrange_len = initial_quant_max - initial_quant_min + 1
             assert 0 < qrange_len <= 256, \
                 "quantization range should be positive and not exceed the maximum bit range (=256)."
             if self.dtype == torch.qint8:
-                qmin, qmax = -qrange_len // 2, qrange_len // 2 - 1
+                quant_min, quant_max = -qrange_len // 2, qrange_len // 2 - 1
             else:
-                qmin, qmax = 0, qrange_len - 1
+                quant_min, quant_max = 0, qrange_len - 1
             if self.reduce_range:
-                qmin, qmax = qmin // 2, qmax // 2
+                quant_min, quant_max = quant_min // 2, quant_max // 2
         else:
             # Fallback onto default 8-bit qmin and qmax calculation if dynamic range is not used.
             if self.dtype == torch.qint8:
                 if self.reduce_range:
-                    qmin, qmax = -64, 63
+                    quant_min, quant_max = -64, 63
                 else:
-                    qmin, qmax = -128, 127
+                    quant_min, quant_max = -128, 127
             else:
                 if self.reduce_range:
-                    qmin, qmax = 0, 127
+                    quant_min, quant_max = 0, 127
                 else:
-                    qmin, qmax = 0, 255
-        return qmin, qmax
+                    quant_min, quant_max = 0, 255
+        return quant_min, quant_max
 
     @torch.jit.export
     def _calculate_qparams(self, min_val, max_val):
@@ -213,7 +217,7 @@ class _ObserverBase(ObserverBase):
                 min_val, max_val
             )
 
-        qmin, qmax = self._calculate_qmin_qmax()
+        quant_min, quant_max = self._calculate_qmin_qmax()
         min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
         max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
 
@@ -223,16 +227,16 @@ class _ObserverBase(ObserverBase):
 
         if self.qscheme == torch.per_tensor_symmetric or self.qscheme == torch.per_channel_symmetric:
             max_val_pos = torch.max(-min_val_neg, max_val_pos)
-            scale = max_val_pos / (float(qmax - qmin) / 2)
+            scale = max_val_pos / (float(quant_max - quant_min) / 2)
             scale = torch.max(scale, torch.tensor(self.eps, device=device, dtype=scale.dtype))
             if self.dtype == torch.quint8:
-                if self.is_dynamic_qrange:
-                    # When dynamic quantization range is used, down-rounded midpoint of the range is chosen.
-                    zero_point = zero_point.new_full(zero_point.size(), (qmin + qmax) // 2)
+                if self.has_customized_qrange:
+                    # When customized quantization range is used, down-rounded midpoint of the range is chosen.
+                    zero_point = zero_point.new_full(zero_point.size(), (quant_min + quant_max) // 2)
                 else:
                     zero_point = zero_point.new_full(zero_point.size(), 128)
         elif self.qscheme == torch.per_channel_affine_float_qparams:
-            scale = (max_val - min_val) / float(qmax - qmin)
+            scale = (max_val - min_val) / float(quant_max - quant_min)
             scale = torch.where(scale > self.eps, scale, torch.ones_like(scale))
             # We use the quantize function
             # xq = Round(Xf * inv_scale + zero_point),
@@ -240,11 +244,11 @@ class _ObserverBase(ObserverBase):
             # Xq = Round((Xf - min) * inv_scale)
             zero_point = -1 * min_val / scale
         else:
-            scale = (max_val_pos - min_val_neg) / float(qmax - qmin)
+            scale = (max_val_pos - min_val_neg) / float(quant_max - quant_min)
             scale = torch.max(scale, torch.tensor(self.eps, device=device, dtype=scale.dtype))
-            zero_point = qmin - torch.round(min_val_neg / scale)
-            zero_point = torch.max(zero_point, torch.tensor(qmin, device=device, dtype=zero_point.dtype))
-            zero_point = torch.min(zero_point, torch.tensor(qmax, device=device, dtype=zero_point.dtype))
+            zero_point = quant_min - torch.round(min_val_neg / scale)
+            zero_point = torch.max(zero_point, torch.tensor(quant_min, device=device, dtype=zero_point.dtype))
+            zero_point = torch.min(zero_point, torch.tensor(quant_max, device=device, dtype=zero_point.dtype))
 
         # For scalar values, cast them to Tensors of size 1 to keep the shape
         # consistent with default values in FakeQuantize.
@@ -273,9 +277,8 @@ class MinMaxObserver(_ObserverBase):
         dtype: Quantized data type
         qscheme: Quantization scheme to be used
         reduce_range: Reduces the range of the quantized data type by 1 bit
-        initial_dynamic_qrange: Nullable tuple containing the initial qmin and qmax values
-                                to support dynamic quantization range. If unspecified,
-                                the initialization of qmin and qmax follows the 8-bit setup.
+        quant_min: Minimum quantization value. If unspecified, it will follow the 8-bit setup.
+        quant_max: Maximum quantization value. If unspecified, it will follow the 8-bit setup.
 
     Given running min/max as :math:`x_\text{min}` and :math:`x_\text{max}`,
     scale :math:`s` and zero point :math:`z` are computed as:
@@ -327,7 +330,7 @@ class MinMaxObserver(_ObserverBase):
     """
 
     def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine,
-                 reduce_range=False, initial_dynamic_qrange=None):
+                 reduce_range=False, quant_min=None, quant_max=None):
         # For x86 quantized kernels, we need to ensure that the vpmaddubsw
         # instruction does not overflow. We allow for a reduce_range argument to
         # observers that reduces the quantized range to (0,127) or (-64, 63).
@@ -338,7 +341,8 @@ class MinMaxObserver(_ObserverBase):
         super(MinMaxObserver, self).__init__(dtype=dtype,
                                              qscheme=qscheme,
                                              reduce_range=reduce_range,
-                                             initial_dynamic_qrange=initial_dynamic_qrange)
+                                             quant_min=quant_min,
+                                             quant_max=quant_max)
         self.register_buffer('min_val', torch.tensor([]))
         self.register_buffer('max_val', torch.tensor([]))
         if self.qscheme == torch.per_tensor_symmetric and \
@@ -408,9 +412,8 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         dtype: Quantized data type
         qscheme: Quantization scheme to be used
         reduce_range: Reduces the range of the quantized data type by 1 bit
-        initial_dynamic_qrange: Nullable tuple containing the initial qmin and qmax values
-                                to support dynamic quantization range. If unspecified,
-                                the initialization of qmin and qmax follows the 8-bit setup.
+        quant_min: Minimum quantization value. If unspecified, it will follow the 8-bit setup.
+        quant_max: Maximum quantization value. If unspecified, it will follow the 8-bit setup.
 
     The moving average min/max is computed as follows
 
@@ -440,12 +443,13 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
     """
     def __init__(self, averaging_constant=0.01, dtype=torch.quint8,
                  qscheme=torch.per_tensor_affine, reduce_range=False,
-                 initial_dynamic_qrange=None):
+                 quant_min=None, quant_max=None):
         self.averaging_constant = averaging_constant
         super(MovingAverageMinMaxObserver, self).__init__(dtype=dtype,
                                                           qscheme=qscheme,
                                                           reduce_range=reduce_range,
-                                                          initial_dynamic_qrange=initial_dynamic_qrange)
+                                                          quant_min=quant_min,
+                                                          quant_max=quant_max)
 
     def forward(self, x_orig):
         x = x_orig.detach()  # avoid keeping autograd tape
@@ -554,9 +558,8 @@ class PerChannelMinMaxObserver(_ObserverBase):
         dtype: Quantized data type
         qscheme: Quantization scheme to be used
         reduce_range: Reduces the range of the quantized data type by 1 bit
-        initial_dynamic_qrange: Nullable tuple containing the initial qmin and qmax values
-                                to support dynamic quantization range. If unspecified,
-                                the initialization of qmin and qmax follows the 8-bit setup.
+        quant_min: Minimum quantization value. If unspecified, it will follow the 8-bit setup.
+        quant_max: Maximum quantization value. If unspecified, it will follow the 8-bit setup.
 
     The quantization parameters are computed the same way as in
     :class:`~torch.quantization.observer.MinMaxObserver`, with the difference
@@ -569,11 +572,12 @@ class PerChannelMinMaxObserver(_ObserverBase):
 
     def __init__(self, ch_axis=0, dtype=torch.quint8,
                  qscheme=torch.per_channel_affine, reduce_range=False,
-                 initial_dyanmic_qrange=None):
+                 quant_min=None, quant_max=None):
         super(PerChannelMinMaxObserver, self).__init__(dtype=dtype,
                                                        qscheme=qscheme,
                                                        reduce_range=reduce_range,
-                                                       initial_dynamic_qrange=initial_dyanmic_qrange)
+                                                       quant_min=quant_min,
+                                                       quant_max=quant_max)
         self.ch_axis = ch_axis
         self.register_buffer('min_vals', torch.tensor([]))
         self.register_buffer('max_vals', torch.tensor([]))
@@ -656,9 +660,8 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         dtype: Quantized data type
         qscheme: Quantization scheme to be used
         reduce_range: Reduces the range of the quantized data type by 1 bit
-        initial_dynamic_qrange: Nullable tuple containing the initial qmin and qmax values
-                                to support dynamic quantization range. If unspecified,
-                                the initialization of qmin and qmax follows the 8-bit setup.
+        quant_min: Minimum quantization value. If unspecified, it will follow the 8-bit setup.
+        quant_max: Maximum quantization value. If unspecified, it will follow the 8-bit setup.
 
     The quantization parameters are computed the same way as in
     :class:`~torch.quantization.observer.MovingAverageMinMaxObserver`, with the
@@ -671,10 +674,10 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
 
     def __init__(self, averaging_constant=0.01, ch_axis=0, dtype=torch.quint8,
                  qscheme=torch.per_channel_affine, reduce_range=False,
-                 initial_dynamic_qrange=None):
+                 quant_min=None, quant_max=None):
         super(MovingAveragePerChannelMinMaxObserver, self).__init__(
             ch_axis=ch_axis, dtype=dtype, qscheme=qscheme,
-            reduce_range=reduce_range, initial_dyanmic_qrange=initial_dynamic_qrange)
+            reduce_range=reduce_range, quant_min=quant_min, quant_max=quant_max)
         self.averaging_constant = averaging_constant
 
     def forward(self, x_orig):


### PR DESCRIPTION
Summary:
In this diff, clearer semantics and namings for are introduced by splitting the original `init_dynamic_qrange` into 2 separate `Optional[int]` types `qmin` and `qmax` to avoid the confusion of the parameters with dynamic quantization.

The `qmin` and `qmax` parameters allow customers to specify their own customary quantization range and enables specific use cases for lower bit quantization.

Test Plan:
To assert the correctness and compatibility of the changes with existing observers, on a devvm, execute the following command to run the unit tests:

`buck test //caffe2/test:quantization -- observer`

Differential Revision: D22948334

