### PR TITLE
[JIT] Do not allow creating generics with None types

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -265,7 +265,8 @@ struct SingleElementType : public Type {
  protected:
   SingleElementType(TypePtr elem) : Type(Kind), elem(std::move(elem)) {
     if (!this->elem) {
-      throw std::runtime_error("Can not create Generic with None type");
+      throw std::runtime_error(c10::str(
+            "Can not create ", typeKindToString(Kind), " with None type"));
     }
   }
 

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -263,7 +263,11 @@ struct SingleElementType : public Type {
   }
 
  protected:
-  SingleElementType(TypePtr elem) : Type(Kind), elem(std::move(elem)) {}
+  SingleElementType(TypePtr elem) : Type(Kind), elem(std::move(elem)) {
+    if (!this->elem) {
+      throw std::runtime_error("Can not create Generic with None type");
+    }
+  }
 
  private:
   TypePtr elem;

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -716,6 +716,9 @@ TupleType::TupleType(
       schema_(std::move(schema)) {
   has_free_variables_ =
       std::any_of(elements_.begin(), elements_.end(), [](TypePtr v) {
+        if (!v) {
+          throw std::runtime_error("Can not create tuple with None type");
+        }
         return v->hasFreeVariables();
       });
   if (schema_) {

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1155,6 +1155,11 @@ class TestList(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, r"Attempted to use List without a contained type"):
             torch.jit.script(annotated_fn)
 
+    def test_list_none(self):
+        with self.assertRaisesRegex(RuntimeError, "Can not create ListType with None type"):
+            x = torch._C.ListType(None)
+
+
 
 class TestDict(JitTestCase):
     def dict(self):


### PR DESCRIPTION
Otherwise, invoking something like  `python -c "import torch._C;print(torch._C.ListType(None))"` will result in SIGSEGV

Discovered while trying to create a torch script for function with the following type annotation `Tuple[int, Ellipsis] -> None`
