### PR TITLE
[Caffe2] Fix LayerNormOp when batch_size == 0.

### DIFF
--- a/caffe2/operators/layer_norm_op.h
+++ b/caffe2/operators/layer_norm_op.h
@@ -52,6 +52,11 @@ class LayerNormOp final : public Operator<Context> {
     T* sigma_data = sigma->template mutable_data<T>();
     T* scale_data = scale_.template mutable_data<T>();
     T* bias_data = bias_.template mutable_data<T>();
+
+    if (M == 0) {
+      return true;
+    }
+
     const std::array<int, 2> X_dims = {M, N};
     const std::array<int, 2> Y_dims = {M, 1};
     math::Moments<T, Context>(
@@ -172,6 +177,16 @@ class LayerNormGradientOp final : public Operator<Context> {
       dgamma_data = dgamma->template mutable_data<T>();
       dbeta_data = dbeta->template mutable_data<T>();
       g_scale_data = g_scale_.template mutable_data<T>();
+    }
+
+    if (M == 0) {
+      if (N > 0 && dgamma_data != nullptr) {
+        math::Set<T, Context>(N, T(0), dgamma_data, &context_);
+      }
+      if (N > 0 && dbeta_data != nullptr) {
+        math::Set<T, Context>(N, T(0), dbeta_data, &context_);
+      }
+      return true;
     }
 
     ComputeInternalGradients<T>(

--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -373,6 +373,34 @@ class TestLayerNormOp(serial.SerializedTestCase):
         self.ws.create_net(model.param_init_net).run()
         self.ws.create_net(model.net).run()
 
+    @given(N=st.integers(1, 10), elementwise_affine=st.booleans(), **hu.gcs)
+    @settings(deadline=None)
+    def test_layer_norm_with_empty_batch(self, N, elementwise_affine, gc, dc):
+        X = np.random.randn(0, N).astype(np.float32)
+        gamma = np.random.rand(N).astype(np.float32)
+        beta = np.random.rand(N).astype(np.float32)
+
+        op = core.CreateOperator(
+            "LayerNorm",
+            ["X", "gamma", "beta"] if elementwise_affine else ["X"],
+            ["Y", "mean", "sigma"],
+            elementwise_affine=elementwise_affine,
+        )
+
+        def ref(X, gamma=None, beta=None):
+            Y = np.zeros_like(X)
+            axis = 1
+            mean = np.zeros(X.shape[:axis] + (1,), dtype=X.dtype)
+            sigma = np.zeros(X.shape[:axis] + (1,), dtype=X.dtype)
+            return Y, mean, sigma
+
+
+        inputs = [X, gamma, beta] if elementwise_affine else [X]
+        self.assertReferenceChecks(gc, op, inputs, ref)
+        self.assertDeviceChecks(dc, op, inputs, [0, 1])
+        for i in range(len(inputs)):
+            self.assertGradientChecks(gc, op, inputs, i, [0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: [Caffe2] Fix LayerNormOp when batch_size == 0.

Test Plan: buck test mode/dev-nosan //caffe2/caffe2/python/operator_test:layer_norm_op_test

Differential Revision: D23892091

