### PR TITLE
Grammatical corrections

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -204,8 +204,8 @@ Disable JIT for Debugging
 
 Setting the environment variable ``PYTORCH_JIT=0`` will disable all script
 and tracing annotations. If there is hard-to-debug error in one of your
-TorchScript model, you can use this flag to force everything to run using native
-Python. Since TorchScript (scripting and tracing) are disabled with this flag,
+TorchScript models, you can use this flag to force everything to run using native
+Python. Since TorchScript (scripting and tracing) is disabled with this flag,
 you can use tools like ``pdb`` to debug the model code.  For example::
 
     @torch.jit.script


### PR DESCRIPTION
**Few documentation corrections.**

1. [...] If there is hard-to-debug error in one of your TorchScript **models**, you can use this flag [...]
2. [...] Since TorchScript (scripting and tracing) **is** disabled with this flag [...]

**Before corrections (as of now):**
![before-fix](https://user-images.githubusercontent.com/45713346/90977203-d8bc2580-e543-11ea-9609-fbdf5689dcb9.jpg)


**After corrections:**
![after-fix](https://user-images.githubusercontent.com/45713346/90977209-dbb71600-e543-11ea-8259-011618efd95b.jpg)
