### PR TITLE
Implement sort for list of tuples

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -3,6 +3,7 @@
 #include <ATen/core/Formatting.h>
 #include <ATen/core/function.h>
 #include <ATen/core/jit_type.h>
+#include <ATen/core/stack.h>
 #include <c10/util/StringUtil.h>
 #include <cmath>
 
@@ -44,50 +45,6 @@ bool operator==(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs) {
              lhs.elements_.cend(),
              rhs.elements_.cbegin(),
              _fastEqualsForContainer);
-}
-
-bool operator<(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs) {
-  const auto& lhs_vals = lhs.elements();
-  const auto& rhs_vals = rhs.elements();
-
-  TORCH_INTERNAL_ASSERT(
-      lhs_vals.size() == rhs_vals.size(),
-      "tuples of different length can not be compared");
-
-  const size_t n = lhs_vals.size();
-  for(size_t i = 0; i < n; ++i) {
-    if(lhs_vals[i] < rhs_vals[i]) {
-      return true;
-    }
-    if(lhs_vals[i] > rhs_vals[i]) {
-      return false;
-    }
-  }
-
-  // Reaching here means rhs and lhs are equal.
-  return false;
-}
-
-bool operator>(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs) {
-  const auto& lhs_vals = lhs.elements();
-  const auto& rhs_vals = rhs.elements();
-
-  TORCH_INTERNAL_ASSERT(
-      lhs_vals.size() == rhs_vals.size(),
-      "tuples of different length can not be compared");
-
-  const size_t n = lhs_vals.size();
-  for(size_t i = 0; i < n; ++i) {
-    if(lhs_vals[i] > rhs_vals[i]) {
-      return true;
-    }
-    if(lhs_vals[i] < rhs_vals[i]) {
-      return false;
-    }
-  }
-
-  // Reaching here means rhs and lhs are equal.
-  return false;
 }
 
 TupleTypePtr Tuple::type() const {
@@ -507,48 +464,121 @@ std::ostream& IValue::repr(
   }
 }
 
