### PR TITLE
[JIT] Fix function schema subtype checking

### DIFF
--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -288,12 +288,12 @@ inline bool FunctionSchema::isSubtypeOf(
     bool as_method,
     std::ostream* why_not) const {
   size_t start = as_method ? 1 : 0;
-  // functions are covariant in arguments but contravariant in returns
+  // functions are contravariant in arguments but covariant in returns
   return isSubtypeOfList(
-             ArrayRef<Argument>(arguments()).slice(start),
              ArrayRef<Argument>(rhs.arguments()).slice(start),
+             ArrayRef<Argument>(arguments()).slice(start),
              why_not) &&
-      isSubtypeOfList(rhs.returns(), returns(), why_not);
+      isSubtypeOfList(returns(), rhs.returns(), why_not);
 }
 
 } // namespace c10


### PR DESCRIPTION
Summary:
**Summary**
This commit fixes `FunctionSchema::isSubtypeOf` so that the subtyping rule it
implements for `FunctionSchema` instances is contravariant in argument
types and covariant in return type. At present, the rule is covariant in
argument types and contravariant in return type, which is not correct.

A brief but not rigourous explanation follows. Suppose there are two
`FunctionSchema`s, `M = (x: T) -> R` and `N = (x: U) -> S`. For `M <= N`
to be true (i.e. that `M` is a subtype of `N`), it must be true that `U
<= T` and `R <= S`. This generalizes to functions with multiple
arguments.

**Test Plan**
This commit extends `TestModuleInterface.test_module_interface_subtype`
with two new tests cases that test the contravariance of argument types
and covariance of return types in determining whether a `Module`
implements an interface type.

Test Plan: Imported from OSS

Differential Revision: D24970883

