### PR TITLE
T66557700 Support default argument values of a method

### DIFF
--- a/aten/src/ATen/core/builtin_function.h
+++ b/aten/src/ATen/core/builtin_function.h
@@ -102,7 +102,7 @@ struct BuiltinOpFunction : public Function {
 
   std::string pretty_print_schema() const override {
     TORCH_INTERNAL_ASSERT(false);
-    return "";
+    return ""; // TODO: suppress unreachable code warning
   }
 
   Function& setSchema(c10::FunctionSchema schema) override {

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -133,14 +133,20 @@ constexpr uint64_t kMaxSupportedFileFormatVersion = 0x5L;
 //      when given bool or integer fill values.
 constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 
-// the version we write when the archive contains bytecode.
+// The version we write when the archive contains bytecode.
 // It must be higher or eq to kProducedFileFormatVersion.
 // Because torchscript changes is likely introduce bytecode change.
 // If kProducedFileFormatVersion is increased, kProducedBytecodeVersion
 // should be increased too. The relationship is:
 // kMaxSupportedFileFormatVersion >= (most likely ==) kProducedBytecodeVersion
 //   >= kProducedFileFormatVersion
-constexpr uint64_t kProducedBytecodeVersion = 0x4L;
+// Versions:
+//  0x1L: Initial version
+//  0x2L: (Comment missing)
+//  0x3L: (Comment missing)
+//  0x4L: (Comment missing)
+//  0x5L: Added schema to function tuple
+constexpr uint64_t kProducedBytecodeVersion = 0x5L;
 
 static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
     "kProducedBytecodeVersion must be higher or equal to kProducedFileFormatVersion.");

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -65,38 +65,49 @@ TEST(LiteInterpreterTest, CheckAttrAccess) {
   AT_ASSERT(!mobile_optimized);
 }
 
-TEST(LiteInterpreterTest, Add) {
-  Module m("m");
-  m.register_parameter("foo", torch::ones({}), false);
-  // TODO: support default param val, which was pushed in
-  // function schema's checkAndNormalizeInputs()
-  //  m.define(R"(
-  //    def add_it(self, x, b : int = 4):
-  //      return self.foo + x + b
-  //  )");
-  m.define(R"(
-    def add_it(self, x):
-      b = 4
-      return self.foo + x + b
-  )");
+TEST(LiteInterpreterTest, MethodInvocation) { // NOLINT (use =delete in gtest)
+  const std::vector<std::string> test_programs{
+      // test invoking a method with default parameter
+      R"(
+      def test_func(self, x, b : int = 4):
+        return self.foo + x + b
+      )",
+      // inner method call with default parameter (gets inlined)
+      R"(
+      def add_with_default_arg(self, x, b : int = 4):
+        return self.foo + x + b
+      def test_func(self, x):
+        return self.add_with_default_arg(x)  # invoke method w/ default arg
+      )",
+      // simple method call
+      R"(
+      def test_func(self, x):
+        b = 4
+        return self.foo + x + b
+      )",
+  };
+  for (const auto& test_program : test_programs) {
+    Module m("m");
+    m.register_parameter("foo", torch::ones({}), false);
+    m.define(test_program);
 
-  std::vector<IValue> inputs;
-  auto minput = 5 * torch::ones({});
-  inputs.emplace_back(minput);
-  auto ref = m.run_method("add_it", minput);
+    const int fortyTwo = 42; // (keep linter happy)
+    auto minput = fortyTwo * torch::ones({});
+    auto ref = m.run_method("test_func", minput);
 
-  std::stringstream ss;
-  m._save_for_mobile(ss);
-  mobile::Module bc = _load_for_mobile(ss);
-  IValue res;
-  for (int i = 0; i < 3; ++i) {
-    auto bcinputs = inputs;
-    res = bc.get_method("add_it")(bcinputs);
+    std::stringstream ss;
+    m._save_for_mobile(ss);
+    mobile::Module bc = _load_for_mobile(ss);
+    const auto& test_func = bc.get_method("test_func");
+    IValue res;
+    for (int i = 0; i < 3; ++i) {
+      res = test_func({minput});
+    }
+
+    auto resd = res.toTensor().item<float>();
+    auto refd = ref.toTensor().item<float>();
+    AT_ASSERT(resd == refd);
   }
-
-  auto resd = res.toTensor().item<float>();
-  auto refd = ref.toTensor().item<float>();
-  AT_ASSERT(resd == refd);
 }
 
 TEST(LiteInterpreterTest, Conv) {

--- a/test/mobile/test_lite_script_module.py
+++ b/test/mobile/test_lite_script_module.py
@@ -190,6 +190,37 @@ class TestLiteScriptModule(unittest.TestCase):
         mobile_module_result = mobile_module.forward(*bundled_inputs[0])
         torch.testing.assert_allclose(script_module_result, mobile_module_result)
 
+    def test_method_calls_with_optional_arg(self):
+        class A(torch.nn.Module):
+            def __init__(self):
+                super(A, self).__init__()
+
+            def forward(self, x, two: int = 2):  # opt arg in script-to-script invocation
+                return x + two
+
+        class B(torch.nn.Module):
+            def __init__(self):
+                super(B, self).__init__()
+                self.A0 = A()
+
+            def forward(self, x, one: int = 1):  # opt arg in Python-to-script invocation
+                return self.A0(x) + one
+
+        script_module = torch.jit.script(B())
+        buffer = io.BytesIO(script_module._save_to_buffer_for_lite_interpreter())
+        mobile_module = _load_for_lite_interpreter(buffer)
+
+        input = torch.tensor([5])
+        script_module_forward_result = script_module.forward(input)
+        mobile_module_forward_result = mobile_module.forward(input)
+        torch.testing.assert_allclose(script_module_forward_result, mobile_module_forward_result)
+
+        script_module_forward_result = script_module.forward(input, 2)  # change ref only
+        self.assertFalse((script_module_forward_result == mobile_module_forward_result).all().item())
+
+        mobile_module_forward_result = mobile_module.forward(input, 2)  # now both match again
+        torch.testing.assert_allclose(script_module_forward_result, mobile_module_forward_result)
+
     def test_unsupported_createobject(self):
         class Foo():
             def __init__(self):

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -107,13 +107,13 @@ Module Method::owner() const {
   return Module(owner_);
 }
 void Method::run(Stack& stack) {
-  stack.insert(stack.begin(), owner()._ivalue());
+  stack.insert(stack.begin(), owner()._ivalue()); // self
   RECORD_TORCHSCRIPT_FUNCTION(name(), stack);
   function_->run(stack);
 }
 
 IValue Method::operator()(std::vector<IValue> stack, const Kwargs& kwargs) {
-  stack.insert(stack.begin(), owner()._ivalue());
+  stack.insert(stack.begin(), owner()._ivalue()); // self
   RECORD_TORCHSCRIPT_FUNCTION(name(), stack);
   return (*function_)(std::move(stack), kwargs);
 }

--- a/torch/csrc/jit/mobile/function.cpp
+++ b/torch/csrc/jit/mobile/function.cpp
@@ -58,12 +58,12 @@ bool Function::append_operator(
   }
 
   if (model_version == 0x3L &&
-      model_version < caffe2::serialize::kProducedBytecodeVersion &&
       opname == c10::OperatorName("aten::_convolution", "")) {
-    // A default-value argument will be added in
-    // https://github.com/pytorch/pytorch/pull/40737. This wrapper is used to
-    // handle backward compatibility, where there is no default bool value in
-    // old models.
+    // Since byte-code versions 0x4L, convolution has an additional
+    // default-value argument (allow_tf32=True, see
+    // https://github.com/pytorch/pytorch/pull/40737). This wrapper handles
+    // backward compatibility with models of byte-code version <= 0x3L, where
+    // this bool argument does not yet exist.
     fn = [fn](Stack& stack) {
       stack.push_back(true);
       fn(stack);
@@ -107,14 +107,26 @@ std::string Function::get_module_debug_info(size_t pc) const {
   return pc_to_module_debug_info_[pc];
 }
 
+void Function::setSchema(c10::FunctionSchema schema) {
+  schema_ = std::move(schema);
+}
+
+const at::optional<c10::FunctionSchema>& Function::getSchema() const {
+  return schema_;
+}
+
 bool Function::run(Stack& stack) const {
+  const auto& schema = getSchema();
+  if (schema) { // if we have a schema then resolve optional args if any
+    schema->checkAndNormalizeInputs(
+        stack, std::unordered_map<std::string, IValue>{} /*kwargs*/);
+  }
   InterpreterState interp_state(code_);
   return interp_state.run(stack);
 }
 
-c10::IValue Function::operator()(Stack& stack) {
-  InterpreterState interp_state(code_);
-  interp_state.run(stack);
+c10::IValue Function::operator()(Stack& stack) const {
+  run(stack);
   return stack.front();
 }
 

--- a/torch/csrc/jit/mobile/function.h
+++ b/torch/csrc/jit/mobile/function.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/core/ivalue.h>
 //#include <aten/src/Aten/core/operator_name.h>
+#include <ATen/core/function_schema.h>
 #include <vector>
 
 namespace torch {
@@ -15,7 +16,7 @@ class Function {
  public:
   Function(c10::QualifiedName name);
   bool run(Stack& stack) const;
-  c10::IValue operator()(Stack& stack);
+  c10::IValue operator()(Stack& stack) const;
   const std::string& name() const;
   const c10::QualifiedName& qualname() const;
   void append_instruction(OpCode op, int X, int N);
@@ -32,9 +33,13 @@ class Function {
 
   std::string get_module_debug_info(size_t pc) const;
 
+  void setSchema(c10::FunctionSchema schema);
+  const at::optional<c10::FunctionSchema>& getSchema() const;
+
  private:
   c10::QualifiedName name_;
   std::shared_ptr<Code> code_;
+  at::optional<c10::FunctionSchema> schema_; // (byte-code version 5+ only)
   std::vector<std::string> pc_to_module_debug_info_;
 };
 

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -15,28 +15,46 @@
 
 // The import process to serialize the bytecode package.
 // An example for bytecode.pkl of a small mobile_module looks like:
-// (3,
-//   ('__torch__.m.forward',
-//     (('instructions',
-//       (('STOREN', 1, 2),
-//        ('DROPR', 1, 0),
-//        ('MOVE', 2, 0),
-//        ('OP', 0, 0),
-//        ('RET', 0, 0))),
-//      ('operators', (('aten::Int', 'Tensor'),)),
-//      ('constants', ()),
-//      ('types', ()),
-//      ('register_size', 2))))
+// (5,  # model version number (caffe2::serialize::kProducedBytecodeVersion)
+//  # first method
+//  (
+//   # function name
+//   '__torch__.m.forward',
+//   # code
+//   (('instructions',
+//     (('STOREN', 1, 2),
+//      ('DROPR', 1, 0),
+//      ('MOVE', 2, 0),
+//      ('OP', 0, 0),
+//      ('RET', 0, 0))),
+//    ('operators', (('aten::Int', 'Tensor'),)),
+//    ('constants', ()),
+//    ('types', ()),
+//    ('register_size', 2)),
+//   # schema
+//   (('arguments',
+//     ((('name', 'x'), ('type', 'Tensor'), ('default_value', 13)),
+//      ...)),  # more args follow here
+//    ('returns',
+//     ((('name', ''), ('type', 'Tensor'), ('default_value', None)),
+//      ...)),  # more return values follow here
+//   )),
+//  # more methods follow here
+//  ...)
 
 // In addition, the module debugging information can be saved
 // in mobile_debug.pkl. An example for it looks like:
-// (3,
-//   ('__torch__.m.forward',
-//     (('module_debug_info', (top(A).foo(B).forward)))))
+// (5,
+//  ('__torch__.m.forward',
+//   (('module_debug_info', (top(A).foo(B).forward)))))
 
 // Note that currently the backward compatibility is not supported by bytecode.
-// This format and process need to be revisted and redesigned if we want to
+// This format and process need to be revisited and redesigned if we want to
 // support backward compatibility in future.
+
+// Note that the following function-schema fields are not supported:
+//  - Argument::{known_length_,kwarg_only_}
+//  - FunctionSchema::{overload_name_, is_vararg_, is_varret_}
 
 namespace c10 {
 // std::string serializeType(const Type &t);
@@ -90,7 +108,57 @@ void print_unsupported_ops_and_throw(
       error_message);
 }
 
-void parseMethods(
+// The deserializer class which loads the bytecode package from bc files.
+class BytecodeDeserializer final {
+ public:
+  explicit BytecodeDeserializer(std::unique_ptr<PyTorchStreamReader> reader);
+  mobile::Module deserialize(
+      c10::optional<at::Device> device,
+      ExtraFilesMap& extra_files);
+  std::unordered_map<std::string, std::string> deserializeMetadata(
+      c10::optional<at::Device> device);
+
+ private:
+  TypePtr resolveTypeName(const c10::QualifiedName& qn);
+  void parseMethods(
+      const std::vector<IValue>& vals,
+      const c10::optional<std::vector<IValue>>& debug_info_vals,
+      mobile::CompilationUnit& mcu);
+  c10::IValue readArchive(
+      const std::string& archive_name,
+      std::shared_ptr<mobile::CompilationUnit> mcu);
+  std::unordered_map<std::string, std::string> readMobileMetadata(
+      std::shared_ptr<mobile::CompilationUnit> mcu);
+  std::shared_ptr<CompilationUnit> compilation_unit_;
+  std::unordered_set<std::string> imported_libs_;
+  std::unique_ptr<PyTorchStreamReader> reader_;
+  c10::optional<at::Device> device_;
+};
+
+BytecodeDeserializer::BytecodeDeserializer(
+    std::unique_ptr<PyTorchStreamReader> reader)
+    : compilation_unit_(std::make_shared<CompilationUnit>()),
+      reader_(std::move(reader)) {}
+
+TypePtr BytecodeDeserializer::resolveTypeName(const c10::QualifiedName& qn) {
+  static const c10::QualifiedName torchPrefix = "__torch__";
+  // HACK: first we check whether the name starts with `__torch__` to
+  // tell if it's "supposed" to be a class type. This is a reliable
+  // check today, but there is no guarantee that this is the case. The
+  // real solution is to merge type parsers so we can share class
+  // resolution logic.
+  if (torchPrefix.isPrefixOf(qn)) {
+    if (compilation_unit_->get_class(qn) == nullptr) {
+      auto typeptr = ClassType::create(qn, compilation_unit_, true);
+      compilation_unit_->register_type(typeptr);
+    }
+    return compilation_unit_->get_class(qn);
+  } else {
+    return c10::parseType(qn.qualifiedName());
+  }
+}
+
+void BytecodeDeserializer::parseMethods(
     const std::vector<IValue>& vals,
     const c10::optional<std::vector<IValue>>& debug_info_vals,
     mobile::CompilationUnit& mcu) {
@@ -126,27 +194,32 @@ void parseMethods(
     const auto& element = vals[i];
     const auto& m_tuple = element.toTuple()->elements();
     const std::string& function_name = m_tuple[0].toStringRef();
-    IValue table = m_tuple[1];
+    IValue codeTable = m_tuple[1];
+    auto schemaTable = // older files do not store function schema
+        (model_version >= 0x5L) ? at::optional<IValue>{m_tuple[2]} // NOLINT
+                                : at::nullopt;
 
     auto function = std::unique_ptr<mobile::Function>(
         new mobile::Function(c10::QualifiedName(function_name)));
 
     const auto& ins_list =
-        expect_field(table, "instructions", BYTECODE_INDEX_INSTRUCTION)
+        expect_field(codeTable, "instructions", BYTECODE_INDEX_INSTRUCTION)
             .toTuple()
             ->elements();
     const auto& ops_list =
-        expect_field(table, "operators", BYTECODE_INDEX_OPERATOR)
+        expect_field(codeTable, "operators", BYTECODE_INDEX_OPERATOR)
             .toTuple()
             ->elements();
     const auto& consts_list =
-        expect_field(table, "constants", BYTECODE_INDEX_CONSTANT)
+        expect_field(codeTable, "constants", BYTECODE_INDEX_CONSTANT)
             .toTuple()
             ->elements();
     const auto& types_list =
-        expect_field(table, "types", BYTECODE_INDEX_TYPE).toTuple()->elements();
+        expect_field(codeTable, "types", BYTECODE_INDEX_TYPE)
+            .toTuple()
+            ->elements();
     const auto& register_size =
-        expect_field(table, "register_size", BYTECODE_INDEX_REGISTER_SIZE)
+        expect_field(codeTable, "register_size", BYTECODE_INDEX_REGISTER_SIZE)
             .toInt();
 
     std::vector<IValue> module_debug_info_list;
@@ -218,36 +291,50 @@ void parseMethods(
 
     function->set_register_size(register_size);
 
+    // function schema
+    if (schemaTable) { // (schema is optional for back compat)
+      auto parseArgList = [this](const std::vector<IValue>& argTables) {
+        std::vector<c10::Argument> args;
+        for (auto&& argTable : argTables) {
+          auto name =
+              expect_field(argTable, "name", BYTECODE_INDEX_ARGUMENT_NAME)
+                  .toStringRef();
+          const auto& type = resolveTypeName(
+              (expect_field(argTable, "type", BYTECODE_INDEX_ARGUMENT_TYPE))
+                  .toStringRef());
+          auto default_value = expect_field(
+                                   argTable,
+                                   "default_value",
+                                   BYTECODE_INDEX_ARGUMENT_DEFAULT_VALUE)
+                                   .toIValue();
+          auto arg =
+              c10::Argument(name, type, c10::nullopt /*N*/, default_value);
+          args.emplace_back(std::move(arg));
+        }
+        return args;
+      };
+      const auto& arg_list =
+          expect_field(
+              *schemaTable, "arguments", BYTECODE_INDEX_SCHEMA_ARGUMENTS)
+              .toTuple()
+              ->elements();
+      const auto& ret_list =
+          expect_field(*schemaTable, "returns", BYTECODE_INDEX_SCHEMA_RETURNS)
+              .toTuple()
+              ->elements();
+      c10::FunctionSchema schema(
+          function_name,
+          "" /*overload_name*/,
+          parseArgList(arg_list),
+          parseArgList(ret_list),
+          false /*is_varargs*/,
+          false /*is_varret*/);
+      function->setSchema(std::move(schema));
+    }
+
     mcu.register_function(std::move(function));
   }
 }
-
-// The deserializer class which loads the bytecode package from bc files.
-class BytecodeDeserializer final {
- public:
-  explicit BytecodeDeserializer(std::unique_ptr<PyTorchStreamReader> reader);
-  mobile::Module deserialize(
-      c10::optional<at::Device> device,
-      ExtraFilesMap& extra_files);
-  std::unordered_map<std::string, std::string> deserializeMetadata(
-      c10::optional<at::Device> device);
-
- private:
-  c10::IValue readArchive(
-      const std::string& archive_name,
-      std::shared_ptr<mobile::CompilationUnit> mcu);
-  std::unordered_map<std::string, std::string> readMobileMetadata(
-      std::shared_ptr<mobile::CompilationUnit> mcu);
-  std::shared_ptr<CompilationUnit> compilation_unit_;
-  std::unordered_set<std::string> imported_libs_;
-  std::unique_ptr<PyTorchStreamReader> reader_;
-  c10::optional<at::Device> device_;
-};
-
-BytecodeDeserializer::BytecodeDeserializer(
-    std::unique_ptr<PyTorchStreamReader> reader)
-    : compilation_unit_(std::make_shared<CompilationUnit>()),
-      reader_(std::move(reader)) {}
 
 std::unordered_map<std::string, std::string> BytecodeDeserializer::
     deserializeMetadata(c10::optional<at::Device> device) {
@@ -320,23 +407,8 @@ c10::IValue BytecodeDeserializer::readArchive(
     return len;
   };
 
-  static const c10::QualifiedName torchPrefix = "__torch__";
-  auto type_resolver = [&](const c10::QualifiedName& qn) {
-    TypePtr type;
-    // HACK: first we check whether the name starts with `__torch__` to tell if
-    // it's "supposed" to be a class type. This is a reliable check today, but
-    // there is no guarantee that this is the case. The real solution is to
-    // merge type parsers so we can share class resolution logic.
-    if (torchPrefix.isPrefixOf(qn)) {
-      if (compilation_unit_->get_class(qn) == nullptr) {
-        auto typeptr = ClassType::create(qn, compilation_unit_, true);
-        compilation_unit_->register_type(typeptr);
-      }
-      type = compilation_unit_->get_class(qn);
-    } else {
-      type = c10::parseType(qn.qualifiedName());
-    }
-    return c10::StrongTypePtr(compilation_unit_, type);
+  auto type_resolver = [this](const c10::QualifiedName& qn) {
+    return c10::StrongTypePtr(compilation_unit_, resolveTypeName(qn));
   };
 
   auto obj_loader = [&](at::StrongTypePtr type, IValue input) {

--- a/torch/csrc/jit/mobile/method.h
+++ b/torch/csrc/jit/mobile/method.h
@@ -10,12 +10,12 @@ class Module;
 struct TORCH_API Method {
   Method(const Module* owner, Function* function);
 
-  void run(Stack& stack);
-  void run(Stack&& stack) {
+  void run(Stack& stack) const;
+  void run(Stack&& stack) const {
     run(stack);
   }
 
-  c10::IValue operator()(std::vector<c10::IValue> stack);
+  c10::IValue operator()(std::vector<c10::IValue> stack) const;
 
   const std::string& name() const {
     return function_->name();

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -119,7 +119,7 @@ bool Module::is_training() const {
 Method::Method(const Module* owner, Function* function)
     : owner_(owner), function_(function) {}
 
-void Method::run(Stack& stack) {
+void Method::run(Stack& stack) const {
   auto observer = torch::observerConfig().getModuleObserver();
   auto instance_key = std::rand();
   /* if the metadata dict doesn't contain "model_name", copy the metadata and
@@ -141,7 +141,7 @@ void Method::run(Stack& stack) {
   at::DebugInfoGuard guard(at::DebugInfoKind::MOBILE_RUNTIME_INFO, debug_info);
 
   try {
-    stack.insert(stack.begin(), owner_->_ivalue());
+    stack.insert(stack.begin(), owner_->_ivalue()); // self
     function_->run(stack);
     if (observer) {
       observer->onExitRunMethod(instance_key);
@@ -172,7 +172,7 @@ void Method::run(Stack& stack) {
   }
 }
 
-c10::IValue Method::operator()(std::vector<IValue> stack) {
+c10::IValue Method::operator()(std::vector<IValue> stack) const {
   run(stack);
   TORCH_INTERNAL_ASSERT(!stack.empty());
   return stack.front();

--- a/torch/csrc/jit/mobile/module.h
+++ b/torch/csrc/jit/mobile/module.h
@@ -1,5 +1,4 @@
 #pragma once
-//#include <ATen/core/function_schema.h>
 #include <torch/csrc/jit/mobile/function.h>
 #include <torch/csrc/jit/mobile/method.h>
 

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -222,12 +222,47 @@ std::pair<IValue, c10::optional<IValue>> getFunctionTuple(
   // register size
   auto register_size = static_cast<int>(code.register_size());
 
-  auto table = Table({{"instructions", Tup(instructions)},
-                      {"operators", Tup(operators)},
-                      {"constants", Tup(constants)},
-                      {"types", Tup(types)},
-                      {"register_size", register_size}});
-  auto bytecode_vals = Tup({func.qualname().qualifiedName(), table});
+  auto codeTable = Table({{"instructions", Tup(instructions)},
+                          {"operators", Tup(operators)},
+                          {"constants", Tup(constants)},
+                          {"types", Tup(types)},
+                          {"register_size", register_size}});
+
+  // schema
+  const auto& schema = func.getSchema();
+  TORCH_CHECK(
+      schema.overload_name().empty(), // @TODO: is this check correct?
+      "Overloads are not supported in mobile modules.");
+  TORCH_CHECK(
+      !schema.is_vararg(), "Python *args are not supported in mobile modules.");
+  TORCH_CHECK(
+      !schema.is_varret(),
+      "A variable number of return values is not supported in mobile modules.");
+  auto makeArgTuple = [](const std::vector<Argument>& args) {
+    std::vector<IValue> argTables;
+    for (auto&& arg : args) {
+      TORCH_CHECK(
+          !arg.N(),
+          "Arguments with known list lengths are not supported in mobile modules.");
+      TORCH_CHECK(
+          !arg.kwarg_only(),
+          "Keyword-only arguments are not supported in mobile modules.");
+      argTables.emplace_back(Table({
+          {"name", arg.name()},
+          {"type", arg.type()->annotation_str()},
+          {"default_value", arg.default_value()},
+      }));
+    }
+    return Tup(argTables);
+  };
+  auto schemaTable = Table({
+      {"arguments", makeArgTuple(schema.arguments())},
+      {"returns", makeArgTuple(schema.returns())},
+  });
+
+  // function tuple
+  auto bytecode_vals =
+      Tup({func.qualname().qualifiedName(), codeTable, schemaTable});
 
   c10::optional<IValue> debug_info_vals;
   if (save_mobile_debug_info) {
@@ -278,7 +313,7 @@ void setstateTuple(
 
 void moduleMethodsTuple(
     const Module& module,
-    std::vector<c10::IValue>& elements,
+    std::vector<c10::IValue>& elements, // note: appended to in-place
     c10::optional<std::vector<c10::IValue>>& debug_info_elements,
     bool save_mobile_debug_info) {
   auto methods = module.get_methods();

--- a/torch/csrc/jit/serialization/import_export_constants.h
+++ b/torch/csrc/jit/serialization/import_export_constants.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 namespace torch {
 namespace jit {
@@ -7,6 +8,14 @@ constexpr size_t BYTECODE_INDEX_OPERATOR = 1;
 constexpr size_t BYTECODE_INDEX_CONSTANT = 2;
 constexpr size_t BYTECODE_INDEX_TYPE = 3;
 constexpr size_t BYTECODE_INDEX_REGISTER_SIZE = 4;
+
+constexpr size_t BYTECODE_INDEX_SCHEMA_ARGUMENTS = 0;
+constexpr size_t BYTECODE_INDEX_SCHEMA_RETURNS = 1;
+
+constexpr size_t BYTECODE_INDEX_ARGUMENT_NAME = 0;
+constexpr size_t BYTECODE_INDEX_ARGUMENT_TYPE = 1;
+constexpr size_t BYTECODE_INDEX_ARGUMENT_DEFAULT_VALUE = 2;
+
 constexpr size_t BYTECODE_INDEX_MODULE_DEBUG_INFO = 0;
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Support default arguments when invoking a module via PyTorch Lite (`mobile::Module`).

Test Plan: buck test mode/dbg //caffe2/test/cpp/jit:jit -- LiteInterpreterTest.MethodInvocation

Differential Revision: D25152559

