### PR TITLE
Add torch._foreach_zero_ API

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -214,4 +214,12 @@ std::vector<Tensor> foreach_tensor_##NAME##_slow(TensorList tensors1, TensorList
 FOREACH_MAXIMUM_MINIMUM_OP(maximum)
 FOREACH_MAXIMUM_MINIMUM_OP(minimum)
 
+void foreach_tensor_zero_slow_(TensorList tensors) { 
+  check_foreach_api_restrictions(tensors);
+
+  for (auto& t : tensors) {
+    t.zero_();
+  }
+}
+
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -246,6 +246,46 @@ struct BinaryOpListAlphaFunctor {
 //
 
 template<typename T, int depth, int r_args_depth, int res_arg_index>
+struct ZeroFunctor {
+    __device__ __forceinline__ void operator() (
+        int chunk_size,
+        TensorListMetadata<1>& tl) {
+            int tensor_loc = tl.block_to_tensor[blockIdx.x];
+            int chunk_idx = tl.block_to_chunk[blockIdx.x];
+            int n = tl.sizes[tensor_loc];
+
+            T* args[depth];
+            bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+            n -= chunk_idx * chunk_size;
+            T r_args[r_args_depth][kILP];
+
+            // to make things simple, we put aligned case in a different code path
+            if(n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+                for(int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+                    // load
+                    load_store(r_args[0], args[0], 0, i_start);
+#pragma unroll
+                    for(int ii = 0; ii < kILP; ii++) {
+                        r_args[0][ii] = 0;
+                    }
+                    // store
+                    load_store(args[0], r_args[0], i_start, 0);
+                }
+            }
+            else {
+                for(int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+                    load_args<depth>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+                    for(int ii = 0; ii < kILP; ii++) {
+                        r_args[0][ii] = 0;
+                    }
+                    store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+                }
+            }
+        }
+};
+
+template<typename T, int depth, int r_args_depth, int res_arg_index>
 struct UnaryOpFunctor {
     using opmath_t = typename get_opmath_t<T>::opmath_t;
     template<typename Op> __device__ __forceinline__ void operator() (

--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -252,7 +252,7 @@ struct ZeroFunctor {
         TensorListMetadata<1>& tl) {
             int tensor_loc = tl.block_to_tensor[blockIdx.x];
             int chunk_idx = tl.block_to_chunk[blockIdx.x];
-            int n = tl.sizes[tensor_loc];
+            int n = tl.numel_for_tensor[tensor_loc];
 
             T* args[depth];
             bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7632,6 +7632,14 @@
     CPU: foreach_tensor_exp_slow
     CUDA: foreach_tensor_exp_cuda
 
+- func: _foreach_zero_(Tensor(a!)[] self) -> ()
+  use_c10_dispatcher: full
+  device_guard: False
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_zero_slow_
+    CUDA: foreach_tensor_zero_cuda_
+
 - func: _foreach_exp_(Tensor(a!)[] self) -> ()
   use_c10_dispatcher: full
   device_guard: False

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -498,7 +498,8 @@ class FunctionSchema:
                     '_foreach_addcmul_.Scalar',
                     '_foreach_addcdiv_.Scalar',
                     '_foreach_addcmul_.ScalarList',
-                    '_foreach_addcdiv_.ScalarList']:
+                    '_foreach_addcdiv_.ScalarList',
+                    '_foreach_zero_']:
                 assert len(self.returns) == 1
 
     def is_out_fn(self) -> bool:

--- a/torch/optim/_multi_tensor/adadelta.py
+++ b/torch/optim/_multi_tensor/adadelta.py
@@ -1,5 +1,6 @@
 import torch
 from ..optimizer import Optimizer
+from collections import defaultdict
 
 class Adadelta(Optimizer):
     """Implements Adadelta algorithm.
@@ -97,3 +98,27 @@ class Adadelta(Optimizer):
             torch._foreach_addcmul_(acc_deltas, deltas, deltas, value=1 - rho)
 
         return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)
+

--- a/torch/optim/_multi_tensor/adadelta.py
+++ b/torch/optim/_multi_tensor/adadelta.py
@@ -121,4 +121,3 @@ class Adadelta(Optimizer):
             for _, per_dtype_grads in per_device_and_dtype_grads.items():
                 for grads in per_dtype_grads.values():
                     torch._foreach_zero_(grads)
-

--- a/torch/optim/_multi_tensor/adam.py
+++ b/torch/optim/_multi_tensor/adam.py
@@ -163,4 +163,3 @@ class Adam(Optimizer):
             for _, per_dtype_grads in per_device_and_dtype_grads.items():
                 for grads in per_dtype_grads.values():
                     torch._foreach_zero_(grads)
-

--- a/torch/optim/_multi_tensor/adam.py
+++ b/torch/optim/_multi_tensor/adam.py
@@ -1,6 +1,7 @@
 import math
 import torch
 from ..optimizer import Optimizer
+from collections import defaultdict
 
 class Adam(Optimizer):
     r"""Implements Adam algorithm with multi tensor APIs.
@@ -139,3 +140,27 @@ class Adam(Optimizer):
             torch._foreach_addcdiv_(params_with_grad, exp_avg, denom, step_size)
 
         return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)
+

--- a/torch/optim/_multi_tensor/adamax.py
+++ b/torch/optim/_multi_tensor/adamax.py
@@ -1,6 +1,6 @@
 import torch
 from ..optimizer import Optimizer
-
+from collections import defaultdict
 
 class Adamax(Optimizer):
     """Implements Adamax algorithm (a variant of Adam based on infinity norm).
@@ -103,3 +103,28 @@ class Adamax(Optimizer):
             torch._foreach_addcdiv_(params_with_grad, exp_avgs, exp_infs, clr)
 
         return loss
+
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)
+

--- a/torch/optim/_multi_tensor/adamax.py
+++ b/torch/optim/_multi_tensor/adamax.py
@@ -104,7 +104,6 @@ class Adamax(Optimizer):
 
         return loss
 
-
     # TODO: refactor to a base class once foreach ops are in a good shape.
     def zero_grad(self, set_to_none: bool = False):
         per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
@@ -127,4 +126,3 @@ class Adamax(Optimizer):
             for _, per_dtype_grads in per_device_and_dtype_grads.items():
                 for grads in per_dtype_grads.values():
                     torch._foreach_zero_(grads)
-

--- a/torch/optim/_multi_tensor/adamw.py
+++ b/torch/optim/_multi_tensor/adamw.py
@@ -164,4 +164,3 @@ class AdamW(Optimizer):
             for _, per_dtype_grads in per_device_and_dtype_grads.items():
                 for grads in per_dtype_grads.values():
                     torch._foreach_zero_(grads)
-

--- a/torch/optim/_multi_tensor/adamw.py
+++ b/torch/optim/_multi_tensor/adamw.py
@@ -1,7 +1,7 @@
 import math
 import torch
 from ..optimizer import Optimizer
-
+from collections import defaultdict
 
 class AdamW(Optimizer):
     r"""Implements AdamW algorithm.
@@ -141,3 +141,27 @@ class AdamW(Optimizer):
             torch._foreach_addcdiv_(params_with_grad, exp_avg, denom, step_size)
 
         return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)
