### PR TITLE
[NNC] Simplify and fix some bugs in Bounds Inference

### DIFF
--- a/test/cpp/tensorexpr/test_boundsinference.cpp
+++ b/test/cpp/tensorexpr/test_boundsinference.cpp
@@ -324,67 +324,6 @@ void testBoundsInference_6() {
   }
 }
 
-void testBoundsInferenceNonOverlapping() {
-  KernelScope kernel_scope;
-  ExprHandle H(3);
-  Placeholder a(BufHandle("a", {10}, kFloat));
-  Tensor* b =
-      Compute("b", {{H, "x"}}, [&](const VarHandle& x) { return a.load(x); });
-  Tensor* c = Compute(
-      "c", {{H, "x"}}, [&](const VarHandle& x) { return a.load(x + H + 1); });
-  LoopNest l({b, c});
-  std::vector<For*> loops = NodeFinder<For>::find(l.root_stmt());
-
-  {
-    // Infer bounds on the top-level loop scope
-    auto bounds_info = inferBounds(loops[0]);
-    ASSERT_EQ(bounds_info.size(), 2);
-
-    // reads from a[0:2], writes to b[0:2]
-    ASSERT_EQ(bounds_info.at(a.data()).size(), 1);
-    ASSERT_EQ(bounds_info.at(a.data())[0].kind, kLoad);
-    verifyConstBounds(bounds_info.at(a.data())[0], {{0, 2}});
-
-    ASSERT_EQ(bounds_info.at(b->buf()).size(), 1);
-    ASSERT_EQ(bounds_info.at(b->buf())[0].kind, kStore);
-    verifyConstBounds(bounds_info.at(b->buf())[0], {{0, 2}});
-  }
-  {
-    // Infer bounds on the inner loop scope
-    auto bounds_info = inferBounds(loops[1]);
-    ASSERT_EQ(bounds_info.size(), 2);
-
-    // reads from a[0+4:2+4], writes to c[0:2]
-    ASSERT_EQ(bounds_info.at(a.data()).size(), 1);
-    ASSERT_EQ(bounds_info.at(a.data())[0].kind, kLoad);
-    verifyConstBounds(bounds_info.at(a.data())[0], {{4, 6}});
-
-    ASSERT_EQ(bounds_info.at(c->buf()).size(), 1);
-    ASSERT_EQ(bounds_info.at(c->buf())[0].kind, kStore);
-    verifyConstBounds(bounds_info.at(c->buf())[0], {{0, 2}});
-  }
-  {
-    // Infer bounds on the high level program.
-    auto bounds_info = inferBounds(l.root_stmt());
-    ASSERT_EQ(bounds_info.size(), 3);
-
-    // Should be union of above 2 bounds.
-    ASSERT_EQ(bounds_info.at(a.data()).size(), 2);
-    ASSERT_EQ(bounds_info.at(a.data())[0].kind, kLoad);
-    verifyConstBounds(bounds_info.at(a.data())[0], {{0, 2}});
-    ASSERT_EQ(bounds_info.at(a.data())[0].kind, kLoad);
-    verifyConstBounds(bounds_info.at(a.data())[1], {{4, 6}});
-
-    ASSERT_EQ(bounds_info.at(b->buf()).size(), 1);
-    ASSERT_EQ(bounds_info.at(b->buf())[0].kind, kStore);
-    verifyConstBounds(bounds_info.at(b->buf())[0], {{0, 2}});
-
-    ASSERT_EQ(bounds_info.at(c->buf()).size(), 1);
-    ASSERT_EQ(bounds_info.at(c->buf())[0].kind, kStore);
-    verifyConstBounds(bounds_info.at(c->buf())[0], {{0, 2}});
-  }
-}
-
 void testBoundsInferenceAdjacent() {
   KernelScope kernel_scope;
   ExprHandle H(6);
@@ -445,382 +384,213 @@ void testBoundsInferenceAdjacent() {
   }
 }
 
-void testMergeInferredBounds() {
+void testBoundsInferenceMultipleTopLoopLoad() {
   KernelScope kernel_scope;
-  Placeholder a(BufHandle("a", {10}, kFloat));
+  Placeholder a(BufHandle("a", {100}, kFloat));
+  Tensor* b =
+      Compute("b", {{64, "x"}}, [&](const VarHandle& x) { return a.load(x); });
+  Tensor* c = Compute(
+      "c", {{32, "x"}}, [&](const VarHandle& x) { return a.load(x + 10); });
+  Tensor* d = Compute(
+      "d", {{96, "x"}}, [&](const VarHandle& x) { return a.load(x + 2); });
+  LoopNest l({b, c, d});
 
-  // There are seven cases to consider in mergeTensorAccesses(A, B)
-  //   * A is lower than B and does not overlap.
-  //   * A is higher than B and does not overlap.
-  //   * A overlaps B on both ends.
-  //   * B overlaps A on both ends.
-  //   * A overlaps B on the lower end. (equiv to B overlaps A on upper end).
-  //   * A overlaps B on the upper end. (likewise covers reverse)
-  //   * A and B are the same range.
+  auto bounds_info = inferBounds(l.root_stmt());
 
-  BoundsInfo info;
-  // Test no overlap, both ways.
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(3)}});
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {new IntImm(7)}});
-  info[a.data()].push_back({kLoad, {new IntImm(9)}, {new IntImm(9)}});
-  BoundsInfo res = mergeTensorAccesses(info);
-  ASSERT_EQ(res.size(), 1);
-  ASSERT_EQ(res[a.data()].size(), 3);
+  ASSERT_EQ(bounds_info.size(), 4);
 
