### PR TITLE
Inline coverage report combining/reporting

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -889,12 +889,20 @@ def main():
             print_to_stderr(err_message)
     finally:
         if options.coverage:
+            from coveage import Coverage
+            cwd = os.getcwd()
             test_dir = os.path.dirname(os.path.abspath(__file__))
-            if not PYTORCH_COLLECT_COVERAGE:
-                shell(['coverage', 'combine'], cwd=test_dir)
-                shell(['coverage', 'html'], cwd=test_dir)
-            else:
-                shell(['coverage', 'combine', '--append'], cwd=test_dir)
+            try:
+                os.chdir(test_dir)
+                cov = Coverage()
+                if PYTORCH_COLLECT_COVERAGE:
+                    cov.load()
+                cov.combine(strict=False)
+                cov.save()
+                if not PYTORCH_COLLECT_COVERAGE:
+                    cov.html_report()
+            finally:
+                os.chdir(cwd)
 
     if options.continue_through_error and has_failed:
         for err in failure_messages:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -889,7 +889,7 @@ def main():
             print_to_stderr(err_message)
     finally:
         if options.coverage:
-            from coveage import Coverage
+            from coverage import Coverage
             cwd = os.getcwd()
             test_dir = os.path.dirname(os.path.abspath(__file__))
             try:


### PR DESCRIPTION
Instead of calling coverage frontend import coverage module and call combine() and html_report()

Fixes https://github.com/pytorch/pytorch/issues/49596 by not using a strict mode when combining those reports

