### PR TITLE
caffe2 missing cctype header

### DIFF
--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -2,6 +2,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/core/tensor_int8.h"
 #include "caffe2/utils/string_utils.h"
+#include <cctype>
 
 namespace caffe2 {
 


### PR DESCRIPTION
Summary:
`<cctype>` is what provides `isuppper`, etc.
https://en.cppreference.com/w/cpp/header/cctype

clang on windows complaining about the missing header.

Test Plan: CI green

Differential Revision: D24201925

