### PR TITLE
[fakelowp] add optional qparam input to int8 quant/FC NNPI ops

### DIFF
--- a/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.cc
+++ b/caffe2/contrib/fakelowp/int8_quantize_op_nnpi.cc
@@ -7,9 +7,10 @@ OPERATOR_SCHEMA(Int8QuantizeNNPI)
     .IdenticalTypeAndShape()
     .Arg("Y_scale", "Output tensor quantization scale")
     .Arg("Y_zero_point", "Output tensor quantization offset")
-    .NumInputs(1)
+    .NumInputs(1, 2)
     .NumOutputs(1)
     .Input(0, "X", "FP32 Tensor X.")
+    .Input(1, "Qparam", "Optional quantization params blob.")
     .Output(0, "Y", "Int8 Tensor qX representing X with linear quantization.");
 
 } // namespace caffe2


### PR DESCRIPTION
Summary: online training int8FC converter uses optional input blobs to pass qparams to Int8Quantize and Int8FC. Mirror this change to fakelowp to run eval workflow on fakelowp.

Test Plan:
f214808928
f214822077

Reviewed By: hyuen

Differential Revision: D23375568

