### PR TITLE
[NNC] Remove all deferred expansion from Reductions

### DIFF
--- a/test/cpp/tensorexpr/test_memdependency.cpp
+++ b/test/cpp/tensorexpr/test_memdependency.cpp
@@ -575,11 +575,15 @@ void testMemDependencyCheckerLoopReduce() {
   // The loop contents depend on the initializer too.
   ASSERT_TRUE(analyzer.dependsDirectly(loop, aInit));
 
+  // Find loads within the reduction:
+  auto reduceLoads = NodeFinder<Load>::find(reduce.node());
   // Pull out the access for the load inside the loop.
-  auto loopLoad = analyzer.accessFor(reduce.node());
-  // It should have 10 element long bounds.
-  ASSERT_TRUE(indexBoundsEquals(
-      loopLoad->bounds(), {Bound(new IntImm(0), new IntImm(9))}));
+  for (auto* load : reduceLoads) {
+    auto loopLoad = analyzer.accessFor(load);
+    // It should have 10 element long bounds.
+    ASSERT_TRUE(indexBoundsEquals(
+        loopLoad->bounds(), {Bound(new IntImm(0), new IntImm(9))}));
+  }
 }
 
 // Lowering a reduction doesn't affect dependency analysis.

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -242,6 +242,7 @@ core_sources_full = [
     "torch/csrc/jit/tensorexpr/block_codegen.cpp",
     "torch/csrc/jit/tensorexpr/loopnest.cpp",
     "torch/csrc/jit/tensorexpr/mem_arena.cpp",
+    "torch/csrc/jit/tensorexpr/reduction.cpp",
     "torch/csrc/jit/tensorexpr/registerizer.cpp",
     "torch/csrc/jit/tensorexpr/tensor.cpp",
     "torch/csrc/jit/tensorexpr/types.cpp",

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -270,7 +270,7 @@ const Expr* IRMutator::mutate(const MinTerm* v) {
 const Expr* IRMutator::mutate(const ReduceOp* v) {
   const Expr* buf_new_expr = v->accumulator()->accept_mutator(this);
   const Buf* buf_new = dynamic_cast<const Buf*>(buf_new_expr);
-  auto body = v->body().node()->accept_mutator(this);
+  const Expr* body_new = v->body()->accept_mutator(this);
 
   std::vector<const Expr*> new_output_args;
   std::vector<const Var*> new_reduce_args;
@@ -282,11 +282,7 @@ const Expr* IRMutator::mutate(const ReduceOp* v) {
   }
 
   return new ReduceOp(
-      buf_new,
-      ExprHandle(body),
-      v->interaction(),
-      new_output_args,
-      new_reduce_args);
+      buf_new, body_new, new_output_args, new_reduce_args, v->reducer());
 }
 
 const Expr* IRMutator::mutate(const BaseCallNode* v) {

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -349,8 +349,7 @@ void IRPrinter::visit(const MinTerm* v) {
 
 void IRPrinter::visit(const ReduceOp* v) {
   os() << "ReduceOp(";
-  os() << *v->accumulator() << ", ";
-  os() << v->complete() << ", ";
+  os() << *v->body() << ", ";
 
   bool first = true;
   os() << "out_args={";

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -227,7 +227,7 @@ void IRVisitor::visit(const MinTerm* v) {
 
 void IRVisitor::visit(const ReduceOp* v) {
   v->accumulator()->accept(this);
-  v->body().node()->accept(this);
+  v->body()->accept(this);
 
   for (auto* e : v->output_args()) {
     e->accept(this);

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1612,7 +1612,7 @@ class CacheReplacer : public IRMutator {
       return IRMutator::mutate(v);
     }
 
-    const Expr* newBody = v->body().node()->accept_mutator(this);
+    const Expr* newBody = v->body()->accept_mutator(this);
 
     // Map indices to call-parameters.
     std::vector<const Expr*> newIndices;
@@ -1625,11 +1625,7 @@ class CacheReplacer : public IRMutator {
     }
 
     return new ReduceOp(
-        cache_,
-        ExprHandle(newBody),
-        v->interaction(),
-        newIndices,
-        v->reduce_args());
+        cache_, newBody, newIndices, v->reduce_args(), v->reducer());
   }
 
   const Buf* buf_;
@@ -1739,10 +1735,9 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
     Stmt* tmp_store = new Store(
         producer,
         tmp_params,
-        new ReduceOp(
+        reduceOp->reducer()(
             producer,
             ExprHandle(new Load(tmp_buf, new_loop_vars_expr, new IntImm(1))),
-            reduceOp->interaction(),
             tmp_params,
             {}),
         new IntImm(1));
@@ -2030,6 +2025,70 @@ class StoreFinder : public IRVisitor {
   const Store* store_;
 };
 
+class BufReplacer : public IRMutator {
+ public:
+  BufReplacer(
+      const Buf* old_buf,
+      const std::vector<const Expr*>& old_indices,
+      const Buf* new_buf,
+      const std::vector<const Expr*>& new_indices)
+      : old_buf_(old_buf),
+        old_indices_(old_indices),
+        new_buf_(new_buf),
+        new_indices_(new_indices) {}
+
+  const Expr* mutate(const Load* v) override {
+    if (v->buf() != old_buf_) {
+      return IRMutator::mutate(v);
+    }
+
+    TORCH_INTERNAL_ASSERT(old_indices_.size() == v->indices().size());
+
+    bool equal_indices = true;
+    for (size_t i = 0; i < v->indices().size(); ++i) {
+      if (!exprEquals(v->indices()[i], old_indices_[i])) {
+        equal_indices = false;
+        break;
+      }
+    }
+    if (!equal_indices) {
+      return IRMutator::mutate(v);
+    }
+
+    const Expr* mask_new = v->mask()->accept_mutator(this);
+    return new Load(new_buf_, new_indices_, mask_new);
+  }
+
+  Stmt* mutate(const Store* v) override {
+    if (v->buf() != old_buf_) {
+      return IRMutator::mutate(v);
+    }
+
+    TORCH_INTERNAL_ASSERT(old_indices_.size() == v->indices().size());
+
+    bool equal_indices = true;
+    for (size_t i = 0; i < v->indices().size(); ++i) {
+      if (!exprEquals(v->indices()[i], old_indices_[i])) {
+        equal_indices = false;
+        break;
+      }
+    }
+    if (!equal_indices) {
+      return IRMutator::mutate(v);
+    }
+
+    const Expr* new_value = v->value()->accept_mutator(this);
+    const Expr* mask_new = v->mask()->accept_mutator(this);
+    return new Store(new_buf_, new_indices_, new_value, mask_new);
+  }
+
+ private:
+  const Buf* old_buf_;
+  const std::vector<const Expr*>& old_indices_;
+  const Buf* new_buf_;
+  const std::vector<const Expr*>& new_indices_;
+};
+
 void LoopNest::rfactor(
     const Expr* r,
     const Var* reduction_var,
@@ -2102,7 +2161,7 @@ void LoopNest::rfactor(
 
   std::vector<const Expr*> new_dims = {};
   Buf* tmp_buf =
-      new Buf(new Var("tmp_buf", kHandle), new_dims, reduce_op->body().dtype());
+      new Buf(new Var("tmp_buf", kHandle), new_dims, reduce_op->dtype());
 
   auto old_acc = reduce_op->accumulator();
   auto new_inner = reduce_op->reduce_args();
@@ -2130,26 +2189,19 @@ void LoopNest::rfactor(
   }
   new_outer.emplace_back(reduction_var);
 
+  BufReplacer bufReplacer(
+      reduce_op->accumulator(), reduce_op->output_args(), tmp_buf, new_outer);
+  const Expr* new_body = reduce_op->body()->accept_mutator(&bufReplacer);
+
   auto first_reduce = new ReduceOp(
-      tmp_buf,
-      reduce_op->body(),
-      reduce_op->interaction(),
-      new_outer,
-      new_inner);
+      tmp_buf, new_body, new_outer, new_inner, reduce_op->reducer());
 
   auto second_reduce_load_indices = reduce_op->output_args();
   second_reduce_load_indices.emplace_back(reduction_var);
-  auto second_reduce_load = ExprHandle(new Load(
-      reduce_op->body().dtype(),
-      tmp_buf,
-      second_reduce_load_indices,
-      new IntImm(1)));
-  auto second_reduce = new ReduceOp(
-      old_acc,
-      second_reduce_load,
-      reduce_op->interaction(),
-      reduce_op->output_args(),
-      {reduction_var});
+  auto second_reduce_load = new Load(
+      reduce_op->dtype(), tmp_buf, second_reduce_load_indices, new IntImm(1));
+  auto second_reduce = reduce_op->reducer()(
+      old_acc, second_reduce_load, reduce_op->output_args(), {reduction_var});
 
   // 1) replace target for loop (which is a reduction loop)
   // with an iterative for loop by removing the reduction var from the

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -588,51 +588,6 @@ void MemDependencyChecker::visit(const FunctionCall* v) {
   currentScope_->accesses_.push_back(call);
 }
 
-void MemDependencyChecker::visit(const ReduceOp* v) {
-  auto indicesScope =
-      std::make_shared<Scope>(currentScope_->block, currentScope_);
-  currentScope_ = indicesScope;
-
-  for (const Expr* ind : v->output_args()) {
-    ind->accept(this);
-  }
-
-  const Var* var = v->accumulator()->base_handle();
-
-  // ReduceOps are functionally Loads, and the distinction isn't meaningful so
-  // just record them as Loads. They get lowered directly to load during
-  // prepareForCodegen anyway.
-  auto load = std::make_shared<AccessInfo>(
-      nextAccess_++,
-      AccessType::Load,
-      v,
-      lastStmt_,
-      var,
-      getIndicesBounds(v->output_args()));
-
-  // If there were loads in the output_args, this call depends on them, also
-  // merge.
-  if (!indicesScope->accesses_.empty()) {
-    for (auto& access : indicesScope->accesses_) {
-      load->addDependency(access);
-      access->addDependent(load);
-    }
-    mergeScope(indicesScope, indicesScope->parent, false);
-  }
-
-  stmtToAccess_.emplace(lastStmt_, load);
-  exprToAccess_.emplace(v, load);
-
-  // Intentionally using operator[], we want it to be created if it does not
-  // exist.
-  auto& writeHistory = currentScope_->openWrites_[var];
-  updateWriteHistory(writeHistory, load, load->id());
-  currentScope_->accesses_.push_back(load);
-
-  // accept the body of the reduction to handle further reads.
-  v->body().node()->accept(this);
-}
-
 // This check determines if two accesses within a loop are "safe" from loop-self
 // dependence. This function does not consider overlap in bound range, but
 // rather the stride of the bound relative to the loop variable. This is the

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -240,7 +240,6 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
   void visit(const Store* v) override;
   void visit(const Load* v) override;
   void visit(const FunctionCall* v) override;
-  void visit(const ReduceOp* v) override;
   void visit(const For* v) override;
   void visit(const Cond* v) override;
   void visit(const IfThenElse* v) override;

--- a/torch/csrc/jit/tensorexpr/reduction.cpp
+++ b/torch/csrc/jit/tensorexpr/reduction.cpp
@@ -1,0 +1,37 @@
+
+#include <torch/csrc/jit/tensorexpr/reduction.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+ReduceOp* Reducer::operator()(
+    const Buf* result_buf,
+    ExprHandle body,
+    const std::vector<const Expr*>& output,
+    const std::vector<const Var*>& inner) const {
+  return new ReduceOp(
+      result_buf,
+      complete(result_buf, interaction_, body, output, inner),
+      output,
+      inner,
+      *this);
+}
+
+ReduceOp* Reducer::operator()(
+    const Buf* result_buf,
+    const Expr* body,
+    const std::vector<const Expr*>& output,
+    const std::vector<const Var*>& inner) const {
+  return new ReduceOp(
+      result_buf,
+      complete(result_buf, interaction_, ExprHandle(body), output, inner),
+      output,
+      inner,
+      *this);
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -4,7 +4,6 @@
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
-#include <torch/csrc/jit/tensorexpr/tensor.h>
 #include <torch/csrc/jit/tensorexpr/types.h>
 
 #include <functional>
@@ -17,76 +16,12 @@ namespace tensorexpr {
 using ParameterList = const std::vector<VarHandle>;
 using ReduceInteraction = std::function<ExprHandle(ExprHandle, ExprHandle)>;
 
-// An expression representing a Reduction operation (e.g. Sum, Max) broken into
-// it's component parts: initialization, accumulation var, acquisition of value
-// to be reduced and interaction.
-//
-// This is intended to be expanded in the loopnest and not make it to codegen.
-class ReduceOp : public ExprNode<ReduceOp> {
- public:
-  ReduceOp(
-      const Buf* accum,
-      ExprHandle body,
-      ReduceInteraction c,
-      const std::vector<const Expr*>& output_args,
-      const std::vector<const Var*>& reduce_args)
-      : ExprNodeBase(body.dtype()),
-        accumulator_(accum),
-        body_(body),
-        interaction_(c),
-        output_args_(output_args),
-        reduce_args_(reduce_args) {}
-
-  // return the accumulation load expression.
-  const Buf* accumulator() const {
-    return accumulator_;
-  }
-
-  // return the body expression which obtains the value to be reduced.
-  ExprHandle body() const {
-    return body_;
-  }
-
-  // returns a function encoding the interaction between accumulator and the
-  // reduction value.
-  ReduceInteraction interaction() const {
-    return interaction_;
-  }
-
-  // returns variables associated with the output Tensor.
-  const std::vector<const Expr*>& output_args() const {
-    return output_args_;
-  }
-
-  // returns variables associated with the axes of reduction.
-  const std::vector<const Var*>& reduce_args() const {
-    return reduce_args_;
-  }
-
-  // Completes the reduction operator by applying the interaction function to
-  // the accumulation and the body expression.
-  ExprHandle complete() const {
-    std::vector<const Expr*> indices(output_args_.begin(), output_args_.end());
-    ExprHandle accum = ExprHandle(
-        new Load(body_.dtype(), accumulator_, indices, new IntImm(1)));
-    auto e = interaction_(accum, body_);
-    return e;
-  }
-
- private:
-  const Buf* accumulator_;
-  ExprHandle body_;
-  ReduceInteraction interaction_;
-  std::vector<const Expr*> output_args_;
-  std::vector<const Var*> reduce_args_;
-};
-
 // A Reducer is a user interface describing a particular reduction
 // operation. It has three components: An initialization value, a way of
 // interacting each value with the accumulation, and a method for obtaining the
 // current value to be reduced. It is materialized into a ReduceOp when loop
 // variables are known.
-class Reducer {
+class TORCH_API Reducer {
  public:
   Reducer(ExprHandle init, ReduceInteraction& interaction)
       : init_(init.node()), interaction_(interaction) {}
@@ -98,6 +33,7 @@ class Reducer {
   Reducer(ExprHandle init, RI interaction) : init_(init.node()) {
     interaction_ = interaction;
   }
+  virtual ~Reducer() {}
 
   const Expr* initializer() const {
     return init_;
@@ -106,10 +42,14 @@ class Reducer {
   ReduceOp* operator()(
       const Buf* result_buf,
       ExprHandle body,
-      std::vector<const Expr*> output,
-      std::vector<const Var*> inner) const {
-    return new ReduceOp(result_buf, body, interaction_, output, inner);
-  }
+      const std::vector<const Expr*>& output,
+      const std::vector<const Var*>& inner) const;
+
+  ReduceOp* operator()(
+      const Buf* result_buf,
+      const Expr* body,
+      const std::vector<const Expr*>& output,
+      const std::vector<const Var*>& inner) const;
 
   // Polymorphic handling of Body functions with a variety of parameters.
   static ExprHandle getReduceBody(
@@ -161,9 +101,76 @@ class Reducer {
     return func(vars[0], vars[1], vars[2], vars[3]);
   }
 
+  // Completes the reduction operator by applying the interaction function to
+  // the accumulation and the body expression.
+  static Expr* complete(
+      const Buf* accumulator,
+      ReduceInteraction interaction,
+      ExprHandle body,
+      const std::vector<const Expr*>& output_args,
+      const std::vector<const Var*>& reduce_args) {
+    ExprHandle accum = ExprHandle(
+        new Load(body.dtype(), accumulator, output_args, new IntImm(1)));
+    auto e = interaction(accum, body);
+    return e.node();
+  }
+
  private:
   const Expr* init_;
   ReduceInteraction interaction_;
+};
+
+// An expression representing a Reduction operation (e.g. Sum, Max) broken into
+// it's component parts: initialization, accumulation var, acquisition of value
+// to be reduced and interaction.
+//
+// This is intended to be expanded in the loopnest and not make it to codegen.
+class ReduceOp : public ExprNode<ReduceOp> {
+ public:
+  ReduceOp(
+      const Buf* accum,
+      const Expr* body,
+      const std::vector<const Expr*>& output_args,
+      const std::vector<const Var*>& reduce_args,
+      const Reducer& reducer)
+      : ExprNodeBase(body->dtype()),
+        accumulator_(accum),
+        body_(body),
+        output_args_(output_args),
+        reduce_args_(reduce_args),
+        reducer_(reducer) {}
+
+  // return the accumulation load expression.
+  const Buf* accumulator() const {
+    return accumulator_;
+  }
+
+  // return the body expression which obtains the value to be reduced.
+  const Expr* body() const {
+    return body_;
+  }
+
+  // Returns the original Reducer factory that can create ReduceOps.
+  const Reducer& reducer() const {
+    return reducer_;
+  }
+
+  // returns variables associated with the output Tensor.
+  const std::vector<const Expr*>& output_args() const {
+    return output_args_;
+  }
+
+  // returns variables associated with the axes of reduction.
+  const std::vector<const Var*>& reduce_args() const {
+    return reduce_args_;
+  }
+
+ private:
+  const Buf* accumulator_;
+  const Expr* body_;
+  std::vector<const Expr*> output_args_;
+  std::vector<const Var*> reduce_args_;
+  const Reducer reducer_;
 };
 
 class Sum : public Reducer {
@@ -232,7 +239,7 @@ class ReductionExpander : public IRMutator {
   }
 
   const Expr* mutate(const ReduceOp* v) override {
-    return v->complete().node();
+    return v->body();
   }
 };
 

--- a/torch/csrc/jit/tensorexpr/var_substitutor.h
+++ b/torch/csrc/jit/tensorexpr/var_substitutor.h
@@ -37,7 +37,7 @@ class VarSubMutator : public IRMutator {
   }
 
   const Expr* mutate(const ReduceOp* var) override {
-    auto body = var->body().node()->accept_mutator(this);
+    auto body = var->body()->accept_mutator(this);
     std::vector<const Expr*> new_outer;
     std::vector<const Var*> new_inner;
 
@@ -59,10 +59,10 @@ class VarSubMutator : public IRMutator {
 
     return new ReduceOp(
         const_cast<Buf*>(var->accumulator()),
-        ExprHandle(body),
-        var->interaction(),
+        body,
         new_outer,
-        new_inner);
+        new_inner,
+        var->reducer());
   }
 
  private:


### PR DESCRIPTION
Refactors the ReduceOp node to remove the last remaining deferred functionality: completing the interaction between the accumulator buffer and the body. This fixes two issues with reductions:
1. Nodes inside the interaction could not be visited or modified, meaning we could generate bad code when the interaction was complex.
2. The accumulator load was created at expansion time and so could not be modified in some ways (ie. vectorization couldn't act on these loads).

This simplifies reduction logic quite a bit, but theres a bit more involved in the rfactor transform.