### PR TITLE
Implement fused Mul/Int8Quantize operator

### DIFF
--- a/caffe2/quantization/server/fused_equalize_int8_quantize_op.cc
+++ b/caffe2/quantization/server/fused_equalize_int8_quantize_op.cc
@@ -1,0 +1,130 @@
+#include "fused_equalize_int8_quantize_op.h"
+#include "dnnlowp_op.h"
+
+#include "caffe2/core/tensor_int8.h"
+#include "caffe2/quantization/server/int8_gen_quant_params.h"
+#include "caffe2_dnnlowp_utils.h"
+#include "dnnlowp_partition.h"
+
+namespace caffe2 {
+
+template <typename T>
+FusedEqualizeInt8QuantizeOp<T>::FusedEqualizeInt8QuantizeOp(
+    const OperatorDef& operator_def,
+    Workspace* ws)
+    : Operator<CPUContext>(operator_def, ws),
+      qfactory_(dnnlowp::GetQuantizationFactoryOf(this)) {}
+
+template <typename T>
+bool FusedEqualizeInt8QuantizeOp<T>::RunOnDevice() {
+  // fuse broadcast multiplication of equalization vector with int8quant
+  // the activations) and the weight
+  using namespace dnnlowp;
+
+  if (!arguments_parsed_) {
+    dnnlowp::ParseDNNLowPOperatorArguments(this);
+    arguments_parsed_ = true;
+  }
+
+  // get activation matrix and equalization vector
+  CAFFE_ENFORCE(InputSize() <= 3);
+  const auto& X = Input(0);
+  const auto& S = Input(1);
+  CAFFE_ENFORCE_EQ(X.dim(), 2);
+  CAFFE_ENFORCE_EQ(S.dim(), 1);
+
+  const int64_t numRow = X.size_to_dim(1);
+  const int64_t numCol = X.size_from_dim(1);
+
+  CAFFE_ENFORCE_EQ(numCol, S.size_to_dim(1));
+  CAFFE_ENFORCE(X.template IsType<float>());
+
+  const float* X_data = X.template data<float>();
+  const float* S_data = S.template data<float>();
+
+  // quantized output
+  int8::Int8TensorCPU* Xq =
+      Outputs()[0]->template GetMutable<int8::Int8TensorCPU>();
+  Xq->t.ResizeLike(X);
+  T* Xq_data = Xq->t.template mutable_data<T>();
+
+  std::vector<float> Xeq(numCol);
+  float* Xeq_data = Xeq.data();
+
+  bool use_input_qparam = false;
+  float in_scale = 0;
+  int in_zero_point = 0;
+  if (InputSize() == 3) {
+    // if qparam is given
+    use_input_qparam = true;
+    const auto* input_qparam_blob =
+        Input<caffe2::unique_ptr<Int8QuantParamsBlob>>(2).get();
+    CAFFE_ENFORCE(input_qparam_blob);
+    in_scale = input_qparam_blob->qparam.scale;
+    in_zero_point = input_qparam_blob->qparam.zero_point;
+  }
+
+  TensorQuantizationParams in_qparams;
+
+  if (use_input_qparam) {
+    in_qparams.scale = in_scale;
+    in_qparams.zero_point = in_zero_point;
+    in_qparams.precision = qfactory_->GetActivationPrecision();
+  } else {
+    if (HasStaticQuantization(this)) {
+      in_qparams = GetStaticQuantizationParamsOf(this, 0);
+    } else {
+      in_qparams = GetInputTensorQuantizationParamsOf(this, 0, qfactory_.get());
+    }
+  }
+
+  // fused equalization and quantization
+  for (int64_t i = 0; i < numRow; ++i) {
+    const int64_t idx = numCol * i;
+    for (int64_t j = 0; j < numCol; ++j) {
+      Xeq_data[j] = X_data[idx + j] * S_data[j];
+    }
+    fbgemm::Quantize<T>(Xeq_data, Xq_data + idx, numCol, in_qparams);
+  }
+
+  PropagateOutputTensorQuantizationParams(this, 0, in_qparams);
+
+  return true;
+}
+
+OPERATOR_SCHEMA(FusedEqualizeInt8Quantize)
+    .NumInputs(2, 3)
+    .NumOutputs(1)
+    .Input(
+        0,
+        "X",
+        "The input data, or last N samples of the output activations.")
+    .Input(
+        1,
+        "S",
+        "Equalized scale that will be multiplied to the columns of input.")
+    .Output(0, "X_q", "Equalized and int8 quantized input data.")
+    .SetDoc(R"DOC(
+Given an activation matrix X and a vector of equalization parameter S,
+return the equalized and quantized activation matrix X_q.
+
+)DOC")
+    .IdenticalTypeAndShapeOfInput(0);
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FusedEqualizeInt8Quantize,
+    DNNLOWP,
+    FusedEqualizeInt8QuantizeOp<uint8_t>);
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FusedEqualizeInt8Quantize,
+    DNNLOWP_ROWWISE,
+    FusedEqualizeInt8QuantizeOp<uint8_t>);
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FusedEqualizeInt8Quantize,
+    DNNLOWP_16,
+    FusedEqualizeInt8QuantizeOp<uint16_t>);
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    FusedEqualizeInt8Quantize,
+    DNNLOWP_ROWWISE_16,
+    FusedEqualizeInt8QuantizeOp<uint16_t>);
+} // namespace caffe2

