### PR TITLE
Instantiate PackedConvWeight to avoid linking error

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -170,6 +170,8 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeight<
   return ret_ptr;
 }
 
+template struct PackedConvWeight<2>;
+template struct PackedConvWeight<3>;
 #endif // USE_FBGEMM
 
 #ifdef USE_PYTORCH_QNNPACK


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49442 Instantiate PackedConvWeight to avoid linking error**

When moving Aten/native to app level, symbols from native/quantized may sit in a target away from some of its call sites. As a result, there are linking errors of missing symbols of instantiations of PackedConvWeight::prepack. The solution is to instantiate PackedConvWeight in the same compilation unit. It's similar to D24941989.

Differential Revision: [D25576703](https://our.internmc.facebook.com/intern/diff/D25576703/)