### PR TITLE
use std::tuple for Future stream

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -155,8 +155,8 @@ class ProcessGroupNCCL : public ProcessGroup {
     // Store a reference to NCCL collective's outputs to be used by getFuture.
     std::shared_ptr<std::vector<at::Tensor>> outputs_;
     // Store streams that run FutureNCCL then callbacks.
-    std::vector<std::shared_ptr<at::cuda::CUDAStream>>
-        futureNCCLCallbackStreams_;
+    std::tuple<uint64_t, std::shared_ptr<at::cuda::CUDAStream>>
+        futureNCCLCallbackStream_;
 
     friend class ProcessGroupNCCL;
   };
@@ -620,12 +620,10 @@ class ProcessGroupNCCL : public ProcessGroup {
   // In single-process single-device mode, WorkNCCL::getFuture is supported.
   // Depending on the device index of collective outputs, WorkNCCL will pass
   // the corresponding device's then callback stream to FutureNCCL.
-  // We just inititalize futureNCCLCallbackStreams_ inside the constructor and
-  // set its size to the total number of available devices and depending on the
-  // device of the NCCL collective's outputs, we later set the callback stream
-  // of the corresponding device inside ProcessGroupNCCL::getNCCLComm if not set
+  // We later create the callback stream on this process' device
+  // inside ProcessGroupNCCL::getNCCLComm if not created
   // before.
-  std::vector<std::shared_ptr<at::cuda::CUDAStream>> futureNCCLCallbackStreams_;
+  std::tuple<uint64_t, std::shared_ptr<at::cuda::CUDAStream>> futureNCCLCallbackStream_;
 };
 
 } // namespace c10d


### PR DESCRIPTION
future callbacks are supported only in single-gpu per process mode, so there's no need to create a stream on every device for them (or even allocate an array without creating streams). Using std::tuple instead of std::vector makes this semantics a bit clearer. 

Also, what do you guys think of adding tests that would make sure that additional contexts are not created, to prevent breakages similar to one fixed by #44097? Creating extra contexts is very bad, and for multi-gpu jobs leads to half of GPU memory being thrown away. 
