### PR TITLE
Enable fp16 for UniformFill

### DIFF
--- a/caffe2/operators/half_float_ops.cc
+++ b/caffe2/operators/half_float_ops.cc
@@ -123,7 +123,8 @@ bool Float16ConstantFillOp::RunOnDevice() {
   return true;
 }
 
-bool Float16UniformFillOp::RunOnDevice() {
+template <>
+bool Float16UniformFillOp<CPUContext>::RunOnDevice() {
   auto* output = Output(0, shape_, at::dtype<at::Half>());
   at::Half* out = output->template mutable_data<at::Half>();
 
@@ -144,7 +145,7 @@ bool Float16UniformFillOp::RunOnDevice() {
 }
 
 REGISTER_CPU_OPERATOR(Float16ConstantFill, Float16ConstantFillOp);
-REGISTER_CPU_OPERATOR(Float16UniformFill, Float16UniformFillOp);
+REGISTER_CPU_OPERATOR(Float16UniformFill, Float16UniformFillOp<CPUContext>);
 OPERATOR_SCHEMA(Float16UniformFill)
     .NumInputs(0)
     .NumOutputs(1)

--- a/caffe2/operators/half_float_ops.cu
+++ b/caffe2/operators/half_float_ops.cu
@@ -51,8 +51,40 @@ bool HalfToFloatOp<CUDAContext>::RunOnDevice() {
   return true;
 }
 
+template <>
+bool Float16UniformFillOp<CUDAContext>::RunOnDevice() {
+  auto* output = Output(0, shape_, at::dtype<at::Half>());
+  at::Half* out = output->template mutable_data<at::Half>();
+
+  auto leading_dim_sz = output->size(0);
+  CAFFE_ENFORCE_GT(leading_dim_sz, 0,
+      "The input shape should have the first dimension greater than 0");
+  int rowsz = output->numel() / output->size(0);
+
+  ReinitializeTensor(
+    &temp_data_buffer_, {rowsz}, at::dtype<float>().device(CUDA));
+  float* temp_data = temp_data_buffer_.template mutable_data<float>();
+
+  for (uint64_t i = 0; i < leading_dim_sz; i++) {
+    math::RandUniform<float, CUDAContext>(
+        rowsz, min_, max_, temp_data, &context_);
+
+    FloatToHalfKernel<<<
+      CAFFE_GET_BLOCKS(rowsz),
+      CAFFE_CUDA_NUM_THREADS,
+      0,
+      context_.cuda_stream()>>>(
+      rowsz,
+      temp_data,
+      reinterpret_cast<half*>(out + i * rowsz));
+  }
+
+  return true;
+}
+
 REGISTER_CUDA_OPERATOR(FloatToHalf, FloatToHalfOp<CUDAContext>);
 REGISTER_CUDA_OPERATOR(HalfToFloat, HalfToFloatOp<CUDAContext>);
+REGISTER_CUDA_OPERATOR(Float16UniformFill, Float16UniformFillOp<CUDAContext>);
 } // namespace caffe2
 
 #endif // CAFFE_HAS_CUDA_FP16

--- a/caffe2/operators/half_float_ops.h
+++ b/caffe2/operators/half_float_ops.h
@@ -45,11 +45,12 @@ class Float16ConstantFillOp : public Operator<CPUContext> {
   vector<int64_t> shape_;
 };
 
-class Float16UniformFillOp : public Operator<CPUContext> {
+template <class Context>
+class Float16UniformFillOp : public Operator<Context> {
  public:
   template <class... Args>
   explicit Float16UniformFillOp(Args&&... args)
-      : Operator<CPUContext>(std::forward<Args>(args)...),
+      : Operator<Context>(std::forward<Args>(args)...),
         shape_(this->template GetRepeatedArgument<int64_t>("shape")),
         min_(this->template GetSingleArgument<float>("min", 0)),
         max_(this->template GetSingleArgument<float>("max", 1)) {
@@ -66,7 +67,7 @@ class Float16UniformFillOp : public Operator<CPUContext> {
     }
   }
 
-  USE_OPERATOR_FUNCTIONS(CPUContext);
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
   virtual ~Float16UniformFillOp() {}
 
   bool RunOnDevice() override;
@@ -75,6 +76,8 @@ class Float16UniformFillOp : public Operator<CPUContext> {
   vector<int64_t> shape_;
   float min_;
   float max_;
+
+  Tensor temp_data_buffer_;
 };
 
 inline std::vector<TensorShape> Float16FillerTensorInference(


### PR DESCRIPTION
Summary: Support output type to be fp16 for UniformFill

Reviewed By: jianyuh

Differential Revision: D23558030

