### PR TITLE
eager QAT: fix numerics issue introduced by #47415

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -136,8 +136,7 @@ def add_observer_(module, qconfig_propagation_list=None, non_leaf_module_list=No
             m._forward_hooks.move_to_end(handle.id, last=False)
 
     for name, child in module.named_children():
-        if type(child) in [nnq.FloatFunctional, nnq.QFunctional] or \
-           isinstance(child, _FusedModule):
+        if type(child) in [nnq.FloatFunctional, nnq.QFunctional]:
             if needs_observation(child):
                 child.activation_post_process = get_activation_post_process(child.qconfig, device)
         elif _has_special_act_post_process(child):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47941 eager quant: undo conv, linear, bn numeric changes from #47415
* **#47939 eager QAT: fix numerics issue introduced by #47415**

Summary:

After https://github.com/pytorch/pytorch/pull/47415, numerics for
QAT fused modules in Eager mode regressed.  The reason is that
activations for fused `conv-bn-relu` modules no longer received
calibration data, because they were moved outside of the hook
path.

Fixing by moving these back to the path which adds observers via
the forward hook.

Test Plan:

OSS:
```
python test/test_quantization.py TestQuantizationAwareTraining.test_fused_modules_activations_get_observed
```

FB - verified this fixes the numerical discrepancies between Eager and
FX for reference models.

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D24962451](https://our.internmc.facebook.com/intern/diff/D24962451)