### PR TITLE
Fix type hint warnings for common_methods_invocations.py

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -62,9 +62,6 @@ ignore_errors = True
 [mypy-torch.testing._internal.hypothesis_utils.*]
 ignore_errors = True
 
-[mypy-torch.testing._internal.common_methods_invocations.*]
-ignore_errors = True
-
 [mypy-torch.testing._internal.common_nn.*]
 ignore_errors = True
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1,6 +1,7 @@
 from functools import reduce
 from operator import mul, itemgetter
 import collections
+import typing
 
 import torch
 import numpy as np

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7,6 +7,8 @@ import numpy as np
 from torch._six import inf, istuple
 from torch.autograd import Variable
 
+from typing import List, Tuple, Dict, Any
+
 from torch.testing import \
     (make_non_contiguous, _dispatch_dtypes,
      floating_types, floating_types_and, floating_and_complex_types,
@@ -1540,7 +1542,7 @@ tri_tests_args = [
     (2028, 1, -1)
 ]
 
-tri_large_tests_args = [
+tri_large_tests_args: List[Tuple[int, ...]] = [
     # Large test cases below are deliberately commented out to speed up CI
     # tests and to avoid OOM error. When modifying implementations of
     # tril_indices and triu_indices, please enable these tests and make sure
@@ -1602,9 +1604,9 @@ EXCLUDE_FUNCTIONAL = {
     'reshape',
     'where'  # argument order
 }
-EXCLUDE_GRADCHECK = {
+EXCLUDE_GRADCHECK: Dict[str, Any]  = {
 }
-EXCLUDE_GRADGRADCHECK = {
+EXCLUDE_GRADGRADCHECK: Dict[str, Any]  = {
 }
 EXCLUDE_GRADGRADCHECK_BY_TEST_NAME = {
     # *det methods uses svd in backward when matrix is not invertible. However,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1,7 +1,6 @@
 from functools import reduce
 from operator import mul, itemgetter
 import collections
-import typing
 
 import torch
 import numpy as np
@@ -1605,9 +1604,9 @@ EXCLUDE_FUNCTIONAL = {
     'reshape',
     'where'  # argument order
 }
-EXCLUDE_GRADCHECK: Dict[str, Any]  = {
+EXCLUDE_GRADCHECK: Dict[str, Any] = {
 }
-EXCLUDE_GRADGRADCHECK: Dict[str, Any]  = {
+EXCLUDE_GRADGRADCHECK: Dict[str, Any] = {
 }
 EXCLUDE_GRADGRADCHECK_BY_TEST_NAME = {
     # *det methods uses svd in backward when matrix is not invertible. However,


### PR DESCRIPTION
Fixes a subtask of #42969 

Tested the following and no warnings were seen.

python test/test_type_hints.py         
....
----------------------------------------------------------------------
Ran 4 tests in 180.759s

OK



