### PR TITLE
.circleci: downgrade conda-package-handling to 1.6.0

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -7,6 +7,11 @@ set -eux -o pipefail
 
 python_nodot="\$(echo $DESIRED_PYTHON | tr -d m.u)"
 
+# There was a bug that was introduced in conda-package-handling >= 1.6.1 that makes archives
+# above a certain size fail out when attempting to extract
+# see: https://github.com/conda/conda-package-handling/issues/71
+conda install -y conda-package-handling=1.6.0
+
 # Set up Python
 if [[ "$PACKAGE_TYPE" == conda ]]; then
   retry conda create -qyn testenv python="$DESIRED_PYTHON"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49423 DO NOT MERGE, testing downgrade of conda-package-handling
* **#49434 .circleci: downgrade conda-package-handling to 1.6.0**

There was a bug that was introduced in conda-package-handling >= 1.6.1 that makes archives
above a certain size fail out when attempting to extract
see: https://github.com/conda/conda-package-handling/issues/71

coincides with https://github.com/pytorch/builder/pull/611

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D25573390](https://our.internmc.facebook.com/intern/diff/D25573390)