### PR TITLE
Fix the activation setting of Quantization Aware Training

### DIFF
--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -94,7 +94,7 @@ def get_default_qat_qconfig(backend='fbgemm'):
     if backend == 'fbgemm':
         qconfig = QConfig(activation=FakeQuantize.with_args(observer=MovingAverageMinMaxObserver,
                                                             quant_min=0,
-                                                            quant_max=255,
+                                                            quant_max=127,
                                                             reduce_range=True),
                           weight=default_per_channel_weight_fake_quant)
     elif backend == 'qnnpack':


### PR DESCRIPTION
From https://github.com/pytorch/pytorch/blob/master/torch/quantization/observer.py, 

``` language=python
            if self.dtype == torch.qint8:
                if self.reduce_range:
                    quant_min, quant_max = -64, 63
                else:
                    quant_min, quant_max = -128, 127
            else:
                if self.reduce_range:
                    quant_min, quant_max = 0, 127
                else:
                    quant_min, quant_max = 0, 255
```

 we can find that the data range of a quantized activation tensor is [0, 127] if reduce_range is enabled.

However, in https://github.com/pytorch/pytorch/blob/master/torch/quantization/qconfig.py, the quant_max is set as 255.
``` language=python
    if backend == 'fbgemm':
        qconfig = QConfig(activation=FakeQuantize.with_args(observer=MovingAverageMinMaxObserver,
                                                            quant_min=0,
                                                            quant_max=255,
                                                            reduce_range=True),
                          weight=default_per_channel_weight_fake_quant)
```