### PR TITLE
[JIT] Modify to_backend API so that it accepts wrapped modules

### DIFF
--- a/test/custom_backend/backend.py
+++ b/test/custom_backend/backend.py
@@ -33,7 +33,7 @@ def to_custom_backend(module):
     Returns:
         The module, lowered so that it can run on TestBackend.
     """
-    lowered_module = torch._C._jit_to_backend("custom_backend", module._c, {"forward": {"": ""}})
+    lowered_module = torch._C._jit_to_backend("custom_backend", module, {"forward": {"": ""}})
     return lowered_module
 
 

--- a/test/jit/test_backends.py
+++ b/test/jit/test_backends.py
@@ -94,7 +94,7 @@ class BasicModuleTest(JitBackendTestCase):
         self.module = BasicModule()
         self.scripted_module = torch.jit.script(BasicModule())
         self.lowered_module = to_test_backend_multi(
-            self.scripted_module._c,
+            self.scripted_module,
             {"accum": {"": ""}, "sub_accum": {"": ""}, "forward": {"": ""}},
         )
 
@@ -154,7 +154,7 @@ class NestedModuleTest(JitBackendTestCase):
         # Both modules in self.scripted_module are ScriptModules.
         self.scripted_module = torch.jit.script(NestedModuleTest.NestedModule(BasicModule()))
         lowered_module = to_test_backend_multi(
-            self.scripted_module._c, {"forward": {"": ""}}
+            self.scripted_module, {"forward": {"": ""}}
         )
         # self.lowered_module is a ScriptModule, but its submodule is a lowered module.
         self.lowered_module = torch.jit.script(NestedModuleTest.NestedModule(lowered_module))

--- a/torch/csrc/jit/backends/backend_init.cpp
+++ b/torch/csrc/jit/backends/backend_init.cpp
@@ -226,11 +226,13 @@ void initJitBackendBindings(PyObject* module) {
   m.def(
       "_jit_to_backend",
       [=](const std::string& backend_name,
-          const Module& orig_module,
+          py::handle orig_module,
           const py::dict& method_compile_spec) {
         return py::module::import("torch.jit._recursive")
-            .attr("wrap_cpp_module")(
-                codegen_lambda(backend_name, orig_module, method_compile_spec));
+            .attr("wrap_cpp_module")(codegen_lambda(
+                backend_name,
+                py::cast<Module>(orig_module.attr("_c")),
+                method_compile_spec));
       });
 }
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43613 [JIT] Add selective backend lowering API
* **#43612 [JIT] Modify to_backend API so that it accepts wrapped modules**

**Summary**
This commit modifies the `torch._C._jit_to_backend` function so that it
accepts `ScriptModules` as inputs. It already returns `ScriptModules`
(as opposed to C++ modules), so this makes sense and makes the API more
intuitive.

**Test Plan**
Continuous integration, which includes unit tests and out-of-tree tests
for custom backends.

**Fixes**
This commit fixes #41432.

Differential Revision: [D23339854](https://our.internmc.facebook.com/intern/diff/D23339854)