### PR TITLE
[Gloo] Compute Local Rank for Single-host Multi-GPU training

### DIFF
--- a/caffe2/contrib/gloo/store_handler.cc
+++ b/caffe2/contrib/gloo/store_handler.cc
@@ -10,7 +10,7 @@ void StoreHandlerWrapper::set(
   handler_.set(key, stringValue);
 }
 
-std::vector<char> StoreHandlerWrapper::get(const std::string& key) {
+std::vector<char> StoreHandlerWrapper::get(const std::string& key, bool /* unused */) {
   std::string str = handler_.get(key);
   return std::vector<char>(str.begin(), str.end());
 }

--- a/caffe2/contrib/gloo/store_handler.h
+++ b/caffe2/contrib/gloo/store_handler.h
@@ -17,7 +17,7 @@ class CAFFE2_API StoreHandlerWrapper : public ::gloo::rendezvous::Store {
   virtual void set(const std::string& key, const std::vector<char>& data)
       override;
 
-  virtual std::vector<char> get(const std::string& key) override;
+  virtual std::vector<char> get(const std::string& key, bool ignorePrefix=false) override;
 
   virtual void wait(const std::vector<std::string>& keys) override {
     wait(keys, ::gloo::rendezvous::Store::kDefaultTimeout);

--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -13,7 +13,7 @@ namespace c10d {
 class Store : public torch::CustomClassHolder {
  public:
   static constexpr std::chrono::milliseconds kDefaultTimeout =
-      std::chrono::seconds(300);
+      std::chrono::seconds(3);
   static constexpr std::chrono::milliseconds kNoTimeout =
       std::chrono::milliseconds::zero();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47928 [Gloo] Compute Local Rank for Single-host Multi-GPU training**

Compute the local rank in Gloo given the global rank passed during process group construction.

Differential Revision: [D24902139](https://our.internmc.facebook.com/intern/diff/D24902139/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24902139/)!