### PR TITLE
[TensorExpr] Pick meaningful names for functions in TE codegen.

### DIFF
--- a/torch/csrc/jit/tensorexpr/block_codegen.h
+++ b/torch/csrc/jit/tensorexpr/block_codegen.h
@@ -111,8 +111,9 @@ class TORCH_API BlockCodeGen : public CodeGen {
   BlockCodeGen(
       Stmt* stmt,
       const std::vector<BufferArg>& buffer_args,
-      at::Device device = at::Device(at::kCPU))
-      : CodeGen(stmt, buffer_args, device) {
+      at::Device device = at::Device(at::kCPU),
+      const std::string& kernel_func_name = "func")
+      : CodeGen(stmt, buffer_args, device, kernel_func_name) {
     Initialize();
   }
 

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -41,10 +41,11 @@ std::unique_ptr<CodeGen> CreateCodeGen(
     const std::string& name,
     Stmt* stmt,
     const std::vector<CodeGen::BufferArg>& params,
-    at::Device device) {
+    at::Device device,
+    const std::string& kernel_func_name) {
   RegisterCodeGenList::StmtFactoryMethod method =
       RegisterCodeGenList::GetInstance().FindStmtFactoryMethod(name);
-  return method(stmt, params, device);
+  return method(stmt, params, device, kernel_func_name);
 }
 
 const Expr* GenericIntrinsicsExpander::mutate(const Intrinsics* v) {

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -23,8 +23,12 @@ class TORCH_API CodeGen {
   CodeGen(
       Stmt* stmt,
       const std::vector<BufferArg>& buffer_args,
-      at::Device device = at::kCPU)
-      : stmt_(stmt), buffer_args_(buffer_args), device_(device) {}
+      at::Device device = at::kCPU,
+      const std::string& kernel_func_name = "func")
+      : stmt_(stmt),
+        buffer_args_(buffer_args),
+        device_(device),
+        kernel_func_name_(kernel_func_name) {}
 
   virtual ~CodeGen() {}
 
@@ -51,7 +55,6 @@ class TORCH_API CodeGen {
   at::Device device() {
     return device_;
   }
-
   // This function returns the generated code as
   // a string. Currently only implemented for Block.
   // TODO. Rename this, as we can return other than string
@@ -62,10 +65,15 @@ class TORCH_API CodeGen {
 
   virtual void call(const std::vector<CallArg>& args) = 0;
 
+  const std::string& kernel_func_name() const {
+    return kernel_func_name_;
+  }
+
  private:
   Stmt* stmt_;
   std::vector<BufferArg> buffer_args_;
   at::Device device_ = at::kCPU;
+  std::string kernel_func_name_ = "func";
 };
 
 class CodeGen::BufferArg {
@@ -147,7 +155,8 @@ class RegisterCodeGenList {
   using StmtFactoryMethod = std::function<std::unique_ptr<CodeGen>(
       Stmt* stmt,
       const std::vector<CodeGen::BufferArg>&,
-      at::Device device)>;
+      at::Device device,
+      const std::string& kernel_func_name)>;
 
   TORCH_API StmtFactoryMethod FindStmtFactoryMethod(const std::string& name);
 
@@ -173,9 +182,10 @@ class RegisterCodeGen {
         name,
         [](Stmt* stmt,
            const std::vector<CodeGen::BufferArg>& params,
-           at::Device device) {
+           at::Device device,
+           const std::string& kernel_func_name) {
           std::unique_ptr<CodeGen> method(
-              new CodeGenType(stmt, params, device));
+              new CodeGenType(stmt, params, device, kernel_func_name));
           return method;
         });
   }
@@ -185,7 +195,8 @@ TORCH_API std::unique_ptr<CodeGen> CreateCodeGen(
     const std::string& name,
     Stmt* stmt,
     const std::vector<CodeGen::BufferArg>& params,
-    at::Device device = at::kCPU);
+    at::Device device = at::kCPU,
+    const std::string& kernel_func_name = "func");
 
 class TORCH_API GenericIntrinsicsExpander : public IRMutator {
  protected:

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -928,7 +928,7 @@ void CudaCodeGen::Initialize() {
     os() << fuser::cuda::half_support_literal << std::endl;
   }
 
-  std::string func_name = GetUniqueFuncName("func");
+  std::string func_name = GetUniqueFuncName(kernel_func_name());
   os() << "extern \"C\" __global__" << std::endl;
 #ifdef USE_ROCM
   // CUDA has a default limit of threads per block (=flat work group size)

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -197,8 +197,9 @@ class TORCH_CUDA_API CudaCodeGen : public CodeGen {
   CudaCodeGen(
       Stmt* stmt,
       const std::vector<BufferArg>& buffer_args,
-      at::Device device = at::Device(at::kCUDA, at::cuda::current_device()))
-      : CodeGen(stmt, buffer_args, device) {
+      at::Device device = at::Device(at::kCUDA, at::cuda::current_device()),
+      const std::string& kernel_func_name = "func")
+      : CodeGen(stmt, buffer_args, device, kernel_func_name) {
     Initialize();
   }
 

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -2,6 +2,7 @@
 
 #include <c10/util/string_utils.h>
 #include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/utils/subgraph_utils.h>
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
@@ -1844,7 +1845,12 @@ void TensorExprKernel::compile() {
   std::vector<CodeGen::BufferArg> params = prepareBufferArgs();
 
   // Generate code.
-  codegen_ = CreateCodeGen(getCodeGenName(backendType), stmt, params, device_);
+  codegen_ = CreateCodeGen(
+      getCodeGenName(backendType),
+      stmt,
+      params,
+      device_,
+      SubgraphUtils::generateNameForGraph(graph_));
 }
 
 TensorExprKernel::TensorExprKernel(const std::shared_ptr<Graph>& subgraph)

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -205,8 +205,9 @@ LLVMCodeGen::LLVMCodeGen(
     Stmt* stmt,
     const std::vector<BufferArg>& args,
     at::Device device,
-    Dtype dtype)
-    : CodeGen(stmt, args, device),
+    Dtype dtype,
+    const std::string& kernel_func_name)
+    : CodeGen(stmt, args, device, kernel_func_name),
       impl_(std::make_unique<LLVMCodeGenImpl>(stmt, args, device, dtype)) {}
 
 static void* argToPtr(
@@ -301,7 +302,10 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   }
   llvm::FunctionType* fntype = llvm::FunctionType::get(retTy, params, false);
   fn_ = llvm::Function::Create(
-      fntype, llvm::Function::PrivateLinkage, "pytorch", module_.get());
+      fntype,
+      llvm::Function::PrivateLinkage,
+      kernel_func_name(),
+      module_.get());
   fn_->addAttribute(
       llvm::AttributeList::AttrIndex::FunctionIndex,
       llvm::Attribute::AlwaysInline);

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -205,8 +205,8 @@ LLVMCodeGen::LLVMCodeGen(
     Stmt* stmt,
     const std::vector<BufferArg>& args,
     at::Device device,
-    Dtype dtype,
-    const std::string& kernel_func_name)
+    const std::string& kernel_func_name,
+    Dtype dtype)
     : CodeGen(stmt, args, device, kernel_func_name),
       impl_(std::make_unique<LLVMCodeGenImpl>(stmt, args, device, dtype)) {}
 
