### PR TITLE
Optimize graph before saving to mobile

### DIFF
--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -13,6 +13,7 @@
 #include <torch/csrc/jit/serialization/python_print.h>
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
 #include <torch/csrc/jit/serialization/type_name_uniquer.h>
+#include <torch/csrc/jit/runtime/graph_executor_impl.h>
 
 #include <caffe2/serialize/inline_container.h>
 
@@ -76,6 +77,7 @@ std::pair<IValue, c10::optional<IValue>> getFunctionTuple(
     bool save_mobile_debug_info) {
   auto graph = func.graph()->copy();
 
+  runOptimization(graph, false);
   Inline(*graph);
   if (save_mobile_debug_info) {
     ReconstructScopes(module, *graph, "top");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47758 Optimize graph before saving to mobile**

There are some model size inconsistencies when we call _save_for_mobile. As discussed with @kimishpatel , runOptimization() may help to remove the dead code and purge dangling constants. However, it may not be always called after some transformations, and may not be applied to each function. 

By adding runOptimization() in the export process we could have a final application on the graph before inlining the graph and serializing the bytecode.

Differential Revision: [D24891173](https://our.internmc.facebook.com/intern/diff/D24891173)