### PR TITLE
Fix backward compatibility test

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -59,7 +59,7 @@ allow_list = [
     ("aten::unflatten", datetime.date(2020, 8, 14)),
     ("aten::linalg_outer", datetime.date(2020, 8, 30)),
     ("aten::linalg_outer.out", datetime.date(2020, 8, 30)),
-    ("aten::_compute_linear_combination.out", datetime.date(2020, 9, 1)),
+    ("aten::_compute_linear_combination", datetime.date(2020, 9, 1)),
 ]
 
 


### PR DESCRIPTION
Drop `.out` suffix from allow_list pattern added by #43272

