### PR TITLE
Refactor six

### DIFF
--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -26,10 +26,6 @@ import torch.optim as optim
 import torchvision
 
 
-if not torch._six.PY3:
-    raise RuntimeError("DDP benchmark requires Python 3")
-
-
 def allgather_object(obj):
     buffer = io.BytesIO()
     torch.save(obj, buffer)

--- a/benchmarks/distributed/ddp/diff.py
+++ b/benchmarks/distributed/ddp/diff.py
@@ -9,10 +9,6 @@ import json
 import numpy as np
 
 
-if not torch._six.PY3:
-    raise RuntimeError("DDP benchmark requires Python 3")
-
-
 def load(path):
     with open(path, 'r') as f:
         return json.load(f)

--- a/caffe2/contrib/tensorboard/tensorboard_exporter.py
+++ b/caffe2/contrib/tensorboard/tensorboard_exporter.py
@@ -1,13 +1,7 @@
-
-
-
-
-
 from builtins import bytes
 import copy
 import logging
 import os
-import six
 
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
@@ -93,7 +87,7 @@ def _get_blob_names(ops):
 
 
 def _remap_keys(m, f):
-    m2 = {f(key): value for key, value in six.iteritems(m)}
+    m2 = {f(key): value for key, value in m.items()}
     m.clear()
     m.update(m2)
 

--- a/caffe2/python/compatibility.py
+++ b/caffe2/python/compatibility.py
@@ -1,8 +1,2 @@
-from six import PY2, PY3
-
-if PY2:
-    import collections
-    container_abcs = collections
-elif PY3:
-    import collections.abc
-    container_abcs = collections.abc
+import collections.abc
+container_abcs = collections.abc

--- a/caffe2/python/context.py
+++ b/caffe2/python/context.py
@@ -1,12 +1,7 @@
 ## @package context
 # Module caffe2.python.context
-
-
-
-
-
+import functools
 import threading
-import six
 
 
 class _ContextInfo(object):
@@ -76,7 +71,7 @@ def __exit__(self, *args):
 
 
 def __call__(self, func):
-    @six.wraps(func)
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         with self:
             return func(*args, **kwargs)

--- a/caffe2/python/experiment_util.py
+++ b/caffe2/python/experiment_util.py
@@ -1,16 +1,11 @@
 ## @package experiment_util
 # Module caffe2.python.experiment_util
 
-
-
-
-
 import datetime
 import time
 import logging
 import socket
 import abc
-import six
 
 from collections import OrderedDict
 from future.utils import viewkeys, viewvalues
@@ -26,7 +21,7 @@ an external log destination.
 
 
 class ExternalLogger(object):
-    six.add_metaclass(abc.ABCMeta)
+    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def set_runtime_args(self, runtime_args):

