### PR TITLE
JIT: guard DifferentiableGraph node

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -68,6 +68,21 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
         }
       }
       out << ")";
+    } else {
+      if (type_verbosity() >= TypeVerbosity::Full) {
+        size_t i = 0;
+        if (value->requiresGrad()) {
+          out << "("
+              << "requires_grad=" << *value->requiresGrad();
+          i++;
+        }
+        if (value->device()) {
+          out << ((i++ > 0) ? ", " : "(") << "device=" << *value->device();
+        }
+        if (i > 0) {
+          out << ")";
+        }
+      }
     }
 
     if (value->undefined() && *value->undefined()) {
@@ -600,8 +615,10 @@ bool TensorType::matchTensor(const at::Tensor& t) {
   }
   // Here we know t.defined() == true and compare all other properties.
   bool rg = at::GradMode::is_enabled() && t.requires_grad();
-  bool matched_strides = (!t.has_storage() && !stride_properties().isComplete())
-    || stride_properties() == computeStrideProps(t.sizes(), t.strides(), t.is_contiguous());
+  bool matched_strides = (!stride_properties().size()) ||
+      (!t.has_storage() && !stride_properties().isComplete()) ||
+      stride_properties() ==
+          computeStrideProps(t.sizes(), t.strides(), t.is_contiguous());
   return scalarType().value_or(t.scalar_type()) == t.scalar_type()
     && device().value_or(t.device()) == t.device()
     && requiresGrad().value_or(rg) == rg

--- a/test/cpp/jit/test_interpreter.cpp
+++ b/test/cpp/jit/test_interpreter.cpp
@@ -23,7 +23,7 @@ class TypeCheckTest : public ::testing::Test {
         R"IR(
 graph(%a.1 : Tensor,
       %b.1 : Tensor):
-  %t0 : Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), %t1 : Float(3, 3, strides=[3, 1]), %type_matched : bool = prim::TypeCheck(%a.1, %b.1)
+  %t0 : Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), %t1 : Float(3, 3, strides=[3, 1]), %type_matched : bool = prim::TypeCheck[types=[Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), Float(3, 3, strides=[3, 1])]](%a.1, %b.1)
   return (%t0, %t1, %type_matched)
   )IR",
         &*graph,

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -29,7 +29,10 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
                 return ge.graph_for(*inputs)
 
     def assertGraphSize(self, graph, size):
-        nodes = list(filter(lambda n : n.kind() != "prim::BailOut" and n.kind() != "prim::BailoutTemplate", graph.nodes()))
+        nodes = list(filter(lambda n: (n.kind() != "prim::BailOut" and
+                                       n.kind() != "prim::BailoutTemplate" and
+                                       n.kind() != "prim::TypeCheck"),
+                            graph.nodes()))
         self.assertEqual(len(list(nodes)), size)
 
     def test_chunk_constant_script_ad(self):

--- a/test/jit/test_fuser_common.py
+++ b/test/jit/test_fuser_common.py
@@ -1,0 +1,17 @@
+import torch
+from torch.testing._internal.jit_utils import JitTestCase
+
+class TestFuserCommon(JitTestCase):
+    def test_autodiff_fallback(self):
+        for rq in [True, False]:
+            @torch.jit.script
+            def fn(x):
+                return torch.max(x**2.0, x**3.0)
+
+            x = torch.randn(5, requires_grad=not rq)
+            # cause optimization to be created
+            for i in range(5):
+                fn(x)
+            # test fallback when optimization is not applicable
+            y = fn(torch.randn(5, requires_grad=rq))
+            self.assertEqual(y.requires_grad, rq)

--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -117,7 +117,7 @@ class TestProfiler(JitTestCase):
 
         g = torch.jit.last_executed_optimized_graph()
         # Types should remain specialized for typecheck outputs & fusion outputs
-        FileCheck().check("Double(").check_same("prim::TypeCheck").check("Double").check_same("TensorExpr").run(g)
+        FileCheck().check("Double(").check_same("prim::TypeCheck").check_same("\n").check("Double").check_same("TensorExpr").run(g)
 
         # other outputs should not be specialized
         FileCheck().check("Tensor = prim::If").run(g)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7153,7 +7153,8 @@ a")
         else:
             g = test_dtype.graph_for(5)
             # first should have type set second should not
