### PR TITLE
Add jit.ignore in custom_lstms.py to bypass issue #25135

### DIFF
--- a/benchmarks/fastrnns/custom_lstms.py
+++ b/benchmarks/fastrnns/custom_lstms.py
@@ -86,6 +86,7 @@ def script_lnlstm(input_size, hidden_size, num_layers, bias=True,
 LSTMState = namedtuple('LSTMState', ['hx', 'cx'])
 
 
+@jit.ignore
 def reverse(lst):
     # type: (List[Tensor]) -> List[Tensor]
     return lst[::-1]


### PR DESCRIPTION
`custom_lstms.py` mentioned in https://pytorch.org/blog/optimizing-cuda-rnn-with-torchscript/ is a really nice example on how to use torchscript to speed up models. However, due to issue #25135, the following function could not be added to a ScriptModule:
```python
def reverse(lst):
    # type: (List[Tensor]) -> List[Tensor]
    return lst[::-1]
```
This PR adds a `@jit.ignore` on this function to make the code runnable again.

Thank you for your time on reviewing this PR.