### PR TITLE
[NNC] IRSimplifier rules for Compare and Mod

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -194,6 +194,7 @@ namespace jit {
   _(SimplifyMuls)                                   \
   _(SimplifySubs)                                   \
   _(SimplifyDiv)                                    \
+  _(SimplifyMod)                                    \
   _(SimplifyMultiOp)                                \
   _(SimplifyManyOps)                                \
   _(SimplifyFactorization)                          \
@@ -214,6 +215,8 @@ namespace jit {
   _(SimplifyConstantBranches)                       \
   _(SimplifyConstantCond)                           \
   _(SimplifyEliminateEmptyCond)                     \
+  _(SimplifyConstantComparisons)                    \
+  _(SimplifySymbolicComparisons)                    \
   _(SimplifyEliminateZeroLengthFor)                 \
   _(SimplifyOneLoopFor)                             \
   _(SimplifyForWontLoseLoopOptions)                 \

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -984,15 +984,100 @@ const Expr* PolynomialTransformer::mutate(const Div* v) {
   }
 
   // If numberator and denominator are equal the result is 1.
-  if (hasher_.hash(lhs_new) == hasher_.hash(rhs_new)) {
-    return getImmediateByType(v->dtype(), 1);
-  }
+  // Unless the demoninator could be zero.
+  // if (hasher_.hash(lhs_new) == hasher_.hash(rhs_new)) {
+  //   return getImmediateByType(v->dtype(), 1);
+  // }
 
   if (auto ret = factorizeDivision(lhs_new, rhs_new)) {
-    return ret;
+    return ret->accept_mutator(this);
   }
 
   return new Div(lhs_new, rhs_new);
+}
+
+const Expr* PolynomialTransformer::mutate(const Mod* v) {
+  const Expr* lhs_new = v->lhs()->accept_mutator(this);
+  const Expr* rhs_new = v->rhs()->accept_mutator(this);
+
+  // Constant Folding.
+  if (lhs_new->isConstant() && rhs_new->isConstant()) {
+    return evaluateOp(new Mod(lhs_new, rhs_new));
+  }
+
+  // 0 % x => 0.
+  if (lhs_new->isConstant() && immediateEquals(lhs_new, 0)) {
+    return lhs_new;
+  }
+
+  // x % 1 == 0.
+  if (rhs_new->isConstant() && immediateEquals(rhs_new, 1)) {
+    return getImmediateByType(v->dtype(), 0);
+  }
+
+  // x % x => 0.
+  if (hasher_.hash(lhs_new) == hasher_.hash(rhs_new)) {
+    return getImmediateByType(v->dtype(), 0);
+  }
+
+  const Term* lhsTerm = dynamic_cast<const Term*>(lhs_new);
+  if (!lhsTerm) {
+    const Polynomial* lhsPoly = dynamic_cast<const Polynomial*>(lhs_new);
+    if (lhsPoly) {
+      // Can still optimize this out if we can factorize the polynomial.
+      lhsTerm = factorizePolynomial(lhsPoly);
+    }
+  }
+
+  if (lhsTerm) {
+    // ((C1 * C2) * x) % C1 => 0.
+    if (rhs_new->isConstant() &&
+        immediateEquals(evaluateOp(new Mod(lhsTerm->scalar(), rhs_new)), 0)) {
+      return getImmediateByType(v->dtype(), 0);
+    }
+
+    // (x * y * z) % x => 0.
+    for (auto* component : lhsTerm->variables()) {
+      if (hasher_.hash(component) == hasher_.hash(rhs_new)) {
+        return getImmediateByType(v->dtype(), 0);
+      }
+    }
+
+    // (6 * x * y) % (3 * x * y) => 0.
+    // also, (x * y * z) % (z * y) => 0.
+    // This requires all variable terms found in the RHS to be present in the
+    // LHS.
+    const Term* rhsTerm = dynamic_cast<const Term*>(rhs_new);
+    if (rhsTerm) {
+      auto& lVars = lhsTerm->variables();
+      auto& rVars = rhsTerm->variables();
+      size_t rLeft = rVars.size();
+
+      auto rIt = rVars.begin();
+
+      for (auto lIt = lVars.begin(); lIt != lVars.end() && !rVars.empty();
+           ++lIt) {
+        auto lHash = hasher_.hash(*lIt);
+        for (; rIt != rVars.end(); ++rIt) {
+          auto rHash = hasher_.hash(*rIt);
+          if (lHash == rHash) {
+            --rLeft;
+            break;
+          } else if (lHash < rHash) {
+            break;
+          }
+        }
+      }
+
+      if (rLeft == 0 &&
+          immediateEquals(
+              evaluateOp(new Mod(lhsTerm->scalar(), rhsTerm->scalar())), 0)) {
+        return getImmediateByType(v->dtype(), 0);
+      }
+    }
+  }
+
+  return new Mod(lhs_new, rhs_new);
 }
 
 namespace {
@@ -1202,17 +1287,54 @@ const Expr* PolynomialTransformer::mutate(const Min* v) {
 const Expr* PolynomialTransformer::mutate(const CompareSelect* v) {
   const Expr* lhs_new = v->lhs()->accept_mutator(this);
   const Expr* rhs_new = v->rhs()->accept_mutator(this);
-  const Expr* retval1_new = v->ret_val1()->accept_mutator(this);
-  const Expr* retval2_new = v->ret_val2()->accept_mutator(this);
-  const Expr* v_new = new CompareSelect(
-      lhs_new, rhs_new, retval1_new, retval2_new, v->compare_select_op());
+  const Expr* true_branch = v->ret_val1()->accept_mutator(this);
+  const Expr* false_branch = v->ret_val2()->accept_mutator(this);
 
   // Constant Folding.
   if (lhs_new->isConstant() && rhs_new->isConstant()) {
+    const Expr* v_new = new CompareSelect(
+        lhs_new, rhs_new, true_branch, false_branch, v->compare_select_op());
     return evaluateOp(v_new);
   }
 
-  return v_new;
+  // If the comparison is done in float, don't attempt diff simplification,
+  // since we can't correctly handle NaN.
+  if (lhs_new->dtype().is_floating_point() ||
+      rhs_new->dtype().is_floating_point()) {
+    return new CompareSelect(
+        lhs_new, rhs_new, true_branch, false_branch, v->compare_select_op());
+  }
+
+  // If diff is constant, we can determine it.
+  const Expr* diff = new Sub(rhs_new, lhs_new);
+  diff = diff->accept_mutator(this);
+
+  if (!diff->isConstant()) {
+    return new CompareSelect(
+        lhs_new, rhs_new, true_branch, false_branch, v->compare_select_op());
+  }
+
+  bool equal = immediateEquals(diff, 0);
+  bool lhsSmaller = !equal && !immediateIsNegative(diff);
+
+  switch (v->compare_select_op()) {
+    case CompareSelectOperation::kEQ:
+      return equal ? true_branch : false_branch;
+    case CompareSelectOperation::kGT:
+      return (lhsSmaller || equal) ? false_branch : true_branch;
+    case CompareSelectOperation::kGE:
+      return lhsSmaller ? false_branch : true_branch;
+    case CompareSelectOperation::kLT:
+      return lhsSmaller ? true_branch : false_branch;
+    case CompareSelectOperation::kLE:
+      return (lhsSmaller || equal) ? true_branch : false_branch;
+    case CompareSelectOperation::kNE:
+      return equal ? false_branch : true_branch;
+  }
+
+  // should not be possible but just in case.
+  return new CompareSelect(
+      lhs_new, rhs_new, true_branch, false_branch, v->compare_select_op());
 }
 
 const Expr* PolynomialTransformer::mutate(const Intrinsics* v) {
@@ -1655,7 +1777,7 @@ const Expr* simplifyRoundModPattern(const Polynomial* poly) {
 }
 
 // Trivially factorize terms by GCD of scalar components.
-const Expr* TermExpander::factorizePolynomial(const Polynomial* poly) {
+const Term* IRSimplifierBase::factorizePolynomial(const Polynomial* poly) {
   const Expr* scalar = poly->scalar();
   const std::vector<const Term*>& variables = poly->variables();
 

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -414,6 +414,9 @@ class TORCH_API IRSimplifierBase : public IRMutator {
 
   Stmt* mutate(const For* v) override;
 
+  // Trivially factorize terms by GCD of scalar components.
+  const Term* factorizePolynomial(const Polynomial* poly);
+
   HashProvider& hasher() {
     return hasher_;
   }
@@ -471,9 +474,7 @@ class TORCH_API PolynomialTransformer : public IRSimplifierBase {
 
   const Expr* mutate(const Div* v) override;
 
-  const Expr* mutate(const Mod* v) override {
-    return mutateBinaryOp(v, this);
-  }
+  const Expr* mutate(const Mod* v) override;
 
   const Expr* mutate(const And* v) override {
     return mutateBinaryOp(v, this);
@@ -547,9 +548,6 @@ class TORCH_API TermExpander : public IRSimplifierBase {
 
   // Expand Terms out to a series of Muls.
   const Expr* mutate(const Term* v) override;
-
-  // Trivially factorize terms by GCD of scalar components.
-  const Expr* factorizePolynomial(const Polynomial* poly);
 
   // Expand Polynomials out to a series of Adds.
   const Expr* mutate(const Polynomial* v) override;


### PR DESCRIPTION
Adds new rules to the NNC IRSimplifier to take care of the following cases:

* Comparisons which are symbolic but have a constant difference. E.g. this is most useful in cases like `if (x > x + 4) ...` which we can now eliminate.

* Simplification of `Mod` nodes, including simple rules such as `0 % x` and `x % 1`, but also factorization of both sides to find common symbolic multiples. E.g. `(x * y) % x` can be cancelled out to `0`.

See tests for many more examples!