### PR TITLE
quant: add type annotations on quantization.fx.Quantizer class vars

### DIFF
--- a/torch/quantization/fx/pattern_utils.py
+++ b/torch/quantization/fx/pattern_utils.py
@@ -1,6 +1,11 @@
 import torch
 import sys
 from collections import OrderedDict
+from typing import Dict, Any, Union, Tuple, Callable
+
+# TODO(future PR): fix the typing on QuantizeHandler (currently a circular dependency)
+QuantizeHandler = Any
+Pattern = Union[Callable, Tuple[Callable, Callable], Tuple[Callable, Callable, Callable]]
 
 # pattern for conv bn fusion
 DEFAULT_FUSION_PATTERNS = OrderedDict()
@@ -10,7 +15,7 @@ def register_fusion_pattern(pattern):
         return fn
     return insert
 
-def get_default_fusion_patterns():
+def get_default_fusion_patterns() -> Dict[Pattern, QuantizeHandler]:
     return DEFAULT_FUSION_PATTERNS
 
 DEFAULT_QUANTIZATION_PATTERNS = OrderedDict()
@@ -29,12 +34,12 @@ def register_quant_pattern(pattern, output_activation_post_process=None):
     return insert
 
 # Get patterns for both static quantization and qat
-def get_default_quant_patterns():
+def get_default_quant_patterns() -> Dict[Pattern, QuantizeHandler]:
     return DEFAULT_QUANTIZATION_PATTERNS
 
 # a map from pattern to output activation post process constructor
 # e.g. torch.sigmoid -> default_affine_fixed_qparam_fake_quant
-def get_default_output_activation_post_process_map():
+def get_default_output_activation_post_process_map() -> Dict[Pattern, torch.quantization.observer.ObserverBase]:
     return DEFAULT_OUTPUT_ACTIVATION_POST_PROCESS_MAP
 
 # a set of QuantizeHandler classes that are not observed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48357 quant: make each line of fx/quantize.py <=80 chars
* #48356 quant fx: fix typo
* #48350 quant: add type annotations on quantization.fx.Quantizer matches
* **#48343 quant: add type annotations on quantization.fx.Quantizer class vars**
* #48331 quant: enable mypy on torch/quantization/fx

Summary:

Annotates the 4 class variables on `Quantizer` with real types,
fixing the small things uncovered by this along the way.

Test Plan:

```
mypy torch/quantization/
python test/test_quantization.py TestQuantizeFx
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25136212](https://our.internmc.facebook.com/intern/diff/D25136212)