### PR TITLE
add channels last for AdaptiveAvgPool2d

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -1,7 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
-#include <ATen/Parallel.h>
-#include <tuple>
+#include <ATen/native/AdaptivePooling.h>
 
 
 namespace at {
@@ -9,295 +8,66 @@ namespace native {
 
 namespace {
 
-  inline int start_index(int a, int b, int c) {
-    return (int)std::floor((float)(a * c) / b);
-  }
-
-  inline int end_index(int a, int b, int c) {
-    return (int)std::ceil((float)((a + 1) * c) / b);
-  }
-
-  template <typename scalar_t>
-  static void adaptive_avg_pool2d_single_out_frame(
-            scalar_t *input_p,
-            scalar_t *output_p,
-            int64_t sizeD,
-            int64_t isizeH,
-            int64_t isizeW,
-            int64_t osizeH,
-            int64_t osizeW,
-            int64_t istrideD,
-            int64_t istrideH,
-            int64_t istrideW)
-  {
-    at::parallel_for(0, sizeD, 0, [&](int64_t start, int64_t end) {
-      for (auto d = start; d < end; d++)
-      {
-        /* loop over output */
-        int64_t oh, ow;
-        for(oh = 0; oh < osizeH; oh++)
-        {
-          int istartH = start_index(oh, osizeH, isizeH);
-          int iendH   = end_index(oh, osizeH, isizeH);
-          int kH = iendH - istartH;
-
-          for(ow = 0; ow < osizeW; ow++)
-          {
-            int istartW = start_index(ow, osizeW, isizeW);
-            int iendW   = end_index(ow, osizeW, isizeW);
-            int kW = iendW - istartW;
-
-            /* local pointers */
-            scalar_t *ip = input_p   + d*istrideD + istartH*istrideH + istartW*istrideW;
-            scalar_t *op = output_p  + d*osizeH*osizeW + oh*osizeW + ow;
-
-            /* compute local average: */
-            scalar_t sum = 0;
-            int ih, iw;
-            for(ih = 0; ih < kH; ih++)
-            {
-              for(iw = 0; iw < kW; iw++)
-              {
-                scalar_t val = *(ip + ih*istrideH + iw*istrideW);
-                sum += val;
-              }
-            }
-
-            /* set output to local average */
-            *op = sum / kW / kH;
-          }
-        }
-      }
-    });
-  }
-
-  template <typename scalar_t>
-  void adaptive_avg_pool2d_out_frame(
-    scalar_t *input_p,
-    scalar_t *output_p,
-    int64_t sizeB,
-    int64_t sizeD,
-    int64_t isizeH,
-    int64_t isizeW,
-    int64_t osizeH,
-    int64_t osizeW,
-    int64_t istrideB,
-    int64_t istrideD,
-    int64_t istrideH,
-    int64_t istrideW)
-  {
-    at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
-      for (auto b = start; b < end; b++)
-      {
-        adaptive_avg_pool2d_single_out_frame<scalar_t>(
-          input_p + b * istrideB,
-          output_p + b * sizeD * osizeH * osizeW,
-          sizeD,
-          isizeH, isizeW,
-          osizeH, osizeW,
-          istrideD,
-          istrideH, istrideW);
-      }
-    });
-  }
-
   void adaptive_avg_pool2d_out_cpu_template(
     at::Tensor& output,
     at::Tensor const& input,
     IntArrayRef output_size)
   {
     TORCH_CHECK(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
-    for (int64_t i = 0; i < input.ndimension(); i++) {
+    int64_t ndim = input.ndimension();
+    for (int64_t i = 0; i < ndim; i++) {
       TORCH_CHECK(input.size(i) > 0,
         "adaptive_avg_pooling2d(): expected input to have non-empty spatial dimensions, "
         "but input has sizes ", input.sizes(), " with dimension ", i, " being "
         "empty");
     }
 
-    TORCH_CHECK((input.ndimension() == 3 || input.ndimension() == 4),
+    TORCH_CHECK((ndim == 3 || ndim == 4),
       "non-empty 3D or 4D (batch mode) tensor expected for input");
+    TORCH_CHECK(input.dtype() == output.dtype(),
+      "expected dtype ", input.dtype(), " for `output` but got dtype ", output.dtype());
 
-    /* sizes */
-    int64_t sizeD  = input.size(-3);
-    int64_t isizeH = input.size(-2);
-    int64_t isizeW = input.size(-1);
-    /* strides */
-    int64_t istrideD = input.stride(-3);
-    int64_t istrideH = input.stride(-2);
-    int64_t istrideW = input.stride(-1);
+    int64_t channels  = input.size(-3);
+    int64_t input_height = input.size(-2);
+    int64_t input_width = input.size(-1);
+    int64_t output_height = output_size[0];
+    int64_t output_width = output_size[1];
 
-    auto osizeH = output_size[0];
-    auto osizeW = output_size[1];
-
-    /* resize output */
-    if (input.ndimension() == 3 || input.size(-4) == 1)
-    {
-      if (input.ndimension() == 3) {
-        output.resize_({sizeD, osizeH, osizeW});
-      } else {
-        output.resize_({1, sizeD, osizeH, osizeW});
-      }
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "adaptive_avg_pool2d_cpu", [&] {
-          auto input_data = input.data_ptr<scalar_t>();
-          auto output_data = output.data_ptr<scalar_t>();
-          adaptive_avg_pool2d_single_out_frame<scalar_t>(
-            input_data,
-            output_data,
-            sizeD,
-            isizeH, isizeW,
-            osizeH, osizeW,
-            istrideD,
-            istrideH, istrideW);
-        }
-      );
+    if (ndim == 3) {
+      output.resize_({channels, output_height, output_width});
+    } else {
+      int64_t nbatch = input.size(0);
+      output.resize_({nbatch, channels, output_height, output_width}, input.suggest_memory_format());
     }
-    else
-    {
-      int64_t sizeB = input.size(-4);
-      output.resize_({sizeB, sizeD, osizeH, osizeW});
-      int64_t istrideB = input.stride(-4);
 
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "adaptive_avg_pool2d_cpu", [&] {
-        auto input_data = input.data_ptr<scalar_t>();
-        auto output_data = output.data_ptr<scalar_t>();
-        adaptive_avg_pool2d_out_frame<scalar_t>(
-          input_data,
-          output_data,
-          sizeB,
-          sizeD,
-          isizeH, isizeW,
-          osizeH, osizeW,
-          istrideB,
-          istrideD,
-          istrideH, istrideW);
-      });
-    }
-  }
-
-  template <typename scalar_t>
-  static void adaptive_avg_pool2d_backward_single_out_frame(
-    scalar_t *gradInput_p,
-    scalar_t *gradOutput_p,
-    int64_t sizeD,
-    int64_t isizeH,
-    int64_t isizeW,
-    int64_t osizeH,
-    int64_t osizeW)
-  {
-    at::parallel_for(0, sizeD, 0, [&](int64_t start, int64_t end) {
-      for (auto d = start; d < end; d++)
-      {
-        scalar_t *gradInput_p_d = gradInput_p + d*isizeW*isizeH;
-        scalar_t *gradOutput_p_d = gradOutput_p + d*osizeW*osizeH;
-
-        /* calculate average */
-        int64_t oh, ow;
-        for(oh = 0; oh < osizeH; oh++)
-        {
-          int istartH = start_index(oh, osizeH, isizeH);
-          int iendH   = end_index(oh, osizeH, isizeH);
-          int kH = iendH - istartH;
-
-          for(ow = 0; ow < osizeW; ow++)
-          {
-
-            int istartW = start_index(ow, osizeW, isizeW);
-            int iendW   = end_index(ow, osizeW, isizeW);
-            int kW = iendW - istartW;
-
-            scalar_t grad_delta = gradOutput_p_d[oh*osizeW +ow] / kH / kW;
-
-            int ih, iw;
-            for(ih = istartH; ih < iendH; ih++)
-            {
-              for(iw = istartW; iw < iendW; iw++)
-              {
-                /* update gradient */
-                gradInput_p_d[ih*isizeW + iw] += grad_delta;
-              }
-            }
-          }
-        }
-      }
-    });
-  }
-
-  template <typename scalar_t>
-  void adaptive_avg_pool2d_backward_out_frame(
-    scalar_t *gradInput_p,
-    scalar_t *gradOutput_p,
-    int64_t sizeB,
-    int64_t sizeD,
-    int64_t isizeH,
-    int64_t isizeW,
-    int64_t osizeH,
-    int64_t osizeW)
-  {
-    at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
-      for (auto b = start; b < end; b++)
-      {
-        scalar_t *gradInput_p_d = gradInput_p + b * sizeD * isizeW * isizeH;
-        scalar_t *gradOutput_p_d = gradOutput_p + b * sizeD * osizeW * osizeH;
-        adaptive_avg_pool2d_backward_single_out_frame<scalar_t>(
-          gradInput_p_d,
-          gradOutput_p_d,
-          sizeD,
-          isizeH, isizeW,
-          osizeH, osizeW);
-      }
-    });
+    adaptive_avg_pool2d_kernel(kCPU, output, input, output_size);
   }
 
   Tensor& adaptive_avg_pool2d_backward_out_cpu_template(
-    Tensor& gradInput,
-    const Tensor& gradOutput_,
+    Tensor& grad_input,
+    const Tensor& grad_output,
     const Tensor& input)
   {
-    /* sizes */
-    int sizeD  = input.size(-3);
-    int isizeH = input.size(-2);
-    int isizeW = input.size(-1);
-    int osizeH = gradOutput_.size(-2);
-    int osizeW = gradOutput_.size(-1);
-
-    /* get contiguous gradOutput */
-    auto gradOutput = gradOutput_.contiguous();
-
-    /* backprop */
-    if (input.ndimension() == 3 || input.size(-4) == 1)
-    {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        input.scalar_type(), "adaptive_avg_pool2d_backward_cpu", [&] {
-          /* get raw pointers */
-          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-
-          adaptive_avg_pool2d_backward_single_out_frame<scalar_t>(
-            gradInput_data, gradOutput_data,
-            sizeD,
-            isizeH, isizeW,
-            osizeH, osizeW);
-        }
-      );
+    int64_t ndim = grad_output.ndimension();
+    for (int64_t i = 0; i < ndim; i++) {
+      TORCH_CHECK(grad_output.size(i) > 0,
+        "adaptive_avg_pooling2d_backward(): expected grad_output to have non-empty spatial dimensions, "
+        "but grad_output has sizes ", grad_output.sizes(), " with dimension ", i, " being "
+        "empty");
     }
-    else
-    {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        input.scalar_type(), "adaptive_avg_pool2d_backward_cpu", [&] {
-          /* get raw pointers */
-          scalar_t *gradInput_data = gradInput.data_ptr<scalar_t>();
-          scalar_t *gradOutput_data = gradOutput.data_ptr<scalar_t>();
-          int64_t sizeB = input.size(-4);
 
-          adaptive_avg_pool2d_backward_out_frame<scalar_t>(
-            gradInput_data, gradOutput_data,
-            sizeB, sizeD,
-            isizeH, isizeW,
-            osizeH, osizeW);
-        }
-      );
-    }
-    return gradInput;
+    TORCH_CHECK((ndim == 3 || ndim == 4),
+      "non-empty 3D or 4D (batch mode) tensor expected for grad_output");
+    TORCH_CHECK(input.dtype() == grad_output.dtype(),
+      "expected dtype ", input.dtype(), " for `grad_output` but got dtype ", grad_output.dtype());
+    TORCH_CHECK(input.dtype() == grad_input.dtype(),
+      "expected dtype ", input.dtype(), " for `grad_input` but got dtype ", grad_input.dtype());
+
+    grad_input.resize_(input.sizes(), input.suggest_memory_format());
+    grad_input.zero_();
+
+    adaptive_avg_pool2d_backward_kernel(kCPU, grad_input, grad_output);
+    return grad_input;
   }
 
 } // namespace
