### PR TITLE
Upgrading lcov install to install v1.15 to be compatible with GCC9

### DIFF
--- a/.circleci/docker/common/install_lcov.sh
+++ b/.circleci/docker/common/install_lcov.sh
@@ -2,5 +2,7 @@
 
 set -ex
 
-sudo apt-get -qq update
-sudo apt-get -qq install lcov
+git clone --branch v1.15 https://github.com/linux-test-project/lcov.git
+pushd lcov
+sudo make install   # will be installed in /usr/local/bin/lcov
+popd


### PR DESCRIPTION
According to [this issue](https://github.com/linux-test-project/lcov/issues/58), LCOV 1.14 and below are not compatible with GCC9 when gathering coverage. 

Instead of installing `lcov` with `apt-get`, which installs version 1.13, this PR would install v1.15 from source onto the ubuntu Docker images.