### PR TITLE
Make async_execution compatible with RRef helpers

### DIFF
--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -115,12 +115,6 @@ def async_execution(fn):
         >>>         )
         >>>         return ret_fut
         >>>
-        >>>     @rpc.functions.async_execution
-        >>>     def bound_async_add(self, to, x, y, z):
-        >>>         return rpc.rpc_async(to, torch.add, args=(x, y)).then(
-        >>>             lambda fut: fut.wait() + z
-        >>>         )
-        >>>
         >>> # On worker0
         >>> ret = rpc.rpc_sync(
         >>>     "worker1",

--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -115,6 +115,12 @@ def async_execution(fn):
         >>>         )
         >>>         return ret_fut
         >>>
+        >>>     @rpc.functions.async_execution
+        >>>     def bound_async_add(self, to, x, y, z):
+        >>>         return rpc.rpc_async(to, torch.add, args=(x, y)).then(
+        >>>             lambda fut: fut.wait() + z
+        >>>         )
+        >>>
         >>> # On worker0
         >>> ret = rpc.rpc_sync(
         >>>     "worker1",

--- a/torch/distributed/rpc/rref_proxy.py
+++ b/torch/distributed/rpc/rref_proxy.py
@@ -1,16 +1,37 @@
 from functools import partial
 
+from . import functions
 
 def _local_invoke(rref, func_name, args, kwargs):
     return getattr(rref.local_value(), func_name)(*args, **kwargs)
 
+@functions.async_execution
+def _local_invoke_async_execution(rref, func_name, args, kwargs):
+    return getattr(rref.local_value(), func_name)(*args, **kwargs)
 
 def _invoke_rpc(rref, rpc_api, func_name, *args, **kwargs):
-    return rpc_api(
-        rref.owner(),
-        _local_invoke,
-        args=(rref, func_name, args, kwargs)
-    )
+    rref_type = rref._get_type()
+
+    if not hasattr(rref_type, func_name):
+        raise ValueError(
+            f"Function {func_name} is not an attribute of type {rref_type} "
+            f"referenced by RRef {rref}."
+        )
+
+    func = getattr(rref_type, func_name)
+
+    if hasattr(func, "_wrapped_async_rpc_function"):
+        return rpc_api(
+            rref.owner(),
+            _local_invoke_async_execution,
+            args=(rref, func_name, args, kwargs)
+        )
+    else:
+        return rpc_api(
+            rref.owner(),
+            _local_invoke,
+            args=(rref, func_name, args, kwargs)
+        )
 
 
 class RRefProxy:

--- a/torch/distributed/rpc/rref_proxy.py
+++ b/torch/distributed/rpc/rref_proxy.py
@@ -2,6 +2,8 @@ from functools import partial
 
 from . import functions
 
+import torch
+
 def _local_invoke(rref, func_name, args, kwargs):
     return getattr(rref.local_value(), func_name)(*args, **kwargs)
 
@@ -12,26 +14,23 @@ def _local_invoke_async_execution(rref, func_name, args, kwargs):
 def _invoke_rpc(rref, rpc_api, func_name, *args, **kwargs):
     rref_type = rref._get_type()
 
-    if not hasattr(rref_type, func_name):
-        raise ValueError(
-            f"Function {func_name} is not an attribute of type {rref_type} "
-            f"referenced by RRef {rref}."
-        )
+    _invoke_func = _local_invoke
+    if rref_type is not torch._C.ScriptModule:
+        if not hasattr(rref_type, func_name):
+            raise ValueError(
+                f"Function {func_name} is not an attribute of type {rref_type} "
+                f"referenced by RRef {rref}."
+            )
 
-    func = getattr(rref_type, func_name)
+        func = getattr(rref_type, func_name)
+        if hasattr(func, "_wrapped_async_rpc_function"):
+            _invoke_func = _local_invoke_async_execution
 
-    if hasattr(func, "_wrapped_async_rpc_function"):
-        return rpc_api(
-            rref.owner(),
-            _local_invoke_async_execution,
-            args=(rref, func_name, args, kwargs)
-        )
-    else:
-        return rpc_api(
-            rref.owner(),
-            _local_invoke,
-            args=(rref, func_name, args, kwargs)
-        )
+    return rpc_api(
+        rref.owner(),
+        _invoke_func,
+        args=(rref, func_name, args, kwargs)
+    )
 
 
 class RRefProxy:

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -531,6 +531,20 @@ class RpcTest(RpcAgentTestFixture):
         dst = worker_name((self.rank + 1) % self.world_size)
         self._test_self_remote_rref_as_remote_arg(dst)
 
+    @dist_init
+    def test_rref_proxy_non_exist(self):
+        dst = worker_name((self.rank + 1) % self.world_size)
+        rref = rpc.remote(dst, my_function, args=(torch.ones(2, 2), 1, 3))
+        msg = "non_exist is not an attribute of type"
+        with self.assertRaisesRegex(ValueError, msg):
+            rref.rpc_sync().non_exist()
+
+        with self.assertRaisesRegex(ValueError, msg):
+            rref.rpc_async().non_exist()
+
+        with self.assertRaisesRegex(ValueError, msg):
+            rref.remote().non_exist()
+
     def _test_rref_proxy_tensor(self, dst):
         rref = rpc.remote(dst, my_function, args=(torch.ones(2, 2), 1, 3))
 
@@ -3035,7 +3049,7 @@ class RpcTest(RpcAgentTestFixture):
             ret = rref.remote().static_async_add(dst2, x, x, y).to_here()
             ret += rref.remote().class_async_add(dst2, x, x, y).to_here()
 
-        self.assertEqual(ret, 2* 4 * x)
+        self.assertEqual(ret, 2 * 4 * x)
 
     @dist_init
     def test_async_class_rref_proxy(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44716 Add bound method tests for async_execution with RRef helper
* **#44666 Make async_execution compatible with RRef helpers**
* #44663 Add _get_type() API to RRef

This commit uses the `RRef._get_type()` to check whether the
given function is decorated with `async_execution` and then
calls the corresponding RPC target function.

Differential Revision: [D23691989](https://our.internmc.facebook.com/intern/diff/D23691989)