### PR TITLE
[JIT] Remove profiling nodes in autodiff forward graph

### DIFF
--- a/torch/csrc/jit/passes/insert_guards.cpp
+++ b/torch/csrc/jit/passes/insert_guards.cpp
@@ -5,6 +5,19 @@
 namespace torch {
 namespace jit {
 
+void removeProfilingNodes(Block* b) {
+  for (auto it = b->nodes().begin(); it != b->nodes().end(); it++) {
+    if (it->kind() == prim::profile) {
+      it->output()->replaceAllUsesWith(it->input());
+      it.destroyCurrent();
+    } else {
+      for (Block* ib : it->blocks()) {
+        removeProfilingNodes(ib);
+      }
+    }
+  }
+}
+
 struct GuardInserter {
   GuardInserter(std::shared_ptr<Graph> graph) : graph_(std::move(graph)) {}
 
@@ -14,18 +27,6 @@ struct GuardInserter {
   }
 
  private:
-  void removeProfilingNodes(Block* b) {
-    for (auto it = b->nodes().begin(); it != b->nodes().end(); it++) {
-      if (it->kind() == prim::profile) {
-        it.destroyCurrent();
-      } else {
-        for (Block* ib : it->blocks()) {
-          removeProfilingNodes(ib);
-        }
-      }
-    }
-  }
-
   void insertGuards(Block* b) {
     for (auto it = b->nodes().begin(); it != b->nodes().end(); it++) {
       auto n = *it;
@@ -58,6 +59,11 @@ void InsertGuards(std::shared_ptr<Graph> graph) {
   GuardInserter gi(std::move(graph));
   gi.run();
 }
+
+void RemoveProfilingNodes(std::shared_ptr<Graph> graph) {
+  removeProfilingNodes(graph->block());
+}
+
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/insert_guards.cpp
+++ b/torch/csrc/jit/passes/insert_guards.cpp
@@ -64,6 +64,5 @@ void RemoveProfilingNodes(std::shared_ptr<Graph> graph) {
   removeProfilingNodes(graph->block());
 }
 
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/insert_guards.h
+++ b/torch/csrc/jit/passes/insert_guards.h
@@ -15,5 +15,7 @@ namespace jit {
 
 TORCH_API void InsertGuards(std::shared_ptr<Graph> graph);
 
+TORCH_API void RemoveProfilingNodes(std::shared_ptr<Graph> graph);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -370,7 +370,8 @@ void ProfilingGraphExecutorImpl::runProfilingOptimizations(
     InlineAutodiffSubgraphs(
         copy,
         getAutodiffSubgraphInlining() ? autodiffSubgraphInlineThreshold : 1);
-    GRAPH_DEBUG("After InlineAutodiffSubgraphs\n", *copy);
+    RemoveProfilingNodes(copy);
+    GRAPH_DEBUG("After InlineAutodiffSubgraphs and Removing Profiling Nodes\n", *copy);
   } else {
     runNoGradOptimizations(copy);
   }

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -371,7 +371,8 @@ void ProfilingGraphExecutorImpl::runProfilingOptimizations(
         copy,
         getAutodiffSubgraphInlining() ? autodiffSubgraphInlineThreshold : 1);
     RemoveProfilingNodes(copy);
-    GRAPH_DEBUG("After InlineAutodiffSubgraphs and Removing Profiling Nodes\n", *copy);
+    GRAPH_DEBUG(
+        "After InlineAutodiffSubgraphs and Removing Profiling Nodes\n", *copy);
   } else {
     runNoGradOptimizations(copy);
   }


### PR DESCRIPTION
Previously we were not removing profiling nodes in graphs that required grad and contained diff graphs 