### PR TITLE
[Bootcamp] add CUDA kernel checks to ATen/native/cuda

### DIFF
--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -112,6 +112,7 @@ Tensor prelu_cuda(const Tensor& self, const Tensor& weight_) {
         input_stride0,
         input_stride1,
         input_numel);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     });
   }
   return result;
@@ -229,6 +230,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cuda(const Tensor& grad_out_, const Te
         input_stride0,
         input_stride1,
         input_numel);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     });
     // update weight_grad
     std::vector<int64_t> reduce_dims;
@@ -405,7 +407,7 @@ void hardswish_backward_kernel(TensorIterator& iter) {
     const T_ACC neg_three(-3.0f);
     const T_ACC one_half(0.5f);
     gpu_kernel(
-      iter, 
+      iter,
       [zero, three, neg_three, one_half]GPU_LAMBDA(scalar_t grad_val_, scalar_t self_val_) -> scalar_t {
         T_ACC grad_val = static_cast<T_ACC>(grad_val_);
         T_ACC self_val = static_cast<T_ACC>(self_val_);
@@ -442,7 +444,7 @@ void hardsigmoid_backward_kernel(TensorIterator& iter) {
     const T_ACC neg_three(-3.0f);
     const T_ACC one_sixth(1.0f / 6.0f);
     gpu_kernel(
-      iter, 
+      iter,
       [zero, three, neg_three, one_sixth]GPU_LAMBDA(scalar_t grad_val_, scalar_t self_val_) -> scalar_t {
         T_ACC grad_val = static_cast<T_ACC>(grad_val_);
         T_ACC self_val = static_cast<T_ACC>(self_val_);

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -520,6 +520,7 @@ namespace {
                 sizeB, sizeC, isizeH, isizeW, osizeH, osizeW,
                 kernel_stride_C, kernel_size_C,
                 istrideB, istrideC, istrideH, istrideW);
+              TORCH_CUDA_KERNEL_LAUNCH_CHECK();
             }
           );
         break;
@@ -562,6 +563,7 @@ namespace {
                 input_data, output_data,
                 isizeH, isizeW, osizeH, osizeW,
                 istrideD, istrideH, istrideW);
+              TORCH_CUDA_KERNEL_LAUNCH_CHECK();
             }
           );
         break;
@@ -571,7 +573,6 @@ namespace {
           false,
           "Unsupported memory format. Supports only ChannelsLast, Contiguous");
     }
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 
   void adaptive_avg_pool2d_backward_out_cuda_template(
@@ -665,6 +666,7 @@ namespace {
                 sizeB, sizeC, isizeH, isizeW, osizeH, osizeW,
                 kernel_stride_C, kernel_size_C,
                 ostrideB, ostrideC, ostrideH, ostrideW);
+              TORCH_CUDA_KERNEL_LAUNCH_CHECK();
             }
           );
         break;
@@ -701,6 +703,7 @@ namespace {
                 atomic_adaptive_average_gradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
                   gradInput_data, gradOutput_data,
                   isizeH, isizeW, osizeH, osizeW);
+                TORCH_CUDA_KERNEL_LAUNCH_CHECK();
               }
               else
               {
@@ -708,6 +711,7 @@ namespace {
                 adaptive_average_gradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
                   gradInput_data, gradOutput_data,
                   isizeH, isizeW, osizeH, osizeW);
+                TORCH_CUDA_KERNEL_LAUNCH_CHECK();
               }
             }
           );
@@ -719,7 +723,6 @@ namespace {
           "Unsupported memory format. Supports only ChannelsLast, Contiguous");
 
     }
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 
 } // namespace

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
@@ -123,10 +123,9 @@ void adaptiveaveragepool_loop(
         istrideD,
         istrideT, istrideH, istrideW,
         offsetZ);
-
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     totalZ -= 65535;
     offsetZ += 65535;
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 }
 
@@ -217,10 +216,9 @@ void adaptiveaveragegradinput_loop(
         isizeT, isizeH, isizeW,
         osizeT, osizeH, osizeW,
         offsetZ);
-
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     totalZ -= 65535;
     offsetZ += 65535;
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 }
 
