### PR TITLE
[caffe2][memonger] Add support for distributed inference predict nets in DAG memonger

### DIFF
--- a/caffe2/core/memonger.cc
+++ b/caffe2/core/memonger.cc
@@ -199,10 +199,13 @@ class ComputeBlobRecyclingForDag {
     }
 
     // The main recursive call. Here we do start DFS in the operator graph
-    // from the input blobs.
+    // from the input blobs. Note that the input ordering does not indicate
+    // operator graph ordering. To avoid traversing children operators first,
+    // traversal begins from root ops and then recursively children ops are
+    // visited.
     for (const auto& input_blob : heads) {
       for (const int op_index : blob_to_ops_[input_blob]) {
-        if (!op_visited_[op_index]) {
+        if (!op_visited_[op_index] && !op_inputs_[op_index]) {
           vector<std::pair<int, string>> free_blobs;
           std::unordered_set<int> tokens{tokens_counter_++};
           process_op(
@@ -271,6 +274,12 @@ class ComputeBlobRecyclingForDag {
         apply_recurrent_blob_assignments(optimized_net.mutable_op(i));
       }
 
+      // Special handling for AsyncIf ops, where internal nets can
+      // refer to memongered blobs
+      if (optimized_net.op(i).type() == "AsyncIf") {
+        apply_asyncif_blob_assignments(optimized_net.mutable_op(i));
+      }
+
       for (int j = 0; j < optimized_net.op(i).input_size(); ++j) {
         const string& input_name =
             get_blob_or_mapped_blob(optimized_net.op(i).input(j));
@@ -326,6 +335,39 @@ class ComputeBlobRecyclingForDag {
         Argument* map_arg = op->add_arg();
         map_arg->set_name(b + ".rename");
         map_arg->set_s(mapped);
+      }
+    }
+  }
+
+  void apply_asyncif_blob_assignments(OperatorDef* op) {
+    for (int i = 0; i < op->arg_size(); i++) {
+      Argument* arg = op->mutable_arg(i);
+      const string& name = arg->name();
+      if (name == "then_net" || name == "else_net") {
+        NetDef* step_net_ref = arg->mutable_n();
+        NetDef optimized_net = apply_assignments(*step_net_ref);
+
+        // update external inputs and outputs mappings as well
+        // for this internal net
+        std::vector<string> optim_external_inputs;
+        for (auto& blob_name : optimized_net.external_input()) {
+          optim_external_inputs.push_back(get_blob_or_mapped_blob(blob_name));
+        }
+        optimized_net.mutable_external_input()->Clear();
+        for (const auto& blob_name : optim_external_inputs) {
+          optimized_net.add_external_input(blob_name);
+        }
+
+        std::vector<string> optim_external_outputs;
+        for (auto& blob_name : optimized_net.external_output()) {
+          optim_external_outputs.push_back(get_blob_or_mapped_blob(blob_name));
+        }
+        optimized_net.mutable_external_output()->Clear();
+        for (const auto& blob_name : optim_external_outputs) {
+          optimized_net.add_external_output(blob_name);
+        }
+
+        step_net_ref->CopyFrom(optimized_net);
       }
     }
   }

--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -1,8 +1,3 @@
-
-
-
-
-
 import numpy as np
 
 from caffe2.python import workspace, memonger, core, model_helper, brew
@@ -455,6 +450,52 @@ class MemongerTest(hu.HypothesisTestCase):
         optimized_loss2 = workspace.FetchBlob("name_x/loss2")
         np.testing.assert_almost_equal(loss1, optimized_loss1)
         np.testing.assert_almost_equal(loss2, optimized_loss2)
+
+    # This test reproduces scenario where dag traversal for finding
+    # shared blobs was not always starting from ops with in degree of 0
+    @settings(deadline=10000)
+    def test_forward_optim_tree_dag_traversal(self):
+        input_dim = 4
+        output_dim = 4
+        batch_size = 4
+
+        m = model_helper.ModelHelper()
+        m.Proto().type = "dag"
+        m.Proto().num_workers = 4
+
+        with core.NameScope("name_x"):
+            fc1 = brew.fc(m, "data", "fc1", dim_in=input_dim, dim_out=output_dim)
+            fc2 = brew.fc(m, fc1, "fc2", dim_in=output_dim, dim_out=output_dim)
+
+            fc3 = brew.fc(m, fc2, "fc3", dim_in=output_dim, dim_out=output_dim)
+            fc4 = brew.fc(m, fc3, "fc4", dim_in=output_dim, dim_out=output_dim)
+            fc5 = brew.fc(m, fc4, "fc5", dim_in=output_dim, dim_out=output_dim)
+
+            # Branch
+            fc3b = brew.fc(m, fc2, "fc3b", dim_in=output_dim, dim_out=output_dim)
+            fc4b = brew.fc(m, fc3b, "fc4b", dim_in=output_dim, dim_out=output_dim)
+            fc5b = brew.fc(m, fc4b, "fc5b", dim_in=output_dim, dim_out=output_dim)
+
+            fc5sum = brew.sum(m, [fc5, fc5b], "fc5sum")
+
+            fc5.Relu([], fc5sum) \
+               .Softmax([], "pred1") \
+               .LabelCrossEntropy(["label"], ["xent1"]) \
+               .AveragedLoss([], "loss1")
+            fc6 = brew.fc(m, fc5, "fc6", dim_in=output_dim, dim_out=output_dim)
+            fc6.Relu([], fc6) \
+               .Softmax([], "pred2") \
+               .LabelCrossEntropy(["label"], ["xent2"]) \
+               .AveragedLoss([], "loss2")
+
+        blobs_before = count_blobs(m.net.Proto())
+        # adding name_x/fc5_w as heads (which belongs to non-root op)
+        # to make sure that dag traversal always starts from root ops
+        optim_proto = memonger.optimize_inference_for_dag(
+            m.net, ["name_x/fc5_w", "name_x/data"], "name_x"
+        )
+        blobs_after = count_blobs(optim_proto)
+        self.assertLess(blobs_after, blobs_before)
 
     def test_rnn(self):
         from caffe2.python import rnn_cell


### PR DESCRIPTION
Summary:
Distributed Inference splits a predict net into multiple parts, part0 being the main part which contains ops to make remote calls to other parts. part0 predict net may contain AsyncIf ops to optimize rpc call usage. AsyncIf ops have internal nets which may refer to memongered blobs. This change handles AsyncIf ops to update internal nets to refer to memongered blobs.

As part of this change, I am also updating dag memonger traversal to always start from root op, i.e. ops with 0 in degree. Earlier logic will start traversing ops based on input head blobs and if one of the head inputs is getting used in a non-root op which gets visited before its parent, the traversal will throwing assertion error here: https://fburl.com/diffusion/ob110s9z . Almost for all the distributed inference part0 nets, it was throwing this assertion error.

Test Plan: Added corresponding tests in memonger_test.py .  Could not find unit tests in c++ version of memonger.

Differential Revision: D24872010

