### PR TITLE
support registering makeNamedNotSupported for non boxing ops

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -174,7 +174,7 @@ inline KernelFunction KernelFunction::makeFromUnboxedLambda(Lambda&& lambda) {
 }
 
 inline void KernelFunction::setManuallyBoxedKernel_(InternalBoxedKernelFunction* func) {
-    if (boxed_kernel_func_ == &fallthrough_kernel) {
+    if (boxed_kernel_func_ == &fallthrough_kernel || boxed_kernel_func_ == &named_not_supported_kernel) {
       // special case no-op
       return;
     }

--- a/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
+++ b/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
@@ -104,6 +104,8 @@ TEST(BackendFallbackTest, TestBackendFallbackWithWrapper) {
 TEST(BackendFallbackTest, TestFallthroughBackendFallback) {
   auto m = MAKE_TORCH_LIBRARY_IMPL(aten, TESTING_ONLY_GenericMode);
   m.impl("mul.Tensor", torch::CppFunction::makeFromBoxedFunction<&generic_mode_fallback>());
+  m.impl("abs_", torch::CppFunction::makeNamedNotSupported());
+  m.impl("add.Tensor", torch::CppFunction::makeNamedNotSupported());
 
   auto gm = MAKE_TORCH_LIBRARY_IMPL(_, TESTING_ONLY_GenericMode);
   gm.fallback(torch::CppFunction::makeFallthrough());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42862 support registering makeNamedNotSupported for non boxing ops**

Differential Revision: [D23055525](https://our.internmc.facebook.com/intern/diff/D23055525)