### PR TITLE
Revert "Revert D25199264: Enable callgrind collection for C++ snippets"

### DIFF
--- a/torch/utils/benchmark/utils/cpp_jit.py
+++ b/torch/utils/benchmark/utils/cpp_jit.py
@@ -3,6 +3,7 @@ import atexit
 import os
 import re
 import shutil
+import tempfile
 import textwrap
 import threading
 import uuid
@@ -30,8 +31,8 @@ SOURCE_ROOT = os.path.split(os.path.abspath(__file__))[0]
 # `setup` and `stmt` do not change, so we can reuse the executable from the
 # first pass through the loop.
 BUILD_ROOT = os.path.join(
-    torch._appdirs.user_cache_dir(appname="benchmark_utils_jit"),
-    f"build_{uuid.uuid4()}".replace("-", "")
+    tempfile.gettempdir(),
+    f"benchmark_utils_jit_build_{uuid.uuid4()}".replace("-", "")
 )
 
 # BACK_TESTING_NOTE:
@@ -141,3 +142,13 @@ def compile_timeit_template(stmt: str, setup: str) -> TimeitModuleType:
     module = _compile_template(stmt, setup, src, is_standalone=False)
     assert isinstance(module, TimeitModuleType)
     return module
+
+
+def compile_callgrind_template(stmt: str, setup: str) -> str:
+    template_path: str = os.path.join(SOURCE_ROOT, "valgrind_wrapper", "timer_callgrind_template.cpp")
+    with open(template_path, "rt") as f:
+        src: str = f.read()
+
+    target = _compile_template(stmt, setup, src, is_standalone=True)
+    assert isinstance(target, str)
+    return target

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -421,15 +421,15 @@ class Timer(object):
         if not isinstance(self._task_spec.stmt, str):
             raise ValueError("`collect_callgrind` currently only supports string `stmt`")
 
-        if self._language != Language.PYTHON:
-            raise NotImplementedError("C++ Callgrind is later in the stack.")
-
         # Check that the statement is valid. It doesn't guarantee success, but it's much
         # simpler and quicker to raise an exception for a faulty `stmt` or `setup` in
         # the parent process rather than the valgrind subprocess.
         self._timer.timeit(1)
+        is_python = (self._language == Language.PYTHON)
+        assert is_python or not self._globals
         return valgrind_timer_interface.wrapper_singleton().collect_callgrind(
             task_spec=self._task_spec,
             globals=self._globals,
             number=number,
-            collect_baseline=collect_baseline)
+            collect_baseline=collect_baseline and is_python,
+            is_python=is_python)

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
@@ -1,0 +1,47 @@
+/* C++ template for Timer.collect_callgrind
+
+This template will be consumed by `cpp_jit.py`, and will replace:
+    `SETUP_TEMPLATE_LOCATION`
+      and
+    `STMT_TEMPLATE_LOCATION`
+sections with user provided statements.
+*/
+
+#include <string>
+
+#include <callgrind.h>
+#include <torch/torch.h>
+
+#if defined(NVALGRIND)
+static_assert(false);
+#endif
+
+int main(int argc, char* argv[]) {
+    // This file should only be called inside of `Timer`, so we can adopt a
+    // very simple and rigid argument parsing scheme.
+    TORCH_CHECK(argc == 7);
+    TORCH_CHECK(std::string(argv[1]) == "--number");
+    auto number = std::stoi(argv[2]);
+
+    TORCH_CHECK(std::string(argv[3]) == "--number_warmup");
+    auto number_warmup = std::stoi(argv[4]);
+
+    TORCH_CHECK(std::string(argv[5]) == "--number_threads");
+    auto number_threads = std::stoi(argv[6]);
+    torch::set_num_threads(number_threads);
+
+    // Setup
+    // SETUP_TEMPLATE_LOCATION
+
+    // Warmup
+    for (int i = 0; i < number_warmup; i++) {
+        // STMT_TEMPLATE_LOCATION
+    }
+
+    // Main loop
+    CALLGRIND_TOGGLE_COLLECT;
+    for (int i = 0; i < number; i++) {
+        // STMT_TEMPLATE_LOCATION
+    }
+    CALLGRIND_TOGGLE_COLLECT;
+}

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -483,10 +483,13 @@ class _ValgrindWrapper(object):
         task_spec: common.TaskSpec,
         globals: Dict[str, Any],
         number: int,
