### PR TITLE
BatchedFallback: stop emitting the entire schema in the fallback warning

### DIFF
--- a/aten/src/ATen/BatchedFallback.cpp
+++ b/aten/src/ATen/BatchedFallback.cpp
@@ -51,15 +51,15 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
   const auto& schema = op.schema();
   const auto num_returns = schema.returns().size();
   TORCH_CHECK(!schema.is_mutable() && !schema.hasAnyAliasInfo(),
-              "Batching rule not implemented for ", schema, "; ",
+              "Batching rule not implemented for ", schema.operator_name(), "; ",
               "the fallback path doesn't work on in-place or view ops.");
   TORCH_CHECK(areAllReturnsTensors(schema) && !areAnyArgumentsTensorList(schema),
-              "Batching rule not implemented for ", schema, ". ",
+              "Batching rule not implemented for ", schema.operator_name(), ". ",
               "We could not generate a fallback.");
   TORCH_CHECK(num_returns >= 1,
-              "Batching rule not implemented for ", schema, ". ",
+              "Batching rule not implemented for ", schema.operator_name(), ". ",
               "The fallback path does not support operations with no returns.");
-  TORCH_WARN("Batching rule not implemented for ", schema, " falling back "
+  TORCH_WARN("Batching rule not implemented for ", schema.operator_name(), " falling back "
              "to slow (for loop and stack) implementation");
 
   const auto num_arguments = schema.arguments().size();

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -123,7 +123,11 @@ class TestVmapAPI(TestCase):
     def test_unsupported_op_err_msg(self):
         # Unsupported view op
         tensor = torch.randn(2, 3)
-        with self.assertRaisesRegex(RuntimeError, "doesn't work on in-place or view ops"):
+        msg = (
+            "Batching rule not implemented for aten::as_strided; the "
+            "fallback path doesn't work on in-place or view ops"
+        )
+        with self.assertRaisesRegex(RuntimeError, msg):
             vmap(torch.as_strided, (0, None, None))(tensor, [2, 3], [0, 0])
 
         # The fallback doesn't support TensorList


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44052 Register some backwards functions as operators
* **#44051 BatchedFallback: stop emitting the entire schema in the fallback warning**

Instead, just emit the operator name. The entire schema is pretty wordy
and doesn't add any additional information.

Test Plan:
- modified test: `pytest test/test_vmap.py -v`

Differential Revision: [D23481184](https://our.internmc.facebook.com/intern/diff/D23481184)