### PR TITLE
[NNC] Fix masking for all block and thread dimensions in CudaCodeGen

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -432,8 +432,15 @@ namespace jit {
   _(CudaHalfSupport)                       \
   _(CudaPrioritizeDependents)              \
   _(CudaMaskBlockDim)                      \
-  _(CudaMaskThreadDim)
-// _(CudaMaskBlockAndThreadDim)
+  _(CudaMaskThreadDim)                     \
+  _(CudaMaskMultiBlockDim)                 \
+  _(CudaMaskBlockAndThreadDim)             \
+  _(CudaMaskMultiDim)                      \
+  _(CudaMaskMultiDimSymbolic)              \
+  _(CudaMaskCompoundInnerLoop)             \
+  _(CudaMaskInnerLoopOneBlock)             \
+  _(CudaMaskMultiDimMultiAxis)             \
+  _(CudaMaskMultiDimMultiLevel)
 
 #define DECLARE_TENSOREXPR_TEST(name) void test##name();
 TH_FORALL_TENSOREXPR_TESTS(DECLARE_TENSOREXPR_TEST)

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -63,7 +63,12 @@ class CudaAnalysis : public IRVisitor {
   std::vector<const Expr*> gpu_thread_extents_;
 };
 
-// An IRMutator that replaces binding loop options with Cuda metavars.
+// An IRMutator that replaces binding loop options with Cuda metavars, and masks
+// statements blocks which should execute with less reach than the launch
+// parameter extent.
+//
+// We do this by segmenting each block into chunks which should have the same
+// execution parameters, then if those params differ from the max mask each dim.
 class GPUMetaVarRewriter : public IRMutator {
  public:
   explicit GPUMetaVarRewriter(const CudaAnalysis* cuda_analysis)
@@ -74,6 +79,9 @@ class GPUMetaVarRewriter : public IRMutator {
     gpu_thread_vars_ = {new Var("threadIdx.x", kInt),
                         new Var("threadIdx.y", kInt),
                         new Var("threadIdx.z", kInt)};
+
+    current_block_reach_ = {new IntImm(1), new IntImm(1), new IntImm(1)};
+    current_thread_reach_ = {new IntImm(1), new IntImm(1), new IntImm(1)};
   }
 
   Stmt* mutate(const For* v) override;
@@ -96,8 +104,39 @@ class GPUMetaVarRewriter : public IRMutator {
   }
 
  private:
+  // When processing a block, stores the contents of each sub-segment.
+  class Segment {
+   public:
+    void reset(bool mask) {
+      stmts_.clear();
+      mask_ = mask;
+    }
+
+    bool empty() const {
+      return stmts_.empty();
+    }
+
+    std::vector<Stmt*>& stmts() {
+      return stmts_;
+    }
+    bool mask() {
+      return mask_;
+    }
+
+   private:
+    std::vector<Stmt*> stmts_;
+    bool mask_{true};
+  };
+
+  // Returns true if the current execution scope is equivalent to the launch
+  // parameters.
+  bool isFullExtent();
+
   std::vector<const Var*> gpu_block_vars_;
   std::vector<const Var*> gpu_thread_vars_;
+
+  std::vector<const Expr*> current_block_reach_;
+  std::vector<const Expr*> current_thread_reach_;
 
   bool need_sync_ = false;
   const Expr* last_thread_dim_ = nullptr;

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -594,6 +594,14 @@ class TORCH_API CompareSelect : public ExprNode<CompareSelect> {
     }
   }
 
+  CompareSelect(const Expr* lhs, const Expr* rhs, CompareSelectOperation cmp_op)
+      : ExprNodeBase(kInt),
+        lhs_(lhs),
+        rhs_(rhs),
+        ret_val1_(new IntImm(1)),
+        ret_val2_(new IntImm(0)),
+        compare_op_(cmp_op) {}
+
  private:
   const Expr* lhs_;
   const Expr* rhs_;


### PR DESCRIPTION
Unifies a number of partial solutions to the thread and block dimension extent masking, including the NoThreadIdxWriter and my last fix #44325. The NoThreadIdxWriter is gone in favour of tracking the current loop extents and masking any statements that have a lower rank than the launch parameters in any Block or Thread dimension, which handles both the "no" and "smaller" axis binding cases.

For example it will transform the following:
```
for i in 0..10 // blockIdx.x
  for j in 0..10 // threadIdx.x
    do thing(i, j);
  for k in 0..5 // threadIdx.x
    do other thing(i, k);
```

Into:
```
do thing(blockIdx.x, threadIdx.x);
if (threadIdx.x < 5) {
  do other thing(blockIdx.x, threadIdx.x);
}
```

And handle the case where statements are not bound by any axis, eg.
```
do outer thing;
for i in 0..10 // blockIdx.x
  for j in 0..10 // threadIdx.x
    do thing(i, j);
  do other thing(i);
```

will become:

```
if (blockIdx.x < 1) {
  if (threadIdx.x < 1) {
    do outer thing;
  }
}
syncthreads();
do thing(blockIdx.x, threadIdx.x);
syncthreads();
if (threadIdx.x < 1) {
  do other thing(blockIdx.x);
}
```

