### PR TITLE
In copy_weights_to_flat_buf_views() explicitly construct tuple

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -684,7 +684,7 @@ namespace cudnn_rnn {
       }
     }
 
-    return {weight_buf, params_arr};
+    return std::make_tuple(weight_buf, params_arr);
   }
 
 } // namespace cudnn_rnn


### PR DESCRIPTION
In some versions of GCC, tuple constructor from initializer list  is marked as explicit, which results in the following compilation error:
```
/var/lib/jenkins/workspace/aten/src/ATen/native/cudnn/RNN.cpp: In function 'std::tuple<at::Tensor, std::vector<at::Tensor, std::allocator<at::Tensor> > > at::native::cudnn_rnn::copy_weights_to_flat_buf_views(at::TensorList, int64_t, int64_t, int64_t, int64_t, int64_t, bool, bool, cudnnDataType_t, const c10::TensorOptions&, bool, bool, bool)':
/var/lib/jenkins/workspace/aten/src/ATen/native/cudnn/RNN.cpp:687:35: error: converting to 'std::tuple<at::Tensor, std::vector<at::Tensor, std::allocator<at::Tensor> > >' from initializer list would use explicit constructor 'constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = at::Tensor&; _U2 = std::vector<at::Tensor>&; <template-parameter-2-3> = void; _T1 = at::Tensor; _T2 = std::vector<at::Tensor>]'
     return {weight_buf, params_arr};
```
This regression was introduced by https://github.com/pytorch/pytorch/pull/42385
