### PR TITLE
Remove explicit use of infer_size in BCE loss

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -164,13 +164,7 @@ inline Tensor binary_cross_entropy(
       "Please ensure they have the same size.");
   }
 
-  auto weight_ = weight;
-  if (weight_.defined()) {
-    auto new_size = at::infer_size(target.sizes(), weight_.sizes());
-    weight_ = weight_.expand(new_size);
-  }
-
-  return torch::binary_cross_entropy(input, target, weight_, reduction_enum);
+  return torch::binary_cross_entropy(input, target, weight, reduction_enum);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5,7 +5,7 @@ import warnings
 import math
 
 import torch
-from torch._C import _infer_size, _add_docstr
+from torch._C import _add_docstr
 from . import _reduction as _Reduction
 from .modules import utils
 from .modules.utils import _single, _pair, _triple, _list_with_default
@@ -2510,10 +2510,6 @@ def binary_cross_entropy(input, target, weight=None, size_average=None,
     if target.size() != input.size():
         raise ValueError("Using a target size ({}) that is different to the input size ({}) is deprecated. "
                          "Please ensure they have the same size.".format(target.size(), input.size()))
-
-    if weight is not None:
-        new_size = _infer_size(target.size(), weight.size())
-        weight = weight.expand(new_size)
 
     return torch._C._nn.binary_cross_entropy(
         input, target, weight, reduction_enum)


### PR DESCRIPTION
Fixes #40679
infer_size behaves differently under tracing: in order to preserve
any data dependency on input sizes, it replaces the tuple(int)
representation of Size with tuple(1d-tensor) and piggybacks on the
tracing machinery in tensor.

In this case rather than implement a version of infer_size that
handles Size composed of tensors, recognize that infer_size is
not commonly used outside of cpp API and in the case of BCE loss,
a broadcast will happen in the kernel anyway.

Fixes #{issue number}
