### PR TITLE
added tests for complex dtype support

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -339,6 +339,11 @@ class TestTensorCreation(TestCase):
         expected = torch.eye(4, dtype=torch.complex128)
         self.assertEqual(result, expected)
 
+        # Complex support for torch.diag
+        result = torch.diag(torch.ones(4, dtype=torch.complex128))
+        expected = torch.eye(4, dtype=torch.complex128)
+        self.assertEqual(result, expected)
+
     def test_block_diag(self, device):
         def block_diag_workaround(*arrs):
             arrs_expanded = []

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -339,7 +339,8 @@ class TestTensorCreation(TestCase):
         expected = torch.eye(4, dtype=torch.complex128)
         self.assertEqual(result, expected)
 
-        # Complex support for torch.diag
+     # Complex support for torch.diag
+    def test_diag_complex(self, device):
         result = torch.diag(torch.ones(4, dtype=torch.complex128))
         expected = torch.eye(4, dtype=torch.complex128)
         self.assertEqual(result, expected)


### PR DESCRIPTION
Fixes #48519 
It looked like complex dtype supported was already added for `[torch.diagflat]`(https://github.com/pytorch/pytorch/issues/47499) and it looks like `torch.diag `uses `torch.diagflat` , so I've added the tests for the same.