### PR TITLE
[reland ci-all tests] move rebuild buckets from end of first iteration to beginning of second iteration

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -181,7 +181,10 @@ PyObject* c10d_init(PyObject* _unused) {
               -> void { reducer.prepare_for_backward({output}); },
           py::call_guard<py::gil_scoped_release>())
       .def("get_backward_stats", &::c10d::Reducer::get_backward_stats)
-      .def("_rebuild_buckets", &::c10d::Reducer::rebuild_buckets)
+      .def(
+          "_rebuild_buckets",
+          &::c10d::Reducer::rebuild_buckets,
+          py::call_guard<py::gil_scoped_release>())
       .def(
           "get_bucket_tensors",
           &::c10d::Reducer::get_bucket_tensors,

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -3,6 +3,7 @@ import copy
 import itertools
 import os
 import inspect
+import logging
 
 import torch
 
@@ -583,6 +584,15 @@ class DistributedDataParallel(Module):
                 work, ones, self.ddp_join_divide_by_initial_world_size
             )
 
+        # Calling _rebuild_buckets before forward compuation,
+        # It may allocate new buckets before deallocating old buckets
+        # inside _rebuild_buckets. To save peak memory usage,
+        # call _rebuild_buckets before the peak memory usage increases
+        # during forward computation.
+        # This should be called only once during whole training period.
+        if self.reducer._rebuild_buckets():
+            logging.info("Reducer buckets have been rebuilt in this iteration.")
+
         if self.require_forward_param_sync:
             self._sync_params()
 
@@ -805,7 +815,6 @@ class DistributedDataParallel(Module):
             if enable and not has_error:
                 all_procs_joined = False
                 is_last_joiner = True
-                buckets_rebuilt = False
                 # Schedules allreduce to match fwd pass allreduce in non-joined procs
                 while not all_procs_joined:
                     num_active_procs = self._schedule_shadow_all_reduce_for_fwd_pass()
@@ -815,6 +824,8 @@ class DistributedDataParallel(Module):
                         # Some DDP process still needs to be joined.
                         if is_last_joiner:
                             is_last_joiner = False
+                        # It will rebuild buckets only once during training period
+                        self.reducer._rebuild_buckets()
                         # Schedule a corresponding broadcast if we are syncing module
                         # buffers in the forward pass.
                         self._check_and_sync_module_buffers()
@@ -840,11 +851,8 @@ class DistributedDataParallel(Module):
                         # Check if we need to allreduce locally unused params.
                         if self.find_unused_parameters:
                             self._match_unused_params_allreduce()
-                        # If buckets not rebuilt, will push original bucket
-                        # indices to simulate a rebuild.
-                        if not buckets_rebuilt and not self.find_unused_parameters:
-                            self.reducer._push_all_rebuilt_params()
-                            buckets_rebuilt = self.reducer._rebuild_buckets()
+                        # It will push rebuilt params only once during training period
+                        self.reducer._push_all_rebuilt_params()
 
                 # All procs joined. Agree on authoritative rank and broadcast the model.
                 self._sync_final_model(is_last_joiner)


### PR DESCRIPTION
This PR is pushing the same commit of #44798 to ci-all/... branch for triggering all tests. 

Update for relanding: in ddp.join(), moved _rebuild_buckets from end of backward to beginning of forward as well.

Part of relanding PR #41954, this refactoring is to move rebuild_buckets call from end of first iteration to beginning of second iteration

