### PR TITLE
fix nvrtc PTX architecture cap for CUDA toolkit

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -247,43 +247,11 @@ NvrtcFunction nvrtcCompile(
   }
 
   const auto prop = at::cuda::getCurrentDeviceProperties();
-  int nvrtc_major, nvrtc_minor;
-  AT_CUDA_NVRTC_CHECK(
-      at::globalContext().getNVRTC().nvrtcVersion(&nvrtc_major, &nvrtc_minor));
 
-  // Short-circuits if NVRTC version too low
-  TORCH_INTERNAL_ASSERT(nvrtc_major >= 6);
-  // Major and minor is determined by device properties and
-  // possibly "downcompiled" to a lower (compatible) compute architecture
-  // based on the NVRTC version
-  int major = prop->major;
-  int minor = prop->minor;
+  int major, minor;
+  getMajorMinor(prop, major, minor);
+
   nvrtcProgram program;
-
-  if (nvrtc_major <= 7 && prop->major > 5) { // 7 supports 2-5.x
-    major = 5;
-    minor = 0;
-  } else if (nvrtc_major <= 8 && prop->major > 6) { // 8 supports 2-6.x
-    major = 6;
-    minor = 0;
-  } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
-    major = 7;
-    if (prop->major == 7 && prop->minor <= 2)
-      minor = prop->minor;
-    else
-      minor = 0;
-  } else if (nvrtc_major <= 10 && prop->major >= 7) { // 10 supports 3-7.5
-    major = 7;
-    if (prop->major == 7 && prop->minor <= 5)
-      minor = prop->minor;
-    else
-      minor = 0;
-  } else if (
-      nvrtc_major == 11 && nvrtc_minor == 0 &&
-      prop->major >= 8) { // 11.0 supports 3.5-8.0
-    major = 8;
-    minor = 0;
-  }
 
   {
     FUSER_PERF_SCOPE("nvrtcCreateProgram");

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_resource_strings.h>
+#include <torch/csrc/jit/codegen/fuser/cuda/fused_kernel.h>
 #include <torch/csrc/jit/resource_guard.h>
 
 #include <fstream>

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -260,12 +260,17 @@ NvrtcFunction nvrtcCompile(
   int minor = prop->minor;
   nvrtcProgram program;
 
-  if (nvrtc_major < 10 || (nvrtc_major == 10 && nvrtc_minor == 0)) { // clamp at sm_72 for CUDA < 10.1
+  if (nvrtc_major < 10 ||
+      (nvrtc_major == 10 &&
+       nvrtc_minor == 0)) { // clamp at sm_72 for CUDA < 10.1
     if (major > 7 || (major == 7 && minor > 2)) {
       major = 7;
       minor = 2;
     }
-  } else if (nvrtc_major < 11 || (nvrtc_major == 11 && nvrtc_minor == 0)) { // clamp at sm_75 for CUDA < 11.1
+  } else if (
+      nvrtc_major < 11 ||
+      (nvrtc_major == 11 &&
+       nvrtc_minor == 0)) { // clamp at sm_75 for CUDA < 11.1
     if (major > 7 || (major == 7 && minor > 5)) {
       major = 7;
       minor = 5;

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -249,10 +249,10 @@ NvrtcFunction nvrtcCompile(
 
   const auto prop = at::cuda::getCurrentDeviceProperties();
 
-  int major, minor;
+  int major = 0, minor = 0;
   getMajorMinor(prop, major, minor);
 
-  nvrtcProgram program;
+  nvrtcProgram program; // NOLINT(cppcoreguidelines-init-variables)
 
   {
     FUSER_PERF_SCOPE("nvrtcCreateProgram");

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -260,26 +260,29 @@ NvrtcFunction nvrtcCompile(
   int minor = prop->minor;
   nvrtcProgram program;
 
-  if (nvrtc_major < 10 ||
-      (nvrtc_major == 10 &&
-       nvrtc_minor == 0)) { // clamp at sm_72 for CUDA < 10.1
-    if (major > 7 || (major == 7 && minor > 2)) {
-      major = 7;
-      minor = 2;
-    }
-  } else if (
-      nvrtc_major < 11 ||
-      (nvrtc_major == 11 &&
-       nvrtc_minor == 0)) { // clamp at sm_75 for CUDA < 11.1
-    if (major > 7 || (major == 7 && minor > 5)) {
-      major = 7;
-      minor = 5;
-    }
-  } else if (nvrtc_major == 11 && nvrtc_minor == 1) {
-    if (major > 8 || (major == 8 && minor > 0)) {
-      major = 8;
+  if (nvrtc_major <= 7 && prop->major > 5) { // 7 supports 2-5.x
+    major = 5;
+    minor = 0;
+  } else if (nvrtc_major <= 8 && prop->major > 6) { // 8 supports 2-6.x
+    major = 6;
+    minor = 0;
+  } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
+    major = 7;
+    if (prop->major == 7 && prop->minor <= 2)
+      minor = prop->minor;
+    else
       minor = 0;
-    }
+  } else if (nvrtc_major <= 10 && prop->major >= 7) { // 10 supports 3-7.5
+    major = 7;
+    if (prop->major == 7 && prop->minor <= 5)
+      minor = prop->minor;
+    else
+      minor = 0;
+  } else if (
+      nvrtc_major == 11 && nvrtc_minor == 0 &&
+      prop->major >= 8) { // 11.0 supports 3.5-8.0
+    major = 8;
+    minor = 0;
   }
 
   {

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -256,9 +256,26 @@ NvrtcFunction nvrtcCompile(
   // Major and minor is determined by device properties and
   // possibly "downcompiled" to a lower (compatible) compute architecture
   // based on the NVRTC version
-  const int major = prop->major;
-  const int minor = prop->minor;
+  int major = prop->major;
+  int minor = prop->minor;
   nvrtcProgram program;
+
+  if (nvrtc_major < 10 || (nvrtc_major == 10 && nvrtc_minor == 0)) { // clamp at sm_72 for CUDA < 10.1
+    if (major > 7 || (major == 7 && minor > 2)) {
+      major = 7;
+      minor = 2;
+    }
+  } else if (nvrtc_major < 11 || (nvrtc_major == 11 && nvrtc_minor == 0)) { // clamp at sm_75 for CUDA < 11.1
+    if (major > 7 || (major == 7 && minor > 5)) {
+      major = 7;
+      minor = 5;
+    }
+  } else if (nvrtc_major == 11 && nvrtc_minor == 1) {
+    if (major > 8 || (major == 8 && minor > 0)) {
+      major = 8;
+      minor = 0;
+    }
+  }
 
   {
     FUSER_PERF_SCOPE("nvrtcCreateProgram");

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -61,6 +61,12 @@ static void getMajorMinor(
       minor = prop->minor;
     else
       minor = 0;
+  } else if (nvrtc_major == 11 && nvrtc_minor == 0 && prop->major >= 7) { // 11.0 supports 3.5-7.5
+    major = 7;
+    minor = 5;
+  } else if (nvrtc_major == 11 && nvrtc_minor == 1 && prop->major >= 8) { // 11.0 supports 3.5-7.5
+    major = 8;
+    minor = 0;
   }
 }
 

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -63,12 +63,7 @@ static void getMajorMinor(
       minor = 0;
   } else if (
       nvrtc_major == 11 && nvrtc_minor == 0 &&
-      prop->major >= 7) { // 11.0 supports 3.5-7.5
-    major = 7;
-    minor = 5;
-  } else if (
-      nvrtc_major == 11 && nvrtc_minor == 1 &&
-      prop->major >= 8) { // 11.0 supports 3.5-7.5
+      prop->major >= 8) { // 11.0 supports 3.5-8.0
     major = 8;
     minor = 0;
   }

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -29,7 +29,7 @@ const at::cuda::NVRTC& nvrtc() {
 }
 
 void getMajorMinor(const cudaDeviceProp* const prop, int& major, int& minor) {
-  int nvrtc_major, nvrtc_minor;
+  int nvrtc_major = 0, nvrtc_minor = 0;
   AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcVersion(&nvrtc_major, &nvrtc_minor));
 
   // Short-circuits if NVRTC version too low
@@ -48,13 +48,19 @@ void getMajorMinor(const cudaDeviceProp* const prop, int& major, int& minor) {
     minor = 0;
   } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
     major = 7;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     minor = (prop->major == 7 && prop->minor <= 2) ? prop->minor : 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_major <= 10 && prop->major >= 7) { // 10 supports 3-7.5
     major = 7;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     minor = (prop->major == 7 && prop->minor <= 5) ? prop->minor : 0;
   } else if (
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       nvrtc_major == 11 && nvrtc_minor == 0 &&
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       prop->major >= 8) { // 11.0 supports 3.5-8.0
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 8;
     minor = 0;
   }

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -61,10 +61,14 @@ static void getMajorMinor(
       minor = prop->minor;
     else
       minor = 0;
-  } else if (nvrtc_major == 11 && nvrtc_minor == 0 && prop->major >= 7) { // 11.0 supports 3.5-7.5
+  } else if (
+      nvrtc_major == 11 && nvrtc_minor == 0 &&
+      prop->major >= 7) { // 11.0 supports 3.5-7.5
     major = 7;
     minor = 5;
-  } else if (nvrtc_major == 11 && nvrtc_minor == 1 && prop->major >= 8) { // 11.0 supports 3.5-7.5
+  } else if (
+      nvrtc_major == 11 && nvrtc_minor == 1 &&
+      prop->major >= 8) { // 11.0 supports 3.5-7.5
     major = 8;
     minor = 0;
   }

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -28,10 +28,7 @@ const at::cuda::NVRTC& nvrtc() {
   return at::globalContext().getNVRTC();
 }
 
-static void getMajorMinor(
-    const cudaDeviceProp* const prop,
-    int& major,
-    int& minor) {
+void getMajorMinor(const cudaDeviceProp* const prop, int& major, int& minor) {
   int nvrtc_major, nvrtc_minor;
   AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcVersion(&nvrtc_major, &nvrtc_minor));
 
@@ -51,16 +48,10 @@ static void getMajorMinor(
     minor = 0;
   } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
     major = 7;
-    if (prop->major == 7 && prop->minor <= 2)
-      minor = prop->minor;
-    else
-      minor = 0;
+    minor = (prop->major == 7 && prop->minor <= 2) ? prop->minor : 0;
   } else if (nvrtc_major <= 10 && prop->major >= 7) { // 10 supports 3-7.5
     major = 7;
-    if (prop->major == 7 && prop->minor <= 5)
-      minor = prop->minor;
-    else
-      minor = 0;
+    minor = (prop->major == 7 && prop->minor <= 5) ? prop->minor : 0;
   } else if (
       nvrtc_major == 11 && nvrtc_minor == 0 &&
       prop->major >= 8) { // 11.0 supports 3.5-8.0

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.h
@@ -17,6 +17,11 @@ namespace jit {
 namespace fuser {
 namespace cuda {
 
+TORCH_CUDA_API void getMajorMinor(
+    const cudaDeviceProp* const prop,
+    int& major,
+    int& minor);
+
 // A class holding metadata for an actual CUDA function.
 // Note: CUDA functions are per device.
 struct TORCH_CUDA_API FusedKernelCUDA

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -86,9 +86,15 @@ static void getMajorMinor(
     max_dev_version = CudaVersion(5, 0);
   } else if (nvrtc_version.first <= 8) { // 8 supports 2-6.x
     max_dev_version = CudaVersion(6, 0);
-  } else if (nvrtc_version.first <= 9 || (nvrtc_version.first == 10 && nvrtc_version.second == 0)) { // 9 & 10.0 supports 3-7.2
+  } else if (
+      nvrtc_version.first <= 9 ||
+      (nvrtc_version.first == 10 &&
+       nvrtc_version.second == 0)) { // 9 & 10.0 supports 3-7.2
     max_dev_version = CudaVersion(7, 2);
-  } else if (nvrtc_version.first <= 10 || (nvrtc_version.first == 11 && nvrtc_version.second == 0)) { // 10.1-11.0 supports 3-7.5
+  } else if (
+      nvrtc_version.first <= 10 ||
+      (nvrtc_version.first == 11 &&
+       nvrtc_version.second == 0)) { // 10.1-11.0 supports 3-7.5
     max_dev_version = CudaVersion(7, 5);
   } else if (nvrtc_version.first == 11 && nvrtc_version.second == 1) {
     // 11.1 supports 3-8.0

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -86,18 +86,12 @@ static void getMajorMinor(
     max_dev_version = CudaVersion(5, 0);
   } else if (nvrtc_version.first <= 8) { // 8 supports 2-6.x
     max_dev_version = CudaVersion(6, 0);
-  } else if (
-      nvrtc_version.first <= 9 ||
-      (nvrtc_version.first == 10 &&
-       nvrtc_version.second == 0)) { // 9 & 10.0 supports 3-7.2
+  } else if (nvrtc_version.first <= 9) { // 9 supports 3-7.2
     max_dev_version = CudaVersion(7, 2);
-  } else if (
-      nvrtc_version.first <= 10 ||
-      (nvrtc_version.first == 11 &&
-       nvrtc_version.second == 0)) { // 10.1-11.0 supports 3-7.5
+  } else if (nvrtc_version.first <= 10) { // 10 supports 3-7.5
     max_dev_version = CudaVersion(7, 5);
-  } else if (nvrtc_version.first == 11 && nvrtc_version.second == 1) {
-    // 11.1 supports 3-8.0
+  } else if (nvrtc_version.first == 11 && nvrtc_version.second == 0) {
+    // 11.0 supports 3-8.0
     max_dev_version = CudaVersion(8, 0);
   }
   if (dev_version > max_dev_version) {

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -86,12 +86,12 @@ static void getMajorMinor(
     max_dev_version = CudaVersion(5, 0);
   } else if (nvrtc_version.first <= 8) { // 8 supports 2-6.x
     max_dev_version = CudaVersion(6, 0);
-  } else if (nvrtc_version.first <= 9) { // 9 supports 3-7.2
+  } else if (nvrtc_version.first <= 9 || (nvrtc_version.first == 10 && nvrtc_version.second == 0)) { // 9 & 10.0 supports 3-7.2
     max_dev_version = CudaVersion(7, 2);
-  } else if (nvrtc_version.first <= 10) { // 10 supports 3-7.5
+  } else if (nvrtc_version.first <= 10 || (nvrtc_version.first == 11 && nvrtc_version.second == 0)) { // 10.1-11.0 supports 3-7.5
     max_dev_version = CudaVersion(7, 5);
-  } else if (nvrtc_version.first == 11 && nvrtc_version.second == 0) {
-    // 11.0 supports 3-8.0
+  } else if (nvrtc_version.first == 11 && nvrtc_version.second == 1) {
+    // 11.1 supports 3-8.0
     max_dev_version = CudaVersion(8, 0);
   }
   if (dev_version > max_dev_version) {


### PR DESCRIPTION
Fixes #48200 

CUDA 11.0 only supports < sm_80 (https://docs.nvidia.com/cuda/archive/11.0/nvrtc/#group__options)

Note: NVRTC documentation is not a reliable source to query supported architecture. Rule of thumb is that nvrtc supports the same set of arch for nvcc, so the best way to query that is something like `nvcc -h | grep -o "compute_[0-9][0-9]" | sort | uniq`