### PR TITLE
Restrict conversion to SmallVector

### DIFF
--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -957,7 +957,17 @@ class SmallVector : public SmallVectorImpl<T> {
     this->append(S, E);
   }
 
-  template <typename Container>
+  // note: The enable_if restricts Container to types that have a .begin() and .end()
+  // that return valid input iterators.
+  template <typename Container, std::enable_if_t<
+      std::is_convertible<
+          typename std::iterator_traits<decltype(std::declval<Container>().begin())>::iterator_category,
+          std::input_iterator_tag
+      >::value &&
+      std::is_convertible<
+          typename std::iterator_traits<decltype(std::declval<Container>().end())>::iterator_category,
+          std::input_iterator_tag
+      >::value, int> = 0>
   explicit SmallVector(Container&& c) : SmallVectorImpl<T>(N) {
     this->append(c.begin(), c.end());
   }
@@ -981,7 +991,17 @@ class SmallVector : public SmallVectorImpl<T> {
       SmallVectorImpl<T>::operator=(::std::move(RHS));
   }
 
-  template <typename Container>
+  // note: The enable_if restricts Container to types that have a .begin() and .end()
+  // that return valid input iterators.
+  template <typename Container, std::enable_if_t<
+      std::is_convertible<
+          typename std::iterator_traits<decltype(std::declval<Container>().begin())>::iterator_category,
+          std::input_iterator_tag
+      >::value &&
+      std::is_convertible<
+          typename std::iterator_traits<decltype(std::declval<Container>().end())>::iterator_category,
+          std::input_iterator_tag
+      >::value, int> = 0>
   const SmallVector& operator=(const Container& RHS) {
     this->assign(RHS.begin(), RHS.end());
     return *this;
@@ -1002,7 +1022,17 @@ class SmallVector : public SmallVectorImpl<T> {
     return *this;
   }
 
-  template <typename Container>
+  // note: The enable_if restricts Container to types that have a .begin() and .end()
+  // that return valid input iterators.
+  template <typename Container, std::enable_if_t<
+      std::is_convertible<
+          typename std::iterator_traits<decltype(std::declval<Container>().begin())>::iterator_category,
+          std::input_iterator_tag
+      >::value &&
+      std::is_convertible<
+          typename std::iterator_traits<decltype(std::declval<Container>().end())>::iterator_category,
+          std::input_iterator_tag
+      >::value, int> = 0>
   const SmallVector& operator=(Container&& C) {
     this->assign(C.begin(), C.end());
     return *this;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42694 Restrict conversion to SmallVector**

The old implementation allowed calling SmallVector constructor and operator= for any type without restrictions,
but then failed with a compiler error when the type wasn't a collection.

Instead, we should only use it if Container follows a container concept and just not match the constructor otherwise.

This fixes an issue @kimishpatel was running into.

Differential Revision: [D22983020](https://our.internmc.facebook.com/intern/diff/D22983020/)