### PR TITLE
skip cuda test_cholesky_solve_batched_many_batches due to illegal memory access

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1895,6 +1895,7 @@ class TestLinalg(TestCase):
             self.assertEqual(x, x_exp)
 
     @slowTest
+    @onlyCPU  # GPU magma has illegal memory access. See https://github.com/pytorch/pytorch/issues/48996
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1895,7 +1895,7 @@ class TestLinalg(TestCase):
             self.assertEqual(x, x_exp)
 
     @slowTest
-    @onlyCPU  # GPU magma has illegal memory access. See https://github.com/pytorch/pytorch/issues/48996
+    @skipCUDAIf(True, "See https://github.com/pytorch/pytorch/issues/48996")
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/issues/48996