### PR TITLE
[quant] consolidate chooseQuantizationParams in the codebase

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -5,6 +5,7 @@
 #include <ATen/native/quantized/cpu/quant_utils.h>
 #include <ATen/quantized/QTensorImpl.h>
 #include <ATen/quantized/Quantizer.h>
+#include <fbgemm/QuantUtils.h>
 
 namespace at {
 namespace native {
@@ -220,14 +221,13 @@ std::tuple<double, int64_t> _choose_qparams_per_tensor(
     reduce_range = false;
   }
 
-  auto q_params = quant_utils::ChooseQuantizationParams(
+  auto q_params = fbgemm::ChooseQuantizationParams(
       /*min=*/x_min,
       /*max=*/x_max,
       /*qmin=*/0,
       /*qmax=*/255,
       /*preserve_sparsity=*/false,
-      /*force_scale_power_of_two=*/false,
-      /*reduce_range=*/reduce_range);
+      /*force_scale_power_of_two=*/false);
 
   return std::make_tuple(q_params.scale, q_params.zero_point);
 }

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -225,7 +225,7 @@ std::tuple<double, int64_t> _choose_qparams_per_tensor(
       /*min=*/x_min,
       /*max=*/x_max,
       /*qmin=*/0,
-      /*qmax=*/255,
+      /*qmax=*/reduce_range ? 127 : 255,
       /*preserve_sparsity=*/false,
       /*force_scale_power_of_two=*/false);
 

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/quantized/cpu/quant_utils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
+#include <fbgemm/QuantUtils.h>
 
 #include <torch/custom_class.h>
 
@@ -60,16 +61,20 @@ at::Tensor PackedLinearWeight::apply_dynamic_impl(at::Tensor input, bool reduce_
   static constexpr int precision = 8;
   static constexpr bool is_signed = false;
 
+  auto qmin = is_signed ? -(1 << (precision - 1)) : 0;
+  auto qmax =  is_signed ? ((1 << (precision - 1)) - 1) : (1 << precision) - 1;
+  if (reduce_range) {
+    qmin = qmin / 2;
+    qmax = qmax / 2;
+  }
   // Calculate scale and zero point for quantization of input tensor
-  auto q_params = quant_utils::ChooseQuantizationParams(
+  auto q_params = fbgemm::ChooseQuantizationParams(
       /*min=*/x_min,
       /*max=*/x_max,
-      /*qmin=*/is_signed ? -(1 << (precision - 1)) : 0,
-      /*qmax=*/
-      is_signed ? ((1 << (precision - 1)) - 1) : (1 << precision) - 1,
+      /*qmin=*/qmin,
+      /*qmax=*/qmax,
       /*preserve_sparsity=*/false,
-      /*force_scale_power_of_two=*/false,
-      /*reduce_range=*/reduce_range);
+      /*force_scale_power_of_two=*/false);
 
   q_params.precision = precision;
 
@@ -253,7 +258,7 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(at::Tensor input) {
     x_max = 0;
   }
 
-  auto q_params = quant_utils::ChooseQuantizationParams(
+  auto q_params = fbgemm::ChooseQuantizationParams(
       /*min=*/x_min,
       /*max=*/x_max,
       /*qmin=*/0,

--- a/aten/src/ATen/native/quantized/cpu/quant_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/quant_utils.h
@@ -35,6 +35,7 @@ bool CheckAndSaturate(T max_val, T* element) {
 }
 }
 using namespace std;
+/*
 // A structure to hold quantization parameters 'scale' and 'zero_point'.
 // The meaning of these values is as the constants in the quantization equation
 //
@@ -149,7 +150,7 @@ inline TensorQuantizationParams ChooseQuantizationParams(
   result.zero_point = nudged_zero_point;
   return result;
 }
-
+*/
 // This function helps to convert the Conv1D dimensions usable by the Conv2d op.
 constexpr int64_t kConv1dSqueezeDim = 0;
 static torch::List<int64_t> MakeArgForConv1d(const torch::List<int64_t>& arg,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46688 [quant] consolidate chooseQuantizationParams in the codebase**

Summary:
Ideally this shouldn't depend on USE_FBGEMM macro since this is just a util function that can be used even when fbgemm is disabled

Test Plan:
python test/test_quantization.py
CI tests

Reviewers:

Subscribers:

Tasks:

Tags: