### PR TITLE
.circleci: Call test.bat directly in binary_windows_test

### DIFF
--- a/.circleci/scripts/binary_windows_test.sh
+++ b/.circleci/scripts/binary_windows_test.sh
@@ -14,6 +14,7 @@ fi
 
 pushd "$BUILDER_ROOT"
 
+./windows/internal/test.bat
 ./windows/internal/smoke_test.bat
 
 popd


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48136 .circleci: Call test.bat directly in binary_windows_test**

This was being called right after build but the conda environment was
not clean so this makes it explicitly clean

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>