### PR TITLE
[static runtime] Add NNC

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -510,18 +510,18 @@ class TensorExprFuser {
       // TODO: add support for tensor constants.
       return false;
     }
-    if (!allShapesAreKnown(node)) {
-      return false;
-    }
+    // if (!allShapesAreKnown(node)) {
+    //  return false;
+    //}
 
     // Don't include nodes whose inputs are tensor constants - we cannot handle
     // them at the moment.
     // TODO: actually support tensor constants and remove this.
     for (Value* input : node->inputs()) {
-      if (input->node()->kind() == prim::Constant &&
-          input->type()->cast<TensorType>()) {
-        return false;
-      }
+      // if (input->node()->kind() == prim::Constant &&
+      //    input->type()->cast<TensorType>()) {
+      //  return false;
+      //}
     }
     return tensorexpr::isSupported(node);
   }

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -193,7 +193,8 @@ void mergeNodeIntoSubgraph(
     if (inputsMap.count(input) == 0) {
       // Clone constants inside the subgraph instead of referencing them, to
       // enable more optimizations
-      if (auto value = toIValue(input)) {
+      auto value = toIValue(input);
+      if (value && !value->isTensor()) {
         auto nv = subgraph->insertConstant(*value);
         nv->setType(input->type()); // Need to retain type information on Nones
         inputsMap[input] = nv;

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -3,6 +3,7 @@
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>
 #include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/codegen/fuser/arg_spec.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
 #include <torch/csrc/jit/passes/inliner.h>
@@ -54,6 +55,7 @@ class ProcessedNode {
   Node* node_;
   c10::optional<Operation> op_;
   c10::optional<std::function<void(StaticRuntime::ConstantMap&)>> fn_;
+  mutable std::unordered_map<uint64_t, Operation> compiled_;
 };
 
 } // namespace jit


### PR DESCRIPTION
47% more throughput for BS=1 when using NNC

This is a WIP diff that relies on some yet to be added features in NNC:

[ ] NNC fusion group without shapes
[ ] Constant tensors as inputs to nodes in the fusion group

Before NNC

```
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_deep_wide_base/1                         39591 ns      39590 ns      17765
BM_deep_wide_base/8                         42038 ns      42037 ns      16989
BM_deep_wide_base/20                        42543 ns      42543 ns      16300
BM_deep_wide_jit_graph_executor/1           35839 ns      35838 ns      19552
BM_deep_wide_jit_graph_executor/8           37477 ns      37476 ns      18534
BM_deep_wide_jit_graph_executor/20          38583 ns      38583 ns      17974
BM_deep_wide_jit_profiling_executor/1       35827 ns      35826 ns      19471
BM_deep_wide_jit_profiling_executor/8       37532 ns      37531 ns      18567
BM_deep_wide_jit_profiling_executor/20      38720 ns      38719 ns      18129
BM_deep_wide_static/1                       18535 ns      18534 ns      37765
BM_deep_wide_static/8                       20236 ns      20236 ns      35014
BM_deep_wide_static/20                      21667 ns      21667 ns      32349
```

After NNC

```
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_deep_wide_base/1                         40185 ns      40184 ns      17510
BM_deep_wide_base/8                         42276 ns      42276 ns      16354
BM_deep_wide_base/20                        43900 ns      43899 ns      15929
BM_deep_wide_jit_graph_executor/1           36170 ns      36169 ns      19377
BM_deep_wide_jit_graph_executor/8           37939 ns      37938 ns      18382
BM_deep_wide_jit_graph_executor/20          39146 ns      39145 ns      17910
BM_deep_wide_jit_profiling_executor/1       36331 ns      36331 ns      19329
BM_deep_wide_jit_profiling_executor/8       37922 ns      37921 ns      18466
BM_deep_wide_jit_profiling_executor/20      39396 ns      39395 ns      17912
BM_deep_wide_static/1                       13531 ns      13530 ns      52040
BM_deep_wide_static/8                       15022 ns      15022 ns      45990
BM_deep_wide_static/20                      16896 ns      16896 ns      41179
```

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44119 [static runtime] Add NNC**
* #44118 Add Deep and wide to test and flatten/tranpose for good measure
* #44117 Add _out variants and reuse memory
* #44116 Swap to out-variant compatible nodes

