### PR TITLE
[TESTING] Don't skip NotImplementedError in check_cuda for CriterionTests.

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5145,8 +5145,8 @@ class CriterionTest(InputVariableMixin, TestBase):
             # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
             test_case.assertEqualIgnoreType(cpu_gradInput, gpu_gradInput,
                                             atol=1e-1 if dtype in {torch.half, torch.bfloat16} else 4e-4, rtol=0)
-        except NotImplementedError:
-            pass
+        except NotImplementedError as e:
+            raise AssertionError("received error", e)
 
     def _get_target(self):
         return self._get_arg('target', False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44146 [TESTING] Don't skip NotImplementedError in check_cuda for CriterionTests.**

Differential Revision: [D23509216](https://our.internmc.facebook.com/intern/diff/D23509216)