### PR TITLE
[quant][graphmode][fx] Allow user to specify qconfig for call_method

### DIFF
--- a/torch/quantization/fx/qconfig_utils.py
+++ b/torch/quantization/fx/qconfig_utils.py
@@ -50,12 +50,13 @@ def convert_dict_to_ordered_dict(qconfig_dict):
     _convert_to_ordered_dict('module_name_regex', qconfig_dict)
     _convert_to_ordered_dict('module_name', qconfig_dict)
 
-def get_module_type_qconfig(qconfig_dict, module_type, fallback_qconfig):
+def get_object_type_qconfig(qconfig_dict, object_type, fallback_qconfig):
+    # object_type can be
+    # 1. Module type (call_module)
+    # 2. function (call_function)
+    # 3. string (call_method)
     return qconfig_dict['object_type'].get(
-        module_type, fallback_qconfig)
-
-def get_function_qconfig(qconfig_dict, function, fallback_qconfig):
-    return qconfig_dict['object_type'].get(function, fallback_qconfig)
+        object_type, fallback_qconfig)
 
 def get_module_name_regex_qconfig(qconfig_dict, module_name, fallback_qconfig):
     for regex_pattern, qconfig in \
@@ -80,7 +81,7 @@ def get_module_name_qconfig(qconfig_dict, module_name, fallback_qconfig):
 # global_qconfig if necessary
 def get_qconfig(modules, qconfig_dict, module_name, global_qconfig):
     assert modules is not None
-    module_type_qconfig = get_module_type_qconfig(
+    module_type_qconfig = get_object_type_qconfig(
         qconfig_dict, type(modules[module_name]), global_qconfig)
     module_name_regex_qconfig = get_module_name_regex_qconfig(
         qconfig_dict, module_name, module_type_qconfig)

--- a/torch/quantization/fx/qconfig_utils.py
+++ b/torch/quantization/fx/qconfig_utils.py
@@ -1,6 +1,12 @@
-from .utils import _parent_name
+import torch
 from collections import OrderedDict
+from typing import Union, Callable, Any
 import re
+
+from .utils import _parent_name
+
+QConfigAny = Union[torch.quantization.QConfig,
+                   torch.quantization.QConfigDynamic, None]
 
 def get_flattened_qconfig_dict(qconfig_dict):
     """ flatten the global, object_type and module_name qconfig
@@ -50,9 +56,12 @@ def convert_dict_to_ordered_dict(qconfig_dict):
     _convert_to_ordered_dict('module_name_regex', qconfig_dict)
     _convert_to_ordered_dict('module_name', qconfig_dict)
 
-def get_object_type_qconfig(qconfig_dict, object_type, fallback_qconfig):
+def get_object_type_qconfig(
+        qconfig_dict: Any,
+        object_type: Union[Callable, str],
+        fallback_qconfig: QConfigAny) -> QConfigAny:
     # object_type can be
-    # 1. Module type (call_module)
+    # 1. module type (call_module)
     # 2. function (call_function)
     # 3. string (call_method)
     return qconfig_dict['object_type'].get(

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -302,7 +302,7 @@ class Quantizer:
                 # precedence: [TODO] module_name_qconfig (need scope support
                 # from fx)
                 # > function_qconfig > global_qconfig
-                function_qconfig = get_function_qconfig(
+                function_qconfig = get_object_type_qconfig(
                     qconfig_dict, node.target, global_qconfig)
                 self.qconfig_map[node.name] = function_qconfig
             elif node.op == 'call_method':
@@ -318,6 +318,7 @@ class Quantizer:
                         "qconfig for value {}".format(node.name))
                     qconfig = get_qconfig(
                         self.modules, qconfig_dict, '', global_qconfig)
+                qconfig = get_object_type_qconfig(qconfig_dict, node.target, qconfig)
                 self.qconfig_map[node.name] = qconfig
             elif node.op == 'call_module':
                 module_qconfig = get_qconfig(

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -64,9 +64,6 @@ import warnings
 from typing import Optional, Dict, Any, List, Union, Tuple, Set, Callable
 
 # Define helper types
-
-QConfigAny = Union[torch.quantization.QConfig,
-                   torch.quantization.QConfigDynamic, None]
 MatchResult = Tuple[Node, List[Node], Optional[Pattern], QuantizeHandler,
                     QConfigAny]
 

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -61,7 +61,7 @@ from .qconfig_utils import *
 
 import warnings
 
-from typing import Optional, Dict, Any, List, Union, Tuple, Set, Callable
+from typing import Optional, Dict, Any, List, Tuple, Set, Callable
 
 # Define helper types
 MatchResult = Tuple[Node, List[Node], Optional[Pattern], QuantizeHandler,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49621 [quant][graphmode][fx] Allow user to specify qconfig for call_method**

Summary:
This adds support to configure qconfig for a call_method, e.g. x.chunk, this will help workaround
a problem in our internal model.

TODO: since call_method is also a string and we flatten the qconfig, might need to resolve namespace conflict between
call_method and module_name
TODO: Add scope support to set the qconfig for call_method correctly with original qconfig

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25651828](https://our.internmc.facebook.com/intern/diff/D25651828)