### PR TITLE
Use python 3.8 in pytorch docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #       For reference: 
 #           https://docs.docker.com/develop/develop-images/build_enhancements/
 ARG BASE_IMAGE=ubuntu:18.04
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.8
 
 FROM ${BASE_IMAGE} as dev-base
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45466 Use python 3.8 in pytorch docker image**

Differential Revision: [D23975294](https://our.internmc.facebook.com/intern/diff/D23975294)