### PR TITLE
caffe2/plan_executor: wait for 1 minute after exception and then abort

### DIFF
--- a/caffe2/core/plan_executor.cc
+++ b/caffe2/core/plan_executor.cc
@@ -17,10 +17,18 @@ C10_DEFINE_bool(
     "If used we will handle exceptions in executor threads. "
     "This avoids SIGABRT but may cause process to deadlock");
 
+C10_DEFINE_int(
+    caffe2_plan_executor_exception_timeout,
+    60,
+    "Number of seconds to wait for concurrent threads to stop on exception"
+    "before terminating.");
+
 namespace caffe2 {
 
 namespace {
 
+// ExceptionWrapper holds an exception. If exception pointers are being used,
+// it'll hold the original exception pointer otherwise just the message.
 class ExceptionWrapper {
  public:
   ExceptionWrapper() : hasException_(false) {}
@@ -39,6 +47,10 @@ class ExceptionWrapper {
 #endif
   }
 
+  const std::string& what() const {
+    return exceptionMsg_;
+  }
+
   operator bool() {
     return hasException_;
   }
@@ -49,6 +61,33 @@ class ExceptionWrapper {
   std::exception_ptr exception_;
 #endif
   std::string exceptionMsg_;
+};
+
+// ExceptionWrapperTerminate terminates the program with the specified
+// exception. This preserves the exception ptr and ExceptionTracer will
+// correctly grab it on exit.
+class ExceptionWrapperTerminate {
+ public:
+  explicit ExceptionWrapperTerminate(ExceptionWrapper&& ew) : ew_(std::move(ew)) {}
+
+  ~ExceptionWrapperTerminate() {
+    ew_.rethrowException();
+  }
+
+ private:
+  ExceptionWrapper ew_;
+};
+
+// ScopeExitGuard runs the provided function when it's destructed.
+class ScopeExitGuard {
+ public:
+  explicit ScopeExitGuard(std::function<void()>&& f) : f_(std::move(f)) {}
+  ~ScopeExitGuard() {
+    f_();
+  }
+
+ private:
+  std::function<void()> f_;
 };
 
 struct NetDefInfo {
@@ -460,9 +499,16 @@ bool ExecuteStepRecursive(ExecutionStepWrapper& stepWrapper) {
                 << " with " << step.substep().size() << " concurrent substeps";
 
         std::atomic<int> next_substep{0};
+        std::condition_variable cv;
+        std::atomic<int> done{0};
         std::mutex exception_mutex;
         ExceptionWrapper first_exception;
         auto worker = [&]() {
+          ScopeExitGuard on_exit([&] {
+            done += 1;
+            cv.notify_all();
+          });
+
           auto num_substeps = compiledStep->recurringSubsteps.size();
           int substep_id = next_substep++ % num_substeps;
           if (compiledStep->gotFailure) {
@@ -500,6 +546,23 @@ bool ExecuteStepRecursive(ExecutionStepWrapper& stepWrapper) {
         for (size_t i = 0; i < numThreads; ++i) {
           threads.emplace_back(worker);
         }
+
+        auto workersDone = [&] { return done == numThreads; };
+
+        // If we get an exception, try to wait for all threads to stop
+        // gracefully.
+        std::unique_lock<std::mutex> guard(exception_mutex);
+        cv.wait(guard, [&] { return workersDone() || first_exception; });
+        cv.wait_for(
+            guard,
+            std::chrono::seconds(FLAGS_caffe2_plan_executor_exception_timeout),
+            [&] { return workersDone(); });
+        if (!workersDone() && first_exception) {
+          LOG(ERROR) << "failed to stop concurrent workers after exception: "
+                     << first_exception.what();
+          ExceptionWrapperTerminate(std::move(first_exception));
+        }
+
         for (auto& thread : threads) {
           thread.join();
         }

--- a/caffe2/core/plan_executor_test.cc
+++ b/caffe2/core/plan_executor_test.cc
@@ -67,6 +67,29 @@ class ErrorOp final : public Operator<CPUContext> {
 REGISTER_CPU_OPERATOR(Error, ErrorOp);
 OPERATOR_SCHEMA(Error).NumInputs(0).NumOutputs(0);
 
+static std::atomic<int> blockingErrorRuns{0};
+class BlockingErrorOp final : public Operator<CPUContext> {
+ public:
+  BlockingErrorOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    // First n op executions should block and then start throwing errors.
+    if (blockingErrorRuns.fetch_sub(1) >= 1) {
+      LOG(INFO) << "blocking";
+      while (true) {
+        std::this_thread::sleep_for(std::chrono::hours(10));
+      }
+    } else {
+      LOG(INFO) << "throwing";
+      throw TestError();
+    }
+  }
+};
+
+REGISTER_CPU_OPERATOR(BlockingError, BlockingErrorOp);
+OPERATOR_SCHEMA(BlockingError).NumInputs(0).NumOutputs(0);
+
 PlanDef parallelErrorPlan() {
   PlanDef plan_def;
 
@@ -101,10 +124,12 @@ PlanDef parallelErrorPlan() {
 }
 
 struct HandleExecutorThreadExceptionsGuard {
-  HandleExecutorThreadExceptionsGuard() {
+  HandleExecutorThreadExceptionsGuard(int timeout = 60) {
     globalInit({
         "caffe2",
         "--caffe2_handle_executor_threads_exceptions=1",
+        "--caffe2_plan_executor_exception_timeout=" +
+            caffe2::to_string(timeout),
     });
   }
 
@@ -137,6 +162,38 @@ TEST(PlanExecutorTest, ErrorAsyncPlan) {
   Workspace ws;
   ASSERT_THROW(ws.RunPlan(plan_def), TestError);
   ASSERT_EQ(cancelCount, 1);
+}
+
+TEST(PlanExecutorTest, BlockingErrorPlan) {
+  ASSERT_DEATH(
+      [] {
+        HandleExecutorThreadExceptionsGuard guard(/*timeout=*/1);
+
+        PlanDef plan_def;
+
+        std::string plan_def_template = R"DOC(
+          network {
+            name: "net"
+            op {
+              type: "BlockingError"
+            }
+          }
+          execution_step {
+            num_concurrent_instances: 2
+            substep {
+              network: "net"
+            }
+          }
+        )DOC";
+
+        CAFFE_ENFORCE(
+            TextFormat::ParseFromString(plan_def_template, &plan_def));
+        Workspace ws;
+        blockingErrorRuns = 1;
+        ws.RunPlan(plan_def);
+        FAIL() << "shouldn't have reached this point";
+      }(),
+      "failed to stop concurrent workers after exception: test error");
 }
 
 } // namespace caffe2


### PR DESCRIPTION
Summary: If we have two concurrent substeps and one of them throws an exception and the other is blocking, we'll currently hang. This waits up to 1 minute for it to complete before terminating the process.

Test Plan: buck test caffe2/caffe2:caffe2_test_cpu -- PlanExecutorTest --stress-runs 100

Differential Revision: D20850851