@@ -302,10 +302,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   }
   llvm::FunctionType* fntype = llvm::FunctionType::get(retTy, params, false);
   fn_ = llvm::Function::Create(
-      fntype,
-      llvm::Function::PrivateLinkage,
-      kernel_func_name(),
-      module_.get());
+      fntype, llvm::Function::PrivateLinkage, "pytorch", module_.get());
   fn_->addAttribute(
       llvm::AttributeList::AttrIndex::FunctionIndex,
       llvm::Attribute::AlwaysInline);

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.h
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.h
@@ -22,8 +22,8 @@ class TORCH_API LLVMCodeGen : public CodeGen {
       Stmt* stmt,
       const std::vector<BufferArg>& args,
       at::Device device = at::kCPU,
-      Dtype dtype = kInt,
-      const std::string& kernel_func_name = "func");
+      const std::string& kernel_func_name = "func",
+      Dtype dtype = kInt);
   explicit LLVMCodeGen(Stmt* stmt);
 
   LLVMCodeGen() = delete;

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.h
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.h
@@ -22,7 +22,8 @@ class TORCH_API LLVMCodeGen : public CodeGen {
       Stmt* stmt,
       const std::vector<BufferArg>& args,
       at::Device device = at::kCPU,
-      Dtype dtype = kInt);
+      Dtype dtype = kInt,
+      const std::string& kernel_func_name = "func");
   explicit LLVMCodeGen(Stmt* stmt);
 
   LLVMCodeGen() = delete;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47255 [TensorExpr] Pick meaningful names for functions in TE codegen.**
