### PR TITLE
Standardized clamp kernels to Numpy-like implementation

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -615,23 +615,12 @@ inline T minimum(const T& a, const T& b) {
   return c;
 }
 
-// To save BC, it will not propagate NaN based on IEEE 754 201X
 template <class T,
           typename std::enable_if<!c10::is_complex<T>::value, int>::type = 0>
 Vec256<T> inline clamp(const Vec256<T> &a, const Vec256<T> &min_vec, const Vec256<T> &max_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
-    c[i] = a[i] < min_vec[i] ? min_vec[i] : (a[i] > max_vec[i] ? max_vec[i] : a[i]);
-  }
-  return c;
-}
-
-template <class T,
-          typename std::enable_if<c10::is_complex<T>::value, int>::type = 0>
-Vec256<T> inline clamp(const Vec256<T> &a, const Vec256<T> &min_vec, const Vec256<T> &max_vec) {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size(); i++) {
-    c[i] = std::abs(a[i]) < std::abs(min_vec[i]) ? min_vec[i] : (std::abs(a[i]) > std::abs(max_vec[i]) ? max_vec[i] : a[i]);
+    c[i] = std::min(std::max(a[i], min_vec[i]), max_vec[i]);
   }
   return c;
 }
@@ -647,31 +636,11 @@ Vec256<T> inline clamp_max(const Vec256<T> &a, const Vec256<T> &max_vec) {
 }
 
 template <class T,
-          typename std::enable_if<c10::is_complex<T>::value, int>::type = 0>
-Vec256<T> inline clamp_max(const Vec256<T> &a, const Vec256<T> &max_vec) {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size(); i++) {
-    c[i] = std::abs(a[i]) > std::abs(max_vec[i]) ? max_vec[i] : a[i];
-  }
-  return c;
-}
-
-template <class T,
           typename std::enable_if<!c10::is_complex<T>::value, int>::type = 0>
 Vec256<T> inline clamp_min(const Vec256<T> &a, const Vec256<T> &min_vec) {
   Vec256<T> c = Vec256<T>();
   for (int i = 0; i != Vec256<T>::size(); i++) {
     c[i] = a[i] < min_vec[i] ? min_vec[i] : a[i];
-  }
-  return c;
-}
-
-template <class T,
-          typename std::enable_if<c10::is_complex<T>::value, int>::type = 0>
-Vec256<T> inline clamp_min(const Vec256<T> &a, const Vec256<T> &min_vec) {
-  Vec256<T> c = Vec256<T>();
-  for (int i = 0; i != Vec256<T>::size(); i++) {
-    c[i] = std::abs(a[i]) < std::abs(min_vec[i]) ? min_vec[i] : a[i];
   }
   return c;
 }

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -417,32 +417,6 @@ Vec256<c10::complex<double>> inline minimum(const Vec256<c10::complex<double>>& 
 }
 
 template <>
-Vec256<c10::complex<double>> inline clamp(const Vec256<c10::complex<double>>& a, const Vec256<c10::complex<double>>& min, const Vec256<c10::complex<double>>& max) {
-  auto abs_a = a.abs_2_();
-  auto abs_min = min.abs_2_();
-  auto max_mask = _mm256_cmp_pd(abs_a, abs_min, _CMP_LT_OQ);
-  auto abs_max = max.abs_2_();
-  auto min_mask = _mm256_cmp_pd(abs_a, abs_max, _CMP_GT_OQ);
-  return _mm256_blendv_pd(_mm256_blendv_pd(a, min, max_mask), max, min_mask);
-}
-
-template <>
-Vec256<c10::complex<double>> inline clamp_min(const Vec256<c10::complex<double>>& a, const Vec256<c10::complex<double>>& min) {
-  auto abs_a = a.abs_2_();
-  auto abs_min = min.abs_2_();
-  auto max_mask = _mm256_cmp_pd(abs_a, abs_min, _CMP_LT_OQ);
-  return _mm256_blendv_pd(a, min, max_mask);
-}
-
-template <>
-Vec256<c10::complex<double>> inline clamp_max(const Vec256<c10::complex<double>>& a, const Vec256<c10::complex<double>>& max) {
-  auto abs_a = a.abs_2_();
-  auto abs_max = max.abs_2_();
-  auto min_mask = _mm256_cmp_pd(abs_a, abs_max, _CMP_GT_OQ);
-  return _mm256_blendv_pd(a, max, min_mask);
-}
-
-template <>
 Vec256<c10::complex<double>> inline operator&(const Vec256<c10::complex<double>>& a, const Vec256<c10::complex<double>>& b) {
   return _mm256_and_pd(a, b);
 }

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -457,32 +457,6 @@ Vec256<c10::complex<float>> inline minimum(const Vec256<c10::complex<float>>& a,
 }
 
 template <>
