### PR TITLE
[PyTorch] Avoid storage refcount bump in copy_tensor_metadata

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -293,7 +293,8 @@ c10::intrusive_ptr<TensorImpl> TensorImpl::shallow_copy_and_detach(
     const c10::VariableVersion& version_counter,
     bool allow_tensor_metadata_change) const {
   auto impl = c10::make_intrusive<TensorImpl>(
-      Storage(storage()), key_set_, data_type_);
+      // No need to populate Storage; copy_tensor_metadata will do it for us.
+      key_set_, data_type_, device_opt_);
   copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),
@@ -308,7 +309,8 @@ c10::intrusive_ptr<TensorImpl> TensorImpl::shallow_copy_and_detach(
     c10::VariableVersion&& version_counter,
     bool allow_tensor_metadata_change) const {
   auto impl = c10::make_intrusive<TensorImpl>(
-      Storage(storage()), key_set_, data_type_);
+      // No need to populate Storage; copy_tensor_metadata will do it for us.
+      key_set_, data_type_, device_opt_);
   copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48877 [PyTorch] Avoid storage refcount bump in copy_tensor_metadata**
* #48681 [PyTorch] Add VariableVersion&& overload for TensorImpl::shallow_copy_and_detach
* #48680 [PyTorch] Move TensorImpl::shallow_copy_and_detach to .cpp file

Setting `Storage` in the TensorImpl ctor only to set it again in
`copy_tensor_metadata` wastes one refcount bump.

Differential Revision: [D25353529](https://our.internmc.facebook.com/intern/diff/D25353529/)