### PR TITLE
Move var and std overloads to Functions.cpp and remove native:: reference

### DIFF
--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -8,19 +8,19 @@
 namespace at {
 
 Tensor var(const Tensor& self, int dim) {
-  return at::native::var(self, IntArrayRef{dim});
+  return at::var(self, IntArrayRef{dim});
 }
 
 std::tuple<Tensor,Tensor> var_mean(const Tensor& self, int dim) {
-  return at::native::var_mean(self, IntArrayRef{dim});
+  return at::var_mean(self, IntArrayRef{dim});
 }
 
 Tensor std(const Tensor& self, int dim) {
-  return at::native::std(self, IntArrayRef{dim});
+  return at::std(self, IntArrayRef{dim});
 }
 
 std::tuple<Tensor,Tensor> std_mean(const Tensor& self, int dim) {
-  return at::native::std_mean(self, IntArrayRef{dim});
+  return at::std_mean(self, IntArrayRef{dim});
 }
 
 ${function_definitions}

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -7,6 +7,22 @@
 
 namespace at {
 
+Tensor var(const Tensor& self, int dim) {
+  return at::native::var(self, IntArrayRef{dim});
+}
+
+std::tuple<Tensor,Tensor> var_mean(const Tensor& self, int dim) {
+  return at::native::var_mean(self, IntArrayRef{dim});
+}
+
+Tensor std(const Tensor& self, int dim) {
+  return at::native::std(self, IntArrayRef{dim});
+}
+
+std::tuple<Tensor,Tensor> std_mean(const Tensor& self, int dim) {
+  return at::native::std_mean(self, IntArrayRef{dim});
+}
+
 ${function_definitions}
 
 }

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -24,21 +24,10 @@ ${function_declarations}
 // Special C++ only overloads for std()-like functions (See gh-40287)
 // These are needed because int -> bool conversion takes precedence over int -> IntArrayRef
 // So, for example std(0) would select the std(unbiased=False) overload
-inline Tensor var(const Tensor& self, int dim) {
-  return at::native::var(self, IntArrayRef{dim});
-}
-
-inline std::tuple<Tensor,Tensor> var_mean(const Tensor& self, int dim) {
-  return at::native::var_mean(self, IntArrayRef{dim});
-}
-
-inline Tensor std(const Tensor& self, int dim) {
-  return at::native::std(self, IntArrayRef{dim});
-}
-
-inline std::tuple<Tensor,Tensor> std_mean(const Tensor& self, int dim) {
-  return at::native::std_mean(self, IntArrayRef{dim});
-}
+CAFFE2_API Tensor var(const Tensor& self, int dim);
+CAFFE2_API std::tuple<Tensor,Tensor> var_mean(const Tensor& self, int dim);
+CAFFE2_API Tensor std(const Tensor& self, int dim);
+CAFFE2_API std::tuple<Tensor,Tensor> std_mean(const Tensor& self, int dim);
 
 namespace {
   inline std::vector<int64_t> zero_sizes(const TensorOptions& options) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48687 Delete NativeFunctions.h include from Functions.h
* **#48683 Move var and std overloads to Functions.cpp and remove native:: reference**
* #48659 Refactor TensorIterator to do allocations via MetaBase::set_output
* #48195 Move argument grouping into FunctionSchema
* #48182 Refactor argument fields in FunctionSchema to Arguments
* #48116 Structured kernels generate Meta registrations

I want to delete NativeFunctions.h from Functions.h header. To do this I must remove all references to native:: However; I also must avoid trampling over iseeyuan's work of making ATen compilable without reference to ATen_cpu. In this particular case, I fix the Functions.h problem by moving it to a cpp file, and removing the native:: short-circuit (ostensibly there for performances). This also fixes a hypothetical correctness bug where these would not dispatch properly if the underlying functions no longer uniformly used a single native:: implementation.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D25261843](https://our.internmc.facebook.com/intern/diff/D25261843)