### PR TITLE
Add CUDA kernel checks to fbcode/caffe2/caffe2/sgd

### DIFF
--- a/caffe2/sgd/adadelta_op_gpu.cu
+++ b/caffe2/sgd/adadelta_op_gpu.cu
@@ -47,6 +47,7 @@ void AdadeltaUpdate<CUDAContext>(
       CAFFE_CUDA_NUM_THREADS,
       0,
       context->cuda_stream()>>>(N, w, g, h, d, epsilon, decay, lr, nw, nh, nd);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 } // namespace
@@ -154,6 +155,7 @@ class CUDASparseAdadeltaOp final : public Operator<Context> {
             paramOut,
             momentOut,
             momentDeltaOut);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     return true;
   }
 

--- a/caffe2/sgd/adagrad_fused_op_gpu.cu
+++ b/caffe2/sgd/adagrad_fused_op_gpu.cu
@@ -638,6 +638,7 @@ class CUDASparseAdagradFusedWithSparseLengthsSumGradientOp final
              0,
              context_.cuda_stream()>>>(
               grad, lengths, grad_buffer_data, block_size);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     if (block_size <= maxThreads) {
@@ -660,6 +661,7 @@ class CUDASparseAdagradFusedWithSparseLengthsSumGradientOp final
           is_mean ? grad_buffer_data : grad,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       // calling cuda kernel with ExactBlock = false
       sparse_adagrad_fused_length_sum_gradient_kernel<
@@ -678,6 +680,7 @@ class CUDASparseAdagradFusedWithSparseLengthsSumGradientOp final
           is_mean ? grad_buffer_data : grad,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
     return true;
   }
@@ -819,6 +822,7 @@ class CUDASparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (block_size > 64) {
       sparse_adagrad_fused_length_weighted_sum_gradient_kernel<
           IndexType,
@@ -838,6 +842,7 @@ class CUDASparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (block_size > 32) {
       sparse_adagrad_fused_length_weighted_sum_gradient_kernel<
           IndexType,
@@ -857,6 +862,7 @@ class CUDASparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       sparse_adagrad_fused_length_weighted_sum_gradient_kernel<
           IndexType,
@@ -876,6 +882,7 @@ class CUDASparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
     return true;
   }
@@ -1005,6 +1012,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
              0,
              context_.cuda_stream()>>>(
               grad, lengths, grad_buffer_data, block_size);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     // 0: nearest rounding
@@ -1037,6 +1045,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
             lr,
             seed,
             weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         rowwise_sparse_adagrad_fused_length_sum_gradient_kernel<
             IndexType,
@@ -1056,6 +1065,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
             lr,
             seed,
             weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     } else {
       if (round_option_) {
@@ -1081,6 +1091,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
                 lr,
                 seed,
                 weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         rowwise_sparse_adagrad_fused_length_sum_gradient_kernel<
             IndexType,
@@ -1104,6 +1115,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientOp final
                 lr,
                 seed,
                 weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     }
     return true;
@@ -1241,6 +1253,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp final
              0,
              context_.cuda_stream()>>>(
               grad, lengths, grad_buffer_data, block_size);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     sorted_linear_ind_buffer_.ResizeLike(indicesInput);
@@ -1252,6 +1265,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp final
             indices,
             prefix_sum_length_data,
             seg_id_buffer_.template mutable_data<int>());
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 
     sort_pairs_wrapper<IndexType>(
         num_indices,
@@ -1316,6 +1330,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp final
                 lr,
                 seed,
                 weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         rowwise_sparse_adagrad_fused_length_sum_gradient_dedup_kernel<
             IndexType,
@@ -1342,6 +1357,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp final
                 lr,
                 seed,
                 weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     } else {
       const int sm_size = block_size * sizeof(float);
@@ -1376,6 +1392,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp final
                 lr,
                 seed,
                 weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
         rowwise_sparse_adagrad_fused_length_sum_gradient_dedup_kernel<
             IndexType,
@@ -1402,6 +1419,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp final
                 lr,
                 seed,
                 weight_decay_);
+        TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       }
     }
 
