### PR TITLE
[OpBenchMobile] Enable operator_benchmark to run the benchmark on mobile through AiBench

### DIFF
--- a/benchmarks/operator_benchmark/README.md
+++ b/benchmarks/operator_benchmark/README.md
@@ -60,13 +60,15 @@ add_short_configs = op_bench.cross_product_configs(
 )
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K):
-        self.input_one = torch.rand(M, N, K)
-        self.input_two = torch.rand(M, N, K)
+    def init(self, M, N, K, device):
+        self.inputs = {
+            "input_one": torch.rand(M, N, K, device=device, requires_grad=self.auto_set()),
+            "input_two": torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
+        }
         self.set_module_name("add")
 
-    def forward(self):
-        return torch.add(self.input_one, self.input_two)
+    def forward(self, input_one, input_two):
+        return torch.add(input_one, input_two)
 
 op_bench.generate_pt_test(add_short_configs, AddBenchmark)
 ```
@@ -174,14 +176,15 @@ add_short_configs = op_bench.config_list(
 )
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, device):
+        self.inputs = {
+            "input_one": torch.rand(M, N, K, device=device, requires_grad=self.auto_set()),
+            "input_two": torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
+        }
+        self.set_module_name("add")
 
-    def init(self, M, N, K):
-        self.input_one = torch.rand(M, N, K)
-        self.input_two = torch.rand(M, N, K)
-        self.set_module_name("add")
-
-    def forward(self):
-        return torch.add(self.input_one, self.input_two)
+    def forward(self, input_one, input_two):
+        return torch.add(input_one, input_two)
 
 op_bench.generate_pt_test(add_long_configs + add_short_configs, AddBenchmark)
 
@@ -218,26 +221,28 @@ Let's look at it in detail:
 
 #### Part 2. Create Tensors and Add Computation
 After inputs are provided, we now look at adding the computation of an operator. Adding a new operator requires implementing a new `TorchBenchmarkBase` subclass. Every new class is required to implement 2 methods:
-* `init` is used to create tensors based on the inputs we provided before. In this example, the parameters to `init` are `M, N, and K` which have been specified in the input configuration.
-* `forward` includes the operator to be tested and the computation based on the created tensors in `init`. Besides the object itself, it doesn't take any additional parameters. 
+* `init` is used to create tensors based on the inputs we provided before. In this example, the parameters to `init` are `M, N, and K` which have been specified in the input configuration. `init` also packed all the needed inputs together into a dictionary `self.inputs` which will be provided to `forward` as arguments for running the benchmark.
+* `forward` includes the operator to be tested and the computation based on the created tensors in `init`. Apart from `self`, the order of the arguments must match the entries specified in `self.inputs`.  
 
 The example below shows the code for `torch.add`:  
 ```
 # Given one set of M, N, K, the init method creates input tensors based on
 # that. The forward method does torch.add calculation on those input tensors.
-class AddBenchmark(op_bench.TorchBenchmarkBase):
 
-    def init(self, M, N, K):
+class AddBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, device):
         # this is the method where you need to create tensors
         # M, N, and K can be in different order, but they must match with
         # names in the configs.
-        self.input_one = torch.rand(M, N, K)
-        self.input_two = torch.rand(M, N, K)
-        self.set_module_name("add")
+        self.inputs = {
+            "input_one": torch.rand(M, N, K, device=device, requires_grad=self.auto_set()),
+            "input_two": torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
+        }
+        self.set_module_name("add")
 
-    def forward(self):
+    def forward(self, input_one, input_two):
         # this is the method to have operator and do computation
-        return torch.add(self.input_one, self.input_two)
+        return torch.add(input_one, input_two)
 ```
 
 #### Part 3. Register Tests With the Benchmark Suite
@@ -336,13 +341,14 @@ unary_ops_list = op_bench.op_list(
 )
 
 class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, device, op_func):
+        self.inputs = {
+            "input": torch.rand(M, N, device=device)
+        }
+        self.op_func = op_func
 
-    def init(self, M, N, op_func):
-        self.input_one = torch.rand(M, N)
-        self.op_func = op_func
-
-    def forward(self):
-        return self.op_func(self.input_one)
+    def forward(self, input):
+        return self.op_func(input)
 
 op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
 
@@ -371,20 +377,21 @@ unary_ops_list = op_bench.op_list(
 In this example, both operators share the same input so we only need to implement one TorchBenchmakrBase subclass. 
 Every new subclass is required to implement 3 methods:
 * `init` is used to create tensors and set the operator name and function. In this example, the parameters to `init` are `M`, `N`, and `op_func` which have been specified in the configurations.
-* `forward` includes the operator to be tested and the computation based on the created tensors in `init`. Besides the object itself, it doesn't take any additional parameters. 
+* `forward` includes the operator to be tested and the computation based on the created tensors in `init`. Apart from `self`, the order of the arguments must match the entries specified in `self.inputs`.
 Here is the code for `abs` and `acos`:
 
 ```
 class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
-
-    def init(self, M, N, op_func):
+    def init(self, M, N, device, op_func):
         # The M and N match with the attr_names in the input configuration
         # The op_func matches with the attr_name in the ops configuration
