### PR TITLE
ret is never reassigned, return 0 directly

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -168,7 +168,6 @@ void TensorIterator::reorder_dimensions(const TensorIteratorConfig& config) {
   // returns 1 if the dim0 should come after dim1, -1 if dim0 should come
   // before dim1, and 0 if the comparison is ambiguous.
   auto should_swap = [&](size_t dim0, size_t dim1) {
-    int ret = 0;
     for (int arg = 0; arg < ntensors(); arg++) {
       // ignore undefined or incorrectly sized tensors
       if (operands_[arg].stride_bytes.empty() || operands_[arg].will_resize) {
@@ -202,7 +201,7 @@ void TensorIterator::reorder_dimensions(const TensorIteratorConfig& config) {
          }
       }
     }
-    return ret;
+    return 0;
   };
 
   // insertion sort with support for ambiguous comparisons


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48613 TensorIteratorConfig is not used by reorder_dimensions
* **#48609 ret is never reassigned, return 0 directly**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D25228678](https://our.internmc.facebook.com/intern/diff/D25228678)