### PR TITLE
Update the documentation for scatter to include streams parameter.

### DIFF
--- a/torch/nn/parallel/comm.py
+++ b/torch/nn/parallel/comm.py
@@ -160,6 +160,9 @@ def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=
           into equal chunks.
         dim (int, optional): A dimension along which to chunk :attr:`tensor`.
           Default: ``0``.
+        streams (Iterable[Stream], optional): an iterable of Streams, among
+          which to execute the scatter. If not specified, the default stream will
+          be utilized.
         out (Sequence[Tensor], optional, keyword-only): the GPU tensors to
           store output results. Sizes of these tensors must match that of
           :attr:`tensor`, except for :attr:`dim`, where the total size must


### PR DESCRIPTION
Fixes #41827 

![Screenshot from 2020-08-10 13-41-20](https://user-images.githubusercontent.com/46765601/89813181-41041380-db0f-11ea-88c2-a97d7b994ac5.png)

Current:
https://pytorch.org/docs/stable/cuda.html#communication-collectives