### PR TITLE
[JIT] Make type singletons const references

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -224,7 +224,7 @@ struct CAFFE2_API AnyType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyType;
   // global singleton
-  static const AnyTypePtr get();
+  static const AnyTypePtr& get();
 
  private:
   AnyType() : Type(TypeKind::AnyType) {}
@@ -318,7 +318,7 @@ struct CAFFE2_API OptionalType
     return false;
   }
   // common cast Optional[Tensor] for undefined tensor type
-  static const OptionalTypePtr ofTensor();
+  static const OptionalTypePtr& ofTensor();
 
  private:
   OptionalType(TypePtr elem) : SingleElementType(elem) {}
@@ -804,7 +804,7 @@ struct CAFFE2_API TensorType : public Type {
 
   c10::optional<bool> undefined() const { return undefined_; }
 
-  static const TensorTypePtr get();
+  static const TensorTypePtr& get();
 
   static const TypeKind Kind = TypeKind::TensorType;
 
@@ -885,11 +885,11 @@ struct CAFFE2_API ListType
   bool isSubtypeOfExt(const TypePtr rhs, std::ostream* why_not) const override;
 
   // common cast List[Tensor]
-  static const ListTypePtr ofTensors();
-  static const ListTypePtr ofInts();
-  static const ListTypePtr ofFloats();
-  static const ListTypePtr ofBools();
-  static const ListTypePtr ofStrings();
+  static const ListTypePtr& ofTensors();
+  static const ListTypePtr& ofInts();
+  static const ListTypePtr& ofFloats();
+  static const ListTypePtr& ofBools();
+  static const ListTypePtr& ofStrings();
 
  private:
   ListType(TypePtr elem) : SingleElementType(elem) {}
@@ -1268,7 +1268,7 @@ struct CAFFE2_API AnyEnumType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyEnumType;
   // global singleton
-  static const AnyEnumTypePtr get();
+  static const AnyEnumTypePtr& get();
 private:
   AnyEnumType()
   : Type(TypeKind::AnyEnumType) {}
@@ -1293,7 +1293,7 @@ struct CAFFE2_API NumberType : public Type {
   }
   static const TypeKind Kind = TypeKind::NumberType;
   // global singleton
-  static const NumberTypePtr get();
+  static const NumberTypePtr& get();
 
  protected:
   NumberType(TypeKind kind = TypeKind::NumberType) : Type(kind) {}
@@ -1323,7 +1323,7 @@ struct CAFFE2_API FloatType : public NumberType {
   }
   static const TypeKind Kind = TypeKind::FloatType;
   // global singleton
-  static const FloatTypePtr get();
+  static const FloatTypePtr& get();
 
  private:
   FloatType() : NumberType(TypeKind::FloatType) {}
@@ -1350,7 +1350,7 @@ struct CAFFE2_API IntType : public NumberType {
   }
   static const TypeKind Kind = TypeKind::IntType;
   // global singleton
-  static const IntTypePtr get();
+  static const IntTypePtr& get();
 
  private:
   IntType() : NumberType(TypeKind::IntType) {}
@@ -1374,7 +1374,7 @@ struct CAFFE2_API BoolType : public Type {
   }
   static const TypeKind Kind = TypeKind::BoolType;
   // global singleton
-  static const BoolTypePtr get();
+  static const BoolTypePtr& get();
 
  private:
   BoolType() : Type(TypeKind::BoolType) {}
@@ -1399,7 +1399,7 @@ struct CAFFE2_API StringType : public Type {
   }
   static const TypeKind Kind = TypeKind::StringType;
   // global singleton
-  static const StringTypePtr get();
+  static const StringTypePtr& get();
 
  private:
   StringType() : Type(TypeKind::StringType) {}
@@ -1457,7 +1457,7 @@ struct CAFFE2_API NoneType : public Type {
   }
   static const TypeKind Kind = TypeKind::NoneType;
   // global singleton
-  static const NoneTypePtr get();
+  static const NoneTypePtr& get();
 
  private:
   NoneType() : Type(TypeKind::NoneType) {}
@@ -1479,7 +1479,7 @@ struct CAFFE2_API GeneratorType : public Type {
   }
   static const TypeKind Kind = TypeKind::GeneratorType;
   // global singleton
-  static const GeneratorTypePtr get();
+  static const GeneratorTypePtr& get();
 
  private:
   GeneratorType() : Type(TypeKind::GeneratorType) {}
@@ -1501,7 +1501,7 @@ struct CAFFE2_API QuantizerType : public Type {
   }
   static const TypeKind Kind = TypeKind::QuantizerType;
   // global singleton
-  static const QuantizerTypePtr get();
+  static const QuantizerTypePtr& get();
 
  private:
   QuantizerType() : Type(TypeKind::QuantizerType) {}
@@ -1523,7 +1523,7 @@ struct CAFFE2_API QSchemeType : public Type {
   }
   static const TypeKind Kind = TypeKind::QSchemeType;
   // global singleton
-  static const QSchemeTypePtr get();
+  static const QSchemeTypePtr& get();
 
  private:
   QSchemeType() : Type(TypeKind::QSchemeType) {}
@@ -1545,7 +1545,7 @@ struct CAFFE2_API DeviceObjType : public Type {
   }
   static const TypeKind Kind = TypeKind::DeviceObjType;
   // global singleton
-  static const DeviceObjTypePtr get();
+  static const DeviceObjTypePtr& get();
 
  private:
   DeviceObjType() : Type(TypeKind::DeviceObjType) {}
@@ -1567,7 +1567,7 @@ struct CAFFE2_API StreamObjType : public Type {
   }
   static const TypeKind Kind = TypeKind::StreamObjType;
   // global singleton
-  static const StreamObjTypePtr get();
+  static const StreamObjTypePtr& get();
 
 private:
   StreamObjType() : Type(TypeKind::StreamObjType) {}
@@ -1616,7 +1616,7 @@ struct CAFFE2_API CapsuleType : public Type {
   }
   static const TypeKind Kind = TypeKind::CapsuleType;
   // global singleton
-  static const CapsuleTypePtr get();
+  static const CapsuleTypePtr& get();
 private:
   CapsuleType()
   : Type(TypeKind::CapsuleType) {}
@@ -1637,7 +1637,7 @@ struct CAFFE2_API PyObjectType : public Type {
   }
   static const TypeKind Kind = TypeKind::PyObjectType;
   // global singleton
-  static const PyObjectTypePtr get();
+  static const PyObjectTypePtr& get();
 private:
   PyObjectType()
   : Type(TypeKind::PyObjectType) {}
@@ -2408,7 +2408,7 @@ return "Layout";
 }
 static const TypeKind Kind = TypeKind::LayoutType;
 // global singleton
