### PR TITLE
[FX] Fix submodule naming for subgraph split

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from torch.fx import symbolic_trace, Proxy, Node, GraphModule, Tracer, Graph
 from torch.fx.experimental import GraphManipulation
 from torch.fx.experimental import shape_prop
-from torch.fx.experimental.subgraph_creation_example import split_module
 from torch.fx.immutable_collections import immutable_dict, immutable_list
 from copy import deepcopy
 
@@ -879,43 +878,6 @@ class TestFX(JitTestCase):
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
         x = torch.rand(3, 4)
         self.assertEqual(gm(x), (x + float('inf'), x + float('nan')))
-
-    def test_subgraph_creation(self):
-        class MyModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.param = torch.nn.Parameter(torch.rand(3, 4))
-                self.linear = torch.nn.Linear(4, 5)
-
-            def forward(self, x, y):
-                z = self.linear(x + self.param).clamp(min=0.0, max=1.0)
-                w = self.linear(y).clamp(min=0.0, max=1.0)
-                return z + w
-
-        # symbolically trace model
-        my_module = MyModule()
-        my_module_traced = symbolic_trace(my_module)
-
-        # random mod partitioning
-        partition_counter = 0
-        NPARTITIONS = 3
-
-        def mod_partition(node: Node):
-            nonlocal partition_counter
-            partition = partition_counter % NPARTITIONS
-            partition_counter = (partition_counter + 1) % NPARTITIONS
-            return partition
-
-        # split module in module with submodules
-        module_with_submodules = split_module(my_module_traced, my_module, mod_partition)
-
-        x = torch.rand(3, 4)
-        y = torch.rand(3, 4)
-
-        orig_out = my_module_traced(x, y)
-        submodules_out = module_with_submodules(x, y)
-
-        self.assertEqual(orig_out, submodules_out)
 
     def test_deepcopy_recursion_depth(self):
         depth = sys.getrecursionlimit() + 20

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -538,7 +538,7 @@ terrible spacing
         m = resnet18()
         traced = symbolic_trace(m)
         a = torch.rand(64, 3, 7, 7)
-        module_with_submodules = split_module(traced,m,lambda node: 0)
+        module_with_submodules = split_module(traced, m, lambda node: 0)
         module_with_submodules(a)
 
     def test_traceable_function_with_nonstandard_name(self):

--- a/torch/fx/experimental/subgraph_creation_example.py
+++ b/torch/fx/experimental/subgraph_creation_example.py
@@ -115,7 +115,8 @@ def split_module(
                     if not hasattr(target_attr, atom):
                         raise RuntimeError(f'Operator target {node.target} not found!')
                     target_attr = getattr(target_attr, atom)
-                target = target_atoms[-1]
+                # target = target_atoms[-1]
+                target = '_'.join(target_atoms)
                 partition.targets[target] = target_attr
 
             assert isinstance(gathered_args, tuple)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47869 [FX] Fix submodule naming for subgraph split**

Submodules copied into a partition were using only the last atom in the qualified name, which caused problems when different Modules with the same last atom are put into the same Partition. Use the full qualname with underscores instead

Differential Revision: [D24925283](https://our.internmc.facebook.com/intern/diff/D24925283)