### PR TITLE
Annotate torch._tensor_str

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -6,7 +6,7 @@ from typing import Union, Optional
 
 class __PrinterOptions(object):
     precision: int = 4
-    threshold: Union[str, float] = 1000
+    threshold: float = 1000
     edgeitems: int = 3
     linewidth: int = 80
     sci_mode: Optional[bool] = None

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -1,7 +1,7 @@
 import math
 import torch
 from torch._six import inf
-from typing import Union, Optional
+from typing import Optional
 
 
 class __PrinterOptions(object):


### PR DESCRIPTION
This is a follow up PR of #48463 

> Rather than requiring that users write import numbers and then use numbers.Float etc., this PEP proposes a straightforward shortcut that is almost as effective: when an argument is annotated as having type float, an argument of type int is acceptable; similar, for an argument annotated as having type complex, arguments of type float or int are acceptable.
