### PR TITLE
remove deadline enforcement for hypothesis

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
@@ -20,7 +20,7 @@ core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
 
 class TestBatchMatMul(serial.SerializedTestCase):
     @given(
-        #C=0, #st.integers(min_value=0, max_value=3),  # number of batch dims
+        # C=0, #st.integers(min_value=0, max_value=3),  # number of batch dims
         M=st.integers(min_value=1, max_value=10),
         K=st.integers(min_value=1, max_value=10),
         N=st.integers(min_value=1, max_value=10),

--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-import time
 import unittest
 
 import caffe2.python.fakelowp.init_shared_libs  # noqa
@@ -14,13 +13,11 @@ from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.onnx.tests.test_utils import TestCase
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
-import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--glow_global_fp16=1",
-                      "--glow_global_fused_scale_offset_fp16=1",
-                      "--glow_global_force_sls_fp16_accum=1"])
+                 "--glow_global_fused_scale_offset_fp16=1",
+                 "--glow_global_force_sls_fp16_accum=1"])
 
 GLOW_LOWERED_BATCHNORM = False
 
@@ -30,7 +27,7 @@ def reference_spatialbn_test16(X, scale, bias, mean, var, epsilon, order):
     scale = scale.astype(np.float16)
     bias = bias.astype(np.float16)
     mean = mean.astype(np.float16)
-    #var = var.astype(np.float16)
+    # var = var.astype(np.float16)
     assert(order == "NCHW")
 
     scale = scale[np.newaxis, :, np.newaxis, np.newaxis]
@@ -48,7 +45,7 @@ class BatchnormTest(unittest.TestCase):
            size=st.integers(2, 30),
            input_channels=st.integers(2, 40),
            batch_size=st.integers(2, 20))
-    @settings(max_examples=100, deadline=1000)
+    @settings(max_examples=100, deadline=None)
     def test_bn(self, seed, size, input_channels, batch_size):
         workspace.ResetWorkspace()
         np.random.seed(seed)

--- a/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-import time
 import unittest
 
 import caffe2.python.fakelowp.init_shared_libs  # noqa
@@ -24,7 +23,7 @@ GLOW_MATMUL_RTOL = 0
 
 class FCTest(serial.SerializedTestCase):
     @given(seed=st.integers(0, 65534))
-    @settings(deadline=1000)
+    @settings(deadline=None)
     def test_clip(self, seed):
         np.random.seed(seed)
         m, n, k = 8, 8, 8
@@ -78,7 +77,7 @@ class FCTest(serial.SerializedTestCase):
         np.testing.assert_allclose(Y_glow, np.full((m, n), 65504.0, dtype))
 
     @given(seed=st.integers(0, 65534))
-    @settings(deadline=1000)
+    @settings(deadline=None)
     def test_fc_exercise(self, seed):
         """ Test that the matmul engine is working, this doesn't test
             precision
@@ -132,14 +131,21 @@ class FCTest(serial.SerializedTestCase):
             workspace.RunNet(pred_net.name)
             Y_c2 = workspace.FetchBlob('Y')
             if not np.allclose(Y_c2, Y_glow):
-                print_test_debug_info("fc",
-                    {"seed": seed, "m": m, "k": k, "n": n, "X": X0, "W0": W0,
-                      "b0": b0, "Y_glow": Y_glow, "Y_c2": Y_c2,
-                     "diff": np.abs((Y_c2 - Y_glow) / Y_c2)})
+                print_test_debug_info("fc", {
+                    "seed": seed,
+                    "m": m,
+                    "k": k,
+                    "n": n,
+                    "X": X0,
+                    "W0": W0,
+                    "b0": b0,
+                    "Y_glow": Y_glow,
+                    "Y_c2": Y_c2,
+                    "diff": np.abs((Y_c2 - Y_glow) / Y_c2)})
                 assert(0)
 
     @given(seed=st.integers(0, 65534))
-    @settings(deadline=1000)
+    @settings(deadline=None)
     def test_fc_numeric_cases(self, seed):
         """ Test numerics, use examples found from the unit test.
             Use Fp16FCAcc16NNPI as a reference.
