### PR TITLE
Add Python code coverage

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -10,8 +10,8 @@ CONFIG_TREE_DATA = [
         ]),
         ("gcc", [
             ("5.4", [  # All this subtree rebases to master and then build
-                XImportant("3.6"),
                 ("3.6", [
+                    ("important", [X(True)]),
                     ("parallel_tbb", [X(True)]),
                     ("parallel_native", [X(True)]),
                 ]),
@@ -69,7 +69,11 @@ CONFIG_TREE_DATA = [
             ]),
         ]),
         ("gcc", [
-            ("9", [XImportant("3.8")]),
+            ("9", [
+                ("3.8", [
+                    ("coverage", [XImportant(True)]),
+                ]),
+            ]),
         ]),
     ]),
 ]
@@ -145,7 +149,8 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
             "libtorch": LibTorchConfigNode,
             "important": ImportantConfigNode,
             "build_only": BuildOnlyConfigNode,
-            "cuda_gcc_override": CudaGccOverrideConfigNode
+            "cuda_gcc_override": CudaGccOverrideConfigNode,
+            "coverage": CoverageConfigNode,
         }
         return next_nodes[experimental_feature]
 
@@ -227,6 +232,15 @@ class BuildOnlyConfigNode(TreeConfigNode):
 
     def init2(self, node_name):
         self.props["build_only"] = node_name
+
+    def child_constructor(self):
+        return ExperimentalFeatureConfigNode
+
+
+class CoverageConfigNode(TreeConfigNode):
+
+    def init2(self, node_name):
+        self.props["is_coverage"] = node_name
 
     def child_constructor(self):
         return ExperimentalFeatureConfigNode

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -306,8 +306,12 @@ def instantiate_configs():
         is_important = fc.find_prop("is_important") or False
         parallel_backend = fc.find_prop("parallel_backend") or None
         build_only = fc.find_prop("build_only") or False
+        is_coverage = fc.find_prop("is_coverage") or False
         if build_only and restrict_phases is None:
             restrict_phases = ["build"]
+        if is_coverage and restrict_phases is None:
+            restrict_phases = ["build", "coverage_test"]
+
 
         gpu_resource = None
         if cuda_version and cuda_version != "10":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,6 +660,13 @@ jobs:
 
           echo "Retrieving test reports"
           docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
+          if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
+              echo "Retrieving coverage report"
+              docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
+              docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              python3 -mpip install codecov
+              python3 -mcodecov
+          fi
         when: always
     - store_test_results:
         path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6529,10 +6529,10 @@ workflows:
           build_environment: "pytorch-linux-bionic-py3.8-gcc9-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
       - pytorch_linux_test:
-          name: pytorch_linux_bionic_py3_8_gcc9_test
+          name: pytorch_linux_bionic_py3_8_gcc9_coverage_test
           requires:
             - pytorch_linux_bionic_py3_8_gcc9_build
-          build_environment: "pytorch-linux-bionic-py3.8-gcc9-test"
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage_test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
           resource_class: large
       - pytorch_macos_10_13_py3_build:

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -199,6 +199,13 @@ jobs:
 
           echo "Retrieving test reports"
           docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
+          if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
+              echo "Retrieving coverage report"
+              docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
+              docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              python3 -mpip install codecov
+              python3 -mcodecov
+          fi
         when: always
     - store_test_results:
         path: test-reports

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 ## PyTorch
 
 .coverage
+coverage.xml
 .gradle
 .hypothesis
 .mypy_cache

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -13,7 +13,7 @@ echo "Testing pytorch"
 
 if [ -n "${IN_CIRCLECI}" ]; then
   # TODO move this to docker
-  pip_install unittest-xml-reporting coverage codecov
+  pip_install unittest-xml-reporting coverage
 
   if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]]; then
     # TODO: move this to Docker
@@ -400,4 +400,10 @@ else
   test_distributed
   test_benchmarks
   test_rpc
+  if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
+    pushd test
+    echo "Generating XML coverage report"
+    time python -mcoverage xml
+    popd
+  fi
 fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -13,7 +13,7 @@ echo "Testing pytorch"
 
 if [ -n "${IN_CIRCLECI}" ]; then
   # TODO move this to docker
