### PR TITLE
Add "torch/testing/_internal/data/*.pt" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ torch/nn/functional.pyi
 torch/csrc/autograd/generated/*
 # Listed manually because some files in this directory are not generated
 torch/testing/_internal/generated/annotated_fn_args.py
+torch/testing/_internal/data/*.pt
 torch/csrc/cudnn/cuDNN.cpp
 torch/csrc/generated
 torch/csrc/generic/TensorMethods.cpp


### PR DESCRIPTION
I usually get this extra "legacy_conv2d.pt" file in my git "changed files". I found that this is from tests with `download_file`
https://github.com/pytorch/pytorch/blob/42c895de4d3a8ea539c26473b761e49ff7309996/test/test_nn.py#L410-L426

and its definition (see `data_dir` for download output location)
https://github.com/pytorch/pytorch/blob/f17d7a5556940156b81b595bb39783192ba1e16f/torch/testing/_internal/common_utils.py#L1338-L1357

I assume a file "generated" by test should not be tracked in VCS? Also, if the file is updated on the server, users may still use the old version of it if they have already downloaded that before. 