### PR TITLE
deleted unnecessary dlconvertor internals from test file

### DIFF
--- a/aten/src/ATen/test/dlconvertor_test.cpp
+++ b/aten/src/ATen/test/dlconvertor_test.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 
 using namespace at;
+
 TEST(TestDlconvertor, TestDlconvertor) {
   manual_seed(123);
 
@@ -35,10 +36,19 @@ TEST(TestDlconvertor, TestDlconvertorNullDeleter) {
   manual_seed(123);
 
   Tensor a = rand({3, 4});
-  DLManagedTensor* dlMTensor = toDLPack(a);
-  dlMTensor->deleter = nullptr;
 
-  Tensor b = fromDLPack(dlMTensor);
+  // no deleter necessary since dlManagedTensor is initialized on the stack
+  DLManagedTensor dlMTensor;
+  dlMTensor.deleter = nullptr;
+  dlMTensor.dl_tensor.data = a.data_ptr();
+  dlMTensor.dl_tensor.ctx = getDLContext(a, 0);
+  dlMTensor.dl_tensor.ndim = a.dim();
+  dlMTensor.dl_tensor.dtype = getDLDataType(a);
+  dlMTensor.dl_tensor.shape = const_cast<int64_t*>(a.sizes().data());
+  dlMTensor.dl_tensor.strides = const_cast<int64_t*>(a.strides().data());
+  dlMTensor.dl_tensor.byte_offset = 0;
+
+  Tensor b = fromDLPack(&dlMTensor);
 
   ASSERT_TRUE(a.equal(b));
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43416 deleted unnecessary dlconvertor internals from test file**
* #43271 don't run deleter if it is null. issue #43166

