### PR TITLE
[v1.7] Disable tcuda_fuser tests in Profiling Mode (#45638)

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -804,5 +804,5 @@ class TestPassManagerCudaFuser(JitTestCase):
 
 
 if __name__ == '__main__':
-    if not TEST_WITH_ROCM:
+    if not TEST_WITH_ROCM and GRAPH_EXECUTOR != ProfilingMode.PROFILING:
         run_tests()


### PR DESCRIPTION
Summary:
Disable tcuda_fuser tests in Profiling Mode to address flakey tests until fuser switches to the new approach.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/45638

Reviewed By: mrshenli

Differential Revision: D24057230

Pulled By: Krovatkin

fbshipit-source-id: 8f7a47610d9b7da6ad3057208057a5a596e1bffa
