### PR TITLE
Document the default behavior for dist.new_group() when ranks=None

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1894,7 +1894,8 @@ def new_group(ranks=None, timeout=default_pg_timeout, backend=None):
     should be created in the same order in all processes.
 
     Arguments:
-        ranks (list[int]): List of ranks of group members.
+        ranks (list[int]): List of ranks of group members. If ``None``, will be
+            set to all ranks. Default is ``None``.
         timeout (timedelta, optional): Timeout for operations executed against
             the process group. Default value equals 30 minutes.
             This is only applicable for the ``gloo`` backend.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44000 Document the default behavior for dist.new_group() when ranks=None**

This wasn't documented, so add a doc saying all ranks are used when
ranks=None

Differential Revision: [D23465034](https://our.internmc.facebook.com/intern/diff/D23465034/)