### PR TITLE
[docs] fix torch.swap{dim/axes} to showup in docs

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -99,6 +99,8 @@ Indexing, Slicing, Joining, Mutating Ops
     split
     squeeze
     stack
+    swapaxes
+    swapdims
     t
     take
     tensor_split


### PR DESCRIPTION
Fixes #48372 

Verified locally that it is generated
![Screenshot from 2020-11-22 20-38-15](https://user-images.githubusercontent.com/19503980/99907517-298a1880-2d03-11eb-9a8f-9809609c2d2d.png)
