### PR TITLE
Normalize loops with non-zero start.

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -225,6 +225,13 @@ namespace jit {
   _(UnrollEmpty)                            \
   _(NoUnroll)                               \
   _(UnrollWithLet)                          \
+  _(NormalizeStartPositive)                 \
+  _(NormalizeStartNegative)                 \
+  _(NormalizeStartZero)                     \
+  _(NormalizeStartVariable)                 \
+  _(NormalizeOnNestedOuterLoop)             \
+  _(NormalizeOnNestedInnerLoop)             \
+  _(NormalizeAndSplitWithTail)              \
   _(Kernel_1)                               \
   _(Kernel_2)                               \
   _(Kernel_3)                               \

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1204,6 +1204,40 @@ void LoopNest::unroll(For* f, Stmt** unrolled) {
   p->replace_stmt(f, *unrolled);
 }
 
+void LoopNest::normalize(For* f, For** normalized) {
+  if (!f) {
+    throw malformed_input("normalize attempted on null loop");
+  }
+  Block* p = dynamic_cast<Block*>(f->get_parent());
+  if (!p) {
+    throw malformed_input("normalize attempted on loop with no parent");
+  }
+
+  if (!f->start()->isConstant()) {
+    // Do not normalize when the loop start is not a constant.
+    *normalized = f;
+    return;
+  }
+
+  int start_idx = immediateAs<int>(f->start());
+  if (start_idx == 0) {
+    // No need to normalize in this case.
+    *normalized = f;
+    return;
+  }
+
+  auto for_body_normalized = Substitute(
+      Stmt::clone(f->body()),
+      {{f->var(), (VarHandle(f->var()) + ExprHandle(f->start())).node()}});
+  *normalized = For::make(
+      VarHandle(f->var()),
+      ExprHandle(0),
+      ExprHandle(f->stop()) - ExprHandle(f->start()),
+      for_body_normalized);
+
+  p->replace_stmt(f, *normalized);
+}
+
 std::vector<For*> LoopNest::getLoopStmtsFor(Tensor* t) const {
   std::vector<For*> result;
   Stmt* cur_stmt = tensor_to_stmt_.at(t);

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -40,6 +40,7 @@ class TORCH_API LoopNest {
   void splitWithMask(For* f, int factor, For** outer, For** inner);
   void reorderAxis(For* a, For* b);
   static void unroll(For* f, Stmt** unrolled);
+  static void normalize(For* f, For** normalized);
 
   void setGPUBlockIndex(For* f, int idx);
   void setGPUThreadIndex(For* f, int idx);


### PR DESCRIPTION
This diff normalizes for-loops that have non 0 loop starts to always start from 0. Given a for-loop, this normalization changes the loop start to be 0 and adjusts the loop end and all accesses to the index variable within the loop body appropriately. 

This diff also adds tests for several cases of normalization and also tests normalization in conjunction with `splitwithTail` transformation.