### PR TITLE
Support Python Slice class in TorchScript

### DIFF
--- a/test/jit/test_slice.py
+++ b/test/jit/test_slice.py
@@ -1,0 +1,107 @@
+import os
+import sys
+
+import torch
+from typing import List
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+# Tests that Python slice class is supported in TorchScript
+class TestSlice(JitTestCase):
+    def test_slice_kwarg(self):
+        def slice_kwarg(x: List[int]):
+            return x[slice(1, stop=2)]
+
+        with self.assertRaisesRegex(RuntimeError, "Slice does not accept any keyword arguments"):
+            torch.jit.script(slice_kwarg)
+
+    def test_slice_three_nones(self):
+        def three_nones(x: List[int]):
+            return x[slice(None, None, None)]
+
+        self.checkScript(three_nones, (range(10),))
+
+    def test_slice_two_nones(self):
+        def two_nones(x: List[int]):
+            return x[slice(None, None)]
+
+        self.checkScript(two_nones, (range(10),))
+
+    def test_slice_one_none(self):
+        def one_none(x: List[int]):
+            return x[slice(None)]
+
+        self.checkScript(one_none, (range(10),))
+
+    def test_slice_stop_only(self):
+        def fn(x: List[int]):
+            return x[slice(5)]
+        self.checkScript(fn, (range(10),))
+
+    def test_slice_stop_only_with_nones(self):
+        def fn(x: List[int]):
+            return x[slice(None, 5, None)]
+        self.checkScript(fn, (range(10),))
+
+    def test_slice_start_stop(self):
+        def fn(x: List[int]):
+            return x[slice(1, 5)]
+
+        self.checkScript(fn, (range(10),))
+
+    def test_slice_start_stop_with_none(self):
+        def fn(x: List[int]):
+            return x[slice(1, 5, None)]
+
+        self.checkScript(fn, (range(10),))
+
+    def test_slice_start_stop_step(self):
+        def fn(x: List[int]):
+            return x[slice(0, 6, 2)]
+
+        self.checkScript(fn, (range(10),))
+
+    def test_slice_string(self):
+        def fn(x: str):
+            return x[slice(None, 3, 1)]
+
+        self.checkScript(fn, ("foo_bar",))
+
+    def test_slice_tensor(self):
+        def fn(x: torch.Tensor):
+            return x[slice(None, 3, 1)]
+
+        self.checkScript(fn, (torch.ones(10),))
+
+    def test_slice_tensor_multidim(self):
+        def fn(x: torch.Tensor):
+            return x[slice(None, 3, 1), 0]
+
+        self.checkScript(fn, (torch.ones((10, 10)),))
+
+    def test_slice_tensor_multidim_with_dots(self):
+        def fn(x: torch.Tensor):
+            return x[slice(None, 3, 1), ...]
+
+        self.checkScript(fn, (torch.ones((10, 10)),))
+
+    def test_slice_as_variable(self):
+        def fn(x: List[int]):
+            a = slice(1)
+            return x[a]
+
+        self.checkScript(fn, (range(10),))
+
+    def test_slice_stop_clipped(self):
+        def fn(x: List[int]):
+            return x[slice(1000)]
+
+        self.checkScript(fn, (range(10),))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -32,6 +32,7 @@ from jit.test_onnx_export import TestONNXExport  # noqa: F401
 from jit.test_with import TestWith  # noqa: F401
 from jit.test_enum import TestEnum, TestEnumFeatureGuard  # noqa: F401
 from jit.test_profiler import TestProfiler  # noqa: F401
+from jit.test_slice import TestSlice  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -3326,6 +3326,57 @@ struct to_ir {
     return emitBuiltinCall(loc, *graph, aten::select, {input, dim, index}, {});
   }
 
