### PR TITLE
Distribute GPUs in round robin mode for distributed_test

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -362,16 +362,14 @@ class DistributedTest:
             """
             nGPUs = torch.cuda.device_count()
             world_size = dist.get_world_size()
-            visible_devices = range(nGPUs)
 
             if BACKEND == "nccl":
                 apply_hack_for_nccl()
 
             nGPUs_per_process = nGPUs // world_size
             rank_to_GPU = {
-                i: list(
-                    visible_devices[i * nGPUs_per_process: (i + 1) * nGPUs_per_process]
-                )
+                # Each rank has to get the GPU with the index equal to its rank
+                i: [i + gpu_num * world_size for gpu_num in range(nGPUs_per_process)]
                 for i in range(world_size)
             }
             return rank_to_GPU


### PR DESCRIPTION
The ProcessGroupNCCL::barrier implementation assumes that when 1 GPU/rank is used the GPU-Index equals the rank. Due to NCCL communicator reuse this then leads to rank 0 using the (kinda) temporary communicator while the other processes might use other GPUs leading to them trying to create a new communicator and waiting for rank 0 until that creates a new (potentially unrelated) one.

See #46248 for details

**Note that this is a workaround only!** The real issue is much harder to solve and might affect more. See https://github.com/pytorch/pytorch/issues/46248#issuecomment-708510746