@@ -346,25 +116,27 @@ namespace {
   }
 
   Tensor& adaptive_avg_pool2d_backward_out_cpu(
-    Tensor& gradInput,
-    const Tensor& gradOutput,
+    Tensor& grad_input,
+    const Tensor& grad_output,
     const Tensor& input)
   {
-    gradInput.resize_as_(input);
     adaptive_avg_pool2d_backward_out_cpu_template(
-      gradInput, gradOutput, input);
-    return gradInput;
+      grad_input, grad_output, input);
+    return grad_input;
   }
 
   Tensor adaptive_avg_pool2d_backward_cpu(
-    const Tensor& gradOutput,
+    const Tensor& grad_output,
     const Tensor& input)
   {
-    auto gradInput = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+    auto grad_input = at::empty({0}, input.options());
     adaptive_avg_pool2d_backward_out_cpu_template(
-      gradInput, gradOutput, input);
-    return gradInput;
+      grad_input, grad_output, input);
+    return grad_input;
   }
+
+DEFINE_DISPATCH(adaptive_avg_pool2d_kernel);
+DEFINE_DISPATCH(adaptive_avg_pool2d_backward_kernel);
 
 } // at::native
 } // at

--- a/aten/src/ATen/native/AdaptivePooling.h
+++ b/aten/src/ATen/native/AdaptivePooling.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at { namespace native {
+
+using adaptive_avg_pooling_fn = void(*)(Tensor& output, const Tensor& input, IntArrayRef output_size);
+using adaptive_avg_pooling_backward_fn = void(*)(Tensor& grad_input, const Tensor& grad_output);
+DECLARE_DISPATCH(adaptive_avg_pooling_fn, adaptive_avg_pool2d_kernel);
+DECLARE_DISPATCH(adaptive_avg_pooling_backward_fn, adaptive_avg_pool2d_backward_kernel);
+
+static inline int64_t start_index(int64_t a, int64_t b, int64_t c) {
+  return (int64_t)std::floor((float)(a * c) / b);
+}
+
+static inline int64_t end_index(int64_t a, int64_t b, int64_t c) {
+  return (int64_t)std::ceil((float)((a + 1) * c) / b);
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
@@ -1,0 +1,311 @@
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/native/AdaptivePooling.h>
+#include <ATen/Parallel.h>
+#include <ATen/cpu/vec256/vec256.h>
+#include <ATen/native/cpu/utils.h>
+
+namespace at { namespace native {
+
+namespace {
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool(
+    Tensor& output_,
+    const Tensor& input_,
+    IntArrayRef output_size) {
+  auto input = input_.contiguous();
+  auto output = output_.contiguous();
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+
+  int64_t ndim = input.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? input.size(0) : input.size(0) * input.size(1);
+  int64_t input_height = input.size(-2);
+  int64_t input_width = input.size(-1);
+  int64_t output_height = output_size[0];
+  int64_t output_width = output_size[1];
+
+  // parallel on dim of N, C
+  at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t c = begin; c < end; c++) {
+      scalar_t* input_ptr = input_data + c * input_height * input_width;
+      scalar_t* output_ptr = output_data + c * output_height * output_width;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        int64_t ih0 = start_index(oh, output_height, input_height);
+        int64_t ih1 = end_index(oh, output_height, input_height);
+        int64_t kh = ih1 - ih0;
+
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t iw0 = start_index(ow, output_width, input_width);
+          int64_t iw1 = end_index(ow, output_width, input_width);
+          int64_t kw = iw1 - iw0;
+
+          // compute local average
+          scalar_t sum = 0;
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              sum += input_ptr[ih * input_width + iw];
+            }
+          }
+          output_ptr[oh * output_width + ow] = sum / kh / kw;
+        }
+      }
+    }
+  });
+
+  if (!output_.is_contiguous()) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool_channels_last(
+    Tensor& output_,
+    const Tensor& input_,
+    IntArrayRef output_size) {
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto input = input_.contiguous(memory_format);
+  auto output = output_.contiguous(memory_format);
+
+  auto input_data = input.data_ptr<scalar_t>();
+  auto output_data = output.data_ptr<scalar_t>();
+
+  int64_t nbatch = input.size(0);
+  int64_t channels = input.size(1);
+  int64_t input_height = input.size(2);
+  int64_t input_width = input.size(3);
+  int64_t output_height = output_size[0];
+  int64_t output_width = output_size[1];
+
+  using Vec = vec256::Vec256<scalar_t>;
+  // parallel on dim N, H, W
+  at::parallel_for(0, nbatch * output_height * output_width, 0, [&](int64_t begin, int64_t end) {
+    int64_t n = 0;
+    int64_t oh = 0;
+    int64_t ow = 0;
+    data_index_init(begin, n, nbatch, oh, output_height, ow, output_width);
+
+    for (int64_t i = begin; i < end; i++) {
+      int64_t ih0 = start_index(oh, output_height, input_height);
+      int64_t ih1 = end_index(oh, output_height, input_height);
+      int64_t kh = ih1 - ih0;
+
+      int64_t iw0 = start_index(ow, output_width, input_width);
+      int64_t iw1 = end_index(ow, output_width, input_width);
+      int64_t kw = iw1 - iw0;
+
+      scalar_t* out = output_data + i * channels;
+      int64_t size = channels;
+
+      // Note: For oridinary usage scenario, each out lane should
+      //   fit in L1 cache; otherwise consider block dim C.
+      // Pass I: zero the out lane
+      int64_t d1 = 0;
+      for (; d1 < size - (size % Vec::size()); d1 += Vec::size()) {
+        Vec out_vec = Vec(scalar_t(0));
+        out_vec.store(out + d1);
+      }
+      for (; d1 < size; d1++) {
+        out[d1] = scalar_t(0);
+      }
+      // Pass II: compute local sum
+      for (int64_t ih = ih0; ih < ih1; ih++) {
+        for (int64_t iw = iw0; iw < iw1; iw++) {
+          scalar_t* in = input_data + n * input_height * input_width * channels +
+              ih * input_width * channels + iw * channels;
+
+          int64_t d2 = 0;
+          for (; d2 < size - (size % Vec::size()); d2 += Vec::size()) {
+            Vec out_vec = Vec::loadu(out + d2) + Vec::loadu(in + d2);
+            out_vec.store(out + d2);
+          }
+          for (; d2 < size; d2++) {
+            out[d2] += in[d2];
+          }
+        }
+      }
+      // Pass III: compute local average
+      int64_t d3 = 0;
+      for (; d3 < size - (size % Vec::size()); d3 += Vec::size()) {
+        Vec out_vec = Vec::loadu(out + d3) / Vec(scalar_t(kh * kw));
+        out_vec.store(out + d3);
+      }
+      for (; d3 < size; d3++) {
+        out[d3] = out[d3] / kh / kw;
+      }
+
+      // move on to next output index
+      data_index_step(n, nbatch, oh, output_height, ow, output_width);
+    }
+  });
+
+  if (!output_.is_contiguous(memory_format)) {
+    output_.copy_(output);
+  }
+}
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool_backward(
+    Tensor& grad_input_,
+    const Tensor& grad_output_) {
+  auto grad_output = grad_output_.contiguous();
+  auto grad_input = grad_input_.contiguous();
+
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+
+  int64_t ndim = grad_output.ndimension();
+  // treat batch size and channels as one dimension
+  int64_t channels = ndim == 3 ? grad_output.size(0) : grad_output.size(0) * grad_output.size(1);
+  int64_t input_height = grad_input.size(-2);
+  int64_t input_width = grad_input.size(-1);
+  int64_t output_height = grad_output.size(-2);
+  int64_t output_width = grad_output.size(-1);
+
+  // parallel on dim of N, C
+  at::parallel_for(0, channels, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t c = begin; c < end; c++) {
+      scalar_t* grad_input_ptr = grad_input_data + c * input_height * input_width;
+      scalar_t* grad_output_ptr = grad_output_data + c * output_height * output_width;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        int64_t ih0 = start_index(oh, output_height, input_height);
+        int64_t ih1 = end_index(oh, output_height, input_height);
+        int64_t kh = ih1 - ih0;
+
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t iw0 = start_index(ow, output_width, input_width);
+          int64_t iw1 = end_index(ow, output_width, input_width);
+          int64_t kw = iw1 - iw0;
+
+          scalar_t grad_delta = grad_output_ptr[oh * output_width + ow] / kh / kw;
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              grad_input_ptr[ih * input_width + iw] += grad_delta;
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous()) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+template <typename scalar_t>
+void cpu_adaptive_avg_pool_backward_channels_last(
+    Tensor& grad_input_,
+    const Tensor& grad_output_) {
+  auto memory_format = at::MemoryFormat::ChannelsLast;
+  auto grad_input = grad_input_.contiguous(memory_format);
+  auto grad_output = grad_output_.contiguous(memory_format);
+
+  auto grad_input_data = grad_input.data_ptr<scalar_t>();
+  auto grad_output_data = grad_output.data_ptr<scalar_t>();
+
+  int64_t nbatch = grad_input.size(0);
+  int64_t channels = grad_input.size(1);
+  int64_t input_height = grad_input.size(2);
+  int64_t input_width = grad_input.size(3);
+  int64_t output_height = grad_output.size(2);
+  int64_t output_width = grad_output.size(3);
+
+  using Vec = vec256::Vec256<scalar_t>;
+  // parallel on dim N
+  at::parallel_for(0, nbatch, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t n = begin; n < end; n++) {
+      scalar_t* grad_input_ptr = grad_input_data + n * input_height * input_width * channels;
+      scalar_t* grad_output_ptr = grad_output_data + n * output_height * output_width * channels;
+
+      for (int64_t oh = 0; oh < output_height; oh++) {
+        int64_t ih0 = start_index(oh, output_height, input_height);
+        int64_t ih1 = end_index(oh, output_height, input_height);
+        int64_t kh = ih1 - ih0;
+
+        for (int64_t ow = 0; ow < output_width; ow++) {
+          int64_t iw0 = start_index(ow, output_width, input_width);
+          int64_t iw1 = end_index(ow, output_width, input_width);
+          int64_t kw = iw1 - iw0;
+
+          scalar_t* gout = grad_output_ptr + oh * output_width * channels + ow * channels;
+          int64_t size = channels;
+          for (int64_t ih = ih0; ih < ih1; ih++) {
+            for (int64_t iw = iw0; iw < iw1; iw++) {
+              scalar_t* gin = grad_input_ptr + ih * input_width * channels + iw * channels;
+
+              int64_t d = 0;
+              for (; d < size - (size % Vec::size()); d += Vec::size()) {
+                Vec gin_vec = Vec::loadu(gin + d) + Vec::loadu(gout + d) / Vec(scalar_t(kh * kw));
+                gin_vec.store(gin + d);
+              }
+              for (; d < size; d++) {
+                gin[d] += gout[d] / kw / kw;
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!grad_input_.is_contiguous(memory_format)) {
+    grad_input_.copy_(grad_input);
+  }
+}
+
+void adaptive_avg_pool2d_kernel_impl(
+    Tensor& output,
+    const Tensor& input,
+    IntArrayRef output_size) {
+  switch (input.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d", [&] {
+        cpu_adaptive_avg_pool<scalar_t>(output, input, output_size);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d_channels_last", [&]{
+        cpu_adaptive_avg_pool_channels_last<scalar_t>(output, input, output_size);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+void adapative_avg_pool2d_backward_kernel_impl(
+    Tensor& grad_input,
+    const Tensor& grad_output) {
+  switch (grad_output.suggest_memory_format()) {
+    case at::MemoryFormat::Contiguous: {
+      AT_DISPATCH_FLOATING_TYPES(grad_output.scalar_type(), "adaptive_avg_pool2d_backward", [&] {
+        cpu_adaptive_avg_pool_backward<scalar_t>(grad_input, grad_output);
+      });
+      break;
+    }
+    case at::MemoryFormat::ChannelsLast: {
+      AT_DISPATCH_FLOATING_TYPES(grad_output.scalar_type(), "adaptive_avg_pool2d_backward_channels_last", [&]{
+        cpu_adaptive_avg_pool_backward_channels_last<scalar_t>(grad_input, grad_output);
+      });
+      break;
+    }
+    default:
+      TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
+  }
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(adaptive_avg_pool2d_kernel, &adaptive_avg_pool2d_kernel_impl);
+REGISTER_DISPATCH(adaptive_avg_pool2d_backward_kernel, &adapative_avg_pool2d_backward_kernel_impl);
+
+}} // at::native

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -4,35 +4,11 @@
 #include <ATen/native/UpSample.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec256/vec256.h>
+#include <ATen/native/cpu/utils.h>
 
 namespace at {
 namespace native {
 namespace {
-
-template <typename T>
-inline T data_index_init(T offset) {
-  return offset;
-}
-
-template <typename T, typename... Args>
-inline T data_index_init(T offset, T &x, const T &X, Args &&... args) {
-  offset = data_index_init(offset, std::forward<Args>(args)...);
-  x = offset % X;
-  return offset / X;
-}
-
-inline bool data_index_step() {
-  return true;
-}
-
-template <typename T, typename... Args>
-inline bool data_index_step(T &x, const T &X, Args &&... args) {
-  if (data_index_step(std::forward<Args>(args)...)) {
-    x = ((x + 1) == X) ? 0 : (x + 1);
-    return x == 0;
-  }
-  return false;
-}
 
 static inline int64_t nearest_idx(
     int64_t output_index,

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace at { namespace native { namespace {
+
+template <typename T>
+inline T data_index_init(T offset) {
+  return offset;
+}
+
+template <typename T, typename... Args>
+inline T data_index_init(T offset, T &x, const T &X, Args &&... args) {
+  offset = data_index_init(offset, std::forward<Args>(args)...);
+  x = offset % X;
+  return offset / X;
+}
+
+inline bool data_index_step() {
+  return true;
+}
+
+template <typename T, typename... Args>
+inline bool data_index_step(T &x, const T &X, Args &&... args) {
+  if (data_index_step(std::forward<Args>(args)...)) {
+    x = ((x + 1) == X) ? 0 : (x + 1);
+    return x == 0;
+  }
+  return false;
+}
+
+}}}  // namespace at::native::<anonymous>

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3587,49 +3587,57 @@ class TestNN(NNTestCase):
                 output = module(input)
                 self.assertEqual(output.size(), (4,) + (2,) * (numel - 1) + (4,))
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_adaptive_pooling_avg_nhwc(self):
-        input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32, device="cuda")
-        input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
-        grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32, device="cuda")
-        pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        device_list = ['cpu']
+        if TEST_CUDA:
+            device_list.append('cuda')
 
-        ref_input = input.detach().clone().contiguous().requires_grad_(True)
-        ref_grad = grad.detach().clone().contiguous()
-        ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        for device in device_list:
+            input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
+            input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
+            grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
+            pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        out = pool(input)
-        out.backward(grad)
-        ref_out = ref_pool(ref_input)
-        ref_out.backward(ref_grad)
+            ref_input = input.detach().clone().contiguous().requires_grad_(True)
+            ref_grad = grad.detach().clone().contiguous()
+            ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-        self.assertTrue(ref_out.is_contiguous())
-        self.assertEqual(out, ref_out)
-        self.assertEqual(input.grad, ref_input.grad)
+            out = pool(input)
+            out.backward(grad)
+            ref_out = ref_pool(ref_input)
+            ref_out.backward(ref_grad)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+            self.assertTrue(ref_out.is_contiguous())
+            self.assertEqual(out, ref_out)
+            self.assertEqual(input.grad, ref_input.grad)
+
     def test_adaptive_pooling_avg_nhwc_non_contiguous(self):
-        input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32, device="cuda")
-        input = input.contiguous(memory_format=torch.channels_last)
-        input = input[:, ::2, :, :].requires_grad_()
-        grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32, device="cuda")
-        grad = grad[:, ::2, :, :]
-        pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        device_list = ['cpu']
+        if TEST_CUDA:
+            device_list.append('cuda')
 
-        ref_input = input.detach().clone().contiguous().requires_grad_(True)
-        ref_grad = grad.detach().clone().contiguous()
-        ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).cuda()
+        for device in device_list:
+            input = torch.randint(1, 10, (4, 8, 8, 8), dtype=torch.float32).to(device)
+            input = input.contiguous(memory_format=torch.channels_last)
+            input = input[:, ::2, :, :].requires_grad_()
+            grad = torch.randint(1, 10, (4, 8, 7, 7), dtype=torch.float32).to(device)
+            grad = grad[:, ::2, :, :]
+            pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        out = pool(input)
-        out.backward(grad)
-        ref_out = ref_pool(ref_input)
-        ref_out.backward(ref_grad)
+            ref_input = input.detach().clone().contiguous().requires_grad_(True)
+            ref_grad = grad.detach().clone().contiguous()
+            ref_pool = torch.nn.AdaptiveAvgPool2d((7, 7)).to(device)
 
-        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-        self.assertTrue(ref_out.is_contiguous())
-        self.assertEqual(out, ref_out)
-        self.assertEqual(input.grad, ref_input.grad)
+            out = pool(input)
+            out.backward(grad)
+            ref_out = ref_pool(ref_input)
+            ref_out.backward(ref_grad)
+
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+            self.assertTrue(ref_out.is_contiguous())
+            self.assertEqual(out, ref_out)
+            self.assertEqual(input.grad, ref_input.grad)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @largeTensorTest('12GB', device='cuda')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #48920 add channels last for AdapativeMaxPool2d
* #48919 optimize channels last for BatchNorm2d on CPU
* #48918 add channels last support for AvgPool2d on CPU
* #48917 add channels last for MaxPool2d
* **#48916 add channels last for AdaptiveAvgPool2d**

optimize adaptive average pool2d forward path

optimize adaptive average pool2d backward path

remove unused headers

minor change

minor change

rename the header; add adaptive max pooling in future.

minor change

loosen adapative_pool2d test on nhwc to both device cuda and cpu

minor change

Differential Revision: [D25399469](https://our.internmc.facebook.com/intern/diff/D25399469)