### PR TITLE
[torchscript] Fix constant propagation schemas

### DIFF
--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -58,16 +58,16 @@ c10::optional<std::vector<IValue>> runNodeIfInputsAreConstant(
       isinstance(stack, n->tys(attr::types));
     } break;
     default: {
-      const auto& the_operator = n->getOperator();
-      if (the_operator.schema().is_vararg()) {
+      const auto maybe_schema = n->maybeSchema();
+      if (maybe_schema && maybe_schema->is_vararg()) {
         // vararg schemas require the number of inputs at the top of the stack
         // but this is broken in other places in constant prop, so disable it
         // for now
         return c10::nullopt;
       }
 
-      auto op = n->getOperation();
       try {
+        auto op = n->getOperation();
         op(&stack);
       } catch (...) {
         return c10::nullopt;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49605 [torchscript] Fix constant propagation schemas**

Differential Revision: [D25643157](https://our.internmc.facebook.com/intern/diff/D25643157)


Steps to reproduce the problem:
```
import torch
import torchvision
from torch.utils.mobile_optimizer import optimize_for_mobile

from torchvision.models.detection import FasterRCNN
from torchvision.models.detection.rpn import AnchorGenerator

model_300_500 = torchvision.models.detection.fasterrcnn_resnet50_fpn(pretrained=True, min_size=300, max_size=500)
model_300_500.eval()
script_model = torch.jit.script(model_300_500)
torch._C._freeze_module(script_model._c)

The error:
Traceback (most recent call last):
   File "run.py", line 17, in <module>
     torch._C._freeze_module(script_model._c)
 RuntimeError:
 Schema not found for node. File a bug report.
 Node: %2692 : (float, float, float, float) = prim::GetAttr[name="weights"](%self.rpn.box_coder)
```

Works without errors after fix.