### PR TITLE
docker: Add make variable to add docker build args

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -1,31 +1,38 @@
-DOCKER_REGISTRY  = docker.io
-DOCKER_ORG       = $(shell docker info 2>/dev/null | sed '/Username:/!d;s/.* //')
-DOCKER_IMAGE     = pytorch
-DOCKER_FULL_NAME = $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE)
+DOCKER_REGISTRY           = docker.io
+DOCKER_ORG                = $(shell docker info 2>/dev/null | sed '/Username:/!d;s/.* //')
+DOCKER_IMAGE              = pytorch
+DOCKER_FULL_NAME          = $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE)
 
 ifeq ("$(DOCKER_ORG)","")
 $(warning WARNING: No docker user found using results from whoami)
-DOCKER_ORG       = $(shell whoami)
+DOCKER_ORG                = $(shell whoami)
 endif
 
-CUDA_VERSION     = 11.0
-CUDNN_VERSION    = 8
-BASE_RUNTIME     = ubuntu:18.04
-BASE_DEVEL       = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu18.04
+CUDA_VERSION              = 11.0
+CUDNN_VERSION             = 8
+BASE_RUNTIME              = ubuntu:18.04
+BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu18.04
 
 # The conda channel to use to install pytorch / torchvision
-INSTALL_CHANNEL  = pytorch
+INSTALL_CHANNEL           = pytorch
 
-PYTHON_VERSION   = 3.7
+PYTHON_VERSION            = 3.7
 # Can be either official / dev
-BUILD_TYPE       = dev
-BUILD_PROGRESS   = auto
-BUILD_ARGS       = --build-arg BASE_IMAGE=$(BASE_IMAGE) \
-				   --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
-				   --build-arg CUDA_VERSION=$(CUDA_VERSION) \
-				   --build-arg INSTALL_CHANNEL=$(INSTALL_CHANNEL)
-DOCKER_BUILD     = DOCKER_BUILDKIT=1 docker build --progress=$(BUILD_PROGRESS) --target $(BUILD_TYPE) -t $(DOCKER_FULL_NAME):$(DOCKER_TAG) $(BUILD_ARGS) .
-DOCKER_PUSH      = docker push $(DOCKER_FULL_NAME):$(DOCKER_TAG)
+BUILD_TYPE                = dev
+BUILD_PROGRESS            = auto
+BUILD_ARGS                = --build-arg BASE_IMAGE=$(BASE_IMAGE) \
+							--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+							--build-arg CUDA_VERSION=$(CUDA_VERSION) \
+							--build-arg INSTALL_CHANNEL=$(INSTALL_CHANNEL)
+EXTRA_DOCKER_BUILD_FLAGS ?=
+DOCKER_BUILD              = DOCKER_BUILDKIT=1 \
+							docker build \
+								--progress=$(BUILD_PROGRESS) \
+								$(EXTRA_DOCKER_BUILD_FLAGS) \
+								--target $(BUILD_TYPE) \
+								-t $(DOCKER_FULL_NAME):$(DOCKER_TAG) \
+								$(BUILD_ARGS) .
+DOCKER_PUSH               = docker push $(DOCKER_FULL_NAME):$(DOCKER_TAG)
 
 .PHONY: all
 all: devel-image


### PR DESCRIPTION
Adds an extra make variable 'EXTRA_DOCKER_BUILD_FLAGS' that allows us to
add extra docker build flags to the docker build command.

Example:

    make -f docker.Makefile EXTRA_DOCKER_BUILD_FLAGS=--no-cache devel-image

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
