### PR TITLE
[JIT] Disallow plain Tuple type annotation without arg

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -627,6 +627,13 @@ def _get_overloaded_methods(method, mod_class):
 
 
 def is_tuple(ann):
+    if ann is Tuple:
+        raise RuntimeError(
+            "Attempted to use Tuple without a "
+            "contained type. Please add a contained type, e.g. "
+            "Tuple[int]"
+        )
+
     # For some reason Python 3.7 violates the Type[A, B].__origin__ == Type rule
     if not hasattr(ann, '__module__'):
         return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44586 [JIT] Disallow plain Optional type annotation without arg
* **#44585 [JIT] Disallow plain Tuple type annotation without arg**
* #44584 [JIT] Disallow plain List type annotation without arg
* #44334 [JIT] Disallow plain Dict type annotation without arg

**Summary**
This commit disallows plain `Tuple` type annotations without any
contained types both in type comments and in-line as Python3-style
type annotations.

**Test Plan**
This commit adds a unit test for these two situations.

Differential Revision: [D23721515](https://our.internmc.facebook.com/intern/diff/D23721515)