### PR TITLE
Move Autograd to an alias dispatch key

### DIFF
--- a/aten/src/ATen/core/LegacyTypeDispatch.h
+++ b/aten/src/ATen/core/LegacyTypeDispatch.h
@@ -47,7 +47,7 @@ struct CAFFE2_API AutoNonVariableTypeMode {
   // NB: The enabled parameter must ALWAYS be black, as Henry Ford used to say.
   // TODO: Eliminate this parameter entirely
   AutoNonVariableTypeMode(bool enabled = true) :
-    autograd_guard_(c10::AutogradDispatchKeys()) {
+    autograd_guard_(getRuntimeDispatchKeySet(DispatchKey::Autograd)) {
 
     TORCH_INTERNAL_ASSERT(enabled);
   }

--- a/aten/src/ATen/core/VariableFallbackKernel.cpp
+++ b/aten/src/ATen/core/VariableFallbackKernel.cpp
@@ -28,6 +28,7 @@ using c10::KernelFunction;
 
 namespace {
 
+// Register fallthrough for Autograd backends dispatch keys
 TORCH_LIBRARY_IMPL(_, Autograd, m) {
   m.fallback(torch::CppFunction::makeFallthrough());
 }

--- a/aten/src/ATen/core/boxing/impl/test_helpers.h
+++ b/aten/src/ATen/core/boxing/impl/test_helpers.h
@@ -13,7 +13,7 @@ inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
   return {std::forward<Inputs>(inputs)...};
 }
 
-inline at::Tensor dummyTensor(c10::DispatchKeySet ks) {
+inline at::Tensor dummyTensor(c10::DispatchKeySet ks, bool requires_grad=false) {
   auto* allocator = c10::GetCPUAllocator();
   int64_t nelements = 1;
   auto dtype = caffe2::TypeMeta::Make<float>();
@@ -24,11 +24,18 @@ inline at::Tensor dummyTensor(c10::DispatchKeySet ks) {
       allocator->allocate(size_bytes),
       allocator,
       /*resizable=*/true);
-  return at::detail::make_tensor<c10::TensorImpl>(storage_impl, ks, dtype);
+  at::Tensor t = at::detail::make_tensor<c10::TensorImpl>(storage_impl, ks, dtype);
+  // TODO: We add this to simulate the ideal case where we only have Autograd backend keys
+  //       on Tensor when it requires grad. But currently Autograd keys are added in TensorImpl
+  //       constructor by default.
+  if (!requires_grad) {
+    t.unsafeGetTensorImpl()->remove_autograd_key();
+  }
+  return t;
 }
 
-inline at::Tensor dummyTensor(c10::DispatchKey dispatch_key) {
-  return dummyTensor(c10::DispatchKeySet(dispatch_key));
+inline at::Tensor dummyTensor(c10::DispatchKey dispatch_key, bool requires_grad=false) {
+  return dummyTensor(c10::DispatchKeySet(dispatch_key), requires_grad);
 }
 
 template<class... Args>

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -15,7 +15,9 @@ namespace impl {
 // Some keys are ALWAYS considered for inclusion by default, so they are
 // included in the set here.  (const appears to be sufficient for
 // always_included to get inlined, constexpr not necessary)
-const DispatchKeySet always_included{DispatchKey::Autograd, DispatchKey::BackendSelect};
+// Note DispatchKey::Autograd used to be in this set and it now has been
+// moved to TensorImpl constructor.
+const DispatchKeySet always_included{DispatchKey::BackendSelect};
 
 // Take a DispatchKeySet for a Tensor and determine what the actual dispatch
 // DispatchKey should be, taking into account TLS, and skipping backends which

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -340,6 +340,8 @@ template<class... Args> inline void unused_arg_(const Args&...) {}
 template<class Return, class... Args>
 inline Return Dispatcher::callWithDispatchKey(const TypedOperatorHandle<Return(Args...)>& op, DispatchKey dispatchKey, Args... args) const {
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
+  // No alias dispatch key is allowed at runtime.
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!c10::isAliasDispatchKey(dispatchKey));
   const KernelFunction& kernel = op.operatorIterator_->op.lookup(dispatchKey);
 
 #ifndef PYTORCH_DISABLE_PER_OP_PROFILING
@@ -355,7 +357,7 @@ inline Return Dispatcher::callWithDispatchKey(const TypedOperatorHandle<Return(A
       int64_t seq_num = -1;
       // Setting sequence number in the Autograd case to associate
       // the forward range with the coresponding Autograd's node
-      if (dispatchKey == DispatchKey::Autograd && at::GradMode::is_enabled()) {
+      if (isIncludedInAlias(dispatchKey, DispatchKey::Autograd) && at::GradMode::is_enabled()) {
         seq_num = at::sequence_number::peek();
       }
       if (guard.needs_inputs) {
@@ -406,7 +408,7 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
   if (C10_UNLIKELY(guard.active)) {
     if (shouldRecord(dispatchKey) && entry.isObserved()) {
       int64_t seq_num = -1;
-      if (dispatchKey == DispatchKey::Autograd && at::GradMode::is_enabled()) {
+      if (isIncludedInAlias(dispatchKey, DispatchKey::Autograd) && at::GradMode::is_enabled()) {
         seq_num = at::sequence_number::peek();
       }
       if (guard.needs_inputs) {

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -155,6 +155,23 @@ const KernelFunction& OperatorEntry::computeDispatchTableEntry(const c10::Dispat
 
 std::pair<const AnnotatedKernel&, const char*> OperatorEntry::computeDispatchTableEntryWithDebug(const c10::Dispatcher& dispatcher, DispatchKey dispatch_key) const {
   auto dispatch_ix = static_cast<uint8_t>(dispatch_key);
+  // [Note] DispatchTable computation
+  // dispatchTable contains entries for runtime dispatch keys.
+  // For any dispatch key, it'll pick a kernel using the following order:
+  //  (1) Use kernel if it's directly registered to this key
+  //  (2) Handle runtime keys that have kernels available from alias keys
+  //    (2.1) Use kernel from DispatchKey::Autograd if available
+  //    (2.2) Use catchAllKernel_(as if it was populated to DispatchKey::Autograd) if available
+  //          Tensor factory functions used to have no registration to Autograd key but only to catchAll.
+  //          In the past we directly call into backends(filled with catchAll) after BackendSelect.
+  //          Now that we first call Autograd backend keys after BackendSelect, we should fill those
+  //          with catchAll as well.
+  //  (3) Use fallthrough kernel that are registered as fallback.
+  //  (4) Use catchAll kernel if available
+  // TODO: currently Autograd is the only alias key, we'll update alias key precedence after we add new
+  //      alias keys AutogradDispatchCPUOrCUDA and Math.
+  // TODO: we can remove (2.2) and (4) after TypeDefault registrations are moved from catchAll to Math
+  //       so that Math can populate to Autograd backend keys before fallback kernels.
 
   // 1. Operator registration
   auto kern_it = kernels_.find(dispatch_key);
@@ -163,25 +180,43 @@ std::pair<const AnnotatedKernel&, const char*> OperatorEntry::computeDispatchTab
     TORCH_INTERNAL_ASSERT(kern_it->second.front().kernel.isValid());
     return {kern_it->second.front(), "kernel"};
 
-  // 2. Backend fallback
-  } else if (dispatcher.backendFallbackKernels_[dispatch_ix].kernel.isValid()) {
+  } else if (isIncludedInAlias(dispatch_key, DispatchKey::Autograd)) {
+    // 2.1. For autograd backend keys, use kernel from DispatchKey::Autograd if available
+    auto kern_autograd = kernels_.find(DispatchKey::Autograd);
+    if (kern_autograd != kernels_.end()) {
+      TORCH_INTERNAL_ASSERT(!kern_autograd->second.empty());
+      TORCH_INTERNAL_ASSERT(kern_autograd->second.front().kernel.isValid());
+      return {kern_autograd->second.front(), "autograd kernel"};
+
+    // 2.2. For autograd backend keys, we do this before step 4 to make it higher precedence than
+    //      the fallthrough kernel we registered to Autograd backend keys as fallback.
+    } else if (!catchAllKernel_.empty()) {
+      TORCH_INTERNAL_ASSERT(catchAllKernel_.front().kernel.isValid());
+      return {catchAllKernel_.front(), "autograd catch all"};
+    }
+  }
+
+  // 3. Backend fallback
+  if (dispatcher.backendFallbackKernels_[dispatch_ix].kernel.isValid()) {
     return {dispatcher.backendFallbackKernels_[dispatch_ix], "backend fallback"};
 
-  // 3. Catch all
+  // 4. Catch all
   } else if (!catchAllKernel_.empty()) {
     TORCH_INTERNAL_ASSERT(catchAllKernel_.front().kernel.isValid());
     return {catchAllKernel_.front(), "catch all"};
 
-  // 4. Default to error
+  // 5. Default to error
   } else {
     return {missingKernel_, "missing"};
   }
 }
 
 void OperatorEntry::updateDispatchTable_(const c10::Dispatcher& dispatcher, DispatchKey dispatch_key) {
-  auto dispatch_ix = static_cast<uint8_t>(dispatch_key);
-  dispatchTable_[dispatch_ix] = computeDispatchTableEntry(dispatcher, dispatch_key);
-  dispatchKeyExtractor_.setOperatorHasFallthroughForKey(dispatch_key, dispatchTable_[dispatch_ix].isFallthrough());
+  for (auto k : c10::getRuntimeDispatchKeys(dispatch_key)) {
+    auto dispatch_ix = static_cast<uint8_t>(k);
+    dispatchTable_[dispatch_ix] = computeDispatchTableEntry(dispatcher, k);
+    dispatchKeyExtractor_.setOperatorHasFallthroughForKey(k, dispatchTable_[dispatch_ix].isFallthrough());
+  }
 }
 
 void OperatorEntry::updateDispatchTableFull_(const c10::Dispatcher& dispatcher) {

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -217,13 +217,15 @@ Library& Library::_fallback(CppFunction&& f) & {
     "this fallback function globally, please define a separate block:\n\n",
     "    TORCH_LIBRARY_IMPL(_, ", *dispatch_key, ", m) { m.fallback(...); }\n\n",
     ERROR_CONTEXT);
-  registrars_.emplace_back(
-    c10::Dispatcher::singleton().registerFallback(
-      *dispatch_key,
-      std::move(f.func_),
-      debugString(std::move(f.debug_), file_, line_)
-    )
-  );
+  for (auto k : c10::getRuntimeDispatchKeys(*dispatch_key)) {
+    registrars_.emplace_back(
+      c10::Dispatcher::singleton().registerFallback(
+        k,
+        std::move(f.func_),
+        debugString(std::move(f.debug_), file_, line_)
+      )
+    );
+  }
   return *this;
 }
 

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -812,7 +812,12 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernel_thenCanCallAutograd
   ASSERT_TRUE(op.has_value());
 
   called_autograd = false;
-  op->typed<void(Tensor)>().call(dummyTensor(DispatchKey::CPU)); // note: all tensors have VariableTypeId set
+  expectThrows<c10::Error>([&] {
+    callOp(*op, dummyTensor(c10::DispatchKey::CPU));
+  }, "Could not run '_test::dummy' with arguments from the 'CPU'"
+  " backend.");
+
+  op->typed<void(Tensor)>().call(dummyTensor(DispatchKey::CPU, /*requires_grad=*/true));
   EXPECT_TRUE(called_autograd);
 }
 
@@ -825,7 +830,7 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernelWithRegularKernel_th
   ASSERT_TRUE(op.has_value());
 
   called_nonautograd = called_autograd = false;
-  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU)); // note: all tensors have VariableTypeId set
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU, /*requires_grad=*/true));
   EXPECT_FALSE(called_nonautograd);
   EXPECT_TRUE(called_autograd);
 }
@@ -854,7 +859,7 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernelWithCatchAllKernel_t
   ASSERT_TRUE(op.has_value());
 
   called_nonautograd = called_autograd = false;
-  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU));  // note: all tensors have VariableTypeId set
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU, /*requires_grad=*/true));
   EXPECT_FALSE(called_nonautograd);
   EXPECT_TRUE(called_autograd);
 }
@@ -874,7 +879,36 @@ TEST(OperatorRegistrationTest, whenRegisteringAutogradKernelWithCatchAllKernel_t
   EXPECT_FALSE(called_autograd);
 }
 
-TEST(OperatorRegistrationTest, xlaPreAutogradOverridesAutogradKernel) {
+TEST(OperatorRegistrationTest, AutogradBackendOverridesAutogradKernel) {
+  auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options()
+    .kernel<decltype(nonautograd_kernel), &nonautograd_kernel>(DispatchKey::AutogradCPU)
+    .kernel<decltype(autograd_kernel), &autograd_kernel>(DispatchKey::Autograd));
+
+  auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
+  ASSERT_TRUE(op.has_value());
+
+  expectThrows<c10::Error>([&] {
+    callOp(*op, dummyTensor(c10::DispatchKey::CPU));
+  }, "Could not run '_test::dummy' with arguments from the 'CPU'"
+  " backend.");
+
+  expectThrows<c10::Error>([&] {
+    callOp(*op, dummyTensor(c10::DispatchKey::CUDA));
+  }, "Could not run '_test::dummy' with arguments from the 'CUDA'"
+  " backend.");
+
+  called_nonautograd = called_autograd = false;
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU, /*requires_grad=*/true));
+  EXPECT_TRUE(called_nonautograd);
+  EXPECT_FALSE(called_autograd);
+
+  called_nonautograd = called_autograd = false;
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CUDA, /*requires_grad=*/true));
+  EXPECT_TRUE(called_autograd);
+  EXPECT_FALSE(called_nonautograd);
+}
+
+TEST(OperatorRegistrationTest, AutogradXLAOverridesAutogradKernel) {
   auto registrar = c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", c10::RegisterOperators::options()
     .kernel<decltype(nonautograd_kernel), &nonautograd_kernel>(DispatchKey::AutogradXLA)
     .kernel<decltype(autograd_kernel), &autograd_kernel>(DispatchKey::Autograd));
