### PR TITLE
[ONNX] Export split_to_sequence as slice when output number is static

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -61,6 +61,23 @@ class TestUtilityFuns(TestCase):
         assert "Provided key invalid_name2 for dynamic axes is not a valid input/output name" in messages
         assert len(messages) == 2
 
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_split_to_slice(self):
+        class SplitModule(torch.nn.Module):
+            def forward(self, x, y, t):
+                splits = (x.size(1), y.size(1))
+                out, out2 = torch.split(t, splits, dim=1)
+                return out, out2
+
+        _set_opset_version(self.opset_version)
+        _set_operator_export_type(OperatorExportTypes.ONNX)
+        x = torch.randn(2, 3)
+        y = torch.randn(2, 4)
+        t = torch.randn(2, 7)
+        graph, _, _ = utils._model_to_graph(SplitModule(), (x, y, t))
+        for node in graph.nodes():
+            assert node.kind() != "onnx::SplitToSequence"
+
     def test_constant_fold_transpose(self):
         class TransposeModule(torch.nn.Module):
             def forward(self, x):
@@ -827,7 +844,7 @@ class TestUtilityFuns(TestCase):
                           opset_version=self.opset_version, training=torch.onnx.TrainingMode.TRAINING)
         ort_sess = onnxruntime.InferenceSession(f.getvalue())
         ort_inputs = {ort_sess.get_inputs()[0].name: x.cpu().numpy()}
-        ort_outs1 = ort_sess.run(None, ort_inputs)      
+        ort_outs1 = ort_sess.run(None, ort_inputs)
         f = io.BytesIO()
         torch.onnx.export(model, (x,), f,
                           opset_version=self.opset_version, training=torch.onnx.TrainingMode.EVAL)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -368,7 +368,7 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
             return split_out
         # Convert to multiple slice nodes iff number of splits and number of outputs are statically known.
         if sym_help._is_value(split_size_or_sizes) and split_size_or_sizes.node().kind() == 'prim::ListConstruct' \
-            and len(list(split_size_or_sizes.node().inputs())) == _outputs:
+                and len(list(split_size_or_sizes.node().inputs())) == _outputs:
             split_sizes = [g.op("Unsqueeze", v, axes_i=[0]) for v in split_size_or_sizes.node().inputs()]
             start = g.op("Constant", value_t=torch.tensor([0], dtype=torch.long))
             end = split_sizes[0]

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -366,6 +366,19 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
         split_out = g.op("SplitToSequence", self, split_size_or_sizes, axis_i=dim)
         if _outputs is None:
             return split_out
+        # Convert to multiple slice nodes iff number of splits and number of outputs are statically known.
+        if sym_help._is_value(split_size_or_sizes) and split_size_or_sizes.node().kind() == 'prim::ListConstruct' \
+            and len(list(split_size_or_sizes.node().inputs())) == _outputs:
+            split_sizes = [g.op("Unsqueeze", v, axes_i=[0]) for v in split_size_or_sizes.node().inputs()]
+            start = g.op("Constant", value_t=torch.tensor([0], dtype=torch.long))
+            end = split_sizes[0]
+            axis = g.op("Constant", value_t=torch.tensor([dim], dtype=torch.long))
+            res = []
+            for i in range(_outputs):
+                res.append(g.op("Slice", self, start, end, axis))
+                start = end
+                end = g.op("Add", start, end)
+            return res
         return [g.op("SequenceAt", split_out, g.op("Constant", value_t=torch.tensor([i], dtype=torch.long)))
                 for i in range(_outputs)]
     else:

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -367,9 +367,8 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
         if _outputs is None:
             return split_out
         # Convert to multiple slice nodes iff number of splits and number of outputs are statically known.
-        if sym_help._is_value(split_size_or_sizes) and split_size_or_sizes.node().kind() == 'prim::ListConstruct' \
-                and len(list(split_size_or_sizes.node().inputs())) == _outputs:
-            split_sizes = [g.op("Unsqueeze", v, axes_i=[0]) for v in split_size_or_sizes.node().inputs()]
+        if sym_help._is_packed_list(split_size_or_sizes) and len(sym_help._unpack_list(split_size_or_sizes)) == _outputs:
+            split_sizes = [g.op("Unsqueeze", v, axes_i=[0]) for v in sym_help._unpack_list(split_size_or_sizes)]
             start = g.op("Constant", value_t=torch.tensor([0], dtype=torch.long))
             end = split_sizes[0]
             axis = g.op("Constant", value_t=torch.tensor([dim], dtype=torch.long))


### PR DESCRIPTION
Optimize exported graph to export slice nodes for aten::split when the number of split outputs are fixed. Previously under some cases these are exported as onnx::SplitToSequence, which is dynamic in tensor output count.