### PR TITLE
[JIT] Modify Type::isSubtypeOf[Ext] to take in a const Type&

### DIFF
--- a/aten/src/ATen/BatchedFallback.cpp
+++ b/aten/src/ATen/BatchedFallback.cpp
@@ -32,7 +32,7 @@ static bool areAnyArgumentsTensorList(const FunctionSchema& schema) {
   return std::any_of(
       schema.arguments().begin(),
       schema.arguments().end(),
-      [] (const Argument& arg) { return arg.type()->isSubtypeOf(ListType::ofTensors()); });
+      [] (const Argument& arg) { return arg.type()->isSubtypeOf(*ListType::ofTensors()); });
 }
 
 // Returns if an operator is in-place. An operator is inplace if:

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -155,7 +155,7 @@ private:
         " arguments but this PyTorch build only supports ", c10::utils::bitset::NUM_BITS());
     c10::utils::bitset dispatch_arg_indices_reverse;
     for (size_t index = 0; index < schema.arguments().size(); ++index) {
-      if (schema.arguments()[index].type()->isSubtypeOf(TensorType::get()) || schema.arguments()[index].type()->isSubtypeOf(ListType::ofTensors())) {
+      if (schema.arguments()[index].type()->isSubtypeOf(*TensorType::get()) || schema.arguments()[index].type()->isSubtypeOf(*ListType::ofTensors())) {
         dispatch_arg_indices_reverse.set(schema.arguments().size() - 1 - index);
       }
     }

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -64,7 +64,7 @@ inline bool Argument::isBackwardCompatibleWith(
     if (lhs->kwarg_only() && !rhs->kwarg_only()) {
       return false;
     }
-    if (!rhs->type()->isSubtypeOfExt(lhs->type(), why_not)) {
+    if (!rhs->type()->isSubtypeOfExt(*lhs->type(), why_not)) {
       return false;
     }
     if (rhs->default_value().has_value() &&
@@ -155,7 +155,7 @@ inline void FunctionSchema::checkArg(
     // Fast-path for the common case
     return;
   }
-  if (!value.type()->isSubtypeOf(argument.type())) {
+  if (!value.type()->isSubtypeOf(*argument.type())) {
     TORCH_CHECK(
         false,
         formatTypeMismatchMsg(
@@ -280,7 +280,7 @@ inline bool isSubtypeOfList(
     if (c.name() != p.name()) {
       return false;
     }
-    if (!c.type()->isSubtypeOfExt(p.type(), why_not)) {
+    if (!c.type()->isSubtypeOfExt(*p.type(), why_not)) {
       return false;
     }
   }

--- a/caffe2/core/export_c10_op_to_caffe2.h
+++ b/caffe2/core/export_c10_op_to_caffe2.h
@@ -46,7 +46,7 @@ class C10OperatorWrapper final : public Operator<Context> {
     AT_ASSERT(
         !has_preallocated_outputs_ ||
         op_.schema().arguments().back().type()->isSubtypeOf(
-            OptionalType::create(ListType::ofTensors())));
+            *OptionalType::create(ListType::ofTensors())));
 
     AT_ASSERT(operator_def.output_size() == op_.schema().returns().size());
     AT_ASSERT(
@@ -88,26 +88,26 @@ class C10OperatorWrapper final : public Operator<Context> {
 
         AT_ASSERTM(
             argument.type()->isSubtypeOf(
-                OptionalType::create(ListType::ofTensors())),
+                *OptionalType::create(ListType::ofTensors())),
             "Error in caffe2->c10 wrapper: Operator schema has a parameter named ",
             detail::PREALLOCATED_OUTPUT_ARGNAME,
             ", but it's not of type TensorList?");
         stack_.emplace_back(preallocated_outputs_());
 
-      } else if (argument.type()->isSubtypeOf(TensorType::get())) {
+      } else if (argument.type()->isSubtypeOf(*TensorType::get())) {
         AT_ASSERTM(
             input_tensor_index < InputSize(),
             "Error in caffe2->c10 wrapper: Too few tensor arguments given (",
             InputSize(),
             "), operator schema expected more.");
         stack_.emplace_back(at::Tensor(Input(input_tensor_index++)));
-      } else if (argument.type()->isSubtypeOf(OptionalType::ofTensor())) {
+      } else if (argument.type()->isSubtypeOf(*OptionalType::ofTensor())) {
         if (input_tensor_index < InputSize()) {
           stack_.emplace_back(at::Tensor(Input(input_tensor_index++)));
         } else {
           stack_.emplace_back(IValue());
         }
-      } else if (argument.type()->isSubtypeOf(ListType::ofTensors())) {
+      } else if (argument.type()->isSubtypeOf(*ListType::ofTensors())) {
         AT_ASSERTM(
             input_tensor_index == 0,
             "Error in caffe2->c10 wrapper: Schema can only have either one or more Tensor inputs or one TensorList input.");
@@ -159,13 +159,13 @@ class C10OperatorWrapper final : public Operator<Context> {
   }
 
   IValue get_nontensor_argument_(const c10::Argument& argument) {
-    if (argument.type()->isSubtypeOf(IntType::get())) {
+    if (argument.type()->isSubtypeOf(*IntType::get())) {
       return get_nontensor_argument_<int>(
           argument.name(), argument.default_value());
-    } else if (argument.type()->isSubtypeOf(FloatType::get())) {
+    } else if (argument.type()->isSubtypeOf(*FloatType::get())) {
       return get_nontensor_argument_<double>(
           argument.name(), argument.default_value());
-    } else if (argument.type()->isSubtypeOf(BoolType::get())) {
+    } else if (argument.type()->isSubtypeOf(*BoolType::get())) {
       return get_nontensor_argument_<bool>(
           argument.name(), argument.default_value());
     } else {

--- a/caffe2/core/export_caffe2_op_to_c10.h
+++ b/caffe2/core/export_caffe2_op_to_c10.h
@@ -55,7 +55,7 @@ inline void _call_caffe2_op_from_c10(
   AT_ASSERT(
       schema.arguments().size() != 0 &&
       schema.arguments().back().type()->isSubtypeOf(
-          OptionalType::create(ListType::ofTensors())));
+          *OptionalType::create(ListType::ofTensors())));
   IValue preallocated_outputs = torch::jit::pop(*stack);
 
   const size_t num_outputs = schema.returns().size();

--- a/test/cpp/jit/test_custom_operators.cpp
+++ b/test/cpp/jit/test_custom_operators.cpp
@@ -85,17 +85,17 @@ TEST(CustomOperatorTest, ListParameters) {
   ASSERT_EQ(op->schema().arguments().size(), 3);
   ASSERT_EQ(op->schema().arguments()[0].name(), "ints");
   ASSERT_TRUE(
-      op->schema().arguments()[0].type()->isSubtypeOf(ListType::ofInts()));
+      op->schema().arguments()[0].type()->isSubtypeOf(*ListType::ofInts()));
   ASSERT_EQ(op->schema().arguments()[1].name(), "floats");
   ASSERT_TRUE(
-      op->schema().arguments()[1].type()->isSubtypeOf(ListType::ofFloats()));
+      op->schema().arguments()[1].type()->isSubtypeOf(*ListType::ofFloats()));
   ASSERT_EQ(op->schema().arguments()[2].name(), "tensors");
   ASSERT_TRUE(
-      op->schema().arguments()[2].type()->isSubtypeOf(ListType::ofTensors()));
+      op->schema().arguments()[2].type()->isSubtypeOf(*ListType::ofTensors()));
 
   ASSERT_EQ(op->schema().returns().size(), 1);
   ASSERT_TRUE(
-      op->schema().returns()[0].type()->isSubtypeOf(ListType::ofFloats()));
+      op->schema().returns()[0].type()->isSubtypeOf(*ListType::ofFloats()));
 
   Stack stack;
   push(stack, c10::List<int64_t>({1, 2}));
@@ -124,11 +124,11 @@ TEST(CustomOperatorTest, ListParameters2) {
   ASSERT_EQ(op->schema().arguments().size(), 1);
   ASSERT_EQ(op->schema().arguments()[0].name(), "tensors");
   ASSERT_TRUE(
-      op->schema().arguments()[0].type()->isSubtypeOf(ListType::ofTensors()));
+      op->schema().arguments()[0].type()->isSubtypeOf(*ListType::ofTensors()));
 
   ASSERT_EQ(op->schema().returns().size(), 1);
   ASSERT_TRUE(
-      op->schema().returns()[0].type()->isSubtypeOf(ListType::ofTensors()));
+      op->schema().returns()[0].type()->isSubtypeOf(*ListType::ofTensors()));
 
   Stack stack;
   push(stack, c10::List<at::Tensor>({at::ones(5)}));

--- a/test/cpp/jit/test_irparser.cpp
+++ b/test/cpp/jit/test_irparser.cpp
@@ -145,7 +145,7 @@ TEST(IRParserTest, InferredTypeIsTensor) {
 graph(%a):
   return (%a))IR",
       &*graph);
-  AT_ASSERT(graph->inputs()[0]->type()->isSubtypeOf(TensorType::get()));
+  AT_ASSERT(graph->inputs()[0]->type()->isSubtypeOf(*TensorType::get()));
 }
 
 TEST(IRParserTest, ValueReuse) {
@@ -259,7 +259,7 @@ TEST(IRParserTest, FileCheck) {
       return (%a))IR";
 
   parseIR(text, &*graph);
-  AT_ASSERT(graph->inputs()[0]->type()->isSubtypeOf(TensorType::get()));
+  AT_ASSERT(graph->inputs()[0]->type()->isSubtypeOf(*TensorType::get()));
   torch::jit::testing::FileCheck().run(text, *graph);
 }
 

--- a/test/cpp/jit/test_jit_type.cpp
+++ b/test/cpp/jit/test_jit_type.cpp
@@ -12,14 +12,14 @@ TEST(JitTypeTest, UnifyTypes) {
   auto bool_tensor = TensorType::get()->withScalarType(at::kBool);
   auto opt_bool_tensor = OptionalType::create(bool_tensor);
   auto unified_opt_bool = unifyTypes(bool_tensor, opt_bool_tensor);
-  TORCH_INTERNAL_ASSERT(opt_bool_tensor->isSubtypeOf(*unified_opt_bool));
+  TORCH_INTERNAL_ASSERT(opt_bool_tensor->isSubtypeOf(*(*unified_opt_bool)));
 
   auto tensor = TensorType::get();
-  TORCH_INTERNAL_ASSERT(!tensor->isSubtypeOf(opt_bool_tensor));
+  TORCH_INTERNAL_ASSERT(!tensor->isSubtypeOf(*opt_bool_tensor));
   auto unified = unifyTypes(opt_bool_tensor, tensor);
   TORCH_INTERNAL_ASSERT(unified);
   auto elem = (*unified)->expect<OptionalType>()->getElementType();
-  TORCH_INTERNAL_ASSERT(elem->isSubtypeOf(TensorType::get()));
+  TORCH_INTERNAL_ASSERT(elem->isSubtypeOf(*TensorType::get()));
 
   auto opt_tuple_none_int = OptionalType::create(
       TupleType::create({NoneType::get(), IntType::get()}));
@@ -38,7 +38,7 @@ TEST(JitTypeTest, UnifyTypes) {
   auto fut_out = unifyTypes(fut_1, fut_2);
   TORCH_INTERNAL_ASSERT(fut_out);
   TORCH_INTERNAL_ASSERT((*fut_out)->isSubtypeOf(
-      FutureType::create(OptionalType::create(IntType::get()))));
+      *FutureType::create(OptionalType::create(IntType::get()))));
 
   auto dict_1 = DictType::create(IntType::get(), NoneType::get());
   auto dict_2 = DictType::create(IntType::get(), IntType::get());

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -497,21 +497,21 @@ TEST(SchemaParserTest, NestedArrays) {
   // nested arrays
   auto s = parseSchema("at::what(int[][4] foo) -> ()");
   ASSERT_TRUE(s.arguments().at(0).N() == 4);
-  ASSERT_TRUE(IntType::get()->isSubtypeOf(s.arguments()
-                                              .at(0)
-                                              .type()
-                                              ->expect<ListType>()
-                                              ->getElementType()
-                                              ->expect<ListType>()
-                                              ->getElementType()));
+  ASSERT_TRUE(IntType::get()->isSubtypeOf(*s.arguments()
+                                               .at(0)
+                                               .type()
+                                               ->expect<ListType>()
+                                               ->getElementType()
+                                               ->expect<ListType>()
+                                               ->getElementType()));
   auto s2 = parseSchema("at::what(int[][] foo) -> ()");
-  ASSERT_TRUE(IntType::get()->isSubtypeOf(s2.arguments()
-                                              .at(0)
-                                              .type()
-                                              ->expect<ListType>()
-                                              ->getElementType()
-                                              ->expect<ListType>()
-                                              ->getElementType()));
+  ASSERT_TRUE(IntType::get()->isSubtypeOf(*s2.arguments()
+                                               .at(0)
+                                               .type()
+                                               ->expect<ListType>()
+                                               ->getElementType()
+                                               ->expect<ListType>()
+                                               ->getElementType()));
 }
 
 TEST(SchemaParserTest, NamedReturns) {
@@ -527,7 +527,7 @@ TEST(SchemaParserTest, Futures) {
   // futures
   auto s4 = parseSchema("at::what(Future(int) foo) -> ()");
   ASSERT_TRUE(IntType::get()->isSubtypeOf(
-      s4.arguments().at(0).type()->expect<FutureType>()->getElementType()));
+      *s4.arguments().at(0).type()->expect<FutureType>()->getElementType()));
 }
 
 TEST(SchemaParserTest, AnnotatedAliasSets) {

--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -115,8 +115,8 @@ TEST(SerializationTest, TypeTags) {
   for (auto item : items) {
     auto bytes = torch::pickle_save(item.value);
     auto loaded = torch::pickle_load(bytes);
-    ASSERT_TRUE(loaded.type()->isSubtypeOf(item.expected_type));
-    ASSERT_TRUE(item.expected_type->isSubtypeOf(loaded.type()));
+    ASSERT_TRUE(loaded.type()->isSubtypeOf(*item.expected_type));
+    ASSERT_TRUE(item.expected_type->isSubtypeOf(*loaded.type()));
   }
 }
 

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -72,7 +72,7 @@ TypePtr tryInferTypeWithTypeHint(
     TORCH_CHECK(
         type_hint_ptr != nullptr &&
             module.value().type()->isSubtypeOfExt(
-                type_hint_ptr, &subtype_check_msg),
+                *type_hint_ptr, &subtype_check_msg),
         module.value().type()->repr_str(),
         " is not a subtype of the type hint: ",
         type_qualified_name.qualifiedName(),

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -343,7 +343,7 @@ c10::intrusive_ptr<OwnerRRef> RRefContext::getOrCreateOwnerRRef(
     // information on other workers because it's only information only.
     if (type == TensorType::get()) {
       TORCH_INTERNAL_ASSERT(
-          ownerRRef->type()->isSubtypeOf(TensorType::get()),
+          ownerRRef->type()->isSubtypeOf(*TensorType::get()),
           "Expect OwnerRRef to be a sub-type of TensorType, but got ",
           ownerRRef->type()->repr_str());
     } else {

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -506,7 +506,7 @@ struct TORCH_API BufferPolicy {
     return std::move(v).toTensor();
   }
   static bool valid(const ClassTypePtr& typ, size_t i, const IValue& v) {
-    return typ->getAttribute(i)->isSubtypeOf(TensorType::get()) &&
+    return typ->getAttribute(i)->isSubtypeOf(*TensorType::get()) &&
         !typ->is_parameter(i);
   }
   static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = false;

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -45,7 +45,7 @@ struct TORCH_API Object {
     } else if (auto slot = _ivalue()->type()->findAttributeSlot(name)) {
       const c10::TypePtr& expected = _ivalue()->type()->getAttribute(*slot);
       TORCH_CHECK(
-          v.type()->isSubtypeOf(expected),
+          v.type()->isSubtypeOf(*expected),
           "Expected a value of type '",
           expected->repr_str(),
           "' for field '",

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -553,7 +553,7 @@ GraphCache::GraphCache(const std::shared_ptr<Graph>& graph) {
         // TODO: I think merge cannot handle broadcast - Go verify it later;
         // TODO: Since we are only handling permutation here, we should just
         //       merge the stride_index_;
-        acc_type = acc_type->merge(input_type);
+        acc_type = acc_type->merge(*input_type);
       } else {
         acc_type = input_type;
       }

--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -120,7 +120,7 @@ class CudaFusionManager {
           // TODO: I think merge cannot handle broadcast - Go verify it later;
           // TODO: Since we are only handling permutation here, we should just
           //       merge the stride_index_;
-          acc_type = acc_type->merge(input_type);
+          acc_type = acc_type->merge(*input_type);
         } else {
           acc_type = input_type;
         }

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -476,7 +476,7 @@ class IrParser {
           [](const Node* node) -> bool {
             // we don't support cast of output types yet;
             if (!node->inputs()[3]->type()->isSubtypeOf(
-                    static_cast<c10::TypePtr>(NoneType::get()))) {
+                    *static_cast<c10::TypePtr>(NoneType::get()))) {
               // We can only handle output as half and float;
               if (const auto opt_ivalue = toIValue(node->input(3))) {
                 const auto scalar_type = opt_ivalue->toScalarType();
@@ -539,7 +539,8 @@ class IrParser {
   }
 
   bool registerScalar(const JitValue* val) {
-    if (val->type()->isSubtypeOf(static_cast<c10::TypePtr>(FloatType::get()))) {
+    if (val->type()->isSubtypeOf(
+            *static_cast<c10::TypePtr>(FloatType::get()))) {
       CgValue cg_val;
       if (auto ival = constant_as<float>(val)) {
         cg_val = new Float(ival.value());
@@ -549,7 +550,7 @@ class IrParser {
       value_map_.emplace(val->unique(), cg_val);
       return true;
     } else if (val->type()->isSubtypeOf(
-                   static_cast<c10::TypePtr>(IntType::get()))) {
+                   *static_cast<c10::TypePtr>(IntType::get()))) {
       CgValue cg_val;
       if (auto ival = constant_as<int>(val)) {
         cg_val = new Int(ival.value());
@@ -559,7 +560,7 @@ class IrParser {
       value_map_.emplace(val->unique(), cg_val);
       return true;
     } else if (val->type()->isSubtypeOf(
-                   static_cast<c10::TypePtr>(BoolType::get()))) {
+                   *static_cast<c10::TypePtr>(BoolType::get()))) {
       CgValue cg_val;
       if (auto ival = constant_as<bool>(val)) {
         cg_val = new Bool(ival.value());
@@ -569,7 +570,7 @@ class IrParser {
       value_map_.emplace(val->unique(), cg_val);
       return true;
     } else if (val->type()->isSubtypeOf(
-                   static_cast<c10::TypePtr>(NoneType::get()))) {
+                   *static_cast<c10::TypePtr>(NoneType::get()))) {
       // TODO: should we consider adding support for NoneType;
       return true;
     } else if (val->type()->cast<ListType>()) {

--- a/torch/csrc/jit/codegen/cuda/partition.cpp
+++ b/torch/csrc/jit/codegen/cuda/partition.cpp
@@ -15,7 +15,7 @@ namespace {
 //   2. on the same device;
 // TODO: update this when codegen can output scalar
 static c10::optional<c10::Device> getDevice(const Value* value) {
-  if (!value->type()->isSubtypeOf(TensorType::get())) {
+  if (!value->type()->isSubtypeOf(*TensorType::get())) {
     // not tensor type, return false as the op is not outputing scalar.
     return c10::nullopt;
   }

--- a/torch/csrc/jit/codegen/cuda/shape_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/shape_inference.cpp
@@ -43,7 +43,7 @@ class NaiveTypePropagator {
     switch (node->kind()) {
       // Constant:
       case prim::Constant: {
-        if (node->output()->type()->isSubtypeOf(TensorType::get())) {
+        if (node->output()->type()->isSubtypeOf(*TensorType::get())) {
           node->output()->inferTypeFrom(node->t(attr::value));
         }
         break;
@@ -152,7 +152,7 @@ class NaiveTypePropagator {
 
         // accept dtype input to `aten::sum` node
         if (!node->input(3)->type()->isSubtypeOf(
-                static_cast<c10::TypePtr>(NoneType::get()))) {
+                *static_cast<c10::TypePtr>(NoneType::get()))) {
           if (auto opt_ivalue = toIValue(node->input(3))) {
             out_type = out_type->withScalarType(opt_ivalue->toScalarType());
           }

--- a/torch/csrc/jit/codegen/fuser/compiler.cpp
+++ b/torch/csrc/jit/codegen/fuser/compiler.cpp
@@ -122,7 +122,7 @@ static std::vector<int64_t> getInputDependencies(const Value* output) {
     // This needs to be revisited when you start allowing
     // other things e.g. nonconstant scalars.
     if (producer->kind() == prim::Param &&
-        val->type()->isSubtypeOf(TensorType::get())) {
+        val->type()->isSubtypeOf(*TensorType::get())) {
       inputs.insert(val);
       continue;
     }
@@ -229,10 +229,10 @@ std::shared_ptr<FusedKernel> compileKernel(
   {
     size_t input_index = 0;
     for (const auto& p : graph->inputs()) {
-      if (p->type()->isSubtypeOf(FloatType::get())) {
+      if (p->type()->isSubtypeOf(*FloatType::get())) {
         flat_inputs.emplace_back(p, c10::nullopt);
       }
-      if (!p->type()->isSubtypeOf(TensorType::get())) {
+      if (!p->type()->isSubtypeOf(*TensorType::get())) {
         continue;
       }
       if (const Node* chunk = usedInFusedChunk(p)) {

--- a/torch/csrc/jit/codegen/fuser/kernel_spec.h
+++ b/torch/csrc/jit/codegen/fuser/kernel_spec.h
@@ -74,7 +74,7 @@ struct TORCH_API KernelSpec {
     }
     nTensorInputs_ = std::count_if(
         graph_->inputs().begin(), graph_->inputs().end(), [](const Value* v) {
-          return v->type()->isSubtypeOf(TensorType::get());
+          return v->type()->isSubtypeOf(*TensorType::get());
         });
   }
 

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     Function& m,
     const std::string& field) {
   // Allow method-style casts on Tensor types. e.g. x.int()
-  if (value_->type()->isSubtypeOf(TensorType::get())) {
+  if (value_->type()->isSubtypeOf(*TensorType::get())) {
     if (builtin_cast_method_to_scalar_type().count(field)) {
       return std::make_shared<TensorCastValue>(
           builtin_cast_method_to_scalar_type().at(field),
@@ -192,7 +192,7 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
   }
 
   // Handle calling tolist() on a Tensor.
-  if (value_->type()->isSubtypeOf(TensorType::get()) && field == "tolist") {
+  if (value_->type()->isSubtypeOf(*TensorType::get()) && field == "tolist") {
     return SpecialFormValue::create(prim::tolist);
   }
 
@@ -232,7 +232,7 @@ std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(
 }
 
 static bool isRecursive(const TypePtr& classType, const TypePtr& attrType) {
-  if (attrType->isSubtypeOf(classType)) {
+  if (attrType->isSubtypeOf(*classType)) {
     return true;
   }
 
@@ -310,7 +310,7 @@ void SimpleValue::setAttr(
 
   // Check type correctness
   const auto newType = newValue->type();
-  if (!newType->isSubtypeOf(expectedType)) {
+  if (!newType->isSubtypeOf(*expectedType)) {
     throw ErrorReport(loc) << "Wrong type for attribute assignment. Expected "
                            << expectedType->repr_str() << " but got "
                            << newType->repr_str();
@@ -366,7 +366,7 @@ Value* SimpleValue::len(const SourceRange& loc, Function& m) {
   TypePtr val_type = val->type();
   Graph& g = *m.graph();
   if (val_type->cast<ListType>() || val_type->cast<StringType>() ||
-      val_type->isSubtypeOf(TensorType::get())) {
+      val_type->isSubtypeOf(*TensorType::get())) {
     return g.insert(aten::len, {val}, {}, loc);
   } else {
     throw ErrorReport(loc) << "'" << val_type->repr_str() << "'"
@@ -390,7 +390,7 @@ SugaredValuePtr SimpleValue::getitem(
   } else if (auto dict_type = val_type->cast<DictType>()) {
     return std::make_shared<SimpleValue>(
         g.insert(aten::__getitem__, {val, idx}, {}, loc));
-  } else if (val_type->isSubtypeOf(TensorType::get())) {
+  } else if (val_type->isSubtypeOf(*TensorType::get())) {
     return std::make_shared<SimpleValue>(
         g.insert(aten::select, {val, 0, idx}, {}, loc));
   } else if (auto class_type = val_type->cast<ClassType>()) {
@@ -670,7 +670,7 @@ std::shared_ptr<BuiltinFunction> BuiltinFunction::tryCreate(
         continue;
       }
       const auto concrete_type = tryEvalTypeVariables(formal_type, type_env);
-      if (!concrete_type || !self->type()->isSubtypeOf(concrete_type)) {
+      if (!concrete_type || !self->type()->isSubtypeOf(*concrete_type)) {
         continue;
       }
       return std::make_shared<BuiltinFunction>(symbol, self);

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -511,7 +511,7 @@ struct TORCH_API CastValue : public BuiltinFunction {
       size_t n_binders) override {
     if (args.size() == 1 && kwargs.size() == 0) {
       auto v = args[0].value(*m.graph());
-      if (v->type()->isSubtypeOf(type_)) {
+      if (v->type()->isSubtypeOf(*type_)) {
         return std::make_shared<SimpleValue>(v);
       }
     }
@@ -753,7 +753,7 @@ struct TORCH_API ExceptionValue : public SugaredValue {
     auto exception_message = insertConstant(*m.graph(), message_ + ": ", loc);
     for (auto& input : args) {
       auto input_str = input.value(*m.graph());
-      if (!input_str->type()->isSubtypeOf(StringType::get())) {
+      if (!input_str->type()->isSubtypeOf(*StringType::get())) {
         input_str =
             emitBuiltinCall(loc, *m.graph(), aten::str, {input_str}, {});
       }

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -280,9 +280,9 @@ Value* TracingState::getOutput(const IValue& iv, size_t i) {
     TypePtr key_type = dict.keyType();
     TypePtr value_type = dict.valueType();
 
-    bool key_type_valid = key_type->isSubtypeOf(StringType::get()) ||
-        key_type->isSubtypeOf(TensorType::get());
-    bool value_type_valid = value_type->isSubtypeOf(TensorType::get());
+    bool key_type_valid = key_type->isSubtypeOf(*StringType::get()) ||
+        key_type->isSubtypeOf(*TensorType::get());
+    bool value_type_valid = value_type->isSubtypeOf(*TensorType::get());
 
     if (!key_type_valid || !value_type_valid) {
       std::ostringstream os;
@@ -313,7 +313,7 @@ static IValue addInput(
     const TypePtr& type,
     Value* value) {
   value->setType(type);
-  if (type->isSubtypeOf(TensorType::get())) {
+  if (type->isSubtypeOf(*TensorType::get())) {
     auto input_tensor = input.toTensor();
     auto name = Variable(input_tensor).name();
     if (state->hasValue(input)) {
@@ -406,7 +406,7 @@ static void gatherParametersAndBuffers(
                                 ->s_(attr::scope, qualname)
                                 ->output()
                                 ->setType(s.value.type());
-    if (s.value.type()->isSubtypeOf(TensorType::get())) {
+    if (s.value.type()->isSubtypeOf(*TensorType::get())) {
       addInput(state, s.value, s.value.type(), trace_get_attr);
     }
     if (isCustomClass(s.value)) {

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -146,16 +146,16 @@ c10::optional<IValue> toIValue(const Value* v) {
   }
   const Node* node = v->node();
   const TypePtr& type = v->type();
-  if (type->isSubtypeOf(TensorType::get())) {
+  if (type->isSubtypeOf(*TensorType::get())) {
     return node->t(attr::value);
-  } else if (type->isSubtypeOf(BoolType::get())) {
+  } else if (type->isSubtypeOf(*BoolType::get())) {
     return (bool)node->i(attr::value);
   } else if (
-      type->isSubtypeOf(NumberType::get()) &&
+      type->isSubtypeOf(*NumberType::get()) &&
       node->kindOf(attr::value) == AttributeKind::i) {
     return node->i(attr::value);
   } else if (
-      type->isSubtypeOf(NumberType::get()) &&
+      type->isSubtypeOf(*NumberType::get()) &&
       node->kindOf(attr::value) == AttributeKind::f) {
     return node->f(attr::value);
   } else if (

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -918,7 +918,7 @@ bool Node::matches(const FunctionSchema& schema) const {
     // we will not succeed at matching T. However None <: Optional[T] so this
     // check can still succeed.
 
-    if (!actuals[i]->type()->isSubtypeOf(formal)) {
+    if (!actuals[i]->type()->isSubtypeOf(*formal)) {
       return false;
     }
   }
@@ -1641,7 +1641,7 @@ Node* Graph::createList(const TypePtr& elem_type, at::ArrayRef<Value*> values) {
   auto n = create(prim::ListConstruct, values);
   for (const auto& v : values) {
     TORCH_CHECK(
-        v->type()->isSubtypeOf(elem_type),
+        v->type()->isSubtypeOf(*elem_type),
         "Expected a list element that subtypes '",
         elem_type->repr_str(),
         "' but got an element of type '",
@@ -1669,8 +1669,8 @@ Node* Graph::createDict(
   AT_ASSERT(keys.size() == values.size());
   auto n = create(prim::DictConstruct, 1);
   for (size_t i = 0; i < keys.size(); ++i) {
-    AT_ASSERT(keys[i]->type()->isSubtypeOf(key_type));
-    AT_ASSERT(values[i]->type()->isSubtypeOf(value_type));
+    AT_ASSERT(keys[i]->type()->isSubtypeOf(*key_type));
+    AT_ASSERT(values[i]->type()->isSubtypeOf(*value_type));
 
     n->addInput(keys[i]);
     n->addInput(values[i]);

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -369,7 +369,7 @@ void IRParser::parseOperator(Block* b) {
         // Don't currently support checking against type variables
         // TODO: support?
         if (!schema_return_type->hasFreeVariables() &&
-            !v.type->isSubtypeOf(schema_return_type)) {
+            !v.type->isSubtypeOf(*schema_return_type)) {
           throw ErrorReport(source_range)
               << "Annotated type " << v.type->repr_str()
               << " does not match schema type "

--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -200,14 +200,14 @@ size_t HashNode::operator()(const Node* k) const {
   size_t constant_hash = 0;
   if (k->kind() == prim::Constant) {
     TypePtr type = k->output()->type();
-    if (type->isSubtypeOf(NumberType::get()) &&
+    if (type->isSubtypeOf(*NumberType::get()) &&
         k->kindOf(attr::value) == AttributeKind::i) {
       constant_hash = std::hash<int64_t>{}(k->i(attr::value));
     } else if (
-        type->isSubtypeOf(NumberType::get()) &&
+        type->isSubtypeOf(*NumberType::get()) &&
         k->kindOf(attr::value) == AttributeKind::f) {
       constant_hash = std::hash<double>{}(k->f(attr::value));
-    } else if (type->isSubtypeOf(BoolType::get())) {
+    } else if (type->isSubtypeOf(*BoolType::get())) {
       constant_hash = std::hash<bool>{}(k->i(attr::value));
     }
   }

--- a/torch/csrc/jit/passes/clear_profiling.cpp
+++ b/torch/csrc/jit/passes/clear_profiling.cpp
@@ -7,7 +7,7 @@ namespace jit {
 
 static void unprofileGraphInputs(const std::shared_ptr<Graph>& graph) {
   for (auto i : graph->inputs()) {
-    if (i->type()->isSubtypeOf(TensorType::get())) {
+    if (i->type()->isSubtypeOf(*TensorType::get())) {
       i->setType(unshapedType(i->type()));
     }
   }
@@ -23,7 +23,7 @@ static void unprofileBlock(Block* start_block) {
 
     for (auto n : block->nodes()) {
       for (auto o : n->outputs()) {
-        if (o->type()->isSubtypeOf(TensorType::get())) {
+        if (o->type()->isSubtypeOf(*TensorType::get())) {
           o->setType(unshapedType(o->type()));
         }
       }

--- a/torch/csrc/jit/passes/decompose_ops.cpp
+++ b/torch/csrc/jit/passes/decompose_ops.cpp
@@ -20,7 +20,7 @@ c10::AliasAnalysisKind aliasAnalysisFromSchema() {
 // statically defined (neither a None constant nor a Optional[Tensor] type)
 // return yes, no, or no value if we can't tell
 c10::optional<bool> isDefined(Value* tensor) {
-  if (tensor->type()->isSubtypeOf(TensorType::get())) {
+  if (tensor->type()->isSubtypeOf(*TensorType::get())) {
     return true;
   }
   if (tensor->node()->mustBeNone()) {
@@ -35,7 +35,7 @@ bool isDecomposableNorm(Node* normalize_op) {
       "aten::layer_norm(Tensor input, int[] normalized_shape, Tensor? weight, Tensor? bias, float eps, bool cudnn_enable) -> Tensor",
   };
   Value* input = normalize_op->namedInput(attr::input);
-  if (!input->type()->isSubtypeOf(TensorType::get())) {
+  if (!input->type()->isSubtypeOf(*TensorType::get())) {
     return false;
   }
   auto device = input->type()->expect<TensorType>()->device();

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -9,7 +9,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
   for (auto it = block->nodes().begin(), end = block->nodes().end(); it != end;
        ++it) {
     for (auto inp : it->inputs()) {
-      if (inp->type()->isSubtypeOf(NumberType::get())) {
+      if (inp->type()->isSubtypeOf(*NumberType::get())) {
         inp->setType(TensorType::get());
       }
     }
@@ -20,10 +20,10 @@ static void EraseNumberTypesOnBlock(Block* block) {
       case prim::Constant: {
         // remove primitive constants, replacing with tensor equivalent
         // ONNX does not support non-tensor constants
-        if (it->output()->type()->isSubtypeOf(NumberType::get()) ||
-            it->output()->type()->isSubtypeOf(BoolType::get())) {
+        if (it->output()->type()->isSubtypeOf(*NumberType::get()) ||
+            it->output()->type()->isSubtypeOf(*BoolType::get())) {
           at::Scalar s;
-          if (it->output()->type()->isSubtypeOf(BoolType::get())) {
+          if (it->output()->type()->isSubtypeOf(*BoolType::get())) {
             s = static_cast<int64_t>(*constant_as<bool>(it->output()));
           } else {
             s = *constant_as<at::Scalar>(it->output());
@@ -48,9 +48,9 @@ static void EraseNumberTypesOnBlock(Block* block) {
       } break;
       default: {
         for (auto o : it->outputs()) {
-          if (o->type()->isSubtypeOf(NumberType::get())) {
+          if (o->type()->isSubtypeOf(*NumberType::get())) {
             o->setType(TensorType::fromNumberType(o->type()));
-          } else if (o->type()->isSubtypeOf(BoolType::get())) {
+          } else if (o->type()->isSubtypeOf(*BoolType::get())) {
             o->setType(TensorType::fromBoolType());
           }
         }

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -519,7 +519,7 @@ class AttributePropagator {
 
   bool moduleEscapes(Module& subModule, std::shared_ptr<Graph>& graph) {
     for (auto& output : graph->outputs()) {
-      if (subModule.type()->isSubtypeOf(output->type())) {
+      if (subModule.type()->isSubtypeOf(*output->type())) {
         return true;
       }
     }

--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -243,7 +243,7 @@ struct GuardElimination {
       if ((input->node()->kind() == prim::Guard &&
            !input->type()->expect<TensorType>()->isSummarized()) ||
           input->node()->kind() == prim::Constant ||
-          (allow_numbers && input->type()->isSubtypeOf(NumberType::get())) ||
+          (allow_numbers && input->type()->isSubtypeOf(*NumberType::get())) ||
           except.count(i) != 0) {
         AT_ASSERT(
             input->node()->kind() != prim::Guard ||

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -291,7 +291,7 @@ void LoopsPeeler::peelLoops() {
 void PeelProfilingLoops(const std::shared_ptr<Graph>& graph) {
   auto peel_predicate = [](Node* n) {
     for (auto i : n->inputs()) {
-      if (i->type()->isSubtypeOf(TensorType::get())) {
+      if (i->type()->isSubtypeOf(*TensorType::get())) {
         return true;
       }
     }

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -59,7 +59,7 @@ void checkONNXCompatibility(const c10::FunctionSchema& schema) {
     if (type->kind() == TypeKind::ListType) {
       const auto& elem_type =
           reinterpret_cast<ListType*>(type.get())->getElementType();
-      if (elem_type->isSubtypeOf(TensorType::get())) {
+      if (elem_type->isSubtypeOf(*TensorType::get())) {
         AT_ASSERTM(
             !has_tensor_list,
             "ONNX export supports at most one TensorList as input.");
@@ -98,7 +98,7 @@ void preprocessCaffe2Ops(Block* block) {
             AT_ASSERT(type->kind() != TypeKind::OptionalType);
           }
         }
-        if (type->isSubtypeOf(TensorType::get())) {
+        if (type->isSubtypeOf(*TensorType::get())) {
           it->addInput(origin_input);
         } else if (
             type->kind() == TypeKind::BoolType ||
@@ -120,7 +120,7 @@ void preprocessCaffe2Ops(Block* block) {
           AT_ASSERT(
               list_node->kind() == prim::ListConstruct ||
               list_node->kind() == prim::Constant);
-          if (elem_type->isSubtypeOf(TensorType::get())) {
+          if (elem_type->isSubtypeOf(*TensorType::get())) {
             AT_ASSERT(list_node->kind(), prim::ListConstruct);
             const auto& tensor_list = origin_input->node()->inputs();
             for (const auto& t : tensor_list) {

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -43,7 +43,7 @@ bool IsCondCastRequired(Value* cond_val) {
       return *scalar_type != c10::kBool;
     }
   }
-  return !type->isSubtypeOf(BoolType::get());
+  return !type->isSubtypeOf(*BoolType::get());
 }
 
 bool IsErasableSequence(const Node* loop_node, size_t i) {
@@ -297,7 +297,7 @@ void ONNXFixupUninitializedOutput(Node* node) {
 
   // Check if the input to ONNX If node is node Bool, and insert
   // cast to Bool if needed.
-  if (!if_node->input()->type()->isSubtypeOf(BoolType::get())) {
+  if (!if_node->input()->type()->isSubtypeOf(*BoolType::get())) {
     Node* cast_node = CreateCastToBoolNode(if_node->input(), graph);
     cast_node->insertBefore(if_node);
     if_node->replaceInputWith(if_node->input(), cast_node->output());

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -317,7 +317,7 @@ void unpackQuantizedWeightsHelper(
 
     auto input_val = match_vmap.at(vmap.at("r"))->node()->inputs()[0];
     TORCH_INTERNAL_ASSERT(
-        input_val->type()->isSubtypeOf(TensorType::get()),
+        input_val->type()->isSubtypeOf(*TensorType::get()),
         "Unsupported input type. Expected TensorType, got ",
         input_val->type()->str());
 

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -73,7 +73,7 @@ struct PeepholeOptimizeImpl {
           for (Use u : uses) {
             if (u.user->matches(
                     "aten::_grad_sum_to_size(Tensor(a) self, int[]? size) -> Tensor(a)") &&
-                u.user->input(1)->type()->isSubtypeOf(ListType::ofInts())) {
+                u.user->input(1)->type()->isSubtypeOf(*ListType::ofInts())) {
               GRAPH_UPDATE(
                   getHeader(node),
                   " (x._grad_sum_to_size(y)._grad_sum_to_size(z) == x._grad_sum_to_size(z)) is replaced with ",
@@ -247,7 +247,7 @@ struct PeepholeOptimizeImpl {
         // losing anything by calling unshapedType here
         auto input_type = unshapedType(node->input()->type());
         auto output_type = unshapedType(node->output()->type());
-        if (input_type->isSubtypeOf(output_type)) {
+        if (input_type->isSubtypeOf(*output_type)) {
           GRAPH_UPDATE(
               "Removing ",
               getHeader(node),

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -339,14 +339,14 @@ std::vector<Value*> getPassThroughInputs(Value* v) {
     return inputs;
   } else if (n->kind() == prim::ListUnpack || n->kind() == prim::TupleUnpack) {
     // only propagate dequantize for Tensor
-    if (v->type()->isSubtypeOf(TensorType::get())) {
+    if (v->type()->isSubtypeOf(*TensorType::get())) {
       return {n->input(0)};
     } else {
       return {};
     }
   } else if (
       n->kind() == prim::ListConstruct &&
-      v->type()->isSubtypeOf(ListType::ofTensors())) {
+      v->type()->isSubtypeOf(*ListType::ofTensors())) {
     std::vector<Value*> inputs;
     for (auto* v : n->inputs()) {
       inputs.push_back(v);
@@ -355,7 +355,7 @@ std::vector<Value*> getPassThroughInputs(Value* v) {
   } else if (n->kind() == prim::TupleConstruct) {
     std::vector<Value*> inputs;
     for (auto* input : n->inputs()) {
-      if (input->type()->isSubtypeOf(TensorType::get())) {
+      if (input->type()->isSubtypeOf(*TensorType::get())) {
         inputs.push_back(input);
       }
     }
@@ -554,8 +554,8 @@ bool alwaysRaisesException(Block* block) {
 // Check if a value in the graph is a Scalar value
 bool isScalar(Value* v) {
   auto iv = toIValue(v);
-  return v->type()->isSubtypeOf(NumberType::get()) ||
-      (v->type()->isSubtypeOf(TensorType::get()) && iv && iv->isTensor() &&
+  return v->type()->isSubtypeOf(*NumberType::get()) ||
+      (v->type()->isSubtypeOf(*TensorType::get()) && iv && iv->isTensor() &&
        iv->toTensor().dim() == 0);
 }
 

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -1172,8 +1172,8 @@ bool InsertObserversHelper::valueNeedsToBeQuantized(
     Value* v,
     const QConfig& qconfig) {
   if (isBiasOfConvOrLinear(v) ||
-      !(v->type()->isSubtypeOf(TensorType::get()) ||
-        v->type()->isSubtypeOf(ListType::ofTensors())) ||
+      !(v->type()->isSubtypeOf(*TensorType::get()) ||
+        v->type()->isSubtypeOf(*ListType::ofTensors())) ||
       isEmbeddingBagNonInput(v)) {
     return false;
   }

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -978,7 +978,7 @@ std::tuple<c10::QScheme, QParamVector> InsertQuantDeQuantHelper::
   // TODO: refactor findObserverName to take Node* as input
   Value* v = n->output();
   TORCH_INTERNAL_ASSERT(
-      v->type()->isSubtypeOf(TensorType::get()),
+      v->type()->isSubtypeOf(*TensorType::get()),
       "Expected output of observer node to be Tensor");
   auto observer_name = findObserverName(v);
   TORCH_INTERNAL_ASSERT(
@@ -1305,7 +1305,7 @@ void InsertQuantDeQuantHelper::runWeightObserver(
     blocks_to_visit.pop();
     for (auto n : b->nodes()) {
       for (Value* v : n->outputs()) {
-        if (!v->type()->isSubtypeOf(TensorType::get())) {
+        if (!v->type()->isSubtypeOf(*TensorType::get())) {
           continue;
         }
         auto observer_name = findObserverName(v);
@@ -1369,7 +1369,7 @@ void InsertQuantDeQuantHelper::run(
   std::vector<Value*> input_values;
   for (size_t idx = 1; idx < method.num_inputs(); ++idx) {
     auto& v = graph->inputs()[idx];
-    if (v->type()->isSubtypeOf(TensorType::get())) {
+    if (v->type()->isSubtypeOf(*TensorType::get())) {
       input_values.push_back(v);
     }
   }
@@ -1382,7 +1382,7 @@ void InsertQuantDeQuantHelper::run(
     for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end;) {
       Node* n = *it++;
       for (Value* v : n->outputs()) {
-        if (!v->type()->isSubtypeOf(TensorType::get())) {
+        if (!v->type()->isSubtypeOf(*TensorType::get())) {
           continue;
         }
         collectObserverNodesAndValueToQuantize(module, v);

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -44,18 +44,18 @@ bool isValidArgumentForRunning(Value* v) {
     }
     return !at::isIntegralType(*tt->scalarType(), /*includeBool=*/false);
   }
-  return v->type()->isSubtypeOf(FloatType::get());
+  return v->type()->isSubtypeOf(*FloatType::get());
 }
 
 bool isValidReturnForRunning(Value* v) {
-  return v->type()->isSubtypeOf(TensorType::get()) ||
-      v->type()->isSubtypeOf(NumberType::get());
+  return v->type()->isSubtypeOf(*TensorType::get()) ||
+      v->type()->isSubtypeOf(*NumberType::get());
 }
 
 bool containsTensorType(const TypePtr& t) {
   auto n_contained = t->containedTypes().size();
   if (n_contained == 1) {
-    return t->containedTypes().at(0)->isSubtypeOf(TensorType::get());
+    return t->containedTypes().at(0)->isSubtypeOf(*TensorType::get());
   } else if (n_contained > 1) {
     return std::any_of(
         t->containedTypes().begin(),
@@ -109,7 +109,7 @@ class ShapePropagator {
     // ops which take the result and write to input "out"
     if (auto out_arg_index = n->schema().argumentIndexWithName("out")) {
       auto arg = n->schema().arguments().at(*out_arg_index);
-      return arg.kwarg_only() && arg.type()->isSubtypeOf(TensorType::get());
+      return arg.kwarg_only() && arg.type()->isSubtypeOf(*TensorType::get());
     }
     return false;
   }
@@ -170,7 +170,7 @@ class ShapePropagator {
             .zero_();
       }
       // fallthrough
-    } else if (type_->isSubtypeOf(FloatType::get())) {
+    } else if (type_->isSubtypeOf(*FloatType::get())) {
       return 0.f;
     }
     // we should not get here because isValidArgumentForRunning should have
@@ -201,9 +201,9 @@ class ShapePropagator {
       return c10::nullopt;
     }
     for (size_t i = 0; i < args.size(); ++i) {
-      if (args[i].type()->isSubtypeOf(ListType::ofTensors())) {
+      if (args[i].type()->isSubtypeOf(*ListType::ofTensors())) {
         return c10::nullopt;
-      } else if (args[i].type()->isSubtypeOf(TensorType::get())) {
+      } else if (args[i].type()->isSubtypeOf(*TensorType::get())) {
         if (auto type = node->input(i)->type()->cast<TensorType>()) {
           if (complete && !type->isComplete()) {
             return c10::nullopt;
@@ -603,11 +603,11 @@ class ShapePropagator {
         return; // correct num type is already set
       case prim::NumToTensor: {
         TypePtr typ = node->input()->type();
-        if (typ->isSubtypeOf(IntType::get()) ||
-            typ->isSubtypeOf(BoolType::get())) {
+        if (typ->isSubtypeOf(*IntType::get()) ||
+            typ->isSubtypeOf(*BoolType::get())) {
           node->output()->setType(TensorType::create(
               at::kLong, at::kCPU, 0, /*requires_grad=*/c10::nullopt));
-        } else if (node->input()->type()->isSubtypeOf(FloatType::get())) {
+        } else if (node->input()->type()->isSubtypeOf(*FloatType::get())) {
           node->output()->setType(TensorType::create(
               at::kDouble, at::kCPU, 0, /*requires_grad=*/c10::nullopt));
         }
@@ -618,7 +618,7 @@ class ShapePropagator {
         // as_tensor has an overloaded schema and can either have a tensor or
         // a list as the first input, if the input is a tensor, we delegate
         // the shape propagation in PropagateTensorShapeOnNode
-        if (node->inputs().at(0)->type()->isSubtypeOf(TensorType::get())) {
+        if (node->inputs().at(0)->type()->isSubtypeOf(*TensorType::get())) {
           break;
         }
         return propagateTorchTensorShape(node);
@@ -645,16 +645,16 @@ class ShapePropagator {
         return;
       }
       case prim::Constant: {
-        if (node->output()->type()->isSubtypeOf(TensorType::get())) {
+        if (node->output()->type()->isSubtypeOf(*TensorType::get())) {
           node->output()->inferTypeFrom(node->t(attr::value));
         }
         return;
       }
       case prim::unchecked_unwrap_optional: {
         // If we have specialized the optional type to the element type,
-        // we want to pass it down. We write this as input.isSubtypeOf(output)
+        // we want to pass it down. We write this as input.isSubtypeOf(*output)
         // to be sure that we don't screw up nested optionals.
-        if (node->input()->type()->isSubtypeOf(node->output()->type())) {
+        if (node->input()->type()->isSubtypeOf(*node->output()->type())) {
           node->output()->setType(node->input()->type());
         }
         return;
@@ -693,9 +693,9 @@ class ShapePropagator {
       }
       case aten::_unwrap_optional: {
         // If we have specialized the optional type to the element type,
-        // we want to pass it down. We write this as input.isSubtypeOf(output)
+        // we want to pass it down. We write this as input.isSubtypeOf(*output)
         // to be sure that we don't screw up nested optionals.
-        if (node->input()->type()->isSubtypeOf(node->output()->type())) {
+        if (node->input()->type()->isSubtypeOf(*node->output()->type())) {
           node->output()->setType(node->input()->type());
         }
         return;
@@ -1593,7 +1593,7 @@ class ShapePropagator {
           auto outputs = node->outputs();
           AT_ASSERT(types.size() == outputs.size());
           for (size_t i = 0; i < types.size(); ++i) {
-            AT_ASSERT(outputs[i]->type()->isSubtypeOf(TensorType::get()));
+            AT_ASSERT(outputs[i]->type()->isSubtypeOf(*TensorType::get()));
             outputs[i]->setType(types[i]);
           }
           return true;

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -70,8 +70,8 @@ struct AutogradZeroSpecializer {
           state_[input] = State::Unknown;
         }
       } else if (
-          tp->isSubtypeOf(TensorType::get()) ||
-          tp->isSubtypeOf(ListType::ofTensors())) {
+          tp->isSubtypeOf(*TensorType::get()) ||
+          tp->isSubtypeOf(*ListType::ofTensors())) {
         state_[input] = State::Nonzero;
       } else {
         state_[input] = State::Unknown;

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -324,7 +324,7 @@ class TensorExprFuser {
     auto sinputs = subgraph->inputs();
     AT_ASSERT(inputs.size() == sinputs.size());
     for (size_t i = 0; i < inputs.size(); ++i) {
-      if (inputs[i]->type()->isSubtypeOf(TensorType::get())) {
+      if (inputs[i]->type()->isSubtypeOf(*TensorType::get())) {
         Value* soutput = graph->insert(aten::size, {inputs[i]});
         aliasDb_->createValue(soutput);
         GRAPH_DEBUG(
@@ -384,7 +384,7 @@ class TensorExprFuser {
         continue;
       }
       auto tensor_inputs = filter(n->inputs(), [](Value* v) {
-        return v->type()->isSubtypeOf(TensorType::get());
+        return v->type()->isSubtypeOf(*TensorType::get());
       });
       GRAPH_DEBUG("Building sizes for ", getHeader(n));
       bool all_inputs_have_sizes = true;

--- a/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
+++ b/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
@@ -176,7 +176,7 @@ c10::optional<IValue> toIValueProp(const Value* v) {
     } else if (containedType == FloatType::get()) {
       return IValue(
           fmap(genericList, [](const IValue& v) { return v.toDouble(); }));
-    } else if (containedType->isSubtypeOf(TensorType::get())) {
+    } else if (containedType->isSubtypeOf(*TensorType::get())) {
       return IValue(
           fmap(genericList, [](const IValue& v) { return v.toTensor(); }));
     } else {

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -500,7 +500,7 @@ inline InferredType tryToInferContainerType(py::handle input) {
 }
 
 inline bool isTraceableType(TypePtr type) {
-  if (type->isSubtypeOf(TensorType::get())) {
+  if (type->isSubtypeOf(*TensorType::get())) {
     return true;
   }
 
@@ -751,7 +751,7 @@ inline IValue toIValue(
       }
       // check if the classType conform with the interface or not
       std::stringstream why_not;
-      if (!classType->isSubtypeOfExt(interfaceType, &why_not)) {
+      if (!classType->isSubtypeOfExt(*interfaceType, &why_not)) {
         throw py::cast_error(c10::str(
             "Object ",
             py::str(obj),

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -733,7 +733,7 @@ void initPythonIRBindings(PyObject* module_) {
             if (!other) {
               return false;
             }
-            return self->isSubtypeOf(other);
+            return self->isSubtypeOf(*other);
           })
       .def("is_interface_type", [](const std::shared_ptr<Type>& self) {
         return self->cast<InterfaceType>() != nullptr;

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -261,7 +261,7 @@ SugaredValuePtr ModuleValue::getitem(
         const auto& attr_type = self_type->getAttribute(i);
         if (attr_type->is_module()) {
           std::stringstream ss;
-          if (!attr_type->isSubtypeOfExt(type_hint, &ss)) {
+          if (!attr_type->isSubtypeOfExt(*type_hint, &ss)) {
             auto loc = self_->node()->sourceRange();
             throw ErrorReport(loc)
                 << "Attribute " << self_type->getAttributeName(i)
@@ -795,7 +795,7 @@ TypePtr registerNamedTuple(const py::object& obj, const SourceRange& loc) {
   auto tt = TupleType::createNamed(qualifiedName, fields, annotations);
   if (auto type = get_python_cu()->get_type(qualifiedName)) {
     TORCH_CHECK(
-        type->isSubtypeOf(tt),
+        type->isSubtypeOf(*tt),
         "Can't to redefine NamedTuple: ",
         tt->repr_str());
     return type;
@@ -843,7 +843,7 @@ std::shared_ptr<SugaredValue> PythonSliceClass::call(
   Graph& graph = *(caller.graph());
 
   auto ValOr = [&](Value* given, int64_t default_val) {
-    if (!given || given->type()->isSubtypeOf(NoneType::get())) {
+    if (!given || given->type()->isSubtypeOf(*NoneType::get())) {
       return graph.insertConstant(default_val, loc);
     }
     return given;

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -526,7 +526,7 @@ bool ivalue_tags_match(const Module& lhs, const Module& rhs) {
       visited.emplace(item.a.internalToPointer());
     }
     if (!unshapedType(item.b.type())
-             ->isSubtypeOf(unshapedType(item.b.type()))) {
+             ->isSubtypeOf(*unshapedType(item.b.type()))) {
       // Since named types are saved and loaded in the test suite, we cannot
       // expect them to be equal. We should still check their slots however.
       if (!item.a.type()->cast<c10::NamedType>()) {

--- a/torch/csrc/jit/runtime/argument_spec.cpp
+++ b/torch/csrc/jit/runtime/argument_spec.cpp
@@ -29,10 +29,10 @@ void ArgumentSpecCreator::scan(
   if (depth >= ARG_SPEC_DEPTH_LIMIT) {
     instructions_.emplace_back(SKIP);
   }
-  if (typ->isSubtypeOf(TensorType::get())) {
+  if (typ->isSubtypeOf(*TensorType::get())) {
     num_tensors_++;
     instructions_.emplace_back(SPECIALIZE_TENSOR);
-  } else if (typ->isSubtypeOf(OptionalType::ofTensor())) {
+  } else if (typ->isSubtypeOf(*OptionalType::ofTensor())) {
     num_tensors_++;
     num_optionals_++;
     instructions_.emplace_back(SPECIALIZE_OPTIONAL_TENSOR);

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -216,7 +216,7 @@ class GradientHelper {
 
       Value* input_list;
       if (grad_values.size() == 1 &&
-          grad_values[0]->type()->isSubtypeOf(ListType::ofTensors())) {
+          grad_values[0]->type()->isSubtypeOf(*ListType::ofTensors())) {
         input_list = grad_values[0];
       } else {
         input_list =

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -101,7 +101,7 @@ ProfileOptionalOp* ProfilingRecord::createProfileOptionalNode(
 
 static void unprofileGraphInputs(const std::shared_ptr<Graph>& graph) {
   for (auto i : graph->inputs()) {
-    if (i->type()->isSubtypeOf(TensorType::get())) {
+    if (i->type()->isSubtypeOf(*TensorType::get())) {
       i->setType(unshapedType(i->type()));
     }
   }
@@ -117,7 +117,7 @@ static void unprofileBlock(Block* start_block) {
 
     for (auto n : block->nodes()) {
       for (auto o : n->outputs()) {
-        if (o->type()->isSubtypeOf(TensorType::get())) {
+        if (o->type()->isSubtypeOf(*TensorType::get())) {
           o->setType(unshapedType(o->type()));
         }
       }
@@ -180,7 +180,7 @@ void ProfilingRecord::insertShapeProfile(Node* n, size_t offset) {
         } else {
           auto type = profiled_types.at(pno);
           GRAPH_DEBUG("Existing type for %", pno->debugName(), " ", *type);
-          pttp = type->merge(pttp);
+          pttp = type->merge(*pttp);
           GRAPH_DEBUG("Result for %", pno->debugName(), " ", *pttp);
           profiled_types[pno] = pttp;
         }
@@ -312,7 +312,7 @@ void ProfilingRecord::instrumentBlock(Block* block) {
   for (size_t offset = 0; offset < block->return_node()->inputs().size();
        offset++) {
     auto i = block->return_node()->input(offset);
-    if (i->type()->isSubtypeOf(TensorType::get())) {
+    if (i->type()->isSubtypeOf(*TensorType::get())) {
       insertShapeProfile(block->return_node(), offset);
     }
   }
@@ -381,7 +381,7 @@ std::unique_ptr<ProfilingRecord> ProfilingRecord::instrumentGraph(
             merged_profiled_types[val_type_pair.first] = val_type_pair.second;
           } else {
             auto type = merged_profiled_types[val_type_pair.first];
-            auto merged_type = type->merge(val_type_pair.second);
+            auto merged_type = type->merge(*val_type_pair.second);
             if (merged_type->sizes().size().has_value()) {
               auto new_shape = raw_pr->mergeSymbolicShapes(
                   val_type_pair.second->symbolic_sizes(),
@@ -399,7 +399,7 @@ std::unique_ptr<ProfilingRecord> ProfilingRecord::instrumentGraph(
               merged_profiled_types[val_type_pair.first] = merged_type;
             } else {
               // reset symbolic shapes when ranks are different
-              type = type->merge(val_type_pair.second);
+              type = type->merge(*val_type_pair.second);
               merged_profiled_types[val_type_pair.first] = type;
             }
           }

--- a/torch/csrc/jit/runtime/register_c10_ops.cpp
+++ b/torch/csrc/jit/runtime/register_c10_ops.cpp
@@ -49,7 +49,7 @@ Operator createOperatorFromC10_withTracingHandledHere(
             type = type->expect<OptionalType>()->getElementType();
           }
         }
-        if (type->isSubtypeOf(TensorType::get())) {
+        if (type->isSubtypeOf(*TensorType::get())) {
           AT_ASSERT(iter->isTensor());
           tracer::addInputs(node, args[i].name().c_str(), iter->toTensor());
         } else if (type->kind() == TypeKind::FloatType) {
@@ -68,7 +68,7 @@ Operator createOperatorFromC10_withTracingHandledHere(
           tracer::addInputs(node, args[i].name().c_str(), iter->toScalar());
         } else if (type->kind() == TypeKind::ListType) {
           const auto& elem_type = type->expect<ListType>()->getElementType();
-          if (elem_type->isSubtypeOf(TensorType::get())) {
+          if (elem_type->isSubtypeOf(*TensorType::get())) {
             AT_ASSERT(iter->isTensorList());
             auto list = iter->toTensorVector();
             tracer::addInputs(node, args[i].name().c_str(), list);
@@ -130,12 +130,12 @@ Operator createOperatorFromC10_withTracingHandledHere(
       for (auto iter = stack->end() - output_size; iter != stack->end();
            ++iter, ++i) {
         const auto& type = op.schema().returns()[i].type();
-        if (type->isSubtypeOf(TensorType::get())) {
+        if (type->isSubtypeOf(*TensorType::get())) {
           AT_ASSERT(iter->isTensor());
           tracer::addOutput(node, iter->toTensor());
         } else if (type->kind() == TypeKind::ListType) {
           const auto& elem_type = type->expect<ListType>()->getElementType();
-          if (elem_type->isSubtypeOf(TensorType::get())) {
+          if (elem_type->isSubtypeOf(*TensorType::get())) {
             AT_ASSERT(iter->isTensorList());
             tracer::addOutput(node, iter->toTensorList());
           } else {

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -32,13 +32,13 @@ c10::AliasAnalysisKind aliasAnalysisConservative() {
 }
 
 void checkListInputType(const c10::TypePtr& elem_type, bool empty_list) {
-  if (!elem_type->isSubtypeOf(NumberType::get()) &&
+  if (!elem_type->isSubtypeOf(*NumberType::get()) &&
       elem_type != BoolType::get()) {
     std::stringstream error;
     error << "Input must be of ints, floats, or bools, "
           << "got " << elem_type->repr_str();
     // special case empty list torch.tensor([])
-    if (elem_type->isSubtypeOf(TensorType::get())) {
+    if (elem_type->isSubtypeOf(*TensorType::get())) {
       if (empty_list) {
         error << "\nEmpty lists default to List[Tensor]. Add a variable "
                  "annotation to the assignment to create an empty list "

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -241,7 +241,7 @@ void createObject(Stack& stack, at::ClassTypePtr type) {
 void isinstance(Stack& stack, at::ArrayRef<at::TypePtr> types) {
   at::TypePtr ty = pop(stack).type();
   for (const at::TypePtr& candidate : types) {
-    if (ty->isSubtypeOf(candidate)) {
+    if (ty->isSubtypeOf(*candidate)) {
       push(stack, true);
       return;
     }

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -664,7 +664,7 @@ bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls) {
       set_schema.returns().size(),
       " return values");
   TORCH_CHECK(
-      set_schema.returns().at(0).type()->isSubtypeOf(NoneType::get()),
+      set_schema.returns().at(0).type()->isSubtypeOf(*NoneType::get()),
       "'__setstate__' must return None, but found value of type",
       set_schema.returns().at(0).type()->annotation_str());
 
@@ -674,7 +674,7 @@ bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls) {
   auto set_type = set_schema.arguments().at(1).type();
 
   TORCH_CHECK(
-      get_type->isSubtypeOf(set_type),
+      get_type->isSubtypeOf(*set_type),
       "'__getstate__'s return type (",
       get_type->annotation_str(),
       ") does not match '__setstate__'s argument type (",

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1090,7 +1090,7 @@ struct PythonPrintImpl {
         // we cannot recover the type of unwrap_optional(None),
         // using normal schema matching, so we route around this by rewriting
         // the call to unwrap_optional(annotated(Optional[T], None))
-        if (node->input()->type()->isSubtypeOf(NoneType::get()) ||
+        if (node->input()->type()->isSubtypeOf(*NoneType::get()) ||
             node->input()->mustBeNone()) {
           auto input_type = OptionalType::create(node->output()->type());
           stmt << "annotate(" << input_type->annotation_str(type_printer_)

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -209,11 +209,11 @@ std::vector<ExprHandle> TensorExprKernel::sizesForValue(
     }
   }
 
-  if (v->type()->isSubtypeOf(FloatType::get()) ||
-      v->type()->isSubtypeOf(IntType::get())) {
+  if (v->type()->isSubtypeOf(*FloatType::get()) ||
+      v->type()->isSubtypeOf(*IntType::get())) {
     return {1};
   }
-  if (v->type()->isSubtypeOf(NoneType::get())) {
+  if (v->type()->isSubtypeOf(*NoneType::get())) {
     return {};
   }
 

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -251,7 +251,7 @@ class class_ {
     auto setstate_schema = classTypePtr->getMethod("__setstate__").getSchema();
     auto arg_type = setstate_schema.arguments().at(1).type();
     TORCH_CHECK(
-        ser_type->isSubtypeOf(arg_type),
+        ser_type->isSubtypeOf(*arg_type),
         "__getstate__'s return type should be a subtype of "
         "input argument of __setstate__. Got ",
         ser_type->repr_str(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48131 [JIT] Modify Type::isSubtypeOf[Ext] to take in a const Type&**

**Summary**
`Type::isSubtypeOf[Ext]` accepts a `const TypePtr` as the `rhs` argument
even though it uses that argument like a `const` reference. This commit
modifies this function to accept `const Type&` instead.

**Test Plan**
Existing unit tests.