### PR TITLE
avoid redundant c10::isCustomClassRegistered() checks

### DIFF
--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -49,8 +49,19 @@ namespace impl {
     at::Dimname
   >;
 
+  // We have an unboxed functor in hand that takes C++ arguments, and
+  // we're building a boxed functor wrapper for it that takes IValues.
+  // So "outside" is boxed and "inside" is unboxed.
+  //
+  // So a valid input type is one that our boxed functor wrapper can
+  // unbox from an IValue into a C++ value.
+  //
+  // Whereas a valid output type is one that our wrapper can recieve
+  // as a C++ value from the unboxed functor, and box into an IValue.
+
   //
   // assert_is_valid_input_type
+  // checks that T can be unboxed from an IValue into a C++ value.
   //
 
   template<class T, bool AllowDeprecatedTypes, class Enable = void>
@@ -59,8 +70,8 @@ namespace impl {
       guts::if_constexpr<guts::typelist::contains<supported_primitive_arg_types, T>::value>([] {
         /* everything is ok, this is a primitive type */
       }, /* else */ [] {
-        /* otherwise T must be a custom class. this is dynamically checked in IValue constructor,
-           so no benefit in double-checking here */
+        /* otherwise this must be an instance of a valid custom class, since it can only
+           have been created via IValue(x), which ensures this. */
       });
     }
   };
@@ -166,8 +177,8 @@ namespace impl {
       guts::if_constexpr<guts::typelist::contains<supported_primitive_arg_types, T>::value>([] {
         /* everything is ok, this is a primitive type */
       }, /* else */ [] {
-        /* otherwise this must be an instance of a valid custom class, since it can only
-           have entered the jit via IValue(x), which checks this dynamically. */
+        /* otherwise T is verified to be a registered custom class in the IValue
+          constructor, so no benefit in double-checking here */
       });
     }
   };

--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -59,13 +59,8 @@ namespace impl {
       guts::if_constexpr<guts::typelist::contains<supported_primitive_arg_types, T>::value>([] {
         /* everything is ok, this is a primitive type */
       }, /* else */ [] {
-        // TODO This is called for each operator call and potentially expensive.
-        // This check should be moved to operator registration time instead.
-        TORCH_CHECK(
-          c10::isCustomClassRegistered<T>(),
-          "Tried to use undefined class ",
-          c10::util::get_fully_qualified_type_name<T>(),
-          " as input argument");
+        /* otherwise T must be a custom class. this is dynamically checked in IValue constructor,
+           so no benefit in double-checking here */
       });
     }
   };
@@ -171,9 +166,8 @@ namespace impl {
       guts::if_constexpr<guts::typelist::contains<supported_primitive_arg_types, T>::value>([] {
         /* everything is ok, this is a primitive type */
       }, /* else */ [] {
-        // TODO This is called for each operator call and potentially expensive.
-        // This check should be moved to operator registration time instead.
-        TORCH_CHECK(c10::isCustomClassRegistered<T>(), "Tried to use undefined class ", c10::util::get_fully_qualified_type_name<T>(), " as output");
+        /* otherwise this must be an instance of a valid custom class, since it can only
+           have entered the jit via IValue(x), which checks this dynamically. */
       });
     }
   };

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1010,7 +1010,8 @@ template <typename T, std::enable_if_t<std::is_base_of<torch::CustomClassHolder,
 IValue::IValue(c10::intrusive_ptr<T> custom_class) {
   if (!c10::isCustomClassRegistered<c10::intrusive_ptr<T>>()) {
     throw c10::Error(
-        "Trying to instantiate a class that isn't a registered custom class.",
+        "Trying to instantiate a class that isn't a registered custom class: " +
+          std::string(c10::util::get_fully_qualified_type_name<T>()),
         "");
   }
   auto classType = c10::getCustomClassType<c10::intrusive_ptr<T>>();
@@ -1136,10 +1137,6 @@ IValue from_(T x, std::true_type) {
 }
 template <typename T>
 IValue from_(c10::intrusive_ptr<T> x, std::false_type) {
-  using inputType = c10::intrusive_ptr<T>;
-  if (!isCustomClassRegistered<inputType>()) {
-    throw c10::Error("Trying to return a class that we don't support and isn't a registered custom class.", "");
-  }
   return IValue(x);
 }
 template <typename T>

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -261,11 +261,6 @@ class class_ {
 ///     IValue custom_class_iv = torch::make_custom_class<MyClass>(3, "foobarbaz");
 template <typename CurClass, typename... CtorArgs>
 c10::IValue make_custom_class(CtorArgs&&... args) {
-  if (!c10::isCustomClassRegistered<c10::intrusive_ptr<CurClass>>()) {
-    throw c10::Error(
-        "Trying to instantiate a class that isn't a registered custom class.",
-        "");
-  }
   auto userClassInstance = c10::make_intrusive<CurClass>(std::forward<CtorArgs>(args)...);
   return c10::IValue(std::move(userClassInstance));
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42893 add CustomClassHolder inheritance check to boxing wrapper templates
* **#42852 avoid redundant c10::isCustomClassRegistered() checks**
* #42851 format make_boxed_from_unboxed_functor.h for readability

Differential Revision: [D23048381](https://our.internmc.facebook.com/intern/diff/D23048381)