### PR TITLE
[CUDAExtension] support all visible cards when building a cudaextension

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -838,20 +838,21 @@ def CUDAExtension(name, sources, *args, **kwargs):
     will make nvcc fall back to building kernels with the newest version of PTX your nvcc does
     support (see below for details on PTX).
 
-    However, you can explicitly specify which archs you want the extension to support like so:
+    You can override the default behavior using `TORCH_CUDA_ARCH_LIST` to explicitly specify which
+    CCs you want the extension to support:
 
     TORCH_CUDA_ARCH_LIST="6.1 8.6" python build_my_extension.py
     TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX" python build_my_extension.py
 
     The +PTX option causes extension kernel binaries to include PTX instructions for the specified
-    compute capability (CC). PTX is an intermediate representation that allows kernels to
-    runtime-compile for any CC >= the specified CC (for example, 8.6+PTX generates PTX that can
-    runtime-compile for any GPU with CC >= 8.6). This improves your binary's forward compatibility.
-    However, relying on older PTX to provide forward compat by runtime-compiling for newer CCs can
-    modestly reduce performance on those newer CCs. If you know exact CC(s) of the GPUs you want to
-    target, you're always better off specifying them individually. For example, if you want your
-    extension to run on 8.0 and 8.6, "8.0+PTX" would work functionally because it includes PTX that
-    can runtime-compile for 8.6, but "8.0 8.6" would be better.
+    CC. PTX is an intermediate representation that allows kernels to runtime-compile for any CC >=
+    the specified CC (for example, 8.6+PTX generates PTX that can runtime-compile for any GPU with
+    CC >= 8.6). This improves your binary's forward compatibility. However, relying on older PTX to
+    provide forward compat by runtime-compiling for newer CCs can modestly reduce performance on
+    those newer CCs. If you know exact CC(s) of the GPUs you want to target, you're always better
+    off specifying them individually. For example, if you want your extension to run on 8.0 and 8.6,
+    "8.0+PTX" would work functionally because it includes PTX that can runtime-compile for 8.6, but
+    "8.0 8.6" would be better.
 
     Note that while it's possible to include all supported archs, the more archs get included the
     slower the building process will be, as it will build a separate kernel image for each arch.

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -847,19 +847,18 @@ def CUDAExtension(name, sources, *args, **kwargs):
     TORCH_CUDA_ARCH_LIST="6.1 8.6" python build_my_extension.py
     TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX" python build_my_extension.py
 
-    The `+PTX` option is special and if provided as shown in the last example will support any card
-    whose compute capability was not compiled for and it'll use JIT at runtime instead (that's, of
-    course, if the instruction sets match - some old cards won't be possible to use.)
+    The +PTX option causes extension kernel binaries to include PTX instructions for the specified
+    compute capability (CC). PTX is an intermediate representation that allows kernels to
+    runtime-compile for any CC >= the specified CC (for example, 8.6+PTX generates PTX that can
+    runtime-compile for any GPU with CC >= 8.6). This improves your binary's forward compatibility.
+    However, relying on older PTX to provide forward compat by runtime-compiling for newer CCs can
+    modestly reduce performance on those newer CCs. If you know exact CC(s) of the GPUs you want to
+    target, you're always better off specifying them individually. For example, if you want your
+    extension to run on 8.0 and 8.6, "8.0+PTX" would work functionally because it includes PTX that
+    can runtime-compile for 8.6, but "8.0 8.6" would be better.
 
