### PR TITLE
.circleci: Bump MAX_JOBS to 12

### DIFF
--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -7,7 +7,7 @@ source /env
 # Defaults here so they can be changed in one place
 # This script is run inside Docker.2XLarge+ container that has 20 CPU cores
 # But ncpu will return total number of cores on the system
-export MAX_JOBS=18
+export MAX_JOBS=16
 
 # Parse the parameters
 if [[ "$PACKAGE_TYPE" == 'conda' ]]; then

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -7,7 +7,7 @@ source /env
 # Defaults here so they can be changed in one place
 # This script is run inside Docker.2XLarge+ container that has 20 CPU cores
 # But ncpu will return total number of cores on the system
-export MAX_JOBS=16
+export MAX_JOBS=12
 
 # Parse the parameters
 if [[ "$PACKAGE_TYPE" == 'conda' ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44413 DO NOT MERGE, testing MAX_JOBS=16
* **#44412 .circleci: Bump MAX_JOBS to 12**

We were experiencing a ton of build slow downs, we may be overloading
the CPU here so let's reduce the amount of MAX_JOBS

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>