### PR TITLE
Dump optimized graph when logging in already-optimized PE

### DIFF
--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -460,7 +460,7 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   }
 
   if (optimized_plan_) {
-    GRAPH_DUMP("plan already optimized:", graph);
+    GRAPH_DUMP("plan already optimized:", (*optimized_plan_).graph);
     return *optimized_plan_;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44315 Dump optimized graph when logging in already-optimized PE**

Summary: I find it more intuitive to dump the optimized graph if we have one;
when I first saw the unoptimized graph being dumped I thought we had failed to
apply any optimizations.

Test Plan: Observe output by hand

Differential Revision: [D23578813](https://our.internmc.facebook.com/intern/diff/D23578813)