### PR TITLE
[FakeLowP] Addressing FakeLowP OSS issues.

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -14,6 +14,7 @@ from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.fakelowp.test_utils import print_test_debug_info
+import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--glow_global_fp16=1",
                  "--glow_global_fused_scale_offset_fp16=1",
@@ -39,7 +40,7 @@ def reference_spatialbn_test16(X, scale, bias, mean, var, epsilon, order):
 
 
 # Test the lowered BN op
-class BatchnormTest(unittest.TestCase):
+class BatchnormTest(serial.SerializedTestCase):
     # TODO: using hypothesis seed, sweep dimensions
     @given(seed=st.integers(0, 65535),
            size=st.integers(2, 30),

--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -22,8 +22,6 @@ kEpsilon = 1e-8
 
 
 class ArithmeticOpsTest(serial.SerializedTestCase):
-    @given(seed=st.integers(0, 65534))
-    @settings(deadline=None)
     def _test_binary_op_graph(self, name, seed):
         np.random.seed(seed)
         workspace.ResetWorkspace()
@@ -107,26 +105,22 @@ class ArithmeticOpsTest(serial.SerializedTestCase):
     @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
     def test_add_graph(self, seed):
-        np.random.seed(seed)
-        self._test_binary_op_graph("Add")
+        self._test_binary_op_graph("Add", seed)
 
     @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
     def test_sub_graph(self, seed):
-        np.random.seed(seed)
-        self._test_binary_op_graph("Sub")
+        self._test_binary_op_graph("Sub", seed)
 
     @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
     def test_mul_graph(self, seed):
-        np.random.seed(seed)
-        self._test_binary_op_graph("Mul")
+        self._test_binary_op_graph("Mul", seed)
 
     @given(seed=st.integers(0, 65534))
     @settings(deadline=None)
     def test_div_graph(self, seed):
-        np.random.seed(seed)
-        self._test_binary_op_graph("Div")
+        self._test_binary_op_graph("Div", seed)
 
 
 class UnaryOpTest(serial.SerializedTestCase):


### PR DESCRIPTION
Summary:
[12:39 AM] Cherckez, Tal
please review the following patch.
should address these issues that our validation team found:
A) test_op_nnpi_fp16: hypothesis to trigger max_example*max_example.
B) batchnorm: batchNorm has derived from unit test which doesnt have setting required for hypothesis. hence default value as 100 getting set.

Test Plan:
buck test //caffe2/caffe2/contrib/fakelowp/test/...
https://our.intern.facebook.com/intern/testinfra/testrun/5910974543950859

Reviewed By: hyuen

Differential Revision: D23740970

