### PR TITLE
replacing THC_CLASS and THC_API with TORCH_CUDA_API

### DIFF
--- a/aten/src/THC/THCBlas.h
+++ b/aten/src/THC/THCBlas.h
@@ -6,11 +6,11 @@
 #include <c10/util/BFloat16.h>
 
 /* Level 3 */
-THC_API void THCudaBlas_Sgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, float alpha, float *a, int64_t lda, float *b, int64_t ldb, float beta, float *c, int64_t ldc);
-THC_API void THCudaBlas_Dgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, double alpha, double *a, int64_t lda, double *b, int64_t ldb, double beta, double *c, int64_t ldc);
+TORCH_CUDA_API void THCudaBlas_Sgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, float alpha, float *a, int64_t lda, float *b, int64_t ldb, float beta, float *c, int64_t ldc);
+TORCH_CUDA_API void THCudaBlas_Dgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, double alpha, double *a, int64_t lda, double *b, int64_t ldb, double beta, double *c, int64_t ldc);
 
-THC_API void THCudaBlas_Hgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, THHalf alpha, THHalf *a, int64_t lda, THHalf *b, int64_t ldb, THHalf beta, THHalf *c, int64_t ldc);
+TORCH_CUDA_API void THCudaBlas_Hgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, THHalf alpha, THHalf *a, int64_t lda, THHalf *b, int64_t ldb, THHalf beta, THHalf *c, int64_t ldc);
 
-THC_API void THCudaBlas_Bgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, at::BFloat16 alpha, at::BFloat16 *a, int64_t lda, at::BFloat16 *b, int64_t ldb, at::BFloat16 beta, at::BFloat16 *c, int64_t ldc);
+TORCH_CUDA_API void THCudaBlas_Bgemm(THCState *state, char transa, char transb, int64_t m, int64_t n, int64_t k, at::BFloat16 alpha, at::BFloat16 *a, int64_t lda, at::BFloat16 *b, int64_t ldb, at::BFloat16 beta, at::BFloat16 *c, int64_t ldc);
 
 #endif

--- a/aten/src/THC/THCCachingHostAllocator.h
+++ b/aten/src/THC/THCCachingHostAllocator.h
@@ -21,13 +21,13 @@
 // Note that this allocator does not split larger allocations into smaller
 // blocks, unlike the caching device allocator.
 //
-THC_API c10::Allocator* getTHCCachingHostAllocator(void);
+TORCH_CUDA_API c10::Allocator* getTHCCachingHostAllocator(void);
 
 // Records an event in the specified stream. The allocation 'ptr' will not be
 // re-used until the event has occurred.
-THC_API cudaError_t THCCachingHostAllocator_recordEvent(void *ptr, at::cuda::CUDAStream stream);
+TORCH_CUDA_API cudaError_t THCCachingHostAllocator_recordEvent(void *ptr, at::cuda::CUDAStream stream);
 
 // Releases cached pinned memory allocations via cudaHostFree
-THC_API void THCCachingHostAllocator_emptyCache(void);
+TORCH_CUDA_API void THCCachingHostAllocator_emptyCache(void);
 
 #endif

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -14,11 +14,6 @@
 
 #cmakedefine USE_MAGMA
 
-// TH & THC are now part of the same library as ATen and Caffe2
-// NB: However, we are planning to split it out to a torch_cuda library
-#define THC_API TORCH_CUDA_API
-#define THC_CLASS TORCH_CUDA_API
-
 #ifndef THAssert
 #define THAssert(exp)                                                   \
   do {                                                                  \
@@ -36,22 +31,22 @@ typedef struct _THCCudaResourcesPerDevice {
   size_t scratchSpacePerStream;
 } THCCudaResourcesPerDevice;
 
-THC_API THCState* THCState_alloc(void);
-THC_API void THCState_free(THCState* state);
+TORCH_CUDA_API THCState* THCState_alloc(void);
+TORCH_CUDA_API void THCState_free(THCState* state);
 
-THC_API void THCudaInit(THCState* state);
-THC_API void THCudaShutdown(THCState* state);
+TORCH_CUDA_API void THCudaInit(THCState* state);
+TORCH_CUDA_API void THCudaShutdown(THCState* state);
 
 /* If device `dev` can access allocations on device `devToAccess`, this will return */
 /* 1; otherwise, 0. */
-THC_API int THCState_getPeerToPeerAccess(THCState* state, int dev, int devToAccess);
+TORCH_CUDA_API int THCState_getPeerToPeerAccess(THCState* state, int dev, int devToAccess);
 
-THC_API c10::Allocator* THCState_getCudaHostAllocator(THCState* state);
+TORCH_CUDA_API c10::Allocator* THCState_getCudaHostAllocator(THCState* state);
 
-THC_API void THCMagma_init(THCState *state);
+TORCH_CUDA_API void THCMagma_init(THCState *state);
 
 /* For the current device and stream, returns the allocated scratch space */
-THC_API size_t THCState_getCurrentDeviceScratchSpaceSize(THCState* state);
+TORCH_CUDA_API size_t THCState_getCurrentDeviceScratchSpaceSize(THCState* state);
 
 #define THCAssertSameGPU(expr) if (!expr) THError("arguments are located on different GPUs")
 #define THCudaCheck(err)  __THCudaCheck(err, __FILE__, __LINE__)
@@ -59,16 +54,16 @@ THC_API size_t THCState_getCurrentDeviceScratchSpaceSize(THCState* state);
 #define THCublasCheck(err)  __THCublasCheck(err,  __FILE__, __LINE__)
 #define THCusparseCheck(err)  __THCusparseCheck(err,  __FILE__, __LINE__)
 
-THC_API void __THCudaCheck(cudaError_t err, const char *file, const int line);
-THC_API void __THCudaCheckWarn(cudaError_t err, const char *file, const int line);
-THC_API void __THCublasCheck(cublasStatus_t status, const char *file, const int line);
-THC_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line);
+TORCH_CUDA_API void __THCudaCheck(cudaError_t err, const char *file, const int line);
+TORCH_CUDA_API void __THCudaCheckWarn(cudaError_t err, const char *file, const int line);
+TORCH_CUDA_API void __THCublasCheck(cublasStatus_t status, const char *file, const int line);
+TORCH_CUDA_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line);
 
-THC_API void* THCudaMalloc(THCState *state, size_t size);
-THC_API void THCudaFree(THCState *state, void* ptr);
+TORCH_CUDA_API void* THCudaMalloc(THCState *state, size_t size);
+TORCH_CUDA_API void THCudaFree(THCState *state, void* ptr);
 
 at::DataPtr THCudaHostAlloc(THCState *state, size_t size);
 
-THC_API void THCudaHostRecord(THCState *state, void *ptr);
+TORCH_CUDA_API void THCudaHostRecord(THCState *state, void *ptr);
 
 #endif

