### PR TITLE
[TensorExpr] Fuser: do not fuse ops with 0-dim tensors.

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -246,6 +246,7 @@ namespace jit {
   _(FuserPass_1)                            \
   _(FuserPass_2)                            \
   _(FuserPass_3)                            \
+  _(FuserPass_0DimInput)                    \
   _(TrainBasic)
 
 #define TH_FORALL_TENSOREXPR_TESTS_LLVM(_) \

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -105,7 +105,8 @@ class TestTEFuser(JitTestCase):
     @unittest.skipIf(IS_SANDCASTLE, "NYI: fuser CPU support for Sandcastle")
     def test_sum_simple(self):
         def func(x):
-            return x.sum() * 2
+            x2 = x * x
+            return x2.sum()
 
         a = torch.tensor(list(x for x in range(0, 15)), dtype=torch.float, device='cpu')
         a = a.reshape(5, 3)

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -464,8 +464,13 @@ class TensorExprFuser {
   bool allShapesAreKnown(Node* node) {
     // TODO: Relax the checks to support dynamic shapes
     for (Value* input : node->inputs()) {
-      if (input->type()->cast<TensorType>() && !input->isCompleteTensor()) {
-        return false;
+      if (input->type()->cast<TensorType>()) {
+        if (!input->isCompleteTensor()) {
+          return false;
+        }
+        if (*input->type()->cast<TensorType>()->dim() == 0) {
+          return false;
+        }
       }
     }
     return true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44073 [TensorExpr] Fuser: do not fuse ops with 0-dim tensors.**
* #43961 [JIT] Remove profile nodes before BatchMM.

We don't have a proper support on NNC and JIT IR->NNC lowering side for it yet.

Differential Revision: [D23487905](https://our.internmc.facebook.com/intern/diff/D23487905)