### PR TITLE
check sparse sizes

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_utils import TestCase, run_tests, skipIfRocm
 from torch.testing._internal.common_cuda import TEST_CUDA, _get_torch_cuda_version
 from numbers import Number
 from torch.autograd.gradcheck import gradcheck
+from typing import Dict, Any
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -161,7 +162,7 @@ class TestSparse(TestCase):
             self.assertEqual(i, x._indices())
             self.assertEqual(v, x._values())
             self.assertEqual(x.ndimension(), len(with_size))
-            self.assertEqual(self.safeCoalesce(x)._nnz(), nnz)
+            self.assertEqual(x.coalesce()._nnz(), nnz)
             self.assertEqual(list(x.size()), with_size)
 
             # Test .indices() and .values()
@@ -183,7 +184,7 @@ class TestSparse(TestCase):
         i = self.index_tensor([[9, 0, 0, 0, 8, 1, 1, 1, 2, 7, 2, 2, 3, 4, 6, 9]])
         v = self.value_tensor([[idx**2, idx] for idx in range(i.size(1))])
         x = self.sparse_tensor(i, v, torch.Size([10, 2]))
-        self.assertEqual(self.safeCoalesce(x)._nnz(), 9)
+        self.assertEqual(x.coalesce()._nnz(), 9)
 
         # Make sure we can access empty indices / values
         x = self.legacy_sparse_tensor()
@@ -191,13 +192,50 @@ class TestSparse(TestCase):
         self.assertEqual(x._values().numel(), 0)
 
     def test_coalesce(self):
+
+        def _test_coalesce(x):
+            tc = t.coalesce()
+            self.assertEqual(tc.to_dense(), t.to_dense())
+            self.assertTrue(tc.is_coalesced())
+            # Our code below doesn't work when nnz is 0, because
+            # then it's a 0D tensor, not a 2D tensor.
+            if t._nnz() == 0:
+                self.assertEqual(t._indices(), tc._indices())
+                self.assertEqual(t._values(), tc._values())
+                return tc
+
+            value_map: Dict[Any, Any] = {}
+            for idx, val in zip(t._indices().t(), t._values()):
+                idx_tup = tuple(idx.tolist())
+                if idx_tup in value_map:
+                    value_map[idx_tup] += val
+                else:
+                    value_map[idx_tup] = val.clone() if isinstance(val, torch.Tensor) else val
+
+            new_indices = sorted(list(value_map.keys()))
+            _new_values = [value_map[idx] for idx in new_indices]
+            if t._values().ndimension() < 2:
+                new_values = t._values().new(_new_values)
+            else:
+                new_values = torch.stack(_new_values)
+
+            new_indices = t._indices().new(new_indices).t()
+            tg = t.new(new_indices, new_values, t.size())
+
+            self.assertEqual(tc._indices(), tg._indices())
+            self.assertEqual(tc._values(), tg._values())
+
+            if t.is_coalesced():
+                self.assertEqual(tc._indices(), t._indices())
+                self.assertEqual(tc._values(), t._values())
+
         for empty_i, empty_v, empty_nnz in itertools.product([True, False], repeat=3):
             sparse_size = [] if empty_i else [2, 1]
             dense_size = [1, 0, 2] if empty_v else [1, 2]
             nnz = 0 if empty_nnz else 5
 
             t, _, _ = self._gen_sparse(len(sparse_size), nnz, sparse_size + dense_size)
