### PR TITLE
[fx] get rid of graph_module.root

### DIFF
--- a/test/fx/quantization.py
+++ b/test/fx/quantization.py
@@ -190,7 +190,7 @@ def matches(modules, node, pattern, max_uses=sys.maxsize):
 
 class Quantizer:
     def __init__(self, mod, patterns=DEFAULT_QUANTIZATION_PATTERNS, quant_ctor=DefaultQuant):
-        self.root = mod.root
+        self.root = mod
         self.graph = mod.graph
         self.quant_ctor = quant_ctor
 

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -169,8 +169,8 @@ class TestFX(TestCase):
         a = resnet(ip)
         b = res_graph(ip)
         c = res_script(ip)
-        assert torch.allclose(a, b)
-        assert torch.allclose(a, c)
+        self.assertEqual(a, b)
+        self.assertEqual(a, c)
 
         quantizer = Quantizer(res_graph)
 
@@ -184,7 +184,7 @@ class TestFX(TestCase):
         e = qgraph_script(ip)
 
         assert (a - d).abs().max() < 2
-        assert torch.allclose(d, e)
+        self.assertEqual(d, e)
 
     def test_unpack(self):
         class M(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43483 [fx] get rid of graph_module.root**

instead submodules and weights are installed directly on the
graph_module by transferring the original modules. This makes it more
likely that scripting will succeed (since we no longer have submodules
that are not used in the trace). It also prevents layered transforms
from having to special case handling of the `root` module. GraphModules
can now be re-traced as part of the input to other transforms.

Differential Revision: [D23288808](https://our.internmc.facebook.com/intern/diff/D23288808)