### PR TITLE
[jit] expand buffer/param policy in cpp module to cover optional[tensor]

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3569,6 +3569,22 @@ def foo(x):
                     'parameters_r': ['P']}
         self.assertEqual(expected, result)
 
+    def test_module_register_optional_buffer(self):
+        class Net(torch.nn.Module):
+            buffer_0: Optional[torch.Tensor]
+
+            def __init__(self):
+                super(Net, self).__init__()
+                self.register_buffer("buffer_0", torch.zeros(1))
+
+            def forward(self, x):
+                return x
+
+        scripted_mod = torch.jit.script(Net())
+        for name, buffer in scripted_mod.named_buffers():
+            self.assertEqual(name, "buffer_0")
+            self.assertEqual(buffer, torch.zeros(1))
+
     def test_parameter_order(self):
         m = nn.Module()
         for i, name in enumerate(string.ascii_letters):

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -494,7 +494,8 @@ struct TORCH_API ParameterPolicy {
     return std::move(v).toTensor();
   }
   static bool valid(const ClassTypePtr& typ, size_t i, const IValue& v) {
-    return typ->is_parameter(i) && v.isTensor();
+    bool is_optional_tensor = v.isTensor() || v.isNone();
+    return typ->is_parameter(i) && is_optional_tensor;
   }
   static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = false;
 };
@@ -507,8 +508,8 @@ struct TORCH_API BufferPolicy {
     return std::move(v).toTensor();
   }
   static bool valid(const ClassTypePtr& typ, size_t i, const IValue& v) {
-    return typ->getAttribute(i)->isSubtypeOf(TensorType::get()) &&
-        !typ->is_parameter(i);
+    bool is_optional_tensor = v.isTensor() || v.isNone();
+    return typ->is_buffer(i) && !typ->is_parameter(i) && is_optional_tensor;
   }
   static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = false;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48756 [jit] expand buffer/param policy in cpp module to cover optional[tensor]**

as titled, this should match with the existing python APIs to accept
optional[tensor], and after scripting it shouldn't disappear