### PR TITLE
Don't proceed into setup.py too far if Python version is unsupported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,17 @@ if sys.platform == 'win32' and sys.maxsize.bit_length() == 31:
     print("32-bit Windows Python runtime is not supported. Please switch to 64-bit Python.")
     sys.exit(-1)
 
+import platform
+python_min_version = (3, 6, 1)
+python_min_version_str = '.'.join((str(num) for num in python_min_version))
+python_max_version = (3, 9, 0)
+python_max_version_str = '.'.join((str(num) for num in python_max_version))
+if sys.version_info < python_min_version or sys.version_info >= python_max_version:
+    print("You are using Python {}. Python >={},<{} is required.".format(platform.python_version(),
+                                                                         python_min_version_str,
+                                                                         python_max_version_str))
+    sys.exit(-1)
+
 from setuptools import setup, Extension, distutils, find_packages
 from collections import defaultdict
 from distutils import core
@@ -883,7 +894,7 @@ if __name__ == '__main__':
         download_url='https://github.com/pytorch/pytorch/tags',
         author='PyTorch Team',
         author_email='packages@pytorch.org',
-        python_requires='>=3.6.1',
+        python_requires='>={},<{}'.format(python_min_version_str, python_max_version_str),
         # PyPI package information.
         classifiers=[
             'Development Status :: 5 - Production/Stable',
@@ -891,18 +902,15 @@ if __name__ == '__main__':
             'Intended Audience :: Education',
             'Intended Audience :: Science/Research',
             'License :: OSI Approved :: BSD License',
-            'Programming Language :: C++',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Scientific/Engineering :: Artificial Intelligence',
             'Topic :: Software Development',
             'Topic :: Software Development :: Libraries',
             'Topic :: Software Development :: Libraries :: Python Modules',
-        ],
+            'Programming Language :: C++',
+            'Programming Language :: Python :: 3',
+        ] + ['Programming Language :: Python :: 3.{}' for i in range(python_min_version[1], python_max_version[1])],
         license='BSD-3',
         keywords='pytorch machine learning',
     )


### PR DESCRIPTION
This prevents confusing errors when the interpreter encounters some
syntax errors in the middle.