### PR TITLE
Always checkout github.head_ref

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -14,16 +14,8 @@ jobs:
           architecture: x64
       - name: Fetch PyTorch
         uses: actions/checkout@v1
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
+        with:
+          ref: ${{ github.head_ref }}
       - name: Run clang-format
         run: |
           set -eu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@v1
+        with:
+          ref: ${{ github.head_ref }}
       - name: Ensure consistent CircleCI YAML config
         run: |
           pip install -r requirements.txt
@@ -62,16 +64,8 @@ jobs:
           architecture: x64
       - name: Fetch PyTorch
         uses: actions/checkout@v1
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
+        with:
+          ref: ${{ github.head_ref }}
       - name: Run flake8
         run: |
           set -eux
@@ -83,7 +77,7 @@ jobs:
         with:
           check_name: 'flake8-py3'
           linter_output_path: 'flake8-output.txt'
-          commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
+          commit_sha: ${{ github.head_ref }}
           regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorCode>\w\d+) (?<errorDesc>.*)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,16 +93,8 @@ jobs:
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@v1
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
+        with:
+          ref: ${{ github.head_ref }}
       - name: Install dependencies
         run: |
           set -eux
@@ -184,7 +170,7 @@ jobs:
         with:
           check_name: 'clang-tidy'
           linter_output_path: 'clang-tidy-output.txt'
-          commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
+          commit_sha: ${{ github.head_ref }}
           regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorDesc>.*?) \[(?<errorCode>.*)\]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -199,16 +185,8 @@ jobs:
           architecture: x64
       - name: Fetch PyTorch
         uses: actions/checkout@v1
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
+        with:
+          ref: ${{ github.head_ref }}
       - name: Run cmakelint
         run: |
           set -eux


### PR DESCRIPTION
This PR was prompted by a surprising divergence between two runs of the same `quick-checks` job:

- https://github.com/pytorch/pytorch/runs/1573529842 (failure in "Ensure no tabs")
  - `master` was https://github.com/pytorch/pytorch/commit/6db5e857269a5e68c59c7452c268bf4847d7aa29
- https://github.com/pytorch/pytorch/runs/1573634166 (success)
  - `master` was https://github.com/pytorch/pytorch/commit/ea4ccc730eba6063cd918cb37cbd9cf890c495d0

This was caused by [`actions/checkout@v1`](https://github.com/actions/checkout/tree/v1) merging into `master` by default, causing nondeterministic CI behavior regardless of the base of the current PR. All our other current jobs mitigate this issue by adding a "Checkout PR tip" step that checks out `${{ github.event.pull_request.head.sha }}` when on a PR, but that step was missing from the `quick-checks` job. This PR replaces all those additional steps with just a bit of extra configuration on the `actions/checkout@v1` step itself, which is shorter and less error-prone:
```yaml
with:
  ref: ${{ github.head_ref }}
```

Solution and discussion can be found here: https://github.com/actions/checkout/issues/27#issuecomment-535897113