### PR TITLE
[PyTorch][QPL] Add instance_key into MOBILE_MODULE_LOAD_STATS logging.

### DIFF
--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -171,8 +171,9 @@ mobile::Module _load_data(
     std::unique_ptr<ReadAdapterInterface> rai,
     c10::optional<c10::Device> device) {
   auto observer = torch::observerConfig().getModuleObserver();
+  auto instance_key = std::rand();
   if (observer) {
-    observer->onEnterLoadModel();
+    observer->onEnterLoadModel(instance_key);
   }
   try {
     auto reader = torch::make_unique<PyTorchStreamReader>(std::move(rai));
@@ -186,12 +187,12 @@ mobile::Module _load_data(
       copied_metadata["model_name"] = result.name();
     }
     if (observer) {
-      observer->onExitLoadModel(copied_metadata);
+      observer->onExitLoadModel(instance_key, copied_metadata);
     }
     return result;
   } catch (c10::Error& error) {
     if (observer) {
-      observer->onFailLoadModel(error.what());
+      observer->onFailLoadModel(instance_key, error.what());
     }
     TORCH_RETHROW(error);
   } catch (...) {
@@ -208,7 +209,7 @@ mobile::Module _load_data(
       }
     } catch (c10::Error& error) {
       if (observer) {
-        observer->onFailLoadModel(error.what());
+        observer->onFailLoadModel(instance_key, error.what());
       }
       TORCH_RETHROW(error);
     }

--- a/torch/csrc/jit/mobile/observer.h
+++ b/torch/csrc/jit/mobile/observer.h
@@ -74,11 +74,13 @@ class MobileModuleObserver {
       const std::string&) {}
   virtual void onExitRunMethod(const int32_t) {}
   virtual void onFailRunMethod(const int32_t, const char*) {}
-  virtual void onEnterLoadModel() {}
+  virtual void onEnterLoadModel(const int32_t) {}
   virtual void onExitLoadModel(
+      const int32_t,
       const std::unordered_map<std::string, std::string>&) {}
-  virtual void onFailLoadModel(const char*) {}
+  virtual void onFailLoadModel(const int32_t, const char*) {}
   virtual void onFailLoadModel(
+      const int32_t,
       const char*,
       const std::unordered_map<std::string, std::string>&) {}
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45518 [PyTorch][QPL] Add instance_key into MOBILE_MODULE_LOAD_STATS logging.**
* #45517 [PyTorch][QPL] Add instance_key into MOBILE_MODULE_STATS logging.

Similar to previous diff,  Add instance_key into MOBILE_MODULE_LOAD_STATS logging.

Differential Revision: [D23996150](https://our.internmc.facebook.com/intern/diff/D23996150/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D23996150/)!