### PR TITLE
pin numpy version to 1.18.5

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -67,9 +67,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   if [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
     # DO NOT install typing if installing python-3.8, since its part of python-3.8 core packages
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    conda_install numpy pyyaml mkl mkl-include setuptools cffi future six llvmdev=8.0.0
+    conda_install numpy=1.18.5 pyyaml mkl mkl-include setuptools cffi future six llvmdev=8.0.0
   else
-    conda_install numpy pyyaml mkl mkl-include setuptools cffi typing future six
+    conda_install numpy=1.18.5 pyyaml mkl mkl-include setuptools cffi typing future six
   fi
   if [[ "$CUDA_VERSION" == 9.2* ]]; then
     conda_install magma-cuda92 -c pytorch

--- a/docker/caffe2/jenkins/common/install_python.sh
+++ b/docker/caffe2/jenkins/common/install_python.sh
@@ -154,7 +154,7 @@ pip install --no-cache-dir \
     future \
     hypothesis \
     jupyter \
-    numpy \
+    numpy==1.18.5 \
     protobuf \
     pytest \
     pyyaml \


### PR DESCRIPTION
Using numpy 1.19.x instead of 1.18.x breaks certain unit tests.
Fixes #42561.  Likely also fixes #42583.

CC @ezyang @xw285cornell @sunway513 