### PR TITLE
[AARCH64] Fix vst1q_f32_x2 implementation

### DIFF
--- a/aten/src/ATen/cpu/vec256/missing_vst1_neon.h
+++ b/aten/src/ATen/cpu/vec256/missing_vst1_neon.h
@@ -4,6 +4,5 @@ __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_f32_x2 (float32_t * __a, float32x4x2_t val)
 {
-  asm ("st1 {%S0.4s - %T0.4s}, [%1]" :: "w" (val), "r"(__a) :);
+  asm ("st1 {%S1.4s - %T1.4s}, [%2]" : "=m" (*__a) : "w" (val), "r"(__a) : "memory");
 }
-


### PR DESCRIPTION
Add memory operands to inline asm, that informs the compiler that this instruction writes to memory.

Fixes https://github.com/pytorch/pytorch/issues/48901

