### PR TITLE
handle the case of -0.0 on tanh quantization

### DIFF
--- a/caffe2/contrib/fakelowp/quant_lut_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/quant_lut_fp16_fake_op.h
@@ -57,7 +57,16 @@ class TanhInt8QuantizeNNPIOp final : public Operator<CPUContext> {
     for (int i = 0; i < X.numel(); i++) {
         float val = X_data[i];
         short shortAbsInput = _cvtss_sh(abs(val), 0);
-        short clampShortAbsInput = std::clamp(shortAbsInput, (short)tanhLUTMinOffset, (short)(tanhLUTMaxOffset - 1));
+        // Clamp the input in the range of
+        //  (short)tanhLUTMinOffset to (short)(tanhLUTMaxOffset - 1)
+        short clampShortAbsInput = shortAbsInput;
+        if (shortAbsInput < (short)tanhLUTMinOffset) {
+            clampShortAbsInput = (short)tanhLUTMinOffset;
+        }
+
+        if (shortAbsInput > (short)(tanhLUTMaxOffset - 1)) {
+            clampShortAbsInput = (short)(tanhLUTMaxOffset - 1);
+        }
         short inputInLutRange = clampShortAbsInput - tanhLUTMinOffset;
         short temp =  tanhLUT[inputInLutRange];
 

--- a/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
@@ -29,7 +29,7 @@ class TestBatchMatMul(serial.SerializedTestCase):
         trans_b=st.booleans(),
         run_ints=st.booleans()
     )
-    @settings(deadline=None, max_examples=100)
+    @settings(deadline=None)
     def test_batch_matmul(self, M, K, N, C, rand_seed, trans_a, trans_b, run_ints):
         np.random.seed(rand_seed)
         workspace.ResetWorkspace()

--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -45,7 +45,7 @@ class BatchnormTest(unittest.TestCase):
            size=st.integers(2, 30),
            input_channels=st.integers(2, 40),
            batch_size=st.integers(2, 20))
-    @settings(max_examples=100, deadline=None)
+    @settings(deadline=None)
     def test_bn(self, seed, size, input_channels, batch_size):
         workspace.ResetWorkspace()
         np.random.seed(seed)

--- a/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
@@ -146,11 +146,13 @@ class FCTest(serial.SerializedTestCase):
                     "diff": np.abs((Y_c2 - Y_glow) / Y_c2)})
                 assert(0)
 
-    @settings(deadline=None, max_examples=1)
-    def test_fc_numeric_cases(self):
+    @given(seed=st.integers(0, 65534))
+    @settings(deadline=None)
+    def test_fc_numeric_cases(self, seed):
         """ Test numerics, use examples found from the unit test.
             Use Fp16FCAcc16NNPI as a reference.
         """
+        np.random.seed(seed)
         m = 1
         k = 20
         n = 1
@@ -263,7 +265,6 @@ class FCTest(serial.SerializedTestCase):
                     "rowdiff": rowdiff})
                 assert(0)
 
-    @settings(deadline=None)
     @given(
         m=st.integers(1, 50),
         k=st.integers(1, 1000),
@@ -271,6 +272,7 @@ class FCTest(serial.SerializedTestCase):
         seed=st.integers(0, 65534),
         use_packed=st.integers(0, 2)
     )