@@ -312,10 +310,9 @@ void atomicadaptiveaveragegradinput_loop(
         isizeT, isizeH, isizeW,
         osizeT, osizeH, osizeW,
         offsetZ);
-
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     totalZ -= 65535;
     offsetZ += 65535;
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 }
 

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -251,10 +251,9 @@ void adaptive_max_pool2d_out_cuda_template(
                                     indices_data,
                                     isizeH, isizeW, osizeH, osizeW,
                                     istrideD, istrideH, istrideW);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     );
-    AT_CUDA_CHECK(cudaGetLastError());
-
   } else {
     Tensor input_ = input.contiguous();
     int64_t sizeB  = input_.size(0);
@@ -288,10 +287,9 @@ void adaptive_max_pool2d_out_cuda_template(
                                     indices_data,
                                     isizeH, isizeW, osizeH, osizeW,
                                     istrideD, istrideH, istrideW);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     );
-    AT_CUDA_CHECK(cudaGetLastError());
-
   }
 }
 
@@ -346,6 +344,7 @@ void adaptive_max_pool2d_backward_out_cuda_template(
                                               gradInput_data, gradOutput_data,
                                               indices_data,
                                               isizeH, isizeW, osizeH, osizeW);
+          TORCH_CUDA_KERNEL_LAUNCH_CHECK();
         }
         else
         {
@@ -354,10 +353,10 @@ void adaptive_max_pool2d_backward_out_cuda_template(
                                               gradInput_data, gradOutput_data,
                                               indices_data,
                                               isizeH, isizeW, osizeH, osizeW);
+          TORCH_CUDA_KERNEL_LAUNCH_CHECK();
         }
       }
     );
-    AT_CUDA_CHECK(cudaGetLastError());
   } else {
     int64_t sizeB  = input.size(0);
     int64_t sizeD  = input.size(1);
@@ -392,6 +391,7 @@ void adaptive_max_pool2d_backward_out_cuda_template(
                                               gradInput_data, gradOutput_data,
                                               indices_data,
                                               isizeH, isizeW, osizeH, osizeW);
+          TORCH_CUDA_KERNEL_LAUNCH_CHECK();
         }
         else
         {
@@ -400,10 +400,10 @@ void adaptive_max_pool2d_backward_out_cuda_template(
                                               gradInput_data, gradOutput_data,
                                               indices_data,
                                               isizeH, isizeW, osizeH, osizeW);
+          TORCH_CUDA_KERNEL_LAUNCH_CHECK();
         }
       }
     );
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 }
 

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -131,10 +131,10 @@ void adaptivemaxpool_loop(
     adaptivemaxpool<<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
       input_data, output_data, indices_data, isizeT, isizeH, isizeW,
       osizeT, osizeH, osizeW, istrideD, istrideT, istrideH, istrideW, offsetZ);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 
     totalZ -= 65535;
     offsetZ += 65535;
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 }
 
@@ -209,10 +209,9 @@ void adaptivemaxgradinput_loop(
     adaptivemaxgradinput<<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
       gradInput_data, gradOutput_data, indices_data,
       isizeT, isizeH, isizeW, osizeT, osizeH, osizeW, offsetZ);
-
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     totalZ -= 65535;
     offsetZ += 65535;
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 }
 
@@ -286,10 +285,9 @@ void atomicadaptivemaxgradinput_loop(
     atomicadaptivemaxgradinput<<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
       gradInput_data, gradOutput_data, indices_data,
       isizeT, isizeH, isizeW, osizeT, osizeH, osizeW, offsetZ);
-
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     totalZ -= 65535;
     offsetZ += 65535;
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 }
 

