### PR TITLE
Simplify nested Min and Max patterns.

### DIFF
--- a/test/cpp/tensorexpr/test_boundsinference.cpp
+++ b/test/cpp/tensorexpr/test_boundsinference.cpp
@@ -712,7 +712,7 @@ void testMergeSymbolicBounds() {
   res = mergeTensorAccesses(info);
   ASSERT_EQ(res[a.data()].size(), 1);
   pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "Min(Z, X, 1)");
+  ASSERT_EQ(pair.first, "Min(X, Z, 1)");
   ASSERT_EQ(pair.second, "Y");
 
   // If either side is only one apart, they must be adjacent.
@@ -733,7 +733,7 @@ void testMergeSymbolicBounds() {
   res = mergeTensorAccesses(info);
   ASSERT_EQ(res[a.data()].size(), 1);
   pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "Min(Z, X, 1)");
+  ASSERT_EQ(pair.first, "Min(X, Z, 1)");
   ASSERT_EQ(pair.second, "Y");
 
   // If either side is 2 apart, they may not be overlapping.
@@ -812,7 +812,7 @@ void testMergeSymbolicAdjacent() {
   ASSERT_EQ(res[a.data()].size(), 1);
   pair = boundAsStringPair(res[a.data()][0]);
   ASSERT_EQ(pair.first, "5");
-  ASSERT_EQ(pair.second, "Max(Y, X, 1)");
+  ASSERT_EQ(pair.second, "Max(X, Y, 1)");
 
   info.clear();
   info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(6)}});
@@ -820,7 +820,7 @@ void testMergeSymbolicAdjacent() {
   res = mergeTensorAccesses(info);
   ASSERT_EQ(res[a.data()].size(), 1);
   pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "Min(Y, X, 1)");
