### PR TITLE
[fix] nn.Embedding.from_pretrained : honour `padding_idx` argument

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3025,6 +3025,12 @@ class TestNN(NNTestCase):
         output = embedding(input)
         self.assertEqual(a, output)
 
+    def test_embedding_from_pretrained_padding_idx(self):
+        padding_idx = 2
+        embeddings = torch.rand(4, 3, requires_grad=True)
+        embedding_nn = nn.Embedding.from_pretrained(embeddings, padding_idx=padding_idx)
+        self.assertEqual(embedding_nn.weight[padding_idx].sum(), 0)
+
     def test_embedding_from_pretrained_options(self):
         a = torch.Tensor([[1, 2, 3], [4, 5, 6]])
         opts = {

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -129,10 +129,14 @@ class Embedding(Module):
             assert list(_weight.shape) == [num_embeddings, embedding_dim], \
                 'Shape of weight does not match num_embeddings and embedding_dim'
             self.weight = Parameter(_weight)
+            self._fill_padding_idx_with_zero()
         self.sparse = sparse
 
     def reset_parameters(self) -> None:
         init.normal_(self.weight)
+        self._fill_padding_idx_with_zero()
+
+    def _fill_padding_idx_with_zero(self) -> None:
         if self.padding_idx is not None:
             with torch.no_grad():
                 self.weight[self.padding_idx].fill_(0)


### PR DESCRIPTION
Fixes #46585 (first snippet)

Now the behaviour of `padding_idx` agrees with documentation.