### PR TITLE
Add C++ coverage for Ubuntu cpu tests

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -84,7 +84,11 @@ CONFIG_TREE_DATA = [
         ("gcc", [
             ("9", [
                 ("3.8", [
-                    ("coverage", [XImportant(True)]),
+                    ("coverage", [
+                        (True, [
+                            ("shard_test", [XImportant(True)]),
+                        ]),
+                    ]),
                 ]),
             ]),
         ]),

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -84,6 +84,7 @@ CONFIG_TREE_DATA = [
         ("gcc", [
             ("9", [
                 ("3.8", [
+                    ("profile", [XImportant(True)]),
                     ("coverage", [XImportant(True)]),
                 ]),
             ]),
@@ -162,6 +163,7 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
 
         next_nodes = {
             "asan": AsanConfigNode,
+            "profile": ProfileConfigNode,
             "xla": XlaConfigNode,
             "vulkan": VulkanConfigNode,
             "parallel_tbb": ParallelTBBConfigNode,
@@ -206,6 +208,17 @@ class AsanConfigNode(TreeConfigNode):
 
     def init2(self, node_name):
         self.props["is_asan"] = node_name
+
+    def child_constructor(self):
+        return ExperimentalFeatureConfigNode
+
+
+class ProfileConfigNode(TreeConfigNode):
+    def modify_label(self, label):
+        return "Profile=" + str(label)
+
+    def init2(self, node_name):
+        self.props["profile"] = node_name
 
     def child_constructor(self):
         return ExperimentalFeatureConfigNode

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -84,7 +84,6 @@ CONFIG_TREE_DATA = [
         ("gcc", [
             ("9", [
                 ("3.8", [
-                    ("profile", [XImportant(True)]),
                     ("coverage", [XImportant(True)]),
                 ]),
             ]),
@@ -163,7 +162,6 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
 
         next_nodes = {
             "asan": AsanConfigNode,
-            "profile": ProfileConfigNode,
             "xla": XlaConfigNode,
             "vulkan": VulkanConfigNode,
             "parallel_tbb": ParallelTBBConfigNode,
@@ -208,17 +206,6 @@ class AsanConfigNode(TreeConfigNode):
 
     def init2(self, node_name):
         self.props["is_asan"] = node_name
-
-    def child_constructor(self):
-        return ExperimentalFeatureConfigNode
-
-
-class ProfileConfigNode(TreeConfigNode):
-    def modify_label(self, label):
-        return "Profile=" + str(label)
-
-    def init2(self, node_name):
-        self.props["profile"] = node_name
 
     def child_constructor(self):
         return ExperimentalFeatureConfigNode

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -272,6 +272,7 @@ def instantiate_configs():
         compiler_version = fc.find_prop("compiler_version")
         is_xla = fc.find_prop("is_xla") or False
         is_asan = fc.find_prop("is_asan") or False
+        profile = fc.find_prop("profile") or False
         is_onnx = fc.find_prop("is_onnx") or False
         is_pure_torch = fc.find_prop("is_pure_torch") or False
         is_vulkan = fc.find_prop("is_vulkan") or False
@@ -310,6 +311,10 @@ def instantiate_configs():
             parms_list.append("asan")
             python_version = fc.find_prop("pyver")
             parms_list[0] = fc.find_prop("abbreviated_pyver")
+
+        if profile:
+            parms_list_ignored_for_docker_image.append("profile")
+            python_version = fc.find_prop("pyver")
 
         if is_onnx:
             parms_list.append("onnx")

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -272,7 +272,7 @@ def instantiate_configs():
         compiler_version = fc.find_prop("compiler_version")
         is_xla = fc.find_prop("is_xla") or False
         is_asan = fc.find_prop("is_asan") or False
-        profile = fc.find_prop("profile") or False
+        is_coverage = fc.find_prop("is_coverage") or False
         is_onnx = fc.find_prop("is_onnx") or False
         is_pure_torch = fc.find_prop("is_pure_torch") or False
         is_vulkan = fc.find_prop("is_vulkan") or False
@@ -312,8 +312,8 @@ def instantiate_configs():
             python_version = fc.find_prop("pyver")
             parms_list[0] = fc.find_prop("abbreviated_pyver")
 
-        if profile:
-            parms_list_ignored_for_docker_image.append("profile")
+        if is_coverage:
+            parms_list_ignored_for_docker_image.append("coverage")
             python_version = fc.find_prop("pyver")
 
         if is_onnx:
@@ -330,7 +330,6 @@ def instantiate_configs():
         is_important = fc.find_prop("is_important") or False
         parallel_backend = fc.find_prop("parallel_backend") or None
         build_only = fc.find_prop("build_only") or False
-        is_coverage = fc.find_prop("is_coverage") or False
         shard_test = fc.find_prop("shard_test") or False
         # TODO: fix pure_torch python test packaging issue.
         if shard_test:
@@ -338,9 +337,6 @@ def instantiate_configs():
             restrict_phases.extend(["test1", "test2"])
         if build_only or is_pure_torch:
             restrict_phases = ["build"]
-        if is_coverage and restrict_phases is None:
-            restrict_phases = ["build", "coverage_test"]
-
 
         gpu_resource = None
         if cuda_version and cuda_version != "10":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,9 +655,15 @@ jobs:
           echo "Retrieving test reports"
           docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
-              echo "Retrieving coverage report"
+              echo "Retrieving Python coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              python3 -mpip install codecov
+              python3 -mcodecov
+          fi
+          if [[ ${BUILD_ENVIRONMENT} == *"profile"* ]]; then
+              echo "Retrieving C++ coverage report"
+              docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov
           fi
@@ -6875,6 +6881,19 @@ workflows:
             - pytorch_vulkan_linux_bionic_py3_6_clang9_build
           build_environment: "pytorch-vulkan-linux-bionic-py3.6-clang9-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9"
+          resource_class: large
+      - pytorch_linux_build:
+          name: pytorch_linux_bionic_py3_8_gcc9_profile_build
+          requires:
+            - "docker-pytorch-linux-bionic-py3.8-gcc9"
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-profile-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
+      - pytorch_linux_test:
+          name: pytorch_linux_bionic_py3_8_gcc9_profile_test
+          requires:
+            - pytorch_linux_bionic_py3_8_gcc9_profile_build
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-profile-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
           resource_class: large
       - pytorch_linux_build:
           name: pytorch_linux_bionic_py3_8_gcc9_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,10 +658,6 @@ jobs:
               echo "Retrieving Python coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
-              python3 -mpip install codecov
-              python3 -mcodecov
-          fi
-          if [[ ${BUILD_ENVIRONMENT} == *"profile"* ]]; then
               echo "Retrieving C++ coverage report"
               docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
@@ -6883,29 +6879,16 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9"
           resource_class: large
       - pytorch_linux_build:
-          name: pytorch_linux_bionic_py3_8_gcc9_profile_build
+          name: pytorch_linux_bionic_py3_8_gcc9_coverage_build
           requires:
             - "docker-pytorch-linux-bionic-py3.8-gcc9"
-          build_environment: "pytorch-linux-bionic-py3.8-gcc9-profile-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
-      - pytorch_linux_test:
-          name: pytorch_linux_bionic_py3_8_gcc9_profile_test
-          requires:
-            - pytorch_linux_bionic_py3_8_gcc9_profile_build
-          build_environment: "pytorch-linux-bionic-py3.8-gcc9-profile-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
-          resource_class: large
-      - pytorch_linux_build:
-          name: pytorch_linux_bionic_py3_8_gcc9_build
-          requires:
-            - "docker-pytorch-linux-bionic-py3.8-gcc9"
-          build_environment: "pytorch-linux-bionic-py3.8-gcc9-build"
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
       - pytorch_linux_test:
           name: pytorch_linux_bionic_py3_8_gcc9_coverage_test
           requires:
-            - pytorch_linux_bionic_py3_8_gcc9_build
-          build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage_test"
+            - pytorch_linux_bionic_py3_8_gcc9_coverage_build
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
           resource_class: large
       - pytorch_linux_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6885,10 +6885,17 @@ workflows:
           build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
       - pytorch_linux_test:
-          name: pytorch_linux_bionic_py3_8_gcc9_coverage_test
+          name: pytorch_linux_bionic_py3_8_gcc9_coverage_test1
           requires:
             - pytorch_linux_bionic_py3_8_gcc9_coverage_build
-          build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage-test"
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage-test1"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
+          resource_class: large
+      - pytorch_linux_test:
+          name: pytorch_linux_bionic_py3_8_gcc9_coverage_test2
+          requires:
+            - pytorch_linux_bionic_py3_8_gcc9_coverage_build
+          build_environment: "pytorch-linux-bionic-py3.8-gcc9-coverage-test2"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.8-gcc9"
           resource_class: large
       - pytorch_linux_build:

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -217,9 +217,15 @@ jobs:
           echo "Retrieving test reports"
           docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
-              echo "Retrieving coverage report"
+              echo "Retrieving Python coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
+              python3 -mpip install codecov
+              python3 -mcodecov
+          fi
+          if [[ ${BUILD_ENVIRONMENT} == *"profile"* ]]; then
+              echo "Retrieving C++ coverage report"
+              docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov
               python3 -mcodecov
           fi

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -220,10 +220,6 @@ jobs:
               echo "Retrieving Python coverage report"
               docker cp $id:/var/lib/jenkins/workspace/test/.coverage ./test
               docker cp $id:/var/lib/jenkins/workspace/test/coverage.xml ./test
-              python3 -mpip install codecov
-              python3 -mcodecov
-          fi
-          if [[ ${BUILD_ENVIRONMENT} == *"profile"* ]]; then
               echo "Retrieving C++ coverage report"
               docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
               python3 -mpip install codecov

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -42,6 +42,11 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   nvcc --version
 fi
 
+if [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
+  # enable build option in CMake
+  export USE_CPP_CODE_COVERAGE=ON
+fi
+
 # TODO: Don't run this...
 pip_install -r requirements.txt || true
 

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -42,7 +42,7 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   nvcc --version
 fi
 
-if [[ "$BUILD_ENVIRONMENT" == *profile* ]]; then
+if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
   # enable build option in CMake
   export USE_CPP_CODE_COVERAGE=ON
 fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -391,20 +391,29 @@ elif [[ "${BUILD_ENVIRONMENT}" == pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4
 else
   install_torchvision
   test_python_shard1
-  test_python_shard2
-  test_aten
-  test_vec256
-  test_libtorch
-  test_custom_script_ops
-  test_custom_backend
-  test_torch_function_benchmark
-  test_distributed
-  test_benchmarks
-  test_rpc
+  # test_python_shard2 # MAKING TESTING GO FASTER, for experiment only
+  # test_aten
+  # test_vec256
+  # test_libtorch
+  # test_custom_script_ops
+  # test_custom_backend
+  # test_torch_function_benchmark
+  # test_distributed
+  # test_benchmarks
+  # test_rpc
   if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
     pushd test
     echo "Generating XML coverage report"
     time python -mcoverage xml
+    popd
+  fi
+  if [[ "$BUILD_ENVIRONMENT" = *profile* ]]; then
+    pushd build
+    echo "Generating lcov coverage report for C++ sources"
+    lcov --version
+    export PATH=/usr/local/bin/lcov:$PATH
+    lcov --version
+    time lcov --capture --directory . --output-file coverage.info
     popd
   fi
 fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -391,28 +391,23 @@ elif [[ "${BUILD_ENVIRONMENT}" == pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc5.4
 else
   install_torchvision
   test_python_shard1
-  # test_python_shard2 # MAKING TESTING GO FASTER, for experiment only
-  # test_aten
-  # test_vec256
-  # test_libtorch
-  # test_custom_script_ops
-  # test_custom_backend
-  # test_torch_function_benchmark
-  # test_distributed
-  # test_benchmarks
-  # test_rpc
+  test_python_shard2
+  test_aten
+  test_vec256
+  test_libtorch
+  test_custom_script_ops
+  test_custom_backend
+  test_torch_function_benchmark
+  test_distributed
+  test_benchmarks
+  test_rpc
   if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
     pushd test
     echo "Generating XML coverage report"
     time python -mcoverage xml
     popd
-  fi
-  if [[ "$BUILD_ENVIRONMENT" = *profile* ]]; then
     pushd build
     echo "Generating lcov coverage report for C++ sources"
-    lcov --version
-    export PATH=/usr/local/bin/lcov:$PATH
-    lcov --version
     time lcov --capture --directory . --output-file coverage.info
     popd
   fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -401,14 +401,15 @@ else
   test_distributed
   test_benchmarks
   test_rpc
-  if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
-    pushd test
-    echo "Generating XML coverage report"
-    time python -mcoverage xml
-    popd
-    pushd build
-    echo "Generating lcov coverage report for C++ sources"
-    time lcov --capture --directory . --output-file coverage.info
-    popd
-  fi
+fi
+
+if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
+  pushd test
+  echo "Generating XML coverage report"
+  time python -mcoverage xml
+  popd
+  pushd build
+  echo "Generating lcov coverage report for C++ sources"
+  time lcov --capture --directory . --output-file coverage.info
+  popd
 fi


### PR DESCRIPTION
In order to enable C++ code coverage for tests, we need to build pytorch with the correct coverage flags. This PR should introduce a build that allows coverage tests to stem from a specific coverage build. 

This PR does the following:
1. Adds a new build to `*-coverage_*` build with the correct `--coverage` flag for C++ coverage
2. Calls `lcov` at the end of testing to capture C++ coverage results
3. Pushes C++ results along with Python results
4. Shards the coverage test to not take ~4hrs 

