### PR TITLE
Add TorchBind-based Python and TorchScript binding for ProcessGroup

### DIFF
--- a/test/distributed/test_jit_c10d.py
+++ b/test/distributed/test_jit_c10d.py
@@ -1,7 +1,9 @@
 import unittest
+import tempfile
 from sys import platform
 import torch
 import torch.distributed as c10d
+from typing import List
 
 import torch.testing._internal.common_utils as common
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_rocm_single_process
@@ -31,6 +33,10 @@ class ProcessGroupNCCLJitTest(TestCase):
     def setUp(self):
         self.rank = self.MAIN_PROCESS_RANK
         self.world_size = 1
+        self.file = tempfile.NamedTemporaryFile(delete=False)
+        self.num_gpus = torch.cuda.device_count()
+        if self.num_gpus < 2:
+            raise unittest.SkipTest("NCCL test requires 2+ GPUs")
 
     def _create_nccl_pg(self):
         addr = "localhost"
@@ -39,6 +45,14 @@ class ProcessGroupNCCLJitTest(TestCase):
         opts = torch.classes.dist_c10d.ProcessGroupNCCLOptions(0, True)
 
         return torch.classes.dist_c10d.ProcessGroupNCCL(tcp_store, self.rank, self.world_size, opts)  
+
+    def _create_nccl_pg_as_base_process_group(self):
+        addr = "localhost"
+        port = common.find_free_port()
+        tcp_store = torch.classes.dist_c10d.TCPStore(addr, port, 1, True)
+
+        return torch.classes.c10d.frontend().newProcessGroupHelper(
+            self.world_size, self.rank, [], "NCCL", tcp_store, "test_process_group", 0)
 
     @requires_nccl()
     @skip_if_rocm_single_process
@@ -56,6 +70,33 @@ class ProcessGroupNCCLJitTest(TestCase):
         @torch.jit.script
         def run_pg_nccl_alltoall(
             pg: torch.classes.dist_c10d.ProcessGroupNCCL,
+            output: torch.Tensor,
+            input: torch.Tensor
+        ):
+            output_split_sizes: List[int] = []
+            input_split_sizes: List[int] = []
+            work = pg.alltoall_base(output, input, output_split_sizes, input_split_sizes)
+            work.wait()
+            return work.result()
+
+        run_pg_nccl_alltoall(nccl_pg, output, input)
+
+    @requires_nccl()
+    @skip_if_rocm_single_process
+    def test_init_process_group_nccl_as_base_process_group_torchbind(self):
+        self._create_nccl_pg_as_base_process_group()
+
+    @requires_nccl()
+    @skip_if_rocm_single_process
+    def test_process_group_nccl_as_base_process_group_torchbind_alltoall(self):
+        nccl_pg = self._create_nccl_pg_as_base_process_group()
+
+        input = torch.rand(16).cuda()
+        output = torch.rand(16).cuda()
+
+        @torch.jit.script
+        def run_pg_nccl_alltoall(
+            pg: torch.classes.dist_c10d.ProcessGroup,
             output: torch.Tensor,
             input: torch.Tensor
         ):

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -26,12 +26,15 @@
 #include <pybind11/chrono.h>
 
 #include <c10d/comm.hpp>
+#include <c10d/frontend.hpp>
 #include <c10d/reducer.hpp>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/distributed/c10d/python_comm_hook.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/pybind.h>
