### PR TITLE
Reduce kineto logging

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -242,6 +242,7 @@ void prepareProfiler(
 
   if (!libkineto::api().isProfilerRegistered()) {
     libkineto_init();
+    libkineto::api().suppressLogMessages();
   }
 
   if (!libkineto::api().isProfilerInitialized()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49201 Set USE_KINETO=1
* **#49216 Reduce kineto logging**

Summary:
Libkineto is pretty verbose by default, using libkineto api
to reduce amount of logging

Test Plan:
TORCH_CUDA_ARCH_LIST="6.0;7.0" USE_CUDA=1 USE_MKLDNN=1 BUILD_BINARY=1
python setup.py develop install --cmake

python test/test_profiler.py

Reviewers:ngimel, robieta

Differential Revision: [D25488109](https://our.internmc.facebook.com/intern/diff/D25488109)