### PR TITLE
Revert "[PyTorch] Make tls_local_dispatch_key_set inlineable (reapply) (#49412)"

### DIFF
--- a/c10/core/impl/LocalDispatchKeySet.cpp
+++ b/c10/core/impl/LocalDispatchKeySet.cpp
@@ -5,6 +5,10 @@
 namespace c10 {
 namespace impl {
 
+C10_DEFINE_bool(disable_variable_dispatch, false, "This flag forcibly disables the Variable code paths from executing, which currently breaks profiling in the process.");
+
+namespace {
+
 /// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
 /// thread_local is not supported.
 #ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
@@ -14,15 +18,25 @@ thread_local PODLocalDispatchKeySet raw_local_dispatch_key_set;
 
 #else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
 
-PODLocalDispatchKeySet raw_local_dispatch_key_set;
+static PODLocalDispatchKeySet raw_local_dispatch_key_set;
 
 #endif
 
-#ifdef _MSC_VER
+} // anonymous namespace
+
 LocalDispatchKeySet tls_local_dispatch_key_set() {
+  // Hack until variable performance is fixed
+  //
+  // ezyang: I'm pretty unhappy about this implementation, it looks wrong
+  // to me, as it seems to be performing a mutation on
+  // raw_local_dispatch_key_set.  I can't conveniently test the correct
+  // version though...
+  if (FLAGS_disable_variable_dispatch) {
+    raw_local_dispatch_key_set.set_excluded(
+      raw_local_dispatch_key_set.excluded() | autograd_dispatch_keyset);
+  }
   return raw_local_dispatch_key_set;
 }
-#endif // _MSC_VER
 
 void _force_tls_local_dispatch_key_set(LocalDispatchKeySet key_set) {
   raw_local_dispatch_key_set = PODLocalDispatchKeySet {

--- a/c10/core/impl/LocalDispatchKeySet.h
+++ b/c10/core/impl/LocalDispatchKeySet.h
@@ -23,6 +23,8 @@
 namespace c10 {
 namespace impl {
 
+C10_DECLARE_bool(disable_variable_dispatch);
+
 // POD version of LocalDispatchKeySet.  Declared here just so that
 // we can put it in the guards.
 struct C10_API PODLocalDispatchKeySet {
@@ -52,24 +54,7 @@ struct C10_API LocalDispatchKeySet {
   DispatchKeySet excluded_;
 };
 
-// thread_local variables cannot be C10_API on Windows.
-#ifdef _MSC_VER
 C10_API LocalDispatchKeySet tls_local_dispatch_key_set();
-#else // _MSC_VER
-/// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
-/// thread_local is not supported.
-#ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
-  extern C10_API thread_local PODLocalDispatchKeySet raw_local_dispatch_key_set;
-#else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
-  extern C10_API PODLocalDispatchKeySet raw_local_dispatch_key_set;
-#endif
-
-inline C10_API LocalDispatchKeySet tls_local_dispatch_key_set() {
-  // Don't let people fiddle with the thread_local directly just
-  // because they include this header.
-  return raw_local_dispatch_key_set;
-}
-#endif // _MSC_VER
 
 // Internal, use ThreadLocalStateGuard
 C10_API void _force_tls_local_dispatch_key_set(LocalDispatchKeySet key_set);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49548 Revert "[PyTorch] Make tls_local_dispatch_key_set inlineable (reapply) (#49412)"**

This reverts commit 6f928a4a53f022c486df6416e73c69e2acfdd2de.