### PR TITLE
Do not ignore `torch/__init__.pyi`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ test/test-reports/
 third_party/build/
 tools/shared/_utils_internal.py
 torch.egg-info/
-torch/__init__.pyi
 torch/_C/__init__.pyi
 torch/_C/_nn.pyi
 torch/_C/_VariableFunctions.pyi


### PR DESCRIPTION
Delete abovementioned from .gitignore as the file is gone since https://github.com/pytorch/pytorch/issues/42908 and no longer should be autogenerated.

