### PR TITLE
Create experimental graph manipulation library

### DIFF
--- a/torch/fx/experimental/GraphManipulation.py
+++ b/torch/fx/experimental/GraphManipulation.py
@@ -1,0 +1,7 @@
+def replace_all_uses_with(fx_module, old_op, old_target, new_op, new_target):
+    """Modifies all nodes  in nodes which match the op code and target of old_node, and updates them to match new_node"""
+    for node in fx_module.graph.nodes:
+        if node.op == old_op and node.target == old_target:
+            node.op = new_op
+            node.target = new_target
+    fx_module._generate_forward()


### PR DESCRIPTION
This PR adds a new experimental GraphManipulation library for operation on the FX graphModule. 
It also has an initial method replace_all_uses_with, which replaces all uses of a specified op/target with another op/target. 