### PR TITLE
Stricter backward compatibility check

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -161,13 +161,14 @@ struct FunctionSchema {
   // [Function structure] The new schema's name, overload-name, varargs, and
   //      return arity are the same.
   // [Output Narrowing] The new schema's output type must be the same class
-  //      or inherit from the old schema's output type
+  //      or inherit from the old schema's output type.
   // [Argument count] The new schema must have at least as many arguments as
   //      the old schema (considering the list of positional and kwargs).
   // [Arg Compatibility] Every argument in the old schema has a corresponding
   //      argument in the new schema that:
   //        * is at the same position.
   //        * has the same name.
+  //        * is either positional, or kwarg and the old argument was kwarg.
   //        * has the same type, or the old argument's type inherits from the
   //          new argument's type.
   // [Default Values] Every new argument must have a default value.
@@ -175,6 +176,7 @@ struct FunctionSchema {
   //   OK    f_new(a, b, c=1) => f_old(a, b)
   //   NOK   f_new(a, c=1, *, b) => f_old(a, *, b)
   //   OK    f_new(a, b, *, c) => f_old(a, *, b, c)
+  //   NOK   f_new(a, *, b, c) -> f_old(a, b, *, c)
   //   NOK   f_new(a, *, c, b) => f_old(a, *, b, c)
   //   OK    f_new(a, *, b, c, d=1) => f_old(a, *, b, c)
   bool isBackwardCompatibleWith(

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -158,14 +158,19 @@ struct FunctionSchema {
 
   // Checks whether this schema is backward compatible with the old one.
   // The following conditions must be true:
-  // * The function's structure of old and new match (e.g. name,
-  //   overload name, etc.).
-  // * Considering as 'arguments' the concatenation of positional arguments
-  //   and kwargs in a function, all the arguments in the old function schema
-  //   must have a matching backward compatible argument in the same position
-  //   in this schema.
-  // * All remaining (i.e. new) arguments in this schema must appear last in
-  //   the list of arguments, and have a default value.
+  // [Function structure] The new schema's name, overload-name, varargs, and
+  //      return arity are the same.
+  // [Output Narrowing] The new schema's output type must be the same class
+  //      or inherit from the old schema's output type
+  // [Argument count] The new schema must have at least as many arguments as
+  //      the old schema (considering the list of positional and kwargs).
+  // [Arg Compatibility] Every argument in the old schema has a corresponding
+  //      argument in the new schema that:
+  //        * is at the same position.
+  //        * has the same name.
+  //        * has the same type, or the old argument's type inherits from the
+  //          new argument's type.
+  // [Default Values] Every new argument must have a default value.
   // E.g.
   //   OK    f_new(a, b, c=1) => f_old(a, b)
   //   NOK   f_new(a, c=1, *, b) => f_old(a, *, b)

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -156,18 +156,22 @@ struct FunctionSchema {
     checkSchema();
   }
 
-  // check whether this schema is backward compatible with the old one.
-  // the following conditions are considered as this schema is backward
-  // compatible with old:
-  //   1) two schemas are equal
-  //   2) this schema has the same or more positional args than old,
-  //      and any positional arg in this schema is backward compatible
-  //      with the corresponding one in old schema, which could be an arg
-  //      or a kwarg, if it has, or it must provide a default value
-  //   3) this schema has the same or more kwargs than old, and all the kwargs
-  //      in old schema can find the corresponding kwarg in this schema which
-  //      is backward compatible with the old kwarg, and the extra kwargs in
-  //      this schema must provide default values.
+  // Checks whether this schema is backward compatible with the old one.
+  // The following conditions must be true:
+  // * The function's structure of old and new match (e.g. name,
+  //   overload name, etc.).
+  // * Considering as 'arguments' the concatenation of positional arguments
+  //   and kwargs in a function, all the arguments in the old function schema
+  //   must have a matching backward compatible argument in the same position
+  //   in this schema.
+  // * All remaining (i.e. new) arguments in this schema must appear be
+  //   appended to the list of arguments, and have a default value.
+  // E.g.
+  //   OK    f_new(a, b, c=1) => f_old(a, b)
+  //   NOK   f_new(a, c=1, *, b) => f_old(a, *, b)
+  //   OK    f_new(a, b, *, c) => f_old(a, *, b, c)
+  //   NOK   f_new(a, *, c, b) => f_old(a, *, b, c)
+  //   OK    f_new(a, *, b, c, d=1) => f_old(a, *, b, c)
   bool isBackwardCompatibleWith(
       const FunctionSchema& old,
       std::ostream* why_not = nullptr) const;

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -164,8 +164,8 @@ struct FunctionSchema {
   //   and kwargs in a function, all the arguments in the old function schema
   //   must have a matching backward compatible argument in the same position
   //   in this schema.
-  // * All remaining (i.e. new) arguments in this schema must appear be
-  //   appended to the list of arguments, and have a default value.
+  // * All remaining (i.e. new) arguments in this schema must appear last in
+  //   the list of arguments, and have a default value.
   // E.g.
   //   OK    f_new(a, b, c=1) => f_old(a, b)
   //   NOK   f_new(a, c=1, *, b) => f_old(a, *, b)

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -27,11 +27,14 @@ class TestFunctionSchema(TestCase):
         self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
 
     def test_backward_compatible_kwargs(self):
-        old_schema = parse_schema('any(Tensor self, *, Tensor out) -> Tensor')
-        new_schema = parse_schema('any(Tensor self, *, bool extra1=True, Tensor out, bool extra2=False) -> Tensor')
+        old_schema = parse_schema('any(Tensor self, *, Tensor b, Tensor c) -> Tensor')
+        new_schema = parse_schema('any(Tensor self, Tensor b, Tensor c) -> Tensor')
         self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
         self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, Tensor out) -> Tensor')
+        new_schema = parse_schema('any(Tensor self, Tensor b, *, Tensor c) -> Tensor')
+        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
+        new_schema = parse_schema('any(Tensor self, *, Tensor b, Tensor c, int d=1) -> Tensor')
         self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
         self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
 
@@ -85,7 +88,7 @@ class TestFunctionSchema(TestCase):
         new_schema = parse_schema('any(Tensor self, int dims, bool keepdim=False) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
         self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int[] dim, bool keepdim=False, bool? extra=None) -> Tensor')
+        new_schema = parse_schema('any(Tensor self, int[] diff, bool keepdim=False, bool? extra=None) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
         self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
 
@@ -97,7 +100,16 @@ class TestFunctionSchema(TestCase):
         new_schema = parse_schema('any(Tensor self, int[] dims, *, bool keepdim=False, bool extra) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
         self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-
+        new_schema = parse_schema('any(Tensor self, int[] dims, bool extra1=True, *, bool keepdim) -> Tensor')
+        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
+        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
+        new_schema = parse_schema('any(Tensor self, int[] dims, *, bool extra1=True, bool keepdim) -> Tensor')
+        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
+        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
+        old_schema = parse_schema('any(Tensor self, *, Tensor b, Tensor c) -> Tensor')
+        new_schema = parse_schema('any(Tensor self, *, Tensor c, Tensor b) -> Tensor')
+        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
+        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -14,102 +14,73 @@ class TestFunctionSchema(TestCase):
             self.assertEqual(parsed_schema, schema)
             self.assertTrue(parsed_schema.is_backward_compatible_with(schema))
 
-    def test_backward_compatible_args(self):
-        old_schema = parse_schema('any(Tensor self, int dim) -> Tensor')
-        new_schema = parse_schema('any(Tensor self, int? dim) -> Tensor')
+    def test_backward_compatible_structure(self):
+        old_schema = parse_schema('any.over(Tensor self, *, Tensor b) -> Tensor')
+        # BC: A new schema without changes.
+        new_schema = parse_schema('any.over(Tensor self, *, Tensor b) -> Tensor')
         self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int dim=5) -> Tensor')
-        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> Tensor')
-        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-
-    def test_backward_compatible_kwargs(self):
-        old_schema = parse_schema('any(Tensor self, *, Tensor b, Tensor c) -> Tensor')
-        new_schema = parse_schema('any(Tensor self, Tensor b, Tensor c) -> Tensor')
-        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, Tensor b, *, Tensor c) -> Tensor')
-        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, *, Tensor b, Tensor c, int d=1) -> Tensor')
-        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-
-    def test_backward_compatible_ret(self):
-        old_schema = parse_schema('any(Tensor self) -> Tensor?')
-        new_schema = parse_schema('any(Tensor self) -> Tensor')
-        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-
-    def test_backward_incompatible_name(self):
-        old_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> Tensor')
-        new_schema = parse_schema('any_(Tensor self, int dim, bool keepdim=False) -> Tensor')
+        # No-BC: A new schema with different name.
+        new_schema = parse_schema('any_.over(Tensor self, *, Tensor b) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
+        # No-BC: A new schema with different overload name.
+        new_schema = parse_schema('any.other(Tensor self, *, Tensor b) -> Tensor')
+        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
+        # No-BC: A new schema that adds vararg.
+        new_schema = parse_schema('any.over(Tensor self, *, Tensor b, ...) -> Tensor')
+        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
+        # No-BC: A new schema with different number of outputs.
+        new_schema = parse_schema('any.over(Tensor self, *, Tensor b) -> (Tensor, Tensor)')
+        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
 
-    def test_backward_incompatible_vararg(self):
-        old_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> Tensor')
-        new_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False, ...) -> Tensor')
+    def test_backward_compatible_outputs(self):
+        old_schema = parse_schema('any.over(Tensor self, *, Tensor b) -> Tensor')
+        # No-BC: A new schema with output becoming of optional type.
+        new_schema = parse_schema('any.over(Tensor self, *, Tensor b) -> Tensor?')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-
-    def test_backward_incompatible_returns(self):
-        old_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> Tensor')
-        new_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> (Tensor, ...)')
-        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> int')
-        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> Tensor?')
-        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
+        # BC: (the opposite case) An schema where the output is not of optional type anymore.
         self.assertTrue(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)')
+        # No-BC: A new schema with a different output type.
+        new_schema = parse_schema('any.over(Tensor self, *, Tensor b) -> int')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int dim, bool keepdim=False) -> Tensor out')
+        # No-BC: A new schema with a different output type.
+        new_schema = parse_schema('any.over(Tensor self, *, Tensor b) -> Tensor out')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
 
-    def test_backward_incompatible_args(self):
-        old_schema = parse_schema('any(Tensor self, int[] dims, bool keepdim=False) -> Tensor')
-        new_schema = parse_schema('any(Tensor s, int[] dims, bool keepdim=False) -> Tensor')
+    def test_backward_compatible_arguments(self):
+        old_schema = parse_schema('any(Tensor self, *, Tensor b, int c) -> Tensor')
+        # No-BC: A new schema with less arguments.
+        new_schema = parse_schema('any(Tensor self, *, Tensor b) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int[3] dims, bool keepdim=False) -> Tensor')
+        # No-BC: A new schema with more arguments, appended, but no default value.
+        new_schema = parse_schema('any(Tensor self, *, Tensor b, int c, int d) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int[](a) dims, bool keepdim=False) -> Tensor')
+        # BC: A new schema with more arguments, appended, that have a default value.
+        new_schema = parse_schema('any(Tensor self, *, Tensor b, int c, int d=1) -> Tensor')
+        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        # No-BC: A new schema with more arguments, not-appended, that have a default value.
+        new_schema = parse_schema('any(Tensor self, int d=1, *, Tensor b, int c) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int dims, bool keepdim=False) -> Tensor')
+        # BC: A new schema where old kwargs becomes positional.
+        new_schema = parse_schema('any(Tensor self, Tensor b, *, int c) -> Tensor')
+        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        # BC: A new schema where all old kwargs become positional.
+        new_schema = parse_schema('any(Tensor self, Tensor b, int c) -> Tensor')
+        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        # No-BC: A new schema where old kwargs appear in different order.
+        new_schema = parse_schema('any(Tensor self, *, int c, Tensor b) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int[] diff, bool keepdim=False, bool? extra=None) -> Tensor')
+        # BC: A new schema where argument becomes of type optional.
+        new_schema = parse_schema('any(Tensor self, *, Tensor b, int? c) -> Tensor')
+        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        # BC: A new schema where argument gains a default value.
+        new_schema = parse_schema('any(Tensor self, *, Tensor b, int c=1) -> Tensor')
+        self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        # No-BC: A new schema where argument is "renamed".
+        new_schema = parse_schema('any(Tensor self, *, Tensor b, int renamed) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-
-    def test_backward_incompatible_kwargs(self):
-        old_schema = parse_schema('any(Tensor self, int[] dims, *, bool keepdim=False) -> Tensor')
-        new_schema = parse_schema('any(Tensor self, int[] dims, *, bool keepdim) -> Tensor')
+        # No-BC: A new schema where argument type changes to an incompatible type.
+        new_schema = parse_schema('any(Tensor self, *, Tensor b, int[] c) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertTrue(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int[] dims, *, bool keepdim=False, bool extra) -> Tensor')
-        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int[] dims, bool extra1=True, *, bool keepdim) -> Tensor')
-        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        new_schema = parse_schema('any(Tensor self, int[] dims, *, bool extra1=True, bool keepdim) -> Tensor')
-        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
-        old_schema = parse_schema('any(Tensor self, *, Tensor b, Tensor c) -> Tensor')
-        new_schema = parse_schema('any(Tensor self, *, Tensor c, Tensor b) -> Tensor')
-        self.assertFalse(new_schema.is_backward_compatible_with(old_schema))
-        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -63,9 +63,13 @@ class TestFunctionSchema(TestCase):
         # BC: A new schema where old kwargs becomes positional.
         new_schema = parse_schema('any(Tensor self, Tensor b, *, int c) -> Tensor')
         self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        # BC: (the opposite case) A new schema where an old positional argument becomes kwarg.
+        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
         # BC: A new schema where all old kwargs become positional.
         new_schema = parse_schema('any(Tensor self, Tensor b, int c) -> Tensor')
         self.assertTrue(new_schema.is_backward_compatible_with(old_schema))
+        # BC: (the opposite case) A new schema where all old positional arguments become kwarg.
+        self.assertFalse(old_schema.is_backward_compatible_with(new_schema))
         # No-BC: A new schema where old kwargs appear in different order.
         new_schema = parse_schema('any(Tensor self, *, int c, Tensor b) -> Tensor')
         self.assertFalse(new_schema.is_backward_compatible_with(old_schema))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45773 Stricter backward compatibility check**

Changes the function schema's backward compatibility check to be stricter to comply with C++ API backwards compatibility capabilities.

See #45784 for description

Differential Revision: [D24089751](https://our.internmc.facebook.com/intern/diff/D24089751/)