### PR TITLE
[CircleCI] Fix CUDA test setup

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -126,20 +126,21 @@ def TruePred(_):
 
 # MKLDNN compilation fails with VC-19.27
 _VC2019 = VcSpec(2019, ["14", "26"], hide_version=True)
+_VC2019_Latest = VcSpec(2019)
 
 WORKFLOW_DATA = [
     # VS2019 CUDA-10.1
     WindowsJob(None, _VC2019, CudaVersion(10, 1)),
-    WindowsJob(1, _VC2019, CudaVersion(10, 1)),
-    WindowsJob(2, _VC2019, CudaVersion(10, 1)),
+    WindowsJob(1, _VC2019_Latest, CudaVersion(10, 1)),
+    WindowsJob(2, _VC2019_Latest, CudaVersion(10, 1)),
     # VS2019 CUDA-11.0
     WindowsJob(None, _VC2019, CudaVersion(11, 0)),
-    WindowsJob(1, _VC2019, CudaVersion(11, 0), master_only_pred=TruePred),
-    WindowsJob(2, _VC2019, CudaVersion(11, 0), master_only_pred=TruePred),
+    WindowsJob(1, _VC2019_Latest, CudaVersion(11, 0), master_only_pred=TruePred),
+    WindowsJob(2, _VC2019_Latest, CudaVersion(11, 0), master_only_pred=TruePred),
     # VS2019 CPU-only
     WindowsJob(None, _VC2019, None),
-    WindowsJob(1, _VC2019, None, master_only_pred=TruePred),
-    WindowsJob(2, _VC2019, None, master_only_pred=TruePred),
+    WindowsJob(1, _VC2019_Latest, None, master_only_pred=TruePred),
+    WindowsJob(2, _VC2019_Latest, None, master_only_pred=TruePred),
     WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True, master_only_pred=TruePred),
 ]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7122,7 +7122,7 @@ workflows:
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: Community
-          vc_version: "14.26"
+          vc_version: ""
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
@@ -7135,7 +7135,7 @@ workflows:
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: Community
-          vc_version: "14.26"
+          vc_version: ""
           vc_year: "2019"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
@@ -7163,7 +7163,7 @@ workflows:
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: Community
-          vc_version: "14.26"
+          vc_version: ""
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
@@ -7182,7 +7182,7 @@ workflows:
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: Community
-          vc_version: "14.26"
+          vc_version: ""
           vc_year: "2019"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cpu-py3
@@ -7209,7 +7209,7 @@ workflows:
           test_name: pytorch-windows-test1
           use_cuda: "0"
           vc_product: Community
-          vc_version: "14.26"
+          vc_version: ""
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
@@ -7227,7 +7227,7 @@ workflows:
           test_name: pytorch-windows-test2
           use_cuda: "0"
           vc_product: Community
-          vc_version: "14.26"
+          vc_version: ""
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3


### PR DESCRIPTION
Circle updated windows-nvidia-2019:canary image to exclude VC++ 14.26
Update the config to use 14.27
