### PR TITLE
Update torch.randint documentation to include missing note

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6819,7 +6819,7 @@ Example::
             [6, 7]])
 
 
-""".format(**factory_common_args))
+""".format(**merge_dicts(common_args, factory_like_common_args)))
 
 add_docstr(torch.randint_like,
            """

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6786,7 +6786,7 @@ between :attr:`low` (inclusive) and :attr:`high` (exclusive).
 
 The shape of the tensor is defined by the variable argument :attr:`size`.
 
-.. note:
+.. note::
     With the global dtype default (``torch.float32``), this function returns
     a tensor with dtype ``torch.int64``.
 
@@ -6819,7 +6819,7 @@ Example::
             [6, 7]])
 
 
-""".format(**merge_dicts(common_args, factory_like_common_args)))
+""".format(**factory_common_args))
 
 add_docstr(torch.randint_like,
            """


### PR DESCRIPTION
Fixes #46497

Includes note about returning dtype torch.int64.

Current documentation: https://pytorch.org/docs/stable/generated/torch.randint.html?highlight=randint#torch.randint
New documentation:
![image](https://user-images.githubusercontent.com/14858254/101196939-48977d00-3616-11eb-90a5-a7b706e8505f.png)

Test:
Built documentation and checked generated docs