### PR TITLE
Add serialize GraphModule to JSON support

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1,36 +1,121 @@
 import torch
+from typing import Dict
 from torch.fx.symbolic_trace import symbolic_trace
 from torch.fx.graph_module import GraphModule
+from torch.fx.node import Node
 from torch.fx.experimental import GraphManipulation
 from torch.fx.experimental.Partitioner import Partitioner, Device, PartitionerConfig
 from torch.fx.experimental.rewriter import RewritingTracer
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.jit_utils import JitTestCase
-from torch.fx.experimental.partitioner_utils import NodeLatency, \
-    get_partition_to_latency_mapping, get_latency_of_partitioned_graph
+from torch.fx.experimental.partitioner_utils import (
+    NodeLatency,
+    get_partition_to_latency_mapping,
+    get_latency_of_partitioned_graph,
+)
 from typing import Union, Callable
 
+
 def symbolic_trace_with_rewrite(root: Union[torch.nn.Module, Callable]) -> GraphModule:
-    return GraphModule(root if isinstance(root, torch.nn.Module) else torch.nn.Module(), RewritingTracer().trace(root))
+    return GraphModule(
+        root if isinstance(root, torch.nn.Module) else torch.nn.Module(),
+        RewritingTracer().trace(root),
+    )
+
 
 class TestFXExperimental(JitTestCase):
