### PR TITLE
.circleci: Don't quote glob for conda upload

### DIFF
--- a/.circleci/scripts/binary_upload.sh
+++ b/.circleci/scripts/binary_upload.sh
@@ -39,7 +39,7 @@ conda_upload() {
     set -x
     ${ANACONDA} \
       upload  \
-      "${PKG_DIR}/*.tar.bz2" \
+      ${PKG_DIR}/*.tar.bz2 \
       -u "pytorch-${UPLOAD_CHANNEL}" \
       --label main \
       --no-progress \


### PR DESCRIPTION
Globs don't get expanded if you quote them in a bash script...
apparently.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
