### PR TITLE
[static runtime] Initial memonger

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -112,3 +112,19 @@ torch::jit::Module getLeakyReLUConstScriptModel() {
   module.define(leaky_relu_model_const);
   return module;
 }
+
+const std::string long_model = R"JIT(
+  def forward(self, a, b, c):
+      d = torch.relu(a * b)
+      e = torch.relu(a * c)
+      f = torch.relu(e * d)
+      g = torch.relu(f * f)
+      h = torch.relu(g * c)
+      return h
+)JIT";
+
+torch::jit::Module getLongScriptModel() {
+  torch::jit::Module module("m");
+  module.define(long_model);
+  return module;
+}

--- a/benchmarks/static_runtime/deep_wide_pt.h
+++ b/benchmarks/static_runtime/deep_wide_pt.h
@@ -134,3 +134,5 @@ torch::jit::Module getTrivialScriptModel();
 torch::jit::Module getLeakyReLUScriptModel();
 
 torch::jit::Module getLeakyReLUConstScriptModel();
+
+torch::jit::Module getLongScriptModel();

--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -146,6 +146,26 @@ static void BM_leaky_relu(benchmark::State& state) {
 
 BENCHMARK(BM_leaky_relu)->RangeMultiplier(8)->Ranges({{1, 20}});
 BENCHMARK(BM_leaky_relu_const)->RangeMultiplier(8)->Ranges({{1, 20}});
+
+static void BM_long_static_memory_optimization(benchmark::State& state) {
+  auto mod = getLongScriptModel();
+  torch::jit::InferenceModuleOptions opts;
+  opts.optimize_memory = state.range(1);
+  auto g = torch::jit::PrepareForStaticRuntime(mod, opts);
+  torch::jit::StaticRuntime runtime(g);
+
+  const auto N = state.range(0);
+  auto a = torch::randn({N, N});
+  auto b = torch::randn({N, N});
+  auto c = torch::randn({N, N});
+  std::vector<at::Tensor> inputs({a, b, c});
+
+  runtime.run(inputs);
+  for (auto _ : state) {
+    runtime.run(inputs);
+  }
+}
+
 BENCHMARK(BM_deep_wide_base)->RangeMultiplier(8)->Ranges({{1, 20}});
 BENCHMARK(BM_deep_wide_fast)->RangeMultiplier(8)->Ranges({{1, 20}});
 
@@ -160,4 +180,19 @@ BENCHMARK(BM_deep_wide_jit_profiling_executor)
 BENCHMARK(BM_deep_wide_static)->RangeMultiplier(8)->Ranges({{1, 20}});
 BENCHMARK(BM_deep_wide_static_threaded)->Threads(8);
 
-BENCHMARK_MAIN();
+BENCHMARK(BM_long_static_memory_optimization)
+  ->Args({2<<0, 0})
+  ->Args({2<<2, 0})
+  ->Args({2<<4, 0})
+  ->Args({2<<8, 0})
+  ->Args({2<<0, 1})
+  ->Args({2<<2, 1})
+  ->Args({2<<4, 1})
+  ->Args({2<<8, 1});
+
+int main(int argc, char** argv)
+{
+  c10::ParseCommandLineFlags(&argc, &argv);
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -2,6 +2,24 @@
 #include <gtest/gtest.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 
+TEST(StaticRuntime, LongModel) {
+  torch::jit::Module mod = getLongScriptModel();
+  auto a = torch::randn({2, 2});
+  auto b = torch::randn({2, 2});
+  auto c = torch::randn({2, 2});
+
+  // run jit graph executor
+  std::vector<at::IValue> input_ivalues({a, b, c});
+  at::Tensor output_1 = mod.forward(input_ivalues).toTensor();
+
+  // run static runtime
+  std::vector<at::Tensor> input_tensors({a, b, c});
+  auto g = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(g);
+  at::Tensor output_2 = runtime.run(input_tensors)[0];
+  EXPECT_TRUE(output_1.equal(output_2));
+}
+
 TEST(StaticRuntime, TrivialModel) {
   torch::jit::Module mod = getTrivialScriptModel();
   auto a = torch::randn({2, 2});

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -11,6 +11,10 @@
 namespace torch {
 namespace jit {
 
+struct TORCH_API InferenceModuleOptions {
+  bool optimize_memory{true}; // TODO remove when logic moves to runtime
+};
+
 struct TORCH_API StaticRuntimeOptions {
   bool cleanup_activations{true};
   bool enable_out_variant{true};
@@ -59,8 +63,10 @@ struct TORCH_API StaticRuntimeOptions {
 // Group readonly data structures into InferenceModule
 struct TORCH_API InferenceModule {
  public:
-  explicit InferenceModule(const torch::jit::Module& m);
-  explicit InferenceModule(std::shared_ptr<torch::jit::Graph> g);
+  explicit InferenceModule(const torch::jit::Module& m, InferenceModuleOptions);
+  explicit InferenceModule(
+      std::shared_ptr<torch::jit::Graph> g,
+      InferenceModuleOptions);
   torch::jit::Module module;
   std::shared_ptr<torch::jit::Graph> graph;
   std::unique_ptr<c10::FunctionSchema> schema;
@@ -70,19 +76,23 @@ struct TORCH_API InferenceModule {
   std::vector<size_t> input_regs; // inputs to the graph
   std::vector<size_t> output_regs; // outputs of the graph
   std::vector<size_t> internals;
+  size_t reused_regs = 0;
+  InferenceModuleOptions opts;
 
  private:
   void init();
 };
 
 inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
-    const torch::jit::Module& m) {
-  return std::make_shared<InferenceModule>(m);
+    const torch::jit::Module& m,
+    InferenceModuleOptions opts = InferenceModuleOptions()) {
+  return std::make_shared<InferenceModule>(m, opts);
 }
 
 inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
-    std::shared_ptr<torch::jit::Graph> g) {
-  return std::make_shared<InferenceModule>(g);
+    std::shared_ptr<torch::jit::Graph> g,
+    InferenceModuleOptions opts = InferenceModuleOptions()) {
+  return std::make_shared<InferenceModule>(g, opts);
 }
 
 class MemoryPlanner;
@@ -208,6 +218,9 @@ class MemoryPlanner {
 
   void allocate();
   void deallocate();
+  size_t total_managed() const {
+    return internal_blob_max_sizes_sum_;
+  }
 
  private:
   const std::vector<IValue>& reg_;


### PR DESCRIPTION
Summary:
Parity reached :)

*/0 -> no memonger
*/1 -> memonger on
We can see that the impact is large when activations don't all fit in cache (6x speed up on this micro bench)
```
BM_long_static_memory_optimization/2/0         8563 ns       8559 ns      86370
BM_long_static_memory_optimization/8/0         8326 ns       8322 ns      84099
BM_long_static_memory_optimization/32/0       11446 ns      11440 ns      56107
BM_long_static_memory_optimization/512/0    6116629 ns    6113108 ns        128
BM_long_static_memory_optimization/2/1         8151 ns       8149 ns      87000
BM_long_static_memory_optimization/8/1         7905 ns       7902 ns      85124
BM_long_static_memory_optimization/32/1       10652 ns      10639 ns      66055
BM_long_static_memory_optimization/512/1    1101415 ns    1100673 ns        641
```

TODO:
[x] implementation
[x] enable/disable flag
[x] statistics about memory saved
[x] additional models

Test Plan:
```
buck test //caffe2/test:static_runtime
buck test //caffe2/benchmarks/static_runtime:static_runtime_cpptest
buck test //caffe2/caffe2/fb/predictor:pytorch_predictor_test
```

Differential Revision: D24824445

