### PR TITLE
Issue 43057

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -157,15 +157,20 @@ def register_module_backward_hook(
     _global_backward_hooks[handle.id] = hook
     return handle
 
+
+# Trick mypy into not applying contravariance rules to inputs by defining
+# forward as a value, rather than a function.  See also
+# https://github.com/python/mypy/issues/8795
 def _forward_unimplemented(self, *input: Any) -> None:
-    r"""Forward defines the computation performed at every call.
+    r"""Defines the computation performed at every call.
 
-        Should be overridden by all subclasses.
+    Should be overridden by all subclasses.
 
-        .. note:
-            Trick mypy into not applying contravariance rules to inputs
-            by defining forward as a value, rather than a function.  See also
-            https://github.com/python/mypy/issues/8795
+    .. note::
+        Although the recipe for forward pass needs to be defined within
+        this function, one should call the :class:`Module` instance afterwards
+        instead of this since the former takes care of running the
+        registered hooks while the latter silently ignores them.
     """
     raise NotImplementedError
 
@@ -232,16 +237,6 @@ class Module:
         self._load_state_dict_pre_hooks = OrderedDict()
         self._modules = OrderedDict()
 
-    r"""Defines the computation performed at every call.
-
-    Should be overridden by all subclasses.
-
-    .. note::
-        Although the recipe for forward pass needs to be defined within
-        this function, one should call the :class:`Module` instance afterwards
-        instead of this since the former takes care of running the
-        registered hooks while the latter silently ignores them.
-    """
     forward: Callable[..., Any] = _forward_unimplemented
 
     def register_buffer(self, name: str, tensor: Optional[Tensor], persistent: bool = True) -> None:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -158,7 +158,7 @@ def register_module_backward_hook(
     return handle
 
 def _forward_unimplemented(self, *input: Any) -> None:
-    r"""Defines the computation performed at every call.
+    r"""Forward defines the computation performed at every call.
 
         Should be overridden by all subclasses.
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -157,11 +157,16 @@ def register_module_backward_hook(
     _global_backward_hooks[handle.id] = hook
     return handle
 
-
-# Trick mypy into not applying contravariance rules to inputs by defining
-# forward as a value, rather than a function.  See also
-# https://github.com/python/mypy/issues/8795
 def _forward_unimplemented(self, *input: Any) -> None:
+    r"""Defines the computation performed at every call.
+
+        Should be overridden by all subclasses.
+
+        .. note:
+            Trick mypy into not applying contravariance rules to inputs
+            by defining forward as a value, rather than a function.  See also
+            https://github.com/python/mypy/issues/8795
+    """
     raise NotImplementedError
 
 


### PR DESCRIPTION
A small change that adds a docstring that can be found with 
`getattr(nn.Module, nn.Module.forward.__name__, None).__doc__`

Fixes #43057
