### PR TITLE
test_ops: skipTest only takes a single argument

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -64,7 +64,7 @@ class TestGradients(TestCase):
         if variant is None:
             self.skipTest("Skipped! Variant not implemented.")
         if not op.supports_dtype(dtype, torch.device(device).type):
-            self.skipTest("Skipped! {} does not support dtype {}".format(op.name, str(dtype)))
+            self.skipTest(f"Skipped! {op.name} does not support dtype {str(dtype)}")
 
         samples = op.sample_inputs(device, dtype, requires_grad=True)
         for sample in samples:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -64,7 +64,7 @@ class TestGradients(TestCase):
         if variant is None:
             self.skipTest("Skipped! Variant not implemented.")
         if not op.supports_dtype(dtype, torch.device(device).type):
-            self.skipTest("Skipped! ", op.name, ' does not support dtype ', str(dtype))
+            self.skipTest("Skipped! {} does not support dtype {}".format(op.name, str(dtype)))
 
         samples = op.sample_inputs(device, dtype, requires_grad=True)
         for sample in samples:


### PR DESCRIPTION
Fixes a broken skipTest from #43451, e.g. in the ROCm CI.
