### PR TITLE
Remove an accidental copy in a range-based for loop

### DIFF
--- a/caffe2/opt/mobile.cc
+++ b/caffe2/opt/mobile.cc
@@ -99,7 +99,7 @@ void fuseNNPACKConvRelu(repr::NNModule* nn) {
       return false;
     }
     caffe2::string algo = "AUTO";
-    for (const auto arg : op.arg()) {
+    for (const auto &arg : op.arg()) {
       if (arg.name() == "algo") {
         algo = arg.s();
       }


### PR DESCRIPTION
Summary:
This was copying the iterator varaible instead of taking a reference.
Fix the trivial error here.

Test Plan:
clang11 catches this and throws a warning that we promote with
-Werror. This change fixes the error.

Reviewed By: smeenai

Differential Revision: D24970929

