### PR TITLE
Perform explicit cast

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1040,8 +1040,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       return;
     }
     auto newCapacity = sizes_;
-    newCapacity[0] = std::max<size_t>(
-        newDims[0], std::ceil(sizes_[0] * (growthPct + 100) / 100));
+    newCapacity[0] = std::max(
+        newDims[0], static_cast<int64_t>(std::ceil(sizes_[0] * (1 + growthPct / 100))));
     auto oldData = std::move(storage_.data_ptr());
     auto oldSize = numel_;
     auto oldDims = sizes_;


### PR DESCRIPTION
Summary:
`std::ceil` returns a `float` which is cast to `size_t` by the `max` operation.

We convert to `int64_t` to suppress the warning while matching the type of `newDims[0]`.

Since the types match, we don't need an explicit template type for `max`. This allows `max` to take `int64_t` as its values, matching the type of `newCapacity`.

Test Plan: Standard pre-commit test rig.

Reviewed By: malfet

Differential Revision: D24481684

