### PR TITLE
[NNC] Read/Write Dependency analysis

### DIFF
--- a/test/cpp/tensorexpr/test_memdependency.cpp
+++ b/test/cpp/tensorexpr/test_memdependency.cpp
@@ -1,0 +1,3145 @@
+#include <test/cpp/tensorexpr/test_base.h>
+
+#include <torch/csrc/jit/tensorexpr/bounds_overlap.h>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_printer.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/mem_dependency_checker.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+
+namespace torch {
+namespace jit {
+
+using namespace torch::jit::tensorexpr;
+
+// Test helper function used to determine if two regions of a buffer have an
+// overlap. No Overlap & partial overlap is obvious. Contains means A is
+// larger and fully encloses B, while ContainedOrEqual is the reverse. Equal
+// ranges are ContainedOrEqual.
+void testBoundOverlap() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+
+  auto CB = [](int s, int e) { return Bound(new IntImm(s), new IntImm(e)); };
+
+  // Sanity check 3 overlap cases.
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(0, 0), CB(0, 0)));
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 3), CB(2, 5)));
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(0, 0), CB(1, 1)));
+
+  // Partial overlap works in either order.
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 10), CB(7, 14)));
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(7, 14), CB(0, 10)));
+
+  // Total Overlap works when one bound encloses the other, and returns which.
+  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(7, 9)));
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 15), CB(0, 16)));
+
+  // Total overlap works when the bounds are an identical range, returns
+  // ContainedOrEqual.
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 15), CB(2, 15)));
+
+  // Total overlap when only one end of the bound matches.
+  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(2, 10)));
+  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(3, 15)));
+  ASSERT_EQ(Contains, boundOverlap(CB(0, 10), CB(0, 9)));
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 10), CB(2, 15)));
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(3, 15), CB(2, 15)));
+
+  // No overlap when a < b.
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(0, 2), CB(5, 10)));
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(2, 2), CB(3, 3)));
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(100, 120), CB(130, 130)));
+
+  // No overlap when a > b.
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(5, 10), CB(0, 2)));
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(3, 3), CB(2, 2)));
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(130, 130), CB(100, 120)));
+
+  // No overlap when adjacent.
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(0, 100), CB(101, 120)));
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(2, 3), CB(0, 1)));
+
+  // Partial overlap when middle bounds match.
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 100), CB(100, 120)));
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 2), CB(2, 4)));
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(100, 120), CB(0, 100)));
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(2, 3), CB(1, 2)));
+
+  // Total overlap when one bound is single length over one end of the other.
+  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(15, 15)));
+  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(2, 2)));
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 2), CB(2, 15)));
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(15, 15), CB(2, 15)));
+}
+
+void testBoundOverlapSymbolic() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  VarHandle z("z", kInt);
+  VarHandle w("w", kInt);
+
+  using namespace analysis;
+
+  auto CB = [](ExprHandle s, ExprHandle e) {
+    return Bound(s.node(), e.node());
+  };
+
+  // Sanity check cases where the start and end is symbolic but the diff is
+  // constant.
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(x, x), CB(x, x)));
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(x, x + 3), CB(x + 2, x + 5)));
+  ASSERT_EQ(NoOverlap, boundOverlap(CB(x, x), CB(x + 1, x + 1)));
+
+  // We can't infer the sign of y, so cannot tell whether adding y is larger or
+  // smaller than y/2.
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(x, x + y), CB(x, x + y / 2)));
+
+  // No information about this bound, have to take the most conservative option:
+  // there may be an overlap.
+  ASSERT_EQ(PartialOverlap, boundOverlap(CB(x, y), CB(z, w)));
+
+  // Math on opaque terms works.
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(x + w, y - z), CB(x + w, y - z)));
+  // Even requiring simplification.
+  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(x - w - w, y), CB(x - w * 2, y)));
+}
+
+// Tests the helper function for overlap of multi dimensional indices bounds.
+// This uses boundOverlap on each dimension and return the "lowest" kind of
+// overlap.
+void testBoundOverlapMultiDim() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+
+  auto CB = [](int s, int e) { return Bound(new IntImm(s), new IntImm(e)); };
+
+  // Sanity check one dimensional cases.
+  ASSERT_EQ(ContainedOrEqual, overlaps({CB(0, 0)}, {CB(0, 0)}));
+  ASSERT_EQ(NoOverlap, overlaps({CB(0, 2)}, {CB(5, 10)}));
+  ASSERT_EQ(PartialOverlap, overlaps({CB(0, 100)}, {CB(100, 120)}));
+
+  // Total overlap in 3 dims.
+  ASSERT_EQ(
+      ContainedOrEqual,
+      overlaps({CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 5), CB(0, 4)}));
+  ASSERT_EQ(
+      ContainedOrEqual,
+      overlaps(
+          {CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 5), CB(0, 10)}));
+
+  // Total overlap in 2 dims, no overlap in another.
+  ASSERT_EQ(
+      NoOverlap,
+      overlaps(
+          {CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 5), CB(5, 10)}));
+
+  // Total overlap in 2 dims, partial overlap in another.
+  ASSERT_EQ(
+      PartialOverlap,
+      overlaps(
+          {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(0, 2), CB(0, 5), CB(5, 10)}));
+  // This case is most important, so verify the overlap in any dim. (dim 2)
+  ASSERT_EQ(
+      PartialOverlap,
+      overlaps({CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(0, 2), CB(2, 6), CB(0, 5)}));
+  // Dim 1.
+  ASSERT_EQ(
+      PartialOverlap,
+      overlaps({CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(1, 3), CB(0, 5), CB(0, 5)}));
+  // Total overlap in 1 dim, partial in 2.
+  ASSERT_EQ(
+      PartialOverlap,
+      overlaps(
+          {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(2, 6), CB(0, 5), CB(5, 10)}));
+  // Total overlap, partial overlap, no overlap.
+  ASSERT_EQ(
+      NoOverlap,
+      overlaps(
+          {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(2, 6), CB(11, 15), CB(0, 5)}));
+
+  // Total overlap (B) in 2 dims, total overlap (A) in another.
+  ASSERT_EQ(
+      Contains,
+      overlaps({CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 3), CB(0, 4)}));
+
+  // Total overlap (A) in 2 dims, total overlap (B) in another.
+  ASSERT_EQ(
+      Contains,
+      overlaps(
+          {CB(0, 12), CB(0, 15), CB(0, 4)}, {CB(0, 2), CB(0, 3), CB(0, 14)}));
+
+  // Total (B), No Overlap, Total (A).
+  ASSERT_EQ(
+      NoOverlap,
+      overlaps(
+          {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(0, 6), CB(11, 15), CB(1, 2)}));
+}
+
+// Test the helper we use to subtract bounds: returns the regions(s) of A which
+// remain after removing the region of B.
+void testBoundSubtract() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+
+  auto CB = [](int s, int e) { return Bound(new IntImm(s), new IntImm(e)); };
+  auto EQ = [](const IndexBounds& x, const IndexBounds& y) {
+    return indexBoundsEquals(x, y);
+  };
+
+  // One element subtract.
+  ASSERT_EQ(subtractBound(CB(0, 0), CB(0, 0)).size(), 0);
+  ASSERT_EQ(subtractBound(CB(5, 5), CB(5, 5)).size(), 0);
+
+  // No Overlap.
+  ASSERT_TRUE(EQ(subtractBound(CB(5, 5), CB(2, 2)), {CB(5, 5)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(5, 5), CB(0, 4)), {CB(5, 5)}));
+
+  // one side overlap.
+  ASSERT_TRUE(EQ(subtractBound(CB(1, 5), CB(4, 7)), {CB(1, 3)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(0, 5), CB(5, 7)), {CB(0, 4)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(4, 5), CB(1, 4)), {CB(5, 5)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(1, 5), CB(0, 4)), {CB(5, 5)}));
+
+  // both sides overlap.
+  ASSERT_TRUE(EQ(subtractBound(CB(1, 5), CB(0, 7)), {}));
+  ASSERT_TRUE(EQ(subtractBound(CB(5, 5), CB(5, 7)), {}));
+
+  // internal overlap.
+  ASSERT_TRUE(EQ(subtractBound(CB(1, 5), CB(2, 3)), {CB(1, 1), CB(4, 5)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(0, 5), CB(2, 4)), {CB(0, 1), CB(5, 5)}));
+}
+
+void testBoundSubtractSymbolic() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  VarHandle z("z", kInt);
+  VarHandle w("w", kInt);
+
+  using namespace analysis;
+
+  auto CB = [](ExprHandle s, ExprHandle e) {
+    return Bound(s.node(), e.node());
+  };
+  auto EQ = [](const IndexBounds& x, const IndexBounds& y) {
+    return indexBoundsEquals(x, y);
+  };
+
+  // One element subtract.
+  ASSERT_TRUE(EQ(subtractBound(CB(x, x), CB(x, x)), {}));
+  ASSERT_TRUE(EQ(subtractBound(CB(x + 1, x + 1), CB(x + 1, x + 1)), {}));
+  ASSERT_TRUE(EQ(subtractBound(CB(x * 2, x * 2), CB(x * 2, x * 2)), {}));
+
+  // Subtract constant range low.
+  ASSERT_TRUE(
+      EQ(subtractBound(CB(x, x + 10), CB(x, x + 4)), {CB(x + 5, x + 10)}));
+  // Subtract constant range high.
+  ASSERT_TRUE(
+      EQ(subtractBound(CB(x, x + 10), CB(x + 6, x + 12)), {CB(x, x + 5)}));
+  // Subtract constant range total overlap.
+  ASSERT_TRUE(EQ(subtractBound(CB(x, x + 10), CB(x, x + 10)), {}));
+  ASSERT_TRUE(EQ(subtractBound(CB(x + 2, x + 10), CB(x, x + 12)), {}));
+  // Subtract constant range internal.
+  ASSERT_TRUE(
+      EQ(subtractBound(CB(x, x + 10), CB(x + 3, x + 7)),
+         {CB(x, x + 2), CB(x + 8, x + 10)}));
+
+  // Size is inferable but not constant, only works with a single var.
+  ASSERT_TRUE(EQ(subtractBound(CB(0, x), CB(0, x * 2)), {}));
+  ASSERT_TRUE(EQ(subtractBound(CB(0, x * 2), CB(0, x - 1)), {CB(x, x * 2)}));
+
+  // Size is not inferable.
+  ASSERT_TRUE(EQ(subtractBound(CB(x, y), CB(z, w)), {CB(x, y)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(x, y), CB(x, z)), {CB(x, y)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(x, y), CB(0, x)), {CB(x, y)}));
+  ASSERT_TRUE(EQ(subtractBound(CB(x, x), CB(0, 0)), {CB(x, x)}));
+}
+
+// Tests the helper function that does subtraction, but for multi dimensional
+// indices bounds.
+void testBoundSubtractMultiDim() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+
+  auto CB = [](int s, int e) { return Bound(new IntImm(s), new IntImm(e)); };
+  auto EQ = [](std::vector<IndexBounds> x, std::vector<IndexBounds> y) {
+    if (x.size() != y.size()) {
+      return false;
+    }
+    for (auto i = 0; i < x.size(); ++i) {
+      if (!indexBoundsEquals(x[i], y[i])) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // sanity check one dimension.
+  ASSERT_TRUE(EQ(subtractIndicesBounds({CB(0, 9)}, {CB(0, 9)}), {}));
+  ASSERT_TRUE(EQ(subtractIndicesBounds({CB(3, 9)}, {CB(0, 12)}), {}));
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, 12)}, {CB(0, 9)}), {{CB(10, 12)}}));
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, 12)}, {CB(3, 12)}), {{CB(0, 2)}}));
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(0, 9)}, {CB(1, 8)}), {{CB(0, 0)}, {CB(9, 9)}}));
+
+  // Multi dim total overlap.
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(0, 9), CB(0, 2)}, {CB(0, 9), CB(0, 2)}), {}));
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(0, 9), CB(0, 2)}, {CB(0, 10), CB(0, 20)}), {}));
+
+  // Mutli dim one way partial in dim 1.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, 9), CB(0, 2)}, {CB(0, 3), CB(0, 2)}),
+         {{CB(4, 9), CB(0, 2)}}));
+
+  // Mutli dim one way partial in dim 2.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, 9), CB(0, 20)}, {CB(0, 9), CB(0, 10)}),
+         {{CB(0, 9), CB(11, 20)}}));
+
+  // Partial overlap in 2 dims.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, 5), CB(0, 5)}, {CB(2, 8), CB(2, 8)}),
+         {{CB(0, 1), CB(0, 5)}, {CB(2, 5), CB(0, 1)}}));
+
+  // Partial overlap in 3 dims.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds(
+             {CB(0, 5), CB(0, 5), CB(0, 5)}, {CB(2, 8), CB(2, 8), CB(2, 8)}),
+         {{CB(0, 1), CB(0, 5), CB(0, 5)},
+          {CB(2, 5), CB(0, 1), CB(0, 5)},
+          {CB(2, 5), CB(2, 5), CB(0, 1)}}));
+}
+
+// Tests the multi dimensional subtraction code for bounds that cannot be fully
+// materialized.
+void testBoundSubtractMultiDimSymbolic() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+
+  using namespace analysis;
+
+  auto CB = [](ExprHandle s, ExprHandle e) {
+    return Bound(s.node(), e.node());
+  };
+
+  auto EQ = [](std::vector<IndexBounds> x, std::vector<IndexBounds> y) {
+    if (x.size() != y.size()) {
+      return false;
+    }
+    for (auto i = 0; i < x.size(); ++i) {
+      if (!indexBoundsEquals(x[i], y[i])) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // Cannot determine overlaps.
+  ASSERT_TRUE(EQ(subtractIndicesBounds({CB(x, x)}, {CB(0, 0)}), {{CB(x, x)}}));
+
+  // Various total Overlaps.
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(x, x), CB(x, x)}, {CB(x, x), CB(x, x)}), {}));
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(x, y), CB(x, y)}, {CB(x, y), CB(x, y)}), {}));
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(x, x), CB(y, y)}, {CB(x, x), CB(y, y)}), {}));
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(0, x), CB(0, y)}, {CB(0, x), CB(0, y)}), {}));
+
+  // one-way overlap in first dim.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, x), CB(0, y)}, {CB(0, x - 5), CB(0, y)}),
+         {{CB(x - 4, x), CB(0, y)}}));
+  // second dim.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, x), CB(0, y)}, {CB(0, x), CB(5, y)}),
+         {{CB(0, x), CB(0, 4)}}));
+
+  // Internal overlap in first dim.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds({CB(0, x), CB(0, y)}, {CB(2, x - 5), CB(0, y)}),
+         {{CB(0, 1), CB(0, y)}, {CB(x - 4, x), CB(0, y)}}));
+  // second dim.
+  ASSERT_TRUE(EQ(
+      subtractIndicesBounds({CB(0, x), CB(0, y)}, {CB(0, x), CB(10, y - 10)}),
+      {{CB(0, x), CB(0, 9)}, {CB(0, x), CB(y - 9, y)}}));
+
+  // Overlap in both dimensions.
+  ASSERT_TRUE(
+      EQ(subtractIndicesBounds(
+             {CB(0, x), CB(0, y)}, {CB(5, x - 5), CB(10, y - 10)}),
+         {
+             {CB(0, 4), CB(0, y)},
+             {CB(x - 4, x), CB(0, y)},
+             {CB(0, x), CB(0, 9)},
+             {CB(0, x), CB(y - 9, y)},
+         }));
+}
+
+// Simple check that the analyzer does anything at all...
+void testMemDependencyCheckerSimple() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {1}, kInt);
+  BufHandle b("B", {1}, kInt);
+
+  analysis::MemDependencyChecker analyzer;
+
+  /*
+   * A[0] = 3;
+   * B[0] = A[0] + 1;
+   */
+
+  Store* aStore = Store::make(a, {0}, 3, 1);
+  Store* bStore = Store::make(b, {0}, Add::make(Load::make(a, {0}, 1), 1), 1);
+
+  Stmt* stmt = Block::make({aStore, bStore});
+
+  stmt->accept(&analyzer);
+
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, aStore));
+  ASSERT_FALSE(analyzer.dependsIndirectly(aStore, bStore));
+  // sanity check, but anything that depends directly must depend indirectly.
+  ASSERT_TRUE(analyzer.dependsIndirectly(bStore, aStore));
+}
+
+// Check that there is a difference between direct and indirect dependence.
+void testMemDependencyCheckerMultiStmt() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {1}, kInt);
+  BufHandle b("B", {1}, kInt);
+  BufHandle c("C", {1}, kInt);
+
+  analysis::MemDependencyChecker analyzer;
+
+  /*
+   * A[0] = 3;
+   * B[0] = A[0];
+   * C[0] = B[0] + 1;
+   */
+
+  Store* aStore = Store::make(a, {0}, 3, 1);
+  Store* bStore = Store::make(b, {0}, Load::make(a, {0}, 1), 1);
+  Store* cStore = Store::make(c, {0}, Add::make(Load::make(b, {0}, 1), 1), 1);
+
+  Stmt* stmt = Block::make({aStore, bStore, cStore});
+
+  stmt->accept(&analyzer);
+
+  // C depends on A indirectly.
+  ASSERT_FALSE(analyzer.dependsDirectly(cStore, aStore));
+  ASSERT_TRUE(analyzer.dependsIndirectly(cStore, aStore));
+
+  // C depends on B directly, which depends on A directly.
+  ASSERT_TRUE(analyzer.dependsDirectly(cStore, bStore));
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, aStore));
+
+  // Dependency goes top to bottom only.
+  ASSERT_FALSE(analyzer.dependsIndirectly(bStore, cStore));
+  ASSERT_FALSE(analyzer.dependsIndirectly(aStore, bStore));
+  ASSERT_FALSE(analyzer.dependsIndirectly(aStore, cStore));
+}
+
+// Verify that we do filter writes that are totally overlapped by later writes.
+void testMemDependencyCheckerOverlap() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {1}, kInt);
+  BufHandle b("B", {1}, kInt);
+
+  analysis::MemDependencyChecker analyzer;
+
+  /*
+   * A[0] = 3;
+   * A[0] = 6;
+   * B[0] = A[0] + 1;
+   */
+
+  Store* aStore = Store::make(a, {0}, 3, 1);
+  Store* a2Store = Store::make(a, {0}, 6, 1);
+  Store* bStore = Store::make(b, {0}, Add::make(Load::make(a, {0}, 1), 1), 1);
+
+  Stmt* stmt = Block::make({aStore, a2Store, bStore});
+
+  stmt->accept(&analyzer);
+
+  // B store depends on second A store but not first since it is completely
+  // overlapped.
+  ASSERT_TRUE(analyzer.dependsIndirectly(bStore, a2Store));
+  ASSERT_FALSE(analyzer.dependsIndirectly(bStore, aStore));
+
+  // No dependency between either A store.
+  ASSERT_FALSE(analyzer.dependsIndirectly(aStore, a2Store));
+  ASSERT_FALSE(analyzer.dependsIndirectly(a2Store, aStore));
+}
+
+// Verify that bounds match loop iterations, and that dependencies progress
+// across loop scopes.
+void testMemDependencyCheckerLoop() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {1}, kInt);
+  BufHandle b("B", {1}, kInt);
+  VarHandle x("x", kInt);
+
+  using namespace analysis;
+
+  MemDependencyChecker analyzer;
+
+  /*
+   * for (int x = 0; x < 10; ++x) {
+   *   A[x] = x;
+   * }
+   * B[0] = A[0] + 1;
+   */
+
+  Store* aStore = Store::make(a, {x}, x, 1);
+  Stmt* loop = For::make(x, 0, 10, aStore);
+  Store* bStore = Store::make(b, {0}, Add::make(Load::make(a, {4}, 1), 1), 1);
+
+  Stmt* stmt = Block::make({loop, bStore});
+
+  stmt->accept(&analyzer);
+
+  // Same A->B dependency.
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, aStore));
+
+  // B depends on the loop.
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, loop));
+  // A is in the loop but does not depend on any loop iteration.
+  ASSERT_FALSE(analyzer.dependsIndirectly(aStore, loop));
+
+  auto aStoreAccess = analyzer.accessFor(aStore);
+  ASSERT_NE(aStoreAccess, nullptr);
+
+  // It should have bounds covering the range of x: 0 <= x < 10.
+  ASSERT_TRUE(indexBoundsEquals(
+      aStoreAccess->bounds(), {Bound(new IntImm(0), new IntImm(9))}));
+}
+
+// Reductions should promote dependencies as well.
+void testMemDependencyCheckerLoopReduce() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  VarHandle x("x", kInt);
+
+  using namespace analysis;
+
+  MemDependencyChecker analyzer;
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; ++x) {
+   *   A[0] = A[x] + 1;
+   * }
+   * B[0] = A[0];
+   */
+
+  Store* aInit = Store::make(a, {0}, 0, 1);
+  ExprHandle reduce =
+      ExprHandle(Sum()(a.node(), ExprHandle(1), {x.node()}, {x.node()}));
+  Store* aReduce = Store::make(a, {0}, reduce, 1);
+  Stmt* loop = For::make(x, 0, 10, aReduce);
+  Store* bStore = Store::make(b, {0}, Load::make(a, {0}, 1), 1);
+
+  Stmt* stmt = Block::make({aInit, loop, bStore});
+
+  stmt->accept(&analyzer);
+
+  // B -> A.
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, aReduce));
+
+  // B depends indirectly on the intializer of A, since the reduction depends
+  // on it.
+  ASSERT_FALSE(analyzer.dependsDirectly(bStore, aInit));
+  ASSERT_TRUE(analyzer.dependsIndirectly(bStore, aInit));
+
+  ASSERT_TRUE(analyzer.dependsDirectly(aReduce, aInit));
+
+  // B depends on the loop.
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, loop));
+  // A is in the loop and depends on other iterations.
+  ASSERT_TRUE(analyzer.dependsDirectly(aReduce, loop));
+
+  // The loop contents depend on the initializer too.
+  ASSERT_TRUE(analyzer.dependsDirectly(loop, aInit));
+
+  // Pull out the access for the load inside the loop.
+  auto loopLoad = analyzer.accessFor(reduce.node());
+  // It should have 10 element long bounds.
+  ASSERT_TRUE(indexBoundsEquals(
+      loopLoad->bounds(), {Bound(new IntImm(0), new IntImm(9))}));
+}
+
+// Lowering a reduction doesn't affect dependency analysis.
+void testMemDependencyCheckerLoopReduceExpanded() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  VarHandle x("x", kInt);
+
+  using namespace analysis;
+
+  MemDependencyChecker analyzer;
+
+  /*
+   * A[0] = 0;
+   * for (int x = 0; x < 10; ++x) {
+   *   A[0] = A[x] + 1;
+   * }
+   * B[0] = A[0];
+   */
+
+  Store* aInit = Store::make(a, {0}, 0, 1);
+  ExprHandle aLoad = Load::make(a, {x}, 1);
+  Store* aReduce = Store::make(a, {0}, Add::make(aLoad, 1));
+  Stmt* loop = For::make(x, 0, 10, aReduce);
+  Store* bStore = Store::make(b, {0}, Load::make(a, {0}, 1), 1);
+
+  Stmt* stmt = Block::make({aInit, loop, bStore});
+
+  stmt->accept(&analyzer);
+
+  // B -> A.
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, aReduce));
+
+  // B depends indirectly on the intializer of A, since the reduction depends
+  // on it.
+  ASSERT_FALSE(analyzer.dependsDirectly(bStore, aInit));
+  ASSERT_TRUE(analyzer.dependsIndirectly(bStore, aInit));
+
+  ASSERT_TRUE(analyzer.dependsDirectly(aReduce, aInit));
+
+  // B depends on the loop.
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, loop));
+  // A is in the loop and depends on other iterations.
+  ASSERT_TRUE(analyzer.dependsDirectly(aReduce, loop));
+
+  // The loop contents depend on the initializer too.
+  ASSERT_TRUE(analyzer.dependsDirectly(loop, aInit));
+
+  // Pull out the access for the store inside the loop.
+  auto loopLoad = analyzer.accessFor(aLoad.node());
+  // It should have 10 element long bounds.
+  ASSERT_TRUE(indexBoundsEquals(
+      loopLoad->bounds(), {Bound(new IntImm(0), new IntImm(9))}));
+}
+
+// Can determine dependencies of outputs, through to inputs.
+void testMemDependencyCheckerInputsOutputs() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  VarHandle x("x", kInt);
+
+  // initialize analyzer with inputs and outputs.
+  analysis::MemDependencyChecker analyzer({a}, {b});
+
+  // Here's a Relu.
+  /*
+   * for (int x = 0; x < 10; ++x) {
+   *   B[x] = Max(A[x], 0);
+   * }
+   */
+
+  ExprHandle aLoad = Load::make(a, {x}, 1);
+  Store* bStore = Store::make(b, {x}, Max::make(aLoad, 0, true), 1);
+  Stmt* loop = For::make(x, 0, 10, bStore);
+
+  Stmt* stmt = Block::make({loop});
+
+  stmt->accept(&analyzer);
+
+  // Output depends indirectly on input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+  // aLoad depends directly on the input A.
+  ASSERT_TRUE(analyzer.dependsDirectly(aLoad.node(), a.node()));
+  // bStore therefore depends directly on the input A.
+  ASSERT_TRUE(analyzer.dependsDirectly(bStore, a.node()));
+  // The output depends directly on the store.
+  ASSERT_TRUE(analyzer.dependsDirectly(b.node(), bStore));
+
+  // Check AccessInfo based overloads.
+  auto input = analyzer.input(a.node());
+  auto output = analyzer.output(b.node());
+
+  // Output depends indirectly on input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(output, input));
+  // Not directly.
+  ASSERT_FALSE(analyzer.dependsDirectly(output, input));
+  // Not in reverse order.
+  ASSERT_FALSE(analyzer.dependsIndirectly(input, output));
+
+  // output -> bStore -> bLoad -> input.
+  auto storeAccess = analyzer.accessFor(bStore);
+  auto loadAccess = analyzer.accessFor(aLoad.node());
+
+  ASSERT_TRUE(analyzer.dependsDirectly(output, storeAccess));
+  ASSERT_TRUE(analyzer.dependsDirectly(loadAccess, input));
+}
+
+// Can tell if an output does not depend on an input.
+void testMemDependencyCheckerOutputDoesntDepend() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  VarHandle x("x", kInt);
+
+  // initialize analyzer with inputs and outputs.
+  analysis::MemDependencyChecker analyzer({a}, {b});
+
+  // Here's a dumb Relu.
+  /*
+   * for (int x = 0; x < 10; ++x) {
+   *   B[x] = Max(x, 0);
+   * }
+   */
+
+  Store* bStore = Store::make(b, {x}, Max::make(x, 0, true), 1);
+  Stmt* loop = For::make(x, 0, 10, bStore);
+
+  Stmt* stmt = Block::make({loop});
+
+  stmt->accept(&analyzer);
+
+  // Output does not depend indirectly on input.
+  ASSERT_FALSE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+  // The output still depends directly on the store.
+  ASSERT_TRUE(analyzer.dependsDirectly(b.node(), bStore));
+
+  // Check AccessInfo based overloads.
+  auto input = analyzer.input(a.node());
+  auto output = analyzer.output(b.node());
+
+  // Output does not depend indirectly on input.
+  ASSERT_FALSE(analyzer.dependsIndirectly(output, input));
+}
+
+// Verify different loop extents produce accesses with different bounds, and
+// that later accesses find dependencies that overlap their entire bound range.
+void testMemDependencyCheckerLoopBounds() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  BufHandle c("C", {10}, kInt);
+  VarHandle x("x", kInt);
+  using namespace analysis;
+
+  MemDependencyChecker analyzer({a}, {c});
+
+  // This enables using the execution order of the loops to determine if some
+  // loops are self dependent or not.
+  analyzer.allowLoopExecutionOrderAnalysis();
+
+  /*
+   * for (int x = 1; x < 10; ++x) {
+   *   B[x] = A[x];
+   * }
+   * for (int x = 1; x < 9; ++x) {
+   *   B[x] = B[x] * 2;
+   * }
+   * for (int x = 3; x < 4; ++x) {
+   *   C[x] = A[x];
+   * }
+   * for (int x = 0; x < 10; ++x) {
+   *   C[x] = B[x];
+   * }
+   */
+
+  std::vector<Stmt*> stmts(
+      {For::make(x, 1, 10, Store::make(b, {x}, Load::make(a, {x}, 1), 1)),
+       For::make(
+           x,
+           1,
+           9,
+           Store::make(b, {x}, Mul::make(Load::make(b, {x}, 1), 2), 1)),
+       For::make(x, 3, 4, Store::make(c, {x}, Load::make(a, {x}, 1), 1)),
+       For::make(x, 0, 10, Store::make(c, {x}, Load::make(b, {x}, 1), 1))});
+
+  Stmt* stmt = Block::make(stmts);
+
+  stmt->accept(&analyzer);
+
+  auto input = analyzer.input(a.node());
+  auto output = analyzer.output(c.node());
+
+  // sanity check Output -> Input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(output, input));
+
+  // Check the For loop dependencies:
+
+  // Last write to C depends on both writes to B since they contain the last
+  // write to at least one element.
+  ASSERT_TRUE(analyzer.dependsIndirectly(stmts[3], stmts[1]));
+  ASSERT_TRUE(analyzer.dependsIndirectly(stmts[3], stmts[0]));
+
+  // The last write to C does not depend on the other write to C.
+  ASSERT_FALSE(analyzer.dependsIndirectly(stmts[3], stmts[2]));
+
+  auto CB = [](int s, int e) { return Bound(new IntImm(s), new IntImm(e)); };
+  auto EQ = [](const IndexBounds& x, const IndexBounds& y) {
+    return indexBoundsEquals(x, y);
+  };
+
+  /*  0. Input: A[(0, 9)] - dependents: 1 5
+   *  1. Load: A[(1, 9)] - depends on: 0  - dependents: 2
+   *  2. Store: B[(1, 9)] - depends on: 1  - dependents: 3 7
+   *  3. Load: B[(1, 8)] - depends on: 2  - dependents: 4
+   *  4. Store: B[(1, 8)] - depends on: 3  - dependents: 7
+   *  5. Load: A[(3, 3)] - depends on: 0  - dependents: 6
+   *  6. Store: C[(3, 3)] - depends on: 5
+   *  7. Load: B[(0, 9)] - depends on: 2 4  - dependents: 8
+   *  8. Store: C[(0, 9)] - depends on: 7  - dependents: 9
+   *  9. Output: C[(0, 9)] - depends on: 8
+   */
+
+  // Now let's look at the bounds of each access.
+  // There are 9 accesses in this Stmt, so this is exhaustive, we wont do this
+  // much.
+  auto history = analyzer.getHistory();
+  ASSERT_EQ(history.size(), 10);
+  const Var* aVar = a.node()->base_handle();
+  const Var* bVar = b.node()->base_handle();
+  const Var* cVar = c.node()->base_handle();
+
+  // The first access is the input A.
+  ASSERT_EQ(history[0]->type(), AccessType::Input);
+  ASSERT_EQ(history[0]->var(), aVar);
+  // It has the bounds of the producing Input.
+  ASSERT_TRUE(EQ(history[0]->bounds(), {CB(0, 9)}));
+  // sanity check the input we retrieved earlier matches.
+  ASSERT_EQ(history[0], input);
+
+  // The second access is the load of A in the first loop.
+  ASSERT_EQ(history[1]->type(), AccessType::Load);
+  ASSERT_EQ(history[1]->var(), aVar);
+  // It has the bounds of the loop, i.e. start == 1.
+  ASSERT_TRUE(EQ(history[1]->bounds(), {CB(1, 9)}));
+  // It reads from A, so it should have a dependency on the last write to this
+  // range - with is the input.
+  ASSERT_EQ(history[1]->dependencies().size(), 1);
+  ASSERT_TRUE(history[1]->hasDependency(history[0]));
+
+  // The third access is the store into B in the first loop.
+  ASSERT_EQ(history[2]->type(), AccessType::Store);
+  ASSERT_EQ(history[2]->var(), bVar);
+  // It also has the bounds of the loop, i.e. start == 1.
+  ASSERT_TRUE(EQ(history[2]->bounds(), {CB(1, 9)}));
+  // The previous load is in its RHS, so it depends on it.
+  ASSERT_EQ(history[2]->dependencies().size(), 1);
+  ASSERT_TRUE(history[2]->hasDependency(history[1]));
+
+  // The third access is the load from B in the second loop.
+  ASSERT_EQ(history[3]->type(), AccessType::Load);
+  ASSERT_EQ(history[3]->var(), bVar);
+  // It has the bounds of the second loop, i.e. >= 1 < 9.
+  ASSERT_TRUE(EQ(history[3]->bounds(), {CB(1, 8)}));
+  // It reads from B in a smaller range, so should depend on the previous
+  // store.
+  ASSERT_EQ(history[3]->dependencies().size(), 1);
+  ASSERT_TRUE(history[3]->hasDependency(history[2]));
+
+  // The fourth: the store to B in the second loop.
+  ASSERT_EQ(history[4]->type(), AccessType::Store);
+  ASSERT_EQ(history[4]->var(), bVar);
+  // It also has the bounds of the second loop.
+  ASSERT_TRUE(EQ(history[4]->bounds(), {CB(1, 8)}));
+  // The previous load is in its RHS, so it depends on it as before.
+  ASSERT_EQ(history[4]->dependencies().size(), 1);
+  ASSERT_TRUE(history[4]->hasDependency(history[3]));
+
+  // The fifth access is the load is from the 3rd loop, and skips previous B
+  // accesses.
+  ASSERT_EQ(history[5]->type(), AccessType::Load);
+  ASSERT_EQ(history[5]->var(), aVar);
+  // It has the bounds of the third loop: >= 3 < 4.
+  ASSERT_TRUE(EQ(history[5]->bounds(), {CB(3, 3)}));
+  // It depends on the last thing to write to A, which is the A input.
+  ASSERT_EQ(history[5]->dependencies().size(), 1);
+  ASSERT_TRUE(history[5]->hasDependency(history[0]));
+
+  // Sixth: the store into the output C.
+  ASSERT_EQ(history[6]->type(), AccessType::Store);
+  ASSERT_EQ(history[6]->var(), cVar);
+  // It also has the bounds of the third loop.
+  ASSERT_TRUE(EQ(history[6]->bounds(), {CB(3, 3)}));
+  // The previous load is in its RHS, so it depends on it as always.
+  ASSERT_EQ(history[6]->dependencies().size(), 1);
+  ASSERT_TRUE(history[6]->hasDependency(history[5]));
+
+  // The seventh access is the load of B in the fourth loop.
+  ASSERT_EQ(history[7]->type(), AccessType::Load);
+  ASSERT_EQ(history[7]->var(), bVar);
+  // It has the bounds of the final loop, >= 0 < 10
+  ASSERT_TRUE(EQ(history[7]->bounds(), {CB(0, 9)}));
+  // The bounds of this read are larger than the bounds of the previous write,
+  // so it depends on both previous Stores to B.
+  ASSERT_EQ(history[7]->dependencies().size(), 2);
+  ASSERT_TRUE(history[7]->hasDependency(history[2]));
+  ASSERT_TRUE(history[7]->hasDependency(history[4]));
+
+  // Eight: the final store into the output C.
+  ASSERT_EQ(history[8]->type(), AccessType::Store);
+  ASSERT_EQ(history[8]->var(), cVar);
+  // It also has the bounds of the final loop.
+  ASSERT_TRUE(EQ(history[8]->bounds(), {CB(0, 9)}));
+  // The previous load is in its RHS, so it depends on it as always.
+  ASSERT_EQ(history[8]->dependencies().size(), 1);
+  ASSERT_TRUE(history[8]->hasDependency(history[7]));
+
+  // The last access represents the output Buf.
+  ASSERT_EQ(history[9]->type(), AccessType::Output);
+  ASSERT_EQ(history[9]->var(), cVar);
+  // It has the bounds of the output Buf.
+  ASSERT_TRUE(EQ(history[9]->bounds(), {CB(0, 9)}));
+  // sanity check the input we retrieved earlier matches.
+  ASSERT_EQ(history[9], output);
+  // It depends on the last write to C only.
+  ASSERT_EQ(history[9]->dependencies().size(), 1);
+  ASSERT_TRUE(history[9]->hasDependency(history[8]));
+}
+
+// Verify that we can still infer bounds when the loop var is offset.
+void testMemDependencyCheckerLoopBoundsIndexShift() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  VarHandle x("x", kInt);
+
+  using namespace analysis;
+
+  MemDependencyChecker analyzer({a}, {b});
+
+  // This enables using the execution order of the loops to determine if some
+  // loops are self dependent or not.
+  analyzer.allowLoopExecutionOrderAnalysis();
+
+  /*
+   * for (int x = 1; x < 10; x++) {
+   *   A[x] = A[x - 1];
+   * }
+   * for (int x = 0; x < 9; x++) {
+   *   A[x] = A[x + 1];
+   * }
+   * for (int x = 0; x < 9; x++) {
+   *   A[9 - x] = A[8 - x];
+   * }
+   * for (int x = 0; x < 10; x++) {
+   *   A[x] = A[9 - x];
+   * }
+   * for (int x = 0; x < 10; x++) {
+   *   B[x] = A[x];
+   * }
+   */
+
+  Stmt* stmt = Block::make(
+      {For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1}, 1), 1)),
+       For::make(x, 0, 9, Store::make(a, {x}, Load::make(a, {x + 1}, 1), 1)),
+       For::make(
+           x,
+           0,
+           9,
+           Store::make(
+               a,
+               {ExprHandle(9) - x},
+               Load::make(a, {ExprHandle(8) - x}, 1),
+               1)),
+       For::make(
+           x,
+           0,
+           10,
+           Store::make(a, {x}, Load::make(a, {ExprHandle(9) - x}, 1), 1)),
+       For::make(x, 0, 10, Store::make(b, {x}, Load::make(a, {x}, 1), 1))});
+
+  stmt->accept(&analyzer);
+
+  // Sanity check output depends on Input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+  auto CB = [](int s, int e) { return Bound(new IntImm(s), new IntImm(e)); };
+  auto EQ = [](const IndexBounds& x, const IndexBounds& y) {
+    return indexBoundsEquals(x, y);
+  };
+
+  /*  0. Input: A[(0, 9)] - dependents: 1
+   *  1. Load: A[(0, 8)] - depends on: 0 2  - dependents: 2
+   *  2. Store: A[(1, 9)] - depends on: 1  - dependents: 1 3
+   *  3. Load: A[(1, 9)] - depends on: 2  - dependents: 4
+   *  4. Store: A[(0, 8)] - depends on: 3  - dependents: 5 7
+   *  5. Load: A[(0, 8)] - depends on: 4  - dependents: 6
+   *  6. Store: A[(1, 9)] - depends on: 5  - dependents: 7
+   *  7. Load: A[(0, 9)] - depends on: 4 6 8  - dependents: 8
+   *  8. Store: A[(0, 9)] - depends on: 7  - dependents: 7 9
+   *  9. Load: A[(0, 9)] - depends on: 8  - dependents: 10
+   *  10. Store: B[(0, 9)] - depends on: 9  - dependents: 11
+   *  11. Output: B[(0, 9)] - depends on: 10
+   */
+
+  // Now let's look at the bounds of each access.
+  auto history = analyzer.getHistory();
+  ASSERT_EQ(history.size(), 12);
+  const Var* aVar = a.node()->base_handle();
+  const Var* bVar = b.node()->base_handle();
+
+  // The first access is the input A.
+  ASSERT_EQ(history[0]->type(), AccessType::Input);
+  ASSERT_EQ(history[0]->var(), aVar);
+  // It has the bounds of the producing Input.
+  ASSERT_TRUE(EQ(history[0]->bounds(), {CB(0, 9)}));
+
+  // The second access is the load A[x-1].
+  ASSERT_EQ(history[1]->type(), AccessType::Load);
+  ASSERT_EQ(history[1]->var(), aVar);
+  // It has the bounds of the loop modified by the offset of each index, in
+  // this case -1.
+  ASSERT_TRUE(EQ(history[1]->bounds(), {CB(0, 8)}));
+  // It depends on the input, but also the store in the same loop, since
+  // different interations of the loop depend on each other.
+  ASSERT_EQ(history[1]->dependencies().size(), 2);
+  ASSERT_TRUE(history[1]->hasDependency(history[0]));
+  ASSERT_TRUE(history[1]->hasDependency(history[2]));
+
+  // The third access is the Store to A[x] in the first loop.
+  ASSERT_EQ(history[2]->type(), AccessType::Store);
+  ASSERT_EQ(history[2]->var(), aVar);
+  // It has no offset on x, so should have the same bounds as the loop.
+  ASSERT_TRUE(EQ(history[2]->bounds(), {CB(1, 9)}));
+
+  // The fourth access is the load A[x+1] in the second loop.
+  ASSERT_EQ(history[3]->type(), AccessType::Load);
+  ASSERT_EQ(history[3]->var(), aVar);
+  // It has the bounds of the loop (0 <= x < 9) modified by the offset of each
+  // index, in this case 1.
+  ASSERT_TRUE(EQ(history[3]->bounds(), {CB(1, 9)}));
+  // This load totally overlaps the previous write to A, so it depends only on
+  // it and not the input.
+  ASSERT_EQ(history[3]->dependencies().size(), 1);
+  ASSERT_TRUE(history[3]->hasDependency(history[2]));
+
+  // The fifth access is the store to A[x] in the second loop.
+  ASSERT_EQ(history[4]->type(), AccessType::Store);
+  ASSERT_EQ(history[4]->var(), aVar);
+  // It has no offset on x, so should have the same bounds as the loop.
+  ASSERT_TRUE(EQ(history[4]->bounds(), {CB(0, 8)}));
+
+  // The sixth access is the load to A[8 - x] in the third loop.
+  ASSERT_EQ(history[5]->type(), AccessType::Load);
+  ASSERT_EQ(history[5]->var(), aVar);
+  // It has the bounds of the loop (0 <= x < 9) modified by the offset of each
+  // index, in this case 8 - x.
+  // This access has a negative stride, which will be normalized.
+  ASSERT_TRUE(EQ(history[5]->bounds(), {CB(0, 8)}));
+  // This load totally overlaps the most recent write to A, so it depends only
+  // on it and not the input or the first write to A.
+  ASSERT_EQ(history[5]->dependencies().size(), 1);
+  ASSERT_TRUE(history[5]->hasDependency(history[4]));
+
+  // The seventh access is the store to A[9 - x] in the third loop.
+  ASSERT_EQ(history[6]->type(), AccessType::Store);
+  ASSERT_EQ(history[6]->var(), aVar);
+  // This store has a negative stride on it's indices, but is notmalized
+  // internally.
+  ASSERT_TRUE(EQ(history[6]->bounds(), {CB(1, 9)}));
+
+  // The eighth access is the load A[9-x] in the second loop.
+  ASSERT_EQ(history[7]->type(), AccessType::Load);
+  ASSERT_EQ(history[7]->var(), aVar);
+  // It has the bounds of the loop (0 <= x < 9), modified by the offset 9 - x,
+  // which esstentially traverses the loop backwards.
+  ASSERT_TRUE(EQ(history[7]->bounds(), {CB(0, 9)}));
+  // This Load has three write dependencies:
+  ASSERT_EQ(history[7]->dependencies().size(), 3);
+  //  * The previous store (#6) for elements 1-9
+  ASSERT_TRUE(history[7]->hasDependency(history[6]));
+  //  * An earlier store (#4) covering element 0
+  ASSERT_TRUE(history[7]->hasDependency(history[4]));
+  //  * A future store inside this loop, since this loop modifies the buffer
+  //  in a non distinct way (due to the load and store having different access
+  //  strides).
+  ASSERT_TRUE(history[7]->hasDependency(history[8]));
+
+  // The ninth access is the store to A[x] in the fourth loop.
+  ASSERT_EQ(history[8]->type(), AccessType::Store);
+  ASSERT_EQ(history[8]->var(), aVar);
+  // This store has a negative stride on it's indices, but is notmalized
+  // internally.
+  ASSERT_TRUE(EQ(history[8]->bounds(), {CB(0, 9)}));
+
+  // The tenth and 11th acceses are the copy from A[x] to B[x].
+  ASSERT_EQ(history[9]->type(), AccessType::Load);
+  ASSERT_EQ(history[9]->var(), aVar);
+  ASSERT_EQ(history[10]->type(), AccessType::Store);
+  ASSERT_EQ(history[10]->var(), bVar);
+
+  // The last access represents the output Buf.
+  ASSERT_EQ(history[11]->type(), AccessType::Output);
+  ASSERT_EQ(history[11]->var(), bVar);
+  // It has the bounds of the output Buf.
+  ASSERT_TRUE(EQ(history[11]->bounds(), {CB(0, 9)}));
+  // It depends on the last write to B only.
+  ASSERT_EQ(history[11]->dependencies().size(), 1);
+  ASSERT_TRUE(history[11]->hasDependency(history[10]));
+
+  // ok that's enough of that.
+}
+
+// Check many different cases of loop self dependency - when a load within a
+// loop is dependent on a Store later in the same loop but in different
+// iteration. This is affected by whether or not we can trust the execution
+// order of the loop.
+void testMemDependencyCheckerLoopSelfDependency() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {5}, kInt);
+  BufHandle b("B", {5}, kInt);
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  VarHandle z("z", kInt);
+
+  using namespace analysis;
+
+  // This check assumes that the Stmt has a single Store with a single Load on
+  // the RHS.
+  auto isSelfDependent =
+      [](const std::deque<std::shared_ptr<AccessInfo>>& history) -> bool {
+    return history.front()->hasDependency(history.back());
+  };
+
+  {
+    /* for (int y = 0; y < 10; y++) {
+     *   A[y] = (A[y]) + 1;
+     * } */
+
+    // Not self dependent since all loop iterations use a different y.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        y,
+        0,
+        10,
+        Block::make(
+            {Store::make(a, {y}, Add::make(Load::make(a, {y}, 1), 1), 1)}));
+
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int y = 0; y < 10; y++) {
+     *   A[y + 1] = (A[y + 1]) + 1;
+     * }
+     */
+
+    // Not self dependent due to different y (with offset).
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        y,
+        0,
+        10,
+        Block::make({Store::make(
+            a, {y + 1}, Add::make(Load::make(a, {y + 1}, 1), 1), 1)}));
+
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[0] = (A[0]) + x;
+     * }
+     */
+
+    // Is self dependent since all loops use a common constant element of A.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x,
+        0,
+        10,
+        Block::make(
+            {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[0] = (B[0]) + x;
+     * }
+     */
+
+    // Is not self dependent beacause there is no store to the buffer that is
+    // read.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x,
+        0,
+        10,
+        Block::make(
+            {Store::make(a, {0}, Add::make(Load::make(b, {0}, 1), x), 1)}));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[y] = (A[y]) + x;
+     * }
+     */
+
+    // Is self dependent since all loops use a common symbolic element of A.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x,
+        0,
+        10,
+        Block::make(
+            {Store::make(a, {y}, Add::make(Load::make(a, {y}, 1), x), 1)}));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x] = A[x + 1];
+     * }
+     */
+
+    // In this case it depends if we are considering execution order.
+
+    MemDependencyChecker analyzer;
+
+    Stmt* stmt =
+        For::make(x, 0, 10, Store::make(a, {x}, Load::make(a, {x + 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    // With analysis of order disabled, this is self dependent since the read
+    // from X+1 and the write to X+1 could be in reverse order.
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x] = A[x + 1];
+     * }
+     */
+
+    MemDependencyChecker analyzer;
+    analyzer.allowLoopExecutionOrderAnalysis();
+
+    Stmt* stmt =
+        For::make(x, 0, 10, Store::make(a, {x}, Load::make(a, {x + 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    // If order analysis is enabled, this is not dependent since the read for
+    // each element occurs before the write to that element.
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 1; x < 10; x++) {
+     *   A[x] = A[x - 1];
+     * }
+     */
+
+    MemDependencyChecker analyzer;
+
+    Stmt* stmt =
+        For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 1; x < 10; x++) {
+     *   A[x] = A[x - 1];
+     * }
+     */
+
+    MemDependencyChecker analyzer;
+    analyzer.allowLoopExecutionOrderAnalysis();
+
+    Stmt* stmt =
+        For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    // In this case, even with order analysis the Load is dependent on the
+    // Store, since the write to X occurs before the read from X.
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 9; x++) {
+     *   A[9 - x] = A[8 - x];
+     * }
+     */
+
+    // Still works if the execution order is reversed, so long as the read
+    // comes before the write.
+
+    MemDependencyChecker analyzer;
+    analyzer.allowLoopExecutionOrderAnalysis();
+
+    Stmt* stmt = For::make(
+        x,
+        3,
+        10,
+        Store::make(
+            a, {ExprHandle(9) - x}, Load::make(a, {ExprHandle(8) - x}, 1), 1));
+    stmt->accept(&analyzer);
+
+    // However here was can determine the A store is earlier in the order than
+    // the load.
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 9; x++) {
+     *   A[8 - x] = A[9 - x];
+     * }
+     */
+
+    // But not if it doesn't.
+
+    MemDependencyChecker analyzer;
+    analyzer.allowLoopExecutionOrderAnalysis();
+
+    Stmt* stmt = For::make(
+        x,
+        3,
+        10,
+        Store::make(
+            a, {ExprHandle(8) - x}, Load::make(a, {ExprHandle(9) - x}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 9; x++) {
+     *   A[9 - x] = A[8 - x];
+     * }
+     */
+
+    // And not if we're not relying on execution order.
+
+    MemDependencyChecker analyzer;
+
+    Stmt* stmt = For::make(
+        x,
+        3,
+        10,
+        Store::make(
+            a, {ExprHandle(9) - x}, Load::make(a, {ExprHandle(8) - x}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 3; x < 10; x++) {
+     *   A[x - 2] = A[x - 1];
+     * }
+     */
+
+    // Forward order but negative indices.
+
+    MemDependencyChecker analyzer;
+    analyzer.allowLoopExecutionOrderAnalysis();
+
+    Stmt* stmt = For::make(
+        x, 3, 10, Store::make(a, {x - 2}, Load::make(a, {x - 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    // However here was can determine the A store is earlier in the order than
+    // the load.
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 2];
+     * }
+     */
+
+    // With an access stride.
+
+    MemDependencyChecker analyzer;
+    // Execution order doesn't matter since the read and the write are totally
+    // distinct.
+
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 2}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 2 + 1];
+     * }
+     */
+
+    // Here we can use the common stride of the accesses to determine they are
+    // distinct.
+    // Note, this is the only place (loop self depedency) we use this stride
+    // to avoid unnecessary depedence.
+
+    MemDependencyChecker analyzer;
+    // Execution order doesn't matter since the read and the write are totally
+    // distinct.
+
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 2 + 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 2 - 1];
+     * }
+     */
+
+    // same if the read is behind the write so long as they are distinct.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 1, 10, Store::make(a, {x * 2}, Load::make(a, {x * 2 - 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 2 + 2];
+     * }
+     */
+
+    // But not if the offset is in the stride.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 2 + 2}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 2 - 2];
+     * }
+     */
+
+    // Works with negative offsets too.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 1, 10, Store::make(a, {x * 2}, Load::make(a, {x * 2 - 2}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 2 + 7];
+     * }
+     */
+
+    // Detects accesses are distinct when offset is large but not a multiple
+    // of stride.
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 2 + 7}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 2 + 4];
+     * }
+     */
+
+    // Works with offsets which are multiples of the stride.
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 2 + 4}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 6] = A[x * 6 + 5];
+     * }
+     */
+
+    // detects accesses are distinct with large strides when the offset is
+    // within.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 6}, Load::make(a, {x * 6 + 5}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 6];
+     * }
+     */
+
+    // detects accesses are overlapping when stride is different but a
+    // multiple.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 6}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 4] = A[x * 2];
+     * }
+     */
+
+    // still works when the read axis is the smaller stride.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 4}, Load::make(a, {x * 2}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 6 + 1];
+     * }
+     */
+
+    // detects accesses are distinct when stride is different but a multiple
+    // and there is an offset.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 6 + 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 6 + 4];
+     * }
+     */
+
+    // The smaller stride determines whether there is overlap.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 6 + 4}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2 + 3] = A[x * 6];
+     * }
+     */
+
+    // The smaller stride determines whether there is overlap, not the larger.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2 + 3}, Load::make(a, {x * 6}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[x * 3 + 1];
+     * }
+     */
+
+    // If they have strides with no common muliple > 1, they overlap.
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x * 2}, Load::make(a, {x * 3 + 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x] = A[x + 10];
+     * }
+     */
+
+    // If the offset is greater than the size of the loop, they can't overlap.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt =
+        For::make(x, 0, 10, Store::make(a, {x}, Load::make(a, {x + 10}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x] = A[9 - x];
+     * }
+     */
+
+    // If they have different execution orders they may overlap.
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x,
+        0,
+        10,
+        Store::make(a, {x}, Load::make(a, {ExprHandle(9) - x}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x * 2] = A[19 - x * 2];
+     * }
+     */
+
+    // Or they may not, depending on their start offset and strides.
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x,
+        0,
+        10,
+        Store::make(a, {x * 2}, Load::make(a, {ExprHandle(19) - x * 2}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x / 2] = A[x / 2];
+     * }
+     */
+
+    // If the stride is not monotonic, they overlap.
+
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x / 2}, Load::make(a, {x / 2}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x / 2] = A[x / 2] + 1;
+     * }
+     */
+
+    // If the stride is not monotonic, they overlap - even with an offset.
+    MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x, 0, 10, Store::make(a, {x / 2}, Load::make(a, {x / 2 + 1}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   A[x % 2] = A[x % 2];
+     * }
+     */
+
+    // Mod too...
+
+    analysis::MemDependencyChecker analyzer;
+    Stmt* stmt = For::make(
+        x,
+        0,
+        10,
+        Store::make(
+            a, {Mod::make(x, 2)}, Load::make(a, {Mod::make(x, 2)}, 1), 1));
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+  }
+
+  {
+    /* for (int x = y; x < z; x++) {
+     *   A[x] = A[x + 1];
+     * }
+     */
+
+    // Still works with symbolic loop extents.
+
+    {
+      MemDependencyChecker analyzer;
+      Stmt* stmt =
+          For::make(x, y, z, Store::make(a, {x}, Load::make(a, {x + 1}, 1), 1));
+      stmt->accept(&analyzer);
+
+      ASSERT_TRUE(isSelfDependent(analyzer.getHistory()));
+    }
+
+    {
+      MemDependencyChecker analyzer;
+      analyzer.allowLoopExecutionOrderAnalysis();
+      Stmt* stmt =
+          For::make(x, y, z, Store::make(a, {x}, Load::make(a, {x + 1}, 1), 1));
+      stmt->accept(&analyzer);
+
+      ASSERT_FALSE(isSelfDependent(analyzer.getHistory()));
+    }
+  }
+}
+
+// Verify that a strided access still works.
+// TODO: actually this only works because of the size of the ranges, revist this
+// test after strided overlap is implemented.
+void testMemDependencyCheckerLoopDistinctStrides() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {20}, kInt);
+  BufHandle b("B", {20}, kInt);
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+
+  using namespace analysis;
+  MemDependencyChecker analyzer({a.node()}, {b.node()});
+  Stmt* stmt = Block::make(
+      {For::make(
+           x,
+           0,
+           10,
+           Store::make(b, {x * 2 + 1}, Load::make(a, {x * 2 + 1}, 1), 1)),
+       For::make(
+           x, 0, 10, Store::make(b, {x * 2}, Load::make(a, {x * 2}, 1), 1))
+
+      });
+  stmt->accept(&analyzer);
+
+  // Sanity check output depends on input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+  // Output has 2 dependencies... the store in each loop.
+  auto outputAccess = analyzer.output(b.node());
+  ASSERT_EQ(outputAccess->dependencies().size(), 2);
+}
+
+/* TODO(nickg) - this test will fail due to the lack of stride math in Bound
+void testMemDependencyCheckerLoopDistinctStrides() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {20}, kInt);
+  BufHandle b("B", {20}, kInt);
+  BufHandle c("C", {10}, kInt);
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+
+  {
+    analysis::MemDependencyChecker analyzer({a.node()}, {c.node()});
+    Stmt* stmt = Block::make(
+        {For::make(
+             x,
+             0,
+             10,
+             Store::make(b, {x * 2 + 1}, Load::make(a, {x * 2 + 1}, 1), 1)),
+         For::make(
+             x, 0, 10, Store::make(b, {x * 2}, Load::make(a, {x * 2}, 1), 1)),
+         For::make(x, 0, 10, Store::make(c, {x}, Load::make(b, {x}, 1), 1))
+
+        });
+    stmt->accept(&analyzer);
+
+    std::cout << *stmt << "\n";
+    for (auto& wi : analyzer.getHistory()) {
+      wi->print();
+    }
+  }
+}*/
+
+// analysis on Stmts using Cond.
+void testMemDependencyCheckerLoopBoundsCond() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  BufHandle c("C", {10}, kInt);
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+
+  using namespace analysis;
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[x];
+     * }
+     * if (y<5 ? 1 : 0) {
+     *   C[0] = (B[0]) + 1;
+     * } else {
+     *   C[0] = (B[1]) + 1;
+     * }
+     */
+
+    // Future usages may depend on accesses in both branches of a condition.
+
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make(
+        {For::make(x, 0, 10, Store::make(c, {x}, Load::make(a, {x}, 1), 1)),
+         Cond::make(
+             CompareSelect::make(y, 5, CompareSelectOperation::kLT),
+             Store::make(c, {0}, Add::make(Load::make(b, {0}, 1), 1), 1),
+             Store::make(c, {0}, Add::make(Load::make(b, {1}, 1), 1), 1))});
+
+    stmt->accept(&analyzer);
+
+    // Output C should have 3 dependencies, each of the three stores.
+    auto outputAccess = analyzer.output(c.node());
+    ASSERT_NE(outputAccess, nullptr);
+    ASSERT_EQ(outputAccess->dependencies().size(), 3);
+
+    // C depends indirectly on A and B.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[x];
+     * }
+     * if (y<5 ? 1 : 0) {
+     *   for (int x = 0; x < 10; x++) {
+     *     C[x] = B[x];
+     *   }
+     * } else {
+     *   for (int x = 0; x < 10; x++) {
+     *     C[x] = (B[x]) + 1;
+     *   }
+     * }
+     */
+
+    // Future usages may depend on accesses in both branches of a condition.
+
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make(
+        {For::make(x, 0, 10, Store::make(c, {x}, Load::make(a, {x}, 1), 1)),
+         Cond::make(
+             CompareSelect::make(y, 5, CompareSelectOperation::kLT),
+             For::make(x, 0, 10, Store::make(c, {x}, Load::make(b, {x}, 1), 1)),
+             For::make(
+                 x,
+                 0,
+                 10,
+                 Store::make(
+                     c, {x}, Add::make(Load::make(b, {x}, 1), 1), 1)))});
+
+    stmt->accept(&analyzer);
+
+    // Output C should have 3 dependencies, each of the three stores.
+    auto outputAccess = analyzer.output(c.node());
+    ASSERT_NE(outputAccess, nullptr);
+    ASSERT_EQ(outputAccess->dependencies().size(), 3);
+
+    // TODO(nickg): actually since the true and false branch cover the total
+    // range of the first store this should have 2 dependencies, but we don't
+    // do that yet.
+
+    // C depends indirectly on A and B.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[x];
+     * }
+     * if (y<5 ? 1 : 0) {
+     *   for (int x = 0; x < 10; x++) {
+     *     C[x] = (B[x]) + 1;
+     *   }
+     * }
+     */
+
+    // Only has true branch.
+
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make(
+        {For::make(x, 0, 10, Store::make(c, {x}, Load::make(a, {x}, 1), 1)),
+         Cond::make(
+             CompareSelect::make(y, 5, CompareSelectOperation::kLT),
+             For::make(
+                 x,
+                 0,
+                 10,
+                 Store::make(c, {x}, Add::make(Load::make(b, {x}, 1), 1), 1)),
+             nullptr)});
+
+    stmt->accept(&analyzer);
+
+    // Output C should have 3 dependencies, each of the three stores.
+    auto outputAccess = analyzer.output(c.node());
+    ASSERT_NE(outputAccess, nullptr);
+    ASSERT_EQ(outputAccess->dependencies().size(), 2);
+
+    // C depends indirectly on A and B.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[x];
+     * }
+     * if (y<5 ? 1 : 0) {
+     * } else {
+     *   for (int x = 0; x < 10; x++) {
+     *     C[x] = (B[x]) + 1;
+     *   }
+     * }
+     */
+
+    // Only has false branch.
+
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make(
+        {For::make(x, 0, 10, Store::make(c, {x}, Load::make(a, {x}, 1), 1)),
+         Cond::make(
+             CompareSelect::make(y, 5, CompareSelectOperation::kLT),
+             nullptr,
+             For::make(
+                 x,
+                 0,
+                 10,
+                 Store::make(
+                     c, {x}, Add::make(Load::make(b, {x}, 1), 1), 1)))});
+
+    stmt->accept(&analyzer);
+
+    // Output C should have 3 dependencies, each of the three stores.
+    auto outputAccess = analyzer.output(c.node());
+    ASSERT_NE(outputAccess, nullptr);
+    ASSERT_EQ(outputAccess->dependencies().size(), 2);
+
+    // C depends indirectly on A and B.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[x];
+     * }
+     * if (C[0]<5 ? 1 : 0) {
+     *   C[0] = 5;
+     * }
+     */
+
+    // Cond's Condition depends on a previous access.
+
+    MemDependencyChecker analyzer({a}, {c});
+    Store* initStore = Store::make(c, {x}, Load::make(a, {x}, 1), 1);
+    ExprHandle conditionalLoad = Load::make(c, {0}, 1);
+    Stmt* stmt =
+        Block::make({For::make(x, 0, 10, initStore),
+                     Cond::make(
+                         CompareSelect::make(
+                             conditionalLoad, 5, CompareSelectOperation::kLT),
+                         Store::make(c, {0}, 5, 1),
+                         nullptr)});
+
+    stmt->accept(&analyzer);
+
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+
+    ASSERT_TRUE(analyzer.dependsDirectly(conditionalLoad.node(), initStore));
+    ASSERT_FALSE(analyzer.dependsDirectly(conditionalLoad.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(conditionalLoad.node(), a.node()));
+  }
+}
+
+// Stmts using IfThenElse.
+void testMemDependencyCheckerIfThenElse() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  BufHandle c("C", {10}, kInt);
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+
+  using namespace analysis;
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[x];
+     * }
+     * C[0] = (y < 5 ? (B[0]) + 1 : (B[1]) + 1;
+     */
+
+    // Future usages may depend on accesses in both branches of a condition.
+
+    MemDependencyChecker analyzer({a, b}, {c});
+    Store* ifStore = Store::make(
+        c,
+        {0},
+        IfThenElse::make(
+            CompareSelect::make(y, 5, CompareSelectOperation::kLT),
+            Add::make(Load::make(b, {0}, 1), 1),
+            Add::make(Load::make(b, {1}, 1), 1)),
+        1);
+    Stmt* stmt = Block::make(
+        {For::make(x, 0, 10, Store::make(c, {x}, Load::make(a, {x}, 1), 1)),
+         ifStore});
+
+    stmt->accept(&analyzer);
+
+    // Output C should have 2 dependencies, each of the two stores.
+    auto outputAccess = analyzer.output(c.node());
+    ASSERT_NE(outputAccess, nullptr);
+    ASSERT_EQ(outputAccess->dependencies().size(), 2);
+
+    // Now we need to check the Store containing the IfThenElse.
+    auto ifStoreAccess = analyzer.accessFor(ifStore);
+
+    // It should have 2 dependencies.
+    ASSERT_EQ(ifStoreAccess->dependencies().size(), 2);
+
+    // C depends indirectly on A and B.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[x];
+     * }
+     * C[0] = (y < 5 ? (B[0]) + 1 : 42;
+     */
+
+    // If the load appears in only one side of an IfThenElse the output may be
+    // dependent on it.
+
+    MemDependencyChecker analyzer({a, b}, {c});
+    Store* ifStore = Store::make(
+        c,
+        {0},
+        IfThenElse::make(
+            CompareSelect::make(y, 5, CompareSelectOperation::kLT),
+            Add::make(Load::make(b, {0}, 1), 1),
+            42),
+        1);
+    Stmt* stmt = Block::make(
+        {For::make(x, 0, 10, Store::make(c, {x}, Load::make(a, {x}, 1), 1)),
+         ifStore});
+
+    stmt->accept(&analyzer);
+
+    // C depends indirectly on A and B.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = (x < 5 ? B[x] : A[x];
+     * }
+     */
+
+    // In this case C is dependent on both A and B.
+
+    // TODO: in cases like this it would be possible to split the range of B
+    // into two bounds, one dependent on A and one depenent on B. We'd need to
+    // examine conditions relative to previously encountered loop variables. I'm
+    // uncertain if this would be helpful.
+
+    MemDependencyChecker analyzer({a, b}, {c});
+    Store* ifStore = Store::make(
+        c,
+        {0},
+        IfThenElse::make(
+            CompareSelect::make(y, 5, CompareSelectOperation::kLT),
+            Load::make(b, {x}, 1),
+            Load::make(a, {x}, 1)),
+        1);
+    Stmt* stmt = Block::make({For::make(x, 0, 10, ifStore)});
+
+    stmt->accept(&analyzer);
+
+    // C depends indirectly on A and B.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+  }
+}
+
+// Cutting a loop with single elem writes
+void testMemDependencyCheckerCutLoop() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {10}, kInt);
+  BufHandle b("B", {10}, kInt);
+  VarHandle x("x", kInt);
+
+  using namespace analysis;
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   B[x] = A[x];
+     * }
+     * B[5] = 100;
+     */
+
+    // Cutting a loop with single element writes.
+
+    MemDependencyChecker analyzer({a}, {b});
+    Stmt* stmt = Block::make(
+        {For::make(x, 0, 10, Store::make(b, {x}, Load::make(a, {x}, 1), 1)),
+         Store::make(b, {5}, 100, 1)});
+
+    stmt->accept(&analyzer);
+
+    // Output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+    // Output has 2 depdenencies.
+    auto outputAccess = analyzer.output(b.node());
+    ASSERT_NE(outputAccess, nullptr);
+    ASSERT_EQ(outputAccess->dependencies().size(), 2);
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   B[x] = A[x];
+     * }
+     * for (int x = 4; x < 7; x++) {
+     *   B[x] = B[x] + 3;
+     * }
+     * B[5] = 100;
+     * B[6] = 101;
+     * B[7] = 102;
+     */
+
+    // Cutting a loop with a smaller loop but then totally overlap that second
+    // loop with one element writes.
+
+    MemDependencyChecker analyzer({a}, {b});
+    For* firstLoop =
+        For::make(x, 0, 10, Store::make(b, {x}, Load::make(a, {x}, 1), 1));
+    Store* secondStore =
+        Store::make(b, {x}, Add::make(Load::make(b, {x}, 1), 1), 3);
+    For* secondLoop = For::make(x, 4, 7, secondStore);
+
+    Stmt* stmt = Block::make({firstLoop,
+                              secondLoop,
+                              Store::make(b, {4}, 100, 1),
+                              Store::make(b, {5}, 101, 1),
+                              Store::make(b, {6}, 102, 1)});
+
+    stmt->accept(&analyzer);
+
+    // Output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+    // Output has 4 depdenencies.
+    auto outputAccess = analyzer.output(b.node());
+    ASSERT_NE(outputAccess, nullptr);
+    ASSERT_EQ(outputAccess->dependencies().size(), 4);
+
+    // Second loop depends on first loop.
+    ASSERT_TRUE(analyzer.dependsDirectly(secondLoop, firstLoop));
+
+    // Output does not depend on second loop or store.
+    ASSERT_FALSE(analyzer.dependsIndirectly(b.node(), secondLoop));
+    ASSERT_FALSE(analyzer.dependsIndirectly(b.node(), secondStore));
+  }
+}
+
+// Dynamic shapes (load in indices).
+void testMemDependencyCheckerDynamicShapes() {
+  KernelScope kernel_scope;
+  BufHandle a("A", {100}, kInt);
+  BufHandle b("B", {100}, kInt);
+  BufHandle c("C", {100}, kInt);
+  VarHandle x("x", kInt);
+
+  using namespace analysis;
+
+  auto CB = [](ExprHandle s, ExprHandle e) {
+    return Bound(s.node(), e.node());
+  };
+
+  auto EQ = [](const IndexBounds& x, const IndexBounds& y) {
+    return indexBoundsEquals(x, y);
+  };
+
+  {
+    /* for (int x = 0; x < B[0]; x++) {
+     *   C[x] = A[x];
+     * }
+     */
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        Load::make(b, {0}, 1),
+        Store::make(c, {x}, Load::make(a, {x}, 1), 1))});
+
+    stmt->accept(&analyzer);
+
+    /*  0. Input: B[(0, 99)] - dependents: 2
+     *  1. Input: A[(0, 99)] - dependents: 3
+     *  2. Load: B[(0, 0)] - depends on: 0  - dependents: 3 4
+     *  3. Load: A[(0, (B[0]) - 1)] - depends on: 1 2  - dependents: 4
+     *  4. Store: C[(0, (B[0]) - 1)] - depends on: 2 3  - dependents: 5
+     *  5. Output: C[(0, 99)] - depends on: 4
+     */
+
+    // Output dependent on A input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    // Also dependent on B input to determine the size of the region written.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 6);
+
+    // The accesses in the loop depend on the load in the stop condition.
+    ASSERT_TRUE(history[4]->hasDependency(history[2]));
+    ASSERT_TRUE(history[3]->hasDependency(history[2]));
+
+    // Make a load from B to compare against.
+    ExprHandle loadFromB = Load::make(b, {0}, 1);
+
+    ASSERT_TRUE(EQ(history[3]->bounds(), {CB(0, loadFromB - 1)}));
+    ASSERT_TRUE(EQ(history[4]->bounds(), {CB(0, loadFromB - 1)}));
+  }
+
+  {
+    /* for (int x = B[0]; x < B[1]; x++) {
+     *   C[x] = A[x];
+     * }
+     */
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        Load::make(b, {0}, 1),
+        Load::make(b, {1}, 1),
+        Store::make(c, {x}, Load::make(a, {x}, 1), 1))});
+
+    stmt->accept(&analyzer);
+
+    /*  0. Input: B[(0, 99)] - dependents: 2 3
+     *  1. Input: A[(0, 99)] - dependents: 4
+     *  2. Load: B[(0, 0)] - depends on: 0  - dependents: 4 5
+     *  3. Load: B[(1, 1)] - depends on: 0  - dependents: 4 5
+     *  4. Load: A[(B[0], (B[1]) - 1)] - depends on: 1 2 3  - dependents: 5
+     *  5. Store: C[(B[0], (B[1]) - 1)] - depends on: 2 3 4  - dependents: 6
+     *  6. Output: C[(0, 99)] - depends on: 5
+     */
+
+    // Sanity check output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 7);
+
+    // The accesses in the loop depend on the load in the start condition.
+    ASSERT_TRUE(history[5]->hasDependency(history[2]));
+    ASSERT_TRUE(history[4]->hasDependency(history[2]));
+
+    // also the stop condition.
+    ASSERT_TRUE(history[5]->hasDependency(history[3]));
+    ASSERT_TRUE(history[4]->hasDependency(history[3]));
+
+    // Make loads from B to compare against.
+    ExprHandle loadFromB0 = Load::make(b, {0}, 1);
+    ExprHandle loadFromB1 = Load::make(b, {1}, 1);
+    ASSERT_TRUE(EQ(history[4]->bounds(), {CB(loadFromB0, loadFromB1 - 1)}));
+    ASSERT_TRUE(EQ(history[5]->bounds(), {CB(loadFromB0, loadFromB1 - 1)}));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[x] = A[B[x]];
+     * }
+     */
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        10,
+        Store::make(c, {x}, Load::make(a, {Load::make(b, {x}, 1)}, 1), 1))});
+
+    stmt->accept(&analyzer);
+
+    /*  0. Input: B[(0, 99)] - dependents: 2
+     *  1. Input: A[(0, 99)] - dependents: 3
+     *  2. Load: B[(0, 9)] - depends on: 0  - dependents: 3 4
+     *  3. Load: A[(B[0], B[9])] - depends on: 1 2  - dependents: 4
+     *  4. Store: C[(0, 9)] - depends on: 2 3  - dependents: 5
+     *  5. Output: C[(0, 99)] - depends on: 4
+     */
+
+    // Sanity check output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 6);
+
+    // The store depends on both loads, the load of A depends on the load of B.
+    ASSERT_TRUE(history[4]->hasDependency(history[2]));
+    ASSERT_TRUE(history[4]->hasDependency(history[3]));
+
+    ASSERT_TRUE(history[3]->hasDependency(history[2]));
+
+    // The loads in the indices depend on the relevant input buffer.
+    ASSERT_TRUE(history[3]->hasDependency(history[1]));
+    ASSERT_TRUE(history[2]->hasDependency(history[0]));
+
+    // The load from B has the loop bounds.
+    ASSERT_TRUE(EQ(history[2]->bounds(), {CB(0, 9)}));
+
+    // The load from A has bounds B[0] to B[9].
+    ExprHandle loadFromB0 = Load::make(b, {0}, 1);
+    ExprHandle loadFromB9 = Load::make(b, {9}, 1);
+    ASSERT_TRUE(EQ(history[3]->bounds(), {CB(loadFromB0, loadFromB9)}));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[B[x]] = A[x];
+     * }
+     */
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        10,
+        Store::make(c, {Load::make(b, {x}, 1)}, Load::make(a, {x}, 1), 1))});
+
+    stmt->accept(&analyzer);
+
+    /*  0. Input: B[(0, 99)] - dependents: 3
+     *  1. Input: A[(0, 99)] - dependents: 2
+     *  2. Load: A[(0, 9)] - depends on: 1  - dependents: 4
+     *  3. Load: B[(0, 9)] - depends on: 0  - dependents: 4
+     *  4. Store: C[(B[0], B[9])] - depends on: 2 3  - dependents: 5
+     *  5. Output: C[(0, 99)] - depends on: 4
+     */
+    // Sanity check output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 6);
+
+    // The store depends on both loads, neither load is dependent.
+    ASSERT_TRUE(history[4]->hasDependency(history[2]));
+    ASSERT_TRUE(history[4]->hasDependency(history[3]));
+
+    ASSERT_FALSE(history[3]->hasDependency(history[2]));
+    ASSERT_FALSE(history[2]->hasDependency(history[3]));
+
+    // The loads each depend on their relevant input. (but accesses are in a
+    // different order than the last case).
+    ASSERT_TRUE(history[3]->hasDependency(history[0]));
+    ASSERT_TRUE(history[2]->hasDependency(history[1]));
+
+    // The load from B has the loop bounds.
+    ASSERT_TRUE(EQ(history[3]->bounds(), {CB(0, 9)}));
+
+    // And so does the load from A.
+    ASSERT_TRUE(EQ(history[2]->bounds(), {CB(0, 9)}));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   C[B[A[x]]] = x;
+     * }
+     */
+    MemDependencyChecker analyzer({a, b}, {c});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        10,
+        Store::make(c, {Load::make(b, {Load::make(a, {x}, 1)}, 1)}, x, 1))});
+
+    stmt->accept(&analyzer);
+
+    /*  0. Input: B[(0, 99)] - dependents: 3
+     *  1. Input: A[(0, 99)] - dependents: 2
+     *  2. Load: A[(0, 9)] - depends on: 1  - dependents: 3 4
+     *  3. Load: B[(A[0], A[9])] - depends on: 0 2  - dependents: 4
+     *  4. Store: C[(B[A[0]], B[A[9]])] - depends on: 2 3  - dependents: 5
+     *  5. Output: C[(0, 99)] - depends on: 4
+     */
+
+    // Sanity check output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(c.node(), b.node()));
+
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 6);
+
+    // The store depends on both loads.
+    ASSERT_TRUE(history[4]->hasDependency(history[2]));
+    ASSERT_TRUE(history[4]->hasDependency(history[3]));
+
+    // The outer load depends on the inner.
+    ASSERT_TRUE(history[3]->hasDependency(history[2]));
+
+    // The loads each depend on their relevant input. (but accesses are in a
+    // different order than the last case).
+    ASSERT_TRUE(history[3]->hasDependency(history[0]));
+    ASSERT_TRUE(history[2]->hasDependency(history[1]));
+
+    // The load from A has the loop bounds.
+    ASSERT_TRUE(EQ(history[2]->bounds(), {CB(0, 9)}));
+    // The load from B as bounds A[0] to A[9].
+    ExprHandle loadFromA0 = Load::make(a, {0}, 1);
+    ExprHandle loadFromA9 = Load::make(a, {9}, 1);
+    ASSERT_TRUE(EQ(history[3]->bounds(), {CB(loadFromA0, loadFromA9)}));
+
+    // The store has bounds of B[A[0]] to B[A[9]].
+    ExprHandle loadFromBA0 = Load::make(b, {loadFromA0}, 1);
+    ExprHandle loadFromBA9 = Load::make(b, {loadFromA9}, 1);
+    ASSERT_TRUE(EQ(history[4]->bounds(), {CB(loadFromBA0, loadFromBA9)}));
+  }
+}
+
+// Verify multi dimensional bounds work.
+void testMemDependencyCheckerMultiDim() {
+  KernelScope kernel_scope;
+  int M = 10, N = 9, K = 12;
+  BufHandle a("A", {M, N, K}, kInt);
+  BufHandle b("B", {M, N, K}, kInt);
+  BufHandle c("C", {M, K}, kInt);
+  VarHandle x("x", kInt);
+  VarHandle y("y", kInt);
+  VarHandle z("z", kInt);
+
+  using namespace analysis;
+
+  auto CB = [](ExprHandle s, ExprHandle e) {
+    return Bound(s.node(), e.node());
+  };
+
+  auto EQ = [](const IndexBounds& x, const IndexBounds& y) {
+    return indexBoundsEquals(x, y);
+  };
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   for (int y = 0; y < 9; y++) {
+     *     for (int z = 0; z < 12; z++) {
+     *       B[x, y, z] = A[x, y, z];
+     *     }
+     *   }
+     * }
+     */
+    // Full range.
+
+    MemDependencyChecker analyzer({a}, {b});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        M,
+        For::make(
+            y,
+            0,
+            N,
+            For::make(
+                z,
+                0,
+                K,
+                Store::make(b, {x, y, z}, Load::make(a, {x, y, z}, 1), 1))))});
+
+    stmt->accept(&analyzer);
+
+    // Sanity test: Output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+    // 4 accesses: input, load, store, output.
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 4);
+
+    // Simple chain from input to output.
+    ASSERT_TRUE(history[3]->hasDependency(history[2]));
+    ASSERT_TRUE(history[2]->hasDependency(history[1]));
+    ASSERT_TRUE(history[1]->hasDependency(history[0]));
+
+    ASSERT_TRUE(
+        EQ(history[1]->bounds(), {CB(0, M - 1), CB(0, N - 1), CB(0, K - 1)}));
+    ASSERT_TRUE(
+        EQ(history[2]->bounds(), {CB(0, M - 1), CB(0, N - 1), CB(0, K - 1)}));
+  }
+
+  {
+    /* for (int x = 0; x < 5; x++) {
+     *   for (int y = 0; y < 5; y++) {
+     *     for (int z = 0; z < 5; z++) {
+     *       B[x, y, z] = A[x, y, z];
+     *     }
+     *   }
+     * }
+     */
+    // Partial range.
+
+    MemDependencyChecker analyzer({a}, {b});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        5,
+        For::make(
+            y,
+            0,
+            5,
+            For::make(
+                z,
+                0,
+                5,
+                Store::make(b, {x, y, z}, Load::make(a, {x, y, z}, 1), 1))))});
+
+    stmt->accept(&analyzer);
+
+    // Sanity test: Output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+    // 4 accesses: input, load, store, output.
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 4);
+
+    // Simple chain from input to output.
+    ASSERT_TRUE(history[3]->hasDependency(history[2]));
+    ASSERT_TRUE(history[2]->hasDependency(history[1]));
+    ASSERT_TRUE(history[1]->hasDependency(history[0]));
+
+    ASSERT_TRUE(EQ(history[1]->bounds(), {CB(0, 4), CB(0, 4), CB(0, 4)}));
+    ASSERT_TRUE(EQ(history[2]->bounds(), {CB(0, 4), CB(0, 4), CB(0, 4)}));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   for (int y = 0; y < 12; y++) {
+     *     B[x, 0, y] = A[x, 0, y];
+     *   }
+     * }
+     */
+
+    // Partial loops.
+
+    MemDependencyChecker analyzer({a}, {b});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        N,
+        For::make(
+            y,
+            0,
+            K,
+            Store::make(b, {x, 0, y}, Load::make(a, {x, 0, y}, 1), 1)))});
+
+    stmt->accept(&analyzer);
+
+    // Sanity test: Output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+    // 4 accesses: input, load, store, output.
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 4);
+
+    // Simple chain from input to output.
+    ASSERT_TRUE(history[3]->hasDependency(history[2]));
+    ASSERT_TRUE(history[2]->hasDependency(history[1]));
+    ASSERT_TRUE(history[1]->hasDependency(history[0]));
+
+    ASSERT_TRUE(
+        EQ(history[1]->bounds(), {CB(0, N - 1), CB(0, 0), CB(0, K - 1)}));
+    ASSERT_TRUE(
+        EQ(history[2]->bounds(), {CB(0, N - 1), CB(0, 0), CB(0, K - 1)}));
+  }
+
+  {
+    /* for (int x = 0; x < 10; x++) {
+     *   for (int y = 0; y < 100; y++) {
+     *     for (int z = 0; z < 12; z++) {
+     *       B[x, 0, z] = (A[x, 0, z]) + (C[x, z]);
+     *     }
+     *   }
+     * }
+     */
+
+    // Loops that don't correspond to an index, bufs with different
+    // dimensionality.
+
+    MemDependencyChecker analyzer({a, c}, {b});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        M,
+        For::make(
+            y,
+            0,
+            100,
+            For::make(
+                z,
+                0,
+                K,
+                Store::make(
+                    b,
+                    {x, 0, z},
+                    Add::make(
+                        Load::make(a, {x, 0, z}, 1), Load::make(c, {x, z}, 1)),
+                    1))))});
+
+    stmt->accept(&analyzer);
+
+    // Sanity test: Output depends on both inputs.
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), c.node()));
+
+    // 6 accesses: 2 inputs, 2 loads, store, output.
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 6);
+
+    // Simple chain from input to output over the A buf.
+    // history[0] is the C input, history[3] is the load from C.
+    ASSERT_TRUE(history[5]->hasDependency(history[4]));
+    ASSERT_TRUE(history[4]->hasDependency(history[2]));
+    ASSERT_TRUE(history[2]->hasDependency(history[1]));
+    // The store also depends on the load from the C input.
+    ASSERT_TRUE(history[4]->hasDependency(history[3]));
+    ASSERT_TRUE(history[3]->hasDependency(history[0]));
+
+    // A Buf accesses.
+    ASSERT_TRUE(
+        EQ(history[4]->bounds(), {CB(0, M - 1), CB(0, 0), CB(0, K - 1)}));
+    ASSERT_TRUE(
+        EQ(history[2]->bounds(), {CB(0, M - 1), CB(0, 0), CB(0, K - 1)}));
+
+    // C buf access.
+    ASSERT_TRUE(EQ(history[3]->bounds(), {CB(0, M - 1), CB(0, K - 1)}));
+  }
+
+  {
+    /* for (int x = 0; x < 9; x++) {
+     *   for (int y = 0; y < 10; y++) {
+     *     for (int z = 0; z < 12; z++) {
+     *       B[x, 0, 0] = (B[x, y, z]) + (A[x, y, z]);
+     *     }
+     *   }
+     * }
+     */
+    // Multi-dim reductions.
+
+    MemDependencyChecker analyzer({a}, {b});
+    Stmt* stmt = Block::make({For::make(
+        x,
+        0,
+        M,
+        For::make(
+            y,
+            0,
+            N,
+            For::make(
+                z,
+                0,
+                K,
+                Store::make(
+                    b,
+                    {x, 0, 0},
+                    Add::make(
+                        Load::make(b, {x, y, z}, 1),
+                        Load::make(a, {x, y, z}, 1)),
+                    1))))});
+
+    stmt->accept(&analyzer);
+
+    // Sanity test: Output depends on input.
+    ASSERT_TRUE(analyzer.dependsIndirectly(b.node(), a.node()));
+
+    // 4 accesses: input, 2 loads, store, output.
+    auto history = analyzer.getHistory();
+    ASSERT_EQ(history.size(), 5);
+
+    // Simple chain from input to output.
+    ASSERT_TRUE(history[4]->hasDependency(history[3]));
+    ASSERT_TRUE(history[3]->hasDependency(history[2]));
+    ASSERT_TRUE(history[3]->hasDependency(history[1]));
+    ASSERT_TRUE(history[2]->hasDependency(history[0]));
+
+    // The load from B depends on the store to B.
+    ASSERT_TRUE(history[1]->hasDependency(history[3]));
+
+    ASSERT_TRUE(
+        EQ(history[1]->bounds(), {CB(0, M - 1), CB(0, N - 1), CB(0, K - 1)}));
+    ASSERT_TRUE(
+        EQ(history[2]->bounds(), {CB(0, M - 1), CB(0, N - 1), CB(0, K - 1)}));
+    ASSERT_TRUE(EQ(history[3]->bounds(), {CB(0, M - 1), CB(0, 0), CB(0, 0)}));
+  }
+}
+
+// Various tests using the external Compute/Reduce API.
+void testMemDependencyCheckerComputeAPI() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+
+  /* for (int m = 0; m < 4; m++) {
+   *   for (int n = 0; n < 5; n++) {
+   *     for (int k = 0; k < 6; k++) {
+   *       broadcast_add[m, n, k] = (a[m, n]) + (b[n, k]);
+   *     }
+   *   }
+   * }
+   * for (int m_1 = 0; m_1 < 4; m_1++) {
+   *   for (int n_1 = 0; n_1 < 5; n_1++) {
+   *     for (int k_1 = 0; k_1 < 6; k_1++) {
+   *       d[m_1, n_1, k_1] = (broadcast_add(m_1, n_1, k_1)) + float(1);
+   *     }
+   *   }
+   * }
+   */
+
+  // Can determine if 2 loops created by Compute are dependent.
+  Placeholder a_buf("a", kFloat, {4, 5});
+  Placeholder b_buf("b", kFloat, {5, 6});
+  Tensor* c = Compute(
+      "broadcast_add",
+      {{4, "m"}, {5, "n"}, {6, "k"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf.load(m, n) + b_buf.load(n, k);
+      });
+  Tensor* d = Compute(
+      "d",
+      {{4, "m"}, {5, "n"}, {6, "k"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return c->call(m, n, k) + 1;
+      });
+
+  LoopNest l({d});
+
+  MemDependencyChecker analyzer({a_buf.data(), b_buf.data()}, {d->buf()});
+
+  l.root_stmt()->accept(&analyzer);
+
+  // Sanity test: Output depends on input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(d->buf(), a_buf.data()));
+  ASSERT_TRUE(analyzer.dependsIndirectly(d->buf(), b_buf.data()));
+
+  // Second loop depends on first loop.
+  auto* c_loop = l.getLoopStmtsFor(c)[0];
+  auto* d_loop = l.getLoopStmtsFor(d)[0];
+  ASSERT_TRUE(analyzer.dependsDirectly(d_loop, c_loop));
+}
+
+void testMemDependencyCheckerComputeInline() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+
+  /* for (int m = 0; m < 4; m++) {
+   *   for (int n = 0; n < 5; n++) {
+   *     for (int k = 0; k < 6; k++) {
+   *       d[m, n, k] = ((a[m, n]) + (b[n, k])) + float(1);
+   *     }
+   *   }
+   * }
+   */
+
+  // Check inlining affects the number of accesses returned.
+
+  Placeholder a_buf("a", kFloat, {4, 5});
+  Placeholder b_buf("b", kFloat, {5, 6});
+  Tensor* c = Compute(
+      "broadcast_add",
+      {{4, "m"}, {5, "n"}, {6, "k"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf.load(m, n) + b_buf.load(n, k);
+      });
+  Tensor* d = Compute(
+      "d",
+      {{4, "m"}, {5, "n"}, {6, "k"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return c->call(m, n, k) + 1;
+      });
+
+  LoopNest l({d});
+  l.computeInline(c->buf());
+
+  MemDependencyChecker analyzer({a_buf.data(), b_buf.data()}, {d->buf()});
+  l.root_stmt()->accept(&analyzer);
+
+  // Sanity test: Output depends on input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(d->buf(), a_buf.data()));
+  ASSERT_TRUE(analyzer.dependsIndirectly(d->buf(), b_buf.data()));
+
+  // broadcast_add tensor should not appear in trace at all.
+  for (auto& wi : analyzer.getHistory()) {
+    ASSERT_NE(wi->var(), c->buf()->base_handle());
+  }
+}
+
+void testMemDependencyCheckerComputeSplit() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+  // Split an axis, so the number of loops != the number of dimensions.
+
+  Placeholder a_buf("a", kFloat, {4, 5});
+  Placeholder b_buf("b", kFloat, {5, 6});
+  Tensor* c = Compute(
+      "broadcast_add",
+      {{4, "m"}, {5, "n"}, {6, "k"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf.load(m, n) + b_buf.load(n, k);
+      });
+
+  LoopNest l({c});
+
+  MemDependencyChecker analyzer_before(
+      {a_buf.data(), b_buf.data()}, {c->buf()});
+  l.root_stmt()->accept(&analyzer_before);
+
+  For *o, *i, *t;
+  l.splitWithTail(l.getLoopStmtsFor(c)[0], 2, &o, &i, &t);
+
+  MemDependencyChecker analyzer_after({a_buf.data(), b_buf.data()}, {c->buf()});
+  Stmt* stmt = IRSimplifier::simplify(l.root_stmt());
+  stmt->accept(&analyzer_after);
+
+  // Splitting should not change accesses at all.
+  auto history_before = analyzer_before.getHistory();
+  auto history_after = analyzer_after.getHistory();
+
+  ASSERT_EQ(history_before.size(), history_after.size());
+
+  for (size_t i = 0; i < history_before.size(); ++i) {
+    ASSERT_EQ(history_before[i]->type(), history_after[i]->type());
+    ASSERT_EQ(history_before[i]->var(), history_after[i]->var());
+    ASSERT_EQ(
+        history_before[i]->bounds().size(), history_after[i]->bounds().size());
+    ASSERT_TRUE(indexBoundsEquals(
+        history_before[i]->bounds(), history_after[i]->bounds()));
+    ASSERT_EQ(
+        history_before[i]->dependencies().size(),
+        history_after[i]->dependencies().size());
+    ASSERT_EQ(
+        history_before[i]->dependents().size(),
+        history_after[i]->dependents().size());
+  }
+}
+
+void testMemDependencyCheckerComputeReorder() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+  // Reorder an axis, so the loop order doesn't match the indexing order.
+
+  Placeholder a_buf("a", kFloat, {4, 5});
+  Placeholder b_buf("b", kFloat, {5, 6});
+  Tensor* c = Compute(
+      "broadcast_add",
+      {{4, "m"}, {5, "n"}, {6, "k"}},
+      [&](const VarHandle& m, const VarHandle& n, const VarHandle& k) {
+        return a_buf.load(m, n) + b_buf.load(n, k);
+      });
+
+  LoopNest l({c});
+
+  MemDependencyChecker analyzer_before(
+      {a_buf.data(), b_buf.data()}, {c->buf()});
+  l.root_stmt()->accept(&analyzer_before);
+
+  auto loops = l.getLoopStmtsFor(c);
+  l.reorderAxis(loops[0], loops[1]);
+
+  MemDependencyChecker analyzer_after({a_buf.data(), b_buf.data()}, {c->buf()});
+  Stmt* stmt = IRSimplifier::simplify(l.root_stmt());
+  stmt->accept(&analyzer_after);
+
+  // Reordering should not change accesses at all.
+  auto history_before = analyzer_before.getHistory();
+  auto history_after = analyzer_after.getHistory();
+
+  ASSERT_EQ(history_before.size(), history_after.size());
+
+  for (size_t i = 0; i < history_before.size(); ++i) {
+    ASSERT_EQ(history_before[i]->type(), history_after[i]->type());
+    ASSERT_EQ(history_before[i]->var(), history_after[i]->var());
+    ASSERT_EQ(
+        history_before[i]->bounds().size(), history_after[i]->bounds().size());
+    ASSERT_TRUE(indexBoundsEquals(
+        history_before[i]->bounds(), history_after[i]->bounds()));
+    ASSERT_EQ(
+        history_before[i]->dependencies().size(),
+        history_after[i]->dependencies().size());
+    ASSERT_EQ(
+        history_before[i]->dependents().size(),
+        history_after[i]->dependents().size());
+  }
+}
+
+void testMemDependencyCheckerComputeReduce() {
+  KernelScope kernel_scope;
+
+  using namespace analysis;
+  /* for (int l2 = 0; l2 < 2; l2++) {
+   *   for (int n1 = 0; n1 < 3; n1++) {
+   *     for (int m1 = 0; m1 < 6; m1++) {
+   *       scale[l2, n1, m1] = (b[l2, n1, m1]) * (a[l2, n1, m1]);
+   *     }
+   *   }
+   * }
+   * for (int l1 = 0; l1 < 2; l1++) {
+   *   sum[l1] = float(0);
+   *   for (int n1_1 = 0; n1_1 < 3; n1_1++) {
+   *     for (int m1_1 = 0; m1_1 < 6; m1_1++) {
+   *       sum[l1] = ReduceOp(sum, (sum[l1]) + (scale(l1, n1_1, m1_1)),
+   *                    out_args={l1}, reduce_args={n1, m1});
+   *     }
+   *   }
+   * }
+   */
+
+  // Can determine dependencies of a Reduction.
+
+  Placeholder a(BufHandle("a", {2, 3, 6}, kFloat));
+  Placeholder b(BufHandle("b", {2, 3, 6}, kFloat));
+
+  Tensor* c = Compute(
+      "scale",
+      {{2, "l2"}, {3, "n1"}, {6, "m1"}},
+      [&](const VarHandle& l, const VarHandle& n, const VarHandle& m) {
+        return b.load(l, n, m) * a.load(l, n, m);
+      });
+  Tensor* d = Reduce("sum", {{2, "l1"}}, Sum(), c, {{3, "n1"}, {6, "m1"}});
+  LoopNest l({d});
+
+  MemDependencyChecker analyzer({a.data(), b.data()}, {d->buf()});
+
+  l.root_stmt()->accept(&analyzer);
+
+  // Sanity test: Output depends on input.
+  ASSERT_TRUE(analyzer.dependsIndirectly(d->buf(), a.data()));
+  ASSERT_TRUE(analyzer.dependsIndirectly(d->buf(), b.data()));
+
+  // Second loop depends on first loop.
+  auto* c_loop = l.getLoopStmtsFor(c)[0];
+  auto* d_loop = l.getLoopStmtsFor(d)[0];
+  ASSERT_TRUE(analyzer.dependsDirectly(d_loop, c_loop));
+
+  // Reduction depends on both inputs.
+  auto reduces = NodeFinder<ReduceOp>::find(l.root_stmt());
+  ASSERT_TRUE(analyzer.dependsIndirectly(reduces[0], a.data()));
+  ASSERT_TRUE(analyzer.dependsIndirectly(reduces[0], b.data()));
+}
+
+void testMemDependencyCheckerComputeGEMM() {
+  KernelScope kernel_scope;
+  int M = 1024;
+  int N = 1024;
+  int K = 2048;
+  using namespace analysis;
+
+  Placeholder AP(BufHandle("A", {M, K}, kFloat));
+  Placeholder BP(BufHandle("B", {K, N}, kFloat));
+  Tensor* CT = Reduce(
+      "gemm",
+      {{M, "M"}, {N, "N"}},
+      Sum(),
+      [&](const ExprHandle& m, const ExprHandle& n, const ExprHandle& k) {
+        return AP.load(m, k) * BP.load(k, n);
+      },
+      {{K, "K"}});
+  LoopNest loop({CT});
+
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    For* m = loops[0];
+    For* mo;
+    For* mi;
+    loop.splitWithMask(m, 4, &mo, &mi);
+  }
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    For* n = loops[2];
+    For* no;
+    For* ni;
+    loop.splitWithMask(n, 16, &no, &ni);
+  }
+  // mo, mi, no, ni, k ->
+  // mo, no, mi, ni, k
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    For* mi = loops[1];
+    For* no = loops[2];
+    loop.reorderAxis(mi, no);
+  }
+  // mo, no, mi, ni, k ->
+  // mo, no, mi, k, ni
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    For* ni = loops[3];
+    For* k = loops[4];
+    loop.reorderAxis(ni, k);
+  }
+  // mo, no, mi, k, ni ->
+  // mo, no, k, mi, ni
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    For* mi = loops[2];
+    For* k = loops[3];
+    loop.reorderAxis(mi, k);
+  }
+  {
+    auto const& loops = loop.getLoopStmtsFor(CT);
+    loop.cacheAccesses(CT->buf(), "C_regs", loops[2]);
+  }
+
+  MemDependencyChecker analyzer_unlowered(
+      loop.getInputBufs(), loop.getOutputBufs());
+
+  MemDependencyChecker analyzer_lowered(
+      loop.getInputBufs(), loop.getOutputBufs());
+
+  // Test both unlowered and lowered form.
+  {
+    Stmt* stmt = IRSimplifier::simplify(loop.root_stmt());
+    stmt->accept(&analyzer_unlowered);
+
+    // Outputs depend on inputs.
+    ASSERT_TRUE(analyzer_unlowered.dependsIndirectly(CT->buf(), AP.data()));
+    ASSERT_TRUE(analyzer_unlowered.dependsIndirectly(CT->buf(), BP.data()));
+
+    // The last write to gemm should cover the total bound of the output.
+    std::shared_ptr<AccessInfo> outputAccess =
+        analyzer_unlowered.output(CT->buf());
+    // A single dependency.
+    ASSERT_EQ(outputAccess->dependencies().size(), 1);
+
+    // dependencies is a set with 1 element, so can just deref begin().
+    std::shared_ptr<AccessInfo> gemmStore =
+        outputAccess->dependencies().begin()->second;
+    // Check its a store.
+    ASSERT_EQ(gemmStore->type(), AccessType::Store);
+
+    ASSERT_TRUE(indexBoundsEquals(outputAccess->bounds(), gemmStore->bounds()));
+
+    // Likewise the first read from each input cover the entire range of the
+    // input.
+    auto aInput = analyzer_unlowered.input(AP.data());
+    auto bInput = analyzer_unlowered.input(BP.data());
+
+    // A single dependent each.
+    ASSERT_EQ(aInput->dependents().size(), 1);
+    ASSERT_EQ(bInput->dependents().size(), 1);
+
+    // They're both loads.
+    std::shared_ptr<AccessInfo> aLoad = aInput->dependents().begin()->second;
+    std::shared_ptr<AccessInfo> bLoad = bInput->dependents().begin()->second;
+    ASSERT_EQ(aLoad->type(), AccessType::Load);
+    ASSERT_EQ(bLoad->type(), AccessType::Load);
+
+    ASSERT_TRUE(indexBoundsEquals(aInput->bounds(), aLoad->bounds()));
+    ASSERT_TRUE(indexBoundsEquals(bInput->bounds(), bLoad->bounds()));
+  }
+
+  loop.prepareForCodegen();
+
+  // now check lowered dependency graph.
+  {
+    Stmt* stmt = IRSimplifier::simplify(loop.root_stmt());
+    stmt->accept(&analyzer_lowered);
+
+    // Lowering will change the dimensionality of all bounds due to index
+    // flattening, but not the number of accesses.
+
+    auto history_before = analyzer_unlowered.getHistory();
+    auto history_after = analyzer_lowered.getHistory();
+
+    ASSERT_EQ(history_before.size(), history_after.size());
+
+    for (size_t i = 0; i < history_before.size(); ++i) {
+      ASSERT_EQ(history_before[i]->type(), history_after[i]->type());
+      ASSERT_EQ(history_before[i]->var(), history_after[i]->var());
+      ASSERT_EQ(
+          history_before[i]->dependencies().size(),
+          history_after[i]->dependencies().size());
+      ASSERT_EQ(
+          history_before[i]->dependents().size(),
+          history_after[i]->dependents().size());
+
+      // Inputs and outputs are not flattened, only accesses.
+      if (history_before[i]->type() == AccessType::Input ||
+          history_before[i]->type() == AccessType::Output) {
+        ASSERT_EQ(
+            history_before[i]->bounds().size(),
+            history_after[i]->bounds().size());
+        ASSERT_TRUE(indexBoundsEquals(
+            history_before[i]->bounds(), history_after[i]->bounds()));
+      } else {
+        ASSERT_EQ(history_after[i]->bounds().size(), 1);
+        const Expr* flat_bounds = new IntImm(1);
+
+        for (auto& b : history_before[i]->bounds()) {
+          flat_bounds = new Mul(flat_bounds, new Add(b.end, new IntImm(1)));
+
+          ASSERT_TRUE(exprEquals(b.start, history_after[i]->bounds()[0].start));
+        }
+
+        flat_bounds = IRSimplifier::simplify(flat_bounds);
+        const Expr* after_bounds = IRSimplifier::simplify(
+            new Add(history_after[i]->bounds()[0].end, new IntImm(1)));
+        ASSERT_TRUE(exprEquals(flat_bounds, after_bounds));
+      }
+    }
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -315,6 +315,36 @@ namespace jit {
   _(MergeAdjacentBounds)                            \
   _(MergeSymbolicBounds)                            \
   _(MergeSymbolicAdjacent)                          \
+  _(BoundOverlap)                                   \
+  _(BoundOverlapSymbolic)                           \
+  _(BoundOverlapMultiDim)                           \
+  _(BoundSubtract)                                  \
+  _(BoundSubtractSymbolic)                          \
+  _(BoundSubtractMultiDim)                          \
+  _(BoundSubtractMultiDimSymbolic)                  \
+  _(MemDependencyCheckerSimple)                     \
+  _(MemDependencyCheckerMultiStmt)                  \
+  _(MemDependencyCheckerOverlap)                    \
+  _(MemDependencyCheckerLoop)                       \
+  _(MemDependencyCheckerLoopReduce)                 \
+  _(MemDependencyCheckerLoopReduceExpanded)         \
+  _(MemDependencyCheckerInputsOutputs)              \
+  _(MemDependencyCheckerOutputDoesntDepend)         \
+  _(MemDependencyCheckerLoopBounds)                 \
+  _(MemDependencyCheckerLoopBoundsIndexShift)       \
+  _(MemDependencyCheckerLoopSelfDependency)         \
+  _(MemDependencyCheckerLoopDistinctStrides)        \
+  _(MemDependencyCheckerLoopBoundsCond)             \
+  _(MemDependencyCheckerIfThenElse)                 \
+  _(MemDependencyCheckerCutLoop)                    \
+  _(MemDependencyCheckerDynamicShapes)              \
+  _(MemDependencyCheckerMultiDim)                   \
+  _(MemDependencyCheckerComputeAPI)                 \
+  _(MemDependencyCheckerComputeInline)              \
+  _(MemDependencyCheckerComputeSplit)               \
+  _(MemDependencyCheckerComputeReorder)             \
+  _(MemDependencyCheckerComputeReduce)              \
+  _(MemDependencyCheckerComputeGEMM)                \
   _(LoopNestComputeAt_1)                            \
   _(LoopNestComputeAt_2)                            \
   _(LoopNestComputeAt_3)                            \

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -225,6 +225,8 @@ core_sources_full = [
     "torch/csrc/jit/serialization/python_print.cpp",
     "torch/csrc/jit/serialization/source_range_serialization.cpp",
     "torch/csrc/jit/tensorexpr/bounds_inference.cpp",
+    "torch/csrc/jit/tensorexpr/bounds_overlap.cpp",
+    "torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp",
     "torch/csrc/jit/tensorexpr/codegen.cpp",
     "torch/csrc/jit/tensorexpr/eval.cpp",
     "torch/csrc/jit/tensorexpr/expr.cpp",

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -38,9 +38,15 @@ class NodeFinder : public IRVisitor {
     IRVisitor::visit(v);
   }
 
-  static std::vector<Node*> find(Stmt* s) {
+  static std::vector<Node*> find(const Stmt* s) {
     NodeFinder<Node> nf;
     s->accept(&nf);
+    return nf.nodes;
+  }
+
+  static std::vector<Node*> find(const Expr* e) {
+    NodeFinder<Node> nf;
+    e->accept(&nf);
     return nf.nodes;
   }
 

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -1,0 +1,241 @@
+#include <torch/csrc/jit/tensorexpr/bounds_overlap.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+namespace analysis {
+
+OverlapKind boundOverlap(Bound a, Bound b) {
+  // If they're equal they're equal.
+  bool startEqual = exprEquals(a.start, b.start);
+  bool endEqual = exprEquals(a.end, b.end);
+  if (startEqual && endEqual) {
+    return ContainedOrEqual;
+  }
+
+  const Expr* lowDiff = IRSimplifier::simplify(new Sub(a.start, b.end));
+  const Expr* highDiff = IRSimplifier::simplify(new Sub(b.start, a.end));
+
+  if (lowDiff->isConstant() && highDiff->isConstant()) {
+    int low = immediateAs<int>(lowDiff);
+    int high = immediateAs<int>(highDiff);
+    // No overlap.
+    if (low > 0 || high > 0) {
+      return NoOverlap;
+    }
+  }
+
+  const Expr* diff_start = IRSimplifier::simplify(new Sub(b.start, a.start));
+  const Expr* diff_end = IRSimplifier::simplify(new Sub(b.end, a.end));
+
+  // If one side fully encloses the other, they're adjacent.
+  if (diff_start->isConstant() && diff_end->isConstant()) {
+    int start = immediateAs<int>(diff_start);
+    int end = immediateAs<int>(diff_end);
+    // If diff_start and diff_end have different signs they are enclosing.
+    if (start <= 0 && end >= 0) {
+      return ContainedOrEqual;
+    }
+
+    if (start >= 0 && end <= 0) {
+      return Contains;
+    }
+  }
+
+  // We can't be sure there's no overlap so the conservative answer is
+  // partial.
+  return PartialOverlap;
+}
+
+bool indexBoundsEquals(const IndexBounds& A, const IndexBounds& B) {
+  if (A.size() != B.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i != A.size(); ++i) {
+    if (!A[i].equals(B[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Bound flattenBounds(const IndexBounds& a) {
+  if (a.empty()) {
+    return Bound();
+  }
+  Bound ret = a[0];
+
+  for (size_t i = 1; i < a.size(); ++i) {
+    ret.start = new Mul(ret.start, a[i].start);
+    ret.end = new Mul(ret.end, a[i].end);
+  }
+
+  ret.start = IRSimplifier::simplify(ret.start);
+  ret.end = IRSimplifier::simplify(ret.end);
+  return ret;
+}
+
+OverlapKind overlaps(const IndexBounds& a, const IndexBounds& b) {
+  // All accesses to a buf must have the same dimensionality.
+
+  if (a.size() != b.size()) {
+    return boundOverlap(flattenBounds(a), flattenBounds(b));
+  }
+  TORCH_INTERNAL_ASSERT(a.size() == b.size());
+
+  OverlapKind overlap = boundOverlap(a[0], b[0]);
+  for (size_t i = 1; i < a.size(); ++i) {
+    OverlapKind bOverlap = boundOverlap(a[i], b[i]);
+    if (bOverlap == NoOverlap) {
+      return NoOverlap;
+    }
+
+    if (overlap == ContainedOrEqual && bOverlap == Contains) {
+      overlap = Contains;
+    }
+
+    if (overlap == Contains && bOverlap == ContainedOrEqual) {
+      continue;
+    }
+
+    if (bOverlap != overlap) {
+      overlap = PartialOverlap;
+      break;
+    }
+  }
+
+  return overlap;
+}
+
+std::vector<Bound> subtractBound(Bound a, Bound b, OverlapKind overlap) {
+  // The bounds must overlap.
+  std::vector<Bound> res;
+
+  if (a.start->isConstant() != b.start->isConstant() ||
+      a.end->isConstant() != b.end->isConstant()) {
+    return {a};
+  }
+
+  const Expr* lowDiff = IRSimplifier::simplify(new Sub(b.start, a.start));
+  const Expr* highDiff = IRSimplifier::simplify(new Sub(b.end, a.end));
+
+  // If the diff has only a single var, we can try to guess sign.
+  if (!lowDiff->isConstant()) {
+    auto vars = VarFinder::find(lowDiff);
+    if (vars.size() == 1) {
+      lowDiff = IRSimplifier::simplify(new Sub(
+          Substitute(b.start, {{*vars.begin(), new IntImm(1)}}),
+          Substitute(a.start, {{*vars.begin(), new IntImm(1)}})));
+    }
+  }
+
+  if (!highDiff->isConstant()) {
+    auto vars = VarFinder::find(highDiff);
+    if (vars.size() == 1) {
+      highDiff = IRSimplifier::simplify(new Sub(
+          Substitute(b.end, {{*vars.begin(), new IntImm(1)}}),
+          Substitute(a.end, {{*vars.begin(), new IntImm(1)}})));
+    }
+  }
+
+  bool hasHead = lowDiff->isConstant() && immediateAs<int>(lowDiff) > 0;
+  bool hasTail = highDiff->isConstant() && immediateAs<int>(highDiff) < 0;
+
+  bool constantExtents = lowDiff->isConstant() && highDiff->isConstant();
+
+  if (!constantExtents) {
+    // If we can't infer the bound lengths, there's no way to create a safe
+    // subset. Just bail out.
+    return {a};
+  }
+
+  if (hasHead) {
+    res.emplace_back(
+        a.start, IRSimplifier::simplify(new Sub(b.start, new IntImm(1))));
+  }
+
+  if (hasTail) {
+    const Expr* tailStart =
+        IRSimplifier::simplify(new Add(b.end, new IntImm(1)));
+    res.emplace_back(tailStart, a.end);
+  }
+
+  return res;
+}
+
+std::vector<Bound> subtractBound(Bound a, Bound b) {
+  OverlapKind overlap = boundOverlap(a, b);
+  if (overlap == NoOverlap) {
+    return {a};
+  }
+  if (overlap == ContainedOrEqual) {
+    return {};
+  }
+
+  return subtractBound(a, b, overlap);
+}
+
+std::vector<IndexBounds> subtractIndicesBounds(
+    const IndexBounds& A,
+    const IndexBounds& B,
+    OverlapKind overlap) {
+  if (overlap == NoOverlap) {
+    return {A};
+  }
+
+  if (overlap == ContainedOrEqual) {
+    return {};
+  }
+  // All accesses to a buf must have the same dimensionality.
+  TORCH_INTERNAL_ASSERT(A.size() == B.size());
+
+  // Each dimension can be sliced into multiple bound segments.
+  std::vector<IndexBounds> boundSlices;
+  std::vector<Bound> remainingOuterBounds;
+
+  for (size_t i = 0; i < A.size(); ++i) {
+    auto slices = subtractBound(A[i], B[i]);
+
+    Bound remaining = A[i];
+
+    for (auto slice : slices) {
+      IndexBounds newRegion;
+      newRegion.reserve(A.size());
+      TORCH_INTERNAL_ASSERT(remainingOuterBounds.size() == i);
+
+      for (size_t j = 0; j < i; ++j) {
+        newRegion.push_back(remainingOuterBounds[j]);
+      }
+      newRegion.push_back(slice);
+      for (size_t j = i + 1; j < A.size(); ++j) {
+        newRegion.push_back(A[j]);
+      }
+
+      boundSlices.push_back(newRegion);
+
+      if (slice.equals(A[i])) {
+        remaining = A[i];
+      } else {
+        auto remainingSlices = subtractBound(remaining, slice);
+        TORCH_INTERNAL_ASSERT(remainingSlices.size() == 1);
+        remaining = remainingSlices[0];
+      }
+    }
+
+    remainingOuterBounds.push_back(remaining);
+  }
+
+  return boundSlices;
+}
+
+std::vector<IndexBounds> TORCH_API
+subtractIndicesBounds(const IndexBounds& A, const IndexBounds& B) {
+  return subtractIndicesBounds(A, B, overlaps(A, B));
+}
+
+} // namespace analysis
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.h
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/ir_visitor.h>
+#include <torch/csrc/jit/tensorexpr/stmt.h>
+#include <deque>
+#include <vector>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+namespace analysis {
+
+// A simple class containing the start and end of a range in a single dimension.
+struct TORCH_API Bound {
+  const Expr* start{nullptr};
+  const Expr* end{nullptr};
+
+  // This stores whether or not the start and end of this Bound have previously
+  // been swapped. This occurs when the bound is in a loop with a negative
+  // stride.
+  bool swapped{false};
+
+  Bound() = default;
+  Bound(const Expr* s, const Expr* e) : start(s), end(e) {}
+
+  void print() const {
+    std::cout << "(" << *start << ", " << *end << ")";
+  }
+
+  bool equals(const Bound& other) const {
+    return exprEquals(start, other.start) && exprEquals(end, other.end);
+  }
+
+  void swap() {
+    std::swap(start, end);
+    swapped = !swapped;
+  }
+};
+
+// The type of overlap found. Each condition is true only if none of the
+// previous conditions hold.
+//     ContainedOrEqual: All elements in the Bound A are in the Bound B (this
+//                       includes the case where the bounds are equal).
+//     Contains: All elements in the Bound B are in the Bound B.
+//     PartialOverlap: Any elements in the Bound B are in the Bound A.
+//     NoOverlap: No elements in the Bound A are in the bound B.
+enum OverlapKind { ContainedOrEqual, Contains, PartialOverlap, NoOverlap };
+
+// Returns the kind of overlap between Bound A and Bound A in a single
+// dimension.
+OverlapKind TORCH_API boundOverlap(Bound A, Bound B);
+
+// A multi dimensional bound representing the bound of a set of indices.
+using IndexBounds = std::vector<Bound>;
+
+// Returns true if two IndexBounds are equivalent.
+bool TORCH_API indexBoundsEquals(const IndexBounds& A, const IndexBounds& B);
+
+// Flattens a multi dimensional bound to a single dimension. The IndexBounds "a"
+// *must* encapsulate the entire range of the buffer.
+Bound TORCH_API flattenBounds(const IndexBounds& a);
+
+// Determines the kind of overlap in X dimensions.
+OverlapKind TORCH_API overlaps(const IndexBounds& a, const IndexBounds& b);
+
+// Returns the Bound slices created by subtracing bound B from bound A.
+// Multiple Bounds can be returned in the case where B slices A into two
+// distinct regions with no overlap.
+//
+// Note: this doesn't use IndexBounds because the Bounds returned do not
+// represent multiple different dimensions.
+std::vector<Bound> TORCH_API subtractBound(Bound a, Bound b);
+std::vector<Bound> TORCH_API
+subtractBound(Bound a, Bound b, OverlapKind overlap);
+
+// Returns the bound slices created by subtracting the IndexBounds B from A.
+std::vector<IndexBounds> TORCH_API subtractIndicesBounds(
+    const IndexBounds& A,
+    const IndexBounds& B,
+    OverlapKind overlap);
+std::vector<IndexBounds> TORCH_API
+subtractIndicesBounds(const IndexBounds& A, const IndexBounds& B);
+
+} // namespace analysis
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -449,6 +449,15 @@ LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
   }
 
   root_stmt_ = new Block(loops);
+
+  // If it's referenced in the root_stmt, but it's not in output_bufs_ or
+  // intermediate_bufs_ then it must be an input.
+  auto bufs = NodeFinder<Buf>::find(root_stmt_);
+  for (auto* buf : bufs) {
+    if (!output_bufs_.count(buf) && !intermediate_bufs_.count(buf)) {
+      input_bufs_.insert(buf);
+    }
+  }
 }
 
 Stmt* LoopNest::lowerToStmt(Tensor* t) {

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -113,6 +113,13 @@ class TORCH_API LoopNest {
   // for the LLVM backend, when no reductions are involved.
   void vectorizeInnerLoops();
 
+  const std::unordered_set<const Buf*> getInputBufs() {
+    return input_bufs_;
+  }
+  const std::unordered_set<const Buf*> getOutputBufs() {
+    return output_bufs_;
+  }
+
  private:
   std::vector<Tensor*> findAllNeededTensors(
       const std::vector<Tensor*>& tensors);
@@ -121,6 +128,7 @@ class TORCH_API LoopNest {
 
   Stmt* root_stmt_;
 
+  std::unordered_set<const Buf*> input_bufs_;
   std::unordered_set<const Buf*> output_bufs_;
   std::unordered_set<const Buf*> intermediate_bufs_;
   // Holds the initializer Expr of buffers that have been initialized.

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -1,0 +1,1275 @@
+#include <torch/csrc/jit/tensorexpr/mem_dependency_checker.h>
+#include <fstream>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+namespace analysis {
+
+const char* AccessToString(AccessType a) {
+  switch (a) {
+    case AccessType::Input:
+      return "Input";
+    case AccessType::Output:
+      return "Output";
+    case AccessType::Load:
+      return "Load";
+    case AccessType::Store:
+      return "Store";
+    case AccessType::Call:
+      return "Call";
+    case AccessType::AtomicAdd:
+      return "AtomicAdd";
+    default:
+      break;
+  }
+  return "Unknown";
+}
+
+void getDependencyChain(
+    const std::shared_ptr<AccessInfo>& info,
+    DependencySet& dependencies) {
+  if (!dependencies.insert(info).second) {
+    return;
+  }
+
+  for (auto& dep : info->dependencies()) {
+    getDependencyChain(dep.second, dependencies);
+  }
+}
+
+void getDependentsChain(
+    const std::shared_ptr<AccessInfo>& info,
+    DependencySet& dependents) {
+  if (!dependents.insert(info).second) {
+    return;
+  }
+
+  for (auto& dep : info->dependents()) {
+    getDependencyChain(dep.second, dependents);
+  }
+}
+
+// AccessInfo
+
+std::vector<const Expr*> AccessInfo::getIndices() const {
+  std::vector<const Expr*> indices;
+
+  if (expr_) {
+    if (auto* load = dynamic_cast<const Load*>(expr_)) {
+      indices = load->indices();
+    } else if (auto* call = dynamic_cast<const FunctionCall*>(expr_)) {
+      indices = call->params();
+    } else if (auto* reduce = dynamic_cast<const ReduceOp*>(expr_)) {
+      indices = reduce->output_args();
+    }
+  } else {
+    if (auto* store = dynamic_cast<const Store*>(stmt_)) {
+      indices = store->indices();
+    }
+  }
+  return indices;
+}
+
+void AccessInfo::addDependency(const std::shared_ptr<AccessInfo>& write) {
+  auto res = dependencies_.emplace(write->id(), write);
+  TORCH_INTERNAL_ASSERT(res.second);
+}
+
+void AccessInfo::addDependent(const std::shared_ptr<AccessInfo>& read) {
+  auto res = dependents_.emplace(read->id(), read);
+  TORCH_INTERNAL_ASSERT(res.second);
+}
+
+bool AccessInfo::hasDependency(const std::shared_ptr<AccessInfo>& info) const {
+  return dependencies_.count(info->id()) != 0;
+}
+
+DependencySet AccessInfo::getDirectDependencies() {
+  DependencySet res;
+  for (auto& depPair : dependencies_) {
+    res.insert(depPair.second);
+  }
+  return res;
+}
+
+DependencySet AccessInfo::getIndirectDependencies() {
+  DependencySet res;
+  for (auto& depPair : dependencies_) {
+    getDependencyChain(depPair.second, res);
+  }
+  return res;
+}
+
+DependencySet AccessInfo::getDirectDependents() {
+  DependencySet res;
+  for (auto& depPair : dependents_) {
+    res.insert(depPair.second);
+  }
+  return res;
+}
+
+DependencySet AccessInfo::getIndirectDependents() {
+  DependencySet res;
+  for (auto& depPair : dependencies_) {
+    getDependentsChain(depPair.second, res);
+  }
+  return res;
+}
+
+bool AccessInfo::isRead() const {
+  switch (type_) {
+    case AccessType::Output:
+    case AccessType::Load:
+    case AccessType::Call:
+    case AccessType::AtomicAdd:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+bool AccessInfo::isWrite() const {
+  switch (type_) {
+    case AccessType::Input:
+    case AccessType::Store:
+    case AccessType::AtomicAdd:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+void AccessInfo::print() const {
+  std::cout << id_ << ". " << AccessToString(type_) << ": " << *var_ << "[";
+  if (bounds_.size() > 0) {
+    for (size_t i = 0; i < bounds_.size() - 1; ++i) {
+      bounds_[i].print();
+      std::cout << ", ";
+    }
+
+    size_t i = bounds_.size() - 1;
+    bounds_[i].print();
+  }
+  std::cout << "]";
+
+  if (!dependencies_.empty()) {
+    std::cout << " - depends on: ";
+    for (auto& pair : dependencies_) {
+      std::cout << pair.second->id() << " ";
+    }
+  }
+
+  if (!dependents_.empty()) {
+    std::cout << " - dependents: ";
+    for (auto& pair : dependents_) {
+      std::cout << pair.second->id() << " ";
+    }
+  }
+
+  std::cout << "\n";
+}
+
+void AccessInfo::dumpDOT(std::ostream& os) const {
+  if (type_ == AccessType::Input || type_ == AccessType::Output) {
+    os << "n" << id_ << " [\n";
+    os << "label = \"" << AccessToString(type_) << "\\n " << *var_ << "[";
+    if (bounds_.size() > 0) {
+      for (size_t i = 0; i < bounds_.size() - 1; ++i) {
+        os << *IRSimplifier::simplify(new Add(bounds_[i].end, new IntImm(1)))
+           << ", ";
+      }
+
+      size_t i = bounds_.size() - 1;
+      os << *IRSimplifier::simplify(new Add(bounds_[i].end, new IntImm(1)));
+      os << "]\"\n ";
+    }
+    if (isWrite()) {
+      os << "\tshape = \"invhouse\"\n";
+    } else {
+      os << "\tshape = \"house\"\n";
+    }
+  } else {
+    os << "n" << id_ << " [\n";
+    os << "label = \"" << AccessToString(type_) << " (#" << id_ << ")\\n";
+    os << "buf : " << *var_ << "\\n";
+    os << "bounds : \[";
+    if (bounds_.size() > 0) {
+      for (size_t i = 0; i < bounds_.size() - 1; ++i) {
+        os << "(" << *bounds_[i].start << ", " << *bounds_[i].end << "), ";
+      }
+
+      size_t i = bounds_.size() - 1;
+      os << "(" << *bounds_[i].start << ", " << *bounds_[i].end << ")]";
+    }
+    os << "\"\n";
+    os << "\tshape = \"box\"\n";
+  }
+  os << "\tstyle=\"filled\"\n";
+  os << "\tcolor=\"" << AccessTypeColour() << "\"\n";
+  std::string edgeColour;
+  if (isWrite()) {
+    edgeColour = "cornflowerblue";
+  } else {
+    edgeColour = "goldenrod";
+  }
+  os << "]\n";
+  for (auto& pair : dependencies_) {
+    os << "n" << pair.second->id() << " -> "
+       << "n" << id_ << " [color=\"" << edgeColour << "\"]\n";
+  }
+}
+
+const char* AccessInfo::AccessTypeColour() const {
+  switch (type_) {
+    case AccessType::Input:
+    case AccessType::Output:
+      return "palegreen";
+    case AccessType::Load:
+      return "peachpuff";
+    case AccessType::Store:
+      return "dodgerblue";
+    case AccessType::Call:
+      return "violet";
+    default:
+      break;
+  }
+  return "white";
+}
+
+// MemDependencyChecker
+//
+MemDependencyChecker::MemDependencyChecker() {
+  currentScope_ = std::make_shared<Scope>(nullptr, nullptr);
+}
+
+MemDependencyChecker::MemDependencyChecker(
+    const std::unordered_set<const Buf*>& inputs,
+    const std::unordered_set<const Buf*>& outputs) {
+  for (auto* s : inputs) {
+    inputs_[s] = nullptr;
+  }
+  for (auto* s : outputs) {
+    outputs_[s] = nullptr;
+  }
+
+  currentScope_ = std::make_shared<Scope>(nullptr, nullptr);
+}
+
+MemDependencyChecker::MemDependencyChecker(
+    const std::vector<BufHandle>& inputs,
+    const std::vector<BufHandle>& outputs) {
+  for (auto& s : inputs) {
+    inputs_[s.node()] = nullptr;
+  }
+  for (auto& s : outputs) {
+    outputs_[s.node()] = nullptr;
+  }
+
+  currentScope_ = std::make_shared<Scope>(nullptr, nullptr);
+}
+
+bool MemDependencyChecker::allowLoopExecutionOrderAnalysis(bool allow) {
+  std::swap(allowExecutionOrderAnalysis_, allow);
+  return allow;
+}
+
+const std::deque<std::shared_ptr<AccessInfo>>& MemDependencyChecker::
+    getHistory() const {
+  return currentScope_->accesses_;
+}
+
+void MemDependencyChecker::dumpDAG(const std::string& filename) const {
+  std::ofstream dotfile(filename);
+
+  dotfile << "digraph {\n";
+  for (auto& wi : getHistory()) {
+    wi->dumpDOT(dotfile);
+  }
+  dotfile << "}\n";
+  dotfile.close();
+}
+
+// dependsDirectly, dependsIndirectly and friends:
+
+DependencySet MemDependencyChecker::getAllWriteDependencies(
+    const DependencySet& products) {
+  DependencySet writes;
+
+  for (auto& info : products) {
+    DependencySet dependencies;
+    getDependencyChain(info, dependencies);
+    for (auto& other : dependencies) {
+      if (other->isWrite()) {
+        writes.insert(other);
+      }
+    }
+  }
+
+  return writes;
+}
+
+bool MemDependencyChecker::dependsDirectly(const Expr* A, const Stmt* B) {
+  return dependsDirectlyHelper(A, B);
+}
+
+bool MemDependencyChecker::dependsDirectly(const Stmt* A, const Stmt* B) {
+  return dependsDirectlyHelper(A, B);
+}
+
+bool MemDependencyChecker::dependsDirectly(const Buf* O, const Stmt* B) {
+  auto outputAccess = output(O);
+  auto bWrites = getAllWritesWithin(B);
+
+  for (auto& depPair : outputAccess->dependencies()) {
+    if (bWrites.count(depPair.second) != 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool MemDependencyChecker::dependsDirectly(const Stmt* A, const Buf* I) {
+  auto aReads = getAllReadsWithin(A);
+  auto inputAccess = input(I);
+
+  for (auto& depPair : inputAccess->dependents()) {
+    if (aReads.count(depPair.second) != 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool MemDependencyChecker::dependsDirectly(const Expr* A, const Buf* I) {
+  auto aReads = getAllReadsWithin(A);
+  auto inputAccess = input(I);
+
+  for (auto& depPair : inputAccess->dependents()) {
+    if (aReads.count(depPair.second) != 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool MemDependencyChecker::dependsDirectly(
+    const std::shared_ptr<AccessInfo>& A,
+    const std::shared_ptr<AccessInfo>& B) {
+  return A->hasDependency(B) && B->isWrite();
+}
+
+bool MemDependencyChecker::dependsIndirectly(const Expr* A, const Stmt* B) {
+  return dependsIndirectlyHelper(A, B);
+}
+
+bool MemDependencyChecker::dependsIndirectly(const Stmt* A, const Stmt* B) {
+  return dependsIndirectlyHelper(A, B);
+}
+
+bool MemDependencyChecker::dependsIndirectly(const Buf* O, const Stmt* B) {
+  auto outputAccess = output(O);
+
+  DependencySet dependencies;
+  getDependencyChain(outputAccess, dependencies);
+
+  auto bWrites = getAllWritesWithin(B);
+  for (auto& dep : dependencies) {
+    if (bWrites.count(dep) != 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool MemDependencyChecker::dependsIndirectly(const Stmt* A, const Buf* I) {
+  auto aReads = getAllReadsWithin(A);
+  auto inputAccess = input(I);
+
+  auto aDeps = getAllWriteDependencies(aReads);
+
+  return aDeps.count(inputAccess) != 0;
+}
+
+bool MemDependencyChecker::dependsIndirectly(const Expr* A, const Buf* I) {
+  auto aReads = getAllReadsWithin(A);
+  auto inputAccess = input(I);
+
+  auto aDeps = getAllWriteDependencies(aReads);
+
+  return aDeps.count(inputAccess) != 0;
+}
+
+bool MemDependencyChecker::dependsIndirectly(const Buf* O, const Buf* I) {
+  auto outputAccess = output(O);
+  auto inputAccess = input(I);
+
+  return dependsIndirectly(outputAccess, inputAccess);
+}
+
+bool MemDependencyChecker::dependsIndirectly(
+    const std::shared_ptr<AccessInfo>& A,
+    const std::shared_ptr<AccessInfo>& B) {
+  if (!B->isWrite()) {
+    return false;
+  }
+
+  DependencySet dependencies;
+  getDependencyChain(A, dependencies);
+  if (dependencies.count(B) == 0) {
+    return false;
+  }
+
+  return true;
+}
+
+std::shared_ptr<AccessInfo> MemDependencyChecker::accessFor(
+    const Stmt* A) const {
+  auto bound = stmtToAccess_.equal_range(A);
+  for (auto it = bound.first; it != bound.second; ++it) {
+    if (it->second->expr() == nullptr) {
+      return it->second;
+    }
+  }
+  return nullptr;
+}
+
+std::shared_ptr<AccessInfo> MemDependencyChecker::accessFor(
+    const Expr* A) const {
+  // TODO exprs can have multiple accesses... we're returning the first but that
+  // isn't great. Can't do much here.
+  auto bound = exprToAccess_.equal_range(A);
+  if (bound.first != exprToAccess_.end()) {
+    return bound.first->second;
+  }
+
+  return nullptr;
+}
+
+std::shared_ptr<AccessInfo> MemDependencyChecker::input(const Buf* b) const {
+  auto it = inputs_.find(b);
+  if (it == inputs_.end()) {
+    return nullptr;
+  }
+  return it->second;
+}
+
+std::shared_ptr<AccessInfo> MemDependencyChecker::output(const Buf* b) const {
+  auto it = outputs_.find(b);
+  if (it == outputs_.end()) {
+    return nullptr;
+  }
+  return it->second;
+}
+
+// Node visitors:
+
+void MemDependencyChecker::visit(const Store* v) {
+  const Stmt* last = lastStmt_;
+  lastStmt_ = v;
+  v->value()->accept(this);
+
+  for (const Expr* ind : v->indices()) {
+    ind->accept(this);
+  }
+  lastStmt_ = last;
+
+  // Create a new AccessInfo for the store.
+  const Var* var = v->buf()->base_handle();
+  auto info = std::make_shared<AccessInfo>(
+      nextAccess_++, AccessType::Store, v, var, getIndicesBounds(v->indices()));
+
+  // Add a dependency to any accesses that are within the scope of this store
+  // (ie. the RHS).
+  auto bound = stmtToAccess_.equal_range(v);
+  for (auto it = bound.first; it != bound.second; ++it) {
+    info->addDependency(it->second);
+    it->second->addDependent(info);
+  }
+
+  stmtToAccess_.emplace(v, info);
+
+  // This write is open, and will close any open writes that it totally
+  // overlaps.
+  auto& history = currentScope_->openWrites_[var];
+  updateWriteHistory(history, info, info->id());
+  currentScope_->accesses_.push_back(info);
+}
+
+void MemDependencyChecker::visit(const Load* v) {
+  // Create a temporary scope to hold any loads that occur within the indices of
+  // this load.
+  auto indicesScope =
+      std::make_shared<Scope>(currentScope_->block, currentScope_);
+  currentScope_ = indicesScope;
+
+  for (const Expr* ind : v->indices()) {
+    ind->accept(this);
+  }
+
+  // Create a new AccessInfo for the load.
+  const Var* var = v->buf()->base_handle();
+  auto load = std::make_shared<AccessInfo>(
+      nextAccess_++,
+      AccessType::Load,
+      v,
+      lastStmt_,
+      var,
+      getIndicesBounds(v->indices()));
+
+  // If there were loads in the indices, this load depends on them, and merge
+  // them in.
+  if (!indicesScope->accesses_.empty()) {
+    for (auto& access : indicesScope->accesses_) {
+      load->addDependency(access);
+      access->addDependent(load);
+    }
+    mergeScope(indicesScope, indicesScope->parent, false);
+  }
+
+  currentScope_ = indicesScope->parent;
+
+  stmtToAccess_.emplace(lastStmt_, load);
+  exprToAccess_.emplace(v, load);
+
+  // This is a read, and does not close any accesses - but we need to establish
+  // dependencies on accesses in the same scope.
+  // Intentionally using operator[], we want it to be created if it does not
+  // exist.
+  auto& writeHistory = currentScope_->openWrites_[var];
+  updateWriteHistory(writeHistory, load, load->id());
+  currentScope_->accesses_.push_back(load);
+}
+
+void MemDependencyChecker::visit(const FunctionCall* v) {
+  // This is essentially the same as Load.
+  auto paramScope =
+      std::make_shared<Scope>(currentScope_->block, currentScope_);
+  currentScope_ = paramScope;
+
+  for (const Expr* param : v->params()) {
+    param->accept(this);
+  }
+
+  const Var* var = v->tensor()->buf()->base_handle();
+  auto call = std::make_shared<AccessInfo>(
+      nextAccess_++,
+      AccessType::Call,
+      v,
+      lastStmt_,
+      var,
+      getIndicesBounds(v->params()));
+
+  // If there were loads in the parameters, this call depends on them, also
+  // merge.
+  if (!paramScope->accesses_.empty()) {
+    for (auto& access : paramScope->accesses_) {
+      call->addDependency(access);
+      access->addDependent(call);
+    }
+    mergeScope(paramScope, paramScope->parent, false);
+  }
+
+  currentScope_ = paramScope->parent;
+
+  stmtToAccess_.emplace(lastStmt_, call);
+  exprToAccess_.emplace(v, call);
+
+  // Intentionally using operator[], we want it to be created if it does not
+  // exist.
+  auto& writeHistory = currentScope_->openWrites_[var];
+  updateWriteHistory(writeHistory, call, call->id());
+  currentScope_->accesses_.push_back(call);
+}
+
+void MemDependencyChecker::visit(const ReduceOp* v) {
+  auto indicesScope =
+      std::make_shared<Scope>(currentScope_->block, currentScope_);
+  currentScope_ = indicesScope;
+
+  for (const Expr* ind : v->output_args()) {
+    ind->accept(this);
+  }
+
+  const Var* var = v->accumulator()->base_handle();
+
+  // ReduceOps are functionally Loads, and the distinction isn't meaningful so
+  // just record them as Loads. They get lowered directly to load during
+  // prepareForCodegen anyway.
+  auto load = std::make_shared<AccessInfo>(
+      nextAccess_++,
+      AccessType::Load,
+      v,
+      lastStmt_,
+      var,
+      getIndicesBounds(v->output_args()));
+
+  // If there were loads in the output_args, this call depends on them, also
+  // merge.
+  if (!indicesScope->accesses_.empty()) {
+    for (auto& access : indicesScope->accesses_) {
+      load->addDependency(access);
+      access->addDependent(load);
+    }
+    mergeScope(indicesScope, indicesScope->parent, false);
+  }
+
+  stmtToAccess_.emplace(lastStmt_, load);
+  exprToAccess_.emplace(v, load);
+
+  // Intentionally using operator[], we want it to be created if it does not
+  // exist.
+  auto& writeHistory = currentScope_->openWrites_[var];
+  updateWriteHistory(writeHistory, load, load->id());
+  currentScope_->accesses_.push_back(load);
+
+  // accept the body of the reduction to handle further reads.
+  v->body().node()->accept(this);
+}
+
+// This check determines if two accesses within a loop are "safe" from loop-self
+// dependence. This function does not consider overlap in bound range, but
+// rather the stride of the bound relative to the loop variable. This is the
+// section of the code which considers iteration order, if allowed.
+bool executionSafetyCheck(
+    const std::shared_ptr<AccessInfo>& info,
+    const std::shared_ptr<AccessInfo>& other,
+    const std::vector<const Expr*>& aStrides,
+    const std::vector<const Expr*>& oStrides,
+    bool parallelized) {
+  for (size_t b = 0; b < info->bounds().size(); ++b) {
+    const Expr* aIndexStride = aStrides[b];
+    const Expr* oIndexStride = oStrides[b];
+    // can't be safe on this index if we can't determine stride.
+    if (!aIndexStride->isConstant() || !oIndexStride->isConstant()) {
+      continue;
+    }
+
+    const Expr* minStride =
+        IRSimplifier::simplify(new Min(aIndexStride, oIndexStride, true));
+    const Expr* maxStride =
+        IRSimplifier::simplify(new Max(aIndexStride, oIndexStride, true));
+
+    // If the first access has no stride don't apply safety).
+    if (immediateEquals(minStride, 0)) {
+      continue;
+    }
+
+    const Expr* modCheck =
+        IRSimplifier::simplify(new Mod(maxStride, minStride));
+
+    // if the strides can't have easily inferable distinct offsets, they're not
+    // safe.
+    if (!immediateEquals(modCheck, 0)) {
+      continue;
+    }
+
+    // If the loop has a defined execution order (ie. sequential for) then
+    // the order of execution can provide safety from overlaps.
+    // Specifically if the difference in first access position for any
+    // axis is the same sign as the common stride, then they will not
+    // overlap.
+
+    const Expr* startDiff = IRSimplifier::simplify(
+        new Sub(info->bounds()[b].start, other->bounds()[b].start));
+
+    bool diffNegative = immediateIsNegative(startDiff);
+    bool strideNegative = immediateIsNegative(minStride);
+
+    // Invert the startDiff so mod works.
+    if (diffNegative != strideNegative) {
+      startDiff = IRSimplifier::simplify(new Sub(new IntImm(0), startDiff));
+    }
+
+    // If both accesses have the same stride, and the difference in start
+    // element is smaller than this stride then the entire range is distinct.
+    if (exprEquals(minStride, maxStride)) {
+      const Expr* check1 =
+          IRSimplifier::simplify(new CompareSelect(startDiff, minStride, kLT));
+      if (check1->isConstant() && immediateEquals(check1, 1)) {
+        return true;
+      }
+    }
+
+    startDiff = IRSimplifier::simplify(new Mod(startDiff, minStride));
+
+    CompareSelectOperation op = strideNegative ? kLT : kGT;
+
+    const Expr* check =
+        IRSimplifier::simplify(new CompareSelect(startDiff, new IntImm(0), op));
+
+    // If the start difference modulo the minimum stride is offset from that
+    // stride, then the ranges have distinct strides.
+    if (check->isConstant() && immediateEquals<int>(check, 1)) {
+      return true;
+    }
+
+    // If we can consider execution order and the difference in offset is
+    // opposite signed to the stride then the read occurs in the past and we can
+    // infer safety.
+    if (!parallelized && diffNegative == strideNegative &&
+        immediateEquals(startDiff, 0)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void MemDependencyChecker::visit(const For* v) {
+  const Var* var = v->var();
+
+  const Stmt* last = lastStmt_;
+  lastStmt_ = v;
+
+  v->var()->accept(this);
+
+  // Loads inside the For's start and stop expression are special.
+  // They exist in the enclosing scope, but accesses within the loop body may
+  // depend on them via usage of the loop variable.
+  // The way we handle this is to create a new scope so we have an easily
+  // accessible list of the acceses within the extents.
+  auto extentsScope =
+      std::make_shared<Scope>(currentScope_->block, currentScope_);
+  currentScope_ = extentsScope;
+
+  v->start()->accept(this);
+  v->stop()->accept(this);
+
+  currentScope_ = currentScope_->parent;
+
+  auto newScope = std::make_shared<Scope>(v->body(), currentScope_);
+  currentScope_ = newScope;
+
+  v->body()->accept(this);
+
+  lastStmt_ = last;
+
+  // Ok now we need to determine whether accesses in the loop depend on
+  // other loop iterations.
+  //
+  // This is the real challenge here, it depends on both the fully expanded
+  // bounds and the symbolic bounds.
+
+  // The indices must change monotonically to avoid intersection. This is
+  // hard to determine, so here's our heuristic I hope it's conservative
+  // enough.
+
+  // the size of at least one dependent index must be >= the size of the
+  // loop.
+
+  // First step is to infer the stride relative to each dimension of each
+  // access, which we do via substituting the loop var with (var+1) into the
+  // indices expr.
+
+  std::vector<std::vector<const Expr*>> loopStrides;
+  loopStrides.resize(currentScope_->accesses_.size());
+
+  for (size_t a = 0; a < currentScope_->accesses_.size(); ++a) {
+    auto& info = currentScope_->accesses_[a];
+
+    std::vector<const Expr*> indices = info->getIndices();
+
+    std::vector<const Expr*>& loopIndicesStride = loopStrides[a];
+    loopIndicesStride.resize(indices.size());
+
+    // index expr must depend on the loop var in some way to have a stride.
+    for (size_t i = 0; i < indices.size(); i++) {
+      VarFinder vf;
+      if (vf.find(indices[i]).count(var) == 0) {
+        loopIndicesStride[i] = new IntImm(0);
+      } else {
+        // If we've previously swapped the start and end of this bound, we
+        // should apply the substitution to the reverse of the bounds.
+        if (info->bounds()[i].swapped) {
+          info->bounds()[i].end = IRSimplifier::simplify(
+              Substitute(info->bounds()[i].end, {{var, v->start()}}));
+          info->bounds()[i].start = IRSimplifier::simplify(Substitute(
+              info->bounds()[i].start,
+              {{var, new Sub(v->stop(), new IntImm(1))}}));
+
+        } else {
+          info->bounds()[i].start = IRSimplifier::simplify(
+              Substitute(info->bounds()[i].start, {{var, v->start()}}));
+          info->bounds()[i].end = IRSimplifier::simplify(Substitute(
+              info->bounds()[i].end,
+              {{var, new Sub(v->stop(), new IntImm(1))}}));
+        }
+
+        const Expr* zeroStep = indices[i];
+        const Expr* oneStep =
+            Substitute(indices[i], {{var, new Add(var, new IntImm(1))}});
+        loopIndicesStride[i] =
+            IRSimplifier::simplify(new Sub(oneStep, zeroStep));
+
+        // If the start < end then swap the order of the bound.
+        const Expr* diff = IRSimplifier::simplify(
+            new Sub(info->bounds()[i].end, info->bounds()[i].start));
+        if (diff->isConstant() && immediateIsNegative(diff)) {
+          info->bounds()[i].swap();
+        }
+
+        // If this access uses the loop var, it depends on loads used to compute
+        // the loop var.
+        for (auto& extentLoad : extentsScope->accesses_) {
+          info->addDependency(extentLoad);
+          extentLoad->addDependent(info);
+        }
+      }
+    }
+  }
+
+  // Now we need to update the bounds in openWrites since that is what we use to
+  // merge.
+  for (auto& openWritePair : currentScope_->openWrites_) {
+    for (auto& pair : openWritePair.second) {
+      IndexBounds& bounds = pair.first;
+
+      // The bounds may not contain the loop var, but in that case Substitute
+      // does nothing.
+      for (auto& bound : bounds) {
+        bound.start = IRSimplifier::simplify(
+            Substitute(bound.start, {{var, v->start()}}));
+        bound.end = IRSimplifier::simplify(
+            Substitute(bound.end, {{var, new Sub(v->stop(), new IntImm(1))}}));
+
+        // If the start < end then swap the order of the bound.
+        const Expr* diff =
+            IRSimplifier::simplify(new Sub(bound.end, bound.start));
+        if (diff->isConstant() && immediateIsNegative(diff)) {
+          bound.swap();
+        }
+      }
+    }
+  }
+
+  // TODO this isn't a scalable way to determine parallelism.
+  bool parallelized = v->loop_options().is_gpu_block_index() ||
+      v->loop_options().is_gpu_thread_index();
+
+  // Scanning from the top of the loop, we look for accesses which may depend
+  // on a previous or parallel loop iteration.
+  for (size_t a = 0; a < currentScope_->accesses_.size(); ++a) {
+    auto& info = currentScope_->accesses_[a];
+    if (!info->isRead()) {
+      continue;
+    }
+
+    // Copy the bounds so we can keep track of open bounds internally without
+    // affecting the merge into the enclosing scope. The open portion of the
+    // bounds may be cut into multiple independent slices.
+    std::vector<IndexBounds> openBounds({info->bounds()});
+
+    // Scan from the bottom of the loop.
+    for (size_t j = currentScope_->accesses_.size() - 1; j > a; --j) {
+      std::shared_ptr<AccessInfo> other = currentScope_->accesses_[j];
+      if (!other->isWrite()) {
+        continue;
+      }
+
+      if (info->var() != other->var()) {
+        continue;
+      }
+
+      if (info->hasDependency(other)) {
+        continue;
+      }
+
+      // Whether or not the accesses within the loop are dependent on other
+      // iterations depends whether the loop could be parallelized, the
+      // difference in their strides and their start offset.
+      bool iterationsDistinct = executionSafetyCheck(
+          info,
+          other,
+          loopStrides[a],
+          loopStrides[j],
+          !allowExecutionOrderAnalysis_ || parallelized);
+
+      if (iterationsDistinct) {
+        continue;
+      }
+
+      std::vector<IndexBounds> newBoundSlices;
+      for (auto& b : openBounds) {
+        OverlapKind overlap = overlaps(b, other->bounds());
+        if (overlap == NoOverlap) {
+          newBoundSlices.push_back(b);
+          continue;
+        }
+
+        // It's dependent, link it to other.
+        info->addDependency(other);
+        other->addDependent(info);
+
+        if (overlap == Contains) {
+          continue;
+        }
+
+        // Otherwise update openBounds.
+        auto slices = subtractIndicesBounds(b, other->bounds(), overlap);
+        std::move(
+            slices.begin(), slices.end(), std::back_inserter(newBoundSlices));
+      }
+
+      if (newBoundSlices.empty()) {
+        break;
+      }
+      openBounds.swap(newBoundSlices);
+    }
+  }
+
+  // it's a little faster to merge without closing, and since no writes can
+  // occur within the start and stop exprs we'll do that.
+  mergeScope(extentsScope, extentsScope->parent, false);
+  mergeScope(currentScope_, currentScope_->parent, true);
+  currentScope_ = currentScope_->parent;
+}
+
+void MemDependencyChecker::visit(const Cond* v) {
+  const Stmt* last = lastStmt_;
+  lastStmt_ = v;
+
+  // condition is in enclosing scope.
+  v->condition()->accept(this);
+
+  Block* true_stmt = v->true_stmt();
+  Block* false_stmt = v->false_stmt();
+
+  auto enclosingScope = currentScope_;
+  // Create scopes so the Block visitor doesn't create and merge a new scope.
+  auto trueScope = std::make_shared<Scope>(true_stmt, enclosingScope);
+  auto falseScope = std::make_shared<Scope>(false_stmt, enclosingScope);
+
+  if (true_stmt) {
+    currentScope_ = trueScope;
+    true_stmt->accept(this);
+  }
+
+  if (false_stmt) {
+    currentScope_ = falseScope;
+    false_stmt->accept(this);
+  }
+
+  // TODO(nickg): this logic isn't quite correct, if a write's Bound range is
+  // present in both the true and false branches then we can close overlapping
+  // accesses in the enclosing scope. Without that analysis future accesses
+  // may be dependent on a write of a common range in all three of the
+  // enclosing, true and false scope. This is a false positve so not too bad
+  // in the short term, I think.
+
+  // Merge both true and false branches into the parent, but don't close any
+  // accesses.
+  mergeScope(trueScope, enclosingScope, false);
+  mergeScope(falseScope, enclosingScope, false);
+
+  currentScope_ = enclosingScope;
+  lastStmt_ = last;
+}
+
+void MemDependencyChecker::visit(const IfThenElse* v) {
+  // condition is in enclosing scope.
+  v->condition()->accept(this);
+
+  const Expr* true_value = v->true_value();
+  const Expr* false_value = v->false_value();
+
+  auto enclosingScope = currentScope_;
+
+  // Create scopes to hold downstream Loads. It's safe to put nullptr for the
+  // Scope's Block as it is only used by Stmts, not Exprs.
+  auto trueScope = std::make_shared<Scope>(nullptr, enclosingScope);
+  auto falseScope = std::make_shared<Scope>(nullptr, enclosingScope);
+
+  if (true_value) {
+    currentScope_ = trueScope;
+    true_value->accept(this);
+  }
+
+  if (false_value) {
+    currentScope_ = falseScope;
+    false_value->accept(this);
+  }
+
+  // This doesn't have the same issue as Cond where there could be false
+  // positives from the enclosing scope since there are no Exprs which are
+  // writes.
+
+  // Merge both true and false branches into the parent, but don't close any
+  // accesses.
+  mergeScope(trueScope, enclosingScope, false);
+  mergeScope(falseScope, enclosingScope, false);
+
+  currentScope_ = enclosingScope;
+}
+
+void MemDependencyChecker::visit(const CompareSelect* v) {
+  // condition is in enclosing scope.
+  v->lhs()->accept(this);
+  v->rhs()->accept(this);
+
+  const Expr* true_value = v->ret_val1();
+  const Expr* false_value = v->ret_val2();
+
+  auto enclosingScope = currentScope_;
+
+  // Create scopes to hold downstream Loads. It's safe to put nullptr for the
+  // Scope's Block as it is only used by Stmts, not Exprs.
+  auto trueScope = std::make_shared<Scope>(nullptr, enclosingScope);
+  auto falseScope = std::make_shared<Scope>(nullptr, enclosingScope);
+
+  if (true_value) {
+    currentScope_ = trueScope;
+    true_value->accept(this);
+  }
+
+  if (false_value) {
+    currentScope_ = falseScope;
+    false_value->accept(this);
+  }
+
+  // This doesn't have the same issue as Cond where there could be false
+  // positives from the enclosing scope since there are no Exprs which are
+  // writes.
+
+  // Merge both true and false branches into the parent, but don't close any
+  // accesses.
+  mergeScope(trueScope, enclosingScope, false);
+  mergeScope(falseScope, enclosingScope, false);
+
+  currentScope_ = enclosingScope;
+}
+
+// Inserts accesses for a map of buffers (ie. for inputs and outputs).
+void MemDependencyChecker::insertBuffers(
+    std::unordered_map<const Buf*, std::shared_ptr<AccessInfo>>& bufs,
+    AccessType type) {
+  for (auto& pair : bufs) {
+    const Buf* b = pair.first;
+    const Var* var = b->base_handle();
+    IndexBounds bounds;
+    for (auto* d : b->dims()) {
+      bounds.push_back(
+          {new IntImm(0), IRSimplifier::simplify(new Sub(d, new IntImm(1)))});
+    }
+    auto info =
+        std::make_shared<AccessInfo>(nextAccess_++, type, nullptr, var, bounds);
+
+    bufs[b] = info;
+
+    auto& history = currentScope_->openWrites_[var];
+    updateWriteHistory(history, info, info->id());
+    currentScope_->accesses_.push_back(info);
+  }
+}
+
+void MemDependencyChecker::visit(const Block* v) {
+  auto prev_scope = currentScope_;
+
+  // handle kernel inputs.
+  if (prev_scope->block == nullptr) {
+    insertBuffers(inputs_, AccessType::Input);
+  }
+
+  if (currentScope_->block != v) {
+    currentScope_ = std::make_shared<Scope>((Block*)v, prev_scope);
+  }
+
+  for (auto* s : *v) {
+    s->accept(this);
+  }
+
+  for (auto* v : currentScope_->localVars) {
+    knownVarBounds_.erase(v);
+  }
+  for (auto& pair : currentScope_->shadowedVarBounds) {
+    knownVarBounds_[pair.first] = pair.second;
+  }
+
+  if (currentScope_ != prev_scope) {
+    mergeScope(currentScope_, prev_scope, true);
+    currentScope_ = prev_scope;
+  }
+
+  // handle kernel outputs.
+  if (prev_scope->block == nullptr) {
+    insertBuffers(outputs_, AccessType::Output);
+  }
+}
+
+void MemDependencyChecker::visit(const Let* v) {
+  const Stmt* last = lastStmt_;
+  lastStmt_ = v;
+
+  IRVisitor::visit(v);
+
+  lastStmt_ = last;
+
+  const Var* var = v->var();
+  if (knownVarBounds_.count(var) != 0) {
+    currentScope_->shadowedVarBounds[var] = knownVarBounds_[var];
+  }
+
+  currentScope_->localVars.insert(var);
+  knownVarBounds_[var] = {v->value(), v->value()};
+}
+
+// Don't support AtomicAdd yet, it's a bit more complex since it's both a read
+// and a write. It's only inserted during Cuda codegen so this should be okay.
+void MemDependencyChecker::visit(const AtomicAdd* v) {
+  throw std::runtime_error("MemDependencyChecker AtomicAdd unimplemented");
+}
+
+void MemDependencyChecker::updateWriteHistory(
+    std::list<BoundRelationship>& writeHistory,
+    const std::shared_ptr<AccessInfo>& info,
+    size_t latestAccessToClose,
+    bool closeOverlapped,
+    bool insert) {
+  bool isWrite = info->isWrite();
+
+  for (auto it = writeHistory.begin(); it != writeHistory.end();) {
+    auto& indexBounds = it->first;
+    std::shared_ptr<AccessInfo> other = it->second;
+    if (info->hasDependency(other)) {
+      ++it;
+      continue;
+    }
+
+    OverlapKind overlap = overlaps(indexBounds, info->bounds());
+
+    if (overlap == NoOverlap) {
+      ++it;
+      continue;
+    }
+
+    // Only writes can close open accesses.
+    if (!isWrite) {
+      info->addDependency(other);
+      other->addDependent(info);
+      ++it;
+      continue;
+    }
+
+    // If we're not closing accesses we can stop here.
+    if (!closeOverlapped || other->id() > latestAccessToClose) {
+      ++it;
+      continue;
+    }
+
+    if (overlap == ContainedOrEqual) {
+      // Total overlap is easy - the new access totally replaces the old.
+      it = writeHistory.erase(it);
+    } else {
+      // The new write partially overlaps a previous write. We want to keep
+      // both, but only track the unconvered part of the earlier write.
+
+      // Determine the slices of the earlier bound not covered by info.
+      auto newBounds =
+          subtractIndicesBounds(indexBounds, info->bounds(), overlap);
+
+      // Erase the old slice.
+      it = writeHistory.erase(it);
+
+      // Add all new slices.
+      for (auto& b : newBounds) {
+        it = writeHistory.insert(it, std::make_pair(b, other));
+      }
+      it++;
+    }
+  }
+
+  if (insert && isWrite) {
+    writeHistory.emplace_back(std::make_pair(info->bounds(), info));
+  }
+}
+
+void MemDependencyChecker::mergeScope(
+    const std::shared_ptr<Scope>& child,
+    const std::shared_ptr<Scope>& parent,
+    bool closeOverlapped) {
+  if (child->accesses_.empty()) {
+    return;
+  }
+
+  // Update dependencies, but don't add new open writes yet.
+  for (auto& info : child->accesses_) {
+    // Intentionally using operator[], we want it to be created if it does not
+    // exist.
+    auto& writeHistory = parent->openWrites_[info->var()];
+
+    size_t latestAccessToClose = child->accesses_.front()->id();
+    updateWriteHistory(
+        writeHistory, info, latestAccessToClose, closeOverlapped, false);
+  }
+
+  // Copy open writes up.
+  for (auto& pair : child->openWrites_) {
+    const Var* var = pair.first;
+
+    // Intentionally using operator[], we want it to be created if it does not
+    // exist.
+    auto& writeHistory = parent->openWrites_[var];
+
+    for (auto& rel : pair.second) {
+      writeHistory.push_back(rel);
+    }
+  }
+
+  // the parent scope is responsible for holding all accesses now.
+  parent->accesses_.insert(
+      parent->accesses_.end(),
+      std::make_move_iterator(child->accesses_.begin()),
+      std::make_move_iterator(child->accesses_.end()));
+}
+
+// A visitor which applies known Bounds to symbolic expressions.
+class VarBoundBinder : public IRVisitor {
+ public:
+  VarBoundBinder(const VarBoundMap& vars) : vars_(vars) {}
+
+  Bound getBounds(const Expr* e) {
+    min_ = e;
+    max_ = e;
+    e->accept(this);
+    min_ = IRSimplifier::simplify(min_);
+    max_ = IRSimplifier::simplify(max_);
+    return {min_, max_};
+  }
+
+ private:
+  void visit(const Var* v) override {
+    auto it = vars_.find(v);
+    if (it == vars_.end()) {
+      return;
+    }
+
+    min_ = Substitute(min_, {{v, it->second.start}});
+    max_ = Substitute(max_, {{v, it->second.end}});
+  }
+
+  const Expr* min_{nullptr};
+  const Expr* max_{nullptr};
+  const VarBoundMap& vars_;
+};
+
+std::vector<Bound> MemDependencyChecker::getIndicesBounds(
+    const std::vector<const Expr*>& indices) {
+  std::vector<Bound> bounds;
+  bounds.reserve(indices.size());
+  VarBoundBinder binder(knownVarBounds_);
+  for (auto* s : indices) {
+    bounds.push_back(binder.getBounds(s));
+  }
+  return bounds;
+}
+
+} // namespace analysis
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -1,0 +1,402 @@
+#pragma once
+#include <c10/core/ScalarType.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <deque>
+#include <vector>
+
+#include <torch/csrc/jit/tensorexpr/bounds_overlap.h>
+#include <torch/csrc/jit/tensorexpr/ir_mutator.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/ir_visitor.h>
+#include <torch/csrc/jit/tensorexpr/stmt.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+namespace analysis {
+
+enum class AccessType { Input, Output, Load, Store, Call, AtomicAdd };
+const char* AccessToString(AccessType a);
+
+class AccessInfo;
+using DependencySet = std::unordered_set<std::shared_ptr<AccessInfo>>;
+
+/* AccessInfo
+ *
+ * Represents a single bounded memory access to a buffer, for instance a Load or
+ * a Store. Holds infomation relating to the specific access and links to
+ * connected accesses in the dependency graph.
+ */
+class TORCH_API AccessInfo {
+ public:
+  AccessInfo(
+      size_t id,
+      AccessType type,
+      const Stmt* stmt,
+      const Var* var,
+      IndexBounds bounds)
+      : id_(id),
+        type_(type),
+        stmt_(stmt),
+        expr_(nullptr),
+        var_(var),
+        bounds_(bounds) {}
+
+  AccessInfo(
+      size_t id,
+      AccessType type,
+      const Expr* expr,
+      const Stmt* stmt,
+      const Var* var,
+      IndexBounds bounds)
+      : id_(id),
+        type_(type),
+        stmt_(stmt),
+        expr_(expr),
+        var_(var),
+        bounds_(bounds) {}
+
+  // Id is a unique int representing the order this access occured in the graph.
+  size_t id() const {
+    return id_;
+  }
+
+  // The type of the access (Load, Store, etc).
+  AccessType type() const {
+    return type_;
+  }
+
+  // The enclosing Stmt this access represents. E.g. if this is a Store then
+  // Stmt is the Store itself, while if the access is caused by an Expr, this is
+  // the most immediate parent Stmt.
+  const Stmt* stmt() const {
+    return stmt_;
+  }
+
+  // If the access is represented by an Expr (such as Load or Call) then this is
+  // it, otherwise it's nullptr.
+  const Expr* expr() const {
+    return expr_;
+  }
+
+  // The Var representing the underlying Buffer.
+  const Var* var() const {
+    return var_;
+  }
+
+  // A vector of Bounds representing the start and end expression for each
+  // dimension.
+  IndexBounds& bounds() {
+    return bounds_;
+  }
+
+  // Each access that this depends upon,
+  // eg. if this is a Load, then it contains every Store that immediately
+  // contributes to a load of the bounds.
+  // or: if this is a Store, it contains all reads on the RHS of the Store.
+  const std::map<size_t, std::shared_ptr<AccessInfo>>& dependencies() const {
+    return dependencies_;
+  }
+
+  // Each access that depends on this one.
+  // ie. this access is present in the dependencies map of all accesses that are
+  // dependent.
+  const std::map<size_t, std::shared_ptr<AccessInfo>>& dependents() const {
+    return dependents_;
+  }
+
+  // Returns the symbolic expression of the indices of this access.
+  std::vector<const Expr*> getIndices() const;
+
+  // Establishes a dependency or dependent relationship with another access.
+  void addDependency(const std::shared_ptr<AccessInfo>& write);
+  void addDependent(const std::shared_ptr<AccessInfo>& read);
+
+  // helper for checking dependencies.
+  bool hasDependency(const std::shared_ptr<AccessInfo>& info) const;
+
+  // Returns the set of all nodes that are direct (immediate) dependencies of
+  // this access.
+  DependencySet getDirectDependencies();
+  // likewise, returns all nodes that directly depend on this one.
+  DependencySet getDirectDependents();
+
+  // Returns the full list of all nodes in the graph that this access depends
+  // on, and all nodes they depend on, and so forth, back to the inputs.
+  DependencySet getIndirectDependencies();
+  // likewise, returns the full list of all nodes that depend on this node, and
+  // all nodes that depend on those nodes and so on down to the outputs.
+  DependencySet getIndirectDependents();
+
+  // Does this access represent a read of memory (Load, ReduceOp, Call, etc).
+  bool isRead() const;
+  // Does this access represent a write of memory (Store, etc).
+  bool isWrite() const;
+
+  // Helpers for dumping accesses in various formats.
+  void print() const;
+  void dumpDOT(std::ostream& os) const;
+  const char* AccessTypeColour() const;
+
+ private:
+  size_t id_;
+  AccessType type_;
+  const Stmt* stmt_;
+  const Expr* expr_;
+  const Var* var_;
+  IndexBounds bounds_;
+
+  // Yes these should be sorted.
+  std::map<size_t, std::shared_ptr<AccessInfo>> dependencies_;
+  std::map<size_t, std::shared_ptr<AccessInfo>> dependents_;
+};
+
+using VarBoundMap = std::unordered_map<const Var*, Bound>;
+
+/* MemDepedencyChecker analyses a IR fragment and builds a dependency graph of
+ * accesses contained within.
+ *
+ * It's possible to retrieve the entire graph in node-object form, or can be
+ * used as an oracle for answering dependency questions. e.g:
+ *
+ *  analyzer.hasIndirectDependency(BufA, BufB); or,
+ *  analyzer.hasDirectDependency(LoadA, StoreB);
+ */
+class TORCH_API MemDependencyChecker : public IRVisitor {
+  struct Scope;
+
+ public:
+  MemDependencyChecker();
+  MemDependencyChecker(
+      const std::unordered_set<const Buf*>& inputs,
+      const std::unordered_set<const Buf*>& outputs);
+  MemDependencyChecker(
+      const std::vector<BufHandle>& inputs,
+      const std::vector<BufHandle>& outputs);
+
+  virtual ~MemDependencyChecker() {}
+
+  // Whether or not to allow loop execution order to influence dependency
+  // calculation. If the loop may later be parallelized you don't want this.
+  bool allowLoopExecutionOrderAnalysis(bool allow = true);
+
+  // Dependency Checking API.
+  // The goal is to have enough overloads here so you don't really have to think
+  // about it.
+
+  // Returns true if any read in A has a direct dependence on a write in B.
+  bool dependsDirectly(const Stmt* A, const Stmt* B);
+  bool dependsDirectly(const Expr* A, const Stmt* B);
+
+  // Returns true of the output depends directly on a write contained in B.
+  bool dependsDirectly(const Buf* output, const Stmt* B);
+
+  // Returns true if a read in A depends directly on the provided input.
+  bool dependsDirectly(const Stmt* A, const Buf* input);
+  bool dependsDirectly(const Expr* A, const Buf* input);
+
+  // Outputs/inputs cannot depend directly.
+
+  // Returns true if the access A has B as an immediate dependency.
+  bool dependsDirectly(
+      const std::shared_ptr<AccessInfo>& A,
+      const std::shared_ptr<AccessInfo>& B);
+
+  // Returns true if any read in A has an ancestor write contained in B.
+  bool dependsIndirectly(const Stmt* A, const Stmt* B);
+  bool dependsIndirectly(const Expr* A, const Stmt* B);
+
+  // Returns true of the output depends indirectly on a write contained in B.
+  bool dependsIndirectly(const Buf* output, const Stmt* B);
+
+  // Returns true if a read in A depends indirectly on the provided input.
+  bool dependsIndirectly(const Stmt* A, const Buf* input);
+  bool dependsIndirectly(const Expr* A, const Buf* input);
+
+  // returns true if the output uses any load of the input.
+  bool dependsIndirectly(const Buf* output, const Buf* input);
+
+  // Returns true if the access A has a dependency chain to access B.
+  bool dependsIndirectly(
+      const std::shared_ptr<AccessInfo>& A,
+      const std::shared_ptr<AccessInfo>& B);
+
+  // Retuns the AccessInfo
+  std::shared_ptr<AccessInfo> accessFor(const Stmt* A) const;
+  std::shared_ptr<AccessInfo> accessFor(const Expr* A) const;
+
+  // Accesses relating to input and output buffers.
+  std::shared_ptr<AccessInfo> input(const Buf* B) const;
+  std::shared_ptr<AccessInfo> output(const Buf* B) const;
+
+  // Returns the full history of reads and writes.
+  const std::deque<std::shared_ptr<AccessInfo>>& getHistory() const;
+
+  // Dumps the dependency graph in DOT format.
+  void dumpDAG(const std::string& filename) const;
+
+ private:
+  // Node visitors.
+  void visit(const Store* v) override;
+  void visit(const Load* v) override;
+  void visit(const FunctionCall* v) override;
+  void visit(const ReduceOp* v) override;
+  void visit(const For* v) override;
+  void visit(const Cond* v) override;
+  void visit(const IfThenElse* v) override;
+  void visit(const CompareSelect* v) override;
+  void visit(const Block* v) override;
+  void visit(const Let* v) override;
+  void visit(const AtomicAdd* v) override;
+
+#define STMT_ON_STACK(Op)                    \
+  virtual void visit(const Op* v) override { \
+    const Stmt* last = lastStmt_;            \
+    lastStmt_ = v;                           \
+    IRVisitor::visit(v);                     \
+    lastStmt_ = last;                        \
+  }
+  STMT_ON_STACK(Allocate);
+  STMT_ON_STACK(Free);
+
+#undef STMT_ON_STACK
+
+  using BoundRelationship = std::pair<IndexBounds, std::shared_ptr<AccessInfo>>;
+
+  // An internal struct holding the accesses found within a scope Block.
+  struct Scope {
+    Scope(Block* b, std::shared_ptr<Scope> p) : block(b), parent(p) {}
+
+    Block* block;
+    std::shared_ptr<Scope> parent;
+
+    std::unordered_map<const Var*, Bound> shadowedVarBounds;
+    std::unordered_set<const Var*> localVars;
+
+    std::deque<std::shared_ptr<AccessInfo>> accesses_;
+
+    std::unordered_map<const Var*, std::list<BoundRelationship>> openWrites_;
+  };
+  std::shared_ptr<Scope> currentScope_;
+
+  bool allowExecutionOrderAnalysis_{false};
+
+  std::unordered_multimap<const Stmt*, std::shared_ptr<AccessInfo>>
+      stmtToAccess_;
+  std::unordered_multimap<const Expr*, std::shared_ptr<AccessInfo>>
+      exprToAccess_;
+
+  VarBoundMap knownVarBounds_;
+
+  // Finds all accesses that are reads within the scope of v.
+  template <typename StmtOrExpr>
+  DependencySet getAllReadsWithin(const StmtOrExpr* v) {
+    DependencySet reads;
+    auto insertAllReads = [&](const auto& nodes) {
+      for (auto* l : nodes) {
+        auto bound = exprToAccess_.equal_range(l);
+        for (auto it = bound.first; it != bound.second; ++it) {
+          if (it->second->isRead()) {
+            reads.insert(it->second);
+          }
+        }
+      }
+    };
+
+    // Look for and insert accesses belonging to all nodes that act like reads.
+    insertAllReads(NodeFinder<Load>::find(v));
+    insertAllReads(NodeFinder<FunctionCall>::find(v));
+    insertAllReads(NodeFinder<ReduceOp>::find(v));
+
+    return reads;
+  }
+
+  // Finds all accesses that are writes within the scope of v.
+  // Writes cannot occur in Exprs, so this is a little simpler.
+  DependencySet getAllWritesWithin(const Stmt* v) {
+    DependencySet writes;
+
+    // writes just Store currently.
+    auto stores = NodeFinder<Store>::find(v);
+    for (auto* s : stores) {
+      auto bound = stmtToAccess_.equal_range(s);
+      for (auto it = bound.first; it != bound.second; ++it) {
+        if (it->second->isWrite()) {
+          writes.insert(it->second);
+        }
+      }
+    }
+    return writes;
+  }
+
+  // Templated helpers to work on either Exprs or Stmts.
+  template <typename StmtOrExpr>
+  bool dependsDirectlyHelper(const StmtOrExpr* A, const Stmt* B) {
+    auto aReads = getAllReadsWithin(A);
+    auto bWrites = getAllWritesWithin(B);
+
+    for (auto& read : aReads) {
+      for (auto& depPair : read->dependencies()) {
+        if (bWrites.count(depPair.second) != 0) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  template <typename StmtOrExpr>
+  bool dependsIndirectlyHelper(const StmtOrExpr* A, const Stmt* B) {
+    auto aReads = getAllReadsWithin(A);
+    auto bWrites = getAllWritesWithin(B);
+
+    auto aDeps = getAllWriteDependencies(aReads);
+
+    for (auto& dependency : aDeps) {
+      if (bWrites.count(dependency) != 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  DependencySet getAllWriteDependencies(const DependencySet& products);
+
+  // Maps for inputs and outputs, since they aren't present directly in the IR.
+  std::unordered_map<const Buf*, std::shared_ptr<AccessInfo>> inputs_;
+  std::unordered_map<const Buf*, std::shared_ptr<AccessInfo>> outputs_;
+
+  // Inserts accesses for Buf's: specifically for inputs and outputs.
+  void insertBuffers(
+      std::unordered_map<const Buf*, std::shared_ptr<AccessInfo>>& bufs,
+      AccessType type);
+
+  // Update the write history with a new write, adding dependencies and closing
+  // any overlapped writes (if possible).
+  void updateWriteHistory(
+      std::list<BoundRelationship>& writeHistory,
+      const std::shared_ptr<AccessInfo>& info,
+      size_t latestAccessToClose,
+      bool closeOverlapped = true,
+      bool insert = true);
+
+  // Merge a child scope into a parent scope, adding dependencies for open
+  // writes in the parent to accesses in the child.
+  void mergeScope(
+      const std::shared_ptr<Scope>& child,
+      const std::shared_ptr<Scope>& parent,
+      bool closeOverlapped = true);
+
+  // Binds symbolic vars in indices with the low and high bound for those vars.
+  std::vector<Bound> getIndicesBounds(const std::vector<const Expr*>& indices);
+
+  size_t nextAccess_{0};
+  const Stmt* lastStmt_{nullptr};
+};
+
+} // namespace analysis
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -104,7 +104,7 @@ class Reducer {
   }
 
   ReduceOp* operator()(
-      Buf* result_buf,
+      const Buf* result_buf,
       ExprHandle body,
       std::vector<const Expr*> output,
       std::vector<const Var*> inner) const {
@@ -201,8 +201,8 @@ inline ExprHandle minimumVal(ScalarType type) {
 
 class Maximum : public Reducer {
  public:
-  // TODO possible to remove this arg by deferring the init value until we know
-  // the dtype of the body.
+  // TODO possible to remove this arg by deferring the init value until we
+  // know the dtype of the body.
   Maximum(Dtype dtype)
       : Reducer(
             minimumVal(dtype.scalar_type()),


### PR DESCRIPTION
Adds a new piece of infrastructure to the NNC fused-kernel generation compiler, which builds a dependency graph of the reads and writes to memory regions in a kernel.

It can be used to generate graphs like this from the GEMM benchmark (not this only represents memory hierarchy not compute hierarchy):

![image](https://user-images.githubusercontent.com/701287/97368797-e99d5600-1868-11eb-9a7e-ceeb91ce72b8.png)

Or to answer questions like this:
```
Tensor* c = Compute(...);
Tensor* d = Compute(...);
LoopNest loop({d});
MemDependencyChecker analyzer;
loop.root_stmt()->accept(analyzer);
if (analyzer.dependsDirectly(loop.getLoopStmtsFor(d)[0], loop.getLoopStmtsFor(c)[0]) {
  // do something, maybe computeInline
}
```

Or this:
```
Tensor* d = Compute(...);
LoopNest loop({d});
MemDependencyChecker analyzer(loop.getInputs(), loop.getOutputs());
const Buf* output = d->buf();
for (const Buf* input : inputs) {
  if (!analyzer.dependsIndirectly(output, input)) {
    // signal that this input is unused
  }
}
```

This is a monster of a diff, and I apologize. I've tested it as well as possible for now, but it's not hooked up to anything yet so should not affect any current usages of the NNC fuser.

**How it works:**

Similar to the registerizer, the MemDependencyChecker walks the IR aggregating memory accesses into scopes, then merges those scopes into their parent scope and tracks which writes are responsible for the last write to a particular region of memory, adding dependency links where that region is used.

This relies on a bunch of math on symbolic contiguous regions which I've pulled out into its own file (bounds_overlap.h/cpp). Sometimes this wont be able to infer dependence with 100% accuracy but I think it should always be conservative and occaisionally add false positives but I'm aware of no false negatives.

The hardest part of the analysis is determining when a Load inside a For loop depends on a Store that is lower in the IR from a previous iteration of the loop. This depends on a whole bunch of factors, including whether or not we should consider loop iteration order. The analyzer comes with configuration of this setting. For example this loop:
```
for (int i = 0; i < 10; ++i) {
 A[x] = B[x] + 1;
}
```

has no inter loop dependence, since each iteration uses a distinct slice of both A and B. But this one:

```
for (int i = 0; i < 10; ++i) {
 A[0] = A[0] + B[x];
}
```

Has a self loop dependence between the Load and the Store of A. This applies to many cases that are not reductions as well. In this example:

```
for (int i =0; i < 10; ++i) {
  A[x] = A[x+1] + x;
}
```

Whether or not it has self-loop dependence depends on if we are assuming the execution order is fixed (or whether this loop could later be parallelized). If the read from `A[x+1]` always comes before the write to that same region then it has no dependence.

The analyzer can correctly handle dynamic shapes, but we may need more test coverage of real world usages of dynamic shapes. I unit test some simple and pathological cases, but coverage could be better.

**Next Steps:**

Since the PR was already so big I didn't actually hook it up anywhere, but I had planned on rewriting bounds inference based on the dependency graph. Will do that next.

There are few gaps in this code which could be filled in later if we need it:
* Upgrading the bound math to work with write strides, which will reduce false positive dependencies.
* Better handling of Conditions, reducing false positive dependencies when a range is written in both branches of a Cond.
* Support for AtomicAdd node added in Cuda codegen.

**Testing:**

See new unit tests, I've tried to be verbose about what is being tested. I ran the python tests but there shouldn't be any way for this work to affect them yet.
