### PR TITLE
Move jit_profiling tests into test1 on Windows

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -126,12 +126,10 @@ WORKFLOW_DATA = [
     WindowsJob(None, VcSpec(2019), CudaVersion(10, 1)),
     WindowsJob(1, VcSpec(2019), CudaVersion(10, 1)),
     WindowsJob(2, VcSpec(2019), CudaVersion(10, 1)),
-    WindowsJob("-jit-profiling-tests", VcSpec(2019), CudaVersion(10, 1), master_only_pred=FalsePred),
     # VS2019 CUDA-11.0
     WindowsJob(None, VcSpec(2019), CudaVersion(11, 0)),
     WindowsJob(1, VcSpec(2019), CudaVersion(11, 0)),
     WindowsJob(2, VcSpec(2019), CudaVersion(11, 0)),
-    WindowsJob("-jit-profiling-tests", VcSpec(2019), CudaVersion(11, 0), master_only_pred=FalsePred),
     # VS2019 CPU-only
     WindowsJob(None, VcSpec(2019), None),
     WindowsJob(1, VcSpec(2019), None, master_only_pred=TruePred),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6351,19 +6351,6 @@ workflows:
           vc_product: Community
           vc_version: ""
           vc_year: "2019"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
-          cuda_version: "10"
-          executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda10.1_test-jit-profiling-tests
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2019_py36_cuda10.1_build
-          test_name: pytorch-windows-test-jit-profiling-tests
-          use_cuda: "1"
-          vc_product: Community
-          vc_version: ""
-          vc_year: "2019"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11"
@@ -6395,19 +6382,6 @@ workflows:
           requires:
             - pytorch_windows_vs2019_py36_cuda11.0_build
           test_name: pytorch-windows-test2
-          use_cuda: "1"
-          vc_product: Community
-          vc_version: ""
-          vc_year: "2019"
-      - pytorch_windows_test:
-          build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11"
-          executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.0_test-jit-profiling-tests
-          python_version: "3.6"
-          requires:
-            - pytorch_windows_vs2019_py36_cuda11.0_build
-          test_name: pytorch-windows-test-jit-profiling-tests
           use_cuda: "1"
           vc_product: Community
           vc_version: ""

--- a/.jenkins/pytorch/win-test-helpers/test_python_jit_profiling.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_jit_profiling.bat
@@ -2,7 +2,7 @@ call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
 pushd test
 
-echo Run nn tests
+echo Run jit_profiling tests
 python run_test.py --include test_jit_profiling test_jit_fuser_te test_tensorexpr --verbose --determine-from="%1"
 if ERRORLEVEL 1 exit /b 1
 

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -47,12 +47,13 @@ run_tests() {
         if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
             $SCRIPT_HELPERS_DIR/test_python_nn.bat "$DETERMINE_FROM" && \
             $SCRIPT_HELPERS_DIR/test_libtorch.bat
+            if [[ "${USE_CUDA}" == "1" ]]; then
+              $SCRIPT_HELPERS_DIR/test_python_jit_profiling.bat "$DETERMINE_FROM"
+            fi
         elif [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
             $SCRIPT_HELPERS_DIR/test_python_all_except_nn.bat "$DETERMINE_FROM" && \
             $SCRIPT_HELPERS_DIR/test_custom_backend.bat && \
             $SCRIPT_HELPERS_DIR/test_custom_script_ops.bat
-        elif [[ "${JOB_BASE_NAME}" == *jit-profiling-tests ]]; then
-            $SCRIPT_HELPERS_DIR/test_python_jit_profiling.bat "$DETERMINE_FROM"
         fi
     fi
 }


### PR DESCRIPTION
Test takes 5 min to finish and 5 min to spin up the environment, so it doesn't make much sense to keep it as separate config
Limit those tests to be run only when `USE_CUDA` environment variable is set to tru


