### PR TITLE
Fix "save binary size" steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1045,7 +1045,7 @@ jobs:
         command: |
             source /env
             cd /pytorch && export COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-            pip3 install requests && \
+            python3 -mpip install requests && \
             SCRIBE_GRAPHQL_ACCESS_TOKEN=${SCRIBE_GRAPHQL_ACCESS_TOKEN} \
             python3 /pytorch/.circleci/scripts/upload_binary_size_to_scuba.py || exit 0
 

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -52,7 +52,7 @@
         command: |
             source /env
             cd /pytorch && export COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
-            pip3 install requests && \
+            python3 -mpip install requests && \
             SCRIBE_GRAPHQL_ACCESS_TOKEN=${SCRIBE_GRAPHQL_ACCESS_TOKEN} \
             python3 /pytorch/.circleci/scripts/upload_binary_size_to_scuba.py || exit 0
 


### PR DESCRIPTION
`pip3` alias might not be available, so call `python3 -mpip` to be on the safe side
Should fix failures like that:
https://app.circleci.com/pipelines/github/pytorch/pytorch/203448/workflows/3837b2d6-b089-4a19-b797-38bdf989c82e/jobs/6913032/parallel-runs/0/steps/0-109

