### PR TITLE
make a way to disable callgrind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,9 @@ option(USE_SNPE "Use Qualcomm's SNPE library" OFF)
 option(USE_SYSTEM_EIGEN_INSTALL
     "Use system Eigen instead of the one under third_party" OFF)
 option(USE_TENSORRT "Using Nvidia TensorRT library" OFF)
+cmake_dependent_option(
+    USE_VALGRIND "Use Valgrind. Only available on Linux." ON
+    "LINUX" OFF)
 option(USE_VULKAN "Use Vulkan GPU backend" OFF)
 option(USE_VULKAN_WRAPPER "Use Vulkan wrapper" ON)
 option(USE_VULKAN_SHADERC_RUNTIME "Use Vulkan Shader compilation runtime(Needs shaderc lib)" OFF)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -189,6 +189,10 @@ if(USE_NCCL AND NOT WIN32)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_NCCL)
 endif()
 
+if(USE_VALGRIND AND NOT WIN32)
+    list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_VALGRIND)
+endif()
+
 # In the most recent CMake versions, a new 'TRANSFORM' subcommand of 'list' allows much of the boilerplate of defining the lists
 # of type stub files to be omitted.
 # For comptability with older CMake versions, we omit it for now, but leave it as a comment in case comptability with the older

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -61,9 +61,7 @@
 #endif
 #endif
 
-#if (defined(_WIN32) || defined(_WIN64) || defined(FBCODE_CAFFE2) || defined(C10_MOBILE))
-#define NVALGRIND
-#else
+#if defined(USE_VALGRIND)
 #include <callgrind.h>
 #endif
 
@@ -831,20 +829,20 @@ Call this whenever a new thread is created in order to propagate values from
 
   py_module.def(
     "valgrind_supported_platform", [](){
-      #if defined(NVALGRIND)
-      return false;
-      #else
+      #if defined(USE_VALGRIND)
       return true;
+      #else
+      return false;
       #endif
     }
   );
 
   py_module.def(
     "valgrind_toggle", [](){
-      #if defined(NVALGRIND)
-      TORCH_CHECK(false, "Valgrind is not supported.");
-      #else
+      #if defined(USE_VALGRIND)
       CALLGRIND_TOGGLE_COLLECT;
+      #else
+      TORCH_CHECK(false, "Valgrind is not supported.");
       #endif
     }
   );


### PR DESCRIPTION
Summary: Ideally I would just use one of the existing preprocessor flags such as `FBCODE_CAFFE2`, but this implies a whole bunch of other things elsewhere, so it is not really a solution for ovrsource.

Test Plan: CI green, we are able to disable it internally with `-DNVALGRIND`

Differential Revision: D24227360

