### PR TITLE
[PyTorch] Add foreach_copy_API

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -65,6 +65,15 @@ void foreach_tensor_##OP##_list_kernel_slow_(TensorList tensors1, TensorList ten
   }                                                                                                       \
 }
 
+#define FOREACH_BINARY_OP_LIST_IN_PLACE(OP)                                                               \
+void foreach_tensor_##OP##_list_kernel_slow_(TensorList tensors1, TensorList tensors2) {                  \
+  check_foreach_api_restrictions(tensors1, tensors2);                                                     \
+                                                                                                          \
+  for (int i = 0; i < tensors1.size(); i++) {                                                             \
+    tensors1[i].OP##_(tensors2[i]);                                                                       \
+  }                                                                                                       \
+}
+
 #define FOREACH_BINARY_OP_LIST_ALPHA(OP)                                                                                \
 std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(TensorList tensors1, TensorList tensors2, Scalar alpha) {    \
   check_foreach_api_restrictions(tensors1, tensors2);                                                                   \
@@ -159,6 +168,7 @@ FOREACH_BINARY_OP_SCALARLIST(mul);
 FOREACH_BINARY_OP_SCALARLIST(div);
 FOREACH_BINARY_OP_LIST(mul);
 FOREACH_BINARY_OP_LIST(div);
+FOREACH_BINARY_OP_LIST_IN_PLACE(copy);
 FOREACH_UNARY_OP(sqrt);
 FOREACH_UNARY_OP(exp);
 FOREACH_POINTWISE_OP_SCALAR(addcdiv);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6935,6 +6935,14 @@
     CPU: foreach_tensor_mul_list_kernel_slow_
     CUDA: foreach_tensor_mul_list_kernel_cuda_
 
+- func: _foreach_copy_.List(Tensor(a!)[] self, Tensor[] other) -> ()
+  use_c10_dispatcher: full
+  device_guard: False
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_copy_list_kernel_slow_
+    CUDA: foreach_tensor_copy_list_kernel_cuda_
+
 - func: _foreach_div.List(Tensor[] tensors1, Tensor[] tensors2) -> Tensor[]
   use_c10_dispatcher: full
   device_guard: False

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -373,6 +373,7 @@ class FunctionSchema:
                     '_foreach_sub_.List',
                     '_foreach_mul_.List',
                     '_foreach_div_.List',
+                    '_foreach_copy_.List',
                     '_foreach_exp_',
                     '_foreach_sqrt_',
                     '_foreach_addcmul_.Scalar',


### PR DESCRIPTION
Summary: Adding foreach_copy_(TensorList, TensorList) API

Test Plan:
```
[jiayisuse@devgpu026 ~/fbcode]$ ./buck-out/gen/caffe2/test/others#binary.par -r copy
/data/users/jiayisuse/fbsource/fbcode/buck-out/opt/gen/caffe2/test/others#binary,link-tree/torch/nn/modules/conv.py:29: DeprecationWarning: invalid escape sequence \_
  :math:`\\frac{\\text{out\_channels}}{\\text{in\_channels}}`).""",  # noqa: W605
test_copy_list_cpu_bfloat16 (test_foreach.TestForeachCPU) ... Couldn't download test skip set, leaving all tests enabled...
ok
test_copy_list_cpu_bool (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_complex128 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_complex64 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_float16 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_float32 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_float64 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_int16 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_int32 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_int64 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_int8 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cpu_uint8 (test_foreach.TestForeachCPU) ... ok
test_copy_list_cuda_bfloat16 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_bool (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_complex128 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_complex64 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_float16 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_float32 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_float64 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_int16 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_int32 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_int64 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_int8 (test_foreach.TestForeachCUDA) ... ok
test_copy_list_cuda_uint8 (test_foreach.TestForeachCUDA) ... ok

----------------------------------------------------------------------
Ran 24 tests in 21.612s

OK
```

Differential Revision: D24615077

