### PR TITLE
Automatically infer the type of the iterator in a range-based for loop

### DIFF
--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -172,7 +172,7 @@ std::string show_config() {
   }
 
   ss << "  - Build settings: ";
-  for (const std::pair<std::string, std::string>& pair : caffe2::GetBuildOptions()) {
+  for (const auto& pair : caffe2::GetBuildOptions()) {
     if (!pair.second.empty()) {
       ss << pair.first << "=" << pair.second << ", ";
     }


### PR DESCRIPTION
Summary:
This was not the correct type that's being generated via the begin()
function and thus a new object was being created and attempted to take a
reference to. Instead just take a reference to whatever the range-based loop
generates.

Test Plan: This fixes a build error from a new warnign in llvm11

Reviewed By: smeenai

Differential Revision: D24970920

