### PR TITLE
Allow replicate/circular padding of single dimension of 4D/5D tensor

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3140,9 +3140,12 @@ class TestNN(NNTestCase):
         self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='replicate'), (inputs,)))
         self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='reflect'), (inputs,)))
         self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1, -2, 1), mode='circular'), (inputs,)))
+        self.assertTrue(gradcheck(lambda x: F.pad(x, (-1, 1), mode='reflect'), (inputs,)))
 
         inputs = torch.randn(1, 2, 3, 4, 4, requires_grad=True)
         self.assertTrue(gradcheck(lambda x: F.pad(x, (1, 1, 1, 1, 1, 1), mode='replicate'), (inputs,)))
+        self.assertTrue(gradcheck(lambda x: F.pad(x, (1, 1, 1, 1), mode='replicate'), (inputs,)))
+        self.assertTrue(gradcheck(lambda x: F.pad(x, (1, 1), mode='circular'), (inputs,)))
 
         # Assert assertion errors are raised for invalid circular padding values
         inputs = torch.randn(1, 1, 4, requires_grad=True)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3477,10 +3477,11 @@ def _pad(input, pad, mode='constant', value=0):
         See :class:`torch.nn.ConstantPad2d`, :class:`torch.nn.ReflectionPad2d`, and
         :class:`torch.nn.ReplicationPad2d` for concrete examples on how each of the
         padding modes works. Constant padding is implemented for arbitrary dimensions.
-        Replicate padding is implemented for padding the last 3 dimensions of 5D input
-        tensor, or the last 2 dimensions of 4D input tensor, or the last dimension of
-        3D input tensor. Reflect padding is only implemented for padding the last 2
-        dimensions of 4D input tensor, or the last dimension of 3D input tensor.
+        Replicate padding is implemented for padding any or all of the last 3 dimensions
+        of 5D input tensor, or one or both of the last 2 dimensions of 4D input tensor,
+        or the last dimension of 3D input tensor. Reflect padding is only implemented
+        for padding one or both of the last 2 dimensions of 4D input tensor, or the last
+        dimension of 3D input tensor.
 
     Note:
         When using the CUDA backend, this operation may induce nondeterministic

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3535,7 +3535,9 @@ def _pad(input, pad, mode='constant', value=0):
                 raise NotImplementedError
 
         elif input.dim() == 4:
-            assert len(pad) == 4, '4D tensors expect 4 values for padding'
+            if len(pad) == 2:
+                pad = list(pad) + [0, 0]
+            assert len(pad) == 4, '4D tensors expect 2 or 4 values for padding'
             if mode == 'reflect':
                 return torch._C._nn.reflection_pad2d(input, pad)
             elif mode == 'replicate':
@@ -3546,7 +3548,11 @@ def _pad(input, pad, mode='constant', value=0):
                 raise NotImplementedError
 
         elif input.dim() == 5:
-            assert len(pad) == 6, '5D tensors expect 6 values for padding'
+            if len(pad) == 2:
+                pad = list(pad) + [0, 0, 0, 0]
+            elif len(pad) == 4:
+                pad = list(pad) + [0, 0]
+            assert len(pad) == 6, '5D tensors expect 2, 4, or 6 values for padding'
             if mode == 'reflect':
                 raise NotImplementedError
             elif mode == 'replicate':


### PR DESCRIPTION
`torch.nn.functional.pad` accepts a flexible number of padding dimensions when doing constant padding, e.g. from the docs
```python
>>> t4d = torch.empty(3, 3, 4, 2)
>>> p1d = (1, 1) # pad last dim by 1 on each side
>>> out = F.pad(t4d, p1d, "constant", 0)  # effectively zero padding
>>> print(out.size())
torch.Size([3, 3, 4, 4])
```
But you cannot pad a single dimension when mode is circular, replicate, or reflect:
```python
>>> out = F.pad(t4d, p1d, "circular")
# AssertionError: 4D tensors expect 4 values for padding
```
You can work around this by appending zeros, `p1d = (1,1,0,0)`.
```python
>>> out = F.pad(t4d,(1,1,0,0), "circular")
>>> print(out.size())
torch.Size([3, 3, 4, 4])
```
These differences are unexpected and unnecessary.
This PR appends the zero entries to the pad if necessary.

I can update docs/tests if interested in merging.
Thanks!