### PR TITLE
Fix inplace check logic to be triggered when written to Tensor does not require gradients

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4731,49 +4731,6 @@ for shape in [(1,), ()]:
         with self.assertRaisesRegex(RuntimeError, leaf_grad_err):
             output.zero_()
 
-    def test_inplace_not_requires_grad(self):
-        class MyFn(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, inp):
-                return inp.view_as(inp)
-
-            @staticmethod
-            def backward(ctx, grad):
-                return grad
-
-        # Original Tensor does not require grad
-        a = torch.rand(1, 2)
-
-        # Tensor being written does require grad
-        b = torch.rand(1, requires_grad=True)
-
-        # Take an invalid view on a that should raise a warning
-        view_a = MyFn.apply(a)
-
-        with self.assertWarnsRegex(UserWarning, 'This view was created inside a custom Function'):
-            view_a += b
-
-        # Extra test of copy that is a manual implementation and could be easily
-        # forgotten when the codegen is updated
-        a = torch.rand(1, 2)
-        b = torch.rand(1, requires_grad=True)
-        view_a = MyFn.apply(a)
-
-        with self.assertWarnsRegex(UserWarning, 'This view was created inside a custom Function'):
-            view_a.copy_(b)
-
-        # Functions that should throw must properly throw
-        a = torch.rand(1, 2)
-        b = torch.rand(1, requires_grad=True)
-        view_a = a.unbind()[0]
-        with self.assertRaisesRegex(RuntimeError, 'output of a function that returns multiple views'):
-            view_a.copy_(b)
-
-        # Sanity check that views that should work still work
-        a = torch.rand(1, 2)
-        b = torch.rand(1, requires_grad=True)
-        a.select(1, 0).copy_(b)
-
     def test_grad_mode_restored_reentrant(self):
         class MyFunction(Function):
             @staticmethod

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4354,26 +4354,27 @@ for shape in [(1,), ()]:
         # Tensor being written does require grad
         b = torch.rand(1, requires_grad=True)
 
-        # Take an invalid view on a that should raise an error
+        # Take an invalid view on 'a' that should raise an error (warns during deprecation)
         view_a = MyFn.apply(a)
 
-        with self.assertRaisesRegex(RuntimeError, 'Output 0 of a function created in no_grad mode is a view'):
+        with self.assertWarnsRegex(UserWarning, "This view was created inside a custom Function"):
             view_a += b
 
         # Extra test for copy_ that is a manual implementation and could be easily
-        # forgotten when the codegen is updated
+        # forgotten when the codegen is updated (warns during deprecation)
         a = torch.rand(1, 2)
         b = torch.rand(1, requires_grad=True)
         view_a = MyFn.apply(a)
 
-        with self.assertRaisesRegex(RuntimeError, 'Output 0 of a function created in no_grad mode is a view'):
+        with self.assertWarnsRegex(UserWarning, "This view was created inside a custom Function"):
             view_a.copy_(b)
 
         # Functions that should throw must properly throw
         a = torch.rand(1, 2)
         b = torch.rand(1, requires_grad=True)
         view_a = a.unbind()[0]
-        with self.assertRaisesRegex(RuntimeError, 'Output 0 of a function created in no_grad mode is a view'):
+        with self.assertRaisesRegex(RuntimeError, "This view is the output of a function that returns "
+                                                  "multiple views."):
             view_a.copy_(b)
 
         # Sanity check that views that should work still work

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4731,6 +4731,49 @@ for shape in [(1,), ()]:
         with self.assertRaisesRegex(RuntimeError, leaf_grad_err):
             output.zero_()
 
