### PR TITLE
Fixed usage of std::move function

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/container/parameterlist.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/parameterlist.h
@@ -57,7 +57,7 @@ class ParameterListImpl : public Cloneable<ParameterListImpl> {
   void append(const torch::Tensor& param) {
     bool requires_grad = param.requires_grad();
     register_parameter(
-        c10::to_string(parameters_.size()), std::move(param), requires_grad);
+        c10::to_string(parameters_.size()), param, requires_grad);
   }
 
   /// push the a given parameter at the end of the list

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -107,7 +107,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   explicit SequentialImpl(torch::OrderedDict<std::string, AnyModule>&& ordered_dict) {
     modules_.reserve(ordered_dict.size());
     for (auto& item : ordered_dict) {
-      push_back(std::move(item.key()), std::move(item.value()));
+      push_back(item.key(), std::move(item.value()));
     }
   }
 


### PR DESCRIPTION
Removed std::move in situations when move wasn't really possible (therefore std::move didn't move anything but created copy instead).