### PR TITLE
[FX][EZ] Add Node.all_input_nodes

### DIFF
--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -136,6 +136,18 @@ class Node:
         """
         self._update_args_kwargs(self._args, map_arg(k, lambda x: x))  # type: ignore
 
+    @property
+    def all_input_nodes(self) -> List['Node']:
+        """
+        Return all Nodes that are inputs to this Node. This is equivalent to
+        iterating over `args` and `kwargs` and only collecting the values that
+        are Nodes
+        """
+        all_nodes : List['Node'] = []
+        map_arg(self.args, lambda n: all_nodes.append(n))
+        map_arg(self.kwargs, lambda n: all_nodes.append(n))
+        return all_nodes
+
     def _update_args_kwargs(self, new_args : Tuple[Argument, ...], new_kwargs : Dict[str, Argument]):
         self._args = new_args
         self._kwargs = new_kwargs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48270 [FX] Add Node.all_input_nodes**

Seems the discoverability of the pattern of using `map_arg` to pull out the input nodes from `args` and `kwargs` wasn't very good, and people were doing hacks (e.g. inverting the `users` relations) to get input `Nodes` per `Node`. This adds `Node.all_input_nodes`, which just directly returns all the `Node` inputs.

Differential Revision: [D25100241](https://our.internmc.facebook.com/intern/diff/D25100241)