### PR TITLE
[caffe2] Allow memonger to optimize nets with inplace(enforced) ops

### DIFF
--- a/caffe2/core/memonger.cc
+++ b/caffe2/core/memonger.cc
@@ -34,14 +34,6 @@ NetDef optimize_inference_net(
           schema->Verify(op),
           "Operator def did not pass schema checking: ",
           ProtoDebugString(op));
-      for (int in_idx = 0; in_idx < op.input_size(); in_idx++) {
-        for (int out_idx = 0; out_idx < op.output_size(); out_idx++) {
-          if (schema->inplace_enforced(in_idx, out_idx)) {
-            LOG(INFO) << "Memonger does not support in-place ops yet";
-            return net;
-          }
-        }
-      }
     }
     ops.push_back(op);
   }


### PR DESCRIPTION
Summary:
Follow-up for D24236604 (https://github.com/pytorch/pytorch/commit/16c52d918b8b3e90c81eb6d2a1fb0945dc187932).

For nets that pass the schema check, memonger actually makes sure to preserve the inplaceness of operators if they are already inplace. So we can safely enable it for correct input nets.

Differential Revision: D24402482

