### PR TITLE
Adding .build_profile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ build_android
 build_ios
 /build_*
 .build_debug/*
+.build_profile/*
 .build_release/*
 distribute/*
 *.testbin


### PR DESCRIPTION
For CPU profiling (and troubleshooting release builds in general), one would normally get best results from a RelWithDebInfo build. 

This tiny PR just adds another "known" build subdirectory to .gitignore : .build_profile 
