### PR TITLE
[Release/1.7.1] Add max supported SM for nvrtc-11.0

### DIFF
--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -89,6 +89,9 @@ static void getMajorMinor(
     max_dev_version = CudaVersion(7, 2);
   } else if (nvrtc_version.first <= 10) { // 10 supports 3-7.5
     max_dev_version = CudaVersion(7, 5);
+  } else if (nvrtc_version.first == 11 && nvrtc_version.second == 0) {
+    // 11.0 supports 3-8.0
+    max_dev_version = CudaVersion(8, 0);
   }
   if (dev_version > max_dev_version) {
     dev_version = max_dev_version;


### PR DESCRIPTION
Should fix the regression when nvrtc from CUDA-11.0 is used on the system with RTX3080

Addresses issue described in https://github.com/pytorch/pytorch/issues/47669#issuecomment-725073808

This is a cherry-pick of https://github.com/pytorch/pytorch/pull/48151 into release/1.7