### PR TITLE
[caffe2] Add unittests for schema.Field init

### DIFF
--- a/caffe2/python/schema_test.py
+++ b/caffe2/python/schema_test.py
@@ -10,6 +10,31 @@ import unittest
 import pickle
 import random
 
+class TestField(unittest.TestCase):
+    def testInitShouldSetEmptyParent(self):
+        f = schema.Field([])
+        self.assertTupleEqual(f._parent, (None, 0))
+
+    def testInitShouldSetFieldOffsets(self):
+        f = schema.Field([
+            schema.Scalar(dtype=np.int32),
+            schema.Struct(
+                ('field1', schema.Scalar(dtype=np.int32)),
+                ('field2', schema.List(schema.Scalar(dtype=str))),
+            ),
+            schema.Scalar(dtype=np.int32),
+            schema.Struct(
+                ('field3', schema.Scalar(dtype=np.int32)),
+                ('field4', schema.List(schema.Scalar(dtype=str)))
+            ),
+            schema.Scalar(dtype=np.int32),
+        ])
+        self.assertListEqual(f._field_offsets, [0, 1, 4, 5, 8, 9])
+
+    def testInitShouldSetFieldOffsetsIfNoChildren(self):
+        f = schema.Field([])
+        self.assertListEqual(f._field_offsets, [0])
+
 
 class TestDB(unittest.TestCase):
     def testPicklable(self):


### PR DESCRIPTION
Summary:
I deleted the last line of `__init__` -- `self._field_offsets.append(offset)` -- and the unittests didn't fail.

So this diff is to improve test coverage.

Test Plan:
```
    ✓ Pass: caffe2/caffe2/python:schema_test - testInitShouldSetEmptyParent (caffe2.caffe2.python.schema_test.TestField) (8.225)
    ✓ Pass: caffe2/caffe2/python:schema_test - testInitShouldSetFieldOffsetsIfNoChildren (caffe2.caffe2.python.schema_test.TestField) (8.339)
    ✓ Pass: caffe2/caffe2/python:schema_test - testInitShouldSetFieldOffsets (caffe2.caffe2.python.schema_test.TestField) (8.381)
```

Reviewed By: dzhulgakov

Differential Revision: D24767188

