### PR TITLE
[WIP] Add warning message to cuDNN convolution for specific memory formats and GPU arch

### DIFF
--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -174,7 +174,16 @@ static void check_args(CheckedFrom c, IntArrayRef args, size_t expected_size, co
 }
 
 static void warn_memory_formats(CheckedFrom c, MemoryFormat memory_format, ScalarType scalar_type) {
-
+  if (scalar_type == at::kFloat) {
+    if ((memory_format == at::MemoryFormat::ChannelsLast) || memory_format == at::MemoryFormat::ChannelsLast3d) {
+      TORCH_WARN_ONCE(
+        "Using torch.float data type with torch.channels_last or torch.channels_last_3d memory format "
+        "is generally not recommended in GPU convolution. "
+        "If you experience slow performance in convolution, please try "
+        "torch.float + torch.contiguous_format or torch.half (pure half or Automatic Mixed Precision) + torch.channels_last(_3d)."
+      );
+    }
+  }
 }
 
 // NOTE [ Convolution checks ]

--- a/aten/src/ATen/native/cudnn/ConvShared.cpp
+++ b/aten/src/ATen/native/cudnn/ConvShared.cpp
@@ -180,7 +180,7 @@ static void warn_memory_formats(CheckedFrom c, MemoryFormat memory_format, Scala
         "Using torch.float data type with torch.channels_last or torch.channels_last_3d memory format "
         "is generally not recommended in GPU convolution. "
         "If you experience slow performance in convolution, please try "
-        "torch.float + torch.contiguous_format or torch.half (pure half or Automatic Mixed Precision) + torch.channels_last(_3d)."
+        "torch.float + torch.contiguous_format or torch.half (full .half() or Automatic Mixed Precision) + torch.channels_last(_3d)."
       );
     }
   }


### PR DESCRIPTION
Related https://github.com/pytorch/pytorch/issues/47912

This PR adds warning messages if user calls cuDNN convolution with

- [x] FP32 + channels_last(_3d)

The following warning message is **not** enabled for now, do we need this?

- [ ] FP16 + channels_last(_3d) **and** cuda compute capability is lower than 7 (GPU doesn't have Tensor Core, e.g. Pascal, Maxwell, Kepler)