### PR TITLE
Add some simple tests for OperatorNameView.

### DIFF
--- a/aten/src/ATen/core/operator_name_test.cpp
+++ b/aten/src/ATen/core/operator_name_test.cpp
@@ -1,0 +1,6 @@
+#include <ATen/core/operator_name.h>
+
+static_assert(c10::OperatorNameView("foo", "bar").name == "foo", "");
+static_assert(c10::OperatorNameView("foo", "bar").overload_name == "bar", "");
+static_assert(c10::OperatorNameView::parse("foo.bar").name == "foo", "");
+static_assert(c10::OperatorNameView::parse("foo.bar").overload_name == "bar", "");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43412 Add some simple tests for OperatorNameView.**
* #43408 Use c10::string_view in more places.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D23269576](https://our.internmc.facebook.com/intern/diff/D23269576)