### PR TITLE
[caffe2] plan executor error propagation test with blocking cancellable op

### DIFF
--- a/caffe2/core/plan_executor_test.cc
+++ b/caffe2/core/plan_executor_test.cc
@@ -18,6 +18,35 @@ static std::atomic<int> cancelCount{0};
 static std::atomic<bool> stuckRun{false};
 } // namespace
 
+class StuckBlockingOp final : public Operator<CPUContext> {
+ public:
+  StuckBlockingOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    // StuckBlockingOp runs and notifies ErrorOp.
+    stuckRun = true;
+
+    while (!cancelled_) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    return true;
+  }
+
+  void Cancel() override {
+    LOG(INFO) << "cancelled StuckBlockingOp.";
+    cancelCount += 1;
+    cancelled_ = true;
+  }
+
+ private:
+  std::atomic<bool> cancelled_{false};
+};
+
+REGISTER_CPU_OPERATOR(StuckBlocking, StuckBlockingOp);
+OPERATOR_SCHEMA(StuckBlocking).NumInputs(0).NumOutputs(0);
+
 class StuckAsyncOp final : public Operator<CPUContext> {
  public:
   StuckAsyncOp(const OperatorDef& operator_def, Workspace* ws)
@@ -55,7 +84,7 @@ class ErrorOp final : public Operator<CPUContext> {
       : Operator<CPUContext>(operator_def, ws) {}
 
   bool RunOnDevice() override {
-    // Wait for StuckAsyncOp to run first.
+    // Wait for StuckAsyncOp or StuckBlockingOp to run first.
     while (!stuckRun) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
@@ -114,6 +143,39 @@ PlanDef parallelErrorPlan() {
   {
     auto* substep = execution_step->add_substep();
     substep->add_network(stuck_net->name());
+  }
+  {
+    auto* substep = execution_step->add_substep();
+    substep->add_network(error_net->name());
+  }
+
+  return plan_def;
+}
+
+PlanDef parallelErrorPlanWithCancellableStuckNet() {
+  // Set a plan with two nets: one stuck net with blocking operator that never
+  // returns; one error net with error op that throws.
+  PlanDef plan_def;
+
+  auto* stuck_blocking_net = plan_def.add_network();
+  stuck_blocking_net->set_name("stuck_blocking_net");
+  {
+    auto* op = stuck_blocking_net->add_op();
+    op->set_type("StuckBlocking");
+  }
+
+  auto* error_net = plan_def.add_network();
+  error_net->set_name("error_net");
+  {
+    auto* op = error_net->add_op();
+    op->set_type("Error");
+  }
+
+  auto* execution_step = plan_def.add_execution_step();
+  execution_step->set_concurrent_substeps(true);
+  {
+    auto* substep = execution_step->add_substep();
+    substep->add_network(stuck_blocking_net->name());
   }
   {
     auto* substep = execution_step->add_substep();
@@ -206,6 +268,16 @@ TEST(PlanExecutorTest, BlockingErrorPlan) {
       "failed to stop concurrent workers after exception: test error");
 }
 #endif
+
+TEST(PlanExecutorTest, ErrorPlanWithCancellableStuckNet) {
+  HandleExecutorThreadExceptionsGuard guard;
+
+  PlanDef plan_def = parallelErrorPlanWithCancellableStuckNet();
+  Workspace ws;
+
+  ASSERT_THROW(ws.RunPlan(plan_def), TestError);
+  ASSERT_EQ(cancelCount, 1);
+}
 
 } // namespace caffe2
 


### PR DESCRIPTION
Summary:
## Motivation
* `Cancel` is now added to `OperatorBase` and `NetBase` (https://github.com/pytorch/pytorch/pull/44145)
* We need a test to cover and exhibit that we can cancel stuck net and propagate error with plan executor.

## Summary
* Added `ErrorPlanWithCancellableStuckNet` for plan executor.
* We set a plan with two nets: one stuck net with blocking operator that never returns, and one with error
  net with error op that throws, and tested it throw and cancel.

Test Plan:
## Unit Test added
```
buck test caffe2/caffe2:caffe2_test_cpu -- PlanExecutorTest
buck test caffe2/caffe2:caffe2_test_cpu -- PlanExecutorTest --stress-runs 100
```
```
Summary
  Pass: 400
  ListingSuccess: 2
```

Reviewed By: d4l3k

Differential Revision: D23920548

