### PR TITLE
unify reproducibility notes

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -3,6 +3,7 @@
 import torch._C
 from torch._C import _add_docstr as add_docstr
 from ._torch_docs import parse_kwargs
+from ._torch_docs import reproducibility_notes
 
 
 def add_docstr_all(method, docstr):
@@ -1628,12 +1629,7 @@ length of :attr:`index` (which must be a vector), and all other dimensions must
 match :attr:`self`, or an error will be raised.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {forward_reproducibility_note}
 
 Args:
     dim (int): dimension along which to index
@@ -1651,7 +1647,7 @@ Example::
             [  8.,   9.,  10.],
             [  1.,   1.,   1.],
             [  5.,   6.,   7.]])
-""")
+""".format(**reproducibility_notes))
 
 add_docstr_all('index_copy_',
                r"""
@@ -2960,9 +2956,6 @@ is updated as::
 Reducing with the addition operation is the same as using
 :meth:`~torch.Tensor.scatter_add_`.
 
-Note:
-    Reduction is not yet implemented for the CUDA backend.
-
 Args:
     dim (int): the axis along which to index
     index (LongTensor): the indices of elements to scatter,
@@ -3020,12 +3013,7 @@ dimensions ``d``, and that ``index.size(d) <= self.size(d)`` for all dimensions
 ``d != dim``.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {forward_reproducibility_note}
 
 Args:
     dim (int): the axis along which to index
@@ -3045,7 +3033,7 @@ Example::
             [1.0000, 1.0427, 1.0000, 1.6782, 1.0000],
             [1.7953, 1.0000, 1.6480, 1.0000, 1.9620]])
 
-""")
+""".format(**reproducibility_notes))
 
 add_docstr_all('select',
                r"""

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -110,6 +110,20 @@ tf32_notes = {
     "tf32_note": """This operator supports :ref:`TensorFloat32<tf32_on_ampere>`."""
 }
 
