### PR TITLE
[Pytorch Mobile] Disable OutOfPlace calls for mobile

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -111,7 +111,7 @@ core_trainer_sources = [
     "torch/csrc/jit/serialization/type_name_uniquer.cpp",
 ]
 
-core_sources_full = [
+core_sources_full_mobile = [
     "torch/csrc/jit/api/function_impl.cpp",
     "torch/csrc/jit/api/module.cpp",
     "torch/csrc/jit/api/object.cpp",
@@ -216,8 +216,6 @@ core_sources_full = [
     "torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp",
     "torch/csrc/jit/runtime/profiling_record.cpp",
     "torch/csrc/jit/runtime/symbolic_script.cpp",
-    "torch/csrc/jit/runtime/static/impl.cpp",
-    "torch/csrc/jit/runtime/static/ops.cpp",
     "torch/csrc/jit/serialization/import.cpp",
     "torch/csrc/jit/serialization/import_export_helpers.cpp",
     "torch/csrc/jit/serialization/import_source.cpp",
@@ -251,6 +249,11 @@ core_sources_full = [
     "torch/csrc/jit/testing/hooks_for_testing.cpp",
     "torch/csrc/utils/tensor_flatten.cpp",
     "torch/csrc/utils/variadic.cpp",
+]
+
+core_sources_full = core_sources_full_mobile + [
+    "torch/csrc/jit/runtime/static/impl.cpp",
+    "torch/csrc/jit/runtime/static/ops.cpp",
 ]
 
 libtorch_core_sources = sorted(core_sources_common + core_sources_full + core_trainer_sources)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48255 [Pytorch Mobile] Disable OutOfPlace calls for mobile**

There's effort to move aten::native files to app level. After this effort, the operators and their kernels in aten::native can be selectively built per app.

There are some direct reference to at::native symbols in jit/runtime/static/ops.cpp. Those symbols are missing if their implementations are moved up to app level in Android.

Files in jit/runtime/static folder belongs to full-jit and should not be built from mobile. However, since Federated Learning is still using full-jit in fb4a, as a temporary solution, in this diff we disable the static calls for mobile build.

When FL team migrates to lite_trainer, we could remove those macros because ops.cpp will not be included in mobile build. In longer term if we want to make use of the perf advantage of static ops, we could move this file to app level with some decoupling effort.

Differential Revision: [D24822690](https://our.internmc.facebook.com/intern/diff/D24822690/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D24822690/)!