### PR TITLE
Gitignore cachegrind and callgrind files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,6 @@ TAGS
 
 # bazel symlinks
 bazel-*
+
+cachegrind*
+callgrind*


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44799 Conjugate view tensor
* **#44962 Gitignore cachegrind and callgrind files**
* #44722 Vectorize complex copy.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>