### PR TITLE
[caffe2] temp remove ErrorPlanWithCancellableStuckNet

### DIFF
--- a/caffe2/core/plan_executor_test.cc
+++ b/caffe2/core/plan_executor_test.cc
@@ -229,7 +229,6 @@ TEST(PlanExecutorTest, ErrorAsyncPlan) {
 // death tests not supported on mobile
 #if !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
 TEST(PlanExecutorTest, BlockingErrorPlan) {
-
   // TSAN doesn't play nicely with death tests
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
@@ -268,16 +267,6 @@ TEST(PlanExecutorTest, BlockingErrorPlan) {
       "failed to stop concurrent workers after exception: test error");
 }
 #endif
-
-TEST(PlanExecutorTest, ErrorPlanWithCancellableStuckNet) {
-  HandleExecutorThreadExceptionsGuard guard;
-
-  PlanDef plan_def = parallelErrorPlanWithCancellableStuckNet();
-  Workspace ws;
-
-  ASSERT_THROW(ws.RunPlan(plan_def), TestError);
-  ASSERT_EQ(cancelCount, 1);
-}
 
 } // namespace caffe2
 


### PR DESCRIPTION
Summary: temp removal of ErrorPlanWithCancellableStuckNet, will fill out more

Test Plan:
```
buck test caffe2/caffe2:caffe2_test_cpu -- PlanExecutorTest
```
remove a test

Differential Revision: D24213971