--- a/aten/src/THC/THCReduceApplyUtils.cuh
+++ b/aten/src/THC/THCReduceApplyUtils.cuh
@@ -147,6 +147,6 @@ __device__ T reduceBlockWithNThreadLocalReductions(T *smem,
 void THCCheckTensorDims(THCState* state, THCudaTensor* tensor, int arg);
 
 // Produces a grid with at least one point per tile
-THC_API bool THC_getGridFromTiles(ptrdiff_t gridTiles, dim3& grid);
+TORCH_CUDA_API bool THC_getGridFromTiles(ptrdiff_t gridTiles, dim3& grid);
 
 #endif // THC_REDUCE_APPLY_UTILS_INC

--- a/aten/src/THC/THCSleep.h
+++ b/aten/src/THC/THCSleep.h
@@ -5,6 +5,6 @@
 #include <time.h>
 
 // enqueues a kernel that spins for the specified number of cycles
-THC_API void THC_sleep(THCState* state, int64_t cycles);
+TORCH_CUDA_API void THC_sleep(THCState* state, int64_t cycles);
 
 #endif

--- a/aten/src/THC/THCStorage.hpp
+++ b/aten/src/THC/THCStorage.hpp
@@ -13,17 +13,17 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
-THC_API THCStorage* THCStorage_new(THCState* state);
+TORCH_CUDA_API THCStorage* THCStorage_new(THCState* state);
 
-THC_API void THCStorage_retain(THCState *state, THCStorage *storage);
+TORCH_CUDA_API void THCStorage_retain(THCState *state, THCStorage *storage);
 
-THC_API void THCStorage_resizeBytes(
+TORCH_CUDA_API void THCStorage_resizeBytes(
     THCState* state,
     THCStorage* storage,
     ptrdiff_t size_bytes);
-THC_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
+TORCH_CUDA_API int THCStorage_getDevice(THCState* state, const THCStorage* storage);
 
-THC_API THCStorage* THCStorage_newWithDataAndAllocator(
+TORCH_CUDA_API THCStorage* THCStorage_newWithDataAndAllocator(
     THCState* state,
     at::DataPtr&& data,
     ptrdiff_t size,

--- a/aten/src/THC/THCTensor.h
+++ b/aten/src/THC/THCTensor.h
@@ -9,7 +9,7 @@
 
 #define THC_DESC_BUFF_LEN 64
 
-typedef struct THC_CLASS THCDescBuff
+typedef struct TORCH_CUDA_API THCDescBuff
 {
     char str[THC_DESC_BUFF_LEN];
 } THCDescBuff;

--- a/aten/src/THC/THCTensor.hpp
+++ b/aten/src/THC/THCTensor.hpp
@@ -12,46 +12,46 @@
 #include <ATen/ATen.h>
 
 // See [NOTE: nDimension vs nDimensionLegacyNoScalars vs nDimensionLegacyAll]
-THC_API int THCTensor_nDimension(THCState *state, const THCTensor *self);
-THC_API int THCTensor_nDimensionLegacyNoScalars(THCState *state, const THCTensor *self);
-THC_API int THCTensor_nDimensionLegacyAll(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_nDimension(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_nDimensionLegacyNoScalars(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_nDimensionLegacyAll(THCState *state, const THCTensor *self);
 
-THC_API int64_t THCTensor_size(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_sizeLegacyNoScalars(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_strideLegacyNoScalars(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API int64_t THCTensor_size(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API int64_t THCTensor_sizeLegacyNoScalars(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API int64_t THCTensor_stride(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API int64_t THCTensor_strideLegacyNoScalars(THCState *state, const THCTensor *self, int dim);
 
-THC_API THCTensor *THCTensor_new(THCState *state, caffe2::TypeMeta type_meta);
+TORCH_CUDA_API THCTensor *THCTensor_new(THCState *state, caffe2::TypeMeta type_meta);
 
-THC_API void THCTensor_resize(THCState *state, THCTensor *tensor, at::IntArrayRef size, at::IntArrayRef stride);
-THC_API void THCTensor_resizeNd(THCState *state, THCTensor *tensor, int nDimension, const int64_t *size, const int64_t *stride);
-THC_API void THCTensor_resizeAs(THCState *state, THCTensor *tensor, THCTensor *src);
+TORCH_CUDA_API void THCTensor_resize(THCState *state, THCTensor *tensor, at::IntArrayRef size, at::IntArrayRef stride);
+TORCH_CUDA_API void THCTensor_resizeNd(THCState *state, THCTensor *tensor, int nDimension, const int64_t *size, const int64_t *stride);
+TORCH_CUDA_API void THCTensor_resizeAs(THCState *state, THCTensor *tensor, THCTensor *src);
 
-THC_API void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src);
-THC_API void THCTensor_setStorage(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, at::IntArrayRef size_, at::IntArrayRef stride_);
+TORCH_CUDA_API void THCTensor_set(THCState *state, THCTensor *self, THCTensor *src);
+TORCH_CUDA_API void THCTensor_setStorage(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_, at::IntArrayRef size_, at::IntArrayRef stride_);
 
-THC_API void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
-THC_API void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
+TORCH_CUDA_API void THCTensor_squeeze1d(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
+TORCH_CUDA_API void THCTensor_unsqueeze1d(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
 
-THC_API bool THCTensor_allContiguous(THCState *state, THCTensor **inputs, int numInputs);
-THC_API ptrdiff_t THCTensor_nElement(THCState *state, const THCTensor *self);
+TORCH_CUDA_API bool THCTensor_allContiguous(THCState *state, THCTensor **inputs, int numInputs);
+TORCH_CUDA_API ptrdiff_t THCTensor_nElement(THCState *state, const THCTensor *self);
 
-THC_API void THCTensor_retain(THCState *state, THCTensor *self);
-THC_API void THCTensor_free(THCState *state, THCTensor *self);
+TORCH_CUDA_API void THCTensor_retain(THCState *state, THCTensor *self);
+TORCH_CUDA_API void THCTensor_free(THCState *state, THCTensor *self);
 
-THC_API int THCTensor_getDevice(THCState* state, const THCTensor* tensor);
-THC_API bool THCTensor_allSameDevice(THCState* state, THCTensor ** inputs, int numInputs);
+TORCH_CUDA_API int THCTensor_getDevice(THCState* state, const THCTensor* tensor);
+TORCH_CUDA_API bool THCTensor_allSameDevice(THCState* state, THCTensor ** inputs, int numInputs);
 
 /* Can we use 32 bit math for indexing? */
-THC_API bool THCTensor_canUse32BitIndexMath(THCState* state, const THCTensor* t, ptrdiff_t max_elem=INT32_MAX);
+TORCH_CUDA_API bool THCTensor_canUse32BitIndexMath(THCState* state, const THCTensor* t, ptrdiff_t max_elem=INT32_MAX);
 /* Are all tensors 32-bit indexable? */
-THC_API bool THCTensor_all32BitIndexable(THCState* state, THCTensor** inputs, int numInputs);
-THC_API void THCTensor_preserveReduceDimSemantics(THCState *state, THCTensor *tensor, int in_dims,
+TORCH_CUDA_API bool THCTensor_all32BitIndexable(THCState* state, THCTensor** inputs, int numInputs);
+TORCH_CUDA_API void THCTensor_preserveReduceDimSemantics(THCState *state, THCTensor *tensor, int in_dims,
                                                   int64_t dimension, int keepdim);
 /* Returns false if there is no possibility that the tensor    */
 /* has more than one index that references the same datapoint, */
 /* true otherwise.                                             */
-THC_API bool THCTensor_maybeOverlappingIndices(THCState* state, const THCTensor* t);
+TORCH_CUDA_API bool THCTensor_maybeOverlappingIndices(THCState* state, const THCTensor* t);
 
 #include <THC/generic/THCTensor.hpp>
 #include <THC/THCGenerateAllTypes.h>

--- a/aten/src/THC/THCTensorRandom.h
+++ b/aten/src/THC/THCTensorRandom.h
@@ -11,7 +11,7 @@
 
 #include <ATen/CUDAGeneratorImpl.h>
 
-THC_API void THCRandom_getRNGState(at::Generator gen_, THByteTensor *rng_state);
-THC_API void THCRandom_setRNGState(at::Generator gen_, THByteTensor *rng_state);
+TORCH_CUDA_API void THCRandom_getRNGState(at::Generator gen_, THByteTensor *rng_state);
+TORCH_CUDA_API void THCRandom_setRNGState(at::Generator gen_, THByteTensor *rng_state);
 
 #endif

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -19,34 +19,34 @@
 #define THCudaComplexFloatStorage           THCStorage
 #define THCudaComplexDoubleStorage          THCStorage
 
-THC_API scalar_t* THCStorage_(data)(THCState *state, const THCStorage*);
-THC_API int THCStorage_(elementSize)(THCState *state);
+TORCH_CUDA_API scalar_t* THCStorage_(data)(THCState *state, const THCStorage*);
+TORCH_CUDA_API int THCStorage_(elementSize)(THCState *state);
 
 /* slow access -- checks everything */
-THC_API void THCStorage_(set)(THCState *state, THCStorage*, ptrdiff_t, scalar_t);
-THC_API scalar_t THCStorage_(get)(THCState *state, const THCStorage*, ptrdiff_t);
+TORCH_CUDA_API void THCStorage_(set)(THCState *state, THCStorage*, ptrdiff_t, scalar_t);
+TORCH_CUDA_API scalar_t THCStorage_(get)(THCState *state, const THCStorage*, ptrdiff_t);
 
-THC_API THCStorage* THCStorage_(new)(THCState *state);
-THC_API THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size);
-THC_API THCStorage* THCStorage_(newWithSize1)(THCState *state, scalar_t);
-THC_API THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *filename, ptrdiff_t size, int shared);
+TORCH_CUDA_API THCStorage* THCStorage_(new)(THCState *state);
+TORCH_CUDA_API THCStorage* THCStorage_(newWithSize)(THCState *state, ptrdiff_t size);
+TORCH_CUDA_API THCStorage* THCStorage_(newWithSize1)(THCState *state, scalar_t);
+TORCH_CUDA_API THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *filename, ptrdiff_t size, int shared);
 
-THC_API THCStorage* THCStorage_(newWithAllocator)(
+TORCH_CUDA_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
   at::Allocator* allocator);
-THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
+TORCH_CUDA_API THCStorage* THCStorage_(newWithDataAndAllocator)(
   THCState *state, at::DataPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);
 
-THC_API void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag);
-THC_API void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const char flag);
-THC_API void THCStorage_(retain)(THCState *state, THCStorage *storage);
+TORCH_CUDA_API void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag);
+TORCH_CUDA_API void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const char flag);
+TORCH_CUDA_API void THCStorage_(retain)(THCState *state, THCStorage *storage);
 
-THC_API void THCStorage_(free)(THCState *state, THCStorage *storage);
-THC_API void THCStorage_(
+TORCH_CUDA_API void THCStorage_(free)(THCState *state, THCStorage *storage);
+TORCH_CUDA_API void THCStorage_(
     resizeBytes)(THCState* state, THCStorage* storage, ptrdiff_t size_bytes);
-THC_API void THCStorage_(fill)(THCState *state, THCStorage *storage, scalar_t value);
+TORCH_CUDA_API void THCStorage_(fill)(THCState *state, THCStorage *storage, scalar_t value);
 
-THC_API int THCStorage_(getDevice)(THCState* state, const THCStorage* storage);
+TORCH_CUDA_API int THCStorage_(getDevice)(THCState* state, const THCStorage* storage);
 
 #endif

--- a/aten/src/THC/generic/THCStorageCopy.h
+++ b/aten/src/THC/generic/THCStorageCopy.h
@@ -4,57 +4,57 @@
 
 /* Support for copy between different Storage types */
 
-THC_API void THCStorage_(copy)(THCState *state, THCStorage *storage, THCStorage *src);
+TORCH_CUDA_API void THCStorage_(copy)(THCState *state, THCStorage *storage, THCStorage *src);
 #if !defined(THC_REAL_IS_COMPLEXFLOAT) && !defined(THC_REAL_IS_COMPLEXDOUBLE)
-    THC_API void THCStorage_(copyByte)(THCState *state, THCStorage *storage, struct THByteStorage *src);
-    THC_API void THCStorage_(copyChar)(THCState *state, THCStorage *storage, struct THCharStorage *src);
-    THC_API void THCStorage_(copyShort)(THCState *state, THCStorage *storage, struct THShortStorage *src);
-    THC_API void THCStorage_(copyInt)(THCState *state, THCStorage *storage, struct THIntStorage *src);
-    THC_API void THCStorage_(copyLong)(THCState *state, THCStorage *storage, struct THLongStorage *src);
-    THC_API void THCStorage_(copyFloat)(THCState *state, THCStorage *storage, struct THFloatStorage *src);
-    THC_API void THCStorage_(copyDouble)(THCState *state, THCStorage *storage, struct THDoubleStorage *src);
-    THC_API void THCStorage_(copyHalf)(THCState *state, THCStorage *storage, struct THHalfStorage *src);
-    THC_API void THCStorage_(copyBool)(THCState *state, THCStorage *storage, struct THBoolStorage *src);
-    THC_API void THCStorage_(copyBFloat16)(THCState *state, THCStorage *storage, struct THBFloat16Storage *src);
+    TORCH_CUDA_API void THCStorage_(copyByte)(THCState *state, THCStorage *storage, struct THByteStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyChar)(THCState *state, THCStorage *storage, struct THCharStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyShort)(THCState *state, THCStorage *storage, struct THShortStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyInt)(THCState *state, THCStorage *storage, struct THIntStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyLong)(THCState *state, THCStorage *storage, struct THLongStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyFloat)(THCState *state, THCStorage *storage, struct THFloatStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyDouble)(THCState *state, THCStorage *storage, struct THDoubleStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyHalf)(THCState *state, THCStorage *storage, struct THHalfStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyBool)(THCState *state, THCStorage *storage, struct THBoolStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyBFloat16)(THCState *state, THCStorage *storage, struct THBFloat16Storage *src);
 #else
-    THC_API void THCStorage_(copyComplexFloat)(THCState *state, THCStorage *storage, struct THComplexFloatStorage *src);
-    THC_API void THCStorage_(copyComplexDouble)(THCState *state, THCStorage *storage, struct THComplexDoubleStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyComplexFloat)(THCState *state, THCStorage *storage, struct THComplexFloatStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyComplexDouble)(THCState *state, THCStorage *storage, struct THComplexDoubleStorage *src);
 #endif
 
 #if !defined(THC_REAL_IS_COMPLEXFLOAT) && !defined(THC_REAL_IS_COMPLEXDOUBLE)
-    THC_API void THCStorage_(copyCudaByte)(THCState *state, THCStorage *storage, struct THCudaByteStorage *src);
-    THC_API void THCStorage_(copyCudaChar)(THCState *state, THCStorage *storage, struct THCudaCharStorage *src);
-    THC_API void THCStorage_(copyCudaShort)(THCState *state, THCStorage *storage, struct THCudaShortStorage *src);
-    THC_API void THCStorage_(copyCudaInt)(THCState *state, THCStorage *storage, struct THCudaIntStorage *src);
-    THC_API void THCStorage_(copyCudaLong)(THCState *state, THCStorage *storage, struct THCudaLongStorage *src);
-    THC_API void THCStorage_(copyCudaFloat)(THCState *state, THCStorage *storage, struct THCudaStorage *src);
-    THC_API void THCStorage_(copyCudaDouble)(THCState *state, THCStorage *storage, struct THCudaDoubleStorage *src);
-    THC_API void THCStorage_(copyCudaHalf)(THCState *state, THCStorage *storage, struct THCudaHalfStorage *src);
-    THC_API void THCStorage_(copyCudaBool)(THCState *state, THCStorage *storage, struct THCudaBoolStorage *src);
-    THC_API void THCStorage_(copyCudaBFloat16)(THCState *state, THCStorage *storage, struct THCudaBFloat16Storage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaByte)(THCState *state, THCStorage *storage, struct THCudaByteStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaChar)(THCState *state, THCStorage *storage, struct THCudaCharStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaShort)(THCState *state, THCStorage *storage, struct THCudaShortStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaInt)(THCState *state, THCStorage *storage, struct THCudaIntStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaLong)(THCState *state, THCStorage *storage, struct THCudaLongStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaFloat)(THCState *state, THCStorage *storage, struct THCudaStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaDouble)(THCState *state, THCStorage *storage, struct THCudaDoubleStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaHalf)(THCState *state, THCStorage *storage, struct THCudaHalfStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaBool)(THCState *state, THCStorage *storage, struct THCudaBoolStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaBFloat16)(THCState *state, THCStorage *storage, struct THCudaBFloat16Storage *src);
 #else
-    THC_API void THCStorage_(copyCudaComplexFloat)(THCState *state, THCStorage *storage, struct THCudaComplexFloatStorage *src);
-    THC_API void THCStorage_(copyCudaComplexDouble)(THCState *state, THCStorage *storage, struct THCudaComplexDoubleStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaComplexFloat)(THCState *state, THCStorage *storage, struct THCudaComplexFloatStorage *src);
+    TORCH_CUDA_API void THCStorage_(copyCudaComplexDouble)(THCState *state, THCStorage *storage, struct THCudaComplexDoubleStorage *src);
 #endif
 
 #if !defined(THC_REAL_IS_COMPLEXFLOAT) && !defined(THC_REAL_IS_COMPLEXDOUBLE)
-    THC_API void TH_CONCAT_2(THByteStorage_copyCuda  , Real)(THCState *state, THByteStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THCharStorage_copyCuda  , Real)(THCState *state, THCharStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THShortStorage_copyCuda , Real)(THCState *state, THShortStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THIntStorage_copyCuda   , Real)(THCState *state, THIntStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THLongStorage_copyCuda  , Real)(THCState *state, THLongStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THFloatStorage_copyCuda , Real)(THCState *state, THFloatStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THDoubleStorage_copyCuda, Real)(THCState *state, THDoubleStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THHalfStorage_copyCuda, Real)(THCState *state, THHalfStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THBoolStorage_copyCuda, Real)(THCState *state, THBoolStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THBFloat16Storage_copyCuda, Real)(THCState *state, THBFloat16Storage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THByteStorage_copyCuda  , Real)(THCState *state, THByteStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THCharStorage_copyCuda  , Real)(THCState *state, THCharStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THShortStorage_copyCuda , Real)(THCState *state, THShortStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THIntStorage_copyCuda   , Real)(THCState *state, THIntStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THLongStorage_copyCuda  , Real)(THCState *state, THLongStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THFloatStorage_copyCuda , Real)(THCState *state, THFloatStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THDoubleStorage_copyCuda, Real)(THCState *state, THDoubleStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THHalfStorage_copyCuda, Real)(THCState *state, THHalfStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THBoolStorage_copyCuda, Real)(THCState *state, THBoolStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THBFloat16Storage_copyCuda, Real)(THCState *state, THBFloat16Storage *self, struct THCStorage *src);
 #else
-    THC_API void TH_CONCAT_2(THComplexFloatStorage_copyCuda , Real)(THCState *state, THComplexFloatStorage *self, struct THCStorage *src);
-    THC_API void TH_CONCAT_2(THComplexDoubleStorage_copyCuda, Real)(THCState *state, THComplexDoubleStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THComplexFloatStorage_copyCuda , Real)(THCState *state, THComplexFloatStorage *self, struct THCStorage *src);
+    TORCH_CUDA_API void TH_CONCAT_2(THComplexDoubleStorage_copyCuda, Real)(THCState *state, THComplexDoubleStorage *self, struct THCStorage *src);
 #endif
 
-THC_API void THStorage_(copyCuda)(THCState *state, THStorage *self, THCStorage *src);
-THC_API void THCStorage_(copyCuda)(THCState *state, THCStorage *self, THCStorage *src);
-THC_API void THCStorage_(copyCPU)(THCState *state, THCStorage *self, THStorage *src);
+TORCH_CUDA_API void THStorage_(copyCuda)(THCState *state, THStorage *self, THCStorage *src);
+TORCH_CUDA_API void THCStorage_(copyCuda)(THCState *state, THCStorage *self, THCStorage *src);
+TORCH_CUDA_API void THCStorage_(copyCPU)(THCState *state, THCStorage *self, THStorage *src);
 
 #endif

--- a/aten/src/THC/generic/THCTensor.h
+++ b/aten/src/THC/generic/THCTensor.h
@@ -20,87 +20,87 @@
 #define THCudaComplexDoubleTensor   THCTensor
 
 /**** access methods ****/
-THC_API THCStorage* THCTensor_(storage)(THCState *state, const THCTensor *self);
-THC_API ptrdiff_t THCTensor_(storageOffset)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API THCStorage* THCTensor_(storage)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API ptrdiff_t THCTensor_(storageOffset)(THCState *state, const THCTensor *self);
 
 // See [NOTE: nDimension vs nDimensionLegacyNoScalars vs nDimensionLegacyAll]
-THC_API int THCTensor_(nDimension)(THCState *state, const THCTensor *self);
-THC_API int THCTensor_(nDimensionLegacyNoScalars)(THCState *state, const THCTensor *self);
-THC_API int THCTensor_(nDimensionLegacyAll)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_(nDimension)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_(nDimensionLegacyNoScalars)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_(nDimensionLegacyAll)(THCState *state, const THCTensor *self);
 
-THC_API int64_t THCTensor_(size)(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_(sizeLegacyNoScalars)(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_(stride)(THCState *state, const THCTensor *self, int dim);
-THC_API int64_t THCTensor_(strideLegacyNoScalars)(THCState *state, const THCTensor *self, int dim);
-THC_API scalar_t *THCTensor_(data)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int64_t THCTensor_(size)(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API int64_t THCTensor_(sizeLegacyNoScalars)(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API int64_t THCTensor_(stride)(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API int64_t THCTensor_(strideLegacyNoScalars)(THCState *state, const THCTensor *self, int dim);
+TORCH_CUDA_API scalar_t *THCTensor_(data)(THCState *state, const THCTensor *self);
 
-THC_API void THCTensor_(setFlag)(THCState *state, THCTensor *self, const char flag);
-THC_API void THCTensor_(clearFlag)(THCState *state, THCTensor *self, const char flag);
+TORCH_CUDA_API void THCTensor_(setFlag)(THCState *state, THCTensor *self, const char flag);
+TORCH_CUDA_API void THCTensor_(clearFlag)(THCState *state, THCTensor *self, const char flag);
 
 
 /**** creation methods ****/
-THC_API THCTensor *THCTensor_(new)(THCState *state);
-THC_API THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor);
-THC_API THCTensor *THCTensor_(newWithStorage1d)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_,
+TORCH_CUDA_API THCTensor *THCTensor_(new)(THCState *state);
+TORCH_CUDA_API THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor);
+TORCH_CUDA_API THCTensor *THCTensor_(newWithStorage1d)(THCState *state, THCStorage *storage_, ptrdiff_t storageOffset_,
                                 int64_t size0_, int64_t stride0_);
 
 /* stride might be NULL */
-THC_API THCTensor *THCTensor_(newWithSize1d)(THCState *state, int64_t size0_);
+TORCH_CUDA_API THCTensor *THCTensor_(newWithSize1d)(THCState *state, int64_t size0_);
 
-THC_API THCTensor *THCTensor_(newClone)(THCState *state, THCTensor *self);
-THC_API THCTensor *THCTensor_(newContiguous)(THCState *state, THCTensor *tensor);
-THC_API THCTensor *THCTensor_(newSelect)(THCState *state, THCTensor *tensor, int dimension_, int64_t sliceIndex_);
-THC_API THCTensor *THCTensor_(newNarrow)(THCState *state, THCTensor *tensor, int dimension_, int64_t firstIndex_, int64_t size_);
-THC_API THCTensor *THCTensor_(newTranspose)(THCState *state, THCTensor *tensor, int dimension1_, int dimension2_);
-THC_API THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input);
+TORCH_CUDA_API THCTensor *THCTensor_(newClone)(THCState *state, THCTensor *self);
+TORCH_CUDA_API THCTensor *THCTensor_(newContiguous)(THCState *state, THCTensor *tensor);
+TORCH_CUDA_API THCTensor *THCTensor_(newSelect)(THCState *state, THCTensor *tensor, int dimension_, int64_t sliceIndex_);
+TORCH_CUDA_API THCTensor *THCTensor_(newNarrow)(THCState *state, THCTensor *tensor, int dimension_, int64_t firstIndex_, int64_t size_);
+TORCH_CUDA_API THCTensor *THCTensor_(newTranspose)(THCState *state, THCTensor *tensor, int dimension1_, int dimension2_);
+TORCH_CUDA_API THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input);
 
 // resize* methods simply resize the storage. So they may not retain the current data at current indices.
 // This is especially likely to happen when the tensor is not contiguous. In general, if you still need the
 // values, unless you are doing some size and stride tricks, do not use resize*.
-THC_API void THCTensor_(resizeNd)(THCState *state, THCTensor *tensor, int nDimension, const int64_t *size, const int64_t *stride);
-THC_API void THCTensor_(resizeAs)(THCState *state, THCTensor *tensor, THCTensor *src);
-THC_API void THCTensor_(resize0d)(THCState *state, THCTensor *tensor);
-THC_API void THCTensor_(resize1d)(THCState *state, THCTensor *tensor, int64_t size0_);
-THC_API void THCTensor_(resize2d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_);
-THC_API void THCTensor_(resize3d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_);
-THC_API void THCTensor_(resize4d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_);
-THC_API void THCTensor_(resize5d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_, int64_t size4_);
+TORCH_CUDA_API void THCTensor_(resizeNd)(THCState *state, THCTensor *tensor, int nDimension, const int64_t *size, const int64_t *stride);
+TORCH_CUDA_API void THCTensor_(resizeAs)(THCState *state, THCTensor *tensor, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(resize0d)(THCState *state, THCTensor *tensor);
+TORCH_CUDA_API void THCTensor_(resize1d)(THCState *state, THCTensor *tensor, int64_t size0_);
+TORCH_CUDA_API void THCTensor_(resize2d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_);
+TORCH_CUDA_API void THCTensor_(resize3d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_);
+TORCH_CUDA_API void THCTensor_(resize4d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_);
+TORCH_CUDA_API void THCTensor_(resize5d)(THCState *state, THCTensor *tensor, int64_t size0_, int64_t size1_, int64_t size2_, int64_t size3_, int64_t size4_);
 
-THC_API void THCTensor_(set)(THCState *state, THCTensor *self, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(set)(THCState *state, THCTensor *self, THCTensor *src);
 
-THC_API void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int dimension_, int64_t firstIndex_, int64_t size_);
-THC_API void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int dimension_, int64_t sliceIndex_);
-THC_API void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int dimension1_, int dimension2_);
+TORCH_CUDA_API void THCTensor_(narrow)(THCState *state, THCTensor *self, THCTensor *src, int dimension_, int64_t firstIndex_, int64_t size_);
+TORCH_CUDA_API void THCTensor_(select)(THCState *state, THCTensor *self, THCTensor *src, int dimension_, int64_t sliceIndex_);
+TORCH_CUDA_API void THCTensor_(transpose)(THCState *state, THCTensor *self, THCTensor *src, int dimension1_, int dimension2_);
 
-THC_API void THCTensor_(squeeze1d)(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
-THC_API void THCTensor_(unsqueeze1d)(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
+TORCH_CUDA_API void THCTensor_(squeeze1d)(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
+TORCH_CUDA_API void THCTensor_(unsqueeze1d)(THCState *state, THCTensor *self, THCTensor *src, int dimension_);
 
-THC_API int THCTensor_(isContiguous)(THCState *state, const THCTensor *self);
-THC_API int THCTensor_(isSameSizeAs)(THCState *state, const THCTensor *self, const THCTensor *src);
-THC_API ptrdiff_t THCTensor_(nElement)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_(isContiguous)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_(isSameSizeAs)(THCState *state, const THCTensor *self, const THCTensor *src);
+TORCH_CUDA_API ptrdiff_t THCTensor_(nElement)(THCState *state, const THCTensor *self);
 
-THC_API void THCTensor_(retain)(THCState *state, THCTensor *self);
-THC_API void THCTensor_(free)(THCState *state, THCTensor *self);
-THC_API void THCTensor_(freeCopyTo)(THCState *state, THCTensor *self, THCTensor *dst);
+TORCH_CUDA_API void THCTensor_(retain)(THCState *state, THCTensor *self);
+TORCH_CUDA_API void THCTensor_(free)(THCState *state, THCTensor *self);
+TORCH_CUDA_API void THCTensor_(freeCopyTo)(THCState *state, THCTensor *self, THCTensor *dst);
 
 /* Slow access methods [check everything] */
-THC_API void THCTensor_(set0d)(THCState *state, THCTensor *tensor, scalar_t value);
-THC_API void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, scalar_t value);
-THC_API void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, scalar_t value);
-THC_API void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, scalar_t value);
-THC_API void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, scalar_t value);
+TORCH_CUDA_API void THCTensor_(set0d)(THCState *state, THCTensor *tensor, scalar_t value);
+TORCH_CUDA_API void THCTensor_(set1d)(THCState *state, THCTensor *tensor, int64_t x0, scalar_t value);
+TORCH_CUDA_API void THCTensor_(set2d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, scalar_t value);
+TORCH_CUDA_API void THCTensor_(set3d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, scalar_t value);
+TORCH_CUDA_API void THCTensor_(set4d)(THCState *state, THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3, scalar_t value);
 
-THC_API scalar_t THCTensor_(get0d)(THCState *state, const THCTensor *tensor);
-THC_API scalar_t THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0);
-THC_API scalar_t THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1);
-THC_API scalar_t THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2);
-THC_API scalar_t THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3);
+TORCH_CUDA_API scalar_t THCTensor_(get0d)(THCState *state, const THCTensor *tensor);
+TORCH_CUDA_API scalar_t THCTensor_(get1d)(THCState *state, const THCTensor *tensor, int64_t x0);
+TORCH_CUDA_API scalar_t THCTensor_(get2d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1);
+TORCH_CUDA_API scalar_t THCTensor_(get3d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2);
+TORCH_CUDA_API scalar_t THCTensor_(get4d)(THCState *state, const THCTensor *tensor, int64_t x0, int64_t x1, int64_t x2, int64_t x3);
 
 /* CUDA-specific functions */
-THC_API int THCTensor_(getDevice)(THCState *state, const THCTensor *self);
-THC_API int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...);
+TORCH_CUDA_API int THCTensor_(getDevice)(THCState *state, const THCTensor *self);
+TORCH_CUDA_API int THCTensor_(checkGPU)(THCState *state, unsigned int nTensors, ...);
 
 /* debug methods */
-THC_API THCDescBuff THCTensor_(sizeDesc)(THCState *state, const THCTensor *tensor);
+TORCH_CUDA_API THCDescBuff THCTensor_(sizeDesc)(THCState *state, const THCTensor *tensor);
 
 #endif

--- a/aten/src/THC/generic/THCTensor.hpp
+++ b/aten/src/THC/generic/THCTensor.hpp
@@ -8,9 +8,9 @@
 // NOTE: functions exist here only to support dispatch via Declarations.cwrap.  You probably don't want to put
 // new functions in here, they should probably be un-genericized.
 
-THC_API void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
+TORCH_CUDA_API void THCTensor_(setStorage)(THCState *state, THCTensor *self, THCStorage *storage_, ptrdiff_t storageOffset_,
                                     at::IntArrayRef size_, at::IntArrayRef stride_);
 
-THC_API void THCTensor_(resize)(THCState *state, THCTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
+TORCH_CUDA_API void THCTensor_(resize)(THCState *state, THCTensor *self, at::IntArrayRef size, at::IntArrayRef stride);
 
 #endif

--- a/aten/src/THC/generic/THCTensorCopy.h
+++ b/aten/src/THC/generic/THCTensorCopy.h
@@ -2,10 +2,10 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorCopy.h"
 #else
 
-THC_API void THCTensor_(copy)(THCState *state, THCTensor *self, THCTensor *src);
-THC_API void THCTensor_(copyIgnoringOverlaps)(THCState *state, THCTensor *self, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(copy)(THCState *state, THCTensor *self, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(copyIgnoringOverlaps)(THCState *state, THCTensor *self, THCTensor *src);
 
-THC_API void THCTensor_(copyAsyncCPU)(THCState *state, THCTensor *self, THTensor *src);
-THC_API void THTensor_(copyAsyncCuda)(THCState *state, THTensor *self, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(copyAsyncCPU)(THCState *state, THCTensor *self, THTensor *src);
+TORCH_CUDA_API void THTensor_(copyAsyncCuda)(THCState *state, THTensor *self, THCTensor *src);
 
 #endif

--- a/aten/src/THC/generic/THCTensorIndex.h
+++ b/aten/src/THC/generic/THCTensorIndex.h
@@ -2,10 +2,10 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorIndex.h"
 #else
 
-THC_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
-THC_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, scalar_t val);
-THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
-THC_API void THCTensor_(take)(THCState *state, THCTensor *res_, THCTensor *src, THCudaLongTensor *index);
-THC_API void THCTensor_(put)(THCState *state, THCTensor *res_, THCudaLongTensor *indices, THCTensor *src, int accumulate);
+TORCH_CUDA_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, scalar_t val);
+TORCH_CUDA_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
+TORCH_CUDA_API void THCTensor_(take)(THCState *state, THCTensor *res_, THCTensor *src, THCudaLongTensor *index);
+TORCH_CUDA_API void THCTensor_(put)(THCState *state, THCTensor *res_, THCudaLongTensor *indices, THCTensor *src, int accumulate);
 
 #endif

--- a/aten/src/THC/generic/THCTensorMasked.h
+++ b/aten/src/THC/generic/THCTensorMasked.h
@@ -2,35 +2,35 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorMasked.h"
 #else
 
-THC_API void THCTensor_(maskedFill)(THCState *state,
+TORCH_CUDA_API void THCTensor_(maskedFill)(THCState *state,
                                     THCTensor *tensor,
                                     THCudaByteTensor *mask,
                                     scalar_t value);
 
 
-THC_API void THCTensor_(maskedFillBool)(THCState *state,
+TORCH_CUDA_API void THCTensor_(maskedFillBool)(THCState *state,
                                         THCTensor *tensor,
                                         THCudaBoolTensor *mask,
                                         scalar_t value);
 
 // FIXME: remove now that we have THCudaByteTensor?
-THC_API void THCTensor_(maskedFillByte)(THCState *state,
+TORCH_CUDA_API void THCTensor_(maskedFillByte)(THCState *state,
                                         THCTensor *tensor,
                                         THByteTensor *mask,
                                         scalar_t value);
 
-THC_API void THCTensor_(maskedCopy)(THCState *state,
+TORCH_CUDA_API void THCTensor_(maskedCopy)(THCState *state,
                                     THCTensor *tensor,
                                     THCudaByteTensor *mask,
                                     THCTensor *src);
 
-THC_API void THCTensor_(maskedCopyBool)(THCState *state,
+TORCH_CUDA_API void THCTensor_(maskedCopyBool)(THCState *state,
                                         THCTensor *tensor,
                                         THCudaBoolTensor *mask,
                                         THCTensor *src);
 
 // FIXME: remove now that we have THCudaByteTensor?
-THC_API void THCTensor_(maskedCopyByte)(THCState *state,
+TORCH_CUDA_API void THCTensor_(maskedCopyByte)(THCState *state,
                                         THCTensor *tensor,
                                         THByteTensor *mask,
                                         THCTensor *src);

--- a/aten/src/THC/generic/THCTensorMath.h
+++ b/aten/src/THC/generic/THCTensorMath.h
@@ -2,9 +2,9 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorMath.h"
 #else
 
-THC_API void THCTensor_(fill)(THCState *state, THCTensor *self, scalar_t value);
-THC_API void THCTensor_(zero)(THCState *state, THCTensor *self);
-THC_API ptrdiff_t THCTensor_(numel)(THCState *state, THCTensor *t);
+TORCH_CUDA_API void THCTensor_(fill)(THCState *state, THCTensor *self, scalar_t value);
+TORCH_CUDA_API void THCTensor_(zero)(THCState *state, THCTensor *self);
+TORCH_CUDA_API ptrdiff_t THCTensor_(numel)(THCState *state, THCTensor *t);
 
 
 #endif

--- a/aten/src/THC/generic/THCTensorMathMagma.h
+++ b/aten/src/THC/generic/THCTensorMathMagma.h
@@ -5,9 +5,9 @@
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
 
 // MAGMA (i.e. CUDA implementation of LAPACK functions)
-THC_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_);
-THC_API void THCTensor_(potri)(THCState *state, THCTensor *ra_, THCTensor *a, bool upper);
-THC_API void THCTensor_(geqrf)(THCState *state, THCTensor *ra_, THCTensor *rtau_, THCTensor *a_);
+TORCH_CUDA_API void THCTensor_(gels)(THCState *state, THCTensor *rb_, THCTensor *ra_, THCTensor *b_, THCTensor *a_);
+TORCH_CUDA_API void THCTensor_(potri)(THCState *state, THCTensor *ra_, THCTensor *a, bool upper);
+TORCH_CUDA_API void THCTensor_(geqrf)(THCState *state, THCTensor *ra_, THCTensor *rtau_, THCTensor *a_);
 
 #endif // defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE)
 

--- a/aten/src/THC/generic/THCTensorMathPairwise.h
+++ b/aten/src/THC/generic/THCTensorMathPairwise.h
@@ -2,11 +2,11 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorMathPairwise.h"
 #else
 
-THC_API int THCTensor_(equal)(THCState *state, THCTensor *self, THCTensor *src);
+TORCH_CUDA_API int THCTensor_(equal)(THCState *state, THCTensor *self, THCTensor *src);
 
 #if !defined(THC_REAL_IS_BOOL)
 
-THC_API void THCTensor_(mul)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
+TORCH_CUDA_API void THCTensor_(mul)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 
 #endif
 

--- a/aten/src/THC/generic/THCTensorMathPointwise.h
+++ b/aten/src/THC/generic/THCTensorMathPointwise.h
@@ -6,20 +6,20 @@
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
 
-THC_API void THCTensor_(atan)(THCState *state, THCTensor *self, THCTensor *src);
-THC_API void THCTensor_(sqrt)(THCState *state, THCTensor *self, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(atan)(THCState *state, THCTensor *self, THCTensor *src);
+TORCH_CUDA_API void THCTensor_(sqrt)(THCState *state, THCTensor *self, THCTensor *src);
 
 #endif
 
-THC_API void THCTensor_(clamp)(THCState *state, THCTensor *self, THCTensor *src, scalar_t min_value, scalar_t max_value);
-THC_API void THCTensor_(crossKernel)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2, int dimension);
+TORCH_CUDA_API void THCTensor_(clamp)(THCState *state, THCTensor *self, THCTensor *src, scalar_t min_value, scalar_t max_value);
+TORCH_CUDA_API void THCTensor_(crossKernel)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2, int dimension);
 
-THC_API void THCTensor_(cadd)(THCState *state, THCTensor *self, THCTensor *src1, scalar_t value, THCTensor *src2);
-THC_API void THCTensor_(csub)(THCState *state, THCTensor *self, THCTensor *src1, scalar_t value, THCTensor *src2);
-THC_API void THCTensor_(cmul)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
-THC_API void THCTensor_(cdiv)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
-THC_API void THCTensor_(clshift)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
-THC_API void THCTensor_(crshift)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
+TORCH_CUDA_API void THCTensor_(cadd)(THCState *state, THCTensor *self, THCTensor *src1, scalar_t value, THCTensor *src2);
+TORCH_CUDA_API void THCTensor_(csub)(THCState *state, THCTensor *self, THCTensor *src1, scalar_t value, THCTensor *src2);
+TORCH_CUDA_API void THCTensor_(cmul)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
+TORCH_CUDA_API void THCTensor_(cdiv)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
+TORCH_CUDA_API void THCTensor_(clshift)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
+TORCH_CUDA_API void THCTensor_(crshift)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2);
 
 #endif
 #endif

--- a/aten/src/THC/generic/THCTensorMathReduce.h
+++ b/aten/src/THC/generic/THCTensorMathReduce.h
@@ -6,16 +6,16 @@
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
 
-THC_API void THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t value, int dimension, scalar_t max_norm);
-THC_API void THCTensor_(norm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t value, int dimension, int keepdim);
+TORCH_CUDA_API void THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t value, int dimension, scalar_t max_norm);
+TORCH_CUDA_API void THCTensor_(norm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t value, int dimension, int keepdim);
 
-THC_API accreal THCTensor_(std_all)(THCState *state, THCTensor *self, bool unbiased);
-THC_API accreal THCTensor_(normall)(THCState *state, THCTensor *self, scalar_t value);
-THC_API accreal THCTensor_(var_all)(THCState *state, THCTensor *self, bool unbiased);
+TORCH_CUDA_API accreal THCTensor_(std_all)(THCState *state, THCTensor *self, bool unbiased);
+TORCH_CUDA_API accreal THCTensor_(normall)(THCState *state, THCTensor *self, scalar_t value);
+TORCH_CUDA_API accreal THCTensor_(var_all)(THCState *state, THCTensor *self, bool unbiased);
 
 #endif
 
-THC_API void THCTensor_(prod)(THCState *state, THCTensor *self, THCTensor *src, int dim, int keepdim);
+TORCH_CUDA_API void THCTensor_(prod)(THCState *state, THCTensor *self, THCTensor *src, int dim, int keepdim);
 
 #endif
 

--- a/aten/src/THC/generic/THCTensorMode.h
+++ b/aten/src/THC/generic/THCTensorMode.h
@@ -4,7 +4,7 @@
 
 /* Returns the mode, and index of the mode, for the set of values
  * along a given dimension in the input tensor. */
-THC_API void THCTensor_(mode)(THCState *state,
+TORCH_CUDA_API void THCTensor_(mode)(THCState *state,
                               THCTensor *values,
                               THCudaLongTensor *indices,
                               THCTensor *input,

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -6,8 +6,8 @@
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
 
-THC_API void THCTensor_(multinomialAliasSetup)(struct THCState *state, THCTensor *probs, THCudaLongTensor *J, THCTensor *q);
-THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor *self, THCTensor *_q, THCudaLongTensor *_J, int n_sample, c10::optional<at::Generator> gen_);
+TORCH_CUDA_API void THCTensor_(multinomialAliasSetup)(struct THCState *state, THCTensor *probs, THCudaLongTensor *J, THCTensor *q);
+TORCH_CUDA_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor *self, THCTensor *_q, THCudaLongTensor *_J, int n_sample, c10::optional<at::Generator> gen_);
 
 #endif
 #endif

--- a/aten/src/THC/generic/THCTensorScatterGather.h
+++ b/aten/src/THC/generic/THCTensorScatterGather.h
@@ -2,6 +2,6 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorScatterGather.h"
 #else
 
-THC_API void THCTensor_(gather)(THCState* state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
+TORCH_CUDA_API void THCTensor_(gather)(THCState* state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
 
 #endif

--- a/aten/src/THC/generic/THCTensorSort.h
+++ b/aten/src/THC/generic/THCTensorSort.h
@@ -4,14 +4,14 @@
 
 /* Performs an in-place sort of (keys, values). Only works for slice sizes
    <= 2048 at the moment (slice size == size of keys/values dim `dim`) */
-THC_API void THCTensor_(sortKeyValueInplace)(THCState* state,
+TORCH_CUDA_API void THCTensor_(sortKeyValueInplace)(THCState* state,
                                              THCTensor* keys,
                                              THCudaLongTensor* values,
                                              int dim, bool dir);
 
 /* Performs an out-of-place sort of `input`, returning the per-slice indices
    in `indices` and the sorted values in `sorted` */
-THC_API void THCTensor_(sort)(THCState* state,
+TORCH_CUDA_API void THCTensor_(sort)(THCState* state,
                               THCTensor* sorted,
                               THCudaLongTensor* indices,
                               THCTensor* input,

--- a/aten/src/THC/generic/THCTensorTopK.h
+++ b/aten/src/THC/generic/THCTensorTopK.h
@@ -4,7 +4,7 @@
 
 /* Returns the set of all kth smallest (or largest) elements, depending */
 /* on `dir` */
-THC_API void THCTensor_(topk)(THCState* state,
+TORCH_CUDA_API void THCTensor_(topk)(THCState* state,
                                THCTensor* topK,
                                THCudaLongTensor* indices,
                                THCTensor* input,

--- a/aten/src/THCUNN/generic/THCUNN.h
+++ b/aten/src/THCUNN/generic/THCUNN.h
@@ -5,7 +5,7 @@
 #include <ATen/core/Reduction.h>
 #include <ATen/Generator.h>
 
-THC_API void THNN_(ClassNLLCriterion_updateOutput)(
+TORCH_CUDA_API void THNN_(ClassNLLCriterion_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -15,7 +15,7 @@ THC_API void THNN_(ClassNLLCriterion_updateOutput)(
                   THCTensor *total_weight,
                   int64_t ignore_index);
 
-THC_API void THNN_(ClassNLLCriterion_updateGradInput)(
+TORCH_CUDA_API void THNN_(ClassNLLCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -26,33 +26,33 @@ THC_API void THNN_(ClassNLLCriterion_updateGradInput)(
                   THCTensor *total_weight,
                   int64_t ignore_index);
 
-THC_API void THNN_(GatedLinear_updateOutput)(
+TORCH_CUDA_API void THNN_(GatedLinear_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *output,
                   int dim);
 
-THC_API void THNN_(GatedLinear_updateGradInput)(
+TORCH_CUDA_API void THNN_(GatedLinear_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *gradOutput,
                   THCTensor *gradInput,
                   int dim);
 
-THC_API void THNN_(LogSigmoid_updateOutput)(
+TORCH_CUDA_API void THNN_(LogSigmoid_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *output,
                   THCTensor *buffer);
 
-THC_API void THNN_(LogSigmoid_updateGradInput)(
+TORCH_CUDA_API void THNN_(LogSigmoid_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *gradOutput,
                   THCTensor *gradInput,
                   THCTensor *buffer);
 
-THC_API void THNN_(MultiLabelMarginCriterion_updateOutput)(
+TORCH_CUDA_API void THNN_(MultiLabelMarginCriterion_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -60,7 +60,7 @@ THC_API void THNN_(MultiLabelMarginCriterion_updateOutput)(
                   THCTensor *is_target,
                   int64_t reduction);
 
-THC_API void THNN_(MultiLabelMarginCriterion_updateGradInput)(
+TORCH_CUDA_API void THNN_(MultiLabelMarginCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -69,7 +69,7 @@ THC_API void THNN_(MultiLabelMarginCriterion_updateGradInput)(
                   THCTensor *is_target,
                   int64_t reduction);
 
-THC_API void THNN_(MultiMarginCriterion_updateOutput)(
+TORCH_CUDA_API void THNN_(MultiMarginCriterion_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -79,7 +79,7 @@ THC_API void THNN_(MultiMarginCriterion_updateOutput)(
                   THCTensor *weights,           // [OPTIONAL]
                   accreal margin);
 
-THC_API void THNN_(MultiMarginCriterion_updateGradInput)(
+TORCH_CUDA_API void THNN_(MultiMarginCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -90,7 +90,7 @@ THC_API void THNN_(MultiMarginCriterion_updateGradInput)(
                   THCTensor *weights,           // [OPTIONAL]
                   accreal margin);
 
-THC_API void THNN_(SpatialClassNLLCriterion_updateOutput)(
+TORCH_CUDA_API void THNN_(SpatialClassNLLCriterion_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -100,7 +100,7 @@ THC_API void THNN_(SpatialClassNLLCriterion_updateOutput)(
                   THCTensor *total_weight,
                   int64_t ignore_index);
 
-THC_API void THNN_(SpatialClassNLLCriterion_updateGradInput)(
+TORCH_CUDA_API void THNN_(SpatialClassNLLCriterion_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCIndexTensor *target,
@@ -111,7 +111,7 @@ THC_API void THNN_(SpatialClassNLLCriterion_updateGradInput)(
                   THCTensor *total_weight,
                   int64_t ignore_index);
 
-THC_API void THNN_(SpatialConvolutionMM_updateOutput)(
+TORCH_CUDA_API void THNN_(SpatialConvolutionMM_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *output,
@@ -123,7 +123,7 @@ THC_API void THNN_(SpatialConvolutionMM_updateOutput)(
                   int dW, int dH,
                   int padW, int padH);
 
-THC_API void THNN_(SpatialConvolutionMM_updateGradInput)(
+TORCH_CUDA_API void THNN_(SpatialConvolutionMM_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *gradOutput,
@@ -135,7 +135,7 @@ THC_API void THNN_(SpatialConvolutionMM_updateGradInput)(
                   int dW, int dH,
                   int padW, int padH);
 
-THC_API void THNN_(SpatialConvolutionMM_accGradParameters)(
+TORCH_CUDA_API void THNN_(SpatialConvolutionMM_accGradParameters)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *gradOutput,
@@ -148,7 +148,7 @@ THC_API void THNN_(SpatialConvolutionMM_accGradParameters)(
                   int padW, int padH,
                   accreal scale);
 
-THC_API void THNN_(SpatialDepthwiseConvolution_updateOutput)(
+TORCH_CUDA_API void THNN_(SpatialDepthwiseConvolution_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *output,
@@ -159,7 +159,7 @@ THC_API void THNN_(SpatialDepthwiseConvolution_updateOutput)(
                   int padW, int padH,
                   int dilationW, int dilationH);
 
-THC_API void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
+TORCH_CUDA_API void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *gradOutput,
@@ -170,7 +170,7 @@ THC_API void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
                   int padW, int padH,
                   int dilationW, int dilationH);
 
-THC_API void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
+TORCH_CUDA_API void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *gradOutput,
@@ -180,7 +180,7 @@ THC_API void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
                   int padW, int padH,
                   int dilationW, int dilationH);
 
-THC_API void THNN_(RReLU_updateOutput)(
+TORCH_CUDA_API void THNN_(RReLU_updateOutput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *output,
@@ -191,7 +191,7 @@ THC_API void THNN_(RReLU_updateOutput)(
                   bool inplace,
                   c10::optional<at::Generator> generator);
 
-THC_API void THNN_(RReLU_updateGradInput)(
+TORCH_CUDA_API void THNN_(RReLU_updateGradInput)(
                   THCState *state,
                   THCTensor *input,
                   THCTensor *gradOutput,

--- a/tools/shared/cwrap_common.py
+++ b/tools/shared/cwrap_common.py
@@ -178,8 +178,8 @@ def parse_header(path):
             else:
                 fn_name = fn_name[:-1]
             generic_functions.append(Function(fn_name))
-        elif l.startswith('THC_API void THNN_'):
-            fn_name = l[len('THC_API void THNN_'):]
+        elif l.startswith('TORCH_CUDA_API void THNN_'):
+            fn_name = l[len('TORCH_CUDA_API void THNN_'):]
             if fn_name[0] == '(' and fn_name[-2] == ')':
                 fn_name = fn_name[1:-2]
             else:


### PR DESCRIPTION
THC_API and THC_CLASS were leftover macros from before the consolidation of caffe2, aten, and torch. Now that they're combined, these are misleading and should just be TORCH_CUDA_API. The only file I manually edited was `THCGeneral.h.in`.
