### PR TITLE
update breathe

### DIFF
--- a/docs/cpp/requirements.txt
+++ b/docs/cpp/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==3.1.2
-breathe==4.19.2
+breathe==4.25.0
 exhale==0.2.3
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 bs4


### PR DESCRIPTION
Fixes #47462, but not completely.

Update breathe to the latest version to get fixes for the "Unable to resolve..." issues. There are still some build errors, but much fewer than before. 
