### PR TITLE
Support Bitwise shorthands in TorchScript

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6851,6 +6851,17 @@ a")
                     with self.assertRaisesRegex(RuntimeError, 'division by 0'):
                         foo(i, j)
 
+    # Testing bitwise shorthand aug assignment
+    def test_bool_augassign(self):
+        @torch.jit.script
+        def func(a:bool, b:bool):
+            a |= b
+            return a
+        self.assertEqual(func(True, False), True | False)
+        self.assertEqual(func(True, True), True | True)
+        self.assertEqual(func(False, False), False | False)
+        self.assertEqual(func(False, True), False | True)
+
     def test_number_augassign(self):
         def func():
             z = 1

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6852,15 +6852,59 @@ a")
                         foo(i, j)
 
     # Testing bitwise shorthand aug assignment
-    def test_bool_augassign(self):
-        @torch.jit.script
-        def func(a : bool, b : bool):
+    def test_bool_augassign_bitwise_or(self):
+        def func(a: bool, b: bool) -> bool:
             a |= b
             return a
-        self.assertEqual(func(True, False), True | False)
-        self.assertEqual(func(True, True), True | True)
-        self.assertEqual(func(False, False), False | False)
-        self.assertEqual(func(False, True), False | True)
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_bool_augassign_bitwise_and(self):
+          def func(a: bool, b: bool) -> bool:
+              a &= b
+              return a
+
+          self.checkScript(func, (True, False), optimize=True)
+          self.checkScript(func, (True, True), optimize=True)
+          self.checkScript(func, (False, False), optimize=True)
+          self.checkScript(func, (False, True), optimize=True)
+
+    def test_bool_augassign_bitwise_xor(self):
+        def func(a: bool, b: bool) -> bool:
+            a ^= b
+            return a
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_number_augassign_bitwise_lshift(self):
+        def func():
+            z = 8
+            z <<= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
+
+    def test_number_augassign_bitwise_rshift(self):
+        def func():
+            z = 8
+            z >>= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
+
+    def test_number_augassign_bitwise_pow(self):
+        def func():
+            z = 8
+            z **= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
 
     def test_number_augassign(self):
         def func():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6852,15 +6852,59 @@ a")
                         foo(i, j)
 
     # Testing bitwise shorthand aug assignment
-    def test_bool_augassign(self):
-        @torch.jit.script
-        def func(a : bool, b : bool):
+    def test_bool_augassign_bitwise_or(self):
+        def func(a: bool, b: bool) -> bool:
             a |= b
             return a
-        self.assertEqual(func(True, False), True | False)
-        self.assertEqual(func(True, True), True | True)
-        self.assertEqual(func(False, False), False | False)
-        self.assertEqual(func(False, True), False | True)
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_bool_augassign_bitwise_and(self):
+        def func(a: bool, b: bool) -> bool:
+            a &= b
+            return a
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_bool_augassign_bitwise_xor(self):
+        def func(a: bool, b: bool) -> bool:
+            a ^= b
+            return a
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_number_augassign_bitwise_lshift(self):
+        def func():
+            z = 8
+            z <<= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
+
+    def test_number_augassign_bitwise_rshift(self):
+        def func():
+            z = 8
+            z >>= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
+
+    def test_number_augassign_bitwise_pow(self):
+        def func():
+            z = 8
+            z **= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
 
     def test_number_augassign(self):
         def func():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6852,15 +6852,59 @@ a")
                         foo(i, j)
 
     # Testing bitwise shorthand aug assignment
-    def test_bool_augassign(self):
-        @torch.jit.script
-        def func(a:bool, b:bool):
+    def test_bool_augassign_bitwise_or(self):
+        def func(a: bool, b: bool) -> bool:
             a |= b
             return a
