### PR TITLE
[JIT] Disallow plain List type annotation without arg

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -635,6 +635,13 @@ def is_tuple(ann):
             getattr(ann, '__origin__', None) is tuple)
 
 def is_list(ann):
+    if ann is List:
+        raise RuntimeError(
+            "Attempted to use List without a "
+            "contained type. Please add a contained type, e.g. "
+            "List[int]"
+        )
+
     if not hasattr(ann, '__module__'):
         return False
     return ann.__module__ == 'typing' and \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44586 [JIT] Disallow plain Optional type annotation without arg
* #44585 [JIT] Disallow plain Tuple type annotation without arg
* **#44584 [JIT] Disallow plain List type annotation without arg**
* #44334 [JIT] Disallow plain Dict type annotation without arg

**Summary**
This commit extends the work done in #38130 and disallows plain
Python3-style `List` type annotations.

**Test Plan**
This commit extends `TestList.test_no_element_type_annotation` to the
Python3-style type annotation.

Differential Revision: [D23721514](https://our.internmc.facebook.com/intern/diff/D23721514)