### PR TITLE
Be more careful with device ids

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -318,7 +318,7 @@ static inline void manual_seed(uint64_t seed) {
   if (hasCUDA() && num_gpus > 0) {
     for (int i = 0; i < num_gpus; i++) {
       auto cuda_gen = globalContext().defaultGenerator(
-        Device(at::kCUDA, static_cast<c10::DeviceIndex>(i))
+        Device(at::kCUDA, i)
       );
       {
         // See Note [Acquire lock when using random generators]

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <functional>
 #include <iosfwd>
+#include <limits>
 #include <string>
 
 namespace c10 {
@@ -32,8 +33,10 @@ struct C10_API Device final {
 
   /// Constructs a new `Device` from a `DeviceType` and an optional device
   /// index.
-  /* implicit */ Device(DeviceType type, DeviceIndex index = -1)
-      : type_(type), index_(index) {
+  /* implicit */ Device(DeviceType type, int64_t index = -1) : type_(type) {
+    TORCH_CHECK(std::numeric_limits<DeviceIndex>::min() <= index, "Device index too small!");
+    TORCH_CHECK(index <= std::numeric_limits<DeviceIndex>::max(), "Device index too large!");
+    index_ = static_cast<DeviceIndex>(index);
     validate();
   }
 
@@ -57,8 +60,10 @@ struct C10_API Device final {
   }
 
   /// Sets the device index.
-  void set_index(DeviceIndex index) {
-    index_ = index;
+  void set_index(int64_t index) {
+    TORCH_CHECK(std::numeric_limits<DeviceIndex>::min()<=index, "Device index too small!");
+    TORCH_CHECK(index<=std::numeric_limits<DeviceIndex>::max(), "Device index too large!");
+    index_ = static_cast<DeviceIndex>(index);
   }
 
   /// Returns the type of device this is.

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -324,7 +324,7 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
   }
 
  protected:
-  int gpu_id_;
+  c10::DeviceIndex gpu_id_;
   int random_seed_;
   curandGenerator_t curand_generator_{nullptr};
   static ThreadLocalCUDAObjects& getCudaObjects();

--- a/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
@@ -74,8 +74,7 @@ class AsyncInputIsOutputTest : public AsyncTest {
     for (auto i = 0; i < numTensors_; i++) {
       inputs_[i] = at::empty(
           {16, 16},
-          at::device(
-              {at::kCUDA, static_cast<c10::DeviceIndex>(i % numDevices_)}));
+          at::device({at::kCUDA, i % numDevices_}));
     }
 
     // Allocate a stream per device.


### PR DESCRIPTION
Summary:
A common pattern is for device ids to be integers of various sizes; however, all of these are internally stored as int16_t. At the moment this conversion happens silently, so erroneous values may not be caught.

This diff causes the device constructor to take larger ints as inputs and value check them before downcasting, catching potential issues before they happen.

Test Plan:
```
buck test mode/dev-nosan //caffe2/torch/fb/sparsenn:gpu_test
```

Differential Revision: D24866941

