### PR TITLE
[reland][quant][fix] Remove activation_post_process in qat modules (#42343)

### DIFF
--- a/test/quantization/test_quantize.py
+++ b/test/quantization/test_quantize.py
@@ -998,14 +998,16 @@ class TestQuantizationAwareTraining(QuantizationTestCase):
         model = prepare_qat(model)
 
         def checkHooksIsPresent(model, before_convert=True):
+            forward_hooks = 1
             if before_convert:
                 self.assertEqual(len(model.quant._forward_hooks.values()), 1,
                                  "Quantization observer hook has disappeared")
+                forward_hooks = 2
             self.assertObjectIn(fw_pre_hook, model.fc._forward_pre_hooks.values())
             self.assertObjectIn(fw_hook, model.fc._forward_hooks.values())
             self.assertEqual(len(model.fc._forward_pre_hooks.values()), 1,
                              "Extra pre forward hooks have appeared on a layer")
-            self.assertEqual(len(model.fc._forward_hooks.values()), 1,
+            self.assertEqual(len(model.fc._forward_hooks.values()), forward_hooks,
                              "Extra post forward hooks have appeared on a layer")
 
         checkHooksIsPresent(model, True)

--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -35,7 +35,6 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
         self.qconfig = qconfig
         self.freeze_bn = freeze_bn if self.training else True
         self.bn = nn.BatchNorm2d(out_channels, eps, momentum, True, True)
-        self.activation_post_process = self.qconfig.activation()
         self.weight_fake_quant = self.qconfig.weight()
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -96,7 +95,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
         return super(_ConvBnNd, self).extra_repr()
 
     def forward(self, input):
-        return self.activation_post_process(self._forward(input))
+        return self._forward(input)
 
     def train(self, mode=True):
         """
@@ -186,7 +185,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
 class ConvBn2d(_ConvBnNd, nn.Conv2d):
     r"""
     A ConvBn2d module is a module fused from Conv2d and BatchNorm2d,
-    attached with FakeQuantize modules for both output activation and weight,
+    attached with FakeQuantize modules for weight,
     used in quantization aware training.
 
     We combined the interface of :class:`torch.nn.Conv2d` and
@@ -199,7 +198,6 @@ class ConvBn2d(_ConvBnNd, nn.Conv2d):
 
     Attributes:
         freeze_bn:
-        activation_post_process: fake quant module for output activation
         weight_fake_quant: fake quant module for weight
 
     """
@@ -230,7 +228,7 @@ class ConvBn2d(_ConvBnNd, nn.Conv2d):
 class ConvBnReLU2d(ConvBn2d):
     r"""
     A ConvBnReLU2d module is a module fused from Conv2d, BatchNorm2d and ReLU,
-    attached with FakeQuantize modules for both output activation and weight,
+    attached with FakeQuantize modules for weight,
     used in quantization aware training.
 
     We combined the interface of :class:`torch.nn.Conv2d` and
@@ -242,8 +240,6 @@ class ConvBnReLU2d(ConvBn2d):
     default.
 
     Attributes:
-        observer: fake quant module for output activation, it's called observer
-            to align with post training flow
         weight_fake_quant: fake quant module for weight
 
     """
@@ -270,7 +266,7 @@ class ConvBnReLU2d(ConvBn2d):
                                            qconfig)
 
     def forward(self, input):
-        return self.activation_post_process(F.relu(ConvBn2d._forward(self, input)))
+        return F.relu(ConvBn2d._forward(self, input))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):
@@ -279,14 +275,13 @@ class ConvBnReLU2d(ConvBn2d):
 class ConvReLU2d(nnqat.Conv2d):
     r"""
     A ConvReLU2d module is a fused module of Conv2d and ReLU, attached with
-    FakeQuantize modules for both output activation and weight for
+    FakeQuantize modules for weight for
     quantization aware training.
 
     We combined the interface of :class:`~torch.nn.Conv2d` and
     :class:`~torch.nn.BatchNorm2d`.
 
     Attributes:
-        activation_post_process: fake quant module for output activation
         weight_fake_quant: fake quant module for weight
 
     """
@@ -302,12 +297,11 @@ class ConvReLU2d(nnqat.Conv2d):
                                          qconfig=qconfig)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
-        self.activation_post_process = self.qconfig.activation()
         self.weight_fake_quant = self.qconfig.weight()
 
     def forward(self, input):
-        return self.activation_post_process(F.relu(
-            self._conv_forward(input, self.weight_fake_quant(self.weight))))
+        return F.relu(
+            self._conv_forward(input, self.weight_fake_quant(self.weight)))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):

--- a/torch/nn/intrinsic/qat/modules/linear_relu.py
+++ b/torch/nn/intrinsic/qat/modules/linear_relu.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 class LinearReLU(nnqat.Linear):
     r"""
     A LinearReLU module fused from Linear and ReLU modules, attached with
-    FakeQuantize modules for output activation and weight, used in
+    FakeQuantize modules for weight, used in
     quantization aware training.
 
     We adopt the same interface as :class:`torch.nn.Linear`.
@@ -15,7 +15,6 @@ class LinearReLU(nnqat.Linear):
     default.
 
     Attributes:
-        activation_post_process: fake quant module for output activation
         weight: fake quant module for weight
 
     Examples::
@@ -33,8 +32,7 @@ class LinearReLU(nnqat.Linear):
         super(LinearReLU, self).__init__(in_features, out_features, bias, qconfig)
 
     def forward(self, input):
-        return self.activation_post_process(F.relu(
-            F.linear(input, self.weight_fake_quant(self.weight), self.bias)))
+        return F.relu(F.linear(input, self.weight_fake_quant(self.weight), self.bias))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):

--- a/torch/nn/qat/modules/conv.py
+++ b/torch/nn/qat/modules/conv.py
@@ -4,8 +4,8 @@ from torch.nn.intrinsic import ConvReLU2d
 
 class Conv2d(nn.Conv2d):
     r"""
-    A Conv2d module attached with FakeQuantize modules for both output
-    activation and weight, used for quantization aware training.
+    A Conv2d module attached with FakeQuantize modules for weight,
+    used for quantization aware training.
 
     We adopt the same interface as `torch.nn.Conv2d`, please see
     https://pytorch.org/docs/stable/nn.html?highlight=conv2d#torch.nn.Conv2d
@@ -15,7 +15,6 @@ class Conv2d(nn.Conv2d):
     default.
 
     Attributes:
-        activation_post_process: fake quant module for output activation
         weight_fake_quant: fake quant module for weight
     """
     _FLOAT_MODULE = nn.Conv2d
@@ -28,12 +27,10 @@ class Conv2d(nn.Conv2d):
                                      groups=groups, bias=bias, padding_mode=padding_mode)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
