### PR TITLE
DOC: dynamically create a version pull-down using javascript

### DIFF
--- a/.circleci/scripts/python_doc_push_script.sh
+++ b/.circleci/scripts/python_doc_push_script.sh
@@ -57,7 +57,7 @@ pushd docs
 # Build the docs
 pip -q install -r requirements.txt
 if [ "$is_master_doc" = true ]; then
-  make html
+  make html 
   make coverage
   # Now we have the coverage report, we need to make sure it is empty.
   # Count the number of lines in the file and turn that number into a variable
@@ -79,6 +79,7 @@ if [ "$is_master_doc" = true ]; then
   fi
 else
   # Don't fail the build on coverage problems
+  VERSION=$version
   make html-stable
 fi
 
@@ -87,14 +88,6 @@ popd
 popd
 git rm -rf "$install_path" || true
 mv "$pt_checkout/docs/build/html" "$install_path"
-
-# Add the version handler by search and replace.
-# XXX: Consider moving this to the docs Makefile or site build
-if [ "$is_master_doc" = true ]; then
-  find "$install_path" -name "*.html" -print0 | xargs -0 perl -pi -w -e "s@master\s+\((\d\.\d\.[A-Fa-f0-9]+\+[A-Fa-f0-9]+)\s+\)@<a href='http://pytorch.org/docs/versions.html'>\1 \&#x25BC</a>@g"
-else
-  find "$install_path" -name "*.html" -print0 | xargs -0 perl -pi -w -e "s@master\s+\((\d\.\d\.[A-Fa-f0-9]+\+[A-Fa-f0-9]+)\s+\)@<a href='http://pytorch.org/docs/versions.html'>$version \&#x25BC</a>@g"
-fi
 
 # Prevent Google from indexing $install_path/_modules. This folder contains
 # generated source files.

--- a/docs/source/_static/docversions.js
+++ b/docs/source/_static/docversions.js
@@ -1,4 +1,4 @@
-/* Create version-related dynamic output: instert_version_links() will output
+/* Create version-related dynamic output: insert_version_links() will output
    <li> elements for each string in `version`. The content will be an <a>,
    with the href to the parallel document in the other version. Using jquery
    ajax, it will check that the document exists, if not the href will point to
@@ -58,4 +58,3 @@ function insert_version_links() {
                         .replace('URL', url));
     }
 }
-

--- a/docs/source/_static/docversions.js
+++ b/docs/source/_static/docversions.js
@@ -1,0 +1,45 @@
+var versions = ['master',  '1.7.0', '1.6.0',
+                '1.5.1', '1.5.0', '1.4.0', '1.3.1', '1.3.0', '1.2.0',
+                '1.1.0', '1.0.1', '1.0.0', '0.4.1', '0.4.0', '0.3.1',
+                '0.3.0', '0.2.0', '0.1.12'];
+
+function insert_version_links() {
+    for (i = 0; i < versions.length; i++){
+        open_list = '<li>'
+        label = 'v' + versions[i];
+        switch (label){
+            case 'vmaster':
+                label = 'master (unstable)';
+                break;
+            case '1.7.0':
+                label += ' (rc1)';
+                break;
+            case '1.6.0':
+                label += ' (stable release)';
+                break;
+        }
+        if (typeof(DOCUMENTATION_OPTIONS) !== 'undefined') {
+            if (DOCUMENTATION_OPTIONS['VERSION'] == versions[i])
+            {
+                open_list = '<li id="current">'
+            }
+        }
+        const pathPattern = /docs\/(build\/html|stable|master|[0-9.rc]+)(.*)/;
+        const m = location.pathname.match(pathPattern);
+        base_url = 'https://pytorch.org/docs/' + versions[i];
+        if (m == null) {
+            url = base_url
+        } else {
+            url = 'https://pytorch.org/docs/' + versions[i] + m[2];
+            // Checks synchronously if the page exists, fail -> replace the link
+            $.ajax({url: url, cache: true, async: false}).fail(function(jqXHR, textStatus) {
+                url = base_url
+                });
+        }
+        document.write(open_list);
+        document.write('<a id=ID href="URL">VERSION</a> </li>\n'
+                        .replace('VERSION', label)
+                        .replace('URL', url));
+    }
+}
+

--- a/docs/source/_static/docversions.js
+++ b/docs/source/_static/docversions.js
@@ -1,3 +1,11 @@
+/* Create version-related dynamic output: instert_version_links() will output
+   <li> elements for each string in `version`. The content will be an <a>,
+   with the href to the parallel document in the other version. Using jquery
+   ajax, it will check that the document exists, if not the href will point to
+   the root of the other version
+ */
+
+// These are all the valid directories in pytorch/pytorch.github.io/docs
 var versions = ['master',  '1.7.0', '1.6.0',
                 '1.5.1', '1.5.0', '1.4.0', '1.3.1', '1.3.0', '1.2.0',
                 '1.1.0', '1.0.1', '1.0.0', '0.4.1', '0.4.0', '0.3.1',
@@ -24,7 +32,15 @@ function insert_version_links() {
                 open_list = '<li id="current">'
             }
         }
