### PR TITLE
collect_env.py: Print CPU architecture after Linux OS name

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -215,12 +215,12 @@ def get_os(run_lambda):
         # Ubuntu/Debian based
         desc = get_lsb_version(run_lambda)
         if desc is not None:
-            return desc
+            return '{} ({})'.format(desc, machine())
 
         # Try reading /etc/*-release
         desc = check_release_file(run_lambda)
         if desc is not None:
-            return desc
+            return '{} ({})'.forat(desc, machine())
 
         return '{} ({})'.format(platform, machine())
 


### PR DESCRIPTION
Missed this case in https://github.com/pytorch/pytorch/pull/42887
