### PR TITLE
Add a warning log when there is high skew of uneven inputs in DDP training

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -5,6 +5,7 @@ import os
 import inspect
 import logging
 import warnings
+
 import torch
 
 from . import comm

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -824,7 +824,7 @@ class DistributedDataParallel(Module):
                         warnings.warn(
                             "Detected uneven input skew of greater "
                             f"than {WARN_THRESHOLD}. This means that rank {my_rank} "
-                            f"has at least {WARN_THRESHOLD} less inputs than "
+                            f"has at least {WARN_THRESHOLD} fewer inputs than "
                             "other currently active ranks. This level of skew could "
                             "lead to performance degradation during training."
                         )

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -817,9 +817,9 @@ class DistributedDataParallel(Module):
                 is_last_joiner = True
                 i = 0
                 WARN_THRESHOLD = 1000
-                warned = False
+                warnings.simplefilter("once")
                 while not all_procs_joined:
-                    if i > WARN_THRESHOLD and not warned:
+                    if i > WARN_THRESHOLD:
                         my_rank = dist.get_rank(self.process_group)
                         warnings.warn(
                             "Detected uneven input skew of greater "
@@ -828,7 +828,6 @@ class DistributedDataParallel(Module):
                             "other currently active ranks. This level of skew could "
                             "lead to performance degradation during training."
                         )
-                        warned = True
                     # Schedules allreduce to match fwd pass allreduce in non-joined procs
                     num_active_procs = self._schedule_shadow_all_reduce_for_fwd_pass()
                     if num_active_procs == 0:

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -814,6 +814,9 @@ class DistributedDataParallel(Module):
             if enable and not has_error:
                 all_procs_joined = False
                 is_last_joiner = True
+                i = 0
+                WARN_THRESHOLD = 1000
+                warned = False
                 while not all_procs_joined:
                     if i > WARN_THRESHOLD and not warned:
                         my_rank = dist.get_rank(self.process_group)
@@ -862,6 +865,7 @@ class DistributedDataParallel(Module):
                             self._match_unused_params_allreduce()
                         # It will push rebuilt params only once during training period
                         self.reducer._push_all_rebuilt_params()
+                        i += 1
 
                 # All procs joined. Agree on authoritative rank and broadcast the model.
                 self._sync_final_model(is_last_joiner)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45238 Add a warning log when there is high skew of uneven inputs in DDP training**

This request came up in feature review for DDP uneven inputs, so this PR adds a warning when there is much higher than expected amount of
discrepancy of inputs across different processes when running with uneven
inputs. This is because a skew in the thousands can reduce performance a
nontrivial amount as shown in benchmarks in https://github.com/pytorch/pytorch/pull/42577, and it was proposed to add this
warning as a result. Tested by running the tests so the threshold is hit and
observing the output.

Differential Revision: [D23719270](https://our.internmc.facebook.com/intern/diff/D23719270/)