### PR TITLE
[jit] better message for bad type annotation

### DIFF
--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -342,7 +342,7 @@ def ann_to_type(ann, loc):
     the_type = try_ann_to_type(ann, loc)
     if the_type is not None:
         return the_type
-    raise ValueError(f"Unknown type annotation: '{ann}'")
+    raise ValueError(f"Unknown type annotation: '{ann}' at {loc.highlight()}")
 
 
 __all__ = [


### PR DESCRIPTION
Summary:
```
ValueError: Unknown type annotation: 'typing.Sequence[torch.Tensor]' at  File "xxx.py", line 223
        images = [x["image"].to(self.device) for x in batched_inputs]
        images = [(x - self.pixel_mean) / self.pixel_std for x in images]
        images = ImageList.from_tensors(images, self.backbone.size_divisibility)
                 ~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
        return images
```

Otherwise have no clue where the error is.

Test Plan: sandcastle

Differential Revision: D24764886

