### PR TITLE
Adding adaptive timing method on torch Timer #44219

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -611,6 +611,28 @@ class TestBenchmarkUtils(TestCase):
         median = timer.blocked_autorange(min_run_time=0.1).median
         self.assertIsInstance(median, float)
 
+    def test_adaptive_timer(self):
+        # Validate both on different sizes validate against blocked_autorange
+        # This looks for relative differences btetween orders of magnitude to
+        # provide a stable/portable test which is somewhat informative.
+        timer = benchmark_utils.Timer(
+            stmt="torch.sum(torch.ones((10,10)))",
+        )
+        small = timer.adaptive_autorange(min_run_time=0.1).median
+        timer = benchmark_utils.Timer(
+            stmt="torch.sum(torch.ones((100,100)))",
+        )
+        medium = timer.adaptive_autorange(min_run_time=0.1).median
+        blocked_medium = timer.blocked_autorange(min_run_time=0.1).median
+        self.assertLess(small, medium)
+        self.assertLess(small, blocked_medium)
+        timer = benchmark_utils.Timer(
+            stmt="torch.sum(torch.ones((1000,1000)))",
+        )
+        large = timer.adaptive_autorange(min_run_time=0.1).median
+        self.assertLess(medium, large)
+        self.assertLess(blocked_medium, large)
+
     def test_compare(self):
         compare = benchmark_utils.Compare([
             benchmark_utils.Timer(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -618,18 +618,21 @@ class TestBenchmarkUtils(TestCase):
         timer = benchmark_utils.Timer(
             stmt="torch.sum(torch.ones((10,10)))",
         )
-        small = timer.adaptive_autorange(min_run_time=0.1).median
+        small = timer.adaptive_autorange(min_run_time=0.1)
+        self.assertFalse(small.has_warnings())
         timer = benchmark_utils.Timer(
-            stmt="torch.sum(torch.ones((100,100)))",
+            stmt="torch.sum(torch.ones((500,100)))",
         )
-        medium = timer.adaptive_autorange(min_run_time=0.1).median
-        blocked_medium = timer.blocked_autorange(min_run_time=0.1).median
+        medium = timer.adaptive_autorange(min_run_time=0.1)
+        self.assertFalse(medium.has_warnings())
+        blocked_medium = timer.blocked_autorange(min_run_time=0.1)
         self.assertLess(small, medium)
         self.assertLess(small, blocked_medium)
         timer = benchmark_utils.Timer(
             stmt="torch.sum(torch.ones((1000,1000)))",
         )
         large = timer.adaptive_autorange(min_run_time=0.1).median
+        self.assertFalse(large.has_warnings())
         self.assertLess(medium, large)
         self.assertLess(blocked_medium, large)
 

--- a/torch/utils/_benchmark/utils/common.py
+++ b/torch/utils/_benchmark/utils/common.py
@@ -76,6 +76,9 @@ class Measurement:
     def __setstate__(self, state: Dict[str, Any]):
         self.__init__(**state)  # type: ignore
 
+    def meets_confidence(self, threshold=_IQR_WARN_THRESHOLD):
+        return self._iqr / self._median < threshold
+
     def _populate_warnings(self):
         warnings, rel_iqr = [], self._iqr / self._median * 100
 
@@ -87,7 +90,7 @@ class Measurement:
 
         if self._iqr / self._median > _IQR_GROSS_WARN_THRESHOLD:
             add_warning("This suggests significant environmental influence.")
-        elif self._iqr / self._median > _IQR_WARN_THRESHOLD:
+        elif not self.meets_confidence():
             add_warning("This could indicate system fluctuation.")
         return warnings
 


### PR DESCRIPTION
Fixes #{issue number}

This adds adaptive timing for benchmarking. This auto-determines how many times to run the benchmark to get an accurate measurement. 