### PR TITLE
Revert "rename macro. TORCH_LIBRARY_FRAGMENT_THIS_API_IS_FOR_PER_OP_REGISTRATION_ONLY to TORCH_LIBRARY_FRAGMENT (#47320)"

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1859,7 +1859,7 @@ static auto cell_params_base_registry =
               return cell_params_deserializers[type](std::move(state));
             });
 
-TORCH_LIBRARY_FRAGMENT(aten, m) {
+TORCH_LIBRARY_FRAGMENT_THIS_API_IS_FOR_PER_OP_REGISTRATION_ONLY(aten, m) {
   m.def(
       TORCH_SELECTIVE_SCHEMA("aten::quantized_lstm.input(Tensor input, Tensor[] hx, __torch__.torch.classes.rnn.CellParamsBase[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first, *, ScalarType? dtype=None, bool use_dynamic=False) -> (Tensor, Tensor, Tensor)"));
   m.def(
@@ -1878,7 +1878,7 @@ TORCH_LIBRARY_FRAGMENT(aten, m) {
       TORCH_SELECTIVE_SCHEMA("aten::quantized_gru.data_legacy(Tensor data, Tensor batch_sizes, Tensor hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional) -> (Tensor, Tensor)"));
 }
 
-TORCH_LIBRARY_FRAGMENT(quantized, m) {
+TORCH_LIBRARY_FRAGMENT_THIS_API_IS_FOR_PER_OP_REGISTRATION_ONLY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::make_quantized_cell_params_dynamic(__torch__.torch.classes.quantized.LinearPackedParamsBase w_ih, __torch__.torch.classes.quantized.LinearPackedParamsBase w_hh, Tensor bias_ih, Tensor bias_hh, bool reduce_range=False) -> __torch__.torch.classes.rnn.CellParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::make_quantized_cell_params_fp16(__torch__.torch.classes.quantized.LinearPackedParamsBase w_ih, __torch__.torch.classes.quantized.LinearPackedParamsBase w_hh) -> __torch__.torch.classes.rnn.CellParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::make_quantized_cell_params(Tensor w_ih, Tensor w_hh, Tensor b_ih, Tensor b_hh) -> __torch__.torch.classes.rnn.CellParamsBase"));

--- a/test/mobile/op_deps/simple_ops.cpp
+++ b/test/mobile/op_deps/simple_ops.cpp
@@ -89,7 +89,7 @@ TORCH_LIBRARY(_test, m) {
   m.def("DD", TORCH_FN(DD_op));
 }
 
-TORCH_LIBRARY_FRAGMENT(_test, m) {
+TORCH_LIBRARY_FRAGMENT_THIS_API_IS_FOR_PER_OP_REGISTRATION_ONLY(_test, m) {
   m.def("EE(Tensor self) -> Tensor");
   m.def("FF(Tensor self) -> Tensor");
   m.def("GG(Tensor self) -> Tensor");

--- a/torch/library.h
+++ b/torch/library.h
@@ -653,12 +653,9 @@ public:
 /// \private
 ///
 /// This macro is a version of TORCH_LIBRARY() that doesn't enforce that there
-/// is only one library (it is a "fragment").  This is used inside the
-/// PerOpRegistration.cpp file, as well as in places where all op registrations
-/// within the same namespace cannot be easily put into one macro block
-/// (this is mostly the case for custom ops in fbcode that were ported from
-/// the old API)
-#define TORCH_LIBRARY_FRAGMENT(ns, m) \
+/// is only one library (it is a "fragment").  This should ONLY be used
+/// inside the PerOpRegistration.cpp file (as its name suggests).
+#define TORCH_LIBRARY_FRAGMENT_THIS_API_IS_FOR_PER_OP_REGISTRATION_ONLY(ns, m) \
   static void TORCH_LIBRARY_FRAGMENT_init_ ## ns ## _ ## k (torch::Library&); \
   static torch::detail::TorchLibraryInit TORCH_LIBRARY_FRAGMENT_static_init_ ## ns ## _ ## k ( \
     torch::Library::FRAGMENT, \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48081 Revert "remove ops in the __caffe2 namespace (#47318)"
* #48080 Revert "update legacy dispatcher registration API tests to avoid duplicate def() calls (#47319)"
* **#48079 Revert "rename macro. TORCH_LIBRARY_FRAGMENT_THIS_API_IS_FOR_PER_OP_REGISTRATION_ONLY to TORCH_LIBRARY_FRAGMENT (#47320)"**
* #48078 Revert "migrate export_caffe2_op_to_c10.h macros to the new dispatcher registration API (#47321)"

This reverts commit 93d98373752c1ed53a7d67ed1ee691170f51c89e.

Differential Revision: [D25014920](https://our.internmc.facebook.com/intern/diff/D25014920)