### PR TITLE
[pytorch][codegen] simplify dunder method check in gen_python_functions.py

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -108,7 +108,7 @@ def should_generate_py_binding(f: NativeFunction) -> bool:
 
     return True
 
-def get_pycname(name: str) -> str:
+def get_pycname(name: BaseOperatorName) -> str:
     return f'THPVariable_{name}'
 
 def is_noarg(overloads: Sequence[PythonSignatureNativeFunctionPair]) -> bool:
@@ -169,12 +169,12 @@ def create_python_bindings(
     py_method_defs: List[str] = []
     py_forwards: List[str] = []
 
-    grouped: Dict[str, List[PythonSignatureNativeFunctionPair]] = defaultdict(list)
+    grouped: Dict[BaseOperatorName, List[PythonSignatureNativeFunctionPair]] = defaultdict(list)
     for pair in pairs:
         if pred(pair.function):
-            grouped[str(pair.function.func.name.name)].append(pair)
+            grouped[pair.function.func.name.name].append(pair)
 
-    for name in sorted(grouped.keys()):
+    for name in sorted(grouped.keys(), key=lambda x: str(x)):
         overloads = grouped[name]
         py_methods.append(method_impl(name, module, overloads, method=method))
         py_method_defs.append(method_def(name, module, overloads, method=method))
@@ -469,7 +469,7 @@ static PyObject * ${pycname}(PyObject* self_, PyObject* args)
 """)
 
 def method_impl(
-    name: str,
+    name: BaseOperatorName,
     module: Optional[str],
     overloads: Sequence[PythonSignatureNativeFunctionPair],
     *,
@@ -530,7 +530,7 @@ def method_impl(
     )
 
 def gen_has_torch_function_check(
-    name: str, module: Optional[str], *, noarg: bool, method: bool
+    name: BaseOperatorName, module: Optional[str], *, noarg: bool, method: bool
 ) -> str:
     if noarg:
         if method:
@@ -596,7 +596,7 @@ def emit_dispatch_case(
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 def forward_decls(
-    name: str,
+    name: BaseOperatorName,
     overloads: Sequence[PythonSignatureNativeFunctionPair],
     *,
     method: bool
@@ -620,30 +620,8 @@ static PyObject * {pycname}(PyObject* self_, PyObject* args, PyObject* kwargs);
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
-# Python binary operator dunder methods
-BINARY_OP_NAMES = [
-    '__lt__', '__le__',
-    '__gt__', '__ge__',
-    '__eq__', '__ne__',
-
-    '__add__', '__radd__', '__iadd__',
-    '__sub__', '__rsub__', '__isub__',
-    '__mul__', '__rmul__', '__imul__',
-    '__matmul__', '__rmatmul__', '__imatmul__',
-    '__truediv__', '__rtruediv__', '__itruediv__',
-    '__floordiv__', '__rfloordiv__', '__ifloordiv__',
-    '__mod__', '__rmod__', '__imod__',
-    '__divmod__', '__rdivmod__', '__idivmod__',
-    '__pow__', '__rpow__', '__ipow__',
-    '__lshift__', '__rlshift__', '__ilshift__',
-    '__rshift__', '__rrshift__', '__irshift__',
-    '__and__', '__rand__', '__iand__',
-    '__xor__', '__rxor__', '__ixor__',
-    '__or__', '__ror__', '__ior__',
-]
-
 def method_def(
-    name: str,
+    name: BaseOperatorName,
     module: Optional[str],
     overloads: Sequence[PythonSignatureNativeFunctionPair],
     *,
@@ -664,7 +642,7 @@ def method_def(
     if module == "torch":
         flags += ' | METH_STATIC'
 
-    if name in BINARY_OP_NAMES:
+    if name.dunder_method:
         # PyMethodDef entry for binary op, throws not implemented error
         return f"""\
 {{"{name}", {pyfunc_cast}(TypeError_to_NotImplemented_<{pycname}>), {flags}, NULL}},"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #47977 [pytorch][codegen] simplify python signature creation logic
* **#47976 [pytorch][codegen] simplify dunder method check in gen_python_functions.py**
* #47975 [pytorch][codegen] remove dead code in gen_variable_type.py

Confirmed byte-for-byte compatible with the old codegen:

```
Run it before and after this PR:
  .jenkins/pytorch/codegen-test.sh <baseline_output_dir>
  .jenkins/pytorch/codegen-test.sh <test_output_dir>

Then run diff to compare the generated files:
  diff -Naur <baseline_output_dir> <test_output_dir>
```

Differential Revision: [D24976273](https://our.internmc.facebook.com/intern/diff/D24976273)