### PR TITLE
skip test_tanhquantize for now

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_fusions.py
+++ b/caffe2/contrib/fakelowp/test/test_fusions.py
@@ -28,7 +28,7 @@ class Fusions(serial.SerializedTestCase):
         rand_seed=st.integers(0, 65534),
     )
     @settings(deadline=None, max_examples=100)
-    def test_tanhquantize(self, scale, zp, size, rand_seed):
+    def Skip_test_tanhquantize(self, scale, zp, size, rand_seed):
         np.random.seed(rand_seed)
 
         workspace.ResetWorkspace()


### PR DESCRIPTION
Summary: This test is failing now when running on card. Let's disable it while Intel is investigating the issue.

Test Plan: Sandcastle

Differential Revision: D23577475