--- a/aten/src/ATen/native/cuda/AmpKernels.cu
+++ b/aten/src/ATen/native/cuda/AmpKernels.cu
@@ -156,9 +156,9 @@ void _amp_foreach_non_finite_check_and_unscale_cuda_(TensorList scaled_grads,
 
       // multi_tensor_apply guards onto tensor_lists[0][0], no need to guard explicitly.
       multi_tensor_apply<1>(tensor_lists,
-                            UnaryOpFunctor<scalar_t, 
+                            UnaryOpFunctor<scalar_t,
                                            /* depth */ 1,
-                                           /* r_args_depth */ 1, 
+                                           /* r_args_depth */ 1,
                                            /* res_arg_index */ 0>(),
                             [found_inf_ptr, inv_scale_ptr] GPU_LAMBDA (opmath_t val) -> opmath_t {
                               // There is a slight asymmetry here with the TensorIterator kernel above.
@@ -243,6 +243,7 @@ Tensor _amp_update_scale_cuda(Tensor& growth_tracker,
     growth_factor,
     backoff_factor,
     growth_interval);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 
   return new_scale;
 }

--- a/aten/src/ATen/native/cuda/Bucketization.cu
+++ b/aten/src/ATen/native/cuda/Bucketization.cu
@@ -86,7 +86,7 @@ void searchsorted_cuda_contiguous(Tensor& result, const Tensor& input, const Ten
 
   searchsorted_cuda_kernel<<<grid, block, 0, stream>>>(
     data_out, data_in, data_bd, idim_in, idim_bd, numel_in, right, boundaries.dim() == 1);
-  THCudaCheck(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 void dispatch(Tensor& result, const Tensor& input, const Tensor& boundaries, bool out_int32, bool right) {

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -235,6 +235,7 @@ Tensor embedding_backward_cuda_kernel(
               segment_offsets.data_ptr<index_t>(),
               num_of_segments,
               numel);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     // In order to compute `partial_segment_offset`, which is the start index
@@ -262,6 +263,7 @@ Tensor embedding_backward_cuda_kernel(
               partials_per_segment_offset.data_ptr<index_t>(),
               segment_offsets.data_ptr<index_t>(),
               num_of_segments);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     const int stride_warped = ceil_div(stride, C10_WARP_SIZE)*C10_WARP_SIZE;
@@ -294,6 +296,7 @@ Tensor embedding_backward_cuda_kernel(
                   partial_segment_offset.data_ptr<index_t>(),
                   num_of_partial_segments, grad_weight_per_segment.data_ptr<partial_weight_t>(),
                   stride_warped);
+                TORCH_CUDA_KERNEL_LAUNCH_CHECK();
           } else {
                 compute_grad_weight<scalar_t><<<grid, block, 0, stream>>>(
                   orig_indices.data_ptr<index_t>(),
@@ -304,8 +307,8 @@ Tensor embedding_backward_cuda_kernel(
                   num_of_partial_segments,
                   grad_weight_per_segment.data_ptr<partial_weight_t>(),
                   stride_warped);
+                TORCH_CUDA_KERNEL_LAUNCH_CHECK();
           }
-          AT_CUDA_CHECK(cudaGetLastError());
 
           // Finally, we sum all the partial-sums and scatter them
           // into `grad_weight`.
@@ -320,7 +323,7 @@ Tensor embedding_backward_cuda_kernel(
                 num_of_partial_segments,
                 padding_idx,
                 stride_warped);
-          AT_CUDA_CHECK(cudaGetLastError());
+          TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       });
     });
   });

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -244,10 +244,10 @@ Tensor embedding_bag_backward_cuda_max(const Tensor &grad,
               scalar_t, index_t><<<grid, block, 0, stream>>>(
               max_indices.data_ptr<index_t>(), grad.data_ptr<scalar_t>(),
               grad_weight.data_ptr<scalar_t>(), stride, numBags);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
         });
       });
 
-  AT_CUDA_CHECK(cudaGetLastError());
   return grad_weight;
 }
 }
@@ -335,11 +335,11 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices,
             mode == MODE_MAX ? max_indices.data_ptr<index_t>() : NULL,
             per_sample_weights.defined() ? per_sample_weights.data_ptr<scalar_t>() : NULL,
             per_sample_weights.defined() ? per_sample_weights.stride(0) : 0);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       });
     });
   });
 
-  AT_CUDA_CHECK(cudaGetLastError());
   return std::tuple<Tensor, Tensor, Tensor, Tensor>(output, offset2bag, bag_size, max_indices);
 }
 
