### PR TITLE
Remove deadlines for Caffe2 hypothesis_test when running on GPU.

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -18,6 +18,21 @@ from caffe2.proto import caffe2_pb2
 
 dyndep.InitOpsLibrary('@/caffe2/caffe2/fb/optimizers:sgd_simd_ops')
 
+if workspace.has_gpu_support:
+    # NOTE: During GPU stress tests, the number of workers exceeds the number
+    #       of GPUs which results in flakiness from GPU contention. As a
+    #       result, deadlines are not enforced on CUDA runs.
+    _hypothesis_settings = settings
+
+    def settings(**kwargs):
+        if 'deadline' in kwargs:
+            kwargs['deadline'] = None
+            kwargs.setdefault('max_examples', 50)
+
+        def wrapped(f):
+            return _hypothesis_settings(**kwargs)(f)
+        return wrapped
+
 
 def sigmoid(x):
     return 1.0 / (1.0 + np.exp(-x))


### PR DESCRIPTION
Summary:
A bunch of these tests are marked flaky, and have been since time immemorial. (Read: as far back as Buck will build.) However closer inspection reveals that they fail if and only if run on a GPU worker. What seems to be going on is that there are more jobs than GPUs, so the contention causes waits which registers as timeouts on the test.

This diff is kind of hacky, but it basically just drops deadlines if a GPU is present. Because Caffe2 is going away I'm not too terribly concerned about a beautiful solution, but we may as well keep some test coverage if it's easy.

CC Sebastian, Ilia, Min, and Hongzheng who also have tasks for what seems to be the same flakiness.

Test Plan: Turn the tests back on and see if they fall over. (The failure repros reliably on an OnDemand GPU and is fixed by this change, so it's not really just a hail Mary.)

Reviewed By: ngimel

Differential Revision: D25632981

