### PR TITLE
Disable test on windows

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -282,6 +282,7 @@ class TestProfiler(TestCase):
         print(p.key_averages().table(
             sort_by="self_cuda_time_total", row_limit=-1))
 
+    @unittest.skipIf(IS_WINDOWS, "Disabled on windows (permissions)")
     def test_export_stacks(self):
         with profile(with_stack=True, use_kineto=kineto_available()) as p:
             x = torch.randn(10, 10)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49636 Disable test on windows**

Summary:
test_export_stacks fails with permission errors, only on windows
e.g. https://app.circleci.com/pipelines/github/pytorch/pytorch/253433/workflows/be48f35c-398d-4020-b556-dbc57a069240/jobs/9757169

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25654680](https://our.internmc.facebook.com/intern/diff/D25654680)