### PR TITLE
skip test_all_reduce_sum_cuda_async test case for ROCM

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1378,6 +1378,7 @@ class DistributedTest:
             "Only Gloo and NCCL backends will have CUDA allReduce tested",
         )
         @skip_if_no_gpu
+        @skip_if_rocm
         def test_all_reduce_sum_cuda_async(self):
             group, group_id, rank = self._init_global_test()
             rank_to_GPU = self._init_multigpu_helper()


### PR DESCRIPTION
Skip the following test case for rocm (When PYTORCH_TEST_WITH_ROCM=1):
- test_all_reduce_sum_cuda_async (__main__.TestDistBackendWithFork)

@jeffdaily
@pruthvistony