### PR TITLE
Fix bazel build after sleef update

### DIFF
--- a/third_party/sleef.BUILD
+++ b/third_party/sleef.BUILD
@@ -178,12 +178,12 @@ genrule(
 genrule(
     name = "sleef_h",
     srcs = [
-        "src/libm/sleeflibm_header.h.org",
+        "src/libm/sleeflibm_header.h.org.in",
         "src/libm/sleeflibm_footer.h.org",
     ],
     outs = ["build/include/sleef.h"],
     cmd = "{ " + "; ".join([
-        "cat $(location src/libm/sleeflibm_header.h.org)",
+        "cat $(location src/libm/sleeflibm_header.h.org.in)",
         "$(location :mkrename) cinz_ 2 4 __m128d __m128 __m128i __m128i __SSE2__",
         "$(location :mkrename) cinz_ 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse2",
         "$(location :mkrename) cinz_ 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse4",


### PR DESCRIPTION
In https://github.com/shibatch/sleef/pull/361 `src/libm/sleeflibm_header.h.org` was renamed to `src/libm/sleeflibm_header.h.org.in`
Updating bazel build rule for sleef accordingly


