### PR TITLE
Fix typo in docstrings and displayed strings.

### DIFF
--- a/torch/fft/__init__.py
+++ b/torch/fft/__init__.py
@@ -327,7 +327,7 @@ Example:
     tensor([ 6.+0.j, -2.+2.j, -2.+0.j, -2.-2.j])
 
     Notice that the symmetric element ``T[-1] == T[1].conj()`` is omitted.
-    At the Nyquist frequency ``T[-2] == T[2]`` is it's own symmetric pair,
+    At the Nyquist frequency ``T[-2] == T[2]`` is its own symmetric pair,
     and therefore must always be real-valued.
 """)
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -19,7 +19,7 @@ class Container(Module):
     def __init__(self, **kwargs: Any) -> None:
         super(Container, self).__init__()
         # DeprecationWarning is ignored by default <sigh>
-        warnings.warn("nn.Container is deprecated. All of it's functionality "
+        warnings.warn("nn.Container is deprecated. All of its functionality "
                       "is now implemented in nn.Module. Subclass that instead.")
         for key, value in kwargs.items():
             self.add_module(key, value)
@@ -243,9 +243,9 @@ class ModuleDict(Module):
 
     * the order of insertion, and
 
-    * in :meth:`~torch.nn.ModuleDict.update`, the order of the merged 
+    * in :meth:`~torch.nn.ModuleDict.update`, the order of the merged
       ``OrderedDict``, ``dict`` (started from Python 3.6) or another
-      :class:`~torch.nn.ModuleDict` (the argument to 
+      :class:`~torch.nn.ModuleDict` (the argument to
       :meth:`~torch.nn.ModuleDict.update`).
 
     Note that :meth:`~torch.nn.ModuleDict.update` with other unordered mapping

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -154,7 +154,7 @@ class UpsamplingNearest2d(Upsample):
     channels.
 
     To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
-    as it's constructor argument.
+    as its constructor argument.
 
     When :attr:`size` is given, it is the output size of the image `(h, w)`.
 
@@ -199,7 +199,7 @@ class UpsamplingBilinear2d(Upsample):
     channels.
 
     To specify the scale, it takes either the :attr:`size` or the :attr:`scale_factor`
-    as it's constructor argument.
+    as its constructor argument.
 
     When :attr:`size` is given, it is the output size of the image `(h, w)`.
 

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4741,7 +4741,7 @@ class TestBase(object):
                 if name in {'constructor_args', 'extra_args'}:
                     kwargs[name] = tuple()
                 else:
-                    raise ValueError("{}: Specify {} by a value, a function to generate it, or it's size!"
+                    raise ValueError("{}: Specify {} by a value, a function to generate it, or its size!"
                                      .format(self.get_name(), name))
         self._extra_kwargs = kwargs
         self._arg_cache = {}

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -271,11 +271,11 @@ class SummaryWriter(object):
 
         Args:
             hparam_dict (dict): Each key-value pair in the dictionary is the
-              name of the hyper parameter and it's corresponding value.
+              name of the hyper parameter and its corresponding value.
               The type of the value can be one of `bool`, `string`, `float`,
               `int`, or `None`.
             metric_dict (dict): Each key-value pair in the dictionary is the
-              name of the metric and it's corresponding value. Note that the key used
+              name of the metric and its corresponding value. Note that the key used
               here should be unique in the tensorboard record. Otherwise the value
               you added by ``add_scalar`` will be displayed in hparam plugin. In most
               cases, this is unwanted.


### PR DESCRIPTION
Very small PR to fix some typos.

### Context
I noticed a typo in the documentation of `torch/utils/tensorboard/writer.py` (_it's_ instead of _its_) and took the opportunity to check for this typo in other files' strings that are displayed either in the documentation or in the terminal.

### Description
- Fixed 7 typos (replaced _it's_ by _its_)