### PR TITLE
Simplify target handling in nn gradcheck.

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5067,23 +5067,18 @@ class CriterionTest(InputVariableMixin, TestBase):
             return
 
         test_case.check_criterion_jacobian(module, input, target, extra_args=self.extra_args)
-        self._do_extra_tests(test_case, module, input, target)
 
-    def _do_extra_tests(self, test_case, module, input, target):
         params = tuple(x for x in module.parameters())
         if not isinstance(input, tuple):
-            inputs = (input,) + params
+            inputs = (input,) + params + (target,)
 
-            def apply_fn(input, *params):
+            def apply_fn(input, target, *params):
                 return module(input, target)
         else:
-            inputs = input + params
+            inputs = input + params + (target,)
 
-            def apply_fn(input1, input2, *params):
+            def apply_fn(input1, input2, target, *params):
                 return module(input1, input2, target)
-
-        if target.requires_grad:
-            inputs = inputs + (target,)
 
         gradcheck(apply_fn, inputs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44507 Simplify target handling in nn gradcheck.**
* #44486 Fix SmoothL1Loss when target.requires_grad is True.
* #44471 Fix L1Loss when target.requires_grad is True.
* #44437 Fix MSELoss when target.requires_grad is True.
* #44398 Merge criterion_tests and new_criterion_tests.
* #43958 Combine criterion and new criterion tests in test_jit.

Differential Revision: [D23635799](https://our.internmc.facebook.com/intern/diff/D23635799)