### PR TITLE
Fix fallback graph in specialize autogradzero

### DIFF
--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -178,5 +178,3 @@ class TestProfiler(JitTestCase):
 
         g = torch.jit.last_executed_optimized_graph()
         FileCheck().check("fallback_function").check_next("CallFunction").run(g)
-        
-        

--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -178,3 +178,5 @@ class TestProfiler(JitTestCase):
 
         g = torch.jit.last_executed_optimized_graph()
         FileCheck().check("fallback_function").check_next("CallFunction").run(g)
+        
+        

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -112,7 +112,7 @@ struct AutogradZeroSpecializer {
     replaceBlockInputsWithGraphInputs(true_block);
     false_block->cloneFrom(graph_->block(), value_map);
     replaceBlockInputsWithGraphInputs(false_block);
-    replaceBlockWithFallbackGraph(graph_->block(), graph_->inputs());
+    replaceBlockWithFallbackGraph(false_block, graph_->inputs());
 
     WithInsertPoint wip{graph_->block()->param_node()->next()};
     Value* none_val = graph_->insertConstant(IValue());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44654 Fix fallback graph in specialize autogradzero**

Previously we weren't creating a fallback graph as intended in specialize autograd zero, so if a Tensor failed one of our undefinedness checks we would run the backward normally without reprofiling & optimizing.

Differential Revision: [D23691764](https://our.internmc.facebook.com/intern/diff/D23691764)