### PR TITLE
Do not call nullptr deleter in at::fromDLPack #43166

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -212,7 +212,7 @@ Tensor fromDLPack(const DLManagedTensor* src) {
   Device device = getATenDevice(src->dl_tensor.ctx);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   auto deleter = [src](void* self) {
-    src->deleter(const_cast<DLManagedTensor*>(src));
+    if (src->deleter) src->deleter(const_cast<DLManagedTensor*>(src));
   };
   if (!src->dl_tensor.strides) {
     return at::from_blob(src->dl_tensor.data,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43266 Do not call nullptr deleter in at::fromDLPack #43166**

