### PR TITLE
[ci-all tests] [reland] Improve logging in ProcessGroupNCCL for debugging purposes.

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -1619,6 +1619,10 @@ class ProcessGroupNCCLNoGPUTest(TestCase):
             c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
 
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "TSAN is not fork-safe since we're forking in a multi-threaded environment",
+)
 class ProcessGroupNCCLTest(TestCase):
     MAIN_PROCESS_RANK = 0
 
@@ -3828,7 +3832,6 @@ class ComputeBucketAssignmentTest(TestCase):
         self.assertEqual([[0], [1], [2, 4], [3, 5]], result)
 
 
-@skip_if_rocm
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
 class NcclErrorHandlingTest(MultiProcessTestCase):
     def setUp(self):
@@ -3993,7 +3996,7 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
                     return
                 else:
                     raise e
-            time.sleep(0.1)
+            time.sleep(1)
 
     @requires_nccl()
     @skip_if_lt_x_gpu(3)

--- a/torch/lib/c10d/ProcessGroup.cpp
+++ b/torch/lib/c10d/ProcessGroup.cpp
@@ -4,6 +4,62 @@
 
 namespace c10d {
 
+std::string opTypeToString(OpType opType) {
+  switch (opType) {
+    case OpType::BROADCAST:
+      return "BROADCAST";
+    case OpType::ALLREDUCE:
+      return "ALLREDUCE";
+    case OpType::ALLREDUCE_COALESCED:
+      return "ALLREDUCE_COALESCED";
+    case OpType::REDUCE:
+      return "REDUCE";
+    case OpType::ALLGATHER:
+      return "ALLGATHER";
+    case OpType::ALLGATHER_BASE:
+      return "ALLGATHER_BASE";
+    case OpType::ALLGATHER_COALESCED:
+      return "ALLGATHER_COALESCED";
+    case OpType::GATHER:
+      return "GATHER";
+    case OpType::SCATTER:
+      return "SCATTER";
+    case OpType::REDUCE_SCATTER:
+      return "REDUCE_SCATTER";
+    case OpType::ALLTOALL_BASE:
+      return "ALLTOALL_BASE";
+    case OpType::ALLTOALL:
+      return "ALLTOALL";
+    case OpType::SEND:
+      return "SEND";
+    case OpType::RECV:
+      return "RECV";
+    case OpType::RECVANYSOURCE:
+      return "RECVANYSOURCE";
+    case OpType::BARRIER:
+      return "BARRIER";
+    case OpType::UNKNOWN:
+      return "UNKNOWN";
+    default:
+      TORCH_INTERNAL_ASSERT("Unknown op type!");
+  }
+  return "UNKNOWN";
+}
+
+bool isP2POp(OpType opType) {
+  return opType == OpType::SEND || opType == OpType::RECV ||
+      opType == OpType::RECVANYSOURCE;
+}
+
+ProcessGroup::Work::Work() : rank_(-1), opType_(OpType::UNKNOWN) {}
+
+ProcessGroup::Work::Work(int rank, OpType opType)
+    : rank_(rank), opType_(opType) {}
+
+OpType ProcessGroup::Work::retrieveOpType() {
+  return opType_;
+}
+
 ProcessGroup::Work::~Work() {}
 
 bool ProcessGroup::Work::isCompleted() {

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -241,8 +241,22 @@ constexpr int64_t kSynchronizeBusyWaitMillis = 10;
 const int64_t ProcessGroupNCCL::kProcessGroupNCCLOpTimeoutMillis = 10 * 1000;
 thread_local uint64_t ProcessGroupNCCL::ncclActiveGroupCounter_ = 0;
 
-ProcessGroupNCCL::WorkNCCL::WorkNCCL(const std::vector<at::Device>& devices)
-    : devices_(devices), workStartTime_(std::chrono::steady_clock::now()) {
+std::ostream& operator<<(
+    std::ostream& output,
+    const ProcessGroupNCCL::WorkNCCL& workNCCL) {
+  return output << "WorkNCCL("
+                << "OpType=" << opTypeToString(workNCCL.opType_)
+                << ", TensorShape=" << (*workNCCL.outputs_)[0].sizes()
+                << ", Timeout(ms)=" << workNCCL.opTimeout_.count() << ")";
+}
+
+ProcessGroupNCCL::WorkNCCL::WorkNCCL(
+    const std::vector<at::Device>& devices,
+    int rank,
+    OpType opType)
+    : Work(rank, opType),
+      devices_(devices),
+      workStartTime_(std::chrono::steady_clock::now()) {
   // Creates the CUDA event wrappers
   // Note: The actual events are lazily created when first recorded to with
   // DEFAULT_FLAGS = cudaEventDisableTiming.
@@ -252,7 +266,8 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(const std::vector<at::Device>& devices)
 }
 
 ProcessGroupNCCL::WorkNCCL::WorkNCCL(const WorkNCCL& w)
-    : std::enable_shared_from_this<WorkNCCL>(w),
+    : Work(w.rank_, w.opType_),
+      std::enable_shared_from_this<WorkNCCL>(w),
       devices_(w.devices_),
       cudaEvents_(w.cudaEvents_),
       ncclComms_(w.ncclComms_),
@@ -375,9 +390,19 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeInternal(
           ncclComm->ncclCommAbort();
           const auto& storeKey = getNcclAbortedCommStoreKey(
               buildNcclUniqueIdStr(ncclComm->getNcclId()));
-          store_->set(storeKey, {});
-          LOG(INFO) << "Wrote aborted communicator id to store: " << storeKey;
+          auto rankStr = std::to_string(rank_);
+          store_->set(
+              storeKey,
+              std::vector<uint8_t>(
+                  reinterpret_cast<const uint8_t*>(rankStr.data()),
+                  reinterpret_cast<const uint8_t*>(rankStr.data()) +
+                      rankStr.size()));
+          LOG(INFO) << "[Rank " << rank_
+                    << "] Wrote aborted communicator id to store: " << storeKey;
         }
+        LOG(INFO) << "[Rank " << rank_
+                  << "] Caught collective operation timeout for work: "
+                  << (*this);
         throw std::runtime_error("Operation timed out!");
       }
       // Check for errors and throw appropriate exception.
@@ -430,7 +455,6 @@ void ProcessGroupNCCL::parseNcclAsyncErrorHandling() {
     auto val = std::stoi(errorHandle);
     if (val == 1) {
       asyncErrorHandling_ = true;
-      LOG(INFO) << "[Rank " << rank_ << "] NCCL Async Error Handling enabled.";
     } else if (val != 0) {
       throw std::runtime_error(
           "Invalid value for environment variable: " +
@@ -483,6 +507,12 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   if (asyncErrorHandling_) {
     workCleanupThread_ = std::thread(&ProcessGroupNCCL::workCleanupLoop, this);
   }
+  LOG(INFO) << "[Rank " << rank_
+            << "] ProcessGroupNCCL initialized with following options:"
+            << "\nNCCL_ASYNC_ERROR_HANDLING: " << asyncErrorHandling_
+            << "\nNCCL_BLOCKING_WAIT: " << blockingWait_
+            << "\nTIMEOUT(ms): " << opTimeout_.count()
+            << "\nUSE_HIGH_PRIORITY_STREAM: " << isHighPriorityStream_;
 }
 
 ProcessGroupNCCL::~ProcessGroupNCCL() {
@@ -513,12 +543,17 @@ ProcessGroupNCCL::~ProcessGroupNCCL() {
 
 void ProcessGroupNCCL::ncclCommWatchdog() {
   try {
+    LOG(INFO) << "[Rank " << rank_ << "] NCCL watchdog thread started!";
     ncclCommWatchdogInternal();
-    LOG(INFO) << "[Rank " << rank_ << "] NCCL watchdog thread terminated normally";
+    LOG(INFO) << "[Rank " << rank_
+              << "] NCCL watchdog thread terminated normally";
   } catch (std::exception& e) {
-    LOG(INFO) << "NCCL watchdog thread terminated with exception: " << e.what();
+    LOG(INFO) << "[Rank " << rank_
+              << "] NCCL watchdog thread terminated with exception: "
+              << e.what();
   } catch (...) {
-    LOG(INFO) << "NCCL watchdog thread terminated with unknown exception";
+    LOG(INFO) << "[Rank " << rank_
+              << "] NCCL watchdog thread terminated with unknown exception";
   }
 }
 
@@ -539,10 +574,12 @@ void ProcessGroupNCCL::ncclCommWatchdogInternal() {
         }
 
         if (checkForNCCLErrors(ncclComms)) {
-          LOG(INFO) << "Received NCCL errors for communicators in the cache";
+          LOG(INFO) << "[Rank " << rank_
+                    << "] Received NCCL errors for communicators in the cache";
 
           if (blockingWait_ || asyncErrorHandling_) {
-            LOG(INFO) << "Aborting communicators that received errors";
+            LOG(INFO) << "[Rank " << rank_
+                      << "] Aborting communicators that received errors";
             // We abort NCCL communicators that have received errors from this
             // thread, and exceptions are set on the corresponding work objects.
             // The workCleanupThread will then loop through the unfinished
@@ -559,7 +596,8 @@ void ProcessGroupNCCL::ncclCommWatchdogInternal() {
               // a communicator the application receives an exception and its
               // their responsibility to destroy the process group and recreate
               // it to recover from errors.
-              abortedCommIds.emplace(buildNcclUniqueIdStr(ncclComm->getNcclId()));
+              abortedCommIds.emplace(
+                  buildNcclUniqueIdStr(ncclComm->getNcclId()));
             }
           }
         }
@@ -578,7 +616,10 @@ void ProcessGroupNCCL::ncclCommWatchdogInternal() {
         // Check for Timeouts in the WorkNCCL Operations, and abort all
         // communicators accordingly.
         if (work.timedOut()) {
-          LOG(INFO) << "[" << rank_ << "] caught collective operation timeout";
+          LOG(INFO)
+              << "[Rank " << rank_
+              << "] Watchdog caught collective operation timeout for work: "
+              << work;
           std::exception_ptr exception_ptr = std::make_exception_ptr(
               std::runtime_error("NCCL Operation Timed Out"));
           work.setException(exception_ptr);
@@ -601,8 +642,15 @@ void ProcessGroupNCCL::ncclCommWatchdogInternal() {
       for (const auto& abortedCommId : abortedCommIds) {
         abortedComms_.emplace(abortedCommId);
         const auto& storeKey = getNcclAbortedCommStoreKey(abortedCommId);
-        store_->set(storeKey, {});
-        LOG(INFO) << "Watchdog wrote aborted communicator id to store: "
+        auto rankStr = std::to_string(rank_);
+        store_->set(
+            storeKey,
+            std::vector<uint8_t>(
+                reinterpret_cast<const uint8_t*>(rankStr.data()),
+                reinterpret_cast<const uint8_t*>(rankStr.data()) +
+                    rankStr.size()));
+        LOG(INFO) << "[Rank " << rank_
+                  << "] Watchdog wrote aborted communicator id to store: "
                   << storeKey;
       }
 
@@ -616,7 +664,11 @@ void ProcessGroupNCCL::ncclCommWatchdogInternal() {
             store_->wait(
                 {storeKey},
                 std::chrono::milliseconds(kWaitForAbortCommStoreKey));
-            LOG(INFO) << "Found key in store: " << storeKey
+            auto val = store_->get(storeKey);
+            std::string rank(reinterpret_cast<char*>(val.data()), val.size());
+            LOG(INFO) << "[Rank " << rank_
+                      << "] Found key in store: " << storeKey
+                      << ", from rank: " << rank
                       << ", aborting appropriate communicators";
 
             // Now abort the appropriate communicators.
@@ -627,7 +679,9 @@ void ProcessGroupNCCL::ncclCommWatchdogInternal() {
               ncclComm->ncclCommAbort();
             }
             abortedComms_.emplace(commId);
-            LOG(INFO) << "Aborted communicators for key in store: " << storeKey;
+            LOG(INFO) << "[Rank " << rank_
+                      << "] Aborted communicators for key in store: "
+                      << storeKey;
           } catch (std::exception& e) {
             VLOG(1) << "Did not find key in store: " << storeKey
                     << ", error: " << e.what();
@@ -726,7 +780,7 @@ void ProcessGroupNCCL::broadcastUniqueNCCLID(ncclUniqueId* ncclID) {
 std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     const std::string& devicesKey,
     const std::vector<at::Device>& devices,
-    NCCLCommType commType,
+    OpType opType,
     int p2pRank) {
   // Sanity check
   if (devicesKey.empty()) {
@@ -755,7 +809,7 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
   ncclUniqueId ncclID;
 
   // For point-to-point communication, lower rank of the two will get unique id.
-  if (rank_ == 0 || (commType != NCCLCommType::COLL && p2pRank == 0)) {
+  if (rank_ == 0 || (isP2POp(opType) && p2pRank == 0)) {
     C10D_NCCL_CHECK(ncclGetUniqueId(&ncclID));
   }
 
@@ -793,12 +847,12 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     // GPU world size and GPU rank
     int numRanks, rank;
 
-    if (commType == NCCLCommType::COLL) {
+    if (!isP2POp(opType)) {
       numRanks = getSize() * devices.size();
       rank = getRank() * devices.size() + i;
     } else {
-    // For point-to-point operation, there are only 2 processes involved so
-    // the GPU rank is either 0 or 1.
+      // For point-to-point operation, there are only 2 processes involved so
+      // the GPU rank is either 0 or 1.
       numRanks = 2;
       rank = p2pRank;
     }
@@ -816,7 +870,8 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     std::lock_guard<std::mutex> lock(mutex_);
     if (futureNCCLCallbackStreams_[deviceIndex] == nullptr) {
       futureNCCLCallbackStreams_[deviceIndex] =
-          std::make_shared<at::cuda::CUDAStream>(at::cuda::getStreamFromPool(isHighPriorityStream_));
+          std::make_shared<at::cuda::CUDAStream>(
+              at::cuda::getStreamFromPool(isHighPriorityStream_));
     }
   }
 
@@ -947,8 +1002,10 @@ std::vector<at::Tensor> flatten_for_scatter_gather(
 } // namespace
 
 std::shared_ptr<ProcessGroupNCCL::WorkNCCL> ProcessGroupNCCL::initWork(
-    std::vector<at::Device> devices) {
-  return std::make_shared<ProcessGroupNCCL::WorkNCCL>(devices);
+    std::vector<at::Device> devices,
+    int rank,
+    OpType opType) {
+  return std::make_shared<ProcessGroupNCCL::WorkNCCL>(devices, rank, opType);
 }
 
 std::vector<at::Tensor> ProcessGroupNCCL::WorkNCCL::result() {
@@ -982,7 +1039,8 @@ void ProcessGroupNCCL::workEnqueue(
   }
 }
 ProcessGroupNCCL::Options::Options()
-    : opTimeout(kProcessGroupNCCLOpTimeoutMillis), isHighPriorityStream(false) {}
+    : opTimeout(kProcessGroupNCCLOpTimeoutMillis),
+      isHighPriorityStream(false) {}
 
 template <typename Fn, typename PreProcess, typename PostProcess>
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
@@ -990,16 +1048,17 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
     std::vector<at::Tensor>& outputs,
     Fn fn,
     PreProcess pre,
-    PostProcess post) {
+    PostProcess post,
+    OpType opType) {
   const auto devices = getDeviceList(inputs);
   const auto key = getKeyFromDevices(devices);
-  auto& ncclComms = getNCCLComm(key, devices);
+  auto& ncclComms = getNCCLComm(key, devices, opType);
 
   // First let NCCL streams wait for input tensors allocation streams
   syncStreams(devices, ncclEvents_[key], ncclStreams_[key]);
 
   // Work itself will create the CUDA events on all GPUs of tensors
-  auto work = initWork(devices);
+  auto work = initWork(devices, rank_, opType);
 
   // Store references to outputs and futureNCCLCallbackStream to be used by
   // WorkNCCL::getFuture.
@@ -1043,10 +1102,12 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
     (*work->cudaEvents_)[i].record(ncclStream);
     work->ncclComms_[i] = ncclComms[i];
-    work->blockingWait_ = blockingWait_;
-    work->opTimeout_ = opTimeout_;
-    work->store_ = store_;
   }
+
+  // Set appropriate work parameters.
+  work->blockingWait_ = blockingWait_;
+  work->opTimeout_ = opTimeout_;
+  work->store_ = store_;
 
   if (asyncErrorHandling_) {
     workEnqueue(work);
@@ -1060,21 +1121,21 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
     std::vector<at::Tensor>& tensors,
     Fn fn,
     int peer,
-    NCCLCommType commType,
+    OpType opType,
     PreProcess pre,
     PostProcess post) {
   const auto devices = getDeviceList(tensors);
   const auto key = getKeySendRecv(rank_, peer);
   int p2pRank = rank_ < peer ? 0 : 1;
-  auto& ncclComms = getNCCLComm(key, devices, commType, p2pRank);
+  auto& ncclComms = getNCCLComm(key, devices, opType, p2pRank);
 
   // First let NCCL streams wait for input tensors allocation streams
   syncStreams(devices, ncclEvents_[key], ncclStreams_[key]);
 
   // Work itself will create the CUDA events on all GPUs of tensors
-  auto work = initWork(devices);
+  auto work = initWork(devices, rank_, opType);
 
-  if (commType == NCCLCommType::RECV) {
+  if (opType == OpType::RECV) {
     // Store references to outputs and futureNCCLCallbackStream to be used by
     // WorkNCCL::getFuture.
     work->outputs_ = std::make_shared<std::vector<at::Tensor>>(tensors);
@@ -1130,13 +1191,15 @@ template <typename Fn>
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
     std::vector<at::Tensor>& inputs,
     std::vector<at::Tensor>& outputs,
-    Fn fn) {
+    Fn fn,
+    OpType opType) {
   return collective(
       inputs,
       outputs,
       fn,
       [](std::vector<at::cuda::CUDAStream>&) {},
-      [](std::vector<at::cuda::CUDAStream>&) {});
+      [](std::vector<at::cuda::CUDAStream>&) {},
+      opType);
 }
 
 template <typename Fn>
@@ -1144,12 +1207,12 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
     std::vector<at::Tensor>& tensor,
     Fn fn,
     int peer,
-    NCCLCommType type) {
+    OpType opType) {
   return pointToPoint(
       tensor,
       fn,
       peer,
-      type,
+      opType,
       [](std::vector<at::cuda::CUDAStream>&) {},
       [](std::vector<at::cuda::CUDAStream>&) {});
 }
@@ -1174,7 +1237,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
             getNcclReduceOp(opts.reduceOp, input),
             comm,
             stream.stream());
-      });
+      },
+      OpType::ALLREDUCE);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce_coalesced(
@@ -1204,7 +1268,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
             root,
             comm,
             stream.stream());
-      });
+      },
+      OpType::BROADCAST);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce(
@@ -1229,7 +1294,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce(
             root,
             comm,
             stream.stream());
-      });
+      },
+      OpType::REDUCE);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
@@ -1272,7 +1338,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
             outputTensors[i][j].copy_(outputFlattened[i][j], true);
           }
         }
