### PR TITLE
Fix return-type-is-always-copy warning

### DIFF
--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -2097,8 +2097,8 @@ TEST_F(ModulesTest, TripletMarginWithDistanceLossDefaultParity) {
 
   for (auto& reduction : reductions) {
     for (auto& margin : margins) {
-      for (const auto& swap : swaps) {
-        auto anchor = 
+      for (const auto swap : swaps) {
+        auto anchor =
             torch::randn({100, 128}, torch::dtype(torch::kFloat).requires_grad(true));
         auto positive =
             torch::randn({100, 128}, torch::dtype(torch::kFloat).requires_grad(true));
@@ -2158,7 +2158,7 @@ TEST_F(ModulesTest, TripletMarginWithDistanceLossFunctionalParity) {
   for (auto& function : distance_functions) {
     for (auto& reduction : reductions) {
       for (auto& margin : margins) {
-        for (const auto& swap : swaps) {
+        for (const auto swap : swaps) {
           auto moduleOptions =
               TripletMarginWithDistanceLossOptions()
                   .distance_function(function)


### PR DESCRIPTION
`std::vector<bool>` can not return values by reference, since they are stored as bit fields

