### PR TITLE
[pytorch] Expand PixelShuffle to support any number of batch dims

### DIFF
--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -4,31 +4,51 @@
 #include <c10/util/Exception.h>
 
 #include <algorithm>
+#include <numeric>
 #include <vector>
 
 namespace at {
 namespace native {
 
 Tensor pixel_shuffle(const Tensor& self, int64_t upscale_factor) {
-  AT_ASSERTM(self.dim() == 4,
-             "pixel_shuffle expects 4D input, but got input with sizes ",self.sizes());
-  int64_t b = self.size(0);
-  int64_t c = self.size(1);
-  int64_t h = self.size(2);
-  int64_t w = self.size(3);
+  TORCH_CHECK(self.dim() >= 3,
+              "pixel_shuffle expects input to have at least 3 dimensions, but got input with ",
+              self.dim(), " dimension(s)");
+  // Format: (B1, ..., Bn), C, H, W
+  int64_t c = self.size(-3);
+  int64_t h = self.size(-2);
+  int64_t w = self.size(-1);
+  const auto NUM_NON_BATCH_DIMS = 3;
+  const auto last_batch_dim = self.sizes().end() - NUM_NON_BATCH_DIMS;
+
   int64_t upscale_factor_squared = upscale_factor * upscale_factor;
-  AT_ASSERTM(c % upscale_factor_squared == 0,
-             "pixel_shuffle expects input channel to be divisible by square of "
-             "upscale_factor, but got input with sizes ", self.sizes(),
-             ", upscale_factor=", upscale_factor,
-             ", and self.size(1)=", c, " is not divisible by ", upscale_factor_squared);
+  TORCH_CHECK(c % upscale_factor_squared == 0,
+              "pixel_shuffle expects its input's 'channel' dimension to be divisible by the square of "
+              "upscale_factor, but input.size(-3)=", c, " is not divisible by ", upscale_factor_squared);
   int64_t oc = c / upscale_factor_squared;
   int64_t oh = h * upscale_factor;
   int64_t ow = w * upscale_factor;
 
-  auto input_reshaped = self.reshape({b, oc, upscale_factor, upscale_factor, h, w});
-  return input_reshaped.permute({0 /* b */, 1 /* oc */, 4 /* h */, 2 /* 1st upscale_factor */, 5 /* w */, 3 /* 2nd upscale_factor */})
-                       .reshape({b, oc, oh, ow});
+  // First, reshape to expand the channels dim from c into 3 separate dims: (oc, upscale_factor, upscale_factor).
+  // This allows shuffling to be done next by permuting dims.
+  std::vector<int64_t> expanded_shape(self.sizes().begin(), last_batch_dim);
+  expanded_shape.insert(expanded_shape.end(), {oc, upscale_factor, upscale_factor, h, w});
+  const auto input_expanded = self.reshape(expanded_shape);
+
+  // Next, shuffle by permuting the new upscale_factor dims alongside the height and width dims.
+  std::vector<int64_t> permutation(self.sizes().begin(), last_batch_dim);
+  // std::iota is used to maintain the batch dims within the permutation.
+  // Since expansion added 2 dims, the correct batch dim offsets are now: -expanded_shape.size(), ..., -7, -6.
+  std::iota(permutation.begin(), permutation.end(), -expanded_shape.size());
+  permutation.insert(permutation.end(), {-5 /* oc */, -2 /* h */, -4 /* 1st upscale_factor */, -1 /* w */,
+                                         -3 /* 2nd upscale_factor */});
+  const auto input_permuted = input_expanded.permute(permutation);
+
+  // Finally, upscale by collapsing (h, upscale_factor) -> a single dim (oh)
+  // and (w, upscale_factor) -> a single dim (ow).
+  std::vector<int64_t> final_shape(self.sizes().begin(), last_batch_dim);
+  final_shape.insert(final_shape.end(), {oc, oh, ow});
+  return input_permuted.reshape(final_shape);
 }
 
 }} // namespace at::native

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -15,12 +15,15 @@ class PixelShuffle(Module):
     `Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network`_
     by Shi et. al (2016) for more details.
 
+    Note that this function can take inputs with any number of batch dimensions:
+    :math:`(L, H_{in}, W_{in})`, :math:`(N, L, H_{in}, W_{in})`, :math:`(N_1, N_2, L, H_{in}, W_{in})`, etc.
+
     Args:
         upscale_factor (int): factor to increase spatial resolution by
 
     Shape:
-        - Input: :math:`(N, L, H_{in}, W_{in})` where :math:`L=C \times \text{upscale\_factor}^2`
-        - Output: :math:`(N, C, H_{out}, W_{out})` where
+        - Input: :math:`(*, L, H_{in}, W_{in})` where :math:`L=C \times \text{upscale\_factor}^2`
+        - Output: :math:`(*, C, H_{out}, W_{out})` where
           :math:`H_{out} = H_{in} \times \text{upscale\_factor}`
           and :math:`W_{out} = W_{in} \times \text{upscale\_factor}`
 


### PR DESCRIPTION
Summary: Expands the implementation of PixelShuffle to support any number of batch dimensions. This addresses https://github.com/pytorch/pytorch/issues/42150

Test Plan: `buck test caffe2/test:nn -- test_pixel_shuffle`

Differential Revision: D25399058