### PR TITLE
[Gradient Compression] Minor update of the comments on PowerSGD.

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -47,6 +47,8 @@ class PowerSGDState(object):
         random_seed=0,
     ):
         self.process_group = process_group
+        # The low rank for matrix approximation.
+        # Typically only 1 or 2 is used. See https://arxiv.org/pdf/1905.13727.pdf.
         self.matrix_approximation_rank = matrix_approximation_rank
         # Error feedback is usually crucial for both for convergence and generalization,
         # because PowerSGD is a biased compressor,
@@ -97,8 +99,6 @@ def powerSGD_hook(
         bucket (dist._GradBucket): Bucket that stores a 1D flattened gradient tensor that batches multiple per-variable tensors.
             Note that since DDP comm hook only supports single process single device mode at this time,
             only exactly one tensor is stored in this bucket.
-        matrix_approximation_rank (int): The low rank for matrix approximation.
-            Typically only 1 or 2 is used. See https://arxiv.org/pdf/1905.13727.pdf.
 
     Returns:
         Future handler of the communication, which updates the gradients in place.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49246 [Gradient Compression] Minor update the comments on PowerSGD.**

Previously the comment on matrix_approximation_rank was in PowerSGD_hook function. Now move it into PowerSGDState, because the function arg is already moved to this state as an attribute.

Original PR issue: Investigate Applying PowerSGD to Communication Hook for Gradient Compression #47202

Differential Revision: [D25501091](https://our.internmc.facebook.com/intern/diff/D25501091/)