@@ -475,7 +475,7 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
             num_samples,
             embedding_features,
             output.data_ptr<scalar_t>());
-        AT_CUDA_CHECK(cudaGetLastError());
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       });
     }
   );

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -205,9 +205,9 @@ void fractional_max_pool2d_out_cuda_template(
         <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
           devOutput, devIndices, devInput, devSamples,
           poolSizeH, poolSizeW);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
        }
      );
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 void fractional_max_pool2d_backward_out_cuda_template(
@@ -272,9 +272,9 @@ void fractional_max_pool2d_backward_out_cuda_template(
       fractional_max_pool2d_backward_out_cuda_frame<scalar_t>
         <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
         devGradInput, devGradOutput, devIndices);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     );
-  AT_CUDA_CHECK(cudaGetLastError());
 }
 
 }// namespace

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -241,9 +241,9 @@ void fractional_max_pool3d_out_cuda_template(
           randomSamples.packed_accessor64<scalar_t, 3>(),
           poolSizeT, poolSizeH, poolSizeW
         );
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     );
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 
 void fractional_max_pool3d_backward_out_cuda_template(
@@ -327,9 +327,9 @@ void fractional_max_pool3d_backward_out_cuda_template(
           gradOutput_.packed_accessor64<scalar_t, 5>(),
           indices_.packed_accessor64<int64_t, 5>()
         );
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     );
-    AT_CUDA_CHECK(cudaGetLastError());
   }
 
 }// namespace

--- a/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
+++ b/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
@@ -37,8 +37,7 @@ void _lauch_kernel(int total_n_elems, const func_t& f) {
   auto stream = at::cuda::getCurrentCUDAStream();
   _elemwise_kernel<n_threads, n_elems_per_thread, func_t>
     <<<grid, block, 0, stream>>>(total_n_elems, f);
-
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -455,7 +455,7 @@ namespace {
             for (index_t j = 0; j < 4; ++j) {
 
               // set input gradient
-              add_value_bounded<scalar_t>(gInp_ptr_NC, ix_nw - 1 + i, iy_nw - 1 + j, inp_W, inp_H, 
+              add_value_bounded<scalar_t>(gInp_ptr_NC, ix_nw - 1 + i, iy_nw - 1 + j, inp_W, inp_H,
                 gInp_sW, gInp_sH, gOut * x_coeffs[i] * y_coeffs[j], padding_mode, align_corners);
 
               // set grid gradient
@@ -708,6 +708,7 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
             align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         grid_sampler_2d_kernel<scalar_t>
           <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
@@ -718,6 +719,7 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
             align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });
   }
@@ -747,16 +749,18 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
             align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
-      grid_sampler_3d_kernel<scalar_t>
-        <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-          count,
-          getTensorInfo<scalar_t, int64_t>(input),
-          getTensorInfo<scalar_t, int64_t>(grid),
-          getTensorInfo<scalar_t, int64_t>(output),
-          static_cast<GridSamplerInterpolation>(interpolation_mode),
-          static_cast<GridSamplerPadding>(padding_mode),
-          align_corners);
+        grid_sampler_3d_kernel<scalar_t>
+          <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            count,
+            getTensorInfo<scalar_t, int64_t>(input),
+            getTensorInfo<scalar_t, int64_t>(grid),
+            getTensorInfo<scalar_t, int64_t>(output),
+            static_cast<GridSamplerInterpolation>(interpolation_mode),
+            static_cast<GridSamplerPadding>(padding_mode),
+            align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });
   }
@@ -792,6 +796,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
             align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         grid_sampler_2d_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
@@ -804,6 +809,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input,
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
             align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });
   }
@@ -840,6 +846,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
             align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         grid_sampler_3d_backward_kernel<scalar_t>
           <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
