### PR TITLE
[PyTorch] Declare the instantiation of PackedConvWeightsQnnp<2>::prepack

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -274,6 +274,18 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsQnnp<
   return ret_ptr;
 }
 
+template
+c10::intrusive_ptr<ConvPackedParamsBase<2>> PackedConvWeightsQnnp<
+    2>::
+    prepack(
+        at::Tensor weight,
+        c10::optional<at::Tensor> bias_in,
+        torch::List<int64_t> stride,
+        torch::List<int64_t> padding,
+        torch::List<int64_t> output_padding,
+        torch::List<int64_t> dilation,
+        int64_t groups,
+        bool transpose);
 #endif // USE_PYTORCH_QNNPACK
 
 namespace at {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48256 [PyTorch] Declare the instantiation of PackedConvWeightsQnnp<2>::prepack**

`PackedConvWeightsQnnp<2>::prepack` is referenced by both `quantized::conv_prepack` and fbgemm.cpp. Since `quantized::conv_prepack` is in the same compilation unit as the class template it was fine. However, if we make operator registration selective, the reference from `quantized::conv_prepack` is gone. The reference from fbgemm.cpp is in another compilation unit and there is link error.

To avoid the link error, instantiate the symbol in the cpp file. It should also work to move all implementations to .h file, but to keep the existing code structure and to avoid (small chance of) code bloat, the implementations are kept as is.

Differential Revision: [D24941989](https://our.internmc.facebook.com/intern/diff/D24941989/)