### PR TITLE
[StaticRuntime] Implement StaticRuntime::run_individual

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -34,6 +34,33 @@ class TORCH_API StaticRuntime {
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs) const;
 
+  void benchmark(
+      const std::vector<c10::IValue>& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs,
+      const int warmup_runs,
+      const int main_runs) const;
+
+  float benchmark_model(
+      const std::vector<c10::IValue>& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs,
+      const int warmup_runs,
+      const int main_runs) const;
+
+  struct IndividualMetrics {
+    float setup_time;
+    float total_time;
+    std::vector<float> time_per_node;
+    std::unordered_map<std::string, float> time_per_node_type;
+    std::unordered_map<std::string, float> percent_per_node_type;
+    std::unordered_map<std::string, int> instances_per_node_type;
+  };
+
+  IndividualMetrics benchmark_individual_ops(
+      const std::vector<c10::IValue>& args,
+      const std::unordered_map<std::string, c10::IValue>& kwargs,
+      const int warmup_runs,
+      const int main_runs) const;
+
 #ifdef FBCODE_CAFFE2
   using ConstantMap = folly::F14FastMap<Value*, IValue>;
 #else

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -6,18 +6,70 @@ namespace jit {
 
 void initStaticRuntimeBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
-  py::class_<StaticRuntime>(m, "StaticRuntime")
+  py::class_<StaticRuntime> static_runtime(m, "StaticRuntime");
+  py::class_<StaticRuntime::IndividualMetrics>(
+      static_runtime, "IndividualMetrics")
+      .def_readonly("setup_time", &StaticRuntime::IndividualMetrics::setup_time)
+      .def_readonly("total_time", &StaticRuntime::IndividualMetrics::total_time)
+      .def_readonly(
+          "time_per_node", &StaticRuntime::IndividualMetrics::time_per_node)
+      .def_readonly(
+          "time_per_node_type",
+          &StaticRuntime::IndividualMetrics::time_per_node_type)
+      .def_readonly(
+          "percent_per_node_type",
+          &StaticRuntime::IndividualMetrics::percent_per_node_type)
+      .def_readonly(
+          "instances_per_node_type",
+          &StaticRuntime::IndividualMetrics::instances_per_node_type);
+  static_runtime
       .def(
           "run",
           py::overload_cast<const std::vector<at::Tensor>&>(
-              &StaticRuntime::run, py::const_));
+              &StaticRuntime::run, py::const_))
+      .def(
+          "run",
+          [](StaticRuntime& self,
+             const std::vector<at::Tensor>& args,
+             const std::unordered_map<std::string, at::Tensor>& kwargs) {
+            std::vector<c10::IValue> arg_ivalues{args.begin(), args.end()};
+            std::unordered_map<std::string, c10::IValue> kwarg_ivalues{
+                kwargs.begin(), kwargs.end()};
+            c10::IValue ret = self.run(arg_ivalues, kwarg_ivalues);
+            return toPyObject(ret);
+          })
+      .def(
+          "benchmark",
+          [](StaticRuntime& self,
+             const std::vector<at::Tensor>& args,
+             const std::unordered_map<std::string, at::Tensor>& kwargs,
+             const int warmup_runs,
+             const int main_runs) {
+            std::vector<c10::IValue> arg_ivalues{args.begin(), args.end()};
+            std::unordered_map<std::string, c10::IValue> kwarg_ivalues{
+                kwargs.begin(), kwargs.end()};
+            self.benchmark(arg_ivalues, kwarg_ivalues, warmup_runs, main_runs);
+          })
+      .def(
+          "benchmark_individual_ops",
+          [](StaticRuntime& self,
+             const std::vector<at::Tensor>& args,
+             const std::unordered_map<std::string, at::Tensor>& kwargs,
+             const int warmup_runs,
+             const int main_runs) {
+            std::vector<c10::IValue> arg_ivalues{args.begin(), args.end()};
+            std::unordered_map<std::string, c10::IValue> kwarg_ivalues{
+                kwargs.begin(), kwargs.end()};
+            return self.benchmark_individual_ops(
+                arg_ivalues, kwarg_ivalues, warmup_runs, main_runs);
+          });
   m.def(
        "_jit_to_static_runtime",
        [](const std::shared_ptr<torch::jit::Graph>& g) {
          return StaticRuntime(PrepareForStaticRuntime(g));
        })
       .def("_jit_to_static_runtime", [](const torch::jit::Module& m) {
-        return StaticRuntime(PrepareForStaticRuntime(m));
+        return StaticRuntime(m);
       });
 }
 

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -6,14 +6,16 @@ namespace torch {
 namespace jit {
 
 bool canRunOutOfPlace(Node* n) {
+  static std::unordered_set<std::string> out_of_place_nodes{"aten::add",
+                                                            "aten::mul",
+                                                            "aten::addmm"
+                                                            "aten::bmm",
+                                                            "aten::sigmoid",
+                                                            "aten::cat",
+                                                            "aten::transpose",
+                                                            "aten::flatten"};
   auto str = std::string(n->kind().toQualString());
-  if ((str == "aten::add") || (str == "aten::mul") || (str == "aten::addmm") ||
-      (str == "aten::bmm") || (str == "aten::sigmoid") ||
-      (str == "aten::cat") || (str == "aten::transpose") ||
-      (str == "aten::flatten")) {
-    return true;
-  }
-  return false;
+  return out_of_place_nodes.count(str) > 0;
 }
 
 std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(


### PR DESCRIPTION
Summary: `StaticRuntime::run_individual` is to mimic the caffe2 operator benchmark `SimpleNet::TEST_Benchmark`, so we can accurate information on the operator breakdown. We found that the PyTorch AutogradProfiler adds a lot of overhead to small models, such as the adindexer precomputation_merge net, 100% for batch_size 1, 33% for batch_size 20. This implementation adds very little overhead, as shown in the test plan.

Test Plan: Test results are fb internal only.

Differential Revision: D24012088

