### PR TITLE
add close() method to tqdm mock

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -39,6 +39,9 @@ except ImportError:
                     sys.stderr.write("\r{0:.1f}%".format(100 * self.n / float(self.total)))
                 sys.stderr.flush()
 
+            def close(self):
+                self.disable = True
+
             def __enter__(self):
                 return self
 


### PR DESCRIPTION
In `torchvision` we use [`torch.hub.tqdm`](https://github.com/pytorch/vision/blob/2cc20d7485458a6368e8995e3f79799589b632bd/torchvision/datasets/utils.py#L11) to display the dataset download. One of our methods uses [`tqdm().close()`](https://github.com/pytorch/vision/blob/2cc20d7485458a6368e8995e3f79799589b632bd/torchvision/datasets/utils.py#L188), which is [not included in the mock](https://github.com/pmeier/pytorch/blob/283ae1998cd6920b588907adfb88909afb522ae2/torch/hub.py#L22-L49). This PR adds a `close()` method to the mock.

Cc @fmassa