### PR TITLE
Fix out-of-bounds access for caching allocator calls

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -966,8 +966,8 @@ std::mutex* getFreeMutex()
 }
 
 static inline void assertValidDevice(int device) {
-  int device_num = device_count();
-  AT_ASSERTM(0 <= device && device < device_num, "Invalid device argument.");
+  int device_num = caching_allocator.device_allocator.size();
+  TORCH_CHECK(0 <= device && device < device_num, "Invalid device argument.");
 }
 
 DeviceStats getDeviceStats(int device) {


### PR DESCRIPTION
In assertValidDevice() compare device index to `caching_allocator.device_allocator` rather than to `device_no`

Fixes potential crashes when caching allocator is accessed before being initialized, for example by calling something like:
`python -c "import torch;print(torch.cuda.memory_stats(0))"`

Fixes https://github.com/pytorch/pytorch/issues/46437
