### PR TITLE
ONNX export: propagate node metadata across passes

### DIFF
--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -355,7 +355,7 @@ class TestONNXExport(JitTestCase):
             torch.onnx.export_to_pretty_string(
                 torch.jit.script(mod), (x_in,), f)
 
-    def test_sourcerange_propagation(self):
+    def test_source_range_propagation(self):
         class ExpandingModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -11,7 +11,7 @@ pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 from torch.testing._internal.common_utils import suppress_warnings
 from torch.testing._internal.jit_utils import JitTestCase
-from torch.onnx import OperatorExportTypes
+from torch.onnx import OperatorExportTypes, utils
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -354,3 +354,24 @@ class TestONNXExport(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, r"DictConstruct.+is not supported."):
             torch.onnx.export_to_pretty_string(
                 torch.jit.script(mod), (x_in,), f)
+
+    def test_sourcerange_propagation(self):
+        class ExpandingModule(torch.nn.Module):
+            def __init__(self):
+                super(ExpandingModule, self).__init__()
+                # Will be expanded during ONNX export
+                self.ln = torch.nn.LayerNorm([1])
+
+            def forward(self, input):
+                return self.ln(input)
+
+        mod = ExpandingModule()
+
+        graph, _, _ = utils._model_to_graph(
+            mod, (torch.zeros(1),),
+            operator_export_type=OperatorExportTypes.ONNX)
+
+        # Ensure that every node in the graph has a valid source range
+        for node in graph.nodes():
+            srng = node.sourceRange()
+            assert srng is not None and len(srng) > 0

--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -358,7 +358,7 @@ class TestONNXExport(JitTestCase):
     def test_sourcerange_propagation(self):
         class ExpandingModule(torch.nn.Module):
             def __init__(self):
-                super(ExpandingModule, self).__init__()
+                super().__init__()
                 # Will be expanded during ONNX export
                 self.ln = torch.nn.LayerNorm([1])
 
@@ -373,5 +373,4 @@ class TestONNXExport(JitTestCase):
 
         # Ensure that every node in the graph has a valid source range
         for node in graph.nodes():
-            srng = node.sourceRange()
-            assert srng is not None and len(srng) > 0
+            self.assertTrue(node.sourceRange())

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -368,20 +368,34 @@ void NodeToONNX(
       py_inputs[input_nr++] = py::cast(envFn(input));
     }
 
+    Graph* g = new_block->owningGraph();
+    std::unordered_set<Node*> nodes_before;
+    for (auto node : g->nodes()) {
+      nodes_before.emplace(node);
+    }
+
     WithInsertPoint insert_point_guard(new_block);
-    WithCurrentScope scope_guard(*new_block->owningGraph(), n->scope());
+    WithCurrentScope scope_guard(*g, n->scope());
     py::object raw_output = onnx.attr("_run_symbolic_function")(
-        new_block->owningGraph(),
+        g,
         new_block,
         n,
         py_inputs,
         env,
         operator_export_type);
 
+    // Find new nodes that have been created by _run_symbolic_function and
+    // propagate metadata
+    for (auto node : g->nodes()) {
+      if (nodes_before.find(node) == nodes_before.end()) {
+        node->copyMetadata(n);
+      }
+    }
+
     // TODO: Assert it's an ATen identifier???
     // (Sometimes it's not...)
     processSymbolicOutput(n->kind().toUnqualString(), n, raw_output);
-    GRAPH_DUMP("after processSymbolicOutput: ", new_block->owningGraph());
+    GRAPH_DUMP("after processSymbolicOutput: ", g);
   };
 
   auto callPySymbolicMethod = [&](ConcretePythonOp* op) {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -377,12 +377,7 @@ void NodeToONNX(
     WithInsertPoint insert_point_guard(new_block);
     WithCurrentScope scope_guard(*g, n->scope());
     py::object raw_output = onnx.attr("_run_symbolic_function")(
-        g,
-        new_block,
-        n,
-        py_inputs,
-        env,
-        operator_export_type);
+        g, new_block, n, py_inputs, env, operator_export_type);
 
     // Find new nodes that have been created by _run_symbolic_function and
     // propagate metadata

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -266,6 +266,7 @@ static void UpdateScalarTypeForInputs(
         at::Tensor val = input->node()->t(attr::value);
         at::Tensor new_val = val.to(scalar_type);
         Node* const_node = n->owningGraph()->create(onnx::Constant);
+        const_node->copyMetadata(n);
         const_node->t_(attr::value, new_val);
         const_node->insertBefore(n);
         const_node->output()->setType(TensorType::create(new_val));
@@ -273,6 +274,7 @@ static void UpdateScalarTypeForInputs(
       } else {
         Node* cast_node = n->owningGraph()->create(onnx::Cast);
         cast_node->addInput(input);
+        cast_node->copyMetadata(n);
         cast_node->i_(attr::to, onnx_type);
         cast_node->insertBefore(n);
         cast_node->output()->setType(CreateProfiledTensorTypeWithScalarType(

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -47,7 +47,7 @@ void RemoveInplaceOps(Block* block) {
       // create a replacement out of place op
       auto newNode = graph->create(inPlaceToOutOfPlace.at(node->kind()));
       newNode->insertBefore(node);
-      newNode->setScope(node->scope());
+      newNode->copyMetadata(node);
       // copy inputs
       for (auto input : node->inputs()) {
         newNode->addInput(input);


### PR DESCRIPTION
Fixes #45255 

Mostly straightforward. Only downside in this PR is the lack of more scalable way to check for all newly-created nodes in `callPySymbolicFunction`. The other options were:
* Create a scope within the node's scope and loop through all nodes that correspond to the scope. The code would still need to loop through all nodes.
* Add extra state to the graph (no good reason to do so).
* Add extra state to the ONNX exporter, since python calls go back to `g.op(...)` (no good reason to do so, also not very pythonic).


cc @BowenBao @neginraoof