### PR TITLE
Fix model_name not logged properly issue.

### DIFF
--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -126,7 +126,7 @@ void Method::run(Stack& stack) {
   std::unordered_map<std::string, std::string> copied_metadata =
       owner_->metadata();
   if (owner_->metadata().find("model_name") == owner_->metadata().end()) {
-    copied_metadata["model_name"] = name();
+    copied_metadata["model_name"] = owner_->name();
   }
   if (observer) {
     observer->onEnterRunMethod(copied_metadata, function_->name());

--- a/torch/csrc/jit/mobile/module.h
+++ b/torch/csrc/jit/mobile/module.h
@@ -43,7 +43,7 @@ class TORCH_API Module {
     return get_method("forward")(std::move(inputs));
   }
   c10::optional<Method> find_method(const std::string& basename) const;
-  std::string name() {
+  const std::string name() const {
     return object_->name();
   }
   const std::vector<at::IValue>& slots() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45488 Fix model_name not logged properly issue.**

model_name logging was broken, issue is from the recent change of assigning the method name into the module name, this diff is fixing it.

Differential Revision: [D23984165](https://our.internmc.facebook.com/intern/diff/D23984165/)