### PR TITLE
torchscript graph mode quant: remove benchmark filter

### DIFF
--- a/torch/csrc/jit/passes/graph_rewrite_helper.cpp
+++ b/torch/csrc/jit/passes/graph_rewrite_helper.cpp
@@ -117,7 +117,6 @@ void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
       return false;
     }
     return !calc_value_map["transposed"].toBool() &&
-        !calc_value_map["benchmark"].toBool() &&
         !calc_value_map["deterministic"].toBool() &&
         calc_value_map["cudnn_enabled"].toBool() &&
         (calc_value_map["output_padding"].toIntList()[0] == 0);
@@ -132,7 +131,6 @@ void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
       return false;
     }
     return !calc_value_map["transposed"].toBool() &&
-        !calc_value_map["benchmark"].toBool() &&
         !calc_value_map["deterministic"].toBool() &&
         calc_value_map["cudnn_enabled"].toBool() &&
         (calc_value_map["output_padding"].toIntList()[0] == 0) &&
@@ -150,7 +148,6 @@ void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
         }
 
         return calc_value_map["transposed"].toBool() &&
-            !calc_value_map["benchmark"].toBool() &&
             !calc_value_map["deterministic"].toBool() &&
             calc_value_map["cudnn_enabled"].toBool();
       };
@@ -164,7 +161,6 @@ void replaceConvolutionWithAtenConv(std::shared_ptr<Graph>& graph) {
       return false;
     }
     return !calc_value_map["transposed"].toBool() &&
-        !calc_value_map["benchmark"].toBool() &&
         !calc_value_map["deterministic"].toBool() &&
         calc_value_map["cudnn_enabled"].toBool() &&
         (calc_value_map["output_padding"].toIntList()[0] == 0) &&


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44165 torchscript graph mode quant: remove benchmark filter**

Summary:

Allows convolutions to be quantized if `torch.cudnn.backends.benchmark`
flag was set.  There were people confused by why these get filtered out, and it
seems like this flag should not matter for quantization.

Test Plan:

Added test to cover.

in the gist below, the resulting graph now has quantized convolutions
https://gist.github.com/vkuzo/622213cb12faa0996b6700b08d6ab2f0

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23518775](https://our.internmc.facebook.com/intern/diff/D23518775)