### PR TITLE
[TensorExpr] Fuser: check node inputs' device before merging the node into a fusion group.

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -249,6 +249,7 @@ namespace jit {
   _(FuserPass_0DimInput)                    \
   _(FuserPass_UnfusibleDevice)              \
   _(FuserPass_UnknownShapes)                \
+  _(FuserPass_Multidevice)                  \
   _(TrainBasic)
 
 #define TH_FORALL_TENSOREXPR_TESTS_LLVM(_) \

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -549,34 +549,37 @@ class TensorExprFuser {
     return true;
   }
 
+#define REQ(cond)                           \
+  if (!(cond)) {                            \
+    GRAPH_DEBUG("Failed cond " #cond "\n"); \
+    return false;                           \
+  }
+
   bool canHandle(Node* node) {
-    if (node->kind() == prim::Constant) {
-      // TODO: add support for tensor constants.
-      return false;
-    }
-    if (!allShapesAreKnown(node)) {
-      return false;
-    }
-    if (!isFusableOnDevice(node)) {
-      return false;
-    }
+    REQ(node->kind() != prim::Constant);
+    REQ(allShapesAreKnown(node));
+    REQ(isFusableOnDevice(node));
 
     // Don't include nodes whose inputs are tensor constants - we cannot handle
     // them at the moment.
     // TODO: actually support tensor constants and remove this.
     for (Value* input : node->inputs()) {
-      if (input->node()->kind() == prim::Constant &&
-          input->type()->cast<TensorType>()) {
-        return false;
+      if (input->node()->kind() == prim::Constant) {
+        REQ(!input->type()->cast<TensorType>())
       }
     }
-    return tensorexpr::isSupported(node);
-  }
+    if (node->kind() == aten::cat) {
+      REQ(node->input(0)->node()->kind() == prim::ListConstruct);
+      REQ(node->input(0)->uses().size() == 1);
+      REQ(node->input(1)->node()->kind() == prim::Constant);
+      auto const& listconstruct = node->input(0)->node();
+      REQ(tensorexpr::pickDeviceType(listconstruct->inputs()));
+    } else {
+      REQ(tensorexpr::pickDeviceType(node->inputs()));
+    }
 
-#define REQ(cond)                           \
-  if (!(cond)) {                            \
-    GRAPH_DEBUG("Failed cond " #cond "\n"); \
-    return false;                           \
+    REQ(tensorexpr::isSupported(node));
+    return true;
   }
 
   bool canMerge(Node* consumer, Node* producer) {
@@ -587,6 +590,17 @@ class TensorExprFuser {
     REQ(canHandle(producer));
     TORCH_INTERNAL_ASSERT(
         consumer->kind() == prim::TensorExprGroup || canHandle(consumer));
+
+    // Device checks
+    if (consumer->kind() != aten::cat && producer->kind() != aten::cat) {
+      // aten::cat needs a special handling because it takes a Tensor[] as its
+      // input We deal with that in the code below.
+      auto consumer_device = tensorexpr::pickDeviceType(consumer->inputs());
+      REQ(consumer_device);
+      auto producer_device = tensorexpr::pickDeviceType(producer->inputs());
+      REQ(producer_device);
+      REQ(*consumer_device == *producer_device);
+    }
 
     // Alias checks
     REQ(aliasDb_->couldMoveBeforeTopologically(producer, consumer));
@@ -617,6 +631,15 @@ class TensorExprFuser {
       REQ(producer->input(0)->uses().size() == 1);
       REQ(producer->input(1)->node()->kind() == prim::Constant);
       auto const& listConstruct = producer->input(0)->node();
+      // We're merging listconstruct->cat->consumer. cat is the producer here
+      // and we cannot determine its device type - we should use device of the
+      // listconstruct instead
+      auto listconstruct_device =
+          tensorexpr::pickDeviceType(listConstruct->inputs());
+      auto consumer_device = tensorexpr::pickDeviceType(consumer->inputs());
+      REQ(listconstruct_device);
+      REQ(consumer_device);
+      REQ(*listconstruct_device == *consumer_device);
       for (auto const& input : listConstruct->inputs()) {
         REQ(isFusableOnDevice(input->node()));
       }
@@ -625,9 +648,13 @@ class TensorExprFuser {
       REQ(consumer->input(0)->uses().size() == 1);
       REQ(consumer->input(1)->node()->kind() == prim::Constant);
       auto const& listConstruct = consumer->input(0)->node();
-      for (auto const& input : listConstruct->inputs()) {
-        REQ(isFusableOnDevice(input->node()));
-      }
+      // We're merging listconstruct->cat. cat is the consumer and listconstruct
+      // is the producer. cat doesn't have its device type and thus the only
+      // thing we should check is that listconstruct's device is well defined
+      // (e.g. all its inputs has the same device).
+      auto listconstruct_device =
+          tensorexpr::pickDeviceType(listConstruct->inputs());
+      REQ(listconstruct_device);
     } else {
       REQ(isFusableOnDevice(producer));
     }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -67,6 +67,21 @@ bool& getTEGenerateBlockCode() {
   return te_generate_block_code;
 }
 
+c10::optional<at::Device> pickDeviceType(
+    const at::ArrayRef<torch::jit::Value*>& inputs) {
+  c10::optional<at::Device> device = c10::nullopt;
+  for (auto const& input : inputs) {
+    auto tt = input->type()->cast<TensorType>();
+    if (tt && tt->device()) {
+      if (device && *device != *tt->device()) {
+        return c10::nullopt;
+      }
+      device = *tt->device();
+    }
+  }
+  return device;
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch
@@ -1486,17 +1501,6 @@ static bool isValidPrimProperty(const c10::optional<T>& a, T b) {
   return !a.has_value() || *a == b;
 }
 
-at::Device TensorExprKernel::pickDeviceType(
-    const at::ArrayRef<torch::jit::Value*>& inputs) {
-  for (auto const& input : inputs) {
-    auto tt = input->type()->cast<TensorType>();
-    if (tt && tt->device()) {
-      return *tt->device();
-    }
-  }
-  throw std::runtime_error("No tensor inputs");
-}
-
 TensorExprKernel::BackendType TensorExprKernel::inferBackendTypeFromDevice(
     at::Device device) {
   BackendType backendType = BackendType::kUninitialized;
@@ -1731,7 +1735,7 @@ void TensorExprKernel::compile() {
     tensors_.erase(output->unique());
   }
 
-  device_ = pickDeviceType(graph_->inputs());
+  device_ = *pickDeviceType(graph_->inputs());
   BackendType backendType = inferBackendTypeFromDevice(device_);
   Stmt* stmt = generateStmt(backendType);
   // Set up formal params (inputs, then outputs) for kernel.

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -133,7 +133,6 @@ class TORCH_API TensorExprKernel {
       const at::ArrayRef<IValue>& inputs,
       std::vector<at::Tensor>& outputs);
   BackendType inferBackendTypeFromDevice(at::Device device);
-  at::Device pickDeviceType(const at::ArrayRef<torch::jit::Value*>& inputs);
 
   void bindInput(const torch::jit::Value* input);
 
@@ -212,6 +211,9 @@ TORCH_API int& getTECudaPointwiseBlockSize();
 TORCH_API bool& getTEGenerateBlockCode();
 TORCH_API bool fallbackAllowed();
 TORCH_API bool setFallbackAllowed(bool value);
+
+TORCH_API c10::optional<at::Device> pickDeviceType(
+    const at::ArrayRef<torch::jit::Value*>& inputs);
 
 } // namespace tensorexpr
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43671 [TensorExpr] Fuser: try merging adjacent fusion groups.
* **#44241 [TensorExpr] Fuser: check node inputs' device before merging the node into a fusion group.**

Differential Revision: [D23554192](https://our.internmc.facebook.com/intern/diff/D23554192)