### PR TITLE
[caffe2][autograd] Avoid extensive -Wunused-variable warnings on _any_requires_grad

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -188,6 +188,7 @@ std::shared_ptr<${op}> grad_fn;
 
 SETUP_ANY_REQUIRES_GRAD = CodeTemplate("""\
 auto _any_requires_grad = compute_requires_grad( ${args_with_derivatives} );
+(void)_any_requires_grad;
 """)
 
 SETUP_DERIVATIVE = CodeTemplate("""\


### PR DESCRIPTION
Summary:
Building with clang and a fair warning level can result in hundreds of lines of compiler output of the form:
```
caffe2\gen_aten_libtorch\autograd\generated\VariableType_1.cpp(2279,8): warning: unused variable '_any_requires_grad' [-Wunused-variable]
   auto _any_requires_grad = compute_requires_grad( self );
        ^
caffe2\gen_aten_libtorch\autograd\generated\VariableType_1.cpp(2461,8): warning: unused variable '_any_requires_grad' [-Wunused-variable]
   auto _any_requires_grad = compute_requires_grad( grad_output, self );
        ^
caffe2\gen_aten_libtorch\autograd\generated\VariableType_1.cpp(2677,8): warning: unused variable '_any_requires_grad' [-Wunused-variable]
   auto _any_requires_grad = compute_requires_grad( self );
        ^
...
```
This happens when requires_derivative == False. Let's mark `_any_requires_grad` as potentially unused. If this were C++17 we would use `[[maybe_unused]]` but to retain compatibility with C++11 we just mark it with `(void)`.

Test Plan: CI + locally built

Differential Revision: D25421548

