### PR TITLE
Fix "Missing return statement" mypy error

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -468,6 +468,8 @@ c10::impl::hacky_wrapper_for_legacy_signatures<
                 return f'm.impl("{f.func.name}", {payload});'
             else:
                 assert_never(self.target)
+                # Silence mypy's "Missing return statement" error
+                return None
 
         return list(mapMaybe(gen_one, g.functions()))
 


### PR DESCRIPTION
Adds `return None` after `assert_never` in the inner `get_one` function
Without it, TestTypeHints.test_run_mypy_strict using mypy  0.770 fails with the above mentioned error, see https://app.circleci.com/pipelines/github/pytorch/pytorch/249909/workflows/597d8e34-ff04-4efa-9dde-9e28fbded341/jobs/9557705

Probably caused by https://github.com/python/mypy/issues/8129 

