### PR TITLE
Allocating warp to an input index in compute_cuda_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/Repeat.cu
+++ b/aten/src/ATen/native/cuda/Repeat.cu
@@ -4,12 +4,14 @@
 
 __global__ static void compute_cuda_kernel(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *result_ptr, int64_t size) {
     int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int64_t stride = blockDim.x * gridDim.x;
-    for (int64_t i = idx; i < size; i += stride) {
+    int64_t stride = (blockDim.x * gridDim.x) / C10_WARP_SIZE;
+    int warp_id = idx / C10_WARP_SIZE;
+    int tid_in_warp = idx % C10_WARP_SIZE;
+    for (int64_t i = warp_id; i < size; i += stride) {
         int64_t end = cumsum_ptr[i];
         int64_t repeat = repeat_ptr[i];
         int64_t start = end - repeat;
-        for(int64_t j = start; j < end; j++) {
+        for(int64_t j = start + tid_in_warp; j < end; j += C10_WARP_SIZE) {
             result_ptr[j] = i;
         }
     }
@@ -17,7 +19,9 @@ __global__ static void compute_cuda_kernel(int64_t *repeat_ptr, int64_t *cumsum_
 
 static void compute_cuda(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *result_ptr, int64_t size) {
     int64_t block = 512;
-    int64_t grid = std::min<int64_t>((size + block - 1) / block, 2048L);
+    int64_t warps_per_block = block / C10_WARP_SIZE;
+    int64_t grid = std::min<int64_t>((size + warps_per_block - 1) / warps_per_block, 2048L);
+
     compute_cuda_kernel<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(repeat_ptr, cumsum_ptr, result_ptr, size);
 }
 


### PR DESCRIPTION
Summary: Instead of assigning a thread to an input index for repeating that index, we assign a warp to an index. This helps us in avoiding the costly uncoaelesced memory accesses and brach divergence which occur when each thread is repeating the index.

Test Plan: Run trainer to test

Differential Revision: D23230917

