### PR TITLE
Adding fix for invalid annotation types for dictionary

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15187,6 +15187,23 @@ dedent """
             def foo():
                 new_item = {'score': [1.0], 'ys': [1, 2, 3]}
 
+    def test_dict_invalid_annotations(self):
+        # Check for invalid value type annotation
+        with self.assertRaisesRegex(AssertionError, "Unsupported annotation"):
+            def fn(dictionary: Dict[str, torch.jit.ScriptModule]):
+                return
+
+        # Check for invalid key type annotation
+        with self.assertRaisesRegex(AssertionError, "Unsupported annotation"):
+            def fn(dictionary: Dict[torch.jit.ScriptModule, str]):
+                return
+
+        # Check for invalid key and value type annotation
+        with self.assertRaisesRegex(AssertionError, "Unsupported annotation"):
+            def fn(dictionary: Dict[torch.jit.ScriptModule, torch.jit.ScriptModule]):
+                return
+
+
     def test_get_set_state_with_tensors(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15187,6 +15187,26 @@ dedent """
             def foo():
                 new_item = {'score': [1.0], 'ys': [1, 2, 3]}
 
+    def test_dict_invalid_annotations(self):
+        # Check for invalid value type annotation
+        with self.assertRaisesRegex(AssertionError, "Unsupported annotation"):
+            @torch.jit.script
+            def fn(dictionary: Dict[str, torch.jit.ScriptModule]):
+                return
+
+        # Check for invalid key type annotation
+        with self.assertRaisesRegex(AssertionError, "Unsupported annotation"):
+            @torch.jit.script
+            def fn(dictionary: Dict[torch.jit.ScriptModule, str]):
+                return
+
+        # Check for invalid key and value type annotation
+        with self.assertRaisesRegex(AssertionError, "Unsupported annotation"):
+            @torch.jit.script
+            def fn(dictionary: Dict[torch.jit.ScriptModule, torch.jit.ScriptModule]):
+                return
+
+
     def test_get_set_state_with_tensors(self):
         class M(torch.nn.Module):
             def __init__(self):

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -284,6 +284,12 @@ def try_ann_to_type(ann, loc):
     if is_dict(ann):
         key = try_ann_to_type(ann.__args__[0], loc)
         value = try_ann_to_type(ann.__args__[1], loc)
+        msg = "Unsupported annotation {} could not be resolved because {} could not be resolved."
+        # Assert if key or value is None
+        if key is None:
+            assert key, msg.format(repr(ann.__args__[0]), repr(key))
+        if value is None:
+            assert value, msg.format(repr(ann.__args__[1]), repr(value))
         return DictType(key, value)
     if is_optional(ann):
         if issubclass(ann.__args__[1], type(None)):


### PR DESCRIPTION
Fixes #49362

**Summary:**
This PR fixes the issue where invalid annotation types are used for a dictionary.
Unsupported assertion message is generated for all invalid annotations

**Test Case**:
python test/test_jit.py TestJit.test_dict_invalid_annotations
 
