### PR TITLE
Tensor-expression fuser bugfixes for 1.7.1

### DIFF
--- a/test/cpp/tensorexpr/test_te_fuser_pass.cpp
+++ b/test/cpp/tensorexpr/test_te_fuser_pass.cpp
@@ -330,5 +330,55 @@ void testFuserPass_UnknownShapesIgnored() {
   testing::FileCheck().check("prim::TensorExprGroup")->run(*g);
 }
 
+void testFuserPass_IgnoreUnknownShapeAtStart() {
+  WithCPUFuser cf;
+  const auto graph_string = R"IR(
+    graph(%x : Bool(8:1, device=cpu),
+          %y : Bool(8:1, device=cpu)):
+      %a : Bool(8:1, device=cpu) = aten::__and__(%x, %y)
+      %b : Tensor = aten::__or__(%a, %y)
+      return (%b)
+    )IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+  g->lint();
+  FuseTensorExprs(g, /* min_group_size= */ 2);
+  testing::FileCheck().check_not("prim::TensorExprGroup")->run(*g);
+}
+
+void testFuserPass_Where() {
+  WithCPUFuser cf;
+  const auto graph_string = R"IR(
+    graph(%x : Float(8:1, device=cpu),
+          %y : Float(8:1, device=cpu),
+          %z : Float(8:1, device=cpu)):
+      %cond : Bool(8:1, device=cpu) = aten::eq(%x, %y)
+      %b : Float(8:1, device=cpu) = aten::where(%cond, %y, %z)
+      return (%b)
+    )IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+  g->lint();
+  FuseTensorExprs(g, /* min_group_size= */ 2);
+  testing::FileCheck().check("prim::TensorExprGroup")->run(*g);
+}
+
+void testFuserPass_WhereList() {
+  WithCPUFuser cf;
+  const auto graph_string = R"IR(
+    graph(%x : Float(8:1, device=cpu),
+          %y : Float(8:1, device=cpu),
+          %z : Float(8:1, device=cpu)):
+      %cond : Bool(8:1, device=cpu) = aten::eq(%x, %y)
+      %b : Tensor[] = aten::where(%cond)
+      return (%b)
+    )IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::parseIR(graph_string, g.get());
+  g->lint();
+  FuseTensorExprs(g, /* min_group_size= */ 2);
+  testing::FileCheck().check_not("prim::TensorExprGroup")->run(*g);
+}
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -298,6 +298,8 @@ namespace jit {
   _(FuserPass_UnknownShapes)                \
   _(FuserPass_UnknownShapesIgnored)         \
   _(FuserPass_MergeGroups)                  \
+  _(FuserPass_Where)                        \
+  _(FuserPass_WhereList)                    \
   _(TrainBasic)
 
 #define TH_FORALL_TENSOREXPR_TESTS_LLVM(_) \

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -297,7 +297,6 @@ namespace jit {
   _(FuserPass_UnfusibleDevice)              \
   _(FuserPass_UnknownShapes)                \
   _(FuserPass_UnknownShapesIgnored)         \
-  _(FuserPass_Multidevice)                  \
   _(FuserPass_MergeGroups)                  \
   _(TrainBasic)
 

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1426,6 +1426,17 @@ class TestTEFuser(JitTestCase):
         x = torch.rand(64, 1, 3072, dtype=torch.float, device='cuda')
         script = self.checkScript(eager, (x,))
 
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_eq_unsqueeze_type_as(self):
+        def eager(a, b):
+            mask = b == 1
+            mask = torch.unsqueeze(mask, -1)
+            x = mask.type_as(a)
+            return x, mask
+        a = torch.rand(1, 64, 1024, device='cuda', dtype=torch.float)
+        b = torch.randint(-2, 2, (1, 64), device='cuda', dtype=torch.long)
+        script = self.checkScript(eager, (a, b))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1418,6 +1418,14 @@ class TestTEFuser(JitTestCase):
         t = torch.rand(8, dtype=torch.float, device='cuda')
         scripted = self.checkScript(eager, (t, t, t, t, 0.1))
 
+    @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
+    def test_chunk_mul_one(self):
+        def eager(x):
+            z, y, w = torch.chunk(x, 3, -1)
+            return z * 3, y, w
+        x = torch.rand(64, 1, 3072, dtype=torch.float, device='cuda')
+        script = self.checkScript(eager, (x,))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -140,7 +140,6 @@ bool isSupported(Node* node) {
       "aten::where.ScalarSelf(Tensor condition, Scalar self, Tensor other) -> Tensor",
       "aten::where.ScalarOther(Tensor condition, Tensor self, Scalar other) -> Tensor",
       "aten::where.Scalar(Tensor condition, Scalar self, Scalar other) -> Tensor",
-      "aten::where(Tensor condition) -> Tensor[]",
       // TODO: enable other min/max variants, operators that can be both
       // elementwise or reductions:
       "aten::min.other(Tensor self, Tensor other) -> Tensor",

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -219,7 +219,7 @@ bool texprReductionsEnabled() {
   return texpr_reductions_enabled;
 }
 
-// TODO: if a value has differently typed uses, temporarrily insert a node
+// TODO: if a value has differently typed uses, temporarily insert a node
 // specializing the type for each use and later remove, instead of bailing
 bool profiledWithDifferentTypes(Value* v) {
   std::vector<TypePtr> types;
@@ -258,7 +258,9 @@ void removeProfileNodesAndSpecializeTypes(Block* b) {
 }
 
 void RemoveProfileNodesAndSpecializeTypes(std::shared_ptr<Graph>& graph) {
+  GRAPH_DEBUG("Before removeProfileNodesAndSpecializeTypes", *graph);
   removeProfileNodesAndSpecializeTypes(graph->block());
+  GRAPH_DEBUG("After removeProfileNodesAndSpecializeTypes", *graph);
 }
 
 void removeTensorTypeSpecialization(Value* v) {
@@ -656,16 +658,27 @@ class TensorExprFuser {
     return fusion_group;
   }
 
+  bool shapeIsKnown(Value* v) {
+    if (v->type()->cast<TensorType>()) {
+      if (!v->isCompleteTensor()) {
+        return false;
+      }
+      if (*v->type()->cast<TensorType>()->dim() == 0) {
+        return false;
+      }
+    }
+    return true;
+  }
   bool allShapesAreKnown(Node* node) {
     // TODO: Relax the checks to support dynamic shapes
     for (Value* input : node->inputs()) {
-      if (input->type()->cast<TensorType>()) {
-        if (!input->isCompleteTensor()) {
-          return false;
-        }
-        if (*input->type()->cast<TensorType>()->dim() == 0) {
-          return false;
-        }
+      if (!shapeIsKnown(input)) {
+        return false;
+      }
+    }
+    for (Value* output : node->outputs()) {
+      if (!shapeIsKnown(output)) {
+        return false;
       }
     }
     return true;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -123,9 +123,12 @@ ExprHandle TensorExprKernel::broadcast(
 ExprHandle TensorExprKernel::chunk(
     Tensor* t,
     size_t chunkIdx,
-    size_t dim,
-    size_t chunks,
+    int64_t dim,
+    int64_t chunks,
     const std::vector<ExprHandle>& axes) {
+  if (dim < 0) {
+    dim = axes.size() + dim;
+  }
   auto sizes = bufferSizes(t);
   size_t step = sizes[dim] / chunks;
 

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -65,8 +65,8 @@ class TORCH_API TensorExprKernel {
   ExprHandle chunk(
       Tensor* t,
       size_t chunkIdx,
-      size_t dim,
-      size_t chunks,
+      int64_t dim,
+      int64_t chunks,
       const std::vector<ExprHandle>& axes);
 
   std::vector<ExprHandle> valueShape(const torch::jit::Value* v);


### PR DESCRIPTION
Cherry-picks to fix small issues with the new TE-based fuser.  These issues can cause silent data corruption or crashes.

[pytorch][te] Don't start TE fusion groups with an unknown-typed result (#47884)
[pytorch][te] Do not merge Tensor[] variant of aten::where into fusion group (#48063)
[pytorch][te] Handle negative axis in chunk (#48084)
[pytorch][te] aten::type_as is unary, not binary (#48085)