### PR TITLE
Fix remainder type promotion test failed problem

### DIFF
--- a/test/onnx/expect/TestOperators.test_remainder.expect
+++ b/test/onnx/expect/TestOperators.test_remainder.expect
@@ -3,41 +3,30 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    input: "0"
     input: "1"
     output: "2"
-    name: "Cast_0"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 1
-      type: INT
-    }
-  }
-  node {
-    input: "0"
-    input: "2"
-    output: "3"
-    name: "Div_1"
+    name: "Div_0"
     op_type: "Div"
   }
   node {
-    input: "3"
-    output: "4"
-    name: "Floor_2"
+    input: "2"
+    output: "3"
+    name: "Floor_1"
     op_type: "Floor"
   }
   node {
-    input: "4"
-    input: "2"
-    output: "5"
-    name: "Mul_3"
+    input: "3"
+    input: "1"
+    output: "4"
+    name: "Mul_2"
     op_type: "Mul"
   }
   node {
     input: "0"
-    input: "5"
-    output: "6"
-    name: "Sub_4"
+    input: "4"
+    output: "5"
+    name: "Sub_3"
     op_type: "Sub"
   }
   name: "torch-jit-export"
@@ -80,7 +69,7 @@ graph {
     }
   }
   output {
-    name: "6"
+    name: "5"
     type {
       tensor_type {
         elem_type: 1


### PR DESCRIPTION
The remainder() method changes that deletes the "cast op" in symboloc_opset9.py. This causes test result dismatchs the expect file.

TODO: confirm to modify the expect file or recover the "cast" op.
  