### PR TITLE
Move CUDA kernel check to c10

### DIFF
--- a/aten/src/ATen/cuda/Exceptions.h
+++ b/aten/src/ATen/cuda/Exceptions.h
@@ -79,11 +79,6 @@ const char *cusparseGetErrorString(cusparseStatus_t status);
 
 #define AT_CUDA_CHECK(EXPR) C10_CUDA_CHECK(EXPR)
 
-// This should be used directly after every kernel launch to ensure
-// the launch happened correctly and provide an early, close-to-source
-// diagnostic if it didn't.
-#define TORCH_CUDA_KERNEL_LAUNCH_CHECK() AT_CUDA_CHECK(cudaGetLastError())
-
 // For CUDA Driver API
 //
 // This is here instead of in c10 because NVRTC is loaded dynamically via a stub

--- a/c10/cuda/CUDAException.h
+++ b/c10/cuda/CUDAException.h
@@ -29,3 +29,8 @@
       TORCH_WARN("CUDA warning: ", cudaGetErrorString(__err)); \
     }                                                          \
   } while (0)
+
+// This should be used directly after every kernel launch to ensure
+// the launch happened correctly and provide an early, close-to-source
+// diagnostic if it didn't.
+#define TORCH_CUDA_KERNEL_LAUNCH_CHECK() C10_CUDA_CHECK(cudaGetLastError())

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -8103,6 +8103,7 @@ C10_MAPPINGS = collections.OrderedDict(
         ("setCurrentCUDAStream", ("setCurrentHIPStream", API_C10)),
         ("cuda::CUDACachingAllocator", ("hip::HIPCachingAllocator", API_C10)),
         ("CUDACachingAllocator", ("HIPCachingAllocator", API_C10)),
+        ("TORCH_CUDA_KERNEL_LAUNCH_CHECK", ("TORCH_HIP_KERNEL_LAUNCH_CHECK", API_C10))
     ]
 )
 


### PR DESCRIPTION
Summary:
We move `TORCH_CUDA_KERNEL_LAUNCH_CHECK` from `//caffe2/aten/src/ATen/cuda/Exceptions.h` to `//caffe2/c10/cuda/CUDAException.h`.

The primary reason is for allowing us to use this MACRO in other subdirectories of //caffe2, not just in ATen. Refer to D24309971 (https://github.com/pytorch/pytorch/commit/353e7f940f548e0a0cb3b420b4190b4624ae9b41) for context.

An example of this use case is D24868557, where we add these checks to `//caffe2/caffe2/sgd`.

Also, this should not affect current files, because `Exceptions.h` includes `CUDAException.h`.

Test Plan:
```
buck build //caffe2/aten:ATen-cu
```
- https://fburl.com/buck/oq3rxbir

Also wait for sandcastle tests.

Reviewed By: ngimel

Differential Revision: D25101720

