### PR TITLE
[JIT] Revert  Freezing shared type PR

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1213,10 +1213,10 @@ class TestFreezing(JitTestCase):
 
             def forward(self, cond: bool):
                 if cond:
-                    val = self.mod1.val
+                    mod = self.mod1
                 else:
-                    val = self.mod2.val
-                return val
+                    mod = self.mod2
+                return mod.val
 
         mod = Mod()
         mod.eval()

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1197,19 +1197,16 @@ class TestFreezing(JitTestCase):
             self.assertEqual(m_res, m_frozen_res)
 
     def test_module_getattr_indirection(self):
-        class ValMod(nn.Module):
-            def __init__(self, val):
-                super(ValMod, self).__init__()
-                self.val = val
-
-            def forward(self):
-                return self.val
+        @torch.jit.script
+        class ValHolder(object):
+            def __init__(self, val: int):
+                self.val: int = val
 
         class Mod(nn.Module):
             def __init__(self):
                 super(Mod, self).__init__()
-                self.mod1 = ValMod(1)
-                self.mod2 = ValMod(2)
+                self.mod1 = ValHolder(1)
+                self.mod2 = ValHolder(2)
 
             def forward(self, cond: bool):
                 if cond:

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1197,9 +1197,9 @@ class TestFreezing(JitTestCase):
             self.assertEqual(m_res, m_frozen_res)
 
     def test_module_getattr_indirection(self):
-        class Add(nn.Module):
+        class ValMod(nn.Module):
             def __init__(self, val):
-                super(Add, self).__init__()
+                super(ValMod, self).__init__()
                 self.val = val
 
             def forward(self):
@@ -1208,18 +1208,18 @@ class TestFreezing(JitTestCase):
         class Mod(nn.Module):
             def __init__(self):
                 super(Mod, self).__init__()
-                self.mod1 = Add(1)
-                self.mod2 = Add(2)
+                self.mod1 = ValMod(1)
+                self.mod2 = ValMod(2)
 
             def forward(self, cond: bool):
                 if cond:
-                    return self.mod1()
+                    val = self.mod1.val
                 else:
-                    return self.mod2()
+                    val = self.mod2.val
+                return val
 
         mod = Mod()
         mod.eval()