@@ -852,6 +859,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
             static_cast<GridSamplerInterpolation>(interpolation_mode),
             static_cast<GridSamplerPadding>(padding_mode),
             align_corners);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });
   }

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -90,7 +90,7 @@ static void launch_kernel(int64_t N, const func_t& f) {
   dim3 grid((N + block.x * vt - 1) / (block.x * vt));
   auto stream = at::cuda::getCurrentCUDAStream();
   index_elementwise_kernel<nt, vt, func_t><<<grid, block, 0, stream>>>(N, f);
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename func_t>

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -183,7 +183,7 @@ static inline void launch_unrolled_kernel_for_multi_outputs(int64_t N, const fun
   int64_t grid = (N + block_work_size - 1) / block_work_size;
   auto stream = at::cuda::getCurrentCUDAStream();
   unrolled_elementwise_kernel_for_multi_outputs<num_outputs, func_t, array_t><<<grid, num_threads, 0, stream>>>(N, f, data, ic, oc);
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename func_t>

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -281,7 +281,7 @@ std::tuple<Tensor, Tensor> ctc_loss_gpu_template(const Tensor& log_probs, const 
                       log_alpha.stride(0), log_alpha.stride(1), log_alpha.stride(2),
                       tg_batch_offsets.data_ptr<int64_t>(), tg_target_stride,
                       batch_size, BLANK);
-  AT_CUDA_CHECK(cudaGetLastError()); // catch launch errors
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   return std::make_tuple(neg_log_likelihood, log_alpha);
 }
 
@@ -633,7 +633,7 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
        log_beta.stride(0), log_beta.stride(1), log_beta.stride(2),
        tg_batch_offsets.data_ptr<int64_t>(), tg_target_stride,
        batch_size, BLANK);
-    AT_CUDA_CHECK(cudaGetLastError()); // catch launch errors
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   }
 
   // Very crude heuristic for what is a small problem., based on linearly regressing problem dimensions on
@@ -690,7 +690,7 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
        log_beta.stride(0), log_beta.stride(1), log_beta.stride(2),
        tg_batch_offsets.data_ptr<int64_t>(), tg_target_stride,
        batch_size, num_labels, BLANK, zero_infinity);
-    AT_CUDA_CHECK(cudaGetLastError()); // catch launch errors
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   } else { // small problem, use naive algorithm
     // Still no block/grid configuration guru...
     int threads_input = max_threads;
@@ -713,7 +713,7 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
        log_beta.stride(0), log_beta.stride(1), log_beta.stride(2),
        tg_batch_offsets.data_ptr<int64_t>(), tg_target_stride,
        batch_size, num_labels, BLANK, zero_infinity);
-    AT_CUDA_CHECK(cudaGetLastError()); // catch launch errors
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK(); // catch launch errors
   }
 
   // zero those invalid graident elements due to padding
@@ -737,7 +737,7 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
       grad.size(1),
       grad.size(2)
     );
-    AT_CUDA_CHECK(cudaGetLastError());
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   }
 
   return grad;

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -169,8 +169,8 @@ Tensor& max_unpooling2d_forward_out_cuda(
             oheight,
             owidth,
             output.data_ptr<scalar_t>());
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }));
-  AT_CUDA_CHECK(cudaGetLastError());
   if (self.ndimension() == 3) {
     output.resize_({numChannels, oheight, owidth});
   }
@@ -343,7 +343,7 @@ Tensor& max_unpooling3d_forward_out_cuda(
               oH,
               oW,
               offsetZ);
-          AT_CUDA_CHECK(cudaGetLastError());
+          TORCH_CUDA_KERNEL_LAUNCH_CHECK();
           totalZ -= 65535;
           offsetZ += 65535;
         }
@@ -446,8 +446,8 @@ at::Tensor& max_unpooling2d_backward_out_cuda(
             oheight,
             owidth,
             grad_input.data_ptr<scalar_t>());
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }));
-  AT_CUDA_CHECK(cudaGetLastError());
   return grad_input;
 }
 at::Tensor max_unpooling2d_backward_cuda(
@@ -550,7 +550,7 @@ at::Tensor& max_unpooling3d_backward_out_cuda(
               indices.packed_accessor64<int64_t, 4>(),
               grad_input_reshaped.packed_accessor64<scalar_t, 4>(),
               offsetZ);
-          AT_CUDA_CHECK(cudaGetLastError());
+          TORCH_CUDA_KERNEL_LAUNCH_CHECK();
           totalZ -= 65535;
           offsetZ += 65535;
         }

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -96,8 +96,7 @@ void multi_tensor_apply(
                         tensorListMeta,
                         callable,
                         args...);
