### PR TITLE
Add shape inference to SparseLengthsSumSparse ops

### DIFF
--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -138,6 +138,63 @@ TEST(BoundShapeInference, SparseLengthsSumFused8BitRowwise) {
       {spec.max_batch_size, 50});
 }
 
+TEST(BoundShapeInference, SparseLengthsSum8BitRowwiseSparse) {
+  NetDef net;
+  net.add_op()->CopyFrom(CreateOperatorDef(
+      "SparseLengthsSum8BitRowwiseSparse",
+      "",
+      {"Weights", "Data", "Lengths", "Mapping"},
+      {"Out"},
+      {}));
+  ShapeInfoMap shape_map;
+  shape_map.emplace(
+      "Weights",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1000, 58},
+          TensorProto_DataType_INT8));
+  shape_map.emplace(
+      "Mapping",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT},
+          {2000},
+          TensorProto_DataType_INT32));
+  BoundShapeSpec spec(20, 1000);
+  BoundShapeInferencer eng(spec);
+  eng.InferBoundShapeAndType(net, shape_map, nullptr);
+  const auto& out_shape = eng.shape_info();
+  verifyShapeInfo(
+      out_shape,
+      "Weights",
+      {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
+      {1000, 58},
+      TensorProto_DataType_INT8);
+  verifyShapeInfo(
+      out_shape,
+      "Mapping",
+      {TensorBoundShape_DimType_CONSTANT},
+      {2000},
+      TensorProto_DataType_INT32);
+  verifyShapeInfo(
+      out_shape,
+      "Data",
+      {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
+      {spec.max_batch_size * spec.max_seq_size},
+      TensorProto_DataType_INT64);
+  verifyShapeInfo(
+      out_shape,
+      "Lengths",
+      {TensorBoundShape_DimType_BATCH},
+      {spec.max_batch_size},
+      TensorProto_DataType_INT32);
+  verifyShapeInfo(
+      out_shape,
+      "Out",
+      {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
+      {spec.max_batch_size, 50});
+}
+
 TEST(BoundShapeInference, SparseLengthsSumFused4BitRowwise) {
   NetDef net;
   net.add_op()->CopyFrom(CreateOperatorDef(

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -123,12 +123,18 @@ void BoundShapeInferencer::Initialize(
 void BoundShapeInferencer::InferOps(
     const OperatorDef& op,
     caffe2::Workspace* /* ws */) {
-  if (op.type() == "SparseLengthsSum" ||
-      op.type() == "SparseLengthsSumFused8BitRowwise" ||
-      op.type() == "SparseLengthsWeightedSum" ||
-      op.type() == "SparseLengthsWeightedSumFused8BitRowwise" ||
-      op.type() == "SparseLengthsSumFused4BitRowwise" ||
-      op.type() == "SparseLengthsWeightedSumFused4BitRowwise") {
+  const static std::unordered_set<std::string> kSlsOps = {
+      "SparseLengthsSum",
+      "SparseLengthsSumFused8BitRowwise",
+      "SparseLengthsWeightedSum",
+      "SparseLengthsWeightedSumFused8BitRowwise",
+      "SparseLengthsSumFused4BitRowwise",
+      "SparseLengthsWeightedSumFused4BitRowwise",
+      "SparseLengthsSum4BitRowwiseSparse",
+      "SparseLengthsWeightedSum4BitRowwiseSparse",
+      "SparseLengthsSum8BitRowwiseSparse",
+      "SparseLengthsWeightedSum8BitRowwiseSparse"};
+  if (kSlsOps.count(op.type())) {
     InferSparseLengthsSum(op);
   } else if (op.type() == "Add" || op.type() == "Mul") {
     InferElementwiseOp(op);
@@ -348,18 +354,32 @@ void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
       op.input(0),
       "needs to be 2D");
 
-  int weight = (op.type() == "SparseLengthsWeightedSum" ||
-                op.type() == "SparseLengthsWeightedSumFused8BitRowwise" ||
-                op.type() == "SparseLengthsWeightedSumFused4BitRowwise")
+  const int weight =
+      (op.type() == "SparseLengthsWeightedSum" ||
+       op.type() == "SparseLengthsWeightedSumFused8BitRowwise" ||
+       op.type() == "SparseLengthsWeightedSumFused4BitRowwise" ||
+       op.type() == "SparseLengthsWeightedSum4BitRowwiseSparse" ||
+       op.type() == "SparseLengthsWeightedSum8BitRowwiseSparse")
       ? 1
       : 0;
 
-  const bool is4bit = op.type() == "SparseLengthsSumFused4BitRowwise" ||
-      op.type() == "SparseLengthsWeightedSumFused4BitRowwise";
+  const bool is4bit =
+      (op.type() == "SparseLengthsSumFused4BitRowwise" ||
+       op.type() == "SparseLengthsWeightedSumFused4BitRowwise" ||
+       op.type() == "SparseLengthsWeightedSum4BitRowwiseSparse" ||
+       op.type() == "SparseLengthsSum4BitRowwiseSparse");
+
+  const bool isSparse =
+      (op.type() == "SparseLengthsSum4BitRowwiseSparse" ||
+       op.type() == "SparseLengthsWeightedSum4BitRowwiseSparse" ||
+       op.type() == "SparseLengthsSum8BitRowwiseSparse" ||
+       op.type() == "SparseLengthsWeightedSum8BitRowwiseSparse");
 
   if (weight) {
-    CAFFE_ENFORCE_EQ(
-        op.input_size(), 4, "SparseLengthsWeightedSum must have 4 inputs");
+    CAFFE_ENFORCE_GE(
+        op.input_size(),
+        4,
+        "SparseLengthsWeightedSum(Sparse) must have 4 or 5 inputs");
     SetTensorBoundShapeIfNotExist(
         op.input(weight),
         {TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT},
@@ -382,6 +402,15 @@ void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
       TensorProto_DataType_INT32,
       false);
 
+  if (isSparse) {
+    const auto mit = shape_info_.find(op.input(3 + weight));
+    CAFFE_ENFORCE(
+        mit != shape_info_.end(),
+        "Shape of COMPRESSED_INDICES_MAPPING input of SparseLengthsSumSparse ",
+        op.input(3 + weight),
+        " needs to be presented");
+  }
+
   // Infer output
   CAFFE_ENFORCE_EQ(it->second.shape.dims_size(), 2);
   current_dim_type_ = TensorBoundShape_DimType_BATCH;
@@ -390,7 +419,9 @@ void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {
   // If the op is SparseLengthsSumFused8BitRowwise, we need to extract 4 bytes
   // for fp32 scale and 4 bytes for fp32 bias (https://fburl.com/t6dp9tsc)
   if (op.type() == "SparseLengthsSumFused8BitRowwise" ||
-      op.type() == "SparseLengthsWeightedSumFused8BitRowwise") {
+      op.type() == "SparseLengthsWeightedSumFused8BitRowwise" ||
+      op.type() == "SparseLengthsSum8BitRowwiseSparse" ||
+      op.type() == "SparseLengthsWeightedSum8BitRowwiseSparse") {
     output_dim1 -= 8;
   }
   // If the op is SparseLengthsSumFused4BitRowwise, we need to extract 2 bytes

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -639,7 +639,7 @@ void splitSparseLengthsSumSparse(NetDef* net, const Workspace& ws) {
       {"SparseLengthsSum4BitRowwiseSparse", "SparseLengthsSumFused4BitRowwise"},
       {"SparseLengthsWeightedSum4BitRowwiseSparse",
        "SparseLengthsWeightedSumFused4BitRowwise"},
-      {"SparseLengthsSum8BitRowwiseSparse", "SparseLengthsSum8FusedBitRowwise"},
+      {"SparseLengthsSum8BitRowwiseSparse", "SparseLengthsSumFused8BitRowwise"},
       {"SparseLengthsWeightedSum8BitRowwiseSparse",
        "SparseLengthsWeightedSumFused8BitRowwise"},
       {"SparseLengthsSum2BitRowwiseSparse", "SparseLengthsSumFused2BitRowwise"},

--- a/caffe2/opt/split_slss_test.cc
+++ b/caffe2/opt/split_slss_test.cc
@@ -38,7 +38,7 @@ void check(
       {"SparseLengthsSum4BitRowwiseSparse", "SparseLengthsSumFused4BitRowwise"},
       {"SparseLengthsWeightedSum4BitRowwiseSparse",
        "SparseLengthsWeightedSumFused4BitRowwise"},
-      {"SparseLengthsSum8BitRowwiseSparse", "SparseLengthsSum8FusedBitRowwise"},
+      {"SparseLengthsSum8BitRowwiseSparse", "SparseLengthsSumFused8BitRowwise"},
       {"SparseLengthsWeightedSum8BitRowwiseSparse",
        "SparseLengthsWeightedSumFused8BitRowwise"},
       {"SparseLengthsSum2BitRowwiseSparse", "SparseLengthsSumFused2BitRowwise"},


### PR DESCRIPTION
Summary: att

Test Plan:
```
buck test caffe2/caffe2/opt:bound_shape_inference_test
```

Differential Revision: D23097145

