### PR TITLE
test_linalg regex fix

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -59,7 +59,7 @@ CONFIG_TREE_DATA = [
             ]),
             ("11.1", [
                 ("3.8", [
-                    X(True),
+                    ("important", [X(True)]),
                     ("libtorch", [
                         (True, [
                             ('build_only', [XImportant(True)]),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7286,24 +7286,12 @@ workflows:
           name: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_build
           requires:
             - "docker-pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7"
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           build_environment: "pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7"
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test
           requires:
             - pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           build_environment: "pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7"
           use_cuda_docker_runtime: "1"

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1353,7 +1353,7 @@ class TestLinalg(TestCase):
         def run_test_singular_input(batch_dim, n):
             x = torch.eye(3, 3, dtype=dtype, device=device).reshape((1, 3, 3)).repeat(batch_dim, 1, 1)
             x[n, -1, -1] = 0
-            with self.assertRaisesRegex(RuntimeError, r'.*For batch .* : U(3,3) is zero.*'):
+            with self.assertRaisesRegex(RuntimeError, rf'inverse_{device}: For batch {n}: U\(3,3\) is zero, singular U.'):
                 torch.inverse(x)
 
         for params in [(1, 0), (2, 0), (2, 1), (4, 0), (4, 2), (10, 2)]:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1353,7 +1353,7 @@ class TestLinalg(TestCase):
         def run_test_singular_input(batch_dim, n):
             x = torch.eye(3, 3, dtype=dtype, device=device).reshape((1, 3, 3)).repeat(batch_dim, 1, 1)
             x[n, -1, -1] = 0
-            with self.assertRaisesRegex(RuntimeError, rf'For batch {n}: U\(3,3\) is zero'):
+            with self.assertRaisesRegex(RuntimeError, r'.*For batch .* : U(3,3) is zero.*'):
                 torch.inverse(x)
 
         for params in [(1, 0), (2, 0), (2, 1), (4, 0), (4, 2), (10, 2)]:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1353,7 +1353,8 @@ class TestLinalg(TestCase):
         def run_test_singular_input(batch_dim, n):
             x = torch.eye(3, 3, dtype=dtype, device=device).reshape((1, 3, 3)).repeat(batch_dim, 1, 1)
             x[n, -1, -1] = 0
-            with self.assertRaisesRegex(RuntimeError, rf'inverse_{device}: For batch {n}: U\(3,3\) is zero, singular U.'):
+            device_no_index = device.split(':')[0]
+            with self.assertRaisesRegex(RuntimeError, rf'inverse_{device_no_index}: For batch {n}: U\(3,3\) is zero, singular U.'):
                 torch.inverse(x)
 
         for params in [(1, 0), (2, 0), (2, 1), (4, 0), (4, 2), (10, 2)]:


### PR DESCRIPTION
Should fix [pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test](https://app.circleci.com/pipelines/github/pytorch/pytorch/240146/workflows/dbf5e5ff-1725-4153-ad4b-02a3ccbfc278/jobs/8991489)

With CUDA 11.1, the error message is slightly more specific. Using regex wildcard to capture all possible error messages from different CUDAs.

Disclaimer: As a result, I had to make the regex more general--am not sure this is the best approach.