### PR TITLE
add SparseLengthsSum8BitRowwiseSparse converter from c2 to pt

### DIFF
--- a/caffe2/python/brew.py
+++ b/caffe2/python/brew.py
@@ -72,6 +72,7 @@ class HelperWrapper(object):
         'cond' : cond,
         'loop' : loop,
         'db_input' : db_input,
+        'sparse_lengths_sum_8bit_rowwise_sparse': sparse_lengths_sum_8bit_rowwise_sparse,
     }
 
     def __init__(self, wrapped):

--- a/caffe2/python/helpers/algebra.py
+++ b/caffe2/python/helpers/algebra.py
@@ -39,3 +39,7 @@ def batch_mat_mul(model, blob_in, blob_out,
         kwargs['engine'] = 'TENSORCORE'
 
     return model.net.BatchMatMul(blob_in, blob_out, **kwargs)
+
+
+def sparse_lengths_sum_8bit_rowwise_sparse(model, blob_in, blob_out, **kwargs):
+    model.net.SparseLengthsSum8BitRowwiseSparse(blob_in, blob_out, **kwargs)


### PR DESCRIPTION
Summary: This diff adds the support for converting the `SparseLengthsSum8BitRowwiseSparse` operator from `caffe2` to `pytorch` as a part of `c2_pt_converter` (https://fburl.com/diffusion/jp1qxgom).

Test Plan:
New test included in diff.
`buck test //caffe2/torch/fb/model_transform/c2_convert:c2_pt_converter_test`

Differential Revision: D24944834

