### PR TITLE
[caffe2] Fix the timeout (stuck) issues of dedup SparseAdagrad C2 kernel

### DIFF
--- a/caffe2/sgd/adagrad_fused_op_gpu.cu
+++ b/caffe2/sgd/adagrad_fused_op_gpu.cu
@@ -267,7 +267,7 @@ __global__ void linear_index_weight_offsets_dedup_kernel(
       : prefix_sum_length_data[group - 1]; // start offset of the segment
   int end = prefix_sum_length_data[group]; // end offset of the segment
 
-  for (int line = start; line < end; line += threadIdx.x) {
+  for (int line = start + threadIdx.x; line < end; line += blockDim.x) {
     // line: the idx in the indices
     seg_id_data[line] = group;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42768 [caffe2] Fix the timeout (stuck) issues of dedup SparseAdagrad C2 kernel**

Backout D22800959. This one is causing the timeout (machine stuck) issues for dedup kernels. Reverting it make the unit test pass.

The issues is that previously I mixed up with threadIdx.x and blockDim.x. The step size (threadIdx.x) can be 0 in the code and it will cause one thread to always hang...

Original commit changeset: 641d52a51070

Differential Revision: [D23008389](https://our.internmc.facebook.com/intern/diff/D23008389/)