### PR TITLE
[PyTorch][QPL] Add instance_key into MOBILE_MODULE_STATS logging.

### DIFF
--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -121,6 +121,7 @@ Method::Method(const Module* owner, Function* function)
 
 void Method::run(Stack& stack) {
   auto observer = torch::observerConfig().getModuleObserver();
+  auto instance_key = std::rand();
   /* if the metadata dict doesn't contain "model_name", copy the metadata and
   set the value of "model_name" as name() */
   std::unordered_map<std::string, std::string> copied_metadata =
@@ -129,7 +130,8 @@ void Method::run(Stack& stack) {
     copied_metadata["model_name"] = name();
   }
   if (observer) {
-    observer->onEnterRunMethod(copied_metadata, function_->name());
+    observer->onEnterRunMethod(
+        copied_metadata, instance_key, function_->name());
   }
 
   auto debug_info = std::make_shared<MobileDebugInfo>();
@@ -142,11 +144,11 @@ void Method::run(Stack& stack) {
     stack.insert(stack.begin(), owner_->_ivalue());
     function_->run(stack);
     if (observer) {
-      observer->onExitRunMethod();
+      observer->onExitRunMethod(instance_key);
     }
   } catch (c10::Error& error) {
     if (observer) {
-      observer->onFailRunMethod(error.what());
+      observer->onFailRunMethod(instance_key, error.what());
     }
     TORCH_RETHROW(error);
   } catch (...) {
@@ -163,7 +165,7 @@ void Method::run(Stack& stack) {
       }
     } catch (c10::Error& error) {
       if (observer) {
-        observer->onFailRunMethod(error.what());
+        observer->onFailRunMethod(instance_key, error.what());
       }
       TORCH_RETHROW(error);
     }

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -70,10 +70,10 @@ class MobileModuleObserver {
 
   virtual void onEnterRunMethod(
       const std::unordered_map<std::string, std::string>&,
+      const int32_t,
       const std::string&) {}
-  virtual void onExitRunMethod() {}
-  virtual void onCancelRunMethod(const std::string&) {}
-  virtual void onFailRunMethod(const char*) {}
+  virtual void onExitRunMethod(const int32_t) {}
+  virtual void onFailRunMethod(const int32_t, const char*) {}
   virtual void onEnterLoadModel() {}
   virtual void onExitLoadModel(
       const std::unordered_map<std::string, std::string>&) {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45518 [PyTorch][QPL] Add instance_key into MOBILE_MODULE_LOAD_STATS logging.
* **#45517 [PyTorch][QPL] Add instance_key into MOBILE_MODULE_STATS logging.**

Add unique instance_key instead of the default one into MOBILE_MODULE_STATS logging to avoid multiple events overlaps.

Differential Revision: [D23985178](https://our.internmc.facebook.com/intern/diff/D23985178/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D23985178/)!