### PR TITLE
qat conv_fused.py: one more patch for forward compatibility

### DIFF
--- a/torch/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/nn/intrinsic/qat/modules/conv_fused.py
@@ -146,6 +146,16 @@ class _ConvBnNd(nn.modules.conv._ConvNd):
                 if prefix + v1_name in state_dict:
                     state_dict[prefix + v2_name] = state_dict[prefix + v1_name]
                     state_dict.pop(prefix + v1_name)
+                elif prefix + v2_name in state_dict:
+                    # there was a brief period where forward compatibility
+                    # for this module was broken (between
+                    # https://github.com/pytorch/pytorch/pull/38478
+                    # and https://github.com/pytorch/pytorch/pull/38820)
+                    # and modules emitted the v2 state_dict format while
+                    # specifying that version == 1. This patches the forward
+                    # compatibility issue by allowing the v2 style entries to
+                    # be used.
+                    pass
                 elif strict:
                     missing_keys.append(prefix + v2_name)
 


### PR DESCRIPTION
Summary:
See comments inline - the FC between
https://github.com/pytorch/pytorch/pull/38478 and
https://github.com/pytorch/pytorch/pull/38820 was broken,
patching it.

Test Plan: Verified with customer hitting the issue that this fixes their issue.

Differential Revision: D23694029

