### PR TITLE
[FX] Fix recursion depth issue on Graph deepcopy

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -850,7 +850,6 @@ class TestFX(JitTestCase):
             orig_users_equiv = set(val_map[u] for u in orig_users)
             new_users = set(new_node.users.keys())
             self.assertEqual(orig_users_equiv, new_users)
-            val_map[orig_node] = new_node
 
     @skipIfNoTorchVision
     def test_replace_uses(self):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -841,6 +841,17 @@ class TestFX(JitTestCase):
 
         copied_graph = copy.deepcopy(g)
 
+        val_map = {}
+        for orig_node, new_node in zip(g.nodes, copied_graph.nodes):
+            val_map[orig_node] = new_node
+
+        for orig_node, new_node in zip(g.nodes, copied_graph.nodes):
+            orig_users = set(orig_node.users.keys())
+            orig_users_equiv = set(val_map[u] for u in orig_users)
+            new_users = set(new_node.users.keys())
+            self.assertEqual(orig_users_equiv, new_users)
+            val_map[orig_node] = new_node
+
     @skipIfNoTorchVision
     def test_replace_uses(self):
         rn18 = resnet18()

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -137,6 +137,22 @@ class Graph:
             val_map[node] = self.node_copy(node, lambda n : val_map[n])
         return None
 
+    def __deepcopy__(self, memo=None) -> 'Graph':
+        """
+        Explicitly implement __deepcopy__ to prevent excessive recursion depth
+        from the default implementation. This uses graph_copy to copy the nodes
+        in an interative way, rather than recursive. It also populates the
+        memoization table to prevent unnecessary copies (e.g. references to
+        nodes or other parts of the Graph from a custom GraphModule implementation
+        """
+        g = Graph()
+        output_val = g.graph_copy(self, val_map=memo)
+        g.output(output_val)
+        hashable_attrs = ['_root', '_insert', '_len']
+        for attr in hashable_attrs:
+            memo[getattr(self, attr)] = getattr(g, attr)
+        return g
+
     def create_node(self, op: str, target: Target,
                     args: Optional[Tuple[Argument, ...]] = None,
                     kwargs: Optional[Dict[str, Argument]] = None,

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -141,16 +141,14 @@ class Graph:
         """
         Explicitly implement __deepcopy__ to prevent excessive recursion depth
         from the default implementation. This uses graph_copy to copy the nodes
-        in an interative way, rather than recursive. It also populates the
+        in an iterative way, rather than recursive. It also populates the
         memoization table to prevent unnecessary copies (e.g. references to
         nodes or other parts of the Graph from a custom GraphModule implementation
         """
+        memo = memo if memo else {}
         g = Graph()
         output_val = g.graph_copy(self, val_map=memo)
         g.output(output_val)
-        hashable_attrs = ['_root', '_insert', '_len']
-        for attr in hashable_attrs:
-            memo[getattr(self, attr)] = getattr(g, attr)
         return g
 
     def create_node(self, op: str, target: Target,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46692 [FX] Make wrapped functions traceable
* **#46669 [FX] Fix recursion depth issue on Graph deepcopy**

Make `Graph`'s deepcopy behavior iterative rather than recursive. This prevents stack overflow issues with very large `Graph`s

Differential Revision: [D24455120](https://our.internmc.facebook.com/intern/diff/D24455120)