### PR TITLE
[cpp] Generic Triplet Margin Loss

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -325,7 +325,7 @@ TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   KERNEL(ADD_NS(margin_ranking_loss), "margin_ranking_loss", Tensor (const Tensor &, const Tensor &, const Tensor &, double, int64_t), fp32)
   KERNEL(ADD_NS(multilabel_margin_loss), "multilabel_margin_loss", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
   KERNEL(ADD_NS(soft_margin_loss), "soft_margin_loss", Tensor (const Tensor &, const Tensor &, int64_t), fp32)
-  KERNEL(ADD_NS(triplet_margin_loss), "triplet_margin_loss", Tensor (const Tensor &, const Tensor &, const Tensor &, double, double, double, bool, int64_t), fp32)
+  KERNEL(ADD_NS(triplet_margin_loss), "triplet_margin_loss", Tensor (const Tensor &, const Tensor &, const Tensor &, double, double, double, bool, int64_t, const c10::optional<std::function<Tensor(const Tensor&, const Tensor&)>>&, bool), fp32)
   KERNEL(ADD_NS(multi_margin_loss), "multi_margin_loss", Tensor (const Tensor &, const Tensor &, Scalar, Scalar, const c10::optional<Tensor>&, int64_t), fp32)
   KERNEL(ADD_NS(binary_cross_entropy_with_logits), "binary_cross_entropy_with_logits", Tensor (const Tensor &, const Tensor &, const c10::optional<Tensor>&, const c10::optional<Tensor>&, int64_t), fp32)
   KERNEL(ADD_NS(dist), "dist", Tensor (const Tensor &, const Tensor &, Scalar), fp32)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3158,7 +3158,7 @@
 - func: _trilinear(Tensor i1, Tensor i2, Tensor i3, int[] expand1, int[] expand2, int[] expand3, int[] sumdim, int unroll_dim=1) -> Tensor
   use_c10_dispatcher: full
 
-- func: triplet_margin_loss(Tensor anchor, Tensor positive, Tensor negative, float margin=1.0, float p=2, float eps=1e-06, bool swap=False, int reduction=Mean) -> Tensor
+- func: triplet_margin_loss(Tensor anchor, Tensor positive, Tensor negative, float margin=1.0, float p=2, float eps=1e-06, bool swap=False, int reduction=Mean, TODO? distance_function=None, bool is_similarity_function=False) -> Tensor
   use_c10_dispatcher: full
 
 - func: true_divide.Tensor(Tensor self, Tensor other) -> Tensor
@@ -3202,7 +3202,7 @@
 - func: fix(Tensor self) -> Tensor
   use_c10_dispatcher: full
   variants: function, method
-  
+
 - func: fix_(Tensor(a!) self) -> Tensor(a!)
   use_c10_dispatcher: full
   variants: function, method

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -501,7 +501,9 @@ inline Tensor triplet_margin_loss(
     double p,
     double eps,
     bool swap,
-    TripletMarginLossFuncOptions::reduction_t reduction) {
+    TripletMarginLossFuncOptions::reduction_t reduction,
+    c10::optional<TripletMarginLossFuncOptions::distance_function_t> distance_function,
+    bool is_similarity_function) {
   return torch::triplet_margin_loss(
       anchor,
       positive,
@@ -510,7 +512,9 @@ inline Tensor triplet_margin_loss(
       p,
       eps,
       swap,
-      enumtype::reduction_get_enum(reduction));
+      enumtype::reduction_get_enum(reduction),
+      distance_function,
+      is_similarity_function);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -539,7 +543,9 @@ inline Tensor triplet_margin_loss(
     options.p(),
     options.eps(),
     options.swap(),
-    options.reduction());
+    options.reduction(),
+    options.distance_function(),
+    options.is_similarity_function());
 }
 
 // ============================================================================

--- a/torch/csrc/api/include/torch/nn/options/loss.h
+++ b/torch/csrc/api/include/torch/nn/options/loss.h
@@ -357,6 +357,7 @@ using MultilabelSoftMarginLossFuncOptions = MultiLabelSoftMarginLossOptions;
 /// ```
 struct TORCH_API TripletMarginLossOptions {
   typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
+  typedef std::function<Tensor(const Tensor&, const Tensor&)> distance_function_t;
 
   /// Specifies the threshold for which the distance of a negative sample must
   /// reach in order to incur zero loss. Default: 1
@@ -370,6 +371,10 @@ struct TORCH_API TripletMarginLossOptions {
   TORCH_ARG(bool, swap) = false;
   /// Specifies the reduction to apply to the output. Default: Mean
   TORCH_ARG(reduction_t, reduction) = torch::kMean;
+  /// Specifies an optional distance function for computing distance. Default: nullopt
+  TORCH_ARG(c10::optional<distance_function_t>, distance_function) = c10::nullopt;
+  /// Specifies whether the optional distance module is a similarity metric. Default: False
+  TORCH_ARG(bool, is_similarity_function) = false;
 };
 
 namespace functional {

--- a/torch/csrc/api/src/nn/modules/loss.cpp
+++ b/torch/csrc/api/src/nn/modules/loss.cpp
@@ -175,7 +175,9 @@ Tensor TripletMarginLossImpl::forward(
     options.p(),
     options.eps(),
     options.swap(),
-    options.reduction());
+    options.reduction(),
+    options.distance_function(),
+    options.is_similarity_function());
 }
 
 // ============================================================================
@@ -223,9 +225,9 @@ void SmoothL1LossImpl::pretty_print(std::ostream& stream) const {
 Tensor SmoothL1LossImpl::forward(const Tensor& input, const Tensor& target) {
   return F::detail::smooth_l1_loss(input, target, options.reduction());
 }
-  
+
 // ============================================================================
-  
+
 CTCLossImpl::CTCLossImpl(const CTCLossOptions& options_) : options(options_) {}
 
 void CTCLossImpl::reset() {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43639 [cpp] Generic Triplet Margin Loss**

Differential Revision: [D23351411](https://our.internmc.facebook.com/intern/diff/D23351411)

[WIP; tests are forthcoming]

This pull request resolves #43342 by refactoring the C++ and Python implementations to take an additional function argument.  The high-level design is as follows:

* Add an optional `distance_function` argument of type `std::function<Tensor(const Tensor&, const Tensor&)>` to the C++ functional and module APIs
* [TODO] Add an optional `distance_function` argument to the Python functional and module APIs
* Add a `is_similarity_function` boolean argument (default = `False`) to the C++ functional and module APIs
* Refactor the aTen implementation of `torch::triplet_margin_loss` to take/use the new `distance_function` and `is_similarity_function` arguments.

Currently blocked on figuring out how to update the signature in `native_functions.yaml` to accept the `std::function` arg; workarounds or alternatives welcomed.