### PR TITLE
Handle fused scale and bias in fake fp16 layernorm

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -16,6 +16,8 @@ class Int8OpsTest(serial.SerializedTestCase):
         tensor_max = np.max(tensor)
         tensor_min = min(0, np.min(tensor))
         scale = np.float32(np.float16((tensor_max - tensor_min) / 255.0))
+        if scale < 1e-6:
+            scale = 1e-6
         zero_point = 0 - tensor_min / scale
         zero_point = int(round(np.clip(zero_point, 0, 255.0)))
         return (scale, zero_point)
@@ -122,24 +124,24 @@ class Int8OpsTest(serial.SerializedTestCase):
         n=st.integers(1, 1024),
         m=st.integers(1, 1024),
         k=st.integers(1, 1024),
+        f=st.integers(10, 50),
         rand_seed=st.integers(0, 65534),
         quantize_bias=st.sampled_from([False]),
     )
     @settings(max_examples=100)
     def test_int8_fc(
-        self, n, m, k, rand_seed, quantize_bias
+        self, n, m, k, rand_seed, quantize_bias, f
     ):
         print(
-            "n={}, m={}, k={}, rand_seed={}, quantize_bias={}".format(
-                n, m, k, rand_seed, quantize_bias
-            )
+            f"n={n}, m={m}, k={k}, rand_seed={rand_seed}, quantize_bias={quantize_bias}"
         )
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
 
-        X_fp32 = np.random.rand(m, k).astype(np.float16).astype(np.float32)
-        W_fp32 = np.random.rand(n, k).astype(np.float32)
-        b_fp32 = np.random.rand(n).astype(np.float16).astype(np.float32)
+        ff = float(f)
+        X_fp32 = np.random.uniform(-ff, ff, size=(m, k)).astype(np.float32)
+        W_fp32 = np.random.uniform(-ff, ff, size=(n, k)).astype(np.float32)
+        b_fp32 = np.random.uniform(-ff, ff, size=(n)).astype(np.float32)
 
         X_scale, X_zero_point = self._get_scale_zp(X_fp32)
         Y_fp32 = np.dot(X_fp32, W_fp32.T) + b_fp32
@@ -233,7 +235,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
 
-        X_fp32 = np.random.uniform(0.01, 0.03, size=(n, n)).astype(np.float16).astype(np.float32)
+        X_fp32 = np.random.uniform(0.01, 0.03, size=(n, n)).astype(np.float32)
         W_fp32 = np.identity(n, dtype=np.float32)
         b_fp32 = np.zeros((n,), dtype=np.float32)
 

--- a/caffe2/opt/custom/fakefp16_transform.cc
+++ b/caffe2/opt/custom/fakefp16_transform.cc
@@ -66,6 +66,77 @@ std::unordered_map<std::string, std::string> getFakeFp16OpMapping(
   return fake_fp16_op_conversion_map;
 }
 
+std::vector<OperatorDef*> findMutableOperatorByInput(
+    NetDef* net,
+    const std::string& input) {
+  std::vector<OperatorDef*> ops;
+
+  for (auto& op : *net->mutable_op()) {
+    for (const auto& i : op.input()) {
+      if (input == i) {
+        ops.push_back(&op);
+      }
+    }
+  }
+  return ops;
+}
+
+void fakeFp16FoldLayerNorm(NetDef* net) {
+  for (auto& op : *net->mutable_op()) {
+    if (op.type() == "LayerNormFakeFP16NNPI") {
+      LOG(INFO) << "Attemping to fuse LayerNormFakeFP16NNPI at "
+                << ArgumentHelper::GetSingleArgument<OperatorDef, int>(
+                       op, "net_pos", -1);
+      if (op.input().size() != 1) {
+        LOG(INFO) << "input isn't 1, skipping";
+        continue;
+      }
+
+      const std::string& lm_output = op.output(0);
+      auto next_ops = findMutableOperatorByInput(net, lm_output);
+
+      if (next_ops.size() != 1 || next_ops[0]->type() != "MulFakeFp16") {
+        LOG(INFO) << "next op isn't MulFakeFp16, skipping";
+        continue;
+      }
+
+      auto* mul_op = next_ops[0];
+
+      auto next_next_ops = findMutableOperatorByInput(net, mul_op->output(0));
+
+      if (next_next_ops.size() != 1 ||
+          next_next_ops[0]->type() != "AddFakeFp16") {
+        LOG(INFO) << "next op isn't AddFakeFp16, skipping";
+        continue;
+      }
+
+      auto* add_op = next_next_ops[0];
+
+      *(op.mutable_input()->Add()) = mul_op->input(1);
+      *(op.mutable_input()->Add()) = add_op->input(1);
+      *op.mutable_output(0) = add_op->output(0);
+
+      mul_op->set_type("delete_me_optimized_away");
+      add_op->set_type("delete_me_optimized_away");
+
+      LOG(INFO) << "Fused LayerNormFakeFP16NNPI";
+    }
+  }
+}
+
+void fakeFp16FuseOps(NetDef* net) {
+  fakeFp16FoldLayerNorm(net);
+
+  auto iter = net->mutable_op()->begin();
+  while (iter != net->mutable_op()->end()) {
+    if (iter->type() == "delete_me_optimized_away") {
+      iter = net->mutable_op()->erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+}
+
 void fakeFp16Transform(NetDef* net) {
   static const std::unordered_map<std::string, std::string>
       kFakeFp16OpConversionMap = getFakeFp16OpMapping(
@@ -101,6 +172,8 @@ void fakeFp16Transform(NetDef* net) {
       op->set_type(it->second);
     }
   }
+
+  fakeFp16FuseOps(net);
 }
 
 } // namespace opt

--- a/caffe2/opt/custom/fakefp16_transform.h
+++ b/caffe2/opt/custom/fakefp16_transform.h
@@ -16,6 +16,8 @@ CAFFE2_API std::unordered_map<std::string, std::string> getFakeFp16OpMapping(
     bool use_fp16_acc = false,
     bool use_nnpi = false);
 
+void fakeFp16FuseOps(NetDef* net);
+
 // Transform normal fp32 operators to fakefp16 operators.
 void fakeFp16Transform(NetDef* net);
 

--- a/caffe2/quantization/server/fbgemm_pack_op.h
+++ b/caffe2/quantization/server/fbgemm_pack_op.h
@@ -15,7 +15,7 @@ void QuantizeConvBias(
     int M,
     const dnnlowp::TensorQuantizationParams& in_qparams,
     const vector<dnnlowp::TensorQuantizationParams>& filter_qparams,
-    std::vector<int32_t>& b_quantized, bool round_nearest_even=true);
+    std::vector<int32_t>& b_quantized, bool use_fp16=false, bool round_nearest_even=true);
 
 class FullyConnectedDNNLowPPackWeightOp final
     : public DNNLowPOp<std::uint8_t, FCFp32Op> {


### PR DESCRIPTION
Summary: Allow passing scale and bias to fake fp16 layernorm.

Test Plan: net_runner. Now matches glow's fused layernorm.

Reviewed By: hyuen

Differential Revision: D22952646

