### PR TITLE
caffe2: refactor context to allow being typed

### DIFF
--- a/caffe2/python/checkpoint.py
+++ b/caffe2/python/checkpoint.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 
-@context.define_context()
-class Job(object):
+class Job(context.Managed):
     """
     A Job defines three TaskGroups: the `init_group`, the `epoch_group` and the
     `exit_group` which will be run by a JobRunner.
@@ -97,11 +96,13 @@ class Job(object):
         self.exit_group = session_class.compile(self.exit_group)
 
     def __enter__(self):
+        super(Job, self).__enter__()
         self.epoch_group.__enter__()
         return self
 
     def __exit__(self, *args):
         self.epoch_group.__exit__()
+        super(Job, self).__exit__(*args)
 
     def add_stop_condition(self, output):
         if isinstance(output, core.BlobReference):

--- a/caffe2/python/context.py
+++ b/caffe2/python/context.py
@@ -1,19 +1,15 @@
 ## @package context
 # Module caffe2.python.context
 
-
-
-
-
+import inspect
 import threading
 import six
 
 
 class _ContextInfo(object):
-    def __init__(self, cls, allow_default, arg_name):
+    def __init__(self, cls, allow_default):
         self.cls = cls
         self.allow_default = allow_default
-        self.arg_name = arg_name
         self._local_stack = threading.local()
 
     @property
@@ -43,14 +39,10 @@ class _ContextRegistry(object):
     def __init__(self):
         self._ctxs = {}
 
-    def register(self, ctx_info):
-        assert isinstance(ctx_info, _ContextInfo)
-        assert (ctx_info.cls not in self._ctxs), (
-            'Context %s already registered' % ctx_info.cls)
-        self._ctxs[ctx_info.cls] = ctx_info
-
     def get(self, cls):
-        assert cls in self._ctxs, 'Context %s not registered.' % cls
+        if cls not in self._ctxs:
+            assert issubclass(cls, Managed), "must be a context managed class, got {}".format(cls)
+            self._ctxs[cls] = _ContextInfo(cls, allow_default=issubclass(cls, DefaultManaged))
         return self._ctxs[cls]
 
 
@@ -62,62 +54,53 @@ def _context_registry():
     return _CONTEXT_REGISTRY
 
 
-def __enter__(self):
-    if self._prev_enter is not None:
-        self._prev_enter()
-    _context_registry().get(self._ctx_class).enter(self)
-    return self
+def _get_managed_classes(obj):
+    return [
+        cls for cls in inspect.getmro(obj.__class__)
+        if issubclass(cls, Managed) and cls != Managed and cls != DefaultManaged
+    ]
 
 
-def __exit__(self, *args):
-    _context_registry().get(self._ctx_class).exit(self)
-    if self._prev_exit is not None:
-        self._prev_exit(*args)
+
+class Managed(object):
+    """
+    Managed makes the inheritted class a context managed class.
+
+        class Foo(Managed): ...
+
+        with Foo() as f:
+            assert f == Foo.current()
+    """
+
+    @classmethod
+    def current(cls, value=None, required=True):
+        ctx_info = _context_registry().get(cls)
+        if value is not None:
+            assert isinstance(value, cls), (
+                'Wrong context type. Expected: %s, got %s.' % (cls, type(value)))
+            return value
+        return ctx_info.get_active(required=required)
+
+    def __enter__(self):
+        for cls in _get_managed_classes(self):
+            _context_registry().get(cls).enter(self)
+        return self
+
+    def __exit__(self, *args):
+        for cls in _get_managed_classes(self):
+            _context_registry().get(cls).exit(self)
+
+    def __call__(self, func):
+        @six.wraps(func)
+        def wrapper(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+        return wrapper
 
 
-def __call__(self, func):
-    @six.wraps(func)
-    def wrapper(*args, **kwargs):
-        with self:
-            return func(*args, **kwargs)
-    return wrapper
-
-
-@classmethod
-def _current(cls, value=None, required=True):
-    return _get_active_context(cls, value, required)
-
-
-class define_context(object):
-    def __init__(self, arg_name=None, allow_default=False):
-        self.arg_name = arg_name
-        self.allow_default = allow_default
-
-    def __call__(self, cls):
-        assert not hasattr(cls, '_ctx_class'), (
-            '%s parent class (%s) already defines context.' % (
-                cls, cls._ctx_class))
-        cls._ctx_class = cls
-
-        _context_registry().register(
-            _ContextInfo(cls, self.allow_default, self.arg_name)
-        )
-
-        cls._prev_enter = cls.__enter__ if hasattr(cls, '__enter__') else None
-        cls._prev_exit = cls.__exit__ if hasattr(cls, '__exit__') else None
-
-        cls.__enter__ = __enter__
-        cls.__exit__ = __exit__
-        cls.__call__ = __call__
-        cls.current = _current
-
-        return cls
-
-
-def _get_active_context(cls, val=None, required=True):
-    ctx_info = _context_registry().get(cls)
-    if val is not None:
-        assert isinstance(val, cls), (
-            'Wrong context type. Expected: %s, got %s.' % (cls, type(val)))
-        return val
-    return ctx_info.get_active(required=required)
+class DefaultManaged(Managed):
+    """
+    DefaultManaged is similar to Managed but if there is no parent when
+    current() is called it makes a new one.
+    """
+    pass

--- a/caffe2/python/context.pyi
+++ b/caffe2/python/context.pyi
@@ -1,0 +1,13 @@
+from typing import Optional, TypeVar, Type
+
+T = TypeVar('T')
+
+class Managed:
+    @classmethod
+    def current(cls: Type[T], value: Optional[T] = None, required: bool = True) -> T: ...
+
+    def __call__(self, func: T) -> T: ...
+
+    def __enter__(self: T) -> T: ...
+
+class DefaultManaged(Managed): ...

--- a/caffe2/python/layers/tags.py
+++ b/caffe2/python/layers/tags.py
@@ -10,8 +10,7 @@ import six
 from caffe2.python import context
 
 
-@context.define_context(allow_default=True)
-class TagContext(object):
+class TagContext(context.DefaultManaged):
     """
     Scope driven way to provide tags to the layers.
     """
@@ -61,7 +60,7 @@ class Tags(object):
     COMPONENT = 'component:'
     PIPELINE = 'pipeline:'
     """
