### PR TITLE
Set default compiler differently according to platform

### DIFF
--- a/tools/code_coverage/README.md
+++ b/tools/code_coverage/README.md
@@ -2,41 +2,41 @@
 
 ## Overview
 
-This tool is designed for calculating code coverage for Pytorch project in both fbcode and oss. But it also goes beyond Pytorch, applying to other folders in fbcode.
-
-It’s an integrated tool. You can use this tool to build, run, and generate both file-level and line-level report with both C++ tests and Python tests.
+This tool is designed for calculating code coverage for Pytorch project.
+It’s an integrated tool. You can use this tool to run and generate both file-level and line-level report for C++ and Python tests. It will also be the tool we use in *CircleCI* to generate report for each master commit.
 
 ### Simple
 * *Simple command to run:*
     * `python oss_coverage.py  `
-* *Argument --clean will do all the messy clean up things for you*
+* *Argument `--clean` will do all the messy clean up things for you*
 
 ### But Powerful
 
 * *Choose your own interested folder*:
-    * Choose the folder you want to collect coverage for
-    * Flexible: default folder is good enough, but you can choose one or more other folders
+    * Default folder will be good enough in most times
+    * Flexible: you can specify one or more folder(s) that you are interested in
 * *Run only the test you want:*
-    * use --run-only to run the tests you want
-    * apply to both cpp and python tests
+    * By default it will run all the c++ and python tests
+    * Flexible: you can specify one or more test(s) that you want to run
 * *Final report:*
-    * File-Level: The coverage for each file you are interested in
-    * Line-Level: The coverage for each line in each file you are interested in
+    * File-Level: The coverage percentage for each file you are interested in
+    * Line-Level: The coverage details for each line in each file you are interested in
 * *More complex but flexible options:*
-    * Use different stages like *--build, --run, --summary* to achieve more flexible functionality
+    * Use different stages like *--run, --export, --summary* to achieve more flexible functionality
 
 ## How to use
 
 This part will introduce about the arguments you can use when run this tool. The arguments are powerful, giving you full flexibility to do different work.
-If you are not familiar with the procedure of generating code coverage report by using clang, read [Source-based Code Coverage](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) will be helpful.
+We have two different compilers, `gcc` and `clang`, and this tool supports both. But it is recommended to use `gcc` because it's much faster and use less disk place. The examples will also be divided to two parts, for `gcc` and `clang`.
 
 
 ## Examples
-
-First step is to set some experimental value.
+First step is to set some experimental value if needed:
 ```bash
 # pytorch folder, by default all the c++ binaries are in build/bin/
 export PYTORCH_FOLDER=...
+# set compiler type
+export COMPILER_TYPE="GCC" or export COMPILER_TYPE="CLANG"
 # make sure llvm-cov is available, by default it is /usr/local/opt/llvm/bin
 export LLVM_TOOL_PATH=...
 ```
@@ -57,3 +57,11 @@ python oss_coverage.py --run-only atest basic test_nn.py
 
 ### For more complex arguments and functionality
 *To Be Done*