+

--- a/torch/optim/_multi_tensor/asgd.py
+++ b/torch/optim/_multi_tensor/asgd.py
@@ -115,4 +115,3 @@ class ASGD(Optimizer):
             for _, per_dtype_grads in per_device_and_dtype_grads.items():
                 for grads in per_dtype_grads.values():
                     torch._foreach_zero_(grads)
-

--- a/torch/optim/_multi_tensor/asgd.py
+++ b/torch/optim/_multi_tensor/asgd.py
@@ -1,7 +1,7 @@
 import math
 import torch
 from ..optimizer import Optimizer
-
+from collections import defaultdict
 
 class ASGD(Optimizer):
     """Implements Averaged Stochastic Gradient Descent.
@@ -92,3 +92,27 @@ class ASGD(Optimizer):
                 state['mu'] = 1 / max(1, state['step'] - group['t0'])
 
         return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)
+

--- a/torch/optim/_multi_tensor/rmsprop.py
+++ b/torch/optim/_multi_tensor/rmsprop.py
@@ -144,4 +144,3 @@ class RMSprop(Optimizer):
             for _, per_dtype_grads in per_device_and_dtype_grads.items():
                 for grads in per_dtype_grads.values():
                     torch._foreach_zero_(grads)
-

--- a/torch/optim/_multi_tensor/rmsprop.py
+++ b/torch/optim/_multi_tensor/rmsprop.py
@@ -1,6 +1,6 @@
 import torch
 from ..optimizer import Optimizer
-
+from collections import defaultdict
 
 class RMSprop(Optimizer):
     r"""Implements RMSprop algorithm.
@@ -121,3 +121,27 @@ class RMSprop(Optimizer):
                 torch._foreach_addcdiv_(params_with_grad, grads, avg, value=-group['lr'])
 
         return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)
+

--- a/torch/optim/_multi_tensor/rprop.py
+++ b/torch/optim/_multi_tensor/rprop.py
@@ -1,6 +1,6 @@
 import torch
 from ..optimizer import Optimizer
-
+from collections import defaultdict
 
 class Rprop(Optimizer):
     """Implements the resilient backpropagation algorithm.
@@ -93,3 +93,26 @@ class Rprop(Optimizer):
                 states[i]['prev'].copy_(grads[i])
 
         return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)

--- a/torch/optim/_multi_tensor/sgd.py
+++ b/torch/optim/_multi_tensor/sgd.py
@@ -1,6 +1,6 @@
 import torch
 from ..optimizer import Optimizer, required
-
+from collections import defaultdict
 
 class SGD(Optimizer):
     r"""Implements stochastic gradient descent (optionally with momentum).
@@ -152,3 +152,26 @@ class SGD(Optimizer):
                     params_with_grad[i].add_(grads[i], alpha=-group['lr'])
 
         return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)


### PR DESCRIPTION
**In this PR**
- add `_foreach_zero_` API
- Update all optimizers under /_multi_tensor/ to use `_foreach_zero_` in `zero_grad` method

Performance improvement 
----------------- OP:  zero_  -----------------
for-loop: 630.36 us
foreach: 90.84 us

script

```
import torch
import torch.optim as optim
import torch.nn as nn
import torchvision
import torch.utils.benchmark as benchmark_utils

inputs = [torch.rand(3, 200, 200, device="cuda") for _ in range(100)]

def main():
    for op in [
            "zero_"
        ]:
        print("\n\n----------------- OP: ", op, " -----------------")
        stmt = "[torch.{op}(t) for t in inputs]"
        timer = benchmark_utils.Timer(
            stmt=stmt.format(op = op),
            globals=globals(),
            label="str(optimizer)",
        )
        print(f"autorange:\n{timer.blocked_autorange()}\n\n")


        stmt = "torch._foreach_{op}(inputs)"
        timer_mta = benchmark_utils.Timer(
            stmt=stmt.format(op = op),
            globals=globals(),
            label="str(optimizer_mta)",
        )
        print(f"autorange:\n{timer_mta.blocked_autorange()}\n\n")

if __name__ == "__main__":
    main()

```
**TODO**
- Refactor zero_grad once foreach APIs are stable.

**Tested** via unit tests