### PR TITLE
Fix return value of PyErr_WarnEx ignored (SystemError)

### DIFF
--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -186,12 +186,13 @@ static PyObject * THPVariable_range(PyObject* self, PyObject* args, PyObject* kw
   auto r = parser.parse(args, kwargs, parsed_args);
 
   if (r.idx == 0) {
-    PyErr_WarnEx(
+    auto ret = PyErr_WarnEx(
         PyExc_UserWarning,
         "torch.range is deprecated and will be removed in a future release "
         "because its behavior is inconsistent with Python's range builtin. "
         "Instead, use torch.arange, which produces values in [start, end).",
         1);
+    if (ret != 0) throw python_error();
     if (r.isNone(3)) {
       const auto options = TensorOptions()
           .dtype(r.scalartype(4))

--- a/torch/csrc/autograd/python_legacy_variable.cpp
+++ b/torch/csrc/autograd/python_legacy_variable.cpp
@@ -30,9 +30,10 @@ static PyObject *THPVariable_pynew(PyTypeObject* type, PyObject *args, PyObject 
     grad_fn = nullptr;
 
   if (is_volatile) {
-    PyErr_WarnEx(PyExc_UserWarning,
+    auto r = PyErr_WarnEx(PyExc_UserWarning,
         "volatile was removed and now has no effect. Use `with torch.no_grad():` "
         "instead.", 1);
+    if (r != 0) throw python_error();
   }
 
   if (is_volatile && requires_grad) {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -334,24 +334,27 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad, void *unused)
 
 PyObject *THPVariable_get_volatile(THPVariable *self, void *unused)
 {
+  HANDLE_TH_ERRORS
   if (check_has_torch_function((PyObject *)self)) {
-    HANDLE_TH_ERRORS
     return handle_torch_function_getter(self, "volatile");
-    END_HANDLE_TH_ERRORS
   }
   const char* msg = "volatile was removed (Variable.volatile is always False)";
-  PyErr_WarnEx(PyExc_UserWarning, msg, 1);
+  auto r = PyErr_WarnEx(PyExc_UserWarning, msg, 1);
+  if (r != 0) throw python_error();
   Py_RETURN_FALSE;
+  END_HANDLE_TH_ERRORS
 }
 
 int THPVariable_set_volatile(THPVariable *self, PyObject *obj, void *unused)
 {
+  HANDLE_TH_ERRORS
   if (check_has_torch_function((PyObject *)self)) {
-    HANDLE_TH_ERRORS
     return handle_torch_function_setter(self, "volatile", obj);
-    END_HANDLE_TH_ERRORS_RET(-1)
   }
-  return PyErr_WarnEx(PyExc_UserWarning, VOLATILE_WARNING, 1);
+  auto r = PyErr_WarnEx(PyExc_UserWarning, VOLATILE_WARNING, 1);
+  if (r != 0) throw python_error();
+  return 0;
+  END_HANDLE_TH_ERRORS_RET(-1)
 }
 
 PyObject *THPVariable_get_output_nr(THPVariable *self, void *unused)

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -702,9 +702,10 @@ Tensor tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, Py
   if (r.idx == 0) {
     PyObject* data = r.pyobject(0);
     if (THPVariable_Check(data)) {
-      PyErr_WarnEx(PyExc_UserWarning,
+      auto ret = PyErr_WarnEx(PyExc_UserWarning,
         "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
         "or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).", 1);
+      if (ret != 0) throw python_error();
     }
 
     bool type_inference = r.isNone(1);
@@ -762,9 +763,10 @@ Tensor new_tensor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyO
   if (r.idx == 0) {
     PyObject* data = r.pyobject(0);
     if (THPVariable_Check(data)) {
-      PyErr_WarnEx(PyExc_UserWarning,
+      auto ret = PyErr_WarnEx(PyExc_UserWarning,
         "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() "
         "or sourceTensor.clone().detach().requires_grad_(True), rather than tensor.new_tensor(sourceTensor).", 1);
+      if (ret != 0) throw python_error();
     }
 
     bool args_requires_grad = r.toBool(3);


### PR DESCRIPTION
This PR fixes unexpected `SystemError` when warnings are emitted and warning filters are set.

## Current behavior

```
$ python -Werror
>>> import torch
>>> torch.range(1, 3)
UserWarning: torch.range is deprecated in favor of torch.arange and will be removed in 0.5. Note that arange generates values in [start; end), not [start; end].

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: <built-in method range of type object at 0x7f38c7703a60> returned a result with an error set
```

## Expected behavior

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UserWarning: torch.range is deprecated and will be removed in a future release because its behavior is inconsistent with Python's range builtin. Instead, use torch.arange, which produces values in [start, end).
```

## Note

Python exception must be raised if `PyErr_WarnEx` returns `-1` ([python docs](https://docs.python.org/3/c-api/exceptions.html#issuing-warnings)). This PR fixes warnings raised in the following code:
```py
import torch

torch.range(1, 3)
torch.autograd.Variable().volatile
torch.autograd.Variable().volatile = True
torch.tensor(torch.tensor([]))
torch.tensor([]).new_tensor(torch.tensor([]))
```