-  ASSERT_EQ(res.at(a.data())[0].kind, kLoad);
-  ASSERT_EQ(res.at(a.data())[1].kind, kLoad);
-  ASSERT_EQ(res.at(a.data())[2].kind, kLoad);
-  verifyConstBounds(res.at(a.data())[0], {{1, 3}});
-  verifyConstBounds(res.at(a.data())[1], {{5, 7}});
-  verifyConstBounds(res.at(a.data())[2], {{9, 9}});
+  // a only read.
+  {
+    auto bounds = bounds_info[a.data()];
+    ASSERT_EQ(bounds.size(), 1);
+    // One dimension.
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kLoad);
+    // Bounds:
+    // start: Min of the 3 load bounds = Min of loop starts + offset = 0+0 (b).
+    // stop: Max of the 3 load bounds = Max of loop stops + offset - 1 =
+    //       96 + 2 - 1 (d).
+    verifyConstBounds(bound, {{0, 97}});
+  }
 
-  // Test full overlap, A over B.
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(7)}});
-  info[a.data()].push_back({kLoad, {new IntImm(3)}, {new IntImm(6)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{1, 7}});
-
-  // B over A.
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(3)}, {new IntImm(6)}});
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(7)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{1, 7}});
-
-  // Test partial overlap on the low end, A over B.
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {new IntImm(7)}});
-  info[a.data()].push_back({kLoad, {new IntImm(3)}, {new IntImm(6)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{3, 7}});
-
-  // Test partial overlap on the high end.
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(2)}, {new IntImm(5)}});
-  info[a.data()].push_back({kLoad, {new IntImm(4)}, {new IntImm(6)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{2, 6}});
-
-  // Test equality is deduped.
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(4)}, {new IntImm(6)}});
-  info[a.data()].push_back({kLoad, {new IntImm(4)}, {new IntImm(6)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{4, 6}});
+  // b, c, d only written.
+  {
+    auto bounds = bounds_info[b->buf()];
+    ASSERT_EQ(bounds.size(), 1);
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kStore);
+    // Just the loop extents for b.
+    verifyConstBounds(bound, {{0, 63}});
+  }
+  {
+    auto bounds = bounds_info[c->buf()];
+    ASSERT_EQ(bounds.size(), 1);
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kStore);
+    // Just the loop extents for c.
+    verifyConstBounds(bound, {{0, 31}});
+  }
+  {
+    auto bounds = bounds_info[d->buf()];
+    ASSERT_EQ(bounds.size(), 1);
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kStore);
+    // Just the loop extents for d.
+    verifyConstBounds(bound, {{0, 95}});
+  }
 }
 
-void testMergeInferredLoadStoreDiff() {
+void testBoundsInferenceMultipleTopLoopStore() {
   KernelScope kernel_scope;
-  Placeholder a(BufHandle("a", {10}, kFloat));
+  BufHandle a("a", {100}, kFloat);
+  BufHandle b("b", {100}, kFloat);
+  BufHandle c("c", {100}, kFloat);
+  BufHandle d("d", {100}, kFloat);
+  VarHandle x("x", kInt);
 
-  // Loads and Stores do not merge:
-  BoundsInfo info;
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(7)}});
-  info[a.data()].push_back({kStore, {new IntImm(3)}, {new IntImm(9)}});
+  // Same as above but the offsets are on the Store now.
+  // Can't do this through ComputeAPI without transforms we don't have yet.
+  Stmt* stmt = Block::make(
+      {For::make(x, 0, 64, Store::make(b, {x}, Load::make(a, {x}, 1), 1)),
+       For::make(x, 0, 32, Store::make(c, {x + 10}, Load::make(a, {x}, 1), 1)),
+       For::make(x, 0, 96, Store::make(d, {x + 2}, Load::make(a, {x}, 1), 1))});
 
-  BoundsInfo res = mergeTensorAccesses(info);
-  ASSERT_EQ(res.size(), 1);
-  ASSERT_EQ(res[a.data()].size(), 2);
-  ASSERT_EQ(res.at(a.data())[0].kind, kLoad);
-  ASSERT_EQ(res.at(a.data())[1].kind, kStore);
-  verifyConstBounds(res.at(a.data())[0], {{1, 7}});
-  verifyConstBounds(res.at(a.data())[1], {{3, 9}});
+  auto bounds_info = inferBounds(stmt);
 
