### PR TITLE
Add operator to compute the equalization scale

### DIFF
--- a/caffe2/quantization/server/compute_equalization_scale.cc
+++ b/caffe2/quantization/server/compute_equalization_scale.cc
@@ -1,0 +1,96 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+#include "caffe2/quantization/server/compute_equalization_scale.h"
+#include <functional>
+
+namespace caffe2 {
+using namespace std;
+
+bool ComputeEqualizationScaleOp::RunOnDevice() {
+  // Generate equalization scale based on the input data (last N samples of
+  // the activations) and the weight
+  const auto& X = Input(0);
+  const auto& W = Input(1);
+  CAFFE_ENFORCE_EQ(X.dim(), 2);
+  CAFFE_ENFORCE_EQ(W.dim(), 2);
+
+  const int64_t M = X.size_to_dim(1);
+  const int64_t N = W.size_to_dim(1);
+  const int64_t K = W.size_from_dim(1);
+  auto* S = Output(0, K, at::dtype<float>());
+  auto* S_INV = Output(1, K, at::dtype<float>());
+  const float* X_data = X.template data<float>();
+  const float* W_data = W.template data<float>();
+  float* S_data = S->template mutable_data<float>();
+  float* S_INV_data = S_INV->template mutable_data<float>();
+
+  float WcolMax, XcolMax;
+  for (int64_t j = 0; j < K; j++) {
+    WcolMax = std::abs(W_data[j]);
+    XcolMax = std::abs(X_data[j]);
+    int64_t idx;
+    for (int64_t i = 0; i < N; i++) {
+      idx = i * K + j;
+      WcolMax = std::max(WcolMax, std::abs(W_data[idx]));
+    }
+    for (int64_t i = 0; i < M; i++) {
+      idx = i * K + j;
+      XcolMax = std::max(XcolMax, std::abs(X_data[idx]));
+    }
+    if (WcolMax == 0 || XcolMax == 0) {
+      S_data[j] = 1;
+      S_INV_data[j] = 1;
+    } else {
+      S_data[j] = std::sqrt(WcolMax / XcolMax);
+      S_INV_data[j] = 1 / S_data[j];
+    }
+  }
+  return true;
+}
+
+REGISTER_CPU_OPERATOR(ComputeEqualizationScale, ComputeEqualizationScaleOp);
+OPERATOR_SCHEMA(ComputeEqualizationScale)
+    .NumInputs(2)
+    .NumOutputs(2)
+    .SetDoc(R"DOC(
+Given a weight matrix W and input matrix X, the output S is the equalization parameter
+vector computed from W and X, and S_INV = 1 / S
+
+S is computed by:
+S[j] = max(abs(W[][j])) == 0 || max(abs(X[][j])) == 0 ? 1 :
+  sqrt(max(abs(W[][j])) / max(abs(X[][j]))),
+
+)DOC")
+    .TensorInferenceFunction([](const OperatorDef& /* def */,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out(2);
+
+      if (in[0].unknown_shape() || in[1].unknown_shape()) {
+        out[0].set_unknown_shape(true);
+        out[1].set_unknown_shape(true);
+        return out;
+      }
+      const int64_t K = size_from_dim_(1, GetDimsVector(in[0]));
+      vector<int64_t> s_shape(2);
+      s_shape[0] = 1;
+      s_shape[1] = K;
+      out[0] = CreateTensorShape(s_shape, TensorProto_DataType_FLOAT);
+      out[1] = CreateTensorShape(s_shape, TensorProto_DataType_FLOAT);
+      return out;
+    })
+    .Input(
+        0,
+        "X",
+        "The input data, or last N samples of the output activations.")
+    .Input(1, "W", "The weight that we want to equalize with the input.")
+    .Output(
+        0,
+        "S",
+        "Scale computed that will be multiplied to the columns of input.")
+    .Output(
+        1,
+        "S_INV",
+        "Scale inverse that will be multiplied to the columns of weight.")
+    .SetDoc(
+        R"DOC(Operator to compute equalization scale given the input data and weight)DOC");
+
+} // namespace caffe2

--- a/caffe2/quantization/server/compute_equalization_scale.h
+++ b/caffe2/quantization/server/compute_equalization_scale.h
@@ -1,0 +1,18 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+#include "caffe2/quantization/server/caffe2_dnnlowp_utils.h"
+#include "caffe2/quantization/server/dnnlowp.h"
+
+namespace caffe2 {
+
+class ComputeEqualizationScaleOp final : public Operator<CPUContext> {
+ public:
+  ComputeEqualizationScaleOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override;
+
+}; // class ComputeEqualizationScaleOp
+
+} // namespace caffe2

--- a/caffe2/quantization/server/compute_equalization_scale_test.py
+++ b/caffe2/quantization/server/compute_equalization_scale_test.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core
+from hypothesis import given, settings
+
+
+class TestComputeEqualizationScaleOp(hu.HypothesisTestCase):
+    @settings(max_examples=10)
+    @given(
+        m=st.integers(1, 50),
+        n=st.integers(1, 50),
+        k=st.integers(1, 50),
+        rnd_seed=st.integers(1, 5),
+        **hu.gcs_cpu_only
+    )
+    def test_compute_equalization_scale(self, m, n, k, rnd_seed, gc, dc):
+        np.random.seed(rnd_seed)
+        W = np.random.rand(n, k).astype(np.float32) - 0.5
+        X = np.random.rand(m, k).astype(np.float32) - 0.5
+
+        def ref_compute_equalization_scale(X, W):
+            S = np.ones([X.shape[1]])
+            S_INV = np.ones([X.shape[1]])
+            for j in range(W.shape[1]):
+                WcolMax = np.absolute(W[:, j]).max()
+                XcolMax = np.absolute(X[:, j]).max()
+                if WcolMax and XcolMax:
+                    S[j] = np.sqrt(WcolMax / XcolMax)
+                    S_INV[j] = 1 / S[j]
+            return S, S_INV
+
+        net = core.Net("test")
+
+        ComputeEqualizationScaleOp = core.CreateOperator("ComputeEqualizationScale", ["X", "W"], ["S", "S_INV"])
+        net.Proto().op.extend([ComputeEqualizationScaleOp])
+
+        self.ws.create_blob("X").feed(X, device_option=gc)
+        self.ws.create_blob("W").feed(W, device_option=gc)
+        self.ws.run(net)
+
+        S = self.ws.blobs["S"].fetch()
+        S_INV = self.ws.blobs["S_INV"].fetch()
+        S_ref, S_INV_ref = ref_compute_equalization_scale(X, W)
+        np.testing.assert_allclose(S, S_ref, atol=1e-3, rtol=1e-3)
+        np.testing.assert_allclose(S_INV, S_INV_ref, atol=1e-3, rtol=1e-3)


### PR DESCRIPTION
Summary:
Add operator to compute the equalization scale. This will be used in the integration of equalization into dper int8 fixed quant scheme quantization flow.

Design docs:
https://fb.quip.com/bb7SAGBxPGNC

https://fb.quip.com/PDAOAsgoLfRr

Test Plan: buck test caffe2/caffe2/quantization/server:compute_equalization_scale_test

Differential Revision: D23779870

