### PR TITLE
Define objects using classes instead of namedtuples in torch.utils.data._utils.worker

### DIFF
--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -7,7 +7,6 @@ static methods.
 import torch
 import random
 import os
-from collections import namedtuple
 from torch._six import queue
 from torch._utils import ExceptionWrapper
 from typing import Union
@@ -110,10 +109,13 @@ def get_worker_info():
 
 
 r"""Dummy class used to signal the end of an IterableDataset"""
-_IterableDatasetStopIteration = namedtuple('_IterableDatasetStopIteration', ['worker_id'])
+class _IterableDatasetStopIteration(object):
+    def __init__(self, worker_id):
+        self.worker_id = worker_id
 
 r"""Dummy class used to resume the fetching when worker reuse is enabled"""
-_ResumeIteration = namedtuple('_ResumeIteration', [])
+class _ResumeIteration(object):
+    pass
 
 def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                  auto_collation, collate_fn, drop_last, seed, init_fn, worker_id,

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -110,6 +110,7 @@ def get_worker_info():
 
 r"""Dummy class used to signal the end of an IterableDataset"""
 class _IterableDatasetStopIteration(object):
+    __slots__ = ['worker_id']
     def __init__(self, worker_id):
         self.worker_id = worker_id
 

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -7,6 +7,7 @@ static methods.
 import torch
 import random
 import os
+from dataclasses import dataclass
 from torch._six import queue
 from torch._utils import ExceptionWrapper
 from typing import Union
@@ -109,12 +110,12 @@ def get_worker_info():
 
 
 r"""Dummy class used to signal the end of an IterableDataset"""
+@dataclass(frozen=True)
 class _IterableDatasetStopIteration(object):
-    __slots__ = ['worker_id']
-    def __init__(self, worker_id):
-        self.worker_id = worker_id
+    worker_id: int
 
 r"""Dummy class used to resume the fetching when worker reuse is enabled"""
+@dataclass(frozen=True)
 class _ResumeIteration(object):
     pass
 


### PR DESCRIPTION
This PR fixes a bug when torch is used with pyspark, by converting namedtuples in `torch.utils.data._utils.worker` into classes. 

Before this PR, creating an IterableDataset and then running `list(torch.utils.data.DataLoader(MyIterableDataset(...), num_workers=2)))` will not terminate, if pyspark is also being used. This is because pyspark hijacks namedtuples to make them pickleable ([see here](https://github.com/apache/spark/blob/master/python/pyspark/serializers.py#L370)). So `_IterableDatasetStopIteration` would be modified, and then the check at [this line in dataloader.py](https://github.com/pytorch/pytorch/blob/5472426b9f85c8107aade5d256cf4cde572eab5c/torch/utils/data/dataloader.py#L1072) is never true. 
Converting the namedtuples to classes avoids this hijack and allows the iteration to correctly stop when signaled.