-        const pathPattern = /docs\/(build\/html|stable|master|[0-9.rc]+)(.*)/;
+        /* CI will be       https://circle-artifacts.com/0/docs/distributed.html
+           deployed will be https://pytorch.org/docs/stable/index.html
+                         or https://pytorch.org/docs/1.7.0/index.html
+                   or maybe https://pytorch.org/docs/1.7.1rc2/index.html
+           local build will be file:///tmp/pytorch/docs/build/html/index.html
+           So we want to capture '/docs', then any of '/build/html',
+           '/' + version[i], or an empty string (the final '|'), in that order.
+         */ 
+        const pathPattern = /docs(\/build\/html\/|\/stable|\/master|\/[0-9.rc]+|)(.*)/;
         const m = location.pathname.match(pathPattern);
         base_url = 'https://pytorch.org/docs/' + versions[i];
         if (m == null) {

--- a/docs/source/_templates-stable/layout.html
+++ b/docs/source/_templates-stable/layout.html
@@ -1,9 +1,42 @@
 {% extends "!layout.html" %}
 <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
 
+{% block extrahead %}
+       <!-- Early load javascript files -->
+       <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+       {%- for scriptfile in script_files %}
+         {{ js_tag(scriptfile) }}
+       {%- endfor %}
+       <script type="text/javascript" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/docversions.js', 1) }}"></script>
+{{ super() }}
+{% endblock %}
+
 {% block menu %}
 
 {{ super() }}
+{% endblock %}
+
+{% block sidebartitle %}
+            {% include "searchbox.html" %}
+            {% if theme_display_version %}
+              {%- set nav_version = version %}
+              {% if READTHEDOCS and current_version %}
+                {%- set nav_version = current_version %}
+              {% endif %}
+              {% if nav_version %}
+                <button onclick="versiontoggle()">{{ nav_version }} &#x25BC;</button>
+                <ul id="versionList" style="display: none;">
+                <script type="text/javascript">
+                    document.addEventListener("DOMContentLoaded", insert_version_links());
+                </script>
+                </ul>
+                <script type="text/javascript">
+                  function versiontoggle() {
+                    $("#versionList").toggle()
+                  };
+                </script>
+              {% endif %}
+            {% endif %}
 {% endblock %}
 
 {% block footer %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,6 +1,16 @@
 {% extends "!layout.html" %}
-
 <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
+
+{% block extrahead %}
+       <!-- Early load javascript files -->
+       <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+       {%- for scriptfile in script_files %}
+         {{ js_tag(scriptfile) }}
+       {%- endfor %}
+       <script type="text/javascript" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/docversions.js', 1) }}"></script>
+{{ super() }}
+{% endblock %}
+
 {% block menu %}
 <div>
   <a style="color:#F05732" href="{{ theme_canonical_url }}{{ pagename }}.html">
@@ -9,6 +19,29 @@
   </a>
 </div>
 {{ super() }}
+{% endblock %}
+
+{% block sidebartitle %}
+            {% include "searchbox.html" %}
+            {% if theme_display_version %}
+              {%- set nav_version = version %}
+              {% if READTHEDOCS and current_version %}
+                {%- set nav_version = current_version %}
+              {% endif %}
+              {% if nav_version %}
+                <button onclick="versiontoggle()">{{ nav_version }} &#x25BC;</button>
+                <ul id="versionList" style="display: none;">
+                <script type="text/javascript">
+                    document.addEventListener("DOMContentLoaded", insert_version_links());
+                </script>
+                </ul>
+                <script type="text/javascript">
+                  function versiontoggle() {
+                    $("#versionList").toggle()
+                  };
+                </script>
+              {% endif %}
+            {% endif %}
 {% endblock %}
 
 {% block footer %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ except ImportError:
     warnings.warn('unable to load "torchvision" package')
 
 RELEASE = os.environ.get('RELEASE', False)
+VERSION = os.environ.get('VERSION', False)
 
 import pytorch_sphinx_theme
 
@@ -155,8 +156,12 @@ author = 'Torch Contributors'
 # built documents.
 #
 # The short X.Y version.
-# TODO: change to [:2] at v1.0
-version = 'master (' + torch.__version__ + ' )'
+
+if VERSION:
+    # For tagged builds, like v1.7.0 or v1.7.0rc1. Will show up in left navmenu
+    version = VERSION
+else:
+    version = 'master (' + torch.__version__ + ' )'
 # The full version, including alpha/beta/rc tags.
 # TODO: verify this works as expected
 release = 'master'


### PR DESCRIPTION
Enhancement to create a version pulldown rather than a link to a static list of `versions.html`

- The version is now passed to sphinx from the environment, so the post-processing to mangle the version is no longer needed
- The layout template has been changed
  - The javascript scripts are loaded in the header, this should be backported to the upstream [pytorch_sphinx_theme repo](https://github.com/pytorch/pytorch_sphinx_theme) since now the loading stanza appears twice on the page :(. I needed this to activate the new javascript function as the page loads.
  - A new snippet of javascript builds a `ul` list of versions on document loading (provides consistency across documentation versions)
    - The snippet will try to match the current document to the one from the other versions. If there is a match, switching versions will keep you at the same page. 
  - The version list is now below the search bar.

I could not get the page existence check to work asynchronously, so page loading time takes a hit. Is the UX improvement worth it? I was basing this off the [warning in the NumPy docs](https://numpy.org/doc/1.13/) when you view older documentation, [this](https://numpy.org/doc/1.13/reference/routines.random.html) is a page with no parallel in the latest version, so the message will pre-populate a search qeury (source code [here](https://github.com/numpy/doc/blob/master/_static/versionwarning.js_t)). maybe I missed something? In any case, the NumPy script only needs to check for the latest page, my adaptaion scans all the versions.

Help here would be welcome from people fluent in web front-end programming.