### PR TITLE
renaming env var IN_CIRCLECI to a broader name of IN_CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -780,7 +780,7 @@ jobs:
           no_output_timeout: "30m"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
@@ -1269,7 +1269,7 @@ jobs:
           no_output_timeout: "1h"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
@@ -1305,7 +1305,7 @@ jobs:
           no_output_timeout: "1h"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
 
             chmod a+x .jenkins/pytorch/macos-test.sh
             unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
@@ -1553,7 +1553,7 @@ jobs:
           no_output_timeout: "1h"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             export TCLLIBPATH="/usr/local/lib"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -780,7 +780,7 @@ jobs:
           no_output_timeout: "30m"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
@@ -1269,7 +1269,7 @@ jobs:
           no_output_timeout: "1h"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
@@ -1305,7 +1305,7 @@ jobs:
           no_output_timeout: "1h"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
 
             chmod a+x .jenkins/pytorch/macos-test.sh
             unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
@@ -1553,7 +1553,7 @@ jobs:
           no_output_timeout: "1h"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             export TCLLIBPATH="/usr/local/lib"

--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -54,7 +54,7 @@ add_to_env_file() {
   echo "${content}" >> "${BASH_ENV:-/tmp/env}"
 }
 
-add_to_env_file "IN_CIRCLECI=1"
+add_to_env_file "OUTPUT_XUNIT=1"
 add_to_env_file "COMMIT_SOURCE=${CIRCLE_BRANCH:-}"
 add_to_env_file "BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}"
 add_to_env_file "CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}"

--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -54,7 +54,7 @@ add_to_env_file() {
   echo "${content}" >> "${BASH_ENV:-/tmp/env}"
 }
 
-add_to_env_file "OUTPUT_XUNIT=1"
+add_to_env_file "IN_CI=1"
 add_to_env_file "COMMIT_SOURCE=${CIRCLE_BRANCH:-}"
 add_to_env_file "BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}"
 add_to_env_file "CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}"

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -124,7 +124,7 @@
           no_output_timeout: "1h"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
@@ -160,7 +160,7 @@
           no_output_timeout: "1h"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
 
             chmod a+x .jenkins/pytorch/macos-test.sh
             unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
@@ -408,7 +408,7 @@
           no_output_timeout: "1h"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             export TCLLIBPATH="/usr/local/lib"

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -124,7 +124,7 @@
           no_output_timeout: "1h"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
 
             # Install sccache
             sudo curl --retry 3 https://s3.amazonaws.com/ossci-macos/sccache --output /usr/local/bin/sccache
@@ -160,7 +160,7 @@
           no_output_timeout: "1h"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
 
             chmod a+x .jenkins/pytorch/macos-test.sh
             unbuffer .jenkins/pytorch/macos-test.sh 2>&1 | ts
@@ -408,7 +408,7 @@
           no_output_timeout: "1h"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
             WORKSPACE=/Users/distiller/workspace
             PROJ_ROOT=/Users/distiller/project
             export TCLLIBPATH="/usr/local/lib"

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -346,7 +346,7 @@ jobs:
           no_output_timeout: "30m"
           command: |
             set -e
-            export IN_CIRCLECI=1
+            export OUTPUT_XUNIT=1
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -346,7 +346,7 @@ jobs:
           no_output_timeout: "30m"
           command: |
             set -e
-            export OUTPUT_XUNIT=1
+            export IN_CI=1
             set +x
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -8,7 +8,7 @@
 COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 
 # Temp: use new sccache
