### PR TITLE
Added entry for torch.linalg.cond to linalg.rst

### DIFF
--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -13,6 +13,7 @@ Functions
 ---------
 
 .. autofunction:: cholesky
+.. autofunction:: cond
 .. autofunction:: det
 .. autofunction:: eigh
 .. autofunction:: eigvalsh


### PR DESCRIPTION
This PR makes documentation for `cond` available at https://pytorch.org/docs/master/linalg.html
I forgot to include this change in #45832.