### PR TITLE
Fix test comparison ops check for scalar overflow

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -177,19 +177,23 @@ class TestBinaryUfuncs(TestCase):
     # TODO: update to work on CUDA, too
     @onlyCPU
     def test_comparison_ops_check_for_zerodim_tensor_overflow(self, device):
+        t1 = torch.tensor([1 << 5], dtype=torch.uint8)
+        t2 = torch.tensor([1 << 30], dtype=torch.int32)
+        ts1 = torch.tensor(1 << 20, dtype=torch.int32)
+        ts2 = torch.tensor(1 << 40, dtype=torch.int64)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            torch.tensor([1 << 5], dtype=torch.uint8) < torch.tensor(1 << 20, dtype=torch.int32)    # noqa: B015
-            torch.tensor(1 << 40, dtype=torch.int64) < torch.tensor([1 << 30], dtype=torch.int32)   # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) <= torch.tensor(1 << 20, dtype=torch.int32)   # noqa: B015
-            torch.tensor(1 << 40, dtype=torch.int64) <= torch.tensor([1 << 30], dtype=torch.int32)  # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) > torch.tensor(1 << 20, dtype=torch.int32)    # noqa: B015
-            torch.tensor(1 << 40, dtype=torch.int64) > torch.tensor([1 << 30], dtype=torch.int32)   # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) >= torch.tensor(1 << 20, dtype=torch.int32)   # noqa: B015
-            torch.tensor(1 << 40, dtype=torch.int64) >= torch.tensor([1 << 30], dtype=torch.int32)  # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) == torch.tensor(1 << 20, dtype=torch.int32)   # noqa: B015
-            torch.tensor(1 << 40, dtype=torch.int64) == torch.tensor([1 << 30], dtype=torch.int32)  # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) != torch.tensor(1 << 20, dtype=torch.int32)   # noqa: B015
-            torch.tensor(1 << 40, dtype=torch.int64) != torch.tensor([1 << 30], dtype=torch.int32)  # noqa: B015
+            t1 < ts1    # noqa: B015
+            ts2 < t2   # noqa: B015
+            t1 <= ts1   # noqa: B015
+            ts2 <= t2  # noqa: B015
+            t1 > ts1    # noqa: B015
+            ts2 > t2   # noqa: B015
+            t1 >= ts1   # noqa: B015
+            ts2 >= t2  # noqa: B015
+            t1 == ts1   # noqa: B015
+            ts2 == t2  # noqa: B015
+            t1 != ts1   # noqa: B015
+            ts2 != t2  # noqa: B015
 
     # TODO: update to work on CUDA, too
     @onlyCPU

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -158,19 +158,21 @@ class TestBinaryUfuncs(TestCase):
     # TODO: update to work on CUDA, too
     @onlyCPU
     def test_comparison_ops_check_for_scalar_overflow(self, device):
+        s = 1 << 20
+        t = torch.tensor([1 << 5], dtype=torch.uint8)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            torch.tensor([1 << 5], dtype=torch.uint8) < (1 << 20)   # noqa: B015
-            (1 << 20) < torch.tensor([1 << 5], dtype=torch.uint8)   # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) <= (1 << 20)  # noqa: B015
-            (1 << 20) <= torch.tensor([1 << 5], dtype=torch.uint8)  # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) > (1 << 20)   # noqa: B015
-            (1 << 20) > torch.tensor([1 << 5], dtype=torch.uint8)   # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) >= (1 << 20)  # noqa: B015
-            (1 << 20) >= torch.tensor([1 << 5], dtype=torch.uint8)  # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) == (1 << 20)  # noqa: B015
-            (1 << 20) == torch.tensor([1 << 5], dtype=torch.uint8)  # noqa: B015
-            torch.tensor([1 << 5], dtype=torch.uint8) != (1 << 20)  # noqa: B015
-            (1 << 20) != torch.tensor([1 << 5], dtype=torch.uint8)  # noqa: B015
+            t < s   # noqa: B015
+            s < t   # noqa: B015
+            t <= s  # noqa: B015
+            s <= t  # noqa: B015
+            t > s   # noqa: B015
+            s > t   # noqa: B015
+            t >= s  # noqa: B015
+            s >= t  # noqa: B015
+            t == s  # noqa: B015
+            s == t  # noqa: B015
+            t != s  # noqa: B015
+            s != t  # noqa: B015
 
     # TODO: update to work on CUDA, too
     @onlyCPU

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -162,16 +162,27 @@ class TestBinaryUfuncs(TestCase):
         t = torch.tensor([1 << 5], dtype=torch.uint8)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t < s   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             s < t   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t <= s  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             s <= t  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t > s   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             s > t   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t >= s  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             s >= t  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t == s  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             s == t  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t != s  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             s != t  # noqa: B015
 
     # TODO: update to work on CUDA, too
