### PR TITLE
.github: Switch pull_request -> pull_request_target

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -1,7 +1,7 @@
 name: clang-format
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   clang-format:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-  pull_request:
+  pull_request_target:
 
 jobs:
   quick-checks:


### PR DESCRIPTION
The `pull_request` event doesn't actually allow write access for the
GITHUB_TOKEN credential if the pull request comes from a forked
repository.

See
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
for more information

I'm not entirely sure if this affects the "checkout" portion of the action though, will need to test this further.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
