### PR TITLE
[caffe2] adds Cancel to OperatorBase and NetBase

### DIFF
--- a/caffe2/core/net.cc
+++ b/caffe2/core/net.cc
@@ -97,6 +97,12 @@ bool NetBase::RunAsync() {
   return DoRunAsync();
 }
 
+void NetBase::Cancel() {
+  for (auto& op : GetOperators()) {
+    op->Cancel();
+  }
+}
+
 namespace {
 const std::string kSimpleNet = "simple";
 

--- a/caffe2/core/net.h
+++ b/caffe2/core/net.h
@@ -62,7 +62,7 @@ class CAFFE2_API NetBase : public Observable<NetBase> {
 
   virtual bool RunAsync();
 
-  virtual void Cancel() {}
+  virtual void Cancel();
 
   /* Benchmarks a network for one individual run so that we can feed new
    * inputs on additional calls.

--- a/caffe2/core/net_async_scheduling.cc
+++ b/caffe2/core/net_async_scheduling.cc
@@ -270,6 +270,8 @@ bool AsyncSchedulingNet::RunAsync() {
 
 void AsyncSchedulingNet::Cancel() {
   success_ = false;
+  NetBase::Cancel();
+
   CancelAndFinishAsyncTasks();
 }
 
@@ -294,10 +296,10 @@ void AsyncSchedulingNet::CancelAndFinishAsyncTasks() {
   }
 }
 
-AsyncSchedulingNet::~AsyncSchedulingNet() {
-  Wait();
-}
+  AsyncSchedulingNet::~AsyncSchedulingNet() {
+    Wait();
+  }
 
-REGISTER_NET(async_scheduling, AsyncSchedulingNet);
+  REGISTER_NET(async_scheduling, AsyncSchedulingNet);
 
 } // namespace caffe2

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -206,7 +206,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
         ival.isTensor(),
         "Input(int, DeviceType) is only available for IValues that store Tensors");
     auto t = ival.toTensor();
-    if (!t.is_contiguous()){
+    if (!t.is_contiguous()) {
       t = t.contiguous();
     }
     Tensor tensor = caffe2::Tensor(std::move(t));
@@ -483,6 +483,8 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   virtual void CancelAsyncCallback() {}
+
+  virtual void Cancel() {}
 
   // RunAsync, if implemented by the specific operators, will schedule the
   // computation on the corresponding context and record the event in its

--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -54,7 +54,7 @@ class ExceptionWrapper {
 struct NetDefInfo {
   const NetDef* netDef;
   // in order to keep the "override existing nets" on the top-level workflow,
-  // we need to makr the nets that already exist so that we can override them
+  // we need to mark the nets that already exist so that we can override them
   // exactly once.
   bool needsOverride;
 };
@@ -144,7 +144,7 @@ inline bool getShouldStop(const Blob* b) {
 /**
  * Injects a blob named 'GLOBAL_WORKSPACE_ID' for each workspace, only if
  * another blob named 'NODE_ID' is present. 'NODE_ID' blob can be used in a
- * distribued run and in this case 'GLOBAL_WORKSPACE_ID' can be used across
+ * distributed run and in this case 'GLOBAL_WORKSPACE_ID' can be used across
  * machines for other purposes (e.g. to support model parallelism). Essentially,
  * 'GLOBAL_WORKSPACE_ID' is an identifier for a workspace that is unique across
  * all 'NODE_ID's.


### PR DESCRIPTION
Summary:
## Motivation

* To be able to make C2 ops cancellable so we can safely exit.
* Some C2 operators are now blocking thus being non-cancellable. If an error
  occurs we need to be able to safely stop all net execution so we can throw
  the exception to the caller.

## Summary
*  Adds `NetBase::Cancel()` to NetBase which iterates over the entire list of
   operators and call Cancel.
* Cancel on all ops was added to Net since there's nothing Asyc specific about it.
* `AsyncSchedulingNet` calls parent Cancel.
* To preserve backwards compatibility, `AsyncSchedulingNet`'s Cancel still calls
   `CancelAndFinishAsyncTasks` .
* Adds `Cancel()` to `OperatorBase`.

Differential Revision: D23279202

