### PR TITLE
fix: Fixed typing of bool in _ConvNd

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -57,7 +57,7 @@ class _ConvNd(Module):
     groups: int
     padding_mode: str
     weight: Tensor
-    bias: bool
+    bias: Optional[Tensor]
 
     def __init__(self,
                  in_channels: int,

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -57,7 +57,7 @@ class _ConvNd(Module):
     groups: int
     padding_mode: str
     weight: Tensor
-    bias: Optional[Tensor]
+    bias: bool
 
     def __init__(self,
                  in_channels: int,
@@ -69,7 +69,7 @@ class _ConvNd(Module):
                  transposed: bool,
                  output_padding: _size_1_t,
                  groups: int,
-                 bias: Optional[Tensor],
+                 bias: bool,
                  padding_mode: str) -> None:
         super(_ConvNd, self).__init__()
         if in_channels % groups != 0:


### PR DESCRIPTION
Hello there :wave: 

I do believe there is some typo in the typing of the `bool` argument of `_ConvNd`constructor.
The typing of the attribute is correct, but the constructor argument, while being named the same way, is not the value that will be assigned to `self.bias`. 

This PR simply corrects that.

Any feedback is welcome!
