### PR TITLE
Add error messages and workaround for RET failure of containers with a torch class type

### DIFF
--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -131,6 +131,18 @@ std::pair<IValue, c10::optional<IValue>> getFunctionTuple(
                 "use a dictionary type's key-value pair itmes or ",
                 "a pytorch class (class Foo(torch.nn.Module))'s attributes.'");
           }
+        } else if (
+            input_type->kind() == TypeKind::ListType ||
+            input_type->kind() == TypeKind::DictType) {
+          for (const TypePtr& element_type : input_type->containedTypes()) {
+            TORCH_CHECK(
+                element_type->kind() != TypeKind::ClassType,
+                "Returining a list or dictionary with pytorch class type ",
+                "is not supported in mobile module "
+                "(List[Foo] or Dict[int, Foo] for class Foo(torch.nn.Module)). "
+                "Workaround: instead of using pytorch class as their element type, ",
+                "use a combination of list, dictionary, and single types.");
+          }
         }
       }
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46543 Add error messages and workaround for RET failure of containers with a torch class type**

Add error messages and workaround for RET failure of containers with a torch class type.
 - Error case condition
  1) ins.op == RET
  2) input_type == TypeKind::ListType or TypeKind::DictType
  3) Any(input_type's element type) == TypeKind::ClassType

Differential Revision: [D24388483](https://our.internmc.facebook.com/intern/diff/D24388483/)