### PR TITLE
[NNC] Intermediate allocs flattened and dependency support

### DIFF
--- a/test/cpp/tensorexpr/test_reductions.cpp
+++ b/test/cpp/tensorexpr/test_reductions.cpp
@@ -1583,7 +1583,7 @@ TEST(Reductions, ReductionCacheBodyAccess) {
   oss << *result;
   const std::string& expected_ir =
       R"IR(
-#CHECK: Allocate(scale_local, float, {1, 32, 12});
+#CHECK: Allocate(scale_local, float, {384});
 #CHECK: for (int j = 0; j < 32; j++) {
 #CHECK:   for (int k = 0; k < 12; k++) {
 #CHECK:     scale_local[k + 12 * j] = scale[(k + 384 * l1) + 12 * j];

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -881,7 +881,12 @@ Stmt* LoopNest::insertAllocFree(Stmt* stmt) {
   // Insert allocations and frees for temporary buffers in the innermost
   // possible scope.
   for (const Buf* buf : intermediate_bufs_) {
-    Stmt* alloc = new Allocate(buf->base_handle(), buf->dtype(), buf->dims());
+    const Expr* flat_size = new IntImm(1);
+    for (auto& d : buf->dims()) {
+      flat_size = new Mul(flat_size, d);
+    }
+    flat_size = IRSimplifier::simplify(flat_size);
+    Stmt* alloc = new Allocate(buf->base_handle(), buf->dtype(), {flat_size});
     Stmt* free = new Free(buf->base_handle());
     Block* alloc_block = findLowestContainingBlock(uses.at(buf));
     alloc_block->prepend_stmt(alloc);

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -14,7 +14,16 @@ namespace jit {
 namespace tensorexpr {
 namespace analysis {
 
-enum class AccessType { Input, Output, Load, Store, Call, AtomicAdd };
+enum class AccessType {
+  Input,
+  Output,
+  Load,
+  Store,
+  Call,
+  AtomicAdd,
+  Alloc,
+  Free
+};
 const char* AccessToString(AccessType a);
 
 class AccessInfo;
@@ -255,18 +264,8 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
   void visit(const Block* v) override;
   void visit(const Let* v) override;
   void visit(const AtomicAdd* v) override;
-
-#define STMT_ON_STACK(Op)                    \
-  virtual void visit(const Op* v) override { \
-    const Stmt* last = lastStmt_;            \
-    lastStmt_ = v;                           \
-    IRVisitor::visit(v);                     \
-    lastStmt_ = last;                        \
-  }
-  STMT_ON_STACK(Allocate);
-  STMT_ON_STACK(Free);
-
-#undef STMT_ON_STACK
+  void visit(const Allocate* v) override;
+  void visit(const Free* v) override;
 
   using BoundRelationship = std::pair<IndexBounds, std::shared_ptr<AccessInfo>>;
 
@@ -377,6 +376,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
   // Maps for inputs and outputs, since they aren't present directly in the IR.
   std::unordered_map<const Buf*, std::shared_ptr<AccessInfo>> inputs_;
   std::unordered_map<const Buf*, std::shared_ptr<AccessInfo>> outputs_;
+  std::unordered_map<const Var*, std::shared_ptr<AccessInfo>> intermediates_;
 
   // Inserts accesses for Buf's: specifically for inputs and outputs.
   void insertBuffers(


### PR DESCRIPTION
Makes two changes in NNC for intermediate buffer allocations:
1. Flattens dimensions of buffers allocated in LoopNest::prepareForCodegen() to match their flattened usages.
2. Adds support for tracking memory dependencies of Alloc/Free to the MemDependencyChecker, which will allow us to check safety of accesses to intermediate buffers (coming in a future diff).

I didn't add any new tests as the mem dependency checker tests already cover it pretty well, particularly the GEMM test.