### PR TITLE
fix celu in quantized benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/qactivation_test.py
+++ b/benchmarks/operator_benchmark/pt/qactivation_test.py
@@ -84,7 +84,8 @@ class QActivationBenchmarkBase(op_bench.TorchBenchmarkBase):
         self.qop = op_func
 
     def forward(self):
-        if self.qop in (nnq.functional.hardswish, nnq.functional.elu):
+        if self.qop in (nnq.functional.hardswish, nnq.functional.elu,
+                        nnq.functional.celu):
             return self.qop(self.q_input, scale=self.scale, zero_point=self.zero_point)
         return self.qop(self.q_input)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42756 fix celu in quantized benchmark**

Summary:

Similar to ELU, CELU was also broken in the quantized benchmark, fixing.

Test Plan:

```
cd benchmarks/operator_benchmark
python -m pt.qactivation_test
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23010863](https://our.internmc.facebook.com/intern/diff/D23010863)