### PR TITLE
Fix the bucketization wrong doc for right argument

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9581,16 +9581,16 @@ satisfies the following rules:
      - *returned index satisfies*
    * - 1-D
      - False
-     - ``sorted_sequence[i-1] <= values[m][n]...[l][x] < sorted_sequence[i]``
+     - ``sorted_sequence[i-1] < values[m][n]...[l][x] <= sorted_sequence[i]``
    * - 1-D
      - True
-     - ``sorted_sequence[i-1] < values[m][n]...[l][x] <= sorted_sequence[i]``
+     - ``sorted_sequence[i-1] <= values[m][n]...[l][x] < sorted_sequence[i]``
    * - N-D
      - False
-     - ``sorted_sequence[m][n]...[l][i-1] <= values[m][n]...[l][x] < sorted_sequence[m][n]...[l][i]``
+     - ``sorted_sequence[m][n]...[l][i-1] < values[m][n]...[l][x] <= sorted_sequence[m][n]...[l][i]``
    * - N-D
      - True
-     - ``sorted_sequence[m][n]...[l][i-1] < values[m][n]...[l][x] <= sorted_sequence[m][n]...[l][i]``
+     - ``sorted_sequence[m][n]...[l][i-1] <= values[m][n]...[l][x] < sorted_sequence[m][n]...[l][i]``
 
 Args:
     sorted_sequence (Tensor): N-D or 1-D tensor, containing monotonically increasing sequence on the *innermost*
@@ -9654,9 +9654,9 @@ formally, the returned index satisfies the following rules:
    * - :attr:`right`
      - *returned index satisfies*
    * - False
-     - ``boundaries[i-1] <= input[m][n]...[l][x] < boundaries[i]``
-   * - True
      - ``boundaries[i-1] < input[m][n]...[l][x] <= boundaries[i]``
+   * - True
+     - ``boundaries[i-1] <= input[m][n]...[l][x] < boundaries[i]``
 
 Args:
     input (Tensor or Scalar): N-D tensor or a Scalar containing the search value(s).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45684 Fix the bucketization wrong doc for right argument**

This is to fix the issue in #43458

![bucketization screen](https://user-images.githubusercontent.com/32228059/94874653-7bf43a80-0420-11eb-91b2-4c1af2c6e19d.png)

![searchsorted screen](https://user-images.githubusercontent.com/32228059/94874655-7dbdfe00-0420-11eb-9479-3e5961646272.png)

Differential Revision: [D24057996](https://our.internmc.facebook.com/intern/diff/D24057996)