### PR TITLE
Vectorize int8_t on CPU

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -503,6 +503,256 @@ public:
 };
 
 template <>
+class Vec256<int8_t> : public Vec256i {
+private:
+  static const Vec256<int8_t> ones;
+public:
+  using value_type = int8_t;
+  static constexpr int size() {
+    return 32;
+  }
+  using Vec256i::Vec256i;
+  Vec256() {}
+  Vec256(int8_t v) { values = _mm256_set1_epi8(v); }
+  Vec256(int8_t val1, int8_t val2, int8_t val3, int8_t val4,
+         int8_t val5, int8_t val6, int8_t val7, int8_t val8,
+         int8_t val9, int8_t val10, int8_t val11, int8_t val12,
+         int8_t val13, int8_t val14, int8_t val15, int8_t val16,
+         int8_t val17, int8_t val18, int8_t val19, int8_t val20,
+         int8_t val21, int8_t val22, int8_t val23, int8_t val24,
+         int8_t val25, int8_t val26, int8_t val27, int8_t val28,
+         int8_t val29, int8_t val30, int8_t val31, int8_t val32) {
+    values = _mm256_setr_epi8(val1, val2, val3, val4, val5, val6, val7, val8,
+                              val9, val10, val11, val12, val13, val14, val15, val16,
+                              val17, val18, val19, val20, val21, val22, val23, val24,
+                              val25, val26, val27, val28, val29, val30, val31, val32);
+  }
+  template <int64_t mask>
+  static Vec256<int8_t> blend(Vec256<int8_t> a, Vec256<int8_t> b) {
+    __at_align32__ int8_t tmp_values[size()];
+    a.store(tmp_values);
+    if (mask & 0x01)
+      tmp_values[0] = _mm256_extract_epi8(b.values, 0);
+    if (mask & 0x02)
+      tmp_values[1] = _mm256_extract_epi8(b.values, 1);
+    if (mask & 0x04)
+      tmp_values[2] = _mm256_extract_epi8(b.values, 2);
+    if (mask & 0x08)
+      tmp_values[3] = _mm256_extract_epi8(b.values, 3);
+    if (mask & 0x10)
+      tmp_values[4] = _mm256_extract_epi8(b.values, 4);
+    if (mask & 0x20)
+      tmp_values[5] = _mm256_extract_epi8(b.values, 5);
+    if (mask & 0x40)
+      tmp_values[6] = _mm256_extract_epi8(b.values, 6);
+    if (mask & 0x80)
+      tmp_values[7] = _mm256_extract_epi8(b.values, 7);
+    if (mask & 0x100)
+      tmp_values[8] = _mm256_extract_epi8(b.values, 8);
+    if (mask & 0x200)
+      tmp_values[9] = _mm256_extract_epi8(b.values, 9);
+    if (mask & 0x400)
+      tmp_values[10] = _mm256_extract_epi8(b.values, 10);
+    if (mask & 0x800)
+      tmp_values[11] = _mm256_extract_epi8(b.values, 11);
+    if (mask & 0x1000)
+      tmp_values[12] = _mm256_extract_epi8(b.values, 12);
+    if (mask & 0x2000)
+      tmp_values[13] = _mm256_extract_epi8(b.values, 13);
+    if (mask & 0x4000)
+      tmp_values[14] = _mm256_extract_epi8(b.values, 14);
+    if (mask & 0x8000)
+      tmp_values[15] = _mm256_extract_epi8(b.values, 15);
+    if (mask & 0x010000)
+      tmp_values[16] = _mm256_extract_epi8(b.values, 16);
+    if (mask & 0x020000)
+      tmp_values[17] = _mm256_extract_epi8(b.values, 17);
+    if (mask & 0x040000)
+      tmp_values[18] = _mm256_extract_epi8(b.values, 18);
+    if (mask & 0x080000)
+      tmp_values[19] = _mm256_extract_epi8(b.values, 19);
+    if (mask & 0x100000)
+      tmp_values[20] = _mm256_extract_epi8(b.values, 20);
+    if (mask & 0x200000)
+      tmp_values[21] = _mm256_extract_epi8(b.values, 21);
+    if (mask & 0x400000)
+      tmp_values[22] = _mm256_extract_epi8(b.values, 22);
+    if (mask & 0x800000)
+      tmp_values[23] = _mm256_extract_epi8(b.values, 23);
+    if (mask & 0x1000000)
+      tmp_values[24] = _mm256_extract_epi8(b.values, 24);
+    if (mask & 0x2000000)
+      tmp_values[25] = _mm256_extract_epi8(b.values, 25);
+    if (mask & 0x4000000)
+      tmp_values[26] = _mm256_extract_epi8(b.values, 26);
+    if (mask & 0x8000000)
+      tmp_values[27] = _mm256_extract_epi8(b.values, 27);
+    if (mask & 0x10000000)
+      tmp_values[28] = _mm256_extract_epi8(b.values, 28);
+    if (mask & 0x20000000)
+      tmp_values[29] = _mm256_extract_epi8(b.values, 29);
+    if (mask & 0x40000000)
+      tmp_values[30] = _mm256_extract_epi8(b.values, 30);
+    if (mask & 0x80000000)
+      tmp_values[31] = _mm256_extract_epi8(b.values, 31);
+    return loadu(tmp_values);
+  }
+  static Vec256<int8_t> blendv(const Vec256<int8_t>& a, const Vec256<int8_t>& b,
+                               const Vec256<int8_t>& mask) {
+    return _mm256_blendv_epi8(a.values, b.values, mask.values);
+  }
+  template <typename step_t>
+  static Vec256<int8_t> arange(int8_t base = 0, step_t step = static_cast<step_t>(1)) {
+    return Vec256<int8_t>(
+      base,             base +      step, base +  2 * step, base +  3 * step,
+      base +  4 * step, base +  5 * step, base +  6 * step, base +  7 * step,
+      base +  8 * step, base +  9 * step, base + 10 * step, base + 11 * step,
+      base + 12 * step, base + 13 * step, base + 14 * step, base + 15 * step,
+      base + 16 * step, base + 17 * step, base + 18 * step, base + 19 * step,
+      base + 20 * step, base + 21 * step, base + 22 * step, base + 23 * step,
+      base + 24 * step, base + 25 * step, base + 26 * step, base + 27 * step,
+      base + 28 * step, base + 29 * step, base + 30 * step, base + 31 * step);
+  }
+  static Vec256<int8_t>
+  set(Vec256<int8_t> a, Vec256<int8_t> b, int8_t count = size()) {
+    switch (count) {
+      case 0:
+        return a;
+      case 1:
+        return blend<0x1>(a, b);
+      case 2:
+        return blend<0x3>(a, b);
+      case 3:
+        return blend<0x7>(a, b);
+      case 4:
+        return blend<0xF>(a, b);
+      case 5:
+        return blend<0x1F>(a, b);
+      case 6:
+        return blend<0x3F>(a, b);
+      case 7:
+        return blend<0x7F>(a, b);
+      case 8:
+        return blend<0xFF>(a, b);
+      case 9:
+        return blend<0x1FF>(a, b);
+      case 10:
+        return blend<0x3FF>(a, b);
+      case 11:
+        return blend<0x7FF>(a, b);
+      case 12:
+        return blend<0xFFF>(a, b);
+      case 13:
+        return blend<0x1FFF>(a, b);
+      case 14:
+        return blend<0x3FFF>(a, b);
+      case 15:
+        return blend<0x7FFF>(a, b);
+      case 16:
+        return blend<0xFFFF>(a, b);
+      case 17:
+        return blend<0x1FFFF>(a, b);
+      case 18:
+        return blend<0x3FFFF>(a, b);
+      case 19:
+        return blend<0x7FFFF>(a, b);
+      case 20:
+        return blend<0xFFFFF>(a, b);
+      case 21:
+        return blend<0x1FFFFF>(a, b);
+      case 22:
+        return blend<0x3FFFFF>(a, b);
+      case 23:
+        return blend<0x7FFFFF>(a, b);
+      case 24:
+        return blend<0xFFFFFF>(a, b);
+      case 25:
+        return blend<0x1FFFFFF>(a, b);
+      case 26:
+        return blend<0x3FFFFFF>(a, b);
+      case 27:
+        return blend<0x7FFFFFF>(a, b);
+      case 28:
+        return blend<0xFFFFFFF>(a, b);
+      case 29:
+        return blend<0x1FFFFFFF>(a, b);
+      case 30:
+        return blend<0x3FFFFFFF>(a, b);
+      case 31:
+        return blend<0x7FFFFFFF>(a, b);
+    }
+    return b;
+  }
+  static Vec256<int8_t> loadu(const void* ptr) {
+    return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
+  }
+  static Vec256<int8_t> loadu(const void* ptr, int8_t count) {
+    __at_align32__ int8_t tmp_values[size()];
+    // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
+    // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
+    // instructions while a loop would be compiled to one instruction.
+    for (size_t i = 0; i < size(); ++ i) {
+      tmp_values[i] = 0;
+    }
+    std::memcpy(tmp_values, ptr, count * sizeof(int8_t));
+    return loadu(tmp_values);
+  }
+  void store(void* ptr, int count = size()) const {
+    if (count == size()) {
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
+    } else if (count > 0) {
+      __at_align32__ int8_t tmp_values[size()];
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
+      std::memcpy(ptr, tmp_values, count * sizeof(int8_t));
+    }
+  }
+  const int8_t& operator[](int idx) const  = delete;
+  int8_t& operator[](int idx)  = delete;
+  Vec256<int8_t> abs() const {
+    return _mm256_abs_epi8(values);
+  }
+  Vec256<int8_t> angle() const {
+    return _mm256_set1_epi8(0);
+  }
+  Vec256<int8_t> real() const {
+    return *this;
+  }
+  Vec256<int8_t> imag() const {
+    return _mm256_set1_epi8(0);
+  }
+  Vec256<int8_t> conj() const {
+    return *this;
+  }
+  Vec256<int8_t> frac() const;
+  Vec256<int8_t> neg() const;
+  Vec256<int8_t> operator==(const Vec256<int8_t>& other) const {
+    return _mm256_cmpeq_epi8(values, other.values);
+  }
+  Vec256<int8_t> operator!=(const Vec256<int8_t>& other) const {
+    return invert(_mm256_cmpeq_epi8(values, other.values));
+  }
+  Vec256<int8_t> operator<(const Vec256<int8_t>& other) const {
+    return _mm256_cmpgt_epi8(other.values, values);
+  }
+  Vec256<int8_t> operator<=(const Vec256<int8_t>& other) const {
+    return invert(_mm256_cmpgt_epi8(values, other.values));
+  }
+  Vec256<int8_t> operator>(const Vec256<int8_t>& other) const {
+    return _mm256_cmpgt_epi8(values, other.values);
+  }
+  Vec256<int8_t> operator>=(const Vec256<int8_t>& other) const {
+    return invert(_mm256_cmpgt_epi8(other.values, values));
+  }
+
+  Vec256<int8_t> eq(const Vec256<int8_t>& other) const;
+  Vec256<int8_t> ne(const Vec256<int8_t>& other) const;
+  Vec256<int8_t> gt(const Vec256<int8_t>& other) const;
+  Vec256<int8_t> ge(const Vec256<int8_t>& other) const;
+  Vec256<int8_t> lt(const Vec256<int8_t>& other) const;
+  Vec256<int8_t> le(const Vec256<int8_t>& other) const;
+};
+
+template <>
 Vec256<int64_t> inline operator+(const Vec256<int64_t>& a, const Vec256<int64_t>& b) {
   return _mm256_add_epi64(a, b);
 }
