### PR TITLE
Concat/Tile/Split for 2D inputs during inbatch broadcast

### DIFF
--- a/caffe2/opt/custom/in_batch_broadcast.cc
+++ b/caffe2/opt/custom/in_batch_broadcast.cc
@@ -75,16 +75,17 @@ void inBatchBroadcast(
     broadcast_net.add_op()->CopyFrom(op);
   }
 
-  auto setShape = [&shape_hints, batch_size](
-                      const std::string& blob,
-                      const std::string& new_blob) mutable {
+  // We are done with the Fused8BitRowwiseQuantizedToFloat swapping heuristics.
+  // Now we focus on creating Tile ops based on `to_broadcast_copy`. Here is a
+  // convenient function to change the blob shape from batch size to 1, while
+  // returning the old batch size.
+  auto unbatchShape = [&shape_hints, batch_size](
+                          const std::string& blob) mutable {
     auto it = shape_hints.find(blob);
     CAFFE_ENFORCE(it != shape_hints.end(), "Cannot find shape info for ", blob);
     auto& shape = it->second;
     CAFFE_ENFORCE(shape.shape.dims_size(), "Dim size for ", blob, " is 0");
-    if (!new_blob.empty()) {
-      shape_hints.emplace(new_blob, shape);
-    }
+    auto old_shape = shape;
     CAFFE_ENFORCE_EQ(
         shape.shape.dims(0) % batch_size,
         0,
@@ -95,28 +96,89 @@ void inBatchBroadcast(
         " cannot be divided by batch_size ");
     shape.shape.set_dims(0, shape.shape.dims(0) / batch_size);
     shape.setDimType(0, TensorBoundShape_DimType_CONSTANT);
+    return old_shape;
   };
+
+  // Build the tile ops. For inputs that are 2D, we have this Concat/Tile/Split
+  // optimization. We hardcode it as 2D as this is our expected input shape to
+  // apply optimization. If certain to-broadcast inputs are not 2D, we end up
+  // lose some performance by adding one Tile for each such input. We can also
+  // improve this by covering the 1D, 3D cases but we can keep it simple for
+  // now.
+  int total_dim1 = 0;
+  std::vector<std::string> concatInputs;
+  std::vector<int> split;
+  std::vector<std::string> splitOutputs;
   for (const auto& blob : to_broadcast_copy) {
-    auto new_blob = blob + kTILE_SUFFIX;
-    auto* op = broadcast_net.add_op();
-    op->CopyFrom(CreateOperatorDef(
-        "Tile",
-        "",
-        {blob},
-        {new_blob},
-        {MakeArgument<int>("tiles", batch_size),
-         MakeArgument<int>("axis", 0),
-         // Indicating that we are tiling to max_batch_size
-         MakeArgument<int>("dynamic", 1),
-         MakeArgument<int>("net_pos", current_pos++)}));
-    setShape(blob, new_blob);
+    const auto new_blob = blob + kTILE_SUFFIX;
+    auto old_shape = unbatchShape(blob);
+    if (old_shape.shape.dims_size() == 2) {
+      // For 2D input we prepare info to create one Concat/Tile/Split chain
+      const auto& new_shape = shape_hints.at(blob);
+      total_dim1 += new_shape.shape.dims(1);
+      concatInputs.emplace_back(blob);
+      split.emplace_back(new_shape.shape.dims(1));
+      splitOutputs.emplace_back(new_blob);
+    } else {
+      // Otherwise we create one Tile for each input
+      broadcast_net.add_op()->CopyFrom(CreateOperatorDef(
+          "Tile",
+          "",
+          {blob},
+          {new_blob},
+          {MakeArgument<int>("tiles", batch_size),
+           MakeArgument<int>("axis", 0),
+           // Indicating that we are tiling to max_batch_size
+           MakeArgument<int>("dynamic", 1),
+           MakeArgument<int>("net_pos", current_pos++)}));
+    }
+    shape_hints.emplace(new_blob, old_shape);
+
+    // If this blob is the output of a Fused8BitRowwiseQuantizedToFloat op, we
+    // need to further unbatch the input of that
+    // Fused8BitRowwiseQuantizedToFloat op.
     const auto rit = reversed.find(blob);
     if (rit != reversed.end()) {
       const auto& orignal_input = rit->second;
-      setShape(orignal_input, "");
+      unbatchShape(orignal_input);
     }
   }
 
+  // Create one Concat/Tile/Split chain for all the 2D inputs
+  if (!concatInputs.empty()) {
+    broadcast_net.add_op()->CopyFrom(CreateOperatorDef(
+        "Concat",
+        "",
+        concatInputs,
+        {"inbatch_concat", "inbatch_concat_splitinfo"},
+        {MakeArgument<int>("axis", 1),
+         MakeArgument<int>("net_pos", current_pos++)}));
+    auto shape_info = shape_hints.at(concatInputs.front());
+    shape_info.shape.set_dims(1, total_dim1);
+    shape_hints.emplace("inbatch_concat", shape_info);
+    broadcast_net.add_op()->CopyFrom(CreateOperatorDef(
+        "Tile",
+        "",
+        {"inbatch_concat"},
+        {"inbatch_concat_tile"},
+        {MakeArgument<int>("tiles", batch_size),
+         MakeArgument<int>("axis", 0),
+         MakeArgument<int>("dynamic", 1),
+         MakeArgument<int>("net_pos", current_pos++)}));
+    shape_info.shape.set_dims(0, shape_info.shape.dims(0) * batch_size);
+    shape_info.setDimType(0, TensorBoundShape_DimType_BATCH);
+    shape_hints.emplace("inbatch_concat_tile", shape_info);
+    broadcast_net.add_op()->CopyFrom(CreateOperatorDef(
+        "Split",
+        "",
+        {"inbatch_concat_tile"},
+        splitOutputs,
+        {MakeArgument<int>("axis", 1),
+         MakeArgument<vector<int>>("split", split),
+         MakeArgument<int>("net_pos", current_pos++)}));
+  }
+
+  // Add rest of the ops and reroute them to consume the broadcasted blobs
   for (auto& op : post_ops) {
     for (int j = 0; j < op.input_size(); j++) {
       if (to_broadcast_copy.count(op.input(j))) {

--- a/caffe2/opt/custom/in_batch_broadcast_test.cc
+++ b/caffe2/opt/custom/in_batch_broadcast_test.cc
@@ -8,7 +8,7 @@ using namespace caffe2;
 namespace {
 
 void checkNet(NetDef& net, NetDef& expected_net) {
-  CHECK_EQ(net.op().size(), expected_net.op().size());
+  CHECK_EQ(net.op().size(), expected_net.op().size()) << ProtoDebugString(net);
   for (int i = 0; i < net.op().size(); i++) {
     auto& op1 = net.op(i);
     auto& op2 = expected_net.op(i);
@@ -32,9 +32,20 @@ void checkNet(NetDef& net, NetDef& expected_net) {
       }
       CHECK(helper2.HasArgument(name))
           << "Argument " << name << "doesn't exist";
-      const auto arg1 = helper1.GetSingleArgument<int>(name, 0);
-      const auto arg2 = helper2.GetSingleArgument<int>(name, 0);
-      CHECK_EQ(arg1, arg2);
+      if (arg.has_i()) {
+        const auto arg1 = helper1.GetSingleArgument<int>(name, 0);
+        const auto arg2 = helper2.GetSingleArgument<int>(name, 0);
+        CHECK_EQ(arg1, arg2);
+      } else if (arg.ints_size()) {
+        const auto& arg1 = helper1.GetRepeatedArgument<int>(name);
+        const auto& arg2 = helper2.GetRepeatedArgument<int>(name);
+        CHECK_EQ(arg1.size(), arg2.size());
+        for (int k = 0; k < arg1.size(); ++k) {
+          CHECK_EQ(arg1[k], arg2[k]);
+        }
+      } else {
+        CAFFE_THROW("Don't know how to compare the argument: ", name);
+      }
     }
   }
 }
@@ -42,10 +53,11 @@ void checkNet(NetDef& net, NetDef& expected_net) {
 void checkShapeInfo(ShapeInfoMap& shape_map, ShapeInfoMap& expected_shape_map) {
   CHECK_EQ(shape_map.size(), expected_shape_map.size());
   for (auto& [name, shape] : shape_map) {
+    LOG(INFO) << "Checking shape of " << name;
     auto it = expected_shape_map.find(name);
     CHECK(it != expected_shape_map.end());
     auto& shape2 = it->second;
-    EXPECT_EQ(shape.getDimType(), shape2.getDimType());
+    ASSERT_EQ(shape.getDimType(), shape2.getDimType());
     ASSERT_EQ(shape.shape.dims_size(), shape2.shape.dims_size());
     for (int i = 0; i < shape.shape.dims_size(); ++i) {
       EXPECT_EQ(shape.shape.dims(i), shape2.shape.dims(i));
@@ -72,42 +84,101 @@ ShapeInfo makeTensorInfo(
 TEST(InBatchBroadcast, main) {
   NetDef net;
   net.add_op()->CopyFrom(
-      CreateOperatorDef("Float2Half", "", {"blob"}, {"blob_half"}, {}));
+      CreateOperatorDef("Float2Half", "", {"blob0"}, {"blob0_half"}, {}));
+  net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob1"}, {"blob1_half"}, {}));
+  net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob2"}, {"blob2_half"}, {}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
-      "blob",
+      "blob0",
       makeTensorInfo(
           {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
           {32, 16}));
-  std::unordered_set<std::string> transform_blob({"blob"});
+  shape_map.emplace(
+      "blob1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 9}));
+  // 1D input
+  shape_map.emplace(
+      "blob2", makeTensorInfo({TensorBoundShape_DimType_BATCH}, {32}));
+  std::unordered_set<std::string> transform_blob({"blob0", "blob1", "blob2"});
   opt::inBatchBroadcast(&net, transform_blob, 32, shape_map);
   NetDef expected_net;
-  auto op1 = expected_net.add_op();
-  op1->CopyFrom(CreateOperatorDef(
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
       "Tile",
       "",
-      {"blob"},
-      {"blob_tile"},
+      {"blob2"},
+      {"blob2_tile"},
       {MakeArgument<int>("tiles", 32),
        MakeArgument<int>("axis", 0),
        MakeArgument<int>("dynamic", 1)}));
-  op1->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
-  auto op2 = expected_net.add_op();
-  op2->CopyFrom(
-      CreateOperatorDef("Float2Half", "", {"blob_tile"}, {"blob_half"}, {}));
-  op2->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
+      "Concat",
+      "",
+      {"blob0", "blob1"},
+      {"inbatch_concat", "inbatch_concat_splitinfo"},
+      {MakeArgument<int>("axis", 1)}));
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
+      "Tile",
+      "",
+      {"inbatch_concat"},
+      {"inbatch_concat_tile"},
+      {MakeArgument<int>("tiles", 32),
+       MakeArgument<int>("axis", 0),
+       MakeArgument<int>("dynamic", 1)}));
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
+      "Split",
+      "",
+      {"inbatch_concat_tile"},
+      {"blob0_tile", "blob1_tile"},
+      {MakeArgument<int>("axis", 1),
+       MakeArgument<vector<int>>("split", {16, 9})}));
+  expected_net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob0_tile"}, {"blob0_half"}, {}));
+  expected_net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob1_tile"}, {"blob1_half"}, {}));
+  expected_net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob2_tile"}, {"blob2_half"}, {}));
   ShapeInfoMap expected_shape_map;
   expected_shape_map.emplace(
-      "blob",
+      "blob0",
       makeTensorInfo(
           {TensorBoundShape_DimType_CONSTANT,
            TensorBoundShape_DimType_CONSTANT},
           {1, 16}));
   expected_shape_map.emplace(
-      "blob_tile",
+      "blob1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 9}));
+  expected_shape_map.emplace(
+      "blob2", makeTensorInfo({TensorBoundShape_DimType_CONSTANT}, {1}));
+  expected_shape_map.emplace(
+      "blob0_tile",
       makeTensorInfo(
           {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
           {32, 16}));
+  expected_shape_map.emplace(
+      "blob1_tile",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 9}));
+  expected_shape_map.emplace(
+      "blob2_tile", makeTensorInfo({TensorBoundShape_DimType_BATCH}, {32}));
+  expected_shape_map.emplace(
+      "inbatch_concat",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 16 + 9}));
+  expected_shape_map.emplace(
+      "inbatch_concat_tile",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 16 + 9}));
   checkNet(net, expected_net);
   checkShapeInfo(shape_map, expected_shape_map);
 }
