### PR TITLE
Expose script_if_tracing as public API

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -45,6 +45,7 @@ Creating TorchScript Code
 
     script
     trace
+    script_if_tracing
     trace_module
     fork
     wait

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3096,7 +3096,7 @@ def foo(x):
         FileCheck().check_not("goodbye").check_not("hello").run(traced_bad.graph)
 
         # Working example
-        untraceable = torch.jit._script_if_tracing(untraceable)
+        untraceable = torch.jit.script_if_tracing(untraceable)
 
         def fn2(x):
             return untraceable(x)
@@ -3109,7 +3109,7 @@ def foo(x):
         def foo(x: int):
             return x + 1
 
-        @torch.jit._script_if_tracing
+        @torch.jit.script_if_tracing
         def fee(x: int = 2):
             return foo(1) + x
 

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -49,7 +49,7 @@ def _log_modified_bessel_fn(x, order=0):
     return result
 
 
-@torch.jit._script_if_tracing
+@torch.jit.script_if_tracing
 def _rejection_sample(loc, concentration, proposal_r, x):
     done = torch.zeros(x.shape, dtype=torch.bool, device=loc.device)
     while not done.all():

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -70,5 +70,26 @@ def annotate(the_type, the_value):
     return the_value
 
 
+def script_if_tracing(fn):
+    """
+    Compiles ``fn`` when it is first called during tracing. ``torch.jit.script``
+    has a non-negligible start up time when it is first called due to
+    lazy-initializations of many compiler builtins. Therefore you should not use
+    it in library code. However, you may want to have parts of your library work
+    in tracing even if they use control flow. In these cases, you should use
+    ``@torch.jit.script_if_tracing`` to substitute for
+    ``torch.jit.script``.
+
+    Arguments:
+        fn: A function to compile.
+
+    Returns:
+        If called during tracing, a :class:`ScriptFunction` created by `torch.jit.script` is returned.
+        Otherwise, the original function `fn` is returned.
+    """
+
+    return _script_if_tracing(fn)
+
+
 if not torch._C._jit_init():
     raise RuntimeError("JIT initialization failed")

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1083,16 +1083,6 @@ class TopLevelTracedModule(TracedModule):
 
 
 def _script_if_tracing(fn):
-    """
-    Compiles ``fn`` when it is first called during tracing. ``torch.jit.script``
-    has a non-negligible start up time when it is first called due to
-    lazy-initializations of many compiler builtins. Therefore you should not use
-    it in library code. However, you may want to have parts of your library work
-    in tracing even if they use control flow. In these cases, you should use
-    ``@torch.jit._script_if_tracing`` to substitute for
-    ``torch.jit.script``.
-    """
-
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         if not is_tracing():


### PR DESCRIPTION
Fixes #45921

`@torch.jit._script_if_tracing` is still kept for BC