-        self.assertEqual(func(True, False), True | False)
-        self.assertEqual(func(True, True), True | True)
-        self.assertEqual(func(False, False), False | False)
-        self.assertEqual(func(False, True), False | True)
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_bool_augassign_bitwise_and(self):
+        def func(a: bool, b: bool) -> bool:
+            a &= b
+            return a
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_bool_augassign_bitwise_xor(self):
+        def func(a: bool, b: bool) -> bool:
+            a ^= b
+            return a
+
+        self.checkScript(func, (True, False), optimize=True)
+        self.checkScript(func, (True, True), optimize=True)
+        self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
+
+    def test_number_augassign_bitwise_lshift(self):
+        def func():
+            z = 8
+            z <<= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
+
+    def test_number_augassign_bitwise_rshift(self):
+        def func():
+            z = 8
+            z >>= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
+
+    def test_number_augassign_bitwise_pow(self):
+        def func():
+            z = 8
+            z **= 2
+            return z
+
+        self.checkScript(func, (), optimize=True)
 
     def test_number_augassign(self):
         def func():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6870,7 +6870,6 @@ a")
         self.checkScript(func, (True, False), optimize=True)
         self.checkScript(func, (True, True), optimize=True)
         self.checkScript(func, (False, False), optimize=True)
-        self.checkScript(func, (False, True), optimize=True)
 
     def test_bool_augassign_bitwise_xor(self):
         def func(a: bool, b: bool) -> bool:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6870,6 +6870,7 @@ a")
         self.checkScript(func, (True, False), optimize=True)
         self.checkScript(func, (True, True), optimize=True)
         self.checkScript(func, (False, False), optimize=True)
