### PR TITLE
upgrade clang-tidy to 11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,10 +110,10 @@ jobs:
           # Install dependencies
           pip install pyyaml
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main"
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-8
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-8 1000
+          sudo apt-get install -y clang-tidy-11
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-11 1000
       - name: Run clang-tidy
         run: |
           set -eux


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46043 upgrade clang-tidy to 11**

As title, this is necessary for some internal linter thing

Differential Revision: [D24197316](https://our.internmc.facebook.com/intern/diff/D24197316)