### PR TITLE
Consolidate CODEOWNERS file for distributed package.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,10 +4,6 @@
 /docs/cpp @goldsborough @ebetica @yf225
 /torch/csrc/api/ @ebetica @goldsborough @yf225
 /test/cpp/api/ @ebetica @goldsborough @yf225
-/torch/lib/c10d/ @pietern @mrshenli @zhaojuanmao
-/torch/csrc/distributed/ @pietern @mrshenli @zhaojuanmao
-/torch/distributed/ @apaszke @pietern @mrshenli @zhaojuanmao
-/test/test_c10d.py @pietern @mrshenli @zhaojuanmao
 /torch/utils/cpp_extension.py @goldsborough @fmassa @soumith @ezyang
 
 # Not there to strictly require the approval, but to be tagged as a reviewer
@@ -20,17 +16,19 @@
 /torch/jit/ @apaszke
 /torch/utils/data/ @apaszke
 
-# Distributed RPC Framework.
-/torch/csrc/distributed/rpc @mrshenli @pritamdamania87 @zhaojuanmao
-/torch/csrc/distributed/autograd @mrshenli @pritamdamania87 @zhaojuanmao
-/torch/distributed/rpc @mrshenli @pritamdamania87 @zhaojuanmao
-/torch/distributed/autograd @mrshenli @pritamdamania87 @zhaojuanmao
-/torch/distributed/optim @mrshenli @pritamdamania87 @zhaojuanmao @aazzolini
-
 # Tensorpipe RPC Agent.
 /torch/csrc/distributed/rpc/tensorpipe_agent.cpp @jiayisuse @osalpekar @lw @beauby
 /torch/csrc/distributed/rpc/tensorpipe_agent.h @jiayisuse @osalpekar @lw @beauby
 
+# Distributed package
+# This list is mostly if you'd like to be tagged as reviewer, feel free to add
+# or remove yourself from it.
+/torch/lib/c10d/ @pietern @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma
+/torch/csrc/distributed/ @pietern @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma
+/torch/distributed/ @apaszke @pietern @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma
+
 # Distributed tests
-/test/distributed @mrshenli @pritamdamania87 @zhaojuanmao
-/torch/testing/_internal/distributed @mrshenli @pritamdamania87 @zhaojuanmao
+# This list is mostly if you'd like to be tagged as reviewer, feel free to add
+# or remove yourself from it.
+/test/distributed @mrshenli @pritamdamania87 @zhaojuanmao @rohan-varma
+/torch/testing/_internal/distributed @mrshenli @pritamdamania87 @zhaojuanmao @rohan-varma


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44763 Consolidate CODEOWNERS file for distributed package.**

The file had separate rules for RPC and DDP/c10d, consolidated all of
it together and placed all the distributed rules together.

Differential Revision: [D23721162](https://our.internmc.facebook.com/intern/diff/D23721162/)