### PR TITLE
Fixing error: "member may not be initialized" due to constexpr at Windows 

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -2061,9 +2061,8 @@ TypePtr NamedValue::type() const {
   }
 }
 
-CONSTEXPR_EXCEPT_WIN_CUDA Symbol ProfileOp::Kind = ::c10::prim::profile;
-CONSTEXPR_EXCEPT_WIN_CUDA Symbol ProfileOptionalOp::Kind =
-    ::c10::prim::profile_optional;
+const Symbol ProfileOp::Kind = ::c10::prim::profile;
+const Symbol ProfileOptionalOp::Kind = ::c10::prim::profile_optional;
 
 OperatorSet::OperatorSet(std::initializer_list<const char*> sig_literals) {
   for (const char* sig : sig_literals) {

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -2061,8 +2061,9 @@ TypePtr NamedValue::type() const {
   }
 }
 
-constexpr Symbol ProfileOp::Kind;
-constexpr Symbol ProfileOptionalOp::Kind;
+CONSTEXPR_EXCEPT_WIN_CUDA Symbol ProfileOp::Kind = ::c10::prim::profile;
+CONSTEXPR_EXCEPT_WIN_CUDA Symbol ProfileOptionalOp::Kind =
+    ::c10::prim::profile_optional;
 
 OperatorSet::OperatorSet(std::initializer_list<const char*> sig_literals) {
   for (const char* sig : sig_literals) {

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1326,7 +1326,7 @@ inline const Graph* Value::owningGraph() const {
 
 /************* All nodes not required to be defined before Graph **************/
 struct ProfileOp : public Node {
-  static CONSTEXPR_EXCEPT_WIN_CUDA Symbol Kind;
+  static const Symbol Kind;
   ProfileOp(Graph* graph, std::function<void(std::vector<IValue>&)> callback)
       : Node(graph, ::c10::prim::profile), callback_(std::move(callback)) {}
 
@@ -1346,7 +1346,7 @@ struct ProfileOp : public Node {
 };
 
 struct TORCH_API ProfileOptionalOp : public Node {
-  static CONSTEXPR_EXCEPT_WIN_CUDA Symbol Kind;
+  static const Symbol Kind;
   ProfileOptionalOp(
       Graph* graph,
       std::function<void(std::vector<IValue>&)> callback)

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1326,7 +1326,7 @@ inline const Graph* Value::owningGraph() const {
 
 /************* All nodes not required to be defined before Graph **************/
 struct ProfileOp : public Node {
-  static CONSTEXPR_EXCEPT_WIN_CUDA Symbol Kind = ::c10::prim::profile;
+  static CONSTEXPR_EXCEPT_WIN_CUDA Symbol Kind;
   ProfileOp(Graph* graph, std::function<void(std::vector<IValue>&)> callback)
       : Node(graph, ::c10::prim::profile), callback_(std::move(callback)) {}
 
@@ -1346,7 +1346,7 @@ struct ProfileOp : public Node {
 };
 
 struct TORCH_API ProfileOptionalOp : public Node {
-  static CONSTEXPR_EXCEPT_WIN_CUDA Symbol Kind = ::c10::prim::profile_optional;
+  static CONSTEXPR_EXCEPT_WIN_CUDA Symbol Kind;
   ProfileOptionalOp(
       Graph* graph,
       std::function<void(std::vector<IValue>&)> callback)

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -209,7 +209,7 @@ class TORCH_API Pickler {
   // the left of a '::', its type cannot be deduced by the compiler so one must
   // explicitly instantiate the template, i.e. push<int>(int) works, push(int)
   // does not)
-  static constexpr size_t kBufferSize = 256;
+  static CONSTEXPR_EXCEPT_WIN_CUDA size_t kBufferSize = 256;
   template <typename T>
   void push(typename std::common_type<T>::type value) {
     const char* begin = reinterpret_cast<const char*>(&value);


### PR DESCRIPTION
Fixes #48835
Fixes #48716
