### PR TITLE
Let torch.sign support complex types

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -274,7 +274,7 @@ static void sign_kernel(TensorIterator& iter){
                    } else {
                      return (0 < a.imag()) - (a.imag() < 0);
                    }
-                 });
+      });
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.dtype(), "sign_cpu", [&]() {

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -38,7 +38,7 @@ void sign_kernel_cuda(TensorIterator& iter){
   } else if (isComplexType(iter.dtype())) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "sign_cuda", [&]() {
       gpu_kernel(iter,
-                 [](scalar_t a) -> scalar_t {
+                 []GPU_LAMBDA(scalar_t a) -> scalar_t {
                    if (::isnan(a.real()) || ::isnan(a.imag())) {
                      return scalar_t(::nan(""), 0);
                    } else if (a.real() != 0) {

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -46,7 +46,7 @@ void sign_kernel_cuda(TensorIterator& iter){
                    } else {
                      return (0 < a.imag()) - (a.imag() < 0);
                    }
-                 });
+      });
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND(ScalarType::Half, iter.dtype(), "sign_cuda", [&]() {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11898,10 +11898,22 @@ class TestTorchDeviceType(TestCase):
     def test_sign(self, device):
         for dtype in torch.testing.get_all_math_dtypes(device):
             if dtype.is_complex:
-                continue
-
+                a = torch.tensor([complex(float('nan'), 1),
+                                  complex(1, float('nan')),
+                                  0,
+                                  complex(71, -1),
+                                  complex(-71, 10),
+                                  complex(0, 21),
+                                  complex(0, -3)], device=device, dtype=dtype)
+                a_target = torch.tensor([complex(float('nan'), 0),
+                                         complex(float('nan'), 0),
+                                         0,
+                                         1,
+                                         -1,
+                                         1,
+                                         -1], device=device, dtype=dtype)
             # Include NaN for floating point numbers
-            if dtype.is_floating_point:
+            elif dtype.is_floating_point:
                 dt_info = torch.finfo(dtype)
 
                 # Create tensor (with NaN checking)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43243 Let torch.sign support complex types**
* #43242 Do not define the macro "isnan"

The rule follows those of NumPy: https://numpy.org/doc/stable/reference/generated/numpy.sign.html