### PR TITLE
Saves a copy of vector<Tensor> in view ops returning TensorList.

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -697,8 +697,9 @@ def emit_body(declaration):
                         creation_meta = "CreationMeta::MULTI_OUTPUT_SAFE"
                     else:
                         creation_meta = "CreationMeta::MULTI_OUTPUT_NODE"
-                    rhs_value = ("as_view(/* base */ {}, /* output */ {}, /* is_differentiable */ true, "
-                                 "/* creation_meta */ {})").format(view_info, var, creation_meta)
+                    call += ("as_view(/* base */ {}, /* output */ {}, /* is_differentiable */ true, "
+                             "/* creation_meta */ {});\n").format(view_info, var, creation_meta)
+                    rhs_value = 'std::move({})'.format(var)
                 else:
                     call += emit_view_lambda()
                     creation_meta = "GradMode::is_enabled() ? CreationMeta::DEFAULT: CreationMeta::NO_GRAD_MODE"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49149 Saves a copy of vector<Tensor> in view ops returning TensorList.**
* #48896 Only 1 TensorImpl allocation in differentiable views.

Differential Revision: [D25480104](https://our.internmc.facebook.com/intern/diff/D25480104)