@@ -882,13 +916,18 @@ TEST(OperatorRegistrationTest, xlaPreAutogradOverridesAutogradKernel) {
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
 
+  expectThrows<c10::Error>([&] {
+    callOp(*op, dummyTensor(c10::DispatchKey::XLA));
+  }, "Could not run '_test::dummy' with arguments from the 'XLA'"
+  " backend.");
+
   called_nonautograd = called_autograd = false;
-  op->typed<void (Tensor)>().call(dummyTensor(c10::DispatchKeySet{DispatchKey::XLA, DispatchKey::AutogradXLA}));
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::XLA, /*requires_grad=*/true));
   EXPECT_TRUE(called_nonautograd);
   EXPECT_FALSE(called_autograd);
 
   called_nonautograd = called_autograd = false;
-  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU));
+  op->typed<void (Tensor)>().call(dummyTensor(DispatchKey::CPU, /*requires_grad=*/true));
   EXPECT_TRUE(called_autograd);
   EXPECT_FALSE(called_nonautograd);
 }
@@ -1582,7 +1621,15 @@ TEST(NewOperatorRegistrationTest, dispatch) {
     auto op = Dispatcher::singleton().findSchema({"test::fn_autograd", ""});
     ASSERT_TRUE(op.has_value());
     ASSERT_FALSE(autograd_called);
-    callOp(*op, dummyTensor(c10::DispatchKey::Autograd));
+    callOp(*op, dummyTensor(c10::DispatchKey::CPU, /*requires_grad=*/true));
+    ASSERT_TRUE(autograd_called);
+  }
+
+  {
+    autograd_called = false;
+    auto op = Dispatcher::singleton().findSchema({"test::fn_autograd", ""});
+    ASSERT_TRUE(op.has_value());
+    callOp(*op, dummyTensor(c10::DispatchKey::XLA, /*requires_grad=*/true));
     ASSERT_TRUE(autograd_called);
   }
 }
