### PR TITLE
Codegen - error when an argument that looks like an out argument isn't a kwarg (fix #43273)

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -391,7 +391,7 @@ def emit_namedtuple_typedefs(declarations):
         fn_key = '_'.join(fieldnames)
         fieldsname = flddefnames.get(fn_key)
         if fieldsname is None:
-            fieldsname = 'NamedTuple_fields{}'.format('' if flddefs == [] else len(fielddefs))
+            fieldsname = 'NamedTuple_fields{}'.format('' if flddefs == [] else len(flddefs))
             fields = ['{{"{}", ""}}'.format(fn) for fn in fieldnames]
             fieldsdef = PY_NAMEDTUPLE_FIELDSDEF.substitute(
                 fieldsname=fieldsname,

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -368,7 +368,8 @@ class FunctionSchema:
         mutable_returns = [ret for ret in self.returns if ret.annotation is not None and ret.annotation.is_write]
         for ret in mutable_returns:
             assert any([ret.annotation == arg.annotation for arg in out_and_self]), \
-                "All mutable returns must be aliased either to a keyword argument, or to \"self\""
+                "All mutable returns must be aliased either to a keyword argument, or to \"self\". " \
+                "Did you forget to mark an out argument as keyword-only?"
         if self.out_arguments:
             assert len(self.out_arguments) == len(self.returns), \
                 "Must return as many arguments as there are out arguments"

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -360,6 +360,15 @@ class FunctionSchema:
             assert arg.annotation == ret.annotation, \
                 "Out arguments must have matching return Tensor; furthermore, " \
                 "the ith-argument needs to correspond to the ith return"
+        # Invariant: we expect out arguments to appear as keyword arguments in the schema.
+        # This means that all mutable returns should be aliased to a keyword argument
+        # (except for "self", which we explicitly don't treat as an out argument because of its use in methods)
+        # See Note [is_out_fn]
+        out_and_self = list(self.out_arguments) + [arg for arg in self.arguments if arg.name == "self"]
+        mutable_returns = [ret for ret in self.returns if ret.annotation is not None and ret.annotation.is_write]
+        for ret in mutable_returns:
+            assert any([ret.annotation == arg.annotation for arg in out_and_self]), \
+                "All mutable returns must be aliased either to a keyword argument, or to \"self\""
         if self.out_arguments:
             assert len(self.out_arguments) == len(self.returns), \
                 "Must return as many arguments as there are out arguments"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47284 Codegen - error when an argument that looks like an out argument isn't a kwarg (fix #43273)**

Differential Revision: [D24706763](https://our.internmc.facebook.com/intern/diff/D24706763)