### PR TITLE
Fixed undefined behavior in BatchedFallback

### DIFF
--- a/aten/src/ATen/BatchedFallback.cpp
+++ b/aten/src/ATen/BatchedFallback.cpp
@@ -123,12 +123,14 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
       // We assume that torch::jit::Stack is backed by vector<IValue> for
       // simplicity. When that is not the case, this code should be updated.
       const auto& argument = (*stack)[arguments_begin + arg_idx];
-      if (arg_idx != *batched_tensor_inputs_pos_iter) {
+      if (batched_tensor_inputs_pos_iter == batched_tensor_inputs_position.end()
+          || arg_idx != *batched_tensor_inputs_pos_iter) {
         // argument isn't a BatchedTensor
         torch::jit::push(stack, argument);
         continue;
       }
       // argument is a BatchedTensor
+      TORCH_INTERNAL_ASSERT(input_physical_views_iter != input_physical_views.end());
       const auto& physical_view_for_argument = *input_physical_views_iter;
       torch::jit::push(stack, physical_view_for_argument.tensor().index(index));
       batched_tensor_inputs_pos_iter++;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43731 TestVmapOperators: add structured tests that batching rules get invoked
* **#43705 Fixed undefined behavior in BatchedFallback**

This was causing fb-internal flakiness. I'm surprised that the ASAN
builds don't catch this behavior.

The problem is that dereferencing the end() pointer of a vector is
undefined behavior. This PR fixes one callsite where BatchedFallback
dereferences the end() pointer and adds an assert to make sure another
callsite doesn't do that.

Test Plan:
- Make sure all tests pass (`pytest test/test_vmap.py -v`)
- It's hard to write a new test for this because most of the time this
doesn't cause a crash. It really depends on what lives at the end()
pointer.

Differential Revision: [D23373352](https://our.internmc.facebook.com/intern/diff/D23373352)