### PR TITLE
 Support varying size input in numeric suite at 10/30/2020, …

### DIFF
--- a/torch/quantization/_numeric_suite.py
+++ b/torch/quantization/_numeric_suite.py
@@ -169,23 +169,16 @@ class ShadowLogger(Logger):
 
     def __init__(self):
         super(ShadowLogger, self).__init__()
-        self.stats["float"] = None
-        self.stats["quantized"] = None
+        self.stats["float"] = []
+        self.stats["quantized"] = []
 
     def forward(self, x, y):
         if len(x) > 1:
             x = x[0]
         if len(y) > 1:
             y = y[0]
-        if self.stats["quantized"] is None:
-            self.stats["quantized"] = x.detach()
-        else:
-            self.stats["quantized"] = torch.cat((self.stats["quantized"], x.detach()))
-
-        if self.stats["float"] is None:
-            self.stats["float"] = y.detach()
-        else:
-            self.stats["float"] = torch.cat((self.stats["float"], y.detach()))
+        self.stats["quantized"].append(x.detach())
+        self.stats["float"].append(y.detach())
 
 
 class OutputLogger(Logger):
@@ -194,13 +187,11 @@ class OutputLogger(Logger):
 
     def __init__(self):
         super(OutputLogger, self).__init__()
-        self.stats["tensor_val"] = None
+        self.stats["tensor_val"] = []
+
 
     def forward(self, x):
-        if self.stats["tensor_val"] is None:
-            self.stats["tensor_val"] = x
-        else:
-            self.stats["tensor_val"] = torch.cat((self.stats["tensor_val"], x))
+        self.stats["tensor_val"].append(x)
         return x
 
 


### PR DESCRIPTION

Current Numeric Suite will fail if it's collecting for multiple inputs and each input is of not same size.  This fix adds support for varying size input in numeric suite.

Differential Revision: [D24662271](https://our.internmc.facebook.com/intern/diff/D24662271/)

ghstack-source-id: 115785435
Pull Request resolved: https://github.com/pytorch/pytorch/pull/47391

Fixes #{issue number}
