### PR TITLE
[NVFuser]Benchmark minor update

### DIFF
--- a/benchmarks/tensorexpr/__main__.py
+++ b/benchmarks/tensorexpr/__main__.py
@@ -133,6 +133,7 @@ Works only with Python3.\n A few examples:
     elif args.cuda_fuser == "nvf":
         import torch
         torch._C._jit_set_profiling_executor(True)
+        torch._C._jit_set_texpr_fuser_enabled(False)
         torch._C._jit_set_nvfuser_enabled(True)
         torch._C._jit_set_profiling_mode(True)
     else :

--- a/benchmarks/tensorexpr/elementwise.py
+++ b/benchmarks/tensorexpr/elementwise.py
@@ -219,7 +219,7 @@ class DynamicSimpleElementBench(benchmark.DynamicShape, SimpleElementBench):
 
     @classmethod
     def module(cls):
-        return "dynamicsimple_element"
+        return "simple_dynamic_element"
 
     def instantiate_input(self):
         N, = self.rand_shape([self.N])

--- a/benchmarks/tensorexpr/elementwise.py
+++ b/benchmarks/tensorexpr/elementwise.py
@@ -219,7 +219,7 @@ class DynamicSimpleElementBench(benchmark.DynamicShape, SimpleElementBench):
 
     @classmethod
     def module(cls):
-        return "dynamic_simple_element"
+        return "dynamicsimple_element"
 
     def instantiate_input(self):
         N, = self.rand_shape([self.N])

--- a/benchmarks/tensorexpr/reduction.py
+++ b/benchmarks/tensorexpr/reduction.py
@@ -175,7 +175,7 @@ class DynamicReduce2DBench(benchmark.DynamicShape, Reduce2DBench):
 
     @staticmethod
     def module():
-        return "dynamic_reduce2d"
+        return "dynamicreduce2d"
 
 
 class DynamicReduce2DInnerBench(DynamicReduce2DBench):
@@ -184,7 +184,7 @@ class DynamicReduce2DInnerBench(DynamicReduce2DBench):
 
     @staticmethod
     def module():
-        return "dynamic_reduce2d_inner"
+        return "reduce2d_dynamic_inner"
 
 
 class DynamicReduce2DOuterBench(DynamicReduce2DBench):
@@ -193,7 +193,7 @@ class DynamicReduce2DOuterBench(DynamicReduce2DBench):
 
     @staticmethod
     def module():
-        return "dynamic_reduce2d_outer"
+        return "reduce2d_dynamic_outer"
 
 benchmark.register_benchmark_class(DynamicReduce2DInnerBench)
 benchmark.register_benchmark_class(DynamicReduce2DOuterBench)

--- a/benchmarks/tensorexpr/rnn_eltwise.py
+++ b/benchmarks/tensorexpr/rnn_eltwise.py
@@ -43,7 +43,11 @@ class RNNEltwise(benchmark.Benchmark):
         hy = outgate * torch.tanh(cy)
 
         return hy, cy
-
+    
+    @staticmethod
+    def input_iterable() :
+        return True
+    
     def config(self):
         return [self.b, self.hs]
 

--- a/benchmarks/tensorexpr/rnn_eltwise.py
+++ b/benchmarks/tensorexpr/rnn_eltwise.py
@@ -43,11 +43,7 @@ class RNNEltwise(benchmark.Benchmark):
         hy = outgate * torch.tanh(cy)
 
         return hy, cy
-    
-    @staticmethod
-    def input_iterable() :
-        return True
-    
+
     def config(self):
         return [self.b, self.hs]
 


### PR DESCRIPTION
This is a tiny PR for two minor fixes:

1. Added `torch._C._jit_set_texpr_fuser_enabled(False)` to enable shape inference on nv fuser runs.
2. Renamed dynamic benchmark module names to avoid multiple matching. i.e. `simple_element` with `dynamic_simple_element`. I guess it'd be much easier if the pattern matching was based on `startswith`. Would be happy to update that if agreed.