### PR TITLE
BAND, BOR and BXOR for NCCL (all_)reduce should throw runtime errors

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -1619,7 +1619,6 @@ class ProcessGroupNCCLTest(TestCase):
     def test_allreduce_ops(self):
         store = c10d.FileStore(self.file.name, self.world_size)
         pg = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
-
         def allreduce(tensors, op):
             opts = c10d.AllreduceOptions()
             opts.reduceOp = op
@@ -1673,14 +1672,20 @@ class ProcessGroupNCCLTest(TestCase):
         for i in range(self.num_gpus):
             self.assertEqual(torch.tensor([self.num_gpus]), tensors[i])
 
+        for op in (c10d.ReduceOp.BAND, c10d.ReduceOp.BOR, c10d.ReduceOp.BXOR):
+            with self.assertRaises(RuntimeError):
+                allreduce(tensors, op)
+            
     def test_reduce_ops(self):
         store = c10d.FileStore(self.file.name, self.world_size)
         pg = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
-        def reduce(xs, rootRank, rootTensor):
+        def reduce(xs, rootRank, rootTensor, op=None):
             opts = c10d.ReduceOptions()
             opts.rootRank = rootRank
             opts.rootTensor = rootTensor
+            if op:
+                opts.reduceOp = op
             work = pg.reduce(xs, opts)
             work.wait()
 
@@ -1696,6 +1701,10 @@ class ProcessGroupNCCLTest(TestCase):
             self.assertEqualIgnoreType(
                 torch.tensor([float(self.num_gpus * (self.num_gpus + 1) / 2)]),
                 tensors[rt])
+
+            for op in (c10d.ReduceOp.BAND, c10d.ReduceOp.BOR, c10d.ReduceOp.BXOR):
+                with self.assertRaises(RuntimeError):
+                    reduce(tensors, self.rank, rt, op)
 
     def test_allgather_ops(self):
         store = c10d.FileStore(self.file.name, self.world_size)

--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -1619,6 +1619,7 @@ class ProcessGroupNCCLTest(TestCase):
     def test_allreduce_ops(self):
         store = c10d.FileStore(self.file.name, self.world_size)
         pg = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
         def allreduce(tensors, op):
             opts = c10d.AllreduceOptions()
             opts.reduceOp = op
@@ -1673,9 +1674,9 @@ class ProcessGroupNCCLTest(TestCase):
             self.assertEqual(torch.tensor([self.num_gpus]), tensors[i])
 
         for op in (c10d.ReduceOp.BAND, c10d.ReduceOp.BOR, c10d.ReduceOp.BXOR):
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(RuntimeError, "Cannot use " + str(op) + " with NCCL"):
                 allreduce(tensors, op)
-            
+
     def test_reduce_ops(self):
         store = c10d.FileStore(self.file.name, self.world_size)
         pg = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
@@ -1703,7 +1704,7 @@ class ProcessGroupNCCLTest(TestCase):
                 tensors[rt])
 
             for op in (c10d.ReduceOp.BAND, c10d.ReduceOp.BOR, c10d.ReduceOp.BXOR):
-                with self.assertRaises(RuntimeError):
+                with self.assertRaisesRegex(RuntimeError, "Cannot use " + str(op) + " with NCCL"):
                     reduce(tensors, self.rank, rt, op)
 
     def test_allgather_ops(self):

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -10,7 +10,6 @@
 #include <c10/cuda/CUDAGuard.h>
 
 #include <c10d/Utils.hpp>
-
 namespace c10d {
 
 constexpr const char* const kNCCLAbortedCommStoreKey = "NCCLABORTEDCOMM";
@@ -69,13 +68,28 @@ ncclDataType_t getNcclDataType(at::ScalarType type) {
 }
 
 ncclRedOp_t getNcclReduceOp(const ReduceOp reduceOp, at::Tensor& input) {
-  if (reduceOp == ReduceOp::SUM && input.scalar_type() == at::kBool) {
-    // For bool tensors, map sum to max, which both represent a bitwise or.
-    // This is to prevent overflow issues with sum, since we use uint8 to
-    // represent a bool (see ncclDataType mapping).
-    return ncclMax;
+  switch (reduceOp) {
+    case ReduceOp::BAND:
+      throw std::runtime_error("Cannot use ReduceOp.BAND with NCCL");
+      break;
+    case ReduceOp::BOR:
+      throw std::runtime_error("Cannot use ReduceOp.BOR with NCCL");
+      break;
+    case ReduceOp::BXOR:
+      throw std::runtime_error("Cannot use ReduceOp.BXOR with NCCL");
+      break;
+    case ReduceOp::UNUSED:
+      throw std::runtime_error("Unhandled ReduceOp");
+      break;
+    default:
+      if (reduceOp == ReduceOp::SUM && input.scalar_type() == at::kBool) {
+        // For bool tensors, map sum to max, which both represent a bitwise or.
+        // This is to prevent overflow issues with sum, since we use uint8 to
+        // represent a bool (see ncclDataType mapping).
+        return ncclMax;
+      }
+      return ncclOp[reduceOp];
   }
-  return ncclOp[reduceOp];
 }
 
 // Get the deviceList String from the list of devices


### PR DESCRIPTION
cc @rohan-varma 
Fixes #41362 #39708

# Description
NCCL doesn't support `BAND, BOR, BXOR`. Since the [current mapping](https://github.com/pytorch/pytorch/blob/0642d17efc73041e5209e3be265d9a39892e8908/torch/lib/c10d/ProcessGroupNCCL.cpp#L39) doesn't contain any of the mentioned bitwise operator, a default value of `ncclSum` is used instead. 

This PR should provide the expected behaviour where a runtime exception is thrown.

# Notes
- The way I'm throwing exceptions is derived from [ProcessGroupGloo.cpp](https://github.com/pytorch/pytorch/blob/0642d17efc73041e5209e3be265d9a39892e8908/torch/lib/c10d/ProcessGroupGloo.cpp#L101)

