### PR TITLE
Optimize torch zeros

### DIFF
--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -106,7 +106,25 @@ Tensor& fill_diagonal_(Tensor& self, Scalar fill_value, bool wrap) {
   return self;
 }
 
+Tensor& zero_cpu_(Tensor &self, int64_t nelements) {
+  void* ptr = self.data_ptr();
+  if (nullptr == ptr) {
+    return self.fill_(0);
+  }
+  int64_t size_bytes = nelements * self.dtype().itemsize();
+  if (size_bytes > 0) {
+    std::memset(ptr, 0, size_bytes);
+  }
+  return self;
+}
+
 Tensor& zero_(Tensor &self) {
+  int64_t nelements = at::prod_intlist(self.sizes());
+  if (self.device() == at::kCPU &&
+      self.is_non_overlapping_and_dense() &&
+      nelements < internal::GRAIN_SIZE) {
+    return zero_cpu_(self, nelements);
+  }
   return self.fill_(0);
 }
 

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -80,6 +80,25 @@ void TestAdd(DeprecatedTypeProperties& type) {
   }
 }
 
+void TestZeros(DeprecatedTypeProperties& type) {
+  auto begin = std::chrono::high_resolution_clock::now();
+  Tensor a = zeros({1024, 1024}, type);
+  for (int i = 1; i < 1000; ++i) {
+    a = zeros({1024, 1024}, type);
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  std::cout << std::dec << "   "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(
+                   end - begin)
+                   .count()
+            << " ms" << std::endl;
+
+   std::srand(std::time(nullptr));
+   for (auto l = 0; l < 100; ++l) {
+     ASSERT_EQ(a[std::rand() % 1024][std::rand() % 1024].item<double>(), 0.0);
+   }
+}
+
 void TestLoadsOfAdds(DeprecatedTypeProperties& type) {
   auto begin = std::chrono::high_resolution_clock::now();
   Tensor d = ones({3, 4}, type);
@@ -309,6 +328,7 @@ void test(DeprecatedTypeProperties& type) {
   TestSort(type);
   TestRandperm(type);
   TestAdd(type);
+  TestZeros(type);
   TestLoadsOfAdds(type);
   TestLoadOfAddsWithCopy(type);
   TestIsContiguous(type);


### PR DESCRIPTION
Summary: After creating empty tensor 'memset' used to zero out items of tensor

Test Plan:
1. Use scripts/arvindkannan/benchmark.py
2. TestZeros in basic.cpp

OMP_NUM_THREADS=1 MKL_NUM_THREADS=1  buck test mode/opt caffe2/aten:basic -- --print-passing-details BasicTest.BasicTestCPU

TestZeros will print runtime for torch.zeros in milliseconds .

Before: 50975
After:    43469

pytorch benchmark tool results:

timer = benchmark_utils.Timer(stmt="torch.zeros((1024, 4096))")

Before: 1007 us
After:     841.26 us
1 measurement, 10000 runs , 1 thread

Differential Revision: D23925113

