### PR TITLE
.circleci: Transfer linux binary build scripts

### DIFF
--- a/.circleci/scripts/binary_builds/linux/build_common.sh
+++ b/.circleci/scripts/binary_builds/linux/build_common.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# meant to be called only from the neighboring build.sh and build_cpu.sh scripts
+
+set -ex
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# Require only one python installation
+if [[ -z "$DESIRED_PYTHON" ]]; then
+    echo "Need to set DESIRED_PYTHON env variable"
+    exit 1
+fi
+if [[ -n "$BUILD_PYTHONLESS" && -z "$LIBTORCH_VARIANT" ]]; then
+    echo "BUILD_PYTHONLESS is set, so need LIBTORCH_VARIANT to also be set"
+    echo "LIBTORCH_VARIANT should be one of shared-with-deps shared-without-deps static-with-deps static-without-deps"
+    exit 1
+fi
+
+# Function to retry functions that sometimes timeout or have flaky failures
+retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+}
+
+# TODO move this into the Docker images
+OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+    retry yum install -q -y zip openssl
+elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+    retry apt-get update
+    retry apt-get -y install zip openssl
+fi
+
+# We use the package name to test the package by passing this to 'pip install'
+# This is the env variable that setup.py uses to name the package. Note that
+# pip 'normalizes' the name first by changing all - to _
+if [[ -z "$TORCH_PACKAGE_NAME" ]]; then
+    TORCH_PACKAGE_NAME='torch'
+fi
+TORCH_PACKAGE_NAME="$(echo $TORCH_PACKAGE_NAME | tr '-' '_')"
+echo "Expecting the built wheels to all be called '$TORCH_PACKAGE_NAME'"
+
+# Version: setup.py uses $PYTORCH_BUILD_VERSION.post$PYTORCH_BUILD_NUMBER if
+# PYTORCH_BUILD_NUMBER > 1
+build_version="$PYTORCH_BUILD_VERSION"
+build_number="$PYTORCH_BUILD_NUMBER"
+if [[ -n "$OVERRIDE_PACKAGE_VERSION" ]]; then
+    # This will be the *exact* version, since build_number<1
+    build_version="$OVERRIDE_PACKAGE_VERSION"
+    build_number=0
+fi
+if [[ -z "$build_version" ]]; then
+    build_version=1.0.0
+fi
+if [[ -z "$build_number" ]]; then
+    build_number=1
+fi
+export PYTORCH_BUILD_VERSION=$build_version
+export PYTORCH_BUILD_NUMBER=$build_number
+
+export CMAKE_LIBRARY_PATH="/opt/intel/lib:/lib:$CMAKE_LIBRARY_PATH"
+export CMAKE_INCLUDE_PATH="/opt/intel/include:$CMAKE_INCLUDE_PATH"
+
+
+# If given a python version like 3.6m or 2.7mu, convert this to the format we
+# expect. The binary CI jobs pass in python versions like this; they also only
+# ever pass one python version, so we assume that DESIRED_PYTHON is not a list
+# in this case
+if [[ -n "$DESIRED_PYTHON" && "$DESIRED_PYTHON" != cp* ]]; then
+    if [[ "$DESIRED_PYTHON" == '2.7mu' ]]; then
+      DESIRED_PYTHON='cp27-cp27mu'
+    elif [[ "$DESIRED_PYTHON" == '3.8m' ]]; then
+      DESIRED_PYTHON='cp38-cp38'
+    else
+      python_nodot="$(echo $DESIRED_PYTHON | tr -d m.u)"
+      DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}m"
+    fi
+fi
+py_majmin="${DESIRED_PYTHON:2:1}.${DESIRED_PYTHON:3:1}"
+pydir="/opt/python/$DESIRED_PYTHON"
+export PATH="$pydir/bin:$PATH"
+echo "Will build for Python version: ${DESIRED_PYTHON} with ${python_installation}"
+
+mkdir -p /tmp/$WHEELHOUSE_DIR
+
+# Clone pytorch source code
+pytorch_rootdir="/pytorch"
+if [[ ! -d "$pytorch_rootdir" ]]; then
+    # TODO probably safe to completely remove this
+    git clone https://github.com/pytorch/pytorch $pytorch_rootdir
+    pushd $pytorch_rootdir
+    if ! git checkout v${PYTORCH_BUILD_VERSION}; then
+          git checkout tags/v${PYTORCH_BUILD_VERSION}
+    fi
+else
+    pushd $pytorch_rootdir
+fi
+git submodule update --init --recursive
+
+export PATCHELF_BIN=/usr/local/bin/patchelf
+patchelf_version=`$PATCHELF_BIN --version`
+echo "patchelf version: " $patchelf_version
+if [[ "$patchelf_version" == "patchelf 0.9" ]]; then
+    echo "Your patchelf version is too old. Please use version >= 0.10."
+    exit 1
+fi
+
+########################################################
+# Compile wheels as well as libtorch
+#######################################################
+python setup.py clean
+retry pip install -qr requirements.txt
+if [[ "$DESIRED_PYTHON"  == "cp37-cp37m" ]]; then
+    retry pip install -q numpy==1.15
+elif [[ "$DESIRED_PYTHON"  == "cp38-cp38" ]]; then
+    retry pip install -q numpy==1.15
+else
+    retry pip install -q numpy==1.11
+fi
+
+if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
+    export _GLIBCXX_USE_CXX11_ABI=1
+else
+    export _GLIBCXX_USE_CXX11_ABI=0
+fi
+
+echo "Calling setup.py bdist at $(date)"
+time CMAKE_ARGS=${CMAKE_ARGS[@]} \
+     EXTRA_CAFFE2_CMAKE_FLAGS=${EXTRA_CAFFE2_CMAKE_FLAGS[@]} \
+     python setup.py bdist_wheel -d /tmp/$WHEELHOUSE_DIR
+echo "Finished setup.py bdist at $(date)"
+
+# Build libtorch packages
+if [[ -n "$BUILD_PYTHONLESS" ]]; then
+    # Now build pythonless libtorch
+    # Note - just use whichever python we happen to be on
+    python setup.py clean
+
+    if [[ $LIBTORCH_VARIANT = *"static"* ]]; then
+        STATIC_CMAKE_FLAG="-DTORCH_STATIC=1"
+    fi
+
+    mkdir -p build
+    pushd build
+    echo "Calling tools/build_libtorch.py at $(date)"
+    time CMAKE_ARGS=${CMAKE_ARGS[@]} \
+         EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
+         python ../tools/build_libtorch.py
+    echo "Finished tools/build_libtorch.py at $(date)"
+    popd
+
+    mkdir -p libtorch/{lib,bin,include,share}
+    cp -r build/build/lib libtorch/
+
+    # for now, the headers for the libtorch package will just be copied in
+    # from one of the wheels (this is from when this script built multiple
+    # wheels at once)
+    ANY_WHEEL=$(ls /tmp/$WHEELHOUSE_DIR/torch*.whl | head -n1)
+    unzip -d any_wheel $ANY_WHEEL
+    if [[ -d any_wheel/torch/include ]]; then
+        cp -r any_wheel/torch/include libtorch/
+    else
+        cp -r any_wheel/torch/lib/include libtorch/
+    fi
+    cp -r any_wheel/torch/share/cmake libtorch/share/
+    rm -rf any_wheel
+
+    echo $PYTORCH_BUILD_VERSION > libtorch/build-version
+    echo "$(pushd $pytorch_rootdir && git rev-parse HEAD)" > libtorch/build-hash
+
+    mkdir -p /tmp/$LIBTORCH_HOUSE_DIR
+
+    if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
+        LIBTORCH_ABI="cxx11-abi-"
+    else
+        LIBTORCH_ABI=
+    fi
+
+    zip -rq /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION.zip libtorch
+    cp /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION.zip \
+       /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-latest.zip
+fi
+
+popd
+
+#######################################################################
+# ADD DEPENDENCIES INTO THE WHEEL
+#
+# auditwheel repair doesn't work correctly and is buggy
+# so manually do the work of copying dependency libs and patchelfing
+# and fixing RECORDS entries correctly
+######################################################################
+
+fname_with_sha256() {
+    HASH=$(sha256sum $1 | cut -c1-8)
+    DIRNAME=$(dirname $1)
+    BASENAME=$(basename $1)
+    if [[ $BASENAME == "libnvrtc-builtins.so" ]]; then
+        echo $1
+    else
+        INITNAME=$(echo $BASENAME | cut -f1 -d".")
+        ENDNAME=$(echo $BASENAME | cut -f 2- -d".")
+        echo "$DIRNAME/$INITNAME-$HASH.$ENDNAME"
+    fi
+}
+
+make_wheel_record() {
+    FPATH=$1
+    if echo $FPATH | grep RECORD >/dev/null 2>&1; then
+        # if the RECORD file, then
+        echo "$FPATH,,"
+    else
+        HASH=$(openssl dgst -sha256 -binary $FPATH | openssl base64 | sed -e 's/+/-/g' | sed -e 's/\//_/g' | sed -e 's/=//g')
+        FSIZE=$(ls -nl $FPATH | awk '{print $5}')
+        echo "$FPATH,sha256=$HASH,$FSIZE"
+    fi
+}
+
+echo 'Built this wheel:'
+ls /tmp/$WHEELHOUSE_DIR
+mkdir -p "/$WHEELHOUSE_DIR"
+mv /tmp/$WHEELHOUSE_DIR/torch*linux*.whl /$WHEELHOUSE_DIR/
+if [[ -n "$BUILD_PYTHONLESS" ]]; then
+    mkdir -p /$LIBTORCH_HOUSE_DIR
+    mv /tmp/$LIBTORCH_HOUSE_DIR/*.zip /$LIBTORCH_HOUSE_DIR
+    rm -rf /tmp/$LIBTORCH_HOUSE_DIR
+fi
+rm -rf /tmp/$WHEELHOUSE_DIR
+rm -rf /tmp_dir
+mkdir /tmp_dir
+pushd /tmp_dir
+
+for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do
+
+    # if the glob didn't match anything
+    if [[ ! -e $pkg ]]; then
+        continue
+    fi
+
+    rm -rf tmp
+    mkdir -p tmp
+    cd tmp
+    cp $pkg .
+
+    unzip -q $(basename $pkg)
+    rm -f $(basename $pkg)
+
+    if [[ -d torch ]]; then
+        PREFIX=torch
+    else
+        PREFIX=libtorch
+    fi
+
+    if [[ $pkg != *"without-deps"* ]]; then
+        # copy over needed dependent .so files over and tag them with their hash
+        patched=()
+        for filepath in "${DEPS_LIST[@]}"; do
+            filename=$(basename $filepath)
+            destpath=$PREFIX/lib/$filename
+            if [[ "$filepath" != "$destpath" ]]; then
+                cp $filepath $destpath
+            fi
+
+            patchedpath=$(fname_with_sha256 $destpath)
+            patchedname=$(basename $patchedpath)
+            if [[ "$destpath" != "$patchedpath" ]]; then
+                mv $destpath $patchedpath
+            fi
+            patched+=("$patchedname")
+            echo "Copied $filepath to $patchedpath"
+        done
+
+        echo "patching to fix the so names to the hashed names"
+        for ((i=0;i<${#DEPS_LIST[@]};++i)); do
+            find $PREFIX -name '*.so*' | while read sofile; do
+                origname=${DEPS_SONAME[i]}
+                patchedname=${patched[i]}
+                if [[ "$origname" != "$patchedname" ]]; then
+                    set +e
+                    $PATCHELF_BIN --print-needed $sofile | grep $origname 2>&1 >/dev/null
+                    ERRCODE=$?
+                    set -e
+                    if [ "$ERRCODE" -eq "0" ]; then
+                        echo "patching $sofile entry $origname to $patchedname"
+                        $PATCHELF_BIN --replace-needed $origname $patchedname $sofile
+                    fi
+                fi
+            done
+        done
+    fi
+
+    # set RPATH of _C.so and similar to $ORIGIN, $ORIGIN/lib
+    find $PREFIX -maxdepth 1 -type f -name "*.so*" | while read sofile; do
+        echo "Setting rpath of $sofile to " '$ORIGIN:$ORIGIN/lib'
+        $PATCHELF_BIN --set-rpath '$ORIGIN:$ORIGIN/lib' $sofile
+        $PATCHELF_BIN --print-rpath $sofile
+    done
+
+    # set RPATH of lib/ files to $ORIGIN
+    find $PREFIX/lib -maxdepth 1 -type f -name "*.so*" | while read sofile; do
+        echo "Setting rpath of $sofile to " '$ORIGIN'
+        $PATCHELF_BIN --set-rpath '$ORIGIN' $sofile
+        $PATCHELF_BIN --print-rpath $sofile
+    done
+
+    # regenerate the RECORD file with new hashes
+    record_file=`echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g'`
+    if [[ -e $record_file ]]; then
+        echo "Generating new record file $record_file"
+        rm -f $record_file
+        # generate records for folders in wheel
+        find * -type f | while read fname; do
+            echo $(make_wheel_record $fname) >>$record_file
+        done
+    fi
+
+    # zip up the wheel back
+    zip -rq $(basename $pkg) $PREIX*
+
+    # replace original wheel
+    rm -f $pkg
+    mv $(basename $pkg) $pkg
+    cd ..
+    rm -rf tmp
+done
+
+# Copy wheels to host machine for persistence before testing
+if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
+    mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
+    if [[ -n "$BUILD_PYTHONLESS" ]]; then
+        cp /$LIBTORCH_HOUSE_DIR/libtorch*.zip "$PYTORCH_FINAL_PACKAGE_DIR"
+    else
+        cp /$WHEELHOUSE_DIR/torch*.whl "$PYTORCH_FINAL_PACKAGE_DIR"
+    fi
+fi
+
+# remove stuff before testing
+rm -rf /opt/rh
+if ls /usr/local/cuda* >/dev/null 2>&1; then
+    rm -rf /usr/local/cuda*
+fi
+
+
+# Test that all the wheels work
+if [[ -z "$BUILD_PYTHONLESS" ]]; then
+  export OMP_NUM_THREADS=4 # on NUMA machines this takes too long
+  pushd $pytorch_rootdir/test
+
+  # Install the wheel for this Python version
+  pip uninstall -y "$TORCH_PACKAGE_NAME"
+  pip install "$TORCH_PACKAGE_NAME" --no-index -f /$WHEELHOUSE_DIR --no-dependencies -v
+
+  # Print info on the libraries installed in this wheel
+  installed_libraries=($(find "$pydir/lib/python${py_majmin}/site-packages/torch/" -name '*.so*'))
+  echo "The wheel installed all of the libraries: ${installed_libraries[@]}"
+  for installed_lib in "${installed_libraries[@]}"; do
+      ldd "$installed_lib"
+  done
+
+  # Run the tests
+  echo "$(date) :: Running tests"
+  pushd "$pytorch_rootdir"
+  LD_LIBRARY_PATH=/usr/local/nvidia/lib64 \
+          "${SOURCE_DIR}/../run_tests.sh" manywheel "${py_majmin}" "$DESIRED_CUDA"
+  popd
+  echo "$(date) :: Finished tests"
+fi

--- a/.circleci/scripts/binary_builds/linux/build_conda.sh
+++ b/.circleci/scripts/binary_builds/linux/build_conda.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+if [[ -x "/remote/anaconda_token" ]]; then
+    . /remote/anaconda_token || true
+fi
+
+set -ex
+
+# TODO there is a LOT of duplicate code everywhere. There's duplicate code for
+# mac siloing of pytorch and conda installations with wheel/build_wheel.sh.
+# There's also duplicate versioning logic amongst *all* the building scripts
+
+# Env variables that should be set
+# PYTORCH_FINAL_PACKAGE_DIR
+#   Absolute path (in docker space) to folder where final packages will be
+#   stored.
+#
+# MACOS env variables that should be set
+#   MAC_PACKAGE_WORK_DIR
+#     Absolute path to a workdir in which to clone an isolated conda
+#     installation and pytorch checkout. If the pytorch checkout already exists
+#     then it will not be overwritten.
+#
+# WINDOWS env variables that should be set
+#   WIN_PACKAGE_WORK_DIR
+#     Absolute path to a workdir in which to clone an isolated conda
+#     installation and pytorch checkout. If the pytorch checkout already exists
+#     then it will not be overwritten.
+
+# Function to retry functions that sometimes timeout or have flaky failures
+retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+}
+
+# Parse arguments and determmine version
+###########################################################
+if [[ -n "$DESIRED_CUDA" && -n "$PYTORCH_BUILD_VERSION" && -n "$PYTORCH_BUILD_NUMBER" ]]; then
+    desired_cuda="$DESIRED_CUDA"
+    build_version="$PYTORCH_BUILD_VERSION"
+    build_number="$PYTORCH_BUILD_NUMBER"
+else
+    if [ "$#" -ne 3 ]; then
+        echo "Illegal number of parameters. Pass cuda version, pytorch version, build number"
+        echo "CUDA version should be Mm with no dot, e.g. '80'"
+        echo "DESIRED_PYTHON should be M.m, e.g. '2.7'"
+        exit 1
+    fi
+
+    desired_cuda="$1"
+    build_version="$2"
+    build_number="$3"
+fi
+if [[ "$desired_cuda" != cpu ]]; then
+  desired_cuda="$(echo $desired_cuda | tr -d cuda. )"
+fi
+echo "Building cuda version $desired_cuda and pytorch version: $build_version build_number: $build_number"
+
+if [[ "$OSTYPE" == "msys" && "$CIRCLECI" == 'true' ]]; then
+    export PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:.:$PATH"
+fi
+
+# Version: setup.py uses $PYTORCH_BUILD_VERSION.post$PYTORCH_BUILD_NUMBER if
+# PYTORCH_BUILD_NUMBER > 1
+if [[ -n "$OVERRIDE_PACKAGE_VERSION" ]]; then
+    # This will be the *exact* version, since build_number<1
+    build_version="$OVERRIDE_PACKAGE_VERSION"
+    build_number=0
+fi
+export PYTORCH_BUILD_VERSION=$build_version
+export PYTORCH_BUILD_NUMBER=$build_number
+
+if [[ -z "$PYTORCH_BRANCH" ]]; then
+    PYTORCH_BRANCH="v$build_version"
+fi
+
+# Fill in missing env variables
+if [ -z "$ANACONDA_TOKEN" ]; then
+    # Token needed to upload to the conda channel above
+    echo "ANACONDA_TOKEN is unset. Please set it in your environment before running this script";
+fi
+if [[ -z "$ANACONDA_USER" ]]; then
+    # This is the channel that finished packages will be uploaded to
+    ANACONDA_USER=soumith
+fi
+if [[ -z "$GITHUB_ORG" ]]; then
+    GITHUB_ORG='pytorch'
+fi
+if [[ -z "$CMAKE_ARGS" ]]; then
+    # These are passed to tools/build_pytorch_libs.sh::build()
+    CMAKE_ARGS=()
+fi
+if [[ -z "$EXTRA_CAFFE2_CMAKE_FLAGS" ]]; then
+    # These are passed to tools/build_pytorch_libs.sh::build_caffe2()
+    EXTRA_CAFFE2_CMAKE_FLAGS=()
+fi
+if [[ -z "$DESIRED_PYTHON" ]]; then
+    if [[ "$OSTYPE" == "msys" ]]; then
+        DESIRED_PYTHON=('3.5' '3.6' '3.7')
+    else
+        DESIRED_PYTHON=('2.7' '3.5' '3.6' '3.7' '3.8')
+    fi
+fi
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    DEVELOPER_DIR=/Applications/Xcode9.app/Contents/Developer
+fi
+if [[ "$desired_cuda" == 'cpu' ]]; then
+    cpu_only=1
+else
+    # Switch desired_cuda to be M.m to be consistent with other scripts in
+    # pytorch/builder
+    cuda_nodot="$desired_cuda"
+
+    if [[ ${#cuda_nodot} -eq 2 ]]; then
+        desired_cuda="${desired_cuda:0:1}.${desired_cuda:1:1}"
+    elif [[ ${#cuda_nodot} -eq 3 ]]; then
+        desired_cuda="${desired_cuda:0:2}.${desired_cuda:2:1}"
+    else
+        echo "unknown cuda version $cuda_nodot"
+        exit 1
+    fi
+fi
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Produce macOS builds with torch.distributed support.
+    # This is enabled by default on Linux, but disabled by default on macOS,
+    # because it requires an non-bundled compile-time dependency (libuv
+    # through gloo). This dependency is made available through meta.yaml, so
+    # we can override the default and set USE_DISTRIBUTED=1.
+    export USE_DISTRIBUTED=1
+fi
+
+echo "Will build for all Pythons: ${DESIRED_PYTHON[@]}"
+echo "Will build for CUDA version: ${desired_cuda}"
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+if [[ -z "$MAC_PACKAGE_WORK_DIR" ]]; then
+    MAC_PACKAGE_WORK_DIR="$(pwd)/tmp_conda_${DESIRED_PYTHON}_$(date +%H%M%S)"
+fi
+if [[ "$OSTYPE" == "msys" && -z "$WIN_PACKAGE_WORK_DIR" ]]; then
+    WIN_PACKAGE_WORK_DIR="$(echo $(pwd -W) | tr '/' '\\')\\tmp_conda_${DESIRED_PYTHON}_$(date +%H%M%S)"
+fi
+
+# Clone the Pytorch repo
+###########################################################
+if [[ "$(uname)" == 'Darwin' ]]; then
+    mkdir -p "$MAC_PACKAGE_WORK_DIR" || true
+    pytorch_rootdir="${MAC_PACKAGE_WORK_DIR}/pytorch"
+elif [[ "$OSTYPE" == "msys" ]]; then
+    mkdir -p "$WIN_PACKAGE_WORK_DIR" || true
+    pytorch_rootdir="$(realpath ${WIN_PACKAGE_WORK_DIR})/pytorch"
+    git config --system core.longpaths true
+    # The jobs are seperated on Windows, so we don't need to clone again.
+    if [[ -d "$NIGHTLIES_PYTORCH_ROOT" ]]; then
+        cp -R "$NIGHTLIES_PYTORCH_ROOT" "$pytorch_rootdir"
+    fi
+elif [[ -d '/pytorch' ]]; then
+    # All docker binary builds
+    pytorch_rootdir='/pytorch'
+else
+    # Shouldn't actually happen anywhere. Exists for builds outisde of nightly
+    # infrastructure
+    pytorch_rootdir="$(pwd)/root_${GITHUB_ORG}pytorch${PYTORCH_BRANCH}"
+fi
+if [[ ! -d "$pytorch_rootdir" ]]; then
+    git clone "https://github.com/${PYTORCH_REPO}/pytorch" "$pytorch_rootdir"
+    pushd "$pytorch_rootdir"
+    git checkout "$PYTORCH_BRANCH"
+    popd
+fi
+pushd "$pytorch_rootdir"
+git submodule update --init --recursive
+echo "Using Pytorch from "
+git --no-pager log --max-count 1
+popd
+
+# Windows builds need to install conda
+if [[ "$(uname)" == 'Darwin' ]]; then
+    tmp_conda="${MAC_PACKAGE_WORK_DIR}/conda"
+    miniconda_sh="${MAC_PACKAGE_WORK_DIR}/miniconda.sh"
+    rm -rf "$tmp_conda"
+    rm -f "$miniconda_sh"
+    retry curl -sS https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o "$miniconda_sh"
+    chmod +x "$miniconda_sh" && \
+        "$miniconda_sh" -b -p "$tmp_conda" && \
+        rm "$miniconda_sh"
+    export PATH="$tmp_conda/bin:$PATH"
+    retry conda install -yq conda-build
+elif [[ "$OSTYPE" == "msys" ]]; then
+    export tmp_conda="${WIN_PACKAGE_WORK_DIR}\\conda"
+    export miniconda_exe="${WIN_PACKAGE_WORK_DIR}\\miniconda.exe"
+    rm -rf "$tmp_conda"
+    rm -f "$miniconda_exe"
+    curl -sSk https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o "$miniconda_exe"
+    "$SOURCE_DIR/install_conda.bat" && rm "$miniconda_exe"
+    pushd $tmp_conda
+    export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"
+    popd
+    retry conda install -yq conda-build
+fi
+
+cd "$SOURCE_DIR"
+
+# Determine which build folder to use
+###########################################################
+if [[ -n "$TORCH_CONDA_BUILD_FOLDER" ]]; then
+    build_folder="$TORCH_CONDA_BUILD_FOLDER"
+else
+    if [[ "$OSTYPE" == 'darwin'* || "$desired_cuda" == '9.0' ]]; then
+        build_folder='pytorch'
+    elif [[ -n "$cpu_only" ]]; then
+        build_folder='pytorch-cpu'
+    else
+        build_folder="pytorch-$cuda_nodot"
+    fi
+    build_folder="$build_folder-$build_version"
+fi
+if [[ ! -d "$build_folder" ]]; then
+    echo "ERROR: Cannot find the build_folder: $build_folder"
+    exit 1
+fi
+meta_yaml="$build_folder/meta.yaml"
+echo "Using conda-build folder $build_folder"
+
+# Switch between CPU or CUDA configerations
+###########################################################
+build_string_suffix="$PYTORCH_BUILD_NUMBER"
+if [[ -n "$cpu_only" ]]; then
+    export USE_CUDA=0
+    export CONDA_CUDATOOLKIT_CONSTRAINT=""
+    export MAGMA_PACKAGE=""
+    export CUDA_VERSION="0.0"
+    export CUDNN_VERSION="0.0"
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+        build_string_suffix="cpu_${build_string_suffix}"
+    fi
+    # on Linux, advertise that the package sets the cpuonly feature
+    export CONDA_CPU_ONLY_FEATURE="    - cpuonly # [not osx]"
+else
+    # Switch the CUDA version that /usr/local/cuda points to. This script also
+    # sets CUDA_VERSION and CUDNN_VERSION
+    echo "Switching to CUDA version $desired_cuda"
+    export CONDA_CPU_ONLY_FEATURE=""
+    . ./switch_cuda_version.sh "$desired_cuda"
+    # TODO, simplify after anaconda fixes their cudatoolkit versioning inconsistency.
+    # see: https://github.com/conda-forge/conda-forge.github.io/issues/687#issuecomment-460086164
+    if [[ "$desired_cuda" == "11.0" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=11.0,<11.1 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda110 # [not osx and not win]"
+    elif [[ "$desired_cuda" == "10.2" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=10.2,<10.3 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda102 # [not osx and not win]"
+    elif [[ "$desired_cuda" == "10.1" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=10.1,<10.2 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda101 # [not osx and not win]"
+    elif [[ "$desired_cuda" == "10.0" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=10.0,<10.1 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda100 # [not osx and not win]"
+    elif [[ "$desired_cuda" == "9.2" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=9.2,<9.3 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda92 # [not osx and not win]"
+    elif [[ "$desired_cuda" == "9.0" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=9.0,<9.1 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda90 # [not osx and not win]"
+    elif [[ "$desired_cuda" == "8.0" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=8.0,<8.1 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda80 # [not osx and not win]"
+    else
+        echo "unhandled desired_cuda: $desired_cuda"
+        exit 1
+    fi
+
+    build_string_suffix="cuda${CUDA_VERSION}_cudnn${CUDNN_VERSION}_${build_string_suffix}"
+    if [[ "$desired_cuda" == '9.2' ]]; then
+        # ATen tests can't build with CUDA 9.2 and the old compiler used here
+        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
+    fi
+
+fi
+
+# Some tricks for sccache with conda builds on Windows
+if [[ "$OSTYPE" == "msys" && "$USE_SCCACHE" == "1" ]]; then
+    if [[ ! -d "/c/cb" ]]; then
+        rm -rf /c/cb
+    fi
+    mkdir -p /c/cb/pytorch_1000000000000
+    export CONDA_BLD_PATH="C:\\cb"
+    export CONDA_BUILD_EXTRA_ARGS="--dirty"
+else
+    export CONDA_BUILD_EXTRA_ARGS=""
+fi
+
+# Loop through all Python versions to build a package for each
+for py_ver in "${DESIRED_PYTHON[@]}"; do
+    build_string="py${py_ver}_${build_string_suffix}"
+    folder_tag="${build_string}_$(date +'%Y%m%d')"
+
+    # Create the conda package into this temporary folder. This is so we can find
+    # the package afterwards, as there's no easy way to extract the final filename
+    # from conda-build
+    output_folder="out_$folder_tag"
+    rm -rf "$output_folder"
+    mkdir "$output_folder"
+
+    # We need to build the compiler activation scripts first on Windows
+    if [[ "$OSTYPE" == "msys" ]]; then
+        vs_package="vs$VC_YEAR"
+
+        time VSDEVCMD_ARGS=${VSDEVCMD_ARGS[@]} \
+             conda build -c "$ANACONDA_USER" \
+                         --no-anaconda-upload \
+                         --output-folder "$output_folder" \
+                         $vs_package
+
+        cp "$vs_package/conda_build_config.yaml" "pytorch-nightly/conda_build_config.yaml"
+    fi
+
+    # Output the meta.yaml for easy debugging
+    echo 'Finalized meta.yaml is'
+    cat "$meta_yaml"
+
+    # Build the package
+    echo "Build $build_folder for Python version $py_ver"
+    conda config --set anaconda_upload no
+    echo "Calling conda-build at $(date)"
+    time CMAKE_ARGS=${CMAKE_ARGS[@]} \
+         EXTRA_CAFFE2_CMAKE_FLAGS=${EXTRA_CAFFE2_CMAKE_FLAGS[@]} \
+         PYTORCH_GITHUB_ROOT_DIR="$pytorch_rootdir" \
+         PYTORCH_BUILD_STRING="$build_string" \
+         PYTORCH_MAGMA_CUDA_VERSION="$cuda_nodot" \
+         conda build -c "$ANACONDA_USER" \
+                     --no-anaconda-upload \
+                     --python "$py_ver" \
+                     --output-folder "$output_folder" \
+                     --no-test $CONDA_BUILD_EXTRA_ARGS \
+                     "$build_folder"
+    echo "Finished conda-build at $(date)"
+
+    # Create a new environment to test in
+    # TODO these reqs are hardcoded for pytorch-nightly
+    test_env="env_$folder_tag"
+    retry conda create -yn "$test_env" python="$py_ver"
+    source activate "$test_env"
+
+    # Extract the package for testing
+    ls -lah "$output_folder"
+    built_package="$(find $output_folder/ -name '*pytorch*.tar.bz2')"
+
+    # Copy the built package to the host machine for persistence before testing
+    if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
+        mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
+        cp "$built_package" "$PYTORCH_FINAL_PACKAGE_DIR/"
+    fi
+
+    conda install -y "$built_package"
+
+    # Run tests
+    echo "$(date) :: Running tests"
+    pushd "$pytorch_rootdir"
+    if [[ "$cpu_only" == 1 ]]; then
+        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" 'cpu'
+    else
+        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" "cu$cuda_nodot"
+    fi
+    popd
+    echo "$(date) :: Finished tests"
+
+    # Clean up test folder
+    source deactivate
+    conda env remove -yn "$test_env"
+    rm -rf "$output_folder"
+done
+
+# Cleanup the tricks for sccache with conda builds on Windows
+if [[ "$OSTYPE" == "msys" ]]; then
+    rm -rf /c/cb/pytorch_1000000000000
+    unset CONDA_BLD_PATH
+fi
+unset CONDA_BUILD_EXTRA_ARGS
+
+unset PYTORCH_BUILD_VERSION
+unset PYTORCH_BUILD_NUMBER

--- a/.circleci/scripts/binary_builds/linux/build_cpu.sh
+++ b/.circleci/scripts/binary_builds/linux/build_cpu.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -ex
+
+export TH_BINARY_BUILD=1
+export USE_CUDA=0
+
+# Keep an array of cmake variables to add to
+if [[ -z "$CMAKE_ARGS" ]]; then
+    # These are passed to tools/build_pytorch_libs.sh::build()
+    CMAKE_ARGS=()
+fi
+if [[ -z "$EXTRA_CAFFE2_CMAKE_FLAGS" ]]; then
+    # These are passed to tools/build_pytorch_libs.sh::build_caffe2()
+    EXTRA_CAFFE2_CMAKE_FLAGS=()
+fi
+
+WHEELHOUSE_DIR="wheelhousecpu"
+LIBTORCH_HOUSE_DIR="libtorch_housecpu"
+if [[ -z "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
+    if [[ -z "$BUILD_PYTHONLESS" ]]; then
+        PYTORCH_FINAL_PACKAGE_DIR="/remote/wheelhousecpu"
+    else
+        PYTORCH_FINAL_PACKAGE_DIR="/remote/libtorch_housecpu"
+    fi
+fi
+mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
+
+OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+    LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
+elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+    LIBGOMP_PATH="/usr/lib/x86_64-linux-gnu/libgomp.so.1"
+fi
+
+DEPS_LIST=(
+    "$LIBGOMP_PATH"
+)
+
+DEPS_SONAME=(
+    "libgomp.so.1"
+)
+
+rm -rf /usr/local/cuda*
+
+# builder/test.sh requires DESIRED_CUDA to know what tests to exclude
+export DESIRED_CUDA='cpu'
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+if [[ -z "$BUILD_PYTHONLESS" ]]; then
+    BUILD_SCRIPT=build_common.sh
+else
+    BUILD_SCRIPT=build_libtorch.sh
+fi
+source $SCRIPTPATH/${BUILD_SCRIPT}

--- a/.circleci/scripts/binary_builds/linux/build_libtorch.sh
+++ b/.circleci/scripts/binary_builds/linux/build_libtorch.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# meant to be called only from the neighboring build.sh and build_cpu.sh scripts
+
+set -e pipefail
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# Require only one python installation
+if [[ -z "$DESIRED_PYTHON" ]]; then
+    echo "Need to set DESIRED_PYTHON env variable"
+    exit 1
+fi
+if [[ -n "$BUILD_PYTHONLESS" && -z "$LIBTORCH_VARIANT" ]]; then
+    echo "BUILD_PYTHONLESS is set, so need LIBTORCH_VARIANT to also be set"
+    echo "LIBTORCH_VARIANT should be one of shared-with-deps shared-without-deps static-with-deps static-without-deps"
+    exit 1
+fi
+
+# Function to retry functions that sometimes timeout or have flaky failures
+retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+}
+
+# TODO move this into the Docker images
+OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+    retry yum install -q -y zip openssl
+elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+    retry apt-get update
+    retry apt-get -y install zip openssl
+fi
+
+# Version: setup.py uses $PYTORCH_BUILD_VERSION.post$PYTORCH_BUILD_NUMBER if
+# PYTORCH_BUILD_NUMBER > 1
+build_version="$PYTORCH_BUILD_VERSION"
+build_number="$PYTORCH_BUILD_NUMBER"
+if [[ -n "$OVERRIDE_PACKAGE_VERSION" ]]; then
+    # This will be the *exact* version, since build_number<1
+    build_version="$OVERRIDE_PACKAGE_VERSION"
+    build_number=0
+fi
+if [[ -z "$build_version" ]]; then
+    build_version=1.0.0
+fi
+if [[ -z "$build_number" ]]; then
+    build_number=1
+fi
+export PYTORCH_BUILD_VERSION=$build_version
+export PYTORCH_BUILD_NUMBER=$build_number
+
+export CMAKE_LIBRARY_PATH="/opt/intel/lib:/lib:$CMAKE_LIBRARY_PATH"
+export CMAKE_INCLUDE_PATH="/opt/intel/include:$CMAKE_INCLUDE_PATH"
+
+
+# If given a python version like 3.6m or 2.7mu, convert this to the format we
+# expect. The binary CI jobs pass in python versions like this; they also only
+# ever pass one python version, so we assume that DESIRED_PYTHON is not a list
+# in this case
+if [[ -n "$DESIRED_PYTHON" && "$DESIRED_PYTHON" != cp* ]]; then
+    if [[ "$DESIRED_PYTHON" == '2.7mu' ]]; then
+      DESIRED_PYTHON='cp27-cp27mu'
+    elif [[ "$DESIRED_PYTHON" == '3.8m' ]]; then
+      DESIRED_PYTHON='cp38-cp38'
+    else
+      python_nodot="$(echo $DESIRED_PYTHON | tr -d m.u)"
+      DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}m"
+    fi
+fi
+pydir="/opt/python/$DESIRED_PYTHON"
+export PATH="$pydir/bin:$PATH"
+
+# Clone pytorch source code
+pytorch_rootdir="/pytorch"
+if [[ ! -d "$pytorch_rootdir" ]]; then
+    # TODO probably safe to completely remove this
+    git clone https://github.com/pytorch/pytorch $pytorch_rootdir
+    pushd $pytorch_rootdir
+    if ! git checkout v${PYTORCH_BUILD_VERSION}; then
+          git checkout tags/v${PYTORCH_BUILD_VERSION}
+    fi
+else
+    pushd $pytorch_rootdir
+fi
+pushd $pytorch_rootdir
+git submodule update --init --recursive
+
+export PATCHELF_BIN=/usr/local/bin/patchelf
+patchelf_version=`$PATCHELF_BIN --version`
+echo "patchelf version: " $patchelf_version
+if [[ "$patchelf_version" == "patchelf 0.9" ]]; then
+    echo "Your patchelf version is too old. Please use version >= 0.10."
+    exit 1
+fi
+
+########################################################
+# Compile wheels as well as libtorch
+#######################################################
+python setup.py clean
+retry pip install -qr requirements.txt
+if [[ "$DESIRED_PYTHON"  == "cp37-cp37m" ]]; then
+    retry pip install -q numpy==1.15
+elif [[ "$DESIRED_PYTHON"  == "cp38-cp38" ]]; then
+    retry pip install -q numpy==1.15
+else
+    retry pip install -q numpy==1.11
+fi
+
+if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
+    export _GLIBCXX_USE_CXX11_ABI=1
+else
+    export _GLIBCXX_USE_CXX11_ABI=0
+fi
+
+echo "Calling setup.py install at $(date)"
+
+if [[ $LIBTORCH_VARIANT = *"static"* ]]; then
+    STATIC_CMAKE_FLAG="-DTORCH_STATIC=1"
+fi
+
+(
+    set -x
+
+    mkdir -p build
+
+    time CMAKE_ARGS=${CMAKE_ARGS[@]} \
+        EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
+        python setup.py install
+
+    mkdir -p libtorch/{lib,bin,include,share}
+
+    # Copy over all lib files
+    cp -rv build/lib/*                libtorch/lib/
+    cp -rv build/lib*/torch/lib/*     libtorch/lib/
+
+    # Copy over all include files
+    cp -rv build/include/*            libtorch/include/
+    cp -rv build/lib*/torch/include/* libtorch/include/
+
+    # Copy over all of the cmake files
+    cp -rv build/lib*/torch/share/*   libtorch/share/
+
+    echo "${PYTORCH_BUILD_VERSION}" > libtorch/build-version
+    echo "$(pushd $pytorch_rootdir && git rev-parse HEAD)" > libtorch/build-hash
+
+)
+
+if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
+    LIBTORCH_ABI="cxx11-abi-"
+else
+    LIBTORCH_ABI=
+fi
+
+(
+    set -x
+
+    mkdir -p /tmp/$LIBTORCH_HOUSE_DIR
+    zip -rq /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION.zip libtorch
+    cp /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION.zip \
+       /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-latest.zip
+)
+
+
+popd
+
+#######################################################################
+# ADD DEPENDENCIES INTO THE WHEEL
+#
+# auditwheel repair doesn't work correctly and is buggy
+# so manually do the work of copying dependency libs and patchelfing
+# and fixing RECORDS entries correctly
+######################################################################
+
+fname_with_sha256() {
+    HASH=$(sha256sum $1 | cut -c1-8)
+    DIRNAME=$(dirname $1)
+    BASENAME=$(basename $1)
+    if [[ $BASENAME == "libnvrtc-builtins.so" ]]; then
+        echo $1
+    else
+        INITNAME=$(echo $BASENAME | cut -f1 -d".")
+        ENDNAME=$(echo $BASENAME | cut -f 2- -d".")
+        echo "$DIRNAME/$INITNAME-$HASH.$ENDNAME"
+    fi
+}
+
+make_wheel_record() {
+    FPATH=$1
+    if echo $FPATH | grep RECORD >/dev/null 2>&1; then
+        # if the RECORD file, then
+        echo "$FPATH,,"
+    else
+        HASH=$(openssl dgst -sha256 -binary $FPATH | openssl base64 | sed -e 's/+/-/g' | sed -e 's/\//_/g' | sed -e 's/=//g')
+        FSIZE=$(ls -nl $FPATH | awk '{print $5}')
+        echo "$FPATH,sha256=$HASH,$FSIZE"
+    fi
+}
+
+echo 'Built this package:'
+(
+    set -x
+    mkdir -p /$LIBTORCH_HOUSE_DIR
+    mv /tmp/$LIBTORCH_HOUSE_DIR/*.zip /$LIBTORCH_HOUSE_DIR
+    rm -rf /tmp/$LIBTORCH_HOUSE_DIR
+)
+TMP_DIR=$(mktemp -d)
+trap "rm -rf ${TMP_DIR}" EXIT
+pushd "${TMP_DIR}"
+
+for pkg in /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do
+
+    # if the glob didn't match anything
+    if [[ ! -e $pkg ]]; then
+        continue
+    fi
+
+    rm -rf tmp
+    mkdir -p tmp
+    cd tmp
+    cp $pkg .
+
+    unzip -q $(basename $pkg)
+    rm -f $(basename $pkg)
+
+    PREFIX=libtorch
+
+    if [[ $pkg != *"without-deps"* ]]; then
+        # copy over needed dependent .so files over and tag them with their hash
+        patched=()
+        for filepath in "${DEPS_LIST[@]}"; do
+            filename=$(basename $filepath)
+            destpath=$PREFIX/lib/$filename
+            if [[ "$filepath" != "$destpath" ]]; then
+                cp $filepath $destpath
+            fi
+
+            patchedpath=$(fname_with_sha256 $destpath)
+            patchedname=$(basename $patchedpath)
+            if [[ "$destpath" != "$patchedpath" ]]; then
+                mv $destpath $patchedpath
+            fi
+            patched+=("$patchedname")
+            echo "Copied $filepath to $patchedpath"
+        done
+
+        echo "patching to fix the so names to the hashed names"
+        for ((i=0;i<${#DEPS_LIST[@]};++i)); do
+            find $PREFIX -name '*.so*' | while read sofile; do
+                origname=${DEPS_SONAME[i]}
+                patchedname=${patched[i]}
+                if [[ "$origname" != "$patchedname" ]]; then
+                    set +e
+                    $PATCHELF_BIN --print-needed $sofile | grep $origname 2>&1 >/dev/null
+                    ERRCODE=$?
+                    set -e
+                    if [ "$ERRCODE" -eq "0" ]; then
+                        echo "patching $sofile entry $origname to $patchedname"
+                        $PATCHELF_BIN --replace-needed $origname $patchedname $sofile
+                    fi
+                fi
+            done
+        done
+    fi
+
+    # set RPATH of _C.so and similar to $ORIGIN, $ORIGIN/lib
+    find $PREFIX -maxdepth 1 -type f -name "*.so*" | while read sofile; do
+        echo "Setting rpath of $sofile to " '$ORIGIN:$ORIGIN/lib'
+        $PATCHELF_BIN --set-rpath '$ORIGIN:$ORIGIN/lib' $sofile
+        $PATCHELF_BIN --print-rpath $sofile
+    done
+
+    # set RPATH of lib/ files to $ORIGIN
+    find $PREFIX/lib -maxdepth 1 -type f -name "*.so*" | while read sofile; do
+        echo "Setting rpath of $sofile to " '$ORIGIN'
+        $PATCHELF_BIN --set-rpath '$ORIGIN' $sofile
+        $PATCHELF_BIN --print-rpath $sofile
+    done
+
+    # regenerate the RECORD file with new hashes
+    record_file=`echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g'`
+    if [[ -e $record_file ]]; then
+        echo "Generating new record file $record_file"
+        rm -f $record_file
+        # generate records for folders in wheel
+        find * -type f | while read fname; do
+            echo $(make_wheel_record $fname) >>$record_file
+        done
+    fi
+
+    # zip up the wheel back
+    zip -rq $(basename $pkg) $PREIX*
+
+    # replace original wheel
+    rm -f $pkg
+    mv $(basename $pkg) $pkg
+    cd ..
+    rm -rf tmp
+done
+
+# Copy wheels to host machine for persistence before testing
+if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
+    cp /$LIBTORCH_HOUSE_DIR/libtorch*.zip "$PYTORCH_FINAL_PACKAGE_DIR"
+fi

--- a/.circleci/scripts/binary_builds/linux/build_manywheel.sh
+++ b/.circleci/scripts/binary_builds/linux/build_manywheel.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+set -ex
+
+export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
+export NCCL_ROOT_DIR=/usr/local/cuda
+export TH_BINARY_BUILD=1
+export USE_STATIC_CUDNN=1
+export USE_STATIC_NCCL=1
+export ATEN_STATIC_CUDA=1
+export USE_CUDA_STATIC_LINK=1
+export INSTALL_TEST=0 # dont install test binaries into site-packages
+
+# Keep an array of cmake variables to add to
+if [[ -z "$CMAKE_ARGS" ]]; then
+    # These are passed to tools/build_pytorch_libs.sh::build()
+    CMAKE_ARGS=()
+fi
+if [[ -z "$EXTRA_CAFFE2_CMAKE_FLAGS" ]]; then
+    # These are passed to tools/build_pytorch_libs.sh::build_caffe2()
+    EXTRA_CAFFE2_CMAKE_FLAGS=()
+fi
+
+# Determine CUDA version and architectures to build for
+#
+# NOTE: We should first check `DESIRED_CUDA` when determining `CUDA_VERSION`,
+# because in some cases a single Docker image can have multiple CUDA versions
+# on it, and `nvcc --version` might not show the CUDA version we want.
+if [[ -n "$DESIRED_CUDA" ]]; then
+    # cu90, cu92, cu100, cu101
+    if [[ ${#DESIRED_CUDA} -eq 4 ]]; then
+        CUDA_VERSION="${DESIRED_CUDA:2:1}.${DESIRED_CUDA:3:1}"
+    elif [[ ${#DESIRED_CUDA} -eq 5 ]]; then
+        CUDA_VERSION="${DESIRED_CUDA:2:2}.${DESIRED_CUDA:4:1}"
+    fi
+    echo "Using CUDA $CUDA_VERSION as determined by DESIRED_CUDA"
+
+    # There really has to be a better way to do this - eli
+    # Possibly limiting builds to specific cuda versions be delimiting images would be a choice
+    if [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+        echo "Switching to CUDA version $desired_cuda"
+        /builder/conda/switch_cuda_version.sh "${DESIRED_CUDA}"
+    fi
+else
+    CUDA_VERSION=$(nvcc --version|tail -n1|cut -f5 -d" "|cut -f1 -d",")
+    echo "CUDA $CUDA_VERSION Detected"
+fi
+
+export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;7.0"
+case ${CUDA_VERSION} in
+    11.*)
+        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5;8.0"
+        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
+        ;;
+    10.*)
+        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5"
+        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
+        ;;
+    9.*)
+        export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
+        ;;
+    *)
+        echo "unknown cuda version $CUDA_VERSION"
+        exit 1
+        ;;
+esac
+echo $TORCH_CUDA_ARCH_LIST
+
+cuda_version_nodot=$(echo $CUDA_VERSION | tr -d '.')
+
+# Package directories
+WHEELHOUSE_DIR="wheelhouse$cuda_version_nodot"
+LIBTORCH_HOUSE_DIR="libtorch_house$cuda_version_nodot"
+if [[ -z "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
+    if [[ -z "$BUILD_PYTHONLESS" ]]; then
+        PYTORCH_FINAL_PACKAGE_DIR="/remote/wheelhouse$cuda_version_nodot"
+    else
+        PYTORCH_FINAL_PACKAGE_DIR="/remote/libtorch_house$cuda_version_nodot"
+    fi
+fi
+mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
+
+OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+    LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
+elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+    LIBGOMP_PATH="/usr/lib/x86_64-linux-gnu/libgomp.so.1"
+fi
+
+if [[ $CUDA_VERSION == "9.0" ]]; then
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.9.0"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.9.0"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "$LIBGOMP_PATH"
+)
+
+DEPS_SONAME=(
+    "libcudart.so.9.0"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.9.0"
+    "libnvrtc-builtins.so"
+    "libgomp.so.1"
+)
+elif [[ $CUDA_VERSION == "9.2" ]]; then
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.9.2"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.9.2"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "$LIBGOMP_PATH"
+)
+
+DEPS_SONAME=(
+    "libcudart.so.9.2"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.9.2"
+    "libnvrtc-builtins.so"
+    "libgomp.so.1"
+)
+elif [[ $CUDA_VERSION == "10.0" ]]; then
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.10.0"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.10.0"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "$LIBGOMP_PATH"
+)
+
+DEPS_SONAME=(
+    "libcudart.so.10.0"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.10.0"
+    "libnvrtc-builtins.so"
+    "libgomp.so.1"
+)
+elif [[ $CUDA_VERSION == "10.1" ]]; then
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.10.1"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.10.1"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "$LIBGOMP_PATH"
+)
+
+DEPS_SONAME=(
+    "libcudart.so.10.1"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.10.1"
+    "libnvrtc-builtins.so"
+    "libgomp.so.1"
+)
+elif [[ $CUDA_VERSION == "10.2" ]]; then
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.10.2"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.10.2"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "$LIBGOMP_PATH"
+)
+
+DEPS_SONAME=(
+    "libcudart.so.10.2"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.10.2"
+    "libnvrtc-builtins.so"
+    "libgomp.so.1"
+)
+elif [[ $CUDA_VERSION == "11.0" ]]; then
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.11.0"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.11.0"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "$LIBGOMP_PATH"
+)
+
+DEPS_SONAME=(
+    "libcudart.so.11.0"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.11.0"
+    "libnvrtc-builtins.so"
+    "libgomp.so.1"
+)
+else
+    echo "Unknown cuda version $CUDA_VERSION"
+    exit 1
+fi
+
+# builder/test.sh requires DESIRED_CUDA to know what tests to exclude
+export DESIRED_CUDA="$cuda_version_nodot"
+
+# Switch `/usr/local/cuda` to the desired CUDA version
+rm -rf /usr/local/cuda || true
+ln -s "/usr/local/cuda-${CUDA_VERSION}" /usr/local/cuda
+
+# Switch `/usr/local/magma` to the desired CUDA version
+rm -rf /usr/local/magma || true
+ln -s /usr/local/cuda-${CUDA_VERSION}/magma /usr/local/magma
+
+export CUDA_VERSION=$(ls /usr/local/cuda/lib64/libcudart.so.*|sort|tac | head -1 | rev | cut -d"." -f -3 | rev) # 10.0.130
+export CUDA_VERSION_SHORT=$(ls /usr/local/cuda/lib64/libcudart.so.*|sort|tac | head -1 | rev | cut -d"." -f -3 | rev | cut -f1,2 -d".") # 10.0
+export CUDNN_VERSION=$(ls /usr/local/cuda/lib64/libcudnn.so.*|sort|tac | head -1 | rev | cut -d"." -f -3 | rev)
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+if [[ -z "$BUILD_PYTHONLESS" ]]; then
+    BUILD_SCRIPT=build_common.sh
+else
+    BUILD_SCRIPT=build_libtorch.sh
+fi
+source $SCRIPTPATH/${BUILD_SCRIPT}

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 echo "RUNNING ON $(uname -a) WITH $(nproc) CPUS AND $(free -m)"
 set -eux -o pipefail
 source /env
@@ -9,12 +11,12 @@ export MAX_JOBS=${MAX_JOBS:-$(nproc --ignore=1)}
 
 # Parse the parameters
 if [[ "$PACKAGE_TYPE" == 'conda' ]]; then
-  build_script='conda/build_pytorch.sh'
+  build_script='build_conda.sh'
 elif [[ "$DESIRED_CUDA" == cpu ]]; then
-  build_script='manywheel/build_cpu.sh'
+  build_script='build_cpu.sh'
 else
-  build_script='manywheel/build.sh'
+  build_script='build_manywheel.sh'
 fi
 
 # Build the package
-SKIP_ALL_TESTS=1 stdbuf -i0 -o0 -e0 "/builder/$build_script"
+SKIP_ALL_TESTS=1 stdbuf -i0 -o0 -e0 "${DIR}/binary_builds/${build_script}"

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -19,4 +19,4 @@ else
 fi
 
 # Build the package
-SKIP_ALL_TESTS=1 stdbuf -i0 -o0 -e0 "${DIR}/binary_builds/${build_script}"
+SKIP_ALL_TESTS=1 stdbuf -i0 -o0 -e0 "${DIR}/binary_builds/linux/${build_script}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43975 DO NOT MERGE, testing binary build changes
* **#43997 .circleci: Transfer linux binary build scripts**
* #43974 .circleci: Remove un-needed steps from binary builds

The binary build scripts currently exist in pytorch/builder and these
make it so that they now exist in the main repository instead.

These are a direct lift and shift of the scripts used to build binaries in `pytorch/builder`

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>