### PR TITLE
Implement JIT serialization of ProcessGroup

### DIFF
--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -17,6 +17,7 @@ fi
 
 python tools/download_mnist.py --quiet -d test/cpp/api/mnist
 OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="test/cpp/api/mnist" build/bin/test_api
+time python test/run_test.py --verbose -i distributed/test_jit_c10d
 time python test/run_test.py --verbose -i distributed/test_distributed_fork
 time python test/run_test.py --verbose -i distributed/test_c10d
 time python test/run_test.py --verbose -i distributed/test_c10d_spawn

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -204,6 +204,7 @@ def allow_listed(schema, allow_list):
 dont_parse_list = [
     ("_TorchScriptTesting.*", datetime.date(2099, 9, 17)),
     ("test_backend", datetime.date(2099, 9, 17)),
+    ("c10d.frontend", datetime.date(2020, 12, 30)),
 ]
 
 

--- a/test/distributed/test_jit_c10d.py
+++ b/test/distributed/test_jit_c10d.py
@@ -3,11 +3,13 @@ import tempfile
 from sys import platform
 import torch
 import torch.distributed as c10d
+import time
 from typing import List
 
 import torch.testing._internal.common_utils as common
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_rocm_single_process
-from torch.testing._internal.common_utils import TestCase, load_tests, TEST_WITH_TSAN
+from torch.testing._internal.common_utils import load_tests, TEST_WITH_TSAN, run_tests, IS_WINDOWS
+from torch.testing._internal.jit_utils import JitTestCase
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -17,17 +19,24 @@ if not c10d.is_available():
     print('c10d not available, skipping tests', file=sys.stderr)
     sys.exit(0)
 
-
 if platform == 'darwin':
     LOOPBACK = 'lo0'
 else:
     LOOPBACK = 'lo'
 
+def unique_process_group_name(prefix):
+    # Append timestamp to process group name to make it unique, so
+    # that when tests run multiple times or in parallel there
+    # wouldn't be name conflicts.
+    now = int(time.time() * 1000)
+    return "%s_%d" % (prefix, now)
+
 @unittest.skipIf(
     TEST_WITH_TSAN,
     "TSAN is not fork-safe since we're forking in a multi-threaded environment",
 )
-class ProcessGroupNCCLJitTest(TestCase):
+@unittest.skipIf(IS_WINDOWS, "TCPStore not available on Windows")
+class ProcessGroupNCCLJitTest(JitTestCase):
     MAIN_PROCESS_RANK = 0
 
     def setUp(self):
@@ -38,31 +47,33 @@ class ProcessGroupNCCLJitTest(TestCase):
         if self.num_gpus < 2:
             raise unittest.SkipTest("NCCL test requires 2+ GPUs")
 
-    def _create_nccl_pg(self):
+    def _create_nccl_pg(self, name_prefix):
         addr = "localhost"
         port = common.find_free_port()
         tcp_store = torch.classes.dist_c10d.TCPStore(addr, port, 1, True)
         opts = torch.classes.dist_c10d.ProcessGroupNCCLOptions(0, True)
 
-        return torch.classes.dist_c10d.ProcessGroupNCCL(tcp_store, self.rank, self.world_size, opts)  
+        name = unique_process_group_name(name_prefix)
 
-    def _create_nccl_pg_as_base_process_group(self):
+        return torch.classes.dist_c10d.ProcessGroupNCCL(tcp_store, self.rank, self.world_size, opts, name)  
+
+    def _create_nccl_pg_as_base_process_group(self, name):
         addr = "localhost"
         port = common.find_free_port()
         tcp_store = torch.classes.dist_c10d.TCPStore(addr, port, 1, True)
 
-        return torch.classes.c10d.frontend().newProcessGroupHelper(
-            self.world_size, self.rank, [], "NCCL", tcp_store, "test_process_group", 0)
+        return torch.classes.dist_c10d.frontend().new_process_group_helper(
+            self.world_size, self.rank, [], "nccl", tcp_store, name, 0)
 
     @requires_nccl()
     @skip_if_rocm_single_process
     def test_init_process_group_nccl_torchbind(self):
-        self._create_nccl_pg()
+        self._create_nccl_pg("raw_process_group_nccl_torchbind")
 
     @requires_nccl()
     @skip_if_rocm_single_process
     def test_process_group_nccl_torchbind_alltoall(self):
-        nccl_pg = self._create_nccl_pg()
+        nccl_pg = self._create_nccl_pg("process_group_nccl_as_base_class")
 
         input = torch.rand(16).cuda()
         output = torch.rand(16).cuda()
@@ -84,12 +95,14 @@ class ProcessGroupNCCLJitTest(TestCase):
     @requires_nccl()
     @skip_if_rocm_single_process
     def test_init_process_group_nccl_as_base_process_group_torchbind(self):
-        self._create_nccl_pg_as_base_process_group()
+        name = unique_process_group_name("creation_test_process_group")
+        self._create_nccl_pg_as_base_process_group(name)
 
     @requires_nccl()
     @skip_if_rocm_single_process
     def test_process_group_nccl_as_base_process_group_torchbind_alltoall(self):
