### PR TITLE
Clip Binomial results for different endpoints in curand_uniform

### DIFF
--- a/aten/src/ATen/native/Distributions.h
+++ b/aten/src/ATen/native/Distributions.h
@@ -166,13 +166,7 @@ C10_DEVICE scalar_t binomial_inversion(scalar_t count, scalar_t prob, BaseSample
 
   while (1) {
     U = standard_uniform.sample();
-    // Cuda's curand_uniform can return 1.0 but not 0.0
-    // Reject 1.0 since it will produce geom == 0.0
-    accscalar_t logU = compat_log(U);
-    if (logU == 0.0) {
-      continue;
-    }
-    accscalar_t geom = compat_ceil(logU / logprob);
+    accscalar_t geom = compat_ceil(compat_log(U) / logprob);
     geom_sum += geom;
     if (geom_sum > count) {
       break;

--- a/aten/src/ATen/native/Distributions.h
+++ b/aten/src/ATen/native/Distributions.h
@@ -166,7 +166,13 @@ C10_DEVICE scalar_t binomial_inversion(scalar_t count, scalar_t prob, BaseSample
 
   while (1) {
     U = standard_uniform.sample();
-    accscalar_t geom = compat_ceil(compat_log(U) / logprob);
+    // Cuda's curand_uniform can return 1.0 but not 0.0
+    // Reject 1.0 since it will produce geom == 0.0
+    accscalar_t logU = compat_log(U);
+    if (logU == 0.0) {
+      continue;
+    }
+    accscalar_t geom = compat_ceil(logU / logprob);
     geom_sum += geom;
     if (geom_sum > count) {
       break;

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -69,14 +69,11 @@ struct curand_uniform_wrapper {
   curandStatePhilox4_32_10_t &state;
   __device__ curand_uniform_wrapper(curandStatePhilox4_32_10_t &state): state(state) {}
   __device__ float operator()() {
-    auto val = curand_uniform(&state);
-    // val is from 0.0 to 1.0, where 1.0 is included and 0.0 is excluded
-    // We want 1.0 excluded and 0.0 included
-    // Use the same trick as in uniform_real to rescale val
-    constexpr auto MASK = (static_cast<uint64_t>(1) << std::numeric_limits<float>::digits) - 1;
-    constexpr auto DIVISOR = static_cast<float>(1) / (static_cast<uint64_t>(1) << std::numeric_limits<float>::digits);
-    val = (static_cast<uint64_t>(val) & MASK) * DIVISOR;
-    return val;
+
+  uint val = curand(&state); //need just bits
+  constexpr auto MASK = static_cast<uint>((static_cast<uint64_t>(1) << std::numeric_limits<float>::digits) - 1);
+  constexpr auto DIVISOR = static_cast<float>(1) / (static_cast<uint>(1) << std::numeric_limits<float>::digits);
+    return (val & MASK) * DIVISOR;
   }
 };
 

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -69,7 +69,13 @@ struct curand_uniform_wrapper {
   curandStatePhilox4_32_10_t &state;
   __device__ curand_uniform_wrapper(curandStatePhilox4_32_10_t &state): state(state) {}
   __device__ float operator()() {
-    return curand_uniform(&state);
+    auto val = curand_uniform(&state);
+    // val is from 0.0 to 1.0, where 1.0 is included and 0.0 is excluded
+    // We want 1.0 excluded and 0.0 included
+    if (val == 1.0F) {
+        val = 0.0F;
+    }
+    return val;
   }
 };
 

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -70,9 +70,9 @@ struct curand_uniform_wrapper {
   __device__ curand_uniform_wrapper(curandStatePhilox4_32_10_t &state): state(state) {}
   __device__ float operator()() {
 
-  uint val = curand(&state); //need just bits
-  constexpr auto MASK = static_cast<uint>((static_cast<uint64_t>(1) << std::numeric_limits<float>::digits) - 1);
-  constexpr auto DIVISOR = static_cast<float>(1) / (static_cast<uint>(1) << std::numeric_limits<float>::digits);
+  uint32_t val = curand(&state); //need just bits
+  constexpr auto MASK = static_cast<uint32_t>((static_cast<uint64_t>(1) << std::numeric_limits<float>::digits) - 1);
+  constexpr auto DIVISOR = static_cast<float>(1) / (static_cast<uint32_t>(1) << std::numeric_limits<float>::digits);
     return (val & MASK) * DIVISOR;
   }
 };

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -72,9 +72,10 @@ struct curand_uniform_wrapper {
     auto val = curand_uniform(&state);
     // val is from 0.0 to 1.0, where 1.0 is included and 0.0 is excluded
     // We want 1.0 excluded and 0.0 included
-    if (val == 1.0F) {
-        val = 0.0F;
-    }
+    // Use the same trick as in uniform_real to rescale val
+    constexpr auto MASK = (static_cast<uint64_t>(1) << std::numeric_limits<float>::digits) - 1;
+    constexpr auto DIVISOR = static_cast<float>(1) / (static_cast<uint64_t>(1) << std::numeric_limits<float>::digits);
+    val = (static_cast<uint64_t>(val) & MASK) * DIVISOR;
     return val;
   }
 };

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1100,6 +1100,12 @@ class TestDistributions(TestCase):
                         probs=torch.tensor(0.1).cuda()
                         ).sample(torch.Size((100000000,)))
         self.assertTrue((vals < 2).all())
+        vals = Binomial(total_count=torch.tensor(1.0).cuda(),
+                        probs=torch.tensor(0.5).cuda()
+                        ).sample(torch.Size((10000,)))
+        # vals should be roughly half zeroes, half ones
+        assert (vals == 0.0).sum() > 4000
+        assert (vals == 1.0).sum() > 4000
 
     def test_multinomial_1d(self):
         total_count = 10

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1090,6 +1090,17 @@ class TestDistributions(TestCase):
             expected = scipy.stats.nbinom(total_count.cpu().numpy(), 1 - probs.cpu().numpy()).logpmf(sample)
             self.assertEqual(log_prob, expected, atol=1e-4, rtol=0)
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_zero_excluded_binomial(self):
+        vals = Binomial(total_count=torch.tensor(1.0).cuda(),
+                        probs=torch.tensor(0.9).cuda()
+                        ).sample(torch.Size((100000000,)))
+        self.assertTrue((vals >= 0).all())
+        vals = Binomial(total_count=torch.tensor(1.0).cuda(),
+                        probs=torch.tensor(0.1).cuda()
+                        ).sample(torch.Size((100000000,)))
+        self.assertTrue((vals < 2).all())
+
     def test_multinomial_1d(self):
         total_count = 10
         p = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)


### PR DESCRIPTION
Fixes #42153

As [documented](https://docs.nvidia.com/cuda/curand/device-api-overview.html) (search for `curand_uniform` on the page), `curand_uniform` returns "from 0.0 to 1.0, where 1.0 is included and 0.0 is excluded." These endpoints are different than the CPU equivalent, and makes the calculation in the PR fail when the value is 1.0.

The test from the issue is added, it failed for me consistently before the PR even though I cut the number of samples by 10.