### PR TITLE
[redo] Fix SyncBatchNorm forward pass for non-default process group

### DIFF
--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -24,7 +24,7 @@ class SyncBatchNorm(Function):
             torch.empty_like(combined) for k in range(world_size)
         ]
         # Use allgather instead of allreduce since I don't trust in-place operations ..
-        dist.all_gather(combined_list, combined, async_op=False)
+        dist.all_gather(combined_list, combined, process_group, async_op=False)
         combined = torch.stack(combined_list, dim=0)
         # world_size * (2C + 1) -> world_size * C, world_size * C, world_size * 1
         mean_all, invstd_all, count_all = torch.split(combined, num_channels, dim=1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43861 Fix SyncBatchNorm forward pass for non-default process group**

Summary:

This is a redo of https://github.com/pytorch/pytorch/pull/38874, and
fixing my original bug from
https://github.com/pytorch/pytorch/pull/38246.

Test Plan: 

run DDP + SyncBN on two process groups:
https://gist.github.com/vkuzo/8501121d0d25261b70110aae4465ae0a
the script fails before this PR and works after this PR

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23418816](https://our.internmc.facebook.com/intern/diff/D23418816)