--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -34,10 +34,6 @@ The key functions are:
   implemented on the CPU.
 """
 
-
-
-
-
 from caffe2.proto import caffe2_pb2
 from caffe2.python import (
     workspace, device_checker, gradient_checker, test_util, core)
@@ -50,7 +46,6 @@ import hypothesis.strategies as st
 import logging
 import numpy as np
 import os
-import six
 import struct
 
 
@@ -750,5 +745,5 @@ class HypothesisTestCase(test_util.TestCase):
             if regexp is None:
                 self.assertRaises(exception, workspace.RunOperatorOnce, op)
             else:
-                six.assertRaisesRegex(
-                    self, exception, regexp, workspace.RunOperatorOnce, op)
+                self.assertRaisesRegex(
+                    exception, regexp, workspace.RunOperatorOnce, op)

--- a/caffe2/python/layer_model_helper.py
+++ b/caffe2/python/layer_model_helper.py
@@ -1,10 +1,6 @@
 # @package layer_model_helper
 # Module caffe2.python.layer_model_helper
 
-
-
-
-
 from caffe2.python import core, model_helper, schema, scope, utils, muji
 from caffe2.python.modeling.parameter_info import (
     ParameterInfo,
@@ -22,7 +18,6 @@ from future.utils import viewitems, viewvalues
 
 import logging
 import numpy as np
-import six
 import copy
 logger = logging.getLogger(__name__)
 
@@ -125,7 +120,7 @@ class LayerModelHelper(model_helper.ModelHelper):
 
     def add_ad_hoc_plot_blob(self, blob, dtype=None):
         assert isinstance(
-            blob, (six.string_types, core.BlobReference)
+            blob, (str, core.BlobReference)
         ), "expect type str or BlobReference, but got {}".format(type(blob))
         dtype = dtype or (np.float, (1, ))
         self.add_metric_field(str(blob), schema.Scalar(dtype, blob))
@@ -173,7 +168,7 @@ class LayerModelHelper(model_helper.ModelHelper):
     def add_global_constant(
         self, name, array=None, dtype=None, initializer=None
     ):
-        assert isinstance(name, six.string_types), (
+        assert isinstance(name, str), (
             'name should be a string as we are using it as map key')
         # This is global namescope for constants. They will be created in all
         # init_nets and there should be very few of them.
@@ -310,7 +305,7 @@ class LayerModelHelper(model_helper.ModelHelper):
                      ps_param=None, regularizer=None):
         if isinstance(param_name, core.BlobReference):
             param_name = str(param_name)
-        elif isinstance(param_name, six.string_types):
+        elif isinstance(param_name, str):
             # Parameter name will be equal to current Namescope that got
             # resolved with the respect of parameter sharing of the scopes.
             param_name = parameter_sharing_context.get_parameter_name(
@@ -750,6 +745,6 @@ class LayerModelHelper(model_helper.ModelHelper):
         # TODO(xlwang): provide more rich feature information in breakdown_map;
         # and change the assertion accordingly
         assert isinstance(breakdown_map, dict)
-        assert all(isinstance(k, six.string_types) for k in breakdown_map)
+        assert all(isinstance(k, str) for k in breakdown_map)
         assert sorted(breakdown_map.values()) == list(range(len(breakdown_map)))
         self._breakdown_map = breakdown_map

--- a/caffe2/python/layer_parameter_sharing_test.py
+++ b/caffe2/python/layer_parameter_sharing_test.py
@@ -9,7 +9,6 @@ from caffe2.python.modeling.parameter_sharing import (
 )
 from caffe2.python.optimizer import AdagradOptimizer, AdamOptimizer
 from caffe2.python.layer_test_util import LayersTestCase
-import six
 
 
 class ParameterSharingTest(LayersTestCase):
@@ -116,7 +115,7 @@ class ParameterSharingTest(LayersTestCase):
                 self.assertEquals(self.model.layers[-1].w,
                                   'global_scope/fc/w')
 
-                with six.assertRaisesRegex(self, ValueError, 'Got inconsistent shapes .*'):
+                with self.assertRaisesRegex(self, ValueError, 'Got inconsistent shapes .*'):
                     self.model.FC(
                         self.model.input_feature_schema.float_features,
                         output_dims + 1

--- a/caffe2/python/layers/functional.py
+++ b/caffe2/python/layers/functional.py
@@ -1,17 +1,12 @@
 # @package functional
 # Module caffe2.python.layers.functional
 
-
-
-
-
 from caffe2.python import core, schema, scope, workspace
 from caffe2.python.layers.layers import (
     ModelLayer,
 )
 import caffe2.proto.caffe2_pb2 as caffe2_pb2
 import numpy as np
-import six
 import logging
 
 logger = logging.getLogger(__name__)
@@ -31,7 +26,7 @@ class Functional(ModelLayer):
         self._kwargs = kwargs
         return_struct = (
             isinstance(output_names_or_num, list) or
-            (isinstance(output_names_or_num, six.integer_types) and
+            (isinstance(output_names_or_num, int) and
              output_names_or_num != 1)
         )
 

--- a/caffe2/python/layers/sampling_trainable_mixin.py
+++ b/caffe2/python/layers/sampling_trainable_mixin.py
@@ -1,15 +1,11 @@
 ## @package sampling_trainable_mixin
 # Module caffe2.python.layers.sampling_trainable_mixin
 
-
-
-
-
 import abc
-import six
 
 
-class SamplingTrainableMixin(six.with_metaclass(abc.ABCMeta, object)):
+class SamplingTrainableMixin(object):
+    __metaclass__ = abc.ABCMeta
 
     def __init__(self, *args, **kwargs):
         super(SamplingTrainableMixin, self).__init__(*args, **kwargs)

--- a/caffe2/python/layers/tags.py
+++ b/caffe2/python/layers/tags.py
@@ -1,12 +1,7 @@
 ## @package tags
 # Module caffe2.python.layers.tags
 
-
-
-
-
-import six
-
+import functools
 from caffe2.python import context
 
 
@@ -61,7 +56,7 @@ class Tags(object):
     COMPONENT = 'component:'
     PIPELINE = 'pipeline:'
     """
