### PR TITLE
match batchmatmul on 1.0.0.6

### DIFF
--- a/caffe2/contrib/fakelowp/fp16_gemm_utils.cc
+++ b/caffe2/contrib/fakelowp/fp16_gemm_utils.cc
@@ -428,26 +428,6 @@ void custom_fp16_gemm_strided_batched(
     float* C,
     const int C_stride,
     CPUContext* context) {
-  if (!use_acc_fp16 && (!use_custom_acc32 || !use_temp_accumulator)) {
-    math::GemmStridedBatched<float, CPUContext>(
-        trans_A,
-        trans_B,
-        batch_size,
-        M,
-        N,
-        K,
-        alpha,
-        A,
-        A_stride,
-        B,
-        B_stride,
-        beta,
-        C,
-        C_stride,
-        context);
-    return;
-  }
-
   // loop over matrices in the batch
   for (int i = 0; i < batch_size; ++i) {
     if (use_acc_fp16) {
@@ -465,7 +445,6 @@ void custom_fp16_gemm_strided_batched(
           use_temp_accumulator);
 
     } else {
-      CAFFE_ENFORCE(use_custom_acc32 && use_temp_accumulator);
       custom_fp16_gemm_with_trans(
           trans_A,
           trans_B,

--- a/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
@@ -20,35 +20,31 @@ core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])
 
 class TestBatchMatMul(serial.SerializedTestCase):
     @given(
-        # C=0, #st.integers(min_value=0, max_value=3),  # number of batch dims
+        C=st.integers(min_value=1, max_value=10),
         M=st.integers(min_value=1, max_value=50),
-        K=st.integers(min_value=1, max_value=50),
+        K=st.integers(min_value=1, max_value=512),
         N=st.integers(min_value=1, max_value=50),
         rand_seed=st.integers(0, 65534),
         trans_a=st.booleans(),
         trans_b=st.booleans(),
         run_ints=st.booleans()
     )
-    @settings(deadline=None)
-    def test_batch_matmul(self, M, K, N, rand_seed, trans_a, trans_b, run_ints):
+    @settings(deadline=None, max_examples=100)
+    def test_batch_matmul(self, M, K, N, C, rand_seed, trans_a, trans_b, run_ints):
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()
-        C = 0  # TODO
-        batch_dims = np.random.randint(
-            low=1,
-            high=3,
-            size=C,
-            dtype=np.int64).tolist()
+
+        batch_dims = [C]
 
         if run_ints:
-            X = np.random.randint(low=1, high=3, size=((1, M, K))).astype(np.float32)
+            X = np.random.randint(low=1, high=3, size=((C, M, K))).astype(np.float32)
         else:
             X = 100 * (np.random.rand(*(batch_dims + [M, K])).astype(np.float32) - 0.5)
         if trans_a:
             X = X.swapaxes(-1, -2)
 
         if run_ints:
-            Y = np.random.randint(low=1, high=3, size=((1, K, N))).astype(np.float32)
+            Y = np.random.randint(low=1, high=3, size=((C, K, N))).astype(np.float32)
         else:
             Y = 100 * (np.random.rand(*(batch_dims + [K, N])).astype(np.float32) - 0.5)
         if trans_b:
@@ -93,8 +89,7 @@ class TestBatchMatMul(serial.SerializedTestCase):
         workspace.RunNet(pred_net_ref)
         out_c2_fakefp16 = workspace.FetchBlob('out')
 
-        diff = np.abs((out_c2_fakefp16 - out_glow) / (out_c2_fakefp16 + 1e-8))
-        rowdiff = np.max(diff, axis=1)
+        diff = np.abs(out_c2_fakefp16 - out_glow)
 
         if not np.allclose(out_glow, out_c2_fakefp16):
             print_test_debug_info("bmm", {


### PR DESCRIPTION
Summary:
- remove mkl strided gemm since it was acting weird in some cases, use the plain for loop for gemm for now, it will have performance implications but this closes the gap for the ctr_instagram_5x model
- reproduced the failure scenario of batchmatmul on ctr_instagram_5x by increasing the dimensions of the inputs
- added an option in netrunner to skip bmm if needed

Test Plan:
- net runner passes with ctr_instagram 5x
- bmm unit test repros the discrepancy fixed

Differential Revision: D23320857

