### PR TITLE
Pin destination memory for cuda_tensor.to("cpu", non_blocking=True)

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -29,7 +29,8 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
     return self;
   }
 
-  bool pin_out = (non_blocking && self.is_cuda() && options.device().is_cpu());
+  bool pin_out = (non_blocking && self.is_cuda() && options.device().is_cpu() &&
+                  (options.layout() == c10::kStrided));
 
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -29,6 +29,10 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
     return self;
   }
 
+  if (non_blocking && self.is_cuda() && options.device().is_cpu()) {
+    options.pinned_memory(true);
+  }
+
   if (memory_format == MemoryFormat::Preserve) {
     if (self.is_non_overlapping_and_dense()) {
       // Copy all strides

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -525,12 +525,12 @@ class TestCuda(TestCase):
             src = torch.randn(1000000, device="cuda" if dst == "cpu" else "cpu")
             _test_to_non_blocking(src, try_non_blocking, dst)
 
-        # Ensures device to host copy chooses "safe" behavior (blocking copy to non-pinned memory) by default.
+    def test_to_cpu_blocking_by_default(self):
         src = torch.randn(1000000, device="cuda")
         torch.cuda.synchronize()
         torch.cuda._sleep(int(100 * get_cycles_per_ms()))
         dst = src.to(device="cpu")
-        self.assertEqual(stream.query(), True)
+        self.assertEqual(torch.cuda.current_stream().query(), True)
         self.assertEqual(src, dst)
         self.assertFalse(dst.is_pinned())
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -505,7 +505,6 @@ class TestCuda(TestCase):
         y = torch.ones(10000000, dtype=torch.uint8).cuda()
         _test_copy_non_blocking(x, y)
 
-    @skipIfRocm
     def test_to_non_blocking(self):
         stream = torch.cuda.current_stream()
 
@@ -522,7 +521,9 @@ class TestCuda(TestCase):
 
         for dst, try_non_blocking in product(("cuda", "cpu"), (True, False)):
             # Creates source on the opposite device from destination.
-            src = torch.randn(1000000, device="cuda" if dst == "cpu" else "cpu")
+            src = torch.randn(1000000,
+                              device="cuda" if dst == "cpu" else "cpu",
+                              pin_memory=True if dst == "cuda" else False)
             _test_to_non_blocking(src, try_non_blocking, dst)
 
     def test_to_cpu_blocking_by_default(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -505,6 +505,7 @@ class TestCuda(TestCase):
         y = torch.ones(10000000, dtype=torch.uint8).cuda()
         _test_copy_non_blocking(x, y)
 
+    @skipIfRocm
     def test_to_non_blocking(self):
         def _test_to_non_blocking(a, non_blocking, dst):
             stream = torch.cuda.current_stream()


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/39694.

[`torch.cuda._sleep(int(100 * get_cycles_per_ms()))`](https://github.com/pytorch/pytorch/pull/46878/files#diff-893b1eea27352f336f4cd832919e48d721e4e90186e63400b8596db6b82e7450R511-R513) in the test helps avoid flakiness noted by @ngimel (https://github.com/pytorch/pytorch/pull/35144#issuecomment-602103631).