### PR TITLE
Merge CriterionTest into NewCriterionTest.

### DIFF
--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -184,8 +184,7 @@ def move_cpp_tensors_to_device(cpp_tensor_stmts, device):
     return ['{}.to("{}")'.format(tensor_stmt, device) for tensor_stmt in cpp_tensor_stmts]
 
 def is_criterion_test(test_instance):
-    return isinstance(test_instance, common_nn.CriterionTest) or \
-        isinstance(test_instance, common_nn.NewCriterionTest)
+    return isinstance(test_instance, common_nn.NewCriterionTest)
 
 # This function computes the following:
 # - What variable declaration statements should show up in the C++ parity test function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44060 For CriterionTests, have check_gradgrad actually only affect gradgrad checks.
* #44056 Rename CriterionTest to NewCriterionTest.
* **#44055 Merge CriterionTest into NewCriterionTest.**
* #44050 Allow criterion backwards test on modules requiring extra args (i.e. CTCLoss).
* #44030 Actually run backward criterion tests.

There is no functional change here.  Another patch will rename NewCriterionTest to CriterionTest.

Differential Revision: [D23482572](https://our.internmc.facebook.com/intern/diff/D23482572)