### PR TITLE
For CriterionTests, have check_gradgrad actually only affect gradgrad checks.

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5070,9 +5070,6 @@ class CriterionTest(InputVariableMixin, TestBase):
         self._do_extra_tests(test_case, module, input, target)
 
     def _do_extra_tests(self, test_case, module, input, target):
-        if not self.check_gradgrad:
-            return
-
         test_case.assertFalse(target.requires_grad)
 
         params = tuple(x for x in module.parameters())
@@ -5090,6 +5087,10 @@ class CriterionTest(InputVariableMixin, TestBase):
         # TODO: we don't pass `target` as part of inputs because we don't
         # currently compute the gradient w.r.t. target for loss functions.
         gradcheck(apply_fn, inputs)
+
+        if not self.check_gradgrad:
+            return
+
         gradgradcheck(apply_fn, inputs)
 
     def test_cuda(self, test_case, dtype=None, extra_args=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44060 For CriterionTests, have check_gradgrad actually only affect gradgrad checks.**
* #44056 Rename CriterionTest to NewCriterionTest.
* #44055 Merge CriterionTest into NewCriterionTest.
* #44050 Allow criterion backwards test on modules requiring extra args (i.e. CTCLoss).
* #44030 Actually run backward criterion tests.

Right now it skips grad checks as well.

Differential Revision: [D23484018](https://our.internmc.facebook.com/intern/diff/D23484018)