### PR TITLE
[vulkan] Add reshape ops for Vulkan

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -227,7 +227,9 @@ void Command::Buffer::bind(
 
 void Command::Buffer::copy(
     const Resource::Buffer::Object source,
-    const Resource::Buffer::Object destination) {
+    const Resource::Buffer::Object destination,
+    VkDeviceSize srcOffset,
+    VkDeviceSize dstOffset) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       command_buffer_,
       "This command buffer is in an invalid state! "
@@ -242,8 +244,8 @@ void Command::Buffer::copy(
       "Invalid Vulkan destination buffer!");
 
   const VkBufferCopy buffer_copy{
-    0u,
-    0u,
+    srcOffset,
+    dstOffset,
     std::min(source.range, destination.range),
   };
 

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -35,7 +35,11 @@ struct Command final {
     void barrier(const Pipeline::Barrier& barrier);
     void bind(const Pipeline::Object& pipeline);
     void bind(const Descriptor::Set& set);
-    void copy(Resource::Buffer::Object source, Resource::Buffer::Object destination);
+    void copy(
+        Resource::Buffer::Object source,
+        Resource::Buffer::Object destination,
+        VkDeviceSize srcOffset = 0,
+        VkDeviceSize dstOffset = 0);
     void dispatch(const Shader::WorkGroup& global_work_group);
     void submit(VkQueue queue, Resource::Fence fence = {});
 

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -95,11 +95,18 @@ Tensor cat(const TensorList tensors, int64_t dim) {
   return convert(v_output);
 }
 
+Tensor unsqueeze(const Tensor& self, int64_t dim) {
+  auto sizes = self.sizes().vec();
+  sizes.insert(sizes.begin() + dim, 1);
+  return reshape_copy(self, sizes);
+}
+
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
   m.impl("view", TORCH_FN(reshape_copy));
   m.impl("cat", TORCH_FN(cat));
+  m.impl("unsqueeze", TORCH_FN(unsqueeze));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -7,17 +7,99 @@ namespace vulkan {
 namespace ops {
 namespace {
 
-Tensor view(
-    const Tensor& self_arg,
-    IntArrayRef shape) {
+int64_t normalize_dim(int64_t d, int64_t n) {
+  return (d % n + n) % n;
+}
 
-  return self_arg.cpu().view(shape).vulkan();
+Tensor reshape_copy(const Tensor& self_arg, IntArrayRef shape) {
+  api::Context* const context = api::context();
+
+  const vTensor& v_self = convert(self_arg);
+
+  vTensor v_output{
+      context,
+      shape.vec(),
+      self_arg.options(),
+  };
+
+  api::Command::Buffer command_buffer =
+      api::context()->command().pool.allocate();
+  command_buffer.begin();
+
+  command_buffer.copy(
+      v_self.buffer(command_buffer),
+      v_output.buffer(command_buffer, vTensor::Access::Write));
+
+  command_buffer.end();
+  command_buffer.submit(api::context()->gpu().queue);
+
+  return convert(v_output);
+}
+
+Tensor cat(const TensorList tensors, int64_t dim) {
+  const auto norm_dim = normalize_dim(dim, 4);
+  TORCH_INTERNAL_ASSERT(
+      norm_dim == 0 || norm_dim == 1,
+      "Vulkan cat is implemented only for batch and channels dimensions");
+
+  int64_t cat_dim_size = 0;
+  std::vector<vTensor> vTensors{};
+  for (int i = 0; i < tensors.size(); ++i) {
+    const auto& t = tensors[i];
+    TORCH_INTERNAL_ASSERT(
+        t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
+    TORCH_INTERNAL_ASSERT(t.is_vulkan(), "Vulkan cat expects Vulkan inputs");
+
+    for (int d = 0; d < 4; ++d) {
+      if (d == dim) {
+        continue;
+      }
+      TORCH_INTERNAL_ASSERT(
+          t.size(d) == tensors[0].size(d),
+          "Vulkan cat inputs must have matching sizes except concatenated dimension");
+    }
+    vTensors.push_back(convert(t));
+    cat_dim_size += t.size(dim);
+  }
+
+  api::Context* const context = api::context();
+
+  auto result_size = tensors[0].sizes().vec();
+  result_size[dim] = cat_dim_size;
+
+  vTensor v_output{
+      context,
+      result_size,
+      vTensors[0].options(),
+  };
+
+  api::Command::Buffer command_buffer =
+      api::context()->command().pool.allocate();
+  command_buffer.begin();
+
+  VkDeviceSize outputOffset = 0;
+  for (int i = 0; i < tensors.size(); ++i) {
+    const auto& tv = vTensors[i];
+    command_buffer.copy(
+        tv.buffer(command_buffer),
+        v_output.buffer(command_buffer, vTensor::Access::Write),
+        0,
+        outputOffset);
+    const auto sizeBytes = sizeof(float) * prod_intlist(tv.sizes());
+    outputOffset += sizeBytes;
+  }
+
+  command_buffer.end();
+  command_buffer.submit(api::context()->gpu().queue);
+
+  return convert(v_output);
 }
 
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
-  m.impl("view", TORCH_FN(view));
+  m.impl("view", TORCH_FN(reshape_copy));
+  m.impl("cat", TORCH_FN(cat));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -270,21 +270,23 @@ TEST(VulkanAPITest, avg_pool2d) {
 }
 
 TEST(VulkanAPITest, reshape) {
-  const auto a_cpu = at::rand({1,3,2,2}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_cpu =
+      at::rand({1, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
   const auto a_vulkan = a_cpu.vulkan();
 
-  const auto c_cpu = at::reshape(a_cpu, {2,3,1,2});
-  const auto c_vulkan = at::reshape(a_vulkan, {2,3,1,2});
+  auto c_cpu = at::reshape(a_cpu, {2, 3, 1, 2});
+  auto c_vulkan = at::reshape(a_vulkan, {2, 3, 1, 2});
 
   ASSERT_TRUE(almostEqual(c_cpu, c_vulkan.cpu()));
 }
 
 TEST(VulkanAPITest, reshape_) {
-  const auto a_cpu = at::rand({1,3,2,2}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_cpu =
+      at::rand({1, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
   const auto a_vulkan = a_cpu.vulkan();
 
-  a_cpu.reshape({2,3,1,2});
-  a_vulkan.reshape({2,3,1,2});
+  a_cpu.reshape({2, 3, 1, 2});
+  a_vulkan.reshape({2, 3, 1, 2});
 
   ASSERT_TRUE(almostEqual(a_cpu, a_vulkan.cpu()));
 }
@@ -298,6 +300,26 @@ TEST(VulkanAPITest, copy) {
 TEST(VulkanAPITest, empty) {
   ASSERT_NO_THROW(
       at::empty({1, 17, 41, 53}, at::device(at::kVulkan).dtype(at::kFloat)));
+}
+
+TEST(VulkanAPITest, cat) {
+  auto t_in0 =
+      at::rand({1, 1, 3, 3}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+  auto t_in1 =
+      at::rand({1, 2, 3, 3}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+  auto t_in2 =
+      at::rand({1, 5, 3, 3}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+
+  auto t_out_expected = at::cat({t_in0, t_in1, t_in2}, 1);
+  auto tv_out = at::cat({t_in0.vulkan(), t_in1.vulkan(), t_in2.vulkan()}, 1);
+  auto t_out = tv_out.cpu();
+
+  const auto check = almostEqual(t_out, t_out_expected);
+  if (!check) {
+    std::cout << "expected:" << t_out_expected << std::endl;
+    std::cout << "got:" << t_out << std::endl;
+  }
+  ASSERT_TRUE(check);
 }
 
 } // namespace

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -273,8 +273,8 @@ TEST(VulkanAPITest, reshape) {
   const auto a_cpu = at::rand({1,3,2,2}, at::device(at::kCPU).dtype(at::kFloat));
   const auto a_vulkan = a_cpu.vulkan();
 
-  auto c_cpu = at::reshape(a_cpu, {2,3,1,2});
-  auto c_vulkan = at::reshape(a_vulkan, {2,3,1,2});
+  const auto c_cpu = at::reshape(a_cpu, {2,3,1,2});
+  const auto c_vulkan = at::reshape(a_vulkan, {2,3,1,2});
 
   ASSERT_TRUE(almostEqual(c_cpu, c_vulkan.cpu()));
 }

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -270,23 +270,21 @@ TEST(VulkanAPITest, avg_pool2d) {
 }
 
 TEST(VulkanAPITest, reshape) {
-  const auto a_cpu =
-      at::rand({1, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_cpu = at::rand({1,3,2,2}, at::device(at::kCPU).dtype(at::kFloat));
   const auto a_vulkan = a_cpu.vulkan();
 
-  auto c_cpu = at::reshape(a_cpu, {2, 3, 1, 2});
-  auto c_vulkan = at::reshape(a_vulkan, {2, 3, 1, 2});
+  auto c_cpu = at::reshape(a_cpu, {2,3,1,2});
+  auto c_vulkan = at::reshape(a_vulkan, {2,3,1,2});
 
   ASSERT_TRUE(almostEqual(c_cpu, c_vulkan.cpu()));
 }
 
 TEST(VulkanAPITest, reshape_) {
-  const auto a_cpu =
-      at::rand({1, 3, 2, 2}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_cpu = at::rand({1,3,2,2}, at::device(at::kCPU).dtype(at::kFloat));
   const auto a_vulkan = a_cpu.vulkan();
 
-  a_cpu.reshape({2, 3, 1, 2});
-  a_vulkan.reshape({2, 3, 1, 2});
+  a_cpu.reshape({2,3,1,2});
+  a_vulkan.reshape({2,3,1,2});
 
   ASSERT_TRUE(almostEqual(a_cpu, a_vulkan.cpu()));
 }
@@ -315,6 +313,21 @@ TEST(VulkanAPITest, cat) {
   auto t_out = tv_out.cpu();
 
   const auto check = almostEqual(t_out, t_out_expected);
+  if (!check) {
+    std::cout << "expected:" << t_out_expected << std::endl;
+    std::cout << "got:" << t_out << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+TEST(VulkanTest, unsqueeze) {
+  auto t_in =
+      at::rand({1, 2, 2}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+  auto tv_in = t_in.vulkan();
+
+  auto t_out_expected = t_in.unsqueeze(1);
+  auto t_out = tv_in.unsqueeze(1);
+  const auto check = almostEqual(t_out.cpu(), t_out_expected);
   if (!check) {
     std::cout << "expected:" << t_out_expected << std::endl;
     std::cout << "got:" << t_out << std::endl;


### PR DESCRIPTION
Add "reshape" based ops for Vulkan:
* cat
* unsqueeze
* view

Note that these ops will perform a copy into a new tensor.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47467 [vulkan] Add reshape ops for Vulkan**

Differential Revision: [D24787023](https://our.internmc.facebook.com/intern/diff/D24787023)