### PR TITLE
fx qat: respect device affinity

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -28,12 +28,17 @@ from torch.quantization import (
 )
 
 # test utils
+from torch.testing._internal.common_cuda import TEST_MULTIGPU, TEST_CUDA
 from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
     skipIfNoFBGEMM,
     skip_if_no_torchvision,
     train_one_epoch,
     run_ddp,
+)
+
+from torch.testing._internal.common_quantized import (
+    override_qengines,
 )
 
 from torch.testing._internal.common_distributed import skip_if_not_multigpu
@@ -167,6 +172,51 @@ class TestQuantizeFx(QuantizationTestCase):
         weight_obs(quantized.root.weight)
         ref_qparams = weight_obs.calculate_qparams()
         self.assertEqual(qparams, ref_qparams)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @override_qengines
+    def test_qat_prepare_device_affinity(self):
+        """
+        Tests that FX QAT prepare pass respects device affinity
+        """
+        class Model(nn.Module):
+
+            def __init__(self):
+                super(Model, self).__init__()
+                self.conv = nn.Conv2d(1, 1, 1)
+                self.bn = nn.BatchNorm2d(1)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.bn(x)
+                x = self.relu(x)
+                return x
+
+        model = Model()
+        qengine = torch.backends.quantized.engine
+        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig(qengine)}
+        device = torch.device('cuda:0')
+        model.to(device)
+
+        # symbolically trace
+        model = symbolic_trace(model)
+
+        # QAT prepare
+        model = fuse_fx(model)
+        model = prepare_fx(model, qconfig_dict)
+
+        # ensure that running an input on CUDA works without any needed changes
+        input = torch.randn(4, 1, 4, 4, device=device)
+        model(input)
+
+        # ensure all buffers and parameters are on the device we expect
+        model_devices = {p.device for p in model.parameters()} | \
+            {p.device for p in model.buffers()}
+        self.assertEqual(len(model_devices), 1)
+        model_device = next(iter(model_devices))
+        self.assertEqual(model_device, device)
 
 
 class TestQuantizeFxOps(QuantizationTestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44125 fx quant prepare: clarify naming
* **#44115 fx qat: respect device affinity**

Summary:

Fixes device affinity in the FX prepare pass for QAT. Before this PR, observers
were always created on CPU. After this PR, observers are created on the
same device as the rest of the model. This will enable QAT prepare to
work regardless of whether users move the model to cuda before or after
calling this pass.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx.test_qat_prepare_device_affinity
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23502291](https://our.internmc.facebook.com/intern/diff/D23502291)