### PR TITLE
Add complex tensor dtypes for the __cuda_array_interface__ spec

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -105,6 +105,8 @@ class TestNumbaIntegration(common.TestCase):
         """Torch __cuda_array_adaptor__ exposes tensor data to numba.cuda."""
 
         torch_dtypes = [
+            torch.complex64,
+            torch.complex128,
             torch.float16,
             torch.float32,
             torch.float64,
@@ -244,6 +246,8 @@ class TestNumbaIntegration(common.TestCase):
         """
 
         dtypes = [
+            numpy.complex64,
+            numpy.complex128,
             numpy.float64,
             numpy.float32,
             numpy.int64,
@@ -263,31 +267,31 @@ class TestNumbaIntegration(common.TestCase):
                 numba_ary = numba.cuda.to_device(numpy_ary)
                 torch_ary = torch.as_tensor(numba_ary, device="cuda")
                 self.assertEqual(numba_ary.__cuda_array_interface__, torch_ary.__cuda_array_interface__)
-                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
                 # Check that `torch_ary` and `numba_ary` points to the same device memory
                 torch_ary += 42
-                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
             # Implicit-copy because `torch_ary` is a CPU array
             for numpy_ary in numpy_arys:
                 numba_ary = numba.cuda.to_device(numpy_ary)
                 torch_ary = torch.as_tensor(numba_ary, device="cpu")
-                self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary))
+                self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
                 # Check that `torch_ary` and `numba_ary` points to different memory
                 torch_ary += 42
-                self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary) + 42)
+                self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary, dtype=dtype) + 42)
 
             # Explicit-copy when using `torch.tensor()`
             for numpy_ary in numpy_arys:
                 numba_ary = numba.cuda.to_device(numpy_ary)
                 torch_ary = torch.tensor(numba_ary, device="cuda")
-                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype))
 
                 # Check that `torch_ary` and `numba_ary` points to different memory
                 torch_ary += 42
-                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary) + 42)
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary, dtype=dtype) + 42)
 
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -690,6 +690,8 @@ class Tensor(torch._C._TensorBase):
         # CUDA devices are little-endian and tensors are stored in native byte
         # order. 1-byte entries are endian-agnostic.
         typestr = {
+            torch.complex64: "<c8",
+            torch.complex128: "<c16",
             torch.float16: "<f2",
             torch.float32: "<f4",
             torch.float64: "<f8",


### PR DESCRIPTION
Fixes #42860 

The `__cuda_array_interface__` tensor specification is missing the appropriate datatypes for the newly merged complex64 and complex128 tensors. This PR addresses this issue by casting:

* `torch.complex64` to 'c8'
* `torch.complex128` to 'c16'