### PR TITLE
qnnpack quantized activations: fix memory format issues

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
@@ -43,9 +43,10 @@ Tensor qnnpack_hardsigmoid(Tensor input) {
                         "failed to create QNNPACK Hardsigmoid operator");
   Tensor qy = at::_empty_affine_quantized(
     input_contig.sizes(),
-    input_contig.options(),
+    at::device(kCPU).dtype(input_contig.dtype()),
     o_scale,
-    o_zero_point);
+    o_zero_point,
+    input_contig.suggest_memory_format());
 
   const pytorch_qnnp_status setupStatus = pytorch_qnnp_setup_hardsigmoid_nc_q8(
     hardsigmoid_op,

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -52,9 +52,10 @@ Tensor qnnpack_sigmoid(Tensor input) {
                         "failed to create QNNPACK sigmoid operator");
   qy = at::_empty_affine_quantized(
     input_contig.sizes(),
-    input.options(),
+    at::device(kCPU).dtype(input_contig.dtype()),
     output_scale,
-    output_zero_point);
+    output_zero_point,
+    input_contig.suggest_memory_format());
 
   const pytorch_qnnp_status setupStatus = pytorch_qnnp_setup_sigmoid_nc_q8(
     sigmoid_op,

--- a/aten/src/ATen/native/quantized/cpu/qtanh.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qtanh.cpp
@@ -50,9 +50,10 @@ Tensor qnnpack_tanh(Tensor input) {
                         "failed to create QNNPACK TanH operator");
   qy = at::_empty_affine_quantized(
     input_contig.sizes(),
-    input.options(),
+    at::device(kCPU).dtype(input_contig.dtype()),
     output_scale,
-    output_zero_point);
+    output_zero_point,
+    input_contig.suggest_memory_format());
 
   const pytorch_qnnp_status setupStatus = pytorch_qnnp_setup_tanh_nc_q8(
     tanh_op,

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -1,5 +1,6 @@
 from builtins import round
 
+import copy
 import itertools
 import numpy as np
 import sys
@@ -162,44 +163,57 @@ class TestQuantizedOps(TestCase):
         for op_group in test_configs:
             ref_op = op_group['reference_fn']
             for q_op in op_group['quantized_fn']:
-                # Quantizes and dequantizes to account for max error.
-                qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                               dtype=torch_type)
-                dqX = qX.dequantize()
-                dqY_hat = ref_op(dqX.clone())
 
-                # Retrieves the inplace keyword arguments
-                # some functions require inplace=True to test in-place.
-                inplace_kwarg = op_group.get('inplace_kwarg', dict())
+                for memory_format in (torch.channels_last, torch.contiguous_format):
+                    if memory_format == torch.channels_last and len(X.shape) != 4:
+                        continue
+                    X = X.to(memory_format=memory_format)
 
-                # Adjusts output_scale if needed.
-                # The output_scale determines the quantization scale for functions that
-                # have a constrained output range. e.x. sigmoid ranges from 0 to 1.
-                output_scale = scale
-                if 'output_range' in op_group:
-                    (f_min, f_max) = op_group['output_range']
-                    output_scale = (f_max - f_min) / (q_max - q_min + 1.0)
+                    # Retrieves the inplace keyword arguments
+                    # some functions require inplace=True to test in-place.
+                    # copy.copy is needed because these are modified in place
+                    extra_kwargs = \
+                        copy.copy(op_group.get('extra_kwargs', dict()))
+                    output_is_observed = \
+                        copy.copy(op_group.get('output_is_observed', False))
 
-                # Adjusts output_zero_point if needed (see explanation for the
-                # change_zero_point parameter above).
-                # output_zero_point determines the additional offset that will be
-                # added to a scaled value during quantization.
-                if op_group.get('change_zero_point', False):
-                    output_zero_point = 0 if torch_type == torch.qint32 else q_min
-                else:
-                    output_zero_point = zero_point
-
-                # Quantizes the dequantized version of Y_hat.
-                qY_hat = torch.quantize_per_tensor(dqY_hat, scale=output_scale,
-                                                   zero_point=output_zero_point,
+                    # Quantizes and dequantizes to account for max error.
+                    qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
                                                    dtype=torch_type)
