### PR TITLE
[fx] add missing modules for type annoations

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -797,6 +797,11 @@ class TestFX(JitTestCase):
         fxed_scripted = torch.jit.script(fxed)
         fxed_scripted(Pair(torch.rand(5), torch.rand(5)), torch.rand(5), 3)
 
+    def test_fn_type_annotation_empty(self):
+        def forward(a : List[torch.Tensor]):
+            return a[0]
+        torch.jit.script(symbolic_trace(forward))
+
     def test_wrapped_method(self):
         def wrap_with_relu(fn):
             @functools.wraps(fn)

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -330,7 +330,14 @@ class Graph:
 
         def type_repr(o : Any):
             typename = _type_repr(o)
-            register_modules_used(typename)
+            if all(x.isidentifier() for x in typename.split('.')):
+                register_modules_used(typename)
+            else:
+                # this is a constructor type, e.g. typing.List[torch.Tensor]
+                modules_used.add(o.__module__)
+                for sub_type in o.__args__:
+                    # make sure we have torch.Tensor
+                    type_repr(sub_type)
             return typename
 
         for node in self.nodes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47537 [fx] add missing modules for type annoations**

When a module only appears in a type constructor List[torch.Tensor],
it previously didn't get added to the list of used modules. This fixes it
by introspecting on the type constructor.

Differential Revision: [D24806317](https://our.internmc.facebook.com/intern/diff/D24806317)