### PR TITLE
[FX] Fix name mangling (again...)

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -607,6 +607,7 @@ terrible spacing
         a, b, c, d = torch.ones(4), torch.ones(4), torch.ones(4), torch.ones(4)
         mm = MyModule()
         traced = symbolic_trace(mm)
+
         def split_cb(node : torch.fx.Node):
             if node.name == 'a' or node.name == 'b' or node.name == 'add_1':
                 return 0

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -615,7 +615,6 @@ terrible spacing
         module_with_submodule = split_module(traced, mm, split_cb)
         self.assertEqual(module_with_submodule(a, b, c, d), traced(a, b, c, d))
 
-
     def test_traceable_function_with_nonstandard_name(self):
         def foo(x):
             return torch.relu(x)

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -589,6 +589,33 @@ terrible spacing
         module_with_submodules = split_module(traced, m, lambda node: 0)
         module_with_submodules(a)
 
+    def test_subgraph_uniquename(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, a, b, c, d):
+                add_1 = a + b
+                add_2 = add_1 + c
+                linear_1 = self.linear(add_1)
+                add_3 = add_2 + d
+                add_4 = add_2 + linear_1
+                add_5 = add_3 + add_4
+                return add_5
+
+        a, b, c, d = torch.ones(4), torch.ones(4), torch.ones(4), torch.ones(4)
+        mm = MyModule()
+        traced = symbolic_trace(mm)
+        def split_cb(node : torch.fx.Node):
+            if node.name == 'a' or node.name == 'b' or node.name == 'add_1':
+                return 0
+            else:
+                return 1
+        module_with_submodule = split_module(traced, mm, split_cb)
+        self.assertEqual(module_with_submodule(a, b, c, d), traced(a, b, c, d))
+
+
     def test_traceable_function_with_nonstandard_name(self):
         def foo(x):
             return torch.relu(x)

--- a/torch/fx/experimental/subgraph_creation_example.py
+++ b/torch/fx/experimental/subgraph_creation_example.py
@@ -155,6 +155,9 @@ def split_module(
         output_vals = output_vals[0] if len(output_vals) == 1 else output_vals  # type: ignore
         partition.graph.output(output_vals)
 
+        # Lint graph
+        partition.graph.lint()
+
         # Construct GraphModule for this partition
         submod_name = f'submod_{partition_name}'
         base_mod_attrs[submod_name] = torch.fx.graph_module.GraphModule(partition.targets, partition.graph)
@@ -173,5 +176,8 @@ def split_module(
     for node in m.graph.nodes:
         if node.op == 'output':
             base_mod_graph.output(torch.fx.graph.map_arg(node.args[0], lambda n : base_mod_env[n.name]))
+
+    # Lint base graph
+    base_mod_graph.lint()
 
     return torch.fx.graph_module.GraphModule(base_mod_attrs, base_mod_graph)

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -472,7 +472,10 @@ class Graph:
                not _shadows_builtin_name(op):
                 return op
         i = self._used_names[op] = self._used_names[op] + 1
-        return f'{op}_{i}'
+        # Someone may have explicitly created a name line `add_0`, so recursively
+        # enter this function again to check that that string is not already
+        # used.
+        return self._register_name_used(f'{op}_{i}')
 
     def python_code(self, root_module: str) -> str:
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48157 [WIP][FX] Revamp node unique name logic + add additional uniquing in codegen
* **#48112 [FX] Fix name mangling (again...)**

Someone can explicitly add a name like `add_0`, which previously wouldn't get caught by `_register_name_used`.

Differential Revision: [D25028695](https://our.internmc.facebook.com/intern/diff/D25028695)