### PR TITLE
Fix benchmark_caffe2

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -3,7 +3,7 @@ from caffe2.python import core
 from caffe2.proto import caffe2_pb2
 import benchmark_utils
 from collections import namedtuple
-from benchmark_test_generator import _generate_test
+from benchmark_test_generator import _register_test
 
 """Caffe2 performance microbenchmarks.
 
@@ -107,7 +107,7 @@ class Caffe2OperatorTestCase(object):
         self.test_config = test_config
         self.framework = "Caffe2"
 
-    def run_forward(self, num_runs, print_per_iter=False):
+    def run_forward(self, num_runs, print_per_iter=False, cubda_sync=False):
         """ Run the forward path of an operator in a loop
         """
         with core.DeviceScope(self.op_bench.dev):
@@ -185,12 +185,12 @@ def generate_c2_test_from_ops(ops_metadata, bench_op, tags):
 def generate_c2_test(configs, c2_bench_op):
     """ This function creates Caffe2 op test based on the given operator
     """
-    return _generate_test(configs, c2_bench_op, create_caffe2_op_test_case,
-                          run_backward=False)
+    return _register_test(configs, c2_bench_op, create_caffe2_op_test_case,
+                          False)
 
 
 def generate_c2_gradient_test(configs, c2_bench_op):
     """ This function creates Caffe2 op test based on the given operator
     """
-    return _generate_test(configs, c2_bench_op, create_caffe2_op_test_case,
-                          run_backward=True)
+    return _register_test(configs, c2_bench_op, create_caffe2_op_test_case,
+                          True)


### PR DESCRIPTION
Summary: benchmakr_caffe2 is broken, due to some refactoring which change from eager test generation to register only.

Test Plan:
`buck run caffe2/benchmarks/operator_benchmark/c2:add_test`

```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking Caffe2: add
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1021 08:07:06.350742 390665 init.h:137] Caffe2 GlobalInit should be run before any other API calls.
# Name: add_M8_N16_K32_dtypeint
# Input: M: 8, N: 16, K: 32, dtype: int
Forward Execution Time (us) : 652.748

# Benchmarking Caffe2: add
# Name: add_M16_N16_K64_dtypefloat
# Input: M: 16, N: 16, K: 64, dtype: float
Forward Execution Time (us) : 63.570

# Benchmarking Caffe2: add
# Name: add_M64_N64_K128_dtypeint
# Input: M: 64, N: 64, K: 128, dtype: in
```

Differential Revision: D24448374

