### PR TITLE
[pytorch][codegen] move is_abstract property to NativeFunction model

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -845,12 +845,6 @@ def compute_declaration_yaml(f: NativeFunction) -> object:
     is_factory_method = any(isinstance(a.argument, TensorOptionsArguments) for a in cpp_args) \
         and Variant.method not in f.variants
 
-    if f.structured_delegate:
-        # Structured functions MUST have a dispatch table
-        is_abstract = True
-    else:
-        is_abstract = f.dispatch.keys() != {'Math'}
-
     return OrderedDict([
         ('name', cpp.name(f.func)),
         ('operator_name', str(f.func.name.name)),
@@ -869,22 +863,7 @@ def compute_declaration_yaml(f: NativeFunction) -> object:
         ('returns', returns),
         ('inplace', f.func.name.name.inplace),
         ('is_factory_method', is_factory_method),
-        # Note [Abstract ATen methods]
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # An abstract ATen method is one whose dispatch differs between
-        # types.  These are implemented in derived types (with a
-        # standard (throwing) definition in Type).  A concrete ATen
-        # method is one which has the same dispatch for all types;
-        # we just implement it in the base Type.  This is exposed
-        # in Declarations.yaml via a field named 'abstract'.
-        #
-        # Although this is what we have historically exposed, it is
-        # actually not all that useful for end users, who are also interested
-        # whether or not there is an explicit entry in derivatives.yaml
-        # for the entry or not (as this affects whether or not the operation is
-        # overrideable or not.)  Once this all gets cleaned up, this
-        # property will be obsolete.
-        ('abstract', is_abstract),
+        ('abstract', f.is_abstract),
         ('device_guard', f.device_guard),
         ('with_gil', False),
         ('deprecated', False),

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -125,6 +125,29 @@ class NativeFunction:
     # in terms of the out kernel referenced by the string here.
     structured_delegate: Optional['OperatorName']
 
+    # Note [Abstract ATen methods]
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # An abstract ATen method is one whose dispatch differs between
+    # types.  These are implemented in derived types (with a
+    # standard (throwing) definition in Type).  A concrete ATen
+    # method is one which has the same dispatch for all types;
+    # we just implement it in the base Type.  This is exposed
+    # in Declarations.yaml via a field named 'abstract'.
+    #
+    # Although this is what we have historically exposed, it is
+    # actually not all that useful for end users, who are also interested
+    # whether or not there is an explicit entry in derivatives.yaml
+    # for the entry or not (as this affects whether or not the operation is
+    # overrideable or not.)  Once this all gets cleaned up, this
+    # property will be obsolete.
+    @property
+    def is_abstract(self) -> bool:
+        if self.structured_delegate:
+            # Structured functions MUST have a dispatch table
+            return True
+        else:
+            return self.dispatch.keys() != {'Math'}
+
     # NB: The benefit of defining a dataclass is that we automatically get
     # a constructor defined for all the fields we specify.  No need
     # to explicitly write it out.

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -133,13 +133,6 @@ class NativeFunction:
     # method is one which has the same dispatch for all types;
     # we just implement it in the base Type.  This is exposed
     # in Declarations.yaml via a field named 'abstract'.
-    #
-    # Although this is what we have historically exposed, it is
-    # actually not all that useful for end users, who are also interested
-    # whether or not there is an explicit entry in derivatives.yaml
-    # for the entry or not (as this affects whether or not the operation is
-    # overrideable or not.)  Once this all gets cleaned up, this
-    # property will be obsolete.
     @property
     def is_abstract(self) -> bool:
         if self.structured_delegate:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48249 [pytorch][codegen] add autograd data model
* **#48252 [pytorch][codegen] move is_abstract property to NativeFunction model**

Moved to a shared place so that gen_variable_type.py can reuse it.

Differential Revision: [D25087808](https://our.internmc.facebook.com/intern/diff/D25087808)