### PR TITLE
Disable test_distributed_for for multigpu test env

### DIFF
--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -17,7 +17,7 @@ fi
 
 python tools/download_mnist.py --quiet -d test/cpp/api/mnist
 OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="test/cpp/api/mnist" build/bin/test_api
-time python test/run_test.py --verbose -i distributed/test_distributed_fork
+time python test/run_test.py --verbose -i distributed/test_distributed_spawn
 time python test/run_test.py --verbose -i distributed/test_c10d
 time python test/run_test.py --verbose -i distributed/test_c10d_spawn
 assert_git_not_dirty

--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -17,7 +17,6 @@ fi
 
 python tools/download_mnist.py --quiet -d test/cpp/api/mnist
 OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="test/cpp/api/mnist" build/bin/test_api
-time python test/run_test.py --verbose -i distributed/test_distributed_spawn
 time python test/run_test.py --verbose -i distributed/test_c10d
 time python test/run_test.py --verbose -i distributed/test_c10d_spawn
 assert_git_not_dirty


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47703 Disable test_distributed_for for multigpu test env**



Differential Revision: [D24871454](https://our.internmc.facebook.com/intern/diff/D24871454)