### PR TITLE
[WIP] 47917: Fix crash when reading zip archive without constants.kpl

### DIFF
--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -263,9 +263,11 @@ Module ScriptModuleDeserializer::deserialize(
     AT_ERROR("Legacy model format is not supported on mobile.");
 #endif
   }
-  auto tuple = readArchive("constants").toTuple();
-  for (auto constant : tuple->elements()) {
-    constants_table_.push_back(constant.toIValue());
+  if (reader_->hasRecord("constants")) {
+    auto tuple = readArchive("constants").toTuple();
+    for (auto constant : tuple->elements()) {
+      constants_table_.push_back(constant.toIValue());
+    }
   }
   auto m = Module(readArchive("data").toObject());
   rewriteQuantizedConvForBC(m);


### PR DESCRIPTION
Fixes #47917 .

This was caused by unconditionally reading `constants.kpl` from the zip archive even though it may not exist.
This PR fixes this.