### PR TITLE
add user vs internal msg support in common_utils.TestCase

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -434,9 +434,9 @@ class TestTesting(TestCase):
 
     def test_assert_messages(self, device):
         self.assertIsNone(self._get_assert_msg(msg=None))
-        self.assertEqual("no_debug_msg", self._get_assert_msg("no_debug_msg"))
-        self.assertEqual("\nno_user_msg", self._get_assert_msg(msg=None, debug_msg="no_user_msg"))
-        self.assertEqual("user_msg\ndebug_msg", self._get_assert_msg(msg="user_msg", debug_msg="debug_msg"))
+        self.assertEqual("\nno_debug_msg", self._get_assert_msg("no_debug_msg"))
+        self.assertEqual("no_user_msg", self._get_assert_msg(msg=None, debug_msg="no_user_msg"))
+        self.assertEqual("debug_msg\nuser_msg", self._get_assert_msg(msg="user_msg", debug_msg="debug_msg"))
 
 instantiate_device_type_tests(TestTesting, globals())
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -432,6 +432,12 @@ class TestTesting(TestCase):
         with self.assertRaises(RuntimeError):
             torch.isclose(t, t, atol=-1, rtol=-1)
 
+    def test_assert_messages(self, device):
+        self.assertIsNone(self._get_assert_msg(msg=None))
+        self.assertEqual("no_debug_msg", self._get_assert_msg("no_debug_msg"))
+        self.assertEqual("\nno_user_msg", self._get_assert_msg(msg=None, debug_msg="no_user_msg"))
+        self.assertEqual("user_msg\ndebug_msg", self._get_assert_msg(msg="user_msg", debug_msg="debug_msg"))
+
 instantiate_device_type_tests(TestTesting, globals())
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1041,10 +1041,10 @@ class TestCase(expecttest.TestCase):
 
     # Construct assert messages basd on internal debug message and user provided message.
     def _get_assert_msg(self, msg, debug_msg=None):
-        if debug_msg is None:
-            return msg
+        if msg is None:
+            return debug_msg
         else:
