### PR TITLE
Update Torchvision commit to release/0.8.0

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -66,7 +66,7 @@ function get_bazel() {
   chmod +x tools/bazel
 }
 
-TORCHVISION_COMMIT=e70c91a9ff9b8a20e05c133aec6ec3ed538c32fb
+TORCHVISION_COMMIT=883f1fb01a8ba0e1b1cdc16c16f2e6e0ef87e3bd
 
 function install_torchvision() {
   # Check out torch/vision at Jun 11 2020 commit


### PR DESCRIPTION
Update Torchvision commit to the [release/0.8.0 hash](https://github.com/pytorch/vision/commits/release/0.8.0?before=6455a4c68d4d1bd2a78962527104aab8d286e19f+245&branch=release%2F0.8.0) for the PyTorch 1.7.0 release