+
+## Reference
+
+For `gcc`
+* See about how to invoke `gcov`, read [Invoking gcov](https://gcc.gnu.org/onlinedocs/gcc/Invoking-Gcov.html#Invoking-Gcov) will be helpful
+
+For `clang`
+* If you are not familiar with the procedure of generating code coverage report by using `clang`, read [Source-based Code Coverage](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) will be helpful.

--- a/tools/code_coverage/README.md
+++ b/tools/code_coverage/README.md
@@ -23,7 +23,7 @@ It’s an integrated tool. You can use this tool to build, run, and generate bot
     * File-Level: The coverage for each file you are interested in
     * Line-Level: The coverage for each line in each file you are interested in
 * *More complex but flexible options:*
-    * Use different stages like --build, --run, --summary to achieve more flexible functionality
+    * Use different stages like *--build, --run, --summary* to achieve more flexible functionality
 
 ## How to use
 
@@ -34,7 +34,7 @@ If you are not familiar with the procedure of generating code coverage report by
 ## Examples
 
 First step is to set some experimental value.
-```
+```bash
 # pytorch folder, by default all the c++ binaries are in build/bin/
 export PYTORCH_FOLDER=...
 # make sure llvm-cov is available, by default it is /usr/local/opt/llvm/bin
@@ -42,15 +42,15 @@ export LLVM_TOOL_PATH=...
 ```
 
 then command will run all the tests in `build/bin/` and `test/` folder
-```
+```bash
 python oss_coverage.py
 ```
 Most times you don't want collect coverage for the entire Pytorch folder, use --interested-folder to report coverage only over the folder you want:
-```
+```bash
 python oss_coverage.py --interested-folder=aten
 ```
 Then, still in most cases, if you only run one or several test(s):
-```
+```bash
 python oss_coverage.py --run-only=atest
 python oss_coverage.py --run-only atest basic test_nn.py
 ```

--- a/tools/code_coverage/oss_coverage.py
+++ b/tools/code_coverage/oss_coverage.py
@@ -4,6 +4,7 @@ import time
 from package.oss.cov_json import get_json_report
 from package.oss.init import initialization
 from package.tool.summarize_jsons import summarize_jsons
+from package.util.setting import TestPlatform
 
 
 def report_coverage() -> None:
@@ -13,7 +14,9 @@ def report_coverage() -> None:
     get_json_report(test_list, options)
     # collect coverage data from json profiles
     if options.need_summary:
-        summarize_jsons(test_list, interested_folders, [""], start_time)
+        summarize_jsons(
+            test_list, interested_folders, [""], TestPlatform.OSS, start_time
+        )
 
 
 if __name__ == "__main__":

--- a/tools/code_coverage/package/oss/cov_json.py
+++ b/tools/code_coverage/package/oss/cov_json.py
@@ -2,8 +2,8 @@ import time
 
 from ..tool import clang_coverage, gcc_coverage
 from ..util.setting import Option, TestList, TestPlatform
-from ..util.utils import check_compiler_type, get_cov_type, print_time
-from .init import gcc_export_init
+from ..util.utils import check_compiler_type, print_time
+from .init import gcc_export_init, get_cov_type
 from .run import clang_run, gcc_run
 
 

--- a/tools/code_coverage/package/oss/init.py
+++ b/tools/code_coverage/package/oss/init.py
@@ -72,7 +72,7 @@ def parse_arguments(
     args = parser.parse_args()
     # get option
     options = get_options(args)
-    return (options, args.interested_folder, args.run_only, args.clean)
+    return (options, args.interest_only, args.run_only, args.clean)
 
 
 def get_test_list_by_type(

--- a/tools/code_coverage/package/oss/init.py
+++ b/tools/code_coverage/package/oss/init.py
@@ -13,7 +13,6 @@ from ..util.setting import (
 from ..util.utils import (
     clean_up,
     create_folder,
-    get_cov_type,
     print_log,
     raise_no_test_found_exception,
     remove_file,
@@ -22,6 +21,7 @@ from ..util.utils import (
 from ..util.utils_init import add_arguments_utils, create_folders, get_options
 from .utils import (
     clean_up_gcda,
+    get_cov_type,
     get_llvm_tool_path,
     get_oss_binary_folder,
     get_pytorch_folder,

--- a/tools/code_coverage/package/oss/init.py
+++ b/tools/code_coverage/package/oss/init.py
@@ -117,7 +117,7 @@ def get_interested_folder(arg_interested_folder: Optional[List[str]]) -> List[st
         # if this argument is specified, just return itself
         return arg_interested_folder
     else:
-        return [""]
+        return []
 
 
 def gcc_export_init():

--- a/tools/code_coverage/package/oss/utils.py
+++ b/tools/code_coverage/package/oss/utils.py
@@ -43,6 +43,10 @@ def get_pytorch_folder() -> str:
     return os.environ.get("PYTORCH_FOLDER", SCRIPT_FOLDER)
 
 
+def get_cov_type() -> str:
+    return os.environ.get("COMPILER_TYPE", "GCC")
+
+
 def clean_up_gcda() -> None:
     gcda_files = get_gcda_files()
     for item in gcda_files:

--- a/tools/code_coverage/package/tool/clang_coverage.py
+++ b/tools/code_coverage/package/tool/clang_coverage.py
@@ -148,7 +148,9 @@ def export(test_list: TestList, platform_type: TestPlatform) -> None:
                 binary_file = ""
                 shared_library_list = []
                 if platform_type == TestPlatform.FBCODE:
-                    from ..fbcode.utils import get_fbcode_binary_folder
+                    from caffe2.fb.code_coverage.tool.package.fbcode.utils import (
+                        get_fbcode_binary_folder,
+                    )
 
                     binary_file = os.path.join(
                         get_fbcode_binary_folder(path),

--- a/tools/code_coverage/package/tool/print_report.py
+++ b/tools/code_coverage/package/tool/print_report.py
@@ -118,18 +118,19 @@ def print_total_program_time(start_time: float, summary_file: IO) -> None:
 
 def print_file_summary(
     covered_summary: int, total_summary: int, summary_file: IO
-) -> None:
+) -> float:
     # print summary first
     try:
-        coverage_percentage = round(1.0 * covered_summary / total_summary * 100, 2)
+        coverage_percentage = 100.0 * covered_summary / total_summary
     except ZeroDivisionError:
-        raise ZeroDivisionError(
-            "Failed to generate coverage report, please check if json profiles are valid in profile/json"
-        )
+        coverage_percentage = 0
     print(
-        f"SUMMARY\ncovered: {covered_summary}\nuncovered: {total_summary}\npercentage: {coverage_percentage}%\n\n",
+        f"SUMMARY\ncovered: {covered_summary}\nuncovered: {total_summary}\npercentage: {coverage_percentage:.2f}%\n\n",
         file=summary_file,
     )
+    if coverage_percentage == 0:
+        print("Coverage is 0, Please check if json profiles are valid")
+    return coverage_percentage
 
 
 def print_file_oriented_report(
@@ -143,7 +144,9 @@ def print_file_oriented_report(
     coverage_only: List[str],
     program_start_time: float,
 ) -> None:
-    print_file_summary(covered_summary, total_summary, summary_file)
+    coverage_percentage = print_file_summary(
+        covered_summary, total_summary, summary_file
+    )
     print_total_program_time(program_start_time, summary_file)
     # print test condition (interested folder / tests that are successsful or failed)
     print_test_condition(
@@ -164,9 +167,7 @@ def print_file_oriented_report(
             file=summary_file,
         )
 
-    print(
-        f"summary percentage:{round(1.0 * covered_summary / total_summary * 100, 2)}%"
-    )
+    print(f"summary percentage:{coverage_percentage:.2f}%")
 
 
 def file_oriented_report(

--- a/tools/code_coverage/package/tool/summarize_jsons.py
+++ b/tools/code_coverage/package/tool/summarize_jsons.py
@@ -93,7 +93,7 @@ def get_json_obj(json_file: str) -> Tuple[Any, int]:
     return None, 2
 
 
-def parse_json(json_file: str) -> List[CoverageRecord]:
+def parse_json(json_file: str, platform: TestPlatform) -> List[CoverageRecord]:
     print("start parse:", json_file)
     json_obj, read_status = get_json_obj(json_file)
     if read_status == 0:
@@ -105,8 +105,9 @@ def parse_json(json_file: str) -> List[CoverageRecord]:
         raise RuntimeError(
             "Fail to do code coverage! Fail to load json file: ", json_file
         )
-    cov_type = get_cov_type()
-    check_compiler_type(cov_type)
+
+    cov_type = get_cov_type(platform)
+
     coverage_records: List[CoverageRecord] = []
     if cov_type == "CLANG":
         coverage_records = LlvmCoverageParser(json_obj).parse("fbcode")
@@ -126,13 +127,13 @@ def parse_jsons(
         for file_name in file_list:
             if file_name.endswith(".json"):
                 # if compiler is clang, we only analyze related json / when compiler is gcc, we analyze all jsons
-                if get_cov_type() == "CLANG" and not related_to_test_list(
+                if get_cov_type(platform) == "CLANG" and not related_to_test_list(
                     file_name, test_list
                 ):
                     continue
                 json_file = os.path.join(path, file_name)
                 try:
-                    coverage_records = parse_json(json_file)
+                    coverage_records = parse_json(json_file, platform)
                 except RuntimeError:
                     print_error("Fail to load json file: ", json_file)
                     continue

--- a/tools/code_coverage/package/tool/utils.py
+++ b/tools/code_coverage/package/tool/utils.py
@@ -14,7 +14,7 @@ def run_cpp_test(binary_file: str) -> None:
 
 def get_tool_path_by_platform(platform: TestPlatform):
     if platform == TestPlatform.FBCODE:
-        from ..fbcode.utils import get_llvm_tool_path
+        from caffe2.fb.code_coverage.tool.package.fbcode.utils import get_llvm_tool_path
 
         return get_llvm_tool_path()
     else:

--- a/tools/code_coverage/package/util/utils.py
+++ b/tools/code_coverage/package/util/utils.py
@@ -80,9 +80,18 @@ def get_raw_profiles_folder() -> str:
     return os.environ.get("RAW_PROFILES_FOLDER", os.path.join(PROFILE_DIR, "raw"))
 
 
-# TODO auto detect
-def get_cov_type() -> str:
-    return os.environ.get("COMPILER_TYPE", "CLANG")
+def get_cov_type(platform: TestPlatform) -> str:
+    if platform == TestPlatform.OSS:
+        from package.oss.utils import get_cov_type
+
+        cov_type = get_cov_type()
+    else:
+        from caffe2.fb.code_coverage.tool.package.fbcode.utils import get_cov_type
+
+        cov_type = get_cov_type()
+
+    check_compiler_type(cov_type)
+    return cov_type
 
 
 def get_test_name_from_whole_path(path: str) -> str:

--- a/tools/code_coverage/package/util/utils_init.py
+++ b/tools/code_coverage/package/util/utils_init.py
@@ -45,7 +45,7 @@ def add_arguments_utils(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         action="store_true",
     )
     parser.add_argument(
-        "--interested-folder",
+        "--interest-only",
         help="Final report will be only about these folders and its sub-folders; for example: caff2/c10;",
         nargs="+",
         default=None,


### PR DESCRIPTION
Summary: set `gcc` as default compiler type in oss, and `clang` as default compiler type in fbcode

Test Plan: test locally

Differential Revision: D23420034

