### PR TITLE
[FX] Fix python code having spurious newlines from placeholders

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -619,6 +619,8 @@ class Graph:
             not used in the remainder of the code are freed and the memory usage
             of the code is optimal.
             """
+            if user.op == 'placeholder':
+                return
             if user.op == 'output':
                 body.append('\n')
                 return
@@ -637,7 +639,7 @@ class Graph:
                 free_vars.append(f'{node.target}{maybe_type_annotation}{maybe_default_arg}')
                 raw_name = node.target.replace('*', '')
                 if raw_name != node.name:
-                    body.append(f'{node.name} = {raw_name}')
+                    body.append(f'{node.name} = {raw_name}\n')
                 return
             elif node.op == 'call_method':
                 assert isinstance(node.target, str)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49720 [FX] Fix python code having spurious newlines from placeholders**

The logic in `Graph.python_code` didn't account for `placeholder` nodes with `name == target` not emitting a line, so it was spuriously emitting one newline per placeholder in the `Graph`. This patch fixes that.

Test script:

```
import torch
import torch.fx

graph = torch.fx.Graph()
for i in range(30):
    ph_value = graph.placeholder(f'v{i}')
graph.output(ph_value)

print(graph.python_code(''))
```

Before

```
def forward(self, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29):
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    return v29
```

After

```
def forward(self, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29):
    return v29
```

Differential Revision: [D25675825](https://our.internmc.facebook.com/intern/diff/D25675825)