@@ -1551,6 +1569,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (block_size > 64) {
       rowwise_sparse_adagrad_fused_length_weighted_sum_gradient_kernel<
           IndexType,
@@ -1570,6 +1589,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (block_size > 32) {
       rowwise_sparse_adagrad_fused_length_weighted_sum_gradient_kernel<
           IndexType,
@@ -1589,6 +1609,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       rowwise_sparse_adagrad_fused_length_weighted_sum_gradient_kernel<
           IndexType,
@@ -1608,6 +1629,7 @@ class CUDARowWiseSparseAdagradFusedWithSparseLengthsWeightedSumGradientOp final
           out_weight_grads,
           lr,
           weight_decay_);
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
     return true;

--- a/caffe2/sgd/adagrad_op_gpu.cu
+++ b/caffe2/sgd/adagrad_op_gpu.cu
@@ -44,6 +44,7 @@ void adagrad_update<CUDAContext>(
       0,
       context->cuda_stream()>>>(
       N, w, g, h, nw, nh, epsilon, decay, lr, weight_decay);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename SIndex, typename THalf>
@@ -188,6 +189,7 @@ class CUDASparseAdagradOp final : public Operator<Context> {
             Input(GRAD).template data<float>(),
             Input(LR).template data<float>(),
             weight_decay_);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
     return true;
   }
 
@@ -231,6 +233,7 @@ bool RowWiseSparseAdagradOp<CUDAContext>::DoRunWithType() {
       Input(GRAD).template data<float>(),
       Input(LR).template data<float>(),
       weight_decay_);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   return true;
 }
 

