### PR TITLE
Add tensorpipe agent tests to multigpu tests.

### DIFF
--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -21,4 +21,5 @@ time python test/run_test.py --verbose -i distributed/test_jit_c10d
 time python test/run_test.py --verbose -i distributed/test_distributed_fork
 time python test/run_test.py --verbose -i distributed/test_c10d
 time python test/run_test.py --verbose -i distributed/test_c10d_spawn
+time python test/run_test.py --verbose -i distributed/rpc/test_tensorpipe_agent
 assert_git_not_dirty


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49210 Add tensorpipe agent tests to multigpu tests.**

The RPC tests use multiple gpus in some cases (ex: DDP + RPC and Pipe
+ DDP). We should enable multigpu tests for this purpose.

Differential Revision: [D25485506](https://our.internmc.facebook.com/intern/diff/D25485506/)