### PR TITLE
[JIT] SubgraphUtils: add a function for generating a string name for a given graph.

### DIFF
--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -398,14 +398,21 @@ std::string truncateStrWithHash(const std::string& s, size_t maxlen) {
   if (s.size() <= maxlen) {
     return s;
   }
+  std::string hash_str = std::to_string(std::hash<std::string>{}(s));
+  // If hash-string plus '_' can fit into maxlen, then truncate the original
+  // string correspondingly so that the final string with the hash included fits
+  // into maxlen. If that's not possible, at least truncate the original string
+  // to maxlen (and appen the hash to it).
+  size_t trunc_len =
+      (maxlen > hash_str.size() + 1) ? (maxlen - hash_str.size() - 1) : maxlen;
   std::stringstream truncated;
-  truncated << s.substr(0, maxlen);
-  truncated << "_" << std::hash<std::string>{}(s) << "_";
+  truncated << s.substr(0, trunc_len);
+  truncated << "_" << hash_str;
   return truncated.str();
 }
 
 std::string generateNameForGraph(
-    std::shared_ptr<Graph> graph,
+    const std::shared_ptr<Graph>& graph,
     size_t maxlen,
     const std::string& prefix) {
   std::stringstream graph_name;

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -398,7 +398,7 @@ std::string truncateStrWithHash(const std::string& s, size_t maxlen) {
   if (s.size() <= maxlen) {
     return s;
   }
-  std::string hash_str = std::to_string(std::hash<std::string>{}(s));
+  std::string hash_str = c10::to_string(c10::hash<std::string>{}(s));
   // If hash-string plus '_' can fit into maxlen, then truncate the original
   // string correspondingly so that the final string with the hash included fits
   // into maxlen. If that's not possible, at least truncate the original string

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -394,6 +394,31 @@ Node* createSingletonSubgraphAndUpdateAliasing(
       });
 }
 
+std::string truncateStrWithHash(const std::string& s, size_t maxlen) {
+  if (s.size() <= maxlen) {
+    return s;
+  }
+  std::stringstream truncated;
+  truncated << s.substr(0, maxlen);
+  truncated << "_" << std::hash<std::string>{}(s) << "_";
+  return truncated.str();
+}
+
+std::string generateNameForGraph(
+    std::shared_ptr<Graph> graph,
+    size_t maxlen,
+    const std::string& prefix) {
+  std::stringstream graph_name;
+  graph_name << prefix;
+  for (Node* node : graph->nodes()) {
+    if (!node->kind().is_aten()) {
+      continue;
+    }
+    graph_name << "_" << node->kind().toUnqualString();
+  }
+  return truncateStrWithHash(graph_name.str(), maxlen);
+}
+
 } // namespace SubgraphUtils
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/utils/subgraph_utils.h
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.h
@@ -69,7 +69,7 @@ TORCH_API void unmergeSubgraph(
 std::shared_ptr<Graph> getSubgraph(Node* n);
 
 TORCH_API std::string generateNameForGraph(
-    std::shared_ptr<Graph> graph,
+    const std::shared_ptr<Graph>& graph,
     size_t maxlen = 40,
     const std::string& prefix = "fused");
 

--- a/torch/csrc/jit/passes/utils/subgraph_utils.h
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.h
@@ -68,6 +68,11 @@ TORCH_API void unmergeSubgraph(
 // Convenience function
 std::shared_ptr<Graph> getSubgraph(Node* n);
 
+TORCH_API std::string generateNameForGraph(
+    std::shared_ptr<Graph> graph,
+    size_t maxlen = 40,
+    const std::string& prefix = "fused");
+
 } // namespace SubgraphUtils
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47255 [TensorExpr] Pick meaningful names for functions in TE codegen.
* #47254 [TensorExpr] CudaCodegen: restart counter for function names unique ID inside each codegen instantiation.
* **#47253 [JIT] SubgraphUtils: add a function for generating a string name for a given graph.**

The function simply goes over all aten nodes in the graph and
concatenates their names, truncating the final name to a given length.

Differential Revision: [D24698272](https://our.internmc.facebook.com/intern/diff/D24698272)