### PR TITLE
Add support for integer dim arg in `torch.linalg.norm`

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7354,19 +7354,19 @@
 
 - func: ger.out(Tensor self, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: linalg_norm(Tensor self, Scalar? ord=None, int[]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- func: linalg_norm(Tensor self, Scalar? ord=None, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   python_module: linalg
   variants: function
 
-- func: linalg_norm.ord_str(Tensor self, str ord, int[]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+- func: linalg_norm.ord_str(Tensor self, str ord, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   python_module: linalg
   variants: function
 
-- func: linalg_norm.out(Tensor self, Scalar? ord=None, int[]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: linalg_norm.out(Tensor self, Scalar? ord=None, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg
   variants: function
 
-- func: linalg_norm.ord_str_out(Tensor self, str ord, int[]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+- func: linalg_norm.ord_str_out(Tensor self, str ord, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg
   variants: function
 

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -74,6 +74,10 @@ allow_list = [
     ("aten::linalg_outer", datetime.date(2020, 8, 30)),
     # WARNING: overload name here doesn't do anything
     ("aten::linalg_outer.out", datetime.date(2020, 8, 30)),
+    ("aten::linalg_norm", datetime.date(2020, 9, 30)),
+    ("aten::linalg_norm.ord_str", datetime.date(2020, 9, 30)),
+    ("aten::linalg_norm.out", datetime.date(2020, 9, 30)),
+    ("aten::linalg_norm.ord_str_out", datetime.date(2020, 9, 30)),
     ("aten::_compute_linear_combination", datetime.date(2020, 9, 1)),
     ("__getstate__", datetime.date(2020, 9, 1), "Conv[23]dPackedParams"),
     ("aten::_foreach_add_", datetime.date(2020, 10, 1)),

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -135,12 +135,12 @@ class TestLinalg(TestCase):
         test_cases = [
             # input size, p settings, dim
             ((S, ), ord_vector, None),
-            ((S, ), ord_vector, (0, )),
-            ((S, S, S), ord_vector, (0, )),
-            ((S, S, S), ord_vector, (1, )),
-            ((S, S, S), ord_vector, (2, )),
-            ((S, S, S), ord_vector, (-1, )),
-            ((S, S, S), ord_vector, (-2, )),
+            ((S, ), ord_vector, 0),
+            ((S, S, S), ord_vector, 0),
+            ((S, S, S), ord_vector, 1),
+            ((S, S, S), ord_vector, 2),
+            ((S, S, S), ord_vector, -1),
+            ((S, S, S), ord_vector, -2),
         ]
         L = 1_000_000
         if dtype == torch.double:
@@ -299,8 +299,8 @@ class TestLinalg(TestCase):
             ((S, ), ['nuc'], None, RuntimeError, r'order "nuc" can only be used if either len\(dim\) == 2'),
             ((S, S), [3.5], None, RuntimeError, r'Order 3.5 not supported for matrix norm'),
             ((S, S), [0], None, RuntimeError, r'Order 0 not supported for matrix norm'),
-            ((S, S), ['nuc'], (0, ), RuntimeError, r'order "nuc" can only be used if either len\(dim\) == 2'),
-            ((S, S), ['fro'], (0, ), RuntimeError, r'order "fro" can only be used if either len\(dim\) == 2'),
+            ((S, S), ['nuc'], 0, RuntimeError, r'order "nuc" can only be used if either len\(dim\) == 2'),
+            ((S, S), ['fro'], 0, RuntimeError, r'order "fro" can only be used if either len\(dim\) == 2'),
             ((S, S), ['nuc'], (0, 0), RuntimeError, r'duplicate or invalid dimensions'),
             ((S, S), ['fro', 0], (0, 0), RuntimeError, r'Expected dims to be different'),
             ((S, S), ['fro', 'nuc', 0], (0, 4), IndexError, r'Dimension out of range'),
@@ -397,13 +397,6 @@ class TestLinalg(TestCase):
             with self.assertRaisesRegex(RuntimeError, error_msg):
                 torch.linalg.norm(x, ord)
 
-    # Make sure that linalg.norm raises an error if dim is an integer
-    # TODO: When integer dims are supported in norm, remove this test
-    def test_norm_dim_int_error(self, device):
-        input = torch.randn(10, device=device)
-        with self.assertRaisesRegex(TypeError, r'linalg_norm\(\) received an invalid combination of arguments'):
-            torch.linalg.norm(input, dim=0)
-
     # Test that linal.norm gives the same result as numpy when inputs
     # contain extreme values (inf, -inf, nan)
     @skipCUDAIfNoMagma
@@ -480,10 +473,10 @@ class TestLinalg(TestCase):
         test_cases = [
             # input size, p settings that cause error, dim
             ((0, ), [inf, -inf], None),
-            ((0, S), [inf, -inf], (0,)),
-            ((0, S), [], (1,)),
-            ((S, 0), [], (0,)),
-            ((S, 0), [inf, -inf], (1,)),
+            ((0, S), [inf, -inf], 0),
+            ((0, S), [], 1),
+            ((S, 0), [], 0),
+            ((S, 0), [inf, -inf], 1),
         ]
         for keepdim in [True, False]:
             for input_size, error_ords, dim in test_cases:


### PR DESCRIPTION
Since PR #43262 is merged, this works now.

Part of #24802
