### PR TITLE
[caffe2][torch] Clean up unused variable 'device'

### DIFF
--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -150,7 +150,6 @@ c10::optional<at::ScalarType> SchemaTypeParser::parseTensorDType(
 }
 
 c10::optional<c10::Device> SchemaTypeParser::tryToParseDeviceType() {
-  c10::optional<c10::Device> device;
   L.expect('=');
   const std::string& dev = L.expect(TK_IDENT).text();
 


### PR DESCRIPTION
Summary:
Fix this warning that pops up with clang and `-Wunused-variable`:
```
caffe2\torch\csrc\jit\frontend\schema_type_parser.cpp(153,30): warning: unused variable 'device' [-Wunused-variable]
```

Test Plan: Locally built & continuous integration

Differential Revision: D25194298

