### PR TITLE
caffe2: expose CPUContext RandSeed for backwards compatibility with external RNG

### DIFF
--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -68,13 +68,17 @@ class CAFFE2_API CPUContext final : public BaseContext {
 
   inline rand_gen_type& RandGenerator() {
     if (!random_generator_.get()) {
-      if (!random_seed_set_) {
-        random_seed_ = RandomNumberSeed();
-        random_seed_set_ = true;
-      }
-      random_generator_.reset(new rand_gen_type(random_seed_));
+      random_generator_.reset(new rand_gen_type(RandSeed()));
     }
     return *random_generator_.get();
+  }
+
+  inline uint32_t RandSeed() {
+    if (!random_seed_set_) {
+      random_seed_ = RandomNumberSeed();
+      random_seed_set_ = true;
+    }
+    return static_cast<uint32_t>(random_seed_);
   }
 
   inline static at::DataPtr New(size_t nbytes) {


### PR DESCRIPTION
Summary:
This is an incremental step as part of the process to migrate caffe2 random number generator off of std::mt19937 and to instead use at::mt19937+at::CPUGeneratorImpl. The ATen variants are much more performant (10x faster).

This adds a way to get the CPUContext RandSeed for tail use cases that require a std::mt19937 and borrow the CPUContext one.

Test Plan: This isn't used anywhere within the caffe2 codebase. Compile should be sufficient.

Differential Revision: D23203280

