### PR TITLE
[static runtime] Add Internal Ops to the registry

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -160,23 +160,30 @@ LivenessMap(const std::shared_ptr<torch::jit::Graph>& graph) {
 
 std::unordered_set<Value*> GetOptimizableValues(
     const std::shared_ptr<torch::jit::Graph>& graph) {
-  std::unordered_set<Value*> is_out_of_place;
-  std::unordered_set<Value*> is_not_out_of_place;
+  std::unordered_set<Value*> can_reuse;
+  // values used by unsupported ops (as either inputs or outputs)
+  // these need to be removed from "can_reuse" after analyzing all nodes
+  std::unordered_set<Value*> cannot_reuse;
   for (const auto& n : graph->nodes()) {
-    for (const auto& container : {n->inputs(), n->outputs()}) {
-      for (const auto& v : container) {
-        if (canRunOutOfPlace(n)) {
-          is_out_of_place.insert(v);
-        } else {
-          is_not_out_of_place.insert(v);
-        }
+    for (const auto& v : n->inputs()) {
+      if (canRunOutOfPlace(n) && canReuseInputs(n)) {
+        can_reuse.insert(v);
+      } else {
+        cannot_reuse.insert(v);
+      }
+    }
+    for (const auto& v : n->outputs()) {
+      if (canRunOutOfPlace(n) && canReuseOutputs(n)) {
+        can_reuse.insert(v);
+      } else {
+        cannot_reuse.insert(v);
       }
     }
   }
-  for (auto v : is_not_out_of_place) {
-    is_out_of_place.erase(v);
+  for (auto v : cannot_reuse) {
+    can_reuse.erase(v);
   }
-  return is_out_of_place;
+  return can_reuse;
 }
 
 size_t AssignRegisters(

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -6,17 +6,23 @@
 namespace torch {
 namespace jit {
 
-namespace {
-inline at::Tensor create_empty_from(const at::Tensor& t) {
-  return at::empty({0}, t.options());
-}
-} // namespace
-
 C10_DEFINE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
 
 bool canRunOutOfPlace(Node* n) {
   auto op_name = std::string(n->kind().toQualString());
   return SROperatorRegistry()->Has(op_name);
+}
+
+bool canReuseInputs(Node* n) {
+  auto op_name = std::string(n->kind().toQualString());
+  DCHECK(SROperatorRegistry()->Has(op_name));
+  return SROperatorRegistry()->Create(op_name)->CanReuseInput();
+}
+
+bool canReuseOutputs(Node* n) {
+  auto op_name = std::string(n->kind().toQualString());
+  DCHECK(SROperatorRegistry()->Has(op_name));
+  return SROperatorRegistry()->Create(op_name)->CanReuseOutput();
 }
 
 // TODO: expand to include all view producing ops, mostly in

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -10,21 +10,48 @@ using SROperator =
     std::function<void(const ProcessedNode*, std::vector<IValue>&)>;
 using SROpFunctor = std::function<SROperator(Node* n)>;
 struct SROperatorFunctor {
-  virtual SROperator Generate(Node*) = 0;
+  virtual SROperator Generate(Node*) {
+    std::function<void(const ProcessedNode*, std::vector<IValue>&)> out;
+    return out;
+  }
+  virtual bool CanReuseInput() {
+    return false;
+  }
+  virtual bool CanReuseOutput() {
+    return false;
+  }
   virtual ~SROperatorFunctor() = default;
 };
 
 C10_DECLARE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
-#define REGISTER_OPERATOR_FUNCTOR(name, id, ...)             \
-  struct SROperatorFunctor_##id : public SROperatorFunctor { \
-    const SROpFunctor fn = __VA_ARGS__;                      \
-    SROperator Generate(Node* n) override {                  \
-      return fn(n);                                          \
-    }                                                        \
-  };                                                         \
+
+// TODO: reuse_inp reuse_out can be deprecated with further analysis
+// try to avoid this API.
+#define REGISTER_OPERATOR_FUNCTOR_OPT(name, id, reuse_inp, reuse_out, ...) \
+  struct SROperatorFunctor_##id : public SROperatorFunctor {               \
+    const SROpFunctor fn = __VA_ARGS__;                                    \
+    bool CanReuseInput() override {                                        \
+      return reuse_inp;                                                    \
+    }                                                                      \
+    bool CanReuseOutput() override {                                       \
+      return reuse_out;                                                    \
+    }                                                                      \
+    SROperator Generate(Node* n) override {                                \
+      return fn(n);                                                        \
+    }                                                                      \
+  };                                                                       \
   C10_REGISTER_CLASS(SROperatorRegistry, name, SROperatorFunctor_##id);
 
+#define REGISTER_OPERATOR_FUNCTOR(name, id, ...) \
+  REGISTER_OPERATOR_FUNCTOR_OPT(name, id, true, true, __VA_ARGS__)
+
+inline at::Tensor create_empty_from(const at::Tensor& t) {
+  return at::empty({0}, t.options());
+}
+
 bool canRunOutOfPlace(Node* n);
+bool canReuseInputs(Node* n);
+bool canReuseOutputs(Node* n);
 std::function<void(const ProcessedNode*, std::vector<IValue>&)>
 getOutOfPlaceOperation(Node* n);
 


### PR DESCRIPTION
Summary:
This adds a couple of _out variants and then registers them to the registry.

I also added the concept of "canReuse{Input,Output}" so that we can annotate tensors that are not optimizable (specifically, non-float tensors).

In the future we can change this (with this D25062301)

after removing `RecordFunction`, we see these results

```
BS=20
 ---
caffe2:           0.651617 ~ 0.666354
static runtime:   0.753481
pytorch:          0.866658

BS=1
 ---
caffe2:           0.0858684 ~ 0.08633
static runtime:   0.209897
pytorch:          0.232694
```

Test Plan: standard internal test of ads model against caffe2 reference (see the scripts in this quip: https://fb.quip.com/ztERAYjuzdlr)

Differential Revision: D25066823

