### PR TITLE
Fix misleading doc string in quint8.h

### DIFF
--- a/c10/util/quint8.h
+++ b/c10/util/quint8.h
@@ -6,7 +6,7 @@
 namespace c10 {
 
 /**
- * qint8 is for signed 8 bit quantized Tensors
+ * quint8 is for unsigned 8 bit quantized Tensors
  */
 struct alignas(1) quint8 {
   using underlying = uint8_t;


### PR DESCRIPTION
The doc string let suppose that `quint8` is for singed 8 bit values.