### PR TITLE
Add Profile template argument to dispatcher.

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -135,6 +135,7 @@ public:
   Return redispatch(const TypedOperatorHandle<Return (Args...)>& op, DispatchKey currentDispatchKey, Args... args) const;
 
   // Invoke an operator via the boxed calling convention using an IValue stack
+  template<bool Profile=false>
   void callBoxed(const OperatorHandle& op, Stack* stack) const;
 
   // ------------------------------------------------------------------------
@@ -288,8 +289,9 @@ public:
     return TypedOperatorHandle<FuncType>(operatorIterator_);
   }
 
+  template <bool Profile=false>
   void callBoxed(Stack* stack) const {
-    c10::Dispatcher::singleton().callBoxed(*this, stack);
+    c10::Dispatcher::singleton().callBoxed<Profile>(*this, stack);
   }
 
 private:
@@ -405,6 +407,7 @@ inline Return Dispatcher::redispatch(const TypedOperatorHandle<Return (Args...)>
   return kernel.template call<Return, Args...>(op, std::forward<Args>(args)...);
 }
 
+template<bool Profile>
 inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const {
   // note: this doesn't need the mutex because write operations on the list keep iterators intact.
   const auto& entry = op.operatorIterator_->op;

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -1692,7 +1692,7 @@ TEST(NewOperatorRegistrationTest, BackendSelectRedispatchesToCPU) {
   m.impl("fn", c10::DispatchKey::BackendSelect, [&](const Tensor& x) {
      backend_generic_called = true;
      auto op = c10::Dispatcher::singleton().findSchema({"test::fn", ""}).value().typed<Tensor (const Tensor&)>();
-     return c10::Dispatcher::singleton().redispatch<Tensor, const Tensor&>(op, c10::DispatchKey::BackendSelect, x);
+     return op.redispatch(c10::DispatchKey::BackendSelect, x);
    });
 
   auto op = Dispatcher::singleton().findSchema({"test::fn", ""});

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -379,14 +379,14 @@ UNBOXED_TRACE_DISPATCH = CodeTemplate("""\
 static auto op = c10::Dispatcher::singleton()
     .findSchemaOrThrow("aten::${operator_name}", "${overload_name}")
     .typed<${return_type} (${arg_types})>();
-${assign_return_values}c10::Dispatcher::singleton().redispatch<${ret_and_arg_types}>(${trace_dispatch_args});
+${assign_return_values}op.redispatch(${trace_dispatch_args});
 """)
 TRACE_DISPATCH = CodeTemplate("""\
 static auto op = c10::Dispatcher::singleton()
     .findSchemaOrThrow("aten::${operator_name}", "${overload_name}")
     .typed<${return_type} (${schema_order_arg_types})>();
-${assign_return_values}c10::Dispatcher::singleton()
-    .redispatch<${schema_order_ret_and_arg_types}>(${schema_order_trace_dispatch_args});
+${assign_return_values}op
+    .redispatch(${schema_order_trace_dispatch_args});
 """)
 
 
@@ -744,8 +744,8 @@ def emit_trace_body(declaration):
     schema_order_ret_and_arg_types = ', '.join(
         [declaration['return_type']] + [a['type'] for a in declaration['schema_order_arguments']])
 
-    trace_dispatch_args = ['op', 'c10::DispatchKey::Tracer'] + declaration['args']
-    schema_order_trace_dispatch_args = ['op', 'c10::DispatchKey::Tracer'] + declaration['schema_order_args']
+    trace_dispatch_args = ['c10::DispatchKey::Tracer'] + declaration['args']
+    schema_order_trace_dispatch_args = ['c10::DispatchKey::Tracer'] + declaration['schema_order_args']
     assign_return_values = '{} = '.format(tie_return_values) if not modifies_arguments and not returns_void else ''
     if declaration['use_c10_dispatcher'] == 'full':
         call = TRACE_DISPATCH.substitute(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44033 DeviceGuard dispatch key
* **#44053 Add Profile template argument to dispatcher.**

The profile template argument can be used to prevent generation of
profiling code for a dispatch call, which is a good idea when your
dispatch handler is very small and you shouldn't spend time profiling
it.

While doing this, I also restructured redispatch so it also was
a method on TypedOperatorHandle, and rewrote some call sites to use
the direct method, which shortened some of our generated code.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>