### PR TITLE
Fix BC breaking change introduced in einsum

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -255,10 +255,12 @@ Tensor einsum(std::string equation, TensorList operands) {
 
   // Start index of ellipsis dimensions in the permuted shape
   int64_t ell_index = 0;
+  found_ell = false;
 
   if (arrow_pos == std::string::npos) {
     // Implicit output is ellipsis (...) + labels seen only once
     perm_index = ell_num_dim;
+    found_ell = true;
     for (int label = 0; label < total_labels; ++label) {
       if (label_count[label] == 1) {
         label_perm_index[label] = perm_index++;
@@ -267,7 +269,6 @@ Tensor einsum(std::string equation, TensorList operands) {
   } else {
     // Parse explicit output
     std::string rhs = equation.substr(arrow_pos + 2);
-    found_ell = false;
     for (std::size_t i = 0; i < rhs.length(); ++i) {
       switch (rhs[i]) {
         case ' ':

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -309,15 +309,16 @@ Tensor einsum(std::string equation, TensorList operands) {
           label_count[rhs[i] - 'a'] = -1;
       }
     }
-
-    TORCH_CHECK(
-        // Dimensions under ellipsis are not contracted, so ensure it appears in output
-        ell_num_dim <= 0 || found_ell,
-        "einsum() ellipsis (...) covering one or more dimensions was given in the input but not in the output");
   }
 
   // Save output size before adding sum dims
   int out_size = perm_index;
+
+  // If ellipsis is not part of the output, add to contraction dimensions
+  if (ell_num_dim > 0 && !found_ell) {
+    ell_index = perm_index;
+    perm_index += ell_num_dim;
+  }
 
   // Add contraction labels (labels not present in output)
   for (int label = 0; label < total_labels; ++label) {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1382,7 +1382,7 @@ class TestLinalg(TestCase):
         # Test ellipsis
         check("i...->...", H)
         check("ki,...k->i...", A.t(), B)
-        check("k...,jk", A.t(), B)
+        check("k...,jk->...", A.t(), B)
         check('...ik, ...kj -> ...ij', torch.rand(2, 3, 4), torch.rand(1, 5))
         check('bik,k...j->i...j', torch.rand(5, 2, 3), torch.rand(3, 2))
         check('i...j, ij... -> ...ij', torch.rand(2, 3, 4), torch.rand(2, 4, 2, 3))
@@ -1428,8 +1428,12 @@ class TestLinalg(TestCase):
         check('...', 1, expected_output=1)
         check('...->', 1, expected_output=1)
         check('...->...', 1, expected_output=1)
+        check('...', [1], expected_output=[1])
+        check('...->', [1], expected_output=1)
         check('i...->i', [1], expected_output=[1])
         check('i...->...i', [1], expected_output=[1])
+        check('...a->', [[2], [4]], expected_output=6)
+        check('a...b->ab', [[[1], [2]], [[3], [4]]], expected_output=[[3], [7]])
 
     def test_einsum_error_cases(self, device):
         def check(equation, operands, regex, exception=RuntimeError):
@@ -1456,8 +1460,6 @@ class TestLinalg(TestCase):
         check('a->A', [x], r'subscripts must be in range \[a, z\] but found A for the output')
         check('a->aa', [x], r'output subscript a appears more than once in the output')
         check('a->i', [x], r'output subscript i does not appear in the equation for any input operand')
-        check('...->', [x], r'ellipsis \(...\) covering one or more dimensions was given in the input '
-                            r'but not in the output')
         check('aa', [y], r'subscript a is repeated for operand 0 but the sizes don\'t match, 3 != 2')
         check('a, ba', [x, y], r'operands do not broadcast with remapped shapes \[original->remapped\]: '
                                r'\[2\]->\[1, 2\] \[2, 3\]->\[2, 3\]')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47852 Fix BC breaking change introduced in einsum**

My previous PR https://github.com/pytorch/pytorch/pull/46398 introduced a BC breaking change that enforced ellipsis to be in the output. This is similar to NumPy but differs from our previous einsum impl. This PR removes this restriction and allows dimensions under ellipsis to be contracted again.