### PR TITLE
Fixed quantile nan-propagation

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -1,15 +1,18 @@
-#include <ATen/native/Sorting.h>
-
 #include <ATen/ATen.h>
+#include <ATen/NamedTensorUtils.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/Parallel.h>
 #include <ATen/WrapDimUtils.h>
+#include <ATen/native/Resize.h>
+#include <ATen/native/Sorting.h>
 #include <ATen/native/SortingUtils.h>
-#include <ATen/NamedTensorUtils.h>
-#include <ATen/NamedTensorUtils.h>
+
+#include <utility>
 
 namespace at {
 namespace native {
+
+DEFINE_DISPATCH(topk_stub);
 
 namespace {
 
@@ -80,7 +83,7 @@ void quick_select_template(
       if (j < i)
         break;
       swap_fn(i, j);
-    } while (1);
+    } while (true);
     swap_fn(L, j);
 
     // Re-set active partition
@@ -88,12 +91,117 @@ void quick_select_template(
       L = i;
     if (j >= k)
       R = j - 1;
-  } while (1);
+  } while (true);
 }
 
-} // namespace
+void quantile_impl(
+    Tensor& out,
+    const Tensor& self,
+    const Tensor& q,
+    optional<int64_t> _dim,
+    bool keepdim) {
+  int64_t dim = at::maybe_wrap_dim(_dim.value_or(0), self.dim(), true);
 
-static std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
+  TORCH_CHECK(self.numel() > 0, "quantile() input tensor must be non-empty");
+  TORCH_CHECK(q.dim() <= 1, "quantile() q must be a scalar or 1D tensor");
+
+  TORCH_CHECK(
+      self.scalar_type() == kFloat || self.scalar_type() == kDouble,
+      "quantile() input tensor must be either float or double dtype");
+  TORCH_CHECK(
+      self.scalar_type() == q.scalar_type(),
+      "quantile() q must be same dtype as the input tensor");
+  TORCH_CHECK(
+      self.device() == q.device(),
+      "quantile() q must be on the same device as the input tensor");
+
+  // Compute output shape: q_size + reduced_size
+  std::vector<int64_t> out_shape;
+  if (_dim && self.dim() > 0) {
+    out_shape = self.sizes().vec();
+    if (keepdim) {
+      out_shape[dim] = 1;
+    } else {
+      out_shape.erase(out_shape.begin() + dim);
+    }
+  } else if (keepdim) {
+    out_shape = std::vector<int64_t>(self.dim(), 1);
+  }
+  if (q.dim() > 0) {
+    out_shape.insert(out_shape.begin(), q.numel());
+  }
+
+  // Check or resize output
+  if (out.numel() > 0) {
+    TORCH_CHECK(
+        out.sizes().vec() == out_shape,
+        "quantile() expected output shape to be ",
+        out_shape,
+        " but got ",
+        out.sizes().vec());
+    TORCH_CHECK(
+        self.scalar_type() == out.scalar_type(),
+        "quantile() out tensor must be same dtype as the input tensor");
+    TORCH_CHECK(
+        self.device() == out.device(),
+        "quantile() out tensor must be on the same device as the input tensor");
+  } else {
+    resize_output(out, out_shape);
+  }
+
+  // Do this check only on cpu to prevent implicit sync on CUDA
+  if (self.device().is_cpu()) {
+    TORCH_CHECK(
+        q.ge(0).logical_and_(q.le(1)).all().item<bool>(),
+        "quantile() q values must be in the range [0, 1]");
+  }
+
+  // If q is scalar, treat as 1D during computations
+  if (q.dim() == 0) {
+    out_shape.insert(out_shape.begin(), q.numel());
+  }
+
+  // Move dimension to reduce as last dimension and flatten if no dim was
+  // specified by the user. Sort to efficiently query kth values.
+  Tensor sorted;
+  if (!_dim) {
+    sorted = std::get<0>(self.flatten().sort());
+  } else if (dim == self.dim() - 1) {
+    sorted = std::get<0>(self.sort());
+  } else {
+    sorted = std::get<0>(self.unsqueeze(-1).transpose_(dim, -1).sort());
+  }
+
+  // View input as reduced_size + reduction_size
+  std::vector<int64_t> in_shape(out_shape.size());
+  std::copy(out_shape.begin() + 1, out_shape.end(), in_shape.begin());
+  in_shape[in_shape.size() - 1] = sorted.size(-1);
+  sorted = sorted.view(in_shape);
+
+  // Ensure converting from int64_t to double won't overflow
+  TORCH_CHECK(
+      sorted.size(-1) <= std::pow(2, 24),
+      "quantile() input tensor is too large");
+  
+  Tensor ranks = q * (sorted.size(-1) - 1);
+  Tensor ranks_below = ranks.toType(kLong);
+  Tensor weights = ranks - ranks_below;
+  Tensor ranks_above = ranks.ceil_().toType(kLong);
+  Tensor values_below = sorted.index_select(-1, ranks_below);
+  Tensor values_above = sorted.index_select(-1, ranks_above);
+
+  // Make out match expected shape for lerp
+  Tensor result = q.dim() == 0
+      ? out.unsqueeze(-1)
+      : out.unsqueeze(-1).transpose_(0, -1).squeeze_(0);
+
+  at::lerp_out(result, values_below, values_above, weights);
+
+  Tensor nan_mask = sorted.isnan().any(-1, false);
+  out.masked_fill_(nan_mask, NAN);
+}
+
+std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
     Tensor& values,
     Tensor& indices,
     const Tensor& self,
