### PR TITLE
Fixing "naive" `forward` of `ModuleList` and `ModuleDict

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1206,6 +1206,18 @@ class TestNN(NNTestCase):
         module_list.extend(s.modules())
         check()
 
+        # verify the correct exception is thrown when calling ModuleList
+        try:
+            module_list()
+        except Exception as e:
+            self.assertIsInstance(e, NotImplementedError)
+        
+        try:
+            module_list(torch.rand(1,3))
+        except Exception as e:
+            self.assertIsInstance(e, NotImplementedError)
+
+
     def test_ModuleDict(self):
         modules = OrderedDict([
             ('act', nn.ReLU()),
@@ -1298,6 +1310,17 @@ class TestNN(NNTestCase):
         self.assertEqual(len(module_dict), 0)
         modules.clear()
         check()
+
+        # verify the correct exception is thrown when calling ModuleDict
+        try:
+            module_dict()
+        except Exception as e:
+            self.assertIsInstance(e, NotImplementedError)
+        
+        try:
+            module_dict(torch.rand(1,3))
+        except Exception as e:
+            self.assertIsInstance(e, NotImplementedError)
 
     def test_ParameterList(self):
         def make_param():

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -228,8 +228,7 @@ class ModuleList(Module):
             self.add_module(str(offset + i), module)
         return self
 
-    def forward(self):
-        raise NotImplementedError()
+    # remove forward alltogether to fallback on Module's _forward_unimplemented
 
 
 class ModuleDict(Module):
@@ -368,8 +367,7 @@ class ModuleDict(Module):
                                      "; 2 is required")
                 self[m[0]] = m[1]
 
-    def forward(self):
-        raise NotImplementedError()
+    # remove forward alltogether to fallback on Module's _forward_unimplemented
 
 
 class ParameterList(Module):


### PR DESCRIPTION
**Goal:** Making sure "calling"/"forwarding" a `ModuleList` or `ModuleDict` produce the intended `NotImpmentedError`.

**Current behavior:**  
Currently, when naively calling `forward`  user ends up with the confusing error message:
```python
TypeError: forward() takes 1 positional argument but 2 were given
```
Instead of the intended `NotImplementedError.`
This minor issue was brought up by @vadimkantorov in issue #37718 [here][1], also by a confused stackoverflow user [here][2].

**What this PR includes:**  
Remove `forward` altogether from `ModuleList` and `ModuleDict` to fall back on the `_forward_unimplemented` of `Module` that properly throws `NotImplementedError` regardless of input arguments.

Appropriate test was added to `test_nn.py`

Fixes previous PR #48698

Tested added according to @ngimel [request][3].

[1]: https://github.com/pytorch/pytorch/issues/37718#issuecomment-736333345
[2]: https://stackoverflow.com/q/65096679/1714410
[3]: https://github.com/pytorch/pytorch/pull/48698#issuecomment-737398693