### PR TITLE
trying to make pow work for tensor raised to the power of a scalar

### DIFF
--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -11,7 +11,7 @@ DEFINE_DISPATCH(pow_tensor_tensor_stub);
 DEFINE_DISPATCH(pow_tensor_scalar_stub);
 
 Tensor& pow_out(Tensor& result, const Tensor& base, const Tensor& exp) {
-  if (exp.dim() == 0) {
+  if (exp.dim() == 0 && base.dim() != 0) {
     return native::pow_out(result, base, exp.item());
   }
   auto iter = TensorIterator::binary_op(result, base, exp);

--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -62,6 +62,9 @@ Tensor& pow_(Tensor& base, Scalar alpha) {
 }
 
 Tensor pow(const Tensor& base, const Tensor& exp) {
+  if (exp.dim() == 0) {
+    return native::pow(base, exp.item());
+  }
   auto dtype = at::result_type(base, exp);
   Tensor result = at::empty({0}, base.options().dtype(dtype));
   return native::pow_out(result, base, exp);

--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -11,6 +11,9 @@ DEFINE_DISPATCH(pow_tensor_tensor_stub);
 DEFINE_DISPATCH(pow_tensor_scalar_stub);
 
 Tensor& pow_out(Tensor& result, const Tensor& base, const Tensor& exp) {
+  if (exp.dim() == 0) {
+    return native::pow_out(result, base, exp.item());
+  }
   auto iter = TensorIterator::binary_op(result, base, exp);
   pow_tensor_tensor_stub(iter.device_type(), iter);
   return result;
@@ -62,9 +65,6 @@ Tensor& pow_(Tensor& base, Scalar alpha) {
 }
 
 Tensor pow(const Tensor& base, const Tensor& exp) {
-  if (exp.dim() == 0) {
-    return native::pow(base, exp.item());
-  }
   auto dtype = at::result_type(base, exp);
   Tensor result = at::empty({0}, base.options().dtype(dtype));
   return native::pow_out(result, base, exp);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1101,7 +1101,7 @@ class AbstractTestCases:
         def test_topk_arguments(self):
             q = torch.randn(10, 2, 10)
             # Make sure True isn't mistakenly taken as the 2nd dimension (interpreted as 1)
-            self.assertRaises(TypeError, lambda: q.topk(4, True))        
+            self.assertRaises(TypeError, lambda: q.topk(4, True))
 
         def test_mode(self):
             x = torch.arange(1., SIZE * SIZE + 1).clone().resize_(SIZE, SIZE)
@@ -6376,7 +6376,7 @@ class TestTorchDeviceType(TestCase):
     # Tests clamp and its alias, clip
     @dtypes(torch.int64, torch.float32)
     def test_clamp(self, device, dtype):
-        op_list = (torch.clamp, torch.Tensor.clamp, torch.Tensor.clamp_, 
+        op_list = (torch.clamp, torch.Tensor.clamp, torch.Tensor.clamp_,
                    torch.clip, torch.Tensor.clip, torch.Tensor.clip_)
 
         # min/max argument product
@@ -6404,7 +6404,7 @@ class TestTorchDeviceType(TestCase):
                     self.assertEqual(Y_expected, Y_out)
 
     def test_clamp_propagates_nans(self, device):
-        op_list = (torch.clamp, torch.Tensor.clamp, torch.Tensor.clamp_, 
+        op_list = (torch.clamp, torch.Tensor.clamp, torch.Tensor.clamp_,
                    torch.clip, torch.Tensor.clip, torch.Tensor.clip_)
 
         # min/max argument product
@@ -6415,9 +6415,9 @@ class TestTorchDeviceType(TestCase):
                 if min_val is None and max_val is None:
                     continue
 
-                X, Y_expected = self.generate_clamp_baseline(device, torch.float, 
-                                                             min_vals=min_val, 
-                                                             max_vals=max_val, 
+                X, Y_expected = self.generate_clamp_baseline(device, torch.float,
+                                                             min_vals=min_val,
+                                                             max_vals=max_val,
                                                              with_nans=True)
                 Y_expected = torch.isnan(Y_expected)
 
@@ -13789,6 +13789,14 @@ class TestTorchDeviceType(TestCase):
         tensor = torch.tensor(floats, dtype=torch.float32, device=device)
         for base in floats:
             self._test_pow(base, tensor)
+
+    @onlyCUDA
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_cuda_tensor_pow_scalar_tensor(self, device):
+        cuda_tensor = torch.randn((3, 3), device='cuda')
+        scalars_tensors = [torch.tensor(5), torch.tensor(4.2), torch.tensor(-0.5)]
+        for exp in scalars_tensors:
+            self._test_pow(cuda_tensor, exp)
 
     @onlyOnCPUAndCUDA
     @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13793,9 +13793,9 @@ class TestTorchDeviceType(TestCase):
     @onlyCUDA
     @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
     def test_cuda_tensor_pow_scalar_tensor(self, device):
-        cuda_tensor = torch.randn((3, 3), device='cuda')
-        scalars_tensors = [torch.tensor(5), torch.tensor(4.2), torch.tensor(-0.5)]
-        for exp in scalars_tensors:
+        cuda_tensor = torch.randn((3, 3), device=device)
+        scalar_tensors = [torch.tensor(5), torch.tensor(-3), torch.tensor(1)]
+        for exp in scalar_tensors:
             self._test_pow(cuda_tensor, exp)
 
     @onlyOnCPUAndCUDA


### PR DESCRIPTION
Fixes #46037

I'm not sure this is the most performant solution, but this works:

torch.pow(cuda_tensor, 5) should work and worked before.
torch.pow(cuda_tensor, torch.tensor(5)), should work **and works now!**
torch.pow(cuda_tensor, torch.tensor((5,))), should NOT work and complain the tensors are on different devices and indeed continues to complain.