-      });
+      },
+      OpType::ALLGATHER);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather_coalesced(
@@ -1324,7 +1391,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
           }
         }
       },
-      [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {});
+      [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {},
+      OpType::REDUCE_SCATTER);
 }
 
 std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier(
@@ -1394,7 +1462,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::alltoall_base(
               getNcclDataType(input.scalar_type()),
               comm,
               stream.stream());
-        });
+        },
+        OpType::ALLTOALL_BASE);
   } else {
     c10d::checkSplitSizes(inputSplitSizes, inputTensor, size_);
     c10d::checkSplitSizes(outputSplitSizes, outputTensor, size_);
@@ -1426,7 +1495,8 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::alltoall_base(
               getNcclDataType(input.scalar_type()),
               comm,
               stream.stream());
-        });
+        },
+        OpType::ALLTOALL_BASE);
   }
 }
 
@@ -1450,7 +1520,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::send(
             stream.stream());
       },
       dstRank,
-      NCCLCommType::SEND);
+      OpType::SEND);
   return ret;
 }
 
@@ -1459,7 +1529,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recv(
     int srcRank,
     int /* unused */) {
   check_gpu_tensors(tensors);
-  auto ret= pointToPoint(
+  auto ret = pointToPoint(
       tensors,
       [&](at::Tensor& output,
           ncclComm_t comm,
@@ -1474,7 +1544,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::recv(
             stream.stream());
       },
       srcRank,
-      NCCLCommType::RECV);
+      OpType::RECV);
   return ret;
 }
 #else

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <list>
 #include <mutex>
 #include <thread>
