### PR TITLE
[RFC] Update generate_code, unboxing-wrapper codegen, and autograd codegen to accept the operator selector paradigm as opposed to a selected operator list

### DIFF
--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -27,7 +27,9 @@ import os
 import yaml
 import re
 from collections import defaultdict
-from .utils import YamlLoader, split_name_params, op_name_without_overload
+from .utils import YamlLoader, split_name_params, op_name_with_overload
+from tools.codegen.model import OperatorName
+from tools.codegen.selective_build.selector import SelectiveBuildBase
 
 # See NOTE [ Autograd View Variables ] in variable.h for details.
 # If you update list VIEW_FUNCTIONS or RETURNS_VIEWS_OF_INPUT,
@@ -231,15 +233,18 @@ def load_deprecated_signatures(aten_decls, deprecated_path):
     return declarations
 
 
-def gen_autograd(aten_path, out, autograd_dir, disable_autograd=False, selected_op_list=None):
+def gen_autograd(aten_path, out, autograd_dir, operator_selector: SelectiveBuildBase, disable_autograd=False):
     full_aten_decls = load_aten_declarations(aten_path)
 
-    def filter_decls(aten_decls, selected_op_list):
-        if selected_op_list is None:
-            return aten_decls
-        return [decl for decl in aten_decls if op_name_without_overload(decl) in selected_op_list]
+    def filter_decls(aten_decls, operator_selector):
+        def is_op_selected(decl):
+            op_name = op_name_with_overload(decl)
+            op_obj = OperatorName.parse(op_name)
+            return operator_selector.is_operator_selected(op_obj)
 
-    aten_decls = filter_decls(full_aten_decls, selected_op_list)
+        return [decl for decl in aten_decls if is_op_selected(decl)]
+
+    aten_decls = filter_decls(full_aten_decls, operator_selector)
 
     # Parse and load derivatives.yaml
     from .load_derivatives import load_derivatives

--- a/tools/autograd/utils.py
+++ b/tools/autograd/utils.py
@@ -74,6 +74,12 @@ def is_tensor_method(declaration):
 def is_out_variant(decl):
     return decl['name'].endswith('_out')
 
+def op_name_with_overload(decl):
+    name = decl['operator_name_with_overload'] \
+        if not is_out_variant(decl) else \
+        decl['operator_name_with_overload'][:-len('_out')]
+    return name
+
 def op_name_without_overload(decl):
     name = decl['name'] if not is_out_variant(decl) else decl['name'][:-4]
     return 'aten::{}'.format(name)

--- a/tools/jit/gen_unboxing_wrappers.py
+++ b/tools/jit/gen_unboxing_wrappers.py
@@ -23,7 +23,9 @@ import re
 from itertools import groupby
 from ..autograd.gen_autograd import load_aten_declarations
 from ..autograd.gen_autograd import RETURNS_VIEWS_OF_INPUT
-from ..autograd.utils import CodeTemplate, write, is_out_variant, op_name_without_overload
+from ..autograd.utils import CodeTemplate, write, is_out_variant, op_name_with_overload
+from tools.codegen.model import OperatorName
+from tools.codegen.selective_build.selector import SelectiveBuildBase
 
 # JIT has a type system of
 # Scalar = int | float | bool # int is the largest int (int64_t),
@@ -279,8 +281,8 @@ def gen_unboxing_wrappers(
     declarations,
     out,
     template_path,
+    operator_selector: SelectiveBuildBase,
     disable_autograd=False,
-    selected_op_list=None,
     force_schema_registration=False,
 ):
     GENERATED_UNBOXING_WRAPPERS_CPP = CodeTemplate.from_file(template_path + '/generated_unboxing_wrappers.cpp')