-        self.activation_post_process = qconfig.activation()
         self.weight_fake_quant = qconfig.weight()
 
     def forward(self, input):
-        return self.activation_post_process(
-            self._conv_forward(input, self.weight_fake_quant(self.weight)))
+        return self._conv_forward(input, self.weight_fake_quant(self.weight))
 
     @classmethod
     def from_float(cls, mod, qconfig=None):

--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -5,8 +5,8 @@ from torch.nn.intrinsic import LinearReLU
 
 class Linear(nn.Linear):
     r"""
-    A linear module attached with FakeQuantize modules for both output
-    activation and weight, used for quantization aware training.
+    A linear module attached with FakeQuantize modules for weight,
+    used for quantization aware training.
 
     We adopt the same interface as `torch.nn.Linear`, please see
     https://pytorch.org/docs/stable/nn.html#torch.nn.Linear
@@ -16,7 +16,6 @@ class Linear(nn.Linear):
     default.
 
     Attributes:
-        activation_post_process: fake quant module for output activation
         weight: fake quant module for weight
     """
     _FLOAT_MODULE = nn.Linear
@@ -26,12 +25,10 @@ class Linear(nn.Linear):
         super(Linear, self).__init__(in_features, out_features, bias)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
-        self.activation_post_process = qconfig.activation()
         self.weight_fake_quant = qconfig.weight()
 
     def forward(self, input):