+
+#include <torch/custom_class.h>
 
 namespace torch {
 namespace distributed {
@@ -967,9 +970,9 @@ Arguments:
             ::c10d::ProcessGroupGloo::Options options;
 
             // Use interfaces listed in "GLOO_SOCKET_IFNAME", if set.
-            char* ifnameEnv = getenv(GLOO_SOCKET_IFNAME_ENV);
+            char* ifnameEnv = getenv(::c10d::GLOO_SOCKET_IFNAME_ENV);
             if (ifnameEnv) {
-              for (const auto& iface : split(',', ifnameEnv)) {
+              for (const auto& iface : ::c10d::split(',', ifnameEnv)) {
                 options.devices.push_back(
                     ::c10d::ProcessGroupGloo::createDeviceForInterface(iface));
               }
@@ -1258,11 +1261,257 @@ static const auto ProcessGroupWorkTorchBind =
             })
         .def("result", &::c10d::ProcessGroup::Work::result);
 
+
+// TODO: Support argument names in Python API.
 static const auto ProcessGroupTorchBind =
-    torch::class_<::c10d::ProcessGroup>("dist_c10d", "ProcessGroup");
+    torch::class_<::c10d::ProcessGroup>("dist_c10d", "ProcessGroup")
+        .def(
+            "rank",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self) {
+              return static_cast<int64_t>(self->getRank());
+            })
+        .def(
+            "size",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self) {
+              return static_cast<int64_t>(self->getSize());
+            })
+        // TODO: make BroadcastOptions compatible with TorchBind to provide
+        // the full API in python.
+        /*
+        // TODO: Enable this method when TorchBind supports overloading.
+        .def(
+            "broadcast",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> data) { return self->broadcast(data); })
+        */
+        .def(
+            "broadcast",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               at::Tensor tensor,
+               int64_t rootRank) {
+              ::c10d::BroadcastOptions opts;
+              opts.rootRank = rootRank;
+              std::vector<at::Tensor> tensors = {std::move(tensor)};
+              return self->broadcast(tensors, opts);
+            })
+        // TODO: make AllreduceOptions compatible with TorchBind to provide
+        // the full API in python.
+        .def(
+            "allreduce",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> tensors) {
+              return self->allreduce(tensors);
+            })
+        /*
+        // TODO: Enable these methods when TorchBind supports overloading.
+        // TODO: Enable these methods when ReduceOp can be torchbinded.
+        .def(
+            "allreduce",
+            [](c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                std::vector<at::Tensor>& tensors,
+                c10::intrusive_ptr<::c10d::ReduceOp> op) {
+                    ::c10d::AllreduceOptions opts;
+                    opts.reduceOp = *op;
+                    return self->allreduce(tensors, opts);
+                }
+        )
+        .def(
+            "allreduce",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               at::Tensor& tensor,
+               c10::intrusive_ptr<::c10d::ReduceOp> op) {
+                    ::c10d::AllreduceOptions opts;
+                    opts.reduceOp = *op;
+                    std::vector<at::Tensor> tensors = {tensor};
+                    return self->allreduce(tensors, opts);
+               }
+         )
+        */
+        // TODO: make AllreduceCoalescedOptions compatible with TorchBind to
+        // provide the full API in python.
+        .def(
+            "allreduce_coalesced",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> tensors) {
+              ::c10d::AllreduceCoalescedOptions opts;
+              return self->allreduce_coalesced(tensors, opts);
+            })
+        .def(
+            "reduce",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> tensors) {
+              ::c10d::ReduceOptions opts;
+              return self->reduce(tensors, opts);
+            })
+        /*
+        // TODO: Enable this when c10d::ReduceOp is TorchBind compatible.
+        .def(
+            "reduce",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+            at::Tensor& tensor,
+            int rootRank,
+            c10::intrusive_ptr<::c10d::ReduceOp> op) {
+            ::c10d::ReduceOptions opts;
+            opts.reduceOp = *op;
+            opts.rootRank = rootRank;
+            std::vector<at::Tensor> tensors = {tensor};
+            return self->reduce(tensors, opts);
+            })
+        */
+        .def(
+            "allgather",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<std::vector<at::Tensor>> outputTensors,
+               std::vector<at::Tensor> inputTensors) {
+              ::c10d::AllgatherOptions opts;
+              return self->allgather(outputTensors, inputTensors, opts);
+            })
+        /*
+        // TODO: Enable these methods when TorchBind supports overloading.
+        .def(
+            "allgather",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> output,
+               at::Tensor input) {
+              std::vector<std::vector<at::Tensor>> outputs = {
+                  std::move(output)};
+              std::vector<at::Tensor> inputs = {std::move(input)};
+              ::c10d::AllgatherOptions opts;
+              return self->allgather(outputs, inputs, opts);
+            })
+        */
+        .def(
+            "allgather_coalesced",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<std::vector<at::Tensor>> output_lists,
+               std::vector<at::Tensor> input_list) {
+              ::c10d::AllgatherOptions opts;
+              return self->allgather_coalesced(output_lists, input_list, opts);
+            })
+        /*
+        // TODO: Enable this method when TorchBind supports overloading.
+        .def(
+            "gather",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<std::vector<at::Tensor>> output_tensors,
+               std::vector<at::Tensor> input_tensors) {
+              ::c10d::GatherOptions opts;
+              return self->gather(output_tensors, input_tensors, opts);
+            })
+        */
+        .def(
+            "gather",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> output,
+               at::Tensor input,
+               int64_t rootRank) {
+              ::c10d::GatherOptions opts;
+              opts.rootRank = rootRank;
+              std::vector<std::vector<at::Tensor>> outputs = {
+                  std::move(output)};
+              std::vector<at::Tensor> inputs = {std::move(input)};
+              return self->gather(outputs, inputs, opts);
+            })
+        /*
+        // TODO: Enable this method when TorchBind supports overloading.
+        .def(
+            "scatter",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> outputTensors,
+               std::vector<std::vector<at::Tensor>> inputTensors) {
+              ::c10d::ScatterOptions opts;
+              self->scatter(outputTensors, inputTensors, opts);
+            })
+        */
+        .def(
+            "scatter",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               at::Tensor output,
+               std::vector<at::Tensor> input,
+               int64_t rootRank) {
+              ::c10d::ScatterOptions opts;
+              opts.rootRank = rootRank;
+              std::vector<std::vector<at::Tensor>> inputs = {std::move(input)};
+              std::vector<at::Tensor> outputs = {std::move(output)};
+              return self->scatter(outputs, inputs, opts);
+            })
+        /*
+        // TODO: Enable this method when TorchBind supports overloading.
+        // TODO: Enable this method when TorchBind supports
+        ReduceScatterOptions. .def( "reduce_scatter",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> outputTensors,
+               std::vector<std::vector<at::Tensor>> inputTensors) {
+              ::c10d::ReduceScatterOptions opts;
+              return self->reduce_scatter(outputTensors, inputTensors, opts);
+            })
+        */
+        .def(
+            "reduce_scatter",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               at::Tensor output,
+               std::vector<at::Tensor> input) {
+              std::vector<at::Tensor> outputs = {std::move(output)};
+              std::vector<std::vector<at::Tensor>> inputs = {std::move(input)};
+              ::c10d::ReduceScatterOptions opts;
+              return self->reduce_scatter(outputs, inputs, opts);
+            })
+        .def(
+            "alltoall_base",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               at::Tensor outputTensor,
+               at::Tensor inputTensor,
+               std::vector<int64_t> outputSplitSizes,
+               std::vector<int64_t> inputSplitSizes) {
+              ::c10d::AllToAllOptions opts;
+              return self->alltoall_base(
+                  outputTensor,
+                  inputTensor,
+                  outputSplitSizes,
+                  inputSplitSizes,
+                  opts);
+            })
+        .def(
+            "alltoall",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> outputTensors,
+               std::vector<at::Tensor> inputTensors) {
+              ::c10d::AllToAllOptions opts;
+              return self->alltoall(outputTensors, inputTensors, opts);
+            })
+        .def(
+            "send",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> tensors,
+               int64_t dstRank,
+               int64_t tag) {
+              return self->send(
+                  tensors, static_cast<int>(dstRank), static_cast<int>(tag));
+            })
+        .def(
+            "recv",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> tensors,
+               int64_t srcRank,
+               int64_t tag) {
+              return self->recv(
+                  tensors, static_cast<int>(srcRank), static_cast<int>(tag));
+            })
+        .def(
+            "recv_anysource",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+               std::vector<at::Tensor> tensors,
+               int64_t tag) {
+              return self->recvAnysource(tensors, static_cast<int>(tag));
+            })
+        .def(
+            "barrier",
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self) {
+              ::c10d::BarrierOptions opts;
+              return self->barrier(opts);
+            });
 
 #ifdef USE_C10D_NCCL
