### PR TITLE
Don't require setting GLOO_SOCKET_IFNAME for TensorPipe

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -275,11 +275,11 @@ endif()
 
 if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
   if(USE_DISTRIBUTED)
-    add_library(process_group_agent "${TORCH_SRC_DIR}/csrc/distributed/rpc/process_group_agent.cpp" "${TORCH_SRC_DIR}/csrc/distributed/rpc/process_group_agent.h")
+    add_library(process_group_agent STATIC "${TORCH_SRC_DIR}/csrc/distributed/rpc/process_group_agent.cpp" "${TORCH_SRC_DIR}/csrc/distributed/rpc/process_group_agent.h")
     target_link_libraries(process_group_agent PRIVATE torch c10d fmt::fmt-header-only)
     add_dependencies(process_group_agent torch c10d)
 
-    add_library(tensorpipe_agent "${TORCH_SRC_DIR}/csrc/distributed/rpc/tensorpipe_agent.cpp" "${TORCH_SRC_DIR}/csrc/distributed/rpc/tensorpipe_agent.h")
+    add_library(tensorpipe_agent STATIC "${TORCH_SRC_DIR}/csrc/distributed/rpc/tensorpipe_agent.cpp" "${TORCH_SRC_DIR}/csrc/distributed/rpc/tensorpipe_agent.h")
     target_link_libraries(tensorpipe_agent PRIVATE torch c10d tensorpipe fmt::fmt-header-only)
     add_dependencies(tensorpipe_agent torch c10d tensorpipe)
   endif()

--- a/test/cpp/rpc/test_e2e_tensorpipe.cpp
+++ b/test/cpp/rpc/test_e2e_tensorpipe.cpp
@@ -2,7 +2,6 @@
 
 #include "e2e_test_base.h"
 
-#include <c10d/ProcessGroupGloo.hpp>
 #include <torch/csrc/distributed/rpc/request_callback_no_python.h>
 #include <torch/csrc/distributed/rpc/tensorpipe_agent.h>
 #include <torch/torch.h>
@@ -16,9 +15,6 @@ using namespace torch::distributed::autograd;
 class TestE2ETensorPipe : public TestE2EBase {
  protected:
   void buildRpcAgent() override {
-    c10d::ProcessGroupGloo::Options options;
-    options.devices.push_back(
-        ::c10d::ProcessGroupGloo::createDeviceForHostname(serverAddress));
     float rpcTimeout = 30;
 
     TensorPipeRpcBackendOptions opts(

--- a/test/cpp/rpc/test_e2e_tensorpipe.cpp
+++ b/test/cpp/rpc/test_e2e_tensorpipe.cpp
@@ -21,10 +21,6 @@ class TestE2ETensorPipe : public TestE2EBase {
         ::c10d::ProcessGroupGloo::createDeviceForHostname(serverAddress));
     float rpcTimeout = 30;
 
-    // Initialize server rpc agent.
-    auto pg =
-        std::make_shared<c10d::ProcessGroupGloo>(store, 0, numWorkers, options);
-
     TensorPipeRpcBackendOptions opts(
         /*numWorkerThreads=*/std::max(16U, std::thread::hardware_concurrency()),
         /*transports=*/nullopt,
@@ -37,7 +33,6 @@ class TestE2ETensorPipe : public TestE2EBase {
         "worker",
         0,
         numWorkers,
-        pg,
         opts,
         std::make_unique<RequestCallbackNoPython>());
   }

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -511,14 +511,12 @@ PyObject* rpc_init(PyObject* /* unused */) {
                       std::string selfName,
                       worker_id_t selfId,
                       int worldSize,
-                      std::shared_ptr<::c10d::ProcessGroup> processGroup,
                       TensorPipeRpcBackendOptions opts) {
             return std::make_shared<TensorPipeAgent>(
                 store,
                 std::move(selfName),
                 selfId,
                 worldSize,
-                std::move(processGroup),
                 std::move(opts),
                 std::make_unique<RequestCallbackImpl>());
           }),
@@ -526,7 +524,6 @@ PyObject* rpc_init(PyObject* /* unused */) {
           py::arg("name"),
           py::arg("rank"),
           py::arg("world_size"),
-          py::arg("process_group"),
           py::arg("rpc_backend_options"))
       .def(
           "join",

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -122,7 +122,6 @@ class TensorPipeAgent : public RpcAgent {
       std::string selfName,
       worker_id_t selfId,
       int worldSize,
-      std::shared_ptr<c10d::ProcessGroup> processGroup,
       TensorPipeRpcBackendOptions opts,
       std::unique_ptr<RequestCallback> cb);
 
@@ -249,7 +248,7 @@ class TensorPipeAgent : public RpcAgent {
   // The join method is required to behave like a barrier and perform collective
   // operations. For simplicity and reliability, we offload this to a process
   // group, but probably one day we might want to re-implement them using RPCs.
-  const std::shared_ptr<c10d::ProcessGroup> processGroup_;
+  std::shared_ptr<c10d::ProcessGroup> processGroup_;
 
   mutable std::mutex mutex_;
   uint64_t nextMessageID_{0};

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -187,15 +187,9 @@ def _tensorpipe_init_backend_handler(store, name, rank, world_size, rpc_backend_
             )
         )
 
-    # The agent's join method is required to behave like a barrier and perform
-    # collective operations, for which it relies on a process group, instead of
-    # re-implementing this on top of RPCs.
-
-    group = _init_process_group(store, rank, world_size)
-
     # TODO: add try-except and destroy _agent in all processes if any fails.
     return TensorPipeAgent(
-        store, name, rank, world_size, group, rpc_backend_options
+        store, name, rank, world_size, rpc_backend_options
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43007 Don't require setting GLOO_SOCKET_IFNAME for TensorPipe**

The TensorPipe agent currently uses Gloo internally to help during the join step, before shutdown, as that requires a collective operation. This Gloo context will open its own TCP connections, not honoring the TP_SOCKET_IFNAME env var, and requiring its own GLOO_SOCKET_IFNAME to be set instead. We're fixing it here by propagating the right options.

Differential Revision: [D23103898](https://our.internmc.facebook.com/intern/diff/D23103898/)