### PR TITLE
[JIT] add support for torch.jit.Final in python 3.6

### DIFF
--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -159,7 +159,6 @@ class TestRecursiveScript(JitTestCase):
             # Make sure that no entries are left over from the previous failure
             FileCheck().check_count("is being compiled", 2).run(str(e))
 
-    @unittest.skipIf(sys.version_info[:2] < (3, 7), "Class annotations are a thing in > 3.5, need to fix for < 3.7")
     def test_constants_with_final(self):
         class M1(torch.nn.Module):
             x : torch.jit.Final[int]

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -1,4 +1,3 @@
-import unittest
 import os
 import sys
 import typing

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -717,7 +717,7 @@ if torch.distributed.rpc.is_available():
 
 def is_final(ann):
     return ann.__module__ in {'typing', 'typing_extensions'} and \
-        (getattr(ann, '__origin__', None) is Final)
+        (getattr(ann, '__origin__', None) is Final or isinstance(ann, type(Final)))
 
 # allows BroadcastingList instance to be subscriptable
 class BroadcastingListCls(object):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -717,7 +717,8 @@ if torch.distributed.rpc.is_available():
 
 def is_final(ann):
     return ann.__module__ in {'typing', 'typing_extensions'} and \
-        (getattr(ann, '__origin__', None) is Final or isinstance(ann, type(Final)))
+        (getattr(ann, '__origin__', None) is Final \
+            or isinstance(ann, type(Final)))
 
 # allows BroadcastingList instance to be subscriptable
 class BroadcastingListCls(object):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -717,8 +717,7 @@ if torch.distributed.rpc.is_available():
 
 def is_final(ann):
     return ann.__module__ in {'typing', 'typing_extensions'} and \
-        (getattr(ann, '__origin__', None) is Final \
-            or isinstance(ann, type(Final)))
+        (getattr(ann, '__origin__', None) is Final or isinstance(ann, type(Final)))
 
 # allows BroadcastingList instance to be subscriptable
 class BroadcastingListCls(object):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47393 [JIT] add support for torch.jit.Final in python 3.6**

Python added support for typing.Final in 3.8, and there exists a backport for 3.7 and 3.6 in typing_extensions.Final

The 3.6 version of typing_extensions.Final doesn't support the `getattr(x, '__origin__')` to determine if an object is of the Final type while 3.7 does. This PR allows for the Final type of an object to be discoverable in 3.6


Differential Revision: [D24739402](https://our.internmc.facebook.com/intern/diff/D24739402)