### PR TITLE
[JIT] Add support for `named_parameters` in TorchScript

### DIFF
--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -190,6 +190,10 @@ struct VISIBILITY_HIDDEN ModuleValue : public SugaredValue {
       const SourceRange& loc,
       Function& m);
 
+  std::shared_ptr<SugaredDict> getSugaredNamedParameterDict(
+      const SourceRange& loc,
+      Function& m);
+
   void setAttr(
       const SourceRange& loc,
       Function& m,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46784 [JIT] Add support for `named_parameters` in TorchScript**

**Summary**
This commit adds support for `named_parameters`. The implementation is
similar to `named_modules`; accessing the `named_parameters` attribute
of a module creates a `ModuleDictMethod` that, when called, returns a
statically built iterable containing the names and parameters of all
parameters in the module hierarchy as SugaredValues in depth-first order.

`named_parameters` recurses into submodules by default, but this
behaviour can be disabled in eager mode by passing `recurse=False`.
Given that `named_parameters` and similar methods are statically
unrolled in a sense, it is not possible to support this extra argument
unless the value is statically determinable at compile time.
Consequently, the implementation in this commit recurses into submodules
by default and produces an error when any arguments are passed.

**Test Plan**
This commit adds two unit tests to test this method, one for a standard
`Module` and another for `ModuleDict`.

**Fixes**
This commit closes #46549.

Differential Revision: [D24512618](https://our.internmc.facebook.com/intern/diff/D24512618)