### PR TITLE
[jit] Switch Value::setDebugName() from stringstream to fmt::format

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/jit/runtime/operator.h>
 #include <torch/csrc/jit/serialization/python_print.h>
 
+#include <fmt/format.h>
 #include <algorithm>
 #include <iostream>
 #include <set>
@@ -794,9 +795,7 @@ Value* Value::setDebugName(const std::string& name) {
     }
     std::string replacement_name;
     do {
-      std::stringstream ss;
-      ss << name_base << "." << suffix++;
-      replacement_name = ss.str();
+      replacement_name = fmt::format("{}.{}", name_base, suffix++);
     } while (names.count(replacement_name) > 0);
     old_owner_of_name->second->setDebugName(replacement_name);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44811 [jit] Switch Value::setDebugName() from stringstream to fmt::format**

This format call is taking ~11% of a data_preproc/perf_test benchmark.

If I microbenchmark both the stringstream version and the libfmt version,
libfmt is better than 10x faster:
   (For 1000 iterations, so really 244ns vs 21ns)
   WithStringStream    244.38us    4.09K
   WithLibFmt           21.89us   45.67K

Differential Revision: [D23740188](https://our.internmc.facebook.com/intern/diff/D23740188/)