### PR TITLE
[FX][EZ] Allow constructing GraphModule with dict for root

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -512,6 +512,26 @@ class TestFX(JitTestCase):
         for s in ['args', 'kwargs', 'uses']:
             assert s in stringed
 
+    def test_construct_root_dict(self):
+        graph : torch.fx.Graph = torch.fx.Graph()
+        a : torch.fx.Node = graph.create_node('placeholder', 'x')
+        b : torch.fx.Node = graph.create_node('call_module', 'foo.bar.baz', args=(a,))
+        c : torch.fx.Node = graph.create_node('get_param', 'zip.zap.zam')
+        d : torch.fx.Node = graph.create_node('call_function', operator.add, args=(b, c))
+        graph.output(d)
+
+        linear_mod : torch.nn.Module = torch.nn.Linear(3, 4)
+        add_param : torch.Tensor = torch.rand(3, 4)
+        gm : torch.fx.GraphModule = torch.fx.GraphModule(
+            {'foo.bar.baz': linear_mod, 'zip.zap.zam' : add_param}, graph)
+
+        assert 'self.foo.bar.baz' in gm.code
+
+        x : torch.Tensor = torch.rand(3, 3)
+        out : torch.Tensor = gm(x)
+        ref_out : torch.Tensor = linear_mod(x) + add_param
+        self.assertEqual(out, ref_out)
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -88,12 +88,6 @@ def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
     *prefix, field = target.split('.')
     for item in prefix:
         t = getattr(to_module, item, None)
-        if from_obj is t:
-            # we have already installed one of its parents
-            # (e.g. target = root.linear.weight, but we have already installed root.linear)
-            # once we install a parent, we no longer need to copy the children
-            # since all the needed properties will already be present
-            return
 
         if t is None:
             t = torch.nn.Module()

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -21,7 +21,7 @@ Argument = Optional[Union[
 ]]
 
 class Node:
-    def __init__(self, graph: 'Graph', name: str, op: str, target: Target, 
+    def __init__(self, graph: 'Graph', name: str, op: str, target: Target,
                  args: Tuple[Argument, ...], kwargs: Dict[str, Argument]) -> None:
         self.graph = graph
         self.name = name  # unique name of value being created


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44679 [FX][EZ] Allow constructing GraphModule with dict for root**

When generating a GraphModule programmatically (i.e. not from symbolic_trace)(e.g. when splitting up a `GraphModule` into multiple `GraphModules`), it's pretty annoying to materialize a full Module hierarchy before instantiating the `GraphModule` just to copy over attributes into the right place. This change makes it so that `root` on the `GraphModule` constructor can take a dictionary mapping qualified names to the attributes that should be stored at those places in the GraphModule's hierarchy.

The GraphModule in the test case ends up looking like:

```
GraphModuleImpl(
  (foo): Module(
    (bar): Module(
      (baz): Linear(in_features=3, out_features=4, bias=True)
    )
  )
  (zip): Module(
    (zap): Module()
  )
)
def forward(self, x):
    foo_bar_baz = self.foo.bar.baz(x)
    zip_zap_zam = self.zip.zap.zam
    add_1 = foo_bar_baz + zip_zap_zam
    

    return add_1

```


Differential Revision: [D23696766](https://our.internmc.facebook.com/intern/diff/D23696766)