### PR TITLE
Adds torch.linalg namespace

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -214,6 +214,7 @@ libtorch_python_generated_sources = [
         "torch/csrc/autograd/generated/python_torch_functions.cpp",
         "torch/csrc/autograd/generated/python_nn_functions.cpp",
         "torch/csrc/autograd/generated/python_fft_functions.cpp",
+        "torch/csrc/autograd/generated/python_linalg_functions.cpp",
 ]
 
 genrule(

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1077,7 +1077,9 @@ def create_generic(top_env, declarations):
 
     def process_native(option):
         # type: (FunctionOption) -> Optional[OutputDeclaration]
-        assert option['python_module'] == '' or option['python_module'] == 'nn' or option['python_module'] == 'fft', \
+        valid_modules = {'nn', 'fft', 'linalg'}
+        assert (option['python_module'] == '' or
+                option['python_module'] in valid_modules), \
             "Found python_module of {} for decl {}, but only \'\' string, \'nn\' and \'fft\' are supported".format(
                 option['python_module'], option['name'])
         use_optional_tensors_in_cpp_frontend = option['use_c10_dispatcher'] == 'full'

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -174,6 +174,15 @@ Tensor ger(const Tensor& self, const Tensor& vec2) {
   return result;
 }
 
+// linalg.outer, an alias for ger
+Tensor& linalg_outer_out(Tensor &result, const Tensor& self, const Tensor& vec2) {
+  return at::ger_out(result, self, vec2);
+}
+
+Tensor linalg_outer(const Tensor& self, const Tensor& vec2) {
+  return self.ger(vec2);
+}
+
 static void addmm_impl_cpu_(
     Tensor &result, const Tensor &self, Tensor m1, Tensor m2, Scalar beta, Scalar alpha) {
   TORCH_INTERNAL_ASSERT(self.dim() == 2 && m1.dim() == 2 && m2.dim() == 2);

--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -379,8 +379,9 @@ name that we skip in python binding generation, e.g. `*_backward`. Check
 `tools/autograd/gen_python_functions.py` for the latest rules.
 
 The generated bindings are either exposed as methods on python_variable or functions on
-the torch._C._nn (marked with `python_module: nn`) or
-torch._C._fft (marked with `python_module: fft`) objects.
+the torch._C._nn (marked with `python_module: nn`),
+torch._C._fft (marked with `python_module: fft`),
+or torch._C._linalg (marked with `python_module: linalg`) objects.
 
 ### Can it handle being passed Variables?
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1457,6 +1457,22 @@
 - func: hinge_embedding_loss(Tensor self, Tensor target, float margin=1.0, int reduction=Mean) -> Tensor
   use_c10_dispatcher: full
 
+# linalg namespace
+# Note [linalg namespace binding]
+# Functions in the linalg python module should have their names start with
+#   "linalg_" and be bound to the desired Python name in
+#   torch/linalg/__init__.py, and the desired C++ name in torch/csrc/api/include/torch/linalg.h.
+#
+# See linalg_outer as an example.
+
+- func: linalg_outer(Tensor self, Tensor vec2) -> Tensor
+  python_module: linalg
+  use_c10_dispatcher: full
+  variants: function
+
+- func: linalg_outer.out(Tensor self, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
+  python_module: linalg
+
 - func: ger(Tensor self, Tensor vec2) -> Tensor
   use_c10_dispatcher: full
   variants: function, method

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -339,6 +339,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     "${TORCH_SRC_DIR}/csrc/autograd/generated/python_torch_functions.cpp"
     "${TORCH_SRC_DIR}/csrc/autograd/generated/python_nn_functions.cpp"
     "${TORCH_SRC_DIR}/csrc/autograd/generated/python_fft_functions.cpp"
+    "${TORCH_SRC_DIR}/csrc/autograd/generated/python_linalg_functions.cpp"
     )
 
   set(GENERATED_H_PYTHON
@@ -381,6 +382,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     "${TOOLS_PATH}/autograd/templates/python_torch_functions.cpp"
     "${TOOLS_PATH}/autograd/templates/python_nn_functions.cpp"
     "${TOOLS_PATH}/autograd/templates/python_fft_functions.cpp"
+    "${TOOLS_PATH}/autograd/templates/python_linalg_functions.cpp"
     "${TOOLS_PATH}/autograd/templates/variable_factories.h"
     "${TOOLS_PATH}/autograd/templates/annotated_fn_args.py"
     "${TOOLS_PATH}/autograd/deprecated.yaml"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,7 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
    futures
    torch.hub <hub>
    torch.jit <jit>
+   torch.linalg <linalg>
    nn.init
    onnx
    optim

--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -1,0 +1,15 @@
+.. role:: hidden
+    :class: hidden-section
+
+torch.linalg
+============
+
+Common linear algebra operations.
+
+.. automodule:: torch.linalg
+.. currentmodule:: torch.linalg
+
+Functions
+---------
+
+.. autofunction:: outer

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2,9 +2,9 @@ import torch
 import unittest
 
 from torch.testing._internal.common_utils import \
-    (TestCase, run_tests, TEST_NUMPY, slowTest)
+    (TestCase, run_tests, TEST_NUMPY)
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, dtypes, onlyCPU, skipCPUIfNoLapack)
+    (instantiate_device_type_tests, dtypes)
 
 if TEST_NUMPY:
     import numpy as np

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1,0 +1,38 @@
+import torch
+import unittest
+
+from torch.testing._internal.common_utils import \
+    (TestCase, run_tests, TEST_NUMPY, slowTest)
+from torch.testing._internal.common_device_type import \
+    (instantiate_device_type_tests, dtypes, onlyCPU, skipCPUIfNoLapack)
+
+if TEST_NUMPY:
+    import numpy as np
+
+class TestLinalg(TestCase):
+    exact_dtype = True
+
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    @dtypes(torch.float)
+    def test_outer(self, device, dtype):
+        a = torch.randn(50, device=device, dtype=dtype)
+        b = torch.randn(50, device=device, dtype=dtype)
+
+        def fn(a, b):
+            return torch.linalg.outer(a, b)
+        scripted_outer = torch.jit.script(fn)
+
+        expected = np.outer(a.cpu().numpy(), b.cpu().numpy())
+        original = torch.ger(a, b)
+        actual = torch.linalg.outer(a, b)
+        scripted = scripted_outer(a, b)
+
+        self.assertEqual(actual, expected, exact_device=False)
+        self.assertEqual(actual, original)
+        self.assertEqual(actual, scripted)
+
+
+instantiate_device_type_tests(TestLinalg, globals())
+
+if __name__ == '__main__':
+    run_tests()

--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -297,6 +297,8 @@ def gen_autograd_python(aten_path, out, autograd_dir):
         out, aten_decls, template_path)
     gen_python_functions.gen_py_fft_functions(
         out, aten_decls, template_path)
+    gen_python_functions.gen_py_linalg_functions(
+        out, aten_decls, template_path)
 
 
 def main():

--- a/tools/autograd/templates/python_linalg_functions.cpp
+++ b/tools/autograd/templates/python_linalg_functions.cpp
@@ -1,0 +1,57 @@
+// ${generated_comment}
+
+#include "torch/csrc/Device.h"
+#include "torch/csrc/DynamicTypes.h"
+#include "torch/csrc/Exceptions.h"
+#include "torch/csrc/autograd/python_linalg_functions.h"
+#include "torch/csrc/autograd/python_variable.h"
+#include "torch/csrc/autograd/utils/wrap_outputs.h"
+#include "torch/csrc/autograd/utils/python_arg_parsing.h"
+#include "torch/csrc/utils/python_arg_parser.h"
+#include "torch/csrc/utils/structseq.h"
+
+using at::Tensor;
+using at::Scalar;
+using at::MemoryFormat;
+using at::Generator;
+using at::IntArrayRef;
+
+using namespace torch::autograd::utils;
+
+namespace torch { namespace autograd {
+
+// generated forward declarations start here
+
+${py_forwards}
+
+static PyMethodDef linalg_functions[] = {
+  ${py_method_defs}
+  {NULL}
+};
+
+static PyObject* THPLinalgVariableFunctionsModule = NULL;
+
+void initLinalgFunctions(PyObject* module) {
+  static struct PyModuleDef def = {
+     PyModuleDef_HEAD_INIT,
+     "torch._C._linalg",
+     NULL,
+     -1,
+     linalg_functions
+  };
+  PyObject* linalg = PyModule_Create(&def);
+  THPLinalgVariableFunctionsModule = linalg;
+  if (!linalg) {
+    throw python_error();
+  }
+  // steals a reference to linalg
+  if (PyModule_AddObject(module, "_linalg", linalg) != 0) {
+    throw python_error();
+  }
+}
+
+// generated methods start here
+
+${py_methods}
+
+}} // namespace torch::autograd

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -23,6 +23,7 @@ GENERATED_CPP = [
     "autograd/generated/python_functions.cpp",
     "autograd/generated/python_nn_functions.cpp",
     "autograd/generated/python_fft_functions.cpp",
+    "autograd/generated/python_linalg_functions.cpp",
     "autograd/generated/python_torch_functions.cpp",
     "autograd/generated/python_variable_methods.cpp",
 ]
@@ -553,6 +554,7 @@ def glob_libtorch_python_sources(gencode_pattern = ":generate-code[{}]"):
         "autograd/generated/python_functions.cpp",
         "autograd/generated/python_nn_functions.cpp",
         "autograd/generated/python_fft_functions.cpp",
+        "autograd/generated/python_linalg_functions.cpp",
         "autograd/generated/python_torch_functions.cpp",
         "autograd/generated/python_variable_methods.cpp",
     ]]

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -471,6 +471,7 @@ import torch.sparse
 import torch.utils.backcompat
 import torch.onnx
 import torch.jit
