### PR TITLE
[mlf][efficiency] modify equalization scale operator to return single output

### DIFF
--- a/caffe2/quantization/server/compute_equalization_scale_test.py
+++ b/caffe2/quantization/server/compute_equalization_scale_test.py
@@ -38,19 +38,17 @@ class TestComputeEqualizationScaleOp(hu.HypothesisTestCase):
 
         def ref_compute_equalization_scale(X, W):
             S = np.ones([X.shape[1]])
-            S_INV = np.ones([X.shape[1]])
             for j in range(W.shape[1]):
                 WcolMax = np.absolute(W[:, j]).max()
                 XcolMax = np.absolute(X[:, j]).max()
                 if WcolMax and XcolMax:
                     S[j] = np.sqrt(WcolMax / XcolMax)
-                    S_INV[j] = 1 / S[j]
-            return S, S_INV
+            return S
 
         net = core.Net("test")
 
         ComputeEqualizationScaleOp = core.CreateOperator(
-            "ComputeEqualizationScale", ["X", "W"], ["S", "S_INV"]
+            "ComputeEqualizationScale", ["X", "W"], ["S"]
         )
         net.Proto().op.extend([ComputeEqualizationScaleOp])
 
@@ -59,16 +57,14 @@ class TestComputeEqualizationScaleOp(hu.HypothesisTestCase):
         self.ws.run(net)
 
         S = self.ws.blobs["S"].fetch()
-        S_INV = self.ws.blobs["S_INV"].fetch()
-        S_ref, S_INV_ref = ref_compute_equalization_scale(X, W)
+        S_ref = ref_compute_equalization_scale(X, W)
         np.testing.assert_allclose(S, S_ref, atol=1e-3, rtol=1e-3)
-        np.testing.assert_allclose(S_INV, S_INV_ref, atol=1e-3, rtol=1e-3)
 
     def test_compute_equalization_scale_shape_inference(self):
         X = np.array([[1, 2], [2, 4], [6, 7]]).astype(np.float32)
         W = np.array([[2, 3], [5, 4], [8, 2]]).astype(np.float32)
         ComputeEqualizationScaleOp = core.CreateOperator(
-            "ComputeEqualizationScale", ["X", "W"], ["S", "S_INV"]
+            "ComputeEqualizationScale", ["X", "W"], ["S"]
         )
         workspace.FeedBlob("X", X)
         workspace.FeedBlob("W", W)
@@ -81,9 +77,7 @@ class TestComputeEqualizationScaleOp(hu.HypothesisTestCase):
             blob_types={"X": core.DataType.FLOAT, "W": core.DataType.FLOAT},
         )
         assert (
-            "S" in shapes and "S" in types and "S_INV" in shapes and "S_INV" in types
+            "S" in shapes and "S" in types
         ), "Failed to infer the shape or type of output"
         self.assertEqual(shapes["S"], [1, 2])
-        self.assertEqual(shapes["S_INV"], [1, 2])
         self.assertEqual(types["S"], core.DataType.FLOAT)
-        self.assertEqual(types["S_INV"], core.DataType.FLOAT)


### PR DESCRIPTION
Summary: modifies `ComputeEqualizationScale` to have a single output `S`

Test Plan:
```
buck test caffe2/caffe2/quantization/server:compute_equalization_scale_test
```

plus e2e tests

Reviewed By: hx89

Differential Revision: D23946768

