### PR TITLE
quant docs: document how to customize qconfigs in eager mode

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -402,9 +402,15 @@ prior to quantization. This is because currently quantization works on a module
 by module basis. Specifically, for all quantization techniques, the user needs to:
 
 1. Convert any operations that require output requantization (and thus have
-   additional parameters) from functionals to module form.
+   additional parameters) from functionals to module form (for example,
+   using ``torch.nn.ReLU`` instead of ``torch.nn.functional.relu``).
 2. Specify which parts of the model need to be quantized either by assigning
-   ``.qconfig`` attributes on submodules or by specifying ``qconfig_dict``
+   ``.qconfig`` attributes on submodules or by specifying ``qconfig_dict``.
+   For example, setting ``model.conv1.qconfig = None`` means that the
+   ``model.conv`` layer will not be quantized, and setting
+   ``model.linear1.qconfig = custom_qconfig`` means that the quantization
+   settings for ``model.linear1`` will be using ``custom_qconfig`` instead
+   of the global qconfig.
 
 For static quantization techniques which quantize activations, the user needs
 to do the following in addition:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45306 quant docs: document how to customize qconfigs in eager mode**
* #45305 quant docs: add reduce_range explanatation to top level doc
* #45135 Quantization: combine previous summary with new summary
* #45093 Quantization: add API summary section

Adds details to the main quantization doc on how specifically
users can skip or customize quantization of layers.

Differential Revision: [D23917034](https://our.internmc.facebook.com/intern/diff/D23917034)