### PR TITLE
[WIP][JIT] Allow DAG module hierarchies and module container attributes

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.jit._recursive import wrap_cpp_module
 
 import io
+import unittest
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -424,8 +425,7 @@ class TestFreezing(JitTestCase):
         output_f = mf.forward(input)
         self.assertEqual(output_s, output_f)
 
-    # FIXME: JIT is not honoring aliasing. 'Sub' module is copied. As a result
-    # Eager and Script modules produce different output.
+    @unittest.skip("Module aliasing has been fixed")
     def test_freeze_module_with_nestedaliasingscalar(self):
         class SubModule(nn.Module):
             def __init__(self):
@@ -478,7 +478,7 @@ class TestFreezing(JitTestCase):
         output_s = ms.forward(input)
         output_f = mf.forward(input)
         # Should be equal
-        self.assertNotEqual(output, output_s)
+        self.assertEqual(output, output_s)
         self.assertEqual(output_s, output_f)
 
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8640,7 +8640,7 @@ a")
                     print(1)
                 return 4
 
-        with self.assertRaisesRegex(RuntimeError, "has no attribute 'mods'"):
+        with self.assertRaisesRegex(RuntimeError, "attribute 'mods' contains reference to another module that is not an attribute"):
             M()
 
     class DerivedStateModule(torch.jit.ScriptModule):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43311 [WIP][JIT] Allow DAG module hierarchies and module container attributes**

Before: recursive scripting implicitly assumes that every module appears
only once in the module hierarchy (i.e. the module structure is a tree).
If the user referenced a module more than once in the hierarchy, it
would just get copied. In pictures:

```
// If you need a module hierarchy that looks like this,
// it won't work as expected.

    A      # `A` is the top-level module
   / \
  B   C    # B and C both have D as a submodule
   \ /
    D

// after scripting, this becomes:

    A
   / \
  B   C
   \   \
    D1  D2     # D1 and D2 have a very weird relationship.
               # Any tensors between them are shared, but nothing else is.
```

This PR adds a deepcopy-style memoization table so that we re-use ScriptModule
objects when they are re-used in the original nn.Module hierarchy. It
also adds support for module attributes that are containers (lists,
dicts, tuples) of submodules.