### PR TITLE
Use explicit templates in CUDALoops kernels

### DIFF
--- a/aten/src/ATen/native/cuda/AbsKernel.cu
+++ b/aten/src/ATen/native/cuda/AbsKernel.cu
@@ -6,11 +6,16 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct AbsFunctor {
+  __device__ __forceinline__ scalar_t operator() (const scalar_t a) const {
+    return std::abs(a);
+  }
+};
+
 void abs_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Bool, iter.dtype(), "abs_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-      return std::abs(a);
-    });
+    gpu_kernel(iter, AbsFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
@@ -8,12 +8,20 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct AddFunctor {
+  AddFunctor(scalar_t a): alpha(a) {}
+  __device__ __forceinline__ scalar_t operator() (const scalar_t a, const scalar_t b) const {
+    return a + alpha * b;
+  }
+  private:
+    scalar_t alpha;
+};
+
 void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
-    auto alpha = alpha_scalar.to<scalar_t>();
-    gpu_kernel_with_scalars(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return a + alpha * b;
-    });
+    AddFunctor<scalar_t> f(alpha_scalar.to<scalar_t>());
+    gpu_kernel_with_scalars(iter, f);
   });
 }
 

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -11,6 +11,39 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t, typename accscalar_t>
+struct MulScalarFunctor {
+    MulScalarFunctor(accscalar_t b_): b(b_) {}
+    __device__ scalar_t operator() (scalar_t a) const {
+      return a * b;
+    }
+  private:
+    accscalar_t b;
+};
+
+template<typename scalar_t>
+struct DivFunctor {
+  __device__ scalar_t operator() (scalar_t a, scalar_t b) const {
+    return a / b;
+  }
+};
+
+template<typename scalar_t>
+struct MulFunctor {
+  __device__ scalar_t operator() (scalar_t a, scalar_t b) const {
+    return a * b;
+  }
+};
+
+// Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
+template<>
+struct MulFunctor<bool> {
+  __device__ bool operator() (bool a, bool b) const {
+    return a && b;
+  }
+};
+
+
 void div_kernel_cuda(TensorIterator& iter) {
   if (!isIntegralType(iter.common_dtype(), /*includeBool*/ false) && iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
@@ -20,44 +53,35 @@ void div_kernel_cuda(TensorIterator& iter) {
       using accscalar_t = at::acc_type<scalar_t, true>;
       auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
       iter.remove_operand(2);
-      gpu_kernel(iter, [inv_b]GPU_LAMBDA(scalar_t a) -> scalar_t {
-        return a * inv_b;
-      });
+      MulScalarFunctor<scalar_t, decltype(inv_b)> f(inv_b);
+      gpu_kernel(iter, f);
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, iter.common_dtype(), "div_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return a / b;
-      });
+      DivFunctor<scalar_t> f;
+      gpu_kernel_with_scalars(iter, f);
     });
   }
 }
 
 void mul_kernel_cuda(TensorIterator& iter) {
-  if (iter.common_dtype() == ScalarType::Bool) {
-    // Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
-      return a && b;
-    });
-  } else if (!isIntegralType(iter.common_dtype(), /*includeBool*/ false) &&
+  if (!isIntegralType(iter.common_dtype(), /*includeBool*/ false) &&
     (iter.is_cpu_scalar(1) || iter.is_cpu_scalar(2))) {
-  //if common dtype is half the scalar constant can overflow in half precision, and yet the result can
-  //still be representable in the half dtype. Cast scalar to acc_type to have better accuracy
-          AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "mul_cuda", [&]() {
-            using accscalar_t = at::acc_type<scalar_t, true>;
-            int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
-            auto b = iter.scalar_value<accscalar_t>(scalar_arg);
-            iter.remove_operand(scalar_arg);
-            const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
-            gpu_kernel(iter, [b]GPU_LAMBDA(scalar_t a) -> scalar_t {
-              return a * b;
-            });
-          });
+    //if common dtype is half the scalar constant can overflow in half precision, and yet the result can
+    //still be representable in the half dtype. Cast scalar to acc_type to have better accuracy
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "mul_cuda", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
+      auto b = iter.scalar_value<accscalar_t>(scalar_arg);
+      iter.remove_operand(scalar_arg);
+      const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
+      MulScalarFunctor<scalar_t, decltype(b)> f(b);
+      gpu_kernel(iter, f);
+    });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, iter.common_dtype(), "mul_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        return a * b;
-      });
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "mul_cuda", [&]() {
+      MulFunctor<scalar_t> f;
+      gpu_kernel_with_scalars(iter, f);
     });
   }
 }

