### PR TITLE
 add channels last support for AvgPool2d on CPU path

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -201,6 +201,17 @@ public:
     }
     return mask;
   }
+  Vec256<T> isnan() const {
+    Vec256<T> vec;
+    for (int64_t i = 0; i != size(); i++) {
+      if (_isnan(values[i])) {
+        std::memset(static_cast<void*>(vec.values + i), 0xFF, sizeof(T));
+      } else {
+        std::memset(static_cast<void*>(vec.values + i), 0, sizeof(T));
+      }
+    }
+    return vec;
+  }
   Vec256<T> map(T (*f)(T)) const {
     Vec256<T> ret;
     for (int64_t i = 0; i != size(); i++) {

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -95,6 +95,9 @@ public:
     __m256d cmp = _mm256_cmp_pd(values, _mm256_set1_pd(0.0), _CMP_EQ_OQ);
     return _mm256_movemask_pd(cmp);
   }
+  Vec256<double> isnan() const {
+    return _mm256_cmp_pd(values, _mm256_set1_pd(0.0), _CMP_UNORD_Q);
+  }
   Vec256<double> map(double (*f)(double)) const {
     __at_align32__ double tmp[size()];
     store(tmp);

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -102,6 +102,9 @@ public:
     __m256 cmp = _mm256_cmp_ps(values, _mm256_set1_ps(0.0f), _CMP_EQ_OQ);
     return _mm256_movemask_ps(cmp);
   }
+  Vec256<float> isnan() const {
+    return _mm256_cmp_ps(values, _mm256_set1_ps(0.0f), _CMP_UNORD_Q);
+  }
   Vec256<float> map(float (*f)(float)) const {
     __at_align32__ float tmp[size()];
     store(tmp);

--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -1,7 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
-#include <ATen/Parallel.h>
-#include <tuple>
+#include <ATen/native/AdaptivePooling.h>
 
 
 namespace at {
@@ -9,295 +8,66 @@ namespace native {
 
 namespace {
 
-  inline int start_index(int a, int b, int c) {
-    return (int)std::floor((float)(a * c) / b);
-  }
-
-  inline int end_index(int a, int b, int c) {
-    return (int)std::ceil((float)((a + 1) * c) / b);
-  }
-
-  template <typename scalar_t>
-  static void adaptive_avg_pool2d_single_out_frame(
-            scalar_t *input_p,
-            scalar_t *output_p,
-            int64_t sizeD,
-            int64_t isizeH,
-            int64_t isizeW,
-            int64_t osizeH,
-            int64_t osizeW,
-            int64_t istrideD,
-            int64_t istrideH,
-            int64_t istrideW)
-  {
-    at::parallel_for(0, sizeD, 0, [&](int64_t start, int64_t end) {
-      for (auto d = start; d < end; d++)
-      {
-        /* loop over output */
-        int64_t oh, ow;
-        for(oh = 0; oh < osizeH; oh++)
-        {
-          int istartH = start_index(oh, osizeH, isizeH);
-          int iendH   = end_index(oh, osizeH, isizeH);
-          int kH = iendH - istartH;
-
-          for(ow = 0; ow < osizeW; ow++)
-          {
-            int istartW = start_index(ow, osizeW, isizeW);
-            int iendW   = end_index(ow, osizeW, isizeW);
-            int kW = iendW - istartW;
-
-            /* local pointers */
-            scalar_t *ip = input_p   + d*istrideD + istartH*istrideH + istartW*istrideW;
-            scalar_t *op = output_p  + d*osizeH*osizeW + oh*osizeW + ow;
-
-            /* compute local average: */
-            scalar_t sum = 0;
-            int ih, iw;
-            for(ih = 0; ih < kH; ih++)
-            {
-              for(iw = 0; iw < kW; iw++)
-              {
-                scalar_t val = *(ip + ih*istrideH + iw*istrideW);
-                sum += val;
-              }
-            }
-
-            /* set output to local average */
-            *op = sum / kW / kH;
-          }
-        }
-      }
-    });
-  }
-
-  template <typename scalar_t>
-  void adaptive_avg_pool2d_out_frame(
-    scalar_t *input_p,
-    scalar_t *output_p,
-    int64_t sizeB,
-    int64_t sizeD,
-    int64_t isizeH,
-    int64_t isizeW,
-    int64_t osizeH,
-    int64_t osizeW,
-    int64_t istrideB,
-    int64_t istrideD,
-    int64_t istrideH,
-    int64_t istrideW)
-  {
-    at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
-      for (auto b = start; b < end; b++)
-      {
-        adaptive_avg_pool2d_single_out_frame<scalar_t>(
-          input_p + b * istrideB,
-          output_p + b * sizeD * osizeH * osizeW,
-          sizeD,
-          isizeH, isizeW,
-          osizeH, osizeW,
-          istrideD,
-          istrideH, istrideW);
-      }
-    });
-  }
-
   void adaptive_avg_pool2d_out_cpu_template(
     at::Tensor& output,
     at::Tensor const& input,
     IntArrayRef output_size)
   {
     TORCH_CHECK(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
-    for (int64_t i = 0; i < input.ndimension(); i++) {
+    int64_t ndim = input.ndimension();
+    for (int64_t i = 0; i < ndim; i++) {
       TORCH_CHECK(input.size(i) > 0,
         "adaptive_avg_pooling2d(): expected input to have non-empty spatial dimensions, "
         "but input has sizes ", input.sizes(), " with dimension ", i, " being "
         "empty");
     }
 
-    TORCH_CHECK((input.ndimension() == 3 || input.ndimension() == 4),
+    TORCH_CHECK((ndim == 3 || ndim == 4),
       "non-empty 3D or 4D (batch mode) tensor expected for input");
+    TORCH_CHECK(input.dtype() == output.dtype(),
+      "expected dtype ", input.dtype(), " for `output` but got dtype ", output.dtype());
 
-    /* sizes */
-    int64_t sizeD  = input.size(-3);
-    int64_t isizeH = input.size(-2);
-    int64_t isizeW = input.size(-1);
-    /* strides */
-    int64_t istrideD = input.stride(-3);
-    int64_t istrideH = input.stride(-2);
-    int64_t istrideW = input.stride(-1);
+    int64_t channels  = input.size(-3);
+    int64_t input_height = input.size(-2);
+    int64_t input_width = input.size(-1);
+    int64_t output_height = output_size[0];
+    int64_t output_width = output_size[1];
 
-    auto osizeH = output_size[0];
-    auto osizeW = output_size[1];
-
-    /* resize output */
-    if (input.ndimension() == 3 || input.size(-4) == 1)
-    {
-      if (input.ndimension() == 3) {
-        output.resize_({sizeD, osizeH, osizeW});
-      } else {
-        output.resize_({1, sizeD, osizeH, osizeW});
-      }
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "adaptive_avg_pool2d_cpu", [&] {
-          auto input_data = input.data_ptr<scalar_t>();
-          auto output_data = output.data_ptr<scalar_t>();
-          adaptive_avg_pool2d_single_out_frame<scalar_t>(
-            input_data,
-            output_data,
-            sizeD,
-            isizeH, isizeW,
-            osizeH, osizeW,
-            istrideD,
-            istrideH, istrideW);
-        }
-      );
+    if (ndim == 3) {
+      output.resize_({channels, output_height, output_width});
+    } else {
+      int64_t nbatch = input.size(0);
+      output.resize_({nbatch, channels, output_height, output_width}, input.suggest_memory_format());
     }
-    else
-    {
-      int64_t sizeB = input.size(-4);
-      output.resize_({sizeB, sizeD, osizeH, osizeW});
-      int64_t istrideB = input.stride(-4);
 
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "adaptive_avg_pool2d_cpu", [&] {
-        auto input_data = input.data_ptr<scalar_t>();
-        auto output_data = output.data_ptr<scalar_t>();
-        adaptive_avg_pool2d_out_frame<scalar_t>(
-          input_data,
-          output_data,
-          sizeB,
-          sizeD,
-          isizeH, isizeW,
-          osizeH, osizeW,
-          istrideB,
-          istrideD,
-          istrideH, istrideW);
-      });
-    }
-  }
-
-  template <typename scalar_t>
-  static void adaptive_avg_pool2d_backward_single_out_frame(
-    scalar_t *gradInput_p,
-    scalar_t *gradOutput_p,
-    int64_t sizeD,
-    int64_t isizeH,
-    int64_t isizeW,
-    int64_t osizeH,
-    int64_t osizeW)
-  {
-    at::parallel_for(0, sizeD, 0, [&](int64_t start, int64_t end) {
-      for (auto d = start; d < end; d++)
-      {
-        scalar_t *gradInput_p_d = gradInput_p + d*isizeW*isizeH;
-        scalar_t *gradOutput_p_d = gradOutput_p + d*osizeW*osizeH;
-
-        /* calculate average */
-        int64_t oh, ow;
-        for(oh = 0; oh < osizeH; oh++)
-        {
-          int istartH = start_index(oh, osizeH, isizeH);
-          int iendH   = end_index(oh, osizeH, isizeH);
-          int kH = iendH - istartH;
-
-          for(ow = 0; ow < osizeW; ow++)
-          {
-
-            int istartW = start_index(ow, osizeW, isizeW);
-            int iendW   = end_index(ow, osizeW, isizeW);
-            int kW = iendW - istartW;
-
-            scalar_t grad_delta = gradOutput_p_d[oh*osizeW +ow] / kH / kW;
-
-            int ih, iw;
-            for(ih = istartH; ih < iendH; ih++)
-            {
-              for(iw = istartW; iw < iendW; iw++)
-              {
-                /* update gradient */
-                gradInput_p_d[ih*isizeW + iw] += grad_delta;
-              }
-            }
-          }
-        }
-      }
-    });
-  }
-
-  template <typename scalar_t>
-  void adaptive_avg_pool2d_backward_out_frame(
-    scalar_t *gradInput_p,
-    scalar_t *gradOutput_p,
-    int64_t sizeB,
-    int64_t sizeD,
-    int64_t isizeH,
-    int64_t isizeW,
-    int64_t osizeH,
-    int64_t osizeW)
-  {
-    at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
-      for (auto b = start; b < end; b++)
-      {
-        scalar_t *gradInput_p_d = gradInput_p + b * sizeD * isizeW * isizeH;
-        scalar_t *gradOutput_p_d = gradOutput_p + b * sizeD * osizeW * osizeH;
-        adaptive_avg_pool2d_backward_single_out_frame<scalar_t>(
-          gradInput_p_d,
-          gradOutput_p_d,
-          sizeD,
-          isizeH, isizeW,
-          osizeH, osizeW);
-      }
-    });
+    adaptive_avg_pool2d_kernel(kCPU, output, input, output_size);
   }
 
   Tensor& adaptive_avg_pool2d_backward_out_cpu_template(
-    Tensor& gradInput,
-    const Tensor& gradOutput_,
+    Tensor& grad_input,
+    const Tensor& grad_output,
     const Tensor& input)
   {
-    /* sizes */
-    int sizeD  = input.size(-3);
-    int isizeH = input.size(-2);
-    int isizeW = input.size(-1);
-    int osizeH = gradOutput_.size(-2);
-    int osizeW = gradOutput_.size(-1);
-
-    /* get contiguous gradOutput */
-    auto gradOutput = gradOutput_.contiguous();
-
-    /* backprop */
-    if (input.ndimension() == 3 || input.size(-4) == 1)
-    {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        input.scalar_type(), "adaptive_avg_pool2d_backward_cpu", [&] {
-          /* get raw pointers */
-          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-
-          adaptive_avg_pool2d_backward_single_out_frame<scalar_t>(
-            gradInput_data, gradOutput_data,
-            sizeD,
-            isizeH, isizeW,
-            osizeH, osizeW);
-        }
-      );
+    int64_t ndim = grad_output.ndimension();
+    for (int64_t i = 0; i < ndim; i++) {
+      TORCH_CHECK(grad_output.size(i) > 0,
+        "adaptive_avg_pooling2d_backward(): expected grad_output to have non-empty spatial dimensions, "
+        "but grad_output has sizes ", grad_output.sizes(), " with dimension ", i, " being "
+        "empty");
     }
-    else
-    {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        input.scalar_type(), "adaptive_avg_pool2d_backward_cpu", [&] {
-          /* get raw pointers */
-          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-          int64_t sizeB = input.size(-4);
 
-          adaptive_avg_pool2d_backward_out_frame<scalar_t>(
-            gradInput_data, gradOutput_data,
-            sizeB, sizeD,
-            isizeH, isizeW,
-            osizeH, osizeW);
-        }
-      );
-    }
-    return gradInput;
+    TORCH_CHECK((ndim == 3 || ndim == 4),
+      "non-empty 3D or 4D (batch mode) tensor expected for grad_output");
+    TORCH_CHECK(input.dtype() == grad_output.dtype(),
+      "expected dtype ", input.dtype(), " for `grad_output` but got dtype ", grad_output.dtype());
+    TORCH_CHECK(input.dtype() == grad_input.dtype(),
+      "expected dtype ", input.dtype(), " for `grad_input` but got dtype ", grad_input.dtype());
+
+    grad_input.resize_(input.sizes(), input.suggest_memory_format());
+    grad_input.zero_();
+
+    adaptive_avg_pool2d_backward_kernel(kCPU, grad_input, grad_output);
+    return grad_input;
   }
 
 } // namespace
@@ -346,25 +116,27 @@ namespace {
   }
 
   Tensor& adaptive_avg_pool2d_backward_out_cpu(
-    Tensor& gradInput,
-    const Tensor& gradOutput,
+    Tensor& grad_input,
+    const Tensor& grad_output,
     const Tensor& input)
   {
-    gradInput.resize_as_(input);
     adaptive_avg_pool2d_backward_out_cpu_template(
-      gradInput, gradOutput, input);
-    return gradInput;
+      grad_input, grad_output, input);
+    return grad_input;
   }
 
   Tensor adaptive_avg_pool2d_backward_cpu(
-    const Tensor& gradOutput,
+    const Tensor& grad_output,
     const Tensor& input)
   {
-    auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    auto grad_input = at::empty({0}, input.options());
     adaptive_avg_pool2d_backward_out_cpu_template(
-      gradInput, gradOutput, input);
-    return gradInput;
+      grad_input, grad_output, input);
+    return grad_input;
   }
