### PR TITLE
.circleci: Switch to dynamic MAX_JOBS

### DIFF
--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -7,7 +7,7 @@ source /env
 # Defaults here so they can be changed in one place
 # This script is run inside Docker.2XLarge+ container that has 20 CPU cores
 # But ncpu will return total number of cores on the system
-export MAX_JOBS=18
+export MAX_JOBS=$(( $(nproc) - 2 ))
 
 # Parse the parameters
 if [[ "$PACKAGE_TYPE" == 'conda' ]]; then

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -5,9 +5,7 @@ set -eux -o pipefail
 source /env
 
 # Defaults here so they can be changed in one place
-# This script is run inside Docker.2XLarge+ container that has 20 CPU cores
-# But ncpu will return total number of cores on the system
-export MAX_JOBS=$(( $(nproc) - 2 ))
+export MAX_JOBS=${MAX_JOBS:-$(( $(nproc) - 2 ))}
 
 # Parse the parameters
 if [[ "$PACKAGE_TYPE" == 'conda' ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44729 .circleci: Switch to dynamic MAX_JOBS**

Switches our MAX_JOBS from a hardcoded value to a more dynamic value so
that we can always utilize all of the core that are available to us

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D23759643](https://our.internmc.facebook.com/intern/diff/D23759643)