### PR TITLE
Use unsafe_split/chunk to preserve same behavior as 1.6

### DIFF
--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -322,8 +322,8 @@ std::vector<at::Tensor> scatter(
   }
   dim = at::maybe_wrap_dim(dim, tensor);
   std::vector<at::Tensor> chunks = chunk_sizes
-      ? tensor.split_with_sizes(/*split_sizes=*/*chunk_sizes, /*dim=*/dim)
-      : tensor.chunk(/*chunks=*/devices.size(), /*dim=*/dim);
+      ? tensor.unsafe_split_with_sizes(/*split_sizes=*/*chunk_sizes, /*dim=*/dim)
+      : tensor.unsafe_chunk(/*chunks=*/devices.size(), /*dim=*/dim);
   at::cuda::OptionalCUDAStreamGuard cuda_guard;
   for (size_t i = 0; i < chunks.size(); ++i) {
     const auto device_index = static_cast<int16_t>(devices[i]);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46361 Use unsafe_split/chunk to preserve same behavior as 1.6**

https://github.com/pytorch/pytorch/pull/41567 changed the behavior
of chunk and split, and renamed the previous version as unsafe_*.
As a result, comm.scatter outputs become views, which leads to
the regression reported in https://github.com/pytorch/pytorch/issues/46242

This commit revert to use the previous versions of split and chunk.

Differential Revision: [D24320603](https://our.internmc.facebook.com/intern/diff/D24320603)