--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -10,11 +10,16 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct CompareEqFunctor {
+  __device__ __forceinline__ bool operator() (scalar_t a, scalar_t b) const {
+    return a == b;
+  }
+};
+
 void eq_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "eq_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a == b;
-    });
+    gpu_kernel_with_scalars(iter, CompareEqFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/CompareGEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareGEKernel.cu
@@ -10,11 +10,16 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct CompareGEFunctor {
+  __device__ __forceinline__ bool operator() (scalar_t a, scalar_t b) const {
+    return a >= b;
+  }
+};
+
 void ge_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "ge_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a >= b;
-    });
+    gpu_kernel_with_scalars(iter, CompareGEFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/CompareGTKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareGTKernel.cu
@@ -10,11 +10,16 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct CompareGTFunctor {
+  __device__ __forceinline__ bool operator() (scalar_t a, scalar_t b) const {
+    return a > b;
+  }
+};
+
 void gt_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "gt_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a > b;
-    });
+    gpu_kernel_with_scalars(iter, CompareGTFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/CompareLEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareLEKernel.cu
@@ -10,11 +10,16 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct CompareLEFunctor {
+  __device__ __forceinline__ bool operator() (scalar_t a, scalar_t b) const {
+    return a <= b;
+  }
+};
+
 void le_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "le_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a <= b;
-    });
+    gpu_kernel_with_scalars(iter, CompareLEFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/CompareLTKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareLTKernel.cu
@@ -10,11 +10,16 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct CompareLTFunctor {
+  __device__ __forceinline__ bool operator() (scalar_t a, scalar_t b) const {
+    return a < b;
+  }
+};
+
 void lt_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "lt_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a < b;
-    });
+    gpu_kernel_with_scalars(iter, CompareLTFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/CompareNEKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareNEKernel.cu
@@ -10,11 +10,16 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct CompareNEFunctor {
+  __device__ __forceinline__ bool operator() (scalar_t a, scalar_t b) const {
+    return a != b;
+  }
+};
+
 void ne_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "ne_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return a != b;
-    });
+    gpu_kernel_with_scalars(iter, CompareNEFunctor<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/cuda/FillKernel.cu
+++ b/aten/src/ATen/native/cuda/FillKernel.cu
@@ -6,12 +6,19 @@
 
 namespace at { namespace native {
 
+template<typename scalar_t>
+struct FillFunctor {
+  FillFunctor(scalar_t v): value(v) {}
+  __device__ __forceinline__ scalar_t operator() () const {
+    return value;
+  }
+  private:
+    scalar_t value;
+};
+
 void fill_kernel_cuda(TensorIterator& iter, Scalar value) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "fill_cuda", [&]() {
-    auto value_converted = value.to<scalar_t>();
-    gpu_kernel(iter, [value_converted]GPU_LAMBDA() -> scalar_t {
-      return value_converted;
-    });
+    gpu_kernel(iter, FillFunctor<scalar_t>(value.to<scalar_t>()));
   });
 }
 

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -140,7 +140,6 @@ struct BUnaryFunctor {
 
 template <typename func_t>
 void gpu_kernel_with_scalars(TensorIterator& iter, const func_t& f) {
-  ASSERT_HOST_DEVICE_LAMBDA(func_t);
   TORCH_INTERNAL_ASSERT(iter.ntensors() == 3);
 
   using traits = function_traits<func_t>;


### PR DESCRIPTION
Reland attempt of https://github.com/pytorch/pytorch/pull/41059
Use explicit templates instead of lambdas to reduce binary size without affecting the perf by 100-200Kb per arch per CU, namely:
BinaryMulDivKernel.cu 3.8Mb -> 3.5Mb
CompareEQKernel.cu 1.8Mb -> 1.7Mb
BinaryAddSubKernel.cu 2.0Mb -> 1.8Mb
BinaryBitwiseOpsKernels.cu 2.6Mb -> 2.3Mb


