### PR TITLE
Replace -f with -x for pytest tests.

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -313,6 +313,13 @@ def run_test(test_module, test_directory, options, launcher_cmd=None, extra_unit
     if extra_unittest_args:
         assert isinstance(extra_unittest_args, list)
         unittest_args.extend(extra_unittest_args)
+
+    # If using pytest, replace -f with equivalent -x
+    if options.pytest:
+        for idx, arg in enumerate(unittest_args):
+            if arg == '-f':
+                unittest_args[idx] = '-x'
+
     # Can't call `python -m unittest test_*` here because it doesn't run code
     # in `if __name__ == '__main__': `. So call `python test_*.py` instead.
     argv = [test_module + '.py'] + unittest_args

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -316,9 +316,7 @@ def run_test(test_module, test_directory, options, launcher_cmd=None, extra_unit
 
     # If using pytest, replace -f with equivalent -x
     if options.pytest:
-        for idx, arg in enumerate(unittest_args):
-            if arg == '-f':
-                unittest_args[idx] = '-x'
+        unittest_args = [arg if arg != '-f' else '-x' for arg in unittest_args]
 
     # Can't call `python -m unittest test_*` here because it doesn't run code
     # in `if __name__ == '__main__': `. So call `python test_*.py` instead.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46967 Replace -f with -x for pytest tests.**

Tests under `tests/distributed/_pipeline/sync` use pytest and
specifying the `-f` option for such tests as follows: `python test/run_test.py
-i distributed/_pipeline/sync/skip/test_api -- -f` doesn't work.

The equivalent option for pytest is `-x`. To resolve this issue, I've updated
`run_test.py` to replace `-f` with `-x` for pytest tests.

More details in https://github.com/pytorch/pytorch/issues/46782

#Closes: https://github.com/pytorch/pytorch/issues/46782

Differential Revision: [D24584556](https://our.internmc.facebook.com/intern/diff/D24584556/)