### PR TITLE
[Docs] Updating init_process_group docs to indicate correct rank range

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -382,7 +382,8 @@ def init_process_group(backend,
                                      Mutually exclusive with ``store``.
         world_size (int, optional): Number of processes participating in
                                     the job. Required if ``store`` is specified.
-        rank (int, optional): Rank of the current process.
+        rank (int, optional): Rank of the current process (it should be a
+                              number between 0 and ``world_size``-1).
                               Required if ``store`` is specified.
         store(Store, optional): Key/value store accessible to all workers, used
                                 to exchange connection/address information.


### PR DESCRIPTION
Summary:
Users frequently assume the correct range of ranks is (1 ...`world_size`).
This PR updates the docs to indicate that the correct rank range
users should specify is (0 ... `world_size` - 1).

Test Plan: Rendering and Building Docs

Differential Revision: D25410532

