### PR TITLE
Fix `at::native::view_as_real()` for ComplexHalf Tensors

### DIFF
--- a/aten/src/ATen/native/ComplexHelper.h
+++ b/aten/src/ATen/native/ComplexHelper.h
@@ -45,8 +45,8 @@ inline std::vector<int64_t> computeStrideForViewAsComplex(IntArrayRef oldstride)
 // and returns back a tensor with corresponding complex dtype
 Tensor view_as_complex(const Tensor& self) {
   TORCH_CHECK(
-    self.scalar_type() == kFloat || self.scalar_type() == kDouble,
-    "view_as_complex is only supported for float and double tensors, but got a tensor of scalar type: ", self.scalar_type());
+    self.scalar_type() == kFloat || self.scalar_type() == kDouble || self.scalar_type() == kHalf,
+    "view_as_complex is only supported for half, float and double tensors, but got a tensor of scalar type: ", self.scalar_type());
 
   auto new_sizes = self.sizes().vec();
   TORCH_CHECK(new_sizes[self.dim()-1] == 2, "Tensor must have a last dimension of size 2");

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -315,6 +315,7 @@ static inline bool isSignedType(ScalarType t) {
       return std::numeric_limits<ctype>::is_signed;
 
   switch (t) {
+    case ScalarType::ComplexHalf: \
     case ScalarType::ComplexFloat: \
     case ScalarType::ComplexDouble: \
       return true; \
@@ -331,6 +332,8 @@ static inline bool isUnderlying(ScalarType type, ScalarType qtype) {
 
 static inline ScalarType toValueType(ScalarType t) {
   switch (t) {
+    case ScalarType::ComplexHalf:
+      return ScalarType::Half;
     case ScalarType::ComplexFloat:
       return ScalarType::Float;
     case ScalarType::ComplexDouble:
@@ -342,6 +345,8 @@ static inline ScalarType toValueType(ScalarType t) {
 
 static inline ScalarType toComplexType(ScalarType t) {
   switch (t) {
+    case ScalarType::Half:
+      return ScalarType::ComplexHalf;
     case ScalarType::Float:
       return ScalarType::ComplexFloat;
     case ScalarType::Double:

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -374,6 +374,8 @@ struct alignas(4) complex<Half> {
   }
   inline complex(c10::complex<float> value)
       : real_(value.real()), imag_(value.imag()) {}
+  inline complex(c10::complex<double> value)
+      : real_(value.real()), imag_(value.imag()) {}
   inline operator c10::complex<float>() const {
     return {real_, imag_};
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11609,7 +11609,7 @@ class TestTorchDeviceType(TestCase):
                             self.assertTrue(from_ <= double_t.min() <= (from_ + delta))
                             self.assertTrue((to_ - delta) <= double_t.max() < to_)
 
-    @dtypes(torch.float, torch.double, torch.complex64, torch.complex128)
+    @dtypes(torch.float, torch.double, torch.half, torch.complex32, torch.complex64, torch.complex128)
     def test_randn(self, device, dtype):
         for size in [0, SIZE]:
             torch.manual_seed(123456)

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -20,6 +20,7 @@ inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
       break;
     case at::kFloat: *(float*)data = (float)THPUtils_unpackDouble(obj); break;
     case at::kDouble: *(double*)data = THPUtils_unpackDouble(obj); break;
+    case at::kComplexHalf: *(c10::complex<at::Half>*)data = (c10::complex<at::Half>)THPUtils_unpackComplexDouble(obj); break;
     case at::kComplexFloat: *(c10::complex<float>*)data = (c10::complex<float>)THPUtils_unpackComplexDouble(obj); break;
     case at::kComplexDouble: *(c10::complex<double>*)data = THPUtils_unpackComplexDouble(obj); break;
     case at::kBool: *(bool*)data = THPUtils_unpackNumberAsBool(obj); break;
@@ -40,8 +41,12 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kHalf: return PyFloat_FromDouble(at::convert<double, at::Half>(*(at::Half*)data));
     case at::kFloat: return PyFloat_FromDouble(*(float*)data);
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
+    case at::kComplexHalf: {
+      auto data_ = (c10::complex<at::Half>*)data;
+      return PyComplex_FromDoubles(data_->real(), data_->imag());
+    }
     case at::kComplexFloat: {
-      c10::complex<float>* data_ = (c10::complex<float>*)data;
+      auto data_ = reinterpret_cast<c10::complex<float>*>(data);
       return PyComplex_FromDoubles(data_->real(), data_->imag());
     }
     case at::kComplexDouble: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((c10::complex<double>*)data));

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -42,7 +42,7 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kFloat: return PyFloat_FromDouble(*(float*)data);
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
     case at::kComplexHalf: {
-      auto data_ = (c10::complex<at::Half>*)data;
+      auto data_ = reinterpret_cast<c10::complex<at::Half>*>(data);
       return PyComplex_FromDoubles(data_->real(), data_->imag());
     }
     case at::kComplexFloat: {


### PR DESCRIPTION
Add ComplexHalf case to toValueType, which fixes the logic how view_as_real and view_as_complex slices complex tensor to the floating point one, as it is used to generate tensor of random complex values, see:
https://github.com/pytorch/pytorch/blob/018b4d7abb894c3de21f9f10b0678c80a7b0a701/aten/src/ATen/native/DistributionTemplates.h#L200
Also add ability to convert python complex object to `c10::complex<at::Half>`

Add `torch.half` and `torch.complex32` to the list of `test_randn` dtypes

Fixes https://github.com/pytorch/pytorch/issues/43143
