### PR TITLE
[GPU] Add metal to DispatchKeySet

### DIFF
--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -204,6 +204,7 @@ constexpr DispatchKeySet autogradother_backends = DispatchKeySet({
   DispatchKey::FPGA,
   DispatchKey::MSNPU,
   DispatchKey::Vulkan,
+  DispatchKey::Metal,
   DispatchKey::MKLDNN,
   DispatchKey::OpenGL,
   DispatchKey::OpenCL,

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -235,7 +235,7 @@ def compute_type_method(
             return_kw = "    return "
 
             cuda_guard = ""
-            if dispatch_to_all_backends or 'CUDA' in dispatch or 'Vulkan' == dispatch or 'Metal' == dispatch:  # type: ignore
+            if dispatch_to_all_backends or 'CUDA' in dispatch or 'Vulkan' == dispatch:  # type: ignore
                 self_args = (a for a in f.func.arguments if a.name == "self")
 
                 # There is precedence for which argument we use to do
@@ -260,7 +260,7 @@ def compute_type_method(
 
                 # TODO: There is probably a simpler version of this that
                 # works just as well.
-                if f.device_guard and (dispatch_to_all_backends or 'Vulkan' == dispatch or 'Metal' == dispatch) and has_tensor_options:
+                if f.device_guard and (dispatch_to_all_backends or 'Vulkan' == dispatch) and has_tensor_options:
                     cuda_guard = cuda_guard_from_tensor_options
                 elif f.device_guard and dispatch is not None and 'CUDA' in dispatch and has_tensor_options:
                     cuda_guard = f"""\

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -235,7 +235,7 @@ def compute_type_method(
             return_kw = "    return "
 
             cuda_guard = ""
-            if dispatch_to_all_backends or 'CUDA' in dispatch or 'Vulkan' == dispatch:  # type: ignore
+            if dispatch_to_all_backends or 'CUDA' in dispatch or 'Vulkan' == dispatch or 'Metal' == dispatch:  # type: ignore
                 self_args = (a for a in f.func.arguments if a.name == "self")
 
                 # There is precedence for which argument we use to do
@@ -260,7 +260,7 @@ def compute_type_method(
 
                 # TODO: There is probably a simpler version of this that
                 # works just as well.
-                if f.device_guard and (dispatch_to_all_backends or 'Vulkan' == dispatch) and has_tensor_options:
+                if f.device_guard and (dispatch_to_all_backends or 'Vulkan' == dispatch or 'Metal' == dispatch) and has_tensor_options:
                     cuda_guard = cuda_guard_from_tensor_options
                 elif f.device_guard and dispatch is not None and 'CUDA' in dispatch and has_tensor_options:
                     cuda_guard = f"""\


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46456 [Metal] Add the Python binding for optimize_for_mobile
* #46384 [Metal]  Enable optimize_for_mobile on Linux
* #46383 [GPU] Introduce USE_PYTORCH_METAL
* **#46455 [GPU] Add metal to DispatchKeySet**

After this PR(https://github.com/pytorch/pytorch/pull/46236 ) landed, the `aten::copy_` can no longer be dispatched to Metal kernels.

Differential Revision: [D24356769](https://our.internmc.facebook.com/intern/diff/D24356769/)