### PR TITLE
Update the QR documentation to include a warning about when the QR.backward is well-defined.

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5394,6 +5394,12 @@ with :math:`Q` being an orthogonal matrix or batch of orthogonal matrices and
 If :attr:`some` is ``True``, then this function returns the thin (reduced) QR factorization.
 Otherwise, if :attr:`some` is ``False``, this function returns the complete QR factorization.
 
+.. warning::
+          If you plan to propagate through QR, note that the current backward implementation
+          is only well-defined when the first :math:`\min(input.size(-1), input.size(-2))`
+          columns of :attr:`input` are linearly independent.
+          This behavior will propably change once QR supports pivoting.
+
 .. note:: precision may be lost if the magnitudes of the elements of :attr:`input`
           are large
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5395,7 +5395,7 @@ If :attr:`some` is ``True``, then this function returns the thin (reduced) QR fa
 Otherwise, if :attr:`some` is ``False``, this function returns the complete QR factorization.
 
 .. warning::
-          If you plan to propagate through QR, note that the current backward implementation
+          If you plan to backpropagate through QR, note that the current backward implementation
           is only well-defined when the first :math:`\min(input.size(-1), input.size(-2))`
           columns of :attr:`input` are linearly independent.
           This behavior will propably change once QR supports pivoting.


### PR DESCRIPTION
As per title.