### PR TITLE
[Segmentation] Convert the C2 model to PyTorch

### DIFF
--- a/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
+++ b/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
@@ -82,6 +82,13 @@ c10::intrusive_ptr<Conv2dOpContext> conv2d_prepack(
     c10::optional<Scalar> output_min,
     c10::optional<Scalar> output_max) {
   TORCH_CHECK(weight.dim() == 4);
+  if(weight.sizes()[1] >= 12 && weight.sizes()[0] >= 12){
+    std::cout<<"conv2d_prepacking: "<<weight.sizes()<<std::endl;
+    std::tuple<double, int64_t> qp =
+      at::_choose_qparams_per_tensor(std::move(weight), false);
+    weight = at::quantize_per_tensor(
+      std::move(weight), std::get<0>(qp), std::get<1>(qp), c10::kQUInt8);
+  }
   return c10::make_intrusive<Conv2dOpContext>(
       std::move(weight),
       std::move(bias),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47804 [Segmentation] Convert the C2 model to PyTorch**
* #47733 [Person Seg] Compress the person seg model
* #47635 [GPU] Enable Metal on macosx
* #47634 [GPU] Make permuteWeights inline

This script converts the person and hair segmentation model (HE) from Caffe2 to PyTorch. The original caffe2 models are

- v106 for person segmentation
- v1 for hair segmentation

Commands

-  `buck run segmentation:converter --  --type person`
-  `buck run segmentation:converter --  --type hair`

By default, the results are saved under

- `/mnt/vol/gfsai-east/ai-group/datasets/aidenxu/tmp/Debug/taox/person_seg/pytorch/gpu`
- `/mnt/vol/gfsai-east/ai-group/datasets/aidenxu/tmp/Debug/taox/hair_seg/pytorch/gpu`

Differential Revision: [D24560110](https://our.internmc.facebook.com/intern/diff/D24560110/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24560110/)!