### PR TITLE
Make TensorExpr Enums convertable to/from Strings

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -234,7 +234,6 @@ core_sources_full = [
     "torch/csrc/jit/tensorexpr/ir.cpp",
     "torch/csrc/jit/tensorexpr/ir_mutator.cpp",
     "torch/csrc/jit/tensorexpr/ir_printer.cpp",
-    "torch/csrc/jit/tensorexpr/ir_serializer.cpp",
     "torch/csrc/jit/tensorexpr/ir_simplifier.cpp",
     "torch/csrc/jit/tensorexpr/ir_visitor.cpp",
     "torch/csrc/jit/tensorexpr/kernel.cpp",

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -234,6 +234,7 @@ core_sources_full = [
     "torch/csrc/jit/tensorexpr/ir.cpp",
     "torch/csrc/jit/tensorexpr/ir_mutator.cpp",
     "torch/csrc/jit/tensorexpr/ir_printer.cpp",
+    "torch/csrc/jit/tensorexpr/ir_serializer.cpp",
     "torch/csrc/jit/tensorexpr/ir_simplifier.cpp",
     "torch/csrc/jit/tensorexpr/ir_visitor.cpp",
     "torch/csrc/jit/tensorexpr/kernel.cpp",

--- a/torch/csrc/jit/tensorexpr/types.h
+++ b/torch/csrc/jit/tensorexpr/types.h
@@ -31,6 +31,40 @@ enum class ScalarType : int8_t {
   NumOptions
 };
 
+static inline const char* toString(ScalarType t) {
+#define DEFINE_CASE(_, name) \
+  case ScalarType::name:     \
+    return #name;
+
+  switch (t) {
+    AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_CASE)
+    DEFINE_CASE(_, Undefined)
+    DEFINE_CASE(_, Handle)
+    DEFINE_CASE(_, Uninitialized)
+    DEFINE_CASE(_, None)
+    DEFINE_CASE(_, NumOptions)
+    default:
+      return "UNKNOWN_SCALAR";
+  }
+#undef DEFINE_CASE
+}
+
+static inline ScalarType toDtype(const std::string& s) {
+#define DEFINE_CASE(_, name) \
+  if (s == #name) {          \
+    return ScalarType::name; \
+  }
+  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(DEFINE_CASE)
+  DEFINE_CASE(_, Undefined)
+  DEFINE_CASE(, Handle)
+  DEFINE_CASE(_, Uninitialized)
+  DEFINE_CASE(_, None)
+  DEFINE_CASE(_, NumOptions)
+
+  assert(false);
+#undef DEFINE_CASE
+}
+
 TORCH_API std::ostream& operator<<(
     std::ostream& stream,
     const ScalarType& dtype);

--- a/torch/csrc/jit/tensorexpr/types.h
+++ b/torch/csrc/jit/tensorexpr/types.h
@@ -46,6 +46,8 @@ static inline const char* toString(ScalarType t) {
     default:
       return "UNKNOWN_SCALAR";
   }
+
+  assert(false);
 #undef DEFINE_CASE
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46553 [TensorExpr] Add serializer / deserializer
* **#46552 Make TensorExpr Enums convertable to/from Strings**
* #46551 [JIT] [Temp] Add dependency

Makes TensorExpr enums convertable to/from Strings, which is helpful for. having debuggable serialization.

