### PR TITLE
quant: enable mypy on torch/quantization/fx

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -68,9 +68,6 @@ ignore_errors = True
 [mypy-torch.testing._internal.distributed.*]
 ignore_errors = True
 
-[mypy-torch.quantization.fx.*]
-ignore_errors = True
-
 [mypy-torch._tensor_str]
 ignore_errors = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -68,9 +68,6 @@ ignore_errors = True
 [mypy-torch.testing._internal.distributed.*]
 ignore_errors = True
 
-[mypy-torch.quantization.quantize_fx]
-ignore_errors = True
-
 [mypy-torch.quantization.fx.*]
 ignore_errors = True
 

--- a/torch/quantization/fx/fuse.py
+++ b/torch/quantization/fx/fuse.py
@@ -1,4 +1,6 @@
-from torch.fx import (
+from typing import Dict, Any
+
+from torch.fx import (  # type: ignore
     GraphModule,
     map_arg
 )
@@ -30,7 +32,7 @@ class Fuser:
         # find fusion
         fusion_pairs = self._find_matches(input_root, input_graph, fusion_patterns)
         self.fused_graph = Graph()
-        env = {}
+        env: Dict[Any, Any] = {}
 
         def load_arg(a):
             return map_arg(a, lambda node: env[node.name])

--- a/torch/quantization/fx/fusion_patterns.py
+++ b/torch/quantization/fx/fusion_patterns.py
@@ -71,7 +71,7 @@ class ConvBNReLUFusion():
         conv_parent_name, conv_name = _parent_name(self.conv_node.target)
         fuser_method = get_fuser_method(op_type_list, additional_fuser_method_mapping)
         if fuser_method is None:
-            raise NotImplementedError("Cannot fuse modules: {}".format(types))
+            raise NotImplementedError("Cannot fuse modules: {}".format(op_type_list))
         fused = fuser_method(*op_list)
         setattr(quantizer.modules[conv_parent_name], conv_name, fused)
 

--- a/torch/quantization/fx/observed_module.py
+++ b/torch/quantization/fx/observed_module.py
@@ -1,6 +1,6 @@
 import torch
 import copy
-from torch.fx import GraphModule
+from torch.fx import GraphModule  # type: ignore
 
 class ObservedGraphModule(GraphModule):
 

--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -396,7 +396,7 @@ class LinearReLUQuantizeHandler(QuantizeHandler):
                         'call_function', torch.ops.quantized.linear, qlinear_args, kwargs)
                 else:
                     linear_input = load_arg(quantized=False)(self.linear_node.args[0])
-                    qlinear_args = (linear_input, packed_weight)
+                    qlinear_args = (linear_input, packed_weight)  # type: ignore
                     return quantizer.quantized_graph.create_node(
                         'call_function', torch.ops.quantized.linear_dynamic, qlinear_args, kwargs)
 
@@ -669,7 +669,7 @@ class StandaloneModuleQuantizeHandler(QuantizeHandler):
     def convert(self, quantizer, node, load_arg, debug=False, convert_custom_config_dict=None):
         assert node.op == 'call_module'
         qconfig = quantizer.qconfig_map[node.name]
-        convert = torch.quantization.quantize_fx._convert_standalone_module_fx
+        convert = torch.quantization.quantize_fx._convert_standalone_module_fx  # type: ignore
         observed_standalone_module = quantizer.modules[node.target]
         quantized_standalone_module = convert(observed_standalone_module, debug=debug)
         parent_name, name = _parent_name(node.target)

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -1,5 +1,5 @@
 import torch
