### PR TITLE
[NNC] Fix two more bugs in Cuda Half support

### DIFF
--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -546,6 +546,7 @@ class PrioritizeLoad : public IRMutator {
     const Var* load_new_var = new Var("v", v->dtype());
     const Expr* new_value = IRMutator::mutate(v);
     load_list.push_back(std::make_pair(load_new_var, new_value));
+
     return load_new_var;
   }
 
@@ -983,6 +984,10 @@ void CudaCodeGen::Initialize() {
   stmt_v = stmt_v->accept_mutator(&atomic_add_fuser);
 
   stmt_v = registerize(stmt_v);
+
+  // The registerizer might insert half-type scalars, we don't want this.
+  CudaHalfScalarRewriter hsFix;
+  stmt_v = stmt_v->accept_mutator(&hsFix);
 
   PrioritizeLoad prioritize_load;
   stmt_v = stmt_v->accept_mutator(&prioritize_load);

--- a/torch/csrc/jit/tensorexpr/cuda_half_support.h
+++ b/torch/csrc/jit/tensorexpr/cuda_half_support.h
@@ -32,6 +32,7 @@ class CudaHalfChecker : public IRMutator {
     if (v->value()->dtype().scalar_type() == ScalarType::Half) {
       // TODO discards lanes.
       new_val = new Cast(kHalf, new_val);
+      inserted_half_casts_.insert(new_val);
       hasHalf_ = true;
     }
 
@@ -43,8 +44,55 @@ class CudaHalfChecker : public IRMutator {
     return new Cast(kFloat, v);
   }
 
+  const Expr* mutate(const Cast* v) override {
+    const Expr* child = v->src_value()->accept_mutator(this);
+
+    // just don't allow half casts we didn't insert.
+    if (v->dtype().scalar_type() == ScalarType::Half) {
+      if (inserted_half_casts_.count(v) < 1) {
+        // TODO: discards lanes.
+        return new Cast(kFloat, child);
+      }
+    }
+
+    if (child == v->src_value()) {
+      return v;
+    }
+
+    return new Cast(v->dtype(), child);
+  }
+
  private:
   bool hasHalf_{false};
+  std::unordered_set<const Expr*> inserted_half_casts_;
+};
+
+class CudaHalfScalarRewriter : public IRMutator {
+  Stmt* mutate(const Let* v) override {
+    if (v->dtype().scalar_type() == ScalarType::Half) {
+      // TODO: discards lanes.
+      const Var* load_new_var = new Var(v->var()->name_hint(), kFloat);
+      const Expr* new_value =
+          new Cast(kFloat, v->value()->accept_mutator(this));
+      var_map[v->var()] = load_new_var;
+
+      return new Let(load_new_var, new_value);
+    }
+
+    return IRMutator::mutate(v);
+  }
+
+  const Expr* mutate(const Var* v) override {
+    auto it = var_map.find(v);
+    if (it != var_map.end()) {
+      return it->second;
+    }
+
+    return v;
+  }
+
+ private:
+  std::unordered_map<const Var*, const Var*> var_map;
 };
 
 } // namespace tensorexpr


### PR DESCRIPTION
Fixes two bugs reported by #45953 in the NNC Cuda codegen which could break when using Half floats:

1. The Registerizer will generate new scalars with the type of the load being replaced, and doesn't have Cuda specific logic to avoid using the half type. I've added a quick mutator to coerce these to float, similar to the existing load casting rules.

2. We're not handling explicit casts to Half inserted by the user (in the report the user being the JIT). Addressing this by replacing these with casts to Float since thats the type we do Half math in.

Fixes #45953.