### PR TITLE
vmap fallback: gracefully error out when vmap over dim of size 0

### DIFF
--- a/aten/src/ATen/BatchedFallback.cpp
+++ b/aten/src/ATen/BatchedFallback.cpp
@@ -161,6 +161,11 @@ void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, torch::j
       batch_sizes.end(),
       1,
       std::multiplies<int64_t>());
+  // Without a shape-checking API, we're unable to compute the correct shape of
+  // the output so we just error out.
+  TORCH_CHECK(num_batches > 0,
+      "Batching rule not implemented for ", schema.operator_name(), ". ",
+      "The fallback path does not support vmap over dims of size 0.");
 
   // Strategy: For each batch, we are going to push slices (where applicable)
   // of the arguments onto `stack`, and call `op`.
@@ -293,6 +298,11 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
       batch_sizes.end(),
       1,
       std::multiplies<int64_t>());
+  // Without a shape-checking API, we're unable to compute the correct shape of
+  // the output so we just error out.
+  TORCH_CHECK(num_batches > 0,
+      "Batching rule not implemented for ", schema.operator_name(), ". ",
+      "The fallback path does not support vmap over dims of size 0.");
 
   // Strategy: For each batch, we are going to push slices (where applicable)
   // of the arguments onto `stack`, call `op`, and store the result in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46846 vmap fallback: gracefully error out when vmap over dim of size 0**

Previously, this would crash with a floating point error. If the user vmaps
over a dimension of size 0, ideally we would return a tensor with a
batch dim of size 0 and the correct output shape. However, this isn't
possible without a shape-checking API. This PR changes the vmap fallback
to error out gracefully if it sees vmap occuring over a dimension of
size 0.

If we want to support vmapping over dimension of size 0 for a specific
op, then the guidance is to implement a batching rule for that op that
handles 0-sized dims.

Test Plan:
- new test

Differential Revision: [D24539315](https://our.internmc.facebook.com/intern/diff/D24539315)