### PR TITLE
as_strided batching rule

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -344,6 +344,135 @@ Tensor view_batching_rule(const Tensor& self, IntArrayRef size) {
   return self_physical.newLogicalFromPhysical(result);
 }
 
+// What are the semantics of as_strided inside of vmap?
+// y = vmap(lambda x: x.as_strided(sizes, strides, offset))(xs)
+// This returns a view on `x`, `y`, such that each y[i] has:
+// - sizes: `sizes`
+// - strides: `strides`
+// - storage_offset: offset + i * x.stride(batch_dim)
+//
+// In other words, it is as if we had treated each x[i] as having storage
+// offset equal to xs.offset() and called as_strided(sizes, sizes, offset).
+// (that is equivalent to x[i].as_strided(
+//    sizes, sizes, offset + x[i].storage_offset() - xs.offset()) for all i)
+//
+// Note that this *may* be different from actually running as_strided
+// in a for-loop. This is due to how as_strided takes in `offset` to be
+// an *absolute* offset. As an example, consider:
+// >>> x = torch.tensor([0., 1., 2., 3., 4.]).as_strided([4], [1], 1)
+// >>> z = [x[i].as_strided([1], [1], 1) for i in range(4)]
+// Each z[i] is actually the same view on x (z[i] == torch.tensor([1.]))!
+// However, we consider the above for-loop comprehension to be a user error:
+// a user should have written the following if they wanted to use as_strided
+// in a per-sample way:
+// >>> z = [x[i].as_strided([1], [1], 1 + x[i].storage_offset() - 1) for i in range(4)]
+Tensor as_strided_batching_rule(
+    const Tensor& tensor,
+    IntArrayRef sizes,
+    IntArrayRef strides,
+    optional<int64_t> storage_offset) {
+  auto physical_view = at::MultiBatchVmapTransform::logicalToPhysical(tensor);
+  auto num_batch_dims = physical_view.numBatchDims();
+  auto physical_sizes = physical_view.getPhysicalShape(sizes);
+
+  // physical_strides = physical tensor's batch strides + (logical) strides
+  at::VmapDimVector physical_strides;
+  physical_strides.reserve(num_batch_dims + strides.size());
+  physical_strides.insert(
+      physical_strides.end(),
+      physical_view.tensor().strides().begin(),
+      physical_view.tensor().strides().begin() + num_batch_dims);
+  physical_strides.insert(
+      physical_strides.end(),
+      strides.begin(),
+      strides.end());
+
+  // If zi = xs[i].as_strided(sizes, strides, offset + xs[i].offset() - xs.offset())
+  // is valid for all i, then it turns out that
+  // xs.as_strided(physical_sizes, physical_strides, offset) always succeeds
+  // and creates a tensor y such that each y[i] references the same memory
+  // locations as zi. See NOTE: [When will the as_strided batching rule fail?]
+  auto result = physical_view.tensor().as_strided(
+      physical_sizes, physical_strides, storage_offset);
+  return physical_view.newLogicalFromPhysical(result);
+}
+
+// NOTE: [When will the as_strided batching rule fail?]
+// If zi = xs[i].as_strided(sizes, strides, offset + xs[i].offset() - xs.offset())
+// is valid for all i, then it turns out that
+// xs.as_strided(physical_sizes, physical_strides, offset) always succeeds and
+// creates a tensor y such that each y[i] refers to the same memory as zi.
+//
+// Let's say we have xs[i].as_strided(sizes, strides, offset + xs[i].offset() - xs.offset()).
+// Furthermore, let's say that as a part of being "valid" this as_strided call
+// does not return a result that can index memory not indexable by xs[i].
+//
+// Assume that there's only one batch dim and it is at the front of the
+// `xs` tensor.
+//
+// Let B be the batch size and S be the stride of the batch dim.
+//
+// [[A]]
+// xs[i].as_strided(sizes, strides, offset + xs[i].offset() - xs.offset()) has:
+// - sizes: sizes
+// - strides: strides
+// - offset: offset + S * i
+//
+// x.as_strided itself checks that:
+// - (sizes, strides, offset) are in bounds for `x`'s storage.
+// - strides are positive
+// - offset is positive
+//
+// Claim 1: if xs[i].as_strided(sizes, strides, offset + xs[i].offset() - xs.offset())
+// is valid, then
+// ([B] + sizes, [S] + strides, offset + xs.offset()) are in bounds for `xs`'s storage.
+//
+// If we have the claim, then xs.as_strided([B] + sizes, [S] + strides, offset)
+// won't error out. So all we need to check is that the memory locations are
+// what we expected. See [[B]] for proof (it's not very important)
+//
+// xs.as_strided(physical_sizes, physical_strides, offset) is equivalent to
+// xs.as_strided([B] + sizes, [S] + strides, offset)
+//
+// xs.as_strided([B] + sizes, [S] + strides, offset) has:
+// - sizes: [B] + sizes
+// - strides: [S] + strides
+// - offset: offset
+//
+// xs.as_strided([B] + sizes, [S] + strides, offset)[i] has:
+// - sizes: sizes
+// - strides: strides
+// - offset: offset + S * i
+// These memory locations are exactly the same as what we got for [[A]],
+// so the xs.as_strided([B] + sizes, [S] + strides, offset) is valid.
+//
+// [[B]] Hand-wavy proof of Claim 1:
+// Part of our definition of being valid is that xs[i].as_strided(...)
+// must return a tensor that only uses memory indexable by xs[i].
+// This means that (sizes, strides, offset + xs[i].offset() - xs.offset()) satisfies:
+//    offset + xs[i].offset() - xs.offset() + 1 + \sum_j (sizes[j] - 1) * strides[j]
+//    <= xs[i].offset() + 1 + \sum_j (xs[i].size(j) - 1) * xs[i].stride(j)
+// (the largest-index memory location of xs[i].as_strided(...) must be \leq
+// the largest-index memory location of xs[i])
+//
+// Fiddling that inequality gives us:
+//    offset - xs.offset() + 1 + \sum_j (sizes[j] - 1) * strides[j]
+//    <= 1 + \sum_j (xs[i].size(j) - 1) * xs[i].stride(j)
+//
+//    offset - xs.offset() + 1 + (B-1)*S + \sum_j (sizes[j] - 1) * strides[j]
+//    <= 1 + (B-1)*S + \sum_j (xs[i].size(j) - 1) * xs[i].stride(j)
+//
+//    offset - xs.offset() + 1 + (B-1)*S + \sum_j (sizes[j] - 1) * strides[j]
+//    <= 1 + \sum_j (xs.size(j) - 1) * xs.stride(j)
+//
+//    offset + 1 + (B-1)*S + \sum_j (sizes[j] - 1) * strides[j]
+//    <= xs.offset() + 1 + \sum_j (xs.size(j) - 1) * xs.stride(j)
+// (the largest-index memory location of xs.as_strided(size, stride, offset)
+// is \leq than the largest-index memory location of xs)
+//
+// Therefore ([B] + sizes, [S] + strides, offset) are in bounds for
+// `xs`'s storage.
+
 template <typename F, F Func, typename... ExtraArgs>
 Tensor unwrap_and_call(const Tensor& input, ExtraArgs... args) {
   auto* input_batched = unsafeGetBatchedImpl(input);
@@ -582,6 +711,7 @@ TORCH_LIBRARY_IMPL(aten, Batched, m) {
   m.impl("is_complex", native::is_complex);
 
   // view operations
+  m.impl("as_strided", as_strided_batching_rule);
   m.impl("chunk", chunk_batching_rule);
   m.impl("tensor_split.sections", tensor_split_sections_batching_rule);
   m.impl("tensor_split.indices", tensor_split_indices_batching_rule);

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -1108,7 +1108,8 @@ class TestVmapOperators(Namespace.TestVmapBase):
             vmap(op)(torch.randn(B0, 2, 2, 2), torch.randn(B0, 2))
         with self.assertRaisesRegex(RuntimeError, msg):
             vmap(op, in_dims=(0, None))(torch.randn(B0, 3, 3, 2), torch.randn(2, 2))
-        with self.assertRaisesRegex(RuntimeError, msg): vmap(op, in_dims=(None, 0))(torch.randn(2, 2), torch.randn(B0, 2, 2, 2))
+        with self.assertRaisesRegex(RuntimeError, msg):
+            vmap(op, in_dims=(None, 0))(torch.randn(2, 2), torch.randn(B0, 2, 2, 2))
 
         # left arg is vmapped
         test(op, (torch.rand(B0, 2, 3, 5), torch.rand(2, 5, 3)), in_dims=(0, None))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47227 Batched gradient support for view+inplace operations
* #47226 Batching rule for Tensor.new_empty_strided
* #47225 Implement Tensor.new_empty_strided(sizes, strides, *, dtype, device, requires_grad)
* **#47224 as_strided batching rule**
* #47223 Batched grad for advanced indexing (index)
* #47189 Fix sum batching rule, add simple clone batching rule
* #47188 Batching rules for complex view functions

This PR adds a batching rule for as_strided. `as_strided` is a really weird
operation and I hope that users don't use it very much.

Motivation
----------
The motivation for adding a batching rule for as_strided is for
batched gradient computation.

AsStridedBackward appears in PyTorch when handling view+in-place
operations and calls `as_strided`. AsStridedBackward calls as_strided on
a fresh tensor with storage_offset equal to 0. We would like to be able
to vmap through the backward graph of view+in-place operations to
for batched gradient computation, especially because internally we have
a number of functions that are implemented as a view+in-place.

Alternatives
------------
If we think that as_strided is too crazy to have a batching rule, we
could either:
- have a flag that controls the autograd view+in-place
behavior
- require that the input tensor's storage offset must be equal to 0
to make it easier to reason about.

I think the batching rule makes sense, so I didn't pursue the
alternatives.

The batching rule
-----------------
```
y = vmap(lambda x: x.as_strided(sizes, strides, offset))(xs)
```
The result of the above should be "equivalent" to:
- Assume that each x has storage offset equal to xs.storage_offset()
(call that S).
- Calling as_strided with (sizes, sizes, offset + x[i].storage_offset() - S) on each x.

More concretely,
this returns a view on `xs`, such that each y[i] has:
- sizes: `sizes`
- strides: `strides`
- storage_offset: offset + i * x.stride(batch_dim)

Why the behavior can be weird
-----------------------------
The behavior of the batching rule may be different from actually running
as_strided in a for-loop because `as_strided` takes in `offset` as a
"absolute offset". As an example, consider

```
>>> x = torch.tensor([0., 1., 2., 3., 4.])
>>> z = [x[i].as_strided([1], [1], 1) for i in range(5)]
```
Each z[i] is actually the same view on x (z[i] == torch.tensor([0.]))!
However, we consider the above for-loop comprehension to be a user error:
a user should have written the following if they wanted to use as_strided
in a per-sample way:
```
>>> z = [x[i].as_strided([1], [1], 1 + x[i].storage_offset()) for i in range(4)]
```

Test Plan
---------
- Added some tests that compare vmap+as_strided to vmap+(the equivalent operator)