### PR TITLE
[TensorExpr] Fix lowering for aten::div.

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1308,6 +1308,7 @@ class TestTEFuser(JitTestCase):
             torch.max,
             lambda x, y: torch.lerp(x, y, 0.5),
             torch.atan2,
+            torch.div,
 
             # FIXME: comparison ops yield different results when fused
             # torch.eq,
@@ -1316,12 +1317,13 @@ class TestTEFuser(JitTestCase):
             # torch.gt,
             # torch.lt,
 
-            # TODO: test operators exercising division too
+            # TODO: fails on CPU backend with int8
             # torch.fmod,
             # torch.remainder,
+
+            # FIXME: segfaults on CPU backend
             # operator.__rshift__,
             # operator.__lshift__,
-            # torch.div,
         ]
         devices = self.devices
         for dtype, op, device in product(dtypes, binary_ops, devices):
@@ -1358,7 +1360,7 @@ class TestTEFuser(JitTestCase):
             torch.float16,
             torch.float32,
             torch.float64,
-            # torch.bool intentionally not included
+            torch.bool
         ]
         binary_ops = [
             operator.__and__,
@@ -1369,14 +1371,12 @@ class TestTEFuser(JitTestCase):
             torch.mul,
             torch.eq,
             torch.ne,
+            torch.div,
 
             # FIXME: fails with dtype=uint8, scalar=-1
             # torch.ge,
             # torch.lt,
             # torch.gt,
-
-            # FIXME: fails with integer dtype and scalar={3,0}
-            # torch.div,
 
             # FIXME: segfaults on CPU backend
             # operator.__rshift__,

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1414,7 +1414,8 @@ class TestTEFuser(JitTestCase):
             torch.int16,
             torch.int32,
             torch.int64,
-            torch.float16,
+            # FIXME: breaks in IR eval
+            # torch.float16,
             torch.float32,
             torch.float64,
             torch.bool

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -780,7 +780,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
     case aten::div: {
       return computeTwoOperand(
           "aten_div", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
-            return boolToInteger(lhs) / boolToInteger(rhs);
+            return promoteIntegerToFloat(lhs) / promoteIntegerToFloat(rhs);
           });
     } break;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48355 [TensorExpr] Add a envvar to disable LLVM backend and use IR Eval instead.
* #48354 [TensorExpr] IREval: fix div for Half dtype.
* **#48329 [TensorExpr] Fix lowering for aten::div.**
* #48326 [TensorExpr] Fix aten::atan2 lowering and disable aten::pow lowering on CPU.

Differential Revision: [D25130750](https://our.internmc.facebook.com/intern/diff/D25130750)