@@ -156,6 +264,8 @@ static std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
   return std::forward_as_tuple(values, indices);
 }
 
+} // namespace
+
 std::tuple<Tensor&, Tensor&> kthvalue_out_cpu(
     Tensor& values,
     Tensor& indices,
@@ -183,114 +293,13 @@ std::tuple<Tensor, Tensor> kthvalue(
   return std::make_tuple(values, indices);
 }
 
-// Compute the output shape for the quantile operator
-static std::vector<int64_t> quantile_out_shape(
-    const Tensor& self,
-    const Tensor& q,
-    c10::optional<int64_t> _dim,
-    bool keepdim
-) {
-  auto dim = _dim ? at::maybe_wrap_dim(*_dim, self.dim(), true) : 0;
-  std::vector<int64_t> out_shape;
-  if (_dim) {
-    out_shape = self.sizes().vec();
-    if (keepdim) {
-      out_shape[dim] = 1;
-    } else {
-      out_shape.erase(out_shape.begin() + dim);
-    }
-  } else if (keepdim) {
-    out_shape = std::vector<int64_t>(self.dim(), 1);
-  }
-  if (q.dim() > 0) {
-    out_shape.insert(out_shape.begin(), q.numel());
-  }
-  return out_shape;
-}
-
-static Tensor quantile_impl(
-    const Tensor& self,
-    const Tensor& q,
-    c10::optional<int64_t> _dim,
-    bool keepdim) {
-  TORCH_CHECK(self.numel() > 0, "Input tensor must be non-empty");
-  TORCH_CHECK(q.dim() <= 1, "q must be a scalar or 1D tensor");
-  
-  TORCH_CHECK(self.scalar_type() == kFloat || self.scalar_type() == kDouble, 
-      "Input tensor must be either float or double dtype");
-  TORCH_CHECK(self.scalar_type() == q.scalar_type(), 
-      "q must be same dtype as the input tensor");
-  
-  TORCH_CHECK(self.device() == q.device(), 
-      "q must be on the same device as the input tensor");
-
-  if (self.device() == kCPU) {
-    TORCH_CHECK(q.ge(0).logical_and_(q.le(1)).all().item<bool>(),
-        "q values must be in the range [0, 1]");
-  }
-
-  // If user didn't specify a dimension then we flatten the input tensor
-  auto in = _dim ? self : self.flatten();
-  auto dim = _dim ? at::maybe_wrap_dim(*_dim, self.dim(), true) : 0;
-
-  // We sort the input tensor to efficiently query multiple kth values.
-  // In the future, it might be worthwhile to implement multiple quickselect.
-  auto sorted = std::get<0>(in.sort(dim));
-
-  // Convert quantile into indices in the given dimension.
-  // Check for overflow when casting to a floating point type.
-  TORCH_CHECK(sorted.size(dim) <= std::pow(2, 24), "Input tensor is too large");
-  auto indices = q * (sorted.size(dim) - 1);
-  auto indices_below = indices.floor().toType(kLong);
-  auto indices_above = indices.ceil().toType(kLong);
-
-  // Extract values from tensor
-  auto values_below = sorted.index_select(dim, indices_below);
-  auto values_above = sorted.index_select(dim, indices_above);
-
-  // Interpolate values to get quantiles
-  std::vector<int64_t> broadcast_shape(sorted.dim(), 1);
-  broadcast_shape[dim] = -1;
-  auto weights = (indices - indices_below).reshape(broadcast_shape);
-  auto quantiles = values_below.lerp_(values_above, weights);
-
-  // when the q tensor is not a scalar, numpy will prepend a new dimension
-  // to contain the quantiles. This code ensures we follow the same order
-  if (q.dim() > 0) {
-    quantiles.unsqueeze_(0);
-    ++dim;
-    std::vector<int64_t> numpy_dim_order;
-    for (int64_t i = 0; i < quantiles.dim(); ++i) {
-      numpy_dim_order.push_back(i);
-    }
-    std::iter_swap(numpy_dim_order.begin(), numpy_dim_order.begin() + dim);
-    quantiles = quantiles.permute(numpy_dim_order);
-  }
-
-  return quantiles;
-}
-
 Tensor& quantile_out(
     Tensor& out,
     const Tensor& self,
     const Tensor& q,
-    c10::optional<int64_t> _dim,
+    optional<int64_t> _dim,
     bool keepdim) {
-  auto out_shape = quantile_out_shape(self, q, _dim, keepdim);
-
-  TORCH_CHECK(out.sizes().vec() == out_shape,
-      "expected out shape to be ", out_shape, " but got ", out.sizes().vec());
-  TORCH_CHECK(self.scalar_type() == out.scalar_type(), 
-      "out tensor must be same dtype as the input tensor");
-  TORCH_CHECK(self.device() == out.device(), 
-      "out tensor must be on the same device as the input tensor");
-
-  if (q.numel() == 0) {
-    return out;
-  }
-
-  out.copy_(quantile_impl(self, q, _dim, keepdim).reshape(out_shape));
-
+  quantile_impl(out, self, q, std::move(_dim), keepdim);
   return out;
 }
 
@@ -298,33 +307,37 @@ Tensor& quantile_out(
     Tensor& out,
     const Tensor& self,
     double q,
-    c10::optional<int64_t> _dim,
+    optional<int64_t> _dim,
     bool keepdim) {
-  TORCH_CHECK(q >= 0 && q <= 1, "q must be in the range [0, 1]");
-  return at::quantile_out(out, self, at::scalar_tensor(q, self.options()), _dim, keepdim);
+  TORCH_CHECK(
+      q >= 0 && q <= 1, "quantile() q must be in the range [0, 1] but got ", q);
+  return at::quantile_out(
+      out,
+      self,
+      at::scalar_tensor(q, self.options()),
+      std::move(_dim),
+      keepdim);
 }
 
 Tensor quantile(
     const Tensor& self,
     const Tensor& q,
-    c10::optional<int64_t> _dim,
+    optional<int64_t> _dim,
     bool keepdim) {
-  auto out_shape = quantile_out_shape(self, q, _dim, keepdim);
-
-  if (q.numel() == 0) {
-    return at::empty(out_shape, self.options());
-  }
-
-  return quantile_impl(self, q, _dim, keepdim).reshape(out_shape);
+  Tensor out = at::empty({0}, self.options());
+  quantile_impl(out, self, q, std::move(_dim), keepdim);
+  return out;
 }
 
 Tensor quantile(
     const Tensor& self,
     double q,
-    c10::optional<int64_t> _dim,
+    optional<int64_t> _dim,
     bool keepdim) {
-  TORCH_CHECK(q >= 0 && q <= 1, "q must be in the range [0, 1]");
-  return at::quantile(self, at::scalar_tensor(q, self.options()), _dim, keepdim);
+  TORCH_CHECK(
+      q >= 0 && q <= 1, "quantile() q must be in the range [0, 1] but got ", q);
+  return at::quantile(
+      self, at::scalar_tensor(q, self.options()), std::move(_dim), keepdim);
 }
 
 std::tuple<Tensor&, Tensor&> topk_out_cpu(
@@ -392,7 +405,8 @@ std::tuple<Tensor&, Tensor&> median_out(
     const Tensor& self,
     Dimname dim,
     bool keepdim) {
-  return at::median_out(values, indices, self, dimname_to_position(self, dim), keepdim);
+  return at::median_out(
+      values, indices, self, dimname_to_position(self, dim), keepdim);
 }
 
 std::tuple<Tensor, Tensor> median(
@@ -409,7 +423,8 @@ std::tuple<Tensor&, Tensor&> kthvalue_out(
     int64_t k,
     Dimname dim,
     bool keepdim) {
-  return at::kthvalue_out(values, indices, self, k, dimname_to_position(self, dim), keepdim);
+  return at::kthvalue_out(
+      values, indices, self, k, dimname_to_position(self, dim), keepdim);
 }
 
 std::tuple<Tensor, Tensor> kthvalue(
@@ -446,8 +461,6 @@ Tensor median_cpu(const Tensor& self) {
   });
   return result.view({});
 }
-
-DEFINE_DISPATCH(topk_stub);
 
 } // namespace native
 } // namespace at

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10417,10 +10417,8 @@ class TestTorchDeviceType(TestCase):
             run_test(tensor_dims, some)
 
     @dtypes(torch.float, torch.double)
