### PR TITLE
Explicitly cast an implicit conversion from some macro defined type to a double

### DIFF
--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -172,7 +172,7 @@ std::string show_config() {
   }
 
   ss << "  - Build settings: ";
-  for (const std::pair<std::string, std::string>& pair : caffe2::GetBuildOptions()) {
+  for (const auto& pair : caffe2::GetBuildOptions()) {
     if (!pair.second.empty()) {
       ss << pair.first << "=" << pair.second << ", ";
     }

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -308,7 +308,7 @@ static void min_values_kernel_impl(TensorIterator& iter) {
       iter,
       [](scalar_t a, scalar_t b) -> scalar_t { return min_impl(a, b); },
       [](Vec256<scalar_t> a, Vec256<scalar_t> b) { return minimum(a, b); },
-      upper_bound<scalar_t>());
+      static_cast<double>(upper_bound<scalar_t>()));
   });
 }
 

--- a/caffe2/opt/mobile.cc
+++ b/caffe2/opt/mobile.cc
@@ -99,7 +99,7 @@ void fuseNNPACKConvRelu(repr::NNModule* nn) {
       return false;
     }
     caffe2::string algo = "AUTO";
-    for (const auto arg : op.arg()) {
+    for (const auto &arg : op.arg()) {
       if (arg.name() == "algo") {
         algo = arg.s();
       }


### PR DESCRIPTION
Summary:
`scalar_t` here is expanded from nested macros to be an input value and
`upper_bound` is templated upon it. Whatever it gives back is unconditionally
cast to a `double` via the fact that it is always passed to
`binary_kernel_reduce_vec` which has a `double` as the fourth argument.

Change it here to be an explicit `static_cast<double>` to do what the compiler
was implicitly doing.

Test Plan: this is an error with -Werror in llvm11. This allows it to build

Differential Revision: D25111258

