### PR TITLE
[doc] small typo

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -374,8 +374,8 @@ It shows the explicit need to synchronize when using collective outputs on diffe
         output.add_(100)
     if rank == 0:
         # if the explicit call to wait_stream was omitted, the output below will be
-        # non-deterministically 1 or 101, depending on whether the all_reduce overwrote
-        # the value after the add completed.
+        # non-deterministically 1 or 101, depending on whether all_reduce overwrote
+        # the value after add completed.
         print(output)
 
 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -374,7 +374,7 @@ It shows the explicit need to synchronize when using collective outputs on diffe
         output.add_(100)
     if rank == 0:
         # if the explicit call to wait_stream was omitted, the output below will be
-        # non-deterministically 1 or 101, depending on whether the allreduce overwrote
+        # non-deterministically 1 or 101, depending on whether the all_reduce overwrote
         # the value after the add completed.
         print(output)
 


### PR DESCRIPTION
This PR:

* s/allreduce/all_reduce/ in the comment to match the function in the example code.
* remove leading "the" as it's missing the counterpart "function", so simpler to just use the function name.

