### PR TITLE
[dper] supress excessive msg

### DIFF
--- a/caffe2/python/schema.py
+++ b/caffe2/python/schema.py
@@ -30,7 +30,6 @@ from itertools import islice
 from six import StringIO
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 FIELD_SEPARATOR = ':'
 


### PR DESCRIPTION
Summary:
On bento this is printing a lot of msgs like (see N408483 if you're an internal user)
```
W1123 120952.322 schema.py:811] Scalar should be considered immutable. Only call Scalar.set() on newly created Scalar with unsafe=True. This will become an error soon.
```
And it's ignoring the log level I set at global level. Removing this line unless this is super important.

Test Plan: build a local dper package and verify

Differential Revision: D25163808

