### PR TITLE
setup: Only include dataclasses for py < 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -340,7 +340,11 @@ def build_deps():
 ################################################################################
 
 # the list of runtime dependencies required by this built package
-install_requires = ['future', 'typing_extensions', 'dataclasses']
+install_requires = [
+    'future',
+    'typing_extensions',
+    'dataclasses; python_version < "3.7"'
+]
 
 missing_pydep = '''
 Missing build dependency: Unable to `import {importname}`.

--- a/setup.py
+++ b/setup.py
@@ -343,7 +343,7 @@ def build_deps():
 install_requires = [
     'future',
     'typing_extensions',
-    'dataclasses; python_version < "3.7"'
+    'dataclasses; python_version < "3.8"'
 ]
 
 missing_pydep = '''


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45611 setup: Only include dataclasses for py < 3.8**

dataclasses was made a standard library item in 3.8

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D24031740](https://our.internmc.facebook.com/intern/diff/D24031740)