### PR TITLE
quant bn/gn/in: move scale and zp to buffers

### DIFF
--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -7,14 +7,15 @@ class BatchNorm2d(torch.nn.BatchNorm2d):
     """
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1):
-        super(BatchNorm2d, self).__init__(num_features)
-        self.eps = eps
-        self.scale = 1.0
-        self.zero_point = 0
+        super(BatchNorm2d, self).__init__(num_features, eps)
+        self.register_buffer('scale', torch.Tensor([1.0]))
+        self.register_buffer('zero_point', torch.Tensor([0]).int())
 
     def forward(self, input):
-        return torch.ops.quantized.batch_norm2d(input, self.weight, self.bias, self.running_mean,
-                                                self.running_var, self.eps, self.scale, self.zero_point)
+        return torch.ops.quantized.batch_norm2d(
+            input, self.weight, self.bias, self.running_mean,
+            self.running_var, self.eps, self.scale.item(),
+            self.zero_point.item())
 
     def _get_name(self):
         return 'QuantizedBatchNorm2d'
@@ -32,8 +33,8 @@ class BatchNorm2d(torch.nn.BatchNorm2d):
         new_mod.bias = mod.bias
         new_mod.running_mean = mod.running_mean
         new_mod.running_var = mod.running_var
-        new_mod.scale = float(scale)
-        new_mod.zero_point = int(zero_point)
+        new_mod.scale.copy_(torch.Tensor([float(scale)]))
+        new_mod.zero_point.copy_(torch.Tensor([int(zero_point)]).int())
         return new_mod
 
 class BatchNorm3d(torch.nn.BatchNorm3d):
@@ -43,12 +44,13 @@ class BatchNorm3d(torch.nn.BatchNorm3d):
     def __init__(self, num_features, eps=1e-5, momentum=0.1):
         super(BatchNorm3d, self).__init__(num_features)
         self.eps = eps
-        self.scale = 1.0
-        self.zero_point = 0
+        self.register_buffer('scale', torch.Tensor([1.0]))
+        self.register_buffer('zero_point', torch.Tensor([0]).int())
 
     def forward(self, input):
-        return torch.ops.quantized.batch_norm3d(input, self.weight, self.bias, self.running_mean,
-                                                self.running_var, self.eps, self.scale, self.zero_point)
+        return torch.ops.quantized.batch_norm3d(
+            input, self.weight, self.bias, self.running_mean,
+            self.running_var, self.eps, self.scale.item(), self.zero_point.item())
 
     def _get_name(self):
         return 'QuantizedBatchNorm3d'
@@ -67,6 +69,6 @@ class BatchNorm3d(torch.nn.BatchNorm3d):
         new_mod.bias = mod.bias
         new_mod.running_mean = mod.running_mean
         new_mod.running_var = mod.running_var
-        new_mod.scale = float(scale)
-        new_mod.zero_point = int(zero_point)
+        new_mod.scale.copy_(torch.Tensor([float(scale)]))
+        new_mod.zero_point.copy_(torch.Tensor([int(zero_point)]).int())
         return new_mod

--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -8,7 +8,7 @@ class BatchNorm2d(torch.nn.BatchNorm2d):
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1):
         super(BatchNorm2d, self).__init__(num_features, eps)
-        self.register_buffer('scale', torch.Tensor([1.0]))
+        self.register_buffer('scale', torch.Tensor([1.0]).float())
         self.register_buffer('zero_point', torch.Tensor([0]).int())
 
     def forward(self, input):
@@ -33,7 +33,7 @@ class BatchNorm2d(torch.nn.BatchNorm2d):
         new_mod.bias = mod.bias
         new_mod.running_mean = mod.running_mean
         new_mod.running_var = mod.running_var
-        new_mod.scale.copy_(torch.Tensor([float(scale)]))
+        new_mod.scale.copy_(torch.Tensor([float(scale)]).float())
         new_mod.zero_point.copy_(torch.Tensor([int(zero_point)]).int())
         return new_mod
 
@@ -44,7 +44,7 @@ class BatchNorm3d(torch.nn.BatchNorm3d):
     def __init__(self, num_features, eps=1e-5, momentum=0.1):
         super(BatchNorm3d, self).__init__(num_features)
         self.eps = eps
-        self.register_buffer('scale', torch.Tensor([1.0]))
+        self.register_buffer('scale', torch.Tensor([1.0]).float())
         self.register_buffer('zero_point', torch.Tensor([0]).int())
 
     def forward(self, input):
@@ -69,6 +69,6 @@ class BatchNorm3d(torch.nn.BatchNorm3d):
         new_mod.bias = mod.bias
         new_mod.running_mean = mod.running_mean
         new_mod.running_var = mod.running_var
-        new_mod.scale.copy_(torch.Tensor([float(scale)]))
+        new_mod.scale.copy_(torch.Tensor([float(scale)]).float())
         new_mod.zero_point.copy_(torch.Tensor([int(zero_point)]).int())
         return new_mod

--- a/torch/nn/quantized/modules/normalization.py
+++ b/torch/nn/quantized/modules/normalization.py
@@ -16,7 +16,7 @@ class LayerNorm(torch.nn.LayerNorm):
             normalized_shape, eps=eps, elementwise_affine=elementwise_affine)
         self.weight = weight
         self.bias = bias
-        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('scale', torch.Tensor([scale]).float())
         self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
@@ -51,7 +51,7 @@ class GroupNorm(torch.nn.GroupNorm):
         super(GroupNorm, self).__init__(num_groups, num_channels, eps, affine)
         self.weight = weight
         self.bias = bias
-        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('scale', torch.Tensor([scale]).float())
         self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
@@ -86,7 +86,7 @@ class InstanceNorm1d(torch.nn.InstanceNorm1d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('scale', torch.Tensor([scale]).float())
         self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
@@ -121,7 +121,7 @@ class InstanceNorm2d(torch.nn.InstanceNorm2d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('scale', torch.Tensor([scale]).float())
         self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
@@ -156,7 +156,7 @@ class InstanceNorm3d(torch.nn.InstanceNorm3d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('scale', torch.Tensor([scale]).float())
         self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):

--- a/torch/nn/quantized/modules/normalization.py
+++ b/torch/nn/quantized/modules/normalization.py
@@ -16,13 +16,14 @@ class LayerNorm(torch.nn.LayerNorm):
             normalized_shape, eps=eps, elementwise_affine=elementwise_affine)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
         return torch.ops.quantized.layer_norm(
             input, self.normalized_shape, weight=self.weight, bias=self.bias,
-            eps=self.eps, output_scale=self.scale, output_zero_point=self.zero_point)
+            eps=self.eps, output_scale=self.scale.item(),
+            output_zero_point=self.zero_point.item())
 
     def _get_name(self):
         return 'QuantizedLayerNorm'
@@ -50,13 +51,13 @@ class GroupNorm(torch.nn.GroupNorm):
         super(GroupNorm, self).__init__(num_groups, num_channels, eps, affine)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
         return torch.ops.quantized.group_norm(
-            input, self.num_groups, self.weight, self.bias, self.eps, self.scale,
-            self.zero_point)
+            input, self.num_groups, self.weight, self.bias, self.eps,
+            self.scale.item(), self.zero_point.item())
 
     def _get_name(self):
         return 'QuantizedGroupNorm'
@@ -85,13 +86,13 @@ class InstanceNorm1d(torch.nn.InstanceNorm1d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
         return torch.ops.quantized.instance_norm(
-            input, self.weight, self.bias, self.eps, self.scale,
-            self.zero_point)
+            input, self.weight, self.bias, self.eps, self.scale.item(),
+            self.zero_point.item())
 
     def _get_name(self):
         return 'QuantizedInstanceNorm1d'
@@ -120,13 +121,13 @@ class InstanceNorm2d(torch.nn.InstanceNorm2d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
         return torch.ops.quantized.instance_norm(
-            input, self.weight, self.bias, self.eps, self.scale,
-            self.zero_point)
+            input, self.weight, self.bias, self.eps, self.scale.item(),
+            self.zero_point.item())
 
     def _get_name(self):
         return 'QuantizedInstanceNorm2d'
@@ -155,13 +156,13 @@ class InstanceNorm3d(torch.nn.InstanceNorm3d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.Tensor(scale))
+        self.register_buffer('zero_point', torch.Tensor([zero_point]).int())
 
     def forward(self, input):
         return torch.ops.quantized.instance_norm(
-            input, self.weight, self.bias, self.eps, self.scale,
-            self.zero_point)
+            input, self.weight, self.bias, self.eps, self.scale.item(),
+            self.zero_point.item())
 
     def _get_name(self):
         return 'QuantizedInstanceNorm3d'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45313 quant bn/gn/in: move scale and zp to buffers**

Summary:

Fixes https://github.com/pytorch/pytorch/issues/43774

Currently the scale and zero_point in these modules is not
saved in the state_dict, so saving them and loading them
back does not work.  Fixing by making them buffers.

Note: not handling loading old state_dicts on purpose as unfortunately
there isn't a way to recover correct scales and zero_points as we did
not save them.

The # of people affected by this should be small,
as most people fuse BNs into preceding layers during quantization, and quantized
BN/IN support is very new.

Test Plan:

```
python test/test_quantization.py TestStaticQuantizedModule
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D23919143](https://our.internmc.facebook.com/intern/diff/D23919143)