### PR TITLE
[TensorExpr] Add log1p support to the LLVM backend

### DIFF
--- a/test/cpp/tensorexpr/test_base.h
+++ b/test/cpp/tensorexpr/test_base.h
@@ -58,6 +58,17 @@ void ExpectAllNear(
   }
 }
 
+template <typename U, typename V>
+void ExpectAllNear(
+    const std::vector<U>& vec,
+    const U& val,
+    V threshold,
+    const std::string& name = "") {
+  for (size_t i = 0; i < vec.size(); i++) {
+    ASSERT_NEAR(vec[i], val, threshold, "element index: ", i, ", name: ", name);
+  }
+}
+
 template <typename T>
 static void assertAllEqual(const std::vector<T>& vec, const T& val) {
   for (auto const& elt : vec) {

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -390,6 +390,7 @@ namespace jit {
   _(LLVMElemwiseAdd)                       \
   _(LLVMElemwiseAddFloat)                  \
   _(LLVMElemwiseLog10Float)                \
+  _(LLVMElemwiseLog1pFloat)                \
   _(LLVMElemwiseMaxInt)                    \
   _(LLVMElemwiseMinInt)                    \
   _(LLVMElemwiseMaxFloat)                  \

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -1257,6 +1257,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #endif
         SIMD_UNARY_MATH_CASE(kLog10, "log10f", FloatTy_)
         SIMD_UNARY_MATH_CASE(kLog, "logf", FloatTy_)
+        SIMD_UNARY_MATH_CASE(kLog1p, "log1pf", FloatTy_)
         SIMD_UNARY_MATH_CASE(kLog2, "log2f", FloatTy_)
         SIMD_UNARY_MATH_CASE(kExp, "expf", FloatTy_)
         SIMD_UNARY_MATH_CASE(kCos, "cosf", FloatTy_)
@@ -1401,6 +1402,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #endif
       SIMD_UNARY_MATH_CASE(kLog10, "log10", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kLog, "log", DoubleTy_)
+      SIMD_UNARY_MATH_CASE(kLog1p, "log1p", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kLog2, "log2", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kExp, "exp", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kCos, "cos", DoubleTy_)

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -32,6 +32,8 @@ class TORCH_API PytorchLLVMJITImpl {
     cantFail(LLJ->defineAbsolute(
         *Mangle("log10f"), {llvm::pointerToJITTargetAddress(&log10f), {}}));
     cantFail(LLJ->defineAbsolute(
+        *Mangle("log1pf"), {llvm::pointerToJITTargetAddress(&log1pf), {}}));
+    cantFail(LLJ->defineAbsolute(
         *Mangle("logf"), {llvm::pointerToJITTargetAddress(&logf), {}}));
     cantFail(LLJ->defineAbsolute(
         *Mangle("log2f"), {llvm::pointerToJITTargetAddress(&log2f), {}}));
@@ -127,7 +129,7 @@ class TORCH_API PytorchLLVMJITImpl {
         *Mangle("Sleef_log10f4"),
         {llvm::pointerToJITTargetAddress(&Sleef_log10f4_u10), {}}));
     cantFail(LLJ->defineAbsolute(
-        *Mangle("Sleef_logf1pf4"),
+        *Mangle("Sleef_log1pf4"),
         {llvm::pointerToJITTargetAddress(&Sleef_log1pf4_u10), {}}));
     cantFail(LLJ->defineAbsolute(
         *Mangle("Sleef_sqrtf4"),
@@ -212,7 +214,7 @@ class TORCH_API PytorchLLVMJITImpl {
         *Mangle("Sleef_log10f8"),
         {llvm::pointerToJITTargetAddress(&Sleef_log10f8_u10), {}}));
     cantFail(LLJ->defineAbsolute(
-        *Mangle("Sleef_logf1pf8"),
+        *Mangle("Sleef_log1pf8"),
         {llvm::pointerToJITTargetAddress(&Sleef_log1pf8_u10), {}}));
     cantFail(LLJ->defineAbsolute(
         *Mangle("Sleef_sqrtf8"),
@@ -297,7 +299,7 @@ class TORCH_API PytorchLLVMJITImpl {
         *Mangle("Sleef_log10d2"),
         {llvm::pointerToJITTargetAddress(&Sleef_log10d2_u10), {}}));
     cantFail(LLJ->defineAbsolute(
-        *Mangle("Sleef_logf1pd2"),
+        *Mangle("Sleef_log1pd2"),
         {llvm::pointerToJITTargetAddress(&Sleef_log1pd2_u10), {}}));
     cantFail(LLJ->defineAbsolute(
         *Mangle("Sleef_sqrtd2"),
@@ -382,7 +384,7 @@ class TORCH_API PytorchLLVMJITImpl {
         *Mangle("Sleef_log10d4"),
         {llvm::pointerToJITTargetAddress(&Sleef_log10d4_u10), {}}));
     cantFail(LLJ->defineAbsolute(
-        *Mangle("Sleef_logf1pd4"),
+        *Mangle("Sleef_log1pd4"),
         {llvm::pointerToJITTargetAddress(&Sleef_log1pd4_u10), {}}));
     cantFail(LLJ->defineAbsolute(
         *Mangle("Sleef_sqrtd4"),


### PR DESCRIPTION
Summary:

Also corrected Sleef_log1p registrations, float versions had a redundant f.

Test Plan:

test_tensorexpr --gtest_filter=TensorExprTest.LLVMElemwiseLog1pFloat_LLVM