### PR TITLE
Add Enum convert back to Python object support

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -59,7 +59,7 @@ bool operator==(const ivalue::EnumHolder& lhs, const ivalue::EnumHolder& rhs) {
 }
 
 const std::string ivalue::EnumHolder::qualifiedClassName() const {
-  return type_->qualifiedClassName().name();
+  return type_->qualifiedClassName().qualifiedName();
 }
 
 } // namespace ivalue

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -559,7 +559,7 @@ struct ivalue::EnumHolder : c10::intrusive_ptr_target {
       std::ostream& out,
       const EnumHolder& v);
 
-  const std::string qualifiedClassName() const;
+  CAFFE2_API const std::string qualifiedClassName() const;
 
   const std::string& name() const {
     return name_;

--- a/test/jit/test_enum.py
+++ b/test/jit/test_enum.py
@@ -17,10 +17,12 @@ if __name__ == '__main__':
 
 class TestEnum(JitTestCase):
     def setUp(self):
+        super().setUp()
         self.saved_enum_env_var = os.environ.get("EXPERIMENTAL_ENUM_SUPPORT", None)
         os.environ["EXPERIMENTAL_ENUM_SUPPORT"] = "1"
 
     def tearDown(self):
+        super().tearDown()
         if self.saved_enum_env_var:
             os.environ["EXPERIMENTAL_ENUM_SUPPORT"] = self.saved_enum_env_var
 
@@ -108,15 +110,14 @@ class TestEnum(JitTestCase):
             scripted_enum_comp(Foo.ITEM1),
             False)
 
-
     def test_heterogenous_value_type_enum_error(self):
-        global Color
+        global ColorDiffType
 
-        class Color(Enum):
+        class ColorDiffType(Enum):
             RED = 1
             GREEN = "green"
 
-        def enum_comp(x: Color, y: Color) -> bool:
+        def enum_comp(x: ColorDiffType, y: ColorDiffType) -> bool:
             return x == y
 
         # TODO(gmagogsfm): Re-enable hooks when serialization/deserialization
@@ -167,15 +168,19 @@ class TestEnum(JitTestCase):
             RED = 1
             GREEN = 2
 
-        @torch.jit.script
         def enum_const(x: Color) -> bool:
             if x == Color.RED:
                 return True
             else:
                 return False
 
-        self.assertEqual(enum_const(Color.RED), True)
-        self.assertEqual(enum_const(Color.GREEN), False)
+        # TODO(gmagogsfm): Re-enable hooks when serialization/deserialization
+        # is supported.
+        with torch._jit_internal._disable_emit_hooks():
+            scripted = torch.jit.script(enum_const)
+
+        self.assertEqual(scripted(Color.RED), True)
+        self.assertEqual(scripted(Color.GREEN), False)
 
     def test_non_existent_enum_value(self):
         global Color
@@ -262,17 +267,60 @@ class TestEnum(JitTestCase):
 
         self.assertEqual(scripted(), Color.RED.value)
 
-    def test_enum_iterate(self):
-        global ColorForIterate
+    def test_enum_return(self):
+        global Color
 
-        class ColorForIterate(Enum):
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+
+        def return_enum(cond: bool):
+            if cond:
+                return Color.RED
+            else:
+                return Color.GREEN
+
+        # TODO(gmagogsfm): Re-enable hooks when serialization/deserialization
+        # is supported.
+        with torch._jit_internal._disable_emit_hooks():
+            scripted = torch.jit.script(return_enum)
+
+        self.assertEqual(scripted(True), Color.RED)
+        self.assertEqual(scripted(False), Color.GREEN)
+
+    def test_enum_module_return(self):
+        global Color
+
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, e: Color):
+                super(TestModule, self).__init__()
+                self.e = e
+
+            def forward(self):
+                return self.e
+
+        m = TestModule(Color.RED)
+        with torch._jit_internal._disable_emit_hooks():
+            scripted = torch.jit.script(m)
+
+        self.assertEqual(scripted(), Color.RED)
+
+
+    def test_enum_iterate(self):
+        global Color
+
+        class Color(Enum):
             RED = 1
             GREEN = 2
             PURPLE = 3
 
-        def iterate_enum(x: ColorForIterate):
+        def iterate_enum(x: Color):
             res: List[int] = []
-            for e in ColorForIterate:
+            for e in Color:
                 if e != x:
                     res.append(e.value)
             return res
@@ -281,8 +329,8 @@ class TestEnum(JitTestCase):
             scripted = torch.jit.script(iterate_enum)
 
         # PURPLE always appear last because we follow Python's Enum definition order.
