### PR TITLE
Fix doc builds for bool kwargs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -389,6 +389,7 @@ def patched_make_field(self, types, domain, items, **kw):
                 typename = typename.replace('int', 'python:int')
                 typename = typename.replace('long', 'python:long')
                 typename = typename.replace('float', 'python:float')
+                typename = typename.replace('bool', 'python:bool')
                 typename = typename.replace('type', 'python:type')
                 par.extend(self.make_xrefs(self.typerolename, domain, typename,
                                            addnodes.literal_emphasis, **kw))

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -997,6 +997,8 @@ If :attr:`input` is a :math:`(b \times n \times m)` tensor, :attr:`mat2` is a
 Args:
     input (Tensor): the first batch of matrices to be multiplied
     mat2 (Tensor): the second batch of matrices to be multiplied
+
+Keyword Args:
     deterministic (bool, optional): flag to choose between a faster non-deterministic
                                     calculation, or a slower deterministic calculation.
                                     This argument is only available for sparse-dense CUDA bmm.


### PR DESCRIPTION
Fixes #43669

The bool will still link to https://docs.python.org/3/library/functions.html#bool.
Tested using bmm:
![image](https://user-images.githubusercontent.com/16063114/93156438-2ad11080-f6d6-11ea-9b81-96e02ee68d90.png)
