### PR TITLE
[tensorexpr] Fix registration of intrinsics on llvm-fb

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -24,6 +24,157 @@
 #include <string>
 #include <vector>
 
+using namespace torch::jit::tensorexpr;
+
+template <typename T>
+static llvm::JITTargetAddress toAddress(T* Ptr) {
+  return static_cast<llvm::JITTargetAddress>(reinterpret_cast<uintptr_t>(Ptr));
+}
+
+static void registerIntrinsics(
+    llvm::orc::JITDylib& JD,
+    llvm::orc::MangleAndInterner& Mangle) {
+  using namespace llvm;
+  using namespace llvm::orc;
+
+  auto entry = [&](const char* name, auto ptr) -> SymbolMap::value_type {
+    return {Mangle(name), {toAddress(ptr), JITSymbolFlags::None}};
+  };
+
+  assertSuccess(JD.define(absoluteSymbols({
+    entry("log10f", &log10f), entry("log1pf", &log1pf), entry("logf", &logf),
+        entry("log2f", &log2f), entry("expf", &expf), entry("erff", &erff),
+        entry("cosf", &cosf), entry("sinf", &sinf), entry("tanf", &tanf),
+        entry("acosf", &acosf), entry("asinf", &asinf), entry("atanf", &atanf),
+        entry("coshf", &coshf), entry("sinhf", &sinhf), entry("tanhf", &tanhf),
+        entry("sqrtf", &sqrtf), entry("fabsf", &fabsf),
+        entry("floorf", &floorf), entry("ceilf", &ceilf),
+        entry("roundf", &roundf), entry("truncf", &truncf),
+        entry("atan2f", &atan2f), entry("fmodf", &fmodf),
+        entry("remainderf", &remainderf),
+
+        // FP32 Sleef functions -- SSE
+        entry("Sleef_acosf4", &Sleef_acosf4_u10),
+        entry("Sleef_asinf4", &Sleef_asinf4_u10),
+        entry("Sleef_atanf4", &Sleef_atanf4_u10),
+        entry("Sleef_cosf4", &Sleef_cosf4_u10),
+        entry("Sleef_sinf4", &Sleef_sinf4_u10),
+        entry("Sleef_tanf4", &Sleef_tanf4_u10),
+        entry("Sleef_coshf4", &Sleef_coshf4_u10),
+        entry("Sleef_sinhf4", &Sleef_sinhf4_u10),
+        entry("Sleef_tanhf4", &Sleef_tanhf4_u10),
+        entry("Sleef_erff4", &Sleef_erff4_u10),
+        entry("Sleef_erfcf4", &Sleef_erfcf4_u15),
+        entry("Sleef_expf4", &Sleef_expf4_u10),
+        entry("Sleef_expm1f4", &Sleef_expm1f4_u10),
+        entry("Sleef_logf4", &Sleef_logf4_u10),
+        entry("Sleef_log2f4", &Sleef_log2f4_u10),
+        entry("Sleef_log10f4", &Sleef_log10f4_u10),
+        entry("Sleef_log1pf4", &Sleef_log1pf4_u10),
+        entry("Sleef_sqrtf4", &Sleef_sqrtf4_u05),
+        entry("Sleef_fabsf4", &Sleef_fabsf4),
+        entry("Sleef_floorf4", &Sleef_floorf4),
+        entry("Sleef_ceilf4", &Sleef_ceilf4),
+        entry("Sleef_truncf4", &Sleef_truncf4),
+        entry("Sleef_roundf4", &Sleef_roundf4),
+        entry("Sleef_lgammaf4", &Sleef_lgammaf4_u10),
+        entry("Sleef_atan2f4", &Sleef_atan2f4_u10),
+        entry("Sleef_powf4", &Sleef_powf4_u10),
+        entry("Sleef_fmodf4", &Sleef_fmodf4),
+
+    // FP32 Sleef functions -- AVX2
+#if defined(__AVX__) && !defined(_MSC_VER)
+        entry("Sleef_acosf8", &Sleef_acosf8_u10),
+        entry("Sleef_asinf8", &Sleef_asinf8_u10),
+        entry("Sleef_atanf8", &Sleef_atanf8_u10),
+        entry("Sleef_cosf8", &Sleef_cosf8_u10),
+        entry("Sleef_sinf8", &Sleef_sinf8_u10),
+        entry("Sleef_tanf8", &Sleef_tanf8_u10),
+        entry("Sleef_coshf8", &Sleef_coshf8_u10),
+        entry("Sleef_sinhf8", &Sleef_sinhf8_u10),
+        entry("Sleef_tanhf8", &Sleef_tanhf8_u10),
+        entry("Sleef_erff8", &Sleef_erff8_u10),
+        entry("Sleef_erfcf8", &Sleef_erfcf8_u15),
+        entry("Sleef_expf8", &Sleef_expf8_u10),
+        entry("Sleef_expm1f8", &Sleef_expm1f8_u10),
+        entry("Sleef_logf8", &Sleef_logf8_u10),
+        entry("Sleef_log2f8", &Sleef_log2f8_u10),
+        entry("Sleef_log10f8", &Sleef_log10f8_u10),
+        entry("Sleef_log1pf8", &Sleef_log1pf8_u10),
+        entry("Sleef_sqrtf8", &Sleef_sqrtf8_u05),
+        entry("Sleef_fabsf8", &Sleef_fabsf8),
+        entry("Sleef_floorf8", &Sleef_floorf8),
+        entry("Sleef_ceilf8", &Sleef_ceilf8),
+        entry("Sleef_truncf8", &Sleef_truncf8),
+        entry("Sleef_roundf8", &Sleef_roundf8),
+        entry("Sleef_lgammaf8", &Sleef_lgammaf8_u10),
+        entry("Sleef_atan2f8", &Sleef_atan2f8_u10),
+        entry("Sleef_powf8", &Sleef_powf8_u10),
+        entry("Sleef_fmodf8", &Sleef_fmodf8),
+#endif
+
+        // FP64 Sleef functions -- SSE
+        entry("Sleef_acosd2", &Sleef_acosd2_u10),
+        entry("Sleef_asind2", &Sleef_asind2_u10),
+        entry("Sleef_atand2", &Sleef_atand2_u10),
+        entry("Sleef_cosd2", &Sleef_cosd2_u10),
+        entry("Sleef_sind2", &Sleef_sind2_u10),
+        entry("Sleef_tand2", &Sleef_tand2_u10),
+        entry("Sleef_coshd2", &Sleef_coshd2_u10),
+        entry("Sleef_sinhd2", &Sleef_sinhd2_u10),
+        entry("Sleef_tanhd2", &Sleef_tanhd2_u10),
+        entry("Sleef_erfd2", &Sleef_erfd2_u10),
+        entry("Sleef_erfcd2", &Sleef_erfcd2_u15),
+        entry("Sleef_expd2", &Sleef_expd2_u10),
+        entry("Sleef_expm1d2", &Sleef_expm1d2_u10),
+        entry("Sleef_logd2", &Sleef_logd2_u10),
+        entry("Sleef_log2d2", &Sleef_log2d2_u10),
+        entry("Sleef_log10d2", &Sleef_log10d2_u10),
+        entry("Sleef_log1pd2", &Sleef_log1pd2_u10),
+        entry("Sleef_sqrtd2", &Sleef_sqrtd2_u05),
+        entry("Sleef_fabsd2", &Sleef_fabsd2),
+        entry("Sleef_floord2", &Sleef_floord2),
+        entry("Sleef_ceild2", &Sleef_ceild2),
+        entry("Sleef_truncd2", &Sleef_truncd2),
+        entry("Sleef_roundd2", &Sleef_roundd2),
+        entry("Sleef_lgammad2", &Sleef_lgammad2_u10),
+        entry("Sleef_atan2d2", &Sleef_atan2d2_u10),
+        entry("Sleef_powd2", &Sleef_powd2_u10),
+        entry("Sleef_fmodd2", &Sleef_fmodd2),
+
+    // FP64 Sleef functions -- AVX2
+#if defined(__AVX__) && !defined(_MSC_VER)
+        entry("Sleef_acosd4", &Sleef_acosd4_u10),
+        entry("Sleef_asind4", &Sleef_asind4_u10),
+        entry("Sleef_atand4", &Sleef_atand4_u10),
+        entry("Sleef_cosd4", &Sleef_cosd4_u10),
+        entry("Sleef_sind4", &Sleef_sind4_u10),
+        entry("Sleef_tand4", &Sleef_tand4_u10),
+        entry("Sleef_coshd4", &Sleef_coshd4_u10),
+        entry("Sleef_sinhd4", &Sleef_sinhd4_u10),
+        entry("Sleef_tanhd4", &Sleef_tanhd4_u10),
+        entry("Sleef_erfd4", &Sleef_erfd4_u10),
+        entry("Sleef_erfcd4", &Sleef_erfcd4_u15),
+        entry("Sleef_expd4", &Sleef_expd4_u10),
+        entry("Sleef_expm1d4", &Sleef_expm1d4_u10),
+        entry("Sleef_logd4", &Sleef_logd4_u10),
+        entry("Sleef_log2d4", &Sleef_log2d4_u10),
+        entry("Sleef_log10d4", &Sleef_log10d4_u10),
+        entry("Sleef_log1pd4", &Sleef_log1pd4_u10),
+        entry("Sleef_sqrtd4", &Sleef_sqrtd4_u05),
+        entry("Sleef_fabsd4", &Sleef_fabsd4),
+        entry("Sleef_floord4", &Sleef_floord4),
+        entry("Sleef_ceild4", &Sleef_ceild4),
+        entry("Sleef_truncd4", &Sleef_truncd4),
+        entry("Sleef_roundd4", &Sleef_roundd4),
+        entry("Sleef_lgammad4", &Sleef_lgammad4_u10),
+        entry("Sleef_atan2d4", &Sleef_atan2d4_u10),
+        entry("Sleef_powd4", &Sleef_powd4_u10),
+        entry("Sleef_fmodd4", &Sleef_fmodd4),
+#endif
+  })));
+}
+
 namespace llvm {
 namespace orc {
 
@@ -35,9 +186,9 @@ class TORCH_API PytorchLLVMJITImpl {
   std::unique_ptr<LLJIT> LLJ;
 
  public:
-  PytorchLLVMJITImpl() : LLJ(cantFail(LLJITBuilder().create())) {
+  PytorchLLVMJITImpl() : LLJ(assertSuccess(LLJITBuilder().create())) {
     auto ProcSymbolsGenerator =
-        cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(
+        assertSuccess(DynamicLibrarySearchGenerator::GetForCurrentProcess(
             LLJ->getDataLayout().getGlobalPrefix()));
     auto& JD = LLJ->getMainJITDylib();
 #if LLVM_VERSION_MAJOR == 9
@@ -50,395 +201,7 @@ class TORCH_API PytorchLLVMJITImpl {
     MangleAndInterner Mangle(LLJ->getExecutionSession(), LLJ->getDataLayout());
 
     // Register implementations of intrinsics
-    cantFail(JD.define(absoluteSymbols({
-      {Mangle("log10f"),
-       {llvm::pointerToJITTargetAddress(&log10f), JITSymbolFlags::None}},
-          {Mangle("log1pf"),
-           {llvm::pointerToJITTargetAddress(&log1pf), JITSymbolFlags::None}},
-          {Mangle("logf"),
-           {llvm::pointerToJITTargetAddress(&logf), JITSymbolFlags::None}},
-          {Mangle("log2f"),
-           {llvm::pointerToJITTargetAddress(&log2f), JITSymbolFlags::None}},
-          {Mangle("expf"),
-           {llvm::pointerToJITTargetAddress(&expf), JITSymbolFlags::None}},
-          {Mangle("erff"),
-           {llvm::pointerToJITTargetAddress(&erff), JITSymbolFlags::None}},
-          {Mangle("cosf"),
-           {llvm::pointerToJITTargetAddress(&cosf), JITSymbolFlags::None}},
-          {Mangle("sinf"),
-           {llvm::pointerToJITTargetAddress(&sinf), JITSymbolFlags::None}},
-          {Mangle("tanf"),
-           {llvm::pointerToJITTargetAddress(&tanf), JITSymbolFlags::None}},
-          {Mangle("acosf"),
-           {llvm::pointerToJITTargetAddress(&acosf), JITSymbolFlags::None}},
-          {Mangle("asinf"),
-           {llvm::pointerToJITTargetAddress(&asinf), JITSymbolFlags::None}},
-          {Mangle("atanf"),
-           {llvm::pointerToJITTargetAddress(&atanf), JITSymbolFlags::None}},
-          {Mangle("coshf"),
-           {llvm::pointerToJITTargetAddress(&coshf), JITSymbolFlags::None}},
-          {Mangle("sinhf"),
-           {llvm::pointerToJITTargetAddress(&sinhf), JITSymbolFlags::None}},
-          {Mangle("tanhf"),
-           {llvm::pointerToJITTargetAddress(&tanhf), JITSymbolFlags::None}},
-          {Mangle("sqrtf"),
-           {llvm::pointerToJITTargetAddress(&sqrtf), JITSymbolFlags::None}},
-          {Mangle("fabsf"),
-           {llvm::pointerToJITTargetAddress(&fabsf), JITSymbolFlags::None}},
-          {Mangle("floorf"),
-           {llvm::pointerToJITTargetAddress(&floorf), JITSymbolFlags::None}},
-          {Mangle("ceilf"),
-           {llvm::pointerToJITTargetAddress(&ceilf), JITSymbolFlags::None}},
-          {Mangle("roundf"),
-           {llvm::pointerToJITTargetAddress(&roundf), JITSymbolFlags::None}},
-          {Mangle("truncf"),
-           {llvm::pointerToJITTargetAddress(&truncf), JITSymbolFlags::None}},
-          {Mangle("atan2f"),
-           {llvm::pointerToJITTargetAddress(&atan2f), JITSymbolFlags::None}},
-          {Mangle("fmodf"),
-           {llvm::pointerToJITTargetAddress(&fmodf), JITSymbolFlags::None}},
-          {Mangle("remainderf"),
-           {llvm::pointerToJITTargetAddress(&remainderf),
-            JITSymbolFlags::None}},
-
-          // FP32 Sleef functions -- SSE
-          {Mangle("Sleef_acosf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_acosf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_asinf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_asinf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atanf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atanf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_cosf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_cosf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sinf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sinf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tanf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tanf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_coshf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_coshf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sinhf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sinhf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tanhf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tanhf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erff4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erff4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erfcf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erfcf4_u15),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expm1f4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expm1f4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_logf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_logf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log2f4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log2f4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log10f4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log10f4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log1pf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log1pf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sqrtf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sqrtf4_u05),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_fabsf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_fabsf4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_floorf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_floorf4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_ceilf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_ceilf4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_truncf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_truncf4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_roundf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_roundf4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_lgammaf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_lgammaf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atan2f4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atan2f4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_powf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_powf4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_fmodf4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_fmodf4),
-            JITSymbolFlags::None}},
-
-      // FP32 Sleef functions -- AVX2
-#if defined(__AVX__) && !defined(_MSC_VER)
-          {Mangle("Sleef_acosf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_acosf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_asinf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_asinf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atanf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atanf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_cosf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_cosf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sinf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sinf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tanf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tanf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_coshf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_coshf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sinhf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sinhf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tanhf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tanhf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erff8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erff8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erfcf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erfcf8_u15),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expm1f8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expm1f8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_logf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_logf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log2f8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log2f8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log10f8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log10f8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log1pf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log1pf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sqrtf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sqrtf8_u05),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_fabsf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_fabsf8),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_floorf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_floorf8),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_ceilf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_ceilf8),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_truncf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_truncf8),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_roundf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_roundf8),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_lgammaf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_lgammaf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atan2f8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atan2f8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_powf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_powf8_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_fmodf8"),
-           {llvm::pointerToJITTargetAddress(&Sleef_fmodf8),
-            JITSymbolFlags::None}},
-#endif
-
-          // FP64 Sleef functions -- SSE
-          {Mangle("Sleef_acosd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_acosd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_asind2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_asind2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atand2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atand2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_cosd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_cosd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sind2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sind2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tand2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tand2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_coshd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_coshd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sinhd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sinhd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tanhd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tanhd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erfd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erfd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erfcd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erfcd2_u15),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expm1d2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expm1d2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_logd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_logd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log2d2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log2d2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log10d2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log10d2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log1pd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log1pd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sqrtd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sqrtd2_u05),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_fabsd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_fabsd2),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_floord2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_floord2),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_ceild2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_ceild2),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_truncd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_truncd2),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_roundd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_roundd2),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_lgammad2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_lgammad2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atan2d2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atan2d2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_powd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_powd2_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_fmodd2"),
-           {llvm::pointerToJITTargetAddress(&Sleef_fmodd2),
-            JITSymbolFlags::None}},
-
-      // FP64 Sleef functions -- AVX2
-#if defined(__AVX__) && !defined(_MSC_VER)
-          {Mangle("Sleef_acosd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_acosd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_asind4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_asind4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atand4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atand4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_cosd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_cosd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sind4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sind4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tand4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tand4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_coshd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_coshd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sinhd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sinhd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_tanhd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_tanhd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erfd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erfd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_erfcd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_erfcd4_u15),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_expm1d4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_expm1d4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_logd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_logd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log2d4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log2d4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log10d4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log10d4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_log1pd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_log1pd4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_sqrtd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_sqrtd4_u05),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_fabsd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_fabsd4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_floord4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_floord4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_ceild4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_ceild4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_truncd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_truncd4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_roundd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_roundd4),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_lgammad4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_lgammad4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_atan2d4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_atan2d4_u10),
-            JITSymbolFlags::None}},
-          {Mangle("Sleef_powd4"),
-           {llvm::pointerToJITTargetAddress(&Sleef_powd4_u10),
-            JITSymbolFlags::None}},
-      {
-        Mangle("Sleef_fmodd4"), {
-          llvm::pointerToJITTargetAddress(&Sleef_fmodd4), JITSymbolFlags::None
-        }
-      }
-#endif
-    })));
+    registerIntrinsics(JD, Mangle);
   }
 
   Error addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> C) {
@@ -450,7 +213,7 @@ class TORCH_API PytorchLLVMJITImpl {
   }
 
   JITSymbol findSymbol(const std::string Name) {
-    return cantFail(LLJ->lookup(Name));
+    return assertSuccess(LLJ->lookup(Name));
   }
 
   const DataLayout& getDataLayout() {
@@ -493,16 +256,22 @@ class TORCH_API PytorchLLVMJITImpl {
       : Resolver(createLegacyLookupResolver(
             ES,
             [this](const std::string& Name) -> JITSymbol {
-              if (auto Sym = CompileLayer.findSymbol(Name, false))
+              if (auto Sym = CompileLayer.findSymbol(Name, false)) {
                 return Sym;
-              else if (auto Err = Sym.takeError())
+              } else if (auto Err = Sym.takeError()) {
                 return std::move(Err);
+              }
               if (auto SymAddr =
-                      RTDyldMemoryManager::getSymbolAddressInProcess(Name))
+                      RTDyldMemoryManager::getSymbolAddressInProcess(Name)) {
                 return JITSymbol(SymAddr, JITSymbolFlags::Exported);
-              return nullptr;
+              }
+              MangleAndInterner Mangle(ES, DL);
+              return assertSuccess(
+                  lookup({&ES.getMainJITDylib()}, Mangle(Name)));
             },
-            [](Error Err) { cantFail(std::move(Err), "lookupFlags failed"); })),
+            [](Error Err) {
+              assertSuccess(std::move(Err), "lookupFlags failed");
+            })),
         TM(EngineBuilder().selectTarget()),
         DL(TM->createDataLayout()),
         ObjectLayer(
@@ -512,6 +281,9 @@ class TORCH_API PytorchLLVMJITImpl {
                   std::make_shared<SectionMemoryManager>(), Resolver};
             }),
         CompileLayer(ObjectLayer, SimpleCompiler(*TM)) {
+    auto& JD = ES.getMainJITDylib();
+    MangleAndInterner Mangle(ES, DL);
+    registerIntrinsics(JD, Mangle);
     llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
   }
 
@@ -522,7 +294,9 @@ class TORCH_API PytorchLLVMJITImpl {
   VModuleKey addModule(std::unique_ptr<Module> M) {
     // Add the module to the JIT with a new VModuleKey.
     auto K = ES.allocateVModule();
-    cantFail(CompileLayer.addModule(K, std::move(M)));
+    assertSuccess(
+        CompileLayer.addModule(K, std::move(M)),
+        "Failed to add module to compile layer");
     return K;
   }
 
@@ -534,11 +308,11 @@ class TORCH_API PytorchLLVMJITImpl {
   }
 
   JITTargetAddress getSymbolAddress(const std::string Name) {
-    return cantFail(findSymbol(Name).getAddress());
+    return assertSuccess(findSymbol(Name).getAddress());
   }
 
   void removeModule(VModuleKey K) {
-    cantFail(CompileLayer.removeModule(K));
+    assertSuccess(CompileLayer.removeModule(K));
   }
 
   const DataLayout& getDataLayout() {

--- a/torch/csrc/jit/tensorexpr/llvm_jit.h
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifdef TORCH_ENABLE_LLVM
+#include <c10/util/Exception.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <llvm/ExecutionEngine/JITSymbol.h>
@@ -10,6 +11,32 @@
 
 #include <memory>
 #include <string>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+inline std::string formatError(llvm::Error&& err, const char* msg) {
+  static constexpr char* defaultErrorMsg = "Unexpected failure in LLVM JIT";
+  std::string errorMsg(msg ? msg : defaultErrorMsg);
+  llvm::raw_string_ostream ss(errorMsg);
+  ss << ": " << err;
+  return ss.str();
+}
+
+template <typename T>
+T assertSuccess(llvm::Expected<T> valOrErr, const char* msg = nullptr) {
+  TORCH_INTERNAL_ASSERT(valOrErr, formatError(valOrErr.takeError(), msg));
+  return std::move(*valOrErr);
+}
+
+inline void assertSuccess(llvm::Error err, const char* msg = nullptr) {
+  TORCH_INTERNAL_ASSERT(!err, formatError(std::move(err), msg));
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch
 
 namespace llvm {
 namespace orc {


### PR DESCRIPTION
Summary:
In FB's hybrid llvm 7/8 flavor, we (read: I) forgot to register
intrinsics.  It was... a bit annoying to figure out how to do this, and I'm
sure it could be done more efficiently by someone who isn't just cargo-culting
the API from KaleidoscopeJIT.  Anyways.

There are kind of 3 independent changes here but they're a bit annoying to separate out, so:

0. (trivial) Add the correct #defines to the internal build to run test_llvm.
1. (easy) add an assertSuccess function to convert llvm::Errors into
   `TORCH_INTERNAL_ASSERT`s, for better/easier debugging.
2. (medium) Factor out the gigantic register-all-the-things function into a
   helper so we can call it from both the LLVM and LLVM-FB constructors.
3. (hard) Fix the symbol resolver in llvm-fb to do a lookup using the
   ExecutionSession.  This is the bit I don't really understand; it feels like the
   CompileLayer lookup should find these symbols but it doesn't.  Whatever.

Test Plan: `buck test //caffe2/test/cpp/tensorexpr:tensorexpr`

Differential Revision: D24807361

