### PR TITLE
Disable tcuda_fuser tests in Profiling Mode

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -804,5 +804,5 @@ class TestPassManagerCudaFuser(JitTestCase):
 
 
 if __name__ == '__main__':
-    if not TEST_WITH_ROCM:
+    if not TEST_WITH_ROCM and GRAPH_EXECUTOR != ProfilingMode.PROFILING:
         run_tests()


### PR DESCRIPTION
Disable tcuda_fuser tests in Profiling Mode to address flakey tests until fuser switches to the new approach.
