### PR TITLE
Fix documentation to point to torch.overrides instead of _overrides.

### DIFF
--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -605,13 +605,13 @@ provides a developer-facing API for ensuring full support for
 changes without warning in the future.
 
 First, to get a listing of all overridable functions, use
-``torch._overrides.get_overridable_functions``. This returns a dictionary whose
+``torch.overrides.get_overridable_functions``. This returns a dictionary whose
 keys are namespaces in the ``PyTorch`` Python API and whose values are a list of
 functions in that namespace that can be overriden. For example, let's print the
 names of the first 5 functions in ``torch.nn.functional`` that can be
 overriden::
 
-  >>> from torch._overrides import get_overridable_functions
+  >>> from torch.overrides import get_overridable_functions
   >>> func_dict = get_overridable_functions()
   >>> nn_funcs = func_dict[torch.nn.functional]
   >>> print([f.__name__ for f in nn_funcs[:5])
@@ -622,20 +622,20 @@ This listing of functions makes it possible to iterate over all overridable
 functions, however in practice this is not enough to write tests for all of
 these functions without laboriously and manually copying the signature of each
 function for each test. To ease this process, the
-``torch._overrides.get_testing_overrides`` function returns a dictionary mapping
+``torch.overrides.get_testing_overrides`` function returns a dictionary mapping
 overridable functions in the ``PyTorch`` API to dummy lambda functions that have
 the same signature as the original function but unconditionally return -1. These
 functions are most useful to use with ``inspect`` to analyze the function
 signature of the original ``PyTorch`` function::
 
   >>> import inspect
-  >>> from torch._overrides import get_testing_overrides
+  >>> from torch.overrides import get_testing_overrides
   >>> override_dict = get_testing_overrides()
   >>> dummy_add = override_dict[torch.add]
   >>> inspect.signature(dummy_add)
   <Signature (input, other, out=None)>
 
-Finally, ``torch._overrides.get_ignored_functions`` returns a tuple of functions
+Finally, ``torch.overrides.get_ignored_functions`` returns a tuple of functions
 that explicitly cannot be overrided by ``__torch_function__``. This list can be
 useful to confirm that a function that isn't present in the dictionary returned
 by ``get_overridable_functions`` cannot be overriden.


### PR DESCRIPTION
Redo of #47842 for 1.7 branch.
