### PR TITLE
Document fix for logspace and linspace

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3732,9 +3732,9 @@ spaced from :attr:`start` to :attr:`end`, inclusive. That is, the value are:
 
 .. math::
     (\text{start},
-    \text{start} + \frac{\text{end} - \text{start}}{\text{steps}},
+    \text{start} + \frac{\text{end} - \text{start}}{\text{steps} - 1},
     \ldots,
-    \text{start} + (\text{steps} - 1) * \frac{\text{end} - \text{start}}{\text{steps}},
+    \text{start} + (\text{steps} - 2) * \frac{\text{end} - \text{start}}{\text{steps} - 1},
     \text{end})
 """ + """
 
@@ -4057,9 +4057,9 @@ with base :attr:`base`. That is, the values are:
 
 .. math::
     (\text{base}^{\text{start}},
-    \text{base}^{(\text{start} + \frac{\text{end} - \text{start}}{ \text{steps}})},
+    \text{base}^{(\text{start} + \frac{\text{end} - \text{start}}{ \text{steps} - 1})},
     \ldots,
-    \text{base}^{(\text{start} + (\text{steps} - 1) * \frac{\text{end} - \text{start}}{ \text{steps}})},
+    \text{base}^{(\text{start} + (\text{steps} - 2) * \frac{\text{end} - \text{start}}{ \text{steps} - 1})},
     \text{base}^{\text{end}})
 """ + """
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46056 Document fix for logspace and linspace**

The result:
* logspace
![image](https://user-images.githubusercontent.com/68879799/95513793-e6f5c200-0988-11eb-8279-b093612743ca.png)
* linspace
![image](https://user-images.githubusercontent.com/68879799/95513824-f543de00-0988-11eb-9910-72d28d7b6277.png)

Differential Revision: [D24204441](https://our.internmc.facebook.com/intern/diff/D24204441)