### PR TITLE
Fix `torch.nn.functional.grid_sample` crashes if `grid` has NaNs

### DIFF
--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -203,7 +203,8 @@ struct ComputeLocationBase<scalar_t, /*align_corners=*/true> {
   }
 
   inline Vec clip_coordinates(const Vec &in) const {
-    return minimum(Vec(max_val), maximum(in, Vec(0)));
+    // Invert order of clamp_min operands in order to clamp Nans to zero
+    return clamp_max(Vec(max_val), clamp_min(Vec(0), in));
   }
 
   // same as clip_coordinates but also returns the gradient multiplier
@@ -284,7 +285,8 @@ struct ComputeLocationBase<scalar_t, /*align_corners=*/false> {
   }
 
   inline Vec clip_coordinates(const Vec &in) const {
-    return minimum(Vec(max_val), maximum(in, Vec(0)));
+    // Invert order of clamp_min operands in order to clamp Nans to zero
+    return clamp_max(Vec(max_val), clamp_min(Vec(0), in));
   }
 
   // same as clip_coordinates but also returns the gradient multiplier

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11323,6 +11323,17 @@ class TestNNDeviceType(NNTestCase):
                 res2.backward(torch.randn_like(res2))
                 self.assertTrue(math.isinf(res2.item()))
 
+    @onlyOnCPUAndCUDA
+    @dtypes(torch.float, torch.double)
+    def test_grid_sample_nan_inf(self, device, dtype):
+        input = torch.zeros([1, 1, 3, 3], device=device, dtype=dtype)
+        grid = torch.tensor([[[[nan, 0], [0, inf]]]], device=device, dtype=dtype)
+        for padding_mode in ('reflection', 'border', 'zeros'):
+            sample = torch.nn.functional.grid_sample(input=input, grid=grid, mode='nearest',
+                                                     padding_mode=padding_mode, align_corners=False)
+            self.assertEqual(sample, torch.zeros([1, 1, 1, 2], device=device, dtype=dtype))
+
+
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float)
     @onlyOnCPUAndCUDA  # TODO: Fails on XLA

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3330,6 +3330,9 @@ def grid_sample(input, grid, mode='bilinear', padding_mode='zeros', align_corner
         behaviour in its backward pass that is not easily switched off.
         Please see the notes on :doc:`/notes/randomness` for background.
 
+    Note:
+        NaN values in :attr:`grid` would be interpreted as ``-1``.
+
     Args:
         input (Tensor): input of shape :math:`(N, C, H_\text{in}, W_\text{in})` (4-D case)
                         or :math:`(N, C, D_\text{in}, H_\text{in}, W_\text{in})` (5-D case)


### PR DESCRIPTION
In `clip_coordinates` replace `minimum(maximum(in))` composition with `clamp_max(clamp_min(in))` 
Swap order of `clamp_min` operands to clamp NaNs in grid to 0

Fixes #42616 
