### PR TITLE
Fix SortingKernel compilation with MSVC-16.8+

### DIFF
--- a/aten/src/ATen/native/CompositeRandomAccessorCommon.h
+++ b/aten/src/ATen/native/CompositeRandomAccessorCommon.h
@@ -129,7 +129,7 @@ public:
 
   // Pointer-like operations {
   C10_HOST_DEVICE
-  reference operator*() {
+  reference operator*() const {
     return TupleInfo::tie(*keys, *values);
   }
 


### PR DESCRIPTION
Add const qualifier to `CompositeRandomAccessor::operator*()`

Fixes a typical mismatch between "const iterator" and "const_iterator"

Fixes https://github.com/pytorch/pytorch/issues/48517
