### PR TITLE
Fix freezing  attribute not found

### DIFF
--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -570,10 +570,13 @@ class AttributePropagator {
           auto mptr =
               getModulePtrForGetAttrNode(n->input(0)->node(), graph, module_);
           auto module = Module(mptr);
-          if (module.type() == n->inputs()[0]->type() && module.hasattr(name)) {
-            auto attr = module.attr(name);
-            insertMutableAttr(name, attr, mptr);
-          }
+          TORCH_INTERNAL_ASSERT(module.hasattr(name));
+          // FIXME: This is catching type inconsistency between GetAttr and
+          // attribute types. Observed that some models the type insconstent
+          // between GetAttr node and attribute types.
+          n->input(0)->setType(module.type());
+          auto attr = module.attr(name);
+          insertMutableAttr(name, attr, mptr);
         } else if (n->kind() == prim::fork) {
           applyToForkSubgraph(
               n,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46054 Fix freezing  attribute not found**

In some model type of GetAttr and attribute types are not the same. This patch
handles these scenarios

Differential Revision: [D24203081](https://our.internmc.facebook.com/intern/diff/D24203081)