### PR TITLE
fixes lda condition for blas functions, fixes bug with beta=0 in addmv slow path

### DIFF
--- a/aten/src/ATen/native/Blas.cpp
+++ b/aten/src/ATen/native/Blas.cpp
@@ -15,7 +15,7 @@ template<typename scalar_t>
 scalar_t vdot_impl(int64_t n, scalar_t *x, int64_t incx, scalar_t *y, int64_t incy);
 
 constexpr inline bool lda_cond(int64_t m, int64_t n, int64_t lda) {
-  return n == 1 || lda > std::max<int64_t>(1L, m);
+  return n == 1 || lda >= std::max<int64_t>(1L, m);
 }
 
 Tensor &addmv_impl_cpu(Tensor& result, const Tensor &self, const Tensor &mat, const Tensor &vec, Scalar beta_, Scalar alpha_) {

--- a/aten/src/ATen/native/BlasKernel.cpp
+++ b/aten/src/ATen/native/BlasKernel.cpp
@@ -191,12 +191,15 @@ void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, scalar_t *a, int64_t
       }
     }
   } else {
-    if (beta != scalar_t(1)) scal<scalar_t>(m, beta, y, incy);
+    if (beta != scalar_t(1) && beta != scalar_t(0)) scal<scalar_t>(m, beta, y, incy);
 
     for (int64_t j = 0; j < n; j++) {
       scalar_t *column_ = a + lda * j;
       scalar_t z = alpha * x[j * incx];
       for (int64_t i = 0; i < m; i++) {
+        if (j==0 && beta==scalar_t(0)) {
+         y[i * incy] = scalar_t(0);
+        }
         y[i * incy] += z * column_[i];
       }
     }

--- a/aten/src/ATen/native/BlasKernel.cpp
+++ b/aten/src/ATen/native/BlasKernel.cpp
@@ -197,6 +197,7 @@ void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, scalar_t *a, int64_t
       scalar_t *column_ = a + lda * j;
       scalar_t z = alpha * x[j * incx];
       for (int64_t i = 0; i < m; i++) {
+        //output values are ignored if beta is 0, and set to 0, nans and infs are not propagated
         if (j==0 && beta==scalar_t(0)) {
          y[i * incy] = scalar_t(0);
         }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -449,24 +449,6 @@ class AbstractTestCases:
                                    [0, 1, 1],
                                    [1, 1, 1]]))
 
-        @slowTest
-        def test_mv(self) -> None:
-            def _test_mv(m1: torch.Tensor, v1: torch.Tensor) -> None:
-                res1 = torch.mv(m1, v1)
-                res2 = res1.clone().zero_()
-                for i, j in iter_indices(m1):
-                    res2[i] += m1[i][j] * v1[j]
-
-                self.assertEqual(res1, res2, atol=1e-5, rtol=0)
-
-            _test_mv(torch.randn(100, 100, dtype=torch.float32), torch.randn(100, dtype=torch.float32))
-            _test_mv(torch.randn(100, 100, dtype=torch.float64), torch.randn(100, dtype=torch.float64))
-            _test_mv(torch.randint(0, 100, (100, 100), dtype=torch.int32), torch.randint(0, 100, (100, ), dtype=torch.int32))
-            _test_mv(torch.randint(0, 100, (100, 100), dtype=torch.int64), torch.randint(0, 100, (100, ), dtype=torch.int64))
-            _test_mv(torch.randn(100, 100, dtype=torch.float32).bfloat16(), torch.randn(100, dtype=torch.float32).bfloat16())
-            _test_mv(torch.randn(100, 100, dtype=torch.cfloat), torch.randn(100, dtype=torch.cfloat))
-            _test_mv(torch.randn(100, 100, dtype=torch.cdouble), torch.randn(100, dtype=torch.cdouble))
-
         def test_numpy_args(self):
             x1 = torch.randn(10)
             x2 = torch.randn(10)
@@ -16418,32 +16400,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         for m in ms:
             for v in vs:
                 self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
