### PR TITLE
[torch][te] aten::type_as is unary, not binary

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1355,6 +1355,17 @@ class TestTEFuser(JitTestCase):
         x = torch.rand(64, 1, 3072, dtype=torch.float, device='cuda')
         script = self.checkScript(eager, (x,))
 
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_eq_unsqueeze_type_as(self):
+        def eager(a, b):
+            mask = b == 1
+            mask = torch.unsqueeze(mask, -1)
+            x = mask.type_as(a)
+            return x, mask
+        a = torch.rand(1, 64, 1024, device='cuda', dtype=torch.float)
+        b = torch.randint(-2, 2, (1, 64), device='cuda', dtype=torch.long)
+        script = self.checkScript(eager, (a, b))
+
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48085 [torch][te] aten::type_as is unary, not binary**
* #48084 [pytorch][te] Handle negative axis in chunk

We were treating it as a binary operator, which implies shape
broadcasting, even though the second arg is thrown away aside from the type.
Treating it as a unary is the proper approach.

Differential Revision: [D25017585](https://our.internmc.facebook.com/intern/diff/D25017585/)