### PR TITLE
Removing caffe2 and third_party from our code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,3 +18,6 @@ comment:
 fixes:
   - "/opt/conda/lib/python3.8/site-packages/::project/"
   - "C:/Users/circleci/project/build/win_tmp/build/::project/"
+ignore:
+  - caffe2
+  - third_party

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,5 +19,5 @@ fixes:
   - "/opt/conda/lib/python3.8/site-packages/::project/"
   - "C:/Users/circleci/project/build/win_tmp/build/::project/"
 ignore:
-  - caffe2
-  - third_party
+  - "caffe2"
+  - "third_party"


### PR DESCRIPTION
Our tests do not test these folders (as they shouldn't), and their inclusion in codecov obfuscates our coverage metrics.

We ask codecov to ignore these folders when calculating our coverage.