-    @precisionOverride({torch.float: 1e-3, torch.double: 1e-6})
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_quantile(self, device, dtype):
-
         # Generate some random test cases
         a_sizes = [tuple(np.random.randint(2, 10, size=i)) for i in range(1, 4)]
         q_values = [tuple(np.random.rand(i)) for i in range(0, 4)]
@@ -10436,43 +10434,51 @@ class TestTorchDeviceType(TestCase):
             else:
                 a = torch.tensor(size, dtype=dtype, device=device)
             q = torch.tensor(quantiles, dtype=dtype, device=device)
+
+            # Make some random elements NaN
+            a.masked_fill_(torch.randint_like(a, 10) == 0, float('nan'))
+
             # Compute quantile along every dimension and flattened tensor
             for dim in [None] + list(range(a.ndim)):
-                result = torch.quantile(a, q, dim=dim, keepdim=keepdim).cpu()
-                expected = np.quantile(a.cpu().numpy(), q.cpu().numpy(), axis=dim, keepdims=keepdim)
-                expected = torch.from_numpy(np.array(expected)).type(result.type())
-                self.assertEqual(result, expected)
+                result = torch.quantile(a, q, dim, keepdim)
+                expected = np.quantile(a.cpu().numpy(), q.cpu().numpy(), dim, keepdims=keepdim)
+                self.assertTrue(np.allclose(result.cpu().numpy(), expected, atol=1e-06, equal_nan=True))
+
                 # Test out variation
