### PR TITLE
[FX] Fix NamedTuple literal value printing

### DIFF
--- a/test/fx/named_tup.py
+++ b/test/fx/named_tup.py
@@ -1,0 +1,7 @@
+from typing import NamedTuple
+
+import torch
+
+class MyNamedTup(NamedTuple):
+    i : torch.Tensor
+    f : torch.Tensor

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1171,6 +1171,8 @@ class TestFX(JitTestCase):
                 return Pair(x, x)
 
         traced = symbolic_trace(NamedTupReturn())
+        input = torch.rand(3, 4)
+        self.assertEqual(traced(input), Pair(input, input))
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -21,6 +21,8 @@ from typing import Any, Callable, Dict, NamedTuple, List, Optional, Tuple, Union
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM, IS_WINDOWS, IS_SANDCASTLE, IS_MACOS
 from torch.testing._internal.jit_utils import JitTestCase
 
+from fx.named_tup import MyNamedTup
+
 try:
     from torchvision.models import resnet18
     HAS_TORCHVISION = True
@@ -1138,6 +1140,15 @@ class TestFX(JitTestCase):
 
         m = M()
         self.checkGraphModule(m, ())
+
+    def test_namedtuple_return_qualname(self):
+        class NamedTupReturn(torch.nn.Module):
+            def forward(self, x):
+                return MyNamedTup(x, x)
+
+        traced = symbolic_trace(NamedTupReturn())
+        input = torch.rand(3, 4)
+        self.assertEqual(traced(input), MyNamedTup(input, input))
 
     def test_torchbind_class_attribute_in_fx(self):
         if TEST_WITH_ROCM or IS_SANDCASTLE or IS_WINDOWS or IS_MACOS:

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -644,6 +644,7 @@ class Graph:
                 #     overrides `__repr__` s.t. it prints the fully-qualified
                 #     name rather than just the base name
                 register_modules_used(torch.typename(a))
+
                 class NTReprWrapper(a.__class__):
                     def __repr__(self):
                         value_strs = []

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -645,7 +645,7 @@ class Graph:
                 #     name rather than just the base name
                 register_modules_used(torch.typename(a))
 
-                class NTReprWrapper(a.__class__):
+                class NTReprWrapper(a.__class__):  # type: ignore
                     def __repr__(self):
                         value_strs = []
                         for field in self._fields:
@@ -654,7 +654,7 @@ class Graph:
                         # type we constructed it from.
                         assert len(self.__class__.__bases__) == 1
                         return f'{torch.typename(self.__class__.__bases__[0])}({",".join(value_strs)})'
-                return NTReprWrapper(*(getattr(a, field) for field in a._fields))
+                return NTReprWrapper(*(getattr(a, field) for field in a._fields))  # type: ignore
             elif isinstance(a, tuple):
                 return tuple(preprocess_values(elem) for elem in a)
             elif isinstance(a, list):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49513 [FX] NamedTuple repr approach 3: NTReprWrapper in create_arg
* #49512 [FX] NamedTuple repr approach 2: FakeNamedTuple type in create_arg
* **#49414 [FX] Fix NamedTuple literal value printing**

Previously, when a `NamedTuple` value was used in `args`/`kwargs` and the `NamedTuple` definition was in a different module (necessitating an `import` statement), we would miss 1) Adding the import statement and 2) having the `repr()` that refers to the right fully-qualified name, since the default `repr` for `NamedTuple` in Python does not print the FQN. This patch adds a preprocessing function that swaps out `NamedTuple` instances with an equivalent wrapper that implements `__repr__` to print the right thing.

Differential Revision: [D25564075](https://our.internmc.facebook.com/intern/diff/D25564075)