### PR TITLE
[C2] Revive unsafe CoalesceOp

### DIFF
--- a/caffe2/operators/unsafe_coalesce.cc
+++ b/caffe2/operators/unsafe_coalesce.cc
@@ -1,0 +1,27 @@
+#include "caffe2/operators/unsafe_coalesce.h"
+
+namespace caffe2 {
+
+OPERATOR_SCHEMA(UnsafeCoalesce)
+    .NumInputsOutputs([](int inputs, int outputs) {
+      return inputs + 1 == outputs;
+    })
+    .AllowInplace([](int input, int output) { return input == output; })
+    .SetDoc(R"DOC(
+Coalesce the N inputs into N outputs and a single coalesced output blob.
+This allows operations that operate over multiple small kernels (e.g.
+biases in a deep CNN) to be coalesced into a single larger operation,
+amortizing the kernel launch overhead, synchronization costs for
+distributed computation, etc.
+The operator:
+- computes the total size of the coalesced blob by summing the input sizes
+- allocates the coalesced output blob as the total size
+- copies the input vectors into the coalesced blob, at the correct offset.
+- aliases each Output(i) to- point into the coalesced blob, at the corresponding offset for Input(i).
+This is 'unsafe' as the output vectors are aliased, so use with
+caution.
+)DOC");
+
+REGISTER_CPU_OPERATOR(UnsafeCoalesce, UnsafeCoalesceOp<CPUContext>);
+
+} // namespace caffe2

--- a/caffe2/operators/unsafe_coalesce.cu
+++ b/caffe2/operators/unsafe_coalesce.cu
@@ -1,0 +1,8 @@
+#include "caffe2/operators/unsafe_coalesce.h"
+#include "caffe2/core/context_gpu.h"
+
+namespace caffe2 {
+
+REGISTER_CUDA_OPERATOR(UnsafeCoalesce, UnsafeCoalesceOp<CUDAContext>);
+
+}

--- a/caffe2/operators/unsafe_coalesce.h
+++ b/caffe2/operators/unsafe_coalesce.h
@@ -1,0 +1,69 @@
+#ifndef CAFFE2_OPERATORS_UNSAFE_COALESCE_OP_H_
+#define CAFFE2_OPERATORS_UNSAFE_COALESCE_OP_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/export_caffe2_op_to_c10.h"
+#include "caffe2/core/operator.h"
+
+
+namespace caffe2 {
+
+template <class Context>
+class UnsafeCoalesceOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  using Operator<Context>::Operator;
+
+  bool RunOnDevice() override {
+    size_t coalesced_size = 0;
+    for (int i = 0; i < InputSize(); ++i) {
+      // For now only float type is supported
+      CAFFE_ENFORCE(
+          Input(i).dtype().template Match<float>(),
+          "Must only coalesce float type, error at input: ",
+          i);
+    }
+
+    for (int i = 0; i < InputSize(); ++i) {
+      coalesced_size += Input(i).numel();
+    }
+    auto* coalesced = Output(OutputSize() - 1, coalesced_size, at::dtype<float>());
+    auto coalesced_data = coalesced->template mutable_data<float>();
+
+    size_t coalesced_offset = 0;
+    for (auto i = 0; i < InputSize(); ++i) {
+      const auto num_elems = Input(i).numel();
+      auto input_sizes = Input(i).sizes().vec();
+      // Don't do anything if both tensors are already pointing on the same data
+      auto input_data = Input(i).template data<float>();
+      if (input_data != coalesced_data + coalesced_offset) {
+        // Make sure that we don't run operation on the same tensor
+        CAFFE_ENFORCE_NE(
+            input_data - Input(i).unsafeGetTensorImpl()->storage_offset(),
+            coalesced_data -
+                Output(OutputSize() - 1)
+                    ->unsafeGetTensorImpl()
+                    ->storage_offset(),
+            "Tensors used in UnsafeCoalesce operator cannot share storage, unless it's inplace operation");
+        context_.CopyItemsSameDevice(
+            Input(i).dtype(),
+            num_elems,
+            input_data,
+            coalesced_data + coalesced_offset);
+
+        // Note: this could cause Input(i) to free it's data if
+        // Output(i) and Input(i) alias each other. This is safe on a
+        // GPU (as the copy will happen-before the free), but it's
+        // worth mentioning.
+        OperatorBase::SetOutputTensor(i, coalesced->Alias());
+        Output(i)->unsafeGetTensorImpl()->set_storage_offset(coalesced_offset);
+        Output(i)->Resize(input_sizes);
+      }
+      coalesced_offset += num_elems;
+    }
+    return true;
+  }
+};
+} // namespace caffe2
+
+#endif /* CAFFE2_OPERATORS_UNSAFE_COALESCE_OP_H_ */

