### PR TITLE
[JIT] Use `is_buffer` in `BufferPolicy::valid`

### DIFF
--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -508,7 +508,7 @@ struct TORCH_API BufferPolicy {
   }
   static bool valid(const ClassTypePtr& typ, size_t i, const IValue& v) {
     return typ->getAttribute(i)->isSubtypeOf(TensorType::get()) &&
-        !typ->is_parameter(i);
+        typ->is_buffer(i);
   }
   static CONSTEXPR_EXCEPT_WIN_CUDA bool all_slots = false;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49053 [JIT] Use `is_buffer` in `BufferPolicy::valid`**

**Summary**
`BufferPolicy::valid` uses `!typ->is_parameter(i)` to check if an
attribute is a buffer or not; it should use `type->is_buffer(i)` instead.

**Test Plan**
It is difficult to write an additional test that would have failed before this
commit because the two booleans `is_parameter` and `is_buffer` are never set
to `true` at the same time.

**Fixes**
This commit fixes #48746.

Differential Revision: [D25434956](https://our.internmc.facebook.com/intern/diff/D25434956)