### PR TITLE
Cache vkBuffer and vkImage creations.

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -311,6 +311,7 @@ struct Resource final {
       std::unique_ptr<Policy> policy;
     } memory_;
 
+
     struct {
       std::vector<Handle<Buffer, void(*)(const Buffer&)>> pool;
     } buffer_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49112 Optimize Vulkan command buffer submission rate.
* **#49573 Cache vkBuffer and vkImage creations.**
* #49572 Remove incorrect usage of layout(std430) on uniform buffers, correctly now treated as error in the latest release of Vulkan SDK.

