### PR TITLE
Bump up the CUDA OOM test memory size

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -384,8 +384,8 @@ class TestCuda(TestCase):
     def test_out_of_memory(self):
         tensor = torch.zeros(1024, device='cuda')
 
-        with self.assertRaisesRegex(RuntimeError, "Tried to allocate 80.00 GiB"):
-            torch.empty(1024 * 1024 * 1024 * 80, dtype=torch.int8, device='cuda')
+        with self.assertRaisesRegex(RuntimeError, "Tried to allocate 8000000000.00 GiB"):
+            torch.empty(1024 * 1024 * 1024 * 8000000000, dtype=torch.int8, device='cuda')
 
         # ensure out of memory error doesn't disturb subsequent kernel
         tensor.fill_(1)


### PR DESCRIPTION
80GB is no longer large any more https://nvidianews.nvidia.com/news/nvidia-doubles-down-announces-a100-80gb-gpu-supercharging-worlds-most-powerful-gpu-for-ai-supercomputing

Hopefully, the new size could be OK until the end of Moore's Law :)