### PR TITLE
Complex Version of torch.remainder

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -131,10 +131,8 @@ void remainder_kernel(TensorIterator& iter) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "remainder_cpu", [&]() {
       cpu_kernel(iter,
         [=](scalar_t a, scalar_t b) -> scalar_t {
-          auto q = std::trunc(a.real() / b.real());
-          auto r = std::fmod(a.real(), b.real()); 
-          auto arg = (a - q * b) / std::abs(a - q * b);
-          return arg * r;
+          auto q = std::trunc(std::abs(a) / std::abs(b));
+          return a - q * b;
         });
     });
   } else {

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -131,11 +131,10 @@ void remainder_kernel(TensorIterator& iter) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "remainder_cpu", [&]() {
       cpu_kernel(iter,
         [=](scalar_t a, scalar_t b) -> scalar_t {
-          scalar_t mod = a - floor_impl (a / b) * b;
-          const scalar_t zero = scalar_t(0); 
-          if ((mod != zero) && ((std::real(b) < std::real(zero)) != (std::real(mod) < std::real(zero)))) 
-            mod += b;
-          return mod;
+          auto q = std::trunc(a.real() / b.real());
+          auto r = std::fmod(a.real(), b.real()); 
+          auto arg = (a - q * b) / std::abs(a - q * b);
+          return arg * r;
         });
     });
   } else {

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -127,6 +127,17 @@ void remainder_kernel(TensorIterator& iter) {
         return r;
       });
     });
+  } else if (isComplexType(iter.dtype())) {
+    AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "remainder_cpu", [&]() {
+      cpu_kernel(iter,
+        [=](scalar_t a, scalar_t b) -> scalar_t {
+          scalar_t mod = a - floor_impl (a / b) * b;
+          const scalar_t zero = scalar_t(0); 
+          if ((mod != zero) && ((std::real(b) < std::real(zero)) != (std::real(mod) < std::real(zero)))) 
+            mod += b;
+          return mod;
+        });
+    });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "remainder_cpu", [&]() {
       cpu_kernel_vec(iter,

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -31,11 +31,10 @@ void remainder_kernel_cuda(TensorIterator& iter) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          scalar_t mod = a - floor_wrapper (a / b) * b;
-          const scalar_t zero = scalar_t(0); 
-          if ((mod != zero) && ((std::real(b) < std::real(zero)) != (std::real(mod) < std::real(zero)))) 
-            mod += b;
-          return mod;
+          auto q = std::trunc(a.real() / b.real());
+          auto r = std::fmod(a.real(), b.real()); 
+          auto arg = (a - q * b) / std::abs(a - q * b);
+          return arg * r;
         });
     });
   } else {

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -31,10 +31,8 @@ void remainder_kernel_cuda(TensorIterator& iter) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-          auto q = std::trunc(a.real() / b.real());
-          auto r = std::fmod(a.real(), b.real()); 
-          auto arg = (a - q * b) / std::abs(a - q * b);
-          return arg * r;
+          auto q = std::trunc(std::abs(a) / std::abs(b));
+          return a - q * b;
         });
     });
   } else {

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -33,7 +33,7 @@ void remainder_kernel_cuda(TensorIterator& iter) {
         []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
           scalar_t mod = a - floor_wrapper (a / b) * b;
           const scalar_t zero = scalar_t(0); 
-          if ((mod != zero) && ((std::abs(b) < std::abs(zero)) != (std::abs(mod) < std::abs(zero)))) 
+          if ((mod != zero) && ((std::real(b) < std::real(zero)) != (std::real(mod) < std::real(zero)))) 
             mod += b;
           return mod;
         });


### PR DESCRIPTION
Resolves Complex Version of torch.remainder #38349 and #34266 for CPU/CUDA.

- [ ] Complex Version of torch.remainder
  - [x]  CPU implementation
  - [ ]  Vectorized CPU implementation
  - [x]  CUDA implementation 
  - [ ]  unit tests
  - [ ]  update documentation