### PR TITLE
Add masked_softmax to speed up masking in multihead attention

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3153,6 +3153,23 @@
     CPU: softmax_backward_cpu
     CUDA: softmax_backward_cuda
 
+- func: masked_softmax.int(Tensor self, Tensor mask, int dim, ScalarType? dtype=None) -> Tensor
+  use_c10_dispatcher: full
+  variants: function, method
+
+- func: masked_softmax.Dimname(Tensor self, Tensor mask, Dimname dim, *, ScalarType? dtype=None) -> Tensor
+  variants: function, method
+
+- func: _masked_softmax(Tensor self, Tensor mask, int dim, bool half_to_float) -> Tensor
+  use_c10_dispatcher: full
+  dispatch:
+    CPU: masked_softmax_cpu
+
+# - func: _masked_softmax_backward_data(Tensor grad_output, Tensor output, int dim, Tensor self, Tensor mask) -> Tensor
+#   use_c10_dispatcher: full
+#   dispatch:
+#     CPU: masked_softmax_backward_cpu
+
 - func: unsafe_split.Tensor(Tensor self, int split_size, int dim=0) -> Tensor[]
   use_c10_dispatcher: full
   variants: function, method

--- a/benchmarks/operator_benchmark/pt/masked_softmax_cpp_test.py
+++ b/benchmarks/operator_benchmark/pt/masked_softmax_cpp_test.py
@@ -1,0 +1,69 @@
+
+import operator_benchmark as op_bench
+import torch
+import torch.nn as nn
+
+
+"""
+Microbenchmarks for the masked_softmax operators.
+"""
+
+
+# Configs for masked_softmax ops
+masked_softmax_configs_short = op_bench.config_list(
+    attr_names=[
+        'N', 'C', 'H', 'W'
+    ],
+    attrs=[
+        [1, 3, 256, 256],
+        [4, 3, 256, 256],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+        'sparsity': [0., 0.01, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.92, 0.94, 0.96, 0.98, 0.99, 1],
+    },
+    tags=['short'],
+)
+
+
+masked_softmax_configs_long = op_bench.cross_product_configs(
+    N=[8, 16],
+    C=[3],
+    H=[256, 512],
+    W=[256, 512],
+    device=['cpu'],
+    tags=['long'],
+    sparsity=[0., 0.01, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.92, 0.94, 0.96, 0.98, 0.99, 1],
+)
+
+
+masked_softmax_ops_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['masked_softmax', lambda x, mask: x.masked_softmax(mask, dim=-1)],
+    ],
+)
+
+
+class MaskedSoftmaxCppBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, N, C, H, W, device, op_func, sparsity):
+        self.input_one = torch.rand(N, C, H, W, device=device)
+        self.input_two = torch.multinomial(
+            torch.Tensor([sparsity, 1. - sparsity]),
+            num_samples=self.input_one.numel(),
+            replacement=True,
+        ).view(self.input_one.shape).to(torch.bool)
+        self.op_func = op_func
+        self.set_module_name("masked_softmax_cpp")
+
+    def forward(self):
+        return self.op_func(self.input_one, self.input_two)
+
+
+op_bench.generate_pt_tests_from_op_list(masked_softmax_ops_list,
+                                        masked_softmax_configs_short + masked_softmax_configs_long,
+                                        MaskedSoftmaxCppBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/pt/masked_softmax_cpp_test.py
+++ b/benchmarks/operator_benchmark/pt/masked_softmax_cpp_test.py
@@ -1,7 +1,6 @@
 
 import operator_benchmark as op_bench
 import torch
-import torch.nn as nn
 
 
 """

--- a/benchmarks/operator_benchmark/pt/masked_softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/masked_softmax_test.py
@@ -1,0 +1,69 @@
+
+import operator_benchmark as op_bench
+import torch
+import torch.nn as nn
+
+
+"""
+Microbenchmarks for the masked_softmax operators.
+"""
+
+
+# Configs for masked_softmax ops
+masked_softmax_configs_short = op_bench.config_list(
+    attr_names=[
+        'N', 'C', 'H', 'W'
+    ],
+    attrs=[
+        [1, 3, 256, 256],
+        [4, 3, 256, 256],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+        'sparsity': [0., 0.01, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.92, 0.94, 0.96, 0.98, 0.99, 1],
+    },
+    tags=['short'],
+)
+
+
+masked_softmax_configs_long = op_bench.cross_product_configs(
+    N=[8, 16],
+    C=[3],
+    H=[256, 512],
+    W=[256, 512],
+    device=['cpu'],
+    tags=['long'],
+    sparsity=[0., 0.01, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.92, 0.94, 0.96, 0.98, 0.99, 1],
+)
+
+
+masked_softmax_ops_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['masked_softmax', nn.functional.masked_softmax],
+    ],
+)
+
+
+class MaskedSoftmaxBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, N, C, H, W, device, op_func, sparsity):
+        self.input_one = torch.rand(N, C, H, W, device=device)
+        self.input_two = torch.multinomial(
+            torch.Tensor([sparsity, 1. - sparsity]),
+            num_samples=self.input_one.numel(),
+            replacement=True,
+        ).view(self.input_one.shape)
+        self.op_func = op_func
+        self.set_module_name("masked_softmax")
+
+    def forward(self):
+        return self.op_func(self.input_one, self.input_two, dim=-1)
+
+
+op_bench.generate_pt_tests_from_op_list(masked_softmax_ops_list,
+                                        masked_softmax_configs_short + masked_softmax_configs_long,
+                                        MaskedSoftmaxBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/pt/multi_head_attention_forward_test.py
+++ b/benchmarks/operator_benchmark/pt/multi_head_attention_forward_test.py
@@ -1,0 +1,73 @@
+
+import operator_benchmark as op_bench
+import torch
+import torch.nn as nn
+
+
+"""
+Microbenchmarks for the masked_softmax operators on MHA.
+"""
+
+
+# Configs for masked_softmax ops
+mha_configs_short = op_bench.config_list(
+    attr_names=['L', 'N', 'E', 'S', 'num_heads', 'device'],
+    attrs=[
+        [256, 5, 16, 256, 4, 'cpu']
+    ],
+    tags=['short'],
+    cross_product_configs={
+        'sparsity': [0., 0.01, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.92, 0.94, 0.96, 0.98, 0.99, 1],
+    },
+)
+
+
+mha_configs_long = op_bench.cross_product_configs(
+    L=[256],
+    N=[5],
+    E=[16],
+    S=[256],
+    num_heads=[4],
+    device=['cpu'],
+    tags=['long'],
+    sparsity=[0., 0.01, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.92, 0.94, 0.96, 0.98, 0.99, 1],
+)
+
+
+mha_ops_list = op_bench.op_list(
+    attr_names=['op_name', 'op_func'],
+    attrs=[
+        ['multi_head_attention_forward', lambda x, q, k, v, attn_mask: x.forward(q, k, v, attn_mask=attn_mask)]
+    ],
+)
+
+
+class MHABenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, L, N, E, S, device, num_heads, op_func, sparsity):
+        self.query = torch.rand(L, N, E, device=device)
+        self.key = torch.rand(S, N, E, device=device)
+        self.value = torch.rand(S, N, E, device=device)
+
+        self.attn_mask = torch.multinomial(
+            torch.Tensor([sparsity, 1. - sparsity]),
+            num_samples=L*S,
+            replacement=True,
+        ).view(S, L).to(torch.bool)
+
+        self.mha = torch.nn.MultiheadAttention(embed_dim=E, num_heads=num_heads)
+
+        self.op_func = op_func
+        self.set_module_name("mha")
+
+    def forward(self):
+        with torch.no_grad():
+            return self.op_func(self.mha, self.query, self.key, self.value, attn_mask=self.attn_mask)
+
+
+op_bench.generate_pt_tests_from_op_list(mha_ops_list,
+                                        mha_configs_short + mha_configs_long,
+                                        MHABenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/pt/multi_head_attention_forward_test.py
+++ b/benchmarks/operator_benchmark/pt/multi_head_attention_forward_test.py
@@ -1,7 +1,6 @@
 
 import operator_benchmark as op_bench
 import torch
-import torch.nn as nn
 
 
 """
@@ -50,7 +49,7 @@ class MHABenchmark(op_bench.TorchBenchmarkBase):
 
         self.attn_mask = torch.multinomial(
             torch.Tensor([sparsity, 1. - sparsity]),
-            num_samples=L*S,
+            num_samples=L * S,
             replacement=True,
         ).view(S, L).to(torch.bool)
 


### PR DESCRIPTION
Implemented new `masked_softmax`, which extends `softmax` by allowing for an extra mask tensor argument. Equivalent to `inputs.masked_fill(mask, float('-inf'))` plus a `softmax`, thus, effectively, ignoring the masked entries.

Naive python implementation found at `torch/nn/functional.py`. Implemented a custom C++ kernel for CPU in `aten/src/ATen/native/SoftMax.cpp`. 

Provided tests at `test/test_nn.py` and benchmarks at `benchmarks/operator_benchmark/pt/` by adding the files `masked_softmax_test.py`, `masked_softmax_cpp_test.py`, and `multi_head_attention_forward_test.py`. 

Limitations: inputs must be float32. Mask must be bool or uint8 (cast to bool). Only CPU kernel.

Example usage: 
```python
inputs = torch.rand((2, 2), dtype=torch.float32)
mask = torch.tensor([[1, 1], [0, 1]], dtype=torch.bool)
outputs = torch.nn.functional.masked_softmax(inputs, mask, dim=-1)
```
or
```python
outputs = inputs.masked_softmax(mask, dim=-1)
```

Preliminary benchmarks show promise in speeding up the `forward` of `nn.MultiheadAttention` by replacing the `masked_fill`+ `softmax` with this new `masked_softmax`:

![image](https://user-images.githubusercontent.com/6855965/100193182-2a0fe400-2ea8-11eb-9fb6-c305e9ba7b8a.png)
The following parameters were used for `nn.MultiheadAttention` in the benchmark above: `L: 256, N: 5, E: 16, S: 256, num_heads: 4, device: cpu`.

TODO: backward computation; documentation.

