### PR TITLE
Filter `strtod_l` is undeclared errors from sccache log

### DIFF
--- a/.jenkins/pytorch/print_sccache_log.py
+++ b/.jenkins/pytorch/print_sccache_log.py
@@ -6,6 +6,7 @@ with open(log_file_path) as f:
     lines = f.readlines()
 
 for line in lines:
-    # Ignore errors from CPU instruction set testing
-    if 'src.c' not in line:
+    # Ignore errors from CPU instruction set or symbol existing testing
+    keywords = ['src.c', 'CheckSymbolExists.c']
+    if all([keyword not in line for keyword in keywords]):
         print(line)


### PR DESCRIPTION
This prevents DrCI from misidentifying test failures for the compilation failures, such as:
```
/var/lib/jenkins/workspace/build/CMakeFiles/CMakeTmp/CheckSymbolExists.c:8:19: error: use of undeclared identifier \'strtod_l\'
  return ((int*)(&strtod_l))[argc];
```

