### PR TITLE
Add missing .to_sparse(ndim) gradient, fixes #46720

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1082,6 +1082,9 @@
 - name: to_sparse(Tensor self) -> Tensor
   self: grad.to_dense()
 
+- name: to_sparse.sparse_dim(Tensor self, int sparse_dim) -> Tensor
+  self: grad.to_dense()
+
 - name: to_mkldnn(Tensor self) -> Tensor
   self: to_mkldnn_backward(grad, self)
 


### PR DESCRIPTION
Fixes #46720

Not sure what the best way to test this is. I did run the tests with:

https://github.com/pytorch/pytorch/blob/c31ced42469cd5f0b4e758f5484be40a9515bc38/test/test_autograd.py#L5047-L5048

changed to `.to_sparse(1)`, which failed before but passes now.
