### PR TITLE
[JIT] Make objects throw Python AttributeError on nonexistent attr access

### DIFF
--- a/test/jit/test_torchbind.py
+++ b/test/jit/test_torchbind.py
@@ -286,3 +286,7 @@ class TestTorchbind(JitTestCase):
             if e.name == '_TorchScriptTesting::take_an_instance':
                 found_event = True
         self.assertTrue(found_event)
+
+    def test_torchbind_getattr(self):
+        foo = torch.classes._TorchScriptTesting._StackString(["test"])
+        self.assertEqual(None, getattr(foo, 'bar', None))

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -159,7 +159,7 @@ ValueError::ValueError(const char *format, ...) {
   va_end(fmt_args);
 }
 
-AttributeError::AttributeError(const char *format, ...) {
+AttributeError::AttributeError(const char* format, ...) {
   va_list fmt_args;
   va_start(fmt_args, format);
   msg = formatMessage(format, fmt_args);

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -159,6 +159,13 @@ ValueError::ValueError(const char *format, ...) {
   va_end(fmt_args);
 }
 
+AttributeError::AttributeError(const char *format, ...) {
+  va_list fmt_args;
+  va_start(fmt_args, format);
+  msg = formatMessage(format, fmt_args);
+  va_end(fmt_args);
+}
+
 void PyWarningHandler::process(
     const c10::SourceLocation& source_location,
     const std::string& msg,

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -291,6 +291,14 @@ struct NotImplementedError : public PyTorchError {
   }
 };
 
+// Translates to Python AttributeError
+struct AttributeError : public PyTorchError {
+  AttributeError(const char *format, ...) TORCH_FORMAT_FUNC(2, 3);
+  PyObject* python_type() override {
+    return PyExc_AttributeError;
+  }
+};
+
 struct WarningMeta {
   WarningMeta(const c10::SourceLocation& _source_location,
       const std::string& _msg,

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -293,7 +293,7 @@ struct NotImplementedError : public PyTorchError {
 
 // Translates to Python AttributeError
 struct AttributeError : public PyTorchError {
-  AttributeError(const char *format, ...) TORCH_FORMAT_FUNC(2, 3);
+  AttributeError(const char* format, ...) TORCH_FORMAT_FUNC(2, 3);
   PyObject* python_type() override {
     return PyExc_AttributeError;
   }

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -2,8 +2,8 @@
 
 #include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
-#include <torch/csrc/jit/api/method.h>
 #include <torch/csrc/Exceptions.h>
+#include <torch/csrc/jit/api/method.h>
 
 namespace torch {
 namespace jit {
@@ -68,10 +68,8 @@ struct TORCH_API Object {
       return _ivalue()->type()->getConstant(*r);
     }
     std::stringstream err;
-    err << _ivalue()->type()->repr_str()
-        << " does not have a field with name '"
-        << name.c_str()
-        << "'";
+    err << _ivalue()->type()->repr_str() << " does not have a field with name '"
+        << name.c_str() << "'";
     throw ObjectAttributeError(err.str());
   }
 

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -2,7 +2,6 @@
 
 #include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
-#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/jit/api/method.h>
 
 namespace torch {

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -3,6 +3,7 @@
 #include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
 #include <torch/csrc/jit/api/method.h>
+#include <torch/csrc/Exceptions.h>
 
 namespace torch {
 namespace jit {
@@ -11,6 +12,13 @@ struct Resolver;
 using ResolverPtr = std::shared_ptr<Resolver>;
 
 using ObjectPtr = c10::intrusive_ptr<c10::ivalue::Object>;
+
+// Throw this in C++ land if `attr` fails. This will be converted to a Python
+// AttributeError by the Python binding code
+class ObjectAttributeError : public std::runtime_error {
+ public:
+  ObjectAttributeError(const std::string& what) : std::runtime_error(what) {}
+};
 
 struct TORCH_API Object {
   Object() {}
@@ -59,12 +67,12 @@ struct TORCH_API Object {
     if (auto r = _ivalue()->type()->findConstantSlot(name)) {
       return _ivalue()->type()->getConstant(*r);
     }
-    TORCH_CHECK(
-        false,
-        _ivalue()->type()->repr_str(),
-        " does not have a field with name '",
-        name,
-        "'");
+    std::stringstream err;
+    err << _ivalue()->type()->repr_str()
+        << " does not have a field with name '"
+        << name.c_str()
+        << "'";
+    throw ObjectAttributeError(err.str());
   }
 
   c10::IValue attr(const std::string& name, c10::IValue or_else) const {

--- a/torch/csrc/jit/ir/attributes.h
+++ b/torch/csrc/jit/ir/attributes.h
@@ -138,8 +138,8 @@ struct TORCH_API GraphsAttr : public AttributeValue {
   ValueType value_;
 };
 
-struct AttributeError : public std::exception {
-  AttributeError(Symbol name, bool defined) {
+struct IRAttributeError : public std::exception {
+  IRAttributeError(Symbol name, bool defined) {
     std::stringstream ss;
     if (!defined) {
       ss << "required keyword attribute '" << name.toUnqualString()

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -810,7 +810,7 @@ struct TORCH_API Node {
     auto it = findAttr(name, true);
     auto* child = dynamic_cast<T*>(it->get());
     if (child == nullptr) {
-      throw AttributeError(name, true);
+      throw IRAttributeError(name, true);
     }
     return child->value();
   }
@@ -825,7 +825,7 @@ struct TORCH_API Node {
       return v->name == name;
     });
     if (required && it == values_.end()) {
-      throw AttributeError(name, false);
+      throw IRAttributeError(name, false);
     }
     AT_ASSERT(!required || it != values_.end());
     return it;
@@ -837,7 +837,7 @@ struct TORCH_API Node {
       return v->name == name;
     });
     if (required && it == values_.end()) {
-      throw AttributeError(name, false);
+      throw IRAttributeError(name, false);
     }
     AT_ASSERT(!required || it != values_.end());
     return it;

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -743,18 +743,26 @@ void initJitScriptBindings(PyObject* module) {
           .def(
               "getattr",
               [](Object& self, const std::string& name) {
-                return toPyObject(self.attr(name));
+                try {
+                  return toPyObject(self.attr(name));
+                } catch (ObjectAttributeError err) {
+                  throw AttributeError(err.what());
+                }
               })
           .def(
               "__getattr__",
               [](Object& self, const std::string& name) -> py::object {
-                if (name == "__qualname__") {
-                  return py::cast(self.type()->name()->name());
+                try {
+                  if (name == "__qualname__") {
+                    return py::cast(self.type()->name()->name());
+                  }
+                  if (auto method = self.find_method(name)) {
+                    return py::cast(*method);
+                  }
+                  return toPyObject(self.attr(name));
+                } catch (ObjectAttributeError err) {
+                  throw AttributeError(err.what());
                 }
-                if (auto method = self.find_method(name)) {
-                  return py::cast(*method);
-                }
-                return toPyObject(self.attr(name));
               })
           .def(
               "hasattr",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#45911 [JIT] Make objects throw Python AttributeError on nonexistent attr access**

Previously the Object API was just throwing a generic exception when trying to access an attribute that did not exist on that object's class. However, Python will check if the thrown exception is of type `AttributeError` for things like returning a default value (https://github.com/python/cpython/blob/d583738a87c3019dcfe06ed4a0002d1d6c9e9762/Objects/object.c#L1242). So, let's define a C++ `AttributeError` class that corresponds to the Python class and throw that instead. This gets further complicated by Python/C++ .so boundaries, so I put some conversion code in script_init.cpp.

Differential Revision: [D24140971](https://our.internmc.facebook.com/intern/diff/D24140971)