### PR TITLE
Add named tuple's error message and workaround for RET failure

### DIFF
--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -117,6 +117,21 @@ std::pair<IValue, c10::optional<IValue>> getFunctionTuple(
         TORCH_INTERNAL_ASSERT(
             false, "Unsupported node kind on CALL opcode for mobile");
       }
+    } else if (ins.op == RET) {
+      auto node = code.instructions_source()[i];
+      for (const auto input : node->inputs()) {
+        auto input_type = input->type();
+        if (input_type->kind() == TypeKind::TupleType) {
+          if (auto name_typed_input = input_type->cast<at::NamedType>()) {
+            TORCH_CHECK(
+                !name_typed_input->name(),
+                "A named tuple type is not supported in mobile module. ",
+                "Workaround: instead of using a named tuple type's fields, ",
+                "use a dictionary type's key-value pair itmes or ",
+                "a pytorch class (class Foo(torch.nn.Module))'s attributes.'");
+          }
+        }
+      }
     } else {
       TORCH_CHECK(
           ins.op != CREATE_OBJECT,


### PR DESCRIPTION
Summary:
Added the named tuple's error messages & workarounds when it returns from a function of a class in Pytorch Mobile.

To identify the error cases (returning NamedTuple type), I used the following coditions:
1) ins.op == RET  (for returing)
2) type->kind() == TypeKind::TupleType  (for pruning non-tuple types)
3) type->cast<TupleType>().name()  (for pruning Tuple type)
  - I could use the type's str (str() or repr_str()) directly, but I used whether it has the "name" attribute. Please give the comment for this.

[Information of Tuple and NamedTuple types]
1. Tuple
type->str(): (int, int)
type->repr_str(): Tuple[int, int]
type->kind():  TypeKind::TupleType         # different with other types
type()->cast<NamedType>(): True
type()->cast<NamedType>()>name(): False    # different with NamedTuple

2. NamedTuple
type->str():  __torch__.myNamedTuple
type->repr_str(): __torch__.myNamedTuple
type->kind():  TypeKind::TupleType         # different with other types
type()->cast<NamedType>(): True
type->cast<TupleType>().name() = True      # different with Tuple

(From the next diff, I will handle the other error cases: 1) returning List<module class>, Dict<module class> and 2) accessing Module class's member functions)

Test Plan:
[Added test results]
  buck test mode/dev caffe2/test:mobile -- 'test_unsupported_return'

  Summary
    Pass: 2
    ListingSuccess: 1
    Finished test run: https://our.intern.facebook.com/intern/testinfra/testrun/7036874440497926

[Whole test results]
  buck test mode/dev caffe2/test:mobile -- 'test'

  Summary
    Pass: 11
    ListingSuccess: 1
    Finished test run: https://our.intern.facebook.com/intern/testinfra/testrun/4503599664074084

Reviewed By: iseeyuan

Differential Revision: D24291962

