### PR TITLE
try to solve duplication of Config.h

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -592,7 +592,6 @@ cc_library(
         "aten/src/THCUNN/generic/*.cu.cc",
     ]) + [
         ":generated_cpp",
-        ":aten_src_ATen_config",
     ],
     includes = [
         "aten/src",


### PR DESCRIPTION
Fixes #{43212}
aten_src_Aten_config at line 595 seems like to be a duplication from the Config.h we made as output at line 534. There are 4 more warnings which are very similar to this one. This is my first time to try out open source, and not sure about anything yet. So if this change fix the problem then I will correct the other 4 problems as well. Thank you for reviewing my first pull request!!!
![aten_src_Aten_config](https://user-images.githubusercontent.com/67231523/92693857-31e1d280-f314-11ea-9db0-26265bd8a702.png)
![Screen Shot 2020-09-10 at 2 51 07 AM](https://user-images.githubusercontent.com/67231523/92693867-34442c80-f314-11ea-99d1-b67423ad2d10.png)

