### PR TITLE
Evenly distribute output grad  into all matching inputs for min/max/median

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5846,12 +5846,13 @@ class TestAutogradFunctional(TestCase):
 # Generic device type autograd tests.
 class TestAutogradDeviceType(TestCase):
 
-    def test_min_max_median_backprops_to_single_value(self, device):
+    def test_min_max_median_backprops_to_all_values(self, device):
         for f in [torch.min, torch.max, torch.median]:
             x = torch.tensor([1., 0., 1., 0., 1., 0.], device=device, requires_grad=True)
             y = f(x)
             y.backward()
             self.assertEqual(x.grad.sum(), 1.)
+            self.assertEqual((x.grad == 1 / 3).sum(), 3)
 
     # skip this test if running on rocm, because in cdist
     # we use __shfl_down_sync on CUDA for fast reduction

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -670,7 +670,7 @@
   self: index_select_backward(grad, dim, indices, self.sizes(), keepdim)
 
 - name: max(Tensor self) -> Tensor
-  self: select_first_equal_backward(grad, self, result)
+  self: evenly_dispatch_backward(grad, self, result)
 
 - name: max.other(Tensor self, Tensor other) -> Tensor
   self: grad.clone().masked_fill_(self <= other, 0)
@@ -683,7 +683,7 @@
   self: sum_backward(grad, self.sizes(), dim, keepdim).to(self.scalar_type()) / _safe_size(self.sizes(), dim)
 
 - name: median(Tensor self) -> Tensor
-  self: select_first_equal_backward(grad, self, result)
+  self: evenly_dispatch_backward(grad, self, result)
 
 # This is in theory incorrect in the following case:
 #   sorted list: [..., a, b, b, ..., b, b, c, ...] with median = b and the value
@@ -706,7 +706,7 @@
   self: index_select_backward(grad, dim, indices, self.sizes(), keepdim)
 
 - name: min(Tensor self) -> Tensor
-  self: select_first_equal_backward(grad, self, result)
+  self: evenly_dispatch_backward(grad, self, result)
 
 - name: min.other(Tensor self, Tensor other) -> Tensor
   self: grad.clone().masked_fill_(self >= other, 0)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -670,7 +670,7 @@
   self: index_select_backward(grad, dim, indices, self.sizes(), keepdim)
 
 - name: max(Tensor self) -> Tensor
-  self: evenly_dispatch_backward(grad, self, result)
+  self: evenly_distribute_backward(grad, self, result)
 
 - name: max.other(Tensor self, Tensor other) -> Tensor
   self: grad.clone().masked_fill_(self <= other, 0)
@@ -683,7 +683,7 @@
   self: sum_backward(grad, self.sizes(), dim, keepdim).to(self.scalar_type()) / _safe_size(self.sizes(), dim)
 
 - name: median(Tensor self) -> Tensor
-  self: evenly_dispatch_backward(grad, self, result)
+  self: evenly_distribute_backward(grad, self, result)
 
 # This is in theory incorrect in the following case:
 #   sorted list: [..., a, b, b, ..., b, b, c, ...] with median = b and the value
@@ -706,7 +706,7 @@
   self: index_select_backward(grad, dim, indices, self.sizes(), keepdim)
 
 - name: min(Tensor self) -> Tensor
-  self: evenly_dispatch_backward(grad, self, result)
+  self: evenly_distribute_backward(grad, self, result)
 
 - name: min.other(Tensor self, Tensor other) -> Tensor
   self: grad.clone().masked_fill_(self >= other, 0)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -726,20 +726,10 @@ Tensor _fused_dropout_backward(Tensor grad, Tensor mask, double p1m) {
   }
 }
 
-Tensor select_first_equal_backward(Tensor grad, const Tensor & input, const Tensor & value) {
-  auto grad_input = at::zeros_like(input);
-
-  // find indices of the first element for which input[idx] == value
-  auto first_value_idx = (input == value).nonzero().select(0, 0);
-
-  if (grad_input.dim() == 0) {
-    grad_input.copy_(grad);
-  }
-  else {
-    grad_input.index_put_(at::chunk(first_value_idx, grad_input.dim()), grad);
-  }
-
-  return grad_input;
+Tensor evenly_dispatch_backward(Tensor grad, const Tensor & input, const Tensor & value) {
+  auto mask = (input == value);
+  auto count = mask.sum(input.scalar_type());
+  return at::zeros_like(input).masked_fill_(mask, grad / count);
 }
 
 Tensor index_select_backward(Tensor grad, int64_t dim, Tensor indices, IntArrayRef sizes, bool keepdim) {


### PR DESCRIPTION
[bc-breaking note]. Previously, in case there were multiple max/min/median elements with the same value, gradient propagated only to the first element with this value, now gradient is evenly distributed between all the elements. This results in a minimum subnorm gradient. 
cc: @ngimel @mruberry 