### PR TITLE
observers: use torch.all to check for valid min and max values

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -235,7 +235,7 @@ class _ObserverBase(ObserverBase):
                 min_val, max_val
             )
         else:
-            assert torch.sum(min_val <= max_val) == len(min_val), "min {} should be less than max {}".format(
+            assert torch.all(min_val <= max_val), "min {} should be less than max {}".format(
                 min_val, max_val
             )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43151 observers: use torch.all to check for valid min and max values**
* #43150 observers: use clamp instead of min/max in calculate_qparams
* #43149 observers: make eps a buffer
* #42956 quant bench: update observer configs

Summary:

Using `torch.all` instead of `torch.sum` and length check.

yields a ~20% latency improvement on per-channel CUDA microbenchmarks for small tensors
(prev diff: P139074706, this diff: P139074994)

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23170426](https://our.internmc.facebook.com/intern/diff/D23170426)