### PR TITLE
[jit/detectron2] support @jit.ignore + properties

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -628,6 +628,11 @@ class TestScriptPy3(JitTestCase):
             def ignored_attr(self):
                 return sum([self.a])
 
+            @property
+            @jit.ignore
+            def ignored_attr_2(self):
+                return sum([self.a])
+
             @attr.setter
             def attr(self, a: int):
                 if a > 0:
@@ -657,6 +662,9 @@ class TestScriptPy3(JitTestCase):
 
         with self.assertRaisesRegex(torch.nn.modules.module.ModuleAttributeError, "has no attribute"):
             scripted_mod.ignored_attr
+
+        with self.assertRaisesRegex(torch.nn.modules.module.ModuleAttributeError, "has no attribute"):
+            scripted_mod.ignored_attr_2
 
     def test_export_opnames_interface(self):
         global OneTwoModule

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -16,7 +16,7 @@ from torch._C._jit_tree_views import (
 )
 from torch._utils_internal import get_source_lines_and_file
 
-from torch._jit_internal import SourceContext, should_drop, is_static_fn
+from torch._jit_internal import SourceContext, should_drop, is_ignored_fn, is_static_fn
 import torch.jit.annotations
 
 # Borrowed from cPython implementation
@@ -147,7 +147,7 @@ def get_class_properties(cls, self_name):
     # Create Property TreeView objects from inspected property objects.
     properties = []
     for prop in props:
-        if prop[0] not in ignored_properties:
+        if prop[0] not in ignored_properties and not is_ignored_fn(prop[1].fget):
             getter = get_jit_def(prop[1].fget, f"__{prop[0]}_getter", self_name=self_name)
             setter = get_jit_def(prop[1].fset, f"__{prop[0]}_setter", self_name=self_name) if prop[1].fset else None
             properties.append(Property(getter.range(), Ident(getter.range(), prop[0]), getter, setter))


### PR DESCRIPTION
Summary:
This way it should be backward-compatible (tested on PyTorch 1.4-6 at
https://app.circleci.com/pipelines/github/facebookresearch/detectron2/890/workflows/c843a73a-9ba1-4b3d-91dd-0a98ff82db22)

Test Plan: buck test mode/dev-nosan //vision/fair/detectron2/tests:test_anchor_generator

Differential Revision: D23797598

