### PR TITLE
enabling lcov for coverage tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,8 +653,10 @@ jobs:
               echo "Retrieving coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov
+              python3 -mcodecov -f coverage.info
           fi
         when: always
     - store_test_results:

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -219,8 +219,10 @@ jobs:
               echo "Retrieving coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov
+              python3 -mcodecov -f coverage.info
           fi
         when: always
     - store_test_results:

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -64,6 +64,11 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   nvcc --version
 fi
 
+if [[ "$BUILD_ENVIRONMENT" ==  *coverage* ]]; then
+  # enable build option in CMake
+  export USE_CPP_CODE_COVERAGE=ON
+fi
+
 # TODO: Don't run this...
 pip_install -r requirements.txt || true
 

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -417,7 +417,10 @@ else
     pushd test
     echo "Generating XML coverage report"
     time python -mcoverage xml
-    time lcov --capture --directory build/ --output-file coverage.info
+    popd
+    pushd build
+    echo "Generating lcov coverage report for C++ sources"
+    time lcov --capture --directory . --output-file coverage.info
     popd
   fi
 fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -417,6 +417,7 @@ else
     pushd test
     echo "Generating XML coverage report"
     time python -mcoverage xml
+    time lcov --capture --directory build/ --output-file coverage.info
     popd
   fi
 fi


### PR DESCRIPTION
Uses lcov to enable C++ code coverage for coverage tests. Currently, there is only Python code coverage.