-        self.assertEqual(scripted(ColorForIterate.RED), [ColorForIterate.GREEN.value, ColorForIterate.PURPLE.value])
-        self.assertEqual(scripted(ColorForIterate.GREEN), [ColorForIterate.RED.value, ColorForIterate.PURPLE.value])
+        self.assertEqual(scripted(Color.RED), [Color.GREEN.value, Color.PURPLE.value])
+        self.assertEqual(scripted(Color.GREEN), [Color.RED.value, Color.PURPLE.value])
 
         # TODO(gmagogsfm): Add FileCheck test after serialization and ir representation is completed.
 
@@ -290,11 +338,13 @@ class TestEnum(JitTestCase):
 # Tests that Enum support features are properly guarded before they are mature.
 class TestEnumFeatureGuard(JitTestCase):
     def setUp(self):
+        super().setUp()
         self.saved_enum_env_var = os.environ.get("EXPERIMENTAL_ENUM_SUPPORT", None)
         if self.saved_enum_env_var:
             del os.environ["EXPERIMENTAL_ENUM_SUPPORT"]
 
     def tearDown(self):
+        super().tearDown()
         if self.saved_enum_env_var:
             os.environ["EXPERIMENTAL_ENUM_SUPPORT"] = self.saved_enum_env_var
 

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/ivalue.h>
 #include <ATen/core/jit_type.h>
+#include <ATen/core/qualified_name.h>
 #include <ATen/core/stack.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -291,9 +292,9 @@ inline InferredType tryToInferType(py::handle input) {
   py::bool_ isEnumValue = py::isinstance(input, enum_type);
   if (py::cast<bool>(isEnumValue)) {
     auto enum_class = input.attr("__class__");
-    auto enum_type =
-        py::cast<TypePtr>(py::module::import("torch.jit.annotations")
-                              .attr("try_ann_to_type")(enum_class, py::none()));
+    auto enum_type = py::cast<TypePtr>(
+        py::module::import("torch.jit.annotations")
+            .attr("try_ann_to_type")(enum_class, SourceRange()));
     return InferredType(enum_type);
   }
 
@@ -822,6 +823,19 @@ inline IValue returnToIValue(const TypePtr& type, py::handle object) {
   }
 }
 
+inline py::object getScriptedClassOrError(const std::string& name) {
+  auto py_class = py::module::import("torch.jit._state")
+                      .attr("_get_script_class")(name.c_str());
+  if (py_class.is_none()) {
+    std::stringstream err;
+    err << "Unknown reference to ScriptClass ";
+    err << name;
+    err << ". (Did you forget to import it?)";
+    throw std::runtime_error(err.str());
+  }
+  return py_class;
+}
+
 inline py::object toPyObject(IValue ivalue) {
   if (ivalue.isNone()) {
     return py::none();
@@ -900,15 +914,7 @@ inline py::object toPyObject(IValue ivalue) {
     }
     const auto classType = pyCu->get_class(c10::QualifiedName(obj->name()));
     AT_ASSERT(classType);
-    auto pyClass = py::module::import("torch.jit._state")
-                       .attr("_get_script_class")(obj->name());
-    if (pyClass.is_none()) {
-      std::stringstream err;
-      err << "Unknown reference to ScriptClass ";
-      err << obj->name();
-      err << ". Did you forget to import it?)";
-      throw std::runtime_error(err.str());
-    }
+    auto pyClass = getScriptedClassOrError(obj->name());
     auto pyObj = pyClass.attr("__new__")(pyClass);
 
     const auto numAttrs = classType->numAttributes();
@@ -927,6 +933,12 @@ inline py::object toPyObject(IValue ivalue) {
     return py::cast(ivalue.toCapsule());
   } else if (ivalue.isFuture()) {
     return py::cast(std::make_shared<PythonFutureWrapper>(ivalue.toFuture()));
+  } else if (ivalue.isEnum()) {
+    auto enum_holder = ivalue.toEnumHolder();
+    auto qualified_class_name = enum_holder->qualifiedClassName();
+
+    auto py_class = getScriptedClassOrError(qualified_class_name);
+    return py_class.attr(enum_holder->name().c_str());
   } else if (ivalue.isRRef()) {
 #ifdef USE_DISTRIBUTED
     return py::cast(torch::distributed::rpc::PyRRef(

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -318,6 +318,8 @@ def try_ann_to_type(ann, loc):
             warnings.warn("Enum support is work in progress, enum class {}"
                           " is not compiled".format(ann))
             return None
+        if not hasattr(ann, "__torch_script_class__"):
+            torch.jit._script._recursive_compile_class(ann, loc)
         return EnumType(_qualified_name(ann), get_enum_value_type(ann, loc))
     if inspect.isclass(ann):
         if hasattr(ann, "__torch_script_class__"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #42963 Add Enum TorchScript serialization and deserialization support
* #42874 Fix enum constant printing and add FileCheck to all Enum tests
* #42873 Add Enum convert back to Python object support
* **#42872 Add Enum convert back to Python object support**

