### PR TITLE
[PyTorch] Stringize kernel tag names consistently during macro expansion and require all tag names to be a compile time character array

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -294,7 +294,7 @@ static void signbit_kernel(TensorIterator& iter){
 }
 
 static void sgn_kernel(TensorIterator& iter){
-  AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), 'sgn_cpu', [&]() {
+  AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "sgn_cpu", [&]() {
     cpu_kernel_vec(
       iter,
       [=](scalar_t a) -> scalar_t { return sgn_impl(a); },
@@ -587,7 +587,7 @@ static void rsqrt_kernel(TensorIterator& iter) {
 #define IMPLEMENT_FLOAT_KERNEL(dispatchtypes, op)                             \
   static void op##_kernel(TensorIterator& iter) {                             \
     TORCH_INTERNAL_ASSERT(iter.ntensors() == 2);                              \
-    AT_DISPATCH_FLOATING_TYPES_AND(kBFloat16, iter.dtype(), op##_vml_cpu, [&]() {            \
+    AT_DISPATCH_FLOATING_TYPES_AND(kBFloat16, iter.dtype(), #op "_vml_cpu", [&]() {            \
       iter.serial_for_each(                                                   \
           [&](char** data_, const int64_t* strides, int64_t n) { \
             scalar_t* out_data = reinterpret_cast<scalar_t*>(data_[0]);       \
@@ -618,7 +618,7 @@ static void rsqrt_kernel(TensorIterator& iter) {
 #define IMPLEMENT_COMPLEX_KERNEL(dispatchtypes, op)                             \
   static void op##_kernel(TensorIterator& iter) {                             \
     TORCH_INTERNAL_ASSERT(iter.ntensors() == 2);                              \
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(kBFloat16, iter.dtype(), op##_vml_cpu, [&]() {\
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(kBFloat16, iter.dtype(), #op "_vml_cpu", [&]() {\
       iter.serial_for_each(                                                   \
           [&](char** data_, const int64_t* strides, int64_t n) {              \
             scalar_t* out_data = reinterpret_cast<scalar_t*>(data_[0]);       \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46074 [PyTorch] Stringize kernel? names consistently during macro expansion**

I found 2 instances where the NAME parameter passed in to the dispatch macros is not a C++ string (constant) (i.e. double quoted compile time string).

In one instance it is a single quoted multi-character constant (I don't know what this resolves to in practice), and in the other instance, it is an unquoted identified generated as a result of concatenating 2 identifiers using the `##` operator.

In addition, I found 2 instances where the `NAME` of the tag passed in is not a constant character array, but an `std::string` variable instead. I am changing it to a constant character array with the same name as the variable name (earlier). For the purposes of any code using this data, eveything remains the same since the code was string-izing the value anyway using `#NAME` so it would get the name of the variable and not the contents.

Differential Revision: [D24211393](https://our.internmc.facebook.com/intern/diff/D24211393/)