### PR TITLE
[NNC] Registerizer for GPU [1/x]

### DIFF
--- a/test/cpp/tensorexpr/test_registerizer.cpp
+++ b/test/cpp/tensorexpr/test_registerizer.cpp
@@ -1,0 +1,768 @@
+#include "test/cpp/tensorexpr/test_base.h"
+
+#include "test/cpp/tensorexpr/test_utils.h"
+#include "torch/csrc/jit/tensorexpr/ir_simplifier.h"
+#include "torch/csrc/jit/tensorexpr/registerizer.h"
+
+#include <iostream>
+
+namespace torch {
+namespace jit {
+using namespace torch::jit::tensorexpr;
+
+// Can replace a simple scalar access with a local variable.
+void testRegisterizerSimple() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt =
+      Block::make({Store::make(a, {0}, 0, 1),
+                   For::make(
+                       x,
+                       0,
+                       10,
+                       Block::make({Store::make(
+                           a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[0] = (A[0]) + x;
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A_ = x + A_;
+   * }
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A[
+# CHECK:   A_ =
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Won't do replacement of a loop access.
+void testRegisterizerLoop() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {10}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt =
+      Block::make({Store::make(a, {0}, 0, 1),
+                   For::make(
+                       x,
+                       0,
+                       10,
+                       Block::make({Store::make(
+                           a, {x}, Add::make(Load::make(a, {x}, 1), x), 1)}))});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[x] = (A[x]) + x;
+   * }
+   */
+
+  // No change.
+  registerize(stmt);
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[x] = (A[x]) + x;
+   * }
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK-NOT: int
+# CHECK: A[0] = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A_
+# CHECK:   A[x] =
+# CHECK-NOT: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Won't replace even if the load is a fixed scalar, since the store could
+// invalidate it.
+void testRegisterizerLoopFixedLoad() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt =
+      Block::make({Store::make(a, {0}, 0, 1),
+                   For::make(
+                       x,
+                       0,
+                       10,
+                       Block::make({Store::make(
+                           a, {x}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[0] = (A[0]) + x;
+   * }
+   */
+
+  // No change.
+  registerize(stmt);
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[0] = (A[0]) + x;
+   * }
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK-NOT: int
+# CHECK: A[0] = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A_
+# CHECK:   A[x] =
+# CHECK-NOT: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Will registerize multiple accesses of different items of the same buffer.
+void testRegisterizerMultiVar() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {2}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt = Block::make({
+      Store::make(a, {0}, 0, 1),
+      Store::make(a, {1}, 0, 1),
+      For::make(
+          x,
+          0,
+          10,
+          Block::make(
+              {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1),
+               Store::make(a, {1}, Sub::make(Load::make(a, {1}, 1), x), 1)})),
+  });
+
+  /*
+   * A[0] = 0;
+   * A[1] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[0] = (A[0]) + x;
+   *   A[1] = (A[1]) - x;
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = 0;
+   * int A__1 = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A__1 = x + A__1;
+   *   A_ = A_ - x;
+   * }
+   * A[1] = A__1;
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: int A__1 = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A[
+# CHECK:   A_ =
+# CHECK:   A__1 =
+# CHECK: A[1] = A__1
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Will registerize the valid accesses while skipping invalid replacements.
+void testRegisterizerVariableLoad() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  Buffer b(BufHandle("B", {10}, kInt));
+  VarHandle x("x", kInt);
+  VarHandle x2("x", kInt);
+  Stmt* stmt = Block::make(
+      {Store::make(a, {0}, 0, 1),
+       For::make(x, 0, 10, Store::make(b, {x}, x, 1)),
+       For::make(
+           x2,
+           0,
+           10,
+           Block::make({Store::make(
+               a,
+               {0},
+               Add::make(Load::make(a, {0}, 1), Load::make(b, {x2}, 1)),
+               1)}))});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   B[x] = x;
+   * }
+   * for (int x_1 = 0; x_1 < 10; x_1++) {
+   *   A[0] = (A[0]) + (B[x_1]);
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   B[x] = x;
+   * }
+   * for (int x_1 = 0; x_1 < 10; x_1++) {
+   *   A_ = A_ + (B[x_1]);
+   * }
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK:   B[x] = x
+# CHECK: for (int x_1 = 0; x_1 < 10; x_1++)
+# CHECK-NOT: A[
+# CHECK:   A_ =
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Can registerize variable accesses so long as the variable does not change.
+void testRegisterizerSymbolicIndices() {
+  KernelScope kernel_scope;
+  VarHandle i("i", kInt);
+  VarHandle N("N", kInt);
+  Buffer a(BufHandle("A", {N}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt =
+      Block::make({Store::make(a, {i}, 0, 1),
+                   For::make(
+                       x,
+                       0,
+                       10,
+                       Block::make({Store::make(
+                           a, {i}, Add::make(Load::make(a, {i}, 1), x), 1)}))});
+
+  /*
+   * A[i] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[i] = (A[i]) + x;
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A_ = x + A_;
+   * }
+   * A[i] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A[
+# CHECK:   A_ =
+# CHECK: A[i] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Will not registerize if a variable usage of the sclar may overlap the target
+// scalar.
+// TODO: we can support this by writing back to the buffer before the variable
+// access, but we'd need temporal analysis of dependencies which we don't have
+// yet. Will have to fix soon though.
+void testRegisterizerEarlyStop() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt = Block::make(
+      {Store::make(a, {0}, 0, 1),
+       For::make(
+           x,
+           0,
+           10,
+           Block::make(
+               {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)})),
+       For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1}, 1), 1))});
+
+  std::ostringstream before;
+  before << *stmt;
+
+  // No change.
+  registerize(stmt);
+
+  std::ostringstream after;
+  after << *stmt;
+
+  ASSERT_EQ(before.str(), after.str());
+}
+
+// Can registerize accesses dependent on multiple loop vars.
+void testRegisterizerMultiLoop() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  Stmt* stmt = Block::make(
+      {Store::make(a, {0}, 0, 1),
+       For::make(
+           x,
+           0,
+           10,
+           For::make(
+               y,
+               0,
+               10,
+               Block::make({Store::make(
+                   a,
+                   {0},
+                   Mul::make(Add::make(Load::make(a, {0}, 1), x), y),
+                   1)})))});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   for (int y = 0; y < 10; y++) {
+   *     A[0] = x * y + (A[0]) * y;
+   *   }
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   for (int y = 0; y < 10; y++) {
+   *     A_ = x * y + y * A_l
+   *   }
+   * }
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK:   for (int y = 0; y < 10; y++)
+# CHECK-NOT: A[
+# CHECK:     A_ =
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Can registerize correctly if scalars already exist in the program.
+void testRegisterizerRepeated() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {2}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt = Block::make({
+      Store::make(a, {0}, 0, 1),
+      Store::make(a, {1}, 0, 1),
+      For::make(
+          x,
+          0,
+          10,
+          Block::make(
+              {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1),
+               Store::make(a, {1}, Sub::make(Load::make(a, {1}, 1), x), 1)})),
+  });
+
+  // Registerize manually to make sure we only replace a single target.
+  {
+    RegisterizerAnalysis analysis;
+    stmt->accept(&analysis);
+    auto candidates = analysis.getCandidates();
+    ASSERT_EQ(candidates.size(), 2);
+
+    RegisterizerReplacer replacer(candidates.front());
+    stmt = stmt->accept_mutator(&replacer);
+  }
+
+  // Re-analyze and replace the second target.
+  {
+    RegisterizerAnalysis analysis;
+    stmt->accept(&analysis);
+    auto candidates = analysis.getCandidates();
+    ASSERT_EQ(candidates.size(), 1);
+
+    RegisterizerReplacer replacer(candidates.front());
+    stmt = stmt->accept_mutator(&replacer);
+  }
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: int A__1 = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A[
+# CHECK:   A_ =
+# CHECK:   A__1 =
+# CHECK: A[1] = A__1
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Can registerize rthe load of A.
+void testRegisterizerNoLoads() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt = Block::make(
+      {Store::make(a, {0}, 0, 1),
+       For::make(
+           x, 0, 10, Block::make({Store::make(a, {0}, Add::make(x, 1), 1)}))});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[0] = x + 1;
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A_ = x + 1;
+   * }
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A[
+# CHECK:   A_ =
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Can registerize the load of A but not the store of B.
+void testRegisterizerNoRepeatedStores() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  Buffer b(BufHandle("B", {10}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt =
+      Block::make({Store::make(a, {0}, 0, 1),
+                   For::make(
+                       x,
+                       0,
+                       10,
+                       Block::make({Store::make(
+                           b, {x}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   B[x] = (A[0]) + x;
+   * }
+   */
+
+  registerize(stmt);
+
+  // TODO: its unnecessary to reorder the initializer of A[0], but it's not
+  // actually worse so lets not worry for now.
+
+  /*
+   * int A_ = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   B[x] = x + A_;
+   * }
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = 0;
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A_
+# CHECK:   B[x] =
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Won't registerize if there are multiple accesses which may overlap.
+void testRegisterizerMultiVarOverlap() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {2}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt = Block::make({
+      Store::make(a, {0}, 0, 1),
+      Store::make(a, {1}, 0, 1),
+      For::make(
+          x,
+          0,
+          10,
+          Block::make(
+              {Store::make(a, {x}, Add::make(Load::make(a, {0}, 1), x), 1),
+               Store::make(
+                   a, {x + 1}, Sub::make(Load::make(a, {1}, 1), x), 1)})),
+  });
+
+  std::ostringstream before;
+  before << *stmt;
+
+  // No change.
+  registerize(stmt);
+
+  std::ostringstream after;
+  after << *stmt;
+
+  ASSERT_EQ(before.str(), after.str());
+}
+
+void testRegisterizerAllocs() {
+  KernelScope kernel_scope;
+
+  Buffer a(BufHandle("A", {2}, kInt));
+  Buffer b(BufHandle("B", {1}, kInt));
+  Buffer c(BufHandle("C", {1}, kInt));
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+
+  VarHandle b_(b.data()->base_handle());
+
+  Stmt* stmt = Block::make(
+      {Allocate::make(b_, kInt, {Load::make(c, {0}, 1)}),
+       Store::make(a, {0}, Load::make(c, {0}, 1), 1),
+       Store::make(b, {0}, 0, 1),
+       For::make(
+           x,
+           0,
+           10,
+           Block::make(
+               {Store::make(b, {0}, Add::make(Load::make(b, {0}, 1), x), 1),
+                Store::make(a, {0}, Load::make(c, {0}, 1), 1)})),
+       Free::make(b_)});
+
+  /*
+   * Allocate(B, int, {C[0]});
+   * A[0] = C[0];
+   * B[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   B[0] = (B[0]) + x;
+   *   A[0] = C[0];
+   * }
+   * Free(B);
+   */
+
+  registerize(stmt);
+
+  /*
+   * int C_ = C[0];
+   * int A_ = C_;
+   * int B_ = 0;
+   * Allocate(B, int, {C_});
+   * for (int x = 0; x < 10; x++) {
+   *   B_ = B_ + x;
+   *   A_ = C_;
+   * }
+   * B[0] = B_;
+   * A[0] = A_;
+   * Free(B);
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int C_ = C[0];
+# CHECK: int A_ = C_;
+# CHECK: int B_ = 0;
+# CHECK: Allocate(B
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK:   B_ =
+# CHECK:   A_ = C_
+# CHECK: B[0] = B_;
+# CHECK: A[0] = A_;
+# CHECK: Free(B)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+void testRegisterizerNoInitializer() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt = Block::make({For::make(
+      x,
+      0,
+      10,
+      Block::make(
+          {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+
+  /*
+   * for (int x = 0; x < 10; x++) {
+   *   A[0] = (A[0]) + x;
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = A[0];
+   * for (int x = 0; x < 10; x++) {
+   *   A_ = x + A_;
+   * }
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = A[0];
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: A[
+# CHECK:   A_ =
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+void testRegisterizerLoadThenStore() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  Buffer b(BufHandle("B", {1}, kInt));
+  VarHandle x("x", kInt);
+  Stmt* stmt = Block::make({For::make(
+      x,
+      0,
+      10,
+      Block::make({Store::make(b, {0}, Add::make(Load::make(a, {0}, 1), x), 1),
+                   Store::make(a, {0}, Load::make(b, {0}, 1), 1)}))});
+
+  /*
+   * for (int x = 0; x < 10; x++) {
+   *   B[0] = (A[0]) + x;
+   *   A[0] = B[0];
+   * }
+   */
+
+  registerize(stmt);
+
+  /*
+   * int A_ = A[0];
+   * int B_ = B[0];
+   * for (int x = 0; x < 10; x++) {
+   *   B_ = x + A_;
+   *   A_ = B_;
+   * }
+   * B[0] = B_;
+   * A[0] = A_;
+   */
+
+  std::ostringstream oss;
+  oss << *stmt;
+
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: int A_ = A[0];
+# CHECK: int B_ = B[0];
+# CHECK: for (int x = 0; x < 10; x++)
+# CHECK-NOT: B[
+# CHECK:   B_ =
+# CHECK-NOT: A[
+# CHECK:   A_ = B_
+# CHECK: B[0] = B_
+# CHECK: A[0] = A_;)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+void testRegisterizerParallelized() {
+  KernelScope kernel_scope;
+  Buffer a(BufHandle("A", {1}, kInt));
+  VarHandle x("x", kInt);
+  LoopOptions loopOpts;
+  loopOpts.set_gpu_block_index(0);
+  Stmt* stmt =
+      Block::make({Store::make(a, {0}, 0, 1),
+                   For::make(
+                       x,
+                       0,
+                       10,
+                       Block::make({Store::make(
+                           a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}),
+                       loopOpts)});
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; x++) {
+   *   A[0] = (A[0]) + x;
+   * }
+   */
+
+  ASSERT_THROWS_WITH(
+      registerize(stmt),
+      "Registerization must occur after parallelism flattening");
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -172,6 +172,22 @@ namespace jit {
   _(SimplifyEliminateEmptyFor)              \
   _(SimplifyFlattenBlock)                   \
   _(SimplifyEliminateZeroLengthAlloc)       \
+  _(RegisterizerSimple)                     \
+  _(RegisterizerLoop)                       \
+  _(RegisterizerLoopFixedLoad)              \
+  _(RegisterizerMultiVar)                   \
+  _(RegisterizerVariableLoad)               \
+  _(RegisterizerSymbolicIndices)            \
+  _(RegisterizerEarlyStop)                  \
+  _(RegisterizerMultiLoop)                  \
+  _(RegisterizerRepeated)                   \
+  _(RegisterizerNoLoads)                    \
+  _(RegisterizerNoRepeatedStores)           \
+  _(RegisterizerMultiVarOverlap)            \
+  _(RegisterizerAllocs)                     \
+  _(RegisterizerNoInitializer)              \
+  _(RegisterizerLoadThenStore)              \
+  _(RegisterizerParallelized)               \
   _(StmtClone)                              \
   _(BoundsInference_1)                      \
   _(BoundsInference_2)                      \

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -241,6 +241,7 @@ core_sources_full = [
     "torch/csrc/jit/tensorexpr/llvm_jit.cpp",
     "torch/csrc/jit/tensorexpr/loopnest.cpp",
     "torch/csrc/jit/tensorexpr/mem_arena.cpp",
+    "torch/csrc/jit/tensorexpr/registerizer.cpp",
     "torch/csrc/jit/tensorexpr/tensor.cpp",
     "torch/csrc/jit/tensorexpr/types.cpp",
     "torch/csrc/jit/tensorexpr/unique_name_manager.cpp",

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -46,6 +46,27 @@ class NodeFinder : public IRVisitor {
   std::vector<Node*> nodes;
 };
 
+class VarFinder : public IRVisitor {
+ public:
+  virtual void visit(const Var* v) override {
+    vars_.insert(v);
+    IRVisitor::visit(v);
+  }
+
+  static std::unordered_set<const Var*> find(Stmt* s) {
+    VarFinder nf;
+    s->accept(&nf);
+    return nf.vars();
+  }
+
+  const std::unordered_set<const Var*>& vars() {
+    return vars_;
+  }
+
+ private:
+  std::unordered_set<const Var*> vars_;
+};
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -55,7 +55,7 @@ Load::Load(
     const std::vector<const Expr*>& indices,
     const Expr* mask)
     : ExprNodeBase(dtype), buf_(buf), indices_(indices), mask_(mask) {
-  if (buf->base_handle()->dtype() != kHandle) {
+  if (indices_.size() > 0 && buf->base_handle()->dtype() != kHandle) {
     throw malformed_input(
         "Load base handle dtype must be Handle", buf->base_handle());
   }
@@ -102,7 +102,7 @@ Store::Store(
     const Expr* value,
     const Expr* mask)
     : buf_(buf), indices_(std::move(indices)), value_(value), mask_(mask) {
-  if (buf->base_handle()->dtype() != kHandle) {
+  if (indices_.size() > 0 && buf->base_handle()->dtype() != kHandle) {
     throw malformed_input("Store base handle must be Handle");
   }
   /*

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -232,18 +232,22 @@ void IRPrinter::visit(const Ramp* v) {
 
 void IRPrinter::visit(const Load* v) {
   // TODO: support the mask case
-  os() << *v->base_handle() << "[";
-  size_t i = 0;
-  for (const Expr* ind : v->indices()) {
-    if (i++) {
-      os() << ", ";
+  if (v->indices().size() == 0) {
+    os() << *v->base_handle();
+  } else {
+    os() << *v->base_handle() << "[";
+    size_t i = 0;
+    for (const Expr* ind : v->indices()) {
+      if (i++) {
+        os() << ", ";
+      }
+      ind->accept(this);
     }
-    ind->accept(this);
+    if (v->indices().empty()) {
+      os() << "0";
+    }
+    os() << "]";
   }
-  if (v->indices().empty()) {
-    os() << "0";
-  }
-  os() << "]";
 }
 
 void IRPrinter::visit(const Broadcast* v) {
@@ -355,6 +359,11 @@ void IRPrinter::visit(const ReduceOp* v) {
 void IRPrinter::visit(const Store* v) {
   // TODO: handle the mask
   emitIndent();
+  if (v->indices().size() == 0) {
+    os() << *v->base_handle() << " = " << *v->value() << ";" << std::endl;
+    return;
+  }
+
   os() << *v->base_handle() << "[";
   size_t i = 0;
   for (const Expr* ind : v->indices()) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1571,6 +1571,18 @@ Stmt* TermExpander::mutate(const Free* v) {
   return new Free(buffer_var_new);
 }
 
+bool exprEquals(const Expr* A, const Expr* B) {
+  try {
+    const Expr* diff = IRSimplifier::simplify(new Sub(A, B));
+    if (!diff->isConstant()) {
+      return false;
+    }
+    return immediateEquals(diff, 0);
+  } catch (std::exception& e) {
+    return false;
+  }
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -481,6 +481,9 @@ class TORCH_API IRSimplifier {
   }
 };
 
+// Returns true if expressions A and B can be simplified to an equal expression.
+TORCH_API bool exprEquals(const Expr* A, const Expr* B);
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -1,0 +1,319 @@
+#include <torch/csrc/jit/tensorexpr/registerizer.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+void RegisterizerAnalysis::visit(const For* v) {
+  if (v->loop_options().is_gpu_block_index() ||
+      v->loop_options().is_gpu_thread_index()) {
+    throw malformed_input(
+        "Registerization must occur after parallelism flattening");
+  }
+
+  const Expr* old_loopCost = loopCost_;
+  loopCost_ = IRSimplifier::simplify(
+      new Mul(loopCost_, new Sub(v->stop(), v->start())));
+  stmtStack_.push_front(v);
+  v->body()->accept(this);
+  stmtStack_.pop_front();
+
+  loopCost_ = old_loopCost;
+};
+
+void RegisterizerAnalysis::visit(const Block* v) {
+  const Block* last = enclosingBlock_;
+  enclosingBlock_ = v;
+  stmtStack_.push_front(v);
+  costByBlock_[v] = loopCost_;
+  IRVisitor::visit(v);
+  stmtStack_.pop_front();
+  enclosingBlock_ = last;
+}
+
+void RegisterizerAnalysis::visit(const Store* v) {
+  // path into value first.
+  stmtStack_.push_front(v);
+  v->value()->accept(this);
+  stmtStack_.pop_front();
+
+  if (v->indices().empty()) {
+    // already a scalar.
+    return;
+  }
+
+  SimplifierHashType accessHash = hasher_.hash(v->buf());
+  for (auto* i : v->indices()) {
+    accessHash = hasher_.hash_combine(accessHash, i);
+  }
+  accessHash = hasher_.hash_combine(accessHash, v->mask());
+
+  std::shared_ptr<AccessInfo> info;
+  auto candidateIt = candidates_.find(accessHash);
+  if (candidateIt != candidates_.end()) {
+    info = candidateIt->second;
+  } else {
+    info = std::make_shared<AccessInfo>(v->buf(), v->indices());
+    candidates_[accessHash] = info;
+    encounterOrder_.push_back(info);
+  }
+  info->addStore(v, enclosingBlock_, loopCost_);
+}
+
+void RegisterizerAnalysis::visit(const Load* v) {
+  if (v->indices().empty()) {
+    // already a scalar.
+    return;
+  }
+
+  SimplifierHashType accessHash = hasher_.hash(v->buf());
+  for (auto* i : v->indices()) {
+    accessHash = hasher_.hash_combine(accessHash, i);
+  }
+  accessHash = hasher_.hash_combine(accessHash, v->mask());
+
+  std::shared_ptr<AccessInfo> info;
+  auto candidateIt = candidates_.find(accessHash);
+  if (candidateIt != candidates_.end()) {
+    info = candidateIt->second;
+  } else {
+    info = std::make_shared<AccessInfo>(v->buf(), v->indices());
+    candidates_[accessHash] = info;
+    encounterOrder_.push_back(info);
+  }
+
+  info->addLoad(v, enclosingBlock_, loopCost_, stmtStack_.front());
+}
+
+std::vector<std::shared_ptr<AccessInfo>> RegisterizerAnalysis::getCandidates() {
+  std::vector<std::shared_ptr<AccessInfo>> ret;
+
+  // Group accesses by the base buffer they refer to, so it's easier to
+  // determine which accesses may overlap.
+  std::unordered_map<const Buf*, std::vector<std::shared_ptr<AccessInfo>>>
+      access_by_buf;
+  for (const auto& pair : candidates_) {
+    std::shared_ptr<AccessInfo> info = pair.second;
+
+    // We can "hoist" an access up the syntax tree if it's indices do not
+    // depend on any loop vars.
+    VarFinder vf;
+    for (auto* i : info->indices) {
+      i->accept(&vf);
+    }
+
+    const Stmt* ancestor = info->parent;
+    const Stmt* target = nullptr;
+    while (ancestor) {
+      if (const For* f = dynamic_cast<const For*>(ancestor)) {
+        if (vf.vars().count(f->var()) != 0) {
+          break;
+        }
+        target = f->get_parent();
+      }
+
+      ancestor = ancestor->get_parent();
+    }
+
+    if (info->parent != target) {
+      if (const Block* new_parent = dynamic_cast<const Block*>(target)) {
+        info->parent = new_parent;
+      }
+    }
+
+    // Now that analysis is complete we must normalize the costs by the
+    // parent Block we plan to insert the scalar var into.
+    info->store_cost = IRSimplifier::simplify(
+        new Div(info->store_cost, costByBlock_[info->parent]));
+
+    if (!info->loads.empty()) {
+      info->load_cost = IRSimplifier::simplify(
+          new Div(info->load_cost, costByBlock_[info->parent]));
+    }
+
+    access_by_buf[info->buf].push_back(info);
+  }
+
+  // For each buffer, for each access, determine if another access to the
+  // buffer could possibly write to the same region.
+  for (const auto& pair : access_by_buf) {
+    const Buf* buf = pair.first;
+    const std::vector<std::shared_ptr<AccessInfo>>& accesses = pair.second;
+    for (const auto& info : accesses) {
+      // Filter out low cost accesses.
+      if (info->store_cost->isConstant() &&
+          immediateAs<int>(info->store_cost) <= 1 &&
+          info->load_cost->isConstant() &&
+          immediateAs<int>(info->load_cost) <= 1) {
+        info->invalid = true;
+        continue;
+      }
+
+      // TODO: this is n^2 by the number of accesses to a single buffer
+      // program wide, may be an issue in large programs.
+      for (const auto& i2 : accesses) {
+        if (info == i2) {
+          continue;
+        }
+
+        // All accesses to a buf must have the same dimensionality.
+        assert(info->indices.size() == i2->indices.size());
+
+        // They don't overlap if there is a guaranteed difference in any
+        // dimension.
+        bool overlap = true;
+        for (size_t i = 0; i < info->indices.size(); ++i) {
+          const Expr* diff = new Sub(info->indices[i], i2->indices[i]);
+          diff = IRSimplifier::simplify(diff);
+          if (diff->isConstant() && !immediateEquals(diff, 0)) {
+            overlap = false;
+            break;
+          }
+        }
+
+        if (overlap) {
+          info->invalid = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // Return valid access candidates in the order they were first seen.
+  for (const auto& info : encounterOrder_) {
+    if (!info->invalid) {
+      ret.push_back(info);
+    }
+  }
+
+  return ret;
+}
+
+const Expr* RegisterizerReplacer::mutate(const Load* v) {
+  if (v->buf() != info_->buf) {
+    return IRMutator::mutate(v);
+  }
+
+  initializerReady_ = false;
+
+  // sanity check indices for the same buf must have the same dimensionality.
+  assert(v->indices().size() == info_->indices.size());
+  for (size_t i = 0; i < info_->indices.size(); ++i) {
+    if (!exprEquals(v->indices()[i], info_->indices[i])) {
+      return IRMutator::mutate(v);
+    }
+  }
+
+  return var_;
+}
+
+Stmt* RegisterizerReplacer::mutate(const Store* v) {
+  if (v->buf() != info_->buf) {
+    return IRMutator::mutate(v);
+  }
+
+  if (initializerReady_ && info_->parent == v->get_parent()) {
+    initializer_ = v;
+    initializerReady_ = false;
+    // This is the easiest way to return an empty statement;
+    return new Block({});
+  }
+
+  initializerReady_ = false;
+
+  // sanity check indices for the same buf must have the same dimensionality.
+  assert(v->indices().size() == info_->indices.size());
+  for (size_t i = 0; i < info_->indices.size(); ++i) {
+    if (!exprEquals(v->indices()[i], info_->indices[i])) {
+      return IRMutator::mutate(v);
+    }
+  }
+  const Expr* new_val = v->value()->accept_mutator(this);
+
+  Store* s = new Store(var_wrapper_, {}, new_val, v->mask());
+  return s;
+}
+
+// Finds the Stmt in parent which contains stmt.
+const Stmt* RegisterizerReplacer::findInsertionPoint(
+    const Stmt* stmt,
+    const Block* parent) {
+  while (stmt) {
+    if (stmt->get_parent() == parent) {
+      return stmt;
+    }
+    stmt = stmt->get_parent();
+  }
+  return nullptr;
+}
+
+Stmt* RegisterizerReplacer::mutate(const Block* v) {
+  // We need to mutate this block in place, rather than clone - since other
+  // AccessInfo objects may hold a pointer to it.
+  Block* v1 = const_cast<Block*>(v); // NOLINT
+  assert(v1);
+
+  Stmt* first_changed{nullptr};
+  Stmt* last_changed{nullptr};
+  std::list<Stmt*> stmts = v1->stmts();
+  for (Stmt* stmt : stmts) {
+    dirty_ = false;
+    Stmt* stmt_new = stmt->accept_mutator(this);
+    if (dirty_) {
+      first_changed = first_changed ? first_changed : stmt_new;
+      last_changed = stmt_new;
+    }
+
+    if (stmt_new == stmt) {
+      continue;
+    }
+    v1->replace_stmt(stmt, stmt_new);
+    first_changed = first_changed ? first_changed : stmt_new;
+    last_changed = stmt_new;
+  }
+
+  dirty_ = first_changed != nullptr;
+
+  if (v != info_->parent) {
+    return v1;
+  }
+
+  Stmt* let;
+  // If we didn't find an initial store: intialize with the original buffer.
+  if (!initializer_) {
+    let = new Let(
+        var_,
+        new Load(
+            info_->buf->base_handle()->dtype(),
+            info_->buf,
+            info_->indices,
+            new IntImm(1)));
+  } else {
+    let = new Let(var_, initializer_->value());
+  }
+  v1->insert_stmt_before(let, first_changed);
+
+  // If it was written to the buffer, make sure we write it out.
+  if (info_->stores.size() > 0) {
+    v1->insert_stmt_after(
+        new Store(info_->buf, info_->indices, var_, new IntImm(1)),
+        last_changed);
+  }
+  return v1;
+}
+
+// Apply scalar replacement to all accesses in s.
+Stmt* registerize(Stmt* s) {
+  RegisterizerAnalysis analysis;
+  s->accept(&analysis);
+  auto candidates = analysis.getCandidates();
+  for (const auto& info : candidates) {
+    RegisterizerReplacer replacer(info);
+    s = s->accept_mutator(&replacer);
+  }
+  return s;
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -1,0 +1,164 @@
+#pragma once
+#include <c10/core/ScalarType.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <vector>
+
+#include <torch/csrc/jit/tensorexpr/hash_provider.h>
+#include <torch/csrc/jit/tensorexpr/ir_mutator.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/ir_visitor.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+/* The Registerizer performs scalar replacement by looking for common Stores and
+Loads to a single item in a buffer and replacing them with a local temporary
+scalar which is cheaper to write.
+
+For example it can replace:
+
+{
+  A[0] = 0;
+  for (int x = 0; x < 10; x++) {
+    A[0] = (A[0]) + x;
+  }
+}
+
+with:
+
+{
+  int A_ = 0;
+  for (int x = 0; x < 10; x++) {
+    A_ = x + A_;
+  }
+  A[0] = A_;
+}
+
+This is particularly useful on GPUs when parallelizing, since after replacing
+loops with metavars we have a lot of accesses like this. */
+
+// Holds analysis information about accesses to a specific range of a
+// buffer, including the number of loads and stores and the lowest common
+// parent Block.
+struct AccessInfo {
+  AccessInfo() = default;
+  AccessInfo(const Buf* b, const std::vector<const Expr*>& i)
+      : buf(b),
+        indices(i),
+        store_cost(new IntImm(0)),
+        load_cost(new IntImm(0)) {}
+
+  void addStore(const Store* s, const Block* p, const Expr* cost) {
+    store_cost = IRSimplifier::simplify(new Add(store_cost, cost));
+    stores.push_back(s);
+    parent = parent ? Block::getSharedParent(parent, p) : p;
+    first_usage = first_usage ? first_usage : s;
+  }
+
+  void addLoad(
+      const Load* l,
+      const Block* p,
+      const Expr* cost,
+      const Stmt* usage) {
+    load_cost = IRSimplifier::simplify(new Add(load_cost, cost));
+    loads.push_back(l);
+    parent = parent ? Block::getSharedParent(parent, p) : p;
+    first_usage = first_usage ? first_usage : usage;
+  }
+
+  const Buf* buf;
+  std::vector<const Expr*> indices;
+  const Block* parent{nullptr};
+
+  const Stmt* first_usage{nullptr};
+
+  const Expr* store_cost;
+  const Expr* load_cost;
+
+  std::vector<const Store*> stores;
+  std::vector<const Load*> loads;
+
+  bool invalid{false};
+};
+
+// Walks the IR generating AccessInfo for each access.
+class TORCH_API RegisterizerAnalysis : public IRVisitor {
+ public:
+  RegisterizerAnalysis() : loopCost_(new IntImm(1)) {}
+  virtual ~RegisterizerAnalysis() {}
+
+  void visit(const For* v) override;
+
+  void visit(const Block* v) override;
+
+  void visit(const Store* v) override;
+
+  void visit(const Load* v) override;
+
+#define STMT_ON_STACK(Op)                    \
+  virtual void visit(const Op* v) override { \
+    stmtStack_.push_front(v);                \
+    IRVisitor::visit(v);                     \
+    stmtStack_.pop_front();                  \
+  }
+
+  STMT_ON_STACK(AtomicAdd);
+  STMT_ON_STACK(Allocate);
+  STMT_ON_STACK(Free);
+  STMT_ON_STACK(Let);
+  STMT_ON_STACK(Cond);
+
+#undef STMT_ON_STACK
+
+  std::vector<std::shared_ptr<AccessInfo>> getCandidates();
+
+ private:
+  std::unordered_map<SimplifierHashType, std::shared_ptr<AccessInfo>>
+      candidates_;
+  std::unordered_map<const Block*, const Expr*> costByBlock_;
+  std::vector<std::shared_ptr<AccessInfo>> encounterOrder_;
+
+  const Expr* loopCost_;
+
+  std::deque<const Stmt*> stmtStack_;
+  const Block* enclosingBlock_;
+  HashProvider hasher_;
+};
+
+// Walks the IR an replaces a single Acccess with a local scalar Var.
+class TORCH_API RegisterizerReplacer : public IRMutator {
+ public:
+  RegisterizerReplacer(std::shared_ptr<AccessInfo> i) : info_(i) {
+    var_ = new Var(info_->buf->name_hint() + "_", info_->buf->dtype());
+    var_wrapper_ = new Buf(var_, {}, info_->buf->dtype());
+
+    initializer_ = nullptr;
+  }
+
+  const Expr* mutate(const Load* v) override;
+
+  Stmt* mutate(const Store* v) override;
+
+  // Finds the Stmt in parent which contains stmt.
+  const Stmt* findInsertionPoint(const Stmt* stmt, const Block* parent);
+
+  Stmt* mutate(const Block* v) override;
+
+ private:
+  std::shared_ptr<AccessInfo> info_;
+  Var* var_;
+  Buf* var_wrapper_;
+  const Store* initializer_;
+  bool dirty_{false};
+  bool initializerReady_{true};
+};
+
+// Apply scalar replacement to all accesses in s.
+// To produce safe code, this must occur after handling parallelized axes and
+// atomics.
+TORCH_API Stmt* registerize(Stmt* s);
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -99,7 +99,7 @@ class TORCH_API Block : public StmtNode<Block> {
     set_parent(s, this);
   }
 
-  void insert_stmt_before(Stmt* s, Stmt* before) {
+  void insert_stmt_before(Stmt* s, const Stmt* before) {
     if (s->get_parent()) {
       throw malformed_input("Block append Stmt with existing parent", s);
     }
@@ -114,7 +114,7 @@ class TORCH_API Block : public StmtNode<Block> {
     set_parent(s, this);
   }
 
-  void insert_stmt_after(Stmt* s, Stmt* after) {
+  void insert_stmt_after(Stmt* s, const Stmt* after) {
     if (s->get_parent()) {
       throw malformed_input("Block append Stmt with existing parent", s);
     }
@@ -216,6 +216,32 @@ class TORCH_API Block : public StmtNode<Block> {
     }
 
     stmts_.splice(it, other->stmts_);
+  }
+
+  static const Block* getSharedParent(const Stmt* p1, const Stmt* p2) {
+    std::unordered_set<const Block*> enclosing;
+
+    const Stmt* p1_p = p1;
+    while (p1_p) {
+      if (const Block* b = dynamic_cast<const Block*>(p1_p)) {
+        if (b) {
+          enclosing.insert(b);
+        }
+      }
+      p1_p = p1_p->get_parent();
+    }
+
+    const Stmt* p2_p = p2;
+    while (p2_p) {
+      if (const Block* b = dynamic_cast<const Block*>(p2_p)) {
+        if (enclosing.count(b) != 0) {
+          return b;
+        }
+      }
+      p2_p = p2_p->get_parent();
+    }
+
+    return nullptr;
   }
 
  private:

--- a/torch/csrc/jit/tensorexpr/var_substitutor.h
+++ b/torch/csrc/jit/tensorexpr/var_substitutor.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_mutator.h>
 #include <torch/csrc/jit/tensorexpr/ir_visitor.h>
@@ -13,23 +14,6 @@ namespace jit {
 namespace tensorexpr {
 
 using VarMapping = std::vector<std::pair<const Var*, const Expr*>>;
-
-// Finds all Vars present in a subexpr.
-class VarFinder : public IRVisitor {
- public:
-  std::set<const Var*> findVars(const Expr* expr) {
-    vars_.clear();
-    expr->accept(this);
-    return vars_;
-  }
-
-  void visit(const Var* v) {
-    vars_.insert(v);
-  }
-
- private:
-  std::set<const Var*> vars_;
-};
 
 class VarSubMutator : public IRMutator {
  public:
@@ -67,7 +51,8 @@ class VarSubMutator : public IRMutator {
         new_inner.push_back(new_var);
       } else {
         VarFinder varFinder;
-        auto varlist = varFinder.findVars(e);
+        e->accept(&varFinder);
+        auto varlist = varFinder.vars();
         new_inner.insert(new_inner.end(), varlist.begin(), varlist.end());
       }
     }


### PR DESCRIPTION
Adds a new optimization pass, the Registerizer, which looks for common Stores and Loads to a single item in a buffer and replaces them with a local temporary scalar which is cheaper to write.

For example it can replace:
```
A[0] = 0;
for (int x = 0; x < 10; x++) {
  A[0] = (A[0]) + x;
}
```

with:
```
int A_ = 0;
for (int x = 0; x < 10; x++) {
  A_ = x + A_;
}
A[0] = A_;
```

This is particularly useful on GPUs when parallelizing, since after replacing loops with metavars we have a lot of accesses like this. Early tests of simple reductions on a V100 indicates this can speed them up by ~5x. 

This diff got a bit unwieldy with the integration code so that will come in a follow up.