### PR TITLE
[ROCm] enable kernel asserts

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -250,7 +250,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // CUDA_KERNEL_ASSERT checks the assertion
 // even when NDEBUG is defined. This is useful for important assertions in CUDA
 // code that would otherwise be suppressed when building Release.
-#if defined(__ANDROID__) || defined(__APPLE__) || defined(__HIP_PLATFORM_HCC__)
+#if defined(__ANDROID__) || defined(__APPLE__)
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)
 #elif defined(_MSC_VER)

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -124,9 +124,6 @@ endif()
 # Add HIP to the CMAKE Module Path
 set(CMAKE_MODULE_PATH ${HIP_PATH}/cmake ${CMAKE_MODULE_PATH})
 
-# Disable Asserts In Code (Can't use asserts on HIP stack.)
-add_definitions(-DNDEBUG)
-
 macro(find_package_and_print_version PACKAGE_NAME)
   find_package("${PACKAGE_NAME}" ${ARGN})
   message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
@@ -134,6 +131,14 @@ endmacro()
 
 # Find the HIP Package
 find_package_and_print_version(HIP 1.0)
+
+if (HIP_VERSION VERSION_LESS "3.7")
+  # Disable Asserts In Code (Can't use asserts on HIP stack.)
+  add_definitions(-DNDEBUG)
+  message("HIP VERSION < 3.7; disablng asserts")
+else()
+  message("HIP VERSION >= 3.7; enabling asserts")
+endif()
 
 if(HIP_FOUND)
   set(PYTORCH_FOUND_HIP TRUE)
@@ -144,7 +149,7 @@ if(HIP_FOUND)
   execute_process(COMMAND dpkg -l COMMAND grep hsakmt-roct COMMAND awk "{print $2 \" VERSION: \" $3}")
   execute_process(COMMAND dpkg -l COMMAND grep rocr-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
   execute_process(COMMAND dpkg -l COMMAND grep -w hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
-  execute_process(COMMAND dpkg -l COMMAND grep hip_base COMMAND awk "{print $2 \" VERSION: \" $3}")
+  execute_process(COMMAND dpkg -l COMMAND grep hip-base COMMAND awk "{print $2 \" VERSION: \" $3}")
   execute_process(COMMAND dpkg -l COMMAND grep hip_hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
 
   message("\n***** Library versions from cmake find_package *****\n")

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -132,7 +132,7 @@ endmacro()
 # Find the HIP Package
 find_package_and_print_version(HIP 1.0)
 
-if (HIP_VERSION VERSION_LESS "3.7")
+if(HIP_VERSION VERSION_LESS "3.7")
   # Disable Asserts In Code (Can't use asserts on HIP stack.)
   add_definitions(-DNDEBUG)
   message("HIP VERSION < 3.7; disablng asserts")


### PR DESCRIPTION
Addresses missing ROCm feature indicated in #38943.
