### PR TITLE
align qlinear benchmark to linear benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -4,6 +4,10 @@ import operator_benchmark as op_bench
 Configs shared by multiple benchmarks
 """
 
+def remove_cuda(config_list):
+    cuda_config = {'device': 'cuda'}
+    return [config for config in config_list if cuda_config not in config]
+
 # Configs for conv-1d ops
 conv_1d_configs_short = op_bench.config_list(
     attr_names=[
@@ -70,4 +74,26 @@ conv_3d_configs_short = op_bench.config_list(
         'device': ['cpu', 'cuda'],
     },
     tags=['short']
+)
+
+linear_configs_short = op_bench.config_list(
+    attr_names=["N", "IN", "OUT"],
+    attrs=[
+        [1, 1, 1],
+        [4, 256, 128],
+        [16, 512, 256],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=["short"]
+)
+
+
+linear_configs_long = op_bench.cross_product_configs(
+    N=[32, 64],
+    IN=[128, 512],
+    OUT=[64, 128],
+    device=['cpu', 'cuda'],
+    tags=["long"]
 )

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -8,30 +8,10 @@ import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
 
+from . import configs
+
 
 """Microbenchmarks for Linear operator."""
-
-linear_configs_short = op_bench.config_list(
-    attr_names=["N", "IN", "OUT"],
-    attrs=[
-        [1, 1, 1],
-        [4, 256, 128],
-        [16, 512, 256],
-    ],
-    cross_product_configs={
-        'device': ['cpu', 'cuda'],
-    },
-    tags=["short"]
-)
-
-
-linear_configs_long = op_bench.cross_product_configs(
-    N=[32, 64],
-    IN=[128, 512],
-    OUT=[64, 128],
-    device=['cpu', 'cuda'],
-    tags=["long"]
-)
 
 
 class LinearBenchmark(op_bench.TorchBenchmarkBase):
@@ -44,7 +24,7 @@ class LinearBenchmark(op_bench.TorchBenchmarkBase):
         return self.linear(self.input_one)
 
 
-op_bench.generate_pt_test(linear_configs_short + linear_configs_long,
+op_bench.generate_pt_test(configs.linear_configs_short + configs.linear_configs_long,
                           LinearBenchmark)
 
 

--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -64,12 +64,8 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
         return self.qconv2d(self.input)
 
 
-def _remove_cuda(config_list):
-    cuda_config = {'device': 'cuda'}
-    return [config for config in config_list if cuda_config not in config]
-
-op_bench.generate_pt_test(_remove_cuda(configs.conv_1d_configs_short + configs.conv_1d_configs_long), QConv1dBenchmark)
-op_bench.generate_pt_test(_remove_cuda(configs.conv_2d_configs_short + configs.conv_2d_configs_long), QConv2dBenchmark)
+op_bench.generate_pt_test(configs.remove_cuda(configs.conv_1d_configs_short + configs.conv_1d_configs_long), QConv1dBenchmark)
+op_bench.generate_pt_test(configs.remove_cuda(configs.conv_2d_configs_short + configs.conv_2d_configs_long), QConv2dBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/qlinear_test.py
+++ b/benchmarks/operator_benchmark/pt/qlinear_test.py
@@ -10,37 +10,11 @@ import torch
 import torch.nn.quantized as nnq
 import torch.nn.quantized.dynamic as nnqd
 
+from . import configs
 
 """
 Microbenchmarks for Quantized Linear operators.
 """
-
-# Configs for qlinear
-qlinear_configs = op_bench.config_list(
-    attrs=[
-        # matches floating point liner
-        [1, 1, 1],
-        [4, 256, 128],
-        [16, 512, 256],
-        # other
-        [1024, 1024, 1024],
-        [64, 320, 800],
-        [64, 512, 768],
-        [16, 512, 256],
-        [128, 128, 128],
-        [256, 256, 512],
-        [6400, 141, 15],
-        [6400, 141, 8],
-        [16, 2504, 211],
-        [16, 1434, 369],
-        [1, 3496, 1024],
-        [16, 512, 256],
-        [1, 3456, 1600],
-    ],
-    attr_names=["N", "IN", "OUT"],  # M, K, N
-    tags=["short"],
-)
-
 
 class _QLinearBenchmarkBase(op_bench.TorchBenchmarkBase):
     def init(self, N, IN, OUT, linear_under_test):
@@ -62,21 +36,21 @@ class _QLinearBenchmarkBase(op_bench.TorchBenchmarkBase):
         return self.qlinear(self.input)
 
 class QLinearBenchmark(_QLinearBenchmarkBase):
-    def init(self, N, IN, OUT):
+    def init(self, N, IN, OUT, device):
         super(QLinearBenchmark, self).init(N, IN, OUT, nnq.Linear(IN, OUT))
         self.input = self.qX
         self.set_module_name("QLinear")
 
 
 class QDynamicLinearBenchmark(_QLinearBenchmarkBase):
-    def init(self, N, IN, OUT):
+    def init(self, N, IN, OUT, device):
         super(QDynamicLinearBenchmark, self).init(N, IN, OUT, nnqd.Linear(IN, OUT))
         self.input = self.X
         self.set_module_name("QDynamicLinear")
 
 
-op_bench.generate_pt_test(qlinear_configs, QLinearBenchmark)
-op_bench.generate_pt_test(qlinear_configs, QDynamicLinearBenchmark)
+op_bench.generate_pt_test(configs.remove_cuda(configs.linear_configs_short + configs.linear_configs_long), QLinearBenchmark)
+op_bench.generate_pt_test(configs.remove_cuda(configs.linear_configs_short + configs.linear_configs_long), QDynamicLinearBenchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42767 align qlinear benchmark to linear benchmark**
* #42761 align qconv benchmark to conv benchmark
* #42756 fix celu in quantized benchmark

Summary:

Same as previous PR, forcing the qlinear benchmark to follow the fp one

Test Plan:

```
cd benchmarks/operator_benchmark
python -m pt.linear_test
python -m pt.qlinear_test
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23013937](https://our.internmc.facebook.com/intern/diff/D23013937)