### PR TITLE
Use fastAtomicAdd in GPU upsampling trilinear

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
@@ -346,12 +346,12 @@ static void upsample_trilinear3d_backward_out_cuda_template(
       {nbatch, channels, input_depth, input_height, input_width});
   // A contiguous tensor is required for the kernel launch config
   grad_input.contiguous();
-  // initialization to zero is required here. As we launch one thread per output
-  // element, and atomicAdd to input gradient. Given a sparse sampling case, our
-  // threads are not covering the whole input tensor.
+  // Numbers are added atomically to grad_input tensor from multiple threads,
+  // so it has to be initialized to zero.
   grad_input.zero_();
 
-  const size_t num_kernels = nbatch * channels * output_depth * output_height * output_width;
+  // const size_t num_kernels = nbatch * channels * output_depth * output_height * output_width;
+  const size_t num_kernels = grad_output.numel();
   const int num_threads = std::min(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();

--- a/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
@@ -8,11 +8,23 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/native/cuda/UpSample.cuh>
+#include <ATen/native/cuda/KernelUtils.cuh>
 #include <THC/THCAtomics.cuh>
 
 namespace at {
 namespace native {
 namespace {
+
+__device__ __forceinline__ size_t
+idx_3d(const size_t nc,
+    const size_t depth,
+    const size_t height,
+    const size_t width,
+    const size_t z,
+    const size_t y,
+    const size_t x) {
+  return ((nc * depth + z) * height + y) * width + x;
+}
 
 template <typename scalar_t, typename accscalar_t>
 C10_LAUNCH_BOUNDS_1(1024)
@@ -101,43 +113,32 @@ __global__ void upsample_trilinear3d_out_frame(
 template <typename scalar_t, typename accscalar_t>
 C10_LAUNCH_BOUNDS_1(1024)
 __global__ void upsample_trilinear3d_backward_out_frame(
-    const int n,
+    const size_t nc,
+    const int depth1,
+    const int height1,
+    const int width1,
+    const int depth2,
+    const int height2,
+    const int width2,
     const accscalar_t rdepth,
     const accscalar_t rheight,
     const accscalar_t rwidth,
     const bool align_corners,
-    PackedTensorAccessor64<scalar_t, 5> idata,
-    const PackedTensorAccessor64<scalar_t, 5> odata) {
+    scalar_t* __restrict__ idata,
+    const scalar_t* __restrict__ odata) {
   int index = threadIdx.x + blockIdx.x * blockDim.x;
 
-  const int batchsize = idata.size(0);
-  const int channels = idata.size(1);
-  const int depth1 = idata.size(2);
-  const int height1 = idata.size(3);
-  const int width1 = idata.size(4);
-  const int depth2 = odata.size(2);
-  const int height2 = odata.size(3);
-  const int width2 = odata.size(4);
+  const size_t i_numel = nc * depth1 * height1 * width1;
+  const size_t o_numel = nc * depth2 * height2 * width2;
 
-  if (index < n) {
-    const int w2 = (index % (height2 * width2)) % width2; // 0:width2-1
-    const int h2 = (index % (height2 * width2)) / width2; // 0:height2-1
-    const int t2 = index / (height2 * width2); // 0:depth2-1
-    // special case: just copy
-    if (depth1 == depth2 && height1 == height2 && width1 == width2) {
-      const int t1 = t2;
-      const int h1 = h2;
-      const int w1 = w2;
+  for (size_t index = blockDim.x * blockIdx.x + threadIdx.x; index < o_numel; index += blockDim.x * gridDim.x) {
+    size_t index_temp = index;
+    const int w2 = index_temp % width2;   // 0:width2-1
+    index_temp /= width2;
+    const int h2 = index_temp % height2;  // 0:height2-1
+    index_temp /= height2;
+    const int t2 = index_temp % depth2;   // 0:depth2-1
 
-      for (int n = 0; n < batchsize; n++) {
-        for (int c = 0; c < channels; ++c) {
-          const scalar_t val = odata[n][c][t1][h1][w1];
-          idata[n][c][t2][h2][w2] = val;
-        }
-      }
-      return;
-    }
-    //
     const accscalar_t t1r = area_pixel_compute_source_index<accscalar_t>(
         rdepth, t2, align_corners, /*cubic=*/false);
     const int t1 = t1r;
@@ -159,35 +160,55 @@ __global__ void upsample_trilinear3d_backward_out_frame(
     const accscalar_t w1lambda = w1r - w1;
     const accscalar_t w0lambda = static_cast<accscalar_t>(1) - w1lambda;
     //
-    for (int n = 0; n < batchsize; n++) {
-      for (int c = 0; c < channels; ++c) {
-        const scalar_t d2val = odata[n][c][t2][h2][w2];
-        gpuAtomicAdd(
-            &idata[n][c][t1][h1][w1],
-            static_cast<scalar_t>(t0lambda * h0lambda * w0lambda * d2val));
-        gpuAtomicAdd(
-            &idata[n][c][t1][h1][w1 + w1p],
-            static_cast<scalar_t>(t0lambda * h0lambda * w1lambda * d2val));
-        gpuAtomicAdd(
-            &idata[n][c][t1][h1 + h1p][w1],
-            static_cast<scalar_t>(t0lambda * h1lambda * w0lambda * d2val));
-        gpuAtomicAdd(
-            &idata[n][c][t1][h1 + h1p][w1 + w1p],
-            static_cast<scalar_t>(t0lambda * h1lambda * w1lambda * d2val));
-        gpuAtomicAdd(
-            &idata[n][c][t1 + t1p][h1][w1],
-            static_cast<scalar_t>(t1lambda * h0lambda * w0lambda * d2val));
-        gpuAtomicAdd(
-            &idata[n][c][t1 + t1p][h1][w1 + w1p],
-            static_cast<scalar_t>(t1lambda * h0lambda * w1lambda * d2val));
-        gpuAtomicAdd(
-            &idata[n][c][t1 + t1p][h1 + h1p][w1],
-            static_cast<scalar_t>(t1lambda * h1lambda * w0lambda * d2val));
-        gpuAtomicAdd(
-            &idata[n][c][t1 + t1p][h1 + h1p][w1 + w1p],
-            static_cast<scalar_t>(t1lambda * h1lambda * w1lambda * d2val));
-      }
-    }
+    const scalar_t d2val = odata[index];
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, height1, width1, t1, h1, w1),
+      i_numel,
+      static_cast<scalar_t>(t0lambda * h0lambda * w0lambda * d2val),
+      true);
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, width1, height1, t1, h1, w1 + w1p),
+      i_numel,
+      static_cast<scalar_t>(t0lambda * h0lambda * w1lambda * d2val),
+      true);
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, width1, height1, t1, h1 + h1p, w1),
+      i_numel,
+      static_cast<scalar_t>(t0lambda * h1lambda * w0lambda * d2val),
+      true);
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, width1, height1, t1, h1 + h1p, w1 + w1p),
+      i_numel,
+      static_cast<scalar_t>(t0lambda * h1lambda * w1lambda * d2val),
+      true);
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1, w1),
+      i_numel,
+      static_cast<scalar_t>(t1lambda * h0lambda * w0lambda * d2val),
+      true);
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1, w1 + w1p),
+      i_numel,
+      static_cast<scalar_t>(t1lambda * h0lambda * w1lambda * d2val),
+      true);
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1 + h1p, w1),
+      i_numel,
+      static_cast<scalar_t>(t1lambda * h1lambda * w0lambda * d2val),
+      true);
+    fastAtomicAdd(
+      idata,
+      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1 + h1p, w1 + w1p),
+      i_numel,
+      static_cast<scalar_t>(t1lambda * h1lambda * w1lambda * d2val),
+      true);
   }
 }
 