-  pip_install unittest-xml-reporting
+  pip_install unittest-xml-reporting coverage codecov
 
   if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]]; then
     # TODO: move this to Docker
@@ -30,6 +30,9 @@ if [ -n "${IN_CIRCLECI}" ]; then
   if [[ "$BUILD_ENVIRONMENT" == *-slow-* ]]; then
     export PYTORCH_TEST_WITH_SLOW=1
     export PYTORCH_TEST_SKIP_FAST=1
+  fi
+  if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
+    export PYTORCH_COLLECT_COVERAGE=1
   fi
 fi
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/opt/conda/lib/python3.8/site-packages/::project/"

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -200,10 +200,7 @@ def print_to_stderr(message):
 
 def get_executable_command(options, allow_pytest):
     if options.coverage:
-        executable = ['coverage', 'run']
-        if PYTORCH_COLLECT_COVERAGE:
-            executable.append('--append')
-        executable.append('--source=torch')
+        executable = ['coverage', 'run', '--parallel-mode', '--source=torch']
     else:
         executable = [sys.executable]
     if options.pytest:
@@ -720,8 +717,12 @@ def main():
             print_to_stderr(err_message)
     finally:
         if options.coverage:
-            shell(['coverage', 'combine'])
-            shell(['coverage', 'xml'])
+            test_dir = os.path.dirname(os.path.abspath(__file__))
+            if not PYTORCH_COLLECT_COVERAGE:
+                shell(['coverage', 'combine'], cwd=test_dir)
+                shell(['coverage', 'html'], cwd=test_dir)
+            else:
+                shell(['coverage', 'combine', '--append'], cwd=test_dir)
 
     if options.continue_through_error and has_failed:
         for err in failure_messages:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 from datetime import datetime
 import modulefinder
@@ -17,6 +15,7 @@ import torch._six
 from torch.utils import cpp_extension
 from torch.testing._internal.common_utils import TEST_WITH_ROCM, shell
 import torch.distributed as dist
