### PR TITLE
[aten] batch_index_select

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -471,6 +471,87 @@ Tensor index_add(const Tensor & self, int64_t dim, const Tensor & index, const T
   return self.clone(at::MemoryFormat::Preserve).index_add_(dim, index, source);
 }
 
+// Check that indices fall within dimension array size
+// Avoid redispatch call to min/max
+template <typename IndexType>
+static void check_indexarray_range(
+    const IndexType* indices,
+    int64_t n,
+    IndexType indexing_axis_dim) {
+  for (auto i = 0; i < n; ++i) {
+    auto idx = indices[i];
+    TORCH_CHECK(
+        0 <= idx && idx < indexing_axis_dim,
+        "INDICES element is out of DATA bounds, id=",
+        idx,
+        " axis_dim=",
+        indexing_axis_dim);
+  }
+}
+
+Tensor & index_select_out_cpu_dim1_(
+    Tensor & result_contig, const Tensor & self, const Tensor & index_contig) {
+
+  auto self_contig = self.contiguous();
+  const caffe2::TypeMeta dataType = self_contig.dtype();
+  size_t item_bytesize = dataType.itemsize();
+
+  auto out = static_cast<char*>(result_contig.data_ptr());
+
+  auto src_base = static_cast<const char*>(self_contig.data_ptr());
+
+  auto self_sizes = self_contig.sizes();
+  auto outer_dims_product = c10::size_to_dim_(1, self_sizes);
+  auto block_size = c10::size_from_dim_(2, self_sizes);
+  auto block_bytesize = block_size * item_bytesize;
+
+  auto src_indexing_axis_dim = self_sizes[1];
+  auto src_batch_bytesize = self_sizes[1] * block_bytesize;
+  auto N = index_contig.numel();
+
+  auto gathered_batch_bytesize = N * block_bytesize;
+
+  AT_DISPATCH_INDEX_TYPES(
+    index_contig.scalar_type(), "batch_index_select_compute", [&]() {
+
+      const auto* idxs = index_contig.data_ptr<index_t>();
+      check_indexarray_range<index_t>(idxs, N, src_indexing_axis_dim);
+
+      // Special-case single-float copy for efficiency
+      if (self.scalar_type() == ScalarType::Float && block_size == 1) {
+        for (auto batch = 0; batch < outer_dims_product; ++batch) {
+          const float* src_floats =
+              (const float*)(src_base + batch * src_batch_bytesize);
+          float* dst_floats = (float*)(out + batch * gathered_batch_bytesize);
+
+          for (auto i = 0; i < N; ++i) {
+            auto idx = idxs[i];
+            if (idx < 0) {
+              idx = idx + src_indexing_axis_dim;
+            }
+            dst_floats[i] = src_floats[idx];
+          }
+        }
+      } else {
+        // outer_dims_product specifies how many times we repeat inner dimensions,
+        // so we just iterate over it to cover all outer dimensions.
+        for (auto batch = 0; batch < outer_dims_product; ++batch) {
+          for (auto i = 0; i < N; ++i) {
+            auto idx = idxs[i];
+            if (idx < 0) {
+              idx = idx + src_indexing_axis_dim;
+            }
+
+            auto src = src_base + batch * src_batch_bytesize + idx * block_bytesize;
+            auto dst = out + batch * gathered_batch_bytesize + i * block_bytesize;
+            memcpy(dst, src, block_bytesize);
+          }
+        }
+      }
+  });
+  return result_contig;
+}
+
 Tensor & index_select_out_cpu_(Tensor & result, const Tensor & self, int64_t dim, const Tensor & index) {
   dim = maybe_wrap_dim(dim, self.dim());
 
@@ -496,6 +577,11 @@ Tensor & index_select_out_cpu_(Tensor & result, const Tensor & self, int64_t dim
   if (self.dim() > 1) {
     if (numel == 0 || self.numel() == 0) {
       return result;
+    }
+
+    if (dim == 1 && result.is_contiguous()) {
+      // fast pass
+      return index_select_out_cpu_dim1_(result, self, index_contig);
     }
 
     auto selfSlice = self.select(dim, 0);

--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -50,10 +50,15 @@ class Caffe2BenchmarkBase(object):
             Return:
                 C2 tensor of dtype
         """
+        return self.feed_tensor(benchmark_utils.numpy_random(dtype, *shapes), device)
+
+    def feed_tensor(self, tensor, device='cpu'):
+        """ Similar to tensor, but can supply any data compatible with FeedBlob
+        """
         blob_name = 'blob_' + str(Caffe2BenchmarkBase.tensor_index)
         dev = self._device_option(device)
         with core.DeviceScope(dev):
-            workspace.FeedBlob(blob_name, benchmark_utils.numpy_random(dtype, *shapes))
+            workspace.FeedBlob(blob_name, tensor)
         Caffe2BenchmarkBase.tensor_index += 1
         return blob_name
 

--- a/benchmarks/operator_benchmark/c2/batch_gather_test.py
+++ b/benchmarks/operator_benchmark/c2/batch_gather_test.py
@@ -1,0 +1,56 @@
+import benchmark_caffe2 as op_bench_c2
+import operator_benchmark as op_bench
+from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa
+from caffe2.python import core
+import numpy
+
+
+"""Microbenchmarks for element-wise BatchGather operator."""
+
+# Configs for C2 BatherGather operator
+batch_gather_configs_short = op_bench.config_list(
+    attr_names=["M", "N", "K"],
+    attrs=[
+        [8, 8, 1],
+        [256, 512, 1],
+        [512, 512, 1],
+        [8, 8, 2],
+        [256, 512, 2],
+        [512, 512, 2],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=["short"]
+)
+
+batch_gather_configs_long = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
+    K=[1, 2],
+    device=['cpu', 'cuda'],
+    tags=["long"]
+)
+
+class BatchGatherBenchmark(op_bench_c2.Caffe2BenchmarkBase):
+    def init(self, M, N, K, device):
+        self.input_one = self.tensor([M, N, K], device=device)
+        max_val = N
+        numpy.random.seed((1 << 32) - 1)
+        index_dim = numpy.random.randint(0, N)
+        self.index = self.feed_tensor(numpy.random.randint(0, max_val, index_dim), device=device)
+        self.output = self.tensor([M, index_dim, K], device=device)
+        self.set_module_name("batch_gather")
+
+    def forward(self):
+        op = core.CreateOperator("BatchGather", [self.input_one, self.index], self.output)
+        return op
+
+
+op_bench_c2.generate_c2_test(
+    batch_gather_configs_long + batch_gather_configs_short, BatchGatherBenchmark
+)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/pt/index_select_test.py
+++ b/benchmarks/operator_benchmark/pt/index_select_test.py
@@ -1,0 +1,57 @@
+import operator_benchmark as op_bench
+import torch
+import numpy
+
+
+"""Microbenchmarks for index_select operator."""
+
+# An example input from this configuration is M=4, N=4, dim=0.
+index_select_configs_short = op_bench.config_list(
+    attr_names=["M", "N", "K", "dim"],
+    attrs=[
+        [8, 8, 1, 1],
+        [256, 512, 1, 1],
+        [512, 512, 1, 1],
+        [8, 8, 2, 1],
+        [256, 512, 2, 1],
+        [512, 512, 2, 1],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=["short"]
+)
+
+
+index_select_configs_long = op_bench.cross_product_configs(
+    M=[128, 1024],
+    N=[128, 1024],
+    K=[1, 2],
+    dim=[1],
+    device=['cpu', 'cuda'],
+    tags=["long"]
+)
+
+
+class IndexSelectBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, dim, device):
+        max_val = N
+        numpy.random.seed((1 << 32) - 1)
+        index_dim = numpy.random.randint(0, N)
+        self.inputs = {
+            "input_one": torch.rand(M, N, K, device=device),
+            "dim" : dim,
+            "index" : torch.tensor(numpy.random.randint(0, max_val, index_dim), device=device),
+        }
+        self.set_module_name("index_select")
+
+    def forward(self, input_one, dim, index):
+        return torch.index_select(input_one, dim, index)
+
+
+op_bench.generate_pt_test(index_select_configs_short + index_select_configs_long,
+                          IndexSelectBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary:
Add benchmarks for pt index_select, batch_index_select, and c2's BatchGather
Add batch_index_select implementation based on the C2 BatchGather implementation

This currently falls back to index_select for backwards and cuda implementations.

Alternatively, we can look into the specifics of why index_select is slower and
replace the original implementation instead.

Test Plan:
./buck-out/opt/gen/caffe2/benchmarks/operator_benchmark/c2/batch_gather_test.par
./buck-out/opt/gen/caffe2/benchmarks/operator_benchmark/pt/index_select_test.par
P147364467
```
# Benchmarking PyTorch: index_select
# Mode: Eager
# Name: index_select_M256_N512_dim1_cpu
# Input: M: 256, N: 512, dim: 1, device: cpu
Forward Execution Time (us) : 231.990

# Benchmarking PyTorch: index_select
# Mode: Eager
# Name: index_select_M512_N512_dim1_cpu
# Input: M: 512, N: 512, dim: 1, device: cpu
Forward Execution Time (us) : 859.280

# Benchmarking PyTorch: batch_index_select
# Mode: Eager
# Name: batch_index_select_M256_N512_dim1_cpu
# Input: M: 256, N: 512, dim: 1, device: cpu
Forward Execution Time (us) : 130.183

# Benchmarking PyTorch: batch_index_select
# Mode: Eager
# Name: batch_index_select_M512_N512_dim1_cpu
# Input: M: 512, N: 512, dim: 1, device: cpu
Forward Execution Time (us) : 267.071

# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking Caffe2: batch_gather
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1028 19:52:24.284281 3876565 init.h:137] Caffe2 GlobalInit should be run before any other API calls.
# Name: batch_gather_M256_N512_devicecpu
# Input: M: 256, N: 512, device: cpu
Forward Execution Time (us) : 101.225

# Benchmarking Caffe2: batch_gather
# Name: batch_gather_M512_N512_devicecpu
# Input: M: 512, N: 512, device: cpu
Forward Execution Time (us) : 217.274
```

buck test dper3/dper3/modules/low_level_modules/tests:single_operators_test -- test_batch_gather

Differential Revision: D24630227

