### PR TITLE
Revert "migrate export_caffe2_op_to_c10.h macros to the new dispatcher registration API (#47321)"

### DIFF
--- a/torch/library.h
+++ b/torch/library.h
@@ -667,24 +667,6 @@ public:
   ); \
   void TORCH_LIBRARY_FRAGMENT_init_ ## ns ## _ ## k (torch::Library& m)
 
-/// \private
-///
-/// This macro should only be used in a few legacy areas.
-/// This macro is a version of TORCH_LIBRARY() that:
-///     - doesn't enforce that there is only library for the given namespace
-///     - takes in a unique identifier that it appends to the names
-///       of each static variable that it creates
-/// It effectively lets you define multiple TORCH_LIBRARY_FRAGMENT blocks
-/// for the same namespace within the same translation unit, avoiding naming collisions.
-#define TORCH_LIBRARY_FRAGMENT_UNIQUE(ns, m, uid) \
-  static void C10_CONCATENATE(TORCH_LIBRARY_FRAGMENT_init_ ## ns ## _, uid) (torch::Library&); \
-  static torch::detail::TorchLibraryInit C10_CONCATENATE(TORCH_LIBRARY_FRAGMENT_static_init_ ## ns ## _, uid) ( \
-    torch::Library::FRAGMENT, \
-    &C10_CONCATENATE(TORCH_LIBRARY_FRAGMENT_init_ ## ns ## _, uid), \
-    #ns, c10::nullopt, __FILE__, __LINE__ \
-  ); \
-  void C10_CONCATENATE(TORCH_LIBRARY_FRAGMENT_init_ ## ns ## _, uid) (torch::Library& m)
-
 /// Macro for defining a function that will be run at static
 /// initialization time to define operator overrides for dispatch key
 /// `k` (must be an unqualified enum member of c10::DispatchKey) in
@@ -737,28 +719,6 @@ public:
     __FILE__, __LINE__ \
   ); \
   void TORCH_LIBRARY_IMPL_init_ ## ns ## _ ## k (torch::Library& m)
-
-/// \private
-///
-/// This macro should only be used in a few legacy areas.
-/// This macro is a version of TORCH_LIBRARY_IMPL() that:
-///     - takes in a unique identifier that it appends to the names
-///       of each static variable that it creates
-/// It effectively lets you define multiple TORCH_LIBRARY_IMPL blocks
-/// for the same namespace/dispatch key within the same translation unit,
-/// avoiding naming collisions.
-#define TORCH_LIBRARY_IMPL_UNIQUE(ns, k, m, uid) \
-  static void C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_ ## ns ## _ ## k, uid) (torch::Library&); \
-  static torch::detail::TorchLibraryInit C10_CONCATENATE(TORCH_LIBRARY_IMPL_static_init_ ## ns ## _ ## k, uid) ( \
-    torch::Library::IMPL, \
-    c10::guts::if_constexpr<c10::impl::dispatch_key_whitelist_check(c10::DispatchKey::k)>( \
-      []() { return & C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_ ## ns ## _ ## k, uid); }, \
-      []() { return [](torch::Library&) -> void {}; } \
-    ), \
-    #ns, c10::make_optional(c10::DispatchKey::k), \
-    __FILE__, __LINE__ \
-  ); \
-  void C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_ ## ns ## _ ## k, uid) (torch::Library& m)
 
 
 // These are variants of the macros above which are to be used for testing (they


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48081 Revert "remove ops in the __caffe2 namespace (#47318)"
* #48080 Revert "update legacy dispatcher registration API tests to avoid duplicate def() calls (#47319)"
* #48079 Revert "rename macro. TORCH_LIBRARY_FRAGMENT_THIS_API_IS_FOR_PER_OP_REGISTRATION_ONLY to TORCH_LIBRARY_FRAGMENT (#47320)"
* **#48078 Revert "migrate export_caffe2_op_to_c10.h macros to the new dispatcher registration API (#47321)"**

This reverts commit cba26e40cf85b1ab413c837ee19963774c434cde.

Differential Revision: [D25014921](https://our.internmc.facebook.com/intern/diff/D25014921)