### PR TITLE
including tensorexpr tests in CI for all configs

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -206,8 +206,7 @@ JIT_EXECUTOR_TESTS = [
     'test_jit_profiling',
     'test_jit_legacy',
     'test_jit_fuser_legacy',
-    'test_jit_fuser_te',
-    'test_tensorexpr']
+]
 
 def print_to_stderr(message):
     print(message, file=sys.stderr)


### PR DESCRIPTION
Removed test_tensorexpr from the JIT-EXECUTOR exclude list.

CI will now run those tests.
