### PR TITLE
view_as_real doesn't work for all backends since it relies on strides.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -283,7 +283,7 @@
   use_c10_dispatcher: full
   variants: function
   dispatch:
-    DefaultBackend: view_as_real
+    CPU, CUDA: view_as_real
 
 - func: view_as_complex(Tensor(a) self) -> Tensor(a)
   use_c10_dispatcher: full


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47018 view_as_real doesn't work for all backends since it relies on strides.**

Differential Revision: [D24607340](https://our.internmc.facebook.com/intern/diff/D24607340)