### PR TITLE
Merge criterion_tests and new_criterion_tests.

### DIFF
--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -31,7 +31,6 @@ for test_params_dicts, test_instance_class in [
     (common_nn.module_tests, common_nn.ModuleTest),
     (common_nn.new_module_tests, common_nn.NewModuleTest),
     (common_nn.criterion_tests, common_nn.CriterionTest),
-    (common_nn.new_criterion_tests, common_nn.CriterionTest),
 ]:
     for test_params_dict in test_params_dicts:
         if test_params_dict.get('test_cpp_api_parity', True):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -60,7 +60,7 @@ from torch.testing._internal.jit_metaprogramming_utils import create_script_fn, 
     get_call, script_template, EXCLUDE_SCRIPT, additional_module_tests, EXCLUDE_SCRIPT_MODULES, \
     get_nn_module_name_from_kwargs, script_method_template, create_traced_fn
 
-from torch.testing._internal.common_nn import module_tests, new_module_tests, criterion_tests, new_criterion_tests
+from torch.testing._internal.common_nn import module_tests, new_module_tests, criterion_tests
 from torch.testing._internal.common_methods_invocations import method_tests as autograd_method_tests
 from torch.testing._internal.common_methods_invocations import create_input, unpack_variables, \
     exclude_tensor_method, EXCLUDE_GRADCHECK, EXCLUDE_FUNCTIONAL
@@ -15830,7 +15830,7 @@ for test in nn_functional_tests:
 for test in module_tests + new_module_tests + additional_module_tests:
     add_nn_module_test(**test)
 
-for test in criterion_tests + new_criterion_tests:
+for test in criterion_tests:
     test['no_grad'] = True
     add_nn_module_test(**test)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
     ALL_TENSORTYPES2, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
-    module_tests, criterion_tests, new_criterion_tests, loss_reference_fns, \
+    module_tests, criterion_tests, loss_reference_fns, \
     ctcloss_reference, new_module_tests
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
@@ -8739,7 +8739,7 @@ for test_params in module_tests + new_module_tests:
 
         add_test(test, decorator)
 
-for test_params in criterion_tests + new_criterion_tests:
+for test_params in criterion_tests:
     name = test_params.pop('module_name')
     test_params['constructor'] = getattr(nn, name)
     test = CriterionTest(**test_params)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4152,9 +4152,6 @@ criterion_tests = [
         desc='margin',
         check_sum_reduction=True,
     ),
-]
-
-new_criterion_tests = [
     dict(
         module_name='BCEWithLogitsLoss',
         input_fn=lambda: torch.rand(15, 10).clamp_(1e-2, 1 - 1e-2),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44471 Fix L1Loss when target.requires_grad is True.
* #44437 Fix MSELoss when target.requires_grad is True.
* **#44398 Merge criterion_tests and new_criterion_tests.**
* #43958 Combine criterion and new criterion tests in test_jit.

These end up executing the same tests, so no reason to have them separate.

Differential Revision: [D23600855](https://our.internmc.facebook.com/intern/diff/D23600855)