### PR TITLE
[FX] Make Tracer.trace() just return a Graph

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -369,7 +369,7 @@ class TestQuantizeFx(QuantizationTestCase):
         original_ref_m.conv2.weight = torch.nn.Parameter(original_m.standalone.conv.weight.detach())
         original_ref_m.conv2.bias = torch.nn.Parameter(original_m.standalone.conv.bias.detach())
 
-        m = CustomTracer().trace(original_m).eval()
+        m = torch.fx.GraphModule(original_m, CustomTracer().trace(original_m)).eval()
         qconfig_dict = {'': default_qconfig, 'standalone_module_name': ['standalone']}
         # check prepared model
         m = prepare_fx(m, qconfig_dict)
@@ -762,7 +762,7 @@ class TestQuantizeFx(QuantizationTestCase):
             register_observed_custom_module_mapping(CustomModule, ObservedCustomModule)
             register_quantized_custom_module_mapping(CustomModule, QuantizedCustomModule)
 
-            m = CustomTracer().trace(original_m).eval()
+            m = torch.fx.GraphModule(original_m, CustomTracer().trace(original_m)).eval()
             qconfig_dict = {'': default_qconfig}
             # check prepared model
             m = prepare_fx(m, qconfig_dict)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -169,9 +169,9 @@ class TestFX(JitTestCase):
 
         mrm = MyReluMod()
         sym = NoLeafModulesTracer().trace(mrm)
-        for node in sym.graph.nodes:
+        for node in sym.nodes:
             self.assertNotEqual(node.op, 'call_module')
-        sym.graph.lint(sym)
+        sym.lint(sym)
 
     def test_graph_edit_with_proxy(self):
         class M(torch.nn.Module):
@@ -435,7 +435,7 @@ class TestFX(JitTestCase):
                 return a + b
 
         m = M()
-        g = TaggingTracer().trace(m).graph
+        g = TaggingTracer().trace(m)
         g.lint(m)
         for n in g.nodes:
             self.assertTrue(hasattr(n, 'tag'))

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -59,7 +59,8 @@ def deserialize_graphmodule(body : dict) -> torch.nn.Module:
         def is_leaf_module(self, _: torch.nn.Module, __: str) -> bool:
             return True
 
-    return KeepModules().trace(CodeOnlyModule(body))
+    com = CodeOnlyModule(body)
+    return GraphModule(com, KeepModules().trace(com))
 
 # copy an attribute value with qualified name 'target' from 'from_module' to 'to_module'
 # This installs empty Modules where none exist yet if they are subpaths of target

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -152,7 +152,7 @@ class Tracer(TracerBase):
             self.graph.output(self.create_arg(fn(*args)))
         finally:
             torch.nn.Module.__call__ = orig_call
-        return GraphModule(root, self.graph)
+        return self.graph
 
     def _proxy_placeholder(self, name: str) -> Proxy:
         return Proxy(self.create_node('placeholder', name, (), {}), self)
@@ -165,4 +165,4 @@ class Tracer(TracerBase):
 # Args:
 #   - root - the `nn.Module` instance to trace
 def symbolic_trace(root : torch.nn.Module) -> GraphModule:
-    return Tracer().trace(root)
+    return GraphModule(root, Tracer().trace(root))

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -119,7 +119,7 @@ class Tracer(TracerBase):
         """
         return m.__module__.startswith('torch.nn') and not isinstance(m, torch.nn.Sequential)
 
-    def trace(self, root: torch.nn.Module) -> GraphModule:
+    def trace(self, root: torch.nn.Module) -> Graph:
         self.root = root
         self.graph = Graph()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45704 [FX] Make Tracer.trace() just return a Graph**

Adds another layer of customizability. This allows people to do things like wrap up a Graph in a custom subclass of GraphModule, etc.

Closes https://github.com/pytorch/pytorch/issues/45534 

Differential Revision: [D24067982](https://our.internmc.facebook.com/intern/diff/D24067982)