### PR TITLE
[Distributed] Compute Gloo Local Rank for Single-host Multi-GPU training

### DIFF
--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -128,9 +128,10 @@ class CollectiveTest {
     }
 
     std::vector<std::thread> threads;
+    auto store = c10::make_intrusive<::c10d::FileStore>(path, tests.size());
     for (auto i = 0; i < num; i++) {
       threads.push_back(std::thread(
-          [i, &tests, delayed] { tests[i].start(i, tests.size(), delayed); }));
+          [i, &tests, delayed, &store] { tests[i].start(i, tests.size(), delayed, store); }));
     }
     for (auto& thread : threads) {
       thread.join();
@@ -150,9 +151,7 @@ class CollectiveTest {
     return *pg_;
   }
 
-  void start(int rank, int size, bool delayed) {
-    auto store = c10::make_intrusive<::c10d::FileStore>(path_, size);
-
+  void start(int rank, int size, bool delayed, c10::intrusive_ptr<c10d::FileStore> store) {
     // Set a timeout that is small enough to make this test run fast, but also
     // make sure that we don't get timeouts in the ProcessGroupGloo constructor.
     ::c10d::ProcessGroupGloo::Options options;


### PR DESCRIPTION
Summary:
Changes to the Gloo Store downstream required an API change to the GlooStore wrapper in ProcessGroupGloo. Additionally, the Store passed to each ProcessGroup in the ProcessGroupGloo tests were not passed correctly, so that is fixed here.

The OSS CI for this will likely fail unless the Gloo changes are landed first.

Test Plan: Ran all ProcessGroupGloo Tests

Differential Revision: D25106115

