### PR TITLE
Actually run backward criterion tests.

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -19,7 +19,8 @@ from torch.testing._internal.common_utils import TestCase, to_gpu, freeze_rng_st
     TEST_WITH_ROCM, _assertGradAndGradgradChecks
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import expectedAlertNondeterministic
-from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors
+from torch.autograd.gradcheck import get_numerical_jacobian, iter_tensors, \
+    gradcheck, gradgradcheck
 from torch.autograd import Variable
 import torch.backends.cudnn
 
@@ -4861,7 +4862,7 @@ class CriterionTest(TestBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.should_test_cuda = kwargs.get('test_cuda', True)
-        self.check_forward_only = kwargs.get('check_forward_only', True)
+        self.check_forward_only = kwargs.get('check_forward_only', False)
 
     def _get_target(self):
         return self._get_arg('target', True)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4373,6 +4373,7 @@ new_criterion_tests = [
         reference_fn=lambda i, t, il, tl, m:
             ctcloss_reference(i, t, il, tl, blank=14, reduction=get_reduction(m)),
         desc='lengths_intlists',
+        check_forward_only=True,
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,
@@ -4403,6 +4404,7 @@ new_criterion_tests = [
         reference_fn=lambda i, t, il, tl, m:
             ctcloss_reference(i, t, il, tl, blank=14, reduction=get_reduction(m)),
         desc='lengths_tensors',
+        check_forward_only=True,
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,
@@ -4431,6 +4433,7 @@ new_criterion_tests = [
         target_fn=lambda: torch.randint(1, 15, (3, 30), dtype=torch.int),
         reference_fn=lambda i, t, il, tl, m:
             ctcloss_reference(i, t, il, tl, blank=0, reduction=get_reduction(m)),
+        check_forward_only=True,
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,
@@ -4448,6 +4451,7 @@ new_criterion_tests = [
         target_fn=lambda: torch.randint(1, 15, (3, 30), dtype=torch.int),
         reference_fn=lambda i, t, il, tl, m:
             ctcloss_reference(i, t, il, tl, blank=0, reduction=get_reduction(m)),
+        check_forward_only=True,
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,
@@ -4463,6 +4467,7 @@ new_criterion_tests = [
         target_fn=lambda: torch.randint(1, 15, (3, 30), dtype=torch.int),
         reference_fn=lambda i, t, il, tl, m:
             ctcloss_reference(i, t, il, tl, blank=0, reduction=get_reduction(m)),
+        check_forward_only=True,
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44060 For CriterionTests, have check_gradgrad actually only affect gradgrad checks.
* #44056 Rename CriterionTest to NewCriterionTest.
* #44055 Merge CriterionTest into NewCriterionTest.
* #44050 Allow criterion backwards test on modules requiring extra args (i.e. CTCLoss).
* **#44030 Actually run backward criterion tests.**

This looks to have been a mistake from https://github.com/pytorch/pytorch/pull/9287.

Differential Revision: [D23476274](https://our.internmc.facebook.com/intern/diff/D23476274)