+from typing import Dict, Optional
 
 TESTS = [
     'test_autograd',
@@ -157,7 +156,7 @@ SLOW_TESTS = [
     'test_determination',
     'test_futures',
 ]
-_DEP_MODULES_CACHE = {}
+_DEP_MODULES_CACHE: Dict[str, set] = {}
 
 DISTRIBUTED_TESTS_CONFIG = {}
 
@@ -200,7 +199,7 @@ def print_to_stderr(message):
 
 def get_executable_command(options, allow_pytest):
     if options.coverage:
-        executable = ['coverage', 'run', '--parallel-mode', '--source torch']
+        executable = ['coverage', 'run', '--source=torch']
     else:
         executable = [sys.executable]
     if options.pytest:
@@ -564,7 +563,7 @@ def log_test_reason(file_type, filename, test, options):
 
 
 def get_dep_modules(test):
-    # Cache results in case of repitition
+    # Cache results in case of repetition
     if test in _DEP_MODULES_CACHE:
         return _DEP_MODULES_CACHE[test]
 
@@ -611,7 +610,7 @@ def determine_target(test, touched_files, options):
     # Some tests are faster to execute than to determine.
     if test not in SLOW_TESTS:
         if options.verbose:
-            print_to_stderr('Running {} without determination'.format(test))
+            print_to_stderr(f'Running {test} without determination')
         return True
     # HACK: "no_ninja" is not a real module
     if test.endswith('_no_ninja'):
@@ -649,10 +648,30 @@ def determine_target(test, touched_files, options):
 
     # If nothing has determined the test has run, don't run the test.
     if options.verbose:
-        print_to_stderr('Determination is skipping {}'.format(test))
+        print_to_stderr(f'Determination is skipping {test}')
 
     return False
 
+
+def run_test_module(test: str, test_directory: str, options) -> Optional[str]:
+    test_module = parse_test_module(test)
+
+    # Printing the date here can help diagnose which tests are slow
+    print_to_stderr('Running {} ... [{}]'.format(test, datetime.now()))
+    handler = CUSTOM_HANDLERS.get(test, run_test)
+    return_code = handler(test_module, test_directory, options)
+    assert isinstance(return_code, int) and not isinstance(
+        return_code, bool), 'Return code should be an integer'
+    if return_code == 0:
+        return None
+
+    message = f'{test} failed!'
+    if return_code < 0:
+        # subprocess.Popen returns the child process' exit signal as
+        # return code -N, where N is the signal number.
+        signal_name = SIGNALS_TO_NAMES_DICT[-return_code]
+        message += f' Received signal: {signal_name}'
+    return message
 
 def main():
     options = parse_args()
@@ -684,33 +703,20 @@ def main():
 
     has_failed = False
     failure_messages = []
-    for test in selected_tests:
-
-        test_module = parse_test_module(test)
-
-        # Printing the date here can help diagnose which tests are slow
-        print_to_stderr('Running {} ... [{}]'.format(test, datetime.now()))
-        handler = CUSTOM_HANDLERS.get(test, run_test)
-        return_code = handler(test_module, test_directory, options)
-        assert isinstance(return_code, int) and not isinstance(
-            return_code, bool), 'Return code should be an integer'
-        if return_code != 0:
+    try:
+        for test in selected_tests:
+            err_message = run_test_module(test, test_directory, options)
+            if err_message is None:
+                continue
             has_failed = True
-            message = '{} failed!'.format(test)
-            if return_code < 0:
-                # subprocess.Popen returns the child process' exit signal as
-                # return code -N, where N is the signal number.
-                signal_name = SIGNALS_TO_NAMES_DICT[-return_code]
-                message += ' Received signal: {}'.format(signal_name)
-            err = RuntimeError(message)
-            failure_messages.append(err)
-            if options.continue_through_error:
-                print_to_stderr(err)
-            else:
-                raise RuntimeError(err)
-    if options.coverage:
-        shell(['coverage', 'combine'])
-        shell(['coverage', 'html'])
+            failure_messages.append(err_message)
+            if not options.continue_through_error:
+                raise RuntimeError(err_message)
+            print_to_stderr(err_message)
+    finally:
+        if options.coverage:
+            shell(['coverage', 'combine'])
+            shell(['coverage', 'json'])
 
     if options.continue_through_error and has_failed:
         for err in failure_messages:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -192,6 +192,7 @@ or `conda install ninja`. Alternatively, disable said tests with
 `run_test.py --exclude test_cpp_extensions_aot_ninja test_cpp_extensions_jit`.
 """
 
+PYTORCH_COLLECT_COVERAGE = bool(os.environ.get("PYTORCH_COLLECT_COVERAGE"))
 
 def print_to_stderr(message):
     print(message, file=sys.stderr)
@@ -199,7 +200,10 @@ def print_to_stderr(message):
 
 def get_executable_command(options, allow_pytest):
     if options.coverage:
-        executable = ['coverage', 'run', '--source=torch']
+        executable = ['coverage', 'run']
+        if PYTORCH_COLLECT_COVERAGE:
+            executable.append('--append')
+        executable.append('--source=torch')
     else:
         executable = [sys.executable]
     if options.pytest:
@@ -380,7 +384,8 @@ def parse_args():
              'TestTorch with pytest in verbose and coverage mode: '
              'python run_test.py -vci torch -pt')
     parser.add_argument(
-        '-c', '--coverage', action='store_true', help='enable coverage')
+        '-c', '--coverage', action='store_true', help='enable coverage',
+        default=PYTORCH_COLLECT_COVERAGE)
     parser.add_argument(
         '-i',
         '--include',
@@ -681,7 +686,7 @@ def main():
     if options.verbose:
         print_to_stderr('Selected tests: {}'.format(', '.join(selected_tests)))
 
-    if options.coverage:
+    if options.coverage and not PYTORCH_COLLECT_COVERAGE:
         shell(['coverage', 'erase'])
 
     if options.jit:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -721,7 +721,7 @@ def main():
     finally:
         if options.coverage:
             shell(['coverage', 'combine'])
-            shell(['coverage', 'json'])
+            shell(['coverage', 'xml'])
 
     if options.continue_through_error and has_failed:
         for err in failure_messages:


### PR DESCRIPTION
Replace  `test` with  `coverage_test` stage for `pytorch-linux-bionic-py3.8-gcc9` configuration
Add `coverage.xml` to the list of ignored files
Add `codecov.yml` that maps installed pytorch folders back to original locations
Cleanup coverage option utilization in `run_test.py` and adapt it towards combining coverage reports across the runs