### PR TITLE
maybe minor fix to dispatch/backend_fallback_test.cpp?

### DIFF
--- a/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
+++ b/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
@@ -71,10 +71,10 @@ void generic_wrapper_fallback(const c10::OperatorHandle& op, torch::jit::Stack* 
   auto rets = torch::jit::pop(*stack, num_returns);
   for (size_t i = 0; i < num_returns; i++) {
     // TODO: Handle tensor list
-    if (args[i].isTensor()) {
-      torch::jit::push(*stack, at::detail::make_tensor<GenericWrapperTensorImpl>(std::move(args[i]).toTensor()));  // yes move!
+    if (rets[i].isTensor()) {
+      torch::jit::push(*stack, at::detail::make_tensor<GenericWrapperTensorImpl>(std::move(rets[i]).toTensor()));  // yes move!
     } else {
-      torch::jit::push(*stack, std::move(args[i]));
+      torch::jit::push(*stack, std::move(rets[i]));
     }
   }
 }


### PR DESCRIPTION
I think you want to push rewrapped `rets`, not `args`, back to the stack.

Doesn't matter for test purposes because tests only check if/when fallbacks were called, they don't check outputs for correctness.  But it avoids reader confusion.
