### PR TITLE
[GPU] Make permuteWeights inline

### DIFF
--- a/aten/src/ATen/native/metal/MetalPrepackOpContext.h
+++ b/aten/src/ATen/native/metal/MetalPrepackOpContext.h
@@ -70,7 +70,7 @@ class Conv2dOpContext : public torch::jit::CustomClassHolder {
 
 // The MPSCNNConvolution class takes weights in the order
 // [outputChannels][kernelHeight][kernelWidth][inputChannels/groups].
-static std::vector<float> permuteWeights(
+static inline std::vector<float> permuteWeights(
     const float* src,
     const std::vector<int64_t>& sizes) {
   const int64_t M = sizes[0];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Follow up on @dust's diff - D24710102. Make the function inline in order to get rid of the compiler checking `-Werror,-Wunused-function`.

Differential Revision: [D24824637](https://our.internmc.facebook.com/intern/diff/D24824637/)