### PR TITLE
[FX] Only copy over training attr if it's there

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -95,7 +95,8 @@ class GraphModule(torch.nn.Module):
 
     def __init__(self, root: torch.nn.Module, graph: Graph):
         super().__init__()
-        self.training = root.training
+        if hasattr(root, 'training'):
+            self.training = root.training
         for node in graph.nodes:
             if node.op in ['get_param', 'call_module']:
                 assert isinstance(node.target, str)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44147 [FX][RFC] Preserve module qualnames on nodes + split pass
* **#44314 [FX] Only copy over training attr if it\'s there**

Differential Revision: [D23578189](https://our.internmc.facebook.com/intern/diff/D23578189)