### PR TITLE
[Cmake] Drop quotation marks around `$ENV{MAX_JOBS}`

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -34,7 +34,7 @@ if(NOT __NCCL_INCLUDED)
         "BUILDDIR=${__NCCL_BUILD_DIR}"
         "VERBOSE=0"
         "-j"
-        "$ENV{MAX_JOBS}"
+        $ENV{MAX_JOBS}
         BUILD_BYPRODUCTS "${__NCCL_BUILD_DIR}/lib/libnccl_static.a"
       INSTALL_COMMAND ""
       )


### PR DESCRIPTION
Solves `the '-j' option requires a positive integer argument` error on some systems when MAX_JOBS is not defined

