### PR TITLE
[Do not commit] Workaround an assertion failure in aliasingSafeSubgraphMerge

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -486,7 +486,13 @@ class TensorExprFuser {
 
     for (auto n : nodes_to_merge) {
       GRAPH_UPDATE("Merging ", getHeader(n));
-      mergeNodeIntoSubgraphAndUpdateAliasing(n, fusion_group);
+      SubgraphUtils::mergeNodeIntoSubgraph(n, fusion_group);
+      // mergeNodeIntoSubgraphAndUpdateAliasing(n, fusion_group);
+      // TODO: Use that ^ call instead, but currently if fails with:
+      //  $  python -m fastrnns.bench --fuser=te --group=rnns --rnns jit
+      //
+      // RuntimeError: vmap.count(existing_values.at(i)) INTERNAL ASSERT FAILED at "../torch/csrc/jit/passes/tensorexpr_fuser.cpp":263, please report a bug to PyTorch.
+      // Exception raised from aliasingSafeSubgraphMerge at ../torch/csrc/jit/passes/tensorexpr_fuser.cpp:263 (most recent call first):
     }
     return fusion_group;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43814 Add current results.
* **#43913 [Do not commit] Workaround an assertion failure in aliasingSafeSubgraphMerge**
* #43843 [Do not commit] Fix condition in specialize autogradzero.
* #43810 Set number of profiling runs to 2 in benchmarks.
* #43811 [Do not commit] Fix a bug in specialize autogradzero resulting in 2x slowdown on backwards pass.
* #43826 [Do not commit] Do not fail when dumping backwards graph via PYTORCH_JIT_LOG_LEVEL=graph_executor.
* #43825 [Do not commit] Remove profile nodes before BatchMM.
* #43805 [Do not commit] Disable peeling (improves perf on rnn_jit and rnn_jit_premul)
* #43802 [Do not commit][TensorExpr] Fuser: try merging adjacent fusion groups.
* #43801 Benchmarks: add standalone RNN benchmarks.

