### PR TITLE
[TensorExpr] Fix shape inference logic for aten::cat.

### DIFF
--- a/test/cpp/tensorexpr/test_kernel.cpp
+++ b/test/cpp/tensorexpr/test_kernel.cpp
@@ -349,7 +349,7 @@ void testKernel_4() {
     parseIR(graph_string, &*graph);
     auto compile = [&]() {
       TensorExprKernel k(graph);
-      Stmt* s = k.getCodeGenStmt();
+      k.getCodeGenStmt();
     };
     ASSERT_THROWS_WITH(compile(), "Empty input list is passed to aten::cat");
   }

--- a/test/cpp/tensorexpr/test_kernel.cpp
+++ b/test/cpp/tensorexpr/test_kernel.cpp
@@ -335,6 +335,24 @@ void testKernel_4() {
       CHECK_EQ(((float*)o.data_ptr())[i], ((float*)ref.data_ptr())[i]);
     }
   }
+  {
+    // Test that we throw an error when input list for aten::cat is empty
+    KernelScope kernel_scope;
+
+    const auto graph_string = R"IR(
+      graph():
+        %dim : int = prim::Constant[value=1]()
+        %inputs : Tensor[] = prim::ListConstruct()
+        %r : Tensor = aten::cat(%inputs, %dim)
+        return (%r))IR";
+    auto graph = std::make_shared<Graph>();
+    parseIR(graph_string, &*graph);
+    auto compile = [&]() {
+      TensorExprKernel k(graph);
+      Stmt* s = k.getCodeGenStmt();
+    };
+    ASSERT_THROWS_WITH(compile(), "Empty input list is passed to aten::cat");
+  }
 }
 
 namespace {

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1057,13 +1057,12 @@ class TestTensorExprFuser(BaseTestClass):
 
     def _test_cat_negative_dim(self, device):
         def foo(*args):
-            args_2 = [v + i for i, v in enumerate(args)]
-            v = torch.cat(args_2, dim=-1)
+            v = torch.cat(args, dim=-1)
             return v * v
 
         M = 16
         Ns = [128, 16, 1]
-        values = [torch.zeros(M, N, device=device) for N in Ns]
+        values = [torch.randn(M, N, device=device) for N in Ns]
         traced = torch.jit.trace(foo, values)
 
         x = warmup_and_run_forward(traced, *values)

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -324,25 +324,29 @@ std::vector<ExprHandle> TensorExprKernel::inferSizesForValue(
       // The sizes of the output tensor on that dimension is a sum of the
       // corresponding sizes of the input tensors, the other dimension have the
       // same sizes.
-      // Negative dim will correspond to dim = dim + input.dim() + 1.
+      // Negative dim will correspond to dim = dim + input.dim().
       auto const& n = v->node();
       auto inputs = n->input(0)->node()->inputs();
+      if (inputs.size() == 0) {
+        throw std::runtime_error("Empty input list is passed to aten::cat");
+      }
+
       TORCH_INTERNAL_ASSERT(n->input(1)->node()->kind() == prim::Constant);
       int64_t dim = n->input(1)->node()->i(attr::value);
-
-      ExprHandle concat_size = IntImm::make(0);
-      for (auto input : inputs) {
-        concat_size = concat_size + sizesForValue(input)[dim];
-      }
-      concat_size = IRSimplifier::simplify(concat_size);
       auto shape = sizesForValue(inputs[0]);
       if (dim < 0) {
-        dim = dim + shape.size() + 1;
+        dim += shape.size();
       }
       if (dim < 0 || dim > shape.size()) {
         throw std::runtime_error("Invalid 'dim' input in aten::cat");
       }
-      shape[dim] = concat_size;
+
+      ExprHandle concat_dim_size = 0;
+      for (auto input : inputs) {
+        concat_dim_size = concat_dim_size + sizesForValue(input)[dim];
+      }
+      concat_dim_size = IRSimplifier::simplify(concat_dim_size);
+      shape[dim] = concat_dim_size;
       return shape;
     }
 
@@ -1182,6 +1186,10 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
           [this, v](const std::vector<VarHandle>& axes) {
             auto const& n = v->node();
             auto inputs = n->inputs()[0]->node()->inputs();
+            if (inputs.size() == 0) {
+              throw std::runtime_error(
+                  "Empty input list is passed to aten::cat");
+            }
             int64_t dim = n->inputs()[1]->node()->i(attr::value);
             if (dim < 0) {
               dim += axes.size();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46447 [TensorExpr] Re-enable test for torch.cat, add a test for torch.cat being a single node in a fusion group.
* #46500 [TensorExpr] Properly handle input types promotion and special case of empty inputs for aten::cat.
* **#46482 [TensorExpr] Fix shape inference logic for aten::cat.**

Differential Revision: [D24366778](https://our.internmc.facebook.com/intern/diff/D24366778)