### PR TITLE
[TensorExpr] Fix 'isIntegralType is deprecated' warning.

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -413,7 +413,7 @@ ExprHandle TensorExprKernel::constant(const torch::jit::Value* v) {
 
 ExprHandle promoteIntegerToFloat(const ExprHandle& e) {
   auto scalarType = static_cast<c10::ScalarType>(e.dtype().scalar_type());
-  if (!c10::isIntegralType(scalarType)) {
+  if (!c10::isIntegralType(scalarType, /* includeBool = */ false)) {
     return e;
   }
   auto defaultType = static_cast<tensorexpr::ScalarType>(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47403 [TensorExpr] Fix 'isIntegralType is deprecated' warning.**
* #47402 [TensorExpr] Run constant pooling in fusion groups to dedupe constants.

Differential Revision: [D24740958](https://our.internmc.facebook.com/intern/diff/D24740958)