### PR TITLE
[PyTorch] Change representation of SizesAndStrides

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1776,22 +1776,17 @@ protected:
 //    autograd metadata pointer
 //    version counter pointer
 //    PyObject pointer
-//    sizes SmallVector (begin)
-//    sizes SmallVector (end)
-//    sizes SmallVector (capacity)
-//    sizes SmallVector (pre-allocated 0)
-//    sizes SmallVector (pre-allocated 1)
-//    sizes SmallVector (pre-allocated 2)
-//    sizes SmallVector (pre-allocated 3)
-//    sizes SmallVector (pre-allocated 4)
-//    strides SmallVector (begin)
-//    strides SmallVector (end)
-//    strides SmallVector (capacity)
-//    strides SmallVector (pre-allocated 0)
-//    strides SmallVector (pre-allocated 1)
-//    strides SmallVector (pre-allocated 2)
-//    strides SmallVector (pre-allocated 3)
-//    strides SmallVector (pre-allocated 4)
+//    SizesAndStrides size/pointer
+//    SizesAndStrides sizes (pre-allocated 0)
+//    SizesAndStrides sizes (pre-allocated 1)
+//    SizesAndStrides sizes (pre-allocated 2)
+//    SizesAndStrides sizes (pre-allocated 3)
+//    SizesAndStrides sizes (pre-allocated 4)
+//    SizesAndStrides strides (pre-allocated 0)
+//    SizesAndStrides strides (pre-allocated 1)
+//    SizesAndStrides strides (pre-allocated 2)
+//    SizesAndStrides strides (pre-allocated 3)
+//    SizesAndStrides strides (pre-allocated 4)
 //    storage offset
 //    numel
 //    data type
@@ -1800,7 +1795,7 @@ protected:
 //    miscellaneous bitfield
 //
 static_assert(sizeof(void*) != sizeof(int64_t) || // if 64-bit...
-              sizeof(TensorImpl) == sizeof(int64_t) * 29,
+              sizeof(TensorImpl) == sizeof(int64_t) * 24,
               "You changed the size of TensorImpl on 64-bit arch."
               "See Note [TensorImpl size constraints] on how to proceed.");
 } // namespace c10

