### PR TITLE
[PyTorch] Introduce packed SizesAndStrides abstraction

### DIFF
--- a/aten/src/ATen/BatchedTensorImpl.cpp
+++ b/aten/src/ATen/BatchedTensorImpl.cpp
@@ -19,18 +19,17 @@ BatchedTensorImpl::BatchedTensorImpl(Tensor value, BatchDims bdims)
 
   const auto public_dims = value_.dim() - bdims_.size();
   const auto value_sizes = value_.sizes();
-  sizes_.clear();
-  sizes_.reserve(public_dims);
+  sizes_and_strides_.resize(public_dims);
   for (int64_t dim = 0; dim < public_dims; dim++) {
     auto actual_dim = actualDim(dim, /*wrap_dim=*/false);
-    sizes_.push_back(value_sizes.at(actual_dim));
+    sizes_and_strides_.size_at_unchecked(dim) = value_sizes.at(actual_dim);
   }
   refresh_numel();
 }
 
 int64_t BatchedTensorImpl::actualDim(int64_t dim, bool wrap_dim) const {
   if (wrap_dim) {
-    const auto ndim = sizes_.size();
+    const auto ndim = sizes_and_strides_.size();
     dim = maybe_wrap_dim(dim, ndim);
   }
   auto is_bdim = createBatchDimBitset(bdims_);

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -27,7 +27,8 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       c10::IntArrayRef sizes)
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
-    sizes_ = sizes.vec();
+    sizes_and_strides_.resize(sizes.size());
+    std::copy(sizes.begin(), sizes.end(), sizes_and_strides_.sizes_begin());
     refresh_numel();
   }
 
@@ -84,7 +85,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<OpaqueTensorImpl<OpaqueHandle>>(
-        key_set(), dtype(), device(), opaque_handle_, sizes_);
+        key_set(), dtype(), device(), opaque_handle_, IntArrayRef{sizes_and_strides_.sizes_data(), sizes_and_strides_.size()});
     copy_tensor_metadata(
         /*src_impl=*/this,
         /*dest_impl=*/impl.get(),

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -56,7 +56,8 @@ public:
   // respect to indices and values
   void raw_resize_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {
     TORCH_CHECK(allow_tensor_metadata_change(), "raw_resize_ ", err_msg_tensor_metadata_change_not_allowed);
-    sizes_ = size.vec();
+    sizes_and_strides_.resize(size.size());
+    std::copy(size.begin(), size.end(), sizes_and_strides_.sizes_begin());
     sparse_dim_ = sparse_dim;
     dense_dim_ = dense_dim;
     refresh_numel();
@@ -126,7 +127,8 @@ public:
         "shrinking the size of dense dimensions (from ", dense_size_original, " to ", dense_size_new, ") on a non-empty sparse tensor is not supported.\n", alt_options_msg);
     }
 
