### PR TITLE
Pin VC++ version to 16.6

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -96,11 +96,14 @@ class WindowsJob:
 
 
 class VcSpec:
-    def __init__(self, year, version_elements=None):
+    def __init__(self, year, version_elements=None, hide_version=False):
         self.year = year
         self.version_elements = version_elements or []
+        self.hide_version = hide_version
 
     def get_elements(self):
+        if self.hide_version:
+            return [self.prefixed_year()]
         return [self.prefixed_year()] + self.version_elements
 
     def get_product(self):
@@ -113,7 +116,7 @@ class VcSpec:
         return "vs" + str(self.year)
 
     def render(self):
-        return "_".join(filter(None, [self.prefixed_year(), self.dotted_version()]))
+        return "_".join(self.get_elements())
 
 def FalsePred(_):
     return False
@@ -121,20 +124,23 @@ def FalsePred(_):
 def TruePred(_):
     return True
 
+# MKLDNN compilation fails with VC-19.27
+_VC2019 = VcSpec(2019, ["19", "26"], hide_version=True)
+
 WORKFLOW_DATA = [
     # VS2019 CUDA-10.1
-    WindowsJob(None, VcSpec(2019), CudaVersion(10, 1)),
-    WindowsJob(1, VcSpec(2019), CudaVersion(10, 1)),
-    WindowsJob(2, VcSpec(2019), CudaVersion(10, 1)),
+    WindowsJob(None, _VC2019, CudaVersion(10, 1)),
+    WindowsJob(1, _VC2019, CudaVersion(10, 1)),
+    WindowsJob(2, _VC2019, CudaVersion(10, 1)),
     # VS2019 CUDA-11.0
-    WindowsJob(None, VcSpec(2019), CudaVersion(11, 0)),
-    WindowsJob(1, VcSpec(2019), CudaVersion(11, 0)),
-    WindowsJob(2, VcSpec(2019), CudaVersion(11, 0)),
+    WindowsJob(None, _VC2019, CudaVersion(11, 0)),
+    WindowsJob(1, _VC2019, CudaVersion(11, 0)),
+    WindowsJob(2, _VC2019, CudaVersion(11, 0)),
     # VS2019 CPU-only
-    WindowsJob(None, VcSpec(2019), None),
-    WindowsJob(1, VcSpec(2019), None, master_only_pred=TruePred),
-    WindowsJob(2, VcSpec(2019), None, master_only_pred=TruePred),
-    WindowsJob(1, VcSpec(2019), CudaVersion(10, 1), force_on_cpu=True, master_only_pred=TruePred),
+    WindowsJob(None, _VC2019, None),
+    WindowsJob(1, _VC2019, None, master_only_pred=TruePred),
+    WindowsJob(2, _VC2019, None, master_only_pred=TruePred),
+    WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True, master_only_pred=TruePred),
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6329,7 +6329,7 @@ workflows:
           python_version: "3.6"
           use_cuda: "1"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
@@ -6342,7 +6342,7 @@ workflows:
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
@@ -6355,7 +6355,7 @@ workflows:
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
@@ -6364,7 +6364,7 @@ workflows:
           python_version: "3.6"
           use_cuda: "1"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
@@ -6377,7 +6377,7 @@ workflows:
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
@@ -6390,7 +6390,7 @@ workflows:
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cpu-py3
@@ -6399,7 +6399,7 @@ workflows:
           python_version: "3.6"
           use_cuda: "0"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
@@ -6417,7 +6417,7 @@ workflows:
           test_name: pytorch-windows-test1
           use_cuda: "0"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
@@ -6435,7 +6435,7 @@ workflows:
           test_name: pytorch-windows-test2
           use_cuda: "0"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
@@ -6453,7 +6453,7 @@ workflows:
           test_name: pytorch-windows-test1
           use_cuda: "0"
           vc_product: Community
-          vc_version: ""
+          vc_version: "19.26"
           vc_year: "2019"
       - update_s3_htmls:
           context: org-member


### PR DESCRIPTION
Because mkldnn triggers internal compiler error with 16.7, see  https://github.com/oneapi-src/oneDNN/issues/812