-            self.safeCoalesce(t)  # this tests correctness
+            _test_coalesce(t)  # this tests correctness
 
     def test_ctor_size_checks(self):
         indices = self.index_tensor([
@@ -399,7 +437,7 @@ class TestSparse(TestCase):
 
     def test_contig(self):
         def test_tensor(x, exp_i, exp_v):
-            x = self.safeCoalesce(x)
+            x = x.coalesce()
             self.assertEqual(exp_i, x._indices())
             self.assertEqual(exp_v, x._values())
 
@@ -479,7 +517,7 @@ class TestSparse(TestCase):
 
     def test_contig_hybrid(self):
         def test_tensor(x, exp_i, exp_v):
-            x = self.safeCoalesce(x)
+            x = x.coalesce()
             self.assertEqual(exp_i, x._indices())
             self.assertEqual(exp_v, x._values())
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -2065,7 +2065,9 @@ class TestSparse(TestCase):
             if not x.is_cuda:
                 # CUDA sparse tensors currently requires the size to be
                 # specified if nDimV > 0
-                self.assertEqual(x.new(indices, values), x)
+                out = x.new(indices, values).coalesce()
+                x_c = x.coalesce()
+                self.assertEqual((out.indices(), out.values()), (x_c.indices(), x_c.values()))
             self.assertEqual(x.new(indices, values, x.size()), x)
 
         test_shape(3, 10, 100)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -861,7 +861,6 @@ class TestCase(expecttest.TestCase):
         if is_uncoalesced:
             v = torch.cat([v, torch.randn_like(v)], 0)
             i = torch.cat([i, i], 1)
-
         x = torch.sparse_coo_tensor(i, v, torch.Size(size))
 
         if not is_uncoalesced:
@@ -877,14 +876,7 @@ class TestCase(expecttest.TestCase):
         return x, x._indices().clone(), x._values().clone()
 
     def safeToDense(self, t):
-        r = self.safeCoalesce(t)
-        return r.to_dense()
-
-    def safeCoalesce(self, t):
-        tc = t.coalesce()
-        self.assertEqual(tc.to_dense(), t.to_dense())
-        self.assertTrue(tc.is_coalesced())
-        return tc
+        return t.coalesce().to_dense()
 
     # Compares the given Torch and NumPy functions on the given tensor-like object.
     # NOTE: both torch_fn and np_fn should be functions that take a single
@@ -1055,8 +1047,8 @@ class TestCase(expecttest.TestCase):
                         msg = debug_msg_sparse
                     self.assertTrue(False, msg=msg)
 
-                x = self.safeCoalesce(x)
-                y = self.safeCoalesce(y)
+                x = x.coalesce()
+                y = y.coalesce()
                 indices_result, debug_msg = self._compareTensors(x._indices(), y._indices(),
                                                                  rtol=rtol, atol=atol,
                                                                  equal_nan=equal_nan, exact_dtype=exact_dtype,

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -884,40 +884,7 @@ class TestCase(expecttest.TestCase):
         tc = t.coalesce()
         self.assertEqual(tc.to_dense(), t.to_dense())
         self.assertTrue(tc.is_coalesced())
-
-        # Our code below doesn't work when nnz is 0, because
-        # then it's a 0D tensor, not a 2D tensor.
-        if t._nnz() == 0:
-            self.assertEqual(t._indices(), tc._indices())
-            self.assertEqual(t._values(), tc._values())
-            return tc
-
-        value_map: Dict[Any, Any] = {}
-        for idx, val in zip(t._indices().t(), t._values()):
-            idx_tup = tuple(idx.tolist())
-            if idx_tup in value_map:
-                value_map[idx_tup] += val
-            else:
-                value_map[idx_tup] = val.clone() if isinstance(val, torch.Tensor) else val
-
-        new_indices = sorted(list(value_map.keys()))
-        _new_values = [value_map[idx] for idx in new_indices]
-        if t._values().ndimension() < 2:
-            new_values = t._values().new(_new_values)
-        else:
-            new_values = torch.stack(_new_values)
-
-        new_indices = t._indices().new(new_indices).t()
-        tg = t.new(new_indices, new_values, t.size())
-
-        self.assertEqual(tc._indices(), tg._indices())
-        self.assertEqual(tc._values(), tg._values())
-
-        if t.is_coalesced():
-            self.assertEqual(tc._indices(), t._indices())
-            self.assertEqual(tc._values(), t._values())
-
-        return tg
+        return tc
 
     # Compares the given Torch and NumPy functions on the given tensor-like object.
     # NOTE: both torch_fn and np_fn should be functions that take a single
@@ -1081,6 +1048,12 @@ class TestCase(expecttest.TestCase):
             super().assertEqual(x.is_sparse, y.is_sparse, msg=msg)
             super().assertEqual(x.is_quantized, y.is_quantized, msg=msg)
             if x.is_sparse:
+                if x.size() != y.size():
+                    debug_msg = f"Attempted to compare equality of tensors with the different sizes. Got sizes {x.size()} and {y.size()}."
+                    if msg is None:
+                        msg = debug_msg
+                    self.assertTrue(False, msg=msg)
+
                 x = self.safeCoalesce(x)
                 y = self.safeCoalesce(y)
                 indices_result, debug_msg = self._compareTensors(x._indices(), y._indices(),

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1041,7 +1041,7 @@ class TestCase(expecttest.TestCase):
             super().assertEqual(x.is_quantized, y.is_quantized, msg=msg)
             if x.is_sparse:
                 if x.size() != y.size():
-                    debug_msg_sparse = ("Attempted to compare equality of tensors with the different sizes. "
+                    debug_msg_sparse = ("Attempted to compare equality of tensors with different sizes. "
                                         f"Got sizes {x.size()} and {y.size()}.")
                     if msg is None:
                         msg = debug_msg_sparse

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1050,7 +1050,7 @@ class TestCase(expecttest.TestCase):
             if x.is_sparse:
                 if x.size() != y.size():
                     debug_msg_sparse = ("Attempted to compare equality of tensors with the different sizes. "
-                     f"Got sizes {x.size()} and {y.size()}.")
+                                        f"Got sizes {x.size()} and {y.size()}.")
                     if msg is None:
                         msg = debug_msg_sparse
                     self.assertTrue(False, msg=msg)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1049,9 +1049,10 @@ class TestCase(expecttest.TestCase):
             super().assertEqual(x.is_quantized, y.is_quantized, msg=msg)
             if x.is_sparse:
                 if x.size() != y.size():
-                    debug_msg = f"Attempted to compare equality of tensors with the different sizes. Got sizes {x.size()} and {y.size()}."
+                    debug_msg_sparse = ("Attempted to compare equality of tensors with the different sizes. "
+                     f"Got sizes {x.size()} and {y.size()}.")
                     if msg is None:
-                        msg = debug_msg
+                        msg = debug_msg_sparse
                     self.assertTrue(False, msg=msg)
 
                 x = self.safeCoalesce(x)


### PR DESCRIPTION
checks sizes of sparse tensors when comparing them in assertEqual.
Removes additional checks in safeCoalesce, safeCoalesce should not be a test for `.coalesce()` function. 
