### PR TITLE
Delete "-b" flag from pip install command

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -265,7 +265,7 @@ fi
 ###############################################################################
 
 # Install ONNX into a local directory
-pip install --user -b /tmp/pip_install_onnx "file://${ROOT_DIR}/third_party/onnx#egg=onnx"
+pip install --user "file://${ROOT_DIR}/third_party/onnx#egg=onnx"
 
 report_compile_cache_stats
 


### PR DESCRIPTION
"--build <dir>" flag has been deprecated for a while and finally removed in pip-20.3

Before this PR is applied, every change to docker images would result in ONNX failures
