### PR TITLE
Generalize some TensorIterator consumers to take TensorIteratorBase

### DIFF
--- a/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
+++ b/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
@@ -90,7 +90,7 @@ struct TrivialOffsetCalculator {
 };
 
 template<int N>
-static OffsetCalculator<N> make_offset_calculator(const at::TensorIterator& iter) {
+static OffsetCalculator<N> make_offset_calculator(const at::TensorIteratorBase& iter) {
   AT_ASSERT(N <= iter.ntensors());
   std::array<const int64_t*, N> strides;
   for (int i = 0; i < N; i++) {

--- a/aten/src/ATen/native/TensorIteratorDynamicCasting.h
+++ b/aten/src/ATen/native/TensorIteratorDynamicCasting.h
@@ -26,7 +26,7 @@ namespace at { namespace native {
 // (and returns) of func_t
 template<typename func_t, int nargs=function_traits<func_t>::arity>
 struct needs_dynamic_casting {
-  static bool check(TensorIterator& iter) {
+  static bool check(TensorIteratorBase& iter) {
     using traits = function_traits<func_t>;
     using cpp_type = typename traits::template arg<nargs - 1>::type;
     using cpp_map = c10::CppTypeToScalarType<cpp_type>;
@@ -40,7 +40,7 @@ struct needs_dynamic_casting {
 
 template<typename func_t>
 struct needs_dynamic_casting<func_t, 0> {
-  static bool check(TensorIterator& iter) {
+  static bool check(TensorIteratorBase& iter) {
     using traits = function_traits<func_t>;
     using cpp_type = typename traits::result_type;
 

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -185,7 +185,7 @@ static inline void unroll_contiguous_scalar_checks(
 }
 
 template <typename func_t>
-void cpu_kernel(TensorIterator& iter, func_t&& op) {
+void cpu_kernel(TensorIteratorBase& iter, func_t&& op) {
   using traits = function_traits<func_t>;
   // this could be extended to work with void return types
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity);
@@ -207,7 +207,7 @@ void cpu_kernel(TensorIterator& iter, func_t&& op) {
 }
 
 template <bool check_dynamic_cast=true, typename func_t, typename vec_func_t>
-void cpu_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop) {
+void cpu_kernel_vec(TensorIteratorBase& iter, func_t&& op, vec_func_t&& vop) {
   using traits = function_traits<func_t>;
   // this could be extended to work with void return types
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity);
@@ -236,7 +236,7 @@ void cpu_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop) {
 }
 
 template <typename func_t>
-void cpu_serial_kernel(TensorIterator& iter, func_t&& op, const Range& range) {
+void cpu_serial_kernel(TensorIteratorBase& iter, func_t&& op, const Range& range) {
   using traits = function_traits<func_t>;
   constexpr bool result_void = std::is_void<typename traits::result_type>::value;
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity &&
@@ -258,12 +258,12 @@ void cpu_serial_kernel(TensorIterator& iter, func_t&& op, const Range& range) {
 }
 
 template <typename func_t>
-void cpu_serial_kernel(TensorIterator& iter, func_t&& op) {
+void cpu_serial_kernel(TensorIteratorBase& iter, func_t&& op) {
   cpu_serial_kernel(iter, op, {0, iter.numel()});
 }
 
 template <typename func_t, typename vec_func_t>
-void cpu_serial_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop, const Range& range) {
+void cpu_serial_kernel_vec(TensorIteratorBase& iter, func_t&& op, vec_func_t&& vop, const Range& range) {
   using traits = function_traits<func_t>;
   // this could be extended to work with void return types
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity);
@@ -289,7 +289,7 @@ void cpu_serial_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop, 
 }
 
 template <typename func_t, typename vec_func_t>
-void cpu_serial_kernel_vec(TensorIterator& iter, func_t&& op, vec_func_t&& vop) {
+void cpu_serial_kernel_vec(TensorIteratorBase& iter, func_t&& op, vec_func_t&& vop) {
   cpu_serial_kernel_vec(iter, op, vop, {0, iter.numel()});
 }
 

--- a/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
@@ -18,7 +18,7 @@ struct AddFunctor {
     scalar_t alpha;
 };
 
-void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
+void add_kernel_cuda(TensorIteratorBase& iter, Scalar alpha_scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
     AddFunctor<scalar_t> f(alpha_scalar.to<scalar_t>());
     gpu_kernel_with_scalars(iter, f);

--- a/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
@@ -18,7 +18,7 @@ struct AddFunctor {
     scalar_t alpha;
 };
 
-void add_kernel_cuda(TensorIteratorBase& iter, Scalar alpha_scalar) {
+void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
     AddFunctor<scalar_t> f(alpha_scalar.to<scalar_t>());
     gpu_kernel_with_scalars(iter, f);

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -131,7 +131,7 @@ static inline void launch_unrolled_kernel(int64_t N, const func_t& f, array_t da
 }
 
 template <typename func_t>
-void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
+void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
   using traits = function_traits<func_t>;
   using arg0_t = typename traits::result_type;
   constexpr int ntensors = traits::arity + 1;

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -20,7 +20,7 @@ constexpr int block_work_size = BLOCK_WORK_SIZE;
 namespace at { namespace native {
 
 template<int N>
-static OffsetCalculator<N> make_input_offset_calculator(const TensorIterator& iter) {
+static OffsetCalculator<N> make_input_offset_calculator(const TensorIteratorBase& iter) {
   // array size can not be 0, this happens when N == 0
   constexpr int array_size = std::max<int>(N, 1);
   TORCH_INTERNAL_ASSERT(N == iter.ntensors() - iter.noutputs());
@@ -34,7 +34,7 @@ static OffsetCalculator<N> make_input_offset_calculator(const TensorIterator& it
 }
 
 template <int num_outputs = 1>
-static OffsetCalculator<num_outputs> make_output_offset_calculator(const TensorIterator& iter) {
+static OffsetCalculator<num_outputs> make_output_offset_calculator(const TensorIteratorBase& iter) {
   TORCH_INTERNAL_ASSERT(num_outputs == iter.noutputs());
   std::array<const int64_t*, num_outputs> strides;
   int64_t element_sizes[num_outputs];
@@ -88,7 +88,7 @@ __device__ inline void elementwise_kernel_helper(func_t f, policy_t policy) {
 namespace at { namespace native {
 
 template <typename func_t>
-void gpu_kernel(TensorIterator& iter, const func_t& f) {
+void gpu_kernel(TensorIteratorBase& iter, const func_t& f) {
 
   for (int arg = 0; arg < iter.ntensors(); arg++) {
     TORCH_INTERNAL_ASSERT(iter.device(arg).is_cuda());
@@ -139,7 +139,7 @@ struct BUnaryFunctor {
 };
 
 template <typename func_t>
-void gpu_kernel_with_scalars(TensorIterator& iter, const func_t& f) {
+void gpu_kernel_with_scalars(TensorIteratorBase& iter, const func_t& f) {
   TORCH_INTERNAL_ASSERT(iter.ntensors() == 3);
 
   using traits = function_traits<func_t>;
@@ -187,7 +187,7 @@ static inline void launch_unrolled_kernel_for_multi_outputs(int64_t N, const fun
 }
 
 template <typename func_t>
-void gpu_kernel_multiple_outputs_impl(TensorIterator& iter, const func_t& f) {
+void gpu_kernel_multiple_outputs_impl(TensorIteratorBase& iter, const func_t& f) {
   using traits = function_traits<func_t>;
   using output_t = typename traits::result_type;
   static_assert(is_tuple<output_t>::value, "f's return type must be `thrust::tuple`");
@@ -218,7 +218,7 @@ void gpu_kernel_multiple_outputs_impl(TensorIterator& iter, const func_t& f) {
 } // namespace
 
 template <typename func_t>
-void gpu_kernel_multiple_outputs(TensorIterator& iter, const func_t& f) {
+void gpu_kernel_multiple_outputs(TensorIteratorBase& iter, const func_t& f) {
   ASSERT_HOST_DEVICE_LAMBDA(func_t);
 
   for (int arg = 0; arg < iter.ntensors(); arg++) {

--- a/aten/src/ATen/native/cuda/ROCmLoops.cuh
+++ b/aten/src/ATen/native/cuda/ROCmLoops.cuh
@@ -306,7 +306,7 @@ static void launch_kernel(int64_t N, const func_t& f, array_t data) {}
 
 
 template <typename func_t>
-void gpu_kernel_impl(TensorIterator& iter, const func_t& f) {
+void gpu_kernel_impl(TensorIteratorBase& iter, const func_t& f) {
   using traits = function_traits<func_t>;
   using arg0_t = typename traits::result_type;
   constexpr int ntensors = traits::arity + 1;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48718 Class-based structured kernels, with migration of add to framework
* #48728 Header cleanup
* #48731 Fix code review from #48659 and #48116
* **#48727 Generalize some TensorIterator consumers to take TensorIteratorBase**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D25278033](https://our.internmc.facebook.com/intern/diff/D25278033)