+    def test_inplace_not_requires_grad(self):
+        class MyFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, inp):
+                return inp.view_as(inp)
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad
+
+        # Original Tensor does not require grad
+        a = torch.rand(1, 2)
+
+        # Tensor being written does require grad
+        b = torch.rand(1, requires_grad=True)
+
+        # Take an invalid view on a that should raise a warning
+        view_a = MyFn.apply(a)
+
+        with self.assertWarnsRegex(UserWarning, 'This view was created inside a custom Function'):
+            view_a += b
+
+        # Extra test of copy that is a manual implementation and could be easily
+        # forgotten when the codegen is updated
+        a = torch.rand(1, 2)
+        b = torch.rand(1, requires_grad=True)
+        view_a = MyFn.apply(a)
+
+        with self.assertWarnsRegex(UserWarning, 'This view was created inside a custom Function'):
+            view_a.copy_(b)
+
+        # Functions that should throw must properly throw
+        a = torch.rand(1, 2)
+        b = torch.rand(1, requires_grad=True)
+        view_a = a.unbind()[0]
+        with self.assertRaisesRegex(RuntimeError, 'output of a function that returns multiple views'):
+            view_a.copy_(b)
+
+        # Sanity check that views that should work still work
+        a = torch.rand(1, 2)
+        b = torch.rand(1, requires_grad=True)
+        a.select(1, 0).copy_(b)
+
     def test_grad_mode_restored_reentrant(self):
         class MyFunction(Function):
             @staticmethod

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1195,7 +1195,7 @@ def emit_body(declaration):
 
     def emit_any_requires_grad():
         return [SETUP_ANY_REQUIRES_GRAD.substitute(
-                    args_with_derivatives=[arg['name'] for arg in args_with_derivatives]),]
+            args_with_derivatives=[arg['name'] for arg in args_with_derivatives]), ]
 
     def emit_check_inplace():
         if not inplace:

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -274,9 +274,19 @@ DECLARE_GRAD_FN = CodeTemplate("""\
 std::shared_ptr<${op}> grad_fn;
 """)
 
+SETUP_ANY_REQUIRES_GRAD = CodeTemplate("""\
+auto _any_requires_grad = compute_requires_grad( ${args_with_derivatives} );
+""")
+
 SETUP_DERIVATIVE = CodeTemplate("""\
-if (compute_requires_grad( ${args_with_derivatives} )) {
+if (_any_requires_grad) {
   ${setup}
+}
+""")
+
+SETUP_NONE_REQUIRES_GRAD = CodeTemplate("""\
+if (compute_requires_grad( ${args_to_check} )) {
+  throw_error_out_requires_grad("${base_name}");
 }
 """)
 
@@ -930,22 +940,21 @@ def emit_body(declaration):
         return setup
 
     def setup_derivative(differentiable_inputs):
-
         env = {}
         env['args_with_derivatives'] = [arg['name'] for arg in args_with_derivatives]
         env['op'] = func['op'] if func is not None else 'NotImplemented'
         env['op_ctor'] = '' if func is not None else '"{}"'.format(declaration['api_name'])
 
         if is_out_fn:
-            setup = ['throw_error_out_requires_grad("{}");'.format(base_name)]
+            # For out functions, ensure that no input or output requires grad
             body = []
             body.append(DECLARE_GRAD_FN.substitute(op='Node'))
-            body.append(SETUP_DERIVATIVE.substitute(
-                setup=setup,
-                args_with_derivatives=[arg['name'] for arg in differentiable_inputs]))
-            body.append(SETUP_DERIVATIVE.substitute(
-                setup=setup,
-                args_with_derivatives=[arg['name'] for arg in differentiable_outputs]))
+            body.append(SETUP_NONE_REQUIRES_GRAD.substitute(
+                base_name=base_name,
+                args_to_check=[arg['name'] for arg in differentiable_inputs]))
+            body.append(SETUP_NONE_REQUIRES_GRAD.substitute(
+                base_name=base_name,
+                args_to_check=[arg['name'] for arg in differentiable_outputs]))
             return body
 
         setup = []
@@ -955,7 +964,7 @@ def emit_body(declaration):
         body = []
         body.extend(emit_check_no_requires_grad(differentiable_inputs, args_with_derivatives))
         body.append(DECLARE_GRAD_FN.substitute(env))
-        body.append(SETUP_DERIVATIVE.substitute(env, setup=setup))
+        body.append(SETUP_DERIVATIVE.substitute(setup=setup))
         return body
 
     def emit_check_if_in_complex_autograd_allowlist():
@@ -1184,10 +1193,14 @@ def emit_body(declaration):
             return CONDITIONAL.substitute(cond='grad_fn', statements=stmts)
         return ''
 
+    def emit_any_requires_grad():
+        return [SETUP_ANY_REQUIRES_GRAD.substitute(
+                    args_with_derivatives=[arg['name'] for arg in args_with_derivatives]),]
+
     def emit_check_inplace():
         if not inplace:
             return []
