### PR TITLE
Move NCCL installation for xenial-cuda10.1 to Docker image instead of for every job

### DIFF
--- a/.circleci/docker/common/install_nccl.sh
+++ b/.circleci/docker/common/install_nccl.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo apt-get -qq update
+sudo apt-get -qq install --allow-downgrades --allow-change-held-packages libnccl-dev=2.5.6-1+cuda10.1 libnccl2=2.5.6-1+cuda10.1

--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -78,6 +78,11 @@ ADD ./common/install_jni.sh install_jni.sh
 ADD ./java/jni.h jni.h
 RUN bash ./install_jni.sh && rm install_jni.sh
 
+# Install NCCL for *-xenial-cuda10.1*-
+ADD ./common/install_nccl.sh install_nccl.sh
+RUN if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]]; then bash ./install_nccl.sh; fi
+RUN rm install_nccl.sh
+
 # Include BUILD_ENVIRONMENT environment variable in image
 ARG BUILD_ENVIRONMENT
 ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}

--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -80,7 +80,7 @@ RUN bash ./install_jni.sh && rm install_jni.sh
 
 # Install NCCL for *-xenial-cuda10.1*-
 ADD ./common/install_nccl.sh install_nccl.sh
-RUN if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]]; then bash ./install_nccl.sh; fi
+RUN if [ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]; then bash ./install_nccl.sh; fi
 RUN rm install_nccl.sh
 
 # Include BUILD_ENVIRONMENT environment variable in image

--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -78,9 +78,9 @@ ADD ./common/install_jni.sh install_jni.sh
 ADD ./java/jni.h jni.h
 RUN bash ./install_jni.sh && rm install_jni.sh
 
-# Install NCCL for *-xenial-cuda10.1*-
+# Install NCCL for when CUDA is version 10.1
 ADD ./common/install_nccl.sh install_nccl.sh
-RUN if [ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]; then bash ./install_nccl.sh; fi
+RUN if [ "${CUDA_VERSION}" = 10.1 ]; then bash ./install_nccl.sh; fi
 RUN rm install_nccl.sh
 
 # Include BUILD_ENVIRONMENT environment variable in image

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -21,12 +21,6 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 # (2) build with NCCL and MPI
 # (3) build with only MPI
 # (4) build with neither
-if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]]; then
-  # TODO: move this to Docker
-  sudo apt-get -qq update
-  sudo apt-get -qq install --allow-downgrades --allow-change-held-packages libnccl-dev=2.5.6-1+cuda10.1 libnccl2=2.5.6-1+cuda10.1
-fi
-
 if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda9*gcc7* ]] || [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda9*gcc5* ]] || [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]] || [[ "$BUILD_ENVIRONMENT" == *-trusty-py2.7.9* ]]; then
   # TODO: move this to Docker
   sudo apt-get -qq update

--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -14,12 +14,6 @@ if [ -n "${IN_CIRCLECI}" ]; then
   # TODO move this to docker
   pip_install unittest-xml-reporting
 
-  if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]]; then
-    # TODO: move this to Docker
-    sudo apt-get update
-    sudo apt-get install -y --allow-downgrades --allow-change-held-packages libnccl-dev=2.5.6-1+cuda10.1 libnccl2=2.5.6-1+cuda10.1
-  fi
-
   if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-cudnn7-py3* ]]; then
     # TODO: move this to Docker
     sudo apt-get update

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -15,12 +15,6 @@ if [ -n "${IN_CIRCLECI}" ]; then
   # TODO move this to docker
   pip_install unittest-xml-reporting coverage pytest
 
-  if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-* ]]; then
-    # TODO: move this to Docker
-    sudo apt-get -qq update
-    sudo apt-get -qq install --allow-downgrades --allow-change-held-packages libnccl-dev=2.5.6-1+cuda10.1 libnccl2=2.5.6-1+cuda10.1
-  fi
-
   if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda10.1-cudnn7-py3* ]]; then
     # TODO: move this to Docker
     sudo apt-get -qq update


### PR DESCRIPTION
Instead of installing NCCL for every build and test job with environment `*-xenial-cuda10.1-*`, install NCCL into the Docker image. This would save time and remove duplication in our scripts.