-        self.input_one = torch.rand(M, N)
-        self.op_func = op_func
+        self.inputs = {
+            "input": torch.rand(M, N, device=device)
+        }
+        self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.input_one)
+    def forward(self, input):
+        return self.op_func(input)
 ```
 
 #### Part 3. Register a List of Operators

--- a/benchmarks/operator_benchmark/benchmark_all_other_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_other_test.py
@@ -2,9 +2,10 @@ import operator_benchmark as op_bench
 from pt import ( # noqa
     add_test, as_strided_test, batchnorm_test, binary_test, cat_test,  # noqa
     channel_shuffle_test, chunk_test, conv_test, diag_test, embeddingbag_test,  # noqa
-    fill_test, gather_test, linear_test, matmul_test, pool_test,  # noqa
+    fill_test, gather_test, linear_test, matmul_test, nan_to_num_test, pool_test,  # noqa
     softmax_test, hardsigmoid_test, hardswish_test, layernorm_test,  # noqa
-    groupnorm_test, instancenorm_test # noqa
+    groupnorm_test, instancenorm_test, remainder_test, softmax_test,  # noqa
+    split_test, sum_test, tensor_to_test  # noqa
 )
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/benchmark_all_quantized_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_quantized_test.py
@@ -18,6 +18,7 @@ from pt import ( # noqa
     quantization_test,
     qunary_test,
     qembedding_pack_test,
+    qembeddingbag_test,
 )
 
 

--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -93,6 +93,10 @@ class Caffe2BenchmarkBase(object):
             Caffe2BenchmarkBase.test_index += 1
         return name
 
+    def extract_inputs_tuple(self):
+        # add a dummy function here to match the interface of TorchBenchmarkBase
+        pass
+
 
 class Caffe2OperatorTestCase(object):
     """ This class includes all the information needed to benchmark an operator.

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -118,6 +118,7 @@ def _build_test(configs, bench_op, OperatorTestCase, run_backward, op_name_funct
 
         op._set_backward_test(run_backward)
         op.init(**init_dict)
+        op.extract_inputs_tuple()
 
         if not run_backward:
             for _, attr in vars(op).items():

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -10,7 +10,7 @@ This module contains PyTorch-specific functionalities for performance
 microbenchmarks.
 """
 
-class TorchBenchmarkBase(object):
+class TorchBenchmarkBase(torch.nn.Module):
     """ This is a base class used to create Pytorch operator benchmark.
         module_name is the name of the operator being benchmarked.
         test_name is the name (it's created by concatenating all the
@@ -18,8 +18,8 @@ class TorchBenchmarkBase(object):
     """
 
     def __init__(self):
+        super(TorchBenchmarkBase, self).__init__()
         self.user_given_name = None
-        self._jit_forward = None
         self._pass_count = 0
         self._num_inputs_require_grads = 0
 
@@ -49,32 +49,26 @@ class TorchBenchmarkBase(object):
             self._auto_set_counter += 1
             return (self._pass_count == self._auto_set_counter)
 
-    def forward(self):
-        pass
+    def extract_inputs_tuple(self):
+        self.inputs_tuple = tuple(self.inputs.values())
 
-    def _wrap_forward(self, foo):
-        """ The function passed to JIT trace must have at least one argument,
-            this function is to wrap the forward method to meet that requirement.
-            _consume op is used to avoid the dead-code-elimination optimization
-            in JIT.
-        """
-        return torch.ops.operator_benchmark._consume(self.forward())
+    @torch.jit.export
+    def get_inputs(self):
+        # Need to convert the inputs to tuple outside of JIT so that
+        # JIT can infer the size of the inputs.
+        return self.inputs_tuple
 
-    def _generate_jit_forward_graph(self):
-        """ generate a graph for the forward function via tracing
-        """
+    @torch.jit.export
+    def forward_impl(self):
+        # This is to supply the inputs to the forward function which
+        # will be called in both the eager and JIT mode of local runs
+        return self.forward(*self.get_inputs())
 
-        func = torch.jit.trace(self._wrap_forward, torch.rand(1))
-        place_holder = torch.rand(1) # noqa
-
-        @torch.jit.script
-        def _jit_forward_graph(iters, place_holder):
-            # type: (int, Tensor)
-            result = torch.jit.annotate(torch.Tensor, place_holder)
-            for _ in range(iters):
-                result = func(place_holder)
-            return result
-        return _jit_forward_graph
+    @torch.jit.export
+    def forward_consume(self, iters: int):
+        #  _consume is used to avoid the dead-code-elimination optimization
+        for _ in range(iters):
+            torch.ops.operator_benchmark._consume(self.forward_impl())
 
     def module_name(self):
         """ this is used to label the operator being benchmarked
@@ -121,13 +115,20 @@ class PyTorchOperatorTestCase(object):
         self.place_holder_tensor = torch.ones(1)
         self.framework = "PyTorch"
         self.time_series = []
+        self._jit_forward_graph = None
+
+    def _generate_jit_forward_graph(self):
+        """ generate a graph for the forward function via scripting
+        """
+        scripted_op_bench = torch.jit.script(self.op_bench)
+        return scripted_op_bench.forward_consume
 
     def run_jit_forward(self, num_runs, print_per_iter=False, cuda_sync=False):
         """ Run the forward path of an op with JIT mode
         """
-        if self.op_bench._jit_forward is None:
-            self.op_bench._jit_forward = self.op_bench._generate_jit_forward_graph()
-        self.op_bench._jit_forward(num_runs, self.place_holder_tensor)
+        if self._jit_forward_graph is None:
+            self._jit_forward_graph = self._generate_jit_forward_graph()
+        self._jit_forward_graph(num_runs)
 
     def _print_per_iter(self):
         # print last 50 values
@@ -148,14 +149,14 @@ class PyTorchOperatorTestCase(object):
         if print_per_iter:
             for _ in range(num_runs):
                 start_time = time.time()
-                self.output = self.op_bench.forward()
+                self.output = self.op_bench.forward_impl()
                 if cuda_sync:
                     torch.cuda.synchronize(torch.cuda.current_device())
                 end_time = time.time()
                 self.time_series.append((end_time - start_time) * 1e3)
         else:
             for _ in range(num_runs):
-                self.output = self.op_bench.forward()
+                self.output = self.op_bench.forward_impl()
             if cuda_sync:
                 torch.cuda.synchronize(torch.cuda.current_device())
 

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -10,14 +10,12 @@ import benchmark_utils
 This is the main function for running performance microbenchmark tests.
 It also registers existing benchmark tests via Python module imports.
 """
+parser = argparse.ArgumentParser(
+    description="Run microbenchmarks.",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
 
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="Run microbenchmarks.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-
+def parse_args():
     parser.add_argument(
         '--tag_filter',
         help='tag_filter can be used to run the shapes which matches the tag. (all is used to run all the shapes)',
@@ -145,6 +143,10 @@ def main():
     if args.mkl_num_threads:
         benchmark_utils.set_mkl_threads(args.mkl_num_threads)
 
+    return args
+
+def main():
+    args = parse_args()
     benchmark_core.BenchmarkRunner(args).run()
 
 

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -37,3 +37,7 @@ def generate_pt_tests_from_op_list(ops_list, configs, pt_bench_op):
     """
     for op in ops_list:
         _register_test(configs, pt_bench_op, create_pytorch_op_test_case, False, op)
+
+def generate_pt_gradient_tests_from_op_list(ops_list, configs, pt_bench_op):
+    for op in ops_list:
+        _register_test(configs, pt_bench_op, create_pytorch_op_test_case, True, op)

--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -29,12 +29,14 @@ add_short_configs = op_bench.config_list(
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, K, device):
-        self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
-        self.input_two = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
+        self.inputs = {
+            "input_one": torch.rand(M, N, K, device=device, requires_grad=self.auto_set()),
+            "input_two": torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
+        }
         self.set_module_name("add")
 
-    def forward(self):
-        return torch.add(self.input_one, self.input_two)
+    def forward(self, input_one, input_two):
+        return torch.add(input_one, input_two)
 
 # The generated test names based on add_short_configs will be in the following pattern:
 # add_M8_N16_K32_devicecpu
@@ -53,13 +55,15 @@ op_bench.generate_pt_gradient_test(add_long_configs + add_short_configs, AddBenc
 
 class AddmmBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, K, device):
-        self.input_one = torch.rand(M, K, device=device, requires_grad=self.auto_set())
-        self.mat1 = torch.rand(M, N, device=device, requires_grad=self.auto_set())
-        self.mat2 = torch.rand(N, K, device=device, requires_grad=self.auto_set())
+        self.inputs = {
+            "input_one": torch.rand(M, K, device=device, requires_grad=self.auto_set()),
+            "mat1": torch.rand(M, N, device=device, requires_grad=self.auto_set()),
+            "mat2": torch.rand(N, K, device=device, requires_grad=self.auto_set())
+        }
         self.set_module_name("addmm")
 
-    def forward(self):
-        return torch.addmm(self.input_one, self.mat1, self.mat2)
+    def forward(self, input_one, mat1, mat2):
+        return torch.addmm(input_one, mat1, mat2)
 
 op_bench.generate_pt_test(add_long_configs + add_short_configs, AddmmBenchmark)
 op_bench.generate_pt_gradient_test(add_long_configs + add_short_configs, AddmmBenchmark)
@@ -70,13 +74,15 @@ op_bench.generate_pt_gradient_test(add_long_configs + add_short_configs, AddmmBe
 
 class AddrBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, device, dtype):
-        self.input_one = torch.rand((M, N), device=device, requires_grad=self.auto_set(), dtype=dtype)
-        self.vec1 = torch.rand((M,), device=device, requires_grad=self.auto_set(), dtype=dtype)
-        self.vec2 = torch.rand((N,), device=device, requires_grad=self.auto_set(), dtype=dtype)
+        self.inputs = {
+            "input_one": torch.rand((M, N), device=device, requires_grad=self.auto_set(), dtype=dtype),
+            "vec1": torch.rand((M,), device=device, requires_grad=self.auto_set(), dtype=dtype),
+            "vec2": torch.rand((N,), device=device, requires_grad=self.auto_set(), dtype=dtype)
+        }
         self.set_module_name("addr")
 
-    def forward(self):
-        return torch.addr(self.input_one, self.vec1, self.vec2)
+    def forward(self, input_one, vec1, vec2):
+        return torch.addr(input_one, vec1, vec2)
 
 addr_configs = op_bench.cross_product_configs(
     M=[8, 256],
@@ -95,13 +101,15 @@ op_bench.generate_pt_gradient_test(addr_configs, AddrBenchmark)
 
 class AddbmmBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, B, M, N, K, device):
-        self.input_one = torch.rand((M, N), device=device, requires_grad=self.auto_set())
-        self.batch1 = torch.rand((B, M, K), device=device, requires_grad=self.auto_set())
-        self.batch2 = torch.rand((B, K, N,), device=device, requires_grad=self.auto_set())
+        self.inputs = {
+            "input_one": torch.rand((M, N), device=device, requires_grad=self.auto_set()),
+            "batch1": torch.rand((B, M, K), device=device, requires_grad=self.auto_set()),
+            "batch2": torch.rand((B, K, N,), device=device, requires_grad=self.auto_set())
+        }
         self.set_module_name("addbmm")
 
-    def forward(self):
-        return torch.addbmm(self.input_one, self.batch1, self.batch2)
+    def forward(self, input_one, batch1, batch2):
+        return torch.addbmm(input_one, batch1, batch2)
 
 addbmm_configs = op_bench.cross_product_configs(
     B=[2, 100],

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -1,5 +1,6 @@
 import operator_benchmark as op_bench
 import torch
+from typing import List
 
 
 """Microbenchmarks for as_strided operator"""
@@ -32,15 +33,19 @@ as_strided_configs_long = op_bench.cross_product_configs(
 
 class As_stridedBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, size, stride, storage_offset, device):
-        self.input_one = torch.rand(M, N, device=device)
-        self.size = size
-        self.stride = stride
-        self.storage_offset = storage_offset
+        self.inputs = {
+            "input_one": torch.rand(M, N, device=device),
+            "size": size,
+            "stride": stride,
+            "storage_offset": storage_offset
+        }
         self.set_module_name('as_strided')
 
-    def forward(self):
+    def forward(
+        self, input_one, size: List[int], stride: List[int], storage_offset: int
+    ):
         return torch.as_strided(
-            self.input_one, self.size, self.stride, self.storage_offset)
+            input_one, size, stride, storage_offset)
 
 
 op_bench.generate_pt_test(as_strided_configs_short + as_strided_configs_long,

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -28,15 +28,17 @@ batchnorm_configs_long = op_bench.cross_product_configs(
 
 class BatchNormBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, K, device):
-        self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
-        self.mean = torch.rand(N, device=device)
-        self.var = torch.rand(N, device=device)
-        self.weight = torch.rand(N, device=device)
-        self.bias = torch.rand(N, device=device)
+        self.inputs = {
+            "input_one": torch.rand(M, N, K, device=device, requires_grad=self.auto_set()),
+            "mean": torch.rand(N, device=device),
+            "var": torch.rand(N, device=device),
+            "weight": torch.rand(N, device=device),
+            "bias": torch.rand(N, device=device)
+        }
         self.set_module_name("batchnorm")
 
-    def forward(self):
-        return F.batch_norm(self.input_one, self.mean, self.var, self.weight, self.bias)
+    def forward(self, input_one, mean, var, weight, bias):
+        return F.batch_norm(input_one, mean, var, weight, bias)
 
 
 op_bench.generate_pt_test(batchnorm_configs_short + batchnorm_configs_long, BatchNormBenchmark)

--- a/benchmarks/operator_benchmark/pt/binary_test.py
+++ b/benchmarks/operator_benchmark/pt/binary_test.py
@@ -29,12 +29,14 @@ binary_configs_broadcast = op_bench.config_list(
 
 class BinaryOpBcastBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, in_one, in_two, dtype, device, op_func):
-        self.in_one = torch.randn(in_one, device=device).to(dtype=dtype)
-        self.in_two = torch.randn(in_two, device=device).to(dtype=dtype)
+        self.inputs = {
+            "in_one": torch.randn(in_one, device=device).to(dtype=dtype),
+            "in_two": torch.randn(in_two, device=device).to(dtype=dtype)
+        }
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.in_one, self.in_two)
+    def forward(self, in_one, in_two):
+        return self.op_func(in_one, in_two)
 
 
 op_bench.generate_pt_tests_from_op_list(binary_ops_bcast_list,
@@ -42,12 +44,15 @@ op_bench.generate_pt_tests_from_op_list(binary_ops_bcast_list,
                                         BinaryOpBcastBenchmark)
 
 
+def copy(in1, in2):
+    return in1.copy_(in2)
+
 # Benchmark ops performance without broadcast
 binary_ops_list = op_bench.op_list(
     attr_names=['op_name', 'op_func'],
     attrs=[
         ['add', torch.add],
-        ['copy_', lambda in1, in2: in1.copy_(in2)],
+        ['copy_', copy],
     ],
 )
 
@@ -79,12 +84,14 @@ binary_long_configs = op_bench.cross_product_configs(
 
 class BinaryOpBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, K, device, dtype_one, dtype_two, op_func):
-        self.input_one = torch.randn(M, N, K, device=device).to(dtype=dtype_one)
-        self.input_two = torch.randn(M, N, K, device=device).to(dtype=dtype_two)
+        self.inputs = {
+            "input_one": torch.randn(M, N, K, device=device).to(dtype=dtype_one),
+            "input_two": torch.randn(M, N, K, device=device).to(dtype=dtype_two)
+        }
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.input_one, self.input_two)
+    def forward(self, input_one, input_two):
+        return self.op_func(input_one, input_two)
 
 
 op_bench.generate_pt_tests_from_op_list(binary_ops_list,

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -1,6 +1,7 @@
 import operator_benchmark as op_bench
 import torch
 import random
+from typing import List
 
 
 """Microbenchmarks for Cat operator"""
@@ -78,16 +79,19 @@ cat_configs_manyinputs = op_bench.config_list(
 class CatBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, sizes, N, dim, device):
         random.seed(42)
-        self.inputs = []
+        inputs = []
         for i in range(N):
             current_sizes = [old_size() if callable(old_size) else old_size
                              for old_size in sizes]
-            self.inputs.append(torch.rand(current_sizes, device=device))
-        self.dim = dim
+            inputs.append(torch.rand(current_sizes, device=device))
+        self.inputs = {
+            "inputs": inputs,
+            "dim": dim
+        }
         self.set_module_name('cat')
 
-    def forward(self):
-        return torch.cat(self.inputs, dim=self.dim)
+    def forward(self, inputs: List[torch.Tensor], dim: int):
+        return torch.cat(inputs, dim=dim)
 
 
 op_bench.generate_pt_test(cat_configs_short +

--- a/benchmarks/operator_benchmark/pt/channel_shuffle_test.py
+++ b/benchmarks/operator_benchmark/pt/channel_shuffle_test.py
@@ -36,16 +36,19 @@ channel_shuffle_short_configs = op_bench.config_list(
 
 class ChannelSHuffleBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, batch_size, channels_per_group, height, width, groups, channel_last):
-        self.groups = groups
         channels = channels_per_group * groups
         data_shape = (batch_size, channels, height, width)
-        self.input_data = torch.rand(data_shape)
+        input_data = torch.rand(data_shape)
         if channel_last:
-            self.input_data = self.input_data.contiguous(memory_format=torch.channels_last)
+            input_data = input_data.contiguous(memory_format=torch.channels_last)
+        self.inputs = {
+            "input_data": input_data,
+            "groups": groups
+        }
         self.set_module_name('channel_shuffle')
 
-    def forward(self):
-        return torch.channel_shuffle(self.input_data, self.groups)
+    def forward(self, input_data, groups: int):
+        return torch.channel_shuffle(input_data, groups)
 
 
 op_bench.generate_pt_test(channel_shuffle_short_configs + channel_shuffle_long_configs,

--- a/benchmarks/operator_benchmark/pt/chunk_test.py
+++ b/benchmarks/operator_benchmark/pt/chunk_test.py
@@ -30,12 +30,14 @@ chunks_long_configs = op_bench.cross_product_configs(
 
 class ChunkBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, chunks, device):
-        self.input_one = torch.rand(M, N, device=device)
-        self.chunks = chunks
-        self.set_module_name('chunk')
+        self.inputs = {
+            "input_one": torch.rand(M, N, device=device),
+            "chunks": chunks
+        }
+        self.set_module_name("chunk")
 
-    def forward(self):
-        return torch.chunk(self.input_one, self.chunks)
+    def forward(self, input_one, chunks: int):
+        return torch.chunk(input_one, chunks)
 
 
 op_bench.generate_pt_test(chunk_short_configs + chunks_long_configs,

--- a/benchmarks/operator_benchmark/pt/clip_ranges_test.py
+++ b/benchmarks/operator_benchmark/pt/clip_ranges_test.py
@@ -35,13 +35,14 @@ clip_ranges_short_configs = op_bench.config_list(
 
 class ClipRangesBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, LENGTH, M, N, MAX_LENGTH, device, dtype):
-        self.input = torch.rand(LENGTH, M, N, device=device).type(dtype)
-        self.max_length = MAX_LENGTH
+        self.inputs = {
+            "input": torch.rand(LENGTH, M, N, device=device).type(dtype),
+            "max_length": MAX_LENGTH
+        }
         self.set_module_name("clip_ranges")
 
-    def forward(self):
-        output = torch.ops.fb.clip_ranges(self.input, self.max_length)
-        return output
+    def forward(self, input, max_length: int):
+        return torch.ops.fb.clip_ranges(input, max_length)
 
 
 op_bench.generate_pt_test(

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -11,22 +11,26 @@ Microbenchmarks for Conv1d and ConvTranspose1d operators.
 
 class Conv1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, L, device):
-        self.input = torch.rand(N, IC, L, device=device)
+        self.inputs = {
+            "input": torch.rand(N, IC, L, device=device, requires_grad=self.auto_set())
+        }
         self.conv1d = nn.Conv1d(IC, OC, kernel, stride=stride).to(device=device)
         self.set_module_name('Conv1d')
 
-    def forward(self):
-        return self.conv1d(self.input)
+    def forward(self, input):
+        return self.conv1d(input)
 
 
 class ConvTranspose1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, L, device):
-        self.input = torch.rand(N, IC, L, device=device)
+        self.inputs = {
+            "input": torch.rand(N, IC, L, device=device)
+        }
         self.convtranspose1d = nn.ConvTranspose1d(IC, OC, kernel, stride=stride).to(device=device)
         self.set_module_name('ConvTranspose1d')
 
-    def forward(self):
-        return self.convtranspose1d(self.input)
+    def forward(self, input):
+        return self.convtranspose1d(input)
 
 
 op_bench.generate_pt_test(configs.conv_1d_configs_short + configs.conv_1d_configs_long,
@@ -42,24 +46,28 @@ Microbenchmarks for Conv2d and ConvTranspose2d operators.
 
 class Conv2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, H, W, G, pad, device):
-        self.input = torch.rand(N, IC, H, W, device=device)
+        self.inputs = {
+            "input": torch.rand(N, IC, H, W, device=device)
+        }
         self.conv2d = nn.Conv2d(
             IC, OC, kernel, stride=stride, groups=G, padding=pad).to(device=device)
         self.set_module_name('Conv2d')
 
-    def forward(self):
-        return self.conv2d(self.input)
+    def forward(self, input):
+        return self.conv2d(input)
 
 
 class ConvTranspose2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, H, W, G, pad, device):
-        self.input = torch.rand(N, IC, H, W, device=device)
+        self.inputs = {
+            "input": torch.rand(N, IC, H, W, device=device)
+        }
         self.convtranspose2d = nn.ConvTranspose2d(
             IC, OC, kernel, stride=stride, groups=G, padding=pad).to(device=device)
         self.set_module_name('ConvTranspose2d')
 
-    def forward(self):
-        return self.convtranspose2d(self.input)
+    def forward(self, input):
+        return self.convtranspose2d(input)
 
 
 op_bench.generate_pt_test(configs.conv_2d_configs_short + configs.conv_2d_configs_long,
@@ -74,22 +82,26 @@ Microbenchmarks for Conv3d and ConvTranspose3d operators.
 
 class Conv3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, D, H, W, device):
-        self.input = torch.rand(N, IC, D, H, W, device=device)
+        self.inputs = {
+            "input": torch.rand(N, IC, D, H, W, device=device)
+        }
         self.conv3d = nn.Conv3d(IC, OC, kernel, stride=stride).to(device=device)
         self.set_module_name('Conv3d')
 
-    def forward(self):
-        return self.conv3d(self.input)
+    def forward(self, input):
+        return self.conv3d(input)
 
 
 class ConvTranspose3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, IC, OC, kernel, stride, N, D, H, W, device):
-        self.input = torch.rand(N, IC, D, H, W, device=device)
+        self.inputs = {
+            "input": torch.rand(N, IC, D, H, W, device=device)
+        }
         self.convtranspose3d = nn.ConvTranspose3d(IC, OC, kernel, stride=stride).to(device=device)
         self.set_module_name('ConvTranspose3d')
 
-    def forward(self):
-        return self.convtranspose3d(self.input)
+    def forward(self, input):
+        return self.convtranspose3d(input)
 
 
 op_bench.generate_pt_test(configs.conv_3d_configs_short, Conv3dBenchmark)

--- a/benchmarks/operator_benchmark/pt/diag_test.py
+++ b/benchmarks/operator_benchmark/pt/diag_test.py
@@ -22,13 +22,19 @@ diag_configs_short = op_bench.config_list(
 
 class DiagBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, dim, M, N, diagonal, out, device):
-        self.input = torch.rand(M, N, device=device) if dim == 2 else torch.rand(M, device=device)
-        self.diagonal = diagonal
-        self.out = torch.tensor((),) if out else None
+        self.inputs = {
+            "input": torch.rand(M, N, device=device) if dim == 2 else torch.rand(M, device=device),
+            "diagonal": diagonal,
+            "out": out,
+            "out_tensor": torch.tensor((),)
+        }
         self.set_module_name('diag')
 
-    def forward(self):
-        return torch.diag(self.input, diagonal=self.diagonal, out=self.out)
+    def forward(self, input, diagonal: int, out: bool, out_tensor):
+        if out:
+            return torch.diag(input, diagonal=diagonal, out=out_tensor)
+        else:
+            return torch.diag(input, diagonal=diagonal)
 
 
 op_bench.generate_pt_test(diag_configs_short, DiagBenchmark)

--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -14,13 +14,16 @@ class EmbeddingBagBenchmark(op_bench.TorchBenchmarkBase):
             include_last_offset=include_last_offset,
             sparse=sparse).to(device=device)
         numpy.random.seed((1 << 32) - 1)
-        self.input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size), device=device).long()
         offsets = torch.LongTensor([offset], device=device)
-        self.offset = torch.cat((offsets, torch.tensor([self.input.size(0)], dtype=torch.long)), 0)
+        input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size), device=device).long()
+        self.inputs = {
+            "input": input,
+            "offset": torch.cat((offsets, torch.tensor([input.size(0)], dtype=torch.long)), 0)
+        }
         self.set_module_name('embeddingbag')
 
-    def forward(self):
-        return self.embedding(self.input, self.offset)
+    def forward(self, input, offset):
+        return self.embedding(input, offset)
 
 op_bench.generate_pt_test(configs.embeddingbag_short_configs, EmbeddingBagBenchmark)
 op_bench.generate_pt_gradient_test(configs.embeddingbag_short_configs, EmbeddingBagBenchmark)

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -28,11 +28,13 @@ fill_long_configs = op_bench.cross_product_configs(
 
 class Fill_Benchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, device, dtype):
-        self.input_one = torch.zeros(N, device=device).type(dtype)
+        self.inputs = {
+            "input_one": torch.zeros(N, device=device).type(dtype)
+        }
         self.set_module_name("fill_")
 
-    def forward(self):
-        return self.input_one.fill_(10)
+    def forward(self, input_one):
+        return input_one.fill_(10)
 
 
 op_bench.generate_pt_test(fill_short_configs + fill_long_configs,

--- a/benchmarks/operator_benchmark/pt/gather_test.py
+++ b/benchmarks/operator_benchmark/pt/gather_test.py
@@ -30,15 +30,17 @@ gather_configs_long = op_bench.cross_product_configs(
 
 class GatherBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, dim, device):
-        self.input_one = torch.rand(M, N, device=device)
-        self.dim = dim
         min_val = M if dim == 0 else N
         numpy.random.seed((1 << 32) - 1)
-        self.index = torch.tensor(numpy.random.randint(0, min_val, (M, N)), device=device)
+        self.inputs = {
+            "input_one": torch.rand(M, N, device=device),
+            "dim": dim,
+            "index": torch.tensor(numpy.random.randint(0, min_val, (M, N)), device=device)
+        }
         self.set_module_name("gather")
 
-    def forward(self):
-        return torch.gather(self.input_one, self.dim, self.index)
+    def forward(self, input_one, dim: int, index):
+        return torch.gather(input_one, dim, index)
 
 
 op_bench.generate_pt_test(gather_configs_short + gather_configs_long,

--- a/benchmarks/operator_benchmark/pt/groupnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/groupnorm_test.py
@@ -18,16 +18,18 @@ groupnorm_configs_short = op_bench.cross_product_configs(
 
 class GroupNormBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, dims, num_groups):
-        self.X = (torch.rand(*dims) - 0.5) * 256
-        self.num_groups = num_groups
         num_channels = dims[1]
-        self.weight = torch.rand(num_channels, dtype=torch.float)
-        self.bias = torch.rand(num_channels, dtype=torch.float)
-        self.eps = 1e-5
+        self.inputs = {
+            "input": (torch.rand(*dims) - 0.5) * 256,
+            "num_groups": num_groups,
+            "weight": torch.rand(num_channels, dtype=torch.float),
+            "bias": torch.rand(num_channels, dtype=torch.float),
+            "eps": 1e-5
+        }
 
-    def forward(self):
+    def forward(self, input, num_groups: int, weight, bias, eps: float):
         return F.group_norm(
-            self.X, self.num_groups, weight=self.weight, bias=self.bias, eps=self.eps)
+            input, num_groups, weight=weight, bias=bias, eps=eps)
 
 
 op_bench.generate_pt_test(groupnorm_configs_short, GroupNormBenchmark)

--- a/benchmarks/operator_benchmark/pt/hardsigmoid_test.py
+++ b/benchmarks/operator_benchmark/pt/hardsigmoid_test.py
@@ -45,11 +45,13 @@ hardsigmoid_ops_list = op_bench.op_list(
 
 class HardsigmoidBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, C, H, W, device, op_func):
-        self.input_one = torch.rand(N, C, H, W, device=device)
+        self.inputs = {
+            "input_one": torch.rand(N, C, H, W, device=device)
+        }
         self.op_func = op_func()
 
-    def forward(self):
-        return self.op_func(self.input_one)
+    def forward(self, input_one):
+        return self.op_func(input_one)
 
 
 op_bench.generate_pt_tests_from_op_list(hardsigmoid_ops_list,

--- a/benchmarks/operator_benchmark/pt/hardswish_test.py
+++ b/benchmarks/operator_benchmark/pt/hardswish_test.py
@@ -45,11 +45,13 @@ hardswish_ops_list = op_bench.op_list(
 
 class HardswishBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, C, H, W, device, op_func):
-        self.input_one = torch.rand(N, C, H, W, device=device)
+        self.inputs = {
+            "input_one": torch.rand(N, C, H, W, device=device)
+        }
         self.op_func = op_func()
 
-    def forward(self):
-        return self.op_func(self.input_one)
+    def forward(self, input_one):
+        return self.op_func(input_one)
 
 
 op_bench.generate_pt_tests_from_op_list(hardswish_ops_list,

--- a/benchmarks/operator_benchmark/pt/instancenorm_test.py
+++ b/benchmarks/operator_benchmark/pt/instancenorm_test.py
@@ -17,15 +17,17 @@ instancenorm_configs_short = op_bench.cross_product_configs(
 
 class InstanceNormBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, dims):
-        self.X = (torch.rand(*dims) - 0.5) * 256
         num_channels = dims[1]
-        self.weight = torch.rand(num_channels, dtype=torch.float)
-        self.bias = torch.rand(num_channels, dtype=torch.float)
-        self.eps = 1e-5
+        self.inputs = {
+            "input": (torch.rand(*dims) - 0.5) * 256,
+            "weight": torch.rand(num_channels, dtype=torch.float),
+            "bias": torch.rand(num_channels, dtype=torch.float),
+            "eps": 1e-5
+        }
 
-    def forward(self):
+    def forward(self, input, weight, bias, eps: float):
         return F.instance_norm(
-            self.X, weight=self.weight, bias=self.bias, eps=self.eps)
+            input, weight=weight, bias=bias, eps=eps)
 
 
 op_bench.generate_pt_test(instancenorm_configs_short, InstanceNormBenchmark)

--- a/benchmarks/operator_benchmark/pt/layernorm_test.py
+++ b/benchmarks/operator_benchmark/pt/layernorm_test.py
@@ -19,14 +19,17 @@ layernorm_configs_short = op_bench.cross_product_configs(
 
 class LayerNormBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, dims):
-        self.X = (torch.rand(*dims) - 0.5) * 256
-        self.weight = torch.rand(*self.X.size()[1:], dtype=torch.float)
-        self.bias = torch.rand(*self.X.size()[1:], dtype=torch.float)
-        self.eps = 1e-5
+        input = (torch.rand(*dims) - 0.5) * 256
+        self.inputs = {
+            "input": input,
+            "weight": torch.rand(*input.size()[1:], dtype=torch.float),
+            "bias": torch.rand(*input.size()[1:], dtype=torch.float),
+            "eps": 1e-5
+        }
 
-    def forward(self):
+    def forward(self, input, weight, bias, eps: float):
         return F.layer_norm(
-            self.X, self.X.size()[1:], weight=self.weight, bias=self.bias, eps=self.eps)
+            input, input.size()[1:], weight=weight, bias=bias, eps=eps)
 
 
 op_bench.generate_pt_test(layernorm_configs_short, LayerNormBenchmark)

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -11,12 +11,14 @@ from pt import configs
 
 class LinearBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, IN, OUT, device):
-        self.input_one = torch.rand(N, IN, device=device)
+        self.inputs = {
+            "input_one": torch.rand(N, IN, device=device)
+        }
         self.linear = nn.Linear(IN, OUT).to(device=device)
         self.set_module_name("linear")
 
-    def forward(self):
-        return self.linear(self.input_one)
+    def forward(self, input_one):
+        return self.linear(input_one)
 
 
 op_bench.generate_pt_test(configs.linear_configs_short + configs.linear_configs_long,

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -31,14 +31,18 @@ mm_long_configs = op_bench.cross_product_configs(
 
 class MatMulBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, K, trans_a, trans_b, device):
-        self.input_one = torch.rand(M, N, device=device) if trans_a \
-            else torch.rand(N, M, device=device).t()
-        self.input_two = torch.rand(N, K, device=device) if trans_b \
-            else torch.rand(K, N, device=device).t()
+        self.inputs = {
+            "input_one": torch.rand(M, N, device=device)
+            if trans_a
+            else torch.rand(N, M, device=device).t(),
+            "input_two": torch.rand(N, K, device=device)
+            if trans_b
+            else torch.rand(K, N, device=device).t(),
+        }
         self.set_module_name("matmul")
 
-    def forward(self):
-        return torch.matmul(self.input_one, self.input_two)
+    def forward(self, input_one, input_two):
+        return torch.matmul(input_one, input_two)
 
 
 op_bench.generate_pt_test(mm_long_configs + mm_short_configs, MatMulBenchmark)

--- a/benchmarks/operator_benchmark/pt/nan_to_num_test.py
+++ b/benchmarks/operator_benchmark/pt/nan_to_num_test.py
@@ -6,11 +6,19 @@ import math
 """Microbenchmarks for torch.nan_to_num / nan_to_num_ operators"""
 
 # Configs for PT torch.nan_to_num / nan_to_num_ operators
+
+nan_to_num_ops_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['nan_to_num', torch.nan_to_num],
+        ['nan_to_num_', torch.nan_to_num_],
+    ],
+)
+
 nan_to_num_long_configs = op_bench.cross_product_configs(
     M=[32, 64, 128],
     N=range(32, 128, 32),
     dtype=[torch.float, torch.double],
-    op=["nan_to_num", "nan_to_num_"],
     replace_inf=[True, False],
     tags=["long"],
 )
@@ -20,36 +28,32 @@ nan_to_num_short_configs = op_bench.cross_product_configs(
     M=[16, 64],
     N=[64, 64],
     dtype=[torch.float, torch.double],
-    op=["nan_to_num", "nan_to_num_"],
     replace_inf=[True, False],
     tags=["short"],
 )
 
 
 class ReplaceNaNBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, dtype, op, replace_inf):
-        self.input = torch.randn(M, N, dtype=dtype)
-        self.input[0][0] = float("nan")
-        self.op = op
-        self.replace_inf = replace_inf
+    def init(self, M, N, dtype, replace_inf, op_func):
+        input = torch.randn(M, N, dtype=dtype)
+        input[0][0] = float("nan")
+        self.inputs = {
+            "input": input,
+            "replace_inf": replace_inf
+        }
+        self.op_func = op_func
         self.set_module_name("nan_to_num")
 
-    def forward(self):
+    def forward(self, input, replace_inf: bool):
         # compare inplace
-        if self.op == "nan_to_num":
-            if self.replace_inf:
-                output = torch.nan_to_num(self.input, nan=1.0)
-            else:
-                output = torch.nan_to_num(self.input, nan=1.0, posinf=math.inf, neginf=-math.inf)
+        if replace_inf:
+            return self.op_func(input, nan=1.0)
         else:
-            if self.replace_inf:
-                output = torch.nan_to_num_(self.input, nan=1.0)
-            else:
-                output = torch.nan_to_num_(self.input, nan=1.0, posinf=math.inf, neginf=-math.inf)
-        return output
+            return self.op_func(input, nan=1.0, posinf=math.inf, neginf=-math.inf)
 
 
-op_bench.generate_pt_test(
+op_bench.generate_pt_tests_from_op_list(
+    nan_to_num_ops_list,
     nan_to_num_long_configs + nan_to_num_short_configs,
     ReplaceNaNBenchmark,
 )

--- a/benchmarks/operator_benchmark/pt/pool_test.py
+++ b/benchmarks/operator_benchmark/pt/pool_test.py
@@ -41,13 +41,13 @@ pool_1d_ops_list = op_bench.op_list(
 
 class Pool1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, kernel, stride, N, C, L, device, op_func):
-        self.input = torch.rand(N, C, L, device=device)
-        self.kernel = kernel
-        self.stride = stride
-        self.op_func = op_func(self.kernel, stride=self.stride)
+        self.inputs = {
+            "input": torch.rand(N, C, L, device=device)
+        }
+        self.op_func = op_func(kernel, stride=stride)
 
-    def forward(self):
-        return self.op_func(self.input)
+    def forward(self, input):
+        return self.op_func(input)
 
 
 op_bench.generate_pt_tests_from_op_list(pool_1d_ops_list,
@@ -98,14 +98,14 @@ pool_2d_ops_list = op_bench.op_list(
 
 class Pool2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, kernel, stride, N, C, H, W, device, op_func):
-        self.input = torch.rand(N, C, H, W, device=device)
-        self.kernel = kernel
-        self.stride = stride
-        self.op_func = op_func(self.kernel, stride=self.stride)
+        self.inputs = {
+            "input": torch.rand(N, C, H, W, device=device)
+        }
+        self.op_func = op_func(kernel, stride=stride)
 
 
-    def forward(self):
-        return self.op_func(self.input)
+    def forward(self, input):
+        return self.op_func(input)
 
 
 op_bench.generate_pt_tests_from_op_list(pool_2d_ops_list,
@@ -158,13 +158,13 @@ pool_3d_ops_list = op_bench.op_list(
 
 class Pool3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, kernel, stride, N, C, D, H, W, device, op_func):
-        self.input = torch.rand(N, C, D, H, W, device=device)
-        self.kernel = kernel
-        self.stride = stride
-        self.op_func = op_func(self.kernel, stride=self.stride)
+        self.inputs = {
+            "input": torch.rand(N, C, D, H, W, device=device)
+        }
+        self.op_func = op_func(kernel, stride=stride)
 
-    def forward(self):
-        return self.op_func(self.input)
+    def forward(self, input):
+        return self.op_func(input)
 
 
 op_bench.generate_pt_tests_from_op_list(pool_3d_ops_list,

--- a/benchmarks/operator_benchmark/pt/qarithmetic_test.py
+++ b/benchmarks/operator_benchmark/pt/qarithmetic_test.py
@@ -1,5 +1,5 @@
 import torch
-
+from torch._ops import ops
 import operator_benchmark as op_bench
 
 qarithmetic_binary_configs = op_bench.cross_product_configs(
@@ -10,58 +10,77 @@ qarithmetic_binary_configs = op_bench.cross_product_configs(
     tags=('short',)
 )
 
+
 qarithmetic_binary_ops = op_bench.op_list(
     attrs=(
-        ('add', 'add'),
-        ('add_scalar', 'add_scalar'),
-        ('add_relu', 'add_relu'),
-        ('mul', 'mul'),
-        ('mul_scalar', 'mul_scalar'),
+        ('add', ops.quantized.add),
+        ('add_relu', ops.quantized.add_relu),
+        ('mul', ops.quantized.mul),
     ),
     attr_names=('op_name', 'op_func'),
 )
 
+qarithmetic_binary_scalar_ops = op_bench.op_list(
+    attrs=(
+        ('add_scalar', ops.quantized.add_scalar),
+        ('mul_scalar', ops.quantized.mul_scalar),
+    ),
+    attr_names=('op_name', 'op_func'),
+)
 
-r"""Base class to use QFunctional.
-
-Children will need to set `self.qop` to the qfunctional op under test.
-I.e. `self.qop = 'add'`
-"""
 class _QFunctionalBinaryArithmeticBenchmarkBase(op_bench.TorchBenchmarkBase):
     def setup(self, N, dtype, contig):
         self.qfunctional = torch.nn.quantized.QFunctional()
 
         # TODO: Consider more diverse shapes
         f_input = (torch.rand(N, N) - 0.5) * 256
-        scale = 1.0
-        zero_point = 0
-
-        self.q_input_a = torch.quantize_per_tensor(f_input, scale=scale,
-                                                   zero_point=zero_point,
+        self.scale = 1.0
+        self.zero_point = 0
+        self.q_input_a = torch.quantize_per_tensor(f_input, scale=self.scale,
+                                                   zero_point=self.zero_point,
                                                    dtype=dtype)
 
         if not contig:
             permute_dims = list(range(f_input.ndim))[::-1]
             self.q_input_a = self.q_input_a.permute(permute_dims)
 
-    def forward(self):
-        return getattr(self.qfunctional, self.qop)(self.q_input_a,
-                                                   self.q_input_b)
 
-
-class QFunctionalAddBenchmarkBase(_QFunctionalBinaryArithmeticBenchmarkBase):
+class QFunctionalBenchmark(_QFunctionalBinaryArithmeticBenchmarkBase):
     def init(self, N, dtype, contig, op_func):
-        super(QFunctionalAddBenchmarkBase, self).setup(N, dtype, contig)
-        self.qop = op_func
-        if self.qop.endswith('_scalar'):
-            self.q_input_b = 42
-        else:
-            self.q_input_b = self.q_input_a
+        super(QFunctionalBenchmark, self).setup(N, dtype, contig)
+        self.inputs = {
+            "q_input_a": self.q_input_a,
+            "q_input_b": self.q_input_a,
+            "scale": self.scale,
+            "zero_point": self.zero_point
+        }
+        self.op_func = op_func
+
+    def forward(self, q_input_a, q_input_b, scale: float, zero_point: int):
+        return self.op_func(q_input_a, q_input_b, scale=scale, zero_point=zero_point)
 
 
 op_bench.generate_pt_tests_from_op_list(qarithmetic_binary_ops,
                                         qarithmetic_binary_configs,
-                                        QFunctionalAddBenchmarkBase)
+                                        QFunctionalBenchmark)
+
+
+class QFunctionalScalarBenchmark(_QFunctionalBinaryArithmeticBenchmarkBase):
+    def init(self, N, dtype, contig, op_func):
+        super(QFunctionalScalarBenchmark, self).setup(N, dtype, contig)
+        self.inputs = {
+            "q_input": self.q_input_a,
+            "scalar_input": 42
+        }
+        self.op_func = op_func
+
+    def forward(self, q_input, scalar_input: int):
+        return self.op_func(q_input, scalar_input)
+
+
+op_bench.generate_pt_tests_from_op_list(qarithmetic_binary_scalar_ops,
+                                        qarithmetic_binary_configs,
+                                        QFunctionalScalarBenchmark)
 
 
 if __name__ == '__main__':

--- a/benchmarks/operator_benchmark/pt/qbatchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qbatchnorm_test.py
@@ -23,15 +23,17 @@ class QBatchNormBenchmark(op_bench.TorchBenchmarkBase):
         self._init(M, N, K, device)
         x_scale = 0.1
         x_zero_point = 0
-        self.q_input_one = torch.quantize_per_tensor(
-            self.input_one, scale=x_scale, zero_point=x_zero_point, dtype=dtype)
-        self.mean = torch.rand(N)
-        self.var = torch.rand(N)
-        self.weight = torch.rand(N)
-        self.bias = torch.rand(N)
-        self.eps = 1e-5
-        self.Y_scale = 0.1
-        self.Y_zero_point = 0
+        self.inputs = {
+            "q_input_one": torch.quantize_per_tensor(
+                self.input_one, scale=x_scale, zero_point=x_zero_point, dtype=dtype),
+            "mean": torch.rand(N),
+            "var": torch.rand(N),
+            "weight": torch.rand(N),
+            "bias": torch.rand(N),
+            "eps": 1e-5,
+            "Y_scale": 0.1,
+            "Y_zero_point": 0
+        }
 
     def _init(self, M, N, K, device):
         pass
@@ -45,10 +47,20 @@ class QBatchNorm1dBenchmark(QBatchNormBenchmark):
         self.set_module_name("QBatchNorm1d")
         self.input_one = torch.rand(M, N, K, device=device, requires_grad=self.auto_set())
 
-    def forward(self):
+    def forward(
+        self,
+        q_input_one,
+        weight,
+        bias,
+        mean,
+        var,
+        eps: float,
+        Y_scale: float,
+        Y_zero_point: int
+    ):
         return torch.ops.quantized.batch_norm1d(
-            self.q_input_one, self.weight, self.bias, self.mean, self.var, self.eps,
-            self.Y_scale, self.Y_zero_point)
+            q_input_one, weight, bias, mean, var, eps,
+            Y_scale, Y_zero_point)
 
 
 class QBatchNorm2dBenchmark(QBatchNormBenchmark):
@@ -58,10 +70,20 @@ class QBatchNorm2dBenchmark(QBatchNormBenchmark):
         # add a 1 as the last dimension
         self.input_one = torch.rand(M, N, K, 1, device=device, requires_grad=self.auto_set())
 
-    def forward(self):
+    def forward(
+        self,
+        q_input_one,
+        weight,
+        bias,
+        mean,
+        var,
+        eps: float,
+        Y_scale: float,
+        Y_zero_point: int
+    ):
         return torch.ops.quantized.batch_norm2d(
-            self.q_input_one, self.weight, self.bias, self.mean, self.var, self.eps,
-            self.Y_scale, self.Y_zero_point)
+            q_input_one, weight, bias, mean, var, eps,
+            Y_scale, Y_zero_point)
 
 
 op_bench.generate_pt_test(batchnorm_configs_short, QBatchNorm1dBenchmark)

--- a/benchmarks/operator_benchmark/pt/qcat_test.py
+++ b/benchmarks/operator_benchmark/pt/qcat_test.py
@@ -2,6 +2,7 @@ import operator_benchmark as op_bench
 
 import torch
 import torch.nn.quantized as nnq
+from typing import List
 
 
 """Microbenchmarks for quantized Cat operator"""
@@ -53,11 +54,14 @@ class QCatBenchmark(op_bench.TorchBenchmarkBase):
         elif contig == 'none':
             self.input = (q_input_non_contig, q_input_non_contig)
 
-        self.dim = dim
+        self.inputs = {
+            "input": self.input,
+            "dim": dim
+        }
         self.set_module_name('qcat')
 
-    def forward(self):
-        return self.qf.cat(self.input, dim=self.dim)
+    def forward(self, input: List[torch.Tensor], dim: int):
+        return self.qf.cat(input, dim=dim)
 
 
 op_bench.generate_pt_test(qcat_configs_short + qcat_configs_long,

--- a/benchmarks/operator_benchmark/pt/qcomparators_test.py
+++ b/benchmarks/operator_benchmark/pt/qcomparators_test.py
@@ -34,23 +34,32 @@ class QComparatorBenchmark(op_bench.TorchBenchmarkBase):
         q_input_a = torch.quantize_per_tensor(f_input, scale=scale,
                                               zero_point=zero_point,
                                               dtype=dtype)
-        if other_scalar:
-            q_input_b = 42
-        else:
-            q_input_b = q_input_a.clone()
+        q_input_b = q_input_a.clone()
 
         if not contig:
             permute_dims = list(range(f_input.ndim))[::-1]
             q_input_a = q_input_a.permute(permute_dims)
 
         self.qop = op_func
-        self.args = (q_input_a, q_input_b)
-        self.kwargs = {}
-        if out_variant:
-            self.kwargs['out'] = torch.tensor([], dtype=torch.bool)
+        self.inputs = {
+            "q_input_a": q_input_a,
+            "q_input_b": q_input_b,
+            "out_variant": out_variant,
+            "other_scalar": other_scalar,
+        }
 
-    def forward(self):
-        return self.qop(*self.args, **self.kwargs)
+    def forward(self, q_input_a, q_input_b, out_variant: bool, other_scalar: bool):
+        if out_variant:
+            if other_scalar:
+                return self.qop(q_input_a, 42, out=torch.tensor(True, dtype=torch.bool))
+            else:
+                return self.qop(q_input_a, q_input_b, out=torch.tensor(True, dtype=torch.bool))
+        else:
+            if other_scalar:
+                return self.qop(q_input_a, 42)
+            else:
+                return self.qop(q_input_a, q_input_b)
+
 
 
 op_bench.generate_pt_tests_from_op_list(qcomparators_ops,

--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -24,16 +24,18 @@ class QConv1dBenchmark(op_bench.TorchBenchmarkBase):
         W = torch.randn(OC, IC // G, kernel, dtype=torch.float32)
         self.qW = torch.quantize_per_tensor(W, scale=self.scale, zero_point=0, dtype=torch.qint8)
 
-        self.input = qX
+        self.inputs = {
+            "input": qX
+        }
 
         self.qconv1d = nnq.Conv1d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
         self.qconv1d.set_weight_bias(self.qW, None)
-        self.qconv1d.scale = torch.tensor([self.scale], dtype=torch.double)
-        self.qconv1d.zero_point = torch.tensor([self.zero_point], dtype=torch.int)
+        self.qconv1d.scale = torch.tensor(self.scale, dtype=torch.double)
+        self.qconv1d.zero_point = torch.tensor(self.zero_point, dtype=torch.int)
         self.set_module_name("QConv1d")
 
-    def forward(self):
-        return self.qconv1d(self.input)
+    def forward(self, input):
+        return self.qconv1d(input)
 
 
 class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
@@ -51,16 +53,18 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
         W = torch.randn(OC, IC // G, kernel, kernel, dtype=torch.float32)
         self.qW = torch.quantize_per_tensor(W, scale=self.scale, zero_point=0, dtype=torch.qint8)
 
-        self.input = qX
+        self.inputs = {
+            "input": qX
+        }
 
         self.qconv2d = nnq.Conv2d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
         self.qconv2d.set_weight_bias(self.qW, None)
-        self.qconv2d.scale = torch.tensor([self.scale], dtype=torch.double)
-        self.qconv2d.zero_point = torch.tensor([self.zero_point], dtype=torch.int)
+        self.qconv2d.scale = torch.tensor(self.scale, dtype=torch.double)
+        self.qconv2d.zero_point = torch.tensor(self.zero_point, dtype=torch.int)
         self.set_module_name("QConv2d")
 
-    def forward(self):
-        return self.qconv2d(self.input)
+    def forward(self, input):
+        return self.qconv2d(input)
 
 
 op_bench.generate_pt_test(configs.remove_cuda(configs.conv_1d_configs_short + configs.conv_1d_configs_long), QConv1dBenchmark)

--- a/benchmarks/operator_benchmark/pt/qembedding_bag_lookups_test.py
+++ b/benchmarks/operator_benchmark/pt/qembedding_bag_lookups_test.py
@@ -2,7 +2,7 @@
 import operator_benchmark as op_bench
 import torch
 import numpy as np
-
+from typing import Optional
 
 from torch.testing._internal.common_quantization import (
     lengths_to_offsets
@@ -20,7 +20,7 @@ embedding_bag_rowwise_offsets_short_configs = op_bench.cross_product_configs(
     is_pruned_weights=(True, False,),
     use_32bit_indices=(True, False),
     use_32bit_offsets=(True, False),
-    tags=('short',),
+    tags=['short'],
 )
 
 
@@ -33,11 +33,11 @@ embedding_bag_rowwise_offsets_long_configs = op_bench.cross_product_configs(
     is_pruned_weights=(True, False,),
     use_32bit_indices=(True, False),
     use_32bit_offsets=(True, False),
-    tags=('long',)
+    tags=['long']
 )
 
 
-full_configs = embedding_bag_rowwise_offsets_long_configs + embedding_bag_rowwise_offsets_short_configs
+full_configs = embedding_bag_rowwise_offsets_short_configs + embedding_bag_rowwise_offsets_long_configs
 
 four_bit_rowwise_ops = op_bench.op_list(
     attrs=(
@@ -117,14 +117,37 @@ class EmbedddingBag4BitRowwiseOffsetsTest(op_bench.TorchBenchmarkBase):
         if self.is_pruned_weights:
             self.prepacked_weights, self.compressed_indices = get_pruned_weights_and_mapping(self.prepacked_weights)
 
+        self.inputs = {
+            "prepacked_weights": self.prepacked_weights,
+            "indices": self.indices,
+            "offsets": self.offsets,
+            "mode": 0,
+            "per_sample_weights": self.per_sample_weights,
+            "include_last_offset": self.include_last_offset,
+            "is_pruned_weights": self.is_pruned_weights,
+            "compressed_indices": self.compressed_indices
+        }
+
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.prepacked_weights, self.indices, self.offsets,
-                            mode=0, per_sample_weights=self.per_sample_weights,
-                            include_last_offset=self.include_last_offset,
-                            pruned_weights=self.is_pruned_weights,
-                            compressed_indices_mapping=self.compressed_indices)
+    def forward(
+        self,
+        prepacked_weights,
+        indices,
+        offsets,
+        mode: int,
+        per_sample_weights: Optional[torch.Tensor],
+        include_last_offset: bool,
+        is_pruned_weights: bool,
+        compressed_indices: Optional[torch.Tensor]
+    ):
+
+        return self.op_func(prepacked_weights, indices, offsets,
+                            mode=mode,
+                            per_sample_weights=per_sample_weights,
+                            include_last_offset=include_last_offset,
+                            pruned_weights=is_pruned_weights,
+                            compressed_indices_mapping=compressed_indices)
 
 
 class EmbedddingBagByteRowwiseOffsetsTest(op_bench.TorchBenchmarkBase):
@@ -181,11 +204,33 @@ class EmbedddingBagByteRowwiseOffsetsTest(op_bench.TorchBenchmarkBase):
         if self.is_pruned_weights:
             self.prepacked_weights, self.compressed_indices = get_pruned_weights_and_mapping(self.prepacked_weights)
 
+        self.inputs = {
+            "prepacked_weights": self.prepacked_weights,
+            "indices": self.indices,
+            "offsets": self.offsets,
+            "mode": 0,
+            "per_sample_weights": self.per_sample_weights,
+            "include_last_offset": self.include_last_offset,
+            "is_pruned_weights": self.is_pruned_weights,
+            "compressed_indices": self.compressed_indices
+        }
+
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.prepacked_weights, self.indices, self.offsets,
-                            mode=0, per_sample_weights=self.per_sample_weights,
+    def forward(
+        self,
+        prepacked_weights,
+        indices,
+        offsets,
+        mode: int,
+        per_sample_weights: Optional[torch.Tensor],
+        include_last_offset: bool,
+        is_pruned_weights: bool,
+        compressed_indices: Optional[torch.Tensor]
+    ):
+        return self.op_func(prepacked_weights, indices, offsets,
+                            mode=0,
+                            per_sample_weights=per_sample_weights,
                             include_last_offset=self.include_last_offset,
                             pruned_weights=self.is_pruned_weights,
                             compressed_indices_mapping=self.compressed_indices)

--- a/benchmarks/operator_benchmark/pt/qembedding_pack_test.py
+++ b/benchmarks/operator_benchmark/pt/qembedding_pack_test.py
@@ -35,21 +35,25 @@ unpack_ops = op_bench.op_list(
 
 class EmbeddingBagFloatToFusedBase(op_bench.TorchBenchmarkBase):
     def init(self, num_embeddings, embedding_dim, op_func):
-        self.weight = torch.from_numpy((np.random.random_sample((
-            num_embeddings, embedding_dim)) + 1).astype(np.float32))
+        self.inputs = {
+            "weight": torch.from_numpy((np.random.random_sample((
+                num_embeddings, embedding_dim)) + 1).astype(np.float32))
+        }
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.weight)
+    def forward(self, weight):
+        return self.op_func(weight)
 
 class EmbeddingBagFusedToFloatBase(op_bench.TorchBenchmarkBase):
     def init(self, num_embeddings, embedding_dim, op_func):
         weight = torch.randn(num_embeddings, embedding_dim + 8, dtype=torch.float)
-        self.packed_weight = weight.to(torch.uint8)
+        self.inputs = {
+            "packed_weight": weight.to(torch.uint8)
+        }
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.packed_weight)
+    def forward(self, packed_weight):
+        return self.op_func(packed_weight)
 
 
 op_bench.generate_pt_tests_from_op_list(conversion_ops,

--- a/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
@@ -20,10 +20,14 @@ class QEmbeddingBagBenchmark(op_bench.TorchBenchmarkBase):
         self.input = torch.tensor(numpy.random.randint(0, embeddingbags, input_size), device=device).long()
         offset = torch.LongTensor([offset], device=device)
         self.offset = torch.cat((offset, torch.tensor([self.input.size(0)], dtype=torch.long)), 0)
+        self.inputs = {
+            "input": self.input,
+            "offset": self.offset
+        }
         self.set_module_name('qEmbeddingBag')
 
-    def forward(self):
-        return self.embedding(self.input, self.offset)
+    def forward(self, input, offset):
+        return self.embedding(input, offset)
 
 
 op_bench.generate_pt_test(configs.embeddingbag_short_configs, QEmbeddingBagBenchmark)

--- a/benchmarks/operator_benchmark/pt/qinstancenorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qinstancenorm_test.py
@@ -22,19 +22,22 @@ class QInstanceNormBenchmark(op_bench.TorchBenchmarkBase):
         num_channels = dims[1]
         scale = 1.0
         zero_point = 0
-        self.qX = torch.quantize_per_tensor(
-            X, scale=scale, zero_point=zero_point, dtype=dtype)
-        self.weight = torch.rand(num_channels, dtype=torch.float)
-        self.bias = torch.rand(num_channels, dtype=torch.float)
-        self.eps = 1e-5
-        self.Y_scale = 0.1
-        self.Y_zero_point = 0
 
-    def forward(self):
+        self.inputs = {
+            "qX": torch.quantize_per_tensor(
+                X, scale=scale, zero_point=zero_point, dtype=dtype),
+            "weight": torch.rand(num_channels, dtype=torch.float),
+            "bias": torch.rand(num_channels, dtype=torch.float),
+            "eps": 1e-5,
+            "Y_scale": 0.1,
+            "Y_zero_point": 0
+        }
+
+    def forward(self, qX, weight, bias, eps: float, Y_scale: float, Y_zero_point: int):
         return torch.ops.quantized.instance_norm(
-            self.qX, weight=self.weight, bias=self.bias,
-            eps=self.eps, output_scale=self.Y_scale,
-            output_zero_point=self.Y_zero_point)
+            qX, weight=weight, bias=bias,
+            eps=eps, output_scale=Y_scale,
+            output_zero_point=Y_zero_point)
 
 
 op_bench.generate_pt_test(instancenorm_configs_short, QInstanceNormBenchmark)

--- a/benchmarks/operator_benchmark/pt/qinterpolate_test.py
+++ b/benchmarks/operator_benchmark/pt/qinterpolate_test.py
@@ -44,15 +44,18 @@ class QInterpolateBenchmark(op_bench.TorchBenchmarkBase):
                                                  dtype=dtype)
         if not contig:
             permute_dims = list(range(q_input.ndim))[::-1]
-            self.q_input_a = self.q_input_a.permute(permute_dims)
+            self.q_input = self.q_input.permute(permute_dims)
 
-        self.mode = mode
-        self.scale_factor = scale
+        self.inputs = {
+            "q_input": self.q_input,
+            "scale_factor": scale,
+            "mode": mode
+        }
         self.set_module_name('q_interpolate')
 
-    def forward(self):
-        return torch.nn.quantized.functional.interpolate(
-            self.q_input, scale_factor=self.scale_factor, mode=self.mode)
+    def forward(self, q_input, scale_factor: float, mode: str):
+        return torch.nn.functional.interpolate(
+            q_input, scale_factor=scale_factor, mode=mode)
 
 
 op_bench.generate_pt_test(qinterpolate_short_configs + qinterpolate_long_configs,

--- a/benchmarks/operator_benchmark/pt/qlayernorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qlayernorm_test.py
@@ -25,17 +25,21 @@ class QLayerNormBenchmark(op_bench.TorchBenchmarkBase):
         zero_point = 0
         self.qX = torch.quantize_per_tensor(
             X, scale=scale, zero_point=zero_point, dtype=dtype)
-        self.weight = torch.rand(*self.qX.size()[1:], dtype=torch.float)
-        self.bias = torch.rand(*self.qX.size()[1:], dtype=torch.float)
-        self.eps = 1e-5
-        self.Y_scale = 0.1
-        self.Y_zero_point = 0
 
-    def forward(self):
+        self.inputs = {
+            "qX": self.qX,
+            "weight": torch.rand(*self.qX.size()[1:], dtype=torch.float),
+            "bias": torch.rand(*self.qX.size()[1:], dtype=torch.float),
+            "eps": 1e-5,
+            "Y_scale": 0.1,
+            "Y_zero_point": 0
+        }
+
+    def forward(self, qX, weight, bias, eps: float, Y_scale: float, Y_zero_point: int):
         return torch.ops.quantized.layer_norm(
-            self.qX, self.qX.size()[1:], weight=self.weight, bias=self.bias,
-            eps=self.eps, output_scale=self.Y_scale,
-            output_zero_point=self.Y_zero_point)
+            qX, qX.size()[1:], weight=weight, bias=bias,
+            eps=eps, output_scale=Y_scale,
+            output_zero_point=Y_zero_point)
 
 
 op_bench.generate_pt_test(layernorm_configs_short, QLayerNormBenchmark)

--- a/benchmarks/operator_benchmark/pt/qlinear_test.py
+++ b/benchmarks/operator_benchmark/pt/qlinear_test.py
@@ -26,21 +26,25 @@ class _QLinearBenchmarkBase(op_bench.TorchBenchmarkBase):
         self.qlinear.scale = scale
         self.qlinear.zero_point = zero_point
 
-    def forward(self):
+    def forward(self, input):
         # Assume that the `self.input` is set in the child
-        return self.qlinear(self.input)
+        return self.qlinear(input)
 
 class QLinearBenchmark(_QLinearBenchmarkBase):
     def init(self, N, IN, OUT, device):
         super(QLinearBenchmark, self).init(N, IN, OUT, nnq.Linear(IN, OUT))
-        self.input = self.qX
+        self.inputs = {
+            "input": self.qX
+        }
         self.set_module_name("QLinear")
 
 
 class QDynamicLinearBenchmark(_QLinearBenchmarkBase):
     def init(self, N, IN, OUT, device):
         super(QDynamicLinearBenchmark, self).init(N, IN, OUT, nnqd.Linear(IN, OUT))
-        self.input = self.X
+        self.inputs = {
+            "input": self.X
+        }
         self.set_module_name("QDynamicLinear")
 
 

--- a/benchmarks/operator_benchmark/pt/qobserver_test.py
+++ b/benchmarks/operator_benchmark/pt/qobserver_test.py
@@ -104,19 +104,22 @@ q_hist_observer_list = op_bench.op_list(
 
 class QObserverBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, C, M, N, dtype, qscheme, op_func, device):
-        self.f_input = torch.rand(C, M, N, device=device)
+        self.inputs = {
+            "f_input": torch.rand(C, M, N, device=device)
+        }
         self.op_func = op_func(dtype=dtype, qscheme=qscheme).to(device)
 
-    def forward(self):
-        self.op_func(self.f_input)
-        self.op_func.calculate_qparams()
-        return
+    def forward(self, f_input):
+        self.op_func(f_input)
+        return self.op_func.calculate_qparams()
+
 
 class QObserverBenchmarkCalculateQparams(op_bench.TorchBenchmarkBase):
     def init(self, C, M, N, dtype, qscheme, op_func, device):
         self.f_input = torch.rand(C, M, N, device=device)
         self.q_observer = op_func(dtype=dtype, qscheme=qscheme).to(device)
         self.q_observer(self.f_input)
+        self.inputs = {}
 
     def forward(self):
         return self.q_observer.calculate_qparams()

--- a/benchmarks/operator_benchmark/pt/qpool_test.py
+++ b/benchmarks/operator_benchmark/pt/qpool_test.py
@@ -88,8 +88,12 @@ class _QPool2dBenchmarkBase(op_bench.TorchBenchmarkBase):
                 self.q_input = self.q_input.permute(0, 2, 3, 1).contiguous()
                 self.q_input = self.q_input.permute(0, 3, 1, 2)
 
-    def forward(self):
-        return self.pool_op(self.q_input)
+        self.inputs = {
+            "q_input": self.q_input
+        }
+
+    def forward(self, q_input):
+        return self.pool_op(q_input)
 
 
 class QMaxPool2dBenchmark(_QPool2dBenchmarkBase):

--- a/benchmarks/operator_benchmark/pt/qrnn_test.py
+++ b/benchmarks/operator_benchmark/pt/qrnn_test.py
@@ -45,20 +45,25 @@ class LSTMBenchmark(op_bench.TorchBenchmarkBase):
                                                         {nn.LSTM, nn.Linear},
                                                         dtype=dtype)[0]
 
-        self.x = torch.randn(sequence_len,  # sequence length
-                             batch_size,    # batch size
-                             I)             # Number of features in X
-        self.h = torch.randn(NL * (D + 1),  # layer_num * dir_num
-                             batch_size,    # batch size
-                             H)             # hidden size
-        self.c = torch.randn(NL * (D + 1),  # layer_num * dir_num
-                             batch_size,    # batch size
-                             H)             # hidden size
+        x = torch.randn(sequence_len,  # sequence length
+                        batch_size,    # batch size
+                        I)             # Number of features in X
+        h = torch.randn(NL * (D + 1),  # layer_num * dir_num
+                        batch_size,    # batch size
+                        H)             # hidden size
+        c = torch.randn(NL * (D + 1),  # layer_num * dir_num
+                        batch_size,    # batch size
+                        H)             # hidden size
 
+        self.inputs = {
+            "x": x,
+            "h": h,
+            "c": c
+        }
         self.set_module_name("QLSTM")
 
-    def forward(self):
-        return self.cell(self.x, (self.h, self.c))
+    def forward(self, x, h, c):
+        return self.cell(x, (h, c))[0]
 
 op_bench.generate_pt_test(qrnn_configs, LSTMBenchmark)
 

--- a/benchmarks/operator_benchmark/pt/qtensor_method_test.py
+++ b/benchmarks/operator_benchmark/pt/qtensor_method_test.py
@@ -22,16 +22,9 @@ qmethods_configs_long = op_bench.cross_product_configs(
     tags=['long']
 )
 
-qmethods_tensor_input_list = op_bench.op_list(
-    attr_names=['op_name', 'op_func'],
-    attrs=[
-        ['q_copy', 'copy_'],
-    ],
-)
-
 
 class _QMethodBenchmarkBase(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, dtype, contig, op_func):
+    def init(self, M, N, dtype, contig):
         f_input = torch.rand(M, N)
         scale = 1.0
         zero_point = 0
@@ -41,23 +34,20 @@ class _QMethodBenchmarkBase(op_bench.TorchBenchmarkBase):
         if not contig:
             permute_dims = list(range(self.q_input.ndim))[::-1]
             self.q_input = self.q_input.permute(permute_dims)
-        self.op_func = op_func
+
+        self.inputs = {
+            "q_input": self.q_input,
+        }
 
 
-class QMethodTensorInputBenchmark(_QMethodBenchmarkBase):
-    def forward(self):
-        getattr(self.q_input, self.op_func)(self.q_input)
+class QMethodTensorInputCopyBenchmark(_QMethodBenchmarkBase):
+    def forward(self, q_input):
+        return q_input.copy_(q_input)
 
 
-class QMethodNoInputBenchmark(_QMethodBenchmarkBase):
-    def forward(self):
-        getattr(self.q_input, self.op_func)()
-
-
-op_bench.generate_pt_tests_from_op_list(
-    qmethods_tensor_input_list,
+op_bench.generate_pt_test(
     qmethods_configs_short + qmethods_configs_long,
-    QMethodTensorInputBenchmark
+    QMethodTensorInputCopyBenchmark
 )
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/qunary_test.py
+++ b/benchmarks/operator_benchmark/pt/qunary_test.py
@@ -30,13 +30,15 @@ class QUnaryOpBenchmark(op_bench.TorchBenchmarkBase):
         f_input = torch.rand(M, N)
         scale = 1.0
         zero_point = 0
-        self.q_input = torch.quantize_per_tensor(f_input, scale=scale,
+        self.inputs = {
+            "q_input": torch.quantize_per_tensor(f_input, scale=scale,
                                                  zero_point=zero_point,
                                                  dtype=dtype)
+        }
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.q_input)
+    def forward(self, q_input):
+        return self.op_func(q_input)
 
 
 # TODO: Uncomment the ops whenever they are implemented for quantized tensor.
@@ -153,17 +155,19 @@ qunary_ops_topk_configs_long = op_bench.cross_product_configs(
 
 class QTopkOpBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, dtype, k):
-        self.k = k
         f_input = torch.rand(M, N)
         scale = 1.0
         zero_point = 0
-        self.q_input = torch.quantize_per_tensor(f_input, scale=scale,
+        self.inputs = {
+            "q_input": torch.quantize_per_tensor(f_input, scale=scale,
                                                  zero_point=zero_point,
-                                                 dtype=dtype)
+                                                 dtype=dtype),
+            "k": k
+        }
         self.set_module_name('qtopk')
 
-    def forward(self):
-        return torch.topk(self.q_input, self.k)
+    def forward(self, q_input, k: int):
+        return torch.topk(q_input, k)
 
 op_bench.generate_pt_test(qunary_ops_topk_configs_short + qunary_ops_topk_configs_long,
                           QTopkOpBenchmark)

--- a/benchmarks/operator_benchmark/pt/remainder_test.py
+++ b/benchmarks/operator_benchmark/pt/remainder_test.py
@@ -47,10 +47,15 @@ class RemainderOpBenchmark(op_bench.TorchBenchmarkBase):
         # +1 so we don't divide by zero
         self.divisor = (self.divisor * 40 + 1).to(dtype=dtype)
 
+        self.inputs = {
+            "dividend": self.dividend,
+            "divisor": self.divisor
+        }
+
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.dividend, self.divisor)
+    def forward(self, dividend, divisor):
+        return self.op_func(dividend, divisor)
 
 
 op_bench.generate_pt_tests_from_op_list(remainder_ops_list,

--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -47,11 +47,13 @@ softmax_ops_list = op_bench.op_list(
 
 class SoftmaxBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, C, H, W, device, op_func):
-        self.input_one = torch.rand(N, C, H, W, device=device)
+        self.inputs = {
+            "input": torch.rand(N, C, H, W, device=device)
+        }
         self.op_func = op_func()
 
-    def forward(self):
-        return self.op_func(self.input_one)
+    def forward(self, input):
+        return self.op_func(input)
 
 
 op_bench.generate_pt_tests_from_op_list(softmax_ops_list,

--- a/benchmarks/operator_benchmark/pt/split_test.py
+++ b/benchmarks/operator_benchmark/pt/split_test.py
@@ -30,12 +30,14 @@ split_configs_long = op_bench.cross_product_configs(
 
 class SplitBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, parts, device):
-        self.input_one = torch.rand(M, N, device=device)
-        self.split_size = int(M * N / parts)
+        self.inputs = {
+            "input": torch.rand(M, N, device=device),
+            "split_size": int(M * N / parts)
+        }
         self.set_module_name('split')
 
-    def forward(self):
-        return torch.split(self.input_one, self.split_size)
+    def forward(self, input, split_size: int):
+        return torch.split(input, split_size)
 
 
 op_bench.generate_pt_test(split_configs_short + split_configs_long,

--- a/benchmarks/operator_benchmark/pt/sum_test.py
+++ b/benchmarks/operator_benchmark/pt/sum_test.py
@@ -33,11 +33,14 @@ class SumBenchmark(op_bench.TorchBenchmarkBase):
         else:
             self.input_tensor = tensor
 
-        self.dim = dim
+        self.inputs = {
+            "input_tensor": self.input_tensor,
+            "dim": dim
+        }
         self.set_module_name("sum")
 
-    def forward(self):
-        return self.input_tensor.sum(dim=self.dim)
+    def forward(self, input_tensor, dim: int):
+        return input_tensor.sum(dim=dim)
 
 op_bench.generate_pt_test(sum_configs, SumBenchmark)
 

--- a/benchmarks/operator_benchmark/pt/tensor_to_test.py
+++ b/benchmarks/operator_benchmark/pt/tensor_to_test.py
@@ -17,17 +17,21 @@ tensor_conversion_long_configs = op_bench.cross_product_configs(
 
 class FloatToHalfTensorConversionBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, device):
-        self.input = torch.rand(M, N, device=device, requires_grad=False, dtype=torch.float)
+        self.inputs = {
+            "input": torch.rand(M, N, device=device, requires_grad=False, dtype=torch.float)
+        }
 
-    def forward(self):
-        return self.input.to(torch.half)
+    def forward(self, input):
+        return input.to(torch.half)
 
 class HalfToFloatTensorConversionBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, device):
-        self.input = torch.rand(M, N, device=device, requires_grad=False, dtype=torch.half)
+        self.inputs = {
+            "input": torch.rand(M, N, device=device, requires_grad=False, dtype=torch.half)
+        }
 
-    def forward(self):
-        return self.input.to(torch.float)
+    def forward(self, input):
+        return input.to(torch.float)
 
 
 op_bench.generate_pt_test(tensor_conversion_short_configs, FloatToHalfTensorConversionBenchmark)

--- a/benchmarks/operator_benchmark/pt/unary_test.py
+++ b/benchmarks/operator_benchmark/pt/unary_test.py
@@ -27,12 +27,43 @@ unary_ops_configs_long = op_bench.cross_product_configs(
 
 class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, M, N, device, op_func):
-        self.input_one = torch.rand(M, N, device=device)
+        self.inputs = {
+            "input": torch.rand(M, N, device=device)
+        }
         self.op_func = op_func
 
-    def forward(self):
-        return self.op_func(self.input_one)
+    def forward(self, input):
+        return self.op_func(input)
 
+def bernoulli_(input):
+    return input.bernoulli_()
+
+def cauchy_(input):
+    return input.cauchy_()
+
+def digamma_(input):
+    return input.digamma_()
+
+def exponential_(input):
+    return input.exponential_()
+
+def normal_(input):
+    return input.normal_()
+
+def random_(input):
+    return input.random_()
+
+def sign_(input):
+    return input.sign_()
+
+def uniform_(input):
+    return input.uniform_()
+
+def half_(input):
+    return input.half()
+
+def long_(input):
+    return input.long()
 
 unary_ops_list = op_bench.op_list(
     attr_names=['op_name', 'op_func'],
@@ -105,18 +136,18 @@ unary_ops_list = op_bench.op_list(
         ['tanh_', torch.tanh_],
         ['trunc', torch.trunc],
         ['trunc_', torch.trunc_],
-        ['unique', torch.unique],
+        ['unique', torch.functional._return_output],
         ['zero_', torch.zero_],
-        ['bernoulli_', lambda t: t.bernoulli_()],
-        ['cauchy_', lambda t: t.cauchy_()],
-        ['digamma_', lambda t: t.digamma_()],
-        ['exponential_', lambda t: t.exponential_()],
-        ['normal_', lambda t: t.normal_()],
-        ['random_', lambda t: t.random_()],
-        ['sign_', lambda t: t.sign_()],
-        ['uniform_', lambda t: t.uniform_()],
-        ['half', lambda t: t.half()],
-        ['long', lambda t: t.long()],
+        ['bernoulli_', bernoulli_],
+        ['cauchy_', cauchy_],
+        ['digamma_', digamma_],
+        ['exponential_', exponential_],
+        ['normal_', normal_],
+        ['random_', random_],
+        ['sign_', sign_],
+        ['uniform_', uniform_],
+        ['half', half_],
+        ['long', long_],
     ],
 )
 

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -394,7 +394,7 @@ def max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1,
     return torch.nn.functional.max_pool2d(input, kernel_size, stride, padding,
                                           dilation, ceil_mode, return_indices)
 
-def celu(input: Tensor, scale: float, zero_point: int, alpha: Optional[float] = 1.) -> Tensor:
+def celu(input: Tensor, scale: float, zero_point: int, alpha: float = 1.) -> Tensor:
     r"""celu(input, scale, zero_point, alpha=1.) -> Tensor
 
     Applies the quantized CELU function element-wise.
@@ -411,7 +411,7 @@ def celu(input: Tensor, scale: float, zero_point: int, alpha: Optional[float] = 
 
 
 def leaky_relu(input: Tensor, negative_slope: float = 0.01, inplace: bool = False,
-               scale: float = None, zero_point: int = None):
+               scale: Optional[float] = None, zero_point: Optional[int] = None):
     r"""
     Quantized version of the.
     leaky_relu(input, negative_slope=0.01, inplace=False, scale, zero_point) -> Tensor


### PR DESCRIPTION
Summary:
This diff implements the functionality of running benchmark on mobile on top of operator_benchmark framework. It does so through a few steps:

1. create a scripted module from existing benchmark case.
2. run mobile specific optimization pass on the scripted module
3. run the scripted module on AiBench by calling its Python API

A small change in the way of writing a benchmark case is introduced so that both local and mobile run can share the same interface. The change is about having inputs as arguments of the `forward` function, so that mobile optimization pass can be run successfully (otherwise everything will be optimized away by constant propagation).

Test Plan:
## local op_bench run

buck run caffe2/benchmarks/operator_benchmark/pt:add_test -- --use_jit

## saved module graph
```
module __torch__.mobile_benchmark_utils.OpBenchmarkMobile {
  parameters {
  }
  attributes {
    training = True
    num_iters = 1
    benchmark = <__torch__.pt.add_test.___torch_mangle_4.AddBenchmark object at 0x6070001b8b50>
  }
  methods {
    method forward {
      graph(%self : __torch__.mobile_benchmark_utils.OpBenchmarkMobile):
        %12 : None = prim::Constant() # /data/users/wangyang19/fbsource/fbcode/buck-out/dev/gen/caffe2/benchmarks/operator_benchmark/fb/pt/mobile/benchmark_all_test_fbcode#link-tree/mobile_benchmark_utils.py:9:4
        %4 : bool = prim::Constant[value=1]() # /data/users/wangyang19/fbsource/fbcode/buck-out/dev/gen/caffe2/benchmarks/operator_benchmark/fb/pt/mobile/benchmark_all_test_fbcode#link-tree/mobile_benchmark_utils.py:10:8
        %1 : int = prim::GetAttr[name="num_iters"](%self)
         = prim::Loop(%1, %4) # /data/users/wangyang19/fbsource/fbcode/buck-out/dev/gen/caffe2/benchmarks/operator_benchmark/fb/pt/mobile/benchmark_all_test_fbcode#link-tree/mobile_benchmark_utils.py:10:8
          block0(%i : int):
            %6 : __torch__.pt.add_test.___torch_mangle_4.AddBenchmark = prim::GetAttr[name="benchmark"](%self)
            %7 : __torch__.pt.add_test.___torch_mangle_4.AddBenchmark = prim::GetAttr[name="benchmark"](%self)
            %self.inputs_tuple : (Float(1, 1, 1, strides=[1, 1, 1], requires_grad=0, device=cpu), Float(1, 1, 1, strides=[1, 1, 1], requires_grad=0, device=cpu)) = prim::Constant[value=({0.48884}, {0.809042})]()
            %9 : Tensor, %10 : Tensor = prim::TupleUnpack(%self.inputs_tuple)
            %23 : int = prim::Constant[value=1]()
            %24 : Tensor = aten::add(%9, %10, %23) # /data/users/wangyang19/fbsource/fbcode/buck-out/dev/gen/caffe2/benchmarks/operator_benchmark/fb/pt/mobile/benchmark_all_test_fbcode#link-tree/pt/add_test.py:39:15
            -> (%4)
        return (%12)

    }
  }
  submodules {
    module __torch__.pt.add_test.___torch_mangle_4.AddBenchmark {
      parameters {
      }
      attributes {
        mobile_optimized = True
      }
      methods {
        method forward {
          graph(%self : __torch__.pt.add_test.___torch_mangle_4.AddBenchmark,
                %input_one.1 : Tensor,
                %input_two.1 : Tensor):
            %3 : int = prim::Constant[value=1]()
            %4 : Tensor = aten::add(%input_one.1, %input_two.1, %3) # /data/users/wangyang19/fbsource/fbcode/buck-out/dev/gen/caffe2/benchmarks/operator_benchmark/fb/pt/mobile/benchmark_all_test_fbcode#link-tree/pt/add_test.py:39:15
            return (%4)

        }
        method get_inputs {
          graph(%self : __torch__.pt.add_test.___torch_mangle_4.AddBenchmark):
            %self.inputs_tuple : (Float(1, 1, 1, strides=[1, 1, 1], requires_grad=0, device=cpu), Float(1, 1, 1, strides=[1, 1, 1], requires_grad=0, device=cpu)) = prim::Constant[value=({0.48884}, {0.809042})]()
            return (%self.inputs_tuple)

        }
      }
      submodules {
      }
    }
  }
}

```

Differential Revision: D24322214