-static const LayoutTypePtr get();
+static const LayoutTypePtr& get();
 
 private:
 LayoutType() : EnumerationType() {}
@@ -2427,7 +2427,7 @@ return "ScalarType";
 }
 static const TypeKind Kind = TypeKind::ScalarTypeType;
 // global singleton
-static const ScalarTypeTypePtr get();
+static const ScalarTypeTypePtr& get();
 
 private:
 ScalarTypeType() : EnumerationType() {}
@@ -2450,7 +2450,7 @@ struct CAFFE2_API AnyListType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyListType;
   // global singleton
-  static const AnyListTypePtr get();
+  static const AnyListTypePtr& get();
 private:
   AnyListType()
   : Type(TypeKind::AnyListType) {}
@@ -2475,7 +2475,7 @@ struct CAFFE2_API AnyTupleType : public Type {
   static const TypeKind Kind = TypeKind::AnyTupleType;
 
   // global singleton
-  static const AnyTupleTypePtr get();
+  static const AnyTupleTypePtr& get();
 private:
   AnyTupleType()
   : Type(TypeKind::AnyTupleType) {}
@@ -2498,7 +2498,7 @@ struct CAFFE2_API AnyClassType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyClassType;
   // global singleton
-  static const AnyClassTypePtr get();
+  static const AnyClassTypePtr& get();
 private:
   AnyClassType()
   : Type(TypeKind::AnyClassType) {}

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -224,7 +224,7 @@ struct CAFFE2_API AnyType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyType;
   // global singleton
-  static AnyTypePtr get();
+  static const AnyTypePtr get();
 
  private:
   AnyType() : Type(TypeKind::AnyType) {}
@@ -318,7 +318,7 @@ struct CAFFE2_API OptionalType
     return false;
   }
   // common cast Optional[Tensor] for undefined tensor type
-  static OptionalTypePtr ofTensor();
+  static const OptionalTypePtr ofTensor();
 
  private:
   OptionalType(TypePtr elem) : SingleElementType(elem) {}
