### PR TITLE
[TensorExpr] When lanes differ, insert Broadcast instead of Cast

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -217,6 +217,7 @@ namespace jit {
   _(SimplifyFuseConditions)                 \
   _(SimplifySyncThreads)                    \
   _(SimplifyRampSubBroadcast)               \
+  _(SimplifyBroadcastTermExpander)          \
   _(RegisterizerSimple)                     \
   _(RegisterizerLoop)                       \
   _(RegisterizerLoopFixedLoad)              \


### PR DESCRIPTION
Summary:

We need to check if dtypes differ in scalar type or lanes to decide between
Cast and Broadcast.

Test Plan:

test_tensorexpr --gtest_filter=TensorExprTest.SimplifyBroadcastTermExpander
