### PR TITLE
Fix "pointless comparison" warning

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -4,6 +4,8 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 
+#include <type_traits>
+
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
@@ -14,7 +16,7 @@ void remainder_kernel_cuda(TensorIterator& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         scalar_t r = a % b;
-        if ((r != 0) && ((r < 0) != (b < 0))) {
+        if (std::is_signed<scalar_t>::value && (r != 0) && ((r < 0) != (b < 0))) {
           r += b;
         }
         return r;
@@ -25,7 +27,9 @@ void remainder_kernel_cuda(TensorIterator& iter) {
       gpu_kernel_with_scalars(iter,
         []GPU_LAMBDA(scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
           auto mod = ::fmod(a, b);
-          if ((mod != 0) && ((b < 0) != (mod < 0))) mod += b;
+          if (std::is_signed<scalar_t>::value && (mod != 0) && ((b < 0) != (mod < 0))) {
+            mod += b;
+          }
           return mod;
         });
     });

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -1,4 +1,3 @@
-#include <limits>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/AccumulateType.h>
@@ -7,6 +6,9 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Math.cuh>
+
+#include <limits>
+#include <type_traits>
 
 namespace at { namespace native {
 
@@ -45,7 +47,7 @@ void sign_kernel_cuda(TensorIterator& iter){
 
 void signbit_kernel_cuda(TensorIterator& iter){
   AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cuda", [&]() {
-    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return a < 0; });
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> bool { return std::is_signed<scalar_t>::value && a < 0; });
   });
 }
 


### PR DESCRIPTION
Summary: Fixes a pointless comparison against zero warning that arises for some scalar types

Test Plan:
Arises with
```
xbuck test mode/dev-nosan //caffe2/torch/fb/sparsenn:gpu_test -- test_prior_correction_calibration_prediction_binary
```

Differential Revision: D24925955

