### PR TITLE
Benchmarks: add 'default' options for fuser and executor.

### DIFF
--- a/benchmarks/fastrnns/fuser.py
+++ b/benchmarks/fastrnns/fuser.py
@@ -1,7 +1,7 @@
 import torch
 
 def set_fuser(fuser_name, executor_name):
-    assert fuser_name in ['te', 'old', 'none']
+    assert fuser_name in ['te', 'old', 'none', 'default']
     if fuser_name == 'te':
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(True)
@@ -21,6 +21,8 @@ def set_fuser(fuser_name, executor_name):
         torch._C._jit_override_can_fuse_on_gpu(False)
         torch._C._jit_override_can_fuse_on_cpu(False)
         torch._C._jit_set_texpr_fuser_enabled(False)
+    elif fuser_name == 'default':
+        pass
 
     # --executor overrides settings of --fuser
     if executor_name == 'profiling':
@@ -34,3 +36,5 @@ def set_fuser(fuser_name, executor_name):
     elif executor_name == 'legacy':
         torch._C._jit_set_profiling_executor(False)
         torch._C._jit_set_profiling_mode(False)
+    elif executor_name == 'default':
+        pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45349 Benchmarks: tweak PE config settings.
* #45348 CI: Add a run of FastRNN benchmarks in default executor/fuser configuration.
* **#45347 Benchmarks: add 'default' options for fuser and executor.**

Differential Revision: [D23935519](https://our.internmc.facebook.com/intern/diff/D23935519)