### PR TITLE
[quant][graph][fix] Set type for GetAttr nodes in remapTypes

### DIFF
--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -188,7 +188,7 @@ class ModuleCloneHelper {
     }
     for (Node* node : block->nodes()) {
       // remapping type for module instance
-      if (node->kind() == prim::CallMethod) {
+      if (node->kind() == prim::CallMethod || node->kind() == prim::GetAttr) {
         Value* instance = node->inputs()[0];
         auto child_opt = getInvokedModuleOpt(source, node, self);
         if (child_opt.has_value()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46250 [quant][graph][fix] Set type for GetAttr nodes in remapTypes**

Summary:
Previously the type of GetAttr nodes was getting set incorrectly and wasn't matching the module type

Test Plan:
Existing quantization tests

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D24279872](https://our.internmc.facebook.com/intern/diff/D24279872)