### PR TITLE
Preserve module parameters in freezing

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1035,10 +1035,78 @@ class TestFreezing(JitTestCase):
 
         model = torch.jit.script(Net())
         model.train()
-
-        with self.assertRaisesRegex(RuntimeError, 'Freezing module in training mode is not yet supported'):
-            mTrain_freezed = torch._C._freeze_module(model._c)
-
+        mTrain_freezed = torch._C._freeze_module(model._c)
+        # verify mTrain_freezed looks exactly as:
+        # module {
+        #   attributes {
+        #     conv1 = ...
+        #     conv2 = ...
+        #     dropout1 = ...
+        #     dropout2 = ...
+        #     fc1 = ...
+        #     fc2 = ...
+        #   }
+        #   ...
+        #   submodules {
+        #     module conv1 {
+        #       attributes {
+        #          weight = ...
+        #          bias = ...
+        #       }
+        #       ...
+        #     }
+        #     module conv2 {
+        #       attributes {
+        #          weight = ...
+        #          bias = ...
+        #       }
+        #       ...
+        #     }
+        #     module dropout1 {
+        #       attributes {
+        #          training = ...
+        #       }
+        #       ...
+        #     }
+        #     module dropout2 {
+        #       attributes {
+        #          training = ...
+        #       }
+        #       ...
+        #     }
+        #     module fc1 {
+        #       attributes {
+        #          weight = ...
+        #          bias = ...
+        #       }
+        #       ...
+        #     }
+        #     module fc2 {
+        #       attributes {
+        #          weight = ...
+        #          bias = ...
+        #       }
+        #       ...
+        #     }
+        self.assertFalse(mTrain_freezed.hasattr('training'))
+        self.assertTrue(mTrain_freezed.hasattr('conv1'))
+        self.assertFalse(mTrain_freezed.conv1.hasattr('training'))
+        self.assertTrue(mTrain_freezed.conv1.hasattr('weight'))
+        self.assertTrue(mTrain_freezed.conv1.hasattr('bias'))
+        self.assertTrue(mTrain_freezed.hasattr('conv2'))
+        self.assertFalse(mTrain_freezed.conv2.hasattr('training'))
+        self.assertTrue(mTrain_freezed.conv2.hasattr('weight'))
+        self.assertTrue(mTrain_freezed.conv2.hasattr('bias'))
+        self.assertTrue(mTrain_freezed.hasattr('dropout1'))
+        self.assertTrue(mTrain_freezed.dropout1.hasattr('training'))
+        self.assertTrue(mTrain_freezed.hasattr('dropout2'))
+        self.assertTrue(mTrain_freezed.dropout2.hasattr('training'))
+        self.assertTrue(mTrain_freezed.hasattr('fc1'))
+        self.assertTrue(mTrain_freezed.fc1.hasattr('weight'))
+        self.assertTrue(mTrain_freezed.fc1.hasattr('bias'))
+        self.assertTrue(mTrain_freezed.hasattr('fc2'))
+        self.assertTrue(mTrain_freezed.fc2.hasattr('weight'))
+        self.assertTrue(mTrain_freezed.fc2.hasattr('bias'))
         model.eval()
         mEval_freezed = torch._C._freeze_module(model._c)
         self.assertFalse(mEval_freezed.hasattr('conv1'))
@@ -1056,6 +1124,14 @@ class TestFreezing(JitTestCase):
         m = torch.jit.load(buffer)
         FileCheck().check_not('GetAttr[name=') \
                    .run(m._c._get_method('forward').graph)
+        m2 = torch._C._freeze_module(model._c, preserveParameters=True)
+        self.assertTrue(m2.hasattr('conv1'))
+        self.assertTrue(m2.hasattr('conv2'))
+        self.assertFalse(m2.hasattr('dropout1'))
+        self.assertFalse(m2.hasattr('training'))
+        self.assertTrue(m2.hasattr('fc1'))
+        self.assertFalse(m2.hasattr('dropout2'))
+        self.assertTrue(m2.hasattr('fc2'))
 
     def test_freeze_module_detach_gradient(self):
         mod = nn.Conv2d(8, 3, 4, 2, 1)

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -22,7 +22,8 @@ namespace jit {
 TORCH_API Module freeze_module(
     const Module& module,
     std::vector<std::string> preservedAttrs = std::vector<std::string>(),
-    bool freezeInterfaces = true);
+    bool freezeInterfaces = true,
+    bool preserveParameters = false);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -283,12 +283,15 @@ void initJITBindings(PyObject* module) {
           "_freeze_module",
           [](Module& module,
              std::vector<std::string>& preservedAttrs,
-             bool freezeInterfaces) {
-            return freeze_module(module, preservedAttrs, freezeInterfaces);
+             bool freezeInterfaces,
+             bool preserveParameters) {
+            return freeze_module(
+                module, preservedAttrs, freezeInterfaces, preserveParameters);
           },
           py::arg("module"),
           py::arg("preservedAttrs") = std::vector<std::string>(),
-          py::arg("freezeInterfaces") = true)
+          py::arg("freezeInterfaces") = true,
+          py::arg("preserveParameters") = false)
       .def("_jit_pass_fuse_linear", &FuseLinear)
       .def(
           "_jit_pass_fuse_add_relu",


### PR DESCRIPTION
Added preserveParameters to freezing API that allows to preserve module
parameters.

Fixes #{39613}
