### PR TITLE
Expose SparseLengthsSum8BitRowwiseSparse to C10

### DIFF
--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.cc
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h"
 #include "c10/util/Registry.h"
+#include "caffe2/core/export_caffe2_op_to_c10.h"
 
 namespace caffe2 {
 
@@ -611,3 +612,12 @@ fp16 scale and bias), and where rows are pruned.
 NO_GRADIENT(SparseLengthsMean2BitRowwiseSparse);
 
 } // namespace caffe2
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    SparseLengthsSum8BitRowwiseSparse,
+    "_caffe2::SparseLengthsSum8BitRowwiseSparse("
+    "Tensor data, "
+    "Tensor indices, "
+    "Tensor lengths, "
+    "Tensor compressed_indices_mapping) -> Tensor output",
+    caffe2::SparseLengthsNBitRowwiseSparseOp<8>);

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -331,8 +331,9 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
       !(with_weights && is_mean),
       "Cannot have with_weights and is_mean a the same time");
 
-  SparseLengthsNBitRowwiseSparseOp(const OperatorDef& def, Workspace* ws)
-      : Operator<CPUContext>(def, ws) {}
+  template<class... Args>
+  explicit SparseLengthsNBitRowwiseSparseOp(Args&&... args)
+      : Operator<CPUContext>(std::forward<Args>(args)...) {}
   ~SparseLengthsNBitRowwiseSparseOp() override {}
 
   bool RunOnDevice() override {


### PR DESCRIPTION
Summary:
Expose SparseLengthsSum8BitRowwiseSparse to PyTorch, since pt's 8bit embedding doesn't support pruning yet.

It's temporary solution to unblock the QRT test, not best for performance.

Test Plan: ci

Differential Revision: D24709524

