### PR TITLE
Fix ImportError in the OSS land.

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -13,7 +13,7 @@ from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
-from caffe2.python.oss.fakelowp.test_utils import compute_ulp_error
+from caffe2.python.fakelowp.test_utils import compute_ulp_error
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])


### PR DESCRIPTION
Summary: Fixed the ImportError: cannot import name 'compute_ulp_error' from 'caffe2.python.oss.fakelowp.test_utils'

Test Plan: test_op_nnpi_fp16.py

Differential Revision: D23435218

