### PR TITLE
[Distributed] DeleteKey API for c10d TCP Store

### DIFF
--- a/caffe2/distributed/file_store_handler.cc
+++ b/caffe2/distributed/file_store_handler.cc
@@ -127,6 +127,11 @@ int64_t FileStoreHandler::getNumKeys() {
   return 0;
 }
 
+bool FileStoreHandler::deleteKey(const std::string& /* unused */) {
+  CHECK(false) << "deleteKey not implemented for FileStoreHandler";
+  return false;
+}
+
 bool FileStoreHandler::check(const std::vector<std::string>& names) {
   std::vector<std::string> paths;
   for (const auto& name : names) {

--- a/caffe2/distributed/file_store_handler.h
+++ b/caffe2/distributed/file_store_handler.h
@@ -17,6 +17,8 @@ class CAFFE2_API FileStoreHandler : public StoreHandler {
 
   virtual int64_t add(const std::string& name, int64_t value) override;
 
+  virtual bool deleteKey(const std::string& key) override;
+
   virtual int64_t getNumKeys() override;
 
   virtual bool check(const std::vector<std::string>& names) override;

--- a/caffe2/distributed/redis_store_handler.cc
+++ b/caffe2/distributed/redis_store_handler.cc
@@ -81,6 +81,11 @@ int64_t RedisStoreHandler::getNumKeys() {
   return 0;
 }
 
+bool RedisStoreHandler::deleteKey(const std::string& /* unused */) {
+  CHECK(false) << "deleteKey not implemented for RedisStoreHandler";
+  return false;
+}
+
 bool RedisStoreHandler::check(const std::vector<std::string>& names) {
   std::vector<std::string> args;
   args.push_back("EXISTS");

--- a/caffe2/distributed/redis_store_handler.h
+++ b/caffe2/distributed/redis_store_handler.h
@@ -25,6 +25,8 @@ class CAFFE2_API RedisStoreHandler : public StoreHandler {
 
   virtual int64_t getNumKeys() override;
 
+  virtual bool deleteKey(const std::string& key) override;
+
   virtual bool check(const std::vector<std::string>& names) override;
 
   virtual void wait(

--- a/caffe2/distributed/store_handler.h
+++ b/caffe2/distributed/store_handler.h
@@ -47,6 +47,11 @@ class CAFFE2_API StoreHandler {
   virtual int64_t getNumKeys() = 0;
 
   /*
+   * Removes the specified key from the store.
+   */
+  virtual bool deleteKey(const std::string& key) = 0;
+
+  /*
    * Check if a keys exist in the store.
    */
   virtual bool check(const std::vector<std::string>& names) = 0;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -98,6 +98,10 @@ class PythonStore : public ::c10d::Store {
     PYBIND11_OVERLOAD_PURE(int64_t, ::c10d::Store, getNumKeys);
   }
 
+  bool deleteKey(const std::string& key) override {
+    PYBIND11_OVERLOAD_PURE(bool, ::c10d::Store, deleteKey, key);
+  }
+
   bool check(const std::vector<std::string>& keys) override {
     PYBIND11_OVERLOAD_PURE(bool, ::c10d::Store, check, keys);
   }
@@ -306,6 +310,10 @@ They are used in specifying strategies for reduction collectives, e.g.,
           .def(
               "add",
               &::c10d::Store::add,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "delete_key",
+              &::c10d::Store::deleteKey,
               py::call_guard<py::gil_scoped_release>())
           .def(
               "num_keys",

--- a/torch/lib/c10d/FileStore.cpp
+++ b/torch/lib/c10d/FileStore.cpp
@@ -358,6 +358,10 @@ int64_t FileStore::getNumKeys() {
   TORCH_CHECK(false, "getNumKeys not implemented for FileStore");
 }
 
+bool FileStore::deleteKey(const std::string& /* unused */) {
+  TORCH_CHECK(false, "deleteKey not implemented for FileStore");
+}
+
 bool FileStore::check(const std::vector<std::string>& keys) {
   std::unique_lock<std::mutex> l(activeFileOpLock_);
   File file(path_, O_RDONLY, timeout_);

--- a/torch/lib/c10d/FileStore.hpp
+++ b/torch/lib/c10d/FileStore.hpp
@@ -23,6 +23,8 @@ class FileStore : public Store {
 
   int64_t getNumKeys() override;
 
+  bool deleteKey(const std::string& key) override;
+
   bool check(const std::vector<std::string>& keys) override;
 
   void wait(const std::vector<std::string>& keys) override;

--- a/torch/lib/c10d/HashStore.cpp
+++ b/torch/lib/c10d/HashStore.cpp
@@ -83,6 +83,10 @@ int64_t HashStore::getNumKeys() {
   TORCH_CHECK(false, "getNumKeys not implemented for HashStore");
 }
 
+bool HashStore::deleteKey(const std::string& /* unused */) {
+  TORCH_CHECK(false, "deleteKey not implemented for HashStore");
+}
+
 bool HashStore::check(const std::vector<std::string>& keys) {
   std::unique_lock<std::mutex> lock(m_);
   for (const auto& key : keys) {

--- a/torch/lib/c10d/HashStore.hpp
+++ b/torch/lib/c10d/HashStore.hpp
@@ -32,6 +32,8 @@ class HashStore : public Store {
 
   bool check(const std::vector<std::string>& keys) override;
 
+  bool deleteKey(const std::string& key) override;
+
  protected:
   std::unordered_map<std::string, std::vector<uint8_t>> map_;
   std::mutex m_;

--- a/torch/lib/c10d/PrefixStore.cpp
+++ b/torch/lib/c10d/PrefixStore.cpp
@@ -35,6 +35,10 @@ int64_t PrefixStore::add(const std::string& key, int64_t value) {
   return store_->add(joinKey(key), value);
 }
 
+bool PrefixStore::deleteKey(const std::string& key) {
+  return store_->deleteKey(joinKey(key));
+}
+
 int64_t PrefixStore::getNumKeys() {
   return store_->getNumKeys();
 }

--- a/torch/lib/c10d/PrefixStore.hpp
+++ b/torch/lib/c10d/PrefixStore.hpp
@@ -17,6 +17,8 @@ class PrefixStore : public Store {
 
   int64_t add(const std::string& key, int64_t value) override;
 
+  bool deleteKey(const std::string& key) override;
+
   int64_t getNumKeys() override;
 
   bool check(const std::vector<std::string>& keys) override;

--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -30,6 +30,8 @@ class Store {
 
   virtual int64_t add(const std::string& key, int64_t value) = 0;
 
+  virtual bool deleteKey(const std::string& key) = 0;
+
   virtual bool check(const std::vector<std::string>& keys) = 0;
 
   virtual int64_t getNumKeys() = 0;

--- a/torch/lib/c10d/TCPStore.hpp
+++ b/torch/lib/c10d/TCPStore.hpp
@@ -27,6 +27,7 @@ class TCPStoreDaemon {
   void getHandler(int socket) const;
   void checkHandler(int socket) const;
   void getNumKeysHandler(int socket) const;
+  void deleteHandler(int socket);
   void waitHandler(int socket);
 
   bool checkKeys(const std::vector<std::string>& keys) const;
@@ -61,6 +62,8 @@ class TCPStore : public Store {
   std::vector<uint8_t> get(const std::string& key) override;
 
   int64_t add(const std::string& key, int64_t value) override;
+
+  bool deleteKey(const std::string& key) override;
 
   bool check(const std::vector<std::string>& keys) override;
 

--- a/torch/lib/c10d/test/TCPStoreTest.cpp
+++ b/torch/lib/c10d/test/TCPStoreTest.cpp
@@ -36,10 +36,22 @@ void testHelper(const std::string& prefix = "") {
     c10d::test::check(*serverStore, "key0", "value0");
     c10d::test::check(*serverStore, "key1", "value1");
     c10d::test::check(*serverStore, "key2", "value2");
+    serverStore->add("counter", 1);
     auto numKeys = serverStore->getNumKeys();
     // We expect 5 keys since 3 are added above, 'counter' is added by the
     // helper thread, and the init key to coordinate workers.
     EXPECT_EQ(numKeys, 5);
+
+    auto delSuccess = serverStore->deleteKey("key0");
+    // Ensure that the key was successfully deleted
+    EXPECT_TRUE(delSuccess);
+    auto delFailure = serverStore->deleteKey("badKeyName");
+    // The key was not in the store so the delete operation should have failed
+    // and returned false.
+    EXPECT_FALSE(delFailure);
+    numKeys = serverStore->getNumKeys();
+    EXPECT_EQ(numKeys, 4);
+    EXPECT_THROW(serverStore->get("key0"), std::runtime_error);
   });
 
   // Hammer on TCPStore
@@ -57,7 +69,7 @@ void testHelper(const std::string& prefix = "") {
         new c10d::PrefixStore(prefix, clientTCPStores[i])));
   }
 
-  std::string expectedCounterRes = std::to_string(numThreads * numIterations);
+  std::string expectedCounterRes = std::to_string(numThreads * numIterations + 1);
 
   for (auto i = 0; i < numThreads; i++) {
     threads.push_back(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45402 [Distributed] Adding Python tests for the TCPStore getNumKeys and deleteKey
* **#45401 [Distributed] DeleteKey API for c10d TCP Store**

Reland of https://github.com/pytorch/pytorch/pull/43963
Added a DeleteKey API for the TCP Store

Differential Revision: [D23955730](https://our.internmc.facebook.com/intern/diff/D23955730/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D23955730/)!