### PR TITLE
Preserve .ninja_log in build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,6 +506,9 @@ jobs:
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
+          # Copy dist folder back
+          docker cp $id:/var/lib/jenkins/workspace/dist /home/circleci/project/. || echo "Dist folder not found"
+
           # Push intermediate Docker image for next phase to use
           if [ -z "${BUILD_ONLY}" ]; then
             # Note [Special build images]
@@ -539,6 +542,8 @@ jobs:
             docker commit "$id" ${COMMIT_DOCKER_IMAGE}
             time docker push ${COMMIT_DOCKER_IMAGE}
           fi
+    - store_artifacts:
+        path: /home/circleci/project/dist
 
   pytorch_linux_test:
     <<: *pytorch_params
@@ -1022,6 +1027,10 @@ jobs:
         no_output_timeout: "1h"
         command: |
             source "/pytorch/.circleci/scripts/binary_linux_build.sh"
+            # Preserve build log
+            if [ -f /pytorch/build/.ninja_log ]; then
+              cp /pytorch/build/.ninja_log /final_pkgs
+            fi
     - run:
         name: Output binary sizes
         no_output_timeout: "1m"

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -12,6 +12,10 @@
         no_output_timeout: "1h"
         command: |
             source "/pytorch/.circleci/scripts/binary_linux_build.sh"
+            # Preserve build log
+            if [ -f /pytorch/build/.ninja_log ]; then
+              cp /pytorch/build/.ninja_log /final_pkgs
+            fi
     - run:
         name: Output binary sizes
         no_output_timeout: "1m"

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -45,6 +45,9 @@ jobs:
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
+          # Copy dist folder back
+          docker cp $id:/var/lib/jenkins/workspace/dist /home/circleci/project/. || echo "Dist folder not found"
+
           # Push intermediate Docker image for next phase to use
           if [ -z "${BUILD_ONLY}" ]; then
             # Note [Special build images]
@@ -78,6 +81,8 @@ jobs:
             docker commit "$id" ${COMMIT_DOCKER_IMAGE}
             time docker push ${COMMIT_DOCKER_IMAGE}
           fi
+    - store_artifacts:
+        path: /home/circleci/project/dist
 
   pytorch_linux_test:
     <<: *pytorch_params

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -218,9 +218,9 @@ else
     # set only when building other architectures
     # only use for "python setup.py install" line
     if [[ "$BUILD_ENVIRONMENT" != *ppc64le*  && "$BUILD_ENVIRONMENT" != *clang* ]]; then
-      WERROR=1 python setup.py install
+      WERROR=1 python setup.py install bdist_wheel
     else
-      python setup.py install
+      python setup.py install bdist_wheel
     fi
 
     # TODO: I'm not sure why, but somehow we lose verbose commands
@@ -232,6 +232,11 @@ else
     fi
 
     assert_git_not_dirty
+    # Copy ninja build logs to dist folder
+    mkdir -p dist
+    if [ -f build/.ninja_log ]; then
+      cp build/.ninja_log dist
+    fi
 
     # Build custom operator tests.
     CUSTOM_OP_BUILD="$PWD/../custom-op-build"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -218,9 +218,11 @@ else
     # set only when building other architectures
     # only use for "python setup.py install" line
     if [[ "$BUILD_ENVIRONMENT" != *ppc64le*  && "$BUILD_ENVIRONMENT" != *clang* ]]; then
-      WERROR=1 python setup.py install bdist_wheel
+      WERROR=1 python setup.py bdist_wheel
+      python -mpip install dist/*.whl
     else
-      python setup.py install bdist_wheel
+      python setup.py bdist_wheel
+      python -mpip install dist/*.whl
     fi
 
     # TODO: I'm not sure why, but somehow we lose verbose commands


### PR DESCRIPTION
Helpful for later analysis on the build time trends
Also, same .whl files out of regular linux build job
