### PR TITLE
Remove useless py2 compatibility import __future__, part 1

### DIFF
--- a/torch/nn/qat/__init__.py
+++ b/torch/nn/qat/__init__.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from .modules import *

--- a/torch/nn/qat/modules/conv.py
+++ b/torch/nn/qat/modules/conv.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.nn as nn
 from torch.nn.intrinsic import ConvReLU2d
 

--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.intrinsic import LinearReLU

--- a/torch/nn/quantized/__init__.py
+++ b/torch/nn/quantized/__init__.py
@@ -1,6 +1,1 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from .modules import *

--- a/torch/nn/quantized/dynamic/__init__.py
+++ b/torch/nn/quantized/dynamic/__init__.py
@@ -1,4 +1,1 @@
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from .modules import *

--- a/torch/nn/quantized/dynamic/modules/embeddingbag.py
+++ b/torch/nn/quantized/dynamic/modules/embeddingbag.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import torch.nn as nn
 from torch import Tensor  # noqa: F401

--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 from ....modules.linear import Linear as NNLinear
 import torch.nn.quantized as nnq

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numbers
 import warnings
 

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -1,9 +1,4 @@
 r""" Functional interface (quantized)."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from typing import List, Optional
 
 import torch

--- a/torch/nn/quantized/modules/activation.py
+++ b/torch/nn/quantized/modules/activation.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import torch
 import torch.nn.quantized.functional
 

--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import torch
 import torch.nn.quantized.functional
 import torch.nn.intrinsic as nni

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -1,11 +1,6 @@
 # coding=utf-8
 r"""Quantized convolution modules."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from typing import Optional, List
 
 import torch

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import torch
 
 from torch._jit_internal import Optional  # noqa: F401

--- a/torch/nn/quantized/modules/normalization.py
+++ b/torch/nn/quantized/modules/normalization.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import torch
 import torch.nn.quantized.functional
 


### PR DESCRIPTION
To avoid conflicts, this PR does not remove all imports. More are coming in further PRs.