### PR TITLE
[quant] Add benchmarks for quantized embeddingbag module

### DIFF
--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -97,3 +97,15 @@ linear_configs_long = op_bench.cross_product_configs(
     device=['cpu', 'cuda'],
     tags=["long"]
 )
+
+embeddingbag_short_configs = op_bench.cross_product_configs(
+    embeddingbags=[10],#, 120, 1000, 2300],
+    dim=[4],
+    mode=['sum'],
+    input_size=[8],#, 16, 64],
+    offset=[0],
+    sparse=[True],
+    include_last_offset=[True, False],
+    device=['cpu'],
+    tags=['short']
+)

--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -1,40 +1,29 @@
 import operator_benchmark as op_bench
 import torch
 import numpy
+from . import configs
 
 """EmbeddingBag Operator Benchmark"""
 
-embeddingbag_short_configs = op_bench.cross_product_configs(
-    embeddingbags=[80, 120, 1000, 2300],
-    dim=[64],
-    mode=['sum'],
-    input_size=[8, 16, 64],
-    offset=[0],
-    sparse=[True],
-    device=['cpu'],
-    tags=['short']
-)
-
-
 class EmbeddingBagBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, embeddingbags, dim, mode, input_size, offset, sparse, device):
-        self.embegging = torch.nn.EmbeddingBag(
+    def init(self, embeddingbags, dim, mode, input_size, offset, sparse, include_last_offset, device):
+        self.embedding = torch.nn.EmbeddingBag(
             num_embeddings=embeddingbags,
             embedding_dim=dim,
             mode=mode,
+            include_last_offset=include_last_offset,
             sparse=sparse).to(device=device)
         numpy.random.seed((1 << 32) - 1)
         self.input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size), device=device).long()
-        self.offset = torch.LongTensor([offset], device=device)
-
+        offsets = torch.LongTensor([offset], device=device)
+        self.offset = torch.cat((offsets, torch.tensor([self.input.size(0)], dtype=torch.long)), 0)
         self.set_module_name('embeddingbag')
 
     def forward(self):
-        return self.embegging(self.input, self.offset)
+        return self.embedding(self.input, self.offset)
 
-
-op_bench.generate_pt_test(embeddingbag_short_configs, EmbeddingBagBenchmark)
-op_bench.generate_pt_gradient_test(embeddingbag_short_configs, EmbeddingBagBenchmark)
+op_bench.generate_pt_test(configs.embeddingbag_short_configs, EmbeddingBagBenchmark)
+op_bench.generate_pt_gradient_test(configs.embeddingbag_short_configs, EmbeddingBagBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import operator_benchmark as op_bench
+import torch
+import torch.nn.quantized.dynamic as nnqd
+import numpy
+from . import configs
+
+"""
+Microbenchmarks for qEmbeddingBag operators.
+"""
+
+class QEmbeddingBagBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, embeddingbags, dim, mode, input_size, offset, sparse, include_last_offset, device):
+        self.embedding = nnqd.EmbeddingBag(
+            num_embeddings=embeddingbags,
+            embedding_dim=dim,
+            mode=mode,
+            include_last_offset=include_last_offset).to(device=device)
+        numpy.random.seed((1 << 32) - 1)
+        self.input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size), device=device).long()
+        offset = torch.LongTensor([offset], device=device)
+        self.offset = torch.cat((offset, torch.tensor([self.input.size(0)], dtype=torch.long)), 0)
+        self.set_module_name('qEmbeddingBag')
+
+    def forward(self):
+        return self.embedding(self.input, self.offset)
+
+
+op_bench.generate_pt_test(configs.embeddingbag_short_configs, QEmbeddingBagBenchmark)
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43292 [quant] Add benchmarks for quantized embeddingbag module**
* #43176 [quant] Enable from_float for quantized Embedding_Bag
* #43090 [quant] Make offsets an optional argument
* #43088 [quant] Create nn.quantized.dynamic.EmbeddingBag

Summary:
Use common config for float and quantized embedding_bag modules

Test Plan:
```
python -m pt.qembeddingbag_test

Forward Execution Time (us) : 35.738

Forward Execution Time (us) : 62.708

python -m pt.embeddingbag_test

Forward Execution Time (us) : 46.878

Forward Execution Time (us) : 103.904

```

Reviewers:

Subscribers:

Tasks:

Tags: