### PR TITLE
[fx] Add a pass to fetch attributes of nn.Module to fx.node

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1,13 +1,14 @@
 import torch
 import unittest
 import sys
-from typing import Dict
+from typing import Callable, Dict, Union, List
 from torch.fx.symbolic_trace import symbolic_trace
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Node
 from torch.fx.experimental import graph_manipulation
 from torch.fx.experimental.accelerator_partitioner import Partitioner
 from torch.fx.experimental.rewriter import RewritingTracer
+from torch.fx.experimental.param_fetch import lift_lowering_attrs_to_nodes
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.fx.experimental.subgraph_creation_example import split_module
@@ -20,7 +21,6 @@ from torch.fx.experimental.partitioner_utils import (
     PartitionMode
 )
 from torch.fx.experimental.fuser import fuse
-from typing import Union, Callable
 
 try:
     from torchvision.models import resnet18
@@ -779,6 +779,40 @@ terrible spacing
             t = torch.randn(2, 2)
             self.assertEqual(module.Foo()(t), mod(t))
 
+    def test_fetch(self):
+        attrs_for_lowering: Dict[str, List[str]] = {
+            "torch.nn.modules.conv.Conv2d": [
+                "weight", "bias", "kernel_size", "stride", "padding", "dilation", "groups", "padding_mode"
+            ],
+            "torch.nn.modules.batchnorm.BatchNorm2d": [
+                "weight", "bias", "running_mean", "running_var", "eps"
+            ],
+        }
+
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 3, 2)
+                self.bn = torch.nn.BatchNorm2d(3)
+
+            def forward(self, a):
+                a = self.conv(a)
+                a += a
+                return self.bn(a)
+
+        mod = TestModule()
+        traced = symbolic_trace(mod)
+        lift_lowering_attrs_to_nodes(traced)
+
+        for node in traced.graph.nodes:
+            if node.op == "call_module":
+                assert hasattr(node, "attrs_for_lowering")
+                para_list = attrs_for_lowering[node.attrs_for_lowering["name"]]
+
+                # node.attrs_for_lowering has an addition field of class name
+                assert len(para_list) + 1 == len(node.attrs_for_lowering)
+                for p_name in para_list:
+                    assert p_name in node.attrs_for_lowering
 
 
 if __name__ == "__main__":

--- a/torch/fx/experimental/graph_manipulation.py
+++ b/torch/fx/experimental/graph_manipulation.py
@@ -3,6 +3,7 @@ from typing import Dict, List, NamedTuple, Any
 
 import torch
 from torch.fx.experimental.shape_prop import ShapeProp
+from torch.fx.experimental.param_fetch import lift_lowering_attrs_to_nodes
 from torch.fx.graph import Graph, get_qualified_name
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Node, Target, map_arg
@@ -122,19 +123,17 @@ def serialize_weight(tensor: torch.Tensor) -> Dict:
 
 
 def serialize_leaf_module(
-    mod: torch.nn.Module, weights_metadata: Dict, weights: Dict, name_prefix: str
+    node: Node, weights_metadata: Dict, weights: Dict, name_prefix: str
 ) -> Dict:
     parameters: Dict[str, Any] = {}
-    parameters["name"] = type(mod).__name__
-    for name, buffer in mod.named_buffers():
-        weights_metadata[f"{name_prefix}.{name}"] = serialize_weight(buffer)
-        weights[f"{name_prefix}.{name}"] = buffer
-    for name, parameter in mod.named_parameters():
-        weights_metadata[f"{name_prefix}.{name}"] = serialize_weight(parameter)
-        weights[f"{name_prefix}.{name}"] = parameter
-    if isinstance(mod.__constants__, List):
-        for constant in mod.__constants__:
-            parameters[constant] = str(getattr(mod, constant))
+
+    for p_name, p_value in node.attrs_for_lowering.items():  # type: ignore
+        if isinstance(p_value, torch.Tensor):
+            weights_metadata[f"{name_prefix}.{p_name}"] = serialize_weight(p_value)
+            weights[f"{name_prefix}.{p_name}"] = p_value
+        else:
+            parameters[p_name] = str(p_value)
+
     return parameters
 
 
@@ -187,6 +186,7 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
             weight = serialize_weight(p)
             serialized_dict["weights"][prefix + name] = weight
             weights[prefix + name] = p
