### PR TITLE
observers: use clamp instead of min/max in calculate_qparams

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -269,8 +269,7 @@ class _ObserverBase(ObserverBase):
             scale = (max_val_pos - min_val_neg) / float(quant_max - quant_min)
             scale = torch.max(scale, self.eps)
             zero_point = quant_min - torch.round(min_val_neg / scale)
-            zero_point = torch.max(zero_point, torch.tensor(quant_min, device=device, dtype=zero_point.dtype))
-            zero_point = torch.min(zero_point, torch.tensor(quant_max, device=device, dtype=zero_point.dtype))
+            zero_point = torch.clamp(zero_point, quant_min, quant_max)
 
         # For scalar values, cast them to Tensors of size 1 to keep the shape
         # consistent with default values in FakeQuantize.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43151 observers: use torch.all to check for valid min and max values
* **#43150 observers: use clamp instead of min/max in calculate_qparams**
* #43149 observers: make eps a buffer
* #42956 quant bench: update observer configs

Summary:

The current logic was expensive because it created tensors on CUDA.
Switching to clamp since it can work without needing to create tensors.

yields a ~20% latency improvement on the CUDA microbenchmark for small tensors
(prev diff: P139074571, this diff: P139074706)

Test Plan:

benchmarks

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23170427](https://our.internmc.facebook.com/intern/diff/D23170427)