### PR TITLE
Use Blocking Wait if both Blocking Wait and Async Error Handling Are Set

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -453,6 +453,14 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   blockingWait_ = parseEnvVarFlag(NCCL_BLOCKING_WAIT);
   asyncErrorHandling_ = parseEnvVarFlag(NCCL_ASYNC_ERROR_HANDLING);
 
+  if (blockingWait_ && asyncErrorHandling_) {
+    LOG(INFO) << "[Rank " << rank_
+              << "] NCCL_BLOCKING_WAIT and NCCL_ASYNC_ERROR_HANDLING "
+              << "should not both be enabled. " 
+              << "Only NCCL_BLOCKING_WAIT is being used in this process.";
+    asyncErrorHandling_ = false;
+  }
+
 #ifdef ENABLE_NCCL_ERROR_CHECKING
   ncclCommWatchdogThread_ =
       std::thread(&ProcessGroupNCCL::ncclCommWatchdog, this);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47926 Use Blocking Wait if both Blocking Wait and Async Error Handling Are Set**

Given that we're soon enabling async error handling in PET, we should make the behavior explicit when users have set NCCL_BLOCKING_WAIT in their own code while also using PET. This PR essentially gives blocking wait precedence (for now). This way the blast radius of the PET change is smaller, while we continue working with blocking wait users and discussing whether moving to async error handling may be a good fit.

Fixes: https://github.com/pytorch/pytorch/issues/47943

Differential Revision: [D24928149](https://our.internmc.facebook.com/intern/diff/D24928149/)