### PR TITLE
[FX] Fix corner case in name sanitization

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -814,6 +814,11 @@ class TestFX(JitTestCase):
         x, w = torch.rand(3, 4), torch.rand(4, 4)
         self.assertTrue(any(n.target == torch.relu for n in traced.graph.nodes))
 
+    def test_sequential(self):
+        m = torch.nn.Sequential(torch.nn.Conv2d(1, 1, 1))
+        gm = torch.fx.symbolic_trace(m)
+        gm_copy = copy.deepcopy(gm)
+
     def test_ctx_mgr(self):
         @contextlib.contextmanager
         def do_nothing():

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -271,11 +271,12 @@ class Graph:
             sanitized_name = node.name
             if '_' in node.name:
                 base, maybe_idx = node.name.rsplit('_', 1)
-                try:
-                    int(maybe_idx)
-                    sanitized_name = base
-                except ValueError:
-                    pass
+                if base != '':
+                    try:
+                        int(maybe_idx)
+                        sanitized_name = base
+                    except ValueError:
+                        pass
             name = self._name(sanitized_name)
         return self.create_node(node.op, node.target, args, kwargs, name, node.type)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46958 [FX] Fix corner case in name sanitization**

`nn.Sequential` annoyingly names its submodules integer values (e.g. `0`, `1`, ...), which is invalid as a Python identifier. We sanitize this by prepending `_` to the name, to produce names like `_0`. A hilarious issue arises when a graph containing these identifiers is copied (as in `__deepcopy__`): we try to parse out `_\d+` from identifiers and discard that, as that form is also used for name mangling. However, when it gets to `_0` it discards the `_0` part, leaving an empty string. This makes it so that the code that parses out name mangling sequences ignores it if the base string that's left is empty.

Really don't like this whole name mangling business

Differential Revision: [D24580474](https://our.internmc.facebook.com/intern/diff/D24580474)