### PR TITLE
Properly serialize types that only appear at function input

### DIFF
--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1275,11 +1275,9 @@ struct PythonPrintImpl {
     }
 
     const auto& returnType = schema.returns().at(0).type();
-
-    body_ << ") -> "
-          << returnType->annotation_str(type_printer_)
-          << ":\n";
+    body_ << ") -> " << returnType->annotation_str(type_printer_) << ":\n";
     registerClassDependencies(returnType);
+
     printBody(graph.block());
   }
 

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1276,6 +1276,9 @@ struct PythonPrintImpl {
     body_ << ") -> "
           << schema.returns().at(0).type()->annotation_str(type_printer_)
           << ":\n";
+    for (const Value* input : graph.inputs()) {
+      registerClassDependencies(input->type());
+    }
     printBody(graph.block());
   }
 

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1255,6 +1255,7 @@ struct PythonPrintImpl {
     body_ << "def " << func.name() << "(";
     auto param_it = graph.inputs().begin();
     for (const Argument& arg : schema.arguments()) {
+      registerClassDependencies(arg.type());
       std::string arg_name = genName(arg.name());
       if (param_it == graph.inputs().begin()) {
         // the first argument may omit its type when it is implied by context
@@ -1273,12 +1274,12 @@ struct PythonPrintImpl {
       assignValue(*param_it++, arg_name);
     }
 
+    const auto& returnType = schema.returns().at(0).type();
+
     body_ << ") -> "
-          << schema.returns().at(0).type()->annotation_str(type_printer_)
+          << returnType->annotation_str(type_printer_)
           << ":\n";
-    for (const Value* input : graph.inputs()) {
-      registerClassDependencies(input->type());
-    }
+    registerClassDependencies(returnType);
     printBody(graph.block());
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47775 Properly serialize types that only appear at function input**

When serializing graphs, we check every node for named types referenced,
so that we can register them as dependencies. We were skipping this
check for the graph inputs themselves. Since types used at input are
almost always used somewhere in the graph, we never noticed this gap
until a user reported an issue with NamedTuples.

Differential Revision: [D24896289](https://our.internmc.facebook.com/intern/diff/D24896289)