### PR TITLE
Add all ROCm component include subdirectories in include path

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -832,9 +832,11 @@ def include_paths(cuda: bool = False) -> List[str]:
     ]
     if cuda and IS_HIP_EXTENSION:
         paths.append(os.path.join(lib_include, 'THH'))
-        paths.append(_join_rocm_home('include'))
+        rocm_include_path = _join_rocm_home('include')
+        paths.append(rocm_include_path)
         if MIOPEN_HOME is not None:
             paths.append(os.path.join(MIOPEN_HOME, 'include'))
+        paths.extend([f.path for f in os.scandir(rocm_include_path) if f.is_dir()])
     elif cuda:
         cuda_home_include = _join_cuda_home('include')
         # if we have the Debian/Ubuntu packages for cuda, we get /usr as cuda home.


### PR DESCRIPTION
when compiling PyTorch extension files. This is needed because ROCm components have their own subdirectories inside `/opt/rocm/include`, or the `include` dir in wherever ROCm is installed. Some of the ROCm component headers include header files from other ROCm components eg. below, `hiprand.h` includes `rocrand.h`, but it assumes that the directory in which `rocrand.h` resides would be present in the include path while compiling. This PR resolves that for any PyTorch extensions being built for ROCm.

Before this change:
```
x86_64-linux-gnu-gcc ...<snip>... -I/opt/rocm/include -I/opt/rocm/miopen/include -I/usr/include/python3.6m  -c <source file> -o <obj file>
In file included from /opt/rocm/include/hiprand/hiprand.h:56:0,
                 from ...<snip>...
/opt/rocm/include/hiprand/hiprand_hcc.h:24:10: fatal error: rocrand.h: No such file or directory
 #include <rocrand.h>
          ^~~~~~~~~~~
compilation terminated.
```

After this change:
```
x86_64-linux-gnu-gcc ...<snip>... -I/opt/rocm/include -I/opt/rocm/miopen/include -I/opt/rocm/include/miopen -I/opt/rocm/include/roctracer -I/opt/rocm/include/base -I/opt/rocm/include/hipcub -I/opt/rocm/include/rocprofiler -I/opt/rocm/include/internal -I/opt/rocm/include/hsa -I/opt/rocm/include/miopengemm -I/opt/rocm/include/rocrand -I/opt/rocm/include/utils -I/opt/rocm/include/thrust -I/opt/rocm/include/rocprim -I/opt/rocm/include/hiprand -I/opt/rocm/include/hip -I/opt/rocm/include/solvers -I/usr/include/python3.6m -c <source file> -o <obj file>
```