### PR TITLE
[ONNX] Slightly improve indexing with ellipsis under scripting

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1415,7 +1415,8 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(CopyModel(), (x, update))
 
     @skipIfUnsupportedMinOpsetVersion(11)
-    @disableScriptTest()  # Missing input size (with ellipsis indexing)
+    # TODO: Limited scripting support with ellipsis indexing.
+    #       Due to dependency on input tensor rank being known.
     def test_copy_ellipsis_tracing(self):
         class CopyModel(torch.nn.Module):
             def forward(self, x, update):

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -115,10 +115,12 @@ std::unordered_map<int64_t, ConvertedIndex> MergeSliceAndSelectToIndices(
     // this creates offset for latter slice and select nodes.
     auto dim = node->get(attr::dim)->toInt();
     if (dim < 0) {
-      auto input_type = node->input(0)->type()->expect<TensorType>();
+      auto input_type = orig_data->type()->expect<TensorType>();
       if (input_type->dim().has_value()) {
         auto rank = input_type->dim().value();
-        dim = dim + rank;
+        // Rank of original tensor to index on.
+        // Minus the offset created by select operators.
+        dim = dim + rank - dim_offset;
       } else {
         std::cerr
             << "Error: ONNX Remove Inplace Ops - Cannot export ellipsis indexing for input "


### PR DESCRIPTION
Still depending on rank of original tensor being known. i.e.
```python
x[i, j, k] = y  # rank of x must be known at export time
```