### PR TITLE
[jit] fix traced training attribute

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -413,6 +413,15 @@ class TestJit(JitTestCase):
         self.assertEqual(origin_result, m3(input.cpu()))
         self.assertEqual(origin_result, m4(input.cuda(0)))
 
+    def test_trace_retains_train(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x
+        m = M()
+        m.eval()
+        tm = torch.jit.trace(m, (torch.rand(3)))
+        self.assertEqual(tm.training, m.training)
+
     @unittest.skipIf(not RUN_CUDA, "restore device requires CUDA")
     def test_restore_shared_storage_on_cuda(self):
         class Foo(torch.jit.ScriptModule):

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1010,7 +1010,6 @@ class TracedModule(ScriptModule):
                     "TracedModules don't support parameter sharing between modules"
                 )
             id_set.add(param)
-
         tmp_module.training = orig.training
 
         for name, param in orig._parameters.items():
@@ -1046,7 +1045,7 @@ class TracedModule(ScriptModule):
 
         self.__dict__["_name"] = type(orig).__name__
         self.__dict__["_actual_script_module"] = script_module
-        for name in ("_parameters", "_buffers", "_modules"):
+        for name in ("_parameters", "_buffers", "_modules", "training"):
             delattr(self, name)
 
     def forward(self, *args, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47211 [jit] fix traced training attribute**

The attribute is getting shadowed by the default one set on all modules,
and the __setattr__ on the TracedModule object prevents setting it correctly.

    import torch

    inp = torch.zeros(1, 3, 224, 224)
    model = torch.hub.load('pytorch/vision:v0.6.0', 'mobilenet_v2', pretrained=True)
    model.eval()
    print(model.training)
    with torch.no_grad():
        traced = torch.jit.trace(model, inp)
    print(traced.training)
    traced.eval()
    print(traced.training)
    traced.training = False
    print(traced.training)
    torch.jit.freeze(traced)

Differential Revision: [D24686690](https://our.internmc.facebook.com/intern/diff/D24686690)