### PR TITLE
[Gradient Compression] Rename the first arg of pybinding of _register_comm_hook: ddp_model -> reducer.

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -149,7 +149,7 @@ PyObject* c10d_init(PyObject* _unused, PyObject* noargs) {
   module.def(
       "_register_comm_hook",
       &_register_comm_hook,
-      py::arg("ddp_model"),
+      py::arg("reducer"),
       py::arg("state"),
       py::arg("comm_hook"));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46498 [Gradient Compression] Rename the first arg of pybinding of _register_comm_hook: ddp_model -> reducer.**

The name of the first arg "ddp_model" is misleading, because it is actually the reducer of DDP model rather than entire model.

This method is called in the file caffe2/torch/nn/parallel/distributed.py:
`dist._register_comm_hook(self.reducer, state, hook)`

Differential Revision: [D24372827](https://our.internmc.facebook.com/intern/diff/D24372827/)