### PR TITLE
[TESTING] Does only CTCLoss need convert_target?

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5063,7 +5063,7 @@ class CriterionTest(InputVariableMixin, TestBase):
 
         # Convert input, target and module parameters to dtype
         if dtype is not None:
-            if not isinstance(cpu_target, torch.LongTensor) and "CTCLoss" not in str(test_case):
+            if not isinstance(cpu_target, torch.LongTensor) and not cpu_target.is_floating_point and "CTCLoss" not in str(test_case):
                 raise RuntimeError("not CTCLoss")
             cpu_input = convert_dtype(cpu_input, dtype, True)
             # NLLLoss requires target to be LongTensor

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5063,6 +5063,8 @@ class CriterionTest(InputVariableMixin, TestBase):
 
         # Convert input, target and module parameters to dtype
         if dtype is not None:
+            if not isinstance(cpu_target, torch.LongTensor) and "CTCLoss" not in str(test_case):
+                raise RuntimeError("not CTCLoss")
             cpu_input = convert_dtype(cpu_input, dtype, True)
             # NLLLoss requires target to be LongTensor
             if not isinstance(cpu_target, torch.LongTensor) and self.convert_target:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45289 [TESTING] Does only CTCLoss need convert_target?**

Differential Revision: [D23914414](https://our.internmc.facebook.com/intern/diff/D23914414)