### PR TITLE
Fixes function signature assert in c10/util/TypeIndex.h

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -98,8 +98,8 @@ template <typename T>
 inline C10_TYPENAME_CONSTEXPR c10::string_view fully_qualified_type_name_impl() {
 #if defined(_MSC_VER) && !defined(__clang__)
   return extract(
-      "class c10::basic_string_view<char> __cdecl c10::util::detail::fully_qualified_type_name_impl<",
-      ">(void)",
+      "c10::basic_string_view<char> c10::util::detail::fully_qualified_type_name_impl<",
+      ">()",
       __FUNCSIG__);
 #elif defined(__clang__)
   return extract(


### PR DESCRIPTION
Fixing function signature check that causes an assert

Fixes #48568
@peterjc123 