### PR TITLE
Fix multinomial when input has 0 prob

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -530,11 +530,19 @@
   dispatch:
     CPU, CUDA: argmax
 
+- func: argmax.out(Tensor self, int? dim=None, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU, CUDA: argmax_out
+
 - func: argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor
   use_c10_dispatcher: full
   variants: function, method
   dispatch:
     CPU, CUDA: argmin
+
+- func: argmin.out(Tensor self, int? dim=None, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU, CUDA: argmin_out
 
 - func: acosh(Tensor self) -> Tensor
   use_c10_dispatcher: full


### PR DESCRIPTION
Summary:

torch.Tensor.multinomial may generate invalid output 0 with replacement=False when input distribution is a one-hot vector. The current algorithm is S = topk( log(eps) / p ) where eps ~ U(0, 1). However, when the input is a one-hot vector and the sampled eps is 0 for the one position, then it will get -inf / 1 == -inf. While other positions are also log(eps) / 0 == -inf. Then the results will be invalid. The probability for this to happen is the about 2^(-24) for float and 2^(-53) for double.

In this PR, we changed the formula to a modified version of gumbel softmax, which is S = topk( p / q ) where q ~Exp(1). We can prove this is equivalent to the current algorithm. In the current PyTorch implementation, the exponential distribution will never generate 0 on CUDA, and generate 0 on CPU in 2^(-53) no matter what input type is. So this PR can resolve the issue on CUDA and reduce the probability a lot on CPU for float type. 

Test Plan: buck test mode/dev-nosan //caffe2/test:torch -- "multinomial"

Differential Revision: D24699691

