### PR TITLE
[Caffe2] Add RMSNormOp

### DIFF
--- a/caffe2/operators/rms_norm_op.cc
+++ b/caffe2/operators/rms_norm_op.cc
@@ -1,0 +1,171 @@
+#include "caffe2/operators/rms_norm_op.h"
+
+#include <array>
+#include <cmath>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "ATen/Parallel.h"
+
+#include "caffe2/utils/eigen_utils.h"
+#include "caffe2/utils/math/utils.h"
+
+namespace caffe2 {
+
+template <>
+template <typename T>
+bool RMSNormOp<CPUContext>::DoRunWithType() {
+  const auto& X = Input(0);
+  const auto& gamma = Input(1);
+  const auto& beta = Input(2);
+  auto* Y = Output(0, X.sizes(), at::dtype<T>());
+  CAFFE_ENFORCE_GE(X.dim(), 2, "RMSNorm requires input dim >= 2.");
+  const int canonical_axis = X.canonical_axis_index(axis_);
+  const std::vector<int64_t> rms_dims(
+      X.sizes().cbegin(), X.sizes().cbegin() + canonical_axis);
+  auto* rrms = Output(1, rms_dims, at::dtype<T>());
+  const int64_t M = X.size_to_dim(canonical_axis);
+  const int64_t N = X.size_from_dim(canonical_axis);
+  CAFFE_ENFORCE_EQ(gamma.numel(), N);
+  CAFFE_ENFORCE_EQ(beta.numel(), N);
+
+  const T* X_data = X.template data<T>();
+  const T* gamma_data = gamma.template data<T>();
+  const T* beta_data = beta.template data<T>();
+  T* Y_data = Y->template data<T>();
+  T* rrms_data = rrms->template data<T>();
+
+  ConstEigenArrayMap<T> X_arr(X_data, N, M);
+  ConstEigenVectorArrayMap<T> gamma_arr(gamma_data, N);
+  ConstEigenVectorArrayMap<T> beta_arr(beta_data, N);
+  EigenArrayMap<T> Y_arr(Y_data, N, M);
+  at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
+    for (int64_t i = start; i < end; ++i) {
+      const T rrms_val =
+          T(1) / std::sqrt(X_arr.col(i).square().mean() + static_cast<T>(eps_));
+      Y_arr.col(i) = rrms_val * X_arr.col(i) * gamma_arr + beta_arr;
+      rrms_data[i] = rrms_val;
+    }
+  });
+
+  return true;
+}
+
+template <>
+template <typename T>
+void RMSNormGradientOp<CPUContext>::RMSNormBackward(
+    int64_t M,
+    int64_t N,
+    const T* dY,
+    const T* X,
+    const T* gamma,
+    const T* rrms,
+    T* dX) {
+  ConstEigenArrayMap<T> dY_arr(dY, N, M);
+  ConstEigenArrayMap<T> X_arr(X, N, M);
+  ConstEigenVectorArrayMap<T> gamma_arr(gamma, N);
+  EigenArrayMap<T> dX_arr(dX, N, M);
+  const T scale = T(1) / static_cast<T>(N);
+  at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
+    for (int64_t i = start; i < end; ++i) {
+      const T ds = (dY_arr.col(i) * X_arr.col(i) * gamma_arr).sum();
+      const T c1 = rrms[i];
+      const T c2 = -scale * ds * math::utils::Cube<T>(rrms[i]);
+      dX_arr.col(i) = c1 * dY_arr.col(i) * gamma_arr + c2 * X_arr.col(i);
+    }
+  });
+}
+
+template <>
+template <typename T>
+void RMSNormGradientOp<CPUContext>::GammaBetaBackward(
+    int64_t M,
+    int64_t N,
+    const T* dY,
+    const T* X,
+    const T* rrms,
+    T* dgamma,
+    T* dbeta) {
+  math::Set<T, CPUContext>(N, T(0), dgamma, &context_);
+  math::Set<T, CPUContext>(N, T(0), dbeta, &context_);
+  ConstEigenArrayMap<T> dY_arr(dY, N, M);
+  ConstEigenArrayMap<T> X_arr(X, N, M);
+  EigenVectorArrayMap<T> dgamma_arr(dgamma, N);
+  EigenVectorArrayMap<T> dbeta_arr(dbeta, N);
+  for (int64_t i = 0; i < M; ++i) {
+    dgamma_arr += dY_arr.col(i) * X_arr.col(i) * rrms[i];
+    dbeta_arr += dY_arr.col(i);
+  }
+}
+
+REGISTER_CPU_OPERATOR(RMSNorm, RMSNormOp<CPUContext>);
+REGISTER_CPU_OPERATOR(RMSNormGradient, RMSNormGradientOp<CPUContext>);
+
+OPERATOR_SCHEMA(RMSNorm)
+    .NumInputs(3)
+    .NumOutputs(2)
+    .TensorInferenceFunction([](const OperatorDef& def,
+                                const vector<TensorShape>& in) {
+      std::vector<TensorShape> out(2);
+      const auto input_dims_long = GetDimsVector(in[0]);
+      const std::vector<int> input_dims(
+          input_dims_long.cbegin(), input_dims_long.cend());
+      out[0] = CreateTensorShape(input_dims, in[0].data_type());
+      ArgumentHelper helper(def);
+      const int axis = helper.GetSingleArgument<int32_t>("axis", 1);
+      const int canonical_axis =
+          canonical_axis_index_(axis, in[0].dims().size());
+      const std::vector<int> rms_dims(
+          input_dims.cbegin(), input_dims.cbegin() + canonical_axis);
+      out[1] = CreateTensorShape(rms_dims, in[0].data_type());
+      return out;
+    })
+    .Arg(
+        "axis",
+        "(int) default to 1; Describes axis of the inputs. Defaults to one "
+        "because the 0th axis most likely describes the batch size")
+    .Arg(
+        "epsilon",
+        "(float) default to 0.001. Small value to be added to the stdev when"
+        " dividing out by that value. This prevents division by zero.")
+    .Input(
+        0,
+        "input",
+        "Input tensor which layer normalization will be applied to")
+    .Input(
+        1,
+        "gamma",
+        "scale tensor for elementwise_affine, the shape should be the same as "
+        "the dimensions of X begin from axis")
+    .Input(
+        2,
+        "beta",
+        "bias tensor for elementwise_affine, the shape should be the same as "
+        "the dimensions of X begin from axis")
+    .Output(0, "output", "Normalized values")
+    .Output(
+        1,
+        "rrms",
+        "Reciprocal of root mean square for each feature vector");
+
+OPERATOR_SCHEMA(RMSNormGradient).NumInputs(4).NumOutputs(3);
+
+namespace {
+
+class GetRMSNormGradient : public GradientMakerBase {
+  using GradientMakerBase::GradientMakerBase;
+  std::vector<OperatorDef> GetGradientDefs() override {
+    return SingleGradientDef(
+        "RMSNormGradient",
+        "",
+        std::vector<std::string>{GO(0), I(0), I(1), O(1)},
+        std::vector<std::string>{GI(0), GI(1), GI(2)});
+  }
+};
+
+} // namespace
+
+REGISTER_GRADIENT(RMSNorm, GetRMSNormGradient);
+
+} // namespace caffe2

