### PR TITLE
[fx] make sure args/kwargs are immutable

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -9,6 +9,8 @@ from torch.fx import symbolic_trace, Proxy, Node, GraphModule, Tracer, Graph
 from torch.fx.experimental import GraphManipulation
 from torch.fx.experimental import shape_prop
 from torch.fx.experimental.subgraph_creation_example import split_module
+from torch.fx.immutable_collections import immutable_dict, immutable_list
+from copy import deepcopy
 
 from torch.fx.proxy import TraceError
 
@@ -842,7 +844,7 @@ class TestFX(JitTestCase):
         to_erase = []
         for node in rn18_traced.graph.nodes:
             if node.op == 'call_function' and node.target in [torch.relu, torch.nn.functional.relu]:
-                kwargs = node.kwargs
+                kwargs = node.kwargs.copy()
                 # Neg doesn't have in-place
                 kwargs.pop('inplace')
                 with rn18_traced.graph.inserting_before(node):
@@ -896,6 +898,13 @@ class TestFX(JitTestCase):
             if node.target in [operator.add, torch.relu]:
                 with self.assertRaisesRegex(RuntimeError, 'but it still had .* users in the graph'):
                     traced.graph.erase_node(node)
+
+    def test_copy_it(self):
+        d = immutable_dict([(3, 4), (5, 6)])
+        l = immutable_list([(3, 4), (5, 6)])
+
+        self.assertEqual(d, deepcopy(d))
+        self.assertEqual(l, deepcopy(l))
 
     def test_find_uses(self):
         graph = torch.fx.Graph()

--- a/torch/fx/immutable_collections.py
+++ b/torch/fx/immutable_collections.py
@@ -1,0 +1,16 @@
+def _no_mutation(self, *args, **kwargs):
+    raise NotImplementedError(f"'{type(self).__name__}' object does not support mutation")
+
+def _create_immutable_container(base, mutable_functions):
+    container = type('immutable_' + base.__name__, (base,), {})
+    for attr in mutable_functions:
+        setattr(container, attr, _no_mutation)
+    return container
+
+immutable_list = _create_immutable_container(list,
+                                             ['__delitem__', '__iadd__', '__imul__', '__setitem__', 'append',
+                                              'clear', 'extend', 'insert', 'pop', 'remove'])
+immutable_list.__reduce__ = lambda self: (immutable_list, (tuple(iter(self)),))
+
+immutable_dict = _create_immutable_container(dict, ['__delitem__', '__setitem__', 'clear', 'pop', 'popitem', 'update'])
+immutable_dict.__reduce__ = lambda self: (immutable_dict, (iter(self.items()),))

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -1,5 +1,6 @@
 # Nodes represent a definition of a value in our graph of operators.
-from typing import TYPE_CHECKING, Union, Callable, Any, Set, Tuple, List, Optional, Dict
+from typing import TYPE_CHECKING, Union, Callable, Any, Tuple, List, Optional, Dict
+from .immutable_collections import immutable_dict, immutable_list
 import torch
 
 if TYPE_CHECKING:
@@ -31,9 +32,10 @@ class Node:
             assert isinstance(target, str)
         self.target = target  # for method/module/function, the name of the method/module/function/attr
         # being invoked, e.g add, layer1, or torch.add
-        self._args : Tuple[Argument, ...] = ()
-        self._kwargs : Dict[str, Argument] = {}
-        self.args, self.kwargs = args, kwargs
+
+        self._uses : Dict[Node, None] = {}
+        self._update_args_kwargs(map_arg(args, lambda x: x), map_arg(kwargs, lambda x: x))  # type: ignore
+
         # All of the nodes that use the value produced by this Node
         # Note one user may correspond to several uses, e.g. the node fo `x + x`
         # would appear once here, but represents two uses.
@@ -98,7 +100,7 @@ class Node:
 
     @args.setter
     def args(self, a : Tuple[Argument, ...]):
-        self._update_args_kwargs(new_args=a, new_kwargs=self._kwargs)
+        self._update_args_kwargs(map_arg(a, lambda x: x), self._kwargs)  # type: ignore
 
     @property
     def kwargs(self) -> Dict[str, Argument]:
@@ -106,23 +108,21 @@ class Node:
 
     @kwargs.setter
     def kwargs(self, k : Dict[str, Argument]):
-        self._update_args_kwargs(new_args=self._args, new_kwargs=k)
+        self._update_args_kwargs(self._args, map_arg(k, lambda x: x))  # type: ignore
 
     def _update_args_kwargs(self, new_args : Tuple[Argument, ...], new_kwargs : Dict[str, Argument]):
-        old_defs = self._collect_all_defs()
         self._args = new_args
         self._kwargs = new_kwargs
-        new_defs = self._collect_all_defs()
-        for to_remove in old_defs - new_defs:
-            to_remove.users.pop(self)
-        for to_add in new_defs - old_defs:
-            to_add.users.setdefault(self)
 
