### PR TITLE
.circleci: Only do comparisons when available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2057,14 +2057,17 @@ jobs:
                 # explicitly exit the step here ourselves before it causes too much trouble
                 exit 0
               fi
-              if [[ -n "<< pipeline.git.base_revision >>" ]]; then
-                PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
-                # If no image exists but the hash is the same as the previous hash then we should error out here
-                if [[ ${PREVIOUS_DOCKER_TAG} = ${DOCKER_TAG} ]]; then
-                  echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-                  echo "       contact the PyTorch team to restore the original images"
-                  exit 1
-                fi
+              # Covers the case where a previous tag doesn't exist for the tree
+              # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
+              if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
+                exit 0
+              fi
+              PREVIOUS_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+              # If no image exists but the hash is the same as the previous hash then we should error out here
+              if [[ "${PREVIOUS_TAG}" = "${DOCKER_TAG}" ]]; then
+                echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+                echo "       contact the PyTorch team to restore the original images"
+                exit 1
               fi
         - run:
             name: build_docker_image_<< parameters.image_name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2050,7 +2050,6 @@ jobs:
               export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
               eval $(aws ecr get-login --no-include-email --region us-east-1)
               set -x
-              PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
               # Check if image already exists, if it does then skip building it
               if docker manifest inspect "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${IMAGE_NAME}:${DOCKER_TAG}"; then
                 circleci-agent step halt
@@ -2058,11 +2057,14 @@ jobs:
                 # explicitly exit the step here ourselves before it causes too much trouble
                 exit 0
               fi
-              # If no image exists but the hash is the same as the previous hash then we should error out here
-              if [[ ${PREVIOUS_DOCKER_TAG} = ${DOCKER_TAG} ]]; then
-                echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-                echo "       contact the PyTorch team to restore the original images"
-                exit 1
+              if [[ -n "<< pipeline.git.base_revision >>" ]]; then
+                PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+                # If no image exists but the hash is the same as the previous hash then we should error out here
+                if [[ ${PREVIOUS_DOCKER_TAG} = ${DOCKER_TAG} ]]; then
+                  echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+                  echo "       contact the PyTorch team to restore the original images"
+                  exit 1
+                fi
               fi
         - run:
             name: build_docker_image_<< parameters.image_name >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2060,11 +2060,12 @@ jobs:
               # Covers the case where a previous tag doesn't exist for the tree
               # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
               if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
-                exit 0
+                echo "Directory '.circleci/docker' not found in tree << pipeline.git.base_revision >>, you should probably rebase onto a more recent commit"
+                exit 1
               fi
-              PREVIOUS_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+              PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
               # If no image exists but the hash is the same as the previous hash then we should error out here
-              if [[ "${PREVIOUS_TAG}" = "${DOCKER_TAG}" ]]; then
+              if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
                 echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
                 echo "       contact the PyTorch team to restore the original images"
                 exit 1

--- a/.circleci/verbatim-sources/job-specs/docker_jobs.yml
+++ b/.circleci/verbatim-sources/job-specs/docker_jobs.yml
@@ -32,11 +32,12 @@
               # Covers the case where a previous tag doesn't exist for the tree
               # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
               if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
-                exit 0
+                echo "Directory '.circleci/docker' not found in tree << pipeline.git.base_revision >>, you should probably rebase onto a more recent commit"
+                exit 1
               fi
-              PREVIOUS_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+              PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
               # If no image exists but the hash is the same as the previous hash then we should error out here
-              if [[ "${PREVIOUS_TAG}" = "${DOCKER_TAG}" ]]; then
+              if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
                 echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
                 echo "       contact the PyTorch team to restore the original images"
                 exit 1

--- a/.circleci/verbatim-sources/job-specs/docker_jobs.yml
+++ b/.circleci/verbatim-sources/job-specs/docker_jobs.yml
@@ -22,7 +22,6 @@
               export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
               eval $(aws ecr get-login --no-include-email --region us-east-1)
               set -x
-              PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
               # Check if image already exists, if it does then skip building it
               if docker manifest inspect "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${IMAGE_NAME}:${DOCKER_TAG}"; then
                 circleci-agent step halt
@@ -30,11 +29,14 @@
                 # explicitly exit the step here ourselves before it causes too much trouble
                 exit 0
               fi
-              # If no image exists but the hash is the same as the previous hash then we should error out here
-              if [[ ${PREVIOUS_DOCKER_TAG} = ${DOCKER_TAG} ]]; then
-                echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-                echo "       contact the PyTorch team to restore the original images"
-                exit 1
+              if [[ -n "<< pipeline.git.base_revision >>" ]]; then
+                PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+                # If no image exists but the hash is the same as the previous hash then we should error out here
+                if [[ ${PREVIOUS_DOCKER_TAG} = ${DOCKER_TAG} ]]; then
+                  echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+                  echo "       contact the PyTorch team to restore the original images"
+                  exit 1
+                fi
               fi
         - run:
             name: build_docker_image_<< parameters.image_name >>

--- a/.circleci/verbatim-sources/job-specs/docker_jobs.yml
+++ b/.circleci/verbatim-sources/job-specs/docker_jobs.yml
@@ -29,14 +29,17 @@
                 # explicitly exit the step here ourselves before it causes too much trouble
                 exit 0
               fi
-              if [[ -n "<< pipeline.git.base_revision >>" ]]; then
-                PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
-                # If no image exists but the hash is the same as the previous hash then we should error out here
-                if [[ ${PREVIOUS_DOCKER_TAG} = ${DOCKER_TAG} ]]; then
-                  echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-                  echo "       contact the PyTorch team to restore the original images"
-                  exit 1
-                fi
+              # Covers the case where a previous tag doesn't exist for the tree
+              # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
+              if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
+                exit 0
+              fi
+              PREVIOUS_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+              # If no image exists but the hash is the same as the previous hash then we should error out here
+              if [[ "${PREVIOUS_TAG}" = "${DOCKER_TAG}" ]]; then
+                echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+                echo "       contact the PyTorch team to restore the original images"
+                exit 1
               fi
         - run:
             name: build_docker_image_<< parameters.image_name >>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42816 .circleci: Only do comparisons when available**

Comparisons were being done on branches where the directory '.circleci/docker'
didn't exist before so let's just move it so that comparison / code branch is
only run when that variable is available

This makes it so that jobs will error out when a previous comparison isn't available

This should resolve issues where nightly builds were failing due to a failed docker build step

Example: https://app.circleci.com/pipelines/github/pytorch/pytorch/198611/workflows/8a316eef-d864-4bb0-863f-1454696b1e8a/jobs/6610393

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D23032900](https://our.internmc.facebook.com/intern/diff/D23032900)