### PR TITLE
[TensorExpr] Add aten::sum lowering to the kernel

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -239,6 +239,9 @@ namespace jit {
   _(Kernel_2)                               \
   _(Kernel_3)                               \
   _(Kernel_4)                               \
+  _(KernelSumAllAxes)                       \
+  _(KernelSumOneAxis)                       \
+  _(KernelSumMultipleAxes)                  \
   _(FuserPass_1)                            \
   _(FuserPass_2)                            \
   _(FuserPass_3)                            \

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -113,6 +113,8 @@ class TORCH_API TensorExprKernel {
           const ExprHandle&,
           const ExprHandle&)>& innerExpr);
 
+  Tensor* computeSum(const torch::jit::Value* v);
+
   Tensor* computeValue(const torch::jit::Value* v);
 
   void flattenTensors(BackendType backendType);
@@ -128,6 +130,18 @@ class TORCH_API TensorExprKernel {
   at::Device pickDeviceType(const at::ArrayRef<torch::jit::Value*>& inputs);
 
   void bindInput(const torch::jit::Value* input);
+
+  // Captures the information for reduction operation nodes.
+  struct ReductionInfo {
+    std::vector<DimArg> reductionDims;
+    std::vector<DimArg> outputDims;
+    std::vector<size_t> axes;
+    bool keepdim;
+    c10::optional<Dtype> dtype;
+  };
+
+  // Get the reduction info for the given node, based on properties and inputs.
+  ReductionInfo getReductionInfo(const torch::jit::Node* node);
 
  private:
   struct ShapeArg {


### PR DESCRIPTION
Summary:
Handles all dimensions and selected dimensions, per PyTorch semantics.

Test Plan: test_tensorexpr

Reviewers:

Subscribers:

Tasks:

Tags: