### PR TITLE
Test TE fuser unary ops and fix sigmoid(half)

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -384,7 +384,8 @@ namespace jit {
   _(CudaSharedMemReduce_1)                 \
   _(CudaLocalMemReduce_1)                  \
   _(CudaTestRand01)                        \
-  _(CudaSigmoid)
+  _(CudaSigmoid)                           \
+  _(CudaHalfCast)
 
 #define DECLARE_TENSOREXPR_TEST(name) void test##name();
 TH_FORALL_TENSOREXPR_TESTS(DECLARE_TENSOREXPR_TEST)

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1113,5 +1113,63 @@ class TestTEFuser(JitTestCase):
 
         torch._C._jit_override_can_fuse_on_cpu(old_cpu_fuser_state)
 
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_unary_ops(self):
+        def apply(fn):
+            return lambda x: fn(2 * x)
+
+        def rand(dtype, device="cuda"):
+            shape = (4, 4)
+            if dtype == torch.bool:
+                return torch.rand(shape, dtype=torch.float32, device=device) > 0.5
+            elif dtype in [torch.qint8, torch.quint8, torch.qint32]:
+                return torch.quantize_per_tensor(torch.rand(shape, dtype=torch.float32, device=device), .01, 1, dtype=dtype)
+            elif dtype.is_complex:
+                return torch.rand(shape, dtype=dtype, device=device)
+            elif dtype.is_floating_point:
+                return torch.rand(shape, dtype=dtype, device=device)
+            else:
+                # dtype is an integer.
+                return torch.randint(0, 100, shape, dtype=dtype, device=device)
+            raise RuntimeError("Unhandled dtype")
+
+        dtypes = [
+            torch.int8,
+            torch.uint8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            torch.float16,
+            torch.bfloat16,
+            torch.float32,
+            torch.float64,
+            torch.bool,
+            torch.complex32,
+            torch.complex64,
+            torch.complex128,
+            torch.qint8,
+            torch.quint8,
+            torch.qint32,
+        ]
+        unary_ops = [
+            torch.sigmoid,
+        ]
+        devices = [
+            "cuda",
+        ]
+        for dtype, op, device in product(dtypes, unary_ops, devices):
+            x = rand(dtype, device)
+            fn = apply(op)
+            try:
+                ref = fn(x)
+            except Exception:
+                # If eager mode doesn't support a dtype/op/device combo,
+                # neither does the fuser.  Catch everything to avoid needing to
+                # guess what errors might be thrown by eager.
+                continue
+            t = torch.jit.trace(fn, (x,))
+            self.assertEqual(ref, t(x))
+            self.assertAllFused(t.graph_for(x))
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1158,9 +1158,9 @@ class TestTEFuser(JitTestCase):
             "cuda",
         ]
         for dtype, op, device in product(dtypes, unary_ops, devices):
-            x = rand(dtype, device)
-            fn = apply(op)
             try:
+                x = rand(dtype, device)
+                fn = apply(op)
                 ref = fn(x)
             except Exception:
                 # If eager mode doesn't support a dtype/op/device combo,

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -50,8 +50,9 @@ std::unique_ptr<CodeGen> CreateCodeGen(
 const Expr* GenericIntrinsicsExpander::mutate(const Intrinsics* v) {
   if (v->op_type() == kSigmoid) {
     auto x = v->param(0)->accept_mutator(this);
-    ExprHandle y = ExprHandle(1.0f) /
-        (ExprHandle(1.0f) + exp(ExprHandle(-0.0f) - ExprHandle(x)));
+    auto one = ExprHandle(getImmediateByType(v->dtype(), 1.0));
+    auto zero = ExprHandle(getImmediateByType(v->dtype(), 0.0));
+    ExprHandle y = one / (one + exp(zero - ExprHandle(x)));
     return y.node();
   }
   return IRMutator::mutate(v);

--- a/torch/csrc/jit/tensorexpr/cuda_half_support.h
+++ b/torch/csrc/jit/tensorexpr/cuda_half_support.h
@@ -16,9 +16,12 @@ class CudaHalfChecker : public IRVisitor {
 
   void visit(const Load* v) override {
     hasHalf_ |= v->dtype().scalar_type() == ScalarType::Half;
+    IRVisitor::visit(v);
   }
+
   void visit(const Store* v) override {
     hasHalf_ |= v->value()->dtype().scalar_type() == ScalarType::Half;
+    IRVisitor::visit(v);
   }
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44122 [te] Disable reductions by default
* **#44094 Test TE fuser unary ops and fix sigmoid(half)**

Differential Revision: [D23494950](https://our.internmc.facebook.com/intern/diff/D23494950)