+        self.checkScript(func, (False, True), optimize=True)
 
     def test_bool_augassign_bitwise_xor(self):
         def func(a: bool, b: bool) -> bool:

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1956,6 +1956,8 @@ struct to_ir {
         return use_inplace_op ? aten::mul_ : aten::mul;
       case '%':
         return use_inplace_op ? aten::fmod_ : aten::fmod;
+      case '|':
+        return use_inplace_op ? aten::bitwise_or : aten::__or__;
       default:
         throw ErrorReport(stmt)
             << "Unknown augmented assignment: " << kindToString(stmt.aug_op());

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1958,6 +1958,16 @@ struct to_ir {
         return use_inplace_op ? aten::fmod_ : aten::fmod;
       case '|':
         return use_inplace_op ? aten::bitwise_or : aten::__or__;
+      case '&':
+        return use_inplace_op ? aten::bitwise_and : aten::__and__;
+      case '^':
+        return use_inplace_op ? aten::bitwise_xor : aten::__xor__;
+      case TK_LSHIFT:
+        return use_inplace_op ? aten::__lshift__ : aten::__lshift__;
+      case TK_RSHIFT:
+        return use_inplace_op ? aten::__irshift__ : aten::__rshift__;
+      case TK_POW:
+        return use_inplace_op ? aten::pow : aten::pow;
       default:
         throw ErrorReport(stmt)
             << "Unknown augmented assignment: " << kindToString(stmt.aug_op());

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -80,6 +80,12 @@ namespace jit {
   _(TK_TIMES_EQ, "*=", "*=")                     \
   _(TK_DIV_EQ, "/=", "/=")                       \
   _(TK_MOD_EQ, "%=", "%=")                       \
+  _(TK_BIT_OR_EQ, "|=", "|=")                    \
+  _(TK_BIT_AND_EQ, "&=", "&=")                   \
+  _(TK_BIT_XOR_EQ, "^=", "^=")                   \
+  _(TK_LSHIFT_EQ, "<<=", "<<=")                  \
+  _(TK_RSHIFT_EQ, ">>=", ">>=")                  \
+  _(TK_POW_EQ, "**=", "**=")                     \
   _(TK_GLOBAL, "global", "global")               \
   _(TK_BUILT_IN, "built-in", "")                 \
   _(TK_SUBSCRIPT, "subscript", "")               \

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -74,6 +74,12 @@ struct ParserImpl {
       case TK_TIMES_EQ:
       case TK_DIV_EQ:
       case TK_MOD_EQ:
+      case TK_BIT_OR_EQ:
+      case TK_BIT_AND_EQ:
+      case TK_BIT_XOR_EQ:
+      case TK_LSHIFT_EQ:
+      case TK_RSHIFT_EQ:
+      case TK_POW_EQ:
       case TK_NEWLINE:
       case '=':
       case ')':
@@ -193,9 +199,24 @@ struct ParserImpl {
       case TK_MINUS_EQ:
       case TK_TIMES_EQ:
       case TK_DIV_EQ:
+      case TK_BIT_OR_EQ:
+      case TK_BIT_AND_EQ:
+      case TK_BIT_XOR_EQ:
       case TK_MOD_EQ: {
         int modifier = L.next().text()[0];
         return create_compound(modifier, r, {});
+      } break;
+      case TK_LSHIFT_EQ:{
+        L.next();
+        return create_compound(TK_LSHIFT, r, {});
+      } break;
+      case TK_RSHIFT_EQ:{
+        L.next();
+        return create_compound(TK_RSHIFT, r, {});
+      } break;
+      case TK_POW_EQ:{
+        L.next();
+        return create_compound(TK_POW, r, {});
       } break;
       case '=': {
         L.next();

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -206,11 +206,11 @@ struct ParserImpl {
         int modifier = L.next().text()[0];
         return create_compound(modifier, r, {});
       } break;
-      case TK_LSHIFT_EQ:{
+      case TK_LSHIFT_EQ: {
         L.next();
         return create_compound(TK_LSHIFT, r, {});
       } break;
-      case TK_RSHIFT_EQ:{
+      case TK_RSHIFT_EQ: {
         L.next();
         return create_compound(TK_RSHIFT, r, {});
       } break;

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -61,6 +61,8 @@ namespace jit {
 //       |     Mod                                                      '%'
 //       |     MatMult                                                  '@'
 //       |     Pow                                                      TK_POW
+//       |     LShift                                                   TK_LShift
+//       |     RShift                                                   TK_RSHIFT
 //       | UnaryOp(Expr expr)
 //       |     Not                                                      TK_NOT
 //       |     USub                                                     '-'
@@ -599,6 +601,11 @@ struct AugAssignKind : public TreeView {
       case '/':
       case '%':
       case '|':
+      case '&':
+      case '^':
+      case TK_POW:
+      case TK_LSHIFT:
+      case TK_RSHIFT:
         return;
       default:
         throw ErrorReport(tree) << "is not a valid AugAssignKind";

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -598,6 +598,7 @@ struct AugAssignKind : public TreeView {
       case '*':
       case '/':
       case '%':
+      case '|':
         return;
       default:
         throw ErrorReport(tree) << "is not a valid AugAssignKind";

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -321,6 +321,7 @@ class StmtBuilder(Builder):
         ast.Mult: '*',
         ast.Div: '/',
         ast.Mod: '%',
+        ast.BitOr: '|',
     }
 
     @staticmethod

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -322,6 +322,11 @@ class StmtBuilder(Builder):
         ast.Div: '/',
         ast.Mod: '%',
         ast.BitOr: '|',
+        ast.BitAnd: '&',
+        ast.BitXor: '^',
+        ast.LShift: '<<',
+        ast.RShift: '>>',
+        ast.Pow: '**',
     }
 
     @staticmethod


### PR DESCRIPTION
Fixes #{42915}

Summary:
=======
This commit adds support for Bitwise Shorthands in TorchScript, i.e : a |= b

Testing:
======
This commit also adds test for the above fix in test_jit.py
The test can be invoked by
pytest -k augassign test/test_jit.py

Here is a snapshot of the testing:
<img width="858" alt="image" src="https://user-images.githubusercontent.com/70345919/92809353-633cbb80-f371-11ea-8158-dc6a1ce8ec52.png">

