### PR TITLE
Use c10::string_view in more places.

### DIFF
--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -159,7 +159,7 @@ Library& Library::_def(c10::either<c10::OperatorName, c10::FunctionSchema>&& nam
 }
 
 #define IMPL_PRELUDE "impl(\"", name_str, "\", ...): "
-Library& Library::_impl(const char* name_str, CppFunction&& f) & {
+Library& Library::_impl(c10::string_view name_str, CppFunction&& f) & {
   auto name = torch::jit::parseName(name_str);
   auto ns_opt = name.getNamespace();
   // This is kind of similar to the checking in def(), but the error

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -24,8 +24,8 @@ namespace jit {
 
 namespace {
 struct SchemaParser {
-  SchemaParser(const std::string& str)
-      : L(std::make_shared<Source>(str)),
+  SchemaParser(c10::string_view str)
+      : L(std::make_shared<Source>(std::string(str))),
         type_parser(L, /*parse_complete_tensor_types*/ false) {}
 
   either<OperatorName, FunctionSchema> parseDeclaration() {
@@ -292,11 +292,11 @@ struct SchemaParser {
 } // namespace
 
 C10_EXPORT either<OperatorName, FunctionSchema> parseSchemaOrName(
-    const std::string& schemaOrName) {
+    c10::string_view schemaOrName) {
   return SchemaParser(schemaOrName).parseDeclarations().at(0);
 }
 
-C10_EXPORT FunctionSchema parseSchema(const std::string& schema) {
+C10_EXPORT FunctionSchema parseSchema(c10::string_view schema) {
   auto parsed = parseSchemaOrName(schema);
   TORCH_CHECK(
       parsed.is_right(),
@@ -304,7 +304,7 @@ C10_EXPORT FunctionSchema parseSchema(const std::string& schema) {
   return parsed.right();
 }
 
-C10_EXPORT OperatorName parseName(const std::string& name) {
+C10_EXPORT OperatorName parseName(c10::string_view name) {
   auto parsed = parseSchemaOrName(name);
   TORCH_CHECK(
       parsed.is_left(),

--- a/torch/csrc/jit/frontend/function_schema_parser.h
+++ b/torch/csrc/jit/frontend/function_schema_parser.h
@@ -9,9 +9,9 @@ namespace torch {
 namespace jit {
 
 CAFFE2_API c10::either<c10::OperatorName, c10::FunctionSchema> parseSchemaOrName(
-    const std::string& schemaOrName);
-CAFFE2_API c10::FunctionSchema parseSchema(const std::string& schema);
-CAFFE2_API c10::OperatorName parseName(const std::string& name);
+    c10::string_view schemaOrName);
+CAFFE2_API c10::FunctionSchema parseSchema(c10::string_view schema);
+CAFFE2_API c10::OperatorName parseName(c10::string_view name);
 
 } // namespace jit
 } // namespace torch

--- a/torch/library.h
+++ b/torch/library.h
@@ -260,7 +260,7 @@ inline CppFunction dispatch(c10::DeviceType type, Func&& raw_f) {
 /// ```
 ///
 /// \ingroup torch-schema-overloads
-inline c10::FunctionSchema schema(const char* str, c10::AliasAnalysisKind k) {
+inline c10::FunctionSchema schema(c10::string_view str, c10::AliasAnalysisKind k) {
   c10::FunctionSchema s = torch::jit::parseSchema(str);
   s.setAliasAnalysis(k);
   return s;
@@ -269,7 +269,7 @@ inline c10::FunctionSchema schema(const char* str, c10::AliasAnalysisKind k) {
 /// Function schemas can be directly constructed from string literals.
 ///
 /// \ingroup torch-schema-overloads
-inline c10::FunctionSchema schema(const char* s) {
+inline c10::FunctionSchema schema(c10::string_view s) {
   return schema(s, c10::AliasAnalysisKind::FROM_SCHEMA);
 }
 
@@ -289,7 +289,7 @@ namespace detail {
   inline c10::either<c10::OperatorName, c10::FunctionSchema> constructSchemaOrName(c10::OperatorName&& n) {
     return c10::make_left<c10::OperatorName, c10::FunctionSchema>(std::move(n));
   }
-  inline c10::either<c10::OperatorName, c10::FunctionSchema> constructSchemaOrName(const char* str) {
+  inline c10::either<c10::OperatorName, c10::FunctionSchema> constructSchemaOrName(c10::string_view str) {
     auto s = torch::jit::parseSchemaOrName(str);
     if (s.is_right()) {
       s.right().setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
@@ -332,10 +332,10 @@ namespace detail {
   template <bool enabled>
   class SelectiveStr {
   public:
-    constexpr SelectiveStr(const char* name) : name_(name) {}
-    constexpr operator const char*() { return name_; }
+    constexpr SelectiveStr(c10::string_view name) : name_(name) {}
+    constexpr operator c10::string_view() { return name_; }
   private:
-    const char* name_;
+    c10::string_view name_;
   };
 
 #define TORCH_SELECTIVE_NAME(n) torch::detail::SelectiveStr<c10::impl::op_whitelist_check(n)>(n)
@@ -575,7 +575,7 @@ private:
   // public because we only implement & qualifier and not && qualifier
   Library& _def(c10::FunctionSchema&& schema, c10::OperatorName* out_name = nullptr) &;
   Library& _def(c10::either<c10::OperatorName, c10::FunctionSchema>&&, CppFunction&& f) &;
-  Library& _impl(const char* name, CppFunction&& f) &;
+  Library& _impl(c10::string_view name, CppFunction&& f) &;
   Library& _fallback(CppFunction&& f) &;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43412 Add some simple tests for OperatorNameView.
* **#43408 Use c10::string_view in more places.**

Pursuant to https://github.com/pytorch/pytorch/pull/39401#discussion_r474297638

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D23267936](https://our.internmc.facebook.com/intern/diff/D23267936)