### PR TITLE
Add test for trace

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5993,6 +5993,37 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(expected.shape, result.shape)
         self.assertEqual(expected, result)
 
+    def _test_trace(self, device, dtype, legacy):
+        def test(shape):
+            tensor = make_tensor(shape, device, dtype, low=-9, high=9)
+            diag = tensor.diag()
+            if legacy:
+                # NB: trace on cpu doesn't do type promotion...
+                expected = tensor.diag().sum().to(dtype)
+            else:
+                expected = tensor.diag().sum()
+            self.assertEqual(tensor.trace(), expected)
+
+        shapes = (
+            [10, 1],
+            [1, 10],
+            [100, 100],
+            [20, 100],
+            [100, 20],
+        )
+        for shape in shapes:
+            test(shape)
+
+    @onlyCPU
+    @dtypes(*torch.testing.get_all_dtypes(include_complex=False, include_bool=False, include_half=False, include_bfloat16=False))
+    def test_trace_legacy(self, device, dtype):
+        self._test_trace(device, dtype, legacy=True)
+
+    @onlyCUDA
+    @dtypes(*torch.testing.get_all_dtypes(include_complex=False, include_bool=False, include_bfloat16=False))
+    def test_trace(self, device, dtype):
+        self._test_trace(device, dtype, legacy=False)
+
     @onlyCPU
     @dtypes(torch.float)
     def test_broadcast_tensors(self, device, dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47126 Port CPU Trace from TH to ATen
* **#47125 Add test for trace**

We didn't actually have any tests for torch.trace. The tests expose a
discrepancy between the behavior of torch.trace on CPU and CUDA that
I'll file an issue for.

Differential Revision: [D24683260](https://our.internmc.facebook.com/intern/diff/D24683260)