### PR TITLE
[JIT] Disallow plain Optional type annotation without arg

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -408,6 +408,31 @@ class TestScriptPy3(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, "Lists must contain only a single type"):
             torch.jit.script(wrong_type)
 
+    def test_optional_no_element_type_annotation(self):
+        """
+        Test that using an optional with no contained types produces an error.
+        """
+        def fn_with_comment(x):
+            # type: (torch.Tensor) -> Optional
+            return (x, x)
+
+        def annotated_fn(x: torch.Tensor) -> Optional:
+            return (x, x)
+
+        with self.assertRaisesRegex(RuntimeError, r"Attempted to use Optional without a contained type"):
+            cu = torch.jit.CompilationUnit()
+            cu.define(dedent(inspect.getsource(fn_with_comment)))
+
+        with self.assertRaisesRegex(RuntimeError, r"Attempted to use Optional without a contained type"):
+            cu = torch.jit.CompilationUnit()
+            cu.define(dedent(inspect.getsource(annotated_fn)))
+
+        with self.assertRaisesRegex(RuntimeError, r"Attempted to use Optional without a contained type"):
+            torch.jit.script(fn_with_comment)
+
+        with self.assertRaisesRegex(RuntimeError, r"Attempted to use Optional without a contained type"):
+            torch.jit.script(annotated_fn)
+
     def test_tuple_no_element_type_annotation(self):
         """
         Test that using a tuple with no contained types produces an error.

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -670,6 +670,13 @@ def is_dict(ann):
             getattr(ann, '__origin__', None) is dict)
 
 def is_optional(ann):
+    if ann is Optional:
+        raise RuntimeError(
+            "Attempted to use Optional without a "
+            "contained type. Please add a contained type, e.g. "
+            "Optional[int]"
+        )
+
     # Optional[T] is just shorthand for Union[T, None], so check for both
     def safe_is_subclass(the_type, super_type):
         # Don't throw if `the_type` isn't a class type (e.g. if it is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44586 [JIT] Disallow plain Optional type annotation without arg**
* #44585 [JIT] Disallow plain Tuple type annotation without arg
* #44584 [JIT] Disallow plain List type annotation without arg
* #44334 [JIT] Disallow plain Dict type annotation without arg

**Summary**
This commit disallows plain `Optional` type annotations without
any contained types both in type comments and in-line as
Python3-style type annotations.

**Test Plan**
This commit adds a unit test for these two situations.

Differential Revision: [D23721517](https://our.internmc.facebook.com/intern/diff/D23721517)