### PR TITLE
Suppress `warning: calling a constexpr __host__ function from a __host__ __device__ function is not allowed` warning

### DIFF
--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -170,3 +170,5 @@ To checked_convert(From f, const char* name) {
 }
 
 }  // namespace c10
+
+// Trigger tests for D25440771. TODO: Remove this line any time you want.

--- a/c10/util/complex.h
+++ b/c10/util/complex.h
@@ -262,7 +262,7 @@ struct alignas(sizeof(T) * 2) complex {
     return real() || imag();
   }
 
-  constexpr T real() const {
+  C10_HOST_DEVICE constexpr T real() const {
     return real_;
   }
   constexpr void real(T value) {


### PR DESCRIPTION
Summary:
Compiling currently gives a number of these warnings:
```
caffe2/c10/util/TypeCast.h(39): warning: calling a constexpr __host__ function from a __host__ __devic
e__ function is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow thi
s.
          detected during:
            instantiation of "dest_t c10::static_cast_with_inter_type<dest_t, src_t>::apply(src_t) [wi
th dest_t=c10::complex<double>, src_t=__nv_bool]"
(157): here
            instantiation of "To c10::convert<To,From>(From) [with To=c10::complex<double>, From=__nv_
bool]"
(169): here
            instantiation of "To c10::checked_convert<To,From>(From, const char *) [with To=c10::compl
ex<double>, From=__nv_bool]"
caffe2/c10/core/Scalar.h(63): here

caffe2/c10/util/TypeCast.h(39): warning: calling a constexpr __host__ function from a __host__ __device__ function is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
          detected during:
            instantiation of "dest_t c10::static_cast_with_inter_type<dest_t, src_t>::apply(src_t) [with dest_t=c10::complex<double>, src_t=int64_t]"
(157): here
            instantiation of "To c10::convert<To,From>(From) [with To=c10::complex<double>, From=int64_t]"
(169): here
            instantiation of "To c10::checked_convert<To,From>(From, const char *) [with To=c10::complex<double>, From=int64_t]"
caffe2/c10/core/Scalar.h(63): here
```
Here, we take the compiler up on its suggestion and use the `--expt-relaxed-constexpr` flag.

As noted [here](https://stackoverflow.com/questions/55481202/how-to-disable-cuda-host-device-warning-for-just-one-function) either `#pragma nv_exec_check_disable` or `#pragma hd_warning_disable` could also be used. This would have less over-all impact on the code (since using the flag applies to all files touched by NVCC within this target); however, their effects are not as well documented as `constexpr`.

Test Plan:
Compiling
```
buck build mode/dev-nosan -c=python.package_style=inplace dper3/dper3_models/experimental/pytorch/ads:ads_model_generation_script
```
shows this warning.

We rely on sandcastle for testing here.

Reviewed By: xw285cornell

Differential Revision: D25440771

