### PR TITLE
patch enum class as hash key for gcc 5.4

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -107,7 +107,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
       {fusion_.inputs().begin(), fusion_.inputs().end()}, fusion_.outputs());
 
   // Lets collect all IterDomains that are bound to a thread binding
-  std::unordered_map<ParallelType, std::vector<IterDomain*>, TypeHash>
+  std::unordered_map<ParallelType, std::vector<IterDomain*>>
       parallel_iter_domains;
 
   for (auto val : unordered_vals) {

--- a/torch/csrc/jit/codegen/cuda/fusion.h
+++ b/torch/csrc/jit/codegen/cuda/fusion.h
@@ -14,14 +14,6 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
-// https://stackoverflow.com/questions/18837857/cant-use-enum-class-as-unordered-map-key
-struct TypeHash {
-  template <typename T>
-  std::size_t operator()(T t) const {
-    return static_cast<std::size_t>(t);
-  }
-};
-
 /*
  * Usage: FusionGuard and Fusion are required user interfaces for any operation
  * underlying the code generator. In order to create values, expressions, and
@@ -241,7 +233,7 @@ class TORCH_CUDA_API Fusion final {
   std::unordered_set<Expr*> expr_set_;
 
   // Values names counters
-  std::unordered_map<ValType, StmtNameType, TypeHash> val_type_name_map_;
+  std::unordered_map<ValType, StmtNameType> val_type_name_map_;
 
   // Expression names counter
   StmtNameType expr_name_counter_ = 0;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -277,9 +277,9 @@ std::vector<IterDomain*> ReductionOp::getReductionDomains() const {
   return vec_domain;
 }
 
-std::unordered_map<ParallelType, IterDomain*, TypeHash> ReductionOp::
+std::unordered_map<ParallelType, IterDomain*> ReductionOp::
     getParallelReductionDomains() const {
-  std::unordered_map<ParallelType, IterDomain*, TypeHash> parallel_domains;
+  std::unordered_map<ParallelType, IterDomain*> parallel_domains;
   for (auto d : getReductionDomains()) {
     if (d->isThread()) {
       parallel_domains.insert(std::make_pair(d->getParallelType(), d));

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -436,8 +436,8 @@ class TORCH_CUDA_API ReductionOp : public Expr {
     return reduction_op_type_;
   }
 
-  std::unordered_map<ParallelType, IterDomain*, TypeHash>
-  getParallelReductionDomains() const;
+  std::unordered_map<ParallelType, IterDomain*> getParallelReductionDomains()
+      const;
 
  private:
   std::vector<IterDomain*> getReductionDomains() const;

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -195,3 +195,30 @@ enum class LaunchConfigType {
 } // namespace fuser
 } // namespace jit
 } // namespace torch
+
+namespace std {
+
+// https://stackoverflow.com/questions/18837857/cant-use-enum-class-as-unordered-map-key
+// patching gcc 5.4 hash for enum class
+#define HASH_ENUM_CLASS(enum_class)                              \
+  template <>                                                    \
+  struct hash<torch::jit::fuser::enum_class> {                   \
+    size_t operator()(torch::jit::fuser::enum_class key) const { \
+      return std::hash<uint32_t>()(static_cast<uint32_t>(key));  \
+    }                                                            \
+  };
+
+HASH_ENUM_CLASS(ValType)
+HASH_ENUM_CLASS(DataType)
+HASH_ENUM_CLASS(ExprType)
+HASH_ENUM_CLASS(UnaryOpType)
+HASH_ENUM_CLASS(BinaryOpType)
+HASH_ENUM_CLASS(TernaryOpType)
+HASH_ENUM_CLASS(ParallelType)
+HASH_ENUM_CLASS(MemoryType)
+HASH_ENUM_CLASS(IterType)
+HASH_ENUM_CLASS(LaunchConfigType)
+
+#undef HASH_ENUM_CLASS
+
+} // namespace std

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -196,6 +196,7 @@ enum class LaunchConfigType {
 } // namespace jit
 } // namespace torch
 
+#if defined(__GNUC__) && __GNUC__ < 6
 namespace std {
 
 // https://stackoverflow.com/questions/18837857/cant-use-enum-class-as-unordered-map-key
@@ -222,3 +223,4 @@ HASH_ENUM_CLASS(LaunchConfigType)
 #undef HASH_ENUM_CLASS
 
 } // namespace std
+#endif


### PR DESCRIPTION
Fixes #43129 

where gcc doesn't support hash of enum class.