### PR TITLE
[FileStore] Updating Docs to Reflect FileStore changes

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -225,6 +225,7 @@ class StoreTestBase(object):
         fs.add("key3", 4)
         fs.add("key3", 5)
         fs.add("key3", 6)
+        self.assertEqual(fs.num_keys(), self.num_keys_total)
         self.assertEqual(b"6", fs.get("key"))
         self.assertEqual(b"value0", fs.get("key0"))
         self.assertEqual(b"value1", fs.get("key1"))
@@ -233,6 +234,14 @@ class StoreTestBase(object):
 
     def test_set_get(self):
         self._test_set_get(self._create_store())
+
+    # This is the number of keys used in test_set_get. Adding this as a class
+    # property instead of hardcoding in the test since some Store
+    # implementations will have differing number of keys. In the base case,
+    # there will be 5 keys: key, key0, key1, key2, key3.
+    @property
+    def num_keys_total(self):
+        return 5
 
 
 class FileStoreTest(TestCase, StoreTestBase):
@@ -296,6 +305,12 @@ class TCPStoreTest(TestCase, StoreTestBase):
             store1 = c10d.TCPStore(addr, port, 1, True)  # noqa: F841
             store2 = c10d.TCPStore(addr, port, 1, True)  # noqa: F841
 
+    # The TCPStore has 6 keys in test_set_get. It contains the 5 keys added by
+    # the user and one additional key used for coordinate all the workers.
+    @property
+    def num_keys_total(self):
+        return 6
+
     def _test_numkeys_delkeys(self, fs):
         # We start off with one init key in the store to coordinate workers
         self.assertEqual(fs.num_keys(), 1)
@@ -333,6 +348,13 @@ class PrefixTCPStoreTest(TestCase, StoreTestBase):
 
     def _create_store(self):
         return c10d.PrefixStore(self.prefix, self.tcpstore)
+
+    # The PrefixTCPStore has 6 keys in test_set_get. It contains the 5 keys
+    # added by the user and one additional key used for coordinate all the
+    # workers.
+    @property
+    def num_keys_total(self):
+        return 6
 
 
 class MyPythonStore(c10d.Store):

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -480,15 +480,14 @@ and :meth:`~torch.distributed.store.add` since one key is used to coordinate all
 the workers using the store.
 
 .. warning::
-    The ``num_keys`` API is only supported by the :class:`~torch.distributed.TCPStore` and :class:`~torch.distributed.HashStore`. Using this API
-    with the :class:`~torch.distributed.FileStore` will result in an exception.
+    When used with the :class:`~torch.distributed.TCPStore`, ``num_keys`` returns the number of keys written to the underlying file. If the store is destructed and another store is created with the same file, the original keys will be retained.
 
 Returns:
     The number of keys present in the store.
 
 Example::
     >>> import torch.distributed as dist
-    >>> # Using TCPStore as an example, HashStore can also be used
+    >>> # Using TCPStore as an example, other store types can also be used
     >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
     >>> store.set("first_key", "first_value")
     >>> # This should return 2

--- a/torch/lib/c10d/FileStore.cpp
+++ b/torch/lib/c10d/FileStore.cpp
@@ -355,7 +355,11 @@ int64_t FileStore::add(const std::string& key, int64_t value) {
 }
 
 int64_t FileStore::getNumKeys() {
-  TORCH_CHECK(false, "getNumKeys not implemented for FileStore");
+  std::unique_lock<std::mutex> l(activeFileOpLock_);
+  File file(path_, O_RDONLY, timeout_);
+  auto lock = file.lockShared();
+  pos_ = refresh(file, pos_, cache_);
+  return cache_.size();
 }
 
 bool FileStore::deleteKey(const std::string& /* unused */) {

--- a/torch/lib/c10d/test/FileStoreTest.cpp
+++ b/torch/lib/c10d/test/FileStoreTest.cpp
@@ -49,6 +49,8 @@ void testGetSet(std::string path, std::string prefix = "") {
     c10d::test::check(store, "key0", "value0");
     c10d::test::check(store, "key1", "value1");
     c10d::test::check(store, "key2", "value2");
+    auto numKeys = fileStore->getNumKeys();
+    EXPECT_EQ(numKeys, 3);
   }
 
   // Perform get on new instance
@@ -56,6 +58,10 @@ void testGetSet(std::string path, std::string prefix = "") {
     auto fileStore = c10::make_intrusive<c10d::FileStore>(path, 2);
     c10d::PrefixStore store(prefix, fileStore);
     c10d::test::check(store, "key0", "value0");
+    auto numKeys = fileStore->getNumKeys();
+    // There will be 4 keys since we still use the same underlying file as the
+    // other store above.
+    EXPECT_EQ(numKeys, 4);
   }
 }
 


### PR DESCRIPTION
Summary:
Updating the PyTorch docs to reflect that FileStore now supported the
num_keys API. Also included a note to describe the behavior of the API.

Test Plan: build and rendered docs.

Differential Revision: D25619000