-            FileCheck().check("Float(requires_grad=1, device=cpu) = aten::tensor").check("Tensor(requires_grad=0) = aten::tensor").run(g)
+            FileCheck().check("Float(requires_grad=1, device=cpu) = aten::tensor") \
+                       .check("Tensor(requires_grad=0) = aten::tensor").run(g)
 
         @torch.jit.script
         def test_as_tensor_tensor_input(input):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -269,6 +269,8 @@ def get_grad_executor(plan_state, diff_graph_idx=None, skip_check=False):
             nodes = list(filter(lambda n : n.kind() != "prim::BailOut" and n.kind() != "prim::BailoutTemplate", nodes))
             if len(nodes) == 1 or (len(nodes) == 2 and nodes[1].kind() == "prim::TupleConstruct"):
                 pass
+            elif len(nodes) == 2 and nodes[0].kind() == "prim::TypeCheck" and nodes[1].kind() == "prim::If":
+                pass
             else:
                 raise RuntimeError("Can't get a grad_executor for a non-differentiable graph")
     grad_executors = list(plan_state.code.grad_executor_states())
@@ -1306,11 +1308,11 @@ graph(%Ra, %Rb):
           %4 : bool = prim::Constant[value=1]()
           %1 : int = prim::Constant[value=2]()
           %7 : int = prim::Constant[value=0]()
-          # CHECK: FloatTensor = prim::Loop
+          # CHECK: FloatTensor(requires_grad=0, device=cpu) = prim::Loop
           %x : Tensor = prim::Loop(%1, %4, %x.1)
-            # CHECK: : FloatTensor):
+            # CHECK: : FloatTensor(requires_grad=0, device=cpu)):
             block0(%i : int, %x.6 : Tensor):
