### PR TITLE
Disable old fuser internally

### DIFF
--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -1124,6 +1124,13 @@ struct GraphFuser {
   }
 
   void run() {
+    // TODO: old fuser is not maintained internally, somewhere it is being turned on
+    // inadvertently for certain workflows. make this a no-op until we identify
+    // location
+    #if defined(FBCODE_CAFFE2)
+        return;
+    #endif
+
     // Run the pass until no changes are made.
     // This is necessary, because the algorithm can miss out on certain fusion
     // opportunities if ran only once. Consider this graph:


### PR DESCRIPTION
Summary: Disable old fuser internally. I would like to find where we are inadvertently setting the old fuser, but in the meantime I would like to land a diff that I know will 100% cause it not to be run, and verify that it fixes the issue.

Test Plan: sandcastle

Differential Revision: D25126202

