### PR TITLE
[Onnxifi] Warmup cache of output shapes

### DIFF
--- a/caffe2/opt/glow_net_transform.cc
+++ b/caffe2/opt/glow_net_transform.cc
@@ -108,12 +108,13 @@ void onnxifi(
     const std::vector<std::string>& output_names,
     const std::vector<std::string>& weight_names,
     const std::unordered_set<int>& blacklist,
-    const ShapeInfoMap& shape_hints,
+    const ShapeInfoMap& shape_hints_max_bs,
     bool use_onnx,
     size_t max_batch_size,
     size_t max_seq_size,
     bool load_model_by_blob,
-    bool predictor_net_ssa_rewritten) {
+    bool predictor_net_ssa_rewritten,
+    const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs) {
   // Split SparseLengthsSumSparse so that we can lower the SparseLengthsSum part
   splitSparseLengthsSumSparse(net, *ws);
 
@@ -143,8 +144,9 @@ void onnxifi(
   opts.merge_fp32_inputs_into_fp16 = FLAGS_merge_fp32_inputs_into_fp16;
   opts.predictor_net_ssa_rewritten = predictor_net_ssa_rewritten;
   opts.timeout = FLAGS_onnxifi_timeout_ms;
+  opts.shape_hints_per_bs = shape_hints_per_bs;
 
-  ShapeInfoMap more_shape_hints = shape_hints;
+  ShapeInfoMap more_shape_hints = shape_hints_max_bs;
   if (!FLAGS_onnxifi_shape_hints.empty()) {
     parseShapeInfoMapFromString(FLAGS_onnxifi_shape_hints, more_shape_hints);
   }

--- a/caffe2/opt/glow_net_transform.h
+++ b/caffe2/opt/glow_net_transform.h
@@ -26,12 +26,13 @@ void onnxifi(
     const std::vector<std::string>& output_names,
     const std::vector<std::string>& weight_names,
     const std::unordered_set<int>& blacklist,
-    const ShapeInfoMap& shape_hints,
+    const ShapeInfoMap& shape_hints_max_bs,
     bool use_onnx,
     size_t max_batch_size = 0,
     size_t max_seq_size = 0,
     bool load_model_by_blob = false,
-    bool predictor_net_ssa_rewritten = false);
+    bool predictor_net_ssa_rewritten = false,
+    const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs = {});
 
 std::unordered_set<int> ParseNetPositionList(const std::string& str);
 std::unordered_set<std::string> ParseBlackListOps(const std::string& str);

--- a/caffe2/opt/onnxifi_op.h
+++ b/caffe2/opt/onnxifi_op.h
@@ -19,7 +19,7 @@ namespace caffe2 {
 namespace details {
 
 /// Provides slicing info for the outputs. All the vector members should be of
-/// the same size as number of outpus of the Onnxifi op.
+/// the same size as number of outputs of the Onnxifi op.
 struct OutputReshapeInfo {
   std::vector<Tensor> begins;
   std::vector<Tensor> ends;
@@ -55,6 +55,7 @@ class OnnxifiOp final : public Operator<Context> {
         timeout_(this->template GetSingleArgument<int>("timeout", 0)),
         nominal_batch_idx_(
             this->template GetSingleArgument<int>("nominal_batch_idx", 0)),
+        use_passed_output_shapes_(this->template GetSingleArgument<int>("use_passed_output_shapes", 0)),
         adjust_quantized_offset_(this->template GetSingleArgument<int>(
             "adjust_quantized_offset",
             128)) {
@@ -86,7 +87,7 @@ class OnnxifiOp final : public Operator<Context> {
     all_offsets_.reserve(ws->Blobs().size());
     all_scales_.reserve(ws->Blobs().size());
     input_shapes_.resize(input_names_.size());
-    output_shapes_.resize(output_names_.size());
+    output_shapes_max_bs_.resize(output_names_.size());
     quantized_outputs_.resize(output_names_.size(), false);
     int output_idx = 0;
     ArgumentHelper helper(operator_def);
@@ -125,6 +126,30 @@ class OnnxifiOp final : public Operator<Context> {
     }
     if (!has_quantized_output) {
       adjust_quantized_offset_ = 0;
+    }
+
+    if (use_passed_output_shapes_) {
+      // Populate output_shapes_per_bs_
+      for (int bs = 1; bs < max_batch_size_; ++bs) {
+        auto output_shapes_tp = helper.GetRepeatedArgument<TensorProto>("output_shapes_bs_" + caffe2::to_string(bs));
+        auto output_qshapes_tp = helper.GetRepeatedArgument<TensorProto>("output_qshapes_bs_" + caffe2::to_string(bs));
+        CAFFE_ENFORCE_EQ(output_names_.size(), output_shapes_tp.size() + output_qshapes_tp.size());
+
+        std::unordered_map<std::string, details::TensorInfo> name_to_shape;
+        for (const auto& output_shape_tp : output_shapes_tp) {
+          name_to_shape.emplace(output_shape_tp.name(), details::TensorInfo{output_shape_tp});
+        }
+        for (const auto& output_qshape_tp : output_qshapes_tp) {
+          name_to_shape.emplace(output_qshape_tp.name(), details::TensorInfo{output_qshape_tp});
+        }
+
+        for (output_idx = 0; output_idx < output_names_.size(); ++output_idx) {
+          auto it = name_to_shape.find(output_names_[output_idx]);
+          output_shapes_per_bs_[bs].push_back({});
+          auto &output_shapes = output_shapes_per_bs_[bs].back();
+          std::copy(it->second.dims.cbegin(), it->second.dims.cend(), std::back_inserter(output_shapes));
+        }
+      }
     }
 
     // Get output resizing hints
@@ -333,6 +358,14 @@ class OnnxifiOp final : public Operator<Context> {
 #endif
   }
 
+  /// Helper method for extractOutputBatchSizes(), used to deduplicate code of populating output reshape infos
+  template <typename DimContainer>
+  void fillOutputReshapeInfo(
+      const DimContainer& real_shape,
+      c10::ArrayRef<uint64_t> max_shape,
+      details::OutputReshapeInfo &output_reshape_info,
+      int index);
+
   /// Extract output batch size. If the output batch size is going to be at
   /// max_batch_size_, return true indicating that no output shape adjustment is
   /// needed. Otherwise, return false.
@@ -418,7 +451,7 @@ class OnnxifiOp final : public Operator<Context> {
   int nominal_batch_idx_{0};
 
   // We bind the op input/output by position while ONNXIFI binds input/output by
-  // names. In addition, op input/output names can be writtten by, for example,
+  // names. In addition, op input/output names can be written by, for example,
   // memonger. We cache the original input/output name of ONNX object here and
   // bind them by position.
   std::vector<std::string> input_names_;
@@ -428,7 +461,10 @@ class OnnxifiOp final : public Operator<Context> {
   NetDef netdef_;
 
   std::vector<c10::SmallVector<uint64_t, 4>> input_shapes_;
-  std::vector<c10::SmallVector<uint64_t, 4>> output_shapes_;
+  std::vector<c10::SmallVector<uint64_t, 4>> output_shapes_max_bs_;
+
+  // Mapping of batch sizes to output shapes
+  std::unordered_map<int, std::vector<c10::SmallVector<uint64_t, 4>>> output_shapes_per_bs_;
 
   // Indicate if i-th output is a quantized tensor
   std::vector<bool> quantized_outputs_;
@@ -448,6 +484,9 @@ class OnnxifiOp final : public Operator<Context> {
   // input shape info. Used by shape inference when inputs are not at
   // max_batch_size
   std::unordered_map<std::string, ShapeInfo> input_shape_info_;
+
+  // Whether we should use passed output shape hints or do shape inference
+  bool use_passed_output_shapes_{false};
 
   // Whether we need to resize outputs or not
   bool adjust_output_batch_{false};

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -511,7 +511,8 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
     const std::unordered_set<std::string>& initialization_list,
     const std::vector<std::string>& external_inputs,
     const std::vector<std::string>& external_outputs,
-    const std::unordered_map<std::string, ShapeInfo>& shape_hints) {
+    const ShapeInfoMap& shape_hints_max_bs,
+    const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs) {
   OperatorDef op;
   op.set_type("Onnxifi");
   auto* onnx_model_arg = op.add_arg();
@@ -549,9 +550,9 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
   int nominal_batch_idx{0};
   for (const auto& input : external_inputs) {
     if (!initialization_list.count(input)) {
-      const auto it = shape_hints.find(input);
+      const auto it = shape_hints_max_bs.find(input);
       CAFFE_ENFORCE(
-          it != shape_hints.end(), "Input shape for ", input, " not found");
+          it != shape_hints_max_bs.end(), "Input shape for ", input, " not found");
       const auto& info = it->second;
       if (info.getDimType(0) == TensorBoundShape_DimType_BATCH &&
           getBlob1stDimSize(info) == max_batch_size) {
@@ -562,15 +563,15 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
     }
   }
 
-  // Add output size hints
+  // Add output size hints for max batch size
   auto* output_shape_info_arg = op.add_arg();
   output_shape_info_arg->set_name("output_shape_info");
   auto* output_qshape_info_arg = op.add_arg();
   output_qshape_info_arg->set_name("output_qshape_info");
   for (int i = 0; i < op.output_size(); ++i) {
     const auto& o = op.output(i);
-    const auto it = shape_hints.find(o);
-    if (it != shape_hints.end()) {
+    const auto it = shape_hints_max_bs.find(o);
+    if (it != shape_hints_max_bs.end()) {
       if (!it->second.is_quantized) {
         output_shape_info_arg->mutable_tensors()->Add()->CopyFrom(
             wrapShapeInfoIntoTensorProto(o, it->second));
@@ -579,6 +580,33 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
             wrapShapeInfoIntoQTensorProto(o, it->second));
       }
       VLOG(2) << "Adding output hint: " << o;
+    }
+  }
+
+  // Add output size hints for per batch size
+  AddArgument("use_passed_output_shapes", shape_hints_per_bs.empty() ? 0 : 1, &op);
+  if (!shape_hints_per_bs.empty()) {
+    for (int bs = 1; bs < opts_.bound_shape_spec.max_batch_size; ++bs) {
+      auto it = shape_hints_per_bs.find(bs);
+      CAFFE_ENFORCE(it != shape_hints_per_bs.end());
+      const auto& shape_hints_current_bs = it->second;
+
+      auto* output_shape_arg = op.add_arg();
+      output_shape_arg->set_name("output_shapes_bs_" + caffe2::to_string(bs));
+      auto* output_qshape_arg = op.add_arg();
+      output_qshape_arg->set_name("output_qshapes_bs_" + caffe2::to_string(bs));
+
+      for (int output_idx = 0; output_idx < op.output_size(); ++output_idx) {
+        const auto& output_name = op.output(output_idx);
+        auto it_output = shape_hints_current_bs.find(output_name);
+        if (it_output != shape_hints_current_bs.end()) {
+          if (!it_output->second.is_quantized) {
+            output_shape_arg->mutable_tensors()->Add()->CopyFrom(wrapShapeInfoIntoTensorProto(output_name, it_output->second));
+          } else {
+            output_shape_arg->mutable_qtensors()->Add()->CopyFrom(wrapShapeInfoIntoQTensorProto(output_name, it_output->second));
+          }
+        }
+      }
     }
   }
 
@@ -609,7 +637,8 @@ OperatorDef OnnxifiTransformer::buildOnnxifiOp(
 NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaC2(
     const caffe2::NetDef& net,
     const std::unordered_set<std::string>& weights_in_ws,
-    const ShapeInfoMap& shape_hints) {
+    const ShapeInfoMap& shape_hints_max_bs,
+    const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs) {
   int onnxifi_op_id = onnxifi_op_id_;
   if (opts_.debug) {
     WriteProtoToTextFile(
@@ -647,8 +676,8 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaC2(
                       op.type() == "SparseLengthsWeightedSumFused4BitRowwise")
           ? 1
           : 0;
-      const auto& indices_hint = shape_hints.at(op.input(1 + weighted));
-      const auto& lengths_hint = shape_hints.at(op.input(2 + weighted));
+      const auto& indices_hint = shape_hints_max_bs.at(op.input(1 + weighted));
+      const auto& lengths_hint = shape_hints_max_bs.at(op.input(2 + weighted));
       const auto& indices_shape = indices_hint.shape;
       const auto& lengths_shape = lengths_hint.shape;
       if ((indices_hint.getDimType(0) ==
@@ -689,13 +718,13 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaC2(
   onnxifi_net.clear_external_input();
   for (const auto& i : total_inputs_vec) {
     onnxifi_net.add_external_input(i);
-    auto info = shape_hints.at(i);
+    auto info = shape_hints_max_bs.at(i);
     if (!info.is_quantized) {
       shape_arg->mutable_tensors()->Add()->CopyFrom(
-          wrapShapeInfoIntoTensorProto(i, shape_hints.at(i)));
+          wrapShapeInfoIntoTensorProto(i, shape_hints_max_bs.at(i)));
     } else {
       qshape_arg->mutable_qtensors()->Add()->CopyFrom(
-          wrapShapeInfoIntoQTensorProto(i, shape_hints.at(i)));
+          wrapShapeInfoIntoQTensorProto(i, shape_hints_max_bs.at(i)));
     }
   }
 
@@ -724,7 +753,8 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaC2(
       initialization_list,
       onnxifi_net_inputs,
       onnxifi_net_outputs,
-      shape_hints);
+      shape_hints_max_bs,
+      shape_hints_per_bs);
   NetDef net_opt = composeResultNet(onnxifi_op);
 
   // Debugging stuff
@@ -746,7 +776,8 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaOnnx(
     const std::unordered_set<std::string>& weights_in_ws,
     Workspace* ws,
     onnx::OnnxExporter* exporter,
-    ShapeInfoMap* shape_hints) {
+    ShapeInfoMap* shape_hints_max_bs,
+    const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs) {
   if (opts_.min_ops > net.op_size()) {
     return net;
   }
@@ -770,7 +801,7 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaOnnx(
       TensorShape shape;
       shape.mutable_dims()->CopyFrom(t.dims());
       auto ret = shape_hints_onnx_.emplace(t.name(), std::move(shape));
-      shape_hints->emplace(
+      shape_hints_max_bs->emplace(
           std::piecewise_construct,
           std::forward_as_tuple(ret.first->first),
           std::forward_as_tuple(
@@ -845,7 +876,8 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaOnnx(
       initialization_list,
       onnxifi_net_inputs,
       onnxifi_net_outputs,
-      *shape_hints);
+      *shape_hints_max_bs,
+      shape_hints_per_bs);
   NetDef net_opt = composeResultNet(onnxifi_op);
 
   // Debugging stuff
@@ -1163,20 +1195,21 @@ NetDef OnnxifiTransformer::TransformViaC2(
     NetDef* pred_net,
     const std::unordered_set<std::string>& weights,
     const std::unordered_set<int>& blocklisted_ops,
-    const ShapeInfoMap& shape_hints) {
+    const ShapeInfoMap& shape_hints_max_bs,
+    const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs) {
   onnxBackendID backend_id = backend_ids_[idx_];
 
   auto c2_supports = [this,
-                      &shape_hints,
+                      &shape_hints_max_bs,
                       &blocklisted_ops,
                       backend_id,
                       &weights](const caffe2::OperatorDef& op) {
-    return supportOpC2(op, shape_hints, weights, blocklisted_ops, backend_id);
+    return supportOpC2(op, shape_hints_max_bs, weights, blocklisted_ops, backend_id);
   };
 
   auto c2_converter =
-      [this, &weights, &shape_hints](const caffe2::NetDef& net) {
-        return SubnetToOnnxifiOpViaC2(net, weights, shape_hints);
+      [this, &weights, &shape_hints_max_bs, &shape_hints_per_bs](const caffe2::NetDef& net) {
+        return SubnetToOnnxifiOpViaC2(net, weights, shape_hints_max_bs, shape_hints_per_bs);
       };
 
   return opt::OptimizeForBackend(
@@ -1188,7 +1221,8 @@ NetDef OnnxifiTransformer::TransformViaOnnx(
     NetDef* pred_net,
     const std::unordered_set<std::string>& weights,
     const std::unordered_set<int>& blocklisted_ops,
-    ShapeInfoMap* shape_hints) {
+    ShapeInfoMap* shape_hints_max_bs,
+    const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs) {
   onnxBackendID backend_id = backend_ids_[idx_];
 
   // function to tell whether the ONNXIFI backend supports a given C2 op or not
@@ -1202,9 +1236,9 @@ NetDef OnnxifiTransformer::TransformViaOnnx(
   // the same exporter throughout the process to avoid duplicated dummy name
   // generation
   onnx::OnnxExporter exporter2(nullptr);
-  auto onnx_converter = [this, ws, &weights, shape_hints, &exporter2](
+  auto onnx_converter = [this, ws, &weights, shape_hints_max_bs, &exporter2, &shape_hints_per_bs](
                             const caffe2::NetDef& net) mutable {
-    return SubnetToOnnxifiOpViaOnnx(net, weights, ws, &exporter2, shape_hints);
+    return SubnetToOnnxifiOpViaOnnx(net, weights, ws, &exporter2, shape_hints_max_bs, shape_hints_per_bs);
   };
 
   return opt::OptimizeForBackend(
@@ -1264,17 +1298,17 @@ void OnnxifiTransformer::transform(
   // blob for output is created. This causes problem if inferShape uses original
   // ws since it does not expect the output blob to be present.
   Workspace mapped_ws(ws, input_mapping_);
-  ShapeInfoMap shape_hints = inferShapes(
+  ShapeInfoMap shape_hints_max_bs = inferShapes(
       &mapped_ws, pred_net, shape_hints_mapped, opts_.bound_shape_spec);
   if (opts_.use_onnx) {
-    shape_hints_onnx_ = stripShapeInfoMap(shape_hints);
+    shape_hints_onnx_ = stripShapeInfoMap(shape_hints_max_bs);
   }
   if (opts_.enforce_fp32_inputs_into_fp16) {
-    enforceFp32InputsToFp16(weights, pred_net, &shape_hints);
+    enforceFp32InputsToFp16(weights, pred_net, &shape_hints_max_bs);
   }
   if (opts_.merge_fp32_inputs_into_fp16) {
     mergeFp32InputsAndConvertToFp16(
-        opts_.bound_shape_spec.max_batch_size, weights, pred_net, &shape_hints);
+        opts_.bound_shape_spec.max_batch_size, weights, pred_net, &shape_hints_max_bs);
   }
 
   if (opts_.debug) {
@@ -1285,7 +1319,7 @@ void OnnxifiTransformer::transform(
     for (const auto& w : weights) {
       w_arg->add_strings(w);
     }
-    dumpNet(ssa_net, shape_hints, "debug_ssa_net.pb_txt");
+    dumpNet(ssa_net, shape_hints_max_bs, "debug_ssa_net.pb_txt");
   }
   extractPartitionInfo(*pred_net);
 
@@ -1295,13 +1329,13 @@ void OnnxifiTransformer::transform(
   // Apply some filtering rules
   std::unordered_set<int> new_blocklisted_ops(
       blocklisted_ops.begin(), blocklisted_ops.end());
-  applyFilteringRules(*pred_net, shape_hints, weights, &new_blocklisted_ops);
+  applyFilteringRules(*pred_net, shape_hints_max_bs, weights, &new_blocklisted_ops);
 
   // Transform the net
   NetDef net_opt = opts_.use_onnx
       ? TransformViaOnnx(
-            ws, pred_net, weights, new_blocklisted_ops, &shape_hints)
-      : TransformViaC2(pred_net, weights, new_blocklisted_ops, shape_hints);
+            ws, pred_net, weights, new_blocklisted_ops, &shape_hints_max_bs, opts_.shape_hints_per_bs)
+      : TransformViaC2(pred_net, weights, new_blocklisted_ops, shape_hints_max_bs, opts_.shape_hints_per_bs);
 
   // Need to figure out a proper place to handle device option
   net_opt.mutable_device_option()->CopyFrom(pred_net->device_option());
@@ -1309,7 +1343,7 @@ void OnnxifiTransformer::transform(
 
   pred_net->Swap(&net_opt);
 
-  addShapeToNet(*pred_net, shape_hints);
+  addShapeToNet(*pred_net, shape_hints_max_bs);
   if (opts_.debug) {
     WriteProtoToTextFile(*pred_net, "debug_full_opt_net.pb_txt", false);
   }

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -44,6 +44,9 @@ struct OnnxifiTransformerOptions final : public BackendTransformOptions {
 
   // Inference timeout
   int timeout{0};
+
+  // Mapping of batch sizes to shape infos
+  std::unordered_map<int, ShapeInfoMap> shape_hints_per_bs;
 };
 
 class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
@@ -69,13 +72,15 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       const std::unordered_set<std::string>& weights_in_ws,
       Workspace* ws,
       onnx::OnnxExporter* exporter,
-      ShapeInfoMap* shape_hints);
+      ShapeInfoMap* shape_hints_max_bs,
+      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
 
   // Convert a cutoff subgraph net to an Onnxifi op
   caffe2::NetDef SubnetToOnnxifiOpViaC2(
       const caffe2::NetDef& net,
       const std::unordered_set<std::string>& weights_in_ws,
-      const ShapeInfoMap& shape_hints);
+      const ShapeInfoMap& shape_hints_max_bs,
+      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
 
   // We already have all the ops and external inputs and outputs!
   OperatorDef buildOnnxifiOp(
@@ -83,14 +88,16 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       const std::unordered_set<std::string>& initialization_list,
       const std::vector<std::string>& external_inputs,
       const std::vector<std::string>& external_outputs,
-      const std::unordered_map<std::string, ShapeInfo>& shape_hints);
+      const ShapeInfoMap& shape_hints_max_bs,
+      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
 
   // Transform by passing C2 proto to backend
   NetDef TransformViaC2(
       NetDef* pred_net,
       const std::unordered_set<std::string>& weights,
       const std::unordered_set<int>& blocklisted_ops,
-      const ShapeInfoMap& shape_hints);
+      const ShapeInfoMap& shape_hints_max_bs,
+      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
 
   // Transform by passing ONNX proto to backend
   NetDef TransformViaOnnx(
@@ -98,7 +105,8 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       NetDef* pred_net,
       const std::unordered_set<std::string>& weights,
       const std::unordered_set<int>& blocklisted_ops,
-      ShapeInfoMap* shape_hints);
+      ShapeInfoMap* shape_hints_max_bs,
+      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
 
   // Query whether an operator is supported by passing C2 protobuf
   bool supportOpC2(


### PR DESCRIPTION
Summary:
Onnxifi now accepts output shape info for all possible batch sizes. This is used to avoid doing shape inference inside `OnnxifiOp::extractOutputBatchSizes()`.

Differential Revision: D25047110

