### PR TITLE
Minor cleaning of `test_cuda.py`

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1,15 +1,15 @@
-import collections
-import io
-import tempfile
-from typing import NamedTuple
-import unittest
-import sys
 from itertools import repeat, chain, product
-import os
+from typing import NamedTuple
+import collections
 import gc
-import threading
-import queue
+import io
+import os
 import pickle
+import queue
+import sys
+import tempfile
+import threading
+import unittest
 
 import torch
 import torch.cuda
@@ -287,10 +287,10 @@ class TestCuda(TestCase):
         self.assertFalse(t.is_pinned())
         cudart = torch.cuda.cudart()
         r = cudart.cudaHostRegister(t.data_ptr(), t.numel() * t.element_size(), 0)
-        self.assertEquals(r, 0)
+        self.assertEqual(r, 0)
         self.assertTrue(t.is_pinned())
         r = cudart.cudaHostUnregister(t.data_ptr())
-        self.assertEquals(r, 0)
+        self.assertEqual(r, 0)
         self.assertFalse(t.is_pinned())
 
     def test_memory_stats(self):


### PR DESCRIPTION
Summary: Sort includes, fix deprecated test warning

Test Plan:
```
buck run mode/dev-nosan //caffe2/test:cuda
```

Reviewed By: drdarshan

Differential Revision: D24429247

