### PR TITLE
Export TensorPipe RPC agent

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -115,7 +115,7 @@ struct AggregatedNetworkData {
 // to transparently move tensors and payloads through the fastest available
 // transport or channel. It acts like a hybrid RPC transport, providing shared
 // memory (linux) and TCP (linux & mac) support. CUDA support is in progress.
-class TensorPipeAgent : public RpcAgent {
+class TORCH_API TensorPipeAgent : public RpcAgent {
  public:
   TensorPipeAgent(
       const std::shared_ptr<::c10d::Store>& store,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42682 Guard TensorPipe agent by USE_TENSORPIPE
* #42681 Run distributed C++ tests in CircleCI
* #42680 Enroll TensorPipe agent in C++-only E2E test
* #42679 Make TensorPipe agent part of libtorch, not libtorch_python
* #42678 Remove Python dependency from TensorPipe RPC agent
* **#42677 Export TensorPipe RPC agent**

Differential Revision: [D22978713](https://our.internmc.facebook.com/intern/diff/D22978713/)