### PR TITLE
[JIT] Improve error message for unsupported Optional types

### DIFF
--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -292,11 +292,14 @@ def try_ann_to_type(ann, loc):
         value = try_ann_to_type(ann.__args__[1], loc)
         return DictType(key, value)
     if is_optional(ann):
+        print(ann)
+        print(ann.__args__)
         if issubclass(ann.__args__[1], type(None)):
-            valid_type = try_ann_to_type(ann.__args__[0], loc)
+            contained = ann.__args__[0]
         else:
-            valid_type = try_ann_to_type(ann.__args__[1], loc)
-        assert valid_type, "Unsupported annotation {} could not be resolved.".format(repr(ann))
+            contained = ann.__args__[1]
+        valid_type = try_ann_to_type(contained, loc)
+        assert valid_type, "Unsupported annotation {} could not be resolved.".format(repr(contained))
         return OptionalType(valid_type)
     if torch.distributed.rpc.is_available() and is_rref(ann):
         return RRefType(try_ann_to_type(ann.__args__[0], loc))

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -292,14 +292,13 @@ def try_ann_to_type(ann, loc):
         value = try_ann_to_type(ann.__args__[1], loc)
         return DictType(key, value)
     if is_optional(ann):
-        print(ann)
-        print(ann.__args__)
         if issubclass(ann.__args__[1], type(None)):
             contained = ann.__args__[0]
         else:
             contained = ann.__args__[1]
         valid_type = try_ann_to_type(contained, loc)
-        assert valid_type, "Unsupported annotation {} could not be resolved.".format(repr(contained))
+        msg = "Unsupported annotation {} could not be resolved because {} could not be resolved."
+        assert valid_type, msg.format(repr(ann), repr(contained))
         return OptionalType(valid_type)
     if torch.distributed.rpc.is_available() and is_rref(ann):
         return RRefType(try_ann_to_type(ann.__args__[0], loc))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44054 [JIT] Improve error message for unsupported Optional types**

**Summary**
This commit improves the error message that is printed when an
`Optional` type annotation with an unsupported contained type is
encountered. At present, the `Optional` is printed as-is, and
`Optional[T]` is syntatic sugar for `Union[T, None]`, so that is what
shows up in the error message and can be confusing. This commit modifies
the error message so that it prints `T` instead of `Union[T, None]`.

**Test Plan**
Continuous integration.

Example of old message:
```
AssertionError: Unsupported annotation typing.Union[typing.List, NoneType] could not be resolved.
```
Example of new message:
```
AssertionError: Unsupported annotation typing.Union[typing.List, NoneType] could not be resolved because typing.List could not be resolved.
```

**Fixes**
This commit fixes #42859.

Differential Revision: [D23490365](https://our.internmc.facebook.com/intern/diff/D23490365)