### PR TITLE
[jit] print function in the error message

### DIFF
--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -1308,3 +1308,30 @@ class TestClassType(JitTestCase):
 
         with self.assertRaisesRegexWithHighlight(RuntimeError, r"Class does not define __delitem__", "example[key]"):
             self.checkScript(fn, ())
+
+    def test_recursive_script_builtin_type_resolution(self):
+        """
+        Test resolution of built-in torch types(e.g. torch.Tensor, torch.device) when a class is recursively compiled.
+        """
+        # A will be implicitly compiled because it is not annotated with @torch.jit.script
+        # but is used in g() below.
+        tensor_t = torch.Tensor
+        device_t = torch.device
+
+        class A:
+            def __init__(self):
+                pass
+
+            def f(self, x: tensor_t, y: torch.device):
+                return x.to(device=y)
+
+            def h(self, x: device_t) -> device_t:
+                return x
+
+        def g():
+            a = A()
+            return a.f(torch.tensor([1]), torch.device("cpu"))
+
+        self.checkScript(g, ())
+        s = self.getExportImportCopy(torch.jit.script(g))
+        self.assertEqual(s(), g())

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -53,7 +53,7 @@ class TestScriptPy3(JitTestCase):
         def fn():
             return NormalizationInfo(1, 2, 3, 4, 5)
 
-        with self.assertRaisesRegex(OSError, "NormalizationInfo"):
+        with self.assertRaisesRegex(OSError, "could not get source code"):
             torch.jit.script(fn)
 
     def test_optional_dict_construct(self):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -268,7 +268,7 @@ def get_type_hint_captures(fn):
         elif isinstance(annotation, ast.Constant) or isinstance(annotation, ast.NameConstant):
             return f"{annotation.value}"
 
-        raise RuntimeError(f"Unexpected node type: {type(annotation)}")
+        raise RuntimeError(f"Unexpected node type: {type(annotation)} in function {fn}")
 
     # Gather a dictionary of parameter name -> literal annotation.
     name_to_annotation = {arg.arg: get_annotation_str(arg.annotation) for arg in f.args.args if arg.annotation}


### PR DESCRIPTION
Summary: otherwise don't know what is the problematic code

Test Plan:
```
  File "/data/users/yuxinwu/fbsource/fbcode/buck-out/opt/gen/vision/fair/detectron2/tests/test_instances#binary,link-tree/torch/jit/_script.py", line 938, in script
    _compile_and_register_class(obj, _rcb, qualified_name)
  File "/data/users/yuxinwu/fbsource/fbcode/buck-out/opt/gen/vision/fair/detectron2/tests/test_instances#binary,link-tree/torch/jit/_script.py", line 64, in _compile_and_register_cla
ss
    torch._C._jit_script_class_compile(qualified_name, ast, defaults, rcb)
  File "/data/users/yuxinwu/fbsource/fbcode/buck-out/opt/gen/vision/fair/detectron2/tests/test_instances#binary,link-tree/torch/jit/annotations.py", line 332, in try_ann_to_type
    torch.jit._script._recursive_compile_class(ann, loc)
  File "/data/users/yuxinwu/fbsource/fbcode/buck-out/opt/gen/vision/fair/detectron2/tests/test_instances#binary,link-tree/torch/jit/_script.py", line 1069, in _recursive_compile_clas
s
    rcb = _jit_internal.createResolutionCallbackForClassMethods(obj)
  File "/data/users/yuxinwu/fbsource/fbcode/buck-out/opt/gen/vision/fair/detectron2/tests/test_instances#binary,link-tree/torch/_jit_internal.py", line 305, in createResolutionCallba
ckForClassMethods
    captures.update(get_type_hint_captures(fn))
  File "/data/users/yuxinwu/fbsource/fbcode/buck-out/opt/gen/vision/fair/detectron2/tests/test_instances#binary,link-tree/torch/_jit_internal.py", line 288, in get_type_hint_captures
    annotation_to_type[get_annotation_str(f.returns)] = signature.return_annotation
  File "/data/users/yuxinwu/fbsource/fbcode/buck-out/opt/gen/vision/fair/detectron2/tests/test_instances#binary,link-tree/torch/_jit_internal.py", line 271, in get_annotation_str
    raise RuntimeError(f"Unexpected node type: {type(annotation)} in function {fn}")
RuntimeError: Unexpected node type: <class '_ast.Str'> in function <function Boxes.clone at 0x7f1324577d40>
```

Differential Revision: D24971065

