### PR TITLE
Fix bug in caching allocator.

### DIFF
--- a/c10/core/CPUCachingAllocator.cpp
+++ b/c10/core/CPUCachingAllocator.cpp
@@ -95,6 +95,7 @@ CPUCachingAllocator* GetThreadLocalCachingAllocator() {
 
 WithCPUCachingAllocatorGuard::WithCPUCachingAllocatorGuard(
     CPUCachingAllocator* allocator) {
+  caching_allocator_ptr = allocator;
   prev_caching_allocator_ptr_ = GetThreadLocalCachingAllocator();
 }
 


### PR DESCRIPTION
Summary:
Accidentally this slipped through: with guard did not update the current
context

Test Plan: cpu_caching_allocator_test

Differential Revision: D23374453

