### PR TITLE
Destroy autograd device threads at exit

### DIFF
--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -24,6 +24,9 @@
 
 namespace torch { namespace autograd {
 struct ReadyQueue;
+namespace python {
+void at_exit();
+} // namespace torch::autograd::python
 }} // namespace torch::autograd
 
 namespace torch { namespace autograd {
@@ -318,6 +321,7 @@ struct TORCH_API Engine {
       bool should_increment = true);
 
  protected:
+  friend void torch::autograd::python::at_exit();
   Engine();
   void compute_dependencies(Node* root, GraphTask& task);
 
@@ -335,6 +339,7 @@ struct TORCH_API Engine {
   // start device threads (CUDA, XLA, etc.) in Engine,
   // note that it does NOT start CPU thread.
   void start_device_threads();
+  void stop_device_threads();
   void increment_non_reentrant_thread_count();
   void decrement_non_reentrant_thread_count();
   virtual void thread_main(const std::shared_ptr<GraphTask>& task);

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -49,6 +49,10 @@ Engine& PythonEngine::get_python_engine() {
   return engine;
 }
 
+void at_exit() {
+  PythonEngine::get_python_engine().stop_device_threads();
+}
+
 void PythonEngine::thread_init(int device, const std::shared_ptr<ReadyQueue>& ready_queue, bool should_increment) {
   // Increment thread usage count before acquiring the GIL
   if (should_increment) {
@@ -349,5 +353,6 @@ bool THPEngine_initModule(PyObject *module)
   Py_INCREF(&THPEngineType);
   PyModule_AddObject(module, "_ImperativeEngine", (PyObject *)&THPEngineType);
   set_default_engine_stub(python::PythonEngine::get_python_engine);
+  Py_AtExit(python::at_exit);
   return true;
 }

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -9,6 +9,8 @@ bool THPEngine_initModule(PyObject *module);
 
 namespace torch { namespace autograd { namespace python {
 
+void at_exit();
+
 struct PythonEngine : public Engine {
   static Engine& get_python_engine();
   void thread_init(int device,


### PR DESCRIPTION
Register Python atexit handler and finish autograd's PythonEngine device threads during that time

Py_AtExit() is not called with GIL held, so it's safe to wait for the threads to shutdown
