### PR TITLE
eager quant: undo conv, linear, bn numeric changes from #47415

### DIFF
--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -21,9 +21,11 @@ class BatchNorm2d(torch.nn.BatchNorm2d):
 
     @classmethod
     def from_float(cls, mod):
-        activation_post_process = mod.activation_post_process
         if type(mod) == nni.BNReLU2d:
+            activation_post_process = mod[1].activation_post_process
             mod = mod[0]
+        else:
+            activation_post_process = mod.activation_post_process
         scale, zero_point = activation_post_process.calculate_qparams()
         new_mod = cls(mod.num_features, mod.eps)
         new_mod.weight = mod.weight
@@ -54,9 +56,11 @@ class BatchNorm3d(torch.nn.BatchNorm3d):
 
     @classmethod
     def from_float(cls, mod):
-        activation_post_process = mod.activation_post_process
         if type(mod) == nni.BNReLU3d:
+            activation_post_process = mod[1].activation_post_process
             mod = mod[0]
+        else:
+            activation_post_process = mod.activation_post_process
         scale, zero_point = activation_post_process.calculate_qparams()
         new_mod = cls(mod.num_features, mod.eps)
         new_mod.weight = mod.weight

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -182,9 +182,11 @@ class _ConvNd(nn.Module):
                 cls._FLOAT_MODULE.__name__
             assert hasattr(mod, "qconfig"), \
                 "Input float module must have qconfig defined."
-            activation_post_process = mod.activation_post_process
             if type(mod) == cls._NNI_CONV_RELU_MODULE:
+                activation_post_process = mod[1].activation_post_process
                 mod = mod[0]
+            else:
+                activation_post_process = mod.activation_post_process
             weight_post_process = mod.qconfig.weight()
         return cls.get_qconv(mod, activation_post_process, weight_post_process)
 
@@ -447,9 +449,11 @@ class Conv3d(_ConvNd):
             cls._FLOAT_MODULE.__name__
         assert hasattr(mod, 'qconfig'), \
             'Input float module must have qconfig defined.'
-        activation_post_process = mod.activation_post_process
         if type(mod) == nni.ConvReLU3d:
+            activation_post_process = mod[1].activation_post_process
             mod = mod[0]
+        else:
+            activation_post_process = mod.activation_post_process
         return cls.get_qconv(mod, activation_post_process)
 
 # === Transposed Convolutions ===

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -252,9 +252,11 @@ class Linear(torch.nn.Module):
             assert type(mod) == cls._FLOAT_MODULE, ' nnq.' + cls.__name__ + '.from_float only works for ' + \
                 cls._FLOAT_MODULE.__name__
             assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
-            activation_post_process = mod.activation_post_process
             if type(mod) == nni.LinearReLU:
+                activation_post_process = mod[1].activation_post_process
                 mod = mod[0]
+            else:
+                activation_post_process = mod.activation_post_process
             weight_post_process = mod.qconfig.weight()
         weight_post_process(mod.weight)
         dtype = weight_post_process.dtype


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47941 eager quant: undo conv, linear, bn numeric changes from #47415**
* #47939 eager QAT: fix numerics issue introduced by #47415

Summary:

Looks like https://github.com/pytorch/pytorch/pull/47415/ unintentially
changed the numerics by changing which activation gets used for
fusions of conv/linear/bn with relu.  Undoing that part of the PR.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D24962909](https://our.internmc.facebook.com/intern/diff/D24962909)