### PR TITLE
Fix compiler warning variable "num_ivalue_args" was declared but never referenced detected during:

### DIFF
--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -323,8 +323,6 @@ namespace impl {
   call_functor_with_args_from_stack_(Functor* functor, Stack* stack, std::index_sequence<ivalue_arg_indices...>) {
     (void)(stack); // when sizeof...(ivalue_arg_indices) == 0, this argument would be unused and we have to silence the compiler warning.
 
-    constexpr size_t num_ivalue_args = sizeof...(ivalue_arg_indices);
-
     /*
      * For ops that take "Tensor&" as an argument, ivalue_to_arg would still return a "Tensor" by value
      * and C++ doesn't allow us to call (*functor) with a temporary "Tensor" when it expects "Tensor&".
@@ -335,7 +333,7 @@ namespace impl {
     using ArgTypes = typename guts::infer_function_traits_t<Functor>::parameter_types;
     return (*functor)(reference_cast<guts::typelist::element_t<ivalue_arg_indices, ArgTypes>>(
       ivalue_to_arg<std::decay_t<guts::typelist::element_t<ivalue_arg_indices, ArgTypes>>, AllowDeprecatedTypes>::call(
-        std::move(torch::jit::peek(*stack, ivalue_arg_indices, num_ivalue_args))
+        std::move(torch::jit::peek(*stack, ivalue_arg_indices, sizeof...(ivalue_arg_indices)))
     ))...);
   }
 


### PR DESCRIPTION
```
/home/gaoxiang/.local/lib/python3.8/site-packages/torch/include/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h(326): warning: variable "num_ivalue_args" was declared but never referenced
          detected during:
            instantiation of "std::decay_t<c10::guts::infer_function_traits<Functor>::type::return_type> c10::impl::call_functor_with_args_from_stack_<Functor,AllowDeprecatedTypes,ivalue_arg_indices...>(Functor *, c10::Stack *, std::index_sequence<ivalue_arg_indices...>) [with Functor=c10::impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<__nv_bool ()>>, AllowDeprecatedTypes=false, ivalue_arg_indices=<>]" 
(346): here
            instantiation of "std::decay_t<c10::guts::infer_function_traits<Functor>::type::return_type> c10::impl::call_functor_with_args_from_stack<Functor,AllowDeprecatedTypes>(Functor *, c10::Stack *) [with Functor=c10::impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<__nv_bool ()>>, AllowDeprecatedTypes=false]" 
(396): here
            instantiation of "void c10::impl::make_boxed_from_unboxed_functor<KernelFunctor, AllowDeprecatedTypes>::call(c10::OperatorKernel *, const c10::OperatorHandle &, c10::Stack *) [with KernelFunctor=c10::impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<__nv_bool ()>>, AllowDeprecatedTypes=false]" 
/home/gaoxiang/.local/lib/python3.8/site-packages/torch/include/ATen/core/boxing/KernelFunction_impl.h(109): here
            instantiation of "c10::KernelFunction c10::KernelFunction::makeFromUnboxedFunctor<AllowLegacyTypes,KernelFunctor>(std::unique_ptr<c10::OperatorKernel, std::default_delete<c10::OperatorKernel>>) [with AllowLegacyTypes=false, KernelFunctor=c10::impl::WrapFunctionIntoRuntimeFunctor<std::decay_t<__nv_bool ()>>]" 
/home/gaoxiang/.local/lib/python3.8/site-packages/torch/include/ATen/core/boxing/KernelFunction_impl.h(175): here
            instantiation of "c10::KernelFunction c10::KernelFunction::makeFromUnboxedRuntimeFunction(FuncType *) [with AllowLegacyTypes=false, FuncType=__nv_bool ()]" 
/home/gaoxiang/.local/lib/python3.8/site-packages/torch/include/torch/library.h(92): here
            instantiation of "torch::CppFunction::CppFunction(Func *, std::enable_if_t<c10::guts::is_function_type<Func>::value, std::nullptr_t>) [with Func=__nv_bool ()]" 
/home/gaoxiang/.local/lib/python3.8/site-packages/torch/include/torch/library.h(457): here
            instantiation of "torch::Library &torch::Library::def(NameOrSchema &&, Func &&) & [with NameOrSchema=const char (&)[23], Func=__nv_bool (*)()]" 
/home/gaoxiang/extension-jit/test.cu(6): here
```