### PR TITLE
Fix test_rpc_profiling_remote_record_function

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1266,19 +1266,41 @@ class RpcTest(RpcAgentTestFixture):
                 "aten::zero_",
                 "aten::fill_",
             ]
-            remote_ops_time = sum(
-                evt.cpu_time_total
-                for evt in remaining_remote_events
-                if not any(
-                    [
-                        rf_entry_event in evt.name
-                        for rf_entry_event in remote_events_denylist
-                    ]
-                )
-            )
-            self.assertGreaterEqual(
-                record_function_remote_event.cpu_time_total, remote_ops_time
-            )
+
+            REMOTE_OP_STR = "#remote_op: "
+
+            def convert_remote_to_local(event_name):
+                remote_op_key = REMOTE_OP_STR
+                return event_name[event_name.find(remote_op_key) + len(remote_op_key) :]
+
+            # Ideally, we should validate that the sum of remote operations within
+            # record_function are less than record_function's CPU time. However,
+            # there is a known bug in profiling
+            # (https://github.com/pytorch/pytorch/issues/45160) due to which we
+            # can't do this. So, we just validate they are child events.
+            prof.key_averages()
+
+            # cpu_children only returns direct children, so here we get all
+            # children recursively.
+            def get_cpu_children(event):
+                if not event.cpu_children:
+                    return []
+                cpu_children = event.cpu_children
+                for e in event.cpu_children:
+                    cpu_children.extend(get_cpu_children(e))
+                return cpu_children
+
+            record_function_children_names = [
+                convert_remote_to_local(c.name)
+                for c in get_cpu_children(record_function_remote_event)
+            ]
+            for evt in remaining_remote_events:
+                local_name = convert_remote_to_local(evt.name)
+                if local_name not in remote_events_denylist:
+                    self.assertTrue(
+                        local_name in record_function_children_names,
+                        f"{local_name} not in {record_function_children_names}",
+                    )
 
     def validate_profiling_workload(self, dst, prof):
         REMOTE_OP_STR = "#remote_op: "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45162 Fix test_rpc_profiling_remote_record_function**

Closes https://github.com/pytorch/pytorch/issues/45067, https://github.com/pytorch/pytorch/issues/45145. This test was flaky because it was not able to validate that the
overall record_function's CPU times are greater than the sum of its children.
It turns out that this is a general bug in the profiler that can be reproduced
without RPC, see https://github.com/pytorch/pytorch/issues/45160. This means that it should be fixed and tested at the profiler, not RPC, level. Hence,
removing this from the test and replacing it by just validating the expected
children.

Ran the test 1000 times and they all passed.

Differential Revision: [D23851854](https://our.internmc.facebook.com/intern/diff/D23851854/)