### PR TITLE
migrating some straggler pytorch ops in fbcode to the new registration API

### DIFF
--- a/benchmarks/operator_benchmark/pt_extension/extension.cpp
+++ b/benchmarks/operator_benchmark/pt_extension/extension.cpp
@@ -17,9 +17,10 @@ List<Tensor> consume_list(List<Tensor> a) {
 // That caused an issue for our op benchmark which needs to run an op
 // in a loop and report the execution time. This diff resolves that issue by
 // registering this consume op with correct alias information which is DEFAULT.
-auto reg = torch::RegisterOperators()
-               .op("operator_benchmark::_consume", &consume)
-               .op("operator_benchmark::_consume.list", &consume_list);
+TORCH_LIBRARY_FRAGMENT(operator_benchmark, m) {
+    m.def("_consume", &consume);
+    m.def("_consume_list", &consume_list);
+}
 
 PYBIND11_MODULE(cpp_extension, m) {
   m.def("_consume", &consume, "consume");

--- a/torch/csrc/autograd/record_function_ops.cpp
+++ b/torch/csrc/autograd/record_function_ops.cpp
@@ -65,10 +65,10 @@ c10::intrusive_ptr<c10::ivalue::Future> _call_end_callbacks_on_fut(
 }
 
 // Internal only, do not use directly, use Python's record_function()
-static auto registry =
-    RegisterOperators()
-        .op("profiler::_record_function_enter", &record_function_enter)
-        .op("profiler::_record_function_exit", &record_function_exit);
+TORCH_LIBRARY_FRAGMENT(profiler, m) {
+    m.def("_record_function_enter", &record_function_enter);
+    m.def("_record_function_exit", &record_function_exit);
+}
 
 // Needed to register JIT operator in operator registry below
 c10::AliasAnalysisKind aliasAnalysisFromSchema() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Differential Revision: [D25380422](https://our.internmc.facebook.com/intern/diff/D25380422/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D25380422/)!