### PR TITLE
 Embed `libiomp5.dylib` into wheel package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -370,33 +370,37 @@ class build_ext(setuptools.command.build_ext.build_ext):
         libtorch_cpu_path = os.path.join(lib_dir, 'libtorch_cpu.dylib')
         libtorch_path = os.path.join(lib_dir, 'libtorch.dylib')
         libtorch_python_path = os.path.join(lib_dir, 'libtorch_python.dylib')
-        otool_cmds = subprocess.check_output(['otool', '-l', libtorch_cpu_path]).decode("utf-8").split("\n")
+        # Parse libtorch_cpu load commands
+        otool_cmds = subprocess.check_output(['otool', '-l', libtorch_cpu_path]).decode('utf-8').split('\n')
         rpaths, libs = [], []
         for idx, line in enumerate(otool_cmds):
-          if line.strip() == 'cmd LC_LOAD_DYLIB':
-              lib_name = otool_cmds[idx + 2].strip()
-              assert lib_name.startswith('name ')
-              libs.append(lib_name.split(' ', 1)[1].rsplit('(', 1)[0][:-1])
+            if line.strip() == 'cmd LC_LOAD_DYLIB':
+                lib_name = otool_cmds[idx + 2].strip()
+                assert lib_name.startswith('name ')
+                libs.append(lib_name.split(' ', 1)[1].rsplit('(', 1)[0][:-1])
 
-          if line.strip() == 'cmd LC_RPATH':
-              rpath = otool_cmds[idx + 2].strip()
-              assert rpath.startswith('path ')
-              rpaths.append(rpath.split(' ',1)[1].rsplit('(', 1)[0][:-1])
+            if line.strip() == 'cmd LC_RPATH':
+                rpath = otool_cmds[idx + 2].strip()
+                assert rpath.startswith('path ')
+                rpaths.append(rpath.split(' ', 1)[1].rsplit('(', 1)[0][:-1])
 
         omp_lib_name = 'libiomp5.dylib'
         if os.path.join('@rpath', omp_lib_name) not in libs:
             return
+
+        # Copy libiomp5 from rpath locations
         for rpath in rpaths:
             source_lib = os.path.join(rpath, omp_lib_name)
             if not os.path.exists(source_lib):
                 continue
             target_lib = os.path.join(self.build_lib, 'torch', 'lib', omp_lib_name)
             self.copy_file(source_lib, target_lib)
+            break
+
         # Delete rpath from those libs
         for rpath in rpaths:
             for lib in [libtorch_cpu_path, libtorch_path, libtorch_python_path]:
                 subprocess.check_call(['install_name_tool', '-delete_rpath', rpath, lib])
-
 
     def run(self):
         # Report build options. This is run after the build completes so # `CMakeCache.txt` exists and we can get an

--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ import distutils.command.clean
 import distutils.sysconfig
 import filecmp
 import shutil
+import subprocess
 import os
 import json
 import glob
@@ -360,6 +361,36 @@ def check_pydep(importname, module):
 
 
 class build_ext(setuptools.command.build_ext.build_ext):
+
+    # Copy libiomp5.dylib inside the wheel package on OS X
+    def _embed_libiomp(self):
+        if not IS_DARWIN:
+            return
+        lib_dir = os.path.join(self.build_lib, 'torch', 'lib')
+        otool_cmds = subprocess.check_output(['otool', '-l', os.path.join(lib_dir, 'libtorch_cpu.dylib')]).decode("utf-8").split("\n")
+        rpaths, libs = [], []
+        for idx, line in enumerate(otool_cmds):
+          if line.strip() == 'cmd LC_LOAD_DYLIB':
+              lib_name = otool_cmds[idx + 2].strip()
+              assert lib_name.startswith('name ')
+              libs.append(lib_name.split(' ', 1)[1].rsplit('(', 1)[0][:-1])
+
+          if line.strip() == 'cmd LC_RPATH':
+              rpath = otool_cmds[idx + 2].strip()
+              assert rpath.startswith('path ')
+              rpaths.append(rpath.split(' ',1)[1].rsplit('(', 1)[0][:-1])
+
+        omp_lib_name = 'libiomp5.dylib'
+        if os.path.join('@rpath', omp_lib_name) not in libs:
+            return
+        for rpath in rpaths:
+            source_lib = os.path.join(rpath, omp_lib_name)
+            if not os.path.exists(source_lib):
+                continue
+            target_lib = os.path.join(self.build_lib, 'torch', 'lib', omp_lib_name)
+            self.copy_file(source_lib, target_lib)
+
+
     def run(self):
         # Report build options. This is run after the build completes so # `CMakeCache.txt` exists and we can get an
         # accurate report on what is used and what is not.
@@ -408,6 +439,8 @@ class build_ext(setuptools.command.build_ext.build_ext):
 
         # It's an old-style class in Python 2.7...
         setuptools.command.build_ext.build_ext.run(self)
+
+        self._embed_libiomp()
 
         # Copy the essential export library to compile C++ extensions.
         if IS_WINDOWS:


### PR DESCRIPTION
libiomp runtime  is the only external dependency OS X package has if compiled with MKL
Copy it to the stage directory from one of the available rpathes
And remove all absolute rpathes, since project shoudl have none

Fixes https://github.com/pytorch/pytorch/issues/38607