### PR TITLE
Fix FP16 fastAtomicAdd for one case where tensor start address is not 32 bit aligned

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -21,8 +21,8 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
       reinterpret_cast<at::Half*>(tensor) + index,
       static_cast<at::Half>(value));
 #else
-  bool low_bit = (index % 2 == 0) &&
-      (reinterpret_cast<std::uintptr_t>(tensor) % sizeof(__half2) == 0);
+  // Accounts for the chance tensor falls on an odd 16 bit alignment (ie, not 32 bit aligned)
+  bool low_bit = (reinterpret_cast<std::uintptr_t>(tensor + index) % sizeof(__half2) == 0);
 
   if (low_bit && index < (numel - 1)) {
     __half2 value2;

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -23,15 +23,15 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
 #else
   // Accounts for the chance tensor falls on an odd 16 bit alignment (ie, not 32 bit aligned)
   __half* target_addr = reinterpret_cast<__half*>(tensor + index);
-  bool low_bit = (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
+  bool low_byte = (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
 
-  if (low_bit && index < (numel - 1)) {
+  if (low_byte && index < (numel - 1)) {
     __half2 value2;
     value2.x = value;
     value2.y = __int2half_rz(0);
     atomicAdd(reinterpret_cast<__half2*>(target_addr), value2);
 
-  } else if (!low_bit && index > 0) {
+  } else if (!low_byte && index > 0) {
     __half2 value2;
     value2.x = __int2half_rz(0);
     value2.y = value;

--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -22,19 +22,20 @@ __device__ __forceinline__ void fastSpecializedAtomicAdd(
       static_cast<at::Half>(value));
 #else
   // Accounts for the chance tensor falls on an odd 16 bit alignment (ie, not 32 bit aligned)
-  bool low_bit = (reinterpret_cast<std::uintptr_t>(tensor + index) % sizeof(__half2) == 0);
+  __half* target_addr = reinterpret_cast<__half*>(tensor + index);
+  bool low_bit = (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
 
   if (low_bit && index < (numel - 1)) {
     __half2 value2;
     value2.x = value;
     value2.y = __int2half_rz(0);
-    atomicAdd(reinterpret_cast<__half2*>(tensor) + index / 2, value2);
+    atomicAdd(reinterpret_cast<__half2*>(target_addr), value2);
 
   } else if (!low_bit && index > 0) {
     __half2 value2;
     value2.x = __int2half_rz(0);
     value2.y = value;
-    atomicAdd(reinterpret_cast<__half2*>(tensor) + index / 2, value2);
+    atomicAdd(reinterpret_cast<__half2*>(target_addr - 1), value2);
 
   } else {
     atomicAdd(


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/44206 and https://github.com/pytorch/pytorch/issues/42218, I'd like to update trilinear interpolate backward and grid_sample backward to use `fastAtomicAdd`.


As a prelude, I spotted a UB risk in `fastAtomicAdd`.  I think existing code incurs a misaligned `__half2` atomicAdd when `index` is odd and `tensor` is not 32-bit aligned (`index % 2 == 1` and `(reinterpret_cast<std::uintptr_t>(tensor) % sizeof(__half2) == 1`). In this case we think we're `!low_bit` and go down the `!low_bit` code path, but in fact we are `low_bit`.  It appears the original [fastAtomicAdd PR](https://github.com/pytorch/pytorch/pull/21879#discussion_r295040377)'s discussion did not consider that case explicitly.

I wanted to push my tentative fix for discussion ASAP. @jjsjann123 and @mkolod as original authors of `fastAtomicAdd`. (I'm also curious why we need to `reinterpret_cast<std::uintptr_t>(tensor...` for the address modding, but that's minor.)