@@ -385,18 +387,21 @@ def gen_unboxing_wrappers(
 
         return constructor
 
-    def filter_decls(jit_decls, disable_autograd, selected_op_list, force_schema_registration):
+    def filter_decls(jit_decls, disable_autograd, operator_selector: SelectiveBuildBase, force_schema_registration):
         result = []
         for decl in jit_decls:
             if disable_autograd and is_backward_op(decl):
                 continue
-            op_name = op_name_without_overload(decl)
-            if selected_op_list is not None and op_name not in selected_op_list:
+            op_name = op_name_with_overload(decl)
+            op_obj = OperatorName.parse(op_name)
+            if operator_selector.is_operator_selected(op_obj):
+                result.append(decl)
+            else:
                 if force_schema_registration:
                     decl['emit_dummy_placeholder'] = True
-                else:
-                    continue
-            result.append(decl)
+                    result.append(decl)
+                # end if
+            # end if
         return result
 
     # This function declares an order on declarations. This is necessary because
@@ -466,7 +471,7 @@ def gen_unboxing_wrappers(
             reorder_out_args(decl)
 
     jit_decls.extend(additional_jit_decls)
-    jit_decls = filter_decls(jit_decls, disable_autograd, selected_op_list, force_schema_registration)
+    jit_decls = filter_decls(jit_decls, disable_autograd, operator_selector, force_schema_registration)
 
     # generation is deterministic
     jit_decl_groups = sort_decls(jit_decls)

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -2,6 +2,11 @@ import argparse
 import os
 import sys
 
+from tools.autograd.utils import load_op_list_and_strip_overload
+from tools.codegen.selective_build.selector import SelectiveBuildBase
+from tools.codegen.selective_build.selector import SelectiveBuildSelectorFactory
+from tools.codegen.selective_build.selector import SelectiveBuildNotSelective
+
 source_files = {'.py', '.cpp', '.h'}
 
 DECLARATIONS_PATH = 'torch/share/ATen/Declarations.yaml'
@@ -25,15 +30,13 @@ def generate_code(ninja_global=None,
                   install_dir=None,
                   subset=None,
                   disable_autograd=False,
-                  selected_op_list_path=None,
-                  selected_op_list=None,
-                  force_schema_registration=False):
+                  force_schema_registration=False,
+                  operator_selector=SelectiveBuildNotSelective()):
     # cwrap depends on pyyaml, so we can't import it earlier
     root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     sys.path.insert(0, root)
     from tools.autograd.gen_autograd import gen_autograd, gen_autograd_python
     from tools.autograd.gen_annotated_fn_args import gen_annotated
-    from tools.autograd.utils import load_op_list_and_strip_overload
     from tools.jit.gen_unboxing_wrappers import gen_unboxing_wrappers
 
     # Build ATen based Variable classes
@@ -56,21 +59,20 @@ def generate_code(ninja_global=None,
         gen_autograd_python(declarations_path or DECLARATIONS_PATH, autograd_gen_dir, autograd_dir)
 
     if subset == "libtorch" or not subset:
-        selected_op_list = load_op_list_and_strip_overload(selected_op_list, selected_op_list_path)
 
         gen_autograd(
             declarations_path or DECLARATIONS_PATH,
             autograd_gen_dir,
             autograd_dir,
             disable_autograd=disable_autograd,
-            selected_op_list=selected_op_list,
+            operator_selector=operator_selector,
         )
         gen_unboxing_wrappers(
             declarations_path or DECLARATIONS_PATH,
             jit_gen_dir,
             tools_jit_templates,
             disable_autograd=disable_autograd,
-            selected_op_list=selected_op_list,
+            operator_selector=operator_selector,
             force_schema_registration=force_schema_registration)
 
     if subset == "python" or not subset:
@@ -114,6 +116,18 @@ def main():
         'listed on --selected-op-list'
     )
     options = parser.parse_args()
+
+    selected_op_list = load_op_list_and_strip_overload(
+        options.selected_op_list,
+        options.selected_op_list_path,
+    )
+
+    selector: SelectiveBuildBase = SelectiveBuildNotSelective()
+    if selected_op_list is not None:
+        selector = SelectiveBuildSelectorFactory.create_from_legacy_op_registration_allow_list(
+            selected_op_list
+        )
+
     generate_code(
         options.ninja_global,
         options.declarations_path,
@@ -121,9 +135,8 @@ def main():
         options.install_dir,
         options.subset,
         options.disable_autograd,
-        options.selected_op_list_path,
-        options.selected_op_list,
         options.force_schema_registration,
+        operator_selector=selector,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45230 [RFC] Update generate_code, unboxing-wrapper codegen, and autograd codegen to accept the operator selector paradigm as opposed to a selected operator list**
* #45211 [RFC] Switch over gen.py to using the selective build abstraction instead of directly querying op_registration_whitelist
* #45191 [RFC] Add method SelectiveBuildOperator.combine()
* #45190 [RFC] Helpers for various selective build codegen code-paths

In preparation for selective build based on operator name+overload name, we want to clean up call-sites that rely on specific behaviour of the selective build. To that effect, this diff is updating the other codegen code paths to rely on operator selector and not a specific selected operator list. This will make the transition to the overload name based selective build easier and less error prone. See the change where the selector accepts the full operator name and then the specific selector instance decides if it wishes to operate on the full name with overload or without overload name.

Differential Revision: [D23880782](https://our.internmc.facebook.com/intern/diff/D23880782/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D23880782/)!