### PR TITLE
Simplifies unary ufunc testing by not testing against large or extremal complex values, ports more of TestTorchMathOps

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -20307,19 +20307,11 @@ class _TorchMathTestMeta(object):
         self.dtypes = dtypes
         self.replace_inf_with_nan = replace_inf_with_nan
 
-torch_op_tests = [_TorchMathTestMeta('sqrt'),
-                  _TorchMathTestMeta('erf', ref_backend='scipy'),
-                  _TorchMathTestMeta('erfc', ref_backend='scipy'),
-                  _TorchMathTestMeta('exp'),
+torch_op_tests = [_TorchMathTestMeta('exp'),
                   _TorchMathTestMeta('expm1'),
-                  _TorchMathTestMeta('floor'),
-                  _TorchMathTestMeta('ceil'),
                   _TorchMathTestMeta('rad2deg'),
                   _TorchMathTestMeta('deg2rad'),
-                  _TorchMathTestMeta('rsqrt', reffn=lambda x: np.reciprocal(np.sqrt(x))),
                   _TorchMathTestMeta('frac', reffn='fmod', refargs=lambda x: (x.numpy(), 1)),
-                  _TorchMathTestMeta('trunc'),
-                  _TorchMathTestMeta('round'),
                   # FIXME lgamma produces different result compared to scipy at -inf
                   _TorchMathTestMeta('lgamma', reffn='gammaln', ref_backend='scipy', replace_inf_with_nan=True),
                   _TorchMathTestMeta('polygamma', args=[0], substr='_0', reffn='polygamma',
@@ -20334,7 +20326,6 @@ torch_op_tests = [_TorchMathTestMeta('sqrt'),
                   _TorchMathTestMeta('digamma',
                                      input_fn=_generate_gamma_input, inputargs=[True], ref_backend='scipy',
                                      replace_inf_with_nan=True),
-                  _TorchMathTestMeta('abs', input_fn=_medium_2d, dtypes=_types_no_half, rtol=0., atol=0.),
                   _TorchMathTestMeta('logit', ref_backend='scipy')]
 
 

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -130,11 +130,14 @@ def generate_numeric_tensors(device, dtype, *,
         opt_inf_vals = (-float('inf'), float('inf')) if dtype.is_floating_point else tuple()
         opt_nan = (float('nan'),) if dtype.is_floating_point else tuple()
 
+        # NOTE: float (and complex) filter is strictly less than / greater than
+        #   since float domains exclude their endpoints
         unfiltered_vals = _float_vals + large_vals + opt_inf_vals
         filtered_vals = tuple(val for val in unfiltered_vals if (val > low and val < high))
-
         vals = filtered_vals + opt_nan
-        # Converts float -> complex vals if dtype is complex
+
+        # Derives complex values from float values if the dtype is complex
+        # NOTE: complex values are constructed as float val x float val pairs
         if dtype.is_complex:
             vals = tuple(complex(x, y) for x, y in product(vals, vals))
     elif dtype is torch.uint8:

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -61,7 +61,7 @@ if TEST_NUMPY:
 
 # Interesting values and extremal values for different dtypes
 _unsigned_int_vals = (0, 1, 55, 127)
-_int_vals = (0, -1, 1, -55, 55, -127, 127, -128, 128)
+_int_vals = (0, -1, 1, -55, 55, -127, 127, -128)  # NOTE: should fit within int8
 _large_int_vals = (-1113, 1113, -10701, 10701)
 _float_vals = (0.,
                -.001, .001,


### PR DESCRIPTION
This PR simplifies complex unary ufunc testing by no longer including large or extremal complex values in the reference numerics test. This test would frequently fail, often due to cross-platform inconsistencies. For example, it would pass on Linux and Linux CUDA builds but fail on MacOS, Windows, or ROCm builds. These tests would then be disabled, leaving a testing gap. Testing only only smaller complex values should provide a better test signal and avoid tracking down these inconsistencies.

In addition, float and complex domains no longer include their endpoints. Testing for logarithms at zero was also leading to inconsistent results across platforms. 

This PR also ports the following functions from TestTorchMathOps to OpInfos:

- sqrt
- erf
- erfc
- floor
- ceil
- rsqrt
- trunc
- round
- abs


