### PR TITLE
[te][llvm] Enable fused multiply-add (fma) in code generation

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -23,7 +23,7 @@
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 #include <torch/csrc/jit/tensorexpr/types.h>
 
-#define DEBUG_PRINT 0
+#define DEBUG_PRINT 1
 
 using namespace torch::jit::tensorexpr;
 
@@ -174,6 +174,7 @@ static llvm::orc::JITTargetMachineBuilder makeTargetMachineBuilder() {
   // once LLVM 10 is available.
   return llvm::cantFail(llvm::orc::JITTargetMachineBuilder::detectHost());
 #else
+  std::cerr << llvm::sys::getProcessTriple() << "\n";
   llvm::orc::JITTargetMachineBuilder JTMB(
       (llvm::Triple(llvm::sys::getProcessTriple())));
 
@@ -184,13 +185,15 @@ static llvm::orc::JITTargetMachineBuilder makeTargetMachineBuilder() {
   llvm::StringMap<bool> FeatureMap;
   llvm::sys::getHostCPUFeatures(FeatureMap);
   for (auto& Feature : FeatureMap) {
+    std::cerr << Feature.first().str() << ": " << Feature.second << "\n";
     SubtargetFeatures.AddFeature(Feature.first(), Feature.second);
   }
+
+  JTMB.getOptions().AllowFPOpFusion = llvm::FPOpFusion::Fast;
 
   JTMB.setCodeGenOptLevel(llvm::CodeGenOpt::Default);
   JTMB.setCPU(llvm::sys::getHostCPUName());
   JTMB.addFeatures(SubtargetFeatures.getFeatures());
-
   return JTMB;
 #endif
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45906 [te][llvm] Enable fused multiply-add (fma) in code generation**
* #45905 [te] Tiled (m=32 x n=32) gemm benchmark
* #45875 [te] Add a benchmark harness
* #45514 [te] Add a 2D convolution example test



Differential Revision: [D24142404](https://our.internmc.facebook.com/intern/diff/D24142404)