### PR TITLE
[Gradient Compression] Change wait() to value() in some callbacks of PowerSGD communication hook

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -281,7 +281,7 @@ def powerSGD_hook(
         ]
 
     def compute_qs(fut):
-        state.p_memory_dict[bucket_index] = fut.wait()[0]
+        state.p_memory_dict[bucket_index] = fut.value()[0]
         for p in ps:
             _orthogonalize(p)
 
@@ -299,7 +299,7 @@ def powerSGD_hook(
         ]
 
     def decompress(fut):
-        state.q_memory_dict[bucket_index] = fut.wait()[0].div_(world_size)
+        state.q_memory_dict[bucket_index] = fut.value()[0].div_(world_size)
 
         for p, q, tensor in zip(ps, qs, high_rank_tensors):
             torch.matmul(p, q.t(), out=tensor)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49715 [Gradient Compression] Directly let world_size = group_to_use.size()
* #49711 [Gradient Compression] Explicitly restrict the scope of torch.cuda.synchronize to the current device
* **#49709 [Gradient Compression] Change wait() to value() in some callbacks of PowerSGD communication hook**
* #49451 [Gradient Compression] Warm-start of PowerSGD

Since wait() has already been called in the return statements of the precursor callbacks, no need to wait again.

Original PR issue: Investigate Applying PowerSGD to Communication Hook for Gradient Compression #47202

Differential Revision: [D25672068](https://our.internmc.facebook.com/intern/diff/D25672068/)