### PR TITLE
Enable the faster combined weight branch in MHA when query/key/value is same object with nan

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4126,11 +4126,11 @@ def multi_head_attention_forward(query: Tensor,
     scaling = float(head_dim) ** -0.5
 
     if not use_separate_proj_weight:
-        if torch.equal(query, key) and torch.equal(key, value):
+        if (query is key or torch.equal(query, key)) and (key is value or torch.equal(key, value)):
             # self-attention
             q, k, v = linear(query, in_proj_weight, in_proj_bias).chunk(3, dim=-1)
 
-        elif torch.equal(key, value):
+        elif (key is value or torch.equal(key, value)):
             # encoder-decoder attention
             # This is inline in_proj function with in_proj_weight and in_proj_bias
             _b = in_proj_bias


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/47979

For MHA module, it is preferred to use the combined weight branch as much as possible when query/key/value are same (in case of same values by `torch.equal` or exactly same object by `is` ops). This PR will enable the faster branch when a single object with `nan` is passed to MHA.

For the background knowledge
```
import torch
a = torch.tensor([float('NaN'), 1, float('NaN'), 2, 3])
print(a is a) # True
print(torch.equal(a, a)) # False
``` 
