### PR TITLE
Extend pytorch multi tensor rmsprop optimizer to support  lr_in_momentum and decoupled_decay.

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -325,6 +325,10 @@ class TestOptim(TestCase):
             ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=0, centered=True)),
             ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=1, centered=False)),
             ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=0, momentum=1, centered=False)),
+            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=1, centered=True, lr_in_momentum=False)),
+            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=0, centered=True, lr_in_momentum=False)),
+            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=1, centered=False, lr_in_momentum=False)),
+            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=0, momentum=1, centered=False, lr_in_momentum=False)),
             ((optim.Rprop, optim._multi_tensor.Rprop), dict(lr=1e-2, etas=(0.5, 1.2), step_sizes=(1e-6, 50))),
             ((optim.ASGD, optim._multi_tensor.ASGD), dict(weight_decay=0)),
             ((optim.ASGD, optim._multi_tensor.ASGD), dict(weight_decay=1)),
@@ -340,15 +344,15 @@ class TestOptim(TestCase):
         for optimizers, params in optimizer_pairs_with_flags:
             res = []
             for opt in optimizers:
-                weight = torch.tensor([[-0.2109, -0.4976], [-0.1413, -0.3420], [-0.2524, 0.6976]], 
+                weight = torch.tensor([[-0.2109, -0.4976], [-0.1413, -0.3420], [-0.2524, 0.6976]],
                                       dtype=torch.float64, device=device, requires_grad=True)
                 bias = torch.tensor([-0.1085, -0.2979, 0.6892], dtype=torch.float64, device=device, requires_grad=True)
-                weight2 = torch.tensor([[-0.0508, -0.3941, -0.2843]], 
+                weight2 = torch.tensor([[-0.0508, -0.3941, -0.2843]],
                                        dtype=torch.float64, device=device, requires_grad=True)
                 bias2 = torch.tensor([-0.0711], dtype=torch.float64, device=device, requires_grad=True)
                 input = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], dtype=torch.float64, device=device).reshape(3, 2)
 
-                model = torch.nn.Sequential(torch.nn.Linear(2, 3), 
+                model = torch.nn.Sequential(torch.nn.Linear(2, 3),
                                             torch.nn.Sigmoid(),
                                             torch.nn.Linear(3, 1),
                                             torch.nn.Sigmoid())
@@ -363,7 +367,7 @@ class TestOptim(TestCase):
 
                 optimizer = opt(model.parameters(), **params)
 
-                for _ in range(kIterations): 
+                for _ in range(kIterations):
                     optimizer.zero_grad()
                     output = model(input)
                     loss = output.sum()

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -28,10 +28,24 @@ class RMSprop(Optimizer):
         centered (bool, optional) : if ``True``, compute the centered RMSProp,
             the gradient is normalized by an estimation of its variance
         weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
-
+        decoupled_decay (bool, optional): decoupled weight decay as per
+            (https://arxiv.org/abs/1711.05101)
+        lr_in_momentum (bool, optional): learning rate scaling is included in the
+            momentum buffer update
     """
 
-    def __init__(self, params, lr=1e-2, alpha=0.99, eps=1e-8, weight_decay=0, momentum=0, centered=False):
+    def __init__(
+        self,
+        params,
+        lr=1e-2,
+        alpha=0.99,
+        eps=1e-8,
+        weight_decay=0,
+        momentum=0,
+        centered=False,
+        decoupled_decay=False,
+        lr_in_momentum=True
+    ):
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
@@ -43,7 +57,16 @@ class RMSprop(Optimizer):
         if not 0.0 <= alpha:
             raise ValueError("Invalid alpha value: {}".format(alpha))
 
-        defaults = dict(lr=lr, momentum=momentum, alpha=alpha, eps=eps, centered=centered, weight_decay=weight_decay)
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            alpha=alpha,
+            eps=eps,
+            centered=centered,
+            weight_decay=weight_decay,
+            decoupled_decay=decoupled_decay,
+            lr_in_momentum=lr_in_momentum
+        )
         super(RMSprop, self).__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -89,21 +112,31 @@ class RMSprop(Optimizer):
                 state['step'] += 1
 
                 if group['weight_decay'] != 0:
-                    grad = grad.add(p, alpha=group['weight_decay'])
+                    if "decoupled_decay" in group and group["decoupled_decay"]:
+                        p.add_(-group["weight_decay"], p)
+                    else:
+                        grad = grad.add(p, alpha=group['weight_decay'])
 
-                square_avg.mul_(alpha).addcmul_(grad, grad, value=1 - alpha)
+                # square_avg.mul_(alpha).addcmul_(grad, grad, value=1 - alpha)
+                one_minus_alpha = 1.0 - group["alpha"]
+                square_avg.add_(one_minus_alpha, grad.pow(2) - square_avg)
 
                 if group['centered']:
                     grad_avg = state['grad_avg']
                     grad_avg.mul_(alpha).add_(grad, alpha=1 - alpha)
-                    avg = square_avg.addcmul(grad_avg, grad_avg, value=-1).sqrt_().add_(group['eps'])
+                    # eps moved in sqrt
+                    avg = square_avg.addcmul(grad_avg, grad_avg, value=-1).add(group['eps']).sqrt_()
                 else:
-                    avg = square_avg.sqrt().add_(group['eps'])
+                    avg = square_avg.add(group["eps"]).sqrt_()  # eps moved in sqrt
 
                 if group['momentum'] > 0:
                     buf = state['momentum_buffer']
-                    buf.mul_(group['momentum']).addcdiv_(grad, avg)
-                    p.add_(buf, alpha=-group['lr'])
+                    if "lr_in_momentum" in group and group["lr_in_momentum"]:
+                        buf.mul_(group["momentum"]).addcdiv_(group["lr"], grad, avg)
+                        p.add_(-buf)
+                    else:
+                        buf.mul_(group['momentum']).addcdiv_(grad, avg)
+                        p.add_(buf, alpha=-group['lr'])
                 else:
                     p.addcdiv_(grad, avg, value=-group['lr'])
 


### PR DESCRIPTION
Summary: Switch to use the multi-tensor version RMSProp optimizer in the classy vision flow and also make the numeric match with old one

Test Plan: Flow canary: f223946625

Differential Revision: D24102016

