### PR TITLE
TensorIteratorConfig is not used by reorder_dimensions

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -150,7 +150,7 @@ TensorIteratorConfig& TensorIteratorConfig::declare_static_shape(IntArrayRef sha
 // in the strides of trivial dimensions, so physical layout is unaffected but permutation information is lost)
 // We might change this behavior in future once performance considerations are resolved
 
-void TensorIterator::reorder_dimensions(const TensorIteratorConfig& config) {
+void TensorIterator::reorder_dimensions() {
   // Sort the dimensions based on strides in ascending order with reduced dims
   // at the front. NOTE: that this inverts the order of C-contiguous tensors.
   // strides[0] is the fastest moving dimension instead of strides[ndim - 1].
@@ -1285,7 +1285,7 @@ void TensorIterator::build(TensorIteratorConfig& config) {
     // compute each tensor's stride after broadcasting
     compute_strides(config);
     // re-order dimensions to improve coalescing
-    reorder_dimensions(config);
+    reorder_dimensions();
     // allocate the output tensor if it's not provided
     allocate_or_resize_outputs();
     // coalesce adjacent dimensions when possible

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -306,7 +306,7 @@ protected:
   void compute_mem_overlaps(const TensorIteratorConfig&);
   void compute_shape(const TensorIteratorConfig&);
   void compute_strides(const TensorIteratorConfig&);
-  void reorder_dimensions(const TensorIteratorConfig&);
+  void reorder_dimensions();
   void permute_dimensions(IntArrayRef perm);
   void compute_types(const TensorIteratorConfig&);
   ScalarType compute_common_dtype();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48613 TensorIteratorConfig is not used by reorder_dimensions**
* #48609 ret is never reassigned, return 0 directly

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D25228679](https://our.internmc.facebook.com/intern/diff/D25228679)