### PR TITLE
[PyTorch] Reference to c10::GetCPUAllocator() directly

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Context.h>
 
 #include <c10/core/TensorOptions.h>
+#include <c10/core/CPUAllocator.h>
 
 #include <mutex>
 #include <sstream>
@@ -232,7 +233,7 @@ bool Context::setFlushDenormal(bool on) {
 }
 
 Allocator* getCPUAllocator() {
-  return getTHDefaultAllocator();
+  return c10::GetCPUAllocator();
 }
 
 // override_allow_tf32_flag = true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49068 [PyTorch] Reference to c10::GetCPUAllocator() directly**

TH folder has some kernal implementations referenced by ATen/native. It goes with ATen/native in the follow-up diff for per-app selective build. ATen/Context.cpp stays in the lib level and should not reference to symbols in TH directly.

It's a simple change in this diff, as ```getTHDefaultAllocator()``` did nothing but returns ```c10::GetCPUAllocator()```. Use ```c10::GetCPUAllocator()``` instead of going extra route through ```getTHDefaultAllocator()```.

Differential Revision: [D24147914](https://our.internmc.facebook.com/intern/diff/D24147914/)