### PR TITLE
[caffe2] adds Cancel to SafeDequeueBlobsOp and SafeEnqueueBlobsOp

### DIFF
--- a/caffe2/queue/queue_ops.h
+++ b/caffe2/queue/queue_ops.h
@@ -113,6 +113,12 @@ class SafeEnqueueBlobsOp final : public Operator<Context> {
         1, !status, Output(size)->template mutable_data<bool>(), &context_);
     return true;
   }
+
+  void Cancel() override {
+    auto queue = Operator<Context>::Inputs()[0]
+                     ->template Get<std::shared_ptr<BlobsQueue>>();
+    queue->close();
+  }
 };
 
 template <typename Context>
@@ -190,6 +196,12 @@ class SafeDequeueBlobsOp final : public Operator<Context> {
     math::Set<bool, Context>(
         1, !status, Output(size)->template mutable_data<bool>(), &context_);
     return true;
+  }
+
+  void Cancel() override {
+    auto queue = Operator<Context>::Inputs()[0]
+                     ->template Get<std::shared_ptr<BlobsQueue>>();
+    queue->close();
   }
 
  private:


### PR DESCRIPTION
Summary:
## Motivation

* To be able to make C2 ops cancellable so we can safely exit.
* Some C2 operators are now blocking thus being non-cancellable. If an error
  occurs we need to be able to safely stop all net execution so we can throw
  the exception to the caller.

## Summary

* When an error occurs in a net or it got cancelled, running ops will have the
 `Cancel` method called.

* This diff adds `Cancel` method to the `SafeEnqueueBlobsOp`
and `SafeDequeueBlobsOp` to have the call queue->close() to force all the
 blocking ops to return.
* Adds unit test that verified the error propagation.

Test Plan:
## Unit Test added to verify that queue ops propagate errors
```
buck test caffe2/caffe2/python:hypothesis_test
```

Reviewed By: dzhulgakov

Differential Revision: D23236088

