### PR TITLE
Adding SyncThreads in Cuda to honor dependences

### DIFF
--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -175,11 +175,9 @@ std::vector<const Expr*> getBoundExtents(
   return extents;
 }
 
-using BoundSet = std::unordered_set<Bound, BoundHash>;
-
 BoundSet convertBounds(
     const std::vector<TensorAccessBoundsInfo>& bounds,
-    TensorAccessKind filter = kMutate) {
+    TensorAccessKind filter) {
   BoundSet ret;
   for (auto& TABI : bounds) {
     if (filter == kMutate || TABI.kind == filter) {
@@ -194,7 +192,7 @@ BoundSet convertBounds(
 BoundSet convertBounds(
     BoundsInfo& bounds,
     const Buf* buf,
-    TensorAccessKind filter = kMutate) {
+    TensorAccessKind filter) {
   auto it = bounds.find(buf);
   if (it == bounds.end()) {
     return BoundSet();

--- a/torch/csrc/jit/tensorexpr/bounds_inference.h
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/jit/tensorexpr/bounds_overlap.h>
 #include <torch/csrc/jit/tensorexpr/mem_dependency_checker.h>
 
 namespace torch {
@@ -39,6 +40,17 @@ TORCH_API void printBoundsInfo(const BoundsInfo& v);
 
 TORCH_API std::vector<const Expr*> getBoundExtents(
     const std::vector<TensorAccessBoundsInfo>& infos);
+
+using BoundSet = std::unordered_set<analysis::Bound, analysis::BoundHash>;
+
+TORCH_API BoundSet convertBounds(
+    const std::vector<TensorAccessBoundsInfo>& bounds,
+    TensorAccessKind filter = kMutate);
+
+TORCH_API BoundSet convertBounds(
+    BoundsInfo& bounds,
+    const Buf* buf,
+    TensorAccessKind filter = kMutate);
 
 // The kind of dependency found, in increasing order of exclusivity.
 enum class HazardKind {


### PR DESCRIPTION
This PR handles dependences in Cuda by inserting `SyncThreads` in the code as appropriate and necessary.