### PR TITLE
[ROCm] Print name irrespective of seq number assignment for roctx traces

### DIFF
--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -281,8 +281,15 @@ struct ProfilerThreadLocalState
       const std::vector<std::vector<int64_t>>& shapes) const {
     if (sequence_nr >= 0 || shapes.size() > 0) {
       std::stringstream s;
+#ifdef __HIP_PLATFORM_HCC__
+      s << name.str();
+#endif
       if (sequence_nr >= 0) {
+#ifdef __HIP_PLATFORM_HCC__
+        s << msg << sequence_nr;
+#else
         s << name.str() << msg << sequence_nr;
+#endif
       }
       if (shapes.size() > 0) {
         s << ", sizes = [";


### PR DESCRIPTION
Recent changes to the seq_num correlation behavior in profiler (PR #42565)  has changed the behavior for emit_nvtx(record_shapes=True)  which doesn't print the name of the operator properly. 

Created PR to dump out the name in roctx traces, irrespective of the sequence number assigned only for ROCm.

cc: @jeffdaily @sunway513