### PR TITLE
[DO NOT REVIEW] adding explicit in IValue::IValue(bool)

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -422,7 +422,7 @@ struct CAFFE2_API IValue final {
   }
 
   // Bool
-  IValue(bool b) : tag(Tag::Bool), is_intrusive_ptr(false) {
+  explicit IValue(bool b) : tag(Tag::Bool), is_intrusive_ptr(false) {
 #if defined(__clang__) && defined(__x86_64__)
     // Initializing entire payload stops valgrind's from reporting
     // "jump or move depends on uninitialised value" in IValue copy constructor


### PR DESCRIPTION
Boolean conversion for pointers seems strange in this case. https://en.cppreference.com/w/cpp/language/implicit_conversion.
Without explicit, we can wrap any pointer with IValue, which is a very confusing behavior.