### PR TITLE
[NNC] Fix an issue in Cuda fusion with fp16 scalar vars coerced to float

### DIFF
--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -923,7 +923,7 @@ void CudaCodeGen::Initialize() {
   // half_support_literal.
   Stmt* stmt_v = stmt();
   CudaHalfChecker halfChecker;
-  stmt_v = stmt_v->accept_mutator(&halfChecker);
+  stmt_v->accept(&halfChecker);
   if (halfChecker.hasHalf()) {
     os() << fuser::cuda::half_support_literal << std::endl;
   }
@@ -987,12 +987,13 @@ void CudaCodeGen::Initialize() {
 
   stmt_v = registerize(stmt_v);
 
-  // The registerizer might insert half-type scalars, we don't want this.
-  CudaHalfScalarRewriter hsFix;
-  stmt_v = stmt_v->accept_mutator(&hsFix);
-
   PrioritizeLoad prioritize_load;
   stmt_v = stmt_v->accept_mutator(&prioritize_load);
+
+  // The registerizer might insert half-type scalars, we don't want this.
+  CudaHalfRewriter hsFix;
+  stmt_v = stmt_v->accept_mutator(&hsFix);
+
   stmt_v = IRSimplifier::simplify(stmt_v);
   set_stmt(stmt_v);
 

--- a/torch/csrc/jit/tensorexpr/cuda_half_support.h
+++ b/torch/csrc/jit/tensorexpr/cuda_half_support.h
@@ -8,39 +8,63 @@ namespace jit {
 namespace tensorexpr {
 
 // Walk the Statment looking for Half size loads/stores.
-class CudaHalfChecker : public IRMutator {
+class CudaHalfChecker : public IRVisitor {
  public:
   bool hasHalf() {
     return hasHalf_;
   }
 
+  void visit(const Load* v) override {
+    hasHalf_ |= v->dtype().scalar_type() == ScalarType::Half;
+    IRVisitor::visit(v);
+  }
+
+  void visit(const Store* v) override {
+    hasHalf_ |= v->buf()->dtype().scalar_type() == ScalarType::Half;
+    IRVisitor::visit(v);
+  }
+
+  void visit(const HalfImm* v) override {
+    hasHalf_ = true;
+  }
+
+  void visit(const Cast* v) override {
+    hasHalf_ |= v->dtype().scalar_type() == ScalarType::Half;
+    IRVisitor::visit(v);
+  }
+
+ private:
+  bool hasHalf_{false};
+};
+
+class CudaHalfRewriter : public IRMutator {
   const Expr* mutate(const Load* v) override {
     const Expr* child = IRMutator::mutate(v);
     if (child->dtype().scalar_type() != ScalarType::Half) {
       return child;
     }
 
-    hasHalf_ = true;
+    const Expr* ret =
+        new Cast(child->dtype().cloneWithScalarType(ScalarType::Float), child);
 
-    // TODO discards lanes.
-    return new Cast(kFloat, child);
+    inserted_half_casts_.insert(ret);
+    return ret;
   }
 
   Stmt* mutate(const Store* v) override {
     const Expr* new_val = v->value()->accept_mutator(this);
 
-    if (v->value()->dtype().scalar_type() == ScalarType::Half) {
-      // TODO discards lanes.
-      new_val = new Cast(kHalf, new_val);
+    Dtype newType = v->value()->dtype();
+    if (newType.scalar_type() == ScalarType::Half) {
+      new_val =
+          new Cast(newType.cloneWithScalarType(ScalarType::Half), new_val);
       inserted_half_casts_.insert(new_val);
-      hasHalf_ = true;
     }
 
     return new Store(v->buf(), v->indices(), new_val, v->mask());
   }
 
   const Expr* mutate(const HalfImm* v) override {
-    hasHalf_ = true;
     return new Cast(kFloat, v);
   }
 
@@ -50,8 +74,16 @@ class CudaHalfChecker : public IRMutator {
     // just don't allow half casts we didn't insert.
     if (v->dtype().scalar_type() == ScalarType::Half) {
       if (inserted_half_casts_.count(v) < 1) {
-        // TODO: discards lanes.
-        return new Cast(kFloat, child);
+        return child;
+      }
+    }
+
+    // Remove Half(Float()) and friends.
+    const Cast* cast_child = dynamic_cast<const Cast*>(child);
+    if (cast_child) {
+      if (v->dtype().is_floating_point() &&
+          cast_child->dtype().is_floating_point()) {
+        return new Cast(v->dtype(), cast_child->src_value());
       }
     }
 
@@ -61,19 +93,12 @@ class CudaHalfChecker : public IRMutator {
 
     return new Cast(v->dtype(), child);
   }
-
- private:
-  bool hasHalf_{false};
-  std::unordered_set<const Expr*> inserted_half_casts_;
-};
-
-class CudaHalfScalarRewriter : public IRMutator {
   Stmt* mutate(const Let* v) override {
     if (v->dtype().scalar_type() == ScalarType::Half) {
-      // TODO: discards lanes.
       const Var* load_new_var = new Var(v->var()->name_hint(), kFloat);
-      const Expr* new_value =
-          new Cast(kFloat, v->value()->accept_mutator(this));
+      const Expr* new_value = new Cast(
+          v->dtype().cloneWithScalarType(ScalarType::Float),
+          v->value()->accept_mutator(this));
       var_map[v->var()] = load_new_var;
 
       return new Let(load_new_var, new_value);
@@ -92,6 +117,7 @@ class CudaHalfScalarRewriter : public IRMutator {
   }
 
  private:
+  std::unordered_set<const Expr*> inserted_half_casts_;
   std::unordered_map<const Var*, const Var*> var_map;
 };
 

--- a/torch/csrc/jit/tensorexpr/types.h
+++ b/torch/csrc/jit/tensorexpr/types.h
@@ -76,6 +76,10 @@ class TORCH_API Dtype {
     return tensorexpr::is_floating_point(scalar_type_);
   }
 
+  Dtype cloneWithScalarType(ScalarType nt) const {
+    return Dtype(nt, lanes_);
+  }
+
  private:
   friend std::ostream& operator<<(std::ostream& stream, const Dtype& dtype);
   ScalarType scalar_type_;


### PR DESCRIPTION
Fixes an issue where fp16 scalars created by the registerizer could be referenced as floats - causing invalid conversions which would crash in the NVRTX compile. I also noticed that we were inserting patterns like `float(half(float(X)))` and added a pass to collapse those down inside the CudaHalfScalarRewriter.

Fixes #47138


