### PR TITLE
properly handle getGraphExecutorOptimize to not leak memory due to

### DIFF
--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.h
@@ -22,6 +22,8 @@ struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   c10::optional<ExecutionPlan>
       profiling_plan_; // plan to run in order to profiling the code
   c10::optional<ExecutionPlan> optimized_plan_;
+  // this plan is used if getGraphExecutorOptimize is unset
+  c10::optional<ExecutionPlan> fallback_plan_;
   // fallback functions are inserted for tensorexpr fusion groups
   // and by specialize_autogradzero. Whenever, at runtime, input
   // tensor don't match profiled properties, fallback functions are called


### PR DESCRIPTION
properly handle getGraphExecutorOptimize to not leak  memory due to profiling
This is a back port of https://github.com/pytorch/pytorch/pull/46479
Issue: https://github.com/pytorch/pytorch/issues/46380
