### PR TITLE
[fx] get rid of graph_module.root

### DIFF
--- a/test/fx/quantization.py
+++ b/test/fx/quantization.py
@@ -190,7 +190,7 @@ def matches(modules, node, pattern, max_uses=sys.maxsize):
 
 class Quantizer:
     def __init__(self, mod, patterns=DEFAULT_QUANTIZATION_PATTERNS, quant_ctor=DefaultQuant):
-        self.root = mod.root
+        self.root = mod
         self.graph = mod.graph
         self.quant_ctor = quant_ctor
 

--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -162,9 +162,9 @@ class TestQuantizeFx(QuantizationTestCase):
         qconfig = default_dynamic_qconfig
         qconfig_dict = {'': qconfig}
         quantized = quantize_dynamic_fx(original, qconfig_dict, debug=True)
-        qparams = (quantized.root._scale_0, quantized.root._zero_point_0)
+        qparams = (quantized._scale_0, quantized._zero_point_0)
         weight_obs = qconfig.weight()
-        weight_obs(quantized.root.weight)
+        weight_obs(quantized.weight)
         ref_qparams = weight_obs.calculate_qparams()
         self.assertEqual(qparams, ref_qparams)
 

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -191,8 +191,8 @@ class TestFX(JitTestCase):
         a = resnet(ip)
         b = res_graph(ip)
         c = res_script(ip)
-        assert torch.allclose(a, b)
-        assert torch.allclose(a, c)
+        self.assertEqual(a, b)
+        self.assertEqual(a, c)
 
         quantizer = Quantizer(res_graph)
 
@@ -206,7 +206,7 @@ class TestFX(JitTestCase):
         e = qgraph_script(ip)
 
         assert (a - d).abs().max() < 2
-        assert torch.allclose(d, e)
+        self.assertEqual(d, e)
 
     def test_unpack(self):
         class M(torch.nn.Module):
@@ -439,11 +439,10 @@ class TestFX(JitTestCase):
 
         def transform(traced):
             new_graph = copy.deepcopy(traced.graph)
-            delegate = torch.fx.DefaultDelegate(traced.root, new_graph)
-            relu_out = delegate.create_node(
-                kind='call_method', target='neg', args=(new_graph.result,), kwargs={})
+            relu_out = new_graph.create_node(
+                op='call_method', target='neg', args=(new_graph.result,), kwargs={})
             new_graph.output(relu_out)
-            return GraphModule(traced.root, new_graph)
+            return GraphModule(traced, new_graph)
         transformed = transform(traced)
         copied = copy.deepcopy(transformed)
         x = torch.randn(3, 4)

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -34,7 +34,7 @@ def forward_from_src(src : str):
     return gbls['forward']
 
 
-def deserialize_graphmodule(root : torch.nn.Module, src : str) -> torch.nn.Module:
+def deserialize_graphmodule(body : dict) -> torch.nn.Module:
     """
     Deserialize a GraphModule given the original `root` module and the generated
     `forward()` source code (`src`). This will exec() the source of the forward
@@ -45,13 +45,35 @@ def deserialize_graphmodule(root : torch.nn.Module, src : str) -> torch.nn.Modul
     # We create a dummy class here because symbolic_trace pulls the forward()
     # function off of the class, rather than the instance
     class CodeOnlyModule(torch.nn.Module):
-        def __init__(self, root, src):
+        def __init__(self, body):
             super().__init__()
-            self.root = root
-    CodeOnlyModule.forward = forward_from_src(src)
+            self.__dict__ = body
+
+    CodeOnlyModule.forward = forward_from_src(body['code'])
 
     from .symbolic_trace import symbolic_trace
-    return symbolic_trace(CodeOnlyModule(root, src))
+    return symbolic_trace(CodeOnlyModule(body))
+
+# copy an attribute value with qualified name 'target' from 'from_module' to 'to_module'
+# This installs empty Modules where none exist yet if they are subpaths of target
+def _copy_attr(from_module: torch.nn.Module, to_module: torch.nn.Module, target: str):
+    *prefix, field = target.split('.')
+    for item in prefix:
+        f = getattr(from_module, item)
+        t = getattr(to_module, item, None)
+        if f is t:
+            # we have already installed one of its parents
+            # (e.g. target = root.linear.weight, but we have already installed root.linear)
+            # once we install a parent, we no longer need to copy the children
+            # since all the needed properties will already be present
+            return
+
+        if t is None:
+            t = torch.nn.Module()
+            setattr(to_module, item, t)
+        from_module, to_module = f, t
+
+    setattr(to_module, field, getattr(from_module, field))
 
 class GraphModule(torch.nn.Module):
     def __new__(cls: 'Type[GraphModule]', *args, **kwargs):
@@ -66,8 +88,10 @@ class GraphModule(torch.nn.Module):
 
     def __init__(self, root: torch.nn.Module, graph: Graph):
         super().__init__()
-        self.root = root
-        self.training = self.root.training
+        self.training = root.training
+        for node in graph.nodes:
+            if node.op in ['get_param', 'call_module']:
+                _copy_attr(root, self, node.target)
         self.graph = graph
         self._generate_forward()
 
@@ -76,7 +100,6 @@ class GraphModule(torch.nn.Module):
         body = '\n'.join('    ' + line for line in body.split('\n')) + '\n'
         self.code = f"""\
 def forward(self, {', '.join(free_variables)}):
