### PR TITLE
[caffe2] Register BlackBoxPredictor AllocationArenaPool as CPUCachingAllocator

### DIFF
--- a/c10/core/CPUAllocator.h
+++ b/c10/core/CPUAllocator.h
@@ -65,4 +65,11 @@ C10_API at::Allocator* GetDefaultCPUAllocator();
 // Get the Default Mobile CPU Allocator
 C10_API at::Allocator* GetDefaultMobileCPUAllocator();
 
+// The CPUCachingAllocator is experimental and might disappear in the future.
+// The only place that uses it is in StaticRuntime.
+// Set the CPU Caching Allocator
+C10_API void SetCPUCachingAllocator(Allocator* alloc, uint8_t priority = 0);
+// Get the CPU Caching Allocator
+C10_API Allocator* GetCPUCachingAllocator();
+
 } // namespace c10

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/runtime/static/impl.h>
 #include <ATen/core/interned_strings.h>
+#include <c10/core/CPUAllocator.h>
 #include <caffe2/core/scope_guard.h>
 #include <caffe2/core/timer.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
@@ -643,7 +644,7 @@ size_t MemoryPlanner::compute_aligned_tensor_size(size_t nbytes) {
 }
 
 at::DataPtr MemoryPlanner::allocate_buffer(size_t size) {
-  at::Allocator* allocator = c10::GetCPUAllocator();
+  at::Allocator* allocator = c10::GetCPUCachingAllocator();
   return allocator->allocate(size);
 }
 


### PR DESCRIPTION
Summary:
- Register BlackBoxPredictor AllocationArenaPool as CPUCachingAllocator
- Use the AllocationArenaPool in both BlackBoxPredictor and StaticRuntime

Test Plan:
```
buck run //caffe2/caffe2/fb/predictor:black_box_predictor_test
buck run //caffe2/caffe2/fb/predictor:pytorch_predictor_test
```
AF canary:
https://our.intern.facebook.com/intern/ads/canary/430977633998746876

Differential Revision: D24977611

