### PR TITLE
Revert "Revert "remove ops in the __caffe2 namespace""

### DIFF
--- a/caffe2/operators/bbox_transform_op.cc
+++ b/caffe2/operators/bbox_transform_op.cc
@@ -205,24 +205,4 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
       "Tensor output_1"
     ")",
     BBoxTransformOpFloatCPU);
-
-  C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-      BBoxTransform2,
-      "__caffe2::BBoxTransform("
-        "Tensor rois, "
-        "Tensor deltas, "
-        "Tensor im_info, "
-        "float[] weights, "
-        "bool apply_scale, "
-        "bool rotated, "
-        "bool angle_bound_on, "
-        "int angle_bound_lo, "
-        "int angle_bound_hi, "
-        "float clip_angle_thresh, "
-        "bool legacy_plus_one"
-      ") -> ("
-        "Tensor output_0, "
-        "Tensor output_1"
-      ")",
-      BBoxTransformOpFloatCPU);
 // clang-format on

--- a/caffe2/operators/box_with_nms_limit_op.cc
+++ b/caffe2/operators/box_with_nms_limit_op.cc
@@ -338,31 +338,4 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
     ")",
     caffe2::BoxWithNMSLimitOp<caffe2::CPUContext>);
 
-C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-    BoxWithNMSLimit2,
-    "__caffe2::BoxWithNMSLimit("
-      "Tensor scores, "
-      "Tensor boxes, "
-      "Tensor batch_splits, "
-      "float score_thresh, "
-      "float nms, "
-      "int detections_per_im, "
-      "bool soft_nms_enabled, "
-      "str soft_nms_method, "
-      "float soft_nms_sigma, "
-      "float soft_nms_min_score_thres, "
-      "bool rotated, "
-      "bool cls_agnostic_bbox_reg, "
-      "bool input_boxes_include_bg_cls, "
-      "bool output_classes_include_bg_cls, "
-      "bool legacy_plus_one "
-    ") -> ("
-      "Tensor scores, "
-      "Tensor boxes, "
-      "Tensor classes, "
-      "Tensor batch_splits, "
-      "Tensor keeps, "
-      "Tensor keeps_size"
-    ")",
-    caffe2::BoxWithNMSLimitOp<caffe2::CPUContext>);
 // clang-format on

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -416,25 +416,6 @@ SHOULD_NOT_DO_GRADIENT(GenerateProposalsCPP);
 
 // clang-format off
 C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-    GenerateProposals2,
-    "__caffe2::GenerateProposals("
-      "Tensor scores, "
-      "Tensor bbox_deltas, "
-      "Tensor im_info, "
-      "Tensor anchors, "
-      "float spatial_scale, "
-      "int pre_nms_topN, "
-      "int post_nms_topN, "
-      "float nms_thresh, "
-      "float min_size, "
-      "bool angle_bound_on, "
-      "int angle_bound_lo, "
-      "int angle_bound_hi, "
-      "float clip_angle_thresh, "
-      "bool legacy_plus_one"
-    ") -> (Tensor output_0, Tensor output_1)",
-    caffe2::GenerateProposalsOp<caffe2::CPUContext>);
-C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
     GenerateProposals,
     "_caffe2::GenerateProposals("
       "Tensor scores, "

--- a/caffe2/operators/heatmap_max_keypoint_op.cc
+++ b/caffe2/operators/heatmap_max_keypoint_op.cc
@@ -172,12 +172,4 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
     ") -> Tensor keypoints",
     HeatmapMaxKeypointOpFloatCPU);
 
-C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-    HeatmapMaxKeypoint2,
-    "__caffe2::HeatmapMaxKeypoint("
-      "Tensor heatmaps, "
-      "Tensor bboxes_in, "
-      "bool should_output_softmax = True"
-    ") -> Tensor keypoints",
-    HeatmapMaxKeypointOpFloatCPU);
 // clang-format on

--- a/caffe2/operators/roi_align_op.cc
+++ b/caffe2/operators/roi_align_op.cc
@@ -313,16 +313,3 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
     ") -> Tensor",
     caffe2::RoIAlignCPUOp<float>);
 
-C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-    RoIAlign2,
-    "__caffe2::RoIAlign("
-    "    Tensor features,"
-    "    Tensor rois,"
-    "    str order,"
-    "    float spatial_scale,"
-    "    int pooled_h,"
-    "    int pooled_w,"
-    "    int sampling_ratio,"
-    "    bool aligned"
-    ") -> Tensor",
-    caffe2::RoIAlignCPUOp<float>);

--- a/caffe2/operators/roi_align_rotated_op.cc
+++ b/caffe2/operators/roi_align_rotated_op.cc
@@ -424,17 +424,4 @@ C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
     ") -> Tensor",
     RoIAlignRotatedOpFloatCPU);
 
-C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
-    RoIAlignRotated2,
-    "__caffe2::RoIAlignRotated("
-      "Tensor features, "
-      "Tensor rois, "
-      "str order, "
-      "float spatial_scale, "
-      "int pooled_h, "
-      "int pooled_w, "
-      "int sampling_ratio, "
-      "bool aligned"
-    ") -> Tensor",
-    RoIAlignRotatedOpFloatCPU);
 // clang-format on

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -177,6 +177,12 @@ allow_list = [
     ("aten::_foreach_floor_", datetime.date(2020, 11, 15)),
     ("aten::_foreach_log1p", datetime.date(2020, 11, 15)),
     ("aten::_foreach_neg", datetime.date(2020, 11, 15)),
+    ("__caffe2::RoIAlign", datetime.date(2020, 11, 30)),
+    ("__caffe2::HeatmapMaxKeypoint", datetime.date(2020, 11, 30)),
+    ("__caffe2::BoxWithNMSLimit", datetime.date(2020, 11, 30)),
+    ("__caffe2::BBoxTransform", datetime.date(2020, 11, 30)),
+    ("__caffe2::GenerateProposals", datetime.date(2020, 11, 30)),
+    ("__caffe2::RoIAlignRotated", datetime.date(2020, 11, 30)),
 ]
 
 def allow_listed(schema, allow_list):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48098 make duplicate def() calls an error in the dispatcher
* #48097 migrate export_caffe2_op_to_c10.h macros to the new dispatcher registration API
* **#48096 Revert "Revert "remove ops in the __caffe2 namespace""**
* #48095 Revert "remove ops in the __caffe2 namespace"

This reverts commit 610fee8be6ccf9808758521693e6e45609779d8b.

Note that all this does is add back in my prior commit, but with a later backwards-compatibility test date

Differential Revision: [D25022847](https://our.internmc.facebook.com/intern/diff/D25022847)