-if [[ -n "$IN_CIRCLECI" && "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+if [[ -n "$OUTPUT_XUNIT" && "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # Download customized sccache
   sudo curl --retry 3 http://repo.radeon.com/misc/.sccache_amd/sccache -o /opt/cache/bin/sccache
   sudo chmod 755 /opt/cache/bin/sccache
@@ -137,7 +137,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
 
   # ROCm CI is using Caffe2 docker images, which needs these wrapper
   # scripts to correctly use sccache.
-  if [[ -n "${SCCACHE_BUCKET}" && -z "$IN_CIRCLECI" ]]; then
+  if [[ -n "${SCCACHE_BUCKET}" && -z "$OUTPUT_XUNIT" ]]; then
     mkdir -p ./sccache
 
     SCCACHE="$(which sccache)"
@@ -161,7 +161,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export PATH="$CACHE_WRAPPER_DIR:$PATH"
   fi
 
-  if [[ -n "$IN_CIRCLECI" ]]; then
+  if [[ -n "$OUTPUT_XUNIT" ]]; then
       # Set ROCM_ARCH to gtx900 and gtx906 in CircleCI
       echo "Limiting PYTORCH_ROCM_ARCH to gfx90[06] for CircleCI builds"
       export PYTORCH_ROCM_ARCH="gfx900;gfx906"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -8,7 +8,7 @@
 COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 
 # Temp: use new sccache
-if [[ -n "$OUTPUT_XUNIT" && "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+if [[ -n "$IN_CI" && "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # Download customized sccache
   sudo curl --retry 3 http://repo.radeon.com/misc/.sccache_amd/sccache -o /opt/cache/bin/sccache
   sudo chmod 755 /opt/cache/bin/sccache
@@ -137,7 +137,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
 
   # ROCm CI is using Caffe2 docker images, which needs these wrapper
   # scripts to correctly use sccache.
-  if [[ -n "${SCCACHE_BUCKET}" && -z "$OUTPUT_XUNIT" ]]; then
+  if [[ -n "${SCCACHE_BUCKET}" && -z "$IN_CI" ]]; then
     mkdir -p ./sccache
 
     SCCACHE="$(which sccache)"
@@ -161,7 +161,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export PATH="$CACHE_WRAPPER_DIR:$PATH"
   fi
 
-  if [[ -n "$OUTPUT_XUNIT" ]]; then
+  if [[ -n "$IN_CI" ]]; then
       # Set ROCM_ARCH to gtx900 and gtx906 in CircleCI
       echo "Limiting PYTORCH_ROCM_ARCH to gfx90[06] for CircleCI builds"
       export PYTORCH_ROCM_ARCH="gfx900;gfx906"

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -16,13 +16,13 @@ if [[ "${BUILD_ENVIRONMENT}" == *cuda9.2* ]]; then
   export CUDA_HOME=/Developer/NVIDIA/CUDA-${CUDA_VERSION}
   export USE_CUDA=1
 
-  if [ -z "${OUTPUT_XUNIT}" ]; then
+  if [ -z "${IN_CI}" ]; then
     # Eigen gives "explicit specialization of class must precede its first use" error
     # when compiling with Xcode 9.1 toolchain, so we have to use Xcode 8.2 toolchain instead.
     export DEVELOPER_DIR=/Library/Developer/CommandLineTools
   fi
 else
-  if [ -z "${OUTPUT_XUNIT}" ]; then
+  if [ -z "${IN_CI}" ]; then
     export DEVELOPER_DIR=/Applications/Xcode9.app/Contents/Developer
   fi
 fi
@@ -49,7 +49,7 @@ MAX_JOBS=2 USE_DISTRIBUTED=1 python setup.py install
 assert_git_not_dirty
 
 # Upload torch binaries when the build job is finished
-if [ -z "${OUTPUT_XUNIT}" ]; then
+if [ -z "${IN_CI}" ]; then
   7z a ${IMAGE_COMMIT_TAG}.7z ${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages/torch*
   aws s3 cp ${IMAGE_COMMIT_TAG}.7z s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z --acl public-read
 fi

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -16,13 +16,13 @@ if [[ "${BUILD_ENVIRONMENT}" == *cuda9.2* ]]; then
   export CUDA_HOME=/Developer/NVIDIA/CUDA-${CUDA_VERSION}
   export USE_CUDA=1
 
-  if [ -z "${IN_CIRCLECI}" ]; then
+  if [ -z "${OUTPUT_XUNIT}" ]; then
     # Eigen gives "explicit specialization of class must precede its first use" error
     # when compiling with Xcode 9.1 toolchain, so we have to use Xcode 8.2 toolchain instead.
     export DEVELOPER_DIR=/Library/Developer/CommandLineTools
   fi
 else
-  if [ -z "${IN_CIRCLECI}" ]; then
+  if [ -z "${OUTPUT_XUNIT}" ]; then
     export DEVELOPER_DIR=/Applications/Xcode9.app/Contents/Developer
   fi
 fi
@@ -49,7 +49,7 @@ MAX_JOBS=2 USE_DISTRIBUTED=1 python setup.py install
 assert_git_not_dirty
 
 # Upload torch binaries when the build job is finished
-if [ -z "${IN_CIRCLECI}" ]; then
+if [ -z "${OUTPUT_XUNIT}" ]; then
   7z a ${IMAGE_COMMIT_TAG}.7z ${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages/torch*
   aws s3 cp ${IMAGE_COMMIT_TAG}.7z s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z --acl public-read
 fi

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -14,7 +14,7 @@ if [[ ! $(python -c "import sys; print(int(sys.version_info >= (3, 3)))") == "1"
   pip install -q faulthandler
 fi
 
-if [ -z "${IN_CIRCLECI}" ]; then
+if [ -z "${OUTPUT_XUNIT}" ]; then
   rm -rf ${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 fi
 
@@ -23,7 +23,7 @@ git submodule update --init --recursive
 export CMAKE_PREFIX_PATH=${WORKSPACE_DIR}/miniconda3/
 
 # Test PyTorch
-if [ -z "${IN_CIRCLECI}" ]; then
+if [ -z "${OUTPUT_XUNIT}" ]; then
   if [[ "${BUILD_ENVIRONMENT}" == *cuda9.2* ]]; then
     # Eigen gives "explicit specialization of class must precede its first use" error
     # when compiling with Xcode 9.1 toolchain, so we have to use Xcode 8.2 toolchain instead.
@@ -34,7 +34,7 @@ if [ -z "${IN_CIRCLECI}" ]; then
 fi
 
 # Download torch binaries in the test jobs
-if [ -z "${IN_CIRCLECI}" ]; then
+if [ -z "${OUTPUT_XUNIT}" ]; then
   rm -rf ${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages/torch*
   aws s3 cp s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z ${IMAGE_COMMIT_TAG}.7z
   7z x ${IMAGE_COMMIT_TAG}.7z -o"${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages"

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -14,7 +14,7 @@ if [[ ! $(python -c "import sys; print(int(sys.version_info >= (3, 3)))") == "1"
   pip install -q faulthandler
 fi
 
-if [ -z "${OUTPUT_XUNIT}" ]; then
+if [ -z "${IN_CI}" ]; then
   rm -rf ${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 fi
 
@@ -23,7 +23,7 @@ git submodule update --init --recursive
 export CMAKE_PREFIX_PATH=${WORKSPACE_DIR}/miniconda3/
 
 # Test PyTorch
-if [ -z "${OUTPUT_XUNIT}" ]; then
+if [ -z "${IN_CI}" ]; then
   if [[ "${BUILD_ENVIRONMENT}" == *cuda9.2* ]]; then
     # Eigen gives "explicit specialization of class must precede its first use" error
     # when compiling with Xcode 9.1 toolchain, so we have to use Xcode 8.2 toolchain instead.
@@ -34,7 +34,7 @@ if [ -z "${OUTPUT_XUNIT}" ]; then
 fi
 
 # Download torch binaries in the test jobs
-if [ -z "${OUTPUT_XUNIT}" ]; then
+if [ -z "${IN_CI}" ]; then
   rm -rf ${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages/torch*
   aws s3 cp s3://ossci-macos-build/pytorch/${IMAGE_COMMIT_TAG}.7z ${IMAGE_COMMIT_TAG}.7z
   7z x ${IMAGE_COMMIT_TAG}.7z -o"${WORKSPACE_DIR}/miniconda3/lib/python3.6/site-packages"

--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -10,7 +10,7 @@ COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Testing pytorch (distributed only)"
-if [ -n "${IN_CIRCLECI}" ]; then
+if [ -n "${OUTPUT_XUNIT}" ]; then
   # TODO move this to docker
   pip_install unittest-xml-reporting
 

--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -10,7 +10,7 @@ COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Testing pytorch (distributed only)"
-if [ -n "${OUTPUT_XUNIT}" ]; then
+if [ -n "${IN_CI}" ]; then
   # TODO move this to docker
   pip_install unittest-xml-reporting
 

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -11,7 +11,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Testing pytorch"
 
-if [ -n "${OUTPUT_XUNIT}" ]; then
+if [ -n "${IN_CI}" ]; then
   # TODO move this to docker
   pip_install unittest-xml-reporting coverage pytest
 

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -11,7 +11,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Testing pytorch"
 
-if [ -n "${IN_CIRCLECI}" ]; then
+if [ -n "${OUTPUT_XUNIT}" ]; then
   # TODO move this to docker
   pip_install unittest-xml-reporting coverage pytest
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -152,7 +152,7 @@ parser.add_argument('--repeat', type=int, default=1)
 parser.add_argument('--test_bailouts', action='store_true')
 parser.add_argument('--save-xml', nargs='?', type=str,
                     const=_get_test_report_path(),
-                    default=_get_test_report_path() if bool(os.environ.get('OUTPUT_XUNIT')) else None)
+                    default=_get_test_report_path() if bool(os.environ.get('IN_CI')) else None)
 parser.add_argument('--discover-tests', action='store_true')
 parser.add_argument('--log-suffix', type=str, default="")
 parser.add_argument('--run-parallel', type=int, default=1)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -152,7 +152,7 @@ parser.add_argument('--repeat', type=int, default=1)
 parser.add_argument('--test_bailouts', action='store_true')
 parser.add_argument('--save-xml', nargs='?', type=str,
                     const=_get_test_report_path(),
-                    default=_get_test_report_path() if bool(os.environ.get('IN_CIRCLECI')) else None)
+                    default=_get_test_report_path() if bool(os.environ.get('OUTPUT_XUNIT')) else None)
 parser.add_argument('--discover-tests', action='store_true')
 parser.add_argument('--log-suffix', type=str, default="")
 parser.add_argument('--run-parallel', type=int, default=1)


### PR DESCRIPTION
The `IN_CIRCLECI` variable is a misnomer since the flag really indicates when we enable XML reporting because we want to run the test in CI. Since this doesn't necessarily mean CircleCI in particular, IN_CI is more accurate and general.