### PR TITLE
Enable Enum pickling/unpickling.

### DIFF
--- a/test/jit/test_enum.py
+++ b/test/jit/test_enum.py
@@ -265,9 +265,7 @@ class TestEnum(JitTestCase):
                 return self.e.value
 
         m = TestModule(Color.RED)
-        # TODO(gmagogsfm): Re-enable hooks when Enum attr pickling is supported.
-        with torch._jit_internal._disable_emit_hooks():
-            scripted = torch.jit.script(m)
+        scripted = torch.jit.script(m)
 
         FileCheck() \
             .check("TestModule") \
@@ -312,10 +310,7 @@ class TestEnum(JitTestCase):
                 return self.e
 
         m = TestModule(Color.RED)
-
-        # TODO(gmagogsfm): Re-enable hooks when Enum attr pickling is supported.
-        with torch._jit_internal._disable_emit_hooks():
-            scripted = torch.jit.script(m)
+        scripted = torch.jit.script(m)
 
         FileCheck() \
             .check("TestModule") \

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -139,6 +139,13 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
     TORCH_CHECK(
         false, "RRef pickling is only supported with the distributed package");
 #endif
+  } else if (ivalue.isEnum()) {
+    auto enum_holder = ivalue.toEnumHolder();
+    const auto& qualified_class_name =
+        enum_holder->type()->qualifiedClassName();
+    pushGlobal(qualified_class_name.prefix(), qualified_class_name.name());
+    pushIValue(enum_holder->value());
+    push<PickleOpCode>(PickleOpCode::REDUCE);
   } else {
     AT_ERROR("Unknown IValue type for pickling: ", ivalue.tagKind());
   }

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -593,12 +593,28 @@ void Unpickler::readGlobal(
     AT_ASSERT(type_resolver_);
     at::StrongTypePtr type =
         type_resolver_(c10::QualifiedName(module_name, class_name));
-    globals_.emplace_back([this, type] {
-      auto val = stack_.back();
-      stack_.pop_back();
-      auto obj = obj_loader_(type, val);
-      stack_.emplace_back(std::move(obj));
-    });
+    if (auto enum_type = type.type_->cast<c10::EnumType>()) {
+      globals_.emplace_back([this, enum_type] {
+        auto val = stack_.back();
+        stack_.pop_back();
+        for (const auto& p : enum_type->enumNamesValues()) {
+          if (p.second == val) {
+            auto enum_holder = c10::make_intrusive<at::ivalue::EnumHolder>(
+                enum_type, p.first, p.second);
+            stack_.emplace_back(std::move(enum_holder));
+            return;
+          }
+        }
+      });
+    } else {
+      // Otherwise, global is a class/object type.
+      globals_.emplace_back([this, type] {
+        auto val = stack_.back();
+        stack_.pop_back();
+        auto obj = obj_loader_(type, val);
+        stack_.emplace_back(std::move(obj));
+      });
+    }
   }
   stack_.emplace_back(int64_t(globals_.size() - 1));
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43188 Enable Enum pickling/unpickling.**
* #42963 Add Enum TorchScript serialization and deserialization support
* #42874 Fix enum constant printing and add FileCheck to all Enum tests
* #43121 Add Enum convert back to Python object support