+                    dqX = qX.dequantize()
+                    dqY_hat = ref_op(dqX.clone(), **extra_kwargs)
 
-                # Finds qY using in-place or non-in-place quantized operators.
-                qY = q_op(qX, **inplace_kwarg)
+                    # Adjusts output_scale if needed.
+                    # The output_scale determines the quantization scale for functions that
+                    # have a constrained output range. e.x. sigmoid ranges from 0 to 1.
+                    output_scale = scale
+                    if 'output_range' in op_group:
+                        (f_min, f_max) = op_group['output_range']
+                        output_scale = (f_max - f_min) / (q_max - q_min + 1.0)
 
-                self.assertEqual(qY, qY_hat, msg='{} - {} failed: ({} vs. {})'.format(
-                    fn_name, q_op, qY, qY_hat
-                ))
+                    # Adjusts output_zero_point if needed (see explanation for the
+                    # change_zero_point parameter above).
+                    # output_zero_point determines the additional offset that will be
+                    # added to a scaled value during quantization.
+                    if op_group.get('change_zero_point', False):
+                        output_zero_point = 0 if torch_type == torch.qint32 else q_min
+                    else:
+                        output_zero_point = zero_point
+
+                    # Quantizes the dequantized version of Y_hat.
+                    qY_hat = torch.quantize_per_tensor(dqY_hat, scale=output_scale,
+                                                       zero_point=output_zero_point,
+                                                       dtype=torch_type)
+
+                    if output_is_observed:
+                        extra_kwargs.update({'output_scale': output_scale, 'output_zero_point': output_zero_point})
+
+                    # Finds qY using in-place or non-in-place quantized operators.
+                    qY = q_op(qX, **extra_kwargs)
+
+                    self.assertEqual(qY, qY_hat, msg='{} - {} failed: ({} vs. {})'.format(
+                        fn_name, q_op, qY, qY_hat
+                    ))
 
     """Tests the correctness of the quantized::relu op."""
     @override_qengines
@@ -265,9 +279,7 @@ class TestQuantizedOps(TestCase):
 
     """Tests the correctness of the quantized::hardsigmoid op."""
     @override_qengines
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
-                       qparams=hu.qparams()))
-    def test_qhardsigmoid(self, X):
+    def test_qhardsigmoid(self):
         hardsigmoid_test_configs = [
             {
                 'quantized_fn': [
@@ -278,28 +290,38 @@ class TestQuantizedOps(TestCase):
                 'change_zero_point': True
             }
         ]
-        self._test_activation_function(X, 'hardsigmoid', hardsigmoid_test_configs)
+        shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
+        dtypes = (torch.quint8, torch.qint8)
+        test_cases = itertools.product(shapes, dtypes)
+        for shape, dtype in test_cases:
+            X = (np.random.rand(*shape).astype(np.float32), (1.0, 0, dtype))
+            self._test_activation_function(X, 'hardsigmoid', hardsigmoid_test_configs)
 
     """Tests the correctness of the quantized::relu op."""
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
-                       qparams=hu.qparams()),
-           alpha=st.floats(0.0, 1.0, allow_nan=False, allow_infinity=False))
-    def test_qrelu_leaky(self, X, alpha):
-        X, (scale, zero_point, torch_type) = X
+    def test_leaky_relu(self):
+        shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
+        dtypes = (torch.quint8, torch.qint8)
+        memory_formats = (torch.channels_last, torch.contiguous_format)
+        test_cases = itertools.product(shapes, dtypes, memory_formats)
+        for shape, dtype, memory_format in test_cases:
+            if memory_format == torch.channels_last and len(shape) != 4:
+                continue
+            X, scale, zero_point, torch_type, alpha = \
+                torch.randn(*shape), 0.1, 0, dtype, 0.01
+            X = X.to(memory_format=memory_format)
 
-        X = torch.from_numpy(X)
-        qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type)
-        dqX = qX.dequantize()
+            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
+            dqX = qX.dequantize()
 
