### PR TITLE
[ONNX] Update ONNX shape inference

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -31,7 +31,7 @@ def to_numpy(tensor):
         return tensor.cpu().numpy()
 
 def convert_to_onnx(model, input=None, opset_version=9, example_outputs=None,
-                    do_constant_folding=True, keep_initializers_as_inputs=True, 
+                    do_constant_folding=True, keep_initializers_as_inputs=True,
                     dynamic_axes=None, input_names=None, output_names=None,
                     fixed_batch_size=False, training=None,
                     onnx_shape_inference=False,
@@ -2822,6 +2822,20 @@ class TestONNXRuntime(unittest.TestCase):
         inputs = torch.randn(16)
         self.run_test(model, inputs)
 
+    @skipIfONNXShapeInference(False)
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_loop_transpose(self):
+        class LoopModel(torch.nn.Module):
+            def forward(self, x):
+                res = torch.zeros_like(x[0])
+                for i in range(x.size(0)):
+                    res += x[0].transpose(0, 1)
+                return res
+
+        model = torch.jit.script(LoopModel())
+        x = torch.randn(5, 3, 3)
+        self.run_test(model, x)
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_list(self):
         class ListModel(torch.jit.ScriptModule):
@@ -4067,6 +4081,22 @@ class TestONNXRuntime(unittest.TestCase):
                 return out
         x = torch.randn(1, 2, 3, requires_grad=True)
         self.run_test(EmptyBranchModel(), x)
+
+    @skipIfskipIfONNXShapeInference(False)
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_if_transpose(self):
+        class IfModel(torch.nn.Module):
+            def forward(self, x):
+                x = x.transpose(0, 1)
+                if x.size(0) == 2:
+                    return x.transpose(0, 1)
+                else:
+                    return x
+
+        x = torch.randn(2, 3)
+        self.run_test(torch.jit.script(IfModel()), x,
+                      output_names=['output_1'],
+                      dynamic_axes={'output_1': [0, 1]})
 
     def test_onnx_proto_checker(self):
         class Model(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4082,7 +4082,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(1, 2, 3, requires_grad=True)
         self.run_test(EmptyBranchModel(), x)
 
-    @skipIfskipIfONNXShapeInference(False)
+    @skipIfONNXShapeInference(False)
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_if_transpose(self):
         class IfModel(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/symbolic.h>
 #include <torch/csrc/jit/ir/constants.h>
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/python/python_ir.h>
 #include <torch/csrc/utils/pybind.h>
@@ -186,11 +187,54 @@ void BlockToONNX(
     return it->second;
   };
 
+  GRAPH_DEBUG("BlockToONNX: graph of old block: ", old_block->owningGraph()->toString());
+
   // Initialize context and environment
   for (auto input : old_block->inputs()) {
     auto n = ctx.block->addInput()->copyMetadata(input);
     env[input] = n;
   }
+
+  // Merge ONNX inferred type with existing type.
+  // If inferred type is sequence, overwrite old type because it is more compatible
+  // with ONNX shape inference.
+  // If inferred type is tensor type, merge the two types, with inferred type having
+  // higher precedence.
+  auto mergeOutputTypes = [](TypePtr old_type, TypePtr new_type) -> TypePtr {
+    auto new_list_type = new_type->cast<ListType>();
+    if (new_list_type) {
+      return new_type;
+    }
+    auto new_tensor_type = new_type->cast<TensorType>();
+    auto old_tensor_type = old_type->cast<TensorType>();
+
+    if (old_tensor_type) {
+      auto type = old_tensor_type;
+      if (new_tensor_type && new_tensor_type->sizes().isComplete()) {
+        type = type->withSizes(new_tensor_type->sizes().concrete_sizes().value());
+      }
+      if (new_tensor_type && new_tensor_type->scalarType().has_value()) {
+        type = type->withScalarType(new_tensor_type->scalarType());
+      }
+      return type;
+    } else {
+      return new_type;
+    }
+
+    // if (old_tensor_type && old_tensor_type->scalarType().has_value()) {
+    //   if (new_tensor_type && new_tensor_type->sizes().isComplete()) {
+    //     TypePtr old_type_with_sizes = old_tensor_type->withSizes(new_tensor_type->sizes().concrete_sizes().value());
+    //     return old_type_with_sizes;
+    //   }
+    //   return old_type;
+    // }
+    // if (new_tensor_type && new_tensor_type->scalarType().has_value()) {
+    //   return new_type;
+    // }
+
+    // return old_type;
+  };
+
   // Put the new outputs in our environment map, and copy the type from the
   // input graph if they were not set by the symbolic. This is called only
   // with results of symbolic call (not for nodes that are just cloned).
@@ -213,12 +257,10 @@ void BlockToONNX(
         // Allow symbolic() to skip specifying the type of the return node.
         // Unfortunately, they are on the hook for all internal nodes
         // (though in practice, the types are not computed.)
-        auto old_tensor_type = old->type()->cast<TensorType>();
-        if (old_tensor_type == nullptr ||
-            old_tensor_type->scalarType().has_value()) {
-          // Check if Tensor has scalartype when overwriting output type
-          outputs[i]->setType(old->type());
-        }
+        //
+        // If onnx shape inference is turned on, the new outputs will have
+        // types inferred, and they will be merged with the old types.
+        outputs[i]->setType(mergeOutputTypes(old->type(), outputs[i]->type()));
 
         // Copy over source location and scope information to all nodes
         // created by the symbolic
@@ -297,6 +339,7 @@ void BlockToONNX(
     // TODO: Assert it's an ATen identifier???
     // (Sometimes it's not...)
     processSymbolicOutput(n->kind().toUnqualString(), n, raw_output);
+    GRAPH_DUMP("after process output:", ctx.block->owningGraph());
   };
 
   auto callPySymbolicMethod = [&](ConcretePythonOp* op) {
@@ -363,7 +406,6 @@ void BlockToONNX(
   }
   for (auto output : old_block->outputs()) {
     ctx.block->registerOutput(env.at(output));
-    env.at(output)->setType(output->type());
   }
   EliminateDeadCode(
       ctx.block,

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -217,22 +217,8 @@ void BlockToONNX(
         type = type->withScalarType(new_tensor_type->scalarType());
       }
       return type;
-    } else {
-      return new_type;
     }
-
-    // if (old_tensor_type && old_tensor_type->scalarType().has_value()) {
-    //   if (new_tensor_type && new_tensor_type->sizes().isComplete()) {
-    //     TypePtr old_type_with_sizes = old_tensor_type->withSizes(new_tensor_type->sizes().concrete_sizes().value());
-    //     return old_type_with_sizes;
-    //   }
-    //   return old_type;
-    // }
-    // if (new_tensor_type && new_tensor_type->scalarType().has_value()) {
-    //   return new_type;
-    // }
-
-    // return old_type;
+    return new_type;
   };
 
   // Put the new outputs in our environment map, and copy the type from the

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -188,7 +188,9 @@ void BlockToONNX(
     return it->second;
   };
 
-  GRAPH_DEBUG("BlockToONNX: graph of old block: ", old_block->owningGraph()->toString());
+  GRAPH_DEBUG(
+      "BlockToONNX: graph of old block: ",
+      old_block->owningGraph()->toString());
 
   // Initialize context and environment
   for (auto input : old_block->inputs()) {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -208,7 +208,7 @@ void BlockToONNX(
     auto new_tensor_type = new_type->cast<TensorType>();
     auto old_tensor_type = old_type->cast<TensorType>();
 
-    if (old_tensor_type) {
+    if (new_tensor_type && old_tensor_type) {
       auto type = old_tensor_type;
       if (new_tensor_type && new_tensor_type->sizes().isComplete()) {
         type = type->withSizes(new_tensor_type->sizes().concrete_sizes().value());
@@ -218,6 +218,19 @@ void BlockToONNX(
       }
       return type;
     }
+
+    if (old_tensor_type) {
+      return old_type;
+    }
+
+    auto old_list_type = old_type->cast<ListType>();
+    if (new_tensor_type && old_list_type) {
+      if (new_tensor_type->sizes().isComplete()) {
+        return new_type;
+      }
+      return old_type;
+    }
+
     return new_type;
   };
 

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/onnx/peephole.h>
+#include <torch/csrc/jit/jit_log.h>
 
 namespace torch {
 namespace jit {
@@ -17,6 +18,7 @@ Node* CreateCastToBoolNode(Value* val, Graph* graph) {
   Node* cast_node = graph->create(onnx::Cast);
   cast_node->addInput(val);
   cast_node->i_(attr::to, ONNX_TYPE_BOOL);
+  cast_node->output()->setType(BoolType::get());
   return cast_node;
 }
 
@@ -228,6 +230,7 @@ std::vector<Value*> FixupONNXIfNode(Node* node, int opset_version) {
   if (node->kind() != ::c10::onnx::If) {
     return node->outputs().vec();
   }
+  GRAPH_DUMP("Graph before fixing controlflow: ", node->owningGraph());
   auto* if_node = node;
   auto* graph = if_node->owningGraph();
   for (Block* block : node->blocks()) {
@@ -242,7 +245,7 @@ std::vector<Value*> FixupONNXIfNode(Node* node, int opset_version) {
       block->return_node()->replaceInputWith(output, id_node->output());
     }
   }
-
+  GRAPH_DUMP("Graph after fixing controlflow: ", node->owningGraph());
   return if_node->outputs().vec();
 }
 

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -1,7 +1,7 @@
 #include <torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.h>
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/onnx/peephole.h>
-#include <torch/csrc/jit/jit_log.h>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -90,11 +90,9 @@ bool IsSupportedNode(const Node* n) {
     return false;
   }
 
-  // NOTE: should be able to run. At this stage the subgraph has already completed shape inferencing.
   // Skip when block size is zero. This is when the node is first created, doesn't have subblocks attached yet.
+  // Run shape inference for these nodes when the subgraph has already completed shape inferencing.
   if ((node_kind == ::c10::onnx::Loop || node_kind == ::c10::onnx::If) && n->blocks().size() == 0) {
-    // TODO: Support Loop & If shape inference by propagating input shape to
-    // block input.
     return false;
   }
 

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -34,11 +34,16 @@ TypePtr MergeInferredType(TypePtr existing_type, TypePtr inferred_type) {
   auto old_tensor_type = existing_type->cast<TensorType>();
 
   if (new_tensor_type && old_tensor_type) {
+    if (!old_tensor_type->device()) {
+      // device not avaible means this is an invalid tensor type (most likely an empty one)
+      // return inferred type directly.
+      return new_tensor_type;
+    }
     auto type = old_tensor_type;
-    if (new_tensor_type && new_tensor_type->sizes().isComplete()) {
+    if (new_tensor_type->sizes().isComplete()) {
       type = type->withSizes(new_tensor_type->sizes().concrete_sizes().value());
     }
-    if (new_tensor_type && new_tensor_type->scalarType().has_value()) {
+    if (new_tensor_type->scalarType().has_value()) {
       type = type->withScalarType(new_tensor_type->scalarType());
     }
     return type;

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -35,8 +35,8 @@ TypePtr MergeInferredType(TypePtr existing_type, TypePtr inferred_type) {
 
   if (new_tensor_type && old_tensor_type) {
     if (!old_tensor_type->device()) {
-      // device not avaible means this is an invalid tensor type (most likely an empty one)
-      // return inferred type directly.
+      // device not avaible means this is an invalid tensor type (most likely an
+      // empty one) return inferred type directly.
       return new_tensor_type;
     }
     auto type = old_tensor_type;

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.h
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.h
@@ -5,6 +5,8 @@
 namespace torch {
 namespace jit {
 
+TORCH_API TypePtr MergeInferredType(TypePtr existing_type, TypePtr inferred_type);
+
 // Utilize ONNX Shape Inference for node.
 // The node must have ONNX namespace, and is valid ONNX node accroding to spec.
 // On successful ONNX shape inference runs, the function updates output types of

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.h
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.h
@@ -5,7 +5,8 @@
 namespace torch {
 namespace jit {
 
-TORCH_API TypePtr MergeInferredType(TypePtr existing_type, TypePtr inferred_type);
+TORCH_API TypePtr
+MergeInferredType(TypePtr existing_type, TypePtr inferred_type);
 
 // Utilize ONNX Shape Inference for node.
 // The node must have ONNX namespace, and is valid ONNX node accroding to spec.

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/serialization/export.h>
 #include <torch/csrc/autograd/symbolic.h>
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/serialization/import_export_constants.h>
 #include <torch/csrc/jit/serialization/import_export_functions.h>
 #include <torch/csrc/jit/serialization/import_export_helpers.h>
@@ -315,30 +316,50 @@ void EncoderBase::EncodeValueInfo(
         std::unordered_map<int64_t, std::string>>& dynamic_axes) {
   std::string name = n->debugName();
   v->set_name(name);
-  if (TensorTypePtr node_type = n->type()->cast<TensorType>()) {
-    if (!node_type->isComplete()) {
-      return;
-    }
-    onnx::TypeProto* t = v->mutable_type();
-    onnx::TypeProto_Tensor* tensor_type = t->mutable_tensor_type();
-    onnx::TensorShapeProto* shape = tensor_type->mutable_shape();
-    std::vector<std::int64_t> sizes =
-        node_type->sizes().concrete_sizes().value();
-    for (size_t i = 0; i < sizes.size(); i++) {
-      shape->add_dim();
-      if ((dynamic_axes.find(name) != dynamic_axes.end()) &&
-          (dynamic_axes.at(name).find(i) != dynamic_axes.at(name).end())) {
-        shape->mutable_dim(i)->set_dim_param(dynamic_axes.at(name).at(i));
-      } else {
-        shape->mutable_dim(i)->set_dim_value(sizes[i]);
+  auto tensorTypeToONNXType = [&dynamic_axes, &name](
+                                  TensorTypePtr t,
+                                  onnx::TypeProto_Tensor* tensor_type) {
+    if (t->sizes().isComplete()) {
+      // onnx::TypeProto* onnx_type = v->mutable_type();
+      // onnx::TypeProto_Tensor* tensor_type = onnx_type->mutable_tensor_type();
+      onnx::TensorShapeProto* shape = tensor_type->mutable_shape();
+      std::vector<std::int64_t> sizes = t->sizes().concrete_sizes().value();
+      for (size_t i = 0; i < sizes.size(); i++) {
+        shape->add_dim();
+        if ((dynamic_axes.find(name) != dynamic_axes.end()) &&
+            (dynamic_axes.at(name).find(i) != dynamic_axes.at(name).end())) {
+          shape->mutable_dim(i)->set_dim_param(dynamic_axes.at(name).at(i));
+        } else {
+          shape->mutable_dim(i)->set_dim_value(sizes[i]);
+        }
       }
     }
-    tensor_type->set_elem_type(
-        ATenTypeToOnnxType(node_type->scalarType().value()));
+    if (t->scalarType()) {
+      // onnx::TypeProto* onnx_type = v->mutable_type();
+      // onnx::TypeProto_Tensor* tensor_type = onnx_type->mutable_tensor_type();
+      tensor_type->set_elem_type(ATenTypeToOnnxType(t->scalarType().value()));
+    }
+  };
+
+  if (TensorTypePtr node_type = n->type()->cast<TensorType>()) {
+    if (node_type->sizes().isComplete() || node_type->scalarType()) {
+      onnx::TypeProto* onnx_type = v->mutable_type();
+      onnx::TypeProto_Tensor* tensor_type = onnx_type->mutable_tensor_type();
+      tensorTypeToONNXType(node_type, tensor_type);
+    }
   } else if (BoolTypePtr node_type = n->type()->cast<BoolType>()) {
-    onnx::TypeProto* t = v->mutable_type();
-    onnx::TypeProto_Tensor* tensor_type = t->mutable_tensor_type();
+    onnx::TypeProto* onnx_type = v->mutable_type();
+    onnx::TypeProto_Tensor* tensor_type = onnx_type->mutable_tensor_type();
     tensor_type->set_elem_type(ATenTypeToOnnxType(at::kBool));
+  } else if (ListTypePtr list_type = n->type()->cast<ListType>()) {
+    auto elem_type = list_type->getElementType();
+    if (TensorTypePtr inner_node_type = elem_type->cast<TensorType>()) {
+      onnx::TypeProto* onnx_type = v->mutable_type();
+      onnx::TypeProto_Sequence* sequence_type = onnx_type->mutable_sequence_type();
+      onnx::TypeProto_Tensor* tensor_type =
+          sequence_type->mutable_elem_type()->mutable_tensor_type();
+      tensorTypeToONNXType(inner_node_type, tensor_type);
+    }
   }
 }
 
@@ -865,6 +886,7 @@ std::tuple<std::string, RawDataExportMap> export_onnx(
       proto_size <= INT_MAX,
       "Exporting model exceed maximum protobuf size of 2GB. "
       "Please call torch.onnx.export with use_external_data_format=True.");
+  GRAPH_UPDATE("onnx proto:", prettyPrint(graph_encoder.get_model_proto()));
   return std::make_tuple(
       graph_encoder.get_model_proto().SerializeAsString(),
       graph_encoder.get_raw_data_export_map());

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -355,7 +355,8 @@ void EncoderBase::EncodeValueInfo(
     auto elem_type = list_type->getElementType();
     if (TensorTypePtr inner_node_type = elem_type->cast<TensorType>()) {
       onnx::TypeProto* onnx_type = v->mutable_type();
-      onnx::TypeProto_Sequence* sequence_type = onnx_type->mutable_sequence_type();
+      onnx::TypeProto_Sequence* sequence_type =
+          onnx_type->mutable_sequence_type();
       onnx::TypeProto_Tensor* tensor_type =
           sequence_type->mutable_elem_type()->mutable_tensor_type();
       tensorTypeToONNXType(inner_node_type, tensor_type);

--- a/torch/csrc/jit/serialization/onnx.cpp
+++ b/torch/csrc/jit/serialization/onnx.cpp
@@ -58,8 +58,26 @@ void dump(const onnx::TypeProto_Tensor& tensor_type, std::ostream& stream) {
   }
 }
 
+void dump(const onnx::TypeProto& type, std::ostream& stream);
+
+void dump(const onnx::TypeProto_Sequence& sequence_type, std::ostream& stream) {
+  stream << "Sequence<";
+  if (sequence_type.has_elem_type()) {
+    dump(sequence_type.elem_type(), stream);
+  } else {
+    stream << "None";
+  }
+  stream << ">";
+}
+
 void dump(const onnx::TypeProto& type, std::ostream& stream) {
-  dump(type.tensor_type(), stream);
+  if (type.has_tensor_type()) {
+    dump(type.tensor_type(), stream);
+  } else if (type.has_sequence_type()) {
+    dump(type.sequence_type(), stream);
+  } else {
+    stream << "None";
+  }
 }
 
 void dump(const onnx::ValueInfoProto& value_info, std::ostream& stream) {

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -173,7 +173,7 @@ def _is_value(x):
 
 
 def _is_tensor_list(x):
-    return x.type().isSubtypeOf(ListType.ofTensors())
+    return isinstance(x.type(), torch._C.ListType) and isinstance(x.type().getElementType(), torch._C.TensorType)
 
 
 def _unimplemented(op, msg):
@@ -317,7 +317,7 @@ def _get_interpolate_attributes(g, mode, args):
 
 def _interpolate_get_scales(g, scale_factor, dim):
     offsets = g.op("Constant", value_t=torch.ones(2, dtype=torch.float32))
-    if isinstance(scale_factor.type(), torch._C.ListType):
+    if isinstance(scale_factor.type(), torch._C.ListType) or (scale_factor.isCompleteTensor() and scale_factor.type().dim() > 0):
         return g.op("Concat", offsets, scale_factor, axis_i=0)
     else:
         scale_factor = _unsqueeze_helper(g, scale_factor, 0)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import torch
-from torch._C import ListType
 import warnings
 from sys import maxsize as maxsize
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -277,7 +277,7 @@ def _len(g, self):
 
 
 def __getitem_(g, self, i):
-    if self.type().isSubtypeOf(torch._C.ListType.ofTensors()):
+    if sym_help._is_tensor_list(self):
         # SequenceAt requires that the input be a List of Tensors
         return g.op("SequenceAt", self, i)
     else:

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -154,13 +154,13 @@ def true_divide(g, self, other):
     # Case 2: self is floating, other is not
     # Casts other to self's dtype
     if sym_help._is_fp(self):
-        g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
         return div(g, self, other)
 
     # Case 3: other is floating, self is not
     # Casts self to other's dtype
     if sym_help._is_fp(other):
-        g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[other.type().scalarType()])
+        self = g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx[other.type().scalarType()])
         return div(g, self, other)
 
     # Case 4: neither is floating
@@ -171,8 +171,8 @@ def true_divide(g, self, other):
     if torch.get_default_dtype() is torch.double:
         onnx_scalar_type = sym_help.cast_pytorch_to_onnx['Double']
 
-    g.op("Cast", self, to_i=onnx_scalar_type)
-    g.op("Cast", other, to_i=onnx_scalar_type)
+    self = g.op("Cast", self, to_i=onnx_scalar_type)
+    other = g.op("Cast", other, to_i=onnx_scalar_type)
     return div(g, self, other)
 
 
@@ -1540,12 +1540,12 @@ def tensor(g, data, dtype=None, device=None, requires_grad=False):
         if dtype is None:
             dtype = sym_help._unpack_list(data)[0].type().scalarType()
             dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
-        input_list = list()   
+        input_list = list()
         for t in sym_help._unpack_list(data):
             shape_reference = g.op("Constant", value_t=torch.LongTensor([1]))
             t = g.op("Reshape", t, shape_reference)
             t = g.op("Cast", t, to_i=sym_help.scalar_type_to_onnx[dtype])
-            input_list.append(t)    
+            input_list.append(t)
         return g.op("Concat", *input_list, axis_i=0)
     else:
         if dtype is None:
@@ -2222,7 +2222,7 @@ def _std(g, input, dim, unbiased, keepdim):
 # torch.std(input, unbiased=True)
 # torch.std(input, dim, keepdim=False, unbiased=True)
 def std(g, input, *args):
-    if args[0].type().isSubtypeOf(ListType.ofInts()):
+    if len(args) == 3:
         return _std(g, input, *args)
     else:
         return _std(g, input, None, args[0], None)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -889,9 +889,8 @@ def _run_symbolic_function(g, n, inputs, env, operator_export_type=OperatorExpor
                     # Copy input metadata to subblock
                     # This is for Loop only, since If only has a single input.
                     for i, b_in in enumerate(b.inputs()):
-                        if i < 1:
-                            continue
-                        b_in.setType(n.inputsAt(i + 1).type())
+                        if i > 0 and (i + 1) < len(inputs):
+                            b_in.setType(inputs[i + 1].type())
                     torch._C._jit_pass_onnx_block(b, new_block, operator_export_type, env)
                 new_op_outputs = torch._C._jit_pass_fixup_onnx_controlflow_node(new_node, opset_version)
                 # Process Loop and If after subblock is converted.

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -886,6 +886,12 @@ def _run_symbolic_function(g, n, inputs, env, operator_export_type=OperatorExpor
                 new_node = new_op_outputs[0].node() if n.outputsSize() > 1 else new_op_outputs.node()
                 for b in n.blocks():
                     new_block = new_node.addBlock()
+                    # Copy input metadata to subblock
+                    # This is for Loop only, since If only has a single input.
+                    for i, b_in in enumerate(b.inputs()):
+                        if i < 1:
+                            continue
+                        b_in.setType(n.inputsAt(i + 1).type())
                     torch._C._jit_pass_onnx_block(b, new_block, operator_export_type, env)
                 new_op_outputs = torch._C._jit_pass_fixup_onnx_controlflow_node(new_node, opset_version)
                 # Process Loop and If after subblock is converted.


### PR DESCRIPTION
* Support sequence type (de)serialization, enables onnx shape inference on sequence nodes.
* Fix shape inference with block input/output: e.g. Loop and If nodes.
* Fix bugs in symbolic discovered by coverage of onnx shape inference.
* Improve debuggability: added more jit logs. For simplicity, the default log level, when jit log is enabled, will not dump ir graphs. 