-        return self.activation_post_process(
-            F.linear(input, self.weight_fake_quant(self.weight), self.bias))
+        return F.linear(input, self.weight_fake_quant(self.weight), self.bias)
 
     @classmethod
     def from_float(cls, mod, qconfig=None):

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.intrinsic as nni
 import torch.nn.quantized as nnq
+import torch.nn.intrinsic.qat as nniqat
 
 from .default_mappings import (DEFAULT_DYNAMIC_MODULE_MAPPING,
                                DEFAULT_MODULE_MAPPING,
@@ -335,8 +336,18 @@ def prepare_qat(model, mapping=None, inplace=False):
     """
     if mapping is None:
         mapping = DEFAULT_QAT_MODULE_MAPPING
-    model = prepare(model, inplace=inplace)
+    if not inplace:
+        model = copy.deepcopy(model)
+
+    propagate_qconfig_(model, qconfig_dict=None)
+    devices = get_unique_devices_(model)
+    print('devices after propagate qconfig:', devices)
     _convert(model, mapping, inplace=True)
+    devices = get_unique_devices_(model)
+    print('devices after convert:', devices)
+    prepare(model, observer_non_leaf_module_list=set(mapping.values()), inplace=True)
+    devices = get_unique_devices_(model)
+    print('devices after prepare:', devices)
     return model
 
 def quantize_qat(model, run_fn, run_args, inplace=False):
@@ -361,18 +372,18 @@ def quantize_qat(model, run_fn, run_args, inplace=False):
     return model
 
 def convert(module, mapping=None, inplace=False, remove_qconfig=True):
-    r"""Converts the float module with observers (where we can get quantization
-    parameters) to a quantized module. And remove qconfig at the end if remove_qconfig
-    is set to True.
+    r"""Converts submodules in input module to a different module according to `mapping`
+    by calling `from_float` method on the target module class. And remove qconfig at the
+    end if remove_qconfig is set to True.
 
     Args:
-        module: calibrated module with observers
-        mapping: a dictionary that maps from float module type to quantized
+        module: input module
+        mapping: a dictionary that maps from source module type to target
                  module type, can be overwritten to allow swapping user defined
                  Modules
         inplace: carry out model transformations in-place, the original module
                  is mutated
-        remove_qconfig: whether to remove qconfig after convert
+
     """
     if not inplace:
         module = copy.deepcopy(module)
@@ -382,12 +393,12 @@ def convert(module, mapping=None, inplace=False, remove_qconfig=True):
     return module
 
 def _convert(module, mapping=None, inplace=False):
-    r"""Converts the float module with observers (where we can get quantization
-    parameters) to a quantized module.
+    r"""Converts submodules in input module to a different module according to `mapping`
+    by calling `from_float` method on the target module class
 
     Args:
-        module: calibrated module with observers
-        mapping: a dictionary that maps from float module type to quantized
+        module: input module
+        mapping: a dictionary that maps from source module type to target
                  module type, can be overwritten to allow swapping user defined
                  Modules
         inplace: carry out model transformations in-place, the original module
@@ -411,7 +422,9 @@ def _convert(module, mapping=None, inplace=False):
                          nni.ConvReLU1d,
                          nni.ConvBnReLU1d,
                          nni.ConvReLU2d,
-                         nni.ConvReLU3d)
+                         nni.ConvReLU3d,
+                         nniqat.ConvBn2d,
+                         nniqat.ConvBnReLU2d)
 
     for name, mod in module.named_children():
         if type(mod) not in SWAPPABLE_MODULES:

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -110,16 +110,19 @@ def add_observer_(module, qconfig_propagation_list=None, non_leaf_module_list=No
         )
         device = next(iter(devices)) if len(devices) > 0 else None
 
+    def get_activation_post_process(qconfig, device):
+        activation = qconfig.activation()
+        if device is not None:
+            activation.to(device)
+        return activation
+
     for child in module.children():
         if type(child) == nnq.FloatFunctional or type(child) == nnq.QFunctional:
             if hasattr(child, 'qconfig') and child.qconfig is not None:
