### PR TITLE
[StaticRuntime] Threading model

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -76,8 +76,8 @@ static void BM_deep_wide_static(benchmark::State& state) {
   }
 }
 
-const std::shared_ptr<torch::jit::Graph>& getStaticGraph() {
-  static const std::shared_ptr<torch::jit::Graph> g =
+const std::shared_ptr<torch::jit::InferenceModule>& getStaticGraph() {
+  static const std::shared_ptr<torch::jit::InferenceModule> g =
       torch::jit::PrepareForStaticRuntime(getDeepAndWideSciptModel());
   return g;
 }

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -28,7 +28,7 @@ TEST(StaticRuntime, DeepWide) {
   torch::jit::StaticRuntime runtime(g);
 
   for (int batch_size : {1, 8, 32}) {
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 2; ++i) {
       auto ad_emb_packed = torch::randn({batch_size, 1, embedding_size});
       auto user_emb = torch::randn({batch_size, 1, embedding_size});
       auto wide = torch::randn({batch_size, num_features});
@@ -52,7 +52,7 @@ TEST(StaticRuntime, KWargsAPI_1) {
   torch::jit::StaticRuntime runtime(module);
 
   for (int batch_size : {1, 8, 32}) {
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 2; ++i) {
       auto ad_emb_packed = torch::randn({batch_size, 1, embedding_size});
       auto user_emb = torch::randn({batch_size, 1, embedding_size});
       auto wide = torch::randn({batch_size, num_features});
@@ -76,7 +76,7 @@ TEST(StaticRuntime, KWargsAPI_2) {
   torch::jit::StaticRuntime runtime(module);
 
   for (int batch_size : {1, 8, 32}) {
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 2; ++i) {
       auto ad_emb_packed = torch::randn({batch_size, 1, embedding_size});
       auto user_emb = torch::randn({batch_size, 1, embedding_size});
       auto wide = torch::randn({batch_size, num_features});

--- a/torch/csrc/jit/runtime/static/README.md
+++ b/torch/csrc/jit/runtime/static/README.md
@@ -2,7 +2,7 @@
 
 # Static Runtime
 
-The premise of this approach is that a small subset of neural networks are well represented by a 
+The premise of this approach is that a small subset of neural networks are well represented by a
 completely flattened dataflow graph.
 TorchScript supports a far more feature programming paradigm,
 so many models will not work out of the box.
@@ -13,7 +13,6 @@ This is a list of current assumptions for use with
 this feature.
 
 - Inference only execution
-- Single CPU device
 
 After `torch.jit.freeze` and inlining/constant propagation is run on the model:
 
@@ -21,6 +20,46 @@ After `torch.jit.freeze` and inlining/constant propagation is run on the model:
 - No submodule invocations
 - No references to `self`
 - Inlined weights (i.e. no calls to `GetAttr`)
+
+## Threading model
+Static runtime supports two execution modes.
+
+Mode 1: single-threaded with no parallelism except for intra-op parallelism.
+For this mode, you can do either:
+```
+  // m is the TorchScript module
+  auto runtime = StaticRuntime(m, opts);
+  auto output = runtime.run(args, kwargs);
+```
+or
+```
+  auto mod = PrepareForStaticRuntime(m);
+  auto runtime = StaticRuntime(mod, opts);
+  auto output = runtime.run(args, kwargs);
+```
+Mode 2: similar to data parallelism, run the same model for different inputs
+on different threads at the same time. In this case, run
+`PrepareForStaticRuntime` to prepare the graph for Static Runtime. You
+should have one InferenceModule instance per model, and one Static Runtime instance
+per running thread. To avoiding creating StaticRuntime on the fly, use a
+synchronized stack (i.e. `boost::lockfree::stack`) to cache all the Static
+Runtime instances in your code.
+```
+  // initialization
+  auto mod = PrepareForStaticRuntime(m);
+  // 128 is good for most cases. Pick a number that works for you
+  boost::lockfree::stack<std::shared_ptr<StaticRuntime>,
+    boost::lockfree::fixed_sized<true>> pool(128);
+
+  // inference
+  std::shared_ptr<StaticRuntime> runtime = nullptr;
+  pool.pop(runtime);
+  if (!runtime) {
+    runtime = std::make_shared<StaticRuntime>(mod, opts);
+  }
+  auto output = runtime->run(args, kwargs);
+  pool.push(runtime);
+```
 
 ## Planned features
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/runtime/static/impl.h>
 #include <ATen/core/interned_strings.h>
+#include <caffe2/core/scope_guard.h>
 #include <caffe2/core/timer.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
@@ -10,59 +11,53 @@
 
 namespace torch {
 namespace jit {
+namespace {
+void OptimizeGraph(std::shared_ptr<torch::jit::Graph>& graph) {
+  Inline(*graph);
+  ConstantPropagation(graph);
+  Canonicalize(graph);
+  ConstantPropagation(graph);
+  RemoveTensorMutation(graph);
+  ConstantPropagation(graph);
+}
 
-std::shared_ptr<torch::jit::Graph> PrepareForStaticRuntime(
-    std::shared_ptr<torch::jit::Graph> g) {
-  Inline(*g);
-  ConstantPropagation(g);
-  Canonicalize(g);
-  ConstantPropagation(g);
-  RemoveTensorMutation(g);
-  ConstantPropagation(g);
-
-  for (auto n : g->nodes()) {
+void CheckGraphEligibility(const std::shared_ptr<torch::jit::Graph>& graph) {
+  for (auto n : graph->nodes()) {
     if (n->kind() == c10::Symbol::fromQualString("prim::GetAttr")) {
       throw std::runtime_error("Cannot accelerate unfrozen graphs");
     }
   }
+}
 
-  // remove unused input 0 from graph
-  if (g->inputs().at(0)->type()->is_module()) {
-    TORCH_CHECK(!g->inputs().at(0)->hasUses());
-    g->eraseInput(0);
+// remove unused input 0 from graph
+void RemoveSelfFromGraphInput(std::shared_ptr<torch::jit::Graph>& graph) {
+  if (graph->inputs().at(0)->type()->is_module()) {
+    TORCH_CHECK(!graph->inputs().at(0)->hasUses());
+    graph->eraseInput(0);
   }
-
-  return g;
 }
 
-std::shared_ptr<torch::jit::Graph> PrepareForStaticRuntime(
-    const torch::jit::Module& m) {
-  auto module = m.copy();
-  module.eval();
-  module = freeze_module(module);
-  auto g = module.get_method("forward").graph();
-  return PrepareForStaticRuntime(g);
+// remove "self" from function schema
+std::unique_ptr<c10::FunctionSchema> RemoveSelfFromSchema(
+    const c10::FunctionSchema& s) {
+  TORCH_CHECK(s.arguments().size() >= 1 && s.arguments()[0].name() == "self");
+  std::vector<Argument> args({s.arguments().begin() + 1, s.arguments().end()});
+  return std::make_unique<c10::FunctionSchema>(s.cloneWithArguments(args));
 }
 
-StaticRuntime::StaticRuntime(std::shared_ptr<torch::jit::Graph> g)
-    : StaticRuntime(g, c10::nullopt) {}
-
-StaticRuntime::StaticRuntime(const torch::jit::Module& m)
-    : StaticRuntime(PrepareForStaticRuntime(m), m) {}
-
-StaticRuntime::StaticRuntime(
-    std::shared_ptr<torch::jit::Graph> g,
-    c10::optional<torch::jit::Module> m)
-    : graph_(g) {
+void AssignRegisters(
+    const std::shared_ptr<torch::jit::Graph>& graph,
+    std::unordered_map<Value*, size_t>& value_to_reg,
+    std::vector<size_t>& input_regs,
+    std::vector<size_t>& output_regs) {
   // assign register to Value*
-  std::unordered_map<Value*, size_t> value_to_reg;
-  for (Value* input : g->inputs()) {
+  for (Value* input : graph->inputs()) {
     TORCH_CHECK(value_to_reg.count(input) == 0);
     size_t index = value_to_reg.size();
     value_to_reg[input] = index;
-    input_regs_.push_back(index);
+    input_regs.push_back(index);
   }
-  for (Node* node : graph_->nodes()) {
+  for (Node* node : graph->nodes()) {
     for (Value* input : node->inputs()) {
       TORCH_CHECK(value_to_reg.count(input) > 0);
     }
@@ -73,18 +68,78 @@ StaticRuntime::StaticRuntime(
       value_to_reg[output] = index;
     }
   }
-
-  TORCH_CHECK(g->outputs().size() > 0);
-  for (Value* output : g->outputs()) {
+  TORCH_CHECK(graph->outputs().size() > 0);
+  for (Value* output : graph->outputs()) {
     TORCH_CHECK(value_to_reg.count(output) > 0);
-    output_regs_.push_back(value_to_reg[output]);
+    output_regs.push_back(value_to_reg[output]);
   }
+}
 
+void DeduceInternalBlobs(
+    const std::shared_ptr<torch::jit::Graph>& graph,
+    const std::unordered_map<Value*, size_t>& value_to_reg,
+    std::vector<size_t>& internals) {
+  std::unordered_set<Value*> outputs{graph->outputs().begin(),
+                                     graph->outputs().end()};
+  for (Node* node : graph->nodes()) {
+    if (node->kind() != prim::Constant) {
+      for (Value* output : node->outputs()) {
+        if (outputs.count(output) == 0) {
+          internals.push_back(value_to_reg.at(output));
+        }
+      }
+    }
+  }
+}
+} // namespace
+
+void InferenceModule::init() {
+  OptimizeGraph(graph);
+  CheckGraphEligibility(graph);
+  RemoveSelfFromGraphInput(graph);
+  AssignRegisters(graph, value_to_reg, input_regs, output_regs);
+  DeduceInternalBlobs(graph, value_to_reg, internals);
+}
+
+InferenceModule::InferenceModule(const torch::jit::Module& m)
+    : module(m.copy()), graph(nullptr), schema(nullptr) {
+  module.eval();
+  module = freeze_module(module);
+
+  Method method = module.get_method("forward");
+  graph = method.graph();
+
+  const c10::FunctionSchema& s = method.function().getSchema();
+  schema = RemoveSelfFromSchema(s);
+
+  init();
+}
+
+InferenceModule::InferenceModule(std::shared_ptr<torch::jit::Graph> g)
+    : module(), graph(g), schema(nullptr) {
+  init();
+}
+
+StaticRuntime::StaticRuntime(
+    const torch::jit::Module& m,
+    const StaticRuntimeOptions& opts)
+    : StaticRuntime(PrepareForStaticRuntime(m), opts) {}
+
+StaticRuntime::StaticRuntime(
+    std::shared_ptr<InferenceModule> m,
+    const StaticRuntimeOptions& opts)
+    : module_(m), opts_(opts) {
+  TORCH_CHECK(
+      module_ != nullptr,
+      "std::shared_ptr<InferenceModule> module_ cannot be nullptr")
   // initialize registers
-  reg_.resize(value_to_reg.size());
+  reg_.resize(module_->value_to_reg.size());
 
-  // fill workspace_ with constants
-  for (Node* node : graph_->nodes()) {
+  Graph* graph = module_->graph.get();
+  auto& value_to_reg = module_->value_to_reg;
+
+  // fill workspace_ with constants and create ProcessedNodes
+  for (Node* node : graph->nodes()) {
     if (node->kind() == prim::Constant) {
       TORCH_CHECK(node->output()->type()->kind() != FunctionType::Kind);
       reg_[value_to_reg[node->output()]] = toIValue(node->output()).value();
@@ -99,43 +154,27 @@ StaticRuntime::StaticRuntime(
       nodes_.emplace_back(node, std::move(input_regs), std::move(output_regs));
     }
   }
-
-  if (m) {
-    Method method = m->get_method("forward");
-    const c10::FunctionSchema& schema = method.function().getSchema();
-
-    // remove "self" from function schema
-    TORCH_CHECK(
-        schema.arguments().size() >= 1 &&
-        schema.arguments()[0].name() == "self");
-    std::vector<Argument> args(
-        {schema.arguments().begin() + 1, schema.arguments().end()});
-    schema_ =
-        std::make_unique<c10::FunctionSchema>(schema.cloneWithArguments(args));
-  }
 }
 
 std::vector<at::Tensor> StaticRuntime::run(
     const std::vector<at::Tensor>& inps) const {
+  std::vector<c10::IValue> stack;
+  stack.resize(inps.size());
   for (size_t i = 0; i < inps.size(); i++) {
-    Input(i) = inps[i];
+    stack[i] = inps[i];
   }
 
-  for (const auto& n : nodes_) {
-    n.run(reg_);
-  }
+  c10::IValue v = run(stack, std::unordered_map<std::string, c10::IValue>());
 
   std::vector<at::Tensor> out;
-  for (size_t i = 0; i < graph_->outputs().size(); i++) {
-    const IValue& v = Output(i);
-    if (v.isTuple()) {
-      auto t = v.toTuple();
-      for (const auto& el : t->elements()) {
-        out.emplace_back(el.toTensor());
-      }
-    } else {
-      out.emplace_back(v.toTensor());
+
+  if (v.isTuple()) {
+    auto t = v.toTuple();
+    for (const auto& el : t->elements()) {
+      out.emplace_back(el.toTensor());
     }
+  } else {
+    out.emplace_back(v.toTensor());
   }
   return out;
 }
@@ -143,14 +182,25 @@ std::vector<at::Tensor> StaticRuntime::run(
 c10::IValue StaticRuntime::run(
     const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) const {
+  caffe2::MakeGuard([&] {
+    if (opts_.cleanup_activations) {
+      for (size_t i : module_->internals) {
+        if (reg_[i].isTensor()) {
+          // Temporary solution
+          auto t = reg_[i].toTensor();
+          reg_[i] = at::empty({0}, t.options());
+        }
+      }
+    }
+  });
   std::vector<IValue> stack(args);
   if (!kwargs.empty()) {
     // This is not ideal
     TORCH_CHECK(
-        schema_ != nullptr,
+        module_->schema != nullptr,
         "Schema is not available. Consider creating the Static Runtime "
         "with StaticRuntime(const torch::jit::Module& m) instead.");
-    schema_->checkAndNormalizeInputs(stack, kwargs);
+    module_->schema->checkAndNormalizeInputs(stack, kwargs);
   }
   for (size_t i = 0; i < stack.size(); i++) {
     Input(i) = stack[i];
@@ -238,10 +288,10 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   if (!kwargs.empty()) {
     // This is not ideal
     TORCH_CHECK(
-        schema_ != nullptr,
+        module_->schema != nullptr,
         "Schema is not available. Consider creating the Static Runtime "
         "with StaticRuntime(const torch::jit::Module& m) instead.");
-    schema_->checkAndNormalizeInputs(stack, kwargs);
+    module_->schema->checkAndNormalizeInputs(stack, kwargs);
   }
   for (size_t i = 0; i < stack.size(); i++) {
     Input(i) = stack[i];

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -10,22 +10,95 @@
 namespace torch {
 namespace jit {
 
-TORCH_API std::shared_ptr<torch::jit::Graph> PrepareForStaticRuntime(
-    std::shared_ptr<torch::jit::Graph> g);
-TORCH_API std::shared_ptr<torch::jit::Graph> PrepareForStaticRuntime(
-    const torch::jit::Module& m);
+struct TORCH_API StaticRuntimeOptions {
+  bool cleanup_activations{true};
+};
+
+/// Static runime supports two execution modes.
+///
+/// Mode 1: single-threaded with no parallelism except for intra-op parallelism
+/// For this mode, you can do either:
+/// @code
+///   // m is the TorchScript module
+///   auto runtime = StaticRuntime(m, opts);
+///   auto output = runtime.run(args, kwargs);
+/// @endcode
+/// or
+/// @code
+///   auto mod = PrepareForStaticRuntime(m);
+///   auto runtime = StaticRuntime(mod, opts);
+///   auto output = runtime.run(args, kwargs);
+/// @endcode
+/// Mode 2: similar to data parallelism, run the same model for different inputs
+/// on different threads at the same time. In this case, run
+/// PrepareForStaticRuntime to prepare the graph for Static Runtime. You
+/// should have one InferenceModule instance per model, and one Static Runtime
+/// instance per running thread. To avoiding creating StaticRuntime on the fly,
+/// use a synchronized stack (i.e. boost::lockfree::stack) to cache all the
+/// Static Runtime instances in your code.
+/// @code
+///   // initialization
+///   auto mod = PrepareForStaticRuntime(m);
+///   // 128 is good for most cases. Pick a number that works for you
+///   boost::lockfree::stack<std::shared_ptr<StaticRuntime>,
+///   boost::lockfree::fixed_sized<true>> pool(128);
+///
+///   // inference
+///   std::shared_ptr<StaticRuntime> runtime = nullptr;
+///   pool.pop(runtime);
+///   if (!runtime) {
+///     runtime = std::make_shared<StaticRuntime>(mod, opts);
+///   }
+///   auto output = runtime->run(args, kwargs);
+///   pool.push(runtime);
+/// @endcode
+///
+
+// Group readonly data structures into InferenceModule
+struct TORCH_API InferenceModule {
+ public:
+  explicit InferenceModule(const torch::jit::Module& m);
+  explicit InferenceModule(std::shared_ptr<torch::jit::Graph> g);
+  torch::jit::Module module;
+  std::shared_ptr<torch::jit::Graph> graph;
+  std::unique_ptr<c10::FunctionSchema> schema;
+
+  std::unordered_map<Value*, size_t> value_to_reg;
+  std::vector<size_t> input_regs; // inputs to the graph
+  std::vector<size_t> output_regs; // outputs of the graph
+  std::vector<size_t> internals;
+
+ private:
+  void init();
+};
+
+inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
+    const torch::jit::Module& m) {
+  return std::make_shared<InferenceModule>(m);
+}
+
+inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
+    std::shared_ptr<torch::jit::Graph> g) {
+  return std::make_shared<InferenceModule>(g);
+}
 
 class ProcessedNode;
 class TORCH_API StaticRuntime {
  public:
-  // g is the optimized graph produced by PrepareForStaticRuntime
-  explicit StaticRuntime(std::shared_ptr<torch::jit::Graph> g);
+  // InferenceModule m is created by PrepareForStaticRuntime
+  explicit StaticRuntime(
+      std::shared_ptr<InferenceModule> m,
+      const StaticRuntimeOptions& opts = StaticRuntimeOptions());
 
   // m is unoptimized
-  explicit StaticRuntime(const torch::jit::Module& m);
+  explicit StaticRuntime(
+      const torch::jit::Module& m,
+      const StaticRuntimeOptions& opts = StaticRuntimeOptions());
 
   std::vector<at::Tensor> run(const std::vector<at::Tensor>& inps) const;
 
+  // This interface only works module_ that has a non-empty TorchScript module
+  // member; otherwise use the above interface
   c10::IValue run(
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs) const;
@@ -58,34 +131,25 @@ class TORCH_API StaticRuntime {
       const int main_runs) const;
 
  private:
-  explicit StaticRuntime(
-      std::shared_ptr<torch::jit::Graph> g, // optimized graph
-      c10::optional<torch::jit::Module> m);
-
-  std::shared_ptr<torch::jit::Graph> graph_;
-
-  std::unique_ptr<c10::FunctionSchema> schema_{nullptr};
-
   // Static runtime states
+  std::shared_ptr<InferenceModule> module_;
+  StaticRuntimeOptions opts_;
   // IValue table (including inputs, outputs, intermediates, and weights)
   mutable std::vector<IValue> reg_;
-  std::vector<size_t> input_regs_; // inputs to the graph
-  std::vector<size_t> output_regs_; // outputs of the graph
+  // The nodes we need to run
+  std::vector<ProcessedNode> nodes_;
 
   // Input is readwrite
   IValue& Input(size_t i) const {
-    DCHECK(i < input_regs_.size());
-    return reg_[input_regs_[i]];
+    DCHECK(i < module_->input_regs.size());
+    return reg_[module_->input_regs[i]];
   }
 
   // Output is readonly. The writing process happens inside ProcessedNodes
   const IValue& Output(size_t i) const {
-    DCHECK(i < output_regs_.size());
-    return reg_[output_regs_[i]];
+    DCHECK(i < module_->output_regs.size());
+    return reg_[module_->output_regs[i]];
   }
-
-  // The nodes we need to run
-  std::vector<ProcessedNode> nodes_;
 };
 
 class ProcessedNode {

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -65,11 +65,11 @@ void initStaticRuntimeBindings(PyObject* module) {
           });
   m.def(
        "_jit_to_static_runtime",
-       [](const std::shared_ptr<torch::jit::Graph>& g) {
+       [](std::shared_ptr<torch::jit::Graph> g) {
          return StaticRuntime(PrepareForStaticRuntime(g));
        })
       .def("_jit_to_static_runtime", [](const torch::jit::Module& m) {
-        return StaticRuntime(m);
+        return StaticRuntime(PrepareForStaticRuntime(m));
       });
 }
 

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -8,7 +8,7 @@ namespace jit {
 bool canRunOutOfPlace(Node* n) {
   static std::unordered_set<std::string> out_of_place_nodes{"aten::add",
                                                             "aten::mul",
-                                                            "aten::addmm"
+                                                            "aten::addmm",
                                                             "aten::bmm",
                                                             "aten::sigmoid",
                                                             "aten::cat",


### PR DESCRIPTION
Summary:
- Refactor StaticRuntime and group common data structures, the jit graph, and the script module into a separate struct `InferenceModule`:
```
struct InferenceModule {
  explicit InferenceModule(const torch::jit::Module& m);
  explicit InferenceModule(std::shared_ptr<torch::jit::Graph> g);
  torch::jit::Module module;
  std::shared_ptr<torch::jit::Graph> graph;
  std::unique_ptr<c10::FunctionSchema> schema;

  std::unordered_map<Value*, size_t> value_to_reg;
  std::vector<size_t> input_regs; // inputs to the graph
  std::vector<size_t> output_regs; // outputs of the graph
  std::vector<size_t> internals;
};
```
which is stored in the PyTorchPredictor, as well as the static runtime, and shared across threads. Then this is what's left inside the Static Runtime:
```
  mutable std::vector<IValue> reg_;
  // The nodes we need to run
  std::vector<ProcessedNode> nodes_;
```
`reg_` holds all the weights and activations, which is different across threads during running. `nodes_` holds the op nodes and input/output registers, and is the same across threads for now. We could potentially put other stateful data structures in it, so I kept it inside the static runtime. It could be easily moved into the `InferenceModule` if we decide not to anything else into `ProcessedNode`.

- Added StaticRuntimeOptions so we can toggle certain optimizations on/off, for testing and benchmarking. `cleanup_activations` is an example.

- Integration with PyTorchPredictor. Added a lockfree stack in the PyTorchPredictor to hold all the static runtime instances. Benchmark shows that the `push` and `pop` combo takes about 80 ns, which is quite acceptable.

This diff focuses on threading model only. Benchmarks will be separate.

Differential Revision: D24237078

