### PR TITLE
Fixes argument typos in the doc

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7023,7 +7023,7 @@ takes the same shape as the indices.
 
 Args:
     {input}
-    indices (LongTensor): the indices into tensor
+    index (LongTensor): the indices into tensor
 
 Example::
 

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -261,7 +261,7 @@ def quantize_dynamic(model, qconfig_spec=None, dtype=torch.qint8,
     If `qconfig` is provided, the `dtype` argument is ignored.
 
     Args:
-        module: input model
+        model: input model
         qconfig_spec: Either:
 
             - A dictionary that maps from name or type of submodule to quantization


### PR DESCRIPTION
This should fix

1. https://github.com/pytorch/pytorch/issues/43495
2. https://github.com/pytorch/pytorch/issues/43503