-  // Do merge around the other kind of access:
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(3)}});
-  info[a.data()].push_back({kStore, {new IntImm(3)}, {new IntImm(4)}});
-  info[a.data()].push_back({kLoad, {new IntImm(3)}, {new IntImm(5)}});
-  info[a.data()].push_back({kStore, {new IntImm(4)}, {new IntImm(8)}});
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {new IntImm(7)}});
-  res = mergeTensorAccesses(info);
+  ASSERT_EQ(bounds_info.size(), 4);
 
-  ASSERT_EQ(res[a.data()].size(), 2);
-  verifyConstBounds(res.at(a.data())[0], {{1, 7}});
-  verifyConstBounds(res.at(a.data())[1], {{3, 8}});
+  // a only read.
+  {
+    auto bounds = bounds_info[a.node()];
+    ASSERT_EQ(bounds.size(), 1);
+    // One dimension.
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kLoad);
+    // Bounds: there are no offsets, so this is just the max loop bounds.
+    verifyConstBounds(bound, {{0, 95}});
+  }
+
+  // b, c, d only written.
+  {
+    auto bounds = bounds_info[b.node()];
+    ASSERT_EQ(bounds.size(), 1);
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kStore);
+    // This should be equivalent to {offset, extent + offset} for the b loop.
+    // b loop has no offset, so just the loop extents.
+    verifyConstBounds(bound, {{0, 63}});
+  }
+  {
+    auto bounds = bounds_info[c.node()];
+    ASSERT_EQ(bounds.size(), 1);
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kStore);
+    // This should be equivalent to {offset, extent + offset} for the c loop.
+    // Offset is 10, extent is 32-1.
+    verifyConstBounds(bound, {{10, 41}});
+  }
+  {
+    auto bounds = bounds_info[d.node()];
+    ASSERT_EQ(bounds.size(), 1);
+    auto bound = bounds[0];
+    ASSERT_EQ(bound.kind, TensorAccessKind::kStore);
+    // This should be equivalent to {offset, extent + offset} for the d loop.
+    // Offset is 2, extent is 96-1.
+    verifyConstBounds(bound, {{2, 97}});
+  }
 }
 
-void testMergeInferred2DBounds() {
+void testBoundsInferenceCacheReads() {
   KernelScope kernel_scope;
-  Placeholder a(BufHandle("a", {10, 10}, kFloat));
 
-  // Non overlapping in both dimensions:
-  BoundsInfo info;
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(1), new IntImm(1)}, {new IntImm(3), new IntImm(3)}});
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(5), new IntImm(5)}, {new IntImm(9), new IntImm(9)}});
+  Tensor* A = Compute(
+      "A", {{64, "i"}, {64, "j"}}, [](const VarHandle& i, const VarHandle& j) {
+        return i * j;
+      });
+  Tensor* B = Compute(
+      "B", {{20, "i"}, {10, "j"}}, [&](const VarHandle& i, const VarHandle& j) {
+        return A->call(i + 30, j + 3);
+      });
+  Tensor* C = Compute(
+      "C", {{20, "i"}, {10, "j"}}, [&](const VarHandle& i, const VarHandle& j) {
+        return A->call(i + 10, j + 20) + A->call(i + 30, j + 40);
+      });
 
-  BoundsInfo res = mergeTensorAccesses(info);
-  ASSERT_EQ(res.size(), 1);
-  ASSERT_EQ(res[a.data()].size(), 2);
-  ASSERT_EQ(res.at(a.data())[0].kind, kLoad);
-  ASSERT_EQ(res.at(a.data())[1].kind, kLoad);
-  verifyConstBounds(res.at(a.data())[0], {{1, 3}, {1, 3}});
-  verifyConstBounds(res.at(a.data())[1], {{5, 9}, {5, 9}});
+  LoopNest l({B, C});
+  auto bounds_info_before = inferBounds(l.root_stmt());
 
-  // Overlapping in a single dimension should mean we cannot merge.
-  // First dimension:
-  info.clear();
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(1), new IntImm(1)}, {new IntImm(3), new IntImm(3)}});
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(2), new IntImm(5)}, {new IntImm(9), new IntImm(9)}});
+  Stmt* j_loop = l.getLoopStmtsFor(B)[1];
+  l.cacheAccesses(A->buf(), "A_local", j_loop);
 
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-  verifyConstBounds(res.at(a.data())[0], {{1, 3}, {1, 3}});
-  verifyConstBounds(res.at(a.data())[1], {{2, 9}, {5, 9}});
+  auto bounds_info_after = inferBounds(l.root_stmt());
 
