### PR TITLE
Optimization with Backward Implementation of Learnable Fake Quantize Per Channel Kernel (GPU)

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -179,8 +179,6 @@ void _fake_quantize_grad_learnable_zero_point_channel_kernel_cuda(
 
 REGISTER_DISPATCH(fake_quant_per_channel_stub, &fake_quant_per_channel_cuda);
 REGISTER_DISPATCH(fake_quant_grad_per_channel_stub, &fake_quant_grad_per_channel_cuda);
-REGISTER_DISPATCH(fake_quant_grad_learnable_scale_channel_stub, &_fake_quantize_grad_learnable_scale_channel_kernel_cuda);
-REGISTER_DISPATCH(fake_quant_grad_learnable_zero_point_channel_stub, &_fake_quantize_grad_learnable_zero_point_channel_kernel_cuda);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -127,58 +127,33 @@ void fake_quant_grad_per_channel_cuda(TensorIterator &iter, int64_t quant_min, i
     });
 }
 
-void _fake_quantize_grad_learnable_scale_channel_kernel_cuda(
-    Tensor& input_grad,
-    const Tensor& input,
-    const Tensor& output_grad,
-    float scale,
-    int64_t zero_point,
-    int64_t quant_min,
-    int64_t quant_max) {
-  // scalar type of this function is guaranteed to be float
-  float inv_scale = 1.0f / scale;
-  float grad_small = quant_min - zero_point;
-  float grad_big = quant_max - zero_point;
-
-  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
-  gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dy) -> float {
-      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
-      xq = std::max(std::min(xq, quant_max), quant_min);
-      float x_fq = static_cast<float>((xq - zero_point) * scale);
-      if (xq == quant_min) {
-        return dy * grad_small;
-      } else if (xq == quant_max) {
-        return dy * grad_big;
+void _fake_quantize_grad_learnable_channel_kernel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max) {
+  gpu_kernel_multiple_outputs(iter,
+    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> thrust::tuple<float, float, float> {
+      float dx_output, dscale_output, dzero_point_output;
+      float inv_scale = 1.0f / scale_input;
+      float dscale_small = quant_min - zero_point_input;
+      float dscale_big = quant_max - zero_point_input;
+      // Calculate gradients for X.
+      int64_t xqi = std::nearbyint(zero_point_input + x_input * inv_scale);
+      dx_output = dy_input * (xqi >= quant_min && xqi <= quant_max);
+      // Calculate gradients for scale and zero point.
+      xqi = std::max(std::min(xqi, quant_max), quant_min);
+      float xfqi = static_cast<float>((xqi - zero_point_input) * scale_input);
+      if (xqi == quant_min || xqi == quant_max) {
+        dzero_point_output = dy_input * (-1) * scale_input;
+        dscale_output = (xqi == quant_min) ? (dy_input * dscale_small) : (dy_input * dscale_big);
+      } else {
+        dzero_point_output = 0;
+        dscale_output = dy_input * (xfqi - x_input) * inv_scale;
       }
-      return dy * (x_fq - x) * inv_scale;
-    });
-}
-
-void _fake_quantize_grad_learnable_zero_point_channel_kernel_cuda(
-    Tensor& input_grad,
-    const Tensor& input,
-    const Tensor& output_grad,
-    float scale,
-    int64_t zero_point,
-    int64_t quant_min,
-    int64_t quant_max) {
-  // scalar type of this function is guaranteed to be float
-  float inv_scale = 1.0f / scale;
-  auto iter = TensorIterator::binary_op(input_grad, input, output_grad);
-  gpu_kernel(iter,
-    [=] GPU_LAMBDA (float x, float dy) -> float {
-      int64_t xq = static_cast<int64_t>(zero_point + std::nearbyint(x * inv_scale));
-      xq = std::max(std::min(xq, quant_max), quant_min);
-      if (xq == quant_min || xq == quant_max) {
-        return dy * (-1) * scale;
-      }
-      return 0;
+      return {dx_output, dscale_output, dzero_point_output};
     });
 }
 
 REGISTER_DISPATCH(fake_quant_per_channel_stub, &fake_quant_per_channel_cuda);
 REGISTER_DISPATCH(fake_quant_grad_per_channel_stub, &fake_quant_grad_per_channel_cuda);
+REGISTER_DISPATCH(fake_quant_grad_learnable_channel_stub, &_fake_quantize_grad_learnable_channel_kernel_cuda);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -45,8 +45,7 @@ using fake_quant_per_channel_fn = void (*)(
 
 DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_per_channel_stub);
 DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_grad_per_channel_stub);
-DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_scale_channel_stub);
-DECLARE_DISPATCH(fake_quant_grad_tensor_fn, fake_quant_grad_learnable_zero_point_channel_stub);
+DECLARE_DISPATCH(fake_quant_per_channel_fn, fake_quant_grad_learnable_channel_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -12,8 +12,7 @@ namespace native {
 // Use REGISTER_DISPATCH to run CPU and CUDA backend.
 DEFINE_DISPATCH(fake_quant_per_channel_stub);
 DEFINE_DISPATCH(fake_quant_grad_per_channel_stub);
-DEFINE_DISPATCH(fake_quant_grad_learnable_scale_channel_stub);
-DEFINE_DISPATCH(fake_quant_grad_learnable_zero_point_channel_stub);
+DEFINE_DISPATCH(fake_quant_grad_learnable_channel_stub);
 
 /* Per channel fake-quantizes the 'inputs' tensor.
 Args:
@@ -163,24 +162,6 @@ Tensor fake_quantize_per_channel_affine_backward(
   return dX;
 }
 
-TensorIterator _build_iterator(
-    const Tensor& dX,
-    const Tensor& X,
-    const Tensor& dY,
-    const Tensor& scale,
-    const Tensor& zero_point,
-    std::vector<int64_t> expected_shape) {
-  TensorIterator iter = TensorIteratorConfig()
-    .check_all_same_dtype(false)
-    .add_output(dX)
-    .add_input(X)
-    .add_input(dY)
-    .add_input(native::_unsafe_view(scale, expected_shape))
-    .add_input(native::_unsafe_view(zero_point, expected_shape))
-    .build();
-  return iter;
-}
-
 Tensor _get_rounded_zero_point(
     const Tensor& zero_point,
     int64_t quant_min,
@@ -190,43 +171,6 @@ Tensor _get_rounded_zero_point(
     zero_point[i] = static_cast<int64_t>(zero_point[i].item<float>() + 0.5);
   }
   return zero_point.clamp(quant_min, quant_max).to(at::kLong);
-}
-
-std::tuple<Tensor, Tensor> _get_scale_zero_point_per_channel_iter_grads(
-    const Tensor& dY,
-    const Tensor& X,
-    const Tensor& scale,
-    const Tensor& zero_point,
-    int64_t axis,
-    int64_t quant_min,
-    int64_t quant_max) {
-
-  int64_t axis_size = X.size(axis);
-  std::vector<Tensor> X_flattened = at::unbind(X, axis);
-  std::vector<Tensor> dY_flattened = at::unbind(dY, axis);
-
-  Tensor dScale = at::zeros({scale.sizes()[0]});
-  Tensor dZeroPoint = at::zeros({zero_point.sizes()[0]});
-
-  for (int i = 0; i < X_flattened.size(); ++i) {
-    Tensor X_i = X_flattened[i];
-    Tensor dY_i = dY_flattened[i];
-    auto dScale_item_vec = at::empty_like(X_i, X_i.options(), MemoryFormat::Preserve);
-    auto dZeroPoint_item_vec = at::empty_like(X_i, X_i.options(), MemoryFormat::Preserve);
-
-    float scale_i = scale[i].item<float>();
-    int64_t zero_point_i = static_cast<int64_t>(std::min(std::max(zero_point[i].item<float>() + 0.5f, quant_min), quant_max));
-    fake_quant_grad_learnable_scale_channel_stub(
-      scale.device().type(), dScale_item_vec, X_i, dY_i, scale_i, zero_point_i, quant_min, quant_max);
-    fake_quant_grad_learnable_zero_point_channel_stub(
-      zero_point.device().type(), dZeroPoint_item_vec, X_i, dY_i, scale_i, zero_point_i, quant_min, quant_max);
-    float scale_item = dScale_item_vec.sum().unsqueeze(0).item<float>();
-    float zero_point_item = dZeroPoint_item_vec.sum().unsqueeze(0).item<float>();
-
-    dScale[i] = scale_item;
-    dZeroPoint[i] = zero_point_item;
-  }
-  return std::make_tuple(dScale, dZeroPoint);
 }
 
 Tensor _fake_quantize_learnable_per_channel_affine(
@@ -300,21 +244,50 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_channel_affine_b
 
   auto zero_point_rounded = _get_rounded_zero_point(zero_point, quant_min, quant_max);
   auto dX = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  auto dScale_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  auto dZeroPoint_vec = at::empty_like(X, X.options(), MemoryFormat::Preserve);
+  int numDimensions = X.ndimension();
 
-  std::vector<int64_t> expected_shape_X(X.dim(), 1);
-  expected_shape_X[axis] = X.size(axis);
+  // Create an axis mask for vectorizing and reshaping the scale and zero point tensors
+  // into the same shapes as X along the channel axis.
+  int64_t* axis_mask = (int64_t *) calloc(numDimensions, sizeof(int64_t));
+  for (int i = 0; i < numDimensions; ++i) {
+    axis_mask[i] = (i == axis) ? X.size(axis) : 1;
+  }
+  auto X_shape = X.sizes();
+  auto scale_vectorized = scale.reshape(at::IntArrayRef(axis_mask, numDimensions)).expand(X_shape);
+  auto zero_point_vectorized = zero_point.reshape(at::IntArrayRef(axis_mask, numDimensions)).expand(X_shape);
 
-  TensorIterator iter_X = native::_build_iterator(
-    dX, X, dY, scale, zero_point_rounded, expected_shape_X);
+  auto iter = TensorIteratorConfig()
+    .add_output(dX)
+    .add_output(dScale_vec)
+    .add_output(dZeroPoint_vec)
+    .add_input(X)
+    .add_input(dY)
+    .add_input(scale_vectorized)
+    .add_input(zero_point_vectorized)
+    .build();
 
-  fake_quant_grad_per_channel_stub(iter_X.device_type(), iter_X, quant_min, quant_max);
+  fake_quant_grad_learnable_channel_stub(
+    X.device().type(), iter, quant_min, quant_max);
 
-  std::tuple<Tensor, Tensor> dScaleZeroPoints = native::_get_scale_zero_point_per_channel_iter_grads(
-    dY, X, scale, zero_point, axis, quant_min, quant_max);
+  auto numElements = X.ndimension() - 1;
 
-  Tensor dScale = std::get<0>(dScaleZeroPoints).to(scale.device());
-  Tensor dZeroPoint = std::get<1>(dScaleZeroPoints).to(zero_point.device());
+  // Create a collection of axes that include all but the channel axis for
+  // reduction when summing over the dScale and dZeroPoint tensors.
+  int64_t* axis_for_reduction = (int64_t*) calloc(numElements, sizeof(int64_t));
+  for (int i = 0; i < axis; ++i) {
+    axis_for_reduction[i] = i;
+  }
+  for (int i = axis; i < numElements; ++i) {
+    axis_for_reduction[i] = i + 1;
+  }
 
+  auto dScale = dScale_vec.sum(at::IntArrayRef(axis_for_reduction, numElements));
+  auto dZeroPoint = dZeroPoint_vec.sum(at::IntArrayRef(axis_for_reduction, numElements));
+
+  free(axis_mask);
+  free(axis_for_reduction);
   return std::make_tuple(dX, dScale, dZeroPoint);
 }
 } // namespace native

--- a/benchmarks/operator_benchmark/pt/quantization_test.py
+++ b/benchmarks/operator_benchmark/pt/quantization_test.py
@@ -233,8 +233,6 @@ class FakeQuantizePerChannelOpBenchmark(op_bench.TorchBenchmarkBase):
         self.scale = torch.tensor([1.] * C).to(device)
         self.zero_point = torch.tensor([0.] * C).to(device)
         self.input.requires_grad_()
-        self.scale.requires_grad_()
-        self.zero_point.requires_grad_()
         self.args = [
             self.input, self.scale, self.zero_point,
             self.axis, self.quant_min, self.quant_max
@@ -245,6 +243,8 @@ class FakeQuantizePerChannelOpBenchmark(op_bench.TorchBenchmarkBase):
         elif op_type == 'learnable_kernel':
             self.op = torch._fake_quantize_learnable_per_channel_affine
         else:
+            self.scale.requires_grad = False
+            self.args[2] = torch.tensor([0] * C).to(device)
             self.op = torch.fake_quantize_per_channel_affine
 
     def forward(self):

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -1175,7 +1175,7 @@ class TestFakeQuantizePerChannel(TestCase):
                 torch.allclose(dZeroPoint_expected, dZeroPoint_actual, rtol=tolerance, atol=tolerance),
                 "Expected dZeroPoint to match zero_point.grad")
 
-    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(2, 5,),
                                    qparams=hu.qparams(dtypes=torch.quint8)))
     def test_learnable_backward_per_channel_cpu(self, X):
         torch.random.manual_seed(NP_RANDOM_SEED)

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -1187,7 +1187,7 @@ class TestFakeQuantizePerChannel(TestCase):
         self._test_learnable_backward_per_channel(
             X_base, 'cpu', scale_base, zero_point_base, axis)
 
-    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(2, 5,),
                                    qparams=hu.qparams(dtypes=torch.quint8)))
     @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
     def test_learnable_backward_per_channel_cuda(self, X):


### PR DESCRIPTION
Summary:
In this diff, the original backward pass implementation is sped up by merging the 3 iterations computing dX, dScale, and dZeroPoint separately. In this case, a native loop is directly used on a byte-wise level (referenced by `strides`). In addition, broadcasting is used such that scale and zero point are expanded to share the same shape and the element-wise corresponding values to X along the channel axis.

In the benchmark test on the operators, for an input of shape `3x3x256x256`, we have observed the following improvement in performance:
**Speedup from python operator**: ~3.5x
**Speedup from original learnable kernel**: ~2x

Test Plan:
To assert correctness of the new kernel, on a devvm, enter the command

`buck test //caffe2/test:quantization -- learnable_backward_per_channel`

To benchmark the operators, on a devvm, enter the command
1. Set the kernel size to 3x3x256x256 or a reasonable input size.
2. Run
```
buck test mode/dev-nosan //caffe2/benchmarks/operator_benchmark/pt:quantization_test
```
3. The relevant outputs are as follows

**Pre-optimization**:

```
# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typepy_module
# Input: N: 3, C: 3, H: 256, W: 256, device: cpu, op_type: py_module
Backward Execution Time (us) : 6795.173

# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typelearnable_kernel
# Input: N: 3, C: 3, H: 256, W: 256, device: cpu, op_type: learnable_kernel
Backward Execution Time (us) : 4321.351

# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typeoriginal_kernel
# Input: N: 3, C: 3, H: 256, W: 256, device: cpu, op_type: original_kernel
Backward Execution Time (us) : 1052.066
```

**Post-optimization**:
```
# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typepy_module
# Input: N: 3, C: 3, H: 256, W: 256, device: cpu, op_type: py_module
Backward Execution Time (us) : 6737.106

# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typelearnable_kernel
# Input: N: 3, C: 3, H: 256, W: 256, device: cpu, op_type: learnable_kernel
Backward Execution Time (us) : 2112.484

# Benchmarking PyTorch: FakeQuantizePerChannelOpBenchmark
# Mode: Eager
# Name: FakeQuantizePerChannelOpBenchmark_N3_C3_H256_W256_cuda_op_typeoriginal_kernel
# Input: N: 3, C: 3, H: 256, W: 256, device: cpu, op_type: original_kernel
Backward Execution Time (us) : 1078.79
```

Differential Revision: D23002544

