### PR TITLE
Check SparseAdam params are dense on init (#41966)

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -357,6 +357,10 @@ class TestOptim(TestCase):
         )
         with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
             optim.SparseAdam(None, lr=1e-2, betas=(1.0, 0.0))
+        with self.assertRaisesRegex(ValueError, "SparseAdam requires dense parameter tensors"):
+            optim.SparseAdam([torch.zeros(3, layout=torch.sparse_coo)])
+        with self.assertRaisesRegex(ValueError, "SparseAdam requires dense parameter tensors"):
+            optim.SparseAdam([{"params": [torch.zeros(3, layout=torch.sparse_coo)]}])
 
     # ROCm precision is too low to pass this test
     @skipIfRocm

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -31,6 +31,20 @@ class SparseAdam(Optimizer):
             raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+
+        sparse_params = []
+        for index, param in enumerate(params):
+            if isinstance(param, dict):
+                for d_index, d_param in enumerate(param.get("params", [])):
+                    if d_param.is_sparse:
+                        sparse_params.append([index, d_index])
+            elif param.is_sparse:
+                sparse_params.append(index)
+        if sparse_params:
+            raise ValueError(
+                f"Sparse params at indices {sparse_params}: SparseAdam requires dense parameter tensors"
+            )
+
         defaults = dict(lr=lr, betas=betas, eps=eps)
         super(SparseAdam, self).__init__(params, defaults)
 


### PR DESCRIPTION
Fixes #41966 

Raises a value error if user attempts to create SparseAdam optimizer with sparse parameter tensors.
