### PR TITLE
Grammatical corrections for v1.6

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -205,8 +205,8 @@ Disable JIT for Debugging
 
 Setting the environment variable ``PYTORCH_JIT=0`` will disable all script
 and tracing annotations. If there is hard-to-debug error in one of your
-TorchScript model, you can use this flag to force everything to run using native
-Python. Since TorchScript (scripting and tracing) are disabled with this flag,
+TorchScript models, you can use this flag to force everything to run using native
+Python. Since TorchScript (scripting and tracing) is disabled with this flag,
 you can use tools like ``pdb`` to debug the model code.  For example::
 
     @torch.jit.script


### PR DESCRIPTION
**Documentation corrections for v1.6.**

[...] If there is hard-to-debug error in one of your TorchScript models, you can use this flag [...]
[...] Since TorchScript (scripting and tracing) is disabled with this flag [...]

**Before corrections (as of now):**

![before-fix](https://user-images.githubusercontent.com/45713346/91656156-be8bc580-eab6-11ea-893d-7747dc0ef75e.jpg)

**After corrections**:
![after-fix](https://user-images.githubusercontent.com/45713346/91656163-cb101e00-eab6-11ea-8be8-8bd0fc59f5d1.jpg)