@@ -1613,9 +1660,15 @@ TEST(NewOperatorRegistrationTest, dispatchMultiple) {
     ASSERT_TRUE(cuda_called);
   }
 
-  ASSERT_FALSE(autograd_called);
-  callOp(*op, dummyTensor(c10::DispatchKey::Autograd));
-  ASSERT_TRUE(autograd_called);
+  {
+    ASSERT_FALSE(autograd_called);
+    callOp(*op, dummyTensor(c10::DispatchKey::CPU, /*requires_grad=*/true));
+    ASSERT_TRUE(autograd_called);
+
+    autograd_called = false;
+    callOp(*op, dummyTensor(c10::DispatchKey::CUDA, /*requires_grad=*/true));
+    ASSERT_TRUE(autograd_called);
+  }
 }
 
 TEST(NewOperatorRegistrationTest, fallback) {

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -55,7 +55,7 @@ inline bool variable_excluded_from_dispatch() {
   // Please read the comment in `VariableFallbackKernel.cpp` about the background of this change.
   return true;
 #else
-  return c10::impl::tls_local_dispatch_key_set().excluded_.has(DispatchKey::Autograd);
+  return c10::impl::tls_local_dispatch_key_set().excluded_.isSupersetOf(c10::getRuntimeDispatchKeySet(DispatchKey::Autograd));
 #endif
 }
 }

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/DeviceType.h>
 #include <c10/core/DispatchKey.h>
