### PR TITLE
[TensorExpr] Benchmarks: set number of profiling runs to 2 for PE.

### DIFF
--- a/benchmarks/fastrnns/fuser.py
+++ b/benchmarks/fastrnns/fuser.py
@@ -6,6 +6,7 @@ def set_fuser(fuser_name, executor_name):
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(True)
         torch._C._jit_set_bailout_depth(20)
+        torch._C._jit_set_num_profiled_runs(2)
         torch._C._jit_override_can_fuse_on_cpu(False)
         torch._C._jit_override_can_fuse_on_gpu(True)
         torch._C._jit_set_texpr_fuser_enabled(True)
@@ -26,6 +27,7 @@ def set_fuser(fuser_name, executor_name):
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(True)
         torch._C._jit_set_bailout_depth(20)
+        torch._C._jit_set_num_profiled_runs(2)
     elif executor_name == 'simple':
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44112 [TensorExpr] Benchmarks: set number of profiling runs to 2 for PE.**

Differential Revision: [D23500904](https://our.internmc.facebook.com/intern/diff/D23500904)