### PR TITLE
Properly format db.h and db.cc

### DIFF
--- a/caffe2/core/db.cc
+++ b/caffe2/core/db.cc
@@ -22,7 +22,7 @@ C10_DEFINE_REGISTRY(Caffe2DBRegistry, DB, const string&, Mode);
 class MiniDBCursor : public Cursor {
  public:
   explicit MiniDBCursor(FILE* f, std::mutex* mutex)
-    : file_(f), lock_(*mutex), valid_(true) {
+      : file_(f), lock_(*mutex), valid_(true) {
     // We call Next() to read in the first entry.
     Next();
   }
@@ -77,7 +77,9 @@ class MiniDBCursor : public Cursor {
     return string(value_.data(), value_len_);
   }
 
-  bool Valid() override { return valid_; }
+  bool Valid() override {
+    return valid_;
+  }
 
  private:
   FILE* file_;
@@ -92,7 +94,7 @@ class MiniDBCursor : public Cursor {
 class MiniDBTransaction : public Transaction {
  public:
   explicit MiniDBTransaction(FILE* f, std::mutex* mutex)
-    : file_(f), lock_(*mutex) {}
+      : file_(f), lock_(*mutex) {}
   ~MiniDBTransaction() override {
     Commit();
   }
@@ -202,10 +204,9 @@ void DBReaderDeserializer::Deserialize(const BlobProto& proto, Blob* blob) {
 
 namespace {
 // Serialize TensorCPU.
-REGISTER_BLOB_SERIALIZER((TypeMeta::Id<DBReader>()),
-                         DBReaderSerializer);
+REGISTER_BLOB_SERIALIZER((TypeMeta::Id<DBReader>()), DBReaderSerializer);
 REGISTER_BLOB_DESERIALIZER(DBReader, DBReaderDeserializer);
-}  // namespace
+} // namespace
 
-}  // namespace db
-}  // namespace caffe2
+} // namespace db
+} // namespace caffe2

--- a/caffe2/core/db.h
+++ b/caffe2/core/db.h
@@ -21,15 +21,17 @@ enum Mode { READ, WRITE, NEW };
  */
 class CAFFE2_API Cursor {
  public:
-  Cursor() { }
-  virtual ~Cursor() { }
+  Cursor() {}
+  virtual ~Cursor() {}
   /**
    * Seek to a specific key (or if the key does not exist, seek to the
    * immediate next). This is optional for dbs, and in default, SupportsSeek()
    * returns false meaning that the db cursor does not support it.
    */
   virtual void Seek(const string& key) = 0;
-  virtual bool SupportsSeek() { return false; }
+  virtual bool SupportsSeek() {
+    return false;
+  }
   /**
    * Seek to the first key in the database.
    */
@@ -60,8 +62,8 @@ class CAFFE2_API Cursor {
  */
 class CAFFE2_API Transaction {
  public:
-  Transaction() { }
-  virtual ~Transaction() { }
+  Transaction() {}
+  virtual ~Transaction() {}
   /**
    * Puts the key value pair to the database.
    */
@@ -80,7 +82,7 @@ class CAFFE2_API Transaction {
 class CAFFE2_API DB {
  public:
   DB(const string& /*source*/, Mode mode) : mode_(mode) {}
-  virtual ~DB() { }
+  virtual ~DB() {}
   /**
    * Closes the database.
    */
@@ -114,8 +116,8 @@ C10_DECLARE_REGISTRY(Caffe2DBRegistry, DB, const string&, Mode);
  * supported, a nullptr is returned. The caller is responsible for examining the
  * validity of the pointer.
  */
-inline unique_ptr<DB> CreateDB(
-    const string& db_type, const string& source, Mode mode) {
+inline unique_ptr<DB>
+CreateDB(const string& db_type, const string& source, Mode mode) {
   auto result = Caffe2DBRegistry()->Create(db_type, source, mode);
   VLOG(1) << ((!result) ? "not found db " : "found db ") << db_type;
   return result;
@@ -143,7 +145,6 @@ inline bool DBExists(const string& db_type, const string& full_db_name) {
  */
 class CAFFE2_API DBReader {
  public:
-
   friend class DBReaderSerializer;
   DBReader() {}
 
@@ -158,7 +159,8 @@ class CAFFE2_API DBReader {
   explicit DBReader(const DBReaderProto& proto) {
     Open(proto.db_type(), proto.source());
     if (proto.has_key()) {
-      CAFFE_ENFORCE(cursor_->SupportsSeek(),
+      CAFFE_ENFORCE(
+          cursor_->SupportsSeek(),
           "Encountering a proto that needs seeking but the db type "
           "does not support it.");
       cursor_->Seek(proto.key());
@@ -312,7 +314,7 @@ class CAFFE2_API DBReaderDeserializer : public BlobDeserializerBase {
   void Deserialize(const BlobProto& proto, Blob* blob) override;
 };
 
-}  // namespace db
-}  // namespace caffe2
+} // namespace db
+} // namespace caffe2
 
-#endif  // CAFFE2_CORE_DB_H_
+#endif // CAFFE2_CORE_DB_H_


### PR DESCRIPTION
Summary:
Format db.h and db.cc using the default formatter.

This change was split off of D22705434.

Test Plan: Wait for sandcastle.

Reviewed By: marksantaniello

Differential Revision: D23113765