-from torch.fx import (
+from torch.fx import (  # type: ignore
     GraphModule,
     Proxy,
     map_arg
@@ -56,7 +56,7 @@ from collections import OrderedDict
 import warnings
 import re
 
-from typing import Optional
+from typing import Optional, Dict, Any, List
 
 # ------------------------
 # Helper Functions
@@ -119,7 +119,7 @@ def graph_module_from_producer_nodes(root, producer_nodes):
     # since we traced back from node to getattrr
     producer_nodes.reverse()
     graph = Graph()
-    env = {}
+    env: Dict[Any, Any] = {}
 
     def load_arg(a):
         return map_arg(a, lambda node: env[node])
@@ -212,10 +212,10 @@ class Quantizer:
     def __init__(self):
         # mapping from matched node to activation_post_process
         # must be filled before convert
-        self.activation_post_process_map = None
+        self.activation_post_process_map: Optional[Dict[Any, Any]] = None
         # mapping from node name to qconfig that should be used for that node
         # filled out for a model during _generate_qconfig_map
-        self.qconfig_map = None
+        self.qconfig_map: Optional[Dict[Any, Any]] = None
         # mapping from fully qualified module name to module instance
         # for example,
         # {
@@ -223,7 +223,7 @@ class Quantizer:
         #   'linear': Linear(...),
         #   'linear.weight_fake_quant': PerChannelMinMaxObserver(...),
         # }
-        self.modules = None
+        self.modules: Optional[Dict[Any, Any]] = None
         # mapping from a tuple of nodes in reverse order to uninitialized
         #   QuantizeHandler subclass. For example,
         # {
@@ -278,6 +278,7 @@ class Quantizer:
         # fallback to module_name_regex_qconfig, module_type_qconfig, global_qconfig
         # if necessary
         def get_qconfig(module_name):
+            assert self.modules is not None
             module_type_qconfig = \
                 get_module_type_qconfig(type(self.modules[module_name]))
             module_name_regex_qconfig = \
@@ -311,6 +312,7 @@ class Quantizer:
                 # regex is not supported eager mode propagate_qconfig_, we'll need to
                 # set the qconfig explicitly here in case regex
                 # is used
+                assert self.modules is not None
                 self.modules[node.target].qconfig = module_qconfig
                 self.qconfig_map[node.name] = module_qconfig
 
@@ -360,7 +362,7 @@ class Quantizer:
         quants = self._find_quants(model.graph, matches)
 
         self.activation_post_process_map = dict()
-        env = {}
+        env: Dict[Any, Any] = {}
         observed_graph = Graph()
         observed_node_names_set = set()
 
@@ -393,6 +395,7 @@ class Quantizer:
             observer_name = get_new_observer_name(model)
             setattr(model, observer_name, observer)
             # put observer instance activation_post_process map
+            assert self.activation_post_process_map is not None
             self.activation_post_process_map[node.name] = observer
             # insert observer call
             env[node.name] = observed_graph.create_node('call_module', observer_name, (load_arg(node),), {})
@@ -404,6 +407,7 @@ class Quantizer:
               to be observed by parent module
             """
             standalone_module_input_idxs = None
+            assert self.modules is not None
             if isinstance(quantize_handler, CustomModuleQuantizeHandler):
                 custom_module = self.modules[node.target]
                 custom_module_class_mapping = prepare_custom_config_dict.get("float_to_observed_custom_module_class", {})
@@ -416,7 +420,7 @@ class Quantizer:
             elif isinstance(quantize_handler, StandaloneModuleQuantizeHandler):
                 # observe standalone module
                 standalone_module = self.modules[node.target]
-                prepare = torch.quantization.quantize_fx._prepare_standalone_module_fx
+                prepare = torch.quantization.quantize_fx._prepare_standalone_module_fx  # type: ignore
                 observed_standalone_module = prepare(standalone_module, {"": qconfig})
                 observed_standalone_module.qconfig = qconfig
                 standalone_module_input_idxs = observed_standalone_module._standalone_module_observed_input_idxs
@@ -436,6 +440,7 @@ class Quantizer:
             """
             # don't need to insert observer for output if activation does not
             # need to be statically quantized
+            assert self.modules is not None
             if activation_is_statically_quantized(qconfig):
                 if isinstance(quantize_handler, FixedQParamsOpQuantizeHandler) and model.training:
                     # we only insert fake quantize module in qat
@@ -609,8 +614,8 @@ class Quantizer:
         quants = self._find_quants(model.graph, matches)
 
         self.quantized_graph = Graph()
-        env = {}
-        quant_env = {}
+        env: Dict[Any, Any] = {}
+        quant_env: Dict[Any, Any] = {}
 
         graph_inputs = []
         for node in model.graph.nodes:
@@ -694,6 +699,7 @@ class Quantizer:
 
         def is_output_quantized(node):
             """ Check if output node is quantized or not """
+            assert self.modules is not None
             if node.op == 'call_module' and is_observed_standalone_module(self.modules[node.target]):
                 quantized = self.modules[node.target]._output_is_observed
             else:
@@ -719,6 +725,7 @@ class Quantizer:
 
         def insert_quantize_node(node):
             """ Given a activation_post_process module call node, insert a quantize node"""
+            assert self.modules is not None
             observer_module = self.modules[node.target]
             prev_node = node.args[0]
             if observer_module.dtype == torch.float16:
@@ -781,11 +788,11 @@ class Quantizer:
         act_post_process_removed_graph = Graph()
         env = {}
 
-        def load_arg(a):
+        def load_arg_simple(a):
             return map_arg(a, lambda node: env[node.name])
         for node in self.quantized_graph.nodes:
             if node.op == 'output':
-                act_post_process_removed_graph.output(map_arg(node.args[0], load_arg))
+                act_post_process_removed_graph.output(map_arg(node.args[0], load_arg_simple))
                 continue
             if node.op == 'call_module' and \
                is_activation_post_process(self.modules[node.target]):
@@ -821,7 +828,7 @@ class Quantizer:
 
         # remove folded nodes and replace the prepacking node with getattr
         folded_graph = Graph()
-        env = {}
+        env: Dict[Any, Any] = {}
 
         def load_arg(a):
             return map_arg(a, lambda node: env[node.name])
@@ -887,7 +894,7 @@ class Quantizer:
         if standalone_module_names is None:
             standalone_module_names = []
 
-        match_map = {}
+        match_map: Dict[Any, Any] = {}
         all_matched = set()
 
         def record_match(pattern, node, matched):
@@ -900,11 +907,12 @@ class Quantizer:
             else:
                 matched.append(node)
 
+        assert self.qconfig_map is not None
         for node in reversed(graph.nodes):
             if node.name not in match_map and node.name not in all_matched:
                 for pattern, value in patterns.items():
                     if is_match(modules, node, pattern):
-                        matched = []
+                        matched: List[Any] = []
                         record_match(pattern, node, matched)
                         for n in matched:
                             match_map[n.name] = (node, matched, pattern, value(self, node), self.qconfig_map[n.name])
@@ -913,6 +921,7 @@ class Quantizer:
                         break
 
         # add custom module instances to the match result
+        assert self.modules is not None
         for node in graph.nodes:
             if node.op == 'call_module' and \
                type(self.modules[node.target]) in custom_module_classes:
@@ -921,6 +930,7 @@ class Quantizer:
                     node, [node], None, CustomModuleQuantizeHandler(self, node), custom_module_qconfig)
 
         def is_standalone_module(node_target):
+            assert self.modules is not None
             return node_target in standalone_module_names or \
                 type(self.modules[node_target]) in standalone_module_classes
 
@@ -949,14 +959,14 @@ class Quantizer:
          node_name -> (QuantizeHandler instance (always DefaultQuantizeHandler),
          activation_post_process (observer/fake_quantize module) constructor)
         """
-        quants = {}
+        quants: Dict[Any, Any] = {}
 
         def visit(node, matched_pattern, qconfig):
             def visit_arg(arg):
                 is_weight = False
                 if isinstance(node, Node) and node.op == 'call_function' and node.target in WEIGHT_INDEX_DICT:
                     for i, node_arg in enumerate(node.args):
-                        if arg is node_arg and i in WEIGHT_INDEX_DICT[node.target]:
+                        if arg is node_arg and i in WEIGHT_INDEX_DICT[node.target]:  # type: ignore
                             is_weight = True
                 if qconfig is not None and \
                    (activation_is_statically_quantized(qconfig) or is_weight):

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -788,11 +788,11 @@ class Quantizer:
         act_post_process_removed_graph = Graph()
         env = {}
 
-        def load_arg_simple(a):
+        def load_arg(a):  # type: ignore
             return map_arg(a, lambda node: env[node.name])
         for node in self.quantized_graph.nodes:
             if node.op == 'output':
-                act_post_process_removed_graph.output(map_arg(node.args[0], load_arg_simple))
+                act_post_process_removed_graph.output(map_arg(node.args[0], load_arg))
                 continue
             if node.op == 'call_module' and \
                is_activation_post_process(self.modules[node.target]):

--- a/torch/quantization/fx/utils.py
+++ b/torch/quantization/fx/utils.py
@@ -99,7 +99,7 @@ def get_quantize_op_and_qparams(activation_post_process):
         scale = float(scale)
         zero_point = int(zero_point)
         qparams = {'_scale_': scale, '_zero_point_': zero_point, '_dtype_': dtype}
-        quantize_op = torch.quantize_per_tensor
+        quantize_op = torch.quantize_per_tensor  # type: ignore
     return quantize_op, qparams
 
 def quantize_node(root_module, graph, node, activation_post_process):

--- a/torch/quantization/quantize_fx.py
+++ b/torch/quantization/quantize_fx.py
@@ -131,7 +131,7 @@ def fuse_fx(model, fuse_custom_config_dict=None):
     """
     torch._C._log_api_usage_once("quantization_api.quantize_fx.fuse_fx")
     assert not model.training, 'fuse_fx only works on models in eval mode'
-    graph_module = torch.fx.symbolic_trace(model)
+    graph_module = torch.fx.symbolic_trace(model)  # type: ignore
     return _fuse_fx(graph_module, fuse_custom_config_dict)
 
 def prepare_fx(model, qconfig_dict, prepare_custom_config_dict=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48357 quant: make each line of fx/quantize.py <=80 chars
* #48356 quant fx: fix typo
* #48350 quant: add type annotations on quantization.fx.Quantizer matches
* #48343 quant: add type annotations on quantization.fx.Quantizer class vars
* **#48331 quant: enable mypy on torch/quantization/fx**

Summary:

Enables mypy to not ignore type errors in FX quantization files.  Fixes the easy
typing errors inline, and comments out the harder errors to be fixed at a later time.
After this PR, mypy runs without errors on `torch/quantization`.

Test Plan:

```
> mypy torch/quantization/
Success: no issues found in 25 source files
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25133348](https://our.internmc.facebook.com/intern/diff/D25133348)