### PR TITLE
[Do not commit] Fuser: do not try to merge adjacent fusion groups.

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -403,7 +403,7 @@ class TensorExprFuser {
         debugDumpFusionGroup(
             "Trying to merge into the previous fusion group: ",
             prev_fusion_group);
-        if (canMerge(prev_fusion_group, fusion_group)) {
+        if (false && canMerge(prev_fusion_group, fusion_group)) {
           prev_fusion_group = tryMerge(prev_fusion_group, fusion_group);
           debugDumpFusionGroup(
               "Successfully merged into the previous fusion group: ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43814 Add current results.
* #44067 [Do not commit] Undo fusion groups with no tensor inputs.
* **#43979 [Do not commit] Fuser: do not try to merge adjacent fusion groups.**
* #43978 [Do not commit] Fuser: don't fuse ops with scalar inputs.
* #43968 [Do not commit] Nick's PR for function calls integration.
* #43933 [Do not commit] Alias analysis assertion failure fix.
* #43810 Set number of profiling runs to 2 in benchmarks.
* #43826 [Do not commit] Do not fail when dumping backwards graph via PYTORCH_JIT_LOG_LEVEL=graph_executor.
* #43825 [Do not commit] Remove profile nodes before BatchMM.
* #43802 [Do not commit][TensorExpr] Fuser: try merging adjacent fusion groups.
* #43801 Benchmarks: add standalone RNN benchmarks.

