### PR TITLE
[FX] Fix create_arg for NamedTuple

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1154,6 +1154,12 @@ class TestFX(JitTestCase):
         m = FooBar1234()
         self.checkGraphModule(m, ())
 
+    def test_namedtuple_return_trace(self):
+        class NamedTupReturn(torch.nn.Module):
+            def forward(self, x):
+                return Pair(x, x)
+
+        traced = symbolic_trace(NamedTupReturn())
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -190,9 +190,12 @@ class Node:
 
 def map_arg(a: Argument, fn: Callable[[Node], Argument]) -> Argument:
     """ Apply fn to each Node appearing arg. arg may be a list, tuple, slice, or dict with string keys. """
-    if isinstance(a, tuple):
+    if isinstance(a, tuple) and hasattr(a, '_fields'):
+        elements = tuple(map_arg(elem, fn) for elem in a)
+        return type(a)(*elements)  # type: ignore
+    elif isinstance(a, tuple):
         return tuple(map_arg(elem, fn) for elem in a)
-    if isinstance(a, list):
+    elif isinstance(a, list):
         return immutable_list(map_arg(elem, fn) for elem in a)
     elif isinstance(a, dict):
         return immutable_dict((k, map_arg(v, fn)) for k, v in a.items())

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -51,7 +51,14 @@ class TracerBase:
         """
         # aggregates
         if isinstance(a, (tuple, list)):
-            return type(a)(self.create_arg(elem) for elem in a)
+            if hasattr(a, '_fields'):
+                # NamedTuple constructors don't seem to like getting a generator
+                # expression as an argument to their constructor, so build this
+                # intermediate tuple and unpack it into the NamedTuple constructor
+                args = tuple(self.create_arg(elem) for elem in a)
+                return type(a)(*args)
+            else:
+                return type(a)(self.create_arg(elem) for elem in a)
         elif isinstance(a, dict):
             r = {}
             for k, v in a.items():

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -50,15 +50,14 @@ class TracerBase:
         Can be override to support more trace-specific types.
         """
         # aggregates
-        if isinstance(a, (tuple, list)):
-            if hasattr(a, '_fields'):
-                # NamedTuple constructors don't seem to like getting a generator
-                # expression as an argument to their constructor, so build this
-                # intermediate tuple and unpack it into the NamedTuple constructor
-                args = tuple(self.create_arg(elem) for elem in a)
-                return type(a)(*args) # type: ignore
-            else:
-                return type(a)(self.create_arg(elem) for elem in a)
+        if isinstance(a, tuple) and hasattr(a, '_fields'):
+            # NamedTuple constructors don't seem to like getting a generator
+            # expression as an argument to their constructor, so build this
+            # intermediate tuple and unpack it into the NamedTuple constructor
+            args = tuple(self.create_arg(elem) for elem in a)
+            return type(a)(*args)  # type: ignore
+        elif isinstance(a, (tuple, list)):
+            return type(a)(self.create_arg(elem) for elem in a)
         elif isinstance(a, dict):
             r = {}
             for k, v in a.items():

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -56,7 +56,7 @@ class TracerBase:
                 # expression as an argument to their constructor, so build this
                 # intermediate tuple and unpack it into the NamedTuple constructor
                 args = tuple(self.create_arg(elem) for elem in a)
-                return type(a)(*args)
+                return type(a)(*args) # type: ignore
             else:
                 return type(a)(self.create_arg(elem) for elem in a)
         elif isinstance(a, dict):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#48986 [FX] Fix create_arg for NamedTuple**

Closes https://github.com/pytorch/pytorch/issues/48813

Previously, constructing a NamedTuple with `type(a)(self.create_arg(elem) for elem in a)` would fail, saying `__new__() missing 1 required positional argument: 'aux_logits'`, ostensibly because (unlike `tuple()`) a `NamedTuple`'s constructor does not accept a generator expression as input. This adds a special case for `NamedTuple`s in `create_arg`

Differential Revision: [D25387156](https://our.internmc.facebook.com/intern/diff/D25387156)