### PR TITLE
add .cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,6 +261,7 @@ TAGS
 
 # clangd background index
 .clangd/
+.cache/
 
 # bazel symlinks
 bazel-*


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45017 add .cache to gitignore**

this is the default indexing folder for clangd 11.

Differential Revision: [D23817619](https://our.internmc.facebook.com/intern/diff/D23817619)