-        # torch.nn.functional
-        op = torch.nn.functional.leaky_relu
-        dqY = op(dqX, negative_slope=alpha)
-        qY = torch.quantize_per_tensor(dqY, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type)
-        qY_hat = op(qX, negative_slope=alpha)
-        self.assertEqual(qY.dequantize(), qY_hat.dequantize(),
-                         msg="F.leaky_relu failed ({} vs {})".format(qY, qY_hat))
+            # torch.nn.functional
+            op = torch.nn.functional.leaky_relu
+            dqY = op(dqX, negative_slope=alpha)
+            qY = torch.quantize_per_tensor(dqY, scale=scale, zero_point=zero_point,
+                                           dtype=torch_type)
+            qY_hat = op(qX, negative_slope=alpha)
+            self.assertEqual(qY.dequantize(), qY_hat.dequantize(),
+                             msg="F.leaky_relu failed ({} vs {})".format(qY, qY_hat))
 
     """Tests the correctness of the quantized::elu op."""
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
@@ -573,11 +595,11 @@ class TestQuantizedOps(TestCase):
     """Tests the correctness of the quantized::hardswish op."""
     @override_qengines
     def test_hardswish(self):
-        max_sides = (3, 5)
-        side_lens = (1, 7, 8)
+        max_sides = (3, 4)
+        side_lens = (1, 7)
         torch_types = (torch.quint8, torch.qint8)
-        y_scales = (0.1, 4.23)
-        y_zero_points = (0, 1)
+        y_scales = (0.1, )
+        y_zero_points = (1,)
         combined = [max_sides, side_lens, torch_types, y_scales, y_zero_points]
         test_cases = itertools.product(*combined)
         for test_case in test_cases:
@@ -589,20 +611,23 @@ class TestQuantizedOps(TestCase):
             shapes = [side_len] * max_side
             X, X_scale, X_zero_point = \
                 _get_random_tensor_and_q_params(shapes, 2.0, torch_type)
-            qX = torch.quantize_per_tensor(X, scale=X_scale, zero_point=X_zero_point,
-                                           dtype=torch_type)
-            dqX = qX.dequantize()
-
-            dqY_hat = F.hardswish(dqX)
-            qY_hat = torch.quantize_per_tensor(dqY_hat, scale=Y_scale,
-                                               zero_point=Y_zero_point,
+            for memory_format in torch.channels_last, torch.contiguous_format:
+                if memory_format == torch.channels_last and len(shapes) == 4:
+                    X = X.to(memory_format=memory_format)
+                qX = torch.quantize_per_tensor(X, scale=X_scale, zero_point=X_zero_point,
                                                dtype=torch_type)
+                dqX = qX.dequantize()
 
-            qY = torch.nn.quantized.functional.hardswish(
-                qX, scale=Y_scale, zero_point=Y_zero_point)
-            self.assertEqual(
-                qY, qY_hat,
-                msg="Hardswish failed: {} vs {}, {}".format(qY, qY_hat, torch.backends.quantized.engine))
+                dqY_hat = F.hardswish(dqX)
+                qY_hat = torch.quantize_per_tensor(dqY_hat, scale=Y_scale,
+                                                   zero_point=Y_zero_point,
+                                                   dtype=torch_type)
+
+                qY = torch.nn.quantized.functional.hardswish(
+                    qX, scale=Y_scale, zero_point=Y_zero_point)
+                self.assertEqual(
+                    qY, qY_hat,
+                    msg="Hardswish failed: {} vs {}, {}".format(qY, qY_hat, torch.backends.quantized.engine))
 
     """Tests the correctness of the scalar addition."""
     @unittest.skip("Failing on MacOS")
@@ -3845,55 +3870,68 @@ class TestQNNPackOps(TestCase):
 
     """Tests the correctness of the quantized::qnnpack_tanh op."""
     @skipIfNoFBGEMM
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
-                       qparams=hu.qparams(dtypes=torch.quint8)))
-    def test_qnnpack_tanh(self, X):
+    def test_qnnpack_tanh(self):
         # Note: In QNNPACK the output scale and zero_point can only be
         #       2.0/256, 128 respectively, as it uses a LUT with 256 bins.
-        X, (scale, zero_point, torch_type) = X
-        X = torch.from_numpy(X)
-        qX = torch.quantize_per_tensor(X, scale=scale,
-                                       zero_point=zero_point,
-                                       dtype=torch_type)
 