--- a/caffe2/operators/rms_norm_op.cu
+++ b/caffe2/operators/rms_norm_op.cu
@@ -1,0 +1,187 @@
+#include "caffe2/operators/rms_norm_op.h"
+
+#include <vector>
+
+#include <thrust/tuple.h>
+
+#include "c10/cuda/CUDAMathCompat.h"
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/utils/math.h"
+#include "caffe2/utils/math/reduce.cuh"
+#include "caffe2/utils/math/utils.h"
+
+namespace caffe2 {
+
+namespace {
+
+template <typename T>
+__global__ void RowwiseRMSCUDAKernel(int64_t N, T eps, const T* X, T* rrms) {
+  __shared__ typename BlockReduce<T>::TempStorage rms_storage;
+  const int64_t i = blockIdx.x;
+  T sum = 0;
+  for (int64_t j = threadIdx.x; j < N; j += blockDim.x) {
+    const int64_t index = i * N + j;
+    sum += X[index] * X[index];
+  }
+  sum = BlockReduce<T>(rms_storage).Sum(sum);
+  if (threadIdx.x == 0) {
+    rrms[i] =
+        c10::cuda::compat::rsqrt(sum / static_cast<T>(N) + static_cast<T>(eps));
+  }
+}
+
+template <typename T>
+__global__ void RMSNormForwardCUDAKernel(
+    int64_t N,
+    const T* X,
+    const T* gamma,
+    const T* beta,
+    const T* rrms,
+    T* Y) {
+  const int64_t i = blockIdx.x;
+  for (int64_t j = threadIdx.x; j < N; j += blockDim.x) {
+    const int64_t index = i * N + j;
+    Y[index] = rrms[i] * X[index] * gamma[j] + beta[j];
+  }
+}
+
+template <typename T>
+__global__ void ComputeInternalGradientsCUDAKernel(
+    int64_t N,
+    const T* dY,
+    const T* X,
+    const T* gamma,
+    const T* rrms,
+    T* c2) {
+  __shared__ typename BlockReduce<T>::TempStorage ds_storage;
+  const int64_t i = blockIdx.x;
+  T ds = 0;
+  for (int64_t j = threadIdx.x; j < N; j += blockDim.x) {
+    const int index = i * N + j;
+    ds += dY[index] * X[index] * gamma[j];
+  }
+  ds = BlockReduce<T>(ds_storage).Sum(ds);
+  if (threadIdx.x == 0) {
+    c2[i] = -ds * math::utils::Cube<T>(rrms[i]) / static_cast<T>(N);
+  }
+}
+
+template <typename T>
+__global__ void RMSNormBackwardCUDAKernel(
+    int64_t N,
+    const T* dY,
+    const T* X,
+    const T* gamma,
+    const T* c1,
+    const T* c2,
+    T* dX) {
+  const int64_t i = blockIdx.x;
+  for (int64_t j = threadIdx.x; j < N; j += blockDim.x) {
+    const int64_t index = i * N + j;
+    dX[index] = c1[i] * dY[index] * gamma[j] + c2[i] * X[index];
+  }
+}
+
+// Assume the batch size will not be very large, direct implementation is the
+// most efficient one.
+template <typename T>
+__global__ void GammaBetaBackwardCUDAKernel(
+    int64_t M,
+    int64_t N,
+    const T* dY,
+    const T* X,
+    const T* rrms,
+    T* dg,
+    T* db) {
+  const int64_t j = blockIdx.x * blockDim.x + threadIdx.x;
+  if (j < N) {
+    T sum1 = 0;
+    T sum2 = 0;
+    for (int64_t i = 0; i < M; ++i) {
+      const int64_t index = i * N + j;
+      sum1 += dY[index] * X[index] * rrms[i];
+      sum2 += dY[index];
+    }
+    dg[j] = sum1;
+    db[j] = sum2;
+  }
+}
+
+} // namespace
+
+template <>
+template <typename T>
+bool RMSNormOp<CUDAContext>::DoRunWithType() {
+  const auto& X = Input(0);
+  const auto& gamma = Input(1);
+  const auto& beta = Input(2);
+  auto* Y = Output(0, X.sizes(), at::dtype<T>());
+  CAFFE_ENFORCE_GE(X.dim(), 2, "RMSNorm requires input dim >= 2.");
+  const int canonical_axis = X.canonical_axis_index(axis_);
+  const std::vector<int64_t> rms_dims(
+      X.sizes().cbegin(), X.sizes().cbegin() + canonical_axis);
+  auto* rrms = Output(1, rms_dims, at::dtype<T>());
+  const int64_t M = X.size_to_dim(canonical_axis);
+  const int64_t N = X.size_from_dim(canonical_axis);
+  CAFFE_ENFORCE_EQ(gamma.numel(), N);
+  CAFFE_ENFORCE_EQ(beta.numel(), N);
+
+  const T* X_data = X.template data<T>();
+  const T* gamma_data = gamma.template data<T>();
+  const T* beta_data = beta.template data<T>();
+  T* Y_data = Y->template data<T>();
+  T* rrms_data = rrms->template data<T>();
+
+  if (M > 0) {
+    RowwiseRMSCUDAKernel<T>
+        <<<M, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(
+            N, static_cast<T>(eps_), X_data, rrms_data);
+    RMSNormForwardCUDAKernel<T>
+        <<<M, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(
+            N, X_data, gamma_data, beta_data, rrms_data, Y_data);
+  }
+
+  return true;
+}
+
+template <>
+template <typename T>
+void RMSNormGradientOp<CUDAContext>::RMSNormBackward(
+    int64_t M,
+    int64_t N,
+    const T* dY,
+    const T* X,
+    const T* gamma,
+    const T* rrms,
+    T* dX) {
+  ReinitializeTensor(
+      &c2_, {M}, at::dtype<T>().device(CUDAContext::GetDeviceType()));
+  T* c2_data = c2_.mutable_data<T>();
+  ComputeInternalGradientsCUDAKernel<T>
+      <<<M, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(
+          N, dY, X, gamma, rrms, c2_data);
+  RMSNormBackwardCUDAKernel<T>
+      <<<M, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(
+          N, dY, X, gamma, rrms, c2_data, dX);
+}
+
+template <>
+template <typename T>
+void RMSNormGradientOp<CUDAContext>::GammaBetaBackward(
+    int64_t M,
+    int64_t N,
+    const T* dY,
+    const T* X,
+    const T* rrms,
+    T* dgamma,
+    T* dbeta) {
+  const int64_t B = math::DivUp<int64_t>(N, CAFFE_CUDA_NUM_THREADS);
+  GammaBetaBackwardCUDAKernel<T>
+      <<<B, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(
+          M, N, dY, X, rrms, dgamma, dbeta);
+}
+
+REGISTER_CUDA_OPERATOR(RMSNorm, RMSNormOp<CUDAContext>);
+REGISTER_CUDA_OPERATOR(RMSNormGradient, RMSNormGradientOp<CUDAContext>);
+
+} // namespace caffe2

--- a/caffe2/operators/rms_norm_op.h
+++ b/caffe2/operators/rms_norm_op.h
@@ -1,0 +1,111 @@
+#ifndef CAFFE2_OPERATORS_RMS_NORM_OP_H_
+#define CAFFE2_OPERATORS_RMS_NORM_OP_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/core/types.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+// RMSNorm op.
+// https://openreview.net/pdf?id=SygkZ3MTJE
+
+template <class Context>
+class RMSNormOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  template <class... Args>
+  explicit RMSNormOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        OP_SINGLE_ARG(int, "axis", axis_, 1),
+        OP_SINGLE_ARG(float, "eps", eps_, 0.0f) {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<float, double>>::call(this, Input(0));
+  }
+
+  template <typename T>
+  bool DoRunWithType();
+
+ private:
+  const int axis_;
+  const float eps_;
+};
+
+template <class Context>
+class RMSNormGradientOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+
+  template <class... Args>
+  explicit RMSNormGradientOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        OP_SINGLE_ARG(int, "axis", axis_, 1) {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<TensorTypes<float, double>>::call(this, Input(0));
+  }
+
+  template <typename T>
+  bool DoRunWithType() {
+    const auto& dY = Input(0);
+    const auto& X = Input(1);
+    const auto& gamma = Input(2);
+    const auto& rrms = Input(3);
+    const int canonical_axis = X.canonical_axis_index(axis_);
+    const int64_t M = X.size_to_dim(canonical_axis);
+    const int64_t N = X.size_from_dim(canonical_axis);
+    auto* dX = Output(0, X.sizes(), at::dtype<T>());
+    auto* dgamma = Output(1, gamma.sizes(), at::dtype<T>());
+    auto* dbeta = Output(2, gamma.sizes(), at::dtype<T>());
+    const T* dY_data = dY.template data<T>();
+    const T* X_data = X.template data<T>();
+    const T* gamma_data = gamma.template data<T>();
+    const T* rrms_data = rrms.template data<T>();
+    T* dX_data = dX->template mutable_data<T>();
+    T* dgamma_data = dgamma->template mutable_data<T>();
+    T* dbeta_data = dbeta->template mutable_data<T>();
+
+    if (M == 0) {
+      math::Set<T, Context>(N, T(0), dgamma_data, &context_);
+      math::Set<T, Context>(N, T(0), dbeta_data, &context_);
+      return true;
+    }
+
+    RMSNormBackward<T>(M, N, dY_data, X_data, gamma_data, rrms_data, dX_data);
+    GammaBetaBackward<T>(
+        M, N, dY_data, X_data, rrms_data, dgamma_data, dbeta_data);
+
+    return true;
+  }
+
+ private:
+  template <typename T>
+  void RMSNormBackward(
+      int64_t M,
+      int64_t N,
+      const T* dY,
+      const T* X,
+      const T* gamma,
+      const T* rrms,
+      T* dX);
+
+  template <typename T>
+  void GammaBetaBackward(
+      int64_t M,
+      int64_t N,
+      const T* dY,
+      const T* X,
+      const T* rrms,
+      T* dgamma,
+      T* dbeta);
+
+  const int axis_;
+  Tensor c2_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_RMS_NORM_OP_H_

