### PR TITLE
[pytorch][codegen] simplify python signature creation logic

### DIFF
--- a/tools/codegen/api/python.py
+++ b/tools/codegen/api/python.py
@@ -510,12 +510,7 @@ def argument_type_size(t: Type) -> Optional[int]:
     else:
         return None
 
-def argument(cpp_arg: CppArgument) -> PythonArgument:
-    a = cpp_arg.argument
-    if not isinstance(a, Argument):
-        # cpp's TensorOptionsArguments is ignored, we will reintroduce the
-        # scattered fields in tensor_options_args.
-        raise RuntimeError(f'unsupported cpp argument: \'{cpp_arg}\'')
+def argument(a: Argument) -> PythonArgument:
     return PythonArgument(
         name=a.name,
         type=a.type,
@@ -527,25 +522,18 @@ def argument(cpp_arg: CppArgument) -> PythonArgument:
 
 def signature(f: NativeFunction, *, method: bool = False) -> PythonSignature:
     # Use cpp api to gather TensorOptions fields from kwargs.
-    # Always set 'method' to false as ThisArgument is not relevant - 'self'
-    # is still included as regular Argument type.
-    # TODO: maybe directly generate from FunctionSchema to avoid slicing back
-    # into args/kwargs/outputs?
-    cpp_sig = _cpp_signature(f, method=False)
-
     # Skip ThisArgument if this is method signature.
     # Skip TensorOptionsArguments in C++ signature. Python side TensorOptions
     # arguments are created based on different rules - see below.
-    cpp_arguments = tuple(filter(lambda a: not (method and a.name == 'self') and
-                                 not isinstance(a.argument, TensorOptionsArguments), cpp_sig.arguments()))
+    args = tuple(a for a in cpp.group_arguments(f.func, method=method) if isinstance(a, Argument))
 
+    arg_set = set(a.name for a in f.func.arguments)
     kwarg_only_set = set(a.name for a in f.func.kwarg_only_arguments)
     out_arg_set = set(a.name for a in f.func.out_arguments)
 
-    input_args = tuple(map(argument,
-                           filter(lambda a: not (a.name in kwarg_only_set or a.name in out_arg_set), cpp_arguments)))
-    input_kwargs = tuple(map(argument, filter(lambda a: a.name in kwarg_only_set, cpp_arguments)))
-    outputs = tuple(map(argument, filter(lambda a: a.name in out_arg_set, cpp_arguments)))
+    input_args = tuple(map(argument, filter(lambda a: a.name in arg_set, args)))
+    input_kwargs = tuple(map(argument, filter(lambda a: a.name in kwarg_only_set, args)))
+    outputs = tuple(map(argument, filter(lambda a: a.name in out_arg_set, args)))
 
     # Reintroduce the scattered fields of TensorOptions for Python.
     # Compared to the cpp counterpart, the python arguments have new property

--- a/tools/codegen/api/python.py
+++ b/tools/codegen/api/python.py
@@ -527,11 +527,11 @@ def signature(f: NativeFunction, *, method: bool = False) -> PythonSignature:
     # arguments are created based on different rules - see below.
     args = tuple(a for a in cpp.group_arguments(f.func, method=method) if isinstance(a, Argument))
 
-    arg_set = set(a.name for a in f.func.arguments)
+    input_arg_set = set(a.name for a in f.func.arguments)
     kwarg_only_set = set(a.name for a in f.func.kwarg_only_arguments)
     out_arg_set = set(a.name for a in f.func.out_arguments)
 
-    input_args = tuple(map(argument, filter(lambda a: a.name in arg_set, args)))
+    input_args = tuple(map(argument, filter(lambda a: a.name in input_arg_set, args)))
     input_kwargs = tuple(map(argument, filter(lambda a: a.name in kwarg_only_set, args)))
     outputs = tuple(map(argument, filter(lambda a: a.name in out_arg_set, args)))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#47977 [pytorch][codegen] simplify python signature creation logic**
* #47976 [pytorch][codegen] simplify dunder method check in gen_python_functions.py
* #47975 [pytorch][codegen] remove dead code in gen_variable_type.py

Avoid calling CppSignatureGroup api - python signature shouldn't depend on
cpp signature. Still use cpp.group_arguments() to group TensorOptions.

Confirmed byte-for-byte compatible with the old codegen:

```
Run it before and after this PR:
  .jenkins/pytorch/codegen-test.sh <baseline_output_dir>
  .jenkins/pytorch/codegen-test.sh <test_output_dir>

Then run diff to compare the generated files:
  diff -Naur <baseline_output_dir> <test_output_dir>
```

Differential Revision: [D24976334](https://our.internmc.facebook.com/intern/diff/D24976334)