### PR TITLE
[WIP] Do not use cuDNN persistent RNN if hidden_size==1024 when number of SM<80

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -600,6 +600,9 @@ namespace {
                                             const TensorDescriptorListParams& tensors) {
     auto bsize = tensors.mini_batch;
     cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
+    if (rnn.hidden_size == 1024 && prop->multiProcessorCount < 80) {
+      return false;
+    }
     if (prop->major == 7) {
       if (prop->minor == 5) {
         // Excludes Turing from using persistent rnn.


### PR DESCRIPTION
WIP, DO NOT MERGE.

While we were doing some internal testing for RNN with hidden size 1024, we got some weird exceptions. On GPUs with number of SM >= 80 (e.g. V100, A100), everything works fine. On GPUs with number of SM < 80 (e.g. RTX 2080Ti), cuDNN throws exception during backward calculations. 

We probably have to set heuristic for this case.