### PR TITLE
DeviceGuard dispatch key

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -17,7 +17,7 @@ namespace impl {
 // always_included to get inlined, constexpr not necessary)
 // Note DispatchKey::Autograd used to be in this set and it now has been
 // moved to TensorImpl constructor.
-const DispatchKeySet always_included{DispatchKey::BackendSelect};
+const DispatchKeySet always_included{DispatchKey::BackendSelect, DispatchKey::DeviceGuard};
 
 // Take a DispatchKeySet for a Tensor and determine what the actual dispatch
 // DispatchKey should be, taking into account TLS, and skipping backends which

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -461,6 +461,7 @@ void TensorIterator::allocate_or_resize_outputs() {
           // can just return contiguous output
           // it is faster because it avoids allocating 0 size tensor and
           // resizing and restriding it
+          const DeviceGuard device_guard(op.options().device());
           op.tensor = at::empty(tensor_shape, op.options());
         } else {
           at::native::resize_output(op.tensor, tensor_shape);
@@ -1089,6 +1090,7 @@ bool TensorIterator::fast_set_up(const TensorIteratorConfig& config) {
           auto& op = operands_[i];
           if (!op.tensor.defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
+            const DeviceGuard device_guard(op.options().device());
             op.tensor = at::empty(shape_, op.options(), MemoryFormat::Contiguous);
             op.current_dtype = op.target_dtype;
           } else if (op.will_resize) {
@@ -1103,6 +1105,7 @@ bool TensorIterator::fast_set_up(const TensorIteratorConfig& config) {
           auto& op = operands_[i];
           if (!op.tensor.defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
+            const DeviceGuard device_guard(op.options().device());
             op.tensor = at::empty(shape_, op.options(), MemoryFormat::ChannelsLast);
             op.current_dtype = op.target_dtype;
           } else if (op.will_resize) {

--- a/aten/src/ATen/templates/DeviceGuardRegister.cpp
+++ b/aten/src/ATen/templates/DeviceGuardRegister.cpp
@@ -1,0 +1,25 @@
+// ${generated_comment}
+
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <torch/library.h>
+#include <ATen/core/op_registration/hacky_wrapper_for_legacy_signatures.h>
+#include <c10/core/TensorOptions.h>
+
+namespace at {
+
+namespace {
+
+TORCH_LIBRARY_IMPL(_, DeviceGuard, m) {
+  // TODO: proper fallback
+  m.fallback(torch::CppFunction::makeFallthrough());
+}
+
+${device_guard_function_definitions}
+
+TORCH_LIBRARY_IMPL(aten, DeviceGuard, m) {
+  ${device_guard_function_registrations};
+}
+
+} // namespace
+}

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -257,6 +257,8 @@ enum class DispatchKey : uint8_t {
   // for a usage example
   TESTING_ONLY_GenericMode,
 
+  DeviceGuard,
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FIN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
   NumDispatchKeys, // Sentinel, end of runtime keys.
 

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -537,7 +537,7 @@ def compute_device_guard(*, target: Target) -> Callable[[NativeFunction], Option
 // aten::{f.func}
 {legacy_dispatcher_returns_type} {name}({', '.join(a.str_with_default() for a in legacy_dispatcher_args)}) {{
   {guard}
-  c10::impl::ExcludeDispatchKeyGuard(c10::DispatchKey::DeviceGuard);
+  c10::impl::ExcludeDispatchKeyGuard guard(c10::DispatchKey::DeviceGuard);
   static auto op = c10::Dispatcher::singleton()
     .findSchemaOrThrow("aten::{f.func.name.name}", "{f.func.name.overload_name}")
     .typed<{dispatcher_returns_type} ({', '.join(a.type for a in dispatcher_args)})>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44033 DeviceGuard dispatch key**

It turned out this was pretty easy to do after the codegen rewrite, so
I wanted to give it a try in case there were some performance benefits.

The basic concept is to remove DeviceGuard from the CPUType/CUDAType/TypeDefault
codegen (taking us one step closer) and give it its own dispatch key and
codegen.  Unlike the old implementation, where guarding only occurred
immediately before we actually did a backend implementation, in the new
implementation guarding happens as early as possible, and once we've done it
once, we exclude DeviceGuard from the dispatch key set, so that we never
(redundantly) DeviceGuard again.

Need to see if there is a performance benefit or not.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D23476566](https://our.internmc.facebook.com/intern/diff/D23476566)