### PR TITLE
[quant] Add custom freeze pass for quantization attributes

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -210,6 +210,7 @@ core_sources_full = [
     "torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp",
     "torch/csrc/jit/passes/quantization/dedup_module_uses.cpp",
     "torch/csrc/jit/passes/quantization/finalize.cpp",
+    "torch/csrc/jit/passes/quantization/freeze_quant_ops.cpp",
     "torch/csrc/jit/passes/quantization/fusion_passes.cpp",
     "torch/csrc/jit/python/update_graph_executor_opt.cpp",
     "torch/csrc/jit/runtime/argument_spec.cpp",

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -291,39 +291,7 @@ class AttributePropagator {
     }
   }
 
-  IValue overrideGradient(IValue attr) {
-    if (attr.isTensor()) {
-      auto t = attr.toTensor();
-      if (t.requires_grad()) {
-        t = t.detach();
-        t.set_requires_grad(false);
-        attr = IValue(t);
-      }
-    } else if (attr.isTuple()) {
-      auto tuple = std::move(attr).toTuple();
-      std::vector<IValue>& elems = tuple->elements();
-      for (auto& elem : elems) {
-        elem = overrideGradient(elem);
-      }
-      attr = std::move(tuple);
 
-    } else if (attr.isList()) {
-      c10::List<IValue> elems = std::move(attr).toList();
-      for (size_t i = 0; i < elems.size(); i++) {
-        elems.set(i, overrideGradient(elems.extract(i)));
-      }
-      attr = std::move(elems);
-    } else if (attr.isGenericDict()) {
-      auto dict = std::move(attr).toGenericDict();
-      for (const auto& pair : dict) {
-        auto val = pair.value();
-        val = overrideGradient(val);
-      }
-      attr = std::move(dict);
-    }
-
-    return attr;
-  }
 
   // This method is invoked only when 'freezeInterfaces' parameter is on.
   // The module associated with Interface is retrieved and the invoked method
@@ -671,6 +639,40 @@ class AttributePropagator {
   std::deque<std::string> names_;
 }; // class AttributePropagator
 } // namespace