-            return f"\n{debug_msg}" if msg is None else f"{msg}\n{debug_msg}"
+            return f"\n{msg}" if debug_msg is None else f"{debug_msg}\n{msg}"
 
     def assertEqualIgnoreType(self, *args, **kwargs) -> None:
         # If you are seeing this function used, that means test is written wrongly

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1039,12 +1039,12 @@ class TestCase(expecttest.TestCase):
 
         return _compare_scalars_internal(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
-    # Construct assert messages basd on internal messages and user message.
+    # Construct assert messages basd on internal debug message and user provided message.
     def _get_assert_msg(self, msg, debug_msg=None):
-        if msg is None:
-            return f"\n{debug_msg}"
+        if debug_msg is None:
+            return msg
         else:
-            return f"\n{msg}\n{debug_msg}"
+            return f"\n{debug_msg}" if msg is None else f"{msg}\n{debug_msg}"
 
     def assertEqualIgnoreType(self, *args, **kwargs) -> None:
         # If you are seeing this function used, that means test is written wrongly
@@ -1152,12 +1152,12 @@ class TestCase(expecttest.TestCase):
                     debug_msg = "Tensors failed to compare as equal!" + debug_msg_generic
                 super().assertTrue(result, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
         elif isinstance(x, string_classes) and isinstance(y, string_classes):
-            debug_msg = ("Attempted to compare with different [string] types: "
-                         f"Expected: {isinstance(x, string_classes)}; Actual: {isinstance(y, string_classes)}.")
+            debug_msg = ("Attempted to compare [string] types: "
+                         f"Expected: {repr(x)}; Actual: {repr(y)}.")
             super().assertEqual(x, y, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
         elif type(x) == set and type(y) == set:
-            debug_msg = ("Attempted to compare with different [set] types: "
-                         f"Expected: {type(x) == set}; Actual: {type(y) == set}.")
+            debug_msg = ("Attempted to compare [set] types: "
+                         f"Expected: {x}; Actual: {y}.")
             super().assertEqual(x, y, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
         elif isinstance(x, dict) and isinstance(y, dict):
             if isinstance(x, OrderedDict) and isinstance(y, OrderedDict):
@@ -1175,11 +1175,11 @@ class TestCase(expecttest.TestCase):
                                  exact_dtype=exact_dtype, exact_device=exact_device)
         elif isinstance(x, type) and isinstance(y, type):
             # See TestTorch.test_assert_equal_generic_meta
-            debug_msg = ("Attempted to compare with different [type] types: "
-                         f"Expected: {isinstance(x, type)}; Actual: {isinstance(y, type)}.")
+            debug_msg = ("Attempted to compare [type] types: "
+                         f"Expected: {x}; Actual: {y}.")
             super().assertEqual(x, y, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
         elif is_iterable(x) and is_iterable(y):
-            debug_msg = ("Attempted to compare iterables with different length: "
+            debug_msg = ("Attempted to compare the lengths of [iterable] types: "
                          f"Expected: {len(x)}; Actual: {len(y)}.")
             super().assertEqual(len(x), len(y), msg=self._get_assert_msg(msg, debug_msg=debug_msg))
             for x_, y_ in zip(x, y):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1042,9 +1042,9 @@ class TestCase(expecttest.TestCase):
     # Construct assert messages basd on internal messages and user message.
     def _get_assert_msg(self, msg, debug_msg=None):
         if msg is None:
-            return f"internal assert message: {debug_msg}"
+            return f"\n{debug_msg}"
         else:
-            return f"user assert message: {msg}; internal assert message: {debug_msg}"
+            return f"\n{msg}\n{debug_msg}"
 
     def assertEqualIgnoreType(self, *args, **kwargs) -> None:
         # If you are seeing this function used, that means test is written wrongly

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1040,7 +1040,7 @@ class TestCase(expecttest.TestCase):
         return _compare_scalars_internal(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
     # Construct assert messages basd on internal messages and user message.
-    def _get_assert_msg(msg=msg, internal_msg=None): 
+    def _get_assert_msg(self, msg, internal_msg=None):
         if msg is None:
             return f"internal assert message: {internal_msg}"
         else:
@@ -1107,7 +1107,7 @@ class TestCase(expecttest.TestCase):
                 if not values_result:
                     assert debug_msg is not None
                     debug_msg = "Sparse tensor values failed to compare as equal! " + debug_msg
-                super().assertTrue(values_result, msg=msg=_get_assert_msg(msg, internal_msg=debug_msg))
+                super().assertTrue(values_result, msg=_get_assert_msg(msg, internal_msg=debug_msg))
             elif x.is_quantized and y.is_quantized:
                 self.assertEqual(x.qscheme(), y.qscheme(), atol=atol, rtol=rtol,
                                  msg=msg, exact_dtype=exact_dtype,

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1057,6 +1057,7 @@ class TestCase(expecttest.TestCase):
                     atol: Optional[float] = None, rtol: Optional[float] = None,
                     equal_nan=True, exact_dtype=True, exact_device=False) -> None:
         assert (atol is None) == (rtol is None), "If one of atol or rtol is specified, then the other must be too"
+        debug_msg: Optional[str] = None
 
         # Tensor x Number and Number x Tensor comparisons
         if isinstance(x, torch.Tensor) and isinstance(y, Number):
@@ -1180,7 +1181,7 @@ class TestCase(expecttest.TestCase):
         elif is_iterable(x) and is_iterable(y):
             debug_msg = ("Attempted to compare iterables with different length: "
                          f"Expected: {len(x)}; Actual: {len(y)}.")
-            super().assertEqual(x, y, msg=self._get_assert_msg(msg, debug_msg=debug_msg))
+            super().assertEqual(len(x), len(y), msg=self._get_assert_msg(msg, debug_msg=debug_msg))
             for x_, y_ in zip(x, y):
                 self.assertEqual(x_, y_, atol=atol, rtol=rtol, msg=msg,
                                  exact_dtype=exact_dtype, exact_device=exact_device)


### PR DESCRIPTION
should fixes #48879.

To test the effect of the messages: make test break, such as add `self.assertEqual(1, 2, "user_msg")` to any test
* Before:
```
AssertionError: False is not true : user_msg
```
* After
```
AssertionError: False is not true : Scalars failed to compare as equal! Comparing 1 and 2 gives a difference of 1, but the allowed difference with rtol=0 and atol=0 is only 0!
user_msg; 
```