### PR TITLE
Easier way to write cross-platform (cpu and gpu) code

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -526,3 +526,10 @@ from ._vmap_internals import vmap
 # class usage. We add these lines here to preserve backward compatbility.
 quantized_lstm = torch.ops.aten.quantized_lstm
 quantized_gru = torch.ops.aten.quantized_gru
+
+# Set torch default device
+torch._default_device = 'cuda' if torch.cuda.is_available() else 'cpu'
+def to_device(self, *args, **kwargs):
+    return self.to(torch._default_device, *args, **kwargs)
+torch.Tensor.to_device = to_device
+torch.nn.Module.to_device = to_device


### PR DESCRIPTION
It is tedious to keep a record of device for every function for cross-platform codes. This PR aims to make writing cross-platform code easier. 

This PR also makes converting GPU-only codes and v0.3.1 codes to cross-platform codes easier. It may only requires to replace `.cuda()` to `.to_device()`.

0.4 and after version:

```python
# torch.device object used throughout this script
device = torch.device("cuda" if use_cuda else "cpu")

model = MyRNN().to(device)

# train
def train_epoch(train_loader, model, criterion, optimizer, epoch, device):
    total_loss = 0
    for input, target in train_loader:
        input, target = input.to(device), target.to(device)
        hidden = input.new_zeros(*h_shape)  # has the same device & dtype as `input`
        ...  # get loss and optimize
        total_loss += loss.item()           # get Python number from 1-element Tensor

# evaluate
@torch.no_grad():                       # operations inside don't track history
def val_epoch(val_loader, model, criterion, optimizer, epoch, device):
    for input, target in val_loader:
        ...
```

New version with .to_device() (**NO need to maintain and pass the device variable**)

```python
model = MyRNN().to_device()

# train
def train_epoch(train_loader, model, criterion, optimizer, epoch):
    total_loss = 0
    for input, target in train_loader:
        input, target = input.to_device(), target.to_device()
        hidden = input.new_zeros(*h_shape)  # has the same device & dtype as `input`
        ...  # get loss and optimize
        total_loss += loss.item()           # get Python number from 1-element Tensor

# evaluate
@torch.no_grad():                       # operations inside don't track history
def evaluate_epoch(val_loader, model, criterion, optimizer, epoch):
    for input, target in val_loader:
        ...
```

For the new version, to make it CPU-only, one may only need to remove `.to_device()`, to make it GPU-only, one may only need to change `.to_device()` to `.cuda()`. **For the reverse, it may be also true, by adding `.to_device()` or change `.cuda()` to `.to_device()`.**


