### PR TITLE
Fix ScriptModule docstring

### DIFF
--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -271,8 +271,8 @@ if _enabled:
     # which always throws an exception.
 
     class ScriptModule(with_metaclass(ScriptMeta, Module)):  # type: ignore
-        """
-        ``ScriptModule``s wrap a C++ ``torch::jit::Module``. ``ScriptModule``s
+        r"""
+        A wrapper around C++ ``torch::jit::Module``. ``ScriptModule``\s
         contain methods, attributes, parameters, and
         constants. These can be accessed the same as on a normal ``nn.Module``.
         """


### PR DESCRIPTION
Fixes a typo in `ScriptModule`'s docstring and converts it to the raw format (`r"""...`).

Fixes #48634 