### PR TITLE
[NNC] Support vectorization of reductions

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -124,6 +124,9 @@ namespace jit {
   _(ReductionReorderCacheConsumerAccess)            \
   _(ReductionRfactorCacheTempOuter)                 \
   _(ReductionRfactorCacheTempInner)                 \
+  _(ReductionVectorize)                             \
+  _(ReductionVectorizeInner)                        \
+  _(ReductionVectorizeRfactor)                      \
   _(TypeTest01)                                     \
   _(TypePropagation)                                \
   _(Cond01)                                         \
@@ -542,9 +545,9 @@ namespace jit {
   _(LLVMCondNestedTest)                    \
   _(LLVMVectorizerLoadStoreTest)           \
   _(LLVMSimpleReduction)                   \
-  _(LLVMRFactorReduction)
-
-// _(LLVMRFactorVectorizedReduction)
+  _(LLVMRFactorReduction)                  \
+  _(LLVMRFactorVectorizedReduction)        \
+  _(LLVMVectorizedGEMM)
 
 #define TH_FORALL_TENSOREXPR_TESTS_CUDA(_) \
   _(CudaTestVectorAdd01)                   \


### PR DESCRIPTION
Add support for ReduceOp in the Vectorizer, which allows vectorization of reductions. Only non-reduce axes can be vectorized currently, we'd need either automatically pulling out the RHS of reductions (better as a separate transform, I think) or special handling of vector reduce in the LLVM codegen (tricky, maybe not useful?) to make vectorizing reduce axes work.

There was a disabled LLVM test for this case which I reenabled with a bit of massaging, and added a few more.