### PR TITLE
[Gradient Compression] Let the dtype of created low-rank tensors P and Q be the same type as the input tensor

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -162,11 +162,17 @@ def powerSGD_hook(
                 # only fork on CPU and then move the generated tensor to the CUDA device.
                 torch.manual_seed(rng.randint(1_000_000_000))
                 return torch.randn(
-                    square_side_length, state.matrix_approximation_rank, device="cpu"
+                    square_side_length,
+                    state.matrix_approximation_rank,
+                    device="cpu",
+                    dtype=input_tensor.dtype,
                 ).to(device)
         else:
             return torch.empty(
-                square_side_length, state.matrix_approximation_rank, device=device
+                square_side_length,
+                state.matrix_approximation_rank,
+                device=device,
+                dtype=input_tensor.dtype,
             )
 
     p = create_low_rank_tensor(fill_random_values=False, rng=state.rng)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48902 [Gradient Compression] Let the dtype of created low-rank tensors P and Q be the same type as the input tensor**

Previously if the dtype of input gradients is FP16, matrix multiplications will fail, because the created low-rank tensors P and Q use FP32 dtype.

Now let the dtype of P and Q be the same as the input tensor.

Original PR issue: Investigate Applying PowerSGD to Communication Hook for Gradient Compression #47202

Differential Revision: [D25362071](https://our.internmc.facebook.com/intern/diff/D25362071/)