### PR TITLE
Add Enum convert back to Python object support

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -59,7 +59,7 @@ bool operator==(const ivalue::EnumHolder& lhs, const ivalue::EnumHolder& rhs) {
 }
 
 const std::string ivalue::EnumHolder::qualifiedClassName() const {
-  return type_->qualifiedClassName().name();
+  return type_->qualifiedClassName().qualifiedName();
 }
 
 } // namespace ivalue

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -559,7 +559,7 @@ struct ivalue::EnumHolder : c10::intrusive_ptr_target {
       std::ostream& out,
       const EnumHolder& v);
 
-  const std::string qualifiedClassName() const;
+  CAFFE2_API const std::string qualifiedClassName() const;
 
   const std::string& name() const {
     return name_;

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/ivalue.h>
 #include <ATen/core/jit_type.h>
+#include <ATen/core/qualified_name.h>
 #include <ATen/core/stack.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -291,9 +292,9 @@ inline InferredType tryToInferType(py::handle input) {
   py::bool_ isEnumValue = py::isinstance(input, enum_type);
   if (py::cast<bool>(isEnumValue)) {
     auto enum_class = input.attr("__class__");
-    auto enum_type =
-        py::cast<TypePtr>(py::module::import("torch.jit.annotations")
-                              .attr("try_ann_to_type")(enum_class, py::none()));
+    auto enum_type = py::cast<TypePtr>(
+        py::module::import("torch.jit.annotations")
+            .attr("try_ann_to_type")(enum_class, SourceRange()));
     return InferredType(enum_type);
   }
 
@@ -822,6 +823,19 @@ inline IValue returnToIValue(const TypePtr& type, py::handle object) {
   }
 }
 
+inline py::object getScriptedClassOrError(const std::string& name) {
+  auto py_class = py::module::import("torch.jit._state")
+                      .attr("_get_script_class")(name.c_str());
+  if (py_class.is_none()) {
+    std::stringstream err;
+    err << "Unknown reference to ScriptClass ";
+    err << name;
+    err << ". (Did you forget to import it?)";
+    throw std::runtime_error(err.str());
+  }
+  return py_class;
+}
+
 inline py::object toPyObject(IValue ivalue) {
   if (ivalue.isNone()) {
     return py::none();
@@ -900,15 +914,7 @@ inline py::object toPyObject(IValue ivalue) {
     }
     const auto classType = pyCu->get_class(c10::QualifiedName(obj->name()));
     AT_ASSERT(classType);
-    auto pyClass = py::module::import("torch.jit._state")
-                       .attr("_get_script_class")(obj->name());
-    if (pyClass.is_none()) {
-      std::stringstream err;
-      err << "Unknown reference to ScriptClass ";
-      err << obj->name();
-      err << ". Did you forget to import it?)";
-      throw std::runtime_error(err.str());
-    }
+    auto pyClass = getScriptedClassOrError(obj->name());
     auto pyObj = pyClass.attr("__new__")(pyClass);
 
     const auto numAttrs = classType->numAttributes();
@@ -927,6 +933,12 @@ inline py::object toPyObject(IValue ivalue) {
     return py::cast(ivalue.toCapsule());
   } else if (ivalue.isFuture()) {
     return py::cast(std::make_shared<PythonFutureWrapper>(ivalue.toFuture()));
+  } else if (ivalue.isEnum()) {
+    auto enum_holder = ivalue.toEnumHolder();
+    auto qualified_class_name = enum_holder->qualifiedClassName();
+
+    auto py_class = getScriptedClassOrError(qualified_class_name);
+    return py_class.attr(enum_holder->name().c_str());
   } else if (ivalue.isRRef()) {
 #ifdef USE_DISTRIBUTED
     return py::cast(torch::distributed::rpc::PyRRef(

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -318,6 +318,8 @@ def try_ann_to_type(ann, loc):
             warnings.warn("Enum support is work in progress, enum class {}"
                           " is not compiled".format(ann))
             return None
+        if not hasattr(ann, "__torch_script_class__"):
+            torch.jit._script._recursive_compile_class(ann, loc)
         return EnumType(_qualified_name(ann), get_enum_value_type(ann, loc))
     if inspect.isclass(ann):
         if hasattr(ann, "__torch_script_class__"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43188 Enable Enum pickling/unpickling.
* #42963 Add Enum TorchScript serialization and deserialization support
* #42874 Fix enum constant printing and add FileCheck to all Enum tests
* **#43121 Add Enum convert back to Python object support**

Differential Revision: [D23222628](https://our.internmc.facebook.com/intern/diff/D23222628)