### PR TITLE
Do not return unitialized qschame from getQSchemeAndQParamVector

### DIFF
--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -987,7 +987,7 @@ std::tuple<c10::QScheme, QParamVector> InsertQuantDeQuantHelper::
       v->debugName(),
       " exists.");
   QParamVector qparams;
-  c10::QScheme qscheme;
+  c10::QScheme qscheme = c10::kPerTensorAffine;
 
   auto observer_module = module.attr(observer_name.value()).toModule();
   auto scalar_type = observer_module.attr("dtype");


### PR DESCRIPTION
Assign it by default to `kPerTensorAffine`

Fixes regressions accidentally discovered by https://app.circleci.com/pipelines/github/pytorch/pytorch/250370/workflows/6f38ae43-a9a5-43f3-8c1f-0f911df69d75/jobs/9589799

