### PR TITLE
[vulkan] Remove vulkan v2 api ATen/native/vulkan/api/*.cpp from compi…

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -64,7 +64,7 @@ file(GLOB native_cpp "native/*.cpp")
 file(GLOB native_mkl_cpp "native/mkl/*.cpp")
 file(GLOB native_mkldnn_cpp "native/mkldnn/*.cpp")
 file(GLOB vulkan_cpp "vulkan/*.cpp")
-file(GLOB native_vulkan_cpp "native/vulkan/api/*.cpp" "native/vulkan/*.cpp")
+file(GLOB native_vulkan_cpp "native/vulkan/*.cpp")
 file(GLOB native_sparse_cpp "native/sparse/*.cpp")
 file(GLOB native_quantized_cpp
             "native/quantized/*.cpp"


### PR DESCRIPTION
ATen/native/vulkan/api/*.cpp contains the next iteration of PyTorch Vulkan API

Which is not used by current Vulkan API

Building with USE_VULKAN with included those *.cpp files results in warning-errors, depends on cmake version to use

As we do not need this *.cpp for this build - we can exclude them from binary and have smaller size

