### PR TITLE
Do not use `PRId64` in torch/csrc

### DIFF
--- a/torch/csrc/DataLoader.cpp
+++ b/torch/csrc/DataLoader.cpp
@@ -21,6 +21,7 @@
 
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/python_numbers.h>
+#include <fmt/format.h>
 
 using namespace torch;
 
@@ -182,7 +183,7 @@ static PyObject *THPModule_removeWorkerPIDs(PyObject *module, PyObject *loader_i
   int64_t key = THPUtils_unpackLong(loader_id);
   auto it = worker_pids.find(key);
   if (it == worker_pids.end()) {
-    throw ValueError("Cannot find worker information for _BaseDataLoaderIter with id %" PRId64, key);
+    throw ValueError(fmt::format("Cannot find worker information for _BaseDataLoaderIter with id {}", key));
   }
   worker_pids.erase(it);
 

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -15,16 +15,19 @@
 #include <c10/util/StringUtil.h>
 #include <ATen/detail/FunctionTraits.h>
 
+static inline void PyErr_SetString(PyObject* type, const std::string& message) {
+  PyErr_SetString(type, message.c_str());
+}
 /// NOTE [ Conversion Cpp Python Warning ]
 /// The warning handler cannot set python warnings immediately
-/// as it requires acquirering the GIL (potential deadlock)
+/// as it requires acquiring the GIL (potential deadlock)
 /// and would need to cleanly exit if the warning raised a
 /// python error. To solve this, we buffer the warnings and
 /// process them when we go back to python.
 /// This requires the two try/catch blocks below to handle the
 /// following cases:
 ///   - If there is no Error raised in the inner try/catch, the
-///     bufferred warnings are processed as python warnings.
+///     buffered warnings are processed as python warnings.
 ///     - If they don't raise an error, the function process with the
 ///       original return code.
 ///     - If any of them raise an error, the error is set (PyErr_*) and
@@ -53,30 +56,30 @@
     catch (const c10::IndexError& e) {                               \
       auto msg = torch::get_cpp_stacktraces_enabled() ?              \
                     e.what() : e.what_without_backtrace();           \
-      PyErr_SetString(PyExc_IndexError, torch::processErrorMsg(msg).c_str()); \
+      PyErr_SetString(PyExc_IndexError, torch::processErrorMsg(msg)); \
       retstmnt;                                                      \
     }                                                                \
     catch (const c10::ValueError& e) {                               \
       auto msg = torch::get_cpp_stacktraces_enabled() ?              \
                     e.what() : e.what_without_backtrace();           \
-      PyErr_SetString(PyExc_ValueError, torch::processErrorMsg(msg).c_str()); \
+      PyErr_SetString(PyExc_ValueError, torch::processErrorMsg(msg)); \
       retstmnt;                                                      \
     }                                                                \
     catch (const c10::TypeError& e) {                               \
       auto msg = torch::get_cpp_stacktraces_enabled() ?              \
                     e.what() : e.what_without_backtrace();           \
-      PyErr_SetString(PyExc_TypeError, torch::processErrorMsg(msg).c_str()); \
+      PyErr_SetString(PyExc_TypeError, torch::processErrorMsg(msg)); \
       retstmnt;                                                      \
     }                                                                \
     catch (const c10::Error& e) {                                    \
       auto msg = torch::get_cpp_stacktraces_enabled() ?              \
                     e.what() : e.what_without_backtrace();           \
-      PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg).c_str()); \
+      PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg)); \
       retstmnt;                                                      \
     }                                                                \
     catch (torch::PyTorchError & e) {                                \
       auto msg = torch::processErrorMsg(e.what());                   \
-      PyErr_SetString(e.python_type(), msg.c_str());                 \
+      PyErr_SetString(e.python_type(), msg);                         \
       retstmnt;                                                      \
     }
 
@@ -84,7 +87,7 @@
     CATCH_TH_ERRORS(retstmnt)                                        \
     catch (const std::exception& e) {                                \
       auto msg = torch::processErrorMsg(e.what());                   \
-      PyErr_SetString(PyExc_RuntimeError, msg.c_str());              \
+      PyErr_SetString(PyExc_RuntimeError, msg);                      \
       retstmnt;                                                      \
     }
 