-    if ((!size.equals(sizes_)) || (sparse_dim != sparse_dim_) || (dense_dim != dense_dim_)) {
+    const bool size_equals_sizes = size.size() == sizes_and_strides_.size() && memcmp(size.data(), sizes_and_strides_.sizes_data(), sizes_and_strides_.size() * sizeof(*size.data())) == 0;
+    if ((!size_equals_sizes) || (sparse_dim != sparse_dim_) || (dense_dim != dense_dim_)) {
       auto nnz = values().size(0);
       std::vector<int64_t> values_size = {nnz};
       auto dense_size = size.slice(sparse_dim);
@@ -135,7 +137,10 @@ public:
       indices_.resize_({sparse_dim, nnz});
     }
 
-    sizes_ = size.vec();
+    if (!size_equals_sizes) {
+      sizes_and_strides_.resize(size.size());
+      std::copy(size.begin(), size.end(), sizes_and_strides_.sizes_begin());
+    }
     sparse_dim_ = sparse_dim;
     dense_dim_ = dense_dim;
     refresh_numel();
@@ -146,7 +151,8 @@ public:
     TORCH_CHECK(allow_tensor_metadata_change(), "resize_and_clear_ ", err_msg_tensor_metadata_change_not_allowed);
     TORCH_CHECK(sparse_dim + dense_dim == static_cast<int64_t>(size.size()), "number of dimensions must be sparse_dim (", sparse_dim, ") + dense_dim (", dense_dim, "), but got ", size.size());
 
-    sizes_ = size.vec();
+    sizes_and_strides_.resize(size.size());
+    std::copy(size.begin(), size.end(), sizes_and_strides_.sizes_begin());
     sparse_dim_ = sparse_dim;
     dense_dim_ = dense_dim;
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -56,7 +56,6 @@ TensorImpl::TensorImpl(DispatchKeySet key_set, const caffe2::TypeMeta data_type,
 TensorImpl::TensorImpl(Storage&& storage, DispatchKeySet key_set, const caffe2::TypeMeta data_type,
                        c10::optional<c10::Device> device_opt)
     : storage_(std::move(storage)),
-      sizes_{0},
       storage_offset_(0),
       numel_(0),
       data_type_(data_type),
@@ -80,15 +79,14 @@ TensorImpl::TensorImpl(Storage&& storage, DispatchKeySet key_set, const caffe2::
 
   // we would also like to check that non-cpu devices have an index, but some Caffe2 operators create
   // Storages with default devices.
-  strides_.push_back(1);
 }
 
 IntArrayRef TensorImpl::sizes() const {
-  return sizes_;
+  return IntArrayRef{sizes_and_strides_.sizes_data(), sizes_and_strides_.size()};
 }
 
 IntArrayRef TensorImpl::strides() const {
-  return strides_;
+  return IntArrayRef{sizes_and_strides_.strides_data(), sizes_and_strides_.size()};
 }
 
 bool TensorImpl::compute_contiguous() const {
@@ -97,9 +95,10 @@ bool TensorImpl::compute_contiguous() const {
     return is_contiguous;
   int64_t z = 1;
   for (int64_t d = dim() - 1; d >= 0; d--) {
-    if (sizes_[d] != 1) {
-      if (strides_[d] == z) {
-        z *= sizes_[d];
+    const auto size_d = sizes_and_strides_.size_at_unchecked(d);
+    if (size_d != 1) {
+      if (sizes_and_strides_.stride_at_unchecked(d) == z) {
+        z *= size_d;
       } else {
         is_contiguous = false;
         break;
@@ -112,16 +111,17 @@ bool TensorImpl::compute_contiguous() const {
 bool TensorImpl::compute_channels_last_contiguous_2d() const {
   // Please don't combine these code, constant array is used here to let
   // compiler fully unroll the loop to get better performance
-  switch (sizes_.size()) {
+  switch (sizes_and_strides_.size()) {
     case 4:
       {
         int64_t expected = 1;
         for (auto& d : {1, 3, 2, 0}) {
-          if (sizes_[d] != 1) {
-            if (strides_[d] != expected) {
+          const auto size_d = sizes_and_strides_.size_at_unchecked(d);
+          if (size_d != 1) {
+            if (sizes_and_strides_.stride_at_unchecked(d) != expected) {
               return false;
             }
-            expected *= sizes_[d];
+            expected *= size_d;
           }
         }
         return true;
@@ -137,16 +137,17 @@ bool TensorImpl::compute_channels_last_contiguous_2d() const {
 bool TensorImpl::compute_channels_last_contiguous_3d() const {
   // Please don't combine these code, constant array is used here to let
   // compiler fully unroll the loop to get better performance
-  switch (sizes_.size()) {
+  switch (sizes_and_strides_.size()) {
     case 5:
       {
         int64_t expected = 1;
         for (auto& d : {1, 4, 3, 2, 0}) {
-          if (sizes_[d] != 1) {
-            if (strides_[d] != expected) {
+          const auto size_d = sizes_and_strides_.size_at_unchecked(d);
+          if (size_d != 1) {
+            if (sizes_and_strides_.stride_at_unchecked(d) != expected) {
               return false;
             }
-            expected *= sizes_[d];
+            expected *= size_d;
           }
         }
         return true;
@@ -160,16 +161,16 @@ bool TensorImpl::compute_channels_last_contiguous_3d() const {
 }
 
 bool TensorImpl::compute_strides_like_channels_last_2d() const {
-  return is_channels_last_strides_2d(sizes_, strides_);
+  return is_channels_last_strides_2d(sizes(), strides());
 }
 
 bool TensorImpl::compute_strides_like_channels_last_3d() const {
-  return is_channels_last_strides_3d(sizes_, strides_);
+  return is_channels_last_strides_3d(sizes(), strides());
 }
 
 bool TensorImpl::compute_non_overlapping_and_dense() const {
   if (dim() == 1) {
-    return sizes_[0] < 2 || strides_[0] == 1;
+    return sizes_and_strides_.size_at_unchecked(0) < 2 || sizes_and_strides_.stride_at_unchecked(0) == 1;
   }
   SmallVector<int64_t,5> perm;
   perm.resize(dim());
@@ -178,22 +179,23 @@ bool TensorImpl::compute_non_overlapping_and_dense() const {
   }
   // Sort by strides, leaving 0 and 1 sized dims at the end of the array
   std::sort(perm.begin(), perm.end(), [&](int64_t a, int64_t b) {
-      if (sizes_[a] < 2) {
+      if (sizes_and_strides_.size_at_unchecked(a) < 2) {
         return false;
-      } else if (sizes_[b] < 2) {
+      } else if (sizes_and_strides_.size_at_unchecked(a) < 2) {
         return true;
       }
-      return strides_[a] < strides_[b];
+      return sizes_and_strides_.stride_at_unchecked(a) < sizes_and_strides_.stride_at_unchecked(b);
   });
   auto require_stride = 1;
   for (int64_t i = 0; i < dim(); i ++) {
-    if (sizes_[perm[i]] < 2) {
+    const auto size_perm_i = sizes_and_strides_.size_at_unchecked(perm[i]);
+    if (size_perm_i < 2) {
       return true;
     }
-    if (strides_[perm[i]] != require_stride) {
+    if (sizes_and_strides_.stride_at_unchecked(perm[i]) != require_stride) {
       return false;
     }
-    require_stride *= sizes_[perm[i]];
+    require_stride *= size_perm_i;
   }
   return true;
 }
@@ -206,17 +208,17 @@ void TensorImpl::release_resources() {
 }
 
 int64_t TensorImpl::dim() const {
-  return sizes_.size();
+  return sizes_and_strides_.size();
 }
 
 int64_t TensorImpl::size(int64_t d) const {
   d = at::maybe_wrap_dim(d, dim(), false);
-  return sizes_[d];
+  return sizes_and_strides_.size_at_unchecked(d);
 }
 
 int64_t TensorImpl::stride(int64_t d) const {
   d = at::maybe_wrap_dim(d, dim(), false);
-  return strides_[d];
+  return sizes_and_strides_.stride_at_unchecked(d);
 }
 
 bool TensorImpl::has_storage() const {
@@ -295,8 +297,7 @@ void TensorImpl::copy_tensor_metadata(
     const c10::VariableVersion& version_counter,
     bool allow_tensor_metadata_change) {
   dest_impl->storage_ = src_impl->storage_;
-  dest_impl->sizes_ = src_impl->sizes_;
-  dest_impl->strides_ = src_impl->strides_;
+  dest_impl->sizes_and_strides_ = src_impl->sizes_and_strides_;
   dest_impl->storage_offset_ = src_impl->storage_offset_;
   dest_impl->data_type_ = src_impl->data_type_;
   dest_impl->device_opt_ = src_impl->device_opt_;

--- a/c10/core/impl/SizesAndStrides.h
+++ b/c10/core/impl/SizesAndStrides.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+#include <c10/util/ArrayRef.h>
+#include <c10/util/SmallVector.h>
+
+namespace c10 {
+namespace impl {
+
+// Packed container for TensorImpl sizes and strides.
+class C10_API SizesAndStrides {
+ public:
+  // TODO: different iterator types for sizes & strides to prevent
+  // mixing the two accidentally.
+  using sizes_iterator = int64_t*;
+  using sizes_const_iterator = const int64_t*;
+  using strides_iterator = int64_t*;
+  using strides_const_iterator = const int64_t*;
+
+  SizesAndStrides() : sizes_{0}, strides_{1} {}
+
+  size_t size() const {
+    return sizes_.size();
+  }
+
+  const int64_t* sizes_data() const {
+    return sizes_.data();
+  }
+
+  int64_t* sizes_data() {
+    return sizes_.data();
+  }
+
+  sizes_const_iterator sizes_begin() const {
+    return sizes_data();
+  }
+
+  sizes_iterator sizes_begin()  {
+    return sizes_data();
+  }
+
+  sizes_const_iterator sizes_end() const {
+    return sizes_begin() + size();
+  }
+
+  sizes_iterator sizes_end() {
+    return sizes_begin() + size();
+  }
+
+  const int64_t* strides_data() const {
+    return strides_.data();
+  }
+
+  int64_t* strides_data() {
+    return strides_.data();
+  }
+
+  strides_const_iterator strides_begin() const {
+    return strides_data();
+  }
+
+  strides_iterator strides_begin() {
+    return strides_data();
+  }
+
+  strides_const_iterator strides_end() const {
+    return strides_begin() + size();
+  }
+
+  strides_iterator strides_end() {
+    return strides_begin() + size();
+  }
+
+  // Size accessors.
+  int64_t size_at(size_t idx) const {
+    return sizes_.at(idx);
+  }
+
+  int64_t& size_at(size_t idx) {
+    return sizes_.at(idx);
+  }
+
+  int64_t size_at_unchecked(size_t idx) const {
+    return sizes_[idx];
+  }
+
+  int64_t& size_at_unchecked(size_t idx) {
+    return sizes_[idx];
+  }
+
+  // Size accessors.
+  int64_t stride_at(size_t idx) const {
+    return strides_.at(idx);
+  }
+
+  int64_t& stride_at(size_t idx) {
+    return strides_.at(idx);
+  }
+
+  int64_t stride_at_unchecked(size_t idx) const {
+    return strides_[idx];
+  }
+
+  int64_t& stride_at_unchecked(size_t idx) {
+    return strides_[idx];
+  }
+
+  void resize(size_t sz) {
+    sizes_.resize(sz);
+    strides_.resize(sz);
+  }
+
+ private:
+  SmallVector<int64_t,5> sizes_;
+  SmallVector<int64_t,5> strides_;
+};
+
+} // namespace impl
+} // namespace c10

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -1,0 +1,309 @@
+#include <gtest/gtest.h>
+
+#include <c10/core/impl/SizesAndStrides.h>
+
+using namespace c10;
+using namespace c10::impl;
+
+static void checkData(const SizesAndStrides& sz, IntArrayRef sizes, IntArrayRef strides) {
+  EXPECT_EQ(sizes.size(), strides.size()) << "bad test case: size() of sizes and strides don't match";
+  EXPECT_EQ(sz.size(), sizes.size());
+
+  int idx = 0;
+  for (auto x: sizes) {
+    EXPECT_EQ(sz.size_at_unchecked(idx), x);
+    EXPECT_EQ(sz.size_at(idx), x);
+    EXPECT_EQ(sz.sizes_data()[idx], x);
+    EXPECT_EQ(*(sz.sizes_begin() + idx), x);
+    idx++;
+  }
+
+  idx = 0;
+  for (auto x: strides) {
+    EXPECT_EQ(sz.stride_at_unchecked(idx), x);
+    EXPECT_EQ(sz.stride_at(idx), x);
+    EXPECT_EQ(sz.strides_data()[idx], x);
+    EXPECT_EQ(*(sz.strides_begin() + idx), x);
+
+    idx++;
+  }
+}
+
+TEST(SizesAndStridesTest, DefaultConstructor) {
+  SizesAndStrides sz;
+  checkData(sz, {0}, {1});
+  // Can't test size_at() out of bounds because it just asserts for now.
+}
+
+TEST(SizesAndStridesTest, Resize) {
+  SizesAndStrides sz;
+
+  sz.resize(2);
+
+  // Small to small.
+  checkData(sz, {0, 0}, {1, 0});
+
+  // Small to small, again.
+  sz.resize(5);
+  checkData(sz, {0, 0, 0, 0, 0}, {1, 0, 0, 0, 0});
+
+  for (int ii = 0; ii < sz.size(); ++ii) {
+    sz.size_at_unchecked(ii) = ii + 1;
+    sz.stride_at_unchecked(ii) = 2 * (ii + 1);
+  }
+
+  checkData(sz, {1, 2, 3, 4, 5}, {2, 4, 6, 8, 10});
+
+  // Small to big.
+  sz.resize(6);
+
+  checkData(sz, {1, 2, 3, 4, 5, 0}, {2, 4, 6, 8, 10, 0});
+
+  sz.size_at_unchecked(5) = 6;
+  sz.stride_at_unchecked(5) = 12;
+
+  checkData(sz, {1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12});
+
+  // Big to big.
+  sz.resize(7);
+
+  checkData(sz, {1, 2, 3, 4, 5, 6, 0}, {2, 4, 6, 8, 10, 12, 0});
+
+  // Finally, big to small.
+
+  // Give it different data than it had when it was small to avoid
+  // getting it right by accident (i.e., because of leftover inline
+  // storage when going small to big).
+  for (int ii = 0; ii < sz.size(); ++ii) {
+    sz.size_at_unchecked(ii) = ii - 1;
+    sz.stride_at_unchecked(ii) = 2 * (ii - 1);
+  }
+
+  checkData(sz, {-1, 0, 1, 2, 3, 4, 5}, {-2, 0, 2, 4, 6, 8, 10});
+
+  sz.resize(5);
+  checkData(sz, {-1, 0, 1, 2, 3}, {-2, 0, 2, 4, 6});
+}
+
+TEST(SizesAndStridesTest, SetAtIndex) {
+  SizesAndStrides sz;
+
+  sz.resize(5);
+  sz.size_at(4) = 42;
+  sz.stride_at(4) = 23;
+
+  checkData(sz, {0, 0, 0, 0, 42}, {1, 0, 0, 0, 23});
+
+  sz.resize(6);
+  sz.size_at(5) = 43;
+  sz.stride_at(5) = 24;
+
+  checkData(sz, {0, 0, 0, 0, 42, 43}, {1, 0, 0, 0, 23, 24});
+}
+
+TEST(SizesAndStridesTest, SetAtIterator) {
+  SizesAndStrides sz;
+
+  sz.resize(5);
+  *(sz.sizes_begin() + 4) = 42;
+  *(sz.strides_begin() + 4) = 23;
+
+  checkData(sz, {0, 0, 0, 0, 42}, {1, 0, 0, 0, 23});
+
+  sz.resize(6);
+  *(sz.sizes_begin() + 5) = 43;
+  *(sz.strides_begin() + 5) = 24;
+
+  checkData(sz, {0, 0, 0, 0, 42, 43}, {1, 0, 0, 0, 23, 24});
+}
+
+TEST(SizesAndStridesTest, SetViaData) {
+  SizesAndStrides sz;
+
+  sz.resize(5);
+  *(sz.sizes_data() + 4) = 42;
+  *(sz.strides_data() + 4) = 23;
+
+  checkData(sz, {0, 0, 0, 0, 42}, {1, 0, 0, 0, 23});
+
+  sz.resize(6);
+  *(sz.sizes_data() + 5) = 43;
+  *(sz.strides_data() + 5) = 24;
+
+  checkData(sz, {0, 0, 0, 0, 42, 43}, {1, 0, 0, 0, 23, 24});
+}
+
+static SizesAndStrides makeSmall(int offset = 0) {
+  SizesAndStrides small;
+  small.resize(3);
+  for (int ii = 0; ii < small.size(); ++ii) {
+    small.size_at_unchecked(ii) = ii + 1 + offset;
+    small.stride_at_unchecked(ii) = 2 * (ii + 1 + offset);
+  }
+
+  return small;
+}
+
+static SizesAndStrides makeBig(int offset = 0) {
+  SizesAndStrides big;
+  big.resize(8);
+  for (int ii = 0; ii < big.size(); ++ii) {
+    big.size_at_unchecked(ii) = ii - 1 + offset;
+    big.stride_at_unchecked(ii) = 2 * (ii - 1 + offset);
+  }
+
+  return big;
+}
+
+TEST(SizesAndStridesTest, MoveConstructor) {
+  SizesAndStrides empty;
+
+  SizesAndStrides movedEmpty(std::move(empty));
+
+  EXPECT_EQ(empty.size(), 0);
+  EXPECT_EQ(movedEmpty.size(), 1);
+  checkData(movedEmpty, {0}, {1});
+
+  SizesAndStrides small = makeSmall();
+  checkData(small, {1, 2, 3}, {2, 4, 6});
+
+  SizesAndStrides movedSmall(std::move(small));
+  checkData(movedSmall, {1, 2, 3}, {2, 4, 6});
+  EXPECT_EQ(small.size(), 0);
+
+  SizesAndStrides big = makeBig();
+  checkData(big, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+
+  SizesAndStrides movedBig(std::move(big));
+  checkData(movedBig, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  EXPECT_EQ(big.size(), 0);
+}
+
+TEST(SizesAndStridesTest, CopyConstructor) {
+  SizesAndStrides empty;
+
+  SizesAndStrides copiedEmpty(empty);
+
+  EXPECT_EQ(empty.size(), 1);
+  EXPECT_EQ(copiedEmpty.size(), 1);
+  checkData(empty, {0}, {1});
+  checkData(copiedEmpty, {0}, {1});
+
+  SizesAndStrides small = makeSmall();
+  checkData(small, {1, 2, 3}, {2, 4, 6});
+
+  SizesAndStrides copiedSmall(small);
+  checkData(copiedSmall, {1, 2, 3}, {2, 4, 6});
+  checkData(small, {1, 2, 3}, {2, 4, 6});
+
+  SizesAndStrides big = makeBig();
+  checkData(big, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+
+  SizesAndStrides copiedBig(big);
+  checkData(big, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  checkData(copiedBig, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+}
+
+TEST(SizesAndStridesTest, CopyAssignmentSmallToSmall) {
+  SizesAndStrides smallTarget = makeSmall();
+  SizesAndStrides smallCopyFrom = makeSmall(1);
+
+  checkData(smallTarget, {1, 2, 3}, {2, 4, 6});
+  checkData(smallCopyFrom, {2, 3, 4}, {4, 6, 8});
+
+  smallTarget = smallCopyFrom;
+
+  checkData(smallCopyFrom, {2, 3, 4}, {4, 6, 8});
+  checkData(smallTarget, {2, 3, 4}, {4, 6, 8});
+}
+
+TEST(SizesAndStridesTest, MoveAssignmentSmallToSmall) {
+  SizesAndStrides smallTarget = makeSmall();
+  SizesAndStrides smallMoveFrom = makeSmall(1);
+
+  checkData(smallTarget, {1, 2, 3}, {2, 4, 6});
+  checkData(smallMoveFrom, {2, 3, 4}, {4, 6, 8});
+
+  smallTarget = std::move(smallMoveFrom);
+
+  checkData(smallTarget, {2, 3, 4}, {4, 6, 8});
+  EXPECT_EQ(smallMoveFrom.size(), 0);
+}
+
+TEST(SizesAndStridesTest, CopyAssignmentSmallToBig) {
+  SizesAndStrides bigTarget = makeBig();
+  SizesAndStrides smallCopyFrom = makeSmall();
+
+  checkData(bigTarget, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  checkData(smallCopyFrom, {1, 2, 3}, {2, 4, 6});
+
+  bigTarget = smallCopyFrom;
+
+  checkData(bigTarget, {1, 2, 3}, {2, 4, 6});
+  checkData(smallCopyFrom, {1, 2, 3}, {2, 4, 6});
+}
+
+TEST(SizesAndStridesTest, MoveAssignmentSmallToBig) {
+  SizesAndStrides bigTarget = makeBig();
+  SizesAndStrides smallMoveFrom = makeSmall();
+
+  checkData(bigTarget, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  checkData(smallMoveFrom, {1, 2, 3}, {2, 4, 6});
+
+  bigTarget = std::move(smallMoveFrom);
+
+  checkData(bigTarget, {1, 2, 3}, {2, 4, 6});
+  EXPECT_EQ(smallMoveFrom.size(), 0);
+}
+
+TEST(SizesAndStridesTest, CopyAssignmentBigToBig) {
+  SizesAndStrides bigTarget = makeBig();
+  SizesAndStrides bigCopyFrom = makeBig(1);
+
+  checkData(bigTarget, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  checkData(bigCopyFrom, {0, 1, 2, 3, 4, 5, 6, 7}, {0, 2, 4, 6, 8, 10, 12, 14});
+
+  bigTarget = bigCopyFrom;
+
+  checkData(bigTarget, {0, 1, 2, 3, 4, 5, 6, 7}, {0, 2, 4, 6, 8, 10, 12, 14});
+  checkData(bigCopyFrom, {0, 1, 2, 3, 4, 5, 6, 7}, {0, 2, 4, 6, 8, 10, 12, 14});
+}
+
+TEST(SizesAndStridesTest, MoveAssignmentBigToBig) {
+  SizesAndStrides bigTarget = makeBig();
+  SizesAndStrides bigMoveFrom = makeBig(1);
+
+  checkData(bigTarget, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  checkData(bigMoveFrom, {0, 1, 2, 3, 4, 5, 6, 7}, {0, 2, 4, 6, 8, 10, 12, 14});
+
+  bigTarget = std::move(bigMoveFrom);
+
+  checkData(bigTarget, {0, 1, 2, 3, 4, 5, 6, 7}, {0, 2, 4, 6, 8, 10, 12, 14});
+  EXPECT_EQ(bigMoveFrom.size(), 0);
+}
+
+TEST(SizesAndStridesTest, CopyAssignmentBigToSmall) {
+  SizesAndStrides smallTarget = makeSmall();
+  SizesAndStrides bigCopyFrom = makeBig();
+
+  checkData(smallTarget, {1, 2, 3}, {2, 4, 6});
+  checkData(bigCopyFrom, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+
+  smallTarget = bigCopyFrom;
+
+  checkData(smallTarget, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  checkData(bigCopyFrom, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+}
+
+TEST(SizesAndStridesTest, MoveAssignmentBigToSmall) {
+  SizesAndStrides smallTarget = makeSmall();
+  SizesAndStrides bigMoveFrom = makeBig();
+
+  checkData(smallTarget, {1, 2, 3}, {2, 4, 6});
+  checkData(bigMoveFrom, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+
+  smallTarget = std::move(bigMoveFrom);
+
+  checkData(smallTarget, {-1, 0, 1, 2, 3, 4, 5, 6}, {-2, 0, 2, 4, 6, 8, 10, 12});
+  EXPECT_EQ(bigMoveFrom.size(), 0);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47506 [PyTorch] Change representation of SizesAndStrides
* **#47505 [PyTorch] Introduce packed SizesAndStrides abstraction**

This introduces a new SizesAndStrides class as a helper for
TensorImpl, in preparation for changing its representation.

Differential Revision: [D24762557](https://our.internmc.facebook.com/intern/diff/D24762557/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24762557/)!