### PR TITLE
[quant] Fix flaky test test_histogram_observer_against_reference

### DIFF
--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -736,7 +736,7 @@ class TestRecordHistogramObserver(QuantizationTestCase):
         self.assertEqual(myobs.max_val, 8.0)
         self.assertEqual(myobs.histogram, [2., 3., 3.])
 
-    @given(N=st.sampled_from([10, 1000, 10**6]),
+    @given(N=st.sampled_from([10, 1000]),
            bins=st.sampled_from([256, 512, 1024, 2048]),
            dtype=st.sampled_from([torch.qint8, torch.quint8]),
            qscheme=st.sampled_from([torch.per_tensor_affine, torch.per_tensor_symmetric]),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46957 [quant] Fix flaky test test_histogram_observer_against_reference**

Summary:
Possibly due to use of large tensor in hypothesis. Reducing the size to see if it helps

Test Plan:
python test/test_quantization.py TestRecordHistogramObserver.test_histogram_observer_against_reference

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D24580137](https://our.internmc.facebook.com/intern/diff/D24580137)