### PR TITLE
lr_schedule.py redundant code

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -202,7 +202,6 @@ class LambdaLR(_LRScheduler):
                 raise ValueError("Expected {} lr_lambdas, but got {}".format(
                     len(optimizer.param_groups), len(lr_lambda)))
             self.lr_lambdas = list(lr_lambda)
-        self.last_epoch = last_epoch
         super(LambdaLR, self).__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):
@@ -284,7 +283,6 @@ class MultiplicativeLR(_LRScheduler):
                 raise ValueError("Expected {} lr_lambdas, but got {}".format(
                     len(optimizer.param_groups), len(lr_lambda)))
             self.lr_lambdas = list(lr_lambda)
-        self.last_epoch = last_epoch
         super(MultiplicativeLR, self).__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):


### PR DESCRIPTION
The subclass sets "self.last_epoch" when this is set in the parent class's init function. Why would we need to set last_epoch twice? I think calling "super" resets last_epoch anyway, so I am not sure why we would want to include this in the subclass. Am I missing something? 

For the record, I am just a Pytorch enthusiast. I hope my question isn't totally silly.

Fixes #{issue number}
