### PR TITLE
add unittest for operator benchmark

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -107,7 +107,7 @@ class Caffe2OperatorTestCase(object):
         self.test_config = test_config
         self.framework = "Caffe2"
 
-    def run_forward(self, num_runs, print_per_iter=False, cubda_sync=False):
+    def run_forward(self, num_runs, print_per_iter=False, cuda_sync=False):
         """ Run the forward path of an operator in a loop
         """
         with core.DeviceScope(self.op_bench.dev):
@@ -115,7 +115,7 @@ class Caffe2OperatorTestCase(object):
         if not workspace.RunOperatorMultiple(op, num_runs):
             raise ValueError("Unable to run operator test case: {}".format(self.test_name))
 
-    def run_backward(self, num_runs):
+    def run_backward(self, num_runs, print_per_iter=False):
         """ Run the backward path of an operator in a loop
         """
         with core.DeviceScope(self.op_bench.dev):


### PR DESCRIPTION
Summary:
add unittest for operator benchmark.
Covers below cases:
```
generate_c2_test
generate_c2_gradient_test
generate_pt_test
generate_pt_gradient_test
generate_pt_tests_from_op_list
```
Also fixed two issues (incorrect fn signature) found by the unittest in `benchmark_caffe2.py`

Test Plan:
arc lint
buck run caffe2/benchmarks/operator_benchmark:operator_benchmark_unittest
```
test_c2_single_op (operator_benchmark_unittest.BenchmarkTest) ... # ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking Caffe2: add
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1109 23:08:39.932207 639464 init.h:137] Caffe2 GlobalInit should be run before any other API calls.
# Name: add_M8
# Input: M: 8
Forward Execution Time (us) : 36.474

# Benchmarking Caffe2: add
# Name: add_M8
# Input: M: 8
Backward Execution Time (us) : 42.281

ok
test_pt_list_of_ops (operator_benchmark_unittest.BenchmarkTest) ... # ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking Caffe2: add
# Name: add_M8
# Input: M: 8
Forward Execution Time (us) : 36.579

# Benchmarking Caffe2: add
# Name: add_M8
# Input: M: 8
Backward Execution Time (us) : 42.734

# Benchmarking PyTorch: abs
# Mode: Eager
# Name: abs_M8
# Input: M: 8
Forward Execution Time (us) : 148.929

# Benchmarking PyTorch: abs_
# Mode: Eager
# Name: abs__M8
# Input: M: 8
Forward Execution Time (us) : 71.909

ok
test_pt_single_op (operator_benchmark_unittest.BenchmarkTest) ... # ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking Caffe2: add
# Name: add_M8
# Input: M: 8
Forward Execution Time (us) : 36.860

# Benchmarking Caffe2: add
# Name: add_M8
# Input: M: 8
Backward Execution Time (us) : 42.293

# Benchmarking PyTorch: abs
# Mode: Eager
# Name: abs_M8
# Input: M: 8
Forward Execution Time (us) : 148.999

# Benchmarking PyTorch: abs_
# Mode: Eager
# Name: abs__M8
# Input: M: 8
Forward Execution Time (us) : 71.941

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M8
# Input: M: 8
Forward Execution Time (us) : 179.108

# Benchmarking PyTorch: add
# Mode: Eager
# Name: add_M8
# Input: M: 8
Backward Execution Time (us) : 1205.902

ok
```
buck run caffe2/benchmarks/operator_benchmark/c2:add_test
```
# ----------------------------------------
# PyTorch/Caffe2 Operator Micro-benchmarks
# ----------------------------------------
# Tag : short

# Benchmarking Caffe2: add
WARNING: Logging before InitGoogleLogging() is written to STDERR
W1109 23:20:11.551795 654290 init.h:137] Caffe2 GlobalInit should be run before any other API calls.
# Name: add_M8_N16_K32_dtypeint
# Input: M: 8, N: 16, K: 32, dtype: int
Forward Execution Time (us) : 984.510

# Benchmarking Caffe2: add
# Name: add_M16_N16_K64_dtypefloat
# Input: M: 16, N: 16, K: 64, dtype: float
Forward Execution Time (us) : 68.526

# Benchmarking Caffe2: add
# Name: add_M64_N64_K128_dtypeint
# Input: M: 64, N: 64, K: 128, dtype: int
Forward Execution Time (us) : 101617.076
```

Differential Revision: D24854414