-                activation = child.qconfig.activation()
-                if device is not None:
-                    activation.to(device)
-                child.activation_post_process = activation
+                child.activation_post_process = get_activation_post_process(child.qconfig, device)
         elif non_leaf_module_list is not None and type(child) in non_leaf_module_list:
             if hasattr(child, 'qconfig') and child.qconfig is not None:
-                child.add_module('activation_post_process', child.qconfig.activation())
+                child.add_module('activation_post_process', get_activation_post_process(child.qconfig, device))
                 register_activation_post_process_hook(child)
 
                 # Attaching prehook
@@ -135,10 +138,7 @@ def add_observer_(module, qconfig_propagation_list=None, non_leaf_module_list=No
        len(module._modules) == 0 and not isinstance(module, torch.nn.Sequential) \
        and type(module) in qconfig_propagation_list:
         # observer and hook will be gone after we swap the module
-        activation = module.qconfig.activation()
-        if device is not None:
-            activation.to(device)
-        module.add_module('activation_post_process', activation)
+        module.add_module('activation_post_process', get_activation_post_process(module.qconfig, device))
         # Register observer as the first entry in the hook list
         # All post forward hooks are preserved and will be executed after the observer before convert
         handle = register_activation_post_process_hook(module)
@@ -342,7 +342,7 @@ def prepare_qat(model, mapping=None, inplace=False):
     propagate_qconfig_(model, qconfig_dict=None)
     devices = get_unique_devices_(model)
     print('devices after propagate qconfig:', devices)
-    _convert(model, mapping, inplace=True)
+    convert(model, mapping=mapping, inplace=True, remove_qconfig=False)
     devices = get_unique_devices_(model)
     print('devices after convert:', devices)
     prepare(model, observer_non_leaf_module_list=set(mapping.values()), inplace=True)

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -340,14 +340,8 @@ def prepare_qat(model, mapping=None, inplace=False):
         model = copy.deepcopy(model)
 
     propagate_qconfig_(model, qconfig_dict=None)
-    devices = get_unique_devices_(model)
-    print('devices after propagate qconfig:', devices)
     convert(model, mapping=mapping, inplace=True, remove_qconfig=False)
-    devices = get_unique_devices_(model)
-    print('devices after convert:', devices)
     prepare(model, observer_non_leaf_module_list=set(mapping.values()), inplace=True)
-    devices = get_unique_devices_(model)
-    print('devices after prepare:', devices)
     return model
 
 def quantize_qat(model, run_fn, run_args, inplace=False):

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -21,7 +21,9 @@ from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, \
 from torch.quantization.default_mappings import (
     DEFAULT_DYNAMIC_MODULE_MAPPING,
     DEFAULT_QCONFIG_PROPAGATE_WHITE_LIST,
+    DEFAULT_QAT_MODULE_MAPPING,
 )
+
 import unittest
 from torch.testing import FileCheck
 
@@ -196,8 +198,11 @@ class QuantizationTestCase(TestCase):
            and type(module) in propagate_qconfig_list:
             self.assertTrue(hasattr(module, 'activation_post_process'),
                             'module: ' + str(type(module)) + ' do not have observer')
-        for child in module.children():
-            self.checkObservers(child)
+        # we don't need to check observers for child modules of the
+        # qat modules
+        if type(module) not in DEFAULT_QAT_MODULE_MAPPING.values():
+            for child in module.children():
+                self.checkObservers(child)
 
     def checkQuantDequant(self, mod):
         r"""Checks that mod has nn.Quantize and


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43015 [reland][quant][fix] Remove activation_post_process in qat modules (#42343)**

Summary:

Currently activation_post_process are inserted by default in qat modules, which is not
friendly to automatic quantization tools, this PR removes them.

Test Plan: Imported from OSS

Reviewed By: raghuramank100

Differential Revision: [D23105059](https://our.internmc.facebook.com/intern/diff/D23105059)