### PR TITLE
Fixed citation to ensure correct capitalization

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,5 +1,5 @@
 @incollection{NEURIPS2019_9015,
-title = {PyTorch: An Imperative Style, High-Performance Deep Learning Library},
+title = {{PyTorch}: An Imperative Style, High-Performance Deep Learning Library},
 author = {Paszke, Adam and Gross, Sam and Massa, Francisco and Lerer, Adam and Bradbury, James and Chanan, Gregory and Killeen, Trevor and Lin, Zeming and Gimelshein, Natalia and Antiga, Luca and Desmaison, Alban and Kopf, Andreas and Yang, Edward and DeVito, Zachary and Raison, Martin and Tejani, Alykhan and Chilamkurthy, Sasank and Steiner, Benoit and Fang, Lu and Bai, Junjie and Chintala, Soumith},
 booktitle = {Advances in Neural Information Processing Systems 32},
 editor = {H. Wallach and H. Larochelle and A. Beygelzimer and F. d\textquotesingle Alch\'{e}-Buc and E. Fox and R. Garnett},


### PR DESCRIPTION
Without curly brackets, many (if not all) bibliography generators will incorrectly format "PyTorch" as "Pytorch".  

This issue with capitalization was fixed once in an [earlier commit](https://github.com/pytorch/pytorch/commit/847d9c57d1cd019b3077186d3769a41df3813c8e#diff-4d7570ca7e02ca3e76695d11e121a8a0) but was broken again when the [citation was changed](https://github.com/pytorch/pytorch/commit/005146711870a291f4a7a4cc82d97e1e586dcaff#diff-4d7570ca7e02ca3e76695d11e121a8a0) from the workshop to conference version.

Fixes #{issue number}
