### PR TITLE
Adds a RandomSampleDataset for sampling iterable style datasets on the fly

### DIFF
--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -1,4 +1,4 @@
 from .sampler import Sampler, SequentialSampler, RandomSampler, SubsetRandomSampler, WeightedRandomSampler, BatchSampler
 from .distributed import DistributedSampler
-from .dataset import Dataset, IterableDataset, TensorDataset, ConcatDataset, ChainDataset, Subset, random_split
+from .dataset import Dataset, IterableDataset, TensorDataset, ConcatDataset, ChainDataset, RandomSampleDataset, Subset, random_split
 from .dataloader import DataLoader, _DatasetKind, get_worker_info


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42641 Adds a RandomSampleDataset for sampling iterable style datasets on the fly**

We can do more things with multiple iterable style datasets than just a simple ChainDataset. For instance, for training, a RandomSampleDataset is more useful. This diff adds that capability.

Differential Revision: [D22962851](https://our.internmc.facebook.com/intern/diff/D22962851/)