### PR TITLE
[NNC] add hazard analysis to Bounds Inference

### DIFF
--- a/test/cpp/tensorexpr/test_memdependency.cpp
+++ b/test/cpp/tensorexpr/test_memdependency.cpp
@@ -1112,7 +1112,7 @@ void testMemDependencyCheckerLoopSelfDependency() {
   // This check assumes that the Stmt has a single Store with a single Load on
   // the RHS.
   auto isSelfDependent =
-      [](const std::deque<std::shared_ptr<AccessInfo>>& history) -> bool {
+      [](const std::vector<std::shared_ptr<AccessInfo>>& history) -> bool {
     return history.front()->hasDependency(history.back());
   };
 

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -312,6 +312,10 @@ namespace jit {
   _(BoundsInferenceMultipleTopLoopStore)            \
   _(BoundsInferenceCacheReads)                      \
   _(BoundsInferenceFlattened)                       \
+  _(GetPotentialHazards)                            \
+  _(GetPotentialHazardsLoopNoHazard)                \
+  _(GetPotentialHazardsLoopCall)                    \
+  _(GetPotentialHazardsLoopSplit)                   \
   _(BoundOverlap)                                   \
   _(BoundOverlapSymbolic)                           \
   _(BoundOverlapMultiDim)                           \

--- a/torch/csrc/jit/tensorexpr/bounds_inference.h
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.h
@@ -28,10 +28,27 @@ using BoundsInfo =
 
 TORCH_API BoundsInfo inferBounds(Stmt* s, bool distinctAccessKinds = true);
 
+// Bounds inference caching the analysis. The MemDependencyChecker must already
+// have been run.
+TORCH_API BoundsInfo getInferredBounds(
+    analysis::MemDependencyChecker& analyzer,
+    Stmt* s,
+    bool distinctAccessKinds = true);
+
 TORCH_API void printBoundsInfo(const BoundsInfo& v);
 
 TORCH_API std::vector<const Expr*> getBoundExtents(
     const std::vector<TensorAccessBoundsInfo>& infos);
+
+// The kind of dependency found, in increasing order of exclusivity.
+enum class HazardKind {
+  ReadAfterWrite,
+  WriteAfterRead,
+  WriteAfterWrite,
+  NoDependency,
+};
+TORCH_API HazardKind
+getPotentialHazards(analysis::MemDependencyChecker& analyzer, Stmt* A, Stmt* B);
 
 } // namespace tensorexpr
 } // namespace jit

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.h
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.h
@@ -32,9 +32,19 @@ struct TORCH_API Bound {
     return exprEquals(start, other.start) && exprEquals(end, other.end);
   }
 
+  bool operator==(const Bound& other) const {
+    return exprEquals(start, other.start) && exprEquals(end, other.end);
+  }
+
   void swap() {
     std::swap(start, end);
     swapped = !swapped;
+  }
+};
+
+struct BoundHash {
+  size_t operator()(const Bound& b) const {
+    return std::hash<const Expr*>()(b.start) ^ std::hash<const Expr*>()(b.end);
   }
 };
 

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <c10/core/ScalarType.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
-#include <deque>
 #include <vector>
 
 #include <torch/csrc/jit/tensorexpr/bounds_overlap.h>
@@ -221,16 +220,25 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
       const std::shared_ptr<AccessInfo>& A,
       const std::shared_ptr<AccessInfo>& B);
 
-  // Retuns the AccessInfo
+  // Returns the AccessInfo
   std::shared_ptr<AccessInfo> accessFor(const Stmt* A) const;
   std::shared_ptr<AccessInfo> accessFor(const Expr* A) const;
+
+  // Returns all AccessInfos.
+  std::unordered_set<std::shared_ptr<AccessInfo>> accessesWithin(
+      const Stmt* A) const;
+  // TODO: this will return only the AccessInfo for A. It's included for
+  // completeness but be aware it wont return accesses used in the computation
+  // of A.
+  std::unordered_set<std::shared_ptr<AccessInfo>> accessesWithin(
+      const Expr* A) const;
 
   // Accesses relating to input and output buffers.
   std::shared_ptr<AccessInfo> input(const Buf* B) const;
   std::shared_ptr<AccessInfo> output(const Buf* B) const;
 
   // Returns the full history of reads and writes.
-  const std::deque<std::shared_ptr<AccessInfo>>& getHistory() const;
+  const std::vector<std::shared_ptr<AccessInfo>>& getHistory() const;
 
   // Dumps the dependency graph in DOT format.
   void dumpDAG(const std::string& filename) const;
@@ -273,7 +281,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
     std::unordered_map<const Var*, Bound> shadowedVarBounds;
     std::unordered_set<const Var*> localVars;
 
-    std::deque<std::shared_ptr<AccessInfo>> accesses_;
+    std::vector<std::shared_ptr<AccessInfo>> accesses_;
 
     std::unordered_map<const Var*, std::list<BoundRelationship>> openWrites_;
   };
@@ -285,6 +293,8 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
       stmtToAccess_;
   std::unordered_multimap<const Expr*, std::shared_ptr<AccessInfo>>
       exprToAccess_;
+  std::unordered_map<const Stmt*, std::vector<std::shared_ptr<AccessInfo>>>
+      scopeToAccesses_;
 
   VarBoundMap knownVarBounds_;
 
@@ -303,7 +313,8 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
       }
     };
 
-    // Look for and insert accesses belonging to all nodes that act like reads.
+    // Look for and insert accesses belonging to all nodes that act like
+    // reads.
     insertAllReads(NodeFinder<Load>::find(v));
     insertAllReads(NodeFinder<FunctionCall>::find(v));
     insertAllReads(NodeFinder<ReduceOp>::find(v));


### PR DESCRIPTION
Adds a helper function to Bounds Inference / Memory Analaysis infrastructure which returns the kind of hazard found between two Stmts (e.g. Blocks or Loops). E.g.
```
for (int i = 0; i < 10; ++i) {
  A[x] = i * 2;
}
for (int j = 0; j < 10; ++j) {
 B[x] = A[x] / 2;
}
```
The two loops have a `ReadAfterWrite` hazard, while in this example:
```
for (int i = 0; i < 10; ++i) {
  A[x] = i * 2;
}
for (int j = 0; j < 10; ++j) {
 A[x] = B[x] / 2;
}
```
The loops have a `WriteAfterWrite` hazard.

This isn't 100% of what we need for loop fusion, for example we don't check the strides of the loop to see if they match.