### PR TITLE
Only restride if a resize occurred; otherwise preserve strides.

### DIFF
--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -6,9 +6,13 @@
 
 namespace at { namespace native {
 
-void resize_output(Tensor& output, IntArrayRef shape) {
+bool resize_output(Tensor& output, IntArrayRef shape) {
   // Tests for resizing of tensors with one more elements
-  if (output.numel() != 0 && !output.sizes().equals(shape)) {
+  if (output.sizes().equals(shape)) {
+    return false;
+  }
+
+  if (output.numel() != 0) {
     TORCH_WARN(
       "An output with one or more elements was resized since it had ",
       "shape ", output.sizes(), ", which does not match the required ",
@@ -20,6 +24,7 @@ void resize_output(Tensor& output, IntArrayRef shape) {
   }
 
   output.resize_(shape);
+  return true;
 }
 
 // Call the sparse implementation in SparseTensor.cpp directly.

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -14,7 +14,8 @@ namespace at { namespace native {
 // Issues a warning if the output tensor has one or more elements and
 //   needs resizing
 // NOTE: In the future the warning will become an error
-CAFFE2_API void resize_output(Tensor& output, IntArrayRef shape);
+// Returns true if a resize actually happened
+CAFFE2_API bool resize_output(Tensor& output, IntArrayRef shape);
 
 // These functions are called by native::resize_ as well as (legacy) TH resize.
 // They are not in TH/THTensor.cpp because the at namespace is easier

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -296,12 +296,14 @@ if (strides.empty()) {{
             return "// TODO: consistency check?"
         elif k is SchemaKind.out:
             return """
-at::native::resize_output(outputs_[output_idx], sizes);
-if (!strides.empty()) {
-    TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
-    at::native::as_strided_(outputs_[output_idx], sizes, strides);
-} else if (options.memory_format_opt().has_value()) {
-    outputs_[output_idx].get().unsafeGetTensorImpl()->empty_tensor_restride(*options.memory_format_opt());
+bool resized = at::native::resize_output(outputs_[output_idx], sizes);
+if (resized) {
+    if (!strides.empty()) {
+        TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
+        at::native::as_strided_(outputs_[output_idx], sizes, strides);
+    } else if (options.memory_format_opt().has_value()) {
+        outputs_[output_idx].get().unsafeGetTensorImpl()->empty_tensor_restride(*options.memory_format_opt());
+    }
 }
 """
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48854 Only restride if a resize occurred; otherwise preserve strides.**
* #48718 Class-based structured kernels, with migration of add to framework

Signed-off-by: Edward Z. Yang <ezyang@fb.com>