### PR TITLE
Support capturing global value in TorchScript

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -33,6 +33,7 @@ namespace c10 {
   _(prim, Eval)                      \
   _(prim, Expand) /* onnx */         \
   _(prim, FusionGroup)               \
+  _(prim, CapturedGlobalConstVal)    \
   _(prim, CudaFusionGroup)           \
   _(prim, FunctionalGraph)           \
   _(prim, DifferentiableGraph)       \

--- a/test/jit/global_test_lib.py
+++ b/test/jit/global_test_lib.py
@@ -1,0 +1,27 @@
+import torch
+
+
+global_var = None 
+
+
+def set_global_var(v: str):
+    global global_var
+    global_var = v
+
+
+def set_global_var_and_capture(v: str):
+    global global_var
+    global_var = v
+    torch.jit.capture_global_constant_value("global_var")
+
+
+def reset():
+    global global_var
+    global_var = None
+    torch.jit.reset_captured_global_constant_values_registry()
+
+
+def use_global_var():
+    global global_var
+    localized_var: str = str(global_var)
+    return localized_var

--- a/test/jit/test_global.py
+++ b/test/jit/test_global.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+import torch
+
+from . import global_test_lib
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestGlobal(JitTestCase):
+    # This test must not be split into different test cases because it tests
+    # handling of global variable manipulations, which isn't parallel-safe.
+    def test_global(self):
+        # Test case where global variable is not captured.
+        global_test_lib.reset()
+        global_test_lib.set_global_var("foo")
+
+        scripted = torch.jit.script(global_test_lib.use_global_var)
+        with self.assertRaisesRegexWithHighlight(RuntimeError, "not found in CapturedGlobalValuesRegistry", "global_var"):
+            scripted()
+
+        # Test case where global variable is captured
+        global_test_lib.reset()
+        global_test_lib.set_global_var_and_capture("foo")
+        scripted = torch.jit.script(global_test_lib.use_global_var)
+        self.assertEqual(scripted(), "foo")
+
+        # Test update previously captured global variable is supported
+        global_test_lib.set_global_var_and_capture("bar")
+        self.assertEqual(scripted(), "bar")

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -32,6 +32,7 @@ from jit.test_onnx_export import TestONNXExport  # noqa: F401
 from jit.test_with import TestWith  # noqa: F401
 from jit.test_enum import TestEnum, TestEnumFeatureGuard  # noqa: F401
 from jit.test_profiler import TestProfiler  # noqa: F401
+from jit.test_global import TestGlobal  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -216,6 +216,7 @@ core_sources_full = [
     "torch/csrc/jit/python/update_graph_executor_opt.cpp",
     "torch/csrc/jit/runtime/argument_spec.cpp",
     "torch/csrc/jit/runtime/autodiff.cpp",
+    "torch/csrc/jit/runtime/captured_global_values_registry.cpp",
     "torch/csrc/jit/runtime/graph_executor.cpp",
     "torch/csrc/jit/runtime/interpreter.cpp",
     "torch/csrc/jit/runtime/logging.cpp",

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -582,7 +582,7 @@ struct Global : public Stmt {
   explicit Global(const TreeRef& tree) : Stmt(tree) {
     tree_->match(TK_GLOBAL);
   }
-  List<Ident> names() {
+  List<Ident> names() const {
     return List<Ident>(subtree(0));
   }
   static Global create(const SourceRange& range, const List<Ident>& names) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -72,6 +72,7 @@
 #include <torch/csrc/jit/python/script_init.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
 #include <torch/csrc/jit/runtime/autodiff.h>
+#include <torch/csrc/jit/runtime/captured_global_values_registry.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/jit_exception.h>
 #include <torch/csrc/jit/runtime/operator.h>

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -283,7 +283,10 @@ void initTreeViewBindings(PyObject* module) {
   py::class_<ExprStmt, Stmt>(m, "ExprStmt").def(py::init([](const Expr& expr) {
     return ExprStmt::create(expr.range(), expr);
   }));
-
+  py::class_<Global, Stmt>(m, "Global")
+      .def(py::init([](const SourceRange& range, std::vector<Ident>& names) {
+        return Global::create(range, wrap_list(range, std::move(names)));
+      }));
   py::class_<Var, Expr>(m, "Var")
       .def(py::init(
           [](const Ident& name) { return Var::create(name.range(), name); }))

--- a/torch/csrc/jit/runtime/captured_global_values_registry.cpp
+++ b/torch/csrc/jit/runtime/captured_global_values_registry.cpp
@@ -1,0 +1,39 @@
+#include <torch/csrc/jit/runtime/captured_global_values_registry.h>
+
+#include <aten/src/ATen/core/ivalue.h>
+#include <iostream>
+#include <stdexcept>
+
+namespace torch {
+namespace jit {
+
+CapturedGlobalValuesRegistry& CapturedGlobalValuesRegistry::get() {
+  static CapturedGlobalValuesRegistry registry;
+  return registry;
+}
+
+c10::IValue CapturedGlobalValuesRegistry::getValueOrThrow(
+    const std::string& name) const {
+  auto it = registry_.find(name);
+  if (it == registry_.end()) {
+    throw(std::runtime_error(
+        name + " is not found in CapturedGlobalValuesRegistry, " +
+        "did you capture its value with " +
+        "torch.jit.capture_global_constant_value()?"));
+  }
+  return it->second;
+}
+
+void CapturedGlobalValuesRegistry::registerValue(
+    const std::string& name,
+    c10::IValue value) {
+  // Permit overwrite to support value update.
+  registry_[name] = std::move(value);
+}
+
+void CapturedGlobalValuesRegistry::clear() {
+  registry_.clear();
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/runtime/captured_global_values_registry.h
+++ b/torch/csrc/jit/runtime/captured_global_values_registry.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <aten/src/ATen/core/ivalue.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace torch {
+namespace jit {
+
+// Class of a global singleton registry that maintains a mapping from the fully
+// qualified name of a global variable to its captured value (in form of IValue)
+class CapturedGlobalValuesRegistry {
+ public:
+  // Get global singleton registry.
+  TORCH_API static CapturedGlobalValuesRegistry& get();
+
+  // Look up captured global value by name. If not found, throw runtime_error.
+  c10::IValue getValueOrThrow(const std::string& name) const;
+
+  // Add or update a value by name.
+  TORCH_API void registerValue(const std::string& name, c10::IValue value);
+
+  // Clear registry;
+  TORCH_API void clear();
+
+  CapturedGlobalValuesRegistry(const CapturedGlobalValuesRegistry&) = delete;
+  CapturedGlobalValuesRegistry(CapturedGlobalValuesRegistry&&) = delete;
+  CapturedGlobalValuesRegistry& operator=(const CapturedGlobalValuesRegistry&) =
+      delete;
+  CapturedGlobalValuesRegistry& operator=(CapturedGlobalValuesRegistry&&) =
+      delete;
+
+ private:
+  CapturedGlobalValuesRegistry() = default;
+
+  std::unordered_map<std::string, c10::IValue> registry_;
+};
+
+} // namespace jit
+} // namespace torch

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -24,6 +24,8 @@ from torch.jit._script import (
     CompilationUnit,
     ScriptFunction,
     _unwrap_optional,
+    capture_global_constant_value,
+    reset_captured_global_constant_values_registry,
 )
 from torch.jit._trace import (
     trace,

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1074,5 +1074,26 @@ def _unwrap_optional(x):
     return x
 
 
+def capture_global_constant_value(name):
+    call_stack = inspect.stack()
+    caller_frame = inspect.stack()[1]
+    caller_module = inspect.getmodule(caller_frame[0])
+
+    if not hasattr(caller_module, name):
+        raise RuntimeError(caller_module.__name__ + " doesn't have a global variable named: " + name)
+    value = getattr(caller_module, name)
+
+    if caller_module.__name__.startswith("__main__"):
+        normalized_module_name = "__torch__" + caller_module.__name__[len("__main__")]
+    else:
+        normalized_module_name = "__torch__." + caller_module.__name__
+
+    torch._C._capture_global_const_value(normalized_module_name + "." + name, value)
+
+
+def reset_captured_global_constant_values_registry():
+    torch._C._reset_captured_global_constant_values_registry()
+
+
 _register_builtin(_unwrap_optional, "aten::_unwrap_optional")
 _register_builtin(_jit_internal.is_scripting, "aten::is_scripting")


### PR DESCRIPTION
- Allows user to declare a global variable value as "captured" so that it is usable inside a torchscript function.
- Maintains a global singleton registry that keeps track of captured values at *runtime*. In other words, at compile time, no value is captured, just an Any-typed placeholder value.

A canonical usage example:

import torch

global_var = None 

def set_global_var_and_capture(v: str):
    global global_var
    global_var = v
    torch.jit.capture_global_constant_value("global_var")

def use_global_var():
    global global_var
    localized_var: str = str(global_var) #  <-- Assign to local var with cast to get actual type
    return localized_var

- Fixes #43397


