### PR TITLE
[WIP] Correct tracing for torch.numel()

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -982,7 +982,6 @@ Tensor new_empty_strided_batching_rule(
   return physical_view.newLogicalFromPhysical(result);
 }
 
-
 TORCH_LIBRARY_IMPL(_, Batched, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&batchedTensorForLoopFallback>());
 }
@@ -993,6 +992,7 @@ TORCH_LIBRARY_IMPL(aten, Batched, m) {
   // Tensor wrapper, it only has one dispatch key (Batched) on it. The resolution
   // here is to just directly call the underlying implementation.
   m.impl("size.int", static_cast<int64_t (*)(const Tensor&, int64_t)>(native::size));
+  m.impl("numel.int", numel);
   m.impl("_add_batch_dim", native::_add_batch_dim);
   m.impl("_remove_batch_dim", native::_remove_batch_dim);
 

--- a/aten/src/ATen/core/NamedRegistrations.cpp
+++ b/aten/src/ATen/core/NamedRegistrations.cpp
@@ -420,6 +420,7 @@ TORCH_LIBRARY_IMPL(aten, Named, m) {
   m.impl("sinh_", CppFunction::makeFallthrough());
   m.impl("size.Dimname", CppFunction::makeFallthrough());
   m.impl("size.int", CppFunction::makeFallthrough());
+  m.impl("numel.int", CppFunction::makeFallthrough());
   m.impl("slice.Tensor", CppFunction::makeFallthrough());
   m.impl("softmax.Dimname", CppFunction::makeFallthrough());
   m.impl("softmax.int", CppFunction::makeFallthrough());

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3758,6 +3758,12 @@
   device_guard: False
   manual_cpp_binding: True
 
+- func: numel.int(Tensor self) -> Tensor
+  use_c10_dispatcher: full
+  variants: function, method
+  device_guard: False
+  manual_cpp_binding: True
+
 - func: size.Dimname(Tensor self, Dimname dim) -> int
   use_c10_dispatcher: full
   variants: function, method

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -84,6 +84,16 @@ class TestTracer(JitTestCase):
 
         self.checkTrace(f, (x, y))
 
+    def test_trace_torch_numel(self):
+
+        def avg(x):
+            return x.sum()/x.numel()
+
+        traced_avg = torch.jit.trace(avg, torch.empty(2,4,5))
+        inp = torch.ones(2,3,5)
+        print(traced_avg.code)
+        self.assertEqual(traced_avg(inp), avg(inp))
+
     def test_trace_checking_with_global_name(self):
         class MyClass(torch.nn.Module):
             def __init__(self):

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -519,7 +519,7 @@ static PyMethodDef torch_functions[] = {
   {"spmm", castPyCFunctionWithKeywords(THPVariable_mm), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"tensor", castPyCFunctionWithKeywords(THPVariable_tensor), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"get_device", castPyCFunctionWithKeywords(THPVariable_get_device), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
-  {"numel", castPyCFunctionWithKeywords(THPVariable_numel), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
+  //{"numel", castPyCFunctionWithKeywords(THPVariable_numel), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   ${py_method_defs}
   {NULL}
 };
@@ -618,24 +618,24 @@ static PyObject * THPVariable_nonzero(PyObject* self, PyObject* args, PyObject* 
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPVariable_numel(PyObject* self_, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "numel(Tensor input)",
-  }, /*traceable=*/false);
+// static PyObject * THPVariable_numel(PyObject* self_, PyObject* args, PyObject* kwargs)
+// {
+//   HANDLE_TH_ERRORS
+//   static PythonArgParser parser({
+//     "numel(Tensor input)",
+//   }, /*traceable=*/false);
 
-  ParsedArgs<1> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
+//   ParsedArgs<1> parsed_args;
+//   auto r = parser.parse(args, kwargs, parsed_args);
 
-  if(r.has_torch_function()){
-    return handle_torch_function(r, args, kwargs, THPVariableFunctionsModule, "torch");
-  }
+//   if(r.has_torch_function()){
+//     return handle_torch_function(r, args, kwargs, THPVariableFunctionsModule, "torch");
+//   }
 
-  if (r.idx == 0) {
-    return wrap(r.tensor(0).numel());
-  }
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
+//   if (r.idx == 0) {
+//     return wrap(r.tensor(0).numel());
+//   }
+//   Py_RETURN_NONE;
+//   END_HANDLE_TH_ERRORS
+// }
 }} // namespace torch::autograd

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -215,16 +215,16 @@ static PyObject * THPVariable_dim(PyObject* self, PyObject* args)
 }
 
 // implemented on the python object to avoid dispatch overhead
-static PyObject * THPVariable_numel(PyObject* self, PyObject* args)
-{
-   HANDLE_TH_ERRORS
-   if (check_has_torch_function(self)) {
-     return handle_torch_function(self, "numel", args);
-   }
-   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-   return THPUtils_packInt64(self_.numel());
-   END_HANDLE_TH_ERRORS
-}
+// static PyObject * THPVariable_numel(PyObject* self, PyObject* args)
+// {
+//    HANDLE_TH_ERRORS
+//    if (check_has_torch_function(self)) {
+//      return handle_torch_function(self, "numel", args);
+//    }
+//    auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+//    return THPUtils_packInt64(self_.numel());
+//    END_HANDLE_TH_ERRORS
+// }
 
 static Tensor dispatch_contiguous(const Tensor & self, at::MemoryFormat memory_format) {
   pybind11::gil_scoped_release no_gil;
@@ -1172,7 +1172,7 @@ PyMethodDef variable_methods[] = {
   {"new_ones", castPyCFunctionWithKeywords(THPVariable_new_ones), METH_VARARGS | METH_KEYWORDS, NULL},
   {"new_tensor", castPyCFunctionWithKeywords(THPVariable_new_tensor), METH_VARARGS | METH_KEYWORDS, NULL},
   {"nonzero", castPyCFunctionWithKeywords(THPVariable_nonzero), METH_VARARGS | METH_KEYWORDS, NULL},
-  {"numel", THPVariable_numel, METH_NOARGS, NULL},
+  //{"numel", THPVariable_numel, METH_NOARGS, NULL},
   {"numpy", THPVariable_numpy, METH_NOARGS, NULL},
   {"requires_grad_", castPyCFunctionWithKeywords(THPVariable_requires_grad_), METH_VARARGS | METH_KEYWORDS, NULL},
   {"set_", castPyCFunctionWithKeywords(THPVariable_set_), METH_VARARGS | METH_KEYWORDS, NULL},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49466 Correct tracing for torch.numel()**

Summary: Currently, torch.numel() is traced as constant no matter the input. This showed up as an issue at https://github.com/pytorch/pytorch/issues/49372

Test Plan: test case in test_tracer.py

Reviewers:

Subscribers:

Tasks:

Tags: