### PR TITLE
Enable test_cublas_config_deterministic_error for windows

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -17689,7 +17689,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
             self.assertRaises(RuntimeError, lambda: torch.bmm(b1.cuda(), b2))
 
     @onlyCUDA
-    @unittest.skipIf(IS_WINDOWS, "Test is broken on Windows. See https://github.com/pytorch/pytorch/issues/42501")
     @wrapDeterministicFlagAPITest
     def test_cublas_config_deterministic_error(self, device):
         test_cases = [


### PR DESCRIPTION
test_cublas_config_deterministic_error can pass for windows, so enable it.