### PR TITLE
[NNC] cacheAccesses transform (cache_reads + cache_writes)

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -116,6 +116,14 @@ namespace jit {
   _(ReduceInlineReduction)                          \
   _(ReduceInlineConsumer)                           \
   _(ReduceInlineReducerInternal)                    \
+  _(ReductionCacheAccessesOuter)                    \
+  _(ReductionCacheAccessesInner)                    \
+  _(ReductionCacheBodyAccess)                       \
+  _(ReductionCacheConsumerAccess)                   \
+  _(ReductionSplitCacheConsumerAccess)              \
+  _(ReductionReorderCacheConsumerAccess)            \
+  _(ReductionRfactorCacheTempOuter)                 \
+  _(ReductionRfactorCacheTempInner)                 \
   _(TypeTest01)                                     \
   _(TypePropagation)                                \
   _(Cond01)                                         \
@@ -307,7 +315,6 @@ namespace jit {
   _(LoopNestComputeAt_1)                            \
   _(LoopNestComputeAt_2)                            \
   _(LoopNestComputeAt_3)                            \
-  _(LoopNestComputeAt_4)                            \
   _(LoopNestReorderAxis1)                           \
   _(LoopNestReorderPartialAxes)                     \
   _(LoopNestReorderInternalAxis)                    \
@@ -334,6 +341,11 @@ namespace jit {
   _(NormalizeOnNestedInnerLoop)                     \
   _(NormalizeAndSplitWithTail)                      \
   _(DetectInlineRankMismatch)                       \
+  _(CacheReadsSimple)                               \
+  _(CacheReadsOuter)                                \
+  _(CacheReadsInternal)                             \
+  _(CacheReadsInner)                                \
+  _(CacheWritesSimple)                              \
   _(Kernel_1)                                       \
   _(Kernel_2)                                       \
   _(Kernel_3)                                       \

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -15,6 +15,7 @@ class BoundsInference : public IRVisitor {
   void visit(const FunctionCall* v) override;
   void visit(const Load* v) override;
   void visit(const Store* v) override;
+  void visit(const ReduceOp* v) override;
   void visit(const For* v) override;
   void visit(const Block* v) override;
 
@@ -36,6 +37,12 @@ void BoundsInference::visit(const FunctionCall* v) {
 
 void BoundsInference::visit(const Store* v) {
   accesses_[v->buf()].push_back({kStore, v->indices(), v->indices()});
+  IRVisitor::visit(v);
+}
+
+void BoundsInference::visit(const ReduceOp* v) {
+  accesses_[v->accumulator()].push_back(
+      {kLoad, v->output_args(), v->output_args()});
   IRVisitor::visit(v);
 }
 

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -78,11 +78,21 @@ class TORCH_API LoopNest {
   void setGPUBlockIndex(For* f, int idx);
   void setGPUThreadIndex(For* f, int idx);
 
+  using AccessResult = std::pair<const Buf*, Stmt*>;
+  // Insert a cache for the consumer's usages of the buffer produced in
+  // consumer, and redirect reads and writes in the consumer to that cache.
+  // Returns a pair of the new cache buffer, and the new rewritten consumer.
+  AccessResult cacheAccesses(
+      const Buf* producer,
+      const std::string& name,
+      Stmt* consumer);
+
   // Insert a temporary computation of statement S in the scope of loop AT.
   // S is assumed to be a Store or a Block containing a Store. Along with the
   // computation itself, this transformation inserts Alloc/Free statements for
   // the temporary buffer used in the computation.
   void computeAt(Stmt* s, For* at);
+
   void rfactor(
       const Expr* f,
       const Var* reduction_var,

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -163,6 +163,13 @@ class TORCH_API Block : public StmtNode<Block> {
     return stmts_;
   }
 
+  void clear() {
+    for (auto* s : stmts_) {
+      set_parent(s, nullptr);
+    }
+    stmts_.clear();
+  }
+
   explicit Block(const std::vector<Stmt*>& stmts) {
     for (Stmt* s : stmts) {
       if (s->get_parent()) {


### PR DESCRIPTION
Adds a new transform to the NNC compiler, which adds support for buffer access caching. All accesses within a provided scope are redirected to a cache which is initialized or written back as necessary at the boundaries of that scope. For TVM fans, this is essentially a combination of cache_reads and cache_writes. E.g. it can do this kind of thing:

Before:
```
for (int i = 0; i < 64; i++) {
  for (int j = 0; j < 64; j++) {
    A[i, j] = i * j;
  }
}
for (int i_1 = 0; i_1 < 20; i_1++) {
  for (int j_1 = 0; j_1 < 10; j_1++) {
    B[i_1, j_1] = (A(i_1 + 30, j_1 + 40)) + (A(i_1 + 31, j_1 + 41));
  }
```

After `cacheAccesses(A->buf(), "A_local", j_loop);`

```
for (int i = 0; i < 64; i++) {
  for (int j = 0; j < 64; j++) {
    A[i, j] = i * j;
  }
}
for (int i_1 = 0; i_1 < 20; i_1++) {
  for (int i_2 = 0; i_2 < 2; i_2++) {
    for (int j_1 = 0; j_1 < 11; j_1++) {
      A_local[i_2, j_1] = A[(i_2 + i_1) + 30, j_1 + 40];
    }
  }
  for (int j_2 = 0; j_2 < 10; j_2++) {
    B[i_1, j_2] = (A_local[1, j_2 + 1]) + (A_local[0, j_2]);
  }
}
```

Or this reduction:
```
for (int l1 = 0; l1 < 4; l1++) {
  sum[l1] = 0.f;
  for (int n1_1 = 0; n1_1 < 3; n1_1++) {
    for (int m1_1 = 0; m1_1 < 2; m1_1++) {
      sum[l1] = (sum[l1]) + (scale[(6 * l1 + 2 * n1_1) + m1_1]);
    }
  }
}
```

After `l.cacheAccesses(d->buf(), "d_local", n_loop);`:

```
for (int l1 = 0; l1 < 4; l1++) {
  Allocate(d_local, float, {1});
  sum[l1] = 0.f;
  d_local[0] = 0.f;
  for (int n1_1 = 0; n1_1 < 3; n1_1++) {
    for (int m1_1 = 0; m1_1 < 2; m1_1++) {
      d_local[0] = (d_local[0]) + (scale[(6 * l1 + 2 * n1_1) + m1_1]);
    }
  }
  sum[l1] = (sum[l1]) + (d_local[0]);
  Free(d_local);
}
```

I had originally planned to write `cacheReads` and `cacheWrites` wrappers so we could use them just like their TVM cousins, but they just ended up being big masses of checking that reads or writes weren't present. Didn't feel too useful so I removed them, but let me know.

This is based on bounds inference and inherits a few bugs present in that functionality, which I will address in a followup.

While working on this I realized that it overlaps heavily with `computeAt`: which is really just `cacheReads` + `computeInline`. I'm considering refactoring computeAt to be a wrapper around those two transforms. @ZolotukhinM opinions on this?