--- a/c10/core/impl/SizesAndStrides.h
+++ b/c10/core/impl/SizesAndStrides.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <c10/macros/Macros.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/SmallVector.h>
@@ -8,6 +10,17 @@ namespace c10 {
 namespace impl {
 
 // Packed container for TensorImpl sizes and strides.
+// This design improves on the previous approach of using a pair of
+// c10::SmallVector<int64_t, 5> by specializing for the operations we
+// actually use and enforcing that the number of sizes is the same as
+// the number of strides. The memory layout is as follows:
+//
+// 1 tagged intptr_t; if the tag bit is 1, the data is stored inline and
+// the rest of the word indicates the size of the data. If the tag bit
+// is 0, the tag word is a pointer to an array of int64_t holding the
+// data; the first int64_t indicates the size of the rest.
+// 5 int64_t reserved for inline sizes
+// 5 int64_t reserved for inline strides
 class C10_API SizesAndStrides {
  public:
   // TODO: different iterator types for sizes & strides to prevent
@@ -17,26 +30,118 @@ class C10_API SizesAndStrides {
   using strides_iterator = int64_t*;
   using strides_const_iterator = const int64_t*;
 
-  SizesAndStrides() : sizes_{0}, strides_{1} {}
+  SizesAndStrides() {
+    setInlineSize(1);
+    size_at_unchecked(0) = 0;
+    stride_at_unchecked(0) = 1;
+  }
+
+  ~SizesAndStrides() {
+    if (C10_UNLIKELY(!isInline())) {
+      delete outOfLineStorage();
+    }
+  }
+
+  SizesAndStrides(const SizesAndStrides& rhs) {
+    if (C10_LIKELY(rhs.isInline())) {
+      copyFromInline(rhs);
+    } else {
+      taggedStorageOrSize_ = reinterpret_cast<int64_t>(new std::vector<int64_t>(*rhs.outOfLineStorage()));
+    }
+  }
+
+  SizesAndStrides& operator=(const SizesAndStrides& rhs) {
+    if (this == &rhs) {
+      return *this;
+    }
+    if (C10_LIKELY(rhs.isInline())) {
+      if (C10_UNLIKELY(!isInline())) {
+        delete outOfLineStorage();
+      }
+      copyFromInline(rhs);
+    } else {
+      if (isInline()) {
+        taggedStorageOrSize_ = reinterpret_cast<int64_t>(new std::vector<int64_t>(*rhs.outOfLineStorage()));
+      } else {
+        // Both out of line. Copy their storage into ours.
+        *outOfLineStorage() = *rhs.outOfLineStorage();
+      }
+    }
+    return *this;
+  }
+
+  // Move from rhs. rhs.size() == 0 afterwards.
+  SizesAndStrides(SizesAndStrides&& rhs) : taggedStorageOrSize_(rhs.taggedStorageOrSize_) {
+    if (C10_LIKELY(isInline())) {
+      memcpy(inlineStorage_, rhs.inlineStorage_, sizeof(inlineStorage_));
+    }
+
+    rhs.setInlineSize(0);
+  }
+
+  // Move from rhs. rhs.size() == 0 afterwards.
+  SizesAndStrides& operator=(SizesAndStrides&& rhs) {
+    if (this == &rhs) {
+      return *this;
+    }
+    if (C10_LIKELY(rhs.isInline())) {
+      if (C10_UNLIKELY(!isInline())) {
+        delete outOfLineStorage();
+      }
+      copyFromInline(rhs);
+    } else {
+      if (isInline()) {
+        // Steal their vector.
+        taggedStorageOrSize_ = rhs.taggedStorageOrSize_;
+      } else {
+        // Both out of line. Move their storage into ours.
+        *outOfLineStorage() = std::move(*rhs.outOfLineStorage());
+        delete rhs.outOfLineStorage();
+      }
+    }
+    rhs.setInlineSize(0);
+
+    return *this;
+  }
 
   size_t size() const {
-    return sizes_.size();
+    if (C10_LIKELY(isInline())) {
+      return taggedStorageOrSize_ >> 1;
+    } else {
+      return outOfLineStorage()->size() / 2;
+    }
   }
 
   const int64_t* sizes_data() const {
-    return sizes_.data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[0];
+    } else {
+      return outOfLineStorage()->data();
+    }
   }
 
   int64_t* sizes_data() {
-    return sizes_.data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[0];
+    } else {
+      return outOfLineStorage()->data();
+    }
   }
 
   sizes_const_iterator sizes_begin() const {
-    return sizes_data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[0];
+    } else {
+      return outOfLineStorage()->data();
+    }
   }
 
   sizes_iterator sizes_begin()  {
-    return sizes_data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[0];
+    } else {
+      return outOfLineStorage()->data();
+    }
   }
 
   sizes_const_iterator sizes_end() const {
@@ -48,19 +153,35 @@ class C10_API SizesAndStrides {
   }
 
   const int64_t* strides_data() const {
-    return strides_.data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[MAX_INLINE_SIZE];
+    } else {
+      return outOfLineStorage()->data() + size();
+    }
   }
 
   int64_t* strides_data() {
-    return strides_.data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[MAX_INLINE_SIZE];
+    } else {
+      return outOfLineStorage()->data() + size();
+    }
   }
 
   strides_const_iterator strides_begin() const {
-    return strides_data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[MAX_INLINE_SIZE];
+    } else {
+      return outOfLineStorage()->data() + size();
+    }
   }
 
   strides_iterator strides_begin() {
-    return strides_data();
+    if (C10_LIKELY(isInline())) {
+      return &inlineStorage_[MAX_INLINE_SIZE];
+    } else {
+      return outOfLineStorage()->data() + size();
+    }
   }
 
   strides_const_iterator strides_end() const {
@@ -73,46 +194,120 @@ class C10_API SizesAndStrides {
 
   // Size accessors.
   int64_t size_at(size_t idx) const {
-    return sizes_.at(idx);
+    assert(idx < size());
+    return sizes_data()[idx];
   }
 
   int64_t& size_at(size_t idx) {
-    return sizes_.at(idx);
+    assert(idx < size());
+    return sizes_data()[idx];
   }
 
   int64_t size_at_unchecked(size_t idx) const {
-    return sizes_[idx];
+    return sizes_data()[idx];
   }
 
   int64_t& size_at_unchecked(size_t idx) {
-    return sizes_[idx];
+    return sizes_data()[idx];
   }
 
   // Size accessors.
   int64_t stride_at(size_t idx) const {
-    return strides_.at(idx);
+    assert(idx < size());
+    return strides_data()[idx];
   }
 
   int64_t& stride_at(size_t idx) {
-    return strides_.at(idx);
+    assert(idx < size());
+    return strides_data()[idx];
   }
 
   int64_t stride_at_unchecked(size_t idx) const {
-    return strides_[idx];
+    return strides_data()[idx];
   }
 
   int64_t& stride_at_unchecked(size_t idx) {
-    return strides_[idx];
+    return strides_data()[idx];
   }
 
-  void resize(size_t sz) {
-    sizes_.resize(sz);
-    strides_.resize(sz);
+  void resize(const size_t newSize) {
+    const auto oldSize = size();
+    if (newSize == oldSize) {
+      return;
+    }
+    if (C10_LIKELY(newSize <= MAX_INLINE_SIZE)) {
+      size_t oldInlineSize = 0;
+      if (C10_LIKELY(isInline())) {
+        oldInlineSize = oldSize;
+        const auto bytesToZero = (newSize - oldInlineSize) * sizeof(inlineStorage_[0]);
+        memset(&inlineStorage_[oldInlineSize], 0, bytesToZero);
+        memset(&inlineStorage_[MAX_INLINE_SIZE + oldInlineSize], 0, bytesToZero);
+      } else {
+        memcpy(&inlineStorage_[0], outOfLineStorage()->data(), MAX_INLINE_SIZE * sizeof(inlineStorage_[0]));
+        memcpy(
+            &inlineStorage_[MAX_INLINE_SIZE],
+            outOfLineStorage()->data() + outOfLineStorage()->size() / 2,
+            MAX_INLINE_SIZE * sizeof(inlineStorage_[0]));
+        delete outOfLineStorage();
+      }
+      setInlineSize(newSize);
+    } else {
+      if (isInline()) {
+        taggedStorageOrSize_ = reinterpret_cast<int64_t>(new std::vector<int64_t>(newSize * 2));
+        const auto bytesToCopy = oldSize * sizeof(inlineStorage_[0]);
+        memcpy(outOfLineStorage()->data(), &inlineStorage_[0], bytesToCopy);
+        memcpy(outOfLineStorage()->data() + newSize, &inlineStorage_[MAX_INLINE_SIZE], bytesToCopy);
+      } else {
+        const bool isGrowing = oldSize < newSize;
+        if (isGrowing) {
+          // Resize before shifting so that we have room.
+          outOfLineStorage()->resize(newSize * 2);
+        }
+        // Shift the old strides to their new starting point. Note
+        // that this does not occur in the inline path above because
+        // the stride starting point is not moving.
+        memmove(
+            outOfLineStorage()->data() + newSize,
+            outOfLineStorage()->data() + oldSize,
+            std::min(oldSize, newSize) * sizeof(inlineStorage_[0]));
+        if (!isGrowing) {
+          // Resize after shifting so that we don't lose data.
+          outOfLineStorage()->resize(newSize * 2);
+        } else {
+          // Zero the end of the sizes portion.
+          memset(outOfLineStorage()->data() + oldSize, 0, (newSize - oldSize) * sizeof(inlineStorage_[0]));
+        }
+      }
+    }
   }
 
  private:
-  SmallVector<int64_t,5> sizes_;
-  SmallVector<int64_t,5> strides_;
+  bool isInline() const {
+    return (taggedStorageOrSize_ & 1) == 1;
+  }
+
+  std::vector<int64_t>* outOfLineStorage() const {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!isInline());
+    return reinterpret_cast<std::vector<int64_t>*>(taggedStorageOrSize_);
+  }
+
+  void resetToInlineStorage() {
+    setInlineSize(1);
+  }
+
+  void setInlineSize(size_t sz) {
+    taggedStorageOrSize_ = (sz << 1) | 1;
+  }
+
+  void copyFromInline(const SizesAndStrides& rhs) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(rhs.isInline());
+    taggedStorageOrSize_ = rhs.taggedStorageOrSize_;
+    memcpy(inlineStorage_, rhs.inlineStorage_, sizeof(inlineStorage_));
+  }
+
+  static constexpr int MAX_INLINE_SIZE = 5;
+  int64_t taggedStorageOrSize_;
+  int64_t inlineStorage_[MAX_INLINE_SIZE * 2];
 };
 
 } // namespace impl

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -11,19 +11,19 @@ static void checkData(const SizesAndStrides& sz, IntArrayRef sizes, IntArrayRef 
 
   int idx = 0;
   for (auto x: sizes) {
-    EXPECT_EQ(sz.size_at_unchecked(idx), x);
-    EXPECT_EQ(sz.size_at(idx), x);
-    EXPECT_EQ(sz.sizes_data()[idx], x);
-    EXPECT_EQ(*(sz.sizes_begin() + idx), x);
+    EXPECT_EQ(sz.size_at_unchecked(idx), x) << "index: " << idx;
+    EXPECT_EQ(sz.size_at(idx), x) << "index: " << idx;
+    EXPECT_EQ(sz.sizes_data()[idx], x) << "index: " << idx;
+    EXPECT_EQ(*(sz.sizes_begin() + idx), x) << "index: " << idx;
     idx++;
   }
 
   idx = 0;
   for (auto x: strides) {
-    EXPECT_EQ(sz.stride_at_unchecked(idx), x);
-    EXPECT_EQ(sz.stride_at(idx), x);
-    EXPECT_EQ(sz.strides_data()[idx], x);
-    EXPECT_EQ(*(sz.strides_begin() + idx), x);
+    EXPECT_EQ(sz.stride_at_unchecked(idx), x) << "index: " << idx;
+    EXPECT_EQ(sz.stride_at(idx), x) << "index: " << idx;
+    EXPECT_EQ(sz.strides_data()[idx], x) << "index: " << idx;
+    EXPECT_EQ(*(sz.strides_begin() + idx), x) << "index: " << idx;
 
     idx++;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47506 [PyTorch] Change representation of SizesAndStrides**
* #47505 [PyTorch] Introduce packed SizesAndStrides abstraction

This moves SizesAndStrides to a specialized representation
that is 5 words smaller in the common case of tensor rank 5 or less.

Differential Revision: [D24772023](https://our.internmc.facebook.com/intern/diff/D24772023/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24772023/)!