### PR TITLE
Fix complex asin, acos

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -173,24 +173,7 @@ public:
     AT_ERROR("not supported for complex numbers");
   }
   Vec256<c10::complex<double>> asin() const {
-    // asin(x)
-    // = -i*ln(iz + sqrt(1 -z^2))
-    // = -i*ln((ai - b) + sqrt(1 - (a + bi)*(a + bi)))
-    // = -i*ln((-b + ai) + sqrt(1 - (a**2 - b**2) - 2*abi))
-    const __m256d one = _mm256_set1_pd(1);
-
-    auto conj = conj_();
-    auto b_a = _mm256_permute_pd(conj, 0x05);                         //-b        a
-    auto ab = _mm256_mul_pd(conj, b_a);                               //-ab       -ab
-    auto im = _mm256_add_pd(ab, ab);                                  //-2ab      -2ab
-
-    auto val_2 = _mm256_mul_pd(values, values);                       // a*a      b*b
-    auto re = _mm256_hsub_pd(val_2, _mm256_permute_pd(val_2, 0x05));  // a*a-b*b  b*b-a*a
-    re = _mm256_sub_pd(one, re);
-
-    auto root = Vec256(_mm256_blend_pd(re, im, 0x0A)).sqrt();         //sqrt(re + i*im)
-    auto ln = Vec256(_mm256_add_pd(b_a, root)).log();                 //ln(iz + sqrt())
-    return Vec256(_mm256_permute_pd(ln.values, 0x05)).conj();         //-i*ln()
+    return map(std::asin);
   }
   Vec256<c10::complex<double>> acos() const {
     // acos(x) = pi/2 - asin(x)

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -210,25 +210,7 @@ public:
     AT_ERROR("not supported for complex numbers");
   }
   Vec256<c10::complex<float>> asin() const {
-    // asin(x)
-    // = -i*ln(iz + sqrt(1 -z^2))
-    // = -i*ln((ai - b) + sqrt(1 - (a + bi)*(a + bi)))
-    // = -i*ln((-b + ai) + sqrt(1 - (a**2 - b**2) - 2*abi))
-    const __m256 one = _mm256_set1_ps(1);
-
-    auto conj = conj_();
-    auto b_a = _mm256_permute_ps(conj, 0xB1);                         //-b        a
-    auto ab = _mm256_mul_ps(conj, b_a);                               //-ab       -ab
-    auto im = _mm256_add_ps(ab, ab);                                  //-2ab      -2ab
-
-    auto val_2 = _mm256_mul_ps(values, values);                       // a*a      b*b
-    auto re = _mm256_hsub_ps(val_2, _mm256_permute_ps(val_2, 0xB1));  // a*a-b*b  b*b-a*a
-    re = _mm256_permute_ps(re, 0xD8);
-    re = _mm256_sub_ps(one, re);
-
-    auto root = Vec256(_mm256_blend_ps(re, im, 0xAA)).sqrt();         //sqrt(re + i*im)
-    auto ln = Vec256(_mm256_add_ps(b_a, root)).log();                 //ln(iz + sqrt())
-    return Vec256(_mm256_permute_ps(ln.values, 0xB1)).conj();         //-i*ln()
+    return map(std::asin);
   }
   Vec256<c10::complex<float>> acos() const {
     // acos(x) = pi/2 - asin(x)


### PR DESCRIPTION
Fixes #42952, will cause a conflict with #42965 

PR #28735 added vec256 implementation for many functions, among them complex `asin` and `acos`. The complex implementations were never tested. I removed the local implementation of `asin` in favor of the one from `map(std::asin)`, which I am pretty sure uses the glibc function.

I added a test into this PR by hacking the existing one, mainly for verification, and while it now is approximately correct, it still requires a bit of wiggle room to compare to numpy results on my machine (Ubuntu 20.04 with glibc 2.31). PR #42965 is a much more complete rewrite of the tests, so mine should go away when that is merged.