### PR TITLE
Implement JIT Enum type serialization and deserialization

### DIFF
--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -261,36 +261,48 @@ TEST(IValueTest, ListNestedEquality) {
 
 TEST(IValueTest, EnumEquality) {
   auto cu = std::make_shared<CompilationUnit>();
-  auto int_enum_type1 = EnumType::create("enum_class_1", IntType::get(), cu);
-  auto int_enum_type2 = EnumType::create("enum_class_2", IntType::get(), cu);
-  auto string_enum_type = EnumType::create("enum_class_3", StringType::get(), cu);
+  IValue int_ivalue_1(1);
+  IValue int_ivalue_2(2);
+  IValue str_ivalue_1("1");
+  auto int_enum_type1 = EnumType::create(
+      "enum_class_1",
+      IntType::get(),
+      {{"enum_name_1", int_ivalue_1}, {"enum_name_2", int_ivalue_2}},
+      cu);
+  auto int_enum_type2 = EnumType::create(
+      "enum_class_2",
+      IntType::get(),
+      {{"enum_name_1", int_ivalue_1}, {"enum_name_2", int_ivalue_2}},
+      cu);
+  auto string_enum_type = EnumType::create(
+      "enum_class_3", StringType::get(), {{"enum_name_1", str_ivalue_1}}, cu);
 
   EXPECT_EQ(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          int_enum_type1, "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", int_ivalue_1)),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          int_enum_type1, "enum_name_1", IValue(1)))
+          int_enum_type1, "enum_name_1", int_ivalue_1))
   );
 
   EXPECT_NE(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          int_enum_type1, "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", int_ivalue_1)),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          int_enum_type2, "enum_name_1", IValue(1)))
+          int_enum_type2, "enum_name_1", int_ivalue_1))
   );
 
   EXPECT_NE(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          int_enum_type1, "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", int_ivalue_1)),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          int_enum_type1, "enum_name_2", IValue(1)))
+          int_enum_type1, "enum_name_2", int_ivalue_2))
   );
 
   EXPECT_NE(
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          int_enum_type1, "enum_name_1", IValue(1))),
+          int_enum_type1, "enum_name_1", int_ivalue_1)),
       IValue(c10::make_intrusive<ivalue::EnumHolder>(
-          string_enum_type, "enum_name_1", IValue("1")))
+          string_enum_type, "enum_name_1", str_ivalue_1))
   );
 }
 

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -751,5 +751,24 @@ struct TORCH_API ExceptionValue : public SugaredValue {
   std::string message_;
 };
 
+struct TORCH_API SugaredEnumClass : public SugaredValue {
+  explicit SugaredEnumClass(EnumTypePtr enum_type)
+      : enum_type_(std::move(enum_type)) {}
+
+  std::string kind() const override {
+    return "EnumClass";
+  }
+
+  SugaredValuePtr attr(
+      const SourceRange& loc,
+      Function& m,
+      const std::string& field) override;
+
+  SugaredValuePtr iter(const SourceRange& loc, Function& m) override;
+
+ private:
+  EnumTypePtr enum_type_;
+};
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -791,10 +791,20 @@ void initPythonIRBindings(PyObject* module_) {
       }))
       .def("name", [](ClassType& self) { return self.name()->name(); });
   py::class_<EnumType, Type, std::shared_ptr<EnumType>>(m, "EnumType")
