### PR TITLE
updated grammar on tech docs

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -5,7 +5,7 @@ tensors and defines mathematical operations over these tensors.
 Additionally, it provides many utilities for efficient serializing of
 Tensors and arbitrary types, and other useful utilities.
 
-It has a CUDA counterpart, that enables you to run your tensor computations
+It has a CUDA counterpart that enables you to run your tensor computations
 on an NVIDIA GPU with compute capability >= 3.0.
 """
 
@@ -327,7 +327,7 @@ def set_default_dtype(d):
 
 def set_deterministic(d):
     r""" Sets whether PyTorch operations must use "deterministic"
-    algorithms. That is, algorithms which, given the same input, and when
+    algorithms. That is, algorithms, when given the same input and
     run on the same software and hardware, always produce the same output.
     When True, operations will use deterministic algorithms when available,
     and if only nondeterministic algorithms are available they will throw a


### PR DESCRIPTION
Small grammatical updates/rephrase on the torch tech doc. 

<img width="847" alt="Screen Shot 2020-12-07 at 6 05 59 PM" src="https://user-images.githubusercontent.com/63327286/101416031-fa54d900-38b6-11eb-84b3-0066d47499fd.png">
<img width="845" alt="Screen Shot 2020-12-07 at 6 06 18 PM" src="https://user-images.githubusercontent.com/63327286/101416033-fc1e9c80-38b6-11eb-94d9-1546af866da2.png">
