### PR TITLE
Create experimental FX graph manipulation library

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -550,6 +550,24 @@ class TestFX(JitTestCase):
         out = gm(input)
         self.assertEqual(out, ref_out)
 
+    def test_replace_target_nodes_with(self):
+        class testModule(torch.nn.Module):
+            def forward(self, a, b):
+                return a + b
+        m = testModule()
+        traced = symbolic_trace(m)
+        input1 = torch.randn(1)
+        input2 = torch.randn(1)
+        assert (input1 + input2) == traced(input1, input2)
+        GraphManipulation.replace_target_nodes_with(
+            fx_module=traced,
+            old_op="call_function",
+            old_target=operator.add,
+            new_op="call_function",
+            new_target=operator.mul,
+        )
+        assert (input1 * input2) == traced(input1, input2)
+
     def test_pretty_print(self):
         st = SimpleTest()
         traced = symbolic_trace(st)

--- a/torch/fx/experimental/GraphManipulation.py
+++ b/torch/fx/experimental/GraphManipulation.py
@@ -1,7 +1,9 @@
-from typing import List
+from typing import Dict, List
 from torch.fx.graph_module import GraphModule
 from typing import Any
-from torch.fx.node import Node
+from torch.fx.node import Node, Target
+from torch.fx.graph import Graph, map_arg
+
 
 """find_use is used to find out if the node is another node's arg or kwargs."""
 def find_use(arg: Any, node: Node) -> bool:
@@ -29,3 +31,26 @@ def get_all_users_of(fx_module: GraphModule, index: int) -> List[int]:
         if find_use(n.args, current_node) or find_use(n.kwargs, current_node):
             user_indexes.append(i)
     return user_indexes
+
+def replace_target_nodes_with(
+    fx_module: GraphModule,
+    old_op: str,
+    old_target: Target,
+    new_op: str,
+    new_target: Target,
+):
+    """Modifies all nodes in fx_module.graph.nodes which match the specified op code and target,
+    and updates them to match the new op code and target"""
+    new_graph = Graph()
+    val_map : Dict[Node, Node] = {}
+    for node in fx_module.graph.nodes:
+        if node.op == old_op and node.target == old_target:
+            args = map_arg(node.args, lambda n: val_map[n])
+            kwargs = map_arg(node.kwargs, lambda n: val_map[n])
+            assert isinstance(args, tuple)
+            assert isinstance(kwargs, dict)
+            val_map[node] = new_graph.create_node(new_op, new_target, args, kwargs, node.name)
+        else:
+            val_map[node] = new_graph.node_copy(node, lambda n : val_map[n])
+    new_graph.output(map_arg(fx_module.graph.result, lambda n: val_map[n]))
+    fx_module.graph = new_graph


### PR DESCRIPTION
This PR adds a new GraphManipulation library for operating on the GraphModule nodes.
It also adds an implementation of replace_target_nodes_with, which replaces all nodes in the GraphModule or a specific op/target with a new specified op/target. An example use of this function would be replacing a generic operator with an optimized operator for specific sizes and shapes.