### PR TITLE
docker: Add torchelastic to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ FROM conda as conda-installs
 ARG INSTALL_CHANNEL=pytorch-nightly
 RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -y pytorch torchvision cudatoolkit=11.0.221 && \
     /opt/conda/bin/conda clean -ya
+RUN /opt/conda/bin/pip install torchelastic
 
 FROM ${BASE_IMAGE} as official
 LABEL com.nvidia.volumes.needed="nvidia_driver"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45438 docker: Add torchelastic to docker image**

Adds torchelastic (as well as its dependencies) to the official docker
images

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D23963787](https://our.internmc.facebook.com/intern/diff/D23963787)