### PR TITLE
[fx] add test for args/kwargs handling

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -15,13 +15,19 @@ except ImportError:
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 class TestFX(TestCase):
-    def checkGraphModule(self, m: torch.nn.Module, args, kwargs):
+    def checkGraphModule(self, m: torch.nn.Module, args, kwargs=None):
         """Check that an nn.Module's results match the GraphModule version
         for a given set of args/kwargs.
         """
-        ref_outs = m(*args, **kwargs)
+        if kwargs is not None:
+            ref_outs = m(*args, **kwargs)
+        else:
+            ref_outs = m(*args)
         gm = symbolic_trace(m)
-        test_outs = gm(*args, **kwargs)
+        if kwargs is not None:
+            test_outs = gm(*args, **kwargs)
+        else:
+            test_outs = gm(*args)
         self.assertEqual(ref_outs, test_outs)
 
     def test_graph_module(self):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -19,15 +19,10 @@ class TestFX(TestCase):
         """Check that an nn.Module's results match the GraphModule version
         for a given set of args/kwargs.
         """
-        if kwargs is not None:
-            ref_outs = m(*args, **kwargs)
-        else:
-            ref_outs = m(*args)
+        kwargs = kwargs if kwargs else {}
+        ref_outs = m(*args, **kwargs)
         gm = symbolic_trace(m)
-        if kwargs is not None:
-            test_outs = gm(*args, **kwargs)
-        else:
-            test_outs = gm(*args)
+        test_outs = gm(*args, **kwargs)
         self.assertEqual(ref_outs, test_outs)
 
     def test_graph_module(self):
@@ -70,7 +65,7 @@ class TestFX(TestCase):
                 return x
 
         t = T()
-        s = symbolic_trace(t)
+        symbolic_trace(t)
 
     def test_args_kwargs(self):
         class T(torch.nn.Module):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -15,6 +15,15 @@ except ImportError:
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
 class TestFX(TestCase):
+    def checkGraphModule(self, m: torch.nn.Module, args, kwargs):
+        """Check that an nn.Module's results match the GraphModule version
+        for a given set of args/kwargs.
+        """
+        ref_outs = m(*args, **kwargs)
+        gm = symbolic_trace(m)
+        test_outs = gm(*args, **kwargs)
+        self.assertEqual(ref_outs, test_outs)
+
     def test_graph_module(self):
         class MySub(torch.nn.Module):
             def __init__(self):
@@ -55,7 +64,16 @@ class TestFX(TestCase):
                 return x
 
         t = T()
-        symbolic_trace(t)
+        s = symbolic_trace(t)
+
+    def test_args_kwargs(self):
+        class T(torch.nn.Module):
+            def forward(self, *args, **kwargs):
+                x = args[0] + kwargs['foo']
+                return x
+
+        t = T()
+        self.checkGraphModule(t, (torch.rand(1), torch.rand(1)), {'foo': torch.rand(1)})
 
     def test_fx_shifts(self):
         class MyModule(torch.nn.Module):
@@ -65,11 +83,7 @@ class TestFX(TestCase):
         input = torch.LongTensor(10).random_(0, 1024)
 
         m = MyModule()
-        ref_outs = m(input)
-        gm = symbolic_trace(m)
-        test_outs = gm(input)
-
-        self.assertEqual(ref_outs, test_outs)
+        self.checkGraphModule(m, (input,))
 
     def test_dict(self):
         class MyDictMod(torch.nn.Module):
@@ -78,11 +92,8 @@ class TestFX(TestCase):
 
         input_dict = {'3': torch.rand(3, 4)}
         m = MyDictMod()
-        ref_out = m(input_dict)
-        gm = symbolic_trace(m)
-        out = gm(input_dict)
 
-        self.assertEqual(out, ref_out)
+        self.checkGraphModule(m, (input_dict,))
 
     def test_disallow_override(self):
         # Custom delegate to disallow in-place tensor operations
@@ -191,11 +202,11 @@ class TestFX(TestCase):
             def forward(self, a, b):
                 c, d = a
                 return c + d + b
-        m = M()
-        m_g = symbolic_trace(m)
+
         a = (torch.rand(1), torch.rand(1))
         b = torch.rand(1)
-        self.assertEqual(m(a, b), m_g(a, b))
+        m = M()
+        self.checkGraphModule(m, (a, b))
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43575 [fx] avoid naming collisions with built-in names
* **#43640 [fx] add test for args/kwargs handling**

+ added a `self.checkGraphModule` utility function to wrap the common
test assert pattern.

Differential Revision: [D23356262](https://our.internmc.facebook.com/intern/diff/D23356262)