-    self = self.root
 {body}
     return {result}
 """
@@ -84,7 +107,7 @@ def forward(self, {', '.join(free_variables)}):
         cls.forward = forward_from_src(self.code)
 
     def __reduce__(self):
-        return (deserialize_graphmodule, (self.root, self.code))
+        return (deserialize_graphmodule, (self.__dict__,))
 
 # workarounds for issues in __torch_function__
 

--- a/torch/quantization/fx/fuse.py
+++ b/torch/quantization/fx/fuse.py
@@ -17,7 +17,7 @@ from .fusion_patterns import *  # noqa: F401
 import copy
 class Fuser:
     def fuse(self, model, inplace=False):
-        input_root = model.root
+        input_root = model
         if not inplace:
             input_root = copy.deepcopy(input_root)
         input_graph = model.graph

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -168,7 +168,7 @@ class Quantizer:
 
     def _prepare(self, model, qconfig_dict, inplace, is_dynamic_quant):
         assert not inplace, 'inplace prepare is not supported yet'
-        input_root = model.root
+        input_root = model
         if not inplace:
             input_root = copy.deepcopy(input_root)
 
@@ -303,7 +303,7 @@ class Quantizer:
                         weight_observer_nodes = collect_producer_nodes(node_arg)
                         if weight_observer_nodes is not None:
                             weight_observer_module = graph_module_from_producer_nodes(
-                                observed.root, weight_observer_nodes)
+                                observed, weight_observer_nodes)
                             # run the weight observer
                             weight_observer_module()
         return
@@ -319,7 +319,7 @@ class Quantizer:
 
         # move to cpu since we only have quantized cpu kernels
         observed.eval().cpu()
-        observed_root = observed.root
+        observed_root = observed
         observed_graph = observed.graph
         if not inplace:
             observed_root = copy.deepcopy(observed_root)
@@ -514,7 +514,7 @@ class Quantizer:
                         folded_nodes[node_to_fold.name] = node
 
                     prepacking_module = graph_module_from_producer_nodes(
-                        quantized.root, nodes_to_fold)
+                        quantized, nodes_to_fold)
                     packed_weight = prepacking_module()
                     packed_weights[node.name] = packed_weight
 
@@ -525,7 +525,7 @@ class Quantizer:
         def load_arg(a):
             return map_arg(a, lambda node: env[node.name])
         get_new_packed_weight_name = get_new_attr_name_with_prefix('_fx_pass_packed_weight_')
-        quantized_root = quantized.root
+        quantized_root = quantized
         quantized_graph = quantized.graph
         for node in quantized_graph.nodes:
             prepack_node = folded_nodes.get(node.name, None)

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -527,7 +527,7 @@ class QuantizationTestCase(TestCase):
         """
         nodes_in_graph = dict()
         node_list = []
-        modules = dict(graph_module.root.named_modules())
+        modules = dict(graph_module.named_modules())
         for node in graph_module.graph.nodes:
             n = None
             if node.op == 'call_function' or node.op == 'call_method':
@@ -579,7 +579,7 @@ class QuantizationTestCase(TestCase):
                 str(expected_node_list))
 
     def printGraphModule(self, graph_module, print_str=True):
-        modules = dict(graph_module.root.named_modules())
+        modules = dict(graph_module.named_modules())
         node_infos = []
         for n in graph_module.graph.nodes:
             node_info = ' '.join(map(repr, [n.op, n.name, n.target, n.args, n.kwargs]))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44092 [fx] get rid of graph_module.root**

instead submodules and weights are installed directly on the
graph_module by transferring the original modules. This makes it more
likely that scripting will succeed (since we no longer have submodules
that are not used in the trace). It also prevents layered transforms
from having to special case handling of the `root` module. GraphModules
can now be re-traced as part of the input to other transforms.

Differential Revision: [D23504210](https://our.internmc.facebook.com/intern/diff/D23504210)