### PR TITLE
[NNC] Remove VarBinding and go back to Let stmts

### DIFF
--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -69,10 +69,11 @@ void testExprLetStmtTest01() {
 
   ExprHandle load_a = Load::make(a_buf, {0}, 1);
   VarHandle var = VarHandle("v", kFloat);
+  Stmt* let_store = Let::make(var, load_a);
   Stmt* store_b = Store::make(b_buf, {0}, var, 1);
-  Stmt* let_store = Block::make({{var.node(), load_a.node()}}, {store_b});
+  Block* block = Block::make({let_store, store_b});
 
-  SimpleIREvaluator eval(let_store, a_buf, b_buf);
+  SimpleIREvaluator eval(block, a_buf, b_buf);
 
   PaddedBuffer<float> a_v(1);
   PaddedBuffer<float> b_v(1);

--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -166,15 +166,14 @@ void testLLVMLetTest01() {
   std::vector<float> v = {1, 0};
   std::vector<void*> args({v.data()});
   VarHandle x("x", kFloat);
-  auto block = Block::make(
-      {{x.node(), new FloatImm(3.f)}},
-      {
-          Store::make(
-              a,
-              {IntImm::make(0)},
-              ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f)),
-              IntImm::make(1)),
-      });
+  auto block = Block::make({
+      Let::make(x, 3.f),
+      Store::make(
+          a,
+          {IntImm::make(0)},
+          ExprHandle(2.f) + (x * ExprHandle(3.f) + ExprHandle(4.f)),
+          IntImm::make(1)),
+  });
 
   LLVMCodeGen cg(block, {a});
   ASSERT_EQ(cg.value<int>(args), 0);