-                out = torch.empty(result.shape, dtype=dtype, device=device)
-                torch.quantile(a, q, dim=dim, keepdim=keepdim, out=out)
-                self.assertEqual(result, out.cpu())
+                out = torch.empty_like(result)
+                torch.quantile(a, q, dim, keepdim, out=out)
+                self.assertTrue(np.allclose(result.cpu().numpy(), expected, atol=1e-06, equal_nan=True))
 
     def test_quantile_error(self, device):
-        with self.assertRaisesRegex(RuntimeError, "Input tensor must be non-empty"):
-            torch.empty(0, device=device).quantile(0.5)
-        with self.assertRaisesRegex(RuntimeError, "q must be a scalar or 1D tensor"):
-            torch.randn(1, device=device).quantile(torch.rand(2, 3, device=device))
-        with self.assertRaisesRegex(RuntimeError, "Input tensor must be either float or double dtype"):
-            torch.randn(1, dtype=torch.float16, device=device).quantile(0.5)
-        with self.assertRaisesRegex(RuntimeError, "q must be same dtype as the input tensor"):
-            torch.randn(1, device=device).quantile(torch.tensor(0.5, dtype=torch.float64, device=device))
-        with self.assertRaisesRegex(RuntimeError, "out tensor must be same dtype as the input tensor"):
-            torch.quantile(torch.randn(1, device=device), 0.5, out=torch.scalar_tensor(0, dtype=torch.float64, device=device))
-        if self.device_type == "cuda":
-            with self.assertRaisesRegex(RuntimeError, "q must be on the same device as the input tensor"):
-                torch.randn(1, device=device).quantile(torch.tensor(0.5))
-            with self.assertRaisesRegex(RuntimeError, "out tensor must be on the same device as the input tensor"):
-                torch.quantile(torch.randn(1, device=device), 0.5, out=torch.scalar_tensor(1))
-        with self.assertRaisesRegex(RuntimeError, "expected out shape to be 1 but got 1 1"):
-            torch.quantile(torch.randn(1, device=device), torch.tensor([0.5], device=device), out=torch.empty(1, 1, device=device))
-        with self.assertRaisesRegex(RuntimeError, r'q must be in the range \[0, 1\]'):
-            torch.randn(1, device=device).quantile(-1)
-        with self.assertRaisesRegex(RuntimeError, r'q must be in the range \[0, 1\]'):
-            torch.randn(1, device=device).quantile(1.1)
+        def check(a, q, args, kwargs, message):
+            with self.assertRaisesRegex(RuntimeError, r'quantile\(\) ' + message):
+                at = torch.tensor(a, device=device)
+                qt = torch.tensor(q, device=device) if isinstance(q, list) else q
+                torch.quantile(at, qt, *args, **kwargs)
+
+        check([], 0.5, [], {}, r'input tensor must be non-empty')
+        check([1.], [[1.]], [], {}, r'q must be a scalar or 1D tensor')
+        check([1], 0.5, [], {}, r'input tensor must be either float or double dtype')
+        check([1.], [1], [], {}, r'q must be same dtype as the input tensor')
+        check([1.], -1., [], {}, r'q must be in the range \[0, 1\] but got -1')
+        check([1.], 1.1, [], {}, r'q must be in the range \[0, 1\] but got 1.1')
+
+        check([1.], 0.5, [], {'out': torch.empty([], dtype=torch.float64, device=device)},
+              r'out tensor must be same dtype as the input tensor')
+        check([1.], [0.5], [], {'out': torch.empty(1, 1, dtype=torch.float64, device=device)},
+              r'expected output shape to be 1 but got 1 1')
+
         if self.device_type == "cpu":
