### PR TITLE
[Gloo] Compute Local Rank for Single-host Multi-GPU training (#269)

### DIFF
--- a/caffe2/contrib/gloo/store_handler.cc
+++ b/caffe2/contrib/gloo/store_handler.cc
@@ -5,12 +5,13 @@ namespace gloo {
 
 void StoreHandlerWrapper::set(
     const std::string& key,
-    const std::vector<char>& data) {
+    const std::vector<char>& data,
+    bool /* unused */) {
   std::string stringValue(data.data(), data.size());
   handler_.set(key, stringValue);
 }
 
-std::vector<char> StoreHandlerWrapper::get(const std::string& key) {
+std::vector<char> StoreHandlerWrapper::get(const std::string& key, bool /* unused */) {
   std::string str = handler_.get(key);
   return std::vector<char>(str.begin(), str.end());
 }

--- a/caffe2/contrib/gloo/store_handler.h
+++ b/caffe2/contrib/gloo/store_handler.h
@@ -14,10 +14,10 @@ class CAFFE2_API StoreHandlerWrapper : public ::gloo::rendezvous::Store {
 
   virtual ~StoreHandlerWrapper() {}
 
-  virtual void set(const std::string& key, const std::vector<char>& data)
+  virtual void set(const std::string& key, const std::vector<char>& data, bool ignorePrefix=false)
       override;
 
-  virtual std::vector<char> get(const std::string& key) override;
+  virtual std::vector<char> get(const std::string& key, bool ignorePrefix=false) override;
 
   virtual void wait(const std::vector<std::string>& keys) override {
     wait(keys, ::gloo::rendezvous::Store::kDefaultTimeout);

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -110,12 +110,12 @@ class GlooStore : public ::gloo::rendezvous::Store {
  public:
   GlooStore(const c10::intrusive_ptr<::c10d::Store>& store) : store_(store) {}
 
-  void set(const std::string& key, const std::vector<char>& value) override {
+  void set(const std::string& key, const std::vector<char>& value, bool /* unused */) override {
     std::vector<uint8_t> tmp(value.begin(), value.end());
     store_->set(key, tmp);
   }
 
-  std::vector<char> get(const std::string& key) override {
+  std::vector<char> get(const std::string& key, bool /* unused */) override {
     auto value = store_->get(key);
     return std::vector<char>(value.begin(), value.end());
   }

--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -13,7 +13,7 @@ namespace c10d {
 class Store : public torch::CustomClassHolder {
  public:
   static constexpr std::chrono::milliseconds kDefaultTimeout =
-      std::chrono::seconds(300);
+      std::chrono::seconds(3);
   static constexpr std::chrono::milliseconds kNoTimeout =
       std::chrono::milliseconds::zero();
 

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -16,6 +16,7 @@
 #include <torch/cuda.h>
 
 #include <c10d/FileStore.hpp>
+#include <c10d/HashStore.hpp>
 #include <c10d/ProcessGroupGloo.hpp>
 #include <c10d/test/TestUtils.hpp>
 
@@ -128,9 +129,10 @@ class CollectiveTest {
     }
 
     std::vector<std::thread> threads;
+    auto store = c10::make_intrusive<::c10d::FileStore>(path, tests.size());
     for (auto i = 0; i < num; i++) {
       threads.push_back(std::thread(
-          [i, &tests, delayed] { tests[i].start(i, tests.size(), delayed); }));
+          [i, &tests, delayed, &store] { tests[i].start(i, tests.size(), delayed, store); }));
     }
     for (auto& thread : threads) {
       thread.join();
@@ -150,9 +152,7 @@ class CollectiveTest {
     return *pg_;
   }
 
-  void start(int rank, int size, bool delayed) {
-    auto store = c10::make_intrusive<::c10d::FileStore>(path_, size);
-
+  void start(int rank, int size, bool delayed, c10::intrusive_ptr<c10d::FileStore> store) {
     // Set a timeout that is small enough to make this test run fast, but also
     // make sure that we don't get timeouts in the ProcessGroupGloo constructor.
     ::c10d::ProcessGroupGloo::Options options;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/gloo/pull/269

Pull Request resolved: https://github.com/pytorch/pytorch/pull/47928

Compute the local rank in Gloo given the global rank passed during process group construction.
ghstack-source-id: 116648544

Test Plan: Ran all ProcessGroupGloo tests

Differential Revision: D24902139

