### PR TITLE
[pytorch][te] Add compilation time benchmark

### DIFF
--- a/benchmarks/cpp/tensorexpr/CMakeLists.txt
+++ b/benchmarks/cpp/tensorexpr/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(tensorexpr_bench tensorexpr.cpp)
+add_executable(tensorexpr_bench bench_gemm.cpp bench_compile.cpp main.cpp)
 target_link_libraries(tensorexpr_bench PRIVATE torch_library benchmark)

--- a/benchmarks/cpp/tensorexpr/bench_compile.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_compile.cpp
@@ -1,0 +1,74 @@
+#include <benchmark/benchmark.h>
+#include "torch/csrc/jit/tensorexpr/ir_simplifier.h"
+#include "torch/csrc/jit/tensorexpr/loopnest.h"
+#include "torch/csrc/jit/tensorexpr/tensor.h"
+#include "torch/csrc/jit/tensorexpr/llvm_codegen.h"
+
+#ifdef TORCH_ENABLE_LLVM
+namespace te = torch::jit::tensorexpr;
+
+static void BM_CompileSwish(benchmark::State& state) {
+  for (auto _ : state) {
+    constexpr int N = 512;
+    te::KernelScope ks;
+    te::VarHandle n("n", te::kInt);
+    te::Placeholder A(te::BufHandle("A", {N}, te::kFloat));
+    te::Tensor* relu = te::Compute("relu", {{n, "n"}}, [&](const te::VarHandle& i) {
+      return te::Max::make(A.load(i), 0.f, false);
+    });
+    te::Tensor* min6 = te::Compute("min6", {{n, "n"}}, [&](const te::VarHandle& i) {
+      return te::Min::make(relu->call(i), 6.f, false);
+    });
+    te::Tensor* plus3 = te::Compute("plus3", {{n, "n"}}, [&](const te::VarHandle& i) {
+      return min6->call(i) + 3.f;
+    });
+    te::Tensor* times = te::Compute("times", {{n, "n"}}, [&](const te::VarHandle& i) {
+      return A.load(i) * plus3->call(i);
+    });
+    te::Tensor* sixth = te::Compute("sixth", {{n, "n"}}, [&](const te::VarHandle& i) {
+      return times->call(i) * 1.f / 6.f;
+    });
+    te::LoopNest nest({sixth});
+    for (auto tensor : {relu, min6, plus3, times}) {
+      nest.computeInline(tensor->buf());
+    }
+    nest.prepareForCodegen();
+    te::Stmt* s = te::IRSimplifier::simplify(nest.root_stmt());
+    te::LLVMCodeGen cg(s, {A, sixth});
+  }
+}
+
+static void BM_CompileSwishLLVMOnly(benchmark::State& state) {
+  constexpr int N = 512;
+  te::KernelScope ks;
+  te::VarHandle n("n", te::kInt);
+  te::Placeholder A(te::BufHandle("A", {N}, te::kFloat));
+  te::Tensor* relu = te::Compute("relu", {{n, "n"}}, [&](const te::VarHandle& i) {
+    return te::Max::make(A.load(i), 0.f, false);
+  });
+  te::Tensor* min6 = te::Compute("min6", {{n, "n"}}, [&](const te::VarHandle& i) {
+    return te::Min::make(relu->call(i), 6.f, false);
+  });
+  te::Tensor* plus3 = te::Compute("plus3", {{n, "n"}}, [&](const te::VarHandle& i) {
+    return min6->call(i) + 3.f;
+  });
+  te::Tensor* times = te::Compute("times", {{n, "n"}}, [&](const te::VarHandle& i) {
+    return A.load(i) * plus3->call(i);
+  });
+  te::Tensor* sixth = te::Compute("sixth", {{n, "n"}}, [&](const te::VarHandle& i) {
+    return times->call(i) * 1.f / 6.f;
+  });
+  te::LoopNest nest({sixth});
+  for (auto tensor : {relu, min6, plus3, times}) {
+    nest.computeInline(tensor->buf());
+  }
+  nest.prepareForCodegen();
+  te::Stmt* s = te::IRSimplifier::simplify(nest.root_stmt());
+  for (auto _ : state) {
+    te::LLVMCodeGen cg(s, {A, sixth});
+  }
+}
+
+BENCHMARK(BM_CompileSwish);
+BENCHMARK(BM_CompileSwishLLVMOnly);
+#endif // TORCH_ENABLE_LLVM

--- a/benchmarks/cpp/tensorexpr/bench_gemm.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_gemm.cpp
@@ -128,5 +128,3 @@ BENCHMARK_DEFINE_F(Gemm, TensorExprTile32x32)(benchmark::State& state) {
 BENCHMARK_REGISTER_F(Gemm, Torch)->Args({128, 128, 128});
 BENCHMARK_REGISTER_F(Gemm, TensorExprNoopt)->Args({128, 128, 128});
 BENCHMARK_REGISTER_F(Gemm, TensorExprTile32x32)->Args({128, 128, 128});
-
-BENCHMARK_MAIN();

--- a/benchmarks/cpp/tensorexpr/main.cpp
+++ b/benchmarks/cpp/tensorexpr/main.cpp
@@ -1,0 +1,3 @@
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Summary:
We want to make sure we can actually fuse kernels within a fairly
tight time budget.  So here's a quick benchmark of codegen for a simple
pointwise activation function (swish).  I kept all the intermediate tensors
separate to force TE to actually do inlining.

Test Plan:
```
buck run mode/opt //caffe2/benchmarks/cpp/tensorexpr:tensorexpr_bench
```

I've only run in debug mode so results aren't super meaningful, but even in
that mode it's 18ms for compilation, 15 of which are in llvm.

Differential Revision: D24232801

