### PR TITLE
[PyTorch] Avoid refcount decrement in alias_with_sizes_and_strides

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -861,23 +861,20 @@ Tensor alias_with_sizes_and_strides(
     const Tensor& self,
     const c10::IntArrayRef sizes,
     const c10::IntArrayRef strides) {
-  Tensor self_;
+  c10::intrusive_ptr<TensorImpl> impl;
   if (self.is_quantized()) {
-    auto impl = c10::make_intrusive<QTensorImpl>(
+    impl = c10::make_intrusive<QTensorImpl>(
         Storage(self.storage()),
         self.key_set(),
         self.dtype(),
         get_qtensorimpl(self)->quantizer());
-    impl->set_storage_offset(self.storage_offset());
-    impl->set_sizes_and_strides(sizes, strides);
-    self_ = Tensor(std::move(impl));
   } else {
-    auto impl = c10::make_intrusive<TensorImpl>(
+    impl = c10::make_intrusive<TensorImpl>(
         Storage(self.storage()), self.key_set(), self.dtype());
-    impl->set_storage_offset(self.storage_offset());
-    impl->set_sizes_and_strides(sizes, strides);
-    self_ = Tensor(std::move(impl));
   }
+  impl->set_storage_offset(self.storage_offset());
+  impl->set_sizes_and_strides(sizes, strides);
+  Tensor self_(std::move(impl));
   namedinference::propagate_names(self_, self);
   return self_;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48678 [PyTorch] Avoid refcount decrement in alias_with_sizes_and_strides**

The previous code created a temporary `Tensor`, which means
that we had an atomic reference count decrement (expensive!) to
destroy its inner `c10::intrusive_ptr`. Now, we instead create a
temporary `c10::intrusive_ptr` that we ensure is null by destruction
time, avoiding the expensive atomic operation. (`self_` should not be
destroyed because of NRVO.)

Differential Revision: [D25258631](https://our.internmc.facebook.com/intern/diff/D25258631/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D25258631/)!