### PR TITLE
Update COMPILE_TIME_MAX_DEVICE_TYPES to 12

### DIFF
--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -29,7 +29,7 @@ enum class DeviceType : int16_t {
   //  - Change the implementations of DeviceTypeName and isValidDeviceType
   //    in DeviceType.cpp
   //  - Change the number below
-  COMPILE_TIME_MAX_DEVICE_TYPES = 11,
+  COMPILE_TIME_MAX_DEVICE_TYPES = 12,
   ONLY_FOR_TEST = 20901, // This device type is only for test.
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46327 Update COMPILE_TIME_MAX_DEVICE_TYPES to 12**

### Summary

Update the COMPILE_TIME_MAX_DEVICE_TYPES to 12 as we landed a new Metal backend. Issue number: https://github.com/pytorch/pytorch/issues/46310

### Test Plan

- Circle CI

Differential Revision: [D24309189](https://our.internmc.facebook.com/intern/diff/D24309189)