-Vec256<c10::complex<float>> inline clamp(const Vec256<c10::complex<float>>& a, const Vec256<c10::complex<float>>& min, const Vec256<c10::complex<float>>& max) {
-  auto abs_a = a.abs_2_();
-  auto abs_min = min.abs_2_();
-  auto max_mask = _mm256_cmp_ps(abs_a, abs_min, _CMP_LT_OQ);
-  auto abs_max = max.abs_2_();
-  auto min_mask = _mm256_cmp_ps(abs_a, abs_max, _CMP_GT_OQ);
-  return _mm256_blendv_ps(_mm256_blendv_ps(a, min, max_mask), max, min_mask);
-}
-
-template <>
-Vec256<c10::complex<float>> inline clamp_min(const Vec256<c10::complex<float>>& a, const Vec256<c10::complex<float>>& min) {
-  auto abs_a = a.abs_2_();
-  auto abs_min = min.abs_2_();
-  auto max_mask = _mm256_cmp_ps(abs_a, abs_min, _CMP_LT_OQ);
-  return _mm256_blendv_ps(a, min, max_mask);
-}
-
-template <>
-Vec256<c10::complex<float>> inline clamp_max(const Vec256<c10::complex<float>>& a, const Vec256<c10::complex<float>>& max) {
-  auto abs_a = a.abs_2_();
-  auto abs_max = max.abs_2_();
-  auto min_mask = _mm256_cmp_ps(abs_a, abs_max, _CMP_GT_OQ);
-  return _mm256_blendv_ps(a, max, min_mask);
-}
-
-template <>
 Vec256<c10::complex<float>> inline operator&(const Vec256<c10::complex<float>>& a, const Vec256<c10::complex<float>>& b) {
   return _mm256_and_ps(a, b);
 }

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -501,7 +501,7 @@ Tensor signbit(const Tensor& self) {
 }
 
 Tensor& clamp_out(Tensor& result, const Tensor& self, optional<Scalar> min, optional<Scalar> max) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
+  TORCH_CHECK(!self.is_complex(), "clamp does not support complex inputs.");
   if (min && max) {
     TORCH_CHECK(self.layout() == Layout::Strided,
                 "clamp only supports strided layout, got: ", self.layout());
@@ -512,7 +512,7 @@ Tensor& clamp_out(Tensor& result, const Tensor& self, optional<Scalar> min, opti
   } else if (min) {
     at::clamp_min_out(result, self, *min);
   } else {
-    AT_ERROR("At least one of 'min' or 'max' must not be None");
+    TORCH_CHECK(false, "At least one of 'min' or 'max' must not be None");
   }
   return result;
 }
@@ -527,7 +527,7 @@ Tensor& clamp_(Tensor& self, optional<Scalar> min, optional<Scalar> max) {
 }
 
 Tensor& clamp_max_out(Tensor& result, const Tensor& self, Scalar max) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
+  TORCH_CHECK(!self.is_complex(), "clamp does not support complex inputs.");
   TORCH_CHECK(self.layout() == Layout::Strided,
               "clamp_max only supports strided layout, got: ", self.layout());
   auto iter = TensorIterator::unary_op(result, self);
