### PR TITLE
[release/1.7] .jenkins: Bump torchvision commit

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -66,7 +66,7 @@ function get_bazel() {
   chmod +x tools/bazel
 }
 
-TORCHVISION_COMMIT=v0.8.0-rc4
+TORCHVISION_COMMIT=291f7e20339510cfa956b5782741697eb8e6d554
 
 function install_torchvision() {
   # Check out torch/vision at Jun 11 2020 commit


### PR DESCRIPTION
There was a commit added after RC4 was made that should include docs

Bumps to this commit: https://github.com/pytorch/vision/commit/291f7e20339510cfa956b5782741697eb8e6d554

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
