### PR TITLE
Add bool tensor support for where

### DIFF
--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -183,7 +183,7 @@ static void _aminmax_kernel_impl(
 }
 
 static void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(iter.dtype(), "where_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(at::ScalarType::Bool, iter.dtype(), "where_cpu", [&] {
     if (condition_type == at::ScalarType::Byte) {
       cpu_kernel(
         iter,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -405,8 +405,8 @@ class AbstractTestCases:
             height = 5
             width = 5
             for device in torch.testing.get_all_device_types():
-                for dt1 in torch.testing.get_all_math_dtypes(device):
-                    for dt2 in torch.testing.get_all_math_dtypes(device):
+                for dt1 in torch.testing.get_all_dtypes(include_half=device.startswith('cuda'), include_bfloat16=False):
+                    for dt2 in torch.testing.get_all_dtypes(include_half=device.startswith('cuda'), include_bfloat16=False):
                         for contiguous in [True, False]:
                             x1 = get_tensor((height, width), dt1, device, contiguous)
                             x2 = get_tensor((height, width), dt2, device, contiguous)


### PR DESCRIPTION
Fixes #26247

This now works:

```
a = torch.tensor([True, False], device='cpu')
x = torch.tensor([True, True], device='cpu')
y = torch.tensor([False, False], device='cpu')
res = torch.where(a, x, y)

a = torch.tensor([True, False], device='cuda')
x = torch.tensor([True, True], device='cuda')
y = torch.tensor([False, False], device='cuda')
res = torch.where(a, x, y)
```

Also updated where_tensor test to include bools

Test:
pytest test/test_torch.py -k test_where_tensor -vs