### PR TITLE
[numpy compatibility] torch.fmod : Divisor  0

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -624,7 +624,9 @@ void fmod_kernel(TensorIterator& iter) {
   if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "fmod_cpu", [&]() {
       cpu_kernel(iter, [=](scalar_t x, scalar_t d) -> scalar_t {
-        TORCH_CHECK(d != 0, "ZeroDivisionError");
+        if (d == 0) {
+          return 0;
+        }
         return x % d;
       });
     });
@@ -646,8 +648,10 @@ void fmod_scalar_kernel(TensorIterator& iter, Scalar divisor) {
   if (isIntegralType(iter.dtype(), /*includeBool=*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "fmod_scalar_cpu", [&]() {
       const auto div = divisor.to<scalar_t>();
-      TORCH_CHECK(div != 0, "ZeroDivisionError");
       cpu_kernel(iter, [=](scalar_t x) -> scalar_t {
+        if (div == 0){
+          return 0;
+        }
         return x % div;
       });
     });

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16808,10 +16808,8 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
 
         zero = torch.zeros_like(m1)
         if dtype in torch.testing.get_all_int_dtypes():
-            with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
-                m1.fmod(0)
-            with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
-                m1.fmod(zero)
+            self.compare_with_numpy(lambda x: torch.fmod(x, 0), lambda x: np.fmod(x, 0), m1)
+            self.compare_with_numpy(lambda x: torch.fmod(x, zero), lambda x: np.fmod(x, zero), m1)
         else:
             self.assertTrue(torch.all(m1.fmod(0).isnan()))
             self.assertTrue(torch.all(m1.fmod(zero).isnan()))


### PR DESCRIPTION
Fixes #42506 for integral types (CPU only)

Matches numpy's behaviour
```python
>>> a = torch.tensor([1,2,3,4])
>>> np.fmod(a.numpy(), 0)
__main__:1: RuntimeWarning: divide by zero encountered in fmod
array([0, 0, 0, 0])
>>> torch.fmod(a, 0)
tensor([0, 0, 0, 0])
```
