### PR TITLE
[JIT][WIP] ScriptModule to Python converter

### DIFF
--- a/torch/csrc/jit/python/python_materializer.h
+++ b/torch/csrc/jit/python/python_materializer.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/serialization/type_name_uniquer.h>
+#include <torch/csrc/jit/serialization/python_print.h>
+#include <torch/csrc/jit/python/pybind.h>
+
+namespace torch {
+namespace jit {
+
+class TORCH_API PythonMaterializer {
+ public:
+  PythonMaterializer(py::object def_cb, py::object obj_cb) : def_cb_(std::move(def_cb)), obj_cb_(std::move(obj_cb)) {}
+
+  py::object materialize(const Module& module) {
+    class_deps_.push_back(module.type());
+    for (size_t i = 0; i < class_deps_.size(); ++i) {
+      // note: convertNameType may extend class_deps_, so re-checking
+      // .size() is necessary
+      convertNamedType(class_deps_[i]);
+    }
+
+    py::object rv = pyInstanceFromIValueInstance(module._ivalue());
+    return rv;
+  }
+
+ private:
+  void convertNamedType(const c10::NamedTypePtr& class_type) {
+    if (converted_types_.count(class_type)) {
+        return;
+    }
+    converted_types_.insert(class_type);
+    auto qualname = type_name_uniquer_.getUniqueName(class_type);
+    std::string qualifier = qualname.prefix();
+
+    auto type_printer =
+        [&](const c10::ConstTypePtr& t) -> c10::optional<std::string> {
+      auto namedType = t->cast<c10::NamedType>();
+      if (namedType && namedType->name()) {
+        return type_name_uniquer_.getUniqueName(namedType).qualifiedName();
+      }
+      return c10::nullopt;
+    };
+
+    PythonPrint pp(constant_table_, class_deps_, type_printer, /*enforce_importable=*/true);
+
+    pp.printNamedType(class_type);
+    def_cb_(pp.str(), qualifier);
+  }
+
+  py::object pyInstanceFromIValueInstance(ObjectPtr obj) {
+    if (obj->type()->findMethod("__setstate__")) {
+        throw std::runtime_error("NYI");
+    }
+
+    std::unordered_map<std::string, py::object> for_cb;
+    for (size_t i = 0; i < obj->type()->numAttributes(); ++i) {
+      auto name = obj->type()->getAttributeName(i);
+      auto &attr = obj->getSlot(i);
+      if (attr.isObject()) {
+          for_cb[name] = pyInstanceFromIValueInstance(attr.toObject());
+      } else {
+          for_cb[name] = toPyObject(attr);
+      }
+    }
+
+    TORCH_CHECK(obj->type()->name());
+    py::object pyobj = obj_cb_(obj->type()->name()->qualifiedName(), std::move(for_cb));
+
+    return pyobj;
+  }
+
+  py::object def_cb_;
+  py::object obj_cb_;
+
+  std::vector<c10::NamedTypePtr> class_deps_;
+  std::unordered_set<c10::NamedTypePtr> converted_types_;
+  std::vector<at::IValue> constant_table_;
+  TypeNameUniquer type_name_uniquer_;
+};
+
+
+}} // namespace torch::jit

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -19,6 +19,7 @@
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/python/python_tracer.h>
+#include <torch/csrc/jit/python/python_materializer.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/logging.h>
 #include <torch/csrc/jit/serialization/export.h>
@@ -1668,6 +1669,10 @@ void initJitScriptBindings(PyObject* module) {
       py::arg("proto_string"));
   m.def("_jit_is_script_object", [](const py::object& obj) {
     return py::isinstance<Object>(obj);
+  });
+  m.def("_jit_python_materialize", [](const Module& mod, py::object def_cb, py::object obj_cb) {
+    PythonMaterializer pm(std::move(def_cb), std::move(obj_cb));
+    return pm.materialize(mod);
   });
 }
 } // namespace jit

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -18,8 +18,8 @@
 #include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
-#include <torch/csrc/jit/python/python_tracer.h>
 #include <torch/csrc/jit/python/python_materializer.h>
+#include <torch/csrc/jit/python/python_tracer.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/logging.h>
 #include <torch/csrc/jit/serialization/export.h>
@@ -1670,10 +1670,12 @@ void initJitScriptBindings(PyObject* module) {
   m.def("_jit_is_script_object", [](const py::object& obj) {
     return py::isinstance<Object>(obj);
   });
-  m.def("_jit_python_materialize", [](const Module& mod, py::object def_cb, py::object obj_cb) {
-    PythonMaterializer pm(std::move(def_cb), std::move(obj_cb));
-    return pm.materialize(mod);
-  });
+  m.def(
+      "_jit_python_materialize",
+      [](const Module& mod, py::object def_cb, py::object obj_cb) {
+        PythonMaterializer pm(std::move(def_cb), std::move(obj_cb));
+        return pm.materialize(mod);
+      });
 }
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44443 [JIT][WIP] ScriptModule to Python converter**
* #44404 [FX] Test sidechanneling FX over ScriptModule

Quick prototype to see how hard it would be to convert a loaded TorchScript module to Python.

A sample script converting ResNet18 from TorchScript back to Python: https://gist.github.com/jamesr66a/73a7e42b9a601358400236ce6710e14e

Current issues:

```
  def _check_input_dim(self: __torch__.torch.nn.modules.batchnorm.BatchNorm2d,
    input: Tensor) -> None:
    if torch.ne(torch.dim(input), 4):
      _4 = torch.format("expected 4D input (got {}D input)", torch.dim(input))
      ops.prim.RaiseException(_4)
    else:
      pass
    return None
    
==== Errors ====

1. AttributeError: module 'torch' has no attribute 'dim'
2. TypeError: ne() received an invalid combination of arguments - got (int, int), but expected one of:
 * (Tensor input, Tensor other, *, Tensor out)
 * (Tensor input, Number other, *, Tensor out)
```
```
def batch_norm(input: Tensor,
    running_mean: Optional[Tensor],
    running_var: Optional[Tensor],
    weight: Optional[Tensor]=None,
    bias: Optional[Tensor]=None,
    training: bool=False,
    momentum: float=0.10000000000000001,
    eps: float=1.0000000000000001e-05) -> Tensor:
  _0 = __torch__.torch.nn.functional._verify_batch_size
  if training:
    _1 = _0(torch.size(input), )
  else:
    pass
  _2 = torch.batch_norm(input, weight, bias, running_mean, running_var, training, momentum, eps, True)
  return _2
 
===== Errors ====

1. AttributeError: module 'torch' has no attribute 'size'
```

```
def _verify_batch_size(size: List[int]) -> None:
  _0 = "Expected more than 1 value per channel when training, got input size {}"
  size_prods = size[0]
  size_prods0 = size_prods
  for i in range(torch.sub(torch.len(size), 2)):
    size_prods1 = torch.mul(size_prods0, size[torch.add(i, 2)])
    size_prods0 = size_prods1
  if torch.eq(size_prods0, 1):
    ops.prim.RaiseException(torch.format(_0, size))
  else:
    pass
  return None
  
==== Errors ===

1. AttributeError: module 'torch' has no attribute 'len'
2. AttributeError: 'torch.Size' object has no attribute 'len'
```

Differential Revision: [D23614846](https://our.internmc.facebook.com/intern/diff/D23614846)