### PR TITLE
Add complex support to broadcast_coalesced

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 
 
+
 def _type(self, dtype=None, non_blocking=False, **kwargs):
     """Returns the type if `dtype` is not provided, else casts this object to
     the specified type.
@@ -491,3 +492,12 @@ def _get_device_index(device, optional=False, allow_cpu=False) -> int:
             raise ValueError('Expected a torch.device with a specified index '
                              'or an integer, but got:{}'.format(device))
     return device_idx
+
+
+def _handle_complex(tensor):
+    """
+    Returns a real view of a tensor if complex dtype else just the tensor
+    need to check if a UninitializedParameter because otherwise checking is_complex is an error for a LazyModule
+    """
+    return torch.view_as_real(tensor) if not isinstance(tensor,
+                                                        torch.nn.UninitializedParameter) and tensor.is_complex() else tensor

--- a/torch/nn/parallel/comm.py
+++ b/torch/nn/parallel/comm.py
@@ -2,9 +2,8 @@ import warnings
 import torch
 from torch.cuda import nccl
 from torch._utils import _take_tensors, _flatten_dense_tensors, \
-    _unflatten_dense_tensors, _reorder_tensors_as, _get_device_index
+    _unflatten_dense_tensors, _reorder_tensors_as, _get_device_index, _handle_complex
 from typing import List
-
 
 def broadcast(tensor, devices=None, *, out=None):
     r"""Broadcasts a tensor to specified GPU devices.
@@ -27,6 +26,7 @@ def broadcast(tensor, devices=None, *, out=None):
             a tuple containing :attr:`out` tensors, each containing a copy of
             :attr:`tensor`.
     """
+    tensor = _handle_complex(tensor)
     if not ((devices is None) ^ (out is None)):
         raise RuntimeError(
             "Exactly one of 'devices' and 'out' must be specified, but got "
@@ -54,6 +54,7 @@ def broadcast_coalesced(tensors, devices, buffer_size=10485760):
         A tuple containing copies of :attr:`tensor`, placed on :attr:`devices`.
     """
     devices = [_get_device_index(d) for d in devices]
+    tensors = [_handle_complex(t) for t in tensors]
     return torch._C._broadcast_coalesced(tensors, devices, buffer_size)
 
 
@@ -182,6 +183,7 @@ def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=
             a tuple containing :attr:`out` tensors, each containing a chunk of
             :attr:`tensor`.
     """
+    tensor = _handle_complex(tensor)
     if out is None:
         devices = [_get_device_index(d) for d in devices]
         return tuple(torch._C._scatter(tensor, devices, chunk_sizes, dim, streams))
@@ -195,6 +197,7 @@ def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=
                 "'chunk_sizes' must not be specified when 'out' is specified, "
                 "but got chunk_sizes={}".format(chunk_sizes))
         return tuple(torch._C._scatter_out(tensor, out, dim, streams))
+
 
 def gather(tensors, dim=0, destination=None, *, out=None):
     r"""Gathers tensors from multiple GPU devices.
@@ -222,6 +225,7 @@ def gather(tensors, dim=0, destination=None, *, out=None):
             the :attr:`out` tensor, now containing results of concatenating
             :attr:`tensors` along :attr:`dim`.
     """
+    tensors = [_handle_complex(t) for t in tensors]
     if out is None:
         if destination == -1:
             warnings.warn(


### PR DESCRIPTION
Fixes #47330

Add support for DataParallel complex tensors by handling them as `torch.view_as_real` for `broadcast_coalesced`, `scatter` and `gather`


