### PR TITLE
Add LeakyReLU operator to static runtime

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -40,8 +40,7 @@ const std::string trivial_model_1 = R"JIT(
 
 const std::string leaky_relu_model = R"JIT(
   def forward(self, input):
-      m = torch.LeakyReLU(0.1)
-      return m(input)
+      return torch.leaky_relu(input, 0.1)
 )JIT";
 
 

--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -38,6 +38,13 @@ const std::string trivial_model_1 = R"JIT(
       return a + b * c + s
 )JIT";
 
+const std::string leaky_relu_model = R"JIT(
+  def forward(self, input):
+      m = torch.LeakyReLU(0.1)
+      return m(input)
+)JIT";
+
+
 void import_libs(
     std::shared_ptr<at::CompilationUnit> cu,
     const std::string& class_name,
@@ -79,5 +86,11 @@ torch::jit::Module getDeepAndWideSciptModel(int num_features) {
 torch::jit::Module getTrivialScriptModel() {
   torch::jit::Module module("m");
   module.define(trivial_model_1);
+  return module;
+}
+
+torch::jit::Module getLeakyReLUScriptModel() {
+  torch::jit::Module module("leaky_relu");
+  module.define(leaky_relu_model);
   return module;
 }

--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -49,11 +49,11 @@ const std::string leaky_relu_model_const = R"JIT(
 
 const std::string leaky_relu_model = R"JIT(
   def forward(self, input, neg_slope):
-      x = torch.leaky_relu(input, neg_slope[0])
-      x = torch.leaky_relu(x, neg_slope[0])
-      x = torch.leaky_relu(x, neg_slope[0])
-      x = torch.leaky_relu(x, neg_slope[0])
-      return torch.leaky_relu(x, neg_slope[0])
+      x = torch.leaky_relu(input, neg_slope)
+      x = torch.leaky_relu(x, neg_slope)
+      x = torch.leaky_relu(x, neg_slope)
+      x = torch.leaky_relu(x, neg_slope)
+      return torch.leaky_relu(x, neg_slope)
 )JIT";
 
 

--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -40,7 +40,11 @@ const std::string trivial_model_1 = R"JIT(
 
 const std::string leaky_relu_model = R"JIT(
   def forward(self, input):
-      return torch.leaky_relu(input, 0.1)
+      x = torch.leaky_relu(input, 0.1)
+      x = torch.leaky_relu(x, 0.1)
+      x = torch.leaky_relu(x, 0.1)
+      x = torch.leaky_relu(x, 0.1)
+      return torch.leaky_relu(x, 0.1)
 )JIT";
 
 

--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -38,13 +38,22 @@ const std::string trivial_model_1 = R"JIT(
       return a + b * c + s
 )JIT";
 
-const std::string leaky_relu_model = R"JIT(
+const std::string leaky_relu_model_const = R"JIT(
   def forward(self, input):
       x = torch.leaky_relu(input, 0.1)
       x = torch.leaky_relu(x, 0.1)
       x = torch.leaky_relu(x, 0.1)
       x = torch.leaky_relu(x, 0.1)
       return torch.leaky_relu(x, 0.1)
+)JIT";
+
+const std::string leaky_relu_model = R"JIT(
+  def forward(self, input, neg_slope):
+      x = torch.leaky_relu(input, neg_slope[0])
+      x = torch.leaky_relu(x, neg_slope[0])
+      x = torch.leaky_relu(x, neg_slope[0])
+      x = torch.leaky_relu(x, neg_slope[0])
+      return torch.leaky_relu(x, neg_slope[0])
 )JIT";
 
 
