### PR TITLE
Remove object-based collective APIs from public docs

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -384,19 +384,13 @@ Collective functions
 
 .. autofunction:: broadcast 
 
-.. autofunction:: broadcast_object_list
-
 .. autofunction:: all_reduce
 
 .. autofunction:: reduce
 
 .. autofunction:: all_gather
 
-.. autofunction:: all_gather_object
-
 .. autofunction:: gather
-
-.. autofunction:: gather_object
 
 .. autofunction:: scatter
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46075 Remove object-based collective APIs from public docs**

Removes these from public docs for now as we are still
iterating/formalizing these APIs. Will add them back once they are part of a
PyTorch release.

Differential Revision: [D24211510](https://our.internmc.facebook.com/intern/diff/D24211510/)