### PR TITLE
[jit][static] Replace deepcopy with copy

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -54,7 +54,7 @@ static auto reg =
   F(prim::TupleConstruct)
 
 StaticRuntime::StaticRuntime(const torch::jit::Module& m)
-    : module_(m.deepcopy()), graph_(nullptr) {
+    : module_(m.copy()), graph_(nullptr) {
   module_.eval();
   module_ = freeze_module(module_);
   graph_ = module_.get_method("forward").graph();


### PR DESCRIPTION
Summary:
We should avoid using `deepcopy` on the module because it involves copying the weights.

Comparing the implementation of `c10::ivalue::Object::copy()` vs ``c10::ivalue::Object::deepcopy()`, the only difference is `deepcopy` copies the attributes (slots) while `copy` does not.

Differential Revision: D23171770

