### PR TITLE
[quant] Remove prehook option

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -81,19 +81,12 @@ def _observer_forward_hook(self, input, output):
     """
     return self.activation_post_process(output)
 
-def _observer_forward_pre_hook(self, input):
-    ''' Forward pre hook that calls observer on the input (can be a tuple of values)
-    '''
-    self.activation_pre_process(*input)
-    # Returning nothing is Ok, Module._call_impl will intrepret this
-    # as the pre_hook making no changes to the input, as desired
-
 def register_activation_post_process_hook(module):
     assert hasattr(module, 'activation_post_process'), \
         'Expect activation_post_process attribut already attached to the module'
     return module.register_forward_hook(_observer_forward_hook)
 
-def add_observer_(module, qconfig_propagation_list=None, non_leaf_module_list=None, device=None, prehook=None):
+def add_observer_(module, qconfig_propagation_list=None, non_leaf_module_list=None, device=None):
     r"""Add observer for the leaf child of the module.
 
     This function insert observer module to all leaf child module that
@@ -146,31 +139,19 @@ def add_observer_(module, qconfig_propagation_list=None, non_leaf_module_list=No
                 child.activation_post_process = get_activation_post_process(child.qconfig, device)
         elif non_leaf_module_list is not None and type(child) in non_leaf_module_list:
             insert_activation_post_process(child)
-            # TODO: remove
-            if needs_observation(child):
-                # Attaching prehook
-                if prehook is not None:
-                    child.add_module('activation_pre_process', prehook())
-                    child.register_forward_pre_hook(_observer_forward_pre_hook)
         elif needs_observation(child) and is_custom_module_class(type(child)):
             observed_child = get_observed_custom_module_class(type(child)).from_float(child)
             mark_observed_custom_module(observed_child, type(child))
             setattr(module, name, observed_child)
             insert_activation_post_process(observed_child)
         else:
-            add_observer_(child, qconfig_propagation_list, non_leaf_module_list, device, prehook)
+            add_observer_(child, qconfig_propagation_list, non_leaf_module_list, device)
 
     # Insert observers only for leaf nodes, note that this observer is for
     # the output of the module, for input QuantStub will observe them
     if len(module._modules) == 0 and not isinstance(module, torch.nn.Sequential) \
        and type(module) in qconfig_propagation_list:
         insert_activation_post_process(module)
-        # TOOD: remove
-        if needs_observation(module):
-            # Attaching prehook
-            if prehook is not None:
-                module.add_module('activation_pre_process', prehook())
-                module.register_forward_pre_hook(_observer_forward_pre_hook)
 
 def get_unique_devices_(module):
     return {p.device for p in module.parameters()} | \
@@ -199,7 +180,7 @@ def add_quant_dequant(module):
     return module
 
 def prepare(model, inplace=False, allow_list=None,
-            observer_non_leaf_module_list=None, prehook=None):
+            observer_non_leaf_module_list=None):
     r"""Prepares a copy of the model for quantization calibration or quantization-aware training.
 
     Quantization configuration should be assigned preemptively
@@ -213,7 +194,6 @@ def prepare(model, inplace=False, allow_list=None,
         inplace: carry out model transformations in-place, the original module is mutated
         allow_list: list of quantizable modules
         observer_non_leaf_module_list: list of non-leaf modules we want to add observer
-        prehook: observer we want to add to forward_pre_hook
     """
     torch._C._log_api_usage_once("quantization_api.quantize.prepare")
     if not inplace:
@@ -230,7 +210,7 @@ def prepare(model, inplace=False, allow_list=None,
                       "passed correct configuration through `qconfig_dict` or "
                       "by assigning the `.qconfig` attribute directly on submodules")
 
-    add_observer_(model, qconfig_propagation_list, observer_non_leaf_module_list, prehook=prehook)
+    add_observer_(model, qconfig_propagation_list, observer_non_leaf_module_list)
     return model
 
 def _remove_qconfig(module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46298 [quant][graphmode][fx] Support non_traceable_module/module_class
* #46293 [quant][eagermode] Move custom_module registration to prepare/convert_custom_config_dict
* **#46292 [quant] Remove prehook option**
* #46251 [quant][graphmode][fx] Move custom_module_class config to prepare/convert_custom_config_dict

Summary:
since it is not needed

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D24290815](https://our.internmc.facebook.com/intern/diff/D24290815)