### PR TITLE
Add support for homogenous tuples

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -738,6 +738,12 @@ class TestScriptPy3(JitTestCase):
         # self.assertTrue(set(['aten::add.Tensor', 'aten::mul.Scalar']).issubset(
         #     set(torch.jit.export_opnames(scripted_M_mod))))
 
+    def test_homogeneous_tuple(self):
+        @torch.jit.script
+        def foo(a: Tuple[int, ...]) -> int:
+            return len(a)
+
+        FileCheck().check('int[]').run(foo.graph)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -26,8 +26,15 @@ TypePtr ScriptTypeParser::subscriptToType(
     const std::string& typeName,
     const Subscript& subscript) const {
   if (typeName == "Tuple") {
+    auto subscript_exprs = subscript.subscript_exprs();
+    // Arbitrary-length homogeneous tuple as defined in PEP-484
+    if (subscript_exprs.size() == 2 && subscript_exprs[1].kind() == TK_DOTS) {
+      auto elem_type = parseTypeFromExprImpl(subscript_exprs[0]);
+      // Alias arbitrary-length tuple to ListType
+      return ListType::create(elem_type);
+    }
     std::vector<TypePtr> subscript_expr_types;
-    for (auto expr : subscript.subscript_exprs()) {
+    for (auto expr : subscript_exprs) {
       subscript_expr_types.push_back(parseTypeFromExprImpl(expr));
     }
     return TupleType::create(subscript_expr_types);

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -28,10 +28,12 @@ TypePtr ScriptTypeParser::subscriptToType(
   if (typeName == "Tuple") {
     auto subscript_exprs = subscript.subscript_exprs();
     // Arbitrary-length homogeneous tuple as defined in PEP-484
-    if (subscript_exprs.size() == 2 && subscript_exprs[1].kind() == TK_DOTS) {
-      auto elem_type = parseTypeFromExprImpl(subscript_exprs[0]);
-      // Alias arbitrary-length tuple to ListType
-      return ListType::create(elem_type);
+    if (subscript_exprs.size() == 2) {
+      auto second_kind = subscript_exprs[1].kind();
+      if (second_kind == TK_DOTS || second_kind == TK_ELLIPSIS) {
+        auto elem_type = parseTypeFromExprImpl(subscript_exprs[0]);
+        return VariableLengthTupleType::create(elem_type);
+      }
     }
     std::vector<TypePtr> subscript_expr_types;
     for (auto expr : subscript_exprs) {

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -577,8 +577,11 @@ inline IValue toIValue(
       auto device = reinterpret_cast<THPDevice*>(obj.ptr());
       return device->device;
     }
+    case TypeKind::VariableLengthTupleType:
     case TypeKind::ListType: {
-      const auto& elem_type = type->expect<ListType>()->getElementType();
+      const auto& elem_type = type->kind() == TypeKind::ListType
+          ? type->expect<ListType>()->getElementType()
+          : type->expect<VariableLengthTupleType>()->getElementType();
       switch (elem_type->kind()) {
         // allows single int/float to be broadcasted to a fixed size list
         case TypeKind::IntType:

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -104,13 +104,16 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
           to_process.emplace_back(std::move(elem));
         }
       } break;
+      case VariableLengthTupleType::Kind:
       case ListType::Kind: {
         // specialized lists do not need their type refined, so we can exit
         // early here
         if (!w.value.isList()) {
           break;
         }
-        auto elem_type = w.static_type->cast<ListType>()->getElementType();
+        auto elem_type = w.static_type->kind() == ListType::Kind
+            ? w.static_type->cast<ListType>()->getElementType()
+            : w.static_type->cast<VariableLengthTupleType>()->getElementType();
         auto lst = w.value.toList();
         lst.unsafeSetElementType(elem_type);
         for (const IValue& item : lst) {


### PR DESCRIPTION
Alias homogenous tuples to lists in jit frontend parser
Homogenous tuple is defined a `Tuple[Type, ...]` and semantically very similar to `List[Type]`

This would allow one to use `torch.nn.common_types._size_any_t` to type annotate jit functions

