### PR TITLE
Switch all Sequences in tools.codegen.model to Tuple

### DIFF
--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -1,7 +1,7 @@
 import re
 
 from dataclasses import dataclass
-from typing import List, Sequence, Dict, Optional, Iterator, Tuple, Set, NoReturn
+from typing import List, Dict, Optional, Iterator, Tuple, Set, NoReturn
 from enum import Enum
 import itertools
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45277 [PROTOTYPE] Structured kernel definitions
* #45131 Add NativeFunction.signature and kind.
* **#45127 Switch all Sequences in tools.codegen.model to Tuple**

I thought I was being clever by using Sequence, which doesn't commit to
List or Tuple, but forces read-onlyness in the type system.  However,
there is runtime implication to using List or Tuple: Lists can't be
hashed, but Tuples can be!  This is important because I shortly want
to group by FunctionSchema, and to do this I need FunctionSchema to
be hashable.  Switch everything to Tuple for true immutability.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D23872527](https://our.internmc.facebook.com/intern/diff/D23872527)