+    @settings(deadline=None)
     def test_fc_num0(self, seed, m, k, n, use_packed):
         """ Test numerics, fix a dimension and determine the ranges of error.
             Use Fp16FCAcc16 as a reference.

--- a/caffe2/contrib/fakelowp/test/test_fusions.py
+++ b/caffe2/contrib/fakelowp/test/test_fusions.py
@@ -27,7 +27,7 @@ class Fusions(serial.SerializedTestCase):
         size=st.integers(1, 100000),
         rand_seed=st.integers(0, 65534),
     )
-    @settings(deadline=None, max_examples=100)
+    @settings(deadline=None)
     def Skip_test_tanhquantize(self, scale, zp, size, rand_seed):
         np.random.seed(rand_seed)
 

--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -22,12 +22,12 @@ class Int8OpsTest(serial.SerializedTestCase):
         zero_point = int(round(np.clip(zero_point, 0, 255.0)))
         return (scale, zero_point)
 
-    @settings(max_examples=30, deadline=None)
     @given(
         n=st.integers(2, 1024),
         rand_seed=st.integers(0, 65534),
         non_zero_offset=st.booleans()
     )
+    @settings(deadline=None)
     def test_int8_quantize(self, n, rand_seed, non_zero_offset):
         print("n={}, rand_seed={}".format(n, rand_seed))
         np.random.seed(rand_seed)
@@ -128,7 +128,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         rand_seed=st.integers(0, 65534),
         quantize_bias=st.sampled_from([False]),
     )
-    @settings(deadline=None, max_examples=30)
+    @settings(deadline=None)
     def test_int8_fc(
         self, n, m, k, rand_seed, quantize_bias, f
     ):
@@ -229,7 +229,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         n=st.integers(1, 4),
         rand_seed=st.integers(0, 65534)
     )
-    @settings(max_examples=100, deadline=None)
+    @settings(deadline=None)
     def test_int8_small_input(self, n, rand_seed):
         print("n={}, rand_seed={}".format(n, rand_seed))
         np.random.seed(rand_seed)

--- a/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
@@ -30,7 +30,7 @@ class LayerNorm(serial.SerializedTestCase):
            size=st.integers(min_value=2, max_value=128),
            epsilon=st.floats(min_value=1e-4, max_value=1e-3),
            elementwise_affine=st.booleans())
-    @settings(max_examples=100, deadline=None)
+    @settings(deadline=None)
     def Skip_test_layernorm(self, seed, batch_size, size, epsilon, elementwise_affine):
         np.random.seed(seed)
         # Reset the workspace

--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -104,25 +104,32 @@ class ArithmeticOpsTest(serial.SerializedTestCase):
                     "Y_glow": Y_glow, "Y_c2": Y_c2, "diff": diff})
                 assert(0)
 
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_add_graph(self):
+    def test_add_graph(self, seed):
+        np.random.seed(seed)
         self._test_binary_op_graph("Add")
 
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_sub_graph(self):
+    def test_sub_graph(self, seed):
+        np.random.seed(seed)
         self._test_binary_op_graph("Sub")
 
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_mul_graph(self):
+    def test_mul_graph(self, seed):
+        np.random.seed(seed)
         self._test_binary_op_graph("Mul")
 
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_div_graph(self):
+    def test_div_graph(self, seed):
+        np.random.seed(seed)
         self._test_binary_op_graph("Div")
 
 
 class UnaryOpTest(serial.SerializedTestCase):
-    @settings(deadline=None)
     def _test_unary_op(self, opname, X, rtol=1e-5, atol=1e-8):
         workspace.ResetWorkspace()
 
@@ -182,7 +189,7 @@ class UnaryOpTest(serial.SerializedTestCase):
 
         return Y_glow
 
-    def _test_op_w_ulp_error(self, opname, regions, atol=0, err_threshold=2):
+    def _test_op_w_ulp_error(self, seed, opname, regions, atol=0, err_threshold=2):
         ulp_err = 0
         for x0, x1 in regions:
             X = np.linspace(x0, x1, num=1025, dtype=np.float16).astype(np.float32)
@@ -197,46 +204,54 @@ class UnaryOpTest(serial.SerializedTestCase):
     # linear sweep and it is deterministic.
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_sigmoid(self):
+    def test_sigmoid(self, seed):
+        np.random.seed(seed)
         opname = "Sigmoid"
         regions = [[-8., -4.], [-4., -2.], [-2., -1.], [-1., -.5], [-.5, -.25],
                    [-.25, .25], [.25, .5], [.5, 1.], [1., 2.], [2., 4.],
                    [4., 8.]]
-        self._test_op_w_ulp_error(opname, regions, atol=0, err_threshold=2.5)
+        self._test_op_w_ulp_error(seed, opname, regions, atol=0, err_threshold=2.5)
 
     # These tests doesn't need to run multiple times given that it is a
     # linear sweep and it is deterministic.
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_tanh(self):
+    def test_tanh(self, seed):
+        np.random.seed(seed)
         opname = "Tanh"
         regions = [[2.**(-9), 2.**(-8)], [2.**(-8), 2.**(-7)],
                    [2.**(-7), 2.**(-6)], [2.**(-6), 2.**(-5)],
                    [2.**(-5), 2.**(-4)], [2.**(-4), 2.**(-3)],
                    [2.**(-3), 2.**(-2)], [2.**(-2), 2.**(-1)],
                    [2.**(-1), 1.], [1., 2.], [2., 4.], [4., 8.]]
-        self._test_op_w_ulp_error(opname, regions, atol=0, err_threshold=2)
+        self._test_op_w_ulp_error(seed, opname, regions, atol=0, err_threshold=2)
 
     # These tests doesn't need to run multiple times given that it is a
     # linear sweep and it is deterministic.
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
     # TODO: move atol to 1e-8 once we get a non-lowered swish implementation
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_swish(self):
+    def test_swish(self, seed):
+        np.random.seed(seed)
         opname = "Swish"
         regions = [[-20.5, -11.], [-11., -8.], [-8., -1.], [-1., -0.1],
                    [-1. / 8., 1. / 8.], [1. / 8, 5.], [5., 8.]]
-        self._test_op_w_ulp_error(opname, regions, atol=0.008, err_threshold=384)
+        self._test_op_w_ulp_error(seed, opname, regions, atol=0.008, err_threshold=384)
 
     # These tests doesn't need to run multiple times given that it is a
     # linear sweep and it is deterministic.
     # Once hypothesis.testing version is updated, we can re-enable
     # testing with different hypothesis examples.
+    @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
-    def test_logit(self):
+    def test_logit(self, seed):
+        np.random.seed(seed)
         workspace.ResetWorkspace()
         n = 1
         m = 15361

--- a/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
@@ -32,7 +32,7 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
         batch_size=st.integers(1, 5),
         max_weight=st.integers(0, 100),
     )
-    @settings(max_examples=100, deadline=None)
+    @settings(deadline=None)
     def test_slws_fused_8bit_rowwise_acc32_nnpi(
         self, seed, num_rows, embedding_dim, batch_size, max_weight
     ):
@@ -144,7 +144,7 @@ class SparseLengthsSum8BitFakeNNPIFp32Test(serial.SerializedTestCase):
 
 
     @given(seed=st.integers(0, 65535))
-    @settings(deadline=None, max_examples=100)
+    @settings(deadline=None)
     def test_small_sls_acc32(self, seed):
         workspace.GlobalInit(
             [


### PR DESCRIPTION
Summary:
this fix makes fakelowp identical to hw

- mask out the floating point number with 0x7fff so we are always dealing
with positive numbers
- dsp implementation is correct, ice-ref suffers from this same problem

Test Plan: - tested with test_fusions.py, can't enable the test until the fix in ice-ref appears

Differential Revision: D23603878

