### PR TITLE
Fixed RuntimeError during the deserialization

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -139,7 +139,10 @@ class _StorageBase(object):
 
 
 def _load_from_bytes(b):
-    return torch.load(io.BytesIO(b))
+    try:
+        return torch.load(io.BytesIO(b))
+    except RuntimeError:
+        return torch.load(io.BytesIO(b), map_location=torch.device('cpu'))
 
 
 _StorageBase.type = _type


### PR DESCRIPTION
I have serialized a network which was trained on GPU. When I tried to deserialize it on the CPU machine I got the following error:

Traceback (most recent call last):
  File "C:\Anaconda3\envs\python36s\lib\site-packages\IPython\core\interactiveshell.py", line 3319, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-9-c2fb86a07d04>", line 1, in <module>
    entity=joblib.load(fn)
  File "C:\Anaconda3\envs\python36s\lib\site-packages\joblib\numpy_pickle.py", line 585, in load
    obj = _unpickle(fobj, filename, mmap_mode)
  File "C:\Anaconda3\envs\python36s\lib\site-packages\joblib\numpy_pickle.py", line 504, in _unpickle
    obj = unpickler.load()
  File "C:\Anaconda3\envs\python36s\lib\pickle.py", line 1050, in load
    dispatch[key[0]](self)
  File "C:\Anaconda3\envs\python36s\lib\pickle.py", line 1398, in load_reduce
    stack[-1] = func(*args)
  File "C:\Anaconda3\envs\python36s\lib\site-packages\torch\storage.py", line 134, in _load_from_bytes
    return torch.load(io.BytesIO(b))
  File "C:\Anaconda3\envs\python36s\lib\site-packages\torch\serialization.py", line 426, in load
    return _load(f, map_location, pickle_module, **pickle_load_args)
  File "C:\Anaconda3\envs\python36s\lib\site-packages\torch\serialization.py", line 613, in _load
    result = unpickler.load()
  File "C:\Anaconda3\envs\python36s\lib\site-packages\torch\serialization.py", line 576, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "C:\Anaconda3\envs\python36s\lib\site-packages\torch\serialization.py", line 155, in default_restore_location
    result = fn(storage, location)
  File "C:\Anaconda3\envs\python36s\lib\site-packages\torch\serialization.py", line 131, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "C:\Anaconda3\envs\python36s\lib\site-packages\torch\serialization.py", line 115, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.

Here I propose the solution which works for me

Fixes #{issue number}
