### PR TITLE
[NNC] Don't attempt to refactor conditional scalars

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -190,6 +190,7 @@ namespace jit {
   _(RegisterizerNoInitializer)              \
   _(RegisterizerLoadThenStore)              \
   _(RegisterizerParallelized)               \
+  _(RegisterizerConditions)                 \
   _(StmtClone)                              \
   _(BoundsInference_1)                      \
   _(BoundsInference_2)                      \
@@ -388,7 +389,8 @@ namespace jit {
   _(CudaTestRand01)                        \
   _(CudaSigmoid)                           \
   _(CudaHalfCast)                          \
-  _(CudaHalfSupport)
+  _(CudaHalfSupport)                       \
+  _(CudaPrioritizeDependents)
 
 #define DECLARE_TENSOREXPR_TEST(name) void test##name();
 TH_FORALL_TENSOREXPR_TESTS(DECLARE_TENSOREXPR_TEST)

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -57,6 +57,10 @@ void RegisterizerAnalysis::visit(const Store* v) {
     candidates_[accessHash] = info;
     encounterOrder_.push_back(info);
   }
+
+  if (nested_conditions_ > 0) {
+    info->invalid = true;
+  }
   info->addStore(v, enclosingBlock_, loopCost_);
 }
 
@@ -82,7 +86,39 @@ void RegisterizerAnalysis::visit(const Load* v) {
     encounterOrder_.push_back(info);
   }
 
+  if (nested_conditions_ > 0) {
+    info->invalid = true;
+  }
+
   info->addLoad(v, enclosingBlock_, loopCost_, stmtStack_.front());
+}
+
+void RegisterizerAnalysis::visit(const IfThenElse* v) {
+  v->condition()->accept(this);
+  nested_conditions_++;
+  v->true_value()->accept(this);
+  v->false_value()->accept(this);
+  nested_conditions_--;
+}
+
+void RegisterizerAnalysis::visit(const Cond* v) {
+  const Expr* condition = v->condition();
+  Stmt* true_stmt = v->true_stmt();
+  Stmt* false_stmt = v->false_stmt();
+  condition->accept(this);
+
+  stmtStack_.push_front(v);
+  nested_conditions_++;
+
+  if (true_stmt) {
+    true_stmt->accept(this);
+  }
+  if (false_stmt) {
+    false_stmt->accept(this);
+  }
+
+  nested_conditions_--;
+  stmtStack_.pop_front();
 }
 
 std::vector<std::shared_ptr<AccessInfo>> RegisterizerAnalysis::getCandidates() {

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -96,6 +96,10 @@ class TORCH_API RegisterizerAnalysis : public IRVisitor {
 
   void visit(const Load* v) override;
 
+  void visit(const IfThenElse* v) override;
+
+  void visit(const Cond* v) override;
+
 #define STMT_ON_STACK(Op)                    \
   virtual void visit(const Op* v) override { \
     stmtStack_.push_front(v);                \
@@ -107,7 +111,6 @@ class TORCH_API RegisterizerAnalysis : public IRVisitor {
   STMT_ON_STACK(Allocate);
   STMT_ON_STACK(Free);
   STMT_ON_STACK(Let);
-  STMT_ON_STACK(Cond);
 
 #undef STMT_ON_STACK
 
@@ -124,6 +127,8 @@ class TORCH_API RegisterizerAnalysis : public IRVisitor {
   std::deque<const Stmt*> stmtStack_;
   const Block* enclosingBlock_;
   HashProvider hasher_;
+
+  size_t nested_conditions_{0};
 };
 
 // Walks the IR an replaces a single Acccess with a local scalar Var.


### PR DESCRIPTION
Fixes a bug in the NNC registerizer for Cuda where it would hoist reads out of a conditional context when trying to cache them. As a quick fix, prevent scalar replacement if a usage is within a condition.