### PR TITLE
Revert ".circleci: Remove un-needed steps from binary builds (#43974)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1018,6 +1018,35 @@ jobs:
     - run:
         <<: *binary_populate_env
     - run:
+        name: Install unbuffer and ts
+        command: |
+            set -eux -o pipefail
+            source /env
+            OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+            if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+              retry yum -q -y install epel-release
+              retry yum -q -y install expect moreutils
+            elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+              retry apt-get update
+              retry apt-get -y install expect moreutils
+              retry conda install -y -c eumetsat expect
+              retry conda install -y cmake
+            fi
+    - run:
+        name: Update compiler to devtoolset7
+        command: |
+            set -eux -o pipefail
+            source /env
+            if [[ "$DESIRED_DEVTOOLSET" == 'devtoolset7' ]]; then
+              source "/builder/update_compiler.sh"
+
+              # Env variables are not persisted into the next step
+              echo "export PATH=$PATH" >> /env
+              echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> /env
+            else
+              echo "Not updating compiler"
+            fi
+    - run:
         name: Build
         no_output_timeout: "1h"
         command: |
@@ -1036,6 +1065,7 @@ jobs:
             python3 -mpip install requests && \
             SCRIBE_GRAPHQL_ACCESS_TOKEN=${SCRIBE_GRAPHQL_ACCESS_TOKEN} \
             python3 /pytorch/.circleci/scripts/upload_binary_size_to_scuba.py || exit 0
+
     - persist_to_workspace:
         root: /
         paths: final_pkgs

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 source /env
 
 # Defaults here so they can be changed in one place
-export MAX_JOBS=${MAX_JOBS:-$(nproc --ignore=1)}
+export MAX_JOBS=12
 
 # Parse the parameters
 if [[ "$PACKAGE_TYPE" == 'conda' ]]; then
@@ -16,5 +16,15 @@ else
   build_script='manywheel/build.sh'
 fi
 
+# We want to call unbuffer, which calls tclsh which finds the expect
+# package. The expect was installed by yum into /usr/bin so we want to
+# find /usr/bin/tclsh, but this is shadowed by /opt/conda/bin/tclsh in
+# the conda docker images, so we prepend it to the path here.
+if [[ "$PACKAGE_TYPE" == 'conda' ]]; then
+  mkdir /just_tclsh_bin
+  ln -s /usr/bin/tclsh /just_tclsh_bin/tclsh
+  export PATH=/just_tclsh_bin:$PATH
+fi
+
 # Build the package
-SKIP_ALL_TESTS=1 stdbuf -i0 -o0 -e0 "/builder/$build_script"
+SKIP_ALL_TESTS=1 unbuffer "/builder/$build_script" | ts

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -8,6 +8,35 @@
     - run:
         <<: *binary_populate_env
     - run:
+        name: Install unbuffer and ts
+        command: |
+            set -eux -o pipefail
+            source /env
+            OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+            if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
+              retry yum -q -y install epel-release
+              retry yum -q -y install expect moreutils
+            elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
+              retry apt-get update
+              retry apt-get -y install expect moreutils
+              retry conda install -y -c eumetsat expect
+              retry conda install -y cmake
+            fi
+    - run:
+        name: Update compiler to devtoolset7
+        command: |
+            set -eux -o pipefail
+            source /env
+            if [[ "$DESIRED_DEVTOOLSET" == 'devtoolset7' ]]; then
+              source "/builder/update_compiler.sh"
+
+              # Env variables are not persisted into the next step
+              echo "export PATH=$PATH" >> /env
+              echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> /env
+            else
+              echo "Not updating compiler"
+            fi
+    - run:
         name: Build
         no_output_timeout: "1h"
         command: |
@@ -26,6 +55,7 @@
             python3 -mpip install requests && \
             SCRIBE_GRAPHQL_ACCESS_TOKEN=${SCRIBE_GRAPHQL_ACCESS_TOKEN} \
             python3 /pytorch/.circleci/scripts/upload_binary_size_to_scuba.py || exit 0
+
     - persist_to_workspace:
         root: /
         paths: final_pkgs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44164 Revert ".circleci: Remove un-needed steps from binary builds (#43974)"**

This reverts commit 276158fd0566589ca226057a4b484ebc4e41a1f6.