### PR TITLE
[cpp] Add distance-agnostic triplet loss to core

### DIFF
--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -546,6 +546,95 @@ inline Tensor triplet_margin_loss(
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
+inline Tensor triplet_margin_loss_with_distance(
+    const Tensor& anchor,
+    const Tensor& positive,
+    const Tensor& negative,
+    c10::optional<TripletMarginLossWithDistanceFuncOptions::distance_function_t> distance_function,
+    bool is_similarity_function,
+    double margin,
+    bool swap,
+    TripletMarginLossWithDistanceFuncOptions::reduction_t reduction) {
+  Tensor dist_pos, dist_neg;
+  if (distance_function.has_value()) {
+    auto distance_function_impl = distance_function.value();
+    dist_pos = distance_function_impl(anchor, positive);
+    dist_neg = distance_function_impl(anchor, negative);
+  } else {
+    dist_pos = pairwise_distance(anchor, positive);
+    dist_neg = pairwise_distance(anchor, negative);
+  }
+
+  if (swap) {
+    Tensor dist_swap;
+    if (distance_function.has_value()) {
+      dist_swap = distance_function.value()(positive, negative);
+    } else {
+      dist_swap = pairwise_distance(positive, negative);
+    }
+    if (is_similarity_function) {
+      dist_neg = torch::max(dist_neg, dist_swap);
+    } else {
+      dist_neg = torch::min(dist_neg, dist_swap);
+    }
+  }
+
+  Tensor loss, ret;
+  if (is_similarity_function) {
+    loss = torch::clamp_min(dist_neg - dist_pos + margin, 0);
+  } else {
+    loss = torch::clamp_min(dist_pos - dist_neg + margin, 0);
+  }
+
+  if (c10::get_if<enumtype::kNone>(&reduction)) {
+    ret = loss;
+  } else if (c10::get_if<enumtype::kMean>(&reduction)) {
+    ret = loss.mean();
+  } else if (c10::get_if<enumtype::kSum>(&reduction)) {
+    ret = loss.sum();
+  } else {
+    ret = anchor;
+    TORCH_INTERNAL_ASSERT(
+      false,
+      enumtype::get_enum_name(reduction),
+      " is not valid");
+  }
+  return ret;
+}
+} // namespace detail
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+/// See https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.triplet_margin_loss_with_distance
+/// about the exact behavior of this functional.
+///
+/// See the documentation for `torch::nn::functional::TripletMarginLossWithDistanceFuncOptions` class to learn what
+/// optional arguments are supported for this functional.
+///
+/// Example:
+/// ```
+/// namespace F = torch::nn::functional;
+/// F::triplet_margin_loss_with_distance(anchor, positive, negative, F::TripletMarginLossWithDistanceFuncOptions().margin(1.0));
+/// ```
+inline Tensor triplet_margin_loss_with_distance(
+    const Tensor& anchor,
+    const Tensor& positive,
+    const Tensor& negative,
+    const TripletMarginLossWithDistanceFuncOptions& options = {}) {
+  return detail::triplet_margin_loss_with_distance(
+    anchor,
+    positive,
+    negative,
+    options.distance_function(),
+    options.is_similarity_function(),
+    options.margin(),
+    options.swap(),
+    options.reduction());
+}
+
+// ============================================================================
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace detail {
 inline Tensor ctc_loss(const Tensor& log_probs,
                        const Tensor& targets,
                        const Tensor& input_lengths,

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -309,7 +309,7 @@ struct TORCH_API SmoothL1LossImpl : public Cloneable<SmoothL1LossImpl> {
 TORCH_MODULE(SmoothL1Loss);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MultiLabelMarginLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  
+
 /// Creates a criterion that optimizes a multi-class multi-classification
 /// hinge loss (margin-based loss) between input :math:`x` (a 2D mini-batch `Tensor`)
 /// and output :math:`y` (which is a 2D `Tensor` of target class indices).
@@ -421,9 +421,9 @@ TORCH_MODULE(MultiLabelSoftMarginLoss);
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ TripletMarginLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that measures the triplet loss given an input
-/// tensors :math:`x1`, :math:`x2`, :math:`x3` and a margin with a value greater 
+/// tensors :math:`x1`, :math:`x2`, :math:`x3` and a margin with a value greater
 /// than :math:`0`. This is used for measuring a relative similarity between
-/// samples. A triplet is composed by `a`, `p` and `n` (i.e., `anchor`, 
+/// samples. A triplet is composed by `a`, `p` and `n` (i.e., `anchor`,
 /// `positive examples` and `negative examples` respectively). The
 /// shapes of all input tensors should be :math:`(N, D)`.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.TripletMarginLoss to learn
@@ -460,6 +460,48 @@ struct TORCH_API TripletMarginLossImpl : public Cloneable<TripletMarginLossImpl>
 /// See the documentation for `ModuleHolder` to learn about PyTorch's
 /// module storage semantics.
 TORCH_MODULE(TripletMarginLoss);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ TripletMarginLossWithDistance ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Creates a criterion that measures the triplet loss given input
+/// tensors :math:`a`, :math:`p`, and :math:`n` (representing anchor,
+/// positive, and negative examples, respectively); and a real-valued function
+/// between them.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.TripletMarginLossWithDistance to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::TripletMarginLossWithDistanceOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// TripletMarginLossWithDistance model(TripletMarginLossWithDistanceOptions().margin(3).swap(false));
+/// ```
+struct TORCH_API TripletMarginLossWithDistanceImpl : public Cloneable<TripletMarginLossWithDistanceImpl> {
+  explicit TripletMarginLossWithDistanceImpl(
+      const TripletMarginLossWithDistanceOptions& options_ = {});
+
+  void reset() override;
+
+  /// Pretty prints the `TripletMarginLossWithDistance` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override;
+
+  Tensor forward(
+      const Tensor& anchor,
+      const Tensor& positive,
+      const Tensor& negative);
+
+  /// The options with which this `Module` was constructed.
+  TripletMarginLossWithDistanceOptions options;
+};
+
+/// A `ModuleHolder` subclass for `TripletMarginLossWithDistanceImpl`.
+/// See the documentation for `TripletMarginLossWithDistanceImpl` class to learn what methods it
+/// provides, and examples of how to use `TripletMarginLossWithDistance` with
+/// `torch::nn::TripletMarginLossWithDistanceOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
+TORCH_MODULE(TripletMarginLossWithDistance);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CTCLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -626,9 +668,9 @@ TORCH_MODULE(NLLLoss);
 struct TORCH_API CrossEntropyLossImpl : public Cloneable<CrossEntropyLossImpl> {
   explicit CrossEntropyLossImpl(
       const CrossEntropyLossOptions& options_ = {});
-    
+
   void reset() override;
-    
+
   /// Pretty prints the `CrossEntropyLoss` module into the given `stream`.
   void pretty_print(std::ostream& stream) const override;
 

--- a/torch/csrc/api/include/torch/nn/options/loss.h
+++ b/torch/csrc/api/include/torch/nn/options/loss.h
@@ -388,6 +388,49 @@ using TripletMarginLossFuncOptions = TripletMarginLossOptions;
 
 // ============================================================================
 
+/// Options for the `TripletMarginLossWithDistance` module.
+///
+/// Example:
+/// ```
+/// TripletMarginLossWithDistance model(TripletMarginLossWithDistanceOptions().margin(3).swap(false));
+/// ```
+struct TORCH_API TripletMarginLossWithDistanceOptions {
+  typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
+  typedef std::function<Tensor(const Tensor&, const Tensor&)> distance_function_t;
+
+  /// Specifies a metric function that quantifies the relationship
+  /// between two Tensors. Default: nullopt
+  TORCH_ARG(c10::optional<distance_function_t>, distance_function) = c10::nullopt;
+  /// Specifies whether the optional metric function is a similarity metric, i.e.,
+  /// larger values indicate that the Tensors are more similar. Default: False
+  TORCH_ARG(bool, is_similarity_function) = false;
+  /// Specifies the threshold for which the distance of a negative sample must
+  /// reach in order to incur zero loss. Default: 1
+  TORCH_ARG(double, margin) = 1.0;
+  /// The distance swap is described in detail in the paper Learning shallow
+  /// convolutional feature descriptors with triplet losses by V. Balntas,
+  /// E. Riba et al. Default: False
+  TORCH_ARG(bool, swap) = false;
+  /// Specifies the reduction to apply to the output. Default: Mean
+  TORCH_ARG(reduction_t, reduction) = torch::kMean;
+};
+
+namespace functional {
+/// Options for `torch::nn::functional::triplet_margin_loss_with_distance`.
+///
+/// See the documentation for `torch::nn::TripletMarginLossWithDistanceOptions` class to learn what
+/// arguments are supported.
+///
+/// Example:
+/// ```
+/// namespace F = torch::nn::functional;
+/// F::triplet_margin_loss_with_distance(anchor, positive, negative, F::TripletMarginLossWithDistanceFuncOptions().margin(1.0));
+/// ```
+using TripletMarginLossWithDistanceFuncOptions = TripletMarginLossWithDistanceOptions;
+} // namespace functional
+
+// ============================================================================
+
 /// Options for the `CTCLoss` module.
 ///
 /// Example:

--- a/torch/csrc/api/src/nn/modules/loss.cpp
+++ b/torch/csrc/api/src/nn/modules/loss.cpp
@@ -180,6 +180,35 @@ Tensor TripletMarginLossImpl::forward(
 
 // ============================================================================
 
+TripletMarginLossWithDistanceImpl::TripletMarginLossWithDistanceImpl(
+    const TripletMarginLossWithDistanceOptions& options_)
+    : options(options_) {}
+
+void TripletMarginLossWithDistanceImpl::reset() {}
+
+void TripletMarginLossWithDistanceImpl::pretty_print(std::ostream& stream) const {
+  stream << "torch::nn::TripletMarginLossWithDistance(margin=" << options.margin()
+         << std::boolalpha << ", swap=" << options.swap() << ", is_similarity_function="
+         << options.is_similarity_function() << ")";
+}
+
+Tensor TripletMarginLossWithDistanceImpl::forward(
+    const Tensor& anchor,
+    const Tensor& positive,
+    const Tensor& negative) {
+  return F::detail::triplet_margin_loss_with_distance(
+    anchor,
+    positive,
+    negative,
+    options.distance_function(),
+    options.is_similarity_function(),
+    options.margin(),
+    options.swap(),
+    options.reduction());
+}
+
+// ============================================================================
+
 MultiLabelMarginLossImpl::MultiLabelMarginLossImpl(
     const torch::nn::MultiLabelMarginLossOptions& options_)
     : options(options_) {}
@@ -223,9 +252,9 @@ void SmoothL1LossImpl::pretty_print(std::ostream& stream) const {
 Tensor SmoothL1LossImpl::forward(const Tensor& input, const Tensor& target) {
   return F::detail::smooth_l1_loss(input, target, options.reduction());
 }
-  
+
 // ============================================================================
-  
+
 CTCLossImpl::CTCLossImpl(const CTCLossOptions& options_) : options(options_) {}
 
 void CTCLossImpl::reset() {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44072 [cpp] Add distance-agnostic triplet loss to core**
* #43680 [pytorch] Add triplet margin loss with custom distance

Summary: Following up on the C++ side of [this
issue](https://github.com/pytorch/pytorch/issues/43342).  The implementation
here is parallel to that of the Python one, but we don't use native functions
because Callables aren't supported.

Test Plan: Unit test with test_api

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23487547](https://our.internmc.facebook.com/intern/diff/D23487547)