### PR TITLE
Expand GRADIENT_IMPLEMENTED_FOR_COMPLEX to allow named tensors

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4697,6 +4697,13 @@ for shape in [(1,), ()]:
         with self.assertRaisesRegex(RuntimeError, bad_mark_dirty_err):
             fn(a, b)
 
+    def test_named_tensor_for_complex_views(self):
+        names = ["batch", "height", "width", "complex"]
+        z = torch.ones((5, 12, 14, 2), requires_grad=True).refine_names(*names)
+        z_complex = torch.view_as_complex(z.rename(None)).refine_names(*names[:-1])
+        z_complex.sum().backward()
+        self.assertEqual(z.grad, torch.ones_like(z))
+
     def test_custom_function_return_view_in_nograd(self):
         class Alias(Function):
             @staticmethod

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4699,10 +4699,11 @@ for shape in [(1,), ()]:
 
     def test_named_tensor_for_complex_views(self):
         names = ["batch", "height", "width", "complex"]
-        z = torch.ones((5, 12, 14, 2), requires_grad=True).refine_names(*names)
-        z_complex = torch.view_as_complex(z.rename(None)).refine_names(*names[:-1])
+        z = torch.ones((5, 12, 14, 2), requires_grad=True)
+        z_named = z.refine_names(*names)
+        z_complex = torch.view_as_complex(z_named.rename(None)).refine_names(*names[:-1])
         z_complex.sum().backward()
-        self.assertEqual(z.grad, torch.ones_like(z))
+        self.assertEqual(z.grad, torch.view_as_real(torch.ones_like(z_complex).rename(None)))
 
     def test_custom_function_return_view_in_nograd(self):
         class Alias(Function):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -165,7 +165,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     'neg', 'complex', 'select', '_s_where', 'as_strided', 'slice', 'constant_pad_nd',
     'unbind', 'split', 'split_with_sizes', 'unsafe_split', 'split_with_sizes_backward',
     'dot', 'vdot', 'cholesky', 'triangular_solve', 'mm', '_unsafe_view', 'mv', 'ger',
-    'bmm', 'diagonal', 'cholesky', 'atan', 'log', 'log10', 'log1p', 'log2', 'reciprocal',
+    'bmm', 'diagonal', 'alias', 'atan', 'log', 'log10', 'log1p', 'log2', 'reciprocal',
     'tan', 'pow', 'rsqrt', 'tanh', 'tanh_backward', 'asinh', 'acosh', 'take', 'fill_',
     'exp', 'nonzero'
 }


### PR DESCRIPTION
Complex-valued named tensors do not support backpropagation currently. This is due to `tools/autograd/gen_variable_type.py` not containing `alias` in `GRADIENT_IMPLEMENTED_FOR_COMPLEX` which is required to constructed named tensors.

This fixes #47157. Also removed a duplicate `cholesky` in the list and added a test in `test_autograd.py`.

Apologies, this is a duplicate of #47181 as I accidently removed my pytorch fork.

cc: @zou3519 @anjali411 