### PR TITLE
[Gradient Compression] Add a comment on _orthogonalize.

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -5,7 +5,11 @@ import torch.distributed as dist
 
 
 def _orthogonalize(matrix, epsilon=1e-8):
-    """Applies Gram-Schmidt procedure to orthogonalize a given 2D tensor."""
+    """
+    Applies Gram-Schmidt procedure to orthogonalize a given 2D tensor.
+    If epsilon is 0, this is equivalent to `torch.qr(matrix, out=(matrix, _))`,
+    but `torch.qr` is very slow, probably not optimized for the matrix that has few columns.
+    """
     num_cols = matrix.shape[1]
     for i in range(num_cols):
         # Normalize the i'th column.

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -8,7 +8,7 @@ def _orthogonalize(matrix, epsilon=1e-8):
     """
     Applies Gram-Schmidt procedure to orthogonalize a given 2D tensor.
     If epsilon is 0, this is equivalent to `torch.qr(matrix, out=(matrix, _))`,
-    but `torch.qr` is very slow, probably not optimized for the matrix that has few columns.
+    but `torch.qr` is very slow, probably because it is not optimized for a matrix that has a small number of columns.
     """
     num_cols = matrix.shape[1]
     for i in range(num_cols):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48253 [Gradient Compression] Add a comment on _orthogonalize.**

Explained why a hand-crafted orthogonalize function is used instead of `torch.qr`.

Original PR issue: Investigate Applying PowerSGD to Communication Hook for Gradient Compression #47202

Differential Revision: [D25088607](https://our.internmc.facebook.com/intern/diff/D25088607/)