### PR TITLE
Benchmarks: re-enable profiling-te configuration.

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -338,8 +338,10 @@ test_benchmarks() {
     pip_install --user "requests"
     BENCHMARK_DATA="benchmarks/.data"
     mkdir -p ${BENCHMARK_DATA}
-    pytest benchmarks/fastrnns/test_bench.py --benchmark-sort=Name --benchmark-json=${BENCHMARK_DATA}/fastrnns.json
-    python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns.json
+    pytest benchmarks/fastrnns/test_bench.py --benchmark-sort=Name --benchmark-json=${BENCHMARK_DATA}/fastrnns_legacy_old.json --fuser=old --executor=legacy
+    python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_legacy_old.json
+    pytest benchmarks/fastrnns/test_bench.py --benchmark-sort=Name --benchmark-json=${BENCHMARK_DATA}/fastrnns_profiling_te.json --fuser=te --executor=profiling
+    python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_profiling_te.json
     assert_git_not_dirty
   fi
 }

--- a/benchmarks/fastrnns/conftest.py
+++ b/benchmarks/fastrnns/conftest.py
@@ -1,0 +1,17 @@
+import pytest  # noqa: F401
+
+default_rnns = ['cudnn', 'aten', 'jit', 'jit_premul', 'jit_premul_bias', 'jit_simple',
+                         'jit_multilayer', 'py']
+default_cnns = ['resnet18', 'resnet18_jit', 'resnet50', 'resnet50_jit']
+all_nets = default_rnns + default_cnns
+
+def pytest_generate_tests(metafunc):
+    # This creates lists of tests to generate, can be customized
+    if metafunc.cls.__name__ == "TestBenchNetwork":
+        metafunc.parametrize('net_name', all_nets, scope="class")
+        metafunc.parametrize("executor", [metafunc.config.getoption("executor")], scope="class")
+        metafunc.parametrize("fuser", [metafunc.config.getoption("fuser")], scope="class")
+
+def pytest_addoption(parser):
+    parser.addoption("--fuser", default="old", help="fuser to use for benchmarks")
+    parser.addoption("--executor", default="legacy", help="executor to use for benchmarks")

--- a/benchmarks/fastrnns/test_bench.py
+++ b/benchmarks/fastrnns/test_bench.py
@@ -13,7 +13,7 @@ def pytest_generate_tests(metafunc):
     # This creates lists of tests to generate, can be customized
     if metafunc.cls.__name__ == "TestBenchNetwork":
         metafunc.parametrize('net_name', all_nets, scope="class")
-        metafunc.parametrize("executor_and_fuser", ["legacy-old"], scope="class")
+        metafunc.parametrize("executor_and_fuser", ["legacy-old", "profiling-te"], scope="class")
 
 @pytest.fixture(scope='class')
 def modeldef(request, net_name, executor_and_fuser):

--- a/benchmarks/fastrnns/test_bench.py
+++ b/benchmarks/fastrnns/test_bench.py
@@ -4,20 +4,8 @@ import torch
 from .fuser import set_fuser
 from .runner import get_nn_runners
 
-default_rnns = ['cudnn', 'aten', 'jit', 'jit_premul', 'jit_premul_bias', 'jit_simple',
-                         'jit_multilayer', 'py']
-default_cnns = ['resnet18', 'resnet18_jit', 'resnet50', 'resnet50_jit']
-all_nets = default_rnns + default_cnns
-
-def pytest_generate_tests(metafunc):
-    # This creates lists of tests to generate, can be customized
-    if metafunc.cls.__name__ == "TestBenchNetwork":
-        metafunc.parametrize('net_name', all_nets, scope="class")
-        metafunc.parametrize("executor_and_fuser", ["legacy-old", "profiling-te"], scope="class")
-
 @pytest.fixture(scope='class')
-def modeldef(request, net_name, executor_and_fuser):
-    executor, fuser = executor_and_fuser.split("-")
+def modeldef(request, net_name, executor, fuser):
     set_fuser(fuser, executor)
 
     # Given a 'net_name' provided by generate_tests, build the thing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44218 [TensorExpr] Re-enable tests.
* **#44212 Benchmarks: re-enable profiling-te configuration.**

Differential Revision: [D23544563](https://our.internmc.facebook.com/intern/diff/D23544563)