### PR TITLE
Add high level profiling trace for dataloading and optimizer

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -4,6 +4,8 @@ import unittest
 
 import torch
 import torch.nn as nn
+import torch.optim
+import torch.utils.data
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, TEST_WITH_ASAN, IS_WINDOWS)
 from torch.autograd.profiler import profile
@@ -14,6 +16,7 @@ try:
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False
+import pickle
 
 
 @unittest.skipIf(not HAS_PSUTIL, "Requires psutil to run")
@@ -128,6 +131,99 @@ class TestProfiler(TestCase):
         self.assertTrue(found_gemm)
         self.assertTrue(found_memcpy)
         # p.export_chrome_trace("/tmp/test_trace.json")
+
+    def test_high_level_trace(self):
+        """Checks that python side high level events are recorded.
+        """
+        class RepeatedDataset(torch.utils.data.Dataset):
+            def __init__(self, N, D_in, D_out):
+                self.N = N
+                self.x = torch.randn(N, D_in)
+                self.y = torch.randn(N, D_out)
+
+            def __len__(self):
+                return self.N
+
+            def __getitem__(self, idx):
+                return self.x, self.y
+
+        class TwoLayerNet(torch.nn.Module):
+            def __init__(self, D_in, H, D_out):
+                super(TwoLayerNet, self).__init__()
+                self.linear1 = torch.nn.Linear(D_in, H)
+                self.linear2 = torch.nn.Linear(H, D_out)
+
+            def forward(self, x):
+                h_relu = self.linear1(x).clamp(min=0)
+                y_pred = self.linear2(h_relu)
+                return y_pred
+
+        class CustomSGD(torch.optim.SGD):
+            def __init__(self, *args, **kwargs):
+                super(CustomSGD, self).__init__(*args, **kwargs)
+
+        def train():
+            for _, data in enumerate(dataloader):
+                x, y = data[0], data[1]
+                y_pred = model(x)
+                loss = criterion(y_pred, y)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+        N, D_in, H, D_out = 8, 10, 5, 2
+        model = TwoLayerNet(D_in, H, D_out)
+        criterion = torch.nn.MSELoss(reduction='sum')
+        optimizer = torch.optim.SGD(model.parameters(), lr=1e-4)
+        ds = RepeatedDataset(N, D_in, D_out)
+        dataloader = torch.utils.data.DataLoader(ds, batch_size=1)
+
+        try:
+            train()
+        except Exception:
+            self.assertTrue(False, "Expected no exception without profiling.")
+
+        # Create multiple instances, expect each func is hooked only one time.
+        # Nested wrappers(repeated patching) will make following test fail.
+        optimizer_duplicate = torch.optim.SGD(model.parameters(), lr=1e-4)
+        dataloader_duplicate = torch.utils.data.DataLoader(ds, batch_size=1)
+
+        def judge(expected_event_count, prof):
+            actual_event_count = {}
+            for e in prof.function_events:
+                if "#" in e.name:
+                    key = e.name
+                    if key in expected_event_count.keys():
+                        actual_event_count[key] = actual_event_count.setdefault(key, 0) + 1
+            for key, count in expected_event_count.items():
+                self.assertTrue((key in actual_event_count.keys()) and (count == actual_event_count[key]))
+
+        with profile() as prof:
+            train()
+        expected_event_count = {
+            # "+1" because the final iteration will enter __next__ but skip the loop body.
+            "enumerate(DataLoader)#_SingleProcessDataLoaderIter.__next__": (N + 1),
+            "Optimizer.step#SGD.step": N,
+            "Optimizer.zero_grad#SGD.zero_grad": N
+        }
+        judge(expected_event_count, prof)
+
+        # Test on pickle/unpickle. Expect to work in multi-processing.
+        optimizer = pickle.loads(pickle.dumps(optimizer))
+        with profile() as prof:
+            train()
+        judge(expected_event_count, prof)
+
+        # Test on customized optimizer.
+        optimizer = CustomSGD(model.parameters(), lr=1e-4)
+        with profile() as prof:
+            train()
+        expected_event_count = {
+            "enumerate(DataLoader)#_SingleProcessDataLoaderIter.__next__": (N + 1),
+            "Optimizer.step#CustomSGD.step": N,
+            "Optimizer.zero_grad#CustomSGD.zero_grad": N
+        }
+        judge(expected_event_count, prof)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -257,3 +257,5 @@ from torch._C._autograd import (DeviceType, ProfilerActivity, ProfilerState, Pro
 if kineto_available():
     from torch._C._autograd import (ProfilerResult, KinetoEvent,
                                     _prepare_profiler, _enable_profiler, _disable_profiler)
+
+from . import profiler

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -5,6 +5,7 @@ import torch
 from copy import deepcopy
 from itertools import chain
 import warnings
+import functools
 
 
 class _RequiredParameter(object):
@@ -29,6 +30,30 @@ class Optimizer(object):
         defaults: (dict): a dict containing default values of optimization
             options (used when a parameter group doesn't specify them).
     """
+
+    # Because if optimizer object is created by deepcopy or multiprocessing pickle/unpickle,
+    # __init__ will not be called. We put the profiling logic here to support these cases.
+    def __new__(cls, *args, **kwargs):
+
+        def profile_function(func):
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                # The first argument is self, which we use it to get the actual class of the object.
+                obj, *_ = args
+                profile_name = "Optimizer.{}#{}.{}".format(func.__name__, obj.__class__.__name__, func.__name__)
+                with torch.autograd.profiler.record_function(profile_name):
+                    return func(*args, **kwargs)
+
+            wrapper.profile_hooked = True
+            return wrapper
+
+        # In each class, a function is hooked only once.
+        if not getattr(cls.step, "profile_hooked", None):
+            cls.step = profile_function(cls.step)
+        if not getattr(cls.zero_grad, "profile_hooked", None):
+            cls.zero_grad = profile_function(cls.zero_grad)
+        return super().__new__(cls)
 
     def __init__(self, params, defaults):
         torch._C._log_api_usage_once("python.optimizer")

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -35,7 +35,7 @@ class Optimizer(object):
         torch._C._log_api_usage_once("python.optimizer")
         self.defaults = defaults
 
-        self.hook_for_profile()
+        self._hook_for_profile()
 
         if isinstance(params, torch.Tensor):
             raise TypeError("params argument given to the optimizer should be "
@@ -63,7 +63,7 @@ class Optimizer(object):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        self.hook_for_profile()  # To support multiprocessing pickle/unpickle.
+        self._hook_for_profile()  # To support multiprocessing pickle/unpickle.
 
     def __repr__(self):
         format_string = self.__class__.__name__ + ' ('
@@ -76,7 +76,7 @@ class Optimizer(object):
         format_string += ')'
         return format_string
 
-    def hook_for_profile(self):
+    def _hook_for_profile(self):
         self._zero_grad_profile_name = "Optimizer.zero_grad#{}.zero_grad".format(self.__class__.__name__)
 
         def profile_hook_step(func):

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -31,33 +31,11 @@ class Optimizer(object):
             options (used when a parameter group doesn't specify them).
     """
 
-    # Because if optimizer object is created by deepcopy or multiprocessing pickle/unpickle,
-    # __init__ will not be called. We put the profiling logic here to support these cases.
-    def __new__(cls, *args, **kwargs):
-
-        def profile_function(func):
-
-            @functools.wraps(func)
-            def wrapper(*args, **kwargs):
-                # The first argument is self, which we use it to get the actual class of the object.
-                obj, *_ = args
-                profile_name = "Optimizer.{}#{}.{}".format(func.__name__, obj.__class__.__name__, func.__name__)
-                with torch.autograd.profiler.record_function(profile_name):
-                    return func(*args, **kwargs)
-
-            wrapper.profile_hooked = True
-            return wrapper
-
-        # In each class, a function is hooked only once.
-        if not getattr(cls.step, "profile_hooked", None):
-            cls.step = profile_function(cls.step)
-        if not getattr(cls.zero_grad, "profile_hooked", None):
-            cls.zero_grad = profile_function(cls.zero_grad)
-        return super().__new__(cls)
-
     def __init__(self, params, defaults):
         torch._C._log_api_usage_once("python.optimizer")
         self.defaults = defaults
+
+        self.hook_for_profile()
 
         if isinstance(params, torch.Tensor):
             raise TypeError("params argument given to the optimizer should be "
@@ -85,6 +63,7 @@ class Optimizer(object):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        self.hook_for_profile()  # To support multiprocessing pickle/unpickle.
 
     def __repr__(self):
         format_string = self.__class__.__name__ + ' ('
@@ -96,6 +75,24 @@ class Optimizer(object):
                     format_string += '    {0}: {1}\n'.format(key, group[key])
         format_string += ')'
         return format_string
+
+    def hook_for_profile(self):
+        self._zero_grad_profile_name = "Optimizer.zero_grad#{}.zero_grad".format(self.__class__.__name__)
+
+        def profile_hook_step(func):
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                obj, *_ = args
+                profile_name = "Optimizer.step#{}.step".format(obj.__class__.__name__)
+                with torch.autograd.profiler.record_function(profile_name):
+                    return func(*args, **kwargs)
+            return wrapper
+
+        hooked = getattr(self.__class__.step, "hooked", None)
+        if not hooked:
+            self.__class__.step = profile_hook_step(self.__class__.step)
+            self.__class__.step.hooked = True
 
     def state_dict(self):
         r"""Returns the state of the optimizer as a :class:`dict`.
@@ -204,17 +201,18 @@ class Optimizer(object):
                 (in one case it does the step with a gradient of 0 and in the other it skips
                 the step altogether).
         """
-        for group in self.param_groups:
-            for p in group['params']:
-                if p.grad is not None:
-                    if set_to_none:
-                        p.grad = None
-                    else:
-                        if p.grad.grad_fn is not None:
-                            p.grad.detach_()
+        with torch.autograd.profiler.record_function(self._zero_grad_profile_name):
+            for group in self.param_groups:
+                for p in group['params']:
+                    if p.grad is not None:
+                        if set_to_none:
+                            p.grad = None
                         else:
-                            p.grad.requires_grad_(False)
-                        p.grad.zero_()
+                            if p.grad.grad_fn is not None:
+                                p.grad.detach_()
+                            else:
+                                p.grad.requires_grad_(False)
+                            p.grad.zero_()
 
     def step(self, closure):
         r"""Performs a single optimization step (parameter update).

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -201,6 +201,8 @@ class Optimizer(object):
                 (in one case it does the step with a gradient of 0 and in the other it skips
                 the step altogether).
         """
+        if not hasattr(self, "_zero_grad_profile_name"):
+            self._hook_for_profile()
         with torch.autograd.profiler.record_function(self._zero_grad_profile_name):
             for group in self.param_groups:
                 for p in group['params']:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -498,6 +498,7 @@ class _BaseDataLoaderIter(object):
         self._base_seed = torch.empty((), dtype=torch.int64).random_(generator=loader.generator).item()
         self._persistent_workers = loader.persistent_workers
         self._num_yielded = 0
+        self._profile_name = "enumerate(DataLoader)#{}.__next__".format(self.__class__.__name__)
 
     def __iter__(self) -> '_BaseDataLoaderIter':
         return self
@@ -514,22 +515,23 @@ class _BaseDataLoaderIter(object):
         raise NotImplementedError
 
     def __next__(self) -> Any:
-        if self._sampler_iter is None:
-            self._reset()
-        data = self._next_data()
-        self._num_yielded += 1
-        if self._dataset_kind == _DatasetKind.Iterable and \
-                self._IterableDataset_len_called is not None and \
-                self._num_yielded > self._IterableDataset_len_called:
-            warn_msg = ("Length of IterableDataset {} was reported to be {} (when accessing len(dataloader)), but {} "
-                        "samples have been fetched. ").format(self._dataset, self._IterableDataset_len_called,
-                                                              self._num_yielded)
-            if self._num_workers > 0:
-                warn_msg += ("For multiprocessing data-loading, this could be caused by not properly configuring the "
-                             "IterableDataset replica at each worker. Please see "
-                             "https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset for examples.")
-            warnings.warn(warn_msg)
-        return data
+        with torch.autograd.profiler.record_function(self._profile_name):
+            if self._sampler_iter is None:
+                self._reset()
+            data = self._next_data()
+            self._num_yielded += 1
+            if self._dataset_kind == _DatasetKind.Iterable and \
+                    self._IterableDataset_len_called is not None and \
+                    self._num_yielded > self._IterableDataset_len_called:
+                warn_msg = ("Length of IterableDataset {} was reported to be {} (when accessing len(dataloader)), but {} "
+                            "samples have been fetched. ").format(self._dataset, self._IterableDataset_len_called,
+                                                                  self._num_yielded)
+                if self._num_workers > 0:
+                    warn_msg += ("For multiprocessing data-loading, this could be caused by not properly configuring the "
+                                 "IterableDataset replica at each worker. Please see "
+                                 "https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset for examples.")
+                warnings.warn(warn_msg)
+            return data
 
     next = __next__  # Python 2 compatibility
 


### PR DESCRIPTION
Fixes #47441

To give user more information about python level functions in profiler traces, we propose to instrument on the following functions:

```
_BaseDataLoaderIter.__next__
Optimizer.step
Optimizer.zero_grad
```

Because the record_function already uses if (!active) to check whether the profiler is enabled, so we don't explicitly call torch.autograd._profiler_enabled() before each instrument.

Acknowledgement: @nbcsm, @guotuofeng, @gunandrose4u , @guyang3532 , @mszhanyi 