### PR TITLE
Attempt to fix a bug in CosineAnnealingWarmRestarts

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -962,9 +962,8 @@ class CosineAnnealingWarmRestarts(_LRScheduler):
         self.T_mult = T_mult
         self.eta_min = eta_min
 
+        self.T_cur = 0 if last_epoch < 0 else last_epoch
         super(CosineAnnealingWarmRestarts, self).__init__(optimizer, last_epoch, verbose)
-
-        self.T_cur = self.last_epoch
 
     def get_lr(self):
         if not self._get_lr_called_within_step:


### PR DESCRIPTION
This is my attempt to fix a bug which causes AttributeError if we construct CosineAnnealingWarmRestarts with last_epoch greater than or equal to zero.

Fixes #49630
