### PR TITLE
Update the docs of torch.eig about derivative

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2640,7 +2640,7 @@ Computes the dot product of two 1D tensors. The vdot(a, b) function handles comp
 differently than dot(a, b). If the first argument is complex, the complex conjugate of the
 first argument is used for the calculation of the dot product.
 
-.. note:: 
+.. note::
 
     Unlike NumPy's vdot, torch.vdot intentionally only supports computing the dot product
     of two 1D tensors with the same number of elements.
@@ -2672,7 +2672,7 @@ Computes the eigenvalues and eigenvectors of a real square matrix.
 
 .. note::
     Since eigenvalues and eigenvectors might be complex, backward pass is supported only
-    for :func:`torch.symeig`
+    if eigenvalues and eigenvectors are all real valued.
 
 Args:
     input (Tensor): the square matrix of shape :math:`(n \times n)` for which the eigenvalues and eigenvectors


### PR DESCRIPTION
Related: #33090
I just realized that I haven't updated the docs of `torch.eig` when implementing the backward.
Here's the PR updating the docs about the grad of `torch.eig`.

cc @albanD 
