### PR TITLE
[DI] create a new key for threadLocalDebugInfo

### DIFF
--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -13,6 +13,7 @@ enum class C10_API_ENUM DebugInfoKind : uint8_t {
   PRODUCER_INFO = 0,
   MOBILE_RUNTIME_INFO,
   PROFILER_STATE,
+  INFERENCE_CONTEXT, // for inference usage
 
   TEST_INFO, // used only in tests
   TEST_INFO_2, // used only in tests


### PR DESCRIPTION
Summary: In distributed inference, we want to use a new type info to pass some information to operators. add a new key to threadLocalDebugInfo to unblock the development.

Test Plan: Only add a new key. Should have not effect on current build.

Differential Revision: D25291242

