### PR TITLE
[fx] wrap - put arbitrary functions in the graph

### DIFF
--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -84,7 +84,7 @@ Because this code is valid PyTorch code, the resulting `GraphModule` can be used
 '''
 
 from .graph_module import GraphModule
-from .symbolic_trace import symbolic_trace, Tracer
+from .symbolic_trace import symbolic_trace, Tracer, wrap
 from .graph import Graph
 from .node import Node, map_arg
 from .proxy import Proxy


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46943 [fx] wrap - put arbitrary functions in the graph**

This adds a @wrap decorator that can be put on a function. When called during
symbolic tracing, the function will be inserted in the graph rather than
when executing. When called outside of tracing, the function will execute
normally.

Differential Revision: [D24599226](https://our.internmc.facebook.com/intern/diff/D24599226)