### PR TITLE
[StaticRuntime] Permute_out

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -32,7 +32,6 @@ bool canRunNatively(Node* n) {
   const static std::unordered_set<std::string> native_nodes{
       "aten::flatten",
       "aten::narrow",
-      "aten::permute",
       "aten::reshape",
       "aten::slice",
       "aten::transpose",


### PR DESCRIPTION
Summary: Adding an out variant for `permute`. It's better than fixing the copy inside contiguous because 1) we can leverage the c2 math library, 2) contiguous creates a tensor inside the function which isn't managed by the MemoryPlanner in StaticRuntime

Test Plan:
Benchmark:
```
After:
I1214 12:35:32.218775 991920 PyTorchPredictorBenchLib.cpp:209] PyTorch run finished. Milliseconds per iter: 0.0902339. Iters per second: 11082.3

Before:
I1214 12:35:43.368770 992620 PyTorchPredictorBenchLib.cpp:209] PyTorch run finished. Milliseconds per iter: 0.0961521. Iters per second: 10400.2
```

Differential Revision: D25541666

