### PR TITLE
[pt][static_runtime] Add option enable_out_variant

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -463,6 +463,9 @@ std::ostream& IValue::repr(
       return out << enum_holder->qualifiedClassName() << "." <<
           enum_holder->name();
     }
+    case IValue::Tag::Object:
+      out << "object(" << &v.toObjectRef();
+      return out << ")";
     default:
       TORCH_INTERNAL_ASSERT(false, "repr() not defined on: ", v.tagKind());
   }

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -130,6 +130,9 @@ c10::optional<Value*> tryInsertConstant(
   } else if (val.isEnum()) {
     n->ival_(attr::value, val);
     n->output()->setType(val.type());
+  } else if (val.isObject() && !val.toObjectRef().type()->is_module()) {
+    n->ival_(attr::value, val);
+    n->output()->setType(val.type());
   } else {
     n->destroy();
     return c10::nullopt;
@@ -191,6 +194,9 @@ c10::optional<IValue> toIValue(const Value* v) {
   } else if (type->cast<EnumType>()) {
     const auto& enum_val = node->ival(attr::value);
     return enum_val;
+  } else if (type->cast<ClassType>() && !type->is_module()) {
+    const auto& class_val = node->ival(attr::value);
+    return class_val;
   } else {
     std::stringstream ss;
     ss << "constant literal not supported for: " << type->str();

--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -126,6 +126,9 @@ bool ivaluesEqual(const IValue& a1, const IValue& a2) {
   if (a1.isEnum()) {
     return a1.toEnumHolder() == a2.toEnumHolder();
   }
+  if (a1.isObject()) {
+    return &a1.toObjectRef() == &a2.toObjectRef();
+  }
   TORCH_INTERNAL_ASSERT(false);
 }
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -151,7 +151,11 @@ StaticRuntime::StaticRuntime(
       for (Value* output : node->outputs()) {
         output_regs.push_back(value_to_reg[output]);
       }
-      nodes_.emplace_back(node, std::move(input_regs), std::move(output_regs));
+      nodes_.emplace_back(
+          node,
+          std::move(input_regs),
+          std::move(output_regs),
+          opts.enable_out_variant);
     }
   }
 }
@@ -332,7 +336,8 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
 ProcessedNode::ProcessedNode(
     Node* node,
     std::vector<size_t>&& input_regs,
-    std::vector<size_t>&& output_regs)
+    std::vector<size_t>&& output_regs,
+    bool enable_out_variants)
     : node_(node),
       input_regs_(std::move(input_regs)),
       output_regs_(std::move(output_regs)) {
@@ -343,7 +348,7 @@ ProcessedNode::ProcessedNode(
     TORCH_CHECK(op.hasOperation());
     op_ = op.getOperation(node);
   }
-  if (canRunOutOfPlace(node)) {
+  if (enable_out_variants && canRunOutOfPlace(node)) {
     fn_ = getOutOfPlaceOperation(node);
   }
 }

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -12,6 +12,7 @@ namespace jit {
 
 struct TORCH_API StaticRuntimeOptions {
   bool cleanup_activations{true};
+  bool enable_out_variant{true};
 };
 
 /// Static runime supports two execution modes.
@@ -157,7 +158,8 @@ class ProcessedNode {
   ProcessedNode(
       Node* n,
       std::vector<size_t>&& input_regs,
-      std::vector<size_t>&& output_regs);
+      std::vector<size_t>&& output_regs,
+      bool enable_out_variant);
   void run(std::vector<IValue>& reg) const;
 
   Node* get_node() const {


### PR DESCRIPTION
Summary:
- Add option enable_out_variant to Static Runtime
- Add gflags --pt_cleanup_activations and --pt_enable_out_variant to the benchmark script

Reviewed By: yinghai, houseroad

Differential Revision: D24438107

