### PR TITLE
[quant][doc] Print more info for fake quantize module

### DIFF
--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -111,9 +111,11 @@ class FakeQuantize(Module):
     @torch.jit.export
     def extra_repr(self):
         return 'fake_quant_enabled={}, observer_enabled={},\
-            scale={}, zero_point={}'.format(
+            quant_min={}, quant_max={}, dtype={}, qscheme={}, ch_axis={}, \
+        scale={}, zero_point={}'.format(
             self.fake_quant_enabled, self.observer_enabled,
-            self.scale, self.zero_point)
+            self.quant_min, self.quant_max,
+            self.dtype, self.qscheme, self.ch_axis, self.scale, self.zero_point)
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         # We cannot currently register scalar values as buffers, so need to manually


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43031 [quant][doc] Print more info for fake quantize module**

Summary:
fixes: https://github.com/pytorch/pytorch/issues/43023

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23116200](https://our.internmc.facebook.com/intern/diff/D23116200)