### PR TITLE
format make_boxed_from_unboxed_functor.h for readability

### DIFF
--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -34,7 +34,7 @@ namespace impl {
   // supported_primitive_arg_types defines which primitive types we allow in
   // kernel functions as arguments or returns.
   // Additionally, we support lists, dicts and optionals containing these types.
-using supported_primitive_arg_types = guts::typelist::typelist<
+  using supported_primitive_arg_types = guts::typelist::typelist<
     int64_t,
     double,
     bool,
@@ -49,7 +49,12 @@ using supported_primitive_arg_types = guts::typelist::typelist<
     at::Dimname
   >;
 
-  template<class T, bool AllowDeprecatedTypes, class Enable = void> struct assert_is_valid_input_type {
+  //
+  // assert_is_valid_input_type
+  //
+
+  template<class T, bool AllowDeprecatedTypes, class Enable = void>
+  struct assert_is_valid_input_type {
     assert_is_valid_input_type() {
       guts::if_constexpr<guts::typelist::contains<supported_primitive_arg_types, T>::value>([] {
         /* everything is ok, this is a primitive type */
@@ -76,49 +81,58 @@ using supported_primitive_arg_types = guts::typelist::typelist<
   struct TypeCheckHelper<AllowDeprecatedTypes> {};
 
   template <bool AllowDeprecatedTypes, class Head, class... Rest>
-  struct TypeCheckHelper<AllowDeprecatedTypes, Head, Rest...> : TypeCheckHelper<AllowDeprecatedTypes, Rest...> {
+  struct TypeCheckHelper<AllowDeprecatedTypes, Head, Rest...>
+  : TypeCheckHelper<AllowDeprecatedTypes, Rest...> {
     assert_is_valid_input_type<Head, AllowDeprecatedTypes> check;
   };
 
   template<class... Contained, bool AllowDeprecatedTypes>
-  struct assert_is_valid_input_type<std::tuple<Contained...>, AllowDeprecatedTypes> : TypeCheckHelper<AllowDeprecatedTypes, Contained...> {};
+  struct assert_is_valid_input_type<std::tuple<Contained...>, AllowDeprecatedTypes>
+  : TypeCheckHelper<AllowDeprecatedTypes, Contained...> {};
 
   template<class Key, class Value, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<Dict<Key, Value>, AllowDeprecatedTypes>
   : assert_is_valid_input_type<Value, AllowDeprecatedTypes> {
-    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "You tried to register a kernel with an unsupported input type: Dict<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
+    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value,
+      "You tried to register a kernel with an unsupported input type: Dict<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
   };
 
   template<class Key, class Value, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<std::unordered_map<Key, Value>, AllowDeprecatedTypes>
   : assert_is_valid_input_type<Value, AllowDeprecatedTypes> {
-    static_assert(AllowDeprecatedTypes, "You tried to register a kernel with an unsupported input type: std::unordered_map<Key, Value>. Please use Dict<Key, Value> instead.");
-    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "You tried to register a kernel with an unsupported input type: std::unordered_map<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
+    static_assert(AllowDeprecatedTypes,
+      "You tried to register a kernel with an unsupported input type: std::unordered_map<Key, Value>. Please use Dict<Key, Value> instead.");
+    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value,
+      "You tried to register a kernel with an unsupported input type: std::unordered_map<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
   };
 
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<List<T>, AllowDeprecatedTypes>
   : assert_is_valid_input_type<T, AllowDeprecatedTypes> {
-    static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported input type: List<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
+    static_assert(!std::is_same<T, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported input type: List<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
   };
 
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<std::vector<T>, AllowDeprecatedTypes>
   : assert_is_valid_input_type<T, AllowDeprecatedTypes> {
-    static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported input type: std::vector<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
+    static_assert(!std::is_same<T, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported input type: std::vector<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
     // TODO static_assert(AllowDeprecatedTypes, "You tried to register a kernel with an unsupported input type: std::vector<T>. Please use List<T> instead.");
   };
 
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<c10::ArrayRef<T>, AllowDeprecatedTypes>
   : assert_is_valid_input_type<T, AllowDeprecatedTypes> {
-    static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported input type: ArrayRef<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
+    static_assert(!std::is_same<T, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported input type: ArrayRef<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
   };
 
   template<class T, size_t N, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<std::array<T, N>, AllowDeprecatedTypes>
   : assert_is_valid_input_type<T, AllowDeprecatedTypes> {
-    static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported input type: std::array<Scalar, N>. Please use std::array<int64_t, N> instead.");
+    static_assert(!std::is_same<T, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported input type: std::array<Scalar, N>. Please use std::array<int64_t, N> instead.");
   };
 
   // The following specialisations of assert_is_valid_input_type are technically not
@@ -128,22 +142,31 @@ using supported_primitive_arg_types = guts::typelist::typelist<
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_same<float, T>::value>> {
     // There is no reason to support float when we have double. Keep the API lean.
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported input type: float. Please use double instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported input type: float. Please use double instead.");
   };
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_same<const char*, T>::value>> {
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported input type: const char*. Please use std::string instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported input type: const char*. Please use std::string instead.");
   };
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_same<std::vector<bool>, T>::value>> {
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported input type: vector<bool>. Please use List<bool> instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported input type: vector<bool>. Please use List<bool> instead.");
   };
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_input_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_integral<T>::value && !guts::typelist::contains<supported_primitive_arg_types, T>::value>> {
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported integral input type. Please use int64_t instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported integral input type. Please use int64_t instead.");
   };
 
-  template<class T, bool AllowDeprecatedTypes, class Enable = void> struct assert_is_valid_output_type {
+  //
+  // assert_is_valid_output_type
+  //
+
+  template<class T, bool AllowDeprecatedTypes, class Enable = void>
+  struct assert_is_valid_output_type {
     assert_is_valid_output_type() {
       guts::if_constexpr<guts::typelist::contains<supported_primitive_arg_types, T>::value>([] {
         /* everything is ok, this is a primitive type */
@@ -162,35 +185,43 @@ using supported_primitive_arg_types = guts::typelist::typelist<
   template<class Key, class Value, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<Dict<Key, Value>, AllowDeprecatedTypes>
   : assert_is_valid_output_type<Value, AllowDeprecatedTypes> {
-    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "You tried to register a kernel with an unsupported output type: Dict<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
-    static_assert(!std::is_same<Value, at::Scalar>::value, "You tried to register a kernel with an unsupported output type: Dict<Key, Scalar>. Please use Dict<Key, int64_t> or Dict<Key, double>.");
+    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value,
+      "You tried to register a kernel with an unsupported output type: Dict<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
+    static_assert(!std::is_same<Value, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported output type: Dict<Key, Scalar>. Please use Dict<Key, int64_t> or Dict<Key, double>.");
   };
 
   template<class Key, class Value, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<std::unordered_map<Key, Value>, AllowDeprecatedTypes>
   : assert_is_valid_output_type<Value, AllowDeprecatedTypes> {
-    static_assert(AllowDeprecatedTypes, "You tried to register a kernel with an unsupported output type: std::unordered_map<Key, Value>. Please use Dict<Key, Value> instead.");
-    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "You tried to register a kernel with an unsupported output type: std::unordered_map<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
-    static_assert(!std::is_same<Value, at::Scalar>::value, "You tried to register a kernel with an unsupported output type: std::unordered_map<Key, Scalar>. Please use Dict<Key, int64_t> or Dict<Key, double>.");
+    static_assert(AllowDeprecatedTypes,
+      "You tried to register a kernel with an unsupported output type: std::unordered_map<Key, Value>. Please use Dict<Key, Value> instead.");
+    static_assert(guts::typelist::contains<impl::valid_dict_key_types, Key>::value,
+      "You tried to register a kernel with an unsupported output type: std::unordered_map<Key, Value> where Key is invalid. We only support int64_t, double, bool, and string.");
+    static_assert(!std::is_same<Value, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported output type: std::unordered_map<Key, Scalar>. Please use Dict<Key, int64_t> or Dict<Key, double>.");
   };
 
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<List<T>, AllowDeprecatedTypes>
   : assert_is_valid_output_type<T, AllowDeprecatedTypes> {
-    static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported output type: List<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
+    static_assert(!std::is_same<T, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported output type: List<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
   };
 
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<std::vector<T>, AllowDeprecatedTypes>
   : assert_is_valid_output_type<T, AllowDeprecatedTypes> {
-    static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported output type: std::vector<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
+    static_assert(!std::is_same<T, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported output type: std::vector<Scalar>. Please use List<int64_t>, List<double> or Tensor instead.");
     // TODO static_assert(AllowDeprecatedTypes, "You tried to register a kernel with an unsupported output type: std::vector<T>. Please use List<T> instead.");
   };
 
   template<class T, size_t N, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<std::array<T, N>, AllowDeprecatedTypes>
   : assert_is_valid_output_type<T, AllowDeprecatedTypes> {
-    static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported output type: std::array<Scalar, N>. Please use std::array<int64_t, N> instead.");
+    static_assert(!std::is_same<T, at::Scalar>::value,
+      "You tried to register a kernel with an unsupported output type: std::array<Scalar, N>. Please use std::array<int64_t, N> instead.");
   };
 
   // The following specialisations of assert_is_valid_output_type are technically not
@@ -200,20 +231,26 @@ using supported_primitive_arg_types = guts::typelist::typelist<
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_same<float, T>::value>> {
     // There is no reason to support float when we have double. Keep the API lean.
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported output type: float. Please use double instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported output type: float. Please use double instead.");
   };
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_same<const char*, T>::value>> {
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported output type: const char*. Please use std::string instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported output type: const char*. Please use std::string instead.");
   };
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_same<std::vector<bool>, T>::value>> {
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported output type: vector<bool>. Please use List<bool> instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported output type: vector<bool>. Please use List<bool> instead.");
   };
   template<class T, bool AllowDeprecatedTypes>
   struct assert_is_valid_output_type<T, AllowDeprecatedTypes, std::enable_if_t<std::is_integral<T>::value && !guts::typelist::contains<supported_primitive_arg_types, T>::value>> {
-    static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported integral output type. Please use int64_t instead.");
+    static_assert(guts::false_t<T>::value,
+      "You tried to register a kernel with an unsupported integral output type. Please use int64_t instead.");
   };
+
+  // ivalue_to_arg
 
   template<class T, bool AllowDeprecatedTypes>
   struct ivalue_to_arg final {
@@ -248,14 +285,21 @@ using supported_primitive_arg_types = guts::typelist::typelist<
     }
   };
 
+  // return_to_ivalue
+
   template<class T, bool AllowDeprecatedTypes>
   IValue return_to_ivalue(T&& v) {
     assert_is_valid_output_type<T, AllowDeprecatedTypes>();
     return c10::ivalue::from(std::forward<T>(v));
   }
 
+  // call_functor_with_args_from_stack_
+
   template<class Functor, bool AllowDeprecatedTypes, size_t... ivalue_arg_indices>
-  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_args_from_stack_(Functor* functor, Stack* stack, std::index_sequence<ivalue_arg_indices...>) {
+  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_args_from_stack_(
+    Functor* functor,
+    Stack* stack, std::index_sequence<ivalue_arg_indices...>
+  ) {
     (void)(stack); // when sizeof...(ivalue_arg_indices) == 0, this argument would be unused and we have to silence the compiler warning.
 
     constexpr size_t num_ivalue_args = sizeof...(ivalue_arg_indices);
@@ -267,10 +311,15 @@ using supported_primitive_arg_types = guts::typelist::typelist<
   }
 
   template<class Functor, bool AllowDeprecatedTypes>
-  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_args_from_stack(Functor* functor, Stack* stack) {
+  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_args_from_stack(
+    Functor* functor,
+    Stack* stack
+  ) {
     constexpr size_t num_ivalue_args = guts::infer_function_traits_t<Functor>::number_of_parameters;
     return call_functor_with_args_from_stack_<Functor, AllowDeprecatedTypes>(functor, stack, std::make_index_sequence<num_ivalue_args>());
   }
+
+  // push_outputs
 
   template<class OutputType, bool AllowDeprecatedTypes>
   struct push_outputs final {
@@ -296,9 +345,12 @@ using supported_primitive_arg_types = guts::typelist::typelist<
     }
   };
 
+  // make_boxed_from_unboxed_functor
+
   template<class KernelFunctor, bool AllowDeprecatedTypes>
   struct make_boxed_from_unboxed_functor final {
-    static_assert(std::is_base_of<OperatorKernel, KernelFunctor>::value, "Tried to register a kernel functor using the kernel<Functor>() API, but it doesn't inherit from c10::OperatorKernel. Please have the functor inherit from it.");
+    static_assert(std::is_base_of<OperatorKernel, KernelFunctor>::value,
+      "Tried to register a kernel functor using the kernel<Functor>() API, but it doesn't inherit from c10::OperatorKernel. Please have the functor inherit from it.");
 
     static void call(OperatorKernel* functor, const OperatorHandle&, Stack* stack) {
       constexpr size_t num_inputs = guts::infer_function_traits_t<KernelFunctor>::number_of_parameters;
@@ -317,20 +369,30 @@ using supported_primitive_arg_types = guts::typelist::typelist<
     }
   };
 
-  template<class KernelFunctor, class OpSignature> struct wrap_kernel_functor_unboxed_ final {};
-  template<class KernelFunctor, class ReturnType, class... ParameterTypes> struct wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes...)> final {
-    static_assert(std::is_same<ReturnType, typename guts::infer_function_traits_t<KernelFunctor>::return_type>::value, "Return type mismatch");
-    static_assert(std::is_same<guts::typelist::typelist<ParameterTypes...>, typename guts::infer_function_traits_t<KernelFunctor>::parameter_types>::value, "Parameter types mismatch");
+  // wrap_kernel_functor_unboxed_
+
+  template<class KernelFunctor, class OpSignature>
+  struct wrap_kernel_functor_unboxed_ final {};
+
+  template<class KernelFunctor, class ReturnType, class... ParameterTypes>
+  struct wrap_kernel_functor_unboxed_<KernelFunctor, ReturnType(ParameterTypes...)> final {
+    static_assert(std::is_same<ReturnType, typename guts::infer_function_traits_t<KernelFunctor>::return_type>::value,
+      "Return type mismatch");
+    static_assert(std::is_same<guts::typelist::typelist<ParameterTypes...>, typename guts::infer_function_traits_t<KernelFunctor>::parameter_types>::value,
+      "Parameter types mismatch");
 
     static ReturnType call(OperatorKernel* functor, ParameterTypes... args) {
       KernelFunctor* functor_ = static_cast<KernelFunctor*>(functor);
       return (*functor_)(std::forward<ParameterTypes>(args)...);
     }
   };
-  template<class KernelFunctor> using wrap_kernel_functor_unboxed = wrap_kernel_functor_unboxed_<KernelFunctor, typename guts::infer_function_traits_t<KernelFunctor>::func_type>;
-}
 
-}
+  template<class KernelFunctor>
+  using wrap_kernel_functor_unboxed = wrap_kernel_functor_unboxed_<KernelFunctor, typename guts::infer_function_traits_t<KernelFunctor>::func_type>;
+
+} // namespace impl
+
+} // namespace c10
 
 namespace torch {
   using OperatorKernel = c10::OperatorKernel;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42852 avoid redundant c10::isCustomClassRegistered() checks
* **#42851 format make_boxed_from_unboxed_functor.h for readability**

No code changes, just line wrapping, spacing and comments.

Differential Revision: [D23048382](https://our.internmc.facebook.com/intern/diff/D23048382)