-        return ['check_inplace({});'.format(arg['name']) for arg in differentiable_outputs]
+        return ['check_inplace({}, _any_requires_grad);'.format(arg['name']) for arg in differentiable_outputs]
 
     def emit_increment_version():
         if not modifies_arguments:
@@ -1203,6 +1216,7 @@ def emit_body(declaration):
 
     body.extend(unpack_args(env, declaration))
     if requires_derivative:
+        body.extend(emit_any_requires_grad())
         body.extend(emit_check_inplace())
         body.extend(setup_derivative(differentiable_inputs))
     body.append(declare_returned_variables)

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -201,10 +201,10 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
   // it automatically
   auto& self_ = unpack(self, "self", 0);
   auto& src_ = unpack(src, "src", 1);
-  check_inplace(self);
   std::shared_ptr<CopyBackwards> grad_fn;
   auto requires_grad = compute_requires_grad(self, src);
   requires_grad &= isDifferentiableType(self.scalar_type());
+  check_inplace(self, requires_grad);
   if (requires_grad) {
     grad_fn = std::make_shared<CopyBackwards>();
     grad_fn->set_next_edges(collect_next_edges(self, src));

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -53,7 +53,7 @@ inline void check_inplace(const Tensor& tensor, bool requires_grad) {
       auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(tensor));
       // This can throw or warn
       handle_view_on_rebase(diff_view_meta);
-      if (tensor._base().is_leaf()) {
+      if (tensor.requires_grad() && tensor._base().is_leaf()) {
           AT_ERROR(
             "a view of a leaf Variable that requires grad is being used in an in-place operation.");
       }

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -39,12 +39,18 @@ using namespace torch::autograd::generated;
 
 namespace torch { namespace autograd {
 
+// The requires_grad argument is used to know if the inplace operation needs
+// gradient to be setup for it.
+// In particular, we can have tensor.requires_grad() != requires_grad when writing
+// a Tensor that requires gradients inplace into a Tensor that does not require gradients:
+// a = torch.rand(2)
+// b = torch.rand(2, requires_grad=True)
+// a.copy_(b)
 inline void check_inplace(const Tensor& tensor, bool requires_grad) {
-  auto& var = static_cast<const Variable&>(tensor);
   if (requires_grad && GradMode::is_enabled()) {
-    if (var.is_view()) {
+    if (tensor.is_view()) {
       // NB: is_view() ==> get_autograd_meta()
-      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(var));
+      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(tensor));
       // This can throw or warn
       handle_view_on_rebase(diff_view_meta);
       if (tensor._base().is_leaf()) {
@@ -52,7 +58,7 @@ inline void check_inplace(const Tensor& tensor, bool requires_grad) {
             "a view of a leaf Variable that requires grad is being used in an in-place operation.");
       }
     }
-    if (tensor.requires_grad() && var.is_leaf()) {
+    if (tensor.requires_grad() && tensor.is_leaf()) {
       AT_ERROR(
         "a leaf Variable that requires grad is being used in an in-place operation.");
     }

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -39,9 +39,9 @@ using namespace torch::autograd::generated;
 
 namespace torch { namespace autograd {
 
-inline void check_inplace(const Tensor& tensor) {
+inline void check_inplace(const Tensor& tensor, bool requires_grad) {
   auto& var = static_cast<const Variable&>(tensor);
-  if (var.requires_grad() && GradMode::is_enabled()) {
+  if (requires_grad && GradMode::is_enabled()) {
     if (var.is_view()) {
       // NB: is_view() ==> get_autograd_meta()
       auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(var));
@@ -52,16 +52,16 @@ inline void check_inplace(const Tensor& tensor) {
             "a view of a leaf Variable that requires grad is being used in an in-place operation.");
       }
     }
-    if (var.is_leaf()) {
+    if (tensor.requires_grad() && var.is_leaf()) {
       AT_ERROR(
         "a leaf Variable that requires grad is being used in an in-place operation.");
     }
   }
 }
 
-inline void check_inplace(const TensorList tensors) {
+inline void check_inplace(const TensorList tensors, bool requires_grad) {
   for (const auto& tensor : tensors) {
-    check_inplace(tensor);
+    check_inplace(tensor, requires_grad);
   }
 }
 

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -122,12 +122,13 @@ variable_list Gather::apply(variable_list&& inputs) {
   // Disable the autograd during the actual computation
   // torch::cuda::gather does not return a view or change things inplace
   // so no need for extra logic here
+  at::Tensor variable;
   {
     at::AutoNonVariableTypeMode non_var_type_mode(true);
     // This is special logic for torch::cuda::gather!
     const auto destination_index =
         destination_device_.is_cpu() ? -1 : destination_device_.index();
-    auto variable = torch::cuda::gather(tensors, dim_, destination_index);
+    variable = torch::cuda::gather(tensors, dim_, destination_index);
   }
   if (grad_fn) {
     set_history(variable, grad_fn);

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -119,10 +119,16 @@ variable_list Gather::apply(variable_list&& inputs) {
     }
   }
 
-  // This is special logic for torch::cuda::gather!
-  const auto destination_index =
-      destination_device_.is_cpu() ? -1 : destination_device_.index();
-  auto variable = torch::cuda::gather(tensors, dim_, destination_index);
+  // Disable the autograd during the actual computation
+  // torch::cuda::gather does not return a view or change things inplace
+  // so no need for extra logic here
+  {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    // This is special logic for torch::cuda::gather!
+    const auto destination_index =
+        destination_device_.is_cpu() ? -1 : destination_device_.index();
+    auto variable = torch::cuda::gather(tensors, dim_, destination_index);
+  }
   if (grad_fn) {
     set_history(variable, grad_fn);
   }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -483,7 +483,7 @@ void handle_view_on_rebase(DifferentiableViewMeta* diff_view_meta, bool indirect
         TORCH_INTERNAL_ASSERT(false, "Invalid CreationMeta state");
       }
 
-      if (!indirect && !grad_fn) {
+      if (!indirect && !grad_fn && diff_view_meta->requires_grad()) {
         // This view is (wrongly) detected as a leaf that requires grad and would raise the surprising: "a leaf Variable that
         // requires grad is being used in an in-place operation." after the warning. So we make the warning an error directly.
         TORCH_CHECK(false, msg);

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -86,16 +86,7 @@ namespace impl {
         // and either throw an error or clear the warning
         // Temporary error message as a full fix is too risky for now
         // Should be an internal assert again
-        if (diff_view_meta->creation_meta != CreationMeta::DEFAULT) {
-          auto grad_fn = diff_view_meta->grad_fn_.get();
-          auto grad_fn_name = grad_fn? grad_fn->name() : "a function created in no_grad mode";
-          TORCH_CHECK(false, "Output ", diff_view_meta->output_nr_, " of ", grad_fn_name, " is a view and "
-                      "is being modified inplace but this inplace operation is not allowed. You should "
-                      "either replace it by an out of place operation or do a .clone() of the Tensor "
-                      "before modifying it inplace. Note that this can happen when using DataParallel or "
-                      "DistributedDataParallel, which can send views of the original input to the forward "
-                      "method of the model.");
-        }
+        TORCH_INTERNAL_ASSERT(diff_view_meta->creation_meta == CreationMeta::DEFAULT);
         TORCH_INTERNAL_ASSERT(gradient_edge.input_nr == 0);
         TORCH_INTERNAL_ASSERT(gradient_edge.function);
         TORCH_CHECK(

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -485,7 +485,8 @@ void handle_view_on_rebase(DifferentiableViewMeta* diff_view_meta, bool indirect
 
       if (!indirect && !grad_fn && diff_view_meta->requires_grad()) {
         // This view is (wrongly) detected as a leaf that requires grad and would raise the surprising: "a leaf Variable that
-        // requires grad is being used in an in-place operation." after the warning. So we make the warning an error directly.
+        // requires grad is being used in an in-place operation." after the warning from the `check_inplace` function in
+        // VariabbleTypeUtils.h. So we make the warning an error directly.
         TORCH_CHECK(false, msg);
       } else {
         TORCH_WARN(msg);


### PR DESCRIPTION
Fix #46242

This ensures that the `check_inplace()` run the proper checks even if the Tensor that is being modified inplace does not requires gradient. As the Tensor written into it might require gradient and will make this inplace modification actually differentiable.
This contains:
- Codegen changes to tell `check_inplace()` if the inplace will be differentiable
- Changes in `handle_view_on_rebase` to work properly even when called for an input that does not require gradients (which was assumed to be true before)
- Corresponding tests (both warnings and the error raise internal assert errors without this fix)