### PR TITLE
Add soft error reporting to capture all the inference runtime failure.

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -400,17 +400,29 @@ mobile::Module _load_for_mobile(
       observer->onExitLoadModel(result.metadata());
     }
     return result;
-  } catch (const std::exception& ex) {
+  } catch (c10::Error& error) {
     if (observer) {
-      observer->onFailLoadModel(
-          "Error occured during loading model: " + (std::string)ex.what());
+      observer->onFailLoadModel(error.what());
     }
-    TORCH_CHECK(false, ex.what());
+    TORCH_RETHROW(error);
   } catch (...) {
-    if (observer) {
-      observer->onFailLoadModel("unknown exception");
+    auto currentException = std::current_exception();
+    try {
+      if (!currentException) {
+        TORCH_CHECK(false, "Unknown exception");
+      } else {
+        try {
+          std::rethrow_exception(currentException);
+        } catch (const std::exception& e) {
+          TORCH_CHECK(false, e.what());
+        }
+      }
+    } catch (c10::Error& error) {
+      if (observer) {
+        observer->onFailLoadModel(error.what());
+      }
+      TORCH_RETHROW(error);
     }
-    TORCH_CHECK(false, "unknown exception");
   }
 }
 

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -73,11 +73,11 @@ class MobileModuleObserver {
       const std::string&) {}
   virtual void onExitRunMethod() {}
   virtual void onCancelRunMethod(const std::string&) {}
-  virtual void onFailRunMethod(const std::string&) {}
+  virtual void onFailRunMethod(const char*) {}
   virtual void onEnterLoadModel() {}
   virtual void onExitLoadModel(
       const std::unordered_map<std::string, std::string>&) {}
-  virtual void onFailLoadModel(const std::string&) {}
+  virtual void onFailLoadModel(const char*) {}
 };
 
 class MobileObserverConfig {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44078 Add soft error reporting to capture all the inference runtime failure.**

When PyTorch mobile inference failed and throw exception, if caller catch and not crash the app, we are not able to track all the inference failures.

So we are adding native soft error reporting to capture all the failures occurring during module loading and running including both crashing and on-crashing failures. Since c10::Error has good error messaging stack handling (D21202891), we are utilizing it for the error handling and message print out.

Differential Revision: [D23428636](https://our.internmc.facebook.com/intern/diff/D23428636/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D23428636/)!