### PR TITLE
[TensorExpr] Correctly handle negative dimensions in aten::cat when lowering to tensor expressions.

### DIFF
--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1055,6 +1055,29 @@ class TestTensorExprFuser(BaseTestClass):
     def test_cat_cuda(self):
         self._test_cat('cuda')
 
+    def _test_cat_negative_dim(self, device):
+        def foo(*args):
+            args_2 = [v + i for i, v in enumerate(args)]
+            v = torch.cat(args_2, dim=-1)
+            return v*v
+
+        M = 16
+        Ns = [128, 16, 1]
+        values = [torch.zeros(M, N, device=device) for N in Ns]
+        traced = torch.jit.trace(foo, values)
+
+        x = warmup_and_run_forward(traced, *values)
+        self.assertLastGraphAllFused()
+        ref = foo(*values)
+        np.testing.assert_allclose(ref.cpu().numpy(), x.cpu().numpy())
+
+    def test_cat_negative_dim_cpu(self):
+        self._test_cat_negative_dim('cpu')
+
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    def test_cat_negative_dim_cuda(self):
+        self._test_cat_negative_dim('cuda')
+
     def test_scalar(self):
         @torch.jit.script
         def test_float(x, y, z, a, b):

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1059,7 +1059,7 @@ class TestTensorExprFuser(BaseTestClass):
         def foo(*args):
             args_2 = [v + i for i, v in enumerate(args)]
             v = torch.cat(args_2, dim=-1)
-            return v*v
+            return v * v
 
         M = 16
         Ns = [128, 16, 1]

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -559,6 +559,7 @@ void print(const Expr* expr) {
   } else {
     std::cout << "(null expr)";
   }
+  std::cout << "\n";
 }
 
 void print(const Stmt* stmt) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -340,7 +340,7 @@ std::vector<ExprHandle> TensorExprKernel::inferSizesForValue(
         dim = dim + shape.size() + 1;
       }
       if (dim < 0 || dim > shape.size()) {
-        throw std::runtime_error("Invalid 'dim' input in aten::unsqueeze");
+        throw std::runtime_error("Invalid 'dim' input in aten::cat");
       }
       shape[dim] = concat_size;
       return shape;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46447 [TensorExpr] Re-enable test for torch.cat, add a test for torch.cat being a single node in a fusion group.
* **#46446 [TensorExpr] Correctly handle negative dimensions in aten::cat when lowering to tensor expressions.**

Fixes #46440.

Differential Revision: [D24356016](https://our.internmc.facebook.com/intern/diff/D24356016)