### PR TITLE
Back out "[Gradient Compression] Surface C++ comm hooks to Python API as built-in comm hooks"

### DIFF
--- a/torch/csrc/distributed/c10d/comm.h
+++ b/torch/csrc/distributed/c10d/comm.h
@@ -60,9 +60,8 @@ class TORCH_PYTHON_API CommHookInterface {
 
 // This CppCommHook interface only requires implementing runHook method that
 // potentially uses a state.
-// Still need TORCH_PYTHON_API instead of TORCH_API to support Windows platform.
 template <typename T>
-class TORCH_PYTHON_API CppCommHookInterface : public CommHookInterface {
+class TORCH_API CppCommHookInterface : public CommHookInterface {
  public:
   explicit CppCommHookInterface(T& state) : state_(state) {}
 

--- a/torch/csrc/distributed/c10d/default_comm_hooks.h
+++ b/torch/csrc/distributed/c10d/default_comm_hooks.h
@@ -5,26 +5,13 @@
 
 namespace c10d {
 
-enum class BuiltinCommHookType {
-  ALLREDUCE = 1,
-  FP16_COMPRESS = 2,
-};
-
 class AllReduceCommHook : public CppCommHookInterface<ProcessGroup*> {
- public:
-  explicit AllReduceCommHook(ProcessGroup* state)
-      : CppCommHookInterface<ProcessGroup*>(state) {}
-
   ~AllReduceCommHook() override {}
 
   c10::intrusive_ptr<c10::ivalue::Future> runHook(GradBucket& bucket) override;
 };
 
 class FP16CompressCommHook : public CppCommHookInterface<ProcessGroup*> {
- public:
-  explicit FP16CompressCommHook(ProcessGroup* state)
-      : CppCommHookInterface<ProcessGroup*>(state) {}
-
   ~FP16CompressCommHook() override {}
 
   c10::intrusive_ptr<c10::ivalue::Future> runHook(GradBucket& bucket) override;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -124,25 +124,19 @@ class PythonStore : public ::c10d::Store {
   }
 };
 
-// Called from DDP's Python API to create a c10d Python comm hook object.
-// The input state and callable comm_hook are Python objects. It later calls
-// register_comm_hook function of the reducer input to register the hook.
+// This method is called from DDP's Python API. Its inputs are
+// a c10d reducer object, state, and callable comm_hook. State and
+// comm_hook inputs are Python objects and this function creates a
+// c10d PythonCommHook object using these inputs. It later calls
+// register_comm_hook function of the reducer input to register that
+// PythonCommHook object.
 void _register_comm_hook(
     ::c10d::Reducer& reducer,
     py::object state,
     py::object comm_hook) {
   reducer.register_comm_hook(std::make_unique<::c10d::PythonCommHook>(
       std::move(state), std::move(comm_hook)));
-}
-
-// Called from DDP's Python API to create a c10d C++ comm hook.
-// The input is an enum hook type. It later calls register_builtin_comm_hook
-// function of the reducer input to set the hook type.
-void _register_builtin_comm_hook(
-    ::c10d::Reducer& reducer,
-    ::c10d::BuiltinCommHookType comm_hook_type) {
-  reducer.register_builtin_comm_hook(comm_hook_type);
-}
+};
 
 PyObject* c10d_init(PyObject* _unused, PyObject* noargs) {
   C10_LOG_API_USAGE_ONCE("c10d.python.import");
@@ -153,19 +147,12 @@ PyObject* c10d_init(PyObject* _unused, PyObject* noargs) {
 
   auto module = py::handle(c10d_module).cast<py::module>();
 
-  module
-      .def(
-          "_register_comm_hook",
-          &_register_comm_hook,
-          py::arg("reducer"),
-          py::arg("state"),
-          py::arg("comm_hook"),
-          py::call_guard<py::gil_scoped_release>())
-      .def(
-          "_register_builtin_comm_hook",
-          &_register_builtin_comm_hook,
-          py::arg("reducer"),
-          py::arg("comm_hook_type"));
+  module.def(
+      "_register_comm_hook",
+      &_register_comm_hook,
+      py::arg("reducer"),
+      py::arg("state"),
+      py::arg("comm_hook"));
 
   shared_ptr_class_<::c10d::GradBucket>(module, "_GradBucket")
       .def(py::init<std::vector<Tensor>&>(), py::arg("tensors"))
@@ -180,11 +167,6 @@ PyObject* c10d_init(PyObject* _unused, PyObject* noargs) {
             the single process single device mode, this list would consist of only
             a single tensor.
            )");
-
-  py::enum_<::c10d::BuiltinCommHookType>(module, "BuiltinCommHookType", R"(
-An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_COMPRESS``.)")
-      .value("ALLREDUCE", ::c10d::BuiltinCommHookType::ALLREDUCE)
-      .value("FP16_COMPRESS", ::c10d::BuiltinCommHookType::FP16_COMPRESS);
 
   shared_ptr_class_<::c10d::Reducer>(module, "Reducer")
       .def(

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -12,7 +12,6 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/distributed/autograd/context/context.h>
 #include <torch/csrc/distributed/c10d/comm.h>
-#include <torch/csrc/distributed/c10d/default_comm_hooks.h>
 
 namespace c10d {
 
@@ -59,13 +58,7 @@ class Reducer {
   // Registers a hook to the reducer. The hook is `CommHookInterface`
   // type to allow both Python and CPP hooks. This function can only
   // be called once before calling backward.
- // Cannot combine with the call of `register_builtin_comm_hook`.
   void register_comm_hook(std::unique_ptr<CommHookInterface> iface);
-
-  // Registers a built-in C++ comm hook to the reducer. This function can only
-  // be called once before calling backward.
-  // Cannot combine with the call of `register_comm_hook`.
-  void register_builtin_comm_hook(c10d::BuiltinCommHookType comm_hook_type);
 
   // Returns a vector of tensors in each bucket in sequential order.
   std::vector<std::vector<at::Tensor>> get_bucket_tensors() const;

--- a/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from functools import partial
 
-import torch.distributed as dist
 import torch.distributed.algorithms.ddp_comm_hooks.default_hooks as default
 import torch.distributed.algorithms.ddp_comm_hooks.quantization_hooks as quantization
 from torch.nn.parallel import DistributedDataParallel
@@ -39,7 +38,6 @@ def register_ddp_comm_hook(
         to the DDP model. User can specify the type of hook as an enum
         ``DDPCommHookType`` type using ``comm_hook_type`` input. State input will
         be passed to the model.
-        Uses Python comm hook implementations.
 
         Example::
             >>> register_ddp_comm_hook(DDPCommHookType.FP16_COMPRESS, model, state)

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -14,8 +14,6 @@
 #include <ATen/cuda/CUDAEvent.h>
 #include <c10/core/Stream.h>
 #include <c10/core/StreamGuard.h>
-#include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAStream.h>
 
 namespace c10d {
 
@@ -304,29 +302,8 @@ class ProcessGroupNCCL : public ProcessGroup {
 
       // Do not free the underlying data storage of value_ before its
       // usage on futureNCCLCallbackStream_ finish.
-      if (record_stream_cb_ != nullptr) {
-        // If a Python communication hook is used, record_stream_cb_ will be
-        // set in torch/csrc/jit/python/pybind_utils.h, which allows Python
-        // dependency to be imported.
-        record_stream_cb_(value_, futureNCCLCallbackStream_->unwrap());
-      } else {
-        // If a C++ communication hook is used, create and set a record stream
-        // callback.
-        TORCH_INTERNAL_ASSERT(
-            value_.isTensorList() || value_.isTensor(),
-            "the future value must be either a tensor list or a tensor.");
-        at::Tensor tensor;
-        if (value_.isTensorList()) {
-          const auto tensors = value_.toTensorVector();
-          TORCH_INTERNAL_ASSERT(
-              tensors.size() == 1, "expected exactly 1 tensor");
-          tensor = tensors[0];
-        } else {
-          tensor = value_.toTensor();
-        }
-        c10::cuda::CUDACachingAllocator::recordStream(
-            tensor.storage().data_ptr(), *futureNCCLCallbackStream_);
-      }
+      TORCH_INTERNAL_ASSERT(record_stream_cb_);
+      record_stream_cb_(value_, futureNCCLCallbackStream_->unwrap());
 
       // Use the dedicated callback stream to run callback.
       // Cannot move capture std::function in lambda, because it cannot deduce
@@ -581,8 +558,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   // This function iterates through the list of WorkNCCL objects in the
   // workList_ corresponding to incomplete collectives and then aborts NCCL
   // communicators associated with timed out collectives.
-  void abortTimedOutCollectives(
-      std::unordered_set<std::string>& abortedCommIds);
+  void abortTimedOutCollectives(std::unordered_set<std::string>& abortedCommIds);
 
   void workCleanupLoop();
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -975,7 +975,7 @@ class DistributedDataParallel(Module):
 
     def _register_comm_hook(self, state: object, hook: callable):
         r"""
-        Registers a communication hook which is an enhancement that provides a
+        Register a communication hook which is an enhancement that provides a
         flexible hook to users where they can specify how DDP aggregates gradients
         across multiple workers.
 
@@ -1059,40 +1059,6 @@ class DistributedDataParallel(Module):
         """
         self._check_comm_hook(hook)
         dist._register_comm_hook(self.reducer, state, hook)
-
-    def _register_builtin_comm_hook(
-        self, comm_hook_type: dist.BuiltinCommHookType
-    ):
-        r"""
-        Registers a built-in communication hook that specifies how DDP
-        aggregates gradients across multiple workers.
-        The built-in hooks aim to provide efficient C++ implementations for certain hooks,
-        which might not be as efficient if implemented in Python using a Python communication hook.
-
-        Arguments:
-            comm_hook_type (dist.BuiltinCommHookType): type of communication hook, such as
-            ALLREDUCE, FP16_COMPRESS, etc.
-
-        .. warning ::
-            DDP communication hook can only be registered once and should be registered
-            before calling backward.
-
-        .. warning ::
-            DDP communication hook does not support single-process multiple-device mode.
-            Gradbucket tensors should consist of only a single tensor.
-
-        .. warning ::
-            DDP communication hook is experimental and subject to change.
-
-        Example::
-            Below is an example of a FP16 compression where gradients are
-            compressed into 16-bit floating-point numbers before allreduce, and
-            then decompressed after allreduce.
-
-            >>> ddp._register_builtin_comm_hook(dist.BuiltinCommHookType.FP16_COMPRESS)
-
-        """
-        dist._register_builtin_comm_hook(self.reducer, comm_hook_type)
 
     def _distributed_broadcast_coalesced(
         self, tensors, buffer_size, authoritative_rank=0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47234 Back out "[Gradient Compression] Surface C++ comm hooks to Python API as built-in comm hooks"**

Revert the diff because of https://github.com/pytorch/pytorch/issues/47153

Original PR issue: C++ DDP Communication Hook https://github.com/pytorch/pytorch/issues/46348

Differential Revision: [D24691866](https://our.internmc.facebook.com/intern/diff/D24691866/)