### PR TITLE
[quant][graphmode][fx] Add support for general shape ops

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -5,7 +5,17 @@ import torch.nn.quantized as nnq
 import torch.nn.quantized.dynamic as nnqd
 import torch.nn.intrinsic.quantized as nniq
 
-from torch.quantization.fx import QuantType
+# symbolic trace
+from torch.fx import symbolic_trace
+
+# graph mode quantization based on fx
+from torch.quantization._quantize_fx import (
+    Quantizer,
+    QuantType,
+    fuse,
+)
+
+from torch.quantization import default_qconfig
 
 # test utils
 from torch.testing._internal.common_quantization import (
@@ -525,3 +535,121 @@ class TestQuantizeFxOps(QuantizationTestCase):
         ]
         for quant_type in self.static_quant_types:
             m = self.checkGraphModeFxOp(M(), data, checks, quant_type)
+
+
+    def test_general_shape_ops(self):
+        """ A test that checks dequantize will be swapped for
+        all supported general shape ops like aten::flatten
+        without actually checking for execution of these ops
+        """
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.maxpool1d = torch.nn.MaxPool1d(kernel_size=3)
+                self.maxpool2d = torch.nn.MaxPool2d(kernel_size=3)
+                self.maxpool3d = torch.nn.MaxPool3d(kernel_size=3)
+                self.dropout = torch.nn.Dropout()
+                self.conv1 = torch.nn.Conv2d(3, 3, 3)
+                self.conv2 = torch.nn.Conv2d(3, 3, 3)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                x = self.conv1(x)
+                # add_scalar
+                x = x + 3
+                # mul_scalar
+                x = x * 3
+                # add_scalar_out
+                x += 3
+                # mul_scalar_out
+                x *= 3
+                # add_scalar_relu
+                x = x + 3
+                x = F.relu(x)
+                # add_scalar_relu_out
+                x += 3
+                x = F.relu(x)
+                # mul_scalar_relu
+                x = x * 3
+                x = F.relu(x)
+                # mul_scalar_relu_out
+                x *= 3
+                x = F.relu(x)
+                x = self.maxpool1d(x)
+                x = self.maxpool2d(x)
+                x = self.maxpool3d(x)
+                x = torch.flatten(x)
+                x = torch.max(x)
+                x = torch.min(x)
+                x = x.reshape([-1])
+                x = x.resize_(1, 1, x.numel())
+                x = x.view(-1)
+                # prim::ListConstruct
+                xs = [x, x]
+                # prim::ListUnpack
+                x, y = xs
+                # prim::TupleConstruct
+                xs = (x, x)
+                # prim::TupleUnpack
+                x, y = xs
+                x = x.transpose(1, 2)
+                x = x.contiguous()
+                x, y = torch.chunk(x, 2)
+                x = F.dropout(x)
+                x = self.dropout(x)
+                x, _ = torch.sort(x)
+                x = x.permute(0, 2, 3, 1)
+                x = x.repeat_interleave(3, 1)
+                x = torch.repeat_interleave(x, 3, 1)
+                x = self.relu(x)
+                x = F.relu(x)
+                x = F.relu(x, inplace=True)
+                x = x.relu()
+                x.relu_()
+                x = x.squeeze(0)
+                x.squeeze_(0)
+                x = torch.squeeze(x, 0)
+                x = x.unsqueeze(0)
+                x.unsqueeze_(0)
+                x = torch.unsqueeze(x, 0)
+                x = x.detach()
+                x.detach_()
+                x = x.repeat(4, 2)
+                y = []
+                y.append(x)
+                z = torch.stack(y, 0)
+                z = [z, z]
+                x, _ = z
+                x = self.conv2(x)
+                return x
+
+        data = torch.rand(1, 3, 10, 10)
+        # This model is not executable since we just put all ops
+        # in the same forward
+        m = M()
+        original = symbolic_trace(m)
+        # nothing to fuse so skipping the fuse step
+        quantizer = Quantizer()
+        qconfig_dict = {'': default_qconfig}
+        prepared = quantizer.prepare(original, qconfig_dict)
+        # not runnable
+        quantized = quantizer.convert(prepared)
+
+        # This checks that the dequantize from the output of first conv
+        # is being propagated to the end, so that we don't insert extra
+        # observers and also successfully fused two quantized::conv2d
+        # patterns
+        # one quantize_per_tensor for input
+        order_check = [
+            ('call_function', torch.quantize_per_tensor),
+            ('call_module', nnq.Conv2d),
+            ('call_module', nnq.Conv2d),
+            ('call_method', 'dequantize'),
+        ]
+        # check exact counts of quantize and dequantize
+        count_check = {
+            ('call_function', torch.quantize_per_tensor) : 1,
+            ('call_method', 'dequantize') : 1
+        }
+        for check in (order_check, count_check):
+            self.checkGraphModule(quantized, check)

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -784,8 +784,11 @@ class Quantizer:
                 elif node.name in env:
                     return False
             elif isinstance(node, list):
-                if all(map(is_quantized, node)):
+                quantized = map(is_quantized, node)
+                if all(quantized):
                     return True
