### PR TITLE
add aten::str to lite interpreter

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -724,6 +724,14 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      Operator(
+         "aten::str(t elem) -> str",
+         [](Stack* stack) {
+           std::stringstream ss;
+           ss << pop(stack);
+           push(stack, ss.str());
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
          "aten::__getitem__.str(str s, int index) -> str",
          [](Stack& stack) {
            auto index = pop(stack).toInt();


### PR DESCRIPTION
Summary: add aten::str to lite interpreter. This is needed by NLU model.

Test Plan: buck run fbsource//xplat/assistant/model_benchmark_tool/cpp_binary:lite_predictor -- --model /mnt/vol/gfsfblearner-oregon/flow/data/2020-08-18/c93e519b-d5c5-4a75-9387-a32f08b6c613/213015812/2174502053/model.bc --input_file ~/test/gc_model_input.txt --model_input_args "src_tokens,dict_feat" --warmup 1 --iter 2

Differential Revision: D23356240

