### PR TITLE
Follow-up to __torch_function__ for methods PR

### DIFF
--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -325,12 +325,9 @@ static bool dispatch_to_Bool(const Tensor & self) {
 static PyObject * THPVariable_float_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   if (check_has_torch_function(self)) {
-    try {
-      return handle_torch_function(self, "__bool__");
-    }
-    catch(const python_error&) {
-      return nullptr;
-    }
+    HANDLE_TH_ERRORS
+    return handle_torch_function(self, "__bool__");
+    END_HANDLE_TH_ERRORS
   }
   jit::tracer::warn("Converting a tensor to a Python float", jit::tracer::WARN_PYTHON_DATAFLOW);
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
@@ -1016,12 +1013,9 @@ ${py_methods}
 
 static PyObject * THPVariable_bool_scalar(PyObject* self, PyObject* args) {
   if (check_has_torch_function(self)) {
-    try {
-      return handle_torch_function(self, "__bool__");
-    }
-    catch(const python_error&) {
-      return nullptr;
-    }
+    HANDLE_TH_ERRORS
+    return handle_torch_function(self, "__bool__");
+    END_HANDLE_TH_ERRORS
   }
   jit::tracer::warn("Converting a tensor to a Python boolean", jit::tracer::WARN_PYTHON_DATAFLOW);
   return THPVariable_is_nonzero(self, args);

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -325,9 +325,7 @@ static bool dispatch_to_Bool(const Tensor & self) {
 static PyObject * THPVariable_float_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   if (check_has_torch_function(self)) {
-    HANDLE_TH_ERRORS
-    return handle_torch_function(self, "__bool__");
-    END_HANDLE_TH_ERRORS
+    return handle_torch_function(self, "__float__");
   }
   jit::tracer::warn("Converting a tensor to a Python float", jit::tracer::WARN_PYTHON_DATAFLOW);
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
@@ -379,7 +377,7 @@ static Tensor dispatch_invert(const Tensor & self) {
 static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   if (check_has_torch_function(self)) {
-    return handle_torch_function(self, "__float__");
+    return handle_torch_function(self, "__invert__");
   }
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   if (!isIntegralType(self_.scalar_type(), /*includeBool=*/true)) {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -335,12 +335,9 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad, void *unused)
 PyObject *THPVariable_get_volatile(THPVariable *self, void *unused)
 {
   if (check_has_torch_function((PyObject *)self)) {
-    try {
-      return handle_torch_function_getter(self, "volatile");
-    }
-    catch (const python_error&) {
-      return nullptr;
-    }
+    HANDLE_TH_ERRORS
+    return handle_torch_function_getter(self, "volatile");
+    END_HANDLE_TH_ERRORS
   }
   const char* msg = "volatile was removed (Variable.volatile is always False)";
   PyErr_WarnEx(PyExc_UserWarning, msg, 1);
@@ -350,12 +347,9 @@ PyObject *THPVariable_get_volatile(THPVariable *self, void *unused)
 int THPVariable_set_volatile(THPVariable *self, PyObject *obj, void *unused)
 {
   if (check_has_torch_function((PyObject *)self)) {
-    try {
-      return handle_torch_function_setter(self, "volatile", obj);
-    }
-    catch (const python_error&) {
-      return -1;
-    }
+    HANDLE_TH_ERRORS
+    return handle_torch_function_setter(self, "volatile", obj);
+    END_HANDLE_TH_ERRORS_RET(-1)
   }
   return PyErr_WarnEx(PyExc_UserWarning, VOLATILE_WARNING, 1);
 }
@@ -469,12 +463,9 @@ int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj, void *unused
 PyObject *THPVariable_get_name(THPVariable* self, void *unused)
 {
   if (check_has_torch_function((PyObject *)self)) {
-    try {
-      return handle_torch_function_getter(self, "name");
-    }
-    catch (const python_error&) {
-      return nullptr;
-    }
+    HANDLE_TH_ERRORS
+    return handle_torch_function_getter(self, "name");
+    END_HANDLE_TH_ERRORS
   }
   if (self->cdata.name() == "")
     Py_RETURN_NONE;


### PR DESCRIPTION
This is a follow-up PR for #37091, fixing some of the quirks of that PR as that one was landed early to avoid merge conflicts.

This PR addresses the following action items:

- [x] Use error-handling macros instead of a `try`-`catch`.
- [x] Renamed and added comments to clarify the use of `HANDLED_FUNCTIONS_WRAPPERS` in tests. `HANDLED_FUNCTIONS_NAMESPACES` was already removed in the last PR as we had a way to test for methods.

This PR does NOT address the following action item, as it proved to be difficult:

- [ ] Define `__module__`  for whole API.

Single-line repro-er for why this is hard:

```python
>>> torch.Tensor.grad.__get__.__module__ = "torch.Tensor.grad"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'method-wrapper' object has no attribute '__module__'
```

Explanation: Methods  defined in C/properties don't always have a `__dict__` attribute or a mutable `__module__` slot for us to modify.

The documentation action items were addressed in the following commit, with the additional future task of adding the rendered RFCs to the documentation: https://github.com/pytorch/rfcs/pull/3/commits/552ba37c0500f70b8738522591b276c82cb7ca2a