### PR TITLE
[quant] AT_DISPATCH_FLOATING_AND_QINT_TYPES

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -280,6 +280,25 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
     }                                                                       \
   }()
 
+#define AT_DISPATCH_FLOATING_AND_QINT_TYPES(TYPE, NAME, ...)          \
+  [&] {                                                                     \
+    const auto& the_type = TYPE;                                            \
+    /* don't use TYPE again in case it is an expensive or side-effect op */ \
+    at::ScalarType _st = ::detail::scalar_type(the_type);                   \
+    switch (_st) {                                                          \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)     \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)       \
+      AT_QINT_PRIVATE_CASE_TYPE(                                            \
+          at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)            \
+      AT_QINT_PRIVATE_CASE_TYPE(                                            \
+          at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)         \
+      AT_QINT_PRIVATE_CASE_TYPE(                                            \
+          at::kQInt32, at::qint32, at::kInt, int, __VA_ARGS__)              \
+      default:                                                              \
+        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");      \
+    }                                                                       \
+  }()
+
 #define AT_DISPATCH_INTEGRAL_TYPES(TYPE, NAME, ...)                         \
   [&] {                                                                     \
     const auto& the_type = TYPE;                                            \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48051 [quant][refactor] Reflection pad now uses AT_DISPATCH_FLOATING_AND_QINT_TYPES
* **#48050 [quant] AT_DISPATCH_FLOATING_AND_QINT_TYPES**
* #48037 [quant] out-variant for the reflection pad
* #48036 [quant] ReflectionPad2d

The switch does not require testing -- if need to confirm if it works right, you can run the tests for the reflection padding: `python test/test_quantization.py TestPadding`

Differential Revision: [D25004159](https://our.internmc.facebook.com/intern/diff/D25004159)