### PR TITLE
Ignore MSVC's pdb file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ torch/lib/*.exe*
 torch/lib/*.dylib*
 torch/lib/*.h
 torch/lib/*.lib
+torch/lib/*.pdb
 torch/lib/*.so*
 torch/lib/protobuf*.pc
 torch/lib/build


### PR DESCRIPTION
These files are generated by MSVC when building with debug symbols `REL_WITH_DEB_INFO=1`:
```
PS C:\Users\Xiang Gao\source\repos\pytorch> git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        torch/lib/asmjit.pdb
        torch/lib/c10.pdb
        torch/lib/c10_cuda.pdb
        torch/lib/caffe2_detectron_ops_gpu.pdb
        torch/lib/caffe2_module_test_dynamic.pdb
        torch/lib/caffe2_observers.pdb
        torch/lib/fbgemm.pdb
        torch/lib/shm.pdb
        torch/lib/torch_cpu.pdb
        torch/lib/torch_cuda.pdb

nothing added to commit but untracked files present (use "git add" to track)
```