@@ -22,13 +23,6 @@ constexpr const char* NCCL_BLOCKING_WAIT = "NCCL_BLOCKING_WAIT";
 // Environment variable which controls whether or not we perform Async Error
 // Handling with NCCL.
 constexpr const char* NCCL_ASYNC_ERROR_HANDLING = "NCCL_ASYNC_ERROR_HANDLING";
-
-// NCCL Commmunication type
-enum class NCCLCommType : std::uint8_t {
-  SEND = 0,
-  RECV,
-  COLL,
-};
 
 // ProcessGroupNCCL implements NCCL bindings for c10d.
 //
@@ -71,7 +65,7 @@ class ProcessGroupNCCL : public ProcessGroup {
                    public std::enable_shared_from_this<WorkNCCL> {
    public:
     // Constructor takes a list of CUDA devices
-    WorkNCCL(const std::vector<at::Device>& devices);
+    WorkNCCL(const std::vector<at::Device>& devices, int rank, OpType opType);
     // Copy constructor doing partial copy without outputs_. Cleanup thread
     // monitors and removes finished works. However it will deadlock when
     // destructs outputs_ tensors who are view tensors in autograd graph.
@@ -147,6 +141,10 @@ class ProcessGroupNCCL : public ProcessGroup {
     virtual std::exception_ptr checkForNCCLErrors(
         const std::vector<std::shared_ptr<NCCLComm>>& ncclComms) const;
 
+    friend std::ostream& operator<<(
+        std::ostream& output,
+        const WorkNCCL& workNCCL);
+
    private:
     // Helper function for synchronize
     void synchronizeInternal(std::chrono::milliseconds timeout);
@@ -166,6 +164,7 @@ class ProcessGroupNCCL : public ProcessGroup {
 
     // Store a reference to NCCL collective's outputs to be used by getFuture.
     std::shared_ptr<std::vector<at::Tensor>> outputs_;
+
     // Store streams that run FutureNCCL then callbacks.
     std::vector<std::shared_ptr<at::cuda::CUDAStream>>
         futureNCCLCallbackStreams_;
@@ -467,7 +466,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   std::vector<std::shared_ptr<NCCLComm>>& getNCCLComm(
       const std::string& devicesKey,
       const std::vector<at::Device>& devices,
-      NCCLCommType commType = NCCLCommType::COLL,
+      OpType opType,
       int p2pRank = 0);
 
   // Wrapper method which can be overridden for tests.
@@ -475,7 +474,9 @@ class ProcessGroupNCCL : public ProcessGroup {
       const std::vector<std::shared_ptr<NCCLComm>>& ncclComms);
 
   virtual std::shared_ptr<ProcessGroupNCCL::WorkNCCL> initWork(
-      std::vector<at::Device> devices);
+      std::vector<at::Device> devices,
+      int rank,
+      OpType opType);
 
  private:
   // Helper that encapsulates work shared across all collective communication
@@ -488,14 +489,16 @@ class ProcessGroupNCCL : public ProcessGroup {
   std::shared_ptr<ProcessGroup::Work> collective(
       std::vector<at::Tensor>& input,
       std::vector<at::Tensor>& output,
-      Fn fn);
+      Fn fn,
+      OpType opType);
   template <typename Fn, typename PreProcess, typename PostProcess>
   std::shared_ptr<ProcessGroup::Work> collective(
       std::vector<at::Tensor>& input,
       std::vector<at::Tensor>& output,
       Fn fn,
       PreProcess pre,
-      PostProcess post);
+      PostProcess post,
+      OpType opType);
 
   // Helper that encapsulates work shared across point-to-point communication
   // primitives. It is the same structure as the helper used for collective
@@ -505,13 +508,13 @@ class ProcessGroupNCCL : public ProcessGroup {
       std::vector<at::Tensor>& tensor,
       Fn fn,
       int peer,
-      NCCLCommType commType);
+      OpType opType);
   template <typename Fn, typename PreProcess, typename PostProcess>
   std::shared_ptr<ProcessGroup::Work> pointToPoint(
       std::vector<at::Tensor>& tensor,
       Fn fn,
       int peer,
-      NCCLCommType commType,
+      OpType opType,
       PreProcess pre,
       PostProcess post);
 
@@ -537,8 +540,8 @@ class ProcessGroupNCCL : public ProcessGroup {
   // accordingly.
   void parseNcclBlockingWait();
 
-  // Reads the NCCL_ASYNC_ERROR_HANDLING environment variable and sets asyncErrorHandling_
-  // accordingly.
+  // Reads the NCCL_ASYNC_ERROR_HANDLING environment variable and sets
+  // asyncErrorHandling_ accordingly.
   void parseNcclAsyncErrorHandling();
 
   void workCleanupLoop();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46009 [ci-all tests] [reland] Improve logging in ProcessGroupNCCL for debugging purposes.**

When training jobs running with NCCL fail sometimes it is hard to
debug the reason of the failure and our logging doesn't provide enough
information at times to narrow down the issue.

To improve the debugging experience, I've enhanced our logging to add a lot
more information about what the ProcessGroup is doing under the hood.

#Closes: https://github.com/pytorch/pytorch/issues/45310

Sample output:
```
> I1002 15:18:48.539551 1822062 ProcessGroupNCCL.cpp:528] [Rank 2] NCCL watchdog thread started!
> I1002 15:18:48.539533 1821946 ProcessGroupNCCL.cpp:492] [Rank 2] ProcessGroupNCCL initialized with following options:
> NCCL_ASYNC_ERROR_HANDLING: 0
> NCCL_BLOCKING_WAIT: 1
> TIMEOUT(ms): 1000
> USE_HIGH_PRIORITY_STREAM: 0
> I1002 15:18:51.080338 1822035 ProcessGroupNCCL.cpp:530] [Rank 1] NCCL watchdog thread terminated normally
> I1002 15:18:52.161218 1821930 ProcessGroupNCCL.cpp:385] [Rank 0] Wrote aborted communicator id to store: NCCLABORTEDCOMM:a0e17500002836080c8384c50000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
> I1002 15:18:52.161238 1821930 ProcessGroupNCCL.cpp:388] [Rank 0] Caught collective operation timeout for work: WorkNCCL(OpType=ALLREDUCE, TensorShape=[10], Timeout(ms)=1000)
> I1002 15:18:52.162120 1821957 ProcessGroupNCCL.cpp:530] [Rank 0] NCCL watchdog thread terminated normally
> I1002 15:18:58.539937 1822062 ProcessGroupNCCL.cpp:649] [Rank 2] Found key in store: NCCLABORTEDCOMM:a0e17500002836080c8384c50000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, from rank: 0, aborting appropriate communicators
> I1002 15:19:34.740937 1822062 ProcessGroupNCCL.cpp:662] [Rank 2] Aborted communicators for key in store: NCCLABORTEDCOMM:a0e17500002836080c8384c50000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
> I1002 15:19:34.741678 1822062 ProcessGroupNCCL.cpp:530] [Rank 2] NCCL watchdog thread terminated normally
```

Differential Revision: [D24183386](https://our.internmc.facebook.com/intern/diff/D24183386/)