### PR TITLE
Fix pool2d_shape_check breakage as a result of API signature update.

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -119,7 +119,8 @@ Tensor avg_pool2d(
       input_size[Layout::Activation4D::height],
       input_size[Layout::Activation4D::width],
       output_height,
-      output_width);
+      output_width,
+      self_arg.suggest_memory_format());
 
   api::Context* const context = api::context();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47714 Force a sync on non-CPU tensors for the benchmark to reflect the timing accurately.
* #47728 Tweak Vulkan memory use.
* #47727 Update VMA.
* #47937 Fix Vulkan empty (and family) breakage as a result of API update.
* **#47958 Fix pool2d_shape_check breakage as a result of API signature update.**

