### PR TITLE
[PyTorch][Mobile] Insert the module name as `name()` to metadata dict if metadata doesn't contain "model_name"

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -401,8 +401,13 @@ mobile::Module _load_for_mobile(
     auto reader = torch::make_unique<PyTorchStreamReader>(std::move(rai));
     BytecodeDeserializer deserializer(std::move(reader));
     mobile::Module result = deserializer.deserialize(std::move(device));
+    std::unordered_map<std::string, std::string> copied_metadata =
+        result.metadata();
+    if (result.metadata().find("model_name") == result.metadata().end()) {
+      copied_metadata["model_name"] = result.name();
+    }
     if (observer) {
-      observer->onExitLoadModel(result.metadata());
+      observer->onExitLoadModel(copied_metadata);
     }
     return result;
   } catch (c10::Error& error) {

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -180,8 +180,13 @@ mobile::Module _load_data(
     auto mcu = std::make_shared<mobile::CompilationUnit>();
     mobile::Module result = mobile::Module(
         deserializer.deserialize(std::move(device)).toObject(), mcu);
+    std::unordered_map<std::string, std::string> copied_metadata =
+        result.metadata();
+    if (result.metadata().find("model_name") == result.metadata().end()) {
+      copied_metadata["model_name"] = result.name();
+    }
     if (observer) {
-      observer->onExitLoadModel(result.metadata());
+      observer->onExitLoadModel(copied_metadata);
     }
     return result;
   } catch (c10::Error& error) {

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -26,17 +26,19 @@ Function* CompilationUnit::find_function(const c10::QualifiedName& qn) {
 
 c10::IValue Module::run_method(const std::string& method_name, Stack stack) {
   auto observer = torch::observerConfig().getModuleObserver();
-  auto module_metadata = metadata();
+  /* if the metadata dict doesn't contain "model_name", copy the metadata and
+  set the value of "model_name" as name() */
+  std::unordered_map<std::string, std::string> copied_metadata = metadata();
+  if (metadata().find("model_name") == metadata().end()) {
+    copied_metadata["model_name"] = name();
+  }
   if (observer) {
-    observer->onEnterRunMethod(module_metadata, method_name);
+    observer->onEnterRunMethod(copied_metadata, method_name);
   }
 
   auto debug_info = std::make_shared<MobileDebugInfo>();
-  if (module_metadata.find("model_name") != module_metadata.end()) {
-    debug_info->setModelName(module_metadata.at("model_name"));
-  } else {
-    debug_info->setModelName(name());
-  }
+  std::string name = copied_metadata["model_name"];
+  debug_info->setModelName(name);
   debug_info->setMethodName(method_name);
   at::DebugInfoGuard guard(at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44400 [PyTorch][Mobile] Insert the module name as `name()` to metadata dict if metadata doesn't contain "model_name"**

This diff does the identical thing as D23549149 does. A fix included for OSS CI: pytorch_windows_vs2019_py36_cuda10.1_test1

Differential Revision: [D23601050](https://our.internmc.facebook.com/intern/diff/D23601050/)