### PR TITLE
Always use NewModuleTest instead of ModuleTest.

### DIFF
--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -26,9 +26,9 @@ class TestCppApiParity(common.TestCase):
 expected_test_params_dicts = []
 
 for test_params_dicts, test_instance_class in [
-    (sample_module.module_tests, common_nn.ModuleTest),
+    (sample_module.module_tests, common_nn.NewModuleTest),
     (sample_functional.functional_tests, common_nn.NewModuleTest),
-    (common_nn.module_tests, common_nn.ModuleTest),
+    (common_nn.module_tests, common_nn.NewModuleTest),
     (common_nn.new_module_tests, common_nn.NewModuleTest),
     (common_nn.criterion_tests, common_nn.CriterionTest),
 ]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44786 Stop using check_criterion_jacobian.
* #44783 Stop ignoring errors in cuda nn module tests.
* **#44745 Always use NewModuleTest instead of ModuleTest.**

Much like CriterionTest, NewCriterionTest these are outdated formulations and we should just use the new one.

Differential Revision: [D23717808](https://our.internmc.facebook.com/intern/diff/D23717808)