### PR TITLE
Optimize linux CI build/test matrix

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -33,7 +33,11 @@ CONFIG_TREE_DATA = [
                     ("cuda_gcc_override", [X("gcc5.4")]),
                 ])
             ]),
-            ("10.1", [X("3.6")]),
+            ("10.1", [
+                ("3.6", [
+                    ('build_only', [X(True)]),
+                ]),
+            ]),
             ("10.2", [
                 ("3.6", [
                     ("important", [X(True)]),

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -45,13 +45,13 @@ CONFIG_TREE_DATA = [
             ("10.2", [
                 ("3.6", [
                     ("important", [X(True)]),
-                    ("libtorch", [XImportant(True)]),
+                    ("libtorch", [X(True)]),
                 ]),
             ]),
             ("11.0", [
                 ("3.8", [
                     X(True),
-                    ("libtorch", [X(True)])
+                    ("libtorch", [XImportant(True)])
                 ]),
             ]),
         ]),

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -30,7 +30,11 @@ CONFIG_TREE_DATA = [
             ("9.2", [
                 ("3.6", [
                     X(True),
-                    ("cuda_gcc_override", [X("gcc5.4")]),
+                    ("cuda_gcc_override", [
+                        ("gcc5.4", [
+                            ('build_only', [XImportant(True)]),
+                        ]),
+                    ]),
                 ])
             ]),
             ("10.1", [
@@ -204,7 +208,7 @@ class CudaGccOverrideConfigNode(TreeConfigNode):
         self.props["cuda_gcc_override"] = node_name
 
     def child_constructor(self):
-        return ImportantConfigNode
+        return ExperimentalFeatureConfigNode
 
 class BuildOnlyConfigNode(TreeConfigNode):
 
@@ -212,7 +216,7 @@ class BuildOnlyConfigNode(TreeConfigNode):
         self.props["build_only"] = node_name
 
     def child_constructor(self):
-        return ImportantConfigNode
+        return ExperimentalFeatureConfigNode
 
 
 class ImportantConfigNode(TreeConfigNode):

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -28,21 +28,21 @@ CONFIG_TREE_DATA = [
         ]),
         ("cuda", [
             ("9.2", [
-                X("3.6"),
                 ("3.6", [
-                    ("cuda_gcc_override", [X("gcc5.4")])
+                    X(True),
+                    ("cuda_gcc_override", [X("gcc5.4")]),
                 ])
             ]),
             ("10.1", [X("3.6")]),
             ("10.2", [
-                XImportant("3.6"),
                 ("3.6", [
-                    ("libtorch", [XImportant(True)])
+                    ("important", [X(True)]),
+                    ("libtorch", [XImportant(True)]),
                 ]),
             ]),
             ("11.0", [
-                X("3.8"),
                 ("3.8", [
+                    X(True),
                     ("libtorch", [X(True)])
                 ]),
             ]),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5756,20 +5756,6 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7"
       - pytorch_linux_test:
-          name: pytorch_linux_xenial_cuda10_1_cudnn7_py3_gcc7_test
-          requires:
-            - pytorch_linux_xenial_cuda10_1_cudnn7_py3_gcc7_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          build_environment: "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
-      - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda10_1_cudnn7_py3_multigpu_test
           requires:
             - pytorch_linux_xenial_cuda10_1_cudnn7_py3_gcc7_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5807,12 +5807,24 @@ workflows:
           name: pytorch_libtorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_build
           requires:
             - "docker-pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           build_environment: "pytorch-libtorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
       - pytorch_linux_test:
           name: pytorch_libtorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test
           requires:
             - pytorch_libtorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_build
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           build_environment: "pytorch-libtorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
           use_cuda_docker_runtime: "1"
@@ -5847,24 +5859,12 @@ workflows:
           name: pytorch_libtorch_linux_xenial_cuda11_0_cudnn8_py3_gcc7_build
           requires:
             - "docker-pytorch-linux-xenial-cuda11.0-cudnn8-py3-gcc7"
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           build_environment: "pytorch-libtorch-linux-xenial-cuda11.0-cudnn8-py3-gcc7-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.0-cudnn8-py3-gcc7"
       - pytorch_linux_test:
           name: pytorch_libtorch_linux_xenial_cuda11_0_cudnn8_py3_gcc7_test
           requires:
             - pytorch_libtorch_linux_xenial_cuda11_0_cudnn8_py3_gcc7_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           build_environment: "pytorch-libtorch-linux-xenial-cuda11.0-cudnn8-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.0-cudnn8-py3-gcc7"
           use_cuda_docker_runtime: "1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5721,28 +5721,8 @@ workflows:
           name: pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc5_4_build
           requires:
             - "docker-pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4"
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           build_environment: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4"
-      - pytorch_linux_test:
-          name: pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc5_4_test
-          requires:
-            - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc5_4_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-          build_environment: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4"
-          use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda10_1_cudnn7_py3_gcc7_build
           requires:


### PR DESCRIPTION
Make CUDA-10.1 configs build-only, as CUDA-10.1 and CUDA-10.2 test matrix is almost identical, and now, since CUDA-11 is out perhaps it's time to stop testing CUDA-10.1.
Make CUDA-9.2+GCC_5.4 an important (i.e. running on PR) build only config, because of the big overlap between  CUDA-9.2-GCC7 and CUDA-9.2-GCC5.4 test coverage.
Make CUDA-11 libtorch tests important rather that CUDA-10.2.

As result of the change, every PR will be built against CUDA-9.2, CUDA-10.2 and CUDA-11 and tested against CUDA-10.2