### PR TITLE
[tensorboard][writer] Add missing 'dataformats' argument to 'add_image' docs.

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -507,6 +507,8 @@ class SummaryWriter(object):
             global_step (int): Global step value to record
             walltime (float): Optional override default walltime (time.time())
               seconds after epoch of event
+            dataformats (string): Image data format specification of the form
+              CHW, HWC, HW, WH, etc.
         Shape:
             img_tensor: Default is :math:`(3, H, W)`. You can use ``torchvision.utils.make_grid()`` to
             convert a batch of tensor into 3xHxW format or call ``add_images`` and let us do the job.


### PR DESCRIPTION
The [torch.utils.tensorboard.SummaryWriter.add_image](https://pytorch.org/docs/stable/_modules/torch/utils/tensorboard/writer.html#SummaryWriter.add_image) is missing the argument `dataformats` in the docs.

This PR adds the missing argument to the docs (analogous to `add_images` docs).
