### PR TITLE
[NNC] masked fill

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1281,22 +1281,7 @@ class TestTEFuser(JitTestCase):
             self.assertEqual(ref, mod.forward(x))
             self.assertLastGraphAllFused()
 
-    @unittest.skip("temp disabled")
     def test_masked_fill(self):
-        # check scalar overload
-        def foo(x, mask):
-            return torch.masked_fill(x, mask, .6), torch.masked_fill(x, mask, 2)
-
-        mask = torch.tensor([True, False])
-        foo.__disable_jit_function_caching__ = True
-        for inp in (torch.rand([2, 2]).to(torch.int), mask), (torch.rand([2, 2]), mask):
-            ref = foo(*inp)
-            foo_s = torch.jit.script(foo)
-            warmup_forward(foo_s, *inp)
-            self.assertEqual(foo_s(*inp), ref)
-            self.assertLastGraphAllFused()
-
-        # check tensor overload
         dtypes = [
             torch.int8,
             torch.int16,
@@ -1308,27 +1293,21 @@ class TestTEFuser(JitTestCase):
             torch.bool,
         ]
         sizes = [(2,), (4, 4)]
-        for self_dtype, mask_dtype, device, size in product(dtypes, dtypes, self.devices, sizes):
-            try:
-                input_v = self.data_for(self_dtype, device, size=size)
-                val = self.data_for(val_dtype, device, size=size)
-                mask = self.data_for(torch.bool, device, size=size)
+        for self_dtype, device, scalar_val, size in product(dtypes, self.devices, [0.4, 3], sizes):
+            input_v = self.data_for(self_dtype, device, size=size)
+            mask = self.data_for(torch.bool, device, size=size)
 
-                def fn(input_v, val, mask):
-                    return torch.masked_fill(input_v, mask, val)
-                ref = fn(input_v, val, mask)
-            except Exception:
-                # If eager mode doesn't support a dtype/op/device combo,
-                # neither does the fuser.  Catch everything to avoid needing to
-                # guess what errors might be thrown by eager.
-                continue
+            def fn(input_v, mask):
+                return torch.masked_fill(input_v, mask, scalar_val)
+            ref = fn(input_v, mask)
             try:
-                t = torch.jit.trace(fn, (input_v, val, mask))
-                torch.testing.assert_allclose(ref, t((input_v, val, mask)))
-                self.assertAllFused(t.graph_for(x))
+                t = torch.jit.trace(fn, (input_v, mask))
+                torch.testing.assert_allclose(ref, t(input_v, mask))
+                print(torch.jit.last_executed_optimized_graph())
+                self.assertLastGraphAllFused()
             except Exception as e:
                 raise RuntimeError(
-                    " ".join(["Failed:", str(dtype), op.__name__, device, str(size)])
+                    " ".join(["Failed:", str(self_dtype), op.__name__, device, str(size)])
                 )
 
     def test_isnan(self):

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -122,8 +122,8 @@ bool isSupported(Node* node) {
       "aten::round(Tensor self) -> Tensor",
       "aten::trunc(Tensor self) -> Tensor",
       "aten::threshold(Tensor self, Scalar threshold, Scalar value) -> Tensor",
-      // "aten::masked_fill.Scalar(Tensor self, Tensor mask, Scalar value) -> Tensor",
-      // "aten::masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor",
+      "aten::masked_fill.Scalar(Tensor self, Tensor mask, Scalar value) -> Tensor",
+      // "aten::masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor", TODO: requires 0-dim Tensor
       "aten::remainder.Scalar(Tensor self, Scalar other) -> Tensor",
       "aten::remainder.Tensor(Tensor self, Tensor other) -> Tensor",
       "aten::cat(Tensor[] tensors, int dim=0) -> Tensor",

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -961,7 +961,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
 
     case aten::masked_fill: {
       return computeThreeOperand(
-          "aten::masked_fill",
+          "aten_masked_fill",
           v,
           [](const ExprHandle& input,
              const ExprHandle& mask,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49627 masked fill**

There was a bug in the test that was hidden by the `If eager mode doesn't support a dtype/op/device combo` try /  catch, so cuda wasn't being tested 🤡  The fix is just to rename `aten::masked_fill` to `aten_masked_fill`.

Differential Revision: [D25696409](https://our.internmc.facebook.com/intern/diff/D25696409)