### PR TITLE
Suppress "ioctl points to uninitialised" check

### DIFF
--- a/aten/tools/valgrind.sup
+++ b/aten/tools/valgrind.sup
@@ -25,6 +25,15 @@
 }
 
 {
+   ignore_cuda_ioctl_param_points_to_uninitialised_bytes
+   Memcheck:Param
+   ioctl(generic)
+   fun:ioctl
+   obj:*libcuda.so*
+   ...
+}
+
+{
    ignore_libomp_setaffinity_check
    Memcheck:Param
    sched_setaffinity(mask)


### PR DESCRIPTION
libcuda.so from CUDA-11.1 makes ioctl() that valgrind's memcheck tool considers dangerous
Instruct valgrind to suppress that check

Fixes false positives reported in https://app.circleci.com/pipelines/github/pytorch/pytorch/240774/workflows/d4c66de8-f13b-47a2-ae62-2ec1bbe0664b/jobs/9026496
