### PR TITLE
[FX] Enforce args is tuple and kwargs is dict

### DIFF
--- a/torch/fx/experimental/subgraph_creation_example.py
+++ b/torch/fx/experimental/subgraph_creation_example.py
@@ -161,7 +161,7 @@ def split_module(
 
         # Emit call in base graph to this submodule
 
-        output_val = base_mod_graph.call_module(submod_name, [base_mod_env[name] for name in partition.inputs])  # type: ignore
+        output_val = base_mod_graph.call_module(submod_name, tuple(base_mod_env[name] for name in partition.inputs))  # type: ignore
         if len(partition.outputs) > 1:
             # Unpack multiple return values from submodule
             output_val_proxy = torch.fx.proxy.Proxy(output_val)  # type: ignore

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -247,6 +247,8 @@ class Graph:
         assert op in ('call_function', 'call_method', 'get_attr', 'call_module', 'placeholder', 'output')
         args = () if args is None else args
         kwargs = {} if kwargs is None else kwargs
+        assert isinstance(args, tuple), "args must be a tuple"
+        assert isinstance(kwargs, dict), "kwargs must be a dict"
         unique_name = self._create_unique_name(name if name is not None else self._target_to_str(target))
         n = Node(self, unique_name, op, target, args, kwargs, type_expr)
         self._insert(n)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49526 [FX] Enforce args is tuple and kwargs is dict**

Tons of people were passing in the wrong types for these for some reason, so enforce this at runtime. This also brings up the question of type checking coverage. I think internal stuff may not be running any type checking

Differential Revision: [D25606115](https://our.internmc.facebook.com/intern/diff/D25606115)