### PR TITLE
[NNC] Add a non functional Tensor kind

### DIFF
--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -82,7 +82,7 @@ class CodeGen::BufferArg {
   BufferArg(const Placeholder& buffer)
       : var_(buffer.data()->base_handle()), dtype_(buffer.dtype()) {}
   BufferArg(Tensor* tensor)
-      : var_(tensor->buf()->base_handle()), dtype_(tensor->body()->dtype()) {}
+      : var_(tensor->buf()->base_handle()), dtype_(tensor->buf()->dtype()) {}
   BufferArg(const VarHandle& var)
       : var_(var.node()), dtype_(var.dtype()), isVar_(true) {}
 

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -596,6 +596,11 @@ std::string to_string(const Tensor* t) {
     return "(null tensor)\n";
   }
   std::ostringstream oss;
+  if (!t->body()) {
+    oss << "Tensor " << t->buf()->name_hint() << " = " << *t->ElementStmt()
+        << "\n";
+    return oss.str();
+  }
   oss << "Tensor " << t->buf()->name_hint() << "(";
   for (size_t i = 0; i < t->ndim(); i++) {
     if (i != 0) {

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -398,7 +398,11 @@ class DepTracker : public IRVisitor {
  public:
   std::vector<Tensor*> findUsedTensors(Tensor* tensor) {
     used_tensors.clear();
-    tensor->body()->accept(this);
+    if (tensor->body()) {
+      tensor->body()->accept(this);
+    } else {
+      tensor->ElementStmt()->accept(this);
+    }
     return used_tensors;
   }
 
@@ -504,6 +508,11 @@ LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
 
 Stmt* LoopNest::lowerToStmt(Tensor* t) {
   Stmt* body = t->ElementStmt();
+
+  // If this Tensor has no functional body, it already has its axes expanded.
+  if (nullptr == t->body()) {
+    return body;
+  }
 
   if (t->ndim() == 0 && t->reduce_ndim() == 0) {
     return body;

--- a/torch/csrc/jit/tensorexpr/tensor.cpp
+++ b/torch/csrc/jit/tensorexpr/tensor.cpp
@@ -86,7 +86,7 @@ Tensor* Compute(
   return new Tensor(func_name, dims, args_nodes, body);
 }
 
-Stmt* Tensor::ElementStmt() {
+Stmt* Tensor::ElementStmt() const {
   std::vector<const Expr*> indices;
   for (size_t i = 0; i < buf_->ndim(); i++) {
     indices.push_back(args_[i]);


### PR DESCRIPTION
Adds the CompoundTensor, a specialisation of the NNC Tensor which allows arbitrary production statements. This will allow lowering of aten ops into specific NNC IR patterns (which don't need to be functional) - allowing us to shortcut to the optimized form of common patterns.

This is part 1 of trying to clean up the lowering of aten::cat so it is easier to optimize.