### PR TITLE
Add SparseLengthsSum4BitRowwiseSparse in c2_pt_converter

### DIFF
--- a/caffe2/python/brew.py
+++ b/caffe2/python/brew.py
@@ -74,6 +74,7 @@ class HelperWrapper(object):
         'loop' : loop,
         'db_input' : db_input,
         'fused_8bit_rowwise_quantized_to_float' : fused_8bit_rowwise_quantized_to_float,
+        'sparse_lengths_sum_4bit_rowwise_sparse': sparse_lengths_sum_4bit_rowwise_sparse,
     }
 
     def __init__(self, wrapped):

--- a/caffe2/python/helpers/algebra.py
+++ b/caffe2/python/helpers/algebra.py
@@ -39,3 +39,6 @@ def batch_mat_mul(model, blob_in, blob_out,
         kwargs['engine'] = 'TENSORCORE'
 
     return model.net.BatchMatMul(blob_in, blob_out, **kwargs)
+
+def sparse_lengths_sum_4bit_rowwise_sparse(model, blob_in, blob_out, **kwargs):
+    return model.net.SparseLengthsSum4BitRowwiseSparse(blob_in, blob_out, **kwargs)


### PR DESCRIPTION
Summary: Adds the support for converting the SparseLengthsSum4BitRowwiseSparse operator from caffe2 to pytorch as a part of c2_pt_converter

Test Plan:
Added a unit tested

buck test //caffe2/torch/fb/model_transform/c2_convert:c2_pt_converter_test

Successfully Results :  https://fburl.com/testinfra/021rozzb

Differential Revision: D25067833

