### PR TITLE
Make Windows CUDA-11 tests master only

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -134,8 +134,8 @@ WORKFLOW_DATA = [
     WindowsJob(2, _VC2019, CudaVersion(10, 1)),
     # VS2019 CUDA-11.0
     WindowsJob(None, _VC2019, CudaVersion(11, 0)),
-    WindowsJob(1, _VC2019, CudaVersion(11, 0)),
-    WindowsJob(2, _VC2019, CudaVersion(11, 0)),
+    WindowsJob(1, _VC2019, CudaVersion(11, 0), master_only_pred=TruePred),
+    WindowsJob(2, _VC2019, CudaVersion(11, 0), master_only_pred=TruePred),
     # VS2019 CPU-only
     WindowsJob(None, _VC2019, None),
     WindowsJob(1, _VC2019, None, master_only_pred=TruePred),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6373,6 +6373,12 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11"
           executor: windows-with-nvidia-gpu
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda11.0_test1
           python_version: "3.6"
           requires:
@@ -6386,6 +6392,12 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11"
           executor: windows-with-nvidia-gpu
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda11.0_test2
           python_version: "3.6"
           requires:


### PR DESCRIPTION
According to the correlation analysis, CUDA-10.1 vs CUDA-11 test failures are quite dependent on each other

