### PR TITLE
Detect extraneous kernel launch checks

### DIFF
--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -6,7 +6,11 @@ import torch
 import random
 import math
 from typing import cast, List, Optional, Tuple, Union
-from .check_kernel_launches import check_cuda_kernel_launches, check_code_for_cuda_kernel_launches
+from .check_kernel_launches import (
+    check_cuda_kernel_launches,
+    check_code_for_cuda_kernel_launches,
+    check_code_for_cuda_kernel_launch_checks_without_launches
+)
 
 FileCheck = torch._C.FileCheck
 

--- a/torch/testing/check_kernel_launches.py
+++ b/torch/testing/check_kernel_launches.py
@@ -31,6 +31,14 @@ kernel_launch_regex = re.compile(r"""
     )             # End negative lookahead
 """, flags=re.MULTILINE | re.VERBOSE)
 
+# This identifies kernel launch checks that aren't paired with kernels
+unmatched_kernel_launch_regex = re.compile(r"""
+    C10_CUDA_KERNEL_LAUNCH_CHECK\(\); # Desired kernel launch guard
+    (?:                               # Non capturing group
+        (?!>>>).                      # Negative lookahead for ">>>" followed by a character
+    )*?                               # Repeat the group 0-Inf times as few times as possible
+    C10_CUDA_KERNEL_LAUNCH_CHECK\(\); # Kernel launch guard without a kernel
+""", flags=re.MULTILINE | re.VERBOSE | re.DOTALL)
 
 def check_code_for_cuda_kernel_launches(code, filename=None):
     """Checks code for CUDA kernel launches without cuda error checks.
@@ -58,6 +66,32 @@ def check_code_for_cuda_kernel_launches(code, filename=None):
     return len(results)
 
 
+def check_code_for_cuda_kernel_launch_checks_without_launches(code, filename=None):
+    """Checks code for CUDA kernel launch checks without kernel launches.
+       (That is, excess launch checks.)
+
+    Args:
+        filename - Filename of file containing the code. Used only for display
+                   purposes, so you can put anything here.
+        code     - The code to check
+
+    Returns:
+        The number of unmathced launch checks in the code
+    """
+    if filename is None:
+        filename = "##Python Function Call##"
+
+    # We break the code apart and put it back together to add
+    # helpful line numberings for identifying problem areas
+    code = enumerate(code.split("\n"))                             # Split by line breaks
+    code = [f"{lineno}: {linecode}" for lineno, linecode in code]  # Number the lines
+    code = '\n'.join(code)                                         # Put it back together
+
+    results = unmatched_kernel_launch_regex.findall(code)          # Search for unmatched checks
+    for r in results:
+        print(f"Extraneous C10_CUDA_KERNEL_LAUNCH_CHECK in '{filename}'. Context:\n{r}", file=sys.stderr)
+    return len(results)
+
 def check_file(filename):
     """Checks a file for CUDA kernel launches without cuda error checks
 
@@ -65,26 +99,29 @@ def check_file(filename):
         filename - File to check
 
     Returns:
-        The number of unsafe kernel launches in the file
+        A tuple: (# of unsafe kernel launches, # of extra launch checks)
     """
     if not (filename.endswith(".cu") or filename.endswith(".cuh")):
-        return 0
+        return 0, 0
     contents = open(filename, "r").read()
-    return check_code_for_cuda_kernel_launches(contents, filename)
-
+    missing_checks = check_code_for_cuda_kernel_launches(contents, filename)
+    extra_checks = check_code_for_cuda_kernel_launch_checks_without_launches(contents, filename)
+    return missing_checks, extra_checks
 
 def check_cuda_kernel_launches():
     """Checks all pytorch code for CUDA kernel launches without cuda error checks
 
     Returns:
-        The number of unsafe kernel launches in the codebase
+        A tuple: (# of unsafe kernel launches, # of extra launch checks)
     """
     torch_dir = os.path.dirname(os.path.realpath(__file__))
     torch_dir = os.path.dirname(torch_dir)  # Go up to parent torch
     torch_dir = os.path.dirname(torch_dir)  # Go up to parent caffe2
 
     kernels_without_checks = 0
+    extra_launch_checks = 0
     files_without_checks = []
+    files_with_extra_checks = []
     for root, dirnames, filenames in os.walk(torch_dir):
         # `$BASE/build` and `$BASE/torch/include` are generated
         # so we don't want to flag their contents
@@ -96,10 +133,13 @@ def check_cuda_kernel_launches():
 
         for x in filenames:
             filename = os.path.join(root, x)
-            file_result = check_file(filename)
-            if file_result > 0:
-                kernels_without_checks += file_result
+            this_missing_checks, this_extra_checks = check_file(filename)
+            kernels_without_checks += this_missing_checks
+            extra_launch_checks += this_extra_checks
+            if this_missing_checks > 0:
                 files_without_checks.append(filename)
+            if this_extra_checks > 0:
+                files_with_extra_checks.append(filename)
 
     if kernels_without_checks > 0:
         count_str = f"Found {kernels_without_checks} instances in " \
@@ -111,7 +151,17 @@ def check_cuda_kernel_launches():
             print(f"\t{x}", file=sys.stderr)
         print(count_str, file=sys.stderr)
 
-    return kernels_without_checks
+    if extra_launch_checks > 0:
+        count_str = f"Found {extra_launch_checks} instances in " \
+                    f"{len(files_with_extra_checks)} files with extraneous " \
+                    "kernel launch checks."
+        print(count_str, file=sys.stderr)
+        print("Files with extraneous kernel launch checks:", file=sys.stderr)
+        for x in files_with_extra_checks:
+            print(f"\t{x}", file=sys.stderr)
+        print(count_str, file=sys.stderr)
+
+    return kernels_without_checks, extra_launch_checks
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The code being modified detects CUDA kernels whose launches aren't provably being checked for failure. This extends that to locate extraneous instances of such checks.

These checks don't do anything valuable and are semantically misnamed if they don't follow a kernel launch, so it makes sense not to have them in the code.

Test Plan:
```
buck test //caffe2/test:kernel_launch_checks -- --print-passing-details
```

Differential Revision: D25286853

