### PR TITLE
caffe2/core.Net: is_external_input rebuild lookup tables when necessary

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -2343,6 +2343,9 @@ class Net(object):
         )
 
     def is_external_input(self, blob):
+        if self._recreate_lookup_tables:
+            self._RecreateLookupTables()
+
         name = str(blob)
         return name in self._external_input_map
 


### PR DESCRIPTION
Summary: is_external_input doesn't check if the lookup tables are valid. Calling .Proto() should invalidate all lookup tables and have them rebuilt on call to any methods depending on them. This adds this check to is_external_input.

Test Plan: internal unit tests

Differential Revision: D25100464

