### PR TITLE
[TensorExpr] Fuser: rely on input types when checking whether a device is supported.

### DIFF
--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -16,7 +16,6 @@
 #include "torch/csrc/jit/tensorexpr/loopnest.h"
 #include "torch/csrc/jit/tensorexpr/tensor.h"
 
-
 namespace torch {
 namespace jit {
 

--- a/test/cpp/tensorexpr/test_te_fuser_pass.cpp
+++ b/test/cpp/tensorexpr/test_te_fuser_pass.cpp
@@ -158,7 +158,7 @@ void testFuserPass_UnknownShapes() {
   g->lint();
   FuseTensorExprs(g);
 
-  // Test that we're not starting fusion groups from nodes with unfusible device
+  // Test that we're not generating fusion groups when shapes are not known
   testing::FileCheck().check_not("prim::TensorExprGroup")->run(*g);
 }
 } // namespace jit

--- a/test/cpp/tensorexpr/test_te_fuser_pass.cpp
+++ b/test/cpp/tensorexpr/test_te_fuser_pass.cpp
@@ -13,8 +13,8 @@ namespace jit {
 using namespace torch::jit::tensorexpr;
 
 struct WithCPUFuser {
-  WithCPUFuser() : cpuFuserEnabled(canFuseOnCPU()) {
-    overrideCanFuseOnCPU(true);
+  WithCPUFuser(bool val = true) : cpuFuserEnabled(canFuseOnCPU()) {
+    overrideCanFuseOnCPU(val);
   }
 
   ~WithCPUFuser() {
@@ -122,6 +122,43 @@ void testFuserPass_0DimInput() {
   FuseTensorExprs(g);
 
   // We should not fuse 0-dim tensors
+  testing::FileCheck().check_not("prim::TensorExprGroup")->run(*g);
+}
+
+void testFuserPass_UnfusibleDevice() {
+  WithCPUFuser cf(false);
+  KernelScope kernel_scope;
+  const auto graph_string = R"IR(
+    graph(%x : Float(10:1, device=cpu),
+          %y : Float(10:1, device=cpu)):
+      %a : Float(10:1, device=cpu) = aten::mul(%x, %y)
+      return (%a))IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+
+  g->lint();
+  FuseTensorExprs(g, /* min_group_size= */ 1);
+
+  // Test that we're not starting fusion groups from nodes with unfusible device
+  testing::FileCheck().check_not("prim::TensorExprGroup")->run(*g);
+}
+
+void testFuserPass_UnknownShapes() {
+  WithCPUFuser cf;
+  KernelScope kernel_scope;
+  const auto graph_string = R"IR(
+    graph(%x : Tensor,
+          %y : Tensor):
+      %a : Tensor = aten::mul(%x, %y)
+      %b : Tensor = aten::mul(%x, %a)
+      return (%a))IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+
+  g->lint();
+  FuseTensorExprs(g);
+
+  // Test that we're not starting fusion groups from nodes with unfusible device
   testing::FileCheck().check_not("prim::TensorExprGroup")->run(*g);
 }
 } // namespace jit

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -247,6 +247,8 @@ namespace jit {
   _(FuserPass_2)                            \
   _(FuserPass_3)                            \
   _(FuserPass_0DimInput)                    \
+  _(FuserPass_UnfusibleDevice)              \
+  _(FuserPass_UnknownShapes)                \
   _(TrainBasic)
 
 #define TH_FORALL_TENSOREXPR_TESTS_LLVM(_) \

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -495,11 +495,9 @@ class TensorExprFuser {
   }
 
   bool isFusableOnDevice(Node* node) {
-    for (const auto& output : node->outputs()) {
-      if (output->uses().size() > 0) {
-        if (!canFuseOnDevice(output)) {
-          return false;
-        }
+    for (const auto& input : node->inputs()) {
+      if (!canFuseOnDevice(input)) {
+        return false;
       }
     }
     return true;
@@ -511,6 +509,9 @@ class TensorExprFuser {
       return false;
     }
     if (!allShapesAreKnown(node)) {
+      return false;
+    }
+    if (!isFusableOnDevice(node)) {
       return false;
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44139 [TensorExpr] Fuser: rely on input types when checking whether a device is supported.**

Also, make sure that we're checking that condition when we're starting a
new fusion group, not only when we merge a node into an existing fusion
group. Oh, and one more: add a test checking that we're rejecting graphs
with unspecified shapes.

Differential Revision: [D23507510](https://our.internmc.facebook.com/intern/diff/D23507510)