### PR TITLE
Grammatically updated the tech doc for easy understanding

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,8 +12,8 @@ PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.
 
 Features described in this documentation are classified by release status:
 
-  *Stable:*  These features will be maintained long-term and there should generally
-  be no major performance limitations or gaps in documentation.
+  *Stable:*  These features will be maintained for a long period of time and there should generally
+  be no major(noticeable) performance limitations or gaps in documentation.
   We also expect to maintain backwards compatibility (although
   breaking changes can happen and notice will be given one release ahead
   of time).


### PR DESCRIPTION
Fixes #{issue number}
Small grammatical update to the PyTorch documentation.

![Screenshot (63)](https://user-images.githubusercontent.com/66391651/102785937-21d69600-43cd-11eb-930c-b11ec4903c27.png)
