### PR TITLE
[te] Tiled (m=32 x n=32) gemm benchmark

### DIFF
--- a/benchmarks/cpp/tensorexpr/tensorexpr.cpp
+++ b/benchmarks/cpp/tensorexpr/tensorexpr.cpp
@@ -61,7 +61,72 @@ BENCHMARK_DEFINE_F(Gemm, TensorExprNoopt)(benchmark::State& state) {
   }
 }
 
+BENCHMARK_DEFINE_F(Gemm, TensorExprTile32x32)(benchmark::State& state) {
+  te::KernelScope ks;
+
+  te::Placeholder AP(te::BufHandle("A", {M, K}, te::kFloat));
+  te::Placeholder BP(te::BufHandle("B", {K, N}, te::kFloat));
+  te::Tensor* CT = te::Reduce(
+      "gemm",
+      {{M, "M"}, {N, "N"}},
+      te::Sum(),
+      [&](const te::ExprHandle& m, const te::ExprHandle& n, const te::ExprHandle& k) {
+        return AP.load(m, k) * BP.load(k, n);
+      },
+      {{K, "K"}});
+  te::LoopNest loop({CT});
+
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    te::For* m = loops[0];
+    te::For* mo;
+    te::For* mi;
+    loop.splitWithMask(m, 32, &mo, &mi);
+  }
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    te::For* n = loops[2];
+    te::For* no;
+    te::For* ni;
+    loop.splitWithMask(n, 32, &no, &ni);
+  }
+  // mo, mi, no, ni, k ->
+  // mo, no, mi, ni, k
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    te::For* mi = loops[1];
+    te::For* no = loops[2];
+    loop.reorderAxis(mi, no);
+  }
+  // mo, no, mi, ni, k ->
+  // mo, no, mi, k, ni
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    te::For* ni = loops[3];
+    te::For* k = loops[4];
+    loop.reorderAxis(ni, k);
+  }
+  // mo, no, mi, k, ni ->
+  // mo, no, k, mi, ni
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    te::For* mi = loops[2];
+    te::For* k = loops[3];
+    loop.reorderAxis(mi, k);
+  }
+
+  loop.prepareForCodegen();
+  te::Stmt* s = loop.root_stmt();
+  s = te::IRSimplifier::simplify(s);
+  auto cg = CreateCodeGen("llvm_codegen", s, {AP, BP, CT});
+
+  for (auto _ : state) {
+    cg->call({A.data_ptr<float>(), B.data_ptr<float>(), C.data_ptr<float>()});
+  }
+}
+
 BENCHMARK_REGISTER_F(Gemm, Torch)->Args({128, 128, 128});
 BENCHMARK_REGISTER_F(Gemm, TensorExprNoopt)->Args({128, 128, 128});
+BENCHMARK_REGISTER_F(Gemm, TensorExprTile32x32)->Args({128, 128, 128});
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45906 [te][llvm] Enable fused multiply-add (fma) in code generation
* **#45905 [te] Tiled (m=32 x n=32) gemm benchmark**
* #45875 [te] Add a benchmark harness
* #45514 [te] Add a 2D convolution example test



Differential Revision: [D24142402](https://our.internmc.facebook.com/intern/diff/D24142402)