### PR TITLE
Exclude docs/cpp/src from flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,4 +13,4 @@ ignore =
     # these ignores are from flake8-comprehensions; please fix!
     C400,C401,C402,C403,C404,C405,C407,C411,C413,C414,C415
 per-file-ignores = __init__.py: F401 torch/utils/cpp_extension.py: B950
-exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,torch/lib/include,torch/lib/tmp_install,build,torch/include,*.pyi,.git,build,build_test_custom_build,build_code_analyzer
+exclude = docs/src,docs/cpp/src,venv,third_party,caffe2,scripts,docs/caffe2,torch/lib/include,torch/lib/tmp_install,build,torch/include,*.pyi,.git,build,build_test_custom_build,build_code_analyzer


### PR DESCRIPTION
Currently when I run `flake8` locally I get [a bunch of extraneous warnings](https://pastebin.com/DMQevCtC) because the docs build puts a `pytorch-sphinx-theme` dir into `docs/cpp/src`. Those warnings don't show up in CI because the CI lint job doesn't generate that dir. This PR adds that to the Flake8 `exclude` list, similar to how `docs/src` is already present in that list.