### PR TITLE
Refactor VmapPhysicalView::newLogicalToPhysical

### DIFF
--- a/aten/src/ATen/BatchedFallback.cpp
+++ b/aten/src/ATen/BatchedFallback.cpp
@@ -361,7 +361,7 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
         flat_output.sizes().end());
     torch::jit::push(
         stack,
-        input_physical_views.front().newLogicalFromPhysical(flat_output.view(output_sizes)));
+        input_physical_views.front().getPhysicalToLogicalMap().apply(flat_output.view(output_sizes)));
   }
 }
 

--- a/aten/src/ATen/test/vmap_test.cpp
+++ b/aten/src/ATen/test/vmap_test.cpp
@@ -297,7 +297,7 @@ TEST(VmapTest, TestVmapPhysicalViewNewLogicalFromPhysical) {
     VmapPhysicalView physical_view(ones({2, 3, 4}), /*levels = {2}*/4);
     Tensor physical = ones({2, 6, 7});
 
-    auto result = physical_view.newLogicalFromPhysical(physical);
+    auto result = physical_view.getPhysicalToLogicalMap().apply(physical);
     auto* batched = maybeGetBatchedImpl(result);
     ASSERT_TRUE(batched != nullptr);
     ASSERT_TRUE(batched->value().is_same(physical));
@@ -308,7 +308,7 @@ TEST(VmapTest, TestVmapPhysicalViewNewLogicalFromPhysical) {
     VmapPhysicalView physical_view(ones({2, 3, 4, 5, 6}), /*levels = {1, 3, 4}*/2 | 8 | 16);
     Tensor physical = ones({2, 3, 4, 7});
 
-    auto result = physical_view.newLogicalFromPhysical(physical);
+    auto result = physical_view.getPhysicalToLogicalMap().apply(physical);
     auto* batched = maybeGetBatchedImpl(result);
     ASSERT_TRUE(batched != nullptr);
     ASSERT_TRUE(batched->value().is_same(physical));
@@ -319,7 +319,7 @@ TEST(VmapTest, TestVmapPhysicalViewNewLogicalFromPhysical) {
     VmapPhysicalView physical_view(ones({2}), /*levels = {2}*/4);
     Tensor physical = ones({2});
 
-    auto result = physical_view.newLogicalFromPhysical(physical);
+    auto result = physical_view.getPhysicalToLogicalMap().apply(physical);
     auto* batched = maybeGetBatchedImpl(result);
     ASSERT_TRUE(batched != nullptr);
     ASSERT_TRUE(batched->value().is_same(physical));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49482 Refactor VmapPhysicalView::newLogicalToPhysical**

Motivation
==========
Batching rules always invoke newLogicalToPhysical at the very end to turn
a physical tensor into a logical BatchedTensor (an example is below):
```
Tensor select_backward_batching_rule(const Tensor& grad, IntArrayRef input_sizes, int64_t dim, int64_t index) {
  auto grad_physical = MultiBatchVmapTransform::logicalToPhysical(grad);
  auto grad_input = at::zeros(grad_physical.getPhysicalShape(input_sizes), grad.options());
  auto physical_dim = getGradInputPhysicalDim(dim, input_sizes, grad_physical.numBatchDims());
  grad_input.select(physical_dim, index).copy_(grad_physical.tensor());
  return grad_physical.newLogicalFromPhysical(grad_input);
}
```
However, @albanD noted that this function is confusing and ambiguous
because it's unclear which physical tensor is being turned into the logical
(in this case, grad_physical is a VmapPhysicalView, but we're really transforming
grad_input and returning it).
https://github.com/pytorch/pytorch/pull/44505#discussion_r487144018

I didn't want to make too many changes to the batching rule API because
I think we'll change it even more in the future, but this PR attempts to
remove the ambiguity by applying one of the suggestions in
https://github.com/pytorch/pytorch/pull/44505#discussion_r487144018

This PR
=======

The diagnosis of the problem is that we were conflating
"VmapPhysicalView", which maps logical attributes on a Tensor (like
dimension and shape) to physical attributes, with the reverse
physical-to-logical map. This PR creates a new VmapPhysicalToLogicalMap
object that handles the latter.

Instead of calling `grad_physical.newLogicalFromPhysical(grad_input)`,
an author of batching rules should now retrieve the VmapPhysicalToLogicalMap
object and apply it to their physical input. So the above code becomes:
```
grad_physical.getPhysicalToLogicalMap().apply(grad_input)
```

I've also moved VmapPhysicalView::makeLogicalFromPhysicalListInplace
to VmapPhysicalToLogicalMap::applyInplace.

Test Plan
=========
wait for tests

Differential Revision: [D25592645](https://our.internmc.facebook.com/intern/diff/D25592645)