### PR TITLE
third_party: Update pybind to point to fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/pybind11"]
     ignore = dirty
     path = third_party/pybind11
-    url = https://github.com/pybind/pybind11.git
+    url = https://github.com/seemethere/pybind11.git
 [submodule "third_party/cub"]
     ignore = dirty
     path = third_party/cub


### PR DESCRIPTION
There are specific patches we need for Python 3.9 compatibilty and that
process is currently hung up on separate issues.

Let's update to a newer version of our forked pybind to grab the Python
3.9 fixes while we wait for them to be upstreamed

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Relates to: https://github.com/pybind/pybind11/pull/2657

Full comparison for this update looks like this: https://github.com/pybind/pybind11/compare/59a2ac2745d8a57ac94c6accced73620d59fb844...seemethere:v2.6-fb

Fixes #47776 