-
 // XXX: Ideally the Options of ProcessGroupNCCL should be
 // bound using `def_readwrite` like in pybind11, but we
 // didn't do that because: 1. no milisecond support yet
@@ -1300,6 +1549,16 @@ static const auto ProcessGroupNCCLTorchBind =
                   ::c10d::AllToAllOptions());
             });
 #endif
+
+static const auto DistributedC10dFrontendTorchBind =
+    torch::class_<::c10d::DistributedC10d>("c10d", "frontend")
+        .def(torch::init([]() {
+          static c10::intrusive_ptr<::c10d::DistributedC10d>
+              c10d_frontend_singleton =
+                  c10::make_intrusive<::c10d::DistributedC10d>();
+          return c10d_frontend_singleton;
+        }))
+        .def("new_process_group_helper", &::c10d::DistributedC10d::newProcessGroupHelper);
 
 } // namespace
 

--- a/torch/lib/c10d/ProcessGroupMPI.hpp
+++ b/torch/lib/c10d/ProcessGroupMPI.hpp
@@ -170,16 +170,16 @@ class ProcessGroupMPI : public ProcessGroup {
   c10::intrusive_ptr<ProcessGroup::Work> send(
       std::vector<at::Tensor>& tensors,
       int dstRank,
-      int tag);
+      int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recv(
       std::vector<at::Tensor>& tensors,
       int srcRank,
-      int tag);
+      int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
       std::vector<at::Tensor>& tensor,
-      int tag);
+      int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;

