### PR TITLE
change block codegen to handle new inlining in NNC

### DIFF
--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -175,15 +175,15 @@ class CreateBufferMap : public IRVisitor {
  private:
   void visit(const Store* v) override {
     auto load_node = dynamic_cast<const Load*>(v->value());
-    auto call_node = dynamic_cast<const FunctionCall*>(v->value());
-    if (load_node || call_node) {
-      TORCH_INTERNAL_ASSERT(!(load_node && call_node));
-      auto t_buf = load_node ? load_node->buf() : call_node->tensor()->buf();
-      if (load_node) {
-        map_input_to_tensor_bufs_.emplace(t_buf->name_hint(), v->buf());
-      } else {
-        map_input_to_tensor_bufs_.emplace(v->buf()->name_hint(), t_buf);
-      }
+    if (load_node) {
+      auto t_buf = load_node->buf();
+      map_input_to_tensor_bufs_.emplace(t_buf->name_hint(), v->buf());
+    } else {
+      auto add_node = dynamic_cast<const Add*>(v->value());
+      auto mul_node = dynamic_cast<const Mul*>(v->value());
+      // This means for now, v->value() can be Add or Mul
+      TORCH_INTERNAL_ASSERT((add_node || mul_node));
+      map_input_to_tensor_bufs_.emplace(v->buf()->name_hint(), v->buf());
     }
     v->value()->accept(this);
   }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -43,6 +43,9 @@ bool fallbackAllowed() {
 
 bool fallbackEnforced() {
   static const char* enable_c_str = std::getenv("PYTORCH_TENSOREXPR_FALLBACK");
+  if (tensorexpr::getTEGenerateBlockCode()) {
+    return false;
+  }
   if (!enable_c_str) {
     return fallback_allowed;
   }
@@ -1518,10 +1521,21 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
 
   bool hasReduction = NodeFinder<ReduceOp>::find(l.root_stmt()).size() != 0;
 
+  // For Block codegen we create a map of tensor dims before
+  // inlining. Like GPU codegen we need to inline. But the order
+  // where this analysis is run matters.
+  auto block_analysis = std::make_unique<CreateBufferMap>();
+  if (backendType == kBlockCodeGen) {
+    // Run Block analysis to get multi dim buffer info
+    auto root_stmt = l.root_stmt();
+    root_stmt->accept(block_analysis.get());
+  }
+
   // inlining output buffers duplicates computation. it slows down
   // cpu code generation but is enabled on gpu because it avoids difficult
   // synchronization logic across blocks.
-  bool inline_output_buffers = backendType == kCudaCodeGen;
+  bool inline_output_buffers =
+      (backendType == kCudaCodeGen || backendType == kBlockCodeGen);
   l.inlineIntermediateBufs(inline_output_buffers);
 
   if (backendType == kCudaCodeGen) {
@@ -1570,20 +1584,14 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
   }
 
   if (backendType == kBlockCodeGen) {
-    auto block_analysis = std::make_unique<CreateBufferMap>();
     for (auto tensor : tensorOutputs_) {
       const int default_fp16_blocksize = 16;
       const int default_uint8_blocksize = 32;
       int blockSize = default_fp16_blocksize;
       // We only handle looplevels == 2 for now
-      // Run Block analysis to get multi dim buffer info
-      auto root_stmt = l.root_stmt();
-      root_stmt->accept(block_analysis.get());
-
       if (tensor->buf()->dtype().scalar_type() == ScalarType::Byte) {
         blockSize = default_uint8_blocksize;
       }
-
       std::vector<For*> loops = l.getLoopStmtsFor(tensor);
       TORCH_INTERNAL_ASSERT(!loops.empty(), "loops should not be empty");
       For* flattened = nullptr;


### PR DESCRIPTION
minor changes to block codegen to handle new inlining in NNC. 
For Block code generation we need to delay inlining before collecting dimension data about the tensors. 
We need to collect the dimension of the tensor before they were flattened. We don't have this information after the inlining pass, so for Block we run inling after we have collected this data using `CreateBufferMap`  analysis.