### PR TITLE
Fix mypy error

### DIFF
--- a/torch/fx/experimental/fuser.py
+++ b/torch/fx/experimental/fuser.py
@@ -32,6 +32,7 @@ def matches_module_pattern(pattern: Iterable[Type], node: fx.Node, modules: Dict
 
 
 def replace_node_module(node: fx.Node, modules: Dict[str, Any], new_module: torch.nn.Module):
+    assert(isinstance(node.target, str))
     parent_name, name = _parent_name(node.target)
     setattr(modules[parent_name], name, new_module)
 


### PR DESCRIPTION
Fixes error introduced in https://github.com/pytorch/pytorch/pull/47657

`node.target` can be either a str or a callable, but this is checked in the pattern matching portion.