### PR TITLE
Minor RPC doc fixes

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -194,7 +194,7 @@ Process Group Backend
 
 The Process Group agent instantiates a process group from
 the :mod:`~torch.distributed` module and utilizes its point-to-point
-communication capabilities to send RPC messages across. Internally, the process
+communication capabilities to send RPC messages. Internally, the process
 group uses `the Gloo library <https://github.com/facebookincubator/gloo/>`_.
 
 Gloo has been hardened by years of extensive use in PyTorch and is thus very

--- a/torch/csrc/distributed/autograd/init.cpp
+++ b/torch/csrc/distributed/autograd/init.cpp
@@ -146,9 +146,9 @@ Arguments:
 Example::
     >>> import torch.distributed.autograd as dist_autograd
     >>> with dist_autograd.context() as context_id:
-    >>>      pred = model.forward()
-    >>>      loss = loss_func(pred, loss)
-    >>>      dist_autograd.backward(context_id, loss)
+    >>>     pred = model.forward()
+    >>>     loss = loss_func(pred, loss)
+    >>>     dist_autograd.backward(context_id, loss)
 )",
       py::arg("contextId"),
       py::arg("roots"),
@@ -180,13 +180,13 @@ Returns:
 Example::
     >>> import torch.distributed.autograd as dist_autograd
     >>> with dist_autograd.context() as context_id:
-    >>>      t1 = torch.rand((3, 3), requires_grad=True)
-    >>>      t2 = torch.rand((3, 3), requires_grad=True)
-    >>>      loss = t1 + t2
-    >>>      dist_autograd.backward(context_id, [loss.sum()])
-    >>>      grads = dist_autograd.get_gradients(context_id)
-    >>>      print(grads[t1])
-    >>>      print(grads[t2])
+    >>>     t1 = torch.rand((3, 3), requires_grad=True)
+    >>>     t2 = torch.rand((3, 3), requires_grad=True)
+    >>>     loss = t1 + t2
+    >>>     dist_autograd.backward(context_id, [loss.sum()])
+    >>>     grads = dist_autograd.get_gradients(context_id)
+    >>>     print(grads[t1])
+    >>>     print(grads[t2])
 )",
       py::arg("context_id"));
 

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -30,8 +30,8 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
         device_maps (Dict[str, Dict]): Device placement mappings from this
             worker to the callee. Key is the callee worker name and value the
             dictionary (``Dict`` of ``int``, ``str``, or ``torch.device``) that
-            maps this worker's device to the callee worker's device to the
-            callee worker's device. (default: ``None``)
+            maps this worker's devices to the callee worker's devices.
+            (default: ``None``)
     """
     def __init__(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43337 Minor RPC doc fixes**
* #43246 Make TensorPipe the default backend for RPC

Differential Revision: [D23242698](https://our.internmc.facebook.com/intern/diff/D23242698)