### PR TITLE
Leak PythonEngine singleton

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4031,26 +4031,6 @@ class TestAutograd(TestCase):
         b.data = a
         self.assertTrue(b_id_saved == id(b))
 
-    @unittest.skipIf(IS_WINDOWS, "Skipping because doesn't work for windows")
-    def test_thread_shutdown(self):
-        code = """import torch
-from torch.autograd import Function
-class MyFunction(Function):
-    @staticmethod
-    def forward(ctx, x):
-        return x
-
-    @staticmethod
-    def backward(ctx, grad):
-        return grad
-
-for shape in [(1,), ()]:
-    v = torch.ones(shape, requires_grad=True)
-    MyFunction.apply(v).backward()
-"""
-        s = TestCase.runWithPytorchAPIUsageStderr(code)
-        self.assertRegex(s, "PYTORCH_API_USAGE torch.autograd.thread_shutdown")
-
     @unittest.skipIf(IS_MACOS, "Fails with SIGBUS on macOS; https://github.com/pytorch/pytorch/issues/25941")
     def test_deep_reentrant(self):
 

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -53,10 +53,10 @@ Engine& PythonEngine::get_python_engine() {
 }
 
 void PythonEngine::thread_init(int device, const std::shared_ptr<ReadyQueue>& ready_queue, bool should_increment) {
-  // Increment thread usage count before acquiring the GIL
-  if (should_increment) {
-    increment_non_reentrant_thread_count();
-  }
+  //Ignore `should_increment` option, as PythonEngine device threads should never be destroyed
+  // (as Python runtime most likely is invalid during the destruction of singletons/global variables
+  (void)should_increment;
+
   // Create a PyThreadState, but release the GIL. This lets pybind11::gil_scoped_acquire calls
   // inside thread_main acquire the GIL without having to create a new
   // PyThreadState each time.
@@ -64,10 +64,6 @@ void PythonEngine::thread_init(int device, const std::shared_ptr<ReadyQueue>& re
   pybind11::gil_scoped_release no_gil;
   Engine::thread_init(device, ready_queue, false);
 
-  if (should_increment) {
-    // Decrement the count during shutdown if we incremented earlier.
-    decrement_non_reentrant_thread_count();
-  }
 }
 
 void PythonEngine::thread_on_exception(


### PR DESCRIPTION
Avoid autograd threads global shutdown logic complexity by leaking PythongEngine and relying on the OS to do resource cleanup

