### PR TITLE
[TB] Close SummaryWriter on destruction

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -1034,3 +1034,6 @@ class SummaryWriter(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+
+    def __del__(self):
+        self.close()


### PR DESCRIPTION
Summary: Close writer on destruction to explicitly flush log to filesystem. This feature was requested by Lightning and Pyspeech

Differential Revision: D23144971

