### PR TITLE
Ensure that LSTM and RNNCells run with reduced range for activations

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1797,7 +1797,8 @@ return_type name( \
       _packed_w_ih, \
       _packed_w_hh, \
       b_ih, \
-      b_hh); \
+      b_hh, \
+      true); \
   return cell_type{}( \
       input, prepare_hx_fn(hx), params); \
 }

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -11,6 +11,7 @@ from quantization.test_quantized_op import TestQNNPackOps  # noqa: F401
 from quantization.test_quantized_op import TestQuantizedLinear  # noqa: F401
 from quantization.test_quantized_op import TestQuantizedConv  # noqa: F401
 from quantization.test_quantized_op import TestDynamicQuantizedLinear  # noqa: F401
+from quantization.test_quantized_op import TestDynamicQuantizedRNNOp  # noqa: F401
 from quantization.test_quantized_op import TestComparatorOps  # noqa: F401
 from quantization.test_quantized_op import TestPadding  # noqa: F401
 from quantization.test_quantized_op import TestQuantizedEmbeddingBag  # noqa: F401


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44003 Ensure that LSTM and RNNCells run with reduced range for activations**

Add the tests for RNN ops in TestDynamicQuantizedRNNOp to test_quantization.py
Ensure that RNNCells use reduce_range=True for computation.

Differential Revision: [D23465576](https://our.internmc.facebook.com/intern/diff/D23465576/)