-        # # have to use torch.randn(...).to(bfloat16) instead of
-        # # torch.randn(..., dtype=bfloat16). randn does not support
-        # # bfloat16 yet.
-        # t = torch.randn(10, device=device).to(dtype)
-        # m = torch.randn(10, 100, device=device).to(dtype)
-        # v = torch.randn(100, device=device).to(dtype)
-        # self._test_addmm_addmv(torch.addmv, t, m, v)
-
-        # # Test 0-strided
-        # t = torch.randn(1, device=device).to(dtype).expand(10)
-        # m = torch.randn(10, 1, device=device).to(dtype).expand(10, 100)
-        # v = torch.randn(100, device=device).to(dtype)
-        # self._test_addmm_addmv(torch.addmv, t, m, v)
-
-        # # Test beta=0, v=nan
-        # t = torch.full((10,), math.nan, device=device).to(dtype)
-        # m = torch.randn(10, 100, device=device).to(dtype)
-        # v = torch.randn(100, device=device).to(dtype)
-        # self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
-
-        # # Test beta=0, v=nan, 0-strided v
-        # t = torch.full((10,), math.nan, device=device).to(dtype)
-        # m = torch.randn(10, 10, device=device).to(dtype)
-        # v = torch.randn(1, device=device).to(dtype).expand(10)
-        # self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
-        # self._test_addmm_addmv(torch.addmv, t, m.t(), v, beta=0)
 
     @dtypesIfCUDA(*([torch.half, torch.float, torch.double]
                     + ([torch.bfloat16] if TEST_WITH_ROCM else [])))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16405,6 +16405,13 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         v = torch.randn(100, device=device).to(dtype)
         self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
 
+        # Test beta=0, v=nan, 0-strided v
+        t = torch.full((10,), math.nan, device=device).to(dtype)
+        m = torch.randn(10, 10, device=device).to(dtype)
+        v = torch.randn(1, device=device).to(dtype).expand(10)
+        self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
+        self._test_addmm_addmv(torch.addmv, t, m.t(), v, beta=0)
+
     @dtypesIfCUDA(*([torch.half, torch.float, torch.double]
                     + ([torch.bfloat16] if TEST_WITH_ROCM else [])))
     @dtypes(torch.float, torch.double)
@@ -18227,16 +18234,6 @@ else:
         x = (x * random.randint(10, 100)).tolist()
 
         self.compare_with_numpy(torch.nansum, np.nansum, x, device, dtype)
-
-    @onlyCUDA
-    @tf32_on_and_off(0.005)
-    def test_mv_stride_0(self, device):
-        # Reference: https://github.com/pytorch/pytorch/issues/38315
-        mat = torch.randn(2, 2, device=device)
-        vec = torch.tensor(2., device=device).expand(2)
-        mat_cpu = mat.cpu()
-        vec_cpu = vec.cpu()
-        self.assertEqual(mat @ vec, mat_cpu @ vec_cpu)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @dtypes(torch.float32, torch.float64)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16379,7 +16379,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         self.assertEqual(res1, res2)
         self.assertEqual(res1, res3)
 
