### PR TITLE
[NNC] Hook up registerizer to Cuda codegen [2/x]

### DIFF
--- a/test/cpp/tensorexpr/test_registerizer.cpp
+++ b/test/cpp/tensorexpr/test_registerizer.cpp
@@ -582,7 +582,6 @@ void testRegisterizerAllocs() {
   Buffer b(BufHandle("B", {1}, kInt));
   Buffer c(BufHandle("C", {1}, kInt));
   VarHandle x("x", kInt);
-  VarHandle y("y", kInt);
 
   VarHandle b_(b.data()->base_handle());
 
@@ -614,9 +613,9 @@ void testRegisterizerAllocs() {
 
   /*
    * int C_ = C[0];
+   * Allocate(B, int, {C_});
    * int A_ = C_;
    * int B_ = 0;
-   * Allocate(B, int, {C_});
    * for (int x = 0; x < 10; x++) {
    *   B_ = B_ + x;
    *   A_ = C_;
@@ -632,9 +631,9 @@ void testRegisterizerAllocs() {
   const std::string& verification_pattern =
       R"IR(
 # CHECK: int C_ = C[0];
+# CHECK: Allocate(B
 # CHECK: int A_ = C_;
 # CHECK: int B_ = 0;
-# CHECK: Allocate(B
 # CHECK: for (int x = 0; x < 10; x++)
 # CHECK:   B_ =
 # CHECK:   A_ = C_

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -1009,6 +1009,32 @@ void testSimplifySubs() {
   }
 }
 
+void testSimplifyDiv() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+
+  {
+    ExprHandle body = ExprHandle(0) / x;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+
+    IS_IMM_WITH_VAL(Int, simplified.node(), 0);
+  }
+
+  {
+    ExprHandle body = x / 1;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+
+    IS_VAR_WITH_NAME(simplified.node(), "x");
+  }
+
+  {
+    ExprHandle body = x / x;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+
+    IS_IMM_WITH_VAL(Int, simplified.node(), 1);
+  }
+}
+
 // Test that mixing ops together simplifies as expected.
 void testSimplifyMultiOp() {
   KernelScope kernel_scope;

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -149,6 +149,7 @@ namespace jit {
   _(SimplifyAdds)                           \
   _(SimplifyMuls)                           \
   _(SimplifySubs)                           \
+  _(SimplifyDiv)                            \
   _(SimplifyMultiOp)                        \
   _(SimplifyManyOps)                        \
   _(SimplifyFactorization)                  \

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -26,12 +26,67 @@ class CudaAnalysis : public IRVisitor {
     return store_targets_.count(buf) > 0;
   }
 
+  const std::unordered_set<const Var*>& thread_local_bufs() const {
+    return thread_local_bufs_;
+  }
+
+  const std::unordered_set<const Var*>& cross_block_bufs() const {
+    return cross_block_bufs_;
+  }
+
  private:
   void visit(const Store* v) override {
     store_targets_.insert(v->buf());
   }
 
+  void visit(const Allocate* v) override;
+  void visit(const Free* v) override;
+
   std::unordered_set<const Buf*> store_targets_;
+  std::unordered_set<const Var*> thread_local_bufs_;
+  std::unordered_set<const Var*> cross_block_bufs_;
+};
+
+// An IRMutator that replaces binding loop options with Cuda metavars.
+class GPUMetaVarRewriter : public IRMutator {
+ public:
+  explicit GPUMetaVarRewriter() {
+    gpu_block_vars_ = {new Var("blockIdx.x", kInt),
+                       new Var("blockIdx.y", kInt),
+                       new Var("blockIdx.z", kInt)};
+    gpu_thread_vars_ = {new Var("threadIdx.x", kInt),
+                        new Var("threadIdx.y", kInt),
+                        new Var("threadIdx.z", kInt)};
+  }
+
+  Stmt* mutate(const For* v) override;
+  Stmt* mutate(const Block* v) override;
+
+  const std::vector<const Expr*>& gpu_block_extents() const {
+    return gpu_block_extents_;
+  }
+
+  const std::vector<const Expr*>& gpu_thread_extents() const {
+    return gpu_thread_extents_;
+  }
+
+  const std::vector<const Var*>& gpu_block_vars() const {
+    return gpu_block_vars_;
+  }
+
+  const std::vector<const Var*>& gpu_thread_vars() const {
+    return gpu_thread_vars_;
+  }
+
+ private:
+  std::vector<const Expr*> gpu_block_extents_;
+  std::vector<const Expr*> gpu_thread_extents_;
+
+  std::vector<const Var*> gpu_block_vars_;
+  std::vector<const Var*> gpu_thread_vars_;
+
+  bool need_sync_ = false;
+  const Expr* last_thread_dim_ = nullptr;
 };
 
 // A class that overrides the underlying IRPrinter to produce Cuda C.
@@ -62,14 +117,6 @@ class CudaPrinter : public IRPrinter {
   void visit(const Free* v) override;
   void visit(const Let* v) override;
 
-  const std::vector<const Expr*>& gpu_block_extents() const {
-    return gpu_block_extents_;
-  }
-
-  const std::vector<const Expr*>& gpu_thread_extents() const {
-    return gpu_thread_extents_;
-  }
-
   const Var* rand_func() const {
     return rand_func_;
   }
@@ -78,13 +125,8 @@ class CudaPrinter : public IRPrinter {
   using IRPrinter::visit;
 
  private:
-  void maybe_insert_sync();
-  std::vector<const Expr*> gpu_block_extents_;
-  std::vector<const Expr*> gpu_thread_extents_;
   const Var* rand_func_;
   const CudaAnalysis* cuda_analysis_;
-  bool need_sync_ = false;
-  std::unordered_set<const Var*> thread_local_bufs_;
 };
 
 // Construct Cuda C from the buffer and tensor input, and invoke the kernel
@@ -136,6 +178,7 @@ class TORCH_CUDA_API CudaCodeGen : public CodeGen {
   std::ostringstream oss_;
   std::unique_ptr<CudaPrinter> printer_;
   std::unique_ptr<CudaAnalysis> cuda_analysis_;
+  std::unique_ptr<GPUMetaVarRewriter> metavar_rewriter_;
   CUfunction function_;
   bool has_random_ = false;
 

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -370,17 +370,21 @@ Stmt* IRMutator::mutate(const AtomicAdd* v) {
   return new AtomicAdd(buf_new, indices_new, value_new);
 }
 
+Stmt* IRMutator::mutate(const SyncThreads* v) {
+  return new SyncThreads();
+}
+
 Stmt* IRMutator::mutate(const Allocate* v) {
   const Var* buffer_var_old = v->buffer_var();
   const Var* buffer_var_new =
       dynamic_cast<const Var*>(buffer_var_old->accept_mutator(this));
-  bool any_change = buffer_var_new == buffer_var_old;
+  bool any_change = buffer_var_new != buffer_var_old;
 
   std::vector<const Expr*> dims_old = v->dims();
   std::vector<const Expr*> dims_new(dims_old.size());
   for (size_t i = 0; i < dims_old.size(); i++) {
     dims_new[i] = dims_old[i]->accept_mutator(this);
-    any_change |= (dims_new[i] == dims_old[i]);
+    any_change |= (dims_new[i] != dims_old[i]);
   }
 
   if (!any_change) {

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -50,6 +50,7 @@ class Polynomial;
 class RoundOff;
 class ReduceOp;
 class AtomicAdd;
+class SyncThreads;
 
 class TORCH_API IRMutator {
  public:
@@ -99,6 +100,7 @@ class TORCH_API IRMutator {
   virtual Stmt* mutate(const Block* v);
   virtual Stmt* mutate(const Store* v);
   virtual Stmt* mutate(const AtomicAdd* v);
+  virtual Stmt* mutate(const SyncThreads* v);
 
   virtual Stmt* mutate(const Allocate* v);
   virtual Stmt* mutate(const Free* v);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -473,6 +473,11 @@ void IRPrinter::visit(const AtomicAdd* v) {
   os() << std::endl;
 }
 
+void IRPrinter::visit(const SyncThreads* v) {
+  emitIndent();
+  os() << "__syncthreads();\n";
+}
+
 void IRPrinter::emitIndent() {
   os() << std::setw(2 * indent_) << "";
 }

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -50,6 +50,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const ReduceOp* v) override;
 
   void visit(const AtomicAdd* v) override;
+  void visit(const SyncThreads* v) override;
   void visit(const Store* v) override;
   void visit(const For* v) override;
   void visit(const Cond* v) override;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -949,6 +949,21 @@ const Expr* PolynomialTransformer::mutate(const Div* v) {
     return new Div(lhs_new, rhs_new);
   }
 
+  // If the numerator is zero, so is the result.
+  if (lhs_new->isConstant() && immediateEquals(lhs_new, 0)) {
+    return lhs_new;
+  }
+
+  // If the denominator is one, return numerator.
+  if (rhs_new->isConstant() && immediateEquals(rhs_new, 1)) {
+    return lhs_new;
+  }
+
+  // If numberator and denominator are equal the result is 1.
+  if (hasher_.hash(lhs_new) == hasher_.hash(rhs_new)) {
+    return getImmediateByType(v->dtype(), 1);
+  }
+
   if (auto ret = factorizeDivision(lhs_new, rhs_new)) {
     return ret;
   }

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -115,6 +115,8 @@ void IRVisitor::visit(const AtomicAdd* v) {
   v->value()->accept(this);
 }
 
+void IRVisitor::visit(const SyncThreads* v) {}
+
 void IRVisitor::visit(const Block* v) {
   for (Stmt* s : *v) {
     s->accept(this);

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -47,6 +47,7 @@ class Polynomial;
 class RoundOff;
 class ReduceOp;
 class AtomicAdd;
+class SyncThreads;
 
 class TORCH_API IRVisitor {
  public:
@@ -99,6 +100,7 @@ class TORCH_API IRVisitor {
   virtual void visit(const RoundOff* v);
   virtual void visit(const ReduceOp* v);
   virtual void visit(const AtomicAdd* v);
+  virtual void visit(const SyncThreads* v);
 };
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -284,10 +284,7 @@ Stmt* RegisterizerReplacer::mutate(const Block* v) {
     let = new Let(
         var_,
         new Load(
-            info_->buf->base_handle()->dtype(),
-            info_->buf,
-            info_->indices,
-            new IntImm(1)));
+            info_->buf->dtype(), info_->buf, info_->indices, new IntImm(1)));
   } else {
     let = new Let(var_, initializer_->value());
   }

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -690,6 +690,11 @@ class AtomicAdd : public StmtNode<AtomicAdd> {
   const Expr* value_;
 };
 
+class SyncThreads : public StmtNode<SyncThreads> {
+ public:
+  SyncThreads() {}
+};
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Insert the registerizer into the Cuda Codegen pass list, to enable scalar replacement and close the gap in simple reduction performance.

First up the good stuff, benchmark before:
```
          Column sum          Caffe2             NNC          Simple          Better
           (10, 100)          5.7917          9.7037          6.9386          6.0448
          (100, 100)          5.9338          14.972          7.1139          6.3254
        (100, 10000)          21.453          741.54          145.74          12.555
        (1000, 1000)          8.0678          122.75          22.833          9.0778

             Row sum          Caffe2             NNC          Simple          Better
           (10, 100)          5.4502          7.9661          6.1469          5.5587
          (100, 100)          5.7613          13.897           21.49          5.5808
        (100, 10000)          21.702          82.398          75.462          22.793
        (1000, 1000)          22.527             129          176.51          22.517

```

After:
```
          Column sum          Caffe2             NNC          Simple          Better
           (10, 100)          6.0458          9.4966          7.1094           6.056
          (100, 100)          5.9299          9.1482          7.1693           6.593
        (100, 10000)          21.739          121.97          162.63          14.376
        (1000, 1000)          9.2374           29.01          26.883          10.127

             Row sum          Caffe2             NNC          Simple          Better
           (10, 100)          5.9773          8.1792          7.2307          5.8941
          (100, 100)          6.1456          9.3155          24.563          5.8163
        (100, 10000)          25.384          30.212          88.531          27.185
        (1000, 1000)          26.517          32.702          209.31          26.537
```

Speedup about 3-8x depending on the size of the data (increasing with bigger inputs).

The gap between NNC and simple is closed or eliminated - remaining issue appears to be kernel launch overhead. Next up is getting us closer to the _Better_ kernel.

It required a lot of refactoring and bug fixes on the way:
* Refactored flattening of parallelized loops out of the CudaPrinter and into its own stage, so we can transform the graph in the stage between flattening and printing (where registerization occurs).
* Made AtomicAddFuser less pessimistic, it will now recognize that if an Add to a buffer is dependent on all used Block and Thread vars then it has no overlap and does not need to be atomic. This allows registerization to apply to these stores.
* Fixed PrioritizeLoad mutator so that it does not attempt to separate the Store and Load to the same buffer (i.e. reduction case).
* Moved CudaAnalysis earlier in the process, allowing later stages to use the analyzed bufs.
* Fixed a bug in the Registerizer where when adding a default initializer statement it would use the dtype of the underlying var (which is always kHandle) instead of the dtype of the Buf.
* Fixed a bug in the IRMutator where Allocate statements logic was inverted to be replaced only if they did not change.
* Added simplification of simple Division patterns to the IRSimplifier.