### PR TITLE
Add warnings on deprecated ProcesssGroup::Work functionality

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -974,15 +974,44 @@ Arguments:
 
   shared_ptr_class_<::c10d::ProcessGroup::Work>(module, "Work")
       .def("is_completed", &::c10d::ProcessGroup::Work::isCompleted)
-      .def("is_success", &::c10d::ProcessGroup::Work::isSuccess)
-      .def("exception", &::c10d::ProcessGroup::Work::exception)
-      .def("source_rank", &::c10d::ProcessGroup::Work::sourceRank)
+      .def("is_success",
+           [](::c10d::ProcessGroup::Work& work) -> bool {
+             TORCH_WARN_ONCE("ProcessGroup::Work::is_success API is being "
+                  "deprecated, please ping "
+                  "https://github.com/pytorch/pytorch/issues/46291 "
+                  "if you see this warning");
+               return work.isSuccess();
+           })
+      .def("exception",
+           [](::c10d::ProcessGroup::Work& work) -> std::exception_ptr {
+             TORCH_WARN_ONCE("ProcessGroup::Work::exception API is being "
+                  "deprecated, please ping "
+                  "https://github.com/pytorch/pytorch/issues/46291 "
+                  "if you see this warning");
+               return work.exception();
+           })
+      .def("source_rank",
+           [](::c10d::ProcessGroup::Work& work) -> int {
+             TORCH_WARN_ONCE("ProcessGroup::Work::source_rank API is being "
+                  "deprecated, please ping "
+                  "https://github.com/pytorch/pytorch/issues/46291 "
+                  "if you see this warning");
+               return work.sourceRank();
+           })
+      .def("_source_rank", &::c10d::ProcessGroup::Work::sourceRank)
       .def(
           "result",
           [](::c10d::ProcessGroup::Work& work) -> std::vector<at::Tensor> {
             return work.result();
           })
-      .def("synchronize", &::c10d::ProcessGroup::Work::synchronize)
+      .def("synchronize",
+          [](::c10d::ProcessGroup::Work& work) -> void {
+             TORCH_WARN_ONCE("ProcessGroup::Work::synchronize API is being "
+                  "deprecated, please ping "
+                  "https://github.com/pytorch/pytorch/issues/46291 "
+                  "if you see this warning");
+               work.synchronize();
+           })
       .def(
           "wait",
           &::c10d::ProcessGroup::Work::wait,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -756,7 +756,7 @@ def recv(tensor,
     if src is None:
         work = pg.recv_anysource([tensor], tag)
         work.wait()
-        src_rank = work.source_rank()
+        src_rank = work._source_rank()
         if group == GroupMember.WORLD:
             return src_rank
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46295 fix formatting
* **#46294 Add warnings on deprecated ProcesssGroup::Work functionality**
* #46220 Add warning on ProcessGroup and ProcessGroup::Work APIs

