### PR TITLE
Add deprecation warning to PG backend and make TP backend stable.

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -142,9 +142,6 @@ to configure the backend's behavior.
 TensorPipe Backend
 """"""""""""""""""
 
-.. warning::
-    The TensorPipe backend is a **beta feature**.
-
 The TensorPipe agent, which is the default, leverages `the TensorPipe library
 <https://github.com/pytorch/tensorpipe>`_, which provides a natively
 point-to-point communication primitive specifically suited for machine learning
@@ -191,6 +188,10 @@ Example::
 
 Process Group Backend
 """""""""""""""""""""
+
+.. warning ::
+     The Process Group Backend will be deprecated soon, we recommend using the
+     TensorPipe Backend instead.
 
 The Process Group agent instantiates a process group from
 the :mod:`~torch.distributed` module and utilizes its point-to-point


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45356 Add deprecation warning to PG backend and make TP backend stable.**

In this PR, I'm adding a warning to the PG backend mentioning it would
be deprecated in the future. In addition to this I removed the warning from the
TP backend that it is a beta feature.

Differential Revision: [D23940144](https://our.internmc.facebook.com/intern/diff/D23940144/)