### PR TITLE
[pt][static_runtime] Memory model

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -17,7 +17,7 @@ class DeepAndWide(Module):
   def forward(self: __torch__.DeepAndWide,
     ad_emb_packed: Tensor,
     user_emb: Tensor,
-    wide: Tensor) -> Tensor:
+    wide: Tensor) -> Tuple[Tensor]:
     _0 = self._fc_b
     _1 = self._fc_w
     _2 = self._sigma
@@ -29,7 +29,7 @@ class DeepAndWide(Module):
     dp = torch.flatten(dp_unflatten, 1, -1)
     input = torch.cat([dp, wide_preproc], 1)
     fc1 = torch.addmm(_0, input, torch.t(_1), beta=1, alpha=1)
-    return torch.sigmoid(fc1)
+    return (torch.sigmoid(fc1),)
 )JIT";
 
 const std::string trivial_model_1 = R"JIT(

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1,6 +1,6 @@
+#include "deep_wide_pt.h"
 #include <gtest/gtest.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
-#include "deep_wide_pt.h"
 
 TEST(StaticRuntime, TrivialModel) {
   torch::jit::Module mod = getTrivialScriptModel();
@@ -20,6 +20,23 @@ TEST(StaticRuntime, TrivialModel) {
   EXPECT_TRUE(output_1.equal(output_2));
 }
 
+static at::Tensor getTensor(const at::IValue &ival) {
+  if (ival.isTensor()) {
+    return ival.toTensor();
+  } else if (ival.isTensorList()) {
+    auto tensor_vec = ival.toTensorVector();
+    TORCH_CHECK(tensor_vec.size() == 1);
+    return tensor_vec[0];
+  } else if (ival.isTuple()) {
+    auto tuple = ival.toTuple();
+    auto ivalue_vec = tuple->elements();
+    TORCH_CHECK(ivalue_vec.size() == 1);
+    return ivalue_vec[0].toTensor();
+  } else {
+    CAFFE_THROW("Unknown input IValue");
+  }
+}
+
 TEST(StaticRuntime, DeepWide) {
   const int embedding_size = 32;
   const int num_features = 50;
@@ -35,7 +52,7 @@ TEST(StaticRuntime, DeepWide) {
 
       // run jit graph executor
       std::vector<at::IValue> inputs({ad_emb_packed, user_emb, wide});
-      at::Tensor output_1 = mod.forward(inputs).toTensor();
+      auto output_1 = getTensor(mod.forward(inputs));
 
       // run static runtime
       std::vector<at::Tensor> input_tensors({ad_emb_packed, user_emb, wide});
@@ -59,10 +76,10 @@ TEST(StaticRuntime, KWargsAPI_1) {
 
       // run jit graph executor
       std::vector<at::IValue> inputs({ad_emb_packed, user_emb, wide});
-      at::Tensor output_1 = module.forward(inputs).toTensor();
+      at::Tensor output_1 = getTensor(module.forward(inputs));
 
       // run static runtime
-      at::Tensor output_2 = runtime.run(inputs, {}).toTensor();
+      at::Tensor output_2 = getTensor(runtime.run(inputs, {}));
       EXPECT_TRUE(output_1.equal(output_2));
     }
   }
@@ -83,7 +100,7 @@ TEST(StaticRuntime, KWargsAPI_2) {
 
       // run jit graph executor
       std::vector<at::IValue> args({ad_emb_packed, user_emb, wide});
-      at::Tensor output_1 = module.forward(args).toTensor();
+      at::Tensor output_1 = getTensor(module.forward(args));
 
       std::unordered_map<std::string, c10::IValue> kwargs(
           {{"ad_emb_packed", ad_emb_packed},
@@ -91,8 +108,42 @@ TEST(StaticRuntime, KWargsAPI_2) {
            {"wide", wide}});
 
       // run static runtime
-      at::Tensor output_2 = runtime.run({}, kwargs).toTensor();
+      at::Tensor output_2 = getTensor(runtime.run({}, kwargs));
       EXPECT_TRUE(output_1.equal(output_2));
+    }
+  }
+}
+
+TEST(StaticRuntime, CleanUpMemory) {
+  const int embedding_size = 32;
+  const int num_features = 50;
+  torch::jit::Module mod = getDeepAndWideSciptModel();
+  auto g = torch::jit::PrepareForStaticRuntime(mod);
+
+  for (auto cleanup_memory : {true, false}) {
+    for (auto enable_out_variant : {true, false}) {
+      VLOG(1) << "cleanup_memory: " << cleanup_memory
+              << ", enable_out_variant: " << enable_out_variant;
+      torch::jit::StaticRuntimeOptions opts{cleanup_memory, enable_out_variant};
+      torch::jit::StaticRuntime runtime(g, opts);
+
+      for (int batch_size : {1, 8, 32}) {
+        for (int i = 0; i < 2; ++i) {
+          auto ad_emb_packed = torch::randn({batch_size, 1, embedding_size});
+          auto user_emb = torch::randn({batch_size, 1, embedding_size});
+          auto wide = torch::randn({batch_size, num_features});
+
+          // run jit graph executor
+          std::vector<at::IValue> inputs({ad_emb_packed, user_emb, wide});
+          auto output_1 = getTensor(mod.forward(inputs));
+
+          // run static runtime
+          std::vector<at::Tensor> input_tensors(
+              {ad_emb_packed, user_emb, wide});
+          at::Tensor output_2 = runtime.run(input_tensors)[0];
+          EXPECT_TRUE(output_1.equal(output_2));
+        }
+      }
     }
   }
 }

--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -128,8 +128,10 @@ class TestStaticRuntime(TestCase):
         attention_a = StaticRuntime(attention)
         o_test = attention_a(src, src, src, src_mask)
         o_test_kw = attention_a(src, src, value=src, mask=src_mask)
+
         for a, b in zip(o_ref, o_test):
             torch.testing.assert_allclose(a, b)
+
         for a, b in zip(o_ref, o_test_kw):
             torch.testing.assert_allclose(a, b)
 
@@ -150,9 +152,9 @@ class TestStaticRuntime(TestCase):
         attention = torch.jit.script(attention)
         attention_a = StaticRuntime(attention)
 
-        attention_a.benchmark([src, src, src, src_mask], {}, 10, 10)
+        attention_a.benchmark([src, src, src, src_mask], {}, 2, 2)
         metrics = attention_a.benchmark_individual_ops(
-            [src, src, src, src_mask], {}, 10, 10
+            [src, src, src, src_mask], {}, 2, 2
         )
 
     def test_mlp(self):

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -11,7 +11,7 @@
 /** \brief Freeze Module, i.e., Assume all atrributes are constants.
  *
  * Freezing module is a functionality that allows the JIT to internalize
- * imutable attributes. Combined with inlinig, the module is aggressively
+ * immutable attributes. Combined with inlining, the module is aggressively
  * optimized and significant overhead is optimized away. The freezeModule API
  * produces a cloned frozen module.
  */

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -27,6 +27,30 @@ void CheckGraphEligibility(const std::shared_ptr<torch::jit::Graph>& graph) {
       throw std::runtime_error("Cannot accelerate unfrozen graphs");
     }
   }