--- a/caffe2/python/operator_test/rms_norm_op_test.py
+++ b/caffe2/python/operator_test/rms_norm_op_test.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from caffe2.python import core
+from hypothesis import given, settings
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+
+import unittest
+
+
+class TestRMSNormOp(hu.HypothesisTestCase):
+    @given(
+        M=st.integers(0, 8),
+        N=st.integers(1, 16),
+        eps=st.floats(0, 1e-3),
+        dtype=st.sampled_from([np.float32, np.float64]),
+        **hu.gcs,
+    )
+    @settings(deadline=None)
+    def test_rms_norm(self, M, N, eps, dtype, gc, dc):
+        X = (np.random.randn(M, N) * 2.0 + 1.0).astype(dtype)
+        gamma = np.random.randn(N).astype(dtype)
+        beta = np.random.randn(N).astype(dtype)
+
+        op = core.CreateOperator(
+            "RMSNorm",
+            ["X", "gamma", "beta"],
+            ["Y", "rrms"],
+            eps=eps,
+        )
+
+        def rms_norm_ref(X, gamma, beta):
+            rrms = 1.0 / np.sqrt(np.mean(np.square(X), axis=1) + eps)
+            Y = X * np.expand_dims(rrms, axis=1) * gamma + beta
+            return Y, rrms
+
+        inputs = [X, gamma, beta]
+        self.assertReferenceChecks(gc, op, inputs, rms_norm_ref)
+        self.assertDeviceChecks(dc, op, inputs, [0, 1])
+        for i in range(len(inputs)):
+            self.assertGradientChecks(gc, op, inputs, i, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: Add RMSNormOp in Caffe2

Test Plan: buck test mode/dev-nosan //caffe2/caffe2/python/operator_test:rms_norm_op_test

Differential Revision: D23546424

