### PR TITLE
[PyTorch] Remove unnecessary shared_ptr copies in ThreadLocalDebugInfo::get

### DIFF
--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -9,12 +9,12 @@ thread_local std::shared_ptr<ThreadLocalDebugInfo> debug_info = nullptr;
 /* static */
 std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::get(
     DebugInfoKind kind) {
-  auto cur = debug_info;
+  ThreadLocalDebugInfo* cur = debug_info.get();
   while (cur) {
     if (cur->kind_ == kind) {
       return cur->info_;
     }
-    cur = cur->parent_info_;
+    cur = cur->parent_info_.get();
   }
   return nullptr;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47791 [PyTorch] Remove unnecessary shared_ptr copies in ThreadLocalDebugInfo::get**

`debug_info` is `thread_local` and this function is a leaf, so nobody else could free it out from under us. Regular pointer should be fine.

Differential Revision: [D24901749](https://our.internmc.facebook.com/intern/diff/D24901749/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24901749/)!