### PR TITLE
Fix preserve submodule attribute in freezing

### DIFF
--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -42,7 +42,14 @@ class AttributePropagator {
     // explicitly.
     auto checkName = [this](std::string& name) {
       if (module_.hasattr(name)) {
-        insertMutableAttr(name, module_.attr(name), module_._ivalue());
+        auto attr = module_.attr(name);
+
+        // Freezing client wants to presever this submodule. When cleaning
+        // the frozen module, make sure it will be preserved entirely.
+        if (attr.isModule()) {
+          preservedSubModule_.insert(attr.toModule()._ivalue());
+        }
+        insertMutableAttr(name, attr, module_._ivalue());
         return true;
       }
 
@@ -498,7 +505,7 @@ class AttributePropagator {
         return true;
       }
     }
-    return false;
+    return preservedSubModule_.count(subModule._ivalue());
   }
 
   // cleanupFrozenModule function cleans up the Frozen module. It performs the
@@ -651,6 +658,9 @@ class AttributePropagator {
 
   // Contains user specified methods to be preserved in frozen module.
   std::unordered_set<Function*> preservedMethods_;
+
+  // Contains user specified sub module to be preserve in frozen module.
+  std::unordered_set<ModulePtr> preservedSubModule_;
 
   // Track all used attributes ivalues that can be aliased.
   IValue::HashAliasedIValues usedAttrs_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45143 Fix preserve submodule attribute in freezing**

This PR prevents freezing cleaning up a submodule when user requests to
preserve a submodule.

Differential Revision: [D23844969](https://our.internmc.facebook.com/intern/diff/D23844969)