### PR TITLE
Avoid inlining kernel lambdas on mobile

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction.h
+++ b/aten/src/ATen/core/boxing/KernelFunction.h
@@ -205,7 +205,9 @@ public:
    * >      [] (Tensor a, bool b) -> Tensor {...});
    */
   template<bool AllowLegacyTypes = false, class Lambda>
-  static KernelFunction makeFromUnboxedLambda(Lambda&& lambda);
+  static std::enable_if_t<guts::is_stateless_lambda<std::decay_t<Lambda>>::value, KernelFunction> makeFromUnboxedLambda(Lambda&& lambda);
+  template<bool AllowLegacyTypes = false, class Lambda>
+  static std::enable_if_t<!guts::is_stateless_lambda<std::decay_t<Lambda>>::value, KernelFunction> makeFromUnboxedLambda(Lambda&& lambda);
 
   std::string dumpState() const;
   // For testing internal invariants only


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46249 [wip] avoid inlining lambdas on mobile**
* #42845 Rationalize inlining of kernels into the unboxing wrapper

This saves 15kb binary size on ios and increases binary size on android for 30kb. It also reduces size a bit for Android arm. I've talked to Martin and we should land this since Android binary size is much less important because of Voltron.

Differential Revision: [D23057150](https://our.internmc.facebook.com/intern/diff/D23057150/)