@@ -234,7 +255,6 @@ static void upsample_trilinear3d_out_cuda_template(
                   output_depth,
                   output_height,
                   output_width});
-  output.zero_();
 
   AT_ASSERT(
       input_depth > 0 && input_height > 0 && input_width > 0 &&
@@ -325,9 +345,14 @@ static void upsample_trilinear3d_backward_out_cuda_template(
 
   grad_input.resize_(
       {nbatch, channels, input_depth, input_height, input_width});
+  // A contiguous tensor is required for the kernel launch config
+  grad_input.contiguous();
+  // initialization to zero is required here. As we launch one thread per output
+  // element, and atomicAdd to input gradient. Given a sparse sampling case, our
+  // threads are not covering the whole input tensor.
   grad_input.zero_();
 
-  const int num_kernels = output_depth * output_height * output_width;
+  const size_t num_kernels = nbatch * channels * output_depth * output_height * output_width;
   const int num_threads = std::min(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -338,8 +363,8 @@ static void upsample_trilinear3d_backward_out_cuda_template(
       [&] {
         using accscalar_t = at::acc_type<scalar_t, true>;
 
-        auto idata = grad_input.packed_accessor64<scalar_t, 5>();
-        auto odata = grad_output.packed_accessor64<scalar_t, 5>();
+        auto idata = grad_input.data_ptr<scalar_t>();
+        auto odata = grad_output.data_ptr<scalar_t>();
 
         const accscalar_t rdepth = area_pixel_compute_scale<accscalar_t>(
             input_depth, output_depth, align_corners, scales_d);
@@ -349,11 +374,17 @@ static void upsample_trilinear3d_backward_out_cuda_template(
             input_width, output_width, align_corners, scales_w);
 
         upsample_trilinear3d_backward_out_frame<scalar_t, accscalar_t>
-            <<<cuda::ATenCeilDiv(num_kernels, num_threads),
+            <<<cuda::ATenCeilDiv(num_kernels, static_cast<size_t>(num_threads)),
                num_threads,
                0,
                stream>>>(
-                num_kernels,
+                nbatch * channels,
+                input_depth,
+                input_height,
+                input_width,
+                output_depth,
+                output_height,
+                output_width,
                 rdepth,
                 rheight,
                 rwidth,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/44206

This PR basically follows the diff in https://github.com/pytorch/pytorch/pull/21879 for upsampling bilinear.

For the script provided in #44206 , on my 2070 super GPU, the total timing I got (time in second)

| | non-amp | amp |
|---|---|---|
| before PR | 2.88 | 9.6 |
| after PR | 1.5 | 1.6 |

kernel time after PR
| | time | kernel |
| --- | --- | --- |
| non-amp | 0.37 ms | `void at::native::(anonymous namespace)::upsample_trilinear3d_backward_out_frame<float, float>(unsigned long, int, int, int, int, int, int, float, float, float, bool, float*, float const*) ` |
| amp | 0.61 ms | `void at::native::(anonymous namespace)::upsample_trilinear3d_backward_out_frame<c10::Half, float>(unsigned long, int, int, int, int, int, int, float, float, float, bool, c10::Half*, c10::Half const*)` |