### PR TITLE
WIP - experiment with unique APIs

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -152,6 +152,7 @@ _(aten, _trilinear) \
 _(aten, _trunc) \
 _(aten, _unique) \
 _(aten, _unique_dim) \
+_(aten, _unique_good) \
 _(aten, _unsafe_view) \
 _(aten, _validate_sparse_coo_tensor_args) \
 _(aten, _values) \

--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -152,7 +152,7 @@ _(aten, _trilinear) \
 _(aten, _trunc) \
 _(aten, _unique) \
 _(aten, _unique_dim) \
-_(aten, _unique_good) \
+_(aten, _uniq) \
 _(aten, _unsafe_view) \
 _(aten, _validate_sparse_coo_tensor_args) \
 _(aten, _values) \

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -58,7 +58,7 @@ std::tuple<Tensor, Tensor, Tensor, int64_t> compute_unique(
 
   // unique and count
   Tensor counts = at::empty({0}, options);
-  Tensor indices;
+  Tensor indices = at::empty({0}, options);
   int64_t num_out;
   if (!return_counts && !return_indices) {
     num_out = thrust::unique(policy, data, data + num_inp, equal) - data;
@@ -306,7 +306,7 @@ unique_consecutive_cuda(const Tensor& self, const bool return_inverse, const boo
 }
 
 std::tuple<Tensor,Tensor,Tensor,Tensor>
-unique_good_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool return_indices, bool return_counts){
+uniq_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool return_indices, bool return_counts){
   return AT_DISPATCH_ALL_TYPES_AND2(kBool, kHalf, self.scalar_type(), "unique_dim", [&] {
     Tensor output, inverse, counts, indices;
     std::tie(output, inverse, counts, indices) = unique_dim_cuda_template<scalar_t>(self, dim, false, return_inverse, return_counts, return_indices);
@@ -315,7 +315,7 @@ unique_good_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool
 }
 
 std::tuple<Tensor,Tensor,Tensor,Tensor>
-unique_good_cuda(const Tensor & self, bool return_inverse, bool return_indices, bool return_counts){
+uniq_cuda(const Tensor & self, bool return_inverse, bool return_indices, bool return_counts){
   return AT_DISPATCH_ALL_TYPES_AND2(kBool, kHalf, self.scalar_type(), "unique_dim", [&] {
     Tensor output, inverse, counts, indices;
     std::tie(output, inverse, counts, indices) = unique_cuda_template<scalar_t>(self, false, return_inverse, return_counts, return_indices);

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -265,5 +265,27 @@ unique_consecutive_cuda(const Tensor& self, const bool return_inverse, const boo
   return unique_dim_consecutive_cuda(self, dim.value(), return_inverse, return_counts);
 }
 
+std::tuple<Tensor,Tensor,Tensor>
+unique_good_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool return_indices, bool return_counts){
+  Tensor inverse;
+  Tensor indices;
+  Tensor counts;
+  inverse = return_inverse ? at::zeros_like(self, self.options().dtype(kLong)) : inverse;
+  indices = return_indices ? at::zeros_like(self, self.options().dtype(kLong)) : indices;
+  counts = return_counts ? at::zeros_like(self, self.options().dtype(kLong)) : counts;
+  return std::make_tuple(self, inverse, indices);
+}
+
+std::tuple<Tensor,Tensor,Tensor>
+unique_good_cuda(const Tensor & self, bool return_inverse, bool return_indices, bool return_counts){
+  Tensor inverse;
+  Tensor indices;
+  Tensor counts;
+  inverse = return_inverse ? at::zeros_like(self, self.options().dtype(kLong)) : inverse;
+  indices = return_indices ? at::zeros_like(self, self.options().dtype(kLong)) : indices;
+  counts = return_counts ? at::zeros_like(self, self.options().dtype(kLong)) : counts;
+  return std::make_tuple(self, inverse, indices);
+}
+
 }  // namespace native
 }  // namespace at

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -306,19 +306,19 @@ unique_consecutive_cuda(const Tensor& self, const bool return_inverse, const boo
 }
 
 std::tuple<Tensor,Tensor,Tensor,Tensor>
-uniq_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool return_indices, bool return_counts){
+uniq_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool return_index, bool return_counts){
   return AT_DISPATCH_ALL_TYPES_AND2(kBool, kHalf, self.scalar_type(), "unique_dim", [&] {
     Tensor output, inverse, counts, indices;
-    std::tie(output, inverse, counts, indices) = unique_dim_cuda_template<scalar_t>(self, dim, false, return_inverse, return_counts, return_indices);
+    std::tie(output, inverse, counts, indices) = unique_dim_cuda_template<scalar_t>(self, dim, false, return_inverse, return_counts, return_index);
     return std::make_tuple(output, inverse, indices, counts);
   });
 }
 
 std::tuple<Tensor,Tensor,Tensor,Tensor>
-uniq_cuda(const Tensor & self, bool return_inverse, bool return_indices, bool return_counts){
+uniq_cuda(const Tensor & self, bool return_inverse, bool return_index, bool return_counts){
   return AT_DISPATCH_ALL_TYPES_AND2(kBool, kHalf, self.scalar_type(), "unique_dim", [&] {
     Tensor output, inverse, counts, indices;
-    std::tie(output, inverse, counts, indices) = unique_cuda_template<scalar_t>(self, false, return_inverse, return_counts, return_indices);
+    std::tie(output, inverse, counts, indices) = unique_cuda_template<scalar_t>(self, false, return_inverse, return_counts, return_index);
     return std::make_tuple(output, inverse, indices, counts);
   });
 }

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -307,9 +307,6 @@ unique_consecutive_cuda(const Tensor& self, const bool return_inverse, const boo
 
 std::tuple<Tensor,Tensor,Tensor,Tensor>
 unique_good_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool return_indices, bool return_counts){
-  Tensor inverse;
-  Tensor indices;
-  Tensor counts;
   return AT_DISPATCH_ALL_TYPES_AND2(kBool, kHalf, self.scalar_type(), "unique_dim", [&] {
     Tensor output, inverse, counts, indices;
     std::tie(output, inverse, counts, indices) = unique_dim_cuda_template<scalar_t>(self, dim, false, return_inverse, return_counts, return_indices);
@@ -319,9 +316,6 @@ unique_good_dim_cuda(const Tensor & self, int64_t dim, bool return_inverse, bool
 
 std::tuple<Tensor,Tensor,Tensor,Tensor>
 unique_good_cuda(const Tensor & self, bool return_inverse, bool return_indices, bool return_counts){
-  Tensor inverse;
-  Tensor indices;
-  Tensor counts;
   return AT_DISPATCH_ALL_TYPES_AND2(kBool, kHalf, self.scalar_type(), "unique_dim", [&] {
     Tensor output, inverse, counts, indices;
     std::tie(output, inverse, counts, indices) = unique_cuda_template<scalar_t>(self, false, return_inverse, return_counts, return_indices);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3639,13 +3639,13 @@
     CPU: _unique2_cpu
     CUDA: _unique2_cuda
 
-- func: unique_good.dim(Tensor self, int dim, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+- func: _unique_good.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   variants: function, method
   use_c10_dispatcher: full
   dispatch:
     CUDA: unique_good_dim_cuda
 
-- func: unique_good(Tensor self, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+- func: _unique_good(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   variants: function, method
   use_c10_dispatcher: full
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3639,19 +3639,19 @@
     CPU: _unique2_cpu
     CUDA: _unique2_cuda
 
-- func: _unique_good.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- func: _uniq.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   variants: function, method
   use_c10_dispatcher: full
   dispatch:
-    CUDA: unique_good_dim_cuda
-    CPU: unique_good_dim_cpu
+    CUDA: uniq_dim_cuda
+    CPU: uniq_dim_cpu
 
-- func: _unique_good(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- func: _uniq(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   variants: function, method
   use_c10_dispatcher: full
   dispatch:
-    CUDA: unique_good_cuda
-    CPU: unique_good_cpu
+    CUDA: uniq_cuda
+    CPU: uniq_cpu
 
 - func: _unsafe_view(Tensor self, int[] size) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3639,14 +3639,14 @@
     CPU: _unique2_cpu
     CUDA: _unique2_cuda
 
-- func: _uniq.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- func: _uniq.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_index=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   variants: function, method
   use_c10_dispatcher: full
   dispatch:
     CUDA: uniq_dim_cuda
     CPU: uniq_dim_cpu
 
-- func: _uniq(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- func: _uniq(Tensor self, *, bool return_inverse=False, bool return_index=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   variants: function, method
   use_c10_dispatcher: full
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3644,12 +3644,14 @@
   use_c10_dispatcher: full
   dispatch:
     CUDA: unique_good_dim_cuda
+    CPU: unique_good_dim_cpu
 
 - func: _unique_good(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   variants: function, method
   use_c10_dispatcher: full
   dispatch:
     CUDA: unique_good_cuda
+    CPU: unique_good_cpu
 
 - func: _unsafe_view(Tensor self, int[] size) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3639,6 +3639,18 @@
     CPU: _unique2_cpu
     CUDA: _unique2_cuda
 
+- func: unique_good.dim(Tensor self, int dim, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+  variants: function, method
+  use_c10_dispatcher: full
+  dispatch:
+    CUDA: unique_good_dim_cuda
+
+- func: unique_good(Tensor self, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+  variants: function, method
+  use_c10_dispatcher: full
+  dispatch:
+    CUDA: unique_good_cuda
+
 - func: _unsafe_view(Tensor self, int[] size) -> Tensor
   use_c10_dispatcher: full
 

--- a/test/test_namedtuple_return_api.py
+++ b/test/test_namedtuple_return_api.py
@@ -12,7 +12,7 @@ aten_native_yaml = os.path.join(path, '../aten/src/ATen/native/native_functions.
 all_operators_with_namedtuple_return = {
     'max', 'min', 'median', 'nanmedian', 'mode', 'kthvalue', 'svd', 'symeig', 'eig',
     'qr', 'geqrf', 'solve', 'slogdet', 'sort', 'topk', 'lstsq',
-    'triangular_solve', 'cummax', 'cummin'
+    'triangular_solve', 'cummax', 'cummin', '_uniq'
 }
 
 
@@ -64,6 +64,7 @@ class TestNamedTupleAPI(unittest.TestCase):
             op(operators=['symeig', 'eig'], input=(True,), names=('eigenvalues', 'eigenvectors'), hasout=True),
             op(operators=['triangular_solve'], input=(a,), names=('solution', 'cloned_coefficient'), hasout=True),
             op(operators=['lstsq'], input=(a,), names=('solution', 'QR'), hasout=True),
+            op(operators=['_uniq'], input=(0,), names=('values', 'inverse', 'indices', 'counts'), hasout=False)
         ]
 
         for op in operators:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -15320,7 +15320,10 @@ class TestTorchDeviceType(TestCase):
             return  # CPU does not have half support
         maxval = 2 if dtype == torch.bool else 4
         x = torch.randint(2, (8,), dtype=dtype, device=device)
-        exp_val, exp_indices, exp_inverse, exp_counts = np.unique(x.cpu().numpy(), return_index=True, return_inverse=True, return_counts=True)
+        exp_val, exp_indices, exp_inverse, exp_counts = np.unique(x.cpu().numpy(),
+                                                                  return_index=True,
+                                                                  return_inverse=True,
+                                                                  return_counts=True)
         for return_index, return_inverse, return_counts in product((True, False), repeat=3):
             out = x._uniq(return_index=return_index, return_inverse=return_inverse, return_counts=return_counts)
             self.assertEqual(exp_val, out.values)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -14121,144 +14121,127 @@ class TestTorchDeviceType(TestCase):
             x_empty = torch.empty(5, 0, dtype=dtype, device=device)
             x_ill_formed_empty = torch.empty(5, 0, 0, dtype=dtype, device=device)
             x_ill_formed_empty_another = torch.empty(5, 0, 5, dtype=dtype, device=device)
-            expected_unique_dim0 = torch.tensor([[[1., 1.],
-                                                  [0., 1.],
-                                                  [2., 1.],
-                                                  [0., 1.]]],
-                                                dtype=dtype,
+            expected_val = {}
+            expected_inverse = {}
+            expected_counts = {}
+            expected_bool_val = {}
+            expected_bool_inverse = {}
+            expected_bool_counts = {}
+            # dim=0
+            expected_val[0] = torch.tensor([[[1., 1.],
+                                             [0., 1.],
+                                             [2., 1.],
+                                             [0., 1.]]],
+                                           dtype=dtype,
+                                           device=device)
+            expected_inverse[0] = torch.tensor([0, 0])
+            expected_counts[0] = torch.tensor([2])
+            # dim=1
+            expected_val[1] = torch.tensor([[[0., 1.],
+                                             [1., 1.],
+                                             [2., 1.]],
+                                            [[0., 1.],
+                                             [1., 1.],
+                                             [2., 1.]]],
+                                           dtype=dtype,
+                                           device=device)
+            expected_bool_val[1] = torch.tensor([[[False, True], [True, True]],
+                                                 [[False, True], [True, True]]],
+                                                dtype=torch.bool,
                                                 device=device)
-            expected_inverse_dim0 = torch.tensor([0, 0])
-            expected_counts_dim0 = torch.tensor([2])
-            expected_unique_dim1 = torch.tensor([[[0., 1.],
-                                                  [1., 1.],
-                                                  [2., 1.]],
-                                                 [[0., 1.],
-                                                  [1., 1.],
-                                                  [2., 1.]]],
-                                                dtype=dtype,
-                                                device=device)
-            expected_unique_dim1_bool = torch.tensor([[[False, True], [True, True]],
-                                                      [[False, True], [True, True]]],
-                                                     dtype=torch.bool,
-                                                     device=device)
-            expected_inverse_dim1 = torch.tensor([1, 0, 2, 0])
-            expected_inverse_dim1_bool = torch.tensor([1, 0, 1, 0])
-            expected_counts_dim1 = torch.tensor([2, 1, 1])
-            expected_counts_dim1_bool = torch.tensor([2, 2])
-            expected_unique_dim2 = torch.tensor([[[1., 1.],
-                                                  [0., 1.],
-                                                  [2., 1.],
-                                                  [0., 1.]],
-                                                 [[1., 1.],
-                                                  [0., 1.],
-                                                  [2., 1.],
-                                                  [0., 1.]]],
-                                                dtype=dtype,
-                                                device=device)
-            expected_inverse_dim2 = torch.tensor([0, 1])
-            expected_counts_dim2 = torch.tensor([1, 1])
+            expected_inverse[1] = torch.tensor([1, 0, 2, 0])
+            expected_bool_inverse[1] = torch.tensor([1, 0, 1, 0])
+            expected_counts[1] = torch.tensor([2, 1, 1])
+            expected_bool_counts[1] = torch.tensor([2, 2])
+            # dim = 2
+            expected_val[2] = torch.tensor([[[1., 1.],
+                                             [0., 1.],
+                                             [2., 1.],
+                                             [0., 1.]],
+                                            [[1., 1.],
+                                             [0., 1.],
+                                             [2., 1.],
+                                             [0., 1.]]],
+                                           dtype=dtype,
+                                           device=device)
+            expected_inverse[2] = torch.tensor([0, 1])
+            expected_counts[2] = torch.tensor([1, 1])
             expected_unique_empty = torch.tensor([], dtype=dtype, device=device)
             expected_inverse_empty = torch.tensor([], dtype=torch.long, device=device)
             expected_counts_empty = torch.tensor([], dtype=torch.long, device=device)
             # dim0
-            x_unique = torch.unique(x, dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
+            for dim in (0, 1, 2):
+                x_unique = torch.unique(x, dim=dim)
+                if x.dtype == torch.bool and dim == 1:
+                    self.assertEqual(expected_bool_val[dim], x_unique)
+                else:
+                    self.assertEqual(expected_val[dim], x_unique)
 
-            x_unique, x_inverse = torch.unique(
-                x,
-                return_inverse=True,
-                dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
-            self.assertEqual(expected_inverse_dim0, x_inverse)
+                x_unique, x_inverse = torch.unique(
+                    x,
+                    return_inverse=True,
+                    dim=dim)
+                if x.dtype == torch.bool and dim == 1:
+                    self.assertEqual(expected_bool_val[dim], x_unique)
+                    self.assertEqual(expected_bool_inverse[dim], x_inverse)
+                else:
+                    self.assertEqual(expected_val[dim], x_unique)
+                    self.assertEqual(expected_inverse[dim], x_inverse)
 
-            x_unique, x_counts = torch.unique(
-                x,
-                return_inverse=False,
-                return_counts=True,
-                dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
-            self.assertEqual(expected_counts_dim0, x_counts)
+                x_unique, x_counts = torch.unique(
+                    x,
+                    return_inverse=False,
+                    return_counts=True,
+                    dim=dim)
+                if x.dtype == torch.bool and dim == 1:
+                    self.assertEqual(expected_bool_val[dim], x_unique)
+                    self.assertEqual(expected_bool_counts[dim], x_counts)
+                else:
+                    self.assertEqual(expected_val[dim], x_unique)
+                    self.assertEqual(expected_counts[dim], x_counts)
 
-            x_unique, x_inverse, x_counts = torch.unique(
-                x,
-                return_inverse=True,
-                return_counts=True,
-                dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
-            self.assertEqual(expected_inverse_dim0, x_inverse)
-            self.assertEqual(expected_counts_dim0, x_counts)
+                x_unique, x_inverse, x_counts = torch.unique(
+                    x,
+                    return_inverse=True,
+                    return_counts=True,
+                    dim=dim)
+                if x.dtype == torch.bool and dim == 1:
+                    self.assertEqual(expected_bool_val[dim], x_unique)
+                    self.assertEqual(expected_bool_inverse[dim], x_inverse)
+                    self.assertEqual(expected_bool_counts[dim], x_counts)
+                else:
+                    self.assertEqual(expected_val[dim], x_unique)
+                    self.assertEqual(expected_inverse[dim], x_inverse)
+                    self.assertEqual(expected_counts[dim], x_counts)
 
-            # dim1
-            x_unique = torch.unique(x, dim=1)
-            if x.dtype == torch.bool:
-                self.assertEqual(expected_unique_dim1_bool, x_unique)
-            else:
-                self.assertEqual(expected_unique_dim1, x_unique)
+            # test uniq and indices
+            expected_indices = {}
+            expected_bool_indices = {}
+            expected_indices[0] = torch.tensor([0])
+            expected_indices[1] = torch.tensor([1, 0, 2])
+            expected_bool_indices[1] = torch.tensor([1, 0])
+            expected_indices[2] = torch.tensor([0, 1])
+            for dim in (0, 1, 2):
+                for return_inverse, return_counts, return_index in product((True, False), repeat=3):
+                    out = x._uniq(return_inverse=return_inverse, return_counts=return_counts, return_index=return_index, dim=dim)
+                    if x.dtype == torch.bool and dim == 1:
+                        exp_val = expected_bool_val[dim]
+                        exp_inverse = expected_bool_inverse[dim]
+                        exp_counts = expected_bool_counts[dim]
+                        exp_indices = expected_bool_indices[dim]
+                    else:
+                        exp_val = expected_val[dim]
+                        exp_inverse = expected_inverse[dim]
+                        exp_counts = expected_counts[dim]
+                        exp_indices = expected_indices[dim]
 
-            x_unique, x_inverse = torch.unique(
-                x,
-                return_inverse=True,
-                dim=1)
-            if x.dtype == torch.bool:
-                self.assertEqual(expected_unique_dim1_bool, x_unique)
-                self.assertEqual(expected_inverse_dim1_bool, x_inverse)
-            else:
-                self.assertEqual(expected_unique_dim1, x_unique)
-                self.assertEqual(expected_inverse_dim1, x_inverse)
-
-            x_unique, x_counts = torch.unique(
-                x,
-                return_inverse=False,
-                return_counts=True,
-                dim=1)
-            if x.dtype == torch.bool:
-                self.assertEqual(expected_unique_dim1_bool, x_unique)
-                self.assertEqual(expected_counts_dim1_bool, x_counts)
-            else:
-                self.assertEqual(expected_unique_dim1, x_unique)
-                self.assertEqual(expected_counts_dim1, x_counts)
-
-            x_unique, x_inverse, x_counts = torch.unique(
-                x,
-                return_inverse=True,
-                return_counts=True,
-                dim=1)
-            if x.dtype == torch.bool:
-                self.assertEqual(expected_unique_dim1_bool, x_unique)
-                self.assertEqual(expected_inverse_dim1_bool, x_inverse)
-                self.assertEqual(expected_counts_dim1_bool, x_counts)
-            else:
-                self.assertEqual(expected_unique_dim1, x_unique)
-                self.assertEqual(expected_inverse_dim1, x_inverse)
-                self.assertEqual(expected_counts_dim1, x_counts)
-
-            # dim2
-            x_unique = torch.unique(x, dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-
-            x_unique, x_inverse = torch.unique(
-                x,
-                return_inverse=True,
-                dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-            self.assertEqual(expected_inverse_dim2, x_inverse)
-
-            x_unique, x_counts = torch.unique(
-                x,
-                return_inverse=False,
-                return_counts=True,
-                dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-            self.assertEqual(expected_counts_dim2, x_counts)
-
-            x_unique, x_inverse, x_counts = torch.unique(
-                x,
-                return_inverse=True,
-                return_counts=True,
-                dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-            self.assertEqual(expected_inverse_dim2, x_inverse)
-            self.assertEqual(expected_counts_dim2, x_counts)
+                    self.assertEqual(exp_val, out.values)
+                    if return_inverse:
+                        self.assertEqual(exp_inverse, out.inverse)
+                    if return_counts:
+                        self.assertEqual(exp_counts, out.counts)
+                    if return_index:
+                        self.assertEqual(exp_indices, out.indices)
 
             # test empty tensor
             x_unique, x_inverse, x_counts = torch.unique(
@@ -15329,6 +15312,25 @@ class TestTorchDeviceType(TestCase):
         for f in [torch.unique_consecutive, lambda x, **kwargs: x.unique_consecutive(**kwargs)]:
             self._test_unique_with_expects(device, dtype, f, x, expected_unique, expected_inverse, expected_counts, (3, 3))
             self._test_unique_scalar_empty(dtype, device, f)
+
+    @dtypes(*set(torch.testing.get_all_dtypes()) - {torch.bfloat16, torch.complex64, torch.complex128})
+    @onlyOnCPUAndCUDA
+    def test_uniq(self, device, dtype):
+        if dtype is torch.half and self.device_type == 'cpu':
+            return  # CPU does not have half support
+        maxval = 2 if dtype == torch.bool else 4
+        x = torch.randint(2, (8,), dtype=dtype, device=device)
+        exp_val, exp_indices, exp_inverse, exp_counts = np.unique(x.cpu().numpy(), return_index=True, return_inverse=True, return_counts=True)
+        for return_index, return_inverse, return_counts in product((True, False), repeat=3):
+            out = x._uniq(return_index=return_index, return_inverse=return_inverse, return_counts=return_counts)
+            self.assertEqual(exp_val, out.values)
+            if return_inverse:
+                self.assertEqual(exp_inverse, out.inverse)
+            if return_counts:
+                self.assertEqual(exp_counts, out.counts)
+            if return_index:
+                self.assertEqual(exp_indices, out.indices)
+
 
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypes(torch.float, torch.double)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1097,10 +1097,10 @@
 - name: _unique(Tensor self, bool sorted=True, bool return_inverse=False) -> (Tensor, Tensor)
   self: not_implemented("_unique")
 
-- name: _uniq(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- name: _uniq(Tensor self, *, bool return_inverse=False, bool return_index=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   self: not_implemented("unique_good")
 
-- name: _uniq.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- name: _uniq.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_index=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   self: not_implemented("unique_good.dim")
 
 - name: _unsafe_view(Tensor self, int[] size) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1097,6 +1097,12 @@
 - name: _unique(Tensor self, bool sorted=True, bool return_inverse=False) -> (Tensor, Tensor)
   self: not_implemented("_unique")
 
+- name: unique_good(Tensor self, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+  self: not_implemented("unique_good")
+
+- name: unique_good.dim(Tensor self, int dim, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+  self: not_implemented("unique_good.dim")
+
 - name: _unsafe_view(Tensor self, int[] size) -> Tensor
   self: grad.reshape(self.sizes())
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1097,10 +1097,10 @@
 - name: _unique(Tensor self, bool sorted=True, bool return_inverse=False) -> (Tensor, Tensor)
   self: not_implemented("_unique")
 
-- name: _unique_good(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- name: _uniq(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   self: not_implemented("unique_good")
 
-- name: _unique_good.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
+- name: _uniq.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   self: not_implemented("unique_good.dim")
 
 - name: _unsafe_view(Tensor self, int[] size) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1097,10 +1097,10 @@
 - name: _unique(Tensor self, bool sorted=True, bool return_inverse=False) -> (Tensor, Tensor)
   self: not_implemented("_unique")
 
-- name: unique_good(Tensor self, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+- name: _unique_good(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   self: not_implemented("unique_good")
 
-- name: unique_good.dim(Tensor self, int dim, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices)
+- name: _unique_good.dim(Tensor self, int dim, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
   self: not_implemented("unique_good.dim")
 
 - name: _unsafe_view(Tensor self, int[] size) -> Tensor

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -109,6 +109,16 @@ inline PyObject* wrap(PyTypeObject *type, std::tuple<at::Tensor, at::Tensor, at:
   return r.release();
 }
 
+inline PyObject* wrap(PyTypeObject *type, std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> tensors) {
+  auto r = THPObjectPtr{PyStructSequence_New(type)};
+  if (!r) throw python_error();
+  PyStructSequence_SET_ITEM(r.get(), 0, wrap(std::get<0>(tensors)));
+  PyStructSequence_SET_ITEM(r.get(), 1, wrap(std::get<1>(tensors)));
+  PyStructSequence_SET_ITEM(r.get(), 2, wrap(std::get<2>(tensors)));
+  PyStructSequence_SET_ITEM(r.get(), 3, wrap(std::get<3>(tensors)));
+  return r.release();
+}
+
 inline PyObject* wrap(std::tuple<at::Tensor, at::Tensor, at::Tensor, int64_t> tensors) {
   auto r = THPObjectPtr{PyTuple_New(4)};
   if (!r) throw python_error();

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -760,6 +760,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.unbind: lambda input, dim=0: -1,
         torch.unique: lambda input, sorted=True, return_inverse=False, return_counts=False, dim=None: -1,
         torch.unique_consecutive: lambda input, return_inverse=False, return_counts=False, dim=None: -1,
+        torch._uniq: lambda input, return_inverse=False, return_counts=False, return_indices=False, dim=None: -1,
         torch.unsafe_chunk: lambda input, chunks, dim=0: -1,
         torch.unsafe_split: lambda tensor, split_size_or_sections, dim=0: -1,
         torch.unsafe_split_with_sizes: lambda tensor, split_size_or_sections, dim=0: -1,


### PR DESCRIPTION
Our current `unique` function is fragile and almost impossible to modify. This is an attempt to see how unique might look like in a saner world. 
This PR adds _unique_good function that always returns named tuple that contains `value`, `inverse`, `indices` and `counts` fields:
```
func: _uniq(Tensor self, *, bool return_inverse=False, bool return_indices=False, bool return_counts=False) -> (Tensor values, Tensor inverse, Tensor indices, Tensor counts)
```
When some of these values are not needed due to corresponding function argument being `False`, 0-element tensor or undefined tensor (None) can be returned (more on that below, this PR returns 0-element tensors in this case to satisfy scripting limitations) 
Pros:
- return type is always the same (tuple)
- scripting almost works - scripting can't handle undefined (None) tensor, so if we agree that 0-element return in this case is acceptable, it solves scripting problem
- provides numpy functionality (return_indices) that is currently very challenging to add to existing `unique`
- named tuple is a much better UX when there can be up to 4 returns, relying on return order is fragile (especially when things to return are controlled by kwargs and not positional args)

Cons:
- if we decide to change `unique` behavior to this, it's bc-breaking
- it is not numpy compatible (numpy returns either a single nd-array, or a tuple of nd-arrays, not named tuple always)
- returning 0-element tensors to satisfy scripting concerns is worse UX than returning undefined tensors that turn to None in the named tuple. 
- even `None` elements in the named tuple are not the best, ideally they should be omitted but as far as I can see it can be solved only by an additional layer of python wrapping, and that will complicate scripting. 
- if in the future we'll need additional returns, it will also be bc-breaking, since the number of elements in the return tuple is fixed
