### PR TITLE
Support integral types for kAbs in SimpleIREvaluator

### DIFF
--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -302,9 +302,9 @@ TEST(Expr, IntrinsicsDtypes) {
   std::vector<double> b_ref(N, 10.0);
 
   VarHandle i("i", kInt);
-  auto fabs_expr = For::make(i, 0, N, b.store({i}, fabs(a.load(i))));
+  auto abs_expr = For::make(i, 0, N, b.store({i}, abs(a.load(i))));
 
-  SimpleIREvaluator ir_eval(fabs_expr, a, b);
+  SimpleIREvaluator ir_eval(abs_expr, a, b);
   ir_eval(a_buffer, b_buffer);
 
   ASSERT_EQ(a_buffer.size(), N);
@@ -377,7 +377,7 @@ TEST(Expr, UnaryMath01) {
        [](float v) { return std::tanh(v); }},
       {[](const ExprHandle& v) { return exp(v); },
        [](float v) { return std::exp(v); }},
-      {[](const ExprHandle& v) { return fabs(v); },
+      {[](const ExprHandle& v) { return abs(v); },
        [](float v) { return std::fabs(v); }},
       {[](const ExprHandle& v) { return log(v); },
        [](float v) { return std::log(v); }},

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -180,7 +180,7 @@ TEST(Simplify, ConstantFoldIntrinsics) {
   ExprHandle modHandle = Intrinsics::make(kFmod, c, sinHandle);
   ExprHandle logHandle = Intrinsics::make(kLog10, modHandle);
   ExprHandle rndHandle = Intrinsics::make(kRound, logHandle);
-  ExprHandle fn = Intrinsics::make(kFabs, rndHandle);
+  ExprHandle fn = Intrinsics::make(kAbs, rndHandle);
 
   ExprHandle newF = IRSimplifier::simplify(fn);
   ASSERT_NE(newF.AsNode<FloatImm>(), nullptr);

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -287,7 +287,7 @@ void CudaPrinter::visit(const Intrinsics* v) {
   if (returnType == ScalarType::Half || returnType == ScalarType::Float) {
     func_name = func_name + "f";
   }
-  if (v->op_type() == IntrinsicsOp::kFabs && is_integral(returnType)) {
+  if (v->op_type() == IntrinsicsOp::kAbs && is_integral(returnType)) {
     func_name = "abs";
   }
 

--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -124,8 +124,8 @@ ExprHandle expm1(const ExprHandle& v) {
   return Intrinsics::make(kExpm1, v);
 }
 
-ExprHandle fabs(const ExprHandle& v) {
-  return Intrinsics::make(kFabs, v);
+ExprHandle abs(const ExprHandle& v) {
+  return Intrinsics::make(kAbs, v);
 }
 
 ExprHandle log(const ExprHandle& v) {

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -288,7 +288,7 @@ TORCH_API ExprHandle tanh(const ExprHandle& v);
 TORCH_API ExprHandle sigmoid(const ExprHandle& v);
 TORCH_API ExprHandle exp(const ExprHandle& v);
 TORCH_API ExprHandle expm1(const ExprHandle& v);
-TORCH_API ExprHandle fabs(const ExprHandle& v);
+TORCH_API ExprHandle abs(const ExprHandle& v);
 TORCH_API ExprHandle log(const ExprHandle& v);
 TORCH_API ExprHandle log2(const ExprHandle& v);
 TORCH_API ExprHandle log10(const ExprHandle& v);

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -209,7 +209,7 @@ int Intrinsics::OpArgCount(IntrinsicsOp op_type) {
     case kSigmoid:
     case kExp:
     case kExpm1:
-    case kFabs:
+    case kAbs:
     case kLog:
     case kLog2:
     case kLog10:

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -655,7 +655,7 @@ enum IntrinsicsOp {
   kSigmoid,
   kExp,
   kExpm1,
-  kFabs,
+  kAbs,
   kLog,
   kLog2,
   kLog10,
@@ -733,8 +733,8 @@ class Intrinsics : public CallNode<Intrinsics> {
         return "sigmoid";
       case kExp:
         return "exp";
-      case kFabs:
-        return "fabs";
+      case kAbs:
+        return "abs";
       case kLog:
         return "log";
       case kLog2:

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -466,15 +466,6 @@ ExprHandle promoteHalfToFloat(const ExprHandle& e) {
   }
 }
 
-ExprHandle promoteHalfToFloatAndIntegerToDefaultType(const ExprHandle& e) {
-  auto scalarType = static_cast<c10::ScalarType>(e.dtype().scalar_type());
-  if (c10::isIntegralType(scalarType, /*includeBool*/ true)) {
-    return promoteIntegerToDefaultType(e);
-  } else {
-    return promoteHalfToFloat(e);
-  }
-}
-
 bool TensorExprKernel::checkTypes(
     const ScalarType highType,
     const int typeConstraints) {
@@ -1250,9 +1241,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
       return computeOneOperand(
           "aten_abs",
           v,
-          [](const ExprHandle& a) {
-            return fabs(promoteHalfToFloatAndIntegerToDefaultType(a));
-          },
+          [](const ExprHandle& a) { return abs(promoteHalfToFloat(a)); },
           kIntegralTypes | kFloatingPointTypes | kBoolType);
     } break;
 

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -1418,7 +1418,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
         SIMD_UNARY_MATH_CASE(kCos, "cosf", FloatTy_)
         SIMD_UNARY_MATH_CASE(kSin, "sinf", FloatTy_)
         SIMD_UNARY_MATH_CASE(kSqrt, "sqrtf", FloatTy_)
-        SIMD_UNARY_MATH_CASE(kFabs, "fabsf", FloatTy_)
+        SIMD_UNARY_MATH_CASE(kAbs, "fabsf", FloatTy_)
         SIMD_UNARY_MATH_CASE(kFloor, "floorf", FloatTy_)
         SIMD_UNARY_MATH_CASE(kCeil, "ceilf", FloatTy_)
         SIMD_UNARY_MATH_CASE(kTrunc, "truncf", FloatTy_)
@@ -1566,7 +1566,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
       SIMD_UNARY_MATH_CASE(kCos, "cos", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kSin, "sin", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kSqrt, "sqrt", DoubleTy_)
-      SIMD_UNARY_MATH_CASE(kFabs, "fabs", DoubleTy_)
+      SIMD_UNARY_MATH_CASE(kAbs, "fabs", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kFloor, "floor", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kCeil, "ceil", DoubleTy_)
       SIMD_UNARY_MATH_CASE(kTrunc, "trunc", DoubleTy_)
@@ -1668,7 +1668,7 @@ void LLVMCodeGenImpl::visit(const Intrinsics* v) {
         throw unimplemented_lowering(v);
       } break;
     }
-  } else if (v->dtype().is_integral() && v->op_type() == kFabs) {
+  } else if (v->dtype().is_integral() && v->op_type() == kAbs) {
     // abs is only intrinsic defined for integer inputs in pytorch eager
     v->params().front()->accept(this);
     if (is_unsigned_integral(v->dtype().scalar_type())) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49277 Support integral types for kAbs in SimpleIREvaluator**

Summary: This is a follow-up fix for PR #48679, where the previous PR
adds support for integer inputs to aten::abs by promoting integers to
float and then demote the result back to integers. This PR supports
integer inputs to aten::abs more efficiently in the SimpleIREvaluator
by allowing implementing integer inputs for kAbs (renamed from kFabs).

- Rename kFabs to kAbs
- Add support for integer input to kAbs in SimpleIREvalator (note that:
  llvm_codegen and cuda_codegen already supports integer inputs to kAbs)

Test Plan:
  - PYTORCH_TENSOREXPR_DONT_USE_LLVM=1 python test/test_jit_fuser_te.py TestTEFuser.test_unary_ops
  - python test/test_jit_fuser_te.py TestTEFuser.test_unary_ops

Reviewers:

Subscribers:

Tasks:

Tags: