### PR TITLE
use @mode/ndk_libcxx instead of mode/gnustl

### DIFF
--- a/mode/aibench_caffe2_android
+++ b/mode/aibench_caffe2_android
@@ -1,3 +1,3 @@
 --config
 caffe2.strip_glog=0
-@fbsource//fbandroid/mode/gnustl
+@fbsource//fbandroid/mode/ndk_libcxx


### PR DESCRIPTION
Summary: as title

Test Plan:
run ai bench

buck run aibench:run_bench -- -b aibench/specifications/models/caffe2/squeezenet/squeezenet.json --remote --devices s9f

INFO 2020-10-15 12:24:21 everstore.py: 177: Everstore: Try internal upload
INFO 2020-10-15 12:24:21 subprocess_with_logger.py:  56: Running: clowder put --fbtype=24665 /tmp/aibenchj5w4craj/build.sh
INFO 2020-10-15 12:24:25 subprocess_with_logger.py:  39: Process Succeeded: clowder put --fbtype=24665 /tmp/aibenchj5w4craj/build.sh
INFO 2020-10-15 12:24:25 everstore.py: 185: Uploading /tmp/aibenchj5w4craj/build.sh
everstore handle: GIxbhAQoAOdQNqwCAEam42Z-pfQrbllgAAAP
url:
INFO 2020-10-15 12:24:25 run_remote.py: 182: program: //everstore/GIxbhAQoAOdQNqwCAEam42Z-pfQrbllgAAAP/build.sh
INFO 2020-10-15 12:24:25 everstore.py: 177: Everstore: Try internal upload
INFO 2020-10-15 12:24:25 subprocess_with_logger.py:  56: Running: clowder put --fbtype=24665 /tmp/aibenchj5w4craj/program
INFO 2020-10-15 12:24:32 subprocess_with_logger.py:  39: Process Succeeded: clowder put --fbtype=24665 /tmp/aibenchj5w4craj/program
INFO 2020-10-15 12:24:32 everstore.py: 185: Uploading /tmp/aibenchj5w4craj/program
everstore handle: GICWmAA66cD0qNMCAJh4vKJzTU8-bllgAAAP
url:
INFO 2020-10-15 12:24:32 run_remote.py: 182: program: //everstore/GICWmAA66cD0qNMCAJh4vKJzTU8-bllgAAAP/program
Scuba => https://fburl.com/scuba/caffe2_benchmarking/w6tvinl0
Job status for SM-G960F-8.0.0-26 (sm-g960f-26,galaxy-s9f,s9f) is changed to CLAIMED
Job status for SM-G960F-8.0.0-26 (sm-g960f-26,galaxy-s9f,s9f) is changed to RUNNING
Job status for SM-G960F-8.0.0-26 (sm-g960f-26,galaxy-s9f,s9f) is changed to DONE
ID:0	NET latency: 82192.9
You can find more info via https://our.intern.facebook.com/intern/aibench/details/915762192256210

Reviewed By: smeenai

Differential Revision: D24340103

