### PR TITLE
[NNC] Cuda Codegen - mask loops bound to block/thread dimensions

### DIFF
--- a/test/cpp/tensorexpr/test_cuda.cpp
+++ b/test/cpp/tensorexpr/test_cuda.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 
+#include <torch/csrc/jit/testing/file_check.h>
 #include "test/cpp/tensorexpr/padded_buffer.h"
 #include "torch/csrc/jit/tensorexpr/buffer.h"
 #include "torch/csrc/jit/tensorexpr/cuda_codegen.h"
@@ -1034,10 +1035,274 @@ void testCudaPrioritizeDependents() {
   }
 
   ExpectAllNear(c_v, c_ref, 1e-5);
+}
+
+void testCudaMaskBlockDim() {
+  KernelScope kernel_scope;
+  int A_SIZE = 100;
+  int B_SIZE = 50;
+  Buffer a_buf("a", kFloat, {A_SIZE});
+  Buffer b_buf("b", kFloat, {B_SIZE});
+  Tensor* c = Compute(
+      "c", {{A_SIZE, "i"}}, [&](const VarHandle& i) { return a_buf(i) + 10; });
+  Tensor* d = Compute("d", {{B_SIZE, "i"}}, [&](const VarHandle& i) {
+    return a_buf(i) + b_buf(i);
+  });
+
+  LoopNest l({c, d});
+  std::vector<For*> loops = l.getLoopStmtsFor(c);
+  l.setGPUBlockIndex(loops[0], 0);
+  loops = l.getLoopStmtsFor(d);
+  l.setGPUBlockIndex(loops[0], 0);
+
+  l.prepareForCodegen();
+  Stmt* stmt = l.root_stmt();
+  CudaCodeGen cuda_cg(stmt, c, d, a_buf, b_buf);
+
+  std::ostringstream oss;
+  oss << *cuda_cg.stmt();
+
+  // Check the c write is not masked, but the d write is.
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK-NOT: if (blockIdx
+# CHECK: c[blockIdx.x] =
+# CHECK: if (blockIdx.x<50
+# CHECK:   d[blockIdx.x] =)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+
+  auto blockExtents = cuda_cg.gpu_block_extents();
+  auto threadExtents = cuda_cg.gpu_thread_extents();
+  ASSERT_TRUE(exprEquals(blockExtents[0], new IntImm(A_SIZE)));
+  ASSERT_TRUE(exprEquals(threadExtents[0], new IntImm(1)));
+
+  // Sanity check that the kernel works.
+  PaddedBuffer<float> a_v(A_SIZE);
+  PaddedBuffer<float> b_v(B_SIZE);
+  PaddedBuffer<float> c_v(A_SIZE);
+  PaddedBuffer<float> d_v(B_SIZE);
+
+  PaddedBuffer<float> c_ref(A_SIZE);
+  PaddedBuffer<float> d_ref(B_SIZE);
+
+  for (int i = 0; i < A_SIZE; i++) {
+    a_v(i) = (float)i;
+    c_ref(i) = (float)(i + 10);
+  }
+
+  for (int i = 0; i < B_SIZE; i++) {
+    b_v(i) = (float)(B_SIZE - i);
+    d_ref(i) = a_v(i) + b_v(i);
+  }
+
+  float* a_dev = nullptr;
+  cudaMalloc(&a_dev, A_SIZE * sizeof(float));
+  float* b_dev = nullptr;
+  cudaMalloc(&b_dev, B_SIZE * sizeof(float));
+  float* c_dev = nullptr;
+  cudaMalloc(&c_dev, A_SIZE * sizeof(float));
+  float* d_dev = nullptr;
+  cudaMalloc(&d_dev, B_SIZE * sizeof(float));
+  cudaMemcpy(a_dev, a_v.data(), A_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(b_dev, b_v.data(), B_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(c_dev, c_v.data(), A_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_dev, d_v.data(), B_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaDeviceSynchronize();
+
+  cuda_cg(c_dev, d_dev, a_dev, b_dev);
+
+  cudaDeviceSynchronize();
+  cudaMemcpy(c_v.data(), c_dev, A_SIZE * sizeof(float), cudaMemcpyDeviceToHost);
+  cudaMemcpy(d_v.data(), d_dev, B_SIZE * sizeof(float), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+
+  ExpectAllNear(c_v, c_ref, 1e-5);
+  ExpectAllNear(d_v, d_ref, 1e-5);
 
   cudaFree(a_dev);
   cudaFree(b_dev);
   cudaFree(c_dev);
+  cudaFree(d_dev);
+}
+
+void testCudaMaskThreadDim() {
+  KernelScope kernel_scope;
+  int A_SIZE = 50;
+  int B_SIZE = 100;
+  Buffer a_buf("a", kFloat, {A_SIZE});
+  Buffer b_buf("b", kFloat, {B_SIZE});
+  Tensor* c = Compute(
+      "c", {{A_SIZE, "i"}}, [&](const VarHandle& i) { return a_buf(i) + 10; });
+  Tensor* d = Compute("d", {{B_SIZE, "i"}}, [&](const VarHandle& i) {
+    return a_buf(i / 2) + b_buf(i);
+  });
+
+  LoopNest l({c, d});
+  std::vector<For*> loops = l.getLoopStmtsFor(c);
+  l.setGPUThreadIndex(loops[0], 0);
+  loops = l.getLoopStmtsFor(d);
+  l.setGPUThreadIndex(loops[0], 0);
+
+  l.prepareForCodegen();
+  Stmt* stmt = l.root_stmt();
+  CudaCodeGen cuda_cg(stmt, c, d, a_buf, b_buf);
+
+  std::ostringstream oss;
+  oss << *cuda_cg.stmt();
+
+  // Check the c write is masked, but the d write is not.
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: if (threadIdx.x<50
+# CHECK:   c[threadIdx.x] =
+# CHECK-NOT: if (threadIdx.x
+# CHECK: d[threadIdx.x] =)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+
+  auto blockExtents = cuda_cg.gpu_block_extents();
+  auto threadExtents = cuda_cg.gpu_thread_extents();
+  ASSERT_TRUE(exprEquals(blockExtents[0], new IntImm(1)));
+  ASSERT_TRUE(exprEquals(threadExtents[0], new IntImm(B_SIZE)));
+
+  PaddedBuffer<float> a_v(A_SIZE);
+  PaddedBuffer<float> b_v(B_SIZE);
+  PaddedBuffer<float> c_v(A_SIZE);
+  PaddedBuffer<float> d_v(B_SIZE);
+
+  PaddedBuffer<float> c_ref(A_SIZE);
+  PaddedBuffer<float> d_ref(B_SIZE);
+
+  for (int i = 0; i < A_SIZE; i++) {
+    a_v(i) = (float)i;
+    c_ref(i) = (float)(i + 10);
+  }
+
+  for (int i = 0; i < B_SIZE; i++) {
+    b_v(i) = (float)(B_SIZE - i);
+    d_ref(i) = a_v(i / 2) + b_v(i);
+  }
+
+  float* a_dev = nullptr;
+  cudaMalloc(&a_dev, A_SIZE * sizeof(float));
+  float* b_dev = nullptr;
+  cudaMalloc(&b_dev, B_SIZE * sizeof(float));
+  float* c_dev = nullptr;
+  cudaMalloc(&c_dev, A_SIZE * sizeof(float));
+  float* d_dev = nullptr;
+  cudaMalloc(&d_dev, B_SIZE * sizeof(float));
+  cudaMemcpy(a_dev, a_v.data(), A_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(b_dev, b_v.data(), B_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(c_dev, c_v.data(), A_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_dev, d_v.data(), B_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaDeviceSynchronize();
+
+  cuda_cg(c_dev, d_dev, a_dev, b_dev);
+
+  cudaDeviceSynchronize();
+  cudaMemcpy(c_v.data(), c_dev, A_SIZE * sizeof(float), cudaMemcpyDeviceToHost);
+  cudaMemcpy(d_v.data(), d_dev, B_SIZE * sizeof(float), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+
+  ExpectAllNear(c_v, c_ref, 1e-5);
+  ExpectAllNear(d_v, d_ref, 1e-5);
+
+  cudaFree(a_dev);
+  cudaFree(b_dev);
+  cudaFree(c_dev);
+  cudaFree(d_dev);
+}
+
+// TODO: DISABLED, we'd need a NoBlockIdxWriter equivalent.
+void testCudaMaskBlockAndThreadDim() {
+  KernelScope kernel_scope;
+  int A_SIZE = 100;
+  int B_SIZE = 50;
+  Buffer a_buf("a", kFloat, {A_SIZE});
+  Buffer b_buf("b", kFloat, {B_SIZE});
+  Tensor* c = Compute(
+      "c", {{A_SIZE, "i"}}, [&](const VarHandle& i) { return a_buf(i) + 10; });
+  Tensor* d = Compute("d", {{B_SIZE, "i"}}, [&](const VarHandle& i) {
+    return a_buf(i) + b_buf(i);
+  });
+
+  LoopNest l({c, d});
+  std::vector<For*> loops = l.getLoopStmtsFor(c);
+  l.setGPUBlockIndex(loops[0], 0);
+  loops = l.getLoopStmtsFor(d);
+  l.setGPUThreadIndex(loops[0], 0);
+
+  l.prepareForCodegen();
+  Stmt* stmt = l.root_stmt();
+  CudaCodeGen cuda_cg(stmt, c, d, a_buf, b_buf);
+
+  std::ostringstream oss;
+  oss << *cuda_cg.stmt();
+  std::cout << *cuda_cg.stmt() << "\n";
+
+  // TODO: both writes should be masked but we have no equivalent to the
+  // NoThreadIdxWriter for the Block Dim.
+  const std::string& verification_pattern =
+      R"IR(
+# CHECK: if (threadIdx.x<1
+# CHECK:   c[blockIdx.x] =
+# CHECK: }
+# CHECK: d[threadIdx.x] =)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+
+  auto blockExtents = cuda_cg.gpu_block_extents();
+  auto threadExtents = cuda_cg.gpu_thread_extents();
+  ASSERT_TRUE(exprEquals(blockExtents[0], new IntImm(A_SIZE)));
+  ASSERT_TRUE(exprEquals(threadExtents[0], new IntImm(B_SIZE)));
+
+  PaddedBuffer<float> a_v(A_SIZE);
+  PaddedBuffer<float> b_v(B_SIZE);
+  PaddedBuffer<float> c_v(A_SIZE);
+  PaddedBuffer<float> d_v(B_SIZE);
+
+  PaddedBuffer<float> c_ref(A_SIZE);
+  PaddedBuffer<float> d_ref(B_SIZE);
+
+  for (int i = 0; i < A_SIZE; i++) {
+    a_v(i) = (float)i;
+    c_ref(i) = (float)(i + 10);
+  }
+
+  for (int i = 0; i < B_SIZE; i++) {
+    b_v(i) = (float)(B_SIZE - i);
+    d_ref(i) = a_v(i / 2) + b_v(i);
+  }
+
+  float* a_dev = nullptr;
+  cudaMalloc(&a_dev, A_SIZE * sizeof(float));
+  float* b_dev = nullptr;
+  cudaMalloc(&b_dev, B_SIZE * sizeof(float));
+  float* c_dev = nullptr;
+  cudaMalloc(&c_dev, A_SIZE * sizeof(float));
+  float* d_dev = nullptr;
+  cudaMalloc(&d_dev, B_SIZE * sizeof(float));
+  cudaMemcpy(a_dev, a_v.data(), A_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(b_dev, b_v.data(), B_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(c_dev, c_v.data(), A_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_dev, d_v.data(), B_SIZE * sizeof(float), cudaMemcpyHostToDevice);
+  cudaDeviceSynchronize();
+
+  cuda_cg(c_dev, d_dev, a_dev, b_dev);
+
+  cudaDeviceSynchronize();
+  cudaMemcpy(c_v.data(), c_dev, A_SIZE * sizeof(float), cudaMemcpyDeviceToHost);
+  cudaMemcpy(d_v.data(), d_dev, B_SIZE * sizeof(float), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+
+  ExpectAllNear(c_v, c_ref, 1e-5);
+  ExpectAllNear(d_v, d_ref, 1e-5);
+
+  cudaFree(a_dev);
+  cudaFree(b_dev);
+  cudaFree(c_dev);
+  cudaFree(d_dev);
 }
 
 } // namespace jit

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -390,7 +390,10 @@ namespace jit {
   _(CudaSigmoid)                           \
   _(CudaHalfCast)                          \
   _(CudaHalfSupport)                       \
-  _(CudaPrioritizeDependents)
+  _(CudaPrioritizeDependents)              \
+  _(CudaMaskBlockDim)                      \
+  _(CudaMaskThreadDim)
+// _(CudaMaskBlockAndThreadDim)
 
 #define DECLARE_TENSOREXPR_TEST(name) void test##name();
 TH_FORALL_TENSOREXPR_TESTS(DECLARE_TENSOREXPR_TEST)

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -33,6 +33,10 @@ class TORCH_API CodeGen {
     return stmt_;
   }
 
+  void set_stmt(Stmt* s) {
+    stmt_ = s;
+  }
+
   void apply_mutator(IRMutator* mutator) {
     stmt_ = stmt_->accept_mutator(mutator);
   }


### PR DESCRIPTION
Fix an issue where loops of different sizes are bound to the same Cuda dimension / metavar.

Coming soon more info and tests...
