### PR TITLE
Adding profiling option for pytorch build

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -84,11 +84,7 @@ CONFIG_TREE_DATA = [
         ("gcc", [
             ("9", [
                 ("3.8", [
-                    ("profile", [
-                        (True, [
-                            ('build_only', [XImportant(True)]),
-                        ]),
-                    ]),
+                    ("profile", [XImportant(True)]),
                     ("coverage", [XImportant(True)]),
                 ]),
             ]),

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -84,6 +84,11 @@ CONFIG_TREE_DATA = [
         ("gcc", [
             ("9", [
                 ("3.8", [
+                    ("profile", [
+                        (True, [
+                            ('build_only', [XImportant(True)]),
+                        ]),
+                    ]),
                     ("coverage", [XImportant(True)]),
                 ]),
             ]),
@@ -162,6 +167,7 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
 
         next_nodes = {
             "asan": AsanConfigNode,
+            "profile": ProfileConfigNode,
             "xla": XlaConfigNode,
             "vulkan": VulkanConfigNode,
             "parallel_tbb": ParallelTBBConfigNode,
@@ -206,6 +212,17 @@ class AsanConfigNode(TreeConfigNode):
 
     def init2(self, node_name):
         self.props["is_asan"] = node_name
+
+    def child_constructor(self):
+        return ExperimentalFeatureConfigNode
+
+
+class ProfileConfigNode(TreeConfigNode):
+    def modify_label(self, label):
+        return "Profile=" + str(label)
+
+    def init2(self, node_name):
+        self.props["profile"] = node_name
 
     def child_constructor(self):
         return ExperimentalFeatureConfigNode

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -315,7 +315,6 @@ def instantiate_configs():
         if profile:
             parms_list_ignored_for_docker_image.append("profile")
             python_version = fc.find_prop("pyver")
-            parms_list[0] = fc.find_prop("abbreviated_pyver")
             restrict_phases = ["build"]
 
         if is_onnx:

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -272,6 +272,7 @@ def instantiate_configs():
         compiler_version = fc.find_prop("compiler_version")
         is_xla = fc.find_prop("is_xla") or False
         is_asan = fc.find_prop("is_asan") or False
+        profile = fc.find_prop("profile") or False
         is_onnx = fc.find_prop("is_onnx") or False
         is_pure_torch = fc.find_prop("is_pure_torch") or False
         is_vulkan = fc.find_prop("is_vulkan") or False
@@ -310,6 +311,12 @@ def instantiate_configs():
             parms_list.append("asan")
             python_version = fc.find_prop("pyver")
             parms_list[0] = fc.find_prop("abbreviated_pyver")
+
+        if profile:
+            parms_list_ignored_for_docker_image.append("profile")
+            python_version = fc.find_prop("pyver")
+            parms_list[0] = fc.find_prop("abbreviated_pyver")
+            restrict_phases = ["build"]
 
         if is_onnx:
             parms_list.append("onnx")

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -315,7 +315,6 @@ def instantiate_configs():
         if profile:
             parms_list_ignored_for_docker_image.append("profile")
             python_version = fc.find_prop("pyver")
-            restrict_phases = ["build"]
 
         if is_onnx:
             parms_list.append("onnx")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,6 +653,7 @@ jobs:
               echo "Retrieving coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov
           fi
@@ -6864,6 +6865,13 @@ workflows:
             - "docker-pytorch-linux-bionic-py3.8-gcc9"
           build_environment: "pytorch-linux-bionic-py3.8-gcc9-profile-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
+      - pytorch_linux_test:
+          name: pytorch_linux_bionic_py3_8_gcc9_profile_test
+          requires:
+            - pytorch_linux_bionic_py3_8_gcc9_profile_build
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-profile-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
+          resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_bionic_py3_8_gcc9_build
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6859,6 +6859,12 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9"
           resource_class: large
       - pytorch_linux_build:
+          name: pytorch_linux_bionic_py3_gcc9_profile_build
+          requires:
+            - "docker-pytorch-linux-bionic-py3-gcc9"
+          build_environment: "pytorch-linux-bionic-py3-gcc9-profile-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3-gcc9"
+      - pytorch_linux_build:
           name: pytorch_linux_bionic_py3_8_gcc9_build
           requires:
             - "docker-pytorch-linux-bionic-py3.8-gcc9"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,9 +650,14 @@ jobs:
           echo "Retrieving test reports"
           docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
-              echo "Retrieving coverage report"
+              echo "Retrieving Python coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              python3 -mpip install codecov
+              python3 -mcodecov
+          fi
+          if [[ ${BUILD_ENVIRONMENT} == *"profile"* ]]; then
+              echo "Retrieving C++ coverage report"
               docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6859,11 +6859,11 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9"
           resource_class: large
       - pytorch_linux_build:
-          name: pytorch_linux_bionic_py3_gcc9_profile_build
+          name: pytorch_linux_bionic_py3_8_gcc9_profile_build
           requires:
-            - "docker-pytorch-linux-bionic-py3-gcc9"
-          build_environment: "pytorch-linux-bionic-py3-gcc9-profile-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3-gcc9"
+            - "docker-pytorch-linux-bionic-py3.8-gcc9"
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-profile-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
       - pytorch_linux_build:
           name: pytorch_linux_bionic_py3_8_gcc9_build
           requires:

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -219,6 +219,7 @@ jobs:
               echo "Retrieving coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov
           fi

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -216,9 +216,14 @@ jobs:
           echo "Retrieving test reports"
           docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
-              echo "Retrieving coverage report"
+              echo "Retrieving Python coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              python3 -mpip install codecov
+              python3 -mcodecov
+          fi
+          if [[ ${BUILD_ENVIRONMENT} == *"profile"* ]]; then
+              echo "Retrieving C++ coverage report"
               docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -225,6 +225,9 @@ else
     if [[ "$BUILD_ENVIRONMENT" != *ppc64le*  && "$BUILD_ENVIRONMENT" != *clang* ]]; then
       WERROR=1 python setup.py bdist_wheel
       python -mpip install dist/*.whl
+    elif [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
+      CC=/usr/bin/gcc python setup.py bdist_wheel
+      python -mpip install dist/*.whl
     else
       python setup.py bdist_wheel
       python -mpip install dist/*.whl
@@ -321,8 +324,4 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   python setup.py install
   popd
   assert_git_not_dirty
-fi
-
-if [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
-  CC=/usr/bin/gcc python setup.py install
 fi

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -58,6 +58,11 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   nvcc --version
 fi
 
+if [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
+  # enable build option in CMake
+  export USE_CPP_CODE_COVERAGE=ON
+fi
+
 # TODO: Don't run this...
 pip_install -r requirements.txt || true
 

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -222,11 +222,11 @@ else
     # ppc64le build fails when WERROR=1
     # set only when building other architectures
     # only use for "python setup.py install" line
-    if [[ "$BUILD_ENVIRONMENT" != *ppc64le*  && "$BUILD_ENVIRONMENT" != *clang* ]]; then
-      WERROR=1 python setup.py bdist_wheel
+    if [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
+      CC=/usr/bin/gcc WERROR=1 python setup.py bdist_wheel
       python -mpip install dist/*.whl
-    elif [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
-      CC=/usr/bin/gcc python setup.py bdist_wheel
+    elif [[ "$BUILD_ENVIRONMENT" != *ppc64le*  && "$BUILD_ENVIRONMENT" != *clang* ]]; then
+      WERROR=1 python setup.py bdist_wheel
       python -mpip install dist/*.whl
     else
       python setup.py bdist_wheel

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -322,3 +322,7 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   popd
   assert_git_not_dirty
 fi
+
+if [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
+  CC=/usr/bin/gcc python setup.py install
+fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -413,4 +413,10 @@ else
     time python -mcoverage xml
     popd
   fi
+  if [[ "$BUILD_ENVIRONMENT" = *profile* ]]; then
+    pushd build
+    echo "Generating lcov coverage report for C++ sources"
+    time lcov --capture --directory . --output-file coverage.info
+    popd
+  fi
 fi


### PR DESCRIPTION
In order to enable C++ code coverage for tests, we need to build pytorch with the correct coverage flags. This PR should introduce a build that allows profiling by dependent tests in the future.