### PR TITLE
[TensorExpr] Add serializer / deserializer

### DIFF
--- a/test/cpp/tensorexpr/test_base.h
+++ b/test/cpp/tensorexpr/test_base.h
@@ -41,6 +41,9 @@
 
 #endif // defined(USE_GTEST)
 
+#include <torch/csrc/jit/tensorexpr/ir_deserializer.h>
+#include <torch/csrc/jit/tensorexpr/ir_serializer.h>
+
 namespace torch {
 namespace jit {
 namespace tensorexpr {
@@ -82,6 +85,7 @@ static void assertAllEqual(const std::vector<T>& v1, const std::vector<T>& v2) {
     ASSERT_EQ(v1[i], v2[i]);
   }
 }
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/test_base.h
+++ b/test/cpp/tensorexpr/test_base.h
@@ -41,9 +41,6 @@
 
 #endif // defined(USE_GTEST)
 
-#include <torch/csrc/jit/tensorexpr/ir_deserializer.h>
-#include <torch/csrc/jit/tensorexpr/ir_serializer.h>
-
 namespace torch {
 namespace jit {
 namespace tensorexpr {

--- a/test/cpp/tensorexpr/test_ir_printer.cpp
+++ b/test/cpp/tensorexpr/test_ir_printer.cpp
@@ -3,16 +3,24 @@
 
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_deserializer.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
+#include <torch/csrc/jit/tensorexpr/ir_serializer.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 #include <torch/csrc/jit/testing/file_check.h>
 
+#include <torch/csrc/jit/json.hpp>
 #include <sstream>
+
 namespace torch {
 namespace jit {
-
+using json = nlohmann::json;
 using namespace torch::jit::tensorexpr;
+
+ExprHandle roundTrip(const Expr* expr) {
+  return ExprHandle(deserializeExpr(torch::jit::tensorexpr::serialize(expr)));
+}
 
 void testIRPrinterBasicValueTest() {
   KernelScope kernel_scope;
@@ -22,6 +30,10 @@ void testIRPrinterBasicValueTest() {
   std::stringstream ss;
   ss << c;
   ASSERT_EQ(ss.str(), "2 + 3");
+
+  std::stringstream ss2;
+  ss2 << roundTrip(c.node());
+  ASSERT_EQ(ss2.str(), "2 + 3");
 }
 
 void testIRPrinterBasicValueTest02() {
@@ -35,6 +47,10 @@ void testIRPrinterBasicValueTest02() {
   std::stringstream ss;
   ss << f;
   ASSERT_EQ(ss.str(), "(2.f + 3.f) - (4.f + 5.f)");
+
+  std::stringstream ss2;
+  ss2 << roundTrip(f.node());
+  ASSERT_EQ(ss2.str(), "(2.f + 3.f) - (4.f + 5.f)");
 }
 
 void testIRPrinterCastTest() {
@@ -47,6 +63,10 @@ void testIRPrinterCastTest() {
   std::stringstream ss;
   ss << body;
   ASSERT_EQ(ss.str(), "2.f + (float(x) * 3.f + 4.f * y)");
+
+  std::stringstream ss2;
+  ss2 << roundTrip(body.node());
+  ASSERT_EQ(ss2.str(), "2.f + (float(x) * 3.f + 4.f * y)");
 }
 
 void testIRPrinterFunctionName() {
@@ -93,6 +113,19 @@ void testIRPrinterFunctionName() {
  # CHECK:     consumer[i, j] = i * (chunk_1(i, j)IR";
 
   torch::jit::testing::FileCheck().run(verification_pattern, ss.str());
+
+  std::stringstream ss2;
+  ss2 << *deserializeStmt(serialize(body));
+
+  // TODO: right now caching of Tensor expr is now working,
+  // so each reference to a Tensor Expr increments the name
+  const std::string& verification_pattern_adjusted =
+      R"IR(
+ # CHECK:   for (int i
+ # CHECK:    for (int j
+ # CHECK:     consumer[i, j] = i * (chunk_2(i, j)IR";
+
+  torch::jit::testing::FileCheck().run(verification_pattern, ss2.str());
 }
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/test_ir_printer.cpp
+++ b/test/cpp/tensorexpr/test_ir_printer.cpp
@@ -15,12 +15,7 @@
 
 namespace torch {
 namespace jit {
-using json = nlohmann::json;
 using namespace torch::jit::tensorexpr;
-
-ExprHandle roundTrip(const Expr* expr) {
-  return ExprHandle(deserializeExpr(torch::jit::tensorexpr::serialize(expr)));
-}
 
 void testIRPrinterBasicValueTest() {
   KernelScope kernel_scope;
@@ -30,10 +25,6 @@ void testIRPrinterBasicValueTest() {
   std::stringstream ss;
   ss << c;
   ASSERT_EQ(ss.str(), "2 + 3");
-
-  std::stringstream ss2;
-  ss2 << roundTrip(c.node());
-  ASSERT_EQ(ss2.str(), "2 + 3");
 }
 
 void testIRPrinterBasicValueTest02() {
@@ -47,10 +38,6 @@ void testIRPrinterBasicValueTest02() {
   std::stringstream ss;
   ss << f;
   ASSERT_EQ(ss.str(), "(2.f + 3.f) - (4.f + 5.f)");
-
-  std::stringstream ss2;
-  ss2 << roundTrip(f.node());
-  ASSERT_EQ(ss2.str(), "(2.f + 3.f) - (4.f + 5.f)");
 }
 
 void testIRPrinterCastTest() {
@@ -63,10 +50,6 @@ void testIRPrinterCastTest() {
   std::stringstream ss;
   ss << body;
   ASSERT_EQ(ss.str(), "2.f + (float(x) * 3.f + 4.f * y)");
-
-  std::stringstream ss2;
-  ss2 << roundTrip(body.node());
-  ASSERT_EQ(ss2.str(), "2.f + (float(x) * 3.f + 4.f * y)");
 }
 
 void testIRPrinterFunctionName() {
@@ -113,19 +96,6 @@ void testIRPrinterFunctionName() {
  # CHECK:     consumer[i, j] = i * (chunk_1(i, j)IR";
 
   torch::jit::testing::FileCheck().run(verification_pattern, ss.str());
-
-  std::stringstream ss2;
-  ss2 << *deserializeStmt(serialize(body));
-
-  // TODO: right now caching of Tensor expr is now working,
-  // so each reference to a Tensor Expr increments the name
-  const std::string& verification_pattern_adjusted =
-      R"IR(
- # CHECK:   for (int i
- # CHECK:    for (int j
- # CHECK:     consumer[i, j] = i * (chunk_2(i, j)IR";
-
-  torch::jit::testing::FileCheck().run(verification_pattern, ss2.str());
 }
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/test_ir_printer.cpp
+++ b/test/cpp/tensorexpr/test_ir_printer.cpp
@@ -3,18 +3,15 @@
 
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
-#include <torch/csrc/jit/tensorexpr/ir_deserializer.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
-#include <torch/csrc/jit/tensorexpr/ir_serializer.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 #include <torch/csrc/jit/testing/file_check.h>
 
-#include <torch/csrc/jit/json.hpp>
 #include <sstream>
-
 namespace torch {
 namespace jit {
+
 using namespace torch::jit::tensorexpr;
 
 void testIRPrinterBasicValueTest() {

--- a/test/cpp/tensorexpr/test_ir_serialization.cpp
+++ b/test/cpp/tensorexpr/test_ir_serialization.cpp
@@ -1,0 +1,253 @@
+#include <stdexcept>
+#include "test/cpp/tensorexpr/test_base.h"
+
+#include <torch/csrc/jit/tensorexpr/expr.h>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_deserializer.h>
+#include <torch/csrc/jit/tensorexpr/ir_printer.h>
+#include <torch/csrc/jit/tensorexpr/ir_serializer.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+#include <torch/csrc/jit/testing/file_check.h>
+
+#include <torch/csrc/jit/json.hpp>
+#include <sstream>
+
+namespace torch {
+namespace jit {
+using json = nlohmann::json;
+using namespace torch::jit::tensorexpr;
+
+void checkRoundTrip(ExprHandle expr) {
+  std::stringstream original;
+  original << *expr.node();
+  std::stringstream round_trip;
+  std::cout << torch::jit::tensorexpr::serialize(expr.node());
+  round_trip << *deserializeExpr(
+      torch::jit::tensorexpr::serialize(expr.node()));
+  std::string originals = original.str();
+  ASSERT_EQ(originals, round_trip.str());
+  std::cout << originals;
+}
+
+void checkRoundTrip(Stmt* stmt) {
+  std::stringstream original;
+  original << *stmt;
+  std::stringstream round_trip;
+  std::cout << torch::jit::tensorexpr::serialize(stmt);
+  round_trip << *deserializeStmt(torch::jit::tensorexpr::serialize(stmt));
+  std::string originals = original.str();
+  ASSERT_EQ(originals, round_trip.str());
+  std::cout << originals;
+}
+
+// void checkRoundTrip(Stmt * stmt) {
+//   std::stringstream original;
+//   original << *stmt;
+//   std::stringstream round_trip;
+//   round_trip << *deserializeStmt(torch::jit::tensorexpr::serialize(stmt));
+//   ASSERT_EQ(original.str(), round_trip.str());
+// }
+
+void testIRSerializationBasicValueTest() {
+  KernelScope kernel_scope;
+  ExprHandle a = IntImm::make(2), b = IntImm::make(3);
+  ExprHandle c = Add::make(a, b);
+
+  checkRoundTrip(c);
+}
+
+void testIRSerializationLetTest() {
+  KernelScope kernel_scope;
+  Placeholder a_buf("a", kFloat, {1});
+  Placeholder b_buf("b", kFloat, {1});
+
+  ExprHandle load_a = a_buf.load(0);
+  VarHandle var = VarHandle("v", kFloat);
+  Stmt* let_store = Let::make(var, load_a);
+  Stmt* store_b = b_buf.store({0}, var);
+
+  Block* block = Block::make({let_store, store_b});
+  checkRoundTrip(block);
+}
+
+void testIRSerializationIMMTest() {
+  KernelScope kernel_scope;
+
+  ExprHandle body;
+#define IMM_SERIALIZE_TEST(Type, Name)                                      \
+  body = ExprHandle((Type)2) + (ExprHandle((Type)3) + ExprHandle((Type)4)); \
+  checkRoundTrip(body);
+  AT_FORALL_SCALAR_TYPES_AND(Half, IMM_SERIALIZE_TEST);
+
+  // bool doesnt support arithmetic
+  VarHandle x("x", kBool);
+  VarHandle y("y", kBool);
+  checkRoundTrip(x == y);
+}
+
+void testIRSerializationBinOp() {
+  KernelScope kernel_scope;
+  VarHandle a("x", kFloat);
+  VarHandle b("y", kFloat);
+
+  checkRoundTrip(Mul::make(a.node(), b.node()));
+  checkRoundTrip(Sub::make(a.node(), b.node()));
+  checkRoundTrip(Mul::make(a.node(), b.node()));
+  checkRoundTrip(Div::make(a.node(), b.node()));
+  checkRoundTrip(Mod::make(a.node(), b.node()));
+  checkRoundTrip(Max::make(a.node(), b.node(), true));
+  checkRoundTrip(Min::make(a.node(), b.node(), true));
+  checkRoundTrip(And::make(a.node(), b.node()));
+  checkRoundTrip(Or::make(a.node(), b.node()));
+  checkRoundTrip(Xor::make(a.node(), b.node()));
+  checkRoundTrip(Lshift::make(a.node(), b.node()));
+  checkRoundTrip(Rshift::make(a.node(), b.node()));
+  checkRoundTrip(RoundOff::make(a.node(), b.node()));
+}
+
+void testIRSerializationCompareSelect() {
+  KernelScope kernel_scope;
+  constexpr int N = 1024;
+  Placeholder a(BufHandle("A", {N}, kInt));
+  Placeholder b(BufHandle("B", {N}, kInt));
+
+  VarHandle i("i", kInt);
+  checkRoundTrip(
+      CompareSelect::make(a.load(i), b.load(i), CompareSelectOperation::kEQ));
+}
+
+void testIRSerializationCastTest() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kHalf);
+  VarHandle y("y", kFloat);
+  ExprHandle body = ExprHandle(2.f) +
+      (Cast::make(kFloat, x) * ExprHandle(3.f) + ExprHandle(4.f) * y);
+
+  checkRoundTrip(body);
+}
+
+void testIRSerializationRampLoadBroadcast() {
+  KernelScope kernel_scope;
+  const int kVectorSize = 8;
+  const int kVectorCount = 128;
+  const int kTotalSize = kVectorSize * kVectorCount;
+  Placeholder a_buf(BufHandle("A", {ExprHandle(kTotalSize)}, kFloat));
+  VarHandle index = VarHandle("index", kInt);
+  ExprHandle load_a = a_buf.loadWithMask(
+      {Ramp::make(index * kVectorSize, 1, kVectorSize)},
+      Broadcast::make(1, kVectorSize));
+  checkRoundTrip(load_a);
+}
+
+void testIRSerializationStore() {
+  // KernelScope kernel_scope;
+  // const int N = 16;
+  // PaddedBuffer<float> a_v(N);
+  // Placeholder a_buf("a", kFloat, {N});
+  // VarHandle index = VarHandle("index", kInt);
+  // Stmt* assign_x2 = a_buf.store({index}, cast<float>(index) * 2);
+  // checkRoundTrip(assign_x2);
+}
+
+void testIRSerializationForBlock() {
+  KernelScope kernel_scope;
+  const int N = 16;
+
+  Placeholder a_buf("a", kInt, {N});
+  VarHandle index = VarHandle("index", kInt);
+  Stmt* body = a_buf.store({index}, 5);
+  Stmt* loop = For::make(index, 0, N, body);
+  checkRoundTrip(loop);
+}
+
+void testIRSerializationIfThenElse() {
+  KernelScope kernel_scope;
+  ExprHandle v = ifThenElse(ExprHandle(1), ExprHandle(1.0f), ExprHandle(2.0f));
+  checkRoundTrip(v);
+}
+
+void testIRSerializationInstrinsic() {
+  KernelScope kernel_scope;
+  VarHandle var = VarHandle("var", kInt);
+  checkRoundTrip(Intrinsics::make(IntrinsicsOp::kCeil, var));
+}
+
+void testIRSerializationAlloc() {
+  KernelScope kernel_scope;
+
+  const int N = 64;
+  std::vector<Stmt*> block;
+  VarHandle c_var("c", kHandle);
+  std::vector<const Expr*> dims;
+  dims.push_back(ExprHandle(N).node());
+  BufHandle c{new Buf(c_var.node(), dims, kFloat)};
+  Allocate* alloc = Allocate::make(c_var, kFloat, {N});
+  checkRoundTrip(alloc);
+}
+
+void testIRSerializationFree() {
+  KernelScope kernel_scope;
+  VarHandle c_var("c", kHandle);
+  Free* free_stmt = Free::make(c_var);
+  checkRoundTrip(free_stmt);
+}
+
+void testIRSerializationCond() {
+  KernelScope kernel_scope;
+  const int N = 16;
+  Placeholder a_buf("a", kFloat, {N});
+  VarHandle index = VarHandle("index", kInt);
+  Stmt* assign_x2 = a_buf.store({index}, cast<float>(index) * 2);
+  Stmt* assign_x3 = a_buf.store({index}, cast<float>(index) * 3);
+  ExprHandle even_cond = CompareSelect::make(Mod::make(index, 2), 0, kEQ);
+  Stmt* assign = Cond::make(even_cond, assign_x2, assign_x3);
+  checkRoundTrip(assign);
+}
+
+void testIRSerializationFunction() {
+  KernelScope kernel_scope;
+  int M = 4;
+  int N = 20;
+
+  Tensor* producer = Compute(
+      "producer",
+      {{M, "m"}, {N, "n"}},
+      [&](const ExprHandle& m, const ExprHandle& n) { return m * n; });
+
+  Tensor* chunk_0 = Compute(
+      "chunk",
+      {{M, "m"}, {N / 2, "n"}},
+      [&](const ExprHandle& m, const ExprHandle& n) {
+        return producer->call(m, n);
+      });
+
+  LoopNest l({producer, chunk_0});
+  auto* body = l.root_stmt();
+  checkRoundTrip(body);
+}
+
+void testIRSerializationAtomicAdd() {
+  KernelScope kernel_scope;
+
+  VarHandle index = VarHandle("index", kInt);
+  int M = 4;
+  int N = 20;
+
+  std::vector<const Expr*> indices = {index.node()};
+  Tensor* producer = Compute(
+      "producer",
+      {{M, "m"}, {N, "n"}},
+      [&](const ExprHandle& m, const ExprHandle& n) { return m * n; });
+  checkRoundTrip(
+      new AtomicAdd(producer->buf(), indices, IntImm::make(2).node()));
+}
+
+void testIRSerializationLet() {
+  KernelScope scope;
+  checkRoundTrip(new SyncThreads());
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/tensorexpr/test_ir_serialization.cpp
+++ b/test/cpp/tensorexpr/test_ir_serialization.cpp
@@ -23,23 +23,17 @@ void checkRoundTrip(ExprHandle expr) {
   std::stringstream original;
   original << *expr.node();
   std::stringstream round_trip;
-  std::cout << torch::jit::tensorexpr::serialize(expr.node());
   round_trip << *deserializeExpr(
       torch::jit::tensorexpr::serialize(expr.node()));
-  std::string originals = original.str();
-  ASSERT_EQ(originals, round_trip.str());
-  std::cout << originals;
+  ASSERT_EQ(original.str(), round_trip.str());
 }
 
 void checkRoundTrip(Stmt* stmt) {
   std::stringstream original;
   original << *stmt;
   std::stringstream round_trip;
-  std::cout << torch::jit::tensorexpr::serialize(stmt);
   round_trip << *deserializeStmt(torch::jit::tensorexpr::serialize(stmt));
-  std::string originals = original.str();
-  ASSERT_EQ(originals, round_trip.str());
-  std::cout << originals;
+  ASSERT_EQ(original.str(), round_trip.str());
 }
 
 void testIRSerializationBasicValueTest() {

--- a/test/cpp/tensorexpr/test_ir_serialization.cpp
+++ b/test/cpp/tensorexpr/test_ir_serialization.cpp
@@ -42,14 +42,6 @@ void checkRoundTrip(Stmt* stmt) {
   std::cout << originals;
 }
 
-// void checkRoundTrip(Stmt * stmt) {
-//   std::stringstream original;
-//   original << *stmt;
-//   std::stringstream round_trip;
-//   round_trip << *deserializeStmt(torch::jit::tensorexpr::serialize(stmt));
-//   ASSERT_EQ(original.str(), round_trip.str());
-// }
-
 void testIRSerializationBasicValueTest() {
   KernelScope kernel_scope;
   ExprHandle a = IntImm::make(2), b = IntImm::make(3);
@@ -58,7 +50,7 @@ void testIRSerializationBasicValueTest() {
   checkRoundTrip(c);
 }
 
-void testIRSerializationLetTest() {
+void testIRSerializationLetStoreTest() {
   KernelScope kernel_scope;
   Placeholder a_buf("a", kFloat, {1});
   Placeholder b_buf("b", kFloat, {1});
@@ -139,16 +131,6 @@ void testIRSerializationRampLoadBroadcast() {
       {Ramp::make(index * kVectorSize, 1, kVectorSize)},
       Broadcast::make(1, kVectorSize));
   checkRoundTrip(load_a);
-}
-
-void testIRSerializationStore() {
-  // KernelScope kernel_scope;
-  // const int N = 16;
-  // PaddedBuffer<float> a_v(N);
-  // Placeholder a_buf("a", kFloat, {N});
-  // VarHandle index = VarHandle("index", kInt);
-  // Stmt* assign_x2 = a_buf.store({index}, cast<float>(index) * 2);
-  // checkRoundTrip(assign_x2);
 }
 
 void testIRSerializationForBlock() {

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -38,6 +38,23 @@ namespace jit {
   _(IRPrinterBasicValueTest02)              \
   _(IRPrinterCastTest)                      \
   _(IRPrinterFunctionName)                  \
+  _(IRSerializationBasicValueTest)          \
+  _(IRSerializationCastTest)                \
+  _(IRSerializationLetTest)                 \
+  _(IRSerializationIMMTest)                 \
+  _(IRSerializationBinOp)                   \
+  _(IRSerializationCompareSelect)           \
+  _(IRSerializationRampLoadBroadcast)       \
+  _(IRSerializationStore)                   \
+  _(IRSerializationForBlock)                \
+  _(IRSerializationIfThenElse)              \
+  _(IRSerializationInstrinsic)              \
+  _(IRSerializationAlloc)                   \
+  _(IRSerializationFree)                    \
+  _(IRSerializationCond)                    \
+  _(IRSerializationAtomicAdd)               \
+  _(IRSerializationFunction)                \
+  _(IRSerializationLet)                     \
   _(ExprSimple01)                           \
   _(ExprLower01)                            \
   _(ExprSimple02)                           \

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -45,7 +45,6 @@ namespace jit {
   _(IRSerializationBinOp)                   \
   _(IRSerializationCompareSelect)           \
   _(IRSerializationRampLoadBroadcast)       \
-  _(IRSerializationStore)                   \
   _(IRSerializationForBlock)                \
   _(IRSerializationIfThenElse)              \
   _(IRSerializationInstrinsic)              \

--- a/test/elias.py
+++ b/test/elias.py
@@ -1,0 +1,20 @@
+import torch
+# from typing import Literal
+from typing_extensions import Literal
+
+# @torch.jit._overload
+# def foo(x: Literal[True]): ...
+
+# @torch.jit._overload
+# def foo(x: Literal[False]): ...
+
+def foo(x: Literal[True]):
+    if x:
+        return 1, 2
+    else:
+        return 1
+
+def foo2():
+    return foo(True)
+
+print(torch.jit.script(foo2).graph)

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -235,6 +235,7 @@ core_sources_full = [
     "torch/csrc/jit/tensorexpr/ir_mutator.cpp",
     "torch/csrc/jit/tensorexpr/ir_printer.cpp",
     "torch/csrc/jit/tensorexpr/ir_serializer.cpp",
+    "torch/csrc/jit/tensorexpr/ir_deserializer.cpp",
     "torch/csrc/jit/tensorexpr/ir_simplifier.cpp",
     "torch/csrc/jit/tensorexpr/ir_visitor.cpp",
     "torch/csrc/jit/tensorexpr/kernel.cpp",

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -765,12 +765,17 @@ class Intrinsics : public CallNode<Intrinsics> {
   IntrinsicsOp op_type_;
 };
 
+
 class Polynomial;
 class Term;
 class MaxTerm;
 class MinTerm;
 
 class FunctionCall;
+
+// ADDING NEW NODES TO THE IR:
+// If you add a new node to the IR, you must also add handling of it
+// to IRVisitor, IRMutator, IRPrinter, IRSerializer and IRDeserializer
 
 TORCH_API std::vector<const Expr*> ExprHandleVectorToExprVector(
     const std::vector<ExprHandle>&);

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -765,7 +765,6 @@ class Intrinsics : public CallNode<Intrinsics> {
   IntrinsicsOp op_type_;
 };
 
-
 class Polynomial;
 class Term;
 class MaxTerm;

--- a/torch/csrc/jit/tensorexpr/ir_deserializer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_deserializer.cpp
@@ -247,8 +247,7 @@ std::vector<Stmt*> IRDeserializer::dsVecStmt(const json& v) {
   return vec;
 }
 
-Stmt* IRDeserializer::dsStmt(const json& v) {
-  // caching not needed for statements
+Stmt* IRDeserializer::dsStmtImpl(const json& v) {
   std::string stmt_type = v["stmt_type"];
 
 #define CHECK_STMT_TYPE(stmt_name)    \
@@ -267,6 +266,15 @@ Stmt* IRDeserializer::dsStmt(const json& v) {
   CHECK_STMT_TYPE(Allocate)
 
   assert(false);
+}
+
+Stmt* IRDeserializer::dsStmt(const json& v) {
+  if (cachedKernelObj(v)) {
+    return getCachedStmt(v);
+  }
+  Stmt* stmt = dsStmtImpl(v);
+  putObj(v, stmt);
+  return stmt;
 }
 
 const Expr* deserializeExpr(const json& v) {

--- a/torch/csrc/jit/tensorexpr/ir_deserializer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_deserializer.cpp
@@ -1,0 +1,345 @@
+#include <torch/csrc/jit/tensorexpr/ir_deserializer.h>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+
+using json = nlohmann::json;
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+const Expr* IRDeserializer::deserializeBinaryOp(
+    const json& json,
+    IRNodeType type) {
+  bool option = false;
+  if (json.find("propagate_nans") != json.end()) {
+    option = json["propagate_nans"];
+  }
+  const Expr* binop =
+      newBinaryOpOfType(type, dsExpr(json["lhs"]), dsExpr(json["rhs"]), option);
+  return binop;
+}
+
+const LongImm* IRDeserializer::deserializeLongImm(const json& json) {
+  const LongImm* longimm = new LongImm(json["value"]);
+  return longimm;
+}
+
+const ShortImm* IRDeserializer::deserializeShortImm(const json& json) {
+  const ShortImm* longimm = new ShortImm(json["value"]);
+  return longimm;
+}
+const BoolImm* IRDeserializer::deserializeBoolImm(const json& json) {
+  const BoolImm* boolimm = new BoolImm(json["value"]);
+  return boolimm;
+}
+const FloatImm* IRDeserializer::deserializeFloatImm(const json& json) {
+  const FloatImm* floatimm = new FloatImm(json["value"]);
+  return floatimm;
+}
+const DoubleImm* IRDeserializer::deserializeDoubleImm(const json& json) {
+  const DoubleImm* doublimm = new DoubleImm(json["value"]);
+  return doublimm;
+}
+const CharImm* IRDeserializer::deserializeCharImm(const json& json) {
+  const CharImm* charimm = new CharImm(json["value"]);
+  return charimm;
+}
+const HalfImm* IRDeserializer::deserializeHalfImm(const json& json) {
+  float val = json["value"];
+  const HalfImm* charimm = new HalfImm(at::Half(val));
+  return charimm;
+}
+const IntImm* IRDeserializer::deserializeIntImm(const json& json) {
+  const IntImm* intimm = new IntImm(json["value"]);
+  return intimm;
+}
+
+const ByteImm* IRDeserializer::deserializeByteImm(const json& json) {
+  const ByteImm* byteimm = new ByteImm(json["value"]);
+  return byteimm;
+}
+
+Dtype getDtype(const json& v) {
+  std::string dtype = v["dtype"];
+  return Dtype(toDtype(dtype));
+}
+
+const Cast* IRDeserializer::deserializeCast(const json& v) {
+  auto cast = new Cast(getDtype(v), dsExpr(v["src_value"]));
+  return cast;
+}
+
+const Ramp* IRDeserializer::deserializeRamp(const json& v) {
+  auto ramp = new Ramp(dsExpr(v["base"]), dsExpr(v["stride"]), v["lanes"]);
+  return ramp;
+}
+const Broadcast* IRDeserializer::deserializeBroadcast(const json& v) {
+  auto broadcast = new Broadcast(dsExpr(v["value"]), v["lanes"]);
+  return broadcast;
+}
+const Var* IRDeserializer::deserializeVar(const json& v) {
+  auto var = new Var(v["name"], getDtype(v));
+  if (v["name"] == "producer") {
+    std::cout << "here we go\n";
+  }
+  return var;
+}
+const IfThenElse* IRDeserializer::deserializeIfThenElse(const json& v) {
+  auto ifthenelse = new IfThenElse(
+      dsExpr(v["condition"]),
+      dsExpr(v["true_value"]),
+      dsExpr(v["false_value"]));
+  return ifthenelse;
+}
+const MaxTerm* IRDeserializer::deserializeMaxTerm(const json& v) {
+  auto maxterm = new MaxTerm(
+      h_, dsExpr(v["scalar"]), v["propagate_nans"], dsVecExpr(v["variables"]));
+  return maxterm;
+}
+
+const MinTerm* IRDeserializer::deserializeMinTerm(const json& v) {
+  auto minterm = new MinTerm(
+      h_, dsExpr(v["scalar"]), v["propagate_nans"], dsVecExpr(v["variables"]));
+  return minterm;
+}
+
+const FunctionCall* IRDeserializer::deserializeFunctionCall(const json& v) {
+  const Expr* body = dsExpr(v["body"]);
+  std::vector<const Expr*> args = dsVecExpr(v["args"]);
+  std::vector<const Expr*> dims = dsVecExpr(v["dims"]);
+  std::vector<const Var*> arg_vars;
+  for (auto arg : args) {
+    auto var = dynamic_cast<const Var*>(arg);
+    arg_vars.push_back(var);
+  }
+  const std::string name = v["function_name"];
+  // Todo: can Function or Tensor appear multiple times, should I be caching ?
+  // Dependency/ownership of Function/Tensor confusing, leave as is for initial
+  // implementation No visitor for Function or Tensor is defined
+  Function* func = new Function(name, dims, arg_vars, body);
+  Tensor* tensor = new Tensor(func, v["output_index"]);
+  FunctionCall* func_call = new FunctionCall(tensor, dsVecExpr(v["params"]));
+  return func_call;
+}
+
+const Buf* IRDeserializer::deserializeBuf(const json& v) {
+  // TODO: need to add caching to the direct invocations
+  const json& j = v["base_handle"];
+  if (j["name"] == "producer") {
+    std::cout << " hi elias \n";
+  }
+
+  const Var* var = dynamic_cast<const Var*>(dsExpr(v["base_handle"]));
+  const std::vector<const Expr*> dims = dsVecExpr(v["dims"]);
+  Dtype dtype = getDtype(v);
+  auto buf = new Buf(var, dims, dtype);
+  return buf;
+}
+
+const Intrinsics* IRDeserializer::deserializeIntrinsics(const json& v) {
+  const Intrinsics* intrinsics = new Intrinsics(
+      stringToIntrinsics(v["func_name"]), dsVecExpr(v["params"]));
+  return intrinsics;
+}
+
+const std::vector<const Expr*> IRDeserializer::dsVecExpr(const json& v) {
+  std::vector<const Expr*> vec;
+  for (const auto& obj : v.items()) {
+    vec.push_back(dsExpr(obj.value()));
+  }
+  return vec;
+}
+
+AtomicAdd* IRDeserializer::deserializeAtomicAdd(const json& json) {
+  const Buf* buf = dynamic_cast<const Buf*>(dsExpr(json["buf"]));
+  AtomicAdd* atomicadd =
+      new AtomicAdd(buf, dsVecExpr(json["indices"]), dsExpr(json["value"]));
+  return atomicadd;
+}
+
+SyncThreads* IRDeserializer::deserializeSyncThreads(const json& json) {
+  SyncThreads* syncthreads = new SyncThreads();
+  return syncthreads;
+}
+
+Let* IRDeserializer::deserializeLet(const json& json) {
+  const Var* var = dynamic_cast<const Var*>(dsExpr(json["var"]));
+  Let* let = new Let(var, dsExpr(json["value"]));
+  return let;
+}
+
+Store* IRDeserializer::deserializeStore(const json& json) {
+  const Buf* buf = dynamic_cast<const Buf*>(dsExpr(json["buf"]));
+  Store* store = new Store(
+      buf,
+      dsVecExpr(json["indices"]),
+      dsExpr(json["value"]),
+      dsExpr(json["mask"]));
+  return store;
+}
+
+Block* IRDeserializer::deserializeBlock(const json& json) {
+  Block* block = new Block(dsVecStmt(json["stmts"]));
+  return block;
+}
+
+For* IRDeserializer::deserializeFor(const json& v) {
+  const Var* var = static_cast<const Var*>(dsExpr(v["var"]));
+  const json& loop_options = v["loop_options"];
+  const json& buffer_mapping_json = loop_options["buffer_mapping"];
+  std::unordered_map<std::string, const Buf*> buffer_mapping;
+  for (const auto& obj : buffer_mapping_json.items()) {
+    std::string key = obj.key();
+    const Buf* buf = dynamic_cast<const Buf*>(dsExpr(obj.value()));
+    buffer_mapping[key] = buf;
+  }
+  LoopOptions lo;
+  lo.set_buffer_mapping(buffer_mapping);
+  lo.set_gpu_thread_index(loop_options["gpu_thread_index"]);
+  lo.set_gpu_block_index(loop_options["gpu_block_index"]);
+  For* for_var = new For(
+      var, dsExpr(v["start"]), dsExpr(v["stop"]), dsStmt(v["body"]), lo);
+  return for_var;
+}
+
+Free* IRDeserializer::deserializeFree(const json& json) {
+  const Var* var = static_cast<const Var*>(dsExpr(json["buffer_var"]));
+  Free* free = new Free(var);
+  return free;
+}
+
+Cond* IRDeserializer::deserializeCond(const json& json) {
+  Cond* cond = new Cond(
+      dsExpr(json["condition"]),
+      dsStmt(json["true_stmt"]),
+      dsStmt(json["false_stmt"]));
+  return cond;
+}
+
+const Expr* IRDeserializer::dsExprImpl(const json& v) {
+  std::string expr_type = v["expr_type"];
+
+#define CHECK_BINARY_OP(cond)                           \
+  if (expr_type == #cond) {                             \
+    return deserializeBinaryOp(v, IRNodeType::k##cond); \
+  }
+
+  CHECK_BINARY_OP(Xor)
+  CHECK_BINARY_OP(Add)
+  CHECK_BINARY_OP(Sub)
+  CHECK_BINARY_OP(Mul)
+  CHECK_BINARY_OP(Div)
+  CHECK_BINARY_OP(Mod)
+  CHECK_BINARY_OP(Max)
+  CHECK_BINARY_OP(Min)
+  CHECK_BINARY_OP(And)
+  CHECK_BINARY_OP(Or)
+  CHECK_BINARY_OP(Xor)
+  CHECK_BINARY_OP(Lshift)
+  CHECK_BINARY_OP(Rshift)
+  CHECK_BINARY_OP(CompareSelect)
+  CHECK_BINARY_OP(RoundOff)
+#undef CHECK_BINARY_OP
+
+#define CHECK_EXPR_TYPE(expr_name)    \
+  if (expr_type == #expr_name) {      \
+    return deserialize##expr_name(v); \
+  }
+  CHECK_EXPR_TYPE(Cast);
+  CHECK_EXPR_TYPE(Var);
+  CHECK_EXPR_TYPE(Ramp);
+  CHECK_EXPR_TYPE(Broadcast);
+  CHECK_EXPR_TYPE(IfThenElse);
+  // CHECK_EXPR_TYPE(Term);
+  // CHECK_EXPR_TYPE(Polynomial);
+  CHECK_EXPR_TYPE(MaxTerm);
+  CHECK_EXPR_TYPE(MinTerm);
+  CHECK_EXPR_TYPE(FunctionCall);
+  CHECK_EXPR_TYPE(Buf);
+  CHECK_EXPR_TYPE(Intrinsics);
+
+#define IMM_CHECK(Type, Name) CHECK_EXPR_TYPE(Name##Imm);
+  AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_CHECK);
+#undef IMM_CHECK
+
+#undef CHECK_EXPR_TYPE
+
+  assert(false);
+}
+
+const Expr* IRDeserializer::dsExpr(const json& v) {
+  if (cachedKernelObj(v)) {
+    return getCachedExpr(v);
+  }
+  const Expr* expr = dsExprImpl(v);
+  putObj(v, expr);
+  return expr;
+}
+
+std::vector<Stmt*> IRDeserializer::dsVecStmt(const json& v) {
+  std::vector<Stmt*> vec;
+  for (const auto& obj : v.items()) {
+    vec.push_back(dsStmt(obj.value()));
+  }
+  return vec;
+}
+
+Stmt* IRDeserializer::dsStmt(const json& v) {
+  if (v["json_id"] == 8) {
+    std::cout << "Hello\n";
+  }
+
+  // std::cout << " DS STMT:: \n";
+  // std::cout << v;
+  // std::cout << "\n";
+
+  if (cachedKernelObj(v)) {
+    // TODO: separate map for stmts
+    return const_cast<Stmt*>(getCachedStmt(v));
+  }
+
+  // std::cout << " DS STMT:: \n";
+  // std::cout << v;
+  // std::cout << "\n";
+
+  std::string stmt_type = v["stmt_type"];
+
+#define CHECK_STMT_TYPE(stmt_name)    \
+  if (stmt_type == #stmt_name) {      \
+    return deserialize##stmt_name(v); \
+  }
+
+  CHECK_STMT_TYPE(AtomicAdd)
+  CHECK_STMT_TYPE(SyncThreads)
+  CHECK_STMT_TYPE(Let)
+  CHECK_STMT_TYPE(Store)
+  CHECK_STMT_TYPE(Block)
+  CHECK_STMT_TYPE(For)
+  CHECK_STMT_TYPE(Free)
+  CHECK_STMT_TYPE(Cond)
+
+  assert(false);
+}
+
+const Expr* deserializeExpr(const json& json) {
+  IRDeserializer d;
+  return d.dsExpr(json);
+}
+
+const Stmt* deserializeStmt(const json& json) {
+  IRDeserializer d;
+  return d.dsStmt(json);
+}
+
+const KernelScopedObject* deserialize(const json& json) {
+  if (json.find("expr_type") != json.end()) {
+    return deserializeExpr(json);
+  } else {
+    return deserializeStmt(json);
+  }
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir_deserializer.h
+++ b/torch/csrc/jit/tensorexpr/ir_deserializer.h
@@ -22,196 +22,61 @@ using json = nlohmann::json;
  * Uses memoization to avoid excessive recursion. */
 class TORCH_API IRDeserializer : public IRVisitor {
  public:
-  bool cachedKernelObj(const json& json) {
-    size_t id = json["json_id"];
+  bool cachedKernelObj(const json& v) {
+    size_t id = v["json_id"];
     return JSONToObj_.count(id) != 0;
   }
 
-  const Expr* getCachedExpr(const json& json) {
-    if (json.find("name") != json.end()) {
-      std::cout << " GETTING CACHED : " << json["name"];
-    }
-
-    auto it = JSONToObj_.find(json["json_id"]);
+  const Expr* getCachedExpr(const json& v) {
+    auto it = JSONToObj_.find(v["json_id"]);
     if (it != JSONToObj_.end()) {
-      const Expr* obj = dynamic_cast<const Expr*>(it->second);
-      assert(obj);
-      return obj;
+      return it->second;
     }
     assert(false);
   }
 
-  const Stmt* getCachedStmt(const json& json) {
-    auto it = JSONToObj_.find(json["json_id"]);
-    if (it != JSONToObj_.end()) {
-      const Stmt* obj = dynamic_cast<const Stmt*>(it->second);
-      assert(obj);
-      return obj;
-    }
-    assert(false);
-  }
+  const Expr* dsExprImpl(const json& v);
+  const Expr* dsExpr(const json& v);
+  const std::vector<const Expr*> dsVecExpr(const json& v);
 
-  const Expr* dsExprImpl(const json& json);
-  const Expr* dsExpr(const json& json);
-  const std::vector<const Expr*> dsVecExpr(const json& json);
+  const Cast* deserializeCast(const json& v);
+  const Var* deserializeVar(const json& v);
+  const Ramp* deserializeRamp(const json& v);
+  const Broadcast* deserializeBroadcast(const json& v);
+  const IfThenElse* deserializeIfThenElse(const json& v);
+  const FunctionCall* deserializeFunctionCall(const json& v);
+  const Buf* deserializeBuf(const json& v);
+  const Intrinsics* deserializeIntrinsics(const json& v);
+  const Load* deserializeLoad(const json& v);
+  const CompareSelect* deserializeCompareSelect(const json& v);
 
-  const Cast* deserializeCast(const json& json);
-  const Var* deserializeVar(const json& json);
-  const Ramp* deserializeRamp(const json& json);
-  const Broadcast* deserializeBroadcast(const json& json);
-  const IfThenElse* deserializeIfThenElse(const json& json);
-  // const Term * deserializeTerm(const json& json);
-  // const Polynomial * deserializePolynomial(const json& json);
-  const MaxTerm* deserializeMaxTerm(const json& json);
-  const MinTerm* deserializeMinTerm(const json& json);
-  const FunctionCall* deserializeFunctionCall(const json& json);
-  const Buf* deserializeBuf(const json& json);
-  const Intrinsics* deserializeIntrinsics(const json& json);
+  AtomicAdd* deserializeAtomicAdd(const json& v);
+  SyncThreads* deserializeSyncThreads(const json& v);
+  Let* deserializeLet(const json& v);
+  Allocate* deserializeAllocate(const json& v);
 
-  AtomicAdd* deserializeAtomicAdd(const json& json);
-  SyncThreads* deserializeSyncThreads(const json& json);
-  Let* deserializeLet(const json& json);
-  Store* deserializeStore(const json& json);
-  Block* deserializeBlock(const json& json);
-  For* deserializeFor(const json& json);
-  Free* deserializeFree(const json& json);
-  Cond* deserializeCond(const json& json);
+  Store* deserializeStore(const json& v);
+  Block* deserializeBlock(const json& v);
+  For* deserializeFor(const json& v);
+  Free* deserializeFree(const json& v);
+  Cond* deserializeCond(const json& v);
 
   Stmt* dsStmt(const json& v);
   std::vector<Stmt*> dsVecStmt(const json& v);
 
-  const LongImm* deserializeLongImm(const json& json);
-  const ShortImm* deserializeShortImm(const json& json);
-  const BoolImm* deserializeBoolImm(const json& json);
-  const FloatImm* deserializeFloatImm(const json& json);
-  const DoubleImm* deserializeDoubleImm(const json& json);
-  const CharImm* deserializeCharImm(const json& json);
-  const HalfImm* deserializeHalfImm(const json& json);
-  const IntImm* deserializeIntImm(const json& json);
-  const ByteImm* deserializeByteImm(const json& json);
+  const LongImm* deserializeLongImm(const json& v);
+  const ShortImm* deserializeShortImm(const json& v);
+  const BoolImm* deserializeBoolImm(const json& v);
+  const FloatImm* deserializeFloatImm(const json& v);
+  const DoubleImm* deserializeDoubleImm(const json& v);
+  const CharImm* deserializeCharImm(const json& v);
+  const HalfImm* deserializeHalfImm(const json& v);
+  const IntImm* deserializeIntImm(const json& v);
+  const ByteImm* deserializeByteImm(const json& v);
 
-  // void visit(const Load* v) override;
-  // void visit(const Store* v) override;
-  // void visit(const Block* v) override;
-  // void visit(const For* v) override;
-  // void visit(const Allocate* v) override;
-  // void visit(const Free* v) override;
-  // void visit(const Cond* v) override;
-  // void visit(const Term* v) override;
-  // void visit(const Polynomial* v) override;
-  // void visit(const MaxTerm* v) override;
-  // void visit(const MinTerm* v) override;
+  const Expr* deserializeBinaryOp(const json& v, IRNodeType type);
 
-  // void visit(const FunctionCall* v) override;
-  // void visit(const ReduceOp* v) override;
-
-  // void visit(const AtomicAdd* v) override;
-  // void visit(const SyncThreads* v) override;
-  // void visit(const Let* v) override;
-
-  // void visit(const Buf* v) override;
-  // const Add * deserializeAdd(const json& json);
-  // const Sub * deserializeSub(const json& json);
-  // const Mul * deserializeMul(const json& json);
-  // const Div * deserializeDiv(const json& json);
-  // const Mod * deserializeMod(const json& json);
-  // const Max * deserializeMax(const json& json);
-  // const And * deserializeAnd(const json& json);
-  // const Or * deserializeOr(const json& json);
-  // const Xor * deserializeXor(const json& json);
-  // const Lshift * deserializeLshift(const json& json);
-  // const Rshift * deserializeRshift(const json& json);
-  // const CompareSelect * deserializeCompareSelect(const json& json);
-
-  // const Expr * deserializeSub(const json& json);
-  // const Expr * deserializeMul(const json& json);
-  // const Expr * deserializeDiv(const json& json);
-  // const Expr * deserializeMod(const json& json);
-  // const Expr * deserializeMax(const json& json);
-  // const Expr * deserializeAnd(const json& json);
-  // const Expr * deserializeOr(const json& json);
-  // const Expr * deserializeXor(const json& json);
-  // const Expr * deserializeLshift(const json& json);
-  // const Expr * deserializeRshift(const json& json);
-  // const Expr * deserializeCompareSelect(const json& json);
-
-  const Expr* deserializeBinaryOp(const json& json, IRNodeType type);
-
-  //   void visit(const Add* v) override;
-  //   void visit(const Sub* v) override;
-  //   void visit(const Mul* v) override;
-  //   void visit(const Div* v) override;
-  //   void visit(const Mod* v) override;
-  //   void visit(const Max* v) override;
-  //   void visit(const Min* v) override;
-  //   void visit(const And* v) override;
-  //   void visit(const Or* v) override;
-  //   void visit(const Xor* v) override;
-  //   void visit(const Lshift* v) override;
-  //   void visit(const Rshift* v) override;
-  //   void visit(const CompareSelect* v) override;
-
-  // #define IMM_SERIALIZE_VISIT(Type, Name) void visit(const Name##Imm* v)
-  // override;
-  //   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_SERIALIZE_VISIT);
-  // #undef IMM_SERIALIZE_VISIT
-
-  //   void visit(const Cast* v) override;
-  //   void visit(const Var* v) override;
-  //   void visit(const Ramp* v) override;
-  //   void visit(const Load* v) override;
-  //   void visit(const Store* v) override;
-  //   void visit(const Block* v) override;
-  //   void visit(const For* v) override;
-  //   void visit(const Broadcast* v) override;
-  //   void visit(const IfThenElse* v) override;
-  //   void visit(const BaseCallNode* v) override;
-  //   void visit(const Intrinsics* v) override;
-  //   void visit(const Allocate* v) override;
-  //   void visit(const Free* v) override;
-  //   void visit(const Cond* v) override;
-  //   void visit(const Term* v) override;
-  //   void visit(const Polynomial* v) override;
-  //   void visit(const MaxTerm* v) override;
-  //   void visit(const MinTerm* v) override;
-
-  //   void visit(const FunctionCall* v) override;
-  //   void visit(const RoundOff* v) override;
-  //   void visit(const ReduceOp* v) override;
-
-  //   void visit(const AtomicAdd* v) override;
-  //   void visit(const SyncThreads* v) override;
-  //   void visit(const Let* v) override;
-
-  //   void visit(const Buf* v) override;
-
-  //   // BaseCallNode is the base class for all call nodes.
-  //   // For any visitors that only needs the common behavior, only override
-  //   this
-  //   // function is enough. This is because all derived class handlers will
-  //   call
-  //   // this function by default.
-  //   // Override the derived class handler only if the logic is more specific
-  //   to
-  //   // that.
-
-  //   // json JSONOf(const Expr* e) {
-  //   //   auto it = exprToJSON_.find(e);
-  //   //   if (it != exprToJSON_.end()) {
-  //   //     return it->second;
-  //   //   }
-  //   //   assert(false);
-  //   // }
-
-  //   // json JSONOf(const Stmt* s) {
-  //   //   auto it = exprToJSON_.find(s);
-  //   //   if (it != exprToJSON_.end()) {
-  //   //     return it->second;
-  //   //   }
-  //   //   assert(false);
-  //   // }
-
-  void putObj(json h, const KernelScopedObject* e) {
+  void putObj(json h, const Expr* e) {
     size_t id = h["json_id"];
     auto res = JSONToObj_.emplace(id, e);
     if (res.second == false) {
@@ -221,13 +86,12 @@ class TORCH_API IRDeserializer : public IRVisitor {
   }
 
  private:
-  std::unordered_map<size_t, const KernelScopedObject*> JSONToObj_;
-  HashProvider h_;
+  std::unordered_map<size_t, const Expr*> JSONToObj_;
 };
 
-TORCH_API const Stmt* deserializeStmt(const json& json);
-TORCH_API const Expr* deserializeExpr(const json& json);
-TORCH_API const KernelScopedObject* deserialize(const json& json);
+TORCH_API const Stmt* deserializeStmt(const json& v);
+TORCH_API const Expr* deserializeExpr(const json& v);
+TORCH_API const KernelScopedObject* deserialize(const json& v);
 
 } // namespace tensorexpr
 } // namespace jit

--- a/torch/csrc/jit/tensorexpr/ir_deserializer.h
+++ b/torch/csrc/jit/tensorexpr/ir_deserializer.h
@@ -1,0 +1,234 @@
+#pragma once
+
+#include <torch/csrc/jit/json.hpp>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_printer.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/ir_visitor.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+using json = nlohmann::json;
+
+#define JSON_CACHE_GUARD()  \
+  if (cachedKernelObj(v)) { \
+    return;                 \
+  }
+
+/* Expression hasher providing comparable values representing sub-exprs.
+ * Uses memoization to avoid excessive recursion. */
+class TORCH_API IRDeserializer : public IRVisitor {
+ public:
+  bool cachedKernelObj(const json& json) {
+    size_t id = json["json_id"];
+    return JSONToObj_.count(id) != 0;
+  }
+
+  const Expr* getCachedExpr(const json& json) {
+    if (json.find("name") != json.end()) {
+      std::cout << " GETTING CACHED : " << json["name"];
+    }
+
+    auto it = JSONToObj_.find(json["json_id"]);
+    if (it != JSONToObj_.end()) {
+      const Expr* obj = dynamic_cast<const Expr*>(it->second);
+      assert(obj);
+      return obj;
+    }
+    assert(false);
+  }
+
+  const Stmt* getCachedStmt(const json& json) {
+    auto it = JSONToObj_.find(json["json_id"]);
+    if (it != JSONToObj_.end()) {
+      const Stmt* obj = dynamic_cast<const Stmt*>(it->second);
+      assert(obj);
+      return obj;
+    }
+    assert(false);
+  }
+
+  const Expr* dsExprImpl(const json& json);
+  const Expr* dsExpr(const json& json);
+  const std::vector<const Expr*> dsVecExpr(const json& json);
+
+  const Cast* deserializeCast(const json& json);
+  const Var* deserializeVar(const json& json);
+  const Ramp* deserializeRamp(const json& json);
+  const Broadcast* deserializeBroadcast(const json& json);
+  const IfThenElse* deserializeIfThenElse(const json& json);
+  // const Term * deserializeTerm(const json& json);
+  // const Polynomial * deserializePolynomial(const json& json);
+  const MaxTerm* deserializeMaxTerm(const json& json);
+  const MinTerm* deserializeMinTerm(const json& json);
+  const FunctionCall* deserializeFunctionCall(const json& json);
+  const Buf* deserializeBuf(const json& json);
+  const Intrinsics* deserializeIntrinsics(const json& json);
+
+  AtomicAdd* deserializeAtomicAdd(const json& json);
+  SyncThreads* deserializeSyncThreads(const json& json);
+  Let* deserializeLet(const json& json);
+  Store* deserializeStore(const json& json);
+  Block* deserializeBlock(const json& json);
+  For* deserializeFor(const json& json);
+  Free* deserializeFree(const json& json);
+  Cond* deserializeCond(const json& json);
+
+  Stmt* dsStmt(const json& v);
+  std::vector<Stmt*> dsVecStmt(const json& v);
+
+  const LongImm* deserializeLongImm(const json& json);
+  const ShortImm* deserializeShortImm(const json& json);
+  const BoolImm* deserializeBoolImm(const json& json);
+  const FloatImm* deserializeFloatImm(const json& json);
+  const DoubleImm* deserializeDoubleImm(const json& json);
+  const CharImm* deserializeCharImm(const json& json);
+  const HalfImm* deserializeHalfImm(const json& json);
+  const IntImm* deserializeIntImm(const json& json);
+  const ByteImm* deserializeByteImm(const json& json);
+
+  // void visit(const Load* v) override;
+  // void visit(const Store* v) override;
+  // void visit(const Block* v) override;
+  // void visit(const For* v) override;
+  // void visit(const Allocate* v) override;
+  // void visit(const Free* v) override;
+  // void visit(const Cond* v) override;
+  // void visit(const Term* v) override;
+  // void visit(const Polynomial* v) override;
+  // void visit(const MaxTerm* v) override;
+  // void visit(const MinTerm* v) override;
+
+  // void visit(const FunctionCall* v) override;
+  // void visit(const ReduceOp* v) override;
+
+  // void visit(const AtomicAdd* v) override;
+  // void visit(const SyncThreads* v) override;
+  // void visit(const Let* v) override;
+
+  // void visit(const Buf* v) override;
+  // const Add * deserializeAdd(const json& json);
+  // const Sub * deserializeSub(const json& json);
+  // const Mul * deserializeMul(const json& json);
+  // const Div * deserializeDiv(const json& json);
+  // const Mod * deserializeMod(const json& json);
+  // const Max * deserializeMax(const json& json);
+  // const And * deserializeAnd(const json& json);
+  // const Or * deserializeOr(const json& json);
+  // const Xor * deserializeXor(const json& json);
+  // const Lshift * deserializeLshift(const json& json);
+  // const Rshift * deserializeRshift(const json& json);
+  // const CompareSelect * deserializeCompareSelect(const json& json);
+
+  // const Expr * deserializeSub(const json& json);
+  // const Expr * deserializeMul(const json& json);
+  // const Expr * deserializeDiv(const json& json);
+  // const Expr * deserializeMod(const json& json);
+  // const Expr * deserializeMax(const json& json);
+  // const Expr * deserializeAnd(const json& json);
+  // const Expr * deserializeOr(const json& json);
+  // const Expr * deserializeXor(const json& json);
+  // const Expr * deserializeLshift(const json& json);
+  // const Expr * deserializeRshift(const json& json);
+  // const Expr * deserializeCompareSelect(const json& json);
+
+  const Expr* deserializeBinaryOp(const json& json, IRNodeType type);
+
+  //   void visit(const Add* v) override;
+  //   void visit(const Sub* v) override;
+  //   void visit(const Mul* v) override;
+  //   void visit(const Div* v) override;
+  //   void visit(const Mod* v) override;
+  //   void visit(const Max* v) override;
+  //   void visit(const Min* v) override;
+  //   void visit(const And* v) override;
+  //   void visit(const Or* v) override;
+  //   void visit(const Xor* v) override;
+  //   void visit(const Lshift* v) override;
+  //   void visit(const Rshift* v) override;
+  //   void visit(const CompareSelect* v) override;
+
+  // #define IMM_SERIALIZE_VISIT(Type, Name) void visit(const Name##Imm* v)
+  // override;
+  //   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_SERIALIZE_VISIT);
+  // #undef IMM_SERIALIZE_VISIT
+
+  //   void visit(const Cast* v) override;
+  //   void visit(const Var* v) override;
+  //   void visit(const Ramp* v) override;
+  //   void visit(const Load* v) override;
+  //   void visit(const Store* v) override;
+  //   void visit(const Block* v) override;
+  //   void visit(const For* v) override;
+  //   void visit(const Broadcast* v) override;
+  //   void visit(const IfThenElse* v) override;
+  //   void visit(const BaseCallNode* v) override;
+  //   void visit(const Intrinsics* v) override;
+  //   void visit(const Allocate* v) override;
+  //   void visit(const Free* v) override;
+  //   void visit(const Cond* v) override;
+  //   void visit(const Term* v) override;
+  //   void visit(const Polynomial* v) override;
+  //   void visit(const MaxTerm* v) override;
+  //   void visit(const MinTerm* v) override;
+
+  //   void visit(const FunctionCall* v) override;
+  //   void visit(const RoundOff* v) override;
+  //   void visit(const ReduceOp* v) override;
+
+  //   void visit(const AtomicAdd* v) override;
+  //   void visit(const SyncThreads* v) override;
+  //   void visit(const Let* v) override;
+
+  //   void visit(const Buf* v) override;
+
+  //   // BaseCallNode is the base class for all call nodes.
+  //   // For any visitors that only needs the common behavior, only override
+  //   this
+  //   // function is enough. This is because all derived class handlers will
+  //   call
+  //   // this function by default.
+  //   // Override the derived class handler only if the logic is more specific
+  //   to
+  //   // that.
+
+  //   // json JSONOf(const Expr* e) {
+  //   //   auto it = exprToJSON_.find(e);
+  //   //   if (it != exprToJSON_.end()) {
+  //   //     return it->second;
+  //   //   }
+  //   //   assert(false);
+  //   // }
+
+  //   // json JSONOf(const Stmt* s) {
+  //   //   auto it = exprToJSON_.find(s);
+  //   //   if (it != exprToJSON_.end()) {
+  //   //     return it->second;
+  //   //   }
+  //   //   assert(false);
+  //   // }
+
+  void putObj(json h, const KernelScopedObject* e) {
+    size_t id = h["json_id"];
+    auto res = JSONToObj_.emplace(id, e);
+    if (res.second == false) {
+      // This is always a logic bug since we should check the cache first.
+      throw std::runtime_error("hash collision");
+    }
+  }
+
+ private:
+  std::unordered_map<size_t, const KernelScopedObject*> JSONToObj_;
+  HashProvider h_;
+};
+
+TORCH_API const Stmt* deserializeStmt(const json& json);
+TORCH_API const Expr* deserializeExpr(const json& json);
+TORCH_API const KernelScopedObject* deserialize(const json& json);
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir_deserializer.h
+++ b/torch/csrc/jit/tensorexpr/ir_deserializer.h
@@ -13,24 +13,28 @@ namespace tensorexpr {
 
 using json = nlohmann::json;
 
-#define JSON_CACHE_GUARD()  \
-  if (cachedKernelObj(v)) { \
-    return;                 \
-  }
-
-/* Expression hasher providing comparable values representing sub-exprs.
- * Uses memoization to avoid excessive recursion. */
+// Generates Tensor IR from a serialized json form Uses memoization to correctly
+// resolve repeated references to same expr
 class TORCH_API IRDeserializer : public IRVisitor {
  public:
   bool cachedKernelObj(const json& v) {
     size_t id = v["json_id"];
-    return JSONToObj_.count(id) != 0;
+    return JSONToExpr_.count(id) != 0 && JSONToStmt_.count(id) != 0;
   }
 
   const Expr* getCachedExpr(const json& v) {
-    auto it = JSONToObj_.find(v["json_id"]);
-    if (it != JSONToObj_.end()) {
-      return it->second;
+    auto it = JSONToExpr_.find(v["json_id"]);
+    if (it != JSONToExpr_.end()) {
+      return dynamic_cast<const Expr*>(it->second);
+    }
+    assert(false);
+  }
+
+  Stmt* getCachedStmt(const json& v) {
+    auto it = JSONToStmt_.find(v["json_id"]);
+    if (it != JSONToStmt_.end()) {
+      const Stmt* stmt = dynamic_cast<const Stmt*>(it->second);
+      return const_cast<Stmt*>(stmt);
     }
     assert(false);
   }
@@ -61,6 +65,7 @@ class TORCH_API IRDeserializer : public IRVisitor {
   Free* deserializeFree(const json& v);
   Cond* deserializeCond(const json& v);
 
+  Stmt* dsStmtImpl(const json& v);
   Stmt* dsStmt(const json& v);
   std::vector<Stmt*> dsVecStmt(const json& v);
 
@@ -78,7 +83,15 @@ class TORCH_API IRDeserializer : public IRVisitor {
 
   void putObj(json h, const Expr* e) {
     size_t id = h["json_id"];
-    auto res = JSONToObj_.emplace(id, e);
+    auto res = JSONToExpr_.emplace(id, e);
+    if (res.second == false) {
+      // This is always a logic bug since we should check the cache first.
+      throw std::runtime_error("hash collision");
+    }
+  }
+  void putObj(json h, Stmt* e) {
+    size_t id = h["json_id"];
+    auto res = JSONToStmt_.emplace(id, e);
     if (res.second == false) {
       // This is always a logic bug since we should check the cache first.
       throw std::runtime_error("hash collision");
@@ -86,7 +99,8 @@ class TORCH_API IRDeserializer : public IRVisitor {
   }
 
  private:
-  std::unordered_map<size_t, const Expr*> JSONToObj_;
+  std::unordered_map<size_t, const Expr*> JSONToExpr_;
+  std::unordered_map<size_t, Stmt*> JSONToStmt_;
 };
 
 TORCH_API const Stmt* deserializeStmt(const json& v);

--- a/torch/csrc/jit/tensorexpr/ir_serializer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_serializer.cpp
@@ -1,0 +1,557 @@
+#include <torch/csrc/jit/tensorexpr/ir_serializer.h>
+
+using json = nlohmann::json;
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+json IRSerializer::serialize(ExprHandle expr) {
+  expr.node()->accept(this);
+  return JSONOf(expr.node());
+}
+
+json IRSerializer::serialize(const Expr& expr) {
+  expr.accept(this);
+  return JSONOf(&expr);
+}
+
+json IRSerializer::serialize(const Stmt& stmt) {
+  stmt.accept(this);
+  return JSONOf(&stmt);
+}
+
+json serializeDtype(Dtype dtype) {
+  return toString(dtype.scalar_type());
+}
+
+json IRSerializer::visitAndSerialize(const Expr* v) {
+  if (cachedJSON(v)) {
+    return JSONOf(v);
+  }
+  v->accept(this);
+  return JSONOf(v);
+}
+
+json IRSerializer::visitAndSerialize(const std::vector<const Expr*>& v) {
+  std::vector<json> json_vec;
+  for (const auto expr : v) {
+    json_vec.push_back(visitAndSerialize(expr));
+  }
+  return json_vec;
+}
+
+json IRSerializer::visitAndSerialize(const Stmt* v) {
+  if (cachedJSON(v)) {
+    return JSONOf(v);
+  }
+  v->accept(this);
+  return JSONOf(v);
+}
+
+json IRSerializer::visitAndSerialize(const std::vector<const Stmt*>& v) {
+  std::vector<json> json_vec;
+  for (const auto stmt : v) {
+    json_vec.push_back(visitAndSerialize(stmt));
+  }
+  return json_vec;
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::LongImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "LongImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::ShortImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "ShortImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::BoolImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "BoolImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::FloatImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "FloatImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::DoubleImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "DoubleImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::CharImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "CharImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::HalfImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "HalfImm"},
+          {"value", static_cast<float>(v->value())},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::ByteImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "ByteImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void torch::jit::tensorexpr::IRSerializer::visit(
+    torch::jit::tensorexpr::IntImm const* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "IntImm"},
+          {"value", v->value()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+// TODO: change whether to include the parenthesis to the parent expression,
+// we need to look at the operator precedence to make the output simpler.
+template <typename Op>
+void visitBinaryOp(
+    const BinaryOpNode<Op>* v,
+    const std::string& op_str,
+    IRSerializer* serializer) {
+  if (serializer->cachedJSON(v)) {
+    return;
+  }
+  json value = {
+      {"lhs", serializer->visitAndSerialize(v->lhs())},
+      {"rhs", serializer->visitAndSerialize(v->rhs())},
+      {"dtype", serializeDtype(v->dtype())},
+      {"expr_type", op_str},
+  };
+  serializer->putJSON(v, value);
+}
+
+void IRSerializer::visit(const Add* v) {
+  visitBinaryOp(v, "Add", this);
+}
+
+void IRSerializer::visit(const Sub* v) {
+  visitBinaryOp(v, "Sub", this);
+}
+
+void IRSerializer::visit(const Mul* v) {
+  visitBinaryOp(v, "Mul", this);
+}
+
+void IRSerializer::visit(const Div* v) {
+  visitBinaryOp(v, "Div", this);
+}
+
+void IRSerializer::visit(const Mod* v) {
+  visitBinaryOp(v, "Mod", this);
+}
+
+void IRSerializer::visit(const Max* v) {
+  visitBinaryOp(v, "Max", this);
+}
+
+void IRSerializer::visit(const Min* v) {
+  visitBinaryOp(v, "Min", this);
+}
+
+void IRSerializer::visit(const And* v) {
+  visitBinaryOp(v, "And", this);
+}
+
+void IRSerializer::visit(const Or* v) {
+  visitBinaryOp(v, "Or", this);
+}
+
+void IRSerializer::visit(const Xor* v) {
+  visitBinaryOp(v, "Xor", this);
+}
+
+void IRSerializer::visit(const Lshift* v) {
+  visitBinaryOp(v, "Lshift", this);
+}
+
+void IRSerializer::visit(const Rshift* v) {
+  visitBinaryOp(v, "Rshift", this);
+}
+
+void IRSerializer::visit(const CompareSelect* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "CompareSelect"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"lhs", visitAndSerialize(v->lhs())},
+          {"rhs", visitAndSerialize(v->rhs())},
+          {"ret_val1", visitAndSerialize(v->ret_val1())},
+          {"ret_val2", visitAndSerialize(v->ret_val2())},
+          {"CompareSelectOperation", v->compare_select_op()},
+      });
+}
+
+void IRSerializer::visit(const Cast* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {{"expr_type", "Cast"},
+       {"dtype", serializeDtype(v->dtype())},
+       {"src_value", visitAndSerialize(v->src_value())}});
+}
+
+void IRSerializer::visit(const Var* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {{"expr_type", "Var"},
+       {"dtype", serializeDtype(v->dtype())},
+       {"name", name_manager_.get_unique_name(v)}});
+}
+
+void IRSerializer::visit(const Ramp* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "Ramp"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"base", visitAndSerialize(v->base())},
+          {"stride", visitAndSerialize(v->stride())},
+          {"lanes", v->lanes()},
+      });
+}
+
+void IRSerializer::visit(const Load* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"base_handle", visitAndSerialize(v->base_handle())},
+          {"indices", visitAndSerialize(v->indices())},
+          {"mask", visitAndSerialize(v->mask())},
+          {"stmt_type", "Load"},
+      });
+}
+
+void IRSerializer::visit(const Store* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"stmt_type", "Store"},
+          {"indices", visitAndSerialize(v->indices())},
+          {"value", visitAndSerialize(v->value())},
+          {"mask", visitAndSerialize(v->mask())},
+          {"buf", visitAndSerialize(v->buf())},
+      });
+}
+
+void IRSerializer::visit(const Block* v) {
+  JSON_CACHE_GUARD();
+  // TODO: why is Block using std::list instead of std::vector ?
+  std::vector<json> stmts;
+  for (Stmt* s : *v) {
+    s->accept(this);
+    stmts.push_back(JSONOf(s));
+  }
+  putJSON(
+      v,
+      {
+          {"stmt_type", "Block"},
+          {"stmts", stmts},
+      });
+}
+
+void IRSerializer::visit(const For* v) {
+  JSON_CACHE_GUARD();
+  auto buffer_mapping = v->loop_options().get_buffer_mapping();
+  json buffer_mapping_json;
+  for (const auto& mapping : buffer_mapping) {
+    buffer_mapping_json[mapping.first] = visitAndSerialize(mapping.second);
+  }
+  json loop_options_json = {
+      {"buffer_mapping", buffer_mapping_json},
+      {"gpu_block_index", v->loop_options().gpu_block_index()},
+      {"gpu_thread_index", v->loop_options().gpu_thread_index()},
+  };
+  json for_json = {
+      {"stmt_type", "For"},
+      {"var", visitAndSerialize(v->var())},
+      {"start", visitAndSerialize(v->start())},
+      {"stop", visitAndSerialize(v->stop())},
+      {"loop_options", loop_options_json},
+  };
+  if (v->body()) {
+    for_json["body"] = visitAndSerialize(v->body());
+  }
+  putJSON(v, for_json);
+}
+
+void IRSerializer::visit(const Broadcast* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "Broadcast"},
+          {"value", visitAndSerialize(v->value())},
+          {"lanes", v->lanes()},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void IRSerializer::visit(const IfThenElse* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "IfThenElse"},
+          {"true_value", visitAndSerialize(v->true_value())},
+          {"false_value", visitAndSerialize(v->false_value())},
+          {"condition", visitAndSerialize(v->condition())},
+          {"dtype", serializeDtype(v->dtype())},
+      });
+}
+
+void IRSerializer::visit(const BaseCallNode* v) {
+  // should have visited the inherited class
+  assert(false);
+}
+
+void IRSerializer::visit(const Intrinsics* v) {
+  putJSON(
+      v,
+      {{"expr_type", "Intrinsics"},
+       {"dtype", serializeDtype(v->dtype())},
+       {"func_name", v->func_name()},
+       {"params", visitAndSerialize(v->params())}});
+}
+
+void IRSerializer::visit(const Allocate* v) {
+  JSON_CACHE_GUARD();
+  // TODO: why is allocate a stmt and not an expr ?
+  putJSON(
+      v,
+      {
+          {"stmt_type", "Allocate"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"buffer_var", visitAndSerialize(v->buffer_var())},
+          {"dims", visitAndSerialize(v->dims())},
+      });
+}
+
+void IRSerializer::visit(const Free* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"stmt_type", "Free"},
+          {"buffer_var", visitAndSerialize(v->buffer_var())},
+      });
+}
+
+void IRSerializer::visit(const Buf* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {{"expr_type", "Buf"},
+       {"dtype", serializeDtype(v->dtype())},
+       {"base_handle", visitAndSerialize(v->base_handle())},
+       {"dims", visitAndSerialize(v->dims())}});
+}
+
+void IRSerializer::visit(const Cond* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {{"stmt_type", "Cond"},
+       {"condition", visitAndSerialize(v->condition())},
+       {"true_stmt", visitAndSerialize(v->true_stmt())},
+       {"false_stmt", visitAndSerialize(v->false_stmt())}});
+}
+
+void IRSerializer::visit(const Term* v) {
+  JSON_CACHE_GUARD();
+  // TODO: why is Term not a a kernel scoped object ?
+  putJSON(
+      v,
+      {
+          {"expr_type", "Term"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"scalar", visitAndSerialize(v->scalar())},
+          {"variables", visitAndSerialize(v->variables())},
+      });
+}
+
+void IRSerializer::visit(const Polynomial* v) {
+  JSON_CACHE_GUARD();
+  std::vector<json> variables;
+  for (const auto* var : v->variables()) {
+    variables.push_back(visitAndSerialize(var));
+  }
+  putJSON(
+      v,
+      {
+          {"expr_type", "Term"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"scalar", visitAndSerialize(v->scalar())},
+          {"variables", variables},
+      });
+}
+
+void IRSerializer::visit(const MaxTerm* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "MaxTerm"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"scalar", visitAndSerialize(v->scalar())},
+          {"propagate_nans", v->propagate_nans()},
+          {"variables", visitAndSerialize(v->variables())},
+      });
+}
+
+void IRSerializer::visit(const MinTerm* v) {
+  JSON_CACHE_GUARD();
+  putJSON(
+      v,
+      {
+          {"expr_type", "MaxTerm"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"scalar", visitAndSerialize(v->scalar())},
+          {"variables", visitAndSerialize(v->variables())},
+      });
+}
+
+// void IRSerializer::visit(const Tensor * v) {
+//   JSON_CACHE_GUARD
+
+// }
+
+void IRSerializer::visit(const FunctionCall* v) {
+  JSON_CACHE_GUARD();
+  std::vector<json> args;
+  for (const auto arg : v->tensor()->args()) {
+    args.push_back(visitAndSerialize(arg));
+  }
+  putJSON(
+      v,
+      {
+          {"expr_type", "FunctionCall"},
+          {"params", visitAndSerialize(v->params())},
+          {"output_index", v->tensor()->output_index()},
+          {"dtype", serializeDtype(v->dtype())},
+          {"args", args},
+          {"function_name", v->tensor()->buf()->name_hint()},
+          {"dims", visitAndSerialize(v->tensor()->dims())},
+          {"buf", visitAndSerialize(v->tensor()->buf())},
+          {"body", visitAndSerialize(v->tensor()->body())},
+      });
+}
+
+void IRSerializer::visit(const RoundOff* v) {
+  visitBinaryOp(v, "RoundOff", this);
+};
+
+void IRSerializer::visit(const ReduceOp* v) {
+  assert(false);
+  // can't serialize lambda reduction interaction
+  // TOOD: reduction interaction should be a Function Node or something else
+};
+
+void IRSerializer::visit(const AtomicAdd* v) {
+  putJSON(
+      v,
+      {
+          {"stmt_type", "AtomicAdd"},
+          {"indices", visitAndSerialize(v->indices())},
+          {"buf", visitAndSerialize(v->buf())},
+          {"value", visitAndSerialize(v->value())},
+      });
+}
+void IRSerializer::visit(const SyncThreads* v) {
+  putJSON(v, {{"stmt_type", "SyncThreads"}});
+}
+void IRSerializer::visit(const Let* v) {
+  putJSON(
+      v,
+      {
+          {"stmt_type", "Let"},
+          {"dtype", serializeDtype(v->dtype())},
+          {"var", visitAndSerialize(v->var())},
+          {"val", visitAndSerialize(v->value())},
+      });
+}
+
+json serialize(const Expr* expr) {
+  assert(expr);
+  IRSerializer s;
+  return s.serialize(*expr);
+}
+
+json serialize(const Stmt* stmt) {
+  assert(stmt);
+  IRSerializer s;
+  return s.serialize(*stmt);
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir_serializer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_serializer.cpp
@@ -6,6 +6,11 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+#define JSON_CACHE_GUARD() \
+  if (cachedJSON(v)) {     \
+    return;                \
+  }
+
 json IRSerializer::serialize(ExprHandle expr) {
   expr.node()->accept(this);
   return JSONOf(expr.node());
@@ -465,6 +470,7 @@ void IRSerializer::visit(const FunctionCall* v) {
 }
 
 void IRSerializer::visit(const RoundOff* v) {
+  JSON_CACHE_GUARD();
   visitBinaryOp(v, "RoundOff", this);
 };
 
@@ -475,6 +481,7 @@ void IRSerializer::visit(const ReduceOp* v) {
 };
 
 void IRSerializer::visit(const AtomicAdd* v) {
+  JSON_CACHE_GUARD();
   putJSON(
       v,
       {
@@ -485,6 +492,7 @@ void IRSerializer::visit(const AtomicAdd* v) {
       });
 }
 void IRSerializer::visit(const SyncThreads* v) {
+  JSON_CACHE_GUARD();
   putJSON(v, {{"stmt_type", "SyncThreads"}});
 }
 void IRSerializer::visit(const Let* v) {
@@ -497,6 +505,8 @@ void IRSerializer::visit(const Let* v) {
           {"val", visitAndSerialize(v->value())},
       });
 }
+
+#undef JSON_CACHE_GUARD
 
 json serialize(const Expr* expr) {
   assert(expr);

--- a/torch/csrc/jit/tensorexpr/ir_serializer.h
+++ b/torch/csrc/jit/tensorexpr/ir_serializer.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <torch/csrc/jit/json.hpp>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_printer.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/ir_visitor.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+using json = nlohmann::json;
+
+#define JSON_CACHE_GUARD() \
+  if (cachedJSON(v)) {     \
+    return;                \
+  }
+
+class TORCH_API IRSerializer : public IRVisitor {
+ public:
+  bool cachedJSON(const KernelScopedObject* e) {
+    return exprToJSON_.find(e) != exprToJSON_.end();
+  }
+
+  json serialize(ExprHandle);
+  json serialize(const Expr&);
+  json serialize(const Stmt&);
+
+  json visitAndSerialize(const Expr* v);
+  json visitAndSerialize(const std::vector<const Expr*>& v);
+  json visitAndSerialize(const Stmt* v);
+  json visitAndSerialize(const std::vector<const Stmt*>& v);
+
+  void visit(const Add* v) override;
+  void visit(const Sub* v) override;
+  void visit(const Mul* v) override;
+  void visit(const Div* v) override;
+  void visit(const Mod* v) override;
+  void visit(const Max* v) override;
+  void visit(const Min* v) override;
+  void visit(const And* v) override;
+  void visit(const Or* v) override;
+  void visit(const Xor* v) override;
+  void visit(const Lshift* v) override;
+  void visit(const Rshift* v) override;
+  void visit(const CompareSelect* v) override;
+  void visit(const RoundOff* v) override;
+
+#define IMM_SERIALIZE_VISIT(Type, Name) void visit(const Name##Imm* v) override;
+  AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_SERIALIZE_VISIT);
+#undef IMM_SERIALIZE_VISIT
+
+  void visit(const Cast* v) override;
+  void visit(const Var* v) override;
+  void visit(const Ramp* v) override;
+  void visit(const Load* v) override;
+  void visit(const Store* v) override;
+  void visit(const Block* v) override;
+  void visit(const For* v) override;
+  void visit(const Broadcast* v) override;
+  void visit(const IfThenElse* v) override;
+  void visit(const BaseCallNode* v) override;
+  void visit(const Intrinsics* v) override;
+  void visit(const Allocate* v) override;
+  void visit(const Free* v) override;
+  void visit(const Cond* v) override;
+  void visit(const Term* v) override;
+  void visit(const Polynomial* v) override;
+  void visit(const MaxTerm* v) override;
+  void visit(const MinTerm* v) override;
+
+  void visit(const FunctionCall* v) override;
+  void visit(const ReduceOp* v) override;
+
+  void visit(const AtomicAdd* v) override;
+  void visit(const SyncThreads* v) override;
+  void visit(const Let* v) override;
+
+  void visit(const Buf* v) override;
+
+  json JSONOf(const KernelScopedObject* s) {
+    // TODO: we could return just the json id here, since when we deserialize
+    // we cache on ID. this would require always visiting fields in exactly the
+    // same order in deserializer as in the serializer, which is a little
+    // brittle
+    auto it = exprToJSON_.find(s);
+    if (it != exprToJSON_.end()) {
+      return it->second;
+    }
+    throw std::runtime_error("no cached json");
+  }
+
+  void putJSON(const KernelScopedObject* e, json h) {
+    // JSON has no built-in way to make an object serialized twice resolve to
+    // the same reference, so we cache each object and assign a unique ID
+    // that on deserialization will resolve to one object
+
+    h["json_id"] = json_id_++;
+    auto res = exprToJSON_.emplace(e, h);
+    if (res.second == false) {
+      // This is always a logic bug since we should check the cache first.
+      throw std::runtime_error("hash collision");
+    }
+  }
+
+ private:
+  size_t json_id_ = 0;
+  std::unordered_map<const KernelScopedObject*, json> exprToJSON_;
+  UniqueNameManager name_manager_;
+};
+
+TORCH_API json serialize(const Expr* expr);
+TORCH_API json serialize(const Stmt* expr);
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir_serializer.h
+++ b/torch/csrc/jit/tensorexpr/ir_serializer.h
@@ -13,11 +13,6 @@ namespace tensorexpr {
 
 using json = nlohmann::json;
 
-#define JSON_CACHE_GUARD() \
-  if (cachedJSON(v)) {     \
-    return;                \
-  }
-
 class TORCH_API IRSerializer : public IRVisitor {
  public:
   bool cachedJSON(const KernelScopedObject* e) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46553 [TensorExpr] Add serializer / deserializer**
* #46552 Make TensorExpr Enums convertable to/from Strings
* #46551 [JIT] [Temp] Add dependency

This PR adds conversion to and from json to NNC. I have taken a dependency on https://github.com/nlohmann/json for json, which I talked to @malfet, the build lead about. 

A NNC Expression like the following:
`y * 2.f + (float(x) * 3.f + 4.f * y)`

Gets serialized as:
```
{
  "dtype": "Float",
  "expr_type": "Add",
  "json_id": 10,
  "lhs": {
    "dtype": "Float",
    "expr_type": "Mul",
    "json_id": 2,
    "lhs": {
      "dtype": "Float",
      "expr_type": "Var",
      "json_id": 0,
      "name": "y"
    },
    "rhs": {
      "dtype": "Float",
      "expr_type": "FloatImm",
      "json_id": 1,
      "value": 2
    }
  },
  "rhs": {
    "dtype": "Float",
    "expr_type": "Add",
    "json_id": 9,
    "lhs": {
      "dtype": "Float",
      "expr_type": "Mul",
      "json_id": 6,
      "lhs": {
        "dtype": "Float",
        "expr_type": "Cast",
        "json_id": 4,
        "src_value": {
          "dtype": "Half",
          "expr_type": "Var",
          "json_id": 3,
          "name": "x"
        }
      },
      "rhs": {
        "dtype": "Float",
        "expr_type": "FloatImm",
        "json_id": 5,
        "value": 3
      }
    },
    "rhs": {
      "dtype": "Float",
      "expr_type": "Mul",
      "json_id": 8,
      "lhs": {
        "dtype": "Float",
        "expr_type": "FloatImm",
        "json_id": 7,
        "value": 4
      },
      "rhs": {
        "dtype": "Float",
        "expr_type": "Var",
        "json_id": 0,
        "name": "y"
      }
    }
  }
```

A few notes about implementation: 

- JSON has no builtin way to resolve references, so serialized KernelScopedObjects are cached, and assigned a json_id. When we deserialize, we look if we already deserialized a node with that ID in order to maintain multiple references to an object. 

- This memoization is currently broken just for Tensors, so each repeated call to a Tensor increments the name once. I've tried debugging it and would appreciate some help here 😛 This may be because there is no visitor defined for Tensors/Functions, just FunctionCall nodes. I'm not sure exactly though...

- `ReduceOp` is not able to be serialized currently because `interaction` is stored as a lambda. I'm not sure why there is the indirection there instead of directly storing an Expression or function or something.

- Testing : this is certainly light on testing currently. In JIT, any time we compile a graph in test files we test that it serializes correctly. It would be nice to do this also for TensorExprs. This is currently blocked by ReduceOp and Tensor memoization issue I mentioned.



