### PR TITLE
[vulkan] fix invalid memory op and tests

### DIFF
--- a/aten/src/ATen/test/vulkan_test.cpp
+++ b/aten/src/ATen/test/vulkan_test.cpp
@@ -126,10 +126,11 @@ TEST(VulkanTest, conv2d) {
   auto t_in = at::rand({1, C, H, W}, at::device(at::kCPU).dtype(at::kFloat));
   auto t_w = at::rand({OC, C, KH, KW}, at::device(at::kCPU).dtype(at::kFloat));
   auto t_b = at::zeros({OC}, at::device(at::kCPU).dtype(at::kFloat));
-  auto stride = c10::IntArrayRef{1};
-  auto padding = c10::IntArrayRef{0};
-  auto dilation = c10::IntArrayRef{1};
   int64_t groups = 1;
+  std::vector<int64_t> stride{1, 1};
+  std::vector<int64_t> padding{0, 0};
+  std::vector<int64_t> dilation{1, 1};
+
   auto t_out_expected =
       at::conv2d(t_in, t_w, t_b, stride, padding, dilation, groups);
   auto tv_in = t_in.vulkan();
@@ -156,9 +157,9 @@ TEST(VulkanTest, conv2dDWWeightsOnCPU) {
   auto t_w =
       at::rand({groups, 1, KH, KW}, at::device(at::kCPU).dtype(at::kFloat));
   auto t_b = at::zeros({groups}, at::device(at::kCPU).dtype(at::kFloat));
-  auto stride = c10::IntArrayRef{1};
-  auto padding = c10::IntArrayRef{0};
-  auto dilation = c10::IntArrayRef{1};
+  std::vector<int64_t> stride{1, 1};
+  std::vector<int64_t> padding{0, 0};
+  std::vector<int64_t> dilation{1, 1};
   auto t_out_expected =
       at::conv2d(t_in, t_w, t_b, stride, padding, dilation, groups);
   auto tv_in = t_in.vulkan();
@@ -556,9 +557,10 @@ TEST(VulkanTest, conv2dPrepack) {
   auto t_in = at::rand({1, C, 3, 3}, at::device(at::kCPU).dtype(at::kFloat));
   auto t_w = at::rand({OC, C, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
   auto t_b = at::zeros({OC}, at::device(at::kCPU).dtype(at::kFloat));
-  auto stride = c10::IntArrayRef{1};
-  auto padding = c10::IntArrayRef{0};
-  auto dilation = c10::IntArrayRef{1};
+
+  std::vector<int64_t> stride{1, 1};
+  std::vector<int64_t> padding{0, 0};
+  std::vector<int64_t> dilation{1, 1};
   float output_min = 0.25;
   float output_max = 1.0;
 
@@ -622,7 +624,8 @@ TEST(VulkanTest, adaptive_avg_pool2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanTest, adaptive_avg_pool2d_2) {
+// TODO: Enable when view operator for Vulkan landed
+TEST(VulkanTest, DISABLED_adaptive_avg_pool2d_2) {
   if (!at::is_vulkan_available())
     return;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43312 [vulkan] fix invalid memory op and tests**

Differential Revision: [D23232809](https://our.internmc.facebook.com/intern/diff/D23232809)


1. Fix null dereference that was lost during merge conflicts resolution of ( https://github.com/pytorch/pytorch/pull/42194 )

2. Applying lazy allocate storage in pending PRs while was landed https://github.com/pytorch/pytorch/pull/42569

3. Disable test that needs vulkan view which is in PR on review