-    Indicate it's a dense layer or dense param init, 
+    Indicate it's a dense layer or dense param init,
     but we use hogwild across multiple trainers
     """
     HOGWILD_DENSE = "hogwild_dense"
@@ -105,7 +100,7 @@ class Tags(object):
         TagContext.current().remove_tags(self.tags)
 
     def __call__(self, func):
-        @six.wraps(func)
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)

--- a/caffe2/python/model_helper.py
+++ b/caffe2/python/model_helper.py
@@ -1,10 +1,6 @@
 ## @package model_helper
 # Module caffe2.python.model_helper
 
-
-
-
-
 from caffe2.python import core, scope, workspace
 from caffe2.python.helpers.db_input import db_input
 from caffe2.python.modeling import parameter_info
@@ -21,7 +17,6 @@ from future.utils import viewitems, viewkeys
 from itertools import chain
 
 import logging
-import six
 
 
 # _known_working_ops are operators that do not need special care.
@@ -199,7 +194,7 @@ class ModelHelper(object):
         # ParameterSharing will be applied.
         if isinstance(param_name, core.BlobReference):
             param_name = str(param_name)
-        elif isinstance(param_name, six.string_types):
+        elif isinstance(param_name, str):
             # Parameter name will be equal to current Namescope that got
             # resolved with the respect of parameter sharing of the scopes.
             param_name = parameter_sharing_context.get_parameter_name(

--- a/caffe2/python/modeling/initializers.py
+++ b/caffe2/python/modeling/initializers.py
@@ -1,12 +1,5 @@
-
-
-
-
-
 from caffe2.python.core import DataType, BlobReference, ScopedBlobReference
 from caffe2.python.modeling.parameter_info import ParameterInfo
-
-import six
 
 
 class Initializer(object):
@@ -47,7 +40,7 @@ class ExternalInitializer(object):
     def create_param(self, param_name, init_net, shape):
         if isinstance(param_name, BlobReference):
             param = BlobReference(str(param_name), init_net)
-        elif isinstance(param_name, six.string_types):
+        elif isinstance(param_name, str):
             param = ScopedBlobReference(param_name, init_net)
         else:
             raise TypeError("Unsupported type for param_name")

--- a/caffe2/python/modeling/net_modifier.py
+++ b/caffe2/python/modeling/net_modifier.py
@@ -1,13 +1,8 @@
-
-
-
-
-
 import abc
-import six
 
 
-class NetModifier(six.with_metaclass(abc.ABCMeta, object)):
+class NetModifier(object):
+    __metaclass__ = abc.ABCMeta
     """
     An abstraction class for supporting modifying a generated net.
     Inherited classes should implement the modify_net method where

--- a/caffe2/python/onnx/tests/c2_ref_test.py
+++ b/caffe2/python/onnx/tests/c2_ref_test.py
@@ -1,14 +1,8 @@
 # @package onnx
 # Module caffe2.python.onnx.tests.c2_ref_test
 
-
-
-
-
-
 import json
 import os
-import six
 import unittest
 
 from caffe2.python import core
@@ -44,9 +38,8 @@ class TestCaffe2Basic(TestCase):
         b2.convert_node(node_def.SerializeToString())
 
         bad_node_def = make_node("Add", inputs=["X", "Y"], outputs=["Z"], foo=42, bar=56)
-        with six.assertRaisesRegex(self,
-                                   RuntimeError,
-                                   "Don't know how to map unexpected argument (foo|bar)"):
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Don't know how to map unexpected argument (foo|bar)"):
             b2.convert_node(bad_node_def.SerializeToString())
 
     def test_dynamicslice_3inputs_graph(self):

--- a/caffe2/python/onnx/tests/conversion_test.py
+++ b/caffe2/python/onnx/tests/conversion_test.py
@@ -1,12 +1,7 @@
 ## @package onnx
 # Module caffe2.python.onnx.tests.conversion_test
 
-
-
-
-
 import json
-import six
 import tempfile
 import textwrap
 import traceback
