### PR TITLE
Model parameters passed as argument in freezing

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1035,9 +1035,7 @@ class TestFreezing(JitTestCase):
         model = torch.jit.script(Net())
         model.train()
 
-        with self.assertRaisesRegex(RuntimeError, 'Freezing module in training mode is not yet supported'):
-            mTrain_freezed = torch._C._freeze_module(model._c)
-
+        mTrain_freezed = torch._C._freeze_module(model._c)
         model.eval()
         mEval_freezed = torch._C._freeze_module(model._c)
         self.assertFalse(mEval_freezed.hasattr('conv1'))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46211 Model parameters passed as argument in freezing**

This patch passes model parameters as parameters to forward (and other
frozen methods). These parameters are set with the attribute values as
the default argument values.

This patch also enables freezing models set training mode.

Differential Revision: [D24261982](https://our.internmc.facebook.com/intern/diff/D24261982)