-        nccl_pg = self._create_nccl_pg_as_base_process_group()
+        name = unique_process_group_name("alltoall_test_process_group")
+        nccl_pg = self._create_nccl_pg_as_base_process_group(name)
 
         input = torch.rand(16).cuda()
         output = torch.rand(16).cuda()
@@ -107,3 +120,82 @@ class ProcessGroupNCCLJitTest(TestCase):
             return work.result()
 
         run_pg_nccl_alltoall(nccl_pg, output, input)
+
+    @requires_nccl()
+    @skip_if_rocm_single_process
+    def test_process_group_nccl_serialization(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self, pg_nccl):
+                super(TestModule, self).__init__()
+                self.pg = pg_nccl
+
+            def forward(self, input: torch.Tensor):
+                if self.pg is None:
+                    return input + 1
+                else:
+                    return input + 2
+
+        pg_nccl = self._create_nccl_pg("nccl_process_group_as_module_member")
+        self.checkModule(TestModule(pg_nccl), (torch.rand((2, 3)),))
+
+
+@unittest.skipIf(IS_WINDOWS, "TCPStore not available on Windows")
+class C10dFrontendJitTest(JitTestCase):
+    def setUp(self):
+        self.rank = 0
+        self.world_size = 1
+        self.file = tempfile.NamedTemporaryFile(delete=False)
+        self.num_gpus = torch.cuda.device_count()
+        if self.num_gpus < 2:
+            raise unittest.SkipTest("NCCL test requires 2+ GPUs")
+
+    @requires_nccl()
+    @skip_if_rocm_single_process
+    def test_frontend_singleton(self):
+        frontend1 = torch.classes.dist_c10d.frontend()
+        frontend2 = torch.classes.dist_c10d.frontend()
+
+        addr = "localhost"
+        port = common.find_free_port()
+        tcp_store = torch.classes.dist_c10d.TCPStore(addr, port, 1, True)
+
+        pg_name = unique_process_group_name("singleton_test_process_group")
+
+        ProcessGroupNCCL1 = frontend1.new_process_group_helper(
+            self.world_size, self.rank, [], "nccl", tcp_store, pg_name, 0)
+
+        ProcessGroupNCCL2 = frontend2.get_process_group_by_name(pg_name)
+        self.assertEqual(frontend2.get_name_of_process_group(ProcessGroupNCCL2), pg_name)
+
+@unittest.skipIf(IS_WINDOWS, "TCPStore not available on Windows")
+class C10dProcessGroupSerialization(JitTestCase):
+    def setUp(self):
+        self.num_gpus = torch.cuda.device_count()
+        if self.num_gpus < 2:
+            raise unittest.SkipTest("NCCL test requires 2+ GPUs")
+
+    @requires_nccl()
+    @skip_if_rocm_single_process
+    def test_process_group_as_module_member(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+                addr = "localhost"
+                port = common.find_free_port()
+                tcp_store = torch.classes.dist_c10d.TCPStore(addr, port, 1, True)
+
+                name = unique_process_group_name("module_member_process_group")
+                self.pg = torch.classes.dist_c10d.frontend().new_process_group_helper(
+                    1, 0, [], "nccl", tcp_store, name, 0)
+
+            def forward(self, input: torch.Tensor):
+                if self.pg is None:
+                    return input + 1
+                else:
+                    return input + 2
+
+        self.checkModule(TestModule(), (torch.rand((2, 3)),))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1263,6 +1263,28 @@ static const auto ProcessGroupWorkTorchBind =
 // TODO: Support argument names in Python API.
 static const auto ProcessGroupTorchBind =
     torch::class_<::c10d::ProcessGroup>("dist_c10d", "ProcessGroup")
+        .def_pickle(
+            [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self) {
+              auto name =
+                  ::c10d::DistributedC10d::get()->getNameOfProcessGroup(self);
+              return std::vector<std::string>{name};
+            },
+            [](std::vector<std::string> state) {
+                TORCH_CHECK(
+                  state.size() == 1,
+                  "Expecting exactly 1 state when restoring ProcessGroup, got: ",
+                  state.size());
+              const auto& process_group_name = state.front();
+              auto process_group =
+                  ::c10d::DistributedC10d::get()->getProcessGroupByName(
+                      process_group_name);
+              TORCH_CHECK(
+                  process_group.defined(),
+                  "Needed process group not found, ",
+                  "please create a process group with name: ",
+                  process_group_name);
+              return process_group;
+            })
         .def(
             "rank",
             [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self) {
@@ -1527,11 +1549,49 @@ static const auto ProcessGroupNCCLOptionsTorchBind =
 
 static const auto ProcessGroupNCCLTorchBind =
     torch::class_<::c10d::ProcessGroupNCCL>("dist_c10d", "ProcessGroupNCCL")
-        .def(torch::init<
-             const c10::intrusive_ptr<::c10d::Store>&,
-             int64_t,
-             int64_t,
-             const c10::intrusive_ptr<::c10d::ProcessGroupNCCL::Options>&>())
+        .def_pickle(
+            [](const c10::intrusive_ptr<::c10d::ProcessGroupNCCL>& self) {
+              auto base_process_group =
+                  static_intrusive_pointer_cast<::c10d::ProcessGroup>(self);
+              auto name =
+                  ::c10d::DistributedC10d::get()->getNameOfProcessGroup(self);
+              return std::vector<std::string>{name};
+            },
+            [](std::vector<std::string> state) {
+              TORCH_CHECK(
+                  state.size() == 1,
+                  "Expecting exactly 1 state when restoring ProcessGroupNCCL, got: ",
+                  state.size());
+              const auto& process_group_name = state.front();
+              auto base_process_group =
+                  ::c10d::DistributedC10d::get()->getProcessGroupByName(
+                      process_group_name);
+              TORCH_CHECK(
+                  base_process_group.defined(),
+                  "Needed process group not found, ",
+                  "please create a process group with name: ",
+                  process_group_name);
+              c10::intrusive_ptr<::c10d::ProcessGroupNCCL> process_group_nccl =
+                  dynamic_intrusive_pointer_cast<::c10d::ProcessGroupNCCL>(
+                      base_process_group);
+              TORCH_CHECK(
+                  process_group_nccl.defined(),
+                  "Process group ",
+                  process_group_name,
+                  " isn't configured for NCCL backend");
+              return process_group_nccl;
+            })
+        .def(torch::init(
+            [](const c10::intrusive_ptr<::c10d::Store>& store,
+               int64_t rank,
+               int64_t size,
+               c10::intrusive_ptr<::c10d::ProcessGroupNCCL::Options> options,
+               const std::string& name) {
+              auto pg = c10::make_intrusive<::c10d::ProcessGroupNCCL>(store, rank, size, options);
+              ::c10d::DistributedC10d::get()->registerProcessGroupName(
+                  pg, name);
+              return pg;
+            }))
         .def(
             "alltoall_base",
             [](const c10::intrusive_ptr<::c10d::ProcessGroupNCCL>& self,
@@ -1549,14 +1609,17 @@ static const auto ProcessGroupNCCLTorchBind =
 #endif
 
 static const auto DistributedC10dFrontendTorchBind =
-    torch::class_<::c10d::DistributedC10d>("c10d", "frontend")
-        .def(torch::init([]() {
-          static c10::intrusive_ptr<::c10d::DistributedC10d>
-              c10d_frontend_singleton =
-                  c10::make_intrusive<::c10d::DistributedC10d>();
-          return c10d_frontend_singleton;
-        }))
-        .def("new_process_group_helper", &::c10d::DistributedC10d::newProcessGroupHelper);
+    torch::class_<::c10d::DistributedC10d>("dist_c10d", "frontend")
+        .def(torch::init([]() { return ::c10d::DistributedC10d::get(); }))
+        .def(
+            "new_process_group_helper",
+            &::c10d::DistributedC10d::newProcessGroupHelper)
+        .def(
+            "get_process_group_by_name",
+            &::c10d::DistributedC10d::getProcessGroupByName)
+        .def(
+            "get_name_of_process_group",
+            &::c10d::DistributedC10d::getNameOfProcessGroup);
 
 } // namespace
 

--- a/torch/lib/c10d/frontend.hpp
+++ b/torch/lib/c10d/frontend.hpp
@@ -43,9 +43,11 @@ class Backend {
   std::unordered_set<std::string> registered_backends_;
 };
 
-class DistributedC10d : public torch::CustomClassHolder {
+class TORCH_PYTHON_API DistributedC10d : public torch::CustomClassHolder {
  public:
-  DistributedC10d(){};
+  static c10::intrusive_ptr<DistributedC10d> get();
+
+  DistributedC10d() = default;
 
   void initProcessGroup(
       const std::string& backend,
@@ -210,6 +212,13 @@ class DistributedC10d : public torch::CustomClassHolder {
     c10::optional<std::string> group_name,
     int64_t timeout_milisesonds);
 
+  c10::intrusive_ptr<ProcessGroup> getProcessGroupByName(
+      const std::string& name) const;
+
+  std::string getNameOfProcessGroup(
+      const c10::intrusive_ptr<ProcessGroup>& pg) const;
+
+    void registerProcessGroupName(const c10::intrusive_ptr<ProcessGroup>& process_group, const std::string& name);
 
  private:
 


### PR DESCRIPTION
This diff enables JIT serialization of `ProcessGroup`, including both base `ProcessGroup` class and derived classes like `ProcessGroupNCCL`.

If a `ProcessGroup` is created via high-level APIs like `dist_c10d.frontend().new_process_group_helper()`, they are automatically serializable. If a `ProcessGroup` is created via its derived class TorchBind APIs like `dist_c10d.ProcessGroupNCCL()`, then it has to be given a name and registered with `dist_c10d.frontend().register_process_group_name` to be uniquely identifiable and serializable. 

* Fixed a minor bug in new dist_c10d frontend which fails to check whether a process group is used or not
* Fixed an issue where `test_jit_c10d.py` wasn't really run due to a configuration bug. Now tests are run as a slow test (need ci-all/* branch)
