### PR TITLE
Skips spectral tests to prevent ROCm build from timing out

### DIFF
--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -25,7 +25,7 @@ import torch.fft
 class TestFFT(TestCase):
     exact_dtype = True
 
-    @skipCUDAIfROCM
+    @skipCUDAIfRocm
     def test_fft_function_clobbered(self, device):
         t = torch.randn((100, 2), device=device)
         eager_result = fft_fn(t, 1)
@@ -39,7 +39,7 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(TypeError, "'module' object is not callable"):
             torch.fft(t, 1)
 
-    @skipCUDAIfROCM
+    @skipCUDAIfRocm
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @precisionOverride({torch.complex64: 1e-4})
     @dtypes(torch.complex64, torch.complex128)
@@ -67,7 +67,7 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected, exact_dtype=(dtype is torch.complex128))
 
     # Note: NumPy will throw a ValueError for an empty input
-    @skipCUDAIfROCM
+    @skipCUDAIfRocm
     @skipCPUIfNoMkl
     @onlyOnCPUAndCUDA
     @dtypes(torch.complex64, torch.complex128)

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -25,6 +25,7 @@ import torch.fft
 class TestFFT(TestCase):
     exact_dtype = True
 
+    @skipCUDAIfROCM
     def test_fft_function_clobbered(self, device):
         t = torch.randn((100, 2), device=device)
         eager_result = fft_fn(t, 1)
@@ -38,6 +39,7 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(TypeError, "'module' object is not callable"):
             torch.fft(t, 1)
 
+    @skipCUDAIfROCM
     @unittest.skipIf(not TEST_NUMPY, 'NumPy not found')
     @precisionOverride({torch.complex64: 1e-4})
     @dtypes(torch.complex64, torch.complex128)
@@ -65,6 +67,7 @@ class TestFFT(TestCase):
                 self.assertEqual(actual, expected, exact_dtype=(dtype is torch.complex128))
 
     # Note: NumPy will throw a ValueError for an empty input
+    @skipCUDAIfROCM
     @skipCPUIfNoMkl
     @onlyOnCPUAndCUDA
     @dtypes(torch.complex64, torch.complex128)


### PR DESCRIPTION
Per title.