### PR TITLE
Remove Incorrect Comment in tools/build_libtorch and remove Python2 support in the module import

### DIFF
--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -8,9 +8,6 @@ import sys
 pytorch_root = dirname(dirname(abspath(__file__)))
 sys.path.append(pytorch_root)
 
-# If you want to modify flags or environmental variables that is set when
-# building torch, you should do it in tools/setup_helpers/configure.py.
-# Please don't add it here unless it's only used in LibTorch.
 from tools.build_pytorch_libs import build_caffe2
 from tools.setup_helpers.cmake import CMake
 

--- a/tools/download_mnist.py
+++ b/tools/download_mnist.py
@@ -1,17 +1,9 @@
-from __future__ import division
-from __future__ import print_function
-
 import argparse
 import gzip
 import os
+from urllib.error import URLError
+from urllib.request import urlretrieve
 import sys
-
-try:
-    from urllib.error import URLError
-    from urllib.request import urlretrieve
-except ImportError:
-    from urllib2 import URLError
-    from urllib import urlretrieve
 
 MIRRORS = [
     'http://yann.lecun.com/exdb/mnist/',


### PR DESCRIPTION
Fixes #{44293} and removes Python2 imports from MNIST download module as Python2 is not being supported.
