### PR TITLE
Revert "Do not delete rpath from torch.dylib on Darwin (#47337)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -368,6 +368,8 @@ class build_ext(setuptools.command.build_ext.build_ext):
             return
         lib_dir = os.path.join(self.build_lib, 'torch', 'lib')
         libtorch_cpu_path = os.path.join(lib_dir, 'libtorch_cpu.dylib')
+        libtorch_path = os.path.join(lib_dir, 'libtorch.dylib')
+        libtorch_python_path = os.path.join(lib_dir, 'libtorch_python.dylib')
         # Parse libtorch_cpu load commands
         otool_cmds = subprocess.check_output(['otool', '-l', libtorch_cpu_path]).decode('utf-8').split('\n')
         rpaths, libs = [], []
@@ -394,6 +396,11 @@ class build_ext(setuptools.command.build_ext.build_ext):
             target_lib = os.path.join(self.build_lib, 'torch', 'lib', omp_lib_name)
             self.copy_file(source_lib, target_lib)
             break
+
+        # Delete rpath from those libs
+        for rpath in rpaths:
+            for lib in [libtorch_cpu_path, libtorch_path, libtorch_python_path]:
+                subprocess.check_call(['install_name_tool', '-delete_rpath', rpath, lib])
 
     def run(self):
         # Report build options. This is run after the build completes so # `CMakeCache.txt` exists and we can get an


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46900 Add Vulkan op Conv2D.
* #47261 Vulkan tweaks
* #47381 Revert "Embed `libiomp5.dylib` into wheel package (#47262)"
* **#47380 Revert "Do not delete rpath from torch.dylib on Darwin (#47337)"**

This reverts commit 3a0024574dcc2ef4653b969588776c32fd23369a.