### PR TITLE
Fix error in Binomial to retain lazy logit initialization

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -4005,6 +4005,7 @@ class TestNumericalStability(TestCase):
                                  expected_gradient=tensor_type([0.]))
 
 
+# TODO: make this a pytest parameterized test
 class TestLazyLogitsInitialization(TestCase):
     def setUp(self):
         super(TestLazyLogitsInitialization, self).setUp()
@@ -4015,7 +4016,7 @@ class TestLazyLogitsInitialization(TestCase):
 
     def test_lazy_logits_initialization(self):
         for Dist, params in self.examples:
-            param = params[0]
+            param = params[0].copy()
             if 'probs' in param:
                 probs = param.pop('probs')
                 param['logits'] = probs_to_logits(probs)
@@ -4034,7 +4035,7 @@ class TestLazyLogitsInitialization(TestCase):
 
     def test_lazy_probs_initialization(self):
         for Dist, params in self.examples:
-            param = params[0]
+            param = params[0].copy()
             if 'probs' in param:
                 dist = Dist(**param)
                 dist.sample()

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -42,18 +42,13 @@ class Binomial(Distribution):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
         if probs is not None:
             self.total_count, self.probs, = broadcast_all(total_count, probs)
-            self.total_count = self.total_count.type_as(self.logits)
-            is_scalar = isinstance(self.probs, Number)
+            self.total_count = self.total_count.type_as(self.probs)
         else:
             self.total_count, self.logits, = broadcast_all(total_count, logits)
             self.total_count = self.total_count.type_as(self.logits)
-            is_scalar = isinstance(self.logits, Number)
 
         self._param = self.probs if probs is not None else self.logits
-        if is_scalar:
-            batch_shape = torch.Size()
-        else:
-            batch_shape = self._param.size()
+        batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -1,4 +1,3 @@
-from numbers import Number
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution


### PR DESCRIPTION
Some internal tests were sporadically failing for https://github.com/pytorch/pytorch/pull/45648. The cause of this is a bug in `Binomial.__init__` that references the lazy `logits` attribute and sets it when not needed. This cleans up the `is_scalar` logic too which isn't needed given that `broadcast_all` will convert `Number` to a `tensor`. 

The reason for the flakiness is the mutation of the params dict by the first test, which is fixed by doing a shallow copy. It will be better to convert this into a pytest parameterized test once https://github.com/pytorch/pytorch/pull/45648 is merged.

cc. @fritzo, @ezyang 