### PR TITLE
[MLF] Allow for computing prune quantile thresholds on absolute value of indicators in distributed-inference-compatible embedding LUT pruning

### DIFF
--- a/caffe2/operators/self_binning_histogram_op.cc
+++ b/caffe2/operators/self_binning_histogram_op.cc
@@ -35,7 +35,11 @@ OPERATOR_SCHEMA(SelfBinningHistogram)
         "logspace_start",
         "A float that's used as the starting point for logarithmic spacing. "
         "Since logarithmic spacing cannot contain <=0 values this value will "
-        "be used to represent all such values.");
+        "be used to represent all such values.")
+    .Arg(
+        "abs",
+        "Apply abs() on every input value."
+    );
 
 SHOULD_NOT_DO_GRADIENT(SelfBinningHistogram);
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Now `SelfBinningHistogram` can calculate the binning histogram using the absolute values from the given an array of values.

Test Plan:
Passed unit tests in self_binning_histogram_test.

Differential Revision: D24494097