### PR TITLE
test_cpp_rpc: Build test_e2e_process_group.cpp only if USE_GLOO is true

### DIFF
--- a/test/cpp/rpc/CMakeLists.txt
+++ b/test/cpp/rpc/CMakeLists.txt
@@ -6,6 +6,12 @@ set(TORCH_RPC_TEST_SOURCES
   ${TORCH_RPC_TEST_DIR}/test_e2e_process_group.cpp
 )
 
+if(USE_GLOO)
+  list(APPEND TORCH_RPC_TEST_SOURCES
+    ${TORCH_RPC_TEST_DIR}/test_e2e_process_group.cpp
+  )
+endif()
+
 add_executable(test_cpp_rpc ${TORCH_RPC_TEST_SOURCES})
 target_include_directories(
   test_cpp_rpc PRIVATE


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/42776

