### PR TITLE
[te] Add gflag for fast intrinsic expansion

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -34,6 +34,11 @@
 
 using namespace torch::jit::tensorexpr;
 
+C10_DEFINE_bool(
+    torch_jit_llvm_use_fast_intrinsics,
+    false,
+    "Use fast (but slightly less accurate) implementations of tanh and sigmoid");
+
 DEFINE_TRIGGER(llvm_codegen_created);
 DEFINE_TRIGGER(llvm_codegen_executed);
 
@@ -495,12 +500,13 @@ void LLVMCodeGenImpl::emitKernel(
   irb_.SetInsertPoint(bb_);
 
   // Maybe expand some of the intrinsics.
-#ifdef USE_FAST_CPU_INTRINSICS
-  LLVMIntrinsicsExpander intrinsics_expander;
-#else
-  GenericIntrinsicsExpander intrinsics_expander;
-#endif
-  stmt = stmt->accept_mutator(&intrinsics_expander);
+  if (FLAGS_torch_jit_llvm_use_fast_intrinsics) {
+    LLVMIntrinsicsExpander intrinsics_expander;
+    stmt = stmt->accept_mutator(&intrinsics_expander);
+  } else {
+    GenericIntrinsicsExpander intrinsics_expander;
+    stmt = stmt->accept_mutator(&intrinsics_expander);
+  }
 
   // Compile the kernel.
   stmt->accept(this);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49058 [te] Remove vestigial __init__.py from test/cpp/tensorexpr
* #49051 [te] Make llvm backend use GRAPH_DEBUG instead of #ifdef
* **#49048 [te] Add gflag for fast intrinsic expansion**
* #49047 [pe] Add gflags for num_profiled_runs and bailout_depth

TE contains a fast tanh/sigmoid implementation that may be slightly less precise than the eager implementation (I measured 1 ulp in some test cases).  We disabled it by default using an #ifdef but that may be too conservative.  Adding a gflag allows more testing without recompilation.

Differential Revision: [D25406421](https://our.internmc.facebook.com/intern/diff/D25406421/)