### PR TITLE
Bugfix nightly checkout tool to work on Windows

### DIFF
--- a/tools/nightly.py
+++ b/tools/nightly.py
@@ -322,10 +322,10 @@ def pytorch_install(url):
 
 def _site_packages(dirname, platform):
     if platform.startswith("win"):
-        os.path.join(pytdir.name, "Lib", "site-packages")
+        template = os.path.join(dirname, "Lib", "site-packages")
     else:
         template = os.path.join(dirname, "lib", "python*.*", "site-packages")
-        spdir = glob.glob(template)[0]
+    spdir = glob.glob(template)[0]
     return spdir
 
 


### PR DESCRIPTION
Running ./tools/nightly.py checkout -b my-nightly-branch
throws this error:

NameError: name 'pytdir' is not defined

Fix the Windows code path in the _site_packages function to
make the nightly installer work on Windows under the Git Bash
shell.

Could not find an existing bug for this.
