### PR TITLE
change global_fp16_constants for test_fc_nnpi_fp16

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
@@ -48,7 +48,7 @@ class FCTest(serial.SerializedTestCase):
         )
         workspace.GlobalInit(
             ['caffe2', '--caffe2_log_level=0', '--glow_global_fp16=1',
-             '--glow_clip_fp16'])
+             '--glow_clip_fp16', '--glow_global_fp16_constants=1'])
         workspace.SwitchWorkspace("glow_test_ws", True)
         workspace.ResetWorkspace()
         W0 = np.full((n, k), 65536.0, dtype)


### PR DESCRIPTION
Summary: enable the flag inside the test

Test Plan:
GLOW_NNPI=1 USE_INF_API=1 buck-out/opt/gen/caffe2/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16nnpi#binary.par
buck test -c glow.nnpi_use_inf_api=true mode/opt //caffe2/caffe2/contrib/fakelowp/test:test_fc_nnpi_fp16nnpi

Reviewed By: hl475

Differential Revision: D25249575

