### PR TITLE
[hotfix] fix collect_env not working when torch compile/install fails

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 try:
     import torch
     TORCH_AVAILABLE = True
-except (ImportError, NameError, AttributeError):
+except (ImportError, NameError, AttributeError, OSError):
     TORCH_AVAILABLE = False
 
 # System Environment Information


### PR DESCRIPTION
fix collect env not working when pytorch compile from source failed mid-way.
```
Traceback (most recent call last):
OSError: /home/rongr/local/pytorch/torch/lib/libtorch_global_deps.so: cannot open shared object file: No such file or directory
```