### PR TITLE
add `lcov` to oss for beautiful html report

### DIFF
--- a/tools/code_coverage/README.md
+++ b/tools/code_coverage/README.md
@@ -21,6 +21,7 @@ It’s an integrated tool. You can use this tool to run and generate both file-l
 * *Final report:*
     * File-Level: The coverage percentage for each file you are interested in
     * Line-Level: The coverage details for each line in each file you are interested in
+    * Html-Report (only for `gcc`): The beautiful HTML report supported by `lcov`, combine file-level report and line-lever report into a graphical view.
 * *More complex but flexible options:*
     * Use different stages like *--run, --export, --summary* to achieve more flexible functionality
 
@@ -50,7 +51,7 @@ Great, you are ready to run the code coverage tool for the first time! Start fro
 ```
 python oss_coverage.py --run-only=atest
 ```
-This command will run `atest` binary in `build/bin/` folder and generate reoports over the entire *Pytorch* folder. But you may only be interested in the `aten` folder, in this case, try:
+This command will run `atest` binary in `build/bin/` folder and generate reoports over the entire *Pytorch* folder. You can find the reports in `profile/summary`. But you may only be interested in the `aten` folder, in this case, try:
 ```
 python oss_coverage.py --run-only=atest --interested-only=aten
 ```

