### PR TITLE
Check for index-rank consistency in FunctionInliner

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -1967,5 +1967,23 @@ void testNormalizeAndSplitWithTail() {
   torch::jit::testing::FileCheck().run(expected_tail_ir, oss_tail.str());
 }
 
+void testDetectInlineRankMismatch() {
+  KernelScope kernel_scope;
+  const int kTotalSize = 8;
+
+  Buffer a_buf(BufHandle("A", {ExprHandle(kTotalSize)}, kFloat));
+  Tensor* a = Compute(
+      "a", {{kTotalSize, "i"}}, [&](const VarHandle& i) { return a_buf(i); });
+  Tensor* reshape = Compute(
+      "reshape",
+      {{kTotalSize / 2, "i"}, {2, "j"}},
+      [&](const VarHandle& i, const VarHandle& j) { return a->call(i, j); });
+  LoopNest l({reshape});
+  l.computeInline(l.getLoopBodyFor(a));
+  ASSERT_THROWS_WITH(
+      l.prepareForCodegen(),
+      "Buffer indexed access is inconsistent with its rank");
+}
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -235,6 +235,7 @@ namespace jit {
   _(NormalizeOnNestedOuterLoop)             \
   _(NormalizeOnNestedInnerLoop)             \
   _(NormalizeAndSplitWithTail)              \
+  _(DetectInlineRankMismatch)               \
   _(Kernel_1)                               \
   _(Kernel_2)                               \
   _(Kernel_3)                               \

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -390,6 +390,10 @@ class FunctionInliner : public IRMutator {
 
     if (should_inline(func)) {
       // Insert the caller/callee pair into the mapping.
+      if (v->nparams() != buf->ndim()) {
+        throw malformed_input(
+            "Buffer indexed access is inconsistent with its rank", v);
+      }
       for (size_t i = 0; i < buf->ndim(); i++) {
         const Var* func_callee_arg = dynamic_cast<const Var*>(func->arg(i));
         const Expr* func_caller_param = v->param(i);


### PR DESCRIPTION
Summary: When caller / callee pairs are	inserted into the mapping, verify that
the arity of the buffer access is consistent with its declared rank.

Test Plan: CI, test_tensorexpr --gtest_filter=TensorExprTest.DetectInlineRankMismatch