### PR TITLE
[jit] introduce CallFunctionAsync to simplify fork compilation

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -140,6 +140,7 @@ namespace c10 {
   _(prim, TimePoint)                 \
   _(prim, CallFunction)              \
   _(prim, CallMethod)                \
+  _(prim, CallMethodAsync)           \
   _(prim, LoopContinuation)          \
   _(prim, annotate)                  \
   _(prim, TracedModuleForward)       \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -149,6 +149,7 @@ namespace c10 {
   _(prim, rpc_sync)                  \
   _(prim, rpc_remote)                \
   _(prim, is_cuda)                   \
+  _(prim, CallFunctionAsync)         \
   _(aten, abs_)                      \
   _(aten, absolute)                  \
   _(aten, absolute_)                 \

--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -527,6 +527,18 @@ class TestAsync(JitTestCase):
                 fut = returns_future_float(x)
                 return fut.wait()
 
+    def test_async_method_call(self):
+        class SM(torch.nn.Module):
+            def foo(self, x):
+                return x + x
+
+            def forward(self, x, y):
+                f1 = self.foo(x)
+                f2 = torch.jit.fork(self.foo, y)
+                f3 = torch.jit.fork(self.foo, y)
+                return f1 + torch.jit.wait(f2) + torch.jit.wait(f3)
+
+        self.checkModule(SM(), (torch.tensor(1), torch.tensor(2)))
 
 
 if __name__ == '__main__':

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2990,6 +2990,8 @@ struct to_ir {
       at::ArrayRef<NamedValue> kwargs) {
     if (FunctionValue* fnValue = dynamic_cast<FunctionValue*>(forked.get())) {
       return fnValue->callAsync(loc, method, args, kwargs, /*n_binders-*/ 1);
+    } else if (MethodValue* methodValue = dynamic_cast<MethodValue*>(forked.get())) {
+      return methodValue->callAsync(loc, method, args, kwargs, /*n_binders=*/1);
     }
 
     auto g = method.graph();

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2988,6 +2988,10 @@ struct to_ir {
       const std::shared_ptr<SugaredValue>& forked,
       at::ArrayRef<NamedValue> args,
       at::ArrayRef<NamedValue> kwargs) {
+    if (FunctionValue* fnValue = dynamic_cast<FunctionValue*>(forked.get())) {
+      return fnValue->callAsync(loc, method, args, kwargs, /*n_binders-*/1);
+    }
+
     auto g = method.graph();
     Node* fork_node;
     TypePtr out_type;

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2989,7 +2989,7 @@ struct to_ir {
       at::ArrayRef<NamedValue> args,
       at::ArrayRef<NamedValue> kwargs) {
     if (FunctionValue* fnValue = dynamic_cast<FunctionValue*>(forked.get())) {
-      return fnValue->callAsync(loc, method, args, kwargs, /*n_binders-*/1);
+      return fnValue->callAsync(loc, method, args, kwargs, /*n_binders-*/ 1);
     }
 
     auto g = method.graph();

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -419,7 +419,7 @@ struct TORCH_API ClosureValue : public SugaredValue {
 };
 
 // defines how a method obtained from a module/class/interface behaves in script
-struct MethodValue : public SugaredValue {
+struct TORCH_API MethodValue : public SugaredValue {
   MethodValue(Value* self, std::vector<std::string> method_names)
       : self_(std::move(self)), method_names_(std::move(method_names)) {}
   MethodValue(Value* self, std::string method_name)
@@ -434,34 +434,13 @@ struct MethodValue : public SugaredValue {
       Function& f,
       at::ArrayRef<NamedValue> args,
       at::ArrayRef<NamedValue> kwargs,
-      size_t n_binders) override {
-    std::vector<NamedValue> argsWithSelf = {self_};
-    argsWithSelf.insert(argsWithSelf.end(), args.begin(), args.end());
-    std::vector<const FunctionSchema*> schemas;
-    for (const std::string& method_name : method_names_) {
-      if (auto class_type = self_->type()->cast<ClassType>()) {
-        Function& method = class_type->getMethod(method_name);
-        try {
-          method.ensure_defined();
-        } catch (const RecursiveMethodCallError&) {
-          throw ErrorReport(loc)
-              << " method '" << method.name() << "' is called recursively. "
-              << "Recursive calls are not supported";
-        }
-        schemas.push_back(&method.getSchema());
-      } else if (auto interface_type = self_->type()->cast<InterfaceType>()) {
-        schemas.push_back(interface_type->getMethod(method_name));
-      } else {
-        TORCH_INTERNAL_ASSERT(
-            false, "method constructed that is not a class or interface");
-      }
-    }
-    auto match = matchSchemas(schemas, loc, *f.graph(), argsWithSelf, kwargs);
-    Value* output =
-        f.graph()->insertMethodCall(method_names_[match.first], match.second);
-    output->node()->setSourceRange(loc);
-    return std::make_shared<SimpleValue>(output);
-  }
+      size_t n_binders) override;
+  std::shared_ptr<SugaredValue> callAsync(
+      const SourceRange& loc,
+      Function& f,
+      at::ArrayRef<NamedValue> args,
+      at::ArrayRef<NamedValue> kwargs,
+      size_t n_binders);
 
  private:
   Value* self_;

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -476,6 +476,7 @@ void AliasDb::analyzeImpl(Node* node) {
       return analyzeSubgraph(node);
     case prim::fork:
     case prim::CallFunctionAsync:
+    case prim::CallMethodAsync:
       return analyzeFork(node);
     case aten::wait:
       return analyzeWait(node);

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -475,6 +475,7 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::FallbackGraph:
       return analyzeSubgraph(node);
     case prim::fork:
+    case prim::CallFunctionAsync:
       return analyzeFork(node);
     case aten::wait:
       return analyzeWait(node);

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1792,11 +1792,17 @@ Value* Graph::insertFunctionCall(
 
 Value* Graph::insertMethodCall(
     std::string method_name,
-    const MatchedSchema& matched) {
-  Value* result = insertNode(create(prim::CallMethod, matched.inputs))
+    const MatchedSchema& matched,
+    bool isAsync) {
+  Symbol nodeKind = isAsync ? prim::CallMethodAsync : prim::CallMethod;
+  Value* result = insertNode(create(nodeKind, matched.inputs))
                       ->s_(attr::name, std::move(method_name))
-                      ->output()
-                      ->setType(matched.return_types.at(0));
+                      ->output();
+  if (isAsync) {
+    result->setType(FutureType::create(matched.return_types.at(0)));
+  } else {
+    result->setType(matched.return_types.at(0));
+  }
   return result;
 }
 

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1160,7 +1160,8 @@ struct Graph {
       bool isAsync = false);
   TORCH_API Value* insertMethodCall(
       std::string method_name,
-      const MatchedSchema& matched);
+      const MatchedSchema& matched,
+      bool isAsync = false);
 
   // Note: defined in python_ir.cpp and can be used only in python extension
   Node* createPythonOp(

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1156,7 +1156,8 @@ struct Graph {
 
   TORCH_API Value* insertFunctionCall(
       Function* callee,
-      const MatchedSchema& matched);
+      const MatchedSchema& matched,
+      bool isAsync = false);
   TORCH_API Value* insertMethodCall(
       std::string method_name,
       const MatchedSchema& matched);

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1194,6 +1194,15 @@ void initJITBindings(PyObject* module) {
             /*isAsync=*/true);
         output_ivalue = toTypeInferredIValue(py_func_output);
         node_output = jit::tracer::getValueTrace(output_ivalue);
+      } else if (py::isinstance<Method>(f)) {
+        Method& method = py::cast<Method&>(args[0]);
+        py_func_output = invokeScriptMethodFromPython(
+            method,
+            tuple_slice(std::move(args), 1),
+            std::move(kwargs),
+            /*isAsync=*/true);
+        output_ivalue = toTypeInferredIValue(py_func_output);
+        node_output = jit::tracer::getValueTrace(output_ivalue);
       } else {
         // Otherwise, we need to trace the execution of this function under a
         // special `prim::TracedFork` block. This block will later be turned

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -1214,14 +1214,15 @@ inline py::object runAndInsertCall(
 inline py::object invokeScriptFunctionFromPython(
     Function& callee,
     tuple_slice args,
-    py::kwargs kwargs) {
+    py::kwargs kwargs,
+    bool isAsync = false) {
   return runAndInsertCall(
       callee,
       args,
       kwargs,
       /*self=*/c10::nullopt,
       [&](Graph& graph, const MatchedSchema& match) {
-        return graph.insertFunctionCall(&callee, match);
+        return graph.insertFunctionCall(&callee, match, isAsync);
       });
 }
 

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -1229,7 +1229,8 @@ inline py::object invokeScriptFunctionFromPython(
 inline py::object invokeScriptMethodFromPython(
     Method& callee,
     tuple_slice args,
-    py::kwargs kwargs) {
+    py::kwargs kwargs,
+    bool isAsync = false) {
   auto self = callee.owner()._ivalue();
   return runAndInsertCall(
       callee.function(),
@@ -1237,7 +1238,7 @@ inline py::object invokeScriptMethodFromPython(
       kwargs,
       self,
       [&](Graph& graph, const MatchedSchema& match) {
-        return graph.insertMethodCall(callee.name(), match);
+        return graph.insertMethodCall(callee.name(), match, isAsync);
       });
 }
 

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -950,6 +950,11 @@ struct CodeImpl {
           emitInterfaceCall(node->s(attr::name), node->inputs());
         }
         break;
+      case prim::CallMethodAsync: {
+        auto class_type = node->inputs().at(0)->type()->expect<ClassType>();
+        emitCallAsync(
+            &class_type->getMethod(node->s(attr::name)), node->inputs());
+      } break;
       case prim::TypeCheck:
         emitTypeCheck(node);
         break;

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -296,6 +296,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::ConstantChunk,
       prim::BroadcastingChunk,
       prim::fork,
+      prim::CallFunctionAsync,
       prim::CreateObject,
       prim::AutogradAdd,
       prim::GetAttr,

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -297,6 +297,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::BroadcastingChunk,
       prim::fork,
       prim::CallFunctionAsync,
+      prim::CallMethodAsync,
       prim::CreateObject,
       prim::AutogradAdd,
       prim::GetAttr,

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1050,6 +1050,13 @@ struct PythonPrintImpl {
         }
         stmt << ")";
       } break;
+      case prim::CallFunctionAsync: {
+        stmt << "fork(" << useOf(node->inputs().at(0)) << ", ";
+        for (size_t i = 1; i < node->inputs().size(); i++) {
+          stmt << useOf(node->inputs()[i]) << ", ";
+        }
+        stmt << ")";
+      } break;
       case prim::CallMethod: {
         const auto& self = node->inputs().at(0);
         const auto& methodName = node->s(attr::name);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47078 [jit] introduce CallFunctionAsync to simplify fork compilation**

Right now, we are creating an independent closure + fork subgraph for
every call to `torch.jit.fork()`. This balloons compile times
substantially when there are a lot of fork calls, since compiling
closures is pretty slow (as it involves creating a whole sbugraph).

This PR introduces an optimization for the non-closure case, where we
are just forking a function, like:

```
torch.jit.fork(my_func, arg1, arg2)
```

The above code will now generate:
```
%ret : Future[whatever] = prim::CallFunctionAsync(...)
```

instead of `prim::fork` and a closure subgraph to execute.

In practice, we only ever fork functions and methods, since closures are
not possibly to create in the Python frontend. Existing serialized code
will still contain closures as that is how we serialized forked code
previously.

Differential Revision: [D24630722](https://our.internmc.facebook.com/intern/diff/D24630722)