+
+DEFINE_DISPATCH(adaptive_avg_pool2d_kernel);
+DEFINE_DISPATCH(adaptive_avg_pool2d_backward_kernel);
 
 } // at::native
 } // at

--- a/aten/src/ATen/native/AdaptivePooling.h
+++ b/aten/src/ATen/native/AdaptivePooling.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at { namespace native {
+
+using adaptive_avg_pooling_fn = void(*)(Tensor& output, const Tensor& input, IntArrayRef output_size);
+using adaptive_avg_pooling_backward_fn = void(*)(Tensor& grad_input, const Tensor& grad_output);
+DECLARE_DISPATCH(adaptive_avg_pooling_fn, adaptive_avg_pool2d_kernel);
+DECLARE_DISPATCH(adaptive_avg_pooling_backward_fn, adaptive_avg_pool2d_backward_kernel);
+
+static inline int64_t start_index(int64_t a, int64_t b, int64_t c) {
+  return (int64_t)std::floor((float)(a * c) / b);
+}
+
+static inline int64_t end_index(int64_t a, int64_t b, int64_t c) {
+  return (int64_t)std::ceil((float)((a + 1) * c) / b);
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -1,8 +1,6 @@
 #include <ATen/ATen.h>
-#include <ATen/Parallel.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/Pool.h>
-#include <tuple>
 
 
 namespace at {
@@ -10,91 +8,9 @@ namespace native {
 
 namespace {
 
-template <typename scalar_t>
-static void avg_pool2d_out_frame(
-          scalar_t *input_data,
-          scalar_t *output_data,
-          int64_t nbatch,
-          int64_t nInputPlane,
-          int64_t inputWidth,
-          int64_t inputHeight,
-          int64_t outputWidth,
-          int64_t outputHeight,
-          int kW,
-          int kH,
-          int dW,
-          int dH,
-          int padW,
-          int padH,
-          bool count_include_pad,
-          c10::optional<int64_t> divisor_override)
-{
-  at::parallel_for(0, nInputPlane, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
-      int64_t p;
-      for(p = 0; p < nbatch; p++)
-      {
-        int64_t xx, yy;
-        /* For all output pixels... */
-        scalar_t *ptr_output = output_data + p*nInputPlane*outputWidth*outputHeight + k*outputWidth*outputHeight;
-        const scalar_t *ptr_input = input_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight;
-        int64_t i;
-        for(i = 0; i < outputWidth*outputHeight; i++)
-          ptr_output[i] = 0;
-
-        for(yy = 0; yy < outputHeight; yy++)
-        {
-          for(xx = 0; xx < outputWidth; xx++)
-          {
-            /* Compute the mean of the input image... */
-            int64_t hstart = yy * dH - padH;
-            int64_t wstart = xx * dW - padW;
-            int64_t hend = std::min(hstart + kH, inputHeight + padH);
-            int64_t wend = std::min(wstart + kW, inputWidth + padW);
-            int pool_size = (hend - hstart) * (wend - wstart);
-            hstart = std::max(hstart, (int64_t) 0);
-            wstart = std::max(wstart, (int64_t) 0);
-            hend = std::min(hend, inputHeight);
-            wend = std::min(wend, inputWidth);
-
-            if (hstart >= hend || wstart >= wend) {
-              ++ptr_output;
-              continue;
-            }
-
-            scalar_t sum = 0;
-
-            int divide_factor;
-            if (divisor_override.has_value()) {
-              divide_factor = divisor_override.value();
-            } else {
-              if(count_include_pad) {
-                divide_factor = pool_size;
-              } else {
-                divide_factor = (hend - hstart) * (wend - wstart);
-              }
-            }
-
-            int64_t kx, ky;
-
-            for(ky = hstart; ky < hend; ky++)
-            {
-              for(kx = wstart; kx < wend; kx++)
-                sum += ptr_input[ky*inputWidth + kx];
-            }
-            /* Update output */
-            *ptr_output++ += sum/divide_factor;
-          }
-        }
-      }
-    }
-  });
-}
-
 void avg_pool2d_out_cpu_template(
           Tensor &output,
-          const Tensor &input_,
+          const Tensor &input,
           IntArrayRef kernel_size,
           IntArrayRef stride, 
           IntArrayRef padding,
@@ -119,139 +35,47 @@ void avg_pool2d_out_cpu_template(
   const int padH = safe_downcast<int, int64_t>(padding[0]);
   const int padW = padding.size() == 1 ? padH : safe_downcast<int, int64_t>(padding[1]);
 
-  TORCH_CHECK((input_.ndimension() == 3 || input_.ndimension() == 4),
+  TORCH_CHECK((input.ndimension() == 3 || input.ndimension() == 4),
     "non-empty 2D or 3D (batch mode) tensor expected for input");
 
   TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0,
     "divisor must be not zero");
 
+  TORCH_CHECK(input.dtype() == output.dtype(),
+    "expected dtype ", input.dtype(), " for `output` but got dtype ", output.dtype());
+
   /* sizes */
-  const int64_t nbatch = input_.ndimension() == 4 ? input_.size(-4) : 1;
-  const int64_t nInputPlane = input_.size(-3);
-  const int64_t inputHeight = input_.size(-2);
-  const int64_t inputWidth = input_.size(-1);
+  const int64_t nbatch = input.ndimension() == 4 ? input.size(-4) : 1;
+  const int64_t nInputPlane = input.size(-3);
+  const int64_t inputHeight = input.size(-2);
+  const int64_t inputWidth = input.size(-1);
 
   const int64_t outputHeight = pooling_output_shape<int64_t>(inputHeight, kH, padH, dH, 1, ceil_mode);
   const int64_t outputWidth = pooling_output_shape<int64_t>(inputWidth, kW, padW, dW, 1, ceil_mode);
 
   pool2d_shape_check(
-    input_,
+    input,
     kH, kW, dH, dW, padH, padW, 1, 1,
     nInputPlane,
     inputHeight, inputWidth,
     outputHeight, outputWidth);
 
-  if (input_.ndimension() == 3) {
+  if (input.ndimension() == 3) {
     output.resize_({nInputPlane, outputHeight, outputWidth});
   }
   else {
-    output.resize_({nbatch, nInputPlane, outputHeight, outputWidth});
+    output.resize_({nbatch, nInputPlane, outputHeight, outputWidth}, input.suggest_memory_format());
   }
 
-  TORCH_CHECK(output.is_contiguous(), "avg_pool2d: output must be contiguous");
-
-  Tensor input = input_.contiguous();
-
-  AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Long, input.scalar_type(),
-    "avg_pool2d_out_frame",
-    [&] {
-      scalar_t *input_data = input.data_ptr<scalar_t>();
-      scalar_t *output_data = output.data_ptr<scalar_t>();
-
-      avg_pool2d_out_frame(
-        input_data,
-        output_data,
-        nbatch,
-        nInputPlane,
-        inputWidth, inputHeight,
-        outputWidth, outputHeight,
-        kW, kH,
-        dW, dH,
-        padW, padH,
-        count_include_pad,
-        divisor_override);
-    }
-  );
-}
-
-template <typename scalar_t>
-static void avg_pool2d_backward_out_frame(
-          scalar_t *gradInput_data,
-          scalar_t *gradOutput_data,
-          int64_t nbatch,
-          int64_t nInputPlane,
-          int64_t inputWidth,
-          int64_t inputHeight,
-          int64_t outputWidth,
-          int64_t outputHeight,
-          int kW,
-          int kH,
-          int dW,
-          int dH,
-          int padW,
-          int padH,
-          bool count_include_pad,
-          c10::optional<int64_t> divisor_override)
-{
-  at::parallel_for(0, nInputPlane, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
-      int64_t p;
-      for(p = 0; p < nbatch; p++)
-      {
-        const scalar_t *ptr_gradOutput = gradOutput_data + p*nInputPlane*outputHeight*outputWidth + k*outputWidth*outputHeight;
-        int64_t xx, yy;
-
-        scalar_t* ptr_gi = gradInput_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight;
-        scalar_t *ptr_gradInput = gradInput_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight;
-
-        int64_t i;
-        for(i=0; i<inputWidth*inputHeight; i++)
-          ptr_gi[i] = 0.0;
-
-        for(yy = 0; yy < outputHeight; yy++)
-        {
-          for(xx = 0; xx < outputWidth; xx++)
-          {
-            int64_t hstart = yy * dH - padH;
-            int64_t wstart = xx * dW - padW;
-            int64_t hend = std::min(hstart + kH, inputHeight + padH);
-            int64_t wend = std::min(wstart + kW, inputWidth + padW);
-            int pool_size = (hend - hstart) * (wend - wstart);
-            hstart = std::max(hstart, (int64_t) 0);
-            wstart = std::max(wstart, (int64_t) 0);
-            hend = std::min(hend, inputHeight);
-            wend = std::min(wend, inputWidth);
-
-            scalar_t z = *ptr_gradOutput++;
-
-            int divide_factor;
-            if (divisor_override.has_value()) {
-              divide_factor = divisor_override.value();
-            } else {
-              if(count_include_pad) {
-                divide_factor = pool_size;
-              } else {
-                divide_factor = (hend - hstart) * (wend - wstart);
-              }
-            }
-
-            int64_t kx, ky;
-            for(ky = hstart ; ky < hend; ky++)
-            {
-              for(kx = wstart; kx < wend; kx++)
-                ptr_gradInput[ky*inputWidth + kx] += z/divide_factor;
-            }
-          }
-        }
-      }
-    }
-  });
+  avg_pool2d_kernel(
+      kCPU, output, input,
+      kW, kH, dW, dH, padW, padH,
+      count_include_pad, divisor_override);
 }
 
 Tensor& avg_pool2d_backward_out_cpu_template(
   Tensor& gradInput,
-  const Tensor& gradOutput_,
+  const Tensor& gradOutput,
   const Tensor& input,
   IntArrayRef kernel_size,
   IntArrayRef stride,
@@ -284,6 +108,11 @@ Tensor& avg_pool2d_backward_out_cpu_template(
 
   TORCH_CHECK(!divisor_override.has_value() || divisor_override.value() != 0, "divisor must be not zero");
 
+  TORCH_CHECK(input.dtype() == gradOutput.dtype(),
+    "expected dtype ", input.dtype(), " for `gradOutput` but got dtype ", gradOutput.dtype());
+  TORCH_CHECK(input.dtype() == gradInput.dtype(),
+    "expected dtype ", input.dtype(), " for `gradInput` but got dtype ", gradInput.dtype());
+
   /* sizes */
   const int64_t nbatch = input.ndimension() == 4 ? input.size(-4) : 1;
   const int64_t nInputPlane = input.size(-3); // number of channels (or colors)
@@ -294,41 +123,21 @@ Tensor& avg_pool2d_backward_out_cpu_template(
 
   avg_pool2d_backward_shape_check(
     input,
-    gradOutput_,
+    gradOutput,
     nbatch,
     kH, kW, dH, dW, padH, padW,
     nInputPlane,
     inputHeight, inputWidth,
     outputHeight, outputWidth);
 
-  /* get contiguous gradOutput */
-  const Tensor gradOutput = gradOutput_.contiguous();
-
   /* resize */
-  gradInput.resize_as_(input);
+  gradInput.resize_(input.sizes(), input.suggest_memory_format());
   gradInput.zero_();
-  TORCH_CHECK(gradInput.is_contiguous(), "gradInput must be contiguous");
 
-  AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Long, input.scalar_type(),
-    "avg_pool2d_backward_out_frame",
-    [&] {
-       scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-       scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-
-       avg_pool2d_backward_out_frame(
-         gradInput_data,
-         gradOutput_data,
-         nbatch,
-         nInputPlane,
-         inputWidth, inputHeight,
-         outputWidth, outputHeight,
-         kW, kH,
-         dW, dH,
-         padW, padH,
-         count_include_pad,
-         divisor_override);
-    }
-  );
+  avg_pool2d_backward_kernel(
+      kCPU, gradInput, gradOutput,
+      kW, kH, dW, dH, padW, padH,
+      count_include_pad, divisor_override);
 
   return gradInput;
 }
@@ -381,7 +190,7 @@ Tensor avg_pool2d_cpu(
 
 Tensor& avg_pool2d_backward_out_cpu(
   Tensor& gradInput,
-  const Tensor& gradOutput_,
+  const Tensor& gradOutput,
   const Tensor& input,
   IntArrayRef kernel_size,
   IntArrayRef stride,
@@ -392,7 +201,7 @@ Tensor& avg_pool2d_backward_out_cpu(
 {
   avg_pool2d_backward_out_cpu_template(
     gradInput,
-    gradOutput_,
+    gradOutput,
     input,
     kernel_size,
     stride,
@@ -404,7 +213,7 @@ Tensor& avg_pool2d_backward_out_cpu(
 }
 
 Tensor avg_pool2d_backward_cpu(
-  const Tensor& gradOutput_,
+  const Tensor& gradOutput,
   const Tensor& input,
   IntArrayRef kernel_size,
   IntArrayRef stride,
@@ -413,10 +222,10 @@ Tensor avg_pool2d_backward_cpu(
   bool count_include_pad,
   c10::optional<int64_t> divisor_override)
 {
-  auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto gradInput = at::empty({0}, input.options());
   avg_pool2d_backward_out_cpu_template(
     gradInput,
-    gradOutput_,
+    gradOutput,
     input,
     kernel_size,
     stride,
@@ -426,6 +235,9 @@ Tensor avg_pool2d_backward_cpu(
     divisor_override);
   return gradInput;
 }
+
+DEFINE_DISPATCH(avg_pool2d_kernel);
+DEFINE_DISPATCH(avg_pool2d_backward_kernel);
 
 } // at::native
 } // at

--- a/aten/src/ATen/native/DilatedMaxPool2d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool2d.cpp
@@ -1,9 +1,7 @@
 #include <ATen/ATen.h>
-#include <ATen/Parallel.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/native/Pool.h>
-#include <tuple>
 
 
 namespace at {
@@ -11,117 +9,10 @@ namespace native {
 
 namespace {
 
-template <typename scalar_t>
-static void max_pool2d_with_indices_single_out_frame(
-          scalar_t *input_p,
-          scalar_t *output_p,
-          int64_t *ind_p,
-          int64_t nslices,
-          int64_t iwidth,
-          int64_t iheight,
-          int64_t owidth,
-          int64_t oheight,
-          int kW,
-          int kH,
-          int dW,
-          int dH,
-          int padW,
-          int padH,
-          int dilationW,
-          int dilationH
-          )
-{
-  at::parallel_for(0, nslices, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
-      /* loop over output */
-      int64_t i, j;
-      scalar_t *ip = input_p   + k*iwidth*iheight;
-      for(i = 0; i < oheight; i++)
-      {
-        for(j = 0; j < owidth; j++)
-        {
-          int64_t hstart = i * dH - padH;
-          int64_t wstart = j * dW - padW;
-          int64_t hend = std::min(hstart + (kH - 1) * dilationH + 1, iheight);
-          int64_t wend = std::min(wstart + (kW - 1) * dilationW + 1, iwidth);
-          while(hstart < 0)
-            hstart += dilationH;
-          while(wstart < 0)
-            wstart += dilationW;
-
-          /* local pointers */
-          scalar_t *op = output_p  + k*owidth*oheight + i*owidth + j;
-          int64_t *indp = ind_p   + k*owidth*oheight + i*owidth + j;
-
-          /* compute local max: */
-          int64_t maxindex = hstart*iwidth + wstart;
-          scalar_t maxval = -std::numeric_limits<scalar_t>::infinity();
-          for(int64_t y = hstart; y < hend; y += dilationH)
-          {
-            for(int64_t x = wstart; x < wend; x += dilationW)
-            {
-              int64_t tcntr = y*iwidth + x;
-              scalar_t val = *(ip + tcntr);
-              if ((val > maxval) || std::isnan(val))
-              {
-                maxval = val;
-                maxindex = tcntr;
-              }
-            }
-          }
-
-          /* set output to local max */
-          *op = maxval;
-
-          /* store location of max */
-          *indp = maxindex;
-        }
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void max_pool2d_with_indices_out_frame(
-          scalar_t *input_data,
-          scalar_t *output_data,
-          int64_t *indices_data,
-          int64_t nbatch,
-          int64_t nInputPlane,
-          int64_t inputWidth,
-          int64_t inputHeight,
-          int64_t outputWidth,
-          int64_t outputHeight,
-          int kW,
-          int kH,
-          int dW,
-          int dH,
-          int padW,
-          int padH,
-          int dilationW,
-          int dilationH)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
-      max_pool2d_with_indices_single_out_frame(
-        input_data+p*nInputPlane*inputWidth*inputHeight,
-        output_data+p*nInputPlane*outputWidth*outputHeight,
-        indices_data+p*nInputPlane*outputWidth*outputHeight,
-        nInputPlane,
-        inputWidth, inputHeight,
-        outputWidth, outputHeight,
-        kW, kH, dW, dH,
-        padW, padH,
-        dilationW, dilationH);
-    }
-  });
-}
-
 void max_pool2d_with_indices_out_cpu_template(
           Tensor& output,
           Tensor& indices,
-          const Tensor& input_,
+          const Tensor& input,
           IntArrayRef kernel_size,
           IntArrayRef stride,
           IntArrayRef padding,
@@ -152,152 +43,50 @@ void max_pool2d_with_indices_out_cpu_template(
   const int dilationH = safe_downcast<int, int64_t>(dilation[0]);
   const int dilationW = dilation.size() == 1 ? dilationH : safe_downcast<int, int64_t>(dilation[1]);
 
-  TORCH_CHECK((input_.ndimension() == 3 || input_.ndimension() == 4),
+  TORCH_CHECK((input.ndimension() == 3 || input.ndimension() == 4),
     "non-empty 3D or 4D (batch mode) tensor expected for input");
 
+  TORCH_CHECK(input.dtype() == output.dtype(),
+    "expected dtype ", input.dtype(), " for `output` but got dtype ", output.dtype());
+
   /* sizes */
-  const int64_t nbatch = input_.ndimension() == 4 ? input_.size(-4) : 1;
-  const int64_t nInputPlane = input_.size(-3);
-  const int64_t inputHeight = input_.size(-2);
-  const int64_t inputWidth = input_.size(-1);
+  const int64_t nbatch = input.ndimension() == 4 ? input.size(-4) : 1;
+  const int64_t nInputPlane = input.size(-3);
+  const int64_t inputHeight = input.size(-2);
+  const int64_t inputWidth = input.size(-1);
 
   const int64_t outputHeight = pooling_output_shape<int64_t>(inputHeight, kH, padH, dH, dilationH, ceil_mode);
   const int64_t outputWidth = pooling_output_shape<int64_t>(inputWidth, kW, padW, dW, dilationW, ceil_mode);
 
   pool2d_shape_check(
-    input_,
+    input,
     kH, kW, dH, dW, padH, padW, dilationH, dilationW,
     nInputPlane,
     inputHeight, inputWidth,
     outputHeight, outputWidth);
 
-  /* get contiguous input */
-  Tensor input = input_.contiguous();
-
-  /* resize output */
-  if (input.ndimension() == 3)
-  {
+  /* resize output and indices */
+  if (input.ndimension() == 3) {
     output.resize_({nInputPlane, outputHeight, outputWidth});
     /* indices will contain the locations for each output point */
     indices.resize_({nInputPlane, outputHeight, outputWidth});
-
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
-      "max_pool2d_with_indices_cpu",
-      [&] {
-        /* get raw pointers */
-        scalar_t *input_data = input.data_ptr<scalar_t>();
-        scalar_t *output_data = output.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
-
-        max_pool2d_with_indices_single_out_frame(
-          input_data, output_data,
-          indices_data,
-          nInputPlane,
-          inputWidth, inputHeight,
-          outputWidth, outputHeight,
-          kW, kH, dW, dH,
-          padW, padH,
-          dilationW, dilationH);
-      }
-    );
-  }
-  else
-  {
-    output.resize_({nbatch, nInputPlane, outputHeight, outputWidth});
+  } else {
+    output.resize_({nbatch, nInputPlane, outputHeight, outputWidth}, input.suggest_memory_format());
     /* indices will contain the locations for each output point */
-    indices.resize_({nbatch, nInputPlane, outputHeight, outputWidth});
-
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
-      "max_pool2d_with_indices_cpu",
-      [&] {
-        scalar_t *input_data = input.data_ptr<scalar_t>();
-        scalar_t *output_data = output.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
-
-        max_pool2d_with_indices_out_frame(
-          input_data,
-          output_data,
-          indices_data,
-          nbatch,
-          nInputPlane,
-          inputWidth, inputHeight,
-          outputWidth, outputHeight,
-          kW, kH, dW, dH,
-          padW, padH,
-          dilationW, dilationH); }
-    );
+    indices.resize_({nbatch, nInputPlane, outputHeight, outputWidth}, input.suggest_memory_format());
   }
-}
 
-template <typename scalar_t>
-static void max_pool2d_with_indices_backward_single_out_frame(
-          scalar_t *gradInput_p,
-          scalar_t *gradOutput_p,
-          int64_t *ind_p,
-          int64_t nInputPlane,
-          int64_t inputWidth,
-          int64_t inputHeight,
-          int64_t outputWidth,
-          int64_t outputHeight,
-          int dW,
-          int dH)
-{
-  at::parallel_for(0, nInputPlane, 0, [&](int64_t start, int64_t end) {
-    for (auto k = start; k < end; k++)
-    {
-      scalar_t *gradInput_p_k = gradInput_p + k*inputWidth*inputHeight;
-      scalar_t *gradOutput_p_k = gradOutput_p + k*outputWidth*outputHeight;
-      int64_t *ind_p_k = ind_p + k*outputWidth*outputHeight;
-
-      /* calculate max points */
-      int64_t i, j;
-      for(i = 0; i < outputHeight; i++)
-      {
-        for(j = 0; j < outputWidth; j++)
-        {
-          /* retrieve position of max */
-          int64_t maxp = ind_p_k[i*outputWidth + j];
-          if (maxp != -1) {
-            /* update gradient */
-            gradInput_p_k[maxp] += gradOutput_p_k[i*outputWidth + j];
-          }
-        }
-      }
-    }
-  });
-}
-
-template <typename scalar_t>
-static void max_pool2d_with_indices_backward_out_frame(
-          scalar_t *gradInput_data,
-          scalar_t *gradOutput_data,
-          int64_t *indices_data,
-          int64_t nbatch,
-          int64_t nInputPlane,
-          int64_t inputWidth,
-          int64_t inputHeight,
-          int64_t outputWidth,
-          int64_t outputHeight,
-          int dW,
-          int dH)
-{
-  at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
-    for (auto p = start; p < end; p++) {
-      max_pool2d_with_indices_backward_single_out_frame<scalar_t>(
-        gradInput_data+p*nInputPlane*inputWidth*inputHeight,
-        gradOutput_data+p*nInputPlane*outputWidth*outputHeight,
-        indices_data+p*nInputPlane*outputWidth*outputHeight,
-        nInputPlane,
-        inputWidth, inputHeight,
-        outputWidth, outputHeight,
-        dW, dH);
-    }
-  });
+  max_pool2d_kernel(
+      kCPU, output, indices, input,
+      kW, kH,
+      dW, dH,
+      padW, padH,
+      dilationW, dilationH);
 }
 
 Tensor& max_pool2d_with_indices_backward_out_cpu_template(
           Tensor& gradInput,
-          const Tensor& gradOutput_,
+          const Tensor& gradOutput,
           const Tensor& input,
           const Tensor& indices,
           IntArrayRef kernel_size,
@@ -333,11 +122,13 @@ Tensor& max_pool2d_with_indices_backward_out_cpu_template(
   TORCH_CHECK((input.ndimension() == 3 || input.ndimension() == 4),
     "non-empty 3D or 4D (batch mode) tensor expected for input");
 
-  /* get contiguous gradOutput */
-  const Tensor gradOutput = gradOutput_.contiguous();
+  TORCH_CHECK(input.dtype() == gradOutput.dtype(),
+    "expected dtype ", input.dtype(), " for `gradOutput` but got dtype ", gradOutput.dtype());
+  TORCH_CHECK(input.dtype() == gradInput.dtype(),
+    "expected dtype ", input.dtype(), " for `gradInput` but got dtype ", gradInput.dtype());
 
   /* resize */
-  gradInput.resize_as_(input);
+  gradInput.resize_(input.sizes(), input.suggest_memory_format());
   gradInput.zero_();
 
   /* sizes */
@@ -354,7 +145,7 @@ Tensor& max_pool2d_with_indices_backward_out_cpu_template(
 
   max_pool2d_backward_shape_check(
     input,
-    gradOutput_,
+    gradOutput,
     indices,
     nbatch,
     kH, kW, dH, dW, padH, padW, dilationH, dilationW,
@@ -362,48 +153,7 @@ Tensor& max_pool2d_with_indices_backward_out_cpu_template(
     inputHeight, inputWidth,
     outputHeight_for_shape_check, outputWidth_for_shape_check);
 
-  /* backprop */
-  if (input.ndimension() == 3)
-  {
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
-      "max_pool2d_with_indices_backward",
-      [&] {
-        /* get raw pointers */
-        scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-        scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
-
-        max_pool2d_with_indices_backward_single_out_frame(
-          gradInput_data, gradOutput_data,
-          indices_data,
-          nInputPlane,
-          inputWidth, inputHeight,
-          outputWidth, outputHeight,
-          dW, dH);
-      }
-    );
-  }
-  else
-  {
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
-      "max_pool2d_with_indices_backward",
-      [&] {
-        /* get raw pointers */
-        scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-        scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-        int64_t *indices_data = indices.data_ptr<int64_t>();
-
-        max_pool2d_with_indices_backward_out_frame<scalar_t>(
-          gradInput_data, gradOutput_data,
-          indices_data,
-          nbatch,
-          nInputPlane,
-          inputWidth, inputHeight,
-          outputWidth, outputHeight,
-          dW, dH);
-      }
-    );
-  }
+  max_pool2d_backward_kernel(kCPU, gradInput, gradOutput, indices);
 
   return gradInput;
 }
@@ -463,7 +213,7 @@ std::tuple<Tensor, Tensor> max_pool2d_with_indices_cpu(
 
 Tensor& max_pool2d_with_indices_backward_out_cpu(
   Tensor& gradInput,
-  const Tensor& gradOutput_,
+  const Tensor& gradOutput,
   const Tensor& input,
   IntArrayRef kernel_size,
   IntArrayRef stride,
@@ -474,7 +224,7 @@ Tensor& max_pool2d_with_indices_backward_out_cpu(
 {
   max_pool2d_with_indices_backward_out_cpu_template(
     gradInput,
-    gradOutput_,
+    gradOutput,
     input,
     indices,
     kernel_size,
@@ -486,7 +236,7 @@ Tensor& max_pool2d_with_indices_backward_out_cpu(
 }
 
 Tensor max_pool2d_with_indices_backward_cpu(
-  const Tensor& gradOutput_,
+  const Tensor& gradOutput,
   const Tensor& input,
   IntArrayRef kernel_size,
   IntArrayRef stride,
@@ -495,10 +245,10 @@ Tensor max_pool2d_with_indices_backward_cpu(
   bool ceil_mode,
   const Tensor& indices)
 {
-  auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto gradInput = at::empty({0}, input.options());
   max_pool2d_with_indices_backward_out_cpu_template(
     gradInput,
-    gradOutput_,
+    gradOutput,
     input,
     indices,
     kernel_size,
@@ -508,6 +258,9 @@ Tensor max_pool2d_with_indices_backward_cpu(
     ceil_mode);
   return gradInput;
 }
+
+DEFINE_DISPATCH(max_pool2d_kernel);
+DEFINE_DISPATCH(max_pool2d_backward_kernel);
 
 } // at::native
 } // at

--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -1,13 +1,19 @@
 #include <ATen/ATen.h>
-#include <ATen/Parallel.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/div_rtn.h>
-#include <tuple>
+#include <ATen/native/DispatchStub.h>
 
 #pragma once
 
 namespace at {
 namespace native {
+
+using max_pool2d_fn = void(*)(Tensor& output, Tensor& indices, const Tensor& input,
+    int kW, int kH, int dW, int dH, int padW, int padH, int dilationW, int dilationH);
+using max_pool2d_backward_fn = void(*)(Tensor& grad_input, const Tensor& grad_output, const Tensor& indices);
+
+DECLARE_DISPATCH(max_pool2d_fn, max_pool2d_kernel);
+DECLARE_DISPATCH(max_pool2d_backward_fn, max_pool2d_backward_kernel);
 
 namespace {
 

--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -15,6 +15,12 @@ using max_pool2d_backward_fn = void(*)(Tensor& grad_input, const Tensor& grad_ou
 DECLARE_DISPATCH(max_pool2d_fn, max_pool2d_kernel);
 DECLARE_DISPATCH(max_pool2d_backward_fn, max_pool2d_backward_kernel);
 
+// averge pooling has same signature for forward and backward
+using avg_pool2d_fn = void(*)(Tensor& output, const Tensor& input, int kW, int kH,
+    int dW, int dH, int padW, int padH, bool count_include_pad, c10::optional<int64_t> divisor_override);
+DECLARE_DISPATCH(avg_pool2d_fn, avg_pool2d_kernel);
+DECLARE_DISPATCH(avg_pool2d_fn, avg_pool2d_backward_kernel);
+
 namespace {
 
 template <typename dest_t, typename src_t>

--- a/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
@@ -1,0 +1,311 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/native/AdaptivePooling.h>
+#include <ATen/Parallel.h>
+#include <ATen/cpu/vec256/vec256.h>
+#include <ATen/native/cpu/utils.h>
+
+namespace at { namespace native {
+
+namespace {
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool(
+    Tensor& output_,
+    const Tensor& input_,
+    IntArrayRef output_size) {
+  auto input = input_.contiguous();
+  auto output = output_.contiguous();
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+
+  int64_t ndim = input.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? input.size(0) : input.size(0) * input.size(1);
+  int64_t input_height = input.size(-2);
+  int64_t input_width = input.size(-1);
+  int64_t output_height = output_size[0];
+  int64_t output_width = output_size[1];
+
+  // parallel on dim of N, C
+  at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t c = begin; c < end; c++) {
+      scalar_t* input_ptr = input_data + c * input_height * input_width;
+      scalar_t* output_ptr = output_data + c * output_height * output_width;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        int64_t ih0 = start_index(oh, output_height, input_height);
+        int64_t ih1 = end_index(oh, output_height, input_height);
+        int64_t kh = ih1 - ih0;
+
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t iw0 = start_index(ow, output_width, input_width);
+          int64_t iw1 = end_index(ow, output_width, input_width);
+          int64_t kw = iw1 - iw0;
+
+          // compute local average
+          scalar_t sum = 0;
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              sum += input_ptr[ih * input_width + iw];
+            }
+          }
+          output_ptr[oh * output_width + ow] = sum / kh / kw;
+        }
+      }
+    }
+  });
+
+  if (!output_.is_contiguous()) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool_channels_last(
+    Tensor& output_,
+    const Tensor& input_,
+    IntArrayRef output_size) {
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto input = input_.contiguous(memory_format);
+  auto output = output_.contiguous(memory_format);
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_height = input.size(2);
+  int64_t input_width = input.size(3);
+  int64_t output_height = output_size[0];
+  int64_t output_width = output_size[1];
+
+  using Vec = vec256::Vec256<scalar_t>;
+  // parallel on dim N, H, W
+  at::parallel_for(0, nbatch * output_height * output_width, 0, [&](int64_t begin, int64_t end) {
+    int64_t n = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    data_index_init(begin, n, nbatch, oh, output_height, ow, output_width);
+
+    for (int64_t i = begin; i < end; i++) {
+      int64_t ih0 = start_index(oh, output_height, input_height);
+      int64_t ih1 = end_index(oh, output_height, input_height);
+      int64_t kh = ih1 - ih0;
+
+      int64_t iw0 = start_index(ow, output_width, input_width);
+      int64_t iw1 = end_index(ow, output_width, input_width);
+      int64_t kw = iw1 - iw0;
+
+      scalar_t* out = output_data + i * channels;
+      int64_t size = channels;
+
+      // Note: For oridinary usage scenario, each out lane should
+      //   fit in L1 cache; otherwise consider block dim C.
+      // Pass I: zero the out lane
+      int64_t d1 = 0;
+      for (; d1 < size - (size % Vec::size()); d1 += Vec::size()) {
+        Vec out_vec = Vec(scalar_t(0));
+        out_vec.store(out + d1);
+      }
+      for (; d1 < size; d1++) {
+        out[d1] = scalar_t(0);
+      }
+      // Pass II: compute local sum
+      for (int64_t ih = ih0; ih < ih1; ih++) {
+        for (int64_t iw = iw0; iw < iw1; iw++) {
+          scalar_t* in = input_data + n * input_height * input_width * channels +
+              ih * input_width * channels + iw * channels;
+
+          int64_t d2 = 0;
+          for (; d2 < size - (size % Vec::size()); d2 += Vec::size()) {
+            Vec out_vec = Vec::loadu(out + d2) + Vec::loadu(in + d2);
+            out_vec.store(out + d2);
+          }
+          for (; d2 < size; d2++) {
+            out[d2] += in[d2];
+          }
+        }
+      }
+      // Pass III: compute local average
+      int64_t d3 = 0;
+      for (; d3 < size - (size % Vec::size()); d3 += Vec::size()) {
+        Vec out_vec = Vec::loadu(out + d3) / Vec(scalar_t(kh * kw));
+        out_vec.store(out + d3);
+      }
+      for (; d3 < size; d3++) {
+        out[d3] = out[d3] / kh / kw;
+      }
+
+      // move on to next output index
+      data_index_step(n, nbatch, oh, output_height, ow, output_width);
+    }
+  });
+
+  if (!output_.is_contiguous(memory_format)) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool_backward(
+    Tensor& grad_input_,
+    const Tensor& grad_output_) {
+  auto grad_output = grad_output_.contiguous();
+  auto grad_input = grad_input_.contiguous();
+
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+
+  int64_t ndim = grad_output.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? grad_output.size(0) : grad_output.size(0) * grad_output.size(1);
+  int64_t input_height = grad_input.size(-2);
+  int64_t input_width = grad_input.size(-1);
+  int64_t output_height = grad_output.size(-2);
+  int64_t output_width = grad_output.size(-1);
+
+  // parallel on dim of N, C
+  at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t c = begin; c < end; c++) {
+      scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
+      scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        int64_t ih0 = start_index(oh, output_height, input_height);
+        int64_t ih1 = end_index(oh, output_height, input_height);
+        int64_t kh = ih1 - ih0;
+
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t iw0 = start_index(ow, output_width, input_width);
+          int64_t iw1 = end_index(ow, output_width, input_width);
+          int64_t kw = iw1 - iw0;
+
+          scalar_t grad_delta = grad_output_ptr[oh * output_width + ow] / kh / kw;
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              grad_input_ptr[ih * input_width + iw] += grad_delta;
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous()) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool_backward_channels_last(
+    Tensor& grad_input_,
+    const Tensor& grad_output_) {
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto grad_input = grad_input_.contiguous(memory_format);
+  auto grad_output = grad_output_.contiguous(memory_format);
+
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+
+  int64_t nbatch = grad_input.size(0);
+  int64_t channels = grad_input.size(1);
+  int64_t input_height = grad_input.size(2);
+  int64_t input_width = grad_input.size(3);
+  int64_t output_height = grad_output.size(2);
+  int64_t output_width = grad_output.size(3);
+
+  using Vec = vec256::Vec256<scalar_t>;
+  // parallel on dim N
+  at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t n = begin; n < end; n++) {
+      scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
+      scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        int64_t ih0 = start_index(oh, output_height, input_height);
+        int64_t ih1 = end_index(oh, output_height, input_height);
+        int64_t kh = ih1 - ih0;
+
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t iw0 = start_index(ow, output_width, input_width);
+          int64_t iw1 = end_index(ow, output_width, input_width);
+          int64_t kw = iw1 - iw0;
+
+          scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
+          int64_t size = channels;
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              scalar_t* gin = grad_input_ptr + ih * input_width * channels + iw * channels;
+
+              int64_t d = 0;
+              for (; d < size - (size % Vec::size()); d += Vec::size()) {
+                Vec gin_vec = Vec::loadu(gin + d) + Vec::loadu(gout + d) / Vec(scalar_t(kh * kw));
+                gin_vec.store(gin + d);
+              }
+              for (; d < size; d++) {
+                gin[d] += gout[d] / kw / kw;
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous(memory_format)) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+void adaptive_avg_pool2d_kernel_impl(
+    Tensor& output,
+    const Tensor& input,
+    IntArrayRef output_size) {
+  switch (input.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d", [&] {
+        cpu_adaptive_avg_pool<scalar_t>(output, input, output_size);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d_channels_last", [&]{
+        cpu_adaptive_avg_pool_channels_last<scalar_t>(output, input, output_size);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+void adapative_avg_pool2d_backward_kernel_impl(
+    Tensor& grad_input,
+    const Tensor& grad_output) {
+  switch (grad_output.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES(grad_output.scalar_type(), "adaptive_avg_pool2d_backward", [&] {
+        cpu_adaptive_avg_pool_backward<scalar_t>(grad_input, grad_output);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES(grad_output.scalar_type(), "adaptive_avg_pool2d_backward_channels_last", [&]{
+        cpu_adaptive_avg_pool_backward_channels_last<scalar_t>(grad_input, grad_output);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(adaptive_avg_pool2d_kernel, &adaptive_avg_pool2d_kernel_impl);
+REGISTER_DISPATCH(adaptive_avg_pool2d_backward_kernel, &adapative_avg_pool2d_backward_kernel_impl);
+
+}} // at::native

--- a/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
@@ -1,0 +1,416 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/cpu/vec256/vec256.h>
+#include <ATen/native/Pool.h>
+#include <ATen/native/cpu/utils.h>
+
+namespace at { namespace native {
+
+namespace {
+
+template <typename scalar_t>
+void cpu_avg_pool(
+    Tensor& output_,
+    const Tensor& input_,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  auto input = input_.contiguous();
+  auto output = output_.contiguous();
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+
+  int64_t numel = output.numel();
+  int64_t ndim = input.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? input.size(0) : input.size(0) * input.size(1);
+  int64_t input_height = input.size(-2);
+  int64_t input_width = input.size(-1);
+  int64_t output_height = output.size(-2);
+  int64_t output_width = output.size(-1);
+
+  // parallel on dim N, C, H, W
+  at::parallel_for(0, numel, 0, [&](int64_t begin, int64_t end) {
+    int64_t c = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    data_index_init(begin, c, channels, oh, output_height, ow, output_width);
+
+    for (int64_t i = begin; i < end; i++) {
+      output_data[i] = static_cast<scalar_t>(0);
+
+      // local pointers
+      scalar_t* input_ptr = input_data + c * input_height * input_width;
+
+      // compute the mean of the input image...
+      int64_t ih0 = oh * dH - padH;
+      int64_t iw0 = ow * dW - padW;
+      int64_t ih1 = std::min(ih0 + kH, input_height + padH);
+      int64_t iw1 = std::min(iw0 + kW, input_width + padW);
+      int64_t pool_size = (ih1 - ih0) * (iw1 - iw0);
+      ih0 = std::max(ih0, (int64_t) 0);
+      iw0 = std::max(iw0, (int64_t) 0);
+      ih1 = std::min(ih1, input_height);
+      iw1 = std::min(iw1, input_width);
+
+      if (ih0 >= ih1 || iw0 >= iw1) {
+        // move on to next output index
+        data_index_step(c, channels, oh, output_height, ow, output_width);
+        continue;
+      }
+
+      scalar_t sum = 0;
+    
+      int64_t divide_factor;
+      if (divisor_override.has_value()) {
+        divide_factor = divisor_override.value();
+      } else {
+        if(count_include_pad) {
+          divide_factor = pool_size;
+        } else {
+          divide_factor = (ih1 - ih0) * (iw1 - iw0);
+        }
+      }
+
+      for (int64_t ih = ih0; ih < ih1; ih++) {
+        for (int64_t iw = iw0; iw < iw1; iw++) {
+          sum += input_ptr[ih * input_width + iw];
+        }
+      }
+      output_data[i] += sum / divide_factor;
+
+      // move on to next output index
+      data_index_step(c, channels, oh, output_height, ow, output_width);
+    }
+  });
+
+  if (!output_.is_contiguous()) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t>
+void cpu_avg_pool_channels_last(
+    Tensor& output_,
+    const Tensor& input_,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  TORCH_CHECK(input_.ndimension() == 4,
+              "average pooling with channels last format supports tensors with 4 dims");
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto input = input_.contiguous(memory_format);
+  auto output = output_.contiguous(memory_format);
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_height = input.size(2);
+  int64_t input_width = input.size(3);
+  int64_t output_height = output.size(2);
+  int64_t output_width = output.size(3);
+
+  using Vec = vec256::Vec256<scalar_t>;
+  // parallel on dim N, H, W
+  at::parallel_for(0, nbatch * output_height * output_width, 0, [&](int64_t begin, int64_t end) {
+    int64_t n = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    data_index_init(begin, n, nbatch, oh, output_height, ow, output_width);
+
+    int64_t size = channels;
+    int64_t len = size - (size % Vec::size());
+    for (int64_t i = begin; i < end; i++) {
+      // compute the mean of the input image...
+      int64_t ih0 = oh * dH - padH;
+      int64_t iw0 = ow * dW - padW;
+      int64_t ih1 = std::min(ih0 + kH, input_height + padH);
+      int64_t iw1 = std::min(iw0 + kW, input_width + padW);
+      int64_t pool_size = (ih1 - ih0) * (iw1 - iw0);
+      ih0 = std::max(ih0, (int64_t) 0);
+      iw0 = std::max(iw0, (int64_t) 0);
+      ih1 = std::min(ih1, input_height);
+      iw1 = std::min(iw1, input_width);
+
+      int64_t divide_factor;
+      if (divisor_override.has_value()) {
+        divide_factor = divisor_override.value();
+      } else {
+        if(count_include_pad) {
+          divide_factor = pool_size;
+        } else {
+          divide_factor = (ih1 - ih0) * (iw1 - iw0);
+        }
+      }
+
+      scalar_t* out = output_data + i * channels;
+
+      // Pass I: zero the out lane
+      int64_t d1 = 0;
+      for (; d1 < len; d1 += Vec::size()) {
+        Vec out_vec = Vec(scalar_t(0));
+        out_vec.store(out + d1);
+      }
+      for (; d1 < size; d1++) {
+        out[d1] = scalar_t(0);
+      }
+
+      if (ih0 >= ih1 || iw0 >= iw1) {
+        // move on to next output index
+        data_index_step(n, nbatch, oh, output_height, ow, output_width);
+        continue;
+      }
+
+      // Pass II: compute local sum
+      for (int64_t ih = ih0; ih < ih1; ih++) {
+        for (int64_t iw = iw0; iw < iw1; iw++) {
+          scalar_t* in = input_data + n * input_height * input_width * channels +
+              ih * input_width * channels + iw * channels;
+
+          int64_t d2 = 0;
+          for (; d2 < len; d2 += Vec::size()) {
+            Vec out_vec = Vec::loadu(out + d2) + Vec::loadu(in + d2);
+            out_vec.store(out + d2);
+          }
+          for (; d2 < size; d2++) {
+            out[d2] += in[d2];
+          }
+        }
+      }
+
+      // Pass III: compute local average
+      int64_t d3 = 0;
+      for (; d3 < len; d3 += Vec::size()) {
+        Vec out_vec = Vec::loadu(out + d3) / Vec(scalar_t(divide_factor));
+        out_vec.store(out + d3);
+      }
+      for (; d3 < size; d3++) {
+        out[d3] = out[d3] / divide_factor;
+      }
+
+      // move on to next output index
+      data_index_step(n, nbatch, oh, output_height, ow, output_width);
+    }
+  });
+
+  if (!output_.is_contiguous(memory_format)) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t>
+void cpu_avg_pool_backward(
+    Tensor& grad_input_,
+    const Tensor& grad_output_,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  auto grad_output = grad_output_.contiguous();
+  auto grad_input = grad_input_.contiguous();
+
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+
+  int64_t ndim = grad_output.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? grad_output.size(0) : grad_output.size(0) * grad_output.size(1);
+  int64_t input_height = grad_input.size(-2);
+  int64_t input_width = grad_input.size(-1);
+  int64_t output_height = grad_output.size(-2);
+  int64_t output_width = grad_output.size(-1);
+
+  // parallel on dim of N, C
+  at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t c = begin; c < end; c++) {
+      scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
+      scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t ih0 = oh * dH - padH;
+          int64_t iw0 = ow * dW - padW;
+          int64_t ih1 = std::min(ih0 + kH, input_height + padH);
+          int64_t iw1 = std::min(iw0 + kW, input_width + padW);
+          int64_t pool_size = (ih1 - ih0) * (iw1 - iw0);
+          ih0 = std::max(ih0, (int64_t) 0);
+          iw0 = std::max(iw0, (int64_t) 0);
+          ih1 = std::min(ih1, input_height);
+          iw1 = std::min(iw1, input_width);
+
+          int64_t divide_factor;
+          if (divisor_override.has_value()) {
+            divide_factor = divisor_override.value();
+          } else {
+            if(count_include_pad) {
+              divide_factor = pool_size;
+            } else {
+              divide_factor = (ih1 - ih0) * (iw1 - iw0);
+            }
+          }
+
+          scalar_t grad_delta = grad_output_ptr[oh * output_width + ow] / divide_factor;
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              grad_input_ptr[ih * input_width + iw] += grad_delta;
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous()) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+template <typename scalar_t>
+void cpu_avg_pool_backward_channels_last(
+    Tensor& grad_input_,
+    const Tensor& grad_output_,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto grad_input = grad_input_.contiguous(memory_format);
+  auto grad_output = grad_output_.contiguous(memory_format);
+
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+
+  int64_t nbatch = grad_input.size(0);
+  int64_t channels = grad_input.size(1);
+  int64_t input_height = grad_input.size(2);
+  int64_t input_width = grad_input.size(3);
+  int64_t output_height = grad_output.size(2);
+  int64_t output_width = grad_output.size(3);
+
+  using Vec = vec256::Vec256<scalar_t>;
+  // parallel on dim N
+  at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t n = begin; n < end; n++) {
+      scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
+      scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t ih0 = oh * dH - padH;
+          int64_t iw0 = ow * dW - padW;
+          int64_t ih1 = std::min(ih0 + kH, input_height + padH);
+          int64_t iw1 = std::min(iw0 + kW, input_width + padW);
+          int64_t pool_size = (ih1 - ih0) * (iw1 - iw0);
+          ih0 = std::max(ih0, (int64_t) 0);
+          iw0 = std::max(iw0, (int64_t) 0);
+          ih1 = std::min(ih1, input_height);
+          iw1 = std::min(iw1, input_width);
+
+          int64_t divide_factor;
+          if (divisor_override.has_value()) {
+            divide_factor = divisor_override.value();
+          } else {
+            if(count_include_pad) {
+              divide_factor = pool_size;
+            } else {
+               divide_factor = (ih1 - ih0) * (iw1 - iw0);
+            }
+          }
+
+          scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
+          int64_t size = channels;
+          int64_t len = size - (size % Vec::size());
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              scalar_t* gin = grad_input_ptr + ih * input_width * channels + iw * channels;
+
+              int64_t d = 0;
+              for (; d < len; d += Vec::size()) {
+                Vec gin_vec = Vec::loadu(gin + d) + Vec::loadu(gout + d) / Vec(scalar_t(divide_factor));
+                gin_vec.store(gin + d);
+              }
+              for (; d < size; d++) {
+                gin[d] += gout[d] / divide_factor;
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous(memory_format)) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+
+void avg_pool2d_kernel_impl(
+    Tensor& output,
+    const Tensor& input,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  switch (input.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Long, input.scalar_type(), "max_pool2d", [&] {
+        cpu_avg_pool<scalar_t>(output, input, kW, kH, dW, dH, padW, padH, count_include_pad, divisor_override);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Long, input.scalar_type(), "max_pool2d", [&] {
+        cpu_avg_pool_channels_last<scalar_t>(output, input, kW, kH, dW, dH, padW, padH, count_include_pad, divisor_override);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+void avg_pool2d_backward_kernel_impl(
+    Tensor& grad_input,
+    const Tensor& grad_output,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    bool count_include_pad,
+    c10::optional<int64_t> divisor_override) {
+  switch (grad_output.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Long, grad_output.scalar_type(), "avg_pool2d_backward", [&] {
+        cpu_avg_pool_backward<scalar_t>(grad_input, grad_output, kW, kH, dW, dH, padW, padH, count_include_pad, divisor_override);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Long, grad_output.scalar_type(), "avg_pool2d_backward", [&] {
+        cpu_avg_pool_backward_channels_last<scalar_t>(grad_input, grad_output, kW, kH, dW, dH, padW, padH, count_include_pad, divisor_override);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(avg_pool2d_kernel, &avg_pool2d_kernel_impl);
+REGISTER_DISPATCH(avg_pool2d_backward_kernel, &avg_pool2d_backward_kernel_impl);
+
+}} // at::native

--- a/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
@@ -1,0 +1,361 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/cpu/vec256/vec256.h>
+#include <ATen/native/Pool.h>
+#include <ATen/native/cpu/utils.h>
+
+namespace at { namespace native {
+
+namespace {
+
+template <typename scalar_t>
+void cpu_max_pool(
+    Tensor& output_,
+    Tensor indices_,
+    const Tensor& input_,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    int dilationW, int dilationH) {
+  auto input = input_.contiguous();
+  auto output = output_.contiguous();
+  auto indices = indices_.contiguous();
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+  auto indices_data = indices.data_ptr<int64_t>();
+
+  int64_t numel = output.numel();
+  int64_t ndim = input.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? input.size(0) : input.size(0) * input.size(1);
+  int64_t input_height = input.size(-2);
+  int64_t input_width = input.size(-1);
+  int64_t output_height = output.size(-2);
+  int64_t output_width = output.size(-1);
+
+  // parallel on dim N, C, H, W
+  at::parallel_for(0, numel, 0, [&](int64_t begin, int64_t end) {
+    int64_t c = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    data_index_init(begin, c, channels, oh, output_height, ow, output_width);
+
+    for (int64_t i = begin; i < end; i++) {
+      int64_t ih0 = oh * dH - padH;
+      int64_t iw0 = ow * dW - padW;
+      int64_t ih1 = std::min(ih0 + (kH - 1) * dilationH + 1, input_height);
+      int64_t iw1 = std::min(iw0 + (kW - 1) * dilationW + 1, input_width);
+      while(ih0 < 0) { ih0 += dilationH; }
+      while(iw0 < 0) { iw0 += dilationW; }
+
+      // local pointers
+      scalar_t* input_ptr = input_data + c * input_height * input_width;
+
+      // compute local max
+      int64_t maxindex = ih0 * input_width + iw0;
+      scalar_t maxval = -std::numeric_limits<scalar_t>::infinity();
+      for (int64_t ih = ih0; ih < ih1; ih += dilationH) {
+        for (int64_t iw = iw0; iw < iw1; iw += dilationW) {
+          int64_t index = ih * input_width + iw;
+          scalar_t val = input_ptr[index];
+          if ((val > maxval) || std::isnan(val)) {
+            maxval = val;
+            maxindex = index;
+          }
+        }
+      }
+
+      // set output to local max and store location of max
+      output_data[i] = maxval;
+      indices_data[i] = maxindex;
+
+      // move on to next output index
+      data_index_step(c, channels, oh, output_height, ow, output_width);
+    }
+  });
+
+  if (!output_.is_contiguous()) {
+    output_.copy_(output);
+  }
+  if (!indices_.is_contiguous()) {
+    indices_.copy_(indices);
+  }
+}
+
+template <typename scalar_t>
+void cpu_max_pool_channels_last(
+    Tensor& output_,
+    Tensor indices_,
+    const Tensor& input_,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    int dilationW, int dilationH) {
+  TORCH_CHECK(input_.ndimension() == 4,
+              "max pooling with channels last format supports tensors with 4 dims");
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto input = input_.contiguous(memory_format);
+  auto output = output_.contiguous(memory_format);
+  auto indices = indices_.contiguous(memory_format);
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+  auto indices_data = indices.data_ptr<int64_t>();
+
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_height = input.size(2);
+  int64_t input_width = input.size(3);
+  int64_t output_height = output.size(2);
+  int64_t output_width = output.size(3);
+
+  using Vec = vec256::Vec256<scalar_t>;
+  using integer_t = vec256::int_same_size_t<scalar_t>;
+  using iVec = vec256::Vec256<integer_t>;
+  // for the convience of vectorization, use integer of the same size of scalar_t,
+  //   e.g. int32_t for float, int64_t for double
+  // need to make sure doesn't overflow
+  TORCH_CHECK(input_height * input_width < std::numeric_limits<integer_t>::max());
+
+  // parallel on dim N, H, W
+  at::parallel_for(0, nbatch * output_height * output_width, 0, [&](int64_t begin, int64_t end) {
+    int64_t n = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    data_index_init(begin, n, nbatch, oh, output_height, ow, output_width);
+
+    int64_t size = channels;
+    int64_t len = size - (size % Vec::size());
+    // temp buffer holding index with integer_t
+    std::unique_ptr<integer_t []> index_buffer(new integer_t[len]);
+
+    for (int64_t i = begin; i < end; i++) {
+      int64_t ih0 = oh * dH - padH;
+      int64_t iw0 = ow * dW - padW;
+      int64_t ih1 = std::min(ih0 + (kH - 1) * dilationH + 1, input_height);
+      int64_t iw1 = std::min(iw0 + (kW - 1) * dilationW + 1, input_width);
+      while(ih0 < 0) { ih0 += dilationH; }
+      while(iw0 < 0) { iw0 += dilationW; }
+
+      scalar_t* out = output_data + i * channels;
+      int64_t* ind = indices_data + i * channels;
+
+      // Pass I: init out lane
+      iVec index0_vec = iVec(ih0 * input_width + iw0);
+      Vec out_vec = Vec(-std::numeric_limits<scalar_t>::infinity());
+      int64_t d1 = 0;
+      for (; d1 < len; d1 += Vec::size()) {
+        index0_vec.store(index_buffer.get() + d1);
+        out_vec.store(out + d1);
+      }
+      for (; d1 < size; d1++) {
+        ind[d1] = ih0 * input_width + iw0;
+        out[d1] = -std::numeric_limits<scalar_t>::infinity();
+      }
+      // Pass II: compute local max
+      for (int64_t ih = ih0; ih < ih1; ih += dilationH) {
+        for (int64_t iw = iw0; iw < iw1; iw += dilationW) {
+          scalar_t* in = input_data + n * input_height * input_width * channels +
+              ih * input_width * channels + iw * channels;
+
+          int64_t d2 = 0;
+          for (; d2 < len; d2 += Vec::size()) {
+            iVec index_vec = iVec(ih * input_width + iw);
+            Vec val_vec = Vec::loadu(in + d2);
+            iVec maxindex_vec = iVec::loadu(index_buffer.get() + d2);
+            Vec maxval_vec = Vec::loadu(out + d2);
+
+            // true = all ones, false = all zeros
+            Vec mask = (val_vec > maxval_vec) | val_vec.isnan();
+            iVec imask = vec256::cast<integer_t>(mask);
+            Vec out_vec = Vec::blendv(maxval_vec, val_vec, mask);
+            iVec ind_vec = iVec::blendv(maxindex_vec, index_vec, imask);
+
+            out_vec.store(out + d2);
+            ind_vec.store(index_buffer.get() + d2);
+          }
+          for (; d2 < size; d2++) {
+            int64_t index = ih * input_width + iw;
+            scalar_t val = in[d2];
+            int64_t maxindex = ind[d2];
+            scalar_t maxval = out[d2];
+
+            bool mask = (val > maxval) || std::isnan(val);
+            out[d2] = mask ? val : maxval;
+            ind[d2] = mask ? index : maxindex;
+          }
+        }
+      }
+      // convert indice data type
+      vec256::convert<integer_t, int64_t>(index_buffer.get(), ind, len);
+
+      // move on to next output index
+      data_index_step(n, nbatch, oh, output_height, ow, output_width);
+    }
+  });
+
+  if (!output_.is_contiguous(memory_format)) {
+    output_.copy_(output);
+  }
+  if (!indices_.is_contiguous(memory_format)) {
+    indices_.copy_(indices);
+  }
+}
+
+template <typename scalar_t>
+void cpu_max_pool_backward(
+    Tensor& grad_input_,
+    const Tensor& grad_output_,
+    const Tensor& indices_) {
+  auto grad_output = grad_output_.contiguous();
+  auto indices = indices_.contiguous();
+  auto grad_input = grad_input_.contiguous();
+
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+  auto indices_data = indices.data_ptr<int64_t>();
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+
+  int64_t ndim = grad_output.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? grad_output.size(0) : grad_output.size(0) * grad_output.size(1);
+  int64_t input_height = grad_input.size(-2);
+  int64_t input_width = grad_input.size(-1);
+  int64_t output_height = grad_output.size(-2);
+  int64_t output_width = grad_output.size(-1);
+
+  // parallel on dim of N, C
+  at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t c = begin; c < end; c++) {
+      scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
+      scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
+      int64_t * indices_ptr = indices_data + c * output_height * output_width;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          // retrieve position of max
+          int64_t index = oh * output_width + ow;
+          int64_t maxindex = indices_ptr[index];
+          if (maxindex != -1) {
+            // update gradient
+            grad_input_ptr[maxindex] += grad_output_ptr[index];
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous()) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+template <typename scalar_t>
+void cpu_max_pool_backward_channels_last(
+    Tensor& grad_input_,
+    const Tensor& grad_output_,
+    const Tensor& indices_) {
+  TORCH_CHECK(grad_output_.ndimension() == 4,
+              "max pooling backward with channels last format supports tensors with 4 dims.");
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto grad_input = grad_input_.contiguous(memory_format);
+  auto grad_output = grad_output_.contiguous(memory_format);
+  auto indices = indices_.contiguous(memory_format);
+
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+  auto indices_data = indices.data_ptr<int64_t>();
+
+  int64_t nbatch = grad_input.size(0);
+  int64_t channels = grad_input.size(1);
+  int64_t input_height = grad_input.size(2);
+  int64_t input_width = grad_input.size(3);
+  int64_t output_height = grad_output.size(2);
+  int64_t output_width = grad_output.size(3);
+
+  // parallel on dim N
+  at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t n = begin; n < end; n++) {
+      scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
+      scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
+      int64_t* indices_ptr = indices_data + n * output_height * output_width * channels;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t index = oh * output_width + ow;
+
+          scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
+          int64_t* ind = indices_ptr + oh * output_width * channels + ow * channels;
+          // TODO: gcc vectorization
+          for (int64_t c = 0; c < channels; c++) {
+            int64_t maxindex = ind[c];
+            if (maxindex != -1) {
+              grad_input_ptr[maxindex * channels + c] += gout[c];
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous(memory_format)) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+void max_pool2d_kernel_impl(
+    Tensor& output,
+    Tensor& indices,
+    const Tensor& input,
+    int kW, int kH,
+    int dW, int dH,
+    int padW, int padH,
+    int dilationW, int dilationH) {
+  switch (input.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "max_pool2d", [&] {
+        cpu_max_pool<scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "max_pool2d_channels_last", [&] {
+        cpu_max_pool_channels_last<scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+void max_pool2d_backward_kernel_impl(
+    Tensor& grad_input,
+    const Tensor& grad_output,
+    const Tensor& indices) {
+  switch (grad_output.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES(grad_output.scalar_type(), "max_pool2d_backward", [&] {
+        cpu_max_pool_backward<scalar_t>(grad_input, grad_output, indices);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES(grad_output.scalar_type(), "max_pool2d_backward_channels_last", [&] {
+        cpu_max_pool_backward_channels_last<scalar_t>(grad_input, grad_output, indices);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(max_pool2d_kernel, &max_pool2d_kernel_impl);
+REGISTER_DISPATCH(max_pool2d_backward_kernel, &max_pool2d_backward_kernel_impl);
+
+}} // at::native

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -4,35 +4,11 @@
 #include <ATen/native/UpSample.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec256/vec256.h>
+#include <ATen/native/cpu/utils.h>
 
 namespace at {
 namespace native {
 namespace {
-
-template <typename T>
-inline T data_index_init(T offset) {
-  return offset;
-}
-
-template <typename T, typename... Args>
-inline T data_index_init(T offset, T &x, const T &X, Args &&... args) {
-  offset = data_index_init(offset, std::forward<Args>(args)...);
-  x = offset % X;
-  return offset / X;
-}
-
-inline bool data_index_step() {
-  return true;
-}
-
-template <typename T, typename... Args>
-inline bool data_index_step(T &x, const T &X, Args &&... args) {
-  if (data_index_step(std::forward<Args>(args)...)) {
-    x = ((x + 1) == X) ? 0 : (x + 1);
-    return x == 0;
-  }
-  return false;
-}
 
 static inline int64_t nearest_idx(
     int64_t output_index,

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace at { namespace native { namespace {
+
+template <typename T>
+inline T data_index_init(T offset) {
+  return offset;
+}
+
+template <typename T, typename... Args>
+inline T data_index_init(T offset, T &x, const T &X, Args &&... args) {
+  offset = data_index_init(offset, std::forward<Args>(args)...);
+  x = offset % X;
+  return offset / X;
+}
+
+inline bool data_index_step() {
+  return true;
+}
+
+template <typename T, typename... Args>
+inline bool data_index_step(T &x, const T &X, Args &&... args) {
+  if (data_index_step(std::forward<Args>(args)...)) {
+    x = ((x + 1) == X) ? 0 : (x + 1);
+    return x == 0;
+  }
+  return false;
+}
+
+}}}  // namespace at::native::<anonymous>

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10779,7 +10779,8 @@ class TestNNDeviceType(NNTestCase):
         helper(1, 100000, 32, 32, ks=4)
         helper(1, 100000, 1, 4, ks=(1, 4))  # test for max_pool1d
 
-    @onlyCUDA
+    @onlyOnCPUAndCUDA
+    @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     def test_max_pool2d_nhwc(self, device, dtype):
         def helper(n, c, h, w, kernel_size, stride=None):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3536,49 +3536,57 @@ class TestNN(NNTestCase):
                 output = module(input)
                 self.assertEqual(output.size(), (4,) + (2,) * (numel - 1) + (4,))
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_adaptive_pooling_avg_nhwc(self):
-        input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32, device="cuda")
-        input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
-        grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32, device="cuda")
-        pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        device_list = ['cpu']
+        if TEST_CUDA:
+            device_list.append('cuda')
 
-        ref_input = input.detach().clone().contiguous().requires_grad_(True)
-        ref_grad = grad.detach().clone().contiguous()
-        ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        for device in device_list:
+            input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
+            input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
+            grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
+            pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        out = pool(input)
-        out.backward(grad)
-        ref_out = ref_pool(ref_input)
-        ref_out.backward(ref_grad)
+            ref_input = input.detach().clone().contiguous().requires_grad_(True)
+            ref_grad = grad.detach().clone().contiguous()
+            ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-        self.assertTrue(ref_out.is_contiguous())
-        self.assertEqual(out, ref_out)
-        self.assertEqual(input.grad, ref_input.grad)
+            out = pool(input)
+            out.backward(grad)
+            ref_out = ref_pool(ref_input)
+            ref_out.backward(ref_grad)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+            self.assertTrue(ref_out.is_contiguous())
+            self.assertEqual(out, ref_out)
+            self.assertEqual(input.grad, ref_input.grad)
+
     def test_adaptive_pooling_avg_nhwc_non_contiguous(self):
-        input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32, device="cuda")
-        input = input.contiguous(memory_format=torch.channels_last)
-        input = input[:, ::2, :, :].requires_grad_()
-        grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32, device="cuda")
-        grad = grad[:, ::2, :, :]
-        pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        device_list = ['cpu']
+        if TEST_CUDA:
+            device_list.append('cuda')
 
-        ref_input = input.detach().clone().contiguous().requires_grad_(True)
-        ref_grad = grad.detach().clone().contiguous()
-        ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        for device in device_list:
+            input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
+            input = input.contiguous(memory_format=torch.channels_last)
+            input = input[:, ::2, :, :].requires_grad_()
+            grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
+            grad = grad[:, ::2, :, :]
+            pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        out = pool(input)
-        out.backward(grad)
-        ref_out = ref_pool(ref_input)
-        ref_out.backward(ref_grad)
+            ref_input = input.detach().clone().contiguous().requires_grad_(True)
+            ref_grad = grad.detach().clone().contiguous()
+            ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-        self.assertTrue(ref_out.is_contiguous())
-        self.assertEqual(out, ref_out)
-        self.assertEqual(input.grad, ref_input.grad)
+            out = pool(input)
+            out.backward(grad)
+            ref_out = ref_pool(ref_input)
+            ref_out.backward(ref_grad)
+
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+            self.assertTrue(ref_out.is_contiguous())
+            self.assertEqual(out, ref_out)
+            self.assertEqual(input.grad, ref_input.grad)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @largeTensorTest('12GB', device='cuda')

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10652,7 +10652,8 @@ class TestNNDeviceType(NNTestCase):
         for mf in (torch.contiguous_format, torch.channels_last, 'non_contiguous'):
             helper((2, 3, 6, 6), mf)
 
-    @onlyCUDA
+    @onlyOnCPUAndCUDA
+    @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     def test_avg_pool2d_nhwc(self, device, dtype):
         def helper(n, c, h, w, kernel_size, stride=None,


### PR DESCRIPTION
This patch adds channels last support for nn.AvgPool2d for CPU.
For channels last memory format, vectorization is done on dimension of C.

On Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz, 2*20 cores, comparing CL v.s. contiguous:

* single core inference (BS=1): 6.7x speedup
* single socket inference (BS=1): 3.7x speedup
* single socket inference (BS=128): 2.5x speedup

```bash
(before)
### single core inference
AvgPool2d(contiguous): input_size [1, 64, 112, 112] time: 2.100 ms

### single socket inference
AvgPool2d(contiguous): input_size [1, 64, 112, 112] time: 0.132 ms
AvgPool2d(contiguous): input_size [128, 64, 112, 112] time: 16.533 ms

(after)
### single core inference
AvgPool2d(contiguous): input_size [1, 64, 112, 112] time: 2.032 ms
AvgPool2d(channels_last): input_size [1, 64, 112, 112] time: 0.304 ms

### single socket inference
AvgPool2d(contiguous): input_size [1, 64, 112, 112] time: 0.119 ms
AvgPool2d(channels_last): input_size [1, 64, 112, 112] time: 0.032 ms
AvgPool2d(contiguous): input_size [128, 64, 112, 112] time: 14.420 ms
AvgPool2d(channels_last): input_size [128, 64, 112, 112] time: 5.784 ms
```

This patch depends on #42104, #42719