--- a/caffe2/sgd/adam_op_gpu.cu
+++ b/caffe2/sgd/adam_op_gpu.cu
@@ -47,6 +47,7 @@ void adam_update<CUDAContext>(
       0,
       context->cuda_stream()>>>(
       N, g, m, v, ng, nm, nv, beta1, beta2, eps_hat, correction, lr);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 __global__ void AdamCompute(
@@ -94,6 +95,7 @@ void adam_compute<CUDAContext>(
       0,
       context->cuda_stream()>>>(
       N, w, g, m, v, nw, nm, nv, beta1, beta2, eps_hat, correction, lr);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 __global__ void AdamComputeOutputGrad(
@@ -143,6 +145,7 @@ void adam_compute_output_grad<CUDAContext>(
       0,
       context->cuda_stream()>>>(
       N, w, g, m, v, nw, nm, nv, ng, beta1, beta2, eps_hat, correction, lr);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename SIndex>
@@ -333,6 +336,7 @@ bool SparseAdamOp<float, CUDAContext>::DoRunWithType() {
             correction,
             Input(LR).template data<float>(),
             iter);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     Output(OUTPUT_GRAD)->ResizeLike(Input(GRAD));
     SparseAdamOutputGradKernel<SIndex>
@@ -354,6 +358,7 @@ bool SparseAdamOp<float, CUDAContext>::DoRunWithType() {
             correction,
             Input(LR).template data<float>(),
             iter);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   }
 
   return true;
@@ -398,6 +403,7 @@ bool RowWiseSparseAdamOp<float, CUDAContext>::DoRunWithType() {
             Input(GRAD).template data<float>(),
             correction,
             Input(LR).template data<float>());
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     Output(OUTPUT_GRAD)->ResizeLike(Input(GRAD));
     RowWiseSparseAdamOutputGradKernel<SIndex>
@@ -418,6 +424,7 @@ bool RowWiseSparseAdamOp<float, CUDAContext>::DoRunWithType() {
             Input(GRAD).template data<float>(),
             correction,
             Input(LR).template data<float>());
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   }
 
   return true;

--- a/caffe2/sgd/fp16_momentum_sgd_op.cu
+++ b/caffe2/sgd/fp16_momentum_sgd_op.cu
@@ -215,6 +215,7 @@ void fp16_momentum_sgd_update<CUDAContext>(
           nesterov,
           weight_decay,
           reinterpret_cast<half2*>(param));
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       // not setting N to N/2
     } else {
       FP16MomentumSGDFP32Kernel<<<
@@ -232,6 +233,7 @@ void fp16_momentum_sgd_update<CUDAContext>(
           nesterov,
           weight_decay,
           reinterpret_cast<half2*>(param));
+      TORCH_CUDA_KERNEL_LAUNCH_CHECK();
       // not setting N to N/2
     }
 

--- a/caffe2/sgd/fp32_momentum_sgd_op.cu
+++ b/caffe2/sgd/fp32_momentum_sgd_op.cu
@@ -108,6 +108,7 @@ void fp32_momentum_sgd_update<CUDAContext>(
       nesterov,
       weight_decay,
       reinterpret_cast<float2*>(param));
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   // not setting N to N/2
   // TODO_ check float performance vs float2
 }

--- a/caffe2/sgd/lars_op_gpu.cu
+++ b/caffe2/sgd/lars_op_gpu.cu
@@ -31,6 +31,7 @@ void LarsOp<float, CUDAContext>::ComputeLearningRate(
     float* lr_rescaled) {
   ComputeLearningRateKernel<<<1, 1, 0, context_.cuda_stream()>>>(
       wd, trust, lr_max, offset, lr_min, X_norm, dX_norm, lr_rescaled);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 REGISTER_CUDA_OPERATOR(Lars, LarsOp<float, CUDAContext>);

--- a/caffe2/sgd/momentum_sgd_op_gpu.cu
+++ b/caffe2/sgd/momentum_sgd_op_gpu.cu
@@ -82,12 +82,14 @@ void momentum_sgd_update<CUDAContext>(
            CAFFE_CUDA_NUM_THREADS,
            0,
            context->cuda_stream()>>>(N, g, m, ng, nm, lr, momentum, param);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     MomentumSGDKernel<false>
         <<<CaffeGetBlocksSGD(N),
            CAFFE_CUDA_NUM_THREADS,
            0,
            context->cuda_stream()>>>(N, g, m, ng, nm, lr, momentum, param);
+    TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
 
@@ -150,6 +152,7 @@ bool SparseMomentumSGDUpdateOp<float, CUDAContext>::DoRunWithType() {
         Input(GRAD).template data<float>(),
         Output(OUTPUT_GRAD)->template mutable_data<float>(),
         Input(LR).template data<float>());
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   return true;
 }
 

--- a/caffe2/sgd/rmsprop_op_gpu.cu
+++ b/caffe2/sgd/rmsprop_op_gpu.cu
@@ -43,6 +43,7 @@ void rmsprop_update<CUDAContext>(
     CUDAContext* context) {
   RmsPropUpdate<<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
       N, g, ms, mom, ng, nms, nmom, decay, momentum, epsilon, lr);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 

--- a/caffe2/sgd/yellowfin_op_gpu.cu
+++ b/caffe2/sgd/yellowfin_op_gpu.cu
@@ -32,6 +32,7 @@ void YellowFinOp<float, CUDAContext>::GetLrMu() {
   // Finding root of cubic formula for YF's Single Step
   GetLrMuKernel<<<1, 1, 0, context_.cuda_stream()>>>(
       g_norm2_max_deb_, g_norm2_min_deb_, distance_deb_, variance_, mu_, lr_);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
   MovingAverage(1, mu_, mu_avg_, mu_avg_out_, mu_deb_);
   MovingAverage(1, lr_, lr_avg_, lr_avg_out_, lr_deb_);
 }
@@ -78,6 +79,7 @@ void YellowFinOp<float, CUDAContext>::MomentumSgdUpdate() {
       param_out_,
       moment_out_,
       nesterov_);
+  TORCH_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 REGISTER_CUDA_OPERATOR(YellowFin, YellowFinOp<float, CUDAContext>);


### PR DESCRIPTION
Summary:
Add a safety check `TORCH_CUDA_KERNEL_LAUNCH_CHECK()` after each kernel launch. This only includes changes to `//caffe2/caffe2/sgd`. Specifically these files did not have any kernel launch checks before.

Files changed were determined by running `python3 caffe2/torch/testing/check_kernel_launches.py`.

Other directories will be done in seperate diffs.

Test Plan:
Check build status
```
buck build //caffe2/caffe2:caffe2_cu
```
- https://www.internalfb.com/intern/buck/build/5cb3185e-b481-4f83-9c3a-260827dde5ef

Running
```
python3 caffe2/torch/testing/check_kernel_launches.py
```
 results in no files within this subdirectory (as of now)
- P150434759

Differential Revision: D24868557

