### PR TITLE
[BE] Introduce `set_cwd` context manager

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -14,7 +14,7 @@ import tempfile
 import torch
 import torch._six
 from torch.utils import cpp_extension
-from torch.testing._internal.common_utils import TEST_WITH_ROCM, shell, FILE_SCHEMA
+from torch.testing._internal.common_utils import TEST_WITH_ROCM, shell, set_cwd, FILE_SCHEMA
 import torch.distributed as dist
 from typing import Dict, Optional
 
@@ -890,10 +890,8 @@ def main():
     finally:
         if options.coverage:
             from coverage import Coverage
-            cwd = os.getcwd()
             test_dir = os.path.dirname(os.path.abspath(__file__))
-            try:
-                os.chdir(test_dir)
+            with set_cwd(test_dir):
                 cov = Coverage()
                 if PYTORCH_COLLECT_COVERAGE:
                     cov.load()
@@ -901,8 +899,6 @@ def main():
                 cov.save()
                 if not PYTORCH_COLLECT_COVERAGE:
                     cov.html_report()
-            finally:
-                os.chdir(cwd)
 
     if options.continue_through_error and has_failed:
         for err in failure_messages:

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -1,5 +1,5 @@
 import unittest
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests, set_cwd
 import tempfile
 import torch
 import re
@@ -202,17 +202,14 @@ class TestTypeHints(TestCase):
         if numpy.__version__ == '1.20.0.dev0+7af1024':
             self.skipTest("Typeannotations in numpy-1.20.0-dev are broken")
 
-        cwd = os.getcwd()
         # TODO: Would be better not to chdir here, this affects the entire
         # process!
-        os.chdir(repo_rootdir)
-        try:
+        with set_cwd(repo_rootdir):
             (stdout, stderr, result) = mypy.api.run([
                 '--check-untyped-defs',
                 '--follow-imports', 'silent',
             ])
-        finally:
-            os.chdir(cwd)
+
         if result != 0:
             self.fail(f"mypy failed: {stdout} {stderr}")
 
@@ -227,14 +224,11 @@ class TestTypeHints(TestCase):
         if not os.path.exists(mypy_inifile):
             self.skipTest("Can't find PyTorch MyPy strict config file")
 
-        cwd = os.getcwd()
-        os.chdir(repo_rootdir)
-        try:
+        with set_cwd(repo_rootdir):
             (stdout, stderr, result) = mypy.api.run([
                 '--config', mypy_inifile,
             ])
-        finally:
-            os.chdir(cwd)
+
         if result != 0:
             self.fail(f"mypy failed: {stdout} {stderr}")
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -37,7 +37,7 @@ import json
 from urllib.request import urlopen
 import __main__  # type: ignore[import]
 import errno
-from typing import cast, Any, Dict, Iterable, Optional
+from typing import cast, Any, Dict, Iterable, Iterator, Optional
 
 from torch.testing._internal import expecttest
 from torch.testing import \
@@ -1878,6 +1878,16 @@ def _assertGradAndGradgradChecks(test_case, apply_fn, inputs):
     # if we get whether this failed on the gradcheck or the gradgradcheck.
     test_case.assertTrue(gradcheck(apply_fn, inputs))
     test_case.assertTrue(gradgradcheck(apply_fn, inputs))
+
+
+@contextmanager
+def set_cwd(path: str) -> Iterator[None]:
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(old_cwd)
 
 
 # Using @precisionOverride specific to your test is the recommended way


### PR DESCRIPTION
Used to temporarily change working directory, but restore it even if exception is raised
Use it in test_type_hints and during code coverage collection
