### PR TITLE
Prevent accidentally writing old style ops

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -480,9 +480,9 @@ c10::impl::hacky_wrapper_for_legacy_signatures<
 
         if f.func.is_out_fn():
             assert local.use_c10_dispatcher().dispatcher_uses_new_style(), \
-                ("{} takes out arguments and has to be written in the new style. " + \
-                "Please add `use_c10_dispatcher: full` to your operator in native_functions.yaml " + \
-                "and write the C++ implementation to take out arguments in the end.").format(f.func.name)
+                ("{} takes out arguments and has to be written in the new style. " +
+                 "Please add `use_c10_dispatcher: full` to your operator in native_functions.yaml " +
+                 "and write the C++ implementation to take out arguments in the end.").format(f.func.name)
 
         if self.dispatch_key not in f.dispatch:
             return None

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -478,6 +478,12 @@ c10::impl::hacky_wrapper_for_legacy_signatures<
         # for mypy type refinement; would be fixed by TODO on target
         assert self.target is not Target.DECLARATION
 
+        if f.func.is_out_fn():
+            assert local.use_c10_dispatcher().dispatcher_uses_new_style(), \
+                ("{} takes out arguments and has to be written in the new style. " + \
+                "Please add `use_c10_dispatcher: full` to your operator in native_functions.yaml " + \
+                "and write the C++ implementation to take out arguments in the end.").format(f.func.name)
+
         if self.dispatch_key not in f.dispatch:
             return None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49510 Prevent accidentally writing old style ops**

Adding old style operators with out arguments will break XLA. This prevents that. See for background: https://fb.workplace.com/groups/pytorch.dev/permalink/809934446251704/

This is a temporary change that will prevent this breakage for the next couple of days until the problem is resolved for good.
It will be deleted in https://github.com/pytorch/pytorch/pull/49164 then.

Differential Revision: [D25599112](https://our.internmc.facebook.com/intern/diff/D25599112/)