### PR TITLE
[NCCL] Shorten Busy Wait Interval when NCCL_BLOCKING_WAIT is set

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -213,7 +213,7 @@ ncclResult_t ncclAlltoallv(
 const int64_t ProcessGroupNCCL::kWatchdogThreadSleepMillis = 10000;
 const int64_t ProcessGroupNCCL::kWorkCleanupThreadSleepMillis = 1000;
 constexpr int64_t kWaitForAbortCommStoreKey = 1000;
-constexpr int64_t kSynchronizeBusyWaitMillis = 10;
+constexpr int64_t kSynchronizeBusyWaitMillis = 1;
 const int64_t ProcessGroupNCCL::kProcessGroupNCCLOpTimeoutMillis = 10 * 1000;
 thread_local uint64_t ProcessGroupNCCL::ncclActiveGroupCounter_ = 0;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47251 [NCCL] Shorten Busy Wait Interval when NCCL_BLCOKING_WAIT is set**

Experiments show that reducing the busy-wait polling interval from 10ms to 1ms
can result in a 3.2x performance improvement for NCCL-based training when
NCCL_BLOCKING_WAIT is set. This diff shortens the busy wait interval
accordingly.

Differential Revision: [D24696371](https://our.internmc.facebook.com/intern/diff/D24696371/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24696371/)!