### PR TITLE
Suggest autograd.no_grad in nn.Module.{train,eval} (and vice versa)

### DIFF
--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -62,6 +62,8 @@ class no_grad(_DecoratorContextManager):
 
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
 
+    Additionally, consider using :meth:`~torch.nn.eval` when evaluating a model.
+
 
     Example::
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1265,6 +1265,8 @@ class Module:
         mode, if they are affected, e.g. :class:`Dropout`, :class:`BatchNorm`,
         etc.
 
+        Additionally, consider using :class:`~no_grad` when evaluating a model.
+
         Args:
             mode (bool): whether to set training mode (``True``) or evaluation
                          mode (``False``). Default: ``True``.
@@ -1286,6 +1288,8 @@ class Module:
         etc.
 
         This is equivalent with :meth:`self.train(False) <torch.nn.Module.train>`.
+
+        Additionally, consider using :class:`~no_grad` when evaluating a model.
 
         Returns:
             Module: self


### PR DESCRIPTION
Fixes #19160: "Suggest model.eval() in torch.no_grad (and vice versa)"