### PR TITLE
[Pytorch][Annotation] Update inlined callstack with module instance info

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1897,6 +1897,19 @@ std::vector<Value*> inlineCallTo(
   std::unordered_map<InlinedCallStack*, InlinedCallStackPtr>
       new_callstack_entries;
 
+  c10::optional<ModuleInstanceInfo> module_instance_info = c10::nullopt;
+  if (to_replace->kind() == prim::CallMethod) {
+    auto class_type_ptr = to_replace->input(0)->type()->cast<c10::ClassType>();
+    if (to_replace->input(0)->node()->kind() == prim::GetAttr) {
+      module_instance_info = c10::make_optional(ModuleInstanceInfo(
+          class_type_ptr, to_replace->input(0)->node()->s(attr::name)));
+    } else {
+      std::string instance_name_unknown("INSTANCE_NAME_UNKNOWN");
+      module_instance_info = c10::make_optional(
+          ModuleInstanceInfo(class_type_ptr, instance_name_unknown));
+    }
+  }
+
   // TODO: We might need to use nodes_map instead of value_map. Otherwise, we
   // are missing nodes without outputs (e.g. prim::Print).
   std::unordered_set<Node*> updated_nodes;
@@ -1913,13 +1926,19 @@ std::vector<Value*> inlineCallTo(
 
     if (!new_callstack_entries.count(raw_callstack_ptr)) {
       if (new_node_cs) {
+//        new_callstack_entries[raw_callstack_ptr] =
+//            c10::make_intrusive<InlinedCallStack>(
+//                *new_node_cs, callee, to_replace->sourceRange());
         new_callstack_entries[raw_callstack_ptr] =
             c10::make_intrusive<InlinedCallStack>(
-                *new_node_cs, callee, to_replace->sourceRange());
+                *new_node_cs, callee, to_replace->sourceRange(), module_instance_info);
       } else {
+//        new_callstack_entries[raw_callstack_ptr] =
+//            c10::make_intrusive<InlinedCallStack>(
+//                callee, to_replace->sourceRange());
         new_callstack_entries[raw_callstack_ptr] =
             c10::make_intrusive<InlinedCallStack>(
-                callee, to_replace->sourceRange());
+                callee, to_replace->sourceRange(), module_instance_info);
       }
     }
     new_node->setCallStack(new_callstack_entries.at(raw_callstack_ptr));

--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -90,12 +90,30 @@ InlinedCallStack::InlinedCallStack(Function* fn, SourceRange source_range)
     : fn_(fn), source_range_(std::move(source_range)) {}
 
 InlinedCallStack::InlinedCallStack(
+    Function* fn,
+    SourceRange source_range,
+    c10::optional<ModuleInstanceInfo> module_instance_info)
+    : fn_(fn),
+      source_range_(std::move(source_range)),
+      module_instance_info_(std::move(module_instance_info)) {}
+
+InlinedCallStack::InlinedCallStack(
     InlinedCallStackPtr callee,
     Function* fn,
     SourceRange source_range)
     : callee_(std::move(callee)),
       fn_(fn),
       source_range_(std::move(source_range)) {}
+
+InlinedCallStack::InlinedCallStack(
+    InlinedCallStackPtr callee,
+    Function* fn,
+    SourceRange source_range,
+    c10::optional<ModuleInstanceInfo> module_instance_info)
+    : callee_(std::move(callee)),
+      fn_(fn),
+      source_range_(std::move(source_range)),
+      module_instance_info_(std::move(module_instance_info)) {}
 
 c10::optional<InlinedCallStackPtr> InlinedCallStack::callee() const {
   return callee_;
@@ -110,5 +128,10 @@ std::vector<InlinedCallStackEntry> InlinedCallStack::vec() {
   }
   return r;
 }
+
+ModuleInstanceInfo::ModuleInstanceInfo(
+    c10::ClassTypePtr module_type,
+    std::string instance_name)
+    : module_type_(module_type), instance_name_(std::move(instance_name)) {}
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/ir/scope.h
+++ b/torch/csrc/jit/ir/scope.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <ATen/core/interned_strings.h>
+#include <ATen/core/jit_type.h>
 #include <c10/util/Optional.h>
 #include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
@@ -50,6 +51,26 @@ struct TORCH_API Scope : public c10::intrusive_ptr_target {
 
 struct Function;
 struct InlinedCallStack;
+struct ModuleInstanceInfo {
+ private:
+  c10::ClassTypePtr module_type_{nullptr};
+  std::string instance_name_;
+
+ public:
+  ModuleInstanceInfo(c10::ClassTypePtr module_type, std::string instance_name);
+  c10::ClassTypePtr class_type() {
+    return module_type_;
+  }
+  std::string instance_name() {
+    return instance_name_;
+  }
+  c10::ClassTypePtr class_type() const {
+    return module_type_;
+  }
+  std::string instance_name() const {
+    return instance_name_;
+  }
+};
 
 /**
  * InlinedCallStack is an element in a list representing callstack of functions
@@ -81,6 +102,8 @@ struct InlinedCallStack;
  */
 using InlinedCallStackPtr = c10::intrusive_ptr<InlinedCallStack>;
 using InlinedCallStackEntry = std::pair<Function*, SourceRange>;
+using InlinedCallStackWithModuleInfo =
+std::tuple<Function*, SourceRange, c10::optional<ModuleInstanceInfo>>;
 
 struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
  private:
@@ -88,16 +111,29 @@ struct TORCH_API InlinedCallStack : public c10::intrusive_ptr_target {
   Function* fn_;
   SourceRange source_range_;
   InlinedCallStackPtr intrusive_from_this();
+  c10::optional<ModuleInstanceInfo> module_instance_info_;
 
  public:
   // Constructor for a leaf callstack node.
   InlinedCallStack(Function* fn, SourceRange source_range);
+
+  // Constructor for a leaf callstack node.
+  InlinedCallStack(
+      Function* fn,
+      SourceRange source_range,
+      c10::optional<ModuleInstanceInfo> module_instance_info);
 
   // Constructor for an inner callstack node.
   InlinedCallStack(
       InlinedCallStackPtr callee,
       Function* fn,
       SourceRange source_range);
+
+  InlinedCallStack(
+      InlinedCallStackPtr callee,
+      Function* fn,
+      SourceRange source_range,
+      c10::optional<ModuleInstanceInfo> module_instance_info);
 
   // Return next element in the callstack list.
   c10::optional<InlinedCallStackPtr> callee() const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46893 [Pytorch][Annotation] Use call stack to get module path
* **#47419 [Pytorch][Annotation] Update inlined callstack with module instance info**