@@ -189,15 +188,15 @@ void testLLVMLetTest02() {
   std::vector<void*> args({v.data()});
   VarHandle x("x", kFloat);
   VarHandle y("y", kFloat);
-  auto block = Block::make(
-      {{x.node(), new FloatImm(3.f)}, {y.node(), new FloatImm(6.f)}},
-      {
-          Store::make(
-              a,
-              {IntImm::make(0)},
-              ExprHandle(2.f) + (x * ExprHandle(3.f) + y * ExprHandle(4.f)),
-              IntImm::make(1)),
-      });
+  auto block = Block::make({
+      Let::make(x, 3.f),
+      Let::make(y, 6.f),
+      Store::make(
+          a,
+          {IntImm::make(0)},
+          ExprHandle(2.f) + (x * ExprHandle(3.f) + y * ExprHandle(4.f)),
+          IntImm::make(1)),
+  });
 
   LLVMCodeGen cg(block, {a});
   ASSERT_EQ(cg.value<int>(args), 0);
@@ -212,18 +211,17 @@ void testLLVMLetTestMultitype() {
   std::vector<void*> args({v.data()});
   VarHandle x("x", kByte);
   VarHandle y("y", kHalf);
-  auto block = Block::make(
-      {{x.node(), new ByteImm(3)}, {y.node(), new HalfImm(6.f)}},
-      {
-          Store::make(
-              a,
-              {IntImm::make(0)},
-              Cast::make(
-                  kDouble,
-                  ExprHandle(2.f) +
-                      (x * ExprHandle(3.f) + y * ExprHandle(4.f))),
-              IntImm::make(1)),
-      });
+  auto block = Block::make({
+      Let::make(x, 3),
+      Let::make(y, 6.f),
+      Store::make(
+          a,
+          {IntImm::make(0)},
+          Cast::make(
+              kDouble,
+              ExprHandle(2.f) + (x * ExprHandle(3.f) + y * ExprHandle(4.f))),
+          IntImm::make(1)),
+  });
 
   LLVMCodeGen cg(block, {a});
   ASSERT_EQ(cg.value<int>(args), 0);

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -208,7 +208,7 @@ namespace jit {
   _(UnrollMultipleStatements)               \
   _(UnrollEmpty)                            \
   _(NoUnroll)                               \
-  _(UnrollWithVarMap)                       \
+  _(UnrollWithLet)                          \
   _(Kernel_1)                               \
   _(Kernel_2)                               \
   _(Kernel_3)                               \

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -413,21 +413,6 @@ void CudaPrinter::visit(const IfThenElse* v) {
 void CudaPrinter::visit(const Block* v) {
   os() << "{" << std::endl;
   indent_++;
-  for (const auto& pair : v->varBindings()) {
-    emitIndent();
-    const Var* var = pair.first;
-    const Expr* val = pair.second;
-
-    if (var->dtype().scalar_type() == ScalarType::Half) {
-      // we do math in floats so use that.
-      os() << "float";
-    } else {
-      os() << cudaDtypeCppString(var->dtype());
-    }
-    os() << " " << *var << " = ";
-    val->accept(this);
-    os() << "; " << std::endl;
-  }
 
   for (Stmt* s : v->stmts()) {
     s->accept(this);
@@ -436,6 +421,19 @@ void CudaPrinter::visit(const Block* v) {
   indent_--;
   emitIndent();
   os() << "}";
+}
+
+void CudaPrinter::visit(const Let* v) {
+  emitIndent();
+  if (v->dtype().scalar_type() == ScalarType::Half) {
+    // we do math in floats so use that.
+    os() << "float";
+  } else {
+    os() << cudaDtypeCppString(v->dtype());
+  }
+  os() << " " << *v->var() << " = ";
+  v->value()->accept(this);
+  os() << ";" << std::endl;
 }
 
 class PrioritizeLoad : public IRMutator {
@@ -552,14 +550,23 @@ class PrioritizeLoad : public IRMutator {
       return stmt;
     }
 
+    // TODO: this probably isn't going to order nicely in all cases, vars need
+    // too be inserted before their first usage.
     if (Block* b = dynamic_cast<Block*>(stmt)) {
+      Stmt* last = nullptr;
       for (const auto& pair : load_list) {
-        b->add_var_binding(pair.first, pair.second);
+        Stmt* news = new Let(pair.first, pair.second);
+        if (last == nullptr) {
+          b->prepend_stmt(news);
+        } else {
+          b->insert_stmt_after(news, last);
+        }
+        last = news;
       }
       return b;
     }
 
-    return Block::make(load_list, {stmt});
+    return Block::make({stmt});
   }
 
   MemoryLoadStack load_stack_;
@@ -591,12 +598,12 @@ std::string CudaCodeGen::GetUniqueFuncName(const std::string& func_prefix) {
 // and wrap them under a trivial thread idx.
 class NoThreadIdxRewriter : public IRMutator {
  private:
-  Stmt* rewrite(const VarMapping& vars, const std::vector<Stmt*>& stmts) {
+  Stmt* rewrite(const std::vector<Stmt*>& stmts) {
     std::vector<Stmt*> cloned_stmts(stmts.size());
     for (size_t index = 0; index < stmts.size(); index++) {
       cloned_stmts[index] = Stmt::clone(stmts[index]);
     }
-    Stmt* new_block = Block::make(vars, cloned_stmts);
+    Stmt* new_block = Block::make(cloned_stmts);
     // Wrap the new block under a trivial thread-idx
     //   for t in 0..1: // threadIdx
     //     if (t < 1):
@@ -672,7 +679,7 @@ class NoThreadIdxRewriter : public IRMutator {
       Stmt* parent = v->get_parent();
       For* loop_parent = dynamic_cast<For*>(parent);
       if (loop_parent && loop_parent->loop_options().is_gpu_block_index()) {
-        Stmt* new_block = rewrite(v->varBindings(), new_stmts);
+        Stmt* new_block = rewrite(new_stmts);
         return new_block;
       }
       need_rewrite_ = true;
@@ -699,12 +706,12 @@ class NoThreadIdxRewriter : public IRMutator {
       // Rewrite the stmts from [start, stop)
       std::vector<Stmt*> stmts_to_rewrite(
           new_stmts.begin() + start, new_stmts.begin() + stop);
-      Stmt* rewritten_stmt = rewrite(v->varBindings(), stmts_to_rewrite);
+      Stmt* rewritten_stmt = rewrite(stmts_to_rewrite);
       rewrite_stmts.push_back(rewritten_stmt);
 
       start = stop;
     }
-    Stmt* rewritten_block = Block::make(v->varBindings(), rewrite_stmts);
+    Stmt* rewritten_block = Block::make(rewrite_stmts);
     return rewritten_block;
   }
 

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -60,6 +60,7 @@ class CudaPrinter : public IRPrinter {
   void visit(const Block* v) override;
   void visit(const Allocate* v) override;
   void visit(const Free* v) override;
+  void visit(const Let* v) override;
 
   const std::vector<const Expr*>& gpu_block_extents() const {
     return gpu_block_extents_;

--- a/torch/csrc/jit/tensorexpr/hash_provider.cpp
+++ b/torch/csrc/jit/tensorexpr/hash_provider.cpp
@@ -184,11 +184,6 @@ void HashProvider::visit(const Store* v) {
 void HashProvider::visit(const Block* v) {
   CACHE_GUARD();
   SimplifierHashType hash;
-  for (const auto& pair : v->varBindings()) {
-    pair.first->accept(this);
-    pair.second->accept(this);
-    hash = hash_combine(hash, hashOf(pair.first), hashOf(pair.second));
-  }
 
   for (Stmt* s : *v) {
     s->accept(this);

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -307,18 +307,6 @@ Stmt* IRMutator::mutate(const For* v) {
 Stmt* IRMutator::mutate(const Block* v) {
   bool any_change = false;
 
-  Block::VarMapping varMapping;
-  for (const auto& pair : v->varBindings()) {
-    const Var* new_var =
-        static_cast<const Var*>(pair.first->accept_mutator(this));
-    const Expr* new_val = pair.second->accept_mutator(this);
-    if (new_var != pair.first || new_val != pair.second) {
-      any_change = true;
-    }
-
-    varMapping.push_back({new_var, new_val});
-  }
-
   std::vector<Stmt*> stmts;
   for (Stmt* stmt : *v) {
     Stmt* stmt_new = stmt->accept_mutator(this);
@@ -334,7 +322,7 @@ Stmt* IRMutator::mutate(const Block* v) {
   if (!any_change) {
     return (Stmt*)v;
   }
-  return Block::make(varMapping, stmts);
+  return Block::make(stmts);
 }
 
 Stmt* IRMutator::mutate(const Store* v) {
@@ -413,6 +401,20 @@ Stmt* IRMutator::mutate(const Free* v) {
   return new Free(buffer_var_new);
 }
 
+Stmt* IRMutator::mutate(const Let* v) {
+  const Var* var_old = v->var();
+  const Var* var_new = dynamic_cast<const Var*>(var_old->accept_mutator(this));
+
+  const Expr* val_old = v->value();
+  const Expr* val_new = val_old->accept_mutator(this);
+
+  if (var_new == var_old && val_old == val_new) {
+    return (Stmt*)v;
+  }
+
+  return new Let(var_new, val_new);
+}
+
 Stmt* IRMutator::mutate(const Cond* v) {
   const Expr* cond_old = v->condition();
   Stmt* true_old = v->true_stmt();
@@ -449,6 +451,7 @@ class StmtClone : public IRMutator {
   Stmt* mutate(const Store* v) override;
   Stmt* mutate(const Allocate* v) override;
   Stmt* mutate(const Free* v) override;
+  Stmt* mutate(const Let* v) override;
   Stmt* mutate(const Cond* v) override;
   Stmt* mutate(const AtomicAdd* v) override;
 };
@@ -465,7 +468,7 @@ Stmt* StmtClone::mutate(const Block* v) {
   for (Stmt* stmt : *v) {
     stmts.push_back(stmt->accept_mutator(this));
   }
-  return new Block(v->varBindings(), stmts);
+  return new Block(stmts);
 }
 
 Stmt* StmtClone::mutate(const Store* v) {
@@ -482,6 +485,10 @@ Stmt* StmtClone::mutate(const Allocate* v) {
 
 Stmt* StmtClone::mutate(const Free* v) {
   return new Free(v->buffer_var());
+}
+
+Stmt* StmtClone::mutate(const Let* v) {
+  return new Let(v->var(), v->value());
 }
 
 Stmt* StmtClone::mutate(const Cond* v) {

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -42,6 +42,7 @@ class Intrinsics;
 class FunctionCall;
 class Allocate;
 class Free;
+class Let;
 class Cond;
 class Stmt;
 class Term;
@@ -101,6 +102,7 @@ class TORCH_API IRMutator {
 
   virtual Stmt* mutate(const Allocate* v);
   virtual Stmt* mutate(const Free* v);
+  virtual Stmt* mutate(const Let* v);
   virtual Stmt* mutate(const Cond* v);
 
  protected:

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -393,14 +393,6 @@ void IRPrinter::visit(const Block* v) {
   os() << "{" << std::endl;
   indent_++;
 
-  for (const auto& pair : v->varBindings()) {
-    const Var* var = pair.first;
-    const Expr* val = pair.second;
-    emitIndent();
-    os() << var->dtype().ToCppString() << " " << *var << " = " << *val << "; "
-         << std::endl;
-  }
-
   for (Stmt* s : *v) {
     os() << *s;
   }
@@ -426,6 +418,13 @@ void IRPrinter::visit(const Allocate* v) {
 void IRPrinter::visit(const Free* v) {
   emitIndent();
   os() << "Free(" << *v->buffer_var() << ");" << std::endl;
+}
+
+void IRPrinter::visit(const Let* v) {
+  emitIndent();
+  os() << v->dtype().ToCppString() << " " << *v->var();
+  os() << " = " << *v->value();
+  os() << "; " << std::endl;
 }
 
 void IRPrinter::visit(const Cond* v) {

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -56,6 +56,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const Block* v) override;
   void visit(const Allocate* v) override;
   void visit(const Free* v) override;
+  void visit(const Let* v) override;
 
   std::ostream& os() {
     return printer_os_;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1162,7 +1162,6 @@ Stmt* IRSimplifierBase::mutate(const For* v) {
 }
 
 Stmt* IRSimplifierBase::mutate(const Block* v) {
-  auto vars = v->varBindings();
   std::vector<Stmt*> stmts;
   for (Stmt* stmt : *v) {
     Stmt* stmt_new = stmt->accept_mutator(this);
@@ -1171,10 +1170,6 @@ Stmt* IRSimplifierBase::mutate(const Block* v) {
     }
 
     if (auto* subBlock = dynamic_cast<Block*>(stmt_new)) {
-      for (auto& pair : subBlock->varBindings()) {
-        vars.emplace_back(pair.first, pair.second);
-      }
-
       for (Block::iterator I = subBlock->begin(), E = subBlock->end();
            I != E;) {
         // Be careful to avoid invalidating the iterator.
@@ -1187,7 +1182,7 @@ Stmt* IRSimplifierBase::mutate(const Block* v) {
     }
   }
 
-  return new Block(vars, stmts);
+  return new Block(stmts);
 }
 
 // TermExpander

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -116,10 +116,6 @@ void IRVisitor::visit(const AtomicAdd* v) {
 }
 
 void IRVisitor::visit(const Block* v) {
-  for (const auto& pair : v->varBindings()) {
-    pair.first->accept(this);
-    pair.second->accept(this);
-  }
   for (Stmt* s : *v) {
     s->accept(this);
   }
@@ -170,6 +166,11 @@ void IRVisitor::visit(const Allocate* v) {
 
 void IRVisitor::visit(const Free* v) {
   v->buffer_var()->accept(this);
+}
+
+void IRVisitor::visit(const Let* v) {
+  v->var()->accept(this);
+  v->value()->accept(this);
 }
 
 void IRVisitor::visit(const Cond* v) {

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -40,6 +40,7 @@ class Intrinsics;
 class FunctionCall;
 class Allocate;
 class Free;
+class Let;
 class Cond;
 class Term;
 class Polynomial;
@@ -91,6 +92,7 @@ class TORCH_API IRVisitor {
   virtual void visit(const FunctionCall* v);
   virtual void visit(const Allocate* v);
   virtual void visit(const Free* v);
+  virtual void visit(const Let* v);
   virtual void visit(const Cond* v);
   virtual void visit(const Term* v);
   virtual void visit(const Polynomial* v);

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -50,6 +50,8 @@ class LLVMCodeGenImpl : public IRVisitor {
 
   std::unordered_map<const Var*, int> varToArg_;
   std::unordered_map<const Var*, llvm::Value*> varToVal_;
+  std::unordered_map<const Block*, std::vector<const Var*>> scopeToVar_;
+  const Block* scope_;
 
  private:
   llvm::LLVMContext& getContext();
@@ -101,6 +103,7 @@ class LLVMCodeGenImpl : public IRVisitor {
   void visit(const FunctionCall* v) override;
   void visit(const Allocate* v) override;
   void visit(const Free* v) override;
+  void visit(const Let* v) override;
   void visit(const Cond* v) override;
 
   llvm::Value* emitUnmaskedLoad(llvm::Value* addr, llvm::Value* idx);
@@ -1011,24 +1014,21 @@ void LLVMCodeGenImpl::visit(const For* v) {
 }
 
 void LLVMCodeGenImpl::visit(const Block* v) {
-  for (auto pair : v->varBindings()) {
-    const Var* v = pair.first;
-    pair.second->accept(this);
-    if (!varToVal_.count(v)) {
-      varToVal_.emplace(v, value_);
-    } else {
-      throw std::runtime_error("var should not exist before");
-    }
-  }
+  const Block* last = scope_;
+  scope_ = v;
 
   for (Stmt* s : *v) {
     s->accept(this);
   }
 
-  for (auto pair : v->varBindings()) {
-    const Var* v = pair.first;
-    if (varToVal_.erase(v) != 1) {
-      throw std::runtime_error("erasing var that doesn't exist");
+  scope_ = last;
+
+  auto it = scopeToVar_.find(v);
+  if (it != scopeToVar_.end()) {
+    for (const Var* e : it->second) {
+      if (varToVal_.erase(e) != 1) {
+        throw std::runtime_error("erasing var that doesn't exist");
+      }
     }
   }
 }
@@ -1570,6 +1570,16 @@ void LLVMCodeGenImpl::visit(const Free* v) {
   llvm::Value* ptr = varToVal_.at(v->buffer_var());
   if (!llvm::isa<llvm::AllocaInst>(ptr)) {
     irb_.Insert(llvm::CallInst::CreateFree(ptr, irb_.GetInsertBlock()));
+  }
+}
+
+void LLVMCodeGenImpl::visit(const Let* v) {
+  v->value()->accept(this);
+  if (!varToVal_.count(v->var())) {
+    varToVal_.emplace(v->var(), value_);
+    scopeToVar_[scope_].push_back(v->var());
+  } else {
+    throw std::runtime_error("var should not exist before");
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -61,8 +61,6 @@ Stmt* StmtNode<Op>::accept_mutator(IRMutator* mutator) {
 // Concrete Stmt classes
 class TORCH_API Block : public StmtNode<Block> {
  public:
-  using VarMapping = std::vector<std::pair<const Var*, const Expr*>>;
-
   static Block* make(const std::vector<Stmt*>& stmts) {
     std::vector<Stmt*> valid_stmts;
     for (size_t i = 0; i < stmts.size(); i++) {
@@ -75,20 +73,6 @@ class TORCH_API Block : public StmtNode<Block> {
       return nullptr;
     }
     return new Block(valid_stmts);
-  }
-
-  static Block* make(const VarMapping& vars, const std::vector<Stmt*>& stmts) {
-    std::vector<Stmt*> valid_stmts;
-    for (size_t i = 0; i < stmts.size(); i++) {
-      if (!stmts[i]) {
-        continue;
-      }
-      valid_stmts.push_back(stmts[i]);
-    }
-    if (valid_stmts.empty()) {
-      return nullptr;
-    }
-    return new Block(vars, valid_stmts);
   }
 
   int nstmts() const {
@@ -175,40 +159,8 @@ class TORCH_API Block : public StmtNode<Block> {
     return true;
   }
 
-  // adds a new binding to the map, replace
-  bool add_var_binding(const Var* v, const Expr* e) {
-    auto it =
-        std::find_if(varBindings_.begin(), varBindings_.end(), [v](auto p) {
-          return p.first == v;
-        });
-    if (it != varBindings_.end()) {
-      throw malformed_input(
-          "Var binding in Block would shadow existing binding");
-      return false;
-    }
-
-    varBindings_.emplace_back(v, e);
-    return true;
-  }
-
-  bool remove_var_binding(const Var* v) {
-    auto it =
-        std::find_if(varBindings_.begin(), varBindings_.end(), [v](auto p) {
-          return p.first == v;
-        });
-    if (it != varBindings_.end()) {
-      varBindings_.erase(it);
-      return true;
-    }
-    return false;
-  }
-
   std::list<Stmt*> stmts() const {
     return stmts_;
-  }
-
-  VarMapping varBindings() const {
-    return varBindings_;
   }
 
   explicit Block(const std::vector<Stmt*>& stmts) {
@@ -266,24 +218,7 @@ class TORCH_API Block : public StmtNode<Block> {
     stmts_.splice(it, other->stmts_);
   }
 
-  explicit Block(const VarMapping& vars, const std::vector<Stmt*>& stmts) {
-    for (auto& pair : vars) {
-      add_var_binding(pair.first, pair.second);
-    }
-
-    for (Stmt* s : stmts) {
-      if (s->get_parent()) {
-        throw malformed_input(
-            "Block creation has Stmt with existing parent", s);
-      }
-
-      stmts_.push_back(s);
-      set_parent(s, this);
-    }
-  }
-
  private:
-  VarMapping varBindings_;
   std::list<Stmt*> stmts_;
 };
 
@@ -402,6 +337,33 @@ class TORCH_API Free : public StmtNode<Free> {
 
  private:
   const Var* buffer_var_;
+};
+
+class TORCH_API Let : public StmtNode<Let> {
+ public:
+  static Let* make(const VarHandle& var, const ExprHandle& val) {
+    return new Let(var.node(), val.node());
+  }
+
+  Let(const Var* var, const Expr* val)
+      : dtype_(var->dtype()), var_(var), val_(val) {}
+
+  Dtype dtype() const {
+    return dtype_;
+  }
+
+  const Var* var() const {
+    return var_;
+  }
+
+  const Expr* value() const {
+    return val_;
+  }
+
+ private:
+  Dtype dtype_;
+  const Var* var_;
+  const Expr* val_;
 };
 
 class TORCH_API Cond : public StmtNode<Cond> {


### PR DESCRIPTION
Awhile back when commonizing the Let and LetStmt nodes, I ended up removing both and adding a separate VarBinding section the Block. At the time I couldn't find a counter example, but I found it today: Local Vars and Allocations dependencies may go in either direction and so we need to support interleaving of those statements.

So, I've removed all the VarBinding logic and reimplemented Let statements. @ZolotukhinM I think you get to say "I told you so". No new tests, existing tests should cover this.