### PR TITLE
Fix AttributeError in _get_device_attr

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -437,7 +437,7 @@ def _get_available_device_type():
 
 def _get_device_attr(get_member):
     device_type = _get_available_device_type()
-    if device_type.lower() == "cuda":
+    if device_type and device_type.lower() == "cuda":
         return get_member(torch.cuda)
     # add more available device types here
     return None


### PR DESCRIPTION
In PyTorch 1.5, when running `torch.cuda.reset_peak_memory_stats()` on a machine where `torch.cuda.is_available() is False`, I would get:
```
AssertionError: 
Found no NVIDIA driver on your system. Please check that you
have an NVIDIA GPU and installed a driver from
http://www.nvidia.com/Download/index.aspx
```

In PyTorch 1.7, the same gets me a worse error (and a user warning about missing NVIDIA drivers if you look for it):
```
...
  File "/opt/conda/lib/python3.7/site-packages/torch/_utils.py", line 440, in _get_device_attr
    if device_type.lower() == "cuda":
AttributeError: 'NoneType' object has no attribute 'lower'
```

The formerly raised AssertionError is depended on by libraries like pytorch_memlab: https://github.com/Stonesjtu/pytorch_memlab/blob/ec9a72fc302981ddc3ee56d6e16694610d646c36/pytorch_memlab/line_profiler/line_profiler.py#L90
It would be pretty gross if pytorch_memlab had to change that to catch an AttributeError.

With this patch, we get a more sensible:
```
...
  File "/opt/conda/lib/python3.7/site-packages/torch/cuda/memory.py", line 209, in reset_peak_memory_stats
    return torch._C._cuda_resetPeakMemoryStats(device)
RuntimeError: invalid argument to reset_peak_memory_stats
```
