### PR TITLE
Update fallback kernel for Autograd keys.

### DIFF
--- a/aten/src/ATen/core/VariableFallbackKernel.cpp
+++ b/aten/src/ATen/core/VariableFallbackKernel.cpp
@@ -33,19 +33,19 @@ namespace {
 // to override it themselves!
 
 TORCH_LIBRARY_IMPL(_, AutogradOther, m) {
-  m.fallback(torch::CppFunction::makeAutogradNotImplemented());
+  m.fallback(torch::CppFunction::makeFallthrough());
 }
 
 TORCH_LIBRARY_IMPL(_, AutogradCPU, m) {
-  m.fallback(torch::CppFunction::makeAutogradNotImplemented());
+  m.fallback(torch::CppFunction::makeFallthrough());
 }
 
 TORCH_LIBRARY_IMPL(_, AutogradCUDA, m) {
-  m.fallback(torch::CppFunction::makeAutogradNotImplemented());
+  m.fallback(torch::CppFunction::makeFallthrough());
 }
 
 TORCH_LIBRARY_IMPL(_, AutogradXLA, m) {
-  m.fallback(torch::CppFunction::makeAutogradNotImplemented());
+  m.fallback(torch::CppFunction::makeFallthrough());
 }
 
 }

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -29,17 +29,6 @@ void named_not_supported_kernel(OperatorKernel*, const OperatorHandle& op, Stack
     );
 }
 
-void autograd_not_implemented_kernel(OperatorKernel*, const OperatorHandle& op, Stack*) {
-  TORCH_CHECK(0,
-    op.operator_name(), " does not have a kernel registered for Autograd. You're seeing this message likely "
-    "because you're writing a new backend for PyTorch (if not please report a bug). Note registering to "
-    "backend key like PrivateUse1 only support inference. To support training, you should provide either "
-    "a composite kernel or a torch::autograd::Function that handles both forward and backward "
-    "to the corresponding Autograd dispatch key. Currently this throws in forward, we plan to support "
-    "automatically redispatch to backend key and only throws when users call backward in the future(#43908)."
-    );
-}
-
 // single line summary of state
 std::string KernelFunction::dumpState() const {
   std::ostringstream oss;

--- a/aten/src/ATen/core/boxing/KernelFunction.h
+++ b/aten/src/ATen/core/boxing/KernelFunction.h
@@ -26,13 +26,6 @@ CAFFE2_API void fallthrough_kernel(OperatorKernel*, const OperatorHandle&, Stack
 // boxing is universally supported this can be removed.
 [[noreturn]] CAFFE2_API void named_not_supported_kernel(OperatorKernel*, const OperatorHandle&, Stack*);
 
-// Note [autograd_not_implemented_kernel]
-// This kernel implements reporting an error message about missing Autograd kernel.
-// For backend extenders who want to support training while pytorch doesn't have an in-tree
-// Autograd kernel, it's required to explicitly register to Autograd backend key with
-// either a composite kernel or torch::autograd::Function.
-[[noreturn]] CAFFE2_API void autograd_not_implemented_kernel(OperatorKernel*, const OperatorHandle&, Stack*);
-
 /**
  * KernelFunction is similar to std::function but stores a kernel function.
  * You can create a KernelFunction from a boxed or unboxed function/functor/lambda
@@ -189,7 +182,6 @@ public:
 
   static KernelFunction makeFallthrough();
   static KernelFunction makeNamedNotSupported();
-  static KernelFunction makeAutogradNotImplemented();
 
   /**
    * Create a KernelFunction from an unboxed lambda.

--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -91,14 +91,6 @@ inline KernelFunction KernelFunction::makeNamedNotSupported() {
     );
 }
 
-inline KernelFunction KernelFunction::makeAutogradNotImplemented() {
-    return KernelFunction(
-        nullptr,  // no functor_ object
-        &autograd_not_implemented_kernel,
-        nullptr  // no unboxed function pointer
-    );
-}
-
 template<bool AllowLegacyTypes, class KernelFunctor>
 inline KernelFunction KernelFunction::makeFromUnboxedFunctor(std::unique_ptr<OperatorKernel> kernelFunctor) {
     static_assert(guts::is_functor<KernelFunctor>::value, "Tried to call KernelFunction::makeFromUnboxedFunctor<KernelFunctor> but the argument is not a functor.");

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -1777,12 +1777,11 @@ TEST(NewOperatorRegistrationTest, dispatchAutogradPrecedence) {
   }
 
   {
-    // Throw since no autograd kernel registered for this op
+    // AutogradCPU is fallthrough, use CPU kernel
     cpu_called = false;
     auto op = Dispatcher::singleton().findSchema({"test::fn", ""});
-    expectThrows<c10::Error>([&] {
-      callOp(*op, dummyTensor(c10::DispatchKey::CPU, /*requires_grad=*/true));
-    }, "test::fn does not have a kernel registered for Autograd.");
+    callOp(*op, dummyTensor(c10::DispatchKey::CPU, /*requires_grad=*/true));
+    ASSERT_TRUE(cpu_called);
   }
 
   bool autograd_called = false;
