### PR TITLE
Optimize implementation of torch.pow

### DIFF
--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -32,13 +32,11 @@ Tensor& pow_out(Tensor& result, const Tensor& base, Scalar exp) {
            "result type ", common_dtype, " can't be cast to the desired output type ",
            result.scalar_type());
 
-  auto exponent = (exp.isComplex()) ? exp.toComplexDouble() : exp.toDouble();
-
-  if (exponent == 0.0) {
+  if (exp.equal(0.0)) {
     resize_output(result, base.sizes());
     result.fill_(1);
     namedinference::propagate_names(result, base);
-  } else if (exponent == 1.0) {
+  } else if (exp.equal(1.0)) {
     resize_output(result, base.sizes());
     result.copy_(base);
     namedinference::propagate_names(result, base);
@@ -50,10 +48,11 @@ Tensor& pow_out(Tensor& result, const Tensor& base, Scalar exp) {
 }
 
 Tensor& pow_out(Tensor& result, Scalar base, const Tensor& exp) {
-
-  auto exponent = (base.isComplex()) ? base.toComplexDouble() : base.toDouble();
-
-  if (exponent == 1.0) {
+  if (base.isComplex() && base.toComplexDouble() == 1.0) {
+    resize_output(result, exp.sizes());
+    result.fill_(1);
+    namedinference::propagate_names(result, exp);
+  } else if (!base.isComplex() && base.toDouble() == 1.0) {
     resize_output(result, exp.sizes());
     result.fill_(1);
     namedinference::propagate_names(result, exp);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5202,16 +5202,6 @@
     CPU: legacy::cpu::_th_renorm_
     CUDA: legacy::cuda::_th_renorm_
 
-- func: pow_.Scalar(Tensor(a!) self, Scalar exponent) -> Tensor(a!)
-  variants: method
-  dispatch:
-    CPU, CUDA: pow_
-
-- func: pow_.Tensor(Tensor(a!) self, Tensor exponent) -> Tensor(a!)
-  variants: method
-  dispatch:
-    CPU, CUDA: pow_
-
 - func: lerp_.Scalar(Tensor(a!) self, Tensor end, Scalar weight) -> Tensor(a!)
   variants: method
   dispatch:
@@ -6446,6 +6436,18 @@
   dispatch:
     CPU, CUDA: pow
     SparseCPU, SparseCUDA: pow_sparse_scalar
+
+- func: pow_.Scalar(Tensor(a!) self, Scalar exponent) -> Tensor(a!)
+  use_c10_dispatcher: full
+  variants: method
+  dispatch:
+    CPU, CUDA: pow_
+
+- func: pow_.Tensor(Tensor(a!) self, Tensor exponent) -> Tensor(a!)
+  use_c10_dispatcher: full
+  variants: method
+  dispatch:
+    CPU, CUDA: pow_
 
 - func: float_power.Tensor_Tensor_out(Tensor self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
   use_c10_dispatcher: hacky_wrapper_for_legacy_signatures


### PR DESCRIPTION
- Related with #44937 
- Use `resize_output` instead of `resize_as`
- Tuning the `native_functions.yaml`, move the inplace variant `pow_` next to the other `pow` entries