### PR TITLE
[rfc] temporary custom pickle functions for maintaining BC on ConvPackedParams

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -227,71 +227,71 @@ CAFFE2_API torch::class_<ConvPackedParamsBase<kSpatialDim>> register_conv_params
         [](c10::IValue v)
         -> c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> { // __setstate__
 
-					// determine the version based on IValue contents
-					int version = -1;
-					if (v.isTuple()) {
-						auto elements = v.toTuple()->elements();
-						if (elements.size() > 0) {
-							auto firstElement = elements[0];
-							// TODO before land: stronger checks
-							if (firstElement.isTensor()) {
-								version = 1;
-							} else if (firstElement.isString()) {
-								version = 2;
-							}
-						}
-					}
-					TORCH_INTERNAL_ASSERT(version != -1, "Unable to parse serialization version");
+          // determine the version based on IValue contents
+          int version = -1;
+          if (v.isTuple()) {
+            auto elements = v.toTuple()->elements();
+            if (elements.size() > 0) {
+              auto firstElement = elements[0];
+              // TODO before land: stronger checks
+              if (firstElement.isTensor()) {
+                version = 1;
+              } else if (firstElement.isString()) {
+                version = 2;
+              }
+            }
+          }
+          TORCH_INTERNAL_ASSERT(version != -1, "Unable to parse serialization version");
 
           SerializationType state;
 
-					if (version == 1) {
-						// version 1 - convert to version 2 manually
+          if (version == 1) {
+            // version 1 - convert to version 2 manually
 
-						auto elements = v.toTuple()->elements();
+            auto elements = v.toTuple()->elements();
 
-						at::Tensor weight = elements[0].toTensor();
-						// TODO before land: test optional bias
-						c10::optional<at::Tensor> bias = elements[1].toTensor();
-						torch::List<at::Tensor> stride_x_kSpatialDim = elements[2].toTensorList();
-						torch::List<at::Tensor> padding_x_kSpatialDim = elements[3].toTensorList();
-						torch::List<at::Tensor> dilation_x_kSpatialDim = elements[4].toTensorList();
-						at::Tensor groups = elements[5].toTensor();
+            at::Tensor weight = elements[0].toTensor();
+            // TODO before land: test optional bias
+            c10::optional<at::Tensor> bias = elements[1].toTensor();
+            torch::List<at::Tensor> stride_x_kSpatialDim = elements[2].toTensorList();
+            torch::List<at::Tensor> padding_x_kSpatialDim = elements[3].toTensorList();
+            torch::List<at::Tensor> dilation_x_kSpatialDim = elements[4].toTensorList();
+            at::Tensor groups = elements[5].toTensor();
 
-						// create a v2 object with data from v1
-						// TODO before land: clean up everything (this is just the first version which worked)
-						std::string name_v2 = "conv";
-						int64_t version_v2 = 2;
-						std::vector<at::Tensor> required_tensors_v2;
-						required_tensors_v2.push_back(weight);
-						std::vector<c10::optional<at::Tensor>> optional_tensors_v2;
-						optional_tensors_v2.push_back(bias);
-						std::vector<double> doubles_v2;
-						std::vector<int64_t> ints_v2;
-						int64_t spatialDim = stride_x_kSpatialDim.size();
-						ints_v2.push_back(spatialDim);
-						for (int i = 0; i < stride_x_kSpatialDim.size(); i++) {
-							auto stride = stride_x_kSpatialDim.get(0);
-							ints_v2.push_back(stride[0].item<int64_t>());
-						}
-						for (int i = 0; i < padding_x_kSpatialDim.size(); i++) {
-							auto padding = padding_x_kSpatialDim.get(0);
-							ints_v2.push_back(padding[0].item<int64_t>());
-						}
-						for (int i = 0; i < dilation_x_kSpatialDim.size(); i++) {
-							auto dilation = dilation_x_kSpatialDim.get(0);
-							ints_v2.push_back(dilation[0].item<int64_t>());
-						}
+            // create a v2 object with data from v1
+            // TODO before land: clean up everything (this is just the first version which worked)
+            std::string name_v2 = "conv";
+            int64_t version_v2 = 2;
+            std::vector<at::Tensor> required_tensors_v2;
+            required_tensors_v2.push_back(weight);
+            std::vector<c10::optional<at::Tensor>> optional_tensors_v2;
+            optional_tensors_v2.push_back(bias);
+            std::vector<double> doubles_v2;
+            std::vector<int64_t> ints_v2;
+            int64_t spatialDim = stride_x_kSpatialDim.size();
+            ints_v2.push_back(spatialDim);
+            for (int i = 0; i < stride_x_kSpatialDim.size(); i++) {
+              auto stride = stride_x_kSpatialDim.get(0);
+              ints_v2.push_back(stride[0].item<int64_t>());
+            }
+            for (int i = 0; i < padding_x_kSpatialDim.size(); i++) {
+              auto padding = padding_x_kSpatialDim.get(0);
+              ints_v2.push_back(padding[0].item<int64_t>());
+            }
+            for (int i = 0; i < dilation_x_kSpatialDim.size(); i++) {
+              auto dilation = dilation_x_kSpatialDim.get(0);
+              ints_v2.push_back(dilation[0].item<int64_t>());
+            }
 
-						// TODO before land: check numerical equivalency with tests
-						state = std::make_tuple(name_v2, version_v2, required_tensors_v2, optional_tensors_v2,
-								doubles_v2, ints_v2);
+            // TODO before land: check numerical equivalency with tests
+            state = std::make_tuple(name_v2, version_v2, required_tensors_v2, optional_tensors_v2,
+                doubles_v2, ints_v2);
 
-					} else {
+          } else {
 
-						// version 2 - return the value as is
+            // version 2 - return the value as is
             // TODO(before land): implement the conversion from v2 c10::IValue to SerializationType
-					}
+          }
 
           return deserialize_conv<kSpatialDim>(state);
         })

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -217,13 +217,82 @@ CAFFE2_API torch::class_<ConvPackedParamsBase<kSpatialDim>> register_conv_params
   static auto register_conv_params =
     torch::class_<ConvPackedParamsBase<kSpatialDim>>(
         "quantized", "Conv" + c10::to_string(kSpatialDim) + "dPackedParamsBase")
