### PR TITLE
[static runtime] Add Deep and wide to test and flatten/tranpose for good measure

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -18,3 +18,27 @@ TEST(StaticRuntime, TrivialModel) {
   at::Tensor output_2 = runtime.run(input_tensors)[0];
   EXPECT_TRUE(output_1.equal(output_2));
 }
+
+TEST(StaticRuntime, DeepWide) {
+  const int embedding_size = 32;
+  const int num_features = 50;
+  torch::jit::Module mod = getDeepAndWideSciptModel();
+  torch::jit::StaticRuntime runtime(mod);
+
+  for (int batch_size : {1, 8, 32}) {
+    for (int i = 0; i < 5; ++i) {
+      auto ad_emb_packed = torch::randn({batch_size, 1, embedding_size});
+      auto user_emb = torch::randn({batch_size, 1, embedding_size});
+      auto wide = torch::randn({batch_size, num_features});
+
+      // run jit graph executor
+      std::vector<at::IValue> inputs({ad_emb_packed, user_emb, wide});
+      at::Tensor output_1 = mod.forward(inputs).toTensor();
+
+      // run static runtime
+      std::vector<at::Tensor> input_tensors({ad_emb_packed, user_emb, wide});
+      at::Tensor output_2 = runtime.run(input_tensors)[0];
+      EXPECT_TRUE(output_1.equal(output_2));
+    }
+  }
+}

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1,9 +1,10 @@
-#include <torch/csrc/jit/runtime/static/impl.h>
+#include <ATen/core/interned_strings.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/runtime/static/impl.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/vararg_functions.h>
 
@@ -123,7 +124,7 @@ void ProcessedNode::run(StaticRuntime::ConstantMap& workspace) const {
       stack.emplace_back(f->second);
     }
     if (op_) {
-      (*op_)(&stack);
+      op_->operator()(&stack);
     } else {
       if (node_->kind() == prim::ListConstruct) {
         listConstruct(
@@ -150,7 +151,7 @@ void ProcessedNode::run(StaticRuntime::ConstantMap& workspace) const {
       workspace[node_->outputs()[i]] = stack[i];
     }
   } else {
-    (*fn_)(workspace);
+    fn_->operator()(workspace);
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44119 [static runtime] Add NNC
* **#44118 Add Deep and wide to test and flatten/tranpose for good measure**
* #44117 Add _out variants and reuse memory
* #44116 Swap to out-variant compatible nodes

