### PR TITLE
[quant][qat] Ensure observers and fq modules are scriptable

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -52,6 +52,7 @@ from torch.testing._internal.common_quantization import NodeSpec as ns
 from torch.testing._internal.common_quantization import (
     test_only_eval_fn,
 )
+from torch.testing import FileCheck
 
 import itertools
 import operator
@@ -365,6 +366,44 @@ class TestQuantizeFx(QuantizationTestCase):
         for name, module in m.named_modules():
             self.assertFalse(hasattr(module, 'qconfig'),
                              'qconfig is not removed for ' + name)
+
+    def test_qat_and_script(self):
+        class TwoLayerLinear(nn.Module):
+            def __init__(self):
+                super(TwoLayerLinear, self).__init__()
+                self.fc1 = nn.Linear(5, 5)
+                self.fc2 = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.fc1(x)
+                return self.fc2(x)
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.subm = TwoLayerLinear()
+                self.fc = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.subm(x)
+                x = self.fc(x)
+                return x
+
+        model = Model()
+        qengine = torch.backends.quantized.engine
+        qconfig_dict = {'': torch.quantization.get_default_qat_qconfig(qengine)}
+
+        # symbolically trace
+        model = symbolic_trace(model)
+        model = prepare_fx(model, qconfig_dict)
+
+        # ensure scripting works
+        scripted = torch.jit.script(model)
+        # run one round to make sure model runs
+        x = torch.randn(5, 5)
+        scripted(x)
+        FileCheck().check_count('FakeQuantize = prim::GetAttr[name="activation_post_process', 4, exactly=True) \
+                   .run(scripted.graph)
 
 class TestQuantizeFxOps(QuantizationTestCase):
     """Unit tests for individual ops

--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -19,6 +19,7 @@ from torch.quantization import (
     convert_static_fx,
     quantize_static_fx,
     quantize_dynamic_fx,
+    prepare_qat_fx,
 )
 
 from torch.quantization import (
@@ -395,7 +396,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         # symbolically trace
         model = symbolic_trace(model)
-        model = prepare_fx(model, qconfig_dict)
+        model = prepare_qat_fx(model, qconfig_dict)
 
         # ensure scripting works
         scripted = torch.jit.script(model)

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -64,7 +64,7 @@ class FakeQuantize(Module):
 
     @torch.jit.export
     def enable_fake_quant(self, enabled=True):
-        # type: (bool)
+        # type: (bool) -> None
         self.fake_quant_enabled[0] = 1 if enabled else 0
 
     @torch.jit.export
@@ -73,7 +73,7 @@ class FakeQuantize(Module):
 
     @torch.jit.export
     def enable_observer(self, enabled=True):
-        # type: (bool)
+        # type: (bool) -> None
         self.observer_enabled[0] = 1 if enabled else 0
 
     @torch.jit.export

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -64,23 +64,21 @@ class FakeQuantize(Module):
 
     @torch.jit.export
     def enable_fake_quant(self, enabled=True):
-        # type: (bool) -> FakeQuantize
+        # type: (bool)
         self.fake_quant_enabled[0] = 1 if enabled else 0
-        return self
 
     @torch.jit.export
     def disable_fake_quant(self):
-        return self.enable_fake_quant(False)
+        self.enable_fake_quant(False)
 
     @torch.jit.export
     def enable_observer(self, enabled=True):
-        # type: (bool) -> FakeQuantize
+        # type: (bool)
         self.observer_enabled[0] = 1 if enabled else 0
-        return self
 
     @torch.jit.export
     def disable_observer(self):
-        return self.enable_observer(False)
+        self.enable_observer(False)
 
     @torch.jit.export
     def calculate_qparams(self):

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -602,10 +602,10 @@ class PerChannelMinMaxObserver(_ObserverBase):
         max_vals = self.max_vals
         x_dim = x.size()
 
-        new_axis_list = list(range(len(x_dim)))
+        new_axis_list = [i for i in range(len(x_dim))]  # noqa: C416
         new_axis_list[self.ch_axis] = 0
         new_axis_list[0] = self.ch_axis
-        y = x.permute(tuple(new_axis_list))
+        y = x.permute(new_axis_list)
         # Need to match dtype of min/max because the updates to buffers
         # are done in place and types need to match for comparisons
         y = y.to(self.min_vals.dtype)
@@ -691,10 +691,10 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         max_vals = self.max_vals
         x_dim = x.size()
 
-        new_axis_list = list(range(len(x_dim)))
+        new_axis_list = [i for i in range(len(x_dim))]  # noqa: C416
         new_axis_list[self.ch_axis] = 0
         new_axis_list[0] = self.ch_axis
-        y = x.permute(tuple(new_axis_list))
+        y = x.permute(new_axis_list)
         y = torch.flatten(y, start_dim=1)
         if min_vals.numel() == 0 or max_vals.numel() == 0:
             min_vals, max_vals = torch._aminmax(y, 1)

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -595,7 +595,6 @@ class PerChannelMinMaxObserver(_ObserverBase):
     def forward(self, x_orig):
         return self._forward(x_orig)
 
-    @torch.jit.ignore
     def _forward(self, x_orig):
         x = x_orig.detach()  # avoid keeping autograd tape
         min_vals = self.min_vals


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44773 [quant][qat] Ensure fake_quant and observer can be disabled on scriptmodule
* #44765 [quant][fx] Add node name as prefix to observer module name
* **#44749 [quant][qat] Ensure observers and fq modules are scriptable**

Summary:
Ensure fx module is scriptable after calling prepare_qat on it

Test Plan:
python test/test_quantization.py TestQuantizeFx.test_qat_and_script

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23718380](https://our.internmc.facebook.com/intern/diff/D23718380)