### PR TITLE
[PyTorch] Remove unused cudaGetDevice call

### DIFF
--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -15,9 +15,6 @@ static PyObject * THCPStream_pynew(
   PyTypeObject *type, PyObject *args, PyObject *kwargs) {
   HANDLE_TH_ERRORS
 
-  int current_device;
-  THCudaCheck(cudaGetDevice(&current_device));
-
   int priority = 0;
   uint64_t cdata = 0;
 


### PR DESCRIPTION
# Summary
Fixes https://github.com/pytorch/pytorch/issues/44898. 

# Test Plan
Rebuilt with `python setup.py develop` and ran `python test/test_torch.py`.

