### PR TITLE
[jit] Prevent caching of `graph` attribute.

### DIFF
--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -443,7 +443,7 @@ if _enabled:
             Returns a string representation of the internal graph for the
             ``forward`` method. See :ref:`interpreting-graphs` for details.
             """
-            return self.forward.graph
+            return self._c._get_method("forward").graph
 
         @property
         def inlined_graph(self):


### PR DESCRIPTION
`graph` is automatically cached even when the underlying graph changes -- this PR hardcodes a fix to that.
