### PR TITLE
Remove convert_target from NN tests.

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4433,7 +4433,6 @@ criterion_tests = [
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,
-        convert_target=False,
         # `CTCLoss` in C++ frontend doesn't accept integer list for `input_lengths` or `target_lengths`
         test_cpp_api_parity=False,
         check_jit=False,
@@ -4452,7 +4451,6 @@ criterion_tests = [
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,
-        convert_target=False,
     ),
     dict(
         module_name='CTCLoss',
@@ -4468,7 +4466,6 @@ criterion_tests = [
         check_sum_reduction=True,
         check_gradgrad=False,
         check_half=False,
-        convert_target=False,
     ),
 ]
 
@@ -5003,7 +5000,6 @@ class CriterionTest(InputVariableMixin, TestBase):
         self.check_gradgrad = kwargs.get('check_gradgrad', True)
         self.check_half = kwargs.get('check_half', True)
         self.check_bfloat16 = kwargs.get('check_bfloat16', False)
-        self.convert_target = kwargs.get('convert_target', True)
         self.test_cpu = kwargs.get('test_cpu', True)
 
     def __call__(self, test_case):
@@ -5064,8 +5060,7 @@ class CriterionTest(InputVariableMixin, TestBase):
         # Convert input, target and module parameters to dtype
         if dtype is not None:
             cpu_input = convert_dtype(cpu_input, dtype, True)
-            # NLLLoss requires target to be LongTensor
-            if not isinstance(cpu_target, torch.LongTensor) and self.convert_target:
+            if cpu_target.is_floating_point or cpu_target.is_complex:
                 cpu_target = convert_dtype(cpu_target, dtype)
             cpu_module.type(dtype)
             gpu_module.type(dtype)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5042,8 +5042,6 @@ class CriterionTest(InputVariableMixin, TestBase):
         def convert_dtype(obj, dtype, requires_grad=False):
             if isinstance(obj, torch.Tensor):
                 return obj.detach().to(dtype=dtype).requires_grad_(requires_grad)
-            elif isinstance(obj, torch.Tensor):
-                return obj.to(dtype)
             elif isinstance(obj, tuple):
                 return tuple(convert_dtype(o, dtype, requires_grad) for o in obj)
             else:
@@ -5060,7 +5058,7 @@ class CriterionTest(InputVariableMixin, TestBase):
         # Convert input, target and module parameters to dtype
         if dtype is not None:
             cpu_input = convert_dtype(cpu_input, dtype, True)
-            if cpu_target.is_floating_point or cpu_target.is_complex:
+            if cpu_target.is_floating_point() or cpu_target.is_complex():
                 cpu_target = convert_dtype(cpu_target, dtype)
             cpu_module.type(dtype)
             gpu_module.type(dtype)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45316 Remove CriterionTest.test_cuda code for dtype None.
* **#45291 Remove convert_target from NN tests.**

It's not necessary, you can just check if the dtype is integral.

Differential Revision: [D23911963](https://our.internmc.facebook.com/intern/diff/D23911963)