### PR TITLE
Enable inlining into reductions

### DIFF
--- a/test/cpp/tensorexpr/test_kernel.cpp
+++ b/test/cpp/tensorexpr/test_kernel.cpp
@@ -551,9 +551,10 @@ void testKernelSumOneAxis() {
         // Check the IR we produced
         const std::string& verification_pattern =
             R"IR(
-# CHECK: int v = 0
-# CHECK: int v_1 = 0
-# CHECK: input1)IR";
+# CHECK: for (int v = 0; v <
+# CHECK-NEXT: sum
+# CHECK-NEXT: for (int v_1 = 0; v_1 <
+# CHECK-NEXT:   sum)IR";
         torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
 
         std::vector<IValue> stack = fmap<IValue>(inputs);
@@ -612,7 +613,7 @@ void testKernelSumMultipleAxes() {
 # CHECK: int v_1 = 0
 # CHECK: int v_2 = 0
 # CHECK: int v_3 = 0
-# CHECK: input1)IR";
+# CHECK: sum)IR";
         torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
 
         std::vector<IValue> stack = fmap<IValue>(inputs);
@@ -641,20 +642,17 @@ void testKernelSoftmax2D() {
 
   const std::string& verification_template =
       R"IR(
-        # CHECK: for (int i0 = 0; i0 < 5
-        # CHECK-NEXT: for (int i1 = 0; i1 < 3
-        # CHECK-NEXT: input1
-        # CHECK: for (int i${other_dim}_1 = 0; i${other_dim}_1 < ${other_dim_size}
-        # CHECK: for (int i${softmax_dim}_1 = 0; i${softmax_dim}_1 < ${softmax_dim_size}
+        # CHECK: for (int i${other_dim} = 0; i${other_dim} < ${other_dim_size}
+        # CHECK: for (int i${softmax_dim} = 0; i${softmax_dim} < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_max
-        # CHECK: for (int i0_2 = 0; i0_2 < 5
-        # CHECK-NEXT: for (int i1_2 = 0; i1_2 < 3
+        # CHECK: for (int i0_1 = 0; i0_1 < 5
+        # CHECK-NEXT: for (int i1_1 = 0; i1_1 < 3
         # CHECK-NEXT: aten_softmax_exp
-        # CHECK: for (int i${other_dim}_3 = 0; i${other_dim}_3 < ${other_dim_size}
-        # CHECK: for (int i${softmax_dim}_3 = 0; i${softmax_dim}_3 < ${softmax_dim_size}
+        # CHECK: for (int i${other_dim}_2 = 0; i${other_dim}_2 < ${other_dim_size}
+        # CHECK: for (int i${softmax_dim}_2 = 0; i${softmax_dim}_2 < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_sum
-        # CHECK: for (int i0_4 = 0; i0_4 < 5
-        # CHECK-NEXT: for (int i1_4 = 0; i1_4 < 3
+        # CHECK: for (int i0_3 = 0; i0_3 < 5
+        # CHECK-NEXT: for (int i1_3 = 0; i1_3 < 3
         # CHECK-NEXT: aten_softmax)IR";
 
   for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
@@ -705,25 +703,21 @@ void testKernelSoftmax3D() {
 
   const std::string& verification_template =
       R"IR(
-        # CHECK: for (int i0 = 0; i0 < 3
-        # CHECK-NEXT: for (int i1 = 0; i1 < 4
-        # CHECK-NEXT: for (int i2 = 0; i2 < 5
-        # CHECK-NEXT: input1
-        # CHECK: for (int i${dim1}_1 = 0; i${dim1}_1 < ${dim1_size}
-        # CHECK-NEXT: for (int i${dim2}_1 = 0; i${dim2}_1 < ${dim2_size}
-        # CHECK: for (int i${softmax_dim}_1 = 0; i${softmax_dim}_1 < ${softmax_dim_size}
+        # CHECK: for (int i${dim1} = 0; i${dim1} < ${dim1_size}
+        # CHECK-NEXT: for (int i${dim2} = 0; i${dim2} < ${dim2_size}
+        # CHECK: for (int i${softmax_dim} = 0; i${softmax_dim} < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_max
-        # CHECK: for (int i0_2 = 0; i0_2 < 3
-        # CHECK-NEXT: for (int i1_2 = 0; i1_2 < 4
-        # CHECK-NEXT: for (int i2_2 = 0; i2_2 < 5
+        # CHECK: for (int i0_1 = 0; i0_1 < 3
+        # CHECK-NEXT: for (int i1_1 = 0; i1_1 < 4
+        # CHECK-NEXT: for (int i2_1 = 0; i2_1 < 5
         # CHECK-NEXT: aten_softmax_exp
-        # CHECK: for (int i${dim1}_3 = 0; i${dim1}_3 < ${dim1_size}
-        # CHECK-NEXT: for (int i${dim2}_3 = 0; i${dim2}_3 < ${dim2_size}
-        # CHECK: for (int i${softmax_dim}_3 = 0; i${softmax_dim}_3 < ${softmax_dim_size}
+        # CHECK: for (int i${dim1}_2 = 0; i${dim1}_2 < ${dim1_size}
+        # CHECK-NEXT: for (int i${dim2}_2 = 0; i${dim2}_2 < ${dim2_size}
+        # CHECK: for (int i${softmax_dim}_2 = 0; i${softmax_dim}_2 < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_sum
-        # CHECK: for (int i0_4 = 0; i0_4 < 3
-        # CHECK-NEXT: for (int i1_4 = 0; i1_4 < 4
-        # CHECK-NEXT: for (int i2_4 = 0; i2_4 < 5
+        # CHECK: for (int i0_3 = 0; i0_3 < 3
+        # CHECK-NEXT: for (int i1_3 = 0; i1_3 < 4
+        # CHECK-NEXT: for (int i2_3 = 0; i2_3 < 5
         # CHECK-NEXT: aten_softmax)IR";
 
   for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
@@ -782,30 +776,25 @@ void testKernelSoftmax4D() {
 
   const std::string& verification_template =
       R"IR(
-        # CHECK: for (int i0 = 0; i0 < 2
-        # CHECK-NEXT: for (int i1 = 0; i1 < 3
-        # CHECK-NEXT: for (int i2 = 0; i2 < 2
-        # CHECK-NEXT: for (int i3 = 0; i3 < 3
-        # CHECK-NEXT: input1
-        # CHECK: for (int i${dim1}_1 = 0; i${dim1}_1 < ${dim1_size}
-        # CHECK-NEXT: for (int i${dim2}_1 = 0; i${dim2}_1 < ${dim2_size}
-        # CHECK-NEXT: for (int i${dim3}_1 = 0; i${dim3}_1 < ${dim3_size}
-        # CHECK: for (int i${softmax_dim}_1 = 0; i${softmax_dim}_1 < ${softmax_dim_size}
+        # CHECK: for (int i${dim1} = 0; i${dim1} < ${dim1_size}
+        # CHECK-NEXT: for (int i${dim2} = 0; i${dim2} < ${dim2_size}
+        # CHECK-NEXT: for (int i${dim3} = 0; i${dim3} < ${dim3_size}
+        # CHECK: for (int i${softmax_dim} = 0; i${softmax_dim} < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_max
-        # CHECK: for (int i0_2 = 0; i0_2 < 2
-        # CHECK-NEXT: for (int i1_2 = 0; i1_2 < 3
-        # CHECK-NEXT: for (int i2_2 = 0; i2_2 < 2
-        # CHECK-NEXT: for (int i3_2 = 0; i3_2 < 3
+        # CHECK: for (int i0_1 = 0; i0_1 < 2
+        # CHECK-NEXT: for (int i1_1 = 0; i1_1 < 3
+        # CHECK-NEXT: for (int i2_1 = 0; i2_1 < 2
+        # CHECK-NEXT: for (int i3_1 = 0; i3_1 < 3
         # CHECK-NEXT: aten_softmax_exp
-        # CHECK: for (int i${dim1}_3 = 0; i${dim1}_3 < ${dim1_size}
-        # CHECK-NEXT: for (int i${dim2}_3 = 0; i${dim2}_3 < ${dim2_size}
-        # CHECK-NEXT: for (int i${dim3}_3 = 0; i${dim3}_3 < ${dim3_size}
-        # CHECK: for (int i${softmax_dim}_3 = 0; i${softmax_dim}_3 < ${softmax_dim_size}
+        # CHECK: for (int i${dim1}_2 = 0; i${dim1}_2 < ${dim1_size}
+        # CHECK-NEXT: for (int i${dim2}_2 = 0; i${dim2}_2 < ${dim2_size}
+        # CHECK-NEXT: for (int i${dim3}_2 = 0; i${dim3}_2 < ${dim3_size}
+        # CHECK: for (int i${softmax_dim}_2 = 0; i${softmax_dim}_2 < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_sum
-        # CHECK: for (int i0_4 = 0; i0_4 < 2
-        # CHECK-NEXT: for (int i1_4 = 0; i1_4 < 3
-        # CHECK-NEXT: for (int i2_4 = 0; i2_4 < 2
-        # CHECK-NEXT: for (int i3_4 = 0; i3_4 < 3
+        # CHECK: for (int i0_3 = 0; i0_3 < 2
+        # CHECK-NEXT: for (int i1_3 = 0; i1_3 < 3
+        # CHECK-NEXT: for (int i2_3 = 0; i2_3 < 2
+        # CHECK-NEXT: for (int i3_3 = 0; i3_3 < 3
         # CHECK-NEXT: aten_softmax)IR";
 
   for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
@@ -851,6 +840,89 @@ void testKernelSoftmax4D() {
     ASSERT_EQ(output.sizes(), ref.sizes());
     ASSERT_TRUE(at::allclose(output, ref));
   }
+}
+
+void testKernelInlineProducerIntoReduction() {
+  KernelScope kernel_scope;
+
+  // Inline producer (mul) into reduction (sum).
+  const auto graph_string = R"IR(
+      graph(%0 : Float(5, 3, strides=[3, 1], device=cpu),
+            %1 : Float(5, 3, strides=[3, 1], device=cpu)):
+        %2 : Float(5, 3, strides=[3, 1]) = aten::mul(%0, %1)
+        %3 : int = prim::Constant[value=7]()
+        %4 : Float(5, 3, strides=[3, 1]) = aten::sum(%2, %3)
+        return (%4))IR";
+  auto graph = std::make_shared<Graph>();
+  parseIR(graph_string, &*graph);
+
+  TensorExprKernel k(graph);
+  Stmt* s = k.getCodeGenStmt();
+  std::ostringstream oss;
+  oss << *s;
+
+  // Check the IR we produced.
+  // We should have only one loop in the end.
+  const std::string& verification_pattern =
+      R"IR(
+        # CHECK: for (int v = 0; v < 5;
+        # CHECK-NEXT: for (int v_1 = 0; v_1 < 3;
+        # CHECK-NEXT:   sum
+        # CHECK-NOT: for)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+
+  auto a = at::rand({5, 3}, TensorOptions(kCPU).dtype(at::kFloat));
+  auto b = at::rand({5, 3}, TensorOptions(kCPU).dtype(at::kFloat));
+  std::vector<at::Tensor> inputs = {a, b};
+  std::vector<IValue> stack = fmap<IValue>(inputs);
+  k.run(stack);
+  auto o = stack[0].toTensor();
+  auto ref = (a * b).sum(at::kDouble);
+  ASSERT_TRUE(at::allclose(o, ref));
+}
+
+void testKernelInlineReductionIntoConsumer() {
+  KernelScope kernel_scope;
+
+  // Inline producer (mul %2) into reduction (sum %4) but DO NOT
+  // inline the reduction into consumer (mul %4).
+  const auto graph_string = R"IR(
+      graph(%0 : Float(5, 3, strides=[3, 1], device=cpu),
+            %1 : Float(5, 3, strides=[3, 1], device=cpu)):
+        %2 : Float(5, 3, strides=[3, 1]) = aten::mul(%0, %1)
+        %3 : int = prim::Constant[value=6]()
+        %4 : Float(5, 3, strides=[3, 1]) = aten::sum(%2, %3)
+        %5 : Float(5, 3, strides=[3, 1]) = aten::mul(%2, %4)
+        return (%5))IR";
+  auto graph = std::make_shared<Graph>();
+  parseIR(graph_string, &*graph);
+
+  TensorExprKernel k(graph);
+  Stmt* s = k.getCodeGenStmt();
+  std::ostringstream oss;
+  oss << *s;
+
+  // Check the IR we produced.
+  // We should have two loops in the end.
+  const std::string& verification_pattern =
+      R"IR(
+        # CHECK: for (int v = 0; v < 5;
+        # CHECK-NEXT: for (int v_1 = 0; v_1 < 3;
+        # CHECK-NEXT:   sum
+        # CHECK: for (int v_2 = 0; v_2 < 5;
+        # CHECK-NEXT: for (int v_3 = 0; v_3 < 3;
+        # CHECK-NEXT:   aten_mul
+        # CHECK-NOT: for)IR";
+  torch::jit::testing::FileCheck().run(verification_pattern, oss.str());
+
+  auto a = at::rand({5, 3}, TensorOptions(kCPU).dtype(at::kFloat));
+  auto b = at::rand({5, 3}, TensorOptions(kCPU).dtype(at::kFloat));
+  std::vector<at::Tensor> inputs = {a, b};
+  std::vector<IValue> stack = fmap<IValue>(inputs);
+  k.run(stack);
+  auto o = stack[0].toTensor();
+  auto ref = (a * b).sum(at::kFloat) * (a * b);
+  ASSERT_TRUE(at::allclose(o, ref));
 }
 
 } // namespace jit

--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -1337,8 +1337,8 @@ void testReduceInlineReduction() {
   }
 
   LoopNest l1({y});
-  ASSERT_THROWS_WITH(
-      l1.computeInline(x->buf()), "cannot inline a reduction computation");
+  // Cannot inline a reduction computation
+  ASSERT_FALSE(l1.computeInline(x->buf()));
 }
 
 void testReduceInlineConsumer() {

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -367,6 +367,8 @@ namespace jit {
   _(KernelSoftmax2D)                                \
   _(KernelSoftmax3D)                                \
   _(KernelSoftmax4D)                                \
+  _(KernelInlineProducerIntoReduction)              \
+  _(KernelInlineReductionIntoConsumer)              \
   _(FuserPass_1)                                    \
   _(FuserPass_2)                                    \
   _(FuserPass_3)                                    \

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1366,7 +1366,7 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
 
   // Compute non-output tensors_ inline
   for (auto& p : tensors_) {
-    if (!l.hasLoopBodyFor(p.second) || hasReduction) {
+    if (!l.hasLoopBodyFor(p.second)) {
       continue;
     }
     l.computeInline(p.second->buf());

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -51,8 +51,8 @@ class TORCH_API LoopNest {
 
   void vectorize(Stmt*);
 
-  void computeInline(Stmt* s);
-  void computeInline(const Buf* b);
+  bool computeInline(Stmt* s);
+  bool computeInline(const Buf* b);
 
   static void splitWithTail(For* f, int factor);
   static void splitWithTail(


### PR DESCRIPTION
This diff enables inlining producers into reductions. It also guards against inlining reductions themselves.

Prior to this diff, if there was a reduction in the loopnest, no inlining was happening. After this change, we will inline all non-output buffers that do not correspond to a reduction.