### PR TITLE
[te] Get llvm codegen to compile with llvm9 and llvm-fb

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -77,7 +77,7 @@ llvm::CmpInst::Predicate llvm_comparison_predicate(
 
 class LLVMCodeGenImpl : public IRVisitor {
  private:
-  llvm::orc::ThreadSafeContext context_;
+  std::unique_ptr<llvm::LLVMContext> context_;
   llvm::IRBuilder<> irb_;
   std::unique_ptr<llvm::TargetMachine> TM_;
   std::unique_ptr<llvm::orc::PytorchLLVMJIT> jit_;
@@ -313,8 +313,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   emitWrapper(params);
   emitKernel(stmt, params);
 
-  cantFail(jit_->addModule(
-      llvm::orc::ThreadSafeModule(std::move(module_), context_)));
+  cantFail(jit_->addModule(std::move(module_), std::move(context_)));
   auto sym = jit_->findSymbol("wrapper");
   kernelAddress_ = cantFail(sym.getAddress());
   argv_ = std::make_unique<void*[]>(params.size());
@@ -323,7 +322,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
 }
 
 llvm::LLVMContext& LLVMCodeGenImpl::getContext() {
-  return *context_.getContext();
+  return *context_;
 }
 
 llvm::Type* LLVMCodeGenImpl::dtypeToLLVM(Dtype dtype) {
@@ -973,7 +972,7 @@ void LLVMCodeGenImpl::visit(const Load* v) {
       auto addr = irb_.CreateGEP(base, first_idx);
       auto vaddr = irb_.CreateBitOrPointerCast(
           addr, llvm::PointerType::get(loadType, 0));
-      value_ = irb_.CreateAlignedLoad(loadType, vaddr, 4);
+      value_ = irb_.CreateAlignedLoad(vaddr, 4);
       return;
     }
   }
@@ -1221,13 +1220,47 @@ void LLVMCodeGenImpl::visit(const BaseCallNode* v) {
 
 static void applyMathFunctionAttributes(llvm::Function* f) {
   f->addFnAttr(llvm::Attribute::ReadNone);
-  f->addFnAttr(llvm::Attribute::NoFree);
   f->addFnAttr(llvm::Attribute::NoUnwind);
   // TODO: Adding this attr should be correct, but as of LLVM 9.0.1 adding it
   // causes some math functions to incorrectly be turned into tail calls.
   // f->addFnAttr(llvm::Attribute::Speculatable);
+#if LLVM_VERSION_MAJOR == 9
+  f->addFnAttr(llvm::Attribute::NoFree);
   f->addFnAttr(llvm::Attribute::WillReturn);
+#endif
 }
+
+namespace {
+#if LLVM_VERSION_MAJOR == 9
+
+using FunctionCallee = llvm::FunctionCallee;
+
+#elif LLVM_VERSION_MAJOR == 8 && LLVM_VERSION_PATCH == 20181009
+
+struct FunctionCallee {
+  FunctionCallee() {}
+
+  FunctionCallee(llvm::Constant* fn)
+      : v_(fn), ft_(cast<llvm::Function>(v_)->getFunctionType()) {}
+
+  llvm::FunctionType* getFunctionType() {
+    return ft_;
+  }
+
+  llvm::Value* getCallee() {
+    return v_;
+  }
+
+ private:
+  llvm::Value* v_{nullptr};
+  llvm::FunctionType* ft_{nullptr};
+};
+
+#else
+#error Only LLVM versions 8 or 9 are supported.
+#endif
+
+} // namespace
 
 void LLVMCodeGenImpl::visit(const Intrinsics* v) {
   llvm::FunctionType* call_ty = nullptr;
@@ -1250,7 +1283,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #if defined(__AVX__) && !defined(_MSC_VER)
 #define SIMD_UNARY_MATH_CASE(enum, name, type)                               \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 8) {                                           \
       fname = "Sleef_" + std::string(name) + "8";                            \
@@ -1275,7 +1308,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #else
 #define SIMD_UNARY_MATH_CASE(enum, name, type)                               \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 4) {                                           \
       fname = "Sleef_" + std::string(name) + "4";                            \
@@ -1321,7 +1354,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #if defined(__AVX__) && !defined(_MSC_VER)
 #define SIMD_BINARY_MATH_CASE(enum, name, type)                              \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 8) {                                           \
       fname = "Sleef_" + std::string(name) + "8";                            \
@@ -1350,7 +1383,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #else
 #define SIMD_BINARY_MATH_CASE(enum, name, type)                              \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 4) {                                           \
       fname = "Sleef_" + std::string(name) + "4";                            \
@@ -1374,16 +1407,15 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
         SIMD_BINARY_MATH_CASE(kFmod, "fmodf", FloatTy_)
 #undef SIMD_BINARY_MATH_CASE
 
-#define BINARY_MATH_CASE(enum, name, type)                             \
-  case enum: {                                                         \
-    auto callee = module_->getOrInsertFunction(                        \
-        name, llvm::FunctionType::get(type, {type, type}, false), {}); \
-    call_ty = callee.getFunctionType();                                \
-    call_fn = callee.getCallee();                                      \
-    applyMathFunctionAttributes(llvm::cast<llvm::Function>(call_fn));  \
-  } break;
-        BINARY_MATH_CASE(kRemainder, "remainderf", FloatTy_)
-#undef BINARY_MATH_CASE
+      case kRemainder: {
+        FunctionCallee callee = module_->getOrInsertFunction(
+            "remainderf",
+            llvm::FunctionType::get(FloatTy_, {FloatTy_, FloatTy_}, false),
+            {});
+        call_ty = callee.getFunctionType();
+        call_fn = callee.getCallee();
+        applyMathFunctionAttributes(llvm::cast<llvm::Function>(call_fn));
+      } break;
 
       default: {
         throw unimplemented_lowering(v);
@@ -1395,7 +1427,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #if defined(__AVX__) && !defined(_MSC_VER)
 #define SIMD_UNARY_MATH_CASE(enum, name, type)                               \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 4) {                                           \
       fname = "Sleef_" + std::string(name) + "d4";                           \
@@ -1420,7 +1452,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #else
 #define SIMD_UNARY_MATH_CASE(enum, name, type)                               \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 2) {                                           \
       fname = "Sleef_" + std::string(name) + "d2";                           \
@@ -1477,7 +1509,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #if defined(__AVX__) && !defined(_MSC_VER)
 #define SIMD_BINARY_MATH_CASE(enum, name, type)                              \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 4) {                                           \
       fname = "Sleef_" + std::string(name) + "d4";                           \
@@ -1506,7 +1538,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 #else
 #define SIMD_BINARY_MATH_CASE(enum, name, type)                              \
   case enum: {                                                               \
-    llvm::FunctionCallee callee;                                             \
+    FunctionCallee callee;                                                   \
     std::string fname;                                                       \
     if (v->dtype().lanes() == 2) {                                           \
       fname = "Sleef_" + std::string(name) + "d2";                           \
@@ -1532,7 +1564,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
 
 #define BINARY_MATH_CASE(enum, name, type)                             \
   case enum: {                                                         \
-    auto callee = module_->getOrInsertFunction(                        \
+    FunctionCallee callee = module_->getOrInsertFunction(              \
         name, llvm::FunctionType::get(type, {type, type}, false), {}); \
     call_ty = callee.getFunctionType();                                \
     call_fn = callee.getCallee();                                      \

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -2,7 +2,23 @@
 
 #include <torch/csrc/jit/tensorexpr/llvm_jit.h>
 
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/JITSymbol.h>
+#include <llvm/ExecutionEngine/Orc/CompileUtils.h>
+#include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
+#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/LambdaResolver.h>
+#include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/Orc/SymbolStringPool.h>
+#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/Mangler.h>
+#include <llvm/Support/DynamicLibrary.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Target/TargetMachine.h>
+
 #include <sleef.h>
 #include <algorithm>
 #include <memory>
@@ -14,6 +30,7 @@ namespace orc {
 
 // Lightly modified implementation from LLVM's Kaleidoscope JIT tutorial:
 // https://llvm.org/docs/tutorial/BuildingAJIT1.html
+#if LLVM_VERSION_MAJOR == 9
 class TORCH_API PytorchLLVMJITImpl {
  private:
   std::unique_ptr<LLJIT> LLJ;
@@ -420,8 +437,9 @@ class TORCH_API PytorchLLVMJITImpl {
 #endif
   }
 
-  Error addModule(ThreadSafeModule M) {
-    if (auto Err = LLJ->addIRModule(std::move(M))) {
+  Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> C) {
+    if (auto Err =
+            LLJ->addIRModule(ThreadSafeModule(std::move(M), std::move(C)))) {
       return Err;
     }
     return Error::success();
@@ -441,8 +459,10 @@ PytorchLLVMJIT::PytorchLLVMJIT()
 
 PytorchLLVMJIT::~PytorchLLVMJIT() = default;
 
-Error PytorchLLVMJIT::addModule(ThreadSafeModule M) {
-  return impl_->addModule(std::move(M));
+Error PytorchLLVMJIT::addModule(
+    std::unique_ptr<Module> M,
+    std::unique_ptr<LLVMContext> C) {
+  return impl_->addModule(std::move(M), std::move(C));
 }
 
 JITSymbol PytorchLLVMJIT::findSymbol(const std::string Name) {
@@ -452,6 +472,99 @@ JITSymbol PytorchLLVMJIT::findSymbol(const std::string Name) {
 const DataLayout& PytorchLLVMJIT::getDataLayout() {
   return impl_->getDataLayout();
 }
+
+#elif LLVM_VERSION_MAJOR == 8 && LLVM_VERSION_PATCH == 20181009
+
+class TORCH_API PytorchLLVMJITImpl {
+ private:
+  ExecutionSession ES;
+  std::shared_ptr<SymbolResolver> Resolver;
+  std::unique_ptr<TargetMachine> TM;
+  const DataLayout DL;
+  RTDyldObjectLinkingLayer ObjectLayer;
+  IRCompileLayer<decltype(ObjectLayer), SimpleCompiler> CompileLayer;
+
+ public:
+  PytorchLLVMJITImpl()
+      : Resolver(createLegacyLookupResolver(
+            ES,
+            [this](const std::string& Name) -> JITSymbol {
+              if (auto Sym = CompileLayer.findSymbol(Name, false))
+                return Sym;
+              else if (auto Err = Sym.takeError())
+                return std::move(Err);
+              if (auto SymAddr =
+                      RTDyldMemoryManager::getSymbolAddressInProcess(Name))
+                return JITSymbol(SymAddr, JITSymbolFlags::Exported);
+              return nullptr;
+            },
+            [](Error Err) { cantFail(std::move(Err), "lookupFlags failed"); })),
+        TM(EngineBuilder().selectTarget()),
+        DL(TM->createDataLayout()),
+        ObjectLayer(
+            ES,
+            [this](VModuleKey) {
+              return RTDyldObjectLinkingLayer::Resources{
+                  std::make_shared<SectionMemoryManager>(), Resolver};
+            }),
+        CompileLayer(ObjectLayer, SimpleCompiler(*TM)) {
+    llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
+  }
+
+  TargetMachine& getTargetMachine() {
+    return *TM;
+  }
+
+  VModuleKey addModule(std::unique_ptr<Module> M) {
+    // Add the module to the JIT with a new VModuleKey.
+    auto K = ES.allocateVModule();
+    cantFail(CompileLayer.addModule(K, std::move(M)));
+    return K;
+  }
+
+  JITSymbol findSymbol(const std::string Name) {
+    std::string MangledName;
+    raw_string_ostream MangledNameStream(MangledName);
+    Mangler::getNameWithPrefix(MangledNameStream, Name, DL);
+    return CompileLayer.findSymbol(MangledNameStream.str(), true);
+  }
+
+  JITTargetAddress getSymbolAddress(const std::string Name) {
+    return cantFail(findSymbol(Name).getAddress());
+  }
+
+  void removeModule(VModuleKey K) {
+    cantFail(CompileLayer.removeModule(K));
+  }
+
+  const DataLayout& getDataLayout() {
+    return DL;
+  }
+};
+
+PytorchLLVMJIT::PytorchLLVMJIT()
+    : impl_(std::make_unique<PytorchLLVMJITImpl>()) {}
+
+PytorchLLVMJIT::~PytorchLLVMJIT() = default;
+
+Error PytorchLLVMJIT::addModule(
+    std::unique_ptr<Module> M,
+    std::unique_ptr<LLVMContext> C) {
+  impl_->addModule(std::move(M));
+  return Error::success();
+}
+
+JITSymbol PytorchLLVMJIT::findSymbol(const std::string Name) {
+  return impl_->findSymbol(std::move(Name));
+}
+
+const DataLayout& PytorchLLVMJIT::getDataLayout() {
+  return impl_->getDataLayout();
+}
+
+#else // LLVM_VERSION_MAJOR
+#error Only LLVM versions 8 or 9 are supported.
+#endif
 
 } // end namespace orc
 } // end namespace llvm

--- a/torch/csrc/jit/tensorexpr/llvm_jit.h
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.h
@@ -21,11 +21,12 @@ class TORCH_API PytorchLLVMJIT {
   PytorchLLVMJIT();
   ~PytorchLLVMJIT();
 
-  Error addModule(ThreadSafeModule M);
+  Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> C);
 
   JITSymbol findSymbol(const std::string Name);
 
   TargetMachine& getTargetMachine();
+
   const DataLayout& getDataLayout();
 
  private:


### PR DESCRIPTION
Summary:
FB has an old internal platform that uses some random llvm version
that looks sort of like llvm 7.  I've guarded that with the appropriate
LLVM_VERSION_PATCH.

I've also swapped out some of our uses of ThreadSafeModule/ThreadSafeContext
for the variants without ThreadSafe in the name.  As far as I can tell we
weren't using the bundled locks anyways, but I'm like 85% sure this is OK since
we compile under the Torch JIT lock anyways.

Test Plan: unit tests

Differential Revision: D24072697

