### PR TITLE
Recommit: caffe2/plan_executor: wait for 1 minute after exception and then abort

### DIFF
--- a/caffe2/core/plan_executor_test.cc
+++ b/caffe2/core/plan_executor_test.cc
@@ -67,6 +67,29 @@ class ErrorOp final : public Operator<CPUContext> {
 REGISTER_CPU_OPERATOR(Error, ErrorOp);
 OPERATOR_SCHEMA(Error).NumInputs(0).NumOutputs(0);
 
+static std::atomic<int> blockingErrorRuns{0};
+class BlockingErrorOp final : public Operator<CPUContext> {
+ public:
+  BlockingErrorOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    // First n op executions should block and then start throwing errors.
+    if (blockingErrorRuns.fetch_sub(1) >= 1) {
+      LOG(INFO) << "blocking";
+      while (true) {
+        std::this_thread::sleep_for(std::chrono::hours(10));
+      }
+    } else {
+      LOG(INFO) << "throwing";
+      throw TestError();
+    }
+  }
+};
+
+REGISTER_CPU_OPERATOR(BlockingError, BlockingErrorOp);
+OPERATOR_SCHEMA(BlockingError).NumInputs(0).NumOutputs(0);
+
 PlanDef parallelErrorPlan() {
   PlanDef plan_def;
 
@@ -101,10 +124,12 @@ PlanDef parallelErrorPlan() {
 }
 
 struct HandleExecutorThreadExceptionsGuard {
-  HandleExecutorThreadExceptionsGuard() {
+  HandleExecutorThreadExceptionsGuard(int timeout = 60) {
     globalInit({
         "caffe2",
         "--caffe2_handle_executor_threads_exceptions=1",
+        "--caffe2_plan_executor_exception_timeout=" +
+            caffe2::to_string(timeout),
     });
   }
 
@@ -137,6 +162,38 @@ TEST(PlanExecutorTest, ErrorAsyncPlan) {
   Workspace ws;
   ASSERT_THROW(ws.RunPlan(plan_def), TestError);
   ASSERT_EQ(cancelCount, 1);
+}
+
+TEST(PlanExecutorTest, BlockingErrorPlan) {
+  ASSERT_DEATH(
+      [] {
+        HandleExecutorThreadExceptionsGuard guard(/*timeout=*/1);
+
+        PlanDef plan_def;
+
+        std::string plan_def_template = R"DOC(
+          network {
+            name: "net"
+            op {
+              type: "BlockingError"
+            }
+          }
+          execution_step {
+            num_concurrent_instances: 2
+            substep {
+              network: "net"
+            }
+          }
+        )DOC";
+
+        CAFFE_ENFORCE(
+            TextFormat::ParseFromString(plan_def_template, &plan_def));
+        Workspace ws;
+        blockingErrorRuns = 1;
+        ws.RunPlan(plan_def);
+        FAIL() << "shouldn't have reached this point";
+      }(),
+      "failed to stop concurrent workers after exception: test error");
 }
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
This is a recommit of previously reverted D20850851 (https://github.com/pytorch/pytorch/commit/3fbddb92b1be1f70edced886745116b8daeebb17).

TL;DR - combining condition_variables and atomics is a bad idea

https://stackoverflow.com/questions/49622713/c17-atomics-and-condition-variable-deadlock

Test Plan:
buck test mode/opt //caffe2/caffe2/python:hypothesis_test -- --stress-runs 1000 test_atomic_iter_with_concurrent_steps --timeout 120
  buck test mode/opt //caffe2/caffe2/python:hypothesis_test -- --stress-runs 100
  buck test mode/opt caffe2/caffe2:caffe2_test_cpu -- PlanExecutorTest --stress-runs 100

no timeouts https://www.internalfb.com/intern/testinfra/testconsole/testrun/7036874440059883/

will ensure no timeouts in OSS

Differential Revision: D24165505

