### PR TITLE
[pt] Replace size(dim) with sizes()[dim]

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -45,11 +45,12 @@ at::Tensor embedding_bag_4bit_impl(
     }
   }
 
-  const int64_t N = weight.size(0);
-  const int64_t weight_size = weight.size(1);
+  const auto weight_sizes = weight.sizes();
+  const int64_t N = weight_sizes[0];
+  const int64_t weight_size = weight_sizes[1];
   const int64_t D =
       (weight_size - 4) * 2; // NB: 2-byte fp16 scale and 2-byte zero_offset
-  const int64_t M = offsets.size(0);
+  const int64_t M = offsets.sizes()[0];
 
   int64_t output_size = M - 1;
   std::vector<OffsetType> offsets_include_last_val;
@@ -231,9 +232,10 @@ at::Tensor embedding_bag_byte_impl(
     }
   }
 
-  const int64_t N = weight.size(0);
-  const int64_t D = weight.size(1) - 8; // NB: -8 to account for scale and bias
-  const int64_t M = offsets.size(0);
+  const auto weight_sizes = weight.sizes();
+  const int64_t N = weight_sizes[0];
+  const int64_t D = weight_sizes[1] - 8; // NB: -8 to account for scale and bias
+  const int64_t M = offsets.sizes()[0];
 
   int64_t output_size = M - 1;
   std::vector<OffsetType> offsets_include_last_val;
@@ -254,7 +256,8 @@ at::Tensor embedding_bag_byte_impl(
   }
   std::vector<int64_t> shape;
   if (indices.dim() == 2 && is_embedding_op) {
-    shape = {indices.size(0), indices.size(1), D};
+    const auto indices_sizes = indices.sizes();
+    shape = {indices_sizes[0], indices_sizes[1], D};
   } else {
     shape = {output_size, D};
   }
@@ -350,8 +353,8 @@ at::Tensor embedding_bag_byte_helper(
         !offsets_in.has_value(),
         "embedding_bag_byte operator: input is 2D, then offsets has to be None, as input is treated is a mini-batch of fixed length sequences.");
 
-    offsets =
-        at::arange(0, indices.numel(), indices.size(1), indices.scalar_type());
+    offsets = at::arange(
+        0, indices.numel(), indices.sizes()[1], indices.scalar_type());
   } else {
     TORCH_CHECK(
         offsets_in.has_value(),
@@ -443,8 +446,8 @@ at::Tensor embedding_bag_4bit_helper(
         !offsets_in.has_value(),
         "embedding_bag_4bit operator: input is 2D, then offsets has to be None, as input is treated is a mini-batch of fixed length sequences.");
 
-    offsets =
-        at::arange(0, indices.numel(), indices.size(1), indices.scalar_type());
+    offsets = at::arange(
+        0, indices.numel(), indices.sizes()[1], indices.scalar_type());
   } else {
     TORCH_CHECK(
         offsets_in.has_value(),


### PR DESCRIPTION
Summary:
- Replace `size(dim)` with `sizes()[dim]` because `sizes()` does not go through the dispatcher and is marginally better.
- Remove unnecessary `size(dim)` and `sizes()` calls by saving the return value of `sizes()` to a temporary var.

Reviewed By: radkris-git

Differential Revision: D25488129