-    .def_pickle(
+    // TODO(before land): document the hack and add a deprecation date
+    .def_pickle_unboxed_DO_NOT_USE(
         [](const c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>>& params)
         -> SerializationType { // __getstate__
           return serialize_conv<kSpatialDim>(params);
         },
-        [](SerializationType state)
+        // TODO(before land): document everything well
+        [](c10::IValue v)
         -> c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> { // __setstate__
+
+					// determine the version based on IValue contents
+					int version = -1;
+					if (v.isTuple()) {
+						auto elements = v.toTuple()->elements();
+						if (elements.size() > 0) {
+							auto firstElement = elements[0];
+							// TODO before land: stronger checks
+							if (firstElement.isTensor()) {
+								version = 1;
+							} else if (firstElement.isString()) {
+								version = 2;
+							}
+						}
+					}
+					TORCH_INTERNAL_ASSERT(version != -1, "Unable to parse serialization version");
+
+          SerializationType state;
+
+					if (version == 1) {
+						// version 1 - convert to version 2 manually
+
+						auto elements = v.toTuple()->elements();
+
+						at::Tensor weight = elements[0].toTensor();
+						// TODO before land: test optional bias
+						c10::optional<at::Tensor> bias = elements[1].toTensor();
+						torch::List<at::Tensor> stride_x_kSpatialDim = elements[2].toTensorList();
+						torch::List<at::Tensor> padding_x_kSpatialDim = elements[3].toTensorList();
+						torch::List<at::Tensor> dilation_x_kSpatialDim = elements[4].toTensorList();
+						at::Tensor groups = elements[5].toTensor();
+
+						// create a v2 object with data from v1
+						// TODO before land: clean up everything (this is just the first version which worked)
+						std::string name_v2 = "conv";
+						int64_t version_v2 = 2;
+						std::vector<at::Tensor> required_tensors_v2;
+						required_tensors_v2.push_back(weight);
+						std::vector<c10::optional<at::Tensor>> optional_tensors_v2;
+						optional_tensors_v2.push_back(bias);
+						std::vector<double> doubles_v2;
+						std::vector<int64_t> ints_v2;
+						int64_t spatialDim = stride_x_kSpatialDim.size();
+						ints_v2.push_back(spatialDim);
+						for (int i = 0; i < stride_x_kSpatialDim.size(); i++) {
+							auto stride = stride_x_kSpatialDim.get(0);
+							ints_v2.push_back(stride[0].item<int64_t>());
+						}
+						for (int i = 0; i < padding_x_kSpatialDim.size(); i++) {
+							auto padding = padding_x_kSpatialDim.get(0);
+							ints_v2.push_back(padding[0].item<int64_t>());
+						}
+						for (int i = 0; i < dilation_x_kSpatialDim.size(); i++) {
+							auto dilation = dilation_x_kSpatialDim.get(0);
+							ints_v2.push_back(dilation[0].item<int64_t>());
+						}
+
+						// TODO before land: check numerical equivalency with tests
+						state = std::make_tuple(name_v2, version_v2, required_tensors_v2, optional_tensors_v2,
+								doubles_v2, ints_v2);
+
+					} else {
+
+						// version 2 - return the value as is
+            // TODO(before land): implement the conversion from v2 c10::IValue to SerializationType
+					}
+
           return deserialize_conv<kSpatialDim>(state);
         })
     .def("weight", [](const c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>>& self) {

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -218,7 +218,7 @@ CAFFE2_API torch::class_<ConvPackedParamsBase<kSpatialDim>> register_conv_params
     torch::class_<ConvPackedParamsBase<kSpatialDim>>(
         "quantized", "Conv" + c10::to_string(kSpatialDim) + "dPackedParamsBase")
     // TODO(before land): document the hack and add a deprecation date
-    .def_pickle_unboxed_DO_NOT_USE(
+    .def_pickle_setstate_boxed_DO_NOT_USE(
         [](const c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>>& params)
         -> SerializationType { // __getstate__
           return serialize_conv<kSpatialDim>(params);

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -221,6 +221,82 @@ class class_ {
     return *this;
   }
 
+  // This is a temporary hack to change the format of ConvPackedParams without
+  // breaking BC. We modify the default pickle protocol by defining a boxed
+  // version of __set_state__, which knows how to parse historical formats.
+  // TODO(before land): create an issue to delete this in a month and link here.
+  template <typename GetStateFn, typename SetStateFn>
+  class_& def_pickle_unboxed_DO_NOT_USE(
+      GetStateFn&& get_state, SetStateFn&& set_state) {
+    // Note: most of this code is copy-pasta from def_pickle
+    // TODO(before land): if this approach gets consensus, potentially reuse
+    //   more things.
+    static_assert(
+        c10::guts::is_stateless_lambda<std::decay_t<GetStateFn>>::value &&
+            c10::guts::is_stateless_lambda<std::decay_t<SetStateFn>>::value,
+        "def_pickle() currently only supports lambdas as "
+        "__getstate__ and __setstate__ arguments.");
+    def("__getstate__", std::forward<GetStateFn>(get_state));
+
+    // __setstate__ needs to be registered with some custom handling:
+    // We need to wrap the invocation of of the user-provided function
+    // such that we take the return value (i.e. c10::intrusive_ptr<CurrClass>)
+    // and assign it to the `capsule` attribute.
+    using SetStateTraits =
+        c10::guts::infer_function_traits_t<std::decay_t<SetStateFn>>;
+    using SetStateArg = typename c10::guts::typelist::head_t<
+        typename SetStateTraits::parameter_types>;
+    auto setstate_wrapper = [set_state = std::move(set_state)](
+                                c10::tagged_capsule<CurClass> self,
+                                SetStateArg&& arg) {
+      c10::intrusive_ptr<CurClass> classObj =
+          at::guts::invoke(set_state, std::forward<SetStateArg>(arg));
+      auto object = self.ivalue.toObject();
+      object->setSlot(0, c10::IValue::make_capsule(classObj));
+    };
+    defineMethod(
+        "__setstate__",
+        detail::wrap_func<CurClass, decltype(setstate_wrapper)>(
+            std::move(setstate_wrapper)));
+
+    // type validation
+    auto getstate_schema = classTypePtr->getMethod("__getstate__").getSchema();
+    auto format_getstate_schema = [&getstate_schema]() {
+      std::stringstream ss;
+      ss << getstate_schema;
+      return ss.str();
+    };
+    TORCH_CHECK(
+        getstate_schema.arguments().size() == 1,
+        "__getstate__ should take exactly one argument: self. Got: ",
+        format_getstate_schema());
+    auto first_arg_type = getstate_schema.arguments().at(0).type();
+    TORCH_CHECK(
+        *first_arg_type == *classTypePtr,
+        "self argument of __getstate__ must be the custom class type. Got ",
+        first_arg_type->repr_str());
+    TORCH_CHECK(
+        getstate_schema.returns().size() == 1,
+        "__getstate__ should return exactly one value for serialization. Got: ",
+        format_getstate_schema());
+    auto ser_type = getstate_schema.returns().at(0).type();
+    auto setstate_schema = classTypePtr->getMethod("__setstate__").getSchema();
+    // Leaving the below code for clarity, it would be deleted if this approach
+    // is what people want to move forward with.
+    /*
+    auto arg_type = setstate_schema.arguments().at(1).type();
+    TORCH_CHECK(
+        (*arg_type == *ser_type),
+        "__setstate__'s argument should be the same type as the "
+        "return value of __getstate__. Got ",
+        arg_type->repr_str(),
+        " but expected ",
+        ser_type->repr_str());
+        */
+
+    return *this;
+  }
+
  private:
   template <typename Func>
   void defineMethod(std::string name, Func func) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43230 [rfc] temporary custom pickle functions for maintaining BC on ConvPackedParams**
* #43086 not for land: Adding a version serialization type to ConvPackedParam

Summary:

This is an another approach to changing ConvPackedParams structure
while maintaining BC.  We add the ability to add custom pickle functions
where `__set_state__` takes a `c10::IValue` and knows how to parse it,
and define the custom pickle methods with the parsing logic on
`ConvPackedParams`.

There are various TODOs before land left in the diff, ideally we
can align if this is the approach people are OK with and implement
the TODOs after consensus.

For additional context, https://github.com/pytorch/pytorch/pull/43087
contained an alternative version of this.

Test Plan:

For now, check that saving a model with
https://gist.github.com/vkuzo/f3616c5de1b3109cb2a1f504feed69be
on an old revision and loading it on this revision works.
Tests would be needed if this approach sounds good.

Reviewers:

Subscribers:

Tasks:

Tags: