### PR TITLE
torch.dropout: avoid unnecessary mul for p=1

### DIFF
--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -39,6 +39,18 @@ Tensor multiply(const Tensor& input, const Tensor& noise) {
   return input.mul(noise);
 }
 
+template<bool inplace>
+Tensor& zero_tensor(Tensor& input) {
+  static_assert(inplace, "Wrong multiply overload triggered in Dropout.cpp");
+  return input.fill_(0);
+}
+
+template<bool inplace>
+Tensor zero_tensor(const Tensor& input) {
+  static_assert(!inplace, "Wrong multiply overload triggered in Dropout.cpp");
+  return at::zeros_like(input);
+}
+
 template<bool feature_dropout, bool alpha_dropout, bool inplace, typename T>
 Ctype<inplace> _dropout_impl(T& input, double p, bool train) {
   TORCH_CHECK(p >= 0 && p <= 1, "dropout probability has to be between 0 and 1, but got ", p);
@@ -47,7 +59,7 @@ Ctype<inplace> _dropout_impl(T& input, double p, bool train) {
   }
 
   if (p == 1) {
-    return multiply<inplace>(input, at::zeros({}, input.options()));
+    return zero_tensor<inplace>(input);
   }
 
   at::Tensor b; // used for alpha_dropout only


### PR DESCRIPTION
Not sure how often anyone uses p=1 if at all but no mul with 0 is needed in that case.

Benchmark Script

```python
import torch
import itertools
import time
from torch.utils.benchmark import Timer
from torch.utils.benchmark import Compare
import sys

print('Using pytorch %s' % (torch.__version__))

shapes = [(32,), (32, 32), (2, 16, 32), (2, 16, 32, 32), (8, 16, 64, 64)]
num_threads = 8
dtypes = [torch.float, torch.double]
repeats = 10

for dtype in dtypes:
    results = []
    for mat1_shape in shapes:
        mat1 = torch.rand(*mat1_shape, dtype=dtype, device='cpu')
        mat1_cuda = mat1.to('cuda')

        tasks = [("torch.nn.functional.dropout(mat1, p=1.)", "torch.dropout CPU"),
                 ("torch.nn.functional.dropout(mat1, p=1., inplace=True)", "torch.dropout inplace CPU"),
                 # In CUDA, this path is taken only when training is False.
                 ("torch.nn.functional.dropout(mat1_cuda, p=1., training=False, inplace=True)", "torch.dropout CUDA")]

        timers = [Timer(stmt=stmt, num_threads=num_threads, label=f"dropout {dtype}", sub_label=f"{(mat1_shape)}", description=label, globals=globals()) for stmt, label in tasks]

        for i, timer in enumerate(timers * repeats):
            results.append(
                timer.blocked_autorange()
            )
            print(f"\r{i + 1} / {len(timers) * repeats}", end="")
            sys.stdout.flush()
    comparison = Compare(results)
    comparison.print()
```

Note that this also affect, `feature_dropout`, `alpha_dropout`, `feature_alpha_dropout` their benchmark would follow the results below (as they use the same path for the given case).

Benchmark Before Change
```
Using pytorch 1.8.0a0+3f9697b
30 / 30[----------------------------------- dropout torch.float32 ------------------------------------]
                       |  torch.dropout CPU  |  torch.dropout inplace CPU  |  torch.dropout CUDA
8 threads: -------------------------------------------------------------------------------------
      (32,)            |          5.9        |              4.8            |         2.0        
      (32, 32)         |          6.2        |              4.9            |         2.0        
      (2, 16, 32)      |          6.3        |              5.0            |         2.0        
      (2, 16, 32, 32)  |         10.9        |              8.1            |         2.1        
      (8, 16, 64, 64)  |         27.3        |             20.1            |         2.1        

Times are in microseconds (us).

30 / 30[----------------------------------- dropout torch.float64 ------------------------------------]
                       |  torch.dropout CPU  |  torch.dropout inplace CPU  |  torch.dropout CUDA
8 threads: -------------------------------------------------------------------------------------
      (32,)            |          6.0        |              4.9            |         2.0        
      (32, 32)         |          6.5        |              5.2            |         2.0        
      (2, 16, 32)      |          6.5        |              5.3            |         2.1        
      (2, 16, 32, 32)  |         13.9        |             11.2            |         2.0        
      (8, 16, 64, 64)  |         39.2        |             33.2            |         2.1        

Times are in microseconds (us).
```

Benchmark After Change
```
Using pytorch 1.8.0a0+3f9697b
30 / 30[----------------------------------- dropout torch.float32 ------------------------------------]
                       |  torch.dropout CPU  |  torch.dropout inplace CPU  |  torch.dropout CUDA
8 threads: -------------------------------------------------------------------------------------
      (32,)            |          4.7        |              2.7            |         2.1        
      (32, 32)         |          4.8        |              2.8            |         2.1        
      (2, 16, 32)      |          4.9        |              2.8            |         2.1        
      (2, 16, 32, 32)  |          7.7        |              5.3            |         2.1        
      (8, 16, 64, 64)  |         17.3        |             13.8            |         2.1        

Times are in microseconds (us).

30 / 30[----------------------------------- dropout torch.float64 ------------------------------------]
                       |  torch.dropout CPU  |  torch.dropout inplace CPU  |  torch.dropout CUDA
8 threads: -------------------------------------------------------------------------------------
      (32,)            |          4.7        |              2.6            |         2.1        
      (32, 32)         |          5.0        |              2.9            |         2.1        
      (2, 16, 32)      |          4.9        |              2.9            |         2.1        
      (2, 16, 32, 32)  |         10.7        |              8.0            |         2.1        
      (8, 16, 64, 64)  |         25.6        |             22.5            |         2.1        

Times are in microseconds (us).
```

Reference `cuda` skips this path when training is True

https://github.com/pytorch/pytorch/blob/f90da88d8f53a318c2d4d6e60ad949df704c5273/aten/src/ATen/native/Dropout.cpp#L85-L95

https://github.com/pytorch/pytorch/blob/f90da88d8f53a318c2d4d6e60ad949df704c5273/aten/src/ATen/native/Dropout.cpp#L24-L26