+                elif not any(quantized):
+                    return False
                 else:
                     raise Exception("partially quantized inputs in list not handled yet")
 

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -455,7 +455,9 @@ class ELU(QuantizeHandler):
 @register_quant_pattern(torch.nn.AvgPool2d)
 @register_quant_pattern(torch.nn.Dropout)
 @register_quant_pattern(torch.nn.Hardtanh)
+@register_quant_pattern(torch.nn.MaxPool1d)
 @register_quant_pattern(torch.nn.MaxPool2d)
+@register_quant_pattern(torch.nn.MaxPool3d)
 @register_quant_pattern(torch.nn.ReLU)
 @register_quant_pattern(torch.nn.ReLU6)
 @register_quant_pattern(torch.nn.functional.adaptive_avg_pool2d)
@@ -463,22 +465,44 @@ class ELU(QuantizeHandler):
 @register_quant_pattern(torch.nn.functional.hardtanh)
 @register_quant_pattern(torch.nn.functional.hardtanh_)
 @register_quant_pattern(torch.nn.functional.max_pool2d)
+@register_quant_pattern(torch.nn.functional.relu)
 @register_quant_pattern(torch.nn.functional.relu6)
 @register_quant_pattern(torch._C._nn.avg_pool2d)
+@register_quant_pattern(torch.chunk)
 @register_quant_pattern(torch.clamp)
 @register_quant_pattern(torch.flatten)
 @register_quant_pattern(torch.transpose)
+@register_quant_pattern(torch.max)
 @register_quant_pattern(torch.mean)
+@register_quant_pattern(torch.min)
+@register_quant_pattern(torch.repeat_interleave)
+@register_quant_pattern(torch.sort)
+@register_quant_pattern(torch.squeeze)
+@register_quant_pattern(torch.stack)
 @register_quant_pattern(torch.unsqueeze)
 @register_quant_pattern(operator.getitem)
 @register_quant_pattern(operator.floordiv)
 @register_quant_pattern('chunk')
 @register_quant_pattern('clamp')
 @register_quant_pattern('contiguous')
+@register_quant_pattern('detach')
+@register_quant_pattern('detach_')
 @register_quant_pattern('mean')
+@register_quant_pattern('numel')
+@register_quant_pattern('permute')
+@register_quant_pattern('relu')
+@register_quant_pattern('relu_')
+@register_quant_pattern('repeat')
+@register_quant_pattern('repeat_interleave')
 @register_quant_pattern('reshape')
+@register_quant_pattern('resize_')
 @register_quant_pattern('shape')
 @register_quant_pattern('size')
+@register_quant_pattern('squeeze')
+@register_quant_pattern('squeeze_')
+@register_quant_pattern('unsqueeze')
+@register_quant_pattern('unsqueeze_')
+@register_quant_pattern('transpose')
 @register_quant_pattern('view')
 class CopyNode(QuantizeHandler):
     def convert(self, quantizer, node, load_arg, debug=False):
@@ -646,8 +670,13 @@ class Quantizer:
                         'call_function',
                         'call_method'], \
                         'CopyNode of type ' + node.op + ' is not handled'
+                    def is_observed(input_arg):
+                        if isinstance(input_arg, Node):
+                            return input_arg.name in observed
+                        elif isinstance(input_arg, list):
+                            return all(map(is_observed, input_arg))
                     # propagate observed property from input
-                    if node.args[0].name in observed:
+                    if is_observed(node.args[0]):
                         observed.add(node.name)
                 elif (isinstance(obj, Add) or isinstance(obj, Mul)) and not obj.all_nodes:
                     if node.args[0].name in observed:
@@ -745,13 +774,19 @@ class Quantizer:
             return load_arg_impl
 
         def is_quantized(node):
-            assert node.name in env or node.name in quant_env, 'Expecting node to be in the environment'
-            # there might be nodes appearing in both environemnts, but quant_env will take
-            # precedence
-            if node.name in quant_env:
-                return True
-            elif node.name in env:
-                return False
+            if isinstance(node, Node):
+                assert node.name in env or node.name in quant_env, 'Expecting node to be in the environment'
+                # there might be nodes appearing in both environemnts, but quant_env will take
+                # precedence
+                if node.name in quant_env:
+                    return True
+                elif node.name in env:
+                    return False
+            elif isinstance(node, list):
+                if all(map(is_quantized, node)):
+                    return True
+                else:
+                    raise Exception("partially quantized inputs in list not handled yet")
 
         for node in observed_graph.nodes:
             root_node, matched, obj, qconfig = matches.get(node.name, (None, None, None, None))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43445 [quant][graphmode[fx][test][refactor] Refactor tests for graph mode quantization on fx
* #43439 [quant][graphmode][fx] Add support for general value ops
* **#43438 [quant][graphmode][fx] Add support for general shape ops**
* #43437 [quant][graphmode][fx] Add support for clamp

Summary:
Porting op tests from test_quantize_jit.py

Test Plan:
TestQuantizeFxOps

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23278583](https://our.internmc.facebook.com/intern/diff/D23278583)