### PR TITLE
Fix typo in docs for interpolate

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2982,7 +2982,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
             Default: ``False``
         recompute_scale_factor (bool, optional): recompute the scale_factor for use in the
             interpolation calculation.  When `scale_factor` is passed as a parameter, it is used
-            to compute the `output_size`.  If `recompute_scale_factor` is ```False`` or not specified,
+            to compute the `output_size`.  If `recompute_scale_factor` is ``False`` or not specified,
             the passed-in `scale_factor` will be used in the interpolation computation.
             Otherwise, a new `scale_factor` will be computed based on the output and input sizes for
             use in the interpolation computation (i.e. the computation will be identical to if the computed


### PR DESCRIPTION
Removes a spurious backtick in [the docs for `torch.nn.functional.interpolate`](https://pytorch.org/docs/stable/nn.functional.html?highlight=grid_sample#torch.nn.functional.interpolate)