### PR TITLE
[PyTorch] Remove aten::native::empty usage in TensorIndexing

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -228,7 +228,7 @@ static inline Tensor boolToIndexingTensorCPUOrCUDA(const Tensor& self, bool valu
   if (value) {
     return at::native::zeros({1}, {}, self.options().dtype(kLong));
   } else {
-    return at::native::empty({0}, {}, self.options().dtype(kLong));
+    return at::empty({0}, {}, self.options().dtype(kLong));
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49074 [PyTorch] Remove aten::native::empty usage in TensorIndexing**

Try to resolve part of the github issue of https://github.com/pytorch/pytorch/issues/48684 . ```aten::native::empty()``` is referenced in TensorIndexing.h. However, the definition of ```aten::native::empty()``` is nothing but checks and eventually calling ```at::empty()```.

In this diff, ```at::empty()``` is directly used to avoid the reference to native symbols.

Differential Revision: [D25417854](https://our.internmc.facebook.com/intern/diff/D25417854/)