### PR TITLE
[quant] out-variant for the reflection pad

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8064,7 +8064,7 @@
 - func: reflection_pad1d.out(Tensor self, int[2] padding, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
   dispatch:
-    CPU: reflection_pad1d_out_cpu
+    CPU, QuantizedCPU: reflection_pad1d_out_cpu
     CUDA: reflection_pad1d_out_cuda
 
 - func: reflection_pad1d(Tensor self, int[2] padding) -> Tensor
@@ -8090,7 +8090,7 @@
 - func: reflection_pad2d.out(Tensor self, int[4] padding, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
   dispatch:
-    CPU: reflection_pad2d_out_cpu
+    CPU, QuantizedCPU: reflection_pad2d_out_cpu
     CUDA: reflection_pad2d_out_cuda
 
 - func: reflection_pad2d(Tensor self, int[4] padding) -> Tensor

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -4108,7 +4108,10 @@ class TestPadding(TestCase):
         y_ref = padding_op(x)
         qy_ref = torch.quantize_per_tensor(y_ref, scale, zp, qtype)
         qy_hat = padding_op(qx)
+        self.assertEqual(qy_ref, qy_hat)
 
+        # Out variant
+        qy_hat = torch._C._nn.reflection_pad1d(qx, padding, out=qy_hat)
         self.assertEqual(qy_ref, qy_hat)
 
      @given(batch_size=st.integers(1, 64),
@@ -4130,7 +4133,10 @@ class TestPadding(TestCase):
         y_ref = padding_op(x)
         qy_ref = torch.quantize_per_tensor(y_ref, scale, zp, qtype)
         qy_hat = padding_op(qx)
+        self.assertEqual(qy_ref, qy_hat)
 
+        # Out variant
+        qy_hat = torch._C._nn.reflection_pad2d(qx, padding, out=qy_hat)
         self.assertEqual(qy_ref, qy_hat)
 
     @given(batch_size=st.integers(1, 64),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48051 [quant][refactor] Reflection pad now uses AT_DISPATCH_FLOATING_AND_QINT_TYPES
* #48050 [quant] AT_DISPATCH_FLOATING_AND_QINT_TYPES
* **#48037 [quant] out-variant for the reflection pad**
* #48036 [quant] ReflectionPad2d

Differential Revision: [D25000345](https://our.internmc.facebook.com/intern/diff/D25000345)