### PR TITLE
BUG: make cholesky_solve_out do broadcast, error checking

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -504,7 +504,7 @@ Tensor cholesky_solve(const Tensor& self, const Tensor& A, bool upper) {
 
 Tensor& cholesky_solve_out(Tensor& result, const Tensor& self, const Tensor& A, bool upper) {
   Tensor result_tmp;
-  result_tmp = at::_cholesky_solve_helper(self, A, upper);
+  result_tmp = at::cholesky_solve(self, A, upper);
   result.resize_as_(result_tmp).copy_(result_tmp);
   return result;
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8084,6 +8084,9 @@ class TestTorchDeviceType(TestCase):
             L = torch.cholesky(A, upper)
             x = torch.cholesky_solve(b, L, upper=upper)
             self.assertEqual(x, x_exp)
+            # issue gh-42695
+            x = torch.cholesky_solve(b, L, upper=upper, out=x)
+            self.assertEqual(x, x_exp)
 
         # test against numpy.linalg.solve
         for upper in [True, False]:


### PR DESCRIPTION
Fixes #42695 

test, fix `cholesky_solve_out` to use error checking and broadcasting from `cholesky_solve`. Test segfaults before, passes after the fix.