+    lift_lowering_attrs_to_nodes(fx_module)
     for node in fx_module.graph.nodes:
         node_rep: Dict[str, Any] = {}
         # Get shape/type info, currently not needed for call_module.
@@ -217,7 +217,7 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
                 serialized_dict["modules"][node.target] = serialized_module
             else:
                 node_rep["parameters"] = serialize_leaf_module(
-                    submodules[node.target],
+                    node,
                     serialized_dict["weights"],
                     weights,
                     prefix + node.target,

--- a/torch/fx/experimental/param_fetch.py
+++ b/torch/fx/experimental/param_fetch.py
@@ -1,0 +1,60 @@
+from torch.fx.graph_module import GraphModule
+from typing import Any, Callable, Dict, List, Tuple, Type
+import torch
+import torch.nn as nn
+
+
+# Matching method matches the attribute name of current version to the attribute name of `target_version`
+def default_matching(name: str, target_version: int) -> str:
+    """Default matching method
+    """
+    return name
+
+# This dict maps the nn.Module class name to the attribute name list that we want to fetch for lowering.
+# The first integer in the tuple is the version number of the nn.Module class when we create the parameter list.
+# If there's a version mismatch then it means the parameter names in the book might be mismatched with nn.Module.
+module_fetch_book: Dict[Type, Tuple[int, List[str], Callable[[str, int], str]]] = {
+    torch.nn.modules.linear.Linear: (1, ["weight", "bias"], default_matching),
+    torch.nn.modules.conv.Conv2d: (
+        1, ["weight", "bias", "kernel_size", "stride", "padding", "dilation", "groups", "padding_mode"], default_matching
+    ),
+    torch.nn.modules.batchnorm.BatchNorm2d: (2, ["weight", "bias", "running_mean", "running_var", "eps"], default_matching),
+    torch.nn.modules.pooling.AdaptiveAvgPool2d: (1, [], default_matching),
+    torch.nn.modules.pooling.MaxPool2d: (
+        1, ["kernel_size", "stride", "padding", "dilation", "return_indices", "ceil_mode"], default_matching
+    ),
+    torch.nn.modules.activation.ReLU: (1, ["inplace"], default_matching),
+}
+
+def extract_attrs_for_lowering(mod: nn.Module) -> Dict[str, Any]:
+    """If `mod` is in `module_fetch_book`, fetch the mod's attributes that in the `module_fetch_book`
+    after checking module's version is compatible with the `module_fetch_book`.
+    """
+    attrs_for_lowering: Dict[str, Any] = {}
+    attrs_for_lowering["name"] = torch.typename(mod)
+
+    if type(mod) in module_fetch_book:
+        version, param_to_fetch, matching_method = module_fetch_book[type(mod)]
+        if version < mod._version:
+            raise RuntimeError(f"Fetcher version {version} try to fetch {torch.typename(mod)} version {mod._version}, "
+                               "please upgrade the module_fetch_book, open an issue and @842974287 "
+                               "or report a bug to AIACC team directly.")
+        for attr in param_to_fetch:
+            attrs_for_lowering[attr] = getattr(mod, matching_method(attr, mod._version))
+    else:
+        raise RuntimeError(f"{torch.typename(mod)} is not in the module_fetch_book yet, "
+                           "please add it to the module_fetch_book, open an issue and @842974287 "
+                           "or report a bug to AIACC team directly.")
+    return attrs_for_lowering
+
+def lift_lowering_attrs_to_nodes(fx_module: GraphModule) -> None:
+    """Recursively traverse all `fx_module` nodes and fetch the module's attributes if the node is a leaf module.
+    """
+    submodules = dict(fx_module.named_modules())
+
+    for node in fx_module.graph.nodes:
+        if node.op == "call_module":
+            if isinstance(submodules[node.target], GraphModule):
+                lift_lowering_attrs_to_nodes(submodules[node.target])
+            else:
+                node.attrs_for_lowering = extract_attrs_for_lowering(submodules[node.target])


### PR DESCRIPTION
Summary: Fetch the parameters that are needed for lowering from nn.Module to fx.node for leaf_modules.
A `module_fetch_book` maintains the names of attribute that we want to fetch for a specific nn.Module. `_version` is used to ensure that the fetch book is aligned with the module.

Test Plan: A test `test_fetch` is added to test_fx_experimental.py.

Differential Revision: D24957142