--- a/tools/code_coverage/README.md
+++ b/tools/code_coverage/README.md
@@ -65,6 +65,7 @@ python oss_coverage.py --run-only=atest c10_logging_test --interested-only aten/
 ```
 That it is! With these two simple options, you can customize many different functionality according to your need.
 By default, the tool will run all tests in `build/bin` folder (by running all executable binaries in it) and `test/` folder (by running `run_test.py`), and then collect coverage over the entire *Pytorch* folder. If this is what you want, try:
+*(Note: It's not recommended to run default all tests in clang, because it will take too much space)*
 ```bash
 python oss_coverage.py
 ```

--- a/tools/code_coverage/oss_coverage.py
+++ b/tools/code_coverage/oss_coverage.py
@@ -5,6 +5,7 @@ from package.oss.cov_json import get_json_report
 from package.oss.init import initialization
 from package.tool.summarize_jsons import summarize_jsons
 from package.util.setting import TestPlatform
+from package.util.utils import print_time
 
 
 def report_coverage() -> None:
@@ -14,9 +15,9 @@ def report_coverage() -> None:
     get_json_report(test_list, options)
     # collect coverage data from json profiles
     if options.need_summary:
-        summarize_jsons(
-            test_list, interested_folders, [""], TestPlatform.OSS, start_time
-        )
+        summarize_jsons(test_list, interested_folders, [""], TestPlatform.OSS)
+    # print program running time
+    print_time("Program Total Time: ", start_time)
 
 
 if __name__ == "__main__":

--- a/tools/code_coverage/package/oss/cov_json.py
+++ b/tools/code_coverage/package/oss/cov_json.py
@@ -1,14 +1,11 @@
-import time
-
-from ..tool import clang_coverage, gcc_coverage
+from ..tool import clang_coverage
 from ..util.setting import CompilerType, Option, TestList, TestPlatform
-from ..util.utils import check_compiler_type, print_time
-from .init import detect_compiler_type, gcc_export_init
+from ..util.utils import check_compiler_type
+from .init import detect_compiler_type
 from .run import clang_run, gcc_run
 
 
 def get_json_report(test_list: TestList, options: Option):
-    start_time = time.time()
     cov_type = detect_compiler_type()
     check_compiler_type(cov_type)
     if cov_type == CompilerType.CLANG:
@@ -24,11 +21,3 @@ def get_json_report(test_list: TestList, options: Option):
         # run
         if options.need_run:
             gcc_run(test_list)
-        # export
-        if options.need_export:
-            gcc_export_init()
-            gcc_coverage.export()
-
-    print_time(
-        "collect coverage for cpp tests take time: ", start_time, summary_time=True
-    )

--- a/tools/code_coverage/package/tool/print_report.py
+++ b/tools/code_coverage/package/tool/print_report.py
@@ -1,9 +1,9 @@
 import os
-import time
+import subprocess
 from typing import IO, Dict, List, Set
 
+from ..oss.utils import get_pytorch_folder
 from ..util.setting import SUMMARY_FOLDER_DIR, TestList, TestStatusType
-from ..util.utils import convert_time
 
 
 def key_by_percentage(x):
@@ -105,17 +105,6 @@ def line_oriented_report(
             )
 
 
-def print_total_program_time(start_time: float, summary_file: IO) -> None:
-    end_time = time.time()
-    # print to summary file
-    print(
-        f"PROGRAM RUNNING TIME: {convert_time(end_time - start_time)}\n\n",
-        file=summary_file,
-    )
-    # print to terminal
-    print(f"time: {convert_time(end_time - start_time)}")
-
-
 def print_file_summary(
     covered_summary: int, total_summary: int, summary_file: IO
 ) -> float:
@@ -142,12 +131,10 @@ def print_file_oriented_report(
     tests: TestList,
     interested_folders: List[str],
     coverage_only: List[str],
-    program_start_time: float,
 ) -> None:
     coverage_percentage = print_file_summary(
         covered_summary, total_summary, summary_file
     )
-    print_total_program_time(program_start_time, summary_file)
     # print test condition (interested folder / tests that are successsful or failed)
     print_test_condition(
         tests,
@@ -175,12 +162,10 @@ def file_oriented_report(
     tests_type: TestStatusType,
     interested_folders: List[str],
     coverage_only: List[str],
-    program_start_time: float,
     covered_lines: Dict[str, Set[int]],
     uncovered_lines: Dict[str, Set[int]],
 ) -> None:
     with open(os.path.join(SUMMARY_FOLDER_DIR, "file_summary"), "w+") as summary_file:
-        start_time = time.time()
         covered_summary = 0
         total_summary = 0
         coverage = []
@@ -210,5 +195,44 @@ def file_oriented_report(
             tests,
             interested_folders,
             coverage_only,
-            program_start_time,
         )
+
+
+def get_html_ignored_pattern() -> List[str]:
+    return ["/usr/*", "*anaconda3/*", "*third_party/*"]
+
+
+def html_oriented_report():
+    # use lcov to generate the coverage report
+    build_folder = os.path.join(get_pytorch_folder(), "build")
+    coverage_info_file = os.path.join(SUMMARY_FOLDER_DIR, "coverage.info")
+    # generage coverage report -- coverage.info in build folder
+    subprocess.check_call(
+        [
+            "lcov",
+            "--capture",
+            "--directory",
+            build_folder,
+            "--output-file",
+            coverage_info_file,
+        ]
+    )
+    # remove files that are unrelated
+    cmd_array = (
+        ["lcov", "--remove", coverage_info_file]
+        + get_html_ignored_pattern()
+        + ["--output-file", coverage_info_file]
+    )
+    subprocess.check_call(
+        # ["lcov", "--remove", coverage_info_file, "--output-file", coverage_info_file]
+        cmd_array
+    )
+    # generate beautiful html page
+    subprocess.check_call(
+        [
+            "genhtml",
+            coverage_info_file,
+            "--output-directory",
+            os.path.join(SUMMARY_FOLDER_DIR, "html_report"),
+        ]
+    )

--- a/tools/code_coverage/package/tool/summarize_jsons.py
+++ b/tools/code_coverage/package/tool/summarize_jsons.py
@@ -19,7 +19,11 @@ from ..util.utils import (
 from .parser.coverage_record import CoverageRecord
 from .parser.gcov_coverage_parser import GcovCoverageParser
 from .parser.llvm_coverage_parser import LlvmCoverageParser
-from .print_report import file_oriented_report, line_oriented_report
+from .print_report import (
+    file_oriented_report,
+    html_oriented_report,
+    line_oriented_report,
+)
 
 
 # coverage_records: Dict[str, LineInfo] = dict()
@@ -186,26 +190,27 @@ def summarize_jsons(
     interested_folders: List[str],
     coverage_only: List[str],
     platform: TestPlatform,
-    program_start_time: float,
 ) -> None:
     start_time = time.time()
-    parse_jsons(test_list, interested_folders, platform)
-    update_set()
-    line_oriented_report(
-        test_list,
-        tests_type,
-        interested_folders,
-        coverage_only,
-        covered_lines,
-        uncovered_lines,
-    )
-    file_oriented_report(
-        test_list,
-        tests_type,
-        interested_folders,
-        coverage_only,
-        program_start_time,
-        covered_lines,
-        uncovered_lines,
-    )
+    if detect_compiler_type(platform) == CompilerType.GCC:
+        html_oriented_report()
+    else:
+        parse_jsons(test_list, interested_folders, platform)
+        update_set()
+        line_oriented_report(
+            test_list,
+            tests_type,
+            interested_folders,
+            coverage_only,
+            covered_lines,
+            uncovered_lines,
+        )
+        file_oriented_report(
+            test_list,
+            tests_type,
+            interested_folders,
+            coverage_only,
+            covered_lines,
+            uncovered_lines,
+        )
     print_time("summary jsons take time: ", start_time)


### PR DESCRIPTION
Summary:
By `lcov`, we can generate beautiful html. It's better than current file report and line report. Therefore in oss gcc, remove `export` code and `file/line level report` code, only use the html report.

But in clang, since such tool is not available, we will still use file-report and line-report generated by ourself.

Test Plan:
Test in docker ubuntu machine.
## Mesurement
1. After running `atest`, it takes about 15 mins to collect code coverage and genrate the report.
```
# gcc code coverage
python oss_coverage.py --run-only=atest
```

## Presentation
**The html result looks like:**

*Top Level:*

{F328330856}

*File Level:*

{F328336709}

Reviewed By: malfet

Differential Revision: D23550784

