### PR TITLE
Inlining all non-output buffers, including intermediate buffers.

### DIFF
--- a/test/cpp/tensorexpr/test_kernel.cpp
+++ b/test/cpp/tensorexpr/test_kernel.cpp
@@ -645,14 +645,11 @@ void testKernelSoftmax2D() {
         # CHECK: for (int i${other_dim} = 0; i${other_dim} < ${other_dim_size}
         # CHECK: for (int i${softmax_dim} = 0; i${softmax_dim} < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_max
-        # CHECK: for (int i0_1 = 0; i0_1 < 5
-        # CHECK-NEXT: for (int i1_1 = 0; i1_1 < 3
-        # CHECK-NEXT: aten_softmax_exp
-        # CHECK: for (int i${other_dim}_2 = 0; i${other_dim}_2 < ${other_dim_size}
-        # CHECK: for (int i${softmax_dim}_2 = 0; i${softmax_dim}_2 < ${softmax_dim_size}
+        # CHECK: for (int i${other_dim}_1 = 0; i${other_dim}_1 < ${other_dim_size}
+        # CHECK: for (int i${softmax_dim}_1 = 0; i${softmax_dim}_1 < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_sum
-        # CHECK: for (int i0_3 = 0; i0_3 < 5
-        # CHECK-NEXT: for (int i1_3 = 0; i1_3 < 3
+        # CHECK: for (int i0_2 = 0; i0_2 < 5
+        # CHECK-NEXT: for (int i1_2 = 0; i1_2 < 3
         # CHECK-NEXT: aten_softmax)IR";
 
   for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
@@ -707,17 +704,13 @@ void testKernelSoftmax3D() {
         # CHECK-NEXT: for (int i${dim2} = 0; i${dim2} < ${dim2_size}
         # CHECK: for (int i${softmax_dim} = 0; i${softmax_dim} < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_max
-        # CHECK: for (int i0_1 = 0; i0_1 < 3
-        # CHECK-NEXT: for (int i1_1 = 0; i1_1 < 4
-        # CHECK-NEXT: for (int i2_1 = 0; i2_1 < 5
-        # CHECK-NEXT: aten_softmax_exp
-        # CHECK: for (int i${dim1}_2 = 0; i${dim1}_2 < ${dim1_size}
-        # CHECK-NEXT: for (int i${dim2}_2 = 0; i${dim2}_2 < ${dim2_size}
-        # CHECK: for (int i${softmax_dim}_2 = 0; i${softmax_dim}_2 < ${softmax_dim_size}
+        # CHECK: for (int i${dim1}_1 = 0; i${dim1}_1 < ${dim1_size}
+        # CHECK-NEXT: for (int i${dim2}_1 = 0; i${dim2}_1 < ${dim2_size}
+        # CHECK: for (int i${softmax_dim}_1 = 0; i${softmax_dim}_1 < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_sum
-        # CHECK: for (int i0_3 = 0; i0_3 < 3
-        # CHECK-NEXT: for (int i1_3 = 0; i1_3 < 4
-        # CHECK-NEXT: for (int i2_3 = 0; i2_3 < 5
+        # CHECK: for (int i0_2 = 0; i0_2 < 3
+        # CHECK-NEXT: for (int i1_2 = 0; i1_2 < 4
+        # CHECK-NEXT: for (int i2_2 = 0; i2_2 < 5
         # CHECK-NEXT: aten_softmax)IR";
 
   for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {
@@ -781,20 +774,15 @@ void testKernelSoftmax4D() {
         # CHECK-NEXT: for (int i${dim3} = 0; i${dim3} < ${dim3_size}
         # CHECK: for (int i${softmax_dim} = 0; i${softmax_dim} < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_max
-        # CHECK: for (int i0_1 = 0; i0_1 < 2
-        # CHECK-NEXT: for (int i1_1 = 0; i1_1 < 3
-        # CHECK-NEXT: for (int i2_1 = 0; i2_1 < 2
-        # CHECK-NEXT: for (int i3_1 = 0; i3_1 < 3
-        # CHECK-NEXT: aten_softmax_exp
-        # CHECK: for (int i${dim1}_2 = 0; i${dim1}_2 < ${dim1_size}
-        # CHECK-NEXT: for (int i${dim2}_2 = 0; i${dim2}_2 < ${dim2_size}
-        # CHECK-NEXT: for (int i${dim3}_2 = 0; i${dim3}_2 < ${dim3_size}
-        # CHECK: for (int i${softmax_dim}_2 = 0; i${softmax_dim}_2 < ${softmax_dim_size}
+        # CHECK: for (int i${dim1}_1 = 0; i${dim1}_1 < ${dim1_size}
+        # CHECK-NEXT: for (int i${dim2}_1 = 0; i${dim2}_1 < ${dim2_size}
+        # CHECK-NEXT: for (int i${dim3}_1 = 0; i${dim3}_1 < ${dim3_size}
+        # CHECK: for (int i${softmax_dim}_1 = 0; i${softmax_dim}_1 < ${softmax_dim_size}
         # CHECK-NEXT: aten_softmax_sum
-        # CHECK: for (int i0_3 = 0; i0_3 < 2
-        # CHECK-NEXT: for (int i1_3 = 0; i1_3 < 3
-        # CHECK-NEXT: for (int i2_3 = 0; i2_3 < 2
-        # CHECK-NEXT: for (int i3_3 = 0; i3_3 < 3
+        # CHECK: for (int i0_2 = 0; i0_2 < 2
+        # CHECK-NEXT: for (int i1_2 = 0; i1_2 < 3
+        # CHECK-NEXT: for (int i2_2 = 0; i2_2 < 2
+        # CHECK-NEXT: for (int i3_2 = 0; i3_2 < 3
         # CHECK-NEXT: aten_softmax)IR";
 
   for (int softmax_dim = 0; softmax_dim < a.dim(); ++softmax_dim) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1364,13 +1364,8 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
 
   bool hasReduction = NodeFinder<ReduceOp>::find(l.root_stmt()).size() != 0;
 
-  // Compute non-output tensors_ inline
-  for (auto& p : tensors_) {
-    if (!l.hasLoopBodyFor(p.second)) {
-      continue;
-    }
-    l.computeInline(p.second->buf());
-  }
+  l.inlineIntermediateBufs();
+
   if (backendType == kCudaCodeGen) {
     for (auto tensor : tensorOutputs_) {
       std::vector<For*> loops = l.getLoopStmtsFor(tensor);

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -688,6 +688,17 @@ bool LoopNest::computeInline(const Buf* b) {
   return true;
 }
 
+void LoopNest::inlineIntermediateBufs() {
+  // We need to collect all intermediate buffers as the buffers to be inlined
+  // before calling 'computeInline' since the buffers that are inlined are
+  // erased from the set 'intermediate_bufs_' in that function.
+  std::unordered_set<const Buf*> bufs_to_inline(
+      intermediate_bufs_.begin(), intermediate_bufs_.end());
+  for (auto b : bufs_to_inline) {
+    computeInline(b);
+  }
+}
+
 // TODO: Unify with DepTracker
 class UseFinder : public IRVisitor {
  public:

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -53,6 +53,7 @@ class TORCH_API LoopNest {
 
   bool computeInline(Stmt* s);
   bool computeInline(const Buf* b);
+  void inlineIntermediateBufs();
 
   static void splitWithTail(For* f, int factor);
   static void splitWithTail(


### PR DESCRIPTION
This diff enables inlining for all non-output buffers, including the intermediate buffers that are created as part of an op. However, the buffers that correspond to reductions will not be inlined. 