### PR TITLE
Check if pin_memory() is overridden before pinning Tensors

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -43,7 +43,9 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
 
 
 def pin_memory(data):
-    if isinstance(data, torch.Tensor):
+    if hasattr(data, "pin_memory"):
+        return data.pin_memory()
+    elif isinstance(data, torch.Tensor):
         return data.pin_memory()
     elif isinstance(data, string_classes):
         return data
@@ -53,7 +55,5 @@ def pin_memory(data):
         return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, container_abcs.Sequence):
         return [pin_memory(sample) for sample in data]
-    elif hasattr(data, "pin_memory"):
-        return data.pin_memory()
     else:
         return data


### PR DESCRIPTION
Often, it is not necessary to transfer all Tensors returned by the Dataset to the GPU. In these cases, it is unnecessary to perform the expensive pinning operation on all these tensors. However, with the current behavior, batches are pinned completely, unless they are of a very special type.
With the change in this PR, it becomes easy to override the pin_memory() function also for widely used batch types.

As an example we might have a dict-type batch with many items, but only the images have to be transferred to the GPU. With this change, a simple wrapper around the batch would pin only the necessary Tensors.

```
class PinnedMemoryBatch(dict):
    def __init__(self, batch):
        super().__init__(batch)

    def pin_memory(self):
        self['images'] = self['images'].pin_memory()
        return self
```