### PR TITLE
[FX][testing] Outline all sym traced GraphModules

### DIFF
--- a/torch/fx/split.py
+++ b/torch/fx/split.py
@@ -2,7 +2,7 @@ import torch
 from .graph_module import GraphModule
 from .node import Node
 from .graph import Graph
-from .symbolic_trace import DefaultDelegate
+from .delegate import DefaultDelegate
 from typing import List, Set, Dict
 
 def extract_module(mod : GraphModule, target_qualname : str) -> GraphModule:

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -8,6 +8,7 @@ from .node import Node, Argument
 from .graph import Graph
 from .graph_module import GraphModule
 from .proxy import Proxy, _create_proxy
+from .split import fully_outline_module
 
 HAS_VARSTUFF = inspect.CO_VARARGS | inspect.CO_VARKEYWORDS
 
@@ -89,4 +90,5 @@ def symbolic_trace(root : torch.nn.Module, delegate_class=DefaultDelegate) -> Gr
         graph.output(delegate.create_arg(fn(*args)))
     finally:
         torch.nn.Module.__call__ = orig_call
-    return GraphModule(root, graph)
+    orig = GraphModule(root, graph)
+    return fully_outline_module(orig)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44510 [FX][testing] Outline all sym traced GraphModules**
* #44509 [FX] Move Delegate to its own file
* #44147 [FX][RFC] Preserve module qualnames on nodes + split pass

Differential Revision: [D23636103](https://our.internmc.facebook.com/intern/diff/D23636103)