### PR TITLE
[JIT] Fix bug in get_annotation_str for ast.Subscript

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -238,7 +238,7 @@ def get_annotation_str(annotation):
     elif isinstance(annotation, ast.Attribute):
         return '.'.join([get_annotation_str(annotation.value), annotation.attr])
     elif isinstance(annotation, ast.Subscript):
-        return f"{annotation.value}[{get_annotation_str(annotation.slice.value)}]"  # type: ignore
+        return f"{get_annotation_str(annotation.value)}[{get_annotation_str(annotation.slice.value)}]"  # type: ignore
     elif isinstance(annotation, ast.Tuple):
         return ','.join([get_annotation_str(elt) for elt in annotation.elts])
     elif isinstance(annotation, ast.Constant) or isinstance(annotation, ast.NameConstant):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48741 [JIT] Fix bug in get_annotation_str for ast.Subscript**

**Summary**
This commit fixes a bug in the handling of `ast.Subscript` inside
`get_annotation_str`. `annotation.value` (which contains the AST node
representing the container name) should also be processed using
`get_annotation_str`.

**Test Plan**
This commit adds a unit test to `TestClassType` based on the test case
from the issue that reported this bug.

**Fixes**
This commit fixes #47570.

Differential Revision: [D25286013](https://our.internmc.facebook.com/intern/diff/D25286013)