### PR TITLE
Disable profiling when `getGraphExecutorOptimize` is unset

### DIFF
--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -736,7 +736,13 @@ c10::intrusive_ptr<Future> GraphExecutor::runAsync(Stack& stack) {
 }
 
 size_t GraphExecutor::getDefaultNumBailOuts() {
-  return getProfilingMode() ? getBailoutDepth().load() : 0;
+  // if getGraphExecutorOptimize is not set we shouldn't
+  // be profiling. Returning 0 makes us run SimpleExecutor
+  // which in turn also checks getGraphExecutorOptimize
+  // and runs only required passes
+  return getProfilingMode() && getGraphExecutorOptimize()
+      ? getBailoutDepth().load()
+      : 0;
 }
 
 ExecutionPlan GraphExecutor::getPlanFor(

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -736,13 +736,7 @@ c10::intrusive_ptr<Future> GraphExecutor::runAsync(Stack& stack) {
 }
 
 size_t GraphExecutor::getDefaultNumBailOuts() {
-  // if getGraphExecutorOptimize is not set we shouldn't
-  // be profiling. Returning 0 makes us run SimpleExecutor
-  // which in turn also checks getGraphExecutorOptimize
-  // and runs only required passes
-  return getProfilingMode() && getGraphExecutorOptimize()
-      ? getBailoutDepth().load()
-      : 0;
+  return getProfilingMode() ? getBailoutDepth().load() : 0;
 }
 
 ExecutionPlan GraphExecutor::getPlanFor(

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -488,12 +488,6 @@ ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(
   // replaces a fallback graph inserted by
   // specialize_autogradzero if one exists
   replaceFallbackGraphWithFallbackFunction(copy->block());
-  // Make sure there are no prim::profile nodes
-  // in the optimized graph
-  // An example of how this may happen is
-  // a user disables optimizations after they
-  // already did a profiling run
-  RemoveProfilingNodes(copy);
   GRAPH_DUMP("Optimized Graph: ", copy);
   optimized_plan_ =
       ExecutionPlan(copy, function_name_, *remaining_bailout_depth_);

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
@@ -22,6 +22,8 @@ struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   c10::optional<ExecutionPlan>
       profiling_plan_; // plan to run in order to profiling the code
   c10::optional<ExecutionPlan> optimized_plan_;
+  // this plan is used if getGraphExecutorOptimize is unset
+  c10::optional<ExecutionPlan> fallback_plan_;
   // fallback functions are inserted for tensorexpr fusion groups
   // and by specialize_autogradzero. Whenever, at runtime, input
   // tensor don't match profiled properties, fallback functions are called


### PR DESCRIPTION
`getGraphExecutorOptimize` mandates we don't do any optimizations beyond what's required to run graphs. In this scenario, we don't want to do any profiling as profiling information will not be used.
