### PR TITLE
introduce torch.fx.is_tracing() for gating tracing-incompatible module logic

### DIFF
--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -86,7 +86,7 @@ Because this code is valid PyTorch code, the resulting `GraphModule` can be used
 '''
 
 from .graph_module import GraphModule
-from .symbolic_trace import symbolic_trace, DefaultDelegate
+from .symbolic_trace import symbolic_trace, DefaultDelegate, is_tracing
 from .graph import Graph, map_arg
 from .node import Node
 from .proxy import Proxy


### PR DESCRIPTION
Summary: Modules sometimes are written with sanity-checking logic that can be incompatible with symbolic tracing, e.g. `isinstance(t, torch.Tensor)` or things that invoke anti-control-flow behavior like `assert len(t)`. Generally it's save to ignore these during a trace, so `torch.fx.is_tracing()` can be used to gate this behavior much like with `torch.jit.is_scripting()`.

Test Plan: Manually tested on a module that had sanity-checking behavior that normally fails a trace. Please let me know where the best place to put a unit test is if desired.

Differential Revision: D23451666

