### PR TITLE
Improve efficiency of Adam as described in paper

### DIFF
--- a/torch/optim/_multi_tensor/adam.py
+++ b/torch/optim/_multi_tensor/adam.py
@@ -126,16 +126,12 @@ class Adam(Optimizer):
 
                 # Use the max. for normalizing running avg. of gradient
                 max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sq)
-                bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
-                torch._foreach_div_(max_exp_avg_sq_sqrt, bias_correction_sqrt)
                 denom = torch._foreach_add(max_exp_avg_sq_sqrt, group['eps'])
             else:
                 exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sq)
-                bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
-                torch._foreach_div_(exp_avg_sq_sqrt, bias_correction_sqrt)
                 denom = torch._foreach_add(exp_avg_sq_sqrt, group['eps'])
 
-            step_size = [(group['lr'] / bc) * -1 for bc in bias_correction1]
+            step_size = [(group['lr'] * math.sqrt(bc2) / bc1) * -1 for bc1, bc2 in zip(bias_correction1, bias_correction2)]
             torch._foreach_addcdiv_(params_with_grad, exp_avg, denom, step_size)
 
         return loss

--- a/torch/optim/functional.py
+++ b/torch/optim/functional.py
@@ -89,10 +89,10 @@ def adam(params: List[Tensor],
             # Maintains the maximum of all 2nd moment running avg. till now
             torch.maximum(max_exp_avg_sq, exp_avg_sq, out=max_exp_avg_sq)
             # Use the max. for normalizing running avg. of gradient
-            denom = (max_exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
+            denom = max_exp_avg_sq.sqrt().add_(eps)
         else:
-            denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
+            denom = exp_avg_sq.sqrt().add_(eps)
 
-        step_size = lr / bias_correction1
+        step_size = lr *  math.sqrt(bias_correction2) / bias_correction1
 
         param.addcdiv_(exp_avg, denom, value=-step_size)

--- a/torch/optim/functional.py
+++ b/torch/optim/functional.py
@@ -93,6 +93,6 @@ def adam(params: List[Tensor],
         else:
             denom = exp_avg_sq.sqrt().add_(eps)
 
-        step_size = lr *  math.sqrt(bias_correction2) / bias_correction1
+        step_size = lr * math.sqrt(bias_correction2) / bias_correction1
 
         param.addcdiv_(exp_avg, denom, value=-step_size)


### PR DESCRIPTION
[The paper](https://arxiv.org/pdf/1412.6980.pdf) (page 2 one before last paragraph) describes

> Note that the efficiency of algorithm 1 can, at the expense of clarity, be improved upon by changing
> the order of computation, e.g. by replacing the last three lines in the loop with the following lines:
> ...

This changes the hyper parameter epsilon, but the change is so small and can be ignored. I guess.

I came across this while implementing Adam as a tutorial on ([Github repo](https://github.com/lab-ml/nn)) and saw 
a performance gain of about 5%-10% when the scalar multiplication are combined (which is can be expected).

[Here is a link to the short code where I did the performance test](https://lab-ml.com/labml_nn/optimizers/performance_test.html). It includes a link to Google Colab as well.
