### PR TITLE
DOC: Building libtorch using CMake

### DIFF
--- a/docs/libtorch.rst
+++ b/docs/libtorch.rst
@@ -38,20 +38,12 @@ Note that we are working on eliminating tools/build_pytorch_libs.sh in favor of 
 Building libtorch using CMake
 --------------------------------------
 
-You can build C++ libtorch.so directly with cmake.  For example, to build a v1.6.0 Release version that uses CUDA and CUDDN, and install it in the directory specified by CMAKE_INSTALL_PREFIX below, you can use
+You can build C++ libtorch.so directly with cmake.  For example, to build a Release version from the master branch and install it in the directory specified by CMAKE_INSTALL_PREFIX below, you can use
 ::
-   git clone https://github.com/pytorch/pytorch.git
-   cd pytorch
-   git checkout v1.6.0
-   git clean -fdx
-   git submodule update --init --recursive
-   mkdir ../pytorch-build
-   cd ../pytorch-build
-   cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=Release -DPYTHON_EXECUTABLE=`which python3` -DUSE_CUDA:BOOL=ON -DUSE_CUDNN:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install ../pytorch
+   git clone -b master --recurse-submodule https://github.com/pytorch/pytorch.git
+   mkdir pytorch-build
+   cd pytorch-build
+   cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=Release -DPYTHON_EXECUTABLE:PATH=`which python3` -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install ../pytorch
    cmake --build . --target install
 
-You can build the ``Debug`` version instead of ``Release`` and you can turn options off with ``OFF`` instead of ``ON``.  Currently USE_CUDNN and USE_CUDA default to ``ON`` when those packages are available, and these and other options need not be specified when the default values are desired.
-
-Also note that if you want to build the current ``master`` version then the ``git checkout ...`` and ``git clean ...`` commands are not needed.  Furthermore in this case, ``git submodule ...`` is not needed if the ``git clone ...`` command is changed to ``git clone --recurse-submodules https://github.com/pytorch/pytorch.git`` instead.
-
-You will get errors if you do not have needed dependencies such as Python3's PyYAML package.
+To use release branch v1.6.0, for example, replace ``master`` with ``v1.6.0``.  You will get errors if you do not have needed dependencies such as Python3's PyYAML package.

--- a/docs/libtorch.rst
+++ b/docs/libtorch.rst
@@ -50,8 +50,8 @@ You can build C++ libtorch.so directly with cmake.  For example, to build a v1.6
    cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=Release -DPYTHON_EXECUTABLE=`which python3` -DUSE_CUDA:BOOL=ON -DUSE_CUDNN:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install ../pytorch
    cmake --build . --target install
 
-You can build the `Debug` version instead of `Release` and you can turn options off with `OFF` instead of `ON`.  Currently USE_CUDNN and USE_CUDA default to `ON` when those packages are available, and these and other options need not be specified when the default values are desired.
+You can build the ``Debug`` version instead of ``Release`` and you can turn options off with ``OFF`` instead of ``ON``.  Currently USE_CUDNN and USE_CUDA default to ``ON`` when those packages are available, and these and other options need not be specified when the default values are desired.
 
-Also note that if you want to build the current `master` version then the `git checkout ...` and `git clean ...` commands are not needed.  Furthermore in this case, `git submodule ...` is not needed if the `git clone ...` command is changed to `git clone --recurse-submodules https://github.com/pytorch/pytorch.git` instead.
+Also note that if you want to build the current ``master`` version then the ``git checkout ...`` and ``git clean ...`` commands are not needed.  Furthermore in this case, ``git submodule ...`` is not needed if the ``git clone ...`` command is changed to ``git clone --recurse-submodules https://github.com/pytorch/pytorch.git`` instead.
 
 You will get errors if you do not have needed dependencies such as Python3's PyYAML package.

--- a/docs/libtorch.rst
+++ b/docs/libtorch.rst
@@ -5,8 +5,8 @@ The core of pytorch does not depend on Python. A
 CMake-based build system compiles the C++ source code into a shared
 object, libtorch.so.
 
