### PR TITLE
[JIT] add back freeze to docs

### DIFF
--- a/docs/source/jit.rst
+++ b/docs/source/jit.rst
@@ -51,6 +51,7 @@ Creating TorchScript Code
     wait
     ScriptModule
     ScriptFunction
+    freeze
     save
     load
     ignore


### PR DESCRIPTION
freeze was temporarily renamed to _freeze in a reorg, and then removed from doc [here](https://github.com/pytorch/pytorch/pull/43473). add it back to docs.