### PR TITLE
[Distributed] Set smaller Store timeouts to make c10d tests run faster

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -286,6 +286,7 @@ class TCPStoreTest(TestCase, StoreTestBase):
         self.assertEqual(fs.num_keys(), 5)
         fs.delete_key("key")
         self.assertEqual(fs.num_keys(), 4)
+        fs.set_timeout(timedelta(seconds=2))
         with self.assertRaises(RuntimeError):
             fs.get("key")
         fs.delete_key("key0")

--- a/torch/lib/c10d/test/TCPStoreTest.cpp
+++ b/torch/lib/c10d/test/TCPStoreTest.cpp
@@ -9,6 +9,8 @@
 #include <c10d/PrefixStore.hpp>
 #include <c10d/TCPStore.hpp>
 
+constexpr int64_t kShortStoreTimeoutMillis = 100;
+
 // Different ports for different tests.
 void testHelper(const std::string& prefix = "") {
   const auto numThreads = 16;
@@ -51,6 +53,8 @@ void testHelper(const std::string& prefix = "") {
     EXPECT_FALSE(delFailure);
     numKeys = serverStore->getNumKeys();
     EXPECT_EQ(numKeys, 4);
+    auto timeout = std::chrono::milliseconds(kShortStoreTimeoutMillis);
+    serverStore->setTimeout(timeout);
     EXPECT_THROW(serverStore->get("key0"), std::runtime_error);
   });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46067 [Distributed] Set smaller Store timeouts to make c10d tests run faster**

In our store tests, we expect there to be an exception when we call
get on a recently-deleted key. Unforunately, the store waits for the timeout
period for the key to be set before throwing, which causes the tests to idel
wait for 5+ minutes. This PR decreases the timeouts before this set call so
these tests run faster.

Differential Revision: [D24208617](https://our.internmc.facebook.com/intern/diff/D24208617/)