### PR TITLE
Fix incorrect aten::sorted.str return type

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -39,7 +39,7 @@ allow_list = [
     ("aten::__upsample_bilinear", datetime.date(2020, 7, 30)),
     ("aten::hash", datetime.date(2020, 7, 30)),
     ("aten::divmod", datetime.date(2020, 7, 30)),
-    ("aten::sorted", datetime.date(2020, 7, 30)),
+    ("aten::sorted", datetime.date(2020, 8, 30)),
     ("aten::__contains__", datetime.date(2020, 7, 30)),
     ("aten::ne", datetime.date(2020, 7, 30)),
     ("aten::index", datetime.date(2020, 7, 30)),

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4359,6 +4359,12 @@ a")
         def foo(strs: List[str]):
             return sorted(strs)
 
+        FileCheck() \
+            .check("graph") \
+            .check_next("str[] = aten::sorted") \
+            .check_next("return") \
+            .run(str(foo.graph))
+
         inputs = ["str3", "str2", "str1"]
         self.assertEqual(foo(inputs), sorted(inputs))
 

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -754,7 +754,7 @@ RegisterOperators reg2({
         listCopyAndSort<bool>,
         aliasAnalysisFromSchema()),
     Operator(
-        "aten::sorted.str(str[](a) input) -> (bool[])",
+        "aten::sorted.str(str[](a) input) -> (str[])",
         listCopyAndSort<std::string>,
         aliasAnalysisFromSchema()),
 


### PR DESCRIPTION
aten::sorted.str output type was incorrectly set to bool[] due to a copy-paste error. This PR fixes it.

Fixes https://fburl.com/0rv8amz7
