### PR TITLE
Gate _jit_pass_onnx_eval_peephole on the do_constant_folding flag

### DIFF
--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -473,7 +473,7 @@ def _model_to_graph(model, args, verbose=False,
     param_names = input_and_param_names[len(input_and_param_names) - len(params):]
     params_dict = dict(zip(param_names, params))
 
-    if training is None or training == TrainingMode.EVAL:
+    if do_constant_folding and (training is None or training == TrainingMode.EVAL):
         params_dict = torch._C._jit_pass_onnx_eval_peephole(graph, params_dict)
 
     if do_constant_folding and _export_onnx_opset_version in torch.onnx.constant_folding_opset_versions:


### PR DESCRIPTION
This optimization pass will merge BatchNorm into Conv, which is a form of constant folding.

This caused a regression for us from 1.6.0, where we could turn off constant folding and use the weights from the state_dict to evaluate the model. In 1.7.0, there's no way to turn this fusion off in eval mode.

cc @BowenBao @neginraoof