### PR TITLE
[pytorch] upload mobile code analysis result to AWS

### DIFF
--- a/.circleci/cimodel/data/simple/mobile_definitions.py
+++ b/.circleci/cimodel/data/simple/mobile_definitions.py
@@ -48,7 +48,7 @@ class MobileJob:
         if self.is_master_only:
             props_dict["filters"] = cimodel.data.simple.util.branch_filters.gen_filter_dict()
 
-        return [{"pytorch_linux_build": props_dict}]
+        return [{"pytorch_mobile_build": props_dict}]
 
 
 WORKFLOW_DATA = [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1507,6 +1507,67 @@ jobs:
       - store_test_results:
           path: test/test-reports
 
+  pytorch_mobile_build:
+    <<: *pytorch_params
+    machine:
+      image: ubuntu-1604:202007-01
+    steps:
+    - checkout
+    - calculate_docker_image_tag
+    - setup_linux_system_environment
+    - optional_merge_target_branch
+    - setup_ci_environment
+    - run:
+        name: Build
+        no_output_timeout: "1h"
+        command: |
+          set -e
+
+          # Pull Docker image and run build
+          echo "DOCKER_IMAGE: "${DOCKER_IMAGE}:${DOCKER_TAG}
+          time docker pull ${DOCKER_IMAGE}:${DOCKER_TAG} >/dev/null
+          export id=$(docker run --env-file "${BASH_ENV}" --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE}:${DOCKER_TAG})
+
+          git submodule sync && git submodule update -q --init --recursive
+          VOLUME_MOUNTS="-v /home/circleci/project/:/var/lib/jenkins/workspace"
+          export id=$(docker run --env-file "${BASH_ENV}" ${VOLUME_MOUNTS} --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE}:${DOCKER_TAG})
+
+          export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
+
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
+    - run:
+        name: Upload Mobile Code Analysis Result
+        no_output_timeout: "10m"
+        command: |
+          set -e
+          retry() {
+              $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+          }
+
+          if ! [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
+            exit 0
+          fi
+
+          RESULT_PATH="/home/circleci/workspace/torch_result.yaml"
+          S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
+
+          echo "Fetching the mobile code analysis result from docker image..."
+          docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml ${RESULT_PATH}
+
+          echo "============================ BEGIN ============================"
+          cat "${RESULT_PATH}"
+          echo "============================  END  ============================"
+
+          echo "Uploading the mobile code analysis result to AWS S3..."
+          echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH}"
+          echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
+          echo "RESULT_PATH: ${RESULT_PATH}"
+          echo "S3_PATH: ${S3_PATH}"
+
+          # Running the CI job multiple times for the same commit should be idempotent.
+          # TODO: should maintain an index file for downloading.
+          retry aws s3 cp "${RESULT_PATH}" "${S3_PATH}"
+
   pytorch_android_gradle_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build
@@ -6059,28 +6120,28 @@ workflows:
           ios_platform: OS
           name: pytorch_ios_11_2_1_arm64_custom_build
           op_list: mobilenetv2.yaml
-      - pytorch_linux_build:
+      - pytorch_mobile_build:
           build_environment: pytorch-linux-xenial-py3-clang5-mobile-build
           build_only: "1"
           docker_image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan
           name: pytorch_linux_xenial_py3_clang5_mobile_build
           requires:
             - docker-pytorch-linux-xenial-py3-clang5-asan
-      - pytorch_linux_build:
+      - pytorch_mobile_build:
           build_environment: pytorch-linux-xenial-py3-clang5-mobile-custom-build-static
           build_only: "1"
           docker_image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan
           name: pytorch_linux_xenial_py3_clang5_mobile_custom_build_static
           requires:
             - docker-pytorch-linux-xenial-py3-clang5-asan
-      - pytorch_linux_build:
+      - pytorch_mobile_build:
           build_environment: pytorch-linux-xenial-py3-clang5-mobile-custom-build-dynamic
           build_only: "1"
           docker_image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c
           name: pytorch_linux_xenial_py3_clang5_mobile_custom_build_dynamic
           requires:
             - docker-pytorch-linux-xenial-py3-clang5-android-ndk-r19c
-      - pytorch_linux_build:
+      - pytorch_mobile_build:
           build_environment: pytorch-linux-xenial-py3-clang5-mobile-code-analysis
           build_only: "1"
           docker_image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1535,11 +1535,6 @@ jobs:
           export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
-
-          if [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
-            echo "Fetching the mobile code analysis result from docker image..."
-            docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml /home/circleci/workspace/torch_result.yaml
-          fi
     - run:
         name: Upload Mobile Code Analysis Result
         no_output_timeout: "10m"
@@ -1549,22 +1544,23 @@ jobs:
               $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
           }
 