@@ -183,16 +194,27 @@ class TestBinaryUfuncs(TestCase):
         ts2 = torch.tensor(1 << 40, dtype=torch.int64)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t1 < ts1    # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             ts2 < t2   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t1 <= ts1   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             ts2 <= t2  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t1 > ts1    # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             ts2 > t2   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t1 >= ts1   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             ts2 >= t2  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t1 == ts1   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             ts2 == t2  # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             t1 != ts1   # noqa: B015
+        with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
             ts2 != t2  # noqa: B015
 
     # TODO: update to work on CUDA, too

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -161,29 +161,29 @@ class TestBinaryUfuncs(TestCase):
         s = 1 << 20
         t = torch.tensor([1 << 5], dtype=torch.uint8)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t < s   # noqa: B015
+            self.assertTrue(t < s)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            s < t   # noqa: B015
+            self.assertTrue(s < t)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t <= s  # noqa: B015
+            self.assertTrue(t <= s)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            s <= t  # noqa: B015
+            self.assertTrue(s <= t)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t > s   # noqa: B015
+            self.assertTrue(t > s)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            s > t   # noqa: B015
+            self.assertTrue(s > t)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t >= s  # noqa: B015
+            self.assertTrue(t >= s)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            s >= t  # noqa: B015
+            self.assertTrue(s >= t)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t == s  # noqa: B015
+            self.assertTrue(t == s)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            s == t  # noqa: B015
+            self.assertTrue(s == t)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t != s  # noqa: B015
+            self.assertTrue(t != s)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            s != t  # noqa: B015
+            self.assertTrue(s != t)
 
     # TODO: update to work on CUDA, too
     @onlyCPU
@@ -193,29 +193,29 @@ class TestBinaryUfuncs(TestCase):
         ts1 = torch.tensor(1 << 20, dtype=torch.int32)
         ts2 = torch.tensor(1 << 40, dtype=torch.int64)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t1 < ts1    # noqa: B015
+            self.assertTrue(t1 < ts1)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            ts2 < t2   # noqa: B015
+            self.assertTrue(ts2 < t2)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t1 <= ts1   # noqa: B015
+            self.assertTrue(t1 <= ts1)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            ts2 <= t2  # noqa: B015
+            self.assertTrue(ts2 <= t2)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t1 > ts1    # noqa: B015
+            self.assertTrue(t1 > ts1)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            ts2 > t2   # noqa: B015
+            self.assertTrue(ts2 > t2)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t1 >= ts1   # noqa: B015
+            self.assertTrue(t1 >= ts1)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            ts2 >= t2  # noqa: B015
+            self.assertTrue(ts2 >= t2)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t1 == ts1   # noqa: B015
+            self.assertTrue(t1 == ts1)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            ts2 == t2  # noqa: B015
+            self.assertTrue(ts2 == t2)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            t1 != ts1   # noqa: B015
+            self.assertTrue(t1 != ts1)
         with self.assertRaisesRegex(RuntimeError, 'value cannot be converted to type'):
-            ts2 != t2  # noqa: B015
+            self.assertTrue(ts2 != t2)
 
     # TODO: update to work on CUDA, too
     @onlyCPU


### PR DESCRIPTION
Test should verify, that all listed conditions throw, not just the first one
Refactor duplicated constants
Use `self.assertTrue()` instead of suppressing flake8 `B015: Pointless Comparison` warning