-    def _collect_all_defs(self) -> Set['Node']:
-        defs = set()
-        map_arg(self._args, lambda n: defs.add(n))
-        map_arg(self._kwargs, lambda n: defs.add(n))
-        return defs
+        for old_use in self._uses.keys():
+            old_use.users.pop(self)
+
+        self._uses = {}
+        map_arg(self._args, lambda n: self._uses.setdefault(n))
+        map_arg(self._kwargs, lambda n: self._uses.setdefault(n))
+
+        for new_use in self._uses.keys():
+            new_use.users.setdefault(self)
 
     def __repr__(self) -> str:
         return self.name
@@ -152,10 +152,12 @@ class Node:
 
 def map_arg(a: Argument, fn: Callable[[Node], Argument]) -> Argument:
     """ apply fn to each Node appearing arg. arg may be a list, tuple, slice, or dict with string keys. """
-    if isinstance(a, (tuple, list)):
-        return type(a)(map_arg(elem, fn) for elem in a)
+    if isinstance(a, tuple):
+        return tuple(map_arg(elem, fn) for elem in a)
+    if isinstance(a, list):
+        return immutable_list(map_arg(elem, fn) for elem in a)
     elif isinstance(a, dict):
-        return {k: map_arg(v, fn) for k, v in a.items()}
+        return immutable_dict((k, map_arg(v, fn)) for k, v in a.items())
     elif isinstance(a, slice):
         return slice(map_arg(a.start, fn), map_arg(a.stop, fn), map_arg(a.step, fn))
     elif isinstance(a, Node):

--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -88,8 +88,7 @@ class Add(QuantizeHandler):
                 op = torch.ops.quantized.add_relu
             else:
                 op = torch.ops.quantized.add
-            kwargs = self.add_node.kwargs
-            kwargs.update({'scale': scale, 'zero_point': zero_point})
+            kwargs = {**self.add_node.kwargs, 'scale': scale, 'zero_point': zero_point}
             return quantizer.quantized_graph.create_node(
                 'call_function', op, load_arg(quantized=True)(self.add_node.args), kwargs)
 
@@ -126,8 +125,7 @@ class Mul(QuantizeHandler):
                 op = torch.ops.quantized.mul_relu
             else:
                 op = torch.ops.quantized.mul
-            kwargs = self.mul_node.kwargs
-            kwargs.update({'scale': scale, 'zero_point': zero_point})
+            kwargs = {**self.mul_node.kwargs, 'scale': scale, 'zero_point': zero_point}
             return quantizer.quantized_graph.create_node('call_function', op, load_arg(quantized=True)(self.mul_node.args), kwargs)
 
 @register_quant_pattern(torch.cat)
@@ -139,8 +137,7 @@ class Cat(QuantizeHandler):
         scale, zero_point = activation_post_process.calculate_qparams()
         scale = float(scale)
         zero_point = int(zero_point)
-        kwargs = load_arg(quantized=False)(node.kwargs)
-        kwargs.update({'scale': scale, 'zero_point': zero_point})
+        kwargs = {**load_arg(quantized=False)(node.kwargs), 'scale': scale, 'zero_point': zero_point}
         return quantizer.quantized_graph.create_node(
             'call_function', torch.ops.quantized.cat, load_arg(quantized=[0])(node.args), kwargs)
 
@@ -322,7 +319,7 @@ class LinearReLUQuantizeHandler(QuantizeHandler):
                 linear_weight = load_arg(quantized=weight_quantized)(self.linear_node.args[1])
 
                 # get other arguments
-                kwargs = load_arg(quantized=False)(self.linear_node.kwargs)
+                kwargs = {**load_arg(quantized=False)(self.linear_node.kwargs)}
                 # pack weight
                 bias = None
                 # all args after bias, including bias
@@ -429,8 +426,7 @@ class DefaultNode(QuantizeHandler):
 
             quantized_op = get_quantized_operator(node.target)
             args = load_arg(quantized=[0])(node.args)
-            kwargs = load_arg(quantized=False)(node.kwargs)
-            kwargs.update({'output_scale': scale, 'output_zero_point': zero_point})
+            kwargs = {**load_arg(quantized=False)(node.kwargs), 'output_scale': scale, 'output_zero_point': zero_point}
             if quantized_op in ARGS_TO_SKIP:
                 args_to_skip = ARGS_TO_SKIP[quantized_op]
                 for arg in args_to_skip:
@@ -449,8 +445,7 @@ class ELU(QuantizeHandler):
         zero_point = int(zero_point)
         quantized_op = get_quantized_operator(node.target)
         args = load_arg(quantized=[0])(node.args)
-        kwargs = load_arg(quantized=False)(node.kwargs)
-        kwargs.update({'output_scale': scale, 'output_zero_point': zero_point})
+        kwargs = {**load_arg(quantized=False)(node.kwargs), 'output_scale': scale, 'output_zero_point': zero_point}
         kwargs.pop('inplace')
         return quantizer.quantized_graph.create_node(
             'call_function', quantized_op, args, kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #45193 [fx] allow custom behavior for args, kwargs, and bool
* **#46325 [fx] make sure args/kwargs are immutable**

Otherwise, mutating them would make the uses/users lists inaccurate.
You can still mutate the node by assigning a new value to .args or .kwargs

Differential Revision: [D24308672](https://our.internmc.facebook.com/intern/diff/D24308672)