### PR TITLE
[FX] Fix __tensor_constants not scriptable

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -631,6 +631,18 @@ class TestFX(JitTestCase):
         with self.assertRaisesRegex(TraceError, 'Proxy object cannot be iterated.'):
             symbolic_trace(ud)
 
+    def test_script_tensor_constant(self):
+        # TorchScript seems to ignore attributes that start with `__`.
+        # We used to call anonymous Tensor values `__tensor_constant*`, but
+        # they were getting ignored by script. Now they're called
+        # `_tensor_constant*`
+        class IHaveATensorConstant(torch.nn.Module):
+            def forward(self, x):
+                return x + torch.rand(3, 4)
+
+        traced = torch.fx.symbolic_trace(IHaveATensorConstant())
+        torch.jit.script(traced)
+
     def test_torch_custom_ops(self):
         class M(torch.nn.Module):
             def forward(self, a):

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -90,7 +90,7 @@ class Tracer(TracerBase):
             if not qualname:
                 i = 0
                 while True:
-                    qualname = f'__tensor_constant{i}'
+                    qualname = f'_tensor_constant{i}'
                     if not hasattr(self.root, qualname):
                         break
                     i += 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47817 [FX] Fix __tensor_constants not scriptable**

Differential Revision: [D24908959](https://our.internmc.facebook.com/intern/diff/D24908959)