### PR TITLE
[JIT] Update JIT triage project board workflow

### DIFF
--- a/.github/workflows/jit_triage.yml
+++ b/.github/workflows/jit_triage.yml
@@ -19,7 +19,7 @@ jobs:
             // - io: A reference to the @actions/io package
 
             // Check if issue has a JIT label.
-            const kJitLabel = "jit";
+            const kJitLabel = "oncall: jit";
 
             issue = await github.issues.get({
               owner: context.issue.owner,


### PR DESCRIPTION
This commit updates `.github/workflows/jit_triage.yml` to use the new `oncall: jit` tag instead of the old `jit` tag.