@@ -804,7 +804,7 @@ struct CAFFE2_API TensorType : public Type {
 
   c10::optional<bool> undefined() const { return undefined_; }
 
-  static TensorTypePtr get();
+  static const TensorTypePtr get();
 
   static const TypeKind Kind = TypeKind::TensorType;
 
@@ -885,11 +885,11 @@ struct CAFFE2_API ListType
   bool isSubtypeOfExt(const TypePtr rhs, std::ostream* why_not) const override;
 
   // common cast List[Tensor]
-  static ListTypePtr ofTensors();
-  static ListTypePtr ofInts();
-  static ListTypePtr ofFloats();
-  static ListTypePtr ofBools();
-  static ListTypePtr ofStrings();
+  static const ListTypePtr ofTensors();
+  static const ListTypePtr ofInts();
+  static const ListTypePtr ofFloats();
+  static const ListTypePtr ofBools();
+  static const ListTypePtr ofStrings();
 
  private:
   ListType(TypePtr elem) : SingleElementType(elem) {}
@@ -1268,7 +1268,7 @@ struct CAFFE2_API AnyEnumType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyEnumType;
   // global singleton
-  static AnyEnumTypePtr get();
+  static const AnyEnumTypePtr get();
 private:
   AnyEnumType()
   : Type(TypeKind::AnyEnumType) {}
@@ -1293,7 +1293,7 @@ struct CAFFE2_API NumberType : public Type {
   }
   static const TypeKind Kind = TypeKind::NumberType;
   // global singleton
-  static NumberTypePtr get();
+  static const NumberTypePtr get();
 
  protected:
   NumberType(TypeKind kind = TypeKind::NumberType) : Type(kind) {}
@@ -1323,7 +1323,7 @@ struct CAFFE2_API FloatType : public NumberType {
   }
   static const TypeKind Kind = TypeKind::FloatType;
   // global singleton
-  static FloatTypePtr get();
+  static const FloatTypePtr get();
 
  private:
   FloatType() : NumberType(TypeKind::FloatType) {}
@@ -1350,7 +1350,7 @@ struct CAFFE2_API IntType : public NumberType {
   }
   static const TypeKind Kind = TypeKind::IntType;
   // global singleton
-  static IntTypePtr get();
+  static const IntTypePtr get();
 
  private:
   IntType() : NumberType(TypeKind::IntType) {}
@@ -1374,7 +1374,7 @@ struct CAFFE2_API BoolType : public Type {
   }
   static const TypeKind Kind = TypeKind::BoolType;
   // global singleton
-  static BoolTypePtr get();
+  static const BoolTypePtr get();
 
  private:
   BoolType() : Type(TypeKind::BoolType) {}
@@ -1399,7 +1399,7 @@ struct CAFFE2_API StringType : public Type {
   }
   static const TypeKind Kind = TypeKind::StringType;
   // global singleton
-  static StringTypePtr get();
+  static const StringTypePtr get();
 
  private:
   StringType() : Type(TypeKind::StringType) {}
@@ -1457,7 +1457,7 @@ struct CAFFE2_API NoneType : public Type {
   }
   static const TypeKind Kind = TypeKind::NoneType;
   // global singleton
-  static NoneTypePtr get();
+  static const NoneTypePtr get();
 
  private:
   NoneType() : Type(TypeKind::NoneType) {}
@@ -1479,7 +1479,7 @@ struct CAFFE2_API GeneratorType : public Type {
   }
   static const TypeKind Kind = TypeKind::GeneratorType;
   // global singleton
-  static GeneratorTypePtr get();
+  static const GeneratorTypePtr get();
 
  private:
   GeneratorType() : Type(TypeKind::GeneratorType) {}
@@ -1501,7 +1501,7 @@ struct CAFFE2_API QuantizerType : public Type {
   }
   static const TypeKind Kind = TypeKind::QuantizerType;
   // global singleton
-  static QuantizerTypePtr get();
+  static const QuantizerTypePtr get();
 
  private:
   QuantizerType() : Type(TypeKind::QuantizerType) {}
@@ -1523,7 +1523,7 @@ struct CAFFE2_API QSchemeType : public Type {
   }
   static const TypeKind Kind = TypeKind::QSchemeType;
   // global singleton
-  static QSchemeTypePtr get();
+  static const QSchemeTypePtr get();
 
  private:
   QSchemeType() : Type(TypeKind::QSchemeType) {}
@@ -1545,7 +1545,7 @@ struct CAFFE2_API DeviceObjType : public Type {
   }
   static const TypeKind Kind = TypeKind::DeviceObjType;
   // global singleton
-  static DeviceObjTypePtr get();
+  static const DeviceObjTypePtr get();
 
  private:
   DeviceObjType() : Type(TypeKind::DeviceObjType) {}
@@ -1567,7 +1567,7 @@ struct CAFFE2_API StreamObjType : public Type {
   }
   static const TypeKind Kind = TypeKind::StreamObjType;
   // global singleton
-  static StreamObjTypePtr get();
+  static const StreamObjTypePtr get();
 
 private:
   StreamObjType() : Type(TypeKind::StreamObjType) {}
@@ -1616,7 +1616,7 @@ struct CAFFE2_API CapsuleType : public Type {
   }
   static const TypeKind Kind = TypeKind::CapsuleType;
   // global singleton
-  static CapsuleTypePtr get();
+  static const CapsuleTypePtr get();
 private:
   CapsuleType()
   : Type(TypeKind::CapsuleType) {}
@@ -1637,7 +1637,7 @@ struct CAFFE2_API PyObjectType : public Type {
   }
   static const TypeKind Kind = TypeKind::PyObjectType;
   // global singleton
-  static PyObjectTypePtr get();
+  static const PyObjectTypePtr get();
 private:
   PyObjectType()
   : Type(TypeKind::PyObjectType) {}
@@ -2408,7 +2408,7 @@ return "Layout";
 }
 static const TypeKind Kind = TypeKind::LayoutType;
 // global singleton
