### PR TITLE
Additional validation for DistributedSampler.

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1454,6 +1454,12 @@ except RuntimeError as e:
         self.assertEqual(int(math.ceil(float(num_samples) / batch_size)),
                          count_num_samples_in_data_loader)
 
+    def test_distributed_sampler_invalid_rank(self):
+        from torch.utils.data.distributed import DistributedSampler
+        dataset = torch.IntTensor(range(10))
+        with self.assertRaisesRegex(ValueError, "Invalid rank"):
+            sampler = DistributedSampler(dataset, 3, 3)
+
     def test_duplicating_data_with_drop_last(self):
 
         from torch.utils.data.distributed import DistributedSampler

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1460,6 +1460,9 @@ except RuntimeError as e:
         with self.assertRaisesRegex(ValueError, "Invalid rank"):
             sampler = DistributedSampler(dataset, 3, 3)
 
+        with self.assertRaisesRegex(ValueError, "Invalid rank"):
+            sampler = DistributedSampler(dataset, 3, -1)
+
     def test_duplicating_data_with_drop_last(self):
 
         from torch.utils.data.distributed import DistributedSampler

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -67,7 +67,7 @@ class DistributedSampler(Sampler[T_co]):
             if not dist.is_available():
                 raise RuntimeError("Requires distributed package to be available")
             rank = dist.get_rank()
-        if rank >= num_replicas:
+        if rank >= num_replicas or rank < 0:
             raise ValueError(
                 "Invalid rank {}, rank should be in the interval"
                 " [0, {}]".format(rank, num_replicas - 1))

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -67,6 +67,10 @@ class DistributedSampler(Sampler[T_co]):
             if not dist.is_available():
                 raise RuntimeError("Requires distributed package to be available")
             rank = dist.get_rank()
+        if rank >= num_replicas:
+            raise ValueError(
+                "Invalid rank {}, rank should be in the interval"
+                " [0, {}]".format(rank, num_replicas - 1))
         self.dataset = dataset
         self.num_replicas = num_replicas
         self.rank = rank


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48865 Additional validation for DistributedSampler.**

If DistributedSampler was provided an invalid rank (ex:
https://discuss.pytorch.org/t/distributed-datasets-on-multi-machines/105113),
it failed with a cryptic assertion failure.

To fix this issue, I've added an additional check to DistributedSampler to
validate we provide a valid rank.

Differential Revision: [D25344945](https://our.internmc.facebook.com/intern/diff/D25344945/)