### PR TITLE
Allow torch.hub.load() to load models from any local directory with a hubconf.py

### DIFF
--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -79,6 +79,7 @@ Loading models from Hub
 
 Pytorch Hub provides convenient APIs to explore all available models in hub through ``torch.hub.list()``,
 show docstring and examples through ``torch.hub.help()`` and load the pre-trained models using ``torch.hub.load()``
+or ``torch.hub.load_local()``.
 
 
 .. automodule:: torch.hub
@@ -89,6 +90,8 @@ show docstring and examples through ``torch.hub.help()`` and load the pre-traine
 
 .. autofunction:: load
 
+.. autofunction:: load_local
+
 .. autofunction:: download_url_to_file
 
 .. autofunction:: load_state_dict_from_url
@@ -96,8 +99,10 @@ show docstring and examples through ``torch.hub.help()`` and load the pre-traine
 Running a loaded model:
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Note that ``*args, **kwargs`` in :func:`torch.load()` are used to **instantiate** a model.
-After you loaded a model, how can you find out what you can do with the model?
+Note that ``*args`` and ``**kwargs`` in :func:`torch.load()` and
+:func:`torch.load_local()`are used to **instantiate** a model.
+After you have loaded a model, how can you find out what you can do with the
+model?
 A suggested workflow is
 
 - ``dir(model)`` to see all available methods of the model.

--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -80,7 +80,7 @@ Loading models from Hub
 Pytorch Hub provides convenient APIs to explore all available models in hub
 through :func:`torch.hub.list()`, show docstring and examples through
 :func:`torch.hub.help()` and load the pre-trained models using
-:func:`torch.hub.load()` or :func:`torch.hub.load_local()`.
+:func:`torch.hub.load()`.
 
 
 .. automodule:: torch.hub
@@ -91,8 +91,6 @@ through :func:`torch.hub.list()`, show docstring and examples through
 
 .. autofunction:: load
 
-.. autofunction:: load_local
-
 .. autofunction:: download_url_to_file
 
 .. autofunction:: load_state_dict_from_url
@@ -100,10 +98,9 @@ through :func:`torch.hub.list()`, show docstring and examples through
 Running a loaded model:
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Note that ``*args`` and ``**kwargs`` in :func:`torch.hub.load()` and
-:func:`torch.hub.load_local()` are used to **instantiate** a model.
-After you have loaded a model, how can you find out what you can do with the
-model?
+Note that ``*args`` and ``**kwargs`` in :func:`torch.hub.load()` are used to
+**instantiate** a model. After you have loaded a model, how can you find out
+what you can do with the model?
 A suggested workflow is
 
 - ``dir(model)`` to see all available methods of the model.

--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -77,9 +77,10 @@ Important Notice
 Loading models from Hub
 -----------------------
 
-Pytorch Hub provides convenient APIs to explore all available models in hub through ``torch.hub.list()``,
-show docstring and examples through ``torch.hub.help()`` and load the pre-trained models using ``torch.hub.load()``
-or ``torch.hub.load_local()``.
+Pytorch Hub provides convenient APIs to explore all available models in hub
+through :func:`torch.hub.list()`, show docstring and examples through
+:func:`torch.hub.help()` and load the pre-trained models using
+:func:`torch.hub.load()` or :func:`torch.hub.load_local()`.
 
 
 .. automodule:: torch.hub
