### PR TITLE
Enable fp16 for CUDA SparseLengthsSum/Mean

### DIFF
--- a/caffe2/operators/segment_reduction_op_gpu.cuh
+++ b/caffe2/operators/segment_reduction_op_gpu.cuh
@@ -39,8 +39,20 @@ struct SharedMemory<at::Half> {
   }
 };
 
+
+template <typename InType, typename OutType>
+__device__ inline OutType convert_type(const InType in) {
+  return in;
+}
+
+template <>
+__device__ inline float convert_type<at::Half, float>(const at::Half in) {
+  return __half2float(in);
+}
+
 template <
-    typename T,
+    typename InType,
+    typename OutType,
     typename IndexType,
     bool ExactBlock = false,
     bool Average = false>
@@ -48,8 +60,8 @@ template <
 C10_LAUNCH_BOUNDS_2(1024,SEGREDUCE_MINBLOCKS)
 #endif
 __global__ void sparse_length_sum_kernel(
-    const T* __restrict__ in,
-    T* __restrict__ out,
+    const InType* __restrict__ in,
+    OutType* __restrict__ out,
     const int* __restrict__ prefix_sum_length_data,
     const IndexType* __restrict__ indices,
     int N,
@@ -64,22 +76,22 @@ __global__ void sparse_length_sum_kernel(
   CUDA_KERNEL_ASSERT(start <= len_indices);
   CUDA_KERNEL_ASSERT(end <= len_indices);
 
-  struct SharedMemory<T> smem;
-  T* reduceVals = smem.getPointer();
+  struct SharedMemory<OutType> smem;
+  OutType* reduceVals = smem.getPointer();
 
   if (ExactBlock) {
-    T sum = (T)0;
+    OutType sum = (OutType)0;
 
     in += threadIdx.x;
     for (int line = start + threadIdx.y; line < end; line += blockDim.y) {
-      sum += in[indices[line] * post];
+      sum += convert_type<InType, OutType>(in[indices[line] * post]);
     }
 
     reduceVals[threadIdx.y * blockDim.x + threadIdx.x] = sum;
     __syncthreads();
 
     if (threadIdx.y == 0) {
-      sum = (T)0;
+      sum = (OutType)0;
       for (int i = 0; i < blockDim.y; ++i) {
         sum += reduceVals[i * blockDim.x + threadIdx.x];
       }
@@ -91,9 +103,9 @@ __global__ void sparse_length_sum_kernel(
     }
   } else {
     for (int i = threadIdx.x; i < post; i += blockDim.x) {
-      T sum = (T)0;
+      OutType sum = (OutType)0;
       for (int line = start; line < end; ++line) {
-        sum += in[indices[line] * post + i];
+        sum += convert_type<InType, OutType>(in[indices[line] * post + i]);
       }
       if (Average && (end - start) > 1) {
         sum /= (end - start);

--- a/caffe2/python/operator_test/segment_ops_test.py
+++ b/caffe2/python/operator_test/segment_ops_test.py
@@ -14,6 +14,28 @@ from caffe2.python import core, workspace
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
+def sparse_lengths_sum_ref(D, I, L, normalize_by_lengths=False):
+    R = np.zeros(shape=(L.size,) + D.shape[1:], dtype=np.float32)
+    line = 0
+    for g in range(L.size):
+        for _ in range(L[g]):
+            if len(D.shape) > 1:
+                R[g, :] += D[I[line], :]
+            else:
+                R[g] += D[I[line]]
+            line += 1
+
+        if normalize_by_lengths and L[g] > 1:
+            if len(D.shape) > 1:
+                R[g, :] = R[g, :] / L[g]
+            else:
+                R[g] = R[g] / L[g]
+
+    return [R]
+
+def sparse_lengths_mean_ref(D, I, L):
+    return sparse_lengths_sum_ref(D, I, L, normalize_by_lengths=True)
+
 
 class TesterBase:
     def segment_reduce_op(self, data, segment_ids, reducer, indices=None):
@@ -672,6 +694,44 @@ class TestSegmentOps(hu.HypothesisTestCase):
 
         self.assertReferenceChecks(
             gc, op, [D, W, indices, L], ref_sparse)
+
+    @unittest.skipIf(not workspace.has_gpu_support, "No GPU support")
+    @given(
+        input=hu.tensor(min_dim=2, max_dim=2, max_value=20, dtype=np.float16),
+        data_strategy=st.data(),
+        is_mean=st.booleans(),
+        **hu.gcs
+    )
+    @settings(deadline=None)
+    def test_sparse_lengths_fp16(self, input, data_strategy, is_mean, gc, dc):
+        m = input.shape[0]
+
+        lengths = data_strategy.draw(
+            hu.tensor(
+                max_dim=1,
+                max_value=input.shape[0],
+                dtype=np.int32,
+                elements=st.integers(min_value=0, max_value=27),
+            )
+        )
+        lengths_sum = int(np.sum(lengths).item())
+
+        indices = data_strategy.draw(
+            hu.arrays(
+                [lengths_sum], dtype=np.int64, elements=st.sampled_from(np.arange(m))
+            )
+        )
+        if is_mean:
+            op = core.CreateOperator(
+                "SparseLengthsMean", ["input", "indices", "lengths"], "out"
+            )
+            self.assertReferenceChecks(gc, op, [input, indices, lengths], sparse_lengths_mean_ref)
+
+        else:
+            op = core.CreateOperator(
+                "SparseLengthsSum", ["input", "indices", "lengths"], "out"
+            )
+            self.assertReferenceChecks(gc, op, [input, indices, lengths], sparse_lengths_sum_ref)
 
    # @given(
    #     inputs=hu.lengths_tensor(


### PR DESCRIPTION
Summary: Add support of fp16 as input type in SparseLengthSum/Mean caffe2 operator

Differential Revision: D23436877

