### PR TITLE
[caffe2][a10] Remove unreferenced local variable e

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -409,7 +409,7 @@ struct C10_EXPORT ivalue::Future : c10::intrusive_ptr_target {
         [fut](std::function<IValue(void)> cb) {
           try {
             fut->markCompleted(cb());
-          } catch (std::exception& e) {
+          } catch (std::exception&) {
             fut->setError(std::current_exception());
           }
         },


### PR DESCRIPTION
Summary:
Fix this spurious warning:
```
caffe2\aten\src\aten\core\ivalue_inl.h(412): warning C4101: 'e': unreferenced local variable
```

Test Plan: Local build & continuous integration

Differential Revision: D25194281

