### PR TITLE
Use NewCriterionTest in test_cpp_api_parity.py.

### DIFF
--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -30,7 +30,7 @@ for test_params_dicts, test_instance_class in [
     (sample_functional.functional_tests, common_nn.NewModuleTest),
     (common_nn.module_tests, common_nn.ModuleTest),
     (common_nn.new_module_tests, common_nn.NewModuleTest),
-    (common_nn.criterion_tests, common_nn.CriterionTest),
+    (common_nn.criterion_tests, common_nn.NewCriterionTest),
     (common_nn.new_criterion_tests, common_nn.NewCriterionTest),
 ]:
     for test_params_dict in test_params_dicts:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43956 Kill dead code in common_nn as part of merging Criterion and NewCriterionTests.
* **#43954 Use NewCriterionTest in test_cpp_api_parity.py.**

CriterionTest is basically dead -- see https://github.com/pytorch/pytorch/pull/43769 and https://github.com/pytorch/pytorch/pull/43776.

The only exception is the cpp parity test, but the difference there doesn't actually have any effect -- the get_target has unpack=True, but all examples don't require unpacking (I checked).

As a pre-requisite for merging these tests, have the cpp parity test start using the NewCriterionTest.

Differential Revision: [D23452144](https://our.internmc.facebook.com/intern/diff/D23452144)