### PR TITLE
Add multiline string dedent support

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7205,6 +7205,20 @@ a")
         x = torch.rand(3, 4)
         self.assertEqual(scripted_f(x), f(x))
 
+    def test_multiline_string_dedents(self):
+        def foo() -> None:
+            multiline_string_dedent_1 = """
+This is a string dedent """
+            multiline_string_dedent_2 = """ This is a
+  string dedent """
+            multiline_string_dedent_3 = """
+            This is a string
+dedent """
+            multiline_string_dedent_4 = """ This is a string dedent """
+
+        scripted_foo = torch.jit.script(foo)
+        self.assertEqual(scripted_foo(), foo())
+
     # adapted from test in test_torch
     def test_tensor_to(self):
         template = dedent('''

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -197,12 +197,14 @@ def check_and_indent_multiline_strings(sourcelines):
             indices.append(index)
 
     # Adding leading space for every line of the multiline string
-    for i in range(0, len(indices), 2):
-        start = indices[i]
-        end = indices[i + 1]
-        leading_space = len(sourcelines[start]) - len(sourcelines[start].lstrip())
-        for lines in range(start + 1, end + 1):
-            sourcelines[lines] = ' ' * leading_space + sourcelines[lines]
+    indices_length = len(indices)
+    for i in range(0, indices_length, 2):
+        if i+1 < indices_length:
+            start = indices[i]
+            end = indices[i + 1]
+            leading_space = len(sourcelines[start]) - len(sourcelines[start].lstrip())
+            for lines in range(start + 1, end + 1):
+                sourcelines[lines] = ' ' * leading_space + sourcelines[lines]
     return sourcelines
 
 def get_jit_def(fn, def_name, self_name=None):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -197,12 +197,14 @@ def check_and_indent_multiline_strings(sourcelines):
             indices.append(index)
 
     # Adding leading space for every line of the multiline string
-    for i in range(0, len(indices), 2):
-        start = indices[i]
-        end = indices[i + 1]
-        leading_space = len(sourcelines[start]) - len(sourcelines[start].lstrip())
-        for lines in range(start + 1, end + 1):
-            sourcelines[lines] = ' ' * leading_space + sourcelines[lines]
+    indices_length = len(indices)
+    for i in range(0, indices_length, 2):
+        if i + 1 < indices_length:
+            start = indices[i]
+            end = indices[i + 1]
+            leading_space = len(sourcelines[start]) - len(sourcelines[start].lstrip())
+            for lines in range(start + 1, end + 1):
+                sourcelines[lines] = ' ' * leading_space + sourcelines[lines]
     return sourcelines
 
 def get_jit_def(fn, def_name, self_name=None):


### PR DESCRIPTION
Fixes #{44842}
Summary
========
This PR adds support for multiline string dedents.

Test
=====
pytest -k test_multiline_string_dedents test/test_jit.py
