### PR TITLE
[JIT] Represent profiled types as a node attribute

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -266,6 +266,7 @@ namespace c10 {
   _(attr, perm)                      \
   _(attr, sizes)                     \
   _(attr, starts)                    \
+  _(attr, profiled_type)             \
   _(attr, transA)                    \
   _(attr, transB)                    \
   _(attr, name)                      \

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1692,9 +1692,9 @@ void testProfiler() {
   // Tensor = prim::profile[profiled_type=Float(4:512, 512:1, requires_grad=0,
   // device=cpu)]
   testing::FileCheck()
-      .check("Tensor = prim::profile[profiled_type")
+      .check("Tensor = prim::profile[profiled_tygpe")
       ->check_same("512")
-      ->run(pr->profiled_graph_);
+      ->run(*pr->profiled_graph_);
 
   auto begin = pr->profiled_graph_->block()->nodes().begin();
   auto end = pr->profiled_graph_->block()->nodes().end();

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1322,14 +1322,17 @@ graph(%a):
   }
 }
 
+static void checkShape(TypePtr typ, std::vector<int64_t> expected) {
+  auto ptp = typ->expect<TensorType>();
+  ASSERT_EQ(ptp->sizes().concrete_sizes().value(), expected);
+}
+
 static void checkShape(
     Node* n,
     std::vector<int64_t> expected,
     bool prev = true) {
   auto profile = (prev) ? n->inputs().at(0)->node() : n;
-  auto tp = profile->output()->type();
-  auto ptp = tp->expect<TensorType>();
-  ASSERT_EQ(ptp->sizes().concrete_sizes().value(), expected);
+  checkShape(profile->output()->type(), expected);
 }
 
 void count_(
@@ -1685,6 +1688,14 @@ void testProfiler() {
   InterpreterState is{cd};
   is.run(stack);
 
+  // profiled types are stored as attributes and show up in the dump, e.g.
+  // Tensor = prim::profile[profiled_type=Float(4:512, 512:1, requires_grad=0,
+  // device=cpu)]
+  testing::FileCheck()
+      .check("Tensor = prim::profile[profiled_type")
+      .check_same("512")
+      ->run(pr->profiled_graph_);
+
   auto begin = pr->profiled_graph_->block()->nodes().begin();
   auto end = pr->profiled_graph_->block()->nodes().end();
   auto mm =
@@ -1692,14 +1703,14 @@ void testProfiler() {
   ASSERT_NE(mm, end);
   std::vector<int64_t> mm_expected{4, 2048};
   std::vector<int64_t> eltwise{4, 512};
-  checkShape(*mm, mm_expected);
+  checkShape(mm->inputs().at(0)->node()->ty(attr::profiled_type), mm_expected);
   auto mul_n =
       std::find_if(begin, end, [](Node* n) { return n->kind() == aten::mul; });
   ASSERT_NE(mul_n, end);
-  checkShape(*mul_n, eltwise);
+  checkShape(mul_n->inputs().at(0)->node()->ty(attr::profiled_type), eltwise);
   auto tanh_n =
       std::find_if(begin, end, [](Node* n) { return n->kind() == aten::tanh; });
-  checkShape(*tanh_n, eltwise);
+  checkShape(tanh_n->inputs().at(0)->node()->ty(attr::profiled_type), eltwise);
 }
 
 void testCallStack() {

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1693,7 +1693,8 @@ void testProfiler() {
   // device=cpu)]
   testing::FileCheck()
       .check("Tensor = prim::profile[profiled_type")
-      ->check_same("512")->run(pr->profiled_graph_);
+      ->check_same("512")
+      ->run(pr->profiled_graph_);
 
   auto begin = pr->profiled_graph_->block()->nodes().begin();
   auto end = pr->profiled_graph_->block()->nodes().end();

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1692,7 +1692,7 @@ void testProfiler() {
   // Tensor = prim::profile[profiled_type=Float(4:512, 512:1, requires_grad=0,
   // device=cpu)]
   testing::FileCheck()
-      .check("Tensor = prim::profile[profiled_tygpe")
+      .check("Tensor = prim::profile[profiled_type")
       ->check_same("512")
       ->run(*pr->profiled_graph_);
 

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1689,11 +1689,11 @@ void testProfiler() {
   is.run(stack);
 
   // profiled types are stored as attributes and show up in the dump, e.g.
-  // Tensor = prim::profile[profiled_type=Float(4:512, 512:1, requires_grad=0,
-  // device=cpu)]
+  // Tensor = prim::profile[profiled_type=Double(4:256, 256:1, requires_grad=0,
+  // device=cpu)
   testing::FileCheck()
       .check("Tensor = prim::profile[profiled_type")
-      ->check_same("512")
+      ->check_same("256")
       ->run(*pr->profiled_graph_);
 
   auto begin = pr->profiled_graph_->block()->nodes().begin();

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1693,8 +1693,7 @@ void testProfiler() {
   // device=cpu)]
   testing::FileCheck()
       .check("Tensor = prim::profile[profiled_type")
-      .check_same("512")
-      ->run(pr->profiled_graph_);
+      ->check_same("512")->run(pr->profiled_graph_);
 
   auto begin = pr->profiled_graph_->block()->nodes().begin();
   auto end = pr->profiled_graph_->block()->nodes().end();

--- a/torch/csrc/jit/passes/insert_guards.cpp
+++ b/torch/csrc/jit/passes/insert_guards.cpp
@@ -30,7 +30,7 @@ struct GuardInserter {
     for (auto it = b->nodes().begin(); it != b->nodes().end(); it++) {
       auto n = *it;
       if (n->kind() == prim::profile && n->outputs().size() == 1) {
-        auto pttp = n->output()->type()->cast<TensorType>();
+        auto pttp = n->ty(attr::profiled_type)->cast<TensorType>();
         if (pttp) {
           auto guard = graph_->create(prim::Guard, {n->input()}, 1);
           auto go = guard->output();

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -106,6 +106,7 @@ c10::SymbolicShape ProfilingRecord::mergeSymbolicShapes(
 void ProfilingRecord::insertShapeProfile(Node* n, Value* i) {
   auto pn = createProfileNode(nullptr, {i});
   auto pno = pn->addOutput();
+  pn->ty_(attr::profiled_type, TensorType::get());
   pno->setType(TensorType::get());
   std::function<void(Stack&)> shape_profiler = [this, pno](Stack& stack) {
     int64_t frame_id = 0;
@@ -286,7 +287,6 @@ std::unique_ptr<ProfilingRecord> ProfilingRecord::instrumentGraph(
             } else {
               // reset symbolic shapes when ranks are different
               type = type->merge(val_type_pair.second);
-              // type = type->withSymbolicShapes(c10::nullopt);
               merged_profiled_types[val_type_pair.first] = type;
             }
           }
@@ -295,7 +295,8 @@ std::unique_ptr<ProfilingRecord> ProfilingRecord::instrumentGraph(
 
       // update types in the graph
       for (auto val_type_pair : merged_profiled_types) {
-        val_type_pair.first->setType(val_type_pair.second);
+        val_type_pair.first->node()->ty_(
+            attr::profiled_type, val_type_pair.second);
       }
     }
   };


### PR DESCRIPTION
This changes profiled types from being represented as:
`%23 : Float(4:256, 256:1, requires_grad=0, device=cpu) = prim::profile(%0)`
->
`%23 : Tensor = prim::profile[profiled_type=Float(4:256, 256:1, requires_grad=0, device=cpu)](%0)`

Previously, by representing the profiled type in the IR directly it was very easy for optimizations to accidentally use profiled types without inserting the proper guards that would ensure that the specialized type would be seen. 

It would be a nice follow up to extend this to prim::Guard as well, however we have short term plans to get rid of prim::Guard.