-    @precisionOverride({torch.bfloat16: 1e-0, torch.float: 1e-4, torch.double: 1e-8,
+    @precisionOverride({torch.bfloat16: 1e-0, torch.half: 3e-4, torch.float: 1e-4, torch.double: 1e-8,
                         torch.cfloat: 1e-4, torch.cdouble: 1e-8})
     @dtypesIfCUDA(torch.half, torch.float, torch.double, torch.cfloat, torch.cdouble)
     @dtypes(torch.bfloat16, torch.float, torch.double, torch.cfloat, torch.cdouble)
@@ -16388,29 +16388,62 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         # have to use torch.randn(...).to(bfloat16) instead of
         # torch.randn(..., dtype=bfloat16). randn does not support
         # bfloat16 yet.
-        t = torch.randn(10, device=device).to(dtype)
-        m = torch.randn(10, 100, device=device).to(dtype)
-        v = torch.randn(100, device=device).to(dtype)
-        self._test_addmm_addmv(torch.addmv, t, m, v)
-
-        # Test 0-strided
-        t = torch.randn(1, device=device).to(dtype).expand(10)
-        m = torch.randn(10, 1, device=device).to(dtype).expand(10, 100)
-        v = torch.randn(100, device=device).to(dtype)
-        self._test_addmm_addmv(torch.addmv, t, m, v)
-
-        # Test beta=0, v=nan
+        ts = [
+            torch.randn(10, device=device).to(dtype),
+            torch.randn(1, device=device).to(dtype).expand(10),
+        ]
+        vs = [
+            torch.randn(100, device=device).to(dtype),
+            torch.ones(1, device=device).to(dtype).expand(100),  # to reduce errors for low precision
+        ]
+        ms = [
+            # 0d
+            torch.ones((), device=device).to(dtype).expand(10, 100),  # to reduce errirs for low precision
+            # 1d
+            torch.randn((1, 100), device=device).to(dtype).expand(10, 100),
+            # this initialization reduces errors for low precision for broadcasted matrices
+            torch.randint(3, (10, 1), dtype=torch.float, device=device).to(dtype).expand(10, 100),
+            torch.randint(3, (1, 10), dtype=torch.float, device=device).to(dtype).expand(100, 10).t(),
+            torch.randn((100, 1), device=device).to(dtype).expand(100, 10).t(),
+            # 2d
+            torch.randn((10, 100), device=device).to(dtype),
+            torch.randn((100, 10), device=device).to(dtype).t(),
+        ]
+        for m in ms:
+            for v in vs:
+                for t in ts:
+                    self._test_addmm_addmv(torch.addmv, t, m, v)
+        # Test beta=0, t=nan
         t = torch.full((10,), math.nan, device=device).to(dtype)
-        m = torch.randn(10, 100, device=device).to(dtype)
-        v = torch.randn(100, device=device).to(dtype)
-        self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
+        for m in ms:
+            for v in vs:
+                self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
+        # # have to use torch.randn(...).to(bfloat16) instead of
+        # # torch.randn(..., dtype=bfloat16). randn does not support
+        # # bfloat16 yet.
+        # t = torch.randn(10, device=device).to(dtype)
+        # m = torch.randn(10, 100, device=device).to(dtype)
+        # v = torch.randn(100, device=device).to(dtype)
+        # self._test_addmm_addmv(torch.addmv, t, m, v)
 
-        # Test beta=0, v=nan, 0-strided v
-        t = torch.full((10,), math.nan, device=device).to(dtype)
-        m = torch.randn(10, 10, device=device).to(dtype)
-        v = torch.randn(1, device=device).to(dtype).expand(10)
-        self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
-        self._test_addmm_addmv(torch.addmv, t, m.t(), v, beta=0)
+        # # Test 0-strided
+        # t = torch.randn(1, device=device).to(dtype).expand(10)
+        # m = torch.randn(10, 1, device=device).to(dtype).expand(10, 100)
+        # v = torch.randn(100, device=device).to(dtype)
+        # self._test_addmm_addmv(torch.addmv, t, m, v)
+
+        # # Test beta=0, v=nan
+        # t = torch.full((10,), math.nan, device=device).to(dtype)
+        # m = torch.randn(10, 100, device=device).to(dtype)
+        # v = torch.randn(100, device=device).to(dtype)
+        # self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
+
+        # # Test beta=0, v=nan, 0-strided v
+        # t = torch.full((10,), math.nan, device=device).to(dtype)
+        # m = torch.randn(10, 10, device=device).to(dtype)
+        # v = torch.randn(1, device=device).to(dtype).expand(10)
+        # self._test_addmm_addmv(torch.addmv, t, m, v, beta=0)
+        # self._test_addmm_addmv(torch.addmv, t, m.t(), v, beta=0)
 
     @dtypesIfCUDA(*([torch.half, torch.float, torch.double]
                     + ([torch.bfloat16] if TEST_WITH_ROCM else [])))


### PR DESCRIPTION
per title. If `beta=0` and slow path was taken, `nan` and `inf` in the result were not masked as is the case with other linear algebra functions. Similarly, since `mv` is implemented as `addmv` with `beta=0`, wrong results were sometimes produced for `mv` slow path. 