@@ -545,7 +545,7 @@ Tensor& clamp_max_(Tensor& self, Scalar max) {
 }
 
 Tensor& clamp_min_out(Tensor& result, const Tensor& self, Scalar min) {
-  TORCH_CHECK(!self.is_complex(), "clamp is not yet implemented for complex tensors.");
+  TORCH_CHECK(!self.is_complex(), "clamp does not support complex inputs.");
   TORCH_CHECK(self.layout() == Layout::Strided,
               "clamp_min only supports strided layout, got: ", self.layout());
   auto iter = TensorIterator::unary_op(result, self);

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -411,36 +411,33 @@ static void nan_to_num_kernel(
 }
 
 static void clamp_kernel(TensorIterator& iter, Scalar min_scalar, Scalar max_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_cpu", [&]() {
-    c10::scalar_value_type<scalar_t>::type (*zabs_)(scalar_t) = zabs;
+  AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "clamp_cpu", [&]() {
     auto min = min_scalar.to<scalar_t>();
     auto max = max_scalar.to<scalar_t>();
     auto min_vec = Vec256<scalar_t>(min);
     auto max_vec = Vec256<scalar_t>(max);
     cpu_kernel_vec(iter,
-     [=](scalar_t a) -> scalar_t { return zabs_(a) < zabs_(min) ? min : (zabs_(a) > zabs_(max) ? max : a); },
+     [=](scalar_t a) -> scalar_t { return std::min(std::max(a, min), max); },
      [=](Vec256<scalar_t> a) { return vec256::clamp(a, min_vec, max_vec); });
   });
 }
 
 static void clamp_max_kernel(TensorIterator& iter, Scalar max_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_max_cpu", [&]() {
-    c10::scalar_value_type<scalar_t>::type (*zabs_)(scalar_t) = zabs;
+  AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "clamp_max_cpu", [&]() {
     auto max = max_scalar.to<scalar_t>();
     auto max_vec = Vec256<scalar_t>(max);
     cpu_kernel_vec(iter,
-     [=](scalar_t a) -> scalar_t { return zabs_(a) > zabs_(max) ? max : a; },
+     [=](scalar_t a) -> scalar_t { return std::min(a, max); },
      [=](Vec256<scalar_t> a) { return vec256::clamp_max(a, max_vec); });
   });
 }
 
 static void clamp_min_kernel(TensorIterator& iter, Scalar min_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "clamp_min_cpu", [&]() {
-    c10::scalar_value_type<scalar_t>::type (*zabs_)(scalar_t) = zabs;
+  AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "clamp_min_cpu", [&]() {
     auto min = min_scalar.to<scalar_t>();
     auto min_vec = Vec256<scalar_t>(min);
     cpu_kernel_vec(iter,
-     [=](scalar_t a) -> scalar_t { return zabs_(a) < zabs_(min) ? min : a; },
+     [=](scalar_t a) -> scalar_t { return std::max(a, min); },
      [=](Vec256<scalar_t> a) { return vec256::clamp_min(a, min_vec); });
   });
 }

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -12,6 +12,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/NumericUtils.h>
 #include <c10/cuda/CUDAMathCompat.h>
+#include <ATen/NumericUtils.h>
 #include <c10/util/complex.h>
 
 namespace at {
@@ -158,7 +159,12 @@ void clamp_kernel_cuda(TensorIterator& iter, Scalar min_value, Scalar max_value)
     auto lower = min_value.to<scalar_t>();
     auto upper = max_value.to<scalar_t>();
     gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t v) -> scalar_t {
-      return (v < lower) ? lower : (v > upper ? upper : v);
+      // Propagate nan, which doesn't propagate automatically for ROCm
+      if (_isnan(v)) {
+        return v;
+      } else {
+        return ::min(::max(v, lower), upper);
+      }
     });
   });
 }
