### PR TITLE
[PyTorch Mobile] Skip generating code for BoxedKernelWrapper when building or mobile

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -53,6 +53,12 @@ inline Return KernelFunction::call(const OperatorHandle& opHandle, Args... args)
         return callUnboxedKernelFunction<Return, Args...>(unboxed_kernel_func_, functor_.get(), std::forward<Args>(args)...);
     }
 
+#if defined C10_MOBILE
+    TORCH_CHECK(
+        false,
+        "Tried to call KernelFunction::call() on an uninitialized KernelFunction."
+    );
+#else
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         boxed_kernel_func_ != nullptr,
         "Tried to call KernelFunction::call() on an uninitialized KernelFunction."
@@ -64,6 +70,7 @@ inline Return KernelFunction::call(const OperatorHandle& opHandle, Args... args)
         opHandle,
         std::forward<Args>(args)...
     );
+#endif
 }
 
 template<KernelFunction::BoxedKernelFunction* func>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49367 [PyTorch Mobile] Skip generating code for BoxedKernelWrapper when building or mobile**

When building for mobile, we don't need BoxedKernelWrapper since it's used to call boxed implementations of functions with from an unboxed call context (i.e. the wrapper converts an unboxed call into a call to a boxed operator implementation, and then unboxes the return value to pass on to the original caller). This is done using template expansion since the types are all known at build time.

This results in generated code that is practically unused.

Differential Revision: [D25521462](https://our.internmc.facebook.com/intern/diff/D25521462/)