### PR TITLE
[DO NOT MERGE] Warn about assertEqual(actual, expected)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,3 +14,9 @@ ignore =
     C400,C401,C402,C403,C404,C405,C407,C411,C413,C414,C415
 per-file-ignores = __init__.py: F401 torch/utils/cpp_extension.py: B950
 exclude = docs/src,docs/cpp/src,venv,third_party,caffe2,scripts,docs/caffe2,torch/lib/include,torch/lib/tmp_install,build,torch/include,*.pyi,.git,build,build_test_custom_build,build_code_analyzer
+
+[flake8:local-plugins]
+extension =
+    PTA = assert_expected_actual:Plugin
+paths =
+    ./flake8_plugins

--- a/flake8_plugins/assert_expected_actual.py
+++ b/flake8_plugins/assert_expected_actual.py
@@ -1,0 +1,107 @@
+import ast
+import json
+from pathlib import Path
+import re
+
+
+MSG = 'PTA100 expected should come before actual'
+
+
+def is_literal(node):
+    return (
+        isinstance(node, ast.Constant) or
+        (
+            (
+                isinstance(node, ast.List) or
+                isinstance(node, ast.Set) or
+                isinstance(node, ast.Tuple)
+            ) and
+            all(is_literal(elt) for elt in node.elts)
+        ) or
+        (
+            isinstance(node, ast.Dict) and
+            all(is_literal(key) for key in node.keys) and
+            all(is_literal(value) for value in node.values)
+        )
+    )
+
+
+def classify_arg(node):
+    info = {'type': type(node).__name__, 'literal': is_literal(node)}
+    if info['type'] == 'Name':
+        for keyword in ['actual', 'expected']:
+            if re.search(keyword, node.id, re.IGNORECASE):
+                info[keyword] = True
+    return info
+
+
+def known_pattern(left, right):
+    return right.get('actual') or left.get('expected') or left.get('literal')
+
+
+def classify_call(node):
+    info = {'args': len(node.args)}
+    if info['args'] == 2:
+        left, right = map(classify_arg, node.args)
+        info['left'] = left
+        info['right'] = right
+        if known_pattern(left, right):
+            info['good'] = True
+        # check info.get('good') to ignore cases with two literals
+        if not info.get('good') and known_pattern(right, left):
+            info['flipped'] = True
+    return info
+
+
+class Visitor(ast.NodeVisitor):
+    def __init__(self):
+        self.usages = {}
+        self.problems = []
+
+    def visit_Call(self, node):
+        if (
+                isinstance(node.func, ast.Attribute) and
+                isinstance(node.func.value, ast.Name) and
+                node.func.value.id == 'self' and
+                node.func.attr == 'assertEqual'
+        ):
+            info = classify_call(node)
+            pos = node.lineno, node.col_offset
+            self.usages[f'{pos[0]}:{pos[1]}'] = info
+            if info.get('flipped'):
+                self.problems.append(pos)
+        self.generic_visit(node)
+
+
+class Plugin:
+    name = f'pytorch-{__name__.replace("_", "-")}'
+    version = '0.1.0'
+    labels_dir = None
+
+    @classmethod
+    def add_options(cls, option_manager):
+        option_manager.add_option(
+            '--all-assert-equal-usages', metavar='DIR',
+            help="Write each file's labeled self.assertEqual usages into DIR.",
+        )
+
+    @classmethod
+    def parse_options(cls, options):
+        cls.labels_dir = options.all_assert_equal_usages
+
+    def __init__(self, tree, filename):
+        self._tree = tree
+        self._filename = filename
+
+    def run(self):
+        visitor = Visitor()
+        visitor.visit(self._tree)
+        if Plugin.labels_dir:
+            # assumes Path.cwd() is pytorch clone dir
+            rel = Path(self._filename).resolve().relative_to(Path.cwd())
+            path = (Plugin.labels_dir / rel).with_name(f'{rel.name}.json')
+            if not path.exists() and visitor.usages:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(f'{json.dumps(visitor.usages, indent=2)}\n')
+        for line, col in visitor.problems:
+            yield line, col, MSG, type(self)

--- a/test/flake8_plugins/test_assert_expected_actual.py
+++ b/test/flake8_plugins/test_assert_expected_actual.py
@@ -1,0 +1,63 @@
+import ast
+from flake8_plugins.assert_expected_actual import Plugin
+
+
+def lints(source_code):
+    plugin = Plugin(ast.parse(source_code), 'foo.py')
+    return {f'{line}:{col+1} {msg}' for line, col, msg, _ in plugin.run()}
+
+
+def test_empty_program():
+    assert set() == lints('')
+
+
+def test_correct_order():
+    assert set() == lints('self.assertEqual(expected, actual)')
+
+
+def test_two_literals():
+    assert set() == lints('self.assertEqual(3, [4, 5])')
+
+
+def test_left_literal():
+    assert set() == lints('self.assertEqual(42, foo)')
+
+
+def test_neither_contains_string():
+    assert set() == lints('self.assertEqual(foo, bar)')
+    assert set() == lints('self.assertEqual(bar, foo)')
+
+
+def test_incorrect_order():
+    ret = lints('self.assertEqual(actual, expected)')
+    assert {'1:1 PTA100 expected should come before actual'} == ret
+
+
+def test_only_actual():
+    ret = lints('self.assertEqual(actual, foo)')
+    assert {'1:1 PTA100 expected should come before actual'} == ret
+
+
+def test_only_expected():
+    ret = lints('self.assertEqual(foo, expected)')
+    assert {'1:1 PTA100 expected should come before actual'} == ret
+
+
+def test_ignore_case_actual():
+    ret = lints('self.assertEqual(aCtUaL, 42)')
+    assert {'1:1 PTA100 expected should come before actual'} == ret
+
+
+def test_ignore_case_expected():
+    ret = lints('self.assertEqual(baz, ExPeCtEd)')
+    assert {'1:1 PTA100 expected should come before actual'} == ret
+
+
+def test_right_literal():
+    ret = lints('self.assertEqual(foo, 42)')
+    assert {'1:1 PTA100 expected should come before actual'} == ret
+
+
+def test_right_complicated_literal():
+    ret = lints('self.assertEqual(foo, [42, 34, "cat"])')
+    assert {'1:1 PTA100 expected should come before actual'} == ret

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -119,6 +119,7 @@ TESTS = [
     'distributed/_pipeline/sync/test_stream',
     'distributed/_pipeline/sync/test_transparency',
     'distributed/_pipeline/sync/test_worker',
+    'flake8_plugins/test_assert_expected_actual',
 ]
 
 # Tests need to be run with pytest.
