### PR TITLE
[NCCL] Extend work TimedOut to support custom timeouts

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -104,7 +104,7 @@ class ProcessGroupNCCL : public ProcessGroup {
 
     // Helper function that returns True if the WorkNCCL object has timed out
     // and False otherwise.
-    bool timedOut();
+    bool timedOut(std::chrono::milliseconds timeout = kNoTimeout);
 
     std::vector<at::Tensor> result() override;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45237 [NCCL] Extend work TimedOut to support custom timeouts**
* #45236 [WIP][NCCL] Replace work::wait busy wait with cudaEventSynchronize

timedOut should now support custom timeout durations. This PR extends
the helper function as well as support custom timeouts in WorkNCCL::wait.

Differential Revision: [D23829885](https://our.internmc.facebook.com/intern/diff/D23829885/)