### PR TITLE
[tensorexpr] Fix promotion of booleans

### DIFF
--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1268,8 +1268,10 @@ class TestTensorExprFuser(BaseTestClass):
 
     def test_mask(self):
         devices = ["cuda", "cpu"] if torch.cuda.is_available() else ["cpu"]
+
         def test(x):
             return x.unsqueeze(1) == 0
+
         for d in devices:
             x = torch.rand(4, device=d) > 0.5
             scripted = torch.jit.script(test)

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1266,5 +1266,15 @@ class TestTensorExprFuser(BaseTestClass):
         assert torch.allclose(scripted(a), 2 * a)
         assert cx.elapsed_value() == 1
 
+    def test_mask(self):
+        devices = ["cuda", "cpu"] if torch.cuda.is_available() else ["cpu"]
+        def test(x):
+            return x.unsqueeze(1) == 0
+        for d in devices:
+            x = torch.rand(4, device=d) > 0.5
+            scripted = torch.jit.script(test)
+            scripted(x)
+            assert torch.equal(scripted(x), test(x))
+
 if __name__ == '__main__':
     unittest.main()

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -272,20 +272,26 @@ void CudaPrinter::visit(const Load* v) {
       os() << "__half2float(" << *v->base_handle() << "[" << *v->flat_index()
            << "])";
     }
-  } else {
-    // Detects whether the load target is also a store target.
-    // TODO: this is currently too wide. It detects whether a store-target
-    // exists within the program. In fact, this check is only necessary within a
-    // kernel.
-    if (v->indices().empty()) {
-      os() << *v->base_handle();
-    } else if (!cuda_analysis_->is_buf_store_target(v->buf())) {
-      // Cuda __ldg can only be applied on read-only buffers.
-      os() << "__ldg(" << *v->base_handle() << " + " << *v->flat_index() << ")";
-    } else {
-      os() << *v->base_handle() << "[" << *v->flat_index() << "]";
-    }
+    return;
   }
+  // Detects whether the load target is also a store target.
+  // TODO: this is currently too wide. It detects whether a store-target
+  // exists within the program. In fact, this check is only necessary within a
+  // kernel.
+  if (v->indices().empty()) {
+    os() << *v->base_handle();
+    return;
+  }
+  if (v->dtype().scalar_type() == ScalarType::Bool) {
+    os() << *v->base_handle() << "[" << *v->flat_index() << "]";
+    return;
+  }
+  if (cuda_analysis_->is_buf_store_target(v->buf())) {
+    // Cuda __ldg can only be applied on read-only buffers.
+    os() << *v->base_handle() << "[" << *v->flat_index() << "]";
+    return;
+  }
+  os() << "__ldg(" << *v->base_handle() << " + " << *v->flat_index() << ")";
 }
 
 // TODO: maybe this should be a more shared location?

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -283,6 +283,7 @@ void CudaPrinter::visit(const Load* v) {
     return;
   }
   if (v->dtype().scalar_type() == ScalarType::Bool) {
+    // There's no __ldg overload for bool.
     os() << *v->base_handle() << "[" << *v->flat_index() << "]";
     return;
   }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -351,18 +351,10 @@ void TensorExprKernel::promoteInputs(std::vector<ExprHandle>& inputs) {
   // Find the highest type among the inputs.
   ScalarType highType = inputs[0].dtype().scalar_type();
   for (const auto input : inputs) {
-    ScalarType iType = input.dtype().scalar_type();
-    if (iType == ScalarType::Bool) {
-      continue;
-    }
-    highType = promoteTypes(highType, iType);
+    highType = promoteTypes(highType, input.dtype().scalar_type());
   }
 
   for (ExprHandle& e : inputs) {
-    if (e.dtype().scalar_type() == ScalarType::Bool) {
-      continue;
-    }
-
     if (e.dtype().scalar_type() == highType) {
       continue;
     }
@@ -373,7 +365,7 @@ void TensorExprKernel::promoteInputs(std::vector<ExprHandle>& inputs) {
   case ScalarType::Name:      \
     e = cast<Type>(e);        \
     break;
-      AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+      AT_FORALL_SCALAR_TYPES_AND2(Half, Bool, TYPE_CASE);
 #undef TYPE_CASE
       default:
         throw unsupported_dtype();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43097 [tensorexpr] Fix promotion of booleans**

Boolean arguments weren't promoted, so if you tried to write a comparison with
types such as `Tensor(Bool) == Int` you'd fail typechecking inside the TE
engine.

Differential Revision: [D23167926](https://our.internmc.facebook.com/intern/diff/D23167926)