-        collect_baseline: bool
+        collect_baseline: bool,
+        is_python: bool,
     ) -> CallgrindStats:
         """Collect stats, and attach a reference run which can be used to filter interpreter overhead."""
         self._validate()
+        assert is_python or not collect_baseline
+
         baseline_inclusive_stats = FunctionCounts((), inclusive=True)
         baseline_exclusive_stats = FunctionCounts((), inclusive=False)
         if collect_baseline:
@@ -496,15 +499,17 @@ class _ValgrindWrapper(object):
                     common.TaskSpec(
                         stmt="pass",
                         setup="pass",
-                        num_threads=task_spec.num_threads
+                        num_threads=task_spec.num_threads,
                     ),
                     globals={},
                     number=number,
+                    is_python=True,
                 )
             baseline_inclusive_stats, baseline_exclusive_stats = \
                 self._baseline_cache[cache_key]
 
-        stmt_inclusive_stats, stmt_exclusive_stats = self._invoke(task_spec, globals, number)
+        stmt_inclusive_stats, stmt_exclusive_stats = self._invoke(
+            task_spec, globals, number, is_python)
         return CallgrindStats(
             task_spec=task_spec,
             number_per_run=number,
@@ -520,6 +525,7 @@ class _ValgrindWrapper(object):
         task_spec: common.TaskSpec,
         globals: Dict[str, Any],
         number: int,
+        is_python: bool,
     ) -> Tuple[FunctionCounts, FunctionCounts]:
         """Core invocation method for Callgrind collection.
 
@@ -565,20 +571,34 @@ class _ValgrindWrapper(object):
                 f_stdout_stderr.close()
 
         try:
-            if self._bindings_module is not None:
-                shutil.copy(
-                    self._bindings_module.__file__,
-                    os.path.join(working_dir, os.path.split(self._bindings_module.__file__)[1])
-                )
+            if is_python:
+                if self._bindings_module is not None:
+                    shutil.copy(
+                        self._bindings_module.__file__,
+                        os.path.join(working_dir, os.path.split(self._bindings_module.__file__)[1])
+                    )
 
-            with open(script_file, "wt") as f:
-                f.write(self._construct_script(
-                    task_spec,
-                    globals=GlobalsBridge(globals, data_dir),
-                    number=number,
-                    error_log=error_log,
-                    stat_log=stat_log,
-                    bindings=self._bindings_module))
+                script_file = os.path.join(working_dir, "timer_callgrind.py")
+                with open(script_file, "wt") as f:
+                    f.write(self._construct_script(
+                        task_spec,
+                        globals=GlobalsBridge(globals, data_dir),
+                        number=number,
+                        error_log=error_log,
+                        stat_log=stat_log,
+                        bindings=self._bindings_module))
+                run_loop_cmd = ["python", script_file]
+            else:
+                run_loop_exec = cpp_jit.compile_callgrind_template(
+                    task_spec.stmt,
+                    task_spec.setup,
+                )
+                run_loop_cmd = [
+                    run_loop_exec,
+                    "--number", str(number),
+                    "--number_warmup", str(min(number, 10)),
+                    "--number_threads", str(task_spec.num_threads),
+                ]
 
             valgrind_invocation, valgrind_invocation_output = run([
                 "valgrind",
@@ -588,9 +608,7 @@ class _ValgrindWrapper(object):
                 "--dump-instr=yes",
                 "--instr-atstart=yes",
                 "--collect-atstart=no",
-                "python",
-                script_file,
-            ])
+            ] + run_loop_cmd)
 
             if valgrind_invocation.returncode:
                 error_report = ""

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1393,6 +1393,9 @@ def _prepare_ldflags(extra_ldflags, with_cuda, verbose, is_standalone):
         if not is_standalone:
             extra_ldflags.append('-ltorch_python')
 
+        if is_standalone and "TBB" in torch.__config__.parallel_info():
+            extra_ldflags.append('-ltbb')
+
         if is_standalone:
             extra_ldflags.append(f"-Wl,-rpath,{TORCH_LIB_PATH}")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48720 Revert "Revert D25199264: Enable callgrind collection for C++ snippets"**

This reverts commit 6646ff122d3215b77909f669fc26cf6a927030db.

Differential Revision: [D25273994](https://our.internmc.facebook.com/intern/diff/D25273994)