### PR TITLE
[reland][quant] Add FixedQParamsFakeQuantize module (#45538)

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -29,11 +29,9 @@ from quantization.test_qat_module import TestQATModule  # noqa: F401
 from quantization.test_fusion_passes import TestFusionPasses  # noqa: F401
 
 # Module
-# TODO: merge the fake quant per tensor and per channel test cases
 # TODO: some of the tests are actually operator tests, e.g. test_forward_per_tensor, and
 # should be moved to test_quantized_op
-from quantization.test_workflow_module import TestFakeQuantizePerTensor  # noqa: F401
-from quantization.test_workflow_module import TestFakeQuantizePerChannel  # noqa: F401
+from quantization.test_workflow_module import TestFakeQuantize  # noqa: F401
 from quantization.test_workflow_module import TestObserver  # noqa: F401
 # TODO: merge with TestObserver
 # TODO: some tests belong to test_quantize.py, e.g. test_record_observer

--- a/torch/quantization/__init__.py
+++ b/torch/quantization/__init__.py
@@ -44,6 +44,12 @@ _all__ = [
     # Observers
     'ObserverBase', 'WeightObserver', 'observer', 'default_observer',
     'default_weight_observer',
+    # FakeQuantize (for qat)
+    'default_fake_quant', 'default_weight_fake_quant',
+    'default_symmetric_fixed_qparams_fake_quant',
+    'default_affine_fixed_qparams_fake_quant',
+    'default_per_channel_weight_fake_quant',
+    'default_histogram_fake_quant',
     # QConfig
     'QConfig', 'default_qconfig', 'default_dynamic_qconfig', 'float16_dynamic_qconfig',
     # QAT utilities

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -134,7 +134,8 @@ def assert_and_get_unique_device(module):
 
 def is_activation_post_process(module):
     return (isinstance(module, torch.quantization.ObserverBase) or
-            isinstance(module, torch.quantization.FakeQuantize))
+            isinstance(module, torch.quantization.FakeQuantize) or
+            isinstance(module, torch.quantization.FakeQuantizeBase))
 
 def is_submodule_of_fake_quant(name, module, named_modules):
     parent_name, _ = _parent_name(name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46657 [reland][quant] Add FixedQParamsFakeQuantize module (#45538)**

Summary:

This is used to simulate fake quantize operation for ops with fixed quantization parameters
e.g. hardsigmoid

Test Plan: Imported from OSS

Reviewed By: vkuzo

Differential Revision: [D24451406](https://our.internmc.facebook.com/intern/diff/D24451406)