-    Indicate it's a dense layer or dense param init, 
+    Indicate it's a dense layer or dense param init,
     but we use hogwild across multiple trainers
     """
     HOGWILD_DENSE = "hogwild_dense"

--- a/caffe2/python/net_builder.py
+++ b/caffe2/python/net_builder.py
@@ -10,8 +10,7 @@ from caffe2.python.task import Task, TaskGroup
 from caffe2.python.control_ops_util import add_if_op, add_while_op
 
 
-@context.define_context()
-class NetBuilder(object):
+class NetBuilder(context.Managed):
     """
     Scope-driven mechanism for building nets, loops and conditional blocks.
     Arguments:
@@ -138,6 +137,8 @@ class NetBuilder(object):
         return self._children
 
     def __exit__(self, etype, *args):
+        super(NetBuilder, self).__exit__(etype, *args)
+
         if self._use_control_ops and len(self._children) > 0:
             _children = self._children
             self._reset_children()

--- a/caffe2/python/normalizer_context.py
+++ b/caffe2/python/normalizer_context.py
@@ -10,8 +10,7 @@ from caffe2.python.modifier_context import (
     ModifierContext, UseModifierBase)
 
 
-@context.define_context(allow_default=True)
-class NormalizerContext(ModifierContext):
+class NormalizerContext(ModifierContext, context.DefaultManaged):
     """
     provide context to allow param_info to have different normalizers
     """

--- a/caffe2/python/optimizer_context.py
+++ b/caffe2/python/optimizer_context.py
@@ -13,8 +13,7 @@ from caffe2.python.modifier_context import (
 DEFAULT_OPTIM = 'DEFAULT'
 
 
-@context.define_context(allow_default=True)
-class OptimizerContext(ModifierContext):
+class OptimizerContext(ModifierContext, context.DefaultManaged):
     """
     provide context to allow param_info to have different optimizers
     """

--- a/caffe2/python/regularizer_context.py
+++ b/caffe2/python/regularizer_context.py
@@ -10,8 +10,7 @@ from caffe2.python.modifier_context import (
     ModifierContext, UseModifierBase)
 
 
-@context.define_context(allow_default=True)
-class RegularizerContext(ModifierContext):
+class RegularizerContext(ModifierContext, context.DefaultManaged):
     """
     provide context to allow param_info to have different regularizers
     """

--- a/caffe2/python/task.py
+++ b/caffe2/python/task.py
@@ -19,8 +19,7 @@ def _merge_node_kwargs(a, b):
     return c
 
 
-@context.define_context(allow_default=True)
-class Cluster(object):
+class Cluster(context.DefaultManaged):
     """
     Context that keeps track of all the node names used.
     Users shouldn't have to use them directly, since a Cluster is automatically
@@ -53,8 +52,7 @@ class Cluster(object):
             self.nodes(), self.node_kwargs())
 
 
-@context.define_context(allow_default=True)
-class Node(object):
+class Node(context.DefaultManaged):
     """
     A Node context is used to indicate that all Tasks instantiated within will
     run on the given node name. (Only the name of the node actually counts.)
@@ -158,8 +156,7 @@ def add_setup_steps(step, init_nets, exit_nets, name):
     return core.execution_step(name, steps)
 
 
-@context.define_context(allow_default=False)
-class TaskGroup(object):
+class TaskGroup(context.Managed):
     """
     Context that gathers tasks which will run concurrently, potentially on
     multiple nodes. All tasks in the same node will share the same workspace
@@ -440,8 +437,7 @@ class TaskOutputList(object):
         return "TaskOutputList(outputs={})".format(self.outputs)
 
 
-@context.define_context()
-class Task(object):
+class Task(context.Managed):
     """
     A Task is composed of an execution step and zero or more outputs.
     Tasks are executed in the context of a TaskGroup, which, in turn, can
@@ -540,6 +536,8 @@ class Task(object):
         self._num_instances = num_instances
 
     def __enter__(self):
+        super(Task, self).__enter__()
+
         # temporarily remove from _tasks_to_add to ensure correct order
         if self.group is not None:
             self.group._tasks_to_add.remove(self)
@@ -551,6 +549,8 @@ class Task(object):
         return self
 
     def __exit__(self, type, value, traceback):
+        super(Task, self).__exit__(type, value, traceback)
+
         self._net_builder.__exit__(type, value, traceback)
         if type is None:
             self.set_step(self._net_builder)


### PR DESCRIPTION
Summary:
This changes the context managed classes from using a decorator to define them to using inheritance. Inheritance allows the python static type checking to work correctly.

```
context.define_context()
class Bar(object): ...

context.define_context(allow_default=True)
class Foo(object): ...
```

becomes
```
class Foo(context.Managed): ...

class Bar(context.DefaultManaged): ...
```

Behavior differences:
* arg_name has been removed since it's not used anywhere
* classes need to call `super()` in `__enter__/__exit__` methods if they override (none do)

This also defines a context.pyi file to add types for python3.

Test Plan:
ci

  buck test //caffe2/caffe2/python:context_test

Differential Revision: D25133469

