### PR TITLE
reintroduce deadline removal

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -27,6 +27,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         rand_seed=st.integers(0, 65534),
         non_zero_offset=st.booleans()
     )
+    @settings(deadline=None)
     def test_int8_quantize(self, n, rand_seed, non_zero_offset):
         print("n={}, rand_seed={}".format(n, rand_seed))
         np.random.seed(rand_seed)
@@ -127,6 +128,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         rand_seed=st.integers(0, 65534),
         quantize_bias=st.sampled_from([False]),
     )
+    @settings(deadline=None)
     def test_int8_fc(
         self, n, m, k, rand_seed, quantize_bias, f
     ):
@@ -227,6 +229,7 @@ class Int8OpsTest(serial.SerializedTestCase):
         n=st.integers(1, 4),
         rand_seed=st.integers(0, 65534)
     )
+    @settings(deadline=None)
     def test_int8_small_input(self, n, rand_seed):
         print("n={}, rand_seed={}".format(n, rand_seed))
         np.random.seed(rand_seed)


### PR DESCRIPTION
Summary:
we removed deadlines thinking that was the cause for the timeout of
the int8 test, but turns out that the int8 tests were failing because of a
legitimate bug and this was masked as a timeout

Now that the bug has been fixed, the tests are failing because it takes more
than 10s to run the test, this is an option we used to override
https://www.internalfb.com/intern/testinfra/diagnostics/2533274833752501.562949971168104.1606367728/

Test Plan: reran the test manually

Differential Revision: D25184573