-        # Floating point reference
-        Y = torch.tanh(X)
-        qY = torch.quantize_per_tensor(Y, scale=1.0 / 128, zero_point=128,
-                                       dtype=torch.quint8)
-        with override_quantized_engine('fbgemm'):
-            qYserver = torch.tanh(qX)
-        with override_quantized_engine('qnnpack'):
-            qY_hat = torch.tanh(qX)
-            self.assertEqual(qY, qY_hat,
-                             msg="QNNPACK TanH failed (FP ref)!")
-            self.assertEqual(qYserver, qY_hat,
-                             msg="QNNPACK TanH failed (FBGEMM ref)!")
+        shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
+        memory_formats = (torch.channels_last, torch.contiguous_format)
+        test_cases = itertools.product(shapes, memory_formats)
+        for shape, memory_format in test_cases:
+            X, scale, zero_point, torch_type = torch.randn(*shape), 1.0, 0, torch.quint8
+            if memory_format == torch.channels_last and len(shape) != 4:
+                continue
+            X = X.to(memory_format=memory_format)
+            qX = torch.quantize_per_tensor(X, scale=scale,
+                                           zero_point=zero_point,
+                                           dtype=torch_type)
+
+            # Floating point reference
+            Y = torch.tanh(qX.dequantize())
+            qY = torch.quantize_per_tensor(Y, scale=1.0 / 128, zero_point=128,
+                                           dtype=torch.quint8)
+            with override_quantized_engine('fbgemm'):
+                qYserver = torch.tanh(qX)
+            with override_quantized_engine('qnnpack'):
+                qY_hat = torch.tanh(qX)
+                self.assertEqual(
+                    qY, qY_hat,
+                    msg="QNNPACK TanH failed (FP ref), memory_format {}".format(memory_format))
+                self.assertEqual(
+                    qYserver, qY_hat,
+                    msg="QNNPACK TanH failed (FBGEMM ref), memory_format {}".format(memory_format))
 
     """Tests the correctness of the quantized::qnnpack_sigmoid op."""
     @skipIfNoFBGEMM
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
-                       qparams=hu.qparams(dtypes=torch.quint8)))
-    def test_qnnpack_sigmoid(self, X):
+    def test_qnnpack_sigmoid(self):
         # Note: In QNNPACK the output scale and zero_point can only be
         #       1.0/256, 0 respectively, as it uses a LUT with 256 bins.
-        X, (scale, zero_point, torch_type) = X
-        X = torch.from_numpy(X).to(torch.float32)
-        qX = torch.quantize_per_tensor(X, scale=scale,
-                                       zero_point=zero_point,
-                                       dtype=torch_type)
+        shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
+        memory_formats = (torch.channels_last, torch.contiguous_format)
+        test_cases = itertools.product(shapes, memory_formats)
+        for shape, memory_format in test_cases:
+            X, scale, zero_point, torch_type = torch.randn(*shape), 1.0, 0, torch.quint8
+            if memory_format == torch.channels_last and len(shape) != 4:
+                continue
+            X = X.to(memory_format=memory_format)
+            qX = torch.quantize_per_tensor(X, scale=scale,
+                                           zero_point=zero_point,
+                                           dtype=torch_type)
 
-        # Floating point reference
-        Y = torch.sigmoid(X)
-        qY = torch.quantize_per_tensor(Y, scale=1.0 / 256, zero_point=0,
-                                       dtype=torch.quint8)
-        with override_quantized_engine('fbgemm'):
-            qYserver = torch.sigmoid(qX)
-        with override_quantized_engine('qnnpack'):
-            qY_hat = torch.sigmoid(qX)
-            self.assertEqual(qY, qY_hat,
-                             msg="QNNPACK Sigmoid failed (FP ref)!")
-            self.assertEqual(qYserver, qY_hat,
-                             msg="QNNPACK Sigmoid failed (FBGEMM ref)!")
+            # Floating point reference
+            Y = torch.sigmoid(qX.dequantize())
+            qY = torch.quantize_per_tensor(Y, scale=1.0 / 256, zero_point=0,
+                                           dtype=torch.quint8)
+            with override_quantized_engine('fbgemm'):
+                qYserver = torch.sigmoid(qX)
+            with override_quantized_engine('qnnpack'):
+                qY_hat = torch.sigmoid(qX)
+                self.assertEqual(
+                    qY, qY_hat,
+                    msg="QNNPACK Sigmoid failed (FP ref), memory_format {}".format(memory_format))
+                self.assertEqual(
+                    qYserver, qY_hat,
+                    msg="QNNPACK Sigmoid failed (FBGEMM ref), memory_format {}".format(memory_format))
 
     @skipIfNoFBGEMM
     def test_qnnpack_sigmoid_sweep(self):
