### PR TITLE
Make Tensor::data_ptr available only on rvalue

### DIFF
--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -21,7 +21,7 @@ Tensor _bincount_cpu_template(
   if (self.dim() == 1 && self.numel() == 0) {
     return native::zeros({minlength}, kLong);
   }
-  if (self.dim() != 1 || *self.min().data_ptr<input_t>() < 0) {
+  if (self.dim() != 1 || self.min().item<input_t>() < 0) {
     AT_ERROR("bincount only supports 1-d non-negative integral inputs.");
   }
 
@@ -32,7 +32,7 @@ Tensor _bincount_cpu_template(
 
   Tensor output;
   int64_t self_size = self.size(0);
-  int64_t nbins = static_cast<int64_t>(*self.max().data_ptr<input_t>()) + 1L;
+  int64_t nbins = static_cast<int64_t>(self.max().item<input_t>()) + 1L;
   nbins = std::max(nbins, minlength); // at least minlength # of bins
 
   const input_t* self_p = self.data_ptr<input_t>();

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -290,7 +290,7 @@ Tensor _bincount_cuda_template(
   }
   if (self.dim() != 1 ||
       (!std::is_same<input_t, uint8_t>::value &&
-       *self.min().cpu().data_ptr<input_t>() < 0)) {
+       self.min().cpu().item<input_t>() < 0)) {
     AT_ERROR("bincount only supports 1-d non-negative integral inputs.");
   }
 
@@ -299,7 +299,7 @@ Tensor _bincount_cuda_template(
     AT_ERROR("input and weights should have the same length");
   }
 
-  const int64_t nbins = std::max(*self.max().cpu().data_ptr<input_t>() + (int64_t)1, minlength);
+  const int64_t nbins = std::max(self.max().cpu().item<input_t>() + (int64_t)1, minlength);
   const input_t minvalue = 0;
   const input_t maxvalue = nbins;
   // alloc output counter on GPU
@@ -345,8 +345,8 @@ Tensor _histc_cuda_template(
   input_t minvalue = min;
   input_t maxvalue = max;
   if (min == max) {
-    minvalue = *self.min().cpu().data_ptr<input_t>();
-    maxvalue = *self.max().cpu().data_ptr<input_t>();
+    minvalue = self.min().cpu().item<input_t>();
+    maxvalue = self.max().cpu().item<input_t>();
   }
   if (minvalue == maxvalue) {
     minvalue = minvalue - 1;

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -127,14 +127,19 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
     }
   }
 
+  flip_dims_t = flip_dims_t.cuda();
+  strides_t = strides_t.cuda();
+  stride_contiguous = stride_contiguous.cuda();
+  shape_t = shape_t.cuda();
+
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, in_tensor.scalar_type(), "flip_cuda", [&] {
     flip_cuda_kernel<<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
       in_tensor.data_ptr<scalar_t>(), out_tensor.data_ptr<scalar_t>(), N,
-      flip_dims_t.cuda().data_ptr<int64_t>(),
+      flip_dims_t.data_ptr<int64_t>(),
       flip_dims_size,
-      strides_t.cuda().data_ptr<int64_t>(),
-      stride_contiguous.cuda().data_ptr<int64_t>(),
-      shape_t.cuda().data_ptr<int64_t>(),
+      strides_t.data_ptr<int64_t>(),
+      stride_contiguous.data_ptr<int64_t>(),
+      shape_t.data_ptr<int64_t>(),
       total_dims);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   });

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -287,7 +287,8 @@ std::tuple<Tensor, Tensor> choose_qparams_optimized(
   float stepsize = (xmax - xmin) / n_bins;
   // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
   int min_bins = n_bins * (1.0 - (float) ratio);
-  const float* input = input_tensor.contiguous().data_ptr<float>();
+  auto input_contig = input_tensor.contiguous();
+  const float* input = input_contig.data_ptr<float>();
   std::vector<float> q_input(numel);
 
   float loss =

--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -44,7 +44,8 @@ static void avg_pool2d_out_frame(
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t xx, yy;
       /* For all output pixels... */
-      auto input_data = input.contiguous().data_ptr<scalar_t>();
+      auto input_contig = input.contiguous();
+      auto input_data = input_contig.data_ptr<scalar_t>();
       auto output_data = output.data_ptr<scalar_t>();
       scalar_t* ptr_output = output_data +
           b * nInputPlane * outputWidth * outputHeight +

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -200,7 +200,8 @@ namespace at {
 namespace native {
 
 at::Tensor _saturate_weight_to_fp16(const Tensor& weight) {
-  float* weight_contig_ptr = weight.contiguous().data_ptr<float>();
+  auto weight_contig = weight.contiguous();
+  float* weight_contig_ptr = weight_contig.data_ptr<float>();
   quant_utils::HandleWeightsSaturation(weight.size(0) * weight.size(1), weight_contig_ptr);
   return weight;
 }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -401,11 +401,12 @@ std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scales_tensor(
       weight_zp[i] = (uint8_t)(weight_contig.q_zero_point() + 128);
     }
   } else if (qtype == at::kPerChannelAffine) {
+    auto per_channel_zero_points_tensor = weight_contig.q_per_channel_zero_points();
     TORCH_CHECK(
-        weight_contig.q_per_channel_zero_points().scalar_type() == at::kLong,
+        per_channel_zero_points_tensor.scalar_type() == at::kLong,
         "Per channel zero points dtype must be long int.");
     const int64_t* per_channel_zero_points =
-      weight_contig.q_per_channel_zero_points().data_ptr<int64_t>();
+      per_channel_zero_points_tensor.data_ptr<int64_t>();
     for (int i = 0; i < num_output_channels; ++i) {
       weight_zp[i] = (uint8_t)(per_channel_zero_points[i] + 128);
     }
@@ -422,11 +423,11 @@ std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scales_tensor(
       weight_scales_data[i] = weight_contig.q_scale();
     }
   } else if (qtype == at::kPerChannelAffine) {
+    auto per_channel_scales_tensor = weight_contig.q_per_channel_scales();
     TORCH_CHECK(
-        weight_contig.q_per_channel_scales().scalar_type() == at::kDouble,
+        per_channel_scales_tensor.scalar_type() == at::kDouble,
         "Per channel scales dtype must be double.");
-    const double* per_channel_scales =
-      weight_contig.q_per_channel_scales().data_ptr<double>();
+    const double* per_channel_scales = per_channel_scales_tensor.data_ptr<double>();
     for (int i = 0; i < num_output_channels; ++i) {
       weight_scales_data[i] = static_cast<float>(per_channel_scales[i]);
     }

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -479,7 +479,8 @@ vTensor pack_biases(
   Future::Payload v_bias_payload = v_bias_future.wait();
 
   if (bias) {
-    const float* const src_bias_ptr = bias->contiguous().data_ptr<float>();
+    auto bias_contig = bias->expect_contiguous();
+    const float* const src_bias_ptr = bias_contig.data_ptr<float>();
     float* const dst_bias_ptr = v_bias_payload.get();
 
     memset(dst_bias_ptr, 0, v_bias.nbytes());

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -67,9 +67,10 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
 
         Future::Payload v_self_payload = v_self_future.wait();
 
+        auto cpu_src_contig = cpu_src.contiguous();
         memcpy(
             v_self_payload.get(),
-            cpu_src.contiguous().data_ptr<float>(),
+            cpu_src_contig.data_ptr<float>(),
             std::min(src.nbytes(), self.nbytes()));
       }
     }

--- a/aten/src/ATen/native/xnnpack/Convolution.cpp
+++ b/aten/src/ATen/native/xnnpack/Convolution.cpp
@@ -208,6 +208,7 @@ ContextConv2D create(
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   std::array<int64_t, 4> weight_sizes;
 
+  Tensor bias_contig = bias && bias->defined() ? bias->contiguous() : Tensor();
   if (transposed) {
     const Tensor weight_reordered = reorder_weights_for_transpose_conv(weight_nhwc, groups);
     for (int i = 0; i < 4; i++) {
@@ -230,9 +231,7 @@ ContextConv2D create(
       weight_reordered.size(Layout::Filter::output),                  // input_pixel_stride
       weight_reordered.size(Layout::Filter::input) * groups,          // output_pixel_stride
       weight_reordered.data_ptr<float>(),                             // kernel
-      (bias && bias->defined())
-          ? bias->contiguous().data_ptr<float>()
-          : nullptr,                                                  // bias
+      bias_contig.defined() ? bias_contig.data_ptr<float>() : nullptr,// bias
       output_min,                                                     // output_min
       output_max,                                                     // output_max
       0u,                                                             // flags
@@ -258,9 +257,7 @@ ContextConv2D create(
       weight_nhwc.size(Layout::Filter::input) * groups,               // input_pixel_stride
       weight_nhwc.size(Layout::Filter::output),                       // output_pixel_stride
       weight_nhwc.data_ptr<float>(),                                  // kernel
-      (bias && bias->defined())
-          ? bias->contiguous().data_ptr<float>()
-          : nullptr,                                                  // bias
+      bias_contig.defined() ? bias_contig.data_ptr<float>() : nullptr,// bias
       output_min,                                                     // output_min
       output_max,                                                     // output_max
       0u,                                                             // flags

--- a/aten/src/ATen/native/xnnpack/Linear.cpp
+++ b/aten/src/ATen/native/xnnpack/Linear.cpp
@@ -85,15 +85,14 @@ ContextLinear create(
 
   xnn_operator_t linear_op{};
 
+  Tensor bias_contig = bias && bias->defined() ? bias->contiguous() : Tensor();
   const xnn_status create_status = xnn_create_fully_connected_nc_f32(
       weight_contig.size(Layout::Filter::input),                        // input_channels
       weight_contig.size(Layout::Filter::output),                       // output_channels
       weight_contig.size(Layout::Filter::input),                        // input_pixel_stride
       weight_contig.size(Layout::Filter::output),                       // output_pixel_stride
       weight_contig.data_ptr<float>(),                                  // kernel
-      (bias && bias->defined()) ?
-          bias->contiguous().data_ptr<float>() :
-          nullptr,                                                      // bias
+      bias_contig.defined() ? bias_contig.data_ptr<float>() : nullptr,  // bias
       output_min,                                                     // output_min
       output_max,                                                     // output_max
       0u,                                                             // flags

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -59,7 +59,7 @@ ${tensor_method_definitions}
 
 #define DEFINE_CAST(T, name)                                        \
   template <>                                                       \
-  TORCH_API T* Tensor::data_ptr() const {                           \
+  TORCH_API T* Tensor::data_ptr<T>() const& {                       \
     TORCH_CHECK(                                                    \
         scalar_type() == ScalarType::name,                          \
         "expected scalar type "                                     \

--- a/c10/macros/Export.h
+++ b/c10/macros/Export.h
@@ -87,6 +87,7 @@
 // This one is being used by libc10.so
 #ifdef C10_BUILD_MAIN_LIB
 #define C10_API C10_EXPORT
+#define TORCH_BUILD_ANY_MAIN_LIB
 #else
 #define C10_API C10_IMPORT
 #endif
@@ -94,6 +95,7 @@
 // This one is being used by libtorch.so
 #ifdef CAFFE2_BUILD_MAIN_LIB
 #define TORCH_API C10_EXPORT
+#define TORCH_BUILD_ANY_MAIN_LIB
 #else
 #define TORCH_API C10_IMPORT
 #endif
@@ -117,6 +119,7 @@
 // libtorch_cuda_cu.so
 #ifdef TORCH_CUDA_CU_BUILD_MAIN_LIB
 #define TORCH_CUDA_CU_API C10_EXPORT
+#define TORCH_BUILD_ANY_MAIN_LIB
 #elif defined(BUILD_SPLIT_CUDA)
 #define TORCH_CUDA_CU_API C10_IMPORT
 #endif
@@ -124,6 +127,7 @@
 // libtorch_cuda_cpp.so
 #ifdef TORCH_CUDA_CPP_BUILD_MAIN_LIB
 #define TORCH_CUDA_CPP_API C10_EXPORT
+#define TORCH_BUILD_ANY_MAIN_LIB
 #elif defined(BUILD_SPLIT_CUDA)
 #define TORCH_CUDA_CPP_API C10_IMPORT
 #endif
@@ -133,6 +137,7 @@
 #ifdef TORCH_CUDA_BUILD_MAIN_LIB
 #define TORCH_CUDA_CPP_API C10_EXPORT
 #define TORCH_CUDA_CU_API C10_EXPORT
+#define TORCH_BUILD_ANY_MAIN_LIB
 #elif !defined(BUILD_SPLIT_CUDA)
 #define TORCH_CUDA_CPP_API C10_IMPORT
 #define TORCH_CUDA_CU_API C10_IMPORT
@@ -140,6 +145,7 @@
 
 #if defined(TORCH_HIP_BUILD_MAIN_LIB)
 #define TORCH_HIP_API C10_EXPORT
+#define TORCH_BUILD_ANY_MAIN_LIB
 #else
 #define TORCH_HIP_API C10_IMPORT
 #endif

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -425,4 +425,16 @@ __host__ __device__
 #endif
 #endif
 
+// This controls whether some questionable behaviors in C++ codebase should
+// raise errors. We don't want to enable them by default to avoid breaking
+// 3rd party extensions. But unless specified explicitly, we're going to
+// be strict within PyTorch itself
+#ifndef C10_STRICT_WARNING_AS_ERRORS
+#ifdef TORCH_BUILD_ANY_MAIN_LIB
+#define C10_STRICT_WARNING_AS_ERRORS 1
+#else
+#define C10_STRICT_WARNING_AS_ERRORS 0
+#endif
+#endif
+
 #endif // C10_MACROS_MACROS_H_

--- a/caffe2/operators/enforce_finite_op.h
+++ b/caffe2/operators/enforce_finite_op.h
@@ -58,7 +58,7 @@ class EnforceFiniteOp final : public Operator<Context> {
         if (blob != nullptr && blob->IsType<Tensor>()) {
           Tensor* c2Tensor = blob->GetMutable<Tensor>();
           const at::Tensor& tensor = static_cast<at::Tensor>(*c2Tensor);
-          bool blob_finite = tensor.sum().isfinite().cpu().data_ptr<bool>()[0];
+          bool blob_finite = tensor.sum().isfinite().cpu().item<bool>();
           LOG(INFO) << "blob " << blob_name << " isfinite=" << (blob_finite ? "true" : "false");
         }
       } catch (const std::exception& ex) {

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -189,8 +189,8 @@ bool ProcessGroupAgent::hasPendingMessage() {
     for (int to = 0; to < worldSize; ++to) {
       // peerCounts[x][0] is recv counts, and peerCounts[x][1] is send counts
 
-      const auto& sentCnt = peerCounts[from][1][to].data_ptr<int64_t>()[0];
-      const auto& recvCnt = peerCounts[to][0][from].data_ptr<int64_t>()[0];
+      const auto& sentCnt = peerCounts[from][1][to].item<int64_t>();
+      const auto& recvCnt = peerCounts[to][0][from].item<int64_t>();
       // NB: we cannot throw an error when sentCnt < recvCnt here. Because, send
       // and recv counts on different workers are read in a distributed manner.
       // It is possible that the sender reads its send count before sending, but

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -2761,7 +2761,7 @@ RegisterOperators reg2({
           c10::List<int64_t> elems;
           elems.reserve(t.size(0));
           for (int i = 0; i < t.size(0); i++) {
-            elems.push_back(*t[i].data_ptr<int32_t>());
+            elems.push_back(t[i].item<int32_t>());
           }
           push(stack, std::move(elems));
         },

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -3270,7 +3270,8 @@ std::vector<CodeGen::CallArg> TensorExprKernel::prepareRunArgs(
     } else if (input.isDouble()) {
       runArgs.emplace_back(input.toDouble());
     } else if (input.isTensor()) {
-      runArgs.emplace_back(input.toTensor().data_ptr());
+      const auto& t = input.toTensor();
+      runArgs.emplace_back(t.data_ptr());
     }
   }
 


### PR DESCRIPTION
`x.contiguous().data_ptr<T>()` is a common anti-pattern as it leads to use-after-free bugs. This PR forbids `data_ptr` on rvalues explicitly (with the nice error message for the templated version). There of course can be valid use cases for it, but I think it's worth banning them as they are rare and enforcement is more valuable. Specifically, common `*x->data_ptr()` pattern is better served with `x.item()` anyway.

Better ideas welcomed!