-    Notes: 
-
-    - the more archs get included the slower the building process will be, as it will build a
-      separate kernel image for each arch
-
-    - to get the best performance it's always the best to compile for the exact compute capability
-      of the cards you are going to use the extension with. e.g. while sm_80 will work just fine on
-      a sm_86-based card, you could be missing out on the new instruction sets available to the
-      sm_86 card.
+    Note that while it's possible to include all supported archs, the more archs get included the
+    slower the building process will be, as it will build a separate kernel image for each arch.
 
     '''
     library_dirs = kwargs.get('library_dirs', [])

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -833,11 +833,10 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
     By default the extension will be compiled to run on all archs of the cards visible during the
     building process of the extension, plus PTX. If down the road a new card is installed the
-    extension may need to be recompiled.
-
-    If a visible card has a compute capability (CC) that's newer than the newest version for which
-    your nvcc can build fully-compiled binaries, Pytorch will make nvcc fall back to building
-    kernels with the newest version of PTX your nvcc does support (see below for details on PTX).
+    extension may need to be recompiled. If a visible card has a compute capability (CC) that's
+    newer than the newest version for which your nvcc can build fully-compiled binaries, Pytorch
+    will make nvcc fall back to building kernels with the newest version of PTX your nvcc does
+    support (see below for details on PTX).
 
     However, you can explicitly specify which archs you want the extension to support like so:
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -832,15 +832,12 @@ def CUDAExtension(name, sources, *args, **kwargs):
     Compute capabilities:
 
     By default the extension will be compiled to run on all archs of the cards visible during the
-    building process of the extension. If down the road a new card is installed the extension may
-    need to be recompiled.
+    building process of the extension, plus PTX. If down the road a new card is installed the
+    extension may need to be recompiled.
 
-    This default may also clamp a higher arch to a lower one that has the same binary compatibility
-    if pytorch was compiled with that lower one. e.g. ``sm_86`` could be clamped down to `sm_80`.
-    For a variety of technical reasons the distributed pytorch binary doesn't build against the full
-    range of computer capabilities, e.g. it includes only `sm_60` and `sm_70`,but not `sm_61` and
-    `sm_75`. The not included ones are binary compatible with the included ones, but you might not
-    be getting the best performance.
+    If a visible card has a compute capability (CC) that's newer than the newest version for which
+    your nvcc can build fully-compiled binaries, Pytorch will make nvcc fall back to building
+    kernels with the newest version of PTX your nvcc does support (see below for details on PTX).
 
     However, you can explicitly specify which archs you want the extension to support like so:
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1545,6 +1545,7 @@ def _get_cuda_arch_flags(cflags: Optional[List[str]] = None) -> List[str]:
             if arch not in arch_list:
                 arch_list.append(arch)
         arch_list = sorted(arch_list)
+        arch_list[-1] += '+PTX'
     else:
         # Deal with lists that are ' ' separated (only deal with ';' after)
         _arch_list = _arch_list.replace(' ', ';')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1545,7 +1545,7 @@ def _get_cuda_arch_flags(cflags: Optional[List[str]] = None) -> List[str]:
             arch = f'{capability[0]}.{capability[1]}'
             if arch not in arch_list:
                 arch_list.append(arch)
-            arch_list = sorted(arch_list)
+        arch_list = sorted(arch_list)
     else:
         # Deal with lists that are ' ' separated (only deal with ';' after)
         _arch_list = _arch_list.replace(' ', ';')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1542,7 +1542,10 @@ def _get_cuda_arch_flags(cflags: Optional[List[str]] = None) -> List[str]:
             # used to build pytorch, so we use the maximum supported capability of pytorch
             # to clamp the capability.
             capability = min(max_supported_sm, capability)
-            arch_list.append(f'{capability[0]}.{capability[1]}')
+            arch = f'{capability[0]}.{capability[1]}'
+            if arch not in arch_list:
+                arch_list.append(arch)
+            arch_list = sorted(arch_list)
     else:
         # Deal with lists that are ' ' separated (only deal with ';' after)
         _arch_list = _arch_list.replace(' ', ';')


### PR DESCRIPTION
Currently CUDAExtension assumes that all cards are of the same type on the same machine and builds the extension with compute capability of the 0th card. This breaks later at runtime if the machine has cards of different types. 

Specifically resulting in:
```
RuntimeError: CUDA error: no kernel image is available for execution on the device
```
when the cards of the types that weren't compiled for are used. (and the error is far from telling what the problem is to the uninitiated)

My current setup is:
```
$ CUDA_VISIBLE_DEVICES=0 python -c "import torch; print(torch.cuda.get_device_capability())"
(8, 6)
$ CUDA_VISIBLE_DEVICES=1 python -c "import torch; print(torch.cuda.get_device_capability())"
(6, 1)
```
but the extension was getting built with `-gencode=arch=compute_80,code=sm_80`.

This PR:
* [x] introduces a loop over all visible at build time devices to ensure the extension will run on all of them (it sorts the new list generated by the loop, so that the output is easier to debug should a card with lower capacity come last)
* [x] adds `+PTX` to the last entry of ccs derived from local cards (`if not _arch_list:`) to support other archs
* [x] adds a digest of my conversation with @ptrblck on slack in the form of docs which hopefully can help others know which archs to support, how to override defaults, when and how to add PTX, etc.

Please kindly review that my prose is clear and easy to understand.

@ptrblck 