### PR TITLE
[docs] Make spelling of 'nonnegative' consistent in TripletMarginWithDistanceLoss

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1268,7 +1268,7 @@ class TripletMarginWithDistanceLoss(_Loss):
 
     where :math:`N` is the batch size; :math:`d` is a nonnegative, real-valued function
     quantifying the closeness of two tensors, referred to as the :attr:`distance_function`;
-    and :math:`margin` is a non-negative margin representing the minimum difference
+    and :math:`margin` is a nonnegative margin representing the minimum difference
     between the positive and negative distances that is required for the loss to
     be 0.  The input tensors have :math:`N` elements each and can be of any shape
     that the distance function can handle.
@@ -1290,7 +1290,7 @@ class TripletMarginWithDistanceLoss(_Loss):
         distance_function (callable, optional): A nonnegative, real-valued function that
             quantifies the closeness of two tensors. If not specified,
             `nn.PairwiseDistance` will be used.  Default: ``None``
-        margin (float, optional): A non-negative margin representing the minimum difference
+        margin (float, optional): A nonnegative margin representing the minimum difference
             between the positive and negative distances required for the loss to be 0. Larger
             margins penalize cases where the negative examples are not distant enough from the
             anchors, relative to the positives. Default: :math:`1`.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45378 [nn] Make spelling of 'nonnegative' consistent in TripletMarginWithDistanceLoss**

This PR fixes some inconsistencies in the docs of `nn.TripletMarginWithDistanceLoss`, specifically w.r.t. the spelling of the word "nonnegative" (vs. "non-negative").  It seems that "nonnegative" is more common in general, but I'm not sure if there's a preference; I've changed all instances to that for now but am happy to go the other way.

<img width="462" alt="nonnegative" src="https://user-images.githubusercontent.com/12580176/94347737-8e6b1000-ffeb-11ea-92e2-eba4f6ac7792.PNG">
