### PR TITLE
rename torch.Assert to torch._assert (#47763)

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -545,4 +545,4 @@ Utilities
     set_deterministic
     is_deterministic
     vmap
-    Assert
+    _assert

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -731,7 +731,7 @@ class TestFX(JitTestCase):
 
         class AssertsTensorShape(torch.nn.Module):
             def forward(self, x):
-                torch.Assert(x.shape[1] > 4, message)
+                torch._assert(x.shape[1] > 4, message)
                 return x
 
         m = AssertsTensorShape()

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -410,7 +410,7 @@ class TestFXExperimental(JitTestCase):
         # Check the IR to make sure there's a call_function node with target == "Assert"
         self.assertTrue(
             any(
-                node.op == "call_function" and node.target == torch.Assert
+                node.op == "call_function" and node.target == torch._assert
                 for node in traced.graph.nodes
             )
         )
@@ -438,7 +438,7 @@ class TestFXExperimental(JitTestCase):
         # Check the IR to make sure there's a call_function node with target == "Assert"
         self.assertTrue(
             any(
-                node.op == "call_function" and node.target == torch.Assert
+                node.op == "call_function" and node.target == torch._assert
                 for node in traced.graph.nodes
             )
         )
@@ -466,7 +466,7 @@ class TestFXExperimental(JitTestCase):
         # Check the IR to make sure there's a call_function node with target == "Assert"
         self.assertTrue(
             any(
-                node.op == "call_function" and node.target == torch.Assert
+                node.op == "call_function" and node.target == torch._assert
                 for node in traced.graph.nodes
             )
         )
@@ -498,7 +498,7 @@ terrible spacing
         # Check the IR to make sure there's a call_function node with target == "Assert"
         self.assertTrue(
             any(
-                node.op == "call_function" and node.target == torch.Assert
+                node.op == "call_function" and node.target == torch._assert
                 for node in traced.graph.nodes
             )
         )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -637,9 +637,9 @@ class TestHipify(TestCase):
 class TestAssert(TestCase):
     def test_assert_true(self):
         # verify assertions work as expected
-        torch.Assert(True, "foo")
+        torch._assert(True, "foo")
         with self.assertRaisesRegex(AssertionError, "bar"):
-            torch.Assert(False, "bar")
+            torch._assert(False, "bar")
 
 
 if __name__ == '__main__':

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -620,11 +620,11 @@ quantized_lstm = torch.ops.aten.quantized_lstm
 quantized_gru = torch.ops.aten.quantized_gru
 
 
-def Assert(condition, message):
+def _assert(condition, message):
     r"""A wrapper around Python's assert which is symbolically traceable.
     """
     from .overrides import has_torch_function, handle_torch_function
 
     if type(condition) is not torch.Tensor and has_torch_function((condition,)):
-        return handle_torch_function(Assert, (condition,), condition, message)
+        return handle_torch_function(_assert, (condition,), condition, message)
     assert condition, message

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -47,10 +47,10 @@ class AST_Rewriter(ast.NodeTransformer):
     def visit_Assert(self, node):
         """
         Swap out the Assert node (Python's `assert`) with a callsite to the
-        symbolically-traceable torch.Assert function
+        symbolically-traceable torch._assert function
         """
         # Create the Call node
-        n = ast.parse('torch.Assert()', mode='eval')
+        n = ast.parse('torch._assert()', mode='eval')
         assert isinstance(n, ast.Expression)
         call_node = n.body
         assert isinstance(call_node, ast.Call)
@@ -61,7 +61,7 @@ class AST_Rewriter(ast.NodeTransformer):
         expr_wrapper = ast.Expr(value=call_node)
 
         # Return the new Call node to signify that we want to use it as
-        # a replacement for the original Assert node
+        # a replacement for the original _assert node
         return ast.copy_location(expr_wrapper, node)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47973 torch.Assert: make it torch.jit.script'able (#47399)
* **#47972 rename torch.Assert to torch._assert (#47763)**

Summary:

Changing the name due to the discussion in
https://github.com/pytorch/pytorch/pull/47399.

Test Plan:
```
python test/test_utils.py TestAssert.test_assert_true
python test/test_fx.py TestFX.test_symbolic_trace_assert
python test/test_fx_experimental.py
```

Differential Revision: [D24974298](https://our.internmc.facebook.com/intern/diff/D24974298)