@@ -95,5 +104,11 @@ torch::jit::Module getTrivialScriptModel() {
 torch::jit::Module getLeakyReLUScriptModel() {
   torch::jit::Module module("leaky_relu");
   module.define(leaky_relu_model);
+  return module;
+}
+
+torch::jit::Module getLeakyReLUConstScriptModel() {
+  torch::jit::Module module("leaky_relu_const");
+  module.define(leaky_relu_model_const);
   return module;
 }

--- a/benchmarks/static_runtime/deep_wide_pt.h
+++ b/benchmarks/static_runtime/deep_wide_pt.h
@@ -130,3 +130,5 @@ struct DeepAndWideFast : torch::nn::Module {
 torch::jit::Module getDeepAndWideSciptModel(int num_features = 50);
 
 torch::jit::Module getTrivialScriptModel();
+
+torch::jit::Module getLeakyReLUScriptModel();

--- a/benchmarks/static_runtime/deep_wide_pt.h
+++ b/benchmarks/static_runtime/deep_wide_pt.h
@@ -132,3 +132,5 @@ torch::jit::Module getDeepAndWideSciptModel(int num_features = 50);
 torch::jit::Module getTrivialScriptModel();
 
 torch::jit::Module getLeakyReLUScriptModel();
+
+torch::jit::Module getLeakyReLUConstScriptModel();

--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -118,8 +118,7 @@ static void BM_leaky_relu(benchmark::State& state) {
   auto g = torch::jit::PrepareForStaticRuntime(mod);
   torch::jit::StaticRuntime runtime(g);
 
-  const int batch_size = state.range(0);
-  auto data = torch::randn({batch_size, num_features});
+  auto data = torch::randn({num_features, num_features});
 
   std::vector<IValue> inputs({data});
 

--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -120,11 +120,11 @@ static void BM_leaky_relu(benchmark::State& state) {
 
   const int batch_size = state.range(0);
   auto data = torch::randn({batch_size, num_features});
-  std::vector<IValue> inputs({data});
+  std::vector<at::Tensor> inputs({data});
 
-  mod.forward(inputs);
+  runtime.run(inputs);
   for (auto _ : state) {
-    mod.forward(inputs);
+    runtime.run(inputs);
   }
 }
 

--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -134,9 +134,9 @@ static void BM_leaky_relu(benchmark::State& state) {
   torch::jit::StaticRuntime runtime(g);
 
   const int batch_size = state.range(0);
-  auto neg_slope = torch::randn({1});
+  auto neg_slope = torch::randn(1);
   auto data = torch::randn({batch_size, num_features});
-  std::vector<at::Tensor> inputs({data, neg_slope});
+  std::vector<at::Tensor> inputs({data, neg_slope[0]});
 
   runtime.run(inputs);
   for (auto _ : state) {

--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -118,8 +118,8 @@ static void BM_leaky_relu(benchmark::State& state) {
   auto g = torch::jit::PrepareForStaticRuntime(mod);
   torch::jit::StaticRuntime runtime(g);
 
-  auto data = torch::randn({num_features, num_features});
-
+  const int batch_size = state.range(0);
+  auto data = torch::randn({batch_size, num_features});
   std::vector<IValue> inputs({data});
 
   mod.forward(inputs);
@@ -128,7 +128,7 @@ static void BM_leaky_relu(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_leaky_relu);
+BENCHMARK(BM_leaky_relu)->RangeMultiplier(8)->Ranges({{1, 20}});
 BENCHMARK(BM_deep_wide_base)->RangeMultiplier(8)->Ranges({{1, 20}});
 BENCHMARK(BM_deep_wide_fast)->RangeMultiplier(8)->Ranges({{1, 20}});
 

--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -113,6 +113,23 @@ static void BM_deep_wide_static_threaded(benchmark::State& state) {
   }
 }
 
+static void BM_leaky_relu(benchmark::State& state) {
+  auto mod = getLeakyReLUScriptModel();
+  auto g = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(g);
+
+  const int batch_size = state.range(0);
+  auto data = torch::randn({batch_size, num_features});
+
+  std::vector<IValue> inputs({data});
+
+  mod.forward(inputs);
+  for (auto _ : state) {
+    mod.forward(inputs);
+  }
+}
+
+BENCHMARK(BM_leaky_relu);
 BENCHMARK(BM_deep_wide_base)->RangeMultiplier(8)->Ranges({{1, 20}});
 BENCHMARK(BM_deep_wide_fast)->RangeMultiplier(8)->Ranges({{1, 20}});
 

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -20,6 +20,22 @@ TEST(StaticRuntime, TrivialModel) {
   EXPECT_TRUE(output_1.equal(output_2));
 }
 
+TEST(StaticRuntime, LeakyReLU) {
+  torch::jit::Module mod = getLeakyReLUScriptModel();
+  auto inputs = torch::randn({2, 2});
+
+  // run jit graph executor
+  std::vector<at::IValue> input_ivalues({inputs});
+  at::Tensor output_1 = mod.forward(input_ivalues).toTensor();
+
+  // run static runtime
+  std::vector<at::Tensor> input_tensors({inputs});
+  auto g = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(g);
+  at::Tensor output_2 = runtime.run(input_tensors)[0];
+  EXPECT_TRUE(output_1.equal(output_2));
+}
+
 static at::Tensor getTensor(const at::IValue &ival) {
   if (ival.isTensor()) {
     return ival.toTensor();

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -21,7 +21,7 @@ TEST(StaticRuntime, TrivialModel) {
 }
 
 TEST(StaticRuntime, LeakyReLU) {
-  torch::jit::Module mod = getLeakyReLUScriptModel();
+  torch::jit::Module mod = getLeakyReLUConstScriptModel();
   auto inputs = torch::randn({2, 2});
 
   // run jit graph executor

--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -196,7 +196,7 @@ class TestStaticRuntime(TestCase):
         torch.testing.assert_allclose(o_ref, o_test)
 
     def test_leaky_relu(self):
-        s = torch.randn(5,5)
+        s = torch.randn(5, 5)
         tg = torch.jit.script(nn.LeakyReLU(0.1))
         o_ref = tg(s)
         tg_a = StaticRuntime(tg)

--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -195,6 +195,13 @@ class TestStaticRuntime(TestCase):
         o_test = tg_a(s, s, s)[0]
         torch.testing.assert_allclose(o_ref, o_test)
 
+    def test_leaky_relu(self):
+        s = torch.full((2, 2), 2)
+        tg = torch.jit.script(nn.LeakyReLU(0.1))
+        o_ref = tg(s)
+        tg_a = StaticRuntime(tg)
+        o_test = tg_a(s)[0]
+        torch.testing.assert_allclose(o_ref, o_test)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -196,7 +196,7 @@ class TestStaticRuntime(TestCase):
         torch.testing.assert_allclose(o_ref, o_test)
 
     def test_leaky_relu(self):
-        s = torch.full((2, 2), 2)
+        s = torch.randn(5,5)
         tg = torch.jit.script(nn.LeakyReLU(0.1))
         o_ref = tg(s)
         tg_a = StaticRuntime(tg)

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -112,22 +112,22 @@ getOutOfPlaceOperation(Node* n) {
     if (in1) {
       auto in1_s = in1->toScalar();
       return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      if (p_node->Output(0, reg).isNone()) {
-        p_node->Output(0, reg) = create_empty_from(in0_t);
-      }
-      auto out_t = p_node->Output(0, reg).toTensor();
-      at::native::leaky_relu_out(out_t, in0_t, in1_s);
+        auto in0_t = p_node->Input(0, reg).toTensor();
+        if (p_node->Output(0, reg).isNone()) {
+          p_node->Output(0, reg) = create_empty_from(in0_t);
+        }
+        auto out_t = p_node->Output(0, reg).toTensor();
+        at::native::leaky_relu_out(out_t, in0_t, in1_s);
       };
     } else {
       return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_s = p_node->Input(1, reg).toScalar();
-      if (p_node->Output(0, reg).isNone()) {
-        p_node->Output(0, reg) = create_empty_from(in0_t);
-      }
-      auto out_t = p_node->Output(0, reg).toTensor();
-      at::native::leaky_relu_out(out_t, in0_t, in1_s);
+        auto in0_t = p_node->Input(0, reg).toTensor();
+        auto in1_s = p_node->Input(1, reg).toScalar();
+        if (p_node->Output(0, reg).isNone()) {
+          p_node->Output(0, reg) = create_empty_from(in0_t);
+        }
+        auto out_t = p_node->Output(0, reg).toTensor();
+        at::native::leaky_relu_out(out_t, in0_t, in1_s);
       };
     }
   }

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -16,7 +16,7 @@ bool canRunOutOfPlace(Node* n) {
                                                             "aten::addmm",
                                                             "aten::bmm",
                                                             "aten::sigmoid",
-                                                            "aten::leaky_relu"
+                                                            "aten::leaky_relu",
                                                             "aten::cat"};
   auto str = std::string(n->kind().toQualString());
   return out_of_place_nodes.count(str) > 0;

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -26,6 +26,7 @@ getNativeOperation(Node* n);
   F(aten::flatten)       \
   F(aten::index_put_)    \
   F(aten::isnan)         \
+  F(aten::leaky_relu)    \
   F(aten::matmul)        \
   F(aten::mul)           \
   F(aten::permute)       \


### PR DESCRIPTION
- Add LeakyReLU operator to static runtime
- Add LeakyReLU benchmark
- Add LeakyReLU correctness test case

Static Runtime
```
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_leaky_relu/1                              4092 ns       4092 ns     172331
BM_leaky_relu/8                              4425 ns       4425 ns     158434
BM_leaky_relu/20                             4830 ns       4830 ns     145335
BM_leaky_relu_const/1                        3545 ns       3545 ns     198054
BM_leaky_relu_const/8                        3825 ns       3825 ns     183074
BM_leaky_relu_const/20                       4222 ns       4222 ns     165999
```

Interpreter
```
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_leaky_relu/1                              7183 ns       7182 ns      96377
BM_leaky_relu/8                              7580 ns       7580 ns      91588
BM_leaky_relu/20                             8066 ns       8066 ns      87183
BM_leaky_relu_const/1                        6466 ns       6466 ns     107925
BM_leaky_relu_const/8                        7063 ns       7063 ns      98768
BM_leaky_relu_const/20                       7380 ns       7380 ns      94564
```