### PR TITLE
[torch.fx] Add support for custom op

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -466,5 +466,19 @@ class TestFX(JitTestCase):
         with self.assertRaisesRegex(TraceError, 'Proxy object cannot be unpacked as function argument'):
             symbolic_trace(ud)
 
+    def test_torch_custom_ops(self):
+        class M(torch.nn.Module):
+            def forward(self, a):
+                b = torch.ops.aten.sigmoid(a)
+                c = torch.ops.aten.cat([a, b])
+                return torch.ops.aten.cat((c, c))
+        m = M()
+        input = torch.randn(3)
+        ref_out = m(input)
+        gm = symbolic_trace(m)
+        out = gm(input)
+        self.assertEqual(out, ref_out)
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/utils/python_arg_parser.h>
 
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/backends/backend_init.h>
@@ -899,13 +900,67 @@ void initJITBindings(PyObject* module) {
             docstring << "  " << op->schema() << "\n";
           }
 
-          return py::cpp_function(
-              [operations](py::args args, py::kwargs kwargs) {
+          auto func = py::cpp_function(
+              [operations, symbol](py::args args, py::kwargs kwargs) {
+                std::vector<py::handle> overloaded_args;
+                size_t total_arg_num = args.size() + kwargs.size();
+                for (size_t i = 0; i < args.size(); ++i) {
+                  is_tensor_and_append_overloaded(
+                      args[i].ptr(), &overloaded_args);
+                  is_tensor_list_and_append_overloaded(
+                      args[i].ptr(),
+                      &overloaded_args,
+                      static_cast<int>(total_arg_num),
+                      false /* throw_error */);
+                }
+                // NB: for kwargs, we cannot guarantee the order of appending
+                // is the same as the argument order in operator's schema.
+                // This is suboptimal, but should be fine. Later when we have
+                // better schema matching and argument parsing, we could
+                // match the operator in `operations` first, then the order will
+                // be guaranteed.
+                for (auto item : kwargs) {
+                  is_tensor_and_append_overloaded(
+                      item.second.ptr(), &overloaded_args);
+                  is_tensor_list_and_append_overloaded(
+                      item.second.ptr(),
+                      &overloaded_args,
+                      total_arg_num,
+                      false /* throw_error */);
+                }
+                if (overloaded_args.size() > 0) {
+                  std::vector<py::object> overloaded_types;
+                  overloaded_types.reserve(overloaded_args.size());
+                  for (auto& oarg : overloaded_args) {
+                    overloaded_types.push_back(
+                        py::reinterpret_borrow<py::object>(
+                            (PyObject*)Py_TYPE(oarg.ptr())));
+                  }
+                  py::tuple py_types = py::cast(overloaded_types);
+                  py::object ret;
+                  std::string ns = symbol.ns().toUnqualString();
+                  std::string method_name = symbol.toUnqualString();
+                  auto self_func = py::module::import("torch")
+                                       .attr("ops")
+                                       .attr(ns.c_str())
+                                       .attr(method_name.c_str());
+                  std::string module_name("torch.ops");
+                  module_name.append(ns);
+                  return pybind11::reinterpret_steal<py::object>(
+                      handle_torch_function_no_python_arg_parser(
+                          overloaded_args,
+                          args.ptr(),
+                          kwargs.ptr(),
+                          method_name.c_str(),
+                          self_func.ptr(),
+                          module_name.c_str()));
+                }
                 return invokeOperatorFromPython(
                     operations, std::move(args), std::move(kwargs));
               },
               py::name(symbol.toUnqualString()),
               py::doc(docstring.str().c_str()));
+          return func;
         } catch (const c10::Error& error) {
           throw std::runtime_error(error.what_without_backtrace());
         }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -769,20 +769,60 @@ static auto check_has_torch_function(PyObject* obj) -> bool
  *
  * 'torch_api' is a reference to a python torch API namespace.
  *
+ * 'torch_api_function' is the reference to the original torch method, usually,
+ * we can use torch_api and func_name to get torch_api_function. In some cases,
+ * e.g., torch custom op, we create the function in C++, if we still use
+ * torch_api and func_name to fetch original api, a cyclic call will happen.
+ *
+ * 'overloaded_args' is the args which have overloaded __torch_function__.
+ *
+ * 'func_name' is the named of the original torch method.
+ *
+ * TODO: we could use different names for the following 'handle_torch_function'
+ * instead of overloading.
+ *
  */
 // Used for Tensor methods with arguments.
 auto handle_torch_function(PythonArgs &r, PyObject* self, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name) -> PyObject*;
 
-// Used fpr functions.
+// Used for functions which needs to parse python args.
 auto handle_torch_function(PythonArgs &r, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name) -> PyObject*;
 
 // Used for functions that accept no keyword arguments and have no argument parsing
 auto handle_torch_function(PyObject* self, const std::string& func_name, PyObject* args=nullptr, PyObject* torch_api=THPVariableClass, const std::string& module_name="torch.Tensor") -> PyObject*;
+
+// Used for functions created in C++, e.g., C++ custom op, which doesn't use PythonArgParser to get overloaded_args.
+auto handle_torch_function_no_python_arg_parser(const std::vector<py::handle> &overloaded_args, PyObject* args, PyObject* kwargs, const char* func_name, PyObject* torch_api_function, const char* module_name) -> PyObject*;
 
 // Used for getters of Tensor properties
 auto handle_torch_function_getter(THPVariable* self, const std::string& property_name) -> PyObject*;
 
 // Used for setters of Tensor properties.
 auto handle_torch_function_setter(THPVariable* self, const std::string& property_name, PyObject* value) -> int;
+
+/*
+ * Check if the input obj is Tensor type, including its subclass, or overloaded
+ * type. If the type defines __torch_function__, it also returns true.
+ * Otherwise returns flase. If the class is not torch.Tensor, and it defines
+ * __torch_function__, we append obj to overloaded_args.
+ *
+ * 'obj': the input argument to be checked
+ * 'overloaded_args': the vector to append the overloaded args.
+ */
+bool is_tensor_and_append_overloaded(PyObject* obj, std::vector<py::handle>* overloaded_args);
+
+/*
+ * Check if the input obj is Tensor List or Tensor Tuple type. First check
+ * whether obj is Tuple or List type, if true, iterate over each element and
+ * check whether it is Tensor type, including its subclass or overloaded type.
+ * At the same time, the overloaded arg is appended to the overloaded_args.
+ *
+ * 'obj': the input argument to be checked
+ * 'overloaded_args': the vector to append the overloaded args.
+ * 'argnum': the number of total arguments of the function being checked.
+ * 'throw_error': whether throw error if any element in the list or tuple is
+ *                not tensor type or overloaded.
+ */
+bool is_tensor_list_and_append_overloaded(PyObject* obj, std::vector<py::handle>* overloaded_args, int argnum, bool throw_error);
 
 } // namespace torch


