### PR TITLE
[Gradient Compression] Replace the assertions in PowerSGD comm hook by stream syncrhonization

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -268,7 +268,8 @@ def powerSGD_hook(
 
         for p, q, tensor in zip(ps, qs, high_rank_tensors):
             torch.matmul(p, q.t(), out=tensor)
-            assert not torch.any(torch.isnan(tensor))
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
 
         if state.use_error_feedback:
             # Memorize the local errors.
@@ -414,7 +415,8 @@ def batched_powerSGD_hook(
         if state.use_error_feedback:
             # Memorize the local errors.
             state.error_dict[bucket_index] = input_tensor_cp - input_tensor
-            assert not torch.any(torch.isnan(state.error_dict[bucket_index]))
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
         ret = input_tensor.resize_(total_length)
         return [ret]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49451 [Gradient Compression] Warm-start of PowerSGD
* **#49435 [Gradient Compression] Replace the assertions in PowerSGD comm hook by stream syncrhonization**
* #49418 [Gradient Compression] Add error feedback to layerwise PowerSGD
* #49417 [Gradient Compression] Implement the original layerwise PowerSGD

Previously the assertion that prevents illegal memory access is because of the torch.any that returns a boolean value, which initiates a data transfer from the device to the host and forces a synchronization.

An explicit synchronization is more to the point.

Original PR issue: Investigate Applying PowerSGD to Communication Hook for Gradient Compression #47202

Differential Revision: [D25573484](https://our.internmc.facebook.com/intern/diff/D25573484/)