### PR TITLE
[extensions] fix `is_ninja_available` during cuda extension building

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1405,13 +1405,12 @@ def is_ninja_available():
     Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
     available on the system, ``False`` otherwise.
     '''
-    with open(os.devnull, 'wb') as devnull:
-        try:
-            subprocess.check_call('ninja --version'.split(), stdout=devnull)
-        except OSError:
-            return False
-        else:
-            return True
+    try:
+        subprocess.check_output('ninja --version'.split())
+    except:
+        return False
+    else:
+        return True
 
 
 def verify_ninja_availability():

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1407,7 +1407,7 @@ def is_ninja_available():
     '''
     try:
         subprocess.check_output('ninja --version'.split())
-    except:
+    except Exception:
         return False
     else:
         return True


### PR DESCRIPTION
tldr: current version of `is_ninja_available` of `torch/utils/cpp_extension.py` fails to run in the recent incarnations of pip w/ new build isolation feature which is now a default. This PR fixes this problem.

The full story follows:

--------------------------

Currently trying to build https://github.com/facebookresearch/fairscale/ which builds cuda extensions fails with the recent pip versions. The build is failing to perform `is_ninja_available`, which runs a simple subprocess to run `ninja --version` but does it with some /dev/null stream override which seems to break with the new pip versions. Currently I have `pip==20.3.3`. The recent pip performs build isolation which first fetches all dependencies to somewhere under /tmp/pip-install-xyz and then builds the package.

If I build:

```
pip install fairscale --no-build-isolation
```
everything works.

