### PR TITLE
Fix `type qualifiers ignored on return type` warning

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float_neon.h
@@ -259,12 +259,12 @@ public:
   // Only required because vec256_qint refers to this.
   // Once we specialize that implementation for ARM
   // this should be removed. TODO (kimishpatel)
-  const float operator[](int idx) const {
+  float operator[](int idx) const {
     __at_align32__ float tmp[size()];
     store(tmp);
     return tmp[idx];
-  };
-  const float operator[](int idx) {
+  }
+  float operator[](int idx) {
     __at_align32__ float tmp[size()];
     store(tmp);
     return tmp[idx];


### PR DESCRIPTION
This fixes following warning:
```
../aten/src/ATen/cpu/vec256/vec256_float_neon.h:262:3: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
  262 |   const float operator[](int idx) const {
      |   ^~~~~
```