### PR TITLE
fix-process-group-counter

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -404,6 +404,7 @@ def init_process_group(backend,
     global _backend
     global _default_pg
     global _default_pg_init_method
+    global _group_count
 
     if not isinstance(timeout, timedelta):
         raise RuntimeError("Expected timeout argument to be of type"
@@ -457,6 +458,9 @@ def init_process_group(backend,
             group_name=group_name,
             timeout=timeout)
 
+    if not group_name:
+        _group_count += 1
+
     _pg_group_ranks[_default_pg] = {i: i for i in range(_default_pg.size())}
     _backend = _pg_map[_default_pg][0]
     _default_pg_init_method = init_method
@@ -488,7 +492,6 @@ def _new_process_group_helper(world_size,
 
     if not group_name:
         group_name = str(_group_count)
-        _group_count += 1
 
     if group_name in _pg_names.values():
         raise RuntimeError("The specified group name has already been "

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -458,9 +458,6 @@ def init_process_group(backend,
             group_name=group_name,
             timeout=timeout)
 
-    if not group_name:
-        _group_count += 1
-
     _pg_group_ranks[_default_pg] = {i: i for i in range(_default_pg.size())}
     _backend = _pg_map[_default_pg][0]
     _default_pg_init_method = init_method
@@ -490,6 +487,7 @@ def _new_process_group_helper(world_size,
     global _group_count
     global _pg_names
 
+    group_name_=group_name
     if not group_name:
         group_name = str(_group_count)
 
@@ -555,6 +553,9 @@ def _new_process_group_helper(world_size,
                 timeout)
             _pg_map[pg] = (backend, store)
             _pg_names[pg] = group_name
+
+    if not group_name_:
+        _group_count += 1
 
     return pg
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -486,7 +486,7 @@ def _new_process_group_helper(world_size,
     global _group_count
     global _pg_names
 
-    group_name_=group_name
+    group_name_ = group_name
     if not group_name:
         group_name = str(_group_count)
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -404,7 +404,6 @@ def init_process_group(backend,
     global _backend
     global _default_pg
     global _default_pg_init_method
-    global _group_count
 
     if not isinstance(timeout, timedelta):
         raise RuntimeError("Expected timeout argument to be of type"

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -486,6 +486,7 @@ def _new_process_group_helper(world_size,
     global _group_count
     global _pg_names
 
+    group_name_ = group_name
     if not group_name:
         group_name = str(_group_count)
 
@@ -512,7 +513,6 @@ def _new_process_group_helper(world_size,
             return GroupMember.NON_GROUP_MEMBER
         _pg_map[pg] = (Backend.MPI, None)
         _pg_names[pg] = group_name
-        _group_count += 1
     else:
         # If this is a subgroup (which means group_ranks is specified),
         # we check if the current process is a member of the new group.
@@ -533,7 +533,6 @@ def _new_process_group_helper(world_size,
                 timeout=timeout)
             _pg_map[pg] = (Backend.GLOO, store)
             _pg_names[pg] = group_name
-            _group_count += 1
         elif backend == Backend.NCCL:
             if not is_nccl_available():
                 raise RuntimeError("Distributed package doesn't have NCCL "
@@ -545,7 +544,6 @@ def _new_process_group_helper(world_size,
                 timeout)
             _pg_map[pg] = (Backend.NCCL, store)
             _pg_names[pg] = group_name
-            _group_count += 1
         else:
             pg = getattr(Backend, backend.upper())(
                 prefix_store,
@@ -554,7 +552,9 @@ def _new_process_group_helper(world_size,
                 timeout)
             _pg_map[pg] = (backend, store)
             _pg_names[pg] = group_name
-            _group_count += 1
+
+    if not group_name_:
+        _group_count += 1
 
     return pg
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -166,7 +166,7 @@ _pg_group_ranks = {}
 _default_pg = None
 _default_pg_init_method = None
 
-# Process group count for default naming
+# Process group counter for default naming
 _group_count = 0
 
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -486,7 +486,6 @@ def _new_process_group_helper(world_size,
     global _group_count
     global _pg_names
 
-    group_name_ = group_name
     if not group_name:
         group_name = str(_group_count)
 
@@ -513,6 +512,7 @@ def _new_process_group_helper(world_size,
             return GroupMember.NON_GROUP_MEMBER
         _pg_map[pg] = (Backend.MPI, None)
         _pg_names[pg] = group_name
+        _group_count += 1
     else:
         # If this is a subgroup (which means group_ranks is specified),
         # we check if the current process is a member of the new group.
@@ -533,6 +533,7 @@ def _new_process_group_helper(world_size,
                 timeout=timeout)
             _pg_map[pg] = (Backend.GLOO, store)
             _pg_names[pg] = group_name
+            _group_count += 1
         elif backend == Backend.NCCL:
             if not is_nccl_available():
                 raise RuntimeError("Distributed package doesn't have NCCL "
@@ -544,6 +545,7 @@ def _new_process_group_helper(world_size,
                 timeout)
             _pg_map[pg] = (Backend.NCCL, store)
             _pg_names[pg] = group_name
+            _group_count += 1
         else:
             pg = getattr(Backend, backend.upper())(
                 prefix_store,
@@ -552,9 +554,7 @@ def _new_process_group_helper(world_size,
                 timeout)
             _pg_map[pg] = (backend, store)
             _pg_names[pg] = group_name
-
-    if not group_name_:
-        _group_count += 1
+            _group_count += 1
 
     return pg
 


### PR DESCRIPTION
Fixes #46561 

A minimal fix to issue #46561. Increment the global variable `_group_count` at the same time as the others so the global state remains consistent in case of a failure.
