### PR TITLE
Add executor and fuser options to the fastrnn test fixture

### DIFF
--- a/benchmarks/fastrnns/test_bench.py
+++ b/benchmarks/fastrnns/test_bench.py
@@ -29,7 +29,6 @@ def set_fuser(fuser_name):
 
 def set_executor(executor_name):
     if executor_name == 'profiling':
-        print("Setting profiling executor")
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(True)
         torch._C._jit_set_bailout_depth(20)

--- a/benchmarks/fastrnns/test_bench.py
+++ b/benchmarks/fastrnns/test_bench.py
@@ -12,9 +12,39 @@ def pytest_generate_tests(metafunc):
     # This creates lists of tests to generate, can be customized
     if metafunc.cls.__name__ == "TestBenchNetwork":
         metafunc.parametrize('net_name', all_nets, scope="class")
+        metafunc.parametrize("executor_and_fuser", ["legacy-old", "profiling-te"], scope="class")
+
+def set_fuser(fuser_name):
+    if fuser_name == 'te':
+        torch._C._jit_override_can_fuse_on_cpu(False)
+        torch._C._jit_override_can_fuse_on_gpu(False)
+        torch._C._jit_set_texpr_fuser_enabled(True)
+    elif fuser_name == 'old':
+        torch._C._jit_override_can_fuse_on_gpu(True)
+        torch._C._jit_set_texpr_fuser_enabled(False)
+    elif fuser_name == 'none':
+        torch._C._jit_override_can_fuse_on_gpu(False)
+        torch._C._jit_override_can_fuse_on_cpu(False)
+        torch._C._jit_set_texpr_fuser_enabled(False)
+
+def set_executor(executor_name):
+    if executor_name == 'profiling':
+        print("Setting profiling executor")
+        torch._C._jit_set_profiling_executor(True)
+        torch._C._jit_set_profiling_mode(True)
+        torch._C._jit_set_bailout_depth(20)
+    elif executor_name == 'simple':
+        torch._C._jit_set_profiling_executor(True)
+        torch._C._jit_set_profiling_mode(False)
+    elif executor_name == 'legacy':
+        torch._C._jit_set_profiling_executor(False)
+        torch._C._jit_set_profiling_mode(False)
 
 @pytest.fixture(scope='class')
-def modeldef(request, net_name):
+def modeldef(request, net_name, executor_and_fuser):
+    executor, fuser = executor_and_fuser.split("-")
+    set_executor(executor)
+    set_fuser(fuser)
     # Given a 'net_name' provided by generate_tests, build the thing
     name, rnn_creator, context = get_nn_runners(net_name)[0]
     creator_args = creator_args = {

--- a/benchmarks/upload_scribe.py
+++ b/benchmarks/upload_scribe.py
@@ -75,7 +75,8 @@ class PytorchBenchmarkUploader(ScribeUploader):
                 'time', 'rounds',
             ],
             'normal': [
-                'benchmark_group', 'benchmark_name', 'benchmark_class', 'benchmark_time',
+                'benchmark_group', 'benchmark_name', 'benchmark_executor',
+                'benchmark_fuser', 'benchmark_class', 'benchmark_time',
                 'pytorch_commit_id', 'pytorch_branch', 'pytorch_commit_time', 'pytorch_version',
                 'pytorch_git_dirty',
                 'machine_kernel', 'machine_processor', 'machine_hostname',
@@ -92,10 +93,16 @@ class PytorchBenchmarkUploader(ScribeUploader):
         upload_time = int(time.time())
         messages = []
         for b in pytest_json['benchmarks']:
+            test = b['name'].split('[')[0]
+            net_name = b['params']['net_name']
+            benchmark_name = '{}[{}]'.format(test, net_name)
+            executor, fuser = b['params']['executor_and_fuser'].split('-')
             m = self.format_message({
                 "time": upload_time,
                 "benchmark_group": b['group'],
-                "benchmark_name": b['name'],
+                "benchmark_name": benchmark_name,
+                "benchmark_executor": executor,
+                "benchmark_fuser": fuser,
                 "benchmark_class": b['fullname'],
                 "benchmark_time": pytest_json['datetime'],
                 "pytorch_commit_id": commit_info['id'],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#42946 Add executor and fuser options to the fastrnn test fixture**

Summary: There are 3 options for the executor and fuser and some of them aren't
super interesting so I've combined the options into a single parameter, but
made it fairly easy to expand the set if there are other configs we might care
about.

Test Plan: Benchmark it

Reviewers: mvz, whc

Subscribers:

Tasks:

Tags:

Differential Revision: [D23090177](https://our.internmc.facebook.com/intern/diff/D23090177)