@@ -4143,31 +4181,32 @@ class TestQNNPackOps(TestCase):
             np.testing.assert_array_almost_equal(Y.int_repr().numpy(), qY.int_repr().numpy(), decimal=0)
 
     """Tests the correctness of the quantized::hardtanh op."""
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 8, 1, 8, max_numel=10**5),
-                       elements=hu.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
-                       qparams=hu.qparams(dtypes=torch.quint8)),
-           min_val=hu.floats(-1e6, -9.999999974752427e-07, allow_nan=False, allow_infinity=False),
-           max_val=hu.floats(9.999999974752427e-07, 1e6, allow_nan=False, allow_infinity=False))
-    def test_hardtanh(self, X, min_val, max_val):
+    def test_hardtanh(self):
         if 'qnnpack' not in torch.backends.quantized.supported_engines:
             return
         with override_quantized_engine('qnnpack'):
-            X, (scale, zero_point, torch_type) = X
+            shapes = ((4,), (4, 4), (4, 4, 4), (4, 4, 4, 4))
+            memory_formats = (torch.channels_last, torch.contiguous_format)
+            min_vals = (-0.5, -0.3, 0.5)
+            max_vals = (-0.3, 0.3, 0.7)
+            test_cases = itertools.product(shapes, memory_formats, min_vals, max_vals)
+            for shape, memory_format, min_val, max_val in test_cases:
+                X, scale, zero_point, torch_type = torch.randn(*shape), 1.0, 0, torch.quint8
+                if memory_format == torch.channels_last and len(shape) != 4:
+                    continue
 
-            assume(min_val <= max_val)
-            Y = X.copy()
-            Y[Y < min_val] = min_val
-            Y[Y > max_val] = max_val
-            qY = torch.quantize_per_tensor(torch.from_numpy(Y), scale=scale,
-                                           zero_point=zero_point, dtype=torch_type)
-            X = torch.from_numpy(X)
-            qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                           dtype=torch_type)
+                Y = X.clone()
+                Y[Y < min_val] = min_val
+                Y[Y > max_val] = max_val
+                qY = torch.quantize_per_tensor(Y, scale=scale,
+                                               zero_point=zero_point, dtype=torch_type)
+                qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
+                                               dtype=torch_type)
 
-            qY_hat = torch.nn.quantized.functional.hardtanh(qX, min_val, max_val)
-            self.assertEqual(
-                qY, qY_hat,
-                msg="hardtanh failed:\nactual {}\nexpected {}".format(qY_hat, qY))
+                qY_hat = torch.nn.quantized.functional.hardtanh(qX, min_val, max_val)
+                self.assertEqual(
+                    qY, qY_hat,
+                    msg="hardtanh failed:\nactual {}\nexpected {}\nmemory_format {}".format(qY_hat, qY, memory_format))
 
 """Tests the correctness of the tensor comparators."""
 class TestComparatorOps(TestCase):


### PR DESCRIPTION
Summary:
Cherry-pick of https://github.com/pytorch/pytorch/pull/46077 into `release/1.7`

Some of QNNPACK quantized kernels were not handling NHWC correctly,
the data written respected the input format but the memory flag
was always set to contiguous.  This PR
1. adds testing for NHWC for qnnpack activations
2. fixes those activations which did not set the memory format on the output

Test Plan:
```
python test/test_quantization.py TestQuantizedOps.test_qhardsigmoid
python test/test_quantization.py TestQuantizedOps.test_leaky_relu
python test/test_quantization.py TestQuantizedOps.test_hardswish
python test/test_quantization.py TestQNNPackOps.test_qnnpack_tanh
python test/test_quantization.py TestQNNPackOps.test_qnnpack_sigmoid
```

Imported from OSS

Reviewed By: supriyar

Differential Revision: D24213257

fbshipit-source-id: 764fb588a8d8a0a6e6e4d86285904cdbab26d487
