### PR TITLE
[Gradient Compression] Explicitly restrict the scope of torch.cuda.synchronize to the current device

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -304,7 +304,7 @@ def powerSGD_hook(
         for p, q, tensor in zip(ps, qs, high_rank_tensors):
             torch.matmul(p, q.t(), out=tensor)
         if torch.cuda.is_available():
-            torch.cuda.synchronize()
+            torch.cuda.synchronize(device)
 
         if state.use_error_feedback:
             # Memorize the local errors.
@@ -494,7 +494,7 @@ def batched_powerSGD_hook(
             # Memorize the local errors.
             state.error_dict[bucket_index] = input_tensor_cp - input_tensor
         if torch.cuda.is_available():
-            torch.cuda.synchronize()
+            torch.cuda.synchronize(device)
         if not state.warm_start:
             state.p_memory_dict.clear()
             state.q_memory_dict.clear()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #49715 [Gradient Compression] Directly let world_size = group_to_use.size()
* **#49711 [Gradient Compression] Explicitly restrict the scope of torch.cuda.synchronize to the current device**
* #49709 [Gradient Compression] Change wait() to value() in some callbacks of PowerSGD communication hook
* #49451 [Gradient Compression] Warm-start of PowerSGD

`torch.cuda.synchronize` uses the current device by default. Explicitly specify this device for better readability.

Original PR issue: Investigate Applying PowerSGD to Communication Hook for Gradient Compression #47202

Differential Revision: [D25672267](https://our.internmc.facebook.com/intern/diff/D25672267/)