### PR TITLE
[complex] torch.sqrt: fix edge values

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -275,18 +275,7 @@ public:
     return _mm256_round_pd(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC));
   }
   Vec256<c10::complex<double>> sqrt() const {
-    //   sqrt(a + bi)
-    // = sqrt(2)/2 * [sqrt(sqrt(a**2 + b**2) + a) + sgn(b)*sqrt(sqrt(a**2 + b**2) - a)i]
-    // = sqrt(2)/2 * [sqrt(abs() + a) + sgn(b)*sqrt(abs() - a)i]
-
-    const __m256d scalar = _mm256_set1_pd(std::sqrt(2)/2);             //sqrt(2)/2      sqrt(2)/2
-    const __m256d sign_mask = _mm256_setr_pd(0.0, -0.0, 0.0, -0.0);
-    auto sign = _mm256_and_pd(values, sign_mask);
-    auto factor = _mm256_or_pd(scalar, sign);
-
-    auto a_a = _mm256_xor_pd(_mm256_movedup_pd(values), sign_mask);    // a             -a
-    auto res_re_im = _mm256_sqrt_pd(_mm256_add_pd(abs_(), a_a));       // sqrt(abs + a) sqrt(abs - a)
-    return _mm256_mul_pd(factor, res_re_im);
+    return map(std::sqrt);
   }
   Vec256<c10::complex<double>> reciprocal() const;
   Vec256<c10::complex<double>> rsqrt() const {

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -313,18 +313,7 @@ public:
     return _mm256_round_ps(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC));
   }
   Vec256<c10::complex<float>> sqrt() const {
-    //   sqrt(a + bi)
-    // = sqrt(2)/2 * [sqrt(sqrt(a**2 + b**2) + a) + sgn(b)*sqrt(sqrt(a**2 + b**2) - a)i]
-    // = sqrt(2)/2 * [sqrt(abs() + a) + sgn(b)*sqrt(abs() - a)i]
-
-    const __m256 scalar = _mm256_set1_ps(std::sqrt(2)/2);              //sqrt(2)/2      sqrt(2)/2
-    const __m256 sign_mask = _mm256_setr_ps(0.0, -0.0, 0.0, -0.0, 0.0, -0.0, 0.0, -0.0);
-    auto sign = _mm256_and_ps(values, sign_mask);
-    auto factor = _mm256_or_ps(scalar, sign);
-
-    auto a_a = _mm256_xor_ps(_mm256_moveldup_ps(values), sign_mask);   // a             -a
-    auto res_re_im = _mm256_sqrt_ps(_mm256_add_ps(abs_(), a_a));       // sqrt(abs + a) sqrt(abs - a)
-    return _mm256_mul_ps(factor, res_re_im);
+    return map(std::sqrt);
   }
   Vec256<c10::complex<float>> reciprocal() const;
   Vec256<c10::complex<float>> rsqrt() const {

--- a/aten/src/ATen/test/vec256_test_all_types.h
+++ b/aten/src/ATen/test/vec256_test_all_types.h
@@ -1211,22 +1211,7 @@ std::enable_if_t<!is_complex<T>::value, T> local_sqrt(T x) {
 
 template <typename T>
 std::enable_if_t<is_complex<Complex<T>>::value, Complex<T>> local_sqrt(Complex<T> x) {
-#if defined(TEST_AGAINST_DEFAULT)
     return std::sqrt(x);
-#else 
-    PreventFma noFma;
-    // sqrt(2) / 2 * [sqrt(abs() + a) + sgn(b) * sqrt(abs() - a)i]
-    T real = x.real();
-    T imag = x.imag();
-    T abs = local_abs(x).real();
-    T sqrt2_2 = std::sqrt(static_cast<T>(2)) / static_cast<T>(2);
-    T abs_r = noFma.add(abs, real);
-    T abs_i = noFma.sub(abs, real);
-    T res_r = sqrt2_2 * std::sqrt(abs_r);
-    T res_i = sqrt2_2 * std::sqrt(abs_i);
-    if (std::signbit(imag)) res_i = -res_i;
-    return Complex<T>(res_r, res_i);
-#endif
 }
 
 template <typename T>
@@ -1236,26 +1221,7 @@ std::enable_if_t<!is_complex<T>::value, T> local_asin(T x) {
 
 template <typename T>
 std::enable_if_t<is_complex<Complex<T>>::value, Complex<T>> local_asin(Complex<T> x) {
-#if defined(TEST_AGAINST_DEFAULT)
     return std::asin(x);
-#else
-    // asin(x)
-    // = -i*ln(iz + sqrt(1 -z^2))
-    // = -i*ln((ai - b) + sqrt(1 - (a + bi)*(a + bi)))
-    // = -i*ln((-b + ai) + sqrt(1 - (a**2 - b**2) - 2*abi))
-    PreventFma noFma;
-    T a = x.real();
-    T b = x.imag();
-    T aa = a * a;
-    T bb = b * b;
-    T _ab = a * (-b);
-    T _2ab = noFma.add(_ab, _ab);
-    T aa_bb = static_cast<T>(1) - noFma.sub(aa, bb); // 1 - (a*a-b*b)
-    Complex<T> temp = Complex<T>(-b, a) + local_sqrt(Complex<T>(aa_bb, _2ab));
-    auto ln = std::log(temp);
-    //-i*ln() => -i * ln => (ln.imag, -ln.real)
-    return Complex<T>(ln.imag(), -ln.real());
-#endif
 }
 
 template <typename T>
@@ -1265,13 +1231,7 @@ std::enable_if_t<!is_complex<T>::value, T> local_acos(T x) {
 
 template <typename T>
 std::enable_if_t<is_complex<Complex<T>>::value, Complex<T>> local_acos(Complex<T> x) {
-#if defined(TEST_AGAINST_DEFAULT)
     return std::acos(x);
-#else
-    // pi/2 - asin(x) 
-    auto half_pi = static_cast<T>(M_PI) / static_cast<T>(2);
-    return Complex<T>(half_pi, 0) - local_asin(x);
-#endif
 }
 
 template<typename T>

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -19744,6 +19744,14 @@ else:
         self.assertEqual(x / s, x / y)
         self.assertEqual(s / x, y / x)
 
+    @dtypes(torch.cfloat, torch.cdouble)
+    def test_sqrt_complex_edge_values(self, device, dtype):
+        x = torch.tensor(0. - 1.0000e+20j, dtype=dtype, device=device)
+        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
+
+        x = torch.tensor(-1.0000e+20 - 4988429.2000j, dtype=dtype, device=device)
+        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
+
 # Tests that compare a device's computation with the (gold-standard) CPU's.
 class TestDevicePrecision(TestCase):
     exact_dtype = True

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -19744,14 +19744,6 @@ else:
         self.assertEqual(x / s, x / y)
         self.assertEqual(s / x, y / x)
 
-    @dtypes(torch.cfloat, torch.cdouble)
-    def test_sqrt_complex_edge_values(self, device, dtype):
-        x = torch.tensor(0. - 1.0000e+20j, dtype=dtype, device=device)
-        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
-
-        x = torch.tensor(-1.0000e+20 - 4988429.2000j, dtype=dtype, device=device)
-        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
-
 # Tests that compare a device's computation with the (gold-standard) CPU's.
 class TestDevicePrecision(TestCase):
     exact_dtype = True

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -9,7 +9,7 @@ import torch
 
 from torch.testing._internal.common_utils import \
     (TestCase, run_tests, torch_to_numpy_dtype_dict, suppress_warnings,
-     TEST_NUMPY, make_tensor)
+     TEST_NUMPY, IS_MACOS, make_tensor)
 from torch.testing._internal.common_methods_invocations import \
     (unary_ufuncs)
 from torch.testing._internal.common_device_type import \
@@ -479,6 +479,16 @@ class TestUnaryUfuncs(TestCase):
             result = torch.nan_to_num(x, nan=nan, posinf=posinf, neginf=neginf)
             torch.nan_to_num(x, out=out, nan=nan, posinf=posinf, neginf=neginf)
             self.assertEqual(result, out)
+
+    @unittest.skipIf(IS_MACOS, "Skip Reference: https://github.com/pytorch/pytorch/issues/47500")
+    @dtypes(torch.cfloat, torch.cdouble)
+    def test_sqrt_complex_edge_values(self, device, dtype):
+        # Test Reference: https://github.com/pytorch/pytorch/pull/47424
+        x = torch.tensor(0. - 1.0000e+20j, dtype=dtype, device=device)
+        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
+
+        x = torch.tensor(-1.0000e+20 - 4988429.2000j, dtype=dtype, device=device)
+        self.compare_with_numpy(torch.sqrt, np.sqrt, x)
 
 instantiate_device_type_tests(TestUnaryUfuncs, globals())
 


### PR DESCRIPTION
Fixes #47358 

Replace the optimized path with a slower but correct `map(std::sqrt)`

Benchmark posted below in comments.

cc: @dylanbespalko (original author of fast-path)