### PR TITLE
Incorrect Reference to SGD by Sutskever

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -45,8 +45,8 @@ class SGD(Optimizer):
 
         .. math::
             \begin{aligned}
-                v_{t+1} & = \mu * v_{t} + \text{lr} * g_{t+1}, \\
-                p_{t+1} & = p_{t} - v_{t+1}.
+                v_{t+1} & = \mu * v_{t} - \text{lr} * g_{t+1}, \\
+                p_{t+1} & = p_{t} + v_{t+1}.
             \end{aligned}
 
         The Nesterov version is analogously modified.


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/44917


Wrong interpretation of SGD algorithm by [Sutskever et. al. (2013)](http://proceedings.mlr.press/v28/sutskever13.pdf)

```
                v_{t+1} & = \mu * v_{t} + \text{lr} * g_{t+1}, \\
                p_{t+1} & = p_{t} - v_{t+1}.
```

Should instead be (notice the signs): 

```
                v_{t+1} & = \mu * v_{t} - \text{lr} * g_{t+1}, \\
                p_{t+1} & = p_{t} + v_{t+1}.
```

Fixes #44917
