### PR TITLE
Fix structured kernel codegen

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -471,6 +471,7 @@ c10::impl::hacky_wrapper_for_legacy_signatures<
 
         return list(mapMaybe(gen_one, g.functions()))
 
+    @method_with_native_function
     def gen_unstructured(self, f: NativeFunction) -> Optional[str]:
         # for mypy type refinement; would be fixed by TODO on target
         assert self.target is not Target.DECLARATION


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49244 Fix structured kernel codegen**

see https://fb.quip.com/ceEdANd5iVsO

RegisterMkldnnCPU kernels incorrectly used makeUnboxedOnly() calls to register add_.Tensor kernels. This is because the codegen incorrectly thought they're not c10-full.
This PR fixes that.

Differential Revision: [D25500246](https://our.internmc.facebook.com/intern/diff/D25500246/)