### PR TITLE
Disable pruning on embedding look up operators when compressed_indices_mapping = {0}

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -31,10 +31,18 @@ at::Tensor embedding_bag_4bit_impl(
   // Get compressed indices for pruned_weights op.
   int32_t* compressed_indices_mapping_data = nullptr;
   int compressed_index_size = 0;
+  bool fallback_to_no_sparse = false;
   if (pruned_weights) {
     compressed_index_size = compressed_indices_mapping.value().numel();
     compressed_indices_mapping_data =
         compressed_indices_mapping.value().data_ptr<int32_t>();
+
+    // if compressed_indices_mapping is [0], it is a indicator that
+    // we should fallback to non sparse embedding look up kernel.
+    if ((compressed_index_size == 1 &&
+         compressed_indices_mapping_data[0] == 0)) {
+      fallback_to_no_sparse = true;
+    }
   }
 
   const int64_t N = weight.size(0);
@@ -69,7 +77,7 @@ at::Tensor embedding_bag_4bit_impl(
   constexpr int prefetch_distance = 16;
 
 #ifdef USE_FBGEMM
-  if (!pruned_weights) {
+  if (!pruned_weights || fallback_to_no_sparse) {
     // Generate the fbgemm kernel
     auto kernel = fbgemm::GenerateEmbeddingSpMDMNBit<IndexType, OffsetType>(
         /*bit rate=*/4,
@@ -209,10 +217,18 @@ at::Tensor embedding_bag_byte_impl(
   // Get compressed indices for pruned_weights.
   int32_t* compressed_indices_mapping_data = nullptr;
   int compressed_index_size = 0;
+  bool fallback_to_no_sparse = false;
   if (pruned_weights) {
     compressed_index_size = compressed_indices_mapping.value().numel();
     compressed_indices_mapping_data =
         compressed_indices_mapping.value().data_ptr<int32_t>();
+
+    // if compressed_indices_mapping is [0], it is a indicator that
+    // we should fallback to non sparse embedding look up kernel.
+    if ((compressed_index_size == 1 &&
+         compressed_indices_mapping_data[0] == 0)) {
+      fallback_to_no_sparse = true;
+    }
   }
 
   const int64_t N = weight.size(0);
@@ -247,7 +263,7 @@ at::Tensor embedding_bag_byte_impl(
 
   const int index_size = indices.numel();
 #ifdef USE_FBGEMM
-  if (!pruned_weights) {
+  if (!pruned_weights || fallback_to_no_sparse) {
     auto kernel_i8 =
         fbgemm::GenerateEmbeddingSpMDM<uint8_t, IndexType, OffsetType>(
             /*block_size=*/D,
@@ -613,12 +629,12 @@ class QEmbeddingBag final {
           false /* is_embedding_op */);
     } else if (bit_rate == 4) {
       return packed_weight->embeddingbag_4bit(
-        indices,
-        offsets,
-        pruned_weights,
-        per_sample_weights_,
-        compressed_indices_mapping,
-        include_last_offset);
+          indices,
+          offsets,
+          pruned_weights,
+          per_sample_weights_,
+          compressed_indices_mapping,
+          include_last_offset);
     } else {
       TORCH_INTERNAL_ASSERT(
           "Currently only support 8-bit embedding_bag quantization");


### PR DESCRIPTION
Summary: When a user specifies `pruned_weights = True`, compressed_indices_mapping = {0}, it means they have not pruned the weights. In this case, we need to go through non-sparse kernels for embedding bag lookup.

Test Plan:
buck test //caffe2/test:quantization
https://www.internalfb.com/intern/testinfra/testconsole/testrun/3377699760676256/

Reviewed By: radkris-git

Differential Revision: D25252904

