### PR TITLE
[fx] When generating names, avoid shadowing builtins

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -214,5 +214,17 @@ class TestFX(TestCase):
         m = M()
         self.checkGraphModule(m, (a, b))
 
+    def test_reserved_getattr(self):
+        """Ensure that we do not name any nodes with a reserved builtin like `getattr`"""
+        class M(torch.nn.Module):
+            def forward(self, a):
+                return a.foo.bar.baz
+
+        m = M()
+        m_g = symbolic_trace(m)
+        for node in m_g.graph.nodes:
+            self.assertTrue(node.name != "getattr")
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -119,6 +119,7 @@ class Graph:
 
         if op not in self._used_names:
             self._used_names[op] = 0
+            # Avoid shadowing PyTorch and Python builtins.
             if not hasattr(torch, op) and \
                not hasattr(torch.nn.functional, op) and \
                not hasattr(torch.nn, op) and \

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -3,6 +3,10 @@ from .node import Node, Argument, Target
 from typing import Callable, Any, List, Dict, Optional, Tuple
 import builtins
 import torch
+import keyword
+
+def _shadows_builtin_name(name: str) -> bool:
+    return name in builtins.__dict__ or name in keyword.kwlist
 
 def _is_magic(x: str) -> bool:
     return x.startswith('__') and x.endswith('__')
@@ -71,16 +75,16 @@ class Graph:
             return n
         map_arg(a, add_use)
 
-    def create_node(self, op: str, target: Target, 
-                    args: Optional[Tuple[Argument, ...]] = None, 
-                    kwargs: Optional[Dict[str, Argument]] = None, 
+    def create_node(self, op: str, target: Target,
+                    args: Optional[Tuple[Argument, ...]] = None,
+                    kwargs: Optional[Dict[str, Argument]] = None,
                     name: Optional[str] = None):
         assert op in ('call_function', 'call_method', 'get_param', 'call_module', 'placeholder')
         args = () if args is None else args
         kwargs = {} if kwargs is None else kwargs
         self._mark_uses(args)
         self._mark_uses(kwargs)
-        n = Node(self, name if name is not None else self._name(target or op), op, target, args, kwargs)
+        n = Node(self, name if name is not None else self._name(target), op, target, args, kwargs)
         self.nodes.append(n)
         return n
 
@@ -91,9 +95,12 @@ class Graph:
         kwargs = map_arg(node.kwargs, arg_transform)
         assert isinstance(args, tuple)
         assert isinstance(kwargs, dict)
-        return self.create_node(
-            node.op, node.target, args, kwargs,
-            self._name(node.name))
+        if node.op == "placeholder":
+            # Placeholder names are user-visible, so they should be copied as-is without normalizing them.
+            name = node.name
+        else:
+            name = self._name(node.name)
+        return self.create_node(node.op, node.target, args, kwargs, name)
 
     def output(self, result: Argument):
         self.result = result
@@ -112,7 +119,10 @@ class Graph:
 
         if op not in self._used_names:
             self._used_names[op] = 0
-            if not hasattr(torch, op) and not hasattr(torch.nn.functional, op) and not hasattr(torch.nn, op):
+            if not hasattr(torch, op) and \
+               not hasattr(torch.nn.functional, op) and \
+               not hasattr(torch.nn, op) and \
+               not _shadows_builtin_name(op):
                 return op
         i = self._used_names[op] = self._used_names[op] + 1
         return f'{op}_{i}'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43653 [fx] When generating names, avoid shadowing builtins**

When nodes are created without an explicit name, a name is generated for
it based on the target. In these cases, we need to avoid shadowing
builtin names. Otherwise, code like:
```
a.foo.bar
```
results in pretty-printed code like:
```
getattr = a.foo
getattr_1 = getattr.bar
```

While this is technically allowed in Python, it's probably a bad idea,
and more importantly is not supported by TorchScript (where `getattr` is
hardcoded).

This PR changes the name generation logic to avoid shadowing all
builtins and langauge keywords. We already do this for PyTorch
built-ins, so just extend that logic. So now the generated code will
look like:

```
getattr_1 = a.foo
getattr_2 = getattr_1.bar
```
Fixes #43522

Differential Revision: [D23357420](https://our.internmc.facebook.com/intern/diff/D23357420)