### PR TITLE
Add inputsSize to Python IR, like outputsSize

### DIFF
--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -493,6 +493,7 @@ void initPythonIRBindings(PyObject* module_) {
           })
       .def("sourceRange", [](Node& n) { return n.sourceRange().str(); })
       .def("hasMultipleOutputs", [](Node& n) { return n.outputs().size() > 1; })
+      .def("inputsSize", [](Node& n) { return n.inputs().size(); })
       .def("outputsSize", [](Node& n) { return n.outputs().size(); })
       .NS(kind)
       .def("inputsAt", [](Node& n, size_t i) { return n.inputs().at(i); })


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46781 Add a command-line flag for overriding pthreadpool size
* #46780 PyTorch NNAPI integration prototype
* **#46779 Add inputsSize to Python IR, like outputsSize**

Test Plan:
Used it in some notebooks.

Differential Revision: [D24574041](https://our.internmc.facebook.com/intern/diff/D24574041)