### PR TITLE
Update optim.rst for better understanding

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -269,7 +269,7 @@ and start to collect SWA averages of the parameters at epoch 160:
 >>>           optimizer.zero_grad()
 >>>           loss_fn(model(input), target).backward()
 >>>           optimizer.step()
->>>       if i > swa_start:
+>>>       if epoch > swa_start:
 >>>           swa_model.update_parameters(model)
 >>>           swa_scheduler.step()
 >>>       else:


### PR DESCRIPTION
The `i` variable in `Line 272` may cause ambiguity in understanding. I think it should be named as `epoch` variable.

Fixes #{issue number}
