### PR TITLE
[ONNX] Update floor_divide ONNX export to stay consistent

### DIFF
--- a/test/onnx/expect/TestOperators.test_remainder.expect
+++ b/test/onnx/expect/TestOperators.test_remainder.expect
@@ -3,30 +3,41 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "0"
     input: "1"
     output: "2"
-    name: "Div_0"
+    name: "Cast_0"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 1
+      type: INT
+    }
+  }
+  node {
+    input: "0"
+    input: "2"
+    output: "3"
+    name: "Div_1"
     op_type: "Div"
   }
   node {
-    input: "2"
-    output: "3"
-    name: "Floor_1"
+    input: "3"
+    output: "4"
+    name: "Floor_2"
     op_type: "Floor"
   }
   node {
-    input: "3"
-    input: "1"
-    output: "4"
-    name: "Mul_2"
+    input: "4"
+    input: "2"
+    output: "5"
+    name: "Mul_3"
     op_type: "Mul"
   }
   node {
     input: "0"
-    input: "4"
-    output: "5"
-    name: "Sub_3"
+    input: "5"
+    output: "6"
+    name: "Sub_4"
     op_type: "Sub"
   }
   name: "torch-jit-export"
@@ -69,7 +80,7 @@ graph {
     }
   }
   output {
-    name: "5"
+    name: "6"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/expect/TestOperators.test_view_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_view_flatten.expect
@@ -65,40 +65,44 @@ graph {
     }
   }
   node {
-    output: "7"
-    name: "Constant_6"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 7
-        raw_data: "\030\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "7"
     input: "6"
-    output: "8"
-    name: "Div_7"
-    op_type: "Div"
-  }
-  node {
-    input: "8"
     output: "9"
-    name: "Cast_8"
+    name: "Cast_6"
     op_type: "Cast"
     attribute {
       name: "to"
-      i: 7
+      i: 1
       type: INT
     }
   }
   node {
     input: "9"
-    output: "10"
-    name: "Cast_9"
+    output: "11"
+    name: "Cast_7"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 1
+      type: INT
+    }
+  }
+  node {
+    input: "20"
+    input: "11"
+    output: "12"
+    name: "Div_8"
+    op_type: "Div"
+  }
+  node {
+    input: "12"
+    output: "13"
+    name: "Floor_9"
+    op_type: "Floor"
+  }
+  node {
+    input: "13"
+    output: "14"
+    name: "Cast_10"
     op_type: "Cast"
     attribute {
       name: "to"
@@ -108,18 +112,7 @@ graph {
   }
   node {
     input: "3"
-    output: "11"
-    name: "Unsqueeze_10"
-    op_type: "Unsqueeze"
-    attribute {
-      name: "axes"
-      ints: 0
-      type: INTS
-    }
-  }
-  node {
-    input: "10"
-    output: "12"
+    output: "15"
     name: "Unsqueeze_11"
     op_type: "Unsqueeze"
     attribute {
@@ -129,10 +122,21 @@ graph {
     }
   }
   node {
-    input: "11"
-    input: "12"
-    output: "13"
-    name: "Concat_12"
+    input: "14"
+    output: "16"
+    name: "Unsqueeze_12"
+    op_type: "Unsqueeze"
+    attribute {
+      name: "axes"
+      ints: 0
+      type: INTS
+    }
+  }
+  node {
+    input: "15"
+    input: "16"
+    output: "17"
+    name: "Concat_13"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -142,12 +146,17 @@ graph {
   }
   node {
     input: "0"
-    input: "13"
-    output: "14"
-    name: "Reshape_13"
+    input: "17"
+    output: "18"
+    name: "Reshape_14"
     op_type: "Reshape"
   }
   name: "torch-jit-export"
+  initializer {
+    data_type: 1
+    name: "20"
+    raw_data: "\000\000\300A"
+  }
   input {
     name: "0"
     type {
@@ -171,7 +180,7 @@ graph {
     }
   }
   output {
-    name: "14"
+    name: "18"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -871,13 +871,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([-0.5, 0.0, 0.5, 2], dtype=torch.float32)
         self.run_test(FloorModule(), x)
 
-    # NOTE: floor division tests currently restrict themselves to only
-    #   test positive division. PyTorch's floor division was previously
-    #   implemented incorrectly and would truncate, not floor, the result
-    #   of the division. For example, -5 // 3 = -2, but, historically,
-    #   torch.floor_divide(-5, 3) = -1.
-    # This behavior has been fixed in PyTorch but the update has not been
-    #   applied to ONNX export yet. See https://github.com/pytorch/pytorch/issues/44692.
+    # NOTE: Starting from 1.7, PyTorch performs floor divide with floor instead of truncation.
     def test_floor_div(self):
         class FloorDivModule(torch.nn.Module):
             def forward(self, x_f32, x_f64, x_i64, y_f32, y_f64, y_i64):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -872,6 +872,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(FloorModule(), x)
 
     # NOTE: Starting from 1.7, PyTorch performs floor divide with floor instead of truncation.
+    #       The update is applied to ONNX export as well.
     def test_floor_div(self):
         class FloorDivModule(torch.nn.Module):
             def forward(self, x_f32, x_f64, x_i64, y_f32, y_f64, y_i64):

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -134,17 +134,19 @@ static c10::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
       // If output scalar type is available, use that.
       st = output_st;
     } else if (n->kind() == onnx::Mod && !typesFromTensors.empty()) {
-      // Most of the operators like Mul are switched to allow implicit type promotion.
-      // But fmod and remainder still only support implicit casting between scalars.
-      // i.e. for torch.remainder(a, b), if a is LongTensor and b is float, b will be cast to Long.
+      // Most of the operators like Mul are switched to allow implicit type
+      // promotion. But fmod and remainder still only support implicit casting
+      // between scalars. i.e. for torch.remainder(a, b), if a is LongTensor and
+      // b is float, b will be cast to Long.
       st = PromoteScalarTypes(typesFromTensors);
     } else {
-      // PyTorch now does implicit type promotion regardless whether the inputs are tensors or scalars.
-      // (Previously only scalars support implicit casting).
+      // PyTorch now does implicit type promotion regardless whether the inputs
+      // are tensors or scalars. (Previously only scalars support implicit
+      // casting).
       typesFromScalars.insert(
-        typesFromScalars.end(),
-        typesFromTensors.begin(),
-        typesFromTensors.end());
+          typesFromScalars.end(),
+          typesFromTensors.begin(),
+          typesFromTensors.end());
       st = PromoteScalarTypes(typesFromScalars);
     }
   }


### PR DESCRIPTION
Update to match #43879, where `torch.floor_divide` now performs floor on division result, instead of truncation. 

This PR depends on #43879 to be merged first.

Fixes #44692