### PR TITLE
Add ReadAdapterInterface for Buffers

### DIFF
--- a/caffe2/serialize/CMakeLists.txt
+++ b/caffe2/serialize/CMakeLists.txt
@@ -4,6 +4,7 @@ set(Caffe2_CPU_TEST_SRCS ${Caffe2_CPU_TEST_SRCS} ${tmp})
 list(APPEND Caffe2_CPU_SRCS
   ${PROJECT_SOURCE_DIR}/third_party/miniz-2.0.8/miniz.c
   ${CMAKE_CURRENT_SOURCE_DIR}/inline_container.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/buffer_adapter.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/istream_adapter.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/file_adapter.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/crc.cc

--- a/caffe2/serialize/buffer_adapter.cc
+++ b/caffe2/serialize/buffer_adapter.cc
@@ -1,0 +1,37 @@
+#include "buffer_adapter.h"
+#include <c10/util/Exception.h>
+#include "caffe2/serialize/istream_adapter.h"
+
+#include <cstring>
+
+namespace caffe2 {
+namespace serialize {
+
+BufferAdapter::BufferAdapter(void *buffer, size_t size)
+    : buffer_(buffer), size_(size)
+{
+}
+
+size_t BufferAdapter::size() const
+{
+  return size_;
+}
+
+size_t BufferAdapter::read(uint64_t pos,
+                           void *buf,
+                           size_t n,
+                           const char *what) const
+{
+  if (!buffer_) {
+    AT_ERROR("buffer reader failed: ", what, ".");
+  }
+  void *start = static_cast<char *>(buffer_) + pos;
+  size_t bytes = std::min<size_t>(size_ - pos, n);
+  std::memcpy(buf, start, bytes);
+  return bytes;
+}
+
+BufferAdapter::~BufferAdapter() {}
+
+}  // namespace serialize
+}  // namespace caffe2

--- a/caffe2/serialize/buffer_adapter.h
+++ b/caffe2/serialize/buffer_adapter.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "c10/macros/Macros.h"
+#include "caffe2/serialize/read_adapter_interface.h"
+
+namespace caffe2 {
+namespace serialize {
+
+// This is a reader implemented for data buffers.
+class BufferAdapter final : public ReadAdapterInterface {
+ public:
+  explicit BufferAdapter(void *buffer, size_t size);
+  size_t size() const override;
+  size_t read(uint64_t pos,
+              void *buf,
+              size_t n,
+              const char *what = "") const override;
+  ~BufferAdapter();
+
+ private:
+  void *buffer_;
+  size_t size_;
+};
+
+}  // namespace serialize
+}  // namespace caffe2

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -14,6 +14,7 @@
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
 #include <torch/csrc/jit/serialization/unpickler.h>
 
+#include <caffe2/serialize/buffer_adapter.h>
 #include <caffe2/serialize/file_adapter.h>
 #include <caffe2/serialize/inline_container.h>
 #include <caffe2/serialize/istream_adapter.h>
@@ -29,6 +30,7 @@
 namespace torch {
 namespace jit {
 
+using caffe2::serialize::BufferAdapter;
 using caffe2::serialize::FileAdapter;
 using caffe2::serialize::IStreamAdapter;
 using caffe2::serialize::PyTorchStreamReader;
@@ -302,6 +304,16 @@ Module import_ir_module(
   auto reader = torch::make_unique<PyTorchStreamReader>(std::move(rai));
   ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
   return deserializer.deserialize(device, extra_files);
+}
+
+Module load(
+    void* buffer,
+    size_t size,
+    c10::optional<at::Device> device,
+    ExtraFilesMap& extra_files) {
+  auto rai = std::make_unique<BufferAdapter>(buffer, size);
+  auto module = load(std::move(rai), device, extra_files);
+  return module;
 }
 
 Module load(

--- a/torch/csrc/jit/serialization/import.h
+++ b/torch/csrc/jit/serialization/import.h
@@ -36,6 +36,16 @@ TORCH_API Module import_ir_module(
     c10::optional<c10::Device> device = c10::nullopt,
     ExtraFilesMap& extra_files = default_extra_files);
 
+/// Loads a serialized `Module` from the given `buffer`.
+///
+/// The buffer must represent a serialized `Module`, exported via
+/// `torch::jit::ExportModule` in C++.
+TORCH_API Module load(
+    void* buffer,
+    size_t size,
+    c10::optional<c10::Device> device = c10::nullopt,
+    ExtraFilesMap& extra_files = default_extra_files);
+
 /// Loads a serialized `Module` from the given `istream`.
 ///
 /// The istream must contain a serialized `Module`, exported via


### PR DESCRIPTION
Currently serialized modules can either be loaded from an istream or directly from a file. This adds a way to load them from an in-memory buffer.

Use case: The serialized module data could be part of an archive, where it's not easily convertible to an istream, but can be extracted in-memory to a buffer.
For example, I use a zip archive where the model.pt is bundled with some metadata (eg. training information, validation stats).