### PR TITLE
Use compile time cudnn version if linking with it statically

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -148,6 +148,12 @@ if(USE_CUDNN OR USE_ROCM)
     list(APPEND TORCH_PYTHON_SRCS
       ${TORCH_SRC_DIR}/csrc/cuda/shared/cudnn.cpp
       )
+    if(USE_STATIC_CUDNN)
+        set_source_files_properties(
+          ${TORCH_SRC_DIR}/csrc/cuda/shared/cudnn.cpp
+          PROPERTIES COMPILE_DEFINITIONS "USE_STATIC_CUDNN"
+        )
+    endif()
 endif()
 
 if(USE_NUMPY)

--- a/torch/csrc/cuda/shared/cudnn.cpp
+++ b/torch/csrc/cuda/shared/cudnn.cpp
@@ -20,15 +20,23 @@ version_tuple getCompileVersion() {
 }
 
 version_tuple getRuntimeVersion() {
+#ifndef USE_STATIC_CUDNN
   auto version = cudnnGetVersion();
   auto major = version / 1000;
   auto minor = (version % 1000) / 100;
   auto patch = version % 10;
   return version_tuple(major, minor, patch);
+#else
+  return getCompileVersion();
+#endif
 }
 
 size_t getVersionInt() {
+#ifndef USE_STATIC_CUDNN
   return cudnnGetVersion();
+#else
+  return CUDNN_VERSION;
+#endif
 }
 
 }


### PR DESCRIPTION
This should prevent torch_python from linking the entire cudnn library statically just to query its version
