### PR TITLE
add binary_cross_entropy_with_logits op to ONNX opset version 12

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4855,17 +4855,18 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, input, target):
                 return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction='mean')
 
-        self.run_test(BCEWithLogitsLossNone(), input=(x, y))
+        self.run_test(BCEWithLogitsLossMean(), input=(x, y))
 
         class BCEWithLogitsLossSum(torch.nn.Module):
             def forward(self, input, target):
                 return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction='sum')
 
-        self.run_test(BCEWithLogitsLossNone(), input=(x, y))
+        self.run_test(BCEWithLogitsLossSum(), input=(x, y))
 
         class BCEWithLogitsLossWithWeights(torch.nn.Module):
             def forward(self, input, target, weight, pos_weight):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, pos_weight=pos_weight, reduction='sum')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, 
+                                                                            pos_weight=pos_weight, reduction='mean')
 
         self.run_test(BCEWithLogitsLossWithWeights(), input=(x, y, weight, pos_weight))
 

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -61,9 +61,9 @@ def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduc
     sub_1_y = sub(g, p, target)
     log_1_x = log(g, sub_1_x)
     if pos_weight is None or pos_weight.node().mustBeNone():
-        output = neg(g, add(g, mul(g, target, log_sig_x), mul(g, sub_1_y, log_1_x) ) )
+        output = neg(g, add(g, mul(g, target, log_sig_x), mul(g, sub_1_y, log_1_x)))
     else:
-        output = neg(g, add(g, mul(g, mul(g, target, log_sig_x), pos_weight), mul(g, sub_1_y, log_1_x) ) )
+        output = neg(g, add(g, mul(g, mul(g, target, log_sig_x), pos_weight), mul(g, sub_1_y, log_1_x)))
 
     if weight is not None and not sym_help._is_none(weight):
         output = mul(g, weight, output)

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -51,6 +51,35 @@ def nll_loss2d(g, self, target, weight, reduction, ignore_index):
     return nll_loss(g, self, target, weight, reduction, ignore_index)
 
 
+@parse_args('v', 'v', 'v', 'v', 'i')
+def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduction):
+    from torch.onnx.symbolic_opset9 import sigmoid, log, sub, neg, mul, add
+    p = g.op("Constant", value_t=torch.tensor([1]))
+    sig_x = sigmoid(g, input)
+    log_sig_x = log(g, sig_x)
+    sub_1_x = sub(g, p, sig_x)
+    sub_1_y = sub(g, p, target)
+    log_1_x = log(g, sub_1_x)
+    if pos_weight is None or pos_weight.node().mustBeNone():
+        output = neg(g, add(g, mul(g, target, log_sig_x), mul(g, sub_1_y, log_1_x) ) )
+    else:
+        output = neg(g, add(g, mul(g, mul(g, target, log_sig_x), pos_weight), mul(g, sub_1_y, log_1_x) ) )
+
+    if weight is not None and not sym_help._is_none(weight):
+        output = mul(g, weight, output)
+
+    reduction = sym_help._maybe_get_const(reduction, 'i')
+    if reduction == 0:
+        return output
+    elif reduction == 1:
+        return g.op("ReduceMean", output)
+    elif reduction == 2:
+        return g.op("ReduceSum", output)
+    else:
+        return sym_help._onnx_unsupported("binary_cross_entropy_with_logits with reduction other than none, mean, or sum."
+                                          "Please open a bug to request ONNX export support for the missing reduction type.")
+
+
 def celu(g, self, alpha):
     alpha = sym_help._maybe_get_const(alpha, 'f')
     # if the input is of type double cast it to float


### PR DESCRIPTION
Fixes issues 47997 https://github.com/pytorch/pytorch/issues/47997

Exporting the operator binary_cross_entropy_with_logits to ONNX opset version 12.
