### PR TITLE
[quant][refactor] Moving the quant_type into the QConfig

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -257,7 +257,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 node_occurrence[weight_prepack_node] = 0
             self.checkGraphModeFxOp(
                 ModuleClass(*module_constructor_inputs),
-                inputs, quant_type,
+                inputs, quant_type=quant_type,
                 expected_node=quantized_node,
                 expected_node_occurrence=node_occurrence,
                 debug=False)
@@ -276,7 +276,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 node_occurrence[quantized_node] = 0
             self.checkGraphModeFxOp(
                 ModuleClass(*module_constructor_inputs),
-                inputs, quant_type,
+                inputs, quant_type=quant_type,
                 expected_node_occurrence=node_occurrence,
                 debug=True)
 
@@ -889,9 +889,12 @@ class TestQuantizeFx(QuantizationTestCase):
             "dynamic": (default_dynamic_qconfig, DynamicQuantCustomModule, 0)
         }
 
-        for quant_type in [QuantType.DYNAMIC]:
-            key = quant_type_to_str(quant_type)
+        for key in ['dynamic']:
             qconfig, quantized_module_class, num_observers = test_configs[key]
+            quant_type = qconfig.quant_type
+            # Sanity check
+            assert key == quant_type_to_str(quant_type)
+
             qconfig_dict = {"": qconfig}
             if key == "static":
                 prepare_custom_config_dict = {

--- a/test/quantization/test_quantize_jit.py
+++ b/test/quantization/test_quantize_jit.py
@@ -1403,7 +1403,7 @@ class TestQuantizeJitPasses(QuantizationTestCase):
 
         model = MainModule().eval()
         traced = torch.jit.trace(model, (torch.randn(5, 5),))
-        model = prepare_dynamic_jit(traced, {'' : default_qconfig})
+        model = prepare_dynamic_jit(traced, {'' : default_dynamic_qconfig})
         model = convert_dynamic_jit(model)
         FileCheck().check("quantized::linear_dynamic") \
                    .run(model.graph)

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -194,8 +194,7 @@ def _jit_pass_fold_convbn(module: 'torch.jit.ScriptModule'): ...
 def _jit_pass_insert_observers(module: 'torch.jit.ScriptModule',
                                method_name: str,
                                qconfig_dict: Dict[str, Any],
-                               inplace: _bool,
-                               quant_type: _int): ...
+                               inplace: _bool): ...
 def _jit_pass_insert_quant_dequant(module: 'torch.jit.ScriptModule',
                                    method_name: str,
                                    inplace: _bool,

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -1,4 +1,3 @@
-#include <torch/csrc/jit/passes/quantization/insert_observers.h>
 #include <torch/csrc/jit/frontend/schema_matching.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -8,6 +7,7 @@
 #include <torch/csrc/jit/passes/graph_rewrite_helper.h>
 #include <torch/csrc/jit/passes/inline_fork_wait.h>
 #include <torch/csrc/jit/passes/quantization/helper.h>
+#include <torch/csrc/jit/passes/quantization/insert_observers.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 
 #include <regex>
@@ -25,8 +25,9 @@ struct OptionalQConfigHash {
     if (qconfig_opt.has_value()) {
       const auto& m1 = std::get<0>(*qconfig_opt);
       const auto& m2 = std::get<1>(*qconfig_opt);
+      const int m3 = std::get<2>(*qconfig_opt);
       constexpr int CONST = 7;
-      return std::hash<Module>()(m1) + CONST * std::hash<Module>()(m2);
+      return std::hash<Module>()(m1) + CONST * (std::hash<Module>()(m2) + m3);
     }
     return 0;
   }
@@ -48,8 +49,11 @@ void fillQConfigMap(
     const c10::optional<QConfig>& parent_qconfig = c10::nullopt) {
   c10::optional<QConfig> qconfig;
   if (qconfig_dict.find(key) != qconfig_dict.end()) {
-    GRAPH_DEBUG("Got module config for key:", key);
     qconfig = qconfig_dict.at(key);
+    GRAPH_DEBUG("Got module config for key: ", key);
+    if (qconfig.has_value()) {
+      GRAPH_DEBUG(key, "'s QuantType is ", std::get<2>(*qconfig));
+    }
   } else {
     GRAPH_DEBUG("Inheriting qconfig from parent module:", key);
     qconfig = parent_qconfig;
@@ -283,9 +287,8 @@ class ModuleCloneHelper {
 class InsertObserversHelper {
  public:
   explicit InsertObserversHelper(
-      const ModuleQConfigMap& map,
-      QuantType quant_type)
-      : module_qconfig_map_(map), quant_type_(quant_type) {}
+      const ModuleQConfigMap& map)
+      : module_qconfig_map_(map) {}
 
   // TODO: replace (module, method_name) with graph?
   // preprocess to clean up the graph from tracing
@@ -1177,16 +1180,17 @@ bool InsertObserversHelper::valueNeedsToBeQuantized(
       isEmbeddingBagNonInput(v)) {
     return false;
   }
+  const auto& quant_type = static_cast<QuantType>(std::get<2>(qconfig));
   // For dynamic quantization we only insert observers at the input
   // of the quantizable function.
-  if (quant_type_ == QuantType::STATIC) {
+  if (quant_type == QuantType::STATIC) {
     // Check whether producer is quantizable
     if (!isWeightOnlyStaticQuantOp(v->node()) &&
         (nodeQuantizable(v->node()) || isPropagateQuantOp(v->node()))) {
       return true;
     }
   }
-  if (quant_type_ == QuantType::DYNAMIC) {
+  if (quant_type == QuantType::DYNAMIC) {
     // Check the dtype of the observer module.
     Module observer_module = getObserverModuleFor(v, qconfig);
     auto scalar_type = observer_module.attr("dtype");
@@ -1198,7 +1202,7 @@ bool InsertObserversHelper::valueNeedsToBeQuantized(
   }
   // Check whether node input value is quantizable
   for (const auto& use : v->uses()) {
-    if (useQuantizable(use, quant_type_)) {
+    if (useQuantizable(use, quant_type)) {
       return true;
     }
   }
@@ -1585,8 +1589,7 @@ Module InsertObservers(
     Module& input_module,
     const std::string& method_name,
     const QConfigDict& qconfig_dict,
-    bool inplace,
-    QuantType quant_type) {
+    bool inplace) {
   ModuleQConfigMap map_before_clone;
   fillQConfigMap(input_module, qconfig_dict, map_before_clone);
   ModuleCloneHelper mh;
@@ -1595,8 +1598,7 @@ Module InsertObservers(
   // Since the types are changed after clone, we need to fill
   // the qconfig map again
   fillQConfigMap(module, qconfig_dict, module_qconfig_map);
-  GRAPH_DEBUG("Quant type:", quant_type);
-  InsertObserversHelper helper(module_qconfig_map, quant_type);
+  InsertObserversHelper helper(module_qconfig_map);
   helper.preprocess(module, method_name);
   helper.fillBoundaryValueMap(module, method_name);
   // analyze needs to run after fillBoundaryValueMap

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -1,3 +1,4 @@
+#include <torch/csrc/jit/passes/quantization/insert_observers.h>
 #include <torch/csrc/jit/frontend/schema_matching.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -7,7 +8,6 @@
 #include <torch/csrc/jit/passes/graph_rewrite_helper.h>
 #include <torch/csrc/jit/passes/inline_fork_wait.h>
 #include <torch/csrc/jit/passes/quantization/helper.h>
-#include <torch/csrc/jit/passes/quantization/insert_observers.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 
 #include <regex>
@@ -286,8 +286,7 @@ class ModuleCloneHelper {
 
 class InsertObserversHelper {
  public:
-  explicit InsertObserversHelper(
-      const ModuleQConfigMap& map)
+  explicit InsertObserversHelper(const ModuleQConfigMap& map)
       : module_qconfig_map_(map) {}
 
   // TODO: replace (module, method_name) with graph?

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -499,8 +499,6 @@ class InsertObserversHelper {
   // want to add to the module instance that has the block
   std::unordered_map<Block*, NameModuleVector> block_observer_map_;
 
-  // Type of quantization for this pass.
-  QuantType quant_type_ = QuantType::STATIC;
   // These are the IR patterns we match to skip inserting observers.
   // They are compiled once on construction and used repeatedly within
   // the pass.

--- a/torch/csrc/jit/passes/quantization/insert_observers.h
+++ b/torch/csrc/jit/passes/quantization/insert_observers.h
@@ -17,7 +17,7 @@ struct hash<torch::jit::Module> {
 namespace torch {
 namespace jit {
 
-using QConfig = std::tuple<Module, Module>;
+using QConfig = std::tuple<Module, Module, int>;
 using QConfigDict = std::unordered_map<std::string, c10::optional<QConfig>>;
 
 /** \brief Insert observer module and observer function call for
@@ -39,8 +39,7 @@ TORCH_API Module InsertObservers(
     Module& module,
     const std::string& method_name,
     const QConfigDict& qconfig_dict,
-    bool inplace,
-    QuantType quant_type = QuantType::STATIC);
+    bool inplace);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/quantization/quantization_type.cpp
+++ b/torch/csrc/jit/passes/quantization/quantization_type.cpp
@@ -11,6 +11,15 @@ std::ostream& operator<<(std::ostream& os, QuantType t) {
     case QuantType::STATIC:
       os << "static";
       break;
+    case QuantType::QAT:
+      os << "qat";
+      break;
+    case QuantType::WEIGHT_ONLY:
+      os << "weight_only";
+      break;
+    case QuantType::ACTIVATION_ONLY:
+      os << "activation_only";
+      break;
     default:
       os.setstate(std::ios_base::failbit);
   }

--- a/torch/csrc/jit/passes/quantization/quantization_type.h
+++ b/torch/csrc/jit/passes/quantization/quantization_type.h
@@ -6,7 +6,13 @@ namespace jit {
 
 // Quantization type (dynamic quantization, static quantization).
 // Should match the Python enum in quantize_jit.py
-enum QuantType : uint8_t { DYNAMIC = 0, STATIC };
+enum QuantType : uint8_t {
+  DYNAMIC = 0,
+  STATIC = 1,
+  QAT = 2,
+  WEIGHT_ONLY = 3,
+  ACTIVATION_ONLY = 4
+};
 
 std::ostream& operator<<(std::ostream& os, QuantType t);
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -239,20 +239,21 @@ void initJITBindings(PyObject* module) {
           [](Module& module,
              const std::string& method_name,
              const py::dict& qconfig_dict,
-             bool inplace,
-             int quant_type_int) {
+             bool inplace) {
             auto dict = py::cast<std::unordered_map<
                 std::string,
-                c10::optional<std::tuple<Module, Module>>>>(qconfig_dict);
-            auto quant_type = static_cast<QuantType>(quant_type_int);
+                c10::optional<
+                  std::tuple<Module,
+                             Module,
+                             int  // quant_type_int
+                            >>>>(qconfig_dict);
             return InsertObservers(
-                module, method_name, dict, inplace, quant_type);
+                module, method_name, dict, inplace);
           },
           py::arg("module"),
           py::arg("method_name"),
           py::arg("qconfig_dict"),
-          py::arg("inplace"),
-          py::arg("quant_type_int") = 1)
+          py::arg("inplace"))
       .def(
           "_jit_pass_insert_quant_dequant",
           [](Module& module,

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -242,13 +242,12 @@ void initJITBindings(PyObject* module) {
              bool inplace) {
             auto dict = py::cast<std::unordered_map<
                 std::string,
-                c10::optional<
-                  std::tuple<Module,
-                             Module,
-                             int  // quant_type_int
-                            >>>>(qconfig_dict);
-            return InsertObservers(
-                module, method_name, dict, inplace);
+                c10::optional<std::tuple<
+                    Module,
+                    Module,
+                    int // quant_type_int
+                    >>>>(qconfig_dict);
+            return InsertObservers(module, method_name, dict, inplace);
           },
           py::arg("module"),
           py::arg("method_name"),

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -1,9 +1,11 @@
 from collections import namedtuple
-from .observer import *
-from .fake_quantize import *
 import torch.nn as nn
 
-class QConfig(namedtuple('QConfig', ['activation', 'weight'])):
+from .fake_quantize import *
+from .observer import *
+from .quant_type import QuantType
+
+class QConfig(namedtuple('QConfig', ['activation', 'weight', 'quant_type'])):
     """
     Describes how to quantize a layer or a part of the network by providing
     settings (observer classes) for activations and weights respectively.
@@ -19,13 +21,20 @@ class QConfig(namedtuple('QConfig', ['activation', 'weight'])):
 
       my_qconfig = QConfig(activation=MinMaxObserver.with_args(dtype=torch.qint8),
       weight=default_observer.with_args(dtype=torch.qint8))
+
+
+    QConfig can also take the QuantType enum for the `quant_type` argument.
+    This is an optional argument to support proper custom module configuration.
+    By default it is set to STATIC.
     """
-    def __new__(cls, activation, weight):
+    def __new__(cls, activation, weight, quant_type=None):
         # catch common mistakes
         if isinstance(activation, nn.Module) or isinstance(weight, nn.Module):
             raise ValueError("QConfig received observer instance, please pass observer class instead. " +
                              "Use MyObserver.with_args(x=1) to override arguments to constructor if needed")
-        return super(QConfig, cls).__new__(cls, activation, weight)
+        if quant_type is None:
+            quant_type = QuantType.STATIC
+        return super(QConfig, cls).__new__(cls, activation, weight, quant_type)
 
 
 default_qconfig = QConfig(activation=default_observer,
@@ -37,7 +46,7 @@ default_debug_qconfig = QConfig(weight=default_weight_observer,
 default_per_channel_qconfig = QConfig(activation=default_observer,
                                       weight=default_per_channel_weight_observer)
 
-class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight'])):
+class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight', 'quant_type'])):
     """
     Describes how to dynamically quantize a layer or a part of the network by providing
     settings (observer classes) for weights.
@@ -52,13 +61,20 @@ class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight'])):
     method (that behaves like functools.partial):
 
       my_qconfig = QConfigDynamic(weight=default_observer.with_args(dtype=torch.qint8))
+
+    QConfig can also take the QuantType enum for the `quant_type` argument.
+    This is an optional argument to support proper custom module configuration.
+    By default it is set to DYNAMIC
     """
-    def __new__(cls, activation=torch.nn.Identity, weight=torch.nn.Identity):
+    def __new__(cls, activation=torch.nn.Identity, weight=torch.nn.Identity,
+                quant_type=None):
         # catch common mistakes
         if isinstance(weight, nn.Module):
             raise ValueError("QConfigDynamic received observer instance, please pass observer class instead. " +
                              "Use MyObserver.with_args(x=1) to override arguments to constructor if needed")
-        return super(QConfigDynamic, cls).__new__(cls, activation, weight)
+        if quant_type is None:
+          quant_type = QuantType.DYNAMIC
+        return super(QConfigDynamic, cls).__new__(cls, activation, weight, quant_type)
 
 default_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_observer,
                                          weight=default_weight_observer)
@@ -71,12 +87,15 @@ float_qparams_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_
                                                weight=default_float_qparams_observer)
 
 default_qat_qconfig = QConfig(activation=default_fake_quant,
-                              weight=default_weight_fake_quant)
+                              weight=default_weight_fake_quant,
+                              quant_type=QuantType.QAT)
 
 default_weight_only_qconfig = QConfig(activation=torch.nn.Identity,
-                                      weight=default_weight_fake_quant)
+                                      weight=default_weight_fake_quant,
+                                      quant_type=QuantType.WEIGHT_ONLY)
 default_activation_only_qconfig = QConfig(activation=default_fake_quant,
-                                          weight=torch.nn.Identity)
+                                          weight=torch.nn.Identity,
+                                          quant_type=QuantType.ACTIVATION_ONLY)
 
 def get_default_qconfig(backend='fbgemm'):
     if backend == 'fbgemm':
@@ -96,13 +115,15 @@ def get_default_qat_qconfig(backend='fbgemm'):
                                                             quant_min=0,
                                                             quant_max=255,
                                                             reduce_range=True),
-                          weight=default_per_channel_weight_fake_quant)
+                          weight=default_per_channel_weight_fake_quant,
+                          quant_type=QuantType.QAT)
     elif backend == 'qnnpack':
         qconfig = QConfig(activation=FakeQuantize.with_args(observer=MovingAverageMinMaxObserver,
                                                             quant_min=0,
                                                             quant_max=255,
                                                             reduce_range=False),
-                          weight=default_weight_fake_quant)
+                          weight=default_weight_fake_quant,
+                          quant_type=QuantType.QAT)
     else:
         qconfig = default_qat_qconfig
     return qconfig

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -73,7 +73,7 @@ class QConfigDynamic(namedtuple('QConfigDynamic', ['activation', 'weight', 'quan
             raise ValueError("QConfigDynamic received observer instance, please pass observer class instead. " +
                              "Use MyObserver.with_args(x=1) to override arguments to constructor if needed")
         if quant_type is None:
-          quant_type = QuantType.DYNAMIC
+            quant_type = QuantType.DYNAMIC
         return super(QConfigDynamic, cls).__new__(cls, activation, weight, quant_type)
 
 default_dynamic_qconfig = QConfigDynamic(activation=default_dynamic_quant_observer,

--- a/torch/quantization/quant_type.py
+++ b/torch/quantization/quant_type.py
@@ -7,6 +7,7 @@ class QuantType(enum.IntEnum):
     STATIC = 1
     QAT = 2
     WEIGHT_ONLY = 3
+    ACTIVATION_ONLY = 4
 
 
 def quant_type_to_str(quant_type):
@@ -15,5 +16,6 @@ def quant_type_to_str(quant_type):
         QuantType.DYNAMIC: "dynamic",
         QuantType.QAT: "qat",
         QuantType.WEIGHT_ONLY: "weight_only",
+        QuantType.ACTIVATION_ONLY: "activation_only",
     }
     return m[quant_type]

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -601,7 +601,8 @@ class QuantizationTestCase(TestCase):
         return str_to_print
 
     if HAS_FX:
-        def checkGraphModeFxOp(self, model, inputs, quant_type,
+        def checkGraphModeFxOp(self, model, inputs,
+                               quant_type=None,
                                expected_node=None,
                                expected_node_occurrence=None,
                                expected_node_list=None,
@@ -631,19 +632,19 @@ class QuantizationTestCase(TestCase):
             if type(inputs) == list:
                 inputs = inputs[0]
 
-            if quant_type == QuantType.QAT:
-                qconfig = get_default_qat_qconfig(torch.backends.quantized.engine)
-                model.train()
-            elif quant_type == QuantType.STATIC:
-                qconfig = get_default_qconfig(torch.backends.quantized.engine)
-                model.eval()
+            if custom_qconfig is None:
+                if quant_type == QuantType.QAT:
+                    qconfig = get_default_qat_qconfig(torch.backends.quantized.engine)
+                    model.train()
+                elif quant_type == QuantType.STATIC:
+                    qconfig = get_default_qconfig(torch.backends.quantized.engine)
+                    model.eval()
+                else:
+                    qconfig = default_dynamic_qconfig
+                    model.eval()
             else:
-                qconfig = default_dynamic_qconfig
-                model.eval()
-
-            # overwrite qconfig with custom_qconfig
-            if custom_qconfig is not None:
                 qconfig = custom_qconfig
+                quant_type = qconfig.quant_type
 
             if quant_type == QuantType.QAT:
                 prepare = prepare_qat_fx


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47730 [quant] Add another keyword to the 'prepare_custom_config_dict' to be the same as in FX
* **#47656 [quant][refactor] Moving the quant_type into the QConfig**

The quant_type is used in custom module, which can utilize the QConfig
to prepare/convert. Also, this is the first PR in an attempt to enable
the hybrid quantization.