### PR TITLE
Clean up some imports in cuda kernel code.

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryGeometricKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryGeometricKernels.cu
@@ -1,19 +1,8 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
-
-#if defined(__CUDACC__)
-#include <cuda.h>
-#include <cuda_fp16.h>
-#include <c10/cuda/CUDAMathCompat.h>
-#elif defined(__HIPCC__)
-#include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
-#include <c10/hip/HIPMathCompat.h>
-#endif
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -5,16 +5,6 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 
-#if defined(__CUDACC__)
-#include <cuda.h>
-#include <cuda_fp16.h>
-#include <c10/cuda/CUDAMathCompat.h>
-#elif defined(__HIPCC__)
-#include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
-#include <c10/hip/HIPMathCompat.h>
-#endif
-
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 

--- a/aten/src/ATen/native/cuda/CopysignKernel.cu
+++ b/aten/src/ATen/native/cuda/CopysignKernel.cu
@@ -1,7 +1,6 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 

--- a/aten/src/ATen/native/cuda/GcdLcmKernel.cu
+++ b/aten/src/ATen/native/cuda/GcdLcmKernel.cu
@@ -5,16 +5,6 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 
-#if defined(__CUDACC__)
-#include <cuda.h>
-#include <cuda_fp16.h>
-#include <c10/cuda/CUDAMathCompat.h>
-#elif defined(__HIPCC__)
-#include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
-#include <c10/hip/HIPMathCompat.h>
-#endif
-
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -1,19 +1,8 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
-
-#if defined(__CUDACC__)
-#include <cuda.h>
-#include <cuda_fp16.h>
-#include <c10/cuda/CUDAMathCompat.h>
-#elif defined(__HIPCC__)
-#include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
-#include <c10/hip/HIPMathCompat.h>
-#endif
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.

--- a/aten/src/ATen/native/cuda/StepKernel.cu
+++ b/aten/src/ATen/native/cuda/StepKernel.cu
@@ -1,19 +1,8 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
-
-#if defined(__CUDACC__)
-#include <cuda.h>
-#include <cuda_fp16.h>
-#include <c10/cuda/CUDAMathCompat.h>
-#elif defined(__HIPCC__)
-#include <hip/hip_runtime.h>
-#include <hip/hip_fp16.h>
-#include <c10/hip/HIPMathCompat.h>
-#endif
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47414 __noinline__ the top level igamma cuda kernel.
* #47410 Move igamma cuda specific code to kernel file.
* #47401 Split IGamma cuda kernel into it's own file to speed up compilation times.
* **#47400 Clean up some imports in cuda kernel code.**
* #47362 Split up BinaryMiscOpKernels.cu because it's slow to compile.

Differential Revision: [D24740655](https://our.internmc.facebook.com/intern/diff/D24740655)