--- a/torch/lib/c10d/frontend.hpp
+++ b/torch/lib/c10d/frontend.hpp
@@ -13,6 +13,22 @@
 
 namespace c10d {
 
+#ifdef USE_C10D_GLOO
+constexpr char* GLOO_SOCKET_IFNAME_ENV = "GLOO_SOCKET_IFNAME";
+#endif
+
+inline std::vector<std::string> split(
+    char separator,
+    const std::string& string) {
+  std::vector<std::string> pieces;
+  std::stringstream ss(string);
+  std::string item;
+  while (std::getline(ss, item, separator)) {
+    pieces.push_back(std::move(item));
+  }
+  return pieces;
+}
+
 class Backend {
  public:
   // Maps to Backend.__new__ in Python.
@@ -27,8 +43,10 @@ class Backend {
   std::unordered_set<std::string> registered_backends_;
 };
 
-class DistributedC10d {
+class DistributedC10d : public torch::CustomClassHolder {
  public:
+  DistributedC10d(){};
+
   void initProcessGroup(
       const std::string& backend,
       const std::string& init_method,
@@ -183,8 +201,17 @@ class DistributedC10d {
 
   c10::intrusive_ptr<ProcessGroup> worldProcessGroup();
 
+  c10::intrusive_ptr<ProcessGroup> newProcessGroupHelper(
+    const int64_t world_size,
+    const int64_t rank,
+    const std::vector<int64_t>& group_ranks,
+    const std::string& backend_str,
+    const c10::intrusive_ptr<Store>& store,
+    c10::optional<std::string> group_name,
+    int64_t timeout_milisesonds);
+
+
  private:
-  DistributedC10d(){};
 
   bool rankNotInGroup(const c10::intrusive_ptr<ProcessGroup>& group) const;
   int64_t getGroupRank(


### PR DESCRIPTION
Add TorchBind-binding for ProcessGroup class.

Currently there are a few limitation of TorchBind that prevents us from fully matching existing PyBind-binding of ProcessGroup:

- TorchBind doesn't support method overloading. Current PyBind binding uses overloading extensively to provide flexible API, but TorchBind (and TorchScript ClassType behind it) doesn't yet support it. Therefore, we can provide at most one version of API under each name.

- TorchBind doesn't support C++ enums yet. This prevents us from making real uses of XXXOptions, which is widely used in many APIs.
