### PR TITLE
Fixing pow for special case between cuda tensors and cpu tensors and reframed test cases a tiny bit

### DIFF
--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -11,7 +11,8 @@ DEFINE_DISPATCH(pow_tensor_tensor_stub);
 DEFINE_DISPATCH(pow_tensor_scalar_stub);
 
 Tensor& pow_out(Tensor& result, const Tensor& base, const Tensor& exp) {
-  if (exp.dim() == 0 && base.dim() != 0) {
+  if (exp.dim() == 0 && exp.device().type() == DeviceType::CPU
+    && base.device().type() == DeviceType::CUDA) {
     return native::pow_out(result, base, exp.item());
   }
   auto iter = TensorIterator::binary_op(result, base, exp);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13853,10 +13853,18 @@ class TestTorchDeviceType(TestCase):
     @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
     def test_cuda_tensor_pow_scalar_tensor(self, device):
         cuda_tensors = [torch.randn((3, 3), device=device), torch.tensor(3.0, device=device)]
-        scalar_tensors = [torch.tensor(5.0), torch.tensor(-3), torch.tensor(1)]
-        for base in cuda_tensors:
-            for exp in scalar_tensors:
-                self._test_pow(base, exp)
+        scalar_tensors = [torch.tensor(5.0, device='cpu'), torch.tensor(-3), torch.tensor(1)]
+        for base, exp in product(cuda_tensors, scalar_tensors):
+            self._test_pow(base, exp)
+
+    @onlyCUDA
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_cpu_tensor_pow_cuda_scalar_tensor(self, device):
+        cpu_tensors = [torch.randn((3, 3), device='cpu'), torch.tensor(3.0, device='cpu')]
+        cuda_tensors = [torch.tensor(5.0, device='cuda'), torch.tensor(-3, device='cuda')]
+        for base, exp in product(cpu_tensors, cuda_tensors):
+            regex = 'Expected all tensors to be on the same device, but found at least two devices, cuda.* and cpu!'
+            self.assertRaisesRegex(RuntimeError, regex, torch.pow, base, exp)
 
     @onlyOnCPUAndCUDA
     @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5397,8 +5397,8 @@ class TestTorchDeviceType(TestCase):
             return value
 
         try:
-            expected = torch.from_numpy(
-                np.power(to_np(base), to_np(np_exponent)))
+            np_res = np.power(to_np(base), to_np(np_exponent))
+            expected = torch.from_numpy(np_res) if isinstance(np_res, np.ndarray) else torch.tensor(np_res, dtype=base.dtype)
         except ValueError as e:
             err_msg = "Integers to negative integer powers are not allowed."
             self.assertEqual(str(e), err_msg)
@@ -13852,10 +13852,11 @@ class TestTorchDeviceType(TestCase):
     @onlyCUDA
     @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
     def test_cuda_tensor_pow_scalar_tensor(self, device):
-        cuda_tensor = torch.randn((3, 3), device=device)
-        scalar_tensors = [torch.tensor(5), torch.tensor(-3), torch.tensor(1)]
-        for exp in scalar_tensors:
-            self._test_pow(cuda_tensor, exp)
+        cuda_tensors = [torch.randn((3, 3), device=device), torch.tensor(3.0, device=device)]
+        scalar_tensors = [torch.tensor(5.0), torch.tensor(-3), torch.tensor(1)]
+        for base in cuda_tensors:
+            for exp in scalar_tensors:
+                self._test_pow(base, exp)
 
     @onlyOnCPUAndCUDA
     @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')


### PR DESCRIPTION
Fixes #46037

I now isolated the special case to be only between cuda tensor bases and cpu tensor exponents. My previous fix was not a complete fix--it fixed some stuff but broke others. The current fix is a more complete fix:
```
In [1]: import torch                                                                                                                                                                                                                     
In [2]: a=torch.randn(3)                                                                                                                                                                                                                 
In [3]: b=torch.tensor(2, device="cuda")                                                                                                                                                                                                 
In [4]: torch.pow(a,b) #should not work and throws exception now!         
                                                                                                                                                                              
In [5]: a=torch.tensor(3, device="cuda")                                                                                                                                                                                                 
In [6]: b=torch.tensor(2)                                                                                                                                                                                                                
In [7]: torch.pow(a,b) #should work, and now does

In [8]: a=torch.randn(3, device="cuda")                                                                                                                                                                                                  
In [9]: torch.pow(a,b) # yeah, that one is fixed and still works
```

To add a test case to reflect the change, I had to modify the existing setup a little bit. I think it is an improvement but would appreciate any tips on how to make it better!
