### PR TITLE
[Distributed] deleteKey support for HashStore

### DIFF
--- a/torch/lib/c10d/HashStore.cpp
+++ b/torch/lib/c10d/HashStore.cpp
@@ -84,8 +84,10 @@ int64_t HashStore::getNumKeys() {
   return map_.size();
 }
 
-bool HashStore::deleteKey(const std::string& /* unused */) {
-  TORCH_CHECK(false, "deleteKey not implemented for HashStore");
+bool HashStore::deleteKey(const std::string& key) {
+  std::unique_lock<std::mutex> lock(m_);
+  auto numDeleted = map_.erase(key);
+  return (numDeleted == 1);
 }
 
 bool HashStore::check(const std::vector<std::string>& keys) {

--- a/torch/lib/c10d/test/HashStoreTest.cpp
+++ b/torch/lib/c10d/test/HashStoreTest.cpp
@@ -21,6 +21,13 @@ void testGetSet(std::string prefix = "") {
     c10d::test::check(store, "key2", "value2");
     auto numKeys = store.getNumKeys();
     EXPECT_EQ(numKeys, 3);
+    auto delSuccess = store.deleteKey("key0");
+    EXPECT_TRUE(delSuccess);
+    numKeys = store.getNumKeys();
+    EXPECT_EQ(numKeys, 2);
+    auto delFailure = store.deleteKey("badKeyName");
+    EXPECT_FALSE(delFailure);
+    EXPECT_THROW(store.get("key0"), std::runtime_error);
   }
 
   // get() waits up to timeout_.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46049 [Distributed] deleteKey support for HashStore**
* #46048 [Distributed] Adding getNumKeys support to the HashStore

Adding support for the deleteKey API in the c10d HashStore.

Differential Revision: [D24067657](https://our.internmc.facebook.com/intern/diff/D24067657/)