+  // check output types
+  // Static Runtime supports output types include None, Tensor and List/Tuple
+  // of Tensor
+  for (Value* output : graph->outputs()) {
+    VLOG(1) << "output: %" << output->debugName()
+            << " has type: " << output->type()->str();
+    auto kind = output->node()->kind();
+    if (kind == prim::TupleConstruct || kind == prim::ListConstruct) {
+      for (Value* input : output->node()->inputs()) {
+        auto type = input->type();
+        TORCH_CHECK(
+            type->cast<TensorType>() != nullptr,
+            "Static Runtime expects output type as List or Tuple of Tensor, but got List or Tuple of ",
+            type->repr_str());
+      }
+    } else {
+      auto type = output->type();
+      TORCH_CHECK(
+          type->cast<TensorType>() != nullptr ||
+              type->cast<NoneType>() != nullptr,
+          "Static Runtime expects output type as None or Tensor, but got ",
+          type->repr_str());
+    }
+  }
 }
 
 // remove unused input 0 from graph
@@ -48,6 +72,7 @@ std::unique_ptr<c10::FunctionSchema> RemoveSelfFromSchema(
 void AssignRegisters(
     const std::shared_ptr<torch::jit::Graph>& graph,
     std::unordered_map<Value*, size_t>& value_to_reg,
+    std::vector<Value*>& values,
     std::vector<size_t>& input_regs,
     std::vector<size_t>& output_regs) {
   // assign register to Value*
@@ -73,8 +98,15 @@ void AssignRegisters(
     TORCH_CHECK(value_to_reg.count(output) > 0);
     output_regs.push_back(value_to_reg[output]);
   }
+
+  values.resize(value_to_reg.size());
+  for (const auto& p : value_to_reg) {
+    values[p.second] = p.first;
+  }
 }
 
+// Internal blobs (IValues) are discarded after run if
+// opts_.cleanup_activations is true.
 void DeduceInternalBlobs(
     const std::shared_ptr<torch::jit::Graph>& graph,
     const std::unordered_map<Value*, size_t>& value_to_reg,
@@ -97,7 +129,7 @@ void InferenceModule::init() {
   OptimizeGraph(graph);
   CheckGraphEligibility(graph);
   RemoveSelfFromGraphInput(graph);
-  AssignRegisters(graph, value_to_reg, input_regs, output_regs);
+  AssignRegisters(graph, value_to_reg, values, input_regs, output_regs);
   DeduceInternalBlobs(graph, value_to_reg, internals);
 }
 
@@ -136,20 +168,20 @@ StaticRuntime::StaticRuntime(
   reg_.resize(module_->value_to_reg.size());
 
   Graph* graph = module_->graph.get();
-  auto& value_to_reg = module_->value_to_reg;
+  const auto& value_to_reg = module_->value_to_reg;
 
   // fill workspace_ with constants and create ProcessedNodes
   for (Node* node : graph->nodes()) {
     if (node->kind() == prim::Constant) {
       TORCH_CHECK(node->output()->type()->kind() != FunctionType::Kind);
-      reg_[value_to_reg[node->output()]] = toIValue(node->output()).value();
+      reg_[value_to_reg.at(node->output())] = toIValue(node->output()).value();
     } else {
       std::vector<size_t> input_regs, output_regs;
       for (Value* input : node->inputs()) {
-        input_regs.push_back(value_to_reg[input]);
+        input_regs.push_back(value_to_reg.at(input));
       }
       for (Value* output : node->outputs()) {
-        output_regs.push_back(value_to_reg[output]);
+        output_regs.push_back(value_to_reg.at(output));
       }
       nodes_.emplace_back(
           node,
@@ -158,10 +190,11 @@ StaticRuntime::StaticRuntime(
           opts.enable_out_variant);
     }
   }
+  // graph->dump();
 }
 
 std::vector<at::Tensor> StaticRuntime::run(
-    const std::vector<at::Tensor>& inps) const {
+    const std::vector<at::Tensor>& inps) {
   std::vector<c10::IValue> stack;
   stack.resize(inps.size());
   for (size_t i = 0; i < inps.size(); i++) {
@@ -185,18 +218,11 @@ std::vector<at::Tensor> StaticRuntime::run(
 
 c10::IValue StaticRuntime::run(
     const std::vector<c10::IValue>& args,
-    const std::unordered_map<std::string, c10::IValue>& kwargs) const {
-  caffe2::MakeGuard([&] {
-    if (opts_.cleanup_activations) {
-      for (size_t i : module_->internals) {
-        if (reg_[i].isTensor()) {
-          // Temporary solution
-          auto t = reg_[i].toTensor();
-          reg_[i] = at::empty({0}, t.options());
-        }
-      }
-    }
-  });
+    const std::unordered_map<std::string, c10::IValue>& kwargs) {
+  if (planner_) {
+    planner_->allocate();
+  }
+
   std::vector<IValue> stack(args);
   if (!kwargs.empty()) {
     // This is not ideal
@@ -214,14 +240,24 @@ c10::IValue StaticRuntime::run(
     n.run(reg_);
   }
 
-  return Output(0);
+  if (opts_.cleanup_activations) {
+    if (!planner_) {
+      planner_ = std::make_unique<MemoryPlanner>(this);
+    }
+    planner_->deallocate();
+    deallocate_registers(module_->internals);
+  }
+
+  // no need to keep references of outputs in static runtime anymore
+  DCHECK(module_->output_regs.size() == 1);
+  return std::move(reg_[module_->output_regs[0]]);
 }
 
 void StaticRuntime::benchmark(
     const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs,
     const int warmup_runs,
-    const int main_runs) const {
+    const int main_runs) {
   float time_per_iter = benchmark_model(args, kwargs, warmup_runs, main_runs);
   std::cout << "Static runtime ms per iter: " << time_per_iter
             << ". Iters per second: " << 1000.0 / time_per_iter << std::endl;
@@ -261,7 +297,7 @@ float StaticRuntime::benchmark_model(
     const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs,
     const int warmup_runs,
-    const int main_runs) const {
+    const int main_runs) {
   TORCH_CHECK(warmup_runs >= 0 && main_runs >= 1);
 
   for (int i = 0; i < warmup_runs; i++) {
@@ -279,7 +315,7 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
     const std::vector<c10::IValue>& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs,
     const int warmup_runs,
-    const int main_runs) const {
+    const int main_runs) {
   TORCH_CHECK(warmup_runs >= 0 && main_runs >= 1);
 
   IndividualMetrics results;
@@ -309,11 +345,21 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
 
   // main runs
   for (int i = 0; i < main_runs; i++) {
+    if (planner_) {
+      planner_->allocate();
+    }
     for (size_t j = 0; j < nodes_.size(); j++) {
       timer.Start();
       nodes_[j].run(reg_);
       float millis = timer.MilliSeconds();
       results.time_per_node[j] += millis;
+    }
+    if (opts_.cleanup_activations) {
+      if (!planner_) {
+        planner_ = std::make_unique<MemoryPlanner>(this);
+      }
+      planner_->deallocate();
+      deallocate_registers(module_->internals);
     }
   }
 
@@ -333,6 +379,138 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   return results;
 }
 
+void StaticRuntime::deallocate_registers(const std::vector<size_t>& internals) {
+  // discard Tensor objects to reduce memory usage
+  // they will be re-created in the next iteration regardless
+  for (auto i : internals) {
+    if (reg_[i].isTensor()) {
+      if (reg_[i].toTensor().storage().nbytes() > 0) {
+        reg_[i] = IValue();
+      }
+    } else {
+      // TensorLists and Tuples
+      // TODO: cache the List and Tuple objects but release what's inside
+      reg_[i] = IValue();
+    }
+  }
+}
+
+MemoryPlanner::MemoryPlanner(StaticRuntime* runtime)
+    : reg_(runtime->get_registers()) {
+  // collect register indices of outputs of ops with out variant
+  for (const ProcessedNode& node : runtime->get_nodes()) {
+    if (node.has_out_variant()) {
+      for (auto out : node.output_regs()) {
+        reg_out_variant_.insert(out);
+      }
+    }
+  }
+
+  const InferenceModule* module = runtime->get_inference_module();
+
+  // remove model outputs from reg_out_variant_
+  for (size_t output : module->output_regs) {
+    reg_out_variant_.erase(output);
+  }
+
+  // remove tensors in output List/Tuple from reg_out_variant_
+  for (Value* output : module->graph->outputs()) {
+    Node* output_node = output->node();
+    if (output_node->kind() == prim::TupleConstruct ||
+        output_node->kind() == prim::ListConstruct) {
+      for (Value* input : output_node->inputs()) {
+        reg_out_variant_.erase(module->value_to_reg.at(input));
+      }
+    }
+  }
+
+  // debug only
+  for (auto reg : reg_out_variant_) {
+    VLOG(1) << "reg_out_variant_: %" << module->values[reg]->debugName();
+  }
+
+  // dedup tensor storages (tensor views share the same tensor storage)
+  std::unordered_set<c10::StorageImpl*> internal_storages_set;
+  for (auto i : reg_out_variant_) {
+    internal_storages_set.insert(
+        reg_[i].toTensor().storage().unsafeGetStorageImpl());
+  }
+  internal_storages_.assign(
+      internal_storages_set.begin(), internal_storages_set.end());
+
+  internal_blob_max_sizes_.resize(internal_storages_.size());
+}
+
+// Don't change the size if it is already aligned, otherwise increase the size
+// to make it aligned.
+size_t MemoryPlanner::compute_aligned_tensor_size(size_t nbytes) {
+  // Note: everything below is size_t
+  return (nbytes + c10::gAlignment - 1) & (~(c10::gAlignment - 1));
+}
+
+at::DataPtr MemoryPlanner::allocate_buffer(size_t size) {
+  at::Allocator* allocator = c10::GetCPUAllocator();
+  return allocator->allocate(size);
+}
+
+void MemoryPlanner::allocate() {
+  if (internal_blob_max_sizes_sum_ == 0) {
+    return;
+  }
+
+  buffer_ = allocate_buffer(internal_blob_max_sizes_sum_);
+
+  size_t offset = 0;
+  uint8_t* start = static_cast<uint8_t*>(buffer_.get());
+
+  for (auto i = 0; i < internal_storages_.size(); i++) {
+    auto tensor_size = internal_blob_max_sizes_[i];
+    if (tensor_size == 0) {
+      continue;
+    }
+    DCHECK_LE(offset + tensor_size, internal_blob_max_sizes_sum_);
+    void* src = static_cast<void*>(start + offset);
+
+    c10::StorageImpl* impl = internal_storages_[i];
+    impl->set_data_ptr(at::DataPtr(src, src, nullptr, impl->device()));
+    impl->set_nbytes(tensor_size);
+
+    offset += tensor_size;
+  }
+  DCHECK_EQ(offset, internal_blob_max_sizes_sum_);
+}
+
+void MemoryPlanner::verify_internal_storages() {
+  std::unordered_set<c10::StorageImpl*> internal_storages_set;
+  for (auto i : reg_out_variant_) {
+    internal_storages_set.insert(
+        reg_[i].toTensor().storage().unsafeGetStorageImpl());
+  }
+  for (auto* storage_impl : internal_storages_) {
+    TORCH_CHECK(
+        internal_storages_set.count(storage_impl) > 0,
+        "Found internal_storage mismatch");
+  }
+}
+
+void MemoryPlanner::deallocate() {
+#ifndef NDEBUG
+  verify_internal_storages();
+#endif
+  internal_blob_max_sizes_sum_ = 0;
+  // free memory used by outputs of ops in out variants
+  // but keep the TensorImpl and StorageImpl around
+  for (auto i = 0; i < internal_storages_.size(); i++) {
+    c10::StorageImpl* impl = internal_storages_[i];
+    size_t current_size = compute_aligned_tensor_size(impl->nbytes());
+    size_t& max_size = internal_blob_max_sizes_[i];
+    max_size = std::max(max_size, current_size);
+    internal_blob_max_sizes_sum_ += max_size;
+    impl->reset();
+  }
+  buffer_ = {};
+}
+
 ProcessedNode::ProcessedNode(
     Node* node,
     std::vector<size_t>&& input_regs,
@@ -350,11 +528,25 @@ ProcessedNode::ProcessedNode(
   }
   if (enable_out_variants && canRunOutOfPlace(node)) {
     fn_ = getOutOfPlaceOperation(node);
+
+    std::ostringstream ss;
+    node->print(ss, 0, nullptr, false);
+    VLOG(1) << "Switch to out variant for node: " << ss.str();
+  }
+  if (canRunNatively(node)) {
+    native_fn_ = getNativeOperation(node);
+    std::ostringstream ss;
+    node->print(ss, 0, nullptr, false);
+    VLOG(1) << "Switch to native impl for node: " << ss.str();
   }
 }
 
 void ProcessedNode::run(std::vector<IValue>& reg) const {
-  if (!fn_) {
+  if (fn_) {
+    fn_->operator()(this, reg);
+  } else if (native_fn_) {
+    native_fn_->operator()(this, reg);
+  } else {
     std::vector<IValue> stack;
     const size_t size = node_->inputs().size();
     stack.reserve(size);
@@ -391,8 +583,6 @@ void ProcessedNode::run(std::vector<IValue>& reg) const {
     for (auto i = 0; i < node_->outputs().size(); i++) {
       Output(i, reg) = std::move(stack[i]);
     }
-  } else {
-    fn_->operator()(this, reg);
   }
 }
 

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>
+#include <c10/core/CPUAllocator.h>
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
@@ -65,6 +66,7 @@ struct TORCH_API InferenceModule {
   std::unique_ptr<c10::FunctionSchema> schema;
 
   std::unordered_map<Value*, size_t> value_to_reg;
+  std::vector<Value*> values; // useful for debugging
   std::vector<size_t> input_regs; // inputs to the graph
   std::vector<size_t> output_regs; // outputs of the graph
   std::vector<size_t> internals;
@@ -83,6 +85,7 @@ inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
   return std::make_shared<InferenceModule>(g);
 }
 
+class MemoryPlanner;
 class ProcessedNode;
 class TORCH_API StaticRuntime {
  public:
@@ -96,25 +99,25 @@ class TORCH_API StaticRuntime {
       const torch::jit::Module& m,
       const StaticRuntimeOptions& opts = StaticRuntimeOptions());
 
-  std::vector<at::Tensor> run(const std::vector<at::Tensor>& inps) const;
+  std::vector<at::Tensor> run(const std::vector<at::Tensor>& inps);
 
   // This interface only works module_ that has a non-empty TorchScript module
   // member; otherwise use the above interface
   c10::IValue run(
       const std::vector<c10::IValue>& args,
-      const std::unordered_map<std::string, c10::IValue>& kwargs) const;
+      const std::unordered_map<std::string, c10::IValue>& kwargs);
 
   void benchmark(
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs,
       const int warmup_runs,
-      const int main_runs) const;
+      const int main_runs);
 
   float benchmark_model(
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs,
       const int warmup_runs,
-      const int main_runs) const;
+      const int main_runs);
 
   struct IndividualMetrics {
     float setup_time;
@@ -129,19 +132,40 @@ class TORCH_API StaticRuntime {
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs,
       const int warmup_runs,
-      const int main_runs) const;
+      const int main_runs);
+
+  const InferenceModule* get_inference_module() {
+    return module_.get();
+  }
+
+  const std::vector<ProcessedNode>& get_nodes() {
+    return nodes_;
+  }
+
+  const std::vector<IValue>& get_registers() {
+    return reg_;
+  }
 
  private:
   // Static runtime states
   std::shared_ptr<InferenceModule> module_;
   StaticRuntimeOptions opts_;
   // IValue table (including inputs, outputs, intermediates, and weights)
-  mutable std::vector<IValue> reg_;
+  std::vector<IValue> reg_;
   // The nodes we need to run
   std::vector<ProcessedNode> nodes_;
 
+  // Memory planning is only enabled if opts_.cleanup_activations is true.
+  // Otherwise, the memory used by activations is cached inside the static
+  // runtime.
+  std::unique_ptr<MemoryPlanner> planner_;
+  // The memory planner does not take care of the IValues that are stored in the
+  // registers but don't participate in memory planning. They need to be cleaned
+  // up if cleanup_activations is enabled to avoid memory leak.
+  void deallocate_registers(const std::vector<size_t>& internals);
+
   // Input is readwrite
-  IValue& Input(size_t i) const {
+  IValue& Input(size_t i) {
     DCHECK(i < module_->input_regs.size());
     return reg_[module_->input_regs[i]];
   }
@@ -151,6 +175,51 @@ class TORCH_API StaticRuntime {
     DCHECK(i < module_->output_regs.size());
     return reg_[module_->output_regs[i]];
   }
+};
+
+/// There are three types of ops in a processed graph in Static Runtime
+///   1. op with _out variant
+///   2. view producing op
+///   3. tensor producing op (could be replaced with 1 by adding the _out
+///      variant)
+/// The memory planner only manages tensors that are outputs of type 1 ops,
+/// because type 2 ops don't incur memory allocation and for type 3, the output
+/// tensors are allocated inside the operator and can't be directly managed by
+/// memory planner.
+///
+/// Memory planner tries to minimize the number of memory allocations by
+/// tracking the unique StorageImpls of the output tensors of ops with _out
+/// variants. It tries to do this in several steps:
+///   1. record the max memory usage for each StorageImpl at the end of each
+///      iteration
+///   2. in the next iteration, allocate the buffer for the max total usage and
+///      compute the offset of each allocation with regard to the single memory
+///      buffer. In the first iteration, we rely on the default allocator for
+///      memory allocation.
+///   3. free the buffer at the end of each iteration
+/// Steps 1 and 3 are handled by `deallocate()`, and step 2 by `allocate()`.
+/// Only models with simple output types are supported, i.e. None, Tensor or
+/// List/Tuple of Tensors. Complex output types such as List of Lists are not
+/// supported.
+
+class MemoryPlanner {
+ public:
+  explicit MemoryPlanner(StaticRuntime* runtime);
+
+  void allocate();
+  void deallocate();
+
+ private:
+  const std::vector<IValue>& reg_;
+  std::unordered_set<size_t> reg_out_variant_;
+  std::vector<c10::StorageImpl*> internal_storages_;
+  std::vector<size_t> internal_blob_max_sizes_;
+  size_t internal_blob_max_sizes_sum_{0};
+  at::DataPtr buffer_; // allocated each time we call Run()
+
+  static size_t compute_aligned_tensor_size(size_t nbytes);
+  static at::DataPtr allocate_buffer(size_t size);
+  void verify_internal_storages();
 };
 
 class ProcessedNode {
@@ -178,11 +247,25 @@ class ProcessedNode {
     return reg[output_regs_[i]];
   }
 
+  bool has_out_variant() const {
+    return fn_.has_value();
+  }
+
+  const std::vector<size_t>& input_regs() const {
+    return input_regs_;
+  }
+
+  const std::vector<size_t>& output_regs() const {
+    return output_regs_;
+  }
+
  private:
   Node* node_;
   c10::optional<Operation> op_;
   c10::optional<std::function<void(const ProcessedNode*, std::vector<IValue>&)>>
       fn_;
+  c10::optional<std::function<void(const ProcessedNode*, std::vector<IValue>&)>>
+      native_fn_;
 
   std::vector<size_t> input_regs_;
   std::vector<size_t> output_regs_;

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -26,7 +26,7 @@ void initStaticRuntimeBindings(PyObject* module) {
       .def(
           "run",
           py::overload_cast<const std::vector<at::Tensor>&>(
-              &StaticRuntime::run, py::const_))
+              &StaticRuntime::run))
       .def(
           "run",
           [](StaticRuntime& self,

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -10,6 +10,10 @@ bool canRunOutOfPlace(Node* n);
 std::function<void(const ProcessedNode*, std::vector<IValue>&)>
 getOutOfPlaceOperation(Node* n);
 
+bool canRunNatively(Node* n);
+std::function<void(const ProcessedNode*, std::vector<IValue>&)>
+getNativeOperation(Node* n);
+
 #define SUPPORTED_OPS(F) \
   F(aten::__getitem__)   \
   F(aten::add)           \


### PR DESCRIPTION
Summary:
The idea of the memory model is quite similar to that of BlackBoxPredictor, however, it's more complicated in pt due to 1) tensor views that share storage with storage refcount bumps but with different TensorImpls, 2) tensors sharing the same TensorImpl and the same storage, but with no refcount bump of the StorageImpl, 3) data types such as TensorList and Tuples that have Tensors in them, 4) need to support non-out/out variant mix while we move the aten ops to out variants.

As a result, I have to make the following adjustments:
1) remove tensors in output Tuples from internal blob list;
2) for memory allocation/deallocation, get candidate Tensors from the outputs of ops with out variant, extract StorageImpls from the Tensors, dedup, and remove output tensor StorageImpls, and get the final list of blobs for memory planning;
3) during the clean_up_memory pass, clean up memory held by the StorageImpls as well as Tensors/Lists/Tuples in IValues that don't participate in memory planning to reduce overall memory usage

Risk:
PyTorch team is planning to deprecate the current resize_outout api, which we do rely on. This is a pretty big risk.

https://www.internalfb.com/intern/diffusion/FBS/browsefile/master/fbcode/caffe2/aten/src/ATen/native/Resize.cpp?commit=6457b329847607553d34e788a3a7092f41f38895&lines=9-23

Test Plan:
```
buck test //caffe2/test:static_runtime
buck test //caffe2/benchmarks/static_runtime:static_runtime_cpptest
buck test //caffe2/caffe2/fb/predictor:pytorch_predictor_test
```
Benchmarks:
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 13 \
buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench \
--scripted_model=/home/hlu/ads/adindexer/adindexer_ctr_mobilefeed/pt/merge/traced_precomputation.pt \
--pt_inputs=/home/hlu/ads/adindexer/adindexer_ctr_mobilefeed/pt/merge/container_precomputation_bs1.pt \
--iters=1000 --warmup_iters=10000 --num_threads=1 --pt_enable_static_runtime=true \
--pt_cleanup_activations=true --pt_enable_out_variant=false
```

|pt_cleanup_activations	|pt_enable_out_variant	|old ms/iter	|new ms/iter	|
|---	|---	|---	|---	|
|0	|0	|0.31873	|0.30228	|
|0	|1	|0.30018	|0.29184	|
|1	|0	|0.35246	|0.31895	|
|1	|1	|0.35742	|0.30417	|

Differential Revision: D24471854

