### PR TITLE
Support ReduceSum in c2_pt_converter

### DIFF
--- a/caffe2/python/brew.py
+++ b/caffe2/python/brew.py
@@ -52,6 +52,7 @@ class HelperWrapper(object):
         'concat': concat,
         'depth_concat': depth_concat,
         'sum': sum,
+        'reduce_sum': reduce_sum,
         'sub': sub,
         'transpose': transpose,
         'iter': iter,

--- a/caffe2/python/helpers/algebra.py
+++ b/caffe2/python/helpers/algebra.py
@@ -18,6 +18,11 @@ def sum(model, blob_in, blob_out, **kwargs):
     return model.net.Sum(blob_in, blob_out, **kwargs)
 
 
+def reduce_sum(model, blob_in, blob_out, **kwargs):
+    """ReduceSum"""
+    return model.net.ReduceSum(blob_in, blob_out, **kwargs)
+
+
 def sub(model, blob_in, blob_out, **kwargs):
     """Subtract"""
     return model.net.Sub(blob_in, blob_out, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47889 Support ReduceSum in c2_pt_converter**

Adds support for converting the [caffe2 ReduceSum](https://caffe2.ai/docs/operators-catalogue#reducesum) operator to torch.

Differential Revision: [D24925318](https://our.internmc.facebook.com/intern/diff/D24925318/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24925318/)!