### PR TITLE
Add a vector of module type/instance info to inlined call stack

### DIFF
--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -92,10 +92,10 @@ InlinedCallStack::InlinedCallStack(Function* fn, SourceRange source_range)
 InlinedCallStack::InlinedCallStack(
     Function* fn,
     SourceRange source_range,
-    c10::optional<ModuleInstanceInfo> module_instance_info)
+    c10::optional<std::vector<ModuleInstanceInfo>> module_instance_info_vec)
     : fn_(fn),
       source_range_(std::move(source_range)),
-      module_instance_info_(std::move(module_instance_info)){}
+      module_instance_info_vec_(std::move(module_instance_info_vec)){}
 
 InlinedCallStack::InlinedCallStack(
     InlinedCallStackPtr callee,
@@ -109,11 +109,11 @@ InlinedCallStack::InlinedCallStack(
     InlinedCallStackPtr callee,
     Function* fn,
     SourceRange source_range,
-    c10::optional<ModuleInstanceInfo> module_instance_info)
+    c10::optional<std::vector<ModuleInstanceInfo>> module_instance_info_vec)
     : callee_(std::move(callee)),
       fn_(fn),
       source_range_(std::move(source_range)),
-      module_instance_info_(std::move(module_instance_info)){}
+      module_instance_info_vec_(std::move(module_instance_info_vec)){}
 
 c10::optional<InlinedCallStackPtr> InlinedCallStack::callee() const {
   return callee_;
@@ -137,7 +137,7 @@ std::vector<InlinedCallStackWithModuleInfo>
     r.emplace_back(
         std::make_tuple((*current)->fn_,
           (*current)->source_range_,
-          (*current)->module_instance_info_));
+          (*current)->module_instance_info_vec_));
     current = (*current)->callee_;
   }
   return r;

--- a/torch/csrc/jit/ir/scope.h
+++ b/torch/csrc/jit/ir/scope.h
@@ -104,7 +104,7 @@ struct ModuleInstanceInfo {
 using InlinedCallStackPtr = c10::intrusive_ptr<InlinedCallStack>;
 using InlinedCallStackEntry = std::pair<Function*, SourceRange>;
 using InlinedCallStackWithModuleInfo =
-  std::tuple<Function*, SourceRange, c10::optional<ModuleInstanceInfo>>;
+  std::tuple<Function*, SourceRange, c10::optional<std::vector<ModuleInstanceInfo>>>;
 
 struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
  private:
@@ -112,7 +112,7 @@ struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
   Function* fn_;
   SourceRange source_range_;
   InlinedCallStackPtr intrusive_from_this();
-  c10::optional<ModuleInstanceInfo> module_instance_info_;
+  c10::optional<std::vector<ModuleInstanceInfo>> module_instance_info_vec_;
 
  public:
   // Constructor for a leaf callstack node.
@@ -122,7 +122,7 @@ struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
   InlinedCallStack(
       Function* fn,
       SourceRange source_range,
-      c10::optional<ModuleInstanceInfo> module_instance_info);
+      c10::optional<std::vector<ModuleInstanceInfo>> module_instance_info_vec);
 
   // Constructor for an inner callstack node.
   InlinedCallStack(
@@ -134,7 +134,7 @@ struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
       InlinedCallStackPtr callee,
       Function* fn,
       SourceRange source_range,
-      c10::optional<ModuleInstanceInfo> module_instance_info);
+      c10::optional<std::vector<ModuleInstanceInfo>> module_instance_info_vec);
 
   // Return next element in the callstack list.
   c10::optional<InlinedCallStackPtr> callee() const;

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -18,7 +18,7 @@ void pushScopeInfo(Node* node) {
   for (const auto& tup : vec) {
     const auto opt_module_instance_info = std::get<2>(tup);
     if (opt_module_instance_info) {
-      const auto& module_instance_info = opt_module_instance_info.value();
+      const auto& module_instance_info = opt_module_instance_info.value().back();
       if(module_instance_info.class_type()) {
         const auto& class_type = module_instance_info.class_type();
         const auto& instance_name = module_instance_info.instance_name();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44329 Reconstruct module debug info
* **#44328 Add a vector of module type/instance info to inlined call stack**
* #44327 Augment inlined call stack with module type/instance info.

