### PR TITLE
Upload test times to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,7 +639,7 @@ jobs:
           export CIRCLE_JOB="$CIRCLE_JOB"
           export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
           cd workspace
-          python test/print_test_stats.py test
+          python test/print_test_stats.py --upload-to-s3 test
           EOL
           echo "(cat docker_commands.sh | docker exec -u jenkins -i "$id" bash) 2>&1" > command.sh
           unbuffer bash command.sh | ts

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -109,6 +109,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     numba \
     llvmlite \
     unittest-xml-reporting \
+    boto3==1.16.34 \
     coverage \
     hypothesis==4.53.2 \
     mypy==0.770 \

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -201,7 +201,7 @@ jobs:
           export CIRCLE_JOB="$CIRCLE_JOB"
           export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
           cd workspace
-          python test/print_test_stats.py test
+          python test/print_test_stats.py --upload-to-s3 test
           EOL
           echo "(cat docker_commands.sh | docker exec -u jenkins -i "$id" bash) 2>&1" > command.sh
           unbuffer bash command.sh | ts

--- a/test/print_test_stats.py
+++ b/test/print_test_stats.py
@@ -3,11 +3,13 @@
 # Read and print test results statistics
 from xml.dom import minidom
 from glob import glob
+import bz2
 import json
 import os
 import statistics
 import time
 
+import boto3
 import datetime
 import requests
 
@@ -76,15 +78,20 @@ def parse_reports(folder):
             tests_by_class[class_name].append(test_case)
     return tests_by_class
 
+def build_info():
+    return {
+        "build_pr": os.environ.get("CIRCLE_PR_NUMBER"),
+        "build_tag": os.environ.get("CIRCLE_TAG"),
+        "build_sha1": os.environ.get("CIRCLE_SHA1"),
+        "build_branch": os.environ.get("CIRCLE_BRANCH"),
+        "build_job": os.environ.get("CIRCLE_JOB"),
+        "build_workflow_id": os.environ.get("CIRCLE_WORKFLOW_ID"),
+    }
+
 def build_message(test_case):
     return {
         "normal": {
-            "build_pr": os.environ.get("CIRCLE_PR_NUMBER"),
-            "build_tag": os.environ.get("CIRCLE_TAG"),
-            "build_sha1": os.environ.get("CIRCLE_SHA1"),
-            "build_branch": os.environ.get("CIRCLE_BRANCH"),
-            "build_job": os.environ.get("CIRCLE_JOB"),
-            "build_workflow_id": os.environ.get("CIRCLE_WORKFLOW_ID"),
+            **build_info(),
             "test_suite_name": test_case.class_name,
             "test_case_name": test_case.name,
         },
@@ -98,7 +105,7 @@ def build_message(test_case):
         },
     }
 
-def send_report(reports):
+def send_report_to_scribe(reports):
     access_token = os.environ.get("SCRIBE_GRAPHQL_ACCESS_TOKEN")
 
     if not access_token:
@@ -124,6 +131,38 @@ def send_report(reports):
         },
     )
     r.raise_for_status()
+
+def send_report_to_s3(reports, *, total_seconds):
+    job = os.environ.get('CIRCLE_JOB')
+    sha1 = os.environ.get('CIRCLE_SHA1')
+    now = datetime.datetime.utcnow().isoformat()
+    key = f'test_time/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
+    obj = boto3.resource('s3').Object('ossci-metrics', key)
+    # use bz2 because the results are smaller than gzip, and the
+    # compression time penalty we pay is only about half a second for
+    # input files of a few megabytes in size like these JSON files, and
+    # because for some reason zlib doesn't seem to play nice with the
+    # gunzip command whereas Python's bz2 does work with bzip2
+    obj.put(Body=bz2.compress(json.dumps({
+        **build_info(),
+        'total_seconds': total_seconds,
+        'suites': {
+            name: {
+                'total_seconds': suite.total_time,
+                'cases': [
+                    {
+                        'name': case.name,
+                        'seconds': case.time,
+                        'errored': case.errored,
+                        'failed': case.failed,
+                        'skipped': case.skipped,
+                    }
+                    for case in suite.test_cases
+                ],
+            }
+            for name, suite in reports.items()
+        }
+    }).encode()))
 
 def positive_integer(value):
     parsed = int(value)