* #47254 [TensorExpr] CudaCodegen: restart counter for function names unique ID inside each codegen instantiation.
* #47253 [JIT] SubgraphUtils: add a function for generating a string name for a given graph.

As a result of this change, the generated CUDA code for the following fusion group:
```
graph(%0 : Float(32, 32, 1, 1, strides=[32, 1, 1, 1], requires_grad=0, device=cuda:0),
      %1 : Float(32, 32, strides=[32, 1], requires_grad=0, device=cuda:0),
      %2 : Float(32, 32, 1, strides=[32, 1, 1], requires_grad=0, device=cuda:0)):
  %3 : int = prim::Constant[value=1]()
  %v1.1 : Float(32, 32, 32, strides=[1024, 32, 1], requires_grad=0, device=cuda:0) = aten::add(%1, %2, %3) # test/test_tensorexpr.py:155:0
  %5 : int = prim::Constant[value=1]()
  %6 : Float(32, 32, 32, 32, strides=[32768, 1024, 32, 1], requires_grad=0, device=cuda:0) = aten::add(%v1.1, %0, %5) # test/test_tensorexpr.py:156:0
  return (%6)
```

Would look like the following:
```
extern "C" __global__
void fused_add_add(float* t0, float* t1, float* t2, float* aten_add) {
{
  float v = __ldg(t1 + 32 * (((512 * blockIdx.x + threadIdx.x) / 32) % 32) + (512 * blockIdx.x + threadIdx.x) % 32);
  float v_1 = __ldg(t2 + ((512 * blockIdx.x + threadIdx.x) / 32) % 32 + 32 * (((512 * blockIdx.x + threadIdx.x) / 1024) % 32));
  float v_2 = __ldg(t0 + ((512 * blockIdx.x + threadIdx.x) / 1024) % 32 + 32 * ((512 * blockIdx.x + threadIdx.x) / 32768));
  aten_add[((((512 * blockIdx.x + threadIdx.x) / 32768) * 32768 + 32 * (((512 * blockIdx.x + threadIdx.x) / 32) % 32)) + 1024 * (((512 * blockIdx.x + threadIdx.x) / 1024) % 32)) + (512 * blockIdx.x + threadIdx.x) % 32] = (v + v_1) + v_2;
}
}
```

Previously we generated:
```
extern "C" __global__
void func(float* t0, float* t1, float* t2, float* aten_add) {
{
  float v = __ldg(t1 + 32 * (((512 * blockIdx.x + threadIdx.x) / 32) % 32) + (512 * blockIdx.x + threadIdx.x) % 32);
  float v_1 = __ldg(t2 + ((512 * blockIdx.x + threadIdx.x) / 32) % 32 + 32 * (((512 * blockIdx.x + threadIdx.x) / 1024) % 32));
  float v_2 = __ldg(t0 + ((512 * blockIdx.x + threadIdx.x) / 1024) % 32 + 32 * ((512 * blockIdx.x + threadIdx.x) / 32768));
  aten_add[((((512 * blockIdx.x + threadIdx.x) / 32768) * 32768 + 32 * (((512 * blockIdx.x + threadIdx.x) / 32) % 32)) + 1024 * (((512 * blockIdx.x + threadIdx.x) / 1024) % 32)) + (512 * blockIdx.x + threadIdx.x) % 32] = (v + v_1) + v_2;
}
}
```

Differential Revision: [D24698273](https://our.internmc.facebook.com/intern/diff/D24698273)