### PR TITLE
[JIT] Unshare types for modules that define() in __init__

### DIFF
--- a/test/jit/test_type_sharing.py
+++ b/test/jit/test_type_sharing.py
@@ -501,3 +501,23 @@ class TestTypeSharing(JitTestCase):
         c = Foo({'bar': A()})
         self.assertDifferentType(a, b)
         self.assertSameType(b, c)
+
+    def test_type_sharing_define_in_init(self):
+        """
+        Tests that types between instances of a ScriptModule
+        subclass that defines methods in its __init__ are not
+        shared.
+        """
+        class A(torch.jit.ScriptModule):
+            def __init__(self, val):
+                super().__init__()
+                self.define(f"""
+                def forward(self) -> int:
+                    return {val}
+                """)
+
+        one = A(1)
+        two = A(2)
+
+        self.assertEquals(one(), 1)
+        self.assertEquals(two(), 2)

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -191,7 +191,10 @@ class ScriptMeta(type):
 
         @functools.wraps(original_init)
         def init_then_script(self, *args, **kwargs):
+            num_methods = len(cls._methods)
             original_init(self, *args, **kwargs)
+            added_methods_in_init = len(cls._methods) > num_methods
+
             if type(self) == cls:
 
                 def make_stubs(module):
@@ -200,7 +203,7 @@ class ScriptMeta(type):
 
                 self.__dict__[
                     "_actual_script_module"
-                ] = torch.jit._recursive.create_script_module(self, make_stubs)
+                ] = torch.jit._recursive.create_script_module(self, make_stubs, share_types=not added_methods_in_init)
 
                 # Delete the Python attributes that now shadow the ScriptModule
                 # ones, so that __getattr__ and __setattr__ will properly find


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44233 [JIT] Unshare types for modules that define() in __init__**

**Summary**
By default, scripting tries to share concrete and JIT types across
compilations. However, this can lead to incorrect results if a module
extends `torch.jit.ScriptModule`, and injects instance variables into
methods defined using `define`.

This commit detects when this has happened and disables type sharing
for the compilation of the module that uses `define` in `__init__`.

**Test Plan**
This commit adds a test to TestTypeSharing that tests this scenario.

**Fixes**
This commit fixes #43580.

Differential Revision: [D23553870](https://our.internmc.facebook.com/intern/diff/D23553870)