### PR TITLE
[vulkan] Disable USE_VULKAN_WRAPPER for Vulkan CI tests

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -123,6 +123,7 @@ fi
 
 if [[ "$BUILD_ENVIRONMENT" != *android* && "$BUILD_ENVIRONMENT" == *vulkan-linux* ]]; then
   export USE_VULKAN=1
+  export USE_VULKAN_WRAPPER=0
   export VULKAN_SDK=/var/lib/jenkins/vulkansdk/
 fi
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45076 [vulkan] Disable USE_VULKAN_WRAPPER for Vulkan CI tests**
* #45075 [vulkan] support dimensions negative indexing
* #44897 [vulkan][android][test_app] Add test_app variant that runs module on Vulkan
* #44896 [android][vulkan] Module load argument to specify device cpu/vulkan

