### PR TITLE
[NNC] make inlining immediate (take 2) and fix bugs

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -424,6 +424,80 @@ void testScheduleFunctionCall01() {
   ExpectAllNear(d_v, d_ref, 1e-5);
 }
 
+void testScheduleInlineSimple() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+  Buffer a_buf("a", kFloat, {M, N});
+  Buffer b_buf("b", kFloat, {N, K});
+  Buffer c_buf("c", kFloat, {M, N});
+  Buffer d_buf("d", kFloat, {M, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n) * b_buf(n, k);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return c_buf(m, n) * d_buf(m, k) + x->call(m, n, k);
+      });
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, c_buf, d_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, c_buf, d_buf, y);
+
+  PaddedBuffer<float> a_v(M, N);
+  PaddedBuffer<float> b_v(N, K);
+  PaddedBuffer<float> c_v(M, N);
+  PaddedBuffer<float> d_v(M, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      a_v(i, j) = i * i;
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < K; j++) {
+      b_v(i, j) = j * j;
+    }
+  }
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      c_v(i, j) = i + j;
+    }
+  }
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < K; j++) {
+      d_v(i, j) = i * j;
+    }
+  }
+
+  PaddedBuffer<float> y_1(M, N, K);
+  PaddedBuffer<float> y_2(M, N, K);
+
+  eval1(a_v, b_v, c_v, d_v, y_1);
+  eval2(a_v, b_v, c_v, d_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
+}
+
 static std::string remove_space(const std::string& str) {
   std::string str_new = str;
   str_new.erase(
@@ -463,9 +537,9 @@ void InlineFunc01Helper(const std::vector<std::string>& inline_order) {
   LoopNest l({z});
   for (const std::string& order : inline_order) {
     if (order == "x") {
-      l.computeInline(l.getLoopBodyFor(x));
+      l.computeInline(x->buf());
     } else if (order == "y") {
-      l.computeInline(l.getLoopBodyFor(y));
+      l.computeInline(y->buf());
     } else {
       throw std::runtime_error("Invalid order: " + order);
     }
@@ -490,7 +564,7 @@ void InlineFunc01Helper(const std::vector<std::string>& inline_order) {
     }
     for (int i = 0; i < N; i++) {
       for (int j = 0; j < K; j++) {
-        a_v(i, j) = j * j;
+        b_v(i, j) = j * j;
       }
     }
     for (int i = 0; i < M; i++) {
@@ -546,6 +620,489 @@ void testScheduleInlineFunc01() {
   InlineFunc01Helper({"x"});
   InlineFunc01Helper({"y"});
   InlineFunc01Helper({});
+}
+
+// Make sure we cache random vars if we should.
+void testScheduleInlineRandom() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Mod::make(Intrinsics::make(kRand, kInt), 5);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return x->call(m, n, k) + x->call(m, n, k);
+      });
+
+  LoopNest l1({y});
+  l1.computeInline(x->buf());
+
+  // would normally compare results but Rand isn't implemented in the
+  // SimpleIREvaluator, even if we could seed it.
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  std::ostringstream oss;
+  oss << *stmt1;
+
+  // Check the IR we produced
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: for (int m2 = 0; m2 < 4; m2++)
+# CHECK:   for (int n2 = 0; n2 < 5; n2++)
+# CHECK:     for (int k2 = 0; k2 < 6; k2++)
+# CHECK:       int x = rand();
+# CHECK:       y[m2, n2, k2] = 2 * (x % 5);)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Make sure we don't cache random vars that are not being inlined.
+void testScheduleInlineRandomUnrelated() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return m * n * k;
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return x->call(m, n, k) + Intrinsics::make(kRand, kInt) +
+            Intrinsics::make(kRand, kInt);
+      });
+
+  LoopNest l1({y});
+  l1.computeInline(x->buf());
+
+  // would normally compare results but Rand isn't implemented in the
+  // SimpleIREvaluator, even if we could seed it.
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  std::ostringstream oss;
+  oss << *stmt1;
+
+  // Check the IR we produced
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: for (int m2 = 0; m2 < 4; m2++)
+# CHECK:   for (int n2 = 0; n2 < 5; n2++)
+# CHECK:     for (int k2 = 0; k2 < 6; k2++)
+# CHECK:       y[m2, n2, k2] = ((n2 * m2) * k2 + (rand())) + (rand());)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Make sure we generate the right number of random values == the dimensionality
+// of the production tensor.
+void testScheduleInlineRandomLowerDimensions() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Tensor* x = Compute("x", {{M, "m1"}}, [&](const VarHandle& m) {
+    return Mod::make(Intrinsics::make(kRand, kInt), 5);
+  });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return x->call(m) + x->call(m);
+      });
+
+  LoopNest l1({y});
+  l1.computeInline(x->buf());
+
+  // would normally compare results but Rand isn't implemented in the
+  // SimpleIREvaluator, even if we could seed it.
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  std::ostringstream oss;
+  oss << *stmt1;
+
+  // Check the IR we produced
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: for (int m2 = 0; m2 < 4; m2++)
+# CHECK:   int x = rand();
+# CHECK:   for (int n2 = 0; n2 < 5; n2++)
+# CHECK:     for (int k2 = 0; k2 < 6; k2++)
+# CHECK:       y[m2, n2, k2] = 2 * (x % 5);)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Make sure we don't screw up intrinsics thinking they're rand.
+void testScheduleInlineIntrinsics() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+  Buffer a_buf("a", kFloat, {M, N});
+  Buffer b_buf("b", kFloat, {N, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n) * b_buf(n, k);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Intrinsics::make(kSqrt, x->call(m, n, k));
+      });
+
+  PaddedBuffer<float> a_v(M, N);
+  PaddedBuffer<float> b_v(N, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      a_v(i, j) = i * i;
+    }
+  }
+  for (int i = 0; i < N; i++) {
+    for (int j = 0; j < K; j++) {
+      b_v(i, j) = j * j;
+    }
+  }
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, y);
+
+  PaddedBuffer<float> y_1(M, N, K);
+  PaddedBuffer<float> y_2(M, N, K);
+
+  eval1(a_v, b_v, y_1);
+  eval2(a_v, b_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
+}
+
+// Make sure we can handle rand and non-rand intrinsics.
+void testScheduleInlineRandWithIntrinsics() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Intrinsics::make(kRand, kFloat);
+      });
+  Tensor* y = Compute(
+      "y",
+      {{M, "m2"}, {N, "n2"}, {K, "k2"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return Intrinsics::make(kSqrt, x->call(m, n, k));
+      });
+
+  LoopNest l1({y});
+  l1.computeInline(x->buf());
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+
+  std::ostringstream oss;
+  oss << *stmt1;
+
+  // Check the IR we produced
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: for (int m2 = 0; m2 < 4; m2++)
+# CHECK:   for (int n2 = 0; n2 < 5; n2++)
+# CHECK:     for (int k2 = 0; k2 < 6; k2++)
+# CHECK:       float x = rand();
+# CHECK:       y[m2, n2, k2] = sqrt(x);)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+// Split a Compute then inline it into another compute.
+void testScheduleSplitAThenInline() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{2, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  ASSERT_THROWS_WITH(l.computeInline(a->buf()), "compound indices");
+}
+
+// Split a Compute then inline another Compute into it.
+void testScheduleSplitBThenInline() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(b);
+  l.splitWithMask(loops[0], 3, &i_outer, &i_inner);
+  l.computeInline(a->buf());
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+
+  std::vector<int> output(6, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_EQ(output[i], (i + 8) * (i + 8));
+  }
+}
+
+// Split a Compute twice then inline it.
+void testScheduleSplitTwiceThenInline() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{2, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  l.splitWithMask(i_inner, 2, &i_outer, &i_inner);
+  ASSERT_THROWS_WITH(l.computeInline(a->buf()), "compound indices");
+}
+
+// Inline a Compute, then split.
+void testScheduleInlineThenSplit() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  l.computeInline(a->buf());
+
+  std::vector<For*> loops = NodeFinder<For>::find(l.root_stmt());
+  l.splitWithMask(loops.back(), 3, &i_outer, &i_inner);
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(6, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_EQ(output[i], (i + 8) * (i + 8));
+  }
+}
+
+// Split a Compute, inline it, then split the result.
+void testScheduleSplitInlineThenSplit() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{16, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  auto loops = NodeFinder<For>::find(l.root_stmt());
+  l.splitWithMask(loops.back(), 2, &i_outer, &i_inner);
+  l.computeInline(a->buf());
+
+  loops = NodeFinder<For>::find(l.root_stmt());
+  l.splitWithMask(loops.front(), 2, &i_outer, &i_inner);
+  l.prepareForCodegen();
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(16, 0);
+  SimpleIREvaluator eval(s, b);
+  eval(output);
+
+  for (int i = 0; i < 16; ++i) {
+    ASSERT_EQ(output[i], (i + 8) * (i + 8));
+  }
+}
+
+// Oversplit a loop that is simplified out after inlining.
+void testScheduleSplitInlineSimplify() {
+  KernelScope kernel_scope;
+  Tensor* a = Compute("a", {{18, "i"}}, [&](const VarHandle& i) {
+    return ExprHandle(4) * i - ExprHandle(2) * i;
+  });
+  Tensor* b = Compute("b", {{2, "j"}}, [&](const VarHandle& j) {
+    return a->call(j) - ExprHandle(1);
+  });
+
+  LoopNest loop({b});
+  For* i_outer;
+  For* i_inner;
+
+  LoopNest l({b});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  ASSERT_THROWS_WITH(l.computeInline(a->buf()), "compound indices");
+}
+
+// Inline a Compute with two consumers.
+void testScheduleInlineThreeMixedOnce() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.computeInline(a->buf());
+  l.prepareForCodegen();
+
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(4 * 3, 0);
+  SimpleIREvaluator eval(s, c);
+  eval(output);
+
+  for (int k = 0; k < 4; ++k) {
+    for (int l = 0; l < 3; ++l) {
+      ASSERT_EQ(output[k * 3 + l], (k) * (k) * (l + 8) * (l + 8));
+    }
+  }
+}
+
+// Inline Compute A into B, then inline B into C.
+void testScheduleInlineThreeMixedTwice() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.computeInline(a->buf());
+  l.computeInline(b->buf());
+  l.prepareForCodegen();
+
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(4 * 3, 0);
+  SimpleIREvaluator eval(s, c);
+  eval(output);
+
+  for (int k = 0; k < 4; ++k) {
+    for (int l = 0; l < 3; ++l) {
+      ASSERT_EQ(output[k * 3 + l], (k) * (k) * (l + 8) * (l + 8));
+    }
+  }
+}
+
+// Inline a Compute that is both a producer and consumer.
+void testScheduleInlineThreeMixedInner() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.computeInline(b->buf());
+  l.prepareForCodegen();
+
+  Stmt* s = IRSimplifier::simplify(l.root_stmt());
+  std::vector<int> output(4 * 3, 0);
+  SimpleIREvaluator eval(s, c);
+  eval(output);
+
+  for (int k = 0; k < 4; ++k) {
+    for (int l = 0; l < 3; ++l) {
+      ASSERT_EQ(output[k * 3 + l], (k) * (k) * (l + 8) * (l + 8));
+    }
+  }
+}
+
+// Split 3 Computes, then inline the first two into the last.
+void testScheduleInlineThreeMixedSplit() {
+  KernelScope kernel_scope;
+  Tensor* a =
+      Compute("a", {{18, "i"}}, [&](const VarHandle& i) { return i * i; });
+  Tensor* b = Compute("b", {{6, "j"}}, [&](const VarHandle& j) {
+    return a->call(j + ExprHandle(8));
+  });
+  Tensor* c = Compute(
+      "c", {{4, "k"}, {3, "l"}}, [&](const VarHandle& k, const VarHandle& l) {
+        return a->call(k) * b->call(l);
+      });
+
+  For* i_outer;
+  For* i_inner;
+  LoopNest l({c});
+  std::vector<For*> loops = l.getLoopStmtsFor(a);
+  l.splitWithMask(loops[0], 4, &i_outer, &i_inner);
+  loops = l.getLoopStmtsFor(b);
+  l.splitWithMask(loops[0], 3, &i_outer, &i_inner);
+  loops = l.getLoopStmtsFor(c);
+  l.splitWithMask(loops[0], 2, &i_outer, &i_inner);
+
+  ASSERT_THROWS_WITH(l.computeInline(a->buf()), "compound indices");
 }
 
 void testScheduleFuserStyle() {

--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -464,6 +464,99 @@ void testReduceRfactorLike() {
   ASSERT_EQ(out[0], 99 * 50);
 }
 
+void testReduceAsProducer() {
+  KernelScope kernel_scope;
+
+  const int M = 10;
+  VarHandle m("m", kInt);
+
+  Buffer a(BufHandle("a", {2, 3}, kFloat));
+  Buffer b(BufHandle("b", {2, 3, m}, kFloat));
+
+  Tensor* c = Reduce("sum", {{2, "l1"}, {3, "n1"}}, Sum(), b, {{m, "m1"}});
+  Tensor* d = Compute(
+      "scale",
+      {{2, "l2"}, {3, "n1"}},
+      [&](const VarHandle& l, const VarHandle& n) {
+        return c->call(l, n) * a(l, n);
+      });
+  LoopNest loop({d});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {a, b, d, m});
+
+  std::vector<float> aData(2 * 3, 0);
+  std::vector<float> bData(2 * 3 * M, 0);
+  std::vector<float> dData(2 * 3, 6.0f);
+
+  for (int i = 0; i < 2 * 3; ++i) {
+    aData[i] = 6 - i;
+    for (int j = 0; j < M; ++j) {
+      bData[i * M + j] = j;
+    }
+  }
+
+  cg.call({aData, bData, dData, M});
+  float expected = 0;
+  for (int i = 0; i < M; ++i) {
+    expected += i;
+  }
+  for (int i = 0; i < 2 * 3; ++i) {
+    ASSERT_EQ(dData[i], expected * (6 - i));
+  }
+}
+
+void testReduceAsConsumer() {
+  KernelScope kernel_scope;
+
+  const int M = 10;
+  VarHandle m("m", kInt);
+
+  Buffer a(BufHandle("a", {2, 3, m}, kFloat));
+  Buffer b(BufHandle("b", {2, 3, m}, kFloat));
+
+  Tensor* c = Compute(
+      "scale",
+      {{2, "l2"}, {3, "n1"}, {m, "m1"}},
+      [&](const VarHandle& l, const VarHandle& n, const VarHandle& m) {
+        return b(l, n, m) * a(l, n, m);
+      });
+  Tensor* d = Reduce("sum", {{2, "l1"}}, Sum(), c, {{3, "n1"}, {m, "m1"}});
+  LoopNest loop({d});
+  loop.prepareForCodegen();
+  Stmt* s = loop.root_stmt();
+  s = IRSimplifier::simplify(s);
+
+  SimpleIREvaluator cg(s, {a, b, d, m});
+
+  std::vector<float> aData(2 * 3 * M, 0);
+  std::vector<float> bData(2 * 3 * M, 0);
+  std::vector<float> dData(2, 6.0f);
+
+  for (int i = 0; i < 2 * 3; ++i) {
+    for (int j = 0; j < M; ++j) {
+      bData[i * M + j] = j + 1;
+      aData[i * M + j] = 6 - i;
+    }
+  }
+
+  cg.call({aData, bData, dData, M});
+  float expected[2] = {0, 0};
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < M; ++k) {
+        expected[i] += (k + 1) * (6 - (i * 3 + j));
+      }
+    }
+  }
+
+  for (int i = 0; i < 2; ++i) {
+    ASSERT_EQ(dData[i], expected[i]);
+  }
+}
+
 void testSplitReduceAxis() {
   KernelScope kernel_scope;
 
@@ -1214,6 +1307,151 @@ void testReduceOverSplitRfactor() {
 # CHECK: Free(tmp_buf);)IR";
   // TODO: rfactor output is not consistent yet, will fix (@nickg).
   // torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+}
+
+void testReduceInlineReduction() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Buffer a_buf("a", kFloat, {M});
+  Buffer b_buf("b", kFloat, {M, N, K});
+
+  Tensor* x = Reduce("x", {{M, "m1"}}, Sum(), b_buf, {{N, "n1"}, {K, "k1"}});
+  Tensor* y = Compute("y", {{M, "m2"}}, [&](const VarHandle& m) {
+    return a_buf(m) + x->call(m);
+  });
+
+  PaddedBuffer<float> a_v(M);
+  PaddedBuffer<float> b_v(M, N, K);
+
+  for (int i = 0; i < M; i++) {
+    a_v(i) = i * i;
+  }
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < K; k++) {
+        b_v(i, j, k) = j * j * k;
+      }
+    }
+  }
+
+  LoopNest l1({y});
+  ASSERT_THROWS_WITH(
+      l1.computeInline(x->buf()), "cannot inline a reduction computation");
+}
+
+void testReduceInlineConsumer() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Buffer a_buf("a", kFloat, {M, N, K});
+  Buffer b_buf("b", kFloat, {M, N, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n, k) + b_buf(m, n, k);
+      });
+  Tensor* y = Reduce("y", {{M, "m2"}}, Sum(), x, {{N, "n2"}, {K, "k2"}});
+
+  PaddedBuffer<float> a_v(M, N, K);
+  PaddedBuffer<float> b_v(M, N, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < K; k++) {
+        a_v(i, j, k) = i * i + k;
+        b_v(i, j, k) = j * j + k;
+      }
+    }
+  }
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, y);
+
+  PaddedBuffer<float> y_1(M);
+  PaddedBuffer<float> y_2(M);
+
+  eval1(a_v, b_v, y_1);
+  eval2(a_v, b_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
+}
+
+void testReduceInlineReducerInternal() {
+  KernelScope kernel_scope;
+  const int M = 4;
+  const int N = 5;
+  const int K = 6;
+
+  Buffer a_buf("a", kFloat, {M, N, K});
+  Buffer b_buf("b", kFloat, {M, N, K});
+
+  Tensor* x = Compute(
+      "x",
+      {{M, "m1"}, {N, "n1"}, {K, "k1"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf(m, n, k) + b_buf(m, n, k);
+      });
+
+  Reducer minimum(ExprHandle(0.f), [&](ExprHandle a, ExprHandle b) {
+    return Add::make(ExprHandle(1.f), Min::make(a, b, false));
+  });
+  Tensor* y = Reduce("y", {{M, "m2"}}, minimum, x, {{N, "n2"}, {K, "k2"}});
+
+  PaddedBuffer<float> a_v(M, N, K);
+  PaddedBuffer<float> b_v(M, N, K);
+
+  for (int i = 0; i < M; i++) {
+    for (int j = 0; j < N; j++) {
+      for (int k = 0; k < K; k++) {
+        a_v(i, j, k) = i * i + k;
+        b_v(i, j, k) = j * j + k;
+      }
+    }
+  }
+
+  LoopNest l1({y});
+  LoopNest l2({y});
+  l2.computeInline(x->buf());
+
+  l1.prepareForCodegen();
+  l2.prepareForCodegen();
+
+  Stmt* stmt1 = IRSimplifier::simplify(l1.root_stmt());
+  Stmt* stmt2 = IRSimplifier::simplify(l2.root_stmt());
+
+  SimpleIREvaluator eval1(stmt1, a_buf, b_buf, y);
+  SimpleIREvaluator eval2(stmt2, a_buf, b_buf, y);
+
+  PaddedBuffer<float> y_1(M);
+  PaddedBuffer<float> y_2(M);
+
+  eval1(a_v, b_v, y_1);
+  eval2(a_v, b_v, y_2);
+  ExpectAllNear(y_1, y_2, 1e-5);
+  std::ostringstream oss1, oss2;
+  oss1 << *stmt1;
+  oss2 << *stmt2;
+  ASSERT_GT(oss1.str().size(), oss2.str().size());
 }
 
 } // namespace jit

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -46,6 +46,13 @@ using SimpleIRExprEval = ExprEval<SimpleIREvaluator>;
     ASSERT_EQ(node_->name_hint(), name);          \
   }
 
+#define IS_RAND(node)                                    \
+  {                                                      \
+    auto* node_ = dynamic_cast<const Intrinsics*>(node); \
+    ASSERT_NE(nullptr, node_);                           \
+    ASSERT_EQ(node_->op_type(), kRand);                  \
+  }
+
 void testConstantFoldSimple() {
   KernelScope kernel_scope;
   ExprHandle a(2.0f);
@@ -387,6 +394,26 @@ void testHashEquivalence() {
   // Intrinsics sanity check.
   ExprHandle f5 = Intrinsics::make(kSin, x) * Intrinsics::make(kCos, x);
   ASSERT_NE(hasher.hash(f5.node()), (size_t)0);
+}
+
+void testHashEquivalenceRand() {
+  KernelScope kernel_scope;
+  ExprHandle f =
+      Intrinsics::make(kRand, kFloat) + Intrinsics::make(kRand, kInt);
+
+  const Add* root = f.AsNode<Add>();
+  ASSERT_NE(root, nullptr);
+
+  HashProvider hasher;
+  auto hash_f = hasher.hash(f.node());
+  auto hash_l = hasher.hash(root->lhs());
+  auto hash_r = hasher.hash(root->rhs());
+
+  // Root not equal to either branch.
+  ASSERT_NE(hash_f, hash_l);
+  ASSERT_NE(hash_f, hash_r);
+  // and branches are NOT equal.
+  ASSERT_NE(hash_l, hash_r);
 }
 
 void testHashEquivalenceAfterFolding() {
@@ -2530,6 +2557,40 @@ void testSimplifyEliminateZeroLengthAlloc() {
     Stmt* simplified = IRSimplifier::simplify(block1);
     IS_NODE_WITH_NAME(Block, simplified, block2);
     ASSERT_EQ(block2->nstmts(), 2);
+  }
+}
+
+void testDontSimplifyRand() {
+  KernelScope kernel_scope;
+
+  {
+    // rand() + rand() = rand() + rand() NOT 2 * rand().
+    ExprHandle body =
+        Intrinsics::make(kRand, kInt) + Intrinsics::make(kRand, kInt);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Add, simplified.node(), add);
+    IS_RAND(add->lhs());
+    IS_RAND(add->rhs());
+  }
+
+  {
+    // rand() - rand() = rand() - rand() NOT 0.
+    ExprHandle body =
+        Intrinsics::make(kRand, kFloat) - Intrinsics::make(kRand, kFloat);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Sub, simplified.node(), sub);
+    IS_RAND(sub->lhs());
+    IS_RAND(sub->rhs());
+  }
+
+  {
+    // rand() * rand() = rand() * rand().
+    ExprHandle body =
+        Intrinsics::make(kRand, kInt) * Intrinsics::make(kRand, kInt);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
+    IS_RAND(mul->lhs());
+    IS_RAND(mul->rhs());
   }
 }
 

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -47,7 +47,23 @@ namespace jit {
   _(SplitWithMaskWithLoopOptions)           \
   _(ScheduleBroadcastAddBuffer)             \
   _(ScheduleFunctionCall01)                 \
+  _(ScheduleInlineSimple)                   \
   _(ScheduleInlineFunc01)                   \
+  _(ScheduleInlineRandom)                   \
+  _(ScheduleInlineRandomUnrelated)          \
+  _(ScheduleInlineRandomLowerDimensions)    \
+  _(ScheduleInlineIntrinsics)               \
+  _(ScheduleInlineRandWithIntrinsics)       \
+  _(ScheduleSplitAThenInline)               \
+  _(ScheduleSplitBThenInline)               \
+  _(ScheduleSplitTwiceThenInline)           \
+  _(ScheduleInlineThenSplit)                \
+  _(ScheduleSplitInlineThenSplit)           \
+  _(ScheduleSplitInlineSimplify)            \
+  _(ScheduleInlineThreeMixedOnce)           \
+  _(ScheduleInlineThreeMixedTwice)          \
+  _(ScheduleInlineThreeMixedInner)          \
+  _(ScheduleInlineThreeMixedSplit)          \
   _(ScheduleFuserStyle)                     \
   _(ScheduleFuserThreeArg)                  \
   _(ScheduleDynamicShape2D)                 \
@@ -61,6 +77,11 @@ namespace jit {
   _(ReduceAnyAll)                           \
   _(ReduceMatmul2D)                         \
   _(ReduceRfactorLike)                      \
+  _(ReduceAsProducer)                       \
+  _(ReduceAsConsumer)                       \
+  _(SplitReduceAxis)                        \
+  _(SplitNonReduceAxis)                     \
+  _(ReorderedReductionInitializer)          \
   _(ReduceRfactor)                          \
   _(Reduce3DRfactorInternal)                \
   _(Reduce3DRfactorInner)                   \
@@ -78,8 +99,9 @@ namespace jit {
   _(ReduceOverSplitMask)                    \
   _(ReduceSplitRfactor)                     \
   _(ReduceOverSplitRfactor)                 \
-  _(SplitReduceAxis)                        \
-  _(SplitNonReduceAxis)                     \
+  _(ReduceInlineReduction)                  \
+  _(ReduceInlineConsumer)                   \
+  _(ReduceInlineReducerInternal)            \
   _(TypeTest01)                             \
   _(TypePropagation)                        \
   _(Cond01)                                 \
@@ -134,6 +156,7 @@ namespace jit {
   _(UnFoldableExpr)                         \
   _(HashSimple)                             \
   _(HashEquivalence)                        \
+  _(HashEquivalenceRand)                    \
   _(HashEquivalenceAfterFolding)            \
   _(HashDifferenceTypes)                    \
   _(HashLargeExpression)                    \
@@ -176,6 +199,7 @@ namespace jit {
   _(SimplifyEliminateEmptyFor)              \
   _(SimplifyFlattenBlock)                   \
   _(SimplifyEliminateZeroLengthAlloc)       \
+  _(DontSimplifyRand)                       \
   _(RegisterizerSimple)                     \
   _(RegisterizerLoop)                       \
   _(RegisterizerLoopFixedLoad)              \

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -60,6 +60,12 @@ class VarFinder : public IRVisitor {
     return nf.vars();
   }
 
+  static std::unordered_set<const Var*> find(const Expr* e) {
+    VarFinder nf;
+    e->accept(&nf);
+    return nf.vars();
+  }
+
   const std::unordered_set<const Var*>& vars() {
     return vars_;
   }

--- a/torch/csrc/jit/tensorexpr/function.cpp
+++ b/torch/csrc/jit/tensorexpr/function.cpp
@@ -125,6 +125,20 @@ Tensor* Reduce(
       reduce_args);
 }
 
+Tensor* Reduce(
+    const std::string& func_name,
+    const std::vector<DimArg>& dim_args,
+    const Reducer& reducer,
+    Tensor* tensor,
+    const std::vector<DimArg>& reduce_args) {
+  return Reduce(
+      func_name,
+      dim_args,
+      reducer,
+      [&](ParameterList& p) { return tensor->call(p); },
+      reduce_args);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/hash_provider.cpp
+++ b/torch/csrc/jit/tensorexpr/hash_provider.cpp
@@ -241,6 +241,24 @@ void HashProvider::visit(const BaseCallNode* v) {
   putHash(v, hash);
 }
 
+void HashProvider::visit(const Intrinsics* v) {
+  CACHE_GUARD();
+  // calls to rand are not symbolic and have a different value each time, they
+  // should not hash to anything and this is the best we can do.
+  if (v->op_type() == kRand) {
+    putHash(v, (SimplifierHashType)rand());
+    return;
+  }
+
+  SimplifierHashType hash(te_hash(v->func_name()));
+  for (int i = 0; i < v->nparams(); i++) {
+    v->param(i)->accept(this);
+    hash = hash_combine(hash, hashOf(v->param(i)));
+  }
+
+  putHash(v, hash);
+}
+
 void HashProvider::visit(const Allocate* v) {
   CACHE_GUARD();
   const Var* buffer_var = v->buffer_var();

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -99,6 +99,7 @@ class TORCH_API HashProvider : public IRVisitor {
   void visit(const Broadcast* v) override;
   void visit(const IfThenElse* v) override;
   void visit(const BaseCallNode* v) override;
+  void visit(const Intrinsics* v) override;
   void visit(const Allocate* v) override;
   void visit(const Free* v) override;
   void visit(const Cond* v) override;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1292,12 +1292,7 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
     if (!l.hasLoopBodyFor(p.second) || hasReduction) {
       continue;
     }
-    Stmt* loop = l.getLoopBodyFor(p.second);
-    if (torch::jit::tensorexpr::HasRand(loop).has_rand()) {
-      l.computeInlineWithRandom(loop);
-    } else {
-      l.computeInline(loop);
-    }
+    l.computeInline(p.second->buf());
   }
   if (backendType == kCudaCodeGen) {
     for (size_t i = 0; i < flatTensorOutputs_.size(); i++) {
@@ -1305,7 +1300,7 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
 
       // For every output tensor we've created a flattened 1D tensor - let's
       // mark the original output tensor with computeInline
-      l.computeInline(l.getLoopBodyFor(tensorOutputs_[i]));
+      l.computeInline(tensorOutputs_[i]->buf());
 
       int loopLevels = getTECudaPointwiseLoopLevels();
       const int kDefaultLoopLevels = 2;

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -29,25 +29,27 @@ class TORCH_API LoopNest {
     return root_stmt_;
   }
 
+  // These Tensor-based loop/stmt accessors are valid only as long as no
+  // transformations have been made.
   std::vector<For*> getLoopStmtsFor(Tensor*) const;
   Stmt* getLoopBodyFor(Tensor*) const;
   bool hasLoopBodyFor(Tensor*) const;
 
   void vectorize(Stmt*);
+
   void computeInline(Stmt* s);
-  void computeInlineWithRandom(Stmt* s);
-  void prepareForCodegen();
+  void computeInline(const Buf* b);
+
   void splitWithTail(For* f, int factor, For** outer, For** inner, For** tail);
   void splitWithMask(For* f, int factor, For** outer, For** inner);
+
   void reorderAxis(For* a, For* b);
+
   static void unroll(For* f, Stmt** unrolled);
   static void normalize(For* f, For** normalized);
 
   void setGPUBlockIndex(For* f, int idx);
   void setGPUThreadIndex(For* f, int idx);
-  void setBufferMap(
-      For* f,
-      const std::unordered_map<std::string, const Buf*>& map);
 
   // Insert a temporary computation of statement S in the scope of loop AT.
   // S is assumed to be a Store or a Block containing a Store. Along with the
@@ -59,14 +61,18 @@ class TORCH_API LoopNest {
       const Var* reduction_var,
       Block* insertion_point = nullptr /* optional */);
 
+  void setBufferMap(
+      For* f,
+      const std::unordered_map<std::string, const Buf*>& map);
+
+  void prepareForCodegen();
+
  private:
   std::vector<Tensor*> findAllNeededTensors(
       const std::vector<Tensor*>& tensors);
   Stmt* lowerToStmt(Tensor* t);
   Stmt* insertAllocFree(Stmt* stmt);
 
-  std::unordered_set<Function*> inlined_functions_;
-  std::unordered_set<Function*> inlined_random_functions_;
   std::unordered_map<Tensor*, Stmt*> tensor_to_stmt_;
   std::unordered_map<Stmt*, Tensor*> stmt_to_tensor_;
   Stmt* root_stmt_;

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -164,6 +164,15 @@ TORCH_API Tensor* Reduce(
     const Buffer& buffer,
     const std::vector<DimArg>& reduce_args);
 
+// Overload for the common case of all dimensions of a prevously Computed
+// Tensor.
+TORCH_API Tensor* Reduce(
+    const std::string& func_name,
+    const std::vector<DimArg>& dim_args,
+    const Reducer& reducer,
+    Tensor* tensor,
+    const std::vector<DimArg>& reduce_args);
+
 class FunctionCall : public CallNode<FunctionCall> {
  public:
   using BaseClass = CallNode<FunctionCall>;


### PR DESCRIPTION
A rework of `computeInline` which makes it work a bit better, particularly when combined with other transformations. Previously we stored Functions that were inlined and then deferred the actual inlining of the function body until prepareForCodgen was called. This has an issue when transformations are applied to the LoopNest: the function body can be different from what appears in the root_stmt and result in inlining that a) fails, b) reverses other transformations or c) a weird unpredictable combination of the two.

This PR changes that behaviour so that the inlining occurs in the root stmt immediately, which means it reflects any previous transformations and any future transformations have a true view of the internal IR. It also has the benefit that inspecting the root statement gives an accurate view of it without needing to call prepareForCodgen. I also removed the difference between `computeInline` and `computeInlineWithRand` and we handle calls to `rand()` in all branches.

This is a rework of #38696, with the agreed changes from @ZolotukhinM and @zheng-xq: we should only inline if the dimensions are trivial (ie. they are vars not exprs).

This PR is mostly tests, and I fixed a bunch of bugs I found along the way. Partial list:
* When inlining an expression involving rand, we would create random vars equal to the dimensionality of the enclosing Tensor not the produced Tensor - meaning we'd use an incorrect value if the inlined tensor was smaller. E.g: `X[i] = rand(); A[i, j] = X[i]` would produce a tensor where `A[0, 0] != A[0, 1]`. This is fixed by inserting the Let binding of the random variable at the correct loop body.
* When inlining we'd replace all calls to `rand()` rather than just those present in the Tensor being inlined.
* `rand()` was treated symbolically by the simplifier and we would aggregate or cancel calls to `rand()`. Have fixed the hasher to hash all calls to `rand()` distinctly.