### PR TITLE
Fixes fft function calls for C++ API

### DIFF
--- a/test/cpp/api/fft.cpp
+++ b/test/cpp/api/fft.cpp
@@ -1,9 +1,18 @@
 #include <gtest/gtest.h>
 
 #include <torch/torch.h>
+#include <test/cpp/api/support.h>
+
+
+// Tests that the fft function can be called as usual
+TEST(FFTTest, unclobbered_fft) {
+    auto t = torch::randn({64, 2}, torch::dtype(torch::kDouble));
+    torch::fft(t, 1);
+}
+
+// Clobbers torch::fft the function with torch::fft the namespace
 #include <torch/fft.h>
 
-#include <test/cpp/api/support.h>
 
 // NOTE: Visual Studio and ROCm builds don't understand complex literals
 //   as of August 2020

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -7,7 +7,6 @@
 #include <torch/cuda.h>
 #include <torch/data.h>
 #include <torch/enum.h>
-#include <torch/fft.h>
 #include <torch/jit.h>
 #include <torch/linalg.h>
 #include <torch/nn.h>


### PR DESCRIPTION
Fixes #43732.

Requires importing the fft namespace in the C++ API, just like the Python API does, to avoid clobbering torch::fft the function. 