### PR TITLE
Refactor request_callback_no_python.cpp processRpc function

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -148,11 +148,12 @@ std::unique_ptr<RpcCommandBase> RequestCallbackImpl::
 }
 
 void RequestCallbackImpl::processScriptCall(
-    ScriptCall& scriptCall,
+    RpcCommandBase& rpc,
     const std::function<void(Message)>& markComplete,
-    std::vector<at::IValue>& stack,
     const int64_t messageId,
     const std::shared_ptr<FutureMessage>& responseFuture) const {
+  auto& scriptCall = static_cast<ScriptCall&>(rpc);
+  auto& stack = scriptCall.stackRef();
   if (processScriptCallOp(scriptCall, markComplete, stack)) {
     return;
   }

--- a/torch/csrc/distributed/rpc/request_callback_impl.h
+++ b/torch/csrc/distributed/rpc/request_callback_impl.h
@@ -21,9 +21,8 @@ class TORCH_API RequestCallbackImpl : public RequestCallbackNoPython {
       const std::shared_ptr<FutureMessage>& responseFuture) const override;
 
   void processScriptCall(
-      ScriptCall& scriptCall,
+      RpcCommandBase& rpc,
       const std::function<void(Message)>& markComplete,
-      std::vector<at::IValue>& stack,
       const int64_t messageId,
       const std::shared_ptr<FutureMessage>& responseFuture) const override;
 

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -119,11 +119,12 @@ void RequestCallbackNoPython::processRpcWithErrors(
 }
 
 void RequestCallbackNoPython::processScriptCall(
-    ScriptCall& scriptCall,
+    RpcCommandBase& rpc,
     const std::function<void(Message)>& markComplete,
-    std::vector<at::IValue>& stack,
     const int64_t messageId,
     const std::shared_ptr<FutureMessage>& responseFuture) const {
+  auto& scriptCall = static_cast<ScriptCall&>(rpc);
+  auto& stack = scriptCall.stackRef();
   TORCH_CHECK(
       scriptCall.hasOp(), "Only supports the case where ScriptCall has an op");
   processScriptCallOp(scriptCall, markComplete, stack);
@@ -171,21 +172,60 @@ void RequestCallbackNoPython::processPythonRemoteCall(
   C10_THROW_ERROR(Error, "Python call not supported!");
 }
 
-void RequestCallbackNoPython::processRRefBackward(
-      RpcCommandBase& rpc,
-      const int64_t messageId,
-      const std::shared_ptr<FutureMessage>& responseFuture) const {
-  C10_THROW_ERROR(Error, "Python call not supported!");
-}
-
 void RequestCallbackNoPython::processScriptRemoteCall(
     ScriptRemoteCall& scriptRemoteCall,
     const std::function<void(void)>& postProcessing,
     std::vector<at::IValue>& stack,
     const c10::intrusive_ptr<OwnerRRef>& ownerRRef) const {
   TORCH_CHECK(
-      scriptRemoteCall.hasOp(), "ScriptRemoteCall needs to have an op!");
+    scriptRemoteCall.hasOp(), "ScriptRemoteCall needs to have an op!");
   processScriptRemoteCallOp(scriptRemoteCall, postProcessing, stack, ownerRRef);
+}
+
+void RequestCallbackNoPython::processBaseScriptRemoteCall(
+    RpcCommandBase& rpc,
+    const std::function<void(Message)>& markComplete,
+    const int64_t messageId,
+    const std::shared_ptr<FutureMessage>& responseFuture) const {
+  auto& scriptRemoteCall = static_cast<ScriptRemoteCall&>(rpc);
+  auto rrefId = scriptRemoteCall.retRRefId();
+  auto forkId = scriptRemoteCall.retForkId();
+  auto& ctx = RRefContext::getInstance();
+
+  auto postProcessing = [rrefId, forkId, messageId, responseFuture]() {
+    if (rrefId != forkId) {
+      // Caller is a user and callee is the owner, add fork
+      //
+      // NB: rrefId == forkId is true if and only if calling remote to
+      // self. In that case both the caller and the callee will access
+      // the OwnerRRef. Hence, on the callee side (here), it should not
+      // call addForkOfOwner as it is not a fork. To allow callee to
+      // distinguish when this request is sent to self, the caller will
+      // set forkId using rrefId (OwnerRRef does not have a forkId
+      // anyway).
+      RRefContext::getInstance().addForkOfOwner(rrefId, forkId);
+    }
+    Message m = RemoteRet(rrefId, forkId).toMessage();
+    m.setId(messageId);
+    responseFuture->markCompleted(std::move(m));
+  };
+
+  // scriptRemoteCall is only alive within this block, use reference to
+  // avoid copy. If the underlying code runs with a continuation, runAsync()
+  // below will std::move the appropriate portion of the stack.
+  TypePtr returnType = getScriptRemoteCallType(scriptRemoteCall);
+  c10::intrusive_ptr<OwnerRRef> ownerRRef;
+  if (rrefId == forkId) {
+    // Creating an owner RRef on self, should already exist in owners map
+    ownerRRef =
+        ctx.getOwnerRRef(rrefId, /* forceCreated */ true)->constValue();
+  } else {
+    ownerRRef = ctx.getOrCreateOwnerRRef(rrefId, returnType);
+  }
+
+  auto& stack = scriptRemoteCall.stackRef();
+  processScriptRemoteCall(
+      scriptRemoteCall, postProcessing, stack, ownerRRef);
 }
 
 bool RequestCallbackNoPython::processScriptRemoteCallOp(
@@ -216,6 +256,49 @@ bool RequestCallbackNoPython::processScriptRemoteCallOp(
   return false;
 }
 
+void RequestCallbackNoPython::processScriptRRefFetchCall(
+    RpcCommandBase& rpc,
+    const std::function<void(Message)>& markComplete,
+    const int64_t messageId,
+    const std::shared_ptr<FutureMessage>& responseFuture) const {
+  auto& srf = static_cast<ScriptRRefFetchCall&>(rpc);
+  auto& ctx = RRefContext::getInstance();
+
+  auto futureOwner = ctx.getOwnerRRef(srf.rrefId());
+
+  if (futureOwner->completed()) { // optional fast-path
+    // the OwnerRRef has been created
+    const auto& rref = futureOwner->constValue();
+    if (rref->hasValue()) {
+      markComplete(ScriptRRefFetchRet({rref->getValue()}).toMessage());
+      return;
+    }
+  }
+
+  futureOwner->addCallback([responseFuture, messageId, futureOwner]() {
+    const auto& rref = futureOwner->constValue();
+    auto whenValueSet = rref->getFuture();
+
+    // Our response is satisfied when the rpc.remote() request
+    // finishes executing on the owner.
+    whenValueSet->addCallback(
+        [responseFuture, messageId, rref, whenValueSet]() {
+          if (whenValueSet->hasError()) {
+            responseFuture->setError(
+                whenValueSet->tryRetrieveErrorMessage());
+            return;
+          }
+          try {
+            Message m = ScriptRRefFetchRet({rref->getValue()}).toMessage();
+            m.setId(messageId);
+            responseFuture->markCompleted(std::move(m));
+          } catch (const std::exception& e) {
+            responseFuture->setError(e.what());
+          }
+        });
+  });
+}
+
 void RequestCallbackNoPython::processPythonRRefFetchCall(
     RpcCommandBase& rpc,
     const int64_t messageId,
@@ -223,9 +306,254 @@ void RequestCallbackNoPython::processPythonRRefFetchCall(
   C10_THROW_ERROR(Error, "Python call not supported!");
 }
 
+void RequestCallbackNoPython::processRRefUserDelete(RpcCommandBase& rpc,
+    const std::function<void(Message)>& markComplete) const {
+  auto& rud = static_cast<RRefUserDelete&>(rpc);
+  auto& ctx = RRefContext::getInstance();
+  auto deletedRRef = ctx.delForkOfOwner(rud.rrefId(), rud.forkId());
+  handleRRefDelete(deletedRRef);
+  markComplete(std::move(RRefAck()).toMessage());
+}
+
 void RequestCallbackNoPython::handleRRefDelete(
     c10::intrusive_ptr<RRef>& rref) const {
   TORCH_CHECK(!rref->isPyObj(), "RRefs with python objects not supported!");
+}
+
+void RequestCallbackNoPython::processRRefChildAccept(RpcCommandBase& rpc,
+    const std::function<void(Message)>& markComplete) const {
+  auto& rca = static_cast<RRefChildAccept&>(rpc);
+  auto& ctx = RRefContext::getInstance();
+  ctx.delPendingChild(rca.forkId());
+  markComplete(std::move(RRefAck()).toMessage());
+}
+
+void RequestCallbackNoPython::processRRefForkRequest(RpcCommandBase& rpc,
+    const std::function<void(Message)>& markComplete) const {
+  auto& rfr = static_cast<RRefForkRequest&>(rpc);
+  auto& ctx = RRefContext::getInstance();
+  ctx.addForkOfOwnerIfNotPresent(rfr.rrefId(), rfr.forkId());
+  markComplete(RRefAck().toMessage());
+}
+
+void RequestCallbackNoPython::processForwardAutogradReq(RpcCommandBase& rpc,
+    const int64_t messageId,
+    const std::shared_ptr<FutureMessage>& responseFuture) const {
+  auto& rpcWithAutograd = static_cast<RpcWithAutograd&>(rpc);
+
+  // Attach 'recv' autograd function.
+  auto autogradContext = addRecvRpcBackward(
+      rpcWithAutograd.autogradMetadata(),
+      rpcWithAutograd.tensors(),
+      rpcWithAutograd.fromWorkerId());
+  // For this recv thread on server side, before processRpc(),
+  // set current_context_id_ to be context_id passed from client.
+  // In this way, if there is nested rpc call in python rpc call, original
+  // context_id from client can be passed in the chain calls.
+  TORCH_INTERNAL_ASSERT(
+      autogradContext != nullptr,
+      "autogradContext is nullptr, FORWARD_AUTOGRAD_REQ should always get "
+      "or create valid autogradContext in addRecvRpcBackward.");
+
+  DistAutogradContextGuard ctxGuard(autogradContext->contextId());
+
+  // Process the original RPC.
+  auto wrappedMessageType = rpcWithAutograd.wrappedMessageType();
+  // Make an overall future for the wrapped response.
+  auto wrappedRpcResponseFuture = std::make_shared<FutureMessage>();
+  // Kick off processing for the nested RPC command.
+  // wrappedRpcResponseFuture will be a Future<T> to the result.
+  processRpc(
+      rpcWithAutograd.wrappedRpc(),
+      wrappedMessageType,
+      messageId,
+      wrappedRpcResponseFuture);
+
+  auto fromWorkerId = rpcWithAutograd.fromWorkerId();
+  // The original future needs to be marked as completed when the wrapped
+  // one completes, with the autograd context information wrapped.
+  // Uses weak_ptr so we can std::move the value.
+  wrappedRpcResponseFuture->addCallback(
+      [responseFuture,
+        messageId,
+        fromWorkerId,
+        weak = std::weak_ptr<FutureMessage>(wrappedRpcResponseFuture),
+        ctxId = autogradContext->contextId()]() {
+        // As this callback can be invoked by a different thread, we have to
+        // make sure that the thread_local states in the previous thread is
+        // correctly propagated.
+        // NB: The execution of TorchScript functions can also run on a
+        // different thread, which is addressed by
+        // https://github.com/pytorch/pytorch/pull/36395
+        // NB: when adding async UDF support, we should also propagate
+        // thread_local states there.
+        // TODO: Land on a general solution for RPC ThreadLocalState. See
+        // https://github.com/pytorch/pytorch/issues/38510
+        DistAutogradContextGuard cbCtxGuard(ctxId);
+
+        auto wrappedRpcResponseFuture = weak.lock();
+        TORCH_INTERNAL_ASSERT(wrappedRpcResponseFuture);
+        if (wrappedRpcResponseFuture->hasError()) {
+          // Propagate error to responseFuture if we had one.
+          responseFuture->setError(
+              wrappedRpcResponseFuture->error()->what());
+        } else {
+          auto msg = getMessageWithAutograd(
+              fromWorkerId,
+              std::move(*wrappedRpcResponseFuture).moveValue(),
+              MessageType::FORWARD_AUTOGRAD_RESP);
+          msg.setId(messageId);
+          responseFuture->markCompleted(std::move(msg));
+        }
+      });
+}
+
+void RequestCallbackNoPython::processBackwardAutogradReq(
+    RpcCommandBase& rpc,
+    const int64_t messageId,
+    const std::shared_ptr<FutureMessage>& responseFuture) const {
+  auto& gradientsCall = static_cast<PropagateGradientsReq&>(rpc);
+  const auto& autogradMetadata = gradientsCall.getAutogradMetadata();
+
+  // Retrieve the appropriate autograd context.
+  auto autogradContext =
+      DistAutogradContainer::getInstance().retrieveContext(
+          autogradMetadata.autogradContextId);
+
+  // Lookup the appropriate 'send' function to enqueue.
+  std::shared_ptr<SendRpcBackward> sendFunction =
+      autogradContext->retrieveSendFunction(
+          autogradMetadata.autogradMessageId);
+
+  // Attach the gradients to the send function.
+  sendFunction->setGrads(gradientsCall.getGrads());
+
+  // Now execute the autograd graph using the "distributed engine."
+  auto execFuture = DistEngine::getInstance().executeSendFunctionAsync(
+      autogradContext, sendFunction, gradientsCall.retainGraph());
+
+  // Our response is satisfied when the rpcs come back.
+  execFuture->addCallback([responseFuture, messageId, execFuture]() {
+    if (!execFuture->hasError()) {
+      Message m = std::move(PropagateGradientsResp()).toMessage();
+      m.setId(messageId);
+      responseFuture->markCompleted(std::move(m));
+    } else {
+      responseFuture->setError(execFuture->tryRetrieveErrorMessage());
+    }
+  });
+}
+
+void RequestCallbackNoPython::processCleanupAutogradContextReq(
+    RpcCommandBase& rpc,
+    const std::function<void(Message)>& markComplete) const {
+  auto& cleanupContextReq = static_cast<CleanupAutogradContextReq&>(rpc);
+  auto cleanupContextId = cleanupContextReq.getContextId();
+  // release the context if it still exists on this thread. We need to
+  // check if it exists since it may have been deleted by an in-flight
+  // RPC. This can create nested RPCs if there are other nodes that get
+  // notified to clean up their context.
+  DistAutogradContainer::getInstance().releaseContextIfPresent(
+      cleanupContextId);
+  markComplete(std::move(CleanupAutogradContextResp()).toMessage());
+}
+
+void RequestCallbackNoPython::processRunWithProfilingReq(
+    RpcCommandBase& rpc,
+    const int64_t messageId,
+    const std::shared_ptr<FutureMessage>& responseFuture) const {
+  auto& rpcWithProfilingReq = static_cast<RpcWithProfilingReq&>(rpc);
+  auto wrappedMsgType = rpcWithProfilingReq.wrappedMessageType();
+  auto profilingConfig = rpcWithProfilingReq.getProfilingConfig();
+  // If requested with CUDA from caller but CUDA is not available on this
+  // machine, fallback to CPU and log a warning instead of crashing.
+  if (profilingConfig.state ==
+          torch::autograd::profiler::ProfilerState::CUDA &&
+      !this->cudaAvailable()) {
+    profilingConfig = torch::autograd::profiler::ProfilerConfig(
+        torch::autograd::profiler::ProfilerState::CPU,
+        profilingConfig.report_input_shapes,
+        profilingConfig.profile_memory);
+
+    LOG(WARNING)
+        << "Profiler was requested to be enabled with CUDA on this node, but CUDA is not available. "
+        << "Falling back to CPU profiling only.";
+  }
+  TORCH_INTERNAL_ASSERT(
+      profilingConfig.state !=
+              torch::autograd::profiler::ProfilerState::CUDA ||
+          this->cudaAvailable(),
+      "Profiler state set to CUDA but CUDA not available.");
+  const auto profilingKeyId = rpcWithProfilingReq.getProfilingId();
+  auto wrappedRpcResponseFuture = std::make_shared<FutureMessage>();
+  // Enable the profiler with the config from the sender.
+  // When enabling on the main thread, ensure profiler states are cleaned
+  // up, but defer consolidation of all profiled events to the continuation
+  // below.
+  torch::autograd::profiler::ProfilerDisableOptions requestThreadOptions(
+      true /* cleanup TLS state */, false /* consolidate events */);
+  {
+    torch::autograd::profiler::TLSProfilerGuard g(
+        profilingConfig, c10::nullopt, requestThreadOptions);
+    TORCH_INTERNAL_ASSERT(
+        torch::autograd::profiler::profilerEnabled(),
+        "Expected profiler to be enabled!");
+    // Kick off processing for nested work and get Future<T> result in
+    // wrappedRpcResponseFuture
+    processRpc(
+        rpcWithProfilingReq.wrappedRpc(),
+        wrappedMsgType,
+        messageId,
+        wrappedRpcResponseFuture);
+
+    wrappedRpcResponseFuture->addCallback(
+        at::wrapPropagateTLSState<void>([wrappedRpcResponseFuture,
+                                          responseFuture,
+                                          profilingKeyId,
+                                          profilingConfig] {
+          std::vector<torch::autograd::profiler::Event> profiledEvents;
+          // Defer consolidation of profiler events until async work has
+          // completed (such as async UDF)
+
+          TORCH_INTERNAL_ASSERT(
+              torch::autograd::profiler::profilerEnabled(),
+              "Expected profiler to be enabled!");
+
+          // On continuation thread, don't clean up profiler states, since
+          // they will be cleaned up by main thread, and consolidate all
+          // events so we obtain asynchronously run events.
+          torch::autograd::profiler::ProfilerDisableOptions opts(
+              false, true);
+          auto event_lists =
+              torch::autograd::profiler::disableProfiler(opts);
+          if (wrappedRpcResponseFuture->hasError()) {
+            // Propagate error
+            // No need to propagate remote events in the case of an error.
+            responseFuture->setError(
+                wrappedRpcResponseFuture->error()->what());
+          } else {
+            populateRemoteProfiledEvents(
+                profiledEvents, profilingConfig, event_lists);
+            auto rpcWithProfilingResp =
+                std::make_unique<RpcWithProfilingResp>(
+                    MessageType::RUN_WITH_PROFILING_RESP,
+                    std::move(*wrappedRpcResponseFuture).moveValue(),
+                    profiledEvents,
+                    profilingKeyId);
+            responseFuture->markCompleted(
+                std::move(*rpcWithProfilingResp).toMessage());
+          }
+        }));
+    // Exiting the scope will disable the profiler on this thread with the
+    // options specified above.
+  }
+}
+
+void RequestCallbackNoPython::processRRefBackward(
+    RpcCommandBase& rpc,
+    const int64_t messageId,
+    const std::shared_ptr<FutureMessage>& responseFuture) const {
+  C10_THROW_ERROR(Error, "Python call not supported!");
 }
 
 void RequestCallbackNoPython::processRpc(
@@ -237,7 +565,6 @@ void RequestCallbackNoPython::processRpc(
     m.setId(messageId);
     responseFuture->markCompleted(std::move(m));
   };
-
   // TODO: RpcCommandBase should have an abstract execute() method that we can
   // call here instead of having another switch statement here. Even better we
   // could have abstract classes RpcRequest and RpcResp which inherit from
@@ -246,12 +573,7 @@ void RequestCallbackNoPython::processRpc(
   // to a python object.
   switch (messageType) {
     case MessageType::SCRIPT_CALL: {
-      auto& scriptCall = static_cast<ScriptCall&>(rpc);
-
-      // scriptCall is only alive within this block, use reference to avoid copy
-      auto& stack = scriptCall.stackRef();
-      processScriptCall(
-          scriptCall, markComplete, stack, messageId, responseFuture);
+      processScriptCall(rpc, markComplete, messageId, responseFuture);
       return;
     }
     case MessageType::PYTHON_CALL: {
@@ -259,45 +581,7 @@ void RequestCallbackNoPython::processRpc(
       return;
     }
     case MessageType::SCRIPT_REMOTE_CALL: {
-      auto& scriptRemoteCall = static_cast<ScriptRemoteCall&>(rpc);
-      auto rrefId = scriptRemoteCall.retRRefId();
-      auto forkId = scriptRemoteCall.retForkId();
-      auto& ctx = RRefContext::getInstance();
-
-      auto postProcessing = [rrefId, forkId, messageId, responseFuture]() {
-        if (rrefId != forkId) {
-          // Caller is a user and callee is the owner, add fork
-          //
-          // NB: rrefId == forkId is true if and only if calling remote to
-          // self. In that case both the caller and the callee will access
-          // the OwnerRRef. Hence, on the callee side (here), it should not
-          // call addForkOfOwner as it is not a fork. To allow callee to
-          // distinguish when this request is sent to self, the caller will
-          // set forkId using rrefId (OwnerRRef does not have a forkId
-          // anyway).
-          RRefContext::getInstance().addForkOfOwner(rrefId, forkId);
-        }
-        Message m = RemoteRet(rrefId, forkId).toMessage();
-        m.setId(messageId);
-        responseFuture->markCompleted(std::move(m));
-      };
-
-      // scriptRemoteCall is only alive within this block, use reference to
-      // avoid copy. If the underlying code runs with a continuation, runAsync()
-      // below will std::move the appropriate portion of the stack.
-      TypePtr returnType = getScriptRemoteCallType(scriptRemoteCall);
-      c10::intrusive_ptr<OwnerRRef> ownerRRef;
-      if (rrefId == forkId) {
-        // Creating an owner RRef on self, should already exist in owners map
-        ownerRRef =
-            ctx.getOwnerRRef(rrefId, /* forceCreated */ true)->constValue();
-      } else {
-        ownerRRef = ctx.getOrCreateOwnerRRef(rrefId, returnType);
-      }
-
-      auto& stack = scriptRemoteCall.stackRef();
-      processScriptRemoteCall(
-          scriptRemoteCall, postProcessing, stack, ownerRRef);
+      processBaseScriptRemoteCall(rpc, markComplete, messageId, responseFuture);
       return;
     }
     case MessageType::PYTHON_REMOTE_CALL: {
@@ -305,43 +589,7 @@ void RequestCallbackNoPython::processRpc(
       return;
     }
     case MessageType::SCRIPT_RREF_FETCH_CALL: {
-      auto& srf = static_cast<ScriptRRefFetchCall&>(rpc);
-      auto& ctx = RRefContext::getInstance();
-
-      auto futureOwner = ctx.getOwnerRRef(srf.rrefId());
-
-      if (futureOwner->completed()) { // optional fast-path
-        // the OwnerRRef has been created
-        const auto& rref = futureOwner->constValue();
-        if (rref->hasValue()) {
-          markComplete(ScriptRRefFetchRet({rref->getValue()}).toMessage());
-          return;
-        }
-      }
-
-      futureOwner->addCallback([responseFuture, messageId, futureOwner]() {
-        const auto& rref = futureOwner->constValue();
-        auto whenValueSet = rref->getFuture();
-
-        // Our response is satisfied when the rpc.remote() request
-        // finishes executing on the owner.
-        whenValueSet->addCallback(
-            [responseFuture, messageId, rref, whenValueSet]() {
-              if (whenValueSet->hasError()) {
-                responseFuture->setError(
-                    whenValueSet->tryRetrieveErrorMessage());
-                return;
-              }
-              try {
-                Message m = ScriptRRefFetchRet({rref->getValue()}).toMessage();
-                m.setId(messageId);
-                responseFuture->markCompleted(std::move(m));
-              } catch (const std::exception& e) {
-                responseFuture->setError(e.what());
-              }
-            });
-      });
-
+      processScriptRRefFetchCall(rpc, markComplete, messageId, responseFuture);
       return;
     }
     case MessageType::PYTHON_RREF_FETCH_CALL: {
@@ -349,229 +597,31 @@ void RequestCallbackNoPython::processRpc(
       return;
     }
     case MessageType::RREF_USER_DELETE: {
-      auto& rud = static_cast<RRefUserDelete&>(rpc);
-      auto& ctx = RRefContext::getInstance();
-      auto deletedRRef = ctx.delForkOfOwner(rud.rrefId(), rud.forkId());
-      handleRRefDelete(deletedRRef);
-      markComplete(std::move(RRefAck()).toMessage());
+      processRRefUserDelete(rpc, markComplete);
       return;
     }
     case MessageType::RREF_CHILD_ACCEPT: {
-      auto& rca = static_cast<RRefChildAccept&>(rpc);
-      auto& ctx = RRefContext::getInstance();
-      ctx.delPendingChild(rca.forkId());
-      markComplete(std::move(RRefAck()).toMessage());
+      processRRefChildAccept(rpc, markComplete);
       return;
     }
     case MessageType::RREF_FORK_REQUEST: {
-      auto& rfr = static_cast<RRefForkRequest&>(rpc);
-      auto& ctx = RRefContext::getInstance();
-      ctx.addForkOfOwnerIfNotPresent(rfr.rrefId(), rfr.forkId());
-      markComplete(RRefAck().toMessage());
+      processRRefForkRequest(rpc, markComplete);
       return;
     }
     case MessageType::FORWARD_AUTOGRAD_REQ: {
-      auto& rpcWithAutograd = static_cast<RpcWithAutograd&>(rpc);
-
-      // Attach 'recv' autograd function.
-      auto autogradContext = addRecvRpcBackward(
-          rpcWithAutograd.autogradMetadata(),
-          rpcWithAutograd.tensors(),
-          rpcWithAutograd.fromWorkerId());
-      // For this recv thread on server side, before processRpc(),
-      // set current_context_id_ to be context_id passed from client.
-      // In this way, if there is nested rpc call in python rpc call, original
-      // context_id from client can be passed in the chain calls.
-      auto& autogradContainer = DistAutogradContainer::getInstance();
-      TORCH_INTERNAL_ASSERT(
-          autogradContext != nullptr,
-          "autogradContext is nullptr, FORWARD_AUTOGRAD_REQ should always get "
-          "or create valid autogradContext in addRecvRpcBackward.");
-
-      DistAutogradContextGuard ctxGuard(autogradContext->contextId());
-
-      // Process the original RPC.
-      auto wrappedMessageType = rpcWithAutograd.wrappedMessageType();
-      // Make an overall future for the wrapped response.
-      auto wrappedRpcResponseFuture = std::make_shared<FutureMessage>();
-      // Kick off processing for the nested RPC command.
-      // wrappedRpcResponseFuture will be a Future<T> to the result.
-      processRpc(
-          rpcWithAutograd.wrappedRpc(),
-          wrappedMessageType,
-          messageId,
-          wrappedRpcResponseFuture);
-
-      auto fromWorkerId = rpcWithAutograd.fromWorkerId();
-      // The original future needs to be marked as completed when the wrapped
-      // one completes, with the autograd context information wrapped.
-      // Uses weak_ptr so we can std::move the value.
-      wrappedRpcResponseFuture->addCallback(
-          [responseFuture,
-           messageId,
-           fromWorkerId,
-           weak = std::weak_ptr<FutureMessage>(wrappedRpcResponseFuture),
-           ctxId = autogradContext->contextId()]() {
-            // As this callback can be invoked by a different thread, we have to
-            // make sure that the thread_local states in the previous thread is
-            // correctly propagated.
-            // NB: The execution of TorchScript functions can also run on a
-            // different thread, which is addressed by
-            // https://github.com/pytorch/pytorch/pull/36395
-            // NB: when adding async UDF support, we should also propagate
-            // thread_local states there.
-            // TODO: Land on a general solution for RPC ThreadLocalState. See
-            // https://github.com/pytorch/pytorch/issues/38510
-            DistAutogradContextGuard cbCtxGuard(ctxId);
-
-            auto wrappedRpcResponseFuture = weak.lock();
-            TORCH_INTERNAL_ASSERT(wrappedRpcResponseFuture);
-            if (wrappedRpcResponseFuture->hasError()) {
-              // Propagate error to responseFuture if we had one.
-              responseFuture->setError(
-                  wrappedRpcResponseFuture->error()->what());
-            } else {
-              auto msg = getMessageWithAutograd(
-                  fromWorkerId,
-                  std::move(*wrappedRpcResponseFuture).moveValue(),
-                  MessageType::FORWARD_AUTOGRAD_RESP);
-              msg.setId(messageId);
-              responseFuture->markCompleted(std::move(msg));
-            }
-          });
+      processForwardAutogradReq(rpc, messageId, responseFuture);
       return;
     }
     case MessageType::BACKWARD_AUTOGRAD_REQ: {
-      auto& gradientsCall = static_cast<PropagateGradientsReq&>(rpc);
-      const auto& autogradMetadata = gradientsCall.getAutogradMetadata();
-
-      // Retrieve the appropriate autograd context.
-      auto autogradContext =
-          DistAutogradContainer::getInstance().retrieveContext(
-              autogradMetadata.autogradContextId);
-
-      // Lookup the appropriate 'send' function to enqueue.
-      std::shared_ptr<SendRpcBackward> sendFunction =
-          autogradContext->retrieveSendFunction(
-              autogradMetadata.autogradMessageId);
-
-      // Attach the gradients to the send function.
-      sendFunction->setGrads(gradientsCall.getGrads());
-
-      // Now execute the autograd graph using the "distributed engine."
-      auto execFuture = DistEngine::getInstance().executeSendFunctionAsync(
-          autogradContext, sendFunction, gradientsCall.retainGraph());
-
-      // Our response is satisfied when the rpcs come back.
-      execFuture->addCallback([responseFuture, messageId, execFuture]() {
-        if (!execFuture->hasError()) {
-          Message m = std::move(PropagateGradientsResp()).toMessage();
-          m.setId(messageId);
-          responseFuture->markCompleted(std::move(m));
-        } else {
-          responseFuture->setError(execFuture->tryRetrieveErrorMessage());
-        }
-      });
+      processBackwardAutogradReq(rpc, messageId, responseFuture);
       return;
     };
     case MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ: {
-      auto& cleanupContextReq = static_cast<CleanupAutogradContextReq&>(rpc);
-      auto cleanupContextId = cleanupContextReq.getContextId();
-      // release the context if it still exists on this thread. We need to
-      // check if it exists since it may have been deleted by an in-flight
-      // RPC. This can create nested RPCs if there are other nodes that get
-      // notified to clean up their context.
-      DistAutogradContainer::getInstance().releaseContextIfPresent(
-          cleanupContextId);
-      markComplete(std::move(CleanupAutogradContextResp()).toMessage());
+      processCleanupAutogradContextReq(rpc, markComplete);
       return;
     }
     case MessageType::RUN_WITH_PROFILING_REQ: {
-      auto& rpcWithProfilingReq = static_cast<RpcWithProfilingReq&>(rpc);
-      auto wrappedMsgType = rpcWithProfilingReq.wrappedMessageType();
-      auto profilingConfig = rpcWithProfilingReq.getProfilingConfig();
-      // If requested with CUDA from caller but CUDA is not available on this
-      // machine, fallback to CPU and log a warning instead of crashing.
-      if (profilingConfig.state ==
-              torch::autograd::profiler::ProfilerState::CUDA &&
-          !this->cudaAvailable()) {
-        profilingConfig = torch::autograd::profiler::ProfilerConfig(
-            torch::autograd::profiler::ProfilerState::CPU,
-            profilingConfig.report_input_shapes,
-            profilingConfig.profile_memory);
-
-        LOG(WARNING)
-            << "Profiler was requested to be enabled with CUDA on this node, but CUDA is not available. "
-            << "Falling back to CPU profiling only.";
-      }
-      TORCH_INTERNAL_ASSERT(
-          profilingConfig.state !=
-                  torch::autograd::profiler::ProfilerState::CUDA ||
-              this->cudaAvailable(),
-          "Profiler state set to CUDA but CUDA not available.");
-      const auto profilingKeyId = rpcWithProfilingReq.getProfilingId();
-      auto wrappedRpcResponseFuture = std::make_shared<FutureMessage>();
-      // Enable the profiler with the config from the sender.
-      // When enabling on the main thread, ensure profiler states are cleaned
-      // up, but defer consolidation of all profiled events to the continuation
-      // below.
-      torch::autograd::profiler::ProfilerDisableOptions requestThreadOptions(
-          true /* cleanup TLS state */, false /* consolidate events */);
-      {
-        torch::autograd::profiler::TLSProfilerGuard g(
-            profilingConfig, c10::nullopt, requestThreadOptions);
-        TORCH_INTERNAL_ASSERT(
-            torch::autograd::profiler::profilerEnabled(),
-            "Expected profiler to be enabled!");
-        // Kick off processing for nested work and get Future<T> result in
-        // wrappedRpcResponseFuture
-        processRpc(
-            rpcWithProfilingReq.wrappedRpc(),
-            wrappedMsgType,
-            messageId,
-            wrappedRpcResponseFuture);
-
-        wrappedRpcResponseFuture->addCallback(
-            at::wrapPropagateTLSState<void>([wrappedRpcResponseFuture,
-                                             responseFuture,
-                                             profilingKeyId,
-                                             profilingConfig] {
-              std::vector<torch::autograd::profiler::Event> profiledEvents;
-              // Defer consolidation of profiler events until async work has
-              // completed (such as async UDF)
-
-              TORCH_INTERNAL_ASSERT(
-                  torch::autograd::profiler::profilerEnabled(),
-                  "Expected profiler to be enabled!");
-
-              // On continuation thread, don't clean up profiler states, since
-              // they will be cleaned up by main thread, and consolidate all
-              // events so we obtain asynchronously run events.
-              torch::autograd::profiler::ProfilerDisableOptions opts(
-                  false, true);
-              auto event_lists =
-                  torch::autograd::profiler::disableProfiler(opts);
-              if (wrappedRpcResponseFuture->hasError()) {
-                // Propagate error
-                // No need to propagate remote events in the case of an error.
-                responseFuture->setError(
-                    wrappedRpcResponseFuture->error()->what());
-              } else {
-                populateRemoteProfiledEvents(
-                    profiledEvents, profilingConfig, event_lists);
-                auto rpcWithProfilingResp =
-                    std::make_unique<RpcWithProfilingResp>(
-                        MessageType::RUN_WITH_PROFILING_RESP,
-                        std::move(*wrappedRpcResponseFuture).moveValue(),
-                        profiledEvents,
-                        profilingKeyId);
-                responseFuture->markCompleted(
-                    std::move(*rpcWithProfilingResp).toMessage());
-              }
-            }));
-        // Exiting the scope will disable the profiler on this thread with the
-        // options specified above.
-      }
+      processRunWithProfilingReq(rpc, messageId, responseFuture);
       return;
     }
     case MessageType::RREF_BACKWARD_REQ: {

--- a/torch/csrc/distributed/rpc/request_callback_no_python.h
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.h
@@ -47,7 +47,7 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       const std::function<void(void)>& postProcessing,
       std::vector<at::IValue>& stack,
       const c10::intrusive_ptr<OwnerRRef>& ownerRRef) const;
-  
+
   void processBaseScriptRemoteCall(
       RpcCommandBase& rpc,
       const std::function<void(Message)>& markComplete,

--- a/torch/csrc/distributed/rpc/request_callback_no_python.h
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.h
@@ -23,9 +23,8 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       const MessageType& messageType) const;
 
   virtual void processScriptCall(
-      ScriptCall& scriptCall,
+      RpcCommandBase& rpc,
       const std::function<void(Message)>& markComplete,
-      std::vector<at::IValue>& stack,
       const int64_t messageId,
       const std::shared_ptr<FutureMessage>& responseFuture) const;
 
@@ -48,6 +47,12 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       const std::function<void(void)>& postProcessing,
       std::vector<at::IValue>& stack,
       const c10::intrusive_ptr<OwnerRRef>& ownerRRef) const;
+  
+  void processBaseScriptRemoteCall(
+      RpcCommandBase& rpc,
+      const std::function<void(Message)>& markComplete,
+      const int64_t messageId,
+      const std::shared_ptr<FutureMessage>& responseFuture) const;
 
   bool processScriptRemoteCallOp(
       ScriptRemoteCall& scriptRemoteCall,
@@ -61,7 +66,44 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       const int64_t messageId,
       const std::shared_ptr<FutureMessage>& responseFuture) const;
 
+  void processScriptRRefFetchCall(
+      RpcCommandBase& rpc,
+      const std::function<void(Message)>& markComplete,
+      const int64_t messageId,
+      const std::shared_ptr<FutureMessage>& responseFuture) const;
+
   virtual void processPythonRRefFetchCall(
+      RpcCommandBase& rpc,
+      const int64_t messageId,
+      const std::shared_ptr<FutureMessage>& responseFuture) const;
+
+  void processRRefUserDelete(
+      RpcCommandBase& rpc,
+      const std::function<void(Message)>& markComplete) const;
+
+  void processRRefChildAccept(
+      RpcCommandBase& rpc,
+      const std::function<void(Message)>& markComplete) const;
+
+  void processRRefForkRequest(
+      RpcCommandBase& rpc,
+      const std::function<void(Message)>& markComplete) const;
+
+  void processForwardAutogradReq(
+      RpcCommandBase& rpc,
+      const int64_t messageId,
+      const std::shared_ptr<FutureMessage>& responseFuture) const;
+
+  void processBackwardAutogradReq(
+      RpcCommandBase& rpc,
+      const int64_t messageId,
+      const std::shared_ptr<FutureMessage>& responseFuture) const;
+
+  void processCleanupAutogradContextReq(
+      RpcCommandBase& rpc,
+      const std::function<void(Message)>& markComplete) const;
+
+  void processRunWithProfilingReq(
       RpcCommandBase& rpc,
       const int64_t messageId,
       const std::shared_ptr<FutureMessage>& responseFuture) const;


### PR DESCRIPTION
Addresses step 1 of #46564

Took processing logic for each case in request_callback_no_python.cpp and put it in a dedicated function.

cc: @izdeby 