### PR TITLE
align qconv benchmark to conv benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -71,4 +71,3 @@ conv_3d_configs_short = op_bench.config_list(
     },
     tags=['short']
 )
-

--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -1,0 +1,74 @@
+import operator_benchmark as op_bench
+
+"""
+Configs shared by multiple benchmarks
+"""
+
+# Configs for conv-1d ops
+conv_1d_configs_short = op_bench.config_list(
+    attr_names=[
+        'IC', 'OC', 'kernel', 'stride', 'N', 'L'
+    ],
+    attrs=[
+        [128, 256, 3, 1, 1, 64],
+        [256, 256, 3, 2, 4, 64],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=['short']
+)
+
+conv_1d_configs_long = op_bench.cross_product_configs(
+    IC=[128, 512],
+    OC=[128, 512],
+    kernel=[3],
+    stride=[1, 2],
+    N=[8],
+    L=[128],
+    device=['cpu', 'cuda'],
+    tags=["long"]
+)
+
+# Configs for Conv2d and ConvTranspose1d
+conv_2d_configs_short = op_bench.config_list(
+    attr_names=[
+        'IC', 'OC', 'kernel', 'stride', 'N', 'H', 'W', 'G', 'pad',
+    ],
+    attrs=[
+        [256, 256, 3, 1, 1, 16, 16, 1, 0],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=['short']
+)
+
+conv_2d_configs_long = op_bench.cross_product_configs(
+    IC=[128, 256],
+    OC=[128, 256],
+    kernel=[3],
+    stride=[1, 2],
+    N=[4],
+    H=[32],
+    W=[32],
+    G=[1],
+    pad=[0],
+    device=['cpu', 'cuda'],
+    tags=["long"]
+)
+
+# Configs for Conv3d and ConvTranspose3d
+conv_3d_configs_short = op_bench.config_list(
+    attr_names=[
+        'IC', 'OC', 'kernel', 'stride', 'N', 'D', 'H', 'W'
+    ],
+    attrs=[
+        [64, 64, 3, 1, 8, 4, 16, 16],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=['short']
+)
+

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -8,38 +8,11 @@ import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
 
+from . import configs
 
 """
 Microbenchmarks for Conv1d and ConvTranspose1d operators.
 """
-
-
-# Configs for conv-1d ops
-conv_1d_configs_short = op_bench.config_list(
-    attr_names=[
-        'IC', 'OC', 'kernel', 'stride', 'N', 'L'
-    ],
-    attrs=[
-        [128, 256, 3, 1, 1, 64],
-        [256, 256, 3, 2, 4, 64],
-    ],
-    cross_product_configs={
-        'device': ['cpu', 'cuda'],
-    },
-    tags=['short']
-)
-
-conv_1d_configs_long = op_bench.cross_product_configs(
-    IC=[128, 512],
-    OC=[128, 512],
-    kernel=[3],
-    stride=[1, 2],
-    N=[8],
-    L=[128],
-    device=['cpu', 'cuda'],
-    tags=["long"]
-)
-
 
 class Conv1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, L, device):
@@ -61,44 +34,15 @@ class ConvTranspose1dBenchmark(op_bench.TorchBenchmarkBase):
         return self.convtranspose1d(self.input)
 
 
-op_bench.generate_pt_test(conv_1d_configs_short + conv_1d_configs_long,
+op_bench.generate_pt_test(configs.conv_1d_configs_short + configs.conv_1d_configs_long,
                           Conv1dBenchmark)
-op_bench.generate_pt_test(conv_1d_configs_short + conv_1d_configs_long,
+op_bench.generate_pt_test(configs.conv_1d_configs_short + configs.conv_1d_configs_long,
                           ConvTranspose1dBenchmark)
 
 
 """
 Microbenchmarks for Conv2d and ConvTranspose2d operators.
 """
-
-
-# Configs for Conv2d and ConvTranspose1d
-conv_2d_configs_short = op_bench.config_list(
-    attr_names=[
-        'IC', 'OC', 'kernel', 'stride', 'N', 'H', 'W', 'G', 'pad',
-    ],
-    attrs=[
-        [256, 256, 3, 1, 1, 16, 16, 1, 0],
-    ],
-    cross_product_configs={
-        'device': ['cpu', 'cuda'],
-    },
-    tags=['short']
-)
-
-conv_2d_configs_long = op_bench.cross_product_configs(
-    IC=[128, 256],
-    OC=[128, 256],
-    kernel=[3],
-    stride=[1, 2],
-    N=[4],
-    H=[32],
-    W=[32],
-    G=[1],
-    pad=[0],
-    device=['cpu', 'cuda'],
-    tags=["long"]
-)
 
 
 class Conv2dBenchmark(op_bench.TorchBenchmarkBase):
@@ -123,30 +67,15 @@ class ConvTranspose2dBenchmark(op_bench.TorchBenchmarkBase):
         return self.convtranspose2d(self.input)
 
 
-op_bench.generate_pt_test(conv_2d_configs_short + conv_2d_configs_long,
+op_bench.generate_pt_test(configs.conv_2d_configs_short + configs.conv_2d_configs_long,
                           Conv2dBenchmark)
-op_bench.generate_pt_test(conv_2d_configs_short + conv_2d_configs_long,
+op_bench.generate_pt_test(configs.conv_2d_configs_short + configs.conv_2d_configs_long,
                           ConvTranspose2dBenchmark)
 
 
 """
 Microbenchmarks for Conv3d and ConvTranspose3d operators.
 """
-
-# Configs for Conv3d and ConvTranspose3d
-conv_3d_configs_short = op_bench.config_list(
-    attr_names=[
-        'IC', 'OC', 'kernel', 'stride', 'N', 'D', 'H', 'W'
-    ],
-    attrs=[
-        [64, 64, 3, 1, 8, 4, 16, 16],
-    ],
-    cross_product_configs={
-        'device': ['cpu', 'cuda'],
-    },
-    tags=['short']
-)
-
 
 class Conv3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, D, H, W, device):
@@ -168,8 +97,8 @@ class ConvTranspose3dBenchmark(op_bench.TorchBenchmarkBase):
         return self.convtranspose3d(self.input)
 
 
-op_bench.generate_pt_test(conv_3d_configs_short, Conv3dBenchmark)
-op_bench.generate_pt_test(conv_3d_configs_short,
+op_bench.generate_pt_test(configs.conv_3d_configs_short, Conv3dBenchmark)
+op_bench.generate_pt_test(configs.conv_3d_configs_short,
                           ConvTranspose3dBenchmark)
 
 

--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -4,90 +4,29 @@ import operator_benchmark as op_bench
 import torch
 import torch.nn.quantized as nnq
 
+from . import configs
 
 """
 Microbenchmarks for qConv operators.
 """
 
-# Configs for qconv1d
-
-qconv_1d_configs = op_bench.config_list(
-    attrs=[
-        # Shape matching the floating point short benchmark
-        [1, 128, 256, 64, 1, 3, 1, 0],
-        [4, 256, 256, 64, 1, 3, 2, 0],
-    ],
-    attr_names=["N", "IC", "OC", "L", "G", "kernel", "stride", "pad"],
-    tags=["short"],
-)
-
-# Configs for qconv2d
-qconv_2d_configs = op_bench.config_list(
-    attrs=[
-        # Shape matching the floating point short benchmark
-        [1, 256, 256, 16, 16, 1, 3, 1, 0],
-        # Resnext101 - 32x8d shapes
-        [1, 64, 128, 56, 56, 1, 1, 1, 0],
-        [1, 256, 256, 56, 56, 32, 3, 1, 1],
-        [1, 256, 256, 56, 56, 1, 1, 1, 0],
-        [1, 512, 512, 56, 56, 32, 3, 2, 1],
-    ],
-    attr_names=["N", "IC", "OC", "H", "W", "G", "kernel", "stride", "pad"],
-    tags=["short"],
-)
-
-
-# Configs for convolution shapes from Resnext-101 32x4d
-resnext_32_4d_shape_configs = op_bench.config_list(
-    attrs=[
-        [1, 1024, 1024, 14, 14, 1, 1, 1, 0],  # op#312
-        [1, 1024, 1024, 14, 14, 32, 3, 2, 1],  # op#315
-        [1, 1024, 2048, 14, 14, 1, 1, 2, 0],  # op#320
-        [1, 1024, 512, 14, 14, 1, 1, 1, 0],  # op#92
-        [1, 1024, 1024, 7, 7, 32, 3, 1, 1],  # op#327
-        [1, 1024, 2048, 7, 7, 1, 1, 1, 0],  # op#318
-        [1, 128, 128, 56, 56, 32, 3, 1, 1],  # op#9
-        [1, 128, 256, 56, 56, 1, 1, 1, 0],  # op#12
-        [1, 2048, 1024, 7, 7, 1, 1, 1, 0],  # op#324
-        [1, 256, 256, 28, 28, 32, 3, 1, 1],  # op#53
-        [1, 256, 512, 28, 28, 1, 1, 1, 0],  # op#44
-        [1, 256, 128, 56, 56, 1, 1, 1, 0],  # op#28
-        [1, 256, 128, 56, 56, 1, 1, 1, 1],  # op#18
-        [1, 256, 256, 56, 56, 1, 1, 1, 0],  # op#38
-        [1, 256, 256, 56, 56, 32, 3, 2, 1],  # op#41
-        [1, 256, 512, 56, 56, 1, 1, 2, 0],  # op#46
-        [1, 3, 64, 224, 224, 1, 7, 2, 3],  # op#2
-        [1, 512, 1024, 14, 14, 1, 1, 1, 0],  # op#86
-        [1, 512, 512, 14, 14, 32, 3, 1, 1],  # op#95
-        [1, 512, 1024, 28, 28, 1, 1, 2, 0],  # op#88
-        [1, 512, 256, 28, 28, 1, 1, 1, 0],  # op#50
-        [1, 512, 512, 28, 28, 1, 1, 1, 0],  # op#80
-        [1, 512, 512, 28, 28, 32, 3, 2, 1],  # op#83
-        [1, 64, 128, 56, 56, 1, 1, 1, 0],  # op#6
-        [1, 64, 256, 56, 56, 1, 1, 1, 0],  # op#14
-    ],
-    attr_names=["N", "IC", "OC", "H", "W", "G", "kernel", "stride", "pad"],
-    tags=["resnext101_32x4d"],
-)
-
-class _QConvBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, batch_size, input_channels, output_channels, feature_map_shape, groups, kernel, stride, pad):
-        super(_QConvBenchmark, self).__init__()
+class QConv1dBenchmark(op_bench.TorchBenchmarkBase):
+    # def init(self, N, IC, OC, L, G, kernel, stride, pad):
+    def init(self, IC, OC, kernel, stride, N, L, device):
+        G = 1
+        pad = 0
         self.scale = 1.0 / 255
         self.zero_point = 0
-        X = torch.randn(batch_size, input_channels, *feature_map_shape, dtype=torch.float32)
+        X = torch.randn(N, IC, L, dtype=torch.float32)
         qX = torch.quantize_per_tensor(
             X, scale=self.scale, zero_point=self.zero_point, dtype=torch.quint8
         )
         # Convert the tensor to NHWC format
-        W = torch.randn(output_channels, input_channels // groups, *kernel, dtype=torch.float32)
+        W = torch.randn(OC, IC // G, kernel, dtype=torch.float32)
         self.qW = torch.quantize_per_tensor(W, scale=self.scale, zero_point=0, dtype=torch.qint8)
 
         self.input = qX
 
-class QConv1dBenchmark(_QConvBenchmark):
-    def init(self, N, IC, OC, L, G, kernel, stride, pad):
-        super(QConv1dBenchmark, self).init(N, IC, OC, (L, ), G, (kernel, ), stride, pad)
         self.qconv1d = nnq.Conv1d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
         self.qconv1d.set_weight_bias(self.qW, None)
         self.qconv1d.scale = torch.tensor([self.scale], dtype=torch.double)
@@ -98,9 +37,23 @@ class QConv1dBenchmark(_QConvBenchmark):
         return self.qconv1d(self.input)
 
 
-class QConv2dBenchmark(_QConvBenchmark):
-    def init(self, N, IC, OC, H, W, G, kernel, stride, pad):
-        super(QConv2dBenchmark, self).init(N, IC, OC, (H, W), G, (kernel, kernel), stride, pad)
+class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
+    # def init(self, N, IC, OC, H, W, G, kernel, stride, pad):
+    def init(self, IC, OC, kernel, stride, N, H, W, G, pad, device):
+        # super(QConv2dBenchmark, self).init(N, IC, OC, (H, W), G, (kernel, kernel), stride, pad)
+
+        self.scale = 1.0 / 255
+        self.zero_point = 0
+        X = torch.randn(N, IC, H, W, dtype=torch.float32)
+        qX = torch.quantize_per_tensor(
+            X, scale=self.scale, zero_point=self.zero_point, dtype=torch.quint8
+        )
+        # Convert the tensor to NHWC format
+        W = torch.randn(OC, IC // G, kernel, kernel, dtype=torch.float32)
+        self.qW = torch.quantize_per_tensor(W, scale=self.scale, zero_point=0, dtype=torch.qint8)
+
+        self.input = qX
+
         self.qconv2d = nnq.Conv2d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
         self.qconv2d.set_weight_bias(self.qW, None)
         self.qconv2d.scale = torch.tensor([self.scale], dtype=torch.double)
@@ -111,42 +64,12 @@ class QConv2dBenchmark(_QConvBenchmark):
         return self.qconv2d(self.input)
 
 
-class QConv2dChainedBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, N, IC, OC, H, W, G, kernel, stride, pad):
-        scale = 1.0 / 255
-        zero_point = 0
-        X = torch.randn(N, IC, H, W, dtype=torch.float32)
-        qX = torch.quantize_per_tensor(
-            X, scale=scale, zero_point=zero_point, dtype=torch.quint8
-        )
-        W = torch.randn(OC, IC // G, kernel, kernel, dtype=torch.float32)
-        qW = torch.quantize_per_tensor(W, scale=scale, zero_point=0, dtype=torch.qint8)
+def _remove_cuda(config_list):
+    cuda_config = {'device': 'cuda'}
+    return [config for config in config_list if cuda_config not in config]
 
-        self.input = qX
-        self.qconv2d = nnq.Conv2d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
-        self.qconv2d.weight = qW
-        self.qconv2d.scale = torch.tensor([scale], dtype=torch.double)
-        self.qconv2d.zero_point = torch.tensor([zero_point], dtype=torch.int)
-
-        W2 = torch.randn(OC, OC // G, kernel, kernel, dtype=torch.float32)
-        qW2 = torch.quantize_per_tensor(W2, scale=scale, zero_point=0, dtype=torch.qint8)
-        self.qconv2d2 = nnq.Conv2d(OC, OC, kernel, stride=stride, padding=pad, groups=G)
-        self.qconv2d2.weight = qW2
-        self.qconv2d2.scale = torch.tensor([scale], dtype=torch.double)
-        self.qconv2d2.zero_point = torch.tensor([zero_point], dtype=torch.int)
-        self.set_module_name("QConv2dChained")
-
-    def forward(self):
-        # test that layout propagation works fine
-        x = self.qconv2d(self.input)
-        x = x.relu()
-        return self.qconv2d2(x)
-
-
-op_bench.generate_pt_test(qconv_1d_configs, QConv1dBenchmark)
-op_bench.generate_pt_test(qconv_2d_configs, QConv2dBenchmark)
-op_bench.generate_pt_test(resnext_32_4d_shape_configs, QConv2dBenchmark)
-op_bench.generate_pt_test(qconv_2d_configs, QConv2dChainedBenchmark)
+op_bench.generate_pt_test(_remove_cuda(configs.conv_1d_configs_short + configs.conv_1d_configs_long), QConv1dBenchmark)
+op_bench.generate_pt_test(_remove_cuda(configs.conv_2d_configs_short + configs.conv_2d_configs_long), QConv2dBenchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42767 align qlinear benchmark to linear benchmark
* **#42761 align qconv benchmark to conv benchmark**
* #42756 fix celu in quantized benchmark

Summary:

Makes the qconv benchmark follow the conv benchmark exactly. This way
it will be easy to compare q vs fp with the same settings.

Test Plan:

```
cd benchmarks/operator_benchmark
python -m pt.qconv_test
python -m pt.conv_test
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23012533](https://our.internmc.facebook.com/intern/diff/D23012533)