### PR TITLE
Add type-safe, const-safe loops to c10

### DIFF
--- a/c10/test/util/irange_test.cpp
+++ b/c10/test/util/irange_test.cpp
@@ -1,0 +1,58 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <c10/util/irange.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+TEST(irange_test, range_test) {
+    std::vector<int> test_vec;
+    for(const auto i : c10::irange(4, 11)){
+        test_vec.push_back(i);
+    }
+    const std::vector<int> correct = {{4,5,6,7,8,9,10}};
+    ASSERT_EQ(test_vec, correct);
+}
+
+TEST(irange_test, end_test) {
+    std::vector<int> test_vec;
+    for(const auto i : c10::irange(5)){
+        test_vec.push_back(i);
+    }
+    const std::vector<int> correct = {{0, 1, 2, 3, 4}};
+    ASSERT_EQ(test_vec, correct);
+}
+
+TEST(irange_test, neg_range_test) {
+    std::vector<int> test_vec;
+    for(const auto i : c10::irange(-2, 3)){
+        test_vec.push_back(i);
+    }
+    const std::vector<int> correct = {{-2,-1,0,1,2}};
+    ASSERT_EQ(test_vec, correct);
+}
+
+TEST(irange, empty_reverse_range_two_inputs){
+    std::vector<int> test_vec;
+    for(const auto i : c10::irange(3, -3)){
+        test_vec.push_back(i);
+        if(i>20){ //Cap the number of elements we add if something goes wrong
+            break;
+        }
+    }
+    const std::vector<int> correct = {};
+    ASSERT_EQ(test_vec, correct);
+}
+
+TEST(irange, empty_reverse_range_one_input){
+    std::vector<int> test_vec;
+    for(const auto i : c10::irange(-3)){
+        test_vec.push_back(i);
+        if(i>20){ //Cap the number of elements we add if something goes wrong
+            break;
+        }
+    }
+    const std::vector<int> correct = {};
+    ASSERT_EQ(test_vec, correct);
+}

--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -1,0 +1,77 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <c10/util/Exception.h>
+
+#include <iterator>
+#include <type_traits>
+
+namespace c10 {
+
+namespace detail {
+
+template <typename I, std::enable_if_t<std::is_integral<I>{}, int> = 0>
+struct integer_iterator : std::iterator<std::input_iterator_tag, I> {
+    explicit integer_iterator(I value) : value(value) {}
+
+    I operator*() const { return value; }
+
+    I const* operator->() const { return &value; }
+
+    integer_iterator& operator++() {
+        ++value;
+        return *this;
+    }
+
+    integer_iterator operator++(int) {
+        const auto copy = *this;
+        ++*this;
+        return copy;
+    }
+
+    bool operator==(const integer_iterator& other) const {
+        return value == other.value;
+    }
+
+    bool operator!=(const integer_iterator& other) const {
+        return value != other.value;
+    }
+
+ protected:
+    I value;
+};
+
+} // namespace detail
+
+template <typename I, std::enable_if_t<std::is_integral<I>{}, int> = 0>
+struct integer_range {
+ public:
+    integer_range(I begin, I end) : begin_(begin), end_(end) {}
+    detail::integer_iterator<I> begin() const { return begin_; }
+    detail::integer_iterator<I> end() const { return end_; }
+
+ private:
+    detail::integer_iterator<I> begin_;
+    detail::integer_iterator<I> end_;
+};
+
+/// Creates an integer range for the half-open interval [begin, end)
+/// If end<=begin, then the range is empty
+template <typename Integer, std::enable_if_t<std::is_integral<Integer>::value, bool> = true>
+integer_range<Integer> irange(Integer begin, Integer end) {
+    //If end<=begin then the range is empty; we can achieve this effect by
+    //choosing the larger of {begin, end} as the loop terminator
+    return {begin, std::max(begin, end)};
+}
+
+/// Creates an integer range for the half-open interval [0, end)
+/// If end<=begin, then the range is empty
+template <typename Integer, std::enable_if_t<std::is_integral<Integer>::value, bool> = true>
+integer_range<Integer> irange(Integer end) {
+    //If end<=begin then the range is empty; we can achieve this effect by
+    //choosing the larger of {0, end} as the loop terminator
+    return {Integer(), std::max(Integer(), end)};
+}
+
+} // namespace torch


### PR DESCRIPTION
Pull Request resolved: https://github.com/pytorch/pytorch/pull/46414

For loops are often written with mismatched data types which causes silent type and sign coercion in the absence of integer conversion warnings. Getting around this in templated code requires convoluted patterns such as
```
for(auto i=decltype(var){0};i<var;i++)
```
(the above pattern appears ~31 times in the code base) with this diff we can instead write
```
for(const auto i = c10::ranges::indices(var))
```
Note that this loop is type-safe and const-safe. (Type-unsafe loops occur an unknown number of times do to the lack of conversion warnings on compilation.)

The functions introduced here (`c10::ranges::ints` and `c10::ranges::indices`) allow for type-safety and const-ness within for loops, which prevents the accidental truncation or modification of integers and other types, improving code safety. Further, they use the same naming convention as the ranges-v3 library and offer an easy migration path to C++20 functionality.

Test Plan:
```
buck run //caffe2/c10:c10_test_0
```

Differential Revision: D24334732

