### PR TITLE
[torch.fx] Don't add `root.root` when retracing GraphModule

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -40,6 +40,14 @@ class TestFX(TestCase):
 
         ms = torch.jit.script(gm)
 
+        gmr = symbolic_trace(gm)
+        self.assertEqual(len(gm.graph.nodes), len(gmr.graph.nodes))
+        for n, nr in zip(gm.graph.nodes, gmr.graph.nodes):
+            self.assertEqual(n.op, nr.op)
+            self.assertEqual(n.target, nr.target)
+            self.assertEqual(n.name, nr.name)
+        self.assertEqual(gm.graph.result.name, gmr.graph.result.name)
+
         class M2(torch.nn.Module):
             def forward(self, A):
                 m, idx = torch.max(A, 0)


### PR DESCRIPTION
Sometimes it's needed to retrace the graphmodule, e.g. to inline some of the submodules (by providing different is_leaf_module function). In those cases it's annoying that we end up with nested `self.root.root` calls.

This also makes `symbolic_trace` idempotent which is nice by itself.

Alternative idea would be to copy submodules onto GraphModule instead of using the self.root trick. Let me know which one is preferred.