### PR TITLE
[TensorExpr] Fix aten::atan2 lowering and disable aten::pow lowering on CPU.

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1307,16 +1307,14 @@ class TestTEFuser(JitTestCase):
             torch.min,
             torch.max,
             lambda x, y: torch.lerp(x, y, 0.5),
+            torch.atan2,
+
             # FIXME: comparison ops yield different results when fused
             # torch.eq,
             # torch.ne,
             # torch.ge,
             # torch.gt,
             # torch.lt,
-
-            # FIXME: these ops produce different results with int dtype
-            # torch.pow,
-            # torch.atan2,
 
             # TODO: test operators exercising division too
             # torch.fmod,
@@ -1347,7 +1345,7 @@ class TestTEFuser(JitTestCase):
                 )
 
     @unittest.skipIf(not LLVM_ENABLED, "TODO: bugs in ir eval")
-    def test_binary_ops_tensor_scalar(self):
+    def test_binary_tensor_scalar_ops(self):
         def apply_with_scalar(fn, scalar):
             return lambda x: fn(x, scalar)
 
@@ -1380,9 +1378,6 @@ class TestTEFuser(JitTestCase):
             # FIXME: fails with integer dtype and scalar={3,0}
             # torch.div,
 
-            # FIXME: fails with dtype=torch.float16/device=cuda/scalar=0
-            # torch.pow,
-
             # FIXME: segfaults on CPU backend
             # operator.__rshift__,
             # operator.__lshift__,
@@ -1392,6 +1387,48 @@ class TestTEFuser(JitTestCase):
             # torch.fmod,
         ]
         devices = self.devices
+        # Maybe we should split this into separate tests to speed it up by
+        # only using  scalar values relevant to particular ops
+        scalars = [1.5, 3, 0, -2.0, -1]
+        for dtype, op, device, scalar in product(dtypes, binary_ops, devices, scalars):
+            try:
+                x = self.data_for(dtype, device)
+                fn = apply_with_scalar(op, scalar)
+                ref = fn(x)
+            except Exception:
+                # If eager mode doesn't support a dtype/op/device combo,
+                # neither does the fuser.  Catch everything to avoid needing to
+                # guess what errors might be thrown by eager.
+                continue
+            try:
+                t = torch.jit.trace(fn, (x))
+                self.assertEqual(ref, t(x))
+                self.assertAllFused(t.graph_for(x))
+            except Exception as e:
+                raise RuntimeError(
+                    " ".join(["Failed:", str(dtype), op.__name__, device])
+                )
+
+    def test_binary_cuda_only_ops(self):
+        def apply_with_scalar(fn, scalar):
+            return lambda x: fn(x, scalar)
+
+        dtypes = [
+            torch.int8,
+            torch.uint8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            # FIXME: 'pow' fails with dtype=torch.float16/device=cuda/scalar=0
+            # torch.float16,
+            torch.float32,
+            torch.float64,
+            # torch.bool intentionally not included
+        ]
+        binary_ops = [
+            torch.pow,
+        ]
+        devices = ['cuda']
         # Maybe we should split this into separate tests to speed it up by
         # only using  scalar values relevant to particular ops
         scalars = [1.5, 3, 0, -2.0, -1]

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1428,7 +1428,7 @@ class TestTEFuser(JitTestCase):
         binary_ops = [
             torch.pow,
         ]
-        devices = ['cuda']
+        devices = ['cuda'] if torch.cuda.is_available() else []
         # Maybe we should split this into separate tests to speed it up by
         # only using  scalar values relevant to particular ops
         scalars = [1.5, 3, 0, -2.0, -1]

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -967,7 +967,7 @@ class TestTensorExprFuser(BaseTestClass):
         self.assertLastGraphAllFused()
 
     def test_double_intrinsics(self):
-        devices = ["cuda", "cpu"] if torch.cuda.is_available() else ["cpu"]
+        devices = ["cuda"] if torch.cuda.is_available() else []
 
         def do_pow(x):
             return torch.pow(x, 7)

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -967,6 +967,7 @@ class TestTensorExprFuser(BaseTestClass):
         self.assertLastGraphAllFused()
 
     def test_double_intrinsics(self):
+        # TODO: add "cpu" device once `pow` is supported there
         devices = ["cuda"] if torch.cuda.is_available() else []
 
         def do_pow(x):

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1147,7 +1147,8 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
     case aten::atan2: {
       return computeTwoOperand(
           "aten_atan2", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
-            return atan2(lhs, rhs);
+            return atan2(
+                promoteIntegerToFloat(lhs), promoteIntegerToFloat(rhs));
           });
     } break;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48355 [TensorExpr] Add a envvar to disable LLVM backend and use IR Eval instead.
* #48354 [TensorExpr] IREval: fix div for Half dtype.
* #48329 [TensorExpr] Fix lowering for aten::div.
* **#48326 [TensorExpr] Fix aten::atan2 lowering and disable aten::pow lowering on CPU.**

The PR introduces a set of 'cuda-only' ops into `isSupported` function.
It is done to disable `pow` lowering on CPU where it's tricky to support
integer versions.

Differential Revision: [D25129211](https://our.internmc.facebook.com/intern/diff/D25129211)