### PR TITLE
[ROCm] skip test_rpc in .jenkins/pytorch/test.sh

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -227,9 +227,11 @@ test_distributed() {
 }
 
 test_rpc() {
+  if [[ "$BUILD_ENVIRONMENT" != *rocm* ]]; then
     echo "Testing RPC C++ tests"
     mkdir -p test/test-reports/cpp-rpc
     build/bin/test_cpp_rpc --gtest_output=xml:test/test-reports/cpp-rpc/test_cpp_rpc.xml
+  fi
 }
 
 test_custom_backend() {


### PR DESCRIPTION
#42636 added test_rpc, but this test binary is not built for ROCm.  Skip this test for ROCm builds.