### PR TITLE
Add a newline before dependency graph output

### DIFF
--- a/torch/package/exporter.py
+++ b/torch/package/exporter.py
@@ -192,7 +192,7 @@ node [shape=box];
         if result is None:
             extra = ''
             if self.verbose:
-                extra = f' See the dependency graph for more info: {self._write_dep_graph(module.__name__)}'
+                extra = f' See the dependency graph for more info: \n{self._write_dep_graph(module.__name__)}'
             raise ValueError(f'cannot save source for module "{module.__name__}" because '
                              f'its source file "{filename}" could not be found.{extra}')
         return ''.join(result)
@@ -411,7 +411,7 @@ node [shape=box];
                 ...
         """
         if self.verbose:
-            print(f"Dependency graph for exported package: {self._write_dep_graph()}")
+            print(f"Dependency graph for exported package: \n{self._write_dep_graph()}")
 
         # Write each tensor to a file named tensor/the_tensor_key in the zip archive
         for key in sorted(self.serialized_storages.keys()):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49127 Add a newline before dependency graph output**

Small change, but useful: it means that double-clicking the line lets
you copy the url easily

Differential Revision: [D25450408](https://our.internmc.facebook.com/intern/diff/D25450408)