### PR TITLE
Enable type check for torch.testing._internal.common_device_type.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -68,8 +68,8 @@ ignore_errors = True
 [mypy-torch.testing._internal.jit_utils.*]
 ignore_errors = True
 
-[mypy-torch.testing._internal.common_device_type.*]
-ignore_errors = True
+#[mypy-torch.testing._internal.common_device_type.*]
+#ignore_errors = True
 
 [mypy-torch.testing._internal.autocast_test_lists.*]
 ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -68,9 +68,6 @@ ignore_errors = True
 [mypy-torch.testing._internal.jit_utils.*]
 ignore_errors = True
 
-#[mypy-torch.testing._internal.common_device_type.*]
-#ignore_errors = True
-
 [mypy-torch.testing._internal.autocast_test_lists.*]
 ignore_errors = True
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -14,7 +14,7 @@ from torch.testing import \
     (get_all_dtypes)
 
 try:
-    import psutil  #type: ignore[import]
+    import psutil  # type: ignore[import]
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -4,7 +4,7 @@ import inspect
 import runpy
 import threading
 from functools import wraps
-import typing
+from typing import List, Any, ClassVar
 import unittest
 import os
 import torch
@@ -164,7 +164,9 @@ except ImportError:
 # List of device type test bases that can be used to instantiate tests.
 # See below for how this list is populated. If you're adding a device type
 # you should check if it's available and (if it is) add it to this list.
-device_type_test_bases: typing.List[typing.Any] = list()
+
+# set type to List[Any] due to mypy list-of-union issue: https://github.com/python/mypy/issues/3351
+device_type_test_bases: List[Any] = list()
 
 def _construct_test_name(test_name, op, device_type, dtype):
     if op is not None:
@@ -319,10 +321,10 @@ class CUDATestBase(DeviceTypeTestBase):
     device_type = 'cuda'
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
-    primary_device: typing.ClassVar[str]
-    cudnn_version: typing.ClassVar[typing.Any]
-    no_magma: typing.ClassVar[bool]
-    no_cudnn: typing.ClassVar[bool]
+    primary_device: ClassVar[str]
+    cudnn_version: ClassVar[Any]
+    no_magma: ClassVar[bool]
+    no_cudnn: ClassVar[bool]
 
 
     def has_cudnn(self):
@@ -357,8 +359,6 @@ class CUDATestBase(DeviceTypeTestBase):
 
 
 # Adds available device-type-specific test base classes
-# Todo: Error: Argument 1 to "append" of "list" has incompatible type "Type[CUDATestBase]"; expected "Type[CPUTestBase]"
-# tried to add Union to include both..
 device_type_test_bases.append(CPUTestBase)
 if torch.cuda.is_available():
     device_type_test_bases.append(CUDATestBase)
@@ -426,7 +426,8 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
 
         class_name = generic_test_class.__name__ + base.device_type.upper()
 
-        device_type_test_class: typing.Any  = type(class_name, (base, empty_class), {})
+        # type set to Any and suppressed due to unsupport runtime class: https://github.com/python/mypy/wiki/Unsupported-Python-Features
+        device_type_test_class: Any  = type(class_name, (base, empty_class), {})
 
         for name in generic_members:
             if name in generic_tests:  # Instantiates test member

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -4,7 +4,6 @@ import inspect
 import runpy
 import threading
 from functools import wraps
-# how to introduce ClassVar without importing typing?
 import typing
 import unittest
 import os
@@ -165,10 +164,7 @@ except ImportError:
 # List of device type test bases that can be used to instantiate tests.
 # See below for how this list is populated. If you're adding a device type
 # you should check if it's available and (if it is) add it to this list.
-
-#TDeviceTypeTestBase = TypeVar('TDeviceTypeTestBase', bound=DeviceTypeTestBase)
-# todo: need to fix
-device_type_test_bases : typing.List[typing.Union[CPUTestBase, CUDATestBase]] = []
+device_type_test_bases: typing.List[typing.Any] = list()
 
 def _construct_test_name(test_name, op, device_type, dtype):
     if op is not None:
@@ -270,9 +266,7 @@ class DeviceTypeTestBase(TestCase):
                 guard_precision = self.precision
                 try:
                     self.precision = self._get_precision_override(test_fn, dtype)
-                    args = (device_arg, dtype, op)
-                    # todo: need to fix.
-                    args = (arg for arg in args if arg is not None)
+                    args = (arg for arg in (device_arg, dtype, op) if arg is not None)
                     result = test_fn(self, *args)
                 finally:
                     self.precision = guard_precision
@@ -432,9 +426,7 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
 
         class_name = generic_test_class.__name__ + base.device_type.upper()
 
-        # todo: need to fix..
-        # device_type_test_class expects to be either CPUTestBase or CUDATestBase.. How to make it compatible with the right expression?
-        device_type_test_class: type(DeviceTypeTestBase)  = type(class_name, (base, empty_class), {})
+        device_type_test_class: typing.Any  = type(class_name, (base, empty_class), {})
 
         for name in generic_members:
             if name in generic_tests:  # Instantiates test member

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -14,7 +14,7 @@ from torch.testing import \
     (get_all_dtypes)
 
 try:
-    import psutil # type: ignore[import]
+    import psutil  #type: ignore[import]
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False
@@ -165,7 +165,8 @@ except ImportError:
 # See below for how this list is populated. If you're adding a device type
 # you should check if it's available and (if it is) add it to this list.
 
-# set type to List[Any] due to mypy list-of-union issue: https://github.com/python/mypy/issues/3351
+# set type to List[Any] due to mypy list-of-union issue:
+# https://github.com/python/mypy/issues/3351
 device_type_test_bases: List[Any] = list()
 
 def _construct_test_name(test_name, op, device_type, dtype):
@@ -426,8 +427,9 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
 
         class_name = generic_test_class.__name__ + base.device_type.upper()
 
-        # type set to Any and suppressed due to unsupport runtime class: https://github.com/python/mypy/wiki/Unsupported-Python-Features
-        device_type_test_class: Any  = type(class_name, (base, empty_class), {})
+        # type set to Any and suppressed due to unsupport runtime class:
+        # https://github.com/python/mypy/wiki/Unsupported-Python-Features
+        device_type_test_class: Any = type(class_name, (base, empty_class), {})
 
         for name in generic_members:
             if name in generic_tests:  # Instantiates test member

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -182,7 +182,7 @@ def _construct_test_name(test_name, op, device_type, dtype):
     return test_name
 
 class DeviceTypeTestBase(TestCase):
-    device_type : str = 'generic_device_type'
+    device_type: str = 'generic_device_type'
 
     # Precision is a thread-local setting since it may be overridden per test
     _tls = threading.local()


### PR DESCRIPTION
This PR intends to fix the type exceptions in common_device_type.py.