--- a/caffe2/quantization/server/fused_equalize_int8_quantize_op.h
+++ b/caffe2/quantization/server/fused_equalize_int8_quantize_op.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "caffe2/core/operator.h"
+#include "caffe2/quantization/server/caffe2_dnnlowp_utils.h"
+
+namespace caffe2 {
+
+template <typename T>
+class FusedEqualizeInt8QuantizeOp final : public Operator<CPUContext> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CPUContext);
+  FusedEqualizeInt8QuantizeOp(const OperatorDef& operator_def, Workspace* ws);
+
+  bool RunOnDevice() override;
+
+ private:
+  std::unique_ptr<dnnlowp::QuantizationFactory> qfactory_;
+  bool arguments_parsed_{false};
+}; // class FusedMulInt8QuantizeOp
+
+} // namespace caffe2

--- a/caffe2/quantization/server/fused_equalize_int8_quantize_op_test.py
+++ b/caffe2/quantization/server/fused_equalize_int8_quantize_op_test.py
@@ -1,0 +1,85 @@
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+import time
+from caffe2.python import core, dyndep, workspace
+from caffe2.quantization.server import dnnlowp_pybind11
+from hypothesis import given, settings
+
+
+dyndep.InitOpsLibrary("//caffe2/caffe2/quantization/server:dnnlowp_ops")
+workspace.GlobalInit(["caffe2", "--caffe2_omp_num_threads=11"])
+
+
+class FusedMulInt8QuantizeOpTest(hu.HypothesisTestCase):
+
+    @settings(max_examples=10, deadline=None)
+    @given(m=st.integers(8192, 8192),
+           n=st.integers(8192, 8192))
+    def test_fused_mul_int8_quantize(self, m, n):
+        # this test is to verfy the correctness of FusedMulInt8QuantizeOp
+        # it should provide equivalent quantized result as separate Mul + Int8 Ops
+        min_ = -10.0
+        max_ = 20.0
+
+        X = (np.random.rand(m, n) * (max_ - min_) + min_).astype(np.float32)
+        X_min = 0 if X.size == 0 else X.min()
+        X_max = 1 if X.size == 0 else X.max()
+        X_scale = (max(X_max, 0) - min(X_min, 0)) / 255
+        X_zero = np.round(-X_min / X_scale)
+
+        # generate random equalization vector S in range [0,1]
+        S = np.random.rand(X.shape[1]).astype(np.float32)
+
+        X_dq, runtime = [], []
+
+        for fused in (True, False):
+            # test fused/unfused operators
+            net = core.Net("test_net")
+            dnnlowp_pybind11.CreateInt8QuantParamsBlob(
+                "quant_param", float(X_scale), int(X_zero)
+            )
+            workspace.FeedBlob("X", X)
+            workspace.FeedBlob("S", S)
+            ops = []
+            if fused:
+                fuse = core.CreateOperator(  # fused broadcast mul S to X then int8 quant
+                    "FusedEqualizeInt8Quantize",
+                    ["X", "S", "quant_param"],
+                    ["X_q"],
+                    engine="DNNLOWP",
+                )
+                ops = [fuse]
+            else:
+                mul = core.CreateOperator(  # in-place broadcast mul S to each column of X
+                    "Mul",
+                    ["X", "S"],
+                    ["X_equalized"],
+                    broadcast=1,
+                    axis=1,
+                )
+                quantize = core.CreateOperator(  # int8 quant on equalized X
+                    "Quantize",
+                    ["X_equalized", "quant_param"],
+                    ["X_q"],
+                    engine="DNNLOWP",
+                )
+                ops = [mul, quantize]
+
+            net.Proto().op.extend(ops)
+            workspace.CreateNet(net)
+            start_time = time.time()
+            workspace.RunNet(net)
+            rt = time.time() - start_time
+            # print(f"--- {fused} finished in {rt:.2f} sec ---")
+
+            # runtimes = workspace.BenchmarkNet(net.Name(), 1, 1024, True)
+
+            X_q = workspace.FetchInt8Blob("X_q")[0]
+
+            # Dequantize fused and unfused results
+            X_dq.append(X_scale * (X_q - X_zero))
+            runtime.append(rt)
+
+        # check fused/unfused X_dq are close
+        np.testing.assert_allclose(X_dq[0], X_dq[1], atol=1e-3, rtol=1e-3)


### PR DESCRIPTION
Summary:
FusedMulInt8Quantize op which performs equalization and int8 quantization for activation matrix.
- Inputs are activation matrix X, equalization vector S, (optional) quantization param
- Output is equalized and int8 quantized activation matrix
- Equalization vector S is broadcast multiplied to each column of X

Test Plan:
## Unit test
Added a unit test to the new fused Mul/Int8Quantize operator.
It is to verfy the correctness of FusedMulInt8QuantizeOp. It should provide equivalent quantized results as separate Mul + Int8 operators.
```
buck test mode/dev //caffe2/caffe2/quantization/server:fused_mul_int8_quantize_op_test --
```
## Runtime test

Runtime performance is measured on the following Ops:
- FusedMulInt8QuantizeOp
- Mul + Int8Quantize
- Int8Quantize only

For each op, activation matrix and equalization vector is randomly generated with size `m x n and m = n in [   32,   64,  128,  256,  512, 1024, 2048, 4096, 8192]`.
Runtime is measured on function ```workspace.RunNetOnce(net)```. Test is done on devserver. Each sample is repeated 1000 times after setup and final result is averaged.
Runtime results of 3 Ops are shown below. Fused Op is faster than Mul + Int8Quant. There is still room for improvement to make it close to Int8Quant Op.

{F337807523}

Reviewed By: hx89

Differential Revision: D23952854