+#include <c10/core/DispatchKeySet.h>
 #include <c10/util/Exception.h>
 
 #include <stdexcept>
@@ -92,9 +93,9 @@ static inline Backend toDense(Backend b) {
 }
 
 static inline Backend dispatchKeyToBackend(DispatchKey t) {
-  if (t == DispatchKey::CPU) {
+  if (t == DispatchKey::CPU || t == DispatchKey::AutogradCPU) {
     return Backend::CPU;
-  } else if (t == DispatchKey::CUDA) {
+  } else if (t == DispatchKey::CUDA || t == DispatchKey::AutogradCUDA) {
     return Backend::CUDA;
   } else if (t == DispatchKey::HIP) {
     return Backend::HIP;

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -63,29 +63,32 @@ const char* toString(DispatchKey t) {
     case DispatchKey::Meta:
       return "Meta";
 
+    case DispatchKey::Autograd:
+      return "Autograd";
+    case DispatchKey::AutogradCPU:
+      return "AutogradCPU";
+    case DispatchKey::AutogradCUDA:
+      return "AutogradCUDA";
+    case DispatchKey::AutogradXLA:
+      return "AutogradXLA";
+    case DispatchKey::AutogradPrivateUse1:
+      return "AutogradPrivateUse1";
+    case DispatchKey::AutogradPrivateUse2:
+      return "AutogradPrivateUse2";
+    case DispatchKey::AutogradPrivateUse3:
+      return "AutogradPrivateUse3";
+    case DispatchKey::AutogradOther:
+      return "AutogradOther";
     case DispatchKey::BackendSelect:
       return "BackendSelect";
     case DispatchKey::Named:
       return "Named";
 
-    case DispatchKey::Autograd:
-      return "Autograd";
-
     case DispatchKey::Tracer:
       return "Tracer";
 
-    case DispatchKey::AutogradXLA:
-      return "AutogradXLA";
-
     case DispatchKey::Autocast:
       return "Autocast";
-
-    case DispatchKey::PrivateUse1_PreAutograd:
-      return "PrivateUse1_PreAutograd";
-    case DispatchKey::PrivateUse2_PreAutograd:
-      return "PrivateUse2_PreAutograd";
-    case DispatchKey::PrivateUse3_PreAutograd:
-      return "PrivateUse3_PreAutograd";
 
     case DispatchKey::Batched:
       return "Batched";
@@ -106,6 +109,25 @@ const char* toString(DispatchKey t) {
 
 std::ostream& operator<<(std::ostream& str, DispatchKey rhs) {
   return str << toString(rhs);
+}
+
+DispatchKey getAutogradKeyFromBackend(DispatchKey t) {
+  switch (t) {
+    case DispatchKey::CPU:
+      return DispatchKey::AutogradCPU;
+    case DispatchKey::CUDA:
+      return DispatchKey::AutogradCUDA;
+    case DispatchKey::XLA:
+      return DispatchKey::AutogradXLA;
+    case DispatchKey::PrivateUse1:
+      return DispatchKey::AutogradPrivateUse1;
+    case DispatchKey::PrivateUse2:
+      return DispatchKey::AutogradPrivateUse2;
+    case DispatchKey::PrivateUse3:
+      return DispatchKey::AutogradPrivateUse3;
+    default:
+      return DispatchKey::AutogradOther;
+  }
 }
 
 } // namespace c10

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <vector>
 #include <iostream>
 #include <string>
 #include <c10/macros/Macros.h>
+#include <c10/util/ArrayRef.h>
+#include <c10/util/Exception.h>
 
 namespace c10 {
 
@@ -107,6 +110,10 @@ enum class DispatchKey : uint8_t {
   PrivateUse2,
   PrivateUse3,
 
+  // Define an alias key to represent end of backend dispatch keys.
+  // If you add new backend keys after PrivateUse3, please also update it here.
+  EndOfBackendKeys = PrivateUse3,
+
   // The meta function characterizes how an operation affects the metadata of a
   // tensor (shape, dtype) without doing any of the actual computation.  A
   // meta tensor can be used to dry run operators without actually doing
@@ -180,39 +187,46 @@ enum class DispatchKey : uint8_t {
   // constituent parts.
   Named,
 
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ AUTOGRAD ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
+  // Note [Alias Dispatch Key : Autograd]
   // All backends are oblivious to autograd; autograd is handled as a
-  // layer which happens on top of all backends.  It inspects the autograd
+  // layer which happens on top of all backends. It inspects the autograd
   // metadata of all inputs, determines what autograd metadata should be
   // constructed by the output, and otherwise defers to the backend to
   // actually do the numeric computation.  Autograd contains
   // the bulk of this logic.
-  Autograd,
 
-  Tracer,
-
-  // Pre-autograd dispatch keys allow backends to override the autograd behavior
-  // (aka Autograd) for operators which have a Variable kernel
-  // already registered.  For example, XLA wants to define autograd for
-  // einsum directly.  Registering a custom autograd implementation at the
-  // XLA key won't work because we process Autograd
-  // before XLA.  This key has higher priority and gets processed
-  // first.  You generally should NOT redispatch after handling autograd
-  // here (since that would result in execution of the Autograd
-  // operator, which you're trying to skip).  In PreAutograd implementations,
+  // Autograd is now an alias dispatch key which by default maps to all
+  // backend-specific autograd keys.
+  // Backend-specific allow backends to override the default kernel registered
+  // to Autograd key as needed.
+  // For example, XLA wants to define autograd for einsum directly.
+  // Registering a custom autograd implementation at the XLA key won't work
+  // because we process Autograd before XLA.  This key has higher priority and
+  // gets processed first.  You generally should NOT redispatch after handling
+  // autograd here (since that would result in execution of the Autograd
+  // operator, which you're trying to skip).  In AutogradXLA implementations,
   // you are responsible for handling autograd yourself, or deferring to other
   // operators which support autograd.
+
+  // Currently we only have backend-specific autograd keys for CPU/CUDA/XLA and
+  // reserved user-defined backends. All other in-tree backends share the
+  // AutogradOther key. We can add specific autograd key for those backends
+  // upon request.
+  AutogradOther,
+  AutogradCPU,
+  AutogradCUDA,
   AutogradXLA,
+  // Here are some reserved pre-autograd keys for user-defined backends, see
+  // Note [Private use DispatchKey]
+  AutogradPrivateUse1,
+  AutogradPrivateUse2,
+  AutogradPrivateUse3,
+
+  Tracer,
 
   // Autocasting precedes VariableTypeId, to ensure casts are autograd-exposed
   // and inputs are saved for backward in the post-autocast type.
   Autocast,
-
-  // Here are some reserved pre-autograd keys for user-defined backends, see
-  // Note [Private use DispatchKey]
-  PrivateUse1_PreAutograd,
-  PrivateUse2_PreAutograd,
-  PrivateUse3_PreAutograd,
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ WRAPPERS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
   // There are a number of alternative modes which may want to handle before
@@ -244,13 +258,30 @@ enum class DispatchKey : uint8_t {
   TESTING_ONLY_GenericMode,
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FIN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
-  NumDispatchKeys, // Sentinel
+  NumDispatchKeys, // Sentinel, end of runtime keys.
+
+  // ~~~~~~~~~~~~~~~~~~~~~~ Alias Dispatch Keys ~~~~~~~~~~~~~~~~~~~~~~~~~~ //
+  // Alias dispatch keys are synthetic dispatch keys which map to multiple
+  // runtime dispatch keys. Alisa keys have precedence, but they are always
+  // lower precedence than runtime keys. You can register a kernel to an
+  // alias key, the kernel might be populated to the mapped runtime keys
+  // during dispatch table computation.
+  // If a runtime dispatch key has multiple kernels from alias keys, which
+  // kernel wins is done based on the precedence of alias keys (but runtime
+  // keys always have precedence over alias keys).
+  // Alias keys won't be directly called during runtime.
+
+  // See Note [Alias Dispatch Key : Autograd]
+  Autograd,
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~ BC ALIASES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
   // The aliases exist for backwards compatibility reasons, they shouldn't
   // be used
   CPUTensorId = CPU,
   CUDATensorId = CUDA,
+  PrivateUse1_PreAutograd = AutogradPrivateUse1,
+  PrivateUse2_PreAutograd = AutogradPrivateUse2,
+  PrivateUse3_PreAutograd = AutogradPrivateUse3,
 };
 
 // Note [Private use DispatchKey]
@@ -269,13 +300,13 @@ enum class DispatchKey : uint8_t {
 // the PyTorch developers to get a type ID registered in this case.
 //
 // We provide two classes of private user tensor id: regular DispatchKeys
-// and PreAutograd DispatchKeys.  DispatchKeys serve the role of ordinary "backend"
+// and Autograd DispatchKeys.  DispatchKeys serve the role of ordinary "backend"
 // DispatchKeys; if you were adding support for a new type of accelerator, you
-// would use a DispatchKey, and reuse autograd definitions already defined in
-// PyTorch for operators you define.  PreAutograd DispatchKeys serve as "wrapper"
-// DispatchKeys: they are most appropriate for tensors that compose multiple
-// internal tensors, and for cases when the built-in autograd formulas for
-// operators are not appropriate.
+// would use a backend DispatchKey, and ideally automatically reuse AutogradOther
+// definitions already defined in PyTorch.  AutogradPrivateUse DispatchKeys serve
+// as "wrapper" DispatchKeys: they are only necessary for tensors that compose
+// multiple internal tensors, and for cases when the built-in autograd formulas
+// for operators are not appropriate.
 
 static_assert(
   static_cast<uint8_t>(DispatchKey::NumDispatchKeys) < 64,
@@ -284,6 +315,8 @@ static_assert(
 C10_API const char* toString(DispatchKey);
 C10_API std::ostream& operator<<(std::ostream&, DispatchKey);
 
+C10_API DispatchKey getAutogradKeyFromBackend(DispatchKey t);
+
 // These are some convenience identifiers for dispatch keys which are
 // shorter to type than their long counterparts.  Note that some of these
 // dispatch keys directly correspond to DeviceType; and most APIs that
@@ -291,6 +324,10 @@ C10_API std::ostream& operator<<(std::ostream&, DispatchKey);
 // torch::dispatch(torch::kCPU, ...) is also valid.
 constexpr DispatchKey kAutograd = DispatchKey::Autograd;
 
+// Check if a DispatchKey is an alias mapping to other runtime keys.
+inline bool isAliasDispatchKey(DispatchKey k) {
+  return k == DispatchKey::Autograd;
+}
 } // namespace c10
 
 namespace torch {

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -2,16 +2,56 @@
 
 namespace c10 {
 
-static DispatchKeySet autograd_dispatch_keys{
-  DispatchKey::Autograd,
+constexpr DispatchKeySet autograd_dispatch_keyset = DispatchKeySet({
+  DispatchKey::AutogradCPU,
+  DispatchKey::AutogradCUDA,
   DispatchKey::AutogradXLA,
-  DispatchKey::PrivateUse1_PreAutograd,
-  DispatchKey::PrivateUse2_PreAutograd,
-  DispatchKey::PrivateUse3_PreAutograd,
-};
+  DispatchKey::AutogradPrivateUse1,
+  DispatchKey::AutogradPrivateUse2,
+  DispatchKey::AutogradPrivateUse3,
+  DispatchKey::AutogradOther,
+});
 
-DispatchKeySet AutogradDispatchKeys() {
-  return autograd_dispatch_keys;
+DispatchKeySet getRuntimeDispatchKeySet(DispatchKey t) {
+  switch (t) {
+    case DispatchKey::Autograd:
+      return autograd_dispatch_keyset;
+    case DispatchKey::Undefined:
+     return DispatchKeySet();
+   default:
+     return DispatchKeySet(t);
+  }
+}
+
+template <std::size_t... Is>
+constexpr auto make_array_from_sequence(std::index_sequence<Is...>) {
+  return std::array<DispatchKey, sizeof...(Is)>{static_cast<DispatchKey>(Is)...};
+}
+
+constexpr auto runtime_dispatch_keys = make_array_from_sequence(
+  std::make_index_sequence<static_cast<uint8_t>(DispatchKey::NumDispatchKeys)>{});
+
+// Create singleton for alias keys separately to make sure we don't
+// accidentally support DispatchKey::NumDispatchKeys in std::array.
+constexpr std::array<DispatchKey, 7> autograd_dispatch_keys {
+    DispatchKey::AutogradCPU, DispatchKey::AutogradCUDA, DispatchKey::AutogradXLA,
+    DispatchKey::AutogradPrivateUse1, DispatchKey::AutogradPrivateUse2,
+    DispatchKey::AutogradPrivateUse3, DispatchKey::AutogradOther};
+
+ArrayRef<DispatchKey> getRuntimeDispatchKeys(DispatchKey k) {
+  if (isAliasDispatchKey(k)) {
+    switch (k) {
+      case DispatchKey::Autograd:
+        return autograd_dispatch_keys;
+      default:
+        TORCH_INTERNAL_ASSERT(false, "Unable to resolve alias dispatch key");
+    }
+  }
+  return c10::ArrayRef<DispatchKey>(runtime_dispatch_keys).slice(static_cast<uint8_t>(k), 1);
+}
+
+bool isIncludedInAlias(DispatchKey k, DispatchKey alias) {
+  return k != DispatchKey::Undefined && getRuntimeDispatchKeySet(alias).has(k);
 }
 
 std::string toString(DispatchKeySet ts) {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -469,6 +469,14 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return key_set_.has(DispatchKey::Vulkan);
   }
 
+  // TODO: remove this once we don't automatically enabled Autograd dispatch keys
+  //       in TensorImpl constructor.
+  // DON'T USE THIS API!! It's only created for testing purpose in
+  // file aten/src/ATen/core/boxing/impl/test_helpers.h
+  void remove_autograd_key() {
+    key_set_ = key_set_ - getRuntimeDispatchKeySet(DispatchKey::Autograd);
+  }
+
   int64_t get_device() const {
     TORCH_CHECK(
         device_opt_.has_value(),

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -620,6 +620,8 @@ inline DispatchKey computeDispatchKey(TensorOptions options) {
   return options.computeDispatchKey();
 }
 
+// We deliberately ignore handling AutogradCPU/CUDA/XLA... keys to
+// avoid adding asymmetry in device <--> Autograd dispatch key mapping.
 inline DeviceType computeDeviceType(DispatchKey tid) {
   if (tid == DispatchKey::CPU) {
     return DeviceType::CPU;
@@ -642,8 +644,6 @@ inline DeviceType computeDeviceType(DispatchKey tid) {
   } else if (tid == DispatchKey::MSNPU) {
     return DeviceType::MSNPU;
   } else if (tid == DispatchKey::XLA) {
-    return DeviceType::XLA;
-  } else if (tid == DispatchKey::AutogradXLA) {
     return DeviceType::XLA;
   } else if (tid == DispatchKey::SparseCPU) {
     return DeviceType::CPU;

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -194,15 +194,18 @@ class TestDispatch(TestCase):
             lambda m: m.def_("foo(Tensor x) -> Tensor"),
             # m.impl("test_def", [](const Tensor& x) { return x })
             lambda m: m.impl_t_t("foo"),
-            # m.impl("test_def", kAutograd, [](const Tensor& x) { return x })
-            lambda m: m.impl_t_t("foo", dispatch="autograd")
+            # m.impl("test_def", kCPU, [](const Tensor& x) { return x })
+            lambda m: m.impl_t_t("foo", dispatch="cpu"),
+            # m.impl("test_def", kAutogradCPU, [](const Tensor& x) { return x })
+            lambda m: m.impl_t_t("foo", dispatch="autogradcpu")
         ])
         self.assertExpectedInline(r, '''\
 name: test::foo
 schema: test::foo(Tensor x) -> (Tensor)
 debug: registered at /dev/null:0
 alias analysis kind: FROM_SCHEMA
-Autograd: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+CPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+AutogradCPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 catchall: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 ''')
 
@@ -221,15 +224,18 @@ catchall: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
         r = self.commute("foo", [
             # m.def("foo", [](const Tensor & x) { return x })
             lambda m: m.def_name_t_t("foo"),
-            # m.impl("foo", torch::kAutograd, [](const Tensor & x) { return x })
-            lambda m: m.impl_t_t("foo", "autograd")
+            # m.impl("foo", torch::kCPU, [](const Tensor & x) { return x })
+            lambda m: m.impl_t_t("foo", "cpu"),
+            # m.impl("foo", torch::kAutogradCPU, [](const Tensor & x) { return x })
+            lambda m: m.impl_t_t("foo", "autogradcpu")
         ])
         self.assertExpectedInline(r, '''\
 name: test::foo
 schema: test::foo(Tensor _0) -> (Tensor _0)
 debug: registered at /dev/null:0
 alias analysis kind: CONSERVATIVE
-Autograd: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+CPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+AutogradCPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 catchall: default_def_name_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 ''')
 
@@ -249,13 +255,16 @@ alias analysis kind: FROM_SCHEMA
         r = self.commute("foo", [
             # m.impl("foo", [](const Tensor& x) { return x })
             lambda m: m.impl_t_t("foo"),
-            # m.impl("foo", torch::kAutograd, [](const Tensor& x) { return x })
-            lambda m: m.impl_t_t("foo", "autograd")
+            # m.impl("foo", torch::kCPU, [](const Tensor& x) { return x })
+            lambda m: m.impl_t_t("foo", "cpu"),
+            # m.impl("foo", torch::kAutogradCPU, [](const Tensor& x) { return x })
+            lambda m: m.impl_t_t("foo", "autogradcpu")
         ])
         self.assertExpectedInline(r, '''\
 name: test::foo
 schema: (none)
-Autograd: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+CPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+AutogradCPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 catchall: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 ''')
 

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -30,7 +30,7 @@ c10::optional<c10::DispatchKey> parseDispatchKey(const std::string& k) {
     {"cpu", c10::DispatchKey::CPU},
     {"cuda", c10::DispatchKey::CUDA},
     {"xla", c10::DispatchKey::XLA},
-    {"autograd", c10::DispatchKey::Autograd},
+    {"autogradcpu", c10::DispatchKey::AutogradCPU},
     {"", c10::DispatchKey::Undefined},
   };
   auto it = key_map.find(k);

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -337,7 +337,7 @@ void check_base_legacy_new(c10::DispatchKey dispatch_key, at::Layout expected_la
     TORCH_CHECK(dispatch_key == c10::DispatchKey::CPU
                 || dispatch_key == c10::DispatchKey::CUDA
                 || dispatch_key == c10::DispatchKey::HIP
-                || c10::XLA().has(dispatch_key),
+                || dispatch_key == c10::DispatchKey::XLA,
                 "new(): expected DispatchKey: ", c10::DispatchKey::CPU,
                 " or ", c10::DispatchKey::CUDA,
                 " or ", c10::DispatchKey::HIP,


### PR DESCRIPTION
This PR moves `DispatchKey::Autograd` to an alias dispatch key mapping to `AutogradCPU, AutogradCUDA, AutogradXLA, AutogradOther, AutogradPrivate*` keys. 

A few things are handled in this PR:
- Update alias dispatch key mapping and precompute dispatchTable logic
- Move `Autograd` key from `always_included` set to TensorImpl constructor.
- Update `dummyTensor` constructor to take `requires_grad` as optional argument so that it's closer to the real application in op_registration_test. 
- Use `BackendSelect` key for both backend select before and after autograd layer. (1 liner in backend_select codegen)

A few planned followups ordered by priority:
- [cleanup] Update `test_dispatch.py` to include testing `Autograd`.
- [cleanup] Add Math alias key and move catchAll to Math. (to remove 2.2 in `computeDispatchTableEntryWithDebug`)
- [new feature] Add support for Math in native_functions.yaml
- [cleanup] Add iterator like functionality to DispatchKeySet
- [cleanup/large] Only add Autograd backend keys when tensor requires grad. (cc: @ljk53 ?)