@@ -166,6 +205,11 @@ if __name__ == '__main__':
         help="how many longest tests to show from the entire run",
     )
     parser.add_argument(
+        "--upload-to-s3",
+        action="store_true",
+        help="upload test time to S3 bucket",
+    )
+    parser.add_argument(
         "folder",
         help="test report folder",
     )
@@ -176,7 +220,7 @@ if __name__ == '__main__':
         print(f"No test reports found in {args.folder}")
         sys.exit(0)
 
-    send_report(reports)
+    send_report_to_scribe(reports)
 
     longest_tests = []
     total_time = 0
@@ -187,6 +231,9 @@ if __name__ == '__main__':
         total_time += test_suite.total_time
         longest_tests.extend(test_suite.test_cases)
     longest_tests = sorted(longest_tests, key=lambda x: x.time)[-args.longest_of_run:]
+
+    if args.upload_to_s3:
+        send_report_to_s3(reports, total_seconds=total_time)
 
     print(f"Total runtime is {datetime.timedelta(seconds=int(total_time))}")
     print(f"{len(longest_tests)} longest tests of entire run:")


### PR DESCRIPTION
This PR currently just modifies the `test/print_test_stats.py` script (run in the `pytorch_linux_test` job) so that now it uploads test times to the new `ossci-metrics` S3 bucket (rather than just to Scribe) if passed the `--upload-to-s3` parameter.

The next step is to add an additional step to that `pytorch_linux_test` job which checks if it's being run on a PR, and if so, finds the `master` commit to compare against (similar to what's done in the now-unused `.jenkins/pytorch/short-perf-test-{c,g}pu.sh` scripts) and adds test time info to the Dr CI comment if the PR is significantly different from the base revision.

Test plan:

An "integration test" would be to just look in [the `ossci-metrics` S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/ossci-metrics) to confirm that the CI run(s) for this PR did indeed upload their test time data successfully.

To test this locally, first make sure you have all the packages you need, such as these:
```
$ conda install -c anaconda boto3
$ conda install -c conda-forge unittest-xml-reporting
```
Then run whatever tests you want; these are the ones I used for my local smoke test, for no particular reason:
```
$ python test/test_spectral_ops.py --save-xml=/tmp/reports/spectral_ops
```
Once the tests finish, run the script to upload their times to S3:
```
$ CIRCLE_SHA1="$(git rev-parse HEAD)" CIRCLE_JOB=foo test/print_test_stats.py --upload-to-s3 /tmp/reports/spectral_ops
```
Now check that they uploaded successfully:
```
$ aws s3 cp "s3://ossci-metrics/test_time/$(git rev-parse HEAD)/foo/" /tmp/reports --recursive
```
And that it's a valid `*.json.bz2` file:
```
$ bzip2 -kdc /tmp/reports/*Z.json.bz2 | jq . | head -n21
{
  "build_pr": null,
  "build_tag": null,
  "build_sha1": "e46f43621b910bc2f18dd33c08f5af18a542d5ed",
  "build_branch": null,
  "build_job": "foo",
  "build_workflow_id": null,
  "total_seconds": 0.9640000000000003,
  "suites": {
    "TestFFTCPU": {
      "total_seconds": 0.9640000000000003,
      "cases": [
        {
          "name": "test_fft_invalid_dtypes_cpu",
          "seconds": 0.022,
          "errored": false,
          "failed": false,
          "skipped": false
        },
        {
          "name": "test_istft_throws_cpu",
```