### PR TITLE
Removing hack so that NCCL is not removed in base Docker commands

### DIFF
--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -49,12 +49,6 @@ install_ubuntu() {
     wget \
     vim
 
-  # TODO: THIS IS A HACK!!!
-  # distributed nccl(2) tests are a bit busted, see https://github.com/pytorch/pytorch/issues/5877
-  if dpkg -s libnccl-dev; then
-    apt-get remove -y libnccl-dev libnccl2 --allow-change-held-packages
-  fi
-
   # Cleanup package manager
   apt-get autoclean && apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This hack was introduced in 2018 and should be able to b removed now. Previously, all Docker images removed NCCL installation to allow some distributed tests to pass: https://github.com/pytorch/pytorch/issues/5877 

This should no longer be the case.