### PR TITLE
Preserve submodule with __set_state__ in freezing

### DIFF
--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -241,11 +241,20 @@ class AttributePropagator {
           }
 
           auto attr = attrModule.attr(name);
+          auto mptr = attrModule._ivalue();
           if (n->kind() == prim::GetAttr) {
             auto type = n->output()->type();
             // Do not record submodules. Their attributes are tracked
             // individually.
-            if (attr.isObject() || !AliasDb::isMutableType(attr.type())) {
+            if (attr.isObject()) {
+              auto submodule = attr.toModule();
+              if (submodule.find_method("__setstate__")) {
+                insertMutableAttr(name, attr, mptr);
+              }
+              continue;
+            }
+
+            if (!AliasDb::isMutableType(attr.type())) {
               continue;
             }
             usedAttrs_.insert(attr);
@@ -256,7 +265,6 @@ class AttributePropagator {
                 n->kind() == prim::GetAttr ? "attribute: " + name + " in %" +
                         n->output()->debugName() + " has inplace writer"
                                            : "attribute: " + name + " is set");
-            auto mptr = attrModule._ivalue();
             insertMutableAttr(name, attr, mptr);
           }
         } else if (n->kind() == prim::fork) {
@@ -523,6 +531,11 @@ class AttributePropagator {
         return true;
       }
     }
+
+    if (subModule.find_method("__setstate__")) {
+      return true;
+    }
+
     return preservedSubModule_.count(subModule._ivalue());
   }
 
@@ -749,6 +762,9 @@ Module freeze_module(
     std::vector<std::string> preservedAttrs,
     bool freezeInterfaces,
     bool preserveParameters) {
+  TORCH_CHECK(
+      !module.find_method("__setstate__"),
+      "cannot freeze a module that has __set_state__");
   Method method = module.get_method("forward");
   // Check that module does not return itself.
   for (auto& output : method.graph()->outputs()) {


### PR DESCRIPTION
This PR does the following:

-  fail freezing if input module has __set_state__ method
-  preserves attributes of  submodules with __set_state__ method.

Fixes #{issue number}
