### PR TITLE
[caffe2] Fix duplicate name bug in Net.AddExternalInput

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -2025,10 +2025,14 @@ class Net(object):
     def AddExternalInput(self, *inputs):
         assert len(inputs) > 0
         refs = []
+        input_name_set = set()
         for input in inputs:
             input_name = str(input)
-            assert str(input) not in self._external_input_map, (
-                'Net already contains an input named %s' % input_name)
+            assert (
+                input_name not in self._external_input_map
+                and input_name not in input_name_set
+            ), ("Net already contains an input named %s" % input_name)
+            input_name_set.add(input_name)
         for input in inputs:
             input_name = str(input)
             self._net.external_input.extend([input_name])

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -252,6 +252,24 @@ class TestCloneNet(test_util.TestCase):
 
 
 class TestExternalInputs(test_util.TestCase):
+    def testAddExternalInputShouldRaiseIfDuplicate(self):
+        net = core.Net("test")
+        net.AddExternalInput(
+            schema.Struct(("x", schema.Scalar(np.float))),
+        )
+        with self.assertRaises(AssertionError):
+            net.AddExternalInput(
+                schema.Struct(("x", schema.Scalar(np.float))),
+            )
+
+    def testAddExternalInputShouldRaiseIfDuplicateInSameCall(self):
+        net = core.Net("test")
+        with self.assertRaises(AssertionError):
+            net.AddExternalInput(
+                schema.Struct(("x", schema.Scalar(np.float))),
+                schema.Struct(("x", schema.Scalar(np.float))),
+            )
+
     def testSetInputRecordWithBlobs(self):
         net = core.Net("test")
         record = schema.NewRecord(net, schema.Struct(


### PR DESCRIPTION
Summary: `Net.AddExternalInput` should raise if there are duplicate names. The previous code would only raise if the addition of duplicates was in separate calls, but not if it was in the same call.

Test Plan:
Added two new regression tests

```
    ✓ Pass: caffe2/caffe2/python:core_test - testSetInputRecordWithBlobs (caffe2.caffe2.python.core_test.TestExternalInputs) (9.622)
    ✓ Pass: caffe2/caffe2/python:core_test - testAddExternalInputShouldRaiseIfDuplicate (caffe2.caffe2.python.core_test.TestExternalInputs) (9.639)
    ✓ Pass: caffe2/caffe2/python:core_test - testSetInputRecordWithoutBlobs (caffe2.caffe2.python.core_test.TestExternalInputs) (9.883)
    ✓ Pass: caffe2/caffe2/python:core_test - testAddExternalInputShouldRaiseIfDuplicateInSameCall (caffe2.caffe2.python.core_test.TestExternalInputs) (10.153)
```

Reviewed By: dzhulgakov

Differential Revision: D24763586

