### PR TITLE
Make cudaHostRegister actually useful on cudart.

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -281,11 +281,14 @@ class TestCuda(TestCase):
 
     def test_cudart_register(self):
         t = torch.ones(20)
+        self.assertFalse(t.is_pinned())
         cudart = torch.cuda.cudart()
         r = cudart.cudaHostRegister(t.data_ptr(), t.numel() * t.element_size(), 0)
         self.assertEquals(r, 0)
+        self.assertTrue(t.is_pinned())
         r = cudart.cudaHostUnregister(t.data_ptr())
         self.assertEquals(r, 0)
+        self.assertFalse(t.is_pinned())
 
     def test_memory_stats(self):
         gc.collect()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -279,6 +279,14 @@ class TestCuda(TestCase):
         assert_change(0, empty_cache=True)
         assert_change(0, reset_peak=True)
 
+    def test_cudart_register(self):
+        t = torch.ones(20)
+        cudart = torch.cuda.cudart()
+        r = cudart.cudaHostRegister(t.data_ptr(), t.numel() * t.element_size(), 0)
+        self.assertEquals(r, 0)
+        r = cudart.cudaHostUnregister(t.data_ptr())
+        self.assertEquals(r, 0)
+
     def test_memory_stats(self):
         gc.collect()
         torch.cuda.empty_cache()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -279,6 +279,7 @@ class TestCuda(TestCase):
         assert_change(0, empty_cache=True)
         assert_change(0, reset_peak=True)
 
+    @skipIfRocm
     def test_cudart_register(self):
         t = torch.ones(20)
         self.assertFalse(t.is_pinned())

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -29,7 +29,12 @@ void initCudartBindings(PyObject* module) {
   cudart.def("cuda" "GetErrorString", cudaGetErrorString);
   cudart.def("cuda" "ProfilerStart", cudaProfilerStart);
   cudart.def("cuda" "ProfilerStop", cudaProfilerStop);
-  cudart.def("cuda" "HostRegister", cudaHostRegister);
+  cudart.def("cuda" "HostRegister", [](uintptr_t ptr, size_t size, unsigned int flags) -> cudaError_t {
+    return cudaHostRegister((void*)ptr, size, flags);
+  });
+  cudart.def("cuda" "HostUnregister", [](uintptr_t ptr) -> cudaError_t {
+    return cudaHostUnregister((void*)ptr);
+  });
 #ifndef __HIP_PLATFORM_HCC__
   cudart.def("cuda" "ProfilerInitialize", cudaProfilerInitialize);
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45159 Make cudaHostRegister actually useful on cudart.**

By default, pybind11 binds void* to be capsules.  After a lot of
Googling, I have concluded that this is not actually useful:
you can't actually create a capsule from Python land, and our
data_ptr() function returns an int, which means that the
function is effectively unusable.  It didn't help that we had no
tests exercising it.

I've replaced the void* with uintptr_t, so that we now accept int
(and you can pass data_ptr() in directly).  I'm not sure if we
should make these functions accept ctypes types; unfortunately,
pybind11 doesn't seem to have any easy way to do this.

Fixes #43006

Also added cudaHostUnregister which was requested.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D23849731](https://our.internmc.facebook.com/intern/diff/D23849731)