### PR TITLE
[jit][static runtime] Simplify the graph and add operator whitelist

### DIFF
--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -17,6 +17,15 @@ class StaticRuntime:
     def __call__(self, *inps):
         return self.static_runtime.run(inps)
 
+def linear_shim(input, weight, bias=None):
+    # type: (Tensor, Tensor, Optional[Tensor]) -> Tensor
+    output = input.matmul(weight.t())
+    if bias is not None:
+        output += bias
+    ret = output
+    return ret
+torch.nn.functional.linear = linear_shim
+
 
 class MultiHeadAttentionLayer(nn.Module):
     def __init__(self, hid_dim, n_heads, dropout, device):

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1,7 +1,45 @@
 #include <torch/csrc/jit/runtime/static/impl.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <torch/csrc/jit/passes/canonicalize.h>
+#include <torch/csrc/jit/passes/remove_mutation.h>
+#include <torch/csrc/jit/passes/subgraph_rewrite.h>
 
 namespace torch {
 namespace jit {
+
+using c10::DispatchKey;
+using c10::RegisterOperators;
+
+static auto reg =
+    RegisterOperators()
+        .op("static::add(Tensor a, Tensor b) -> Tensor",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](at::Tensor a, at::Tensor b) -> at::Tensor { return a + b; }))
+        .op("static::mul.a(Tensor a, Tensor b) -> Tensor",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](at::Tensor a, at::Tensor b) -> at::Tensor { return a * b; }))
+        .op("static::mul.b(Tensor a, int b) -> Tensor",
+            RegisterOperators::options().kernel(
+                DispatchKey::CPU,
+                [](at::Tensor a, int64_t b) -> at::Tensor { return a * b; }));
+
+#define SUPPORTED_OPS(F) \
+  F(aten::__getitem__)   \
+  F(aten::add)           \
+  F(aten::contiguous)    \
+  F(aten::div)           \
+  F(aten::matmul)        \
+  F(aten::permute)       \
+  F(aten::relu)          \
+  F(aten::sigmoid)       \
+  F(aten::size)          \
+  F(aten::softmax)       \
+  F(aten::view)          \
+  F(prim::Constant)      \
+  F(prim::ListConstruct) \
+  F(prim::TupleConstruct)
 
 StaticRuntime::StaticRuntime(
     const torch::jit::Module& m,
@@ -9,11 +47,40 @@ StaticRuntime::StaticRuntime(
     : graph_(std::move(g)), module_(m.deepcopy()) {
   Inline(*graph_);
   ConstantPropagation(graph_);
+  Canonicalize(graph_);
+  ConstantPropagation(graph_);
+  RemoveTensorMutation(graph_);
+  ConstantPropagation(graph_);
+
   for (auto n : graph_->nodes()) {
     if (n->kind() == c10::Symbol::fromQualString("prim::GetAttr")) {
       throw std::runtime_error("Cannot accelerate unfrozen graphs");
     }
+    bool supported = false;
+#define X(_)                                          \
+  if (n->kind() == c10::Symbol::fromQualString(#_)) { \
+    supported = true;                                 \
   }
+    SUPPORTED_OPS(X)
+#undef X
+    if (!supported) {
+      throw std::runtime_error(
+          std::string("Unsupported operation: ") + n->kind().toQualString());
+    }
+  }
+
+  SubgraphRewriter sr;
+  sr.RegisterRewritePattern(
+      R"IR(
+  graph(%x, %w, %s):
+    %r = aten::add(%x, %w, %s)
+    return (%r))IR",
+      R"IR(
+  graph(%x, %w, %s):
+    %y = static::add(%x, %w)
+    %r = static::mul(%y, %s)
+    return (%r))IR");
+  sr.runOnGraph(graph_);
 }
 
 std::vector<at::Tensor> StaticRuntime::run(


### PR DESCRIPTION
This PR whitelists and simplifies graphs to help with development later on.  Key to note in this PR is the use of both a pattern substitution and the registration of custom operators.  This will likely be one of the main optimization types done in this folder.