When building normally (i.e. without `--no-build-isolation`), the failure is a long long trace, 
<details>
<summary>Full log</summary>
<pre>
pip install fairscale
Collecting fairscale
  Downloading fairscale-0.1.1.tar.gz (83 kB)
     |████████████████████████████████| 83 kB 562 kB/s 
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  ERROR: Command errored out with exit status 1:
   command: /home/stas/anaconda3/envs/main-38/bin/python /home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpjvw00c7v                                                                                                                            
       cwd: /tmp/pip-install-1wq9f8fp/fairscale_347f218384a64f24b8d5ce846641213e                                                                                 
  Complete output (55 lines):                                                                                                                                    
  running egg_info                                                                                                                                               
  writing fairscale.egg-info/PKG-INFO                                                                                                                            
  writing dependency_links to fairscale.egg-info/dependency_links.txt                                                                                            
  writing requirements to fairscale.egg-info/requires.txt                                                                                                        
  writing top-level names to fairscale.egg-info/top_level.txt                                                                                                    
  Traceback (most recent call last):                                                                                                                             
    File "/home/stas/anaconda3/envs/main-38/bin/ninja", line 5, in <module>                                                                                      
      from ninja import ninja                                                                                                                                    
  ModuleNotFoundError: No module named 'ninja'                                                                                                                   
  Traceback (most recent call last):                                                                                                                             
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>                                
      main()                                                                                                                                                     
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main                                    
      json_out['return_val'] = hook(**hook_input['kwargs'])                                                                                                      
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel            
      return hook(config_settings)                                                                                                                               
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 149, in get_requires_for_build_wheel                   
      return self._get_build_requires(                                                                                                                           
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 130, in _get_build_requires                            
      self.run_setup()                                                                                                                                           
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 145, in run_setup                                      
      exec(compile(code, __file__, 'exec'), locals())                                                                                                            
    File "setup.py", line 56, in <module>                                                                                                                        
      setuptools.setup(                                                                                                                                          
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup                                            
      return distutils.core.setup(**attrs)                                                                                                                       
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/core.py", line 148, in setup                                                                 
      dist.run_commands()                                                                                                                                        
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/dist.py", line 966, in run_commands                                                          
      self.run_command(cmd)                                                                                                                                      
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/dist.py", line 985, in run_command                                                           
      cmd_obj.run()                                                                                                                                              
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 298, in run                                      
      self.find_sources()                                                                                                                                        
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 305, in find_sources                             
      mm.run()                                                                                                                                                   
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 536, in run                                      
      self.add_defaults()                                                                                                                                        
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 572, in add_defaults                             
      sdist.add_defaults(self)                                                                                                                                   
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/command/sdist.py", line 228, in add_defaults                                                 
      self._add_defaults_ext()                                                                                                                                   
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/command/sdist.py", line 311, in _add_defaults_ext                                            
      build_ext = self.get_finalized_command('build_ext')                                                                                                        
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/cmd.py", line 298, in get_finalized_command                                                  
      cmd_obj = self.distribution.get_command_obj(command, create)                                                                                               
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/dist.py", line 858, in get_command_obj                                                       
      cmd_obj = self.command_obj[command] = klass(self)                                                                                                          
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 351, in __init__                                   
      if not is_ninja_available():                                                                                                                               
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 1310, in is_ninja_available                        
      subprocess.check_call('ninja --version'.split(), stdout=devnull)                                                                                           
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/subprocess.py", line 364, in check_call                                                                
      raise CalledProcessError(retcode, cmd)                                                                                                                     
  subprocess.CalledProcessError: Command '['ninja', '--version']' returned non-zero exit status 1.                                                               
  ----------------------------------------                                                                                                                       
ERROR: Command errored out with exit status 1: /home/stas/anaconda3/envs/main-38/bin/python /home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpjvw00c7v Check the logs for full command output.
</pre>

</details>

and the middle of it is what we want:

```
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 351, in __init__                                   
      if not is_ninja_available():                                                                                                                               
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 1310, in is_ninja_available                        
      subprocess.check_call('ninja --version'.split(), stdout=devnull)                                                                                           
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/subprocess.py", line 364, in check_call                                                                
      raise CalledProcessError(retcode, cmd)                                                                                                                     
  subprocess.CalledProcessError: Command '['ninja', '--version']' returned non-zero exit status 1. 
```

For some reason pytorch fails to run this simple code:

```
# torch/utils/cpp_extension.py
def is_ninja_available():
    r'''
    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
    available on the system, ``False`` otherwise.
    '''
    with open(os.devnull, 'wb') as devnull:
        try:
            subprocess.check_call('ninja --version'.split(), stdout=devnull)
        except OSError:
            return False
        else:
            return True
```

I suspect that pip does something to `os.devnull` and that's why it fails.

This PR proposes a simpler code which doesn't rely on anything but `subprocess.check_output`:

```
def is_ninja_available():
    r'''
    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
    available on the system, ``False`` otherwise.
    '''
    try:
        subprocess.check_output('ninja --version'.split())
    except Exception:
        return False
    else:
        return True 
```

which doesn't use `os.devnull` and performs the same function. There could be a whole bunch of different exceptions there I think, so I went for the generic one - we don't care why it failed, since this function's only purpose is to suggest whether ninja can be used or not.

Let's check 

```
python -c "import torch.utils.cpp_extension; print(torch.utils.cpp_extension.is_ninja_available())"
True
```

Look ma - no std noise to take care of. (i.e. no need for /dev/null).

I was editing the  installed environment-wide `cpp_extension.py` file directly, so didn't need to tweak `PYTHONPATH` - I made sure to replace `'ninja --version'.` with something that should fail and I did get `False` for the above command line.

I next did a somewhat elaborate cheat to re-package an already existing binary wheel with this corrected version of `cpp_extension.py`, rather than building from source:
```
mkdir /tmp/pytorch-local-channel
cd /tmp/pytorch-local-channel

# get the latest nightly wheel
wget https://download.pytorch.org/whl/nightly/cu110/torch-1.8.0.dev20201215%2Bcu110-cp38-cp38-linux_x86_64.whl

# unpack it
unzip torch-1.8.0.dev20201215+cu110-cp38-cp38-linux_x86_64.whl

# edit torch/utils/cpp_extension.py to fix the python code with the new version as in this PR
emacs torch/utils/cpp_extension.py &

# pack the files back
zip -r torch-1.8.0.dev20201215+cu110-cp38-cp38-linux_x86_64.whl caffe2 torch torch-1.8.0.dev20201215+cu110.dist-info
```

Now I tell pip to use my local channel, plus `--pre` for it to pick up the pre-release as an acceptable wheel
```
# install using this local channel
git clone https://github.com/facebookresearch/fairscale/
cd fairscale
pip install -v --disable-pip-version-check -e . -f file:///tmp/pytorch-local-channel --pre
```
and voila all works.

```
[...]
Successfully installed fairscale
```

I noticed a whole bunch of ninja not found errors in the log, which I think is the same problem with other parts of the build system packages which also use this old check copied all over various projects and build tools, and which the recent pip breaks.

```
    writing manifest file '/tmp/pip-modern-metadata-_nsdesbq/fairscale.egg-info/SOURCES.txt'
    Traceback (most recent call last):
      File "/home/stas/anaconda3/envs/main-38/bin/ninja", line 5, in <module>
        from ninja import ninja
    ModuleNotFoundError: No module named 'ninja'
    [...]
    /tmp/pip-build-env-fqflyevr/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py:364: UserWarning: Attempted to use ninja as the BuildExtension backend but we could not find ninja.. Falling back to using the slow distutils backend.
      warnings.warn(msg.format('we could not find ninja.'))
```

but these don't prevent from the build completing and installing.

I suppose these need to be identified and reported to various other projects, but that's another story.

The new pip does something to `os.devnull` I think which breaks any code relying on it - I haven't tried to figure out what happens to that stream object, but this PR which removes its usage solves the problem.

Also do notice that:

```
git clone https://github.com/facebookresearch/fairscale/
cd fairscale
python setup.py bdist_wheel
pip install dist/fairscale-0.1.1-cp38-cp38-linux_x86_64.whl
```
works too. So it is really a pip issue.

Apologies if the notes are too many, I tried to give the complete picture and probably other projects will need those details as well.

Thank you for reading.