@@ -1808,8 +1807,6 @@ TEST(NewOperatorRegistrationTest, dispatchAutogradPrecedence) {
 TEST(NewOperatorRegistrationTest, dispatchMultipleTensors) {
   bool privateuse1_called = false;
   bool catchall_called = false;
-  auto m1 = MAKE_TORCH_LIBRARY_IMPL(_, AutogradPrivateUse1);
-  m1.fallback(CppFunction::makeAutogradNotImplemented());
 
   auto m = MAKE_TORCH_LIBRARY(test);
   m.def("fn", torch::dispatch(c10::DispatchKey::PrivateUse1, [&](const Tensor& x, const Tensor& y) { privateuse1_called = true; return x; }));
@@ -1841,17 +1838,18 @@ TEST(NewOperatorRegistrationTest, dispatchMultipleTensors) {
   }
 
   {
-    // TODO(#43908): currently this will hit fallback kernel registered to AutogradPrivateUse1
-    // which throws, while backend extenders are indeed expecting to call PrivateUse1 kernel.
-    // Note users could always work around this by registering the same kernel to
-    // AutogradPrivateUse1 as shown below until we support redispatch.
+    // TODO(#43908): currently this will fallthrough AutogradPrivateUse1 then call catchall kernel
+    // at AutogradCPU, while backend extenders are indeed expecting to call PrivateUse1 kernel.
+    // This confusing behavior is caused by we registering fallthrough as backend fallback for
+    // Autograd keys. Note users could always work around this by registering the same kernel to
+    // AutogradPrivateUse1 as shown below until we support it.
     auto op = Dispatcher::singleton().findOp({"test::fn", ""});
     ASSERT_TRUE(op.has_value());
-    expectThrows<c10::Error>([&] {
-      callOp(*op,
-             dummyTensor(c10::DispatchKey::PrivateUse1, /*requires_grad=*/true),
-             dummyTensor(c10::DispatchKey::CPU, /*requires_grad=*/true));
-    }, "test::fn does not have a kernel registered for Autograd.");
+    catchall_called = false;
+    callOp(*op,
+           dummyTensor(c10::DispatchKey::PrivateUse1, /*requires_grad=*/true),
+           dummyTensor(c10::DispatchKey::CPU, /*requires_grad=*/true));
+    ASSERT_TRUE(catchall_called);
   }
 
   m.impl("fn", c10::DispatchKey::AutogradPrivateUse1, [&](const Tensor& x, const Tensor& y) { privateuse1_called = true; return x; });

--- a/torch/library.h
+++ b/torch/library.h
@@ -154,19 +154,6 @@ public:
     );
   }
 
-  /// \private
-  ///
-  /// Creates a function that raises an error saying that named tensors
-  /// are not supported when called.
-  static CppFunction makeAutogradNotImplemented() {
-    return CppFunction(
-      c10::KernelFunction::makeAutogradNotImplemented(),
-      /* cpp_signature */ c10::nullopt, // not known for fallthroughs
-      /* schema */ nullptr
-    );
-  }
-
-
   /// Create a function from a boxed kernel function with signature
   /// `void(const OperatorHandle&, Stack*)`; i.e., they receive a
   /// stack of arguments in a boxed calling convention, rather than


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44360 Update fallback kernel for Autograd keys.**
* #44354 Add alias dispatch key Math.
* #44349 Update fallback kernel for Autograd keys.

