### PR TITLE
histogram observer: ensure buffer shape consistency

### DIFF
--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -461,6 +461,17 @@ class TestObserver(QuantizationTestCase):
         self.assertEqual(min_shape_before, obs.min_val.shape)
         self.assertEqual(max_shape_before, obs.max_val.shape)
 
+    def test_histogram_observer_save_load_state_dict(self):
+        """
+        Smoke test on saving/loading state_dict
+        """
+        obs1 = HistogramObserver()
+        obs1(torch.randn(4, 4, 4, 4))
+        obs2 = HistogramObserver()
+        obs2.load_state_dict(obs1.state_dict())
+        self.assertEqual(obs2.min_val.shape, torch.Size([]))
+        self.assertEqual(obs2.max_val.shape, torch.Size([]))
+
 
 # HistogramObserver that works like it does on master
 class _ReferenceHistogramObserver(HistogramObserver):

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -448,6 +448,19 @@ class TestObserver(QuantizationTestCase):
                 model_device = next(iter(model_devices))
                 self.assertEqual(model_device, device_target)
 
+    def test_histogram_observer_consistent_buffer_shape(self):
+        """
+        Ensures that the buffer shapes do not change from uninitialized to
+        initialized states for HistogramObserver.
+        """
+        obs = HistogramObserver()
+        min_shape_before = obs.min_val.shape
+        max_shape_before = obs.max_val.shape
+        for _ in range(2):
+            obs(torch.randn(4, 4, 4, 4))
+        self.assertEqual(min_shape_before, obs.min_val.shape)
+        self.assertEqual(max_shape_before, obs.max_val.shape)
+
 
 # HistogramObserver that works like it does on master
 class _ReferenceHistogramObserver(HistogramObserver):

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -96,12 +96,18 @@ class _ObserverBase(ObserverBase):
         - ``torch.per_channel_symmetric``
     """
 
+    # Note: the version is shared by all observer types
+    #
     # Version 1/None
     #   self
     #
-    # Version 2
+    # Version 2 (base class only, does not include child class buffers)
     #   self
     #   |--- eps : Tensor
+    #
+    # Version 3
+    #   for HistogramObserver only, changed the shape of uninitialized
+    #   min_val and max_val buffers from torch.Size([0]) to torch.Size([])
     _version = 2
 
     def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine,
@@ -629,6 +635,7 @@ class PerChannelMinMaxObserver(_ObserverBase):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
+
         local_state = ['min_vals', 'max_vals']
         for name in local_state:
             key = prefix + name
@@ -957,7 +964,9 @@ class HistogramObserver(_ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        if self.min_val.numel() == 0 or self.max_val.numel() == 0:
+        is_uninitialized = (self.min_val == float('inf') and
+                            self.max_val == float('-inf'))
+        if is_uninitialized:
             warnings.warn(
                 "must run observer before calling calculate_qparams.\
                                     Returning default scale and zero point "
@@ -979,6 +988,18 @@ class HistogramObserver(_ObserverBase):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
+        version = local_metadata.get('version', None)
+
+        if version is None or version < 3:
+            # if min_val and max_val are not initialized, update their shape
+            # to account for the differences between v2 and v3
+            min_val_name, max_val_name = prefix + 'min_val', prefix + 'max_val'
+            if min_val_name in state_dict:
+                if state_dict[min_val_name].shape == torch.Size([0]):
+                    state_dict[min_val_name] = torch.tensor(float('inf'))
+            if max_val_name in state_dict:
+                if state_dict[max_val_name].shape == torch.Size([0]):
+                    state_dict[max_val_name] = torch.tensor(float('-inf'))
 
         local_state = ['min_val', 'max_val']
         for name in local_state:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44956 histogram observer: ensure buffer shape consistency**

Summary:

Makes buffer shapes for HistogramObserver have the
same shapes in uninitialized versus initialized states.

This is useful because the detectron2 checkpointer assumes
that these states will stay the same, so it removes the
need for manual hacks around the shapes changing.

Test Plan:

```
python test/test_quantization.py TestObserver.test_histogram_observer_consistent_buffer_shape
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23785382](https://our.internmc.facebook.com/intern/diff/D23785382)