### PR TITLE
[FX] Fix handling of `inf` and `nan` literals

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -8,7 +8,7 @@ import keyword
 import re
 
 def _shadows_builtin_name(name: str) -> bool:
-    return name in builtins.__dict__ or name in keyword.kwlist
+    return name in builtins.__dict__ or name in keyword.kwlist or name in {'inf', 'nan'}
 
 def _is_magic(x: str) -> bool:
     return x.startswith('__') and x.endswith('__')
@@ -380,7 +380,11 @@ class Graph:
                 continue
             raise NotImplementedError(f'node: {node.op} {node.target}')
 
-        import_block = '\n'.join(f'import {name}' for name in sorted(modules_used))
+        # repr() for inf and nan floating point values aren't parseable by
+        # python as literals. Explicitly import the names from the `math` module.
+        import_strs = ['from math import inf, nan']
+        import_strs.extend(f'import {name}' for name in sorted(modules_used))
+        import_block = '\n'.join(import_strs)
 
         code = ''.join(body)
         code = '\n'.join('    ' + line for line in code.split('\n')) + '\n'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46894 [FX] Fix handling of `inf` and `nan` literals**

Closes https://github.com/pytorch/pytorch/issues/46748

`repr` for `inf` and `nan` are not something that Python can parse directly as a literal. Instead, import `inf` and `nan` from the `math` module. Also check that these names are not used as variable names

Differential Revision: [D24555136](https://our.internmc.facebook.com/intern/diff/D24555136)