### PR TITLE
Validate number of GPUs in distributed_test.

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -289,6 +289,9 @@ class TestDistBackend(MultiProcessTestCase):
         self = cls(test_name)
         self.rank = rank
         self.file_name = file_name
+
+        if torch.cuda.device_count() != self.world_size:
+            sys.exit(TEST_SKIPS['multi-gpu'].exit_code)
         try:
             dist.init_process_group(
                 init_method=self.init_method,

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -290,7 +290,7 @@ class TestDistBackend(MultiProcessTestCase):
         self.rank = rank
         self.file_name = file_name
 
-        if torch.cuda.device_count() != self.world_size:
+        if torch.cuda.device_count() < int(self.world_size):
             sys.exit(TEST_SKIPS['multi-gpu'].exit_code)
         try:
             dist.init_process_group(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47259 Validate number of GPUs in distributed_test.**

As described in https://github.com/pytorch/pytorch/issues/47257, not
using enough number of GPUs would result in an error.

As a result, before we call `init_process_group` in distributed_test, we
validate we have enough GPUs.

#Closes: https://github.com/pytorch/pytorch/issues/47257

Differential Revision: [D24699122](https://our.internmc.facebook.com/intern/diff/D24699122/)