### PR TITLE
Disable fast sigmoid since it causes divergence

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -495,7 +495,11 @@ void LLVMCodeGenImpl::emitKernel(
   irb_.SetInsertPoint(bb_);
 
   // Maybe expand some of the intrinsics.
+#ifdef USE_FAST_CPU_INTRINSICS
   LLVMIntrinsicsExpander intrinsics_expander;
+#else
+  GenericIntrinsicsExpander intrinsics_expander;
+#endif
   stmt = stmt->accept_mutator(&intrinsics_expander);
 
   // Compile the kernel.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48623 Disable fast sigmoid since it causes divergence**

The error introduced by fast sigmoid/tanh seems to accumulate in a way that's detectable in a macro-benchmark (unfortunately I don't have the model demonstrating it in a format that can be publically committed).

Differential Revision: [D25230376](https://our.internmc.facebook.com/intern/diff/D25230376/)