### PR TITLE
[TEST]Handle ViewMeta in forward kernel instead of Autograd kernel.

### DIFF
--- a/aten/src/ATen/core/VariableHooksInterface.h
+++ b/aten/src/ATen/core/VariableHooksInterface.h
@@ -16,7 +16,7 @@
 // merge the libraries inside Facebook".  Well, the problem is that there
 // are some downstream applications which are at binary size limit, and
 // incorporating all of the extra code from libtorch would push them
-// over (admarket/adreview/service:adreviewservice, see also 
+// over (admarket/adreview/service:adreviewservice, see also
 // https://github.com/pytorch/pytorch/pull/29299)  So if you want to do that,
 // we have to fix all of the services like this.
 //
@@ -45,8 +45,8 @@ struct CAFFE2_API VariableHooksInterface {
   virtual const std::shared_ptr<torch::autograd::Node>& grad_fn(const Tensor&) const = 0;
   virtual unsigned _register_hook(const Tensor&, std::function<Tensor(const Tensor&)> hook) const = 0;
   virtual void remove_hook(const Tensor&, unsigned pos) const = 0;
-  virtual bool is_view(const Tensor&) const = 0;
-  virtual const Tensor& base(const Tensor&) const = 0;
+  //virtual bool is_view(const Tensor&) const = 0;
+  //virtual const Tensor& base(const Tensor&) const = 0;
   virtual const std::string& name(const Tensor&) const = 0;
 };
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -257,6 +257,7 @@ at::DataPtr PlacementDeleteContext::makeDataPtr(
 }
 
 AutogradMetaInterface::~AutogradMetaInterface() {}
+ViewMetaInterface::~ViewMetaInterface() {}
 
 void TensorImpl::set_requires_grad(bool requires_grad) {
   if (!requires_grad && !autograd_meta_) return;
@@ -284,9 +285,19 @@ void TensorImpl::set_autograd_meta(std::unique_ptr<c10::AutogradMetaInterface> a
   autograd_meta_ = std::move(autograd_meta);
 }
 
+void TensorImpl::set_view_meta(std::unique_ptr<c10::ViewMetaInterface> view_meta) {
+  // NB: view_meta may be null!  That just means it's the default
+  // constructor
+  view_meta_ = std::move(view_meta);
+}
+
 c10::AutogradMetaInterface* TensorImpl::autograd_meta() const {
   // NB: Might return null!
   return autograd_meta_.get();
+}
+
+c10::ViewMetaInterface* TensorImpl::view_meta() const {
+ return view_meta_.get();
 }
 
 void TensorImpl::copy_tensor_metadata(

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -260,7 +260,7 @@ Tensor & detach_(Tensor & self) {
   RECORD_FUNCTION("detach_", std::vector<c10::IValue>({self}));
   if (self.is_view()) {
     // NB: is_view() ==> get_autograd_meta()
-    auto diff_view_meta = static_cast<torch::autograd::DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(self));
+    auto diff_view_meta = static_cast<at::ViewMeta*>(torch::autograd::impl::get_view_meta(self));
     // See NOTE [ View + Inplace detection ]
     if (diff_view_meta->creation_meta == CreationMeta::MULTI_OUTPUT_SAFE) {
         TORCH_WARN("This view is an output of a function that "

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -44,9 +44,10 @@ inline void check_inplace(const Tensor& tensor) {
   if (var.requires_grad() && GradMode::is_enabled()) {
     if (var.is_view()) {
       // NB: is_view() ==> get_autograd_meta()
-      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(var));
+      auto diff_view_meta = static_cast<at::ViewMeta*>(impl::get_view_meta(var));
+      auto autograd_meta =static_cast<AutogradMeta*>(impl::get_autograd_meta(var));
       // This can throw or warn
-      handle_view_on_rebase(diff_view_meta);
+      handle_view_on_rebase(diff_view_meta, autograd_meta);
       if (tensor._base().is_leaf()) {
           AT_ERROR(
             "a view of a leaf Variable that requires grad is being used in an in-place operation.");
@@ -128,9 +129,12 @@ template<typename... Args> inline variable_list flatten_tensor_args(Args&&... ar
 }
 
 // See NOTE [ Autograd View Variables ] for details.
+// TODO: remove
 inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable,
         c10::optional<std::function<Tensor(const Tensor&)>> view_func=c10::nullopt,
         CreationMeta creation_meta=CreationMeta::DEFAULT) {
+  return tensor;
+  /*
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     // Set `view_func` using the root base as input.
@@ -194,11 +198,15 @@ inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable
                 "Non-differentiable views must have creation_meta=CreationMeta::DEFAULT");
     return make_variable_non_differentiable_view(std::move(base_var), std::move(tensor));
   }
+  */
 }
 
 // See NOTE [ Autograd View Variables ] for details.
+// TODO: remove
 inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tensors, bool is_differentiable,
                                    CreationMeta creation_meta=CreationMeta::DEFAULT) {
+  return tensors;
+/*
   auto base_var = Variable(base);
   if (base_var.is_view()) {
     base_var = base_var._base();
@@ -213,6 +221,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tens
     }
   }
   return tensors;
+  */
 }
 
 inline void check_no_requires_grad(const Tensor& tensor, const char* name) {

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -123,8 +123,8 @@ variable_list _wrap_outputs(const variable_list &input_vars,
     // See NOTE [ View + Inplace detection ] for why we replace everything by a warning.
     if (!(is_input && is_modified) && var.is_view()) {
       // NB: is_view() ==> get_autograd_meta()
-      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(var));
-      diff_view_meta->creation_meta = CreationMeta::IN_CUSTOM_FUNCTION;
+      auto diff_view_meta = static_cast<at::ViewMeta*>(impl::get_view_meta(var));
+      diff_view_meta->creation_meta = at::CreationMeta::IN_CUSTOM_FUNCTION;
     }
 
     if (is_differentiable) {
@@ -141,8 +141,8 @@ variable_list _wrap_outputs(const variable_list &input_vars,
     for (auto& var: outputs) {
       if (var.is_view()) {
         // NB: is_view() ==> get_autograd_meta()
-        auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(var));
-        diff_view_meta->creation_meta = CreationMeta::MULTI_OUTPUT_NODE;
+        auto diff_view_meta = static_cast<at::ViewMeta*>(impl::get_view_meta(var));
+        diff_view_meta->creation_meta = at::CreationMeta::MULTI_OUTPUT_NODE;
       }
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47302 [TEST]only add autograd keys when requires_grad or has grad_fn
* **#47301 [TEST]Handle ViewMeta in forward kernel instead of Autograd kernel.**

