### PR TITLE
added docs to nn.rst

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -38,6 +38,17 @@ Containers
     ParameterList
     ParameterDict
 
+Global Hooks For Module
+
+.. currentmodule:: torch.nn.modules.module
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    register_module_forward_pre_hook
+    register_module_forward_hook
+    register_module_backward_hook
+
 .. currentmodule:: torch
 
 Convolution Layers


### PR DESCRIPTION
Fixes #{48198}
Added a subsection "Global Hooks For Module" to Containers section in nn.rst.
Added following functions to the subsection:
- register_module_forward_pre_hook
- register_module_forward_hook
- register_module_backward_hook

screenshots:
![image](https://user-images.githubusercontent.com/30429206/99902429-cb9a0880-2ce3-11eb-8249-b3e7a573eaaf.png)
![image](https://user-images.githubusercontent.com/30429206/99902470-11ef6780-2ce4-11eb-9f22-a98b5e577372.png)