-
-
-bool operator<(const IValue& a, const IValue& b) {
-  // Must be same type to be compared.
-  TORCH_INTERNAL_ASSERT(a.tag == b.tag, "IValues of different types can not be compared");
-  switch (a.tag) {
-    case IValue::Tag::Tensor:
-       return a.toTensor().lt(b.toTensor()).is_nonzero();
-    case IValue::Tag::Double:
-       return a.toDouble() < b.toDouble();
-    case IValue::Tag::Int:
-       return a.toInt() < b.toInt();
-    case IValue::Tag::Bool:
-       return a.toBool() == false && b.toBool() == true;
-    case IValue::Tag::String:
-       return a.toString()->string() < b.toString()->string();
-    case IValue::Tag::Tuple:
-       return *a.toTuple() < *b.toTuple();
-    default:
-      AT_ERROR("IValue of type: ", a.tagKind(), " is not comparable");
-  }
+bool simpleClassTypeArg(const Argument& arg, const ClassTypePtr& type) {
+  return arg.type() == type && !arg.kwarg_only() && !arg.default_value();
 }
 
-bool operator>(const IValue& a, const IValue& b) {
-  // Must be same type to be compared.
-  TORCH_INTERNAL_ASSERT(a.tag == b.tag, "IValues of different types can not be compared");
-  switch (a.tag) {
-    case IValue::Tag::Tensor:
-       return a.toTensor().gt(b.toTensor()).is_nonzero();
-    case IValue::Tag::Double:
-       return a.toDouble() > b.toDouble();
-    case IValue::Tag::Int:
-       return a.toInt() > b.toInt();
-    case IValue::Tag::Bool:
-       return a.toBool() == true && b.toBool() == false;
-    case IValue::Tag::String:
-       return a.toString()->string() > b.toString()->string();
-    case IValue::Tag::Tuple:
-       return *a.toTuple() > *b.toTuple();
-    default:
-      AT_ERROR("IValue of type: ", a.tagKind(), " is not comparable");
+torch::jit::Function* checkObjectSortSchema(const c10::ClassTypePtr& t, std::stringstream& why_not) {
+  if (auto method = t->findMethod("__lt__")) {
+      const auto& lt_schema = method->getSchema();
+      const auto& schema_args = lt_schema.arguments();
+      bool error =
+          (schema_args.size() != 2 ||
+           !simpleClassTypeArg(schema_args[0], t) ||
+           !simpleClassTypeArg(schema_args[1], t) ||
+           lt_schema.returns().size() != 1 ||
+           lt_schema.returns()[0].type() != BoolType::get());
+      if (!error) {
+        return method;
+      }
+    }
+
+    why_not << "To sort a list of " << t->repr_str()
+            << " it must define a "
+            << "__lt__ method with two inputs of type "
+            << t->repr_str() << " that "
+            << "returns a bool";
+    return nullptr;
+}
+
+IValueComparator getLessThanComparator(const IValue& v) {
+  if (v.isTensor()) {
+      return [](const IValue& a, const IValue& b) {
+        return a.toTensor().lt(b.toTensor()).is_nonzero();
+      };
   }
+
+  if (v.isDouble()) {
+      return [](const IValue& a, const IValue& b) {
+        return a.toDouble() < b.toDouble();
+      };
+  }
+
+  if (v.isInt()) {
+      return [](const IValue& a, const IValue& b) {
+        return a.toInt() < b.toInt();
+      };
+  }
+
+  if (v.isBool()) {
+      return [](const IValue& a, const IValue& b) {
+        return a.toBool() == false && b.toBool() == true;
+      };
+  }
+
+  if (v.isString()) {
+      return [](const IValue& a, const IValue& b) {
+       return a.toString()->string() < b.toString()->string();
+      };
+  }
+
+  if (v.isTuple()) {
+      const auto& elements = v.toTuple()->elements();
+      size_t n = elements.size();
+
+      std::vector<IValueComparator> elements_lts;
+      elements_lts.reserve(n);
+      for (size_t i = 0; i < n; ++i) {
+        elements_lts.push_back(getLessThanComparator(elements[i]));
+      }
+
+      return [elements_lts=std::move(elements_lts), n](const IValue& a, const IValue& b) {
+        const auto& a_elements = a.toTuple()->elements();
+        const auto& b_elements = b.toTuple()->elements();
+
+        for (size_t i = 0; i < n; ++i) {
+          if (elements_lts[i](a_elements[i], b_elements[i])) {
+            return true;
+          }
+          if (a_elements[i] == b_elements[i]) {
+            continue;
+          }
+          return false;
+        }
+        // Reaching here means two tuples are equal.
+        return false;
+      };
+  }
+
+  if (v.isObject()) {
+    std::stringstream why_not;
+    torch::jit::Function* lt_func =
+        checkObjectSortSchema(v.type()->expect<ClassType>(), why_not);
+    if (!lt_func) {
+      AT_ERROR(why_not.str());
+    }
+
+    return [lt_func](const IValue& a, const IValue& b) {
+      // Quick pass to satisfy "strict weak ordering" requirement
+      if (a.is(b)) {
+        return false;
+      }
+      torch::jit::Stack sort_stack;
+      sort_stack.push_back(a);
+      sort_stack.push_back(b);
+      lt_func->run(sort_stack);
+      return torch::jit::pop(sort_stack).toBool();
+    };
+  }
+
+  AT_ERROR("IValues of type: ", v.tagKind(), " are not comparable");
+}
+
+IValueComparator getGreaterThanComparator(const IValue& v) {
+  auto lt = getLessThanComparator(v);
+  return [lt = std::move(lt)](const IValue& a, const IValue& b) {
+    return lt(b, a);  // gt(a, b) === lt(b, a)
+  };
 }
 
 std::ostream& operator<<(std::ostream& out, const ivalue::EnumHolder& v) {

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -46,6 +46,50 @@ bool operator==(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs) {
              _fastEqualsForContainer);
 }
 
+bool operator<(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs) {
+  const auto& lhs_vals = lhs.elements();
+  const auto& rhs_vals = rhs.elements();
+
+  TORCH_INTERNAL_ASSERT(
+      lhs_vals.size() == rhs_vals.size(),
+      "tuples of different length can not be compared");
+
+  const size_t n = lhs_vals.size();
+  for(size_t i = 0; i < n; ++i) {
+    if(lhs_vals[i] < rhs_vals[i]) {
+      return true;
+    }
+    if(lhs_vals[i] > rhs_vals[i]) {
+      return false;
+    }
+  }
+
+  // Reaching here means rhs and lhs are equal.
+  return false;
+}
+
+bool operator>(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs) {
+  const auto& lhs_vals = lhs.elements();
+  const auto& rhs_vals = rhs.elements();
+
+  TORCH_INTERNAL_ASSERT(
+      lhs_vals.size() == rhs_vals.size(),
+      "tuples of different length can not be compared");
+
+  const size_t n = lhs_vals.size();
+  for(size_t i = 0; i < n; ++i) {
+    if(lhs_vals[i] > rhs_vals[i]) {
+      return true;
+    }
+    if(lhs_vals[i] < rhs_vals[i]) {
+      return false;
+    }
+  }
+
+  // Reaching here means rhs and lhs are equal.
+  return false;
+}
+
 TupleTypePtr Tuple::type() const {
   if (!type_) {
     type_ = TupleType::create(
@@ -460,6 +504,50 @@ std::ostream& IValue::repr(
     }
     default:
       TORCH_INTERNAL_ASSERT(false, "repr() not defined on: ", v.tagKind());
+  }
+}
+
+
+
+bool operator<(const IValue& a, const IValue& b) {
+  // Must be same type to be compared.
+  TORCH_INTERNAL_ASSERT(a.tag == b.tag, "IValues of different types can not be compared");
+  switch (a.tag) {
+    case IValue::Tag::Tensor:
+       return a.toTensor().lt(b.toTensor()).is_nonzero();
+    case IValue::Tag::Double:
+       return a.toDouble() < b.toDouble();
+    case IValue::Tag::Int:
+       return a.toInt() < b.toInt();
+    case IValue::Tag::Bool:
+       return a.toBool() == false && b.toBool() == true;
+    case IValue::Tag::String:
+       return a.toString()->string() < b.toString()->string();
+    case IValue::Tag::Tuple:
+       return *a.toTuple() < *b.toTuple();
+    default:
+      AT_ERROR("IValue of type: ", a.tagKind(), " is not comparable");
+  }
+}
+
+bool operator>(const IValue& a, const IValue& b) {
+  // Must be same type to be compared.
+  TORCH_INTERNAL_ASSERT(a.tag == b.tag, "IValues of different types can not be compared");
+  switch (a.tag) {
+    case IValue::Tag::Tensor:
+       return a.toTensor().gt(b.toTensor()).is_nonzero();
+    case IValue::Tag::Double:
+       return a.toDouble() > b.toDouble();
+    case IValue::Tag::Int:
+       return a.toInt() > b.toInt();
+    case IValue::Tag::Bool:
+       return a.toBool() == true && b.toBool() == false;
+    case IValue::Tag::String:
+       return a.toString()->string() > b.toString()->string();
+    case IValue::Tag::Tuple:
+       return *a.toTuple() > *b.toTuple();
+    default:
+      AT_ERROR("IValue of type: ", a.tagKind(), " is not comparable");
   }
 }
 

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -651,6 +651,9 @@ struct CAFFE2_API IValue final {
       std::function<bool(std::ostream&, const IValue& v)> customFormatter)
       const;
 
+  CAFFE2_API friend bool operator<(const IValue& a, const IValue& b);
+  CAFFE2_API friend bool operator>(const IValue& a, const IValue& b);
+
   // Computes an "informal" string representation of an IValue. This should be
   // used for debugging, or servicing `print()`-like functions.
   // This is different from `repr()` in that there is no expectation that we can

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -30,6 +30,14 @@ using ClassTypePtr = std::shared_ptr<ClassType>;
 
 TORCH_API bool _fastEqualsForContainer(const IValue& lhs, const IValue& rhs);
 
+TORCH_API torch::jit::Function* checkObjectSortSchema(const c10::ClassTypePtr& t, std::stringstream& why_not);
+
+// A comparator that checks ordering of two IValues of same type.
+typedef std::function<bool(const IValue& a, const IValue& b)> IValueComparator;
+
+TORCH_API IValueComparator getLessThanComparator(const IValue& v);
+TORCH_API IValueComparator getGreaterThanComparator(const IValue& v);
+
 namespace ivalue {
 struct Tuple;
 struct Future;
@@ -650,9 +658,6 @@ struct CAFFE2_API IValue final {
       std::ostream& stream,
       std::function<bool(std::ostream&, const IValue& v)> customFormatter)
       const;
-
-  CAFFE2_API friend bool operator<(const IValue& a, const IValue& b);
-  CAFFE2_API friend bool operator>(const IValue& a, const IValue& b);
 
   // Computes an "informal" string representation of an IValue. This should be
   // used for debugging, or servicing `print()`-like functions.

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -225,8 +225,6 @@ struct CAFFE2_API Tuple : c10::intrusive_ptr_target {
   std::shared_ptr<TupleType> type() const;
 
   CAFFE2_API friend bool operator==(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
-  CAFFE2_API friend bool operator<(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
-  CAFFE2_API friend bool operator>(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
 
  private:
   Tuple(std::vector<IValue> elements, std::shared_ptr<TupleType> type = nullptr)

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -224,7 +224,9 @@ struct CAFFE2_API Tuple : c10::intrusive_ptr_target {
   }
   std::shared_ptr<TupleType> type() const;
 
-  friend bool operator==(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
+  CAFFE2_API friend bool operator==(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
+  CAFFE2_API friend bool operator<(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
+  CAFFE2_API friend bool operator>(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
 
  private:
   Tuple(std::vector<IValue> elements, std::shared_ptr<TupleType> type = nullptr)

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -385,6 +385,14 @@ class TestClassType(JitTestCase):
 
         self.assertEqual(test_sorted_copies(), (3, 1))
 
+        @torch.jit.script
+        def test_nested_inside_tuple():
+            li = [(1, Foo(12)), (1, Foo(11))]
+            li.sort()
+            return [(li[0][0], li[0][1].getVal()), (li[1][0], li[1][1].getVal())]
+
+        self.assertEqual(test_nested_inside_tuple(), [(1, 11), (1, 12)])
+
         with self.assertRaisesRegex(RuntimeError, "bool\' for argument \'reverse"):
             @torch.jit.script
             def test():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4436,8 +4436,7 @@ a")
 
         self.checkScript(foo, ())
 
-    def test_string_sort(self):
-        @torch.jit.script
+    def test_string_sorted(self):
         def foo(strs: List[str]):
             return sorted(strs)
 
@@ -4445,10 +4444,62 @@ a")
             .check("graph") \
             .check_next("str[] = aten::sorted") \
             .check_next("return") \
-            .run(str(foo.graph))
+            .run(str(torch.jit.script(foo).graph))
 
         inputs = ["str3", "str2", "str1"]
-        self.assertEqual(foo(inputs), sorted(inputs))
+        self.checkScript(foo, (inputs,))
+
+    def test_string_sort(self):
+        def foo(strs: List[str]):
+            strs.sort()
+            return strs
+
+        inputs = ["str3", "str2", "str1"]
+        self.checkScript(foo, (inputs,))
+
+    def test_tuple_sorted(self):
+        def foo(tups: List[Tuple[int, int]]):
+            return sorted(tups)
+
+        inputs = [(1, 2), (0, 2), (1, 3)]
+        self.checkScript(foo, (inputs,))
+
+    def test_tuple_sort(self):
+        def foo(tups: List[Tuple[int, int]]):
+            tups.sort()
+            return tups
+
+        inputs = [(1, 2), (0, 2), (1, 3)]
+        self.checkScript(foo, (inputs,))
+
+    def test_tuple_sort_reverse(self):
+        def foo(tups: List[Tuple[int, int]]):
+            tups.sort(reverse=True)
+            return tups
+
+        inputs = [(1, 2), (0, 2), (1, 3)]
+        self.checkScript(foo, (inputs,))
+
+
+    def test_tuple_unsortable_element_type(self):
+        @torch.jit.script
+        def foo():
+            tups = [({1: 2}, {2: 3})]
+            tups.sort()
+            return tups
+
+        with self.assertRaisesRegexWithHighlight(RuntimeError, "are not sortable", "tups.sort"):
+            foo()
+
+    def test_tuple_unsortable_diff_type(self):
+        @torch.jit.script
+        def foo(inputs: List[Any]):
+            inputs.sort()
+            return inputs
+
+        inputs = [(1, 2), ("foo", "bar")]
+        with self.assertRaisesRegexWithHighlight(RuntimeError, "Different tuple types can not be sorted", "inputs.sort"):
+            foo(inputs)
 
     def test_string_new_line(self):
         with self.assertRaisesRegex(RuntimeError, "expected a valid token*"):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4480,7 +4480,6 @@ a")
         inputs = [(1, 2), (0, 2), (1, 3)]
         self.checkScript(foo, (inputs,))
 
-
     def test_tuple_unsortable_element_type(self):
         @torch.jit.script
         def foo():
@@ -4498,7 +4497,25 @@ a")
             return inputs
 
         inputs = [(1, 2), ("foo", "bar")]
-        with self.assertRaisesRegexWithHighlight(RuntimeError, "Different tuple types can not be sorted", "inputs.sort"):
+        with self.assertRaisesRegexWithHighlight(RuntimeError, "Only values of same type can be compared", "inputs.sort"):
+            foo(inputs)
+
+    def test_tuple_nested_sort(self):
+        def foo(inputs: List[Tuple[int, Tuple[int, str]]]):
+            inputs.sort()
+            return inputs
+
+        inputs = [(1, (2, "foo")), (1, (2, "bar")), (1, (0, "bar"))]
+        self.checkScript(foo, (inputs,))
+
+    def test_tuple_unsortable_nested_diff_type(self):
+        @torch.jit.script
+        def foo(inputs: List[Any]):
+            inputs.sort()
+            return inputs
+
+        inputs = [(1, (2, 3)), (2, ("foo", "bar"))]
+        with self.assertRaisesRegexWithHighlight(RuntimeError, "Only values of same type can be compared", "inputs.sort"):
             foo(inputs)
 
     def test_string_new_line(self):


### PR DESCRIPTION
* Implement tuple sort by traversing contained IValue types and generate a lambda function as comparator for sort.
* Tuple, class objects can now arbitrarily nest within each other and still be sortable

Fixes #43219
