### PR TITLE
Added serialization of parameters for leaf modules

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -30,10 +30,12 @@ class TestFXExperimental(JitTestCase):
                 super().__init__()
                 self.linear = torch.nn.Linear(4, 4)
                 self.e = torch.rand(4)
+                self.conv = torch.nn.Conv2d(3, 3, 2, bias=False)
 
-            def forward(self, a, b):
+            def forward(self, a, b, c):
                 add_1 = a + b
-                linear = self.linear(add_1)
+                conv1 = self.conv(c)
+                linear = self.linear(add_1 + conv1)
                 add_2 = linear + self.e
                 return add_2
 
@@ -41,7 +43,8 @@ class TestFXExperimental(JitTestCase):
         traced = symbolic_trace(m)
         a = torch.rand(4)
         b = torch.rand(4)
-        GraphManipulation.get_size_of_all_nodes(traced, [a, b])
+        c = torch.rand(3, 3, 2, 2)
+        GraphManipulation.get_size_of_all_nodes(traced, [a, b, c])
 
         partitioner = Partitioner()
         devices = [Device("dev_0", 5000, 0), Device("dev_1", 125, 1)]
@@ -64,13 +67,13 @@ class TestFXExperimental(JitTestCase):
 
         agm1 = GraphManipulation.AcceleratedGraphModule(traced)
         agm2 = GraphManipulation.AcceleratedGraphModule(module_with_submodules)
-        assert len(agm1.weights) == 3
-        assert len(agm2.weights) == 3
-        assert len(agm1.serialized_graph["nodes"]) == 7
-        assert len(agm1.serialized_graph["weights"]) == 3
+        assert len(agm1.weights) == 4
+        assert len(agm2.weights) == 4
+        assert len(agm1.serialized_graph["nodes"]) == 10
+        assert len(agm1.serialized_graph["weights"]) == 4
         assert len(agm1.serialized_graph["modules"]) == 0
-        assert len(agm2.serialized_graph["nodes"]) == 5
-        assert len(agm2.serialized_graph["weights"]) == 3
+        assert len(agm2.serialized_graph["nodes"]) == 6
+        assert len(agm2.serialized_graph["weights"]) == 4
         assert len(agm2.serialized_graph["modules"]) == 1
         assert agm1.serialized_graph["weights"]["linear.weight"]["shape"] == "[4, 4]"
         assert (
@@ -85,8 +88,8 @@ class TestFXExperimental(JitTestCase):
         assert agm1.serialized_graph["nodes"][0]["target"] == "a"
         assert agm1.serialized_graph["nodes"][0]["op_code"] == "placeholder"
         assert agm1.serialized_graph["nodes"][0]["name"] == "a"
-        assert agm1.serialized_graph["nodes"][2]["args"][0]["name"] == "a"
-        assert agm1.serialized_graph["nodes"][2]["args"][0]["is_node"] is True
+        assert agm1.serialized_graph["nodes"][6]["args"][0]["name"] == "add_2"
+        assert agm1.serialized_graph["nodes"][6]["args"][0]["is_node"] is True
 
         # Test quantization info serialization.
         x = torch.tensor([[-1.0, 0.0], [1.0, 2.0]])


### PR DESCRIPTION
This adds the serialization of parameters of leaf nodes to the json serialization.
Specifically __constants__ of the leaf module is serialized as parameters in the JSON.
It also adds type/shape to leaf modules as well.
```
{
            "shape": "[3, 3, 1, 1]",
            "dtype": "torch.float32",
            "parameters": {
                "name": "Conv2d",
                "stride": [
                    1,
                    1
                ],
                "padding": [
                    0,
                    0
                ],
                "dilation": [
                    1,
                    1
                ],
                "groups": 1,
                "padding_mode": "zeros",
                "output_padding": [
                    0,
                    0
                ],
                "in_channels": 3,
                "out_channels": 3,
                "kernel_size": [
                    2,
                    2
                ]
            },
            "target": "conv",
            "op_code": "call_module",
            "name": "conv",
            "args": [
                {
                    "is_node": true,
                    "name": "c"
                }
            ],
            "kwargs": {}
        },
```