### PR TITLE
disable is_non_overlapping_and_dense for sparse tensors

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -54,6 +54,9 @@ IntArrayRef SparseTensorImpl::strides() const {
 bool SparseTensorImpl::is_contiguous(at::MemoryFormat memory_format) const {
   AT_ERROR("sparse tensors do not have is_contiguous");
 }
+bool SparseTensorImpl::is_non_overlapping_and_dense() const {
+  AT_ERROR("sparse tensors do not have is_non_overlapping_and_dense");
+}
 int64_t SparseTensorImpl::stride(int64_t d) const {
   AT_ERROR("sparse tensors do not have strides");
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -42,6 +42,7 @@ public:
 
   IntArrayRef strides() const override;
   bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const override;
+  bool is_non_overlapping_and_dense() const override;
   int64_t stride(int64_t d) const override;
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -33,7 +33,7 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
                   (options.layout() == c10::kStrided));
 
   if (memory_format == MemoryFormat::Preserve) {
-    if (self.is_non_overlapping_and_dense()) {
+    if (self.layout() != c10::kSparse && self.is_non_overlapping_and_dense()) {
       // Copy all strides
       auto r = at::empty_strided(self.sizes(),
                                  self.strides(),

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -311,7 +311,7 @@ Tensor empty_like(
   Tensor result;
 
   if (memory_format == MemoryFormat::Preserve) {
-    if (self.is_non_overlapping_and_dense()) {
+    if (self.layout() != c10::kSparse && self.is_non_overlapping_and_dense()) {
       result = at::empty_strided(self.sizes(), self.strides(), options.memory_format(c10::nullopt));
     } else if (self.unsafeGetTensorImpl()->support_as_strided() && self.layout() == kStrided) {
       // If input tensor is not dense and non-overlapping but strided, we will infer an output strides

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1437,7 +1437,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return is_channels_last_3d_;
   }
 
-  bool is_non_overlapping_and_dense() const {
+  virtual bool is_non_overlapping_and_dense() const {
     return is_non_overlapping_and_dense_;
   }
 


### PR DESCRIPTION
Fixes #48892
`is_non_overlapping_and_dense` is now virtual, like `is_contiguous`.

