### PR TITLE
Implement Tensor.to batching rule

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -322,7 +322,7 @@ TORCH_LIBRARY_IMPL(aten, Batched, m) {
   { \
     using to_type = Tensor(Tensor::*)(__VA_ARGS__) const; \
     m.impl(name, unary_pointwise_method_batching_rule< \
-        to_type, static_cast<to_type>(&Tensor::to), __VA_ARGS__>);\
+        to_type, &Tensor::to, __VA_ARGS__>);\
   }
   TO_BATCHING_RULE("to.device", Device, ScalarType, bool, bool, optional<MemoryFormat>)
   TO_BATCHING_RULE("to.dtype", ScalarType, bool, bool, optional<MemoryFormat>)

--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -234,6 +234,14 @@ Tensor unary_pointwise_batching_rule(const Tensor& input) {
   return makeBatched(output_physical, BatchDims(old_bdims.begin(), old_bdims.end()));
 }
 
+template <typename F, F Func, typename... ExtraArgs>
+Tensor unary_pointwise_method_batching_rule(const Tensor& input, ExtraArgs... extra_args) {
+  auto* input_batched = unsafeGetBatchedImpl(input);
+  auto output_physical = (input_batched->value().*Func)(extra_args...);
+  auto old_bdims = input_batched->bdims();
+  return makeBatched(output_physical, BatchDims(old_bdims.begin(), old_bdims.end()));
+}
+
 TORCH_LIBRARY_IMPL(_, Batched, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&batchedTensorForLoopFallback>());
 }
@@ -310,6 +318,16 @@ TORCH_LIBRARY_IMPL(aten, Batched, m) {
   UNARY_POINTWISE(tanh);
   UNARY_POINTWISE(trunc);
 #undef UNARY_POINTWISE
+#define TO_BATCHING_RULE(name, ...) \
+  { \
+    using to_type = Tensor(Tensor::*)(__VA_ARGS__) const; \
+    m.impl(name, unary_pointwise_method_batching_rule< \
+        to_type, static_cast<to_type>(&Tensor::to), __VA_ARGS__>);\
+  }
+  TO_BATCHING_RULE("to.device", Device, ScalarType, bool, bool, optional<MemoryFormat>)
+  TO_BATCHING_RULE("to.dtype", ScalarType, bool, bool, optional<MemoryFormat>)
+  TO_BATCHING_RULE("to.other", const Tensor&, bool, bool, optional<MemoryFormat>)
+#undef TO_BATCHING_RULE
 }
 
 } // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43218 vmap: Fix bug with x * 0.1
* **#43206 Implement Tensor.to batching rule**

The batching rule is the same as the unary pointwise batching rules:
given a BatchedTensor, we unwrap it, call Tensor.to, and then re-wrap
it.

Test Plan:
- `pytest test/test_vmap.py -v -k`

Differential Revision: [D23189053](https://our.internmc.facebook.com/intern/diff/D23189053)