+  ASSERT_EQ(pair.first, "Min(X, Y, 1)");
   ASSERT_EQ(pair.second, "6");
 }
 

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -170,6 +170,8 @@ namespace jit {
   _(SimplifyIfComponents)                   \
   _(SimplifyOpaqueTerms)                    \
   _(SimplifySymbolicMinMax)                 \
+  _(SimplifyNestedMax)                      \
+  _(SimplifyNestedMin)                      \
   _(SimplifyWontReorderFloat)               \
   _(SimplifyRoundModPattern)                \
   _(SimplifyRoundModPatternFactorization)   \

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -36,6 +36,8 @@ enum IRNodeType {
   kPolynomial,
   kTerm,
   kRoundOff,
+  kMaxTerm,
+  kMinTerm,
   kNone,
   kExtra
 };

--- a/torch/csrc/jit/tensorexpr/hash_provider.cpp
+++ b/torch/csrc/jit/tensorexpr/hash_provider.cpp
@@ -310,6 +310,39 @@ void HashProvider::visit(const Polynomial* v) {
 
   putHash(v, hash);
 }
+
+void HashProvider::visit(const MaxTerm* v) {
+  CACHE_GUARD();
+  SimplifierHashType hash = hash_combine("maxterm");
+  if (v->scalar()) {
+    v->scalar()->accept(this);
+    hash = hash_combine(hash, hashOf(v->scalar()));
+  }
+
+  for (auto* c : v->variables()) {
+    c->accept(this);
+    hash = hash_combine(hash, hashOf(c));
+  }
+
+  putHash(v, hash);
+}
+
+void HashProvider::visit(const MinTerm* v) {
+  CACHE_GUARD();
+  SimplifierHashType hash = hash_combine("minterm");
+  if (v->scalar()) {
+    v->scalar()->accept(this);
+    hash = hash_combine(hash, hashOf(v->scalar()));
+  }
+
+  for (auto* c : v->variables()) {
+    c->accept(this);
+    hash = hash_combine(hash, hashOf(c));
+  }
+
+  putHash(v, hash);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -104,6 +104,8 @@ class TORCH_API HashProvider : public IRVisitor {
   void visit(const Cond* v) override;
   void visit(const Term* v) override;
   void visit(const Polynomial* v) override;
+  void visit(const MaxTerm* v) override;
+  void visit(const MinTerm* v) override;
 
   template <typename... Types>
   SimplifierHashType hash_combine(const Types&... args) {

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -802,6 +802,8 @@ class Intrinsics : public CallNode<Intrinsics> {
 
 class Polynomial;
 class Term;
+class MaxTerm;
+class MinTerm;
 
 class FunctionCall;
 

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -241,6 +241,32 @@ const Expr* IRMutator::mutate(const RoundOff* v) {
       v->lhs()->accept_mutator(this), v->rhs()->accept_mutator(this));
 }
 
+const Expr* IRMutator::mutate(const MaxTerm* v) {
+  const Expr* newScalar = nullptr;
+  if (v->scalar()) {
+    newScalar = v->scalar()->accept_mutator(this);
+  }
+
+  std::vector<const Expr*> variables;
+  for (const auto* t : v->variables()) {
+    variables.push_back(t->accept_mutator(this));
+  }
+  return new MaxTerm(v->hasher(), newScalar, v->propagate_nans(), variables);
+}
+
+const Expr* IRMutator::mutate(const MinTerm* v) {
+  const Expr* newScalar = nullptr;
+  if (v->scalar()) {
+    newScalar = v->scalar()->accept_mutator(this);
+  }
+
+  std::vector<const Expr*> variables;
+  for (const auto* t : v->variables()) {
+    variables.push_back(t->accept_mutator(this));
+  }
+  return new MinTerm(v->hasher(), newScalar, v->propagate_nans(), variables);
+}
+
 const Expr* IRMutator::mutate(const ReduceOp* v) {
   const Expr* buf_new_expr = v->accumulator()->accept_mutator(this);
   const Buf* buf_new = dynamic_cast<const Buf*>(buf_new_expr);

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -48,6 +48,8 @@ class Stmt;
 class Term;
 class Polynomial;
 class RoundOff;
+class MaxTerm;
+class MinTerm;
 class ReduceOp;
 class AtomicAdd;
 class SyncThreads;
@@ -93,6 +95,8 @@ class TORCH_API IRMutator {
   virtual const Expr* mutate(const Term* v);
   virtual const Expr* mutate(const Polynomial* v);
   virtual const Expr* mutate(const RoundOff* v);
+  virtual const Expr* mutate(const MaxTerm* v);
+  virtual const Expr* mutate(const MinTerm* v);
 
   virtual const Expr* mutate(const ReduceOp* v);
 

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -318,6 +318,36 @@ void IRPrinter::visit(const RoundOff* v) {
   os() << ")";
 }
 
+void IRPrinter::visit(const MaxTerm* v) {
+  os() << "MaxTerm(";
+  if (v->scalar()) {
+    v->scalar()->accept(this);
+    os() << ", ";
+  }
+  for (size_t i = 0; i < v->variables().size(); ++i) {
+    v->variables()[i]->accept(this);
+    if (i < v->variables().size() - 1) {
+      os() << ", ";
+    }
+  }
+  os() << ")";
+}
+
+void IRPrinter::visit(const MinTerm* v) {
+  os() << "MinTerm(";
+  if (v->scalar()) {
+    v->scalar()->accept(this);
+    os() << ", ";
+  }
+  for (size_t i = 0; i < v->variables().size(); ++i) {
+    v->variables()[i]->accept(this);
+    if (i < v->variables().size() - 1) {
+      os() << ", ";
+    }
+  }
+  os() << ")";
+}
+
 void IRPrinter::visit(const ReduceOp* v) {
   os() << "ReduceOp(";
   os() << *v->accumulator() << ", ";

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -47,6 +47,8 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const Term* v) override;
   void visit(const Polynomial* v) override;
   void visit(const RoundOff* v) override;
+  void visit(const MaxTerm* v) override;
+  void visit(const MinTerm* v) override;
   void visit(const ReduceOp* v) override;
 
   void visit(const AtomicAdd* v) override;

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -207,6 +207,20 @@ void IRVisitor::visit(const RoundOff* v) {
   v->rhs()->accept(this);
 }
 
+void IRVisitor::visit(const MaxTerm* v) {
+  v->scalar()->accept(this);
+  for (auto* t : v->variables()) {
+    t->accept(this);
+  }
+}
+
+void IRVisitor::visit(const MinTerm* v) {
+  v->scalar()->accept(this);
+  for (auto* t : v->variables()) {
+    t->accept(this);
+  }
+}
+
 void IRVisitor::visit(const ReduceOp* v) {
   v->accumulator()->accept(this);
   v->body().node()->accept(this);

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -45,6 +45,8 @@ class Cond;
 class Term;
 class Polynomial;
 class RoundOff;
+class MaxTerm;
+class MinTerm;
 class ReduceOp;
 class AtomicAdd;
 class SyncThreads;
@@ -98,6 +100,8 @@ class TORCH_API IRVisitor {
   virtual void visit(const Term* v);
   virtual void visit(const Polynomial* v);
   virtual void visit(const RoundOff* v);
+  virtual void visit(const MaxTerm* v);
+  virtual void visit(const MinTerm* v);
   virtual void visit(const ReduceOp* v);
   virtual void visit(const AtomicAdd* v);
   virtual void visit(const SyncThreads* v);


### PR DESCRIPTION
Improve simplification of nested Min and Max patterns. 

Specifically, handles the following pattern simplications:
  * `Max(A, Max(A, Const)) => Max(A, Const)`
  * `Max(Min(A, B), Min(A, C)) => Min(A, Max(B, C))`
  * `Max(Const, Max(A, OtherConst) => Max(A, Max(Const, OtherConst))`
     - This case can have an arbitrarily long chain of Max ops. For example: `Max(5, Max(x, Max(y, Max(z, 8)))) => Max(Max(Max(x, 8), y), z)`

Similarly, for the case of Min as well.