@@ -167,7 +173,12 @@ void clamp_min_kernel_cuda(TensorIterator& iter, Scalar min_value) {
   AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "clamp_min_cuda", [&]() {
     auto lower = min_value.to<scalar_t>();
     gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t v) -> scalar_t {
-      return v < lower ? lower : v;
+      // Propagate nan, which doesn't propagate automatically for ROCm
+      if (_isnan(v)) {
+        return v;
+      } else {
+        return ::max(v, lower);
+      }
     });
   });
 }
@@ -176,7 +187,12 @@ void clamp_max_kernel_cuda(TensorIterator& iter, Scalar max_value) {
   AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "clamp_max_cuda", [&]() {
     auto upper = max_value.to<scalar_t>();
     gpu_kernel(iter, [=]GPU_LAMBDA(scalar_t v) -> scalar_t {
-      return v > upper ? upper : v;
+      // Propagate nan, which doesn't propagate automatically for ROCm
+      if (_isnan(v)) {
+        return v;
+      } else {
+        return ::min(v, upper);
+      }
     });
   });
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6386,85 +6386,96 @@ class TestTorchDeviceType(TestCase):
     def test_logical_or(self, device, dtypes):
         self._test_logical(device, dtypes, 'logical_or', [10, 0, 1, 0], [1, 0, 0, 10], [1, 0, 1, 1])
 
+    def generate_clamp_baseline(self, device, dtype, *, min_vals, max_vals, with_nans):
+        """
+        Creates a random tensor for a given device and dtype, and computes the expected clamped
+        values given the min_vals and/or max_vals.
+        If with_nans is provided, then some values are randomly set to nan.
+        """
+        X = torch.rand(100, device=device).mul(50).add(-25)  # uniform in [-25, 25]
+        X = X.to(dtype)
+        if with_nans:
+            mask = torch.randint(0, 2, X.shape, dtype=torch.bool, device=device)
+            X[mask] = nan
+
+        if isinstance(min_vals, torch.Tensor):
+            min_vals = min_vals.cpu().numpy()
+
+        if isinstance(max_vals, torch.Tensor):
+            max_vals = max_vals.cpu().numpy()
+
+        # Use NumPy implementation as reference
+        X_clamped = torch.tensor(np.clip(X.cpu().numpy(), a_min=min_vals, a_max=max_vals), device=device)
+        return X, X_clamped
+
     # Tests clamp and its alias, clip
-    def test_clamp(self, device):
-        op_list = ((torch.clamp, torch.Tensor.clamp, torch.Tensor.clamp_),
-                   (torch.clip, torch.Tensor.clip, torch.Tensor.clip_))
-        for op, method_op, inplace_op in op_list:
+    @dtypes(torch.int64, torch.float32)
+    def test_clamp(self, device, dtype):
+        op_list = (torch.clamp, torch.Tensor.clamp, torch.Tensor.clamp_, 
+                   torch.clip, torch.Tensor.clip, torch.Tensor.clip_)
 
-            m1 = torch.rand(100, device=device).mul(5).add(-2.5)  # uniform in [-2.5, 2.5]
-            # just in case we're extremely lucky.
-            min_val = -1
-            max_val = 1
-            m1[1] = min_val
-            m1[2] = max_val
+        # min/max argument product
+        args = product((-10, None), (10, None))
 
-            res1 = m1.clone()
-            inplace_op(res1, min_val, max_val)
-            res2 = m1.clone()
-            for i in iter_indices(res2):
-                res2[i] = max(min_val, min(max_val, res2[i]))
-            self.assertEqual(res1, res2)
+        for op in op_list:
+            for min_val, max_val in args:
+                if min_val is None and max_val is None:
+                    continue
 
-            out = m1.clone()
-            op(m1, min=min_val, max=max_val, out=out)
-            self.assertEqual(out, res1)
+                X, Y_expected = self.generate_clamp_baseline(device, dtype,
+                                                             min_vals=min_val,
+                                                             max_vals=max_val,
+                                                             with_nans=False)
 
-            res1 = op(m1, min=min_val)
-            res2 = m1.clone()
-            for i in iter_indices(res2):
-                res2[i] = max(min_val, res2[i])
-            self.assertEqual(res1, res2)
+                # Test op
+                X1 = X.clone()  # So that the in-place ops do not change X
+                Y_actual = op(X1, min_val, max_val)
+                self.assertEqual(Y_expected, Y_actual)
 