@@ -82,9 +77,9 @@ class TestConversion(TestCase):
         caffe2_net.flush()
 
         args = [caffe2_net.name, '--output', output.name]
-        six.assertRaisesRegex(self, Exception,
-                              'value info',
-                              self._run_command, caffe2_to_onnx, args)
+        self.assertRaisesRegex(Exception,
+                               'value info',
+                               self._run_command, caffe2_to_onnx, args)
 
         args.extend([
             '--value-info',

--- a/caffe2/python/operator_test/image_input_op_test.py
+++ b/caffe2/python/operator_test/image_input_op_test.py
@@ -1,8 +1,3 @@
-
-
-
-
-
 import unittest
 try:
     import cv2
@@ -13,7 +8,7 @@ except ImportError:
 from PIL import Image
 import numpy as np
 import shutil
-import six
+import io
 import sys
 import tempfile
 
@@ -134,7 +129,7 @@ def create_test(output_dir, width, height, default_bound, minsize, crop, means,
             img_array = np.random.random_integers(
                 0, 255, [height, width, 3]).astype(np.uint8)
             img_obj = Image.fromarray(img_array)
-            img_str = six.BytesIO()
+            img_str = io.BytesIO()
             img_obj.save(img_str, 'PNG')
 
             # Create a random bounding box for every other image

--- a/caffe2/python/operator_test/reshape_ops_test.py
+++ b/caffe2/python/operator_test/reshape_ops_test.py
@@ -1,9 +1,4 @@
-
-
-
-
 import numpy as np
-import six
 from numpy.testing import assert_array_equal
 
 from caffe2.python import core, workspace

--- a/caffe2/python/operator_test/utility_ops_test.py
+++ b/caffe2/python/operator_test/utility_ops_test.py
@@ -1,8 +1,3 @@
-
-
-
-
-
 from caffe2.python import core, workspace
 from hypothesis import assume, given, settings
 from caffe2.proto import caffe2_pb2
@@ -11,7 +6,6 @@ import caffe2.python.serialized_test.serialized_test_util as serial
 import hypothesis.strategies as st
 import numpy as np
 import random
-import six
 
 
 class TestUtilityOps(serial.SerializedTestCase):
@@ -474,7 +468,7 @@ class TestUtilityOps(serial.SerializedTestCase):
             names[len(inputs) - 1],
             ["Y"]
         )
-        with six.assertRaisesRegex(self, RuntimeError, 'Step size cannot be 0'):
+        with self.assertRaisesRegex(RuntimeError, 'Step size cannot be 0'):
             self.assertReferenceChecks(
                 device_option=gc,
                 op=op,

--- a/caffe2/python/parallel_workers.py
+++ b/caffe2/python/parallel_workers.py
@@ -1,11 +1,6 @@
 # @package parallel_workers
 # Module caffe2.python.parallel_workers
 
-
-
-
-
-
 '''
 This module provides a python-land multithreaded mechanism for executing work.
 
@@ -38,7 +33,6 @@ import threading
 import atexit
 import time
 import collections
-import six
 import traceback
 
 from abc import ABCMeta, abstractmethod
@@ -109,8 +103,8 @@ class Metrics(object):
             self._metrics[count_key] += 1
 
 
-class State():
-    six.add_metaclass(ABCMeta)
+class State(object):
+    __metaclass__ = ABCMeta
 
     @abstractmethod
     def start(self):

--- a/caffe2/python/python_op_test.py
+++ b/caffe2/python/python_op_test.py
@@ -1,14 +1,9 @@
-
-
-
-
 from caffe2.python import core, workspace
 from caffe2.python.core import CreatePythonOperator
 import caffe2.python.hypothesis_test_util as hu
 from hypothesis import given, settings
 import hypothesis.strategies as st
 import numpy as np
-import six
 
 
 class CustomError(Exception):
@@ -55,12 +50,12 @@ class PythonOpTest(hu.HypothesisTestCase):
 
     def test_exception(self):
         op = CreatePythonOperator(MainOpFunctionThatThrowsCustomError, [], [])
-        with six.assertRaisesRegex(self, CustomError, "This is an intentional exception."):
+        with self.assertRaisesRegex(CustomError, "This is an intentional exception."):
             workspace.RunOperatorOnce(op)
 
     def test_exception_builder(self):
         op = CreatePythonOperator(MainOpFunctionThatThrowsCustomErrorInBuilder, [], [])
-        with six.assertRaisesRegex(self, CustomError, "This is an intentional exception in builder."):
+        with self.assertRaisesRegex(CustomError, "This is an intentional exception in builder."):
             workspace.RunOperatorOnce(op)
 
     @given(x=hu.tensor())

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -1,17 +1,11 @@
 ## @package rnn_cell
 # Module caffe2.python.rnn_cell
-
-
-
-
-
 import functools
 import inspect
 import itertools
 import logging
 import numpy as np
 import random
-import six
 from future.utils import viewkeys
 
 from caffe2.proto import caffe2_pb2
@@ -32,7 +26,7 @@ from caffe2.python.model_helper import ModelHelper
 def _RectifyName(blob_reference_or_name):
     if blob_reference_or_name is None:
         return None
-    if isinstance(blob_reference_or_name, six.string_types):
+    if isinstance(blob_reference_or_name, str):
         return core.ScopedBlobReference(blob_reference_or_name)
     if not isinstance(blob_reference_or_name, core.BlobReference):
         raise Exception("Unknown blob reference type")

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -36,7 +36,6 @@ from jit.test_slice import TestSlice  # noqa: F401
 # Torch
 from torch import Tensor
 from torch._C import TensorType, BoolType, parse_ir, _propagate_shapes
-from torch._six import PY37, StringIO
 from torch.autograd import Variable
 from torch.jit.annotations import BroadcastingList2, BroadcastingList3, Any  # noqa: F401
 from torch.testing import FileCheck
@@ -6433,8 +6432,7 @@ a")
         checkMathWrap("ceil", ret_type="int")
         checkMathWrap("gcd", 2, is_float=False, ret_type="int")
         checkMath("isfinite", 1, ret_type="bool")
-        if PY37:
-            checkMathWrap("remainder", 2)
+        checkMathWrap("remainder", 2)
         checkMathWrap("factorial", 1, is_float=False, ret_type="int", vals=[(i, 0) for i in range(-2, 10)])
 
     def test_if_nest_while(self):
@@ -14749,7 +14747,7 @@ a")
             archive = zipfile.ZipFile(fname, 'r')
             pickled_data = archive.read(os.path.join(archive_name, 'data.pkl'))
 
-            out = StringIO()
+            out = io.StringIO()
             pickletools.dis(pickled_data, out=out)
             disassembled = out.getvalue()
 

--- a/test/test_jit_profiling.py
+++ b/test/test_jit_profiling.py
@@ -4,7 +4,6 @@ from test_jit import *
 
 if __name__ == '__main__':
     run_tests()
-    if not PY2:
-        import test_jit_py3
-        suite = unittest.findTestCases(test_jit_py3)
-        unittest.TextTestRunner().run(suite)
+    import test_jit_py3
+    suite = unittest.findTestCases(test_jit_py3)
+    unittest.TextTestRunner().run(suite)

--- a/test/test_jit_simple.py
+++ b/test/test_jit_simple.py
@@ -4,7 +4,6 @@ from test_jit import *
 
 if __name__ == '__main__':
     run_tests()
-    if not PY2:
-        import test_jit_py3
-        suite = unittest.findTestCases(test_jit_py3)
-        unittest.TextTestRunner().run(suite)
+    import test_jit_py3
+    suite = unittest.findTestCases(test_jit_py3)
+    unittest.TextTestRunner().run(suite)

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -33,8 +33,6 @@ int_classes = int
 FileNotFoundError = builtins.FileNotFoundError
 StringIO = io.StringIO
 container_abcs = collections.abc
-PY3 = sys.version_info[0] == 3
-PY37 = sys.version_info[0] == 3 and sys.version_info[1] >= 7
 
 def with_metaclass(meta: type, *bases) -> type:
     """Create a base class with a metaclass."""

--- a/torch/futures/__init__.py
+++ b/torch/futures/__init__.py
@@ -1,20 +1,12 @@
 from typing import cast, Callable, Generic, List, Type, TypeVar
 
 import torch
-from torch._six import PY37
 
 T = TypeVar("T")
 S = TypeVar("S")
 
-if not PY37:
-    # Workaround for https://github.com/python/typing/issues/449 in Python 3.6
-    from typing import GenericMeta
-
-    class _PyFutureMeta(type(torch._C.Future), GenericMeta):   # type: ignore[misc]
-        pass
-else:
-    class _PyFutureMeta(type(torch._C.Future), type(Generic)):  # type: ignore[misc, no-redef]
-        pass
+class _PyFutureMeta(type(torch._C.Future), type(Generic)):  # type: ignore[misc, no-redef]
+    pass
 
 class Future(torch._C.Future, Generic[T], metaclass=_PyFutureMeta):
     r"""

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -4,7 +4,6 @@ import warnings
 import torch
 import torch.backends.cudnn as cudnn
 
-from torch._six import PY37
 from ..nn.modules.utils import _single, _pair, _triple, _quadruple, _list_with_default
 
 from collections import OrderedDict
@@ -122,8 +121,7 @@ def _get_builtin_table():
 
     _builtin_ops.append((math.gcd, "aten::gcd"))
     _builtin_ops.append((math.isfinite, "aten::isfinite"))
-    if PY37:
-        _builtin_ops.append((math.remainder, "aten::mathremainder"))  # type: ignore
+    _builtin_ops.append((math.remainder, "aten::mathremainder"))  # type: ignore
 
     import torch.distributed.autograd as dist_autograd
     if dist_autograd.is_available():

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -23,8 +23,6 @@ from torch.testing._internal.common_utils import enable_profiling_mode  # noqa: 
 from contextlib import contextmanager
 from functools import reduce
 from itertools import chain
-from torch._six import StringIO
-from typing import Any, Dict
 
 import inspect
 import io
@@ -100,7 +98,7 @@ class JitTestCase(TestCase):
         """
         def __enter__(self):
             self.sys_stdout = sys.stdout
-            self.stringio = StringIO()
+            self.stringio = io.StringIO()
             sys.stdout = self.stringio
             return self
 

--- a/torch/utils/tensorboard/_caffe2_graph.py
+++ b/torch/utils/tensorboard/_caffe2_graph.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import os
 import re
-import six
 
 from tensorboard.compat.proto.graph_pb2 import GraphDef
 from tensorboard.compat.proto.node_def_pb2 import NodeDef
@@ -160,7 +159,7 @@ def _remap_keys(old_dict, rename_fn):
         None. Modifies old_dict in-place.
     '''
     new_dict = {rename_fn(key): value for key,
-                value in six.iteritems(old_dict)}
+                value in old_dict.items()}
     old_dict.clear()
     old_dict.update(new_dict)
 

--- a/torch/utils/tensorboard/_convert_np.py
+++ b/torch/utils/tensorboard/_convert_np.py
@@ -3,7 +3,6 @@ This module converts objects into numpy array.
 """
 import numpy as np
 import torch
-import six
 
 
 def make_np(x):
@@ -16,7 +15,7 @@ def make_np(x):
     """
     if isinstance(x, np.ndarray):
         return x
-    if isinstance(x, six.string_types):  # Caffe2 will pass name of blob(s) to fetch
+    if isinstance(x, str):  # Caffe2 will pass name of blob(s) to fetch
         return _prepare_caffe2(x)
     if np.isscalar(x):
         return np.array([x])

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -2,7 +2,6 @@
 consumed by TensorBoard for visualization."""
 
 import os
-import six
 import time
 import torch
 
@@ -243,7 +242,7 @@ class SummaryWriter(object):
         workspace.FetchBlob(blob_name)
         workspace.FetchBlobs([blob_name1, blob_name2, ...])
         """
-        return isinstance(item, six.string_types)
+        return isinstance(item, str)
 
     def _get_file_writer(self):
         """Returns the default FileWriter instance. Recreates it if closed."""
@@ -424,7 +423,7 @@ class SummaryWriter(object):
         if self._check_caffe2_blob(values):
             from caffe2.python import workspace
             values = workspace.FetchBlob(values)
-        if isinstance(bins, six.string_types) and bins == 'tensorflow':
+        if isinstance(bins, str) and bins == 'tensorflow':
             bins = self.default_bins
         self._get_file_writer().add_summary(
             histogram(tag, values, bins, max_bins=max_bins), global_step, walltime)


### PR DESCRIPTION
Partially Fixes #42919. 

We are using `six` for mainly Python2/Python3 compatibility. This is no longer needed. We also have if PY3 checks which is also no longer needed. This PR also addresses metaclass, functools and other type of refactoring.