### PR TITLE
[Person Seg] Compress the person seg model

### DIFF
--- a/torch/csrc/jit/passes/metal_rewrite.cpp
+++ b/torch/csrc/jit/passes/metal_rewrite.cpp
@@ -186,6 +186,7 @@ script::Module metalOptimizeForMobile(
   metalFoldPrePackingOps(cloned_module);
   metalInsertCopyOps(cloned_module);
   removeDropout(cloned_module);
+  cloned_module = freeze_module(cloned_module, preserved_methods);
   cloned_module.register_attribute(
       "optimized_for_metal", BoolType::get(), true);
   return cloned_module;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

### Motivation

The idea is to quantize the weights during model exporting and dequantize them when performing setstate in runtime. To replicate exactly what

Since the code here is restricted to the unet model, I created a custom prepacking context to do the graph rewriting and registering custom ops.

To run on iOS/MacOS, we need to link `unet_metal_prepack` explicitly.
- buck build //xplat/caffe2/fb/custom_ops/unet_metal_prepack:unet_metal_prepackApple
- buck build //xplat/caffe2/fb/custom_ops/unet_metal_prepack:unet_metal_prepackAppleMac

On the server side, the `unet_metal_prepack.cpp` needs to be compiled into the `aten_cpu` in order to do the graph-rewrite via optimize_for_mobile. However, since we don't want to ship it to the production, some local hacks were made to make this happen. More details can be found in the following diffs.

###  Results

-rw-r--r--   1 taox  staff   1.1M Nov 10 22:15 seg_init_net.pb
-rw-r--r--   1 taox  staff   1.1M Nov 10 22:15 seg_predict_net.pb

Note since we quantize the weights, some precision loss are expected, but overall good.

### ARD

- Person seg - v229
- Hair seg - v105

Differential Revision: [D24881316](https://our.internmc.facebook.com/intern/diff/D24881316/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24881316/)!