### PR TITLE
[pytorch][glow][NNPI] Using int32 as indices for embedding_bag operators

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -12,31 +12,23 @@
 torch::class_<EmbeddingPackedParamsBase> register_embedding_params();
 
 namespace {
-at::Tensor embedding_bag_4bit_helper(
+template <typename IndexType, typename OffsetType>
+at::Tensor embedding_bag_4bit_impl(
     const at::Tensor& weight,
     const at::Tensor& indices,
-    const c10::optional<at::Tensor>& offsets_in,
+    const at::Tensor& offsets,
     bool pruned_weights,
     const c10::optional<at::Tensor>& per_sample_weights_,
     const c10::optional<at::Tensor>& compressed_indices_mapping,
     bool include_last_offset) {
-  TORCH_CHECK(
-      offsets_in.has_value(),
-      "embedding_bag_4bit_rowwise_offsets expects offsets to be set");
 
   TORCH_CHECK(weight.dim() == 2);
   TORCH_CHECK(indices.dim() == 1);
-
-  auto offsets = offsets_in.value();
   TORCH_CHECK(offsets.dim() == 1);
 
-  // FBGEMM expects the offsets to be of int type.
-  at::Tensor offsets_new = offsets.toType(at::ScalarType::Int);
-
-  auto offsets_data = offsets_new.data_ptr<int>();
   const auto weight_data = weight.data_ptr<uint8_t>();
-  auto weight_contig = weight.contiguous();
-  uint8_t* input_data = weight_contig.data_ptr<uint8_t>();
+  const auto indices_data = indices.data_ptr<IndexType>();
+  auto offsets_data = offsets.data_ptr<OffsetType>();
 
   // Get compressed indices for pruned_weights op.
   int32_t* compressed_indices_mapping_data = nullptr;
@@ -47,7 +39,6 @@ at::Tensor embedding_bag_4bit_helper(
         compressed_indices_mapping.value().data_ptr<int32_t>();
   }
 
-  const auto indices_data = indices.data_ptr<int64_t>();
   const int64_t N = weight.size(0);
   const int64_t weight_size = weight.size(1);
   const int64_t D =
@@ -55,15 +46,17 @@ at::Tensor embedding_bag_4bit_helper(
   const int64_t M = offsets.size(0);
 
   int64_t output_size = M - 1;
-  std::vector<int> offsets_include_last_val;
+  std::vector<OffsetType> offsets_include_last_val;
   if (!include_last_offset) {
     output_size = M;
     offsets_include_last_val.resize(M + 1);
-    // Avoid `null pointer passed as argument 2` ASAN violation when ofests
+    // Avoid `null pointer passed as argument 2` ASAN violation when offsets
     // tensor is empty.
     if (M > 0) {
       std::memcpy(
-          offsets_include_last_val.data(), offsets_data, sizeof(int) * M);
+          offsets_include_last_val.data(),
+          offsets_data,
+          sizeof(OffsetType) * M);
     }
     offsets_include_last_val[M] = indices.numel();
     offsets_data = offsets_include_last_val.data();
@@ -72,14 +65,15 @@ at::Tensor embedding_bag_4bit_helper(
   const std::vector<int64_t> shape = {output_size, D};
   auto output = at::empty(shape, weight.options().dtype(at::kFloat));
   auto* output_data = output.data_ptr<float>();
-  const int64_t block_size = output.size(1);
-  TORCH_CHECK(block_size % 2 == 0, "block size must be divisible by 2");
+
+  const int64_t block_size = D;
   const int index_size = indices.numel();
   constexpr int prefetch_distance = 16;
+
 #ifdef USE_FBGEMM
   if (!pruned_weights) {
     // Generate the fbgemm kernel
-    auto kernel_64_ = fbgemm::GenerateEmbeddingSpMDMNBit<std::int64_t>(
+    auto kernel = fbgemm::GenerateEmbeddingSpMDMNBit<IndexType, OffsetType>(
         /*bit rate=*/4,
         /*block size=*/block_size,
         /*has weights=*/per_sample_weights_.has_value(),
@@ -88,11 +82,11 @@ at::Tensor embedding_bag_4bit_helper(
         /*is_weight_positional=*/false,
         /*use_offsets=*/true);
 
-    bool success = kernel_64_(
+    bool success = kernel(
         /*output_size=*/output_size,
         /*index_size=*/index_size,
         /*data_size=*/N,
-        /*input=*/input_data,
+        /*input=*/weight_data,
         /*indices=*/indices_data,
         /*offsets=*/offsets_data,
         /*weights=*/
@@ -105,8 +99,8 @@ at::Tensor embedding_bag_4bit_helper(
         success,
         "FBGEMM GenerateEmbeddingSpMDMNBit kernel failed for 4-bit input");
   } else {
-    auto kernel_64_ =
-        fbgemm::GenerateEmbeddingSpMDMNBitRowWiseSparse<std::int64_t>(
+    auto kernel =
+        fbgemm::GenerateEmbeddingSpMDMNBitRowWiseSparse<IndexType, OffsetType>(
             /*bit rate=*/4,
             /*block_size=*/block_size,
             /*has weights=*/per_sample_weights_.has_value(),
@@ -114,11 +108,11 @@ at::Tensor embedding_bag_4bit_helper(
             /*prefetch distance*/ prefetch_distance,
             /*is_weight_positional*/ false,
             /*use_offsets*/ true);
-    bool success = kernel_64_(
+    bool success = kernel(
         /*output_size=*/output_size,
         /*index_size=*/index_size,
         /*data_size=*/compressed_index_size,
-        /*input=*/input_data,
+        /*input=*/weight_data,
         /*indices=*/indices_data,
         /*offsets=*/offsets_data,
         /*weights=*/
@@ -133,8 +127,8 @@ at::Tensor embedding_bag_4bit_helper(
   }
 #else
 
-  auto accessor = offsets.accessor<int64_t, 1>();
-  std::vector<int> lengths_data;
+  auto accessor = offsets.accessor<OffsetType, 1>();
+  std::vector<OffsetType> lengths_data;
 
   int64_t lower = accessor[0];
   for (int64_t i = 1; i < offsets.numel(); ++i) {
@@ -172,7 +166,7 @@ at::Tensor embedding_bag_4bit_helper(
         }
       }
       const at::Half* scale_bias = reinterpret_cast<const at::Half*>(
-          input_data + (idx + 1) * weight_size - 2 * sizeof(at::Half));
+          weight_data + (idx + 1) * weight_size - 2 * sizeof(at::Half));
 
       float weight_val = 1.0f;
       if (per_sample_weights_.has_value()) {
@@ -183,7 +177,7 @@ at::Tensor embedding_bag_4bit_helper(
 
       for (int j = 0; j < block_size; ++j) {
         uint8_t quantized =
-            input_data[idx * weight_size + j / /*NUM_ELEM_PER_BYTE*/ 2];
+            weight_data[idx * weight_size + j / /*NUM_ELEM_PER_BYTE*/ 2];
         quantized >>= (j % 2) * 4;
         quantized &= (1 << 4) - 1;
 
@@ -197,49 +191,51 @@ at::Tensor embedding_bag_4bit_helper(
   return output;
 }
 
-at::Tensor embedding_bag_byte_helper(
-    const at::Tensor& packed_w,
+template <typename IndexType, typename OffsetType>
+at::Tensor embedding_bag_byte_impl(
+    const at::Tensor& weight,
     const at::Tensor& indices,
-    const c10::optional<at::Tensor>& offsets_in,
+    const at::Tensor& offsets,
     bool pruned_weights,
     const c10::optional<at::Tensor>& per_sample_weights_,
     bool include_last_offset) {
-  TORCH_CHECK(
-      offsets_in.has_value(),
-      "embedding_bag_byte_rowwise_offsets expects offsets to be set");
-  auto offsets = offsets_in.value();
-  auto offsets_data = offsets.data_ptr<int64_t>();
-  const auto indices_data = indices.data_ptr<int64_t>();
+  TORCH_CHECK(weight.scalar_type() == at::kByte);
+  TORCH_CHECK(weight.dim() == 2);
+  TORCH_CHECK(indices.dim() == 1);
+  TORCH_CHECK(offsets.dim() == 1);
 
-  const auto weight_data = packed_w.data_ptr<uint8_t>();
+  const auto weight_data = weight.data_ptr<uint8_t>();
+  const auto indices_data = indices.data_ptr<IndexType>();
+  auto offsets_data = offsets.data_ptr<OffsetType>();
 
-  const int64_t N = packed_w.size(0);
-  const int64_t D =
-      packed_w.size(1) - 8; // NB: -8 to account for scale and bias
+  const int64_t N = weight.size(0);
+  const int64_t D = weight.size(1) - 8; // NB: -8 to account for scale and bias
   const int64_t M = offsets.size(0);
 
   int64_t output_size = M - 1;
-  std::vector<int64_t> offsets_include_last;
-
+  std::vector<OffsetType> offsets_include_last_val;
   if (!include_last_offset) {
     output_size = M;
-    offsets_include_last.resize(M + 1);
-    std::memcpy(
-        offsets_include_last.data(),
-        offsets.data_ptr<int64_t>(),
-        sizeof(int64_t) * M);
-    offsets_include_last[M] = indices.numel();
-    offsets_data = offsets_include_last.data();
+    offsets_include_last_val.resize(M + 1);
+    // Avoid `null pointer passed as argument 2` ASAN violation when offsets
+    // tensor is empty.
+    if (M > 0) {
+      std::memcpy(
+          offsets_include_last_val.data(),
+          offsets_data,
+          sizeof(OffsetType) * M);
+    }
+    offsets_include_last_val[M] = indices.numel();
+    offsets_data = offsets_include_last_val.data();
   }
 
   std::vector<int64_t> shape = {output_size, D};
-  auto output = at::empty(shape, packed_w.options().dtype(at::kFloat));
+  auto output = at::empty(shape, weight.options().dtype(at::kFloat));
   auto* output_data = output.data_ptr<float>();
 
 #ifdef USE_FBGEMM
-
-  auto kernel_i8_i64 =
-      fbgemm::GenerateEmbeddingSpMDM<uint8_t, int64_t, int64_t>(
+  auto kernel_i8 =
+      fbgemm::GenerateEmbeddingSpMDM<uint8_t, IndexType, OffsetType>(
           /*block_size=*/D,
           /*has_weight=*/per_sample_weights_.has_value(),
           /*normalize_by_lengths=*/false,
@@ -247,55 +243,156 @@ at::Tensor embedding_bag_byte_helper(
           /*is_weight_positional=*/false,
           /*use_offsets=*/true);
 
-  if (packed_w.is_contiguous()) {
-    at::parallel_for(
-        0, output_size, 1, [&](int64_t start_idx, int64_t end_idx) {
-          bool success = kernel_i8_i64(
-              /*output_size=*/end_idx - start_idx,
-              /*index_size=*/offsets_data[end_idx] - offsets_data[start_idx],
-              /*data_size=*/N,
-              /*input=*/weight_data,
-              /*indices=*/indices_data + offsets_data[start_idx],
-              /*offsets_or_lengths=*/offsets_data + start_idx,
-              /*weights=*/
-              per_sample_weights_
-                  ? per_sample_weights_.value().data_ptr<float>() +
-                      offsets_data[start_idx]
-                  : nullptr,
-              /*out=*/output_data + start_idx * D);
+  at::parallel_for(0, output_size, 1, [&](int64_t start_idx, int64_t end_idx) {
+    bool success = kernel_i8(
+        /*output_size=*/end_idx - start_idx,
+        /*index_size=*/offsets_data[end_idx] - offsets_data[start_idx],
+        /*data_size=*/N,
+        /*input=*/weight_data,
+        /*indices=*/indices_data + offsets_data[start_idx],
+        /*offsets_or_lengths=*/offsets_data + start_idx,
+        /*weights=*/
+        per_sample_weights_ ? per_sample_weights_.value().data_ptr<float>() +
+                offsets_data[start_idx]
+                            : nullptr,
+        /*out=*/output_data + start_idx * D);
 
-          TORCH_CHECK(
-              success,
-              "FBGEMM GenerateEmbeddingSpMDM kernel failed for 8-bit input");
-        });
-  } else {
-    auto weight_contig = packed_w.contiguous();
-    const auto weight_data_contig = weight_contig.data_ptr<uint8_t>();
-    at::parallel_for(
-        0, output_size, 1, [&](int64_t start_idx, int64_t end_idx) {
-          bool success = kernel_i8_i64(
-              /*output_size=*/end_idx - start_idx,
-              /*index_size=*/offsets_data[end_idx] - offsets_data[start_idx],
-              /*data_size=*/N,
-              /*input=*/weight_data_contig,
-              /*indices=*/indices_data + offsets_data[start_idx],
-              /*offsets_or_lengths=*/offsets_data + start_idx,
-              /*weights=*/
-              per_sample_weights_
-                  ? per_sample_weights_.value().data_ptr<float>() +
-                      offsets_data[start_idx]
-                  : nullptr,
-              /*out=*/output_data + start_idx * D);
-          TORCH_CHECK(
-              success,
-              "FBGEMM GenerateEmbeddingSpMDM kernel failed for 8-bit input");
-        });
-  }
+    TORCH_CHECK(
+        success, "FBGEMM GenerateEmbeddingSpMDM kernel failed for 8-bit input");
+  });
 #endif
   // TODO add default (non-FBGEMM) implementation.
   return output;
 }
 
+at::Tensor embedding_bag_byte_helper(
+    const at::Tensor& weight,
+    const at::Tensor& indices,
+    const c10::optional<at::Tensor>& offsets_in,
+    bool pruned_weights,
+    const c10::optional<at::Tensor>& per_sample_weights_,
+    bool include_last_offset) {
+  TORCH_CHECK(
+      offsets_in.has_value(),
+      "embedding_bag_4bit_rowwise_offsets expects offsets to be set");
+  auto offsets = offsets_in.value();
+
+  TORCH_CHECK(
+      indices.scalar_type() == at::kInt || indices.scalar_type() == at::kLong,
+      "Expect 32 or 64 bit indices, but found ",
+      indices.scalar_type(),
+      " instead.");
+  TORCH_CHECK(
+      offsets.scalar_type() == at::kInt || offsets.scalar_type() == at::kLong,
+      "Expect 32 or 64 bit offsets, but found ",
+      offsets.scalar_type(),
+      " instead.");
+
+  // Using helper function to support different type combination without the
+  // need to cast, which can be additional performance overhead
+  if (indices.scalar_type() == at::kInt && offsets.scalar_type() == at::kInt) {
+    return embedding_bag_byte_impl<int, int>(
+        weight.contiguous(),
+        indices,
+        offsets,
+        pruned_weights,
+        per_sample_weights_,
+        include_last_offset);
+  } else if (
+      indices.scalar_type() == at::kInt && offsets.scalar_type() == at::kLong) {
+    return embedding_bag_byte_impl<int, int64_t>(
+        weight.contiguous(),
+        indices,
+        offsets,
+        pruned_weights,
+        per_sample_weights_,
+        include_last_offset);
+  } else if (
+      indices.scalar_type() == at::kLong && offsets.scalar_type() == at::kInt) {
+    return embedding_bag_byte_impl<int64_t, int>(
+        weight.contiguous(),
+        indices,
+        offsets,
+        pruned_weights,
+        per_sample_weights_,
+        include_last_offset);
+  }
+
+  // default case given the TORCH_CHECK above
+  return embedding_bag_byte_impl<int64_t, int64_t>(
+      weight.contiguous(),
+      indices,
+      offsets,
+      pruned_weights,
+      per_sample_weights_,
+      include_last_offset);
+}
+
+at::Tensor embedding_bag_4bit_helper(
+    const at::Tensor& weight,
+    const at::Tensor& indices,
+    const c10::optional<at::Tensor>& offsets_in,
+    bool pruned_weights,
+    const c10::optional<at::Tensor>& per_sample_weights_,
+    const c10::optional<at::Tensor>& compressed_indices_mapping,
+    bool include_last_offset) {
+  TORCH_CHECK(
+      offsets_in.has_value(),
+      "embedding_bag_4bit_rowwise_offsets expects offsets to be set");
+  auto offsets = offsets_in.value();
+
+  TORCH_CHECK(
+      indices.scalar_type() == at::kInt || indices.scalar_type() == at::kLong,
+      "Expect 32 or 64 bit indices, but found ",
+      indices.scalar_type(),
+      " instead.");
+  TORCH_CHECK(
+      offsets.scalar_type() == at::kInt || offsets.scalar_type() == at::kLong,
+      "Expect 32 or 64 bit offsets, but found ",
+      offsets.scalar_type(),
+      " instead.");
+
+  // Using helper function to support different type combination without the
+  // need to cast, which can be additional performance overhead
+  if (indices.scalar_type() == at::kInt && offsets.scalar_type() == at::kInt) {
+    return embedding_bag_4bit_impl<int, int>(
+        weight.contiguous(),
+        indices,
+        offsets,
+        pruned_weights,
+        per_sample_weights_,
+        compressed_indices_mapping,
+        include_last_offset);
+  } else if (
+      indices.scalar_type() == at::kInt && offsets.scalar_type() == at::kLong) {
+    return embedding_bag_4bit_impl<int, int64_t>(
+        weight.contiguous(),
+        indices,
+        offsets,
+        pruned_weights,
+        per_sample_weights_,
+        compressed_indices_mapping,
+        include_last_offset);
+  } else if (
+      indices.scalar_type() == at::kLong && offsets.scalar_type() == at::kInt) {
+    return embedding_bag_4bit_impl<int64_t, int>(
+        weight.contiguous(),
+        indices,
+        offsets,
+        pruned_weights,
+        per_sample_weights_,
+        compressed_indices_mapping,
+        include_last_offset);
+  }
+  return embedding_bag_4bit_impl<int64_t, int64_t>(
+      weight.contiguous(),
+      indices,
+      offsets,
+      pruned_weights,
+      per_sample_weights_,
+      compressed_indices_mapping,
+      include_last_offset);
+}
 } // namespace
 
 at::Tensor PackedEmbeddingBagWeight::embeddingbag_byte(
@@ -305,7 +402,7 @@ at::Tensor PackedEmbeddingBagWeight::embeddingbag_byte(
     const c10::optional<at::Tensor>& per_sample_weights_,
     bool include_last_offset) {
   return embedding_bag_byte_helper(
-      packed_w,
+      packed_w.contiguous(),
       indices,
       offsets_in,
       pruned_weights,
@@ -321,7 +418,7 @@ at::Tensor PackedEmbeddingBagWeight::embeddingbag_4bit(
     const c10::optional<at::Tensor>& compressed_indices_mapping,
     bool include_last_offset) {
   return embedding_bag_4bit_helper(
-      packed_w,
+      packed_w.contiguous(),
       indices,
       offsets_in,
       pruned_weights,
@@ -343,10 +440,8 @@ Tensor embedding_bag_byte_rowwise_offsets(
     bool pruned_weights,
     const c10::optional<Tensor>& per_sample_weights_,
     bool include_last_offset) {
-  TORCH_CHECK(weight.scalar_type() == at::kByte);
-  TORCH_CHECK(weight.dim() == 2);
   return embedding_bag_byte_helper(
-      weight,
+      weight.contiguous(),
       indices,
       offsets_in,
       pruned_weights,
@@ -365,7 +460,7 @@ Tensor embedding_bag_4bit_rowwise_offsets(
     const c10::optional<Tensor>& compressed_indices_mapping,
     bool include_last_offset) {
   return embedding_bag_4bit_helper(
-      weight,
+      weight.contiguous(),
       indices,
       offsets_in,
       pruned_weights,

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2966,7 +2966,9 @@ class TestQuantizedEmbeddingOps(TestCase):
 
     def embedding_bag_rowwise_offsets_run(
             self, bit_rate, num_embeddings,
-            embedding_dim, num_offsets, enable_per_sample_weights,
+            embedding_dim, num_offsets,
+            use_32bit_indices, use_32bit_offsets,
+            enable_per_sample_weights,
             include_last_offset, atol, rtol):
         pt_op = torch.ops.quantized.embedding_bag_byte_rowwise_offsets
         pt_prepack_op = torch.ops.quantized.embedding_bag_byte_prepack
@@ -3027,8 +3029,8 @@ class TestQuantizedEmbeddingOps(TestCase):
             per_sample_weights, indices, offsets)
         result = pt_op(
             q_weights,
-            indices,
-            offsets,
+            indices.int() if use_32bit_indices else indices,
+            offsets.int() if use_32bit_offsets else offsets,
             mode=0,
             per_sample_weights=per_sample_weights,
             include_last_offset=include_last_offset,
@@ -3065,14 +3067,19 @@ class TestQuantizedEmbeddingOps(TestCase):
     @given(num_embeddings=st.integers(10, 100),
            embedding_dim=st.integers(5, 50).filter(lambda x: x % 4 == 0),
            num_offsets=st.integers(1, 20),
+           use_32bit_indices=st.booleans(),
+           use_32bit_offsets=st.booleans(),
            enable_per_sample_weights=st.booleans(),
            include_last_offset=st.booleans())
     def test_embedding_bag_byte(self, num_embeddings,
                                 embedding_dim, num_offsets,
+                                use_32bit_indices,
+                                use_32bit_offsets,
                                 enable_per_sample_weights,
                                 include_last_offset):
         self.embedding_bag_rowwise_offsets_run(
             8, num_embeddings, embedding_dim, num_offsets,
+            use_32bit_indices, use_32bit_offsets,
             enable_per_sample_weights, include_last_offset,
             atol=0.005, rtol=1e-3)
 
@@ -3080,14 +3087,19 @@ class TestQuantizedEmbeddingOps(TestCase):
     @given(num_embeddings=st.integers(10, 100),
            embedding_dim=st.integers(5, 50).filter(lambda x: x % 4 == 0),
            num_offsets=st.integers(1, 20),
+           use_32bit_indices=st.booleans(),
+           use_32bit_offsets=st.booleans(),
            enable_per_sample_weights=st.booleans(),
            include_last_offset=st.booleans())
     def test_embedding_bag_4bit(self, num_embeddings,
                                 embedding_dim, num_offsets,
+                                use_32bit_indices,
+                                use_32bit_offsets,
                                 enable_per_sample_weights,
                                 include_last_offset):
         self.embedding_bag_rowwise_offsets_run(4, num_embeddings,
                                                embedding_dim, num_offsets,
+                                               use_32bit_indices, use_32bit_offsets,
                                                enable_per_sample_weights,
                                                include_last_offset, atol=0.1,
                                                rtol=1e-2)


### PR DESCRIPTION
Summary:
Support int32 as indices and offsets for embedding_bag_byte|4bit_rowwise_offsets, to avoid costly casting operators such as `aten::to`.
Currently we don't make the assumption that indices and offsets should be the same type, which should not be a problem since downstream fbgemm supports either cases.

Test Plan:
```
buck test mode/dev caffe2/test:quantization -- --stress-runs 100 test_embedding_bag
```

Differential Revision: D23854367

