### PR TITLE
Turn on gradgrad check for BCELoss Criterion Tests.

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3966,7 +3966,6 @@ criterion_tests = [
         target_fn=lambda: torch.randn(15, 10).gt(0).double(),
         reference_fn=lambda i, t, m: -(t * i.log() + (1 - t) * (1 - i).log()).sum() /
             (i.numel() if get_reduction(m) else 1),
-        check_gradgrad=False,
         check_bfloat16=TEST_WITH_ROCM,
     ),
     dict(
@@ -3978,7 +3977,6 @@ criterion_tests = [
         reference_fn=lambda i, t, m: -((t * i.log() + (1 - t) * (1 - i).log()) * get_weight(m)).sum() /
             (i.numel() if get_reduction(m) else 1),
         desc='weights',
-        check_gradgrad=False,
         check_bfloat16=TEST_WITH_ROCM,
     ),
     dict(
@@ -4328,7 +4326,6 @@ criterion_tests = [
         reference_fn=lambda i, t, m: -((t * i.log() + (1 - t) * (1 - i).log()) * get_weight(m)).sum() /
             (i.numel() if get_reduction(m) == 'mean' else 1),
         desc='scalar_weights',
-        check_gradgrad=False,
         check_bfloat16=TEST_WITH_ROCM,
     ),
     dict(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44950 Support (single) backwards for binary_cross_entropy target.
* **#44894 Turn on gradgrad check for BCELoss Criterion Tests.**
* #44786 Stop using check_criterion_jacobian.
* #44783 Stop ignoring errors in cuda nn module tests.
* #44745 Always use NewModuleTest instead of ModuleTest.

Looks like we added double backwards support but only turned on the ModuleTests.

Differential Revision: [D23762544](https://our.internmc.facebook.com/intern/diff/D23762544)