### PR TITLE
[JIT][Easy] Merge adjacent autodiff subgraphs

### DIFF
--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -192,3 +192,10 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
         FileCheck().check("prim::If").check("aten::select").check_next("aten::select")\
             .check_next("aten::add_").check("Differentiable").run(graph)
         self.assertGraphContainsExactly(graph, 'prim::DifferentiableGraph', 2)
+
+    def test_adjacent_independent_subgrapahs_merged(self):
+        def foo(a, b, c, d):
+            return a + b, c + d
+
+        graph = self._perform_ad_subgraph_slicing(foo, [2, 2], [2, 2], [2, 2], [2, 2])
+        self.assertGraphContainsExactly(graph, 'prim::DifferentiableGraph', 1)

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -108,8 +108,9 @@ class SubgraphSlicer {
     }
 
     // merge adjacent subgraphs thaat don't have a dependency on each other
-    Node * prev_autodiff_group = nullptr;
-    for (auto it = block_->nodes().end()->reverseIterator(); it != block_->nodes().begin()->reverseIterator();) {
+    Node* prev_autodiff_group = nullptr;
+    for (auto it = block_->nodes().end()->reverseIterator();
+         it != block_->nodes().begin()->reverseIterator();) {
       Node* n = *it;
       it++;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45362 [JIT][Easy] Merge adjacent autodiff subgraphs**

Since tensorexpr_fuser tries to merge adjacent fusion groups that don't have a data dependency, autodiff should too. 

