### PR TITLE
Make "Run flake8" step always succeed again

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
         id: get_pr_tip
       - name: Run flake8
         run: |
-          set -eux -o pipefail
+          set -eux
           pip install flake8==3.8.2 flake8-bugbear flake8-comprehensions flake8-executable flake8-pyi==20.5.0 mccabe pycodestyle==2.6.0 pyflakes==2.2.0
           flake8 --version
           flake8 | tee ${GITHUB_WORKSPACE}/flake8-output.txt


### PR DESCRIPTION
In #46990 I asked whether the "Run flake8" step was supposed to always succeed (so that the "Add annotations" step would be sure to run). The reviewers and I weren't sure of the answer to that question, so we merged it anyway, but that turned out to be wrong: https://github.com/pytorch/pytorch/runs/1327599980 So this PR fixes that issue introduced by #46990.