### PR TITLE
Define macro for DispatchKey::toString.

### DIFF
--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -1,113 +1,18 @@
 #include <c10/core/DispatchKey.h>
 
 namespace c10 {
-
 const char* toString(DispatchKey t) {
+#define DEFINE_CASE(dk) \
+  case DispatchKey::dk: \
+    return #dk;
+
   switch (t) {
-    case DispatchKey::Undefined:
-      return "Undefined";
-
-    case DispatchKey::CPU:
-      return "CPU";
-    case DispatchKey::CUDA:
-      return "CUDA";
-    case DispatchKey::HIP:
-      return "HIP";
-    case DispatchKey::FPGA:
-      return "FPGA";
-    case DispatchKey::MSNPU:
-      return "MSNPU";
-    case DispatchKey::XLA:
-      return "XLA";
-    case DispatchKey::Vulkan:
-      return "Vulkan";
-
-    case DispatchKey::MKLDNN:
-      return "MKLDNN";
-    case DispatchKey::OpenGL:
-      return "OpenGL";
-    case DispatchKey::OpenCL:
-      return "OpenCL";
-    case DispatchKey::IDEEP:
-      return "IDEEP";
-
-    case DispatchKey::QuantizedCPU:
-      return "QuantizedCPU";
-    case DispatchKey::QuantizedCUDA:
-      return "QuantizedCUDA";
-
-    case DispatchKey::ComplexCPU:
-      return "ComplexCPU";
-    case DispatchKey::ComplexCUDA:
-      return "ComplexCUDA";
-
-    case DispatchKey::CustomRNGKeyId:
-      return "CustomRNGKeyId";
-
-    case DispatchKey::MkldnnCPU:
-      return "MkldnnCPU";
-    case DispatchKey::SparseCPU:
-      return "SparseCPU";
-    case DispatchKey::SparseCUDA:
-      return "SparseCUDA";
-    case DispatchKey::SparseHIP:
-      return "SparseHIP";
-
-    case DispatchKey::PrivateUse1:
-      return "PrivateUse1";
-    case DispatchKey::PrivateUse2:
-      return "PrivateUse2";
-    case DispatchKey::PrivateUse3:
-      return "PrivateUse3";
-
-    case DispatchKey::Meta:
-      return "Meta";
-
-    case DispatchKey::Autograd:
-      return "Autograd";
-    case DispatchKey::AutogradCPU:
-      return "AutogradCPU";
-    case DispatchKey::AutogradCUDA:
-      return "AutogradCUDA";
-    case DispatchKey::AutogradXLA:
-      return "AutogradXLA";
-    case DispatchKey::AutogradPrivateUse1:
-      return "AutogradPrivateUse1";
-    case DispatchKey::AutogradPrivateUse2:
-      return "AutogradPrivateUse2";
-    case DispatchKey::AutogradPrivateUse3:
-      return "AutogradPrivateUse3";
-    case DispatchKey::AutogradOther:
-      return "AutogradOther";
-    case DispatchKey::BackendSelect:
-      return "BackendSelect";
-    case DispatchKey::Named:
-      return "Named";
-
-    case DispatchKey::Tracer:
-      return "Tracer";
-
-    case DispatchKey::Autocast:
-      return "Autocast";
-
-    case DispatchKey::Batched:
-      return "Batched";
-
-    case DispatchKey::VmapMode:
-      return "VmapMode";
-
-    case DispatchKey::Math:
-      return "Math";
-
-    case DispatchKey::TESTING_ONLY_GenericWrapper:
-      return "TESTING_ONLY_GenericWrapper";
-
-    case DispatchKey::TESTING_ONLY_GenericMode:
-      return "TESTING_ONLY_GenericMode";
-
+    FOR_EACH_RUNTIME_DISPATCH_KEY(DEFINE_CASE)
+    FOR_EACH_ALIAS_DISPATCH_KEY(DEFINE_CASE)
     default:
       return "UNKNOWN_TENSOR_TYPE_ID";
   }
+#undef DEFINE_CASE
 }
 
 std::ostream& operator<<(std::ostream& str, DispatchKey rhs) {
@@ -115,22 +20,16 @@ std::ostream& operator<<(std::ostream& str, DispatchKey rhs) {
 }
 
 DispatchKey getAutogradKeyFromBackend(DispatchKey t) {
+#define DEFINE_CASE(dk) \
+  case DispatchKey::dk: \
+    return DispatchKey::Autograd##dk;
+
   switch (t) {
-    case DispatchKey::CPU:
-      return DispatchKey::AutogradCPU;
-    case DispatchKey::CUDA:
-      return DispatchKey::AutogradCUDA;
-    case DispatchKey::XLA:
-      return DispatchKey::AutogradXLA;
-    case DispatchKey::PrivateUse1:
-      return DispatchKey::AutogradPrivateUse1;
-    case DispatchKey::PrivateUse2:
-      return DispatchKey::AutogradPrivateUse2;
-    case DispatchKey::PrivateUse3:
-      return DispatchKey::AutogradPrivateUse3;
+    FOR_EACH_BACKEND_DISPATCH_KEY_WITH_AUTOGRAD_KEY(DEFINE_CASE)
     default:
       return DispatchKey::AutogradOther;
   }
+#undef DEFINE_CASE
 }
 
 } // namespace c10

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -8,289 +8,62 @@
 #include <c10/util/Exception.h>
 
 namespace c10 {
+// ~~~~~~~~~~~~~~ ORDER MATTERS IN THE FOLLOWING MACROS ~~~~~~~~~~~~~~~~~~~ //
 
-// Semantically, a dispatch key identifies a possible "level" in our
-// dispatch, for which a handler may be registered.  Traditional
-// backends like CPU and CUDA get dispatch keys; however, so do
-// "wrapping" layers like Variable (for autograd handling).
-//
-// In implementation terms, the dispatch key identifies a specific "bit" in a
-// DispatchKeySet.  Higher bit indexes get handled by dispatching first (because
-// we "count leading zeros" when we extract the highest priority dispatch
-// key.)
-enum class DispatchKey : uint8_t {
+// This list contains dispatch keys with a dedicated Autograd backend key for
+// known backends (private use keys are in FOR_EACH_PRIVATE_USE_BACKEND_DISPATCH_KEY).
+// e.g CPU -> AutogradCPU
+#define FOR_EACH_PUBLIC_BACKEND_DISPATCH_KEY_WITH_AUTOGRAD_KEY(_)            \
+  /* Here are backends which you think of as traditionally specifying
+   * how to implement operations on some device. */                           \
+  _(CPU)  /* registered at build/aten/src/ATen/CPUType.cpp */                 \
+  _(CUDA) /* registered at build/aten/src/ATen/CUDAType.cpp */                \
+  _(XLA)  /* lives out of tree at https://github.com/pytorch/xla */
 
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~ UNDEFINED ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
-  // This is not a "real" tensor id, but it exists to give us a "nullopt"
-  // element we can return for cases when a DispatchKeySet contains no elements.
-  // You can think a more semantically accurate definition of DispatchKey is:
-  //
-  //    using DispatchKey = optional<RealDispatchKey>
-  //
-  // and Undefined == nullopt.  We didn't actually represent
-  // it this way because optional<RealDispatchKey> would take two
-  // words, when DispatchKey fits in eight bits.
-
-  Undefined = 0,
-
-  // Define an alias for Undefined to represent CatchAll (long term
-  // this will get eliminated, but for now it's convenient)
-  CatchAll = Undefined,
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~ BACKENDS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
-  // A "backend" is colloquially used to refer to handlers for dispatch
-  // which actually implement the numerics of an operation in question.
-  //
-  // Due to the nature of the enum, these backends are specified in
-  // an ordered way, but for most backends this order is not semantically
-  // meaningful (e.g., it's valid to reorder these backends without changing
-  // semantics).  The only situation when backend ordering is meaningful
-  // is when the backend participates in multiple dispatch with another
-  // backend; e.g., CPU and SparseCPU (sparse must have
-  // higher priority).
-
-  // Here are backends which you think of as traditionally specifying
-  // how to implement operations on some device.
-  CPU, // registered at build/aten/src/ATen/CPUType.cpp
-  CUDA, // registered at build/aten/src/ATen/CUDAType.cpp
-  HIP, // NB: I think this is not actually used, due to Note [Masquerading as
-       // CUDA]
-  FPGA, // Xilinx support lives out of tree at https://gitlab.com/pytorch-complex/vitis_kernels
-  MSNPU, // unused externally, but tested at
-         // test/cpp_extensions/msnpu_extension.cpp
-  XLA, // lives out of tree at https://github.com/pytorch/xla
-  Vulkan,
-
-  // These are Caffe2 device types which we grandfathered into
-  // DispatchKey.
-  // TODO: Caffe2-only DispatchKeys actually should be removed from this enum
-  // and just simply be undispatchable.
-  MKLDNN, // (MKLDNN is treated as another "device" in Caffe2)
-  OpenGL,
-  OpenCL,
-  IDEEP,
-
-  // Here are backends which specify more specialized operators
-  // based on the dtype of the tensor.
-  QuantizedCPU, // registered at build/aten/src/ATen/QuantizedCPUType.cpp
-  QuantizedCUDA, // registered at build/aten/src/ATen/QuantizedCUDAType.cpp
-  ComplexCPU, // lives out of tree at
-              // https://gitlab.com/pytorch-complex/pytorch-cpu-strided-complex
-  ComplexCUDA, // and
-               // https://gitlab.com/pytorch-complex/pytorch-cuda-strided-complex
-  // tested at test/cpp_extensions/complex_registration_extension.cpp
-  // TODO: Remove Complex dispatch keys when Complex is moved in tree
-
-  // This backend is to support custom RNGs; it lets you go
-  // to a different kernel if you pass in a generator that is not a
-  // traditional CPUGeneratorImpl/CUDAGeneratorImpl.  To make use of this
-  // key:
-  //  1) set it as a second parameter of at::Generator constructor call in
-  //     the user-defined PRNG class.
-  //  2) use it as a dispatch key while registering custom kernels
-  //     (templatized kernels specialized for user-defined PRNG class)
-  // intended for out of tree use; tested by aten/src/ATen/test/rng_test.cpp
-  CustomRNGKeyId,
-
-  // Here are backends which specify more specialized operators
-  // based on the layout of the tensor.  Note that the sparse backends
-  // are one case where ordering matters: sparse multi-dispatches with
-  // the corresponding dense tensors, and must be handled before them.
-  MkldnnCPU, // registered at build/aten/src/ATen/MkldnnCPUType.cpp
-  // NB: not to be confused with MKLDNN, which is Caffe2 only
-  SparseCPU, // registered at build/aten/src/ATen/SparseCPUType.cpp
-  SparseCUDA, // registered at build/aten/src/ATen/SparseCUDAType.cpp
-  SparseHIP, // TODO: I think this is not actually used, due to Note
-             // [Masquerading as CUDA]
-
-  // Here are reserved backends for user-defined backends, see Note [Private use
-  // DispatchKey]
-  // To see some example about how to use this, check out MSNPU
-  PrivateUse1,
-  PrivateUse2,
-  PrivateUse3,
-
-  // Define an alias key to represent end of backend dispatch keys.
-  // If you add new backend keys after PrivateUse3, please also update it here.
-  EndOfBackendKeys = PrivateUse3,
-
-  // The meta function characterizes how an operation affects the metadata of a
-  // tensor (shape, dtype) without doing any of the actual computation.  A
-  // meta tensor can be used to dry run operators without actually doing
-  // any computation, e.g., add on two meta tensors would give you another
-  // meta tensor with the output shape and dtype, but wouldn't actually
-  // add anything.  A meta implementation typically would look something like:
-  //
-  //  Tensor meta::add(const Tensor& self, const Tensor& other) {
-  //    TORCH_CHECK(self.size().equals(other.size()));
-  //    return at::empty_like(self, self.size());
-  //  }
-  //
-  // The meta function would get invoked if you ran an operator passing
-  // in meta tensors.  The call stack in such a case would look something like
-  // this:
-  //
-  //  at::add(x: Meta, y: Meta) {
-  //    return [dispatch] meta::add(x: Meta, y: Meta) {
-  //      output_shape = ...
-  //      [dispatch] meta::empty(output_shape) {
-  //        return ... meta tensor with output_shape but no data allocated ...
-  //      }
-  //    }
-  //  }
-  //
-  // Meta functions have an important secondary function, which is they can
-  // be used as tensor "allocators".  A typical backend implementation should
-  // be implemented in this way:
-  //
-  //  Tensor cpu::add(const Tensor& self, const Tensor& other) {
-  //    Tensor result = meta::add(self, other);
-  //    // ... do the actual computation into result ...
-  //    return result;
-  //  }
-  //
-  // In this case, the internal at::empty_like invocation would dispatch to the
-  // CPU factory function, not the meta factory function.  The call stack in
-  // this case looks like:
-  //
-  //  at::add(x: CPU, y: CPU) {
-  //    return [dispatch] cpu::add(x: CPU, y: CPU) {
-  //      output = [direct] meta::add(x: CPU, y: CPU) {
-  //        output_shape = ...
-  //        [dispatch] cpu::empty(output_shape)
-  //      }
-  //      ... compute on output ...
-  //      return output;
-  //    }
-  //  }
-  //
-  Meta,
-
-  // In some situations, it is not immediately obvious what the correct
-  // backend for function is, because the function in question doesn't
-  // have any "tensor" arguments.  In this case, a BackendSelect function
-  // can be registered to implement the custom determination of the
-  // correct backend.
-  BackendSelect,
-
-  // The named dispatch key is set for any tensors with named dimensions.
-  // Although we have a dispatch key for named tensors, for historical reasons,
-  // this dispatch key doesn't do any of the substantive functionality for named
-  // tensor (though, hypothetically, it could!)  At the moment, it's just
-  // responsible for letting us give good error messages when operations
-  // don't support named tensors.
-  //
-  // NB: If you ever consider moving named tensor functionality into
-  // this dispatch key, note that it might be necessary add another dispatch
-  // key that triggers before composite operators, in case a composite operator
-  // has named dimension propagation that doesn't match that of its
-  // constituent parts.
-  Named,
-
-  // Note [Alias Dispatch Key : Autograd]
-  // All backends are oblivious to autograd; autograd is handled as a
-  // layer which happens on top of all backends. It inspects the autograd
-  // metadata of all inputs, determines what autograd metadata should be
-  // constructed by the output, and otherwise defers to the backend to
-  // actually do the numeric computation.  Autograd contains
-  // the bulk of this logic.
-
-  // Autograd is now an alias dispatch key which by default maps to all
-  // backend-specific autograd keys.
-  // Backend-specific allow backends to override the default kernel registered
-  // to Autograd key as needed.
-  // For example, XLA wants to define autograd for einsum directly.
-  // Registering a custom autograd implementation at the XLA key won't work
-  // because we process Autograd before XLA.  This key has higher priority and
-  // gets processed first.  You generally should NOT redispatch after handling
-  // autograd here (since that would result in execution of the Autograd
-  // operator, which you're trying to skip).  In AutogradXLA implementations,
-  // you are responsible for handling autograd yourself, or deferring to other
-  // operators which support autograd.
-
-  // Currently we only have backend-specific autograd keys for CPU/CUDA/XLA and
-  // reserved user-defined backends. All other in-tree backends share the
-  // AutogradOther key. We can add specific autograd key for those backends
-  // upon request.
-  AutogradOther,
-  AutogradCPU,
-  AutogradCUDA,
-  AutogradXLA,
-  // Here are some reserved pre-autograd keys for user-defined backends, see
-  // Note [Private use DispatchKey]
-  AutogradPrivateUse1,
-  AutogradPrivateUse2,
-  AutogradPrivateUse3,
-
-  Tracer,
-
-  // Autocasting precedes VariableTypeId, to ensure casts are autograd-exposed
-  // and inputs are saved for backward in the post-autocast type.
-  Autocast,
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~ WRAPPERS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
-  // There are a number of alternative modes which may want to handle before
-  // autograd; for example, error checking, tracing, profiling or vmap.  They
-  // go here.
-
-  // This is the dispatch key for BatchedTensorImpl, which is used to implement
-  // batching rules for vmap.
-  Batched,
-
-  // When we are inside a vmap, all tensors dispatch on this key.
-  // See Note: [DispatchKey::VmapMode usage] for more details.
-  VmapMode,
-
-  // TESTING: This is intended to be a generic testing tensor type id.
-  // Don't use it for anything real; its only acceptable use is within a single
-  // process test.  Use it by creating a TensorImpl with this DispatchKey, and
-  // then registering operators to operate on this type id.  See
-  // aten/src/ATen/core/dispatch/backend_fallback_test.cpp for a usage example.
-  TESTING_ONLY_GenericWrapper,
-
-  // TESTING: This is intended to be a generic testing tensor type id.
-  // Don't use it for anything real; its only acceptable use is within a ingle
-  // process test.  Use it by toggling the mode on and off via
-  // TESTING_ONLY_tls_generic_mode_set_enabled and then registering operators
-  // to operate on this type id.  See
-  // aten/src/ATen/core/dispatch/backend_fallback_test.cpp
-  // for a usage example
-  TESTING_ONLY_GenericMode,
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FIN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
-  NumDispatchKeys, // Sentinel, end of runtime keys.
-
-  // ~~~~~~~~~~~~~~~~~~~~~~ Alias Dispatch Keys ~~~~~~~~~~~~~~~~~~~~~~~~~~ //
-  // Alias dispatch keys are synthetic dispatch keys which map to multiple
-  // runtime dispatch keys. Alisa keys have precedence, but they are always
-  // lower precedence than runtime keys. You can register a kernel to an
-  // alias key, the kernel might be populated to the mapped runtime keys
-  // during dispatch table computation.
-  // If a runtime dispatch key has multiple kernels from alias keys, which
-  // kernel wins is done based on the precedence of alias keys (but runtime
-  // keys always have precedence over alias keys).
-  // Alias keys won't be directly called during runtime.
-
-  // See Note [Alias Dispatch Key : Autograd]
-  Autograd,
-  Math,
-
-  // Define an alias key to represent end of alias dispatch keys.
-  // If you add new alias keys after Autograd, please also update it here.
-  EndOfAliasKeys = Math, //
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~ BC ALIASES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
-  // The aliases exist for backwards compatibility reasons, they shouldn't
-  // be used
-  CPUTensorId = CPU,
-  CUDATensorId = CUDA,
-  PrivateUse1_PreAutograd = AutogradPrivateUse1,
-  PrivateUse2_PreAutograd = AutogradPrivateUse2,
-  PrivateUse3_PreAutograd = AutogradPrivateUse3,
-};
+// This list contains dispatch keys without a dedicated Autograd backend key,
+// all of these keys are mapped to AutogradOther.
+#define FOR_EACH_BACKEND_DISPATCH_KEY_MAPPED_TO_AUTOGRAD_OTHER(_)                                    \
+  _(HIP)   /* NB: I think this is not actually used, due to Note [Masquerading as CUDA] */           \
+  _(FPGA)  /* Xilinx support lives out of tree at https://gitlab.com/pytorch-complex/vitis_kernels*/ \
+  _(MSNPU) /* unused externally, but tested at test/cpp_extensions/msnpu_extension.cpp */            \
+  _(Vulkan)                                                                                          \
+  /* These are Caffe2 device types which we grandfathered into DispatchKey.
+   * TODO: Caffe2-only DispatchKeys actually should be removed from this enum
+   * and just simply be undispatchable. */                                                           \
+  _(MKLDNN) /* MKLDNN is treated as another "device" in Caffe2 */                                    \
+  _(OpenGL)                                                                                          \
+  _(OpenCL)                                                                                          \
+  _(IDEEP)                                                                                           \
+  /* Here are backends which specify more specialized operators based on the dtype of the tensor. */ \
+  _(QuantizedCPU)  /* registered at build/aten/src/ATen/QuantizedCPUType.cpp */                      \
+  _(QuantizedCUDA) /* registered at build/aten/src/ATen/QuantizedCUDAType.cpp */                     \
+  _(ComplexCPU)    /* lives out of tree at
+                      https://gitlab.com/pytorch-complex/pytorch-cpu-strided-complex */              \
+  _(ComplexCUDA)   /* https://gitlab.com/pytorch-complex/pytorch-cuda-strided-complex
+                      tested at test/cpp_extensions/complex_registration_extension.cpp */            \
+  /* TODO: Remove Complex dispatch keys when Complex is moved in tree */                             \
+  /* This backend is to support custom RNGs; it lets you go
+   * to a different kernel if you pass in a generator that is not a
+   * traditional CPUGeneratorImpl/CUDAGeneratorImpl.  To make use of this
+   * key:
+   *  1) set it as a second parameter of at::Generator constructor call in
+   *     the user-defined PRNG class.
+   *  2) use it as a dispatch key while registering custom kernels
+   *     (templatized kernels specialized for user-defined PRNG class)
+   * intended for out of tree use; tested by aten/src/ATen/test/rng_test.cpp */                      \
+  _(CustomRNGKeyId)                                                                                  \
+  /* Here are backends which specify more specialized operators
+   * based on the layout of the tensor.  Note that the sparse backends
+   * are one case where ordering matters: sparse multi-dispatches with
+   * the corresponding dense tensors, and must be handled before them. */                            \
+  _(MkldnnCPU) /* registered at build/aten/src/ATen/MkldnnCPUType.cpp
+                  NB: not to be confused with MKLDNN, which is Caffe2 only */                        \
+  _(SparseCPU)  /* registered at build/aten/src/ATen/SparseCPUType.cpp */                            \
+  _(SparseCUDA) /* registered at build/aten/src/ATen/SparseCUDAType.cpp */                           \
+  _(SparseHIP)  /* TODO: I think this is not actually used, due to Note [Masquerading as CUDA] */
 
 // Note [Private use DispatchKey]
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Private use tensor IDs are preallocated tensor type IDs for use in user
 // applications.  Similar to private use fields in HTTP, they can be used
 // by end users for experimental or private applications, without needing
@@ -312,6 +85,242 @@ enum class DispatchKey : uint8_t {
 // as "wrapper" DispatchKeys: they are only necessary for tensors that compose
 // multiple internal tensors, and for cases when the built-in autograd formulas
 // for operators are not appropriate.
+
+// Here are reserved backends for user-defined backends, see Note [Private use DispatchKey]
+// To see some example about how to use this, check out MSNPU.
+#define FOR_EACH_PRIVATE_USE_BACKEND_DISPATCH_KEY(_) \
+  _(PrivateUse1)                                     \
+  _(PrivateUse2)                                     \
+  _(PrivateUse3)
+
+// This list contains **all** dispatch keys with a dedicated Autograd backend key,
+// including both known backends like CPU/CUDA/XLA as well as keys reserved for
+// private use backends.
+#define FOR_EACH_BACKEND_DISPATCH_KEY_WITH_AUTOGRAD_KEY(_)   \
+  FOR_EACH_PUBLIC_BACKEND_DISPATCH_KEY_WITH_AUTOGRAD_KEY(_)  \
+  FOR_EACH_PRIVATE_USE_BACKEND_DISPATCH_KEY(_)
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~ BACKENDS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
+// A "backend" is colloquially used to refer to handlers for dispatch
+// which actually implement the numerics of an operation in question.
+//
+// Due to the nature of the enum, these backends are specified in
+// an ordered way, but for most backends this order is not semantically
+// meaningful (e.g., it's valid to reorder these backends without changing
+// semantics).  The only situation when backend ordering is meaningful
+// is when the backend participates in multiple dispatch with another
+// backend; e.g., CPU and SparseCPU (sparse must have
+// higher priority).
+#define FOR_EACH_BACKEND_DISPATCH_KEY(_)                      \
+  FOR_EACH_PUBLIC_BACKEND_DISPATCH_KEY_WITH_AUTOGRAD_KEY(_)   \
+  FOR_EACH_BACKEND_DISPATCH_KEY_MAPPED_TO_AUTOGRAD_OTHER(_)   \
+  FOR_EACH_PRIVATE_USE_BACKEND_DISPATCH_KEY(_)
+
+// ~~~~~~~~~~~~~~~~~~~~~~ Alias Dispatch Keys ~~~~~~~~~~~~~~~~~~~~~~~~~~ //
+// Alias dispatch keys are synthetic dispatch keys which map to multiple
+// runtime dispatch keys. Alisa keys have precedence, but they are always
+// lower precedence than runtime keys. You can register a kernel to an
+// alias key, the kernel might be populated to the mapped runtime keys
+// during dispatch table computation.
+// If a runtime dispatch key has multiple kernels from alias keys, which
+// kernel wins is done based on the precedence of alias keys (but runtime
+// keys always have precedence over alias keys).
+// Alias keys won't be directly called during runtime.
+#define FOR_EACH_ALIAS_DISPATCH_KEY(_)                           \
+  _(Autograd) /*  See Note [Alias Dispatch Key : Autograd] */    \
+  _(Math)
+
+// Note [Alias Dispatch Key : Autograd]
+// All backends are oblivious to autograd; autograd is handled as a
+// layer which happens on top of all backends. It inspects the autograd
+// metadata of all inputs, determines what autograd metadata should be
+// constructed by the output, and otherwise defers to the backend to
+// actually do the numeric computation.  Autograd contains
+// the bulk of this logic.
+
+// Autograd is now an alias dispatch key which by default maps to all
+// backend-specific autograd keys.
+// Backend-specific allow backends to override the default kernel registered
+// to Autograd key as needed.
+// For example, XLA wants to define autograd for einsum directly.
+// Registering a custom autograd implementation at the XLA key won't work
+// because we process Autograd before XLA.  This key has higher priority and
+// gets processed first.  You generally should NOT redispatch after handling
+// autograd here (since that would result in execution of the Autograd
+// operator, which you're trying to skip).  In AutogradXLA implementations,
+// you are responsible for handling autograd yourself, or deferring to other
+// operators which support autograd.
+
+// Currently we only have backend-specific autograd keys for CPU/CUDA/XLA and
+// reserved user-defined backends. All other in-tree backends share the
+// AutogradOther key. We can add specific autograd key for those backends
+// upon request.
+#define FOR_EACH_RUNTIME_AUTOGRAD_DISPATCH_KEY(_)                             \
+  _(AutogradOther)                                                            \
+  _(AutogradCPU)                                                              \
+  _(AutogradCUDA)                                                             \
+  _(AutogradXLA)                                                              \
+  /* Here are some reserved pre-autograd keys for user-defined backends,
+   * see Note [Private use DispatchKey] */                                    \
+  _(AutogradPrivateUse1)                                                      \
+  _(AutogradPrivateUse2)                                                      \
+  _(AutogradPrivateUse3)
+
+// This list contains **all** runtime dispatch keys.
+#define FOR_EACH_RUNTIME_DISPATCH_KEY(_)                                       \
+  /*~~~~~~~~~~~~~~~~~~~~~~~~~~ UNDEFINED ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * This is not a "real" tensor id, but it exists to give us a "nullopt"
+   * element we can return for cases when a DispatchKeySet contains no elements.
+   * You can think a more semantically accurate definition of DispatchKey is:
+   *
+   *    using DispatchKey = optional<RealDispatchKey>
+   *
+   * and Undefined == nullopt.  We didn't actually represent
+   * it this way because optional<RealDispatchKey> would take two
+   * words, when DispatchKey fits in eight bits.
+   * See Note [Undefined in dispatchTable_] for why Undefined is available in
+   * runtime dispatchTable_. */                                                \
+  _(Undefined)                                                                 \
+  FOR_EACH_BACKEND_DISPATCH_KEY(_)                                             \
+  /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Meta ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * The meta function characterizes how an operation affects the metadata of a
+   * tensor (shape, dtype) without doing any of the actual computation.  A
+   * meta tensor can be used to dry run operators without actually doing
+   * any computation, e.g., add on two meta tensors would give you another
+   * meta tensor with the output shape and dtype, but wouldn't actually
+   * add anything.  A meta implementation typically would look something like:
+   *
+   *  Tensor meta::add(const Tensor& self, const Tensor& other) {
+   *    TORCH_CHECK(self.size().equals(other.size()));
+   *    return at::empty_like(self, self.size());
+   *  }
+   *
+   * The meta function would get invoked if you ran an operator passing
+   * in meta tensors.  The call stack in such a case would look something like
+   * this:
+   *
+   *  at::add(x: Meta, y: Meta) {
+   *    return [dispatch] meta::add(x: Meta, y: Meta) {
+   *      output_shape = ...
+   *      [dispatch] meta::empty(output_shape) {
+   *        return ... meta tensor with output_shape but no data allocated ...
+   *      }
+   *    }
+   *  }
+   *
+   * Meta functions have an important secondary function, which is they can
+   * be used as tensor "allocators".  A typical backend implementation should
+   * be implemented in this way:
+   *
+   *  Tensor cpu::add(const Tensor& self, const Tensor& other) {
+   *    Tensor result = meta::add(self, other);
+   *    // ... do the actual computation into result ...
+   *    return result;
+   *  }
+   *
+   * In this case, the internal at::empty_like invocation would dispatch to the
+   * CPU factory function, not the meta factory function.  The call stack in
+   * this case looks like:
+   *
+   *  at::add(x: CPU, y: CPU) {
+   *    return [dispatch] cpu::add(x: CPU, y: CPU) {
+   *      output = [direct] meta::add(x: CPU, y: CPU) {
+   *        output_shape = ...
+   *        [dispatch] cpu::empty(output_shape)
+   *      }
+   *      ... compute on output ...
+   *      return output;
+   *    }
+   *  } */                                                                     \
+  _(Meta)                                                                      \
+  /* In some situations, it is not immediately obvious what the correct
+   * backend for function is, because the function in question doesn't
+   * have any "tensor" arguments.  In this case, a BackendSelect function
+   * can be registered to implement the custom determination of the
+   * correct backend. */                                                       \
+  _(BackendSelect)                                                             \
+  /* The named dispatch key is set for any tensors with named dimensions.
+   * Although we have a dispatch key for named tensors, for historical reasons,
+   * this dispatch key doesn't do any of the substantive functionality for named
+   * tensor (though, hypothetically, it could!)  At the moment, it's just
+   * responsible for letting us give good error messages when operations
+   * don't support named tensors.
+   *
+   * NB: If you ever consider moving named tensor functionality into
+   * this dispatch key, note that it might be necessary add another dispatch
+   * key that triggers before composite operators, in case a composite operator
+   * has named dimension propagation that doesn't match that of its
+   * constituent parts. */                                                     \
+  _(Named)                                                                     \
+  FOR_EACH_RUNTIME_AUTOGRAD_DISPATCH_KEY(_)                                    \
+  _(Tracer)                                                                    \
+  /* Autocasting precedes VariableTypeId, to ensure casts are autograd-exposed
+   * and inputs are saved for backward in the post-autocast type. */           \
+  _(Autocast)                                                                  \
+  /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~ WRAPPERS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * There are a number of alternative modes which may want to handle before
+   * autograd; for example, error checking, tracing, profiling or vmap.  They
+   * go here. */                                                               \
+  /* This is the dispatch key for BatchedTensorImpl, which is used to implement
+   * batching rules for vmap.*/                                                \
+  _(Batched)                                                                   \
+  /* When we are inside a vmap, all tensors dispatch on this key.
+   * See Note: [DispatchKey::VmapMode usage] for more details.*/               \
+  _(VmapMode)                                                                  \
+  /* TESTING: This is intended to be a generic testing tensor type id.
+   * Don't use it for anything real; its only acceptable use is within a single
+   * process test.  Use it by creating a TensorImpl with this DispatchKey, and
+   * then registering operators to operate on this type id.  See
+   * aten/src/ATen/core/dispatch/backend_fallback_test.cpp for an example.*/   \
+  _(TESTING_ONLY_GenericWrapper)                                               \
+  /* TESTING: This is intended to be a generic testing tensor type id.
+   * Don't use it for anything real; its only acceptable use is within a ingle
+   * process test.  Use it by toggling the mode on and off via
+   * TESTING_ONLY_tls_generic_mode_set_enabled and then registering operators
+   * to operate on this type id.  See
+   * aten/src/ATen/core/dispatch/backend_fallback_test.cpp
+   * for a usage example */                                                    \
+  _(TESTING_ONLY_GenericMode)
+
+// Semantically, a dispatch key identifies a possible "level" in our
+// dispatch, for which a handler may be registered.  Traditional
+// backends like CPU and CUDA get dispatch keys; however, so do
+// "wrapping" layers like Variable (for autograd handling).
+//
+// In implementation terms, the dispatch key identifies a specific "bit" in a
+// DispatchKeySet.  Higher bit indexes get handled by dispatching first (because
+// we "count leading zeros" when we extract the highest priority dispatch
+// key.)
+enum class DispatchKey : uint8_t {
+#define DEFINE_ENUM(name) name,
+  // Runtime dispatch keys
+  FOR_EACH_RUNTIME_DISPATCH_KEY(DEFINE_ENUM)
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FIN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
+  NumDispatchKeys, // Sentinel, end of runtime keys.
+
+  // Alias dispatch keys
+  FOR_EACH_ALIAS_DISPATCH_KEY(DEFINE_ENUM)
+
+  // Define an alias for Undefined to represent CatchAll (long term
+  // this will get eliminated, but for now it's convenient)
+  CatchAll = Undefined,
+  // Define an alias key to represent end of backend dispatch keys.
+  // If you add new backend keys after PrivateUse3, please also update it here.
+  EndOfBackendKeys = PrivateUse3,
+  // Define an alias key to represent end of alias dispatch keys.
+  // If you add new alias keys after Autograd, please also update it here.
+  EndOfAliasKeys = Math,
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~ BC ALIASES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
+  // The aliases exist for backwards compatibility reasons, they shouldn't
+  // be used
+  CPUTensorId = CPU,
+  CUDATensorId = CUDA,
+  PrivateUse1_PreAutograd = AutogradPrivateUse1,
+  PrivateUse2_PreAutograd = AutogradPrivateUse2,
+  PrivateUse3_PreAutograd = AutogradPrivateUse3,
+#undef DEFINE_ENUM
+};
 
 static_assert(
   static_cast<uint8_t>(DispatchKey::NumDispatchKeys) < 64,

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -186,17 +186,26 @@ public:
 C10_API std::string toString(DispatchKeySet);
 C10_API std::ostream& operator<<(std::ostream&, DispatchKeySet);
 
+#define DISPATCH_KEY(dk) \
+  DispatchKey::dk,
 // autograd_dispatch_keyset should include all runtime autograd keys.
 // Alias key DispatchKey::Autograd maps to autograd_dispatch_keyset.
 constexpr DispatchKeySet autograd_dispatch_keyset = DispatchKeySet({
-  DispatchKey::AutogradCPU,
-  DispatchKey::AutogradCUDA,
-  DispatchKey::AutogradXLA,
-  DispatchKey::AutogradPrivateUse1,
-  DispatchKey::AutogradPrivateUse2,
-  DispatchKey::AutogradPrivateUse3,
-  DispatchKey::AutogradOther,
+  FOR_EACH_RUNTIME_AUTOGRAD_DISPATCH_KEY(DISPATCH_KEY)
 });
+
+// autogradother_backends contains all backend keys that maps to
+// AutogradOther.
+constexpr DispatchKeySet autogradother_backends = DispatchKeySet({
+  FOR_EACH_BACKEND_DISPATCH_KEY_MAPPED_TO_AUTOGRAD_OTHER(DISPATCH_KEY)
+});
+
+// backend_dispatch_keyset contains all backend keys
+constexpr DispatchKeySet backend_dispatch_keyset = DispatchKeySet({
+  FOR_EACH_BACKEND_DISPATCH_KEY(DISPATCH_KEY)
+});
+#undef DISPATCH_KEY
+
 
 // Resolve alias dispatch key to DispatchKeySet if applicable
 C10_API DispatchKeySet getRuntimeDispatchKeySet(DispatchKey t);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45150 Resolve comments in #44354.
* **#45206 Define macro for DispatchKey::toString.**

