### PR TITLE
Directly use work.result() to retrieve tensor rather than passing as a separate argument

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -574,6 +574,8 @@ void Reducer::mark_variable_ready(VariableIndex index) {
     if (workHandle && !forwardPassWorkHandle_.useStaticWorldSize) {
       workHandle->wait();
       auto results = workHandle->result();
+      // Guard against the results being empty
+      TORCH_INTERNAL_ASSERT(results.size() > 0);
       at::Tensor& res = results.front();
       divFactor_ = res.item().to<int>();
     }

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -425,11 +425,9 @@ std::vector<std::vector<at::Tensor>> Reducer::get_bucket_tensors() const {
 
 void Reducer::set_forward_pass_work_handle(
     std::shared_ptr<c10d::ProcessGroup::Work> forwardPassWorkHandle,
-    at::Tensor& tensor,
     bool useStaticWorldSize) {
   std::lock_guard<std::mutex> lock(mutex_);
   forwardPassWorkHandle_.workHandle = std::move(forwardPassWorkHandle);
-  forwardPassWorkHandle_.resultTensor = tensor;
   forwardPassWorkHandle_.useStaticWorldSize = useStaticWorldSize;
 }
 
@@ -573,12 +571,11 @@ void Reducer::mark_variable_ready(VariableIndex index) {
   if (divFactor_ == kUnsetDivFactor) {
     divFactor_ = process_group_->getSize();
     auto& workHandle = forwardPassWorkHandle_.workHandle;
-    if (workHandle) {
-      if (!forwardPassWorkHandle_.useStaticWorldSize) {
-        workHandle->wait();
-        at::Tensor& res = forwardPassWorkHandle_.resultTensor;
-        divFactor_ = res.item().to<int>();
-      }
+    if (workHandle && !forwardPassWorkHandle_.useStaticWorldSize) {
+      workHandle->wait();
+      auto results = workHandle->result();
+      at::Tensor& res = results.front();
+      divFactor_ = res.item().to<int>();
     }
   }
 

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -575,7 +575,7 @@ void Reducer::mark_variable_ready(VariableIndex index) {
       workHandle->wait();
       auto results = workHandle->result();
       // Guard against the results being empty
-      TORCH_INTERNAL_ASSERT(!results.empty());
+      TORCH_INTERNAL_ASSERT(results.size() > 0);
       at::Tensor& res = results.front();
       divFactor_ = res.item().to<int>();
     }

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -575,7 +575,7 @@ void Reducer::mark_variable_ready(VariableIndex index) {
       workHandle->wait();
       auto results = workHandle->result();
       // Guard against the results being empty
-      TORCH_INTERNAL_ASSERT(results.size() > 0);
+      TORCH_INTERNAL_ASSERT(!results.empty());
       at::Tensor& res = results.front();
       divFactor_ = res.item().to<int>();
     }

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -89,10 +89,6 @@ class Reducer {
   // corresponding tensor being reduced.
   void set_forward_pass_work_handle(
       std::shared_ptr<c10d::ProcessGroup::Work> forwardPassWorkHandle,
-<<<<<<< HEAD
-      at::Tensor& tensor,
-=======
->>>>>>> 0646efd7bf... Change function signature and remove parameters
       bool useStaticWorldSize);
 
   // Retrieve on-device tensors used to track locally unused parameters. For

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -297,6 +297,7 @@ class Reducer {
   // forward pass, if applicable.
   struct ForwardPassAllreduceWork {
     std::shared_ptr<c10d::ProcessGroup::Work> workHandle;
+    at::Tensor resultTensor;
     // whether we should divide by the initial world_size or the no. of
     // remaining DDP ranks.
     bool useStaticWorldSize;

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -297,7 +297,6 @@ class Reducer {
   // forward pass, if applicable.
   struct ForwardPassAllreduceWork {
     std::shared_ptr<c10d::ProcessGroup::Work> workHandle;
-    at::Tensor resultTensor;
     // whether we should divide by the initial world_size or the no. of
     // remaining DDP ranks.
     bool useStaticWorldSize;

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -89,7 +89,10 @@ class Reducer {
   // corresponding tensor being reduced.
   void set_forward_pass_work_handle(
       std::shared_ptr<c10d::ProcessGroup::Work> forwardPassWorkHandle,
+<<<<<<< HEAD
       at::Tensor& tensor,
+=======
+>>>>>>> 0646efd7bf... Change function signature and remove parameters
       bool useStaticWorldSize);
 
   // Retrieve on-device tensors used to track locally unused parameters. For

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -576,12 +576,9 @@ class DistributedDataParallel(Module):
 
     def forward(self, *inputs, **kwargs):
         if self.ddp_join_enabled:
-            ones = torch.ones(
-                1, device=self.device
-            )
             work = dist.all_reduce(ones, group=self.process_group, async_op=True)
             self.reducer._set_forward_pass_work_handle(
-                work, ones, self.ddp_join_divide_by_initial_world_size
+                work, self.ddp_join_divide_by_initial_world_size
             )
 
         # Calling _rebuild_buckets before forward compuation,

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -576,6 +576,9 @@ class DistributedDataParallel(Module):
 
     def forward(self, *inputs, **kwargs):
         if self.ddp_join_enabled:
+            ones = torch.ones(
+                1, device=self.device
+            )
             work = dist.all_reduce(ones, group=self.process_group, async_op=True)
             self.reducer._set_forward_pass_work_handle(
                 work, self.ddp_join_divide_by_initial_world_size


### PR DESCRIPTION
We currently are fetching an allreduced tensor from Python in C++ in, where we are storing the resulting tensor in a struct's parameter. This PR removes extra tensor paratemeter in the function parameter and fetch from a single place.

Fixes #43960 
