### PR TITLE
[CI] Fix additional CI jobs not launched when PR is created from fork repo

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -33,6 +33,11 @@ else
   export BUILDER_ROOT="$workdir/builder"
 fi
 
+# Try to extract PR number from branch if not already set
+if [[ ! -n "${CIRCLE_PR_NUMBER:-}" ]]; then
+  CIRCLE_PR_NUMBER=`echo ${CIRCLE_BRANCH} | sed -E -n 's/pull\/([0-9]*).*/\1/p'`
+fi
+
 # Clone the Pytorch branch
 retry git clone https://github.com/pytorch/pytorch.git "$PYTORCH_ROOT"
 pushd "$PYTORCH_ROOT"

--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -34,8 +34,8 @@ else
 fi
 
 # Try to extract PR number from branch if not already set
-if [[ ! -n "${CIRCLE_PR_NUMBER:-}" ]]; then
-  CIRCLE_PR_NUMBER=`echo ${CIRCLE_BRANCH} | sed -E -n 's/pull\/([0-9]*).*/\1/p'`
+if [[ -z "${CIRCLE_PR_NUMBER:-}" ]]; then
+  CIRCLE_PR_NUMBER="$(echo ${CIRCLE_BRANCH} | sed -E -n 's/pull\/([0-9]*).*/\1/p')"
 fi
 
 # Clone the Pytorch branch


### PR DESCRIPTION
`CIRCLE_PR_NUMBER` is not always set during CI. 
This is to extract PR NUMBER from BRANCH info in order to launch additional CI jobs.

Should allow tag:`ci/binaries` and `ci/all` worked on forked PRs