### PR TITLE
Guard non_overlapping_and_dense with support_as_strided.

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -33,7 +33,7 @@ static inline Tensor to_impl(const Tensor& self, const TensorOptions& options, b
                   (options.layout() == c10::kStrided));
 
   if (memory_format == MemoryFormat::Preserve) {
-    if (self.is_non_overlapping_and_dense()) {
+    if (self.unsafeGetTensorImpl()->support_as_strided() && self.is_non_overlapping_and_dense()) {
       // Copy all strides
       auto r = at::empty_strided(self.sizes(),
                                  self.strides(),

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1438,7 +1438,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   bool is_non_overlapping_and_dense() const {
-    return is_non_overlapping_and_dense_;
+    return support_as_strided() && is_non_overlapping_and_dense_;
   }
 
 private:

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1438,7 +1438,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   bool is_non_overlapping_and_dense() const {
-    return support_as_strided() && is_non_overlapping_and_dense_;
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(support_as_strided());
+    return is_non_overlapping_and_dense_;
   }
 
 private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49395 Guard non_overlapping_and_dense with support_as_strided.**

Differential Revision: [D25554953](https://our.internmc.facebook.com/intern/diff/D25554953)