### PR TITLE
skip GPU test on sandcastle if sanitizer is enabled

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -366,7 +366,9 @@ def get_device_type_test_bases():
 
     if IS_SANDCASTLE or IS_FBCODE:
         if IS_REMOTE_GPU:
-            test_bases.append(CUDATestBase)
+            # skip if sanitizer is enabled
+            if not TEST_WITH_ASAN and not TEST_WITH_TSAN and not TEST_WITH_UBSAN:
+                test_bases.append(CUDATestBase)
         else:
             test_bases.append(CPUTestBase)
     else:


### PR DESCRIPTION
Summary:
`caffe2/test:cuda` was safeguarded by a GPU availability check however most of the mixed CPU/GPU tests aren't.

Use `TEST_WITH_*SAN` flags to safeguard test discovery for CUDA tests.

Test Plan: sandcastle

Differential Revision: D24842333