### PR DESCRIPTION
Summary: when using torch.fx to symbolic trace nn module, we create Proxy node instead of real Tensor, and Proxy has implemented '__torch_function__'. However, the C++ custom op is just cpp_function. In current cpp_function definition, there is no support for '__torch_function__' override, so we will see complaints about the C++ function expect Tensor input, but got Proxy type. So when calling the cpp_function of the custom op, we first check whether the input args support '__torch_function__' override, if so, we will try to call the override logic instead of the real C++ custom op.

Some perf benchmark:
- sigmoid (input is torch.ones(2))
without change: Op sigmoid had a minimum time of 2.506256103515625 us and a standard deviation of 0.3828478220384568 us.
with change: Op sigmoid had a minimum time of 2.7022361755371094 us and a standard deviation of 0.3112237900495529 us.
- relu (input is torch.ones(2))
without change: Op relu had a minimum time of 2.2428035736083984 us and a standard deviation of 0.4182197153568268 us.
with change: Op relu had a minimum time of 2.4945735931396484 us and a standard deviation of 0.3914815024472773 us.
- cat (input is torch.ones(2), torch.zeros(2))
without change: Op cat had a minimum time of 3.509521484375 us and a standard deviation of 0.5249808309599757 us.
with change: Op cat had a minimum time of 4.532814025878906 us and a standard deviation of 0.6780577823519707 us.

- cat (input is torch.ones(3, 224, 224), torch.zeros(3, 224, 224))
without change: Op cat had a minimum time of 107.0699691772461 us and a standard deviation of 6.263310555368662 us.
with change: Op cat had a minimum time of 106.03904724121094 us and a standard deviation of 5.618293769657612 us.

Test Plan: buck test //caffe2/test:fx -- test_torch_custom_ops

Differential Revision: D23203204

