### PR TITLE
fix BC test, after removing __caffe2 ops

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -177,12 +177,12 @@ allow_list = [
     ("aten::_foreach_floor_", datetime.date(2020, 11, 15)),
     ("aten::_foreach_log1p", datetime.date(2020, 11, 15)),
     ("aten::_foreach_neg", datetime.date(2020, 11, 15)),
-    ("__caffe2::RoIAlign", datetime.date(2020, 11, 15)),
-    ("__caffe2::HeatmapMaxKeypoint", datetime.date(2020, 11, 15)),
-    ("__caffe2::BoxWithNMSLimit", datetime.date(2020, 11, 15)),
-    ("__caffe2::BBoxTransform", datetime.date(2020, 11, 15)),
-    ("__caffe2::GenerateProposals", datetime.date(2020, 11, 15)),
-    ("__caffe2::RoIAlignRotated", datetime.date(2020, 11, 15)),
+    ("__caffe2::RoIAlign", datetime.date(2020, 11, 30)),
+    ("__caffe2::HeatmapMaxKeypoint", datetime.date(2020, 11, 30)),
+    ("__caffe2::BoxWithNMSLimit", datetime.date(2020, 11, 30)),
+    ("__caffe2::BBoxTransform", datetime.date(2020, 11, 30)),
+    ("__caffe2::GenerateProposals", datetime.date(2020, 11, 30)),
+    ("__caffe2::RoIAlignRotated", datetime.date(2020, 11, 30)),
 ]
 
 def allow_listed(schema, allow_list):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48098 make duplicate def() calls an error in the dispatcher
* #48097 migrate export_caffe2_op_to_c10.h macros to the new dispatcher registration API
* **#48099 fix BC test, after removing __caffe2 ops**

Differential Revision: [D25023321](https://our.internmc.facebook.com/intern/diff/D25023321)