### PR TITLE
install lcov in Docker image if coverage is specified

### DIFF
--- a/.circleci/docker/common/install_lcov.sh
+++ b/.circleci/docker/common/install_lcov.sh
@@ -1,0 +1,4 @@
+set -ex
+
+sudo apt-get -qq update
+sudo apt-get -qq install lcov

--- a/.circleci/docker/common/install_lcov.sh
+++ b/.circleci/docker/common/install_lcov.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -ex
 
 sudo apt-get -qq update

--- a/.circleci/docker/ubuntu/Dockerfile
+++ b/.circleci/docker/ubuntu/Dockerfile
@@ -123,6 +123,10 @@ RUN bash ./install_jni.sh && rm install_jni.sh
 ARG BUILD_ENVIRONMENT
 ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}
 
+# Install lcov if coverage is specified
+ADD ./common/install_lcov.sh install_lcov.sh
+RUN if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then bash ./install_lcov.sh; fi
+
 # Install LLVM dev version (Defined in the pytorch/builder github repository)
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
 

--- a/.circleci/docker/ubuntu/Dockerfile
+++ b/.circleci/docker/ubuntu/Dockerfile
@@ -44,6 +44,10 @@ ARG GCC_VERSION
 ADD ./common/install_gcc.sh install_gcc.sh
 RUN bash ./install_gcc.sh && rm install_gcc.sh
 
+# Install lcov for C++ code coverage
+ADD ./common/install_lcov.sh install_lcov.sh
+RUN  bash ./install_lcov.sh && rm install_lcov.sh
+
 # Install non-standard Python versions (via Travis binaries)
 ARG TRAVIS_PYTHON_VERSION
 ARG TRAVIS_DL_URL_PREFIX
@@ -122,10 +126,6 @@ RUN bash ./install_jni.sh && rm install_jni.sh
 # Include BUILD_ENVIRONMENT environment variable in image
 ARG BUILD_ENVIRONMENT
 ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}
-
-# Install lcov if coverage is specified
-ADD ./common/install_lcov.sh install_lcov.sh
-RUN if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then bash ./install_lcov.sh; fi
 
 # Install LLVM dev version (Defined in the pytorch/builder github repository)
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm


### PR DESCRIPTION
As a step to enable C++ code coverage in PyTorch, we want to install `lcov` in the Docker image so that lcov is available to use later on in the process. `lcov` is now installed in all non-rocm non-cuda ubuntu images.
