### PR TITLE
fix typo in embedding_bag_non_contiguous_weight test

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11160,7 +11160,7 @@ class TestNNDeviceType(NNTestCase):
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float, torch.double)
     def test_embedding_bag_non_contiguous_weight(self, device, dtype):
-        weight_tensor = torch.randn(4, 3, dtype=dtype, device=device)
+        weight_tensor = torch.randn(3, 4, dtype=dtype, device=device)
 
         weight_tensor_non_contig = weight_tensor[:, :3]  # This is non-contiguous strided.
         weight_tensor_contig = weight_tensor_non_contig.clone().contiguous()  # Contig-strided.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44382 typo fix in embedding_bag_non_contiguous_weight**

This is to fix a typo that introduced in #44032.

Differential Revision: [D23601316](https://our.internmc.facebook.com/intern/diff/D23601316)