### PR TITLE
[OACR][NLU] Add aten::str operator

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -129,6 +129,14 @@ TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
 
 RegisterOperators reg(
     {Operator(
+         "aten::str(t elem) -> str",
+         [](Stack* stack) {
+           std::stringstream ss;
+           ss << pop(stack);
+           push(stack, ss.str());
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          "aten::list(str t) -> str[]",
          [](Stack& stack) {
            auto str = pop(stack).toStringRef();

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -186,14 +186,6 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      Operator(
-         "aten::str(t elem) -> str",
-         [](Stack* stack) {
-           std::stringstream ss;
-           ss << pop(stack);
-           push(stack, ss.str());
-         },
-         aliasAnalysisFromSchema()),
-     Operator(
          "aten::device(str a) -> Device",
          [](Stack* stack) {
            push(stack, c10::Device(pop(stack).toStringRef()));


### PR DESCRIPTION
Summary: We recently updated the Stella NLU model in D23307228, and the App started to crash with `Following ops cannot be found:{aten::str, }`.

Test Plan: Verified by installing the assistant-playground app on Android.

Reviewed By: czlx0701

Differential Revision: D23325409

