### PR TITLE
[JIT] Erase shapes before fallback graph

### DIFF
--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -145,3 +145,18 @@ class TestProfiler(JitTestCase):
         foo(2, 3)
         g = torch.jit.last_executed_optimized_graph()
         FileCheck().check_not("TensorExpr").run(g)
+
+    def test_fallback_graph_not_specialized(self):
+        @torch.jit.script
+        def foo(a, b):
+            c = a * b
+            d = c * b
+            e = d * b
+            return d + e
+
+        x = torch.ones(1)
+        y = torch.ones(1)
+        foo(x, y)
+        foo(x, y)
+        g = torch.jit.last_executed_optimized_graph()
+        FileCheck().check("CallFunction").check_next("Tensor = prim::TupleUnpack").run(g)

--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -145,3 +145,18 @@ class TestProfiler(JitTestCase):
         foo(2, 3)
         g = torch.jit.last_executed_optimized_graph()
         FileCheck().check_not("TensorExpr").run(g)
+
+    def test_fallback_graph_not_specialized(self):
+        @torch.jit.script
+        def foo(a, b):
+            c = a * b
+            d = c * b
+            e = d * b
+            return d + e
+
+        x = torch.ones(1)
+        y = torch.ones(1)
+        foo(x, y)
+        foo(x, y)
+        g = torch.jit.last_executed_optimized_graph()
+        FileCheck().check("Tensor").check_same("CallFunction").run(g)

--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -145,18 +145,3 @@ class TestProfiler(JitTestCase):
         foo(2, 3)
         g = torch.jit.last_executed_optimized_graph()
         FileCheck().check_not("TensorExpr").run(g)
-
-    def test_fallback_graph_not_specialized(self):
-        @torch.jit.script
-        def foo(a, b):
-            c = a * b
-            d = c * b
-            e = d * b
-            return d + e
-
-        x = torch.ones(1)
-        y = torch.ones(1)
-        foo(x, y)
-        foo(x, y)
-        g = torch.jit.last_executed_optimized_graph()
-        FileCheck().check("Tensor").check_same("CallFunction").run(g)

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -766,6 +766,10 @@ class TensorExprFuser {
     for (Value* output : subgraph_outputs) {
       false_block->registerOutput(output);
     }
+
+    // types get copied to the fallback graph, so remove specializations before
+    // replacing
+    removeTensorTypeSpecializations(false_block);
     replaceBlockWithFallbackGraph(false_block, fusion_group->inputs());
 
     // Fill in the true block. It has all inputs type-checked and its


### PR DESCRIPTION
Previously the specialized types were copied over to the fallback function, although the tensors in the fallback type were not of that type. 