### PR TITLE
[DO NOT MERGE] Checking whether ci-all/ prefix works for branches in forks

### DIFF
--- a/.circleci/cimodel/data/simple/util/branch_filters.py
+++ b/.circleci/cimodel/data/simple/util/branch_filters.py
@@ -1,6 +1,6 @@
 NON_PR_BRANCH_LIST = [
     "master",
-    r"/ci-all\/.*/",
+    r"/ci-all\/.*/",  # this PR is testing this line
     r"/release\/.*/",
 ]
 


### PR DESCRIPTION
It seems that the answer is no.