### PR TITLE
[JIT] Prohibit subscripted assignments for tuple types

### DIFF
--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -45,7 +45,7 @@ struct QualifiedName {
     atoms_ = atoms;
     cacheAccessors();
   }
-  // Unnecessary copy. Ideally we'd use somoething like std::string_view.
+  // Unnecessary copy. Ideally we'd use something like std::string_view.
   /* implicit */ QualifiedName(const char* name)
       : QualifiedName(std::string(name)) {}
 

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -458,6 +458,17 @@ class TestScriptPy3(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, r"Attempted to use Tuple without a contained type"):
             torch.jit.script(annotated_fn)
 
+    def test_tuple_subscripted_assign(self):
+        with self.assertRaisesRegex(RuntimeError, "subscripted assignment"):
+            @torch.jit.script
+            def foo(a: Tuple[int, int]) -> None:
+                a[0] = a[1]
+
+        with self.assertRaisesRegex(RuntimeError, "augmented assignment"):
+            @torch.jit.script
+            def bar(a: Tuple[int, int]) -> None:
+                a[0] += a[1]
+
     def test_subexpression_List_Future(self):
 
         @torch.jit.script

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2268,6 +2268,10 @@ struct to_ir {
             << " subscripted assignment. "
             << "File a bug if you want this";
       }
+      if (sliceable->type()->isSubtypeOf(AnyTupleType::get())) {
+        throw ErrorReport(lhs)
+            << sliceable->type()->repr_str() << " does not support subscripted assignment";
+      }
 
       std::vector<NamedValue> args;
       args.emplace_back(lhs.value().range(), "self", sliceable);

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2269,8 +2269,8 @@ struct to_ir {
             << "File a bug if you want this";
       }
       if (sliceable->type()->isSubtypeOf(AnyTupleType::get())) {
-        throw ErrorReport(lhs)
-            << sliceable->type()->repr_str() << " does not support subscripted assignment";
+        throw ErrorReport(lhs) << sliceable->type()->repr_str()
+                               << " does not support subscripted assignment";
       }
 
       std::vector<NamedValue> args;


### PR DESCRIPTION
This would force jit.script to raise an error if someone tries to mutate tuple
```
Tuple[int, int] does not support subscripted assignment:
  File "/home/nshulga/test/tupleassignment.py", line 9
@torch.jit.script
def foo(x: Tuple[int, int]) -> int:
    x[-1] = x[0] + 1
    ~~~~~ <--- HERE
```