@@ -99,8 +100,8 @@ or ``torch.hub.load_local()``.
 Running a loaded model:
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Note that ``*args`` and ``**kwargs`` in :func:`torch.load()` and
-:func:`torch.load_local()`are used to **instantiate** a model.
+Note that ``*args`` and ``**kwargs`` in :func:`torch.hub.load()` and
+:func:`torch.hub.load_local()` are used to **instantiate** a model.
 After you have loaded a model, how can you find out what you can do with the
 model?
 A suggested workflow is

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -512,6 +512,20 @@ class TestHub(TestCase):
         hub_model = hub.load(
             'ailzhang/torchhub_example',
             'mnist',
+            source='github',
+            pretrained=True,
+            verbose=False)
+        self.assertEqual(sum_of_state_dict(hub_model.state_dict()),
+                         SUM_OF_HUB_EXAMPLE)
+
+    @retry(URLError, tries=3, skip_after_retries=True)
+    def test_load_from_local_dir(self):
+        local_dir = hub._get_cache_or_reload(
+            'ailzhang/torchhub_example', force_reload=False)
+        hub_model = hub.load(
+            local_dir,
+            'mnist',
+            source='local',
             pretrained=True,
             verbose=False)
         self.assertEqual(sum_of_state_dict(hub_model.state_dict()),

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -355,13 +355,14 @@ def load(repo_or_dir, model, *args, **kwargs):
         >>> model = torch.hub.load(path, 'resnet50', pretrained=True)
     """
     source = kwargs.pop('source', 'github').lower()
+    force_reload = kwargs.pop('force_reload', False)
+    verbose = kwargs.pop('verbose', True)
+
     if source not in ('github', 'local'):
         raise ValueError(
             f'Unknown source: "{source}". Allowed values: "github" | "local".')
 
     if source == 'github':
-        force_reload = kwargs.pop('force_reload', False)
-        verbose = kwargs.pop('verbose', True)
         repo_or_dir = _get_cache_or_reload(repo_or_dir, force_reload, verbose)
 
     model = _load_local(repo_or_dir, model, *args, **kwargs)

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -362,8 +362,8 @@ def load_local(hubconf_dir, model, *args, **kwargs):
         a single model with corresponding pretrained weights.
 
     Example:
-        >>> model = torch.hub.load_local(
-                '/local/copy/of/pytorch/vision', 'resnet50', pretrained=True)
+        >>> path = '/some/local/path/pytorch/vision'
+        >>> model = torch.hub.load_local(path, 'resnet50', pretrained=True)
     """
     sys.path.insert(0, hubconf_dir)
 

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -341,15 +341,40 @@ def load(github, model, *args, **kwargs):
 
     repo_dir = _get_cache_or_reload(github, force_reload, verbose)
 
-    sys.path.insert(0, repo_dir)
+    model = load_local(repo_dir, model, *args, **kwargs)
 
-    hub_module = import_module(MODULE_HUBCONF, repo_dir + '/' + MODULE_HUBCONF)
+    return model
+
+
+def load_local(hubconf_dir, model, *args, **kwargs):
+    r"""
+    Load a model from a local directory with a `hubconf.py`.
+
+    Args:
+        hubconf_dir (string): path to a local directory that contains a
+            `hubconf.py`.
+        model (string): name of an entrypoint defined in the directory's
+            `hubconf.py`.
+        *args (optional): the corresponding args for callable `model`.
+        **kwargs (optional): the corresponding kwargs for callable `model`.
+
+    Returns:
+        a single model with corresponding pretrained weights.
+
+    Example:
+        >>> model = torch.hub.load_local(
+                '/local/copy/of/pytorch/vision', 'resnet50', pretrained=True)
+    """
+    sys.path.insert(0, hubconf_dir)
+
+    hubconf_path = os.path.join(hubconf_dir, MODULE_HUBCONF)
+    hub_module = import_module(MODULE_HUBCONF, hubconf_path)
 
     entry = _load_entry_from_hubconf(hub_module, model)
 
     model = entry(*args, **kwargs)
 
-    sys.path.remove(repo_dir)
+    sys.path.remove(hubconf_dir)
 
     return model
 

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -326,8 +326,9 @@ def load(repo_or_dir, model, *args, **kwargs):
     path to a local directory.
 
     Args:
-        repo_or_dir (string): repo name (``repo_owner/repo_name[:tag_name]``)
-            or a path to a local directory. See :attr:`source`.
+        repo_or_dir (string): repo name (``repo_owner/repo_name[:tag_name]``),
+            ``source = 'github'``, or a path to a local directory, if
+            ``source = 'local'``.
         model (string): the name of a callable (entrypoint) defined in the
             repo/dir's ``hubconf.py``.
         *args (optional): the corresponding args for callable :attr:`model`.

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -353,17 +353,14 @@ def load(repo_or_dir, model, *args, **kwargs):
         >>> path = '/some/local/path/pytorch/vision'
         >>> model = torch.hub.load(path, 'resnet50', pretrained=True)
     """
-    source = kwargs.get('source', 'github').lower()
-    kwargs.pop('source', None)
+    source = kwargs.pop('source', 'github').lower()
     if source not in ('github', 'local'):
         raise ValueError(
             f'Unknown source: "{source}". Allowed values: "github" | "local".')
 
     if source == 'github':
-        force_reload = kwargs.get('force_reload', False)
-        kwargs.pop('force_reload', None)
-        verbose = kwargs.get('verbose', True)
-        kwargs.pop('verbose', None)
+        force_reload = kwargs.pop('force_reload', False)
+        verbose = kwargs.pop('verbose', True)
         repo_or_dir = _get_cache_or_reload(repo_or_dir, force_reload, verbose)
 
     model = _load_local(repo_or_dir, model, *args, **kwargs)

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -327,7 +327,7 @@ def load(repo_or_dir, model, *args, **kwargs):
 
     Args:
         repo_or_dir (string): repo name (``repo_owner/repo_name[:tag_name]``),
-            ``source = 'github'``, or a path to a local directory, if
+            if ``source = 'github'``; or a path to a local directory, if
             ``source = 'local'``.
         model (string): the name of a callable (entrypoint) defined in the
             repo/dir's ``hubconf.py``.

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -335,10 +335,12 @@ def load(repo_or_dir, model, *args, **kwargs):
         source (string, optional): ``'github'`` | ``'local'``. Specifies how
             ``repo_or_dir`` is to be interpreted. Default is ``'github'``.
         force_reload (bool, optional): whether to force a fresh download of
-            the github repo unconditionally. Default is ``False``.
+            the github repo unconditionally. Does not have any effect if
+            ``source = 'local'``. Default is ``False``.
         verbose (bool, optional): If ``False``, mute messages about hitting
             local caches. Note that the message about first download cannot be
-            muted. Default is ``True``.
+            muted. Does not have any effect if ``source = 'local'``.
+            Default is ``True``.
         **kwargs (optional): the corresponding kwargs for callable
             :attr:`model`.
 

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -311,59 +311,83 @@ def help(github, model, force_reload=False):
 # but Python2 complains syntax error for it. We have to skip force_reload in function
 # signature here but detect it in kwargs instead.
 # TODO: fix it after Python2 EOL
-def load(github, model, *args, **kwargs):
+def load(repo_or_dir, model, *args, **kwargs):
     r"""
-    Load a model from a github repo, with pretrained weights.
+    Load a model from a github repo or a local directory.
+
+    Note: Loading a model is the typical use case, but this can also be used to
+    for loading other objects such as tokenizers, loss functions, etc.
+
+    If :attr:`source` is ``'github'``, :attr:`repo_or_dir` is expected to be
+    of the form ``repo_owner/repo_name[:tag_name]`` with an optional
+    tag/branch.
+
+    If :attr:`source` is ``'local'``, :attr:`repo_or_dir` is expected to be a
+    path to a local directory.
 
     Args:
-        github (string): a string with format "repo_owner/repo_name[:tag_name]" with an optional
-            tag/branch. The default branch is `master` if not specified.
-            Example: 'pytorch/vision[:hub]'
-        model (string): a string of entrypoint name defined in repo's hubconf.py
-        *args (optional): the corresponding args for callable `model`.
-        force_reload (bool, optional): whether to force a fresh download of github repo unconditionally.
-            Default is `False`.
-        verbose (bool, optional): If False, mute messages about hitting local caches. Note that the message
-            about first download is cannot be muted.
-            Default is `True`.
-        **kwargs (optional): the corresponding kwargs for callable `model`.
+        repo_or_dir (string): repo name (``repo_owner/repo_name[:tag_name]``)
+            or a path to a local directory. See :attr:`source`.
+        model (string): the name of a callable (entrypoint) defined in the
+            repo/dir's ``hubconf.py``.
+        *args (optional): the corresponding args for callable :attr:`model`.
+        source (string, optional): ``'github'`` | ``'local'``. Specifies how
+            ``repo_or_dir`` is to be interpreted. Default is ``'github'``.
+        force_reload (bool, optional): whether to force a fresh download of
+            the github repo unconditionally. Default is ``False``.
+        verbose (bool, optional): If ``False``, mute messages about hitting
+            local caches. Note that the message about first download cannot be
+            muted. Default is ``True``.
+        **kwargs (optional): the corresponding kwargs for callable
+            :attr:`model`.
 
     Returns:
-        a single model with corresponding pretrained weights.
+        The output of the :attr:`model` callable when called with the given
+        ``*args`` and ``**kwargs``.
 
     Example:
-        >>> model = torch.hub.load('pytorch/vision', 'resnet50', pretrained=True)
+        >>> # from a github repo
+        >>> repo = 'pytorch/vision'
+        >>> model = torch.hub.load(repo, 'resnet50', pretrained=True)
+        >>> # from a local directory
+        >>> path = '/some/local/path/pytorch/vision'
+        >>> model = torch.hub.load(path, 'resnet50', pretrained=True)
     """
-    force_reload = kwargs.get('force_reload', False)
-    kwargs.pop('force_reload', None)
-    verbose = kwargs.get('verbose', True)
-    kwargs.pop('verbose', None)
+    source = kwargs.get('source', 'github').lower()
+    kwargs.pop('source', None)
+    if source not in ('github', 'local'):
+        raise ValueError(
+            f'Unknown source: "{source}". Allowed values: "github" | "local".')
 
-    repo_dir = _get_cache_or_reload(github, force_reload, verbose)
+    if source == 'github':
+        force_reload = kwargs.get('force_reload', False)
+        kwargs.pop('force_reload', None)
+        verbose = kwargs.get('verbose', True)
+        kwargs.pop('verbose', None)
+        repo_or_dir = _get_cache_or_reload(repo_or_dir, force_reload, verbose)
 
-    model = load_local(repo_dir, model, *args, **kwargs)
-
+    model = _load_local(repo_or_dir, model, *args, **kwargs)
     return model
 
 
-def load_local(hubconf_dir, model, *args, **kwargs):
+def _load_local(hubconf_dir, model, *args, **kwargs):
     r"""
-    Load a model from a local directory with a `hubconf.py`.
+    Load a model from a local directory with a ``hubconf.py``.
 
     Args:
         hubconf_dir (string): path to a local directory that contains a
-            `hubconf.py`.
+            ``hubconf.py``.
         model (string): name of an entrypoint defined in the directory's
             `hubconf.py`.
-        *args (optional): the corresponding args for callable `model`.
-        **kwargs (optional): the corresponding kwargs for callable `model`.
+        *args (optional): the corresponding args for callable ``model``.
+        **kwargs (optional): the corresponding kwargs for callable ``model``.
 
     Returns:
         a single model with corresponding pretrained weights.
 
     Example:
         >>> path = '/some/local/path/pytorch/vision'
-        >>> model = torch.hub.load_local(path, 'resnet50', pretrained=True)
+        >>> model = _load_local(path, 'resnet50', pretrained=True)
     """
     sys.path.insert(0, hubconf_dir)
 
@@ -371,7 +395,6 @@ def load_local(hubconf_dir, model, *args, **kwargs):
     hub_module = import_module(MODULE_HUBCONF, hubconf_path)
 
     entry = _load_entry_from_hubconf(hub_module, model)
-
     model = entry(*args, **kwargs)
 
     sys.path.remove(hubconf_dir)


### PR DESCRIPTION
Fixes #43622 

- Moves the model loading part of `torch.hub.load()` into a new ~`torch.hub._load_local()`~ `torch.hub._load_local()` function that takes in a path to a local directory that contains a `hubconf.py` instead of a repo name. 
- ~Refactors `torch.hub.load()` so that it now calls `torch.hub.load_local()` after downloading and extracting the repo.~
- Refactors `torch.hub.load()` so that it can now take in a local path instead of a repo name. Adds a `source='github'|'local'` param to choose between the two behaviors.
- Updates `torch.hub` docs to include the new function + minor fixes.
