### PR TITLE
Make `peephole.cpp` in batch_mm more targeted to transpose. 

### DIFF
--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -475,7 +475,9 @@ void BatchMM(std::shared_ptr<Graph>& graph) {
   EliminateDeadCode(graph);
   // It's possible that transpose rearrangements have created sequences of
   // consecutive transposes that didn't exist before.
-  PeepholeOptimize(graph);
+  // Also, disable shape optimizations since they shouldn't affect
+  // transposes and batch_mm called on unguarded profiled types
+  PeepholeOptimize(graph, /*disable_shape_peepholes=*/true);
 }
 
 } // namespace jit


### PR DESCRIPTION
Make `peephole.cpp` in batch_mm more targeted to transposes. 
BatchMM is also used in PE *after* `prim::profile` type information transferred onto output types but the guards aren't inserted yet and might not be inserted at all on some of those types that `peephole` can optimize.