### PR TITLE
[v1.7.0 Patch] SET USE_DISTRIBUTED OFF when libuv is not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,9 +227,29 @@ option(ONNX_ML "Enable traditional ONNX ML API." ON)
 option(HAVE_SOVERSION "Whether to add SOVERSION to the shared objects" OFF)
 
 # Since TensorPipe does not support Windows, set it to OFF when WIN32 detected
+# On Windows platform, if user does not install libuv in build conda env and
+# does not set libuv_ROOT environment variable. Set USE_DISTRIBUTED to OFF.
 if(WIN32)
   set(USE_TENSORPIPE OFF)
   message(WARNING "TensorPipe cannot be used on Windows. Set it to OFF")
+
+  if(USE_DISTRIBUTED AND NOT DEFINED ENV{libuv_ROOT})
+    find_library(
+      libuv_tmp_LIBRARY
+      NAMES uv libuv
+      HINTS $ENV{CONDA_PREFIX}\\Library
+      PATH_SUFFIXES lib
+      REQUIRED
+      NO_DEFAULT_PATH)
+    if(NOT EXISTS ${libuv_tmp_LIBRARY})
+      set(USE_DISTRIBUTED OFF)
+      set(USE_GLOO OFF)
+      message(
+        WARNING "Libuv is not installed in current conda env. Set USE_DISTRIBUTED to OFF.")
+    else()
+      set(ENV{libuv_ROOT} $ENV{CONDA_PREFIX}\\Library)
+    endif()
+  endif()
 endif()
 
 # Linux distributions do not want too many embedded sources, in that sense we
@@ -290,12 +310,6 @@ set(OP_DEPENDENCY "" CACHE STRING
 # https://software.intel.com/en-us/articles/symbol-lookup-error-when-linking-intel-mkl-with-gcc-on-ubuntu
 if(LINUX)
   set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")
-endif()
-
-if(WIN32 AND USE_DISTRIBUTED)
-  if(NOT DEFINED ENV{libuv_ROOT})
-    set(ENV{libuv_ROOT} $ENV{CONDA_PREFIX}\\Library)
-  endif()
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Summary:
Note: This PR has been merged into master after the 1.7.0 branch cut at
 ffd50b82201effa13c8272729e7f8bfc9b7e0884 (see original PR: #45554). This PR is to cherry pick it into 1.7.0.

---- Original Commit Description Follows ---

Pull Request resolved: https://github.com/pytorch/pytorch/pull/45554

Reviewed By: izdeby

Differential Revision: D24016825

Pulled By: mrshenli

fbshipit-source-id: 332d860429626a915c06f98cad31e6db1cbc4eb1

Fixes #{issue number}
