### PR TITLE
Limit MAX_JOBS to 18 for linux binary builds

### DIFF
--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -5,7 +5,9 @@ set -eux -o pipefail
 source /env
 
 # Defaults here so they can be changed in one place
-export MAX_JOBS=${MAX_JOBS:-$(nproc --ignore=1)}
+# This script is run inside Docker.2XLarge+ container that has 20 CPU cores
+# But ncpu will return total number of cores on the system
+export MAX_JOBS=18
 
 # Parse the parameters
 if [[ "$PACKAGE_TYPE" == 'conda' ]]; then


### PR DESCRIPTION
Because those jobs are running in Docker2XLarge+ container that has 20 cores
Unfortunately `nproc` returns number of cores available on the host rather than number of cores available to container