+  Value* emitSliceOp(
+      const SourceRange& loc,
+      Value* sliceable,
+      Value* dim,
+      Value* start,
+      Value* end,
+      Value* step) {
+    std::vector<NamedValue> args;
+    args.reserve(4);
+    args.emplace_back(loc, "self", sliceable);
+
+    // XXX: If list slicing becomes more complicated or stops using
+    // aten::slice, we should separate it from this function.
+    if (dim) {
+      AT_ASSERT(sliceable->type()->isSubtypeOf(TensorType::get()));
+
+      args.emplace_back(dim);
+    } else {
+      AT_ASSERT(!sliceable->type()->isSubtypeOf(TensorType::get()));
+    }
+
+    // Default value for start is 0.
+    if (!start) {
+      start = graph->insertConstant(0, loc);
+    }
+    args.emplace_back(loc, "start", start);
+
+    if (end) {
+      args.emplace_back(loc, "end", end);
+    }
+    if (sliceable->type()->cast<TupleType>()) {
+      if (step) {
+        // TODO: add support for slicing tuples with a step
+        throw ErrorReport(loc)
+            << "Unsupported operation: slicing tuples with a step isn't supported";
+      }
+
+      if (end) {
+        return emitTupleSlice(loc, args[0], args[1], /*end*/ args[2]);
+      } else {
+        return emitTupleSlice(loc, args[0], args[1], c10::nullopt);
+      }
+    }
+
+    if (!step) {
+      step = graph->insertConstant(1, loc);
+    }
+    NamedValue step_nv = NamedValue(loc, "step", step);
+    return emitBuiltinCall(loc, *graph, aten::slice, args, {step_nv});
+  }
+
   // Desugars slice indexing: tensor[begin:end] -> tensor.slice(dim, begin, end,
   // 1)
   Value* emitSlice(
@@ -3333,43 +3384,19 @@ struct to_ir {
       Value* input,
       Value* dim, // Only used for tensor slicing
       const SliceExpr& slice) {
-    std::vector<NamedValue> args;
-    args.reserve(4);
-    args.emplace_back(loc, "self", input);
-
-    // XXX: If list slicing becomes more complicated or stops using
-    // aten::slice, we should separate it from this function.
-    if (dim) {
-      AT_ASSERT(input->type()->isSubtypeOf(TensorType::get()));
-
-      args.emplace_back(dim);
-    } else {
-      AT_ASSERT(!input->type()->isSubtypeOf(TensorType::get()));
+    Value* start = nullptr;
+    Value* end = nullptr;
+    Value* step = nullptr;
+    if (slice.start().present()) {
+      start = emitExpr(Expr(slice.start().get()));
     }
-
-    args.emplace_back(loc, "begin", emitExpr(Expr(slice.startOr(0))));
-    const auto has_end = slice.end().present();
-    if (has_end) {
-      args.emplace_back(loc, "end", emitExpr(Expr(slice.end().get())));
+    if (slice.end().present()) {
+      end = emitExpr(Expr(slice.end().get()));
     }
-    if (input->type()->cast<TupleType>()) {
-      auto has_step = slice.step().present();
-      if (has_step) {
-        // TODO: add support for slicing tuples with a step
-        throw ErrorReport(loc)
-            << "Unsupported operation: slicing tuples with a step isn't supported";
-      }
-
-      if (has_end) {
-        return emitTupleSlice(loc, args[0], args[1], /*end*/ args[2]);
-      } else {
-        return emitTupleSlice(loc, args[0], args[1], c10::nullopt);
-      }
+    if (slice.step().present()) {
+      step = emitExpr(Expr(slice.step().get()));
     }
-
-    auto step = emitExpr(Expr(slice.stepOr(1)));
-    NamedValue step_nv = NamedValue(loc, "step", step);
-    return emitBuiltinCall(loc, *graph, aten::slice, args, {step_nv});
+    return emitSliceOp(loc, input, dim, start, end, step);
   }
 
   Value* emitUnsqueeze(const SourceRange& loc, Value* input, Value* dim_val) {
@@ -3427,6 +3454,8 @@ struct to_ir {
                                int64_t dim,
                                bool is_reverse = false) {
       dims[expr_idx] = dim;
+
+      // Slice expression case, does not represent a single index.
       if (subscript_expr.kind() == TK_SLICE_EXPR) {
         if (is_reverse) {
           return dim - 1;
@@ -3434,6 +3463,17 @@ struct to_ir {
           return dim + 1;
         }
       }
+
+      // Slice object case, does not represent a single index.
+      auto subscript_sv = emitSugaredExpr(subscript_expr, 1);
+      if (dynamic_cast<SliceValue*>(subscript_sv.get())) {
+        if (is_reverse) {
+          return dim - 1;
+        } else {
+          return dim + 1;
+        }
+      }
+
       TypePtr type_hint;
       if (subscript_expr.kind() == TK_NONE) {
         type_hint = NoneType::get();
@@ -3524,7 +3564,25 @@ struct to_ir {
               sliceable,
               insert_value_for_dim(dims[i]),
               SliceExpr(subscript_exprs[i]));
+          continue;
         }
+
+        if (subscript_exprs[i].kind() == TK_DOTS) {
+          continue;
+        }
+
+        auto subscript_sv = emitSugaredExpr(subscript_exprs[i], 1);
+        if (const auto slice_value =
+                dynamic_cast<SliceValue*>(subscript_sv.get())) {
+          sliceable = emitSliceOp(
+              loc,
+              sliceable,
+              insert_value_for_dim(dims[i]),
+              slice_value->start(),
+              slice_value->stop(),
+              slice_value->step());
+        }
+
         continue;
       }
       auto expr = exprs[i].value();
@@ -3734,17 +3792,39 @@ struct to_ir {
             range, sv->asValue(val_range, method), subscript_exprs));
       }
     } else {
-      // Desugars gather syntactic sugar foo[i]
-      Value* idx = emitExpr(subscript_exprs[0]);
-      Value* val = sv->asValue(val_range, method);
       AT_ASSERT(subscript_exprs.size() == 1);
+      Value* sliceable = sv->asValue(val_range, method);
 
-      if (val->type()->cast<TupleType>()) {
+      // In case of subscript expression being a Python Slice object.
+      auto subscript_sv = emitSugaredExpr(subscript_exprs[0], 1);
+      if (const auto slice_value =
+              dynamic_cast<SliceValue*>(subscript_sv.get())) {
+        Value* dim = nullptr;
+        // aten::slice.tensor needs an additional `dim` input.
+        if (sliceable->type()->isSubtypeOf(TensorType::get())) {
+          dim = method.graph()->insertConstant(0, val_range);
+        }
+
+        Value* sliced = emitSliceOp(
+            val_range,
+            sliceable,
+            dim,
+            slice_value->start(),
+            slice_value->stop(),
+            slice_value->step());
+        return std::make_shared<SimpleValue>(sliced);
+      }
+
+      // subscript is not a slice object, then it must be convertible to
+      // a normal value.
+      // Desugars gather syntactic sugar foo[i]
+      Value* idx = subscript_sv->asValue(val_range, method);
+      if (sliceable->type()->cast<TupleType>()) {
         return std::make_shared<SimpleValue>(
             emitTupleIndex(range, sv->asValue(val_range, method), idx));
-      } else if (val->type()->isSubtypeOf(TensorType::get())) {
+      } else if (sliceable->type()->isSubtypeOf(TensorType::get())) {
         return std::make_shared<SimpleValue>(
-            emitMultidimSlicing(range, val, subscript_exprs));
+            emitMultidimSlicing(range, sliceable, subscript_exprs));
       } else {
         return sv->getitem(range, method, idx);
       }

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -773,5 +773,29 @@ struct TORCH_API SugaredEnumClass : public SugaredValue {
   EnumTypePtr enum_type_;
 };
 
+struct TORCH_API SliceValue : public SugaredValue {
+  explicit SliceValue(Value* start, Value* stop, Value* step)
+      : start_(start), stop_(stop), step_(step) {}
+
+  std::string kind() const override {
+    return "Python slice value";
+  }
+
+  Value* start() {
+    return start_;
+  };
+  Value* stop() {
+    return stop_;
+  };
+  Value* step() {
+    return step_;
+  };
+
+ private:
+  Value* start_;
+  Value* stop_;
+  Value* step_;
+};
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/MemoryFormat.h>
 #include <torch/csrc/jit/frontend/schema_matching.h>
 #include <torch/csrc/jit/python/module_python.h>
+#include <climits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -793,6 +794,56 @@ std::shared_ptr<SugaredValue> createSimpleEnumValue(
   return toSimple(m.graph()->insertConstant(enum_ivalue, loc));
 }
 
+std::shared_ptr<SugaredValue> PythonSliceClass::call(
+    const SourceRange& loc,
+    Function& caller,
+    at::ArrayRef<NamedValue> inputs,
+    at::ArrayRef<NamedValue> attributes,
+    size_t /*n_binders*/) {
+  if (!attributes.empty()) {
+    throw ErrorReport(loc) << "Slice does not accept any keyword arguments";
+  }
+
+  static constexpr int64_t default_start = 0;
+  static constexpr int64_t default_stop = std::numeric_limits<int64_t>::max();
+  static constexpr int64_t default_step = 1;
+  Graph& graph = *(caller.graph());
+
+  auto ValOr = [&](Value* given, int64_t default_val) {
+    if (!given || given->type()->isSubtypeOf(NoneType::get())) {
+      return graph.insertConstant(default_val, loc);
+    }
+    return given;
+  };
+
+  Value* start;
+  Value* stop;
+  Value* step;
+  size_t n = inputs.size();
+  // Slice's constructor signature is Slice(start=None, stop, step=None)
+  if (n == 1) {
+    // Case where only `stop` is specified.
+    start = ValOr(nullptr, default_start);
+    stop = ValOr(inputs[0].value(graph), default_stop);
+    step = ValOr(nullptr, default_step);
+  } else if (n == 2) {
+    // Case where `start` and `stop` are specified.
+    start = ValOr(inputs[0].value(graph), default_start);
+    stop = ValOr(inputs[1].value(graph), default_stop);
+    step = ValOr(nullptr, default_step);
+  } else if (n == 3) {
+    // Case where `start`, `stop` and `step` are all specified.
+    start = ValOr(inputs[0].value(graph), default_start);
+    stop = ValOr(inputs[1].value(graph), default_stop);
+    step = ValOr(inputs[2].value(graph), default_step);
+  } else {
+    throw ErrorReport(loc) << "slice accepts exactly 1, 2 or 3 arguments, got: "
+                           << n;
+  }
+
+  return std::make_shared<SliceValue>(start, stop, step);
+}
+
 std::shared_ptr<SugaredValue> toSugaredValue(
     py::object obj,
     Function& m,
@@ -987,6 +1038,10 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     auto rcb = py::module::import("torch._jit_internal")
                    .attr("createResolutionCallbackFromClosure")(obj);
     return std::make_shared<PythonValue>(obj, rcb);
+  }
+
+  if (obj.is(py::module::import("builtins").attr("slice"))) {
+    return std::make_shared<PythonSliceClass>();
   }
 
   return std::make_shared<PythonValue>(obj);

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -305,5 +305,21 @@ struct VISIBILITY_HIDDEN PythonExceptionValue : public ExceptionValue {
       size_t n_binders) override;
 };
 
+// Python Slice class.
+struct VISIBILITY_HIDDEN PythonSliceClass : public SugaredValue {
+  explicit PythonSliceClass() {}
+
+  std::string kind() const override {
+    return "Python slice class";
+  }
+
+  std::shared_ptr<SugaredValue> call(
+      const SourceRange& loc,
+      Function& caller,
+      at::ArrayRef<NamedValue> inputs,
+      at::ArrayRef<NamedValue> attributes,
+      size_t n_binders) override;
+};
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Implements support for[ Python Slice class](https://docs.python.org/3/c-api/slice.html) (not slice expression, which is already supported)

Slice object can be used in any place that supports slice expression, including multi-dim tensor slicing.

Fixes #43511
Fixes #43125