@@ -203,30 +209,30 @@ class FCTest(serial.SerializedTestCase):
         workspace.CreateNet(pred_net_ref)
 
         X_inputs = [
-            np.array([[-2.94921875e-01, -3.58642578e-01, -1.92871094e-01,
-                        2.81250000e-01,
-                       -1.30126953e-01, 2.32696533e-02, -4.55566406e-01,
-                        -2.31811523e-01,
-                       -1.95190430e-01, -7.76977539e-02, -1.29394531e-01,
-                        2.94677734e-01,
-                       8.96453857e-04, 4.97314453e-01, -6.07604980e-02,
-                        2.55371094e-01,
-                       3.49853516e-01, -1.37695312e-01, 2.95410156e-01,
-                        -3.67187500e-01]], dtype=np.float32),
-            np.array([[-0.4494629, -0.22192383, -0.1640625, 0.11480713,
-                        -0.09851074, -0.02084351,
-                       0.19091797, -0.17468262, -0.47485352, 0.07489014,
-                        0.03897095, 0.00197601,
-                       0.02835083, -0.27294922, 0.26757812, -0.20996094,
-                       -0.31103516, -0.41601562,
-                       0.09918213, -0.07696533]], dtype=np.float32),
-            np.array([[0.01150513, -0.20507812, 0.46704102, 0.00906372,
-                        0.19848633, 0.3720703,
-                       0.46557617, -0.47436523, -0.35107422, -0.0362854,
-                        -0.20812988, 0.41918945,
-                       0.09716797, 0.19897461, 0.3876953, -0.0165863,
-                        0.23535156, 0.29956055,
-                       0.24389648, -0.23486328]], dtype=np.float32)
+            np.array([[
+                -2.94921875e-01, -3.58642578e-01, -1.92871094e-01,
+                2.81250000e-01, -1.30126953e-01, 2.32696533e-02,
+                -4.55566406e-01, -2.31811523e-01, -1.95190430e-01,
+                -7.76977539e-02, -1.29394531e-01, 2.94677734e-01,
+                8.96453857e-04, 4.97314453e-01, -6.07604980e-02,
+                2.55371094e-01, 3.49853516e-01, -1.37695312e-01,
+                2.95410156e-01, -3.67187500e-01]], dtype=np.float32),
+            np.array([[
+                -0.4494629, -0.22192383, -0.1640625, 0.11480713,
+                -0.09851074, -0.02084351,
+                0.19091797, -0.17468262, -0.47485352, 0.07489014,
+                0.03897095, 0.00197601,
+                0.02835083, -0.27294922, 0.26757812, -0.20996094,
+                -0.31103516, -0.41601562,
+                0.09918213, -0.07696533]], dtype=np.float32),
+            np.array([[
+                0.01150513, -0.20507812, 0.46704102, 0.00906372,
+                0.19848633, 0.3720703,
+                0.46557617, -0.47436523, -0.35107422, -0.0362854,
+                -0.20812988, 0.41918945,
+                0.09716797, 0.19897461, 0.3876953, -0.0165863,
+                0.23535156, 0.29956055,
+                0.24389648, -0.23486328]], dtype=np.float32)
         ]
 
         for i in range(len(X_inputs)):
@@ -242,10 +248,19 @@ class FCTest(serial.SerializedTestCase):
 
             n_offenders = np.count_nonzero(rowdiff[rowdiff > GLOW_MATMUL_RTOL])
             if n_offenders > 0:
-                print_test_debug_info("fc",
-                    {"seed": seed, "iter": i, "m": m, "k": k, "n": n, "X": X0,
-                     "W0": W0, "b0": b0, "Y_glow": Y_glow, "Y_c2": Y_c2,
-                     "diff": diff, "rowdiff": rowdiff})
+                print_test_debug_info("fc", {
+                    "seed": seed,
+                    "iter": i,
+                    "m": m,
+                    "k": k,
+                    "n": n,
+                    "X": X0,
+                    "W0": W0,
+                    "b0": b0,
+                    "Y_glow": Y_glow,
+                    "Y_c2": Y_c2,
+                    "diff": diff,
+                    "rowdiff": rowdiff})
                 assert(0)
 
     @settings(max_examples=5, deadline=None)
@@ -331,10 +346,19 @@ class FCTest(serial.SerializedTestCase):
 
             n_offenders = np.count_nonzero(rowdiff[rowdiff > GLOW_MATMUL_RTOL])
             if n_offenders > 0:
-                print_test_debug_info("fc",
-                    {"seed": seed, "iter": _, "m": m, "k": k, "n": n, "X": X0,
-                     "W0": W0, "b0": b0, "Y_glow": Y_glow, "Y_c2": Y_c2,
-                     "diff": diff, "rowdiff": rowdiff})
+                print_test_debug_info("fc", {
+                    "seed": seed,
+                    "iter": _,
+                    "m": m,
+                    "k": k,
+                    "n": n,
+                    "X": X0,
+                    "W0": W0,
+                    "b0": b0,
+                    "Y_glow": Y_glow,
+                    "Y_c2": Y_c2,
+                    "diff": diff,
+                    "rowdiff": rowdiff})
                 assert(0)
 
 if __name__ == '__main__':

--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -227,7 +227,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         n=st.integers(1, 4),
         rand_seed=st.integers(0, 65534)
     )
-    @settings(max_examples=100, deadline=1000)
+    @settings(max_examples=100, deadline=None)
     def test_int8_small_input(self, n, rand_seed):
         print("n={}, rand_seed={}".format(n, rand_seed))
         np.random.seed(rand_seed)

--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -23,7 +23,7 @@ kEpsilon = 1e-8
 
 class ArithmeticOpsTest(serial.SerializedTestCase):
     @given(seed=st.integers(0, 65534))
