### PR TITLE
[pytorch] strip out warning message ifdef STRIP_ERROR_MESSAGES

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -387,18 +387,30 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // Report a warning to the user.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
 //
+#ifdef STRIP_ERROR_MESSAGES
+#define TORCH_WARN(...) \
+  ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, {}, false)
+#else
 #define TORCH_WARN(...) \
   ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::str(__VA_ARGS__), false)
+#endif
 
 // Report a warning to the user only once.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
 //
+#ifdef STRIP_ERROR_MESSAGES
+#define TORCH_WARN_ONCE(...) \
+  C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = [&] { \
+    ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, {}, false); \
+    return true; \
+  }()
+#else
 #define TORCH_WARN_ONCE(...) \
   C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = [&] { \
     ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::str(__VA_ARGS__), false); \
     return true; \
   }()
-
+#endif
 
 // ----------------------------------------------------------------------------
 // Deprecated macros


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47825 [pytorch][bot] update mobile op deps
* **#47827 [pytorch] strip out warning message ifdef STRIP_ERROR_MESSAGES**

Similar to TORCH_CHECK_WITH_MSG, strip messages for TORCH_WARN/TORCH_WARN_ONCE.

Differential Revision: [D24913586](https://our.internmc.facebook.com/intern/diff/D24913586)