### PR TITLE
Workaround nvcc miscompilation of two 16-bit fields together.

### DIFF
--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -65,16 +65,17 @@ Device::Device(const std::string& device_string) : Device(Type::CPU) {
   TORCH_CHECK(
     std::regex_match(device_string, match, regex),
     "Invalid device string: '", device_string, "'");
-  type_ = parse_type(match[1].str());
+  auto type = parse_type(match[1].str());
   if (match[2].matched) {
     try {
-      index_ = c10::stoi(match[2].str());
+      auto index = c10::stoi(match[2].str());
     } catch (const std::exception &) {
       AT_ERROR(
         "Could not parse device index '", match[2].str(),
         "' in device string '", device_string, "'");
     }
   }
+  data_ = detail::packDevice(type, index);
   validate();
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44885 Workaround nvcc miscompilation of two 16-bit fields together.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D23760540](https://our.internmc.facebook.com/intern/diff/D23760540)