### PR TITLE
[JIT] Specialize autograd zero: actually remove the original graph after we created its versioned copy.

### DIFF
--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -98,7 +98,6 @@ struct AutogradZeroSpecializer {
     }
     for (Node* n : profiled_opt_uses) {
       n->output()->replaceAllUsesWith(v);
-      n->destroy();
     }
   }
 
@@ -114,7 +113,7 @@ struct AutogradZeroSpecializer {
     false_block->cloneFrom(graph_->block(), value_map);
     replaceBlockInputsWithGraphInputs(false_block);
 
-    WithInsertPoint wip{graph_->block()};
+    WithInsertPoint wip{graph_->block()->param_node()->next()};
     Value* none_val = graph_->insertConstant(IValue());
     std::vector<Value*> checks;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43847 [JIT] Remove loop peeling from the profiling executor pipeline.
* **#43849 [JIT] Specialize autograd zero: actually remove the original graph after we created its versioned copy.**
* #43846 [JIT] Specialize autograd zero: fix the guarding condition.

The original code assumed that the versioning if was inserted in the
beginning of the graph while in fact it was inserted in the end. We're
now also not removing `profile_optional` nodes and rely on DCE to clean
it up later (the reason we're not doing it is that deletion could
invalidate the insertion point being used).

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)