### PR TITLE
Raise error on device mismatch in addmm

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -199,6 +199,11 @@ static void addmm_impl_cpu_(
   auto m2_strides = m2.strides();
   auto m2_sizes = m2.sizes();
 
+  TORCH_CHECK(self.device() == kCPU && m1.device() == kCPU &&
+              m2.device() == kCPU && result.device() == kCPU,
+             "Tensor device mismatch,  {self: ", self.device(), ", mat1: ",
+             m1.device(), ", mat2: ", m2.device(), ", out: ", result.device(), ")");
+
   TORCH_CHECK(
       m1_sizes[1] == m2_sizes[0], "mat1 and mat2 shapes cannot be multiplied (",
       m1_sizes[0], "x", m1_sizes[1], " and ", m2_sizes[0], "x", m2_sizes[1], ")");

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -199,11 +199,6 @@ static void addmm_impl_cpu_(
   auto m2_strides = m2.strides();
   auto m2_sizes = m2.sizes();
 
-  TORCH_CHECK(self.device() == kCPU && m1.device() == kCPU &&
-              m2.device() == kCPU && result.device() == kCPU,
-             "Tensor device mismatch,  {self: ", self.device(), ", mat1: ",
-             m1.device(), ", mat2: ", m2.device(), ", out: ", result.device(), ")");
-
   TORCH_CHECK(
       m1_sizes[1] == m2_sizes[0], "mat1 and mat2 shapes cannot be multiplied (",
       m1_sizes[0], "x", m1_sizes[1], " and ", m2_sizes[0], "x", m2_sizes[1], ")");

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -55,6 +55,9 @@ namespace {
 Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& mat1, const Tensor& mat2, Scalar beta, Scalar alpha) {
   TORCH_CHECK(mat1.dim() == 2 && mat2.dim() == 2, "tensors must be 2-D");
 
+  TensorArg args[]{{result, "out", 0}, {self, "self", 1}, {mat1, "mat1", 2}, {mat2, "mat2", 3}};
+  checkAllSameGPU("addmm", args);
+
   Tensor self_;
   if (&result != &self) {
     std::tie(self_) = expand_size(self, {mat1.size(0), mat2.size(1)}, "addmm");

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3020,5 +3020,29 @@ class TestCudaComm(TestCase):
         self.assertTrue(gathered.is_contiguous(memory_format=torch.channels_last))
 
 
+    def test_matmul_device_mismatch(self):
+        cpu = torch.rand((10, 10))
+        cuda = cpu.cuda()
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            cpu @ cuda
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            cuda @ cpu
+
+        torch.addmm(cpu, cpu, cpu)
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            torch.addmm(cpu, cpu, cuda)
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            torch.addmm(cpu, cuda, cpu)
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            torch.addmm(cpu, cuda, cuda)
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            torch.addmm(cuda, cpu, cpu)
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            torch.addmm(cuda, cpu, cuda)
+        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+            torch.addmm(cuda, cuda, cpu)
+        torch.addmm(cuda, cuda, cuda)
+
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3028,20 +3028,12 @@ class TestCudaComm(TestCase):
         with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
             cuda @ cpu
 
-        torch.addmm(cpu, cpu, cpu)
-        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
-            torch.addmm(cpu, cpu, cuda)
-        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
-            torch.addmm(cpu, cuda, cpu)
-        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
-            torch.addmm(cpu, cuda, cuda)
-        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
-            torch.addmm(cuda, cpu, cpu)
-        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
-            torch.addmm(cuda, cpu, cuda)
-        with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
-            torch.addmm(cuda, cuda, cpu)
-        torch.addmm(cuda, cuda, cuda)
+        for s, m1, m2 in product((cpu, cuda), repeats=3):
+            if s.device == m1.device == m2.device:
+                torch.addmm(s, m1, m2)
+            else:
+                with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
+                    torch.addmm(s, m1, m2)
 
 
 if __name__ == '__main__':

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3028,7 +3028,7 @@ class TestCudaComm(TestCase):
         with self.assertRaisesRegex(RuntimeError, "expected (it|them) to be on GPU"):
             cuda @ cpu
 
-        for s, m1, m2 in product((cpu, cuda), repeats=3):
+        for s, m1, m2 in product((cpu, cuda), repeat=3):
             if s.device == m1.device == m2.device:
                 torch.addmm(s, m1, m2)
             else:


### PR DESCRIPTION
Fixes gh-42282

This adds a device-mismatch check to `addmm` on CPU and CUDA. Although it seems like the dispatcher is always selecting the CUDA version here if any of the inputs are on GPU. So in theory the CPU check is unnecessary, but probably better to err on the side of caution.