### PR TITLE
Adding torch.arange to glow

### DIFF
--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -414,7 +414,9 @@ struct TORCH_API Node {
     return inputs_.at(i);
   }
 
+  bool hasNamedInput(const std::string& name) const;
   Value* namedInput(Symbol name) const;
+  Value* namedInput(const std::string& name) const;
 
   c10::optional<IValue> get(Symbol name) const;
 


### PR DESCRIPTION
Summary: Adding support to glow for torch arange op. Because of varargs from torch.arange call, further support for named input references was added to torch nodes.

Test Plan: buck test mode/no-gpu glow/glow/torch_glow/tests

Differential Revision: D23848438

