### PR TITLE
[pytorch][te] Don't start TE fusion groups with an unknown-typed result

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -407,6 +407,7 @@ namespace jit {
   _(FuserPass_UnfusibleDevice)                      \
   _(FuserPass_UnknownShapes)                        \
   _(FuserPass_UnknownShapesIgnored)                 \
+  _(FuserPass_IgnoreUnknownShapeAtStart)            \
   _(FuserPass_Multidevice)                          \
   _(FuserPass_MergeGroups)                          \
   _(TrainBasic)                                     \

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1330,6 +1330,23 @@ class TestTEFuser(JitTestCase):
                 torch.testing.assert_allclose(test, ref)
         self.assertAllFused(script.graph_for(*inputs))
 
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_sub_gt_and(self):
+        def eager(t1, t2, t3, t4, t: float):
+            w = t1 - t2
+            h = t3 - t4
+            k = (w > t) & (h > t)
+            assert k.dtype == torch.bool
+            if t > 0.5:
+                # Putting a use of k in a never-executed conditional prevents
+                # profiling its type, which leaves it as "Tensor".  If we
+                # propagate Tensor back to the definition of k, we have to be
+                # careful not to create a fusion group containing it.
+                return k + 1
+            return w
+        t = torch.rand(8, dtype=torch.float, device='cuda')
+        scripted = self.checkScript(eager, (t, t, t, t, 0.1))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -223,7 +223,7 @@ bool texprReductionsEnabled() {
   return texpr_reductions_enabled;
 }
 
-// TODO: if a value has differently typed uses, temporarrily insert a node
+// TODO: if a value has differently typed uses, temporarily insert a node
 // specializing the type for each use and later remove, instead of bailing
 bool profiledWithDifferentTypes(Value* v) {
   std::vector<TypePtr> types;
@@ -262,7 +262,9 @@ void removeProfileNodesAndSpecializeTypes(Block* b) {
 }
 
 void RemoveProfileNodesAndSpecializeTypes(std::shared_ptr<Graph>& graph) {
+  GRAPH_DEBUG("Before removeProfileNodesAndSpecializeTypes", *graph);
   removeProfileNodesAndSpecializeTypes(graph->block());
+  GRAPH_DEBUG("After removeProfileNodesAndSpecializeTypes", *graph);
 }
 
 void removeTensorTypeSpecialization(Value* v) {
@@ -662,16 +664,27 @@ class TensorExprFuser {
     return fusion_group;
   }
 
+  bool shapeIsKnown(Value* v) {
+    if (v->type()->cast<TensorType>()) {
+      if (!v->isCompleteTensor()) {
+        return false;
+      }
+      if (*v->type()->cast<TensorType>()->dim() == 0) {
+        return false;
+      }
+    }
+    return true;
+  }
   bool allShapesAreKnown(Node* node) {
     // TODO: Relax the checks to support dynamic shapes
     for (Value* input : node->inputs()) {
-      if (input->type()->cast<TensorType>()) {
-        if (!input->isCompleteTensor()) {
-          return false;
-        }
-        if (*input->type()->cast<TensorType>()->dim() == 0) {
-          return false;
-        }
+      if (!shapeIsKnown(input)) {
+        return false;
+      }
+    }
+    for (Value* output : node->outputs()) {
+      if (!shapeIsKnown(output)) {
+        return false;
       }
     }
     return true;


### PR DESCRIPTION
Summary:
We need to know output types of everything in a fusion group to ensure
that we generate correctly-typed tensors.  We were incorrectly starting a
fusion group with an unknown-typed output.

Test Plan:
New unit tests:
```
buck test //caffe2/test:jit //caffe2/test/cpp/tensorexpr:tensorexpr
```

Differential Revision: D24932786

