### PR TITLE
Update ort-nightly version to dev202008122

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -188,7 +188,7 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
     # default pip version is too old(9.0.2), unable to support tag `manylinux2010`.
     # Fix the pip error: Couldn't find a version that satisfies the requirement
     sudo pip install --upgrade pip
-    pip install -q --user -i https://test.pypi.org/simple/ ort-nightly==1.4.0.dev202007311
+    pip install -q --user -i https://test.pypi.org/simple/ ort-nightly==1.4.0.dev202008122
   fi
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi


### PR DESCRIPTION
Fixes `caffe2_onnx_ort1_py3_6_clang7_ubuntu16_04` test failures