-            # This can only be checked on cpu to avoid implicit device synchronization
-            with self.assertRaisesRegex(RuntimeError, r'q values must be in the range \[0, 1\]'):
-                torch.randn(1).quantile(torch.tensor([0.5, 1.1, -1]))
+            check([1.], [0.5, 1.1, -1], [], {}, r'q values must be in the range \[0, 1\]')
+
+        if self.device_type == "cuda":
+            with self.assertRaisesRegex(
+                    RuntimeError, r'quantile\(\) q must be on the same device as the input tensor'):
+                torch.randn(1, device=device).quantile(torch.tensor(0.5))
+            with self.assertRaisesRegex(
+                    RuntimeError, r'quantile\(\) out tensor must be on the same device as the input tensor'):
+                torch.quantile(torch.randn(1, device=device), 0.5, out=torch.scalar_tensor(1))
+
 
     def test_random_neg_values(self, device):
         signed_dtypes = [torch.double, torch.float, torch.long, torch.int, torch.short]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44336 torch.nanquantile implementation
* **#44318 Fixed quantile nan-propagation**

This PR fixed the nan-propagation behavior of torch.quantile to be the same as np.quantile. That is, if there is any NaN in the vector being reduced than quantile is NaN. It also improved performance by removing some unnecessary copying.