### PR TITLE
Fix default value of `num_replicas` in DistributedSampler docstring

### DIFF
--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -24,7 +24,7 @@ class DistributedSampler(Sampler[T_co]):
     Arguments:
         dataset: Dataset used for sampling.
         num_replicas (int, optional): Number of processes participating in
-            distributed training. By default, :attr:`rank` is retrieved from the
+            distributed training. By default, :attr:`world_size` is retrieved from the
             current distributed group.
         rank (int, optional): Rank of the current process within :attr:`num_replicas`.
             By default, :attr:`rank` is retrieved from the current distributed


### PR DESCRIPTION
Change default value of `num_replicas` from `rank` to `world_size` in DistributedSampler docstring.

Addresses #48055 
