### PR TITLE
Allow outputs to have different strides for reductions with multiple outputs (min and max)

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -786,7 +786,7 @@ void TensorIterator::copy_reduction_outputs(){
     for (auto& op : operands_) {
       if (op.is_output && op.original_tensor.defined()) {
         op.original_tensor.copy_(op.tensor);
-        op.tensor = op.original_tensor;
+        op.tensor=op.original_tensor;
       }
     }
   }
@@ -935,13 +935,17 @@ void TensorIterator::populate_operands(TensorIteratorConfig& config) {
 void TensorIterator::create_reduction_temporaries(){
   //reductions are hardcoded for max 2 outputs
   // 2nd check subsumes the 1st, but 1st is much cheaper and more common, so can be used as a shortcut
-  if ((!operands_[0].tensor.is_contiguous() || !operands_[1].tensor.is_contiguous())
-   && (operands_[0].tensor.strides() !=operands_[0].tensor.strides())){
-     //reduction does not participate in type promotion in TI, so original_tensor won't be overwritten
-     operands_[0].original_tensor = operands_[0].tensor;
-     operands_[0].tensor = operands_[0].tensor.contiguous();
-     operands_[1].original_tensor = operands_[1].tensor.contiguous();
-     operands_[1].tensor = operands_[1].tensor.contiguous();
+  TORCH_INTERNAL_ASSERT(
+      num_outputs_ == 2, "reductions can have a max of 2 outputs");
+  if ((!operands_[0].tensor.is_contiguous() ||
+       !operands_[1].tensor.is_contiguous()) &&
+      (operands_[0].tensor.strides() != operands_[1].tensor.strides())) {
+    // reduction does not participate in type promotion in TI, so
+    // original_tensor won't be overwritten
+    operands_[0].original_tensor = operands_[0].tensor;
+    operands_[0].tensor = operands_[0].tensor.contiguous();
+    operands_[1].original_tensor = operands_[1].tensor;
+    operands_[1].tensor = operands_[1].tensor.contiguous();
   }
 }
 

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -912,8 +912,6 @@ TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tenso
       " and output2 has ", out2.dim());
   TORCH_CHECK(out1.sizes() == out2.sizes(), "reduce_op(): expected both outputs to have same sizes, but output1 has ", out1.sizes(),
       " and output2 has ", out2.sizes());
-  //TORCH_CHECK(out1.strides() == out2.strides(), "reduce_op(): expected both outputs to have same strides, but output1 has ", out1.strides(),
-  //    " and output2 has ", out2.strides());
   return TensorIteratorConfig()
     .set_check_mem_overlap(false)
     .add_output(out1)

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -212,6 +212,9 @@ struct CAFFE2_API TensorIterator {
   // NOTE: only used on CPU
   void cast_outputs();
 
+  // Copies from temporary outputs back to original outputs, only used for GPU reductions
+  void copy_reduction_outputs();
+
   Tensor input(int arg=0) const {
     AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
     return operands_[num_outputs_ + arg].tensor;
@@ -300,6 +303,7 @@ protected:
 
   // Mutable reference as it moves tensors out of TensorIteratorConfig
   void populate_operands(TensorIteratorConfig&);
+  void create_reduction_temporaries();
   void mark_outputs();
   void mark_resize_outputs(const TensorIteratorConfig&);
   void compute_mem_overlaps(const TensorIteratorConfig&);

--- a/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
@@ -101,6 +101,7 @@ static void min_kernel_impl(Tensor& result, Tensor& indice, const Tensor& self, 
       MinOps<scalar_t>{},
       thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
   });
+  iter.copy_reduction_outputs();
 }
 
 static void max_kernel_impl(Tensor& result, Tensor& indice, const Tensor& self, int64_t dim, bool keepdim) {
@@ -111,6 +112,7 @@ static void max_kernel_impl(Tensor& result, Tensor& indice, const Tensor& self, 
       MaxOps<scalar_t>{},
       thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::lower_bound(), 0));
   });
+  iter.copy_reduction_outputs();
 }
 
 static void _aminmax_kernel_impl(
@@ -119,18 +121,19 @@ static void _aminmax_kernel_impl(
     const Tensor& self,
     int64_t dim,
     bool keepdim) {
-  at::TensorIterator iter = make_reduction("_aminmax", min_result, 
+  at::TensorIterator iter = make_reduction("_aminmax", min_result,
     max_result, self, dim, keepdim, self.scalar_type());
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, self.scalar_type(), "_aminmax_cuda", [&]() {
     gpu_reduce_kernel<scalar_t, scalar_t>(
       iter,
       MinMaxOps<scalar_t, scalar_t, int32_t>{},
       thrust::pair<scalar_t, scalar_t>(
-        at::numeric_limits<scalar_t>::upper_bound(), 
+        at::numeric_limits<scalar_t>::upper_bound(),
         at::numeric_limits<scalar_t>::lower_bound()
       )
     );
   });
+  iter.copy_reduction_outputs();
 }
 
 static void min_all_kernel_impl(Tensor& result, const Tensor& input) {

--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -32,6 +32,7 @@ static void std_var_kernel_cuda(TensorIterator& iter, bool unbiased, bool take_s
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "std_cuda", [&]() {
     std_var_kernel_impl<scalar_t>(iter, unbiased, take_sqrt);
   });
+  iter.copy_reduction_outputs();
 }
 
 template <typename scalar_t, typename acc_t=scalar_t, typename out_t=scalar_t>


### PR DESCRIPTION
Fixes #42364 by creating temporaries in case reduction outputs have different strides. This situation is exceedingly rare, and no attempt is made to improve performance in this case. However, this fix does not regress performance for the common cases. 
Note: turns out `var_mean` does not have `out` variant so presently it cannot hit this issue (#45446). 