### PR TITLE
[TensorExpr] Do not inline autodiff graphs if they contain prim::TypeCheck nodes.

### DIFF
--- a/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
@@ -14,7 +14,8 @@ namespace jit {
 bool canRunWithAutograd(Node* node) {
   auto kind = node->kind();
   return kind != prim::FusionGroup && kind != prim::CudaFusionGroup &&
-      kind != prim::TensorExprGroup && (kind.is_aten() || kind.is_prim());
+      kind != prim::TypeCheck && kind != prim::TensorExprGroup &&
+      (kind.is_aten() || kind.is_prim());
 }
 
 namespace {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44564 [TensorExpr] Do not inline autodiff graphs if they contain prim::TypeCheck nodes.**

Before this change we sometimes inlined autodiff subgraph containing
fusion groups. This happened because we didn't look for 'unsupported'
nodes recursively, but fusion groups were inside if-nodes. With this
change we start to look into sub-blocks and also block-list
prim::TypeCheck - if we were to inline those node we would need to
update the expected types and such logic doesn't exist yet.

The problem was detected by @bertmaher in 'LearningToPaint' benchmark
investigation where this bug caused us to keep constantly hitting
fallback paths of the graph.

Differential Revision: [D23657049](https://our.internmc.facebook.com/intern/diff/D23657049)