### PR TITLE
[pytorch][rampup] convenience function for loading a non-DP/DDP model from a DP/DDP state_dict

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -805,6 +805,22 @@ class TestDataParallel(TestCase):
                 r"nn\.ParameterDict is being used with DataParallel but this"):
             model(input)
 
+    @unittest
+    def test_strip_prefix_if_present(self):
+        state_dict = nn.Module.model.state_dict()
+
+        for k in list(state_dict.keys()):
+            v = state_dict[k]
+            if not isinstance(v, np.ndarray) and not isinstance(v, torch.Tensor):
+                raise ValueError(
+                    "Unsupported type found in checkpoint! {}: {}".format(k, type(v))
+                )
+            if not isinstance(v, torch.Tensor):
+                state_dict[k] = torch.from_numpy(v)
+
+        nn.modules.module.strip_prefix_if_present(state_dict, "module.")
+        self.assertFalse("module." in state_dict)
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -175,6 +175,39 @@ def _forward_unimplemented(self, *input: Any) -> None:
     raise NotImplementedError
 
 
+def strip_prefix_if_present(state_dict: Dict[str, Any], prefix: str) -> None:
+    """
+    Strip the prefix in metadata, if any.
+    Args:
+        state_dict (OrderedDict): a state-dict to be loaded to the model.
+        prefix (str): prefix.
+    """
+    keys = sorted(state_dict.keys())
+    if not all(len(key) == 0 or key.startswith(prefix) for key in keys):
+        return
+
+    for key in keys:
+        newkey = key[len(prefix) :]
+        state_dict[newkey] = state_dict.pop(key)
+
+    # also strip the prefix in metadata, if any..
+    try:
+        metadata = state_dict._metadata  # pyre-ignore
+    except AttributeError:
+        pass
+    else:
+        for key in list(metadata.keys()):
+            # for the metadata dict, the key can be:
+            # '': for the DDP module, which we want to remove.
+            # 'module': for the actual model.
+            # 'module.xx.xx': for the rest.
+
+            if len(key) == 0:
+                continue
+            newkey = key[len(prefix) :]
+            metadata[newkey] = metadata.pop(key)
+
+
 class Module:
     r"""Base class for all neural network modules.
 


### PR DESCRIPTION
Summary: Add a converter to strip the module prefix on all items in the state dict and the metadata

Test Plan: buck test  //caffe2:torch

Differential Revision: D24116288

