### PR TITLE
Port math kernel for layer_norm from pytorch/xla.

### DIFF
--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -122,6 +122,7 @@ Tensor group_norm(
 DEFINE_DISPATCH(GroupNormKernel);
 DEFINE_DISPATCH(GroupNormBackwardKernel);
 
+// Ported from pytorch/xla repo
 std::tuple<at::Tensor, at::Tensor, at::Tensor> math_group_norm(
     const at::Tensor& input,
     const at::Tensor& weight,

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -82,5 +82,29 @@ Tensor layer_norm(
 DEFINE_DISPATCH(LayerNormKernel);
 DEFINE_DISPATCH(LayerNormBackwardKernel);
 
+// Ported from pytorch/xla repo
+std::tuple<Tensor, Tensor, Tensor> math_native_layer_norm(
+    const Tensor& input, const Tensor& weight, const Tensor& bias,
+    int64_t M, int64_t N, double eps) {
+  auto input_shape = input.sizes();
+  at::Tensor input_reshaped = input.view({1, M, -1});
+  // Unlike Batch Normalization, which applies scalar scale and bias for each
+  // entire channel/plane with the affine option, Layer Normalization applies
+  // per-element scale and bias. E.g. For input {N, C, H, W}, weight for
+  // batchnorm has shape {C} while weight for layernorm has shape {H, W} or {W}.
+  auto outputs = at::native_batch_norm(
+      input_reshaped, /*weight=*/{}, /*bias=*/{}, /*running_mean=*/{},
+      /*running_var=*/{}, /*training=*/true, /*momentum=*/0, eps);
+  at::Tensor out = std::get<0>(outputs);
+  out = out.view(input_shape);
+  if (weight.defined() && bias.defined()) {
+    out = bias.addcmul(out, weight, 1);
+  } else if (weight.defined()) {
+    out = out.mul(weight);
+  } else if (bias.defined()) {
+    out = out.add(bias);
+  }
+  return std::make_tuple(out, std::get<1>(outputs), std::get<2>(outputs));
+}
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2206,6 +2206,7 @@
   dispatch:
     CPU: layer_norm_cpu
     CUDA: layer_norm_cuda
+    Math: math_native_layer_norm
 
 - func: native_layer_norm_backward(Tensor grad_out, Tensor input, Tensor mean, Tensor rstd, Tensor? weight, int M, int N, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   use_c10_dispatcher: hacky_wrapper_for_legacy_signatures

--- a/aten/src/ATen/test/math_kernel_test.cpp
+++ b/aten/src/ATen/test/math_kernel_test.cpp
@@ -37,4 +37,33 @@ TEST(MathKernelTest, NativeGroupNorm) {
   }
 }
 
+TEST(MathKernelTest, NativeLayerNorm) {
+  const auto input = rand({20, 10, 10, 10});
+  const auto input_shape = input.sizes();
+  const auto input_ndim = input.dim();
+
+  double eps = 1e-05;
+  for (bool undef_weight: {true, false}) {
+    for (int normalized_size: {2, 3}) {
+      Tensor undef;
+      std::vector<int64_t> normalized_shape(normalized_size, 10);
+      const auto weight = rand(normalized_shape);
+      const auto bias = rand(normalized_shape);
+      const int normalized_ndim = normalized_shape.size();
+      const int axis = input_ndim - normalized_ndim;
+      auto M = prod_intlist(input_shape.cbegin(), input_shape.cbegin()+ axis);
+      auto N = prod_intlist(input_shape.cbegin() + axis, input_shape.cend());
+
+      auto out = at::native_layer_norm(
+            input, undef_weight ? undef : weight, undef_weight ? undef : bias ,
+            M, N, eps);
+      auto math_out = at::native::math_native_layer_norm(
+            input, undef_weight ? undef : weight, undef_weight ? undef : bias,
+            M, N, eps);
+      ASSERT_ALLCLOSE_TOLERANCES(std::get<0>(out), std::get<0>(math_out), 1e-4, 1e-6);
+      ASSERT_ALLCLOSE_TOLERANCES(std::get<1>(out), std::get<1>(math_out), 1e-4, 1e-6);
+      ASSERT_ALLCLOSE_TOLERANCES(std::get<2>(out), std::get<2>(math_out), 1e-4, 1e-6);
+    }
+  }
+}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47882 Port math kernel for layer_norm from pytorch/xla.**

Differential Revision: [D24958691](https://our.internmc.facebook.com/intern/diff/D24958691)