### PR TITLE
Convert num_kernels to int64 before calling into CUDA GET_BLOCKS

### DIFF
--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -170,7 +170,7 @@ Tensor& max_unpooling2d_forward_out_cuda(
             owidth,
             output.data_ptr<scalar_t>());
       }));
-  AT_CUDA_CHECK(cudaGetLastError()); 
+  AT_CUDA_CHECK(cudaGetLastError());
   if (self.ndimension() == 3) {
     output.resize_({numChannels, oheight, owidth});
   }
@@ -343,7 +343,7 @@ Tensor& max_unpooling3d_forward_out_cuda(
               oH,
               oW,
               offsetZ);
-          AT_CUDA_CHECK(cudaGetLastError()); 
+          AT_CUDA_CHECK(cudaGetLastError());
           totalZ -= 65535;
           offsetZ += 65535;
         }
@@ -428,7 +428,7 @@ at::Tensor& max_unpooling2d_backward_out_cuda(
   grad_input.resize_as_(self);
   grad_input.zero_();
 
-  int count = self.numel();
+  int64_t count = self.numel();
 
   AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half,
       self.scalar_type(), "max_unpooling2d_backward_kernel", ([&] {
@@ -447,7 +447,7 @@ at::Tensor& max_unpooling2d_backward_out_cuda(
             owidth,
             grad_input.data_ptr<scalar_t>());
       }));
-  AT_CUDA_CHECK(cudaGetLastError()); 
+  AT_CUDA_CHECK(cudaGetLastError());
   return grad_input;
 }
 at::Tensor max_unpooling2d_backward_cuda(

--- a/aten/src/ATen/native/cuda/vol2col.cuh
+++ b/aten/src/ATen/native/cuda/vol2col.cuh
@@ -104,7 +104,7 @@ void vol2col(
     T* data_col) {
   // We are going to launch channels * depth_col * height_col * width_col
   // kernels, each kernel responsible for copying a single-channel grid.
-  int num_kernels = channels * depth_col * height_col * width_col;
+  int64_t num_kernels = channels * depth_col * height_col * width_col;
   // Launch
   vol2col_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, stream>>>(
       num_kernels,

--- a/aten/src/ATen/native/cuda/vol2col.cuh
+++ b/aten/src/ATen/native/cuda/vol2col.cuh
@@ -104,7 +104,8 @@ void vol2col(
     T* data_col) {
   // We are going to launch channels * depth_col * height_col * width_col
   // kernels, each kernel responsible for copying a single-channel grid.
-  int64_t num_kernels = channels * depth_col * height_col * width_col;
+  // We cast an operand to int64 so that the product will not overflow
+  const auto num_kernels = static_cast<int64_t>(channels) * depth_col * height_col * width_col;
   // Launch
   vol2col_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, stream>>>(
       num_kernels,

--- a/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -68,7 +68,7 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   int depthwiseMultiplier = outputChannels / inputChannels;
 
   // One thread per output value
-  int n = THCTensor_(nElement)(state, output);
+  int64_t n = THCTensor_(nElement)(state, output);
   int blocks = GET_BLOCKS(n);
   dim3 grid(blocks);
   dim3 block(CUDA_NUM_THREADS);
@@ -151,7 +151,7 @@ void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
   THAssert(dWeight.isContiguous());
 
   // One thread per gradInput value
-  int n = THCTensor_(nElement)(state, gradInput);
+  int64_t n = THCTensor_(nElement)(state, gradInput);
   int blocks = GET_BLOCKS(n);
   dim3 grid(blocks);
   dim3 block(CUDA_NUM_THREADS);


### PR DESCRIPTION
this addresses the example int64 issue in #44472.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44688 Convert num_kernels to int64 before calling into CUDA GET_BLOCKS**

Differential Revision: [D23699819](https://our.internmc.facebook.com/intern/diff/D23699819)