@@ -236,6 +239,7 @@ THP_API bool get_cpp_stacktraces_enabled();
 
 // Abstract base class for exceptions which translate to specific Python types
 struct PyTorchError : public std::exception {
+  PyTorchError(const std::string& msg_ = std::string()): msg(msg_) {}
   virtual PyObject* python_type() = 0;
   const char* what() const noexcept override {
     return msg.c_str();
@@ -254,6 +258,7 @@ struct PyTorchError : public std::exception {
 
 // Translates to Python IndexError
 struct IndexError : public PyTorchError {
+  using PyTorchError::PyTorchError;
   IndexError(const char *format, ...) TORCH_FORMAT_FUNC(2, 3);
   PyObject* python_type() override {
     return PyExc_IndexError;
@@ -262,6 +267,7 @@ struct IndexError : public PyTorchError {
 
 // Translates to Python TypeError
 struct TypeError : public PyTorchError {
+  using PyTorchError::PyTorchError;
   TORCH_API TypeError(const char *format, ...) TORCH_FORMAT_FUNC(2, 3);
   PyObject* python_type() override {
     return PyExc_TypeError;
@@ -270,6 +276,7 @@ struct TypeError : public PyTorchError {
 
 // Translates to Python ValueError
 struct ValueError : public PyTorchError {
+  using PyTorchError::PyTorchError;
   ValueError(const char *format, ...) TORCH_FORMAT_FUNC(2, 3);
   PyObject* python_type() override {
     return PyExc_ValueError;

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -1,5 +1,3 @@
-#define __STDC_FORMAT_MACROS
-
 #include <torch/csrc/python_headers.h>
 #ifdef _MSC_VER
 #include <Windows.h>
@@ -19,6 +17,8 @@
 #include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
+
+#include <fmt/format.h>
 
 #include <torch/csrc/generic/Storage.cpp>
 #include <TH/THGenerateAllTypes.h>

--- a/torch/csrc/cuda/Storage.cpp
+++ b/torch/csrc/cuda/Storage.cpp
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/python_headers.h>
 #include <structmember.h>
+#include <fmt/format.h>
 
 // See Note [TH abstraction violation]
 //    - Used to get at allocator from storage

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -148,13 +148,9 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     if (nindex < 0)
       nindex += (self->cdata->nbytes() / sizeof(scalar_t));
     if (nindex < 0 || nindex >= (self->cdata->nbytes() / sizeof(scalar_t))) {
-      PyErr_Format(
-          PyExc_IndexError,
-          "index %" PRId64
-          " out of range for storage of "
-          "size %" PRId64,
-          (int64_t)nindex,
-          (int64_t)(self->cdata->nbytes() / sizeof(scalar_t)));
+      PyErr_SetString(PyExc_IndexError, fmt::format(
+            "index {} out of range for storage of size {}",
+            nindex, self->cdata->nbytes() / sizeof(scalar_t)));
       return nullptr;
     }
     scalar_t value = THWStorage_(get)(LIBRARY_STATE self->cdata, nindex);
@@ -166,8 +162,8 @@ static PyObject * THPStorage_(get)(THPStorage *self, PyObject *index)
     if (!THPUtils_parseSlice(index, len, &start, &stop, &step, &slicelength))
       return nullptr;
     if (step != 1) {
-      THPUtils_setError("Trying to slice with a step of %" PRId64 ", but only a step of "
-          "1 is supported", (int64_t)step);
+      THPUtils_setError("Trying to slice with a step of %lld, but only a step of "
+          "1 is supported", (long long)step);
       return nullptr;
     }
 
@@ -222,8 +218,8 @@ static int THPStorage_(set)(THPStorage *self, PyObject *index, PyObject *value)
     if (!THPUtils_parseSlice(index, len, &start, &stop, &step, &slicelength))
       return -1;
     if (step != 1) {
-      THPUtils_setError("Trying to slice with a step of %" PRId64 ", but only a step of "
-          "1 is supported", (int64_t)step);
+      THPUtils_setError("Trying to slice with a step of %lld, but only a step of "
+          "1 is supported", (long long)step);
       return 0;
     }
     // TODO: check the bounds only once

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -125,17 +125,18 @@ static PyObject * THPStorage_(fromBuffer)(PyObject *_unused, PyObject *args, PyO
     return nullptr;
 
   if (offset < 0 || offset > buffer.len) {
-    PyErr_Format(PyExc_ValueError,
-      "offset must be non-negative and no greater than buffer length (%" PRId64 "), "
-      "but got %" PRId64, (int64_t)offset, (int64_t)buffer.len);
+    PyErr_SetString(PyExc_ValueError, fmt::format(
+      "offset must be non-negative and no greater than buffer length ({}) , but got {}",
+      offset, buffer.len));
     PyBuffer_Release(&buffer);
     return nullptr;
   }
 
   if (count < 0) {
     if ((buffer.len - offset) % sizeof(scalar_t) != 0) {
-      PyErr_Format(PyExc_ValueError, "buffer size (%" PRId64 ") must be a multiple "
-          "of element size (%" PRId64 ")", (int64_t)buffer.len, (int64_t)sizeof(scalar_t));
+      PyErr_SetString(PyExc_ValueError, fmt::format(
+         "buffer size ({}) must be a multiple of element size ({})",
+         buffer.len, sizeof(scalar_t)));
       PyBuffer_Release(&buffer);
       return nullptr;
     }
@@ -143,9 +144,9 @@ static PyObject * THPStorage_(fromBuffer)(PyObject *_unused, PyObject *args, PyO
   }
 
   if (offset + (count * (Py_ssize_t)sizeof(scalar_t)) > buffer.len) {
-    PyErr_Format(PyExc_ValueError, "buffer has only %" PRId64 " elements after offset "
-        "%" PRId64 ", but specified a size of %" PRId64, (int64_t)(buffer.len - offset),
-        (int64_t)offset, (int64_t)count);
+    PyErr_SetString(PyExc_ValueError, fmt::format(
+        "buffer has only {} elements after offset {}, but specified a size of {}",
+        buffer.len - offset, offset, count));
     PyBuffer_Release(&buffer);
     return nullptr;
   }


### PR DESCRIPTION
Instead use `fmt::format()` or `%lld` and cast argument to `(long long)`
Fix typos and add helper `PyErr_SetString()` method in torch/csrc/Exceptions.h