+
+IValue overrideGradient(IValue attr) {
+  if (attr.isTensor()) {
+    auto t = attr.toTensor();
+    if (t.requires_grad()) {
+      t = t.detach();
+      t.set_requires_grad(false);
+      attr = IValue(t);
+    }
+  } else if (attr.isTuple()) {
+    auto tuple = std::move(attr).toTuple();
+    std::vector<IValue>& elems = tuple->elements();
+    for (auto& elem : elems) {
+      elem = overrideGradient(elem);
+    }
+    attr = std::move(tuple);
+
+  } else if (attr.isList()) {
+    c10::List<IValue> elems = std::move(attr).toList();
+    for (size_t i = 0; i < elems.size(); i++) {
+      elems.set(i, overrideGradient(elems.extract(i)));
+    }
+    attr = std::move(elems);
+  } else if (attr.isGenericDict()) {
+    auto dict = std::move(attr).toGenericDict();
+    for (const auto& pair : dict) {
+      auto val = pair.value();
+      val = overrideGradient(val);
+    }
+    attr = std::move(dict);
+  }
+
+  return attr;
+}
 
 Module freeze_module(
     const Module& module,

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -24,5 +24,7 @@ TORCH_API Module freeze_module(
     std::vector<std::string> preservedAttrs = std::vector<std::string>(),
     bool freezeInterfaces = true);
 
+IValue overrideGradient(IValue attr);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -26,5 +26,14 @@ TORCH_API Module freeze_module(
 
 IValue overrideGradient(IValue attr);
 
+/*
+* Recursively apply func to the graph.
+*/
+void optimizeSubGraphs(
+    std::shared_ptr<Graph>& graph,
+    const std::function<void(std::shared_ptr<Graph>&)>& func);
+
+bool inlineInterfaceCall(Node* n, const IValue& attr);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/quantization/finalize.cpp
+++ b/torch/csrc/jit/passes/quantization/finalize.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/prepack_folding.h>
+#include <torch/csrc/jit/passes/quantization/freeze_quant_ops.h>
 #include <torch/csrc/jit/passes/quantization/quantization_patterns.h>
 
 namespace torch {
@@ -73,12 +74,31 @@ void FoldQuantizedPrepackingOps(Module& module) {
   PrePackingOpsFolder(module, filter_fn, "quantized");
 }
 
-Module Finalize(Module& module, QuantType quant_type) {
+Module FreezeQuantizedAttrs(Module& module) {
+  auto filter_fn = [](const Node* n) -> bool {
+    return (
+        (n->kind() == Symbol::fromQualString("quantized::linear_prepack")) ||
+        n->kind() == Symbol::fromQualString("quantized::conv1d_prepack") ||
+        n->kind() == Symbol::fromQualString("quantized::conv2d_prepack") ||
+        n->kind() == Symbol::fromQualString("quantized::conv3d_prepack") ||
+        n->kind() == Symbol::fromQualString("quantized::embedding_bag_4bit_prepack") ||
+        n->kind() == Symbol::fromQualString("quantized::embedding_bag_byte_prepack") ||
+        n->kind() == Symbol::fromQualString("quantized::linear"));
+  };
+  return FreezeAndFoldQuantOps(module, filter_fn);
+}
+
+Module Finalize(Module& module, QuantType quant_type, bool freeze_only_quant_ops) {
   auto graph = module.get_method("forward").graph();
   InsertPrepackUnpack(graph);
   GRAPH_DUMP("Before QuantFusion:", graph);
   QuantFusion(graph, quant_type);
-  auto frozen = freeze_module(module);
+  Module frozen;
+  if (freeze_only_quant_ops) {
+    frozen = FreezeQuantizedAttrs(module);
+  } else {
+    frozen = freeze_module(module);
+  }
   FoldQuantizedPrepackingOps(frozen);
   return frozen;
 }

--- a/torch/csrc/jit/passes/quantization/finalize.cpp
+++ b/torch/csrc/jit/passes/quantization/finalize.cpp
@@ -81,14 +81,19 @@ Module FreezeQuantizedAttrs(Module& module) {
         n->kind() == Symbol::fromQualString("quantized::conv1d_prepack") ||
         n->kind() == Symbol::fromQualString("quantized::conv2d_prepack") ||
         n->kind() == Symbol::fromQualString("quantized::conv3d_prepack") ||
-        n->kind() == Symbol::fromQualString("quantized::embedding_bag_4bit_prepack") ||
-        n->kind() == Symbol::fromQualString("quantized::embedding_bag_byte_prepack") ||
+        n->kind() ==
+            Symbol::fromQualString("quantized::embedding_bag_4bit_prepack") ||
+        n->kind() ==
+            Symbol::fromQualString("quantized::embedding_bag_byte_prepack") ||
         n->kind() == Symbol::fromQualString("quantized::linear"));
   };
   return FreezeAndFoldQuantOps(module, filter_fn);
 }
 
-Module Finalize(Module& module, QuantType quant_type, bool freeze_only_quant_ops) {
+Module Finalize(
+    Module& module,
+    QuantType quant_type,
+    bool freeze_only_quant_ops) {
   auto graph = module.get_method("forward").graph();
   InsertPrepackUnpack(graph);
   GRAPH_DUMP("Before QuantFusion:", graph);

--- a/torch/csrc/jit/passes/quantization/finalize.h
+++ b/torch/csrc/jit/passes/quantization/finalize.h
@@ -49,7 +49,8 @@ TORCH_API void InsertPrepackUnpack(Module& module);
 
 TORCH_API script::Module Finalize(
     script::Module& module,
-    QuantType quant_type = QuantType::STATIC);
+    QuantType quant_type = QuantType::STATIC,
+    bool freeze_only_quant_ops = false);
 
 TORCH_API void FoldQuantizedPrepackingOps(Module& module);
 

--- a/torch/csrc/jit/passes/quantization/freeze_quant_ops.cpp
+++ b/torch/csrc/jit/passes/quantization/freeze_quant_ops.cpp
@@ -1,0 +1,201 @@
+#include <stack>
+
+#include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/passes/inliner.h>
+#include <torch/csrc/jit/passes/quantization/freeze_quant_ops.h>
+#include <torch/csrc/jit/runtime/graph_executor_impl.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
+
+namespace torch {
+namespace jit {
+
+namespace {
+class QuantizationAttributeFreezer {
+ public:
+  QuantizationAttributeFreezer(
+      Module& module,
+      const FreezingOpsFilterFn& is_freezable_op)
+      : module_(module), is_freezable_op_(is_freezable_op) {
+    auto method = module.get_method("forward");
+    func_ = &method.function();
+  }
+
+  void run() {
+    auto graph = func_->graph();
+    // Inline the graph to make sure we don't have to traverse different
+    // subgraphs when trying to get the weight attributes.
+    Inline(*graph);
+    std::stack<Block*> blocks_to_visit({graph->block()});
+    while (!blocks_to_visit.empty()) {
+      Block* block = blocks_to_visit.top();
+      blocks_to_visit.pop();
+      for (auto n : block->nodes()) {
+        if (is_freezable_op_(n)) {
+          // Find getattrs in the input of the quant op
+          identifyAndConvertGetAttrs(module_, n, graph);
+        }
+        for (Block* sub_block : n->blocks()) {
+          blocks_to_visit.push(sub_block);
+        }
+      }
+    }
+    runOptimization(graph, false);
+    removeUnusedAttrs();
+    std::cout << "** FINAL Graph ** " << graph->toString();
+  }
+
+ private:
+  /*
+   * Find the GetAttr nodes in the graph that correspond to
+   * either the quantize prepack/run op or the
+   * quantize_per_tensor/quantize_per_channel operator
+   */
+  void identifyAndConvertGetAttrs(
+      Module& module,
+      Node* n,
+      std::shared_ptr<Graph>& graph) {
+    const auto& inputs = n->inputs().vec();
+    for (auto v : inputs) {
+      auto quant_inp_node = v->node();
+      WithInsertPoint ins(quant_inp_node);
+      if (quant_inp_node->kind() == prim::GetAttr) {
+        convertAttrToConst(module, quant_inp_node, graph);
+      } else if (
+          quant_inp_node->kind() == Symbol::aten("quantize_per_tensor") ||
+          quant_inp_node->kind() == Symbol::aten("quantize_per_channel")) {
+        identifyAndConvertGetAttrs(module, quant_inp_node, graph);
+      }
+    }
+  }
+
+  void convertAttrToConst(
+      Module& module,
+      Node* attr_node,
+      std::shared_ptr<Graph>& graph) {
+    // Map from module to list of constant attribute values in the graph
+    std::unordered_map<ModulePtr, std::unordered_map<std::string, Value*>>
+        moduleAttrs;
+    auto name = attr_node->s(attr::name);
+
+    auto attrModule = module;
+    std::deque<std::string> module_names;
+    // Get the module corresponding to the attr
+    if (!updateAttrModule(
+            attr_node->inputs()[0], name, attrModule, module_names, graph)) {
+      TORCH_WARN_ONCE(
+          "Quantization param attribute ",
+          name,
+          " is not a constant in the graph. Cannot be frozen.");
+    }
+    TORCH_INTERNAL_ASSERT(attrModule.hasattr(name));
+    auto attrs = moduleAttrs.find(attrModule._ivalue());
+
+    Value* const_param = nullptr;
+    if (attrs != moduleAttrs.end()) {
+      auto attr_value = attrs->second.find(name);
+      if (attr_value != attrs->second.end()) {
+        const_param = attr_value->second;
+      }
+    }
+    // If constant node hasn't yet been created for this GetAttr then
+    // create one and insert into the graph.
+    if (!const_param) {
+      auto attr = attrModule.attr(name);
+      attr = overrideGradient(attr);
+      if (auto inserted_val = tryInsertConstant(*graph, attr)) {
+        const_param = *inserted_val;
+      } else {
+        TORCH_WARN_ONCE("Attribute ", name, "is not materializable");
+        return;
+      }
+      std::string const_name("self.");
+      for (auto& name : module_names) {
+        const_name += name + '.';
+      }
+      const_name += name;
+      const_param->setDebugName(const_name);
+      moduleAttrs[attrModule._ivalue()][name] = const_param;
+
+      attrsToRemove_[attrModule._ivalue()].insert(name);
+    }
+    attr_node->outputs().at(0)->replaceAllUsesWith(const_param);
+    attr_node->removeAllInputs();
+  }
+
+  /*
+   * Delete attributes from the graph that we already converted
+   * to constant nodes.
+   */
+  void removeUnusedAttrs() {
+    std::vector<std::string> attrNames;
+    for (auto& it : attrsToRemove_) {
+      auto& mptr = it.first;
+      auto type = mptr->type();
+
+      auto attr_names = it.second;
+      for (auto& name : attr_names) {
+        std::cout << "removing attr " << name << " slot "
+                  << type->getAttributeSlot(name) << std::endl;
+        TORCH_CHECK(
+            type->hasAttribute(name),
+            "Expected ClassType to have attribute ",
+            name);
+        mptr->unsafeRemoveAttr(name);
+        type->unsafeRemoveAttribute(name);
+      }
+    }
+  }
+
+  /*
+   * Traverse the module hierarchy to find the module corresponding to the
+   * GetAttr node in the graph.
+   */
+  bool updateAttrModule(
+      Value* input,
+      std::string& name,
+      Module& attrModule,
+      std::deque<std::string>& names,
+      std::shared_ptr<Graph>& graph) {
+    Node* node = input->node();
+    while (!(node->outputs()[0]->type() == graph->inputs()[0]->type())) {
+      if (node->kind() == prim::GetAttr) {
+        names.push_front(node->s(attr::name));
+        node = node->inputs()[0]->node();
+      } else {
+        return false;
+      }
+    }
+    for (auto& moduleName : names) {
+      attrModule = attrModule.attr(moduleName).toModule();
+    }
+    return true;
+  }
+
+  Module& module_;
+  Function* func_;
+
+  const FreezingOpsFilterFn& is_freezable_op_;
+
+  // Map from module ptr to list of attribute names to remove from module.
+  std::unordered_map<ModulePtr, std::set<std::string>> attrsToRemove_;
+
+}; // class QuantizationAttributeFreezer
+
+} // namespace
+
+Module FreezeAndFoldQuantOps(
+    script::Module& input_module,
+    const FreezingOpsFilterFn& is_freezable_op) {
+  auto module = input_module.clone(true);
+  TORCH_CHECK(
+      !module.hasattr("training") || !module.is_training(),
+      "Freezing quantization params in training mode is not yet supported");
+
+  QuantizationAttributeFreezer quantFreezer(module, is_freezable_op);
+  quantFreezer.run();
+  return module;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/quantization/freeze_quant_ops.h
+++ b/torch/csrc/jit/passes/quantization/freeze_quant_ops.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+using FreezingOpsFilterFn = std::function<bool(Node*)>;
+
+/** \brief Freeze Quantization Attributes
+ *
+ * Freezing is a functionality that allows JIT to internalize immutable
+ * attributes. In this method we freeze all attributes related to quantizing
+ * modules like weight, bias and qparams. This method is combined with inlining
+ * and produces a cloned module with only the quantization attributes frozen. If
+ * you wish to freeze all attributes in the graph then refer to the
+ * freeze_module function instead.
+ */
+
+TORCH_API Module FreezeAndFoldQuantOps(
+    script::Module& input_module,
+    const FreezingOpsFilterFn& is_freezable_op);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -280,12 +280,13 @@ void initJITBindings(PyObject* module) {
           [](Module& module) { SwapFunctionalLinear(module); })
       .def(
           "_jit_pass_quant_finalize",
-          [](Module& module, int quant_type_int) {
+          [](Module& module, int quant_type_int, bool freeze_only_quant_ops) {
             auto quant_type = static_cast<QuantType>(quant_type_int);
-            return Finalize(module, quant_type);
+            return Finalize(module, quant_type, false);
           },
           py::arg("module"),
-          py::arg("quant_type_int") = 1)
+          py::arg("quant_type_int") = 1,
+          py::arg("freeze_only_quant_ops") = false)
       .def(
           "_jit_pass_pattern_based_rewrite",
           [](const Module& m) { return PatternBasedRewrite(m); })


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43595 [quant] Expose quantization freeze pass in convert API
* **#43594 [quant] Add custom freeze pass for quantization attributes**

Summary:

This PR decouples quantization finalize pass from the geenric `freeze_module` pass
It only focuses on freezing the attributes related to quantization params so that they can later
be folded into the graph, and used by subsequent JIT pass like prepack_folding

Test Plan:
python test/test_quantization.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23333263](https://our.internmc.facebook.com/intern/diff/D23333263)