### PR TITLE
Move the inline implementations of GradBucket class to the header.

### DIFF
--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -85,13 +85,6 @@ void broadcast_coalesced(
   }
 }
 
-GradBucket::GradBucket(std::vector<at::Tensor> tensors)
-    : tensors_(std::move(tensors)){};
-
-const std::vector<at::Tensor>& GradBucket::getTensors() const {
-  return tensors_;
-}
-
 PythonCommHook::PythonCommHook(py::object state, py::object hook)
     : state_(std::move(state)), hook_(std::move(hook)){};
 

--- a/torch/csrc/distributed/c10d/comm.h
+++ b/torch/csrc/distributed/c10d/comm.h
@@ -20,12 +20,13 @@ void broadcast_coalesced(
 // mappings as well.
 class GradBucket {
  public:
-  explicit GradBucket(std::vector<at::Tensor> tensors);
+  explicit GradBucket(std::vector<at::Tensor> tensors) :
+    tensors_(std::move(tensors)) {}
   // Each tensor in the list that getTensors returns refers to the replica on
   // each device. There will be multiple replicas only in the case of single
   // process multiple device mode. In the single process single device mode,
   // this list would consist of only a single tensor.
-  const std::vector<at::Tensor>& getTensors() const;
+  const std::vector<at::Tensor>& getTensors() const { return tensors_; }
 
  private:
   std::vector<at::Tensor> tensors_;


### PR DESCRIPTION
Summary:
Moved the inline implementations of GradBucket class to the header for
succinctness and readability. This coding style is also consistent with
reducer.h under the same directory.

Test Plan: buck test caffe2/torch/lib/c10d:ProcessGroupGlooTest

Differential Revision: D23569701

