### PR TITLE
whitelist ops we can build shapes for

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -163,6 +163,21 @@ class TestTEFuser(JitTestCase):
     def test_abs_cuda(self):
         self._test_fused_abs(device="cuda")
 
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    def test_unsqueeze_size_calculation(self):
+
+        def foo(b, d):
+            x = d.unsqueeze(1)
+            y = x * 42.
+            z = b + y
+            r = z / 42.
+            return r
+
+        inputs = (torch.rand(20, 28, device='cuda', requires_grad=True), torch.rand(20, device='cuda'))
+
+        scripted = self.checkScript(foo, inputs)
+        self.assertAllFused(scripted.graph_for(*inputs))
+
     def _test_zero_element_tensors(self, device="cpu"):
         def decode(sin_t, cos_t):
             theta = torch.atan2(sin_t.float(), cos_t.float())

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -61,109 +61,6 @@ static const OperatorSet& supported_eltwise_set() {
   // clang-format off
   // breaks up the schema strings so they are no longer discoverable with ctrl-F
     static const OperatorSet supported_eltwise_set{
-        "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor",
-        "aten::add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor",
-        "aten::_cast_Float(Tensor self, bool non_blocking) -> Tensor",
-        "aten::type_as(Tensor self, Tensor other) -> Tensor",
-        "aten::sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor",
-        "aten::sub.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor",
-        "aten::mul.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::mul.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::div.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::div.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::eq.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::eq.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::ne.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::ne.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::ge.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::ge.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::gt.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::gt.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::le.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::le.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::lt.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::lt.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor",
-        // TODO: uncomment when we properly support pow
-        // "aten::pow.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor",
-        // "aten::pow.Scalar(Scalar self, Tensor exponent) -> Tensor",
-        // TODO: support clamp_min, clamp_max
-        "aten::clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor",
-        "aten::lerp.Scalar(Tensor self, Tensor end, Scalar weight) -> Tensor",
-        "aten::lerp.Tensor(Tensor self, Tensor end, Tensor weight) -> Tensor",
-        "aten::lgamma(Tensor self) -> Tensor",
-        "aten::log10(Tensor self) -> Tensor",
-        "aten::log(Tensor self) -> Tensor",
-        "aten::log2(Tensor self) -> Tensor",
-        "aten::log1p(Tensor self) -> Tensor",
-        "aten::exp(Tensor self) -> Tensor",
-        "aten::erf(Tensor self) -> Tensor",
-        "aten::erfc(Tensor self) -> Tensor",
-        "aten::fmod.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::fmod.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::cos(Tensor self) -> Tensor",
-        "aten::sin(Tensor self) -> Tensor",
-        "aten::tan(Tensor self) -> Tensor",
-        "aten::acos(Tensor self) -> Tensor",
-        "aten::asin(Tensor self) -> Tensor",
-        "aten::atan(Tensor self) -> Tensor",
-        "aten::atan2(Tensor self, Tensor other) -> Tensor",
-        "aten::cosh(Tensor self) -> Tensor",
-        "aten::sinh(Tensor self) -> Tensor",
-        "aten::tanh(Tensor self) -> Tensor",
-        "aten::sqrt(Tensor self) -> Tensor",
-        "aten::rsqrt(Tensor self) -> Tensor",
-        "aten::abs(Tensor self) -> Tensor",
-        "aten::floor(Tensor self) -> Tensor",
-        "aten::ceil(Tensor self) -> Tensor",
-        "aten::round(Tensor self) -> Tensor",
-        "aten::trunc(Tensor self) -> Tensor",
-        "aten::threshold(Tensor self, Scalar threshold, Scalar value) -> Tensor",
-        "aten::remainder.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::remainder.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::sigmoid(Tensor self) -> Tensor",
-        "aten::relu(Tensor self) -> Tensor",
-        "aten::addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor",
-        "aten::neg(Tensor self) -> Tensor",
-        "aten::reciprocal(Tensor self) -> Tensor",
-        "aten::expm1(Tensor self) -> Tensor",
-        "aten::frac(Tensor self) -> Tensor",
-        // TODO: uncomment once we can handle rand+broadcasts
-        // "aten::rand_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
-        "aten::__and__.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::__and__.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::__or__.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::__or__.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::__xor__.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::__xor__.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::__lshift__.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::__lshift__.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::__rshift__.Scalar(Tensor self, Scalar other) -> Tensor",
-        "aten::__rshift__.Tensor(Tensor self, Tensor other) -> Tensor",
-        "aten::where.self(Tensor condition, Tensor self, Tensor other) -> Tensor",
-        "aten::where.ScalarSelf(Tensor condition, Scalar self, Tensor other) -> Tensor",
-        "aten::where.ScalarOther(Tensor condition, Tensor self, Scalar other) -> Tensor",
-        "aten::where.Scalar(Tensor condition, Scalar self, Scalar other) -> Tensor",
-        // TODO: enable other min/max variants, operators that can be both
-        // elementwise or reductions:
-        "aten::min.other(Tensor self, Tensor other) -> Tensor",
-        "aten::max.other(Tensor self, Tensor other) -> Tensor",
-        // TODO: enable slice, shape inference is not implemented for this op yet
-    };
-  // clang-format on
-
-  return supported_eltwise_set;
-}
-
-bool isSupported(Node* node) {
-  // For Block codegen we allow limited ops.
-  if (tensorexpr::getTEGenerateBlockCode()) {
-    return isSupportedForBlock(node);
-  }
-
-  // clang-format off
-  // breaks up the schema strings so they are no longer discoverable with ctrl-F
-  static const OperatorSet supported_operator_set{
       "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor",
       "aten::add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor",
       "aten::_cast_Float(Tensor self, bool non_blocking) -> Tensor",
@@ -262,6 +159,17 @@ bool isSupported(Node* node) {
       "aten::max.other(Tensor self, Tensor other) -> Tensor",
       // TODO: enable slice, shape inference is not implemented for this op yet
   };
+  // clang-format on
+
+  return supported_eltwise_set;
+}
+
+bool isSupported(Node* node) {
+  // For Block codegen we allow limited ops.
+  if (tensorexpr::getTEGenerateBlockCode()) {
+    return isSupportedForBlock(node);
+  }
+
   static const OperatorSet cuda_only_operator_set{
       "aten::pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor",
   };


### PR DESCRIPTION
Whitelist ops we can build shapes for.
Otherwise, `buildShapeExpressions` assumes that `aten::unsqueeze` is just a regular op.

```
[DUMP tensorexpr_fuser.cpp:329] buildShapeExpressions for 
[DUMP tensorexpr_fuser.cpp:329] graph(%1 : float,
[DUMP tensorexpr_fuser.cpp:329]       %3 : Float(50, 28, strides=[28, 1], requires_grad=0, device=cuda:0),
[DUMP tensorexpr_fuser.cpp:329]       %8 : float,
[DUMP tensorexpr_fuser.cpp:329]       %10 : Float(50, strides=[1], requires_grad=0, device=cuda:0)):
[DUMP tensorexpr_fuser.cpp:329]   %11 : int = prim::Constant[value=1]()
[DUMP tensorexpr_fuser.cpp:329]   %12 : Float(50, 1, strides=[1, 1], requires_grad=0, device=cuda:0) = aten::unsqueeze(%10, %11)
[DUMP tensorexpr_fuser.cpp:329]   %9 : Float(50, 1, strides=[1, 1], requires_grad=0, device=cuda:0) = aten::mul(%12, %8)
[DUMP tensorexpr_fuser.cpp:329]   %6 : Float(50, 28, strides=[28, 1], requires_grad=0, device=cuda:0) = aten::add(%3, %9, %11)
[DUMP tensorexpr_fuser.cpp:329]   %2 : Float(50, 28, strides=[28, 1], requires_grad=0, device=cuda:0) = aten::div(%6, %1)
[DUMP tensorexpr_fuser.cpp:329]   return (%2, %6, %9)
[DEBUG tensorexpr_fuser.cpp:347] Adding a mapping for %3 %162 : int[] = aten::size(%27)
[DEBUG tensorexpr_fuser.cpp:347] Adding a mapping for %10 %163 : int[] = aten::size(%23)
[DEBUG tensorexpr_fuser.cpp:402] Building sizes for %12 : Float(50, 1, strides=[1, 1], requires_grad=0, device=cuda:0) = aten::unsqueeze(%10, %11)
[DEBUG tensorexpr_fuser.cpp:405] Getting aten::size for %10
[DEBUG tensorexpr_fuser.cpp:402] Building sizes for %9 : Float(50, 1, strides=[1, 1], requires_grad=0, device=cuda:0) = aten::mul(%12, %8)
[DEBUG tensorexpr_fuser.cpp:405] Getting aten::size for %12
[DEBUG tensorexpr_fuser.cpp:402] Building sizes for %6 : Float(50, 28, strides=[28, 1], requires_grad=0, device=cuda:0) = aten::add(%3, %9, %11)
[DEBUG tensorexpr_fuser.cpp:405] Getting aten::size for %3
[DEBUG tensorexpr_fuser.cpp:405] Getting aten::size for %9
[DEBUG tensorexpr_fuser.cpp:402] Building sizes for %2 : Float(50, 28, strides=[28, 1], requires_grad=0, device=cuda:0) = aten::div(%6, %1)
[DEBUG tensorexpr_fuser.cpp:405] Getting aten::size for %6
[DEBUG tensorexpr_fuser.cpp:907] Inserting a typecheck guard for a node%156 : Float(50, 28, strides=[28, 1], requires_grad=0, device=cuda:0) = prim::TensorExprGroup[Subgraph=<Graph>](%3, %27, %16, %23)
[DUMP tensorexpr_fuser.cpp:463] After guarding fusion groups: 
```