### PR TITLE
Force a sync on non-CPU tensors for the benchmark to reflect the timing accurately.

### DIFF
--- a/binaries/speed_benchmark_torch.cc
+++ b/binaries/speed_benchmark_torch.cc
@@ -217,7 +217,11 @@ int main(int argc, char** argv) {
       FLAGS_warmup,
       ".");
   for (int i = 0; i < FLAGS_warmup; ++i) {
-    module.forward(inputs);
+    if (FLAGS_vulkan) {
+      module.forward(inputs).toTensor().cpu();
+    } else {
+      module.forward(inputs);
+    }
   }
 
   std::cout << "Main runs." << std::endl;
@@ -231,7 +235,11 @@ int main(int argc, char** argv) {
   auto micros = timer.MicroSeconds();
   for (int i = 0; i < FLAGS_iter; ++i) {
     auto start = high_resolution_clock::now();
-    module.forward(inputs);
+    if (FLAGS_vulkan) {
+      module.forward(inputs).toTensor().cpu();
+    } else {
+      module.forward(inputs);
+    }
     auto stop = high_resolution_clock::now();
     auto duration = duration_cast<microseconds>(stop - start);
     times.push_back(duration.count());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48856 Force a sync on non-CPU tensors for the benchmark to reflect the timing accurately.**

Differential Revision: [D25339803](https://our.internmc.facebook.com/intern/diff/D25339803)