### PR TITLE
[doc] correct docs for `torch.nonzero`

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4932,6 +4932,9 @@ nonzero(input, *, out=None, as_tuple=False) -> LongTensor or tuple of LongTensor
     gives all nonzero values of tensor ``x``. Of the returned tuple, each index tensor
     contains nonzero indices for a certain dimension.
 
+    `as_tuple` is a required argument since pytorch-1.5. If not passed a warning
+    will be issued.
+
     See below for more details on the two behaviors.
 
 
@@ -4962,6 +4965,7 @@ value, it is treated as a one-dimensional tensor with one element.
 Args:
     {input}
     out (LongTensor, optional): the output tensor containing indices
+    as_tuple (bool, required): see the description above
 
 Returns:
     LongTensor or tuple of LongTensor: If :attr:`as_tuple` is ``False``, the output
@@ -4971,7 +4975,7 @@ Returns:
 
 Example::
 
-    >>> torch.nonzero(torch.tensor([1, 1, 1, 0, 1]))
+    >>> torch.nonzero(torch.tensor([1, 1, 1, 0, 1]), as_tuple=False)
     tensor([[ 0],
             [ 1],
             [ 2],
@@ -4979,7 +4983,7 @@ Example::
     >>> torch.nonzero(torch.tensor([[0.6, 0.0, 0.0, 0.0],
                                     [0.0, 0.4, 0.0, 0.0],
                                     [0.0, 0.0, 1.2, 0.0],
-                                    [0.0, 0.0, 0.0,-0.4]]))
+                                    [0.0, 0.0, 0.0,-0.4]]), as_tuple=False)
     tensor([[ 0,  0],
             [ 1,  1],
             [ 2,  2],

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4921,7 +4921,7 @@ Example::
 
 add_docstr(torch.nonzero,
            r"""
-nonzero(input, *, as_tuple) -> LongTensor or tuple of LongTensors
+nonzero(input, as_tuple) -> LongTensor or tuple of LongTensors
 
 .. note::
     :func:`torch.nonzero(..., as_tuple=False) <torch.nonzero>` returns a

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4932,9 +4932,10 @@ nonzero(input, as_tuple) -> LongTensor or tuple of LongTensors
     gives all nonzero values of tensor ``x``. Of the returned tuple, each index tensor
     contains nonzero indices for a certain dimension.
 
-    `as_tuple` is a required argument since pytorch-1.5. If not passed, a warning
-    will be issued. When `nonzero` is called without any arguments besides the tensor 
-    it conflict with the now deprecated `nonzero(input, *, out)` signature.
+    `as_tuple` is a required argument since pytorch-1.5. If not passed, it will behave 
+    as if `as_tuple=False` was passed and a warning will be issued. When `nonzero` is called 
+    without any arguments besides the tensor it conflict with the now deprecated 
+    `nonzero(input, *, out)` signature.
 
     See below for more details on the two behaviors.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4932,10 +4932,10 @@ nonzero(input, as_tuple) -> LongTensor or tuple of LongTensors
     gives all nonzero values of tensor ``x``. Of the returned tuple, each index tensor
     contains nonzero indices for a certain dimension.
 
-    `as_tuple` is a required argument since pytorch-1.5. If not passed, it will behave 
-    as if `as_tuple=False` was passed and a warning will be issued. When `nonzero` is called 
+    ``as_tuple`` is a required argument since pytorch-1.5. If not passed, it will behave 
+    as if ``as_tuple=False`` was passed and a warning will be issued. When ``nonzero`` is called 
     without any arguments besides the tensor it conflict with the now deprecated 
-    `nonzero(input, *, out)` signature.
+    ``nonzero(input, *, out)`` signature.
 
     See below for more details on the two behaviors.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4921,10 +4921,10 @@ Example::
 
 add_docstr(torch.nonzero,
            r"""
-nonzero(input, *, out=None, as_tuple=False) -> LongTensor or tuple of LongTensors
+nonzero(input, *, as_tuple) -> LongTensor or tuple of LongTensors
 
 .. note::
-    :func:`torch.nonzero(..., as_tuple=False) <torch.nonzero>` (default) returns a
+    :func:`torch.nonzero(..., as_tuple=False) <torch.nonzero>` returns a
     2-D tensor where each row is the index for a nonzero value.
 
     :func:`torch.nonzero(..., as_tuple=True) <torch.nonzero>` returns a tuple of 1-D
@@ -4932,13 +4932,14 @@ nonzero(input, *, out=None, as_tuple=False) -> LongTensor or tuple of LongTensor
     gives all nonzero values of tensor ``x``. Of the returned tuple, each index tensor
     contains nonzero indices for a certain dimension.
 
-    `as_tuple` is a required argument since pytorch-1.5. If not passed a warning
-    will be issued.
+    `as_tuple` is a required argument since pytorch-1.5. If not passed, a warning
+    will be issued. When `nonzero` is called without any arguments besides the tensor 
+    it conflict with the now deprecated `nonzero(input, *, out)` signature.
 
     See below for more details on the two behaviors.
 
 
-**When** :attr:`as_tuple` **is ``False`` (default)**:
+**When** :attr:`as_tuple` **is ``False`` **:
 
 Returns a tensor containing the indices of all non-zero elements of
 :attr:`input`.  Each row in the result contains the indices of a non-zero
@@ -4964,8 +4965,7 @@ value, it is treated as a one-dimensional tensor with one element.
 
 Args:
     {input}
-    out (LongTensor, optional): the output tensor containing indices
-    as_tuple (bool, required): see the description above
+    as_tuple (bool, required): see the detailed description above
 
 Returns:
     LongTensor or tuple of LongTensor: If :attr:`as_tuple` is ``False``, the output


### PR DESCRIPTION
As discussed at https://github.com/pytorch/pytorch/issues/43425
- `as_tuple` is a required argument since pytorch-1.5. If not passed, a warning  will be issued.
- adjust the examples to reflect that
- fix the function signature to reflect reality (`out` out, `as_tuple` in)

Fixes #32994, #43425
