### PR TITLE
fixed the first line of torch.rst to match the __init__.py file's first line

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -1,7 +1,7 @@
 torch
 =====
 The torch package contains data structures for multi-dimensional
-tensors and mathematical operations over these are defined.
+tensors and defines mathematical operations over these tensors.
 Additionally, it provides many utilities for efficient serializing of
 Tensors and arbitrary types, and other useful utilities.
 


### PR DESCRIPTION
Changed the first line of the torch.rst file to match that of the __init__.py file

Fixes #49228
