### PR TITLE
[PyTorch] Save some space in ProcessedNode

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -746,9 +746,9 @@ ProcessedNode::ProcessedNode(
 
 void ProcessedNode::run(std::vector<IValue>& reg) const {
   if (fn_) {
-    fn_->operator()(this, reg);
+    fn_(this, reg);
   } else if (native_fn_) {
-    native_fn_->operator()(this, reg);
+    native_fn_(this, reg);
   } else {
     std::vector<IValue> stack;
     const size_t size = node_->inputs().size();

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -262,7 +262,7 @@ class ProcessedNode {
   }
 
   bool has_out_variant() const {
-    return fn_.has_value();
+    return static_cast<bool>(fn_);
   }
 
   const std::vector<size_t>& input_regs() const {
@@ -281,10 +281,8 @@ class ProcessedNode {
  private:
   Node* node_;
   c10::optional<Operation> op_;
-  c10::optional<std::function<void(const ProcessedNode*, std::vector<IValue>&)>>
-      fn_;
-  c10::optional<std::function<void(const ProcessedNode*, std::vector<IValue>&)>>
-      native_fn_;
+  std::function<void(const ProcessedNode*, std::vector<IValue>&)> fn_;
+  std::function<void(const ProcessedNode*, std::vector<IValue>&)> native_fn_;
 
   std::vector<size_t> input_regs_;
   std::vector<size_t> output_regs_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48861 [PyTorch] Save some space in ProcessedNode**

`std::function` already has an empty state; no need to wrap
it in `c10::Optional`.

Differential Revision: [D25296912](https://our.internmc.facebook.com/intern/diff/D25296912/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D25296912/)!