@@ -115,7 +186,11 @@ TEST(InBatchBroadcast, main) {
 TEST(InBatchBroadcast, fuse8bit) {
   NetDef net;
   net.add_op()->CopyFrom(CreateOperatorDef(
-      "Fused8BitRowwiseQuantizedToFloat", "", {"blob_int8"}, {"blob"}, {}));
+      "Fused8BitRowwiseQuantizedToFloat", "", {"blob_int8"}, {"blob0"}, {}));
+  net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob0"}, {"blob0_half"}, {}));
+  net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob1"}, {"blob1_half"}, {}));
   ShapeInfoMap shape_map;
   shape_map.emplace(
       "blob_int8",
@@ -124,27 +199,45 @@ TEST(InBatchBroadcast, fuse8bit) {
           {32, 24},
           TensorProto_DataType_UINT8));
   shape_map.emplace(
-      "blob",
+      "blob0",
       makeTensorInfo(
           {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
           {32, 16}));
-  std::unordered_set<std::string> transform_blob({"blob_int8"});
+  shape_map.emplace(
+      "blob1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 3}));
+  std::unordered_set<std::string> transform_blob({"blob_int8", "blob1"});
   opt::inBatchBroadcast(&net, transform_blob, 32, shape_map);
   NetDef expected_net;
-  auto* op1 = expected_net.add_op();
-  op1->CopyFrom(CreateOperatorDef(
-      "Fused8BitRowwiseQuantizedToFloat", "", {"blob_int8"}, {"blob"}, {}));
-  op1->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
-  auto* op2 = expected_net.add_op();
-  op2->CopyFrom(CreateOperatorDef(
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
+      "Fused8BitRowwiseQuantizedToFloat", "", {"blob_int8"}, {"blob0"}, {}));
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
+      "Concat",
+      "",
+      {"blob0", "blob1"},
+      {"inbatch_concat", "inbatch_concat_splitinfo"},
+      {MakeArgument<int>("axis", 1)}));
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
       "Tile",
       "",
