### PR TITLE
[caffe2] get rid of Python 3 deprecation warnings about getargspec

### DIFF
--- a/caffe2/python/brew.py
+++ b/caffe2/python/brew.py
@@ -101,7 +101,10 @@ class HelperWrapper(object):
                 "Or you can provide it in kwargs as model=<your_model>.")
                 new_kwargs = copy.deepcopy(model.arg_scope)
             func = self._registry[helper_name]
-            var_names, _, varkw, _= inspect.getargspec(func)
+            if sys.version_info > (3,):
+                var_names, _, varkw, *rest = inspect.getfullargspec(func)
+            else:
+                var_names, _, varkw, _= inspect.getargspec(func)
             if varkw is None:
                 # this helper function does not take in random **kwargs
                 new_kwargs = {

--- a/caffe2/python/operator_test/matmul_op_test.py
+++ b/caffe2/python/operator_test/matmul_op_test.py
@@ -3,6 +3,7 @@
 
 
 
+import sys
 import inspect
 
 import numpy as np
@@ -167,7 +168,10 @@ class TestBatchMatMul(serial.SerializedTestCase):
         # relaxing the "threshold" for fp16 to 150x of the default
         def relax_fp16_check(check_func, *args, **kwargs):
             # inspect the default "threshold" value in check_func
-            argspec = inspect.getargspec(check_func)
+            if sys.version_info > (3,):
+                argspec, *rest = inspect.getfullargspec(check_func)
+            else:
+                argspec, _, _, _= inspect.getargspec(check_func)
             threshold = argspec.defaults[
                 argspec.args.index('threshold') -
                 (len(argspec.args) - len(argspec.defaults))]

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -5,6 +5,7 @@
 
 
 
+import sys
 import functools
 import inspect
 import logging
@@ -177,7 +178,10 @@ class RNNCell(object):
             extra_inputs = _RectifyNames(extra_input_names)
             extra_inputs = zip(extra_input_names, extra_input_sizes)
 
-        arg_names = inspect.getargspec(self.apply_override).args
+        if sys.version_info > (3,):
+            arg_names = inspect.getfullargspec(self.apply_override).args
+        else:
+            arg_names = inspect.getargspec(self.apply_override).args
         rectified = [input_t, seq_lengths, states, timestep]
         if 'extra_inputs' in arg_names:
             rectified.append(extra_inputs)


### PR DESCRIPTION
Remove some deprecation warnings about `inpsect.getargspec`.

Use `inspect.getfullargspec` instead.

Also see https://docs.python.org/3/library/inspect.html#inspect.getargspec

> Deprecated since version 3.0: Use getfullargspec() for an updated API that is usually a drop-in replacement, but also correctly handles function annotations and keyword-only parameters.

related to #15396

Fixes #44185 
