### PR TITLE
[Caffe2] gcs_cuda_only is trivial if CUDA not available

### DIFF
--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -300,10 +300,13 @@ cpu_do = caffe2_pb2.DeviceOption()
 cuda_do = caffe2_pb2.DeviceOption(device_type=caffe2_pb2.CUDA)
 hip_do = caffe2_pb2.DeviceOption(device_type=caffe2_pb2.HIP)
 gpu_do = caffe2_pb2.DeviceOption(device_type=workspace.GpuDeviceType)  # CUDA or ROCm
+_cuda_do_list = ([cuda_do] if workspace.has_cuda_support else [])
+_hip_do_list = ([hip_do] if workspace.has_hip_support else [])
+_gpu_do_list = ([gpu_do] if workspace.has_gpu_support else [])
 # (bddppq) Do not rely on this no_hip option! It's just used to
 # temporarily skip some flaky tests on ROCM before it's getting more mature.
-_device_options_no_hip = [cpu_do] + ([cuda_do] if workspace.has_cuda_support else [])
-device_options = _device_options_no_hip + ([hip_do] if workspace.has_hip_support else [])
+_device_options_no_hip = [cpu_do] + _cuda_do_list
+device_options = _device_options_no_hip + _hip_do_list
 
 # Include device option for each GPU
 expanded_device_options = [cpu_do] + [
@@ -325,8 +328,8 @@ gcs = dict(
 )
 
 gcs_cpu_only = dict(gc=st.sampled_from([cpu_do]), dc=st.just([cpu_do]))
-gcs_cuda_only = dict(gc=st.sampled_from([cuda_do]), dc=st.just([cuda_do]))
-gcs_gpu_only = dict(gc=st.sampled_from([gpu_do]), dc=st.just([gpu_do]))  # CUDA or ROCm
+gcs_cuda_only = dict(gc=st.sampled_from(_cuda_do_list), dc=st.just(_cuda_do_list))
+gcs_gpu_only = dict(gc=st.sampled_from(_gpu_do_list), dc=st.just(_gpu_do_list))  # CUDA or ROCm
 gcs_no_hip = dict(gc=st.sampled_from(_device_options_no_hip), dc=st.just(_device_options_no_hip))
 
 


### PR DESCRIPTION
Make `gcs_cuda_only` and `gcs_gpu_only` return empty device lists if CUDA/GPU(CUDA or RocM) not available
