### PR TITLE
[JIT] Always map node output in vmap

### DIFF
--- a/test/cpp/jit/test_subgraph_utils.cpp
+++ b/test/cpp/jit/test_subgraph_utils.cpp
@@ -81,9 +81,10 @@ graph(%a : Tensor, %b : Tensor, %c : Tensor):
   std::unordered_map<Value*, Value*> vmap2;
   Value* new_tanh_out = new_tanh->output();
   SubgraphUtils::mergeNodeIntoSubgraph(subgraph1, subgraph2, vmap2);
-  // vmap should have 4 entries, since we moved 4 values into the graph (the
+  // vmap should have 6 entries, since we moved 4 values into the graph (the
   // values correspond to the original values '%a', '%b', '%x', and '%y').
-  ASSERT_EQ(vmap2.size(), 4);
+  // and we map the node outputs for '%x' and '%y'
+  ASSERT_EQ(vmap2.size(), 6);
 
   // Check that after mergeNodeIntoSubgraph we can still access the node
   // corresponding to the original node, even if the toMerge node had a subgraph

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -18,6 +18,13 @@ void mergeSubgraph(
   Node* nodeBeforeMergeFrom = mergeFrom->prev();
   Node* nodeAfterMergeFrom = mergeFrom->next();
 
+  // will be used later to map the node outputs -> new subgraph values
+  std::unordered_map<Value*, Value*> node_outputs_to_subgraph_values;
+  for (size_t i = 0; i < mergeFrom->outputs().size(); ++i) {
+    node_outputs_to_subgraph_values[mergeFrom->output(i)] =
+        getSubgraph(mergeFrom)->outputs().at(i);
+  }
+
   // unmerge_map will contain mapping from values from the mergeTo's subgraph
   // (we will call them "original" values) to the corresponding values that we
   // created in the main graph (we will call them "unmerged" values) as we
@@ -49,6 +56,11 @@ void mergeSubgraph(
     } else {
       vmap[kv.first] = kv.second;
     }
+  }
+
+  // fill the value mapping with node output -> new subgraph value
+  for (const auto& mapping : node_outputs_to_subgraph_values) {
+    vmap[mapping.first] = vmap[mapping.second];
   }
 }
 

--- a/torch/csrc/jit/passes/utils/subgraph_utils.h
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.h
@@ -18,7 +18,8 @@ namespace SubgraphUtils {
 // `n` is destroyed.
 //
 // Returns the new subgraph node.
-// An optional argument 'vmap' could be used to retrieve value mappings.
+// An optional argument 'vmap' could be used to retrieve value mappings
+// Values will be mapped to their new subgraph values
 TORCH_API Node* createSingletonSubgraph(Node* n, Symbol subgraphKind);
 TORCH_API Node* createSingletonSubgraph(
     Node* n,
@@ -29,6 +30,7 @@ TORCH_API Node* createSingletonSubgraph(
 // subgraphs are merged.
 // `toMerge` is destroyed.
 // An optional argument 'vmap' could be used to retrieve value mappings.
+// Values will be mapped to their new subgraph values
 TORCH_API void mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode);
 TORCH_API void mergeNodeIntoSubgraph(
     Node* toMerge,


### PR DESCRIPTION
Previously when merging a node without a subgraph, we would merge the node's outputs to the corresponding subgraph values, but when merging a node with a subgraph the node's outputs would be absent in the value mapping. This PR makes it so they are included. 