### PR TITLE
[FX] Make `graph_copy` examine existing values in val_map

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -108,6 +108,8 @@ class Graph:
         Nodes switched to refer to nodes in `self`.
         """
         for node in g._nodes:
+            if node in val_map:
+                continue
             if node.op == 'output':
                 rv = map_arg(node.args[0], lambda n: val_map[n])
                 return rv


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46104 [FX] Make `graph_copy` examine existing values in val_map**

Previously there was actually no way to remap inputs (or other values) in the graph to be copied while calling `graph_copy`. This made it so that you couldn't do things like inline a graph into a graph that already had nodes. This patch fixes that

Differential Revision: [D24224505](https://our.internmc.facebook.com/intern/diff/D24224505)