### PR TITLE
Free original weight after prepacking in XNNPACK based op

### DIFF
--- a/aten/src/ATen/native/xnnpack/OpContext.h
+++ b/aten/src/ATen/native/xnnpack/OpContext.h
@@ -43,13 +43,16 @@ class LinearOpContext : public torch::jit::CustomClassHolder {
   c10::optional<Tensor> orig_bias_;
   c10::optional<Scalar> output_min_;
   c10::optional<Scalar> output_max_;
+  bool orig_weight_and_bias_freed_;
 
  public:
   SerializationTypeLinearPrePack unpack() {
+    TORCH_CHECK(!orig_weight_and_bias_freed_, "Original weight and bias have been freed");
     return std::make_tuple(orig_weight_, orig_bias_, output_min_, output_max_);
   }
 
   virtual Tensor run(const Tensor& input) = 0;
+  virtual void free_orig_weight_and_bias() = 0;
 };
 
 class XNNPackLinearOpContext final : public LinearOpContext {
@@ -68,9 +71,11 @@ class XNNPackLinearOpContext final : public LinearOpContext {
     orig_bias_ = std::move(bias);
     output_min_ = min;
     output_max_ = max;
+    orig_weight_and_bias_freed_ = false;
   }
 
   Tensor run(const Tensor& input) override;
+  void free_orig_weight_and_bias() override;
 
   static c10::intrusive_ptr<LinearOpContext> create_context(
       Tensor&& weight,
@@ -89,9 +94,11 @@ class Conv2dOpContext : public torch::jit::CustomClassHolder {
   int64_t groups_;
   c10::optional<Scalar> output_min_;
   c10::optional<Scalar> output_max_;
+  bool orig_weight_and_bias_freed_;
 
  public:
   SerializationTypeConv2dPrePack unpack() {
+    TORCH_CHECK(!orig_weight_and_bias_freed_, "Original weight and bias have been freed");
     return std::make_tuple(
         orig_weight_,
         orig_bias_,
@@ -104,6 +111,7 @@ class Conv2dOpContext : public torch::jit::CustomClassHolder {
   }
 
   virtual Tensor run(const Tensor& input) = 0;
+  virtual void free_orig_weight_and_bias() = 0;
 };
 
 class TransposeConv2dOpContext : public torch::jit::CustomClassHolder {
@@ -117,9 +125,11 @@ class TransposeConv2dOpContext : public torch::jit::CustomClassHolder {
   int64_t groups_;
   c10::optional<Scalar> output_min_;
   c10::optional<Scalar> output_max_;
+  bool orig_weight_and_bias_freed_;
 
  public:
   SerializationTypeTransposeConv2dPrePack unpack() {
+    TORCH_CHECK(!orig_weight_and_bias_freed_, "Original weight and bias have been freed");
     return std::make_tuple(
         orig_weight_,
         orig_bias_,
@@ -133,6 +143,7 @@ class TransposeConv2dOpContext : public torch::jit::CustomClassHolder {
   }
 
   virtual Tensor run(const Tensor& input) = 0;
+  virtual void free_orig_weight_and_bias() = 0;
 };
 
 class XNNPackConv2dOpContext final : public Conv2dOpContext {
@@ -159,9 +170,11 @@ class XNNPackConv2dOpContext final : public Conv2dOpContext {
     groups_ = groups;
     output_min_ = min;
     output_max_ = max;
+    orig_weight_and_bias_freed_ = false;
   }
 
   Tensor run(const Tensor& input) override;
+  void free_orig_weight_and_bias() override;
 
   static c10::intrusive_ptr<Conv2dOpContext> create_context(
       Tensor&& weight,
@@ -200,9 +213,11 @@ class XNNPackTransposeConv2dOpContext final : public TransposeConv2dOpContext {
     groups_ = groups;
     output_min_ = min;
     output_max_ = max;
+    orig_weight_and_bias_freed_ = false;
   }
 
   Tensor run(const Tensor& input) override;
+  void free_orig_weight_and_bias() override;
 
   static c10::intrusive_ptr<TransposeConv2dOpContext> create_context(
       Tensor&& weight,

--- a/aten/src/ATen/native/xnnpack/OpContext.h
+++ b/aten/src/ATen/native/xnnpack/OpContext.h
@@ -70,7 +70,7 @@ class XNNPackLinearOpContext final : public LinearOpContext {
     output_max_ = max;
   }
 
-  Tensor run(const Tensor& input);
+  Tensor run(const Tensor& input) override;
 
   static c10::intrusive_ptr<LinearOpContext> create_context(
       Tensor&& weight,

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/math_kernel_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/memory_overlapping_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/mobile_memory_cleanup.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_generator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_profiling_allocator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pow_test.cpp

--- a/aten/src/ATen/test/mobile_memory_cleanup.cpp
+++ b/aten/src/ATen/test/mobile_memory_cleanup.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include <torch/csrc/jit/passes/xnnpack_rewrite.h>
+#include <torch/torch.h>
+
+using namespace torch::jit;
+
+#ifdef USE_XNNPACK
+
+TEST(MemoryCleanUp, NoErrorWithoutRelease) {
+  Module m("m");
+  m.register_parameter("weight", torch::ones({20, 1, 5, 5}), false);
+  m.register_parameter("bias", torch::ones({20}), false);
+  m.define(R"(
+    def forward(self, input):
+      return torch._convolution(input, self.weight, self.bias, [1, 1], [0, 0], [1, 1], False, [0, 0], 1, False, False, True, True)
+  )");
+  m.eval();
+  auto m_optimized = optimizeForMobile(m);
+  std::stringstream ss;
+  EXPECT_NO_THROW(m_optimized.save(ss));
+}
+
+TEST(MemoryCleanUp, UnpackError) {
+  at::globalContext().setReleaseWeightsWhenPrepacking(true);
+  Module m("m");
+  m.register_parameter("weight", torch::ones({20, 1, 5, 5}), false);
+  m.register_parameter("bias", torch::ones({20}), false);
+  m.define(R"(
+    def forward(self, input):
+      return torch._convolution(input, self.weight, self.bias, [1, 1], [0, 0], [1, 1], False, [0, 0], 1, False, False, True, True)
+  )");
+  m.eval();
+  auto m_optimized = optimizeForMobile(m);
+  std::stringstream ss;
+  EXPECT_ANY_THROW(m_optimized.save(ss));
+}
+
+#endif


### PR DESCRIPTION
Summary: When weights are prepacked XNNPACK packs the weights in a separate memory. After that original weights are not needed for inference. Having those weights lying around increase memory footprint, so we would like to remove the original weights once prepacking is done.

Differential Revision: D24280928

