### PR TITLE
Add dataclasses to base Docker images.

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -74,9 +74,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   if [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
     # DO NOT install typing if installing python-3.8, since its part of python-3.8 core packages
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    conda_install numpy=1.18.5 pyyaml mkl mkl-include setuptools cffi future six llvmdev=8.0.0
+    conda_install numpy=1.18.5 pyyaml mkl mkl-include setuptools cffi future six llvmdev=8.0.0 dataclasses
   else
-    conda_install numpy=1.18.5 pyyaml mkl mkl-include setuptools cffi typing future six
+    conda_install numpy=1.18.5 pyyaml mkl mkl-include setuptools cffi typing future six dataclasses
   fi
   if [[ "$CUDA_VERSION" == 9.2* ]]; then
     conda_install magma-cuda92 -c pytorch

--- a/.circleci/docker/common/install_travis_python.sh
+++ b/.circleci/docker/common/install_travis_python.sh
@@ -57,7 +57,8 @@ if [ -n "$TRAVIS_PYTHON_VERSION" ]; then
       protobuf \
       pytest \
       pillow \
-      typing
+      typing \
+      dataclasses
 
   as_jenkins pip install mkl mkl-devel
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43217 Add dataclasses to base Docker images.**

Dataclasses is part of standard library in Python 3.7 and there
is a backport for it in Python 3.6.  Our code generation will
start using it, so add it to the default library set.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D23214028](https://our.internmc.facebook.com/intern/diff/D23214028)