### PR TITLE
Fix TCPStore type coercion

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -627,12 +627,12 @@ Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
     >>> # Run on process 1 (server)
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 2, True, timedelta(seconds=30))
+    >>> server_store = dist.TCPStore("127.0.0.1", 1234, 2, True, timedelta(seconds=30))
     >>> # Run on process 2 (client)
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 2, False)
+    >>> client_store = dist.TCPStore("127.0.0.1", 1234, 2, False)
     >>> # Use any of the store methods from either the client or server after initialization
-    >>> store.set("first_key", "first_value")
-    >>> store.get("first_key")
+    >>> server_store.set("first_key", "first_value")
+    >>> client_store.get("first_key")
       )")
       .def(
           py::init<
@@ -644,6 +644,8 @@ Example::
           py::arg("host_name"),
           py::arg("port"),
           py::arg("world_size"),
+          // using noconvert() requires this argument to be True or False
+          // prevents accidental implicit conversion to bool
           py::arg("is_master").noconvert(),
           py::arg("timeout") =
               std::chrono::milliseconds(::c10d::Store::kDefaultTimeout));

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -384,7 +384,7 @@ Arguments:
 Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> store.set("first_key", "first_value")
     >>> # Should return "first_value"
     >>> store.get("first_key")
@@ -413,7 +413,7 @@ Returns:
 Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> store.set("first_key", "first_value")
     >>> # Should return "first_value"
     >>> store.get("first_key")
@@ -438,7 +438,7 @@ Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> store.add("first_key", 1)
     >>> store.add("first_key", 6)
     >>> # Should return 7
@@ -466,7 +466,7 @@ Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
     >>> # Using TCPStore as an example, HashStore can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> store.set("first_key")
     >>> # This should return true
     >>> store.delete_key("first_key")
@@ -493,7 +493,7 @@ Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> store.set("first_key", "first_value")
     >>> # This should return 2
     >>> store.num_keys()
@@ -513,7 +513,7 @@ Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> store.set_timeout(timedelta(seconds=10))
     >>> # This will throw an exception after 10 seconds
     >>> store.wait(["bad_key"])
@@ -536,7 +536,7 @@ Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> # This will throw an exception after 30 seconds
     >>> store.wait(["bad_key"])
 )")
@@ -560,7 +560,7 @@ Example::
     >>> import torch.distributed as dist
     >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> # This will throw an exception after 10 seconds
     >>> store.wait(["bad_key"], timedelta(seconds=10))
 )");

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -383,7 +383,8 @@ Arguments:
 
 Example::
     >>> import torch.distributed as dist
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> from datetime import timedelta
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> store.set("first_key", "first_value")
     >>> # Should return "first_value"
     >>> store.get("first_key")
@@ -411,7 +412,8 @@ Returns:
 
 Example::
     >>> import torch.distributed as dist
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> from datetime import timedelta
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> store.set("first_key", "first_value")
     >>> # Should return "first_value"
     >>> store.get("first_key")
@@ -434,8 +436,9 @@ Arguments:
 
 Example::
     >>> import torch.distributed as dist
+    >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> store.add("first_key", 1)
     >>> store.add("first_key", 6)
     >>> # Should return 7
@@ -461,8 +464,9 @@ Returns:
 
 Example::
     >>> import torch.distributed as dist
+    >>> from datetime import timedelta
     >>> # Using TCPStore as an example, HashStore can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> store.set("first_key")
     >>> # This should return true
     >>> store.delete_key("first_key")
@@ -487,8 +491,9 @@ Returns:
 
 Example::
     >>> import torch.distributed as dist
+    >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> store.set("first_key", "first_value")
     >>> # This should return 2
     >>> store.num_keys()
@@ -506,8 +511,9 @@ Arguments:
 
 Example::
     >>> import torch.distributed as dist
+    >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> store.set_timeout(timedelta(seconds=10))
     >>> # This will throw an exception after 10 seconds
     >>> store.wait(["bad_key"])
@@ -528,8 +534,9 @@ Arguments:
 
 Example::
     >>> import torch.distributed as dist
+    >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> # This will throw an exception after 30 seconds
     >>> store.wait(["bad_key"])
 )")
@@ -551,8 +558,9 @@ Arguments:
 
 Example::
     >>> import torch.distributed as dist
+    >>> from datetime import timedelta
     >>> # Using TCPStore as an example, other store types can also be used
-    >>> store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 1, True, timedelta(seconds=30))
     >>> # This will throw an exception after 10 seconds
     >>> store.wait(["bad_key"], timedelta(seconds=10))
 )");
@@ -617,11 +625,14 @@ Arguments:
 
 Example::
     >>> import torch.distributed as dist
-    >>> server_store = dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
-    >>> client_store = dist.TCPStore("127.0.0.1", 0, False)
+    >>> from datetime import timedelta
+    >>> # Run on process 1 (server)
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 2, True, timedelta(seconds=30))
+    >>> # Run on process 2 (client)
+    >>> store = dist.TCPStore("127.0.0.1", 1234, 2, False)
     >>> # Use any of the store methods from either the client or server after initialization
-    >>> server_store.set("first_key", "first_value")
-    >>> client_store.get("first_key")
+    >>> store.set("first_key", "first_value")
+    >>> store.get("first_key")
       )")
       .def(
           py::init<
@@ -633,7 +644,7 @@ Example::
           py::arg("host_name"),
           py::arg("port"),
           py::arg("world_size"),
-          py::arg("is_master"),
+          py::arg("is_master").noconvert(),
           py::arg("timeout") =
               std::chrono::milliseconds(::c10d::Store::kDefaultTimeout));
 


### PR DESCRIPTION
Fixes #49052

The TCPStore example with 4 arguments was working because the datetime value was being implicitly converted to a bool. Modified the pybind definition and updated documentation.

Test:
```
import torch.distributed as dist
from datetime import timedelta

dist.TCPStore("127.0.0.1", 0, True, timedelta(seconds=30))
```

Now fails with
```
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. torch._C._distributed_c10d.TCPStore(host_name: str, port: int, world_size: int, is_master: bool, timeout: datetime.timedelta = datetime.timedelta(seconds=300))

Invoked with: '127.0.0.1', 0, True, datetime.timedelta(seconds=30)
```