@@ -515,6 +765,11 @@ Vec256<int32_t> inline operator+(const Vec256<int32_t>& a, const Vec256<int32_t>
 template <>
 Vec256<int16_t> inline operator+(const Vec256<int16_t>& a, const Vec256<int16_t>& b) {
   return _mm256_add_epi16(a, b);
+}
+
+template <>
+Vec256<int8_t> inline operator+(const Vec256<int8_t>& a, const Vec256<int8_t>& b) {
+  return _mm256_add_epi8(a, b);
 }
 
 template <>
@@ -532,6 +787,11 @@ Vec256<int16_t> inline operator-(const Vec256<int16_t>& a, const Vec256<int16_t>
   return _mm256_sub_epi16(a, b);
 }
 
+template <>
+Vec256<int8_t> inline operator-(const Vec256<int8_t>& a, const Vec256<int8_t>& b) {
+  return _mm256_sub_epi8(a, b);
+}
+
 // Negation. Defined here so we can utilize operator-
 Vec256<int64_t> Vec256<int64_t>::neg() const {
   return Vec256<int64_t>(0) - *this;
@@ -543,6 +803,10 @@ Vec256<int32_t> Vec256<int32_t>::neg() const {
 
 Vec256<int16_t> Vec256<int16_t>::neg() const {
   return Vec256<int16_t>(0) - *this;
+}
+
+Vec256<int8_t> Vec256<int8_t>::neg() const {
+  return Vec256<int8_t>(0) - *this;
 }
 
 // Emulate operations with no native 64-bit support in avx,
@@ -613,6 +877,24 @@ Vec256<int16_t> inline operator*(const Vec256<int16_t>& a, const Vec256<int16_t>
   return _mm256_mullo_epi16(a, b);
 }
 
+template <typename T, typename Op>
+Vec256<T> inline int_elementwise_binary_256(const Vec256<T>& a, const Vec256<T>& b, Op op) {
+  T values_a[Vec256<T>::size()];
+  T values_b[Vec256<T>::size()];
+  a.store(values_a);
+  b.store(values_b);
+  for (int i = 0; i != Vec256<T>::size(); i++) {
+    values_a[i] = op(values_a[i], values_b[i]);
+  }
+  return Vec256<T>::loadu(values_a);
+}
+
+template <>
+Vec256<int8_t> inline operator*(const Vec256<int8_t>& a, const Vec256<int8_t>& b) {
+  // We don't have an instruction for multiplying int8_t
+  return int_elementwise_binary_256(a, b, std::multiplies<int8_t>());
+}
+
 template <>
 Vec256<int64_t> inline minimum(const Vec256<int64_t>& a, const Vec256<int64_t>& b) {
   return emulate(a, b, [](int64_t a_point, int64_t b_point) {return std::min(a_point, b_point);});
@@ -626,6 +908,11 @@ Vec256<int32_t> inline minimum(const Vec256<int32_t>& a, const Vec256<int32_t>& 
 template <>
 Vec256<int16_t> inline minimum(const Vec256<int16_t>& a, const Vec256<int16_t>& b) {
   return _mm256_min_epi16(a, b);
+}
+
+template <>
+Vec256<int8_t> inline minimum(const Vec256<int8_t>& a, const Vec256<int8_t>& b) {
+  return _mm256_min_epi8(a, b);
 }
 
 template <>
@@ -644,6 +931,11 @@ Vec256<int16_t> inline maximum(const Vec256<int16_t>& a, const Vec256<int16_t>& 
 }
 
 template <>
+Vec256<int8_t> inline maximum(const Vec256<int8_t>& a, const Vec256<int8_t>& b) {
+  return _mm256_max_epi8(a, b);
+}
+
+template <>
 Vec256<int64_t> inline clamp(const Vec256<int64_t>& a, const Vec256<int64_t>& min_val, const Vec256<int64_t>& max_val) {
   return emulate(a, min_val, max_val, [](int64_t a_point, int64_t min_point, int64_t max_point) {return std::min(max_point, std::max(a_point, min_point));});
 }
@@ -656,6 +948,11 @@ Vec256<int32_t> inline clamp(const Vec256<int32_t>& a, const Vec256<int32_t>& mi
 template <>
 Vec256<int16_t> inline clamp(const Vec256<int16_t>& a, const Vec256<int16_t>& min_val, const Vec256<int16_t>& max_val) {
   return _mm256_min_epi16(max_val, _mm256_max_epi16(a, min_val));
+}
+
+template <>
+Vec256<int8_t> inline clamp(const Vec256<int8_t>& a, const Vec256<int8_t>& min_val, const Vec256<int8_t>& max_val) {
+  return _mm256_min_epi8(max_val, _mm256_max_epi8(a, min_val));
 }
 
 template <>
@@ -674,6 +971,11 @@ Vec256<int16_t> inline clamp_max(const Vec256<int16_t>& a, const Vec256<int16_t>
 }
 
 template <>
+Vec256<int8_t> inline clamp_max(const Vec256<int8_t>& a, const Vec256<int8_t>& max_val) {
+  return _mm256_min_epi8(max_val, a);
+}
+
+template <>
 Vec256<int64_t> inline clamp_min(const Vec256<int64_t>& a, const Vec256<int64_t>& min_val) {
   return emulate(a, min_val, [](int64_t a_point, int64_t min_point) {return std::max(min_point, a_point);});
 }
@@ -686,6 +988,11 @@ Vec256<int32_t> inline clamp_min(const Vec256<int32_t>& a, const Vec256<int32_t>
 template <>
 Vec256<int16_t> inline clamp_min(const Vec256<int16_t>& a, const Vec256<int16_t>& min_val) {
   return _mm256_max_epi16(min_val, a);
+}
+
+template <>
+Vec256<int8_t> inline clamp_min(const Vec256<int8_t>& a, const Vec256<int8_t>& min_val) {
+  return _mm256_max_epi8(min_val, a);
 }
 
 template<typename T>
@@ -703,18 +1010,6 @@ Vec256<int32_t> inline convert_to_int32<uint8_t>(const uint8_t* ptr) {
   return _mm256_cvtepu8_epi32(_mm_loadl_epi64(reinterpret_cast<const __m128i*>(ptr)));
 }
 
-template <typename T, typename Op>
-Vec256<T> inline int_elementwise_binary_256(const Vec256<T>& a, const Vec256<T>& b, Op op) {
-  T values_a[Vec256<T>::size()];
-  T values_b[Vec256<T>::size()];
-  a.store(values_a);
-  b.store(values_b);
-  for (int i = 0; i != Vec256<T>::size(); i++) {
-    values_a[i] = op(values_a[i], values_b[i]);
-  }
-  return Vec256<T>::loadu(values_a);
-}
-
 template <>
 Vec256<int64_t> inline operator/(const Vec256<int64_t>& a, const Vec256<int64_t>& b) {
   return int_elementwise_binary_256(a, b, std::divides<int64_t>());
@@ -726,6 +1021,10 @@ Vec256<int32_t> inline operator/(const Vec256<int32_t>& a, const Vec256<int32_t>
 template <>
 Vec256<int16_t> inline operator/(const Vec256<int16_t>& a, const Vec256<int16_t>& b) {
   return int_elementwise_binary_256(a, b, std::divides<int16_t>());
+}
+template <>
+Vec256<int8_t> inline operator/(const Vec256<int8_t>& a, const Vec256<int8_t>& b) {
+  return int_elementwise_binary_256(a, b, std::divides<int8_t>());
 }
 
 template<class T, typename std::enable_if_t<std::is_base_of<Vec256i, Vec256<T>>::value, int> = 0>
@@ -811,6 +1110,30 @@ Vec256<int16_t> Vec256<int16_t>::lt(const Vec256<int16_t>& other) const {
 
 Vec256<int16_t> Vec256<int16_t>::le(const Vec256<int16_t>& other) const {
   return (*this <= other) & Vec256<int16_t>(1);
+}
+
+Vec256<int8_t> Vec256<int8_t>::eq(const Vec256<int8_t>& other) const {
+  return (*this == other) & Vec256<int8_t>(1);
+}
+
+Vec256<int8_t> Vec256<int8_t>::ne(const Vec256<int8_t>& other) const {
+  return (*this != other) & Vec256<int8_t>(1);
+}
+
+Vec256<int8_t> Vec256<int8_t>::gt(const Vec256<int8_t>& other) const {
+  return (*this > other) & Vec256<int8_t>(1);
+}
+
+Vec256<int8_t> Vec256<int8_t>::ge(const Vec256<int8_t>& other) const {
+  return (*this >= other) & Vec256<int8_t>(1);
+}
+
+Vec256<int8_t> Vec256<int8_t>::lt(const Vec256<int8_t>& other) const {
+  return (*this < other) & Vec256<int8_t>(1);
+}
+
+Vec256<int8_t> Vec256<int8_t>::le(const Vec256<int8_t>& other) const {
+  return (*this <= other) & Vec256<int8_t>(1);
 }
 
 #endif

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -691,7 +691,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (size_t i = 0; i < size(); ++ i) {
+    for (size_t i = 0; i < size(); ++i) {
       tmp_values[i] = 0;
     }
     std::memcpy(tmp_values, ptr, count * sizeof(int8_t));

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -879,8 +879,8 @@ Vec256<int16_t> inline operator*(const Vec256<int16_t>& a, const Vec256<int16_t>
 
 template <typename T, typename Op>
 Vec256<T> inline int_elementwise_binary_256(const Vec256<T>& a, const Vec256<T>& b, Op op) {
-  T values_a[Vec256<T>::size()];
-  T values_b[Vec256<T>::size()];
+  __at_align32__ T values_a[Vec256<T>::size()];
+  __at_align32__ T values_b[Vec256<T>::size()];
   a.store(values_a);
   b.store(values_b);
   for (int i = 0; i != Vec256<T>::size(); i++) {


### PR DESCRIPTION
int8_t is not vectorized in vec256_int.h. This PR adds vectorization for
int8_t. As pointed out in #43033, this is an important type for vectorization because 
a lot of images are loaded in this data type.

Related issue: #43033

Benchmark (Debian Buster,  Intel(R) Xeon(R) E-2136 CPU @ 3.30GHz, Turbo off, Release build):

```python
import timeit
dtype = 'torch.int8'
for op in ('+', '-'):
    for n, t in [(10_000, 200000),
                (100_000, 20000)]:
        print(f'a {op} b, numel() == {n} for {t} times, dtype={dtype}')
        print(timeit.timeit(f'c = a {op} b', setup=f'import torch; a = torch.arange(1, {n}, dtype={dtype}); b = torch.arange({n}, 1, -1, dtype={dtype})', number=t))
```

Results:

Before:

```
a + b, numel() == 10000 for 200000 times, dtype=torch.int8
1.2223373489978258
a + b, numel() == 100000 for 20000 times, dtype=torch.int8
0.6108450189931318
a - b, numel() == 10000 for 200000 times, dtype=torch.int8
1.256775538000511
a - b, numel() == 100000 for 20000 times, dtype=torch.int8
0.6101213909860235
```

After:

```
a + b, numel() == 10000 for 200000 times, dtype=torch.int8
0.5713336059998255
a + b, numel() == 100000 for 20000 times, dtype=torch.int8
0.39169703199877404
a - b, numel() == 10000 for 200000 times, dtype=torch.int8
0.5838428330025636
a - b, numel() == 100000 for 20000 times, dtype=torch.int8
0.37486923701362684
```
