### PR TITLE
[static runtime] Silence deprecation warnings with resize_

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -35,6 +35,7 @@ std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(
         ws.emplace(out, create_empty_from(in0_t));
       }
       auto out_t = ws.at(out).toTensor();
+      out_t.resize_(0);
       at::native::add_out(out_t, in0_t, in1_t, in2_s);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::mul")) {
@@ -48,6 +49,7 @@ std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(
         ws.emplace(out, create_empty_from(in0_t));
       }
       auto out_t = ws.at(out).toTensor();
+      out_t.resize_(0);
       at::native::mul_out(out_t, in0_t, in1_t);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::addmm")) {
@@ -67,6 +69,7 @@ std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(
         ws.emplace(out, create_empty_from(in0_t));
       }
       auto out_t = ws.at(out).toTensor();
+      out_t.resize_(0);
       at::native::addmm_cpu_out(out_t, in0_t, in1_t, in2_t, in3_s, in4_s);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::clamp")) {
@@ -82,6 +85,7 @@ std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(
         ws.emplace(out, create_empty_from(in0_t));
       }
       auto out_t = ws.at(out).toTensor();
+      out_t.resize_(0);
       at::native::clamp_out(out_t, in0_t, in1_s, in2_s);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::bmm")) {
@@ -95,6 +99,7 @@ std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(
         ws.emplace(out, create_empty_from(in0_t));
       }
       auto out_t = ws.at(out).toTensor();
+      out_t.resize_(0);
       at::native::bmm_out_cpu(out_t, in0_t, in1_t);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::cat")) {
@@ -108,6 +113,7 @@ std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(
         ws.emplace(out, create_empty_from(in0_tl[0]));
       }
       auto out_t = ws.at(out).toTensor();
+      out_t.resize_(0);
       at::native::_cat_out_cpu(out_t, in0_tl, in1_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::sigmoid")) {
@@ -119,6 +125,7 @@ std::function<void(StaticRuntime::ConstantMap&)> getOutOfPlaceOperation(
         ws.emplace(out, create_empty_from(in0_t));
       }
       auto out_t = ws.at(out).toTensor();
+      out_t.resize_(0);
       at::native::sigmoid_out(out_t, in0_t);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::transpose")) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45694 [static runtime] Silence deprecation warnings with resize_**

```
With resize_(0)

(env) bwasti@ip-172-31-3-220:/mnt/ssd1/bwasti/pytorch$ numactl -C2 ./build/bin/static_runtime_bench
2020-10-01 21:18:23
Running ./build/bin/static_runtime_bench
Run on (96 X 2655.35 MHz CPU s)
CPU Caches:
  L1 Data 32K (x48)
  L1 Instruction 32K (x48)
  L2 Unified 1024K (x48)
  L3 Unified 33792K (x2)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_deep_wide_base/1                         41328 ns      41328 ns      17125
BM_deep_wide_base/8                         44050 ns      44049 ns      15828
BM_deep_wide_base/20                        45065 ns      45065 ns      15558
BM_deep_wide_jit_graph_executor/1           36662 ns      36661 ns      18939
BM_deep_wide_jit_graph_executor/8           38583 ns      38583 ns      17945
BM_deep_wide_jit_graph_executor/20          40060 ns      40059 ns      17514
BM_deep_wide_jit_profiling_executor/1       36568 ns      36567 ns      18996
BM_deep_wide_jit_profiling_executor/8       38383 ns      38382 ns      18129
BM_deep_wide_jit_profiling_executor/20      40040 ns      40039 ns      17556
BM_deep_wide_static/1                       20757 ns      20757 ns      33654
BM_deep_wide_static/8                       22956 ns      22956 ns      31241
BM_deep_wide_static/20                      24113 ns      24113 ns      29046
BM_deep_wide_static_threaded/threads:8      18306 ns      19181 ns      36464

Without resize_(0)

(env) bwasti@ip-172-31-3-220:/mnt/ssd1/bwasti/pytorch$ numactl -C2 ./build/bin/static_runtime_bench
2020-10-01 21:20:42
Running ./build/bin/static_runtime_bench
Run on (96 X 2643.59 MHz CPU s)
CPU Caches:
  L1 Data 32K (x48)
  L1 Instruction 32K (x48)
  L2 Unified 1024K (x48)
  L3 Unified 33792K (x2)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_deep_wide_base/1                         40923 ns      40922 ns      17250
BM_deep_wide_base/8                         43505 ns      43504 ns      16289
BM_deep_wide_base/20                        44529 ns      44528 ns      15704
BM_deep_wide_jit_graph_executor/1           36047 ns      36047 ns      19319
BM_deep_wide_jit_graph_executor/8           37661 ns      37660 ns      18422
BM_deep_wide_jit_graph_executor/20          39056 ns      39055 ns      17950
BM_deep_wide_jit_profiling_executor/1       36198 ns      36197 ns      19268
BM_deep_wide_jit_profiling_executor/8       37777 ns      37776 ns      18602
BM_deep_wide_jit_profiling_executor/20      39103 ns      39102 ns      17922
BM_deep_wide_static/1                       18371 ns      18371 ns      37641
BM_deep_wide_static/8                       20381 ns      20380 ns      34327
BM_deep_wide_static/20                      21879 ns      21879 ns      32137
BM_deep_wide_static_threaded/threads:8      16461 ns      17175 ns      40272
```