### PR TITLE
[pytorch][te] Do not merge Tensor[] variant of aten::where into fusion group

### DIFF
--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -413,6 +413,8 @@ namespace jit {
   _(FuserPass_IgnoreUnknownShapeAtStart)            \
   _(FuserPass_Multidevice)                          \
   _(FuserPass_MergeGroups)                          \
+  _(FuserPass_Where)                                \
+  _(FuserPass_WhereList)                            \
   _(TrainBasic)                                     \
   _(Conv2D)
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -142,7 +142,6 @@ bool isSupported(Node* node) {
       "aten::where.ScalarSelf(Tensor condition, Scalar self, Tensor other) -> Tensor",
       "aten::where.ScalarOther(Tensor condition, Tensor self, Scalar other) -> Tensor",
       "aten::where.Scalar(Tensor condition, Scalar self, Scalar other) -> Tensor",
-      "aten::where(Tensor condition) -> Tensor[]",
       // TODO: enable other min/max variants, operators that can be both
       // elementwise or reductions:
       "aten::min.other(Tensor self, Tensor other) -> Tensor",


### PR DESCRIPTION
Summary: The TE fuser does not know how to construct a list of Tensors.

Test Plan: new unit test

Differential Revision: D25007234

