### PR TITLE
Improves type-checking guards.

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -23,7 +23,7 @@ from ._utils_internal import get_file_path, prepare_multiprocessing_environment,
 from .version import __version__
 from ._six import string_classes as _string_classes
 
-from typing import Set, Type
+from typing import Set, Type, TYPE_CHECKING
 
 __all__ = [
     'typename', 'is_tensor', 'is_storage', 'set_default_tensor_type',
@@ -190,7 +190,7 @@ else:
 
 # Appease the type checker; ordinarily this binding is inserted by the
 # torch._C module initialization code in C
-if False:
+if TYPE_CHECKING:
     import torch._C as _C
 
 __all__ += [name for name in dir(_C)
@@ -419,8 +419,11 @@ del manager_path
 # Note that we will see "too many" functions when reexporting this way; there
 # is not a good way to fix this problem.  Perhaps, try to redesign VariableFunctions
 # so that this import is good enough
-if False:
-    from torch._C._VariableFunctions import *
+if TYPE_CHECKING:
+    # Some type signatures pulled in from _VariableFunctions here clash with 
+    # signatures already imported. For now these clashes are ignored; see
+    # PR #43339 for details.  
+    from torch._C._VariableFunctions import *  # type: ignore
 
 for name in dir(_C._VariableFunctions):
     if name.startswith('__'):


### PR DESCRIPTION
PR #38157 fixed type checking for mypy by including `if False` guards on some type-checker-only imports. However other typecheckers - [like pyright](https://github.com/microsoft/pylance-release/issues/262#issuecomment-677758245) - will respect this logic and ignore the imports. Using [`if TYPE_CHECKING`](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) instead means both mypy and pyright will work correctly.

[For background, an example of where the current code fails](https://github.com/microsoft/pylance-release/issues/262) is if you make a file `tmp.py` with the contents
```python
import torch
torch.ones((1,))
```
Then [`pyright tmp.py --lib`](https://github.com/microsoft/pyright#command-line) will fail with a `"ones" is not a known member of module` error. This is because it can't find the `_VariableFunctions.pyi` stub file, as pyright respects the `if False` logic. After adding the `TYPE_CHECKING` guard, all works correctly.

Credit to @erictraut for suggesting the fix.