### PR TITLE
setup: Dataclasses only when < 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -346,7 +346,7 @@ def build_deps():
 install_requires = [
     'future',
     'typing_extensions',
-    'dataclasses; python_version < "3.8"'
+    'dataclasses; python_version < "3.7"'
 ]
 
 missing_pydep = '''


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45844 setup: Dataclasses only when < 3.7**

Someone pointed out that dataclasses were actually added to the python
stdlib in 3.7 and not 3.8, so bumping down the dependency on dataclasses
from 3.8 -> 3.7 makes sense here

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D24113367](https://our.internmc.facebook.com/intern/diff/D24113367)