### PR TITLE
Function calls for fallback paths

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -95,6 +95,7 @@ namespace c10 {
   _(prim, Guard)                     \
   _(prim, BailOut)                   \
   _(prim, TypeCheck)                 \
+  _(prim, FallbackGraph)             \
   _(prim, FusedConcat)               \
   _(prim, ConstantChunk)             \
   _(prim, MMTreeReduce)              \

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1199,21 +1199,22 @@ void testThreadLocalDebugInfo() {
 }
 
 void testFallbackGraphs() {
-
-
-  static const auto nestGraphIntoFallbackGraph = [](const std::shared_ptr<Graph>& graph) {
-    ProfilingRecord::removeProfileCounter(graph->block());
-    auto fallback =
-        createFallbackGraph(graph->block(), graph->inputs(), graph.get());
-    graph->prependNode(fallback);
-    for (size_t i = 0; i < graph->outputs().size(); i++) {
-      graph->outputs()[i]->replaceAllUsesWith(fallback->output(i));
-      fallback->output(i)->copyMetadata(graph->outputs()[i]);
-    }
-    for (auto it = graph->block()->nodes().rbegin(); it != fallback->iterator(); it++) {
-      it.destroyCurrent();
-    }
-  };
+  static const auto nestGraphIntoFallbackGraph =
+      [](const std::shared_ptr<Graph>& graph) {
+        ProfilingRecord::removeProfileCounter(graph->block());
+        auto fallback =
+            createFallbackGraph(graph->block(), graph->inputs(), graph.get());
+        graph->prependNode(fallback);
+        for (size_t i = 0; i < graph->outputs().size(); i++) {
+          graph->outputs()[i]->replaceAllUsesWith(fallback->output(i));
+          fallback->output(i)->copyMetadata(graph->outputs()[i]);
+        }
+        for (auto it = graph->block()->nodes().rbegin();
+             it != fallback->iterator();
+             it++) {
+          it.destroyCurrent();
+        }
+      };
 
   auto x = at::randn({1}, at::kCPU);
   auto y = at::randn({1}, at::kCPU);
@@ -1267,8 +1268,6 @@ void testFallbackGraphs() {
         .check("(Tensor) = prim::CallFunction")
         ->run(*opt_graph);
   }
-
-
 }
 
 void testAutogradProfiler() {

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -38,7 +38,6 @@
 #include "torch/csrc/jit/runtime/argument_spec.h"
 #include "torch/csrc/jit/runtime/autodiff.h"
 #include "torch/csrc/jit/runtime/custom_operator.h"
-#include "torch/csrc/jit/runtime/graph_executor.h"
 #include "torch/csrc/jit/runtime/interpreter.h"
 #include "torch/csrc/jit/runtime/symbolic_script.h"
 #include "torch/csrc/jit/serialization/import.h"
@@ -46,9 +45,10 @@
 #include "torch/csrc/autograd/engine.h"
 #include "torch/csrc/autograd/variable.h"
 
-#include <torch/csrc/jit/runtime/profiling_graph_executor_impl.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/testing/file_check.h>
 #include <torch/script.h>
+
 #include "torch/csrc/jit/api/module.h"
 #include "torch/csrc/jit/frontend/ir_emitter.h"
 #include "torch/csrc/jit/runtime/profiling_record.h"
@@ -1251,6 +1251,7 @@ void testFallbackGraphs() {
         // this is safe to do since we are done profiling
         ProfilingRecord::removeProfileCounter(opt_graph->block());
         replaceBlockWithFallbackGraph(opt_graph->block());
+        GRAPH_DUMP("replaceBlockWithFallbackGraph:", opt_graph);
         auto it = opt_graph->block()->nodes().begin();
         ASSERT_EQ(it->kind(), prim::FallbackGraph);
         auto fallback = *it++;

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1244,8 +1244,13 @@ void testFallbackGraphs() {
       stack.emplace_back(x.clone());
       stack.emplace_back(y.clone());
       if (i == getNumProfiledRuns()) {
+        // we will be modifying a profiled graph
+        // before ProfilingGraphExecutor
+        // will optimize it in the next iteration
         auto opt_graph = lastExecutedOptimizedGraph();
-        nestGraphIntoFallbackGraph(opt_graph);
+        // this is safe to do since we are done profiling
+        ProfilingRecord::removeProfileCounter(opt_graph->block());
+        replaceBlockWithFallbackGraph(opt_graph->block());
         auto it = opt_graph->block()->nodes().begin();
         ASSERT_EQ(it->kind(), prim::FallbackGraph);
         auto fallback = *it++;

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -8,6 +8,7 @@
 
 #include <torch/csrc/jit/ir/type_hashing.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
+#include <torch/csrc/jit/runtime/profiling_graph_executor_impl.h>
 #include "torch/csrc/autograd/generated/variable_factories.h"
 #include "torch/csrc/autograd/variable.h"
 #include "torch/csrc/jit/codegen/fuser/interface.h"

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -50,6 +50,7 @@ namespace jit {
   _(ClassParser)                                  \
   _(UnifyTypes)                                   \
   _(Profiler)                                     \
+  _(FallbackGraphs)                               \
   _(InsertAndEliminateRedundantGuards)            \
   _(LoopPeeler)                                   \
   _(InsertBailOuts)                               \

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -476,6 +476,7 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::CudaFusionGroup:
     case prim::FunctionalGraph:
     case prim::DifferentiableGraph:
+    case prim::FallbackGraph:
       return analyzeSubgraph(node);
     case prim::fork:
       return analyzeFork(node);

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -53,6 +53,20 @@
 namespace torch {
 namespace jit {
 
+EnableProfilingGuard::EnableProfilingGuard() {
+  auto& profiling_mode = getProfilingMode();
+  old_profiling_mode = profiling_mode;
+  profiling_mode = true;
+  auto& executor_mode = getExecutorMode();
+  old_executor_mode = executor_mode;
+  executor_mode = true;
+}
+
+EnableProfilingGuard::~EnableProfilingGuard() {
+  getProfilingMode() = old_profiling_mode;
+  getExecutorMode() = old_executor_mode;
+}
+
 namespace {
 c10::AliasAnalysisKind aliasAnalysisInternalSpecialCase() {
   return AliasAnalysisKind::INTERNAL_SPECIAL_CASE;

--- a/torch/csrc/jit/runtime/graph_executor.h
+++ b/torch/csrc/jit/runtime/graph_executor.h
@@ -43,6 +43,15 @@ struct GraphExecutorState {
   std::unordered_map<ArgumentSpec, ExecutionPlan> execution_plans;
 };
 
+struct TORCH_API EnableProfilingGuard {
+  EnableProfilingGuard();
+  ~EnableProfilingGuard();
+
+ private:
+  bool old_executor_mode = false;
+  bool old_profiling_mode = false;
+};
+
 struct GraphExecutorImplBase;
 struct TORCH_API GraphExecutor {
   GraphExecutor() = default;

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -241,6 +241,7 @@ bool printerHasSpecialCaseFor(Symbol sym) {
       prim::profile, // used in interpreter only
       prim::profile_optional, // used in interpreter only
       prim::TypeCheck, // used in interpreter only
+      prim::FallbackGraph, // converted into prim::CallFunction
 
   };
 
@@ -307,6 +308,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::rpc_async,
       prim::Enter,
       prim::Exit,
+      prim::FallbackGraph,
   };
 
   // Operators that should not be used by alias analysis

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -487,7 +487,7 @@ static Function* createFallbackPathFunction(
   auto tuple_type = TupleType::create(otypes);
   auto return_tuple = graph->createTuple(graph->return_node()->inputs());
   graph->appendNode(return_tuple);
-  for (int i = graph->outputs().size() - 1; i >= 0; i--) {
+  for (int i = static_cast<int>(graph->outputs().size()) - 1; i >= 0; i--) {
     graph->eraseOutput(i);
   }
   graph->registerOutput(return_tuple->output());

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -425,9 +425,8 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
       PeelProfilingLoops(copy);
     }
     pr_ = ProfilingRecord::instrumentGraph(copy);
-    auto pr_copy = pr_->graph()->copy();
-    GRAPH_DUMP("Profiled Graph: ", pr_copy);
-    profiling_plan_ = ExecutionPlan(pr_copy, function_name_);
+    GRAPH_DUMP("Profiled Graph: ", pr_->graph());
+    profiling_plan_ = ExecutionPlan(pr_->graph(), function_name_);
     // fall-through
   }
 
@@ -436,8 +435,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
     return *profiling_plan_;
   }
 
-  // auto copy = pr_->graph()->copy();
-  auto copy = profiling_plan_->graph->copy();
+  auto copy = pr_->graph()->copy();
   ProfilingRecord::removeProfileCounter(copy->block());
   runProfilingOptimizations(copy);
   // replaces a fallback graph inserted by

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -65,6 +65,21 @@ std::atomic<size_t>& getBailoutDepth() {
   return bailout_depth;
 }
 
+void removeProfilingNodes(Block* b) {
+  for (auto it = b->nodes().begin(); it != b->nodes().end(); it++) {
+    if (it->kind() == prim::profile) {
+      if (it->outputs().size()) {
+        it->output()->replaceAllUsesWith(it->input());
+      }
+      it.destroyCurrent();
+    } else {
+      for (Block* ib : it->blocks()) {
+        removeProfilingNodes(ib);
+      }
+    }
+  }
+}
+
 static bool needsGradientInProfilingMode(Block* b) {
   for (auto n : b->nodes()) {
     if (n->kind() == prim::BailOut) {
@@ -384,12 +399,16 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   std::lock_guard<std::mutex> lock(compile_mutex);
   GRAPH_DEBUG("Running ProfilingGraphExecutorImpl ", this);
 
+  if (!remaining_bailout_depth_.has_value()) {
+    remaining_bailout_depth_ = remaining_bailout_depth;
+  }
+
   if (optimized_plan_) {
     return *optimized_plan_;
   }
 
   // simple executor
-  if (remaining_bailout_depth == 0) {
+  if (*remaining_bailout_depth_ == 0) {
     auto copy = graph->copy();
     runProfilingInsensitiveOptimizations(copy);
     GRAPH_DUMP("Optimized SimpleExecutor Graph : ", copy);
@@ -400,8 +419,9 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   // if a profiling graph hasn't been created yet
   if (!pr_) {
     auto copy = graph->copy();
+    removeProfilingNodes(copy->block());
     runProfilingInsensitiveOptimizations(copy);
-    if (remaining_bailout_depth == getBailoutDepth()) {
+    if (*remaining_bailout_depth_ == getBailoutDepth()) {
       PeelProfilingLoops(copy);
     }
     pr_ = ProfilingRecord::instrumentGraph(copy);
@@ -422,9 +442,10 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   // replaces a fallback graph inserted by
   // specialize_autogradzero if one exists
   replaceFallbackGraphWithFallbackFunction(copy->block());
+  GRAPH_DUMP("Optimized Graph: ", copy);
   // cache
   optimized_plan_ =
-      ExecutionPlan(copy, function_name_, remaining_bailout_depth);
+      ExecutionPlan(copy, function_name_, *remaining_bailout_depth_);
   return *optimized_plan_;
 }
 
@@ -500,7 +521,11 @@ void ProfilingGraphExecutorImpl::replaceFallbackGraphWithFallbackFunction(
     if (it->kind() == prim::FallbackGraph) {
       auto fallback_func = createFallbackPathFunction(
           it->g(attr::Subgraph)->block(), "fallback_function");
-      fallback_func->get_executor().getPlanFor(s, bailout_depth - 1);
+      TORCH_INTERNAL_ASSERT(*remaining_bailout_depth_ > 0);
+      GRAPH_DEBUG(
+          "getPlanFor for", getHeader(*it), " ", *remaining_bailout_depth_);
+      fallback_func->get_executor().getPlanFor(
+          s, *remaining_bailout_depth_ - 1);
       fallback_functions_.emplace_back(fallback_func);
       WithInsertPoint wip{*it};
       auto function_call = insertFallbackFunctionCall(

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -420,7 +420,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   ProfilingRecord::removeProfileCounter(copy->block());
   runProfilingOptimizations(copy);
   // replaces a fallback graph inserted by
-  // if specialize_autogradzero one exists
+  // specialize_autogradzero if one exists
   replaceFallbackGraphWithFallbackFunction(copy->block());
   // cache
   optimized_plan_ =
@@ -460,6 +460,8 @@ static Function* createFallbackPathFunction(
 
   auto otypes = c10::fmap(
       graph->return_node()->inputs(), [](Value* v) { return v->type(); });
+  // a GraphFunction call only have one output, so all the outputs
+  // need to be packed into a tuple
   auto tuple_type = TupleType::create(otypes);
   auto return_tuple = graph->createTuple(graph->return_node()->inputs());
   graph->appendNode(return_tuple);

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -399,7 +399,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   std::lock_guard<std::mutex> lock(compile_mutex);
   GRAPH_DEBUG("Running ProfilingGraphExecutorImpl ", this);
 
-  if (!remaining_bailout_depth_.has_value()) {
+  if (!remaining_bailout_depth_.has_value() || !tensorExprFuserEnabled()) {
     remaining_bailout_depth_ = remaining_bailout_depth;
   }
 
@@ -436,7 +436,8 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
     return *profiling_plan_;
   }
 
-  auto copy = pr_->graph()->copy();
+  // auto copy = pr_->graph()->copy();
+  auto copy = profiling_plan_->graph->copy();
   ProfilingRecord::removeProfileCounter(copy->block());
   runProfilingOptimizations(copy);
   // replaces a fallback graph inserted by

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
@@ -4,6 +4,11 @@
 namespace torch {
 namespace jit {
 
+TORCH_API Node* createFallbackGraph(
+    Block* b,
+    ArrayRef<Value*> inputs,
+    Graph* g);
+
 struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   ProfilingGraphExecutorImpl(
       const std::shared_ptr<Graph>& graph,
@@ -17,10 +22,12 @@ struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
  private:
   void runProfilingInsensitiveOptimizations(std::shared_ptr<Graph>& graph);
   void runProfilingOptimizations(std::shared_ptr<Graph>& graph);
+  void replaceFallbackGraphWithFallbackFunction(Block* b);
   std::unique_ptr<ProfilingRecord> pr_;
   c10::optional<ExecutionPlan>
       profiling_plan_; // plan to run in order to profiling the code
   c10::optional<ExecutionPlan> optimized_plan_;
+  std::vector<std::unique_ptr<Function>> fallback_functions_;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
@@ -36,6 +36,7 @@ struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   // They only exist in the optimized graph which is a private property
   // of the GraphExecutor and only shared with InterpreterState
   std::vector<std::unique_ptr<Function>> fallback_functions_;
+  c10::optional<size_t> remaining_bailout_depth_;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
@@ -9,6 +9,8 @@ TORCH_API Node* createFallbackGraph(
     ArrayRef<Value*> inputs,
     Graph* g);
 
+TORCH_API void replaceBlockWithFallbackGraph(Block* b);
+
 struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   ProfilingGraphExecutorImpl(
       const std::shared_ptr<Graph>& graph,

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
@@ -27,6 +27,14 @@ struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   c10::optional<ExecutionPlan>
       profiling_plan_; // plan to run in order to profiling the code
   c10::optional<ExecutionPlan> optimized_plan_;
+  // fallback functions are inserted for tensorexpr fusion groups
+  // and by specialize_autogradzero. Whenever, at runtime, input
+  // tensor don't match profiled properties, fallback functions are called
+  // They are the deoptimized version of the logic in fusion groups
+  // and/or autograd.
+  // The fallback functions are owned by a GraphExecutor instance
+  // They only exist in the optimized graph which is a private property
+  // of the GraphExecutor and only shared with InterpreterState
   std::vector<std::unique_ptr<Function>> fallback_functions_;
 };
 

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -63,7 +63,7 @@ RegisterOperators reg(
            };
          },
          aliasAnalysisSpecialCase()),
-     Operator(         
+     Operator(
          prim::FallbackGraph,
          [](const Node* node) -> Operation {
            return [](Stack* stack) {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -68,7 +68,7 @@ RegisterOperators reg(
          [](const Node* node) -> Operation {
            return [](Stack* stack) {
              AT_ERROR(
-                 "Must be lowered to Interpreter's PROFILE instruction"); // NOLINT
+                 "Must be converted to prim::FunctionCall by replaceFallbackGraphWithFallbackFunction"); // NOLINT
            };
          },
          aliasAnalysisSpecialCase()),

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -63,6 +63,15 @@ RegisterOperators reg(
            };
          },
          aliasAnalysisSpecialCase()),
+     Operator(         
+         prim::FallbackGraph,
+         [](const Node* node) -> Operation {
+           return [](Stack* stack) {
+             AT_ERROR(
+                 "Must be lowered to Interpreter's PROFILE instruction"); // NOLINT
+           };
+         },
+         aliasAnalysisSpecialCase()),
      Operator(
          "prim::Guard(Tensor(a) t) -> Tensor(a)",
          [](Stack* stack) { AT_ERROR("Should be replaced by prim::BailOut"); },


### PR DESCRIPTION
This PR adds API to package unoptimized/fallback blocks as function calls. It's mainly meant to be used by TensorExpressionsFuser and SpecializeAutogradZero passes as both specialize the original graph but would also like to provide a fallback path in case the assumptions under which the graph was specialized do not hold for some inputs.