### PR TITLE
[NCCL] Fix Hang in Async Error Handling due to Work logging

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -220,10 +220,20 @@ thread_local uint64_t ProcessGroupNCCL::ncclActiveGroupCounter_ = 0;
 std::ostream& operator<<(
     std::ostream& output,
     const ProcessGroupNCCL::WorkNCCL& workNCCL) {
-  return output << "WorkNCCL("
-                << "OpType=" << opTypeToString(workNCCL.opType_)
-                << ", TensorShape=" << (*workNCCL.outputs_)[0].sizes()
-                << ", Timeout(ms)=" << workNCCL.opTimeout_.count() << ")";
+  std::string workInfo;
+  if (workNCCL.outputs_) {
+    workInfo = c10::str("WorkNCCL(",
+                        "OpType=", opTypeToString(workNCCL.opType_),
+                        ", TensorShape=", (*workNCCL.outputs_)[0].sizes(),
+                        ", Timeout(ms)=", workNCCL.opTimeout_.count(),
+                        ")");
+  } else {
+    workInfo = c10::str("WorkNCCL(",
+                        "OpType=", opTypeToString(workNCCL.opType_),
+                        ", Timeout(ms)=", workNCCL.opTimeout_.count(),
+                        ")");
+  }
+  return output << workInfo;
 }
 
 ProcessGroupNCCL::WorkNCCL::WorkNCCL(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46265 [NCCL] Fix Hang in Async Error Handling due to Work logging**

tl;dr - we must remove tensor-related logging from the
WorkNCCL::operator<< function, otherwise printing the work objects tracked in
the workMetaList_ will cause segfaults.

The Work objects we track in the workMetaList for the NCCL Async Error
Handling mechanism don't have any `outputs_`. As described in the workEnqueue
function, destructing the output tensors calls into autograd_meta, which
happens in the user thread, but our system destructs work objects in the
workCleanupThread, so this could lead to a deadlock scenario. We avoid this
problem by not tracking the tensors in the work objects in the workMetaList
(it's called work meta list because these work objects only track the metadata
and not the actual tensors), so when the WorkNCCL::operator<< function tried to
log tensor shapes for work objects from the watchdog thread, the async error
handling mechanism hanged (in the desync test) or segfaulted (in the desync
flow). This PR removes the tensor-related logging from the operator<< function.

Fixes: https://github.com/pytorch/pytorch/issues/46278

Differential Revision: [D24268204](https://our.internmc.facebook.com/intern/diff/D24268204/)