### PR TITLE
[PyTorch][Mobile] Insert the module name as `name()` to metadata dict if metadata doesn't contain "model_name"

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -401,8 +401,13 @@ mobile::Module _load_for_mobile(
     auto reader = torch::make_unique<PyTorchStreamReader>(std::move(rai));
     BytecodeDeserializer deserializer(std::move(reader));
     mobile::Module result = deserializer.deserialize(std::move(device));
+    std::unordered_map<std::string, std::string> copied_metadata =
+        result.metadata();
+    if (result.metadata().find("model_name") == result.metadata().end()) {
+      copied_metadata["model_name"] = result.name();
+    }
     if (observer) {
-      observer->onExitLoadModel(result.metadata());
+      observer->onExitLoadModel(copied_metadata);
     }
     return result;
   } catch (c10::Error& error) {

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -180,8 +180,13 @@ mobile::Module _load_data(
     auto mcu = std::make_shared<mobile::CompilationUnit>();
     mobile::Module result = mobile::Module(
         deserializer.deserialize(std::move(device)).toObject(), mcu);
+    std::unordered_map<std::string, std::string> copied_metadata =
+        result.metadata();
+    if (result.metadata().find("model_name") == result.metadata().end()) {
+      copied_metadata["model_name"] = result.name();
+    }
     if (observer) {
-      observer->onExitLoadModel(result.metadata());
+      observer->onExitLoadModel(copied_metadata);
     }
     return result;
   } catch (c10::Error& error) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44227 [PyTorch][Mobile] Insert the module name as `name()` to metadata dict if metadata doesn't contain "model_name"**

As title

Differential Revision: [D23549149](https://our.internmc.facebook.com/intern/diff/D23549149/)