### PR TITLE
Add an option to getWriteableTensorData to avoid copy CUDA tensor to CPU

### DIFF
--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -596,12 +596,13 @@ void Pickler::pushTuple(const IValue& ivalue) {
   }
 }
 
-WriteableTensorData getWriteableTensorData(const at::Tensor& tensor) {
+WriteableTensorData getWriteableTensorData(
+    const at::Tensor& tensor, bool toCpu) {
   WriteableTensorData result;
   result.tensor_ = tensor;
   result.size_ = tensor.storage().nbytes();
   // TODO HIP support
-  if (tensor.storage().device_type() == DeviceType::CUDA) {
+  if (tensor.storage().device_type() == DeviceType::CUDA && toCpu) {
     // NB: This new tensor is created to support cuda tensors.
     // Storages can be mutated when converting tensors from cuda to cpu,
     // and we need a cpu tensor to copy data from.

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -598,12 +598,12 @@ void Pickler::pushTuple(const IValue& ivalue) {
 
 WriteableTensorData getWriteableTensorData(
     const at::Tensor& tensor,
-    bool toCpu) {
+    bool to_cpu) {
   WriteableTensorData result;
   result.tensor_ = tensor;
   result.size_ = tensor.storage().nbytes();
   // TODO HIP support
-  if (tensor.storage().device_type() == DeviceType::CUDA && toCpu) {
+  if (tensor.storage().device_type() == DeviceType::CUDA && to_cpu) {
     // NB: This new tensor is created to support cuda tensors.
     // Storages can be mutated when converting tensors from cuda to cpu,
     // and we need a cpu tensor to copy data from.

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -597,7 +597,8 @@ void Pickler::pushTuple(const IValue& ivalue) {
 }
 
 WriteableTensorData getWriteableTensorData(
-    const at::Tensor& tensor, bool toCpu) {
+    const at::Tensor& tensor,
+    bool toCpu) {
   WriteableTensorData result;
   result.tensor_ = tensor;
   result.size_ = tensor.storage().nbytes();

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -266,9 +266,8 @@ class TORCH_API Pickler {
 
 // returns a (tensor, record_size) for a tensor, converting it to a CPU tensor
 // if it was CUDA and toCpu is True.
-TORCH_API WriteableTensorData getWriteableTensorData(
-    const at::Tensor& tensor,
-    bool toCpu=true);
+TORCH_API WriteableTensorData
+getWriteableTensorData(const at::Tensor& tensor, bool toCpu = true);
 
 // return the value of the tensor's storage pointer
 uint64_t getStorageKey(const at::Tensor& tensor);

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -107,7 +107,7 @@ struct WriteableTensorData {
 
  private:
   friend TORCH_API WriteableTensorData
-  getWriteableTensorData(const at::Tensor& tensor);
+  getWriteableTensorData(const at::Tensor& tensor, bool toCpu);
   at::Tensor tensor_;
   uint64_t size_;
 };
@@ -266,7 +266,8 @@ class TORCH_API Pickler {
 
 // returns a (tensor, record_size) for a tensor, converting it to a CPU tensor
 // if necessary
-TORCH_API WriteableTensorData getWriteableTensorData(const at::Tensor& tensor);
+TORCH_API WriteableTensorData getWriteableTensorData(
+    const at::Tensor& tensor, bool toCpu=true);
 
 // return the value of the tensor's storage pointer
 uint64_t getStorageKey(const at::Tensor& tensor);

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -265,9 +265,10 @@ class TORCH_API Pickler {
 };
 
 // returns a (tensor, record_size) for a tensor, converting it to a CPU tensor
-// if necessary
+// if it was CUDA and toCpu is True.
 TORCH_API WriteableTensorData getWriteableTensorData(
-    const at::Tensor& tensor, bool toCpu=true);
+    const at::Tensor& tensor,
+    bool toCpu=true);
 
 // return the value of the tensor's storage pointer
 uint64_t getStorageKey(const at::Tensor& tensor);

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -265,7 +265,7 @@ class TORCH_API Pickler {
 };
 
 // returns a (tensor, record_size) for a tensor, converting it to a CPU tensor
-// if it was CUDA and toCpu is True.
+// if it was CUDA and to_cpu is True.
 TORCH_API WriteableTensorData
 getWriteableTensorData(const at::Tensor& tensor, bool to_cpu = true);
 

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -107,7 +107,7 @@ struct WriteableTensorData {
 
  private:
   friend TORCH_API WriteableTensorData
-  getWriteableTensorData(const at::Tensor& tensor, bool toCpu);
+  getWriteableTensorData(const at::Tensor& tensor, bool to_cpu);
   at::Tensor tensor_;
   uint64_t size_;
 };
@@ -267,7 +267,7 @@ class TORCH_API Pickler {
 // returns a (tensor, record_size) for a tensor, converting it to a CPU tensor
 // if it was CUDA and toCpu is True.
 TORCH_API WriteableTensorData
-getWriteableTensorData(const at::Tensor& tensor, bool toCpu = true);
+getWriteableTensorData(const at::Tensor& tensor, bool to_cpu = true);
 
 // return the value of the tensor's storage pointer
 uint64_t getStorageKey(const at::Tensor& tensor);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44418 [WIP] Use streams from pool on RPC callees
* **#46524 Add an option to getWriteableTensorData to avoid copy CUDA tensor to CPU**
* #46523 Enable TP_USE_CUDA and TP_ENABLE_CUDA_IPC

Differential Revision: [D24392794](https://our.internmc.facebook.com/intern/diff/D24392794)