### PR TITLE
Fix output type of torch.max for Tensor subclasses.

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -821,6 +821,15 @@ class TestGradCheckOverride(TestCase):
             torch.add,
         })
 
+class TestNamedTuple(TestCase):
+    "Regression test for gh-?????"
+    def test_max(self):
+        x = torch.tensor([1, 2])
+        xs = x.as_subclass(SubTensor2)
+        r = torch.max(x, dim=0)
+        rs = torch.max(xs, dim=0)
+        self.assertEqual(type(r), type(rs))
+        self.assertEqual(r, rs)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -822,7 +822,7 @@ class TestGradCheckOverride(TestCase):
         })
 
 class TestNamedTuple(TestCase):
-    "Regression test for gh-?????"
+    "Regression test for gh-47090"
     def test_max(self):
         x = torch.tensor([1, 2])
         xs = x.as_subclass(SubTensor2)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -1034,7 +1034,8 @@ def _convert(ret, cls):
     if isinstance(ret, Tensor):
         ret = ret.as_subclass(cls)
 
-    if isinstance(ret, tuple):
-        ret = tuple(_convert(r, cls) for r in ret)
+    if isinstance(ret, (tuple, list)):
+        # Also handles things like namedtuples
+        ret = type(ret)(_convert(r, cls) for r in ret)
 
     return ret


### PR DESCRIPTION
Fixes #47090 
Fixes #46826 