### PR TITLE
[2/3][lite interpreter] add metadata when saving and loading models for mobile

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -224,6 +224,8 @@ class BytecodeDeserializer final {
   c10::IValue readArchive(
       const std::string& archive_name,
       std::shared_ptr<mobile::CompilationUnit> mcu);
+  std::unordered_map<std::string, std::string> readMobileMetadata(
+      std::shared_ptr<mobile::CompilationUnit> mcu);
   std::shared_ptr<CompilationUnit> compilation_unit_;
   std::unordered_set<std::string> imported_libs_;
   std::unique_ptr<PyTorchStreamReader> reader_;
@@ -246,8 +248,23 @@ mobile::Module BytecodeDeserializer::deserialize(
     debug_info_bvals = readArchive("mobile_debug", mcu).toTuple()->elements();
   }
   parseMethods(bvals, debug_info_bvals, *mcu);
+  auto meta_dict = readMobileMetadata(mcu);
+  return mobile::Module(readArchive("data", mcu).toObject(), meta_dict, mcu);
+}
 
-  return mobile::Module(readArchive("data", mcu).toObject(), mcu);
+std::unordered_map<std::string, std::string> BytecodeDeserializer::
+    readMobileMetadata(std::shared_ptr<mobile::CompilationUnit> mcu) {
+  std::unordered_map<std::string, std::string> res;
+  if (!reader_->hasRecord("metadata.pkl")) {
+    return res;
+  }
+  auto ivalue_dict = readArchive("metadata", mcu).toGenericDict();
+  for (auto it = ivalue_dict.begin(); it != ivalue_dict.end(); ++it) {
+    auto key = it->key().toString()->string();
+    auto value = it->value().toString()->string();
+    res[key] = value;
+  }
+  return res;
 }
 
 c10::IValue BytecodeDeserializer::readArchive(

--- a/torch/csrc/jit/mobile/module.h
+++ b/torch/csrc/jit/mobile/module.h
@@ -24,8 +24,15 @@ class TORCH_API Module {
   Module(
       c10::intrusive_ptr<c10::ivalue::Object> object,
       std::shared_ptr<CompilationUnit> cu)
-      : object_(object), cu_(std::move(cu)){};
-  Module() {}
+      : object_(object),
+        metadata_(std::unordered_map<std::string, std::string>()),
+        cu_(std::move(cu)) {}
+  Module(
+      c10::intrusive_ptr<c10::ivalue::Object> object,
+      std::unordered_map<std::string, std::string> metadata,
+      std::shared_ptr<CompilationUnit> cu)
+      : object_(object), metadata_(std::move(metadata)), cu_(std::move(cu)) {}
+  Module() = default;
   c10::IValue run_method(const std::string& method_name, Stack stack);
   c10::IValue forward(std::vector<c10::IValue> inputs) {
     return run_method("forward", std::move(inputs));
@@ -51,9 +58,13 @@ class TORCH_API Module {
   }
   /// True if the module is in training mode.
   bool is_training() const;
+  const std::unordered_map<std::string, std::string> metadata() const {
+    return metadata_;
+  }
 
  private:
   c10::intrusive_ptr<c10::ivalue::Object> object_;
+  std::unordered_map<std::string, std::string> metadata_;
   std::shared_ptr<CompilationUnit> cu_;
 };
 } // namespace mobile

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -88,6 +88,13 @@ TORCH_API void writeArchiveAndTensors(
 using ExportModuleExtraFilesHook = std::function<ExtraFilesMap(const Module&)>;
 TORCH_API void SetExportModuleExtraFilesHook(ExportModuleExtraFilesHook hook);
 
+using ExportModuleMobileInfoConverter =
+    std::function<c10::Dict<std::string, std::string>(
+        const Module&,
+        const std::unordered_map<std::string, std::string>&)>;
+TORCH_API void SetExportModuleMobileInfoConverter(
+    ExportModuleMobileInfoConverter converter);
+
 // Returns a list of names of all operators in the module and its submodules.
 TORCH_API std::vector<std::string> export_opnames(const Module& m);
 

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -35,6 +35,11 @@ ExportModuleExtraFilesHook& GetExtraFilesHook() {
   return func;
 }
 
+ExportModuleMobileInfoConverter& GetMobileInfoConverter() {
+  static ExportModuleMobileInfoConverter func = nullptr;
+  return func;
+}
+
 static IValue Tup(std::vector<IValue> ivalues) {
   return c10::ivalue::Tuple::create(std::move(ivalues));
 }
@@ -242,6 +247,11 @@ void SetExportModuleExtraFilesHook(ExportModuleExtraFilesHook hook) {
   GetExtraFilesHook() = hook;
 }
 
+void SetExportModuleMobileInfoConverter(
+    ExportModuleMobileInfoConverter converter) {
+  GetMobileInfoConverter() = converter;
+}
+
 class ScriptModuleSerializer {
  public:
   explicit ScriptModuleSerializer(const std::string& filename)
@@ -269,6 +279,7 @@ class ScriptModuleSerializer {
     writeArchive("constants", c10::ivalue::Tuple::create(ivalue_constants));
     if (bytecode_format) {
       writeByteCode(module, save_mobile_debug_info);
+      writeMobileMetadata(module, extra_files);
     }
 
     // Acquires and sets minimum (dynamic) version
@@ -334,6 +345,26 @@ class ScriptModuleSerializer {
         const std::string key = "extra/" + kv.first;
         writer_.writeRecord(key, kv.second.data(), kv.second.size());
       }
+    }
+  }
+
+  void writeMobileMetadata(
+      const Module& module,
+      const ExtraFilesMap& extra_files) {
+    auto hook = GetExtraFilesHook();
+    auto converter = GetMobileInfoConverter();
+    if (!converter) {
+      return;
+    }
+    ExtraFilesMap files_to_write = extra_files;
+    // merge hook files and extra files
+    if (hook) {
+      ExtraFilesMap hook_files = hook(module);
+      files_to_write.insert(hook_files.begin(), hook_files.end());
+    }
+    auto content_to_write = converter(module, files_to_write);
+    if (!content_to_write.empty()) {
+      writeArchive("metadata", content_to_write);
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43516 [2/3][lite interpreter] add metadata when saving and loading models for mobile**

1. add `metadata.pkl` to `.bc` file which includes the model info that we are interested in
2. load `metadata.pkl` as a attribute `unordered_map<string, string>` in the module

Differential Revision: [D23047144](https://our.internmc.facebook.com/intern/diff/D23047144/)