+import torch.linalg
 import torch.hub
 import torch.random
 import torch.distributions

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -31,6 +31,7 @@
 #include <torch/csrc/TypeInfo.h>
 #include <torch/csrc/autograd/python_nn_functions.h>
 #include <torch/csrc/autograd/python_fft_functions.h>
+#include <torch/csrc/autograd/python_linalg_functions.h>
 #include <torch/csrc/autograd/python_legacy_variable.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/multiprocessing/init.h>
@@ -696,6 +697,7 @@ PyObject* initModule() {
   torch::throughput_benchmark::initThroughputBenchmarkBindings(module);
   torch::autograd::initNNFunctions(module);
   torch::autograd::initFFTFunctions(module);
+  torch::autograd::initLinalgFunctions(module);
   torch::autograd::init_legacy_variable(module);
   torch::python::init_bindings(module);
 #ifdef USE_CUDA

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -9,6 +9,7 @@
 #include <torch/enum.h>
 #include <torch/fft.h>
 #include <torch/jit.h>
+#include <torch/linalg.h>
 #include <torch/nn.h>
 #include <torch/optim.h>
 #include <torch/serialize.h>

--- a/torch/csrc/api/include/torch/linalg.h
+++ b/torch/csrc/api/include/torch/linalg.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace torch {
+namespace linalg {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace detail {
+
+inline Tensor outer(const Tensor& self, const Tensor& vec2) {
+  return torch::linalg_outer(self, vec2);
+}
+
+inline Tensor outer_out(Tensor &result, const Tensor& self, const Tensor& vec2) {
+  return torch::linalg_outer_out(result, self, vec2);
+}
+
+} // namespace detail
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+/// See the documentation of torch.linalg.outer
+inline Tensor outer(const Tensor& self, const Tensor& vec2) {
+  return detail::outer(self, vec2);
+}
+
+/// See the documentation of torch.linalg.outer
+inline Tensor outer_out(Tensor &result, const Tensor& self, const Tensor& vec2) {
+  return detail::outer_out(result, self, vec2);
+}
+
+}} // torch::linalg

--- a/torch/csrc/autograd/python_linalg_functions.h
+++ b/torch/csrc/autograd/python_linalg_functions.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace torch { namespace autograd {
+
+void initLinalgFunctions(PyObject* module);
+
+}} // namespace torch::autograd

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 
 _builtin_table = None
 
-_modules_containing_builtins = (torch, torch._C._nn, torch._C._fft)
+_modules_containing_builtins = (torch, torch._C._nn, torch._C._fft, torch._C._linalg)
 
 _builtin_ops = [
     # Pairs of (function, op_name)

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -5,8 +5,8 @@ from torch._C import _add_docstr, _linalg  # type: ignore
 
 Tensor = torch.Tensor
 
-# Note: This not only adds the doc strings for the spectral ops, but
-# connects the torch.fft Python namespace to the torch._C._fft builtins.
+# Note: This not only adds doc strings for the linear algebra ops, but
+# also connects the torch.linalg Python namespace to the torch._C._linalg builtins.
 
 outer = _add_docstr(_linalg.linalg_outer, r"""
 linalg.outer(input, vec2, *, out=None) -> Tensor

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1,0 +1,15 @@
+import sys
+
+import torch
+from torch._C import _add_docstr, _linalg  # type: ignore
+
+Tensor = torch.Tensor
+
+# Note: This not only adds the doc strings for the spectral ops, but
+# connects the torch.fft Python namespace to the torch._C._fft builtins.
+
+outer = _add_docstr(_linalg.linalg_outer, r"""
+linalg.outer(input, vec2, *, out=None) -> Tensor
+
+Alias of :func:`torch.ger`.
+""")


### PR DESCRIPTION
This PR adds the `torch.linalg` namespace as part of our continued effort to be more compatible with NumPy. The namespace is tested by adding a single function, `torch.linalg.outer`, and testing it in a new test suite, test_linalg.py. It follows the same pattern that https://github.com/pytorch/pytorch/pull/41911, which added the `torch.fft` namespace, did. 

Future PRs will likely:

- add more functions to torch.linalg
- expand the testing done in test_linalg.py, including legacy functions, like torch.ger
- deprecate existing linalg functions outside of `torch.linalg` in preference to the new namespace