### PR TITLE
[TensorPipe] Avoid using deprecated alias for error

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -498,7 +498,7 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
           // find a better way, Perhaps sending an empty message?
           if ((error.isOfType<tensorpipe::PipeClosedError>() &&
                !rpcAgentRunning_.load()) ||
-              error.isOfType<tensorpipe::transport::EOFError>()) {
+              error.isOfType<tensorpipe::EOFError>()) {
             // This is expected.
           } else {
             LOG(WARNING)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48168 [TensorPipe] Avoid using deprecated alias for error**

TensorPipe deduplicated a set of error (which existed both under the ::transport and the ::channel namespaces). The old names were kept as aliases but we should migrate to the new ones.

Differential Revision: [D25051218](https://our.internmc.facebook.com/intern/diff/D25051218/)