-  // Second dimension:
-  info.clear();
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(1), new IntImm(1)}, {new IntImm(3), new IntImm(3)}});
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(5), new IntImm(2)}, {new IntImm(9), new IntImm(9)}});
+  // CacheAccesses should not change existing bounds, but add a new one for the
+  // cache.
+  for (auto& pair : bounds_info_after) {
+    auto beforeIt = bounds_info_before.find(pair.first);
+    if (beforeIt != bounds_info_before.end()) {
+      // Same number of TensorAccessBoundInfos.
+      ASSERT_EQ(pair.second.size(), beforeIt->second.size());
 
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-  verifyConstBounds(res.at(a.data())[0], {{1, 3}, {1, 3}});
-  verifyConstBounds(res.at(a.data())[1], {{5, 9}, {2, 9}});
+      for (size_t i = 0; i < pair.second.size(); ++i) {
+        TensorAccessBoundsInfo& after = pair.second[i];
+        TensorAccessBoundsInfo& before = beforeIt->second[i];
+        // Same number of dimensions.
+        ASSERT_EQ(before.start.size(), after.start.size());
 
-  // Overlapping in both dimensions:
-  // {1-6, 1-3) | {4-9, 2,7} => {1,9, 1,7}
-  // TODO: this will overestimate and we should fix it.
-  info.clear();
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(1), new IntImm(1)}, {new IntImm(6), new IntImm(3)}});
-  info[a.data()].push_back(
-      {kLoad, {new IntImm(4), new IntImm(2)}, {new IntImm(9), new IntImm(7)}});
+        // Bounds are equal.
+        for (size_t j = 0; j < before.start.size(); ++j) {
+          ASSERT_TRUE(exprEquals(before.start[j], after.start[j]));
+          ASSERT_TRUE(exprEquals(before.stop[j], after.stop[j]));
+        }
+      }
+    } else {
+      // This should be the cache.
+      ASSERT_EQ(pair.first->name_hint(), "A_local");
+      // Should have both a load and a store.
+      ASSERT_EQ(pair.second.size(), 2);
+      TensorAccessBoundsInfo& first = pair.second[0];
+      TensorAccessBoundsInfo& second = pair.second[1];
 
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{1, 9}, {1, 7}});
+      ASSERT_NE(first.kind, second.kind);
+      // 2 dimensions.
+      ASSERT_EQ(first.start.size(), second.start.size());
+      ASSERT_EQ(first.start.size(), 2);
+
+      // bounds for load and store are equal.
+      for (size_t j = 0; j < first.start.size(); ++j) {
+        ASSERT_TRUE(exprEquals(first.start[j], second.start[j]));
+        ASSERT_TRUE(exprEquals(first.stop[j], second.stop[j]));
+      }
+    }
+  }
 }
 
-void testMergeAdjacentBounds() {
+void testBoundsInferenceFlattened() {
   KernelScope kernel_scope;
-  Placeholder a(BufHandle("a", {10}, kFloat));
+  Tensor* b = Compute(
+      "b",
+      {{3, "z"}, {4, "y"}, {5, "x"}},
+      [&](const VarHandle& z, const VarHandle& y, const VarHandle& x) {
+        return x * y + z;
+      });
 
-  // Adjacent but not overlapping bounds can be merged.
-  // e.g. {1-4} | {5-9} => {1-9}
-  BoundsInfo info;
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(4)}});
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {new IntImm(9)}});
-  BoundsInfo res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{1, 9}});
+  LoopNest l({b});
+  // Flatten indices.
+  l.prepareForCodegen();
+  auto bounds_info = inferBounds(l.root_stmt());
 
-  // And on the other side:
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {new IntImm(9)}});
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(4)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  verifyConstBounds(res.at(a.data())[0], {{1, 9}});
+  // There's only one buffer.
+  ASSERT_EQ(bounds_info.size(), 1);
+  auto& TABI = bounds_info[b->buf()][0];
+  ASSERT_EQ(TABI.kind, TensorAccessKind::kStore);
+  // Flattened bounds should have a single dimension.
+  ASSERT_EQ(TABI.start.size(), 1);
+  ASSERT_EQ(TABI.stop.size(), 1);
 
