### PR TITLE
Fix index parsing on Python-3.9

### DIFF
--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -723,9 +723,7 @@ class ExprBuilder(Builder):
             if isinstance(expr.slice.value, ast.Tuple):
                 # N-dimensional indexing using Tuple: x[(i, j, k)] is equivalent to x[i, j, k]
                 # XXX: Indexing using a list is **different**! It triggers advanced indexing.
-                indices = []
-                for index_expr in expr.slice.value.elts:
-                    indices.append(build_expr(ctx, index_expr))
+                indices = [build_expr(ctx, index_expr) for index_expr in expr.slice.value.elts]
                 return Subscript(base, indices)
             else:
                 return Subscript(base, [build_expr(ctx, expr.slice.value)])
@@ -733,6 +731,17 @@ class ExprBuilder(Builder):
             return Subscript(base, [build_SliceExpr(ctx, base, expr.slice)])
         elif sub_type is ast.ExtSlice:
             return Subscript(base, build_ExtSlice(ctx, base, expr.slice))
+        elif sys.version_info >= (3, 9):  # In Python3.9 array indicies are not wrapped in ast.Index
+            if sub_type is ast.Tuple:
+                # N-dimensional indexing using Tuple: x[(i, j, k)] is equivalent to x[i, j, k]
+                indices = []
+                for index_expr in expr.slice.elts:
+                    if isinstance(index_expr, ast.Slice):
+                        indices.append(build_SliceExpr(ctx, base, index_expr))
+                    else:
+                        indices.append(build_expr(ctx, index_expr))
+                return Subscript(base, indices)
+            return Subscript(base, [build_expr(ctx, expr.slice)])
         else:  # Ellipsis (can only happen in Python 2)
             raise NotSupportedError(base.range(), "ellipsis is not supported")
 


### PR DESCRIPTION
In 3.9, `ast.Index` and `ast.ExtSlice` are deprecated, so:
-  `ast.parse('img[3]', model='eval')` evaluates to 
`Expression(body=Subscript(value=Name(id='img'), slice=Constant(value=3)))` by 3.9, 
but was previously evaluated to `Expression(body=Subscript(value=Name(id='img'), slice=Index(value=Num(n=3))))`
- and `ast.parse('img[..., 10:20]', mode='eval')` is evaluated to
`
Subscript(value=Name(id='img'),slice=Tuple(elts=[Constant(value=Ellipsis),Slice(lower=Constant(value=10), upper=Constant(value=20))]))
`
, but was evaluated to
`
Subscript(value=Name(id='img'), slice=ExtSlice(dims=[Index(value=Ellipsis()), Slice(lower=Num(n=10), upper=Num(n=20), step=None)]))
`

Fixes https://github.com/pytorch/pytorch/issues/48674