### PR TITLE
Update `is_floating_point()` docs to mention bfloat16

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3837,7 +3837,7 @@ add_docstr(torch.is_floating_point, r"""
 is_floating_point(input) -> (bool)
 
 Returns True if the data type of :attr:`input` is a floating point data type i.e.,
-one of ``torch.float64``, ``torch.float32`` and ``torch.float16``.
+one of ``torch.float64``, ``torch.float32``, ``torch.float16``, and ``torch.bfloat16``.
 
 Args:
     {input}


### PR DESCRIPTION
Fixes #49610 . Explicitly mentions that `is_floating_point()` will return `True` if passed a `bfloat16` tensor.
