### PR TITLE
Move `fbcode` related coverage code to `fb/` folder and add `TARGETS`

### DIFF
--- a/tools/code_coverage/README.md
+++ b/tools/code_coverage/README.md
@@ -23,7 +23,7 @@ It’s an integrated tool. You can use this tool to build, run, and generate bot
     * File-Level: The coverage for each file you are interested in
     * Line-Level: The coverage for each line in each file you are interested in
 * *More complex but flexible options:*
-    * Use different stages like --build, --run, --summary to achieve more flexible functionality
+    * Use different stages like *--build, --run, --summary* to achieve more flexible functionality
 
 ## How to use
 
@@ -34,7 +34,7 @@ If you are not familiar with the procedure of generating code coverage report by
 ## Examples
 
 First step is to set some experimental value.
-```
+```bash
 # pytorch folder, by default all the c++ binaries are in build/bin/
 export PYTORCH_FOLDER=...
 # make sure llvm-cov is available, by default it is /usr/local/opt/llvm/bin
@@ -42,15 +42,15 @@ export LLVM_TOOL_PATH=...
 ```
 
 then command will run all the tests in `build/bin/` and `test/` folder
-```
+```bash
 python oss_coverage.py
 ```
 Most times you don't want collect coverage for the entire Pytorch folder, use --interested-folder to report coverage only over the folder you want:
-```
+```bash
 python oss_coverage.py --interested-folder=aten
 ```
 Then, still in most cases, if you only run one or several test(s):
-```
+```bash
 python oss_coverage.py --run-only=atest
 python oss_coverage.py --run-only atest basic test_nn.py
 ```

--- a/tools/code_coverage/package/tool/clang_coverage.py
+++ b/tools/code_coverage/package/tool/clang_coverage.py
@@ -148,7 +148,9 @@ def export(test_list: TestList, platform_type: TestPlatform) -> None:
                 binary_file = ""
                 shared_library_list = []
                 if platform_type == TestPlatform.FBCODE:
-                    from ..fbcode.utils import get_fbcode_binary_folder
+                    from caffe2.fb.code_coverage.tool.package.fbcode.utils import (
+                        get_fbcode_binary_folder,
+                    )
 
                     binary_file = os.path.join(
                         get_fbcode_binary_folder(path),

--- a/tools/code_coverage/package/tool/print_report.py
+++ b/tools/code_coverage/package/tool/print_report.py
@@ -118,18 +118,19 @@ def print_total_program_time(start_time: float, summary_file: IO) -> None:
 
 def print_file_summary(
     covered_summary: int, total_summary: int, summary_file: IO
-) -> None:
+) -> float:
     # print summary first
     try:
-        coverage_percentage = round(1.0 * covered_summary / total_summary * 100, 2)
+        coverage_percentage = 100.0 * covered_summary / total_summary
     except ZeroDivisionError:
-        raise ZeroDivisionError(
-            "Failed to generate coverage report, please check if json profiles are valid in profile/json"
-        )
+        coverage_percentage = 0
     print(
-        f"SUMMARY\ncovered: {covered_summary}\nuncovered: {total_summary}\npercentage: {coverage_percentage}%\n\n",
+        f"SUMMARY\ncovered: {covered_summary}\nuncovered: {total_summary}\npercentage: {coverage_percentage:.2f}%\n\n",
         file=summary_file,
     )
+    if coverage_percentage == 0:
+        print("Coverage is 0, Please check if json profiles are valid")
+    return coverage_percentage
 
 
 def print_file_oriented_report(
@@ -143,7 +144,9 @@ def print_file_oriented_report(
     coverage_only: List[str],
     program_start_time: float,
 ) -> None:
-    print_file_summary(covered_summary, total_summary, summary_file)
+    coverage_percentage = print_file_summary(
+        covered_summary, total_summary, summary_file
+    )
     print_total_program_time(program_start_time, summary_file)
     # print test condition (interested folder / tests that are successsful or failed)
     print_test_condition(
@@ -164,9 +167,7 @@ def print_file_oriented_report(
             file=summary_file,
         )
 
-    print(
-        f"summary percentage:{round(1.0 * covered_summary / total_summary * 100, 2)}%"
-    )
+    print(f"summary percentage:{coverage_percentage:.2f}%")
 
 
 def file_oriented_report(

--- a/tools/code_coverage/package/tool/utils.py
+++ b/tools/code_coverage/package/tool/utils.py
@@ -14,7 +14,7 @@ def run_cpp_test(binary_file: str) -> None:
 
 def get_tool_path_by_platform(platform: TestPlatform):
     if platform == TestPlatform.FBCODE:
-        from ..fbcode.utils import get_llvm_tool_path
+        from caffe2.fb.code_coverage.tool.package.fbcode.utils import get_llvm_tool_path
 
         return get_llvm_tool_path()
     else:


### PR DESCRIPTION
Summary:
1. Move fbcode related coverage code to fb/ folder and add TARGETS so that we can use buck run to run the tool and solved the import probelm.

2. Write `README.md` to give users guidance about the tool

Test Plan:
On devserver:
```
buck run //caffe2/fb/code_coverage/tool:coverage -- //caffe2/c10:
```

More examples in README.md

Differential Revision: D23404988

