### PR TITLE
Make optional[T] sortable

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -39,8 +39,10 @@ TORCH_API torch::jit::Function* checkObjectSortSchema(
 // A comparator that checks ordering of two IValues of same type.
 typedef std::function<bool(const IValue& a, const IValue& b)> IValueComparator;
 
-TORCH_API IValueComparator getLessThanComparator(const IValue& v);
-TORCH_API IValueComparator getGreaterThanComparator(const IValue& v);
+TORCH_API IValueComparator getLessThanComparator(const IValue& v, std::stringstream& why_not);
+TORCH_API IValueComparator getLessThanComparatorWithNone(const IValue& v, std::stringstream& why_not);
+TORCH_API IValueComparator getGreaterThanComparator(const IValue& v, std::stringstream& why_not);
+TORCH_API IValueComparator getGreaterThanComparatorWithNone(const IValue& v, std::stringstream& why_not);
 
 namespace ivalue {
 struct Tuple;

--- a/test/jit/test_sortoptional.py
+++ b/test/jit/test_sortoptional.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+import torch
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestSortOptional(JitTestCase):
+    def test_sort_primitive_optional(self):
+        @torch.jit.script
+        def sort_int_optional(inputs: List[Optional[int]]):
+            inputs.sort()
+            return inputs
+
+        self.assertEqual(sort_int_optional([None, 1, 2, 5, None, 8]), [None, None, 1, 2, 5, 8])
+        self.assertEqual(sort_int_optional([1, 2, 5, 8]), [1, 2, 5, 8])
+        self.assertEqual(sort_int_optional([None]), [None])
+        self.assertEqual(sort_int_optional([None, None, None]), [None, None, None])
+        self.assertEqual(sort_int_optional([]), [])
+
+
+    def test_sort_tuple_optional(self):
+        @torch.jit.script
+        def sort_tuple_optional(inputs: List[Optional[Tuple[Optional[int], Optional[int]]]]):
+            inputs.sort()
+            return inputs
+
+        self.assertEqual(sort_tuple_optional([None, (1, 2), (5, 8), None, (3, None)]), [None, None, (1, 2), (3, None), (5, 8)])
+        self.assertEqual(sort_tuple_optional([(1, 2), (5, 8)]), [(1, 2), (5, 8)])
+        self.assertEqual(sort_tuple_optional([None]), [None])
+        self.assertEqual(sort_tuple_optional([None, None, None]), [None, None, None])
+        self.assertEqual(sort_tuple_optional([]), [])

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -33,6 +33,7 @@ from jit.test_enum import TestEnum  # noqa: F401
 from jit.test_profiler import TestProfiler  # noqa: F401
 from jit.test_slice import TestSlice  # noqa: F401
 from jit.test_warn import TestWarn  # noqa: F401
+from jit.test_sortoptional import TestSortOptional  # noqa: F401
 
 # Torch
 from torch import Tensor


### PR DESCRIPTION
Summary:
Addresses #45985.
To support sorting Optional:
  - all sort involves Optional will be handled by `sort_op`.
  - rewrite `isSortableListOfObjectsOrTuples` and `sort_op` to add checks for None in lists.
  - when trying to get a comparator by `getLess/GreaterThanComparator`, return nullptr if we cannot get one instead of throwing an error, and delay checking for nullptr to the callsites. Use whether we can get a comparator to distinguish trying to sort Optional[primitives] (which we consider sortable) and trying to sort a type not supported by sort_op (which should throw an error) in isSortableListOfObjectsOrTuples.
  - now that we can get a comparator when checking if the list if sortable, rename `isSortableListOfObjectsOrTuples` to `checkAndGetComparator` to make it clear.
  - add logic to handle None in `isSortableTupleType`.
  - update comparator for ivalues to handle comparing None.

Test Plan:
`pytest test/test_jit.py`

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #{issue number}
