### PR TITLE
[qunat][graphmode][fx] Standalone module takes float as input and output

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -550,9 +550,9 @@ class TestQuantizeFx(QuantizationTestCase):
                 ns.call_module(torch.quantization.MinMaxObserver): 2
             }
             self.checkGraphModuleNodes(m, expected_node_occurrence=count_check)
-            # for output of conv in the standalone module
+            # for input and output of conv in the standalone module
             count_check = {
-                ns.call_module(torch.quantization.MinMaxObserver): 1
+                ns.call_module(torch.quantization.MinMaxObserver): 2
             }
             self.checkGraphModuleNodes(m.standalone, expected_node_occurrence=count_check)
 
@@ -565,11 +565,11 @@ class TestQuantizeFx(QuantizationTestCase):
             }
             self.checkGraphModuleNodes(m, expected_node_occurrence=count_check)
             count_check = {
-                # quantization of input happens in parent module
-                # quantization of output happens in the quantized conv module
-                ns.call_function(torch.quantize_per_tensor) : 0,
-                # dequantization for output happens in parent module
-                ns.call_method('dequantize') : 0,
+                # standalone module will take float as input and output
+                # so we'll see quantize and dequantize in the modoule
+                ns.call_function(torch.quantize_per_tensor) : 1,
+                ns.call_module(nnq.Conv2d): 1,
+                ns.call_method('dequantize') : 1,
             }
             self.checkGraphModuleNodes(m.standalone, expected_node_occurrence=count_check)
             res = m(data)

--- a/torch/quantization/fx/observed_module.py
+++ b/torch/quantization/fx/observed_module.py
@@ -32,14 +32,6 @@ def is_observed_module(module):
     return isinstance(module, ObservedGraphModule)
 
 class ObservedStandaloneGraphModule(ObservedGraphModule):
-
-    def get_preserved_attr_names(self):
-        return ['_activation_post_process_map',
-                '_patterns',
-                '_qconfig_map',
-                '_standalone_module_observed_input_idxs',
-                '_output_is_observed']
-
     def __deepcopy__(self, memo):
         fake_mod = torch.nn.Module()
         fake_mod.__dict__ = copy.deepcopy(self.__dict__)

--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -676,4 +676,5 @@ class StandaloneModuleQuantizeHandler(QuantizeHandler):
         # update the modules dict
         setattr(quantizer.modules[parent_name], name, quantized_standalone_module)
         quantizer.modules[node.target] = quantized_standalone_module
-        return quantizer.quantized_graph.node_copy(node, load_arg(quantized=None))
+        # standalone module takes float input
+        return quantizer.quantized_graph.node_copy(node, load_arg(quantized=False))

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -519,11 +519,8 @@ class Quantizer:
                         observed_node_names_set.add(node.name)
                 elif isinstance(quantize_handler,
                                 StandaloneModuleQuantizeHandler):
-                    assert node.op == 'call_module'
-                    output_is_observed = \
-                        self.modules[node.target]._output_is_observed
-                    if output_is_observed:
-                        observed_node_names_set.add(node.name)
+                    # output is observed in the standalone module
+                    return
                 elif (quantize_handler.all_node_args and
                       input_output_observed(quantize_handler)):
                     # observer for outputs

--- a/torch/quantization/quantize_fx.py
+++ b/torch/quantization/quantize_fx.py
@@ -99,14 +99,8 @@ def _prepare_standalone_module_fx(model, qconfig_dict, prepare_custom_config_dic
     standalone_module means it a submodule that is not inlined in parent module,
         and will be quantized separately as one unit.
 
-    input of the module is quantized in parent module, output of the module
-    is quantized in the standalone module.
-    Extra attributes in output GraphModule while preparing a standalone module:
-        _standalone_module_observed_input_idxs(List[Int]): a list of indexs for the graph inputs that
-                                         needs to be observed in parent module
-        _output_is_observed(Bool): a boolean variable indicate whether the output of the
-                                   custom module is observed or not
-
+    Both input and output of the module are observed in the
+    standalone module.
     """
     return _prepare_fx(model, qconfig_dict, prepare_custom_config_dict, is_standalone_module=True)
 
@@ -356,11 +350,8 @@ def _convert_standalone_module_fx(graph_module, debug=False, convert_custom_conf
     r""" [Internal use only] Convert a model produced by :func:`~torch.quantization.prepare_standalone_module_fx`
     and convert it to a quantized model
 
-    The inputs will be quantized by parent module, checks `_standalone_module_observed_input_idxs` of
-    input model and will treat these inputs as quantized
-    also will not dequantize the final output
     Return:
-      A quantized standalone module which accepts quantized input(if needed)
-      and produces quantized output (if needed).
+        A quantized standalone module which accepts float input
+        and produces float output.
     """
     return _convert_fx(graph_module, debug, convert_custom_config_dict, is_standalone_module=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48671 [qunat][graphmode][fx] Standalone module takes float as input and output**

Summary:
Standalone module might be called separately so it's better to use float
as interface.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25256184](https://our.internmc.facebook.com/intern/diff/D25256184)