### PR TITLE
Improve sugared value's error message

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11496,7 +11496,7 @@ a")
                 return shutil.abcd
 
     def test_wrong_module_attr_lookup(self):
-        with self.assertRaisesRegex(RuntimeError, 'python value of type \'type\' cannot be used as a value:'):
+        with self.assertRaisesRegex(RuntimeError, 'python value of type \'type\' cannot be used as a value'):
             import io
 
             @torch.jit.script

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -63,6 +63,14 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
       Function& m,
       const std::string& field) override;
 
+  Value* asValue(const SourceRange& loc, Function& m) override {
+    throw ErrorReport(loc)
+        << kind() << " cannot be used as a value. "
+        << "Perhaps it is a closed over global variable? If so, please "
+        << "consider passing it in as an argument or use a local varible "
+        << "instead.";
+  }
+
  protected:
   py::object getattr(const SourceRange& loc, const std::string& name);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42889 Improve sugared value's error message**

I think most (if not all) cases where this code path is reached can be attributed to closing over a global variable.
Improving error message to make this clearer to users.

close #41288