### PR TITLE
remove duplicate autograd srcs

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -39,11 +39,7 @@ def libtorch_generated_sources(gencode_pattern):
         "autograd/generated/TraceType_2.cpp",
         "autograd/generated/TraceType_3.cpp",
         "autograd/generated/TraceType_4.cpp",
-    ]] + [
-        "torch/csrc/autograd/TraceTypeManual.cpp",
-        "torch/csrc/autograd/VariableTypeManual.cpp",
-        "torch/csrc/autograd/FunctionsManual.cpp",
-    ]
+    ]]
 
 # copied from https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/CMakeLists.txt
 jit_core_headers = [


### PR DESCRIPTION
Summary: These files are not generated sources, and they also already exist in another variable in the same file (`libtorch_extra_sources`).

Test Plan: CI green

Differential Revision: D24203450