-            op(m1, min=min_val, out=out)
-            self.assertEqual(out, res1)
+                # Test op-out behavior (out does not exist for method versions)
+                if op in (torch.clamp, torch.clip):
+                    Y_out = torch.empty_like(X)
+                    op(X, min=min_val, max=max_val, out=Y_out)
+                    self.assertEqual(Y_expected, Y_out)
 
-            res1 = op(m1, max=max_val)
-            res2 = m1.clone()
-            for i in iter_indices(res2):
-                res2[i] = min(max_val, res2[i])
-            self.assertEqual(res1, res2)
+    def test_clamp_propagates_nans(self, device):
+        op_list = (torch.clamp, torch.Tensor.clamp, torch.Tensor.clamp_, 
+                   torch.clip, torch.Tensor.clip, torch.Tensor.clip_)
 
-            op(m1, max=max_val, out=out)
-            self.assertEqual(out, res1)
+        # min/max argument product
+        args = product((-10, None), (10, None))
 
-            # if the tensor contains nan case
-            test_tens = torch.tensor([nan], device=device)
+        for op in op_list:
+            for min_val, max_val in args:
+                if min_val is None and max_val is None:
+                    continue
 
-            res1 = test_tens.clone()
-            inplace_op(res1, min_val, max_val)
-            res2 = test_tens.clone()
-            for i in iter_indices(res2):
-                res2[i] = max(min(res2[i], max_val), min_val)
-            self.assertEqual(torch.isnan(res1), torch.isnan(res2))
+                X, Y_expected = self.generate_clamp_baseline(device, torch.float, 
+                                                             min_vals=min_val, 
+                                                             max_vals=max_val, 
+                                                             with_nans=True)
+                Y_expected = torch.isnan(Y_expected)
 
-            out = test_tens.clone()
-            op(test_tens, min=min_val, max=max_val, out=out)
-            self.assertEqual(torch.isnan(out), torch.isnan(res1))
+                # Test op
+                X1 = X.clone()  # So that the in-place ops do not change X
+                Y_actual = op(X1, min_val, max_val)
+                self.assertEqual(Y_expected, torch.isnan(Y_actual))
 
-            res1 = op(test_tens, min=min_val)
-            res2 = test_tens.clone()
-            for i in iter_indices(res2):
-                res2[i] = max(res2[i], min_val)
-            self.assertEqual(torch.isnan(res1), torch.isnan(res2))
+                # Test op-out behavior (out does not exist for method versions)
+                if op in (torch.clamp, torch.clip):
+                    Y_out = torch.empty_like(X)
+                    op(X, min_val, max_val, out=Y_out)
+                    self.assertEqual(Y_expected, torch.isnan(Y_out))
 
