### PR TITLE
Enable `c++` source coverage with `CircleCI` and `codecov.io`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ option(BUILD_MOBILE_AUTOGRAD "Build autograd function in mobile build (in develo
 cmake_dependent_option(
     INSTALL_TEST "Install test binaries if BUILD_TEST is on" ON
     "BUILD_TEST" OFF)
-option(CODE_COVERAGE "Compile C/C++ with code coverage flags" OFF)
+option(USE_CPP_CODE_COVERAGE "Compile C/C++ with code coverage flags" OFF)
 option(COLORIZE_OUTPUT "Colorize output during compilation" ON)
 option(USE_ASAN "Use Address Sanitizer" OFF)
 option(USE_TSAN "Use Thread Sanitizer" OFF)
@@ -626,7 +626,7 @@ endif()
 
 
 # Add code coverage flags to supported compilers
-if(CODE_COVERAGE)
+if(USE_CPP_CODE_COVERAGE)
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     string(APPEND CMAKE_C_FLAGS  " --coverage -fprofile-abs-path")
     string(APPEND CMAKE_CXX_FLAGS  " --coverage -fprofile-abs-path")

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -50,8 +50,8 @@ function(caffe2_print_configuration_summary)
 
   message(STATUS "  INTERN_BUILD_MOBILE   : ${INTERN_BUILD_MOBILE}")
 
-  message(STATUS "  CODE_COVERAGE         : ${CODE_COVERAGE}")
   message(STATUS "  USE_ASAN              : ${USE_ASAN}")
+  message(STATUS "  USE_CPP_CODE_COVERAGE : ${USE_CPP_CODE_COVERAGE}")
   message(STATUS "  USE_CUDA              : ${USE_CUDA}")
   if(${USE_CUDA})
     message(STATUS "    CUDA static link    : ${CAFFE2_STATIC_LINK_CUDA}")


### PR DESCRIPTION
Summary:
Based on D23351877 (https://github.com/pytorch/pytorch/commit/1bda5e480c0fe01dae8db718cd457befa1b46ac6), life becomes much easier for this time.
1.in `build.sh`
- Enable coverage builld option for c++
- `apt-get install lcov`

2.in `test.sh`
- run `lcov`

3.in `pytorch-job-specs.yml`
- copy coverage.info to `test/` folder and upload it to codecov.io

Test Plan: Test on github

Differential Revision: D23464656

