### PR TITLE
[OpBench] add _consume_op.list for processing input with type of List[Tensor]

### DIFF
--- a/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
+++ b/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
@@ -1,8 +1,7 @@
-import torch
-import cpp_extension # noqa
-
 import unittest
 
+import cpp_extension  # noqa
+import torch
 
 
 class TestConsumeOp(unittest.TestCase):
@@ -22,4 +21,25 @@ class TestConsumeOp(unittest.TestCase):
         x = torch.rand(2, 2)
         value = r(x)
         self.assertEqual(value, torch.sum(x))
+        self.assertEqual(occurance, iters)
+
+    def test_jit_consume_op_for_list_input(self):
+        iters = 6
+
+        def foo(x):
+            for i in range(iters):
+                result = torch.ops.operator_benchmark._consume(torch.chunk(x, 2))
+            return result
+
+        r = torch.jit.trace(foo, torch.rand(2, 2))
+
+        graph = str(r.graph)
+        occurance = graph.count("aten::chunk")
+
+        x = torch.rand(2, 2)
+        value = r(x)
+
+        self.assertTrue(
+            all([torch.allclose(t1, t2) for t1, t2 in zip(value, torch.chunk(x, 2))])
+        )
         self.assertEqual(occurance, iters)

--- a/benchmarks/operator_benchmark/pt_extension/extension.cpp
+++ b/benchmarks/operator_benchmark/pt_extension/extension.cpp
@@ -1,9 +1,14 @@
 #include <torch/extension.h>
 #include <torch/script.h>
 
+using torch::List;
 using torch::Tensor;
 
 Tensor consume(Tensor a) {
+  return a;
+}
+
+List<Tensor> consume_list(List<Tensor> a) {
   return a;
 }
 
@@ -13,8 +18,10 @@ Tensor consume(Tensor a) {
 // in a loop and report the execution time. This diff resolves that issue by
 // registering this consume op with correct alias information which is DEFAULT.
 auto reg = torch::RegisterOperators()
-  .op("operator_benchmark::_consume", &consume);
+               .op("operator_benchmark::_consume", &consume)
+               .op("operator_benchmark::_consume.list", &consume_list);
 
 PYBIND11_MODULE(cpp_extension, m) {
   m.def("_consume", &consume, "consume");
+  m.def("_consume_list", &consume_list, "consume_list");
 }


### PR DESCRIPTION
Summary: As titled. In order to fix issue when running `chunk_test`, `split_test`, `qobserver` , `sort in qunary` in jit mode, because the output of `chunk_op` is a list of tensors which can not be handled by the current `_consume_op`

Test Plan:
OSS:
python3 -m benchmark_all_test --iterations 1 --warmup_iterations 1 --use_jit

Reviewed By: mingzhe09088

Differential Revision: D24774105

