### PR TITLE
[tensorexpr] Add flag to fuse with unknown shapes

### DIFF
--- a/test/cpp/tensorexpr/test_te_fuser_pass.cpp
+++ b/test/cpp/tensorexpr/test_te_fuser_pass.cpp
@@ -151,7 +151,7 @@ void testFuserPass_UnknownShapes() {
           %y : Tensor):
       %a : Tensor = aten::mul(%x, %y)
       %b : Tensor = aten::mul(%x, %a)
-      return (%a))IR";
+      return (%b))IR";
   auto g = std::make_shared<Graph>();
   torch::jit::parseIR(graph_string, g.get());
 
@@ -287,5 +287,25 @@ void testFuserPass_Multidevice() {
     testing::FileCheck().check_not("prim::TensorExprGroup")->run(*g);
   }
 }
+
+void testFuserPass_UnknownShapesIgnored() {
+  WithCPUFuser cf;
+  KernelScope kernel_scope;
+  const auto graph_string = R"IR(
+    graph(%x : Float(device=cpu),
+          %y : Float(device=cpu)):
+      %a : Float(device=cpu) = aten::mul(%x, %y)
+      %b : Float(device=cpu) = aten::mul(%x, %a)
+      return (%b))IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+
+  g->lint();
+  FuseTensorExprs(g, /* min_group_size= */ 2, /* disable_shape_checks= */ true);
+
+  // Test that we are generating fusion groups even though shapes are not known
+  testing::FileCheck().check("prim::TensorExprGroup")->run(*g);
+}
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -247,6 +247,7 @@ namespace jit {
   _(FuserPass_0DimInput)                    \
   _(FuserPass_UnfusibleDevice)              \
   _(FuserPass_UnknownShapes)                \
+  _(FuserPass_UnknownShapesIgnored)         \
   _(FuserPass_Multidevice)                  \
   _(TrainBasic)
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -10,9 +10,15 @@ namespace jit {
 struct Graph;
 
 // Run TensorExpressions-based fuser.
+//
+// If shape checks are disabled it is the responsibilty of
+// the caller to ensure that the resultant subgraph is correctly
+// annotated with shapes by the time "getOperation" is called
+// on the node.
 TORCH_API void FuseTensorExprs(
     std::shared_ptr<Graph>& graph,
-    size_t min_group_size = 2);
+    size_t min_group_size = 2,
+    bool disable_shape_checks = false);
 
 TORCH_API void setTensorExprFuserEnabled(bool val);
 TORCH_API bool tensorExprFuserEnabled();


### PR DESCRIPTION
This flag simply allows users to get fusion groups that will *eventually* have shapes (such that `getOperation` is a valid).

This is useful for doing early analysis and compiling just in time.