### PR TITLE
[pytorch] Move the INDEX type dispatcher (int32_t/int64_t) to OSS

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -313,6 +313,25 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
     }                                                                   \
   }()
 
+#define AT_DISPATCH_INDEX_TYPES(TYPE, NAME, ...)                            \
+  [&] {                                                                     \
+    const auto& the_index_type = TYPE;                                      \
+    /* don't use TYPE again in case it is an expensive or side-effect op */ \
+    at::ScalarType _it = ::detail::scalar_type(the_index_type);             \
+    switch (_it) {                                                          \
+      case at::ScalarType::Int: {                                           \
+        using index_t = int32_t;                                            \
+        return __VA_ARGS__();                                               \
+      }                                                                     \
+      case at::ScalarType::Long: {                                          \
+        using index_t = int64_t;                                            \
+        return __VA_ARGS__();                                               \
+      }                                                                     \
+      default:                                                              \
+        AT_ERROR(#NAME, " not implemented for '", toString(_it), "'");      \
+    }                                                                       \
+  }()
+
 #define AT_DISPATCH_ALL_TYPES(TYPE, NAME, ...)                               \
   [&] {                                                                      \
     const auto& the_type = TYPE;                                             \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47510 [pytorch] Move the INDEX type dispatcher (int32_t/int64_t) to OSS**

Differential Revision: [D24791843](https://our.internmc.facebook.com/intern/diff/D24791843/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24791843/)!