### PR TITLE
add self cuda time to avoid double/quadruple counting

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -740,7 +740,7 @@ class FunctionEvent(FormattedTimesMixin):
     @property
     def self_cuda_time_total(self):
         return sum(kinfo.interval.elapsed_us() for kinfo in self.kernels) - \
-        sum([child.cuda_time_total for child in self.cpu_children])
+            sum([child.cuda_time_total for child in self.cpu_children])
 
     @property
     def cpu_time_total(self):

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -47,295 +47,319 @@ namespace {
     NUM_PROFILER_CFG_IVALUE_IDX // must be last in list
   };
 
-CUDAStubs default_stubs;
-constexpr CUDAStubs* default_stubs_addr = &default_stubs;
-// Constant initialization, so it is guaranteed to be initialized before
-// static initialization calls which may invoke registerCUDAMethods
-static CUDAStubs* cuda_stubs = default_stubs_addr;
+  const std::unordered_set<std::string> disable_cuda_profiling = {
+      "aten::view",
+      "aten::t",
+      "aten::transpose",
+      "aten::stride",
+      "aten::empty",
+      "aten::empty_like",
+      "aten::empty_strided"
+      "aten::as_strided",
+      "aten::expand",
+      "aten::resize_",
+      "aten::squeeze",
+      "aten::unsqueeze",
+      "aten::slice",
+      "aten::_unsafe_view",
+      "aten::size"
+      };
 
-// We decompose the profiler logic into the following components:
-//
-// ThreadLocalDebugInfo:
-//
-// ThreadLocalDebugInfo is a thread local mapping from slots into
-// the debug information structs.
-// ThreadLocalDebugInfo is automatically propagated across thread
-// boundaries, including the cases of:
-//  - launching async jobs with at::launch
-//  - executing JIT continuations
-//  - moving from the forward threads into autograd (backward) threads
-//
-// Entries in ThreadLocalDebugInfo are managed by DebugInfoGuard
-// which can be used to add or overwrite an entry in the thread local
-// mapping. A corresponding entry is removed when the guard is destroyed,
-// potentially revealing the previously set value for the same slot.
-//
-// For the async tasks, slots previuosly set in the main thread before
-// launching of an async task are shared and visible in the async task.
-//
-// On the other hand, any adding or overwriting of the mapping by the
-// async task is not visible to the main thread and any modification
-// (including removal of the entries) in the main thread is not visible
-// to the async task if it happends after launching the task.
-//
-// We use ThreadLocalDebugInfo (slot PROFILER_STATE) to store profiler config,
-// as well as a list of events that happen during profiling.
-// An instance of ThreadLocalDebugInfo is created each time we enter
-// profiler (i.e. enter profiling context manager/call enableConfig) and
-// uniquely identifies a profiling run.
-//
-// We automatically propagate ThreadLocalDebugInfo into async tasks,
-// as well as across JIT continuations and autograd thread, so all
-// the operations that happen between profiling start and end
-// (not necessarily within the same thread) are recorded.
-// Unless the profiling slot is overwritten as in the case of nested
-// profiling ranges (in this case events for the subrange are handled
-// by the nested profiler)
-//
-// When we exit a profiling range (either by exiting profiling context
-// manager or by calling disableProfiler), we remove the previously set
-// profiling entry for the given thread local mapping, and consolidate
-// events in the profiling result
-//
-//
-// ThreadLocalState:
-//
-// ThreadLocalState takes a 'snapshot' of thread local variables
-// using provided getters. It is used together with ThreadLocalStateGuard
-// to transfer the snapshot across thread boundary and set the thread local
-// values as in the parent task.
-//
-// Profiler uses ThreadLocalState to propagate profiler's thread local state.
-// ThreadLocalState also automatically propagates profiler callbacks.
-//
-//
-// at::RecordFunction and observers
-//
-// Profiler uses observers mechanism to add a pair of thread local callbacks
-// that are executed on a number of predetermined ranges, including:
-//  - c10/ATen ops
-//  - TorchScript functions/methods
-//  - user defined named ranges (see `record_function` python context manager)
-//
-// Profiler setups a pair of callbacks that record profiling events and save them
-// into the thread local profiler struct (ThreadLocalDebugInfo, PROFILER_STATE slot)
-//
-//
-// Thus, the overall logic is:
-//
-// enableProfiler:
-//  - checks that profiler is not enabled (otherwise throws)
-//  - pushes new ThreadLocalDebugInfo (slot PROFILER_STATE) as the profiler
-//    config for the current thread
-//  - pushes profiling callbacks for the current thread
-//
-// disableProfiler:
-//  - pops PROFILER_STATE slot from the current ThreadLocalDebugInfo and
-//    consolidates events
-//  - removes profiling callbacks
-//
-// ThreadLocalState:
-//  - propagates ThreadLocalDebugInfo across threads
-//  - propagates profiler callbacks across threads
-//
-// Profiler callbacks:
-//  - get the current profiling state (PROFILER slot in ThreadLocalDebugInfo)
-//  - save profiling events into the profiling state
-//
+  CUDAStubs default_stubs;
+  constexpr CUDAStubs* default_stubs_addr = &default_stubs;
+  // Constant initialization, so it is guaranteed to be initialized before
+  // static initialization calls which may invoke registerCUDAMethods
+  static CUDAStubs* cuda_stubs = default_stubs_addr;
 
