### PR TITLE
Add a on_woker_init in Dataset

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -39,7 +39,7 @@ class Dataset(Generic[T_co]):
     # See NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]
     # in pytorch/torch/utils/data/sampler.py
 
-    def on_woker_init(self) -> None:
+    def on_worker_init(self) -> None:
         pass
 
     
@@ -227,9 +227,9 @@ class ConcatDataset(Dataset[T_co]):
                       "cumulative_sizes", DeprecationWarning, stacklevel=2)
         return self.cumulative_sizes
 
-    def on_woker_init(self) -> None:
+    def on_worker_init(self) -> None:
         for d in self.datasets:
-            d.on_woker_init()
+            d.on_worker_init()
 
 
 class ChainDataset(IterableDataset):
@@ -260,9 +260,9 @@ class ChainDataset(IterableDataset):
             total += len(d)  # type: ignore
         return total
 
-    def on_woker_init(self) -> None:
+    def on_worker_init(self) -> None:
         for d in self.datasets:
-            d.on_woker_init()
+            d.on_worker_init()
 
 
 class BufferedShuffleDataset(IterableDataset[T_co]):
@@ -321,8 +321,8 @@ class BufferedShuffleDataset(IterableDataset[T_co]):
         while buf:
             yield buf.pop()
 
-    def on_woker_init(self) -> None:
-        self.dataset.on_woker_init()
+    def on_worker_init(self) -> None:
+        self.dataset.on_worker_init()
 
 class Subset(Dataset[T_co]):
     r"""
@@ -345,8 +345,8 @@ class Subset(Dataset[T_co]):
     def __len__(self):
         return len(self.indices)
 
-    def on_woker_init(self) -> None:
-        self.dataset.on_woker_init()
+    def on_worker_init(self) -> None:
+        self.dataset.on_worker_init()
 
 
 def random_split(dataset: Dataset[T], lengths: Sequence[int],

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -39,7 +39,10 @@ class Dataset(Generic[T_co]):
     # See NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]
     # in pytorch/torch/utils/data/sampler.py
 
+    def on_woker_init(self) -> None:
+        pass
 
+    
 class IterableDataset(Dataset[T_co]):
     r"""An iterable Dataset.
 
@@ -224,6 +227,10 @@ class ConcatDataset(Dataset[T_co]):
                       "cumulative_sizes", DeprecationWarning, stacklevel=2)
         return self.cumulative_sizes
 
+    def on_woker_init(self) -> None:
+        for d in self.datasets:
+            d.on_woker_init()
+
 
 class ChainDataset(IterableDataset):
     r"""Dataset for chainning multiple :class:`IterableDataset` s.
@@ -252,6 +259,10 @@ class ChainDataset(IterableDataset):
             # Cannot verify that all self.datasets are Sized
             total += len(d)  # type: ignore
         return total
+
+    def on_woker_init(self) -> None:
+        for d in self.datasets:
+            d.on_woker_init()
 
 
 class BufferedShuffleDataset(IterableDataset[T_co]):
@@ -310,6 +321,8 @@ class BufferedShuffleDataset(IterableDataset[T_co]):
         while buf:
             yield buf.pop()
 
+    def on_woker_init(self) -> None:
+        self.dataset.on_woker_init()
 
 class Subset(Dataset[T_co]):
     r"""
@@ -331,6 +344,9 @@ class Subset(Dataset[T_co]):
 
     def __len__(self):
         return len(self.indices)
+
+    def on_woker_init(self) -> None:
+        self.dataset.on_woker_init()
 
 
 def random_split(dataset: Dataset[T], lengths: Sequence[int],


### PR DESCRIPTION
Oftentimes, I have a file open in my Dataset and since I want to use parallel loading, I use multiple workers. To avoid concurrent reading changing the file cursor in the middle of a read, I manage to re-open the file in each worker by using the `worker_init_fn` argument of DataLoader in this way:
```python
def worker_init_fn(worker_id):
    worker_info = get_worker_info()
    worker_info.dataset.reopen()
```
However, this become complicated when I want to use the Subset of this dataset, I have to modify the function this way:
```python
def worker_init_fn(worker_id):
    worker_info = get_worker_info()
    worker_info.dataset.dataset.reopen()
```
This can become more complicated if I want to do other things as well.

Thus, I propose to add a `on_woker_init` method to the Dataset class that would be called automatically by the DataLoader class or in this way:
```python
def worker_init_fn(worker_id):
    worker_info = get_worker_info()
    worker_info.dataset.on_woker_init()
```
This PR is not complete yet. It's just to give you an idea of what I have in mind. Let me know what you think and I can complete it if you agree.

Thank you.
