### PR TITLE
[te] Don't throw when re-registering a CodeGen factory

### DIFF
--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -30,11 +30,7 @@ RegisterCodeGenList::StmtFactoryMethod RegisterCodeGenList::
 void RegisterCodeGenList::AddStmtFactoryMethod(
     const std::string& name,
     const StmtFactoryMethod& stmt_factory_method) {
-  auto insert_ret =
-      stmt_factory_methods_.insert(std::make_pair(name, stmt_factory_method));
-  if (!insert_ret.second) {
-    throw std::runtime_error("Duplicated CodeGen names: " + name);
-  }
+  stmt_factory_methods_[name] = stmt_factory_method;
 }
 
 std::unique_ptr<CodeGen> CreateCodeGen(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49174 [te] Don't throw when re-registering a CodeGen factory**

We've seen this happening when libtorch is loaded repeatedly on macOS.  Tbh I'm not sure I understand why this happens; why do we re-construct these static objects but re-use the static registry itself?  But it's fairly straightforward to just overwrite the factory method and no harm in doing so.

Differential Revision: [D25466642](https://our.internmc.facebook.com/intern/diff/D25466642/)