### PR TITLE
Stop including TypeDefault.h from MPSCNNTests.mm

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -7,7 +7,6 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
 #include <ATen/ATen.h>
-#include <ATen/TypeDefault.h>
 #import <ATen/native/metal/mpscnn/tests/MPSCNNTests.h>
 
 #include <stdlib.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#46998 Stop including TypeDefault.h from MPSCNNTests.mm**

It's not using any TypeDefault symbols directly; running
CI to see if it was being included for other headers.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D24621920](https://our.internmc.facebook.com/intern/diff/D24621920)