### PR TITLE
CI: Add a run of FastRNN benchmarks in default executor/fuser configuration.

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -338,6 +338,8 @@ test_benchmarks() {
     pip_install --user "requests"
     BENCHMARK_DATA="benchmarks/.data"
     mkdir -p ${BENCHMARK_DATA}
+    pytest benchmarks/fastrnns/test_bench.py --benchmark-sort=Name --benchmark-json=${BENCHMARK_DATA}/fastrnns_default.json --fuser=default --executor=default
+    python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_default.json
     pytest benchmarks/fastrnns/test_bench.py --benchmark-sort=Name --benchmark-json=${BENCHMARK_DATA}/fastrnns_legacy_old.json --fuser=old --executor=legacy
     python benchmarks/upload_scribe.py --pytest_bench_json ${BENCHMARK_DATA}/fastrnns_legacy_old.json
     pytest benchmarks/fastrnns/test_bench.py --benchmark-sort=Name --benchmark-json=${BENCHMARK_DATA}/fastrnns_profiling_te.json --fuser=te --executor=profiling


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45349 Benchmarks: tweak PE config settings.
* **#45348 CI: Add a run of FastRNN benchmarks in default executor/fuser configuration.**
* #45347 Benchmarks: add 'default' options for fuser and executor.

Differential Revision: [D23935520](https://our.internmc.facebook.com/intern/diff/D23935520)