### PR TITLE
[NNC] Fuse identical conditions in simplifier

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -214,6 +214,7 @@ namespace jit {
   _(SimplifyEliminateZeroLengthAlloc)       \
   _(DontSimplifyRand)                       \
   _(SimplifyReorderForCond)                 \
+  _(SimplifyFuseConditions)                 \
   _(RegisterizerSimple)                     \
   _(RegisterizerLoop)                       \
   _(RegisterizerLoopFixedLoad)              \

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1419,6 +1419,7 @@ Stmt* IRSimplifierBase::mutate(const For* v) {
 
 Stmt* IRSimplifierBase::mutate(const Block* v) {
   std::vector<Stmt*> stmts;
+  // Flatten sub-blocks:
   for (Stmt* stmt : *v) {
     Stmt* stmt_new = stmt->accept_mutator(this);
     if (stmt_new == nullptr) {
@@ -1869,6 +1870,93 @@ Stmt* TermExpander::mutate(const Free* v) {
   }
 
   return new Free(buffer_var_new);
+}
+
+// Combines adjactent Cond nodes with identical conditions.
+Block* TermExpander::fuseConditions(Block* v) {
+  std::vector<Stmt*> stmts;
+  bool did_anything = false;
+  Cond* prev_cond = nullptr;
+
+  for (auto* s : *v) {
+    Cond* cond = dynamic_cast<Cond*>(s);
+    if (!cond) {
+      prev_cond = nullptr;
+      stmts.push_back(s);
+      continue;
+    }
+
+    // If the previous statement is a Cond and the conditions are identical,
+    // then we fuse.
+    if (!prev_cond ||
+        hasher_.hash(prev_cond->condition()) !=
+            hasher_.hash(cond->condition())) {
+      prev_cond = cond;
+      stmts.push_back(s);
+      continue;
+    }
+    // Fuse the two Conds by appending the bodies of the second Cond to the
+    // first.
+    Block* true_block = new Block({});
+    Block* false_block = new Block({});
+
+    if (prev_cond->true_stmt()) {
+      true_block->splice(true_block->end(), prev_cond->true_stmt());
+    }
+
+    if (cond->true_stmt()) {
+      true_block->splice(true_block->end(), cond->true_stmt());
+    }
+
+    if (prev_cond->false_stmt()) {
+      false_block->splice(false_block->end(), prev_cond->false_stmt());
+    }
+
+    if (cond->false_stmt()) {
+      false_block->splice(false_block->end(), cond->false_stmt());
+    }
+
+    // avoid unflattening this Cond if we can.
+    if (true_block->empty()) {
+      true_block = nullptr;
+    }
+
+    if (false_block->empty()) {
+      false_block = nullptr;
+    }
+
+    prev_cond = prev_cond->cloneWithNewBodies(true_block, false_block);
+
+    // erase, which shortens the list.
+    stmts.pop_back();
+    stmts.push_back(prev_cond);
+
+    did_anything = true;
+  }
+
+  if (!did_anything) {
+    return v;
+  }
+
+  // clean up parents.
+  for (auto* s : stmts) {
+    if (s->get_parent() == v) {
+      v->remove_stmt(s);
+    }
+  }
+
+  return new Block(stmts);
+}
+
+Stmt* TermExpander::mutate(const Block* v) {
+  Stmt* new_stmt = IRSimplifierBase::mutate(v);
+  Block* new_block = dynamic_cast<Block*>(new_stmt);
+  if (!new_block) {
+    return new_stmt;
+  }
+
+  // fuseConditions will return the original block if it cannot fuse.
+  return fuseConditions(new_block);
 }
 
 bool exprEquals(const Expr* A, const Expr* B) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -407,6 +407,7 @@ class MinTerm : public ExprNode<MinTerm> {
 class TORCH_API IRSimplifierBase : public IRMutator {
  public:
   virtual ~IRSimplifierBase() {}
+
   Stmt* mutate(const Block* v) override;
 
   Stmt* mutate(const Cond* v) override;
@@ -566,6 +567,10 @@ class TORCH_API TermExpander : public IRSimplifierBase {
   Stmt* mutate(const Allocate* v) override;
 
   Stmt* mutate(const Free* v) override;
+
+  // Override to enable condition fusing.
+  Block* fuseConditions(Block* v);
+  Stmt* mutate(const Block* v) override;
 };
 
 class TORCH_API IRSimplifier {


### PR DESCRIPTION
Adds a pass to the IR Simplifier which fuses together the bodies of Cond statements which have identical conditions. e.g.

```
if (i < 10) {
  do_thing_1;
} else {
  do_thing_2;
}
if (i < 10) {
  do_thing_3;
}
```

is transformed into:

```
if (i < 10) {
  do_thing_1;
  do_thing_3;
} else {
  do_thing_2;
}
```
