### PR TITLE
[FX] autodiff pass proof-of-concept

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,72 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from fx_grad import grad
+
+class SimpleConvNet(nn.Module):
+    def __init__(self):
+        super(SimpleConvNet, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 1, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.fc1 = nn.Linear(57600, 128)
+
+        # TODO: I can't figure out how to create a constant inside
+        # an FX graph so I've hardcoded this here. I need this 1. to seed
+        # gradient computation.
+        self.ones = torch.tensor(1.)
+
+    def forward(self, x, target):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = torch.flatten(x, 1)
+        prediction = self.fc1(x)
+
+        # FIXME: Normally, the loss computation is OUTSIDE the module.
+        # However, with FX, you can only symbolic trace over Modules,
+        # so we've weirdly put the loss computation here.
+        diff = torch.sub(prediction, target)
+        losses = torch.mul(diff, diff)
+        return torch.sum(losses)
+
+x = torch.rand(5, 1, 32, 32)
+targets = torch.ones(5, 128)
+
+# Set up a SimpleConvNet() as the baseline
+torch.manual_seed(0)
+net = SimpleConvNet()
+x.requires_grad_(True)
+net(x, targets).backward()
+
+# Set up grad_loss via fx.
+x.requires_grad_(False)
+torch.manual_seed(0)
+net2 = SimpleConvNet()
+torch.manual_seed(0)
+grad_loss = grad(SimpleConvNet())
+grads = grad_loss(x, targets)
+
+# Check the grads
+def check_grad(param):
+    actual = grads[param]
+    mod, param_ = param.split('.')
+    expected = getattr(getattr(net, mod), param_).grad
+    if torch.allclose(actual, expected, rtol=1e-03, atol=1e-07):
+        return
+    print(f'Mismatch for {param} of {(actual - expected).abs().max()}')
+    assert False
+
+# Prints the graph. Take note of all of the extra ops that compute grad.
+# We probably want to run CSE / DCE on this.
+print(grad_loss.code)
+
+# Run some tests that check parity between the symbolic grad output and
+# regular autograd.
+check_grad('conv2.weight')
+check_grad('conv2.bias')
+check_grad('conv1.weight')
+check_grad('conv1.bias')
+check_grad('fc1.weight')
+check_grad('fc1.bias')
+print("All tests passed!")

--- a/fx_grad.py
+++ b/fx_grad.py
@@ -1,0 +1,172 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.fx import Node, Proxy, symbolic_trace, Graph, GraphModule
+from typing import List, Dict
+
+# Gradient formulas. 
+# FIXME: There are a bunch of interesting problems with defining grad formulas.
+# 1. What do we do with PyTorch ops that are composite w.r.t. autograd?
+#    In FX we may need to write a symbolic gradient for *every* operator,
+#    but that could quickly become intractable.
+# 2. Some ops save intermediate values that are created inside the op for
+#    backwards. How do we do that in FX?
+#    One example is dropout. The dropout mask created inside dropout MUST
+#    be saved for backwards so it can be re-applied.
+# 
+# One potential workaround for both of the above is implement some decomposing
+# logic for the autodiff pass to decompose operations like dropout into
+# something more workable.
+def sum_backward(grad, tensor):
+    return grad.expand_as(tensor)
+
+def mul_backward(grad, tensor, other):
+    return grad * other, grad * tensor
+
+def add_backward(grad, tensor, other):
+    return grad, grad
+
+def sub_backward(grad, tensor, other):
+    return grad, -grad
+
+def relu_backward(grad, tensor):
+    return grad * (tensor >= 0)
+
+# TODO: default arg handling
+def flatten_backward(grad, tensor, start_dim):
+    return grad.unflatten(-1, tensor.shape[start_dim:])
+
+# Register gradient formulas. Feels really hacky to me.
+vjp_map = {
+    torch.sum: sum_backward,
+    torch.mul: mul_backward,
+    torch.sub: sub_backward,
+    torch.add: add_backward,
+    torch.flatten: flatten_backward,
+    F.relu: relu_backward,
+}
+
+# Since modules are first-class citizens, they need their own gradient formulas
+# This is not very ideal because:
+# 1. many of our modules are composite (conv1d, conv2d, conv3d)
+# 2. We may rely on intermediate values (see Dropout) to compute gradients.
+# We can definitely work around (2), but (1) seems important.
+def linear_backward(grad, tensor, weight, bias):
+    # TODO: we're assuming that linear operates on 2D input here.
+    return torch.matmul(grad, weight), torch.matmul(grad.t(), tensor), grad.sum(0)
+
+def linear_backward_no_bias(grad, tensor, weight):
+    return torch.matmul(grad, weight), torch.matmul(grad.t(), tensor)
+
+def conv2d_backward(grad, tensor, weight, bias):
+    # grad_weight computation is tricky.
+    tensor_unfolded = (
+        F.unfold(tensor, weight.shape[2:])
+        .unflatten(1, [tensor.shape[1], weight.shape[2] * weight.shape[3]])
+    )
+    grad_weight = (
+        torch.einsum('nckp,ndp->dck', tensor_unfolded, grad.flatten(-2, -1))
+        .unflatten(-1, weight.shape[2:])
+    )
+
+    return (
+        F.conv_transpose2d(grad, weight),
+        grad_weight,
+        grad.sum([0, 2, 3]),
+    )
+
+# Register gradient formulae for modules here.
+def module_backward_rule(module):
+    if isinstance(module, nn.Linear):
+        if module.bias is not None:
+            return linear_backward
+        return linear_backward_no_bias
+    if isinstance(module, nn.Conv2d):
+        return conv2d_backward
+    assert False
+
+# Gradient transformation logic
+def get_params(module_instance: str, module: nn.Module):
+    return [f'{module_instance}.{name}' for name, _ in module.named_parameters()]
+
+GradDict = Dict[str, Proxy]
+
+def update_grad(grad_dict, key: str, value: Proxy):
+    if key not in grad_dict:
+        grad_dict[key] = value
+    else:
+        grad_dict[key] = torch.add(grad_dict[key], value)
+
+def function_backward(node: Node, grad_dict: GradDict):
+    grad_fn = vjp_map[node.target]
+    args = [Proxy(arg) if isinstance(arg, Node) else arg
+            for arg in node.args]
+
+    # TODO: does fx support nodes with multiple outputs?
+    grad_output = grad_dict[node.name]
+    assert grad_output is not None
+
+    grad_inputs = grad_fn(grad_output, *args)
+    if not isinstance(grad_inputs, tuple):
+        grad_inputs = (grad_inputs,)
+
+    for grad_inp, argname in zip(grad_inputs, map(lambda arg: arg.name, node.args)):
+        update_grad(grad_dict, argname, grad_inp)
+
+def module_backward(
+        owning_module: nn.Module,
+        node: Node,
+        grad_dict: GradDict,
+        leaf_attrs):
+    # For each output, pull the grads. NB: assumes every module has a single output.
+    grad: Proxy = grad_dict[node.name]
+
+    # Pull the module parameters as proxies
+    actual_module = getattr(owning_module, node.target)
+    param_names = get_params(node.target, actual_module)
+    leaf_attrs.update(param_names)
+    params: List[Proxy] = [Proxy(node.graph.get_attr(param_name))
+                           for param_name in param_names]
+
+    # Perform the backward computation
+    module_args = list(map(Proxy, node.args))
+    result = module_backward_rule(actual_module)(grad, *module_args, *params)
+
+    names = [arg.node.name for arg in module_args] + list(param_names)
+    assert len(names) == len(result)
+    for grad, name in zip(result, names):
+        update_grad(grad_dict, name, grad)
+
+def grad(module, only_compute_param_grads=True):
+    gm = symbolic_trace(module)
+    grad_graph = Graph()
+    grad_graph.graph_copy(gm.graph)
+    grad_dict: GradDict = {}
+    leaf_attrs = set({})
+
+    # TODO: Is there a way to create a Tensor in FX?
+    ones = grad_graph.create_node('get_attr', 'ones')
+    grad_dict[gm.graph.result.name] = Proxy(ones)
+
+    # In reverse topological order, update `grad_dict` and `leaf_attrs`.
+    nodes = grad_graph.nodes
+    for node in reversed(nodes):
+        if node.op == 'call_function':
+            function_backward(node, grad_dict)
+        elif node.op == 'call_module':
+            module_backward(module, node, grad_dict, leaf_attrs)
+        elif node.op == 'call_method':
+            raise RuntimeError("NYI")
+        else:
+            continue
+
+    # Set the outputs to be either:
+    # - [all parameters]
+    # - [all inputs] + [all parameters]
+    # TODO: This doesn't actually catch all the parameers.
+    output = {leaf: grad_dict[leaf].node for leaf in leaf_attrs}
+    if not only_compute_param_grads:
+        for inp in [node.name for node in gm.graph.nodes if node.op == 'placeholder']:
+            output[inp] = grad_dict[inp]
+    grad_graph.output(output)
+    return GraphModule(module, grad_graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45340 [FX] autodiff pass proof-of-concept**

*Just a proof of concept, not for review!*

The autodiff pass, at a high level:
- symbolically traces the input module
- for each node in the resulting graph, adds logic to the graph to
compute the backward pass.

This PR shows a proof-of-concept autodiff pass with a example CNN.

Some points of interest:
- It was really easy to write this POC. Being able to manipulate the IR
in Python (as opposed to C++ (TorchScript)) is a big plus.
- FX should really support tracing functions. When computing the grad of
a module, a user generally wants to compute the gradient of some loss
with respect to the parameters. That loss computation generally exists
outside(!!) the module, because the module abstracts the logic for
performing the prediction.
- Composite operations w.r.t. autograd. In eager mode, autograd defines
backward formula for a subset of operators. In FX, there's no way to
really do that, because FX sees operators. It may be intractible to try
to implement backward formulas for *all* operators.
- Some operations must save intermediate values for backwards. It's
difficult to do that with FX right now. Consider F.dropout2d -- we need
to break it into its constituents (i.e., extract the dropout mask from
inside the operator) to actually compute gradients for it.

Future work:
- TBD. I'd like to play around with a toy implementation of vmap in FX
and see how well the vmap + autodiff passes compose.