### PR TITLE
Optimize code path for adaptive_avg_pool2d when output size is (1, 1)

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -333,8 +333,8 @@ namespace {
       // in this case, adaptive pooling is just computing mean over hw
       // dimensions, which can be done more efficiently
       Tensor out = input.mean({-1, -2});
-      return input.dim() == 3 ? out.view({input.size(0), 1, 1})
-                              : out.view({input.size(0), input.size(1), 1, 1});
+      return input.dim() == 3 ? out.resize_({input.size(0), 1, 1}, input.suggest_memory_format())
+                              : out.resize_({input.size(0), input.size(1), 1, 1}, input.suggest_memory_format());
     } else {
       return _adaptive_avg_pool2d(input, output_size);
     }

--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -329,12 +329,10 @@ namespace {
       return at::mkldnn_adaptive_avg_pool2d(input, output_size);
     }
 
-    // TODO: fastpath for Channels_last should be explored later;
-    if (input.suggest_memory_format() == at::MemoryFormat::Contiguous && !input.is_quantized() && output_size[0] == 1 && output_size[1] == 1) {
+    if (!input.is_quantized() && output_size[0] == 1 && output_size[1] == 1) {
       // in this case, adaptive pooling is just computing mean over hw
       // dimensions, which can be done more efficiently
-      int64_t mean_size = input.size(-1) * input.size(-2);
-      Tensor out = input.contiguous().view({-1, mean_size}).mean(-1);
+      Tensor out = input.mean({-1, -2});
       return input.dim() == 3 ? out.view({input.size(0), 1, 1})
                               : out.view({input.size(0), input.size(1), 1, 1});
     } else {

--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -332,14 +332,12 @@ namespace {
     if (!input.is_quantized() && output_size[0] == 1 && output_size[1] == 1) {
       // in this case, adaptive pooling is just computing mean over hw
       // dimensions, which can be done more efficiently
-      Tensor out = input.mean({-1, -2});
-      const int n = input.size(0);
-      const int c = input.size(1);
-      const int ndim = input.dim();
-      out = (ndim == 3) ? out.view({n, 1, 1}) : out.view({n, c, 1, 1});
+      Tensor out = input.mean({-1, -2}, /* keepdim = */ true);
       if (input.suggest_memory_format() == at::MemoryFormat::ChannelsLast) {
-        out.unsafeGetTensorImpl()->set_stride(ndim-1, c);
-        out.unsafeGetTensorImpl()->set_stride(ndim-2, c);
+        // assert ndim == 4, since ndim = 3 doesn't give channels_last
+        const int n = input.size(0);
+        const int c = input.size(1);
+        out.as_strided_({n, c, 1, 1}, {c, 1, c, c});
       }
       return out;
     } else {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9815,7 +9815,7 @@ class TestNNDeviceType(NNTestCase):
 
     def test_adaptive_avg_pool2d_output_size_one(self, device):
         def helper(size, memory_format):
-            x = torch.randint(1, 10, size, dtype=torch.float, device=device)
+            x = torch.randint(1, 10, size, dtype=torch.float, device=device, requires_grad=True)
             if memory_format == 'non_contiguous':
                 x = x[::2, ::2, ::2, ::2]
             else:
@@ -9824,6 +9824,8 @@ class TestNNDeviceType(NNTestCase):
             net = torch.nn.AdaptiveAvgPool2d((1, 1))
             out = net(x)
             ref_out = x.contiguous().mean((-1, -2)).view((x.size(0), x.size(1), 1, 1))
+
+            out.sum().backward()    # make sure it doesn't crash
 
             self.assertEqual(out, ref_out)
             if memory_format == torch.channels_last:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9813,6 +9813,7 @@ class TestNNDeviceType(NNTestCase):
         test('threshold', 3, 2)
         test('threshold', 3, 2, inplace=True)
 
+    @onlyOnCPUAndCUDA   # TODO: fix on XLA
     def test_adaptive_avg_pool2d_output_size_one(self, device):
         def helper(size, memory_format):
             x = torch.randint(1, 10, size, dtype=torch.float, device=device, requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9823,9 +9823,7 @@ class TestNNDeviceType(NNTestCase):
 
             net = torch.nn.AdaptiveAvgPool2d((1, 1))
             out = net(x)
-            ref_out = x.mean((-1, -2)).view((x.size(0), x.size(1), 1, 1))
-            if device == 'cuda':
-                torch.cuda.synchronize()
+            ref_out = x.contiguous().mean((-1, -2)).view((x.size(0), x.size(1), 1, 1))
 
             self.assertEqual(out, ref_out)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9826,6 +9826,14 @@ class TestNNDeviceType(NNTestCase):
             ref_out = x.contiguous().mean((-1, -2)).view((x.size(0), x.size(1), 1, 1))
 
             self.assertEqual(out, ref_out)
+            if memory_format == torch.channels_last:
+                self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+                c = out.size(1)
+                self.assertEqual(out.stride(), [c, 1, c, c])
+            else:
+                self.assertTrue(out.is_contiguous())
+                c = out.size(1)
+                self.assertEqual(out.stride(), [c, 1, 1, 1])
 
         for mf in (torch.contiguous_format, torch.channels_last, 'non_contiguous'):
             helper((2, 3, 6, 6), mf)


### PR DESCRIPTION
Benchmark: 

code: https://github.com/xwang233/code-snippet/blob/master/adaptive-avg-pool2d-output-1x1/adap.ipynb

| shape | time_before (ms) | time_after (ms) |
| --- | --- | --- | 
| (2, 3, 4, 4), torch.contiguous_format, cpu  |  0.035 |  0.031 | 
| (2, 3, 4, 4), torch.contiguous_format, cuda  |  0.041 |  0.031 | 
| (2, 3, 4, 4), torch.channels_last, cpu  |  0.027 |  0.029 | 
| (2, 3, 4, 4), torch.channels_last, cuda  |  0.031 |  0.034 | 
| (2, 3, 4, 4), non_contiguous, cpu  |  0.037 |  0.026 | 
| (2, 3, 4, 4), non_contiguous, cuda  |  0.062 |  0.033 | 
| (4, 16, 32, 32), torch.contiguous_format, cpu  |  0.063 |  0.055 | 
| (4, 16, 32, 32), torch.contiguous_format, cuda  |  0.043 |  0.031 | 
| (4, 16, 32, 32), torch.channels_last, cpu  |  0.052 |  0.064 | 
| (4, 16, 32, 32), torch.channels_last, cuda  |  0.190 |  0.033 | 
| (4, 16, 32, 32), non_contiguous, cpu  |  0.048 |  0.035 | 
| (4, 16, 32, 32), non_contiguous, cuda  |  0.062 |  0.033 | 
| (8, 128, 64, 64), torch.contiguous_format, cpu  |  0.120 |  0.109 | 
| (8, 128, 64, 64), torch.contiguous_format, cuda  |  0.043 |  0.044 | 
| (8, 128, 64, 64), torch.channels_last, cpu  |  1.303 |  0.260 | 
| (8, 128, 64, 64), torch.channels_last, cuda  |  1.237 |  0.049 | 
| (8, 128, 64, 64), non_contiguous, cpu  |  0.132 |  0.128 | 
| (8, 128, 64, 64), non_contiguous, cuda  |  0.062 |  0.031 | 
| (16, 256, 224, 224), torch.contiguous_format, cpu  |  17.232 |  14.807 | 
| (16, 256, 224, 224), torch.contiguous_format, cuda  |  1.930 |  1.930 | 
| (16, 256, 224, 224), torch.channels_last, cpu  |  245.025 |  24.345 | 
| (16, 256, 224, 224), torch.channels_last, cuda  |  15.593 |  1.944 | 
| (16, 256, 224, 224), non_contiguous, cpu  |  11.738 |  6.460 | 
| (16, 256, 224, 224), non_contiguous, cuda  |  0.524 |  0.251 | 
