### PR TITLE
Fix perfornance issue of GroupNorm on CUDA when feature map is small.

### DIFF
--- a/aten/src/ATen/cuda/DeviceUtils.cuh
+++ b/aten/src/ATen/cuda/DeviceUtils.cuh
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cuda.h>
 #include <c10/util/complex.h>
 #include <c10/util/Half.h>

--- a/aten/src/ATen/native/cpu/group_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/group_norm_kernel.cpp
@@ -24,9 +24,9 @@ void GroupNormKernelImplInternal(
     int64_t HxW,
     int64_t group,
     T eps,
-    Tensor* Y,
-    Tensor* mean,
-    Tensor* rstd) {
+    Tensor& Y,
+    Tensor& mean,
+    Tensor& rstd) {
   TORCH_CHECK(X.numel() == N * C * HxW);
   TORCH_CHECK(!gamma.defined() || gamma.numel() == C);
   TORCH_CHECK(!beta.defined() || beta.numel() == C);
@@ -35,9 +35,9 @@ void GroupNormKernelImplInternal(
   const T* X_data = X.data_ptr<T>();
   const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
   const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
-  T* Y_data = Y->data_ptr<T>();
-  T* mean_data = mean->data_ptr<T>();
-  T* rstd_data = rstd->data_ptr<T>();
+  T* Y_data = Y.data_ptr<T>();
+  T* mean_data = mean.data_ptr<T>();
+  T* rstd_data = rstd.data_ptr<T>();
   const T s = T(1) / static_cast<T>(D * HxW);
   const bool gamma_null = (gamma_data == nullptr);
   const bool beta_null = beta_data == nullptr;
@@ -94,9 +94,9 @@ void GroupNormKernelImpl(
     int64_t HxW,
     int64_t group,
     double eps,
-    Tensor* Y,
-    Tensor* mean,
-    Tensor* rstd) {
+    Tensor& Y,
+    Tensor& mean,
+    Tensor& rstd) {
   AT_DISPATCH_FLOATING_TYPES(X.scalar_type(), "GroupNormKernelImpl", [&]() {
     GroupNormKernelImplInternal<scalar_t>(
         X,
@@ -268,9 +268,9 @@ void GroupNormBackwardKernelImplInternal(
     int64_t C,
     int64_t HxW,
     int64_t group,
-    Tensor* dX,
-    Tensor* dgamma,
-    Tensor* dbeta) {
+    Tensor& dX,
+    Tensor& dgamma,
+    Tensor& dbeta) {
   TORCH_CHECK(dY.numel() == N * C * HxW);
   TORCH_CHECK(X.numel() == N * C * HxW);
   TORCH_CHECK(mean.numel() == N * group);
@@ -282,9 +282,9 @@ void GroupNormBackwardKernelImplInternal(
   const T* mean_data = mean.data_ptr<T>();
   const T* rstd_data = rstd.data_ptr<T>();
   const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
-  T* dX_data = dX->defined() ? dX->data_ptr<T>() : nullptr;
-  T* dgamma_data = dgamma->defined() ? dgamma->data_ptr<T>() : nullptr;
-  T* dbeta_data = dbeta->defined() ? dbeta->data_ptr<T>() : nullptr;
+  T* dX_data = dX.defined() ? dX.data_ptr<T>() : nullptr;
+  T* dgamma_data = dgamma.defined() ? dgamma.data_ptr<T>() : nullptr;
+  T* dbeta_data = dbeta.defined() ? dbeta.data_ptr<T>() : nullptr;
   Tensor ds = at::empty({N, C}, X.options());
   Tensor db = at::empty({N, C}, X.options());
   T* ds_data = ds.data_ptr<T>();
@@ -326,9 +326,9 @@ void GroupNormBackwardKernelImpl(
     int64_t C,
     int64_t HxW,
     int64_t group,
-    Tensor* dX,
-    Tensor* dgamma,
-    Tensor* dbeta) {
+    Tensor& dX,
+    Tensor& dgamma,
+    Tensor& dbeta) {
   AT_DISPATCH_FLOATING_TYPES(
       X.scalar_type(), "GroupNormBackwardKernelImpl", [&]() {
         GroupNormBackwardKernelImplInternal<scalar_t>(

--- a/aten/src/ATen/native/cuda/block_reduce.cuh
+++ b/aten/src/ATen/native/cuda/block_reduce.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <THC/THCDeviceUtils.cuh>
+#include <ATen/cuda/DeviceUtils.cuh>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -1,13 +1,18 @@
 #include <ATen/native/group_norm.h>
 
+#include <type_traits>
+
+#include <thrust/tuple.h>
+
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/native/TensorIterator.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
-#include <THC/THCDeviceUtils.cuh>
 
 #include <c10/cuda/CUDAMathCompat.h>
 
@@ -27,8 +32,6 @@ __global__ void RowwiseMomentsCUDAKernel(
     T* mean,
     T* rstd) {
   using T_ACC = acc_type<T, true>;
-  __shared__ T_ACC m_shared[C10_WARP_SIZE];
-  __shared__ T_ACC v_shared[C10_WARP_SIZE];
   const int64_t i = blockIdx.x;
   T_ACC sum1 = 0;
   T_ACC sum2 = 0;
@@ -37,8 +40,15 @@ __global__ void RowwiseMomentsCUDAKernel(
     sum1 += static_cast<T_ACC>(X[index]);
     sum2 += static_cast<T_ACC>(X[index]) * static_cast<T_ACC>(X[index]);
   }
-  sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, m_shared);
-  sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, v_shared);
+  if (blockDim.x <= C10_WARP_SIZE) {
+    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  } else {
+    __shared__ T_ACC m_shared[C10_WARP_SIZE];
+    __shared__ T_ACC v_shared[C10_WARP_SIZE];
+    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, m_shared);
+    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, v_shared);
+  }
   if (threadIdx.x == 0) {
     const T_ACC scale = T_ACC(1) / static_cast<T_ACC>(N);
     sum1 *= scale;
@@ -64,44 +74,190 @@ __global__ void ComputeFusedParamsCUDAKernel(
   if (index < N * C) {
     const int64_t ng = index / (C / group);
     const int64_t c = index % C;
-    const T_ACC x = (gamma == nullptr)
+    const T_ACC scale = (gamma == nullptr)
         ? static_cast<T_ACC>(rstd[ng])
         : static_cast<T_ACC>(rstd[ng]) * static_cast<T_ACC>(gamma[c]);
-    a[index] = x;
-    b[index] = -x * static_cast<T_ACC>(mean[ng]) +
-        (beta == nullptr ? T_ACC(0) : static_cast<T_ACC>(beta[c]));
+    a[index] = scale;
+    b[index] = -scale * static_cast<T_ACC>(mean[ng]) +
+        ((beta == nullptr) ? 0 : static_cast<T_ACC>(beta[c]));
   }
 }
 
 template <typename T>
-__global__ void GroupNormForwardSimpleCUDAKernel(
+__global__ void Compute1dBackwardFusedParamsCUDAKernel(
+    int64_t C,
+    int64_t group,
+    const T* dY,
+    const T* X,
+    const T* mean,
+    const T* rstd,
+    const T* gamma,
+    acc_type<T, true>* c2,
+    acc_type<T, true>* c3) {
+  using T_ACC = acc_type<T, true>;
+  const int64_t G = group;
+  const int64_t D = C / G;
+  const int64_t n = blockIdx.x;
+  const int64_t g = blockIdx.y;
+  const int64_t ng = n * G + g;
+  T_ACC sum1 = 0;
+  T_ACC sum2 = 0;
+  for (int64_t i = threadIdx.x; i < D; i += blockDim.x) {
+    const int64_t index = ng * D + i;
+    const int64_t c = g * D + i;
+    const T_ACC gamma_v =
+        gamma == nullptr ? T_ACC(1) : static_cast<T_ACC>(gamma[c]);
+    sum1 += dY[index] * X[index] * gamma_v;
+    sum2 += dY[index] * gamma_v;
+  }
+  if (blockDim.x <= C10_WARP_SIZE) {
+    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  } else {
+    __shared__ T_ACC ds_shared[C10_WARP_SIZE];
+    __shared__ T_ACC db_shared[C10_WARP_SIZE];
+    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
+    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
+  }
+  if (threadIdx.x == 0) {
+    const T_ACC s = T_ACC(1) / static_cast<T_ACC>(D);
+    const T_ACC x = (sum2 * static_cast<T_ACC>(mean[ng]) - sum1) *
+        static_cast<T_ACC>(rstd[ng]) * static_cast<T_ACC>(rstd[ng]) *
+        static_cast<T_ACC>(rstd[ng]) * s;
+    c2[ng] = x;
+    c3[ng] = -x * static_cast<T_ACC>(mean[ng]) -
+        sum2 * static_cast<T_ACC>(rstd[ng]) * s;
+  }
+}
+
+template <typename T>
+__global__ void GammaBeta1dBackwardCUDAKernel1(
     int64_t N,
     int64_t C,
-    int64_t HxW,
+    int64_t group,
+    const T* dY,
     const T* X,
-    const acc_type<T, true>* a,
-    const acc_type<T, true>* b,
-    T* Y) {
+    const T* mean,
+    const T* rstd,
+    T* dgamma,
+    T* dbeta) {
   using T_ACC = acc_type<T, true>;
-  const int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
-  if (index < N * C * HxW) {
-    const int64_t nc = index / HxW;
-    Y[index] = a[nc] * static_cast<T_ACC>(X[index]) + b[nc];
+  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  if (c < C) {
+    const int64_t G = group;
+    const int64_t D = C / G;
+    T_ACC sum1 = 0;
+    T_ACC sum2 = 0;
+    for (int64_t n = 0; n < N; ++n) {
+      const int64_t nc = n * C + c;
+      const int64_t ng = n * G + c / D;
+      const T_ACC dy_acc = static_cast<T_ACC>(dY[nc]);
+      const T_ACC x_acc = static_cast<T_ACC>(X[nc]);
+      sum1 += (dgamma == nullptr)
+          ? T_ACC(0)
+          : ((dy_acc * x_acc - dy_acc * static_cast<T_ACC>(mean[ng])) *
+             static_cast<T_ACC>(rstd[ng]));
+      sum2 += (dbeta == nullptr) ? T_ACC(0) : dy_acc;
+    }
+    if (dgamma != nullptr) {
+      dgamma[c] = sum1;
+    }
+    if (dbeta != nullptr) {
+      dbeta[c] = sum2;
+    }
   }
 }
 
 template <typename T>
-__global__ void GroupNormForwardCUDAKernel(
-    int64_t HxW,
+__global__ void GammaBeta1dBackwardCUDAKernel2(
+    int64_t N,
+    int64_t C,
+    int64_t group,
+    const T* dY,
     const T* X,
-    const acc_type<T, true>* a,
-    const acc_type<T, true>* b,
-    T* Y) {
+    const T* mean,
+    const T* rstd,
+    T* dgamma,
+    T* dbeta) {
   using T_ACC = acc_type<T, true>;
-  const int64_t nc = blockIdx.x;
-  for (int64_t hw = threadIdx.x; hw < HxW; hw += blockDim.x) {
-    const int64_t index = nc * HxW + hw;
-    Y[index] = a[nc] * static_cast<T_ACC>(X[index]) + b[nc];
+  __shared__ T_ACC g_shared[kReduceTileSize][kReduceTileSize + 1];
+  __shared__ T_ACC b_shared[kReduceTileSize][kReduceTileSize + 1];
+  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  T_ACC dg_sum1 = 0;
+  T_ACC dg_sum2 = 0;
+  T_ACC db_sum1 = 0;
+  T_ACC db_sum2 = 0;
+  if (c < C) {
+    const int64_t G = group;
+    const int64_t D = C / G;
+    // Accumulate each 32 cols into a 32 * 32 tile.
+    // Since the blockDim is (32, 16), accumulate twice for 1st and 2nd 16 rows
+    // of a 32 contiguous elements.
+    for (int64_t n = threadIdx.y; n < N; n += blockDim.y * 2) {
+      const int64_t n1 = n;
+      const int64_t n2 = n + blockDim.y;
+      const int64_t nc1 = n1 * C + c;
+      const int64_t nc2 = n2 * C + c;
+      const int64_t ng1 = n1 * G + c / D;
+      const int64_t ng2 = n2 * G + c / D;
+      const T_ACC dy1_acc = static_cast<T_ACC>(dY[nc1]);
+      const T_ACC x1_acc = static_cast<T_ACC>(X[nc1]);
+      dg_sum1 += dgamma == nullptr
+          ? T_ACC(0)
+          : ((dy1_acc * x1_acc - dy1_acc * static_cast<T_ACC>(mean[ng1])) *
+             static_cast<T_ACC>(rstd[ng1]));
+      db_sum1 += dbeta == nullptr ? T_ACC(0) : dy1_acc;
+      if (n2 < N) {
+        const T_ACC dy2_acc = static_cast<T_ACC>(dY[nc2]);
+        const T_ACC x2_acc = static_cast<T_ACC>(X[nc2]);
+        dg_sum2 += dgamma == nullptr
+            ? T_ACC(0)
+            : ((dy2_acc * x2_acc - dy2_acc * static_cast<T_ACC>(mean[ng2])) *
+               static_cast<T_ACC>(rstd[ng2]));
+        db_sum2 += dbeta == nullptr ? T_ACC(0) : dy2_acc;
+      }
+    }
+  }
+
+  // Write accumulated tile to shared memory.
+  g_shared[threadIdx.y][threadIdx.x] = dg_sum1;
+  g_shared[threadIdx.y + blockDim.y][threadIdx.x] = dg_sum2;
+  b_shared[threadIdx.y][threadIdx.x] = db_sum1;
+  b_shared[threadIdx.y + blockDim.y][threadIdx.x] = db_sum2;
+  __syncthreads();
+
+  // Do warp reduce for the 1st 16 cols in the tile.
+  T_ACC sum1 = g_shared[threadIdx.x][threadIdx.y];
+  T_ACC sum2 = b_shared[threadIdx.x][threadIdx.y];
+  sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+  sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  if (threadIdx.x == 0) {
+    const int64_t c = blockIdx.x * blockDim.x + threadIdx.y;
+    if (c < C) {
+      if (dgamma != nullptr) {
+        dgamma[c] = sum1;
+      }
+      if (dbeta != nullptr) {
+        dbeta[c] = sum2;
+      }
+    }
+  }
+
+  // Do warp reduce for the 2nd 16 cols in the tile.
+  sum1 = g_shared[threadIdx.x][threadIdx.y + blockDim.y];
+  sum2 = b_shared[threadIdx.x][threadIdx.y + blockDim.y];
+  sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+  sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  if (threadIdx.x == 0) {
+    const int64_t c = blockIdx.x * blockDim.x + threadIdx.y + blockDim.y;
+    if (c < C) {
+      if (dgamma != nullptr) {
+        dgamma[c] = sum1;
+      }
+      if (dbeta != nullptr) {
+        dbeta[c] = sum2;
+      }
+    }
   }
 }
 
@@ -113,8 +269,6 @@ __global__ void ComputeInternalGradientsCUDAKernel(
     acc_type<T, true>* ds,
     acc_type<T, true>* db) {
   using T_ACC = acc_type<T, true>;
-  __shared__ T_ACC ds_shared[C10_WARP_SIZE];
-  __shared__ T_ACC db_shared[C10_WARP_SIZE];
   const int64_t nc = blockIdx.x;
   T_ACC sum1 = 0;
   T_ACC sum2 = 0;
@@ -123,29 +277,18 @@ __global__ void ComputeInternalGradientsCUDAKernel(
     sum1 += static_cast<T_ACC>(dY[index]) * static_cast<T_ACC>(X[index]);
     sum2 += static_cast<T_ACC>(dY[index]);
   }
-  sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
-  sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
+  if (blockDim.x <= C10_WARP_SIZE) {
+    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  } else {
+    __shared__ T_ACC ds_shared[C10_WARP_SIZE];
+    __shared__ T_ACC db_shared[C10_WARP_SIZE];
+    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
+    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
+  }
   if (threadIdx.x == 0) {
     ds[nc] = sum1;
     db[nc] = sum2;
-  }
-}
-
-template <typename T>
-__global__ void ComputeGradOutputCoeffientCUDAKernel(
-    int64_t N,
-    int64_t C,
-    int64_t group,
-    const T* rstd,
-    const T* gamma,
-    acc_type<T, true>* c1) {
-  using T_ACC = acc_type<T, true>;
-  const int64_t nc = blockIdx.x * blockDim.x + threadIdx.x;
-  if (nc < N * C) {
-    const int64_t ng = nc / (C / group);
-    const int64_t c = nc % C;
-    c1[nc] = static_cast<T_ACC>(rstd[ng]) *
-        (gamma == nullptr ? T_ACC(1) : static_cast<T_ACC>(gamma[c]));
   }
 }
 
@@ -162,8 +305,6 @@ __global__ void ComputeBackwardFusedParamsCUDAKernel(
     acc_type<T, true>* c2,
     acc_type<T, true>* c3) {
   using T_ACC = acc_type<T, true>;
-  __shared__ T_ACC ds_shared[C10_WARP_SIZE];
-  __shared__ T_ACC db_shared[C10_WARP_SIZE];
   const int64_t G = group;
   const int64_t D = C / G;
   const int64_t n = blockIdx.x;
@@ -179,8 +320,15 @@ __global__ void ComputeBackwardFusedParamsCUDAKernel(
     sum1 += ds[index] * gamma_v;
     sum2 += db[index] * gamma_v;
   }
-  sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
-  sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
+  if (blockDim.x <= C10_WARP_SIZE) {
+    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
+    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
+  } else {
+    __shared__ T_ACC ds_shared[C10_WARP_SIZE];
+    __shared__ T_ACC db_shared[C10_WARP_SIZE];
+    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
+    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
+  }
   if (threadIdx.x == 0) {
     const T_ACC s = T_ACC(1) / static_cast<T_ACC>(D * HxW);
     const T_ACC x = (sum2 * static_cast<T_ACC>(mean[ng]) - sum1) *
@@ -193,51 +341,7 @@ __global__ void ComputeBackwardFusedParamsCUDAKernel(
 }
 
 template <typename T>
-__global__ void GroupNormBackwardSimpleCUDAKernel(
-    int64_t N,
-    int64_t C,
-    int64_t HxW,
-    int64_t group,
-    const T* dY,
-    const T* X,
-    const acc_type<T, true>* c1,
-    const acc_type<T, true>* c2,
-    const acc_type<T, true>* c3,
-    T* dX) {
-  using T_ACC = acc_type<T, true>;
-  const int64_t index = blockIdx.x * blockDim.x + threadIdx.x;
-  if (index < N * C * HxW) {
-    const int64_t nc = index / HxW;
-    const int64_t ng = nc / (C / group);
-    dX[index] = c1[nc] * static_cast<T_ACC>(dY[index]) +
-        c2[ng] * static_cast<T_ACC>(X[index]) + c3[ng];
-  }
-}
-
-template <typename T>
-__global__ void GroupNormBackwardCUDAKernel(
-    int64_t C,
-    int64_t HxW,
-    int64_t group,
-    const T* dY,
-    const T* X,
-    const acc_type<T, true>* c1,
-    const acc_type<T, true>* c2,
-    const acc_type<T, true>* c3,
-    T* dX) {
-  using T_ACC = acc_type<T, true>;
-  const int64_t D = C / group;
-  const int64_t nc = blockIdx.x;
-  const int64_t ng = nc / D;
-  for (int64_t hw = threadIdx.x; hw < HxW; hw += blockDim.x) {
-    const int64_t index = nc * HxW + hw;
-    dX[index] = c1[nc] * static_cast<T_ACC>(dY[index]) +
-        c2[ng] * static_cast<T_ACC>(X[index]) + c3[ng];
-  }
-}
-
-template <typename T>
-__global__ void GammaBetaBackwardSimpleCUDAKernel(
+__global__ void GammaBetaBackwardCUDAKernel1(
     int64_t N,
     int64_t C,
     int64_t group,
@@ -273,7 +377,7 @@ __global__ void GammaBetaBackwardSimpleCUDAKernel(
 }
 
 template <typename T>
-__global__ void GammaBetaBackwardCUDAKernel(
+__global__ void GammaBetaBackwardCUDAKernel2(
     int64_t N,
     int64_t C,
     int64_t group,
@@ -294,6 +398,9 @@ __global__ void GammaBetaBackwardCUDAKernel(
   if (c < C) {
     const int64_t G = group;
     const int64_t D = C / G;
+    // Accumulate each 32 cols into a 32 * 32 tile.
+    // Since the blockDim is (32, 16), accumulate twice for 1st and 2nd 16 rows
+    // of a 32 contiguous elements.
     for (int64_t n = threadIdx.y; n < N; n += blockDim.y * 2) {
       const int64_t n1 = n;
       const int64_t n2 = n + blockDim.y;
@@ -315,11 +422,15 @@ __global__ void GammaBetaBackwardCUDAKernel(
       }
     }
   }
+
+  // Write accumulated tile to shared memory.
   g_shared[threadIdx.y][threadIdx.x] = dg_sum1;
   g_shared[threadIdx.y + blockDim.y][threadIdx.x] = dg_sum2;
   b_shared[threadIdx.y][threadIdx.x] = db_sum1;
   b_shared[threadIdx.y + blockDim.y][threadIdx.x] = db_sum2;
   __syncthreads();
+
+  // Do warp reduce for the 1st 16 cols in the tile.
   T_ACC sum1 = g_shared[threadIdx.x][threadIdx.y];
   T_ACC sum2 = b_shared[threadIdx.x][threadIdx.y];
   sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
@@ -335,6 +446,8 @@ __global__ void GammaBetaBackwardCUDAKernel(
       }
     }
   }
+
+  // Do warp reduce for the 2st 16 cols in the tile.
   sum1 = g_shared[threadIdx.x][threadIdx.y + blockDim.y];
   sum2 = b_shared[threadIdx.x][threadIdx.y + blockDim.y];
   sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
@@ -353,6 +466,78 @@ __global__ void GammaBetaBackwardCUDAKernel(
 }
 
 template <typename T>
+void GroupNorm1dForward(
+    const Tensor& X,
+    const Tensor& mean,
+    const Tensor& rstd,
+    const Tensor& gamma,
+    const Tensor& beta,
+    int64_t N,
+    int64_t C,
+    int64_t group,
+    Tensor& Y) {
+  using T_ACC = acc_type<T, true>;
+  const int64_t G = group;
+  const int64_t D = C / G;
+  if (gamma.defined() && beta.defined()) {
+    auto iter = TensorIteratorConfig()
+                    .resize_outputs(false)
+                    .add_output(Y.view({N, G, D}))
+                    .add_input(X.view({N, G, D}))
+                    .add_input(mean.view({N, G, 1}))
+                    .add_input(rstd.view({N, G, 1}))
+                    .add_input(gamma.view({1, G, D}))
+                    .add_input(beta.view({1, G, D}))
+                    .build();
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd, T gamma, T beta) -> T {
+      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+          static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma) +
+          static_cast<T_ACC>(beta);
+    });
+  } else if (gamma.defined()) {
+    auto iter = TensorIteratorConfig()
+                    .resize_outputs(false)
+                    .add_output(Y.view({N, G, D}))
+                    .add_input(X.view({N, G, D}))
+                    .add_input(mean.view({N, G, 1}))
+                    .add_input(rstd.view({N, G, 1}))
+                    .add_input(gamma.view({1, G, D}))
+                    .build();
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd, T gamma) -> T {
+      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+          static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
+    });
+  } else if (beta.defined()) {
+    auto iter = TensorIteratorConfig()
+                    .resize_outputs(false)
+                    .add_output(Y.view({N, G, D}))
+                    .add_input(X.view({N, G, D}))
+                    .add_input(mean.view({N, G, 1}))
+                    .add_input(rstd.view({N, G, 1}))
+                    .add_input(beta.view({1, G, D}))
+                    .build();
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd, T beta) -> T {
+      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+          static_cast<T_ACC>(rstd) +
+          static_cast<T_ACC>(beta);
+    });
+  } else {
+    auto iter = TensorIteratorConfig()
+                    .resize_outputs(false)
+                    .add_output(Y.view({N * G, D}))
+                    .add_input(X.view({N * G, D}))
+                    .add_input(mean.view({N * G, 1}))
+                    .add_input(rstd.view({N * G, 1}))
+                    .build();
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd) -> T {
+      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+          static_cast<T_ACC>(rstd);
+    });
+  }
+  AT_CUDA_CHECK(cudaGetLastError());
+}
+
+template <typename T>
 void GroupNormKernelImplInternal(
     const Tensor& X,
     const Tensor& gamma,
@@ -362,9 +547,9 @@ void GroupNormKernelImplInternal(
     int64_t HxW,
     int64_t group,
     T eps,
-    Tensor* Y,
-    Tensor* mean,
-    Tensor* rstd) {
+    Tensor& Y,
+    Tensor& mean,
+    Tensor& rstd) {
   using T_ACC = acc_type<T, true>;
   TORCH_CHECK(X.numel() == N * C * HxW);
   TORCH_CHECK(!gamma.defined() || gamma.numel() == C);
@@ -375,30 +560,61 @@ void GroupNormKernelImplInternal(
   const int64_t G = group;
   const int64_t D = C / G;
   const T* X_data = X.data_ptr<T>();
-  const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
-  const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
-  T* Y_data = Y->data_ptr<T>();
-  T* mean_data = mean->data_ptr<T>();
-  T* rstd_data = rstd->data_ptr<T>();
-  const auto kAccType = X.scalar_type() == kHalf ? kFloat : X.scalar_type();
-  Tensor a = at::empty({N, C}, X.options().dtype(kAccType));
-  Tensor b = at::empty({N, C}, X.options().dtype(kAccType));
-  T_ACC* a_data = a.data_ptr<T_ACC>();
-  T_ACC* b_data = b.data_ptr<T_ACC>();
+  T* Y_data = Y.data_ptr<T>();
+  T* mean_data = mean.data_ptr<T>();
+  T* rstd_data = rstd.data_ptr<T>();
+
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
-  RowwiseMomentsCUDAKernel<T>
-      <<<N * G, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
-          D * HxW, eps, X_data, mean_data, rstd_data);
-  int64_t B = (N * C + kCUDANumThreads - 1) / kCUDANumThreads;
-  ComputeFusedParamsCUDAKernel<T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
-      N, C, G, mean_data, rstd_data, gamma_data, beta_data, a_data, b_data);
-  if (HxW < kCUDANumThreads) {
-    B = (N * C * HxW + kCUDANumThreads - 1) / kCUDANumThreads;
-    GroupNormForwardSimpleCUDAKernel<T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
-        N, C, HxW, X_data, a_data, b_data, Y_data);
+  const int64_t num_threads = D * HxW < cuda_utils::kCUDABlockReduceNumThreads
+      ? C10_WARP_SIZE
+      : cuda_utils::kCUDABlockReduceNumThreads;
+  RowwiseMomentsCUDAKernel<T><<<N * G, num_threads, 0, cuda_stream>>>(
+      D * HxW, eps, X_data, mean_data, rstd_data);
+  AT_CUDA_CHECK(cudaGetLastError());
+
+  if (HxW == 1) {
+    GroupNorm1dForward<T>(X, mean, rstd, gamma, beta, N, C, G, Y);
+  } else if (!gamma.defined() && !beta.defined()) {
+    auto iter = TensorIteratorConfig()
+                    .resize_outputs(false)
+                    .add_output(Y.view({N * G, D * HxW}))
+                    .add_input(X.view({N * G, D * HxW}))
+                    .add_input(mean.view({N * G, 1}))
+                    .add_input(rstd.view({N * G, 1}))
+                    .build();
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T mean, T rstd) -> T {
+      return (static_cast<T_ACC>(x) - static_cast<T_ACC>(mean)) *
+          static_cast<T_ACC>(rstd);
+    });
   } else {
-    GroupNormForwardCUDAKernel<T><<<N * C, kCUDANumThreads, 0, cuda_stream>>>(
-        HxW, X_data, a_data, b_data, Y_data);
+    const auto kAccType =
+        (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
+        ? kFloat
+        : X.scalar_type();
+    Tensor a = at::empty({N, C}, X.options().dtype(kAccType));
+    Tensor b = at::empty({N, C}, X.options().dtype(kAccType));
+    const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
+    const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
+    T_ACC* a_data = a.data_ptr<T_ACC>();
+    T_ACC* b_data = b.data_ptr<T_ACC>();
+
+    // TODO: Since there is some issues in gpu_kernel_multiple_outputs, we are
+    // using maunal kernel here. Make it using gpu_kernel_multiple_outputs once
+    // the issue fixed.
+    const int64_t B = (N * C + kCUDANumThreads - 1) / kCUDANumThreads;
+    ComputeFusedParamsCUDAKernel<T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
+        N, C, G, mean_data, rstd_data, gamma_data, beta_data, a_data, b_data);
+    auto iter = TensorIteratorConfig()
+                    .check_all_same_dtype(std::is_same<T, T_ACC>::value)
+                    .resize_outputs(false)
+                    .add_output(Y.view({N * C, HxW}))
+                    .add_input(X.view({N * C, HxW}))
+                    .add_input(a.view({N * C, 1}))
+                    .add_input(b.view({N * C, 1}))
+                    .build();
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC a, T_ACC b) -> T {
+      return a * static_cast<T_ACC>(x) + b;
+    });
   }
   AT_CUDA_CHECK(cudaGetLastError());
 }
@@ -412,30 +628,152 @@ void GroupNormKernelImpl(
     int64_t HxW,
     int64_t group,
     double eps,
-    Tensor* Y,
-    Tensor* mean,
-    Tensor* rstd) {
+    Tensor& Y,
+    Tensor& mean,
+    Tensor& rstd) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
       X.scalar_type(),
       "GroupNormKernelImpl",
       [&]() {
-        AT_SKIP_BFLOAT16_IF_NOT_ROCM(scalar_t, "GroupNormKernelImpl", [&]() {
-          GroupNormKernelImplInternal<scalar_t>(
-              X,
-              gamma,
-              beta,
+        GroupNormKernelImplInternal<scalar_t>(
+            X,
+            gamma,
+            beta,
+            N,
+            C,
+            HxW,
+            group,
+            static_cast<scalar_t>(eps),
+            Y,
+            mean,
+            rstd);
+      });
+}
+
+template <typename T>
+void GroupNorm1dBackward(
+    const Tensor dY,
+    const Tensor X,
+    const Tensor mean,
+    const Tensor rstd,
+    const Tensor gamma,
+    int64_t N,
+    int64_t C,
+    int64_t group,
+    Tensor& dX,
+    Tensor& dgamma,
+    Tensor& dbeta) {
+  using T_ACC = acc_type<T, true>;
+  const int64_t G = group;
+  const int64_t D = C / G;
+  const T* dY_data = dY.data_ptr<T>();
+  const T* X_data = X.data_ptr<T>();
+  const T* mean_data = mean.data_ptr<T>();
+  const T* rstd_data = rstd.data_ptr<T>();
+
+  cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
+  if (dX.defined()) {
+    const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
+    const auto kAccType =
+        (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
+        ? kFloat
+        : X.scalar_type();
+    Tensor c2 = at::empty({N, G}, X.options().dtype(kAccType));
+    Tensor c3 = at::empty({N, G}, X.options().dtype(kAccType));
+    T_ACC* c2_data = c2.data_ptr<T_ACC>();
+    T_ACC* c3_data = c3.data_ptr<T_ACC>();
+    const int64_t num_threads = (C / G) < cuda_utils::kCUDABlockReduceNumThreads
+        ? C10_WARP_SIZE
+        : cuda_utils::kCUDABlockReduceNumThreads;
+    Compute1dBackwardFusedParamsCUDAKernel<T>
+        <<<dim3(N, G), num_threads, 0, cuda_stream>>>(
+            C,
+            G,
+            dY_data,
+            X_data,
+            mean_data,
+            rstd_data,
+            gamma_data,
+            c2_data,
+            c3_data);
+
+    if (gamma.defined()) {
+      auto iter = TensorIteratorConfig()
+                      .check_all_same_dtype(std::is_same<T, T_ACC>::value)
+                      .resize_outputs(false)
+                      .add_output(dX.view({N, G, D}))
+                      .add_input(dY.view({N, G, D}))
+                      .add_input(X.view({N, G, D}))
+                      .add_input(rstd.view({N, G, 1}))
+                      .add_input(gamma.view({1, G, D}))
+                      .add_input(c2.view({N, G, 1}))
+                      .add_input(c3.view({N, G, 1}))
+                      .build();
+      gpu_kernel(
+          iter,
+          [] GPU_LAMBDA(T dy, T x, T rstd, T gamma, T_ACC c2, T_ACC c3) -> T {
+            const T_ACC c1 =
+                static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
+            return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
+                c3;
+          });
+    } else {
+      auto iter = TensorIteratorConfig()
+                      .check_all_same_dtype(std::is_same<T, T_ACC>::value)
+                      .resize_outputs(false)
+                      .add_output(dX.view({N * G, D}))
+                      .add_input(dY.view({N * G, D}))
+                      .add_input(X.view({N * G, D}))
+                      .add_input(rstd.view({N * G, 1}))
+                      .add_input(c2.view({N * G, 1}))
+                      .add_input(c3.view({N * G, 1}))
+                      .build();
+      gpu_kernel(
+          iter, [] GPU_LAMBDA(T dy, T x, T rstd, T_ACC c2, T_ACC c3) -> T {
+            const T_ACC c1 = static_cast<T_ACC>(rstd);
+            return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
+                c3;
+          });
+    }
+  }
+  if (dgamma.defined() || dbeta.defined()) {
+    T* dgamma_data = dgamma.defined() ? dgamma.data_ptr<T>() : nullptr;
+    T* dbeta_data = dbeta.defined() ? dbeta.data_ptr<T>() : nullptr;
+    if (N <= 128) {
+      const int64_t B = (C + kCUDANumThreads - 1) / kCUDANumThreads;
+      GammaBeta1dBackwardCUDAKernel1<T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
+          N,
+          C,
+          G,
+          dY_data,
+          X_data,
+          mean_data,
+          rstd_data,
+          dgamma_data,
+          dbeta_data);
+    } else {
+      const int64_t B = (C + kReduceTileSize - 1) / kReduceTileSize;
+      // The algorithm for colwise reduction here is to accumulate each 32 cols
+      // to a 32 * 32 tile and write the tile to shared memmory. Then do warp
+      // reduce for each col in the tile. So here the blockDim must be (32, 16).
+      constexpr int kThreadX = kReduceTileSize;
+      constexpr int kThreadY = kReduceTileSize / 2;
+      GammaBeta1dBackwardCUDAKernel2<T>
+          <<<B, dim3(kThreadX, kThreadY), 0, cuda_stream>>>(
               N,
               C,
-              HxW,
-              group,
-              static_cast<scalar_t>(eps),
-              Y,
-              mean,
-              rstd);
-        });
-      });
+              G,
+              dY_data,
+              X_data,
+              mean_data,
+              rstd_data,
+              dgamma_data,
+              dbeta_data);
+    }
+    AT_CUDA_CHECK(cudaGetLastError());
+  }
 }
 
 template <typename T>
@@ -449,11 +787,12 @@ void GroupNormBackwardKernelImplInternal(
     int64_t C,
     int64_t HxW,
     int64_t group,
-    Tensor* dX,
-    Tensor* dgamma,
-    Tensor* dbeta) {
+    Tensor& dX,
+    Tensor& dgamma,
+    Tensor& dbeta) {
   using T_ACC = acc_type<T, true>;
   const int64_t G = group;
+  const int64_t D = C / G;
   TORCH_CHECK(dY.numel() == N * C * HxW);
   TORCH_CHECK(X.numel() == N * C * HxW);
   TORCH_CHECK(mean.numel() == N * G);
@@ -462,15 +801,11 @@ void GroupNormBackwardKernelImplInternal(
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
 
   if (N == 0) {
-    if (dgamma->defined()) {
-      T* dgamma_data = dgamma->data_ptr<T>();
-      AT_CUDA_CHECK(cudaMemsetAsync(
-          dgamma_data, 0, dgamma->numel() * sizeof(T), cuda_stream));
+    if (dgamma.defined()) {
+      dgamma.fill_(T(0));
     }
-    if (dbeta->defined()) {
-      T* dbeta_data = dbeta->data_ptr<T>();
-      AT_CUDA_CHECK(cudaMemsetAsync(
-          dbeta_data, 0, dbeta->numel() * sizeof(T), cuda_stream));
+    if (dbeta.defined()) {
+      dbeta.fill_(T(0));
     }
     return;
   }
@@ -480,31 +815,52 @@ void GroupNormBackwardKernelImplInternal(
   const T* mean_data = mean.data_ptr<T>();
   const T* rstd_data = rstd.data_ptr<T>();
   const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
-  T* dX_data = dX->defined() ? dX->data_ptr<T>() : nullptr;
-  const auto kAccType = X.scalar_type() == kHalf ? kFloat : X.scalar_type();
+  const auto kAccType =
+      (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
+      ? kFloat
+      : X.scalar_type();
   Tensor ds = at::empty({N, C}, X.options().dtype(kAccType));
   Tensor db = at::empty({N, C}, X.options().dtype(kAccType));
   T_ACC* ds_data = ds.data_ptr<T_ACC>();
   T_ACC* db_data = db.data_ptr<T_ACC>();
-  ComputeInternalGradientsCUDAKernel<T>
-      <<<N * C, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
-          HxW, dY_data, X_data, ds_data, db_data);
-  if (dX_data != nullptr) {
-    Tensor c1 = at::empty({N, C}, X.options().dtype(kAccType));
+
+  if (HxW == 1) {
+    GroupNorm1dBackward<T>(
+        dY, X, mean, rstd, gamma, N, C, G, dX, dgamma, dbeta);
+    return;
+  }
+
+  int64_t num_threads = HxW < cuda_utils::kCUDABlockReduceNumThreads
+      ? C10_WARP_SIZE
+      : cuda_utils::kCUDABlockReduceNumThreads;
+  ComputeInternalGradientsCUDAKernel<T><<<N * C, num_threads, 0, cuda_stream>>>(
+      HxW, dY_data, X_data, ds_data, db_data);
+  AT_CUDA_CHECK(cudaGetLastError());
+
+  if (dX.defined()) {
+    Tensor c1 = at::empty({0}, X.options().dtype(kAccType));
     Tensor c2 = at::empty({N, G}, X.options().dtype(kAccType));
     Tensor c3 = at::empty({N, G}, X.options().dtype(kAccType));
-    T_ACC* c1_data = c1.data_ptr<T_ACC>();
     T_ACC* c2_data = c2.data_ptr<T_ACC>();
     T_ACC* c3_data = c3.data_ptr<T_ACC>();
-    int64_t B = (N * C + kCUDANumThreads - 1) / kCUDANumThreads;
-    ComputeGradOutputCoeffientCUDAKernel<T>
-        <<<B, kCUDANumThreads, 0, cuda_stream>>>(
-            N, C, G, rstd_data, gamma_data, c1_data);
+
+    if (gamma.defined()) {
+      auto iter = TensorIteratorConfig()
+                      .check_all_same_dtype(std::is_same<T, T_ACC>::value)
+                      .add_output(c1)
+                      .add_input(rstd.view({N, G, 1}))
+                      .add_input(gamma.view({1, G, D}))
+                      .build();
+      gpu_kernel(iter, [] GPU_LAMBDA(T rstd, T gamma) -> T_ACC {
+        return static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
+      });
+    }
+
+    num_threads = (C / G) < cuda_utils::kCUDABlockReduceNumThreads
+        ? C10_WARP_SIZE
+        : cuda_utils::kCUDABlockReduceNumThreads;
     ComputeBackwardFusedParamsCUDAKernel<T>
-        <<<dim3(N, G),
-           cuda_utils::kCUDABlockReduceNumThreads,
-           0,
-           cuda_stream>>>(
+        <<<dim3(N, G), num_threads, 0, cuda_stream>>>(
             C,
             HxW,
             G,
@@ -515,40 +871,66 @@ void GroupNormBackwardKernelImplInternal(
             db_data,
             c2_data,
             c3_data);
-    if (HxW < kCUDANumThreads) {
-      B = (N * C * HxW + kCUDANumThreads - 1) / kCUDANumThreads;
-      GroupNormBackwardSimpleCUDAKernel<
-          T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
-          N, C, HxW, G, dY_data, X_data, c1_data, c2_data, c3_data, dX_data);
+
+    if (gamma.defined()) {
+      auto iter = TensorIteratorConfig()
+                      .check_all_same_dtype(std::is_same<T, T_ACC>::value)
+                      .resize_outputs(false)
+                      .add_output(dX.view({N * G, D, HxW}))
+                      .add_input(dY.view({N * G, D, HxW}))
+                      .add_input(X.view({N * G, D, HxW}))
+                      .add_input(c1.view({N * G, D, 1}))
+                      .add_input(c2.view({N * G, 1, 1}))
+                      .add_input(c3.view({N * G, 1, 1}))
+                      .build();
+      gpu_kernel(
+          iter, [] GPU_LAMBDA(T dy, T x, T_ACC c1, T_ACC c2, T_ACC c3) -> T {
+            return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
+                c3;
+          });
     } else {
-      GroupNormBackwardCUDAKernel<T>
-          <<<N * C, kCUDANumThreads, 0, cuda_stream>>>(
-              C, HxW, G, dY_data, X_data, c1_data, c2_data, c3_data, dX_data);
+      auto iter = TensorIteratorConfig()
+                      .check_all_same_dtype(std::is_same<T, T_ACC>::value)
+                      .resize_outputs(false)
+                      .add_output(dX.view({N * G, D * HxW}))
+                      .add_input(dY.view({N * G, D * HxW}))
+                      .add_input(X.view({N * G, D * HxW}))
+                      .add_input(rstd.view({N * G, 1}))
+                      .add_input(c2.view({N * G, 1}))
+                      .add_input(c3.view({N * G, 1}))
+                      .build();
+      gpu_kernel(
+          iter, [] GPU_LAMBDA(T dy, T x, T_ACC c1, T_ACC c2, T_ACC c3) -> T {
+            return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
+                c3;
+          });
     }
     AT_CUDA_CHECK(cudaGetLastError());
   }
-  if (dgamma->defined() || dbeta->defined()) {
-    T* dgamma_data = dgamma->defined() ? dgamma->data_ptr<T>() : nullptr;
-    T* dbeta_data = dbeta->defined() ? dbeta->data_ptr<T>() : nullptr;
-    if (N < 512) {
+  if (dgamma.defined() || dbeta.defined()) {
+    T* dgamma_data = dgamma.defined() ? dgamma.data_ptr<T>() : nullptr;
+    T* dbeta_data = dbeta.defined() ? dbeta.data_ptr<T>() : nullptr;
+    if (N <= 128) {
       // For small batch size, do colwise reduce directly.
       const int64_t B = (C + kCUDANumThreads - 1) / kCUDANumThreads;
-      GammaBetaBackwardSimpleCUDAKernel<T>
-          <<<B, kCUDANumThreads, 0, cuda_stream>>>(
-              N,
-              C,
-              G,
-              mean_data,
-              rstd_data,
-              ds_data,
-              db_data,
-              dgamma_data,
-              dbeta_data);
+      GammaBetaBackwardCUDAKernel1<T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
+          N,
+          C,
+          G,
+          mean_data,
+          rstd_data,
+          ds_data,
+          db_data,
+          dgamma_data,
+          dbeta_data);
     } else {
       const int64_t B = (C + kReduceTileSize - 1) / kReduceTileSize;
+      // The algorithm for colwise reduction here is to accumulate each 32 cols
+      // to a 32 * 32 tile and write the tile to shared memmory. Then do warp
+      // reduce for each col in the tile. So here the blockDim must be (32, 16).
       constexpr int kThreadX = kReduceTileSize;
       constexpr int kThreadY = kReduceTileSize / 2;
-      GammaBetaBackwardCUDAKernel<T>
+      GammaBetaBackwardCUDAKernel2<T>
           <<<B, dim3(kThreadX, kThreadY), 0, cuda_stream>>>(
               N,
               C,
@@ -560,8 +942,8 @@ void GroupNormBackwardKernelImplInternal(
               dgamma_data,
               dbeta_data);
     }
+    AT_CUDA_CHECK(cudaGetLastError());
   }
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 void GroupNormBackwardKernelImpl(
@@ -574,31 +956,17 @@ void GroupNormBackwardKernelImpl(
     int64_t C,
     int64_t HxW,
     int64_t group,
-    Tensor* dX,
-    Tensor* dgamma,
-    Tensor* dbeta) {
+    Tensor& dX,
+    Tensor& dgamma,
+    Tensor& dbeta) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
       X.scalar_type(),
       "GroupNormBackwardKernelImpl",
       [&]() {
-        AT_SKIP_BFLOAT16_IF_NOT_ROCM(
-            scalar_t, "GroupNormBackwardKernelImpl", [&]() {
-              GroupNormBackwardKernelImplInternal<scalar_t>(
-                  dY,
-                  X,
-                  mean,
-                  rstd,
-                  gamma,
-                  N,
-                  C,
-                  HxW,
-                  group,
-                  dX,
-                  dgamma,
-                  dbeta);
-            });
+        GroupNormBackwardKernelImplInternal<scalar_t>(
+            dY, X, mean, rstd, gamma, N, C, HxW, group, dX, dgamma, dbeta);
       });
 }
 

--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -29,18 +29,7 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm(
   Tensor mean = at::empty({N, group}, X.options());
   Tensor rstd = at::empty({N, group}, X.options());
   GroupNormKernel(
-      X.device().type(),
-      X,
-      gamma,
-      beta,
-      N,
-      C,
-      HxW,
-      group,
-      eps,
-      &Y,
-      &mean,
-      &rstd);
+      X.device().type(), X, gamma, beta, N, C, HxW, group, eps, Y, mean, rstd);
   return std::make_tuple(Y, mean, rstd);
 }
 
@@ -78,9 +67,9 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm_backward(
       C,
       HxW,
       group,
-      &dX,
-      &dgamma,
-      &dbeta);
+      dX,
+      dgamma,
+      dbeta);
   return std::make_tuple(dX, dgamma, dbeta);
 }
 
@@ -123,9 +112,12 @@ Tensor group_norm(
       1LL,
       std::multiplies<int64_t>());
 
+  const Tensor kEmpty;
   const auto& X = input.is_contiguous() ? input : input.contiguous();
-  const auto& gamma = weight.is_contiguous() ? weight : weight.contiguous();
-  const auto& beta = bias.is_contiguous() ? bias : bias.contiguous();
+  const auto& gamma = weight.defined() ? weight.contiguous() : kEmpty;
+  const auto& beta = bias.defined() ? bias.contiguous() : kEmpty;
+  TORCH_CHECK(!gamma.defined() || gamma.numel() == C);
+  TORCH_CHECK(!beta.defined() || beta.numel() == C);
   return std::get<0>(
       at::native_group_norm(X, gamma, beta, N, C, HxW, num_groups, eps));
 }
@@ -134,20 +126,32 @@ DEFINE_DISPATCH(GroupNormKernel);
 DEFINE_DISPATCH(GroupNormBackwardKernel);
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> math_group_norm(
-    const at::Tensor& input, const at::Tensor& weight,
-    const at::Tensor& bias, int64_t N, int64_t C, int64_t HxW,
-    int64_t group, double eps) {
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const at::Tensor& bias,
+    int64_t N,
+    int64_t C,
+    int64_t HxW,
+    int64_t group,
+    double eps) {
   auto input_shape = input.sizes();
   at::Tensor input_reshaped = input.view({1, N * group, N ? -1 : 1});
   auto outputs = at::native_batch_norm(
-      input_reshaped, /*weight=*/{}, /*bias=*/{}, /*running_mean=*/{},
-      /*running_var=*/{}, /*training=*/true, /*momentum=*/0, eps);
+      input_reshaped,
+      /*weight=*/{},
+      /*bias=*/{},
+      /*running_mean=*/{},
+      /*running_var=*/{},
+      /*training=*/true,
+      /*momentum=*/0,
+      eps);
   at::Tensor out = std::get<0>(outputs);
   out = out.view(input_shape);
   std::vector<int64_t> affine_param_shape(input.dim(), 1);
   affine_param_shape[1] = C;
   if (weight.defined() && bias.defined()) {
-    out = bias.view(affine_param_shape).addcmul(out, weight.view(affine_param_shape), 1);
+    out = bias.view(affine_param_shape)
+              .addcmul(out, weight.view(affine_param_shape), 1);
   } else if (weight.defined()) {
     out = out.mul(weight.view(affine_param_shape));
   } else if (bias.defined()) {

--- a/aten/src/ATen/native/group_norm.h
+++ b/aten/src/ATen/native/group_norm.h
@@ -15,9 +15,9 @@ using forward_fn = void (*)(
     int64_t /* HxW */,
     int64_t /* group */,
     double /* eps */,
-    Tensor* /* Y */,
-    Tensor* /* mean */,
-    Tensor* /* rstd */);
+    Tensor& /* Y */,
+    Tensor& /* mean */,
+    Tensor& /* rstd */);
 
 using backward_fn = void (*)(
     const Tensor& /* dY */,
@@ -29,9 +29,9 @@ using backward_fn = void (*)(
     int64_t /* C */,
     int64_t /* HxW */,
     int64_t /* group */,
-    Tensor* /* dX */,
-    Tensor* /* dgamma */,
-    Tensor* /* dbeta */);
+    Tensor& /* dX */,
+    Tensor& /* dgamma */,
+    Tensor& /* dbeta */);
 
 DECLARE_DISPATCH(forward_fn, GroupNormKernel);
 DECLARE_DISPATCH(backward_fn, GroupNormBackwardKernel);

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -1580,7 +1580,29 @@ new_module_tests = [
         input_size=(4, 6, 5),
         cudnn=True,
         check_eval=True,
+        check_bfloat16=True,
         desc='1d_affine',
+    ),
+    dict(
+        module_name='GroupNorm',
+        constructor_args=(3, 12, 1e-3),
+        cpp_constructor_args='torch::nn::GroupNormOptions(3, 12).eps(1e-3)',
+        input_size=(4, 12),
+        cudnn=True,
+        check_eval=True,
+        check_bfloat16=True,
+        desc='1d_affine_GN',
+    ),
+    dict(
+        module_name='GroupNorm',
+        constructor_args=(1, 6, 1e-3),
+        cpp_constructor_args='torch::nn::GroupNormOptions(1, 6).eps(1e-3)',
+        input_size=(150, 6),
+        cudnn=True,
+        check_eval=True,
+        desc='1d_affine_large_batch',  # For large batch_size
+        check_bfloat16=True,
+        test_cpu=False,
     ),
     dict(
         module_name='GroupNorm',
@@ -1589,15 +1611,17 @@ new_module_tests = [
         input_size=(4, 5, 5),
         cudnn=True,
         check_eval=True,
+        check_bfloat16=True,
         desc='1d_no_affine_IN',  # this setting is equivalent with InstanceNormi
     ),
     dict(
         module_name='GroupNorm',
-        constructor_args=(1, 5, 1e-3, False),
-        cpp_constructor_args='torch::nn::GroupNormOptions(1, 5).eps(1e-3).affine(false)',
-        input_size=(4, 5, 5),
+        constructor_args=(1, 10, 1e-3, False),
+        cpp_constructor_args='torch::nn::GroupNormOptions(1, 10).eps(1e-3).affine(false)',
+        input_size=(4, 10),
         cudnn=True,
         check_eval=True,
+        check_bfloat16=True,
         desc='1d_no_affine_LN',  # this setting is equivalent with LayerNorm
     ),
     dict(
@@ -1607,7 +1631,19 @@ new_module_tests = [
         input_size=(4, 6, 2, 3),
         cudnn=True,
         check_eval=True,
+        check_bfloat16=True,
         desc='2d_affine',
+    ),
+    dict(
+        module_name='GroupNorm',
+        constructor_args=(3, 6, 1e-3),
+        cpp_constructor_args='torch::nn::GroupNormOptions(3, 6).eps(1e-3)',
+        input_size=(4, 6, 28, 28),
+        cudnn=True,
+        check_eval=True,
+        check_bfloat16=True,
+        desc='2d_affine_large_feature',
+        test_cpu=False,
     ),
     dict(
         module_name='GroupNorm',
@@ -1616,6 +1652,7 @@ new_module_tests = [
         input_size=(4, 3, 2, 3),
         cudnn=True,
         check_eval=True,
+        check_bfloat16=True,
         desc='2d_no_affine_IN',  # this setting is equivalent with InstanceNorm
     ),
     dict(
@@ -1625,6 +1662,7 @@ new_module_tests = [
         input_size=(4, 3, 2, 3),
         cudnn=True,
         check_eval=True,
+        check_bfloat16=True,
         desc='2d_no_affine_LN',  # this setting is equivalent with LayerNorm
     ),
     dict(


### PR DESCRIPTION
Summary: Fix perfornance issue of GroupNorm on CUDA when feature map is small.

Test Plan: buck test mode/dev-nosan //caffe2/test:nn -- "GroupNorm"

Differential Revision: D24242738

As mentioned in https://github.com/pytorch/pytorch/issues/46086, the current GroupNorm implementation performs bad on CUDA when the feature map is small even compared to the impl via BatchNorm before PyTorch 1.5.1. This PR fixed the performance issue when the feature map is small.

Benchmark script:

```
import torch
import torch.nn.functional as F

from timeit import Timer

norm = torch.nn.GroupNorm(8, 512).cuda()

num = 5000

sizes = [(1024, 512, 14, 14), (1024, 512, 7, 7), (1024, 512)]


def forward(x):
    _ = norm(x)
    torch.cuda.synchronize()


def backward(y, grad):
    y.backward(grad, retain_graph=True)
    torch.cuda.synchronize()


if __name__ == "__main__":
    # warm up
    x = torch.rand(*(sizes[0]), dtype=torch.float,
                   device="cuda", requires_grad=True)
    for _ in range(100):
        forward(x)

    for size in sizes:
        x = torch.rand(*size, dtype=torch.float,
                       device="cuda", requires_grad=True)
        t = Timer("forward(x)", "from __main__ import forward, x")
        print(f"size = {size}:")
        t1 = t.timeit(num) / num * 1e6
        print(f"avg_forward_time =  {t1}us")

        y = norm(x)
        grad = torch.randn_like(y)
        t = Timer("backward(y, grad)", "from __main__ import backward, y, grad")
        t2 = t.timeit(num) / num * 1e6
        print(f"avg_backward_time = {t2}us")
```

Benchmark result after this PR on a V100 devgpu:
```
size = (1024, 512, 14, 14):
avg_forward_time =  1635.6191572034732us
avg_backward_time = 4140.7730475999415us
size = (1024, 512, 7, 7):
avg_forward_time =  463.6513736099005us
avg_backward_time = 1641.7451039887965us
size = (1024, 512):
avg_forward_time =  66.59087920561433us
avg_backward_time = 128.6882139975205us
```

Benchmark result before this PR on a V100 devgpu:
```
size = (1024, 512, 14, 14):
avg_forward_time =  1636.729855206795us
avg_backward_time = 5488.682465581223us
size = (1024, 512, 7, 7):
avg_forward_time =  465.88476160541177us
avg_backward_time = 3129.9425506033003us
size = (1024, 512):
avg_forward_time =  96.90486900508404us
avg_backward_time = 2319.4099438143894us
```

Run this benchmark script on PyTorch 1.5.1 (the build options may be different, just for reference):
```
size = (1024, 512, 14, 14):
avg_forward_time =  2728.9786524139345us
avg_backward_time = 9711.360842408612us
size = (1024, 512, 7, 7):
avg_forward_time =  773.7861637957394us
avg_backward_time = 2496.8661199789494us
size = (1024, 512):
avg_forward_time =  173.00677900202572us
avg_backward_time = 188.9778567943722us

```