### PR TITLE
Preserve python backtrace in autograd engine errors.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6899,6 +6899,19 @@ class TestMultithreadAutograd(TestCase):
         self.assertEqual(grad, grad1)
         self.assertEqual(grad, grad2)
 
+    def test_preserve_backtrace(self):
+        class Foo(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input):
+                return input
+
+            @staticmethod
+            def backward(ctx, *grad):
+                raise ValueError("something")
+
+        t = torch.rand(10, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, r'(?ms)something\nPython Traceback.+raise ValueError'):
+            Foo.apply(t).sum().backward()
 
 for test in method_tests():
     add_test(*test)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43608 Preserve python backtrace in autograd engine errors.**

This PR attempts to address https://github.com/pytorch/pytorch/issues/42560. We add a "Python Traceback"
component to the error message recording the original location from where the
exception was thrown.

This approach isn't ideal since we're extending the exception message itself.
The alternative I considered was extending our Future to record this
information in addition to just the message. The tricky part about this was
avoiding python dependency. Ideally, I'd like to avoid a python dependency in
our Future class. Even if we do avoid the python depedency in our base class by
creating a subclass for python, we would still end up having a python
dependency in things like autograd engine's GraphTask.

For the example in https://github.com/pytorch/pytorch/issues/42560, the exception trace would now look like:

```
> Traceback (most recent call last):
>   File "test_autograd.py", line 6914, in test_preserve_backtrace
>     Foo.apply(t).sum().backward()
>   File "torch/tensor.py", line 214, in backward
>     torch.autograd.backward(self, gradient, retain_graph, create_graph)
>   File "autograd/__init__.py", line 127, in backward
>     allow_unreachable=True)  # allow_unreachable flag
> RuntimeError: something
> Python Traceback (most recent call last):
>   File "torch/autograd/function.py", line 87, in apply
>     return self._forward_cls.backward(self, *args)
>   File "test_autograd.py", line 6909, in backward
>     raise ValueError("something")
```

Differential Revision: [D23337371](https://our.internmc.facebook.com/intern/diff/D23337371/)