### PR TITLE
Throw special exception when backend compilation is met with fatal error

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -181,6 +181,12 @@ class C10_API EnforceFiniteError : public Error {
   using Error::Error;
 };
 
+// Used in Onnxifi backend lowering.  These turn into
+// ExitException when they cross to Python.
+class C10_API OnnxfiBackendSystemError : public Error {
+  using Error::Error;
+};
+
 // A utility function to return an exception std::string by prepending its
 // exception type before its what() content
 C10_API std::string GetExceptionString(const std::exception& e);
@@ -340,7 +346,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 #endif
 #define TORCH_CHECK(cond, ...) TORCH_CHECK_WITH(Error, cond, __VA_ARGS__)
 
-// An utility macro that does what `TORCH_CHECK` does if compiled in the host code, 
+// An utility macro that does what `TORCH_CHECK` does if compiled in the host code,
 // otherwise does nothing. Supposed to be used in the code shared between host and
 // device code as an alternative for `TORCH_CHECK`.
 #if defined(__CUDACC__) || defined(__HIPCC__)

--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -4,6 +4,7 @@
 
 #include "onnx/onnx_pb.h"
 
+#include "c10/util/Exception.h"
 #include "c10/util/SmallVector.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
@@ -65,7 +66,7 @@ class OnnxifiOp final : public Operator<Context> {
     CAFFE_ENFORCE(!onnx_model_str.empty(), "onnx_model cannot be empty");
     if (use_glow_aot_) {
       auto netdef_str =
-        this->template GetSingleArgument<std::string>("netdef_str", "");
+          this->template GetSingleArgument<std::string>("netdef_str", "");
       CAFFE_ENFORCE(ParseProtoFromLargeString(netdef_str, &netdef_));
     } else if (!use_onnx_) {
       CAFFE_ENFORCE(ParseProtoFromLargeString(onnx_model_str, &netdef_));
@@ -187,7 +188,7 @@ class OnnxifiOp final : public Operator<Context> {
         this->template GetRepeatedArgument<std::string>("initializers");
     // Build the Onnxifi engine
     auto backend_index =
-      this->template GetSingleArgument<int>("backend_id", use_onnx_ ? 1 : 0);
+        this->template GetSingleArgument<int>("backend_id", use_onnx_ ? 1 : 0);
     // If using Glow AOT, override the backend_id to 1, since it uses a custom
     // ONNX format, and that's the id we use for the ONNX backend.
     if (use_glow_aot_) {
@@ -266,18 +267,24 @@ class OnnxifiOp final : public Operator<Context> {
 
       static const uint64_t auxPropertiesListAOT[] = {
           ONNXIFI_OPTIMIZATION_AOT, ONNXIFI_GRAPH_PROPERTY_NONE};
-      CAFFE_ENFORCE_EQ(
-          lib_->onnxInitGraph(
-              backend,
-              use_glow_aot_ ? auxPropertiesListAOT : nullptr,
-              onnx_model_str.size(),
-              (const void*)(onnx_model_str.c_str()),
-              weight_descs.size(),
-              weight_descs.data(),
-              &graph,
-              static_cast<uint32_t>(max_seq_size_),
-              defered_blob_reader),
-          ONNXIFI_STATUS_SUCCESS);
+      auto ret = lib_->onnxInitGraph(
+          backend,
+          use_glow_aot_ ? auxPropertiesListAOT : nullptr,
+          onnx_model_str.size(),
+          (const void*)(onnx_model_str.c_str()),
+          weight_descs.size(),
+          weight_descs.data(),
+          &graph,
+          static_cast<uint32_t>(max_seq_size_),
+          defered_blob_reader);
+      if (ret != ONNXIFI_STATUS_SUCCESS) {
+        if (ret == ONNXIFI_STATUS_FATAL_ERROR) {
+          C10_THROW_ERROR(
+              OnnxfiBackendSystemError, "Fatal error during onnxInitGraph");
+        } else {
+          CAFFE_THROW("onnxInitGraph failed");
+        }
+      }
 
       return std::make_shared<onnx::BackendGraphInfo>(
           backend_id, backend, graph, lib_, std::move(weight_shape_info));


### PR DESCRIPTION
Summary: When glow compilation meets with nonrecoverable fatal error (hardware is busted), we would like to throw a special exception other than the normal caffe2::EnforceNotMet so that we can signal the upper layer application to handle it differently.

Test Plan: Manually code some error and add LOG(FATAL) in the special exception path and wait for application to fatal.

Differential Revision: D24156792