-              # CHECK: FloatTensor = aten::unsqueeze
+              # CHECK: FloatTensor(requires_grad=0, device=cpu) = aten::unsqueeze
               %x.3 : Tensor = aten::unsqueeze(%x.6, %7)
               -> (%4, %x.3)
           return (%x)"""
@@ -6208,7 +6210,7 @@ a")
             res = fn(None, t2, False)
         res = fn(None, t2, True)
         g = torch.jit.last_executed_optimized_graph()
-        self.assertEqual(next(g.outputs()).type().str(), "Tensor")
+        self.assertIn(next(g.outputs()).type().str(), ("Tensor", "Tensor(requires_grad=1)"))
 
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.LEGACY, "the current version of Profiler doesn't profile/specialize Optionals")
     def test_optional_list(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7153,7 +7153,7 @@ a")
         else:
             g = test_dtype.graph_for(5)
             # first should have type set second should not
-            FileCheck().check("Float(requires_grad=1, device=cpu) = aten::tensor").check("Tensor = aten::tensor").run(g)
+            FileCheck().check("Float(requires_grad=1, device=cpu) = aten::tensor").check("Tensor(requires_grad=0) = aten::tensor").run(g)
 
         @torch.jit.script
         def test_as_tensor_tensor_input(input):

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -109,15 +109,6 @@ class TestTEFuser(JitTestCase):
                 result += self.findFusionGroups(block)
         return result
 
-    def findNodesInBlocks(self, graph, kind):
-        result = []
-        for n in graph.nodes():
-            if n.kind() == kind:
-                result.append(n)
-            for block in n.blocks():
-                result += self.findNodesInBlocks(block, kind)
-        return result
-
     def _test_fused_abs(self, device='cpu'):
         def func(x):
             return x.abs() * 2
@@ -664,7 +655,7 @@ class TestTEFuser(JitTestCase):
         y = torch.ones(1, requires_grad=True, device='cuda')
         warmup_forward(scripted_f, x, y)
         g = torch.jit.last_executed_optimized_graph()
-        diff_nodes = self.findNodesInBlocks(g, 'prim::DifferentiableGraph')
+        diff_nodes = g.findAllNodes('prim::DifferentiableGraph')
         self.assertEqual(len(diff_nodes), 1)
         g = diff_nodes[0].g('Subgraph')
         if_nodes = [n for n in g.nodes() if n.kind() == 'prim::If']

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -109,6 +109,15 @@ class TestTEFuser(JitTestCase):
                 result += self.findFusionGroups(block)
         return result
 
+    def findNodesInBlocks(self, graph, kind):
+        result = []
+        for n in graph.nodes():
+            if n.kind() == kind:
+                result.append(n)
+            for block in n.blocks():
+                result += self.findNodesInBlocks(block, kind)
+        return result
+
     def _test_fused_abs(self, device='cpu'):
         def func(x):
             return x.abs() * 2
@@ -655,7 +664,7 @@ class TestTEFuser(JitTestCase):
         y = torch.ones(1, requires_grad=True, device='cuda')
         warmup_forward(scripted_f, x, y)
         g = torch.jit.last_executed_optimized_graph()
-        diff_nodes = [n for n in g.nodes() if n.kind() == 'prim::DifferentiableGraph']
+        diff_nodes = self.findNodesInBlocks(g, 'prim::DifferentiableGraph')
         self.assertEqual(len(diff_nodes), 1)
         g = diff_nodes[0].g('Subgraph')
         if_nodes = [n for n in g.nodes() if n.kind() == 'prim::If']
@@ -964,7 +973,7 @@ class TestTEFuser(JitTestCase):
             forward_graph = module.graph_for(*inputs)
             self.assertGraphContainsExactly(
                 forward_graph, FUSION_GROUP, 1, consider_subgraphs=True)
-            FileCheck().check("DifferentiableGraph").check_next("TupleConstruct") \
+            FileCheck().check("DifferentiableGraph").check("TupleConstruct") \
                 .check_next("return").check(FUSION_GROUP).run(str(forward_graph))
             hy, cy = module(*inputs)
             warmup_backward((hy + cy).sum())
@@ -1775,6 +1784,20 @@ class TestTEFuser(JitTestCase):
         self.assertAllFused(script.graph_for(a, s))
         script = self.checkScript(eager_st, (s, b))
         self.assertAllFused(script.graph_for(s, b))
+
+    def test_autodiff_fallback(self):
+        for rq in [True, False]:
+            @torch.jit.script
+            def fn(x):
+                return torch.max(x**2.0, x**3.0)
+
+            x = torch.randn(5, requires_grad=not rq)
+            # cause optimization to be created
+            for i in range(5):
+                fn(x)
+            # test fallback when optimization is not applicable
+            y = fn(torch.randn(5, requires_grad=rq))
+            self.assertEqual(y.requires_grad, rq)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -28,6 +28,8 @@ from test_jit import backward_graph, all_backward_graphs, get_lstm_inputs, get_m
 
 from torch.testing._internal.te_utils import CudaCodeGenExecuted
 
+from jit.test_fuser_common import TestFuserCommon  # noqa: F401
+
 FUSION_GROUP = 'prim::TensorExprGroup'
 LLVM_ENABLED = torch._C._llvm_enabled()
 
@@ -1775,20 +1777,6 @@ class TestTEFuser(JitTestCase):
         self.assertAllFused(script.graph_for(a, s))
         script = self.checkScript(eager_st, (s, b))
         self.assertAllFused(script.graph_for(s, b))
-
-    def test_autodiff_fallback(self):
-        for rq in [True, False]:
-            @torch.jit.script
-            def fn(x):
-                return torch.max(x**2.0, x**3.0)
-
-            x = torch.randn(5, requires_grad=not rq)
-            # cause optimization to be created
-            for i in range(5):
-                fn(x)
-            # test fallback when optimization is not applicable
-            y = fn(torch.randn(5, requires_grad=rq))
-            self.assertEqual(y.requires_grad, rq)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -89,7 +89,8 @@ bool complyWith(
   // check a. if num_dimension check fails or scalar type check fails
   if (*guard_tensor_type->dim() != static_cast<size_t>(tensor.ndimension()) ||
       (guard_tensor_type->scalarType().has_value() &&
-       (guard_tensor_type->scalarType().value() != tensor.scalar_type()))) {
+       (guard_tensor_type->scalarType().value() != tensor.scalar_type())) ||
+      tensor.requires_grad()) {
     return false;
   }
 

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -70,9 +70,11 @@ struct ParsedLiteral {
   int64_t i = 0;
   std::string s = "";
   double f = 0.0;
+  TypePtr ty;
   std::vector<int64_t> is;
   std::vector<std::string> ss;
   std::vector<double> fs;
+  std::vector<TypePtr> tys;
 };
 
 struct VarWithType {
@@ -139,6 +141,7 @@ void IRParser::parseOperatorOutputs(std::vector<VarWithType>* outs) {
 ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
   auto token = L.cur();
   std::string str;
+  std::pair<TypePtr, c10::optional<c10::AliasInfo>> type_alias;
   ParsedLiteral r;
   switch (token.kind) {
     case TK_STRINGLITERAL:
@@ -167,6 +170,13 @@ ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
       }
       L.next();
       return r;
+    case TK_IDENT:
+      // Type literal
+      r.k = AttributeKind::ty;
+      type_alias = type_parser.parseType();
+      AT_ASSERTM(!type_alias.second, "Parsing IR with Alias Info not handled");
+      r.ty = type_alias.first;
+      return r;
     default:
       throw ErrorReport(token.range)
           << "Could not parse literal" << token.text();
@@ -194,6 +204,7 @@ void IRParser::parseAttr(Node* n) {
     c10::List<int64_t> is;
     c10::List<std::string> ss;
     c10::List<double> fs;
+    std::vector<TypePtr> tys;
     int elem_num = 0;
     parseList('[', ',', ']', [&] {
       ParsedLiteral r = parseScalarLiteral(n);
@@ -213,6 +224,11 @@ void IRParser::parseAttr(Node* n) {
           AT_ASSERT(!elem_num++ || k == AttributeKind::fs);
           k = AttributeKind::fs;
           break;
+        case AttributeKind::ty:
+          tys.push_back(r.ty);
+          AT_ASSERT(!elem_num++ || k == AttributeKind::tys);
+          k = AttributeKind::tys;
+          break;
         default:
           throw ErrorReport(L.cur().range) << "Unexpected attr type";
       }
@@ -230,6 +246,9 @@ void IRParser::parseAttr(Node* n) {
       case AttributeKind::is:
         n->ival_(Symbol::attr(attrname), IValue(is));
         break;
+      case AttributeKind::tys:
+        n->tys_(Symbol::attr(attrname), tys);
+        break;
       default:
         throw ErrorReport(L.cur().range) << "Unexpected attr type";
     }
@@ -245,6 +264,9 @@ void IRParser::parseAttr(Node* n) {
         break;
       case AttributeKind::f:
         n->f_(Symbol::attr(attrname), r.f);
+        break;
+      case AttributeKind::ty:
+        n->ty_(Symbol::attr(attrname), r.ty);
         break;
       default:
         throw ErrorReport(L.cur().range) << "Unexpected attr type";

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -6,10 +6,8 @@
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
-#include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
 #include <torch/csrc/jit/runtime/autodiff.h>
-#include <torch/csrc/jit/runtime/graph_executor.h>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -3,10 +3,13 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
+#include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
 #include <torch/csrc/jit/runtime/autodiff.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
 
 namespace torch {
 namespace jit {
@@ -270,7 +273,9 @@ std::vector<Node*> CreateAutodiffSubgraphs(
     size_t threshold) {
   std::vector<Node*> diff_nodes;
   AliasDb db(graph);
+  GRAPH_DEBUG("Before creating autodiff subgraphs", *graph);
   SubgraphSlicer(graph->block(), graph, threshold, db, diff_nodes).run();
+  GRAPH_DEBUG("After creating autodiff subgraphs", *graph);
   return diff_nodes;
 }
 } // namespace jit

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <ATen/record_function.h>
+#include <c10/util/FunctionRef.h>
 #include <torch/csrc/jit/codegen/fuser/interface.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -328,6 +329,102 @@ void removeTensorTypeSpecializations(Block* block) {
 
 void RemoveTensorTypeSpecializations(std::shared_ptr<Graph>& graph) {
   removeTensorTypeSpecializations(graph->block());
+}
+
+void insertTypeGuard(
+    Node* guarded_node,
+    tensor_type_converter_t type_converter) {
+  GRAPH_DEBUG("Inserting a typecheck guard for a node", *guarded_node);
+  auto subgraph = SubgraphUtils::getSubgraph(guarded_node);
+
+  // Fixup types of the subgraph inputs
+  std::vector<Value*> inputs_to_check;
+  std::vector<TypePtr> guard_types;
+  for (Value* input : guarded_node->inputs()) {
+    // We only check inputs of the guarded nodes and expect user to infer
+    // intermediates and outputs shapes
+    if (!input->type()->cast<TensorType>()) {
+      continue;
+    }
+
+    // fusion outputs are already guarded
+    if (input->node()->kind() == prim::Constant ||
+        input->node()->kind() == prim::FusionGroup) {
+      continue;
+    }
+    inputs_to_check.push_back(input);
+    guard_types.push_back(type_converter(input->type()->expect<TensorType>()));
+  }
+  if (!inputs_to_check.size()) {
+    return;
+  }
+
+  // Add prim::TypeCheck node
+  //
+  // TypeCheck nodes  look like the following:
+  //   %out1 : Float(2, 3), %out2 : Int(10, 30), %types_match : bool =
+  //   prim::TypeCheck(%inp1 : Tensor, %inp2 : Tensor)
+  //
+  // They have N inputs whose types we are going to check and N+1 outputs. The
+  // first N outputs specify expected types and N+1-th output holds the result
+  // of the check (bool).
+  Node* typecheck_node =
+      guarded_node->owningGraph()
+          ->create(prim::TypeCheck, inputs_to_check, inputs_to_check.size() + 1)
+          ->insertBefore(guarded_node);
+  typecheck_node->tys_(attr::types, guard_types);
+  Value* typecheck_result = typecheck_node->output(inputs_to_check.size());
+
+  std::unordered_map<Value*, Value*> typechecked_inputs;
+  for (size_t i = 0; i < typecheck_node->inputs().size(); ++i) {
+    typechecked_inputs[typecheck_node->input(i)] = typecheck_node->output(i);
+  }
+
+  // Fixup types of the typecheck node outputs, which are used by the op in
+  // execution
+  typecheck_node->output(inputs_to_check.size())->setType(BoolType::get());
+  for (size_t i = 0; i < typecheck_node->inputs().size(); ++i) {
+    typecheck_node->output(i)->setType(typecheck_node->input(i)->type());
+  }
+
+  // Insert if
+  auto versioning_if =
+      guarded_node->owningGraph()
+          ->create(prim::If, {typecheck_result}, guarded_node->outputs().size())
+          ->insertAfter(typecheck_node);
+  for (size_t idx = 0; idx < guarded_node->outputs().size(); ++idx) {
+    versioning_if->output(idx)->setType(guarded_node->output(idx)->type());
+    guarded_node->output(idx)->replaceAllUsesWith(versioning_if->output(idx));
+  }
+  auto true_block = versioning_if->addBlock();
+  auto false_block = versioning_if->addBlock();
+
+  // Fill in the false block. It should contain the unoptimized
+  // copy of the fused subgraph.
+  WithInsertPoint guard(false_block->return_node());
+  const auto subgraph_outputs = insertGraph(
+      *guarded_node->owningGraph(), *subgraph, guarded_node->inputs());
+  for (Value* output : subgraph_outputs) {
+    false_block->registerOutput(output);
+  }
+
+  // types get copied to the fallback graph, so remove specializations before
+  // replacing
+  removeTensorTypeSpecializations(false_block);
+  replaceBlockWithFallbackGraph(false_block, guarded_node->inputs());
+
+  // Fill in the true block. It has all inputs type-checked and its
+  // body should be the fusion group node.
+  guarded_node->moveBefore(true_block->return_node());
+  for (size_t idx = 0; idx < guarded_node->inputs().size(); ++idx) {
+    if (typechecked_inputs.count(guarded_node->input(idx))) {
+      guarded_node->replaceInput(
+          idx, typechecked_inputs.at(guarded_node->input(idx)));
+    }
+  }
+  for (Value* output : guarded_node->outputs()) {
+    true_block->registerOutput(output);
+  }
 }
 
 class TensorExprFuser {
@@ -961,99 +1058,6 @@ class TensorExprFuser {
   }
 #undef REQ
 
-  void guardFusionGroup(Node* fusion_group) {
-    GRAPH_DEBUG("Inserting a typecheck guard for a node", *fusion_group);
-    auto subgraph = SubgraphUtils::getSubgraph(fusion_group);
-
-    // Fixup types of the subgraph inputs
-    std::vector<Value*> inputs_to_check;
-    for (Value* input : fusion_group->inputs()) {
-      // We only check inputs of the fusion group and expect NNC to infer
-      // intermediates and outputs shapes
-      if (!input->type()->cast<TensorType>()) {
-        continue;
-      }
-
-      // fusion outputs are already guarded
-      if (input->node()->kind() == prim::Constant ||
-          input->node()->kind() == prim::FusionGroup) {
-        continue;
-      }
-      inputs_to_check.push_back(input);
-    }
-    if (!inputs_to_check.size()) {
-      return;
-    }
-
-    // Add prim::TypeCheck node
-    //
-    // TypeCheck nodes  look like the following:
-    //   %out1 : Float(2, 3), %out2 : Int(10, 30), %types_match : bool =
-    //   prim::TypeCheck(%inp1 : Tensor, %inp2 : Tensor)
-    //
-    // They have N inputs whose types we are going to check and N+1 outputs. The
-    // first N outputs specify expected types and N+1-th output holds the result
-    // of the check (bool).
-    Node* typecheck_node =
-        fusion_group->owningGraph()
-            ->create(
-                prim::TypeCheck, inputs_to_check, inputs_to_check.size() + 1)
-            ->insertBefore(fusion_group);
-    Value* typecheck_result = typecheck_node->output(inputs_to_check.size());
-
-    std::unordered_map<Value*, Value*> typechecked_inputs;
-    for (size_t i = 0; i < typecheck_node->inputs().size(); ++i) {
-      typechecked_inputs[typecheck_node->input(i)] = typecheck_node->output(i);
-    }
-
-    // Fixup types of the typecheck node outputs, which are used by the op in
-    // execution
-    typecheck_node->output(inputs_to_check.size())->setType(BoolType::get());
-    for (size_t i = 0; i < typecheck_node->inputs().size(); ++i) {
-      typecheck_node->output(i)->setType(typecheck_node->input(i)->type());
-    }
-
-    // Insert if
-    auto versioning_if =
-        fusion_group->owningGraph()
-            ->create(
-                prim::If, {typecheck_result}, fusion_group->outputs().size())
-            ->insertAfter(typecheck_node);
-    for (size_t idx = 0; idx < fusion_group->outputs().size(); ++idx) {
-      versioning_if->output(idx)->setType(fusion_group->output(idx)->type());
-      fusion_group->output(idx)->replaceAllUsesWith(versioning_if->output(idx));
-    }
-    auto true_block = versioning_if->addBlock();
-    auto false_block = versioning_if->addBlock();
-
-    // Fill in the false block. It should contain the unoptimized
-    // copy of the fused subgraph.
-    WithInsertPoint guard(false_block->return_node());
-    const auto subgraph_outputs = insertGraph(
-        *fusion_group->owningGraph(), *subgraph, fusion_group->inputs());
-    for (Value* output : subgraph_outputs) {
-      false_block->registerOutput(output);
-    }
-
-    // types get copied to the fallback graph, so remove specializations before
-    // replacing
-    removeTensorTypeSpecializations(false_block);
-    replaceBlockWithFallbackGraph(false_block, fusion_group->inputs());
-
-    // Fill in the true block. It has all inputs type-checked and its
-    // body should be the fusion group node.
-    fusion_group->moveBefore(true_block->return_node());
-    for (size_t idx = 0; idx < fusion_group->inputs().size(); ++idx) {
-      if (typechecked_inputs.count(fusion_group->input(idx))) {
-        fusion_group->replaceInput(
-            idx, typechecked_inputs.at(fusion_group->input(idx)));
-      }
-    }
-    for (Value* output : fusion_group->outputs()) {
-      true_block->registerOutput(output);
-    }
-  }
-
   // TODO: support constant tensors instead of setting them as input
   void liftTensorConstantsFromFusionGroups(Node* fusion_group) {
     auto subgraph = SubgraphUtils::getSubgraph(fusion_group);
@@ -1088,7 +1092,7 @@ class TensorExprFuser {
     for (Node* fusion_group : fusion_groups) {
       removeOutputsUsedOnlyInSize(fusion_group);
       liftTensorConstantsFromFusionGroups(fusion_group);
-      guardFusionGroup(fusion_group);
+      insertTypeGuard(fusion_group, [](const TensorTypePtr& t) { return t; });
     }
   }
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -32,6 +32,23 @@ TORCH_API void removeTensorTypeSpecializations(Block* block);
 
 using tensor_type_converter_t =
     c10::function_ref<TensorTypePtr(const TensorTypePtr& t)>;
+
+// inserts a TypeCheck pattern
+//
+// around the guarded node that has a Subgraph attribute, this inserts a pattern
+//
+//   if TypeCheck(...):
+//     guarded_node
+//   else:
+//     FallbackGraph(...)
+//
+// The TypeCheck includes the types of all Tensor inputs to the guarded_node,
+// as processed by the type_converter, a lambda
+// TensorTypePtr(const TensorTypePtr& t). This allows to erase irrelevant
+// aspects of the type.
+//
+// The Fallback graph will have the same subgraph as the guarded node (with the
+// expectation that the guarded_node's subgraph will then be optimized.
 TORCH_API void insertTypeGuard(
     Node* guarded_node,
     tensor_type_converter_t type_converter);

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -28,6 +28,13 @@ TORCH_API bool texprReductionsEnabled();
 TORCH_API void RemoveProfileNodesAndSpecializeTypes(
     std::shared_ptr<Graph>& graph);
 TORCH_API void RemoveTensorTypeSpecializations(std::shared_ptr<Graph>& graph);
+TORCH_API void removeTensorTypeSpecializations(Block* block);
+
+using tensor_type_converter_t =
+    c10::function_ref<TensorTypePtr(const TensorTypePtr& t)>;
+TORCH_API void insertTypeGuard(
+    Node* guarded_node,
+    tensor_type_converter_t type_converter);
 
 TORCH_API bool usedOnlyInSize(Value* v);
 TORCH_API Value* broadcastSizes(at::ArrayRef<Value*> sizes, AliasDb* db);

--- a/torch/csrc/jit/passes/update_differentiable_graph_requires_grad.cpp
+++ b/torch/csrc/jit/passes/update_differentiable_graph_requires_grad.cpp
@@ -9,6 +9,12 @@ void UpdateDifferentiableGraphRequiresGrad(
     Block* block,
     c10::optional<bool> new_requires_grad) {
   for (Node* n : block->nodes()) {
+    for (Value* v : n->inputs()) {
+      auto ty = v->type()->cast<TensorType>();
+      if (ty) {
+        v->setType(ty->withRequiresGrad(new_requires_grad));
+      }
+    }
     if (n->kind() == prim::profile) {
       n->ty_(
           attr::profiled_type,

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -45,7 +45,7 @@ bool needTrimGrad(Node* n) {
   return false;
 }
 
-bool isDifferentiable(Node* n) {
+bool isDifferentiable(const Node* n) {
   // TODO: scalar-tensor ops should be canonicalized
   static OperatorSet differentiable_ops = {
       "aten::thnn_conv2d_forward(Tensor self, Tensor weight, int[] kernel_size, Tensor? bias, int[] stride, int[] padding) -> (Tensor, Tensor, Tensor)",
@@ -89,7 +89,7 @@ bool isDifferentiable(Node* n) {
     return std::all_of(
         body->nodes().begin(),
         body->nodes().end(),
-        static_cast<bool (*)(Node*)>(isDifferentiable));
+        static_cast<bool (*)(const Node*)>(isDifferentiable));
   }
 
   // formulas are only defined with floating point scalars,
@@ -107,7 +107,7 @@ bool isDifferentiable(Graph& g) {
   return std::all_of(
       g.nodes().begin(),
       g.nodes().end(),
-      static_cast<bool (*)(Node*)>(isDifferentiable));
+      static_cast<bool (*)(const Node*)>(isDifferentiable));
 }
 
 // NB: Write gradient using torchscript

--- a/torch/csrc/jit/runtime/autodiff.h
+++ b/torch/csrc/jit/runtime/autodiff.h
@@ -90,7 +90,7 @@ struct Gradient {
 TORCH_API Gradient differentiate(std::shared_ptr<Graph>& graph);
 
 // can we take a derivative of this node symbolically?
-TORCH_API bool isDifferentiable(Node* n);
+TORCH_API bool isDifferentiable(const Node* n);
 TORCH_API bool isDifferentiable(Graph& g);
 TORCH_API bool isZero(Value* v);
 

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -744,8 +744,9 @@ struct CodeImpl {
 
     // Emit the expected type.
     size_t types_start = type_table_.size();
+    auto types = node->tys(attr::types);
     for (size_t i = 0; i < num_inputs; i++) {
-      emitType(node->outputs()[i]->type());
+      emitType(types[i]);
     }
     insertInstruction(TYPECHECK, types_start, num_inputs);
   }

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -123,8 +123,9 @@ void guardDifferentiableGraph(Node* dnode) {
     auto ty = gi[i]->type()->cast<TensorType>();
     if (ty) {
       auto n = gi[i]->uses().at(0).user;
-      TORCH_INTERNAL_ASSERT(n->kind() == prim::profile);
-      dnode->inputs().at(i)->setType(n->ty(attr::profiled_type));
+      if (n->kind() == prim::profile) {
+        dnode->inputs().at(i)->setType(n->ty(attr::profiled_type));
+      }
     }
   }
   insertTypeGuard(dnode, [](const TensorTypePtr& t) {

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -1,3 +1,4 @@
+#include <torch/csrc/jit/runtime/profiling_graph_executor_impl.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/bailout_graph.h>
 #include <torch/csrc/jit/passes/batch_mm.h>
@@ -30,7 +31,6 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/passes/update_differentiable_graph_requires_grad.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
-#include <torch/csrc/jit/runtime/profiling_graph_executor_impl.h>
 
 C10_DEFINE_bool(
     torch_jit_enable_new_executor,

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -1,11 +1,12 @@
-#include <torch/csrc/jit/runtime/profiling_record.h>
 #include <ATen/core/interned_strings.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/clear_profiling.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
+#include <torch/csrc/jit/runtime/autodiff.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/interpreter.h>
+#include <torch/csrc/jit/runtime/profiling_record.h>
 
 namespace torch {
 namespace jit {
@@ -26,6 +27,9 @@ class ProfileRegistry {
 
   bool shouldProfileNode(const Node* node) {
     std::lock_guard<std::mutex> guard(mutex_);
+    if (isDifferentiable(node)) {
+      return true;
+    }
     for (const auto& func : registry_funcs_) {
       if (func(node)) {
         return true;

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -1,3 +1,4 @@
+#include <torch/csrc/jit/runtime/profiling_record.h>
 #include <ATen/core/interned_strings.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/clear_profiling.h>
@@ -6,7 +7,6 @@
 #include <torch/csrc/jit/runtime/autodiff.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/interpreter.h>
-#include <torch/csrc/jit/runtime/profiling_record.h>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -27,6 +27,8 @@ class ProfileRegistry {
 
   bool shouldProfileNode(const Node* node) {
     std::lock_guard<std::mutex> guard(mutex_);
+    // to guard differentiable graphs, we want profiling information
+    // (in particular requires_grad) for nodes handled by autodiff
     if (isDifferentiable(node)) {
       return true;
     }


### PR DESCRIPTION
This adds guarding for DifferentiableGraph nodes in order to not depend on 
Also bailing out on required gradients for the CUDA fuser.

Fixes #49299

I still need to look into a handful of failing tests, but maybe it can be a discussion basis.