### PR TITLE
Move compute_mem_overlaps check later.

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -1270,9 +1270,6 @@ void TensorIterator::build(TensorIteratorConfig& config) {
   populate_operands(config);
   // set is_output and is_read_write flags on appropriate tensors
   mark_outputs();
-  // Check that the outputs have no internal overlap
-  // and do not share memory with inputs.
-  compute_mem_overlaps(config);
   // Check that input dimensions are aligned correctly & compute outnames.
   compute_names(config);
   // compute the broadcasted shape
@@ -1294,6 +1291,10 @@ void TensorIterator::build(TensorIteratorConfig& config) {
   }
   // perform name inference
   propagate_names_to_outputs();
+
+  // Check that the outputs have no internal overlap
+  // and do not share memory with inputs.
+  compute_mem_overlaps(config);
 
   for (auto& op : operands_) {
     TORCH_INTERNAL_ASSERT(op.tensor.defined());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48606 Move compute_mem_overlaps check later.**

I'm going to refactor TensorIterator so that things that
can be done without actual reference to data in tensors
happen first, and then everything that actually requires
tensor data happens afterwards.  Memory overlap testing
requires actual pointers, so it needs to happen later.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D25224932](https://our.internmc.facebook.com/intern/diff/D25224932)