### PR TITLE
[PT][StaticRuntime] Move prim op impl to ops.cpp

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <torch/torch.h>
+
+const auto list_construct_script = R"JIT(
+  def forward(self, a, b):
+    return [a, b]
+)JIT";
+
+const auto list_unpack_script = R"JIT(
+  def forward(self, a, b):
+    c = [a, b]
+    x, y = c
+    z = x + y
+    return z
+)JIT";
+
+const auto tuple_construct_script = R"JIT(
+  def forward(self, a, b):
+    return (a, b)
+)JIT";
+
+const auto add_script = R"JIT(
+  def forward(self, a, b):
+      return a + b
+)JIT";

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -588,8 +588,6 @@ void StaticRuntime::deallocate_registers(const std::vector<size_t>& internals) {
         reg_[i] = IValue();
       }
     } else {
-      // TensorLists and Tuples
-      // TODO: cache the List and Tuple objects but release what's inside
       reg_[i] = IValue();
     }
   }
@@ -733,8 +731,7 @@ ProcessedNode::ProcessedNode(
     std::ostringstream ss;
     node->print(ss, 0, nullptr, false);
     VLOG(1) << "Switch to out variant for node: " << ss.str();
-  }
-  if (canRunNatively(node)) {
+  } else if (canRunNatively(node)) {
     native_fn_ = getNativeOperation(node);
     std::ostringstream ss;
     node->print(ss, 0, nullptr, false);
@@ -754,32 +751,10 @@ void ProcessedNode::run(std::vector<IValue>& reg) const {
     for (size_t i = 0; i < size; i++) {
       stack.emplace_back(Input(i, reg));
     }
-    if (op_) {
-      op_->operator()(&stack);
-    } else {
-      if (node_->kind() == prim::ListConstruct) {
-        listConstruct(
-            stack,
-            node_->output()->type()->expect<ListType>(),
-            node_->inputs().size());
-      } else if (node_->kind() == prim::TupleConstruct) {
-        bool named =
-            node_->output()->type()->expect<TupleType>()->name().has_value();
-        if (named) {
-          namedTupleConstruct(
-              stack,
-              node_->output()->type()->expect<TupleType>(),
-              node_->inputs().size());
-        } else {
-          tupleConstruct(stack, node_->inputs().size());
-        }
-      } else if (node_->kind() == prim::ListUnpack) {
-        size_t num_outputs = node_->outputs().size();
-        listUnpack(stack, num_outputs);
-      } else {
-        TORCH_CHECK(0, "Unhandled operation!", node_->kind().toQualString());
-      }
-    }
+
+    DCHECK(op_);
+    op_->operator()(&stack);
+
     DCHECK_EQ(stack.size(), node_->outputs().size());
     for (auto i = 0; i < node_->outputs().size(); i++) {
       Output(i, reg) = std::move(stack[i]);

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -273,6 +273,11 @@ class ProcessedNode {
     return output_regs_;
   }
 
+  const TypePtr& get_output_type(size_t i) const {
+    DCHECK_LT(i, output_regs().size());
+    return node_->outputs()[i]->type();
+  }
+
  private:
   Node* node_;
   c10::optional<Operation> op_;

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <ATen/NativeFunctions.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/runtime/vararg_functions.h>
 
 namespace torch {
 namespace jit {
@@ -11,17 +12,21 @@ inline at::Tensor create_empty_from(const at::Tensor& t) {
 } // namespace
 
 bool canRunOutOfPlace(Node* n) {
+  // In alphabetical order
   const static std::unordered_set<std::string> out_of_place_nodes{
       "aten::add",
-      "aten::mul",
       "aten::addmm",
       "aten::bmm",
-      "aten::sigmoid",
-      "aten::leaky_relu",
       "aten::cat",
+      "aten::clamp",
+      "aten::leaky_relu",
+      "aten::logit",
+      "aten::mul",
       "aten::nan_to_num",
+      "aten::relu",
+      "aten::sigmoid",
       "aten::stack",
-  };
+      "aten::tanh"};
   auto str = std::string(n->kind().toQualString());
   return out_of_place_nodes.count(str) > 0;
 }
@@ -29,8 +34,13 @@ bool canRunOutOfPlace(Node* n) {
 // TODO: expand to include all view producing ops, mostly in
 // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/TensorShape.cpp
 bool canRunNatively(Node* n) {
-  const static std::unordered_set<std::string> native_nodes{"aten::transpose",
-                                                            "aten::flatten"};
+  // In alphabetical order
+  const static std::unordered_set<std::string> native_nodes{
+      "aten::flatten",
+      "aten::transpose",
+      "prim::ListConstruct",
+      "prim::ListUnpack",
+      "prim::TupleConstruct"};
   auto str = std::string(n->kind().toQualString());
   return native_nodes.count(str) > 0;
 }
@@ -38,7 +48,7 @@ bool canRunNatively(Node* n) {
 std::function<void(const ProcessedNode*, std::vector<IValue>&)>
 getOutOfPlaceOperation(Node* n) {
   if (n->kind() == c10::Symbol::fromQualString("aten::add")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_t = p_node->Input(1, reg).toTensor();
       auto in2_s = p_node->Input(2, reg).toScalar();
@@ -50,7 +60,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::add_out(out_t, in0_t, in1_t, in2_s);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::mul")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_t = p_node->Input(1, reg).toTensor();
       if (p_node->Output(0, reg).isNone()) {
@@ -61,7 +71,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::mul_out(out_t, in0_t, in1_t);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::addmm")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_t = p_node->Input(1, reg).toTensor();
       auto in2_t = p_node->Input(2, reg).toTensor();
@@ -75,7 +85,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::addmm_cpu_out(out_t, in0_t, in1_t, in2_t, in3_s, in4_s);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::clamp")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_s = p_node->Input(1, reg).toScalar();
       auto in2_s = p_node->Input(2, reg).toScalar();
@@ -87,7 +97,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::clamp_out(out_t, in0_t, in1_s, in2_s);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::bmm")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_t = p_node->Input(1, reg).toTensor();
       if (p_node->Output(0, reg).isNone()) {
@@ -114,7 +124,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::nan_to_num_out(out_t, in0_t, in1_d, in2_d, in3_d);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::cat")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_tl = p_node->Input(0, reg).toTensorVector();
       auto in1_i = p_node->Input(1, reg).toInt();
       if (p_node->Output(0, reg).isNone()) {
@@ -125,7 +135,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::_cat_out_cpu(out_t, in0_tl, in1_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::tanh")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       if (p_node->Output(0, reg).isNone()) {
         p_node->Output(0, reg) = create_empty_from(in0_t);
@@ -162,7 +172,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::_cat_out_cpu(out_t, inputs, dim);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::sigmoid")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       if (p_node->Output(0, reg).isNone()) {
         p_node->Output(0, reg) = create_empty_from(in0_t);
@@ -175,7 +185,7 @@ getOutOfPlaceOperation(Node* n) {
     auto in1 = toIValue(n->inputs()[1]);
     if (in1) {
       auto in1_s = in1->toScalar();
-      return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+      return [in1_s](const ProcessedNode* p_node, std::vector<IValue>& reg) {
         auto in0_t = p_node->Input(0, reg).toTensor();
         if (p_node->Output(0, reg).isNone()) {
           p_node->Output(0, reg) = create_empty_from(in0_t);
@@ -184,7 +194,7 @@ getOutOfPlaceOperation(Node* n) {
         at::native::leaky_relu_out(out_t, in0_t, in1_s);
       };
     } else {
-      return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+      return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
         auto in0_t = p_node->Input(0, reg).toTensor();
         auto in1_s = p_node->Input(1, reg).toScalar();
         if (p_node->Output(0, reg).isNone()) {
@@ -195,7 +205,7 @@ getOutOfPlaceOperation(Node* n) {
       };
     }
   } else if (n->kind() == c10::Symbol::fromQualString("aten::relu")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       if (p_node->Output(0, reg).isNone()) {
         p_node->Output(0, reg) = create_empty_from(in0_t);
@@ -205,7 +215,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::threshold_out(out_t, in0_t, 0, 0);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::logit")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_d = p_node->Input(1, reg).toDouble();
       if (p_node->Output(0, reg).isNone()) {
@@ -216,7 +226,7 @@ getOutOfPlaceOperation(Node* n) {
       at::native::logit_out(out_t, in0_t, in1_d);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::clone")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       if (p_node->Output(0, reg).isNone()) {
         p_node->Output(0, reg) = create_empty_from(in0_t);
@@ -232,18 +242,73 @@ getOutOfPlaceOperation(Node* n) {
 std::function<void(const ProcessedNode*, std::vector<IValue>&)>
 getNativeOperation(Node* n) {
   if (n->kind() == c10::Symbol::fromQualString("aten::transpose")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_i = p_node->Input(1, reg).toInt();
       auto in2_i = p_node->Input(2, reg).toInt();
       p_node->Output(0, reg) = at::native::transpose(in0_t, in1_i, in2_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::flatten")) {
-    return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
       auto in0_t = p_node->Input(0, reg).toTensor();
       auto in1_i = p_node->Input(1, reg).toInt();
       auto in2_i = p_node->Input(2, reg).toInt();
       p_node->Output(0, reg) = at::native::flatten(in0_t, in1_i, in2_i);
+    };
+  } else if (n->kind() == prim::TupleConstruct) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+      // prepare inputs
+      std::vector<IValue> stack;
+      const size_t size = p_node->input_regs().size();
+      stack.reserve(size);
+      for (size_t i = 0; i < size; i++) {
+        stack.emplace_back(p_node->Input(i, reg));
+      }
+      // run op
+      auto* node = p_node->get_node();
+      const auto& type = node->output()->type()->expect<TupleType>();
+      if (type->name().has_value()) {
+        namedTupleConstruct(stack, type, node->inputs().size());
+      } else {
+        tupleConstruct(stack, node->inputs().size());
+      }
+      // put output back
+      p_node->Output(0, reg) = std::move(stack[0]);
+    };
+  } else if (n->kind() == prim::ListConstruct) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+      // prepare inputs
+      std::vector<IValue> stack;
+      const size_t size = p_node->input_regs().size();
+      stack.reserve(size);
+      for (size_t i = 0; i < size; i++) {
+        stack.emplace_back(p_node->Input(i, reg));
+      }
+      // run op
+      listConstruct(
+          stack,
+          p_node->get_node()->output()->type()->expect<ListType>(),
+          p_node->input_regs().size());
+      // put output back
+      p_node->Output(0, reg) = std::move(stack[0]);
+    };
+  } else if (n->kind() == prim::ListUnpack) {
+    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+      // prepare inputs
+      std::vector<IValue> stack;
+      const size_t size = p_node->input_regs().size();
+      stack.reserve(size);
+      for (size_t i = 0; i < size; i++) {
+        stack.emplace_back(p_node->Input(i, reg));
+      }
+      // run op
+      size_t num_outputs = p_node->output_regs().size();
+      listUnpack(stack, num_outputs);
+      // put output back
+      DCHECK_EQ(stack.size(), num_outputs);
+      for (auto i = 0; i < num_outputs; i++) {
+        p_node->Output(i, reg) = std::move(stack[i]);
+      }
     };
   }
   return [](const ProcessedNode*, std::vector<IValue>&) { TORCH_CHECK(0); };


### PR DESCRIPTION
Summary:
- Move prim op implementation from `ProcessedNode::run` to `getNativeOperation`
- Add out variant for `prim::listConstruct`

Test Plan:
```
buck test //caffe2/test:static_runtime
buck test //caffe2/benchmarks/static_runtime:static_runtime_cpptest
buck test //caffe2/caffe2/fb/predictor:pytorch_predictor_test

buck run mode/dev //caffe2/caffe2/fb/predictor:ptvsc2_predictor_bench -- \
--scripted_model=/home/hlu/ads/adindexer/adindexer_ctr_mobilefeed/pt/merge/traced_precomputation.pt \
--pt_inputs=/home/hlu/ads/adindexer/adindexer_ctr_mobilefeed/pt/merge/container_precomputation_bs1.pt \
--iters=1 --warmup_iters=1 --num_threads=1 --pt_enable_static_runtime=true \
--pt_cleanup_activations=true --pt_enable_out_variant=true
```

Reviewed By: ajyu

Differential Revision: D24748947

