### PR TITLE
fix minor bug, message variable does not exist

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -855,7 +855,7 @@ def main():
 
     if options.continue_through_error and has_failed:
         for err in failure_messages:
-            print_to_stderr(message)
+            print_to_stderr(err)
         sys.exit(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
When run with `--continue-through-error`, the script ends with the following error:

```
Traceback (most recent call last):
  File "run_test.py", line 745, in <module>
    main()
  File "run_test.py", line 741, in main
    print_to_stderr(message)
NameError: name 'message' is not defined
make: *** [macos-compat] Error 1
```

This PR just changes `message` to `err`, which is the intended variable.
