### PR TITLE
Fix hipify script for pytorch extensions

### DIFF
--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -143,7 +143,7 @@ def matched_files_iter(root_path, includes=('*',), ignores=(), extensions=(), ou
                 and (not _fnmatch(filepath, ignores))
                 and (match_extensions(filepath) or filepath in exact_matches)
             ):
-                if not is_pytorch_extension: # for pytorch extensions, consider all files
+                if not is_pytorch_extension:  # for pytorch extensions, consider all files
                     if not is_pytorch_file(filepath) and not is_caffe2_gpu_file(filepath):
                         continue
                     if out_of_place_only and not is_out_of_place(filepath):

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -109,7 +109,7 @@ class GeneratedFileCleaner:
             for d in self.dirs_to_clean[::-1]:
                 os.rmdir(d)
 
-def matched_files_iter(root_path, includes=('*',), ignores=(), extensions=(), out_of_place_only=False):
+def matched_files_iter(root_path, includes=('*',), ignores=(), extensions=(), out_of_place_only=False, is_pytorch_extension=False):
     def _fnmatch(filepath, patterns):
         return any(fnmatch.fnmatch(filepath, pattern) for pattern in patterns)
 
@@ -143,10 +143,11 @@ def matched_files_iter(root_path, includes=('*',), ignores=(), extensions=(), ou
                 and (not _fnmatch(filepath, ignores))
                 and (match_extensions(filepath) or filepath in exact_matches)
             ):
-                if not is_pytorch_file(filepath) and not is_caffe2_gpu_file(filepath):
-                    continue
-                if out_of_place_only and not is_out_of_place(filepath):
-                    continue
+                if not is_pytorch_extension: # for pytorch extensions, consider all files
+                    if not is_pytorch_file(filepath) and not is_caffe2_gpu_file(filepath):
+                        continue
+                    if out_of_place_only and not is_out_of_place(filepath):
+                        continue
                 yield filepath
 
 
@@ -847,7 +848,8 @@ def hipify(
 
     all_files = list(matched_files_iter(output_directory, includes=includes,
                                         ignores=ignores, extensions=extensions,
-                                        out_of_place_only=out_of_place_only))
+                                        out_of_place_only=out_of_place_only,
+                                        is_pytorch_extension=is_pytorch_extension))
     all_files_set = set(all_files)
     all_files += [f for f in extra_files if f not in all_files_set]
 


### PR DESCRIPTION
PyTorch extensions can have .cpp or .h files which contain CUDA code that needs to be hipified. The current hipify script logic has overly strict conditions to determine which files get considered for hipification: https://github.com/pytorch/pytorch/blob/master/torch/utils/hipify/hipify_python.py#L146

These conditions might apply well to pytorch/caffe2 source code, but are overconstrained for third-party extensions.
`is_pytorch_file` conditions: https://github.com/pytorch/pytorch/blob/master/torch/utils/hipify/hipify_python.py#L549
`is_caffe2_gpu_file` conditions: https://github.com/pytorch/pytorch/blob/master/torch/utils/hipify/hipify_python.py#L561

This PR relaxes these conditions if we're hipifying a pytorch extension (specified by `is_pytorch_extension=True`) and considers all the file extensions specified using the `extensions` parameter: https://github.com/pytorch/pytorch/blob/master/torch/utils/hipify/hipify_python.py#L820