### PR TITLE
[te] Fix spacing in graph dump

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -273,9 +273,9 @@ void removeProfileNodesAndSpecializeTypes(Block* b) {
 }
 
 void RemoveProfileNodesAndSpecializeTypes(std::shared_ptr<Graph>& graph) {
-  GRAPH_DEBUG("Before removeProfileNodesAndSpecializeTypes", *graph);
+  GRAPH_DEBUG("Before removeProfileNodesAndSpecializeTypes:\n", *graph);
   removeProfileNodesAndSpecializeTypes(graph->block());
-  GRAPH_DEBUG("After removeProfileNodesAndSpecializeTypes", *graph);
+  GRAPH_DEBUG("After removeProfileNodesAndSpecializeTypes:\n", *graph);
 }
 
 void removeTensorTypeSpecialization(Value* v) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48829 [te] Fix spacing in graph dump**

The first line was a run-on.

Differential Revision: [D25326136](https://our.internmc.facebook.com/intern/diff/D25326136/)