### PR TITLE
Fix rounding error flakiness in quantized_test

### DIFF
--- a/aten/src/ATen/native/quantized/affine_quantizer.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer.cpp
@@ -375,7 +375,8 @@ uint8_t quantize_val_arm(
     const float value) {
   const int32_t qmin = std::numeric_limits<uint8_t>::min();
   const int32_t qmax = std::numeric_limits<uint8_t>::max();
-  auto r = zero_point + static_cast<int32_t>(Round(value / scale));
+  float inv_scale = 1.0f / scale;
+  auto r = zero_point + static_cast<int32_t>(Round(value * inv_scale));
   r = std::max(r, qmin);
   r = std::min(r, qmax);
   return static_cast<uint8_t>(r);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47468 Fix rounding error flakiness in quantized_test**

**Summary:** QuantizePerChannel4d and QuantizePerChannel4dChannelsLast have issues with flakiness on both ARM and x86 builds.

The flakiness stems from two sources:
1. The rounding strategy used by quantization for half values is to round the number to the nearest even integer (e.g. `4.5->4`, `5.5 -> 6`, `6.5->6`; however the above tests are incorrect by expecting the values to be rounded away from zero.

2. On ARM devices, `quantize_val_arm` calculates `zero_point + round(val / scale)` which behaves differently from `quantize_val`, which calculates `zero_point + round(val * (1.0f/scale))`. This small distinction leaves enough room for the floating point arithmetic errors to change rounding behavior (e.g. `3 / .24 = 12.5` whereas `3 * (1.0f / .24) = 12.500001`).

**Test Plan:**
For local builds:
```
python setup.py develop
./build/bin/quantized_test --gtest_filter='TestQTensor.QuantizePerChannel4d*' --gtest_repeat=10000 | grep FAILURE
```

For ARM Neon:
```
BUILD_MOBILE_BENCHMARK=1 BUILD_MOBILE_TEST=1 ANDROID_DEBUG_SYMBOLS=1 BUILD_PYTORCH_MOBILE=1 ANDROID_ABI="armeabi-v7a with NEON" ./scripts/build_android.sh  -DANDROID_CCACHE=$(which ccache) -DBUILD_BINARY=ON
adb push ./build/bin/quantized_test /data/local/tmp
adb shell "/data/local/tmp/quantized_test --gtest_filter='TestQTensor.QuantizePerChannel4d*' --gtest_repeat=1000 | grep FAILURE"
```

For ARM64:
```
BUILD_MOBILE_BENCHMARK=1 BUILD_MOBILE_TEST=1 ANDROID_DEBUG_SYMBOLS=1 BUILD_PYTORCH_MOBILE=1 ANDROID_ABI=arm64-v8a ./scripts/build_android.sh  -DANDROID_CCACHE=$(which ccache) -DBUILD_BINARY=ON
adb push ./build/bin/quantized_test /data/local/tmp
adb shell "/data/local/tmp/quantized_test --gtest_filter='TestQTensor.QuantizePerChannel4d*' --gtest_repeat=1000 | grep FAILURE"
```

**Reviewers:**

**Subscribers:**

**Tasks:** T79019469

**Tags:**

Differential Revision: [D24769889](https://our.internmc.facebook.com/intern/diff/D24769889)