### PR TITLE
Pruning codeowners who don't actual do code review.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,20 +1,15 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-/docs/cpp @goldsborough @ebetica @yf225 @glaringlee
-/torch/csrc/api/ @ebetica @goldsborough @yf225 @glaringlee
-/test/cpp/api/ @ebetica @goldsborough @yf225 @glaringlee
-/torch/utils/cpp_extension.py @goldsborough @fmassa @soumith @ezyang
+/docs/cpp @glaringlee
+/torch/csrc/api/ @glaringlee
+/test/cpp/api/ @glaringlee
+/torch/utils/cpp_extension.py @fmassa @soumith @ezyang
 
 # Not there to strictly require the approval, but to be tagged as a reviewer
 # on the PRs to push them into a high priority inbox.
-/torch/csrc/api/data/ @apaszke
-/torch/csrc/autograd/ @apaszke @albanD
-/torch/csrc/jit/ @apaszke
-/torch/nn/ @apaszke
-/torch/autograd/ @apaszke @albanD
-/torch/jit/ @apaszke
-/torch/utils/data/ @apaszke
+/torch/csrc/autograd/ @albanD
+/torch/autograd/ @albanD
 
 # Tensorpipe RPC Agent.
 /torch/csrc/distributed/rpc/tensorpipe_agent.cpp @jiayisuse @osalpekar @lw @beauby
@@ -23,9 +18,9 @@
 # Distributed package
 # This list is mostly if you'd like to be tagged as reviewer, feel free to add
 # or remove yourself from it.
-/torch/lib/c10d/ @pietern @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma @mingzhe09088
-/torch/csrc/distributed/ @pietern @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma @mingzhe09088
-/torch/distributed/ @apaszke @pietern @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma @mingzhe09088
+/torch/lib/c10d/ @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma @mingzhe09088
+/torch/csrc/distributed/ @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma @mingzhe09088
+/torch/distributed/ @mrshenli @zhaojuanmao @pritamdamania87 @rohan-varma @mingzhe09088
 
 # Distributed tests
 # This list is mostly if you'd like to be tagged as reviewer, feel free to add


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48109 Pruning codeowners who don't actual do code review.**

Recently, some new folks got confused because CODEOWNERS assigned a reviewer who isn't actually going to review the PR. Easier for people to understand if they have a reviewer or not if we don't assign people who don't actually do reviews in practice.

CC mechanism may still be helpful, we should make a file path version of https://github.com/pytorch/pytorch/issues/24422

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D25026754](https://our.internmc.facebook.com/intern/diff/D25026754)