### PR TITLE
Correctly mark unannotated NamedTuple field to be inferred TensorType

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -839,7 +839,7 @@ def _get_named_tuple_properties(obj):
             the_type = torch.jit.annotations.ann_to_type(obj.__annotations__[field], fake_range())
             annotations.append(the_type)
         else:
-            annotations.append(torch._C.TensorType.get())
+            annotations.append(torch._C.TensorType.getInferred())
     return type(obj).__name__, fields, annotations
 
 


### PR DESCRIPTION
Summary: If there is no annotation given, we want to show users that the type is inferred

Test Plan: Added a new test case that throws an error with the expected error message

Reviewers: Yanan Cao

Subscribers:

Tasks: 

Tags:

Fixes #46326
