### PR TITLE
[torch.fx] Pass placeholders through delegate too

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -128,12 +128,6 @@ class Graph:
         i = self._used_names[op] = self._used_names[op] + 1
         return f'{op}_{i}'
 
-    def get_param(self, name: str) -> Node:
-        return self.create_node('get_param', name)
-
-    def placeholder(self, name: str) -> Node:
-        return self.create_node('placeholder', target=name, name=name.replace('*', ''))
-
     def python_code(self, root_module: str) -> Tuple[str, str, List[str]]:
         free_vars: List[str] = []
         body: List[str] = []

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -884,7 +884,7 @@ class Quantizer:
                         qparam_full_path = key + str(i)
                         if parent_name:
                             qparam_full_path = parent_name + '.' + qparam_full_path
-                        inputs.append(self.quantized_graph.get_param(qparam_full_path))
+                        inputs.append(self.quantized_graph.create_node('get_param', qparam_full_path))
                     quant_env[node.name] = self.quantized_graph.create_node('call_function', torch.quantize_per_tensor, inputs, {})
                     continue
             # dequantize inputs for the node that are not quantized


### PR DESCRIPTION
It's useful if we add additional attributed to nodes in the graph - it's easier to set the attribute on all nodes, even if the value would happen to be None.