+    def test_serialize_graph(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+                self.e = torch.rand(4)
+
+            def forward(self, a, b):
+                add_1 = a + b
+                linear = self.linear(add_1)
+                add_2 = linear + self.e
+                return add_2
+
+        m = TestModule()
+        traced = symbolic_trace(m)
+        a = torch.rand(4)
+        b = torch.rand(4)
+        GraphManipulation.get_size_of_all_nodes(traced, [a, b])
+
+        partitioner = Partitioner()
+        devices = [Device("dev_0", 5000, 0), Device("dev_1", 125, 1)]
+        partitioner_config = PartitionerConfig(devices, is_sparse_nn=True)
+        ret = partitioner.partition_graph(traced, m, partitioner_config)
+        module_with_submodules = ret.module_with_submodules
+        # Fix for now to add type/shape to output
+        for node in traced.graph.nodes:
+            if node.op == "output":
+                node.shape = a.shape
+                node.dtype = a.dtype
+        for mod in module_with_submodules.modules():
+            if isinstance(mod, GraphModule):
+                for node in mod.graph.nodes:
+                    node.shape = a.shape
+                    node.dtype = a.dtype
+        for node in module_with_submodules.graph.nodes:
+            node.shape = a.shape
+            node.dtype = a.dtype
+
+        agm1 = GraphManipulation.AcceleratedGraphModule(traced)
+        agm2 = GraphManipulation.AcceleratedGraphModule(module_with_submodules)
+        assert len(agm1.weights) == 3
+        assert len(agm2.weights) == 3
+        assert len(agm1.serialized_graph["nodes"]) == 7
+        assert len(agm1.serialized_graph["weights"]) == 3
+        assert len(agm1.serialized_graph["modules"]) == 0
+        assert len(agm2.serialized_graph["nodes"]) == 5
+        assert len(agm2.serialized_graph["weights"]) == 3
+        assert len(agm2.serialized_graph["modules"]) == 1
+        assert agm1.serialized_graph["weights"]["linear.weight"]["shape"] == "[4, 4]"
+        assert (
+            agm1.serialized_graph["weights"]["linear.weight"]["dtype"]
+            == "torch.float32"
+        )
+        assert (
+            agm1.serialized_graph["weights"]["linear.weight"]["is_quantized"] is False
+        )
+        assert agm1.serialized_graph["nodes"][0]["shape"] == "[4]"
+        assert agm1.serialized_graph["nodes"][0]["dtype"] == "torch.float32"
+        assert agm1.serialized_graph["nodes"][0]["target"] == "a"
+        assert agm1.serialized_graph["nodes"][0]["op_code"] == "placeholder"
+        assert agm1.serialized_graph["nodes"][0]["name"] == "a"
+        assert agm1.serialized_graph["nodes"][2]["args"][0]["name"] == "a"
+        assert agm1.serialized_graph["nodes"][2]["args"][0]["is_node"] is True
+
+        # Test quantization info serialization.
+        x = torch.tensor([[-1.0, 0.0], [1.0, 2.0]])
+        q_tensor = torch.quantize_per_tensor(x, 1, 0, torch.qint32)
+        q_tensor_channel = torch.quantize_per_channel(
+            x, torch.tensor([0.1, 0.01]), torch.tensor([10, 0]), 0, torch.quint8
+        )
+        result = GraphManipulation.serialize_tensor_quantization(q_tensor)
+        result2 = GraphManipulation.serialize_tensor_quantization(q_tensor_channel)
+        assert result["q_scheme"] == "torch.per_tensor_affine"
+        assert result["q_scale"] == 1.0
+        assert result2["q_scheme"] == "torch.per_channel_affine"
+        assert len(result2["q_per_channel_scales"]) == 2
+
     def test_find_single_partition(self):
         class TestModule(torch.nn.Module):
             def forward(self, a, b):
                 return a + b
+
         m = TestModule()
         traced = symbolic_trace(m)
         a = torch.rand(1)
         b = torch.rand(1)
-        GraphManipulation.get_size_of_all_nodes(
-            traced,
-            [a, b]
-        )
+        GraphManipulation.get_size_of_all_nodes(traced, [a, b])
         partitioner = Partitioner()
         devices = [
-            Device('dev_0', 125, 0),
-            Device('dev_1', 125, 1),
-            Device('dev_2', 125, 2)
+            Device("dev_0", 125, 0),
+            Device("dev_1", 125, 1),
+            Device("dev_2", 125, 2),
         ]
         partitioner_config = PartitionerConfig(devices)
         ret = partitioner.partition_graph(traced, m, partitioner_config)
@@ -56,15 +141,12 @@ class TestFXExperimental(JitTestCase):
         traced = symbolic_trace(m)
         a = torch.rand(4)
         b = torch.rand(4)
-        GraphManipulation.get_size_of_all_nodes(
-            traced,
-            [a, b]
-        )
+        GraphManipulation.get_size_of_all_nodes(traced, [a, b])
         partitioner = Partitioner()
         devices = [
-            Device('dev_0', 125, 0),
-            Device('dev_1', 125, 1),
-            Device('dev_2', 125, 2)
+            Device("dev_0", 125, 0),
+            Device("dev_1", 125, 1),
+            Device("dev_2", 125, 2),
         ]
         partitioner_config = PartitionerConfig(devices)
         ret = partitioner.partition_graph(traced, m, partitioner_config)
@@ -91,15 +173,9 @@ class TestFXExperimental(JitTestCase):
         m = TestModule()
         traced = symbolic_trace(m)
         a = torch.rand(4)
-        GraphManipulation.get_size_of_all_nodes(
-            traced,
-            [a]
-        )
+        GraphManipulation.get_size_of_all_nodes(traced, [a])
         partitioner = Partitioner()
-        devices = [
-            Device('dev_0', 120, 0),
-            Device('dev_1', 160, 1)
-        ]
+        devices = [Device("dev_0", 120, 0), Device("dev_1", 160, 1)]
         partitioner_config = PartitionerConfig(devices, is_sparse_nn=False)
         ret = partitioner.partition_graph(traced, m, partitioner_config)
         module_with_submodules = ret.module_with_submodules
@@ -128,12 +204,12 @@ class TestFXExperimental(JitTestCase):
                 layers = self.create_mlp(3, 24, 24)
                 self.top_layers = torch.nn.Sequential(*layers)
                 self.embedding_layers = torch.nn.ModuleList()
-                el = torch.nn.EmbeddingBag(500000, 4, mode='sum', sparse=True)
+                el = torch.nn.EmbeddingBag(500000, 4, mode="sum", sparse=True)
                 self.embedding_layers.append(el)
                 for i in range(3):
-                    el = torch.nn.EmbeddingBag(1000000, 4, mode='sum', sparse=True)
+                    el = torch.nn.EmbeddingBag(1000000, 4, mode="sum", sparse=True)
                     self.embedding_layers.append(el)
-                el = torch.nn.EmbeddingBag(500000, 4, mode='sum', sparse=True)
+                el = torch.nn.EmbeddingBag(500000, 4, mode="sum", sparse=True)
                 self.embedding_layers.append(el)
 
             def forward(self, a, b, offset):
@@ -141,27 +217,29 @@ class TestFXExperimental(JitTestCase):
                 y = []
                 c = []
                 for i in range(len(self.embedding_layers)):
-                    temp = torch.randint(10, (8, ))
+                    temp = torch.randint(10, (8,))
                     c.append(temp + b)
                 for i in range(len(self.embedding_layers)):
                     if i % 2 == 0:
                         y.append(self.embedding_layers[i](c[i], offset))
                     else:
-                        y.append(self.embedding_layers[i](torch.randint(10, (8, )), offset))
+                        y.append(
+                            self.embedding_layers[i](torch.randint(10, (8,)), offset)
+                        )
                 z = torch.cat([x] + y, dim=1)
                 p = self.top_layers(z)
                 return p
 
         m = MyRecommendationModule()
         a = torch.rand(2, 4)
-        b = torch.randint(10, (8, ))
-        offset = torch.randint(1, (2, ))
+        b = torch.randint(10, (8,))
+        offset = torch.randint(1, (2,))
         traced = symbolic_trace(m)
         GraphManipulation.get_size_of_all_nodes(traced, [a, b, offset])
         devices = [
-            Device('dev_0', 33000000, 0),
-            Device('dev_1', 33000000, 1),
-            Device('dev_2', 33000000, 2)
+            Device("dev_0", 33000000, 0),
+            Device("dev_1", 33000000, 1),
+            Device("dev_2", 33000000, 2),
         ]
         partitioner_config = PartitionerConfig(devices, is_sparse_nn=True)
         partitioner = Partitioner()
@@ -187,15 +265,19 @@ class TestFXExperimental(JitTestCase):
 
         def get_node_to_latency_mapping(fx_module: GraphModule):
             """Given a fx module, generate node latency for each node
-               based on the size of each node
+            based on the size of each node
             """
             node_to_latency_mapping: Dict[Node, NodeLatency] = {}
             for node in fx_module.graph.nodes:
-                if node.op not in {'output', 'placeholder', 'get_attr'}:
+                if node.op not in {"output", "placeholder", "get_attr"}:
                     if node.size_bytes.total_size == node.size_bytes.output_size:
-                        node_to_latency_mapping[node] = NodeLatency(node.size_bytes.total_size, 2. * node.size_bytes.total_size)
+                        node_to_latency_mapping[node] = NodeLatency(
+                            node.size_bytes.total_size, 2.0 * node.size_bytes.total_size
+                        )
                     else:
-                        node_to_latency_mapping[node] = NodeLatency(node.size_bytes.total_size, node.size_bytes.output_size)
+                        node_to_latency_mapping[node] = NodeLatency(
+                            node.size_bytes.total_size, node.size_bytes.output_size
+                        )
             return node_to_latency_mapping
 
         m = TestModule()
@@ -203,36 +285,33 @@ class TestFXExperimental(JitTestCase):
         a = torch.rand(4)
         GraphManipulation.get_size_of_all_nodes(traced, [a])
         node_to_latency_mapping = get_node_to_latency_mapping(traced)
-        devices = [
-            Device('dev_0', 200, 0),
-            Device('dev_1', 200, 1)
-        ]
+        devices = [Device("dev_0", 200, 0), Device("dev_1", 200, 1)]
         partitioner = Partitioner()
         partitioner_config = PartitionerConfig(devices, False)
         ret = partitioner.partition_graph(traced, m, partitioner_config)
         module_with_submodules = ret.module_with_submodules
         self.assertEqual(traced(a), module_with_submodules(a))
         partitions = partitioner.partitions
-        partition_to_latency_mapping = get_partition_to_latency_mapping(partitions, node_to_latency_mapping)
+        partition_to_latency_mapping = get_partition_to_latency_mapping(
+            partitions, node_to_latency_mapping
+        )
         for p in partition_to_latency_mapping:
             if p.partition_id == 0:
-                assert partition_to_latency_mapping[p] == (128., 80., 160.)
+                assert partition_to_latency_mapping[p] == (128.0, 80.0, 160.0)
             else:
-                assert partition_to_latency_mapping[p] == (16., 32., 32.)
+                assert partition_to_latency_mapping[p] == (16.0, 32.0, 32.0)
         transfer_rate_bytes_per_sec = 0.5
         critical_path_latency_sec = get_latency_of_partitioned_graph(
-            partitions,
-            partition_to_latency_mapping,
-            transfer_rate_bytes_per_sec
+            partitions, partition_to_latency_mapping, transfer_rate_bytes_per_sec
         )
-        assert critical_path_latency_sec == 208.
+        assert critical_path_latency_sec == 208.0
 
     def test_call_to_assert_no_msg(self):
-
         class M(torch.nn.Module):
             def forward(self, a, b):
                 assert a == b
                 return a + b
+
         m = M()
         traced = symbolic_trace_with_rewrite(m)
 
@@ -240,7 +319,12 @@ class TestFXExperimental(JitTestCase):
         traced.graph.lint(traced)
 
         # Check the IR to make sure there's a call_function node with target == "Assert"
-        self.assertTrue(any(node.op == "call_function" and node.target == torch.Assert for node in traced.graph.nodes))
+        self.assertTrue(
+            any(
+                node.op == "call_function" and node.target == torch.Assert
+                for node in traced.graph.nodes
+            )
+        )
 
         # Ensure that the assert throws when it's supposed to and doesn't throw when it's not supposed to
         traced(3, 3)
@@ -251,11 +335,11 @@ class TestFXExperimental(JitTestCase):
         self.assertEqual(traced(3, 3), m(3, 3))
 
     def test_call_to_assert_with_msg(self):
-
         class M(torch.nn.Module):
             def forward(self, a, b):
                 assert a == b, "test message"
                 return a + b
+
         m = M()
         traced = symbolic_trace_with_rewrite(m)
 
@@ -263,7 +347,12 @@ class TestFXExperimental(JitTestCase):
         traced.graph.lint(traced)
 
         # Check the IR to make sure there's a call_function node with target == "Assert"
-        self.assertTrue(any(node.op == "call_function" and node.target == torch.Assert for node in traced.graph.nodes))
+        self.assertTrue(
+            any(
+                node.op == "call_function" and node.target == torch.Assert
+                for node in traced.graph.nodes
+            )
+        )
 
         # Ensure that the assert throws when it's supposed to and doesn't throw when it's not supposed to
         traced(3, 3)
@@ -274,11 +363,11 @@ class TestFXExperimental(JitTestCase):
         self.assertEqual(traced(3, 3), m(3, 3))
 
     def test_call_to_assert_with_empty_msg(self):
-
         class M(torch.nn.Module):
             def forward(self, a, b):
                 assert a == b, ""
                 return a + b
+
         m = M()
         traced = symbolic_trace_with_rewrite(m)
 
@@ -286,7 +375,12 @@ class TestFXExperimental(JitTestCase):
         traced.graph.lint(traced)
 
         # Check the IR to make sure there's a call_function node with target == "Assert"
-        self.assertTrue(any(node.op == "call_function" and node.target == torch.Assert for node in traced.graph.nodes))
+        self.assertTrue(
+            any(
+                node.op == "call_function" and node.target == torch.Assert
+                for node in traced.graph.nodes
+            )
+        )
 
         # Ensure that the assert throws when it's supposed to and doesn't throw when it's not supposed to
         traced(3, 3)
@@ -297,7 +391,6 @@ class TestFXExperimental(JitTestCase):
         self.assertEqual(traced(3, 3), m(3, 3))
 
     def test_call_to_assert_with_multiline_message(self):
-
         class M(torch.nn.Module):
             def forward(self, a, b):
                 error_msg = """
@@ -306,6 +399,7 @@ terrible spacing
                 """
                 assert a == b, error_msg
                 return a + b
+
         m = M()
         traced = symbolic_trace_with_rewrite(m)
 
@@ -313,7 +407,12 @@ terrible spacing
         traced.graph.lint(traced)
 
         # Check the IR to make sure there's a call_function node with target == "Assert"
-        self.assertTrue(any(node.op == "call_function" and node.target == torch.Assert for node in traced.graph.nodes))
+        self.assertTrue(
+            any(
+                node.op == "call_function" and node.target == torch.Assert
+                for node in traced.graph.nodes
+            )
+        )
 
         # Ensure that the assert throws when it's supposed to and doesn't throw when it's not supposed to
         error_msg = """
@@ -330,7 +429,9 @@ terrible spacing
     def test_traceable_function_with_nonstandard_name(self):
         def foo(x):
             return torch.relu(x)
+
         traced = symbolic_trace_with_rewrite(foo)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_tests()

--- a/torch/fx/experimental/GraphManipulation.py
+++ b/torch/fx/experimental/GraphManipulation.py
@@ -1,9 +1,12 @@
-from typing import Dict, List, NamedTuple
-from torch.fx.graph_module import GraphModule
-from torch.fx.node import Node, Target, map_arg
-from torch.fx.graph import Graph
+import json
+from typing import Dict, List, NamedTuple, Any
+
 import torch
 from torch.fx.experimental.shape_prop import ShapeProp
+from torch.fx.graph import Graph, get_qualified_name
+from torch.fx.graph_module import GraphModule
+from torch.fx.node import Node, Target, map_arg
+
 
 def replace_target_nodes_with(
     fx_module: GraphModule,
@@ -15,21 +18,25 @@ def replace_target_nodes_with(
     """Modifies all nodes in fx_module.graph.nodes which match the specified op code and target,
     and updates them to match the new op code and target"""
     new_graph = Graph()
-    val_map : Dict[Node, Node] = {}
+    val_map: Dict[Node, Node] = {}
     for node in fx_module.graph.nodes:
         if node.op == old_op and node.target == old_target:
             args = map_arg(node.args, lambda n: val_map[n])
             kwargs = map_arg(node.kwargs, lambda n: val_map[n])
             assert isinstance(args, tuple)
             assert isinstance(kwargs, dict)
-            val_map[node] = new_graph.create_node(new_op, new_target, args, kwargs, node.name)
+            val_map[node] = new_graph.create_node(
+                new_op, new_target, args, kwargs, node.name
+            )
         else:
-            val_map[node] = new_graph.node_copy(node, lambda n : val_map[n])
+            val_map[node] = new_graph.node_copy(node, lambda n: val_map[n])
     fx_module.graph = new_graph
+
 
 class size_bytes(NamedTuple):
     output_size: int
     total_size: int
+
 
 def get_size_of_all_nodes(fx_module: GraphModule, args: List[torch.Tensor]) -> None:
     """Given a fx graph module, update each node with its total size (weights + bias + output)
@@ -40,19 +47,20 @@ def get_size_of_all_nodes(fx_module: GraphModule, args: List[torch.Tensor]) -> N
     # Calculate the total size of the whole fx graph
     total_size_of_graph = 0.0
     for node in fx_module.graph.nodes:
-        if node.op == 'output':
+        if node.op == "output":
             break
         node.size_bytes = get_size_of_node(fx_module, node)
     return
 
+
 def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
     """Given a node with node.dtype and node.shape, return its total size and its output size.
-       total_size = weights + bias + output_size
+    total_size = weights + bias + output_size
     """
     # Total num of elements
     total_num_of_elems = 0
     # For a module, conside all parameters
-    if node.op == 'call_module':
+    if node.op == "call_module":
         submodule_dict = dict(fx_module.named_modules())
         submodule = submodule_dict[node.target]
         parameters = submodule.named_parameters()
@@ -61,18 +69,165 @@ def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
             total_num_of_elems += p.numel()
     # Don't forget the output size
     # node.shape is the shape of this node's output
-    shape = getattr(node, 'shape', None)
+    shape = getattr(node, "shape", None)
     if shape:
         output_elem = shape.numel()
     else:
-        raise RuntimeError('Node has no shape attr')
+        raise RuntimeError("Node has no shape attr")
     total_num_of_elems += output_elem
     size_per_elem_bytes = 0
-    dtype = getattr(node, 'dtype', None)
+    dtype = getattr(node, "dtype", None)
     if dtype:
         size_per_elem_bytes = torch.tensor([], dtype=dtype).element_size()
     else:
-        raise RuntimeError('Node has no dtype attr')
+        raise RuntimeError("Node has no dtype attr")
     total_size = size_per_elem_bytes * total_num_of_elems
     output_size = size_per_elem_bytes * output_elem
     return size_bytes(output_size, total_size)
+
+
+def serialize_shape(shape: torch.Size) -> str:
+    return str(list(shape))
+
+
+def serialize_tensor_quantization(tensor: torch.Tensor) -> Dict[str, Any]:
+    scheme = {}  # type: Dict[str, Any]
+    if tensor.is_quantized:
+        scheme["q_scheme"] = str(tensor.qscheme())
+        if tensor.qscheme() in {torch.per_tensor_affine, torch.per_tensor_symmetric}:
+            scheme["q_scale"] = tensor.q_scale()
+            scheme["q_zero_pont"] = tensor.q_zero_point()
+        if tensor.qscheme() in {
+            torch.per_channel_affine,
+            torch.per_channel_affine_float_qparams,
+            torch.per_channel_symmetric,
+        }:
+            scheme["q_per_channel_scales"] = tensor.q_per_channel_scales().tolist()
+            scheme[
+                "q_per_channel_zero_points"
+            ] = tensor.q_per_channel_zero_points().tolist()
+            scheme["q_per_channel_axis"] = tensor.q_per_channel_axis()
+
+    return scheme
+
+
+def serialize_weight(tensor: torch.Tensor) -> Dict:
+    weight = {}  # type: Dict[str, Any]
+    weight["dtype"] = str(tensor.dtype)
+    weight["is_quantized"] = tensor.is_quantized
+    if tensor.is_quantized:
+        weight["quantized_type"] = serialize_tensor_quantization(tensor)
+    weight["shape"] = serialize_shape(tensor.shape)
+    return weight
+
+
+def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> Dict:
+    """Recursively Serializes a graph module (fx_module) to a dictionary which is later exported to JSON.
+    It also adds all weights the provided weights dictionary by qualified_name.
+    Dictionary Schema:
+    MODULE
+    {
+        modules: {module_name: MODULE],
+        nodes: [NODE],
+        weights {qualified_name: WEIGHT},
+    }
+    NODE
+    {
+        shape: [],
+        dtype: dtype,
+        target: target,
+        op_code: op_code,
+        name: name,
+        args: [],
+        kwargs: {}
+    }
+    WEIGHT
+    {
+        dtype: dtype,
+        is_quantized: bool,
+        shape: [],
+        quantization_info: QUANTIZATION
+    }
+    QUANTIZATION
+    {
+        qscheme: qscheme,
+        q_scale: float,
+        q_zero_point: float,
+        q_per_channel_scales, [],
+        q_per_channel_zero_points: [],
+        q_per_channel_axis, int
+    }
+    """
+    serialized_dict = {}  # type: Dict[str, Any]
+    serialized_dict["modules"] = {}
+    serialized_dict["weights"] = {}
+    serialized_dict["nodes"] = []
+    parameters = fx_module.named_parameters()
+    for name, p in parameters:
+        if isinstance(p, torch.Tensor):
+            weight = serialize_weight(p)
+            prefix = f"{name_prefix}." if name_prefix else ""
+            serialized_dict["weights"][prefix + name] = weight
+            weights[prefix + name] = p
+    for node in fx_module.graph.nodes:
+        node_rep = {}  # type: Dict[str, Any]
+        # Get shape/type info, currently not needed for call_module.
+        if node.op != "call_module":
+            shape = getattr(node, "shape", None)
+            if shape:
+                node_rep["shape"] = serialize_shape(shape)
+            else:
+                raise RuntimeError(
+                    "Node has no shape attr, this is likely because shape propagation has not been run on this Graph."
+                )
+            dtype = getattr(node, "dtype", None)
+            if dtype:
+                node_rep["dtype"] = str(dtype)
+            else:
+                raise RuntimeError(
+                    "Node has no dtype attr, this is likely because shape propagation has not been run on this Graph."
+                )
+
+        # Recurse down into any submodules we are calling.
+        if node.op == "call_module":
+            submodules = dict(fx_module.named_modules())
+            if isinstance(submodules[node.target], GraphModule):
+                serialized_module = serialize_module(
+                    getattr(fx_module, node.target), weights, node.target
+                )
+                serialized_dict["modules"][node.target] = serialized_module
+
+        if node.op == "call_function":
+            node_rep["target"] = get_qualified_name(node.target)
+        else:
+            node_rep["target"] = str(node.target)
+
+        # Make sure we capture all constants.
+        if node.op == "get_attr":
+            target = getattr(fx_module, node.target)
+            prefix = f"{name_prefix}." if name_prefix else ""
+            qualname = prefix + node.target
+            if isinstance(target, torch.Tensor) and qualname not in weights:
+                weight = serialize_weight(target)
+                serialized_dict["weights"][prefix + node.target] = weight
+                weights[prefix + node.target] = target
+
+        node_rep["op_code"] = node.op
+        node_rep["name"] = node.name
+        node_rep["args"] = map_arg(
+            node.args, lambda arg: {"is_node": True, "name": str(arg)}
+        )
+        node_rep["kwargs"] = map_arg(
+            node.kwargs, lambda arg: {"is_node": True, "name": str(arg)}
+        )
+        serialized_dict["nodes"] += [node_rep]
+
+    return serialized_dict
+
+
+class AcceleratedGraphModule:
+    def __init__(self, fx_module: GraphModule):
+        """Creates the needed data structures to pass to the glow runtime"""
+        self.weights = {}  # type: Dict[str, Any]
+        self.serialized_graph = serialize_module(fx_module, self.weights)
+        self.serialized_graph_json = json.dumps(self.serialized_graph, indent=4)

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -16,7 +16,7 @@ def _is_magic(x: str) -> bool:
 def snake_case(s: str) -> str:
     return ''.join(['_' + i.lower() if i.isupper() else i for i in s]).lstrip('_')
 
-def _qualified_name(func: Callable[..., Any]) -> str:
+def get_qualified_name(func: Callable[..., Any]) -> str:
     # things like getattr just appear in builtins
     if getattr(builtins, func.__name__, None) is func:
         return func.__name__
@@ -362,7 +362,7 @@ class Graph:
                     assert isinstance(node.args, tuple)
                     body.append(f'{node.name} = {magic_methods[node.target.__name__].format(*(repr(a) for a in node.args))}\n')
                     continue
-                qualified_name = _qualified_name(node.target)
+                qualified_name = get_qualified_name(node.target)
                 register_modules_used(qualified_name)
                 if qualified_name == 'getattr' and \
                    isinstance(node.args, tuple) and \


### PR DESCRIPTION
re-opening PR, missed mypy issues, they are now addressed.
Example:

class TestModule(torch.nn.Module):
            def __init__(self):
                super().__init__()
                self.linear = torch.nn.Linear(4, 4)
                self.e = torch.rand(4)

            def forward(self, a, b):
                add_1 = a + b
                linear = self.linear(add_1)
                add_2 = linear + self.e
                return add_2
JSON:

{
    "modules": {},
    "weights": {
        "linear.weight": {
            "dtype": "torch.float32",
            "is_quantized": false,
            "shape": "[4, 4]"
        },
        "linear.bias": {
            "dtype": "torch.float32",
            "is_quantized": false,
            "shape": "[4]"
        },
        "e": {
            "dtype": "torch.float32",
            "is_quantized": false,
            "shape": "[4]"
        }
    },
    "nodes": [
        {
            "shape": "[4]",
            "dtype": "torch.float32",
            "target": "a",
            "op_code": "placeholder",
            "name": "a",
            "args": [],
            "kwargs": {}
        },
        {
            "shape": "[4]",
            "dtype": "torch.float32",
            "target": "b",
            "op_code": "placeholder",
            "name": "b",
            "args": [],
            "kwargs": {}
        },
        {
            "shape": "[4]",
            "dtype": "torch.float32",
            "target": "_operator.add",
            "op_code": "call_function",
            "name": "add_1",
            "args": [
                {
                    "is_node": true,
                    "name": "a"
                },
                {
                    "is_node": true,
                    "name": "b"
                }
            ],
            "kwargs": {}
        },
        {
            "target": "linear",
            "op_code": "call_module",
            "name": "linear_1",
            "args": [
                {
                    "is_node": true,
                    "name": "add_1"
                }
            ],
            "kwargs": {}
        },
        {
            "shape": "[4]",
            "dtype": "torch.float32",
            "target": "e",
            "op_code": "get_attr",
            "name": "e",
            "args": [],
            "kwargs": {}
        },
        {
            "shape": "[4]",
            "dtype": "torch.float32",
            "target": "_operator.add",
            "op_code": "call_function",
            "name": "add_2",
            "args": [
                {
                    "is_node": true,
                    "name": "linear_1"
                },
                {
                    "is_node": true,
                    "name": "e"
                }
            ],
            "kwargs": {}
        },
        {
            "shape": "[4]",
            "dtype": "torch.float32",
            "target": "output",
            "op_code": "output",
            "name": "output",
            "args": [
                {
                    "is_node": true,
                    "name": "add_2"
                }
            ],
            "kwargs": {}
        }
    ]
}