### PR TITLE
Add iterator like functionality for DispatchKeySet

### DIFF
--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -111,6 +111,44 @@ public:
 private:
   DispatchKeySet(uint64_t repr) : repr_(repr) {}
   uint64_t repr_ = 0;
+
+public:
+  // STL iterator for DispatchKeySet. Iterates from the first DispatchKey to the
+  // NumDispatchKey enum. The iterate is only invalidated by the destruction of
+  // the underlying DispatchKeySet as the iterator stores a pointer to the raw
+  // represenation of the DispatchKeySet.
+  class iterator {
+   public:
+    using self_type = iterator;
+    using iterator_category = std::input_iterator_tag;
+    using value_type = bool;
+    using difference_type = ptrdiff_t;
+    using pointer = const bool*;
+    using reference = const bool&;
+
+    iterator(uint64_t *data_ptr, uint8_t i=1) : data_ptr_(data_ptr), i_(i) {}
+
+    self_type& operator++() { i_++; return *this; }
+    self_type operator++(int) { self_type i =  *this; i_++; return i; }
+
+    bool operator==(const self_type& rhs) const {return i_ == rhs.i_; }
+    bool operator!=(const self_type& rhs) const {return i_ != rhs.i_; }
+    bool operator*() const {return static_cast<bool> (*data_ptr_ & 1ULL << (i_ - 1)); }
+
+   private:
+    uint64_t *data_ptr_;
+    uint8_t i_;
+  };
+
+ public:
+  // DispatchKey ID of 0 is undefined and cannot be set, so the iterator starts
+  // at the 1st DispatchKey rather than the 0th.
+  iterator begin() const {return iterator(&repr_, 1);}
+
+  // We do not need to iterate beyond NumDispatchKeys so we will treat this as
+  // the end. NumDispatchKeys will always be strictly less than 64.
+  iterator end() const {return iterator(&repr_, static_cast<uint8_t>(DispatchKey::NumDispatchKeys));}
+
 };
 
 C10_API std::string toString(DispatchKeySet);

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -53,3 +53,37 @@ TEST(DispatchKeySet, Full) {
     ASSERT_TRUE(full.has(tid));
   }
 }
+
+TEST(DispatchKeySet, IteratorBasicOps) {
+  DispatchKeySet empty_set;
+  DispatchKeySet full_set(DispatchKeySet::FULL);
+  DispatchKeySet mutated_set = empty_set.add(static_cast<DispatchKey>(1));
+  auto it_begin = empty_set.begin();
+  auto it_end = empty_set.end();
+
+  // Dereference Op
+  ASSERT_EQ(*it_begin, false);
+  ASSERT_TRUE(*full_set.begin());
+  ASSERT_TRUE(*mutated_set.begin());
+
+  // Comparison Ops
+  ASSERT_EQ(it_begin, empty_set.begin());
+  ASSERT_EQ(it_end, empty_set.end());
+  ASSERT_FALSE(it_begin == it_end);
+  ASSERT_TRUE(it_begin != it_end);
+
+  // Increment Ops
+  ASSERT_TRUE(empty_set.begin() == empty_set.begin()++);
+  ASSERT_TRUE(empty_set.begin() != ++empty_set.begin());
+}
+
+TEST(DispatchKeySet, IteratorBasicRange) {
+  DispatchKeySet empty_set;
+  uint8_t i = 0;
+
+  for (auto it = empty_set.begin(); it != empty_set.end(); ++it) {
+    i++;
+  }
+
+  ASSERT_EQ(i, static_cast<uint8_t>(DispatchKey::NumDispatchKeys) - 1);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#43994 Add iterator like functionality for DispatchKeySet**

Add STL Input iterator to DispatchKeySet:
* Iterator is able to iterate from first not undefined DispatchKey
to NumDispatchKeys.
* Iterator is invalidated once underlying DispatchKeySet is invalidated

Note see http://www.cplusplus.com/reference/iterator/ for comparisons of
different iterators.