### PR TITLE
Fix incorrect EnumValue serialization issue

### DIFF
--- a/test/jit/test_enum.py
+++ b/test/jit/test_enum.py
@@ -267,6 +267,26 @@ class TestEnum(JitTestCase):
 
         self.assertEqual(scripted(), Color.RED.value)
 
+    def test_string_enum_as_module_attribute(self):
+        global Color
+
+        class Color(Enum):
+            RED = "red"
+            GREEN = "green"
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, e: Color):
+                super(TestModule, self).__init__()
+                self.e = e
+
+            def forward(self):
+                return (self.e.name, self.e.value)
+
+        m = TestModule(Color.RED)
+        scripted = torch.jit.script(m)
+
+        self.assertEqual(scripted(), (Color.RED.name, Color.RED.value))
+
     def test_enum_return(self):
         global Color
 

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1126,6 +1126,16 @@ struct PythonPrintImpl {
         stmt << useOf(node->input(0)) << ".tolist()"
              << ")";
       } break;
+      case prim::EnumValue:
+        // Note: This CAN NOT be printed as raw operator ops.prim.EnumValue
+        // because its return type depends on type of enum and must be further
+        // resolved, but ops.prim.EnumValue construction does not provide such
+        // functionality.
+        stmt << "(" << useOf(node->input()) << ").value";
+        break;
+      case prim::EnumName:
+        stmt << "(" << useOf(node->input()) << ").name";
+        break;
       default: {
         printOpName(stmt, node->kind());
         const FunctionSchema& schema = node->schema();


### PR DESCRIPTION
Previously, `prim::EnumValue` is serialized to `ops.prim.EnumValue`, which doesn't have the right implementation to refine return type. This diff correctly serializes it to enum.value, thus fixing the issue.

Fixes #44892
