### PR TITLE
[pytorch] Improve/fix heuristics for using mkldnn vs native conv

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -237,7 +237,11 @@ auto ConvParams::use_mkldnn(const at::Tensor& input, const at::Tensor& weight) c
     (input.options().backend() == at::Backend::CPU &&
      input.scalar_type() == kFloat && // only on CPU Float Tensors
      !transposed && // or transposed tensors
-     (groups > 1 || weight.size(2) > 3 || input.size(0) > 1
+     (is_strided() || is_dilated() || input.size(0) >= 16 ||
+      weight.size(-1) != 1 || weight.size(-2) != 1) &&
+     (groups > 1
+      || (weight.size(-1) > 3 && weight.size(-2) > 3)
+      || input.size(0) > 1
       || input.size(0)*input.size(1)*input.size(2)*input.size(3) > 20480)); // for some case, native is faster
 #endif
   return false;


### PR DESCRIPTION
Summary:
We've found a few heuristics for using/not using mkldnn that seem to generally
improve performance on 2d and 3d conv.

- 1x1 convolutions are basically batch matmuls, and mkldnn's implementation
  appears to usually be slower than using the native conv (which lowers to
  aten::mm, which in turn calls mkl gemm).

- 3d conv was often not using mkldnn even when it's beneficial, because the
  heuristic was checking the kernel depth rather than height/width.  mkldnn
  seems to be faster for (1, 7, 7) and (3, 7, 7) kernel sizes, which are
  allowed by the new heuristic.

Test Plan:
Bento notebooks showing before/after:
before: https://www.internalfb.com/intern/anp/view/?id=38089
after: https://www.internalfb.com/intern/anp/view/?id=380893

I need to figure out the right way to share notebooks, and also probably clean
this up into a simple text table for GitHub...

Also, I've run a conv fuzzer, and it generally supports these heuristics.  I'm
not sure how to best share the data since there's a lot of it (I tried about
50k parameter combinations).

For the 1x1 case, about 70% were faster with "native".  I played with
constructing a decision tree (using scikit-learn) and found that switching back
to MKL for batch size > 16 might be slightly better still, but I'm not sure
it's worth complicating the heuristic.

Reviewed By: jansel

Differential Revision: D24452071

Thanks to:
@jansel for finding these convolution shapes and showing that they were underperforming, and developing optimized implementations
@ngimel for realizing that the MKL heuristics were broken in the 3d conv case
@robieta for providing the conv fuzzing and benchmarking tools