### PR TITLE
use sysconfig.BASE_PREFIX to search conda installed libs

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -212,7 +212,7 @@ class CMake:
         # Store build options that are directly stored in environment variables
         build_options = {
             # The default value cannot be easily obtained in CMakeLists.txt. We set it here.
-            'CMAKE_PREFIX_PATH': distutils.sysconfig.get_python_lib()
+            'CMAKE_PREFIX_PATH': distutils.sysconfig.BASE_PREFIX
         }
         # Build options that do not start with "BUILD_", "USE_", or "CMAKE_" and are directly controlled by env vars.
         # This is a dict that maps environment variables to the corresponding variable name in CMake.


### PR DESCRIPTION
Currently CMKAE_PREFIX_PATH is not searching for conda installed lib. Fixing it by moving the prefix path upper