### PR TITLE
Replace map(lambda constructs

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -1524,7 +1524,8 @@ class Net(object):
         ops = net.Proto().op
         if device_option is not None:
             ops = [copy.deepcopy(op) for op in ops]
-            map(lambda x: x.device_option.CopyFrom(device_option), ops)
+            for op in ops:
+                op.device_option.CopyFrom(device_option)
             for op in ops:
                 if op.type == "RecurrentNetwork":
                     for arg in op.arg:

--- a/caffe2/python/operator_test/lengths_top_k_ops_test.py
+++ b/caffe2/python/operator_test/lengths_top_k_ops_test.py
@@ -19,7 +19,7 @@ class TestLengthsTopKOps(serial.SerializedTestCase):
         lens = np.random.randint(low=1, high=2 * K + 1, size=N).astype(np.int32)
         X = []
         for i in lens:
-            X.extend(map(lambda x: x / 100.0, range(0, 6 * i, 6)))
+            X.extend(x / 100.0 for x in range(0, 6 * i, 6))
         X = np.array(X, dtype=np.float32)
         op = core.CreateOperator("LengthsTopK", ["X", "Y"], ["values", "indices"], k=K)
 

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -219,7 +219,7 @@ class Errors(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self.errors:
-            errors_msg = "\n\n".join(map(lambda x: "ERROR: " + x, self.errors))
+            errors_msg = "\n\n".join("ERROR: " + x for x in self.errors)
             final_msg = "{}\n{}\n{}".format(self.msg, '-' * 70, errors_msg)
             raise AssertionError(final_msg)
         if exc_type == self.exc_class:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1986,7 +1986,7 @@ graph(%Ra, %Rb):
         def func():
             print({constant_constructor})
         ''')
-        single_elem_tuples = map(lambda x: "(" + x + ",)", constants)
+        single_elem_tuples = ("(" + x + ",)" for x in constants)
         input_arg = ", ".join(single_elem_tuples)
         scope = {}
         funcs_str = funcs_template.format(constant_constructor=input_arg)
@@ -2012,7 +2012,7 @@ graph(%Ra, %Rb):
         xprod = itertools.product(constants, constants)
 
         # test that equal tuples and dicts correctly work with node hashing
-        for tup in map(lambda x: "(" + x + ",)", constants):
+        for tup in ("(" + x + ",)" for x in constants):
             funcs_str = funcs_template.format(constant_constructor=tup)
             scope = {}
             execWrapper(funcs_str, globals(), scope)
@@ -4161,8 +4161,8 @@ def foo(xyz):
             archive = zipfile.ZipFile(buffer)
             files = list(filter(lambda x: x.startswith('archive/code/'), archive.namelist()))
             debug_files = filter(lambda f: f.endswith('.debug_pkl'), files)
-            debug_files = map(lambda f: archive.open(f), debug_files)
-            debug_files = map(lambda f: pickle.load(f), debug_files)
+            debug_files = (archive.open(f) for f in debug_files)
+            debug_files = (pickle.load(f) for f in debug_files)
             return list(debug_files)
 
         debug_files = debug_records_from_mod(ft3)
@@ -12093,7 +12093,7 @@ dedent """
         self.assertEqual(scripted_fn(torch.tensor(1)), (2, 3))
         tuple_graph = scripted_fn.graph
         slices = tuple_graph.findAllNodes("prim::TupleSlice")
-        num_outputs = set(map(lambda x: len(x.output().type().elements()), slices))
+        num_outputs = set(len(x.output().type().elements()) for x in slices)
         # one tuple slice should have an output with 2 elements, other 4
         self.assertTrue(num_outputs == {2, 4})
         self.run_pass('lower_all_tuples', tuple_graph)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -327,7 +327,7 @@ class TestNN(NNTestCase):
     def _backward(self, module, input: _TensorOrTensors, output, grad_output, create_graph=False):
         output.backward(grad_output, retain_graph=True, create_graph=create_graph)
         if isinstance(input, tuple):
-            return tuple(map(lambda i: i.grad.data if i.grad is not None else None, input))
+            return tuple(i.grad.data if i.grad is not None else None for i in input)
         else:
             return input.grad.data if input.grad is not None else None
 
@@ -353,7 +353,7 @@ class TestNN(NNTestCase):
             gradOutput = torch.ones(())
         criterion(*args).backward(gradOutput.to(input_tuple[0]))
         if isinstance(input, tuple):
-            return tuple(map(lambda i: i.grad.data, input))
+            return tuple(i.grad.data for i in input)
         else:
             return input.grad.data
 
@@ -3664,7 +3664,7 @@ class TestNN(NNTestCase):
         self.assertIn('bn.running_var', state_dict)
         self.assertIn('bn.running_mean', state_dict)
         self.assertIn('bn.num_batches_tracked', state_dict)
-        self.assertFalse(any(map(lambda k: k.startswith('empty'), state_dict.keys())))
+        self.assertFalse(any(k.startswith('empty') for k in state_dict.keys()))
         for k, v in state_dict.items():
             param = net
             for component in k.split('.'):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4627,7 +4627,7 @@ def make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim=0):
             ndim = len(tensor_arg)
         ndim += extra_dim
 
-        n_dim_to_test = sum(map(lambda e: e is DIM_ARG, arg_constr()))
+        n_dim_to_test = sum(e is DIM_ARG for e in arg_constr())
 
         for dims_val in combinations(range(ndim), n_dim_to_test):
             arg = arg_constr()
@@ -7188,7 +7188,7 @@ class TestTorchDeviceType(TestCase):
             for i in range(num_matrices):
                 tensors_batch[i, ...] = tensors_list[i]
 
-            tensors_exp_map = map(lambda x: x.matrix_exp(), tensors_list)
+            tensors_exp_map = (x.matrix_exp() for x in tensors_list)
             tensors_exp_batch = tensors_batch.matrix_exp()
 
             for i, tensor_exp in enumerate(tensors_exp_map):
@@ -15382,7 +15382,7 @@ class TestTorchDeviceType(TestCase):
         ]
 
         incorrect_byteorder = '>' if sys.byteorder == 'little' else '<'
-        incorrect_dtypes = map(lambda t: incorrect_byteorder + t, ['d', 'f'])
+        incorrect_dtypes = [incorrect_byteorder + t for t in ['d', 'f']]
 
         for dtype in correct_dtypes:
             array = np.array([1, 2, 3, 4], dtype=dtype)
@@ -19009,12 +19009,12 @@ else:
 
                         # Compare sequence input
                         torch_sequence_x = (x,) * random.randint(3, 10)
-                        np_sequence_x = tuple(map(lambda x: np.array(x.detach().cpu().numpy()), torch_sequence_x))
+                        np_sequence_x = tuple(np.array(x.detach().cpu().numpy()) for x in torch_sequence_x)
                         torch_res = torch_fn(*torch_sequence_x)
                         np_res = np_fn(*np_sequence_x)
 
-                        torch_res = tuple(map(lambda x: x.cpu(), torch_res))
-                        np_res = tuple(map(lambda x: torch.from_numpy(x), np_res))
+                        torch_res = tuple(x.cpu() for x in torch_res)
+                        np_res = tuple(torch.from_numpy(x) for x in np_res)
                         self.assertEqual(np_res, torch_res)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")

--- a/tools/codegen/api/types.py
+++ b/tools/codegen/api/types.py
@@ -309,7 +309,7 @@ class DispatcherSignature:
 
     # Return the C++ function type, e.g., something like int(bool)
     def type(self) -> str:
-        dispatcher_args_types_str = ', '.join(map(lambda a: a.type, self._arguments))
+        dispatcher_args_types_str = ', '.join(a.type for a in self._arguments)
         return f'{self._returns_type} ({dispatcher_args_types_str})'
 
     @staticmethod

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -230,7 +230,7 @@ def compute_type_method(
                 assert dispatch is not None
                 impl_name = f"at::native::{f.dispatch[dispatch]}"
 
-            args_exprs_str = ', '.join(map(lambda a: a.name, args))
+            args_exprs_str = ', '.join(a.name for a in args)
 
             return_kw = "    return "
 
@@ -355,7 +355,7 @@ def compute_function(*, target: Target) -> Callable[[NativeFunction], Optional[s
             dispatcher_sig = DispatcherSignature.from_schema(f.func)
 
             dispatcher_exprs = dispatcher.cpparguments_exprs(sig.argument_packs())
-            dispatcher_exprs_str = ', '.join(map(lambda a: a.expr, dispatcher_exprs))
+            dispatcher_exprs_str = ', '.join(a.expr for a in dispatcher_exprs)
 
             return f"""
 // aten::{f.func}
@@ -405,7 +405,7 @@ def compute_tensor_method(*, target: Target) -> Callable[[NativeFunction], Optio
             dispatcher_sig = DispatcherSignature.from_schema(f.func)
 
             dispatcher_exprs = dispatcher.cpparguments_exprs(sig.argument_packs())
-            dispatcher_exprs_str = ', '.join(map(lambda a: a.expr, dispatcher_exprs))
+            dispatcher_exprs_str = ', '.join(a.expr for a in dispatcher_exprs)
 
             return f"""
 // aten::{f.func}
@@ -455,7 +455,7 @@ def compute_native_function_declaration(f: NativeFunction) -> List[str]:
         seen.add(n)
         returns_type = native.returns_type(f.func.returns)
         args = native.arguments(f.func)
-        rs.append(f"CAFFE2_API {returns_type} {n}({', '.join(map(lambda a: a.str_with_default(), args))});")
+        rs.append(f"CAFFE2_API {returns_type} {n}({', '.join(a.str_with_default() for a in args)});")
 
     return rs
 

--- a/tools/shared/cwrap_common.py
+++ b/tools/shared/cwrap_common.py
@@ -130,7 +130,7 @@ class Function(object):
         self.arguments.append(arg)
 
     def __repr__(self):
-        return self.name + '(' + ', '.join(map(lambda a: a.__repr__(), self.arguments)) + ')'
+        return self.name + '(' + ', '.join(a.__repr__() for a in self.arguments) + ')'
 
 
 class Argument(object):
@@ -151,13 +151,13 @@ def parse_header(path):
     # Remove empty lines and prebackend directives
     lines = filter(lambda l: l and not l.startswith('#'), lines)
     # Remove line comments
-    lines = map(lambda l: l.partition('//'), lines)
+    lines = (l.partition('//') for l in lines)
     # Select line and comment part
-    lines = map(lambda l: (l[0].strip(), l[2].strip()), lines)
+    lines = ((l[0].strip(), l[2].strip()) for l in lines)
     # Remove trailing special signs
-    lines = map(lambda l: (l[0].rstrip(');').rstrip(','), l[1]), lines)
+    lines = ((l[0].rstrip(');').rstrip(','), l[1]) for l in lines)
     # Split arguments
-    lines = map(lambda l: (l[0].split(','), l[1]), lines)
+    lines = ((l[0].split(','), l[1]) for l in lines)
     # Flatten lines
     new_lines = []
     for l, c in lines:
@@ -166,7 +166,7 @@ def parse_header(path):
     lines = new_lines
     del new_lines
     # Remove unnecessary whitespace
-    lines = map(lambda l: (l[0].strip(), l[1]), lines)
+    lines = ((l[0].strip(), l[1]) for l in lines)
     # Remove empty lines
     lines = filter(lambda l: l[0], lines)
     generic_functions = []

--- a/torch/cuda/profiler.py
+++ b/torch/cuda/profiler.py
@@ -26,7 +26,7 @@ def init(output_file, flags=None, output_mode='key_value'):
     else:
         raise RuntimeError("supported CUDA profiler output modes are: key_value and csv")
     with tempfile.NamedTemporaryFile(delete=True) as f:
-        f.write(b'\n'.join(map(lambda f: f.encode('ascii'), flags)))
+        f.write(b'\n'.join(f.encode('ascii') for f in flags))
         f.flush()
         check_error(rt.cudaProfilerInitialize(f.name, output_file, output_mode_enum))
 

--- a/torch/jit/unsupported_tensor_ops.py
+++ b/torch/jit/unsupported_tensor_ops.py
@@ -35,8 +35,8 @@ def _gen_unsupported_methods_properties():
             else:
                 properties.append(attr)
 
-    mapped_methods = map(lambda x: "\t*  :meth:`~torch.Tensor." + x + r"`", methods)
-    mapped_properties = map(lambda x: "\t*  :attr:`~torch.Tensor." + x + r"`", properties)
+    mapped_methods = ("\t*  :meth:`~torch.Tensor." + x + r"`" for x in methods)
+    mapped_properties = ("\t*  :attr:`~torch.Tensor." + x + r"`" for x in properties)
     return "\n".join(mapped_methods), "\n".join(mapped_properties)
 
 

--- a/torch/nn/parallel/_functions.py
+++ b/torch/nn/parallel/_functions.py
@@ -10,7 +10,7 @@ class Broadcast(Function):
 
     @staticmethod
     def forward(ctx, target_gpus, *inputs):
-        assert all(map(lambda i: i.device.type != 'cpu', inputs)), (
+        assert all(i.device.type != 'cpu' for i in inputs), (
             'Broadcast function not implemented for CPU tensors'
         )
         target_gpus = list(map(lambda x: _get_device_index(x, True), target_gpus))
@@ -52,13 +52,13 @@ class Gather(Function):
 
     @staticmethod
     def forward(ctx, target_device, dim, *inputs):
-        assert all(map(lambda i: i.device.type != 'cpu', inputs)), (
+        assert all(i.device.type != 'cpu' for i in inputs), (
             'Gather function not implemented for CPU tensors'
         )
         target_device = _get_device_index(target_device, True)
         ctx.target_device = target_device
         ctx.dim = dim
-        ctx.input_gpus = tuple(map(lambda i: i.get_device(), inputs))
+        ctx.input_gpus = tuple(i.get_device() for i in inputs)
         if all(t.dim() == 0 for t in inputs) and dim == 0:
             inputs = tuple(t.view(1) for t in inputs)
             warnings.warn('Was asked to gather along dimension 0, but all '
@@ -67,7 +67,7 @@ class Gather(Function):
             ctx.unsqueezed_scalar = True
         else:
             ctx.unsqueezed_scalar = False
-        ctx.input_sizes = tuple(map(lambda i: i.size(ctx.dim), inputs))
+        ctx.input_sizes = tuple(i.size(ctx.dim) for i in inputs)
         return comm.gather(inputs, ctx.dim, ctx.target_device)
 
     @staticmethod

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4956,11 +4956,11 @@ class ModuleTest(TestBase):
             # are unreachable (which can happen if you differentiate
             # only on the gradient.
             cpu_gg = torch.autograd.grad(
-                cpu_output.sum() + sum(map(lambda x: x.sum(), cpu_gradInputs)),
+                cpu_output.sum() + sum(x.sum() for x in cpu_gradInputs),
                 cpu_input_tuple + (cpu_gradOutput,) + tuple(cpu_module.parameters()),
                 retain_graph=True)
             gpu_gg = torch.autograd.grad(
-                gpu_output.sum() + sum(map(lambda x: x.sum(), gpu_gradInputs)),
+                gpu_output.sum() + sum(x.sum() for x in gpu_gradInputs),
                 gpu_input_tuple + (gpu_gradOutput,) + tuple(gpu_module.parameters()),
                 retain_graph=True)
             # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -168,8 +168,7 @@ def require_backends_available(backends):
         if backend == dist.Backend.MPI:
             return dist.is_mpi_available()
         return False
-    backends = map(lambda b: dist.Backend(b), backends)
-    if not all(map(check, backends)):
+    if not all(check(dist.Backend(backend)) for backend in backends):
         return unittest.skip(
             "Test requires backends to be available %s" % backends)
     return lambda func: func

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -182,13 +182,13 @@ class JitTestCase(TestCase):
             files = list(filter(lambda x: x.startswith('archive/code/'), archive.namelist()))
             # unwrap all the code files into strings
             code_files_str = filter(lambda x: x.endswith('.py'), files)
-            code_files_stream = map(lambda f: archive.open(f), code_files_str)
-            code_files = map(lambda file: "".join([line.decode() for line in file]), code_files_stream)
+            code_files_stream = (archive.open(f) for f in code_files_str)
+            code_files = ("".join([line.decode() for line in file]) for file in code_files_stream)
 
             # unpickled all the debug files
             debug_files_str = filter(lambda f: f.endswith('.debug_pkl'), files)
-            debug_files_stream = map(lambda f: archive.open(f), debug_files_str)
-            debug_files = map(lambda f: pickle.load(f), debug_files_stream)
+            debug_files_stream = (archive.open(f) for f in debug_files_str)
+            debug_files = (pickle.load(f) for f in debug_files_stream)
             return code_files, debug_files
 
         # disable the hook while we parse code, otherwise we will re-enter the hook


### PR DESCRIPTION
Follow-up of #46461 with a similar goal

Makes them more readable and possibly faster. Care has to be taken because `map` applies the function immediately while `(x for x in xs)` is a generator expression which gets evaluated later. This is a benefit in some cases where it is not required to actually create the list of values in memory (e.g. when passing to `tuple` or `extend` or `join`)
