### PR TITLE
[Distributed] Adding getNumKeys support to the HashStore

### DIFF
--- a/torch/lib/c10d/HashStore.cpp
+++ b/torch/lib/c10d/HashStore.cpp
@@ -80,7 +80,8 @@ int64_t HashStore::add(const std::string& key, int64_t i) {
 }
 
 int64_t HashStore::getNumKeys() {
-  TORCH_CHECK(false, "getNumKeys not implemented for HashStore");
+  std::unique_lock<std::mutex> lock(m_);
+  return map_.size();
 }
 
 bool HashStore::deleteKey(const std::string& /* unused */) {

--- a/torch/lib/c10d/test/HashStoreTest.cpp
+++ b/torch/lib/c10d/test/HashStoreTest.cpp
@@ -19,6 +19,8 @@ void testGetSet(std::string prefix = "") {
     c10d::test::check(store, "key0", "value0");
     c10d::test::check(store, "key1", "value1");
     c10d::test::check(store, "key2", "value2");
+    auto numKeys = store.getNumKeys();
+    EXPECT_EQ(numKeys, 3);
   }
 
   // get() waits up to timeout_.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46049 [Distributed] deleteKey support for HashStore
* **#46048 [Distributed] Adding getNumKeys support to the HashStore**

This PR adds support for the getNumKeys API for the HashStore

Differential Revision: [D24067658](https://our.internmc.facebook.com/intern/diff/D24067658/)