### PR TITLE
Add prim::TypeCheck operation

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -94,6 +94,7 @@ namespace c10 {
   _(aten, backward)                  \
   _(prim, Guard)                     \
   _(prim, BailOut)                   \
+  _(prim, TypeCheck)                 \
   _(prim, FusedConcat)               \
   _(prim, ConstantChunk)             \
   _(prim, MMTreeReduce)              \

--- a/test/cpp/jit/test_interpreter.cpp
+++ b/test/cpp/jit/test_interpreter.cpp
@@ -5,27 +5,56 @@ namespace torch {
 namespace jit {
 
 void testInterp() {
-  constexpr int batch_size = 4;
-  constexpr int input_size = 256;
-  constexpr int seq_len = 32;
+  {
+    auto graph = std::make_shared<Graph>();
+    std::unordered_map<std::string, Value*> vmap;
+    parseIR(
+        R"IR(
+graph(%a.1 : Tensor,
+      %b.1 : Tensor):
+  %t : Float(2:2, 2:1), %type_matched : bool = prim::TypeCheck(%a.1)
+  %14 : Tensor = prim::If(%type_matched)
+    block0():
+      -> (%a.1)
+    block1():
+      -> (%b.1)
+  return (%14)
+  )IR",
+        &*graph,
+        vmap);
 
-  int hidden_size = 2 * input_size;
+    Code print_function(graph, "");
+    bool cond = false;
+    auto a = at::zeros({2, 2});
+    auto b = at::ones({2, 2});
+    InterpreterState print_interp(print_function);
+    std::vector<IValue> stack({a, b});
+    print_interp.run(stack);
+    // TODO: Check something, not crashing is not good enough
+  }
+  {
+    constexpr int batch_size = 4;
+    constexpr int input_size = 256;
+    constexpr int seq_len = 32;
 
-  auto input = at::randn({seq_len, batch_size, input_size}, at::kCUDA);
-  auto hx = at::randn({batch_size, hidden_size}, at::kCUDA);
-  auto cx = at::randn({batch_size, hidden_size}, at::kCUDA);
-  auto w_ih = t_def(at::randn({4 * hidden_size, input_size}, at::kCUDA));
-  auto w_hh = t_def(at::randn({4 * hidden_size, hidden_size}, at::kCUDA));
+    int hidden_size = 2 * input_size;
 
-  auto lstm_g = build_lstm();
-  Code lstm_function(lstm_g, "");
-  InterpreterState lstm_interp(lstm_function);
-  auto outputs = run(lstm_interp, {input[0], hx, cx, w_ih, w_hh});
-  std::tie(hx, cx) = lstm(input[0], hx, cx, w_ih, w_hh);
+    auto input = at::randn({seq_len, batch_size, input_size}, at::kCUDA);
+    auto hx = at::randn({batch_size, hidden_size}, at::kCUDA);
+    auto cx = at::randn({batch_size, hidden_size}, at::kCUDA);
+    auto w_ih = t_def(at::randn({4 * hidden_size, input_size}, at::kCUDA));
+    auto w_hh = t_def(at::randn({4 * hidden_size, hidden_size}, at::kCUDA));
 
-  // std::cout << almostEqual(outputs[0],hx) << "\n";
-  ASSERT_TRUE(exactlyEqual(outputs[0], hx));
-  ASSERT_TRUE(exactlyEqual(outputs[1], cx));
+    auto lstm_g = build_lstm();
+    Code lstm_function(lstm_g, "");
+    InterpreterState lstm_interp(lstm_function);
+    auto outputs = run(lstm_interp, {input[0], hx, cx, w_ih, w_hh});
+    std::tie(hx, cx) = lstm(input[0], hx, cx, w_ih, w_hh);
+
+    // std::cout << almostEqual(outputs[0],hx) << "\n";
+    ASSERT_TRUE(exactlyEqual(outputs[0], hx));
+    ASSERT_TRUE(exactlyEqual(outputs[1], cx));
+  }
 }
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/instruction.h
+++ b/torch/csrc/jit/runtime/instruction.h
@@ -35,6 +35,7 @@ namespace jit {
   _(WAIT, "") /* wait for a future to be complete */                        \
   _(CALL, "F") /* call function X */                                        \
   _(GUARD, "T") /* check a guard against type_table, true if passes */      \
+  _(TYPECHECK, "T") /* check a guard against type_table, true if passes */  \
   _(FAIL_GUARD, "T") /* fail a guard, patch back to GUARD */                \
   _(PROFILE_OP, "F") /* get a callback from profile_function_table at X */  \
   _(TAIL_CALL, "F") /* replace current frame with function F */             \

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -50,6 +50,13 @@ RegisterOperators reg(
          [](Stack* stack) { AT_ERROR("Should be replaced by prim::BailOut"); },
          aliasAnalysisFromSchema()),
      Operator(
+         "prim::TypeCheck(Tensor(a) x, bool y) -> (Tensor(a), bool)",
+         [](Stack& /* stack */) {
+           AT_ERROR("prim::TypeCheck not yet implemented"); // NOLINT
+           return 0;
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          "prim::BailOut(...) -> Tensor(a)",
          [](Stack* /* stack */) {
            AT_ERROR("prim::BailOut not yet implemented"); // NOLINT


### PR DESCRIPTION
TypeCheck is an new operation to check the shape of tensors to enable
fusers. Currently TypeCheck checks one tensor at a time. A follow up
patch will enable variadic TypeCheck.

%t0 : Tensor = ...
%t1 : Tensor = ...
%0 : bool = prim::Constant(1)  # TRUE
%2 : FLOAT(20, 20), %1 : bool = prim::TypeCheck(%0, %t0)
%3 : FLOAT(30, 30), %4 : bool = prim::TypeCheck(%1, %t1)
prim::If(%4)
...

Fixes #{issue number}
