### PR TITLE
[FX] __str__ for GraphModule and Graph

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -496,6 +496,23 @@ class TestFX(JitTestCase):
         out = gm(input)
         self.assertEqual(out, ref_out)
 
+    def test_pretty_print(self):
+        st = SimpleTest()
+        traced = symbolic_trace(st)
+        printed = str(traced)
+        assert 'SimpleTest()' in printed
+        assert 'torch.relu' in printed
+
+    def test_pretty_print_graph(self):
+        class KwargPrintTest(torch.nn.Module):
+            def forward(self, x):
+                return torch.squeeze(x + 3.0, dim=2)
+        st = KwargPrintTest()
+        traced = symbolic_trace(st)
+        stringed = str(traced.graph)
+        for s in ['args', 'kwargs', 'uses']:
+            assert s in stringed
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -5,8 +5,6 @@ import builtins
 import torch
 import keyword
 
-from collections.abc import Iterable
-
 def _shadows_builtin_name(name: str) -> bool:
     return name in builtins.__dict__ or name in keyword.kwlist
 
@@ -176,6 +174,7 @@ class Graph:
 
     def __str__(self) -> str:
         placeholder_names = []
+
         def format_arg(arg) -> str:
             if isinstance(arg, list):
                 items = ', '.join(format_arg(a) for a in arg)

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -173,7 +173,7 @@ class Graph:
         return src, str(self.result), free_vars
 
     def __str__(self) -> str:
-        placeholder_names = []
+        placeholder_names : List[str] = []
 
         def format_arg(arg) -> str:
             if isinstance(arg, list):
@@ -194,13 +194,14 @@ class Graph:
 
         def format_node(n : Node) -> Optional[str]:
             if n.op == 'placeholder':
+                assert isinstance(n.target, str)
                 placeholder_names.append(n.target)
                 return None
             elif n.op == 'get_param':
-                return f'%{n.name} = {n.target}'
+                return f'%{n.name} : [uses={n.uses}]= {n.target}'
             else:
-                return f'%{n.name} = {n.op}[target={n.target}](' \
-                       f'args = {format_arg(n.args)}, kwargs = {format_arg(n.kwargs)}, uses={n.uses})'
+                return f'%{n.name} : [uses={n.uses}] = {n.op}[target={n.target}](' \
+                       f'args = {format_arg(n.args)}, kwargs = {format_arg(n.kwargs)})'
 
 
         node_strs = [format_node(node) for node in self.nodes]

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -210,6 +210,8 @@ class Graph:
         for node_str in node_strs:
             if node_str:
                 s += '\n    ' + node_str
+        if self.result:
+            s += f'\n    return {format_arg(self.result)}'
         return s
 
 reflectable_magic_methods = {

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -86,6 +86,10 @@ def forward(self, {', '.join(free_variables)}):
     def __reduce__(self):
         return (deserialize_graphmodule, (self.root, self.code))
 
+    def __str__(self) -> str:
+        orig_str = super().__str__()
+        return '\n'.join([orig_str, self.code])
+
 # workarounds for issues in __torch_function__
 
 # WAR for __torch_function__ not handling tensor lists,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44166 [FX] __str__ for GraphModule and Graph**

This makes it so that people don't have to copy-paste my tabular thing all the time

GraphModule prints out the normal Module __str__ as well as `code`:

```
GraphModuleImpl(
  (root): SimpleTest()
)
def forward(self, x):
    self = self.root
    add_1 = x + 3.0
    relu_1 = torch.relu(add_1)
    

    return relu_1
```

Graph prints out an "IR-like" representation with all the node properties:

```
graph(x):
    %add_1 : [uses=1] = call_function[target=<built-in function add>](args = (%x, 3.0), kwargs = {})
    %squeeze_1 : [uses=1] = call_function[target=<built-in method squeeze of type object at 0x7f18e09c8620>](args = (%add_1,), kwargs = {dim: 2})
    return %squeeze_1
```

Differential Revision: [D23520801](https://our.internmc.facebook.com/intern/diff/D23520801)