### PR TITLE
[ROCm] fix bug in miopen findAlgorithm.

### DIFF
--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -468,7 +468,6 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
 
   if (args.params.deterministic && !benchmark) {
     *algo = search::DEFAULT_ALGO;
-    return;
   }
 
   if (cache.find(args.params, algo)) {


### PR DESCRIPTION
findAlgorithm should return if and only if a suitable algorithm is found.
The default algorithm is not guaranteed to have been cached.