### PR TITLE
Add object-based collective APIs to public docs 

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -384,15 +384,23 @@ Collective functions
 
 .. autofunction:: broadcast 
 
+.. autofunction:: broadcast_object_list
+
 .. autofunction:: all_reduce
 
 .. autofunction:: reduce
 
 .. autofunction:: all_gather
 
+.. autofunction:: all_gather_object
+
 .. autofunction:: gather
 
+.. autofunction:: gather_object
+
 .. autofunction:: scatter
+
+.. autofunction:: scatter_object_list
 
 .. autofunction:: reduce_scatter
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #43932 [Docs] Add examples for new object-based c10d APIs
* **#48909 Add object-based collective APIs to public docs**

Adds these new APIs to the documentation

Differential Revision: [D25363279](https://our.internmc.facebook.com/intern/diff/D25363279/)