### PR TITLE
[NNC] Fix some bugs in Round+Mod simplification

### DIFF
--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -1384,12 +1384,33 @@ void testSimplifyRoundModPattern() {
   }
 
   {
+    // Reverse order.
+    // x%y + (x/y)*y => x.
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    ExprHandle body = (x % y) + ((x / y) * y);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_VAR_WITH_NAME(simplified.node(), "x");
+  }
+
+  {
     // Non opaque denominator.
     // (x / (4+y)) * (4+y)) + (x % (y + 4)) => x.
     VarHandle x("x", kInt);
     VarHandle y("y", kInt);
     ExprHandle body = ((x / (ExprHandle(4) + y)) * (ExprHandle(4) + y)) +
         (x % (y + ExprHandle(4)));
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_VAR_WITH_NAME(simplified.node(), "x");
+  }
+
+  {
+    // Reverse order.
+    // (x % (y + 4)) + (x / (4+y)) * (4+y)) => x.
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    ExprHandle body = (x % (y + ExprHandle(4))) +
+        ((x / (ExprHandle(4) + y)) * (ExprHandle(4) + y));
     ExprHandle simplified = IRSimplifier::simplify(body);
     IS_VAR_WITH_NAME(simplified.node(), "x");
   }
@@ -1430,6 +1451,35 @@ void testSimplifyRoundModPattern() {
     IS_NODE_WITH_NAME(Div, simplified.node(), div);
     IS_VAR_WITH_NAME(div->lhs(), "x");
     IS_IMM_WITH_VAL(Int, div->rhs(), 2);
+  }
+
+  {
+    // Numerator and denominator.
+    // ((2*x)/(2*y) * (2*y)) + ((2*x) % (2*y)) => 2 * x.
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    ExprHandle body =
+        (((ExprHandle(2) * x) / (ExprHandle(2) * y)) * (ExprHandle(2) * y)) +
+        ((ExprHandle(2) * x) % (ExprHandle(2) * y));
+    ExprHandle simplified = IRSimplifier::simplify(body);
+
+    IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 2);
+    IS_VAR_WITH_NAME(mul->rhs(), "x");
+  }
+
+  {
+    // Reverse order.
+    // ((2*x) % (2*y)) + ((2*x)/(2*y) * (2*y)) => 2 * x.
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    ExprHandle body = ((ExprHandle(2) * x) % (ExprHandle(2) * y)) +
+        (((ExprHandle(2) * x) / (ExprHandle(2) * y)) * (ExprHandle(2) * y));
+    ExprHandle simplified = IRSimplifier::simplify(body);
+
+    IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 2);
+    IS_VAR_WITH_NAME(mul->rhs(), "x");
   }
 
   {
@@ -1622,6 +1672,26 @@ void testSimplifyRoundModPatternMultivar() {
     IS_NODE_WITH_NAME(Mod, add->rhs(), zMod);
     IS_VAR_WITH_NAME(zMod->lhs(), "z");
     IS_IMM_WITH_VAL(Int, zMod->rhs(), 8);
+  }
+
+  {
+    // Compound.
+    // (x + (z + 512 * y) % 16) + 16 * ((z + 512 * y) / 16)  => x + (z + 512 *
+    // y).
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    VarHandle z("z", kInt);
+
+    ExprHandle body = x + (z + ExprHandle(512) * y) % ExprHandle(16) +
+        ExprHandle(16) * ((z + ExprHandle(512) * y) / ExprHandle(16));
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Add, simplified.node(), add);
+    IS_VAR_WITH_NAME(add->lhs(), "x");
+    IS_NODE_WITH_NAME(Add, add->rhs(), add2);
+    IS_VAR_WITH_NAME(add2->lhs(), "z");
+    IS_NODE_WITH_NAME(Mul, add2->rhs(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 512);
+    IS_VAR_WITH_NAME(mul->rhs(), "y");
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -696,18 +696,27 @@ const Expr* PolynomialTransformer::isRoundOff(
     return nullptr;
   }
 
-  if (hasher_.hash(div->rhs()) == hasher_.hash(other)) {
-    // If the denominator is equal to the other, then yes it's a RoundOff.
-    return new RoundOff(div->lhs(), rhs);
+  const Expr* denom = div->rhs();
+
+  if (const Term* denomTerm = dynamic_cast<const Term*>(denom)) {
+    if (immediateEquals(denomTerm->scalar(), 1) &&
+        denomTerm->variables().size() == 1) {
+      denom = denomTerm->variables()[0];
+    }
   }
 
-  if (div->rhs()->isConstant() && other->isConstant()) {
-    if (immediateEquals(div->rhs(), 0) || immediateEquals(other, 0)) {
+  if (hasher_.hash(denom) == hasher_.hash(other)) {
+    // If the denominator is equal to the other, then yes it's a RoundOff.
+    return new RoundOff(div->lhs(), div->rhs());
+  }
+
+  if (denom->isConstant() && other->isConstant()) {
+    if (immediateEquals(denom, 0) || immediateEquals(other, 0)) {
       return nullptr;
     }
     // If they are both scalar we may be able to find a common factor.
-    if (immediateEquals(evaluateOp(new Mod(other, div->rhs())), 0)) {
-      Expr* scalar = evaluateOp(new Div(other, div->rhs()));
+    if (immediateEquals(evaluateOp(new Mod(other, denom)), 0)) {
+      Expr* scalar = evaluateOp(new Div(other, denom));
       Expr* newDenom = evaluateOp(new Div(other, scalar));
       return new Term(hasher_, scalar, new RoundOff(div->lhs(), newDenom));
     }
@@ -793,6 +802,11 @@ const Expr* PolynomialTransformer::mutate(const Mul* v) {
   // Catch cases of rounding (Div(A/B) * B).
   if (auto* ret = isRoundOff(lhs_new, rhs_new)) {
     return ret;
+  } else if (auto* ret = isRoundOff(v->lhs(), v->rhs())) {
+    // We can break the Round + Mod pattern via factorization of the Div, so
+    // check whether it would have worked on the unsimplified tree. If so, we
+    // need to simplify again.
+    return ret->accept_mutator(this);
   }
 
   const Polynomial* lhsPoly = dynamic_cast<const Polynomial*>(lhs_new);


### PR DESCRIPTION
When working on the Cuda Codegen, I found that running the IRSimplifier before generating code lead to test fails. This was due to a bug in Round+Mod simplification (e.g. (x / y * y) + (x % y) => x) to do with the order in which the terms appeared. After fixing it and writing a few tests around those cases, I found another bug in simplification of the same pattern and have fixed it (with some more test coverage).