### PR TITLE
Fix ROCm CI by increasing test timeout

### DIFF
--- a/caffe2/python/operator_test/activation_ops_test.py
+++ b/caffe2/python/operator_test/activation_ops_test.py
@@ -21,7 +21,7 @@ import unittest
 class TestActivations(serial.SerializedTestCase):
     @given(X=hu.tensor(), in_place=st.booleans(),
                   engine=st.sampled_from(["", "CUDNN"]), **mu.gcs)
-    @settings(deadline=1000)
+    @settings(deadline=3000)
     def test_relu(self, X, in_place, engine, gc, dc):
         if gc == mu.mkl_do:
             in_place = False


### PR DESCRIPTION
ROCm is failing to run this test in the allotted time. See, for example, https://app.circleci.com/pipelines/github/pytorch/pytorch/198759/workflows/f6066acf-b289-46c5-aad0-6f4f663ce820/jobs/6618625.

cc @jeffdaily 