### PR TITLE
[PyTorch] Remove direct reference to native symbols in sparse related non-native codes

### DIFF
--- a/aten/src/ATen/SparseTensorUtils.cpp
+++ b/aten/src/ATen/SparseTensorUtils.cpp
@@ -78,17 +78,17 @@ Tensor flatten_indices_by_dims(const Tensor& indices, const IntArrayRef& sizes, 
 }
 
 Tensor coo_to_csr(const int64_t* indices, int64_t dim, int64_t nnz) {
-  /* 
-    Find the CSR representation for a row `indices` from the COO format 
+  /*
+    Find the CSR representation for a row `indices` from the COO format
     Inputs:
       `indices` is the row pointer from COO indices
-      `dim` is the row dimensionality 
-      `nnz` is the number of non-zeros 
-    
-    Output: 
+      `dim` is the row dimensionality
+      `nnz` is the number of non-zeros
+
+    Output:
       `csr` is a compressed row array in a CSR format
   */
-  Tensor csr = native::zeros({dim + 1}, kLong);
+  Tensor csr = at::zeros({dim + 1}, kLong);
 
   // TODO: eliminate this conditional when zero-size dims supported correctly
   if (nnz > 0) {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -642,17 +642,17 @@ Tensor _sparse_addmm_sparse_backward(const Tensor& grad, const Tensor& sparse_, 
 }
 
 // This function return a new SparseTensor with values from Tensor `input` filtered by indices of `mask`
-// and values are ignored. `input` and `mask` are sparse matrices, a sparse tensor with sparse_dim=2 and  dense_dim=2,  
+// and values are ignored. `input` and `mask` are sparse matrices, a sparse tensor with sparse_dim=2 and  dense_dim=2,
 // and they must have the same shape.
-// Note that the `output` must have the same `indices` as the `mask` so we are using just a clone. 
+// Note that the `output` must have the same `indices` as the `mask` so we are using just a clone.
 // However, to get `values` we have to use specific helper function for CPU/CUDA and use the `mask` data to filter `values`
-// That's why we created this `_sparse_matrix_mask_helper` function. 
+// That's why we created this `_sparse_matrix_mask_helper` function.
 Tensor _sparse_matrix_mask(const Tensor& input, const Tensor& mask){
-  Tensor output = at::native::empty_like(mask);
+  Tensor output = at::empty_like(mask);
   Tensor mask_indices = mask._indices().clone();
   Tensor r_values;
   if (mask._nnz() == 0) {
-    r_values = at::native::zeros_like(mask._values());
+    r_values = at::zeros_like(mask._values());
   } else {
     r_values = _sparse_matrix_mask_helper(input, mask_indices.contiguous());
   }
@@ -666,30 +666,30 @@ Tensor sparse_sparse_matmul_backward(
     const Tensor& b,
     int64_t grad_order) {
   /*
-  To implement the backward algorithm for sparse matrix-matrix matmul (SPMM) we can start from the following definition 
+  To implement the backward algorithm for sparse matrix-matrix matmul (SPMM) we can start from the following definition
   for dense tensors:
-  
-  c = a @ b 
-      then 
+
+  c = a @ b
+      then
   a_grad = c_grad @ b^T
   b_grad = a^T @ c_grad
 
   So for sparse matrices we can use the following definition:
-  
+
   if grad_order == 0:
-      a_grad = sparse_matrix_mask(c_grad @ b^T, mask=a) 
+      a_grad = sparse_matrix_mask(c_grad @ b^T, mask=a)
   else:
-      b_grad = sparse_matrix_mask(a^T @ c_grad, mask=b) 
+      b_grad = sparse_matrix_mask(a^T @ c_grad, mask=b)
   */
   TORCH_CHECK(
       grad_order == 0 || grad_order == 1,
       ": grad_order not in [0, 1] at sparse_sparse_matmul_backward function");
   if (grad_order == 0) {
     auto a_grad = _sparse_sparse_matmul(grad, b.t());
-    return _sparse_matrix_mask(a_grad.coalesce(), a.coalesce()); 
-  } 
+    return _sparse_matrix_mask(a_grad.coalesce(), a.coalesce());
+  }
   auto b_grad = _sparse_sparse_matmul(a.t(), grad);
-  return _sparse_matrix_mask(b_grad.coalesce(), b.coalesce()); 
+  return _sparse_matrix_mask(b_grad.coalesce(), b.coalesce());
 }
 
 Tensor renorm_backward(const Tensor & grad, const Tensor & self, Scalar p, int64_t dim, Scalar maxnorm) {
@@ -2857,7 +2857,7 @@ Tensor constant_pad_nd_backward(const Tensor& grad, IntArrayRef pad) {
 }
 
 Tensor embedding_dense_double_backward(const Tensor & grad, const Tensor & indices, int64_t padding_idx) {
-  // since first backward takes care of scaling by frequency, 
+  // since first backward takes care of scaling by frequency,
   // we don't need to worry about it here.
   auto gg_weight = grad.index_select(0, indices.reshape(-1));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49721 [PyTorch] Remove direct reference to native symbols in sparse related non-native codes**

As a refactor effort of per-app selective build, we are decoupling ATen/native from the rest of aten (D25413998).
All symbols of ATen/native could only be referenced through dispatcher (https://github.com/pytorch/pytorch/issues/48684).

This diff is to decouple the native reference recently introduced for sparse tensors.

Differential Revision: [D25675711](https://our.internmc.facebook.com/intern/diff/D25675711/)