### PR TITLE
Rename NewCriterionTest to CriterionTest.

### DIFF
--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -21,7 +21,7 @@ TorchNNModuleTestParams = namedtuple(
         # Unique identifier for this module config (e.g. "BCELoss_weights_cuda")
         'module_variant_name',
 
-        # An instance of an NN test class (e.g. `NewCriterionTest`) which stores
+        # An instance of an NN test class (e.g. `CriterionTest`) which stores
         # necessary information (e.g. input / target / extra_args) for running the Python test
         'test_instance',
 
@@ -185,7 +185,7 @@ def move_cpp_tensors_to_device(cpp_tensor_stmts, device):
 
 def is_criterion_test(test_instance):
     return isinstance(test_instance, common_nn.CriterionTest) or \
-        isinstance(test_instance, common_nn.NewCriterionTest)
+        isinstance(test_instance, common_nn.CriterionTest)
 
 # This function computes the following:
 # - What variable declaration statements should show up in the C++ parity test function

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -30,8 +30,8 @@ for test_params_dicts, test_instance_class in [
     (sample_functional.functional_tests, common_nn.NewModuleTest),
     (common_nn.module_tests, common_nn.ModuleTest),
     (common_nn.new_module_tests, common_nn.NewModuleTest),
-    (common_nn.criterion_tests, common_nn.NewCriterionTest),
-    (common_nn.new_criterion_tests, common_nn.NewCriterionTest),
+    (common_nn.criterion_tests, common_nn.CriterionTest),
+    (common_nn.new_criterion_tests, common_nn.CriterionTest),
 ]:
     for test_params_dict in test_params_dicts:
         if test_params_dict.get('test_cpp_api_parity', True):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -38,7 +38,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
     get_function_arglist, load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
     ALL_TENSORTYPES2, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
-from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, NewCriterionTest, \
+from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, new_criterion_tests, loss_reference_fns, \
     ctcloss_reference, new_module_tests
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
@@ -8742,7 +8742,7 @@ for test_params in module_tests + new_module_tests:
 for test_params in criterion_tests + new_criterion_tests:
     name = test_params.pop('module_name')
     test_params['constructor'] = getattr(nn, name)
-    test = NewCriterionTest(**test_params)
+    test = CriterionTest(**test_params)
     decorator = test_params.pop('decorator', None)
     add_test(test, decorator)
     if 'check_sum_reduction' in test_params:
@@ -8757,7 +8757,7 @@ for test_params in criterion_tests + new_criterion_tests:
             return sum_reduction_constructor
 
         test_params['constructor'] = gen_sum_reduction_constructor(test_params['constructor'])
-        test = NewCriterionTest(**test_params)
+        test = CriterionTest(**test_params)
         add_test(test, decorator)
 
 

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5032,7 +5032,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):
         return self._get_arg('constructor_args', False)
 
 
-class NewCriterionTest(InputVariableMixin, TestBase):
+class CriterionTest(InputVariableMixin, TestBase):
     # TODO: check that criterions don't ignore grad_output
 
     _required_arg_names = TestBase._required_arg_names.union({'target'})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44060 For CriterionTests, have check_gradgrad actually only affect gradgrad checks.
* **#44056 Rename CriterionTest to NewCriterionTest.**
* #44055 Merge CriterionTest into NewCriterionTest.
* #44050 Allow criterion backwards test on modules requiring extra args (i.e. CTCLoss).
* #44030 Actually run backward criterion tests.

Differential Revision: [D23482573](https://our.internmc.facebook.com/intern/diff/D23482573)