### PR TITLE
[NNC] Complete SimpleIREvaluator support for bitwise ops (#48053)

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -115,6 +115,13 @@ AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_CppTypeToScalarType)
 
 #undef SPECIALIZE_CppTypeToScalarType
 
+#define AT_FORALL_INT_TYPES(_) \
+  _(uint8_t, Byte)             \
+  _(int8_t, Char)              \
+  _(int16_t, Short)            \
+  _(int, Int)                  \
+  _(int64_t, Long)
+
 #define AT_FORALL_SCALAR_TYPES(_) \
   _(uint8_t, Byte)                \
   _(int8_t, Char)                 \

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -457,7 +457,6 @@ class TestTEFuser(JitTestCase):
             ge = self.checkTrace(f, (x, y, z), inputs_require_grads=False)
             self.assertAllFused(ge.graph_for(x, y, z))
 
-    @unittest.skipIf(not LLVM_ENABLED, "TODO: bugs in ir eval")
     def test_bitwise_ops(self):
         def apply(fn):
             return lambda x, y, z: fn(fn(x, y), z)

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -310,6 +310,24 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
         case IRNodeType::kXor:
           result_v[i] = lhs_v[i] ^ rhs_v[i];
           break;
+        default:
+          // TODO: change to a proper error report
+          throw std::runtime_error("invalid operator type");
+      }
+    }
+    return Value(result_v);
+  }
+
+  template <typename T>
+  Value shift_binary_op(
+      const Value& lhs,
+      const Value& rhs,
+      IRNodeType op_type) {
+    std::vector<T> lhs_v = lhs.as_vec<T>();
+    std::vector<T> rhs_v = rhs.as_vec<T>();
+    std::vector<T> result_v(lhs_v.size());
+    for (size_t i = 0; i < lhs_v.size(); i++) {
+      switch (op_type) {
         case IRNodeType::kLshift:
           result_v[i] = lhs_v[i] << rhs_v[i];
           break;
@@ -376,8 +394,7 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
 
     IRNodeType expr_type = v->expr_type();
     if (expr_type == IRNodeType::kAnd || expr_type == IRNodeType::kOr ||
-        expr_type == IRNodeType::kXor || expr_type == IRNodeType::kLshift ||
-        expr_type == IRNodeType::kRshift) {
+        expr_type == IRNodeType::kXor) {
       switch (lhs_v.dtype().scalar_type()) {
 #define TYPE_CASE(Type, Name)                                  \
   case ScalarType::Name:                                       \
@@ -385,6 +402,20 @@ class SimpleIREvaluator : public CodeGen, public IRVisitor {
     break;
         AT_FORALL_INT_TYPES(TYPE_CASE);
 #undef TYPE_CASE
+        case ScalarType::Bool:
+          value_ = bitwise_binary_op<unsigned char>(lhs_v, rhs_v, expr_type);
+          break;
+        default:
+          throw unsupported_dtype();
+      }
+      return;
+    }
+
+    if (expr_type == IRNodeType::kLshift || expr_type == IRNodeType::kRshift) {
+      switch (lhs_v.dtype().scalar_type()) {
+        case ScalarType::Int:
+          value_ = shift_binary_op<int>(lhs_v, rhs_v, expr_type);
+          break;
         default:
           throw unsupported_dtype();
       }


### PR DESCRIPTION
Summary: Add missing types for bitwise_ops in `SimpleIREvaluator`

This is the first part of fixes for issue #48053.
- Original implementation of bitwise_ops supports only int operands, the
fix all support for integral types supported by the IR

Test Plan: `python test/test_jit_fuser_te.py TestTEFuser.test_bitwise_ops`

Reviewers: 

Subscribers:

Tasks: 48053

Tags: NNC
