### PR TITLE
fix int8 FC

### DIFF
--- a/caffe2/contrib/fakelowp/common.h
+++ b/caffe2/contrib/fakelowp/common.h
@@ -1,10 +1,5 @@
-#include <fbgemm/FbgemmConvert.h>
+#pragma once
 
 namespace caffe2 {
-
-template <typename T>
-void fp16_wrap(T* tmp) {
-  fbgemm::RoundToFloat16(tmp, tmp, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
-}
 
 } // namespace caffe2

--- a/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/layernorm_fp16_fake_op.cc
@@ -23,7 +23,7 @@ void LayerNormFakeFp16Op<CPUContext>::calcY(
   std::vector<float> normalized(N);
   for (int i = 0; i < M; ++i) {
     float normFactor = float(1.0f / std_arr[i]);
-    fp16_wrap(&normFactor);
+    fbgemm::RoundToFloat16(&normFactor, &normFactor, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
     for (int j = 0; j < N; ++j) {
       normalized[j] = X_arr.col(i)[j] - mean[i];
@@ -82,7 +82,7 @@ void LayerNormFakeFp16Op<CPUContext>::calcMeanStd(
   std::vector<float> sqr(M, 0.0f);
   std::vector<float> var(M, 0.0f);
   float inv_N_val = 1.0f / N;
-  fp16_wrap(&inv_N_val);
+  fbgemm::RoundToFloat16(&inv_N_val, &inv_N_val, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
 
   constexpr int VEC_SIZE = 32;
   std::vector<float> inv_N_vec(VEC_SIZE, inv_N_val);
@@ -158,7 +158,7 @@ void LayerNormFakeFp16Op<CPUContext>::calcMeanStd(
 
   float teps = eps;
   std::vector<float> tmpVec(M, 0.0f);
-  fp16_wrap(&teps);
+  fbgemm::RoundToFloat16(&teps, &teps, 1, FLAGS_caffe2_fbgemm_fake_fp16_clamp);
   int i = 0;
   for (auto& v: var) {
     if (v < 0.0) {

--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -16,6 +16,8 @@ class Int8OpsTest(serial.SerializedTestCase):
         tensor_max = np.max(tensor)
         tensor_min = min(0, np.min(tensor))
         scale = np.float32(np.float16((tensor_max - tensor_min) / 255.0))
+        if scale < 1e-6:
+            scale = 1e-6
         zero_point = 0 - tensor_min / scale
         zero_point = int(round(np.clip(zero_point, 0, 255.0)))
         return (scale, zero_point)
@@ -122,24 +124,24 @@ class Int8OpsTest(serial.SerializedTestCase):
         n=st.integers(1, 1024),
         m=st.integers(1, 1024),
         k=st.integers(1, 1024),
+        f=st.integers(1, 1),  # TODO: figure a safe number to increase
         rand_seed=st.integers(0, 65534),
         quantize_bias=st.sampled_from([False]),
     )
     @settings(deadline=None, max_examples=30)
     def test_int8_fc(
-        self, n, m, k, rand_seed, quantize_bias
+        self, n, m, k, rand_seed, quantize_bias, f
     ):
         print(
-            "n={}, m={}, k={}, rand_seed={}, quantize_bias={}".format(
-                n, m, k, rand_seed, quantize_bias
-            )
+            f"n={n}, m={m}, k={k}, rand_seed={rand_seed}, quantize_bias={quantize_bias}"
         )
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
 
-        X_fp32 = np.random.rand(m, k).astype(np.float16).astype(np.float32)
-        W_fp32 = np.random.rand(n, k).astype(np.float32)
-        b_fp32 = np.random.rand(n).astype(np.float16).astype(np.float32)
+        ff = float(f)
+        X_fp32 = np.random.uniform(-ff, ff, size=(m, k)).astype(np.float32)
+        W_fp32 = np.random.uniform(-ff, ff, size=(n, k)).astype(np.float32)
+        b_fp32 = np.random.uniform(-ff, ff, size=(n)).astype(np.float32)
 
         X_scale, X_zero_point = self._get_scale_zp(X_fp32)
         Y_fp32 = np.dot(X_fp32, W_fp32.T) + b_fp32
@@ -233,7 +235,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
 
-        X_fp32 = np.random.uniform(0.01, 0.03, size=(n, n)).astype(np.float16).astype(np.float32)
+        X_fp32 = np.random.uniform(0.01, 0.03, size=(n, n)).astype(np.float32)
         W_fp32 = np.identity(n, dtype=np.float32)
         b_fp32 = np.zeros((n,), dtype=np.float32)
 

--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -4,6 +4,7 @@
 #include "caffe2/core/tensor_int8.h"
 
 #include "caffe2_dnnlowp_utils.h"
+#include <fbgemm/FbgemmConvert.h>
 
 C10_DECLARE_int32(caffe2_dnnlowp_nbits_in_non_outlier);
 C10_DECLARE_double(caffe2_dnnlowp_acc16_density_threshold);
@@ -187,7 +188,8 @@ void QuantizeConvBias(
     int M,
     const TensorQuantizationParams& in_qparams,
     const vector<TensorQuantizationParams>& filter_qparams,
-    vector<int32_t>& b_quantized, bool round_to_nearest_even) {
+    vector<int32_t>& b_quantized, bool use_fp16,
+    bool round_to_nearest_even) {
   const auto& bias = blob.IsType<int8::Int8TensorCPU>()
       ? blob.Get<int8::Int8TensorCPU>().t
       : blob.Get<TensorCPU>();
@@ -205,6 +207,13 @@ void QuantizeConvBias(
         bias.data<int32_t>(), bias.data<int32_t>() + bias.numel());
   } else {
     const float* bdata = bias.data<float>();
+    vector<float> bdata_local;
+    if (use_fp16) {
+      bdata_local.resize(bias.numel());
+      fbgemm::RoundToFloat16(
+              bdata, bdata_local.data(), bias.numel(), 1 /* FLAGS_caffe2_fbgemm_fake_fp16_clamp */);
+      bdata = bdata_local.data();
+    }
     b_quantized.resize(bias.numel());
     for (int g = 0; g < filter_qparams.size(); ++g) {
       int i_begin = g * (M / filter_qparams.size());
@@ -222,7 +231,6 @@ void QuantizeConvBias(
           b_quantized[i] = std::max(std::min(b_quantized[i], INT32_MAX), INT32_MIN);
         }
       }
-
     }
   }
 }

--- a/caffe2/quantization/server/fbgemm_pack_op.h
+++ b/caffe2/quantization/server/fbgemm_pack_op.h
@@ -15,7 +15,7 @@ void QuantizeConvBias(
     int M,
     const dnnlowp::TensorQuantizationParams& in_qparams,
     const vector<dnnlowp::TensorQuantizationParams>& filter_qparams,
-    std::vector<int32_t>& b_quantized, bool round_nearest_even=true);
+    std::vector<int32_t>& b_quantized, bool use_fp16=false, bool round_nearest_even=true);
 
 class FullyConnectedDNNLowPPackWeightOp final
     : public DNNLowPOp<std::uint8_t, FCFp32Op> {


### PR DESCRIPTION
Summary:
fix quantization of FC bias to match nnpi
quantize biases to fp16

Test Plan: improved the unit test to have input tensors in fp32

Reviewed By: tracelogfb

Differential Revision: D22941521

