### PR TITLE
Fix spelling mistake: varaible -> variable

### DIFF
--- a/caffe2/opt/custom/in_batch_broadcast.cc
+++ b/caffe2/opt/custom/in_batch_broadcast.cc
@@ -112,8 +112,8 @@ void inBatchBroadcast(
     setShape(blob, new_blob);
     const auto rit = reversed.find(blob);
     if (rit != reversed.end()) {
-      const auto& orignal_input = rit->second;
-      setShape(orignal_input, "");
+      const auto& original_input = rit->second;
+      setShape(original_input, "");
     }
   }
 

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -147,7 +147,7 @@ using ContextPtr = std::shared_ptr<DistAutogradContext>;
 // doesn't know the current context. It's just a util class.
 class TORCH_API ThreadLocalDistAutogradContext {
  public:
-  // Store 'new_context' to the thread local varaible maintained by this class.
+  // Store 'new_context' to the thread local variable maintained by this class.
   explicit ThreadLocalDistAutogradContext(ContextPtr&& new_context);
   ~ThreadLocalDistAutogradContext();
 


### PR DESCRIPTION
The title is pretty self explanatory.
