### PR TITLE
gitignore generated *.hip files and hip/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,13 @@ TAGS
 
 # bazel symlinks
 bazel-*
+
+# ROCm/HIP files
+*.hip
+*/hip/
+*/*/hip/
+*/*/*/hip/
+*/*/*/*/hip/
+*/*/*/*/*/hip/
+aten/src/THH/
+aten/src/THHUNN/


### PR DESCRIPTION
Add *.hip files and hip/ directories to gitignore list.  Intentionally added to the `BEGIN NOT-CLEAN-FILES` section to avoid deleting the files when rebuilding.