-  // One space gap is enough to prevent merging:
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(1)}, {new IntImm(4)}});
-  info[a.data()].push_back({kLoad, {new IntImm(6)}, {new IntImm(9)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-  verifyConstBounds(res.at(a.data())[0], {{1, 4}});
-  verifyConstBounds(res.at(a.data())[1], {{6, 9}});
-}
-
-std::pair<std::string, std::string> boundAsStringPair(
-    TensorAccessBoundsInfo& info,
-    size_t idx = 0) {
-  std::ostringstream start, stop;
-  start << *info.start[idx];
-  stop << *info.stop[idx];
-  return {start.str(), stop.str()};
-}
-
-void testMergeSymbolicBounds() {
-  KernelScope kernel_scope;
-  Placeholder a(BufHandle("a", {10}, kFloat));
-  VarHandle W("W", kInt);
-  VarHandle X("X", kInt);
-  VarHandle Y("Y", kInt);
-  VarHandle Z("Z", kInt);
-
-  // Can do nothing with fully symbolic bounds:
-  BoundsInfo info;
-  info[a.data()].push_back({kLoad, {W.node()}, {Z.node()}});
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  BoundsInfo res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-
-  // Can merge if the difference between bounds is constant and enclosing.
-  // {X-Y} | {X-5 - Y+10} => {X-5 - Y+10}
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  info[a.data()].push_back({kLoad,
-                            {new Sub(X.node(), new IntImm(5))},
-                            {new Add(Y.node(), new IntImm(10))}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-
-  // Cannot merge otherwise.
-  // {X-Y} | {X+5 - Y+10} => could be 2 groups if Y < X+5.
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  info[a.data()].push_back({kLoad,
-                            {new Add(X.node(), new IntImm(5))},
-                            {new Add(Y.node(), new IntImm(10))}});
-
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-
-  // Can't merge if there's a gap of at least one element:
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(4)}});
-  info[a.data()].push_back({kLoad, {new IntImm(6)}, {Y.node()}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-
-  // Can't even though the high of the first bound is above the low of the
-  // second, X can == 6 and Y can == 4 so this can't merge in all cases.
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(6)}});
-  info[a.data()].push_back({kLoad, {new IntImm(4)}, {Y.node()}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-
-  // If either side is equal, they must be overlapping.
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {Z.node()}});
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  auto pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "X");
-  ASSERT_EQ(pair.second, "Max(Y, Z, 1)");
-
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  info[a.data()].push_back({kLoad, {Z.node()}, {Y.node()}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "Min(X, Z, 1)");
-  ASSERT_EQ(pair.second, "Y");
-
-  // If either side is only one apart, they must be adjacent.
-  info.clear();
-  info[a.data()].push_back(
-      {kLoad, {new Add(X.node(), new IntImm(1))}, {Z.node()}});
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "X");
-  ASSERT_EQ(pair.second, "Max(Y, Z, 1)");
-
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  info[a.data()].push_back(
-      {kLoad, {Z.node()}, {new Sub(Y.node(), new IntImm(1))}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "Min(X, Z, 1)");
-  ASSERT_EQ(pair.second, "Y");
-
-  // If either side is 2 apart, they may not be overlapping.
-  // in this case if Y == X+1 they don't overlap.
-  info.clear();
-  info[a.data()].push_back(
-      {kLoad, {new Add(X.node(), new IntImm(2))}, {Z.node()}});
-  info[a.data()].push_back(
-      {kLoad, {X.node()}, {new Sub(Y.node(), new IntImm(1))}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-
-  // In this case they may not overlap if X == Y.
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {Y.node()}});
-  info[a.data()].push_back(
-      {kLoad, {Z.node()}, {new Sub(Y.node(), new IntImm(2))}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 2);
-}
-
-void testMergeSymbolicAdjacent() {
-  KernelScope kernel_scope;
-  Placeholder a(BufHandle("a", {10}, kFloat));
-  VarHandle X("X", kInt);
-  VarHandle Y("Y", kInt);
-
-  BoundsInfo info;
-  // Can merge if a range is adjacent:
-  // {X-5} | {6-Y} => {X-Y}
-  info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(5)}});
-  info[a.data()].push_back({kLoad, {new IntImm(6)}, {Y.node()}});
-  BoundsInfo res = mergeTensorAccesses(info);
-
-  ASSERT_EQ(res[a.data()].size(), 1);
-  auto pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "X");
-  ASSERT_EQ(pair.second, "Y");
-
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(6)}, {Y.node()}});
-  info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(5)}});
-  res = mergeTensorAccesses(info);
-
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "X");
-  ASSERT_EQ(pair.second, "Y");
-
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {Y.node()}});
-  info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(6)}});
-  res = mergeTensorAccesses(info);
-
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "X");
-  ASSERT_EQ(pair.second, "Y");
-
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(6)}});
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {Y.node()}});
-  res = mergeTensorAccesses(info);
-
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "X");
-  ASSERT_EQ(pair.second, "Y");
-
-  // If either the lower or upper bound is adjacent the range then they must
-  // overlap, even if we don't know the extent.
-  info.clear();
-  info[a.data()].push_back({kLoad, {new IntImm(6)}, {X.node()}});
-  info[a.data()].push_back({kLoad, {new IntImm(5)}, {Y.node()}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "5");
-  ASSERT_EQ(pair.second, "Max(X, Y, 1)");
-
-  info.clear();
-  info[a.data()].push_back({kLoad, {X.node()}, {new IntImm(6)}});
-  info[a.data()].push_back({kLoad, {Y.node()}, {new IntImm(5)}});
-  res = mergeTensorAccesses(info);
-  ASSERT_EQ(res[a.data()].size(), 1);
-  pair = boundAsStringPair(res[a.data()][0]);
-  ASSERT_EQ(pair.first, "Min(X, Y, 1)");
-  ASSERT_EQ(pair.second, "6");
+  // Bounds should be 0 -> (3*4*5)-1
+  ASSERT_TRUE(exprEquals(TABI.start[0], new IntImm(0)));
+  ASSERT_TRUE(exprEquals(TABI.stop[0], new IntImm(3 * 4 * 5 - 1)));
 }
 
 } // namespace jit

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -307,14 +307,11 @@ namespace jit {
   _(BoundsInference_4)                              \
   _(BoundsInference_5)                              \
   _(BoundsInference_6)                              \
-  _(BoundsInferenceNonOverlapping)                  \
   _(BoundsInferenceAdjacent)                        \
-  _(MergeInferredBounds)                            \
-  _(MergeInferredLoadStoreDiff)                     \
-  _(MergeInferred2DBounds)                          \
-  _(MergeAdjacentBounds)                            \
-  _(MergeSymbolicBounds)                            \
-  _(MergeSymbolicAdjacent)                          \
+  _(BoundsInferenceMultipleTopLoopLoad)             \
+  _(BoundsInferenceMultipleTopLoopStore)            \
+  _(BoundsInferenceCacheReads)                      \
+  _(BoundsInferenceFlattened)                       \
   _(BoundOverlap)                                   \
   _(BoundOverlapSymbolic)                           \
   _(BoundOverlapMultiDim)                           \

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -10,76 +10,84 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
-class BoundsInference : public IRVisitor {
- public:
-  void visit(const FunctionCall* v) override;
-  void visit(const Load* v) override;
-  void visit(const Store* v) override;
-  void visit(const ReduceOp* v) override;
-  void visit(const For* v) override;
-  void visit(const Block* v) override;
+using namespace analysis;
 
-  BoundsInfo accesses() const {
-    return accesses_;
-  }
+BoundsInfo mergeTensorAccesses(
+    const std::deque<std::shared_ptr<AccessInfo>>& accesses,
+    const std::unordered_map<const Var*, const Buf*>& varToBuf,
+    bool distinctAccessKinds) {
+  BoundsInfo ret;
+  for (auto& access : accesses) {
+    if (access->type() == AccessType::Input ||
+        access->type() == AccessType::Output) {
+      continue;
+    }
 
- private:
-  BoundsInfo accesses_;
-};
+    auto vtbIt = varToBuf.find(access->var());
+    TORCH_INTERNAL_ASSERT(vtbIt != varToBuf.end());
+    const Buf* buf = vtbIt->second;
+    std::vector<TensorAccessBoundsInfo>& infos = ret[buf];
 
-void BoundsInference::visit(const Load* v) {
-  accesses_[v->buf()].push_back({kLoad, v->indices(), v->indices()});
-}
+    bool added = false;
+    // This loop should be small, max of 2 (kLoad, kStore).
+    for (auto& TABI : infos) {
+      TensorAccessKind kind = access->isWrite() ? kStore : kLoad;
+      if (!distinctAccessKinds || kind == TABI.kind) {
+        TORCH_INTERNAL_ASSERT(TABI.start.size() == access->bounds().size());
+        TORCH_INTERNAL_ASSERT(TABI.stop.size() == access->bounds().size());
+        for (size_t i = 0; i < TABI.start.size(); ++i) {
+          TABI.start[i] = IRSimplifier::simplify(
+              new Min(TABI.start[i], access->bounds()[i].start, true));
+          TABI.stop[i] = IRSimplifier::simplify(
+              new Max(TABI.stop[i], access->bounds()[i].end, true));
+          added = true;
 
-void BoundsInference::visit(const FunctionCall* v) {
-  accesses_[v->tensor()->buf()].push_back({kLoad, v->params(), v->params()});
-}
-
-void BoundsInference::visit(const Store* v) {
-  accesses_[v->buf()].push_back({kStore, v->indices(), v->indices()});
-  IRVisitor::visit(v);
-}
-
-void BoundsInference::visit(const ReduceOp* v) {
-  accesses_[v->accumulator()].push_back(
-      {kLoad, v->output_args(), v->output_args()});
-  IRVisitor::visit(v);
-}
-
-void BoundsInference::visit(const For* v) {
-  v->body()->accept(this);
-  for (auto& pair : accesses_) {
-    for (TensorAccessBoundsInfo& access : pair.second) {
-      for (size_t j = 0; j < access.start.size(); j++) {
-        // TODO: This function assumes that all indices grow monotonically and
-        // thus for the loop:
-        //   for i in A..B:
-        //     buf[i] = i
-        // the range for i is [A, B). It should be generalized to correctly
-        // handle all cases.
-        const Expr* old_start = access.start[j];
-        const Expr* old_stop = access.stop[j];
-        const Expr* new_start = Substitute(old_start, {{v->var(), v->start()}});
-        const Expr* new_stop = Substitute(
-            old_stop, {{v->var(), new Sub(v->stop(), new IntImm(1))}});
-
-        access.start[j] = IRSimplifier::simplify(new_start);
-        access.stop[j] = IRSimplifier::simplify(new_stop);
+          if (kind != TABI.kind) {
+            TABI.kind = kMutate;
+          }
+        }
       }
     }
-  }
-}
 
-void BoundsInference::visit(const Block* v) {
-  BoundsInfo res;
-  for (auto s : *v) {
-    s->accept(this);
-    for (auto& pair : accesses_) {
-      res[pair.first].insert(
-          res[pair.first].end(), pair.second.begin(), pair.second.end());
+    if (!added) {
+      TensorAccessBoundsInfo info;
+      info.kind = access->isWrite() ? kStore : kLoad;
+
+      for (auto& b : access->bounds()) {
+        info.start.push_back(b.start);
+        info.stop.push_back(b.end);
+      }
+
+      infos.push_back(info);
     }
   }
-  accesses_ = res;
+
+  return ret;
+}
+
+std::unordered_map<const Var*, const Buf*> getAllBufs(Stmt* s) {
+  std::unordered_map<const Var*, const Buf*> varToBuf;
+
+  auto bufs = NodeFinder<const Buf>::find(s);
+  auto calls = NodeFinder<FunctionCall>::find(s);
+  for (auto* c : calls) {
+    bufs.push_back(c->tensor()->buf());
+  }
+
+  for (auto* b : bufs) {
+    varToBuf[b->base_handle()] = b;
+  }
+  return varToBuf;
+}
+
+BoundsInfo inferBounds(Stmt* s, bool distinctAccessKinds) {
+  auto varToBuf = getAllBufs(s);
+
+  MemDependencyChecker checker;
+  s->accept(&checker);
+
+  return mergeTensorAccesses(
+      checker.getHistory(), varToBuf, distinctAccessKinds);
 }
 
 void printBoundsInfo(const BoundsInfo& v) {
@@ -123,146 +131,39 @@ void printBoundsInfo(const BoundsInfo& v) {
   std::cerr << "}\n";
 }
 
-bool equalExprs(const Expr* A, const Expr* B) {
-  const Expr* diff = IRSimplifier::simplify(new Sub(B, A));
-  return diff->isConstant() && immediateEquals(diff, 0);
-}
+std::vector<const Expr*> getBoundExtents(
+    const std::vector<TensorAccessBoundsInfo>& infos) {
+  std::vector<const Expr*> starts;
+  std::vector<const Expr*> stops;
 
-// returns the bounds of an overlapping range, or {nullptr, nullptr} if the
-// ranges don't overlap.
-std::pair<const Expr*, const Expr*> rangeOverlap(
-    const Expr* s1,
-    const Expr* e1,
-    const Expr* s2,
-    const Expr* e2) {
-  // If they're equal they're equal.
-  if (equalExprs(s1, s2) && equalExprs(e1, e2)) {
-    return {s1, e1};
-  }
-
-  std::pair<const Expr*, const Expr*> noOverlap = {nullptr, nullptr};
-  std::pair<const Expr*, const Expr*> overlap = {
-      IRSimplifier::simplify(new Min(s1, s2, true)),
-      IRSimplifier::simplify(new Max(e1, e2, true))};
-
-  const Expr* lowDiff = IRSimplifier::simplify(new Sub(s1, e2));
-  const Expr* highDiff = IRSimplifier::simplify(new Sub(s2, e1));
-  if (lowDiff->isConstant() && highDiff->isConstant()) {
-    // No overlap.
-    if (!(immediateAs<int>(lowDiff) <= 1 || immediateAs<int>(highDiff) >= 1)) {
-      return noOverlap;
-    }
-
-    return overlap;
-  }
-
-  // Can still merge if we can infer adjacency without knowing static values:
-  // If we know one side, we can use the fact that each eX >= sX.
-  if (highDiff->isConstant() && abs(immediateAs<int>(highDiff)) <= 1) {
-    return {s1, e2};
-  }
-
-  if (lowDiff->isConstant() && abs(immediateAs<int>(lowDiff)) <= 1) {
-    return {s2, e1};
-  }
-
-  const Expr* diffs = IRSimplifier::simplify(new Sub(s2, s1));
-  const Expr* diffe = IRSimplifier::simplify(new Sub(e2, e1));
-
-  // If one side fully encloses the other, they're adjacent.
-  if (diffs->isConstant() && diffe->isConstant()) {
-    int ds_i = immediateAs<int>(diffs);
-    int de_i = immediateAs<int>(diffe);
-    if ((ds_i <= 0 && de_i >= 0) || (ds_i >= 0 && de_i <= 0)) {
-      return overlap;
-    }
-  }
-
-  // If either the start or end is 1 element apart from it's pair, they must
-  // be adjacent.
-  if (diffs->isConstant() && abs(immediateAs<int>(diffs)) <= 1) {
-    return overlap;
-  }
-
-  if (diffe->isConstant() && abs(immediateAs<int>(diffe)) <= 1) {
-    return overlap;
-  }
-
-  return noOverlap;
-}
-
-/*
- * Go through the given BoundsInfo vector and merge entries corresponding to
- * the same buf. E.g. given
- *    [{a, kLoad, 0, 100}, {b, kStore, 0, 100}, {a, kLoad, 10, 110}]
- * produce:
- *    [{a, kLoad, 0, 110}, {b, kStore, 0, 100}]
- */
-BoundsInfo mergeTensorAccesses(const BoundsInfo& unmerged) {
-  BoundsInfo res;
-  // For each buf in the BoundsInfo:
-  for (auto& pair : unmerged) {
-    const std::vector<TensorAccessBoundsInfo>& new_vec = pair.second;
-    std::vector<TensorAccessBoundsInfo>& existing_vec = res[pair.first];
-
-    // For each bound pair in the unmerged set:
-    for (const auto& new_bound : new_vec) {
-      bool found = false;
-      // For each already merged bound pair:
-      for (auto& existing_bound : existing_vec) {
-        // Only merge the same kind of access.
-        if (existing_bound.kind != new_bound.kind) {
-          continue;
-        }
-
-        // Sanity check the buf indices have the same dimensionality.
-        TORCH_INTERNAL_ASSERT(new_bound.start.size() == new_bound.stop.size());
-        TORCH_INTERNAL_ASSERT(
-            existing_bound.start.size() == existing_bound.stop.size());
-        TORCH_INTERNAL_ASSERT(
-            new_bound.start.size() == existing_bound.start.size());
-
-        std::vector<const Expr*> start;
-        std::vector<const Expr*> stop;
-        bool fail = false;
-        // For each dimension:
-        for (size_t i = 0; i < new_bound.start.size(); ++i) {
-          // The range of the new bound must overlap the existing bound.
-          // TODO(nickg): we allow all dimensions to partially overlap,
-          // which will overstate the bounds.
-          auto pair = rangeOverlap(
-              new_bound.start[i],
-              new_bound.stop[i],
-              existing_bound.start[i],
-              existing_bound.stop[i]);
-          if (pair.first == nullptr) {
-            fail = true;
-            break;
-          }
-          start.push_back(pair.first);
-          stop.push_back(pair.second);
-        }
-        if (fail) {
-          continue;
-        }
-        found = true;
-        // Update the existing bound.
-        existing_bound.start = start;
-        existing_bound.stop = stop;
+  // Find the safe size of the temprorary buffer by determining the outer
+  // extents of a union of all bounds.
+  for (const TensorAccessBoundsInfo& p : infos) {
+    for (size_t i = 0; i < p.start.size(); i++) {
+      if (starts.size() <= i) {
+        starts.push_back(p.start[i]);
+      } else {
+        starts[i] =
+            IRSimplifier::simplify(new Min(starts[i], p.start[i], true));
       }
-      if (!found) {
-        existing_vec.push_back(new_bound);
+
+      if (stops.size() <= i) {
+        stops.push_back(p.stop[i]);
+      } else {
+        stops[i] = IRSimplifier::simplify(new Max(stops[i], p.stop[i], true));
       }
     }
   }
 
-  return res;
-}
+  std::vector<const Expr*> extents;
+  for (size_t i = 0; i < starts.size(); ++i) {
+    const Expr* dim = IRSimplifier::simplify(
+        new Add(new Sub(stops[i], starts[i]), new IntImm(1)));
 
-BoundsInfo inferBounds(Stmt* s) {
-  BoundsInference ac;
-  s->accept(&ac);
-  return mergeTensorAccesses(ac.accesses());
+    extents.push_back(dim);
+  }
+
+  return extents;
 }
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/bounds_inference.h
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/jit/tensorexpr/mem_dependency_checker.h>
 
 namespace torch {
 namespace jit {
@@ -14,7 +15,7 @@ class Expr;
 class Buf;
 class Stmt;
 
-enum C10_API_ENUM TensorAccessKind { kLoad, kStore };
+enum C10_API_ENUM TensorAccessKind { kLoad, kStore, kMutate };
 
 struct TORCH_API TensorAccessBoundsInfo {
   TensorAccessKind kind;
@@ -25,11 +26,12 @@ struct TORCH_API TensorAccessBoundsInfo {
 using BoundsInfo =
     std::unordered_map<const Buf*, std::vector<TensorAccessBoundsInfo>>;
 
-TORCH_API BoundsInfo inferBounds(Stmt* s);
+TORCH_API BoundsInfo inferBounds(Stmt* s, bool distinctAccessKinds = true);
 
 TORCH_API void printBoundsInfo(const BoundsInfo& v);
 
-TORCH_API BoundsInfo mergeTensorAccesses(const BoundsInfo& unmerged);
+TORCH_API std::vector<const Expr*> getBoundExtents(
+    const std::vector<TensorAccessBoundsInfo>& infos);
 
 } // namespace tensorexpr
 } // namespace jit

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -78,6 +78,10 @@ Bound flattenBounds(const IndexBounds& a) {
 }
 
 OverlapKind overlaps(const IndexBounds& a, const IndexBounds& b) {
+  if (a.empty() && b.empty()) {
+    return ContainedOrEqual;
+  }
+
   // All accesses to a buf must have the same dimensionality.
 
   if (a.size() != b.size()) {


### PR DESCRIPTION
Refactors NNC bounds inference to use the dependency analysis added in #46952. This ends up being a pretty good simplification because we no longer need the complicated bound merging code that we used to determine contiguous ranges. There were no usages of that code and the memory dependency analyzer is closer to what we want for those use cases anyway.

Added tests for a few cases uncovered by the existing bounds inference test - much of the coverage for this feature is in tests of it's uses: rfactor, computeAt and cacheAccesses.