### PR TITLE
[Release/1.7.1] Make setup.py Python 2 friendly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,8 @@
 #      When turned on, the following cmake variables will be toggled as well:
 #        USE_SYSTEM_CPUINFO=ON USE_SYSTEM_SLEEF=ON BUILD_CUSTOM_PROTOBUF=OFF
 
-
+# This future is needed to print Python2 EOL message
+from __future__ import print_function
 import sys
 if sys.version_info < (3,):
     print("Python 2 has reached end-of-life and is no longer supported by PyTorch.")
@@ -338,7 +339,6 @@ def build_deps():
 
 # the list of runtime dependencies required by this built package
 install_requires = [
-    'future',
     'typing_extensions',
     'dataclasses; python_version < "3.7"'
 ]


### PR DESCRIPTION
Summary:
import print_function to make setup.py invoked by Python2 print human readable error:
```
% python2 setup.py
Python 2 has reached end-of-life and is no longer supported by PyTorch.
```
Also, remove `future` from the list of the PyTorch package install dependencies

Cherry-pick of https://github.com/pytorch/pytorch/pull/46317 into release/1.7

