### PR TITLE
Build test_e2e_tensorpipe only if Gloo is enabled

### DIFF
--- a/test/cpp/rpc/CMakeLists.txt
+++ b/test/cpp/rpc/CMakeLists.txt
@@ -3,8 +3,6 @@ set(TORCH_RPC_TEST_SOURCES
   ${TORCH_ROOT}/test/cpp/common/main.cpp
   ${TORCH_RPC_TEST_DIR}/e2e_test_base.cpp
   ${TORCH_RPC_TEST_DIR}/test_wire_serialization.cpp
-  ${TORCH_RPC_TEST_DIR}/test_e2e_process_group.cpp
-  ${TORCH_RPC_TEST_DIR}/test_e2e_tensorpipe.cpp
 )
 set(TORCH_RPC_TEST_DEPENDENCY_LIBS
   torch c10d gtest process_group_agent tensorpipe_agent
@@ -13,6 +11,7 @@ set(TORCH_RPC_TEST_DEPENDENCY_LIBS
 if(USE_GLOO)
   list(APPEND TORCH_RPC_TEST_SOURCES
     ${TORCH_RPC_TEST_DIR}/test_e2e_process_group.cpp
+    ${TORCH_RPC_TEST_DIR}/test_e2e_tensorpipe.cpp
   )
 endif()
 


### PR DESCRIPTION
test_e2e_tensorpipe depends on ProcessGroupGloo, therefore it could not be tested with Gloo disabled
Otherwise, it re-introduces  https://github.com/pytorch/pytorch/issues/42776