-Building libtorch
------------------
+Building libtorch using Python
+------------------------------
 
 You can use a python script/module located in tools package to build libtorch
 ::
@@ -34,3 +34,18 @@ To produce libtorch.a rather than libtorch.so, set the environment variable `BUI
 To use ninja rather than make, set `CMAKE_GENERATOR="-GNinja" CMAKE_INSTALL="ninja install"`.
 
 Note that we are working on eliminating tools/build_pytorch_libs.sh in favor of a unified cmake build.
+
+Building libtorch without using Python
+--------------------------------------
+
+You can build C++ libtorch.so without relying on Python.  For example to build a v1.6.0 Release version that uses (system-installed) CUDA and CUDDN, and install it in the directory specified by CMAKE_INSTALL_PREFIX below, you can use
+::
+   git clone https://github.com/pytorch/pytorch.git
+   cd pytorch
+   git checkout v1.6.0
+   git clean -fdx
+   git submodule update --init --recursive
+   mkdir ../pytorch-build
+   cd ../pytorch-build
+   cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=Release -DUSE_CUDA:BOOL=ON -DUSE_CUDNN:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install ../pytorch
+   cmake --build . --target install

--- a/docs/libtorch.rst
+++ b/docs/libtorch.rst
@@ -35,7 +35,7 @@ To use ninja rather than make, set `CMAKE_GENERATOR="-GNinja" CMAKE_INSTALL="nin
 
 Note that we are working on eliminating tools/build_pytorch_libs.sh in favor of a unified cmake build.
 
-Building libtorch without using Python
+Building libtorch using CMake
 --------------------------------------
 
 You can build C++ libtorch.so without relying on Python.  For example to build a v1.6.0 Release version that uses (system-installed) CUDA and CUDDN, and install it in the directory specified by CMAKE_INSTALL_PREFIX below, you can use

--- a/docs/libtorch.rst
+++ b/docs/libtorch.rst
@@ -38,7 +38,7 @@ Note that we are working on eliminating tools/build_pytorch_libs.sh in favor of 
 Building libtorch using CMake
 --------------------------------------
 
-You can build C++ libtorch.so without relying on Python.  For example to build a v1.6.0 Release version that uses (system-installed) CUDA and CUDDN, and install it in the directory specified by CMAKE_INSTALL_PREFIX below, you can use
+You can build C++ libtorch.so directly with cmake.  For example, to build a v1.6.0 Release version that uses CUDA and CUDDN, and install it in the directory specified by CMAKE_INSTALL_PREFIX below, you can use
 ::
    git clone https://github.com/pytorch/pytorch.git
    cd pytorch
@@ -47,5 +47,11 @@ You can build C++ libtorch.so without relying on Python.  For example to build a
    git submodule update --init --recursive
    mkdir ../pytorch-build
    cd ../pytorch-build
-   cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=Release -DUSE_CUDA:BOOL=ON -DUSE_CUDNN:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install ../pytorch
+   cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=Release -DPYTHON_EXECUTABLE=`which python3` -DUSE_CUDA:BOOL=ON -DUSE_CUDNN:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=../pytorch-install ../pytorch
    cmake --build . --target install
+
+You can build the `Debug` version instead of `Release` and you can turn options off with `OFF` instead of `ON`.  Currently USE_CUDNN and USE_CUDA default to `ON` when those packages are available, and these and other options need not be specified when the default values are desired.
+
+Also note that if you want to build the current `master` version then the `git checkout ...` and `git clean ...` commands are not needed.  Furthermore in this case, `git submodule ...` is not needed if the `git clone ...` command is changed to `git clone --recurse-submodules https://github.com/pytorch/pytorch.git` instead.
+
+You will get errors if you do not have needed dependencies such as Python3's PyYAML package.


### PR DESCRIPTION
I am adding documentation for building the C++-only libtorch.so without invoking Python in the build and install process.  This works on my Ubuntu 20.04 system and is designed to be operating system agnostic.