### PR TITLE
remove event not ready assertion from TestCuda.test_copy_non_blocking

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -492,7 +492,6 @@ class TestCuda(TestCase):
             event = torch.cuda.Event()
             a.copy_(b, non_blocking=True)
             event.record()
-            self.assertFalse(event.query())
             event.synchronize()
             self.assertEqual(a, b)
 


### PR DESCRIPTION
It is incorrect to assume that a newly recorded event will immediately query as False.
This test is flaky on ROCm due to this incorrect assumption.