### PR TITLE
Benchmarks: tweak PE config settings.

### DIFF
--- a/benchmarks/fastrnns/fuser.py
+++ b/benchmarks/fastrnns/fuser.py
@@ -6,7 +6,7 @@ def set_fuser(fuser_name, executor_name):
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(True)
         torch._C._jit_set_bailout_depth(20)
-        torch._C._jit_set_num_profiled_runs(2)
+        torch._C._jit_set_num_profiled_runs(1)
         torch._C._jit_override_can_fuse_on_cpu(False)
         torch._C._jit_override_can_fuse_on_gpu(True)
         torch._C._jit_set_texpr_fuser_enabled(True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45349 Benchmarks: tweak PE config settings.**
* #45348 CI: Add a run of FastRNN benchmarks in default executor/fuser configuration.
* #45347 Benchmarks: add 'default' options for fuser and executor.

Differential Revision: [D23935518](https://our.internmc.facebook.com/intern/diff/D23935518)