### PR TITLE
Support hashing of various data types by implementing generic hashing for IValues

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -5,6 +5,7 @@
 #include <ATen/core/jit_type.h>
 #include <ATen/core/stack.h>
 #include <c10/util/StringUtil.h>
+#include <c10/util/hash.h>
 #include <cmath>
 
 namespace c10 {
@@ -292,6 +293,46 @@ IValue IValue::equals(const IValue& rhs) const {
       // Unitialized ivalues show up in no-ops when the compiler can prove a
       // value will never be used. Just return false on any equality comparison.
       return false;
+  }
+  // the above switch should be exhaustive
+  TORCH_INTERNAL_ASSERT(false, "we should never reach here")
+}
+
+size_t IValue::hash(const IValue& v) {
+  switch (v.tag) {
+    case Tag::None:
+      return 0;
+    case Tag::Bool:
+      return c10::get_hash(v.payload.as_bool);
+    case Tag::Double:
+      return c10::get_hash(v.payload.as_double);
+    case Tag::Tensor:
+      // Tensor __hash__ is equivalent to `id()`, so take the pointer value of
+      // the tensor to emulate it
+      return c10::get_hash(v.payload.as_int);
+    case Tag::Int:
+      return c10::get_hash(v.payload.as_int);
+    case Tag::String:
+      return c10::get_hash(v.toStringRef());
+    case Tag::Tuple:
+      return c10::get_hash(*v.toTuple());
+    case Tag::Device:
+      return c10::get_hash(v.toDevice());
+    case Tag::GenericDict:
+    case Tag::GenericList:
+    case Tag::Blob:
+    case Tag::Future:
+    case Tag::RRef:
+    case Tag::Object:
+    case Tag::PyObject:
+    case Tag::Capsule:
+    case Tag::Generator:
+    case Tag::Quantizer:
+    case Tag::Enum:
+    case Tag::Stream:
+    case Tag::Uninitialized:
+      throw std::runtime_error(
+          "unhashable type: '" + v.type()->repr_str() + "'");
   }
   // the above switch should be exhaustive
   TORCH_INTERNAL_ASSERT(false, "we should never reach here")

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -206,6 +206,24 @@ struct CAFFE2_API IValue final {
    */
   bool is(const IValue& rhs) const;
 
+   /**
+   * Hashing for IValues. Returns an IValue-boxed int.
+   *
+   * Some notes:
+   * - Like eager, Tensors are hashed by looking at the pointer. This is not
+   *   strictly correct because two value-equal tensors with different tensor
+   *   pointers will hash differently, but we choose to reproduce the eager
+   *   semantics.
+   * - Hashing is not defined on all built-in IValue types (e.g. list and
+   *   dict), following Python. Calling `hash()` on these types will throw.
+   */
+  IValue hash() const {
+    return (int64_t)IValue::hash(*this);
+  }
+  // This is defined because `c10::hash` dispatches to a function of this
+  // signature. See the member function `hash()`.
+  static size_t hash(const IValue& iv);
+
   /**
    * @private [doxygen private]
    * [container equality]

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -14,6 +14,7 @@
 #include <c10/core/TensorImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/hash.h>
 
 namespace torch {
 namespace jit {
@@ -239,6 +240,10 @@ struct CAFFE2_API Tuple : c10::intrusive_ptr_target {
     return std::move(elements_);
   }
   std::shared_ptr<TupleType> type() const;
+
+  static size_t hash(const Tuple& t) {
+    return c10::get_hash(t.elements());
+  }
 
   CAFFE2_API friend bool operator==(
       const ivalue::Tuple& lhs,

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -131,6 +131,7 @@ allow_list = [
     ("aten::conj", datetime.date(2020, 11, 10)),
     ("aten::add_relu", datetime.date(2020, 10, 28)),
     ("aten::add_relu_", datetime.date(2020, 10, 28)),
+    ("aten::hash", datetime.date(2020, 11, 15)),
 ]
 
 def allow_listed(schema, allow_list):

--- a/test/jit/test_hash.py
+++ b/test/jit/test_hash.py
@@ -1,0 +1,107 @@
+import os
+import sys
+
+import torch
+
+from typing import Tuple, List
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == "__main__":
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestHash(JitTestCase):
+    def test_hash_tuple(self):
+        def fn(t1: Tuple[int, int], t2: Tuple[int, int]) -> bool:
+            return hash(t1) == hash(t2)
+
+        self.checkScript(fn, ((1, 2), (1, 2)))
+        self.checkScript(fn, ((1, 2), (3, 4)))
+        self.checkScript(fn, ((1, 2), (2, 1)))
+
+    def test_hash_tuple_nested_unhashable_type(self):
+        # Tuples may contain unhashable types like `list`, check that we error
+        # properly in that case.
+        @torch.jit.script
+        def fn_unhashable(t1: Tuple[int, List[int]]):
+            return hash(t1)
+
+        with self.assertRaisesRegex(RuntimeError, "unhashable"):
+            fn_unhashable((1, [1]))
+
+    def test_hash_tensor(self):
+        """Tensors should hash by identity"""
+        def fn(t1, t2):
+            return hash(t1) == hash(t2)
+
+        tensor1 = torch.tensor(1)
+        tensor1_clone = torch.tensor(1)
+        tensor2 = torch.tensor(2)
+
+        self.checkScript(fn, (tensor1, tensor1))
+        self.checkScript(fn, (tensor1, tensor1_clone))
+        self.checkScript(fn, (tensor1, tensor2))
+
+    def test_hash_none(self):
+        def fn():
+            n1 = None
+            n2 = None
+            return hash(n1) == hash(n2)
+
+        self.checkScript(fn, ())
+
+    def test_hash_bool(self):
+        def fn(b1: bool, b2: bool):
+            return hash(b1) == hash(b2)
+
+        self.checkScript(fn, (True, False))
+        self.checkScript(fn, (True, True))
+        self.checkScript(fn, (False, True))
+        self.checkScript(fn, (False, False))
+
+    def test_hash_float(self):
+        def fn(f1: float, f2: float):
+            return hash(f1) == hash(f2)
+
+        self.checkScript(fn, (1.2345, 1.2345))
+        self.checkScript(fn, (1.2345, 6.789))
+        self.checkScript(fn, (1.2345, float("inf")))
+        self.checkScript(fn, (float("inf"), float("inf")))
+        self.checkScript(fn, (1.2345, float('nan')))
+        self.checkScript(fn, (float("nan"), float("nan")))
+        self.checkScript(fn, (float("nan"), float("inf")))
+
+    def test_hash_int(self):
+        def fn(i1: int, i2: int):
+            return hash(i1) == hash(i2)
+
+        self.checkScript(fn, (123, 456))
+        self.checkScript(fn, (123, 123))
+        self.checkScript(fn, (123, -123))
+        self.checkScript(fn, (-123, -123))
+        self.checkScript(fn, (123, 0))
+
+    def test_hash_string(self):
+        def fn(s1: str, s2: str):
+            return hash(s1) == hash(s2)
+
+        self.checkScript(fn, ("foo", "foo"))
+        self.checkScript(fn, ("foo", "bar"))
+        self.checkScript(fn, ("foo", ""))
+
+    def test_hash_device(self):
+        def fn(d1: torch.device, d2: torch.device):
+            return hash(d1) == hash(d2)
+
+        gpu0 = torch.device('cuda:0')
+        gpu1 = torch.device('cuda:1')
+        cpu = torch.device('cpu')
+        self.checkScript(fn, (gpu0, gpu0))
+        self.checkScript(fn, (gpu0, gpu1))
+        self.checkScript(fn, (gpu0, cpu))
+        self.checkScript(fn, (cpu, cpu))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -35,6 +35,7 @@ from jit.test_profiler import TestProfiler  # noqa: F401
 from jit.test_slice import TestSlice  # noqa: F401
 from jit.test_warn import TestWarn  # noqa: F401
 from jit.test_isinstance import TestIsinstance  # noqa: F401
+from jit.test_hash import TestHash  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -635,11 +635,9 @@ RegisterOperators logging_operators(
          },
          aliasAnalysisFromSchema())});
 
-template <typename T>
 void hashValue(Stack* stack) {
   auto value = pop(stack);
-  auto hash = std::hash<T>()(value.to<T>());
-  push(stack, int64_t(hash));
+  push(stack, value.hash());
 }
 
 // As described in https://docs.python.org/3/library/functions.html#round
@@ -1088,16 +1086,8 @@ RegisterOperators reg2({
 
 #undef DEFINE_DIVMOD_MIXED_OP
     Operator(
-        "aten::hash.str(str t) -> int",
-        hashValue<std::string>,
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::hash.int(int t) -> int",
-        hashValue<int>,
-        aliasAnalysisFromSchema()),
-    Operator(
-        "aten::hash.float(float t) -> int",
-        hashValue<double>,
+        "aten::hash.generic(t value) -> int",
+        hashValue,
         aliasAnalysisFromSchema()),
 });
 


### PR DESCRIPTION
It used to be that TorchScript only supported hashing of `int`, `float` and `str`. This PR adds hashing for many other types including `Tuple`, `bool`, `device` by implementing generic hashing on IValue.

* Tensor hashing follows eager behavior, which is identity-based (hash according to pointer address rather than tensor content).

Fixes #44038

This is based on @suo's #44047, with some cleaning, more tests and fixing BC check issue.