-    @settings(deadline=1000)
+    @settings(deadline=None)
     def _test_binary_op_graph(self, name, seed):
         np.random.seed(seed)
         workspace.ResetWorkspace()
@@ -104,15 +104,19 @@ class ArithmeticOpsTest(serial.SerializedTestCase):
                     "Y_glow": Y_glow, "Y_c2": Y_c2, "diff": diff})
                 assert(0)
 
+    @settings(deadline=None)
     def test_add_graph(self):
         self._test_binary_op_graph("Add")
 
+    @settings(deadline=None)
     def test_sub_graph(self):
         self._test_binary_op_graph("Sub")
 
+    @settings(deadline=None)
     def test_mul_graph(self):
         self._test_binary_op_graph("Mul")
 
+    @settings(deadline=None)
     def test_div_graph(self):
         self._test_binary_op_graph("Div")
 
@@ -193,6 +197,7 @@ class UnaryOpTest(serial.SerializedTestCase):
     # linear sweep and it is deterministic.
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
+    @settings(deadline=None)
     def test_sigmoid(self):
         opname = "Sigmoid"
         regions = [[-8., -4.], [-4., -2.], [-2., -1.], [-1., -.5], [-.5, -.25],
@@ -204,6 +209,7 @@ class UnaryOpTest(serial.SerializedTestCase):
     # linear sweep and it is deterministic.
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
+    @settings(deadline=None)
     def test_tanh(self):
         opname = "Tanh"
         regions = [[2.**(-9), 2.**(-8)], [2.**(-8), 2.**(-7)],
@@ -218,6 +224,7 @@ class UnaryOpTest(serial.SerializedTestCase):
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
     # TODO: move atol to 1e-8 once we get a non-lowered swish implementation
+    @settings(deadline=None)
     def test_swish(self):
         opname = "Swish"
         regions = [[-20.5, -11.], [-11., -8.], [-8., -1.], [-1., -0.1],
@@ -228,6 +235,7 @@ class UnaryOpTest(serial.SerializedTestCase):
     # linear sweep and it is deterministic.
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
+    @settings(deadline=None)
     def test_logit(self):
         workspace.ResetWorkspace()
         n = 1
@@ -292,7 +300,7 @@ class UnaryOpTest(serial.SerializedTestCase):
 
 class ReluTest(serial.SerializedTestCase):
     @given(seed=st.integers(0, 65534))
-    @settings(deadline=10000)
+    @settings(deadline=None)
     def relu_test(self, inputs, gc, dc, seed):
         np.random.seed(seed)
         inputs = np.random.rand(1).astype(np.float32)

--- a/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
@@ -24,7 +24,7 @@ workspace.GlobalInit(["caffe2", "--glow_global_fp16=1",
 
 class SparseLengthsSum4BitFakeNNPIFp16Test(serial.SerializedTestCase):
     @given(seed=st.integers(0, 65535))
-    @settings(deadline=10000)
+    @settings(deadline=None)
     def test_slws_fused_4bit_rowwise_all_same(self, seed):
         np.random.seed(seed)
         workspace.ResetWorkspace()
@@ -39,8 +39,8 @@ class SparseLengthsSum4BitFakeNNPIFp16Test(serial.SerializedTestCase):
                                     size=num_lengths).astype(np.int32)
         num_indices = np.sum(lengths)
         indices = np.zeros(num_indices, dtype=np.int64)
-        weights = np.random.uniform(low=-0.5, high=0.5,
-            size=[len(indices)]).astype(np.float32)
+        weights = np.random.uniform(low=-0.5, high=0.5, size=[len(indices)])\
+            .astype(np.float32)
         weights = np.ones(len(indices)).astype(np.float32)
         pred_net = caffe2_pb2.NetDef()
         pred_net.name = "pred"
@@ -118,7 +118,7 @@ class SparseLengthsSum4BitFakeNNPIFp16Test(serial.SerializedTestCase):
         batch_size=st.integers(1, 32),
         max_weight=st.integers(0, 1),
     )
-    @settings(deadline=10000)
+    @settings(deadline=None)
     def test_slws_fused_4bit_rowwise(self, seed, num_rows, embedding_dim, batch_size, max_weight):
         workspace.ResetWorkspace()
         np.random.seed(seed)

--- a/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
@@ -144,7 +144,7 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
 
 
     @given(seed=st.integers(0, 65535))
-    @settings(max_examples=100)
+    @settings(deadline=None, max_examples=100)
     def test_small_sls_acc32(self, seed):
         workspace.GlobalInit(
             [


### PR DESCRIPTION
Summary:
old version of hypothesis.testing was not enforcing deadlines
after the library got updated, default deadline=200ms, but even with 1s or
more, tests are flaky. Changing deadline to non-enforced which is the same
behavior as the old version

Test Plan: tested fakelowp/tests

Differential Revision: D23059033

