### PR TITLE
[op-bench] modify import path of configs

### DIFF
--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -3,7 +3,7 @@ import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
 
-from . import configs
+from pt import configs
 
 """
 Microbenchmarks for Conv1d and ConvTranspose1d operators.

--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -1,7 +1,7 @@
 import operator_benchmark as op_bench
 import torch
 import numpy
-from . import configs
+from pt import configs
 
 """EmbeddingBag Operator Benchmark"""
 

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -3,7 +3,7 @@ import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
 
-from . import configs
+from pt import configs
 
 
 """Microbenchmarks for Linear operator."""

--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -3,7 +3,7 @@ import operator_benchmark as op_bench
 import torch
 import torch.nn.quantized as nnq
 
-from . import configs
+from pt import configs
 
 """
 Microbenchmarks for qConv operators.

--- a/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
@@ -3,7 +3,7 @@ import operator_benchmark as op_bench
 import torch
 import torch.nn.quantized as nnq
 import numpy
-from . import configs
+from pt import configs
 
 """
 Microbenchmarks for qEmbeddingBag operators.

--- a/benchmarks/operator_benchmark/pt/qlinear_test.py
+++ b/benchmarks/operator_benchmark/pt/qlinear_test.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.quantized as nnq
 import torch.nn.quantized.dynamic as nnqd
 
-from . import configs
+from pt import configs
 
 """
 Microbenchmarks for Quantized Linear operators.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46679 [op-bench] modify import path of configs**

Current way of import configs will have runtime error when a single benchmark is launched directly with buck. The diff fixed that issue.

Differential Revision: [D24459631](https://our.internmc.facebook.com/intern/diff/D24459631/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24459631/)!