-            op(test_tens, min=min_val, out=out)
-            self.assertEqual(torch.isnan(out), torch.isnan(res1))
-
-            res1 = op(test_tens, max=max_val)
-            res2 = test_tens.clone()
-            for i in iter_indices(res2):
-                res2[i] = min(res2[i], max_val)
-            self.assertEqual(torch.isnan(res1), torch.isnan(res2))
-
-            op(test_tens, max=max_val, out=out)
-            self.assertEqual(torch.isnan(out), torch.isnan(res1))
-
-            error_msg = 'At least one of \'min\' or \'max\' must not be None'
-            with self.assertRaisesRegex(RuntimeError, error_msg):
-                method_op(m1)
-            with self.assertRaisesRegex(RuntimeError, error_msg):
-                inplace_op(m1)
+    def test_clamp_raises_arg_errors(self, device):
+        X = torch.randn(100, dtype=torch.float, device=device)
+        error_msg = 'At least one of \'min\' or \'max\' must not be None'
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            X.clamp()
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            X.clamp_()
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            torch.clamp(X)
 
     @onlyOnCPUAndCUDA
     @dtypes(torch.float32, torch.float64)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1651,18 +1651,12 @@ Keyword args:
 add_docstr(torch.clamp, r"""
 clamp(input, min, max, *, out=None) -> Tensor
 
-Clamp all elements in :attr:`input` into the range `[` :attr:`min`, :attr:`max` `]` and return
-a resulting tensor:
+Clamp all elements in :attr:`input` into the range `[` :attr:`min`, :attr:`max` `]`.
+Let min_value and max_value be :attr:`min` and :attr:`max`, respectively, this returns:
 
 .. math::
-    y_i = \begin{cases}
-        \text{min} & \text{if } x_i < \text{min} \\
-        x_i & \text{if } \text{min} \leq x_i \leq \text{max} \\
-        \text{max} & \text{if } x_i > \text{max}
-    \end{cases}
+    y_i = \min(\max(x_i, \text{min\_value}), \text{max\_value})
 """ + r"""
-If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, args :attr:`min`
-and :attr:`max` must be real numbers, otherwise they should be integers.
 
 Args:
     {input}
@@ -1684,9 +1678,6 @@ Example::
 
 Clamps all elements in :attr:`input` to be larger or equal :attr:`min`.
 
-If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, :attr:`value`
-should be a real number, otherwise it should be an integer.
-
 Args:
     {input}
 
@@ -1705,9 +1696,6 @@ Example::
 .. function:: clamp(input, *, max, out=None) -> Tensor
 
 Clamps all elements in :attr:`input` to be smaller or equal :attr:`max`.
-
-If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, :attr:`value`
-should be a real number, otherwise it should be an integer.
 
 Args:
     {input}

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1659,10 +1659,6 @@ EXCLUDE_GRADGRADCHECK_BY_TEST_NAME = {
 def exclude_tensor_method(name, test_name):
     # there are no tensor equivalents for these (inplace or out)
     exclude_all_tensor_method_by_test_name = {
-        'test_clamp_min',
-        'test_clamp_max',
-        'test_clamp_min_scalar',
-        'test_clamp_max_scalar',
         'test_slice',
         'test_where',
         'test_where_broadcast_all',


### PR DESCRIPTION
**BC-breaking note**

For ease of exposition let a_min be the value of the "min" argument to clamp, and a_max be the value of the "max" argument to clamp.

This PR changes the behavior of torch.clamp to always compute min(max(a, a_min), a_max). torch.clamp currently computes this in its vectorized CPU specializations:

https://github.com/pytorch/pytorch/blob/78b95b6204809822def6dd1b06d03cf002cd30c5/aten/src/ATen/cpu/vec256/vec256_double.h#L304

but in other places it clamps differently:

https://github.com/pytorch/pytorch/blob/78b95b6204809822def6dd1b06d03cf002cd30c5/aten/src/ATen/cpu/vec256/vec256_base.h#L624

https://github.com/pytorch/pytorch/blob/78b95b6204809822def6dd1b06d03cf002cd30c5/aten/src/ATen/native/cuda/UnaryOpsKernel.cu#L160

These implementations are the same when a_min < a_max, but divergent when a_min > a_max. This divergence is easily triggered:

```
t = torch.arange(200).to(torch.float)
torch.clamp(t, 4, 2)[0]
: tensor(2.)

torch.clamp(t.cuda(), 4, 2)[0]
: tensor(4., device='cuda:0')

torch.clamp(torch.tensor(0), 4, 2)
: tensor(4)
```

This PR makes the behavior consistent with NumPy's clip. C++'s std::clamp's behavior is undefined when a_min > a_max, but Clang's std::clamp will return 10 in this case (although the program, per the above comment, is in error). Python has no standard clamp implementation.

**PR Summary**

Fixes discrepancy between AVX, CUDA, and base vector implementation for clamp, such that all implementations are consistent and use min(max_vec, max(min_vec, x) formula, thus making it equivalent to numpy.clip in all implementations.

The same fix as in #32587 but isolated to the kernel change only, so that the internal team can benchmark.