### PR TITLE
[rfc] fx quant: add QuantizationFXTraceable marker

### DIFF
--- a/torch/quantization/fx/markers.py
+++ b/torch/quantization/fx/markers.py
@@ -1,0 +1,7 @@
+class QuantizationFXTraceable:
+    r"""
+    Marks a class and all of its children as FX symbolically traceable.
+    """
+    pass
+
+# TODO(future PR): add QuantizationFXNonTraceable to mark a class as a leaf.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47215 [rfc] fx quant: add QuantizationFXTraceable marker**

Summary:

Adds a `QuantizationFXTraceable` class to mark a subgraph as
symbolically traceable for quantization. Adds top level API
support to `prepare_fx` and `convert_fx` to be able to take
non-traceable models with traceable subgraphs, defined by
this marker.

RFC for now, to check with the team on the API. Once we align
on the API, we can fix the docblocks and add more rigorous testing.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx.test_fx_traceable_marker
```

Reviewers:

Subscribers:

Tasks:

Tags: