### PR TITLE
add node by node cost function

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1,9 +1,12 @@
 import torch
 from torch.fx.symbolic_trace import symbolic_trace
+from torch.fx.graph_module import GraphModule
 from torch.fx.experimental import GraphManipulation
 from torch.fx.experimental.Partitioner import Partitioner, Device, PartitionerConfig
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.jit_utils import JitTestCase
+from torch.fx.experimental.partitioner_utils import get_latency_of_one_partition, \
+    NodeLatency
 
 class TestFXExperimental(JitTestCase):
     def test_find_single_partition(self):
@@ -161,6 +164,53 @@ class TestFXExperimental(JitTestCase):
         dag = ret.dag
         self.assertEqual(traced(a, b, offset), module_with_submodules(a, b, offset))
         assert len(module_with_submodules.graph.nodes) == 24
+
+    def test_partition_latency(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, a):
+                add_1 = a + torch.rand(4)
+                add_2 = add_1 + torch.rand(4)
+                linear_1 = self.linear(add_1)
+                add_4 = add_2 + linear_1
+                add_5 = add_2 + add_4
+                return add_5
+
+        def get_node_to_latency_mapping(fx_module: GraphModule):
+            """Given a fx module, generate node latency for each node
+               based on the size of each node
+            """
+            node_to_latency_mapping: Dict[Node, NodeLatency] = {}
+            for node in fx_module.graph.nodes:
+                if node.op not in {'output', 'placeholder', 'get_attr'}:
+                    if node.size_bytes.total_size == node.size_bytes.output_size:
+                        node_to_latency_mapping[node] = NodeLatency(node.size_bytes.total_size, 2. * node.size_bytes.total_size)
+                    else:
+                        node_to_latency_mapping[node] = NodeLatency(node.size_bytes.total_size, node.size_bytes.output_size)
+            return node_to_latency_mapping
+
+        m = TestModule()
+        traced = symbolic_trace(m)
+        a = torch.rand(4)
+        GraphManipulation.get_size_of_all_nodes(traced, [a])
+        node_to_latency_mapping = get_node_to_latency_mapping(traced)
+        devices = [
+            Device('dev_0', 200, 0),
+            Device('dev_1', 200, 0)
+        ]
+        partitioner = Partitioner()
+        partitioner_config = PartitionerConfig(devices, False)
+        ret = partitioner.partition_graph(traced, m, partitioner_config)
+        module_with_submodules = ret.module_with_submodules
+        self.assertEqual(traced(a), module_with_submodules(a))
+        partitions = partitioner.partitions
+        partition_latency_0 = get_latency_of_one_partition(partitions[0], node_to_latency_mapping)
+        assert (128., 80., 160.) == partition_latency_0
+        partition_latency_1 = get_latency_of_one_partition(partitions[1], node_to_latency_mapping)
+        assert (16., 32., 32) == partition_latency_1
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/fx/experimental/partitioner_utils.py
+++ b/torch/fx/experimental/partitioner_utils.py
@@ -1,0 +1,74 @@
+from typing import NamedTuple, Dict, List
+from torch.fx.node import Node, map_arg
+from torch.fx.experimental.Partitioner import Partition
+
+class NodeLatency(NamedTuple):
+    # Latency due to the memory bandwidth
+    mem_latency: float
+    # Latency due to the computation
+    compute_latency: float
+
+class PartitionLatency(NamedTuple):
+    # Sum of all nodes' memory latency on the critical path
+    mem_latency: float
+    # Sum of all nodes' compute latency on the critical path
+    compute_latency: float
+    # Latency of the critical path
+    overall_latency: float
+
+def get_latency_of_one_partition(
+    partition: Partition,
+    node_to_latency_mapping: Dict[Node, NodeLatency]
+) -> PartitionLatency:
+    """Given a partiton and its nodes' latency, return a PartitionLatency for this partition"""
+
+    def get_top_nodes(partition: Partition) -> List[Node]:
+        """Given a partition, return a list of nodes on the top bfs level"""
+        top_nodes: List[Node] = []
+        for node in partition.nodes:
+            # Skip placeholder and get_attr nodes
+            if node.op in {'placeholder', 'get_attr'}:
+                continue
+            input_nodes: Dict[Node, None] = {}
+            map_arg(node.args, lambda n: input_nodes.setdefault(n))
+            map_arg(node.kwargs, lambda n: input_nodes.setdefault(n))
+            # If a node has no input nodes in this partition,
+            # or its input nodes in this partition are placeholders and get_attrs
+            # this node is on the top bfs level in this partition
+            if not any([n in partition.nodes and n.op not in {'placeholder', 'get_attr'} for n in input_nodes]):
+                top_nodes.append(node)
+        return top_nodes
+
+    def dfs_helper(node: Node, partition_latency) -> PartitionLatency:
+        """Given a top node of a partition, this function returns
+           the latency of the critical path in the partition
+        """
+        node_latency = node_to_latency_mapping[node]
+        # Calculate the current overall latency of the partition
+        overall_latency = partition_latency.overall_latency + max(node_latency.compute_latency, node_latency.mem_latency)
+        # Update the mem latency of this path
+        mem_latency = partition_latency.mem_latency + node_latency.mem_latency
+        # Update the compute latency of this path
+        compute_latency = partition_latency.compute_latency + node_latency.compute_latency
+        # Get all users of this node that are in this partition
+        users = set(node.users).intersection(partition.nodes)
+        if users:
+            max_latency = PartitionLatency(mem_latency=0., compute_latency=0., overall_latency=0.)
+            for n in users:
+                # Get new partition latency recursively
+                new_partition_latency = dfs_helper(n, PartitionLatency(mem_latency, compute_latency, overall_latency))
+                if new_partition_latency.overall_latency > max_latency.overall_latency:
+                    max_latency = new_partition_latency
+            return max_latency
+        # If there is no user, the node is at bottom of the partition
+        return PartitionLatency(mem_latency, compute_latency, overall_latency)
+    # Main part starts
+    # Get all top level nodes of this partition
+    top_nodes = get_top_nodes(partition)
+    critical_path_latency = PartitionLatency(mem_latency=0., compute_latency=0., overall_latency=0.)
+    # Go through all top nodes and find the largest latency (critical pass latency)
+    for node in top_nodes:
+        partition_latency = dfs_helper(node, PartitionLatency(mem_latency=0., compute_latency=0., overall_latency=0.))
+        if partition_latency.overall_latency > critical_path_latency.overall_latency:
+            critical_path_latency = partition_latency
+    return critical_path_latency


### PR DESCRIPTION
This PR adds node-by-node cost function. Given a partition of nodes, get_latency_of_one_partition function will find the critical path in the partition and return its latency. A test unit is also provided. In the test unit, a graph module is partitioned into two partitions and the latency of each partition is tested.