-
         frozen_mod = torch.jit.freeze(torch.jit.script(mod))
         mod_eager = Mod()
         self.assertEqual(mod_eager(True), frozen_mod(True))

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -11,25 +11,6 @@ namespace torch {
 namespace jit {
 
 namespace {
-ModulePtr getModulePtrForGetAttrNode(
-    const Node* node,
-    const std::shared_ptr<Graph>& graph,
-    const Module& graph_input_module) {
-  std::vector<std::string> names;
-  names.clear();
-  while (!(node->outputs()[0]->type() == graph->inputs()[0]->type())) {
-    TORCH_INTERNAL_ASSERT(
-        node->kind() == prim::GetAttr, "Expected prim::GetAttr nodes");
-    names.insert(names.begin(), node->s(attr::name));
-    node = node->inputs()[0]->node();
-  }
-  // Copy/paste from quantization/helper.h
-  Module m = graph_input_module;
-  for (const auto& p : names) {
-    m = m.attr(p).toModule();
-  }
-  return m._ivalue();
-}
 
 class AttributePropagator {
  public:
@@ -553,7 +534,7 @@ class AttributePropagator {
     removeUnusedAttrs();
   }
 
-  // Prepraring for clean up phase. At this point, record all  subModules that
+  // Prepraring for clean up phase. At this point, record all subModules that
   // contains mutable attributes.
   void recordReferencedAttrs(std::shared_ptr<Graph>& graph) {
     std::stack<Block*> blocks({graph->block()});
@@ -567,16 +548,22 @@ class AttributePropagator {
         }
         if (n->kind() == prim::GetAttr) {
           auto& name = n->s(attr::name);
+          // For now, use all module ivalues which are the same type
+          // and could be the module that this GetAttr resolves to
+          // TODO: we could attempt to follow the GetAttr chain and 
+          // find the exact ivalue, we would have to be careful
+          // that the chain does not contain any attributes which 
+          // get written to (setAttr calls)
           for (auto& mptr : modules) {
             auto module = Module(mptr);
-            if (module.type() == n->inputs()[0]->type() &&
-                module.hasattr(name)) {
+            if (module.type() == n->inputs()[0]->type()) {
+              TORCH_INTERNAL_ASSERT(module.hasattr(name));
+              auto module = Module(mptr);
               auto attr = module.attr(name);
               insertMutableAttr(name, attr, mptr);
               if (attr.isModule()) {
                 modules.insert(attr.toModule()._ivalue());
               }
-              break;
             }
           }
         } else if (n->kind() == prim::fork) {

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -560,6 +560,10 @@ class AttributePropagator {
               TORCH_INTERNAL_ASSERT(module.hasattr(name));
               auto module = Module(mptr);
               auto attr = module.attr(name);
+              // TODO: this could be insertReferencedAttr to be more clear,
+              // these are attributes we could not inline, which include 
+              // other reasons besides mutation (unsupported constant, 
+              // getAttr resolving to non-getAttr node, etc)
               insertMutableAttr(name, attr, mptr);
               if (attr.isModule()) {
                 modules.insert(attr.toModule()._ivalue());

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -567,12 +567,17 @@ class AttributePropagator {
         }
         if (n->kind() == prim::GetAttr) {
           auto& name = n->s(attr::name);
-          auto mptr =
-              getModulePtrForGetAttrNode(n->input(0)->node(), graph, module_);
-          auto module = Module(mptr);
-          if (module.type() == n->inputs()[0]->type() && module.hasattr(name)) {
-            auto attr = module.attr(name);
-            insertMutableAttr(name, attr, mptr);
+          for (auto& mptr : modules) {
+            auto module = Module(mptr);
+            if (module.type() == n->inputs()[0]->type() &&
+                module.hasattr(name)) {
+              auto attr = module.attr(name);
+              insertMutableAttr(name, attr, mptr);
+              if (attr.isModule()) {
+                modules.insert(attr.toModule()._ivalue());
+              }
+              break;
+            }
           }
         } else if (n->kind() == prim::fork) {
           applyToForkSubgraph(

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -550,9 +550,9 @@ class AttributePropagator {
           auto& name = n->s(attr::name);
           // For now, use all module ivalues which are the same type
           // and could be the module that this GetAttr resolves to
-          // TODO: we could attempt to follow the GetAttr chain and 
+          // TODO: we could attempt to follow the GetAttr chain and
           // find the exact ivalue, we would have to be careful
-          // that the chain does not contain any attributes which 
+          // that the chain does not contain any attributes which
           // get written to (setAttr calls)
           for (auto& mptr : modules) {
             auto module = Module(mptr);
@@ -561,8 +561,8 @@ class AttributePropagator {
               auto module = Module(mptr);
               auto attr = module.attr(name);
               // TODO: this could be insertReferencedAttr to be more clear,
-              // these are attributes we could not inline, which include 
-              // other reasons besides mutation (unsupported constant, 
+              // these are attributes we could not inline, which include
+              // other reasons besides mutation (unsupported constant,
               // getAttr resolving to non-getAttr node, etc)
               insertMutableAttr(name, attr, mptr);
               if (attr.isModule()) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/45902 by reverting https://github.com/pytorch/pytorch/pull/42457 

The test case introduced by https://github.com/pytorch/pytorch/pull/42457 was fixed by https://github.com/pytorch/pytorch/pull/46250, which I'm assuming is the real source of the bug.

In the future it would be good to provide repro's for freezing issues without including a quantization dependency; there was another another issue in freezing (see: https://github.com/pytorch/pytorch/pull/46054) who's root cause was the same quantization issue https://github.com/pytorch/pytorch/pull/46250. 