### PR TITLE
[NNC] Dont inline outputs buffers  on cpu

### DIFF
--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1635,19 +1635,19 @@ class TestTensorExprFuser(BaseTestClass):
             # A bug reported internally similar to the one reported in #48533
             def foo(a, b, c):
                 t_next = c + 1
-                t5 = torch.log(t_next * b)
-                return (t5, torch.relu(t5), torch.log1p(t5))
+                t5 = t_next * b
+                t6 = torch.unsqueeze(t_next, 1)
+                t7 = a * t6
+                return (t7, t5, t_next)
 
             a = torch.rand(20, 20, dtype=torch.float32, device=device)
-            b = torch.rand(20, 20, dtype=torch.float32, device=device)
+            b = torch.rand(20 * 29, dtype=torch.float32, device=device).as_strided([20], [29])
             c = torch.ones(20, dtype=torch.int64, device=device)
             traced = torch.jit.trace(foo, (a, b, c))
             ref = foo(a, b, c)
             exp = traced(a, b, c)
             exp = traced(a, b, c)
-            for i in range(3):
-                assert(torch.allclose(ref[i], exp[i]))
-
+            self.assertEqual(ref, exp)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -26,6 +26,8 @@ class BaseTestClass(JitTestCase):
         self.old_fusion_inlining = torch._C._debug_get_fusion_group_inlining()
         torch._C._debug_set_fusion_group_inlining(False)
 
+        self.devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
+
     def tearDown(self):
         torch._C._jit_set_profiling_executor(self.old_profiling_executor)
         torch._C._jit_set_profiling_mode(self.old_profiling_mode)
@@ -1628,25 +1630,23 @@ class TestTensorExprFuser(BaseTestClass):
 
         torch.testing.assert_allclose(ref, test)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     def test_multiple_outputs(self):
-        # A bug reported internally similar to the one reported in #48533
-        def foo(a, b, c):
-            t_next = c + 1
-            t5 = t_next * b
-            t6 = torch.unsqueeze(t_next, 1)
-            t7 = a * t6
-            return (t7, t5, t_next)
+        for device in self.devices:
+            # A bug reported internally similar to the one reported in #48533
+            def foo(a, b, c):
+                t_next = c + 1
+                t5 = torch.log(t_next * b)
+                return (t5, torch.relu(t5), torch.log1p(t5))
 
-        a = torch.rand(20, 20, dtype=torch.float32, device='cuda')
-        b = torch.rand(20 * 29, dtype=torch.float32, device='cuda').as_strided([20], [29])
-        c = torch.ones(20, dtype=torch.int64, device='cuda')
-        traced = torch.jit.trace(foo, (a, b, c))
-        ref = foo(a, b, c)
-        exp = traced(a, b, c)
-        exp = traced(a, b, c)
-        for i in range(3):
-            assert(torch.allclose(ref[i], exp[i]))
+            a = torch.rand(20, 20, dtype=torch.float32, device=device)
+            b = torch.rand(20, 20, dtype=torch.float32, device=device)
+            c = torch.ones(20, dtype=torch.int64, device=device)
+            traced = torch.jit.trace(foo, (a, b, c))
+            ref = foo(a, b, c)
+            exp = traced(a, b, c)
+            exp = traced(a, b, c)
+            for i in range(3):
+                assert(torch.allclose(ref[i], exp[i]))
 
 
 if __name__ == '__main__':

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1489,7 +1489,11 @@ Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
 
   bool hasReduction = NodeFinder<ReduceOp>::find(l.root_stmt()).size() != 0;
 
-  l.inlineIntermediateBufs();
+  // inlining output buffers duplicates computation. it slows down
+  // cpu code generation but is enabled on gpu because it avoids difficult
+  // synchronization logic across blocks.
+  bool inline_output_buffers = backendType == kCudaCodeGen;
+  l.inlineIntermediateBufs(inline_output_buffers);
 
   if (backendType == kCudaCodeGen) {
     for (auto tensor : tensorOutputs_) {

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -53,7 +53,7 @@ class TORCH_API LoopNest {
 
   bool computeInline(Stmt* s);
   bool computeInline(const Buf* b);
-  void inlineIntermediateBufs();
+  void inlineIntermediateBufs(bool inline_output_buffers);
 
   static void splitWithTail(For* f, int factor);
   static void splitWithTail(


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/48967/ we enabled output buffer inlining,  which results in duplicate computation if one output depends on another. This was done to fix correctness for CUDA, but is not needed for correctness for CPU and results in  perf slowdown.

The output buffer inlining solution for CUDA is intended to be an interim solution because it does not work with reductions.  