### PR TITLE
Fix typo in collect_env.py

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -220,7 +220,7 @@ def get_os(run_lambda):
         # Try reading /etc/*-release
         desc = check_release_file(run_lambda)
         if desc is not None:
-            return '{} ({})'.forat(desc, machine())
+            return '{} ({})'.format(desc, machine())
 
         return '{} ({})'.format(platform, machine())
 


### PR DESCRIPTION
Minor typo fix introduced in yesterdays PR: https://github.com/pytorch/pytorch/pull/42961
