### PR TITLE
DDP communication hook examples

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -981,14 +981,7 @@ void Reducer::finalize_backward() {
           comm_hook_->processFuture(bucket.future_work->value());
 
       for (size_t i = 0; i < future_result.size(); i++) {
-        if (bucket.expect_sparse_gradient) {
-          bucket.replicas[i].contents.copy_(future_result[i]);
-        } else {
-          // Reinitialize bucket_views with the future_result by following
-          // the same logic in `inititalize_buckets`.
-          bucket.replicas[i].bucket_views.clear();
-          initialize_bucketviews(bucket.replicas[i], future_result[i]);
-        }
+        bucket.replicas[i].contents.copy_(future_result[i]);
       }
     }
     if (!bucket.expect_sparse_gradient) {

--- a/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
@@ -1,0 +1,23 @@
+import torch.distributed.algorithms.ddp_comm_hooks.default_hooks as default
+import torch.distributed.algorithms.ddp_comm_hooks.quantization_hooks as quantization
+
+# hook_registry wraps the hooks of ``torch.distributed.algorithms.ddp_comm_hooks``
+# library inside a dictionary. After importing hook_registry user can simply register
+# a hook to a ``ddp_model``` using ``hook_registry(comm_hook)(ddp_model, process_group)``.
+hook_registry = {
+    "quantize per tensor": lambda model, pg: model._register_comm_hook(
+        pg, quantization.quantization_pertensor_hook
+    ),
+    "quantize per channel": lambda model, pg: model._register_comm_hook(
+        pg, quantization.quantization_perchannel_hook
+    ),
+    "allreduce": lambda model, pg: model._register_comm_hook(
+        pg, default.allreduce_hook
+    ),
+    "allgather then aggregate": lambda model, pg: model._register_comm_hook(
+        pg, default.allgather_then_aggregate_hook
+    ),
+    "fp16 compress": lambda model, pg: model._register_comm_hook(
+        pg, default.fp16_compress_hook
+    ),
+}

--- a/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
@@ -1,0 +1,109 @@
+import torch
+import torch.distributed as dist
+
+
+def allreduce_hook(
+    process_group: object, bucket: dist._GradBucket
+) -> torch.futures.Future:
+    """
+        This DDP communication hook just calls ``allreduce`` using ``GradBucket``
+        tensors. Once gradient tensors are aggregated across all workers, its ``then``
+        callback takes the mean and returns the result. If user registers this hook,
+        DDP results is expected to be same as the case where no hook was registered.
+        Hence, this won't change behavior of DDP and user can use this as a reference
+        or modify this hook to log useful information or any other purposes while
+        unaffecting DDP behavior.
+
+        Example::
+            >>> ddp_model._register_comm_hook(process_group, allreduce_hook)
+    """
+    group_to_use = process_group if process_group is not None else dist.group.WORLD
+    world_size = process_group.size() if process_group is not None else dist.get_world_size()
+
+    tensor = bucket.get_tensors()[0]
+    fut = dist.all_reduce(tensor, group=group_to_use, async_op=True).get_future()
+
+    def then_callback(fut):
+        return [fut.value()[0].div_(world_size)]
+
+    return fut.then(then_callback)
+
+
+def get_allgather_out_list(all_gather_in_list, world_size):
+    out_list = [
+        torch.zeros_like(
+            all_gather_in_list,
+            device=all_gather_in_list.device,
+            dtype=all_gather_in_list.dtype,
+        )
+        for _ in range(world_size)
+    ]
+    return out_list
+
+
+def allgather_then_aggregate_hook(
+    process_group: object, bucket: dist._GradBucket
+) -> torch.futures.Future:
+    """
+        Similar to ``allreduce_hook``, this hook first gathers ``GradBucket`` tensors
+        and its ``then`` callback aggregates the gathered gradient tensors and takes
+        mean. Instead of ``allreduce`` this hook uses ``allgather``. Note that with
+        W workers, both the computation and communication time scale as O(W) for
+        allgather compared to O(logW) for allreduce. Therefore, this hook is expected
+        to be much slower than ``allreduce_hook`` although both essentially do the
+        same thing with the gradients.
+
+        .. warning ::
+            This is for test and experiments. User is suggested to use a faster
+            alternative called ``allreduce_hook``  that uses ``allreduce`` protocol
+            instead of ``allgather`` protocol.
+
+        Example::
+            >>> ddp_model._register_comm_hook(process_group, allreduce_hook)
+    """
+    group_to_use = process_group if process_group is not None else dist.group.WORLD
+    rank = process_group.rank() if process_group is not None else dist.get_rank()
+    world_size = process_group.size() if process_group is not None else dist.get_world_size()
+
+    tensor = bucket.get_tensors()[0]
+    fut = dist.all_gather(
+        get_allgather_out_list(tensor, world_size), tensor, group=group_to_use, async_op=True
+    ).get_future()
+
+    def aggregate(fut):
+        all_ranks_tensor = fut.value()[0]
+        tensor = bucket.get_tensors()[0]
+        for r, gathered_tensor in enumerate(all_ranks_tensor):
+            if r != rank:
+                tensor += gathered_tensor
+
+        return [tensor.div_(world_size)]
+
+    return fut.then(aggregate)
+
+
+def fp16_compress_hook(process_group: object, bucket: dist._GradBucket):
+    """
+        This DDP communication hook implements a simple gradient compression
+        approach that converts ``GradBucket`` tensors whose type is assumed to be
+        ``torch.float32`` to half-precision floating point format (``torch.float16``).
+        It allreduces those ``float16`` gradient tensors. Once compressed gradient
+        tensors are allreduced, its then callback called ``decompress`` converts the
+        aggregated result back to ``float32`` and takes the mean.
+
+        Example::
+            >>> ddp_model._register_comm_hook(process_group, fp16_compress_hook)
+    """
+    group_to_use = process_group if process_group is not None else dist.group.WORLD
+    world_size = process_group.size() if process_group is not None else dist.get_world_size()
+
+    compressed_tensor = bucket.get_tensors()[0].to(torch.float16)
+
+    fut = dist.all_reduce(
+        compressed_tensor, group=group_to_use, async_op=True
+    ).get_future()
+
+    def decompress(fut):
+        return [fut.value()[0].to(torch.float32).div_(world_size)]
+
+    return fut.then(decompress)

--- a/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
@@ -1,0 +1,213 @@
+import torch
+import torch.distributed as dist
+from torch import nn
+
+
+def quantize_per_tensor_cuda(x, scale, zero_point):
+    y = torch.round(x / scale) + zero_point
+    y = torch.clamp(y, 0, 255).to(torch.uint8)
+    return y
+
+
+def dequantize_per_tensor_cuda(y, scale, zero_point):
+    x = scale * (y.to(torch.float32) - zero_point)
+    return x
+
+
+def quantize_per_channel_cuda(x, scale, zero_point):
+    y = torch.zeros(x.size(), device=x.device)
+    for i in range(x.size()[0]):
+        y[i, :] = torch.round(x[i, :] / scale[i]) + zero_point[i]
+    y = torch.clamp(y, 0, 255).to(torch.uint8)
+    return y
+
+
+def dequantize_per_channel_cuda(y, scale, zero_point):
+    y = y.to(torch.float32).cuda(y.device)
+    x = torch.zeros_like(y, device=y.device)
+    for i in range(x.size()[0]):
+        x[i, :] = scale[i] * (y[i, :] - zero_point[i])
+    return x
+
+
+def get_allgather_out_list(all_gather_in_list, world_size):
+    out_list = [
+        torch.zeros_like(
+            all_gather_in_list,
+            device=all_gather_in_list.device,
+            dtype=all_gather_in_list.dtype,
+        )
+        for _ in range(world_size)
+    ]
+    return out_list
+
+
+def quantization_pertensor_hook(
+    process_group: object, bucket: dist._GradBucket
+) -> torch.futures.Future:
+    """
+        Applies the ``torch.quantize_per_tensor`` logic to DDP using ``allgather``
+        protocol. Workers first allgather the scale and zero point of their own
+        ``GradBucket`` prior to the quantization. After all workers have that information,
+        the first ``then`` callback called ``quantize_and_allgather`` quantizes worker's
+        own gradient tensors, and uses ``allgather`` to communicate these accross all workers.
+        The final ``then`` callback called ``dequantize_and_aggregate``, dequantizes and
+        aggregates each quantized gradient tensors locally and returns the mean.
+
+        .. warning ::
+            This is experimental, and uses ``allgather`` protocol which is considerably slower than
+            ``allreduce`` protocol. It works only with flattened grads.
+
+        Example::
+            >>> ddp_model._register_comm_hook(process_group, quantization_pertensor_hook)
+    """
+    group_to_use = process_group if process_group is not None else dist.group.WORLD
+    rank = process_group.rank() if process_group is not None else dist.get_rank()
+    world_size = process_group.size() if process_group is not None else dist.get_world_size()
+
+    tensor = bucket.get_tensors()[0]
+
+    myObserver = torch.quantization.MinMaxObserver().cuda(tensor.device)
+    myObserver(tensor)
+
+    s, z = myObserver.calculate_qparams()
+    s_and_z = torch.FloatTensor([s, z]).cuda(tensor.device)
+
+    all_ranks_s_and_z = get_allgather_out_list(s_and_z, world_size)
+
+    # First, allgather scale and zeros.
+    fut = dist.all_gather(
+        all_ranks_s_and_z, s_and_z, group=group_to_use, async_op=True
+    ).get_future()
+
+    def quantize_and_allgather(fut):
+        # Store scale and zeros accross all workers.
+        all_ranks_s_and_z = fut.wait()[0]
+        # All workers quantize their own ``GradBucket`` tensors.
+        quantized_tensor = quantize_per_tensor_cuda(
+            tensor, all_ranks_s_and_z[rank][0], all_ranks_s_and_z[rank][1]
+        )
+        # Allgather quantized tensors.
+        fut = dist.all_gather(
+            get_allgather_out_list(quantized_tensor, world_size),
+            quantized_tensor,
+            group=group_to_use,
+            async_op=True,
+        ).get_future()
+
+        return fut.wait()
+
+    def dequantize_and_aggregate(fut):
+        all_ranks_quantized_tensor = fut.wait()[0]
+
+        aggregated_dequantized_tensor = torch.zeros_like(
+            all_ranks_quantized_tensor[0], device=tensor.device, dtype=torch.float32
+        )
+        # Using previously allgathered scales and zeros, dequantize gradient tensors
+        # locally and then aggregate them.
+        for r, quantized_tensor in enumerate(all_ranks_quantized_tensor):
+            aggregated_dequantized_tensor += dequantize_per_tensor_cuda(
+                quantized_tensor, all_ranks_s_and_z[r][0], all_ranks_s_and_z[r][1]
+            )
+
+        return [aggregated_dequantized_tensor / world_size]
+
+    return fut.then(quantize_and_allgather).then(dequantize_and_aggregate)
+
+
+def quantization_perchannel_hook(
+    process_group: object, bucket: dist._GradBucket, bucket_size=512
+) -> torch.futures.Future:
+    """
+        Applies the ``torch.quantize_per_channel`` logic to DDP using ``allgather``
+        protocol. Compared to pertensor, the main motivation of perchannel is
+        for considerably large tensors such as a tensor that contains 6 million
+        elements quantizing per a bucket size of 512 (or 128) elements may significantly
+        increase the resolution.
+
+        It first splits ``GradBucket`` tensors into multiple chunks (channels) of ``bucket_size``
+        elements. Then, workers allgather the scales and zero points of their own
+        ``GradBucket`` prior to the quantization. After all workers have that information,
+        the first ``then`` callback called ``quantize_and_allgather`` quantizes worker's
+        own gradient tensors, and uses ``allgather`` to communicate these accross all workers.
+        The final ``then`` callback called ``dequantize_and_aggregate``, dequantizes, flattens, and
+        aggregates each quantized gradient tensors locally and returns the mean.
+
+        .. warning ::
+            This is experimental, and uses ``allgather`` protocol which is considerably slower than
+            ``allreduce`` protocol. It works only with flattened grads.
+
+        Example::
+            >>> ddp_model._register_comm_hook(process_group, quantization_perchannel_hook)
+    """
+    group_to_use = process_group if process_group is not None else dist.group.WORLD
+    rank = process_group.rank() if process_group is not None else dist.get_rank()
+    world_size = process_group.size() if process_group is not None else dist.get_world_size()
+
+    tensor = bucket.get_tensors()[0]
+
+    tensor_in_channels = (
+        nn.functional.pad(
+            input=tensor,
+            pad=(0, bucket_size - len(tensor) % bucket_size),
+            mode="constant",
+            value=0,
+        )
+        .view(-1, bucket_size)
+        .cuda(tensor.device)
+    )
+
+    myPerChannelObserver = torch.quantization.PerChannelMinMaxObserver().cuda(
+        tensor.device
+    )
+    myPerChannelObserver(tensor_in_channels)
+
+    s_ch, z_ch = myPerChannelObserver.calculate_qparams()
+    s_and_z = torch.stack((s_ch, z_ch)).cuda(tensor.device)
+
+    all_ranks_s_and_z = get_allgather_out_list(s_and_z, world_size)
+    # First, allgather scale and zeros.
+    fut = dist.all_gather(
+        all_ranks_s_and_z, s_and_z, group=group_to_use, async_op=True
+    ).get_future()
+
+    def quantize_and_allgather(fut):
+        # Store scale and zeros accross all workers.
+        all_ranks_s_and_z = fut.wait()[0]
+        # All workers quantize their corresponding ``GradBucket`` tensors.
+        quantized_tensor = quantize_per_channel_cuda(
+            tensor_in_channels,
+            all_ranks_s_and_z[rank, 0, :],
+            all_ranks_s_and_z[rank, 1, :],
+        )
+        # Allgather quantized tensors.
+        fut = dist.all_gather(
+            get_allgather_out_list(quantized_tensor, world_size),
+            quantized_tensor,
+            group=group_to_use,
+            async_op=True,
+        ).get_future()
+
+        return fut.wait()
+
+    def dequantize_and_aggregate(fut):
+        all_ranks_quantized_tensor = fut.wait()[0]
+
+        aggregated_dequantized_tensor = torch.zeros_like(
+            all_ranks_quantized_tensor[0], device=tensor.device, dtype=torch.float32
+        )
+        # Using previously allgathered scales and zeros, dequantize gradient tensors
+        # locally and then aggregate them.
+        for r, quantized_tensor in enumerate(all_ranks_quantized_tensor):
+            aggregated_dequantized_tensor += dequantize_per_channel_cuda(
+                quantized_tensor, all_ranks_s_and_z[r][0], all_ranks_s_and_z[r][1]
+            )
+
+        return [
+            torch.flatten(aggregated_dequantized_tensor).cuda(tensor.device)[
+                : tensor.size()[0]
+            ]
+            / world_size
+        ]
+
+    return fut.then(quantize_and_allgather).then(dequantize_and_aggregate)

--- a/torch/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
@@ -1,0 +1,203 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+import numpy as np
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+import torch.distributed as c10d
+
+from torch.distributed.algorithms.compression import hook_registry
+
+from torch.testing._internal.common_distributed import MultiProcessTestCase, \
+    requires_nccl, skip_if_lt_x_gpu
+
+from torch.testing._internal.common_utils import run_tests
+
+def gpus_for_rank(world_size):
+    visible_devices = list(range(torch.cuda.device_count()))
+    gpus_per_process = torch.cuda.device_count() // world_size
+    gpus_for_rank = []
+    for rank in range(world_size):
+        gpus_for_rank.append(
+            visible_devices[rank * gpus_per_process : (rank + 1) * gpus_per_process]
+        )
+    return gpus_for_rank
+
+
+class Task(nn.Module):
+    def __init__(self):
+        super(Task, self).__init__()
+        torch.manual_seed(0)
+        self.p = nn.Parameter(torch.randn(40, 20))
+
+    def forward(self, x):
+        return self.p * x
+
+
+class TestDdpCommHook(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.t0 = Task()
+
+    def forward(self, x, rank):
+        return self.t0(x ** (1 + rank))
+
+
+class DistributedDataParallelCommHookTest(MultiProcessTestCase):
+    def setUp(self):
+        super(DistributedDataParallelCommHookTest, self).setUp()
+        self._fork_processes()
+
+    def tearDown(self):
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @property
+    def world_size(self):
+        return 2
+
+
+    def _local_model(self):
+        local_model = TestDdpCommHook().cpu()
+
+        return local_model
+
+    def _get_grads(self, process_group, hook=None):
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        gpu_model = DistributedDataParallel(
+            TestDdpCommHook().to(device_id),
+            device_ids=[device_id],
+            process_group=process_group,
+        )
+
+        # Register DDP Communication Hook if defined
+        if hook is not None:
+            hook_registry[hook](gpu_model, process_group)
+
+        return self._run_and_get_grads(gpu_model)
+
+
+    def _run_and_get_grads(self, model):
+        torch.manual_seed(2020)
+        input = torch.randn(40, 20)
+        # Run forward
+        output = model(input, self.rank)
+
+        # Run backward
+        output.mean().backward()
+
+        return [p.grad.data.cpu().numpy() for p in model.parameters()]
+
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_ddp_comm_hook_allreduce_hook(self):
+        """
+        This unit test verifies the ``allreduce`` hook registered case gives same result
+        with no hook registered case.
+        """
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        def allreduce_hook(state: object, bucket: dist._GradBucket) -> torch._C.Future:
+            tensors = [t / self.world_size for t in bucket.get_tensors()]
+            return process_group.allreduce(tensors).get_future()
+        # No hook registered case, get the reference grads.
+        reference_grads = self._get_grads(process_group, None)
+        # Register hook case, get the hook grads.
+        hook_grads = self._get_grads(process_group, "allreduce")
+
+        np.testing.assert_allclose(hook_grads, reference_grads, rtol=1e-5, atol=0)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_ddp_comm_hook_allgather_hook(self):
+        """
+        This unit test verifies the ``allgather then aggregate`` hook registered case
+        gives the same result with no hook registered case.
+        """
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        def allreduce_hook(state: object, bucket: dist._GradBucket) -> torch._C.Future:
+            tensors = [t / self.world_size for t in bucket.get_tensors()]
+            return process_group.allreduce(tensors).get_future()
+        # No hook registered case, get the reference grads.
+        reference_grads = self._get_grads(process_group, None)
+        # Register hook case, get the hook grads.
+        hook_grads = self._get_grads(process_group, "allgather then aggregate")
+
+        np.testing.assert_allclose(hook_grads, reference_grads, rtol=1e-5, atol=0)
+
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_ddp_comm_hook_fp16compress_hook(self):
+        """
+        This unit test verifies the ``fp16 compress`` hook registered case
+        gives close result with no hook registered case.
+        """
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        def allreduce_hook(state: object, bucket: dist._GradBucket) -> torch._C.Future:
+            tensors = [t / self.world_size for t in bucket.get_tensors()]
+            return process_group.allreduce(tensors).get_future()
+        # No hook registered case, get the reference grads.
+        reference_grads = self._get_grads(process_group, None)
+        # Register hook case, get the hook grads.
+        hook_grads = self._get_grads(process_group, "fp16 compress")
+
+        np.testing.assert_allclose(hook_grads, reference_grads, rtol=1e-5, atol=1e-4)
+
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_ddp_comm_hook_quantize_per_tensor_hook(self):
+        """
+        This unit test verifies the ``quantize per tensor`` hook registered case
+        gives close result with no hook registered case.
+        """
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        def allreduce_hook(state: object, bucket: dist._GradBucket) -> torch._C.Future:
+            tensors = [t / self.world_size for t in bucket.get_tensors()]
+            return process_group.allreduce(tensors).get_future()
+        # No hook registered case, get the reference grads.
+        reference_grads = self._get_grads(process_group, None)
+        # Register hook case, get the hook grads.
+        hook_grads = self._get_grads(process_group, "quantize per tensor")
+
+        np.testing.assert_allclose(hook_grads, reference_grads, rtol=1e-5, atol=1e-4)
+
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_ddp_comm_hook_quantize_per_channel_hook(self):
+        """
+        This unit test verifies the ``quantize per channel`` hook registered case
+        gives close result with no hook registered case.
+        """
+        store = c10d.FileStore(self.file_name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        def allreduce_hook(state: object, bucket: dist._GradBucket) -> torch._C.Future:
+            tensors = [t / self.world_size for t in bucket.get_tensors()]
+            return process_group.allreduce(tensors).get_future()
+        # No hook registered case, get the reference grads.
+        reference_grads = self._get_grads(process_group, None)
+        # Register hook case, get the hook grads.
+        hook_grads = self._get_grads(process_group, "quantize per channel")
+
+        np.testing.assert_allclose(hook_grads, reference_grads, rtol=1e-5, atol=1e-4)
+
+if __name__ == '__main__':
+    assert not torch.cuda._initialized, "test_distributed must not have initialized CUDA context on main process"
+
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43309 DDP communication hook examples**
* #42869 [NCCL] Changed FutureNCCL's then callback logic for better efficiency.

In this diff, we prepared two hooks that quantize float32 into uint8.
1\. The first one `quantization_pertensor_grad_compress_hook` does quantization per tensor and uses the idea in https://pytorch.org/docs/master/generated/torch.quantize_per_tensor.html.  Note that we separately send scale and zero_point (two floats per rank) before quantized tensors.

2\. The second hook `quantization_perchannel_grad_compress_hook` does quantization per channel similar to https://pytorch.org/docs/master/generated/torch.quantize_per_channel.html. The main motivation is that after the initial QSGD study diff, we realized that for considerably large gradient tensors such as a tensor that contains 6 million floats quantizing dividing it into smaller channels (512 float chunks) and quantizing independently may significantly increase the resolution and result with lower error.

We can start to try these two hooks using flow-cli perf/accuracy benchmarks.

Differential Revision: [D22937999](https://our.internmc.facebook.com/intern/diff/D22937999/)