### PR TITLE
fx quantization: add option to leave graph inputs and/or outputs quantized

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -1118,6 +1118,71 @@ class TestQuantizeFx(QuantizationTestCase):
             self.checkGraphModeFxOp(
                 M().eval(), (data,), quant_type, expected_node_list=node_list)
 
+    def _test_quantized_inputs_outputs(
+            self, convert_custom_config_dict, count_check):
+        """
+        Test the option to have inputs and outputs of the graph quantized
+        """
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(1, 1, 1)
+                self.conv2 = torch.nn.Conv2d(1, 1, 1)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x = self.conv2(x)
+                return x
+
+        # quantized input, quantized output
+        m = M()
+        qconfig_dict = {'': torch.quantization.default_qconfig}
+        m.eval()
+        mp = torch.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        mp(torch.randn(1, 1, 4, 4))
+        mq = torch.quantization.quantize_fx.convert_fx(
+            mp, convert_custom_config_dict=convert_custom_config_dict)
+        self.checkGraphModuleNodes(mq, expected_node_occurrence=count_check)
+
+    def test_quantized_input_quantized_output(self):
+        convert_custom_config_dict = {
+            'input_quantized_idxs': [0], 'output_quantized_idxs': [0]}
+        count_check = {
+            ns.call_function(torch.quantize_per_tensor): 0,
+            ns.call_method('dequantize'): 0,
+        }
+        self._test_quantized_inputs_outputs(
+            convert_custom_config_dict, count_check)
+
+    def test_fp32_input_quantized_output(self):
+        convert_custom_config_dict = {
+            'output_quantized_idxs': [0]}
+        count_check = {
+            ns.call_function(torch.quantize_per_tensor): 1,
+            ns.call_method('dequantize'): 0,
+        }
+        self._test_quantized_inputs_outputs(
+            convert_custom_config_dict, count_check)
+
+    def test_quantized_input_fp32_output(self):
+        convert_custom_config_dict = {
+            'input_quantized_idxs': [0]}
+        count_check = {
+            ns.call_function(torch.quantize_per_tensor): 0,
+            ns.call_method('dequantize'): 1,
+        }
+        self._test_quantized_inputs_outputs(
+            convert_custom_config_dict, count_check)
+
+    def test_fp32_input_fp32_output(self):
+        convert_custom_config_dict = {}
+        count_check = {
+            ns.call_function(torch.quantize_per_tensor): 1,
+            ns.call_method('dequantize'): 1,
+        }
+        self._test_quantized_inputs_outputs(
+            convert_custom_config_dict, count_check)
+
 @skipIfNoFBGEMM
 class TestQuantizeFxOps(QuantizationTestCase):
     """Unit tests for individual ops

--- a/torch/quantization/quantize_fx.py
+++ b/torch/quantization/quantize_fx.py
@@ -302,6 +302,7 @@ def convert_fx(graph_module, debug=False, convert_custom_config_dict=None):
         `debug`: flag for producing a debug friendly model (preserve weight attribute)
         `convert_custom_config_dict`: dictionary for custom configurations for convert function:
         convert_custom_config_dict = {
+
           # addtional object (module/operator) mappings that will overwrite the default
           # module mappingn
           "additional_object_mapping": {
@@ -314,6 +315,7 @@ def convert_fx(graph_module, debug=False, convert_custom_config_dict=None):
                 float_op: dynamically_quantized_op
              },
           }
+
           # user will manually define the corresponding quantized
           # module class which has a from_observed class method that converts
           # observed custom module to quantized custom module
@@ -328,6 +330,14 @@ def convert_fx(graph_module, debug=False, convert_custom_config_dict=None):
                  ObservedCustomModule: QuantizedCustomModule
              }
           }
+
+          # By default, inputs and outputs of the graph are assumed to be in
+          # fp32. Providing `input_quantized_idxs` will set the inputs with the
+          # corresponding indices to be quantized. Providing
+          # `output_quantized_idxs` will set the outputs with the corresponding
+          # indices to be quantized.
+          "input_quantized_idxs": [0],
+          "output_quantized_idxs": [0],
         }
 
     Return:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48624 [wip] add option to leave graph inputs and/or outputs quantized**

Summary:

Before this PR, there was an assumption that all graph inputs
and outputs are in floating point, with some exceptions for
`standalone_module`.

This PR adds an option to specify either inputs or outputs
as being quantized.

This is useful for incremental migrations of models using Eager mode.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25231833](https://our.internmc.facebook.com/intern/diff/D25231833)