### PR TITLE
AT_ERROR if mmap allocation has failed

### DIFF
--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -288,6 +288,7 @@ THMapAllocator::THMapAllocator(WithFd, const char *filename, int fd, int flags, 
 
     if (base_ptr_ == MAP_FAILED) {
       base_ptr_ = nullptr; /* let's be sure it is NULL */
+      AT_ERROR("unable to mmap ", size_, " bytes from file <", filename_, ">: ", strerror(errno), " (", errno, ")");
     }
 
     if (flags_ & TH_ALLOCATOR_MAPPED_KEEPFD) {


### PR DESCRIPTION
All other system call failures in `THMapAllocator` constructor are considered failures, but this one, for some reason was not

Fixes https://github.com/pytorch/pytorch/issues/46651