+
+reproducibility_notes = {
+    "forward_reproducibility_note": """When using the CUDA backend, this operation may induce nondeterministic \
+behavior that cannot be switched off. Please see the notes on :doc:`/notes/randomness` for background.""",
+    "backward_reproducibility_note": """When using the CUDA backend, this operation may induce nondeterministic \
+behavior in its backward pass that is not easily switched off. \
+Please see the notes on :doc:`/notes/randomness` for background. """,
+    "cudnn_reproducibility_note": """In some circumstances when using the CUDA backend with CuDNN, this operator \
+may select a nondeterministic algorithm to increase performance. If this is \
+undesirable, you can try to make the operation deterministic (potentially at \
+a performance cost) by setting ``torch.backends.cudnn.deterministic = True``. \
+Please see the notes on :doc:`/notes/randomness` for background."""
+}
+
 add_docstr(torch.abs, r"""
 abs(input, *, out=None) -> Tensor
 
@@ -938,12 +952,7 @@ tensor of size 0. If :attr:`minlength` is specified, the number of bins is at le
 ``out[n] += 1``.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {backward_reproducibility_note}
 
 Arguments:
     input (Tensor): 1-d int tensor
@@ -968,7 +977,7 @@ Example::
 
     >>> input.bincount(weights)
     tensor([0.0000, 0.0000, 0.0000, 1.0000, 1.0000, 0.0000, 0.5000])
-""")
+""".format(**reproducibility_notes))
 
 add_docstr(torch.bitwise_not,
            r"""

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -114,7 +114,7 @@ tf32_notes = {
 reproducibility_notes = {
     "forward_reproducibility_note": """This operation may behave nondeterministically when given tensors on \
 a CUDA device. See :doc:`/notes/randomness` for more information.""",
-    "backward_reproducibility_note": """Backward of operation may behave nondeterministically when given tensors on \
+    "backward_reproducibility_note": """This operation may produce nondeterministic gradients when given tensors on \
 a CUDA device. See :doc:`/notes/randomness` for more information.""",
     "cudnn_reproducibility_note": """In some circumstances when given tensors on a CUDA device \
 and using CuDNN, this operator may select a nondeterministic algorithm to increase performance. If this is \

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -112,16 +112,15 @@ tf32_notes = {
 
 
 reproducibility_notes = {
-    "forward_reproducibility_note": """When using the CUDA backend, this operation may induce nondeterministic \
-behavior that cannot be switched off. Please see the notes on :doc:`/notes/randomness` for background.""",
-    "backward_reproducibility_note": """When using the CUDA backend, this operation may induce nondeterministic \
-behavior in its backward pass that is not easily switched off. \
-Please see the notes on :doc:`/notes/randomness` for background. """,
-    "cudnn_reproducibility_note": """In some circumstances when using the CUDA backend with CuDNN, this operator \
-may select a nondeterministic algorithm to increase performance. If this is \
+    "forward_reproducibility_note": """This operation may behave nondeterministically when given tensors on \
+a CUDA device. See :doc:`/notes/randomness` for more information.""",
+    "backward_reproducibility_note": """Backward of operation may behave nondeterministically when given tensors on \
+a CUDA device. See :doc:`/notes/randomness` for more information.""",
+    "cudnn_reproducibility_note": """In some circumstances when given tensors on a CUDA device \
+and using CuDNN, this operator may select a nondeterministic algorithm to increase performance. If this is \
 undesirable, you can try to make the operation deterministic (potentially at \
 a performance cost) by setting ``torch.backends.cudnn.deterministic = True``. \
-Please see the notes on :doc:`/notes/randomness` for background."""
+See :doc:`/notes/randomness` for more information."""
 }
 
 add_docstr(torch.abs, r"""

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -11,6 +11,7 @@ from . import grad  # noqa: F401
 from torch import _VF
 from .._jit_internal import boolean_dispatch, List, Optional, _overload, Tuple
 from ..overrides import has_torch_function, handle_torch_function
+from torch._torch_docs import reproducibility_notes
 
 
 Tensor = torch.Tensor
@@ -1831,6 +1832,7 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2.,
                  [ 0.0000,  0.0000,  0.0000],
                  [ 0.6262,  0.2438,  0.7471]]])
     """
+
     if padding_idx is not None:
         if padding_idx > 0:
             assert padding_idx < weight.size(0), 'Padding_idx must be within num_embeddings'
@@ -1862,9 +1864,7 @@ def embedding_bag(input, weight, offsets=None, max_norm=None, norm_type=2,
     See :class:`torch.nn.EmbeddingBag` for more details.
 
     Note:
-        When using the CUDA backend, this operation may induce nondeterministic
-        behaviour in its backward pass that is not easily switched off.
-        Please see the notes on :doc:`/notes/randomness` for background.
+        {backward_reproducibility_note}
 
     Args:
         input (LongTensor): Tensor containing bags of indices into the embedding matrix
@@ -1932,6 +1932,7 @@ def embedding_bag(input, weight, offsets=None, max_norm=None, norm_type=2,
         tensor([[ 0.3397,  0.3552,  0.5545],
                 [ 0.5893,  0.4386,  0.5882]])
     """
+
     if not torch.jit.is_scripting():
         tens_ops = (input, weight)
         if any([type(t) is not Tensor for t in tens_ops]) and has_torch_function(tens_ops):
@@ -2017,6 +2018,8 @@ def embedding_bag(input, weight, offsets=None, max_norm=None, norm_type=2,
         per_sample_weights,
         include_last_offset)
     return ret
+
+embedding_bag.__doc__ = embedding_bag.__doc__.format(**reproducibility_notes)
 
 
 def _verify_batch_size(size):
@@ -2152,17 +2155,10 @@ def ctc_loss(log_probs, targets, input_lengths, target_lengths, blank=0,
     See :class:`~torch.nn.CTCLoss` for details.
 
     Note:
-        In some circumstances when using the CUDA backend with CuDNN, this operator
-        may select a nondeterministic algorithm to increase performance. If this is
-        undesirable, you can try to make the operation deterministic (potentially at
-        a performance cost) by setting ``torch.backends.cudnn.deterministic =
-        True``.
-        Please see the notes on :doc:`/notes/randomness` for background.
+        {cudnn_reproducibility_note}
 
     Note:
-        When using the CUDA backend, this operation may induce nondeterministic
-        behaviour in its backward pass that is not easily switched off.
-        Please see the notes on :doc:`/notes/randomness` for background.
+        {backward_reproducibility_note}
 
     Args:
         log_probs: :math:`(T, N, C)` where `C = number of characters in alphabet including blank`,
@@ -2199,6 +2195,7 @@ def ctc_loss(log_probs, targets, input_lengths, target_lengths, blank=0,
     """
     return torch.ctc_loss(log_probs, targets, input_lengths, target_lengths, blank, _Reduction.get_enum(reduction),
                           zero_infinity)
+ctc_loss.__doc__ = ctc_loss.__doc__.format(**reproducibility_notes)
 
 
 def nll_loss(input, target, weight=None, size_average=None, ignore_index=-100,
@@ -2901,9 +2898,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=
         This is equivalent with ``nn.functional.interpolate(...)``.
 
     Note:
-        When using the CUDA backend, this operation may induce nondeterministic
-        behaviour in its backward pass that is not easily switched off.
-        Please see the notes on :doc:`/notes/randomness` for background.
+        {backward_reproducibility_note}
 
     The algorithm used for upsampling is determined by :attr:`mode`.
 
@@ -2953,6 +2948,7 @@ def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=
     """
     warnings.warn("nn.functional.upsample is deprecated. Use nn.functional.interpolate instead.")
     return interpolate(input, size, scale_factor, mode, align_corners)
+upsample.__doc__ = upsample.__doc__.format(**reproducibility_notes)
 
 @_overload  # noqa: F811
 def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corners=None, recompute_scale_factor=None):  # noqa: F811
@@ -3042,9 +3038,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
         calculation.
 
     Note:
-        When using the CUDA backend, this operation may induce nondeterministic
-        behaviour in its backward pass that is not easily switched off.
-        Please see the notes on :doc:`/notes/randomness` for background.
+        {backward_reproducibility_note}
     """
     if not torch.jit.is_scripting():
         if type(input) is not Tensor and has_torch_function((input,)):
@@ -3174,6 +3168,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
     raise NotImplementedError("Input Error: Only 3D, 4D and 5D input Tensors supported"
                               " (got {}D) for the modes: nearest | linear | bilinear | bicubic | trilinear"
                               " (got {})".format(input.dim(), mode))
+interpolate.__doc__ = interpolate.__doc__.format(**reproducibility_notes)
 
 @_overload  # noqa: F811
 def upsample_nearest(input, size=None, scale_factor=None):  # noqa: F811
@@ -3202,13 +3197,12 @@ def upsample_nearest(input, size=None, scale_factor=None):  # noqa: F811
         scale_factor (int): multiplier for spatial size. Has to be an integer.
 
     Note:
-        When using the CUDA backend, this operation may induce nondeterministic
-        behaviour in its backward pass that is not easily switched off.
-        Please see the notes on :doc:`/notes/randomness` for background.
+        {backward_reproducibility_note}
     """
     # DeprecationWarning is ignored by default
     warnings.warn("nn.functional.upsample_nearest is deprecated. Use nn.functional.interpolate instead.")
-    return interpolate(input, size, scale_factor, mode='nearest')
+    return interpolate(input, size, scale_factor, mode = 'nearest')
+upsample_nearest.__doc__ = upsample_nearest.__doc__.format(**reproducibility_notes)
 
 @_overload  # noqa: F811
 def upsample_bilinear(input, size=None, scale_factor=None):  # noqa: F811
@@ -3247,14 +3241,12 @@ def upsample_bilinear(input, size=None, scale_factor=None):  # noqa: F811
         scale_factor (int or Tuple[int, int]): multiplier for spatial size
 
     Note:
-        When using the CUDA backend, this operation may induce nondeterministic
-        behaviour in its backward pass that is not easily switched off.
-        Please see the notes on :doc:`/notes/randomness` for background.
+        {backward_reproducibility_note}
     """
     # DeprecationWarning is ignored by default
     warnings.warn("nn.functional.upsample_bilinear is deprecated. Use nn.functional.interpolate instead.")
     return interpolate(input, size, scale_factor, mode='bilinear', align_corners=True)
-
+upsample_bilinear.__doc__ = upsample_bilinear.__doc__.format(**reproducibility_notes)
 
 GRID_SAMPLE_INTERPOLATION_MODES = {
     'bilinear': 0,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -11,7 +11,7 @@ from . import grad  # noqa: F401
 from torch import _VF
 from .._jit_internal import boolean_dispatch, List, Optional, _overload, Tuple
 from ..overrides import has_torch_function, handle_torch_function
-from torch._torch_docs import reproducibility_notes
+from torch._torch_docs import reproducibility_notes, tf32_notes
 
 
 Tensor = torch.Tensor
@@ -22,17 +22,13 @@ conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> T
 Applies a 1D convolution over an input signal composed of several input
 planes.
 
-This operator supports :ref:`TensorFloat32<tf32_on_ampere>`.
+{tf32_note}
 
 See :class:`~torch.nn.Conv1d` for details and output shape.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {cudnn_reproducibility_note}
+""".format(**reproducibility_notes, **tf32_notes) + r"""
 
 Args:
     input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
@@ -60,19 +56,13 @@ conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> T
 Applies a 2D convolution over an input image composed of several input
 planes.
 
-This operator supports :ref:`TensorFloat32<tf32_on_ampere>`.
+{tf32_note}
 
 See :class:`~torch.nn.Conv2d` for details and output shape.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
-
-
+    {cudnn_reproducibility_note}
+""".format(**reproducibility_notes, **tf32_notes) + r"""
 Args:
     input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
     weight: filters of shape :math:`(\text{out\_channels} , \frac{\text{in\_channels}}{\text{groups}} , kH , kW)`
@@ -100,17 +90,13 @@ conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1) -> T
 Applies a 3D convolution over an input image composed of several input
 planes.
 
-This operator supports :ref:`TensorFloat32<tf32_on_ampere>`.
+{tf32_note}
 
 See :class:`~torch.nn.Conv3d` for details and output shape.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {cudnn_reproducibility_note}
+""".format(**reproducibility_notes, **tf32_notes) + r"""
 
 Args:
     input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iT , iH , iW)`
@@ -138,17 +124,13 @@ conv_transpose1d(input, weight, bias=None, stride=1, padding=0, output_padding=0
 Applies a 1D transposed convolution operator over an input signal
 composed of several input planes, sometimes also called "deconvolution".
 
-This operator supports :ref:`TensorFloat32<tf32_on_ampere>`.
+{tf32_note}
 
 See :class:`~torch.nn.ConvTranspose1d` for details and output shape.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {cudnn_reproducibility_note}
+""".format(**reproducibility_notes, **tf32_notes) + r"""
 
 Args:
     input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
@@ -179,17 +161,13 @@ conv_transpose2d(input, weight, bias=None, stride=1, padding=0, output_padding=0
 Applies a 2D transposed convolution operator over an input image
 composed of several input planes, sometimes also called "deconvolution".
 
-This operator supports :ref:`TensorFloat32<tf32_on_ampere>`.
+{tf32_note}
 
 See :class:`~torch.nn.ConvTranspose2d` for details and output shape.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {cudnn_reproducibility_note}
+""".format(**reproducibility_notes, **tf32_notes) + r"""
 
 Args:
     input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
@@ -222,17 +200,13 @@ conv_transpose3d(input, weight, bias=None, stride=1, padding=0, output_padding=0
 Applies a 3D transposed convolution operator over an input image
 composed of several input planes, sometimes also called "deconvolution"
 
-This operator supports :ref:`TensorFloat32<tf32_on_ampere>`.
+{tf32_note}
 
 See :class:`~torch.nn.ConvTranspose3d` for details and output shape.
 
 Note:
-    In some circumstances when using the CUDA backend with CuDNN, this operator
-    may select a nondeterministic algorithm to increase performance. If this is
-    undesirable, you can try to make the operation deterministic (potentially at
-    a performance cost) by setting ``torch.backends.cudnn.deterministic =
-    True``.
-    Please see the notes on :doc:`/notes/randomness` for background.
+    {cudnn_reproducibility_note}
+""".format(**reproducibility_notes, **tf32_notes) + r"""
 
 Args:
     input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iT , iH , iW)`
@@ -3793,7 +3767,7 @@ def assert_int_or_pair(arg, arg_name, message):
 
 def unfold(input, kernel_size, dilation=1, padding=0, stride=1):
     # type: (Tensor, BroadcastingList2[int], BroadcastingList2[int], BroadcastingList2[int], BroadcastingList2[int]) -> Tensor  # noqa
-    r"""Extracts sliding local blocks from an batched input tensor.
+    r"""Extracts sliding local blocks from a batched input tensor.
 
     .. warning::
         Currently, only 4-D input tensors (batched image-like tensors) are

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3201,7 +3201,7 @@ def upsample_nearest(input, size=None, scale_factor=None):  # noqa: F811
     """
     # DeprecationWarning is ignored by default
     warnings.warn("nn.functional.upsample_nearest is deprecated. Use nn.functional.interpolate instead.")
-    return interpolate(input, size, scale_factor, mode = 'nearest')
+    return interpolate(input, size, scale_factor, mode='nearest')
 upsample_nearest.__doc__ = upsample_nearest.__doc__.format(**reproducibility_notes)
 
 @_overload  # noqa: F811

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -14,7 +14,8 @@ from torch._torch_docs import reproducibility_notes
 from ..common_types import _size_1_t, _size_2_t, _size_3_t
 from typing import Optional, List, Tuple
 
-convolution_notes = {"groups_note": """* :attr:`groups` controls the connections between inputs and outputs.
+convolution_notes = \
+    {"groups_note": """* :attr:`groups` controls the connections between inputs and outputs.
       :attr:`in_channels` and :attr:`out_channels` must both be divisible by
       :attr:`groups`. For example,
 
@@ -25,15 +26,16 @@ convolution_notes = {"groups_note": """* :attr:`groups` controls the connections
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
           its own set of filters (of size
-          : math: `\left\lfloor\\frac{out\_channels}{in\_channels}\\right\\rfloor`).""",
+          : math: `\left\lfloor\\frac{out\_channels}{in\_channels}\\right\\rfloor`).""",  # noqa: W605
+
         "depthwise_separable_note": """When `groups == in_channels` and `out_channels == K * in_channels`,
         where `K` is a positive integer, this operation is also termed in
         literature as depthwise convolution.
 
         In other words, for an input of size :math:`(N, C_{in}, L_{in})`,
         a depthwise convolution with a depthwise multiplier `K`, can be constructed by arguments
-        :math:`(C_\\text{in}=C_{in}, C_\\text{out}=C_{in} \\times K, ..., \\text{groups}=C_{in})`."""
-}
+        :math:`(C_\\text{in}=C_{in}, C_\\text{out}=C_{in} \\times K, ..., \\text{groups}=C_{in})`."""}
+
 
 
 
@@ -270,7 +272,7 @@ class Conv2d(_ConvNd):
     :math:`N` is a batch size, :math:`C` denotes a number of channels,
     :math:`H` is a height of input planes in pixels, and :math:`W` is
     width in pixels.
-    """ +r"""
+    """ + r"""
 
     This module supports :ref:`TensorFloat32<tf32_on_ampere>`.
 
@@ -356,6 +358,7 @@ class Conv2d(_ConvNd):
     .. _link:
         https://github.com/vdumoulin/conv_arithmetic/blob/master/README.md
     """
+
     def __init__(
         self,
         in_channels: int,
@@ -480,6 +483,7 @@ class Conv3d(_ConvNd):
     .. _link:
         https://github.com/vdumoulin/conv_arithmetic/blob/master/README.md
     """
+
     def __init__(
         self,
         in_channels: int,

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -21,20 +21,19 @@ convolution_notes = \
 
         * At groups=1, all inputs are convolved to all outputs.
         * At groups=2, the operation becomes equivalent to having two conv
-          layers side by side, each seeing half the input channels,
+          layers side by side, each seeing half the input channels
           and producing half the output channels, and both subsequently
           concatenated.
         * At groups= :attr:`in_channels`, each input channel is convolved with
           its own set of filters (of size
-          : math: `\left\lfloor\\frac{out\_channels}{in\_channels}\\right\\rfloor`).""",  # noqa: W605
+          :math:`\\frac{\\text{out\_channels}}{\\text{in\_channels}}`).""",  # noqa: W605
 
         "depthwise_separable_note": """When `groups == in_channels` and `out_channels == K * in_channels`,
-        where `K` is a positive integer, this operation is also termed in
-        literature as depthwise convolution.
+        where `K` is a positive integer, this operation is also known as a "depthwise convolution".
 
         In other words, for an input of size :math:`(N, C_{in}, L_{in})`,
-        a depthwise convolution with a depthwise multiplier `K`, can be constructed by arguments
-        :math:`(C_\\text{in}=C_{in}, C_\\text{out}=C_{in} \\times K, ..., \\text{groups}=C_{in})`."""}
+        a depthwise convolution with a depthwise multiplier `K` can be performed with the arguments
+        :math:`(C_\\text{in}=C_\\text{in}, C_\\text{out}=C_\\text{in} \\times \\text{K}, ..., \\text{groups}=C_\\text{in})`."""}  # noqa: W605
 
 
 


### PR DESCRIPTION
Many of our functions contain same warnings about results reproducibility. Make them use common template. 
