### PR TITLE
Add bound method tests for async_execution with RRef helper

### DIFF
--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -135,6 +135,26 @@ def async_execution(fn):
         >>>     args=("worker2", torch.ones(2), 1, 2)
         >>> )
         >>> print(ret)  # prints tensor([4., 4.])
+
+        This decorator also works with RRef helpers, i.e., .
+        :meth:`torch.distributed.rpc.RRef.rpc_sync`,
+        :meth:`torch.distributed.rpc.RRef.rpc_async`, and
+        :meth:`torch.distributed.rpc.RRef.remote`.
+
+        >>> from torch.distributed import rpc
+        >>>
+        >>> # reuse the AsyncExecutionClass class above
+        >>> rref = rpc.remote("worker1", AsyncExecutionClass)
+        >>> ret = rref.rpc_sync().static_async_add("worker2", torch.ones(2), 1, 2)
+        >>> print(ret)  # prints tensor([4., 4.])
+        >>>
+        >>> rref = rpc.remote("worker1", AsyncExecutionClass)
+        >>> ret = rref.rpc_async().static_async_add("worker2", torch.ones(2), 1, 2).wait()
+        >>> print(ret)  # prints tensor([4., 4.])
+        >>>
+        >>> rref = rpc.remote("worker1", AsyncExecutionClass)
+        >>> ret = rref.remote().static_async_add("worker2", torch.ones(2), 1, 2).to_here()
+        >>> print(ret)  # prints tensor([4., 4.])
     """
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -448,6 +448,12 @@ class AsyncExecutionClass:
         )
         return ret_fut
 
+    @rpc.functions.async_execution
+    def bound_async_add(self, to, x, y, z):
+        return rpc.rpc_async(to, torch.add, args=(x, y)).then(
+            lambda fut: fut.wait() + z
+        )
+
 
 def return_future():
     return torch.futures.Future()
@@ -3042,14 +3048,17 @@ class RpcTest(RpcAgentTestFixture):
         if mode == RPCExecMode.SYNC:
             ret = rref.rpc_sync().static_async_add(dst2, x, x, y)
             ret += rref.rpc_sync().class_async_add(dst2, x, x, y)
+            ret += rref.rpc_sync().bound_async_add(dst2, x, x, y)
         elif mode == RPCExecMode.ASYNC:
             ret = rref.rpc_async().static_async_add(dst2, x, x, y).wait()
             ret += rref.rpc_async().class_async_add(dst2, x, x, y).wait()
+            ret += rref.rpc_async().bound_async_add(dst2, x, x, y).wait()
         elif mode == RPCExecMode.REMOTE:
             ret = rref.remote().static_async_add(dst2, x, x, y).to_here()
             ret += rref.remote().class_async_add(dst2, x, x, y).to_here()
+            ret += rref.remote().bound_async_add(dst2, x, x, y).to_here()
 
-        self.assertEqual(ret, 2 * 4 * x)
+        self.assertEqual(ret, 3 * 4 * x)
 
     @dist_init
     def test_async_class_rref_proxy(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44716 Add bound method tests for async_execution with RRef helper**
* #44666 Make async_execution compatible with RRef helpers
* #44663 Add _get_type() API to RRef

Differential Revision: [D23707326](https://our.internmc.facebook.com/intern/diff/D23707326)