-
-                    AT_CUDA_CHECK(cudaGetLastError());
+                    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 
                     // Reset.
                     loc_block_info = 0;
@@ -153,8 +152,7 @@ void multi_tensor_apply(
                         tensorListMeta,
                         callable,
                         args...);
-
-                    AT_CUDA_CHECK(cudaGetLastError());
+                    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 
                     // Reset.
                     loc_block_info = 0;

--- a/aten/src/ATen/native/cuda/im2col.cuh
+++ b/aten/src/ATen/native/cuda/im2col.cuh
@@ -108,7 +108,7 @@ void im2col(
       height_col,
       width_col,
       data_col);
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename dt, typename accT>
@@ -208,7 +208,7 @@ void col2im(
           output_height,
           output_width,
           data_im);
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 } // namespace native

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -278,9 +278,10 @@ void LayerNormKernelImplInternal(
   RowwiseMomentsCUDAKernel<T>
       <<<M, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
           N, eps, X_data, mean_data, rstd_data);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   LayerNormForwardCUDAKernel<T><<<M, kCUDANumThreads, 0, cuda_stream>>>(
       N, X_data, mean_data, rstd_data, gamma_data, beta_data, Y_data);
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 void LayerNormKernelImpl(
@@ -339,6 +340,7 @@ void LayerNormBackwardKernelImplInternal(
     ComputeInternalGradientsCUDAKernel<T>
         <<<M, cuda_utils::kCUDABlockReduceNumThreads, 0, cuda_stream>>>(
             N, dY_data, X_data, gamma_data, ds_data, db_data);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     const int64_t B = (M + kCUDANumThreads - 1) / kCUDANumThreads;
     ComputeGradientFusedParamsCUDAKernel<T>
         <<<B, kCUDANumThreads, 0, cuda_stream>>>(
@@ -350,6 +352,7 @@ void LayerNormBackwardKernelImplInternal(
             db_data,
             scale_data,
             bias_data);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     LayerNormBackwardCUDAKenrel<T><<<M, kCUDANumThreads, 0, cuda_stream>>>(
         N,
         dY_data,
@@ -359,6 +362,7 @@ void LayerNormBackwardKernelImplInternal(
         scale_data,
         bias_data,
         dX_data);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   }
   if (dgamma->defined() || dbeta->defined()) {
     T* dgamma_data =
@@ -377,6 +381,7 @@ void LayerNormBackwardKernelImplInternal(
               rstd_data,
               dgamma_data,
               dbeta_data);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       const int64_t B =
           (N + kColwiseReduceTileSize - 1) / kColwiseReduceTileSize;
@@ -392,6 +397,7 @@ void LayerNormBackwardKernelImplInternal(
               rstd_data,
               dgamma_data,
               dbeta_data);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
   }
 }

--- a/aten/src/ATen/native/cuda/vol2col.cuh
+++ b/aten/src/ATen/native/cuda/vol2col.cuh
@@ -129,7 +129,7 @@ void vol2col(
       height_col,
       width_col,
       data_col);
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename T, typename accT>
@@ -264,7 +264,7 @@ void col2vol(
           output_height,
           output_width,
           data_vol);
-  AT_CUDA_CHECK(cudaGetLastError());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 } // namespace native


### PR DESCRIPTION
Summary:
- Add kernel launch check `TORCH_CUDA_KERNEL_LAUNCH_CHECK()` (D24309971 (https://github.com/pytorch/pytorch/commit/353e7f940f548e0a0cb3b420b4190b4624ae9b41)) to several files in aten/src/ATen/native/cuda
- Get rid of old check `AT_CUDA_CHECK(cudaGetLastError())` in these same files

Test Plan:
Test build:
```
buck build //caffe2/aten:ATen-cu
```
To check for launches without checks:
```
python3 caffe2/torch/testing/check_kernel_launches.py
```
Make sure none of the updated files are in the returned list:

{F343234608}

Reviewed By: r-barnes

Differential Revision: D24724947