-          if ! [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
+          if ! [[ "${BUILD_ENVIRONMENT}" == *"-mobile-custom-build-dynamic"* ]]; then
             exit 0
           fi
 
-          RESULT_PATH="/home/circleci/workspace/torch_result.yaml"
-          S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
-
-          echo "============================ BEGIN ============================"
-          cat "${RESULT_PATH}"
-          echo "============================  END  ============================"
+          RESULT_PATH="/home/circleci/project/build_test_custom_build/build_analyzer/work/torch_result.yaml"
+          FILENAME="${CIRCLE_BRANCH//\//-}.$(git rev-list --count HEAD).${CIRCLE_SHA1}"
+          S3_PATH="s3://pytorch-mobile-build/op_deps/${FILENAME}.yaml"
 
           echo "Uploading the mobile code analysis result to AWS S3..."
           echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH}"
           echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
           echo "RESULT_PATH: ${RESULT_PATH}"
           echo "S3_PATH: ${S3_PATH}"
+
+          echo "============================ BEGIN ============================"
+          cat "${RESULT_PATH}"
+          echo "============================  END  ============================"
 
           # Running the CI job multiple times for the same commit should be idempotent.
           # TODO: should maintain an index file for downloading.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1535,6 +1535,11 @@ jobs:
           export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
+
+          if [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
+            echo "Fetching the mobile code analysis result from docker image..."
+            docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml /home/circleci/workspace/torch_result.yaml
+          fi
     - run:
         name: Upload Mobile Code Analysis Result
         no_output_timeout: "10m"
@@ -1550,9 +1555,6 @@ jobs:
 
           RESULT_PATH="/home/circleci/workspace/torch_result.yaml"
           S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
-
-          echo "Fetching the mobile code analysis result from docker image..."
-          docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml ${RESULT_PATH}
 
           echo "============================ BEGIN ============================"
           cat "${RESULT_PATH}"

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -189,6 +189,11 @@
           export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
+
+          if [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
+            echo "Fetching the mobile code analysis result from docker image..."
+            docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml /home/circleci/workspace/torch_result.yaml
+          fi
     - run:
         name: Upload Mobile Code Analysis Result
         no_output_timeout: "10m"
@@ -204,9 +209,6 @@
 
           RESULT_PATH="/home/circleci/workspace/torch_result.yaml"
           S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
-
-          echo "Fetching the mobile code analysis result from docker image..."
-          docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml ${RESULT_PATH}
 
           echo "============================ BEGIN ============================"
           cat "${RESULT_PATH}"

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -189,11 +189,6 @@
           export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
-
-          if [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
-            echo "Fetching the mobile code analysis result from docker image..."
-            docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml /home/circleci/workspace/torch_result.yaml
-          fi
     - run:
         name: Upload Mobile Code Analysis Result
         no_output_timeout: "10m"
@@ -203,22 +198,23 @@
               $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
           }
 
-          if ! [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
+          if ! [[ "${BUILD_ENVIRONMENT}" == *"-mobile-custom-build-dynamic"* ]]; then
             exit 0
           fi
 
-          RESULT_PATH="/home/circleci/workspace/torch_result.yaml"
-          S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
-
-          echo "============================ BEGIN ============================"
-          cat "${RESULT_PATH}"
-          echo "============================  END  ============================"
+          RESULT_PATH="/home/circleci/project/build_test_custom_build/build_analyzer/work/torch_result.yaml"
+          FILENAME="${CIRCLE_BRANCH//\//-}.$(git rev-list --count HEAD).${CIRCLE_SHA1}"
+          S3_PATH="s3://pytorch-mobile-build/op_deps/${FILENAME}.yaml"
 
           echo "Uploading the mobile code analysis result to AWS S3..."
           echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH}"
           echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
           echo "RESULT_PATH: ${RESULT_PATH}"
           echo "S3_PATH: ${S3_PATH}"
+
+          echo "============================ BEGIN ============================"
+          cat "${RESULT_PATH}"
+          echo "============================  END  ============================"
 
           # Running the CI job multiple times for the same commit should be idempotent.
           # TODO: should maintain an index file for downloading.

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -161,6 +161,67 @@
       - store_test_results:
           path: test/test-reports
 
+  pytorch_mobile_build:
+    <<: *pytorch_params
+    machine:
+      image: ubuntu-1604:202007-01
+    steps:
+    - checkout
+    - calculate_docker_image_tag
+    - setup_linux_system_environment
+    - optional_merge_target_branch
+    - setup_ci_environment
+    - run:
+        name: Build
+        no_output_timeout: "1h"
+        command: |
+          set -e
+
+          # Pull Docker image and run build
+          echo "DOCKER_IMAGE: "${DOCKER_IMAGE}:${DOCKER_TAG}
+          time docker pull ${DOCKER_IMAGE}:${DOCKER_TAG} >/dev/null
+          export id=$(docker run --env-file "${BASH_ENV}" --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE}:${DOCKER_TAG})
+
+          git submodule sync && git submodule update -q --init --recursive
+          VOLUME_MOUNTS="-v /home/circleci/project/:/var/lib/jenkins/workspace"
+          export id=$(docker run --env-file "${BASH_ENV}" ${VOLUME_MOUNTS} --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins ${DOCKER_IMAGE}:${DOCKER_TAG})
+
+          export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
+
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
+    - run:
+        name: Upload Mobile Code Analysis Result
+        no_output_timeout: "10m"
+        command: |
+          set -e
+          retry() {
+              $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+          }
+
+          if ! [[ ${BUILD_ENVIRONMENT} == *-mobile-custom-build-dynamic* ]]; then
+            exit 0
+          fi
+
+          RESULT_PATH="/home/circleci/workspace/torch_result.yaml"
+          S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
+
+          echo "Fetching the mobile code analysis result from docker image..."
+          docker cp $id:/var/lib/jenkins/workspace/build_test_custom_build/build_analyzer/work/torch_result.yaml ${RESULT_PATH}
+
+          echo "============================ BEGIN ============================"
+          cat "${RESULT_PATH}"
+          echo "============================  END  ============================"
+
+          echo "Uploading the mobile code analysis result to AWS S3..."
+          echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH}"
+          echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
+          echo "RESULT_PATH: ${RESULT_PATH}"
+          echo "S3_PATH: ${S3_PATH}"
+
+          # Running the CI job multiple times for the same commit should be idempotent.
+          # TODO: should maintain an index file for downloading.
+          retry aws s3 cp "${RESULT_PATH}" "${S3_PATH}"
+
   pytorch_android_gradle_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build

