### PR TITLE
Int8 FC fix to match NNPI ICE-REF step-C

### DIFF
--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -207,13 +207,6 @@ void QuantizeConvBias(
         bias.data<int32_t>(), bias.data<int32_t>() + bias.numel());
   } else {
     const float* bdata = bias.data<float>();
-    vector<float> bdata_local;
-    if (use_fp16) {
-      bdata_local.resize(bias.numel());
-      fbgemm::RoundToFloat16(
-              bdata, bdata_local.data(), bias.numel(), 1 /* FLAGS_caffe2_fbgemm_fake_fp16_clamp */);
-      bdata = bdata_local.data();
-    }
     b_quantized.resize(bias.numel());
     for (int g = 0; g < filter_qparams.size(); ++g) {
       int i_begin = g * (M / filter_qparams.size());


### PR DESCRIPTION
Summary: Bias should be kept it in FP32. There is no need to convert the bias to FP16.

Test Plan: https://internalfb.com/intern/testinfra/testrun/3096224783699571

Differential Revision: D25179863

