### PR TITLE
Expose alias key info in dumpState and update test_dispatch.

### DIFF
--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -274,6 +274,10 @@ enum class DispatchKey : uint8_t {
   // See Note [Alias Dispatch Key : Autograd]
   Autograd,
 
+  // Define an alias key to represent end of alias dispatch keys.
+  // If you add new alias keys after Autograd, please also update it here.
+  EndOfAliasKeys = Autograd, //
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~ BC ALIASES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
   // The aliases exist for backwards compatibility reasons, they shouldn't
   // be used

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -196,6 +196,8 @@ class TestDispatch(TestCase):
             lambda m: m.impl_t_t("foo"),
             # m.impl("test_def", kCPU, [](const Tensor& x) { return x })
             lambda m: m.impl_t_t("foo", dispatch="cpu"),
+            # m.impl("test_def", kAutograd, [](const Tensor& x) { return x })
+            lambda m: m.impl_t_t("foo", dispatch="autograd"),
             # m.impl("test_def", kAutogradCPU, [](const Tensor& x) { return x })
             lambda m: m.impl_t_t("foo", dispatch="autogradcpu")
         ])
@@ -206,6 +208,7 @@ debug: registered at /dev/null:0
 alias analysis kind: FROM_SCHEMA
 CPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 AutogradCPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+Autograd[alias]: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 catchall: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 ''')
 
@@ -226,6 +229,8 @@ catchall: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
             lambda m: m.def_name_t_t("foo"),
             # m.impl("foo", torch::kCPU, [](const Tensor & x) { return x })
             lambda m: m.impl_t_t("foo", "cpu"),
+            # m.impl("foo", torch::kAutograd, [](const Tensor & x) { return x })
+            lambda m: m.impl_t_t("foo", "autograd"),
             # m.impl("foo", torch::kAutogradCPU, [](const Tensor & x) { return x })
             lambda m: m.impl_t_t("foo", "autogradcpu")
         ])
@@ -236,6 +241,7 @@ debug: registered at /dev/null:0
 alias analysis kind: CONSERVATIVE
 CPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 AutogradCPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+Autograd[alias]: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 catchall: default_def_name_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 ''')
 
@@ -257,6 +263,8 @@ alias analysis kind: FROM_SCHEMA
             lambda m: m.impl_t_t("foo"),
             # m.impl("foo", torch::kCPU, [](const Tensor& x) { return x })
             lambda m: m.impl_t_t("foo", "cpu"),
+            # m.impl("foo", torch::kAutograd, [](const Tensor& x) { return x })
+            lambda m: m.impl_t_t("foo", "autograd"),
             # m.impl("foo", torch::kAutogradCPU, [](const Tensor& x) { return x })
             lambda m: m.impl_t_t("foo", "autogradcpu")
         ])
@@ -265,6 +273,7 @@ name: test::foo
 schema: (none)
 CPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 AutogradCPU: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
+Autograd[alias]: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 catchall: impl_t_t :: (Tensor _0) -> (Tensor _0) [ boxed unboxed ]
 ''')
 

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -30,6 +30,7 @@ c10::optional<c10::DispatchKey> parseDispatchKey(const std::string& k) {
     {"cpu", c10::DispatchKey::CPU},
     {"cuda", c10::DispatchKey::CUDA},
     {"xla", c10::DispatchKey::XLA},
+    {"autograd", c10::DispatchKey::Autograd},
     {"autogradcpu", c10::DispatchKey::AutogradCPU},
     {"", c10::DispatchKey::Undefined},
   };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44088 Check commutativity for computed dispatch table and add a test to check entries.
* **#44081 Expose alias key info in dumpState and update test_dispatch.**
* #44037 Add tests against autograd precedence and multiple dispatch.

Differential Revision: [D23492794](https://our.internmc.facebook.com/intern/diff/D23492794)