### PR TITLE
Updates linalg warning + docs

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1,7 +1,6 @@
 import torch
 import unittest
 import itertools
-import warnings
 from math import inf, nan, isnan
 
 from torch.testing._internal.common_utils import \

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -654,18 +654,6 @@ class TestLinalg(TestCase):
                 for ord in ord_matrix:
                     run_test_case(input, ord, dim, keepdim, ord in error_ords)
 
-    def test_norm_deprecated(self, device):
-        expected_message = (
-            r'torch.norm is deprecated and may be removed in a future PyTorch release. '
-            r'Use torch.linalg.norm instead.')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            for func in [torch.norm, torch.functional.norm]:
-                func(torch.rand(10, device=device))
-        self.assertEqual(len(w), 2)
-        for wi in w:
-            self.assertEqual(str(wi.message), expected_message)
-
     def test_norm_fastpaths(self, device):
         x = torch.randn(3, 5, device=device)
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1214,7 +1214,9 @@ def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa
     .. warning::
 
         torch.norm is deprecated and may be removed in a future PyTorch release.
-        Use :func:`torch.linalg.norm` instead.
+        Use :func:`torch.linalg.norm` instead, but note that :func:`torch.linalg.norm`
+        has a different signature and slightly different behavior that is
+        more consistent with NumPy's numpy.linalg.norm.
 
     Args:
         input (Tensor): the input tensor
@@ -1273,9 +1275,6 @@ def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa
         >>> torch.norm(d[0, :, :]), torch.norm(d[1, :, :])
         (tensor(3.7417), tensor(11.2250))
     """
-    warnings.warn((
-        "torch.norm is deprecated and may be removed in a future PyTorch release. "
-        "Use torch.linalg.norm instead."))
 
     if not torch.jit.is_scripting():
         if type(input) is not Tensor and has_torch_function((input,)):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -9,7 +9,6 @@ from ._lowrank import svd_lowrank, pca_lowrank
 from .overrides import has_torch_function, handle_torch_function
 from ._jit_internal import boolean_dispatch, List
 from ._jit_internal import _overload as overload
-import warnings
 
 Tensor = torch.Tensor
 from torch import _VF


### PR DESCRIPTION
Changes the deprecation of norm to a docs deprecation, since PyTorch components still rely on norm and some behavior, like automatically flattening tensors, may need to be ported to torch.linalg.norm. The documentation is also updated to clarify that torch.norm and torch.linalg.norm are distinct. 