### PR TITLE
[quant] Add support for 2D indices for quantized embedding operators

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/embedding_packed_params.h
+++ b/aten/src/ATen/native/quantized/cpu/embedding_packed_params.h
@@ -24,4 +24,5 @@ struct EmbeddingPackedParamsBase : public torch::jit::CustomClassHolder {
 
   virtual int64_t bit_rate() const = 0;
   virtual int64_t version() const = 0;
+  virtual at::Tensor get_packed_weight() const = 0;
 };

--- a/aten/src/ATen/native/quantized/cpu/embedding_packed_params.h
+++ b/aten/src/ATen/native/quantized/cpu/embedding_packed_params.h
@@ -10,7 +10,8 @@ struct EmbeddingPackedParamsBase : public torch::jit::CustomClassHolder {
     bool pruned_weights,
     const c10::optional<at::Tensor>& per_sample_weights_,
     const c10::optional<at::Tensor>& compressed_indices_mapping,
-    bool include_last_offset) = 0;
+    bool include_last_offset,
+    bool is_embedding_op) = 0;
 
   virtual at::Tensor embeddingbag_4bit(
     const at::Tensor& indices,
@@ -24,5 +25,4 @@ struct EmbeddingPackedParamsBase : public torch::jit::CustomClassHolder {
 
   virtual int64_t bit_rate() const = 0;
   virtual int64_t version() const = 0;
-  virtual at::Tensor get_packed_weight() const = 0;
 };

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -339,6 +339,10 @@ struct CAFFE2_API PackedEmbeddingBagWeight : public EmbeddingPackedParamsBase {
     return version_;
   }
 
+  at::Tensor get_packed_weight() const override {
+    return packed_w;
+  }
+
   at::Tensor embeddingbag_byte(
     const at::Tensor& indices,
     const c10::optional<at::Tensor>& offsets,

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -339,17 +339,14 @@ struct CAFFE2_API PackedEmbeddingBagWeight : public EmbeddingPackedParamsBase {
     return version_;
   }
 
-  at::Tensor get_packed_weight() const override {
-    return packed_w;
-  }
-
   at::Tensor embeddingbag_byte(
     const at::Tensor& indices,
     const c10::optional<at::Tensor>& offsets,
     bool pruned_weights,
     const c10::optional<at::Tensor>& per_sample_weights_,
     const c10::optional<at::Tensor>& compressed_indices_mapping,
-    bool include_last_offset) override;
+    bool include_last_offset,
+    bool is_embedding_op) override;
 
   at::Tensor embeddingbag_4bit(
     const at::Tensor& indices,

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -541,7 +541,7 @@ Tensor embedding_bag_byte_rowwise_offsets(
       per_sample_weights_,
       compressed_indices_mapping,
       include_last_offset,
-      false);
+      false /* is_embedding_op */);
 }
 
 Tensor embedding_bag_4bit_rowwise_offsets(
@@ -585,7 +585,7 @@ class QEmbeddingBag final {
           per_sample_weights_,
           compressed_indices_mapping,
           include_last_offset,
-          false);
+          false /* is_embedding_op */);
     } else if (bit_rate == 4) {
       return packed_weight->embeddingbag_4bit(
           indices,
@@ -619,8 +619,8 @@ class QEmbedding final {
           pruned_weights,
           c10::nullopt,
           c10::nullopt,
-          false,
-          true);
+          false /* include_last_offset */,
+          true /* is_embedding_op */);
 
     } else {
       TORCH_INTERNAL_ASSERT(

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -3163,6 +3163,7 @@ class TestQuantizedEmbeddingOps(TestCase):
         torch.testing.assert_allclose(ref, qresult, atol=0.005, rtol=1e-3)
 
 
+    @skipIfNoFBGEMM
     def test_embedding_2d_indices(self):
         """
         Tests the case where 2D indices are passed into the operator
@@ -3185,7 +3186,7 @@ class TestQuantizedEmbeddingOps(TestCase):
         qresult = quant_op(packed_weight, indices, pruned_weights=False)
         torch.testing.assert_allclose(ref, qresult, atol=0.05, rtol=1e-3)
 
-
+    @skipIfNoFBGEMM
     def test_embedding_bag_2d_indices(self):
         """
         Tests the case where 2D indices are passed into the operator

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2964,6 +2964,7 @@ class TestQuantizedEmbeddingOps(TestCase):
 
         self._test_embedding_bag_unpack_fn(pack_fn, unpack_fn, num_embeddings, embedding_dim, 2, optimized_qparams)
 
+
     def embedding_bag_rowwise_offsets_run(
             self, bit_rate, num_embeddings,
             embedding_dim, num_offsets,
@@ -3160,6 +3161,67 @@ class TestQuantizedEmbeddingOps(TestCase):
 
         ref = torch.embedding(weights, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False)
         torch.testing.assert_allclose(ref, qresult, atol=0.005, rtol=1e-3)
+
+
+    def test_embedding_2d_indices(self):
+        """
+        Tests the case where 2D indices are passed into the operator
+        In this case the operator computes the correct offsets argument.
+        Output shape is dependent on the indices dimension.
+        """
+        quant_op = torch.ops.quantized.embedding_byte
+        prepack_op = torch.ops.quantized.embedding_bag_prepack
+
+        indices = torch.tensor([[9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8], [3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3]])
+        weights = torch.randn(10, 12, dtype=torch.float32)
+
+        ref = torch.embedding(weights, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False)
+        obs = PerChannelMinMaxObserver(dtype=torch.quint8, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
+        obs(weights)
+        qparams = obs.calculate_qparams()
+
+        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
+        packed_weight = prepack_op(qweight)
+        qresult = quant_op(packed_weight, indices, pruned_weights=False)
+        torch.testing.assert_allclose(ref, qresult, atol=0.05, rtol=1e-3)
+
+
+    def test_embedding_bag_2d_indices(self):
+        """
+        Tests the case where 2D indices are passed into the operator
+        In this case the operator computes the correct offsets argument.
+        """
+        indices = torch.tensor([[9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8], [3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3]])
+        weights = torch.randn(10, 12, dtype=torch.float32)
+
+        embedding_bag = torch.nn.EmbeddingBag(
+            num_embeddings=10,
+            embedding_dim=12,
+            include_last_offset=False, _weight=weights,
+            scale_grad_by_freq=False, mode='sum'
+        )
+        result = embedding_bag(indices)
+
+        pt_op = torch.ops.quantized.embedding_bag_byte_rowwise_offsets
+        pt_prepack_op = torch.ops.quantized.embedding_bag_byte_prepack
+        q_weights = pt_prepack_op(weights)
+        qresult = pt_op(q_weights, indices, mode=0, pruned_weights=False)
+        torch.testing.assert_allclose(result, qresult, atol=0.05, rtol=1e-3)
+
+        # Test TorchBind based embedding_bag operator
+        obs = PerChannelMinMaxObserver(dtype=torch.quint8, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0)
+        obs(weights)
+        # Get the scale and zero point for the weight tensor
+        qparams = obs.calculate_qparams()
+
+        # Quantize the weights to 8bits
+        qweight = torch.quantize_per_channel(weights, qparams[0], qparams[1], axis=0, dtype=torch.quint8)
+
+        packed_weight = torch.ops.quantized.embedding_bag_prepack(qweight)
+        qresult = torch.ops.quantized.embedding_bag_byte(packed_weight, indices, mode=0)
+
+        torch.testing.assert_allclose(result, qresult, atol=0.05, rtol=1e-3)
+
 
 class TestQuantizedConv(TestCase):
     def _test_qconv_unpack_impl(self, qconv_prepack_fn, qconv_unpack_fn, inputs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47766 [quant] Add support for 2D indices for quantized embedding operators**

Summary:
The operator now supports accepting 2D indices as inputs.
For embedding operators, we set the default offsets in the op since the FBGEMM kernel expects it to be set
Output shape depends on the shape if the indices.

For embedding_bag operator, if indices is 2D (B, N) then offsets should be set to None by user. In this case
the input is interpreted as B bags each of fixed length N. Output shape is still 2-D in this case.

Test Plan:
python test/test_quantization.py TestQuantizedEmbeddingOps.test_embedding_bag_2d_indices
python test/test_quantization.py TestQuantizedEmbeddingOps.test_embedding_2d_indices

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D24895048](https://our.internmc.facebook.com/intern/diff/D24895048)