### PR TITLE
[pytorch][quantization] adding jit state for QuantizedLeakyReLU

### DIFF
--- a/test/quantization/test_quantized_module.py
+++ b/test/quantization/test_quantized_module.py
@@ -709,6 +709,21 @@ class TestStaticQuantizedModule(QuantizationTestCase):
                          msg="{} module API failed, qY_ref\n{} vs qY\n{}"
                          .format(name, qY_ref, qY))
 
+    def _test_leaky_relu_serialization(self):
+        scale_original = 10.0 / 256
+        zero_point_original = 1.0
+
+        quant_mod_original = nnq.LeakyReLU(scale_original, zero_point_original)
+        state_dict = quant_mod_original.state_dict()
+
+        scale_new = 5.0 / 256
+        zero_point_new = 2.0
+        quant_mod_new = nnq.LeakyReLU(scale_new, zero_point_new)
+        quant_mod_new.load_state_dict(state_dict)
+
+        self.assertEqual(quant_mod_original.scale, quant_mod_new.scale)
+        self.assertEqual(quant_mod_original.zero_point, quant_mod_new.zero_point)
+
     def test_elu(self):
         """Tests the correctness of the ELU module.
         The correctness is defined against the functional implementation.
@@ -717,6 +732,7 @@ class TestStaticQuantizedModule(QuantizationTestCase):
 
     def test_leaky_relu(self):
         self._test_activation_module_impl("LeakyReLU", nn.LeakyReLU, nnq.LeakyReLU, {"negative_slope": 0.2})
+        self._test_leaky_relu_serialization()
 
     def test_sigmoid(self):
         self._test_activation_module_impl("Sigmoid", nn.Sigmoid, nnq.Sigmoid, {})

--- a/torch/nn/quantized/modules/activation.py
+++ b/torch/nn/quantized/modules/activation.py
@@ -97,8 +97,8 @@ class LeakyReLU(torch.nn.LeakyReLU):
     """
     def __init__(self, scale: float, zero_point: int, negative_slope: float = 1e-2, inplace: bool = False):
         super().__init__(negative_slope, inplace)
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.tensor([scale]))
+        self.register_buffer('zero_point', torch.tensor([zero_point]))
 
     def forward(self, input):
         return torch.ops.quantized.leaky_relu(
@@ -113,7 +113,7 @@ class LeakyReLU(torch.nn.LeakyReLU):
         return cls(float(scale), int(zero_point), mod.negative_slope, mod.inplace)
 
 class Sigmoid(torch.nn.Sigmoid):
-    r"""This is the quantized equivalent of :class:`~torch.nn.LeakyReLU`.
+    r"""This is the quantized equivalent of :class:`~torch.nn.Sigmoid`.
 
     Args:
         scale: quantization scale of the output tensor


### PR DESCRIPTION
Summary: Currently, `QuantizedLeakyReLU` doesn't have any items in the `state_dict`. However, this operator needs to store the `scale` and `zero_point` in its state dictionary or the loading state dict for a quantized model with LeakyReLUs that have non-default quantization params would break.

Differential Revision: D24757522