@@ -145,7 +146,7 @@ USE_PYTEST_LIST = [
     'distributed/_pipeline/sync/test_stream',
     'distributed/_pipeline/sync/test_transparency',
     'distributed/_pipeline/sync/test_worker',
-]
+] + [test for test in TESTS if test.startswith('flake8_plugins/')]
 
 WINDOWS_BLOCKLIST = [
     'distributed/nn/jit/test_instantiator',


### PR DESCRIPTION
From the description of the FB-internal task [T77779973](https://www.internalfb.com/tasks/?t=77779973) by @janeyx99:

> I noticed several areas of the code in the `/test` folder with `assertEqual(actual, expected)` instead of `assertEqual(expected, actual)`. This is not great as it creates mixed signal and provides misleading test output for contributors. In addition to the linting efforts we’re currently pursuing, we should also automate and warn people of this pattern.

For context, the above areas were found using a simple `grep` command:
```sh
grep -r "assertEqual(actual" ./test
```

This PR adds a [Flake8 local plugin](https://flake8.pycqa.org/en/latest/user/configuration.html#using-local-plugins) that warns about the above, essentially according to three patterns:

1. the left argument contains the string "actual"
2. the right argument contains the string "expected"
3. the left argument is a literal

(As shown by the code itself, there is a bit more logic than that, to make it behave nicely.)

**NOTE: Currently this PR does not actually _fix_ the Flake8 failures that it introduces. The intention is to get some discussion on the approach before doing the (somewhat tedious) work of fixing all the individual instances.**

Test plan:

Check out this PR and run the unit tests:
```sh
test/run_test.py -vi flake8_plugins/test_assert_expected_actual
```
Next, run this command in `pytorch` to print the Flake8 warnings to stdout and also dump a bunch of data into `/tmp/asserts`:
```sh
flake8 --all-assert-equal-usages=/tmp/asserts
```

Then run this Python script (just copy-paste into your shell) to process all the individual files generated by the above command:
```sh
python3 - <<EOF
import json
from pathlib import Path


def inc(d, k):
    d[k] = d.get(k, 0) + 1


path = Path('/tmp/asserts')
unclassified = {}
stats = {}
for file_path in path.glob('**/*.json'):
    file_data = json.loads(file_path.read_text())
    for location, info in file_data.items():
        inc(stats, 'total')
        args = str(info['args'])
        if args == '2':
            two = stats.setdefault(args, {})
            inc(two, 'total')
            if info.get('flipped'):
                inc(two, 'flipped')
            elif info.get('good'):
                inc(two, 'good')
            else:
                # strip .json suffix
                filename = str(file_path.relative_to(path))[:-5]
                unclassified[filename] = location
                inc(two, 'unclassified')
        else:
            inc(stats, args)
print(json.dumps(stats, indent=2))
Path('/tmp/unclassified.txt').write_text(
    ''.join(f'{k}:{v}\n' for k, v in unclassified.items()),
)
EOF
```

stdout:
```json
{
  "total": 8335,
  "2": {
    "total": 8305,
    "unclassified": 5530,
    "flipped": 2119,
    "good": 656
  },
  "4": 1,
  "3": 22,
  "1": 7
}
```

As the above output shows, the current implementation warns about a quarter of all `self.assertEqual` usages. By comparison, less than 10% of  all `self.assertEqual` usages are actually determined by the current linter to definitely meet the desired `(expected, actual)` pattern.

To see some examples (one per file) of `self.assertEqual` usages that the current linter is unable to classify:
```sh
cat /tmp/unclassified.txt
```
Open a VS Code terminal and click on any of the lines to pull up those files and look at the individual examples.

From looking at them briefly, it seems that these unclassified examples tend to fall into a few categories (nonexhaustive, and in no particular order):

- there is no clear "expected" and "actual" (e.g. both args are generated from code under test, and then compared)
- the "expected" is a literal, but stored in a variable first (without "expected" in the name)
- the "expected" isn't a literal, but is generated by PyTorch (or sometimes just Python) functions that are similar to literals
- the "expected" is a global (assumedly constant) attribute of a module

Concerns:

- Because there are so many unclassified instances of `self.assertEqual`, just going through and (manually or automatically) fixing all these 2119 cases may actually result in _more_ inconsistency rather than less, because
  - the above data don't actually tell us that `(expected, actual)` is more common than `(actual, expected)`, and
  - there are instances of local groups of `self.assertEqual` usages where some are flagged and others are not, so unless a human looks at the whole group, it would become locally inconsistent.
- I don't know how annoying people would find this new lint, especially given how many cases it apparently lets through the cracks; it would be bad to hurt developer experience by landing this.

Thoughts?