### PR TITLE
Minor refactoring of GradBucket class.

### DIFF
--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -85,13 +85,6 @@ void broadcast_coalesced(
   }
 }
 
-GradBucket::GradBucket(std::vector<at::Tensor> tensors)
-    : tensors_(std::move(tensors)){};
-
-const std::vector<at::Tensor>& GradBucket::getTensors() const {
-  return tensors_;
-}
-
 PythonCommHook::PythonCommHook(py::object state, py::object hook)
     : state_(std::move(state)), hook_(std::move(hook)){};
 

--- a/torch/csrc/distributed/c10d/comm.h
+++ b/torch/csrc/distributed/c10d/comm.h
@@ -20,12 +20,13 @@ void broadcast_coalesced(
 // mappings as well.
 class GradBucket {
  public:
-  explicit GradBucket(std::vector<at::Tensor> tensors);
+  explicit GradBucket(std::vector<at::Tensor> tensors) :
+    tensors_(std::move(tensors)) {}
   // Each tensor in the list that getTensors returns refers to the replica on
   // each device. There will be multiple replicas only in the case of single
   // process multiple device mode. In the single process single device mode,
   // this list would consist of only a single tensor.
-  const std::vector<at::Tensor>& getTensors() const;
+  const std::vector<at::Tensor>& getTensors() const { return tensors_; }
 
  private:
   std::vector<at::Tensor> tensors_;

--- a/torch/csrc/distributed/c10d/comm.h
+++ b/torch/csrc/distributed/c10d/comm.h
@@ -12,7 +12,8 @@ namespace c10d {
 void broadcast_coalesced(
     std::shared_ptr<c10d::ProcessGroup> process_group,
     at::TensorList tensors,
-    size_t buffer_size, int rank = 0);
+    size_t buffer_size,
+    int rank = 0);
 
 // This class passes bucket contents tensor (for multiple replicas) to
 // DDP communication hook.
@@ -20,13 +21,15 @@ void broadcast_coalesced(
 // mappings as well.
 class GradBucket {
  public:
-  explicit GradBucket(std::vector<at::Tensor> tensors) :
-    tensors_(std::move(tensors)) {}
+  explicit GradBucket(const std::vector<at::Tensor>& tensors)
+      : tensors_(tensors) {}
   // Each tensor in the list that getTensors returns refers to the replica on
   // each device. There will be multiple replicas only in the case of single
   // process multiple device mode. In the single process single device mode,
   // this list would consist of only a single tensor.
-  const std::vector<at::Tensor>& getTensors() const { return tensors_; }
+  const std::vector<at::Tensor>& getTensors() const {
+    return tensors_;
+  }
 
  private:
   std::vector<at::Tensor> tensors_;


### PR DESCRIPTION
Summary:
1. Moved the inline implementations of GradBucket class to the header for
succinctness and readability. This coding style is also consistent with
reducer.h under the same directory.

2. Changed the constructor of GradBucket to pass the input by const
reference and hence avoided unnecessary explicit move semantics. Since
previously the declaration and definition are separated, passing the input
tensor vector by value looks quite bizarre.

Test Plan: buck test caffe2/torch/lib/c10d:ProcessGroupGlooTest
