### PR TITLE
Add version_info tuple

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -24,7 +24,15 @@ def get_torch_version(sha=None):
             version += '.post' + str(build_number)
     elif sha != 'Unknown':
         version += '+' + sha[:7]
-    return version
+
+    first_non_numeric = min(i for i, c in enumerate(version) if c not in "0123456789.")
+    version_suffix = version[first_non_numeric:]
+    version_info = tuple(
+        [int(part) for part in version[:first_non_numeric].split(".")]
+        + version_suffix.split("+")
+    )
+
+    return version, version_info
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate torch/version.py from build and environment metadata.")
@@ -41,10 +49,11 @@ if __name__ == "__main__":
     pytorch_root = Path(__file__).parent.parent
     version_path = pytorch_root / "torch" / "version.py"
     sha = get_sha()
-    version = get_torch_version(sha)
+    version, version_info = get_torch_version(sha)
 
     with open(version_path, 'w') as f:
         f.write("__version__ = '{}'\n".format(version))
+        f.write("version_info = {}\n".format(version_info))
         # NB: This is not 100% accurate, because you could have built the
         # library code with DEBUG, but csrc without DEBUG (in which case
         # this would claim to be a release build when it's not.)


### PR DESCRIPTION
Add a `version_info` similar to `sys.version_info` for being able to make version tests. Example generated `version.py`:

```
__version__ = '1.8.0a0'
version_info = (1, 8, 0, 'a0')
# or version_info = (1, 8, 0, 'a0', 'deadbeef') if you're in a Git checkout
debug = False
cuda = None
git_version = '671ee71ad4b6f507218d1cad278a8e743780b716'
hip = None
```