### PR TITLE
[TESTING] Check that dtype is always set.

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5062,6 +5062,8 @@ class CriterionTest(InputVariableMixin, TestBase):
                 cpu_target = convert_dtype(cpu_target, dtype)
             cpu_module.type(dtype)
             gpu_module.type(dtype)
+        else:
+            raise RuntimeError("dtype must be set")
 
         # GPU setup
         gpu_input = to_gpu(cpu_input)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45296 [TESTING] Check that dtype is always set.**
* #45291 Remove convert_target from NN tests.

Differential Revision: [D23914318](https://our.internmc.facebook.com/intern/diff/D23914318)