### PR TITLE
[caffe2/aten] Fix clang build

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -318,5 +318,7 @@ inline __device__ float gpuAtomicMul (float * address, float val) {
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
   } while (assumed != old);
+
+  return __int_as_float(old);
 }
 #endif // THC_ATOMICS_INC


### PR DESCRIPTION
Summary:
Fix build errors when using clang to build cuda sources:

```
In file included from aten/src/ATen/native/cuda/DistributionBernoulli.cu:4:
In file included from aten/src/ATen/cuda/CUDAApplyUtils.cuh:5:
caffe2/aten/src/THC/THCAtomics.cuh:321:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
1 error generated when compiling for sm_70.

In file included from aten/src/ATen/native/cuda/DistributionBernoulli.cu:4:
In file included from aten/src/ATen/cuda/CUDAApplyUtils.cuh:5:
caffe2/aten/src/THC/THCAtomics.cuh:321:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
1 error generated when compiling for sm_60.

In file included from aten/src/ATen/native/cuda/DistributionBernoulli.cu:4:
In file included from aten/src/ATen/cuda/CUDAApplyUtils.cuh:5:
caffe2/aten/src/THC/THCAtomics.cuh:321:1: error: control reaches end of non-void function [-Werror,-Wreturn-type]
}
^
1 error generated when compiling for sm_52.
```

Test Plan: CI

Differential Revision: D23775266

