### PR TITLE
`torch.sign` support output of different dtype than input

### DIFF
--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -34,8 +34,8 @@ void sign_kernel_cuda(TensorIterator& iter){
       return a;
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(ScalarType::Half, iter.dtype(), "sign_cuda", [&]() {
-        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+    AT_DISPATCH_ALL_TYPES_AND(ScalarType::Half, iter.input_dtype(), "sign_cuda", [&]() {
+        gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) {
             scalar_t zero = scalar_t(0);
             return (zero < a) - (a < zero);
         });

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11251,7 +11251,6 @@ class TestTorchDeviceType(TestCase):
 
             for with_extremal in [True, False]:
                 shape = self._rand_shape(3, 4, 5)
-                print(inp_dtype, out_dtype)
                 x = self._generate_input(shape, inp_dtype, device, with_extremal)
                 out = torch.empty_like(x).to(out_dtype)
 


### PR DESCRIPTION
Reference : #44968

`out.dtype ==torch.bool` or `out.dtype == torch.uint8` can only be used when corresponding input is either `[torch.bool, torch.uint8]`.

For all other input dtypes, one can use `out.dtype=torch.int8` or any signed dtype with greater range.

Quansight Tracking : q-44968

cc: @malfet 