### PR TITLE
[release/1.7] .circleci: Reintroduce torchvision to docs builds

### DIFF
--- a/.circleci/scripts/python_doc_push_script.sh
+++ b/.circleci/scripts/python_doc_push_script.sh
@@ -52,7 +52,10 @@ rm -rf pytorch || true
 
 # Get all the documentation sources, put them in one place
 pushd "$pt_checkout"
+checkout_install_torchvision
 pushd docs
+rm -rf source/torchvision
+cp -a ../vision/docs/source source/torchvision
 
 # Build the docs
 pip -q install -r requirements.txt

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -66,7 +66,7 @@ function get_bazel() {
   chmod +x tools/bazel
 }
 
-TORCHVISION_COMMIT=c2e8a00885e68ae1200eb6440f540e181d9125de
+TORCHVISION_COMMIT=v0.8.0-rc4
 
 function install_torchvision() {
   # Check out torch/vision at Jun 11 2020 commit

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?= -j auto -WT --keep-going
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SPHINXPROJ    ?= PyTorch
 SOURCEDIR     ?= source


### PR DESCRIPTION
We should be building torchvision docs to go along with our docs, a minor revert of https://github.com/pytorch/pytorch/pull/41335

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