--- a/caffe2/python/operator_test/unsafe_coalesce_test.py
+++ b/caffe2/python/operator_test/unsafe_coalesce_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+import numpy.testing as npt
+from caffe2.python import core, workspace
+from hypothesis import given
+
+
+class TestUnsafeCoalesceOp(hu.HypothesisTestCase):
+    @given(
+        n=st.integers(1, 5),
+        shape=st.lists(st.integers(0, 5), min_size=1, max_size=3),
+        **hu.gcs
+    )
+    def test_unsafe_coalesce_op(self, n, shape, dc, gc):
+        workspace.ResetWorkspace()
+        test_inputs = [(100 * np.random.random(shape)).astype(np.float32) for _ in range(n)]
+        test_input_blobs = ["x_{}".format(i) for i in range(n)]
+
+        coalesce_op = core.CreateOperator(
+            "UnsafeCoalesce",
+            test_input_blobs,
+            test_input_blobs + ["shared_memory_blob"],
+            device_option=gc,
+        )
+
+        def reference_func(*args):
+            self.assertEquals(len(args), n)
+            return list(args) + [np.concatenate([x.flatten() for x in args])]
+
+        self.assertReferenceChecks(gc, coalesce_op, test_inputs, reference_func)
+
+    @given(
+        n=st.integers(1, 5),
+        shape=st.lists(st.integers(1, 5), min_size=1, max_size=3),
+        seed=st.integers(0, 65535),
+        **hu.gcs
+    )
+    def test_unsafe_coalesce_op_blob_sharing(self, n, shape, seed, dc, gc):
+        workspace.ResetWorkspace()
+        # Can make debugging of the test more predictable
+        np.random.seed(seed)
+        test_inputs = [(np.random.random(shape)).astype(np.float32) for _ in range(n)]
+        test_input_blobs = ["x_{}".format(i) for i in range(n)]
+
+        coalesce_op = core.CreateOperator(
+            "UnsafeCoalesce",
+            test_input_blobs,
+            test_input_blobs + ["shared_memory_blob"],
+            device_option=gc,
+        )
+        for name, value in zip(test_input_blobs, test_inputs):
+            workspace.FeedBlob(name, value, device_option=gc)
+
+        workspace.RunOperatorOnce(coalesce_op)
+        blob_value = workspace.blobs["shared_memory_blob"]
+        npt.assert_almost_equal(
+            blob_value,
+            np.concatenate([x.flatten() for x in test_inputs]),
+            decimal=4
+        )
+        # np.random generates values in range [0, 1), so -2 is outside of range
+        blob_value.fill(-2.0)
+        self.assertTrue((blob_value != workspace.blobs["shared_memory_blob"]).all())
+        workspace.FeedBlob("shared_memory_blob", blob_value, device_option=gc)
+
+        # All blobs preserved shape, but got overwritted to -2
+        for name, value in zip(test_input_blobs, test_inputs):
+            self.assertEqual(value.shape, workspace.blobs[name].shape)
+            self.assertTrue((value != workspace.blobs[name]).all())
+            self.assertTrue((workspace.blobs[name] == -2).all())
+
+        # It should be OK to reuse operator as long as it's blob shapes are not changing
+        workspace.RunOperatorOnce(coalesce_op)


### PR DESCRIPTION
Summary:
In cases of NCCLAllReduce operations there could be non-trivial overhead for
launching cooperative kernels (especially in case of async execution of
different parts of the model). This diff is reviving this operator to make it
possible to fuse multiple operations into a single kernel.

Test Plan:
Unit-test.
Used in a later diff.

Differential Revision: D25531206

