### PR TITLE
Fix links in tools/build_variables.bzl

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -41,7 +41,7 @@ def libtorch_generated_sources(gencode_pattern):
         "autograd/generated/TraceType_4.cpp",
     ]]
 
-# copied from https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/CMakeLists.txt
+# copied from https://github.com/pytorch/pytorch/blob/f99a693cd9ff7a9b5fdc71357dac66b8192786d3/aten/src/ATen/core/CMakeLists.txt
 jit_core_headers = [
     "torch/csrc/utils/memory.h",
     "torch/csrc/WindowsTorchApiMacro.h",
@@ -69,7 +69,7 @@ jit_core_sources = [
     "torch/csrc/jit/frontend/source_range.cpp",
 ]
 
-# copied from https://github.com/pytorch/pytorch/blob/master/tools/cpp_build/torch/CMakeLists.txt
+# copied from https://github.com/pytorch/pytorch/blob/0bde610c14b92d351b968a0228df29e92442b1cc/torch/CMakeLists.txt
 # There are some common files used in both internal lite-interpreter and full-jit. Making a separate
 # list for the shared files.
 


### PR DESCRIPTION
I know the `aten/src/ATen/core/CMakeLists.txt` link is now correct because that file was deleted in 061ed739c17028fe907737b52f50a495ab5b4617:
```
$ git log --full-history -- aten/src/ATen/core/CMakeLists.txt | head -n 1
commit 061ed739c17028fe907737b52f50a495ab5b4617
$ git show 061ed739c17028fe907737b52f50a495ab5b4617^ | head -n 1
commit f99a693cd9ff7a9b5fdc71357dac66b8192786d3
```
But I can't tell what the `tools/cpp_build/torch/CMakeLists.txt` link is supposed to be, because that file (indeed, its entire parent directory) doesn't seem to have ever existed:
```
$ git log --full-history -- tools/cpp_build/torch
```
(The output of the above command is empty.) So I saw that the grandparent directory was deleted in 130881f0e37cdedc0e90f6c9ed84957aee6c80ef:
```
$ git log --full-history -- tools/cpp_build | head -n 1
commit 130881f0e37cdedc0e90f6c9ed84957aee6c80ef
$ git show 130881f0e37cdedc0e90f6c9ed84957aee6c80ef^ | head -n 1
commit c6facc2aaa5a568756e971a9d2b7f2af282dff39
```
And looking at [the history of that directory](https://github.com/pytorch/pytorch/commits/c6facc2aaa5a568756e971a9d2b7f2af282dff39/tools/cpp_build), I see that some of the last commits touch `torch/CMakeLists.txt`, so I'm just using that here and hoping it's correct.