### PR TITLE
fix issue with scoping of globals

### DIFF
--- a/torch/utils/_benchmark/utils/valgrind_wrapper/callgrind_trampoline.cpp
+++ b/torch/utils/_benchmark/utils/valgrind_wrapper/callgrind_trampoline.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include <pybind11/embed.h>
 #include <pybind11/pybind11.h>
 
@@ -5,12 +7,12 @@ namespace py = pybind11;
 
 void callgrind_block() {
     /*
-    `stmt_fn` is a magical method defined elsewhere. This method
+    `eval(expr)` is a magical eval defined elsewhere. This method
     works because py::exec shares the same interpreter (and therefore globals)
     as the caller.
     */
     py::exec(R"(
-        stmt_fn()
+        eval(expr)
     )");
 
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44970 [wip] Coalesce TLS accesses in RecordFunction constructor
* #44981 fix (hopefully) issue with subprocess.PIPE causing deadlocks
* #44980 add less noisy counts, and partially unroll loop to reduce background instructions.
* #44979 switch back to control macro approach
* **#44978 fix issue with scoping of globals**
* #44977 replace callgrind macro control with pybind trampoline
* #44976 trim valgrind.h to the parts we need and support multi-line statements
* #44975 move callgrind control to pybind module, and refactor how counts are returned from
* #44974 Add callgrind collection to Timer

