### PR TITLE
[pytorch][te] Handle negative axis in chunk

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1347,6 +1347,14 @@ class TestTEFuser(JitTestCase):
         t = torch.rand(8, dtype=torch.float, device='cuda')
         scripted = self.checkScript(eager, (t, t, t, t, 0.1))
 
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_chunk_mul_one(self):
+        def eager(x):
+            z, y, w = torch.chunk(x, 3, -1)
+            return z * 3, y, w
+        x = torch.rand(64, 1, 3072, dtype=torch.float, device='cuda')
+        script = self.checkScript(eager, (x,))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -129,9 +129,12 @@ ExprHandle TensorExprKernel::broadcast(
 ExprHandle TensorExprKernel::chunk(
     Tensor* t,
     size_t chunkIdx,
-    size_t dim,
-    size_t chunks,
+    int64_t dim,
+    int64_t chunks,
     const std::vector<ExprHandle>& axes) {
+  if (dim < 0) {
+    dim = axes.size() + dim;
+  }
   auto sizes = bufferSizes(t);
   size_t step = sizes[dim] / chunks;
 

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -65,8 +65,8 @@ class TORCH_API TensorExprKernel {
   ExprHandle chunk(
       Tensor* t,
       size_t chunkIdx,
-      size_t dim,
-      size_t chunks,
+      int64_t dim,
+      int64_t chunks,
       const std::vector<ExprHandle>& axes);
 
   std::vector<ExprHandle> valueShape(const torch::jit::Value* v);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48085 [torch][te] aten::type_as is unary, not binary
* **#48084 [pytorch][te] Handle negative axis in chunk**

as title

Differential Revision: [D25017489](https://our.internmc.facebook.com/intern/diff/D25017489/)