### PR TITLE
fix typo in test_dataloader test_multiprocessing_contexts

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1208,7 +1208,8 @@ except RuntimeError as e:
         counting_ds_n = 11
         dl_common_args = dict(num_workers=3, batch_size=3, pin_memory=(not TEST_CUDA))
         for ctx in supported_multiprocessing_contexts:
-            if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS and not TEST_WITH_ROCM:  # windows doesn't support sharing cuda tensor
+            # windows doesn't support sharing cuda tensor; ROCm does not yet fully support IPC
+            if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS and not TEST_WITH_ROCM:
                 ds_cls = CUDACountingDataset
             else:
                 ds_cls = CountingDataset

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1208,7 +1208,7 @@ except RuntimeError as e:
         counting_ds_n = 11
         dl_common_args = dict(num_workers=3, batch_size=3, pin_memory=(not TEST_CUDA))
         for ctx in supported_multiprocessing_contexts:
-            if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS:  # windows doesn't support sharing cuda tensor
+            if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS and not TEST_WITH_ROCM:  # windows doesn't support sharing cuda tensor
                 ds_cls = CUDACountingDataset
             else:
                 ds_cls = CountingDataset

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1209,7 +1209,7 @@ except RuntimeError as e:
         dl_common_args = dict(num_workers=3, batch_size=3, pin_memory=(not TEST_CUDA))
         for ctx in supported_multiprocessing_contexts:
             if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS:  # windows doesn't support sharing cuda tensor
-                dl_cls = CUDACountingDataset
+                ds_cls = CUDACountingDataset
             else:
                 ds_cls = CountingDataset
             self.assertEqual(


### PR DESCRIPTION
#22990 added a multiprocessing_context argument to DataLoader, but a typo in the test causes the wrong DataLoader class to be used.