### PR TITLE
.circleci: Add slash to end of s3 cp

### DIFF
--- a/.circleci/scripts/binary_upload.sh
+++ b/.circleci/scripts/binary_upload.sh
@@ -74,16 +74,16 @@ case "${PACKAGE_TYPE}" in
         | cut -d ':' -f2 \
         | sed -e 's/[[:space:]]//' -e 's/"//g' -e 's/,//' \
     )
-    BACKUP_DIR="conda/${subdir}/"
+    BACKUP_DIR="conda/${subdir}"
     ;;
   libtorch)
     s3_upload "zip" "libtorch"
-    BACKUP_DIR="libtorch/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}/"
+    BACKUP_DIR="libtorch/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
     ;;
   # wheel can either refer to wheel/manywheel
   *wheel)
     s3_upload "whl" "whl"
-    BACKUP_DIR="whl/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}/"
+    BACKUP_DIR="whl/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
     ;;
   *)
     echo "ERROR: unknown package type: ${PACKAGE_TYPE}"

--- a/.circleci/scripts/binary_upload.sh
+++ b/.circleci/scripts/binary_upload.sh
@@ -30,7 +30,7 @@ do_backup() {
   (
     pushd /tmp/workspace
     set -x
-    ${AWS_S3_CP} --recursive . "${BACKUP_BUCKET}/${CIRCLE_TAG}/${backup_dir}"
+    ${AWS_S3_CP} --recursive . "${BACKUP_BUCKET}/${CIRCLE_TAG}/${backup_dir}/"
   )
 }
 
@@ -52,7 +52,7 @@ s3_upload() {
   local pkg_type
   extension="$1"
   pkg_type="$2"
-  s3_dir="${UPLOAD_BUCKET}/${pkg_type}/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
+  s3_dir="${UPLOAD_BUCKET}/${pkg_type}/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}/"
   (
     for pkg in ${PKG_DIR}/*.${extension}; do
       (
@@ -74,16 +74,16 @@ case "${PACKAGE_TYPE}" in
         | cut -d ':' -f2 \
         | sed -e 's/[[:space:]]//' -e 's/"//g' -e 's/,//' \
     )
-    BACKUP_DIR="conda/${subdir}"
+    BACKUP_DIR="conda/${subdir}/"
     ;;
   libtorch)
     s3_upload "zip" "libtorch"
-    BACKUP_DIR="libtorch/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
+    BACKUP_DIR="libtorch/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}/"
     ;;
   # wheel can either refer to wheel/manywheel
   *wheel)
     s3_upload "whl" "whl"
-    BACKUP_DIR="whl/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}"
+    BACKUP_DIR="whl/${UPLOAD_CHANNEL}/${UPLOAD_SUBFOLDER}/"
     ;;
   *)
     echo "ERROR: unknown package type: ${PACKAGE_TYPE}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43792 .circleci: Add slash to end of s3 cp**

This fixes the issue we had with the nightlies not being uploaded
properly, basically what was happening was that `aws s3 cp` doesn't
automatically distinguish between prefixes that are already
"directories" vs a single file with the same name.

This means that if you'd like to upload a file to a "directory" in S3
you need to suffix your destination with a slash.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D23402074](https://our.internmc.facebook.com/intern/diff/D23402074)