### PR TITLE
make validate debug-only in Device copy ctr

### DIFF
--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -93,9 +93,13 @@ struct C10_API Device final {
   DeviceType type_;
   DeviceIndex index_ = -1;
   void validate() {
-    TORCH_CHECK(index_ == -1 || index_ >= 0,
+    // Removing these checks in release builds noticeably improves
+    // performance in micro-benchmarks.
+    // This is safe to do, because backends that use the DeviceIndex
+    // have a later check when we actually try to switch to that device.
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(index_ == -1 || index_ >= 0,
         "Device index must be -1 or non-negative, got ", (int)index_);
-    TORCH_CHECK(!is_cpu() || index_ <= 0,
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!is_cpu() || index_ <= 0,
         "CPU device index must be -1 or zero, got ", (int)index_);
   }
 };

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -341,9 +341,6 @@ class AbstractTestCases:
             self.assertEqual(90, cuda90.index)
 
             self.assertRaises(RuntimeError, lambda: torch.device('cpu:-1'))
-            self.assertRaises(RuntimeError, lambda: torch.device('cpu:1'))
-            self.assertRaises(RuntimeError, lambda: torch.device('cpu', -1))
-            self.assertRaises(RuntimeError, lambda: torch.device('cpu', 1))
             self.assertRaises(RuntimeError, lambda: torch.device('cuda:-1'))
             self.assertRaises(RuntimeError, lambda: torch.device('cuda:2 '))
             self.assertRaises(RuntimeError, lambda: torch.device('cuda: 2'))
@@ -356,7 +353,6 @@ class AbstractTestCases:
             self.assertRaises(RuntimeError, lambda: torch.device('cuda:2 cuda:3'))
             self.assertRaises(RuntimeError, lambda: torch.device('cuda:2+cuda:3'))
             self.assertRaises(RuntimeError, lambda: torch.device('cuda:2cuda:3'))
-            self.assertRaises(RuntimeError, lambda: torch.device('cuda', -1))
             self.assertRaises(RuntimeError, lambda: torch.device(-1))
 
             self.assertRaises(RuntimeError, lambda: torch.device('other'))

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -262,24 +262,6 @@ class RemoteModuleTest(RpcAgentTestFixture):
                 )
             )
 
-        with self.assertRaisesRegex(RuntimeError, r"Invalid device string: 'cpu2'"):
-            list(
-                self._create_remote_module_iter(
-                    "{}/cpu2".format(dst_worker_name),
-                    modes=[ModuleCreationMode.MODULE_CTOR],
-                )
-            )
-
-        with self.assertRaisesRegex(
-            RuntimeError, r"CPU device index must be -1 or zero, got 2"
-        ):
-            list(
-                self._create_remote_module_iter(
-                    "{}/cpu:2".format(dst_worker_name),
-                    modes=[ModuleCreationMode.MODULE_CTOR],
-                )
-            )
-
         with self.assertRaisesRegex(RuntimeError, r"Device string must not be empty"):
             list(
                 self._create_remote_module_iter(

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -262,6 +262,14 @@ class RemoteModuleTest(RpcAgentTestFixture):
                 )
             )
 
+        with self.assertRaisesRegex(RuntimeError, r"Invalid device string: 'cpu2'"):
+            list(
+                self._create_remote_module_iter(
+                    "{}/cpu2".format(dst_worker_name),
+                    modes=[ModuleCreationMode.MODULE_CTOR],
+                )
+            )
+
         with self.assertRaisesRegex(RuntimeError, r"Device string must not be empty"):
             list(
                 self._create_remote_module_iter(


### PR DESCRIPTION
I missed a broken distributed test in the original PR, which I deleted in this PR. Other than that, this PR is taken directly from the original: https://github.com/pytorch/pytorch/pull/47854

-- Copied summary below --

This PR makes the validation check in the `Device` constructor a debug-only assert.

**Background**
Tensors know about the `Device` that they run on, e.g. `cpu` or `cuda:0`. Devices have a DeviceIndex that's only really applicable for cuda/hip, and is effectively ignored for other devices. Previously, we ran "some" validation upon device construction- basically maintain the invariant that `DeviceIndex == -1` for `cpu` devices and `>= 0` for non-cpu devices.

This assertion is technically redundant for cuda/hip devices, and unnecessary for cpu devices.

For cuda/hip, we perform a later check when we try to switch to the specific DeviceIndex anyway. Removing this first check means that we fail slightly later, e.g, if someone creates a `cuda:-1` device we will fail at usage time rather than construction time (this check doesn't cover everything anyway, e.g. indexes that are out of range).

For cpu devices, there isn't really a purpose in maintaining the invariant that `DeviceIndex == -1`, as we never use it anywhere. TBC, that means that code like this runs fine (it used to fail): `torch.device("cpu", 5)`.

**Purpose**
As Ed pointed out in a [previous PR](https://github.com/pytorch/pytorch/pull/44322), this check has a noticeable impact on the wall-time of several microbenchmarks.

Just as a note, the reason is likely because we repeatedly construct Device objects several times in hot-path code. I made an effort to remove the number of Device objects that we construct [here](https://github.com/pytorch/pytorch/pull/47894), but had some trouble finding a noticeable perf improvement.

Framework overhead benchmarks show ~1-10% wall-time improvements, depending on the microbenchmark: https://www.internalfb.com/intern/aibench/details/1862369817/

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49123 Revert "Revert D25003113: make validate debug-only in Device copy ctr"**

This reverts commit 7a4a2df2254b78d8c8d42b9f81b5b261a617466e.

Differential Revision: [D25463531](https://our.internmc.facebook.com/intern/diff/D25463531)