### PR TITLE
Add GradMode::enabled check to max_pool1d

### DIFF
--- a/aten/src/ATen/native/MaxPooling.cpp
+++ b/aten/src/ATen/native/MaxPooling.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/core/grad_mode.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/MaxPooling.h>
 #include <ATen/native/Pool.h>
@@ -98,10 +99,11 @@ Tensor max_pool1d(
     IntArrayRef dilation,
     bool ceil_mode) {
   if (self.is_quantized()) {
-    return at::quantized_max_pool1d(self, kernel_size, stride, padding,
-                                    dilation, ceil_mode);
+    return at::quantized_max_pool1d(
+        self, kernel_size, stride, padding, dilation, ceil_mode);
   }
-  if (self.requires_grad() || !self.device().is_cpu()) {
+  if ((self.requires_grad() && at::GradMode::is_enabled()) ||
+      !self.device().is_cpu()) {
     // Needs indices for grad and with_indices defines CUDA dispatch
     return std::get<0>(at::max_pool1d_with_indices(
         self, kernel_size, stride, padding, dilation, ceil_mode));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46767 Add GradMode::enabled check to max_pool1d**

## Benchmark
```
------------------------------------------------------------------------------------------ benchmark: 2 tests ------------------------------------------------------------------------------------------
Name (time in us)             Min                   Max                  Mean              StdDev                Median                IQR            Outliers         OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_grad_disabled       390.0155 (1.0)        533.4131 (1.0)        392.6161 (1.0)        8.5603 (1.0)        390.7457 (1.0)       0.3912 (1.0)        98;319  2,547.0171 (1.0)        2416           1
test_grad_enabled      3,116.7269 (7.99)     4,073.2883 (7.64)     3,178.0827 (8.09)     122.7487 (14.34)    3,142.2675 (8.04)     33.0228 (84.42)       10;22    314.6551 (0.12)        225           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


*snippet (using pytest benchmark module)*
```
import torch

torch.set_num_threads(1)
x = torch.randn(1000, 10, 36, requires_grad=True)

def test_grad_enabled(benchmark):
    benchmark(torch.max_pool1d, x, 2)

def test_grad_disabled(benchmark):
    torch.set_grad_enabled(False)
    benchmark(torch.max_pool1d, x, 2)
```

Differential Revision: [D24565126](https://our.internmc.facebook.com/intern/diff/D24565126)