### PR TITLE
[fx] Change name semantics for placeholder op

### DIFF
--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -35,7 +35,7 @@ print(tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'
 ```
 opcode         name           target                                                   args                kwargs
 -------------  -------------  -------------------------------------------------------  ------------------  -----------
-placeholder    x              x                                                        ()                  {}
+placeholder    x              ''                                                       ()                  {}
 get_param      linear_weight  linear.weight                                            ()                  {}
 call_function  add_1          <built-in function add>                                  (x, linear_weight)  {}
 call_module    linear_1       linear                                                   (add_1,)            {}
@@ -47,7 +47,8 @@ call_function  topk_1         <built-in method topk of type object at 0x7f1c29dd
 The semantics are as follows:
 
 - `placeholder` represents a function input. The `name` attribute specifies the name this value will take on.
-  `target` is similarly the name of the argument. `args` and `kwargs` are don't-care
+  `target` is normally an empty string, but if the placeholder represents `*args` or `**kwargs` input it will
+  be `*` or `**`. `args` and `kwargs` are don't-care
 - `get_param` retrieves a parameter from the module hierarchy. `name` is similarly the name the result of the
    fetch is assigned to. `target` is the fully-qualified name of the parameter's position in the module hierarchy.
    `args` and `kwargs` are don't-care


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43645 [fx] Change name semantics for placeholder op**
* #43640 [fx] add test for args/kwargs handling

Currently the rules for printing  `placeholder` ops is `name` is how we
print the placeholder in the body of the function, while `target` is how
we print the parameter in the function definition.

In the common case (regular function input), `name` and `target` are the
same. But in the case where the placeholder represents `*args`, the name
is `'args'` and the target is `'*args'`.

This complicates name pre-processing a little bit, because naming info
is denormalized. So if we mutate `name` to be unique, then we need to
mutate `target` as well.

My proposal for new semantics: the name of the variable is always stored
in `name`. `target` is either an empty string, `'*'`, or `'**'`. When
printing the placeholder, we use `name` as before. When printing the
free variable list, we prepend `target` to `name`.