### PR TITLE
[jit] implement generic hashing operator

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -204,6 +204,24 @@ struct CAFFE2_API IValue final {
    */
   TORCH_API friend bool _fastEqualsForContainer(const IValue& lhs, const IValue& rhs);
 
+  /**
+   * Hashing for IValues. Returns an IValue-boxed int.
+   *
+   * Some notes:
+   * - Like eager, Tensors are hashed by looking at the pointer. This is not
+   *   strictly correct because two value-equal tensors with different tensor
+   *   pointers will hash differently, but we choose to reproduce the eager
+   *   semantics.
+   * - Hashing is not defined on all built-in IValue types (e.g. list and
+   *   dict), following Python. Calling `hash()` on these types will throw.
+   */
+  IValue hash() const {
+    return (int64_t)IValue::hash(*this);
+  }
+  // This is defined because `c10::hash` dispatches to a function of this
+  // signature. See the member function `hash()`.
+  static size_t hash(const IValue& iv);
+
   /// @private [doxygen private]
   bool isAliasOf(const IValue& rhs) const {
     if (this->tag != rhs.tag) {

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -9,6 +9,7 @@
 #include <c10/core/TensorImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/hash.h>
 #include <ATen/core/Dict.h>
 #include <ATen/core/List.h>
 #include <ATen/core/qualified_name.h>
@@ -223,6 +224,10 @@ struct CAFFE2_API Tuple : c10::intrusive_ptr_target {
     return std::move(elements_);
   }
   std::shared_ptr<TupleType> type() const;
+
+  static size_t hash(const Tuple& t) {
+    return c10::get_hash(t.elements());
+  }
 
   friend bool operator==(const ivalue::Tuple& lhs, const ivalue::Tuple& rhs);
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15170,6 +15170,20 @@ a")
         input = torch.ones(2, 2)
         self.assertEqual(input, parameter_script(input))
 
+    def test_hash_tuple(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+
+            def forward(self, ids: Tuple[int, int]) -> int:
+                return hash(ids)
+
+        # We don't guarantee the return of `hash` is the same across eager and
+        # Python, but it should not throw.
+        scripted_module = torch.jit.script(TestModule())
+        scripted_module((1, 2))
+
+
 
 # known to be failing in tracer
 EXCLUDE_TRACED = {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -676,6 +676,12 @@ void hashValue(Stack* stack) {
   push(stack, int64_t(hash));
 }
 
+void hashGenericIValue(Stack* stack) {
+  auto value = pop(stack);
+  auto hash = (int64_t)IValue::HashAliasedIValue()(value);
+  push(stack, hash);
+}
+
 // As described in https://docs.python.org/3/library/functions.html#round
 // When a number is exactly halfway between two integers, python builtin round
 // function will round to even number. We use round(x/2)*2 to handle the
@@ -1121,8 +1127,8 @@ RegisterOperators reg2({
 
     DEFINE_DIVMOD_MIXED_OP(int, float),
     DEFINE_DIVMOD_MIXED_OP(float, int),
-
 #undef DEFINE_DIVMOD_MIXED_OP
+
     Operator(
         "aten::hash.str(str t) -> int",
         hashValue<std::string>,
@@ -1134,6 +1140,10 @@ RegisterOperators reg2({
     Operator(
         "aten::hash.float(float t) -> int",
         hashValue<double>,
+        aliasAnalysisFromSchema()),
+    Operator(
+        "aten::hash.generic(t value) -> int",
+        hashGenericIValue,
         aliasAnalysisFromSchema()),
 });
 

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -669,17 +669,9 @@ RegisterOperators logging_operators(
          },
          aliasAnalysisFromSchema())});
 
-template <typename T>
 void hashValue(Stack* stack) {
   auto value = pop(stack);
-  auto hash = std::hash<T>()(value.to<T>());
-  push(stack, int64_t(hash));
-}
-
-void hashGenericIValue(Stack* stack) {
-  auto value = pop(stack);
-  auto hash = (int64_t)IValue::HashAliasedIValue()(value);
-  push(stack, hash);
+  push(stack, value.hash());
 }
 
 // As described in https://docs.python.org/3/library/functions.html#round
@@ -1128,22 +1120,9 @@ RegisterOperators reg2({
     DEFINE_DIVMOD_MIXED_OP(int, float),
     DEFINE_DIVMOD_MIXED_OP(float, int),
 #undef DEFINE_DIVMOD_MIXED_OP
-
-    Operator(
-        "aten::hash.str(str t) -> int",
-        hashValue<std::string>,
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::hash.int(int t) -> int",
-        hashValue<int>,
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::hash.float(float t) -> int",
-        hashValue<double>,
-        aliasAnalysisFromSchema()),
     Operator(
         "aten::hash.generic(t value) -> int",
-        hashGenericIValue,
+        hashValue,
         aliasAnalysisFromSchema()),
 });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44047 [jit] implement generic hashing operator**

We want to hash arbitrary ivalues by binding in our generic IValue
hasher into TorchScript.

closes #44038

Differential Revision: [D23480879](https://our.internmc.facebook.com/intern/diff/D23480879)