### PR TITLE
[fx] split Node into Node/Proxy

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1,8 +1,5 @@
 import torch
-from torch.fx import symbolic_trace
-from torch.fx.symbolic_trace import DefaultDelegate
-from torch.fx.graph import Graph
-from torch.fx.node import Node
+from torch.fx import symbolic_trace, Proxy, Graph, Node, GraphModule,DefaultDelegate
 
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
@@ -81,7 +78,7 @@ class TestFX(TestCase):
     def test_disallow_override(self):
         # Custom delegate to disallow in-place tensor operations
         class NoMutableCallDelegate(DefaultDelegate):
-            def create_node(self, graph : Graph, kind : str, target : Union[str, Callable],
+            def create_node(self, kind : str, target : Union[str, Callable],
                             args : Tuple[Any], kwargs : Dict[str, Any], name : Optional[str] = None) -> Node:
                 name = target if isinstance(target, str) else torch.typename(target)
                 if name[-1] == '_':
@@ -97,7 +94,7 @@ class TestFX(TestCase):
         m = MyInplaceMod()
 
         with self.assertRaisesRegex(RuntimeError, 'In-place operations'):
-            symbolic_trace(m, delegate=NoMutableCallDelegate())
+            symbolic_trace(m, delegate_class=NoMutableCallDelegate)
 
         # Test free function
         class MyInplaceMod2(torch.nn.Module):
@@ -106,7 +103,7 @@ class TestFX(TestCase):
                 return x
         m2 = MyInplaceMod2()
         with self.assertRaisesRegex(RuntimeError, 'In-place operations'):
-            symbolic_trace(m2, delegate=NoMutableCallDelegate())
+            symbolic_trace(m2, delegate_class=NoMutableCallDelegate)
 
         # Test symbolic node as an arg
         class MyInplaceMod3(torch.nn.Module):
@@ -116,7 +113,7 @@ class TestFX(TestCase):
                 return x
         m3 = MyInplaceMod3()
         with self.assertRaisesRegex(RuntimeError, 'In-place operations'):
-            symbolic_trace(m3, delegate=NoMutableCallDelegate())
+            symbolic_trace(m3, delegate_class=NoMutableCallDelegate)
 
     def test_leaf_module(self):
         # Custom delegate to make it so that there are no leaf modules, everything
@@ -134,9 +131,23 @@ class TestFX(TestCase):
                 return self.relu(x)
 
         mrm = MyReluMod()
-        sym = symbolic_trace(mrm, delegate=NoLeafModulesDelegate())
+        sym = symbolic_trace(mrm, delegate_class=NoLeafModulesDelegate)
         for node in sym.graph.nodes:
             self.assertNotEqual(node.op, 'call_module')
+
+    def test_graph_edit_with_proxy(self):
+        class M(torch.nn.Module):
+            def forward(self, a, b):
+                return a + b
+        m = M()
+        g = symbolic_trace(m).graph
+        t = Proxy(g.result) 
+        # test that we can use proxy objects to generate more graph code later for things that do not need to work with modules.
+        g.output((t + t).node)
+        gm = GraphModule(m, g)
+        self.assertEqual(gm(3, 4), 14)
+        
+
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -146,7 +146,6 @@ class TestFX(TestCase):
         g.output((t + t).node)
         gm = GraphModule(m, g)
         self.assertEqual(gm(3, 4), 14)
-        
 
 
 if __name__ == '__main__':

--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -86,4 +86,7 @@ Because this code is valid PyTorch code, the resulting `GraphModule` can be used
 '''
 
 from .graph_module import GraphModule
-from .symbolic_trace import symbolic_trace
+from .symbolic_trace import symbolic_trace, DefaultDelegate
+from .graph import Graph
+from .node import Node
+from .proxy import Proxy

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -58,7 +58,6 @@ def map_arg(a, fn):
     elif isinstance(a, Node):
         return fn(a)
     else:
-        assert "Proxy" not in str(type(a)) 
         return a
 
 class Graph:

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1,5 +1,5 @@
 # type: ignore
-from .node import Node, Attribute, magic_methods
+from .node import Node
 
 import builtins
 import torch
@@ -9,12 +9,6 @@ def _is_magic(x):
 
 def snake_case(s):
     return ''.join(['_' + i.lower() if i.isupper() else i for i in s]).lstrip('_')
-
-def _reference_is_in(x, l):
-    for elem in l:
-        if x is elem:
-            return True
-    return False
 
 def _qualified_name(func):
     # things like getattr just appear in builtins
@@ -64,68 +58,40 @@ def map_arg(a, fn):
     elif isinstance(a, Node):
         return fn(a)
     else:
+        assert "Proxy" not in str(type(a)) 
         return a
 
 class Graph:
-    def __init__(self, delegate, arg_handler=None):
+    def __init__(self):
         self.nodes = []
         self._used_names = {}  # base name -> number
-        self.delegate = delegate
-        self.arg_handler = arg_handler
 
-    def _create_node(self, op, target=None, args=None, kwargs=None, name=None):
+    def _mark_uses(self, a):
+        def add_use(n: Node):
+            n.uses += 1
+            return n
+        map_arg(a, add_use)
+
+    def create_node(self, op, target=None, args=None, kwargs=None, name=None):
+        assert op in ('call_function', 'call_method', 'get_param', 'call_module', 'placeholder')
         args = () if args is None else args
         kwargs = {} if kwargs is None else kwargs
-        args = self._create_args(args)
-        kwargs = self._create_args(kwargs)
-        n = Node(self, name if name is not None else self._name(target or op), op, target, args, kwargs, self.delegate)
+        self._mark_uses(args)
+        self._mark_uses(kwargs)
+        n = Node(self, name if name is not None else self._name(target or op), op, target, args, kwargs)
         self.nodes.append(n)
         return n
-
-    def _create_args(self, a):
-        # aggregates
-        if isinstance(a, (tuple, list)):
-            return type(a)(self._create_args(elem) for elem in a)
-        elif isinstance(a, dict):
-            r = {}
-            for k, v in a.items():
-                if not isinstance(k, str):
-                    raise NotImplementedError(f"dictionaries with non-string keys: {a}")
-                r[k] = self._create_args(v)
-            return r
-        elif isinstance(a, slice):
-            return slice(self._create_args(a.start), self._create_args(a.stop), self._create_args(a.step))
-
-        # individual elements
-        r = NotImplemented
-        if self.arg_handler is not None:
-            r = self.arg_handler(self, a)
-
-        if r is NotImplemented:
-            if isinstance(a, Attribute):
-                if not _reference_is_in(a, self.nodes):
-                    self.nodes.append(a)
-                r = a
-            elif isinstance(a, (str, int, float, bool, Node, torch.dtype, torch.Tensor)) or a is None:
-                r = a
-
-        if r is NotImplemented:
-            raise NotImplementedError(f"argument of type: {type(a)}")
-
-        if isinstance(r, Node):
-            assert r.graph is self
-            r.uses += 1
-        return r
 
     def node_copy(self, node, arg_transform=lambda x: x):
         """ copy a node from one graph into another. arg_transform needs to transform arguments from the graph of node
             to the graph of self"""
-        return self._create_node(
+        return self.create_node(
             node.op, node.target, map_arg(node.args, arg_transform), map_arg(node.kwargs, arg_transform),
             self._name(node.name))
 
     def output(self, result):
         self.result = result
+        self._mark_uses(result)
 
 
     def _name(self, op):
@@ -145,16 +111,10 @@ class Graph:
         return f'{op}_{i}'
 
     def get_param(self, target):
-        return self._create_node('get_param', target)
+        return self.create_node('get_param', target)
 
     def placeholder(self, name):
-        return self._create_node('placeholder', target=name, name=name.replace('*', ''))
-
-    def call_module(self, target, args, kwargs):
-        return self._create_node('call_module', target, args, kwargs)
-
-    def call_function(self, target, args, kwargs):
-        return self._create_node('call_function', target, args, kwargs)
+        return self.create_node('placeholder', target=name, name=name.replace('*', ''))
 
     def python_code(self, root_module):
         free_vars = []
@@ -190,3 +150,31 @@ class Graph:
 
         src = ''.join(body)
         return src, str(self.result), free_vars
+
+reflectable_magic_methods = {
+    'add': '{} + {}',
+    'sub': '{} - {}',
+    'mul': '{} * {}',
+    'floordiv': '{} // {}',
+    'truediv': '{} / {}',
+    'div': '{} / {}',
+    'mod': '{} % {}',
+    'pow': '{} ** {}',
+    'lshift': '{} << {}',
+    'rshift': '{} >> {}',
+    'and': '{} & {}',
+    'or': '{} | {}',
+    'xor': '{} ^ {}',
+    'getitem': '{}[{}]'
+}
+
+magic_methods = dict({
+    'eq': '{} == {}',
+    'ne': '{} != {}',
+    'lt': '{} < {}',
+    'gt': '{} > {}',
+    'le': '{} <= {}',
+    'ge': '{} >= {}',
+    'pos': '+{}',
+    'neg': '-{}',
+    'invert': '~{}'}, **reflectable_magic_methods)

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -71,7 +71,7 @@ def forward(self, {', '.join(free_variables)}):
 # def patched_cat(*args, **kwargs):
 #     tensors = args[0]
 #     for t in tensors:
-#         if isinstance(t, Node):
+#         if isinstance(t, Proxy):
 #             return t.__torch_function__(patched_cat, (), args, kwargs)
 #     return orig_cat(*args, **kwargs)
 # patched_cat.__module__ = 'torch'

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -1,17 +1,8 @@
 # type: ignore
-import dis
-import torch
-import inspect
-import operator
-
-class TraceError(ValueError):
-    pass
 
 # Nodes represent a definition of a value in our graph of operators.
-# For simplicitly, they also have methods defined on them so that they serve as proxy objects for _building_
-# more nodes.
 class Node:
-    def __init__(self, graph, name, op, target, args, kwargs, delegate):
+    def __init__(self, graph, name, op, target, args, kwargs):
         self.graph = graph
         self.name = name  # unique name of value being created
         self.op = op  # the kind of operation = placeholder|call_method|call_module|call_function|getattr
@@ -20,97 +11,6 @@ class Node:
         self.args = args
         self.kwargs = kwargs
         self.uses = 0
-        self.delegate = delegate
 
     def __repr__(self):
         return self.name
-
-    def __getattr__(self, k):
-        # note: not added to the graph yet, if this is a method call
-        # we peephole optimize to the method invocation
-        return Attribute(self, k, self.delegate)
-
-    def __call__(self, *args, **kwargs):
-        return self._create_node('call_method', '__call__', [self] + args, kwargs)
-
-    def __iter__(self):
-        frame = inspect.currentframe()
-        calling_frame = frame.f_back
-        inst = list(dis.get_instructions(calling_frame.f_code))[calling_frame.f_lasti // 2]
-        if inst.opname == 'UNPACK_SEQUENCE':
-            return (self[i] for i in range(inst.argval))
-        self._no_control_flow()
-
-    def _no_control_flow(self):
-        raise TraceError('symbolically traced variables cannot be used as inputs to control flow')
-
-    def __bool__(self):
-        self._no_control_flow()
-
-    def __torch_function__(self, orig_method, types, args=None, kwargs=None):
-        args = args if args else ()
-        kwargs = kwargs if kwargs else {}
-        if torch.overrides.is_tensor_method_or_property(orig_method):
-            return self.delegate.create_node(self.graph, 'call_method', orig_method.__name__, args, kwargs)
-        else:
-            return self.delegate.create_node(
-                self.graph, 'call_function', orig_method, args, kwargs, name=self.graph._name(orig_method.__name__))
-
-class Attribute(Node):
-    def __init__(self, node, attr, delegate):
-        super().__init__(node.graph, node.graph._name(attr), 'call_function', getattr, [node, attr], {}, delegate)
-
-    def __call__(self, *args, **kwargs):
-        return self.delegate.create_node(
-            self.node.graph, 'call_method', self.args[1], [self.args[0]] + list(args), kwargs)
-
-reflectable_magic_methods = {
-    'add': '{} + {}',
-    'sub': '{} - {}',
-    'mul': '{} * {}',
-    'floordiv': '{} // {}',
-    'truediv': '{} / {}',
-    'div': '{} / {}',
-    'mod': '{} % {}',
-    'pow': '{} ** {}',
-    'lshift': '{} << {}',
-    'rshift': '{} >> {}',
-    'and': '{} & {}',
-    'or': '{} | {}',
-    'xor': '{} ^ {}',
-    'getitem': '{}[{}]'
-}
-
-magic_methods = dict({
-    'eq': '{} == {}',
-    'ne': '{} != {}',
-    'lt': '{} < {}',
-    'gt': '{} > {}',
-    'le': '{} <= {}',
-    'ge': '{} >= {}',
-    'pos': '+{}',
-    'neg': '-{}',
-    'invert': '~{}'}, **reflectable_magic_methods)
-
-for method in magic_methods:
-    def scope(method):
-        def impl(*args, **kwargs):
-            g = args[0].graph
-            target = getattr(operator, method)
-            return g._create_node('call_function', target, args, kwargs)
-        impl.__name__ = method
-        as_magic = f'__{method}__'
-        setattr(Node, as_magic, impl)
-    scope(method)
-
-for orig_method_name in reflectable_magic_methods:
-    def scope(orig_method_name):
-        method_name = f'__r{orig_method_name}__'
-
-        def impl(self, rhs):
-            target = getattr(operator, orig_method_name)
-            return self.graph._create_node('call_function', target, [rhs, self])
-        impl.__name__ = method_name
-        impl.__qualname__ = method_name
-        setattr(Node, method_name, impl)
-    scope(orig_method_name)

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -1,0 +1,106 @@
+# type: ignore
+import dis
+import torch
+import inspect
+import operator
+
+from .graph import magic_methods, reflectable_magic_methods
+
+class TraceError(ValueError):
+    pass
+
+# Proxy objects are stand-in values for normal values in a PyTorch computation.
+# Instead of performing compute they record computation into Graph.
+# Each proxy wraps the Node instance that represents the expression that define the
+# value.
+
+# Unwrap the proxies inside args, and kwargs, create the resulting node
+# and then wrap the result in a proxy.
+def _create_proxy(delegate, op, target, args, kwargs, name=None):
+    rn = delegate.create_node(op, target, delegate.create_arg(args), delegate.create_arg(kwargs), name)
+    return Proxy(rn, delegate)
+
+class Proxy:
+    def __init__(self, node, delegate=None):
+        if delegate is None:
+            # this allows you to create a proxy object around a raw node
+            # so that if you are doing graph transforms you can use the overloaded operators
+            # to add additional things to a graph.
+            from .symbolic_trace import DelegateBase
+            delegate = DelegateBase(node.graph)
+        self.delegate = delegate
+        self.node = node
+
+    def __repr__(self):
+        return f'Proxy({self.node.name})'
+
+    def __getattr__(self, k):
+        # note: not added to the graph yet, if this is a method call
+        # we peephole optimize to the method invocation
+        return Attribute(self, k)
+
+    def __call__(self, *args, **kwargs):
+        return _create_proxy(delegate, 'call_method', '__call__', [self] + args, kwargs)
+
+    def __iter__(self):
+        frame = inspect.currentframe()
+        calling_frame = frame.f_back
+        inst = list(dis.get_instructions(calling_frame.f_code))[calling_frame.f_lasti // 2]
+        if inst.opname == 'UNPACK_SEQUENCE':
+            return (self[i] for i in range(inst.argval))
+        self._no_control_flow()
+
+    def _no_control_flow(self):
+        raise TraceError('symbolically traced variables cannot be used as inputs to control flow')
+
+    def __bool__(self):
+        self._no_control_flow()
+
+    def __torch_function__(self, orig_method, types, args=None, kwargs=None):
+        args = args if args else ()
+        kwargs = kwargs if kwargs else {}
+        if torch.overrides.is_tensor_method_or_property(orig_method):
+            return _create_proxy(self.delegate, 'call_method', orig_method.__name__, args, kwargs)
+        else:
+            return _create_proxy(self.delegate, 'call_function', orig_method, args, kwargs, name=self.delegate.graph._name(orig_method.__name__))
+
+class Attribute(Proxy):
+    def __init__(self, root, attr):
+        self.root = root
+        self.attr = attr
+        self.delegate = root.delegate
+        self._node = None
+
+    @property
+    def node(self):
+        # the node for attributes is added lazily, since most will just be method calls
+        # which do not rely on the getitem call
+        if self._node is None:
+            self._node = _create_proxy(self.delegate, 'call_function', getattr, [self.root, self.attr], {}).node
+        return self._node
+
+    def __call__(self, *args, **kwargs):
+        return _create_proxy(self.delegate, 'call_method', self.attr, [self.root] + list(args), kwargs)
+
+for method in magic_methods:
+    def scope(method):
+        def impl(*args, **kwargs):
+            delegate = args[0].delegate
+            target = getattr(operator, method)
+            return _create_proxy(delegate, 'call_function', target, args, kwargs)
+        impl.__name__ = method
+        as_magic = f'__{method}__'
+        setattr(Proxy, as_magic, impl)
+    scope(method)
+
+for orig_method_name in reflectable_magic_methods:
+    def scope(orig_method_name):
+        method_name = f'__r{orig_method_name}__'
+
+        def impl(self, rhs):
+            target = getattr(operator, orig_method_name)
+            return _create_proxy(self.delegate, 'call_function', target, [rhs, self], {})
+        impl.__name__ = method_name
+        impl.__qualname__ = method_name
+        setattr(Proxy, method_name, impl)
+    scope(orig_method_name)

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -62,7 +62,8 @@ class Proxy:
         if torch.overrides.is_tensor_method_or_property(orig_method):
             return _create_proxy(self.delegate, 'call_method', orig_method.__name__, args, kwargs)
         else:
-            return _create_proxy(self.delegate, 'call_function', orig_method, args, kwargs, name=self.delegate.graph._name(orig_method.__name__))
+            return _create_proxy(self.delegate, 'call_function', orig_method, args, kwargs,
+                                 name=self.delegate.graph._name(orig_method.__name__))
 
 class Attribute(Proxy):
     def __init__(self, root, attr):

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -40,7 +40,7 @@ class Proxy:
         return Attribute(self, k)
 
     def __call__(self, *args, **kwargs):
-        return _create_proxy(delegate, 'call_method', '__call__', [self] + args, kwargs)
+        return _create_proxy(self.delegate, 'call_method', '__call__', [self] + args, kwargs)
 
     def __iter__(self):
         frame = inspect.currentframe()

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -7,6 +7,7 @@ import torch
 from .node import Node
 from .graph import Graph
 from .graph_module import GraphModule
+from .proxy import Proxy, _create_proxy
 
 HAS_VARSTUFF = inspect.CO_VARARGS | inspect.CO_VARKEYWORDS
 
@@ -42,7 +43,18 @@ def _patch_function(fn, nargs):
     # so we can't call this function normally, otherwise it would try to unpack them
     # instead, let's make python think that args and kwargs are normay variables
 
-class DefaultDelegate:
+class DelegateBase:
+    def __init__(self, graph: Graph):
+        self.graph = graph
+
+    # A method to insert a graph node given target, args, kwargs, and name.
+    # This method can be overridden to do extra checking, validation, or
+    # modification of values used in node creation. For example, one might
+    # want to disallow in-place operations from being recorded.
+    def create_node(self, kind : str, target : Union[str, Callable],
+                    args : Tuple[Any], kwargs : Dict[str, Any], name : Optional[str] = None) -> Node:
+        return self.graph.create_node(kind, target, args, kwargs, name)
+
     # A method to specify whether a given `nn.Module` is a "leaf"
     # module. Leaf modules are the atomic units that appear in
     # the IR, referenced by `call_module` calls. By default,
@@ -53,13 +65,51 @@ class DefaultDelegate:
     def is_leaf_module(self, m):
         return m.__module__.startswith('torch.nn') and not isinstance(m, torch.nn.Sequential)
 
-    # A method to insert a graph node given target, args, kwargs, and name.
-    # This method can be overridden to do extra checking, validation, or
-    # modification of values used in node creation. For example, one might
-    # want to disallow in-place operations from being recorded.
-    def create_node(self, graph : Graph, kind : str, target : Union[str, Callable],
-                    args : Tuple[Any], kwargs : Dict[str, Any], name : Optional[str] = None) -> Node:
-        return graph._create_node(kind, target, args, kwargs, name)
+    def create_arg(self, a):
+        # aggregates
+        if isinstance(a, (tuple, list)):
+            return type(a)(self.create_arg(elem) for elem in a)
+        elif isinstance(a, dict):
+            r = {}
+            for k, v in a.items():
+                if not isinstance(k, str):
+                    raise NotImplementedError(f"dictionaries with non-string keys: {a}")
+                r[k] = self.create_arg(v)
+            return r
+        elif isinstance(a, slice):
+            return slice(self.create_arg(a.start), self.create_arg(a.stop), self.create_arg(a.step))
+
+        if isinstance(a, torch.nn.Parameter):
+            for n, p in self.root.named_parameters():
+                if a is p:
+                    return self.graph.get_param(n)
+            raise NameError('parameter is not a member of this module')
+        elif isinstance(a, Proxy):
+            # base case: we unwrap the Proxy object
+            return a.node
+        elif isinstance(a, (str, int, float, bool, torch.dtype, torch.Tensor)) or a is None:
+            return a
+
+        raise NotImplementedError(f"argument of type: {type(a)}")
+
+
+class DefaultDelegate(DelegateBase):
+    def __init__(self, root: torch.nn.Module, graph: Graph):
+        super().__init__(graph)
+        self.root = root
+
+    def create_arg(self, a):        
+        if isinstance(a, torch.nn.Parameter):
+            for n, p in self.root.named_parameters():
+                if a is p:
+                    return self.graph.get_param(n)
+            raise NameError('parameter is not a member of this module')
+        return super().create_arg(a)
+
+
+
+def _proxy_placeholder(name, delegate):
+    return Proxy(delegate.graph.placeholder(name), delegate)
 
 # Symbolic tracing API
 #
@@ -69,15 +119,10 @@ class DefaultDelegate:
 # Args:
 #   - root - the `nn.Module` instance to trace
 #   - delegate : An instance of a Delegate object
-def symbolic_trace(root : torch.nn.Module, delegate : Optional[DefaultDelegate] = DefaultDelegate()):
-    def _use_parameter(graph, a):
-        if isinstance(a, torch.nn.Parameter):
-            for n, p in root.named_parameters():
-                if a is p:
-                    return graph.get_param(n)
-            raise NameError('parameter is not a member of this module')
-        return NotImplemented
-    graph = Graph(arg_handler=_use_parameter, delegate=delegate)
+def symbolic_trace(root : torch.nn.Module, delegate_class=DefaultDelegate):
+    graph = Graph()
+    graph.delegate = delegate = delegate_class(root, graph)
+
     fn = type(root).forward
 
     co = fn.__code__
@@ -85,13 +130,13 @@ def symbolic_trace(root : torch.nn.Module, delegate : Optional[DefaultDelegate] 
     names_iter = iter(co.co_varnames)
     next(names_iter)  # skip self
     args = [root]
-    args.extend(graph.placeholder(next(names_iter)) for name in range(1, total_args))
+    args.extend(_proxy_placeholder(next(names_iter), delegate) for name in range(1, total_args))
 
     if co.co_kwonlyargcount > 0 or co.co_flags & HAS_VARSTUFF:
         if co.co_flags & inspect.CO_VARARGS:
-            args.append(graph.placeholder('*' + next(names_iter)))
+            args.append(_proxy_placeholder('*' + next(names_iter), delegate))
         if co.co_flags & inspect.CO_VARKEYWORDS:
-            args.append(graph.placeholder('**' + next(names_iter)))
+            args.append(_proxy_placeholder('**' + next(names_iter), delegate))
         fn = _patch_function(fn, len(args))
 
     args = tuple(args)
@@ -102,10 +147,10 @@ def symbolic_trace(root : torch.nn.Module, delegate : Optional[DefaultDelegate] 
             return orig_call(mod, *args, **kwargs)
         else:
             target = _find_module(root, mod)
-            return graph.call_module(target, args, kwargs)
+            return _create_proxy(delegate, 'call_module', target, args, kwargs)
     try:
         torch.nn.Module.__call__ = module_call_wrapper
-        graph.output(fn(*args))
+        graph.output(delegate.create_arg(fn(*args)))
     finally:
         torch.nn.Module.__call__ = orig_call
     return GraphModule(root, graph)

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -120,7 +120,7 @@ def _proxy_placeholder(name, delegate):
 #   - delegate : An instance of a Delegate object
 def symbolic_trace(root : torch.nn.Module, delegate_class=DefaultDelegate):
     graph = Graph()
-    graph.delegate = delegate = delegate_class(root, graph)
+    delegate = delegate_class(root, graph)
 
     fn = type(root).forward
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43083 [fx] add type annotations
* #43082 [fx] enabling typechecking of fx files
* **#42991 [fx] split Node into Node/Proxy**

Have Node both be a record of the operator in the graph, and the
way we _build_ the graph made it difficult to keep the IR datastructure
separate from the proxying logic in the build.

Among other issues this means that typos when using nodes would add
things to the graph:
```
    for node in graph.nodes:
        node.grph # does not error, returns an node.Attribute object!
```

This separates the builder into a Proxy object. Graph/Node no longer
need to understand `delegate` objects since they are now just pure IR.
This separates the `symbolic_trace` (proxy.py/symbolic_trace.py) from
the IR (node.py, graph.py).

This also allows us to add `create_arg` to the delegate object,
allowing the customization of how aggregate arguments are handled
when converting to a graph.

Differential Revision: [D23099786](https://our.internmc.facebook.com/intern/diff/D23099786)