### PR TITLE
[jit] support tracing tensor __setitem__ with dynamic shape

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -339,6 +339,10 @@ static inline IntArrayRef slicePrefix1sSize(const IntArrayRef& sizes) {
 }
 
 static inline void copy_to(const Tensor& dst, const Tensor& src) {
+  if (dst.sizes().equals(src.sizes())) {
+    dst.copy_(src);
+    return;
+  }
   Tensor b_src;
   std::tie(b_src) = expand_inplace(dst, src.view(slicePrefix1sSize(src.sizes())), "setitem");
   dst.copy_(b_src);

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -340,6 +340,7 @@ static inline IntArrayRef slicePrefix1sSize(const IntArrayRef& sizes) {
 
 static inline void copy_to(const Tensor& dst, const Tensor& src) {
   if (dst.sizes().equals(src.sizes())) {
+    // A shortcut to avoid generating hard-coded constant sizes during tracing.
     dst.copy_(src);
     return;
   }

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -341,6 +341,8 @@ static inline IntArrayRef slicePrefix1sSize(const IntArrayRef& sizes) {
 static inline void copy_to(const Tensor& dst, const Tensor& src) {
   if (dst.sizes().equals(src.sizes())) {
     // A shortcut to avoid generating hard-coded constant sizes during tracing.
+    // This is not a perfect solution: when src & dst have different shapes, constants will still
+    // appear. Users can workaround that case by dst[index..] = src.reshape(..)
     dst.copy_(src);
     return;
   }

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -399,6 +399,18 @@ class TestTracer(JitTestCase):
         self.assertEqual(ge(y).shape, y.shape)
         self.assertEqual(ge(x).shape, x.shape)
 
+    # Test that the trace of setitem doesn't store shapes as constants
+    # Fix https://github.com/pytorch/pytorch/issues/43548
+    def test_trace_slice_setitem_dynamic_shape(self):
+        def slice_setitem(x, y):
+            x[:, 2] = y + 1
+            return x
+
+        x = torch.randn(3, 4)
+        traced = torch.jit.trace(slice_setitem, (x, x[:, 0]))
+        x = torch.randn(10, 5)
+        self.assertEqual(traced(x.clone(), x[:, 0]), slice_setitem(x.clone(), x[:, 0]))
+
     # Suppression: we are intentionally slicing a tensor, we don't care that it
     # will be constantified
     @suppress_warnings


### PR DESCRIPTION
Summary: fix https://github.com/pytorch/pytorch/issues/43548

Test Plan: buck test mode/dev-nosan //caffe2/test:jit -- 'test_trace_slice' --jobs 1

Differential Revision: D24106641

