### PR TITLE
[quant][refactor] Moving the 'quantization/fx/utils.py' to 'quantization/utils.py'

### DIFF
--- a/torch/quantization/__init__.py
+++ b/torch/quantization/__init__.py
@@ -6,7 +6,6 @@ from .fuse_modules import fuse_modules
 from .stubs import *
 from .quant_type import *
 from .quantize_jit import *
-# from .quantize_fx import *
 from .quantization_mappings import *
 from .fuser_method_mappings import *
 

--- a/torch/quantization/fx/fusion_patterns.py
+++ b/torch/quantization/fx/fusion_patterns.py
@@ -2,7 +2,7 @@ import torch
 from .pattern_utils import (
     register_fusion_pattern,
 )
-from .utils import _parent_name
+from ..utils import _parent_name
 from ..fuser_method_mappings import get_fuser_method
 
 # ---------------------

--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -16,7 +16,7 @@ from ..quantization_mappings import (
 from .pattern_utils import (
     register_quant_pattern,
 )
-from .utils import (
+from ..utils import (
     _parent_name,
     quantize_node,
     get_per_tensor_qparams,

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -39,7 +39,7 @@ from .observed_module import (
 
 from .quantization_patterns import *
 
-from .utils import (
+from ..utils import (
     _parent_name,
     quantize_node,
     get_custom_module_class_keys,

--- a/torch/quantization/utils.py
+++ b/torch/quantization/utils.py
@@ -1,6 +1,7 @@
 import re
 import torch
-from ..quant_type import QuantType, quant_type_to_str
+
+from .quant_type import QuantType, quant_type_to_str
 
 # turn foo.bar -> ['foo', 'bar']
 def _parent_name(target):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #46229 [quant] Statically quantized LSTM
* #47802 [quant][refactor] Adding fx to the 'quantization/__init__.py' to enable module import
* **#47801 [quant][refactor] Moving the 'quantization/fx/utils.py' to 'quantization/utils.py'**
* #47730 [quant] Add another keyword to the 'prepare_custom_config_dict' to be the same as in FX

This file has more "generic" utilities, and if we try to use it from the parent, it will cause circular dependency error.