### PR TITLE
quantizaton: add API usage logging

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -215,6 +215,7 @@ def prepare(model, inplace=False, allow_list=None,
         observer_non_leaf_module_list: list of non-leaf modules we want to add observer
         prehook: observer we want to add to forward_pre_hook
     """
+    torch._C._log_api_usage_once("quantization_api.quantize.prepare")
     if not inplace:
         model = copy.deepcopy(model)
 
@@ -262,6 +263,7 @@ def quantize(model, run_fn, run_args, mapping=None, inplace=False):
     Return:
         Quantized model.
     """
+    torch._C._log_api_usage_once("quantization_api.quantize.quantize")
     if mapping is None:
         mapping = get_static_quant_module_mappings()
     if not inplace:
@@ -302,6 +304,7 @@ def quantize_dynamic(model, qconfig_spec=None, dtype=torch.qint8,
             with which the submodule needs to be replaced
 
     """
+    torch._C._log_api_usage_once("quantization_api.quantize.quantize_dynamic")
     if qconfig_spec is None:
         if dtype == torch.qint8:
             qconfig_spec = {
@@ -364,6 +367,7 @@ def prepare_qat(model, mapping=None, inplace=False):
         inplace: carry out model transformations in-place, the original module
                  is mutated
     """
+    torch._C._log_api_usage_once("quantization_api.quantize.prepare_qat")
     if mapping is None:
         mapping = get_qat_module_mappings()
     if not inplace:
@@ -387,6 +391,7 @@ def quantize_qat(model, run_fn, run_args, inplace=False):
     Return:
         Quantized model.
     """
+    torch._C._log_api_usage_once("quantization_api.quantize.quantize_qat")
     if not inplace:
         model = copy.deepcopy(model)
     model.train()
@@ -409,6 +414,7 @@ def convert(module, mapping=None, inplace=False, remove_qconfig=True):
                  is mutated
 
     """
+    torch._C._log_api_usage_once("quantization_api.quantize.convert")
     if not inplace:
         module = copy.deepcopy(module)
     _convert(module, mapping, inplace=True)

--- a/torch/quantization/quantize_fx.py
+++ b/torch/quantization/quantize_fx.py
@@ -72,6 +72,7 @@ def _prepare_standalone_module_fx(model, qconfig_dict, inplace=False):
                                    custom module is observed or not
 
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_fx._prepare_standalone_module_fx")
     return _prepare_fx(model, qconfig_dict, inplace, is_standalone_module=True)
 
 
@@ -89,6 +90,7 @@ def fuse_fx(model, inplace=False):
     m = fuse_fx(m)
     ```
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_fx.fuse_fx")
     assert not model.training, 'fuse_fx only works on models in eval mode'
     graph_module = torch.fx.symbolic_trace(model)
     return _fuse_fx(graph_module, inplace)
@@ -160,6 +162,7 @@ def prepare_fx(model, qconfig_dict, inplace=False):
     calibrate(prepared_model, sample_inference_data)
     ```
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_fx.prepare_fx")
     assert not model.training, 'prepare_fx only works for models in' + \
         'eval mode'
     return _prepare_fx(model, qconfig_dict, inplace)
@@ -195,6 +198,7 @@ def prepare_qat_fx(model, qconfig_dict, inplace=False):
     train_loop(prepared_model, train_loop)
     ```
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_fx.prepare_qat_fx")
     assert model.training, 'prepare_qat_fx only works for models in ' + \
         'train mode'
     return _prepare_fx(model, qconfig_dict, inplace)
@@ -222,6 +226,7 @@ def convert_fx(graph_module, inplace=False, debug=False):
     quantized_model = convert_fx(prepared_model)
     ```
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_fx.convert_fx")
     return _convert_fx(graph_module, inplace, debug)
 
 def _convert_standalone_module_fx(graph_module, inplace=False, debug=False):
@@ -235,4 +240,5 @@ def _convert_standalone_module_fx(graph_module, inplace=False, debug=False):
       A quantized standalone module which accepts quantized input(if needed)
       and produces quantized output (if needed).
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_fx._convert_standalone_module_fx")
     return _convert_fx(graph_module, inplace, debug, is_standalone_module=True)

--- a/torch/quantization/quantize_jit.py
+++ b/torch/quantization/quantize_jit.py
@@ -35,6 +35,7 @@ def fuse_conv_bn_jit(model, inplace=False):
     Args:
         model: TorchScript model from scripting or tracing
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_jit.fuse_conv_bn_jit")
     model_c = model._c
     model_c = torch._C._jit_pass_fold_convbn(model_c)
     if inplace:
@@ -62,9 +63,11 @@ def _prepare_jit(model, qconfig_dict, inplace=False, quant_type=QuantType.STATIC
     return model
 
 def prepare_jit(model, qconfig_dict, inplace=False):
+    torch._C._log_api_usage_once("quantization_api.quantize_jit.prepare_jit")
     return _prepare_jit(model, qconfig_dict, inplace, quant_type=QuantType.STATIC)
 
 def prepare_dynamic_jit(model, qconfig_dict, inplace=False):
+    torch._C._log_api_usage_once("quantization_api.quantize_jit.prepare_dynamic_jit")
     return _prepare_jit(model, qconfig_dict, inplace, quant_type=QuantType.DYNAMIC)
 
 def _convert_jit(model, inplace=False, debug=False, quant_type=QuantType.STATIC,
@@ -87,9 +90,11 @@ def _convert_jit(model, inplace=False, debug=False, quant_type=QuantType.STATIC,
     return model
 
 def convert_jit(model, inplace=False, debug=False, preserved_attrs=None):
+    torch._C._log_api_usage_once("quantization_api.quantize_jit.convert_jit")
     return _convert_jit(model, inplace, debug, quant_type=QuantType.STATIC, preserved_attrs=preserved_attrs)
 
 def convert_dynamic_jit(model, inplace=False, debug=False, preserved_attrs=None):
+    torch._C._log_api_usage_once("quantization_api.quantize_jit.convert_dynamic_jit")
     return _convert_jit(model, inplace, debug, quant_type=QuantType.DYNAMIC, preserved_attrs=preserved_attrs)
 
 def _quantize_jit(model, qconfig_dict, run_fn=None, run_args=None, inplace=False, debug=False, quant_type=QuantType.STATIC):
@@ -157,6 +162,7 @@ def quantize_jit(model, qconfig_dict, run_fn, run_args, inplace=False, debug=Fal
         [data_loader_test])
     ```
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_jit.quantize_jit")
     return _quantize_jit(model, qconfig_dict, run_fn, run_args, inplace, debug, quant_type=QuantType.STATIC)
 
 def quantize_dynamic_jit(model, qconfig_dict, inplace=False, debug=False):
@@ -197,4 +203,5 @@ def quantize_dynamic_jit(model, qconfig_dict, inplace=False, debug=False):
         [data_loader_test])
     ```
     """
+    torch._C._log_api_usage_once("quantization_api.quantize_jit.quantize_dynamic_jit")
     return _quantize_jit(model, qconfig_dict, inplace=inplace, debug=debug, quant_type=QuantType.DYNAMIC)


### PR DESCRIPTION
Summary:
Adds logging on usage of public quantization APIs. This only works in FB codebase
and is a no-op in OSS.

Test Plan: The test plan is fb-only

Differential Revision: D24220817