--- a/.jenkins/pytorch/build-mobile.sh
+++ b/.jenkins/pytorch/build-mobile.sh
@@ -20,6 +20,26 @@ retry pip install --pre torch torchvision \
   -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html \
   --progress-bar off
 
+upload_code_analysis_result() {
+  RESULT_PATH="build_test_custom_build/build_analyzer/work/torch_result.yaml"
+  S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
+
+  echo "Uploading the mobile code analysis result to AWS S3..."
+  echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH}"
+  echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
+  echo "RESULT_PATH: ${RESULT_PATH}"
+  echo "S3_PATH: ${S3_PATH}"
+
+  if [ ! -f "${RESULT_PATH}" ]; then
+    echo "Cannot find the mobile code analysis result."
+    exit 1
+  fi
+
+  # Running the CI job multiple times for the same commit should be idempotent.
+  # TODO: should maintain an index file for downloading.
+  retry aws s3 cp "${RESULT_PATH}" "${S3_PATH}"
+}
+
 # Run end-to-end process of building mobile library, linking into the predictor
 # binary, and running forward pass with a real model.
 if [[ "$BUILD_ENVIRONMENT" == *-mobile-custom-build-static* ]]; then
@@ -28,6 +48,7 @@ elif [[ "$BUILD_ENVIRONMENT" == *-mobile-custom-build-dynamic* ]]; then
   export LLVM_DIR="$(llvm-config-5.0 --prefix)"
   echo "LLVM_DIR: ${LLVM_DIR}"
   TEST_CUSTOM_BUILD_DYNAMIC=1 test/mobile/custom_build/build.sh
+  upload_code_analysis_result
 else
   TEST_DEFAULT_BUILD=1 test/mobile/custom_build/build.sh
 fi

--- a/.jenkins/pytorch/build-mobile.sh
+++ b/.jenkins/pytorch/build-mobile.sh
@@ -20,26 +20,6 @@ retry pip install --pre torch torchvision \
   -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html \
   --progress-bar off
 
-upload_code_analysis_result() {
-  RESULT_PATH="build_test_custom_build/build_analyzer/work/torch_result.yaml"
-  S3_PATH="s3://pytorch-mobile-build/op_deps/${CIRCLE_SHA1}.yaml"
-
-  echo "Uploading the mobile code analysis result to AWS S3..."
-  echo "CIRCLE_BRANCH: ${CIRCLE_BRANCH}"
-  echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
-  echo "RESULT_PATH: ${RESULT_PATH}"
-  echo "S3_PATH: ${S3_PATH}"
-
-  if [ ! -f "${RESULT_PATH}" ]; then
-    echo "Cannot find the mobile code analysis result."
-    exit 1
-  fi
-
-  # Running the CI job multiple times for the same commit should be idempotent.
-  # TODO: should maintain an index file for downloading.
-  retry aws s3 cp "${RESULT_PATH}" "${S3_PATH}"
-}
-
 # Run end-to-end process of building mobile library, linking into the predictor
 # binary, and running forward pass with a real model.
 if [[ "$BUILD_ENVIRONMENT" == *-mobile-custom-build-static* ]]; then
@@ -48,7 +28,6 @@ elif [[ "$BUILD_ENVIRONMENT" == *-mobile-custom-build-dynamic* ]]; then
   export LLVM_DIR="$(llvm-config-5.0 --prefix)"
   echo "LLVM_DIR: ${LLVM_DIR}"
   TEST_CUSTOM_BUILD_DYNAMIC=1 test/mobile/custom_build/build.sh
-  upload_code_analysis_result
 else
   TEST_DEFAULT_BUILD=1 test/mobile/custom_build/build.sh
 fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43596 [pytorch] upload mobile code analysis result to AWS**

Summary:
Use the mobile custom build CI job to upload the static analysis result
to AWS per github PR.

Mobile selective build script could fetch the latest version from AWS
according to local commit hashes.