### PR TITLE
fix move default not compile correctly on cuda92

### DIFF
--- a/c10/util/Optional.cpp
+++ b/c10/util/Optional.cpp
@@ -2,5 +2,9 @@
 
 #include <type_traits>
 
+// CUDA 9.2 and below fail while trying to compile default move constructor
+// see https://github.com/pytorch/csprng/issues/84
+#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
 static_assert(C10_IS_TRIVIALLY_COPYABLE(c10::optional<int>), "c10::optional<int> should be trivially copyable");
 static_assert(C10_IS_TRIVIALLY_COPYABLE(c10::optional<bool>), "c10::optional<bool> should be trivially copyable");
+#endif

--- a/c10/util/Optional.cpp
+++ b/c10/util/Optional.cpp
@@ -4,7 +4,7 @@
 
 // CUDA 9.2 and below fail while trying to compile default move constructor
 // see https://github.com/pytorch/csprng/issues/84
-#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
+#if (!defined(__CUDA_ARCH__) || !defined(CUDA_VERSION) || CUDA_VERSION > 9200)
 static_assert(C10_IS_TRIVIALLY_COPYABLE(c10::optional<int>), "c10::optional<int> should be trivially copyable");
 static_assert(C10_IS_TRIVIALLY_COPYABLE(c10::optional<bool>), "c10::optional<bool> should be trivially copyable");
 #endif

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -388,7 +388,7 @@ struct trivially_copyable_optimization_optional_base {
 
 // CUDA 9.2 and below fail while trying to compile default move constructor
 // see https://github.com/pytorch/csprng/issues/84
-#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
+#if (!defined(__CUDA_ARCH__) || !defined(CUDA_VERSION) || CUDA_VERSION > 9200)
 template <class T>
 using OptionalBase = typename std::conditional<
     std::is_trivially_destructible<T>::value &&
@@ -412,13 +412,13 @@ using OptionalBase = typename std::conditional<
         constexpr_optional_base<typename std::remove_const<
             T>::type>, // use base with trivial destructor
         optional_base<typename std::remove_const<T>::type>>::type;
-#endif // (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
+#endif 
 
 template <class T>
 class optional : private OptionalBase<T> {
 // CUDA 9.2 and below fail while trying to compile default move constructor
 // see https://github.com/pytorch/csprng/issues/84
-#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
+#if (!defined(__CUDA_ARCH__) || !defined(CUDA_VERSION) || CUDA_VERSION > 9200)
   template <class U> // re-declaration for nvcc on Windows.
   using OptionalBase = typename std::conditional<
       std::is_trivially_destructible<U>::value &&
@@ -438,7 +438,7 @@ class optional : private OptionalBase<T> {
           constexpr_optional_base<typename std::remove_const<
               U>::type>, // use base with trivial destructor
           optional_base<typename std::remove_const<U>::type>>::type;
-#endif // (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
+#endif 
 
   static_assert(
       !std::is_same<typename std::decay<T>::type, nullopt_t>::value,
@@ -500,7 +500,7 @@ class optional : private OptionalBase<T> {
 
 // CUDA 9.2 and below fail while trying to compile default move constructor
 // see https://github.com/pytorch/csprng/issues/84
-#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
+#if (!defined(__CUDA_ARCH__) || !defined(CUDA_VERSION) || CUDA_VERSION > 9200)
   optional(optional&& rhs) = default;
 #else
   optional(optional&& rhs) noexcept(

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -504,8 +504,7 @@ class optional : private OptionalBase<T> {
   optional(optional&& rhs) = default;
 #else
   optional(optional&& rhs) noexcept(
-      std::is_nothrow_move_constructible<T>::value)
-      : OptionalBase<T>() {
+      std::is_nothrow_move_constructible<T>::value) {
     if (rhs.initialized()) {
       ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
       OptionalBase<T>::init_ = true;

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -386,6 +386,9 @@ struct trivially_copyable_optimization_optional_base {
   ~trivially_copyable_optimization_optional_base() = default;
 };
 
+// CUDA 9.2 and below fail while trying to compile default move constructor
+// see https://github.com/pytorch/csprng/issues/84
+#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
 template <class T>
 using OptionalBase = typename std::conditional<
     std::is_trivially_destructible<T>::value &&
@@ -402,9 +405,20 @@ using OptionalBase = typename std::conditional<
         constexpr_optional_base<typename std::remove_const<
             T>::type>, // use base with trivial destructor
         optional_base<typename std::remove_const<T>::type>>::type>::type;
+#else
+template <class T>
+using OptionalBase = typename std::conditional<
+        std::is_trivially_destructible<T>::value, // if possible
+        constexpr_optional_base<typename std::remove_const<
+            T>::type>, // use base with trivial destructor
+        optional_base<typename std::remove_const<T>::type>>::type;
+#endif // (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
 
 template <class T>
 class optional : private OptionalBase<T> {
+// CUDA 9.2 and below fail while trying to compile default move constructor
+// see https://github.com/pytorch/csprng/issues/84
+#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
   template <class U> // re-declaration for nvcc on Windows.
   using OptionalBase = typename std::conditional<
       std::is_trivially_destructible<U>::value &&
@@ -417,6 +431,14 @@ class optional : private OptionalBase<T> {
           constexpr_optional_base<typename std::remove_const<
               U>::type>, // use base with trivial destructor
           optional_base<typename std::remove_const<U>::type>>::type>::type;
+#else
+  template <class U>
+  using OptionalBase = typename std::conditional<
+          std::is_trivially_destructible<U>::value, // if possible
+          constexpr_optional_base<typename std::remove_const<
+              U>::type>, // use base with trivial destructor
+          optional_base<typename std::remove_const<U>::type>>::type;
+#endif // (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
 
   static_assert(
       !std::is_same<typename std::decay<T>::type, nullopt_t>::value,
@@ -476,7 +498,20 @@ class optional : private OptionalBase<T> {
 
   optional(const optional& rhs) = default;
 
+// CUDA 9.2 and below fail while trying to compile default move constructor
+// see https://github.com/pytorch/csprng/issues/84
+#if (!defined(CUDA_VERSION) || CUDA_VERSION > 9200)
   optional(optional&& rhs) = default;
+#else
+  optional(optional&& rhs) noexcept(
+      std::is_nothrow_move_constructible<T>::value)
+      : OptionalBase<T>() {
+    if (rhs.initialized()) {
+      ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
+      OptionalBase<T>::init_ = true;
+    }
+  }
+#endif
 
   // see https://github.com/akrzemi1/Optional/issues/16
   // and https://en.cppreference.com/w/cpp/utility/optional/optional,


### PR DESCRIPTION
explicitly define move constructor when using cuda version <= 9200

this fixes https://github.com/pytorch/csprng/issues/84