### PR TITLE
Fix SmoothL1Loss when target.requires_grad is True.

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1229,6 +1229,7 @@
 
 - name: smooth_l1_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   self: smooth_l1_loss_backward(grad, self, target, reduction)
+  target: smooth_l1_loss_backward(grad, target, self, reduction)
 
 - name: soft_margin_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   self: soft_margin_loss_backward(grad, self, target, reduction)
@@ -1597,6 +1598,7 @@
 - name: smooth_l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   grad_output: smooth_l1_loss_double_backward_grad_output(grad, grad_output, self, target, reduction)
   self: smooth_l1_loss_double_backward(grad * grad_output, self, target, reduction)
+  target: -smooth_l1_loss_double_backward(grad * grad_output, self, target, reduction)
 
 - name: softplus_backward(Tensor grad_output, Tensor self, Scalar beta, Scalar threshold, Tensor output) -> Tensor
   grad_output: softplus_backward(grad, self, beta, threshold, output)

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -324,18 +324,8 @@ inline Tensor smooth_l1_loss(
                   "Please ensure they have the same size.");
   }
 
-  Tensor ret;
-
-  if (target.requires_grad()) {
-    ret = _smooth_l1_loss(input, target);
-    if (!c10::get_if<enumtype::kNone>(&reduction)) {
-      ret = c10::get_if<enumtype::kMean>(&reduction) ? torch::mean(ret) : torch::sum(ret);
-    }
-  } else {
-    std::vector<Tensor> expanded_tensors = torch::broadcast_tensors({input, target});
-    ret = torch::smooth_l1_loss(expanded_tensors[0], expanded_tensors[1], enumtype::reduction_get_enum(reduction));
-  }
-  return ret;
+  std::vector<Tensor> expanded_tensors = torch::broadcast_tensors({input, target});
+  return torch::smooth_l1_loss(expanded_tensors[0], expanded_tensors[1], enumtype::reduction_get_enum(reduction));
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2597,15 +2597,9 @@ def smooth_l1_loss(input, target, size_average=None, reduce=None, reduction='mea
                       stacklevel=2)
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
-    if target.requires_grad:
-        _Reduction.get_enum(reduction)  # throw an error if reduction is invalid
-        ret = _smooth_l1_loss(input, target)
-        if reduction != 'none':
-            ret = torch.mean(ret) if reduction == 'mean' else torch.sum(ret)
-    else:
-        expanded_input, expanded_target = torch.broadcast_tensors(input, target)
-        ret = torch._C._nn.smooth_l1_loss(expanded_input, expanded_target, _Reduction.get_enum(reduction))
-    return ret
+
+    expanded_input, expanded_target = torch.broadcast_tensors(input, target)
+    return torch._C._nn.smooth_l1_loss(expanded_input, expanded_target, _Reduction.get_enum(reduction))
 
 
 def l1_loss(input, target, size_average=None, reduce=None, reduction='mean'):

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4101,7 +4101,7 @@ criterion_tests = [
     dict(
         module_name='SmoothL1Loss',
         input_size=(5, 10),
-        target_size=(5, 10),
+        target_fn=lambda: torch.randn((5, 10), requires_grad=True),
         check_sum_reduction=True,
         reference_fn=lambda i, t, m:
             smoothl1loss_reference(i, t, reduction=get_reduction(m)),
@@ -4343,7 +4343,7 @@ criterion_tests = [
     dict(
         module_name='SmoothL1Loss',
         input_size=(),
-        target_size=(),
+        target_fn=lambda: torch.randn((), requires_grad=True),
         check_sum_reduction=True,
         reference_fn=lambda i, t, m:
             smoothl1loss_reference(i, t, reduction=get_reduction(m)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44507 Simplify target handling in nn gradcheck.
* **#44486 Fix SmoothL1Loss when target.requires_grad is True.**
* #44471 Fix L1Loss when target.requires_grad is True.
* #44437 Fix MSELoss when target.requires_grad is True.
* #44398 Merge criterion_tests and new_criterion_tests.
* #43958 Combine criterion and new criterion tests in test_jit.

SmoothL1Loss had a completely different (and incorrect, see #43228) path when target.requires_grad was True.

This PR does the following:

1) adds derivative support for target via the normal derivatives.yaml route
2) kill the different (and incorrect) path for when target.requires_grad was True
3) modify the SmoothL1Loss CriterionTests to verify that the target derivative is checked.

Differential Revision: [D23630699](https://our.internmc.facebook.com/intern/diff/D23630699)