-static LayoutTypePtr get();
+static const LayoutTypePtr get();
 
 private:
 LayoutType() : EnumerationType() {}
@@ -2427,7 +2427,7 @@ return "ScalarType";
 }
 static const TypeKind Kind = TypeKind::ScalarTypeType;
 // global singleton
-static ScalarTypeTypePtr get();
+static const ScalarTypeTypePtr get();
 
 private:
 ScalarTypeType() : EnumerationType() {}
@@ -2450,7 +2450,7 @@ struct CAFFE2_API AnyListType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyListType;
   // global singleton
-  static AnyListTypePtr get();
+  static const AnyListTypePtr get();
 private:
   AnyListType()
   : Type(TypeKind::AnyListType) {}
@@ -2475,7 +2475,7 @@ struct CAFFE2_API AnyTupleType : public Type {
   static const TypeKind Kind = TypeKind::AnyTupleType;
 
   // global singleton
-  static AnyTupleTypePtr get();
+  static const AnyTupleTypePtr get();
 private:
   AnyTupleType()
   : Type(TypeKind::AnyTupleType) {}
@@ -2498,7 +2498,7 @@ struct CAFFE2_API AnyClassType : public Type {
   }
   static const TypeKind Kind = TypeKind::AnyClassType;
   // global singleton
-  static AnyClassTypePtr get();
+  static const AnyClassTypePtr get();
 private:
   AnyClassType()
   : Type(TypeKind::AnyClassType) {}

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -107,118 +107,118 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
   return out;
 }
 
