### PR TITLE
Updates make_tensor ranges

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1498,7 +1498,7 @@ def make_tensor(size, device: torch.device, dtype: torch.dtype, *,
             towards = .05 if direction == "higher" else -.05
             return n + towards
         else:  # dtype is complex, which is not (directly) supported
-            assert False
+            raise AssertionError("Unsupported dtype")
 
         return result
 


### PR DESCRIPTION
Previously integer, floating point and complex tensors generated using `make_tensor` had inclusive ranges. This PR updates these ranges to be inclusive, by default, for integer tensors and exclusive, by default, for floating point and complex tensors. A parameter is added to include or exclude endpoints if a test wants to override this behavior. In the future additional parameters may be added to allow specifying half-open ranges like [-1, 1) or (-1, 1].

Endpoint exclusivity is achieved with a newer helper function, `nudge`, which is scoped to the `make_tensor` function. This function is similar to nextafter but supports all PyTorch dtypes. Since neither PyTorch nor NumPy support nextafter for bfloat16, however, a heuristic update is used instead. For all other supported float dtypes the value actually is the nextafter value, as defined by NumPy's nextafter (which supports half values, unlike PyTorch). 

As a meta note, since these changes are only tested implicitly, in the future we may want to develop test_testing to test the torch.testing module. 