### PR TITLE
Add link to profiling recipe from rpc main docs

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -293,8 +293,11 @@ The RRef design note covers the design of the :ref:`rref` (Remote REFerence) pro
 
 Tutorials
 ---------
-The RPC tutorial introduces users to the RPC framework and provides two example applications using :ref:`torch.distributed.rpc<distributed-rpc-framework>` APIs.
+The RPC tutorials introduce users to the RPC framework, provide several example applications
+using :ref:`torch.distributed.rpc<distributed-rpc-framework>` APIs, and demonstrate how
+to use :ref:`torch.autograd.profiler` to profile RPC-based workloads.
 
 -  `Getting started with Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_tutorial.html>`__
 -  `Implementing a Parameter Server using Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_param_server_tutorial.html>`__
 -  `Combining Distributed DataParallel with Distributed RPC Framework <https://pytorch.org/tutorials/advanced/rpc_ddp_tutorial.html>`__
+-  `Profiling RPC-based Worklads <https://pytorch.org/tutorials/recipes/distributed_rpc_profiling.html>`__

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -295,9 +295,9 @@ Tutorials
 ---------
 The RPC tutorials introduce users to the RPC framework, provide several example applications
 using :ref:`torch.distributed.rpc<distributed-rpc-framework>` APIs, and demonstrate how
-to use :ref:`torch.autograd.profiler` to profile RPC-based workloads.
+to use `the profiler <https://pytorch.org/docs/stable/autograd.html>`__ to profile RPC-based workloads.
 
 -  `Getting started with Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_tutorial.html>`__
 -  `Implementing a Parameter Server using Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_param_server_tutorial.html>`__
 -  `Combining Distributed DataParallel with Distributed RPC Framework <https://pytorch.org/tutorials/advanced/rpc_ddp_tutorial.html>`__
--  `Profiling RPC-based Worklads <https://pytorch.org/tutorials/recipes/distributed_rpc_profiling.html>`__
+-  `Profiling RPC-based Workloads <https://pytorch.org/tutorials/recipes/distributed_rpc_profiling.html>`__


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45235 Add link to profiling recipe from rpc main docs**

This is so that users know that the profiler works as expected with
RPC and they can learn how to use it to profile RPC-based workloads.

Screenshot:
![profiler_ss](https://user-images.githubusercontent.com/8039770/94075767-a145d080-fdb0-11ea-872a-f88a997c0b2a.png)

Differential Revision: [D23777888](https://our.internmc.facebook.com/intern/diff/D23777888/)