-AnyTypePtr AnyType::get() {
+const AnyTypePtr AnyType::get() {
   static auto value = AnyType::create();
   return value;
 }
 
-TensorTypePtr TensorType::get() {
+const TensorTypePtr TensorType::get() {
   static auto value = TensorType::create(
       {}, {}, SymbolicShape(), VaryingShape<Stride>{}, {});
   return value;
 }
 
-NumberTypePtr NumberType::get() {
+const NumberTypePtr NumberType::get() {
   static auto value = NumberType::create();
   return value;
 }
-IntTypePtr IntType::get() {
+const IntTypePtr IntType::get() {
   static auto value = IntType::create();
   return value;
 }
-FloatTypePtr FloatType::get() {
+const FloatTypePtr FloatType::get() {
   static auto value = FloatType::create();
   return value;
 }
-BoolTypePtr BoolType::get() {
+const BoolTypePtr BoolType::get() {
   static auto value = BoolType::create();
   return value;
 }
-NoneTypePtr NoneType::get() {
+const NoneTypePtr NoneType::get() {
   static auto value = NoneType::create();
   return value;
 }
-GeneratorTypePtr GeneratorType::get() {
+const GeneratorTypePtr GeneratorType::get() {
   static auto value = GeneratorType::create();
   return value;
 }
-QuantizerTypePtr QuantizerType::get() {
+const QuantizerTypePtr QuantizerType::get() {
   static auto value = QuantizerType::create();
   return value;
 }
-QSchemeTypePtr QSchemeType::get() {
+const QSchemeTypePtr QSchemeType::get() {
   static auto value = QSchemeType::create();
   return value;
 }
-StringTypePtr StringType::get() {
+const StringTypePtr StringType::get() {
   static auto value = StringType::create();
   return value;
 }
-DeviceObjTypePtr DeviceObjType::get() {
+const DeviceObjTypePtr DeviceObjType::get() {
   static auto value = DeviceObjType::create();
   return value;
 }
-StreamObjTypePtr StreamObjType::get() {
+const StreamObjTypePtr StreamObjType::get() {
   static auto value = StreamObjType::create();
   return value;
 }
-ScalarTypeTypePtr ScalarTypeType::get() {
+const ScalarTypeTypePtr ScalarTypeType::get() {
 static auto value = ScalarTypeType::create();
 return value;
 }
-LayoutTypePtr LayoutType::get() {
+const LayoutTypePtr LayoutType::get() {
 static auto value = LayoutType::create();
 return value;
 }
-OptionalTypePtr OptionalType::ofTensor() {
+const OptionalTypePtr OptionalType::ofTensor() {
   static auto value = OptionalType::create(TensorType::get());
   return value;
 }
-PyObjectTypePtr PyObjectType::get() {
+const PyObjectTypePtr PyObjectType::get() {
   static auto value = PyObjectType::create();
   return value;
 }
-CapsuleTypePtr CapsuleType::get() {
+const CapsuleTypePtr CapsuleType::get() {
   static auto value = CapsuleType::create();
   return value;
 }
-ListTypePtr ListType::ofTensors() {
+const ListTypePtr ListType::ofTensors() {
   static auto value = ListType::create(TensorType::get());
   return value;
 }
-ListTypePtr ListType::ofInts() {
+const ListTypePtr ListType::ofInts() {
   static auto value = ListType::create(IntType::get());
   return value;
 }
-ListTypePtr ListType::ofFloats() {
+const ListTypePtr ListType::ofFloats() {
   static auto value = ListType::create(FloatType::get());
   return value;
 }
-ListTypePtr ListType::ofBools() {
+const ListTypePtr ListType::ofBools() {
   static auto value = ListType::create(BoolType::get());
   return value;
 }
-ListTypePtr ListType::ofStrings() {
+const ListTypePtr ListType::ofStrings() {
   static auto value = ListType::create(StringType::get());
   return value;
 }
 
-AnyListTypePtr AnyListType::get() {
+const AnyListTypePtr AnyListType::get() {
   static auto value = AnyListType::create();
   return value;
 }
 
-AnyTupleTypePtr AnyTupleType::get() {
+const AnyTupleTypePtr AnyTupleType::get() {
   static auto value = AnyTupleType::create();
   return value;
 }
 
-AnyClassTypePtr AnyClassType::get() {
+const AnyClassTypePtr AnyClassType::get() {
   static auto value = AnyClassType::create();
   return value;
 }
 
-AnyEnumTypePtr AnyEnumType::get() {
+const AnyEnumTypePtr AnyEnumType::get() {
   static auto value = AnyEnumType::create();
   return value;
 }

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -107,118 +107,118 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
   return out;
 }
 
-const AnyTypePtr AnyType::get() {
+const AnyTypePtr& AnyType::get() {
   static auto value = AnyType::create();
   return value;
 }
 
-const TensorTypePtr TensorType::get() {
+const TensorTypePtr& TensorType::get() {
   static auto value = TensorType::create(
       {}, {}, SymbolicShape(), VaryingShape<Stride>{}, {});
   return value;
 }
 
-const NumberTypePtr NumberType::get() {
+const NumberTypePtr& NumberType::get() {
   static auto value = NumberType::create();
   return value;
 }
-const IntTypePtr IntType::get() {
+const IntTypePtr& IntType::get() {
   static auto value = IntType::create();
   return value;
 }
-const FloatTypePtr FloatType::get() {
+const FloatTypePtr& FloatType::get() {
   static auto value = FloatType::create();
   return value;
 }
-const BoolTypePtr BoolType::get() {
+const BoolTypePtr& BoolType::get() {
   static auto value = BoolType::create();
   return value;
 }
-const NoneTypePtr NoneType::get() {
+const NoneTypePtr& NoneType::get() {
   static auto value = NoneType::create();
   return value;
 }
-const GeneratorTypePtr GeneratorType::get() {
+const GeneratorTypePtr& GeneratorType::get() {
   static auto value = GeneratorType::create();
   return value;
 }
-const QuantizerTypePtr QuantizerType::get() {
+const QuantizerTypePtr& QuantizerType::get() {
   static auto value = QuantizerType::create();
   return value;
 }
-const QSchemeTypePtr QSchemeType::get() {
+const QSchemeTypePtr& QSchemeType::get() {
   static auto value = QSchemeType::create();
   return value;
 }
-const StringTypePtr StringType::get() {
+const StringTypePtr& StringType::get() {
   static auto value = StringType::create();
   return value;
 }
-const DeviceObjTypePtr DeviceObjType::get() {
+const DeviceObjTypePtr& DeviceObjType::get() {
   static auto value = DeviceObjType::create();
   return value;
 }
-const StreamObjTypePtr StreamObjType::get() {
+const StreamObjTypePtr& StreamObjType::get() {
   static auto value = StreamObjType::create();
   return value;
 }
-const ScalarTypeTypePtr ScalarTypeType::get() {
+const ScalarTypeTypePtr& ScalarTypeType::get() {
 static auto value = ScalarTypeType::create();
 return value;
 }
-const LayoutTypePtr LayoutType::get() {
+const LayoutTypePtr& LayoutType::get() {
 static auto value = LayoutType::create();
 return value;
 }
-const OptionalTypePtr OptionalType::ofTensor() {
+const OptionalTypePtr& OptionalType::ofTensor() {
   static auto value = OptionalType::create(TensorType::get());
   return value;
 }
-const PyObjectTypePtr PyObjectType::get() {
+const PyObjectTypePtr& PyObjectType::get() {
   static auto value = PyObjectType::create();
   return value;
 }
-const CapsuleTypePtr CapsuleType::get() {
+const CapsuleTypePtr& CapsuleType::get() {
   static auto value = CapsuleType::create();
   return value;
 }
-const ListTypePtr ListType::ofTensors() {
+const ListTypePtr& ListType::ofTensors() {
   static auto value = ListType::create(TensorType::get());
   return value;
 }
-const ListTypePtr ListType::ofInts() {
+const ListTypePtr& ListType::ofInts() {
   static auto value = ListType::create(IntType::get());
   return value;
 }
-const ListTypePtr ListType::ofFloats() {
+const ListTypePtr& ListType::ofFloats() {
   static auto value = ListType::create(FloatType::get());
   return value;
 }
-const ListTypePtr ListType::ofBools() {
+const ListTypePtr& ListType::ofBools() {
   static auto value = ListType::create(BoolType::get());
   return value;
 }
-const ListTypePtr ListType::ofStrings() {
+const ListTypePtr& ListType::ofStrings() {
   static auto value = ListType::create(StringType::get());
   return value;
 }
 
-const AnyListTypePtr AnyListType::get() {
+const AnyListTypePtr& AnyListType::get() {
   static auto value = AnyListType::create();
   return value;
 }
 
-const AnyTupleTypePtr AnyTupleType::get() {
+const AnyTupleTypePtr& AnyTupleType::get() {
   static auto value = AnyTupleType::create();
   return value;
 }
 
-const AnyClassTypePtr AnyClassType::get() {
+const AnyClassTypePtr& AnyClassType::get() {
   static auto value = AnyClassType::create();
   return value;
 }
 
-const AnyEnumTypePtr AnyEnumType::get() {
+const AnyEnumTypePtr& AnyEnumType::get() {
   static auto value = AnyEnumType::create();
   return value;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48027 [JIT] Make type singletons const references**

**Summary**
Certain types that cannot be specialized (e.g. `IntType`) have
singletons that are used to represent them in JIT in order to avoid
making and maintaining multiple copies of what is semantically the same
object. These singletons are accessible through `XXXType::get()`.
However, these functions return `XXXTypePtr`, which is an alias for
`std::shared_ptr<XXXType>`, and can therefore be modified by the caller.
This is dangerous, so this commit makes these `get()` functions return
`const XXXTypePtr&` so that they cannot be modified, and so that a new
`std::shared_ptr` is not constructed to return the singleton.

**Test Plan**
Existing unit tests.