### PR TITLE
some documentation and style fixes to smooth_l1_loss

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -296,8 +296,10 @@ Tensor soft_margin_loss(
 }
 
 Tensor smooth_l1_loss(const Tensor& input, const Tensor& target, const int64_t reduction, double beta) {
-  if (beta <= 0)
+  TORCH_CHECK(beta >= 0, "smooth_l1_loss does not support negative values for beta.")
+  if (beta == 0) {
       return at::native::l1_loss(input, target, reduction);
+  }
   Tensor loss;
   auto iter = TensorIterator::binary_op(loss, input, target);
   smooth_l1_stub(iter.device_type(), iter, beta);
@@ -305,8 +307,10 @@ Tensor smooth_l1_loss(const Tensor& input, const Tensor& target, const int64_t r
 }
 
 Tensor& smooth_l1_loss_out(Tensor& result, const Tensor& input, const Tensor& target, int64_t reduction, double beta) {
-  if (beta <= 0)
+  TORCH_CHECK(beta >= 0, "smooth_l1_loss does not support negative values for beta.")
+  if (beta == 0) {
       return at::native::l1_loss_out(result, input, target, reduction);
+  }
   if (reduction != Reduction::None) {
     Tensor loss;
     auto iter = TensorIterator::binary_op(loss, input, target);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7032,6 +7032,10 @@ class TestNN(NNTestCase):
                 torch.nn.L1Loss()(input, torch.zeros_like(input)),
                 input.abs().mean())
 
+    def test_smoothl1loss_negative_beta_not_supported(self):
+        with self.assertRaises(ValueError):
+            F.smooth_l1_loss(torch.randn(2,2), torch.randn(2,2), beta=-1.0)
+
     def test_cosine_similarity(self):
         input1 = torch.randn(4, 4, requires_grad=True)
         input2 = torch.randn(4, 4, requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7033,7 +7033,7 @@ class TestNN(NNTestCase):
                 input.abs().mean())
 
     def test_smoothl1loss_negative_beta_not_supported(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             F.smooth_l1_loss(torch.randn(2, 2), torch.randn(2, 2), beta=-1.0)
 
     def test_cosine_similarity(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7034,7 +7034,7 @@ class TestNN(NNTestCase):
 
     def test_smoothl1loss_negative_beta_not_supported(self):
         with self.assertRaises(ValueError):
-            F.smooth_l1_loss(torch.randn(2,2), torch.randn(2,2), beta=-1.0)
+            F.smooth_l1_loss(torch.randn(2, 2), torch.randn(2, 2), beta=-1.0)
 
     def test_cosine_similarity(self):
         input1 = torch.randn(4, 4, requires_grad=True)

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -758,7 +758,7 @@ class MultiLabelMarginLoss(_Loss):
 
 class SmoothL1Loss(_Loss):
     r"""Creates a criterion that uses a squared term if the absolute
-    element-wise error falls below 1 and an L1 term otherwise.
+    element-wise error falls below beta and an L1 term otherwise.
     It is less sensitive to outliers than the `MSELoss` and in some cases
     prevents exploding gradients (e.g. see `Fast R-CNN` paper by Ross Girshick).
     Also known as the Huber loss:
@@ -779,6 +779,9 @@ class SmoothL1Loss(_Loss):
     the sum operation still operates over all the elements, and divides by :math:`n`.
 
     beta is an optional parameter that defaults to 1.
+
+    Note: When beta is set to 0, this is equivalent to we call out directly to :class:`L1Loss`.
+    Passing a negative value in for beta will result in an exception.
 
     The division by :math:`n` can be avoided if sets ``reduction = 'sum'``.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45588 remove beta defaulting in smooth_l1_loss_backward. added to the bc whitelist
* **#45587 some documentation and style fixes to smooth_l1_loss**

Differential Revision: [D24024313](https://our.internmc.facebook.com/intern/diff/D24024313)