### PR TITLE
Set is_non_overlapping_and_dense_ flag in OpaqueTensorImpl constructor

### DIFF
--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -24,12 +24,13 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       const caffe2::TypeMeta data_type,
       c10::Device device,
       OpaqueHandle opaque_handle,
-      c10::IntArrayRef sizes)
+      c10::IntArrayRef sizes,
+      bool is_non_overlapping_and_dense = true)
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
     sizes_ = sizes.vec();
     refresh_numel();
-    is_non_overlapping_and_dense_ = false;
+    is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
   }
 
   void release_resources() override {

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -24,11 +24,13 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       const caffe2::TypeMeta data_type,
       c10::Device device,
       OpaqueHandle opaque_handle,
-      c10::IntArrayRef sizes)
+      c10::IntArrayRef sizes,
+      bool is_non_overlapping_and_dense=true)
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
     sizes_ = sizes.vec();
     refresh_numel();
+    is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
   }
 
   void release_resources() override {

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -24,13 +24,12 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       const caffe2::TypeMeta data_type,
       c10::Device device,
       OpaqueHandle opaque_handle,
-      c10::IntArrayRef sizes,
-      bool is_non_overlapping_and_dense=true)
+      c10::IntArrayRef sizes)
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
     sizes_ = sizes.vec();
     refresh_numel();
-    is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
+    refresh_contiguous();
   }
 
   void release_resources() override {

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -24,13 +24,12 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       const caffe2::TypeMeta data_type,
       c10::Device device,
       OpaqueHandle opaque_handle,
-      c10::IntArrayRef sizes,
-      bool is_non_overlapping_and_dense=true)
+      c10::IntArrayRef sizes)
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
     sizes_ = sizes.vec();
     refresh_numel();
-    is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
+    is_non_overlapping_and_dense_ = false;
   }
 
   void release_resources() override {

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -24,12 +24,13 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       const caffe2::TypeMeta data_type,
       c10::Device device,
       OpaqueHandle opaque_handle,
-      c10::IntArrayRef sizes)
+      c10::IntArrayRef sizes,
+      bool is_non_overlapping_and_dense=true)
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
     sizes_ = sizes.vec();
     refresh_numel();
-    refresh_contiguous();
+    is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
   }
 
   void release_resources() override {

--- a/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
+++ b/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
@@ -21,7 +21,8 @@ struct VulkanOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
             data_type,
             device,
             opaque_handle,
-            sizes),
+            sizes,
+            false),
         strides_(strides.vec()) {}
 
   IntArrayRef strides() const override {

--- a/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
+++ b/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
@@ -21,8 +21,7 @@ struct VulkanOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
             data_type,
             device,
             opaque_handle,
-            sizes,
-            false),
+            sizes),
         strides_(strides.vec()) {}
 
   IntArrayRef strides() const override {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49470 Set is_non_overlapping_and_dense_ flag in OpaqueTensorImpl constructor**

https://github.com/pytorch/pytorch/pull/48625 changes the default contiguous settings for `TensorImpl` causing the Vulkan backend to crash. Therefore, add argument that can set `is_non_overlapping_and_dense_` back to false for `OpaqueTensorImpl` constructor.

Differential Revision: [D25592826](https://our.internmc.facebook.com/intern/diff/D25592826)