-      .def(py::init([](const std::string& qualified_name, TypePtr value) {
+      .def(py::init([](const std::string& qualified_name,
+                       TypePtr value_type,
+                       const std::vector<py::object>& enum_names_values) {
+        std::vector<std::pair<std::string, IValue>> names_values;
+        names_values.reserve(enum_names_values.size());
+        for (const auto& enum_name_value : enum_names_values) {
+          auto enum_name = py::cast<std::string>(enum_name_value.attr("name"));
+          auto enum_value = toIValue(enum_name_value.attr("value"), value_type);
+          names_values.emplace_back(std::make_pair(enum_name, enum_value));
+        }
         return EnumType::create(
             c10::QualifiedName(qualified_name),
-            std::move(value),
+            std::move(value_type),
+            std::move(names_values),
             get_python_cu());
       }));
   py::class_<InterfaceType, Type, std::shared_ptr<InterfaceType>>(

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -404,7 +404,7 @@ std::shared_ptr<SugaredValue> SugaredDict::attr(
   TORCH_INTERNAL_ASSERT(false);
 }
 
-std::shared_ptr<SugaredEnumClass> SugaredEnumClass::create(
+std::shared_ptr<SugaredEnumClass> createSugaredEnumClassFromObj(
     const py::object& obj,
     Function& m,
     const SourceRange& loc) {
@@ -413,43 +413,7 @@ std::shared_ptr<SugaredEnumClass> SugaredEnumClass::create(
   TORCH_INTERNAL_ASSERT(!annotation_type.is_none());
   auto type = py::cast<TypePtr>(annotation_type);
   auto enum_type = type->expect<EnumType>();
-
-  std::map<std::string, SugaredValuePtr> enum_values;
-  auto enum_values_list = py::cast<py::list>(obj);
-
-  auto enum_value_ivalues = c10::impl::GenericList(enum_type);
-  for (auto enum_value : enum_values_list) {
-    auto enum_name = enum_value.attr("name").cast<std::string>();
-    auto enum_sugared_value =
-        toSugaredValue(py::reinterpret_steal<py::object>(enum_value), m, loc);
-    enum_values.insert(std::make_pair(enum_name, enum_sugared_value));
-    enum_value_ivalues.push_back(toIValue(enum_value, enum_type));
-  }
-
-  IValue enum_value_list_ivalues(enum_value_ivalues);
-  auto enum_values_list_constant = std::make_shared<SimpleValue>(
-      m.graph()->insertConstant(enum_value_list_ivalues, loc));
-
-  return std::make_shared<SugaredEnumClass>(
-      enum_values, enum_values_list_constant, enum_type);
-}
-
-std::shared_ptr<SugaredValue> SugaredEnumClass::attr(
-    const SourceRange& loc,
-    Function& /*m*/,
-    const std::string& field) {
-  auto it = enum_values_.find(field);
-  if (it == enum_values_.end()) {
-    throw ErrorReport(loc) << enum_type_->repr_str() << "'"
-                           << " has no attribute '" << field << "'";
-  }
-  return it->second;
-}
-
-SugaredValuePtr SugaredEnumClass::iter(
-    const SourceRange& /*loc*/,
-    Function& /*m*/) {
-  return enum_values_list_constant_;
+  return std::make_shared<SugaredEnumClass>(enum_type);
 }
 
 // helper function for instantiating a SugaredValue from an IValue
@@ -929,7 +893,7 @@ std::shared_ptr<SugaredValue> toSugaredValue(
   }
 
   if (isEnumClass(obj)) {
-    return SugaredEnumClass::create(obj, m, loc);
+    return createSugaredEnumClassFromObj(obj, m, loc);
   }
 
   auto enum_type = py::module::import("enum").attr("Enum");

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -249,39 +249,6 @@ struct VISIBILITY_HIDDEN SugaredDict : public SugaredValue {
   std::shared_ptr<SugaredTupleValue> modules_;
 };
 
-struct VISIBILITY_HIDDEN SugaredEnumClass : public SugaredValue {
-  explicit SugaredEnumClass(
-      std::map<std::string, SugaredValuePtr> enum_values,
-      SugaredValuePtr enum_values_list_constant,
-      EnumTypePtr enum_type)
-      : enum_values_(std::move(enum_values)),
-        enum_values_list_constant_(std::move(enum_values_list_constant)),
-        enum_type_(std::move(enum_type)) {}
-
-  static std::shared_ptr<SugaredEnumClass> create(
-      const py::object& obj,
-      Function& m,
-      const SourceRange& loc);
-
-  std::string kind() const override {
-    return "EnumClass";
-  }
-
-  SugaredValuePtr attr(
-      const SourceRange& loc,
-      Function& m,
-      const std::string& field) override;
-
-  SugaredValuePtr iter(const SourceRange& loc, Function& m) override;
-
- private:
-  // Using ordered map here to ensure ordering of enum values is deterministic
-  // when iterating through them.
-  std::map<std::string, SugaredValuePtr> enum_values_;
-  SugaredValuePtr enum_values_list_constant_;
-  EnumTypePtr enum_type_;
-};
-
 struct VISIBILITY_HIDDEN BooleanDispatchValue : public SugaredValue {
   BooleanDispatchValue(py::dict dispatched_fn)
       : dispatched_fn_(std::move(dispatched_fn)) {}

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/serialization/import_source.h>
 
 #include <ATen/core/qualified_name.h>
+#include <ATen/core/ivalue_inl.h>
 #include <torch/csrc/jit/frontend/parser.h>
 #include <torch/csrc/jit/frontend/resolver.h>
 #include <torch/csrc/jit/frontend/script_type_parser.h>
@@ -268,6 +269,8 @@ struct SourceImporterImpl : public Resolver,
     } else if (superclass_name == "ModuleInterface") {
       cu_->define_interface(
           qualified_name, class_def, shared_from_this(), /*is_module=*/true);
+    } else if (superclass_name == "Enum") {
+      importEnum(qualified_name, class_def);
     } else {
       throw ErrorReport(class_def.range())
           << "Torchscript does not support class inheritance.";
@@ -493,6 +496,69 @@ struct SourceImporterImpl : public Resolver,
         &self);
   }
 
+  void importEnum(
+      const QualifiedName& qualified_name,
+      const ClassDef& enum_def) {
+    std::vector<at::EnumNameValue> names_values;
+
+    TypePtr value_type = nullptr;
+    auto set_or_check_type = [&value_type](
+                                 const TypePtr& t, const SourceRange& loc) {
+      if (!value_type) {
+        value_type = t;
+      } else if (value_type != t) {
+        throw ErrorReport(loc)
+            << "Enum class with varying value types are not supported.";
+      }
+    };
+
+    for (const auto& statement : enum_def.body()) {
+      if (statement.kind() != TK_ASSIGN) {
+        throw ErrorReport(statement.range())
+            << "Unexpected statement in Enum class body: "
+               "only enum attribute definitions are currently supported.";
+      }
+
+      const auto assign = Assign(statement);
+      const auto name = Var(assign.lhs()).name().name();
+
+      IValue ivalue;
+      auto rhs = assign.rhs().get();
+      switch (rhs.kind()) {
+        case TK_STRINGLITERAL:
+          ivalue = IValue(StringLiteral(rhs).text());
+          set_or_check_type(StringType::get(), statement.range());
+          break;
+        case TK_CONST: {
+          auto numeric_const = Const(rhs);
+          if (numeric_const.isFloatingPoint()) {
+            ivalue = IValue(numeric_const.asFloatingPoint());
+            set_or_check_type(FloatType::get(), statement.range());
+          } else if (numeric_const.isIntegral()) {
+            ivalue = IValue(numeric_const.asIntegral());
+            set_or_check_type(IntType::get(), statement.range());
+          }
+          break;
+        }
+        default:
+          throw ErrorReport(rhs.range())
+              << "Unsupported enum value type: " << rhs.kind()
+              << ". Only Integers, Floats and Strings are supported.";
+      }
+
+      names_values.emplace_back(std::make_pair(name, ivalue));
+    }
+
+    if (!value_type) {
+      throw ErrorReport(enum_def.range())
+          << "No enum values defined for " << qualified_name.qualifiedName();
+    }
+
+    auto enum_type = EnumType::create(
+        qualified_name, std::move(value_type), std::move(names_values), cu_);
+    cu_->register_type(enum_type);
+  }
+
   void importNamedTuple(
       const QualifiedName& qualified_name,
       const ClassDef& named_tuple_def) {
@@ -570,6 +636,8 @@ std::shared_ptr<SugaredValue> ClassNamespaceValue::attr(
       return std::make_shared<ClassValue>(classType);
     } else if (auto tupleType = serializable_type->cast<TupleType>()) {
       return std::make_shared<NamedTupleConstructor>(tupleType);
+    } else if (auto enumType = serializable_type->cast<EnumType>()) {
+      return std::make_shared<SugaredEnumClass>(enumType);
     }
   }
 

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -672,6 +672,8 @@ struct PythonPrintImpl {
       }
     } else if (const auto interfaceType = type->cast<InterfaceType>()) {
       registerDependency(interfaceType);
+    } else if (const auto enumType = type->cast<EnumType>()) {
+      registerDependency(enumType);
     }
     for (const auto& containedType : type->containedTypes()) {
       registerClassDependencies(containedType);
@@ -1411,6 +1413,22 @@ struct PythonPrintImpl {
                 << ":\n";
           indent();
           body_ << "  pass\n";
+        }
+      }
+    } else if (auto enumType = type->cast<EnumType>()) {
+      body_ << "class " << enumType->qualifiedClassName().name() << "(Enum):\n";
+
+      std::string value_wrapper = "";
+      if (enumType->getValueType() == StringType::get()) {
+        value_wrapper = "\"";
+      }
+
+      {
+        auto guard = WithIndented();
+        for (const auto& name_value : enumType->enumNamesValues()) {
+          indent();
+          body_ << name_value.first << " = " << value_wrapper
+                << name_value.second << value_wrapper << "\n";
         }
       }
     } else {

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -320,7 +320,7 @@ def try_ann_to_type(ann, loc):
             return None
         if not hasattr(ann, "__torch_script_class__"):
             torch.jit._script._recursive_compile_class(ann, loc)
-        return EnumType(_qualified_name(ann), get_enum_value_type(ann, loc))
+        return EnumType(_qualified_name(ann), get_enum_value_type(ann, loc), list(ann))
     if inspect.isclass(ann):
         if hasattr(ann, "__torch_script_class__"):
             return ClassType(_qualified_name(ann))


### PR DESCRIPTION
[Re-review tips: nothing changed other than a type in python_ir.cpp to fix a windows build failure]

Adds code printing for enum type
Enhance enum type to include all contained enum names and values
Adds code parsing for enum type in deserialization
Enabled serialization/deserialization test in most TestCases. (With a few dangling issues to be addressed in later PRs to avoid this PR grows too large)

