### PR TITLE
[OpBench] fix jit mode run of operator benchmark for ops with parameters

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -119,6 +119,12 @@ def _build_test(configs, bench_op, OperatorTestCase, run_backward, op_name_funct
         op._set_backward_test(run_backward)
         op.init(**init_dict)
 
+        if not run_backward:
+            for _, attr in vars(op).items():
+                if isinstance(attr, torch.nn.Module):
+                    for param in attr.parameters():
+                        param.requires_grad = False
+
         input_name = None
 
         # _num_inputs_require_grads is used to track the number of tensors


### PR DESCRIPTION
Summary:
For the op with parameters (e.g. conv), the jit mode run currently will raise an error of
`RuntimeError: Cannot insert a Tensor that requires grad as a constant. Consider making it a parameter or input, or detaching the gradient`. After consulting https://www.fburl.com/vtkys6ug, decided to turn-off gradient for the parameters in the forward run. If we want op with parameters to work in backward with jit mode, probably needs to turn `TorchBenchmarkBase` into a sub-class of `nn.Module`

Test Plan: ./buck-out/gen/caffe2/benchmarks/operator_benchmark/pt/conv_test.par  --use_jit

Differential Revision: D24451206