-// Profiler state
-struct ProfilerThreadLocalState
-    : public c10::MemoryReportingInfoBase {
-  explicit ProfilerThreadLocalState(
-      const ProfilerConfig& config)
-    : config_(config), remoteProfiledEvents_{c10::nullopt} {}
-  ~ProfilerThreadLocalState() override = default;
+  // We decompose the profiler logic into the following components:
+  //
+  // ThreadLocalDebugInfo:
+  //
+  // ThreadLocalDebugInfo is a thread local mapping from slots into
+  // the debug information structs.
+  // ThreadLocalDebugInfo is automatically propagated across thread
+  // boundaries, including the cases of:
+  //  - launching async jobs with at::launch
+  //  - executing JIT continuations
+  //  - moving from the forward threads into autograd (backward) threads
+  //
+  // Entries in ThreadLocalDebugInfo are managed by DebugInfoGuard
+  // which can be used to add or overwrite an entry in the thread local
+  // mapping. A corresponding entry is removed when the guard is destroyed,
+  // potentially revealing the previously set value for the same slot.
+  //
+  // For the async tasks, slots previuosly set in the main thread before
+  // launching of an async task are shared and visible in the async task.
+  //
+  // On the other hand, any adding or overwriting of the mapping by the
+  // async task is not visible to the main thread and any modification
+  // (including removal of the entries) in the main thread is not visible
+  // to the async task if it happends after launching the task.
+  //
+  // We use ThreadLocalDebugInfo (slot PROFILER_STATE) to store profiler config,
+  // as well as a list of events that happen during profiling.
+  // An instance of ThreadLocalDebugInfo is created each time we enter
+  // profiler (i.e. enter profiling context manager/call enableConfig) and
+  // uniquely identifies a profiling run.
+  //
+  // We automatically propagate ThreadLocalDebugInfo into async tasks,
+  // as well as across JIT continuations and autograd thread, so all
+  // the operations that happen between profiling start and end
+  // (not necessarily within the same thread) are recorded.
+  // Unless the profiling slot is overwritten as in the case of nested
+  // profiling ranges (in this case events for the subrange are handled
+  // by the nested profiler)
+  //
+  // When we exit a profiling range (either by exiting profiling context
+  // manager or by calling disableProfiler), we remove the previously set
+  // profiling entry for the given thread local mapping, and consolidate
+  // events in the profiling result
+  //
+  //
+  // ThreadLocalState:
+  //
+  // ThreadLocalState takes a 'snapshot' of thread local variables
+  // using provided getters. It is used together with ThreadLocalStateGuard
+  // to transfer the snapshot across thread boundary and set the thread local
+  // values as in the parent task.
+  //
+  // Profiler uses ThreadLocalState to propagate profiler's thread local state.
+  // ThreadLocalState also automatically propagates profiler callbacks.
+  //
+  //
+  // at::RecordFunction and observers
+  //
+  // Profiler uses observers mechanism to add a pair of thread local callbacks
+  // that are executed on a number of predetermined ranges, including:
+  //  - c10/ATen ops
+  //  - TorchScript functions/methods
+  //  - user defined named ranges (see `record_function` python context manager)
+  //
+  // Profiler setups a pair of callbacks that record profiling events and save
+  // them into the thread local profiler struct (ThreadLocalDebugInfo,
+  // PROFILER_STATE slot)
+  //
+  //
+  // Thus, the overall logic is:
+  //
+  // enableProfiler:
+  //  - checks that profiler is not enabled (otherwise throws)
+  //  - pushes new ThreadLocalDebugInfo (slot PROFILER_STATE) as the profiler
+  //    config for the current thread
+  //  - pushes profiling callbacks for the current thread
+  //
+  // disableProfiler:
+  //  - pops PROFILER_STATE slot from the current ThreadLocalDebugInfo and
+  //    consolidates events
+  //  - removes profiling callbacks
+  //
+  // ThreadLocalState:
+  //  - propagates ThreadLocalDebugInfo across threads
+  //  - propagates profiler callbacks across threads
+  //
+  // Profiler callbacks:
+  //  - get the current profiling state (PROFILER slot in ThreadLocalDebugInfo)
+  //  - save profiling events into the profiling state
+  //
 
-  inline const ProfilerConfig& config() const {
-    return config_;
-  }
+  // Profiler state
+  struct ProfilerThreadLocalState : public c10::MemoryReportingInfoBase {
+    explicit ProfilerThreadLocalState(const ProfilerConfig& config)
+        : config_(config), remoteProfiledEvents_{c10::nullopt} {}
+    ~ProfilerThreadLocalState() override = default;
 
-  thread_event_lists consolidate() {
-    std::lock_guard<std::mutex> g(state_mutex_);
-    thread_event_lists result;
-    for (auto& kv : event_lists_map_) {
-      auto& list = kv.second;
-      result.emplace_back(list->consolidate());
+    inline const ProfilerConfig& config() const {
+      return config_;
     }
-    // Consolidate remote events if applicable as well.
-    if (remoteProfiledEvents_) {
-      result.insert(
-          result.end(),
-          std::make_move_iterator(remoteProfiledEvents_->begin()),
-          std::make_move_iterator(remoteProfiledEvents_->end()));
-    }
-    return result;
-  }
 
-  void mark(
-      std::string name,
-      bool include_cuda = true) {
-    if (config_.state == ProfilerState::Disabled) {
-      return;
-    }
-    if (config_.state == ProfilerState::NVTX) {
-      cuda_stubs->nvtxMarkA(name.c_str());
-    } else {
-      Event evt(
-        EventKind::Mark,
-        at::StringView(std::move(name)),
-        at::RecordFunction::currentThreadId(),
-        include_cuda && config_.state == ProfilerState::CUDA
-      );
-      evt.setNodeId(at::RecordFunction::getDefaultNodeId());
-      getEventList().record(std::move(evt));
-    }
-  }
-
-  void setOrAddRemoteProfiledEvents(std::vector<Event>&& remoteProfiledEvents) {
-    // Lock to serialize access from multiple callback threads.
-    std::lock_guard<std::mutex> guard(state_mutex_);
-    if (remoteProfiledEvents_) {
-      (*remoteProfiledEvents_).emplace_back(remoteProfiledEvents);
-    } else {
-      remoteProfiledEvents_ = {std::move(remoteProfiledEvents)};
-    }
-  }
-
-  void pushRange(
-      const at::StringView& name,
-      const char* msg = "",
-      int64_t sequence_nr = -1,
-      std::vector<std::vector<int64_t>>&& shapes = {},
-      at::RecordFunctionHandle handle = 0) {
-    if (config_.state == ProfilerState::Disabled) {
-      return;
-    }
-    if (config_.state == ProfilerState::NVTX) {
-      cuda_stubs->nvtxRangePushA(getNvtxStr(
-          name, msg, sequence_nr, shapes).c_str());
-    } else {
-      Event evt(EventKind::PushRange,
-          name,
-          at::RecordFunction::currentThreadId(),
-          config_.state == ProfilerState::CUDA,
-          handle,
-          std::move(shapes),
-          at::RecordFunction::getDefaultNodeId());
-      evt.setSequenceNr(sequence_nr);
-      getEventList().record(std::move(evt));
-    }
-  }
-
-  void popRange(uint64_t thread_id, at::RecordFunctionHandle handle) {
-    if (config_.state == ProfilerState::Disabled) {
-      return;
-    }
-    if (config_.state == ProfilerState::NVTX) {
-      cuda_stubs->nvtxRangePop();
-    } else {
-      // In some cases RecordFunction (and popRange) may be
-      // called on a different thread than pushRange
-      // As a convention, we put the async pop on the original
-      // thread and save current thread id in pop event
-      Event evt(EventKind::PopRange,
-          at::StringView(""),
-          at::RecordFunction::currentThreadId(),
-          config_.state == ProfilerState::CUDA,
-          handle);
-      evt.setNodeId(at::RecordFunction::getDefaultNodeId());
-      getEventList(thread_id).record(std::move(evt));
-    }
-  }
-
-  void setCallbackHandle(at::CallbackHandle handle) {
-    handle_ = handle;
-  }
-
-  at::CallbackHandle callbackHandle() const {
-    return handle_;
-  }
-
-  void reportMemoryUsage(
-      void* /* unused */, int64_t alloc_size, c10::Device device) override {
-    if (config_.profile_memory && config_.state != ProfilerState::Disabled) {
-      uint64_t thread_id = at::RecordFunction::currentThreadId();
-      Event evt(
-          EventKind::MemoryAlloc,
-          at::StringView(""),
-          thread_id,
-          config_.state == ProfilerState::CUDA);
-      evt.updateMemoryStats(alloc_size, device);
-      getEventList(thread_id).record(std::move(evt));
-    }
-  }
-
-  bool memoryProfilingEnabled() const override {
-    return config_.profile_memory;
-  }
-
- private:
-  std::string getNvtxStr(
-      const at::StringView& name,
-      const char* msg,
-      int64_t sequence_nr,
-      const std::vector<std::vector<int64_t>>& shapes) const {
-    if (sequence_nr >= 0 || shapes.size() > 0) {
-      std::stringstream s;
-      if (sequence_nr >= 0) {
-        s << name.str() << msg << sequence_nr;
+    thread_event_lists consolidate() {
+      std::lock_guard<std::mutex> g(state_mutex_);
+      thread_event_lists result;
+      for (auto& kv : event_lists_map_) {
+        auto& list = kv.second;
+        result.emplace_back(list->consolidate());
       }
-      if (shapes.size() > 0) {
-        s << ", sizes = [";
-        for (size_t idx = 0; idx < shapes.size(); ++idx) {
-          if (shapes[idx].size() > 0) {
-            s << "[";
-            for (size_t dim = 0; dim < shapes[idx].size(); ++dim) {
-              s << shapes[idx][dim];
-              if (dim < shapes[idx].size() - 1) {
-                s << ", ";
-              }
-            }
-            s << "]";
-          } else {
-            s << "[]";
-          }
-          if (idx < shapes.size() - 1) {
-            s << ", ";
-          }
+      // Consolidate remote events if applicable as well.
+      if (remoteProfiledEvents_) {
+        result.insert(
+            result.end(),
+            std::make_move_iterator(remoteProfiledEvents_->begin()),
+            std::make_move_iterator(remoteProfiledEvents_->end()));
+      }
+      return result;
+    }
+
+    void mark(std::string name, bool include_cuda = true) {
+      if (config_.state == ProfilerState::Disabled) {
+        return;
+      }
+      if (config_.state == ProfilerState::NVTX) {
+        cuda_stubs->nvtxMarkA(name.c_str());
+      } else {
+        Event evt(
+            EventKind::Mark,
+            at::StringView(std::move(name)),
+            at::RecordFunction::currentThreadId(),
+            include_cuda && config_.state == ProfilerState::CUDA);
+        evt.setNodeId(at::RecordFunction::getDefaultNodeId());
+        getEventList().record(std::move(evt));
+      }
+    }
+
+    void setOrAddRemoteProfiledEvents(
+        std::vector<Event>&& remoteProfiledEvents) {
+      // Lock to serialize access from multiple callback threads.
+      std::lock_guard<std::mutex> guard(state_mutex_);
+      if (remoteProfiledEvents_) {
+        (*remoteProfiledEvents_).emplace_back(remoteProfiledEvents);
+      } else {
+        remoteProfiledEvents_ = {std::move(remoteProfiledEvents)};
+      }
+    }
+
+    void pushRange(
+        const at::StringView& name,
+        const bool record_cuda,
+        const char* msg = "",
+        int64_t sequence_nr = -1,
+        std::vector<std::vector<int64_t>>&& shapes = {},
+        at::RecordFunctionHandle handle = 0) {
+      if (config_.state == ProfilerState::Disabled) {
+        return;
+      }
+      if (config_.state == ProfilerState::NVTX) {
+        cuda_stubs->nvtxRangePushA(
+            getNvtxStr(name, msg, sequence_nr, shapes).c_str());
+      } else {
+        Event evt(
+            EventKind::PushRange,
+            name,
+            at::RecordFunction::currentThreadId(),
+            record_cuda,
+            handle,
+            std::move(shapes),
+            at::RecordFunction::getDefaultNodeId());
+        evt.setSequenceNr(sequence_nr);
+        getEventList().record(std::move(evt));
+      }
+    }
+
+    void popRange(
+        uint64_t thread_id,
+        const bool record_cuda,
+        at::RecordFunctionHandle handle) {
+      if (config_.state == ProfilerState::Disabled) {
+        return;
+      }
+      if (config_.state == ProfilerState::NVTX) {
+        cuda_stubs->nvtxRangePop();
+      } else {
+        // In some cases RecordFunction (and popRange) may be
+        // called on a different thread than pushRange
+        // As a convention, we put the async pop on the original
+        // thread and save current thread id in pop event
+        Event evt(
+            EventKind::PopRange,
+            at::StringView(""),
+            at::RecordFunction::currentThreadId(),
+            record_cuda,
+            handle);
+        evt.setNodeId(at::RecordFunction::getDefaultNodeId());
+        getEventList(thread_id).record(std::move(evt));
+      }
+    }
+
+    void setCallbackHandle(at::CallbackHandle handle) {
+      handle_ = handle;
+    }
+
+    at::CallbackHandle callbackHandle() const {
+      return handle_;
+    }
+
+    void reportMemoryUsage(
+        void* /* unused */,
+        int64_t alloc_size,
+        c10::Device device) override {
+      if (config_.profile_memory && config_.state != ProfilerState::Disabled) {
+        uint64_t thread_id = at::RecordFunction::currentThreadId();
+        Event evt(
+            EventKind::MemoryAlloc,
+            at::StringView(""),
+            thread_id,
+            config_.state == ProfilerState::CUDA);
+        evt.updateMemoryStats(alloc_size, device);
+        getEventList(thread_id).record(std::move(evt));
+      }
+    }
+
+    bool memoryProfilingEnabled() const override {
+      return config_.profile_memory;
+    }
+
+   private:
+    std::string getNvtxStr(
+        const at::StringView& name,
+        const char* msg,
+        int64_t sequence_nr,
+        const std::vector<std::vector<int64_t>>& shapes) const {
+      if (sequence_nr >= 0 || shapes.size() > 0) {
+        std::stringstream s;
+        if (sequence_nr >= 0) {
+          s << name.str() << msg << sequence_nr;
         }
-        s << "]";
+        if (shapes.size() > 0) {
+          s << ", sizes = [";
+          for (size_t idx = 0; idx < shapes.size(); ++idx) {
+            if (shapes[idx].size() > 0) {
+              s << "[";
+              for (size_t dim = 0; dim < shapes[idx].size(); ++dim) {
+                s << shapes[idx][dim];
+                if (dim < shapes[idx].size() - 1) {
+                  s << ", ";
+                }
+              }
+              s << "]";
+            } else {
+              s << "[]";
+            }
+            if (idx < shapes.size() - 1) {
+              s << ", ";
+            }
+          }
+          s << "]";
+        }
+        return s.str();
+      } else {
+        return name.str();
       }
-      return s.str();
-    } else {
-      return name.str();
     }
-  }
 
-  RangeEventList& getEventList(int64_t thread_id = -1) {
-    if (thread_id < 0) {
-      thread_id = at::RecordFunction::currentThreadId();
+    RangeEventList& getEventList(int64_t thread_id = -1) {
+      if (thread_id < 0) {
+        thread_id = at::RecordFunction::currentThreadId();
+      }
+      RangeEventList* list_ptr = nullptr;
+      std::lock_guard<std::mutex> guard(state_mutex_);
+      auto it = event_lists_map_.find(thread_id);
+      if (it != event_lists_map_.end()) {
+        list_ptr = it->second.get();
+      } else {
+        auto event_list = std::make_shared<RangeEventList>();
+        event_lists_map_[thread_id] = event_list;
+        list_ptr = event_list.get();
+      }
+      return *list_ptr;
     }
-    RangeEventList* list_ptr = nullptr;
-    std::lock_guard<std::mutex> guard(state_mutex_);
-    auto it = event_lists_map_.find(thread_id);
-    if (it != event_lists_map_.end()) {
-      list_ptr = it->second.get();
-    } else {
-      auto event_list = std::make_shared<RangeEventList>();
-      event_lists_map_[thread_id] = event_list;
-      list_ptr = event_list.get();
-    }
-    return *list_ptr;
-  }
 
-  std::mutex state_mutex_;
-  std::unordered_map<uint64_t, std::shared_ptr<RangeEventList>>
-      event_lists_map_;
+    std::mutex state_mutex_;
+    std::unordered_map<uint64_t, std::shared_ptr<RangeEventList>>
+        event_lists_map_;
 
-  ProfilerConfig config_ = ProfilerConfig(ProfilerState::Disabled, false, false);
-  at::CallbackHandle handle_ = 0;
-  c10::optional<std::vector<std::vector<Event>>> remoteProfiledEvents_;
+    ProfilerConfig config_ =
+        ProfilerConfig(ProfilerState::Disabled, false, false);
+    at::CallbackHandle handle_ = 0;
+    c10::optional<std::vector<std::vector<Event>>> remoteProfiledEvents_;
 };
 
 ProfilerThreadLocalState* getProfilerTLSState() {
@@ -351,6 +375,11 @@ void pushProfilingCallbacks() {
         auto state_ptr = getProfilerTLSState();
         if (!state_ptr || state_ptr->config().state == ProfilerState::Disabled) {
           return;
+        }
+        bool record_cuda =
+            state_ptr->config().state == ProfilerState::CUDA;
+        if (record_cuda && disable_cuda_profiling.find(fn.name().str()) != disable_cuda_profiling.end()) {
+          record_cuda = false;
         }
 
         auto* msg = (fn.seqNr() >= 0) ? ", seq = " : "";
@@ -370,9 +399,9 @@ void pushProfilingCallbacks() {
             }
           }
           state_ptr->pushRange(
-              fn.name(), msg, fn.seqNr(), std::move(inputSizes), fn.handle());
+              fn.name(), record_cuda, msg, fn.seqNr(), std::move(inputSizes), fn.handle());
         } else {
-          state_ptr->pushRange(fn.name(), msg, fn.seqNr(), {}, fn.handle());
+          state_ptr->pushRange(fn.name(), record_cuda, msg, fn.seqNr(), {}, fn.handle());
         }
       },
       [](const at::RecordFunction& fn) {
@@ -380,7 +409,12 @@ void pushProfilingCallbacks() {
         if (!state_ptr || state_ptr->config().state == ProfilerState::Disabled) {
           return;
         }
-        state_ptr->popRange(fn.getStartCallbacksThreadId(), fn.handle());
+        bool record_cuda =
+            state_ptr->config().state == ProfilerState::CUDA;
+        if (record_cuda && disable_cuda_profiling.find(fn.name().str()) != disable_cuda_profiling.end()) {
+          record_cuda = false;
+        }
+        state_ptr->popRange(fn.getStartCallbacksThreadId(), record_cuda, fn.handle());
       })
     .needsInputs(state_ptr->config().report_input_shapes)
     .needsIds(true));

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -54,7 +54,7 @@ namespace {
       "aten::stride",
       "aten::empty",
       "aten::empty_like",
-      "aten::empty_strided"
+      "aten::empty_strided",
       "aten::as_strided",
       "aten::expand",
       "aten::resize_",

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1124,6 +1124,9 @@ class RpcTest(RpcAgentTestFixture):
             fut1.wait()
             fut2.wait()
 
+        def get_name(event):
+            return event.name[event.name.find(REMOTE_OP_STR) + len(REMOTE_OP_STR):]
+
         function_events = p.function_events
         for event in function_events:
             if event.is_async:
@@ -1134,22 +1137,18 @@ class RpcTest(RpcAgentTestFixture):
                 if event.node_id == 1:
                     continue
                 self.assertTrue(event.node_id in [dst_cuda_0, dst_cuda_1])
-                self.assertGreater(event.cuda_time_total, 0)
-                self.assertEqual(1, len(event.kernels))
-                kernel = event.kernels[0]
-                if event.node_id == dst_cuda_0:
-                    self.assertEqual(kernel.device, 0)
-                if event.node_id == dst_cuda_1:
-                    self.assertEqual(kernel.device, 1)
-
-                self.assertGreater(event.cuda_time, 0)
+                if get_name(event) in EXPECTED_REMOTE_EVENTS:
+                    self.assertGreater(event.cuda_time_total, 0)
+                    self.assertEqual(1, len(event.kernels))
+                    kernel = event.kernels[0]
+                    if event.node_id == dst_cuda_0:
+                        self.assertEqual(kernel.device, 0)
+                    if event.node_id == dst_cuda_1:
+                        self.assertEqual(kernel.device, 1)
+                    self.assertGreater(event.cuda_time, 0)
 
         # Validate that EXPECTED_REMOTE_EVENTS is a subset of remotely profiled
         # events.
-
-        def get_name(event):
-            return event.name[event.name.find(REMOTE_OP_STR) + len(REMOTE_OP_STR):]
-
         remote_events = [event for event in function_events if event.is_remote]
         remote_event_names = [get_name(event) for event in remote_events if get_name(event) in EXPECTED_REMOTE_EVENTS]
         self.assertEqual(set(remote_event_names), set(EXPECTED_REMOTE_EVENTS))


### PR DESCRIPTION
In profiler, cuda did not report self time, so for composite functions there was no way to determine which function is really taking time. In addition, "total cuda time" reported was frequently more than total wallclock time. This PR adds "self CUDA time" in profiler, and computes total cuda time based on self cuda time, similar to how it's done for CPU. Also, slight formatting changes to make table more compact. Before:
```
--------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  
Name                  Self CPU total %  Self CPU total   CPU total %      CPU total        CPU time avg     CUDA total %     CUDA total       CUDA time avg    Number of Calls  
--------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  
aten::matmul          0.17%            890.805us        99.05%           523.401ms        5.234ms          49.91%           791.184ms        7.912ms          100              
aten::mm              98.09%           518.336ms        98.88%           522.511ms        5.225ms          49.89%           790.885ms        7.909ms          100              
aten::t               0.29%            1.530ms          0.49%            2.588ms          25.882us         0.07%            1.058ms          10.576us         100              
aten::view            0.46%            2.448ms          0.46%            2.448ms          12.238us         0.06%            918.936us        4.595us          200              
aten::transpose       0.13%            707.204us        0.20%            1.058ms          10.581us         0.03%            457.802us        4.578us          100              
aten::empty           0.14%            716.056us        0.14%            716.056us        7.161us          0.01%            185.694us        1.857us          100              
aten::as_strided      0.07%            350.935us        0.07%            350.935us        3.509us          0.01%            156.380us        1.564us          100              
aten::stride          0.65%            3.458ms          0.65%            3.458ms          11.527us         0.03%            441.258us        1.471us          300              
--------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  
Self CPU time total: 528.437ms
CUDA time total: 1.585s

Recorded timeit time:  789.0814 ms

```
Note recorded timeit time (with proper cuda syncs) is 2 times smaller than "CUDA time total" reported by profiler

After
```
--------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
--------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
        aten::matmul         0.15%     802.716us        99.06%     523.548ms       5.235ms     302.451us         0.04%     791.151ms       7.912ms           100  
            aten::mm        98.20%     519.007ms        98.91%     522.745ms       5.227ms     790.225ms        99.63%     790.848ms       7.908ms           100  
             aten::t         0.27%       1.406ms         0.49%       2.578ms      25.783us     604.964us         0.08%       1.066ms      10.662us           100  
          aten::view         0.45%       2.371ms         0.45%       2.371ms      11.856us     926.281us         0.12%     926.281us       4.631us           200  
     aten::transpose         0.15%     783.462us         0.22%       1.173ms      11.727us     310.016us         0.04%     461.282us       4.613us           100  
         aten::empty         0.11%     591.603us         0.11%     591.603us       5.916us     176.566us         0.02%     176.566us       1.766us           100  
    aten::as_strided         0.07%     389.270us         0.07%     389.270us       3.893us     151.266us         0.02%     151.266us       1.513us           100  
        aten::stride         0.60%       3.147ms         0.60%       3.147ms      10.489us     446.451us         0.06%     446.451us       1.488us           300  
--------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 528.498ms
CUDA time total: 793.143ms

Recorded timeit time:  788.9832 ms

```