-      {"blob"},
-      {"blob_tile"},
+      {"inbatch_concat"},
+      {"inbatch_concat_tile"},
       {MakeArgument<int>("tiles", 32),
        MakeArgument<int>("axis", 0),
        MakeArgument<int>("dynamic", 1)}));
-  op2->mutable_device_option()->set_device_type(caffe2::PROTO_CPU);
+  expected_net.add_op()->CopyFrom(CreateOperatorDef(
+      "Split",
+      "",
+      {"inbatch_concat_tile"},
+      {"blob0_tile", "blob1_tile"},
+      {MakeArgument<int>("axis", 1),
+       MakeArgument<vector<int>>("split", {16, 3})}));
+  expected_net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob0_tile"}, {"blob0_half"}, {}));
+  expected_net.add_op()->CopyFrom(
+      CreateOperatorDef("Float2Half", "", {"blob1_tile"}, {"blob1_half"}, {}));
   ShapeInfoMap expected_shape_map;
   expected_shape_map.emplace(
       "blob_int8",
@@ -154,16 +247,38 @@ TEST(InBatchBroadcast, fuse8bit) {
           {1, 24},
           TensorProto_DataType_UINT8));
   expected_shape_map.emplace(
-      "blob",
+      "blob0",
       makeTensorInfo(
           {TensorBoundShape_DimType_CONSTANT,
            TensorBoundShape_DimType_CONSTANT},
           {1, 16}));
   expected_shape_map.emplace(
-      "blob_tile",
+      "blob1",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 3}));
+  expected_shape_map.emplace(
+      "blob0_tile",
       makeTensorInfo(
           {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
           {32, 16}));
+  expected_shape_map.emplace(
+      "blob1_tile",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 3}));
+  expected_shape_map.emplace(
+      "inbatch_concat",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 16 + 3}));
+  expected_shape_map.emplace(
+      "inbatch_concat_tile",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+          {32, 16 + 3}));
   checkNet(net, expected_net);
   checkShapeInfo(shape_map, expected_shape_map);
 }


### PR DESCRIPTION
Summary: This is a rework of D22063348. To keep things safe, we apply such heuristics only on 2D inputs that are being broadcasted. For inputs of other dim size, we just add one Tile per op.

Test Plan:
```
buck test caffe2/caffe2/opt/custom:in_batch_broadcast_test
```

Differential Revision: D23053169

