### PR TITLE
Delete NativeFunctions.h include from Functions.h

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -5,6 +5,10 @@
 #include <ATen/ExpandUtils.h>
 #include <ATen/Functions.h>
 
+// TODO: try to remove this
+// There is some back story, see https://github.com/pytorch/pytorch/issues/48684
+#include <ATen/NativeFunctions.h>
+
 namespace at {
 namespace indexing {
 

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -18,6 +18,29 @@
 
 namespace at {
 
+// These functions are defined in ATen/Utils.cpp.
+#define TENSOR(T, S)                                                          \
+  CAFFE2_API Tensor tensor(ArrayRef<T> values, const TensorOptions& options); \
+  inline Tensor tensor(                                                       \
+      std::initializer_list<T> values, const TensorOptions& options) {        \
+    return at::tensor(ArrayRef<T>(values), options);                          \
+  }                                                                           \
+  inline Tensor tensor(T value, const TensorOptions& options) {               \
+    return at::tensor(ArrayRef<T>(value), options);                           \
+  }                                                                           \
+  inline Tensor tensor(ArrayRef<T> values) {                                  \
+    return at::tensor(std::move(values), at::dtype(k##S));                    \
+  }                                                                           \
+  inline Tensor tensor(std::initializer_list<T> values) {                     \
+    return at::tensor(ArrayRef<T>(values));                                   \
+  }                                                                           \
+  inline Tensor tensor(T value) {                                             \
+    return at::tensor(ArrayRef<T>(value));                                    \
+  }
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
+AT_FORALL_COMPLEX_TYPES(TENSOR)
+#undef TENSOR
+
 ${function_declarations}
 
 // Special C++ only overloads for std()-like functions (See gh-40287)

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -7,7 +7,6 @@
 #include <c10/core/Storage.h>
 #include <ATen/core/Generator.h>
 #include <c10/util/Deprecated.h>
-#include <ATen/NativeFunctions.h> // TODO: try to delete this
 #include <ATen/DeviceGuard.h>
 #include <c10/core/TensorOptions.h>
 #include <ATen/core/Reduction.h>

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -23,29 +23,6 @@ struct Type;
 } // namespace at
 
 namespace at {
-// These functions are defined in ATen/Utils.cpp.
-#define TENSOR(T, S)                                                          \
-  CAFFE2_API Tensor tensor(ArrayRef<T> values, const TensorOptions& options); \
-  inline Tensor tensor(                                                       \
-      std::initializer_list<T> values, const TensorOptions& options) {        \
-    return at::tensor(ArrayRef<T>(values), options);                          \
-  }                                                                           \
-  inline Tensor tensor(T value, const TensorOptions& options) {               \
-    return at::tensor(ArrayRef<T>(value), options);                           \
-  }                                                                           \
-  inline Tensor tensor(ArrayRef<T> values) {                                  \
-    return at::tensor(std::move(values), at::dtype(k##S));                    \
-  }                                                                           \
-  inline Tensor tensor(std::initializer_list<T> values) {                     \
-    return at::tensor(ArrayRef<T>(values));                                   \
-  }                                                                           \
-  inline Tensor tensor(T value) {                                             \
-    return at::tensor(ArrayRef<T>(value));                                    \
-  }
-AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
-AT_FORALL_COMPLEX_TYPES(TENSOR)
-#undef TENSOR
-
 namespace native {
 
 ${native_function_declarations}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48687 Delete NativeFunctions.h include from Functions.h**
* #48683 Move var and std overloads to Functions.cpp and remove native:: reference
* #48659 Refactor TensorIterator to do allocations via MetaBase::set_output
* #48195 Move argument grouping into FunctionSchema
* #48182 Refactor argument fields in FunctionSchema to Arguments
* #48116 Structured kernels generate Meta registrations

Only one header needed to be updated to now include NativeFunctions.h

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D25261845](https://our.internmc.facebook.com/intern/diff/D25261845)