### PR TITLE
[FX] Kill functional transforms name

### DIFF
--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -2,7 +2,7 @@
 r'''
 **This feature is experimental and its stability is not currently guaranteed. Proceed at your own risk**
 
-FX (Functional Transformations) is a toolkit for capturing and transforming functional PyTorch programs. It
+FX is a toolkit for capturing and transforming functional PyTorch programs. It
 consists of GraphModule and a corresponding intermediate representation (IR). When GraphModule is constructed
 with an `nn.Module` instance as its argument, GraphModule will trace through the computation of that Module's
 `forward` method symbolically and record those operations in the FX intermediate representation.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47004 [FX] Kill functional transforms name**

As usual, people were reading only 3 words of the documentation and inferring what the system actually was, reading way too far into the "functional" part. This patch kills the "functional transforms" name. From now on, the name is FX and it doesn't stand for anything

Differential Revision: [D24597581](https://our.internmc.facebook.com/intern/diff/D24597581)