### PR TITLE
Update torch.range warning message regarding the removal version number

### DIFF
--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -186,9 +186,12 @@ static PyObject * THPVariable_range(PyObject* self, PyObject* args, PyObject* kw
   auto r = parser.parse(args, kwargs, parsed_args);
 
   if (r.idx == 0) {
-    PyErr_WarnEx(PyExc_UserWarning, "torch.range is deprecated in favor of torch.arange "
-        "and will be removed in 0.5. Note that arange generates values in [start; end), "
-        "not [start; end].", 1);
+    PyErr_WarnEx(
+        PyExc_UserWarning,
+        "torch.range is deprecated and will be removed in a future release "
+        "because its behavior is inconsistent with Python's range builtin. "
+        "Instead, use torch.arange, which produces values in [start, end) and runs faster.",
+        1);
     if (r.isNone(3)) {
       const auto options = TensorOptions()
           .dtype(r.scalartype(4))

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -190,7 +190,7 @@ static PyObject * THPVariable_range(PyObject* self, PyObject* args, PyObject* kw
         PyExc_UserWarning,
         "torch.range is deprecated and will be removed in a future release "
         "because its behavior is inconsistent with Python's range builtin. "
-        "Instead, use torch.arange, which produces values in [start, end) and runs faster.",
+        "Instead, use torch.arange, which produces values in [start, end).",
         1);
     if (r.isNone(3)) {
       const auto options = TensorOptions()

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5909,7 +5909,7 @@ the gap between two values in the tensor.
 """ + r"""
 .. warning::
     This function is deprecated and will be removed in a future release because its behavior is inconsistent with
-    Python's range builtin. Instead, use :func:`torch.arange`, which produces values in [start, end) and runs faster.
+    Python's range builtin. Instead, use :func:`torch.arange`, which produces values in [start, end).
 
 Args:
     start (float): the starting value for the set of points. Default: ``0``.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5908,7 +5908,8 @@ the gap between two values in the tensor.
     \text{out}_{i+1} = \text{out}_i + \text{step}.
 """ + r"""
 .. warning::
-    This function is deprecated in favor of :func:`torch.arange`.
+    This function is deprecated and will be removed in a future release because its behavior is inconsistent with
+    Python's range builtin. Instead, use :func:`torch.arange`, which produces values in [start, end) and runs faster.
 
 Args:
     start (float): the starting value for the set of points. Default: ``0``.


### PR DESCRIPTION
`torch.range` still hasn't been removed way after version 0.5. This PR fixes the warning message. Alternatively, we can remove `torch.range`.